### PR TITLE
feat: Allowing preserving double dashes for variadic args (#229)

### DIFF
--- a/docs/spec/reference/arg.md
+++ b/docs/spec/reference/arg.md
@@ -24,4 +24,5 @@ arg "<file>" long_help="longer help for --help (as oppoosed to -h)"
 arg "<file>" double_dash="required" # arg must be passed after a double dash (e.g. mycli -- file.txt)
 arg "<file>" double_dash="optional" # arg may be passed after a double dash (e.g. mycli -- file.txt or mycli file.txt)
 arg "<file>..." double_dash="automatic" # once arg is passed, behave as if a double dash was passed (e.g. mycli file.txt --filewithdash)
+arg "<args>..." double_dash="preserve" # preserve double dashes as args (e.g. mycli arg1 -- arg2 -- arg3)
 ```

--- a/lib/src/spec/arg.rs
+++ b/lib/src/spec/arg.rs
@@ -21,6 +21,8 @@ pub enum SpecDoubleDashChoices {
     Optional,
     /// Require "--" to be passed
     Required,
+    /// Preserve "--" tokens as values (only for variadic args)
+    Preserve,
 }
 
 #[derive(Debug, Default, Clone, Serialize)]
@@ -144,7 +146,9 @@ impl From<&SpecArg> for KdlNode {
         if !arg.required {
             node.push(KdlEntry::new_prop("required", false));
         }
-        if arg.double_dash == SpecDoubleDashChoices::Automatic {
+        if arg.double_dash == SpecDoubleDashChoices::Automatic
+            || arg.double_dash == SpecDoubleDashChoices::Preserve
+        {
             node.push(KdlEntry::new_prop(
                 "double_dash",
                 arg.double_dash.to_string(),

--- a/lib/src/spec/builder.rs
+++ b/lib/src/spec/builder.rs
@@ -30,7 +30,7 @@
 //!     .build();
 //! ```
 
-use crate::{SpecArg, SpecCommand, SpecFlag};
+use crate::{spec::arg::SpecDoubleDashChoices, SpecArg, SpecCommand, SpecFlag};
 
 /// Builder for SpecFlag
 #[derive(Debug, Default, Clone)]
@@ -290,6 +290,12 @@ impl SpecArgBuilder {
     /// Set environment variable name
     pub fn env(mut self, env: impl Into<String>) -> Self {
         self.inner.env = Some(env.into());
+        self
+    }
+
+    /// Set the double-dash behavior
+    pub fn double_dash(mut self, behavior: SpecDoubleDashChoices) -> Self {
+        self.inner.double_dash = behavior;
         self
     }
 


### PR DESCRIPTION
Previously, all double dash tokens were discarded when parsed.

A new `preserve` option has been added to the `double_dash` setting for arguments. When set to `preserve` on a variadic argument, any double dash tokens (`--`) encountered while parsing will be retained as part of the argument's value.

Just like for non-preserve behavior, `enable_flags` processing is disabled for preserve behavior as well. That's because any potential common flags like `--verbose` should be captured inside the variadic arg, rather than being treated as flags.

Added tests to verify the new behavior.

Fixes #229

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a new `double_dash` behavior to retain `--` tokens in variadic args and updates parsing, spec, and docs accordingly.
> 
> - Adds `SpecDoubleDashChoices::Preserve` and serializes `double_dash` when `automatic` or `preserve`
> - Parser: `--` always disables flag parsing; when next arg is variadic with `double_dash=preserve`, the `--` token is kept as an arg value
> - Builder: `SpecArgBuilder::double_dash(...)` to set behavior programmatically
> - Docs: updates `arg.md` with `double_dash="preserve"` example
> - Tests: new cases covering preserved/skipped `--`, multiple args, and edge cases
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1ac35b1b552bdada28d6c08ce029d92ca2ae139. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->