### PR TITLE
Add fig generate completion subcommand

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,3 @@
+---
+exclude_paths:
+ - "tasks/fig/generators.ts"

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,3 +1,3 @@
 ---
 exclude_paths:
- - "tasks/fig/generators.ts"
+  - "tasks/fig/generators.ts"

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 CHANGELOG.md
 docs/.vitepress
+docs/cli/reference.md
 docs/public/site.webmanifest
 examples/docs
 lefthook.yml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1476,6 +1476,7 @@ dependencies = [
  "predicates",
  "regex",
  "serde",
+ "serde_json",
  "strum",
  "tera",
  "thiserror",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -42,6 +42,7 @@ tera = "1"
 thiserror = "1"
 usage-lib = { workspace = true, features = ["clap", "docs"] }
 xx = "1"
+serde_json = "1.0"
 
 [dev-dependencies]
 assert_cmd = { version = "2", features = ["color-auto"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -37,12 +37,12 @@ miette = { version = "5", features = ["fancy"] }
 once_cell = "1"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1.0"
 strum = { version = "0.26", features = ["derive"] }
 tera = "1"
 thiserror = "1"
 usage-lib = { workspace = true, features = ["clap", "docs"] }
 xx = "1"
-serde_json = "1.0"
 
 [dev-dependencies]
 assert_cmd = { version = "2", features = ["color-auto"] }

--- a/cli/src/cli/generate/fig.rs
+++ b/cli/src/cli/generate/fig.rs
@@ -16,7 +16,7 @@ pub struct Fig {
     #[clap(short, long)]
     file: Option<PathBuf>,
 
-    /// To generate the fig outputs based on standard input instead of file
+    /// raw string spec input
     #[clap(long, required_unless_present="file", overrides_with = "file")]
     spec: Option<String>,
 

--- a/cli/src/cli/generate/fig.rs
+++ b/cli/src/cli/generate/fig.rs
@@ -130,7 +130,7 @@ impl FigGenerator {
 }
 
 impl FigArg {
-    fn get_template(name: &String) -> Option<String> {
+    fn get_template(name: &str) -> Option<String> {
         name.to_lowercase()
             .contains("file")
             .then(|| "filepaths".to_string())
@@ -144,7 +144,7 @@ impl FigArg {
                 .then(|| "filepaths".to_string()))
     }
 
-    fn get_generator(name: &String) -> Option<FigGenerator> {
+    fn get_generator(name: &str) -> Option<FigGenerator> {
         name.to_lowercase()
             .contains("env_vars")
             .then(|| FigGenerator::create_simple_generator(GeneratorType::EnvVar))
@@ -161,7 +161,7 @@ impl FigArg {
         }
     }
 
-    fn get_name(name: &String) -> String {
+    fn get_name(name: &str) -> String {
         name.replace("<", "")
             .replace(">", "")
             .replace("[", "")

--- a/cli/src/cli/generate/fig.rs
+++ b/cli/src/cli/generate/fig.rs
@@ -1,0 +1,342 @@
+use std::path::PathBuf;
+use std::vec;
+
+use clap::Args;
+use indexmap::IndexMap;
+use itertools::Itertools;
+use usage::{SpecArg, SpecCommand, SpecComplete, SpecFlag};
+
+use serde::{Deserialize, Serialize, Serializer};
+use crate::cli::generate;
+
+#[derive(Args)]
+#[clap()]
+pub struct Fig {
+    /// A usage spec taken in as a file
+    #[clap(short, long)]
+    file: Option<PathBuf>,
+
+    /// To generate the fig outputs based on standard input instead of file
+    #[clap(long, required_unless_present="file", overrides_with = "file")]
+    spec: Option<String>,
+
+    /// File on where to save the generated Fig spec
+    #[clap(long, value_hint = clap::ValueHint::FilePath)]
+    out_file: Option<PathBuf>,
+
+    /// Whether to output to stdout
+    #[clap(long, action = clap::ArgAction::SetTrue, required_unless_present="out_file", overrides_with = "out_file")]
+    stdout: Option<bool>
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
+enum GeneratorType {
+    EnvVar,
+    Complete,
+}
+
+#[derive(Deserialize, Clone)]
+struct FigGenerator {
+    type_: GeneratorType,
+    post_process: String,
+    template_str: String,
+}
+
+impl Serialize for FigGenerator {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> 
+        where
+            S: Serializer {
+        serializer.serialize_str(&self.template_str)
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")] 
+struct FigArg {
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    is_optional: bool,
+    is_variadic: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    template: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    generators: Option<FigGenerator>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    suggestions: Vec<String>
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+struct FigOption {
+    name: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(rename(serialize = "isRepeatable"))]
+    is_repeatable: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    args: Option<FigArg>
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")] 
+struct FigCommand {
+    name: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    subcommands: Vec<FigCommand>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    options: Vec<FigOption>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    args: Vec<FigArg>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    generate_spec: Option<String>
+}
+
+impl FigGenerator {
+    pub fn create_simple_generator(type_: GeneratorType) -> Self {
+        Self {
+            type_: type_.clone(),
+            template_str: FigGenerator::get_generator_name(type_).to_uppercase(),
+            post_process: "".to_string()
+        }
+    }
+
+    fn get_generator_name(type_: GeneratorType) -> String {
+        match type_.clone() {
+            GeneratorType::EnvVar => "envVarGenerator".to_string(),
+            GeneratorType::Complete => "completionGeneratorTemplate".to_string(),
+        }
+    }
+
+    fn get_generator_arg(&self) -> String {
+        match self.type_ {
+            GeneratorType::Complete => {
+                let postprocess = self.post_process.clone();
+                format!("(`{postprocess}`)")
+            }
+            _ => {
+                "".to_string()
+            }
+        }
+    }
+
+    pub fn get_generator_text(&self) -> String {
+        let generator_name = FigGenerator::get_generator_name(self.type_.clone());
+        let arg = self.get_generator_arg();
+
+        format!("{generator_name}{arg}")
+    }
+
+}
+
+impl FigArg {
+    fn get_template(name: &String) -> Option<String> {
+        name.to_lowercase().contains("file")
+            .then(|| "filepaths".to_string())
+            .or(name.to_lowercase().contains("dir").then(|| "folders".to_string()))
+            .or(name.to_lowercase().contains("path").then(|| "filepaths".to_string()))
+    }
+
+    fn get_generator(name: &String) -> Option<FigGenerator> {
+        name.to_lowercase().contains("env_vars")
+        .then(|| FigGenerator::create_simple_generator(GeneratorType::EnvVar))
+        .or(name.to_lowercase().contains("env_var")
+            .then(|| FigGenerator::create_simple_generator(GeneratorType::EnvVar)))
+    }
+
+    pub fn get_generators(&self) -> Vec<FigGenerator> {
+        match self.generators.clone() {
+            Some(a) => vec![a],
+            None => vec![]
+        }
+    }
+
+    fn get_name(name: &String) -> String {
+        name.replace("<", "")
+            .replace(">", "")
+            .replace("[", "")
+            .replace("]", "").to_ascii_lowercase()
+    }
+
+    pub fn parse_from_spec(arg: &SpecArg) -> Self {
+        Self {
+            name: FigArg::get_name(&arg.name),
+            description: arg.help.clone(),
+            is_variadic: arg.var, 
+            is_optional: !arg.required,
+            template: FigArg::get_template(&arg.name),
+            generators: FigArg::get_generator(&arg.name),
+            suggestions: arg.choices.clone().map(|c|c.choices).unwrap_or(vec![])
+        }
+    }
+
+    pub fn update_from_complete(&mut self, spec: SpecComplete) {
+        let name = spec.name;
+        
+        self.generators = self.generators.clone().or_else(|| Some(FigGenerator {
+            type_: GeneratorType::Complete,
+            post_process: spec.run.unwrap_or("".to_string()),
+            template_str: format!("${name}$")
+        }))
+    }
+}
+
+impl FigOption {
+    fn get_names(flag: &SpecFlag) -> Vec<String> {
+        let mut n: Vec<String> = flag.short.iter().map(|c|format!("-{c}")).collect();
+        n.extend(flag.long.iter().map(|l| format!("--{l}")));
+        return n
+    }
+
+    pub fn get_generators(&self) -> Vec<FigGenerator> {
+        self.args.iter().cloned()
+        .filter(|a| a.generators.is_some())
+        .map(|a| a.generators.unwrap())
+        .collect()
+    }
+
+    pub fn get_args(&mut self) -> Vec<&mut FigArg> {
+        self.args.as_mut()
+            .and_then(|a| Some(vec![a]))
+            .unwrap_or(vec![])
+    }
+
+    pub fn parse_from_spec(flag: &SpecFlag) -> Self {
+        Self {
+            name: FigOption::get_names(flag),
+            description: flag.help.clone(),
+            is_repeatable: flag.var,
+            args: flag.arg.clone().map(|arg | FigArg::parse_from_spec(&arg))
+        }
+    }   
+}
+impl FigCommand {
+    fn get_names(cmd: &SpecCommand) -> Vec<String> {
+        let mut r = vec![cmd.name.clone()];
+        r.extend(cmd.aliases.clone());
+        r
+    }
+
+    pub fn get_generators(&self) -> Vec<FigGenerator> {
+        let sub = self.subcommands.iter()
+            .map(|s| s.get_generators())
+            .collect_vec().concat();
+        let opt = self.options.iter().map(|o| o.get_generators()).collect_vec().concat();
+        let args = self.args.iter().map(|a| a.get_generators()).collect_vec().concat();
+        [sub,opt,args].concat()
+    }
+
+    pub fn get_commands(&self) -> Vec<FigCommand> {
+        let subcmds = self.subcommands.iter()
+            .map(|s| s.get_commands())
+            .concat();
+        [subcmds, vec![self.clone()]].concat()
+    }
+
+    pub fn get_args(&mut self) -> Vec<&mut FigArg> {
+        let opt_args = self.options.iter_mut()
+            .map(|o| o.get_args()).concat();
+        let sub_args = self.subcommands.iter_mut()
+            .map(|c| c.get_args()).concat();
+        
+        let args = self.args.iter_mut().map(|a| a).collect_vec();
+        let mut result = Vec::new();
+        for vec in [opt_args, sub_args, args] {
+            result.extend(vec);
+        }
+        result
+    }
+
+    pub fn parse_from_spec(cmd: &SpecCommand) -> Option<Self> {
+        (!cmd.hide).then(|| Self {
+            name: FigCommand::get_names(cmd),
+            description: cmd.help.clone(),
+            subcommands: cmd.subcommands.iter()
+                .filter(|(_, v)| !v.hide)
+                .map(|(_, v)| FigCommand::parse_from_spec(v))
+                .flatten()
+                .collect(),
+            options: cmd.flags.iter()
+                .filter(|f| !f.hide)
+                .map(|flag| FigOption::parse_from_spec(flag))
+                .collect(),
+            args: cmd.args.iter()
+                .filter(|a| !a.hide)
+                .map(|arg| FigArg::parse_from_spec(arg))
+                .collect(),
+            generate_spec: (cmd.mounts.len() > 0).then(|| {
+                let calls = cmd.mounts.iter().cloned().map(|m| {
+                    let run = m.run;
+                    format!("\"{run}\"")
+                }).join(",");
+                format!("${calls}$")
+            })
+        })
+    }
+}
+
+impl Fig {
+    pub fn run(&self) -> miette::Result<()> {
+        let write = |path: &PathBuf, md: &str| -> miette::Result<()> {
+            println!("writing to {}", path.display());
+            xx::file::write(path, format!("{}\n", md.trim()))?;
+            Ok(())
+        };
+        let spec = generate::file_or_spec(&self.file, &self.spec)?;
+        let mut main_command = FigCommand::parse_from_spec(&spec.cmd).unwrap();
+        let args = main_command.get_args();
+        let completes = spec.complete;
+        Fig::fill_args_complete(args, completes);
+        let j = serde_json::to_string_pretty(&main_command).unwrap();
+        let path = self.out_file.clone().unwrap_or(PathBuf::from("./usage.ts"));
+        let mut result = format!("const completionSpec: Fig.Spec = {j}");
+        
+        let generators = main_command.get_generators();
+        generators.iter().cloned().for_each(|g| {
+            let template_str = g.clone().template_str;
+            let generator_call_text = g.get_generator_text();
+            result = result.replace(format!("\"{template_str}\"").as_str(), generator_call_text.as_str())
+        });
+
+        // Handle mount run commands
+        main_command.get_commands().iter().cloned()
+            .filter(|cmd| cmd.generate_spec.is_some())
+            .for_each(|cmd| {
+                let call_template_str = cmd.generate_spec.unwrap();
+                let args = call_template_str.replace("$", "");
+                let replace_str = call_template_str.replace("\"", "\\\"");
+                result = result.replace(format!("\"{replace_str}\"").as_str(), format!("usageGenerateSpec([{args}])").as_str())
+            });
+
+        let output_to_str = self.stdout.unwrap_or(true);
+        if output_to_str {
+            print!("{result}");
+            Ok(())
+        } else {
+            result = [Fig::get_prescript(), result, Fig::get_postscript()].join("\n\n");
+            write(&path, result.as_str())
+        }
+    }
+
+    fn get_prescript() -> String {
+        include_str!("../../../../tasks/fig/generators.ts").to_string()
+    }
+
+    fn get_postscript() -> String {
+        "export default completionSpec;".to_string()
+    }
+
+    fn fill_args_complete(args: Vec<&mut FigArg>, completes: IndexMap<String, SpecComplete>) {
+        let completable_args = args.into_iter().map(|a| {
+            let completekv = completes.get_key_value(&a.name);
+            completekv.and_then(|(_,v)| Some((a, v.clone())))
+        }).filter(Option::is_some);
+        
+        completable_args.for_each(|a| {
+            let x = a.unwrap();
+            x.0.update_from_complete(x.1)
+        });   
+    }
+}

--- a/cli/src/cli/generate/mod.rs
+++ b/cli/src/cli/generate/mod.rs
@@ -4,8 +4,8 @@ use usage::error::UsageErr;
 use usage::Spec;
 
 mod completion;
-mod markdown;
 mod fig;
+mod markdown;
 
 #[derive(clap::Args)]
 #[clap(visible_alias = "g")]

--- a/cli/src/cli/generate/mod.rs
+++ b/cli/src/cli/generate/mod.rs
@@ -5,6 +5,7 @@ use usage::Spec;
 
 mod completion;
 mod markdown;
+mod fig;
 
 #[derive(clap::Args)]
 #[clap(visible_alias = "g")]
@@ -17,6 +18,7 @@ pub struct Generate {
 pub enum Command {
     Completion(completion::Completion),
     Markdown(markdown::Markdown),
+    Fig(fig::Fig),
 }
 
 impl Generate {
@@ -24,6 +26,7 @@ impl Generate {
         match &self.command {
             Command::Completion(cmd) => cmd.run(),
             Command::Markdown(cmd) => cmd.run(),
+            Command::Fig(cmd) => cmd.run(),
         }
     }
 }

--- a/cli/src/cli/generate/mod.rs
+++ b/cli/src/cli/generate/mod.rs
@@ -17,8 +17,8 @@ pub struct Generate {
 #[derive(clap::Subcommand)]
 pub enum Command {
     Completion(completion::Completion),
-    Markdown(markdown::Markdown),
     Fig(fig::Fig),
+    Markdown(markdown::Markdown),
 }
 
 impl Generate {

--- a/cli/usage.usage.kdl
+++ b/cli/usage.usage.kdl
@@ -54,6 +54,18 @@ cmd "generate" subcommand_required=true {
         }
         arg "<BIN>" help="The CLI which we're generates completions for"
     }
+    cmd "fig" {
+        flag "-f --file" help="A usage spec taken in as a file" {
+            arg "<FILE>"
+        }
+        flag "--spec" help="raw string spec input" {
+            arg "<SPEC>"
+        }
+        flag "--out-file" help="File on where to save the generated Fig spec" {
+            arg "<OUT_FILE>"
+        }
+        flag "--stdout" help="Whether to output to stdout"
+    }
     cmd "markdown" {
         alias "md"
         flag "-f --file" help="A usage spec taken in as a file" required=true {

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -1,8 +1,8 @@
 # `usage`
-
 - **version**: 1.0.1
 
 CLI for working with usage-based CLIs
+
 
 - **Usage**: `usage [--usage-spec] [COMPLETIONS] <SUBCOMMAND>`
 
@@ -132,6 +132,29 @@ The CLI which we're generates completions for
 A command which generates a usage spec e.g.: `mycli --usage` or `mycli completion usage` Defaults to "$bin --usage"
 
 #### `-f --file <FILE>`
+
+## `usage generate fig`
+
+- **Usage**: `usage generate fig [FLAGS]`
+- **Source code**: [`cli/src/cli/generate/fig.rs`](https://github.com/jdx/usage/blob/main/cli/src/cli/generate/fig.rs)
+
+### Flags
+
+#### `-f --file <FILE>`
+
+A usage spec taken in as a file
+
+#### `--spec <SPEC>`
+
+raw string spec input
+
+#### `--out-file <OUT_FILE>`
+
+File on where to save the generated Fig spec
+
+#### `--stdout`
+
+Whether to output to stdout
 
 ## `usage generate markdown`
 

--- a/tasks/fig/generators.ts
+++ b/tasks/fig/generators.ts
@@ -1,36 +1,45 @@
-const usageGeneratorTemplate = (usage_cmd: string) : Fig.Generator => {
+const usageGeneratorTemplate = (usage_cmd: string): Fig.Generator => {
   return {
     custom: async (tokens: string[], executeCommand) => {
       const { stdout: spec } = await executeCommand({
-        command: 'sh', args: ['-c', usage_cmd]
+        command: "sh",
+        args: ["-c", usage_cmd],
       });
 
       const { stdout: completes } = await executeCommand({
-        command: 'usage', args: ['complete-word', '--shell', 'bash', '-s', spec]
-      })
+        command: "usage",
+        args: ["complete-word", "--shell", "bash", "-s", spec],
+      });
 
-      return completes.split('\n').map(l => ({name: l.trim(), type: 'special'}))
-      
-    }
-  }
-}
+      return completes
+        .split("\n")
+        .map((l) => ({ name: l.trim(), type: "special" }));
+    },
+  };
+};
 
-const completionGeneratorTemplate = (argSuggestionBash: string): Fig.Generator => {
+const completionGeneratorTemplate = (
+  argSuggestionBash: string,
+): Fig.Generator => {
   return {
     custom: async (tokens: string[], executeCommand) => {
       let arg = argSuggestionBash;
       if (tokens.length >= 1) {
-        arg = argSuggestionBash.replace("{{words[CURRENT]}}", tokens[tokens.length - 1])
+        arg = argSuggestionBash.replace(
+          "{{words[CURRENT]}}",
+          tokens[tokens.length - 1],
+        );
       }
 
       if (tokens.length >= 2) {
-        arg = arg.replace(`{{words[PREV]}}`, tokens[tokens.length - 2])
+        arg = arg.replace(`{{words[PREV]}}`, tokens[tokens.length - 2]);
       }
-      const {stdout: text} = await executeCommand({
-        command: 'sh', args: ['-c', arg]
+      const { stdout: text } = await executeCommand({
+        command: "sh",
+        args: ["-c", arg],
       });
-      if (text.trim().length == 0) return []
+      if (text.trim().length == 0) return [];
       return text.split("\n").map((elm) => ({ name: elm }));
-    }
-  }
-}
+    },
+  };
+};

--- a/tasks/fig/generators.ts
+++ b/tasks/fig/generators.ts
@@ -1,0 +1,132 @@
+export const envVarGenerator = {
+  script: ['sh', '-c', 'env'],
+  postProcess: (output: string) => {
+    return output.split('\n').map(l => ({name: l.split('=')[0]}))
+  }
+}
+
+export const singleCmdNewLineGenerator = (completion_cmd: string): Fig.Generator => ({
+  script: completion_cmd.split(' '),
+  splitOn: '\n'
+})
+
+export const singleCmdJsonGenerator = (cmd: string): Fig.Generator => ({
+  script: cmd.split(' '),
+  postProcess: (out) => (JSON.parse(out).map((r: any) => ({name: r.name, description: r.description})))
+})
+
+export const contextualGeneratorLastWord = (cmd: string): Fig.Generator => ({
+  script: (context) => {
+    if (context.length < 2) {
+      return []
+    }
+    
+    const prev = context[context.length - 2] // -1 is the current word
+    return ['sh', '-c', [cmd, prev].join(' ')]
+  }
+})
+
+
+export const usageGeneratorTemplate = (usage_cmd: string) : Fig.Generator => {
+  return {
+    custom: async (tokens: string[], executeCommand) => {
+      const { stdout: spec } = await executeCommand({
+        command: 'sh', args: ['-c', usage_cmd]
+      });
+
+      const { stdout: completes } = await executeCommand({
+        command: 'usage', args: ['complete-word', '--shell', 'bash', '-s', spec]
+      })
+
+      return completes.split('\n').map(l => ({name: l.trim(), type: 'special'}))
+      
+    }
+  }
+}
+
+export const completionGeneratorTemplate = (argSuggestionBash: string): Fig.Generator => {
+  return {
+    custom: async (tokens: string[], executeCommand) => {
+      let arg = argSuggestionBash;
+      if (tokens.length >= 1) {
+        arg = argSuggestionBash.replace("{{words[CURRENT]}}", tokens[tokens.length - 1])
+      }
+
+      if (tokens.length >= 2) {
+        arg = arg.replace(`{{words[PREV]}}`, tokens[tokens.length - 2])
+      }
+      const {stdout: text} = await executeCommand({
+        command: 'sh', args: ['-c', arg]
+      });
+      if (text.trim().length == 0) return []
+      return text.split("\n").map((elm) => ({ name: elm }));
+    }
+  }
+}
+
+
+// Dynamically generate fig specs on "mount run" commands
+export const usageGenerateSpec = (cmds: string[]) => {
+  return async (tokens: string[], executeCommand: Fig.ExecuteCommandFunction): Promise<Fig.Spec> => {
+    const promises = cmds.map(async (cmd) => {
+      try {
+        const { stdout } = await executeCommand({
+          command: 'sh', args: ['-c', cmd]
+        });
+        const { stdout: figSpecOut } = await executeCommand({
+          command: 'usage', args: ['g', 'fig', '--spec', stdout, '--stdout']
+        })
+        const start_of_json = figSpecOut.indexOf("{")
+        const j = figSpecOut.slice(start_of_json)
+        return JSON.parse(j).subcommands as Fig.Subcommand[]
+      }
+      catch (e){
+        throw e;
+      }
+    })
+
+    const subcommands = (await Promise.allSettled(promises)).filter(p => p.status === 'fulfilled').map(p => p.value);
+    
+    return { subcommands: subcommands.flat() } as Fig.Spec
+  }
+}
+
+
+export const pluginGenerator: Fig.Generator = singleCmdNewLineGenerator('mise plugins --core --user')
+export const allPluginsGenerator: Fig.Generator = singleCmdNewLineGenerator('mise plugins --all')
+export const simpleTaskGenerator = singleCmdJsonGenerator('mise tasks -J')
+export const settingsGenerator = singleCmdNewLineGenerator(`mise settings --keys`)
+
+export const aliasGenerator: Fig.Generator = {
+  ...contextualGeneratorLastWord('mise alias ls'),
+  postProcess: (out) => {
+    //return [{name: out}]
+    //return out.split('\t').map(l => ({name: l}))
+    //return [{name: "test", "description": out}]
+    const tokens = out.split(/\s+/)
+    if (tokens.length == 0)
+      return []
+
+    return tokens.flatMap((_, i) => {
+      if ((i % 3) == 0) {
+        return [tokens[i+1]]
+      }
+      return []
+    }).filter(l => l.trim().length > 0).map(l => ({name: l.trim()}))
+  }
+}
+
+export const pluginWithAlias: Fig.Generator = {
+  script: 'mise alias ls'.split(' '),
+  postProcess: (output: string) => {
+    const plugins = output.split('\n').map((line) => {
+      const tokens = line.split(/\s+/)
+      return tokens[0]
+    })
+    return [... new Set(plugins)].map((p) => ({name: p}))
+  }
+}
+export const configPathGenerator: Fig.Generator = {
+  ...singleCmdJsonGenerator('mise config ls -J'),
+  postProcess: (out) => JSON.parse(out).map((r: any) => ({name: r.path, description: r.path}))
+}

--- a/tasks/fig/generators.ts
+++ b/tasks/fig/generators.ts
@@ -1,33 +1,4 @@
-export const envVarGenerator = {
-  script: ['sh', '-c', 'env'],
-  postProcess: (output: string) => {
-    return output.split('\n').map(l => ({name: l.split('=')[0]}))
-  }
-}
-
-export const singleCmdNewLineGenerator = (completion_cmd: string): Fig.Generator => ({
-  script: completion_cmd.split(' '),
-  splitOn: '\n'
-})
-
-export const singleCmdJsonGenerator = (cmd: string): Fig.Generator => ({
-  script: cmd.split(' '),
-  postProcess: (out) => (JSON.parse(out).map((r: any) => ({name: r.name, description: r.description})))
-})
-
-export const contextualGeneratorLastWord = (cmd: string): Fig.Generator => ({
-  script: (context) => {
-    if (context.length < 2) {
-      return []
-    }
-    
-    const prev = context[context.length - 2] // -1 is the current word
-    return ['sh', '-c', [cmd, prev].join(' ')]
-  }
-})
-
-
-export const usageGeneratorTemplate = (usage_cmd: string) : Fig.Generator => {
+const usageGeneratorTemplate = (usage_cmd: string) : Fig.Generator => {
   return {
     custom: async (tokens: string[], executeCommand) => {
       const { stdout: spec } = await executeCommand({
@@ -44,7 +15,7 @@ export const usageGeneratorTemplate = (usage_cmd: string) : Fig.Generator => {
   }
 }
 
-export const completionGeneratorTemplate = (argSuggestionBash: string): Fig.Generator => {
+const completionGeneratorTemplate = (argSuggestionBash: string): Fig.Generator => {
   return {
     custom: async (tokens: string[], executeCommand) => {
       let arg = argSuggestionBash;
@@ -62,71 +33,4 @@ export const completionGeneratorTemplate = (argSuggestionBash: string): Fig.Gene
       return text.split("\n").map((elm) => ({ name: elm }));
     }
   }
-}
-
-
-// Dynamically generate fig specs on "mount run" commands
-export const usageGenerateSpec = (cmds: string[]) => {
-  return async (tokens: string[], executeCommand: Fig.ExecuteCommandFunction): Promise<Fig.Spec> => {
-    const promises = cmds.map(async (cmd) => {
-      try {
-        const { stdout } = await executeCommand({
-          command: 'sh', args: ['-c', cmd]
-        });
-        const { stdout: figSpecOut } = await executeCommand({
-          command: 'usage', args: ['g', 'fig', '--spec', stdout, '--stdout']
-        })
-        const start_of_json = figSpecOut.indexOf("{")
-        const j = figSpecOut.slice(start_of_json)
-        return JSON.parse(j).subcommands as Fig.Subcommand[]
-      }
-      catch (e){
-        throw e;
-      }
-    })
-
-    const subcommands = (await Promise.allSettled(promises)).filter(p => p.status === 'fulfilled').map(p => p.value);
-    
-    return { subcommands: subcommands.flat() } as Fig.Spec
-  }
-}
-
-
-export const pluginGenerator: Fig.Generator = singleCmdNewLineGenerator('mise plugins --core --user')
-export const allPluginsGenerator: Fig.Generator = singleCmdNewLineGenerator('mise plugins --all')
-export const simpleTaskGenerator = singleCmdJsonGenerator('mise tasks -J')
-export const settingsGenerator = singleCmdNewLineGenerator(`mise settings --keys`)
-
-export const aliasGenerator: Fig.Generator = {
-  ...contextualGeneratorLastWord('mise alias ls'),
-  postProcess: (out) => {
-    //return [{name: out}]
-    //return out.split('\t').map(l => ({name: l}))
-    //return [{name: "test", "description": out}]
-    const tokens = out.split(/\s+/)
-    if (tokens.length == 0)
-      return []
-
-    return tokens.flatMap((_, i) => {
-      if ((i % 3) == 0) {
-        return [tokens[i+1]]
-      }
-      return []
-    }).filter(l => l.trim().length > 0).map(l => ({name: l.trim()}))
-  }
-}
-
-export const pluginWithAlias: Fig.Generator = {
-  script: 'mise alias ls'.split(' '),
-  postProcess: (output: string) => {
-    const plugins = output.split('\n').map((line) => {
-      const tokens = line.split(/\s+/)
-      return tokens[0]
-    })
-    return [... new Set(plugins)].map((p) => ({name: p}))
-  }
-}
-export const configPathGenerator: Fig.Generator = {
-  ...singleCmdJsonGenerator('mise config ls -J'),
-  postProcess: (out) => JSON.parse(out).map((r: any) => ({name: r.path, description: r.path}))
 }


### PR DESCRIPTION
Add a subcommand to `generate` to create a Fig Spec which can be integrated with Amazon CloudWhisperer CLI/Amazon Q/Fig.

Example usage:
`usage g fig -f mise.usage.kdl --out-file tasks/fig/src/mise.ts`

Can be compiled into javascript using the following command on `tasks/fig` folder: `npx @withfig/autocomplete-tools compile` and used locally by moving the resulting `build/mise.js` into `~/.fig/autocomplete/build` (if the folders don't exist just create them)