### PR TITLE
chore: release v2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.2.2](https://github.com/jdx/usage/compare/v2.2.1..v2.2.2) - 2025-07-16
+
+### 📚 Documentation
+
+- fix revert for git-cliff by [@jdx](https://github.com/jdx) in [#302](https://github.com/jdx/usage/pull/302)
+
+### ◀️ Revert
+
+- Revert "fix(completions): ignore aliases and functions named usage" by [@jdx](https://github.com/jdx) in [#301](https://github.com/jdx/usage/pull/301)
+
 ## [2.2.1](https://github.com/jdx/usage/compare/v2.2.0..v2.2.1) - 2025-07-16
 
 ### 🐛 Bug Fixes
@@ -134,6 +144,11 @@
 
 - add v1-fallback for kdl by [@jdx](https://github.com/jdx) in [9516e15](https://github.com/jdx/usage/commit/9516e15d53c0769a1227ec4ab37e0622b4e7bead)
 
+### ◀️ Revert
+
+- Revert "fix: add v1-fallback for kdl" by [@jdx](https://github.com/jdx) in [ef98628](https://github.com/jdx/usage/commit/ef98628658cb3adcc3284aa341b70329743fa3da)
+- Revert "chore: attempt to fix kdl v1-fallback" by [@jdx](https://github.com/jdx) in [c440c2a](https://github.com/jdx/usage/commit/c440c2a4fb843da0670b72f0b6c233602d7c9066)
+
 ### 🔍 Other Changes
 
 - fix publish script by [@jdx](https://github.com/jdx) in [7c72bc3](https://github.com/jdx/usage/commit/7c72bc3450fe0e731331be18354244b5a19223d5)
@@ -141,8 +156,6 @@
 - fix fig syntax rendering by [@jdx](https://github.com/jdx) in [2b2d301](https://github.com/jdx/usage/commit/2b2d30104280c64854b78d829547a5d3fa8694df)
 - attempt to fix kdl v1-fallback by [@jdx](https://github.com/jdx) in [8c0a2c6](https://github.com/jdx/usage/commit/8c0a2c698e51f382888dfa2bc170bb9035df1173)
 - bump by [@jdx](https://github.com/jdx) in [bdc1dfb](https://github.com/jdx/usage/commit/bdc1dfb2c6f12466cad102f1a7b06f30b32ef05e)
-- Revert "fix: add v1-fallback for kdl" by [@jdx](https://github.com/jdx) in [ef98628](https://github.com/jdx/usage/commit/ef98628658cb3adcc3284aa341b70329743fa3da)
-- Revert "chore: attempt to fix kdl v1-fallback" by [@jdx](https://github.com/jdx) in [c440c2a](https://github.com/jdx/usage/commit/c440c2a4fb843da0670b72f0b6c233602d7c9066)
 - bump by [@jdx](https://github.com/jdx) in [6a468df](https://github.com/jdx/usage/commit/6a468df654ce2e7a9fad1de52a279be74268fbbf)
 
 ## [2.0.0](https://github.com/jdx/usage/compare/v1.7.4..v2.0.0) - 2025-01-10

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1823,7 +1823,7 @@ checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "usage-cli"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1850,7 +1850,7 @@ dependencies = [
 
 [[package]]
 name = "usage-lib"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "clap",
  "ctor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT"
 [workspace.dependencies]
 clap_usage = { path = "./clap_usage", version = "2.0.3" }
 usage-cli = { path = "./cli" }
-usage-lib = { path = "./lib", version = "2.2.1", features = ["clap"] }
+usage-lib = { path = "./lib", version = "2.2.2", features = ["clap"] }
 
 [workspace.metadata.release]
 allow-branch = ["main"]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-cli"
 edition = "2021"
-version = "2.2.1"
+version = "2.2.2"
 description = "CLI for working with usage-based CLIs"
 license = { workspace = true }
 authors = { workspace = true }

--- a/cli/usage.usage.kdl
+++ b/cli/usage.usage.kdl
@@ -1,6 +1,6 @@
 name usage-cli
 bin usage
-version "2.2.1"
+version "2.2.2"
 about "CLI for working with usage-based CLIs"
 usage "Usage: usage-cli [OPTIONS] [COMPLETIONS] <COMMAND>"
 flag --usage-spec help="Outputs a `usage.kdl` spec for this CLI itself"

--- a/docs/cli/reference/commands.json
+++ b/docs/cli/reference/commands.json
@@ -689,7 +689,7 @@
   "config": {
     "props": {}
   },
-  "version": "2.2.1",
+  "version": "2.2.2",
   "usage": "Usage: usage-cli [OPTIONS] [COMPLETIONS] <COMMAND>",
   "complete": {},
   "source_code_link_template": "https://github.com/jdx/usage/blob/main/cli/src/cli/{{path}}.rs",

--- a/docs/cli/reference/index.md
+++ b/docs/cli/reference/index.md
@@ -2,7 +2,7 @@
 
 **Usage**: `usage [--usage-spec] [COMPLETIONS] <SUBCOMMAND>`
 
-**Version**: 2.2.1
+**Version**: 2.2.2
 
 - **Usage**: `usage [--usage-spec] [COMPLETIONS] <SUBCOMMAND>`
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-lib"
 edition = "2021"
-version = "2.2.1"
+version = "2.2.2"
 rust-version = "1.70.0"
 include = [
     "/Cargo.toml",


### PR DESCRIPTION
## [2.2.2](https://github.com/jdx/usage/compare/v2.2.1..v2.2.2) - 2025-07-16

### 📚 Documentation

- fix revert for git-cliff by [@jdx](https://github.com/jdx) in [#302](https://github.com/jdx/usage/pull/302)

### ◀️ Revert

- Revert "fix(completions): ignore aliases and functions named usage" by [@jdx](https://github.com/jdx) in [#301](https://github.com/jdx/usage/pull/301)