### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11](https://github.com/jdx/usage/releases/tag/v${version}) - 2024-03-17
+
+### Other
+- fixing cargo metadata
+
 ## [0.1.10](https://github.com/jdx/usage/releases/tag/v${version}) - 2024-03-17
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1328,7 +1328,7 @@ checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "usage-cli"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "usage-lib"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "clap",
  "ctor",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-cli"
 edition = "2021"
-version = "0.1.10"
+version = "0.1.11"
 description = "CLI for working with usage-based CLIs"
 license = { workspace = true }
 authors = { workspace = true }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-lib"
 edition = "2021"
-version = "0.1.10"
+version = "0.1.11"
 rust-version = "1.70.0"
 include = [
     "/Cargo.toml",


### PR DESCRIPTION
## 🤖 New release
* `usage-cli`: 0.1.10 -> 0.1.11
* `usage-lib`: 0.1.10 -> 0.1.11

<details><summary><i><b>Changelog</b></i></summary><p>

## `usage-cli`
<blockquote>

## [0.1.11](https://github.com/jdx/usage/releases/tag/v${version}) - 2024-03-17

### Other
- fixing cargo metadata
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).