### PR TITLE
chore(ci): install publish build targets

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -95,6 +95,9 @@ jobs:
           submodules: recursive
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Install Rust target
+        if: ${{ matrix.target != 'universal-apple-darwin' }}
+        run: rustup target add ${{ matrix.target }}
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
           experimental: true


### PR DESCRIPTION
## Summary
- install the Rust target for each publish matrix entry before `upload-rust-binary-action`
- skip the synthetic `universal-apple-darwin` target because it is not a rustup target

## Root Cause
The v3.5.1 publish job for `x86_64-unknown-linux-musl` failed after `cross` fell back to host `cargo`:

```text
error[E0463]: can't find crate for `core`
= note: the `x86_64-unknown-linux-musl` target may not be installed
```

Installing the matrix target up front makes host-cargo fallback work for musl and other non-default targets.

Failed job: https://github.com/jdx/usage/actions/runs/27660960261/job/81805071490

## Validation
- `actionlint .github/workflows/publish-cli.yml`

_This PR was generated by an AI coding assistant._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change with no runtime or application code impact.
> 
> **Overview**
> Fixes **publish-cli** matrix builds that fail when `cross` falls back to host `cargo` without the target installed (e.g. `x86_64-unknown-linux-musl` with “can't find crate for `core`”).
> 
> Adds an **Install Rust target** step right after the stable toolchain setup: `rustup target add ${{ matrix.target }}` for every matrix entry **except** `universal-apple-darwin`, which is a synthetic fat-binary target and not a rustup triple.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb805ddc46eadac39538ee4fec55a56fc7803e7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->