### PR TITLE
feat: add VT323 retro terminal font and --usage branding

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -16,7 +16,7 @@ const commands = getCommands(spec.cmd);
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
-  title: "Usage",
+  title: "--usage",
   description: "Schema for CLIs",
   appearance: "force-dark",
   lastUpdated: true,

--- a/docs/.vitepress/theme/UsageHero.vue
+++ b/docs/.vitepress/theme/UsageHero.vue
@@ -15,7 +15,7 @@
       <!-- Left Column: Text -->
       <div class="usage-hero-text">
         <!-- Title -->
-        <h1 class="usage-hero-title">Usage</h1>
+        <h1 class="usage-hero-title">--usage</h1>
 
         <!-- Tagline -->
         <p class="usage-hero-tagline">A specification for CLIs</p>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,4 +1,12 @@
 /* Usage Docs Custom Theme */
+@import url('https://fonts.googleapis.com/css2?family=VT323&display=swap');
+
+/* Navbar Title */
+.VPNavBarTitle .title {
+  font-family: 'VT323', monospace;
+  font-size: 1.5rem;
+  color: var(--usage-green) !important;
+}
 
 /* Color Palette - based on logo green */
 :root {
@@ -123,15 +131,15 @@
 
 /* Title */
 .usage-hero-title {
-  font-size: 4rem;
-  font-weight: 700;
+  font-family: 'VT323', monospace;
+  font-size: 5.5rem;
+  font-weight: 400;
   margin: 0 0 0.5rem;
   padding: 0.2em 0;
-  background: linear-gradient(135deg, var(--usage-green-light), var(--usage-green));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-  line-height: 1.2;
+  color: var(--usage-green);
+  line-height: 1;
+  letter-spacing: 0.02em;
+  text-shadow: 0 0 30px var(--usage-green-glow);
 }
 
 /* Tagline */
@@ -317,7 +325,7 @@
   }
 
   .usage-hero-title {
-    font-size: 2.5rem;
+    font-size: 3.5rem;
   }
 
   .usage-hero-tagline {


### PR DESCRIPTION
## Summary
- Add VT323 font (retro terminal style) for hero title and navbar
- Style title as "--usage" (CLI flag style) for consistent branding
- Add green glow text effect to hero title
- Update navbar title to use VT323 with green color

## Preview
The hero and navbar now display "--usage" in the VT323 retro terminal font with a green glow effect, giving the site a CLI-authentic feel.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a CLI-themed visual refresh across the docs.
> 
> - Rename site and hero titles to `--usage` in `config.mts` and `UsageHero.vue`
> - Import VT323 font and style navbar title with VT323 and `--usage` green
> - Restyle hero title: VT323 font, larger size, solid green color, glow text-shadow; tweak responsive sizing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5756c7c67b348ebbf70373d41d3c8570a717e786. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->