### PR TITLE
docs: add documentation to public API structs

### DIFF
--- a/lib/src/spec/arg.rs
+++ b/lib/src/spec/arg.rs
@@ -25,31 +25,62 @@ pub enum SpecDoubleDashChoices {
     Preserve,
 }
 
+/// A positional argument specification.
+///
+/// Arguments are positional values passed to a command without a flag prefix.
+/// They can be required or optional, and can accept multiple values (variadic).
+///
+/// # Example
+///
+/// ```
+/// use usage::SpecArg;
+///
+/// let arg = SpecArg::builder()
+///     .name("file")
+///     .required(true)
+///     .help("Input file to process")
+///     .build();
+/// ```
 #[derive(Debug, Default, Clone, Serialize)]
 pub struct SpecArg {
+    /// Name of the argument (used in help text)
     pub name: String,
+    /// Generated usage string (e.g., "<file>" or "[file]")
     pub usage: String,
+    /// Short help text shown in command listings
     #[serde(skip_serializing_if = "Option::is_none")]
     pub help: Option<String>,
+    /// Extended help text shown with --help
     #[serde(skip_serializing_if = "Option::is_none")]
     pub help_long: Option<String>,
+    /// Markdown-formatted help text
     #[serde(skip_serializing_if = "Option::is_none")]
     pub help_md: Option<String>,
+    /// First line of help text (auto-generated)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub help_first_line: Option<String>,
+    /// Whether this argument must be provided
     pub required: bool,
+    /// How to handle the "--" separator
     pub double_dash: SpecDoubleDashChoices,
+    /// Whether this argument accepts multiple values
     #[serde(skip_serializing_if = "is_false")]
     pub var: bool,
+    /// Minimum number of values for variadic arguments
     #[serde(skip_serializing_if = "Option::is_none")]
     pub var_min: Option<usize>,
+    /// Maximum number of values for variadic arguments
     #[serde(skip_serializing_if = "Option::is_none")]
     pub var_max: Option<usize>,
+    /// Whether to hide this argument from help output
     pub hide: bool,
+    /// Default value(s) if the argument is not provided
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub default: Vec<String>,
+    /// Valid choices for this argument
     #[serde(skip_serializing_if = "Option::is_none")]
     pub choices: Option<SpecChoices>,
+    /// Environment variable that can provide this argument's value
     #[serde(skip_serializing_if = "Option::is_none")]
     pub env: Option<String>,
 }

--- a/lib/src/spec/cmd.rs
+++ b/lib/src/spec/cmd.rs
@@ -14,45 +14,86 @@ use itertools::Itertools;
 use kdl::{KdlDocument, KdlEntry, KdlNode, KdlValue};
 use serde::Serialize;
 
