### PR TITLE
chore: make codecov checks informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
## Summary
- Codecov status checks will no longer block PR merges
- Coverage reports will still be generated and visible, but won't fail the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Configures Codecov to report coverage without blocking merges.
> 
> - Adds `codecov.yml` setting `coverage.status.project.default.informational` and `coverage.status.patch.default.informational` to `true`
> - Makes Codecov status checks informational while keeping reports generated and visible
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9416ee269ae941abb6b14ebe694f05b8c2b0b439. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->