### PR TITLE
fix(publish): run communique after release is published

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -55,12 +55,6 @@ jobs:
           done
           echo "::error::Failed to create release with correct tag after 30 attempts"
           exit 1
-      - name: Enhance release notes with communique
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        continue-on-error: true
-        run: communique generate "${{ github.ref_name }}" --github-release
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
   build-and-publish:
     needs: [create-release]
     strategy:
@@ -127,6 +121,12 @@ jobs:
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
       - run: gh release edit ${{ github.ref_name }} --draft=false
         if: ${{ github.event_name != 'workflow_dispatch' }}
+      - name: Enhance release notes with communique
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        continue-on-error: true
+        run: communique generate "${{ github.ref_name }}" --github-release
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
   # bump-homebrew-formula:
   #   runs-on: macos-latest
   #   needs: [release]


### PR DESCRIPTION
## Summary

- `communique generate --github-release` calls `GET /releases/tags/{tag}` to find the release to update
- That endpoint only returns published releases; draft releases return 404
- While the code has a fallback to `GET /releases?per_page=10` (which does include drafts), it ran within ~700ms of the draft being created — before GitHub's list API reflected it
- Moving communique to after `gh release edit --draft=false` guarantees the release is visible and eliminates the race entirely

Also fixes the related communique bug in `~/src/communique`: `Err(_) => Ok(None)` was silently swallowing list-endpoint errors, making the draft fallback fail invisibly.

## Test plan

- [ ] Trigger a tag push and verify communique successfully updates the release notes after it's published

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that reorders when release notes are generated; main risk is altering release automation timing/behavior if the post-publish step fails (it is `continue-on-error`).
> 
> **Overview**
> Moves the `communique generate --github-release` step out of the draft-release creation job and into the `release` job *after* `gh release edit --draft=false` (and only for non-`workflow_dispatch` runs).
> 
> This ensures release-note enhancement runs against a published release, avoiding race conditions where GitHub’s tag/release lookup APIs can’t find newly created drafts yet.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a7c6efc4392f33945c0e4aae6f299bc846d218c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->