### PR TITLE
fix(completions): ignore aliases and functions named usage

### DIFF
--- a/cli/assets/completions/_usage
+++ b/cli/assets/completions/_usage
@@ -15,7 +15,7 @@ _usage() {
   typeset -A opt_args
   local curcontext="$curcontext" spec cache_policy
 
-  if ! command -v usage &> /dev/null; then
+  if ! command usage &> /dev/null; then
       echo >&2
       echo "Error: usage CLI not found. This is required for completions to work in usage." >&2
       echo "See https://usage.jdx.dev for more information." >&2
@@ -34,7 +34,7 @@ _usage() {
     _store_cache _usage_spec_usage spec
   fi
 
-  _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"
+  _arguments "*: :(($(command usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"
   return 0
 }
 

--- a/cli/assets/completions/usage.bash
+++ b/cli/assets/completions/usage.bash
@@ -1,5 +1,5 @@
 _usage() {
-    if ! command -v usage &> /dev/null; then
+    if ! command usage &> /dev/null; then
         echo >&2
         echo "Error: usage CLI not found. This is required for completions to work in usage." >&2
         echo "See https://usage.jdx.dev for more information." >&2
@@ -13,7 +13,7 @@ _usage() {
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     # shellcheck disable=SC2207
-	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_usage}" --cword="$cword" -- "${words[@]}")"
+	_comp_compgen -- -W "$(command usage complete-word --shell bash -s "${_usage_spec_usage}" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"
     # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then

--- a/cli/assets/completions/usage.fish
+++ b/cli/assets/completions/usage.fish
@@ -1,5 +1,5 @@
 # if "usage" is not installed show an error
-if ! command -v usage &> /dev/null
+if ! command usage &> /dev/null
     echo >&2
     echo "Error: usage CLI not found. This is required for completions to work in usage." >&2
     echo "See https://usage.jdx.dev for more information." >&2
@@ -9,7 +9,7 @@ end
 set _usage_spec_usage (usage --usage-spec | string collect)
 set -l tokens
 if commandline -x >/dev/null 2>&1
-    complete -xc usage -a '(usage complete-word --shell fish -s "$_usage_spec_usage" -- (commandline -xpc) (commandline -t))'
+    complete -xc usage -a '(command usage complete-word --shell fish -s "$_usage_spec_usage" -- (commandline -xpc) (commandline -t))'
 else
-    complete -xc usage -a '(usage complete-word --shell fish -s "$_usage_spec_usage" -- (commandline -opc) (commandline -t))'
+    complete -xc usage -a '(command usage complete-word --shell fish -s "$_usage_spec_usage" -- (commandline -opc) (commandline -t))'
 end

--- a/lib/src/complete/bash.rs
+++ b/lib/src/complete/bash.rs
@@ -17,7 +17,7 @@ pub fn complete_bash(opts: &CompleteOptions) -> String {
     };
     out.push(format!(
         r#"_{bin_snake}() {{
-    if ! command -v {usage_bin} &> /dev/null; then
+    if ! command {usage_bin} &> /dev/null; then
         echo >&2
         echo "Error: {usage_bin} CLI not found. This is required for completions to work in {bin}." >&2
         echo "See https://usage.jdx.dev for more information." >&2
@@ -48,7 +48,7 @@ __USAGE_EOF__"#,
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     # shellcheck disable=SC2207
-	_comp_compgen -- -W "$({usage_bin} complete-word --shell bash -s "${{{spec_variable}}}" --cword="$cword" -- "${{words[@]}}")"
+	_comp_compgen -- -W "$(command {usage_bin} complete-word --shell bash -s "${{{spec_variable}}}" --cword="$cword" -- "${{words[@]}}")"
 	_comp_ltrim_colon_completions "$cur"
     # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then

--- a/lib/src/complete/fish.rs
+++ b/lib/src/complete/fish.rs
@@ -13,7 +13,7 @@ pub fn complete_fish(opts: &CompleteOptions) -> String {
     let mut out = vec![format!(
         r#"
 # if "{usage_bin}" is not installed show an error
-if ! command -v {usage_bin} &> /dev/null
+if ! command {usage_bin} &> /dev/null
     echo >&2
     echo "Error: {usage_bin} CLI not found. This is required for completions to work in {bin}." >&2
     echo "See https://usage.jdx.dev for more information." >&2
@@ -49,9 +49,9 @@ set {spec_variable} '{spec_escaped}'"#
         r#"
 set -l tokens
 if commandline -x >/dev/null 2>&1
-    complete -xc {bin} -a '({usage_bin} complete-word --shell fish -s "${spec_variable}" -- (commandline -xpc) (commandline -t))'
+    complete -xc {bin} -a '(command {usage_bin} complete-word --shell fish -s "${spec_variable}" -- (commandline -xpc) (commandline -t))'
 else
-    complete -xc {bin} -a '({usage_bin} complete-word --shell fish -s "${spec_variable}" -- (commandline -opc) (commandline -t))'
+    complete -xc {bin} -a '(command {usage_bin} complete-word --shell fish -s "${spec_variable}" -- (commandline -opc) (commandline -t))'
 end
 "#
     ).trim().to_string());

--- a/lib/src/complete/snapshots/usage__complete__bash__tests__complete_bash-2.snap
+++ b/lib/src/complete/snapshots/usage__complete__bash__tests__complete_bash-2.snap
@@ -1,10 +1,9 @@
 ---
 source: lib/src/complete/bash.rs
 expression: "complete_bash(&CompleteOptions\n{\n    usage_bin: \"usage\".to_string(), shell: \"bash\".to_string(), bin:\n    \"mycli\".to_string(), cache_key: Some(\"1.2.3\".to_string()), spec: None,\n    usage_cmd: Some(\"mycli complete --usage\".to_string()),\n    include_bash_completion_lib: false,\n})"
-snapshot_kind: text
 ---
 _mycli() {
-    if ! command -v usage &> /dev/null; then
+    if ! command usage &> /dev/null; then
         echo >&2
         echo "Error: usage CLI not found. This is required for completions to work in mycli." >&2
         echo "See https://usage.jdx.dev for more information." >&2
@@ -18,7 +17,7 @@ _mycli() {
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     # shellcheck disable=SC2207
-	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mycli_1_2_3}" --cword="$cword" -- "${words[@]}")"
+	_comp_compgen -- -W "$(command usage complete-word --shell bash -s "${_usage_spec_mycli_1_2_3}" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"
     # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then

--- a/lib/src/complete/snapshots/usage__complete__bash__tests__complete_bash-3.snap
+++ b/lib/src/complete/snapshots/usage__complete__bash__tests__complete_bash-3.snap
@@ -1,10 +1,9 @@
 ---
 source: lib/src/complete/bash.rs
 expression: "complete_bash(&CompleteOptions\n{\n    usage_bin: \"usage\".to_string(), shell: \"bash\".to_string(), bin:\n    \"mycli\".to_string(), cache_key: None, spec:\n    Some(SPEC_KITCHEN_SINK.clone()), usage_cmd: None,\n    include_bash_completion_lib: false,\n})"
-snapshot_kind: text
 ---
 _mycli() {
-    if ! command -v usage &> /dev/null; then
+    if ! command usage &> /dev/null; then
         echo >&2
         echo "Error: usage CLI not found. This is required for completions to work in mycli." >&2
         echo "See https://usage.jdx.dev for more information." >&2
@@ -51,7 +50,7 @@ __USAGE_EOF__
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     # shellcheck disable=SC2207
-	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mycli}" --cword="$cword" -- "${words[@]}")"
+	_comp_compgen -- -W "$(command usage complete-word --shell bash -s "${_usage_spec_mycli}" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"
     # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then

--- a/lib/src/complete/snapshots/usage__complete__bash__tests__complete_bash.snap
+++ b/lib/src/complete/snapshots/usage__complete__bash__tests__complete_bash.snap
@@ -1,10 +1,9 @@
 ---
 source: lib/src/complete/bash.rs
 expression: "complete_bash(&CompleteOptions\n{\n    usage_bin: \"usage\".to_string(), shell: \"bash\".to_string(), bin:\n    \"mycli\".to_string(), cache_key: None, spec: None, usage_cmd:\n    Some(\"mycli complete --usage\".to_string()), include_bash_completion_lib:\n    false,\n})"
-snapshot_kind: text
 ---
 _mycli() {
-    if ! command -v usage &> /dev/null; then
+    if ! command usage &> /dev/null; then
         echo >&2
         echo "Error: usage CLI not found. This is required for completions to work in mycli." >&2
         echo "See https://usage.jdx.dev for more information." >&2
@@ -18,7 +17,7 @@ _mycli() {
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     # shellcheck disable=SC2207
-	_comp_compgen -- -W "$(usage complete-word --shell bash -s "${_usage_spec_mycli}" --cword="$cword" -- "${words[@]}")"
+	_comp_compgen -- -W "$(command usage complete-word --shell bash -s "${_usage_spec_mycli}" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"
     # shellcheck disable=SC2181
     if [[ $? -ne 0 ]]; then

--- a/lib/src/complete/snapshots/usage__complete__fish__tests__complete_fish-2.snap
+++ b/lib/src/complete/snapshots/usage__complete__fish__tests__complete_fish-2.snap
@@ -1,10 +1,9 @@
 ---
 source: lib/src/complete/fish.rs
 expression: "complete_fish(&CompleteOptions\n{\n    usage_bin: \"usage\".to_string(), shell: \"fish\".to_string(), bin:\n    \"mycli\".to_string(), cache_key: Some(\"1.2.3\".to_string()), spec: None,\n    usage_cmd: Some(\"mycli complete --usage\".to_string()),\n    include_bash_completion_lib: false,\n})"
-snapshot_kind: text
 ---
 # if "usage" is not installed show an error
-if ! command -v usage &> /dev/null
+if ! command usage &> /dev/null
     echo >&2
     echo "Error: usage CLI not found. This is required for completions to work in mycli." >&2
     echo "See https://usage.jdx.dev for more information." >&2
@@ -16,7 +15,7 @@ if ! set -q _usage_spec_mycli_1_2_3
 end
 set -l tokens
 if commandline -x >/dev/null 2>&1
-    complete -xc mycli -a '(usage complete-word --shell fish -s "$_usage_spec_mycli_1_2_3" -- (commandline -xpc) (commandline -t))'
+    complete -xc mycli -a '(command usage complete-word --shell fish -s "$_usage_spec_mycli_1_2_3" -- (commandline -xpc) (commandline -t))'
 else
-    complete -xc mycli -a '(usage complete-word --shell fish -s "$_usage_spec_mycli_1_2_3" -- (commandline -opc) (commandline -t))'
+    complete -xc mycli -a '(command usage complete-word --shell fish -s "$_usage_spec_mycli_1_2_3" -- (commandline -opc) (commandline -t))'
 end

--- a/lib/src/complete/snapshots/usage__complete__fish__tests__complete_fish-3.snap
+++ b/lib/src/complete/snapshots/usage__complete__fish__tests__complete_fish-3.snap
@@ -1,10 +1,9 @@
 ---
 source: lib/src/complete/fish.rs
 expression: "complete_fish(&CompleteOptions\n{\n    usage_bin: \"usage\".to_string(), shell: \"fish\".to_string(), bin:\n    \"mycli\".to_string(), cache_key: None, spec:\n    Some(SPEC_KITCHEN_SINK.clone()), usage_cmd: None,\n    include_bash_completion_lib: false,\n})"
-snapshot_kind: text
 ---
 # if "usage" is not installed show an error
-if ! command -v usage &> /dev/null
+if ! command usage &> /dev/null
     echo >&2
     echo "Error: usage CLI not found. This is required for completions to work in mycli." >&2
     echo "See https://usage.jdx.dev for more information." >&2
@@ -48,7 +47,7 @@ cmd plugin {
 '
 set -l tokens
 if commandline -x >/dev/null 2>&1
-    complete -xc mycli -a '(usage complete-word --shell fish -s "$_usage_spec_mycli" -- (commandline -xpc) (commandline -t))'
+    complete -xc mycli -a '(command usage complete-word --shell fish -s "$_usage_spec_mycli" -- (commandline -xpc) (commandline -t))'
 else
-    complete -xc mycli -a '(usage complete-word --shell fish -s "$_usage_spec_mycli" -- (commandline -opc) (commandline -t))'
+    complete -xc mycli -a '(command usage complete-word --shell fish -s "$_usage_spec_mycli" -- (commandline -opc) (commandline -t))'
 end

--- a/lib/src/complete/snapshots/usage__complete__fish__tests__complete_fish.snap
+++ b/lib/src/complete/snapshots/usage__complete__fish__tests__complete_fish.snap
@@ -1,10 +1,9 @@
 ---
 source: lib/src/complete/fish.rs
 expression: "complete_fish(&CompleteOptions\n{\n    usage_bin: \"usage\".to_string(), shell: \"fish\".to_string(), bin:\n    \"mycli\".to_string(), cache_key: None, spec: None, usage_cmd:\n    Some(\"mycli complete --usage\".to_string()), include_bash_completion_lib:\n    false,\n})"
-snapshot_kind: text
 ---
 # if "usage" is not installed show an error
-if ! command -v usage &> /dev/null
+if ! command usage &> /dev/null
     echo >&2
     echo "Error: usage CLI not found. This is required for completions to work in mycli." >&2
     echo "See https://usage.jdx.dev for more information." >&2
@@ -14,7 +13,7 @@ end
 set _usage_spec_mycli (mycli complete --usage | string collect)
 set -l tokens
 if commandline -x >/dev/null 2>&1
-    complete -xc mycli -a '(usage complete-word --shell fish -s "$_usage_spec_mycli" -- (commandline -xpc) (commandline -t))'
+    complete -xc mycli -a '(command usage complete-word --shell fish -s "$_usage_spec_mycli" -- (commandline -xpc) (commandline -t))'
 else
-    complete -xc mycli -a '(usage complete-word --shell fish -s "$_usage_spec_mycli" -- (commandline -opc) (commandline -t))'
+    complete -xc mycli -a '(command usage complete-word --shell fish -s "$_usage_spec_mycli" -- (commandline -opc) (commandline -t))'
 end

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-2.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-2.snap
@@ -1,7 +1,6 @@
 ---
 source: lib/src/complete/zsh.rs
-expression: "complete_zsh(&CompleteOptions\n{\n    shell: \"zsh\".to_string(), bin: \"mycli\".to_string(), cache_key:\n    Some(\"1.2.3\".to_string()), spec: None, usage_cmd:\n    Some(\"mycli complete --usage\".to_string()),\n})"
-snapshot_kind: text
+expression: "complete_zsh(&CompleteOptions\n{\n    usage_bin: \"usage\".to_string(), shell: \"zsh\".to_string(), bin:\n    \"mycli\".to_string(), cache_key: Some(\"1.2.3\".to_string()), spec: None,\n    usage_cmd: Some(\"mycli complete --usage\".to_string()),\n    include_bash_completion_lib: false,\n})"
 ---
 #compdef mycli
 local curcontext="$curcontext"
@@ -20,7 +19,7 @@ _mycli() {
   typeset -A opt_args
   local curcontext="$curcontext" spec cache_policy
 
-  if ! command -v usage &> /dev/null; then
+  if ! command usage &> /dev/null; then
       echo >&2
       echo "Error: usage CLI not found. This is required for completions to work in mycli." >&2
       echo "See https://usage.jdx.dev for more information." >&2
@@ -39,7 +38,7 @@ _mycli() {
     _store_cache _usage_spec_mycli_1_2_3 spec
   fi
 
-  _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"
+  _arguments "*: :(($(command usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"
   return 0
 }
 

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-3.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-3.snap
@@ -1,7 +1,6 @@
 ---
 source: lib/src/complete/zsh.rs
 expression: "complete_zsh(&CompleteOptions\n{\n    usage_bin: \"usage\".to_string(), shell: \"zsh\".to_string(), bin:\n    \"mycli\".to_string(), cache_key: None, spec:\n    Some(SPEC_KITCHEN_SINK.clone()), usage_cmd: None,\n    include_bash_completion_lib: false,\n})"
-snapshot_kind: text
 ---
 #compdef mycli
 local curcontext="$curcontext"
@@ -10,7 +9,7 @@ _mycli() {
   typeset -A opt_args
   local curcontext="$curcontext" spec cache_policy
 
-  if ! command -v usage &> /dev/null; then
+  if ! command usage &> /dev/null; then
       echo >&2
       echo "Error: usage CLI not found. This is required for completions to work in mycli." >&2
       echo "See https://usage.jdx.dev for more information." >&2
@@ -53,7 +52,7 @@ cmd plugin {
 }
 __USAGE_EOF__
 
-  _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"
+  _arguments "*: :(($(command usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"
   return 0
 }
 

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh.snap
@@ -1,7 +1,6 @@
 ---
 source: lib/src/complete/zsh.rs
-expression: "complete_zsh(&CompleteOptions\n{\n    shell: \"zsh\".to_string(), bin: \"mycli\".to_string(), cache_key: None, spec:\n    None, usage_cmd: Some(\"mycli complete --usage\".to_string()),\n})"
-snapshot_kind: text
+expression: "complete_zsh(&CompleteOptions\n{\n    usage_bin: \"usage\".to_string(), shell: \"zsh\".to_string(), bin:\n    \"mycli\".to_string(), cache_key: None, spec: None, usage_cmd:\n    Some(\"mycli complete --usage\".to_string()), include_bash_completion_lib:\n    false,\n})"
 ---
 #compdef mycli
 local curcontext="$curcontext"
@@ -20,7 +19,7 @@ _mycli() {
   typeset -A opt_args
   local curcontext="$curcontext" spec cache_policy
 
-  if ! command -v usage &> /dev/null; then
+  if ! command usage &> /dev/null; then
       echo >&2
       echo "Error: usage CLI not found. This is required for completions to work in mycli." >&2
       echo "See https://usage.jdx.dev for more information." >&2
@@ -39,7 +38,7 @@ _mycli() {
     _store_cache _usage_spec_mycli spec
   fi
 
-  _arguments "*: :(($(usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"
+  _arguments "*: :(($(command usage complete-word --shell zsh -s "$spec" -- "${words[@]}" )))"
   return 0
 }
 

--- a/lib/src/complete/zsh.rs
+++ b/lib/src/complete/zsh.rs
@@ -38,7 +38,7 @@ _{bin_snake}() {{
   typeset -A opt_args
   local curcontext="$curcontext" spec cache_policy
 
-  if ! command -v {usage_bin} &> /dev/null; then
+  if ! command {usage_bin} &> /dev/null; then
       echo >&2
       echo "Error: {usage_bin} CLI not found. This is required for completions to work in {bin}." >&2
       echo "See https://usage.jdx.dev for more information." >&2
@@ -74,7 +74,7 @@ __USAGE_EOF__"#,
 
     out.push(format!(
         r#"
-  _arguments "*: :(($({usage_bin} complete-word --shell zsh -s "$spec" -- "${{words[@]}}" )))"
+  _arguments "*: :(($(command {usage_bin} complete-word --shell zsh -s "$spec" -- "${{words[@]}}" )))"
   return 0
 }}
 

--- a/mise.lock
+++ b/mise.lock
@@ -11,6 +11,7 @@ backend = "aqua:cargo-bins/cargo-binstall"
 
 [tools.cargo-binstall.checksums]
 "cargo-binstall-aarch64-apple-darwin.zip" = "sha256:88467030db096ceddf97405750fe9e67cf25106da241db7a60900c58f192206f"
+"cargo-binstall-x86_64-unknown-linux-musl.tgz" = "blake3:aa9ddfd157319d66f32f01afcf9488215ae3244fe00f5f397fd69c3a59f2df4d"
 
 [tools."cargo:cargo-edit"]
 version = "0.13.2"
@@ -33,6 +34,7 @@ version = "2.71.2"
 backend = "aqua:cli/cli"
 
 [tools.gh.checksums]
+"gh_2.71.2_linux_amd64.tar.gz" = "sha256:6e52767d7ab14f6849c38b9da1daade4c674f3fde75e0434ede33d921bb75d35"
 "gh_2.71.2_macOS_arm64.zip" = "sha256:95e4d3bf841ef8448f6ac828d89de3d49bd994f063f0d1566becbe1aa8c98a81"
 
 [tools."npm:prettier"]
@@ -44,6 +46,7 @@ version = "10.9.0"
 backend = "aqua:pnpm/pnpm"
 
 [tools.pnpm.checksums]
+pnpm-linux-x64 = "blake3:41663d271830dd89537c0b553e14eec97232d22093082179030c4e2a416581b5"
 pnpm-macos-arm64 = "sha256:d6a0114bd409c7da1c8d3b4842c74793171388deecc42068c87e940da00dbec2"
 
 [tools.shellcheck]


### PR DESCRIPTION
Resolves https://github.com/jdx/mise/discussions/5358.

This PR replaces `usage` with `command usage`, to ignore aliases and functions named `usage`.

Also, for consistency, use `command usage` instead of `command -v usage` to check its existence.
In this way, if aliases or functions named `usage` exist but `usage` is not installed, the completions are skipped as expected.

I don't think this is a case, but something like `alias usage=usage --default-flag` will be ignored by this PR.