### PR TITLE
fix: replace unsafe path unwrap chains with proper error handling

### DIFF
--- a/cli/src/cli/exec.rs
+++ b/cli/src/cli/exec.rs
@@ -38,7 +38,11 @@ impl Exec {
             .parent()
             .map(|p| p.to_path_buf())
             .unwrap_or_default();
-        let bin_name = self.bin.file_name().unwrap().to_str().unwrap();
+        let bin_name = self
+            .bin
+            .file_name()
+            .and_then(|n| n.to_str())
+            .ok_or_else(|| miette::miette!("Invalid file path: {}", self.bin.display()))?;
         let dotted_spec_path = parent.join(format!(".{bin_name}.usage.kdl"));
         let spec = if dotted_spec_path.exists() {
             let (spec, _) = Spec::parse_file(&dotted_spec_path)?;
@@ -64,10 +68,11 @@ impl Exec {
         cmd.stdin(Stdio::inherit());
         cmd.stdout(Stdio::inherit());
         cmd.stderr(Stdio::inherit());
-        // TODO: set positional args
-
-        let args = vec![self.bin.to_str().unwrap().to_string()];
-        cmd.args(&args);
+        let bin_path = self
+            .bin
+            .to_str()
+            .ok_or_else(|| miette::miette!("Invalid file path: {}", self.bin.display()))?;
+        cmd.arg(bin_path);
 
         for (key, val) in &parsed.as_env() {
             cmd.env(key, val);

--- a/cli/src/cli/shell.rs
+++ b/cli/src/cli/shell.rs
@@ -51,10 +51,11 @@ impl Shell {
         cmd.stdin(Stdio::inherit());
         cmd.stdout(Stdio::inherit());
         cmd.stderr(Stdio::inherit());
-        // TODO: set positional args
-
-        let args = vec![self.script.to_str().unwrap().to_string()]
-            .into_iter()
+        let script_path = self
+            .script
+            .to_str()
+            .ok_or_else(|| miette::miette!("Invalid file path: {}", self.script.display()))?;
+        let args = std::iter::once(script_path.to_string())
             .chain(self.args.clone())
             .collect_vec();
         cmd.args(&args);

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -74,6 +74,9 @@ pub enum UsageErr {
         max: usize,
         got: usize,
     },
+
+    #[error("Invalid file path: {0}")]
+    InvalidPath(String),
 }
 pub type Result<T> = std::result::Result<T, UsageErr>;
 

--- a/lib/src/spec/mod.rs
+++ b/lib/src/spec/mod.rs
@@ -66,7 +66,11 @@ impl Spec {
         let ctx = ParsingContext::new(file, &spec);
         let mut schema = Self::parse(&ctx, &spec)?;
         if schema.bin.is_empty() {
-            schema.bin = file.file_name().unwrap().to_str().unwrap().to_string();
+            schema.bin = file
+                .file_name()
+                .and_then(|n| n.to_str())
+                .ok_or_else(|| UsageErr::InvalidPath(file.display().to_string()))?
+                .to_string();
         }
         if schema.name.is_empty() {
             schema.name.clone_from(&schema.bin);
@@ -78,7 +82,11 @@ impl Spec {
         let ctx = ParsingContext::new(file, &raw);
         let mut spec = Self::parse(&ctx, &raw)?;
         if spec.bin.is_empty() {
-            spec.bin = file.file_name().unwrap().to_str().unwrap().to_string();
+            spec.bin = file
+                .file_name()
+                .and_then(|n| n.to_str())
+                .ok_or_else(|| UsageErr::InvalidPath(file.display().to_string()))?
+                .to_string();
         }
         if spec.name.is_empty() {
             spec.name.clone_from(&spec.bin);


### PR DESCRIPTION
## Summary

- Replace `.file_name().unwrap().to_str().unwrap()` patterns with proper error handling
- Add `UsageErr::InvalidPath` error variant for invalid file paths
- Return meaningful errors instead of panicking on non-UTF8 paths or paths without a name component

## Changes

- `lib/src/error.rs`: Added `InvalidPath` error variant
- `lib/src/spec/mod.rs`: `parse_file` and `parse_script` now return errors on invalid paths
- `cli/src/cli/exec.rs`: Uses miette errors for invalid paths
- `cli/src/cli/shell.rs`: Uses miette errors for invalid paths

## Test plan

- [x] All existing tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves robustness by eliminating panic-prone path handling and surfacing actionable errors.
> 
> - **lib/error.rs**: Add `UsageErr::InvalidPath` for reporting invalid/non-UTF8 paths
> - **lib/spec/mod.rs**: `parse_file`/`parse_script` now derive `bin` from `file_name()` with error handling; return `InvalidPath` on failure
> - **cli/exec.rs**: Validate `bin` path and name; pass validated path to spawned command; return miette errors instead of panicking
> - **cli/shell.rs**: Validate `script` path; build args with the validated path; return miette errors instead of panicking
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d096884e1c040ade3afe3412da32bfbe9e9326bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->