### PR TITLE
fix(lib): make `ParseValue` cloneable

### DIFF
--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -22,7 +22,7 @@ pub struct ParseOutput {
     pub errors: Vec<UsageErr>,
 }
 
-#[derive(Debug, EnumTryAs)]
+#[derive(Debug, EnumTryAs, Clone)]
 pub enum ParseValue {
     Bool(bool),
     String(String),


### PR DESCRIPTION
Required to simply implement https://github.com/jdx/mise/pull/4605.