### PR TITLE
fix: replace unwrap calls with proper error handling in fig.rs

### DIFF
--- a/cli/src/cli/generate/fig.rs
+++ b/cli/src/cli/generate/fig.rs
@@ -360,8 +360,9 @@ impl Fig {
             Ok(())
         };
         let spec = generate::file_or_spec(&self.file, &self.spec)?;
-        let mut main_command = FigCommand::parse_from_spec(&spec.cmd)
-            .ok_or_else(|| miette::miette!("Failed to parse command spec (command may be hidden)"))?;
+        let mut main_command = FigCommand::parse_from_spec(&spec.cmd).ok_or_else(|| {
+            miette::miette!("Failed to parse command spec (command may be hidden)")
+        })?;
         let args = main_command.get_args();
         let completes = spec.complete;
         Fig::fill_args_complete(args, completes);
@@ -425,11 +426,7 @@ impl Fig {
 
     fn fill_args_complete(args: Vec<&mut FigArg>, completes: IndexMap<String, SpecComplete>) {
         args.into_iter()
-            .filter_map(|a| {
-                completes.get(&a.name).map(|v| (a, v.clone()))
-            })
-            .for_each(|(arg, complete)| {
-                arg.update_from_complete(complete)
-            });
+            .filter_map(|a| completes.get(&a.name).map(|v| (a, v.clone())))
+            .for_each(|(arg, complete)| arg.update_from_complete(complete));
     }
 }


### PR DESCRIPTION
## Summary

Replace risky `unwrap()` calls in the Fig spec generator with proper error handling to prevent panics.

### Changes

- **description_format serializer**: Handle `None` and empty string cases gracefully instead of panicking
- **get_generators**: Replace `filter + unwrap` pattern with `filter_map` for cleaner code
- **run()**: Return proper `miette` errors for:
  - `parse_from_spec` failure (command may be hidden)
  - JSON serialization failure
- **Handle mount commands**: Replace `filter + unwrap` with `filter_map`
- **fill_args_complete**: Simplify with `filter_map` instead of `map + filter + unwrap`

### Before/After

```rust
// Before (could panic)
let s: &str = description.as_ref().unwrap();
v[0] = v[0].to_uppercase().next().unwrap();

// After (handles edge cases)
let s: &str = match description.as_ref() {
    Some(s) => s,
    None => return serializer.serialize_str(""),
};
if let Some(first_upper) = v[0].to_uppercase().next() {
    v[0] = first_upper;
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens robustness and cleans up the Fig spec generator.
> 
> - **description_format serializer**: Gracefully handles `None`/empty descriptions and safely uppercases first char
> - **Fig::run()**: Returns `miette` errors on `parse_from_spec` failure and JSON serialization failure; builds output unchanged otherwise
> - **Iterator refactors**: Replace `filter + unwrap` with `filter_map` in `get_generators`, mount command handling, and `fill_args_complete`
> - Minor: avoid panics when accessing first char; simplify option generator extraction
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b59001736c101642286cbf246ee77f2f48a67e65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->