### PR TITLE
feat(publish): extract communique into separate enhance-release job

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -121,10 +121,17 @@ jobs:
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
       - run: gh release edit ${{ github.ref_name }} --draft=false
         if: ${{ github.event_name != 'workflow_dispatch' }}
-      - name: Enhance release notes with communique
-        if: ${{ github.event_name != 'workflow_dispatch' }}
-        continue-on-error: true
-        run: communique generate "${{ github.ref_name }}" --github-release
+  enhance-release:
+    runs-on: ubuntu-latest
+    needs: [release]
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
+      - run: communique generate "${{ github.ref_name }}" --github-release
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
   # bump-homebrew-formula:


### PR DESCRIPTION
## Summary

- Moves `communique generate` out of the `release` job into a dedicated `enhance-release` job that runs after `release`
- Since it's a separate job, it can be re-run independently from the GitHub Actions UI if it fails (e.g. Anthropic rate limits, transient API errors)
- Runs after `gh release edit --draft=false` so the release is published and visible to communique

## Test plan

- [ ] Trigger a tag push and verify `enhance-release` appears as a separate job in the workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts GitHub Actions job orchestration; no application/runtime code changes, with the main risk being altered release workflow timing/dependencies.
> 
> **Overview**
> Moves release-note enhancement (`communique generate ... --github-release`) out of the release creation flow into a new `enhance-release` job that runs after `release`.
> 
> This makes the AI-backed release-notes step independent/re-runnable and ensures it runs against the published release (adds `fetch-depth: 0` to the checkout in that job).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 379d1d034d91573ead60e8aeb00fdf5206ad0206. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->