### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.10](https://github.com/jdx/usage/releases/tag/v${version}) - 2024-03-17
+
+### Fixed
+- *(deps)* update rust crate heck to v0.5.0 ([#30](https://github.com/jdx/usage/pull/30))
+
+### Other
+- move usage-lib into its own dir
+- added author field

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1328,7 +1328,7 @@ checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "usage-cli"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "usage-lib"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "clap",
  "ctor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.9"
+version = "0.1.10"
 homepage = "https://usage.jdx.dev"
 documentation = "https://github.com/jdx/usage"
 authors = ["Jeff Dickey @jdx"]


### PR DESCRIPTION
## 🤖 New release
* `usage-cli`: 0.1.9 -> 0.1.10
* `usage-lib`: 0.1.9 -> 0.1.10

<details><summary><i><b>Changelog</b></i></summary><p>

## `usage-cli`
<blockquote>

## [0.1.10](https://github.com/jdx/usage/releases/tag/v${version}) - 2024-03-17

### Fixed
- *(deps)* update rust crate heck to v0.5.0 ([#30](https://github.com/jdx/usage/pull/30))

### Other
- move usage-lib into its own dir
- added author field
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).