### PR TITLE
feat(lint): add more lint checks

### DIFF
--- a/cli/src/cli/lint.rs
+++ b/cli/src/cli/lint.rs
@@ -277,10 +277,7 @@ fn lint_command(cmd: &SpecCommand, path: &[&str], issues: &mut Vec<LintIssue>) {
             issues.push(LintIssue {
                 severity: Severity::Warning,
                 code: "variadic-arg-not-last".to_string(),
-                message: format!(
-                    "Variadic argument '{}' is not the last argument",
-                    arg.name
-                ),
+                message: format!("Variadic argument '{}' is not the last argument", arg.name),
                 location: Some(format!("cmd {}", cmd_path)),
             });
         }


### PR DESCRIPTION
## Summary
Adds new lint checks and improves error messages:

### New checks:
| Code | Severity | Description |
|------|----------|-------------|
| `subcommand-required-no-subcommands` | error | Command has `subcommand_required=true` but no subcommands defined |
| `variadic-arg-not-last` | warning | Variadic argument is not the last argument |
| `count-flag-with-arg` | error | Count flag also has an argument (conflicting semantics) |

### Improvements:
- `invalid-default-subcommand` error now shows the list of valid subcommands

### Example output:
```
error [invalid-default-subcommand]: default_subcommand 'nonexistent' does not exist (valid subcommands: install, update)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds additional validation and clearer errors in CLI spec linting.
> 
> - New checks:
>   - `subcommand-required-no-subcommands` (error): `subcommand_required=true` but no subcommands
>   - `variadic-arg-not-last` (warning): variadic arg appears before the last position
>   - `count-flag-with-arg` (error): count flag also has an argument
> - Improves `invalid-default-subcommand` to include valid subcommands in the message
> - Extends test coverage for all new behaviors
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab08e6e26ee4a8b67bd3bc584e3eea1ad902253e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->