### PR TITLE
feat(cli): render all doc-related fields in --help output

### DIFF
--- a/lib/src/docs/cli/mod.rs
+++ b/lib/src/docs/cli/mod.rs
@@ -207,4 +207,72 @@ example "testcli" header="Run normally" help="Just runs the tool"
             $ testcli
         ");
     }
+
+    #[test]
+    fn test_render_help_with_version() {
+        let spec = crate::spec! { r#"
+bin "testcli"
+name "TestCLI"
+version "1.2.3"
+flag "--verbose" help="Enable verbose output"
+        "# }
+        .unwrap();
+
+        assert_snapshot!(render_help(&spec, &spec.cmd, false), @r"
+        TestCLI 1.2.3
+        Usage: testcli [--verbose]
+
+        Flags:
+          --verbose  Enable verbose output
+        ");
+    }
+
+    #[test]
+    fn test_render_help_with_author_license() {
+        let spec = crate::spec! { r#"
+bin "testcli"
+author "Test Author"
+license "MIT"
+flag "--verbose" help="Enable verbose output"
+        "# }
+        .unwrap();
+
+        // Short help should not show author/license
+        assert_snapshot!(render_help(&spec, &spec.cmd, false), @r"
+        Usage: testcli [--verbose]
+
+        Flags:
+          --verbose  Enable verbose output
+        ");
+
+        // Long help should show author/license at the bottom
+        assert_snapshot!(render_help(&spec, &spec.cmd, true), @r"
+        Usage: testcli [--verbose]
+
+        Flags:
+          --verbose  Enable verbose output
+
+        Author: Test Author
+        License: MIT
+        ");
+    }
+
+    #[test]
+    fn test_render_help_with_deprecated_command() {
+        let spec = crate::spec! { r#"
+bin "testcli"
+cmd "old-cmd" help="Do something" deprecated="use new-cmd instead"
+cmd "new-cmd" help="Do something better"
+        "# }
+        .unwrap();
+
+        assert_snapshot!(render_help(&spec, &spec.cmd, false), @r"
+        Usage: testcli <SUBCOMMAND>
+
+        Commands:
+          new-cmd  Do something better
+          old-cmd [deprecated: use new-cmd instead]  Do something
+          help  Print this message or the help of the given subcommand(s)
+        ");
+    }
 }

--- a/lib/src/docs/cli/templates/spec_template_long.tera
+++ b/lib/src/docs/cli/templates/spec_template_long.tera
@@ -7,6 +7,9 @@
 {% elif spec.before_help %}{{ spec.before_help }}
 
 {% endif -%}
+{%- if spec.name and spec.version %}{{ spec.name }} {{ spec.version }}
+{% elif spec.version %}{{ spec.bin }} {{ spec.version }}
+{% endif -%}
 {%- if spec.about_long %}{{ spec.about_long }}
 
 {% elif spec.about %}{{ spec.about }}
@@ -19,6 +22,7 @@ Usage: {{ spec.bin ~ " " ~ cmd.usage | trim }}
 Commands:
 {%- for name, cmd in cmd.subcommands %}
   {{ cmd.usage | trim }}
+{%- if cmd.deprecated %} [deprecated: {{ cmd.deprecated }}]{%- endif %}
 {%- if cmd.aliases %} [aliases: {{ cmd.aliases | join(sep=", ") }}]{% endif %}
 {%- set help = cmd.help_long | default(value=cmd.help | default(value='')) %}
 {%- if help %}
@@ -121,4 +125,13 @@ Examples:
 {%- elif spec.after_help %}
 
 {{ spec.after_help }}
+{%- endif %}
+
+{%- if spec.author or spec.license %}
+{% if spec.author %}
+Author: {{ spec.author }}
+{%- endif %}
+{%- if spec.license %}
+License: {{ spec.license }}
+{%- endif %}
 {%- endif -%}

--- a/lib/src/docs/cli/templates/spec_template_short.tera
+++ b/lib/src/docs/cli/templates/spec_template_short.tera
@@ -3,6 +3,9 @@
 {% elif spec.before_help %}{{ spec.before_help }}
 
 {% endif -%}
+{%- if spec.name and spec.version %}{{ spec.name }} {{ spec.version }}
+{% elif spec.version %}{{ spec.bin }} {{ spec.version }}
+{% endif -%}
 {%- if spec.about %}{{ spec.about }}
 
 {% endif -%}
@@ -13,6 +16,7 @@ Usage: {{ spec.bin ~ " " ~ cmd.usage | trim }}
 Commands:
 {%- for name, cmd in cmd.subcommands %}
   {{ cmd.usage | trim }}
+{%- if cmd.deprecated %} [deprecated: {{ cmd.deprecated }}]{%- endif %}
 {%- if cmd.aliases %} [aliases: {{ cmd.aliases | join(sep=", ") }}]{% endif %}
 {%- if cmd.help %}  {{ cmd.help }}{%- endif %}
 {%- endfor %}


### PR DESCRIPTION
## Summary
- Renders `before_help`, `after_help`, `before_help_long`, `after_help_long` in CLI `-h`/`--help` output
- Shows `name` + `version` header at the top of help output
- Shows `author` and `license` in the long help (`--help`) footer
- Shows `[deprecated: reason]` marker on subcommands
- Renders `examples` with headers, help text, and `$`-prefixed commands
- Short help (`-h`) uses base variants; long help (`--help`) prefers `_long` variants with fallback

Closes #549

## Test plan
- [x] Tests for `before_help`/`after_help` rendering (short and long)
- [x] Tests for `before_help_long`/`after_help_long` fallback behavior
- [x] Tests for examples rendering (short and long, with headers and help text)
- [x] Tests for `version` header display
- [x] Tests for `author`/`license` in long help footer
- [x] Tests for `deprecated` marker on subcommands
- [x] All existing tests pass (`cargo test --all --all-features`)
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CLI `--help`/`-h` rendering templates and snapshot tests, affecting formatting/output only.
> 
> **Overview**
> **Help output is expanded** to render `before_help`/`after_help` (with `_long` variants preferred for `--help`), plus an `Examples` section sourced from command- or spec-level examples.
> 
> The templates now also show name+version headers, annotate deprecated subcommands with `[deprecated: ...]`, and include author/license lines in long help. Snapshot tests were added/updated to cover the new rendering behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2967cc4060772d6d0fa7d34a50df8aa22f9ed69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->