### PR TITLE
docs: clarify fix type is for CLI bugs only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,13 +11,13 @@ All commit messages and PR titles MUST follow conventional commit format:
 **Types:**
 
 - `feat:` - New features
-- `fix:` - Bug fixes
+- `fix:` - Bug fixes that affect the CLI behavior (not CI, docs, or infrastructure)
 - `refactor:` - Code refactoring
 - `docs:` - Documentation changes
 - `style:` - Code style/formatting (no logic changes)
 - `perf:` - Performance improvements
 - `test:` - Testing changes
-- `chore:` - Maintenance tasks, releases, dependency updates
+- `chore:` - Maintenance tasks, releases, dependency updates, CI/infrastructure changes
 - `security:` - Security-related changes
 
 **Scopes:**


### PR DESCRIPTION
## Summary
- Clarify that `fix:` type is for bug fixes that affect CLI behavior (not CI, docs, or infrastructure)
- Clarify that `chore:` includes CI/infrastructure changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines conventional commit guidance.
> 
> - Clarifies `fix:` is only for bugs affecting CLI behavior (not CI, docs, or infrastructure)
> - Expands `chore:` to explicitly include CI/infrastructure changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0031b0bf1edde60340f4f432d5f714b816b30eb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->