### PR TITLE
fix(ci): use trusted publishing for crates

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -3,6 +3,7 @@ name: release-plz
 permissions:
   pull-requests: write
   contents: write
+  id-token: write
 
 on:
   workflow_dispatch:
@@ -33,7 +34,9 @@ jobs:
           experimental: true
           cache: false
       - run: mise trust --all
+      - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
+        id: auth
       - run: mise run release-plz
         env:
           GITHUB_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
## Summary
- request GitHub OIDC tokens in the release-plz workflow
- exchange the OIDC identity for a short-lived crates.io token
- stop using the long-lived CARGO_REGISTRY_TOKEN secret for publishing

## Testing
- actionlint .github/workflows/release-plz.yml
- git diff --check

_This comment was generated by Claude Code._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the release/publish path; misconfiguration could block releases, but the change reduces secret exposure by replacing a static registry token.
> 
> **Overview**
> The **release-plz** workflow now publishes to crates.io via **GitHub OIDC trusted publishing** instead of a long-lived repository secret.
> 
> It grants **`id-token: write`**, runs **`rust-lang/crates-io-auth-action`**, and passes the resulting short-lived token to **`CARGO_REGISTRY_TOKEN`** for `mise run release-plz`. The **`secrets.CARGO_REGISTRY_TOKEN`** reference is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a21f0f98f1067c358ae73a3d27db205ac3e75cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release process security and reliability through updated authentication mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->