### PR TITLE
chore: release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,269 +1,281 @@
 # Changelog
 
-## [0.7.0](https://github.com/jdx/usage/compare/v0.6.0..v0.7.0) - 2024-09-26
+## [0.7.1](https://github.com/jdx/usage/compare/v0.7.0..v0.7.1) - 2024-09-27
 
-### 🚀 Features
+### 🐛 Bug Fixes
 
-- implemented choices for args/flags by jdx in [3db63bd](https://github.com/jdx/usage/commit/3db63bd540d3fe796136218bdf6862f27a678767)
+- fail parsing if required args/flags not found by [@jdx](https://github.com/jdx) in [409145a](https://github.com/jdx/usage/commit/409145ae5db937bffa121e63f00f8f827c49b294)
 
 ### 🔍 Other Changes
 
-- clean up pub exports by Jeff Dickey in [9996ab8](https://github.com/jdx/usage/commit/9996ab8ca041d27a0754096fe7b04ebd3958431b)
+- publish aur releases by [@jdx](https://github.com/jdx) in [#109](https://github.com/jdx/usage/pull/109)
+- move tasks dir by [@jdx](https://github.com/jdx) in [8cb8cc3](https://github.com/jdx/usage/commit/8cb8cc348dbb04f3c41f3ca22c518f82dfa27830)
+- install cargo-binstall before installing mise by [@jdx](https://github.com/jdx) in [6240460](https://github.com/jdx/usage/commit/62404602e602a1c7d578b5764703f0820c45299e)
+
+## [0.7.0](https://github.com/jdx/usage/compare/v0.6.0..v0.7.0) - 2024-09-27
+
+### 🚀 Features
+
+- implemented choices for args/flags by [@jdx](https://github.com/jdx) in [#107](https://github.com/jdx/usage/pull/107)
+
+### 🔍 Other Changes
+
+- clean up pub exports by [@jdx](https://github.com/jdx) in [9996ab8](https://github.com/jdx/usage/commit/9996ab8ca041d27a0754096fe7b04ebd3958431b)
 
 ## [0.6.0](https://github.com/jdx/usage/compare/v0.5.1..v0.6.0) - 2024-09-26
 
 ### 🚀 Features
 
-- negate by Jeff Dickey in [5d1b817](https://github.com/jdx/usage/commit/5d1b817d143227a03651502b7671c9b2853c92eb)
-- negate by Jeff Dickey in [16f754d](https://github.com/jdx/usage/commit/16f754d1925c561198291b304cbf80c9ab2a4dee)
-- mount by Jeff Dickey in [99530f4](https://github.com/jdx/usage/commit/99530f4682140e2b64f2625d844b840925e3d6ae)
+- negate by [@jdx](https://github.com/jdx) in [5d1b817](https://github.com/jdx/usage/commit/5d1b817d143227a03651502b7671c9b2853c92eb)
+- negate by [@jdx](https://github.com/jdx) in [16f754d](https://github.com/jdx/usage/commit/16f754d1925c561198291b304cbf80c9ab2a4dee)
+- mount by [@jdx](https://github.com/jdx) in [99530f4](https://github.com/jdx/usage/commit/99530f4682140e2b64f2625d844b840925e3d6ae)
 
 ### 🐛 Bug Fixes
 
-- remove debug statements by Jeff Dickey in [664b592](https://github.com/jdx/usage/commit/664b592f4d8f7b96f24d3bb2ca2803df36fda512)
-- export SpecMount by Jeff Dickey in [b44c4f1](https://github.com/jdx/usage/commit/b44c4f15c77dee10e59c136b52f52a844f4ee655)
+- remove debug statements by [@jdx](https://github.com/jdx) in [664b592](https://github.com/jdx/usage/commit/664b592f4d8f7b96f24d3bb2ca2803df36fda512)
+- export SpecMount by [@jdx](https://github.com/jdx) in [b44c4f1](https://github.com/jdx/usage/commit/b44c4f15c77dee10e59c136b52f52a844f4ee655)
 
 ### 🔍 Other Changes
 
-- migrate away from deprecated git-cliff syntax by Jeff Dickey in [3062df9](https://github.com/jdx/usage/commit/3062df94a9ad7af3a2e57ba5e5e35d299daa6718)
+- migrate away from deprecated git-cliff syntax by [@jdx](https://github.com/jdx) in [3062df9](https://github.com/jdx/usage/commit/3062df94a9ad7af3a2e57ba5e5e35d299daa6718)
 
 ## [0.5.1](https://github.com/jdx/usage/compare/v0.5.0..v0.5.1) - 2024-09-25
 
 ### 🐛 Bug Fixes
 
-- bail instead of panic on CLI parse error by Jeff Dickey in [b935cca](https://github.com/jdx/usage/commit/b935ccae9a442378c71182293cd24380fdadf744)
+- bail instead of panic on CLI parse error by [@jdx](https://github.com/jdx) in [b935cca](https://github.com/jdx/usage/commit/b935ccae9a442378c71182293cd24380fdadf744)
 
 ## [0.5.0](https://github.com/jdx/usage/compare/v0.4.0..v0.5.0) - 2024-09-25
 
 ### 🚀 Features
 
-- added .as_env() to CLI parser by Jeff Dickey in [b1f6617](https://github.com/jdx/usage/commit/b1f66179b70a4bcdc6792add24a7b62e1afdd81d)
-- added Spec::parse_script fn by Jeff Dickey in [124a705](https://github.com/jdx/usage/commit/124a7050c6b1b5bb502049204556b74b6e8a4b71)
+- added .as_env() to CLI parser by [@jdx](https://github.com/jdx) in [b1f6617](https://github.com/jdx/usage/commit/b1f66179b70a4bcdc6792add24a7b62e1afdd81d)
+- added Spec::parse_script fn by [@jdx](https://github.com/jdx) in [124a705](https://github.com/jdx/usage/commit/124a7050c6b1b5bb502049204556b74b6e8a4b71)
 
 ## [0.4.0](https://github.com/jdx/usage/compare/v0.3.1..v0.4.0) - 2024-09-25
 
 ### 🚀 Features
 
-- add comment syntax for file scripts by Jeff Dickey in [ee75493](https://github.com/jdx/usage/commit/ee7549303a0cf63c5da8257287be21d0af85ce86)
+- add comment syntax for file scripts by [@jdx](https://github.com/jdx) in [ee75493](https://github.com/jdx/usage/commit/ee7549303a0cf63c5da8257287be21d0af85ce86)
 
 ### 🐛 Bug Fixes
 
-- tweak comment syntax by Jeff Dickey in [dfff6e2](https://github.com/jdx/usage/commit/dfff6e2daaafb47200a32d4654482beabbe2f343)
+- tweak comment syntax by [@jdx](https://github.com/jdx) in [dfff6e2](https://github.com/jdx/usage/commit/dfff6e2daaafb47200a32d4654482beabbe2f343)
 
 ### 📚 Documentation
 
-- update flag syntax by Jeff Dickey in [a67de2e](https://github.com/jdx/usage/commit/a67de2e6e855b24d340d559ded9e1464f95c2894)
+- update flag syntax by [@jdx](https://github.com/jdx) in [a67de2e](https://github.com/jdx/usage/commit/a67de2e6e855b24d340d559ded9e1464f95c2894)
 
 ### 📦️ Dependency Updates
 
-- update rust crate serde to v1.0.210 by renovate[bot] in [866ed15](https://github.com/jdx/usage/commit/866ed15fc8b746c5b4a1bbfd3a61994b64dc0246)
-- update rust crate clap to v4.5.18 by renovate[bot] in [161ba00](https://github.com/jdx/usage/commit/161ba0053ee58ac883cbe19b8f18c3790ec5d00a)
+- update rust crate serde to v1.0.210 by [@renovate[bot]](https://github.com/renovate[bot]) in [#102](https://github.com/jdx/usage/pull/102)
+- update rust crate clap to v4.5.18 by [@renovate[bot]](https://github.com/renovate[bot]) in [#101](https://github.com/jdx/usage/pull/101)
 
 ## [0.3.1](https://github.com/jdx/usage/compare/v0.3.0..v0.3.1) - 2024-08-28
 
 ### 🐛 Bug Fixes
 
-- **(brew)** use official homebrew formula by jdx in [42269c9](https://github.com/jdx/usage/commit/42269c93ee608d734eb43ec8f306d4249f801c2a)
-- make shebang scripts work with comments by Jeff Dickey in [9eb2a64](https://github.com/jdx/usage/commit/9eb2a64ff0e3c463f53fe0c283bbb932e5b3dd77)
+- **(brew)** use official homebrew formula by [@jdx](https://github.com/jdx) in [#54](https://github.com/jdx/usage/pull/54)
+- make shebang scripts work with comments by [@jdx](https://github.com/jdx) in [9eb2a64](https://github.com/jdx/usage/commit/9eb2a64ff0e3c463f53fe0c283bbb932e5b3dd77)
 
 ### 📦️ Dependency Updates
 
-- update dependency vitepress to v1.2.2 by renovate[bot] in [f74c0e1](https://github.com/jdx/usage/commit/f74c0e172181ea5364bbfcab7d4fbb484ef4f053)
-- lock file maintenance by renovate[bot] in [4872230](https://github.com/jdx/usage/commit/48722300312e6e0edb1f03458ecbf13c96841976)
-- update rust crate tera to v1.20.0 by renovate[bot] in [6fa06a4](https://github.com/jdx/usage/commit/6fa06a42f0bb94537b122856187760d59e2e5d07)
-- lock file maintenance by renovate[bot] in [bbf39f3](https://github.com/jdx/usage/commit/bbf39f36964666848913cf88260852c93cff7b0e)
-- update dependency vitepress to v1.2.3 by renovate[bot] in [b018c70](https://github.com/jdx/usage/commit/b018c704557729b01cb41e5e376b16261ce6278c)
-- update rust crate clap to v4.5.6 by renovate[bot] in [8613fe1](https://github.com/jdx/usage/commit/8613fe1c9d6b555c192f0064de48b05d0271afe3)
-- update rust crate clap to v4.5.7 by renovate[bot] in [233472d](https://github.com/jdx/usage/commit/233472d11d2d1e89a027cbfc4113d108becc7a3b)
-- update rust crate regex to v1.10.5 by renovate[bot] in [5499b45](https://github.com/jdx/usage/commit/5499b455846ca36a3dfd071fa437480a617a4fd9)
-- update rust crate log to v0.4.22 by renovate[bot] in [dae2215](https://github.com/jdx/usage/commit/dae2215a286d83e63352b3f035c7bac298c1dd58)
-- update rust crate clap to v4.5.8 by renovate[bot] in [d6b32d5](https://github.com/jdx/usage/commit/d6b32d5989bc3ff2ecb917c66777d5e892c8536e)
-- update rust crate serde to v1.0.204 by renovate[bot] in [98e346b](https://github.com/jdx/usage/commit/98e346b77c0e756bab3ccf71b355c17ad0291766)
-- update rust crate clap to v4.5.9 by renovate[bot] in [a4f60f3](https://github.com/jdx/usage/commit/a4f60f377a5e783682446d907194b1aa1c9ae9a1)
-- update rust crate strum to v0.26.3 by renovate[bot] in [4795d1e](https://github.com/jdx/usage/commit/4795d1edeab1ba307501f09d27bc9ac3cb8ff43f)
-- update rust crate thiserror to v1.0.63 by renovate[bot] in [00daa8c](https://github.com/jdx/usage/commit/00daa8ce228945cab52bf792de172779b8cb969b)
-- update dependency vitepress to v1.3.1 by renovate[bot] in [28087f2](https://github.com/jdx/usage/commit/28087f20007f028fea915d90f1f027066e91b941)
-- lock file maintenance by renovate[bot] in [2a52de7](https://github.com/jdx/usage/commit/2a52de7b2def07464cf30369afad3e64298bb3f1)
-- update rust crate predicates to v3.1.2 by renovate[bot] in [629c316](https://github.com/jdx/usage/commit/629c316361e8690e50bc196adcaa0e04b69b9cda)
-- update rust crate assert_cmd to v2.0.15 by renovate[bot] in [1d68130](https://github.com/jdx/usage/commit/1d68130c8d4ff4e69d38afee863d2bd46a8c1167)
-- update rust crate env_logger to v0.11.5 by renovate[bot] in [ebe133c](https://github.com/jdx/usage/commit/ebe133c944b9f163b71e768b14c4f57b7c282bd4)
-- update rust crate clap to v4.5.13 by renovate[bot] in [a8e79bd](https://github.com/jdx/usage/commit/a8e79bd061a24b175a1a747b5bd5aa850672048b)
-- update rust crate assert_cmd to v2.0.16 by renovate[bot] in [f6421c0](https://github.com/jdx/usage/commit/f6421c0e90c849261d37cab09869e257bedf637e)
-- update dependency vitepress to v1.3.2 by renovate[bot] in [816f10f](https://github.com/jdx/usage/commit/816f10f3fdf27086bc62a9ee64bd10b85c02dd9b)
-- update dependency vitepress to v1.3.3 by renovate[bot] in [f17b979](https://github.com/jdx/usage/commit/f17b97932341f73f375f405b1b7bc3e18f05339d)
-- update rust crate clap to v4.5.16 by renovate[bot] in [db6d733](https://github.com/jdx/usage/commit/db6d73300f408a8696ccbda544de318fd67d3541)
-- update dependency vitepress to v1.3.4 by renovate[bot] in [d34840a](https://github.com/jdx/usage/commit/d34840a1dd3f97706547666c4be958b41428d1e4)
-- update rust crate regex to v1.10.6 by renovate[bot] in [49dece6](https://github.com/jdx/usage/commit/49dece6f8a19c32b48845449ddda203489c57deb)
+- update dependency vitepress to v1.2.2 by [@renovate[bot]](https://github.com/renovate[bot]) in [#72](https://github.com/jdx/usage/pull/72)
+- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#73](https://github.com/jdx/usage/pull/73)
+- update rust crate tera to v1.20.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#75](https://github.com/jdx/usage/pull/75)
+- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#76](https://github.com/jdx/usage/pull/76)
+- update dependency vitepress to v1.2.3 by [@renovate[bot]](https://github.com/renovate[bot]) in [#77](https://github.com/jdx/usage/pull/77)
+- update rust crate clap to v4.5.6 by [@renovate[bot]](https://github.com/renovate[bot]) in [#78](https://github.com/jdx/usage/pull/78)
+- update rust crate clap to v4.5.7 by [@renovate[bot]](https://github.com/renovate[bot]) in [#79](https://github.com/jdx/usage/pull/79)
+- update rust crate regex to v1.10.5 by [@renovate[bot]](https://github.com/renovate[bot]) in [#80](https://github.com/jdx/usage/pull/80)
+- update rust crate log to v0.4.22 by [@renovate[bot]](https://github.com/renovate[bot]) in [#82](https://github.com/jdx/usage/pull/82)
+- update rust crate clap to v4.5.8 by [@renovate[bot]](https://github.com/renovate[bot]) in [#81](https://github.com/jdx/usage/pull/81)
+- update rust crate serde to v1.0.204 by [@renovate[bot]](https://github.com/renovate[bot]) in [#85](https://github.com/jdx/usage/pull/85)
+- update rust crate clap to v4.5.9 by [@renovate[bot]](https://github.com/renovate[bot]) in [#84](https://github.com/jdx/usage/pull/84)
+- update rust crate strum to v0.26.3 by [@renovate[bot]](https://github.com/renovate[bot]) in [#86](https://github.com/jdx/usage/pull/86)
+- update rust crate thiserror to v1.0.63 by [@renovate[bot]](https://github.com/renovate[bot]) in [#87](https://github.com/jdx/usage/pull/87)
+- update dependency vitepress to v1.3.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#88](https://github.com/jdx/usage/pull/88)
+- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#89](https://github.com/jdx/usage/pull/89)
+- update rust crate predicates to v3.1.2 by [@renovate[bot]](https://github.com/renovate[bot]) in [#91](https://github.com/jdx/usage/pull/91)
+- update rust crate assert_cmd to v2.0.15 by [@renovate[bot]](https://github.com/renovate[bot]) in [#90](https://github.com/jdx/usage/pull/90)
+- update rust crate env_logger to v0.11.5 by [@renovate[bot]](https://github.com/renovate[bot]) in [#93](https://github.com/jdx/usage/pull/93)
+- update rust crate clap to v4.5.13 by [@renovate[bot]](https://github.com/renovate[bot]) in [#92](https://github.com/jdx/usage/pull/92)
+- update rust crate assert_cmd to v2.0.16 by [@renovate[bot]](https://github.com/renovate[bot]) in [#94](https://github.com/jdx/usage/pull/94)
+- update dependency vitepress to v1.3.2 by [@renovate[bot]](https://github.com/renovate[bot]) in [#95](https://github.com/jdx/usage/pull/95)
+- update dependency vitepress to v1.3.3 by [@renovate[bot]](https://github.com/renovate[bot]) in [#96](https://github.com/jdx/usage/pull/96)
+- update rust crate clap to v4.5.16 by [@renovate[bot]](https://github.com/renovate[bot]) in [#97](https://github.com/jdx/usage/pull/97)
+- update dependency vitepress to v1.3.4 by [@renovate[bot]](https://github.com/renovate[bot]) in [#98](https://github.com/jdx/usage/pull/98)
+- update rust crate regex to v1.10.6 by [@renovate[bot]](https://github.com/renovate[bot]) in [#99](https://github.com/jdx/usage/pull/99)
 
 ## [0.3.0](https://github.com/jdx/usage/compare/v0.2.1..v0.3.0) - 2024-05-26
 
 ### 🚀 Features
 
-- complete descriptions by Jeff Dickey in [a8afca7](https://github.com/jdx/usage/commit/a8afca7d6ad773431acfde8280e9dfb2884ef4e0)
+- complete descriptions by [@jdx](https://github.com/jdx) in [a8afca7](https://github.com/jdx/usage/commit/a8afca7d6ad773431acfde8280e9dfb2884ef4e0)
 
 ## [0.2.1](https://github.com/jdx/usage/compare/v0.2.0..v0.2.1) - 2024-05-25
 
 ### 🔍 Other Changes
 
-- updated deps by Jeff Dickey in [a457da9](https://github.com/jdx/usage/commit/a457da9ccec4890d63f3ab8e2215e51e64fd2425)
+- updated deps by [@jdx](https://github.com/jdx) in [a457da9](https://github.com/jdx/usage/commit/a457da9ccec4890d63f3ab8e2215e51e64fd2425)
 
 ### 📦️ Dependency Updates
 
-- update rust crate xx to v1 by renovate[bot] in [9ee59ba](https://github.com/jdx/usage/commit/9ee59badecf779217ebb2b5ce65e682b5650bf64)
-- lock file maintenance by renovate[bot] in [5e30406](https://github.com/jdx/usage/commit/5e30406a7b4c086a4eecef080d7f9e6740b0dd00)
-- update rust crate serde to v1.0.202 by renovate[bot] in [45fcd91](https://github.com/jdx/usage/commit/45fcd91205382d5f6608916ca3f01f619c0a7a27)
-- update rust crate thiserror to v1.0.61 by renovate[bot] in [65b7d91](https://github.com/jdx/usage/commit/65b7d91c9d44b742c40fa94a78abd616c3325d5d)
+- update rust crate xx to v1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#64](https://github.com/jdx/usage/pull/64)
+- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#65](https://github.com/jdx/usage/pull/65)
+- update rust crate serde to v1.0.202 by [@renovate[bot]](https://github.com/renovate[bot]) in [#68](https://github.com/jdx/usage/pull/68)
+- update rust crate thiserror to v1.0.61 by [@renovate[bot]](https://github.com/renovate[bot]) in [#69](https://github.com/jdx/usage/pull/69)
 
 ## [0.2.0](https://github.com/jdx/usage/compare/v0.1.18..v0.2.0) - 2024-05-12
 
 ### 🚀 Features
 
-- **(exec)** added `usage exec` command by jdx in [f6b8175](https://github.com/jdx/usage/commit/f6b817521b9c2ff4304dc9f4f70f327054a75b60)
+- **(exec)** added `usage exec` command by [@jdx](https://github.com/jdx) in [#51](https://github.com/jdx/usage/pull/51)
 
 ### 🐛 Bug Fixes
 
-- rust beta warning by Jeff Dickey in [8ba775e](https://github.com/jdx/usage/commit/8ba775e02daef37193fa0f43d59f4a4ad3081056)
+- rust beta warning by [@jdx](https://github.com/jdx) in [8ba775e](https://github.com/jdx/usage/commit/8ba775e02daef37193fa0f43d59f4a4ad3081056)
 
 ### 🚜 Refactor
 
-- created reusuable CLI parse function by Jeff Dickey in [8bc895a](https://github.com/jdx/usage/commit/8bc895a02ba6c7df32d47d0847b5b1985a2dbfdb)
+- created reusuable CLI parse function by [@jdx](https://github.com/jdx) in [8bc895a](https://github.com/jdx/usage/commit/8bc895a02ba6c7df32d47d0847b5b1985a2dbfdb)
 
 ### 📚 Documentation
 
-- set GA by Jeff Dickey in [1a786c3](https://github.com/jdx/usage/commit/1a786c354a6e3f147453d8e6f38fb3916d21f889)
-- update cliff.toml by Jeff Dickey in [df5f579](https://github.com/jdx/usage/commit/df5f579deac8d6f0fa2b0d2a492847950e338c94)
+- set GA by [@jdx](https://github.com/jdx) in [1a786c3](https://github.com/jdx/usage/commit/1a786c354a6e3f147453d8e6f38fb3916d21f889)
+- update cliff.toml by [@jdx](https://github.com/jdx) in [df5f579](https://github.com/jdx/usage/commit/df5f579deac8d6f0fa2b0d2a492847950e338c94)
 
 ### 🔍 Other Changes
 
-- **(aur)** added aur packaging by Jeff Dickey in [e00aff9](https://github.com/jdx/usage/commit/e00aff9739bf4c2286124cdb4724bd09f3b39a21)
-- **(aur)** added aur packaging by Jeff Dickey in [e285fe9](https://github.com/jdx/usage/commit/e285fe9dcf6eabd684bb20607d64b8ebca29f663)
-- **(release-plz)** fixed script by Jeff Dickey in [e4b2223](https://github.com/jdx/usage/commit/e4b2223da399ca30fa33917cf4088bb52ee7e49a)
-- bump xx by Jeff Dickey in [c1bb0bb](https://github.com/jdx/usage/commit/c1bb0bb1c7600cf1ccb788c2d17651f6e93adf01)
-- removed mega-linter by Jeff Dickey in [1aaa11f](https://github.com/jdx/usage/commit/1aaa11f49f9a5cd04419c2aebfb71b824f3c5ad1)
-- fixing mise-action by Jeff Dickey in [c6a47fa](https://github.com/jdx/usage/commit/c6a47fa88cbd94de0fa0db2592a266b48c4c04ce)
-- remove invalid config by Jeff Dickey in [eec7f7d](https://github.com/jdx/usage/commit/eec7f7d2324151bc809c45e514040dc353d544cc)
-- better release PR title by Jeff Dickey in [849febb](https://github.com/jdx/usage/commit/849febbf6fc73fff6da6b3df15b9e31dad91580f)
+- **(aur)** added aur packaging by [@jdx](https://github.com/jdx) in [e00aff9](https://github.com/jdx/usage/commit/e00aff9739bf4c2286124cdb4724bd09f3b39a21)
+- **(aur)** added aur packaging by [@jdx](https://github.com/jdx) in [e285fe9](https://github.com/jdx/usage/commit/e285fe9dcf6eabd684bb20607d64b8ebca29f663)
+- **(release-plz)** fixed script by [@jdx](https://github.com/jdx) in [e4b2223](https://github.com/jdx/usage/commit/e4b2223da399ca30fa33917cf4088bb52ee7e49a)
+- bump xx by [@jdx](https://github.com/jdx) in [c1bb0bb](https://github.com/jdx/usage/commit/c1bb0bb1c7600cf1ccb788c2d17651f6e93adf01)
+- removed mega-linter by [@jdx](https://github.com/jdx) in [1aaa11f](https://github.com/jdx/usage/commit/1aaa11f49f9a5cd04419c2aebfb71b824f3c5ad1)
+- fixing mise-action by [@jdx](https://github.com/jdx) in [c6a47fa](https://github.com/jdx/usage/commit/c6a47fa88cbd94de0fa0db2592a266b48c4c04ce)
+- remove invalid config by [@jdx](https://github.com/jdx) in [eec7f7d](https://github.com/jdx/usage/commit/eec7f7d2324151bc809c45e514040dc353d544cc)
+- better release PR title by [@jdx](https://github.com/jdx) in [849febb](https://github.com/jdx/usage/commit/849febbf6fc73fff6da6b3df15b9e31dad91580f)
 
 ### 📦️ Dependency Updates
 
-- update dependency vitepress to v1.1.0 by renovate[bot] in [9ed3581](https://github.com/jdx/usage/commit/9ed3581f72acf66e5e96fbbbd1509ca6e9d9a15b)
-- lock file maintenance by renovate[bot] in [16920d0](https://github.com/jdx/usage/commit/16920d0a112c884aa5ede6f5b712d9dee9dd3248)
-- update dependency vitepress to v1.1.3 by renovate[bot] in [0f4911f](https://github.com/jdx/usage/commit/0f4911fcda305d39f63d44ea6a2b106ca802433e)
-- lock file maintenance by renovate[bot] in [d6437e5](https://github.com/jdx/usage/commit/d6437e537e75ee54d323e4c064a50d52e915d079)
-- update rust crate xx to 0.3 by renovate[bot] in [3298843](https://github.com/jdx/usage/commit/3298843a7a681aafe3df3bbf5e804fe7fcb398e2)
-- update dependency vitepress to v1.1.4 by renovate[bot] in [8257ab4](https://github.com/jdx/usage/commit/8257ab46c5fd807d48ae86103f4d4a16475b94c7)
-- lock file maintenance by renovate[bot] in [3c1e1e5](https://github.com/jdx/usage/commit/3c1e1e551e716ae5c98ede89a2e479a2b5af82ef)
+- update dependency vitepress to v1.1.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#55](https://github.com/jdx/usage/pull/55)
+- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#56](https://github.com/jdx/usage/pull/56)
+- update dependency vitepress to v1.1.3 by [@renovate[bot]](https://github.com/renovate[bot]) in [#57](https://github.com/jdx/usage/pull/57)
+- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#58](https://github.com/jdx/usage/pull/58)
+- update rust crate xx to 0.3 by [@renovate[bot]](https://github.com/renovate[bot]) in [#59](https://github.com/jdx/usage/pull/59)
+- update dependency vitepress to v1.1.4 by [@renovate[bot]](https://github.com/renovate[bot]) in [#60](https://github.com/jdx/usage/pull/60)
+- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#61](https://github.com/jdx/usage/pull/61)
 
 ## [0.1.18](https://github.com/jdx/usage/compare/v0.1.17..v0.1.18) - 2024-04-08
 
 ### 📚 Documentation
 
-- **(changelog)** ran git-cliff by Jeff Dickey in [e2b6df1](https://github.com/jdx/usage/commit/e2b6df1b7fdb0318fa0eed709396cd202abd296b)
-- improve CHANGELOG by jdx in [6280a73](https://github.com/jdx/usage/commit/6280a73c428ada2fda837db63f842eeb81c781ed)
+- **(changelog)** ran git-cliff by [@jdx](https://github.com/jdx) in [e2b6df1](https://github.com/jdx/usage/commit/e2b6df1b7fdb0318fa0eed709396cd202abd296b)
+- improve CHANGELOG by [@jdx](https://github.com/jdx) in [#43](https://github.com/jdx/usage/pull/43)
 
 ### 🔍 Other Changes
 
-- **(release-plz)** add all cargo files by Jeff Dickey in [6bc237d](https://github.com/jdx/usage/commit/6bc237d1babee025a0b4737781a6a742d93b7f4a)
-- switch to dtolnay/rust-toolchain by Jeff Dickey in [d96d2a3](https://github.com/jdx/usage/commit/d96d2a37ff801d10868db265f26c10cf42181a11)
+- **(release-plz)** add all cargo files by [@jdx](https://github.com/jdx) in [6bc237d](https://github.com/jdx/usage/commit/6bc237d1babee025a0b4737781a6a742d93b7f4a)
+- switch to dtolnay/rust-toolchain by [@jdx](https://github.com/jdx) in [d96d2a3](https://github.com/jdx/usage/commit/d96d2a37ff801d10868db265f26c10cf42181a11)
 
 ### 📦️ Dependency Updates
 
-- update dependency vitepress to v1.0.1 by renovate[bot] in [37e4580](https://github.com/jdx/usage/commit/37e4580afecf336fe75b6edb9d906edeff199742)
-- update actions/configure-pages action to v5 by renovate[bot] in [e08bae7](https://github.com/jdx/usage/commit/e08bae762d4c2619d47fef1ff98eb3809dc7a382)
-- lock file maintenance by renovate[bot] in [f2149ec](https://github.com/jdx/usage/commit/f2149eca7937fbdb155c2ae206b3840b9a1f2a64)
-- update dependency vitepress to v1.0.2 by renovate[bot] in [45f1fcb](https://github.com/jdx/usage/commit/45f1fcbc951440f982b8fbed7b3cea50ddac9226)
-- lock file maintenance by renovate[bot] in [ee69aca](https://github.com/jdx/usage/commit/ee69acae0368a6dcefbcaadeb48af95cf1108b47)
+- update dependency vitepress to v1.0.1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#42](https://github.com/jdx/usage/pull/42)
+- update actions/configure-pages action to v5 by [@renovate[bot]](https://github.com/renovate[bot]) in [#44](https://github.com/jdx/usage/pull/44)
+- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#45](https://github.com/jdx/usage/pull/45)
+- update dependency vitepress to v1.0.2 by [@renovate[bot]](https://github.com/renovate[bot]) in [#46](https://github.com/jdx/usage/pull/46)
+- lock file maintenance by [@renovate[bot]](https://github.com/renovate[bot]) in [#47](https://github.com/jdx/usage/pull/47)
 
 ## [0.1.17](https://github.com/jdx/usage/compare/v0.1.16..v0.1.17) - 2024-03-17
 
 ### 🔍 Other Changes
 
-- ensure we publish the CLI by Jeff Dickey in [8b1f379](https://github.com/jdx/usage/commit/8b1f379ed94b5e85429846d0e3d1b0198a1449d1)
-- bump release by Jeff Dickey in [3fa016a](https://github.com/jdx/usage/commit/3fa016a266753e9e5ebeb81eed61c74ced46e5cb)
+- ensure we publish the CLI by [@jdx](https://github.com/jdx) in [8b1f379](https://github.com/jdx/usage/commit/8b1f379ed94b5e85429846d0e3d1b0198a1449d1)
+- bump release by [@jdx](https://github.com/jdx) in [3fa016a](https://github.com/jdx/usage/commit/3fa016a266753e9e5ebeb81eed61c74ced46e5cb)
 
 ## [0.1.16](https://github.com/jdx/usage/compare/v0.1.9..v0.1.16) - 2024-03-17
 
 ### 🐛 Bug Fixes
 
-- **(completions)** add newline before error message by Jeff Dickey in [bbbafad](https://github.com/jdx/usage/commit/bbbafad126889ccc415e586b7601f7bb97c6f5a8)
-- bug fix for release tagging by Jeff Dickey in [2c4832f](https://github.com/jdx/usage/commit/2c4832f7c7c67d8d5c477a11e56a49b487f574b8)
+- **(completions)** add newline before error message by [@jdx](https://github.com/jdx) in [bbbafad](https://github.com/jdx/usage/commit/bbbafad126889ccc415e586b7601f7bb97c6f5a8)
+- bug fix for release tagging by [@jdx](https://github.com/jdx) in [2c4832f](https://github.com/jdx/usage/commit/2c4832f7c7c67d8d5c477a11e56a49b487f574b8)
 
 ### 🚜 Refactor
 
-- move usage-lib into its own dir by Jeff Dickey in [37e2379](https://github.com/jdx/usage/commit/37e2379122f123a85c4888e6efa1f62c631ac013)
+- move usage-lib into its own dir by [@jdx](https://github.com/jdx) in [37e2379](https://github.com/jdx/usage/commit/37e2379122f123a85c4888e6efa1f62c631ac013)
 
 ### 🧪 Testing
 
-- **(markdown-link-check)** ignore placeholder urls by Jeff Dickey in [6744453](https://github.com/jdx/usage/commit/67444538f25a11c09f842e20a5baa30fc3f41fae)
-- **(markdown-link-check)** ignore placeholder urls by Jeff Dickey in [940dfb7](https://github.com/jdx/usage/commit/940dfb7cd5d1dbc8d2f1bab3029c1c4ba786f6ee)
-- fix snapshots by Jeff Dickey in [0ea3d8b](https://github.com/jdx/usage/commit/0ea3d8b6ae7e3343c71c6d23b9e2b5d0f648a575)
-- fix deprecation warnings by Jeff Dickey in [be8d6d5](https://github.com/jdx/usage/commit/be8d6d5b9090103d5596ff6a038ad63e538c1722)
+- **(markdown-link-check)** ignore placeholder urls by [@jdx](https://github.com/jdx) in [6744453](https://github.com/jdx/usage/commit/67444538f25a11c09f842e20a5baa30fc3f41fae)
+- **(markdown-link-check)** ignore placeholder urls by [@jdx](https://github.com/jdx) in [940dfb7](https://github.com/jdx/usage/commit/940dfb7cd5d1dbc8d2f1bab3029c1c4ba786f6ee)
+- fix snapshots by [@jdx](https://github.com/jdx) in [0ea3d8b](https://github.com/jdx/usage/commit/0ea3d8b6ae7e3343c71c6d23b9e2b5d0f648a575)
+- fix deprecation warnings by [@jdx](https://github.com/jdx) in [be8d6d5](https://github.com/jdx/usage/commit/be8d6d5b9090103d5596ff6a038ad63e538c1722)
 
 ### 🔍 Other Changes
 
-- **(release-plz)** autopublish tag/gh release by Jeff Dickey in [5f78550](https://github.com/jdx/usage/commit/5f7855048912adda5ebfa6cfd2375cf5e5ccb79b)
-- **(release-plz)** remove old logic by Jeff Dickey in [9ac8a0e](https://github.com/jdx/usage/commit/9ac8a0e95ae51398633486365a45a447bd8664e5)
-- **(release-plz)** prefix versions with "v" by Jeff Dickey in [964503c](https://github.com/jdx/usage/commit/964503c57d8960abec4d6655257c1b904e585eba)
-- added author field by Jeff Dickey in [b0e815a](https://github.com/jdx/usage/commit/b0e815a72bf4bfad6659a909a058cd86b7f9d56d)
-- snapshots by Jeff Dickey in [3f0f16c](https://github.com/jdx/usage/commit/3f0f16c9b4fc2ff346a97644e97878916c1fa630)
-- added brew tap to gh actions by Jeff Dickey in [e79f386](https://github.com/jdx/usage/commit/e79f386ff75bea7d35f3c90f0060a94656169c51)
-- added git-cliff by Jeff Dickey in [6cca2bb](https://github.com/jdx/usage/commit/6cca2bbc77e459c45838e1957bc35eb42601a727)
-- added release-please by Jeff Dickey in [e60127f](https://github.com/jdx/usage/commit/e60127f63a48a841b9aadfa04c9c4df045167dde)
-- attempt to fix mega-linter by Jeff Dickey in [25a35e0](https://github.com/jdx/usage/commit/25a35e064c2ca29771d1c6b1ac5d2bea2b03b530)
-- bootstrap release-please by jdx in [b6a7584](https://github.com/jdx/usage/commit/b6a758421231e33582c9571aa3690936faa1e59b)
-- release-plz by Jeff Dickey in [b7aa490](https://github.com/jdx/usage/commit/b7aa490d7b401d86ac11569aae824951ab4de27c)
-- cargo update by Jeff Dickey in [0aa872c](https://github.com/jdx/usage/commit/0aa872ca68822d32d9fa8a5228525124ed076abb)
-- remove markdown link checker since it keeps failing by Jeff Dickey in [0668a1f](https://github.com/jdx/usage/commit/0668a1f6dae63bd3ea916939ab0a4c9c58fd0c13)
-- fixing cargo metadata by Jeff Dickey in [64f19d7](https://github.com/jdx/usage/commit/64f19d7d40de0f897ccd22c07cd72e74b98b435f)
-- use custom release-plz logic by Jeff Dickey in [bf4c151](https://github.com/jdx/usage/commit/bf4c151205d0560eefbf7a64cefd2524c57813db)
-- bump version to try another release by Jeff Dickey in [badf251](https://github.com/jdx/usage/commit/badf251feb7fe86d763e4458261060b81f85fe7e)
-- set metadata for usage-lib dependency by Jeff Dickey in [7e3538a](https://github.com/jdx/usage/commit/7e3538a304372c8d010386e22d39c02c9319d297)
-- added git-cliff dependency by Jeff Dickey in [afd74d0](https://github.com/jdx/usage/commit/afd74d020d86fd77fe9b0696ae63863237297009)
-- bump version to try another release by Jeff Dickey in [032f686](https://github.com/jdx/usage/commit/032f6860f569874e8ca2928f7db367191a8e69b3)
-- bump release by Jeff Dickey in [4f3e3ea](https://github.com/jdx/usage/commit/4f3e3ea284968006e677402bd78afd3c592698b4)
-- release on tags by Jeff Dickey in [6fd60be](https://github.com/jdx/usage/commit/6fd60be73ed06d62520fd2d39f175857243ec6e7)
-- bump release by Jeff Dickey in [58be1c4](https://github.com/jdx/usage/commit/58be1c40f45fa86d1d8c6c6e58cbec85451c0d40)
-- bump release by Jeff Dickey in [cd92e36](https://github.com/jdx/usage/commit/cd92e366ee60d9ea2cc6b43f9dadc7f27c0dd63e)
+- **(release-plz)** autopublish tag/gh release by [@jdx](https://github.com/jdx) in [5f78550](https://github.com/jdx/usage/commit/5f7855048912adda5ebfa6cfd2375cf5e5ccb79b)
+- **(release-plz)** remove old logic by [@jdx](https://github.com/jdx) in [9ac8a0e](https://github.com/jdx/usage/commit/9ac8a0e95ae51398633486365a45a447bd8664e5)
+- **(release-plz)** prefix versions with "v" by [@jdx](https://github.com/jdx) in [964503c](https://github.com/jdx/usage/commit/964503c57d8960abec4d6655257c1b904e585eba)
+- added author field by [@jdx](https://github.com/jdx) in [b0e815a](https://github.com/jdx/usage/commit/b0e815a72bf4bfad6659a909a058cd86b7f9d56d)
+- snapshots by [@jdx](https://github.com/jdx) in [3f0f16c](https://github.com/jdx/usage/commit/3f0f16c9b4fc2ff346a97644e97878916c1fa630)
+- added brew tap to gh actions by [@jdx](https://github.com/jdx) in [e79f386](https://github.com/jdx/usage/commit/e79f386ff75bea7d35f3c90f0060a94656169c51)
+- added git-cliff by [@jdx](https://github.com/jdx) in [6cca2bb](https://github.com/jdx/usage/commit/6cca2bbc77e459c45838e1957bc35eb42601a727)
+- added release-please by [@jdx](https://github.com/jdx) in [e60127f](https://github.com/jdx/usage/commit/e60127f63a48a841b9aadfa04c9c4df045167dde)
+- attempt to fix mega-linter by [@jdx](https://github.com/jdx) in [25a35e0](https://github.com/jdx/usage/commit/25a35e064c2ca29771d1c6b1ac5d2bea2b03b530)
+- bootstrap release-please by [@jdx](https://github.com/jdx) in [b6a7584](https://github.com/jdx/usage/commit/b6a758421231e33582c9571aa3690936faa1e59b)
+- release-plz by [@jdx](https://github.com/jdx) in [b7aa490](https://github.com/jdx/usage/commit/b7aa490d7b401d86ac11569aae824951ab4de27c)
+- cargo update by [@jdx](https://github.com/jdx) in [0aa872c](https://github.com/jdx/usage/commit/0aa872ca68822d32d9fa8a5228525124ed076abb)
+- remove markdown link checker since it keeps failing by [@jdx](https://github.com/jdx) in [0668a1f](https://github.com/jdx/usage/commit/0668a1f6dae63bd3ea916939ab0a4c9c58fd0c13)
+- fixing cargo metadata by [@jdx](https://github.com/jdx) in [64f19d7](https://github.com/jdx/usage/commit/64f19d7d40de0f897ccd22c07cd72e74b98b435f)
+- use custom release-plz logic by [@jdx](https://github.com/jdx) in [bf4c151](https://github.com/jdx/usage/commit/bf4c151205d0560eefbf7a64cefd2524c57813db)
+- bump version to try another release by [@jdx](https://github.com/jdx) in [badf251](https://github.com/jdx/usage/commit/badf251feb7fe86d763e4458261060b81f85fe7e)
+- set metadata for usage-lib dependency by [@jdx](https://github.com/jdx) in [7e3538a](https://github.com/jdx/usage/commit/7e3538a304372c8d010386e22d39c02c9319d297)
+- added git-cliff dependency by [@jdx](https://github.com/jdx) in [afd74d0](https://github.com/jdx/usage/commit/afd74d020d86fd77fe9b0696ae63863237297009)
+- bump version to try another release by [@jdx](https://github.com/jdx) in [032f686](https://github.com/jdx/usage/commit/032f6860f569874e8ca2928f7db367191a8e69b3)
+- bump release by [@jdx](https://github.com/jdx) in [4f3e3ea](https://github.com/jdx/usage/commit/4f3e3ea284968006e677402bd78afd3c592698b4)
+- release on tags by [@jdx](https://github.com/jdx) in [6fd60be](https://github.com/jdx/usage/commit/6fd60be73ed06d62520fd2d39f175857243ec6e7)
+- bump release by [@jdx](https://github.com/jdx) in [58be1c4](https://github.com/jdx/usage/commit/58be1c40f45fa86d1d8c6c6e58cbec85451c0d40)
+- bump release by [@jdx](https://github.com/jdx) in [cd92e36](https://github.com/jdx/usage/commit/cd92e366ee60d9ea2cc6b43f9dadc7f27c0dd63e)
 
 ### 📦️ Dependency Updates
 
-- update rust crate heck to v0.5.0 by renovate[bot] in [7026baf](https://github.com/jdx/usage/commit/7026baf79fe51e08310a1a9d0a56071445a1d0ea)
-- update dependency vitepress to v1.0.0-rc.45 by renovate[bot] in [b4b8054](https://github.com/jdx/usage/commit/b4b8054d74d9df6826e2c44b051ec4823b646c0b)
+- update rust crate heck to v0.5.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#30](https://github.com/jdx/usage/pull/30)
+- update dependency vitepress to v1.0.0-rc.45 by [@renovate[bot]](https://github.com/renovate[bot]) in [b4b8054](https://github.com/jdx/usage/commit/b4b8054d74d9df6826e2c44b051ec4823b646c0b)
 
 ## [0.1.9](https://github.com/jdx/usage/compare/v0.1.8..v0.1.9) - 2024-02-13
 
 ### 🐛 Bug Fixes
 
-- fix actionlint by Jeff Dickey in [725bcf9](https://github.com/jdx/usage/commit/725bcf96055aafc9f0a58e0c8affe2c0ac7f3ba9)
+- fix actionlint by [@jdx](https://github.com/jdx) in [725bcf9](https://github.com/jdx/usage/commit/725bcf96055aafc9f0a58e0c8affe2c0ac7f3ba9)
 
 ### 🔍 Other Changes
 
-- improve error by Jeff Dickey in [4621457](https://github.com/jdx/usage/commit/4621457b6cccde7f01ba60afe6c33870201975be)
+- improve error by [@jdx](https://github.com/jdx) in [4621457](https://github.com/jdx/usage/commit/4621457b6cccde7f01ba60afe6c33870201975be)
 
 ## [0.1.8](https://github.com/jdx/usage/compare/v0.1.7..v0.1.8) - 2024-02-10
 
 ### 🐛 Bug Fixes
 
-- fix binstall by Jeff Dickey in [a3b4513](https://github.com/jdx/usage/commit/a3b45132dd4b9f6b4d7a1ae224de455f28de75dd)
+- fix binstall by [@jdx](https://github.com/jdx) in [a3b4513](https://github.com/jdx/usage/commit/a3b45132dd4b9f6b4d7a1ae224de455f28de75dd)
 
 ### 📦️ Dependency Updates
 
-- update stefanzweifel/git-auto-commit-action action to v5 by renovate[bot] in [d94f323](https://github.com/jdx/usage/commit/d94f3231e91b21d39b8b3069298553308d64e721)
+- update stefanzweifel/git-auto-commit-action action to v5 by [@renovate[bot]](https://github.com/renovate[bot]) in [#25](https://github.com/jdx/usage/pull/25)
 
 ## [0.1.7](https://github.com/jdx/usage/compare/v0.1.6..v0.1.7) - 2024-02-10
 
 ### 🐛 Bug Fixes
 
-- fix apple urls for binstall by Jeff Dickey in [06261f0](https://github.com/jdx/usage/commit/06261f0174bc0a95f216a9b22f85b0955f8c4a26)
+- fix apple urls for binstall by [@jdx](https://github.com/jdx) in [06261f0](https://github.com/jdx/usage/commit/06261f0174bc0a95f216a9b22f85b0955f8c4a26)
 
 ## [0.1.6] - 2024-02-10
 
 ### 🔍 Other Changes
 
-- add config for cargo-binstall by Jeff Dickey in [9711365](https://github.com/jdx/usage/commit/9711365fbfe1b39df03597af93caf9ca1b0e1b62)
+- add config for cargo-binstall by [@jdx](https://github.com/jdx) in [9711365](https://github.com/jdx/usage/commit/9711365fbfe1b39df03597af93caf9ca1b0e1b62)
 
 ### 📦️ Dependency Updates
 
-- update actions/checkout action to v4 by renovate[bot] in [d764e27](https://github.com/jdx/usage/commit/d764e272964fa03207466a564469b63910599970)
+- update actions/checkout action to v4 by [@renovate[bot]](https://github.com/renovate[bot]) in [#23](https://github.com/jdx/usage/pull/23)
 
 <!-- generated by git-cliff -->

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
@@ -183,9 +183,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.1.21"
+version = "1.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
+checksum = "9540e661f81799159abee814118cc139a2004b3a3aa3ea37724a1b66530b90e0"
 dependencies = [
  "shlex",
 ]
@@ -261,7 +261,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.78",
 ]
 
 [[package]]
@@ -356,7 +356,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
 dependencies = [
  "quote",
- "syn 2.0.77",
+ "syn 2.0.78",
 ]
 
 [[package]]
@@ -799,7 +799,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.78",
 ]
 
 [[package]]
@@ -932,7 +932,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.78",
 ]
 
 [[package]]
@@ -1169,7 +1169,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.78",
 ]
 
 [[package]]
@@ -1270,7 +1270,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.77",
+ "syn 2.0.78",
 ]
 
 [[package]]
@@ -1314,9 +1314,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "81b9b4733a9c8b8aaa20634df36eeb68cc0c0669f2e18fb287006b496a14195d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1389,7 +1389,7 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.78",
 ]
 
 [[package]]
@@ -1474,7 +1474,7 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "usage-cli"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1501,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "usage-lib"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "clap",
  "ctor",
@@ -1580,7 +1580,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.78",
  "wasm-bindgen-shared",
 ]
 
@@ -1602,7 +1602,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.78",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1689,7 +1689,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.78",
 ]
 
 [[package]]
@@ -1700,7 +1700,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.78",
 ]
 
 [[package]]
@@ -1833,5 +1833,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.78",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT"
 
 [workspace.dependencies]
 usage-cli = { path = "./cli" }
-usage-lib = { path = "./lib", version = "0.7.0", features = ["clap"] }
+usage-lib = { path = "./lib", version = "0.7.1", features = ["clap"] }
 
 [workspace.metadata.release]
 allow-branch = ["main"]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-cli"
 edition = "2021"
-version = "0.7.0"
+version = "0.7.1"
 description = "CLI for working with usage-based CLIs"
 license = { workspace = true }
 authors = { workspace = true }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-lib"
 edition = "2021"
-version = "0.7.0"
+version = "0.7.1"
 rust-version = "1.70.0"
 include = [
     "/Cargo.toml",


### PR DESCRIPTION
## [0.7.1](https://github.com/jdx/usage/compare/v0.7.0..v0.7.1) - 2024-09-27

### 🐛 Bug Fixes

- fail parsing if required args/flags not found by [@jdx](https://github.com/jdx) in [409145a](https://github.com/jdx/usage/commit/409145ae5db937bffa121e63f00f8f827c49b294)

### 🔍 Other Changes

- publish aur releases by [@jdx](https://github.com/jdx) in [#109](https://github.com/jdx/usage/pull/109)
- move tasks dir by [@jdx](https://github.com/jdx) in [8cb8cc3](https://github.com/jdx/usage/commit/8cb8cc348dbb04f3c41f3ca22c518f82dfa27830)
- install cargo-binstall before installing mise by [@jdx](https://github.com/jdx) in [6240460](https://github.com/jdx/usage/commit/62404602e602a1c7d578b5764703f0820c45299e)