### PR TITLE
feat: Print default values if specified

### DIFF
--- a/lib/src/docs/cli/mod.rs
+++ b/lib/src/docs/cli/mod.rs
@@ -82,6 +82,7 @@ bin "testcli"
 arg "<input>" env="MY_INPUT" help="Input file"
 arg "<output>" env="MY_OUTPUT" help="Output file"
 arg "<extra>" help="Extra arg without env"
+arg "[default]" help="Arg with default value" default="default value"
         "# }
         .unwrap();
 
@@ -92,6 +93,7 @@ arg "<extra>" help="Extra arg without env"
           <input>  Input file [env: MY_INPUT]
           <output>  Output file [env: MY_OUTPUT]
           <extra>  Extra arg without env
+          [default]  Arg with default value (default: default value)
         ");
 
         assert_snapshot!(render_help(&spec, &spec.cmd, true), @r"
@@ -106,6 +108,9 @@ arg "<extra>" help="Extra arg without env"
             [env: MY_OUTPUT]
           <extra>
             Extra arg without env
+          [default]
+            Arg with default value
+            (default: default value)
         ");
     }
 }

--- a/lib/src/docs/cli/templates/spec_template_long.tera
+++ b/lib/src/docs/cli/templates/spec_template_long.tera
@@ -35,6 +35,9 @@ Arguments:
 {%- if arg.env %}
     [env: {{ arg.env }}]
 {%- endif %}
+{%- if arg.default %}
+    (default: {{ arg.default }})
+{%- endif %}
 {%- endfor %}
 {%- endif %}
 

--- a/lib/src/docs/cli/templates/spec_template_short.tera
+++ b/lib/src/docs/cli/templates/spec_template_short.tera
@@ -22,6 +22,7 @@ Arguments:
 {%- if arg.help %}  {{ arg.help }}{%- endif %}
 {%- if arg.choices %} [{{ arg.choices.choices | join(sep=", ") }}]{%- endif %}
 {%- if arg.env %} [env: {{ arg.env }}]{%- endif %}
+{%- if arg.default %} (default: {{ arg.default }}){%- endif %}
 {%- endfor %}
 {%- endif %}
 


### PR DESCRIPTION
Uses the same format as Python's ArgumentDefaultsHelpFormatter