### PR TITLE
fix(complete): exit cleanly when words before the cursor fail to parse

### DIFF
--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -98,7 +98,19 @@ impl CompleteWord {
             ctx.insert("PREV", &(cword - 1));
         }
 
-        let parsed = usage::parse::parse_partial(spec, &words)?;
+        // The words before the cursor may not parse (e.g. an unexpected word
+        // earlier on the line). A completion helper must stay silent rather than
+        // surface a hard parse error to stderr, which garbles the shell prompt
+        // mid-completion — emit no candidates instead. (#596)
+        let parsed = match usage::parse::parse_partial(spec, &words) {
+            Ok(parsed) => parsed,
+            Err(e) => {
+                debug!(
+                    "parse_partial failed during completion (words: {words:?}), no candidates: {e}"
+                );
+                return Ok(vec![]);
+            }
+        };
         debug!("parsed cmd: {}", parsed.cmd.full_cmd.join(" "));
 
         // Check if previous token was a restart_token - if so, complete from first arg

--- a/cli/tests/complete_word.rs
+++ b/cli/tests/complete_word.rs
@@ -16,6 +16,21 @@ fn complete_word_completer() {
 }
 
 #[test]
+fn complete_word_after_unexpected_word_is_silent() {
+    // #596: completion after an unexpected word must NOT print a hard parse error
+    // to stderr (which garbles the shell prompt) — the helper should exit 0 with
+    // no candidates instead.
+    let spec = "name \"mycli\"\ncmd \"build\"\ncmd \"test\"\n";
+    Command::new(cargo::cargo_bin!("usage"))
+        .args([
+            "cw", "--shell", "bash", "--spec", spec, "--", "mycli", "help", "",
+        ])
+        .assert()
+        .success()
+        .stdout("");
+}
+
+#[test]
 fn complete_word_subcommands() {
     assert_cmd("basic.usage.kdl", &["plugins", "install"]).stdout(contains("install"));
 }
@@ -258,11 +273,14 @@ fn complete_word_non_global_flags_stop_search() {
     path.insert(0, env::current_dir().unwrap().join("..").join("examples"));
     env::set_var("PATH", env::join_paths(path).unwrap());
 
-    // Non-global flag --local should stop subcommand search
-    // The parser will fail to recognize 'run' as a subcommand and error
+    // Non-global flag --local stops the subcommand search, so 'run' is not
+    // recognized as a subcommand. Completion must still exit cleanly with no
+    // candidates — NOT surface a hard parse error to stderr, which would garble
+    // the shell prompt (#596). (Previously this asserted .failure() with
+    // "unexpected word", which was the bug.)
     let mut cmd = cmd("test-boolean-flags.sh", Some("fish"));
     cmd.args(["--", "--local", "run", ""]);
-    cmd.assert().failure().stderr(contains("unexpected word"));
+    cmd.assert().success().stdout("");
 }
 
 #[test]


### PR DESCRIPTION
Fixes #596.

## the problem

shell completion runs `usage complete-word` inline as you type. when the words before the cursor don't parse (e.g. an unexpected word earlier on the line, or a non-global flag that stops the subcommand search), `complete_word` was calling `parse_partial(...)?` and letting the parse error propagate. that error gets printed to stderr mid-completion, which garbles the prompt instead of just giving you no candidates.

repro with a tiny spec:

```
$ usage cw --shell bash --spec 'name "mycli"
cmd "build"
cmd "test"' -- mycli help ""
# before: exit 1, "unexpected word: help" on stderr -> messes up the prompt
# after:  exit 0, no output -> no candidates, prompt stays clean
```

## the fix

catch the parse error in the completion path and return no candidates (exit 0), logging it at `debug!` so it's still visible when debugging completions. the library `parse_partial` stays strict for every other caller. the completion helper is the one place a parse failure should be silent rather than surfaced, because its stdout/stderr land directly in the user's prompt.

one-line change in `cli/src/cli/complete_word.rs`, plus tests.

## heads up on the test change

i updated an existing test, `complete_word_non_global_flags_stop_search`. it previously asserted `.failure()` with `"unexpected word"` on stderr — which was exactly the buggy behavior #596 reports (a non-global flag stops the search, parse fails, error hits the prompt). with the fix it now asserts `.success()` with empty stdout. flagging it explicitly so the change in expectation is obvious in review rather than buried in the diff. if you'd rather that path keep erroring, let me know and i'll rethink the approach.

also added `complete_word_after_unexpected_word_is_silent` as a direct regression test for the #596 case.

## verification

- `cargo test --all --all-features` — the completion suite is green (one pre-existing bash shell-integration test, `test_bash_completion_init_integration`, fails identically on a clean checkout in my env — unrelated to this change)
- `cargo clippy --all --all-features -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo build --all` — clean

_This PR was authored with the help of Claude Code._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Shell completion no longer emits parse errors to stderr; failures during completion are handled silently and return no suggestions, preventing garbled shell prompts.
* **Tests**
  * Added and updated regression tests to ensure completion remains silent on unexpected input and returns empty results instead of error output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->