### PR TITLE
chore(ci): assert mise run render produces no diff

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,4 +35,13 @@ jobs:
           fi
       - run: mise r build
       - run: mise r test
+      - run: mise r render
+      - name: assert render produces no diff
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::'mise run render' produced changes. Run it locally and commit."
+            git status
+            git diff
+            exit 1
+          fi
       - run: mise r lint


### PR DESCRIPTION
Runs `mise run render` and asserts it produces no diff. Follows up the autofix.ci workflow removal in #631.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only change that adds a determinism check and may only cause new CI failures when generated artifacts are out of date.
> 
> **Overview**
> The `test` GitHub Actions workflow now runs `mise r render` and **fails the job if it changes the working tree**, printing `git status`/`git diff` to help diagnose missing generated-file commits.
> 
> This effectively enforces that render outputs are kept in sync and committed as part of PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a748d4d7a33cc74995674952c8d63cf3cc9302d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->