### PR TITLE
docs: fix banner dark-mode contrast

### DIFF
--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -9,7 +9,7 @@
   align-items: center;
   justify-content: center;
   padding: 0.5rem 2.75rem;
-  background: var(--vp-c-brand-1, #3451b2);
+  background: #3451b2;
   color: #fff;
   font-size: 0.9rem;
   line-height: 1.4;


### PR DESCRIPTION
## Summary
White banner text was unreadable in dark mode because VitePress inverts \`--vp-c-brand-1\` per theme:
- Light mode: \`#3451b2\` (dark indigo) \u2014 white text reads fine
- Dark mode: \`#a8b1ff\` (light lavender) \u2014 white text is nearly invisible

Hardcode the banner bg to \`#3451b2\` so it stays dark with white text in both themes.

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single CSS tweak hardcodes the banner background color to avoid theme-variable inversion; no logic or data flow changes.
> 
> **Overview**
> For the docs site announcement banner, the background color is now hardcoded to `#3451b2` instead of using `var(--vp-c-brand-1)`, keeping white banner text readable in dark mode as well as light mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fa2bc13af37bb91918ac752d5fc163f9ef39f22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->