### PR TITLE
fix: 2 bugs with flags and var=#true

### DIFF
--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -184,15 +184,12 @@ pub fn parse_partial(spec: &Spec, input: &[String]) -> Result<ParseOutput, miett
         if enable_flags && w.starts_with('-') && w.len() > 1 {
             let short = w.chars().nth(1).unwrap();
             if let Some(f) = out.available_flags.get(&format!("-{}", short)) {
-                let mut next = format!("-{}", &w[2..]);
+                if w.len() > 2 {
+                    input.push_front(w[2..].to_string());
+                }
                 if f.arg.is_some() {
                     out.flag_awaiting_value = Some(f.clone());
-                    next = w[2..].to_string();
-                }
-                if !next.is_empty() && next != "-" {
-                    input.push_front(next);
-                }
-                if f.var {
+                } else if f.var {
                     let arr = out
                         .flags
                         .entry(f.clone())
@@ -299,7 +296,7 @@ impl ParseOutput {
                 ParseValue::Bool(b) => if *b { "true" } else { "false" }.to_string(),
                 ParseValue::String(s) => s.clone(),
                 ParseValue::MultiBool(b) => b.iter().filter(|b| **b).count().to_string(),
-                ParseValue::MultiString(s) => s.join(" "),
+                ParseValue::MultiString(s) => shell_words::join(s),
             };
             env.insert(key, val);
         }

--- a/lib/tests/parse.rs
+++ b/lib/tests/parse.rs
@@ -192,6 +192,13 @@ multi_arg_spaces:
     args=r#"a "b c""#,
     expected=r#"{"usage_vars": "a 'b c'"}"#,
 
+multi_flag:
+    spec=r#"
+    flag "-v --vars <vars>" var=#true
+    "#,
+    args=r#"--vars a --vars "b c""#,
+    expected=r#"{"usage_vars": "a 'b c'"}"#,
+
 //shell_escape_arg:
 //    spec=r#"
 //    arg "<vars>" shell_escape=#true


### PR DESCRIPTION
mise was not handling flags with values and var=#true with short flags

it also was not using shell_words::join to provide var flag values in env vars

Fixes https://github.com/jdx/mise/discussions/4294
Fixes https://github.com/jdx/mise/issues/4295