### PR TITLE
ci: add cargo-semver-checks to detect breaking changes

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -9,6 +9,7 @@ gh = "latest"
 "cargo:cargo-edit" = "latest"
 "cargo:cargo-insta" = "latest"
 "cargo:cargo-release" = "latest"
+"cargo:cargo-semver-checks" = "latest"
 "cargo:git-cliff" = "latest"
 "npm:prettier" = "latest"
 shellcheck = "latest"
@@ -63,6 +64,8 @@ run = "prettier -c ."
 run = 'cargo clippy --all --all-features -- -D warnings'
 [tasks."lint:fmt"]
 run = 'cargo fmt --all -- --check'
+[tasks."lint:semver"]
+run = 'cargo semver-checks check-release -p usage-lib'
 
 [tasks.lint-fix]
 run = [


### PR DESCRIPTION
## Summary
- Adds cargo-semver-checks as a mise tool
- Adds `lint:semver` task that runs automatically with `mise run lint` and `mise run ci`

This ensures that breaking changes to the public API are caught during development and CI.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances CI linting to catch semver-breaking API changes.
> 
> - Adds `"cargo:cargo-semver-checks" = "latest"` to `mise.toml` tools
> - Introduces `tasks."lint:semver"` running `cargo semver-checks check-release -p usage-lib`
> - Included in `tasks.lint` aggregate via `depends = ['lint:*']` (runs automatically in CI)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48f23587bc464410c04fe1947fa8ff753d761f6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->