### PR TITLE
chore(ci): add PR autocloser

### DIFF
--- a/.github/workflows/pr-closer.yml
+++ b/.github/workflows/pr-closer.yml
@@ -1,0 +1,54 @@
+name: pr-closer
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # daily at midnight
+  workflow_dispatch:
+
+concurrency:
+  group: pr-closer
+  cancel-in-progress: true
+
+jobs:
+  close-stale-prs:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      checks: read
+      statuses: read
+    steps:
+      - name: Close stale PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -o pipefail
+          CUTOFF=$(date -u -d '7 days ago' +%Y-%m-%d)
+          gh pr list -R "$REPO" --state open --search "updated:<$CUTOFF -author:jdx -label:keep-open draft:false" --json number,mergeStateStatus,statusCheckRollup --limit 500 | \
+          jq -r '
+            def failed_check:
+              (.statusCheckRollup | length > 0) and
+              ([.statusCheckRollup[] | ((.conclusion // .state // "") | ascii_upcase)] | any(. == "FAILURE" or . == "ERROR" or . == "TIMED_OUT" or . == "ACTION_REQUIRED"));
+
+            .[]
+            | failed_check as $failed
+            | ([.statusCheckRollup[] | ((.conclusion // .state // "") | ascii_upcase)] | any(. == "CANCELLED")) as $cancelled
+            | (.mergeStateStatus == "DIRTY") as $conflicted
+            | (.mergeStateStatus == "UNKNOWN") as $unknown
+            | if $failed and $conflicted then [.number, "failing checks and merge conflicts"]
+              elif $failed then [.number, "failing checks"]
+              elif $conflicted then [.number, "merge conflicts"]
+              elif $cancelled then [.number, "cancelled checks", "warn"]
+              elif $unknown then [.number, "unknown merge state", "warn"]
+              else empty
+              end
+            | @tsv
+          ' | \
+          while IFS=$'\t' read -r pr reason action; do
+            if [ "$action" = "warn" ]; then
+              echo "Skipping PR #$pr ($reason)"
+              continue
+            fi
+            echo "Closing PR #$pr ($reason)"
+            gh pr close "$pr" -R "$REPO" -c "This PR has been inactive for at least 7 days and currently has $reason. Feel free to reopen or create a new PR if you'd like to continue working on this." || echo "Warning: failed to close PR #$pr, skipping"
+          done


### PR DESCRIPTION
## Summary
- add a scheduled PR autocloser workflow
- close inactive PRs after 7 days only when they have failing checks or merge conflicts
- keep exclusions for @jdx-authored and keep-open PRs

## Validation
- actionlint .github/workflows/pr-closer.yml
- git diff --check
- jq filter sample validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automatically closing PRs can disrupt contributor workflows if the query/filters are too broad or GitHub status/merge-state signals are misinterpreted. The change is limited to CI automation and uses scoped permissions, but it performs write actions on PRs.
> 
> **Overview**
> Adds a new scheduled and manually-triggerable GitHub Actions workflow (`pr-closer`) that scans open PRs inactive for 7+ days (excluding drafts, `keep-open` labeled PRs, and PRs by `jdx`).
> 
> The job uses `gh pr list` + `jq` to **auto-close** PRs only when they have *failing checks* and/or *merge conflicts*, while only logging and skipping cases with cancelled checks or unknown merge state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e542f0cbd68cf0106286851e112ab14b13f5a4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->