### PR TITLE
chore: release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.3.0](https://github.com/jdx/usage/compare/v1.2.0..v1.3.0) - 2024-11-10
+
+### 🚀 Features
+
+- min_usage_version by [@jdx](https://github.com/jdx) in [#166](https://github.com/jdx/usage/pull/166)
+
+### 🐛 Bug Fixes
+
+- **(fig)** better generate spec for fig mount commands by [@miguelmig](https://github.com/miguelmig) in [#165](https://github.com/jdx/usage/pull/165)
+- completions for bins with dashes by [@jdx](https://github.com/jdx) in [adbb347](https://github.com/jdx/usage/commit/adbb3478b86a4eede4f9812c73fc547f13f00842)
+- bash script with snake case escapes by [@jdx](https://github.com/jdx) in [4e5ba4a](https://github.com/jdx/usage/commit/4e5ba4a6fa9d3adfe04c27a24b489c15af94ef69)
+
+### 📦️ Dependency Updates
+
+- update dependency vitepress to v1.5.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#160](https://github.com/jdx/usage/pull/160)
+
 ## [1.2.0](https://github.com/jdx/usage/compare/v1.1.1..v1.2.0) - 2024-11-05
 
 ### 🚀 Features
@@ -40,10 +56,6 @@
 ### 📦️ Dependency Updates
 
 - update dependency vitepress to v1.4.5 by [@renovate[bot]](https://github.com/renovate[bot]) in [#145](https://github.com/jdx/usage/pull/145)
-
-### New Contributors
-
-- @miguelmig made their first contribution in [#154](https://github.com/jdx/usage/pull/154)
 
 ## [1.0.1](https://github.com/jdx/usage/compare/v1.0.0..v1.0.1) - 2024-10-31
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,9 +177,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.1.35"
+version = "1.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f57c4b4da2a9d619dd035f27316d7a426305b75be93d09e92f2b9229c34feaf"
+checksum = "40545c26d092346d8a8dab71ee48e7685a7a9cba76e634790c215b41a4a7b4cf"
 dependencies = [
  "shlex",
 ]
@@ -720,7 +720,7 @@ checksum = "062c875482ccb676fd40c804a40e3824d4464c18c364547456d1c8e8e951ae47"
 dependencies = [
  "miette",
  "nom",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -731,9 +731,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
 
 [[package]]
 name = "libm"
@@ -787,7 +787,7 @@ dependencies = [
  "supports-unicode",
  "terminal_size",
  "textwrap",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "unicode-width",
 ]
 
@@ -907,7 +907,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "ucd-trie",
 ]
 
@@ -1367,11 +1367,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.68",
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -1385,9 +1385,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1487,7 +1487,7 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "usage-cli"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1516,7 +1516,7 @@ dependencies = [
 
 [[package]]
 name = "usage-lib"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "clap",
  "ctor",
@@ -1834,7 +1834,7 @@ dependencies = [
  "log",
  "miette",
  "regex",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT"
 [workspace.dependencies]
 clap_usage = { path = "./clap_usage", version = "0.2.0" }
 usage-cli = { path = "./cli" }
-usage-lib = { path = "./lib", version = "1.2.0", features = ["clap"] }
+usage-lib = { path = "./lib", version = "1.3.0", features = ["clap"] }
 
 [workspace.metadata.release]
 allow-branch = ["main"]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-cli"
 edition = "2021"
-version = "1.2.0"
+version = "1.3.0"
 description = "CLI for working with usage-based CLIs"
 license = { workspace = true }
 authors = { workspace = true }

--- a/cli/usage.usage.kdl
+++ b/cli/usage.usage.kdl
@@ -1,6 +1,6 @@
 name "usage-cli"
 bin "usage"
-version "1.2.0"
+version "1.3.0"
 about "CLI for working with usage-based CLIs"
 usage "Usage: usage-cli [OPTIONS] [COMPLETIONS] <COMMAND>"
 flag "--usage-spec" help="Outputs a `usage.kdl` spec for this CLI itself"

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -1,5 +1,5 @@
 # `usage`
-- **version**: 1.2.0
+- **version**: 1.3.0
 
 CLI for working with usage-based CLIs
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-lib"
 edition = "2021"
-version = "1.2.0"
+version = "1.3.0"
 rust-version = "1.70.0"
 include = [
     "/Cargo.toml",


### PR DESCRIPTION
## [1.3.0](https://github.com/jdx/usage/compare/v1.2.0..v1.3.0) - 2024-11-10

### 🚀 Features

- min_usage_version by [@jdx](https://github.com/jdx) in [#166](https://github.com/jdx/usage/pull/166)

### 🐛 Bug Fixes

- **(fig)** better generate spec for fig mount commands by [@miguelmig](https://github.com/miguelmig) in [#165](https://github.com/jdx/usage/pull/165)
- completions for bins with dashes by [@jdx](https://github.com/jdx) in [adbb347](https://github.com/jdx/usage/commit/adbb3478b86a4eede4f9812c73fc547f13f00842)
- bash script with snake case escapes by [@jdx](https://github.com/jdx) in [4e5ba4a](https://github.com/jdx/usage/commit/4e5ba4a6fa9d3adfe04c27a24b489c15af94ef69)

### 📦️ Dependency Updates

- update dependency vitepress to v1.5.0 by [@renovate[bot]](https://github.com/renovate[bot]) in [#160](https://github.com/jdx/usage/pull/160)