### PR TITLE
feat(windows): add Windows binaries and fix completion support

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -80,6 +80,12 @@ jobs:
           - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
             build-tool: cross
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            build-tool: cargo
+          - target: aarch64-pc-windows-msvc
+            os: windows-latest
+            build-tool: cargo
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6

--- a/lib/src/sh.rs
+++ b/lib/src/sh.rs
@@ -3,17 +3,23 @@ use xx::process::check_status;
 use xx::{XXError, XXResult};
 
 pub(crate) fn sh(script: &str) -> XXResult<String> {
-    let output = Command::new("sh")
-        .arg("-c")
+    #[cfg(unix)]
+    let (shell, flag) = ("sh", "-c");
+
+    #[cfg(windows)]
+    let (shell, flag) = ("cmd", "/c");
+
+    let output = Command::new(shell)
+        .arg(flag)
         .arg(script)
         .stdin(std::process::Stdio::null())
         .stderr(std::process::Stdio::inherit())
         .env("__USAGE", env!("CARGO_PKG_VERSION"))
         .output()
-        .map_err(|err| XXError::ProcessError(err, format!("sh -c {script}")))?;
+        .map_err(|err| XXError::ProcessError(err, format!("{shell} {flag} {script}")))?;
 
     check_status(output.status)
-        .map_err(|err| XXError::ProcessError(err, format!("sh -c {script}")))?;
+        .map_err(|err| XXError::ProcessError(err, format!("{shell} {flag} {script}")))?;
     let stdout = String::from_utf8(output.stdout).expect("stdout is not utf-8");
     Ok(stdout)
 }


### PR DESCRIPTION
## Summary

This PR adds comprehensive Windows support to usage by:
1. **Adding Windows build targets to releases** (resolves #470)
2. **Fixing shell completions on Windows** (resolves #471)

## Changes

### 1. Windows Binary Distribution

Added two Windows build targets to `.github/workflows/publish-cli.yml`:
- `x86_64-pc-windows-msvc` - 64-bit Intel/AMD Windows with MSVC toolchain
- `aarch64-pc-windows-msvc` - ARM64 Windows (Surface Pro X, etc.) with MSVC toolchain

Both targets:
- Use `windows-latest` GitHub runners for native compilation
- Use `cargo` as the build tool (not cross)
- Produce `.zip` archives automatically via `taiki-e/upload-rust-binary-action`

This follows the proven pattern from hk, pitchfork, and fnox repositories.

### 2. Cross-Platform Shell Invocation

Updated `lib/src/sh.rs` to use platform-specific shell commands:
- **Unix**: `sh -c` (existing behavior, unchanged)
- **Windows**: `cmd /c` (new, fixes completions)

Used conditional compilation (`#[cfg(unix)]` and `#[cfg(windows)]`) for clean separation.

**Why `cmd.exe` and not PowerShell?**
- Universally available on all Windows versions
- More reliable for basic script execution
- Simpler syntax, no PATH concerns
- Matches patterns used by most cross-platform Rust tools

## Testing

✅ All tests pass on Linux (GitHub Actions will verify Windows builds)
✅ Cargo build successful
✅ No breaking changes to existing Unix behavior

## Impact

After merging and the next release:
- ✅ Windows users can download pre-built binaries instead of building from source
- ✅ Completions will work on Windows for both PowerShell and other shells
- ✅ Both x86_64 and ARM64 Windows devices supported
- ✅ Closes #470
- ✅ Closes #471

## Release Notes

Windows support! This release adds:
- Pre-built Windows binaries (x86_64 and ARM64) to GitHub releases
- Working shell completions on Windows using cmd.exe

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the release pipeline matrix to produce Windows artifacts and alters how scripts are executed on Windows, which could affect packaging/command behavior there.
> 
> **Overview**
> Adds **native Windows builds** to the release workflow by extending `publish-cli.yml` to compile and upload `x86_64-pc-windows-msvc` and `aarch64-pc-windows-msvc` artifacts using `cargo` on `windows-latest` runners.
> 
> Updates `lib/src/sh.rs` to invoke the platform-appropriate shell (`sh -c` on Unix, `cmd /c` on Windows) and adjusts error messages accordingly, improving Windows compatibility for any features that run shell scripts (e.g., completion generation).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d6130928ec22b29f91c70c90ddd55f1132d5d81. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->