### PR TITLE
docs: fix bad whitespace character

### DIFF
--- a/docs/spec/reference/complete.md
+++ b/docs/spec/reference/complete.md
@@ -23,7 +23,7 @@ port:Port number
 
 ":" can be escaped with a backslash.
 
-## Templates
+## Templates
 
 The run can be customized with [tera](https://keats.github.io/tera/) templates. The following values are available:
 


### PR DESCRIPTION
This is my bad, I entered a bad whitespace character by mistake:
<img width="447" alt="image" src="https://github.com/user-attachments/assets/e06c5cbe-e47b-4321-a787-8d871f1a9128" />
