### PR TITLE
chore: disable homebrew formula

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -91,15 +91,15 @@ jobs:
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
       - run: gh release edit ${{ github.ref_name }} --draft=false
         if: ${{ github.event_name != 'workflow_dispatch' }}
-  bump-homebrew-formula:
-    runs-on: macos-latest
-    needs: [release]
-    timeout-minutes: 10
-    continue-on-error: true
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-    steps:
-      - name: Bump Homebrew formula
-        uses: dawidd6/action-homebrew-bump-formula@3428a0601bba3173ec0bdcc945be23fa27aa4c31 # v5
-        with:
-          token: ${{ secrets.GH_BOT_TOKEN }}
-          formula: usage
+  # bump-homebrew-formula:
+  #   runs-on: macos-latest
+  #   needs: [release]
+  #   timeout-minutes: 10
+  #   continue-on-error: true
+  #   if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+  #   steps:
+  #     - name: Bump Homebrew formula
+  #       uses: dawidd6/action-homebrew-bump-formula@3428a0601bba3173ec0bdcc945be23fa27aa4c31 # v5
+  #       with:
+  #         token: ${{ secrets.GH_BOT_TOKEN }}
+  #         formula: usage


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Comments out the Homebrew formula bump job in the CLI publish GitHub Actions workflow.
> 
> - **CI (GitHub Actions)**:
>   - In `/.github/workflows/publish-cli.yml`, the `bump-homebrew-formula` job is commented out, effectively disabling automatic Homebrew formula updates after release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6166851091e4313b5bce7f7bf33cb2584530c9dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->