### PR TITLE
feat: add env attribute support for flags

### DIFF
--- a/lib/src/docs/cli/mod.rs
+++ b/lib/src/docs/cli/mod.rs
@@ -35,3 +35,43 @@ static TERA: Lazy<Tera> = Lazy::new(|| {
 
     tera
 });
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use insta::assert_snapshot;
+
+    #[test]
+    fn test_render_help_with_env() {
+        let spec = crate::spec! { r#"
+bin "testcli"
+flag "--color" env="MYCLI_COLOR" help="Enable color output"
+flag "--verbose" env="MYCLI_VERBOSE" help="Verbose output"
+flag "--debug" help="Debug mode"
+        "# }
+        .unwrap();
+
+        assert_snapshot!(render_help(&spec, &spec.cmd, false), @r"
+        Usage: testcli [FLAGS]
+
+        Flags:
+          --color  Enable color output [env: MYCLI_COLOR]
+          --verbose  Verbose output [env: MYCLI_VERBOSE]
+          --debug  Debug mode
+        ");
+
+        assert_snapshot!(render_help(&spec, &spec.cmd, true), @r"
+        Usage: testcli [FLAGS]
+
+        Flags:
+          --color
+            Enable color output
+            [env: MYCLI_COLOR]
+          --verbose
+            Verbose output
+            [env: MYCLI_VERBOSE]
+          --debug
+            Debug mode
+        ");
+    }
+}

--- a/lib/src/docs/cli/templates/spec_template_long.tera
+++ b/lib/src/docs/cli/templates/spec_template_long.tera
@@ -48,5 +48,8 @@ Flags:
 {%- if flag.arg.choices %}
     [possible values: {{ flag.arg.choices.choices | join(sep=", ") }}]
 {%- endif %}
+{%- if flag.env %}
+    [env: {{ flag.env }}]
+{%- endif %}
 {%- endfor %}
 {%- endif -%}

--- a/lib/src/docs/cli/templates/spec_template_short.tera
+++ b/lib/src/docs/cli/templates/spec_template_short.tera
@@ -32,5 +32,6 @@ Flags:
 {%- if flag.aliases %}  [aliases: {{ flag.aliases | join(sep=", ") }}]{% endif %}
 {%- if flag.help %}  {{ flag.help }}{%- endif %}
 {%- if flag.arg.choices %} [{{ flag.arg.choices.choices | join(sep=", ") }}]{%- endif %}
+{%- if flag.env %} [env: {{ flag.env }}]{%- endif %}
 {%- endfor %}
 {%- endif -%}

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -69,6 +69,7 @@ pub struct SpecFlag {
     pub arg: Option<SpecArg>,
     pub default: Option<String>,
     pub negate: Option<String>,
+    pub env: Option<String>,
     pub rendered: bool,
 }
 
@@ -176,6 +177,7 @@ impl From<&crate::SpecFlag> for SpecFlag {
             arg: flag.arg.as_ref().map(SpecArg::from),
             default: flag.default.clone(),
             negate: flag.negate.clone(),
+            env: flag.env.clone(),
             rendered: false,
         }
     }


### PR DESCRIPTION
## Summary
- Added `env` field to `SpecFlag` struct to support environment variable specification
- Updated flag parsing to handle `env` property from KDL specs
- Added `env` to KDL serialization output
- Updated docs models to include `env` field for documentation generation
- Added test case to verify flag env attribute functionality

## Details
Flags can now specify an environment variable similar to how config props work:
```kdl
flag "--color" env="MYCLI_COLOR" help="Enable color output"
```

The env attribute is:
- Parsed and stored in SpecFlag
- Included in KDL serialization
- Exported to docs models for documentation generation  
- Already displayed in markdown templates (template already had support)

## Test plan
- [x] Added unit test `test_flag_with_env` in `lib/src/spec/flag.rs`
- [x] All existing tests pass
- [x] Verified env field is included in docs models

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `env` to flags, parses it from KDL, propagates to docs models, renders in CLI help, and adds tests.
> 
> - **Spec/Parsing**:
>   - Add `env` to `SpecFlag`; parse from `env` prop and child node; include in KDL serialization.
> - **Docs/Models**:
>   - Include `env` in `docs::SpecFlag` and map from core `SpecFlag`.
> - **CLI Help/Templates**:
>   - Render `[env: VAR]` for flags in `spec_template_short.tera` and `spec_template_long.tera`.
>   - Add tests in `docs/cli/mod.rs` verifying short/long help shows env.
> - **Tests**:
>   - Add env parsing/serialization tests in `spec/flag.rs` for prop and child forms.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 331172c6834eefd05e54228e96781e7c28877785. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->