### PR TITLE
fix: replace unimplemented!() with proper errors for unsupported shells

### DIFF
--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -67,7 +67,7 @@ impl CompleteWord {
                         println!("'{c}'")
                     }
                 }
-                _ => unimplemented!("unsupported shell: {}", shell),
+                _ => miette::bail!("unsupported shell: {}", shell),
             }
         }
 

--- a/cli/src/cli/generate/completion.rs
+++ b/cli/src/cli/generate/completion.rs
@@ -63,7 +63,7 @@ impl Completion {
             source_file: self.file.as_ref().map(|f| f.to_string_lossy().to_string()),
         };
 
-        println!("{}", usage::complete::complete(&opts).trim());
+        println!("{}", usage::complete::complete(&opts)?.trim());
         Ok(())
     }
 }

--- a/cli/src/usage_spec.rs
+++ b/cli/src/usage_spec.rs
@@ -15,7 +15,7 @@ pub(crate) fn complete(shell: &str) -> Result<()> {
         "bash" => print!("{}", include_str!("../assets/completions/usage.bash")),
         "fish" => print!("{}", include_str!("../assets/completions/usage.fish")),
         "zsh" => print!("{}", include_str!("../assets/completions/_usage")),
-        _ => unimplemented!("unsupported shell: {}", shell),
+        _ => miette::bail!("unsupported shell: {}", shell),
     };
 
     Ok(())

--- a/lib/src/complete/mod.rs
+++ b/lib/src/complete/mod.rs
@@ -1,3 +1,4 @@
+use crate::error::UsageErr;
 use crate::Spec;
 
 mod bash;
@@ -15,11 +16,11 @@ pub struct CompleteOptions {
     pub source_file: Option<String>,
 }
 
-pub fn complete(options: &CompleteOptions) -> String {
+pub fn complete(options: &CompleteOptions) -> Result<String, UsageErr> {
     match options.shell.as_str() {
-        "bash" => bash::complete_bash(options),
-        "fish" => fish::complete_fish(options),
-        "zsh" => zsh::complete_zsh(options),
-        _ => unimplemented!("unsupported shell: {}", options.shell),
+        "bash" => Ok(bash::complete_bash(options)),
+        "fish" => Ok(fish::complete_fish(options)),
+        "zsh" => Ok(zsh::complete_zsh(options)),
+        _ => Err(UsageErr::UnsupportedShell(options.shell.clone())),
     }
 }

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -77,6 +77,9 @@ pub enum UsageErr {
 
     #[error("Invalid file path: {0}")]
     InvalidPath(String),
+
+    #[error("Unsupported shell: {0}")]
+    UnsupportedShell(String),
 }
 pub type Result<T> = std::result::Result<T, UsageErr>;
 


### PR DESCRIPTION
## Summary
- Adds `UnsupportedShell` error variant to `UsageErr`
- Changes `complete()` to return `Result<String, UsageErr>` instead of `String`
- Replaces `unimplemented!()` with `miette::bail!()` in CLI code

This provides better error messages instead of panicking when an unsupported shell is passed.

**Note:** In practice these error cases won't trigger because shell values are constrained by clap's `value_parser`, but proper error handling is better than panicking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves error handling for shell completion and avoids panics.
> 
> - Adds `UnsupportedShell` to `UsageErr` and updates `lib::complete::complete` to return `Result<String, UsageErr>`, returning `Err(UnsupportedShell)` for unknown shells
> - Updates CLI code to propagate errors: `cli generate completion` now uses `usage::complete::complete(&opts)?`, and `complete_word`/`usage_spec::complete` replace `unimplemented!()` with `miette::bail!()`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4dbd9768d82d3879cb5a1ee4b9bad67fe47ba422. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->