### PR TITLE
chore: add tone calibration to release notes prompt

### DIFF
--- a/scripts/gen-release-notes.sh
+++ b/scripts/gen-release-notes.sh
@@ -37,11 +37,18 @@ prompt=$(
 	cat <<'INSTRUCTIONS'
 Write user-friendly release notes in markdown:
 
-1. First line: `# ` followed by a pithy, descriptive title (not just the version). Examples:
+1. First line: `# ` followed by a pithy, descriptive title (not just the version). For smaller or less impactful releases, keep the title understated and modest. Examples:
    - "# PowerShell Support & Bug Fixes"
    - "# Performance Improvements"
    - "# New Completion Features"
-2. Then 1-2 paragraphs summarizing key changes
+
+TONE CALIBRATION:
+- Match the tone and length to the actual significance of the changes
+- If the release is mostly small bug fixes or minor tweaks, be upfront about that—a sentence or two of summary is fine, don't write multiple paragraphs inflating the importance
+- Reserve enthusiastic, detailed write-ups for releases with genuinely significant features or changes
+- It's okay to say "This is a smaller release focused on bug fixes" when that's the case
+
+2. Then a summary proportional to the significance of the changes
 3. Organize into ## sections (Highlights, Bug Fixes, etc.) as needed
 4. Explain WHY changes matter to users
 5. Include PR links and documentation links (https://usage.jdx.dev/)


### PR DESCRIPTION
## Summary
- Add tone calibration instructions to the release notes LLM prompt so it matches tone and length to the actual significance of changes
- Add title guideline for smaller releases to keep titles understated
- Change summary instruction from fixed "1-2 paragraphs" to "proportional to significance"

## Test plan
- [x] Prompt-only change, no code logic affected
- [ ] Verify next release notes generation produces appropriately-toned output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-text-only change in a release-notes generation script; no runtime or data-handling logic is modified.
> 
> **Overview**
> Adjusts `scripts/gen-release-notes.sh`’s release-notes prompt to **calibrate tone and verbosity** based on the significance of the changelog.
> 
> It adds explicit guidance to keep titles modest for small releases and replaces the fixed “1–2 paragraph” summary requirement with a summary **proportional to the impact**, explicitly allowing brief “mostly bug fixes” notes when appropriate.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 779268e87f2c848cb5492876306c6da51f60b03b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->