### PR TITLE
fix: use correct PowerShell casing in enum variant

### DIFF
--- a/cli/src/cli/mod.rs
+++ b/cli/src/cli/mod.rs
@@ -32,8 +32,8 @@ enum Command {
     Fish(shell::Shell),
     Generate(generate::Generate),
     Lint(lint::Lint),
-    #[clap(about = "Execute a shell script using PowerShell")]
-    Powershell(shell::Shell),
+    #[clap(name = "powershell", about = "Execute a shell script using PowerShell")]
+    PowerShell(shell::Shell),
     #[clap(about = "Execute a shell script using zsh")]
     Zsh(shell::Shell),
 }
@@ -47,7 +47,7 @@ impl Cli {
         match cli.command {
             Command::Bash(mut cmd) => cmd.run("bash"),
             Command::Fish(mut cmd) => cmd.run("fish"),
-            Command::Powershell(mut cmd) => cmd.run("pwsh"),
+            Command::PowerShell(mut cmd) => cmd.run("pwsh"),
             Command::Zsh(mut cmd) => cmd.run("zsh"),
             Command::Generate(cmd) => cmd.run(),
             Command::Exec(mut cmd) => cmd.run(),


### PR DESCRIPTION
## Summary
- Use proper CamelCase `PowerShell` for the Rust enum variant (matching Microsoft's official branding)
- Add `#[clap(name = "powershell")]` to preserve the lowercase command name for CLI usage

## Test plan
- [x] Tests pass
- [x] Generated docs correctly use `powershell.md` (not `power-shell.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures correct PowerShell branding in the CLI while keeping the user-facing subcommand stable.
> 
> - Rename enum variant from `Powershell` to `PowerShell` in `cli/src/cli/mod.rs`
> - Add `#[clap(name = "powershell")]` to preserve the lowercase CLI subcommand name
> - Update the `match` arm to use `Command::PowerShell` when executing `pwsh`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cef822ec8e818b3a567cfe9d1bc445563b649c57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->