### PR TITLE
fix(zsh): escape colons in completion insert strings

### DIFF
--- a/cli/assets/completions/_usage
+++ b/cli/assets/completions/_usage
@@ -29,7 +29,7 @@ _usage() {
   local needs_menu=0 display insert
   while IFS=$'\t' read -r display insert; do
     completions+=("$display")
-    inserts+=("$insert")
+    inserts+=("${insert//:/\\:}")
     [[ "$insert" == "'"* ]] && needs_menu=1
   done < <(command usage complete-word --shell zsh -f "$spec_file" -- "${(Q)words[@]}")
   (( needs_menu )) && compstate[insert]=menu

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-2.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-2.snap
@@ -35,7 +35,7 @@ _mycli() {
   local needs_menu=0 display insert
   while IFS=$'\t' read -r display insert; do
     completions+=("$display")
-    inserts+=("$insert")
+    inserts+=("${insert//:/\\:}")
     [[ "$insert" == "'"* ]] && needs_menu=1
   done < <(command usage complete-word --shell zsh -f "$spec_file" -- "${(Q)words[@]}")
   (( needs_menu )) && compstate[insert]=menu

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-3.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-3.snap
@@ -84,7 +84,7 @@ __USAGE_EOF__
   local needs_menu=0 display insert
   while IFS=$'\t' read -r display insert; do
     completions+=("$display")
-    inserts+=("$insert")
+    inserts+=("${insert//:/\\:}")
     [[ "$insert" == "'"* ]] && needs_menu=1
   done < <(command usage complete-word --shell zsh -f "$spec_file" -- "${(Q)words[@]}")
   (( needs_menu )) && compstate[insert]=menu

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh.snap
@@ -33,7 +33,7 @@ _mycli() {
   local needs_menu=0 display insert
   while IFS=$'\t' read -r display insert; do
     completions+=("$display")
-    inserts+=("$insert")
+    inserts+=("${insert//:/\\:}")
     [[ "$insert" == "'"* ]] && needs_menu=1
   done < <(command usage complete-word --shell zsh -f "$spec_file" -- "${(Q)words[@]}")
   (( needs_menu )) && compstate[insert]=menu

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh_init.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh_init.snap
@@ -23,7 +23,7 @@ _usage_default_complete() {
                 local needs_menu=0 display insert
                 while IFS=$'\t' read -r display insert; do
                   completions+=("$display")
-                  inserts+=("$insert")
+                  inserts+=("${insert//:/\\:}")
                   [[ "$insert" == "'"* ]] && needs_menu=1
                 done < <(command usage complete-word --shell zsh -f "$cmdpath" --cword=$((CURRENT - 1)) -- "${(Q)words[@]}")
                 (( needs_menu )) && compstate[insert]=menu

--- a/lib/src/complete/zsh.rs
+++ b/lib/src/complete/zsh.rs
@@ -12,6 +12,13 @@ use heck::ToSnakeCase;
 /// `compstate[insert]=menu` skips longest-common-prefix insertion when
 /// values share a leading quote.
 ///
+/// `_describe` parses `candidate:description` in BOTH arrays, so colons in
+/// the insert strings must be escaped too (the display column arrives
+/// pre-escaped). Without this, a value like `chezmoi:brew:dump` collapses
+/// to candidate `chezmoi` with `brew:dump` treated as its description —
+/// completion inserts the truncated value, and with `-U` the next <Tab>
+/// replaces what the user already typed past the colon.
+///
 /// `cw_extra_args` is the extra `complete-word` arguments specific to each
 /// caller (e.g. `-f "$spec_file"` vs `-f "$cmdpath" --cword=$((CURRENT - 1))`).
 /// `indent` is prepended to every emitted line.
@@ -20,7 +27,7 @@ fn render_completion_loop(usage_bin: &str, indent: &str, cw_extra_args: &str) ->
 local needs_menu=0 display insert
 while IFS=$'\t' read -r display insert; do
   completions+=("$display")
-  inserts+=("$insert")
+  inserts+=("${insert//:/\\:}")
   [[ "$insert" == "'"* ]] && needs_menu=1
 done < <(command __USAGE_BIN__ complete-word --shell zsh __CW_EXTRA__ -- "${(Q)words[@]}")
 (( needs_menu )) && compstate[insert]=menu


### PR DESCRIPTION
### Problem

Completing values that contain colons — e.g. a mise task named `chezmoi:brew:dump` — truncates at the first colon:

```sh
mise run chez<TAB>        # → "mise run chezmoi"   (expected "mise run chezmoi:")
mise run chezmoi:b<TAB>   # → reverts to "mise run chezmoi"   (expected "mise run chezmoi:brew:")
```

The backend output is correct — display column escaped, insert column raw:

```
$ usage complete-word --shell zsh -f mise.spec -- mise run chezmoi:b
chezmoi\:brew\:commit:🍻 Commit Brewfile changes	chezmoi:brew:commit
chezmoi\:brew\:dump:🍻 Dump list of currently installed apps into Brewfile	chezmoi:brew:dump
```

But zsh's `_describe` parses `candidate:description` in **both** arrays it receives, so every insert string collapses to candidate `chezmoi` with `brew:dump` treated as its description. Completion then inserts the truncated value, and because matches are added with `-U` (replace the current word), the next `<TAB>` destroys what the user already typed past the colon.

### Fix

Escape colons in the insert strings in the zsh completion loop, mirroring the escaping the display column already gets:

```zsh
inserts+=("${insert//:/\\:}")
```

Verified with a zpty completion harness against mise task names:

| input | before | after |
|---|---|---|
| `mise run chez<TAB>` | `mise run chezmoi` | `mise run chezmoi:` |
| `mise run chezmoi:b<TAB>` | `mise run chezmoi` (revert!) | `mise run chezmoi:brew:` |
| `mise run chezmoi:c<TAB>` | `mise run chezmoi` (revert!) | `mise run chezmoi:cleanup` |

Related to but distinct from #558 / the v3.x `_describe` migration — that covered the display side; this is the insert side.

### Changes

- `lib/src/complete/zsh.rs` — escape colons in `render_completion_loop` (covers both the per-bin script and the shebang-fallback handler), plus a doc comment explaining why
- snapshots updated via `cargo insta test --accept`
- `cli/assets/completions/_usage` re-rendered via `mise run render`

`cargo test --all --all-features` and `mise run lint` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Zsh shell completion to properly handle values containing colon characters, preventing parsing issues during completion generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->