### PR TITLE
fix(zsh): show all matches when subcommand names contain `:`

### DIFF
--- a/cli/assets/completions/_usage
+++ b/cli/assets/completions/_usage
@@ -25,15 +25,31 @@ _usage() {
 
   local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_usage.spec"
   usage --usage-spec >| "$spec_file"
-  local -a completions=() inserts=()
-  local needs_menu=0 display insert
-  while IFS=$'\t' read -r display insert; do
-    completions+=("$display")
-    inserts+=("${insert//:/\\:}")
+  local -a values=() descs=() inserts=()
+  local needs_menu=0 value desc insert
+  while IFS=$'\t' read -r value desc insert; do
+    values+=("$value")
+    descs+=("$desc")
+    inserts+=("$insert")
     [[ "$insert" == "'"* ]] && needs_menu=1
   done < <(command usage complete-word --shell zsh -f "$spec_file" -- "${(Q)words[@]}")
   (( needs_menu )) && compstate[insert]=menu
-  _describe 'completions' completions inserts -U -Q -S ''
+  if (( ${#inserts[@]} )); then
+    local -a _usage_display=()
+    local _usage_i _usage_max=0 _usage_v _usage_pad
+    for _usage_v in "${values[@]}"; do
+      (( ${#_usage_v} > _usage_max )) && _usage_max=${#_usage_v}
+    done
+    for ((_usage_i=1; _usage_i<=${#values[@]}; _usage_i++)); do
+      if [[ -n "${descs[_usage_i]}" ]]; then
+        _usage_pad=$(( _usage_max - ${#values[_usage_i]} ))
+        _usage_display+=("${values[_usage_i]}${(l:_usage_pad:: :)}  -- ${descs[_usage_i]}")
+      else
+        _usage_display+=("${values[_usage_i]}")
+      fi
+    done
+    compadd -l -d _usage_display -U -Q -S '' -a inserts
+  fi
   return 0
 }
 

--- a/cli/assets/completions/_usage
+++ b/cli/assets/completions/_usage
@@ -26,12 +26,13 @@ _usage() {
   local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_usage.spec"
   usage --usage-spec >| "$spec_file"
   local -a values=() descs=() inserts=()
-  local needs_menu=0 value desc insert
-  while IFS=$'\t' read -r value desc insert; do
-    values+=("$value")
-    descs+=("$desc")
-    inserts+=("$insert")
-    [[ "$insert" == "'"* ]] && needs_menu=1
+  local needs_menu=0 line
+  while IFS= read -r line; do
+    local -a parts=("${(@ps:\t:)line}")
+    values+=("${parts[1]}")
+    descs+=("${parts[2]}")
+    inserts+=("${parts[3]}")
+    [[ "${parts[3]}" == "'"* ]] && needs_menu=1
   done < <(command usage complete-word --shell zsh -f "$spec_file" -- "${(Q)words[@]}")
   (( needs_menu )) && compstate[insert]=menu
   if (( ${#inserts[@]} )); then

--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -59,20 +59,20 @@ impl CompleteWord {
                     }
                 }
                 "zsh" => {
-                    // Two tab-separated columns per line:
-                    //   1. `value:description` (or just `value`) for _describe's
-                    //      menu rendering and prefix matching, with `:` `(` `)`
-                    //      `[` `]` escaped as `_describe` requires.
-                    //   2. The shell-quoted form that `compadd -Q` should insert
-                    //      verbatim — wrapped in single quotes when the value
-                    //      contains shell metacharacters, raw otherwise.
-                    let display = if any_descriptions {
-                        format!("{}:{}", zsh_escape(&c), zsh_escape(&description))
-                    } else {
-                        zsh_escape(&c)
-                    };
+                    // Three tab-separated columns per line:
+                    //   1. The raw value (used as the menu display label).
+                    //   2. The description (may be empty).
+                    //   3. The shell-quoted form that `compadd -Q` should
+                    //      insert verbatim — wrapped in single quotes when
+                    //      the value contains shell metacharacters, raw
+                    //      otherwise.
+                    // The generated zsh script builds the formatted display
+                    // (`value -- description`) from columns 1 and 2 and uses
+                    // column 3 as the inserted match. Keeping these as three
+                    // distinct fields avoids the `\:`-escaping acrobatics
+                    // that `_describe`'s `value:description` format required.
                     let insert = zsh_shell_quote(&c);
-                    println!("{display}\t{insert}")
+                    println!("{c}\t{description}\t{insert}")
                 }
                 _ => miette::bail!("unsupported shell: {}", shell),
             }
@@ -367,16 +367,6 @@ impl CompleteWord {
             .sorted()
             .collect()
     }
-}
-
-/// Escape special characters for zsh's `_describe` function.
-/// Colons are field separators, parentheses and brackets are glob qualifiers.
-fn zsh_escape(s: &str) -> String {
-    s.replace(':', "\\:")
-        .replace('(', "\\(")
-        .replace(')', "\\)")
-        .replace('[', "\\[")
-        .replace(']', "\\]")
 }
 
 /// Wrap a completion value in single quotes if any character would otherwise

--- a/cli/tests/complete_word.rs
+++ b/cli/tests/complete_word.rs
@@ -388,29 +388,31 @@ fn complete_word_escaped_colons_in_completions() {
 }
 
 #[test]
-fn complete_word_zsh_escapes_parens_and_brackets() {
-    // zsh's _describe interprets parentheses as glob qualifiers and brackets
-    // as character classes, so they must be escaped in the display column.
-    // The second (insert) column is shell-quoted for `compadd -Q`.
+fn complete_word_zsh_three_columns_with_descriptions() {
+    // zsh output is three tab-separated columns per line: raw value, raw
+    // description, shell-quoted insert. No `\:`/`\(`/`\[` escaping is needed
+    // because the generated completion script builds the menu display from
+    // the value/description columns directly (no `_describe`).
     // See: https://github.com/jdx/usage/issues/558
     let mut c = cmd("parens-in-descriptions.usage.kdl", Some("zsh"));
     c.args(["--", "run", ""]);
     c.assert().success().stdout(
-        "connect\\:server:Connect server \\(Hot Reload\\)\tconnect:server\n\
-         test\\:unit:Run tests \\[fast\\]\ttest:unit\n\
-         build:Build project\tbuild\n",
+        "connect:server\tConnect server (Hot Reload)\tconnect:server\n\
+         test:unit\tRun tests [fast]\ttest:unit\n\
+         build\tBuild project\tbuild\n",
     );
 }
 
 #[test]
-fn complete_word_zsh_escapes_colons_without_descriptions() {
-    // Display column has `\:` escapes for `_describe`; insert column has the
-    // raw value (no shell-quoting needed — colons aren't shell-special).
+fn complete_word_zsh_three_columns_without_descriptions() {
+    // Description column is empty when no description is set, but the three
+    // tab-separated columns are still emitted so the receiving template can
+    // parse uniformly with `read -r value desc insert`.
     let mut c = cmd("zsh-colons-without-descriptions.usage.kdl", Some("zsh"));
     c.args(["--", "run", ""]);
     c.assert()
         .success()
-        .stdout("test\\:git\ttest:git\ntest\\:nvim\ttest:nvim\n");
+        .stdout("test:git\t\ttest:git\ntest:nvim\t\ttest:nvim\n");
 }
 
 fn cmd(example: &str, shell: Option<&str>) -> Command {

--- a/cli/tests/shell_completions_integration.rs
+++ b/cli/tests/shell_completions_integration.rs
@@ -641,14 +641,128 @@ arg "<recipient>" required {
         .expect("Failed to generate zsh completion");
     let script = String::from_utf8_lossy(&gen.stdout);
     let expected_fragments = [
-        "(Q)words",                                          // unquote user input
-        r#"IFS=$'\t' read -r display insert"#,               // tab-separated
-        "_describe 'completions' completions inserts -U -Q", // -U -Q on _describe
+        "(Q)words",                            // unquote user input
+        r#"IFS=$'\t' read -r display insert"#, // tab-separated
+        "compadd -l -d _usage_display -U -Q -S '' -a inserts", // -U -Q on compadd
     ];
     for fragment in expected_fragments {
         assert!(
             script.contains(fragment),
             "Expected `{fragment}` in generated script:\n{script}"
+        );
+    }
+
+    let _ = fs::remove_dir_all(&temp_dir);
+}
+
+/// Regression test: subcommands whose names contain `:` (e.g. `release:create`,
+/// `release:docs-sync`, `release:pr`) must all appear in the completion menu.
+///
+/// The previous implementation handed `\:`-escaped `value:description` strings
+/// to `_describe`, which groups matches that share a `\:`-escaped prefix and
+/// surfaces only one entry per group — so out of four `release:*` subcommands
+/// only `release:create` would show. This test feeds the spec through a real
+/// zsh + zpty session and asserts every colon-named subcommand is offered.
+#[test]
+fn test_zsh_completion_includes_all_colon_subcommands() {
+    if skip_if_shell_missing("zsh") {
+        return;
+    }
+
+    let usage_bin = build_usage_binary();
+    let temp_dir = env::temp_dir().join(format!(
+        "usage_zsh_colon_subs_test_{}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&temp_dir).unwrap();
+
+    let spec = r#"
+bin "testcli"
+cmd "release:create" help="Create release"
+cmd "release:docs-sync" help="Refresh docs"
+cmd "release:pr" help="Open release PR"
+cmd "release:update" help="Update release state"
+cmd "lint" help="Run lints"
+cmd "lint:fix" help="Auto-fix lints"
+"#;
+    let spec_kdl_file = temp_dir.join("testcli.kdl");
+    fs::write(&spec_kdl_file, spec).unwrap();
+
+    let gen = Command::new(&usage_bin)
+        .args(["generate", "completion", "zsh", "testcli", "-f"])
+        .arg(spec_kdl_file.to_str().unwrap())
+        .output()
+        .expect("Failed to generate zsh completion");
+    let comp_file = temp_dir.join("_testcli");
+    fs::write(&comp_file, &gen.stdout).unwrap();
+
+    let test_script = format!(
+        r#"#!/bin/zsh
+export PATH="{usage_dir}:$PATH"
+export TMPDIR="{tmp}"
+
+autoload -U compinit
+compinit -D
+
+source {comp}
+echo "LOAD_SUCCESS"
+
+comptest () {{
+    bindkey '^I' complete-word
+    zle -C {{,,}}complete-word
+    complete-word () {{
+        unset 'compstate[vared]'
+        compadd -x $'\002'
+        _main_complete "$@"
+        compadd -J -last- -x $'\003'
+        exit
+    }}
+    vared -c tmp
+}}
+
+zmodload zsh/zpty
+zpty comptest comptest
+zpty -w comptest $'testcli \t'
+zpty -rt 5 comptest REPLY $'*\002' 2>/dev/null
+zpty -rt 5 comptest REPLY $'*\003' 2>/dev/null
+echo "COMPLETIONS_START"
+echo "$REPLY"
+echo "COMPLETIONS_END"
+zpty -d comptest
+"#,
+        usage_dir = usage_bin.parent().unwrap().to_str().unwrap(),
+        tmp = temp_dir.to_str().unwrap(),
+        comp = comp_file.to_str().unwrap(),
+    );
+
+    let script_file = temp_dir.join("test.zsh");
+    fs::write(&script_file, &test_script).unwrap();
+
+    let result = Command::new("timeout")
+        .args(["10", "zsh"])
+        .arg(script_file.to_str().unwrap())
+        .output()
+        .expect("Failed to run zsh test");
+    let stdout = String::from_utf8_lossy(&result.stdout);
+    let stderr = String::from_utf8_lossy(&result.stderr);
+
+    assert!(
+        stdout.contains("LOAD_SUCCESS"),
+        "completion script failed to load.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let expected = [
+        "release:create",
+        "release:docs-sync",
+        "release:pr",
+        "release:update",
+        "lint",
+        "lint:fix",
+    ];
+    for sub in expected {
+        assert!(
+            stdout.contains(sub),
+            "Expected subcommand `{sub}` in completion output.\nstdout:\n{stdout}\nstderr:\n{stderr}"
         );
     }
 

--- a/cli/tests/shell_completions_integration.rs
+++ b/cli/tests/shell_completions_integration.rs
@@ -507,10 +507,10 @@ zpty comptest comptest
 zpty -w comptest $'testcli \t'
 
 # Read up to first delimiter (with timeout)
-zpty -rt 2 comptest REPLY $'*\002' 2>/dev/null
+zpty -r comptest REPLY $'*\002' 2>/dev/null
 
-# Read actual completions (with timeout)
-zpty -rt 2 comptest REPLY $'*\003' 2>/dev/null
+# Read actual completions
+zpty -r comptest REPLY $'*\003' 2>/dev/null
 
 # Check if we got completions
 if [[ -n "${{REPLY%$'\003'}}" ]]; then
@@ -643,7 +643,7 @@ arg "<recipient>" required {
     let script = String::from_utf8_lossy(&gen.stdout);
     let expected_fragments = [
         "(Q)words",                                            // unquote user input
-        r#"IFS=$'\t' read -r value desc insert"#,              // three tab-separated columns
+        r#"${(@ps:\t:)line}"#,                                 // tab-split preserves empty fields
         "compadd -l -d _usage_display -U -Q -S '' -a inserts", // -U -Q on compadd
     ];
     for fragment in expected_fragments {
@@ -662,8 +662,9 @@ arg "<recipient>" required {
 /// The previous implementation handed `\:`-escaped `value:description` strings
 /// to `_describe`, which groups matches that share a `\:`-escaped prefix and
 /// surfaces only one entry per group — so out of four `release:*` subcommands
-/// only `release:create` would show. This test feeds the spec through a real
-/// zsh + zpty session and asserts every colon-named subcommand is offered.
+/// only `release:create` would show. The fix switches to `compadd` driven by
+/// three-column output; this test stubs `compadd` to capture the inserts array
+/// and asserts every colon-named subcommand is passed individually.
 #[test]
 fn test_zsh_completion_includes_all_colon_subcommands() {
     if skip_if_shell_missing("zsh") {
@@ -671,10 +672,8 @@ fn test_zsh_completion_includes_all_colon_subcommands() {
     }
 
     let usage_bin = build_usage_binary();
-    let temp_dir = env::temp_dir().join(format!(
-        "usage_zsh_colon_subs_test_{}",
-        std::process::id()
-    ));
+    let temp_dir =
+        env::temp_dir().join(format!("usage_zsh_colon_subs_test_{}", std::process::id()));
     fs::create_dir_all(&temp_dir).unwrap();
 
     let spec = r#"
@@ -697,39 +696,26 @@ cmd "lint:fix" help="Auto-fix lints"
     let comp_file = temp_dir.join("_testcli");
     fs::write(&comp_file, &gen.stdout).unwrap();
 
+    // Drive the generated `_testcli` function directly with stubbed compadd
+    // so we can inspect the inserts array without needing a real ZLE context.
     let test_script = format!(
-        r#"#!/bin/zsh
+        r#"#!/usr/bin/env zsh
+set -e
 export PATH="{usage_dir}:$PATH"
 export TMPDIR="{tmp}"
 
 autoload -U compinit
-compinit -D
-
+compinit -u
 source {comp}
-echo "LOAD_SUCCESS"
 
-comptest () {{
-    bindkey '^I' complete-word
-    zle -C {{,,}}complete-word
-    complete-word () {{
-        unset 'compstate[vared]'
-        compadd -x $'\002'
-        _main_complete "$@"
-        compadd -J -last- -x $'\003'
-        exit
-    }}
-    vared -c tmp
+compadd() {{
+    local i="${{inserts[*]}}"
+    print -r -- "[compadd:inserts] $i"
 }}
 
-zmodload zsh/zpty
-zpty comptest comptest
-zpty -w comptest $'testcli \t'
-zpty -rt 5 comptest REPLY $'*\002' 2>/dev/null
-zpty -rt 5 comptest REPLY $'*\003' 2>/dev/null
-echo "COMPLETIONS_START"
-echo "$REPLY"
-echo "COMPLETIONS_END"
-zpty -d comptest
+words=(testcli "")
+CURRENT=2
+_testcli
 "#,
         usage_dir = usage_bin.parent().unwrap().to_str().unwrap(),
         tmp = temp_dir.to_str().unwrap(),
@@ -739,18 +725,12 @@ zpty -d comptest
     let script_file = temp_dir.join("test.zsh");
     fs::write(&script_file, &test_script).unwrap();
 
-    let result = Command::new("timeout")
-        .args(["10", "zsh"])
+    let result = Command::new("zsh")
         .arg(script_file.to_str().unwrap())
         .output()
         .expect("Failed to run zsh test");
     let stdout = String::from_utf8_lossy(&result.stdout);
     let stderr = String::from_utf8_lossy(&result.stderr);
-
-    assert!(
-        stdout.contains("LOAD_SUCCESS"),
-        "completion script failed to load.\nstdout:\n{stdout}\nstderr:\n{stderr}"
-    );
 
     let expected = [
         "release:create",
@@ -763,7 +743,7 @@ zpty -d comptest
     for sub in expected {
         assert!(
             stdout.contains(sub),
-            "Expected subcommand `{sub}` in completion output.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+            "Expected subcommand `{sub}` in compadd inserts.\nstdout:\n{stdout}\nstderr:\n{stderr}"
         );
     }
 
@@ -1073,8 +1053,9 @@ fn test_zsh_completion_init_integration() {
     let usage_bin = build_usage_binary();
     let (temp_dir, bin_dir, init_script) = stage_init_test_env(&usage_bin, "zsh", "zsh");
 
-    // Stub `_describe`/`_files` to capture what the handler offers without
+    // Stub `compadd`/`_files` to capture what the handler offers without
     // needing an interactive ZLE context. Drive with $words/$CURRENT.
+    // The init template calls `compadd -l -d <display-arr> -U -Q -S '' -a <inserts-arr>`.
     let test_script = format!(
         r#"#!/usr/bin/env zsh
 set -e
@@ -1083,11 +1064,11 @@ autoload -U compinit
 compinit -u
 source "{init_script}"
 
-_describe() {{
-    local arr_name="$2"
-    local -a items
-    items=("${{(@P)arr_name}}")
-    print -r -- "[describe:$1] ${{items[*]}}"
+compadd() {{
+    local d="${{_usage_display[*]}}"
+    local i="${{inserts[*]}}"
+    print -r -- "[compadd:display] $d"
+    print -r -- "[compadd:inserts] $i"
 }}
 _files() {{ print -r -- "[files-fallback]" }}
 
@@ -1119,13 +1100,116 @@ _usage_default_complete
         "zsh init script exited non-zero. stderr: {stderr}"
     );
     assert!(
-        stdout.contains("[describe:completions] val-1 val-2 val-3"),
-        "expected positional completions via _describe, got: {stdout}"
+        stdout.contains("[compadd:inserts] val-1 val-2 val-3"),
+        "expected positional completions in compadd inserts, got: {stdout}"
     );
     assert!(
-        stdout.contains("--foo:Flag value"),
-        "expected --foo flag with description in _describe items, got: {stdout}"
+        stdout.contains("[compadd:display]") && stdout.contains("--foo"),
+        "expected --foo flag in compadd display, got: {stdout}"
     );
+
+    let _ = fs::remove_dir_all(&temp_dir);
+}
+
+/// Regression: init script (`compdef -default-` handler) must surface every
+/// colon-named subcommand, not collapse them via `_describe` grouping.
+/// Mirrors `test_zsh_completion_includes_all_colon_subcommands` but exercises
+/// the shebang/init path instead of a per-bin `compdef` registration.
+#[test]
+fn test_zsh_init_completion_includes_all_colon_subcommands() {
+    if skip_if_shell_missing("zsh") {
+        return;
+    }
+
+    let usage_bin = build_usage_binary();
+    let temp_dir = env::temp_dir().join(format!(
+        "usage_zsh_init_colon_subs_test_{}",
+        std::process::id()
+    ));
+    let bin_dir = temp_dir.join("bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+
+    let script = "\
+#!/usr/bin/env -S usage bash
+#USAGE bin \"testcli\"
+#USAGE cmd \"release:create\" help=\"Create release\"
+#USAGE cmd \"release:docs-sync\" help=\"Refresh docs\"
+#USAGE cmd \"release:pr\" help=\"Open release PR\"
+#USAGE cmd \"release:update\" help=\"Update release state\"
+#USAGE cmd \"lint\" help=\"Run lints\"
+#USAGE cmd \"lint:fix\" help=\"Auto-fix lints\"
+";
+    let script_path = bin_dir.join("testcli");
+    fs::write(&script_path, script).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&script_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&script_path, perms).unwrap();
+    }
+
+    let gen = Command::new(&usage_bin)
+        .args(["generate", "completion-init", "zsh"])
+        .output()
+        .expect("Failed to generate completion-init");
+    assert!(
+        gen.status.success(),
+        "completion-init failed: {}",
+        String::from_utf8_lossy(&gen.stderr)
+    );
+    let init_script = temp_dir.join("init.zsh");
+    fs::write(&init_script, &gen.stdout).unwrap();
+
+    let test_script = format!(
+        r#"#!/usr/bin/env zsh
+set -e
+export PATH="{bin_dir}:{usage_dir}:$PATH"
+export TMPDIR="{tmp}"
+
+autoload -U compinit
+compinit -u
+source "{init}"
+
+compadd() {{
+    local i="${{inserts[*]}}"
+    print -r -- "[compadd:inserts] $i"
+}}
+
+words=(testcli "")
+CURRENT=2
+_usage_default_complete
+"#,
+        bin_dir = bin_dir.to_str().unwrap(),
+        usage_dir = usage_bin.parent().unwrap().to_str().unwrap(),
+        tmp = temp_dir.to_str().unwrap(),
+        init = init_script.to_str().unwrap(),
+    );
+
+    let script_file = temp_dir.join("test.zsh");
+    fs::write(&script_file, &test_script).unwrap();
+
+    let result = Command::new("zsh")
+        .arg(script_file.to_str().unwrap())
+        .output()
+        .expect("Failed to run zsh init test");
+    let stdout = String::from_utf8_lossy(&result.stdout);
+    let stderr = String::from_utf8_lossy(&result.stderr);
+
+    let expected = [
+        "release:create",
+        "release:docs-sync",
+        "release:pr",
+        "release:update",
+        "lint",
+        "lint:fix",
+    ];
+    for sub in expected {
+        assert!(
+            stdout.contains(sub),
+            "Expected subcommand `{sub}` in init-path compadd inserts.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+    }
 
     let _ = fs::remove_dir_all(&temp_dir);
 }

--- a/cli/tests/shell_completions_integration.rs
+++ b/cli/tests/shell_completions_integration.rs
@@ -731,6 +731,11 @@ _testcli
         .expect("Failed to run zsh test");
     let stdout = String::from_utf8_lossy(&result.stdout);
     let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(
+        result.status.success(),
+        "zsh completion script exited non-zero ({}).\nstdout:\n{stdout}\nstderr:\n{stderr}",
+        result.status
+    );
 
     let expected = [
         "release:create",
@@ -1195,6 +1200,11 @@ _usage_default_complete
         .expect("Failed to run zsh init test");
     let stdout = String::from_utf8_lossy(&result.stdout);
     let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(
+        result.status.success(),
+        "zsh init completion script exited non-zero ({}).\nstdout:\n{stdout}\nstderr:\n{stderr}",
+        result.status
+    );
 
     let expected = [
         "release:create",

--- a/cli/tests/shell_completions_integration.rs
+++ b/cli/tests/shell_completions_integration.rs
@@ -607,9 +607,9 @@ arg "<recipient>" required {
         .expect("Failed to run complete-word");
     let raw_stdout = String::from_utf8_lossy(&raw.stdout);
     let expected_lines = [
-        "Alice Alice\t'Alice Alice'",
-        "Bob Bob\t'Bob Bob'",
-        "Carol Carol\t'Carol Carol'",
+        "Alice Alice\t\t'Alice Alice'",
+        "Bob Bob\t\t'Bob Bob'",
+        "Carol Carol\t\t'Carol Carol'",
     ];
     for line in expected_lines {
         assert!(
@@ -618,8 +618,8 @@ arg "<recipient>" required {
         );
     }
 
-    // 2. The simple unquoted case still emits a tab + the raw value as the
-    //    insert column (no surrounding quotes).
+    // 2. The simple unquoted case still emits the three tab-separated columns
+    //    (value, empty description, raw insert with no surrounding quotes).
     let raw_simple = Command::new(&usage_bin)
         .args(["complete-word", "--shell", "zsh", "-s"])
         .arg(r#"arg "<env>" { choices "dev" "prod" }"#)
@@ -628,12 +628,13 @@ arg "<recipient>" required {
         .expect("Failed to run complete-word");
     let simple_stdout = String::from_utf8_lossy(&raw_simple.stdout);
     assert!(
-        simple_stdout.lines().any(|l| l == "dev\tdev"),
-        "Expected `dev\\tdev` in complete-word output, got:\n{simple_stdout}"
+        simple_stdout.lines().any(|l| l == "dev\t\tdev"),
+        "Expected `dev\\t\\tdev` in complete-word output, got:\n{simple_stdout}"
     );
 
-    // 3. The generated zsh completion script wires these two columns into
-    //    `_describe` with `-U -Q` so zsh inserts the pre-quoted value verbatim.
+    // 3. The generated zsh completion script wires the three columns into
+    //    `compadd -U -Q -d ...` so zsh inserts the pre-quoted value verbatim
+    //    without re-filtering.
     let gen = Command::new(&usage_bin)
         .args(["generate", "completion", "zsh", "testcli", "-f"])
         .arg(spec_kdl_file.to_str().unwrap())
@@ -641,8 +642,8 @@ arg "<recipient>" required {
         .expect("Failed to generate zsh completion");
     let script = String::from_utf8_lossy(&gen.stdout);
     let expected_fragments = [
-        "(Q)words",                            // unquote user input
-        r#"IFS=$'\t' read -r display insert"#, // tab-separated
+        "(Q)words",                                            // unquote user input
+        r#"IFS=$'\t' read -r value desc insert"#,              // three tab-separated columns
         "compadd -l -d _usage_display -U -Q -S '' -a inserts", // -U -Q on compadd
     ];
     for fragment in expected_fragments {
@@ -930,23 +931,24 @@ cmd other help="Another subcommand"
     let spec_file = temp_dir.join("test.spec");
     fs::write(&spec_file, usage_spec).unwrap();
 
-    // Test zsh output format: each line is `<display>\t<insert>` where
-    // <display> is `name:description` (or `name`) for `_describe`'s menu
-    // rendering, and <insert> is the shell-quoted form to insert verbatim
-    // via `compadd -Q`.
+    // Test zsh output format: each line is `<value>\t<description>\t<insert>`
+    // where <value> and <description> are the raw strings (no escaping) and
+    // <insert> is the shell-quoted form for `compadd -Q`. The generated
+    // completion script builds the menu label from value + description
+    // directly, so no `\:` / `\(` / `\[` escaping is needed.
     let output = run_complete_word(&usage_bin, "zsh", &spec_file, &["testcli", ""]);
     let lines: Vec<&str> = output.lines().collect();
 
     assert!(
-        lines.iter().any(|l| *l == "sub:A subcommand\tsub"),
-        "Expected 'sub:A subcommand\\tsub' in zsh output, got: {:?}",
+        lines.iter().any(|l| *l == "sub\tA subcommand\tsub"),
+        "Expected 'sub\\tA subcommand\\tsub' in zsh output, got: {:?}",
         lines
     );
     assert!(
         lines
             .iter()
-            .any(|l| *l == "other:Another subcommand\tother"),
-        "Expected 'other:Another subcommand\\tother' in zsh output, got: {:?}",
+            .any(|l| *l == "other\tAnother subcommand\tother"),
+        "Expected 'other\\tAnother subcommand\\tother' in zsh output, got: {:?}",
         lines
     );
 

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-2.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-2.snap
@@ -39,7 +39,25 @@ _mycli() {
     [[ "$insert" == "'"* ]] && needs_menu=1
   done < <(command usage complete-word --shell zsh -f "$spec_file" -- "${(Q)words[@]}")
   (( needs_menu )) && compstate[insert]=menu
-  _describe 'completions' completions inserts -U -Q -S ''
+  if (( ${#inserts[@]} )); then
+    local -a _usage_display=()
+    local _usage_i _usage_max=0 _usage_v _usage_esc _usage_desc _usage_pad
+    for _usage_v in "${inserts[@]}"; do
+      (( ${#_usage_v} > _usage_max )) && _usage_max=${#_usage_v}
+    done
+    for ((_usage_i=1; _usage_i<=${#inserts[@]}; _usage_i++)); do
+      _usage_esc="${inserts[_usage_i]//:/\\:}"
+      _usage_desc="${completions[_usage_i]#${_usage_esc}}"
+      _usage_desc="${_usage_desc#:}"
+      if [[ -n "$_usage_desc" ]]; then
+        _usage_pad=$(( _usage_max - ${#inserts[_usage_i]} ))
+        _usage_display+=("${inserts[_usage_i]}${(l:_usage_pad:: :)}  -- ${_usage_desc}")
+      else
+        _usage_display+=("${inserts[_usage_i]}")
+      fi
+    done
+    compadd -l -d _usage_display -U -Q -S '' -a inserts
+  fi
   return 0
 }
 

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-2.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-2.snap
@@ -32,12 +32,13 @@ _mycli() {
     mycli complete --usage >| "$spec_file"
   fi
   local -a values=() descs=() inserts=()
-  local needs_menu=0 value desc insert
-  while IFS=$'\t' read -r value desc insert; do
-    values+=("$value")
-    descs+=("$desc")
-    inserts+=("$insert")
-    [[ "$insert" == "'"* ]] && needs_menu=1
+  local needs_menu=0 line
+  while IFS= read -r line; do
+    local -a parts=("${(@ps:\t:)line}")
+    values+=("${parts[1]}")
+    descs+=("${parts[2]}")
+    inserts+=("${parts[3]}")
+    [[ "${parts[3]}" == "'"* ]] && needs_menu=1
   done < <(command usage complete-word --shell zsh -f "$spec_file" -- "${(Q)words[@]}")
   (( needs_menu )) && compstate[insert]=menu
   if (( ${#inserts[@]} )); then

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-2.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-2.snap
@@ -31,29 +31,27 @@ _mycli() {
   if [[ ! -f "$spec_file" ]]; then
     mycli complete --usage >| "$spec_file"
   fi
-  local -a completions=() inserts=()
-  local needs_menu=0 display insert
-  while IFS=$'\t' read -r display insert; do
-    completions+=("$display")
-    inserts+=("${insert//:/\\:}")
+  local -a values=() descs=() inserts=()
+  local needs_menu=0 value desc insert
+  while IFS=$'\t' read -r value desc insert; do
+    values+=("$value")
+    descs+=("$desc")
+    inserts+=("$insert")
     [[ "$insert" == "'"* ]] && needs_menu=1
   done < <(command usage complete-word --shell zsh -f "$spec_file" -- "${(Q)words[@]}")
   (( needs_menu )) && compstate[insert]=menu
   if (( ${#inserts[@]} )); then
     local -a _usage_display=()
-    local _usage_i _usage_max=0 _usage_v _usage_esc _usage_desc _usage_pad
-    for _usage_v in "${inserts[@]}"; do
+    local _usage_i _usage_max=0 _usage_v _usage_pad
+    for _usage_v in "${values[@]}"; do
       (( ${#_usage_v} > _usage_max )) && _usage_max=${#_usage_v}
     done
-    for ((_usage_i=1; _usage_i<=${#inserts[@]}; _usage_i++)); do
-      _usage_esc="${inserts[_usage_i]//:/\\:}"
-      _usage_desc="${completions[_usage_i]#${_usage_esc}}"
-      _usage_desc="${_usage_desc#:}"
-      if [[ -n "$_usage_desc" ]]; then
-        _usage_pad=$(( _usage_max - ${#inserts[_usage_i]} ))
-        _usage_display+=("${inserts[_usage_i]}${(l:_usage_pad:: :)}  -- ${_usage_desc}")
+    for ((_usage_i=1; _usage_i<=${#values[@]}; _usage_i++)); do
+      if [[ -n "${descs[_usage_i]}" ]]; then
+        _usage_pad=$(( _usage_max - ${#values[_usage_i]} ))
+        _usage_display+=("${values[_usage_i]}${(l:_usage_pad:: :)}  -- ${descs[_usage_i]}")
       else
-        _usage_display+=("${inserts[_usage_i]}")
+        _usage_display+=("${values[_usage_i]}")
       fi
     done
     compadd -l -d _usage_display -U -Q -S '' -a inserts

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-3.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-3.snap
@@ -88,7 +88,25 @@ __USAGE_EOF__
     [[ "$insert" == "'"* ]] && needs_menu=1
   done < <(command usage complete-word --shell zsh -f "$spec_file" -- "${(Q)words[@]}")
   (( needs_menu )) && compstate[insert]=menu
-  _describe 'completions' completions inserts -U -Q -S ''
+  if (( ${#inserts[@]} )); then
+    local -a _usage_display=()
+    local _usage_i _usage_max=0 _usage_v _usage_esc _usage_desc _usage_pad
+    for _usage_v in "${inserts[@]}"; do
+      (( ${#_usage_v} > _usage_max )) && _usage_max=${#_usage_v}
+    done
+    for ((_usage_i=1; _usage_i<=${#inserts[@]}; _usage_i++)); do
+      _usage_esc="${inserts[_usage_i]//:/\\:}"
+      _usage_desc="${completions[_usage_i]#${_usage_esc}}"
+      _usage_desc="${_usage_desc#:}"
+      if [[ -n "$_usage_desc" ]]; then
+        _usage_pad=$(( _usage_max - ${#inserts[_usage_i]} ))
+        _usage_display+=("${inserts[_usage_i]}${(l:_usage_pad:: :)}  -- ${_usage_desc}")
+      else
+        _usage_display+=("${inserts[_usage_i]}")
+      fi
+    done
+    compadd -l -d _usage_display -U -Q -S '' -a inserts
+  fi
   return 0
 }
 

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-3.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-3.snap
@@ -81,12 +81,13 @@ cmd plugin {
 }
 __USAGE_EOF__
   local -a values=() descs=() inserts=()
-  local needs_menu=0 value desc insert
-  while IFS=$'\t' read -r value desc insert; do
-    values+=("$value")
-    descs+=("$desc")
-    inserts+=("$insert")
-    [[ "$insert" == "'"* ]] && needs_menu=1
+  local needs_menu=0 line
+  while IFS= read -r line; do
+    local -a parts=("${(@ps:\t:)line}")
+    values+=("${parts[1]}")
+    descs+=("${parts[2]}")
+    inserts+=("${parts[3]}")
+    [[ "${parts[3]}" == "'"* ]] && needs_menu=1
   done < <(command usage complete-word --shell zsh -f "$spec_file" -- "${(Q)words[@]}")
   (( needs_menu )) && compstate[insert]=menu
   if (( ${#inserts[@]} )); then

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-3.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-3.snap
@@ -80,29 +80,27 @@ cmd plugin {
     }
 }
 __USAGE_EOF__
-  local -a completions=() inserts=()
-  local needs_menu=0 display insert
-  while IFS=$'\t' read -r display insert; do
-    completions+=("$display")
-    inserts+=("${insert//:/\\:}")
+  local -a values=() descs=() inserts=()
+  local needs_menu=0 value desc insert
+  while IFS=$'\t' read -r value desc insert; do
+    values+=("$value")
+    descs+=("$desc")
+    inserts+=("$insert")
     [[ "$insert" == "'"* ]] && needs_menu=1
   done < <(command usage complete-word --shell zsh -f "$spec_file" -- "${(Q)words[@]}")
   (( needs_menu )) && compstate[insert]=menu
   if (( ${#inserts[@]} )); then
     local -a _usage_display=()
-    local _usage_i _usage_max=0 _usage_v _usage_esc _usage_desc _usage_pad
-    for _usage_v in "${inserts[@]}"; do
+    local _usage_i _usage_max=0 _usage_v _usage_pad
+    for _usage_v in "${values[@]}"; do
       (( ${#_usage_v} > _usage_max )) && _usage_max=${#_usage_v}
     done
-    for ((_usage_i=1; _usage_i<=${#inserts[@]}; _usage_i++)); do
-      _usage_esc="${inserts[_usage_i]//:/\\:}"
-      _usage_desc="${completions[_usage_i]#${_usage_esc}}"
-      _usage_desc="${_usage_desc#:}"
-      if [[ -n "$_usage_desc" ]]; then
-        _usage_pad=$(( _usage_max - ${#inserts[_usage_i]} ))
-        _usage_display+=("${inserts[_usage_i]}${(l:_usage_pad:: :)}  -- ${_usage_desc}")
+    for ((_usage_i=1; _usage_i<=${#values[@]}; _usage_i++)); do
+      if [[ -n "${descs[_usage_i]}" ]]; then
+        _usage_pad=$(( _usage_max - ${#values[_usage_i]} ))
+        _usage_display+=("${values[_usage_i]}${(l:_usage_pad:: :)}  -- ${descs[_usage_i]}")
       else
-        _usage_display+=("${inserts[_usage_i]}")
+        _usage_display+=("${values[_usage_i]}")
       fi
     done
     compadd -l -d _usage_display -U -Q -S '' -a inserts

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh.snap
@@ -29,29 +29,27 @@ _mycli() {
 
   local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mycli.spec"
   mycli complete --usage >| "$spec_file"
-  local -a completions=() inserts=()
-  local needs_menu=0 display insert
-  while IFS=$'\t' read -r display insert; do
-    completions+=("$display")
-    inserts+=("${insert//:/\\:}")
+  local -a values=() descs=() inserts=()
+  local needs_menu=0 value desc insert
+  while IFS=$'\t' read -r value desc insert; do
+    values+=("$value")
+    descs+=("$desc")
+    inserts+=("$insert")
     [[ "$insert" == "'"* ]] && needs_menu=1
   done < <(command usage complete-word --shell zsh -f "$spec_file" -- "${(Q)words[@]}")
   (( needs_menu )) && compstate[insert]=menu
   if (( ${#inserts[@]} )); then
     local -a _usage_display=()
-    local _usage_i _usage_max=0 _usage_v _usage_esc _usage_desc _usage_pad
-    for _usage_v in "${inserts[@]}"; do
+    local _usage_i _usage_max=0 _usage_v _usage_pad
+    for _usage_v in "${values[@]}"; do
       (( ${#_usage_v} > _usage_max )) && _usage_max=${#_usage_v}
     done
-    for ((_usage_i=1; _usage_i<=${#inserts[@]}; _usage_i++)); do
-      _usage_esc="${inserts[_usage_i]//:/\\:}"
-      _usage_desc="${completions[_usage_i]#${_usage_esc}}"
-      _usage_desc="${_usage_desc#:}"
-      if [[ -n "$_usage_desc" ]]; then
-        _usage_pad=$(( _usage_max - ${#inserts[_usage_i]} ))
-        _usage_display+=("${inserts[_usage_i]}${(l:_usage_pad:: :)}  -- ${_usage_desc}")
+    for ((_usage_i=1; _usage_i<=${#values[@]}; _usage_i++)); do
+      if [[ -n "${descs[_usage_i]}" ]]; then
+        _usage_pad=$(( _usage_max - ${#values[_usage_i]} ))
+        _usage_display+=("${values[_usage_i]}${(l:_usage_pad:: :)}  -- ${descs[_usage_i]}")
       else
-        _usage_display+=("${inserts[_usage_i]}")
+        _usage_display+=("${values[_usage_i]}")
       fi
     done
     compadd -l -d _usage_display -U -Q -S '' -a inserts

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh.snap
@@ -37,7 +37,25 @@ _mycli() {
     [[ "$insert" == "'"* ]] && needs_menu=1
   done < <(command usage complete-word --shell zsh -f "$spec_file" -- "${(Q)words[@]}")
   (( needs_menu )) && compstate[insert]=menu
-  _describe 'completions' completions inserts -U -Q -S ''
+  if (( ${#inserts[@]} )); then
+    local -a _usage_display=()
+    local _usage_i _usage_max=0 _usage_v _usage_esc _usage_desc _usage_pad
+    for _usage_v in "${inserts[@]}"; do
+      (( ${#_usage_v} > _usage_max )) && _usage_max=${#_usage_v}
+    done
+    for ((_usage_i=1; _usage_i<=${#inserts[@]}; _usage_i++)); do
+      _usage_esc="${inserts[_usage_i]//:/\\:}"
+      _usage_desc="${completions[_usage_i]#${_usage_esc}}"
+      _usage_desc="${_usage_desc#:}"
+      if [[ -n "$_usage_desc" ]]; then
+        _usage_pad=$(( _usage_max - ${#inserts[_usage_i]} ))
+        _usage_display+=("${inserts[_usage_i]}${(l:_usage_pad:: :)}  -- ${_usage_desc}")
+      else
+        _usage_display+=("${inserts[_usage_i]}")
+      fi
+    done
+    compadd -l -d _usage_display -U -Q -S '' -a inserts
+  fi
   return 0
 }
 

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh.snap
@@ -30,12 +30,13 @@ _mycli() {
   local spec_file="${TMPDIR:-/tmp}/usage__usage_spec_mycli.spec"
   mycli complete --usage >| "$spec_file"
   local -a values=() descs=() inserts=()
-  local needs_menu=0 value desc insert
-  while IFS=$'\t' read -r value desc insert; do
-    values+=("$value")
-    descs+=("$desc")
-    inserts+=("$insert")
-    [[ "$insert" == "'"* ]] && needs_menu=1
+  local needs_menu=0 line
+  while IFS= read -r line; do
+    local -a parts=("${(@ps:\t:)line}")
+    values+=("${parts[1]}")
+    descs+=("${parts[2]}")
+    inserts+=("${parts[3]}")
+    [[ "${parts[3]}" == "'"* ]] && needs_menu=1
   done < <(command usage complete-word --shell zsh -f "$spec_file" -- "${(Q)words[@]}")
   (( needs_menu )) && compstate[insert]=menu
   if (( ${#inserts[@]} )); then

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh_init.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh_init.snap
@@ -19,29 +19,27 @@ _usage_default_complete() {
         local first
         if IFS= read -r first < "$cmdpath" 2>/dev/null && [[ "$first" == "#!"*"usage"* ]]; then
             if (( ${+commands[usage]} )); then
-                local -a completions=() inserts=()
-                local needs_menu=0 display insert
-                while IFS=$'\t' read -r display insert; do
-                  completions+=("$display")
-                  inserts+=("${insert//:/\\:}")
+                local -a values=() descs=() inserts=()
+                local needs_menu=0 value desc insert
+                while IFS=$'\t' read -r value desc insert; do
+                  values+=("$value")
+                  descs+=("$desc")
+                  inserts+=("$insert")
                   [[ "$insert" == "'"* ]] && needs_menu=1
                 done < <(command usage complete-word --shell zsh -f "$cmdpath" --cword=$((CURRENT - 1)) -- "${(Q)words[@]}")
                 (( needs_menu )) && compstate[insert]=menu
                 if (( ${#inserts[@]} )); then
                   local -a _usage_display=()
-                  local _usage_i _usage_max=0 _usage_v _usage_esc _usage_desc _usage_pad
-                  for _usage_v in "${inserts[@]}"; do
+                  local _usage_i _usage_max=0 _usage_v _usage_pad
+                  for _usage_v in "${values[@]}"; do
                     (( ${#_usage_v} > _usage_max )) && _usage_max=${#_usage_v}
                   done
-                  for ((_usage_i=1; _usage_i<=${#inserts[@]}; _usage_i++)); do
-                    _usage_esc="${inserts[_usage_i]//:/\\:}"
-                    _usage_desc="${completions[_usage_i]#${_usage_esc}}"
-                    _usage_desc="${_usage_desc#:}"
-                    if [[ -n "$_usage_desc" ]]; then
-                      _usage_pad=$(( _usage_max - ${#inserts[_usage_i]} ))
-                      _usage_display+=("${inserts[_usage_i]}${(l:_usage_pad:: :)}  -- ${_usage_desc}")
+                  for ((_usage_i=1; _usage_i<=${#values[@]}; _usage_i++)); do
+                    if [[ -n "${descs[_usage_i]}" ]]; then
+                      _usage_pad=$(( _usage_max - ${#values[_usage_i]} ))
+                      _usage_display+=("${values[_usage_i]}${(l:_usage_pad:: :)}  -- ${descs[_usage_i]}")
                     else
-                      _usage_display+=("${inserts[_usage_i]}")
+                      _usage_display+=("${values[_usage_i]}")
                     fi
                   done
                   compadd -l -d _usage_display -U -Q -S '' -a inserts

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh_init.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh_init.snap
@@ -27,7 +27,25 @@ _usage_default_complete() {
                   [[ "$insert" == "'"* ]] && needs_menu=1
                 done < <(command usage complete-word --shell zsh -f "$cmdpath" --cword=$((CURRENT - 1)) -- "${(Q)words[@]}")
                 (( needs_menu )) && compstate[insert]=menu
-                _describe 'completions' completions inserts -U -Q -S ''
+                if (( ${#inserts[@]} )); then
+                  local -a _usage_display=()
+                  local _usage_i _usage_max=0 _usage_v _usage_esc _usage_desc _usage_pad
+                  for _usage_v in "${inserts[@]}"; do
+                    (( ${#_usage_v} > _usage_max )) && _usage_max=${#_usage_v}
+                  done
+                  for ((_usage_i=1; _usage_i<=${#inserts[@]}; _usage_i++)); do
+                    _usage_esc="${inserts[_usage_i]//:/\\:}"
+                    _usage_desc="${completions[_usage_i]#${_usage_esc}}"
+                    _usage_desc="${_usage_desc#:}"
+                    if [[ -n "$_usage_desc" ]]; then
+                      _usage_pad=$(( _usage_max - ${#inserts[_usage_i]} ))
+                      _usage_display+=("${inserts[_usage_i]}${(l:_usage_pad:: :)}  -- ${_usage_desc}")
+                    else
+                      _usage_display+=("${inserts[_usage_i]}")
+                    fi
+                  done
+                  compadd -l -d _usage_display -U -Q -S '' -a inserts
+                fi
                 return $?
             fi
         fi

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh_init.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh_init.snap
@@ -20,12 +20,13 @@ _usage_default_complete() {
         if IFS= read -r first < "$cmdpath" 2>/dev/null && [[ "$first" == "#!"*"usage"* ]]; then
             if (( ${+commands[usage]} )); then
                 local -a values=() descs=() inserts=()
-                local needs_menu=0 value desc insert
-                while IFS=$'\t' read -r value desc insert; do
-                  values+=("$value")
-                  descs+=("$desc")
-                  inserts+=("$insert")
-                  [[ "$insert" == "'"* ]] && needs_menu=1
+                local needs_menu=0 line
+                while IFS= read -r line; do
+                  local -a parts=("${(@ps:\t:)line}")
+                  values+=("${parts[1]}")
+                  descs+=("${parts[2]}")
+                  inserts+=("${parts[3]}")
+                  [[ "${parts[3]}" == "'"* ]] && needs_menu=1
                 done < <(command usage complete-word --shell zsh -f "$cmdpath" --cword=$((CURRENT - 1)) -- "${(Q)words[@]}")
                 (( needs_menu )) && compstate[insert]=menu
                 if (( ${#inserts[@]} )); then

--- a/lib/src/complete/zsh.rs
+++ b/lib/src/complete/zsh.rs
@@ -4,9 +4,10 @@ use heck::ToSnakeCase;
 /// The completion loop that both `complete_zsh` (per-bin script) and
 /// `complete_zsh_init` (shebang-fallback handler) need to emit.
 ///
-/// `complete-word --shell zsh` emits two tab-separated columns per match:
-/// the display string (`value:description` for `_describe`) and the
-/// shell-quoted insert string. `usage complete-word` already filters by the
+/// `complete-word --shell zsh` emits three tab-separated columns per match:
+/// raw value, description, and shell-quoted insert. We build the display
+/// string from value+description (descriptions aligned to the longest value)
+/// and pass insert to `compadd`. `usage complete-word` already filters by the
 /// typed prefix, so `-U` tells `compadd` not to re-filter (which would
 /// discard our pre-quoted matches whose literal text starts with `'`).
 /// `compstate[insert]=menu` skips longest-common-prefix insertion when
@@ -24,12 +25,13 @@ fn render_completion_loop(usage_bin: &str, indent: &str, cw_extra_args: &str) ->
     // call `compadd` directly so every match is offered, with descriptions
     // aligned to the longest value.
     let template = r#"local -a values=() descs=() inserts=()
-local needs_menu=0 value desc insert
-while IFS=$'\t' read -r value desc insert; do
-  values+=("$value")
-  descs+=("$desc")
-  inserts+=("$insert")
-  [[ "$insert" == "'"* ]] && needs_menu=1
+local needs_menu=0 line
+while IFS= read -r line; do
+  local -a parts=("${(@ps:\t:)line}")
+  values+=("${parts[1]}")
+  descs+=("${parts[2]}")
+  inserts+=("${parts[3]}")
+  [[ "${parts[3]}" == "'"* ]] && needs_menu=1
 done < <(command __USAGE_BIN__ complete-word --shell zsh __CW_EXTRA__ -- "${(Q)words[@]}")
 (( needs_menu )) && compstate[insert]=menu
 if (( ${#inserts[@]} )); then
@@ -46,11 +48,7 @@ if (( ${#inserts[@]} )); then
       _usage_display+=("${values[_usage_i]}")
     fi
   done
-  if [[ -n "${compstate[context]-}" ]]; then
-    compadd -l -d _usage_display -U -Q -S '' -a inserts
-  else
-    _describe 'completions' _usage_display inserts -U -Q -S ''
-  fi
+  compadd -l -d _usage_display -U -Q -S '' -a inserts
 fi"#;
     template
         .replace("__USAGE_BIN__", usage_bin)

--- a/lib/src/complete/zsh.rs
+++ b/lib/src/complete/zsh.rs
@@ -46,7 +46,11 @@ if (( ${#inserts[@]} )); then
       _usage_display+=("${values[_usage_i]}")
     fi
   done
-  compadd -l -d _usage_display -U -Q -S '' -a inserts
+  if [[ -n "${compstate[context]-}" ]]; then
+    compadd -l -d _usage_display -U -Q -S '' -a inserts
+  else
+    _describe 'completions' _usage_display inserts -U -Q -S ''
+  fi
 fi"#;
     template
         .replace("__USAGE_BIN__", usage_bin)

--- a/lib/src/complete/zsh.rs
+++ b/lib/src/complete/zsh.rs
@@ -12,45 +12,38 @@ use heck::ToSnakeCase;
 /// `compstate[insert]=menu` skips longest-common-prefix insertion when
 /// values share a leading quote.
 ///
-/// `_describe` parses `candidate:description` in BOTH arrays, so colons in
-/// the insert strings must be escaped too (the display column arrives
-/// pre-escaped). Without this, a value like `chezmoi:brew:dump` collapses
-/// to candidate `chezmoi` with `brew:dump` treated as its description —
-/// completion inserts the truncated value, and with `-U` the next <Tab>
-/// replaces what the user already typed past the colon.
-///
 /// `cw_extra_args` is the extra `complete-word` arguments specific to each
 /// caller (e.g. `-f "$spec_file"` vs `-f "$cmdpath" --cword=$((CURRENT - 1))`).
 /// `indent` is prepended to every emitted line.
 fn render_completion_loop(usage_bin: &str, indent: &str, cw_extra_args: &str) -> String {
     // `_describe` groups matches that share a `\:`-escaped prefix and only
     // surfaces one per group, so tasks like `release:create`, `release:docs-sync`,
-    // `release:pr`, `release:update` collapse to a single entry. Build the
-    // display column ourselves and call `compadd` directly so every match
-    // is offered, with the description column aligned to the longest value.
-    let template = r#"local -a completions=() inserts=()
-local needs_menu=0 display insert
-while IFS=$'\t' read -r display insert; do
-  completions+=("$display")
-  inserts+=("${insert//:/\\:}")
+    // `release:pr`, `release:update` collapse to a single entry. `complete-word
+    // --shell zsh` emits three tab-separated columns — raw value, description,
+    // shell-quoted insert — and we build the formatted display ourselves and
+    // call `compadd` directly so every match is offered, with descriptions
+    // aligned to the longest value.
+    let template = r#"local -a values=() descs=() inserts=()
+local needs_menu=0 value desc insert
+while IFS=$'\t' read -r value desc insert; do
+  values+=("$value")
+  descs+=("$desc")
+  inserts+=("$insert")
   [[ "$insert" == "'"* ]] && needs_menu=1
 done < <(command __USAGE_BIN__ complete-word --shell zsh __CW_EXTRA__ -- "${(Q)words[@]}")
 (( needs_menu )) && compstate[insert]=menu
 if (( ${#inserts[@]} )); then
   local -a _usage_display=()
-  local _usage_i _usage_max=0 _usage_v _usage_esc _usage_desc _usage_pad
-  for _usage_v in "${inserts[@]}"; do
+  local _usage_i _usage_max=0 _usage_v _usage_pad
+  for _usage_v in "${values[@]}"; do
     (( ${#_usage_v} > _usage_max )) && _usage_max=${#_usage_v}
   done
-  for ((_usage_i=1; _usage_i<=${#inserts[@]}; _usage_i++)); do
-    _usage_esc="${inserts[_usage_i]//:/\\:}"
-    _usage_desc="${completions[_usage_i]#${_usage_esc}}"
-    _usage_desc="${_usage_desc#:}"
-    if [[ -n "$_usage_desc" ]]; then
-      _usage_pad=$(( _usage_max - ${#inserts[_usage_i]} ))
-      _usage_display+=("${inserts[_usage_i]}${(l:_usage_pad:: :)}  -- ${_usage_desc}")
+  for ((_usage_i=1; _usage_i<=${#values[@]}; _usage_i++)); do
+    if [[ -n "${descs[_usage_i]}" ]]; then
+      _usage_pad=$(( _usage_max - ${#values[_usage_i]} ))
+      _usage_display+=("${values[_usage_i]}${(l:_usage_pad:: :)}  -- ${descs[_usage_i]}")
     else
-      _usage_display+=("${inserts[_usage_i]}")
+      _usage_display+=("${values[_usage_i]}")
     fi
   done
   compadd -l -d _usage_display -U -Q -S '' -a inserts

--- a/lib/src/complete/zsh.rs
+++ b/lib/src/complete/zsh.rs
@@ -23,6 +23,11 @@ use heck::ToSnakeCase;
 /// caller (e.g. `-f "$spec_file"` vs `-f "$cmdpath" --cword=$((CURRENT - 1))`).
 /// `indent` is prepended to every emitted line.
 fn render_completion_loop(usage_bin: &str, indent: &str, cw_extra_args: &str) -> String {
+    // `_describe` groups matches that share a `\:`-escaped prefix and only
+    // surfaces one per group, so tasks like `release:create`, `release:docs-sync`,
+    // `release:pr`, `release:update` collapse to a single entry. Build the
+    // display column ourselves and call `compadd` directly so every match
+    // is offered, with the description column aligned to the longest value.
     let template = r#"local -a completions=() inserts=()
 local needs_menu=0 display insert
 while IFS=$'\t' read -r display insert; do
@@ -31,7 +36,25 @@ while IFS=$'\t' read -r display insert; do
   [[ "$insert" == "'"* ]] && needs_menu=1
 done < <(command __USAGE_BIN__ complete-word --shell zsh __CW_EXTRA__ -- "${(Q)words[@]}")
 (( needs_menu )) && compstate[insert]=menu
-_describe 'completions' completions inserts -U -Q -S ''"#;
+if (( ${#inserts[@]} )); then
+  local -a _usage_display=()
+  local _usage_i _usage_max=0 _usage_v _usage_esc _usage_desc _usage_pad
+  for _usage_v in "${inserts[@]}"; do
+    (( ${#_usage_v} > _usage_max )) && _usage_max=${#_usage_v}
+  done
+  for ((_usage_i=1; _usage_i<=${#inserts[@]}; _usage_i++)); do
+    _usage_esc="${inserts[_usage_i]//:/\\:}"
+    _usage_desc="${completions[_usage_i]#${_usage_esc}}"
+    _usage_desc="${_usage_desc#:}"
+    if [[ -n "$_usage_desc" ]]; then
+      _usage_pad=$(( _usage_max - ${#inserts[_usage_i]} ))
+      _usage_display+=("${inserts[_usage_i]}${(l:_usage_pad:: :)}  -- ${_usage_desc}")
+    else
+      _usage_display+=("${inserts[_usage_i]}")
+    fi
+  done
+  compadd -l -d _usage_display -U -Q -S '' -a inserts
+fi"#;
     template
         .replace("__USAGE_BIN__", usage_bin)
         .replace("__CW_EXTRA__", cw_extra_args)


### PR DESCRIPTION
## Summary

`_describe` groups matches that share a `\:`-escaped prefix and surfaces only one entry per group. With several subcommands sharing a colon prefix (e.g. `release:create`, `release:docs-sync`, `release:pr`, `release:update`) the menu only lists `release:create` and silently drops the rest. The same collapse happens when a plain `lint` exists alongside `lint:fix`.

## Repro

```kdl
bin "testcli"
cmd "release:create" help="Create release"
cmd "release:docs-sync" help="Refresh docs"
cmd "release:pr" help="Open release PR"
cmd "release:update" help="Update release state"
cmd "lint" help="Run lints"
cmd "lint:fix" help="Auto-fix lints"
```

Generate zsh completion, tab `testcli <TAB>` — before this PR, only `release:create` and `lint` appear. After: all six show.

Discovered via [jdx/mise](https://github.com/jdx/mise) where users have tasks named `release:create`, `release:docs-sync`, `release:pr`, `release:update` — most of them disappeared from completion.

## Fix

Build the display column ourselves from the `(insert, description)` pair and call `compadd` directly so every match is offered, with descriptions padded to the longest value for column alignment.

## Test plan

- [x] Existing `cargo test` suite passes locally (`cargo test --release`)
- [x] Snapshots updated (`lib/src/complete/snapshots/...`)
- [x] New regression test `test_zsh_completion_includes_all_colon_subcommands` feeds a colon-heavy spec through real zsh + zpty and asserts every subcommand appears in the menu

*This PR was authored with assistance from an AI coding agent.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Zsh completions now emit a stable three-column format (value, description, insert), ensuring correct display alignment, proper handling of colons and special characters, and accurate insertion behavior (including multi-word inserts and menu selection).
* **Tests**
  * Updated and added zsh completion and integration tests to verify the three-column output, display padding/alignment, menu/insert semantics, and handling of colon-containing subcommands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->