### PR TITLE
fix: treat count flags as repeatable

### DIFF
--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -225,7 +225,7 @@ pub fn parse_partial(spec: &Spec, input: &[String]) -> Result<ParseOutput, miett
             if let Some(f) = out.available_flags.get(word) {
                 if f.arg.is_some() {
                     out.flag_awaiting_value.push(f.clone());
-                } else if f.var {
+                } else if f.count {
                     let arr = out
                         .flags
                         .entry(f.clone())
@@ -256,7 +256,7 @@ pub fn parse_partial(spec: &Spec, input: &[String]) -> Result<ParseOutput, miett
                 }
                 if f.arg.is_some() {
                     out.flag_awaiting_value.push(f.clone());
-                } else if f.var {
+                } else if f.count {
                     let arr = out
                         .flags
                         .entry(f.clone())

--- a/lib/tests/parse.rs
+++ b/lib/tests/parse.rs
@@ -226,6 +226,20 @@ multi_flag:
     args=r#"--vars a --vars "b c""#,
     expected=r#"{"usage_vars": "a 'b c'"}"#,
 
+ count_flag_short:
+    spec=r#"
+    flag "-v --verbose" count=#true
+    "#,
+    args="-vvv",
+    expected=r#"{"usage_verbose": "3"}"#,
+
+ count_flag_mixed:
+    spec=r#"
+    flag "-v --verbose" count=#true
+    "#,
+    args="-v --verbose",
+    expected=r#"{"usage_verbose": "2"}"#,
+
 //shell_escape_arg:
 //    spec=r#"
 //    arg "<vars>" shell_escape=#true


### PR DESCRIPTION
## Summary

The parser ignored `SpecFlag.count` when deciding whether to accumulate repeated boolean flags. As a result, flags documented with `count=#true` were exported as a boolean ("true") instead of a numeric occurrence count. This meant that the examples shown in the documentation did not work.

This change makes the parser treat `count` flags as repeatable instead of `var` so repeated occurrences accumulate and are exported as a numeric string.

## ⚠️  Consequences

This makes the implementation match the documentation of the spec (to the best of my limited experience with usage).

However, it does break existing users code who relied or worked around it and simply declared their flags with `var=#true` which served as a workaround.

## Changes

### Core Implementation
- Changed the check from `var` to `count` for boolean accumulation of flags

### Tests
- Added tests for repeated boolean flags as taken from the documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch boolean repeat handling from `var` to `count` so repeated `-v/--verbose` accumulate and export occurrence count; add tests for count behavior.
> 
> - **Parser**:
>   - Use `f.count` (instead of `f.var`) to accumulate repeated boolean flags into `ParseValue::MultiBool` for both long (`--flag`) and short (`-f`) forms in `lib/src/parse.rs`.
> - **Tests**:
>   - Add count-flag cases validating `-vvv` -> `{"usage_verbose": "3"}` and mixed `-v --verbose` -> `{"usage_verbose": "2"}` in `lib/tests/parse.rs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe74170a0d9e47531a2ebcd9d1dfb59a7c418f65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->