### PR TITLE
ci: pin taiki-e/install-action to commit SHA

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,7 @@ jobs:
       - run: rustup component add llvm-tools-preview --toolchain stable-x86_64-unknown-linux-gnu
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        uses: taiki-e/install-action@d79fce544138636ae8155ecac335f73c98e3b198 # cargo-llvm-cov
       - name: Generate code coverage
         run: mise run coverage
       - name: Upload coverage to Codecov


### PR DESCRIPTION
## Summary
- Pin `taiki-e/install-action@cargo-llvm-cov` to a full-length commit SHA in `coverage.yml`. The `cargo-llvm-cov` ref is a tool-alias tag the action's CI auto-bumps; SHA-pinning is required by org policy regardless.

## Test plan
- [ ] coverage workflow still installs cargo-llvm-cov and reports coverage on next push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that pins a GitHub Action to a specific commit; impact is limited to whether the coverage job can still install `cargo-llvm-cov`.
> 
> **Overview**
> Pins the coverage workflow’s `taiki-e/install-action` step for installing `cargo-llvm-cov` from the moving `@cargo-llvm-cov` ref to a specific commit SHA, improving supply-chain/CI determinism.
> 
> No other workflow behavior changes (coverage generation and Codecov upload remain the same).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 252557c8bf8e4d912581be9f4cde3811386ed787. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->