### PR TITLE
docs: prefix star count with ★ glyph and populate it on deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,6 +36,8 @@ jobs:
       - name: Install dependencies
         run: aube install
       - name: Build with VitePress
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           aube run docs:build
           touch docs/.vitepress/dist/.nojekyll

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -369,6 +369,12 @@
   line-height: 1;
 }
 
+.VPSocialLinks .star-count .star-glyph {
+  font-family: -apple-system, "Segoe UI Symbol", sans-serif;
+  line-height: 1;
+  margin-right: 0.2em;
+}
+
 .VPSocialLinks a[href*="github.com/jdx/usage"]:hover .star-count {
   color: var(--vp-c-brand-1);
 }

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -30,8 +30,12 @@ export default {
           if (!githubLink.querySelector('.star-count')) {
             const starBadge = document.createElement('span')
             starBadge.className = 'star-count'
-            starBadge.textContent = starsData.stars
             starBadge.title = 'GitHub Stars'
+            const glyph = document.createElement('span')
+            glyph.className = 'star-glyph'
+            glyph.textContent = '★'
+            glyph.setAttribute('aria-hidden', 'true')
+            starBadge.append(glyph, starsData.stars)
             githubLink.appendChild(starBadge)
           }
         })


### PR DESCRIPTION
## Summary

Three small changes to the docs:

- **Wrap a ★ (U+2605) in a sans-serif `.star-glyph` span** before the count, so the badge reads "★ N" instead of just "N". Switching to sans-serif keeps the glyph crisp at 0.6rem — the mono digit font renders ★ as a smudge at this size.
- **Add CSS** for the new `.star-glyph` span.
- **Pass `GITHUB_TOKEN` to the VitePress build step.** Without it, the build-time data loader in `docs/.vitepress/stars.data.ts` falls back to 0 and returns an empty string, so the badge currently renders blank on the live site (curl-verified). With the token set, the loader can hit the GitHub API and populate the count.

## Test plan

- [ ] Merge → docs deploy runs → reload https://usage.jdx.dev/ → top-nav GitHub icon shows "★ N"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/CSS tweak plus a GitHub Actions env var change; main risk is only around the docs build step now relying on `GITHUB_TOKEN` for API calls/rate limits.
> 
> **Overview**
> Docs Pages builds now pass `GITHUB_TOKEN` into the VitePress build so the `stars.data` loader can successfully query the GitHub API and populate the star badge.
> 
> The GitHub social link star badge UI is updated to render as `★ N` by inserting a dedicated `.star-glyph` element and styling it with a sans-serif font for crisp rendering at small sizes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90998ab512b3fe8d34edb97d2fdbe75552c00999. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->