### PR TITLE
test: add test coverage for untested modules

### DIFF
--- a/lib/src/spec/context.rs
+++ b/lib/src/spec/context.rs
@@ -21,3 +21,37 @@ impl ParsingContext {
         UsageErr::InvalidInput(msg, span, source)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let ctx = ParsingContext::new(Path::new("/path/to/file.kdl"), "name \"test\"");
+        assert_eq!(ctx.file, PathBuf::from("/path/to/file.kdl"));
+        assert_eq!(ctx.spec, "name \"test\"");
+    }
+
+    #[test]
+    fn test_default() {
+        let ctx = ParsingContext::default();
+        assert_eq!(ctx.file, PathBuf::new());
+        assert_eq!(ctx.spec, "");
+    }
+
+    #[test]
+    fn test_build_err() {
+        let ctx = ParsingContext::new(Path::new("test.kdl"), "invalid content");
+        let span: SourceSpan = (0, 7).into();
+        let err = ctx.build_err("test error".to_string(), span);
+        match err {
+            UsageErr::InvalidInput(msg, err_span, _) => {
+                assert_eq!(msg, "test error");
+                assert_eq!(err_span.offset(), 0);
+                assert_eq!(err_span.len(), 7);
+            }
+            _ => panic!("Expected InvalidInput error"),
+        }
+    }
+}

--- a/lib/src/string.rs
+++ b/lib/src/string.rs
@@ -3,3 +3,33 @@ pub use std::string::*;
 pub(crate) fn first_line(s: &str) -> String {
     s.lines().next().unwrap_or_default().to_string()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_first_line_single_line() {
+        assert_eq!(first_line("hello world"), "hello world");
+    }
+
+    #[test]
+    fn test_first_line_multiple_lines() {
+        assert_eq!(first_line("first\nsecond\nthird"), "first");
+    }
+
+    #[test]
+    fn test_first_line_empty() {
+        assert_eq!(first_line(""), "");
+    }
+
+    #[test]
+    fn test_first_line_only_newline() {
+        assert_eq!(first_line("\n"), "");
+    }
+
+    #[test]
+    fn test_first_line_crlf() {
+        assert_eq!(first_line("first\r\nsecond"), "first");
+    }
+}


### PR DESCRIPTION
## Summary

- Add unit tests for `string.rs` (first_line function)
- Add unit tests for `context.rs` (ParsingContext creation and error building)
- Add unit tests for `helpers.rs` (NodeHelper and ParseEntry KDL parsing)

These modules were previously untested. This PR adds 22 new tests covering:
- String utility functions
- Parsing context creation and error generation
- KDL node parsing helpers including argument access, property access, child nodes, and type-safe value extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands test coverage for previously untested modules to validate parsing and utility behaviors.
> 
> - `lib/src/spec/context.rs`: tests `ParsingContext::new`, `Default`, and `build_err` error construction with `SourceSpan`
> - `lib/src/spec/helpers.rs`: tests `NodeHelper` (`name`, `arg`, `args`, `props`, `get`, `children`, `ensure_arg_len`) and `ParseEntry` type checks (`ensure_usize`, `ensure_bool`, `ensure_string`) including mismatch errors
> - `lib/src/string.rs`: tests `first_line` across single-line, multi-line, empty, newline-only, and CRLF inputs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4a5f73c1e5f5bdf318e7d13a4631cf50a4e1693. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->