### PR TITLE
fix(docs): align homepage feature button with integrations page

### DIFF
--- a/docs/.vitepress/theme/UsageHero.vue
+++ b/docs/.vitepress/theme/UsageHero.vue
@@ -64,10 +64,10 @@
           </a>
           <a href="/spec/integrations" class="usage-hero-feature">
             <span class="usage-hero-feature-icon">🌐</span>
-            <span class="usage-hero-feature-text">Any Language</span>
+            <span class="usage-hero-feature-text">Integrations</span>
             <div class="usage-hero-feature-tooltip">
-              <strong>Language Agnostic</strong>
-              <p>Use with bash scripts or integrate with CLIs written in any language via the usage CLI.</p>
+              <strong>Framework Integrations</strong>
+              <p>Generate usage specs from CLI frameworks like clap, with more integrations coming soon.</p>
             </div>
           </a>
         </div>


### PR DESCRIPTION
## Summary

- Renamed the "Any Language" homepage feature button to "Integrations" with an accurate tooltip description
- The previous tooltip described language-agnostic scripting (which matches `/cli/scripts`) but linked to `/spec/integrations` (framework integrations like clap)
- Now the button label, tooltip, and link target are all consistent

Fixes #493

## Test plan

- [x] Verified fix locally with VitePress dev server + Playwright
- [x] Button now reads "Integrations" with tooltip "Framework Integrations"
- [x] Link still navigates to `/spec/integrations`
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)