### PR TITLE
docs: consolidate integration list to single source

### DIFF
--- a/integrations/README.md
+++ b/integrations/README.md
@@ -2,49 +2,7 @@
 
 Integrations that generate usage specs from CLI framework definitions, enabling shell completions, docs, and man pages from a single source.
 
-## Status
-
-- [x] **clap** (Rust) - [`clap_usage`](https://crates.io/crates/clap_usage) ~16k stars
-
-### High Priority
-
-- [x] **Cobra** (Go) - [`cobra_usage`](cobra/) ~43k stars
-- [ ] **Commander.js** (Node.js) - [tj/commander.js](https://github.com/tj/commander.js) ~28k stars
-- [ ] **urfave/cli** (Go) - [urfave/cli](https://github.com/urfave/cli) ~24k stars
-- [ ] **Typer** (Python) - [fastapi/typer](https://github.com/fastapi/typer) ~19k stars
-- [ ] **Click** (Python) - [pallets/click](https://github.com/pallets/click) ~17k stars
-- [ ] **argparse** (Python) - stdlib
-
-### Medium Priority
-
-- [ ] **yargs** (Node.js) - [yargs/yargs](https://github.com/yargs/yargs) ~11k stars
-- [ ] **Spectre.Console** (C#/.NET) - [spectreconsole/spectre.console](https://github.com/spectreconsole/spectre.console) ~11k stars
-- [ ] **Symfony Console** (PHP) - [symfony/console](https://github.com/symfony/console) ~10k stars
-- [ ] **oclif** (Node.js) - [oclif/oclif](https://github.com/oclif/oclif) ~9k stars
-- [ ] **picocli** (Java) - [remkop/picocli](https://github.com/remkop/picocli) ~5k stars
-- [ ] **Thor** (Ruby) - [rails/thor](https://github.com/rails/thor) ~5k stars
-- [ ] **cxxopts** (C++) - [jarro2783/cxxopts](https://github.com/jarro2783/cxxopts) ~5k stars
-- [ ] **CommandLineParser** (C#/.NET) - [commandlineparser/commandline](https://github.com/commandlineparser/commandline) ~5k stars
-- [ ] **CLI11** (C++) - [CLIUtils/CLI11](https://github.com/CLIUtils/CLI11) ~4k stars
-- [ ] **Laravel Zero** (PHP) - [laravel-zero/laravel-zero](https://github.com/laravel-zero/laravel-zero) ~4k stars
-- [ ] **swift-argument-parser** (Swift) - [apple/swift-argument-parser](https://github.com/apple/swift-argument-parser) ~4k stars
-- [ ] **System.CommandLine** (C#/.NET) - [dotnet/command-line-api](https://github.com/dotnet/command-line-api) ~4k stars
-
-### Lower Priority
-
-- [ ] **Kong** (Go) - [alecthomas/kong](https://github.com/alecthomas/kong) ~3k stars
-- [ ] **Clikt** (Kotlin) - [ajalt/clikt](https://github.com/ajalt/clikt) ~3k stars
-- [ ] **JCommander** (Java) - [cbeust/jcommander](https://github.com/cbeust/jcommander) ~2k stars
-- [ ] **argh** (Rust) - [google/argh](https://github.com/google/argh) ~2k stars
-- [ ] **zig-clap** (Zig) - [Hejsil/zig-clap](https://github.com/Hejsil/zig-clap) ~1.5k stars
-- [ ] **optparse-applicative** (Haskell) - [pcapriotti/optparse-applicative](https://github.com/pcapriotti/optparse-applicative) ~1k stars
-- [ ] **kotlinx-cli** (Kotlin) - [Kotlin/kotlinx-cli](https://github.com/Kotlin/kotlinx-cli) ~900 stars
-- [ ] **cligen** (Nim) - [c-blake/cligen](https://github.com/c-blake/cligen) ~560 stars
-- [ ] **argparse** (Lua) - [mpeterv/argparse](https://github.com/mpeterv/argparse) ~285 stars
-- [ ] **Getopt::Long** (Perl) - stdlib
-- [ ] **OptionParser** (Elixir) - stdlib
-- [ ] **OptionParser** (Ruby) - stdlib
-- [ ] **getopt** (C) - POSIX stdlib
+For the full list of available and planned integrations, see the [Integrations documentation](https://usage.jdx.dev/spec/integrations/).
 
 ## How Integrations Work
 


### PR DESCRIPTION
## Summary
- Replaces the duplicated integration list in `integrations/README.md` with a link to the canonical list at https://usage.jdx.dev/spec/integrations/
- Prevents the two lists from getting out of sync (as happened in #531)

Closes #535

## Test plan
- [ ] Verify the link resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that removes a duplicated list and adds an external link; main risk is link correctness/availability.
> 
> **Overview**
> Removes the long, duplicated checklist of planned/available integrations from `integrations/README.md` and replaces it with a single link to the canonical Integrations documentation page to keep the list in one place.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7f26ee23c178907ac46c21408c5975b01df8617. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->