### PR TITLE
fix: issues with very large specs

### DIFF
--- a/cli/assets/completions/_usage
+++ b/cli/assets/completions/_usage
@@ -15,7 +15,7 @@ _usage_usage_cache_policy() {
 
 _usage() {
   typeset -A opt_args
-  local curcontext="$curcontext" spec cache_policy
+  local curcontext="$curcontext" cache_policy
 
   if ! type -p usage &> /dev/null; then
       echo >&2
@@ -24,21 +24,8 @@ _usage() {
       return 1
   fi
 
-  zstyle -s ":completion:${curcontext}:" cache-policy cache_policy
-  if [[ -z $cache_policy ]]; then
-    zstyle ":completion:${curcontext}:" cache-policy _usage_usage_cache_policy
-  fi
-
-  if ( [[ -z "${_usage_spec_usage:-}" ]] || _cache_invalid _usage_spec_usage ) \
-      && ! _retrieve_cache _usage_spec_usage;
-  then
-    spec="$(usage --usage-spec)"
-    _store_cache _usage_spec_usage spec
-  fi
-
   local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_usage.spec"
-  # Always update spec file when not cached
-  echo "$spec" > "$spec_file"
+  usage --usage-spec > "$spec_file"
   _arguments "*: :(($(command usage complete-word --shell zsh -f "$spec_file" -- "${words[@]}" )))"
   return 0
 }

--- a/cli/assets/completions/usage.bash
+++ b/cli/assets/completions/usage.bash
@@ -7,15 +7,10 @@ _usage() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_usage:-} ]]; then
-        _usage_spec_usage="$(usage --usage-spec)"
-    fi
-
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_usage.spec"
-    # Always update spec file when not cached
-    echo "${_usage_spec_usage}" > "$spec_file"
+    usage --usage-spec > "$spec_file"
     # shellcheck disable=SC2207
 	_comp_compgen -- -W "$(command usage complete-word --shell bash -f "$spec_file" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"

--- a/cli/assets/completions/usage.fish
+++ b/cli/assets/completions/usage.fish
@@ -7,12 +7,9 @@ if ! type -p usage &> /dev/null
     echo "See https://usage.jdx.dev for more information." >&2
     return 1
 end
-
-set _usage_spec_usage (usage --usage-spec | string collect)
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
 set -l spec_file "$tmpdir/usage__usage_spec_usage.spec"
-# Always update spec file when not cached
-echo $_usage_spec_usage > "$spec_file"
+usage --usage-spec | string collect > "$spec_file"
 
 set -l tokens
 if commandline -x >/dev/null 2>&1

--- a/lib/src/complete/fish.rs
+++ b/lib/src/complete/fish.rs
@@ -30,7 +30,7 @@ end"#
     ];
 
     if let Some(spec) = &opts.spec {
-        let spec_escaped = spec.to_string().replace("'", r"\\'");
+        let spec_escaped = spec.to_string().replace("'", r"\'");
         out.push(format!(
             r#"
 set {spec_variable} '{spec_escaped}'"#

--- a/lib/src/complete/snapshots/usage__complete__bash__tests__complete_bash-2.snap
+++ b/lib/src/complete/snapshots/usage__complete__bash__tests__complete_bash-2.snap
@@ -11,15 +11,11 @@ _mycli() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mycli_1_2_3:-} ]]; then
-        _usage_spec_mycli_1_2_3="$(mycli complete --usage)"
-    fi
-
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mycli_1_2_3.spec"
     if [[ ! -f "$spec_file" ]]; then
-        echo "${_usage_spec_mycli_1_2_3}" > "$spec_file"
+        mycli complete --usage > "$spec_file"
     fi
     # shellcheck disable=SC2207
 	_comp_compgen -- -W "$(command usage complete-word --shell bash -f "$spec_file" --cword="$cword" -- "${words[@]}")"

