### PR TITLE
docs: use KDLv2 raw multiline strings

### DIFF
--- a/docs/spec/reference/cmd.md
+++ b/docs/spec/reference/cmd.md
@@ -26,19 +26,19 @@ cmd "config" {
 }
 
 cmd "list" {
-  example "Basic usage" r#"
+  example "Basic usage" #"""
     $ mycli list
     FRUIT  COLOR
     apple  red
     banana yellow
-  "#
-  example "JSON output" r#"
+  """#
+  example "JSON output" #"""
     $ mycli list --json
     [
       {"FRUIT": "apple", "COLOR": "red"},
       {"FRUIT": "banana", "COLOR": "yellow"}
     ]
-  "#
+  """#
 }
 ```
 

--- a/docs/spec/reference/flag.md
+++ b/docs/spec/reference/flag.md
@@ -43,10 +43,11 @@ flag "--env <env>" {
 flag "--file <file>" long_help="longer help for --help (as opposed to -h)"
 // this is equivalent to the above but preferred when a lot of space is needed
 flag "--file <file>" {
-  long_help r#"longer help for --help (as opposed to -h)
-   even
-   more
-   text
-   "#
+  long_help #"""
+    longer help for --help (as opposed to -h)
+    even
+    more
+    text
+    """#
 }
 ```

--- a/docs/spec/reference/index.md
+++ b/docs/spec/reference/index.md
@@ -43,7 +43,8 @@ source_code_link_template #"""
 {%- else -%}
 {%- set path = path ~ ".rs" -%}
 {%- endif -%}
-https://github.com/jdx/mise/blob/main/src/cli/{{path}}"""#
+https://github.com/jdx/mise/blob/main/src/cli/{{path}}
+"""#
 ```
 
 ## Examples

--- a/docs/spec/reference/index.md
+++ b/docs/spec/reference/index.md
@@ -36,14 +36,14 @@ This is a tera template that can be used to customize the path for markdown docu
 example, in mise I use the following to convert filenames to snake case:
 
 ```kdl
-source_code_link_template r#"
+source_code_link_template #"""
 {%- set path = path | replace(from='-', to='_') -%}
 {%- if cmd.subcommands | length > 0 -%}
 {%- set path = path | split(pat="/") | slice(end=1) | concat(with="mod.rs") | join(sep="/") -%}
 {%- else -%}
 {%- set path = path ~ ".rs" -%}
 {%- endif -%}
-https://github.com/jdx/mise/blob/main/src/cli/{{path}}"#
+https://github.com/jdx/mise/blob/main/src/cli/{{path}}"""#
 ```
 
 ## Examples

--- a/examples/mise.usage.kdl
+++ b/examples/mise.usage.kdl
@@ -1194,9 +1194,9 @@ case $cur in
     done
     ;;
 esac
-"#
+"""#
 
-complete "installed_tool@version" run=r#"
+complete "installed_tool@version" run=#"""
 cur="{{words[CURRENT]}}"
 case $cur in
   *@*)


### PR DESCRIPTION
Converts the remaining KDLv1 raw (multiline) strings (`r#"..."#`) to KDLv2 raw multiline strings (`#"""..."""#`). usage already supports KDLv2 and makes use of KDLv2-specific syntax in several places in the documentation (e.g. hashtag-prefixed boolean values like `#true`) and links to the [KDLv2 spec](https://kdl.dev/). Hence I think it's confusing to mix v1 and v2 syntax, especially since KDLv2 docs don't mention [v1](https://kdl.dev/spec-v1/) syntax.

The `examples/mise.usage.kdl` file was just imperfectly converted to KDL v2, that's also fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized example block formatting for command reference examples.
  * Reformatted long help text examples for clearer multiline presentation.
  * Updated template example formatting to improve readability.
  * Adjusted shell completion example formatting for consistent presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->