### PR TITLE
chore: release v1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.5.2](https://github.com/jdx/usage/compare/v1.5.1..v1.5.2) - 2024-12-12
+
+### 🐛 Bug Fixes
+
+- remove debug @usage by [@jdx](https://github.com/jdx) in [8178c97](https://github.com/jdx/usage/commit/8178c97f3004bcacb4827083c5cb46fa23bff64e)
+
 ## [1.5.1](https://github.com/jdx/usage/compare/v1.5.0..v1.5.1) - 2024-12-12
 
 ### 🔍 Other Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1485,7 +1485,7 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "usage-cli"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1514,7 +1514,7 @@ dependencies = [
 
 [[package]]
 name = "usage-lib"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "clap",
  "ctor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT"
 [workspace.dependencies]
 clap_usage = { path = "./clap_usage", version = "1.0.0" }
 usage-cli = { path = "./cli" }
-usage-lib = { path = "./lib", version = "1.5.1", features = ["clap"] }
+usage-lib = { path = "./lib", version = "1.5.2", features = ["clap"] }
 
 [workspace.metadata.release]
 allow-branch = ["main"]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-cli"
 edition = "2021"
-version = "1.5.1"
+version = "1.5.2"
 description = "CLI for working with usage-based CLIs"
 license = { workspace = true }
 authors = { workspace = true }

--- a/cli/usage.usage.kdl
+++ b/cli/usage.usage.kdl
@@ -1,6 +1,6 @@
 name "usage-cli"
 bin "usage"
-version "1.5.1"
+version "1.5.2"
 about "CLI for working with usage-based CLIs"
 usage "Usage: usage-cli [OPTIONS] [COMPLETIONS] <COMMAND>"
 flag "--usage-spec" help="Outputs a `usage.kdl` spec for this CLI itself"

--- a/docs/cli/reference/commands.json
+++ b/docs/cli/reference/commands.json
@@ -519,7 +519,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.5.1",
+  "version": "1.5.2",
   "usage": "Usage: usage-cli [OPTIONS] [COMPLETIONS] <COMMAND>",
   "complete": {},
   "source_code_link_template": "https://github.com/jdx/usage/blob/main/cli/src/cli/{{path}}.rs",

--- a/docs/cli/reference/index.md
+++ b/docs/cli/reference/index.md
@@ -2,7 +2,7 @@
 
 **Usage**: `usage [--usage-spec] [COMPLETIONS] <SUBCOMMAND>`
 
-**Version**: 1.5.1
+**Version**: 1.5.2
 
 - **Usage**: `usage [--usage-spec] [COMPLETIONS] <SUBCOMMAND>`
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-lib"
 edition = "2021"
-version = "1.5.1"
+version = "1.5.2"
 rust-version = "1.70.0"
 include = [
     "/Cargo.toml",


### PR DESCRIPTION
## [1.5.2](https://github.com/jdx/usage/compare/v1.5.1..v1.5.2) - 2024-12-12

### 🐛 Bug Fixes

- remove debug @usage by [@jdx](https://github.com/jdx) in [8178c97](https://github.com/jdx/usage/commit/8178c97f3004bcacb4827083c5cb46fa23bff64e)