### PR TITLE
fix(parse): union orphan aliases when merging a re-declared global flag

### DIFF
--- a/cli/tests/complete_word.rs
+++ b/cli/tests/complete_word.rs
@@ -211,6 +211,54 @@ fn complete_word_mounted_global_flag_choices() {
 }
 
 #[test]
+fn complete_word_mounted_orphan_short_flag_choices() {
+    // Follow-up to jdx/mise#10069: a long-only global flag re-declared as a non-global flag
+    // with an ADDED short (`-r --raw`, `-S --silent`) must keep the orphan short recognized.
+    // Completing a mounted task with the short in front must return the task's choices rather
+    // than bailing with "unexpected word" / "Invalid choice" (which mise worked around by
+    // promoting the short back to global).
+    let mut path = env::split_paths(&env::var("PATH").unwrap()).collect::<Vec<_>>();
+    path.insert(
+        0,
+        env::current_dir()
+            .unwrap()
+            .join("..")
+            .join("target")
+            .join("debug"),
+    );
+    path.insert(0, env::current_dir().unwrap().join("..").join("examples"));
+    env::set_var("PATH", env::join_paths(path).unwrap());
+
+    // Orphan short `-r` before the mounted task (the failing case).
+    assert_cmd(
+        "mounted-orphan-short-flags.sh",
+        &["--", "run", "-r", "sample:run", ""],
+    )
+    .stdout("alpha\nbeta\ngamma\n");
+
+    // A different orphan short (`-S`) on the same subcommand.
+    assert_cmd(
+        "mounted-orphan-short-flags.sh",
+        &["--", "run", "-S", "sample:run", ""],
+    )
+    .stdout("alpha\nbeta\ngamma\n");
+
+    // The nested `tasks run` path exercises a second descent level.
+    assert_cmd(
+        "mounted-orphan-short-flags.sh",
+        &["--", "tasks", "run", "-r", "sample:run", ""],
+    )
+    .stdout("alpha\nbeta\ngamma\n");
+
+    // The original long alias still works after the merge.
+    assert_cmd(
+        "mounted-orphan-short-flags.sh",
+        &["--", "run", "--raw", "sample:run", ""],
+    )
+    .stdout("alpha\nbeta\ngamma\n");
+}
+
+#[test]
 fn complete_word_boolean_flags_dont_consume_subcommands() {
     let mut path = env::split_paths(&env::var("PATH").unwrap()).collect::<Vec<_>>();
     path.insert(

--- a/examples/mounted-orphan-short-flags.sh
+++ b/examples/mounted-orphan-short-flags.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env -S usage bash
+#
+# Test fixture for the orphan-short follow-up to jdx/mise#10069.
+#
+# The root declares LONG-ONLY global flags (`--raw`, `--silent`, no short). The `run` and
+# `tasks run` subcommands re-declare them as NON-global but ADD a short (`-r --raw`,
+# `-S --silent`), mirroring what mise emits. Each mounts a task `sample:run` whose positional
+# arg has `choices`.
+#
+# Before the parser fix, the merge that keeps the inherited long-only global discarded the
+# re-declaration wholesale, dropping the orphan short. Completing the task with the short in
+# front (`run -r sample:run <TAB>`) then failed with an "unexpected word" / "Invalid choice"
+# bail because `-r` was no longer recognized and was mis-parsed against the positional.
+#
+# After the fix the orphan short is unioned onto the surviving global flag, so the mounted
+# task's choices complete with the short (or long) prefix, over both `run` and `tasks run`.
+#
+# Example usage:
+#   mounted-orphan-short-flags.sh run -r sample:run <TAB>          # -> alpha beta gamma
+#   mounted-orphan-short-flags.sh tasks run -S sample:run <TAB>    # -> alpha beta gamma
+#
+#USAGE bin "ex"
+#USAGE flag "--raw" help="Raw output" global=#true
+#USAGE flag "--silent" help="Silent output" global=#true
+#USAGE flag "--mount" help="Display kdl spec for mounted tasks"
+#USAGE cmd "run" {
+#USAGE   flag "-r --raw" help="Raw output (non-global re-declaration with added short)"
+#USAGE   flag "-S --silent" help="Silent output (non-global re-declaration with added short)"
+#USAGE   mount run="mounted-orphan-short-flags.sh --mount"
+#USAGE }
+#USAGE cmd "tasks" {
+#USAGE   cmd "run" {
+#USAGE     flag "-r --raw" help="Raw output (non-global re-declaration with added short)"
+#USAGE     flag "-S --silent" help="Silent output (non-global re-declaration with added short)"
+#USAGE     mount run="mounted-orphan-short-flags.sh --mount"
+#USAGE   }
+#USAGE }
+set -eo pipefail
+
+# Declare variables set by usage to avoid SC2154
+: "${usage_mount:=}"
+: "${usage_raw:=}"
+: "${usage_silent:=}"
+
+if [ "${usage_mount:-}" = "true" ]; then
+	# The choices are unconditional: completing them at all proves the orphan short was
+	# recognized as a flag, since an unrecognized `-r`/`-S` would break the subcommand
+	# descent before `sample:run` is found.
+	cat <<EOF
+cmd "sample:run" {
+  arg "<profile>" {
+    choices "alpha" "beta" "gamma"
+  }
+}
+EOF
+	exit
+fi
+
+echo "Running raw=${usage_raw:-false} silent=${usage_silent:-false}"

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -61,6 +61,16 @@ fn merge_subcommand_flags(
                 .cloned()
         });
         if let Some(global_flag) = inherited_global {
+            // Never clobber a *different* inherited global's alias. If this re-declaration's
+            // orphan alias (e.g. `-r`) is already owned by some other global (e.g. an unrelated
+            // `-r --restrict`), that is a genuine collision: keep the existing global, as global
+            // precedence dictates, instead of stealing the alias for the merged flag.
+            if available
+                .get(&key)
+                .is_some_and(|existing| existing.global && !Arc::ptr_eq(existing, &global_flag))
+            {
+                continue;
+            }
             let merged = merged_cache
                 .entry(Arc::as_ptr(&flag) as usize)
                 .or_insert_with(|| {
@@ -1837,6 +1847,67 @@ mod tests {
             parse_partial(&spec, &input(&["test", "run", "-r", "sample:run", "wrong"])),
             "Invalid choice for arg profile: wrong, expected one of alpha, beta, gamma",
         );
+    }
+
+    #[test]
+    fn test_orphan_short_does_not_clobber_unrelated_global() {
+        // When a re-declaration's orphan short collides with a DIFFERENT inherited global's
+        // short, the merge must not steal it. Here the root has both a long-only `--raw` global
+        // and a `-r --restrict` global; `run` re-declares `-r --raw` as non-global. `-r` is a
+        // genuine collision with `--restrict`, so global precedence must keep `-r -> restrict`.
+        let run_cmd = SpecCommand::builder()
+            .name("run")
+            .flag(
+                SpecFlag::builder()
+                    .name("raw")
+                    .short('r')
+                    .long("raw")
+                    .global(false)
+                    .build(),
+            )
+            .build();
+        let mut cmd = SpecCommand::builder()
+            .name("test")
+            .flag(
+                SpecFlag::builder()
+                    .name("raw")
+                    .long("raw")
+                    .global(true)
+                    .build(),
+            )
+            .flag(
+                SpecFlag::builder()
+                    .name("restrict")
+                    .short('r')
+                    .long("restrict")
+                    .global(true)
+                    .build(),
+            )
+            .build();
+        cmd.subcommands.insert("run".to_string(), run_cmd);
+        let spec = Spec {
+            name: "test".to_string(),
+            bin: "test".to_string(),
+            cmd,
+            ..Default::default()
+        };
+
+        let parsed = parse_partial(&spec, &input(&["test", "run"])).unwrap();
+        // `-r` stays owned by the unrelated `--restrict` global, not stolen by the merged raw.
+        assert_eq!(
+            parsed.available_flags.get("-r").map(|f| f.name.as_str()),
+            Some("restrict"),
+            "-r must remain owned by the unrelated global it already belonged to",
+        );
+        // Both globals are still recognized and global after the descent.
+        assert!(parsed
+            .available_flags
+            .get("--raw")
+            .is_some_and(|f| f.global));
+        assert!(parsed
+            .available_flags
+            .get("--restrict")
+            .is_some_and(|f| f.global));
     }
 
     #[test]

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -30,15 +30,81 @@ fn merge_subcommand_flags(
 ) {
     // Keep only inherited global flags from the parent.
     available.retain(|_, f| f.global);
+
+    // Cache the merged (global ∪ orphan-alias) flag per re-declared child so every alias key of
+    // that flag ends up sharing one `Arc`. Keyed by the child `Arc`'s identity.
+    let mut merged_cache: HashMap<usize, Arc<SpecFlag>> = HashMap::new();
+
+    // Iterate the *flattened* child map directly (one entry per alias key). This preserves the
+    // map's existing intra-subcommand collision resolution: when two flags in the same command
+    // share an alias (e.g. `-x --alpha` then `-x --beta`), the BTreeMap already collapsed `-x`
+    // to its last-declared owner, and we must not change which flag owns it.
     for (key, flag) in new_flags {
-        // Don't let a subcommand's non-global re-declaration shadow an inherited global flag.
-        // After the `retain` above, every remaining entry is global, so a present key here is
-        // always an inherited global flag.
-        if !flag.global && available.contains_key(&key) {
+        if flag.global {
+            // A child that re-declares (or adds) a global flag stays recognized everywhere.
+            available.insert(key, flag);
+            continue;
+        }
+
+        // A non-global re-declaration that shares a LONG name with an inherited global flag is
+        // the SAME logical flag (e.g. mise's `-r --raw` re-declaring the long-only `--raw`
+        // global). Keep the global flag (global precedence, so it survives the next descent's
+        // `retain`), but union in any short/long aliases that exist only on the re-declaration,
+        // otherwise those orphan aliases would be silently dropped. Matching on a shared long is
+        // deliberate: a re-declaration sharing only a short letter with an unrelated global
+        // (`-q --quiet` vs `-q --quoting`) is a genuine collision, not an alias addition, and is
+        // handled by the `contains_key` skip below instead.
+        let inherited_global = flag.long.iter().find_map(|l| {
+            available
+                .get(&format!("--{l}"))
+                .filter(|f| f.global)
+                .cloned()
+        });
+        if let Some(global_flag) = inherited_global {
+            let merged = merged_cache
+                .entry(Arc::as_ptr(&flag) as usize)
+                .or_insert_with(|| {
+                    let mut merged = (*global_flag).clone();
+                    for s in &flag.short {
+                        if !merged.short.contains(s) {
+                            merged.short.push(*s);
+                        }
+                    }
+                    for l in &flag.long {
+                        if !merged.long.contains(l) {
+                            merged.long.push(l.clone());
+                        }
+                    }
+                    Arc::new(merged)
+                })
+                .clone();
+            available.insert(key, merged);
+            continue;
+        }
+
+        // Purely-local flag (shares nothing with an inherited global), or one that collides only
+        // on a short with an unrelated global. Insert this alias but never shadow an inherited
+        // global flag. Such non-global flags are dropped by the next descent's `retain`.
+        if available.contains_key(&key) {
             continue;
         }
         available.insert(key, flag);
     }
+}
+
+/// Build the lookup keys a flag is registered under in `available_flags`:
+/// `--<long>` for each long name, `-<short>` for each short char, plus the `negate` token.
+fn flag_keys(flag: &SpecFlag) -> Vec<String> {
+    let mut keys: Vec<String> = flag
+        .long
+        .iter()
+        .map(|l| format!("--{l}"))
+        .chain(flag.short.iter().map(|s| format!("-{s}")))
+        .collect();
+    if let Some(negate) = &flag.negate {
+        keys.push(negate.clone());
+    }
+    keys
 }
 
 /// Extract the flag key from a flag word for lookup in available_flags map
@@ -318,16 +384,10 @@ fn parse_partial_with_env(
             .iter()
             .flat_map(|f| {
                 let f = Arc::new(f.clone()); // One clone per flag, then cheap Arc refs
-                let mut flags = f
-                    .long
-                    .iter()
-                    .map(|l| (format!("--{l}"), Arc::clone(&f)))
-                    .chain(f.short.iter().map(|s| (format!("-{s}"), Arc::clone(&f))))
-                    .collect::<Vec<_>>();
-                if let Some(negate) = &f.negate {
-                    flags.push((negate.clone(), Arc::clone(&f)));
-                }
-                flags
+                flag_keys(&f)
+                    .into_iter()
+                    .map(|key| (key, Arc::clone(&f)))
+                    .collect::<Vec<_>>()
             })
             .collect()
     };
@@ -1644,6 +1704,195 @@ mod tests {
         assert_parse_err(
             parse_partial(&spec, &input(&["test", "run", "sample:run", "wrong"])),
             "Invalid choice for arg profile: wrong, expected one of alpha, beta, gamma",
+        );
+    }
+
+    /// Build a spec mirroring mise's orphan-short re-declarations: a root with a LONG-ONLY
+    /// global boolean flag (`--raw`, no short), a `run` subcommand that re-declares it as a
+    /// NON-global flag while ADDING a short (`-r --raw`) plus a purely-local `-f/--force`
+    /// flag, and a mounted task (`sample:run`) with a `choices` positional arg.
+    fn mounted_orphan_short_spec() -> Spec {
+        let task_cmd = SpecCommand::builder()
+            .name("sample:run")
+            .arg(
+                SpecArg::builder()
+                    .name("profile")
+                    .choices(["alpha", "beta", "gamma"])
+                    .build(),
+            )
+            .build();
+        // `run` re-declares `--raw` as NON-global but adds a `-r` short that exists only here,
+        // and also carries a purely-local `-f/--force` flag (shares nothing with a global).
+        let mut run_cmd = SpecCommand::builder()
+            .name("run")
+            .flag(
+                SpecFlag::builder()
+                    .name("raw")
+                    .short('r')
+                    .long("raw")
+                    .global(false)
+                    .build(),
+            )
+            .flag(
+                SpecFlag::builder()
+                    .name("force")
+                    .short('f')
+                    .long("force")
+                    .global(false)
+                    .build(),
+            )
+            .build();
+        run_cmd
+            .subcommands
+            .insert("sample:run".to_string(), task_cmd);
+
+        // Root global is LONG-ONLY: `--raw` with no short.
+        let mut cmd = SpecCommand::builder()
+            .name("test")
+            .flag(
+                SpecFlag::builder()
+                    .name("raw")
+                    .long("raw")
+                    .global(true)
+                    .build(),
+            )
+            .build();
+        cmd.subcommands.insert("run".to_string(), run_cmd);
+
+        Spec {
+            name: "test".to_string(),
+            bin: "test".to_string(),
+            cmd,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_orphan_short_alias_survives_merge() {
+        // Follow-up to test_prefix_global_flag_does_not_pollute_choices (jdx/mise#10069):
+        // when `run` re-declares the long-only global `--raw` as a non-global `-r --raw`, the
+        // added short `-r` must be unioned onto the surviving inherited global flag instead of
+        // being discarded with the wholesale re-declaration. Otherwise `mycli run -r <task>`
+        // would not recognize `-r` and would mis-validate it against the task's `choices` arg.
+        let spec = mounted_orphan_short_spec();
+
+        let parsed = parse_partial(&spec, &input(&["test", "run", "-r", "sample:run"])).unwrap();
+        assert_eq!(
+            parsed
+                .cmds
+                .iter()
+                .map(|c| c.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["test", "run", "sample:run"],
+        );
+
+        // (a) The orphan short `-r` survives the descent, merged onto the inherited global flag,
+        // and the original long `--raw` is still global too.
+        assert!(
+            parsed.available_flags.get("-r").is_some_and(|f| f.global),
+            "-r must be merged onto the inherited global flag and stay global after descent",
+        );
+        assert!(
+            parsed
+                .available_flags
+                .get("--raw")
+                .is_some_and(|f| f.global),
+            "--raw must stay global after descent",
+        );
+
+        // (b) The token is consumed as a flag, not mistaken for the `choices` positional.
+        assert!(
+            parsed.args.is_empty(),
+            "args should be empty, got {:?}",
+            parsed.args
+        );
+
+        // (c) The value still reaches as_env() so `usage_raw` is produced for execution/mounts.
+        assert_eq!(
+            parsed.as_env().get("usage_raw").map(String::as_str),
+            Some("true"),
+            "merged short's value must survive in as_env(), got {:?}",
+            parsed.as_env(),
+        );
+
+        // (d) Negative case: a purely-local flag that shares nothing with a global is NOT
+        // promoted/merged — it is correctly dropped when descending into the mount.
+        assert!(
+            parsed.available_flags.get("-f").is_none(),
+            "purely-local -f must not be promoted onto a global",
+        );
+        assert!(
+            parsed.available_flags.get("--force").is_none(),
+            "purely-local --force must not be promoted onto a global",
+        );
+
+        // A real, valid choice still parses through the merged short prefix.
+        let parsed =
+            parse_partial(&spec, &input(&["test", "run", "-r", "sample:run", "alpha"])).unwrap();
+        assert_eq!(parsed.args.len(), 1);
+        assert_eq!(parsed.args.values().next().unwrap().to_string(), "alpha");
+
+        // And genuinely invalid choices are still rejected.
+        assert_parse_err(
+            parse_partial(&spec, &input(&["test", "run", "-r", "sample:run", "wrong"])),
+            "Invalid choice for arg profile: wrong, expected one of alpha, beta, gamma",
+        );
+    }
+
+    #[test]
+    fn test_subcommand_alias_collision_keeps_last_owner() {
+        // The orphan-alias merge must not disturb how two flags in the SAME subcommand that
+        // share an alias are resolved. Historically the flattened flag map gave the shared
+        // alias to the LAST-declared flag (last-writer-wins); that must be preserved.
+        let run_cmd = SpecCommand::builder()
+            .name("run")
+            .flag(
+                SpecFlag::builder()
+                    .name("alpha")
+                    .short('x')
+                    .long("alpha")
+                    .global(false)
+                    .build(),
+            )
+            .flag(
+                SpecFlag::builder()
+                    .name("beta")
+                    .short('x')
+                    .long("beta")
+                    .global(false)
+                    .build(),
+            )
+            .build();
+        let mut cmd = SpecCommand::builder().name("test").build();
+        cmd.subcommands.insert("run".to_string(), run_cmd);
+        let spec = Spec {
+            name: "test".to_string(),
+            bin: "test".to_string(),
+            cmd,
+            ..Default::default()
+        };
+
+        let parsed = parse_partial(&spec, &input(&["test", "run"])).unwrap();
+        // `-x` is declared by both flags; the last one (`beta`) keeps it, as before the fix.
+        assert_eq!(
+            parsed.available_flags.get("-x").map(|f| f.name.as_str()),
+            Some("beta"),
+            "the last-declared flag must keep a shared short alias",
+        );
+        // Both distinct long aliases remain recognized and point to their own flag.
+        assert_eq!(
+            parsed
+                .available_flags
+                .get("--alpha")
+                .map(|f| f.name.as_str()),
+            Some("alpha"),
+        );
+        assert_eq!(
+            parsed
+                .available_flags
+                .get("--beta")
+                .map(|f| f.name.as_str()),
+            Some("beta"),
         );
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #649. When a subcommand re-declares an inherited **global** flag as **non-global**, `merge_subcommand_flags` kept the global flag (global precedence) but **discarded the re-declaration wholesale**, silently dropping any alias (short or long) that exists **only** on the re-declaration.

Concrete downstream case (mise): the long-only globals `--raw`/`--silent` are re-declared by `run`/`tasks run` as non-global but with an **added short** (`-r --raw`, `-S --silent`). After #649's merge the surviving global was long-only and the short was thrown away, so completing a mounted task with the short in front failed:

```
mycli run -r sample:run -- <TAB>      # → "unexpected word" / "Invalid choice" instead of the task's choices
mycli tasks run -S sample:run -- <TAB>
```

This is the inverse of the `-C/--cd` case #649 fixed: there the short already lived on the global flag, so nothing was lost; here it lives only on the non-global re-declaration, so global precedence threw it away.

## What changed

When the merge keeps an inherited global over a non-global re-declaration of the **same logical flag**, it now **unions the re-declaration's extra `short`/`long` aliases onto the surviving global flag**:

- "Same logical flag" is matched on a **shared long name** (the precise, safe signal — mise's re-declarations share `--raw`/`--silent`). Sharing only a short with an *unrelated* global (`-q --quiet` vs a hypothetical `-q --quoting`) is a genuine collision, **not** merged.
- The merged flag stays `global`, so the orphan short survives the next descent's `retain` and is recognized wherever the global is — during completion and normal parsing, before and inside a mounted subcommand — and still reaches `as_env()` (so `usage_*` env vars are produced for execution/mount scripts).
- The merge iterates the flattened flag map directly, so **intra-subcommand alias collisions keep their existing last-writer-wins resolution** (no behavior change there).

mise currently works around this by promoting these orphan-short flags back to `global=true` (`promote_orphan_shorts`); this change makes that workaround unnecessary.

## Tests

- **Unit** (`lib/src/parse.rs`):
  - `test_orphan_short_alias_survives_merge` — long-only global `--raw` re-declared by `run` as non-global `-r --raw` + a mounted `sample:run` with a `choices` arg. Asserts the short survives merged onto the global (stays `global`), is consumed as a flag (not the `choices` positional), reaches `as_env()` as `usage_raw=true`, and that a purely-local `-f/--force` is **not** promoted.
  - `test_subcommand_alias_collision_keeps_last_owner` — locks the last-writer-wins resolution for two flags in the same subcommand sharing a short.
- **Integration** (`cli/tests/complete_word.rs` + new `examples/mounted-orphan-short-flags.sh`): covers `run -r`, `run -S`, `tasks run -r`, and the `--raw` long alias, asserting the mounted task's choices complete.

`cargo test --all --all-features`, `cargo clippy --all --all-features -- -D warnings`, and `cargo fmt --all --check` all pass.

## Downstream follow-up (not in this repo)

Once this lands and ships in a usage release:

- mise can delete `promote_orphan_shorts` from `src/cli/usage.rs` and the `-r/-S` `global=#true` markers in `mise.usage.kdl`, relying entirely on usage's parser.
- mise's `min_usage_version` should then be bumped from `"3.4"` to the release containing this fix.

References: mise PR #10176 (the workaround narrowing), discussion #10069, and mise's regression test `e2e/tasks/test_task_completion_global_cd` which exercises the `-r`/`-S` orphan-short paths over both `run` and `tasks run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CLI completion now correctly recognizes short option flags placed before mounted subcommands, preventing completion failures with short-form aliases.

* **Tests**
  * Added a regression test covering completion behavior for orphaned short flags, alias collisions, and env propagation.

* **Documentation**
  * Added an example script demonstrating short-flag handling with mounted subcommands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->