### PR TITLE
fix(publish): anchor gh release create to GITHUB_SHA to avoid untagged release

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -33,7 +33,7 @@ jobs:
           TAG_NAME="${{ github.ref_name }}"
           # Extract first version section from CHANGELOG.md as baseline
           awk '/^## \[/{if(found) exit; found=1} found{print}' CHANGELOG.md >/tmp/release-notes.txt
-          gh release create --draft "$TAG_NAME" \
+          gh release create --draft --target "$GITHUB_SHA" "$TAG_NAME" \
             --title "$TAG_NAME" \
             --notes-file /tmp/release-notes.txt
       - name: Enhance release notes with communique


### PR DESCRIPTION
## Summary

- The v2.17.1 release CI run failed because `gh release create --draft "v2.17.1"` created a release with tag `untagged-d8ea426c8964292e5b9a` instead of `v2.17.1`
- `taiki-e/upload-rust-binary-action` could not find the release by tag name, failing all `build-and-publish` matrix jobs
- Root cause: the new `communique`-based workflow calls `gh release create` almost immediately after checkout, whereas the old workflow had a ~60s `npm install -g @anthropic-ai/claude-code` step first. Without that delay, `gh` hits a race condition where GitHub's Releases API hasn't indexed the newly-pushed tag yet, so it falls back to creating an `untagged-*` draft

## Fix

Add `--target "$GITHUB_SHA"` to `gh release create`. This anchors the release to the exact commit SHA from the workflow trigger, bypassing the GitHub Releases API's tag lookup entirely. The release is still associated with the tag name `v2.17.1` but doesn't depend on the API having indexed the tag yet.

## Test plan

- [ ] Verify next release run creates a draft release with the correct tag (not `untagged-*`)
- [ ] Confirm `taiki-e/upload-rust-binary-action` can find the release and upload binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI workflow change limited to release creation behavior; low risk aside from potentially changing which commit a tag’s release points to if the tag is mis-pushed.
> 
> **Overview**
> Ensures the `publish-cli` workflow always creates draft GitHub releases for the exact commit that triggered the run by adding `--target "$GITHUB_SHA"` to `gh release create`.
> 
> This avoids occasional `untagged-*` draft releases (and downstream publish failures) when the tag hasn’t propagated/indexed yet at release-creation time.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 571ac7e3ecf0f5a954f415b6ab77e73bc9264d8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->