### PR TITLE
fix(publish): use gh api directly to create release with explicit tag_name

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -33,9 +33,17 @@ jobs:
           TAG_NAME="${{ github.ref_name }}"
           # Extract first version section from CHANGELOG.md as baseline
           awk '/^## \[/{if(found) exit; found=1} found{print}' CHANGELOG.md >/tmp/release-notes.txt
-          gh release create --draft --target "$GITHUB_SHA" "$TAG_NAME" \
-            --title "$TAG_NAME" \
-            --notes-file /tmp/release-notes.txt
+          BODY=$(cat /tmp/release-notes.txt)
+          # Use the API directly so tag_name is set explicitly (gh release create
+          # can produce untagged-* drafts when the tag is very recently pushed)
+          gh api repos/${{ github.repository }}/releases \
+            --method POST \
+            -f tag_name="$TAG_NAME" \
+            -f target_commitish="$GITHUB_SHA" \
+            -f name="$TAG_NAME" \
+            -f body="$BODY" \
+            -F draft=true \
+            --jq '.html_url'
       - name: Enhance release notes with communique
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         continue-on-error: true


### PR DESCRIPTION
## Summary

- Previous fix (#506) added `--target "$GITHUB_SHA"` to `gh release create`, but the releases are still created as `untagged-*`
- Root cause (revised): something creates a GitHub release for the tag ~60 seconds before the `publish-cli` workflow starts (timestamps: v2.17.1 release at 12:36:44, workflow start at 12:37:44; v2.17.2 release at 13:07:56, workflow start at 13:08:47). When `gh release create "v2.17.x"` finds an existing release for that tag, it silently creates a new `untagged-*` draft as a fallback instead of failing
- Fix: call `gh api repos/${{ github.repository }}/releases --method POST` directly with explicit `-f tag_name=` and `-f target_commitish=` fields. This bypasses the `gh release create` wrapper entirely and guarantees the `tag_name` is set correctly regardless of pre-existing releases

## Test plan

- [ ] Verify next release creates a draft with `tag_name: v2.x.x` (not `untagged-*`) via `gh api repos/jdx/usage/releases --jq '.[0]'`
- [ ] Confirm `taiki-e/upload-rust-binary-action` finds the release and uploads binaries successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, workflow-only change affecting how GitHub releases are created; primary risk is misconfigured API parameters causing draft release creation to fail.
> 
> **Overview**
> Fixes the `publish-cli` workflow’s draft release creation to avoid accidental `untagged-*` releases when a release already exists for a just-pushed tag.
> 
> Replaces `gh release create` with a direct `gh api POST /repos/{owner}/{repo}/releases`, explicitly setting `tag_name`, `target_commitish`, and the changelog-derived release body before continuing with the existing release-notes enhancement and publish steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ecbb58a2c0afdd3ae10013d05b054483443a724. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->