### PR TITLE
fix: use field assignment for non-exhaustive Spec in benchmarks

### DIFF
--- a/lib/benches/parse.rs
+++ b/lib/benches/parse.rs
@@ -16,12 +16,11 @@ fn build_small_spec() -> Spec {
         .build();
     cmd.subcommands.insert("install".to_string(), install_cmd);
 
-    Spec {
-        name: "test".to_string(),
-        bin: "test".to_string(),
-        cmd,
-        ..Default::default()
-    }
+    let mut spec = Spec::default();
+    spec.name = "test".to_string();
+    spec.bin = "test".to_string();
+    spec.cmd = cmd;
+    spec
 }
 
 fn build_large_spec() -> Spec {
@@ -85,12 +84,11 @@ fn build_large_spec() -> Spec {
         .build();
     cmd.subcommands = subcommands;
 
-    Spec {
-        name: "bench".to_string(),
-        bin: "bench".to_string(),
-        cmd,
-        ..Default::default()
-    }
+    let mut spec = Spec::default();
+    spec.name = "bench".to_string();
+    spec.bin = "bench".to_string();
+    spec.cmd = cmd;
+    spec
 }
 
 fn bench_parse_small_spec(c: &mut Criterion) {


### PR DESCRIPTION
## Summary
- The `coverage` CI job fails with `E0639: cannot create non-exhaustive struct using struct expression` in `lib/benches/parse.rs`
- Benchmarks are compiled as separate crates, so `#[non_exhaustive]` on `Spec` prevents struct literal construction
- Fix: use `Spec::default()` with field assignment instead of struct literal syntax

## Test plan
- [x] `cargo build --benches` compiles successfully
- [ ] Coverage CI job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to benchmark setup code and only adjust `Spec` construction to compile with `#[non_exhaustive]` types.
> 
> **Overview**
> Fixes `lib/benches/parse.rs` to stop using `Spec { ..Default::default() }` struct literals (which fail for `#[non_exhaustive]` types when benches compile as a separate crate). Bench specs are now created with `Spec::default()` followed by explicit field assignment for `name`, `bin`, and `cmd`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3424dc5bae57f4cecdeaeaef7d5e2c77e139e5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->