### PR TITLE
fix(parse): don't split unknown --key=value into two positional args

### DIFF
--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -454,11 +454,11 @@ fn parse_partial_with_env(
         if enable_flags && w.starts_with("--") {
             grouped_flag = false;
             let (word, val) = w.split_once('=').unwrap_or_else(|| (&w, ""));
-            if !val.is_empty() {
-                input.push_front(val.to_string());
-            }
             if let Some(f) = out.available_flags.get(word) {
                 if f.arg.is_some() {
+                    if !val.is_empty() {
+                        input.push_front(val.to_string());
+                    }
                     out.flag_awaiting_value.push(Arc::clone(f));
                 } else if f.count {
                     let arr = out
@@ -1307,6 +1307,41 @@ mod tests {
                 assert_eq!(v.len(), 2);
                 assert_eq!(v[0], "file1.txt");
                 assert_eq!(v[1], "file2.txt");
+            }
+            _ => panic!("Expected MultiString, got {:?}", value),
+        }
+    }
+
+    #[test]
+    fn test_arg_var_true_unknown_long_eq_flag_not_split() {
+        // Regression: `--unknown=value` against a spec with only a variadic
+        // positional must be captured as a single arg, not split into
+        // `--unknown=value` plus a trailing `value`.
+        let cmd = SpecCommand::builder()
+            .name("test")
+            .arg(
+                SpecArg::builder()
+                    .name("args")
+                    .var(true)
+                    .required(false)
+                    .build(),
+            )
+            .build();
+        let spec = Spec {
+            name: "test".to_string(),
+            bin: "test".to_string(),
+            cmd,
+            ..Default::default()
+        };
+
+        let input = vec!["test".to_string(), "--depth=3".to_string()];
+        let parsed = parse(&spec, &input).unwrap();
+
+        assert_eq!(parsed.args.len(), 1);
+        let value = parsed.args.values().next().unwrap();
+        match value {
+            ParseValue::MultiString(v) => {
+                assert_eq!(v, &vec!["--depth=3".to_string()]);
             }
             _ => panic!("Expected MultiString, got {:?}", value),
         }


### PR DESCRIPTION
## Summary

When `--key=value` is parsed against a spec that doesn't declare `--key` as a flag (e.g. a passthrough wrapper using only `arg "[args]..." var=#true`), the value is duplicated: both `--key=value` and `value` end up in the variadic.

Minimal repro (mise task; same shape against the parser directly):

```toml
[tasks.minimal]
usage = '''
arg "[args]..." var=#true
'''
run = 'echo "RAW=<$usage_args>"'
```

```
$ mise run minimal -- --depth=3
RAW=<'--depth=3' 3>
```

## Cause

`lib/src/parse.rs:454-459` (pre-fix):

```rust
if enable_flags && w.starts_with("--") {
    grouped_flag = false;
    let (word, val) = w.split_once('=').unwrap_or_else(|| (&w, ""));
    if !val.is_empty() {
        input.push_front(val.to_string());   // pushed before checking
    }
    if let Some(f) = out.available_flags.get(word) {
        ...
        continue;
    }
    // falls through to positional parsing if --key isn't known
}
```

For `--depth=3` against a spec that only declares `[args]...`:

1. Split into `word=--depth`, `val=3`.
2. `3` is unconditionally pushed to the front of the input queue.
3. `--depth` is not in `available_flags` — the `continue` doesn't fire.
4. The original `--depth=3` token falls through and is consumed as a positional.
5. Next iteration pops `3` — also consumed as a positional.

The short-flag branch already gets this right: it only pushes the grouped-remainder back into the queue *inside* the `if let Some(f) = ...` block (line 489).

## Fix

Move the `push_front` inside the lookup block, and only push when the flag actually takes a value (`f.arg.is_some()`). Unknown `--key=value` tokens now pass through to positional parsing as a single token. Mirrors the short-flag pattern.

## Test plan

- [x] New regression test `test_arg_var_true_unknown_long_eq_flag_not_split` covering the variadic-only case
- [x] `cargo test` — all tests pass (177 lib + integration suites)
- [ ] End-to-end mise verification (requires rebuilding mise with patched usage) — not done; happy to do it if a maintainer wants the extra confirmation
