### PR TITLE
fix(parse): keep inherited global flags when a subcommand re-declares them as non-global

### DIFF
--- a/cli/tests/complete_word.rs
+++ b/cli/tests/complete_word.rs
@@ -162,6 +162,55 @@ fn complete_word_mounted_with_global_flags() {
 }
 
 #[test]
+fn complete_word_mounted_global_flag_choices() {
+    // Regression for the parser-side root cause referenced by jdx/mise#10069:
+    // a value-taking global flag placed before a mounted subcommand must not leak its
+    // consumed tokens into the mounted task's `choices` positional arg.
+    let mut path = env::split_paths(&env::var("PATH").unwrap()).collect::<Vec<_>>();
+    path.insert(
+        0,
+        env::current_dir()
+            .unwrap()
+            .join("..")
+            .join("target")
+            .join("debug"),
+    );
+    path.insert(0, env::current_dir().unwrap().join("..").join("examples"));
+    env::set_var("PATH", env::join_paths(path).unwrap());
+
+    // Baseline: no global flag prefix. The mount sees no `usage_cd`, so it returns the
+    // default choices. This must complete (not error) and not be polluted by stray tokens.
+    assert_cmd(
+        "mounted-global-flags-choices.sh",
+        &["--", "run", "sample:run", ""],
+    )
+    .stdout("one\ntwo\n");
+
+    // Value-taking global flag before the mounted subcommand (the failing case). The choices
+    // switch to the dir2 set, which also proves `usage_cd=dir2` propagated to the mount even
+    // though `run` re-declares `-C/--cd` as non-global.
+    assert_cmd(
+        "mounted-global-flags-choices.sh",
+        &["--", "-C", "dir2", "run", "sample:run", ""],
+    )
+    .stdout("alpha\nbeta\ngamma\n");
+
+    // Long form.
+    assert_cmd(
+        "mounted-global-flags-choices.sh",
+        &["--", "--cd", "dir2", "run", "sample:run", ""],
+    )
+    .stdout("alpha\nbeta\ngamma\n");
+
+    // Embedded-value form.
+    assert_cmd(
+        "mounted-global-flags-choices.sh",
+        &["--", "--cd=dir2", "run", "sample:run", ""],
+    )
+    .stdout("alpha\nbeta\ngamma\n");
+}
+
+#[test]
 fn complete_word_boolean_flags_dont_consume_subcommands() {
     let mut path = env::split_paths(&env::var("PATH").unwrap()).collect::<Vec<_>>();
     path.insert(

--- a/examples/mounted-global-flags-choices.sh
+++ b/examples/mounted-global-flags-choices.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env -S usage bash
+#
+# Test fixture reproducing the parser-side root cause referenced by jdx/mise#10069.
+#
+# A value-taking global flag (-C/--cd) is placed before a mounted subcommand
+# (`run`). The `run` subcommand re-declares the same flag as NON-global (mirroring
+# what mise emits for `run`/`tasks run`), and mounts a task `sample:run` whose
+# positional arg has `choices`.
+#
+# Before the parser fix, completing the task's positional arg produced:
+#   Error: Invalid choice for arg profile: -C, expected one of alpha, beta, gamma
+# because the global flag was dropped from the recognized flags when descending into
+# the re-declaring subcommand, so the leftover token was mis-parsed as the positional.
+#
+# The mounted choices vary by the global flag's value so the test also verifies the
+# global flag (and its value) still propagates to the mount despite the non-global
+# re-declaration in `run` (i.e. it is not silently dropped from the env).
+#
+# Example usage:
+#   mounted-global-flags-choices.sh -C dir2 run sample:run <TAB>   # -> alpha beta gamma
+#   mounted-global-flags-choices.sh run sample:run <TAB>           # -> one two
+#
+#USAGE bin "ex"
+#USAGE flag "-C --cd <dir>" help="Change directory" global=#true
+#USAGE flag "--mount" help="Display kdl spec for mounted tasks"
+#USAGE cmd "run" {
+#USAGE   flag "-C --cd <dir>" help="Change directory (non-global re-declaration)"
+#USAGE   mount run="mounted-global-flags-choices.sh --mount"
+#USAGE }
+set -eo pipefail
+
+# Declare variables set by usage to avoid SC2154
+: "${usage_mount:=}"
+: "${usage_cd:=}"
+
+if [ "${usage_mount:-}" = "true" ]; then
+	# The choices depend on the global flag value to prove it reached the mount.
+	if [ "${usage_cd:-}" = "dir2" ]; then
+		cat <<EOF
+cmd "sample:run" {
+  arg "<profile>" {
+    choices "alpha" "beta" "gamma"
+  }
+}
+EOF
+	else
+		cat <<EOF
+cmd "sample:run" {
+  arg "<profile>" {
+    choices "one" "two"
+  }
+}
+EOF
+	fi
+	exit
+fi
+
+echo "Running with dir: ${usage_cd:-default}"

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -14,6 +14,33 @@ use crate::error::UsageErr;
 use crate::spec::arg::SpecDoubleDashChoices;
 use crate::{Spec, SpecArg, SpecChoices, SpecCommand, SpecFlag};
 
+/// Merge a subcommand's flags into the currently available flags when descending
+/// into that subcommand.
+///
+/// On descent we drop the parent's non-global flags (they are scoped to the parent)
+/// but keep its global flags so they remain recognized further down. A subcommand may
+/// re-declare a flag that the parent exposed as global (e.g. `-C/--cd`) but mark its own
+/// copy as non-global. In that case we must NOT let the non-global re-declaration shadow
+/// the inherited global flag, otherwise the next descent's `retain(global)` would drop it
+/// entirely and later parsing would treat the already-consumed global token as an
+/// unexpected positional/flag value.
+fn merge_subcommand_flags(
+    available: &mut BTreeMap<String, Arc<SpecFlag>>,
+    new_flags: BTreeMap<String, Arc<SpecFlag>>,
+) {
+    // Keep only inherited global flags from the parent.
+    available.retain(|_, f| f.global);
+    for (key, flag) in new_flags {
+        // Don't let a subcommand's non-global re-declaration shadow an inherited global flag.
+        // After the `retain` above, every remaining entry is global, so a present key here is
+        // always an inherited global flag.
+        if !flag.global && available.contains_key(&key) {
+            continue;
+        }
+        available.insert(key, flag);
+    }
+}
+
 /// Extract the flag key from a flag word for lookup in available_flags map
 /// Handles both long flags (--flag, --flag=value) and short flags (-f)
 fn get_flag_key(word: &str) -> &str {
@@ -338,8 +365,7 @@ fn parse_partial_with_env(
             let mut subcommand = subcommand.clone();
             // Pass prefix words (global flags before this subcommand) to mount
             subcommand.mount(&prefix_words)?;
-            out.available_flags.retain(|_, f| f.global);
-            out.available_flags.extend(gather_flags(&subcommand));
+            merge_subcommand_flags(&mut out.available_flags, gather_flags(&subcommand));
             // Remove subcommand from input
             input.remove(idx);
             out.cmds.push(subcommand.clone());
@@ -353,7 +379,14 @@ fn parse_partial_with_env(
             let flag_key = get_flag_key(word);
 
             if let Some(f) = out.available_flags.get(flag_key) {
-                // Only collect global flags for mount execution
+                // Only collect global flags for mount execution.
+                //
+                // We deliberately leave the global flag (and its value) in `input` so that
+                // Phase 2 re-parses it and records it in `out.flags`. That is how global flags
+                // reach `as_env()` for normal execution and for the env passed to mount scripts.
+                // Re-parsing is harmless as long as the flag stays recognized in
+                // `available_flags` (see `merge_subcommand_flags`): Phase 2 consumes it as a
+                // flag instead of mistaking it for a positional argument.
                 if f.global {
                     prefix_words.push(input[idx].clone());
                     idx += 1;
@@ -388,8 +421,7 @@ fn parse_partial_with_env(
                         let mut subcommand = subcommand.clone();
                         // Pass prefix words (global flags before this) to mount
                         subcommand.mount(&prefix_words)?;
-                        out.available_flags.retain(|_, f| f.global);
-                        out.available_flags.extend(gather_flags(&subcommand));
+                        merge_subcommand_flags(&mut out.available_flags, gather_flags(&subcommand));
                         out.cmds.push(subcommand.clone());
                         out.cmd = subcommand.clone();
                         prefix_words.clear();
@@ -1485,6 +1517,134 @@ mod tests {
         assert_eq!(arg.name, "name");
         let value = parsed.args.values().next().unwrap();
         assert_eq!(value.to_string(), "hello");
+    }
+
+    /// Build a spec equivalent to the post-mount structure produced by mise's
+    /// `mise usage` output: a root with a value-taking global flag (`-C/--cd`), a `run`
+    /// subcommand that re-declares the same flag as NON-global, and a mounted task
+    /// (`sample:run`) carrying a positional arg with `choices`.
+    ///
+    /// We construct the merged structure directly instead of executing a real mount so the
+    /// test stays hermetic and cross-platform while still exercising the parser defect.
+    fn mounted_global_flag_spec() -> Spec {
+        let task_cmd = SpecCommand::builder()
+            .name("sample:run")
+            .arg(
+                SpecArg::builder()
+                    .name("profile")
+                    .choices(["alpha", "beta", "gamma"])
+                    .build(),
+            )
+            .build();
+        // `run` re-declares `-C/--cd` but as a NON-global flag, mirroring the mise spec.
+        let mut run_cmd = SpecCommand::builder()
+            .name("run")
+            .flag(
+                SpecFlag::builder()
+                    .name("cd")
+                    .short('C')
+                    .long("cd")
+                    .arg(SpecArg::builder().name("dir").build())
+                    .global(false)
+                    .build(),
+            )
+            .build();
+        run_cmd
+            .subcommands
+            .insert("sample:run".to_string(), task_cmd);
+
+        let mut cmd = SpecCommand::builder()
+            .name("test")
+            .flag(
+                SpecFlag::builder()
+                    .name("cd")
+                    .short('C')
+                    .long("cd")
+                    .arg(SpecArg::builder().name("dir").build())
+                    .global(true)
+                    .build(),
+            )
+            .build();
+        cmd.subcommands.insert("run".to_string(), run_cmd);
+
+        Spec {
+            name: "test".to_string(),
+            bin: "test".to_string(),
+            cmd,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_prefix_global_flag_does_not_pollute_choices() {
+        // Regression for the parser-side root cause referenced by jdx/mise#10069.
+        //
+        // When `run` re-declares the global `-C/--cd` as non-global, descending into it (and
+        // then into the mounted `sample:run`) used to drop the inherited global flag from
+        // `available_flags`. Phase 2 then no longer recognized the prefix `-C`, so it was
+        // mis-validated against the task's `choices` positional arg.
+        let spec = mounted_global_flag_spec();
+
+        // The prefix global flag must stay recognized so it is consumed as a flag (not as the
+        // positional). Before the fix this bailed with "Invalid choice for arg profile: -C".
+        for words in [
+            &["test", "-C", "/tmp", "run", "sample:run"][..],
+            // Embedded-value form must behave identically.
+            &["test", "--cd=/tmp", "run", "sample:run"][..],
+        ] {
+            let parsed = parse_partial(&spec, &input(words)).unwrap();
+            assert_eq!(
+                parsed
+                    .cmds
+                    .iter()
+                    .map(|c| c.name.as_str())
+                    .collect::<Vec<_>>(),
+                vec!["test", "run", "sample:run"],
+            );
+            // No positional arg should have been consumed by the leftover global-flag tokens.
+            assert!(
+                parsed.args.is_empty(),
+                "args should be empty, got {:?}",
+                parsed.args
+            );
+
+            // Fix (B): the inherited global flag survives the descent even though `run`
+            // re-declares `-C/--cd` as non-global.
+            let cd = parsed
+                .available_flags
+                .get("--cd")
+                .expect("--cd should remain available after descending into the subcommand");
+            assert!(cd.global, "--cd must stay global after descent");
+            assert!(
+                parsed.available_flags.get("-C").is_some_and(|f| f.global),
+                "-C must stay global after descent",
+            );
+
+            // The global flag must still be recorded in `out.flags` so it reaches `as_env()`
+            // for normal execution and for the env passed to mount scripts. (Removing the
+            // token in Phase 1 instead of re-parsing it would silently drop `usage_cd`.)
+            assert_eq!(
+                parsed.as_env().get("usage_cd").map(String::as_str),
+                Some("/tmp"),
+                "global flag value must survive in as_env(), got {:?}",
+                parsed.as_env(),
+            );
+        }
+
+        // A real, valid choice still parses through the global flag prefix.
+        let parsed = parse_partial(
+            &spec,
+            &input(&["test", "-C", "/tmp", "run", "sample:run", "alpha"]),
+        )
+        .unwrap();
+        assert_eq!(parsed.args.len(), 1);
+        assert_eq!(parsed.args.values().next().unwrap().to_string(), "alpha");
+
+        // And genuinely invalid choices are still rejected (we didn't disable validation).
+        assert_parse_err(
+            parse_partial(&spec, &input(&["test", "run", "sample:run", "wrong"])),
+            "Invalid choice for arg profile: wrong, expected one of alpha, beta, gamma",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes a `parse_partial` bug where a **value-taking global flag placed before a (mounted) subcommand** breaks completion/parsing when the subcommand re-declares that same flag as non-global.

This fixes the parser-side root cause referenced by jdx/mise#10069.

### Reproduction

mise emits a usage spec where `run` mounts tasks dynamically, a task can have a `choices` positional arg, and `run` re-declares the global `-C/--cd` flag as non-global. Completing such a task with the global flag in front:

```
mycli -C /tmp run sample:run <TAB>
→ Error: × Invalid choice for arg profile: -C, expected one of alpha, beta, gamma
```

Expected: `alpha beta gamma`.

### Root cause

During phase 1 (subcommand scan / global-flag gathering), each descent did:

```rust
out.available_flags.retain(|_, f| f.global);
out.available_flags.extend(gather_flags(&subcommand));
```

When a child subcommand re-declares a parent's **global** flag (same `-C/--cd` key) as **non-global**, `extend` overwrites the inherited global entry with the non-global one, and the *next* descent's `retain(|_, f| f.global)` then drops it entirely.

With the global flag no longer in `available_flags`, phase 2 no longer recognizes the leftover `-C` token and feeds it to the task's `choices` positional arg → `validate_choices` bails.

### Fix

Replace `retain` + `extend` with a small `merge_subcommand_flags` helper that merges with **global precedence**: a subcommand's non-global re-declaration no longer shadows an inherited global flag. The global flag stays recognized, so phase 2 consumes it as a flag (and records it in `as_env()`, preserving `usage_*` env vars for normal execution and for mount scripts) instead of mistaking it for a positional.

> Note: the prefix global flag is intentionally left in `input` so phase 2 re-parses it into `out.flags`; that is how its value reaches `as_env()`. The fix is purely about keeping the flag *recognized* across descents.

## Tests

- **Unit** (`lib/src/parse.rs`): `test_prefix_global_flag_does_not_pollute_choices` builds the post-mount structure directly (root global `-C/--cd`, `run` re-declaring it as non-global, mounted `sample:run` with a `choices` arg) and asserts: no false "Invalid choice" bail, the inherited global flag survives descent, the flag value still reaches `as_env()` (`usage_cd`), valid choices still parse, and genuinely invalid choices are still rejected.
- **Integration** (`cli/tests/complete_word.rs` + `examples/mounted-global-flags-choices.sh`): a new fixture whose mounted `choices` vary by `usage_cd`, so the test also confirms the global flag value propagates through the mount despite the non-global re-declaration.

## Downstream note

mise currently has a temporary workaround (promoting the conflicting `run`/`tasks run` flags to `global=true` in its completion spec generation). Once this lands, that workaround becomes a no-op and can be removed; I'll follow up on jdx/mise#10069.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
