### PR TITLE
fix(nushell): use caret for invoking cmd in completion script

### DIFF
--- a/lib/src/complete/nu.rs
+++ b/lib/src/complete/nu.rs
@@ -31,11 +31,11 @@ pub fn complete_nu(opts: &CompleteOptions) -> String {
         if opts.cache_key.is_some() {
             format!(
                 r#"if not ($spec_file | path exists) {{
-            {usage_cmd} | collect | save $spec_file
+            ^{usage_cmd} | collect | save $spec_file
         }}"#
             )
         } else {
-            format!(r#"{usage_cmd} | collect | save -f $spec_file"#)
+            format!(r#"^{usage_cmd} | collect | save -f $spec_file"#)
         }
     } else if let Some(_spec) = &opts.spec {
         if opts.cache_key.is_some() {
@@ -57,7 +57,7 @@ pub fn complete_nu(opts: &CompleteOptions) -> String {
         let spec_file = $"($nu.temp-dir)/usage_{spec_variable}.spec"
         {file_write_logic}
 
-        ({usage_bin} complete-word -f $spec_file --shell nu -- ...$spans)
+        (^{usage_bin} complete-word -f $spec_file --shell nu -- ...$spans)
         | lines
         | each {{|it| $it | split column "\t" | rename value description | into record }}
     }}

--- a/lib/src/complete/snapshots/usage__complete__nu__tests__complete_nu-2.snap
+++ b/lib/src/complete/snapshots/usage__complete__nu__tests__complete_nu-2.snap
@@ -7,10 +7,10 @@ module _mycli_completions {
     def mycli_completer [spans: list<string>] {
         let spec_file = $"($nu.temp-dir)/usage__usage_spec_mycli_1_2_3.spec"
         if not ($spec_file | path exists) {
-            mycli complete --usage | collect | save $spec_file
+            ^mycli complete --usage | collect | save $spec_file
         }
 
-        (usage complete-word -f $spec_file --shell nu -- ...$spans)
+        (^usage complete-word -f $spec_file --shell nu -- ...$spans)
         | lines
         | each {|it| $it | split column "\t" | rename value description | into record }
     }

--- a/lib/src/complete/snapshots/usage__complete__nu__tests__complete_nu-3.snap
+++ b/lib/src/complete/snapshots/usage__complete__nu__tests__complete_nu-3.snap
@@ -43,7 +43,7 @@ cmd plugin {
         let spec_file = $"($nu.temp-dir)/usage__usage_spec_mycli.spec"
         $_usage_spec_mycli | save -f $spec_file
 
-        (usage complete-word -f $spec_file --shell nu -- ...$spans)
+        (^usage complete-word -f $spec_file --shell nu -- ...$spans)
         | lines
         | each {|it| $it | split column "\t" | rename value description | into record }
     }

--- a/lib/src/complete/snapshots/usage__complete__nu__tests__complete_nu.snap
+++ b/lib/src/complete/snapshots/usage__complete__nu__tests__complete_nu.snap
@@ -6,9 +6,9 @@ expression: "complete_nu(&CompleteOptions\n{\n    usage_bin: \"usage\".to_string
 module _mycli_completions {
     def mycli_completer [spans: list<string>] {
         let spec_file = $"($nu.temp-dir)/usage__usage_spec_mycli.spec"
-        mycli complete --usage | collect | save -f $spec_file
+        ^mycli complete --usage | collect | save -f $spec_file
 
-        (usage complete-word -f $spec_file --shell nu -- ...$spans)
+        (^usage complete-word -f $spec_file --shell nu -- ...$spans)
         | lines
         | each {|it| $it | split column "\t" | rename value description | into record }
     }


### PR DESCRIPTION
This PR modifies the nushell completion script to use caret for invoking commands. This fixes the following issue.

### Issue

The generated nushell completion script does not use [caret for invoking external commands](https://www.nushell.sh/book/running_externals.html) which causes the shell to interpret `{usage_cmd}` as a nushell function, producing an error.

#### Steps to reproduce

1. Add the following to `~/.config/nushell/config.nu`:

```nushell
 ^aube completion nu | save --force ($nu.data-dir | path join "vendor/autoload/aube.nu")
```

2. Load nushell and observe the error:

```
Error: nu::parser::extra_positional

  × Extra positional argument.
   ╭─[/Users/silvanshade/.local/share/nushell/vendor/autoload/aube.nu:6:18]
 5 │         if not ($spec_file | path exists) {
 6 │             aube usage | collect | save $spec_file
   ·                  ──┬──
   ·                    ╰── extra positional argument
 7 │         }
   ╰────
  help: Usage: aube
```
