### PR TITLE
fix(zsh): preserve options for default completion

### DIFF
--- a/cli/tests/shell_completions_integration.rs
+++ b/cli/tests/shell_completions_integration.rs
@@ -1137,6 +1137,7 @@ fn test_zsh_completion_init_integration() {
 
     // Stub `compadd`/`_files` to capture what the handler offers without
     // needing an interactive ZLE context. Drive with $words/$CURRENT.
+    // The fallback must preserve completion-friendly options for `_files`.
     // The init template calls `compadd -l -d <display-arr> -U -Q -S '' -a <inserts-arr>`.
     let test_script = format!(
         r#"#!/usr/bin/env zsh
@@ -1152,13 +1153,19 @@ compadd() {{
     print -r -- "[compadd:display] $d"
     print -r -- "[compadd:inserts] $i"
 }}
-_files() {{ print -r -- "[files-fallback]" }}
+_files() {{
+    print -r -- "[files-fallback] nomatch=$options[nomatch] extendedglob=$options[extendedglob]"
+}}
 
 words=(ex "")
 CURRENT=2
 _usage_default_complete
 
 words=(ex "--f")
+CURRENT=2
+_usage_default_complete
+
+words=(plain "")
 CURRENT=2
 _usage_default_complete
 "#,
@@ -1188,6 +1195,10 @@ _usage_default_complete
     assert!(
         stdout.contains("[compadd:display]") && stdout.contains("--foo"),
         "expected --foo flag in compadd display, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("[files-fallback] nomatch=off extendedglob=on"),
+        "expected file fallback to disable nomatch and enable extendedglob, got: {stdout}"
     );
 
     let _ = fs::remove_dir_all(&temp_dir);

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh_init.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh_init.snap
@@ -8,6 +8,7 @@ expression: "complete_zsh_init(\"usage\")"
 
 _usage_default_complete() {
     emulate -L zsh
+    setopt localoptions nonomatch extendedglob
     local cmd cmdpath
     cmd="${words[1]}"
     if [[ "$cmd" == */* ]]; then

--- a/lib/src/complete/zsh.rs
+++ b/lib/src/complete/zsh.rs
@@ -189,6 +189,7 @@ pub fn complete_zsh_init(usage_bin: &str) -> String {
 
 _usage_default_complete() {{
     emulate -L zsh
+    setopt localoptions nonomatch extendedglob
     local cmd cmdpath
     cmd="${{words[1]}}"
     if [[ "$cmd" == */* ]]; then


### PR DESCRIPTION
## Summary

- keep the generated zsh init fallback in a completion-friendly option state after `emulate -L zsh`
- disable `nomatch` and enable `extendedglob` before delegating to `_files`
- extend the zsh init integration test to cover the non-usage fallback path

Fixes #692.

## Validation

- `cargo test -p usage-lib test_complete_zsh_init`
- `cargo test -p usage-cli test_zsh_completion_init_integration --test shell_completions_integration`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to generated zsh init completion and its tests; no auth, data, or core runtime behavior.
> 
> **Overview**
> The generated zsh **completion-init** handler (`_usage_default_complete`) now runs **`setopt localoptions nonomatch extendedglob`** immediately after **`emulate -L zsh`**, so when a command is not a usage shebang and the handler falls back to **`_files`**, file completion still sees **`nomatch` off** and **`extendedglob` on** instead of whatever `emulate` left behind.
> 
> The zsh init integration test stubs **`_files`** to report those options, adds a **`plain`** (non-usage) completion case to hit the fallback path, and asserts **`nomatch=off extendedglob=on`**. The **`complete_zsh_init`** snapshot is updated for the new line in generated output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d9c234e123f94b597d7035b5a6dc84e2e62749d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->