### PR TITLE
docs: add linux optional packages to aube lock

### DIFF
--- a/aube-lock.yaml
+++ b/aube-lock.yaml
@@ -32,6 +32,15 @@ time:
   "@esbuild/darwin-arm64@0.21.5": 2024-06-09T21:17:13.758Z
   "@esbuild/darwin-arm64@0.23.1": 2024-08-16T22:13:33.762Z
   "@esbuild/darwin-arm64@0.24.2": 2024-12-20T17:56:13.272Z
+  "@esbuild/darwin-x64@0.21.5": 2024-06-09T21:17:00.976Z
+  "@esbuild/darwin-x64@0.23.1": 2024-08-16T22:13:19.973Z
+  "@esbuild/darwin-x64@0.24.2": 2024-12-20T17:56:14.010Z
+  "@esbuild/linux-arm64@0.21.5": 2024-06-09T21:17:23.384Z
+  "@esbuild/linux-arm64@0.23.1": 2024-08-16T22:13:43.777Z
+  "@esbuild/linux-arm64@0.24.2": 2024-12-20T17:57:17.541Z
+  "@esbuild/linux-x64@0.21.5": 2024-06-09T21:17:15.111Z
+  "@esbuild/linux-x64@0.23.1": 2024-08-16T22:13:33.535Z
+  "@esbuild/linux-x64@0.24.2": 2024-12-20T17:56:52.550Z
   "@eslint-community/eslint-utils@4.9.1": 2025-12-31T14:49:52.066Z
   "@eslint-community/regexpp@4.12.2": 2025-10-22T11:56:00.818Z
   "@eslint/config-array@0.23.5": 2026-04-08T09:22:37.796Z
@@ -57,6 +66,11 @@ time:
   "@nodelib/fs.stat@2.0.5": 2021-06-04T07:43:20.317Z
   "@nodelib/fs.walk@1.2.8": 2021-07-08T18:41:05.552Z
   "@rollup/rollup-darwin-arm64@4.60.2": 2026-04-18T13:58:27.555Z
+  "@rollup/rollup-darwin-x64@4.60.2": 2026-04-18T13:59:28.701Z
+  "@rollup/rollup-linux-arm64-gnu@4.60.2": 2026-04-18T13:58:41.555Z
+  "@rollup/rollup-linux-arm64-musl@4.60.2": 2026-04-18T13:58:45.162Z
+  "@rollup/rollup-linux-x64-gnu@4.60.2": 2026-04-18T13:59:43.183Z
+  "@rollup/rollup-linux-x64-musl@4.60.2": 2026-04-18T13:59:46.857Z
   "@shikijs/core@2.5.0": 2025-02-18T09:10:12.142Z
   "@shikijs/engine-javascript@2.5.0": 2025-02-18T09:09:26.369Z
   "@shikijs/engine-oniguruma@2.5.0": 2025-02-18T09:09:33.593Z
@@ -481,6 +495,69 @@ packages:
       - darwin
     cpu:
       - arm64
+  "@esbuild/darwin-x64@0.21.5":
+    resolution:
+      integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==
+    os:
+      - darwin
+    cpu:
+      - x64
+  "@esbuild/darwin-x64@0.23.1":
+    resolution:
+      integrity: sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==
+    os:
+      - darwin
+    cpu:
+      - x64
+  "@esbuild/darwin-x64@0.24.2":
+    resolution:
+      integrity: sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==
+    os:
+      - darwin
+    cpu:
+      - x64
+  "@esbuild/linux-arm64@0.21.5":
+    resolution:
+      integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==
+    os:
+      - linux
+    cpu:
+      - arm64
+  "@esbuild/linux-arm64@0.23.1":
+    resolution:
+      integrity: sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==
+    os:
+      - linux
+    cpu:
+      - arm64
+  "@esbuild/linux-arm64@0.24.2":
+    resolution:
+      integrity: sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==
+    os:
+      - linux
+    cpu:
+      - arm64
+  "@esbuild/linux-x64@0.21.5":
+    resolution:
+      integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==
+    os:
+      - linux
+    cpu:
+      - x64
+  "@esbuild/linux-x64@0.23.1":
+    resolution:
+      integrity: sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==
+    os:
+      - linux
+    cpu:
+      - x64
+  "@esbuild/linux-x64@0.24.2":
+    resolution:
+      integrity: sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==
+    os:
+      - linux
+    cpu:
+      - x64
   "@eslint-community/eslint-utils@4.9.1":
     resolution:
       integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==
@@ -569,6 +646,49 @@ packages:
       - darwin
     cpu:
       - arm64
+  "@rollup/rollup-darwin-x64@4.60.2":
+    resolution:
+      integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==
+    os:
+      - darwin
+    cpu:
+      - x64
+  "@rollup/rollup-linux-arm64-gnu@4.60.2":
+    resolution:
+      integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==
+    os:
+      - linux
+    cpu:
+      - arm64
+    libc:
+      - glibc
+  "@rollup/rollup-linux-arm64-musl@4.60.2":
+    resolution:
+      integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==
+    os:
+      - linux
+    cpu:
+      - arm64
+    libc:
+      - musl
+  "@rollup/rollup-linux-x64-gnu@4.60.2":
+    resolution:
+      integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==
+    os:
+      - linux
+    cpu:
+      - x64
+    libc:
+      - glibc
+  "@rollup/rollup-linux-x64-musl@4.60.2":
+    resolution:
+      integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==
+    os:
+      - linux
+    cpu:
+      - x64
+    libc:
+      - musl
   "@shikijs/core@2.5.0":
     resolution:
       integrity: sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==
