### PR TITLE
docs: fix include syntax to match implementation

### DIFF
--- a/docs/spec/reference/index.md
+++ b/docs/spec/reference/index.md
@@ -27,7 +27,7 @@ example "mycli --version"
 // render a link to the source code in markdown docs
 source_code_link_template "https://github.com/me/myproj/blob/main/src/cli/{{path}}.rs"
 
-include "./my_overrides.usage.kdl" // include another spec, will be merged and override existing values
+include file="./my_overrides.usage.kdl" // include another spec, will be merged and override existing values
 ```
 
 ## Source Code Link Template


### PR DESCRIPTION
## Summary
- Fixes the `include` syntax in the spec reference docs to match the actual implementation
- Docs showed `include "./file.kdl"` but the parser expects `include file="./file.kdl"`

Closes #534

## Test plan
- [ ] Verify `usage lint` accepts the documented syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime code paths are modified.
> 
> **Overview**
> Aligns the spec reference documentation with the implemented `include` directive syntax by changing the example from `include "./file.kdl"` to `include file="./file.kdl"` in `docs/spec/reference/index.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0379e99677ebfd4f860e40a54ab5701d0de8e1ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->