### PR TITLE
docs: add rustdoc for public API functions

### DIFF
--- a/lib/src/complete/mod.rs
+++ b/lib/src/complete/mod.rs
@@ -6,17 +6,39 @@ mod fish;
 mod powershell;
 mod zsh;
 
+/// Options for generating shell completion scripts.
 pub struct CompleteOptions {
+    /// Path to the `usage` binary (e.g., "usage" or "/usr/local/bin/usage").
     pub usage_bin: String,
+    /// Target shell: "bash", "fish", "zsh", or "powershell".
     pub shell: String,
+    /// Name of the CLI binary to generate completions for.
     pub bin: String,
+    /// Optional cache key (e.g., version) to avoid regenerating the spec file.
     pub cache_key: Option<String>,
+    /// The usage spec to embed directly in the completion script.
     pub spec: Option<Spec>,
+    /// Command to run to generate the usage spec dynamically.
     pub usage_cmd: Option<String>,
+    /// Whether to include the bash-completion library sourcing (bash only).
     pub include_bash_completion_lib: bool,
+    /// Source file path for the `@generated` comment.
     pub source_file: Option<String>,
 }
 
+/// Generates a shell completion script for the specified shell.
+///
+/// # Arguments
+/// * `options` - Configuration options including target shell and spec source
+///
+/// # Returns
+/// The generated completion script as a string, or an error if the shell is unsupported.
+///
+/// # Supported Shells
+/// - `bash` - Bash completion using `complete` builtin
+/// - `fish` - Fish shell completions
+/// - `zsh` - Zsh completion using `compdef`
+/// - `powershell` - PowerShell completion using `Register-ArgumentCompleter`
 pub fn complete(options: &CompleteOptions) -> Result<String, UsageErr> {
     match options.shell.as_str() {
         "bash" => Ok(bash::complete_bash(options)),

--- a/lib/src/spec/mod.rs
+++ b/lib/src/spec/mod.rs
@@ -61,7 +61,13 @@ pub struct Spec {
 }
 
 impl Spec {
-    /// Parse a spec from a file (either a .usage.kdl file or a script with embedded spec).
+    /// Parse a spec from a file.
+    ///
+    /// Automatically detects whether the file is:
+    /// - A `.kdl` or `.usage.kdl` file containing a raw spec
+    /// - A script file with embedded `# USAGE:` comments
+    ///
+    /// If `bin` is not specified in the spec, it defaults to the filename.
     #[must_use = "parsing result should be used"]
     pub fn parse_file(file: &Path) -> Result<Spec, UsageErr> {
         let spec = split_script(file)?;
@@ -79,7 +85,10 @@ impl Spec {
         }
         Ok(schema)
     }
-    /// Parse a spec from a script file's USAGE comments.
+    /// Parse a spec from a script file's embedded USAGE comments.
+    ///
+    /// Extracts the spec from comment lines starting with `# USAGE:` or `// USAGE:`.
+    /// If `bin` is not specified in the spec, it defaults to the filename.
     #[must_use = "parsing result should be used"]
     pub fn parse_script(file: &Path) -> Result<Spec, UsageErr> {
         let raw = extract_usage_from_comments(&file::read_to_string(file)?);


### PR DESCRIPTION
## Summary
- Add comprehensive rustdoc documentation for `CompleteOptions` struct and all its fields
- Document `complete()` function with arguments, return value, and supported shells list
- Expand documentation for `Spec::parse_file()` explaining auto-detection behavior
- Expand documentation for `Spec::parse_script()` explaining comment extraction

Note: `SpecMount::parse()` is `pub(crate)` (internal only), so public documentation is not required.

## Test plan
- [x] `cargo build` compiles successfully
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves public API documentation for completion generation and spec parsing.
> 
> - Documents all fields of `CompleteOptions` and the `complete()` function, including arguments, return type, and supported shells (`bash`, `fish`, `zsh`, `powershell`).
> - Expands `Spec::parse_file` docs to explain auto-detection of `.kdl`/`.usage.kdl` vs embedded `USAGE` comments and defaulting `bin` to the filename.
> - Expands `Spec::parse_script` docs to detail extraction from `# USAGE:`/`// USAGE:` markers and the `bin` defaulting behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44465d6cde71d91aa46a671c5898fbc97511e937. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->