@@ -1488,6 +1608,15 @@ snapshots:
   "@esbuild/darwin-arm64@0.21.5": {}
   "@esbuild/darwin-arm64@0.23.1": {}
   "@esbuild/darwin-arm64@0.24.2": {}
+  "@esbuild/darwin-x64@0.21.5": {}
+  "@esbuild/darwin-x64@0.23.1": {}
+  "@esbuild/darwin-x64@0.24.2": {}
+  "@esbuild/linux-arm64@0.21.5": {}
+  "@esbuild/linux-arm64@0.23.1": {}
+  "@esbuild/linux-arm64@0.24.2": {}
+  "@esbuild/linux-x64@0.21.5": {}
+  "@esbuild/linux-x64@0.23.1": {}
+  "@esbuild/linux-x64@0.24.2": {}
   "@eslint-community/eslint-utils@4.9.1(eslint@10.2.1)":
     dependencies:
       eslint: 10.2.1
@@ -1557,6 +1686,11 @@ snapshots:
       "@nodelib/fs.scandir": 2.1.5
       fastq: 1.20.1
   "@rollup/rollup-darwin-arm64@4.60.2": {}
+  "@rollup/rollup-darwin-x64@4.60.2": {}
+  "@rollup/rollup-linux-arm64-gnu@4.60.2": {}
+  "@rollup/rollup-linux-arm64-musl@4.60.2": {}
+  "@rollup/rollup-linux-x64-gnu@4.60.2": {}
+  "@rollup/rollup-linux-x64-musl@4.60.2": {}
   "@shikijs/core@2.5.0":
     dependencies:
       "@shikijs/engine-javascript": 2.5.0
@@ -1866,12 +2000,21 @@ snapshots:
   esbuild@0.21.5:
     optionalDependencies:
       "@esbuild/darwin-arm64": 0.21.5
+      "@esbuild/darwin-x64": 0.21.5
+      "@esbuild/linux-arm64": 0.21.5
+      "@esbuild/linux-x64": 0.21.5
   esbuild@0.23.1:
     optionalDependencies:
       "@esbuild/darwin-arm64": 0.23.1
+      "@esbuild/darwin-x64": 0.23.1
+      "@esbuild/linux-arm64": 0.23.1
+      "@esbuild/linux-x64": 0.23.1
   esbuild@0.24.2:
     optionalDependencies:
       "@esbuild/darwin-arm64": 0.24.2
+      "@esbuild/darwin-x64": 0.24.2
+      "@esbuild/linux-arm64": 0.24.2
+      "@esbuild/linux-x64": 0.24.2
   escalade@3.2.0: {}
   escape-string-regexp@4.0.0: {}
   eslint-plugin-compat@4.2.0(eslint@10.2.1):
@@ -2142,6 +2285,11 @@ snapshots:
       "@types/estree": 1.0.8
     optionalDependencies:
       "@rollup/rollup-darwin-arm64": 4.60.2
+      "@rollup/rollup-darwin-x64": 4.60.2
+      "@rollup/rollup-linux-arm64-gnu": 4.60.2
+      "@rollup/rollup-linux-arm64-musl": 4.60.2
+      "@rollup/rollup-linux-x64-gnu": 4.60.2
+      "@rollup/rollup-linux-x64-musl": 4.60.2
       fsevents: 2.3.3
   run-parallel@1.2.0:
     dependencies:

--- a/package.json
+++ b/package.json
@@ -12,6 +12,22 @@
   "dependencies": {
     "vitepress": "1.6.4"
   },
+  "pnpm": {
+    "supportedArchitectures": {
+      "os": [
+        "current",
+        "linux"
+      ],
+      "cpu": [
+        "current",
+        "x64"
+      ],
+      "libc": [
+        "current",
+        "glibc"
+      ]
+    }
+  },
   "prettier": {
     "trailingComma": "es5",
     "printWidth": 80


### PR DESCRIPTION
## Summary
- add pnpm.supportedArchitectures so aube resolves docs dependencies for macOS and Linux targets
- refresh aube-lock.yaml with Linux Rollup/esbuild optional native packages

## Root cause
The Pages build on main failed during `aube run docs:build` because Rollup could not resolve `@rollup/rollup-linux-x64-gnu`. The lockfile generated on macOS only contained the Darwin Rollup optional package, so the Linux runner installed a graph without Rollup's Linux native package.

## Validation
- `mise x aube@latest -- aube install --lockfile-only --force`
- `rm -rf node_modules && mise x node@24 aube@latest -- aube install && mise x node@24 aube@latest -- aube run docs:build`
- pre-commit hook ran `cargo build --all`, `cargo insta test --accept`, generated docs/completions, and Prettier during commit

Failing job inspected: https://github.com/jdx/usage/actions/runs/24634632439/job/72027785367

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to pnpm configuration and lockfile updates to ensure platform-specific optional native packages resolve on Linux CI.
> 
> **Overview**
> Fixes Linux CI docs builds by teaching pnpm to resolve dependencies for Linux in addition to the current platform via `pnpm.supportedArchitectures` in `package.json`.
> 
> Refreshes `aube-lock.yaml` to include the missing platform-specific optional native packages (notably Rollup and esbuild Linux/Darwin variants) so `aube run docs:build` succeeds on Linux runners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c55828c1a035de86def4030e292e8b4f800c93d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->