### PR TITLE
feat: add _bash suffix env vars for variadic args

### DIFF
--- a/lib/tests/parse.rs
+++ b/lib/tests/parse.rs
@@ -210,21 +210,21 @@ multi_arg:
     arg "<vars>" var=#true
     "#,
     args="a b c",
-    expected=r#"{"usage_vars": "a b c"}"#,
+    expected=r#"{"usage_vars": "a b c", "usage_vars_bash": "(a b c)"}"#,
 
 multi_arg_spaces:
     spec=r#"
     arg "<vars>" var=#true
     "#,
     args=r#"a "b c""#,
-    expected=r#"{"usage_vars": "a 'b c'"}"#,
+    expected=r#"{"usage_vars": "a 'b c'", "usage_vars_bash": "(a 'b c')"}"#,
 
 multi_flag:
     spec=r#"
     flag "-v --vars <vars>" var=#true
     "#,
     args=r#"--vars a --vars "b c""#,
-    expected=r#"{"usage_vars": "a 'b c'"}"#,
+    expected=r#"{"usage_vars": "a 'b c'", "usage_vars_bash": "(a 'b c')"}"#,
 
  count_flag_short:
     spec=r#"


### PR DESCRIPTION
## Summary

For variadic arguments (`var=true`), `as_env()` now emits an additional environment variable with a `_bash` suffix containing a bash array literal that can be directly eval'd into a bash array.

**Example:**
- `usage_files="arg1 'arg with space'"` (existing format)
- `usage_files_bash="(arg1 'arg with space')"` (new format)

This allows bash scripts to properly handle variadic args with spaces:

```bash
eval "files=$usage_files_bash"
for f in "${files[@]}"; do echo "$f"; done
```

## Problem

The existing shell-escaped string format (`'arg1' 'arg with space'`) cannot be reliably converted back into separate arguments in bash without fragile workarounds. Users had to use patterns like:

```bash
eval "files=(${usage_files})"  # Fragile - double parentheses needed
```

This has been a [long-standing pain point](https://github.com/jdx/mise/discussions/6766) for mise task authors.

## Solution

Add a second env var with `_bash` suffix that contains a bash array literal:

```bash
usage_files_bash="(arg1 'arg with space')"
```

Users can now simply:

```bash
eval "files=$usage_files_bash"
touch "${files[@]}"
```

## Backwards Compatibility

- Existing `usage_*` variables remain unchanged
- Only adds new `_bash` suffixed variables for `MultiString` (variadic) values
- Non-variadic args do not get a `_bash` suffix

## Test plan

- [x] Added unit tests for bash array format
- [x] Added tests for single-element variadic args
- [x] Added tests verifying non-variadic args don't get `_bash` suffix
- [x] Updated integration tests

Closes #189

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds additional `usage_*_bash` outputs for `MultiString` values and updates tests; existing env var keys/values remain unchanged.
> 
> **Overview**
> `ParseOutput::as_env()` now emits an extra `usage_<name>_bash` environment variable for variadic (`MultiString`) args and flags, formatted as a bash array literal (e.g., `(arg1 'arg with space')`) while keeping existing `usage_<name>` values unchanged.
> 
> Adds/updates unit and integration tests to validate the new `_bash` variables (including spaced and single-element values) and ensure non-variadic args do not receive the suffix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6eb9d4f2100d8988c3ac360a5b4eaab98c55984. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->