### PR TITLE
chore(release): append en.dev sponsor blurb to release notes

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -134,6 +134,23 @@ jobs:
       - run: communique generate "${{ github.ref_name }}" --github-release
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      - name: Append en.dev sponsor blurb
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          {
+            gh release view "$TAG" --json body --jq .body
+            cat <<'EOF'
+
+          ## 💚 Sponsor usage
+
+          usage is built by [@jdx](https://github.com/jdx) at [**en.dev**](https://en.dev) — an independent developer-tooling studio behind [mise](https://mise.jdx.dev/), [aube](https://aube.en.dev/), hk, and more. Work on usage is funded by sponsorships.
+
+          If `usage` powers CLI specs, docs, or completions for a tool you maintain or use, please consider [sponsoring at en.dev](https://en.dev). Every sponsorship helps the project stay independent and moving.
+          EOF
+          } > /tmp/release-notes.md
+          gh release edit "$TAG" --notes-file /tmp/release-notes.md
   # bump-homebrew-formula:
   #   runs-on: macos-latest
   #   needs: [release]


### PR DESCRIPTION
## Summary

- Appends a **Sponsor usage** section to every GitHub Release body, run after `communique generate` in the `enhance-release` job in [`.github/workflows/publish-cli.yml`](.github/workflows/publish-cli.yml).
- Same pattern as [mise#9272](https://github.com/jdx/mise/pull/9272), adapted for usage.

## What it looks like

Rendered at the bottom of each release body:

> ## 💚 Sponsor usage
>
> usage is built by [@jdx](https://github.com/jdx) at [**en.dev**](https://en.dev) — an independent developer-tooling studio behind [mise](https://mise.jdx.dev/), [aube](https://aube.en.dev/), hk, and more. Work on usage is funded by sponsorships.
>
> If \`usage\` powers CLI specs, docs, or completions for a tool you maintain or use, please consider [sponsoring at en.dev](https://en.dev). Every sponsorship helps the project stay independent and moving.

## Test plan

- [x] \`actionlint\` + \`yamllint\` pass on the modified workflow
- [ ] Next tagged release produces a GitHub Release whose body ends with the sponsor section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts the GitHub Actions release workflow to post-process release notes; no runtime or security-sensitive application code changes.
> 
> **Overview**
> After `communique generate` runs in the `enhance-release` job, the workflow now *edits the GitHub Release body* to append a **“Sponsor usage”** section.
> 
> This is implemented by fetching the current release body via `gh release view`, concatenating the sponsor blurb, and updating the release with `gh release edit --notes-file`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1de688b36a08f336e5f8828435d6acee76f480f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->