### PR TITLE
ci: remove caching from publishing workflows

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -27,10 +27,6 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          shared-key: test
-          save-if: false
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
         with:
           experimental: true


### PR DESCRIPTION
## Summary
- Strips cache actions (`nscloud-cache-action`, `Swatinem/rust-cache`, `actions/cache`) from release / release-plz / publishing workflows.
- These workflows have elevated permissions (write tokens, signing keys, registry credentials). Even with Namespace's protected-branches setting and GHA's ref-scoped cache enforcement, the simplest defense for the publishing surface is to not depend on any cache at all — builds re-run from clean each time.
- For mise's `release-plz.yml`, also removes the now-pointless sccache install/configure since it had no persistent backing store without the nscloud cache.

## Test plan
- [ ] Releases still build successfully (cold cache; expect slower but functional).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts GitHub Actions CI for publishing by removing the `Swatinem/rust-cache` step; main impact is slower cold builds but fewer cache-related supply-chain/permission concerns.
> 
> **Overview**
> The `release-plz` GitHub Actions workflow no longer uses `Swatinem/rust-cache`, so the release/publish job runs without any Rust build caching.
> 
> This reduces reliance on shared caches in a workflow that runs with write-level credentials, at the cost of potentially slower release builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a86d133c00574cf78dd703010051081647e8c552. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->