### PR TITLE
chore(ci): format release lock after aube update

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -33,39 +33,44 @@ checksum = "sha256:283467f9d6202a8cb8c00ad8dd0ee4e685b71fb86a6a56c68fcbb9ae8ed91
 url = "https://github.com/rhysd/actionlint/releases/download/v1.7.10/actionlint_1.7.10_windows_amd64.zip"
 
 [[tools.aube]]
-version = "1.0.0-beta.5"
+version = "1.16.1"
 backend = "github:endevco/aube"
 
 [tools.aube."platforms.linux-arm64"]
-checksum = "sha256:132c0578a46b149e6bbfcc46e79bec633785e200f88ee84cb9bff3158d66629b"
-url = "https://github.com/endevco/aube/releases/download/v1.0.0-beta.5/aube-v1.0.0-beta.5-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/endevco/aube/releases/assets/399980524"
+checksum = "sha256:5e1a207be4b83cd1e0186402764b56e5a702c0332f519959c16d02f4cee9e008"
+url = "https://github.com/endevco/aube/releases/download/v1.16.1/aube-v1.16.1-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/endevco/aube/releases/assets/433127937"
+provenance = "github-attestations"
 
 [tools.aube."platforms.linux-arm64-musl"]
-checksum = "sha256:132c0578a46b149e6bbfcc46e79bec633785e200f88ee84cb9bff3158d66629b"
-url = "https://github.com/endevco/aube/releases/download/v1.0.0-beta.5/aube-v1.0.0-beta.5-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/endevco/aube/releases/assets/399980524"
+checksum = "sha256:8c3098765cee83d654176fd2ed5eadd7224cff08d76f0ce551149fe65ee082d8"
+url = "https://github.com/endevco/aube/releases/download/v1.16.1/aube-v1.16.1-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/endevco/aube/releases/assets/432794003"
+provenance = "github-attestations"
 
 [tools.aube."platforms.linux-x64"]
-checksum = "sha256:70606c2d09d06538eb07de888bf7db5727e80de3c2e8997e08d8ac4bd06fa5ea"
-url = "https://github.com/endevco/aube/releases/download/v1.0.0-beta.5/aube-v1.0.0-beta.5-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/endevco/aube/releases/assets/399980361"
+checksum = "sha256:3f3d183d6a9644391ffa3ac521c010c90cebc4fd6ab208aa9aa552c70986a357"
+url = "https://github.com/endevco/aube/releases/download/v1.16.1/aube-v1.16.1-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/endevco/aube/releases/assets/432797995"
 provenance = "github-attestations"
 
 [tools.aube."platforms.linux-x64-musl"]
-checksum = "sha256:70606c2d09d06538eb07de888bf7db5727e80de3c2e8997e08d8ac4bd06fa5ea"
-url = "https://github.com/endevco/aube/releases/download/v1.0.0-beta.5/aube-v1.0.0-beta.5-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/endevco/aube/releases/assets/399980361"
+checksum = "sha256:2ac54a2bc6248c6b1df9c3a160beea6cf3255102337488f5d3b2dc317ea673a0"
+url = "https://github.com/endevco/aube/releases/download/v1.16.1/aube-v1.16.1-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/endevco/aube/releases/assets/432798092"
+provenance = "github-attestations"
 
 [tools.aube."platforms.macos-arm64"]
-checksum = "sha256:dedacf0c40a208ef8a4a76967208e5e33de18873781cbe1c793b1d7058ea7451"
-url = "https://github.com/endevco/aube/releases/download/v1.0.0-beta.5/aube-v1.0.0-beta.5-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/endevco/aube/releases/assets/399980603"
+checksum = "sha256:3acf85c4373d30800dd739c279bdbecc5f602ee82009498408b82ce99c8e3f72"
+url = "https://github.com/endevco/aube/releases/download/v1.16.1/aube-v1.16.1-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/endevco/aube/releases/assets/432824150"
+provenance = "github-attestations"
 
 [tools.aube."platforms.windows-x64"]
-checksum = "sha256:16f3faf9eaaaede5b27c3f05b742d90f903184c40d69664f4bcb5d7095ba9be3"
-url = "https://github.com/endevco/aube/releases/download/v1.0.0-beta.5/aube-v1.0.0-beta.5-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/endevco/aube/releases/assets/399981981"
+checksum = "sha256:950fb818925c31dca4e122bae72a6088c92edc8760c8374fbf0470620ce5e1fa"
+url = "https://github.com/endevco/aube/releases/download/v1.16.1/aube-v1.16.1-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/endevco/aube/releases/assets/432804595"
+provenance = "github-attestations"
 
 [[tools.cargo-binstall]]
 version = "1.17.4"

--- a/tasks/release-plz
+++ b/tasks/release-plz
@@ -33,12 +33,12 @@ PR_BODY="$(git cliff --bump --unreleased --strip all | tail -n +3)"
 
 cargo set-version "${version#v}" --exclude clap_usage
 mise run render
-mise run lint-fix
 
 git config user.name mise-en-dev
 git config user.email 123107610+mise-en-dev@users.noreply.github.com
 cargo update
 aube update
+mise run lint-fix
 git add \
   {./,cli/,lib/}Cargo.* \
   package.json aube-lock.yaml \


### PR DESCRIPTION
## Summary
- move release-plz lint-fix after aube update so the committed lockfile matches CI render formatting
- bump the locked aube tool from 1.0.0-beta.5 to 1.16.1

## Verification
- mise r render

_This PR was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-script ordering and locked tool version bumps only; no runtime product logic changes.
> 
> **Overview**
> The **release-plz** automation now runs **`mise run lint-fix`** after **`aube update`** instead of right after **`mise run render`**, so Prettier can format **`mise.lock`** (and related files) in the same order CI expects before the release commit.
> 
> **`mise.lock`** pins **`aube`** from **1.0.0-beta.5** to **1.16.1**, with refreshed per-platform download URLs and checksums and **`github-attestations`** provenance on platforms that did not have it before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86fa384606d91b75bace0887c2bb15c814ad8e48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->