### PR TITLE
docs: add integrations directory with framework tracker

### DIFF
--- a/integrations/README.md
+++ b/integrations/README.md
@@ -1,0 +1,58 @@
+# Usage Integrations
+
+Integrations that generate usage specs from CLI framework definitions, enabling shell completions, docs, and man pages from a single source.
+
+## Status
+
+- [x] **clap** (Rust) - [`clap_usage`](https://crates.io/crates/clap_usage) ~16k stars
+
+### High Priority
+
+- [ ] **Cobra** (Go) - [spf13/cobra](https://github.com/spf13/cobra) ~43k stars
+- [ ] **Commander.js** (Node.js) - [tj/commander.js](https://github.com/tj/commander.js) ~28k stars
+- [ ] **urfave/cli** (Go) - [urfave/cli](https://github.com/urfave/cli) ~24k stars
+- [ ] **Typer** (Python) - [fastapi/typer](https://github.com/fastapi/typer) ~19k stars
+- [ ] **Click** (Python) - [pallets/click](https://github.com/pallets/click) ~17k stars
+- [ ] **argparse** (Python) - stdlib
+
+### Medium Priority
+
+- [ ] **yargs** (Node.js) - [yargs/yargs](https://github.com/yargs/yargs) ~11k stars
+- [ ] **Spectre.Console** (C#/.NET) - [spectreconsole/spectre.console](https://github.com/spectreconsole/spectre.console) ~11k stars
+- [ ] **Symfony Console** (PHP) - [symfony/console](https://github.com/symfony/console) ~10k stars
+- [ ] **oclif** (Node.js) - [oclif/oclif](https://github.com/oclif/oclif) ~9k stars
+- [ ] **picocli** (Java) - [remkop/picocli](https://github.com/remkop/picocli) ~5k stars
+- [ ] **Thor** (Ruby) - [rails/thor](https://github.com/rails/thor) ~5k stars
+- [ ] **cxxopts** (C++) - [jarro2783/cxxopts](https://github.com/jarro2783/cxxopts) ~5k stars
+- [ ] **CommandLineParser** (C#/.NET) - [commandlineparser/commandline](https://github.com/commandlineparser/commandline) ~5k stars
+- [ ] **CLI11** (C++) - [CLIUtils/CLI11](https://github.com/CLIUtils/CLI11) ~4k stars
+- [ ] **Laravel Zero** (PHP) - [laravel-zero/laravel-zero](https://github.com/laravel-zero/laravel-zero) ~4k stars
+- [ ] **swift-argument-parser** (Swift) - [apple/swift-argument-parser](https://github.com/apple/swift-argument-parser) ~4k stars
+- [ ] **System.CommandLine** (C#/.NET) - [dotnet/command-line-api](https://github.com/dotnet/command-line-api) ~4k stars
+
+### Lower Priority
+
+- [ ] **Kong** (Go) - [alecthomas/kong](https://github.com/alecthomas/kong) ~3k stars
+- [ ] **Clikt** (Kotlin) - [ajalt/clikt](https://github.com/ajalt/clikt) ~3k stars
+- [ ] **JCommander** (Java) - [cbeust/jcommander](https://github.com/cbeust/jcommander) ~2k stars
+- [ ] **argh** (Rust) - [google/argh](https://github.com/google/argh) ~2k stars
+- [ ] **zig-clap** (Zig) - [Hejsil/zig-clap](https://github.com/Hejsil/zig-clap) ~1.5k stars
+- [ ] **optparse-applicative** (Haskell) - [pcapriotti/optparse-applicative](https://github.com/pcapriotti/optparse-applicative) ~1k stars
+- [ ] **kotlinx-cli** (Kotlin) - [Kotlin/kotlinx-cli](https://github.com/Kotlin/kotlinx-cli) ~900 stars
+- [ ] **cligen** (Nim) - [c-blake/cligen](https://github.com/c-blake/cligen) ~560 stars
+- [ ] **argparse** (Lua) - [mpeterv/argparse](https://github.com/mpeterv/argparse) ~285 stars
+- [ ] **Getopt::Long** (Perl) - stdlib
+- [ ] **OptionParser** (Elixir) - stdlib
+- [ ] **OptionParser** (Ruby) - stdlib
+- [ ] **getopt** (C) - POSIX stdlib
+
+## How Integrations Work
+
+An integration extracts the CLI definition (commands, flags, args, completions) from a framework's internal representation and outputs a [usage spec](https://usage.jdx.dev/spec/) in KDL format. This spec can then drive:
+
+- **Shell completions** for bash, zsh, fish, PowerShell, and nushell
+- **Markdown documentation**
+- **Man pages**
+- **`--help` output**
+
+See [`clap_usage`](../clap_usage/) for a reference implementation.


### PR DESCRIPTION
## Summary

- Adds `integrations/README.md` with a prioritized checklist of 30+ CLI frameworks across 16+ languages
- Organized into high/medium/lower priority tiers based on ecosystem popularity (GitHub stars)
- Includes a "How Integrations Work" section explaining the spec generation approach
- References `clap_usage` as the existing reference implementation

## Highlights

**High priority** (>15k stars): Cobra (Go), Commander.js (Node), urfave/cli (Go), Typer/Click (Python), argparse (Python)

**Medium priority** (4-12k stars): yargs, Spectre.Console (.NET), Symfony Console (PHP), oclif, picocli (Java), Thor (Ruby), swift-argument-parser, and more

**Lower priority** (<3k stars): Kong, Clikt, argh, zig-clap, optparse-applicative, and others

## Test plan

- [x] No code changes, docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change that adds planning/overview material without modifying runtime code paths.
> 
> **Overview**
> Adds a new `integrations/README.md` that tracks planned/implemented CLI-framework integrations via a prioritized checklist and links to the existing `clap_usage` reference implementation.
> 
> Documents the intended integration flow: extracting framework CLI definitions into the KDL usage spec to drive completions, docs, man pages, and `--help` output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6859f09032ce8eb06da55aea716b48ee10d0d2a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->