### PR TITLE
fix: add custom_major_increment_regex for breaking change detection

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -125,6 +125,8 @@ sort_commits = "oldest"
 [bump]
 # Detect breaking changes from conventional commit `!` marker and footer
 breaking_always_bump_major = true
+# Also match the `!` breaking change indicator in commit messages directly
+custom_major_increment_regex = "^(feat|fix|refactor|perf|chore|style|test|docs)(!|\\(.*\\)!):"
 
 [remote.github]
 owner = "jdx"


### PR DESCRIPTION
## Summary
- `breaking_always_bump_major` from #544 didn't work — `git cliff --bumped-version` still returned `v2.18.3` instead of `v3.0.0`
- Adds `custom_major_increment_regex` to explicitly match the `!` breaking change indicator in conventional commits (`feat!:`, `feat(scope)!:`, etc.)
- This is a belt-and-suspenders fix alongside `breaking_always_bump_major`

Follow-up to #544

## Test plan
- [ ] After merge, verify release automation updates PR #527 to v3.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that affects version bumping; main risk is unintended major bumps if the regex matches more commit messages than expected.
> 
> **Overview**
> **Adjusts git-cliff bumping behavior** to more reliably detect breaking changes from conventional commits.
> 
> Adds `custom_major_increment_regex` in `cliff.toml` to explicitly treat `feat!:` / `type(scope)!:` style messages as major-version increments, complementing `breaking_always_bump_major`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e77f510d7af21755ec48448f6d8509f4ddad5611. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->