### PR TITLE
chore(docs): remove shrill.en.dev analytics script

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -126,15 +126,6 @@ export default defineConfig({
     ["meta", { property: "og:type", content: "website" }],
     ["meta", { property: "og:image", content: "https://usage.jdx.dev/android-chrome-512x512.png" }],
     ["meta", { name: "twitter:card", content: "summary" }],
-    ["meta", { name: "twitter:image", content: "https://usage.jdx.dev/android-chrome-512x512.png" }],
-    [
-      "script",
-      {
-        defer: "",
-        "data-domain": "usage.jdx.dev",
-        "data-api": "https://shrill.en.dev/f5f1/event",
-        src: "https://shrill.en.dev/shrill/script.js"
-      }
-    ]
+    ["meta", { name: "twitter:image", content: "https://usage.jdx.dev/android-chrome-512x512.png" }]
   ]
 });


### PR DESCRIPTION
Removes the proxied shrill.en.dev analytics snippet from the VitePress docs config — the endpoint is going away.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-site change; it only removes a third-party analytics script include and should not affect core functionality beyond stopping analytics events.
> 
> **Overview**
> Removes the `shrill.en.dev` analytics `<script>` (and its `data-domain`/`data-api` attributes) from the VitePress `head` config for the docs site, leaving only the existing OpenGraph/Twitter meta tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52c5f7e096b278ccd2a449280e5e17f9472990e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->