### PR TITLE
docs: escape generic type parameters in macro doc comments

### DIFF
--- a/lib/src/macros.rs
+++ b/lib/src/macros.rs
@@ -298,7 +298,7 @@ macro_rules! __spec_cmd_attr {
     };
 }
 
-/// Create a Vec<String> from string literals.
+/// Create a `Vec<String>` from string literals.
 ///
 /// # Examples
 ///
@@ -315,7 +315,7 @@ macro_rules! defaults {
     };
 }
 
-/// Create a Vec<char> for short flags.
+/// Create a `Vec<char>` for short flags.
 ///
 /// # Examples
 ///
@@ -332,7 +332,7 @@ macro_rules! shorts {
     };
 }
 
-/// Create a Vec<String> for long flags.
+/// Create a `Vec<String>` for long flags.
 ///
 /// # Examples
 ///
@@ -349,7 +349,7 @@ macro_rules! longs {
     };
 }
 
-/// Create a Vec<String> for command aliases.
+/// Create a `Vec<String>` for command aliases.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
## Summary

Wrap `Vec<String>` and `Vec<char>` in backticks to prevent them from being interpreted as unclosed HTML tags in rustdoc.

Fixes doc comments for:
- `defaults!` macro
- `shorts!` macro  
- `longs!` macro
- `aliases!` macro

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Minor rustdoc formatting fix.
> 
> - Escapes `Vec<String>` and `Vec<char>` in doc comments for `defaults!`, `shorts!`, `longs!`, and `aliases!` macros to avoid HTML tag interpretation
> - No functional or API changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b009b569c696e9dd3f1bee53b7a545031074a58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->