### PR TITLE
fix: update wrong name package manager

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -31,5 +31,5 @@ brew install usage
 usage is available in [Extra](https://archlinux.org/packages/extra/x86_64/usage/)
 
 ```sh
-pacmac -S usage
+pacman -S usage
 ```


### PR DESCRIPTION
Hello @jdx , I see wrong name package manager on Arch. Can I fix this?