### PR TITLE
fix: add fallback for shell

### DIFF
--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -18,8 +18,8 @@ use crate::cli::generate;
 #[derive(Debug, Args)]
 #[clap(visible_alias = "cw")]
 pub struct CompleteWord {
-    #[clap(long, value_parser = ["bash", "fish", "zsh"])]
-    shell: Option<String>,
+    #[clap(long, default_value = "bash", value_parser = ["bash", "fish", "zsh"])]
+    shell: String,
 
     /// user's input from the command line
     words: Vec<String>,
@@ -41,7 +41,7 @@ impl CompleteWord {
     pub fn run(&self) -> miette::Result<()> {
         let spec = generate::file_or_spec(&self.file, &self.spec)?;
         let choices = self.complete_word(&spec)?;
-        let shell = self.shell.as_deref().unwrap_or_default();
+        let shell = self.shell.as_ref();
         let any_descriptions = choices.iter().any(|(_, d)| !d.is_empty());
         for (c, description) in choices {
             match shell {

--- a/cli/tests/complete_word.rs
+++ b/cli/tests/complete_word.rs
@@ -128,19 +128,23 @@ fn complete_word_fallback_to_files() {
         .stdout(contains("'Cargo.toml'").and(contains("'src'")));
 }
 
-fn cmd(example: &str, shell: &str) -> Command {
+#[test]
+fn complete_word_subcommands_without_shell() {
+    let mut cmd = cmd("basic.usage.kdl", None);
+    cmd.args(["plugins", "install"]);
+    cmd.assert().success().stdout(contains("install"));
+}
+
+fn cmd(example: &str, shell: Option<&str>) -> Command {
     let mut cmd = Command::cargo_bin("usage").unwrap();
-    cmd.args([
-        "cw",
-        "--shell",
-        shell,
-        "-f",
-        &format!("../examples/{example}"),
-        "mycli",
-    ]);
+    cmd.args(["cw"]);
+    if let Some(shell) = shell {
+        cmd.args(["--shell", shell]);
+    }
+    cmd.args(["-f", &format!("../examples/{example}"), "mycli"]);
     cmd
 }
 
 fn assert_cmd(example: &str, args: &[&str]) -> Assert {
-    cmd(example, "zsh").args(args).assert().success()
+    cmd(example, Some("zsh")).args(args).assert().success()
 }


### PR DESCRIPTION
In https://github.com/jdx/usage/pull/341, a "known" shell type was made mandatory for the complete word command. Since `shell` is an optional argument some kind of valid fallback should be supported.

To fix this `shell` is no longer optional and is provided with a default value of "bash". Added a unit test to validate behavior going forward.

> [!NOTE]
> Currently breaking the homebrew test: https://github.com/Homebrew/homebrew-core/pull/250540
> I was unsure if it was better to handle the fallback here or edit the formula to provide a shell value in the test
> In practice I imagine the shell is more of a mandatory field
> I really should've caught this in the initial PR, my bad!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes `--shell` default to `bash` (non-optional) and updates tests to allow running completion without specifying a shell.
> 
> - **CLI**:
>   - `CompleteWord.shell`: change to `String` with `default_value = "bash"` (was `Option<String>`), and adapt access in `run()`.
> - **Tests**:
>   - Add `complete_word_subcommands_without_shell` to validate behavior when `--shell` is omitted.
>   - Update test helpers to accept optional `--shell` and adjust existing calls accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26b72fcca84ecb193ae812edc944d180067d78fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->