### PR TITLE
chore: replace TODO with doc comment for subcommand_lookup

### DIFF
--- a/lib/src/spec/cmd.rs
+++ b/lib/src/spec/cmd.rs
@@ -56,7 +56,7 @@ pub struct SpecCommand {
     #[serde(skip_serializing_if = "IndexMap::is_empty")]
     pub complete: IndexMap<String, SpecComplete>,
 
-    // TODO: make this non-public
+    /// Cache for subcommand name lookups (including aliases)
     #[serde(skip)]
     subcommand_lookup: OnceLock<HashMap<String, String>>,
 }


### PR DESCRIPTION
## Summary
- Removes outdated TODO comment about making `subcommand_lookup` non-public
- The field was already private (no `pub` keyword)
- Adds proper doc comment explaining the field's purpose as a cache for subcommand name lookups

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies intent of the subcommand cache without changing behavior.
> 
> - Replaces TODO with a doc comment for `subcommand_lookup` (cache for subcommand name lookups including aliases) in `lib/src/spec/cmd.rs`
> - No functional changes; serialization remains skipped for this field
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59636b011eb19943924188fa8c39448c0982a2e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->