### PR TITLE
docs: add sponsor feed to docs

### DIFF
--- a/docs/.vitepress/theme/EndevSponsors.vue
+++ b/docs/.vitepress/theme/EndevSponsors.vue
@@ -1,0 +1,122 @@
+<template>
+  <section
+    v-if="sponsors.length"
+    aria-labelledby="endev-sponsors-title"
+    class="EndevSponsors"
+  >
+    <div class="EndevSponsorsInner">
+      <p id="endev-sponsors-title" class="EndevSponsorsTitle">
+        Company sponsors
+      </p>
+      <div class="EndevSponsorsLogos">
+        <a
+          v-for="sponsor in sponsors"
+          :key="sponsor.name"
+          :aria-label="sponsor.name"
+          class="EndevSponsorsLogo"
+          :href="sponsor.url"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <img :alt="sponsor.name" :src="sponsor.logo" />
+        </a>
+      </div>
+      <a class="EndevSponsorsCta" href="https://en.dev/#contact">
+        Sponsor the work
+      </a>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { onMounted, ref } from "vue";
+
+const sponsors = ref([]);
+
+onMounted(async () => {
+  try {
+    const res = await fetch("https://en.dev/sponsors.json", {
+      headers: { Accept: "application/json" },
+    });
+    if (!res.ok) return;
+
+    const payload = await res.json();
+    sponsors.value = (Array.isArray(payload.sponsors) ? payload.sponsors : [])
+      .filter((sponsor) =>
+        sponsor?.kind !== "infrastructure" &&
+        sponsor?.name &&
+        sponsor?.url &&
+        sponsor?.logo
+      );
+  } catch {
+    sponsors.value = [];
+  }
+});
+</script>
+
+<style scoped>
+.EndevSponsors {
+  border-top: 1px solid var(--vp-c-divider);
+  padding: 22px 24px;
+}
+
+.EndevSponsorsInner {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 18px;
+  justify-content: center;
+  margin: 0 auto;
+  max-width: 960px;
+}
+
+.EndevSponsorsTitle {
+  color: var(--vp-c-text-2);
+  font-size: 13px;
+  font-weight: 600;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.EndevSponsorsLogos {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+}
+
+.EndevSponsorsLogo {
+  align-items: center;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  display: inline-flex;
+  height: 40px;
+  justify-content: center;
+  padding: 8px 12px;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.EndevSponsorsLogo:hover {
+  background: var(--vp-c-bg-soft);
+  border-color: var(--vp-c-brand-1);
+}
+
+.EndevSponsorsLogo img {
+  display: block;
+  max-height: 22px;
+  max-width: 120px;
+}
+
+.EndevSponsorsCta {
+  color: var(--vp-c-text-2);
+  font-size: 13px;
+  font-weight: 500;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.EndevSponsorsCta:hover {
+  color: var(--vp-c-brand-1);
+}
+</style>

--- a/docs/.vitepress/theme/EndevSponsors.vue
+++ b/docs/.vitepress/theme/EndevSponsors.vue
@@ -47,7 +47,8 @@ const isSponsor = (sponsor) =>
   typeof sponsor.name === "string" &&
   typeof sponsor.url === "string" &&
   typeof sponsor.logo === "string" &&
-  isSafeUrl(sponsor.url);
+  isSafeUrl(sponsor.url) &&
+  isSafeUrl(sponsor.logo);
 
 onMounted(async () => {
   try {
@@ -58,7 +59,7 @@ onMounted(async () => {
 
     const payload = await res.json();
     sponsors.value = sponsorItems(payload?.sponsors).filter((sponsor) =>
-      sponsor.kind !== "infrastructure" && isSponsor(sponsor),
+      isSponsor(sponsor) && sponsor.kind !== "infrastructure",
     );
   } catch {
     sponsors.value = [];

--- a/docs/.vitepress/theme/EndevSponsors.vue
+++ b/docs/.vitepress/theme/EndevSponsors.vue
@@ -11,14 +11,13 @@
       <div class="EndevSponsorsLogos">
         <a
           v-for="sponsor in sponsors"
-          :key="sponsor.name"
-          :aria-label="sponsor.name"
+          :key="sponsor.url"
           class="EndevSponsorsLogo"
           :href="sponsor.url"
-          rel="noopener noreferrer"
+          rel="noopener noreferrer sponsored"
           target="_blank"
         >
-          <img :alt="sponsor.name" :src="sponsor.logo" />
+          <img :alt="sponsor.name" :src="sponsor.logo" loading="lazy" decoding="async" />
         </a>
       </div>
       <a class="EndevSponsorsCta" href="https://en.dev/#contact">
@@ -33,6 +32,23 @@ import { onMounted, ref } from "vue";
 
 const sponsors = ref([]);
 
+const sponsorItems = (items) => (Array.isArray(items) ? items : []);
+const isSafeUrl = (url) => {
+  try {
+    const { protocol } = new URL(url);
+    return protocol === "https:" || protocol === "http:";
+  } catch {
+    return false;
+  }
+};
+const isSponsor = (sponsor) =>
+  sponsor &&
+  typeof sponsor === "object" &&
+  typeof sponsor.name === "string" &&
+  typeof sponsor.url === "string" &&
+  typeof sponsor.logo === "string" &&
+  isSafeUrl(sponsor.url);
+
 onMounted(async () => {
   try {
     const res = await fetch("https://en.dev/sponsors.json", {
@@ -41,13 +57,9 @@ onMounted(async () => {
     if (!res.ok) return;
 
     const payload = await res.json();
-    sponsors.value = (Array.isArray(payload.sponsors) ? payload.sponsors : [])
-      .filter((sponsor) =>
-        sponsor?.kind !== "infrastructure" &&
-        sponsor?.name &&
-        sponsor?.url &&
-        sponsor?.logo
-      );
+    sponsors.value = sponsorItems(payload?.sponsors).filter((sponsor) =>
+      sponsor.kind !== "infrastructure" && isSponsor(sponsor),
+    );
   } catch {
     sponsors.value = [];
   }

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -2,6 +2,7 @@ import DefaultTheme from 'vitepress/theme'
 import { h, onMounted, onUnmounted } from 'vue'
 import UsageHero from './UsageHero.vue'
 import EndevFooter from './EndevFooter.vue'
+import EndevSponsors from './EndevSponsors.vue'
 import { initBanner } from './banner'
 import { data as starsData } from '../stars.data'
 import './custom.css'
@@ -11,7 +12,7 @@ export default {
   Layout() {
     return h(DefaultTheme.Layout, null, {
       'home-hero-before': () => h(UsageHero),
-      'layout-bottom': () => h(EndevFooter)
+      'layout-bottom': () => [h(EndevSponsors), h(EndevFooter)]
     })
   },
   enhanceApp() {


### PR DESCRIPTION
## Summary

Adds an en.dev company sponsor block to the docs footer.

## Changes

- Adds `EndevSponsors.vue`, which fetches `https://en.dev/sponsors.json` client-side.
- Renders the feed's default `sponsors` list, which is paid company sponsors only.
- Places the sponsor block above the existing en.dev footer.

## Validation

- `npm install --no-package-lock --ignore-scripts --legacy-peer-deps`
- `npm run docs:build`
- Commit hook also ran the repo's Rust checks/formatting before commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only UI that fetches public sponsor JSON with URL validation; no auth, runtime, or product logic changes.
> 
> **Overview**
> Adds a **company sponsors** strip to the VitePress docs layout, placed **above** the existing en.dev footer.
> 
> The new `EndevSponsors` block loads `https://en.dev/sponsors.json` in the browser after mount, keeps only paid company sponsors (excludes `kind: "infrastructure"`), and only renders links/images whose URLs pass basic http(s) checks. Failed fetches or empty lists hide the section entirely. A **Sponsor the work** link points to en.dev contact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0be89ac6670605ec543a7377575bb0c6449ad6c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a company sponsors section to the documentation site displaying sponsor logos with links and a call-to-action to support the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->