### PR TITLE
Generalize bash command to support bash/zsh/fish

### DIFF
--- a/cli/assets/fig.ts
+++ b/cli/assets/fig.ts
@@ -87,33 +87,6 @@ const completionSpec: Fig.Spec = {
   name: "usage",
   subcommands: [
     {
-      name: "bash",
-      description: "Executes a bash script",
-      options: [
-        {
-          name: "-h",
-          description: "Show help",
-          isRepeatable: false,
-        },
-        {
-          name: "--help",
-          description: "Show help",
-          isRepeatable: false,
-        },
-      ],
-      args: [
-        {
-          name: "script",
-        },
-        {
-          name: "args",
-          description: "Arguments to pass to script",
-          isOptional: true,
-          isVariadic: true,
-        },
-      ],
-    },
-    {
       name: ["complete-word", "cw"],
       options: [
         {
@@ -323,6 +296,87 @@ const completionSpec: Fig.Spec = {
               },
             },
           ],
+        },
+      ],
+    },
+    {
+      name: "bash",
+      description: "Use bash to execute the script",
+      options: [
+        {
+          name: "-h",
+          description: "Show help",
+          isRepeatable: false,
+        },
+        {
+          name: "--help",
+          description: "Show help",
+          isRepeatable: false,
+        },
+      ],
+      args: [
+        {
+          name: "script",
+        },
+        {
+          name: "args",
+          description: "Arguments to pass to script",
+          isOptional: true,
+          isVariadic: true,
+        },
+      ],
+    },
+    {
+      name: "fish",
+      description: "use fish to execute the script",
+      options: [
+        {
+          name: "-h",
+          description: "Show help",
+          isRepeatable: false,
+        },
+        {
+          name: "--help",
+          description: "Show help",
+          isRepeatable: false,
+        },
+      ],
+      args: [
+        {
+          name: "script",
+        },
+        {
+          name: "args",
+          description: "Arguments to pass to script",
+          isOptional: true,
+          isVariadic: true,
+        },
+      ],
+    },
+    {
+      name: "zsh",
+      description: "use zsh to execute the script",
+      options: [
+        {
+          name: "-h",
+          description: "Show help",
+          isRepeatable: false,
+        },
+        {
+          name: "--help",
+          description: "Show help",
+          isRepeatable: false,
+        },
+      ],
+      args: [
+        {
+          name: "script",
+        },
+        {
+          name: "args",
+          description: "Arguments to pass to script",
+          isOptional: true,
+          isVariadic: true,
         },
       ],
     },

--- a/cli/src/cli/mod.rs
+++ b/cli/src/cli/mod.rs
@@ -2,10 +2,10 @@ use crate::usage_spec;
 use clap::{Parser, Subcommand};
 use miette::Result;
 
-mod bash;
 mod complete_word;
 mod exec;
 mod generate;
+mod shell;
 
 #[derive(Parser)]
 #[clap(author, version, about)]
@@ -23,10 +23,15 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
-    Bash(bash::Bash),
     CompleteWord(complete_word::CompleteWord),
     Exec(exec::Exec),
     Generate(generate::Generate),
