### PR TITLE
docs: link to all sponsors

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,5 @@ See more at [usage.jdx.dev](https://usage.jdx.dev/).
 ## Sponsors
 
 usage is sponsored by [37signals](https://37signals.com).
+
+[View all sponsors](https://en.dev/sponsors.html).


### PR DESCRIPTION
## Summary
- add a README link to the full en.dev sponsors page

## Tests
- not run (README-only change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only documentation change with no code, build, or runtime impact.
> 
> **Overview**
> The **Sponsors** section in `README.md` now includes a **[View all sponsors](https://en.dev/sponsors.html)** link below the existing 37signals mention, pointing readers to the full sponsor list on en.dev.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f1a87fcebac3171b5abb57626e882aaa5c92eb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a "View all sponsors" link to the sponsors section in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->