### PR TITLE
fix(ci): preserve release push credentials

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
           token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
-          persist-credentials: false
+          persist-credentials: true
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
         with:
           experimental: true


### PR DESCRIPTION
## Summary

- keep checkout credentials persisted in the release-plz workflow so `git push origin release --force` can authenticate

## Testing

- `actionlint .github/workflows/release-plz.yml`

_This PR was generated by AI._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI checkout flag change with no runtime or security surface beyond using the existing release token for pushes as intended.
> 
> **Overview**
> The **release-plz** workflow now sets `actions/checkout` **`persist-credentials: true`** instead of `false`, so the token from `MY_RELEASE_PLEASE_TOKEN` stays configured in the job’s git remote for later steps (e.g. **`git push origin release --force`** from release-plz).
> 
> No application or release logic changes—only checkout behavior for authenticated pushes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8142f683b83546195716d8f203b90ca4f461b565. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->