### PR TITLE
chore(docs): add integrations for JCommander, picocli and Clikt

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -97,6 +97,9 @@ export default defineConfig({
               { text: "yargs (Node.js)", link: "https://www.npmjs.com/package/@usage-spec/yargs" },
               { text: "Typer (Python)", link: "https://pypi.org/project/usage-spec-typer/" },
               { text: "Click (Python)", link: "https://pypi.org/project/usage-spec-click/" },
+              { text: "JCommander (Java)", link: "https://github.com/gaojunran/usage-integrations/packages/3045397" },
+              { text: "picocli (Java)", link: "https://github.com/gaojunran/usage-integrations/packages/3045398" },
+              { text: "Clikt (Kotlin)", link: "https://github.com/gaojunran/usage-integrations/packages/3045396" },
             ]
           }
         ]

--- a/docs/spec/integrations.md
+++ b/docs/spec/integrations.md
@@ -4,17 +4,20 @@ Integrations extract CLI definitions from framework internals and output a [usag
 
 ## Available
 
-| Framework                                                           | Language | Package                                                                        |
-| ------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------ |
-| [Cobra](https://github.com/spf13/cobra)                             | Go       | [`cobra_usage`](/spec/integrations/cobra)                                      |
-| [clap](https://crates.io/crates/clap)                               | Rust     | [`clap_usage`](/spec/integrations/clap)                                        |
-| [argparse](https://docs.python.org/3/library/argparse.html)         | Python   | [`argparse-usage`](https://github.com/acidghost/argparse-usage)                |
-| [OptionParser](https://docs.ruby-lang.org/en/4.0/OptionParser.html) | Ruby     | [`option_parser_usage`](https://github.com/packrat386/option_parser_usage)     |
-| [Commander.js](https://github.com/tj/commander.js)                  | Node.js  | [`@usage-spec/commander`](https://www.npmjs.com/package/@usage-spec/commander) |
-| [oclif](https://oclif.io)                                           | Node.js  | [`@usage-spec/oclif`](https://www.npmjs.com/package/@usage-spec/oclif)         |
-| [yargs](https://yargs.js.org)                                       | Node.js  | [`@usage-spec/yargs`](https://www.npmjs.com/package/@usage-spec/yargs)         |
-| [Typer](https://github.com/fastapi/typer)                           | Python   | [`usage-spec-typer`](https://pypi.org/project/usage-spec-typer/)               |
-| [Click](https://github.com/pallets/click)                           | Python   | [`usage-spec-click`](https://pypi.org/project/usage-spec-click/)               |
+| Framework                                                           | Language | Package                                                                                |
+| ------------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------- |
+| [Cobra](https://github.com/spf13/cobra)                             | Go       | [`cobra_usage`](/spec/integrations/cobra)                                              |
+| [clap](https://crates.io/crates/clap)                               | Rust     | [`clap_usage`](/spec/integrations/clap)                                                |
+| [argparse](https://docs.python.org/3/library/argparse.html)         | Python   | [`argparse-usage`](https://github.com/acidghost/argparse-usage)                        |
+| [OptionParser](https://docs.ruby-lang.org/en/4.0/OptionParser.html) | Ruby     | [`option_parser_usage`](https://github.com/packrat386/option_parser_usage)             |
+| [Commander.js](https://github.com/tj/commander.js)                  | Node.js  | [`@usage-spec/commander`](https://www.npmjs.com/package/@usage-spec/commander)         |
+| [oclif](https://oclif.io)                                           | Node.js  | [`@usage-spec/oclif`](https://www.npmjs.com/package/@usage-spec/oclif)                 |
+| [yargs](https://yargs.js.org)                                       | Node.js  | [`@usage-spec/yargs`](https://www.npmjs.com/package/@usage-spec/yargs)                 |
+| [Typer](https://github.com/fastapi/typer)                           | Python   | [`usage-spec-typer`](https://pypi.org/project/usage-spec-typer/)                       |
+| [Click](https://github.com/pallets/click)                           | Python   | [`usage-spec-click`](https://pypi.org/project/usage-spec-click/)                       |
+| [JCommander](https://github.com/cbeust/jcommander)                  | Java     | [`jcommander-usage`](https://github.com/gaojunran/usage-integrations/packages/3045397) |
+| [picocli](https://github.com/remkop/picocli)                        | Java     | [`picocli-usage`](https://github.com/gaojunran/usage-integrations/packages/3045398)    |
+| [Clikt](https://github.com/ajalt/clikt)                             | Kotlin   | [`clikt-usage`](https://github.com/gaojunran/usage-integrations/packages/3045396)      |
 
 ## Planned
 
@@ -32,7 +35,6 @@ Contributions welcome! Here are the frameworks we'd like to support next.
 | ----------------------------------------------------------------------- | -------- |
 | [Spectre.Console](https://github.com/spectreconsole/spectre.console)    | C#/.NET  |
 | [Symfony Console](https://github.com/symfony/console)                   | PHP      |
-| [picocli](https://github.com/remkop/picocli)                            | Java     |
 | [Thor](https://github.com/rails/thor)                                   | Ruby     |
 | [cxxopts](https://github.com/jarro2783/cxxopts)                         | C++      |
 | [CommandLineParser](https://github.com/commandlineparser/commandline)   | C#/.NET  |
@@ -46,12 +48,9 @@ Contributions welcome! Here are the frameworks we'd like to support next.
 | Framework                                                                  | Language |
 | -------------------------------------------------------------------------- | -------- |
 | [Kong](https://github.com/alecthomas/kong)                                 | Go       |
-| [Clikt](https://github.com/ajalt/clikt)                                    | Kotlin   |
-| [JCommander](https://github.com/cbeust/jcommander)                         | Java     |
 | [argh](https://github.com/google/argh)                                     | Rust     |
 | [zig-clap](https://github.com/Hejsil/zig-clap)                             | Zig      |
 | [optparse-applicative](https://github.com/pcapriotti/optparse-applicative) | Haskell  |
-| [kotlinx-cli](https://github.com/Kotlin/kotlinx-cli)                       | Kotlin   |
 | [cligen](https://github.com/c-blake/cligen)                                | Nim      |
 | [argparse](https://github.com/mpeterv/argparse)                            | Lua      |
 | [Getopt::Long](https://perldoc.perl.org/Getopt::Long)                      | Perl     |


### PR DESCRIPTION
- Note that https://github.com/Kotlin/kotlinx-cli is removed from the `planned` table because this project is claimed to be deprecated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added three Java CLI framework integrations—JCommander, picocli, and Clikt—to the available integrations listing with usage links.
  * Updated navigation/sidebar entries to surface these integrations.
  * Removed picocli from the planned medium-priority list and removed Clikt and JCommander from the planned lower-priority list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->