### PR TITLE
perf: remove unnecessary clone in set_subcommand_ancestors

### DIFF
--- a/lib/src/spec/mod.rs
+++ b/lib/src/spec/mod.rs
@@ -309,14 +309,14 @@ fn extract_usage_from_comments(full: &str) -> String {
 }
 
 fn set_subcommand_ancestors(cmd: &mut SpecCommand, ancestors: &[String]) {
-    let ancestors = ancestors.to_vec();
     for subcmd in cmd.subcommands.values_mut() {
         subcmd.full_cmd = ancestors
-            .clone()
-            .into_iter()
+            .iter()
+            .cloned()
             .chain(once(subcmd.name.clone()))
             .collect();
-        set_subcommand_ancestors(subcmd, &subcmd.full_cmd.clone());
+        let child_ancestors = subcmd.full_cmd.clone();
+        set_subcommand_ancestors(subcmd, &child_ancestors);
     }
     if cmd.usage.is_empty() {
         cmd.usage = cmd.usage();


### PR DESCRIPTION
## Summary

- Remove unnecessary `ancestors.to_vec()` allocation at the start of recursion
- Replace `ancestors.clone().into_iter()` with `ancestors.iter().cloned()` to avoid intermediate Vec allocation

## Before

Each recursion level:
1. `ancestors.to_vec()` - O(n) allocation to convert slice to Vec
2. For each subcommand: `ancestors.clone().into_iter()` - O(n) allocation to clone the Vec

## After

Each recursion level:
1. No upfront allocation
2. For each subcommand: `ancestors.iter().cloned()` - lazy iteration, cloning elements only as needed

This eliminates two Vec allocations per recursion level, which adds up for deeply nested subcommand structures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Optimizes recursive construction of `full_cmd` for subcommands to reduce allocations.
> 
> - Replace `ancestors.clone().into_iter()` with `ancestors.iter().cloned()` when building `full_cmd`
> - Remove upfront `ancestors.to_vec()` allocation
> - Pass `child_ancestors` (a local clone of `full_cmd`) into recursive calls instead of cloning inline
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3a4c9dbe6b2a049c13af19aec213b31a6dcf522. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->