+    #[clap(about = "Use bash to execute the script")]
+    Bash(shell::Shell),
+    #[clap(about = "use fish to execute the script")]
+    Fish(shell::Shell),
+    #[clap(about = "use zsh to execute the script")]
+    Zsh(shell::Shell),
 }
 
 impl Cli {
@@ -36,7 +41,9 @@ impl Cli {
             return usage_spec::generate();
         }
         match cli.command {
-            Command::Bash(mut cmd) => cmd.run(),
+            Command::Bash(mut cmd) => cmd.run("bash"),
+            Command::Fish(mut cmd) => cmd.run("fish"),
+            Command::Zsh(mut cmd) => cmd.run("zsh"),
             Command::Generate(cmd) => cmd.run(),
             Command::Exec(mut cmd) => cmd.run(),
             Command::CompleteWord(cmd) => cmd.run(),

--- a/cli/src/cli/shell.rs
+++ b/cli/src/cli/shell.rs
@@ -18,7 +18,6 @@ use usage::Spec;
 #[clap(disable_help_flag = true, verbatim_doc_comment)]
 pub struct Shell {
     script: PathBuf,
-
     /// arguments to pass to script
     #[clap(allow_hyphen_values = true)]
     args: Vec<String>,

--- a/cli/src/cli/shell.rs
+++ b/cli/src/cli/shell.rs
@@ -8,7 +8,7 @@ use miette::IntoDiagnostic;
 
 use usage::Spec;
 
-/// Executes a bash script
+/// Executes a shell script with the specified shell
 ///
 /// Typically, this will be called by a script's shebang
 ///
@@ -16,8 +16,9 @@ use usage::Spec;
 /// to properly escape and quote values with spaces in them.
 #[derive(Debug, Args)]
 #[clap(disable_help_flag = true, verbatim_doc_comment)]
-pub struct Bash {
+pub struct Shell {
     script: PathBuf,
+
     /// arguments to pass to script
     #[clap(allow_hyphen_values = true)]
     args: Vec<String>,
@@ -31,8 +32,8 @@ pub struct Bash {
     help: bool,
 }
 
-impl Bash {
-    pub fn run(&mut self) -> miette::Result<()> {
+impl Shell {
+    pub fn run(&mut self, shell: &str) -> miette::Result<()> {
         let (spec, _script) = Spec::parse_file(&self.script)?;
         let mut args = self.args.clone();
         args.insert(0, spec.bin.clone());
@@ -47,7 +48,7 @@ impl Bash {
         let parsed = usage::parse::parse(&spec, &args)?;
         debug!("{parsed:?}");
 
-        let mut cmd = std::process::Command::new("bash");
+        let mut cmd = std::process::Command::new(&shell);
         cmd.stdin(Stdio::inherit());
         cmd.stdout(Stdio::inherit());
         cmd.stderr(Stdio::inherit());

--- a/cli/src/cli/shell.rs
+++ b/cli/src/cli/shell.rs
@@ -47,7 +47,7 @@ impl Shell {
         let parsed = usage::parse::parse(&spec, &args)?;
         debug!("{parsed:?}");
 
-        let mut cmd = std::process::Command::new(&shell);
+        let mut cmd = std::process::Command::new(shell);
         cmd.stdin(Stdio::inherit());
         cmd.stdout(Stdio::inherit());
         cmd.stderr(Stdio::inherit());

--- a/cli/usage.usage.kdl
+++ b/cli/usage.usage.kdl
@@ -5,13 +5,6 @@ about "CLI for working with usage-based CLIs"
 usage "Usage: usage-cli [OPTIONS] [COMPLETIONS] <COMMAND>"
 flag --usage-spec help="Outputs a `usage.kdl` spec for this CLI itself"
 arg "[COMPLETIONS]" help="Outputs completions for the specified shell for completing the `usage` CLI itself" required=#false
-cmd bash help="Executes a bash script" {
-    long_help "Executes a bash script\n\nTypically, this will be called by a script's shebang\n\nIf using `var=#true` on args/flags, they will be joined with spaces using `shell_words::join()`\nto properly escape and quote values with spaces in them."
-    flag -h help="show help"
-    flag --help help="show help"
-    arg <SCRIPT>
-    arg "[ARGS]…" help="arguments to pass to script" required=#false var=#true
-}
 cmd complete-word {
     alias cw
     flag --shell {
@@ -99,6 +92,27 @@ cmd generate subcommand_required=#true {
             arg <OUT_FILE>
         }
     }
+}
+cmd bash help="Use bash to execute the script" {
+    long_help "Executes a shell script with the specified shell\n\nTypically, this will be called by a script's shebang\n\nIf using `var=#true` on args/flags, they will be joined with spaces using `shell_words::join()`\nto properly escape and quote values with spaces in them."
+    flag -h help="show help"
+    flag --help help="show help"
+    arg <SCRIPT>
+    arg "[ARGS]…" help="arguments to pass to script" required=#false var=#true
+}
+cmd fish help="use fish to execute the script" {
+    long_help "Executes a shell script with the specified shell\n\nTypically, this will be called by a script's shebang\n\nIf using `var=#true` on args/flags, they will be joined with spaces using `shell_words::join()`\nto properly escape and quote values with spaces in them."
+    flag -h help="show help"
+    flag --help help="show help"
+    arg <SCRIPT>
+    arg "[ARGS]…" help="arguments to pass to script" required=#false var=#true
+}
+cmd zsh help="use zsh to execute the script" {
+    long_help "Executes a shell script with the specified shell\n\nTypically, this will be called by a script's shebang\n\nIf using `var=#true` on args/flags, they will be joined with spaces using `shell_words::join()`\nto properly escape and quote values with spaces in them."
+    flag -h help="show help"
+    flag --help help="show help"
+    arg <SCRIPT>
+    arg "[ARGS]…" help="arguments to pass to script" required=#false var=#true
 }
 
 source_code_link_template "https://github.com/jdx/usage/blob/main/cli/src/cli/{{path}}.rs"

--- a/docs/cli/reference/commands.json
+++ b/docs/cli/reference/commands.json
@@ -5,60 +5,6 @@
     "full_cmd": [],
     "usage": "[--usage-spec] [COMPLETIONS] <SUBCOMMAND>",
     "subcommands": {
-      "bash": {
-        "full_cmd": ["bash"],
-        "usage": "bash [-h] [--help] <SCRIPT> [ARGS]…",
-        "subcommands": {},
-        "args": [
-          {
-            "name": "SCRIPT",
-            "usage": "<SCRIPT>",
-            "required": true,
-            "double_dash": "Optional",
-            "hide": false
-          },
-          {
-            "name": "ARGS",
-            "usage": "[ARGS]…",
-            "help": "arguments to pass to script",
-            "help_first_line": "arguments to pass to script",
-            "required": false,
-            "double_dash": "Optional",
-            "var": true,
-            "hide": false
-          }
-        ],
-        "flags": [
-          {
-            "name": "h",
-            "usage": "-h",
-            "help": "show help",
-            "help_first_line": "show help",
-            "short": ["h"],
-            "long": [],
-            "hide": false,
-            "global": false
-          },
-          {
-            "name": "help",
-            "usage": "--help",
-            "help": "show help",
-            "help_first_line": "show help",
-            "short": [],
-            "long": ["help"],
-            "hide": false,
-            "global": false
-          }
-        ],
-        "mounts": [],
-        "hide": false,
-        "help": "Executes a bash script",
-        "help_long": "Executes a bash script\n\nTypically, this will be called by a script's shebang\n\nIf using `var=#true` on args/flags, they will be joined with spaces using `shell_words::join()`\nto properly escape and quote values with spaces in them.",
-        "name": "bash",
-        "aliases": [],
-        "hidden_aliases": [],
-        "examples": []
-      },
       "complete-word": {
         "full_cmd": ["complete-word"],
         "usage": "complete-word [FLAGS] [WORDS]…",
@@ -544,6 +490,168 @@
         "subcommand_required": true,
         "name": "generate",
         "aliases": ["g"],
+        "hidden_aliases": [],
+        "examples": []
+      },
+      "bash": {
+        "full_cmd": ["bash"],
+        "usage": "bash [-h] [--help] <SCRIPT> [ARGS]…",
+        "subcommands": {},
+        "args": [
+          {
+            "name": "SCRIPT",
+            "usage": "<SCRIPT>",
+            "required": true,
+            "double_dash": "Optional",
+            "hide": false
+          },
+          {
+            "name": "ARGS",
+            "usage": "[ARGS]…",
+            "help": "arguments to pass to script",
+            "help_first_line": "arguments to pass to script",
+            "required": false,
+            "double_dash": "Optional",
+            "var": true,
+            "hide": false
+          }
+        ],
+        "flags": [
+          {
+            "name": "h",
+            "usage": "-h",
+            "help": "show help",
+            "help_first_line": "show help",
+            "short": ["h"],
+            "long": [],
+            "hide": false,
+            "global": false
+          },
+          {
+            "name": "help",
+            "usage": "--help",
+            "help": "show help",
+            "help_first_line": "show help",
+            "short": [],
+            "long": ["help"],
+            "hide": false,
+            "global": false
+          }
+        ],
+        "mounts": [],
+        "hide": false,
+        "help": "Use bash to execute the script",
+        "help_long": "Executes a shell script with the specified shell\n\nTypically, this will be called by a script's shebang\n\nIf using `var=#true` on args/flags, they will be joined with spaces using `shell_words::join()`\nto properly escape and quote values with spaces in them.",
+        "name": "bash",
+        "aliases": [],
+        "hidden_aliases": [],
+        "examples": []
+      },
+      "fish": {
+        "full_cmd": ["fish"],
+        "usage": "fish [-h] [--help] <SCRIPT> [ARGS]…",
+        "subcommands": {},
+        "args": [
+          {
+            "name": "SCRIPT",
+            "usage": "<SCRIPT>",
+            "required": true,
+            "double_dash": "Optional",
+            "hide": false
+          },
+          {
+            "name": "ARGS",
+            "usage": "[ARGS]…",
+            "help": "arguments to pass to script",
+            "help_first_line": "arguments to pass to script",
+            "required": false,
+            "double_dash": "Optional",
+            "var": true,
+            "hide": false
+          }
+        ],
+        "flags": [
+          {
+            "name": "h",
+            "usage": "-h",
+            "help": "show help",
+            "help_first_line": "show help",
+            "short": ["h"],
+            "long": [],
+            "hide": false,
+            "global": false
+          },
+          {
+            "name": "help",
+            "usage": "--help",
+            "help": "show help",
+            "help_first_line": "show help",
+            "short": [],
+            "long": ["help"],
+            "hide": false,
+            "global": false
+          }
+        ],
+        "mounts": [],
+        "hide": false,
+        "help": "use fish to execute the script",
+        "help_long": "Executes a shell script with the specified shell\n\nTypically, this will be called by a script's shebang\n\nIf using `var=#true` on args/flags, they will be joined with spaces using `shell_words::join()`\nto properly escape and quote values with spaces in them.",
+        "name": "fish",
+        "aliases": [],
+        "hidden_aliases": [],
+        "examples": []
+      },
+      "zsh": {
+        "full_cmd": ["zsh"],
+        "usage": "zsh [-h] [--help] <SCRIPT> [ARGS]…",
+        "subcommands": {},
+        "args": [
+          {
+            "name": "SCRIPT",
+            "usage": "<SCRIPT>",
+            "required": true,
+            "double_dash": "Optional",
+            "hide": false
+          },
+          {
+            "name": "ARGS",
+            "usage": "[ARGS]…",
+            "help": "arguments to pass to script",
+            "help_first_line": "arguments to pass to script",
+            "required": false,
+            "double_dash": "Optional",
+            "var": true,
+            "hide": false
+          }
+        ],
+        "flags": [
+          {
+            "name": "h",
+            "usage": "-h",
+            "help": "show help",
+            "help_first_line": "show help",
+            "short": ["h"],
+            "long": [],
+            "hide": false,
+            "global": false
+          },
+          {
+            "name": "help",
+            "usage": "--help",
+            "help": "show help",
+            "help_first_line": "show help",
+            "short": [],
+            "long": ["help"],
+            "hide": false,
+            "global": false
+          }
+        ],
+        "mounts": [],
+        "hide": false,
+        "help": "use zsh to execute the script",
+        "help_long": "Executes a shell script with the specified shell\n\nTypically, this will be called by a script's shebang\n\nIf using `var=#true` on args/flags, they will be joined with spaces using `shell_words::join()`\nto properly escape and quote values with spaces in them.",
+        "name": "zsh",
+        "aliases": [],
         "hidden_aliases": [],
         "examples": []
       }

--- a/docs/cli/reference/fish.md
+++ b/docs/cli/reference/fish.md
@@ -1,7 +1,7 @@
-# `usage bash`
+# `usage fish`
 
-- **Usage**: `usage bash [-h] [--help] <SCRIPT> [ARGS]…`
-- **Source code**: [`cli/src/cli/bash.rs`](https://github.com/jdx/usage/blob/main/cli/src/cli/bash.rs)
+- **Usage**: `usage fish [-h] [--help] <SCRIPT> [ARGS]…`
+- **Source code**: [`cli/src/cli/fish.rs`](https://github.com/jdx/usage/blob/main/cli/src/cli/fish.rs)
 
 Executes a shell script with the specified shell
 

--- a/docs/cli/reference/index.md
+++ b/docs/cli/reference/index.md
@@ -20,10 +20,12 @@ Outputs a `usage.kdl` spec for this CLI itself
 
 ## Subcommands
 
-- [`usage bash [-h] [--help] <SCRIPT> [ARGS]…`](/cli/reference/bash.md)
 - [`usage complete-word [FLAGS] [WORDS]…`](/cli/reference/complete-word.md)
 - [`usage generate <SUBCOMMAND>`](/cli/reference/generate.md)
 - [`usage generate completion [FLAGS] <SHELL> <BIN>`](/cli/reference/generate/completion.md)
 - [`usage generate fig [FLAGS]`](/cli/reference/generate/fig.md)
 - [`usage generate json [-f --file <FILE>] [--spec <SPEC>]`](/cli/reference/generate/json.md)
 - [`usage generate markdown <FLAGS>`](/cli/reference/generate/markdown.md)
+- [`usage bash [-h] [--help] <SCRIPT> [ARGS]…`](/cli/reference/bash.md)
+- [`usage fish [-h] [--help] <SCRIPT> [ARGS]…`](/cli/reference/fish.md)
+- [`usage zsh [-h] [--help] <SCRIPT> [ARGS]…`](/cli/reference/zsh.md)

--- a/docs/cli/reference/zsh.md
+++ b/docs/cli/reference/zsh.md
@@ -1,7 +1,7 @@
-# `usage bash`
+# `usage zsh`
 
-- **Usage**: `usage bash [-h] [--help] <SCRIPT> [ARGS]…`
-- **Source code**: [`cli/src/cli/bash.rs`](https://github.com/jdx/usage/blob/main/cli/src/cli/bash.rs)
+- **Usage**: `usage zsh [-h] [--help] <SCRIPT> [ARGS]…`
+- **Source code**: [`cli/src/cli/zsh.rs`](https://github.com/jdx/usage/blob/main/cli/src/cli/zsh.rs)
 
 Executes a shell script with the specified shell
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,19 +1,18 @@
 [env]
 CARGO_TERM_COLOR = 'always'
-_.path           = ["./target/debug"]
+_.path = ["./target/debug"]
 
 [tools]
-actionlint            = "latest"
-cargo-binstall        = "1"
-gh                    = "latest"
-"cargo:cargo-edit"    = "latest"
-"cargo:cargo-insta"   = "latest"
+actionlint = "latest"
+cargo-binstall = "1"
+gh = "latest"
+"cargo:cargo-edit" = "latest"
+"cargo:cargo-insta" = "latest"
 "cargo:cargo-release" = "latest"
-"cargo:git-cliff"     = "latest"
-shellcheck            = "latest"
-pnpm                  = "latest"
-node                  = "latest"
-"npm:prettier"        = "latest"
+"cargo:git-cliff" = "latest"
+"npm:prettier" = "latest"
+shellcheck = "latest"
+pnpm = "latest"
 
 [tasks.autofix]
 depends = ["render", "lint-fix", "snapshots"]
@@ -21,38 +20,38 @@ depends = ["render", "lint-fix", "snapshots"]
 [tasks.build]
 sources = ['{cli/,}src/**/*.rs', '{cli/,}Cargo.toml']
 outputs = ['target/debug/rtx']
-run     = 'cargo build --all'
+run = 'cargo build --all'
 
 [tasks.cli]
-alias   = ['x']
+alias = ['x']
 depends = ['build']
-run     = 'usage'
-raw     = true
+run = 'usage'
+raw = true
 
 [tasks.complete-word]
-alias   = ['cw']
+alias = ['cw']
 depends = ['build']
-run     = 'usage cw'
-raw     = true
+run = 'usage cw'
+raw = true
 
 [tasks.run-example]
 depends = ['build']
-run     = './examples/example.sh'
-raw     = true
+run = './examples/example.sh'
+raw = true
 
 [tasks.complete_fish]
 depends = ['build']
-run     = 'usage g completion fish -f examples/example.sh > ~/.config/fish/completions/ex.fish'
-raw     = true
+run = 'usage g completion fish -f examples/example.sh > ~/.config/fish/completions/ex.fish'
+raw = true
 
 [tasks."docs:dev"]
 alias = "docs"
-dir   = 'docs'
-run   = 'npm run docs:dev'
+dir = 'docs'
+run = 'npm run docs:dev'
 
 [tasks.test]
 alias = 't'
-run   = 'cargo test --all --all-features'
+run = 'cargo test --all --all-features'
 
 [tasks.lint]
 depends = ['lint:*']

--- a/mise.toml
+++ b/mise.toml
@@ -1,18 +1,19 @@
 [env]
 CARGO_TERM_COLOR = 'always'
-_.path = ["./target/debug"]
+_.path           = ["./target/debug"]
 
 [tools]
-actionlint = "latest"
-cargo-binstall = "1"
-gh = "latest"
-"cargo:cargo-edit" = "latest"
-"cargo:cargo-insta" = "latest"
+actionlint            = "latest"
+cargo-binstall        = "1"
+gh                    = "latest"
+"cargo:cargo-edit"    = "latest"
+"cargo:cargo-insta"   = "latest"
 "cargo:cargo-release" = "latest"
-"cargo:git-cliff" = "latest"
-"npm:prettier" = "latest"
-shellcheck = "latest"
-pnpm = "latest"
+"cargo:git-cliff"     = "latest"
+shellcheck            = "latest"
+pnpm                  = "latest"
+node                  = "latest"
+"npm:prettier"        = "latest"
 
 [tasks.autofix]
 depends = ["render", "lint-fix", "snapshots"]
@@ -20,38 +21,38 @@ depends = ["render", "lint-fix", "snapshots"]
 [tasks.build]
 sources = ['{cli/,}src/**/*.rs', '{cli/,}Cargo.toml']
 outputs = ['target/debug/rtx']
-run = 'cargo build --all'
+run     = 'cargo build --all'
 
 [tasks.cli]
-alias = ['x']
+alias   = ['x']
 depends = ['build']
-run = 'usage'
-raw = true
+run     = 'usage'
+raw     = true
 
 [tasks.complete-word]
-alias = ['cw']
+alias   = ['cw']
 depends = ['build']
-run = 'usage cw'
-raw = true
+run     = 'usage cw'
+raw     = true
 
 [tasks.run-example]
 depends = ['build']
-run = './examples/example.sh'
-raw = true
+run     = './examples/example.sh'
+raw     = true
 
 [tasks.complete_fish]
 depends = ['build']
-run = 'usage g completion fish -f examples/example.sh > ~/.config/fish/completions/ex.fish'
-raw = true
+run     = 'usage g completion fish -f examples/example.sh > ~/.config/fish/completions/ex.fish'
+raw     = true
 
 [tasks."docs:dev"]
 alias = "docs"
-dir = 'docs'
-run = 'npm run docs:dev'
+dir   = 'docs'
+run   = 'npm run docs:dev'
 
 [tasks.test]
 alias = 't'
-run = 'cargo test --all --all-features'
+run   = 'cargo test --all --all-features'
 
 [tasks.lint]
 depends = ['lint:*']


### PR DESCRIPTION
this pr adds `usage zsh` and `usage fish`, the behavior is the same as `usage bash` except with the respective shells.

This is done by renaming `Bash` -> `Shell` and adding an arg to the run method that lets you specify which shell is being used.

![CleanShot 2025-05-12 at 14 54 53](https://github.com/user-attachments/assets/ba3f8d2f-b6f5-4a6a-a601-84643b26022f)

alternatives considered:

- `usage shell --shell=<shell>` this is the most flexible but also is a bigger footgun, it also looks cumbersome in the shebang of a script.
