### PR TITLE
fix: use pithy LLM-generated title for GitHub releases

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -35,18 +35,27 @@ jobs:
         run: |
           TAG_NAME="${{ github.ref_name }}"
           PREV_TAG="$(git describe --tags --abbrev=0 "$TAG_NAME^" 2>/dev/null || echo "")"
+          RELEASE_TITLE="$TAG_NAME"
           # Generate rich release notes using LLM
           if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
-            ./scripts/gen-release-notes.sh "$TAG_NAME" "$PREV_TAG" >/tmp/release-notes.txt || {
+            if ./scripts/gen-release-notes.sh "$TAG_NAME" "$PREV_TAG" >/tmp/release-notes-full.txt; then
+              # First line is pithy title, rest is body
+              PITHY_TITLE="$(head -n1 /tmp/release-notes-full.txt)"
+              # Only concatenate if we got a real title (not just the version fallback)
+              if [[ -n "$PITHY_TITLE" && "$PITHY_TITLE" != "$TAG_NAME" ]]; then
+                RELEASE_TITLE="$TAG_NAME: $PITHY_TITLE"
+              fi
+              tail -n +2 /tmp/release-notes-full.txt >/tmp/release-notes.txt
+            else
               echo "LLM generation failed, falling back to CHANGELOG.md"
               awk '/^## \[/{if(found) exit; found=1} found{print}' CHANGELOG.md >/tmp/release-notes.txt
-            }
+            fi
           else
             echo "ANTHROPIC_API_KEY not set, using CHANGELOG.md"
             awk '/^## \[/{if(found) exit; found=1} found{print}' CHANGELOG.md >/tmp/release-notes.txt
           fi
           gh release create --draft ${{ github.ref_name }} \
-            --title "${{ github.ref_name }}" \
+            --title "$RELEASE_TITLE" \
             --notes-file /tmp/release-notes.txt
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/scripts/gen-release-notes.sh
+++ b/scripts/gen-release-notes.sh
@@ -35,16 +35,20 @@ prompt=$(
 	printf '%s\n' "$changelog"
 	printf '\n'
 	cat <<'INSTRUCTIONS'
-Write user-friendly release notes:
+Write user-friendly release notes in markdown:
 
-1. Start with 1-2 paragraphs summarizing key changes
-2. Organize into ### sections (Highlights, Bug Fixes, etc.)
-3. Explain WHY changes matter to users
-4. Include PR links and documentation links (https://usage.jdx.dev/)
-5. Include contributor usernames (@username)
-6. Skip internal changes
+1. First line: `# ` followed by a pithy, descriptive title (not just the version). Examples:
+   - "# PowerShell Support & Bug Fixes"
+   - "# Performance Improvements"
+   - "# New Completion Features"
+2. Then 1-2 paragraphs summarizing key changes
+3. Organize into ## sections (Highlights, Bug Fixes, etc.) as needed
+4. Explain WHY changes matter to users
+5. Include PR links and documentation links (https://usage.jdx.dev/)
+6. Include contributor usernames (@username)
+7. Skip internal/trivial changes
 
-Output ONLY the release notes, no preamble.
+Output markdown only, starting with the # title line.
 INSTRUCTIONS
 )
 
@@ -77,4 +81,17 @@ if [[ -z $output ]]; then
 	exit 1
 fi
 
-echo "$output"
+# Parse title from first line (# Title) and body from rest
+first_line=$(echo "$output" | head -n1)
+if [[ $first_line == "# "* ]]; then
+	title="${first_line#\# }"
+	body=$(echo "$output" | tail -n +2)
+else
+	echo "Warning: First line not a title, using version" >&2
+	title="$version"
+	body="$output"
+fi
+
+# Output format: first line is title, rest is body
+echo "$title"
+echo "$body"


### PR DESCRIPTION
## Summary
- Updated prompt to ask Claude for a `# Title` on the first line
- Parse title and combine with version: `v1.2.3: Pithy Description`
- Body becomes release notes without duplicate heading

Example release title: `v2.13.2: PowerShell Casing Fix`

## Test plan
- [x] Script parses `# Title` from first line
- [x] Falls back to version if parsing fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves GitHub release creation to use an LLM-generated pithy title and clean body, with safe fallbacks.
> 
> - Workflow now runs `scripts/gen-release-notes.sh` to produce a first-line title and body; sets `RELEASE_TITLE` to ``<tag>: <pithy title>`` when available, else falls back to the tag
> - Passes `--title "$RELEASE_TITLE"` to `gh release create`; release notes body is everything after the first line from the script
> - `gen-release-notes.sh` prompt updated to require markdown starting with a `#` title, then parses the first line as the title and the rest as the body; falls back to the version if parsing fails
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 777f843ee073e3d18a10f4724c03413e17c0a187. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->