### PR TITLE
fix(zsh): escape values without descriptions

### DIFF
--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -59,8 +59,8 @@ impl CompleteWord {
                     }
                 }
                 "zsh" => {
+                    let c = zsh_escape(&c);
                     if any_descriptions {
-                        let c = zsh_escape(&c);
                         let description = zsh_escape(&description);
                         println!("{c}:{description}")
                     } else {

--- a/cli/tests/complete_word.rs
+++ b/cli/tests/complete_word.rs
@@ -302,6 +302,13 @@ fn complete_word_zsh_escapes_parens_and_brackets() {
     );
 }
 
+#[test]
+fn complete_word_zsh_escapes_colons_without_descriptions() {
+    let mut c = cmd("zsh-colons-without-descriptions.usage.kdl", Some("zsh"));
+    c.args(["--", "run", ""]);
+    c.assert().success().stdout("test\\:git\ntest\\:nvim\n");
+}
+
 fn cmd(example: &str, shell: Option<&str>) -> Command {
     let mut cmd = Command::new(cargo::cargo_bin!("usage"));
     cmd.args(["cw"]);

--- a/examples/zsh-colons-without-descriptions.usage.kdl
+++ b/examples/zsh-colons-without-descriptions.usage.kdl
@@ -1,0 +1,5 @@
+cmd "run" {
+    arg "<task>" {
+        choices "test:git" "test:nvim"
+    }
+}


### PR DESCRIPTION
Usage v3.1.0 introduced a regression in zsh completion.  Nested tasks without descriptions would fail to complete.

```text
❯ fd . mise/tasks
mise/tasks/test/
mise/tasks/test/git.sh
mise/tasks/test/nvim.sh

# When the files lack a #MISE description=""
❯ command usage complete-word --shell zsh -f /var/folders/8s/74f40sh52hq66ghhh3c39tz80000gn/T/usage__usage_spec_mise_2026_4_18.spec -- mise run te
test:git
test:nvim

# When the files contain a #MISE description=""
❯ command usage complete-word --shell zsh -f /var/folders/8s/74f40sh52hq66ghhh3c39tz80000gn/T/usage__usage_spec_mise_2026_4_18.spec -- mise run te
test\:git:run git tests
test\:nvim:run nvim tests

```

Commit ae67b383cbbbd2e529af5d52af9fadf23f4d6606 switched zsh completions to `_describe`, but it only escaped completion values when any descriptions were present.  This meant zsh treated nested tasks as descriptions (e.g. in `test:git`, "git" is interpreted as the description of the item "test").

This PR fixes the issue by always escaping zsh candidates so values like `test:git` remain valid `_describe` entries even when no description is emitted.

See: https://github.com/zsh-users/zsh-completions/blob/master/zsh-completions-howto.org#writing-simple-completion-functions-using-_describe
