### PR TITLE
fix: don't thank @jdx in LLM-generated release notes

### DIFF
--- a/scripts/gen-release-notes.sh
+++ b/scripts/gen-release-notes.sh
@@ -45,7 +45,7 @@ Write user-friendly release notes in markdown:
 3. Organize into ## sections (Highlights, Bug Fixes, etc.) as needed
 4. Explain WHY changes matter to users
 5. Include PR links and documentation links (https://usage.jdx.dev/)
-6. Include contributor usernames (@username)
+6. Include contributor usernames (@username). Do not thank @jdx since that is who is writing these notes.
 7. Skip internal/trivial changes
 
 Output markdown only, starting with the # title line.


### PR DESCRIPTION
## Summary
- Updates gen-release-notes prompt to avoid thanking @jdx for contributions since they are the maintainer writing the notes

## Test plan
- [ ] Verify next release notes don't include "thanks @jdx" type phrases

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines the release-notes generation prompt in `scripts/gen-release-notes.sh` to explicitly avoid thanking `@jdx` when listing contributors.
> 
> - Updates instruction bullet to: include contributor usernames but do not thank `@jdx`
> - No functional logic changes to the script or release flow
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53eb957517c2dbf9a76eaccfaef80c9a9260b634. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->