### PR TITLE
chore: release v1.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.3.4](https://github.com/jdx/usage/compare/v1.3.3..v1.3.4) - 2024-12-03
+
+### 🔍 Other Changes
+
+- added shellcheck for bash completion file by [@jdx](https://github.com/jdx) in [#176](https://github.com/jdx/usage/pull/176)
+- skip autofix on renovate prs by [@jdx](https://github.com/jdx) in [ada6c92](https://github.com/jdx/usage/commit/ada6c92da40d54d3afcba9a6366213a22f215272)
+- pin kdl below 4.7 by [@jdx](https://github.com/jdx) in [045c9cf](https://github.com/jdx/usage/commit/045c9cf7edc6b9764fd9a794afbbde5b21ddba76)
+
 ## [1.3.3](https://github.com/jdx/usage/compare/v1.3.2..v1.3.3) - 2024-11-22
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1488,7 +1488,7 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "usage-cli"
-version = "1.3.3"
+version = "1.3.4"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "usage-lib"
-version = "1.3.3"
+version = "1.3.4"
 dependencies = [
  "clap",
  "ctor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT"
 [workspace.dependencies]
 clap_usage = { path = "./clap_usage", version = "0.2.0" }
 usage-cli = { path = "./cli" }
-usage-lib = { path = "./lib", version = "1.3.3", features = ["clap"] }
+usage-lib = { path = "./lib", version = "1.3.4", features = ["clap"] }
 
 [workspace.metadata.release]
 allow-branch = ["main"]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-cli"
 edition = "2021"
-version = "1.3.3"
+version = "1.3.4"
 description = "CLI for working with usage-based CLIs"
 license = { workspace = true }
 authors = { workspace = true }

--- a/cli/usage.usage.kdl
+++ b/cli/usage.usage.kdl
@@ -1,6 +1,6 @@
 name "usage-cli"
 bin "usage"
-version "1.3.3"
+version "1.3.4"
 about "CLI for working with usage-based CLIs"
 usage "Usage: usage-cli [OPTIONS] [COMPLETIONS] <COMMAND>"
 flag "--usage-spec" help="Outputs a `usage.kdl` spec for this CLI itself"

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -1,5 +1,5 @@
 # `usage`
-- **version**: 1.3.3
+- **version**: 1.3.4
 
 CLI for working with usage-based CLIs
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-lib"
 edition = "2021"
-version = "1.3.3"
+version = "1.3.4"
 rust-version = "1.70.0"
 include = [
     "/Cargo.toml",


### PR DESCRIPTION
## [1.3.4](https://github.com/jdx/usage/compare/v1.3.3..v1.3.4) - 2024-12-03

### 🔍 Other Changes

- added shellcheck for bash completion file by [@jdx](https://github.com/jdx) in [#176](https://github.com/jdx/usage/pull/176)
- skip autofix on renovate prs by [@jdx](https://github.com/jdx) in [ada6c92](https://github.com/jdx/usage/commit/ada6c92da40d54d3afcba9a6366213a22f215272)
- pin kdl below 4.7 by [@jdx](https://github.com/jdx) in [045c9cf](https://github.com/jdx/usage/commit/045c9cf7edc6b9764fd9a794afbbde5b21ddba76)