### PR TITLE
chore: release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## [1.1.0](https://github.com/jdx/usage/compare/v1.0.1..v1.1.0) - 2024-11-04
+
+### 🚀 Features
+
+- added clap_usage by [@jdx](https://github.com/jdx) in [#150](https://github.com/jdx/usage/pull/150)
+- added completions for usage-cli itself by [@jdx](https://github.com/jdx) in [#151](https://github.com/jdx/usage/pull/151)
+
+### 🐛 Bug Fixes
+
+- pass exit codes with `usage bash` and `usage exec` by [@jdx](https://github.com/jdx) in [#152](https://github.com/jdx/usage/pull/152)
+- tweaks to fig completions by [@jdx](https://github.com/jdx) in [#153](https://github.com/jdx/usage/pull/153)
+- Include the generator for mount run commands by [@miguelmig](https://github.com/miguelmig) in [#154](https://github.com/jdx/usage/pull/154)
+
+### 📚 Documentation
+
+- fix highlighting by [@jdx](https://github.com/jdx) in [c03b934](https://github.com/jdx/usage/commit/c03b9348d0472891eef45a4ca4db1786bdb3683e)
+
+### 🔍 Other Changes
+
+- generate markdown examples by [@jdx](https://github.com/jdx) in [5057650](https://github.com/jdx/usage/commit/50576504497435138d301d3f2ee18258c8c2e5c0)
+- Add fig generate completion subcommand by [@miguelmig](https://github.com/miguelmig) in [#148](https://github.com/jdx/usage/pull/148)
+- run render when creating release by [@jdx](https://github.com/jdx) in [7d723b7](https://github.com/jdx/usage/commit/7d723b7525cf54a58aaedfcbac7352334fd9c3bb)
+- set clap_usage version by [@jdx](https://github.com/jdx) in [0a4909f](https://github.com/jdx/usage/commit/0a4909f39ac42b11bc4f9e0e23daf01466e12969)
+- do not bump clap_usage on every release by [@jdx](https://github.com/jdx) in [2cac664](https://github.com/jdx/usage/commit/2cac6649ca29bfdad4cb9f3aee0573f6be587d1e)
+- fix autolint action by [@jdx](https://github.com/jdx) in [#155](https://github.com/jdx/usage/pull/155)
+
+### 📦️ Dependency Updates
+
+- update dependency vitepress to v1.4.5 by [@renovate[bot]](https://github.com/renovate[bot]) in [#145](https://github.com/jdx/usage/pull/145)
+
+### New Contributors
+
+- @miguelmig made their first contribution in [#154](https://github.com/jdx/usage/pull/154)
+
 ## [1.0.1](https://github.com/jdx/usage/compare/v1.0.0..v1.0.1) - 2024-10-31
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.17"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a1e53f0f5d86382dafe1cf314783b2044280f406e7e1506368220ad11b1338"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -58,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8365de52b16c035ff4fcafe0092ba9390540e3e352870ac09933bebcaa2c8c56"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
@@ -177,9 +177,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.1.31"
+version = "1.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
+checksum = "67b9470d453346108f93a59222a9a1a5724db32d0a4727b7ab7ace4b4d822dc9"
 dependencies = [
  "shlex",
 ]
@@ -261,7 +261,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -365,7 +365,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
 dependencies = [
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -560,9 +560,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
 
 [[package]]
 name = "heck"
@@ -655,9 +655,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.41.0"
+version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f72d3e19488cf7d8ea52d2fc0f8754fc933398b337cd3cbdb28aaeb35159ef"
+checksum = "7e9ffc4d4892617c50a928c52b2961cb5174b6fc6ebf252b2fac9d21955c48b8"
 dependencies = [
  "console",
  "lazy_static",
@@ -799,7 +799,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -931,7 +931,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1162,7 +1162,7 @@ checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1263,7 +1263,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1307,9 +1307,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.85"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1367,22 +1367,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.65"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
+checksum = "02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.65"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
+checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1467,7 +1467,7 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "usage-cli"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "usage-lib"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "clap",
  "ctor",
@@ -1577,7 +1577,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
@@ -1599,7 +1599,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1686,7 +1686,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1697,7 +1697,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1830,5 +1830,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.87",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT"
 [workspace.dependencies]
 clap_usage = { path = "./clap_usage", version = "0.2.0" }
 usage-cli = { path = "./cli" }
-usage-lib = { path = "./lib", version = "1.0.1", features = ["clap"] }
+usage-lib = { path = "./lib", version = "1.1.0", features = ["clap"] }
 
 [workspace.metadata.release]
 allow-branch = ["main"]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-cli"
 edition = "2021"
-version = "1.0.1"
+version = "1.1.0"
 description = "CLI for working with usage-based CLIs"
 license = { workspace = true }
 authors = { workspace = true }

--- a/cli/usage.usage.kdl
+++ b/cli/usage.usage.kdl
@@ -1,6 +1,6 @@
 name "usage-cli"
 bin "usage"
-version "1.0.1"
+version "1.1.0"
 about "CLI for working with usage-based CLIs"
 usage "Usage: usage-cli [OPTIONS] [COMPLETIONS] <COMMAND>"
 flag "--usage-spec" help="Outputs a `usage.kdl` spec for this CLI itself"

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -1,5 +1,5 @@
 # `usage`
-- **version**: 1.0.1
+- **version**: 1.1.0
 
 CLI for working with usage-based CLIs
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-lib"
 edition = "2021"
-version = "1.0.1"
+version = "1.1.0"
 rust-version = "1.70.0"
 include = [
     "/Cargo.toml",


### PR DESCRIPTION
## [1.1.0](https://github.com/jdx/usage/compare/v1.0.1..v1.1.0) - 2024-11-04

### 🚀 Features

- added clap_usage by [@jdx](https://github.com/jdx) in [#150](https://github.com/jdx/usage/pull/150)
- added completions for usage-cli itself by [@jdx](https://github.com/jdx) in [#151](https://github.com/jdx/usage/pull/151)

### 🐛 Bug Fixes

- pass exit codes with `usage bash` and `usage exec` by [@jdx](https://github.com/jdx) in [#152](https://github.com/jdx/usage/pull/152)
- tweaks to fig completions by [@jdx](https://github.com/jdx) in [#153](https://github.com/jdx/usage/pull/153)
- Include the generator for mount run commands by [@miguelmig](https://github.com/miguelmig) in [#154](https://github.com/jdx/usage/pull/154)

### 📚 Documentation

- fix highlighting by [@jdx](https://github.com/jdx) in [c03b934](https://github.com/jdx/usage/commit/c03b9348d0472891eef45a4ca4db1786bdb3683e)

### 🔍 Other Changes

- generate markdown examples by [@jdx](https://github.com/jdx) in [5057650](https://github.com/jdx/usage/commit/50576504497435138d301d3f2ee18258c8c2e5c0)
- Add fig generate completion subcommand by [@miguelmig](https://github.com/miguelmig) in [#148](https://github.com/jdx/usage/pull/148)
- run render when creating release by [@jdx](https://github.com/jdx) in [7d723b7](https://github.com/jdx/usage/commit/7d723b7525cf54a58aaedfcbac7352334fd9c3bb)
- set clap_usage version by [@jdx](https://github.com/jdx) in [0a4909f](https://github.com/jdx/usage/commit/0a4909f39ac42b11bc4f9e0e23daf01466e12969)
- do not bump clap_usage on every release by [@jdx](https://github.com/jdx) in [2cac664](https://github.com/jdx/usage/commit/2cac6649ca29bfdad4cb9f3aee0573f6be587d1e)
- fix autolint action by [@jdx](https://github.com/jdx) in [#155](https://github.com/jdx/usage/pull/155)

### 📦️ Dependency Updates

- update dependency vitepress to v1.4.5 by [@renovate[bot]](https://github.com/renovate[bot]) in [#145](https://github.com/jdx/usage/pull/145)

### New Contributors

- @miguelmig made their first contribution in [#154](https://github.com/jdx/usage/pull/154)