### PR TITLE
fix(parse): handle variadic ellipsis inside brackets like [args...]

### DIFF
--- a/lib/tests/dump.rs
+++ b/lib/tests/dump.rs
@@ -26,5 +26,5 @@ tests_same! {
     choices bash fish zsh
 }"#,
 
-    double_dash: r#"arg "<-- shell...>""#,
+    double_dash: r#"arg "<-- shell>…" var=#true"#,
 }

--- a/lib/tests/parse.rs
+++ b/lib/tests/parse.rs
@@ -240,6 +240,24 @@ multi_flag:
     args="-v --verbose",
     expected=r#"{"usage_verbose": "2"}"#,
 
+variadic_arg_captures_unknown_flags:
+    spec=r#"
+    flag "-v --verbose" var=#true
+    arg "[database]" default="myapp_dev"
+    arg "[args...]"
+    "#,
+    args="mydb --host localhost",
+    expected=r#"{"usage_args": "--host localhost", "usage_database": "mydb"}"#,
+
+variadic_arg_captures_unknown_short_flags:
+    spec=r#"
+    flag "-v --verbose" var=#true
+    arg "[database]" default="myapp_dev"
+    arg "[args...]"
+    "#,
+    args="mydb -x localhost",
+    expected=r#"{"usage_args": "-x localhost", "usage_database": "mydb"}"#,
+
 //shell_escape_arg:
 //    spec=r#"
 //    arg "<vars>" shell_escape=#true


### PR DESCRIPTION
## Summary
- Fix spec parser to recognize `[args...]` and `<args...>` as variadic arguments
- Previously, only `[args]...` and `<args>...` (ellipsis outside brackets) were recognized as variadic
- The ellipsis check ran before bracket stripping, so `[args...]` (ending with `]`) was missed

## Problem
When a usage spec defines `arg "[args...]"`, the `...` inside brackets was not parsed as making the arg variadic (`var=true`). This caused unknown flags like `--host localhost` to fail with "unexpected word: localhost" instead of being captured into the variadic arg.

Example failing spec:
```
flag "-v --verbose" var=#true
arg "[database]" default="myapp_dev"
arg "[args...]"
```

`mydb --host localhost` would error instead of setting `database="mydb"` and `args=["--host", "localhost"]`.

## Fix
Add a second ellipsis check after bracket stripping in `From<&str> for SpecArg`, so both `[args]...` and `[args...]` correctly set `var=true`.

## Test plan
- [x] New unit tests for `[args...]`, `<args...>`, and `[args…]` syntax in `arg.rs`
- [x] New integration parse tests verifying unknown flags are captured by variadic args
- [x] New unit test parsing spec from string (end-to-end spec parse → arg parse)
- [x] Updated dump round-trip test for `<-- shell...>` which is now correctly parsed as variadic
- [x] All 197 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, targeted change to spec-string parsing for variadic args plus added coverage; main risk is minor behavior change for specs that previously treated `[args...]` as a literal name.
> 
> **Overview**
> Fixes spec parsing so variadic positional args can be declared as `[args...]`/`<args...>` (including unicode `…`) by detecting ellipses after stripping the surrounding brackets.
> 
> Adds regression tests covering end-to-end parsing where unknown flags/words are captured into the variadic arg, and updates the dump round-trip expectation for a `double_dash` variadic arg representation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 600edf53daedfbdd53e1a572127d3ddb13f85fd4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->