### PR TITLE
chore: fix legacy inline snapshot format warnings

### DIFF
--- a/lib/src/docs/markdown/arg.rs
+++ b/lib/src/docs/markdown/arg.rs
@@ -22,6 +22,9 @@ mod tests {
     fn test_render_markdown_arg() {
         let spec = spec! { r#"arg "arg1" help="arg1 description""# }.unwrap();
         let ctx = MarkdownRenderer::new(spec.clone());
-        assert_snapshot!(ctx.render_arg(&spec.cmd.args[0]).unwrap(), @"arg1 description");
+        assert_snapshot!(ctx.render_arg(&spec.cmd.args[0]).unwrap(), @r"
+
+
+arg1 description");
     }
 }

--- a/lib/src/docs/markdown/flag.rs
+++ b/lib/src/docs/markdown/flag.rs
@@ -22,6 +22,9 @@ mod tests {
     fn test_render_markdown_flag() {
         let spec = spec! { r#"flag "--flag1" help="flag1 description""# }.unwrap();
         let ctx = MarkdownRenderer::new(spec.clone()).with_replace_pre_with_code_fences(true);
-        assert_snapshot!(ctx.render_flag(&spec.cmd.flags[0]).unwrap(), @"flag1 description");
+        assert_snapshot!(ctx.render_flag(&spec.cmd.flags[0]).unwrap(), @r"
+
+
+flag1 description");
     }
 }


### PR DESCRIPTION
## Summary
- Updates inline snapshots in markdown arg/flag tests to use raw string literals
- Includes actual output (with leading newlines) in the snapshot value

This resolves the "existing value is in a legacy format" warnings that appeared during test runs for the `render_markdown_arg` and `render_markdown_flag` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates inline snapshots in tests to the new format.
> 
> - `arg.rs` and `flag.rs` tests now use `@r` raw string snapshots and include leading newlines to match actual output
> - No production code changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05cc885d01046221f3398f787f87e5a0c9161787. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->