### PR TITLE
docs: respect banner expires field

### DIFF
--- a/docs/.vitepress/theme/banner.ts
+++ b/docs/.vitepress/theme/banner.ts
@@ -6,6 +6,7 @@ interface BannerData {
   message: string;
   link?: string;
   linkText?: string;
+  expires?: string;
 }
 
 const ENDPOINT = "https://jdx.dev/banner.json";
@@ -17,10 +18,18 @@ export function initBanner(): void {
     .then((r) => (r.ok ? (r.json() as Promise<BannerData>) : null))
     .then((b) => {
       if (!b || !b.enabled) return;
+      if (isExpired(b.expires)) return;
       if (localStorage.getItem(STORAGE_KEY) === b.id) return;
       render(b);
     })
     .catch(() => {});
+}
+
+function isExpired(expires: string | undefined): boolean {
+  if (!expires) return false;
+  const t = Date.parse(expires);
+  if (Number.isNaN(t)) return false;
+  return Date.now() >= t;
 }
 
 function isHttpUrl(value: string): boolean {


### PR DESCRIPTION
## Summary
- Honors the new optional `expires` (ISO-8601) field in [jdx.dev/banner.json](https://jdx.dev/banner.json)
- Banner is hidden once `Date.now() >= Date.parse(expires)`
- No-op when `expires` is absent (preserves existing behavior)
- Requires [jdx/blog#65](https://github.com/jdx/blog/pull/65) to populate the field

## Test plan
- [ ] Set an `expires` in the past → banner hidden
- [ ] Set an `expires` in the future → banner shown
- [ ] No `expires` field → banner shown as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, client-side docs banner change that only gates rendering based on an optional timestamp; no auth or data writes beyond existing localStorage usage.
> 
> **Overview**
> Adds support for an optional `expires` field in `banner.json` so the docs site announcement banner will **not render once the timestamp has passed**.
> 
> Introduces `isExpired()` to safely parse the date (treating missing/invalid values as non-expired) and checks it during `initBanner()` before calling `render()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b64256d6eb73728dbeec1003b61f9d8b165ef113. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->