### PR TITLE
cleanup: remove commented-out trait implementations in mount.rs

### DIFF
--- a/lib/src/spec/mount.rs
+++ b/lib/src/spec/mount.rs
@@ -54,14 +54,3 @@ impl Display for SpecMount {
         write!(f, "{}", self.usage())
     }
 }
-// impl PartialEq for SpecMount {
-//     fn eq(&self, other: &Self) -> bool {
-//         self.run == other.run
-//     }
-// }
-// impl Eq for SpecMount {}
-// impl Hash for SpecMount {
-//     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-//         self.run.hash(state);
-//     }
-// }


### PR DESCRIPTION
## Summary
Remove dead commented-out code for `PartialEq`, `Eq`, and `Hash` trait implementations in `SpecMount`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Cleans up dead commented-out code.
> 
> - Removes commented-out `PartialEq`, `Eq`, and `Hash` impls for `SpecMount` in `lib/src/spec/mount.rs`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a45691bc2d7310866f5e9bb25ad6781c568de6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->