### PR TITLE
docs: fix link to integrations

### DIFF
--- a/integrations/README.md
+++ b/integrations/README.md
@@ -2,7 +2,7 @@
 
 Integrations that generate usage specs from CLI framework definitions, enabling shell completions, docs, and man pages from a single source.
 
-For the full list of available and planned integrations, see the [Integrations documentation](https://usage.jdx.dev/spec/integrations/).
+For the full list of available and planned integrations, see the [Integrations documentation](https://usage.jdx.dev/spec/integrations).
 
 ## How Integrations Work
 


### PR DESCRIPTION
Somehow https://usage.jdx.dev/spec/integrations/ (with a trailing `/`) opens an empty doc page.