### PR TITLE
refactor: simplify Spec::merge with local macros

### DIFF
--- a/lib/src/spec/mod.rs
+++ b/lib/src/spec/mod.rs
@@ -210,50 +210,45 @@ impl Spec {
     }
 
     pub fn merge(&mut self, other: Spec) {
-        if !other.name.is_empty() {
-            self.name = other.name;
+        macro_rules! merge_str {
+            ($field:ident) => {
+                if !other.$field.is_empty() {
+                    self.$field = other.$field;
+                }
+            };
         }
-        if !other.bin.is_empty() {
-            self.bin = other.bin;
+        macro_rules! merge_opt {
+            ($field:ident) => {
+                if other.$field.is_some() {
+                    self.$field = other.$field;
+                }
+            };
         }
-        if !other.usage.is_empty() {
-            self.usage = other.usage;
+        macro_rules! merge_extend {
+            ($field:ident) => {
+                if !other.$field.is_empty() {
+                    self.$field.extend(other.$field);
+                }
+            };
         }
-        if other.about.is_some() {
-            self.about = other.about;
-        }
-        if other.source_code_link_template.is_some() {
-            self.source_code_link_template = other.source_code_link_template;
-        }
-        if other.version.is_some() {
-            self.version = other.version;
-        }
-        if other.author.is_some() {
-            self.author = other.author;
-        }
-        if other.about_long.is_some() {
-            self.about_long = other.about_long;
-        }
-        if other.about_md.is_some() {
-            self.about_md = other.about_md;
-        }
+
+        merge_str!(name);
+        merge_str!(bin);
+        merge_str!(usage);
+        merge_opt!(about);
+        merge_opt!(source_code_link_template);
+        merge_opt!(version);
+        merge_opt!(author);
+        merge_opt!(about_long);
+        merge_opt!(about_md);
+        merge_opt!(disable_help);
+        merge_opt!(min_usage_version);
+        merge_opt!(default_subcommand);
+        merge_extend!(complete);
+        merge_extend!(examples);
+
         if !other.config.is_empty() {
             self.config.merge(&other.config);
-        }
-        if !other.complete.is_empty() {
-            self.complete.extend(other.complete);
-        }
-        if other.disable_help.is_some() {
-            self.disable_help = other.disable_help;
-        }
-        if other.min_usage_version.is_some() {
-            self.min_usage_version = other.min_usage_version;
-        }
-        if !other.examples.is_empty() {
-            self.examples.extend(other.examples);
-        }
-        if other.default_subcommand.is_some() {
-            self.default_subcommand = other.default_subcommand;
         }
         self.cmd.merge(other.cmd);
     }


### PR DESCRIPTION
## Summary
Replace 14+ repetitive if-check patterns in `Spec::merge` with three local macros:
- `merge_str!` for String fields (replace if non-empty)
- `merge_opt!` for Option fields (replace if Some)
- `merge_extend!` for Vec/IndexMap fields (extend if non-empty)

This reduces boilerplate and makes the merging strategy for each field immediately clear.

**Before:** 47 lines with repetitive `if` patterns
**After:** 42 lines with declarative macro calls

## Test plan
- [x] All tests pass
- [x] No behavior changes - macro expansion produces identical code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors `Spec::merge` to reduce duplication and clarify merge behavior without changing functionality.
> 
> - Introduces local macros: `merge_str!` (non-empty `String`), `merge_opt!` (`Option` is `Some`), and `merge_extend!` (extend non-empty collections)
> - Applies macros across `name`, `bin`, `usage`, `about*`, `version`, `author`, `disable_help`, `min_usage_version`, `default_subcommand`, `complete`, and `examples`
> - Retains existing merges for `config` (delegated `merge`) and `cmd` (`self.cmd.merge(...)`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51457145012fcf92ed7c5af9eec0c72200fc1ae9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->