### PR TITLE
docs: add CLAUDE.md for Claude Code guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ The spec model represents a CLI definition parsed from KDL:
 - `SpecMount` - Mount another spec at a subcommand path
 
 Specs can be:
+
 1. Parsed from `.usage.kdl` files
 2. Extracted from embedded `# USAGE:` comments in scripts
 3. Generated from clap Command definitions
@@ -63,6 +64,7 @@ Specs can be:
 ### Shell Completion Generation (`lib/src/complete/`)
 
 Each shell has its own module generating completion scripts:
+
 - `bash.rs` - Uses `complete` builtin
 - `zsh.rs` - Uses `compdef`
 - `fish.rs` - Uses `complete` command
@@ -73,6 +75,7 @@ Completions call back to `usage complete-word` at runtime for dynamic completion
 ### Argument Parsing (`lib/src/parse.rs`)
 
 The `parse()` function parses command-line arguments against a spec, returning:
+
 - Matched command path
 - Parsed args and flags with values
 - Env var and default fallbacks applied
@@ -80,6 +83,7 @@ The `parse()` function parses command-line arguments against a spec, returning:
 ### Documentation Generation (`lib/src/docs/`)
 
 Generates from specs:
+
 - Markdown documentation (`markdown/`)
 - Man pages (`manpage/`)
 - CLI help text (`cli/`)
@@ -89,6 +93,7 @@ Uses Tera templates for markdown rendering.
 ## KDL Spec Format
 
 Specs use KDL syntax. Key nodes:
+
 ```kdl
 name "mycli"
 bin "mycli"


### PR DESCRIPTION
## Summary
Add CLAUDE.md file to provide context for Claude Code when working in this repository.

Contents:
- Build, test, and lint commands (including single test execution)
- Workspace structure explanation (lib, cli, clap_usage crates)
- Architecture overview covering spec model, shell completions, parsing, and docs generation
- KDL spec format example
- Testing notes (insta snapshots, shell integration requirements)
- Key dependencies

## Test plan
- [x] File created with accurate information
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a contributor guidance doc for AI-assisted code workflows.
> 
> - New `CLAUDE.md` with project overview and goals
> - Build/test/lint commands, including single-test and snapshot update flows
> - Workspace structure (lib, cli, clap_usage) and high-level architecture (spec model, completion generation, argument parsing, docs generation)
> - KDL spec format example
> - Testing requirements and notes (shell integrations, `cargo-insta`)
> - Key dependencies overview (`kdl`, `clap`, `miette`, `tera`, `insta`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46db90c8d241c906018c0ca9f5e733a984e29203. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->