### PR TITLE
chore: switch analytics from gtm to plausible

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -129,15 +129,12 @@ export default defineConfig({
     ["meta", { name: "twitter:image", content: "https://usage.jdx.dev/android-chrome-512x512.png" }],
     [
       "script",
-      { async: "", src: "https://www.googletagmanager.com/gtag/js?id=G-63L7VEB1RB" }
-    ],
-    [
-      "script",
-      {},
-      `window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'G-63L7VEB1RB');`
+      {
+        defer: "",
+        "data-domain": "pa-9z3f-p-ATqjtilwc0InyS",
+        "data-api": "https://shrill.en.dev/f5f1/event",
+        src: "https://shrill.en.dev/shrill/script.js"
+      }
     ]
   ]
 });

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -131,7 +131,7 @@ export default defineConfig({
       "script",
       {
         defer: "",
-        "data-domain": "pa-9z3f-p-ATqjtilwc0InyS",
+        "data-domain": "usage.jdx.dev",
         "data-api": "https://shrill.en.dev/f5f1/event",
         src: "https://shrill.en.dev/shrill/script.js"
       }


### PR DESCRIPTION
## Summary

- Drops Google Tag Manager from the docs site
- Adds Plausible Analytics via the shrill.en.dev Cloudflare worker proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates a client-side analytics script in VitePress `head` metadata with no impact on core app logic or data handling beyond pageview tracking.
> 
> **Overview**
> Switches the docs site analytics integration in `docs/.vitepress/config.mts` by removing the inline Google Tag Manager/`gtag` setup and loading a deferred Plausible-style script instead.
> 
> The new script is configured via `data-domain` and a custom `data-api` endpoint pointing at the `shrill.en.dev` proxy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83af975b4e5a8001dbee25ae22caa8a40fca3485. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->