+/// A CLI command or subcommand specification.
+///
+/// Commands define the structure of a CLI, including their flags, arguments,
+/// and nested subcommands. The root command represents the main CLI entry point.
+///
+/// # Example
+///
+/// ```
+/// use usage::{SpecCommand, SpecFlag, SpecArg};
+///
+/// let cmd = SpecCommand::builder()
+///     .name("install")
+///     .help("Install a package")
+///     .alias("i")
+///     .flag(SpecFlag::builder().short('f').long("force").build())
+///     .arg(SpecArg::builder().name("package").required(true).build())
+///     .build();
+/// ```
 #[derive(Debug, Serialize, Clone)]
 pub struct SpecCommand {
+    /// Full command path from root (e.g., ["git", "remote", "add"])
     pub full_cmd: Vec<String>,
+    /// Generated usage string
     pub usage: String,
+    /// Nested subcommands indexed by name
     pub subcommands: IndexMap<String, SpecCommand>,
+    /// Positional arguments for this command
     pub args: Vec<SpecArg>,
+    /// Flags/options for this command
     pub flags: Vec<SpecFlag>,
+    /// Mounted external specs
     pub mounts: Vec<SpecMount>,
+    /// Deprecation message if this command is deprecated
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deprecated: Option<String>,
+    /// Whether to hide this command from help output
     pub hide: bool,
+    /// Whether a subcommand must be provided
     #[serde(skip_serializing_if = "is_false")]
     pub subcommand_required: bool,
     /// Token that resets argument parsing, allowing multiple command invocations.
     /// e.g., `mise run lint ::: test ::: check` with restart_token=":::"
     #[serde(skip_serializing_if = "Option::is_none")]
     pub restart_token: Option<String>,
+    /// Short help text shown in command listings
     #[serde(skip_serializing_if = "Option::is_none")]
     pub help: Option<String>,
+    /// Extended help text shown with --help
     #[serde(skip_serializing_if = "Option::is_none")]
     pub help_long: Option<String>,
+    /// Markdown-formatted help text
     #[serde(skip_serializing_if = "Option::is_none")]
     pub help_md: Option<String>,
+    /// Command name (e.g., "install")
     pub name: String,
+    /// Alternative names for this command
     pub aliases: Vec<String>,
+    /// Hidden alternative names (not shown in help)
     pub hidden_aliases: Vec<String>,
+    /// Text displayed before the help content
     #[serde(skip_serializing_if = "Option::is_none")]
     pub before_help: Option<String>,
+    /// Extended text displayed before help content
     #[serde(skip_serializing_if = "Option::is_none")]
     pub before_help_long: Option<String>,
+    /// Markdown text displayed before help content
     #[serde(skip_serializing_if = "Option::is_none")]
     pub before_help_md: Option<String>,
+    /// Text displayed after the help content
     #[serde(skip_serializing_if = "Option::is_none")]
     pub after_help: Option<String>,
+    /// Extended text displayed after help content
     #[serde(skip_serializing_if = "Option::is_none")]
     pub after_help_long: Option<String>,
+    /// Markdown text displayed after help content
     #[serde(skip_serializing_if = "Option::is_none")]
     pub after_help_md: Option<String>,
+    /// Usage examples for this command
     pub examples: Vec<SpecExample>,
+    /// Custom completers for arguments
     #[serde(skip_serializing_if = "IndexMap::is_empty")]
     pub complete: IndexMap<String, SpecComplete>,
 

--- a/lib/src/spec/flag.rs
+++ b/lib/src/spec/flag.rs
@@ -13,40 +13,76 @@ use crate::spec::helpers::NodeHelper;
 use crate::spec::is_false;
 use crate::{string, SpecArg, SpecChoices};
 
+/// A CLI flag/option specification.
+///
+/// Flags are optional arguments that start with `-` (short) or `--` (long).
+/// They can be boolean switches or accept values.
+///
+/// # Example
+///
+/// ```
+/// use usage::SpecFlag;
+///
+/// let flag = SpecFlag::builder()
+///     .short('v')
+///     .long("verbose")
+///     .help("Enable verbose output")
+///     .build();
+/// ```
 #[derive(Debug, Default, Clone, Serialize)]
 pub struct SpecFlag {
+    /// Internal name for the flag (derived from long/short if not set)
     pub name: String,
+    /// Generated usage string (e.g., "-v, --verbose")
     pub usage: String,
+    /// Short help text shown in command listings
     #[serde(skip_serializing_if = "Option::is_none")]
     pub help: Option<String>,
+    /// Extended help text shown with --help
     #[serde(skip_serializing_if = "Option::is_none")]
     pub help_long: Option<String>,
+    /// Markdown-formatted help text
     #[serde(skip_serializing_if = "Option::is_none")]
     pub help_md: Option<String>,
+    /// First line of help text (auto-generated)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub help_first_line: Option<String>,
+    /// Short flag characters (e.g., 'v' for -v)
     pub short: Vec<char>,
+    /// Long flag names (e.g., "verbose" for --verbose)
     pub long: Vec<String>,
+    /// Whether this flag must be provided
     #[serde(skip_serializing_if = "is_false")]
     pub required: bool,
+    /// Deprecation message if this flag is deprecated
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deprecated: Option<String>,
+    /// Whether this flag can be specified multiple times
     #[serde(skip_serializing_if = "is_false")]
     pub var: bool,
+    /// Minimum number of times this flag must appear (for var flags)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub var_min: Option<usize>,
+    /// Maximum number of times this flag can appear (for var flags)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub var_max: Option<usize>,
+    /// Whether to hide this flag from help output
     pub hide: bool,
+    /// Whether this flag is available to all subcommands
     pub global: bool,
+    /// Whether this is a count flag (e.g., -vvv counts as 3)
     #[serde(skip_serializing_if = "is_false")]
     pub count: bool,
+    /// Argument specification if this flag takes a value
     #[serde(skip_serializing_if = "Option::is_none")]
     pub arg: Option<SpecArg>,
+    /// Default value(s) if the flag is not provided
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub default: Vec<String>,
+    /// Negation prefix (e.g., "no-" for --no-verbose)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub negate: Option<String>,
+    /// Environment variable that can set this flag's value
     #[serde(skip_serializing_if = "Option::is_none")]
     pub env: Option<String>,
 }


### PR DESCRIPTION
## Summary

Add comprehensive doc comments to the main public API types to improve discoverability and IDE support.

### Changes

- **SpecFlag**: Document all fields (name, usage, help variants, short/long, required, deprecated, var, hide, global, count, arg, default, negate, env)
- **SpecArg**: Document all fields (name, usage, help variants, required, double_dash, var, hide, default, choices, env)  
- **SpecCommand**: Document all fields (full_cmd, usage, subcommands, args, flags, mounts, deprecated, hide, subcommand_required, restart_token, help variants, name, aliases, hidden_aliases, before/after_help variants, examples, complete)

Each struct now includes:
- A high-level description
- A usage example demonstrating the builder pattern
- Field-level documentation explaining purpose and behavior

### Benefits

- Better IDE hover documentation
- Improved `cargo doc` output
- Clearer API contract for library users

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances public API documentation for core CLI spec types without changing behavior.
> 
> - **SpecArg**, **SpecFlag**, **SpecCommand**: Add high-level descriptions, usage examples (builder pattern), and field-level docs (help variants, defaults, variadic/count behavior, env, deprecation, aliases, etc.)
> - Improves `cargo doc` output and IDE hover info across these structs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3aab6065b7f9fa28cbc89e1b7b7e8ca7037e9238. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->