### PR TITLE
fix(lib): validate choices for variadic args and flags

### DIFF
--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -473,6 +473,20 @@ fn parse_partial_with_env(
             while let Some(flag) = out.flag_awaiting_value.pop() {
                 let arg = flag.arg.as_ref().unwrap();
                 if flag.var {
+                    if let Some(choices) = &arg.choices {
+                        if !choices.choices.contains(&w) {
+                            if is_help_arg(spec, &w) {
+                                out.errors
+                                    .push(render_help_err(spec, &out.cmd, w.len() > 2));
+                                return Ok(out);
+                            }
+                            bail!(
+                                "Invalid choice for option {}: {w}, expected one of {}",
+                                flag.name,
+                                choices.choices.join(", ")
+                            );
+                        }
+                    }
                     let arr = out
                         .flags
                         .entry(flag)
@@ -504,6 +518,20 @@ fn parse_partial_with_env(
 
         if let Some(arg) = next_arg {
             if arg.var {
+                if let Some(choices) = &arg.choices {
+                    if !choices.choices.contains(&w) {
+                        if is_help_arg(spec, &w) {
+                            out.errors
+                                .push(render_help_err(spec, &out.cmd, w.len() > 2));
+                            return Ok(out);
+                        }
+                        bail!(
+                            "Invalid choice for arg {}: {w}, expected one of {}",
+                            arg.name,
+                            choices.choices.join(", ")
+                        );
+                    }
+                }
                 let arr = out
                     .args
                     .entry(Arc::new(arg.clone()))

--- a/lib/tests/parse.rs
+++ b/lib/tests/parse.rs
@@ -258,6 +258,42 @@ variadic_arg_captures_unknown_short_flags:
     args="mydb -x localhost",
     expected=r#"{"usage_args": "-x localhost", "usage_database": "mydb"}"#,
 
+variadic_arg_choices_ok:
+    spec=r#"
+    arg "<level>" var=#true {
+        choices "debug" "info" "warn" "error"
+    }
+    "#,
+    args="debug info error",
+    expected=r#"{"usage_level": "debug info error"}"#,
+
+variadic_arg_choices_err:
+    spec=r#"
+    arg "<level>" var=#true {
+        choices "debug" "info" "warn" "error"
+    }
+    "#,
+    args="debug invalid error",
+    expected=r#"Invalid choice for arg level: invalid, expected one of debug, info, warn, error"#,
+
+variadic_flag_choices_ok:
+    spec=r#"
+    flag "-l --level <level>" var=#true {
+        choices "debug" "info" "warn" "error"
+    }
+    "#,
+    args="--level debug --level info --level error",
+    expected=r#"{"usage_level": "debug info error"}"#,
+
+variadic_flag_choices_err:
+    spec=r#"
+    flag "-l --level <level>" var=#true {
+        choices "debug" "info" "warn" "error"
+    }
+    "#,
+    args="--level debug --level invalid --level error",
+    expected=r#"Invalid choice for option level: invalid, expected one of debug, info, warn, error"#,
+
 //shell_escape_arg:
 //    spec=r#"
 //    arg "<vars>" shell_escape=#true


### PR DESCRIPTION
## Summary
- Variadic arguments and flags with `choices` were not being validated — any value was accepted
- Added choice validation to both variadic code paths (positional args and flags) in `parse.rs`, matching the existing non-variadic behavior
- Added 4 test cases covering valid and invalid choices for both variadic args and flags

Closes jdx/mise#8334

## Test plan
- [x] `cargo test -p usage-lib --test parse` — all 32 tests pass
- [x] `cargo clippy -p usage-lib --all-features -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to CLI parsing validation: variadic args/flags with `choices` now error where they previously accepted any value, which may affect callers relying on permissive behavior.
> 
> **Overview**
> Fixes a parsing gap where *variadic* positional args and *variadic* flag values (`var=true`) were not being validated against declared `choices`.
> 
> `parse.rs` now enforces `choices` for both variadic arg capture and variadic flag value capture, mirroring the existing non-variadic behavior (including `--help`/`-h` handling). Adds tests ensuring valid values pass and invalid values produce the expected error messages for both variadic args and flags.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88fbc18896939e1b5f6f616f53b573acf1aba52f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->