### PR TITLE
chore(ci): make sponsor blurb append idempotent

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -139,8 +139,16 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.ref_name }}
         run: |
+          # Strip any pre-existing sponsor section (e.g. one inserted by
+          # communique) and trailing blanks before appending the canonical
+          # block. Idempotent regardless of what's already in the body —
+          # avoids the duplicate-block bug seen in mise v2026.5.4.
           {
-            gh release view "$TAG" --json body --jq .body
+            gh release view "$TAG" --json body --jq .body | awk '
+              /^## .*Sponsor usage[[:space:]]*$/ { exit }
+              /^[[:space:]]*$/ { blanks++; next }
+              { while (blanks-- > 0) print ""; blanks = 0; print }
+            '
             cat <<'EOF'
 
           ## 💚 Sponsor usage


### PR DESCRIPTION
## Summary

The "Append en.dev sponsor blurb" step concatenates the GitHub release body with a heredoc'd canonical sponsor section unconditionally — there is no detection of an existing block.

**mise v2026.5.4** just shipped two `Sponsor mise` sections after `communique` started inserting its own `## Sponsor mise` block in the generated body. Fix: [jdx/mise#9745](https://github.com/jdx/mise/pull/9745); the release notes were edited by hand. `usage` uses the same append-without-detection pattern and would fail in the same way the next time `communique` decides to include a sponsor section.

## Fix

Pipe the fetched body through a small `awk` filter that drops any `## .*Sponsor usage` heading and everything after it, plus trailing blank lines, before appending the canonical block. Idempotent regardless of what's currently in the body. Matches the strip-and-reappend approach already used in `hk`, `fnox`, and `communique`.

## Test plan

Simulated against three shapes — a body with no sponsor section (today's case), a body containing `## Sponsor usage` from communique (the failure mode), and a body with trailing blank lines. Each produces exactly one `## 💚 Sponsor usage` block with one blank line of separation. `actionlint` is clean on the modified workflow.

- [ ] Next tagged release shows exactly one `## 💚 Sponsor usage` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that affects GitHub release note formatting; primary risk is accidentally truncating release notes if the `awk` pattern matches unexpected headings.
> 
> **Overview**
> Prevents duplicate sponsor sections in GitHub release notes by making the `Append en.dev sponsor blurb` step idempotent.
> 
> The workflow now filters the existing release body through an `awk` script that strips any prior `## .*Sponsor usage` block (and trailing blank lines) before appending the canonical sponsor blurb and updating the release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c884237a1fca90d51810e78f52d15d16070e1d14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->