### PR TITLE
chore(ci): remove codecov upload

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -38,8 +38,3 @@ jobs:
           fi
       - name: Generate code coverage
         run: mise run coverage
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
-        with:
-          files: codecov.json
-          fail_ci_if_error: true


### PR DESCRIPTION
## Summary

- remove the Codecov upload step from the coverage workflow
- keep the local coverage generation job as the CI coverage check

## Test plan

- `prettier -c .github/workflows/coverage.yml`
- `actionlint .github/workflows/coverage.yml`

_This PR was generated by an AI coding agent._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change with no impact on application code, auth, or data handling.
> 
> **Overview**
> Removes the **Upload coverage to Codecov** step from `.github/workflows/coverage.yml`, so CI no longer sends `codecov.json` to Codecov or fails the job on upload errors (`fail_ci_if_error: true`).
> 
> The coverage job is unchanged otherwise: it still installs tooling, runs **`mise run coverage`**, and uses that as the in-CI coverage check—only external reporting is dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 624225f0a6c8375fcad524f6d965ec76085c7792. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->