### PR TITLE
fix(bash,zsh): use >| to avoid noclobber errors in tab completion

### DIFF
--- a/cli/assets/completions/_usage
+++ b/cli/assets/completions/_usage
@@ -24,7 +24,7 @@ _usage() {
   fi
 
   local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_usage.spec"
-  usage --usage-spec > "$spec_file"
+  usage --usage-spec >| "$spec_file"
   _arguments "*: :(($(command usage complete-word --shell zsh -f "$spec_file" -- "${words[@]}" )))"
   return 0
 }

--- a/cli/assets/completions/usage.bash
+++ b/cli/assets/completions/usage.bash
@@ -10,7 +10,7 @@ _usage() {
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_usage.spec"
-    usage --usage-spec > "$spec_file"
+    usage --usage-spec >| "$spec_file"
     # shellcheck disable=SC2207
 	_comp_compgen -- -W "$(command usage complete-word --shell bash -f "$spec_file" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"

--- a/lib/src/complete/bash.rs
+++ b/lib/src/complete/bash.rs
@@ -35,15 +35,15 @@ pub fn complete_bash(opts: &CompleteOptions) -> String {
         if opts.cache_key.is_some() {
             format!(
                 r#"if [[ ! -f "$spec_file" ]]; then
-        {usage_cmd} > "$spec_file"
+        {usage_cmd} >| "$spec_file"
     fi"#
             )
         } else {
-            format!(r#"{usage_cmd} > "$spec_file""#)
+            format!(r#"{usage_cmd} >| "$spec_file""#)
         }
     } else if let Some(spec) = &opts.spec {
         let heredoc = format!(
-            r#"cat > "$spec_file" <<'__USAGE_EOF__'
+            r#"cat >| "$spec_file" <<'__USAGE_EOF__'
 {spec}
 __USAGE_EOF__"#,
             spec = spec.to_string().trim()

--- a/lib/src/complete/snapshots/usage__complete__bash__tests__complete_bash-2.snap
+++ b/lib/src/complete/snapshots/usage__complete__bash__tests__complete_bash-2.snap
@@ -15,7 +15,7 @@ _mycli() {
     _comp_initialize -n : -- "$@" || return
     local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mycli_1_2_3.spec"
     if [[ ! -f "$spec_file" ]]; then
-        mycli complete --usage > "$spec_file"
+        mycli complete --usage >| "$spec_file"
     fi
     # shellcheck disable=SC2207
 	_comp_compgen -- -W "$(command usage complete-word --shell bash -f "$spec_file" --cword="$cword" -- "${words[@]}")"

--- a/lib/src/complete/snapshots/usage__complete__bash__tests__complete_bash-3.snap
+++ b/lib/src/complete/snapshots/usage__complete__bash__tests__complete_bash-3.snap
@@ -14,7 +14,7 @@ _mycli() {
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mycli.spec"
-    cat > "$spec_file" <<'__USAGE_EOF__'
+    cat >| "$spec_file" <<'__USAGE_EOF__'
 name mycli
 bin mycli
 source_code_link_template "https://github.com/jdx/mise/blob/main/src/cli/{{path}}.rs"

--- a/lib/src/complete/snapshots/usage__complete__bash__tests__complete_bash.snap
+++ b/lib/src/complete/snapshots/usage__complete__bash__tests__complete_bash.snap
@@ -14,7 +14,7 @@ _mycli() {
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mycli.spec"
-    mycli complete --usage > "$spec_file"
+    mycli complete --usage >| "$spec_file"
     # shellcheck disable=SC2207
 	_comp_compgen -- -W "$(command usage complete-word --shell bash -f "$spec_file" --cword="$cword" -- "${words[@]}")"
 	_comp_ltrim_colon_completions "$cur"

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-2.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-2.snap
@@ -29,7 +29,7 @@ _mycli() {
 
   local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mycli_1_2_3.spec"
   if [[ ! -f "$spec_file" ]]; then
-    mycli complete --usage > "$spec_file"
+    mycli complete --usage >| "$spec_file"
   fi
   _arguments "*: :(($(command usage complete-word --shell zsh -f "$spec_file" -- "${words[@]}" )))"
   return 0

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-3.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-3.snap
@@ -18,7 +18,7 @@ _mycli() {
   fi
 
   local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mycli.spec"
-  cat > "$spec_file" <<'__USAGE_EOF__'
+  cat >| "$spec_file" <<'__USAGE_EOF__'
 name mycli
 bin mycli
 source_code_link_template "https://github.com/jdx/mise/blob/main/src/cli/{{path}}.rs"

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh.snap
@@ -28,7 +28,7 @@ _mycli() {
   fi
 
   local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mycli.spec"
-  mycli complete --usage > "$spec_file"
+  mycli complete --usage >| "$spec_file"
   _arguments "*: :(($(command usage complete-word --shell zsh -f "$spec_file" -- "${words[@]}" )))"
   return 0
 }

--- a/lib/src/complete/zsh.rs
+++ b/lib/src/complete/zsh.rs
@@ -56,15 +56,15 @@ _{bin_snake}() {{
         if opts.cache_key.is_some() {
             format!(
                 r#"if [[ ! -f "$spec_file" ]]; then
-    {usage_cmd} > "$spec_file"
+    {usage_cmd} >| "$spec_file"
   fi"#
             )
         } else {
-            format!(r#"{usage_cmd} > "$spec_file""#)
+            format!(r#"{usage_cmd} >| "$spec_file""#)
         }
     } else if let Some(spec) = &opts.spec {
         let heredoc = format!(
-            r#"cat > "$spec_file" <<'__USAGE_EOF__'
+            r#"cat >| "$spec_file" <<'__USAGE_EOF__'
 {spec}
 __USAGE_EOF__"#,
             spec = spec.to_string().trim()


### PR DESCRIPTION
The warning look like this:

```
            |<TAB>
bash-5.3$ hk bash: /var/folders/c4/dnywd0f132q_3328dwgy8sfr0000gn/T//usage__usage_spec_hk.spec: cannot overwrite existing file

builtins    cfg         completion  f           i           install     r           test        util        version
c           check       config      fix         init        migrate     run         uninstall   validate
```