### PR TITLE
fix(ci): use workflow token for release automation

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-          token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+          token: ${{ github.token }}
           persist-credentials: true
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
         with:
@@ -35,5 +35,5 @@ jobs:
       - run: mise trust --all
       - run: mise run release-plz
         env:
-          GITHUB_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary

- use the workflow-provided `github.token` for release-plz checkout credentials
- pass the same workflow token to `mise run release-plz` for GitHub CLI/API operations

## Why

The previous fix preserved credentials, but the preserved `MY_RELEASE_PLEASE_TOKEN` authenticates as `mise-en-dev`, which GitHub rejects for pushing to `jdx/usage`:

```text
remote: Permission to jdx/usage.git denied to mise-en-dev.
```

The job already declares `contents: write` and `pull-requests: write`, so the built-in workflow token has the repo permissions this automation needs.

## Testing

- `actionlint .github/workflows/release-plz.yml`

_This PR was generated by AI._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only credential change; no application code, with permissions already scoped on the job.
> 
> **Overview**
> The **release-plz** workflow now uses the built-in **`github.token`** instead of **`MY_RELEASE_PLEASE_TOKEN`** for checkout and for **`GITHUB_TOKEN`** when running **`mise run release-plz`**.
> 
> That aligns Git pushes and GitHub API calls with the job’s declared **`contents: write`** and **`pull-requests: write`** permissions on this repo, instead of a PAT tied to **`mise-en-dev`**, which was denied push access to **`jdx/usage`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eef6f88882705d1f181f38fc8f506dd207b0054. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->