### PR TITLE
fix(zsh): isolate generated completion options

### DIFF
--- a/cli/assets/completions/_usage
+++ b/cli/assets/completions/_usage
@@ -13,6 +13,7 @@ _usage_usage_cache_policy() {
 }
 
 _usage() {
+  emulate -L zsh
   typeset -A opt_args
   local curcontext="$curcontext" cache_policy
 

--- a/cli/tests/shell_completions_integration.rs
+++ b/cli/tests/shell_completions_integration.rs
@@ -755,6 +755,83 @@ _testcli
     let _ = fs::remove_dir_all(&temp_dir);
 }
 
+/// Regression test for user zsh options leaking into generated completions.
+///
+/// With KSH_ARRAYS enabled, zsh arrays become zero-indexed. The generated
+/// completion script indexes tab-split completion rows as zsh arrays, so it
+/// must enter local zsh emulation before parsing `complete-word` output.
+#[test]
+fn test_zsh_completion_ignores_ksh_arrays_option() {
+    if skip_if_shell_missing("zsh") {
+        return;
+    }
+
+    let usage_bin = build_usage_binary();
+    let temp_dir =
+        env::temp_dir().join(format!("usage_zsh_ksh_arrays_test_{}", std::process::id()));
+    fs::create_dir_all(&temp_dir).unwrap();
+
+    let spec = r#"
+bin "testcli"
+cmd "doctor" help="Check installation"
+"#;
+    let spec_kdl_file = temp_dir.join("testcli.kdl");
+    fs::write(&spec_kdl_file, spec).unwrap();
+
+    let gen = Command::new(&usage_bin)
+        .args(["generate", "completion", "zsh", "testcli", "-f"])
+        .arg(spec_kdl_file.to_str().unwrap())
+        .output()
+        .expect("Failed to generate zsh completion");
+    let comp_file = temp_dir.join("_testcli");
+    fs::write(&comp_file, &gen.stdout).unwrap();
+
+    let test_script = format!(
+        r#"#!/usr/bin/env zsh
+set -e
+setopt KSH_ARRAYS
+export PATH="{usage_dir}:$PATH"
+export TMPDIR="{tmp}"
+
+autoload -U compinit
+compinit -u
+source {comp}
+
+compadd() {{
+    print -r -- "[compadd:inserts] ${{inserts[*]}}"
+}}
+
+words=(testcli d)
+CURRENT=2
+_testcli
+"#,
+        usage_dir = usage_bin.parent().unwrap().to_str().unwrap(),
+        tmp = temp_dir.to_str().unwrap(),
+        comp = comp_file.to_str().unwrap(),
+    );
+
+    let script_file = temp_dir.join("test.zsh");
+    fs::write(&script_file, &test_script).unwrap();
+
+    let result = Command::new("zsh")
+        .arg(script_file.to_str().unwrap())
+        .output()
+        .expect("Failed to run zsh test");
+    let stdout = String::from_utf8_lossy(&result.stdout);
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(
+        result.status.success(),
+        "zsh completion script exited non-zero ({}).\nstdout:\n{stdout}\nstderr:\n{stderr}",
+        result.status
+    );
+    assert!(
+        stdout.contains("[compadd:inserts] doctor"),
+        "Expected only the insert value in compadd inserts.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let _ = fs::remove_dir_all(&temp_dir);
+}
+
 #[test]
 fn test_powershell_completion_integration() {
     if skip_if_shell_missing("pwsh") {

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-2.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-2.snap
@@ -17,6 +17,7 @@ _usage_mycli_cache_policy() {
 }
 
 _mycli() {
+  emulate -L zsh
   typeset -A opt_args
   local curcontext="$curcontext" cache_policy
 

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-3.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-3.snap
@@ -7,6 +7,7 @@ expression: "complete_zsh(&CompleteOptions\n{\n    usage_bin: \"usage\".to_strin
 local curcontext="$curcontext"
 
 _mycli() {
+  emulate -L zsh
   typeset -A opt_args
   local curcontext="$curcontext" cache_policy
 

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh.snap
@@ -17,6 +17,7 @@ _usage_mycli_cache_policy() {
 }
 
 _mycli() {
+  emulate -L zsh
   typeset -A opt_args
   local curcontext="$curcontext" cache_policy
 

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh_init.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh_init.snap
@@ -7,6 +7,7 @@ expression: "complete_zsh_init(\"usage\")"
 # on $PATH whose first line is a `usage` shebang.
 
 _usage_default_complete() {
+    emulate -L zsh
     local cmd cmdpath
     cmd="${words[1]}"
     if [[ "$cmd" == */* ]]; then

--- a/lib/src/complete/zsh.rs
+++ b/lib/src/complete/zsh.rs
@@ -98,6 +98,7 @@ _usage_{bin_snake}_cache_policy() {{
     out.push(format!(
         r#"
 _{bin_snake}() {{
+  emulate -L zsh
   typeset -A opt_args
   local curcontext="$curcontext" cache_policy
 
@@ -187,6 +188,7 @@ pub fn complete_zsh_init(usage_bin: &str) -> String {
 # on $PATH whose first line is a `usage` shebang.
 
 _usage_default_complete() {{
+    emulate -L zsh
     local cmd cmdpath
     cmd="${{words[1]}}"
     if [[ "$cmd" == */* ]]; then


### PR DESCRIPTION
## Summary
- add `emulate -L zsh` to generated zsh completion functions
- update zsh completion snapshots and the checked-in `_usage` completion asset
- add a regression test for `KSH_ARRAYS` leaking into generated completions

## Root Cause
Generated zsh completions parse `complete-word --shell zsh` rows into arrays and index those arrays using normal zsh one-based semantics. If a user's shell has options such as `KSH_ARRAYS` enabled, those semantics can leak into the completion function and shift or empty the parsed insert values, causing tab-delimited completion rows to be inserted incorrectly.

## Validation
- `cargo build --all`
- `cargo test -p usage-lib complete::zsh --all-features`
- `cargo test -p usage-cli test_zsh_completion_ignores_ksh_arrays_option --all-features`
- `mise run render:usage-cli-completions` (includes `cargo clippy --all --all-features --fix --allow-dirty --allow-staged -- -D warnings`, `cargo fmt --all`, and `prettier -w .`)

_This PR was generated by an AI coding assistant._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to generated zsh shell scripts and test/snapshot updates; no runtime CLI or auth/data paths affected.
> 
> **Overview**
> Generated zsh completion scripts now start each completion function with **`emulate -L zsh`** so user shell options (notably **`KSH_ARRAYS`**) do not change how tab-split `complete-word` rows are indexed into `parts[1..3]` and passed to **`compadd`**.
> 
> The generator in **`lib/src/complete/zsh.rs`** applies this to per-binary **`_{bin}`** handlers and the shebang **`_usage_default_complete`** init path; snapshots, **`cli/assets/completions/_usage`**, and a new integration test assert completions still work when **`KSH_ARRAYS`** is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fba8bf394d17e589a251e792e2fa2f0c74770cf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed zsh shell completions to work correctly when KSH_ARRAYS option is enabled, ensuring completion suggestions display properly and array indexing remains accurate.

* **Tests**
  * Added regression test to validate zsh completion functionality with KSH_ARRAYS option enabled in shell environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->