--- a/lib/src/complete/snapshots/usage__complete__bash__tests__complete_bash-3.snap
+++ b/lib/src/complete/snapshots/usage__complete__bash__tests__complete_bash-3.snap
@@ -11,7 +11,10 @@ _mycli() {
         return 1
     fi
 
-    read -r -d '' _usage_spec_mycli <<'__USAGE_EOF__'
+	local cur prev words cword was_split comp_args
+    _comp_initialize -n : -- "$@" || return
+    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mycli.spec"
+    cat > "$spec_file" <<'__USAGE_EOF__'
 name mycli
 bin mycli
 source_code_link_template "https://github.com/jdx/mise/blob/main/src/cli/{{path}}.rs"
@@ -47,12 +50,6 @@ cmd plugin {
     }
 }
 __USAGE_EOF__
-
-	local cur prev words cword was_split comp_args
-    _comp_initialize -n : -- "$@" || return
-    local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mycli.spec"
-    # Always update spec file when not cached
-    echo "${_usage_spec_mycli}" > "$spec_file"
     # shellcheck disable=SC2207
 	_comp_compgen -- -W "$(command usage complete-word --shell bash -f "$spec_file" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"

--- a/lib/src/complete/snapshots/usage__complete__bash__tests__complete_bash.snap
+++ b/lib/src/complete/snapshots/usage__complete__bash__tests__complete_bash.snap
@@ -11,15 +11,10 @@ _mycli() {
         return 1
     fi
 
-    if [[ -z ${_usage_spec_mycli:-} ]]; then
-        _usage_spec_mycli="$(mycli complete --usage)"
-    fi
-
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mycli.spec"
-    # Always update spec file when not cached
-    echo "${_usage_spec_mycli}" > "$spec_file"
+    mycli complete --usage > "$spec_file"
     # shellcheck disable=SC2207
 	_comp_compgen -- -W "$(command usage complete-word --shell bash -f "$spec_file" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"

--- a/lib/src/complete/snapshots/usage__complete__fish__tests__complete_fish-2.snap
+++ b/lib/src/complete/snapshots/usage__complete__fish__tests__complete_fish-2.snap
@@ -11,14 +11,10 @@ if ! type -p usage &> /dev/null
     echo "See https://usage.jdx.dev for more information." >&2
     return 1
 end
-
-if ! set -q _usage_spec_mycli_1_2_3
-  set -g _usage_spec_mycli_1_2_3 (mycli complete --usage | string collect)
-end
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
 set -l spec_file "$tmpdir/usage__usage_spec_mycli_1_2_3.spec"
 if not test -f "$spec_file"
-    echo $_usage_spec_mycli_1_2_3 > "$spec_file"
+    mycli complete --usage | string collect > "$spec_file"
 end
 
 set -l tokens

--- a/lib/src/complete/snapshots/usage__complete__fish__tests__complete_fish-3.snap
+++ b/lib/src/complete/snapshots/usage__complete__fish__tests__complete_fish-3.snap
@@ -49,7 +49,6 @@ cmd plugin {
 '
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
 set -l spec_file "$tmpdir/usage__usage_spec_mycli.spec"
-# Always update spec file when not cached
 echo $_usage_spec_mycli > "$spec_file"
 
 set -l tokens

--- a/lib/src/complete/snapshots/usage__complete__fish__tests__complete_fish.snap
+++ b/lib/src/complete/snapshots/usage__complete__fish__tests__complete_fish.snap
@@ -11,12 +11,9 @@ if ! type -p usage &> /dev/null
     echo "See https://usage.jdx.dev for more information." >&2
     return 1
 end
-
-set _usage_spec_mycli (mycli complete --usage | string collect)
 set -l tmpdir (if set -q TMPDIR; echo $TMPDIR; else; echo /tmp; end)
 set -l spec_file "$tmpdir/usage__usage_spec_mycli.spec"
-# Always update spec file when not cached
-echo $_usage_spec_mycli > "$spec_file"
+mycli complete --usage | string collect > "$spec_file"
 
 set -l tokens
 if commandline -x >/dev/null 2>&1

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-2.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-2.snap
@@ -19,7 +19,7 @@ _usage_mycli_cache_policy() {
 
 _mycli() {
   typeset -A opt_args
-  local curcontext="$curcontext" spec cache_policy
+  local curcontext="$curcontext" cache_policy
 
   if ! type -p usage &> /dev/null; then
       echo >&2
@@ -28,21 +28,9 @@ _mycli() {
       return 1
   fi
 
-  zstyle -s ":completion:${curcontext}:" cache-policy cache_policy
-  if [[ -z $cache_policy ]]; then
-    zstyle ":completion:${curcontext}:" cache-policy _usage_mycli_cache_policy
-  fi
-
-  if ( [[ -z "${_usage_spec_mycli_1_2_3:-}" ]] || _cache_invalid _usage_spec_mycli_1_2_3 ) \
-      && ! _retrieve_cache _usage_spec_mycli_1_2_3;
-  then
-    spec="$(mycli complete --usage)"
-    _store_cache _usage_spec_mycli_1_2_3 spec
-  fi
-
   local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mycli_1_2_3.spec"
   if [[ ! -f "$spec_file" ]]; then
-    echo "$spec" > "$spec_file"
+    mycli complete --usage > "$spec_file"
   fi
   _arguments "*: :(($(command usage complete-word --shell zsh -f "$spec_file" -- "${words[@]}" )))"
   return 0

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-3.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-3.snap
@@ -9,7 +9,7 @@ local curcontext="$curcontext"
 
 _mycli() {
   typeset -A opt_args
-  local curcontext="$curcontext" spec cache_policy
+  local curcontext="$curcontext" cache_policy
 
   if ! type -p usage &> /dev/null; then
       echo >&2
@@ -17,7 +17,9 @@ _mycli() {
       echo "See https://usage.jdx.dev for more information." >&2
       return 1
   fi
-read -r -d '' spec <<'__USAGE_EOF__'
+
+  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mycli.spec"
+  cat > "$spec_file" <<'__USAGE_EOF__'
 name mycli
 bin mycli
 source_code_link_template "https://github.com/jdx/mise/blob/main/src/cli/{{path}}.rs"
@@ -53,10 +55,6 @@ cmd plugin {
     }
 }
 __USAGE_EOF__
-
-  local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mycli.spec"
-  # Always update spec file when not cached
-  echo "$spec" > "$spec_file"
   _arguments "*: :(($(command usage complete-word --shell zsh -f "$spec_file" -- "${words[@]}" )))"
   return 0
 }

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh.snap
@@ -19,7 +19,7 @@ _usage_mycli_cache_policy() {
 
 _mycli() {
   typeset -A opt_args
-  local curcontext="$curcontext" spec cache_policy
+  local curcontext="$curcontext" cache_policy
 
   if ! type -p usage &> /dev/null; then
       echo >&2
@@ -28,21 +28,8 @@ _mycli() {
       return 1
   fi
 
-  zstyle -s ":completion:${curcontext}:" cache-policy cache_policy
-  if [[ -z $cache_policy ]]; then
-    zstyle ":completion:${curcontext}:" cache-policy _usage_mycli_cache_policy
-  fi
-
-  if ( [[ -z "${_usage_spec_mycli:-}" ]] || _cache_invalid _usage_spec_mycli ) \
-      && ! _retrieve_cache _usage_spec_mycli;
-  then
-    spec="$(mycli complete --usage)"
-    _store_cache _usage_spec_mycli spec
-  fi
-
   local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mycli.spec"
-  # Always update spec file when not cached
-  echo "$spec" > "$spec_file"
+  mycli complete --usage > "$spec_file"
   _arguments "*: :(($(command usage complete-word --shell zsh -f "$spec_file" -- "${words[@]}" )))"
   return 0
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switch bash/zsh/fish completions to generate `--usage-spec` directly into temp files (with optional cache-key guard) instead of storing in shell variables, simplifying caching and avoiding large-spec issues.
> 
> - **Completions**:
>   - **General**:
>     - Write `--usage-spec` output directly to `TMPDIR` `spec_file` instead of storing in shell variables.
>     - When a `cache_key` is present, only write the file if it does not exist; otherwise always overwrite.
>   - **Zsh**:
>     - Remove `zstyle` cache-policy and in-memory `spec` handling; use `spec_file` + `_arguments` from file.
>   - **Bash**:
>     - Replace in-memory `_usage_spec_*` with direct `usage --usage-spec` (or command) to `spec_file`.
>   - **Fish**:
>     - Replace variable-based spec with piping command output to `spec_file`.
> - **Tests/Assets**:
>   - Update generated completion assets and snapshot expectations to reflect file-based spec writing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c73f77cbfdf067f95257b6df3ca2b94e123fd288. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->