### PR TITLE
docs: add bash array pattern for variadic args

### DIFF
--- a/docs/spec/reference/arg.md
+++ b/docs/spec/reference/arg.md
@@ -38,10 +38,6 @@ touch "${files[@]}"
 
 This pattern ensures arguments with spaces are handled correctly as separate elements.
 
-> **Note:** `readarray`/`mapfile` are alternatives in bash 4.0+, but macOS ships with
-> bash 3.2 by default which doesn't include them. The `eval` pattern above works
-> with all bash versions.
-
 ```kdl
 arg "<shell>" {
   choices "bash" "zsh" "fish" # <shell> must be one of the choices


### PR DESCRIPTION
## Summary

Documents how to properly convert variadic args (`var=#true`) to bash arrays using the pattern:

```bash
eval "arr=($usage_var)"
```

This handles arguments with spaces correctly.

## Example

```bash
# Given: usage_files="arg1 'arg with space' arg3"

# Convert to bash array:
eval "files=($usage_files)"

# Now use as array:
for f in "${files[@]}"; do
  echo "Processing: $f"
done
```

This addresses the common issue where users struggle to handle variadic args with spaces in bash scripts.

Related: #189

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change; no runtime behavior is modified. Low risk aside from potentially encouraging unsafe `eval` usage if misapplied.
> 
> **Overview**
> Adds a new **“Using Variadic Args in Bash”** section to `docs/spec/reference/arg.md` describing how `var=#true` values are exposed via `usage_<name>` and providing a Bash snippet (`eval "files=($usage_files)"`) to safely iterate/pass variadic args that may contain spaces.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d23303cee79e64acff7b13fff63fc6f687bc1691. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->