### PR TITLE
fix: resolve clippy warnings in test files

### DIFF
--- a/cli/tests/complete_word.rs
+++ b/cli/tests/complete_word.rs
@@ -1,4 +1,5 @@
 use assert_cmd::assert::Assert;
+use assert_cmd::cargo;
 use std::env;
 use std::process::Command;
 
@@ -225,7 +226,7 @@ fn complete_word_mixed_global_flags() {
 #[test]
 fn complete_word_fallback_to_files() {
     // Use a minimal spec with no args or subcommands, so any argument is unknown
-    let mut cmd = Command::cargo_bin("usage").unwrap();
+    let mut cmd = Command::new(cargo::cargo_bin!("usage"));
     cmd.args([
         "cw",
         "--shell",
@@ -252,7 +253,7 @@ fn complete_word_subcommands_without_shell() {
 }
 
 fn cmd(example: &str, shell: Option<&str>) -> Command {
-    let mut cmd = Command::cargo_bin("usage").unwrap();
+    let mut cmd = Command::new(cargo::cargo_bin!("usage"));
     cmd.args(["cw"]);
     if let Some(shell) = shell {
         cmd.args(["--shell", shell]);

--- a/cli/tests/shell_completions_integration.rs
+++ b/cli/tests/shell_completions_integration.rs
@@ -10,8 +10,8 @@ fn build_usage_binary() -> PathBuf {
 
     // Build the usage binary in debug mode
     let output = Command::new("cargo")
-        .args(&["build", "--bin", "usage"])
-        .current_dir(&workspace_root)
+        .args(["build", "--bin", "usage"])
+        .current_dir(workspace_root)
         .output()
         .expect("Failed to build usage binary");
 
@@ -55,11 +55,11 @@ cmd "sub" help="Subcommand" {
 
     // Write spec to a file first (fish completion generator needs a file)
     let spec_kdl_file = temp_dir.join("testcli.kdl");
-    fs::write(&spec_kdl_file, &spec).unwrap();
+    fs::write(&spec_kdl_file, spec).unwrap();
 
     // Generate the completion script using the actual usage binary
     let output = Command::new(&usage_bin)
-        .args(&["generate", "completion", "fish", "testcli"])
+        .args(["generate", "completion", "fish", "testcli"])
         .arg("-f")
         .arg(spec_kdl_file.to_str().unwrap())
         .output()
@@ -205,11 +205,11 @@ cmd "sub" help="Subcommand" {
 
     // Write spec to a file first (bash completion generator needs a file)
     let spec_kdl_file = temp_dir.join("testcli.kdl");
-    fs::write(&spec_kdl_file, &spec).unwrap();
+    fs::write(&spec_kdl_file, spec).unwrap();
 
     // Generate the completion with bash-completion library included
     let output = Command::new(&usage_bin)
-        .args(&["generate", "completion", "bash", "testcli"])
+        .args(["generate", "completion", "bash", "testcli"])
         .arg("-f")
         .arg(spec_kdl_file.to_str().unwrap())
         .arg("--include-bash-completion-lib")
@@ -395,7 +395,7 @@ cmd "sub" help="Subcommand" {
 
     // Write spec to a file first (zsh completion generator needs a file)
     let spec_kdl_file = temp_dir.join("testcli.kdl");
-    fs::write(&spec_kdl_file, &spec).unwrap();
+    fs::write(&spec_kdl_file, spec).unwrap();
 
     // Also write the spec directly to the expected location in usage format
     let usage_spec = r#"name testcli
@@ -411,7 +411,7 @@ cmd sub help=Subcommand {
 
     // Generate the completion
     let output = Command::new(&usage_bin)
-        .args(&["generate", "completion", "zsh", "testcli"])
+        .args(["generate", "completion", "zsh", "testcli"])
         .arg("-f")
         .arg(spec_kdl_file.to_str().unwrap())
         .output()


### PR DESCRIPTION
## Summary

- Remove needless borrows for generic args in `shell_completions_integration.rs`
- Replace deprecated `cargo_bin` usage with `cargo::cargo_bin!` macro in `complete_word.rs`

## Changes

**cli/tests/shell_completions_integration.rs:**
- Fixed 8 instances of needless borrows on `&["..."]` array literals
- Fixed 2 instances of needless borrows on `&spec` and `&workspace_root`

**cli/tests/complete_word.rs:**
- Replaced deprecated `Command::cargo_bin("usage")` with `Command::new(cargo::cargo_bin!("usage"))`
- Added `use assert_cmd::cargo;` import

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] All tests pass via pre-commit hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove needless borrows and replace deprecated cargo_bin usage across CLI test files.
> 
> - **Tests**:
>   - `cli/tests/complete_word.rs`:
>     - Replace `Command::cargo_bin("usage")` with `Command::new(cargo::cargo_bin!("usage"))`.
>     - Add `use assert_cmd::cargo;` and update helper `cmd()` accordingly.
>   - `cli/tests/shell_completions_integration.rs`:
>     - Remove needless borrows in `.args([...])`, `fs::write(...)`, and `.current_dir(...)` calls.
>     - Keep behavior while simplifying argument passing for fish/bash/zsh completion generation and build step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 209e6f60051c0d2a4fe56e87b1fccc10ba2009ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->