### PR TITLE
fix(parse): dedupe required flag validation errors

### DIFF
--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -3,7 +3,7 @@ use indexmap::IndexMap;
 use itertools::Itertools;
 use log::trace;
 use miette::bail;
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::fmt::{Debug, Display, Formatter};
 use std::sync::Arc;
 use strum::EnumTryAs;
@@ -115,6 +115,15 @@ fn flag_keys(flag: &SpecFlag) -> Vec<String> {
         keys.push(negate.clone());
     }
     keys
+}
+
+fn unique_flags<'a>(
+    flags: impl IntoIterator<Item = &'a Arc<SpecFlag>>,
+) -> impl Iterator<Item = &'a Arc<SpecFlag>> {
+    let mut seen = HashSet::new();
+    flags
+        .into_iter()
+        .filter(move |flag| seen.insert(Arc::as_ptr(flag) as usize))
 }
 
 /// Extract the flag key from a flag word for lookup in available_flags map
@@ -704,7 +713,7 @@ fn parse_partial_with_env(
         }
     }
 
-    for flag in out.available_flags.values() {
+    for flag in unique_flags(out.available_flags.values()) {
         if out.flags.contains_key(flag) {
             continue;
         }

--- a/lib/tests/parse.rs
+++ b/lib/tests/parse.rs
@@ -30,6 +30,11 @@ required_flag:
     args="",
     expected=r#"Missing required flag: --name <name>"#,
 
+required_flag_with_short_alias:
+    spec=r#"flag "-n --name <name>" required=#true"#,
+    args="",
+    expected=r#"Missing required flag: --name <name>"#,
+
 negate:
     spec=r#"flag "--force" negate="--no-force""#,
     args="--no-force",


### PR DESCRIPTION
## Summary
- Deduplicate logical flags before required-flag validation
- Add a regression test for a required flag with both short and long aliases

## Root cause
`available_flags` stores one entry per lookup token, such as `-n` and `--name`, and both entries point at the same `SpecFlag`. Required-flag validation iterated the map values directly, so a missing required flag with multiple aliases emitted the same error once per alias.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p usage-lib`
- `cargo test --all --all-features`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to validation error reporting in parse; no change to successful parse behavior or auth/data paths.
> 
> **Overview**
> Fixes **duplicate** `Missing required flag` errors when a required flag registers both short and long aliases in `available_flags` (each alias points at the same `Arc<SpecFlag>`).
> 
> Adds `unique_flags`, which walks flag values once per logical flag via `Arc` pointer identity, and uses it in the **partial-parse** required-flag check instead of iterating every map entry.
> 
> Adds regression coverage for `flag "-n --name <name>" required=#true` so a missing value yields a **single** error message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5450e164c602da2047c6b8ffbbcc9e65ec534e22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed redundant validation of required flags with aliases, improving validation efficiency and preventing unnecessary repeated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->