### PR TITLE
chore(deps): bump communique to 1.1.2

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -120,40 +120,39 @@ version = "2.12.0"
 backend = "cargo:git-cliff"
 
 [[tools.communique]]
-version = "0.1.7"
+version = "1.1.2"
 backend = "github:jdx/communique"
 
 [tools.communique."platforms.linux-arm64"]
-checksum = "sha256:0342c8f422a4bbbe47d43ab7b3373e39d081ea59969e3f24c8502c9282d38652"
-url = "https://github.com/jdx/communique/releases/download/v0.1.7/communique-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/357395421"
+checksum = "sha256:7bb0843207fc3d7b5df2a5c0198bb10539cf13a6b247b4adfbf6b302a68f03de"
+url = "https://github.com/jdx/communique/releases/download/v1.1.2/communique-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/405964161"
 
 [tools.communique."platforms.linux-arm64-musl"]
-checksum = "sha256:0342c8f422a4bbbe47d43ab7b3373e39d081ea59969e3f24c8502c9282d38652"
-url = "https://github.com/jdx/communique/releases/download/v0.1.7/communique-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/357395421"
+checksum = "sha256:b663407be77a370c209df40307b82e436f56a6bc23d4e423510d62ac6e1fedf4"
+url = "https://github.com/jdx/communique/releases/download/v1.1.2/communique-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/405964743"
 
 [tools.communique."platforms.linux-x64"]
-checksum = "sha256:8719b28e79e4cd68dec859b70645ca116d0eb1eac3aff1ee0774af413adcf3f7"
-url = "https://github.com/jdx/communique/releases/download/v0.1.7/communique-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/357395232"
+checksum = "sha256:5e74ead7037f42940c7dba4f6aa4ed968920cbb55a047aa0d291b0c675c65676"
+url = "https://github.com/jdx/communique/releases/download/v1.1.2/communique-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/405963914"
 provenance = "github-attestations"
 
 [tools.communique."platforms.linux-x64-musl"]
-checksum = "sha256:8719b28e79e4cd68dec859b70645ca116d0eb1eac3aff1ee0774af413adcf3f7"
-url = "https://github.com/jdx/communique/releases/download/v0.1.7/communique-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/357395232"
+checksum = "sha256:01a6a8b49e635a5a209fdaf6c7b2e976374debc2db1c846c033f567fdba0d86c"
+url = "https://github.com/jdx/communique/releases/download/v1.1.2/communique-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/405964691"
 
 [tools.communique."platforms.macos-arm64"]
-checksum = "sha256:658704fcd390e8766da4dbf508c5fea5f4f643fbe2fcfe5f972beae4cb128cd8"
-url = "https://github.com/jdx/communique/releases/download/v0.1.7/communique-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/357395448"
+checksum = "sha256:459993e31a6c4ccbd09882f5679a2bc1ea5d9068701ecefc411a00fb69ce82e6"
+url = "https://github.com/jdx/communique/releases/download/v1.1.2/communique-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/405964098"
 
 [tools.communique."platforms.windows-x64"]
-checksum = "sha256:6faff65312e9e49ae7646672621a9153e72846095021b51a58fd252062998f27"
-url = "https://github.com/jdx/communique/releases/download/v0.1.7/communique-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/communique/releases/assets/357395940"
-
+checksum = "sha256:3cc0e880ac2168aed3163223627bbd1eee62e07a9901cb85cb507c6c8927bc93"
+url = "https://github.com/jdx/communique/releases/download/v1.1.2/communique-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/communique/releases/assets/405964430"
 [[tools.gh]]
 version = "2.86.0"
 backend = "aqua:cli/cli"

--- a/mise.lock
+++ b/mise.lock
@@ -153,6 +153,7 @@ url_api = "https://api.github.com/repos/jdx/communique/releases/assets/405964098
 checksum = "sha256:3cc0e880ac2168aed3163223627bbd1eee62e07a9901cb85cb507c6c8927bc93"
 url = "https://github.com/jdx/communique/releases/download/v1.1.2/communique-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/jdx/communique/releases/assets/405964430"
+
 [[tools.gh]]
 version = "2.86.0"
 backend = "aqua:cli/cli"


### PR DESCRIPTION
## Summary
- update the communique mise lock entry to v1.1.2
- refresh release asset URLs and checksums, including musl assets

## Validation
- monitored jdx/communique release workflow 24960017639 to success
- `mise install --locked communique`
- usage pre-commit hooks ran during commit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates the `mise.lock` entry for the `communique` tool (version/asset URLs/checksums) and does not change application/runtime code.
> 
> **Overview**
> Bumps the `communique` tool in `mise.lock` from `0.1.7` to `1.1.2`, refreshing the pinned release asset URLs, GitHub asset IDs, and checksums across supported platforms (including *musl* builds).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9a26be6c660f40ca3d09fae634b280e689aa8b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->