### PR TITLE
fix: bump major version for breaking changes in release automation

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -122,6 +122,10 @@ sort_commits = "oldest"
 # limit the number of commits included in the changelog.
 # limit_commits = 42
 
+[bump]
+# Detect breaking changes from conventional commit `!` marker and footer
+breaking_always_bump_major = true
+
 [remote.github]
 owner = "jdx"
 repo = "usage"


### PR DESCRIPTION
## Summary
- Adds `[bump]` section to `cliff.toml` with `breaking_always_bump_major = true`
- Without this, `git cliff --bumped-version` ignored the `!` breaking change indicator in conventional commits (e.g. `feat!(spec):`) and only bumped the minor version instead of major
- This caused the release PR #527 to incorrectly version as v2.18.3 instead of v3.0.0

## Test plan
- [ ] Verify `git cliff --bumped-version` returns a major bump when breaking commits exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a config-only change that affects release/changelog version bumping, with no runtime code paths impacted.
> 
> **Overview**
> Updates `cliff.toml` to add a `[bump]` configuration enabling `breaking_always_bump_major = true`, so `git cliff --bumped-version` treats conventional-commit breaking changes (e.g., `!`/footer) as a **major** version bump during release automation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc3395c9302eb1717d13c71276d66a8e125c73bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->