### PR TITLE
fix: prevent empty help_rendered from causing inline-empty layout

### DIFF
--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -151,8 +151,11 @@ impl From<&crate::SpecCommand> for SpecCommand {
                 if let Some(help) = help_text {
                     let (rendered, is_multiline) =
                         render_help_text(help, terminal_width, args_usage_col_width);
-                    spec_arg.help_rendered = Some(rendered);
-                    spec_arg.help_is_multiline = is_multiline;
+                    // Only set help_rendered if we have content (empty string signals block layout)
+                    if !rendered.is_empty() {
+                        spec_arg.help_rendered = Some(rendered);
+                        spec_arg.help_is_multiline = is_multiline;
+                    }
                 }
 
                 spec_arg.usage_col_width = args_usage_col_width;
@@ -174,8 +177,11 @@ impl From<&crate::SpecCommand> for SpecCommand {
                 if let Some(help) = help_text {
                     let (rendered, is_multiline) =
                         render_help_text(help, terminal_width, flags_usage_col_width);
-                    spec_flag.help_rendered = Some(rendered);
-                    spec_flag.help_is_multiline = is_multiline;
+                    // Only set help_rendered if we have content (empty string signals block layout)
+                    if !rendered.is_empty() {
+                        spec_flag.help_rendered = Some(rendered);
+                        spec_flag.help_is_multiline = is_multiline;
+                    }
                 }
 
                 spec_flag.usage_col_width = flags_usage_col_width;


### PR DESCRIPTION
## Summary

- Fixed bug where `help_rendered` was set to `Some("")` when `render_help_text` returns an empty string
- This caused the template to use an empty inline layout instead of falling back to block layout
- Now `help_rendered` is only set when the rendered string is non-empty, allowing proper fallback

## Root Cause

When `render_help_text` returns an empty string to signal that block layout should be used (e.g., for help text with newlines or narrow terminals), the code in `lib/src/docs/models.rs:154` and `:177` was setting `help_rendered = Some("")`. The template checks `{% if flag.help_rendered %}`, which evaluates to `true` for `Some("")`, causing it to use the inline-empty layout instead of falling back to the intended block layout.

## Test Plan

- [x] All existing tests pass
- [x] Manually tested with help text containing newlines - now displays correctly in block layout
- [x] Manually tested with narrow terminal width - properly falls back to block layout
- [x] Manually tested with short single-line help - still uses inline layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents empty `help_rendered` from forcing inline layout by only assigning it when the rendered help text is non-empty for both args and flags.
> 
> - **Docs rendering**
>   - In `lib/src/docs/models.rs` within `SpecCommand::from`:
>     - Args: after `render_help_text`, set `help_rendered` and `help_is_multiline` only if the rendered string is non-empty.
>     - Flags: same conditional assignment to avoid empty inline layout and allow block-layout fallback.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8114e3b0f90e92a7860f47ba56fe203b84bbf587. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->