### PR TITLE
chore: mise up

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -1,54 +1,62 @@
 [[tools.actionlint]]
-version = "1.7.7"
+version = "1.7.8"
 backend = "aqua:rhysd/actionlint"
 
+[tools.actionlint.platforms.macos-arm64]
+checksum = "sha256:ffb1f6c429a51dc9f37af9d11f96c16bd52f54b713bf7f8bd92f7fce9fd4284a"
+size = 2056182
+url = "https://github.com/rhysd/actionlint/releases/download/v1.7.8/actionlint_1.7.8_darwin_arm64.tar.gz"
+
 [[tools.cargo-binstall]]
-version = "1.12.3"
+version = "1.15.8"
 backend = "aqua:cargo-bins/cargo-binstall"
 
 [tools.cargo-binstall.platforms.macos-arm64]
-checksum = "blake3:8acd3579060891f60e85b65edd30c49769a1eff3554e9ca291b53c7158df9a73"
-size = 5801964
-url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.12.3/cargo-binstall-aarch64-apple-darwin.zip"
+checksum = "sha256:dfebdc40c67e84b756835d6ea13e72c85272e6862af5a8f49aac55107c0ee1c3"
+size = 6015134
+url = "https://github.com/cargo-bins/cargo-binstall/releases/download/v1.15.8/cargo-binstall-aarch64-apple-darwin.zip"
 
 [[tools."cargo:cargo-edit"]]
-version = "0.13.2"
+version = "0.13.7"
 backend = "cargo:cargo-edit"
 
 [[tools."cargo:cargo-insta"]]
-version = "1.43.0"
+version = "1.43.2"
 backend = "cargo:cargo-insta"
 
 [[tools."cargo:cargo-release"]]
-version = "0.25.18"
+version = "0.25.20"
 backend = "cargo:cargo-release"
 
 [[tools."cargo:git-cliff"]]
-version = "2.8.0"
+version = "2.10.1"
 backend = "cargo:git-cliff"
 
 [[tools.gh]]
-version = "2.71.2"
+version = "2.82.1"
 backend = "aqua:cli/cli"
 
 [tools.gh.platforms.macos-arm64]
-checksum = "sha256:95e4d3bf841ef8448f6ac828d89de3d49bd994f063f0d1566becbe1aa8c98a81"
-size = 13235253
-url = "https://github.com/cli/cli/releases/download/v2.71.2/gh_2.71.2_macOS_arm64.zip"
+checksum = "sha256:8cf015d101a5a43bbf662155d47ba6242bd1a1630c814e764254efa86e448ba7"
+size = 17577889
+url = "https://github.com/cli/cli/releases/download/v2.82.1/gh_2.82.1_macOS_arm64.zip"
 
 [[tools."npm:prettier"]]
-version = "3.5.3"
+version = "3.6.2"
 backend = "npm:prettier"
 
 [[tools.pnpm]]
-version = "10.9.0"
+version = "10.19.0"
 backend = "aqua:pnpm/pnpm"
 
 [tools.pnpm.platforms.macos-arm64]
-checksum = "blake3:2234badc351eb2128be8224d9d0a489ab17841317119a9ede0cc59319cddb501"
-size = 64168208
-url = "https://github.com/pnpm/pnpm/releases/download/v10.9.0/pnpm-macos-arm64"
+checksum = "sha256:41fc22ab28eab1031df380e68b37f98a465a39de81b4830c7411be20df0c6f5f"
+size = 62588240
+url = "https://github.com/pnpm/pnpm/releases/download/v10.19.0/pnpm-macos-arm64"
 
 [[tools.shellcheck]]
-version = "0.10.0"
+version = "0.11.0"
 backend = "aqua:koalaman/shellcheck"
+
+[tools.shellcheck.platforms.macos-arm64-shellcheck]
+checksum = "blake3:dda081f041dedece533bf343f83422af6d478742fcb7b09f8875b787f4829f45"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps multiple tool versions and macOS arm64 artifacts in `mise.lock` (actionlint, cargo-* tools, gh, prettier, pnpm, shellcheck).
> 
> - **Dependencies (mise.lock)**:
>   - Version bumps:
>     - `actionlint` → `1.7.8`
>     - `cargo-binstall` → `1.15.8`
>     - `cargo:cargo-edit` → `0.13.7`
>     - `cargo:cargo-insta` → `1.43.2`
>     - `cargo:cargo-release` → `0.25.20`
>     - `cargo:git-cliff` → `2.10.1`
>     - `gh` → `2.82.1`
>     - `npm:prettier` → `3.6.2`
>     - `pnpm` → `10.19.0`
>     - `shellcheck` → `0.11.0`
>   - macOS arm64 artifact metadata updated (checksums/size/url) for: `actionlint`, `cargo-binstall`, `gh`, `pnpm`, `shellcheck`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50da41b7d19a79f41e2abb16fee6da6377f6f218. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->