### PR TITLE
fix: (#257) implement short flag chaining and update flag handling logic

### DIFF
--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -86,7 +86,8 @@ impl CompleteWord {
             self.complete_long_flag_names(&parsed.available_flags, &ctoken)
         } else if ctoken.starts_with('-') {
             self.complete_short_flag_names(&parsed.available_flags, &ctoken)
-        } else if let Some(flag) = parsed.flag_awaiting_value {
+        } else if let Some(flag) = parsed.flag_awaiting_value.get(0) {
+            dbg!(&flag);
             self.complete_arg(&ctx, spec, &parsed.cmd, flag.arg.as_ref().unwrap(), &ctoken)?
         } else {
             let mut choices = vec![];

--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -86,8 +86,7 @@ impl CompleteWord {
             self.complete_long_flag_names(&parsed.available_flags, &ctoken)
         } else if ctoken.starts_with('-') {
             self.complete_short_flag_names(&parsed.available_flags, &ctoken)
-        } else if let Some(flag) = parsed.flag_awaiting_value.first() {
-            dbg!(&flag);
+        } else if let Some(flag) = parsed.flag_awaiting_value.get(0) {
             self.complete_arg(&ctx, spec, &parsed.cmd, flag.arg.as_ref().unwrap(), &ctoken)?
         } else {
             let mut choices = vec![];

--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -86,7 +86,7 @@ impl CompleteWord {
             self.complete_long_flag_names(&parsed.available_flags, &ctoken)
         } else if ctoken.starts_with('-') {
             self.complete_short_flag_names(&parsed.available_flags, &ctoken)
-        } else if let Some(flag) = parsed.flag_awaiting_value.get(0) {
+        } else if let Some(flag) = parsed.flag_awaiting_value.first() {
             dbg!(&flag);
             self.complete_arg(&ctx, spec, &parsed.cmd, flag.arg.as_ref().unwrap(), &ctoken)?
         } else {

--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -86,7 +86,7 @@ impl CompleteWord {
             self.complete_long_flag_names(&parsed.available_flags, &ctoken)
         } else if ctoken.starts_with('-') {
             self.complete_short_flag_names(&parsed.available_flags, &ctoken)
-        } else if let Some(flag) = parsed.flag_awaiting_value.get(0) {
+        } else if let Some(flag) = parsed.flag_awaiting_value.first() {
             self.complete_arg(&ctx, spec, &parsed.cmd, flag.arg.as_ref().unwrap(), &ctoken)?
         } else {
             let mut choices = vec![];

--- a/docs/cli/scripts.md
+++ b/docs/cli/scripts.md
@@ -53,6 +53,41 @@ const user = usage_user ?? "world";
 fs.appendFileSync(usage_file, `Hello, ${user}\n`);
 ```
 
+## Short Flag Chaining
+
+Short flag chaining allows you to combine multiple single-character flags into a single argument.
+This can make command-line usage more concise and easier to type.
+
+For example, consider the following script:
+
+```bash
+#!/usr/bin/env -S usage bash
+#USAGE flag "-a" help="Option A"
+#USAGE flag "-b" help="Option B"
+#USAGE flag "-c" help="Option C"
+
+if [ "$usage_a" = "true" ]; then
+  echo "Option A is set"
+fi
+if [ "$usage_b" = "true" ]; then
+  echo "Option B is set"
+fi
+if [ "$usage_c" = "true" ]; then
+  echo "Option C is set"
+fi
+```
+
+Assuming this script was located at `./mycli`, it could be used like this:
+
+```bash
+$ ./mycli -abc
+Option A is set
+Option B is set
+Option C is set
+```
+
+In this example, the `-a`, `-b`, and `-c` flags are combined into a single `-abc` argument, enabling all three options at once.
+
 ## Shell Escaping
 
 ### `var=#true`

--- a/lib/tests/parse.rs
+++ b/lib/tests/parse.rs
@@ -40,10 +40,37 @@ flag_short_next:
     args="-sbash",
     expected=r#"{"usage_s": "bash"}"#,
 
+flag_chained_short_next:
+    spec=r#"flag "-s <shell>"; flag "-b <bin>"; flag "-x""#,
+    args="-xsbash",
+    expected=r#"{"usage_b": "ash", "usage_s": "", "usage_x": "true"}"#,
+
+flag_chained_short_next_choices:
+    spec=r#"flag "-b"; flag "-x"; flag "-s <shell>" {
+    choices "bash" "fish" "zsh"
+}"#,
+    args="-xsbzsh",
+    expected=r#"{"usage_b": "true", "usage_s": "zsh", "usage_x": "true"}"#,
+
+flag_chained_short_next_one_arg:
+    spec=r#"flag "-s <shell>"; flag "-b"; flag "-x""#,
+    args="-xsbash",
+    expected=r#"{"usage_b": "true", "usage_s": "ash", "usage_x": "true"}"#,
+
 flag_short_space:
     spec=r#"flag "-s <shell>""#,
     args="-s bash",
     expected=r#"{"usage_s": "bash"}"#,
+
+flag_chained_short_space:
+    spec=r#"flag "-s <shell>"; flag "-b <bin>"; flag "-x""#,
+    args="-xs bash",
+    expected=r#"{"usage_s": "bash", "usage_x": "true"}"#,
+
+flag_chained_short_space_one_arg:
+    spec=r#"flag "-s <shell>"; flag "-b"; flag "-x""#,
+    args="-xsb bash",
+    expected=r#"{"usage_b": "true", "usage_s": "bash", "usage_x": "true"}"#,
 
 flag_choices_ok:
     spec=r#"flag "--shell <shell>" {


### PR DESCRIPTION
This change introduces a fix to support short flag chaining in the core parsing LIB for the CLI. Previously, chaining flags (e.g., -abc) resulted in an error where the tool misinterpreted the flags as a single argument (bc). With this update, the CLI now properly parses chained flags and applies them individually.

**Changes Made:**

- Modified flag-parsing logic to recognize chained short flags.
- Added unit tests to ensure correct functionality of short flag chaining.
- Updated documentation to reflect support for flag chaining.

To implement this change, I modified the logic to adjust the order in which flags are processed. Now, only the last valid short flag in a chain can accept the next argument value. For instance, in the command `./mycli -abc 123`, the value `123` would be assigned exclusively to `usage_c`. Flags `a` and `b`, even if they could accept arguments, would remain set to either true or their default values.

**Testing Details:**

- Verified correct parsing behavior for various flag combinations.
- Added additional unit tests covering various cases for short flag combinations.
- Verified all existing tests are passing.