### PR TITLE
fix(publish): retry draft release creation until tag is indexed

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -31,19 +31,30 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: |
           TAG_NAME="${{ github.ref_name }}"
-          # Extract first version section from CHANGELOG.md as baseline
           awk '/^## \[/{if(found) exit; found=1} found{print}' CHANGELOG.md >/tmp/release-notes.txt
           BODY=$(cat /tmp/release-notes.txt)
-          # Use the API directly so tag_name is set explicitly (gh release create
-          # can produce untagged-* drafts when the tag is very recently pushed)
-          gh api repos/${{ github.repository }}/releases \
-            --method POST \
-            -f tag_name="$TAG_NAME" \
-            -f target_commitish="$GITHUB_SHA" \
-            -f name="$TAG_NAME" \
-            -f body="$BODY" \
-            -F draft=true \
-            --jq '.html_url'
+          # GitHub may not have indexed the tag yet after a push. Draft releases
+          # created before indexing get "untagged-*" placeholder tag names.
+          for attempt in $(seq 1 30); do
+            RESPONSE=$(gh api repos/${{ github.repository }}/releases \
+              --method POST \
+              -f tag_name="$TAG_NAME" \
+              -f target_commitish="$GITHUB_SHA" \
+              -f name="$TAG_NAME" \
+              -f body="$BODY" \
+              -F draft=true)
+            ACTUAL_TAG=$(echo "$RESPONSE" | jq -r '.tag_name')
+            if [ "$ACTUAL_TAG" = "$TAG_NAME" ]; then
+              echo "$RESPONSE" | jq -r '.html_url'
+              exit 0
+            fi
+            RELEASE_ID=$(echo "$RESPONSE" | jq -r '.id')
+            gh api "repos/${{ github.repository }}/releases/$RELEASE_ID" --method DELETE --silent
+            echo "Tag not yet indexed (got $ACTUAL_TAG), retrying in 5s... (attempt $attempt/30)"
+            sleep 5
+          done
+          echo "::error::Failed to create release with correct tag after 30 attempts"
+          exit 1
       - name: Enhance release notes with communique
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         continue-on-error: true


### PR DESCRIPTION
## Summary

- After migrating to communique, draft releases were getting `untagged-*` placeholder tag names because the workflow calls the API within ~5s of checkout, before GitHub has indexed the tag
- The old workflow had ~90s of built-in delay (npm install + Claude CLI generation) that masked the race condition
- Adds a retry loop that creates the draft, verifies `tag_name` matches, and deletes + retries (up to 30 attempts × 5s) if it got an `untagged-*` placeholder

## Test plan

- [ ] Trigger a tag push and verify the draft release is created with the correct tag name
- [ ] Verify `taiki-e/upload-rust-binary-action` finds the release successfully in build-and-publish jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that adds a bounded retry/delete loop to handle a GitHub indexing race; main risk is longer CI time or failure if the GitHub API behavior changes.
> 
> **Overview**
> The `publish-cli` GitHub Actions workflow now retries draft release creation after a tag push, verifying the created release’s `tag_name` matches the pushed tag.
> 
> If GitHub returns an `untagged-*` placeholder, the workflow deletes the draft release, waits 5 seconds, and retries up to 30 times before failing with an explicit error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a40bd0776c89e94bfbaf076d4501f2f9321f33a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->