### PR TITLE
Update sponsor references for jdx.dev

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -94,7 +94,7 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - name: Install Rust target
         if: ${{ matrix.target != 'universal-apple-darwin' }}
         run: rustup target add ${{ matrix.target }}

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -155,7 +155,7 @@ jobs:
       - run: communique generate "${GITHUB_REF_NAME}" --github-release
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      - name: Append en.dev sponsor blurb
+      - name: Append jdx.dev sponsor blurb
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.ref_name }}
@@ -174,9 +174,9 @@ jobs:
 
           ## 💚 Sponsor usage
 
-          usage is built by [@jdx](https://github.com/jdx) at [**en.dev**](https://en.dev) — an independent developer-tooling studio behind [mise](https://mise.jdx.dev/), [aube](https://aube.en.dev/), hk, and more. Work on usage is funded by sponsorships.
+          usage is maintained by [@jdx](https://github.com/jdx), an open source developer for [**entire.io**](https://entire.io), the title sponsor of the [jdx.dev](https://jdx.dev) open source tools including [mise](https://mise.jdx.dev/), [aube](https://aube.jdx.dev/), hk, and more. Work on usage is funded by sponsorships.
 
-          If `usage` powers CLI specs, docs, or completions for a tool you maintain or use, please consider [sponsoring at en.dev](https://en.dev). Every sponsorship helps the project stay independent and moving.
+          If `usage` powers CLI specs, docs, or completions for a tool you maintain or use, please consider [sponsoring at jdx.dev](https://jdx.dev/sponsors.html). Every sponsorship helps the project stay independent and moving.
           EOF
           } > /tmp/release-notes.md
           gh release edit "$TAG" --notes-file /tmp/release-notes.md

--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ See more at [usage.jdx.dev](https://usage.jdx.dev/).
 
 ## Sponsors
 
-usage is sponsored by [entire.io](https://entire.io), [37signals](https://37signals.com), and [CodeRabbit](https://coderabbit.link/mise).
+usage is sponsored by [entire.io](https://entire.io) and [37signals](https://37signals.com).
 
 [View all sponsors](https://jdx.dev/sponsors.html).

--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ See more at [usage.jdx.dev](https://usage.jdx.dev/).
 
 ## Sponsors
 
-usage is sponsored by [37signals](https://37signals.com).
+usage is sponsored by [entire.io](https://entire.io), [37signals](https://37signals.com), [CodeRabbit](https://coderabbit.link/mise), and [Supabase](https://supabase.com).
 
-[View all sponsors](https://en.dev/sponsors.html).
+[View all sponsors](https://jdx.dev/sponsors.html).

--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ See more at [usage.jdx.dev](https://usage.jdx.dev/).
 
 ## Sponsors
 
-usage is sponsored by [entire.io](https://entire.io), [37signals](https://37signals.com), [CodeRabbit](https://coderabbit.link/mise), and [Supabase](https://supabase.com).
+usage is sponsored by [entire.io](https://entire.io), [37signals](https://37signals.com), and [CodeRabbit](https://coderabbit.link/mise).
 
 [View all sponsors](https://jdx.dev/sponsors.html).

--- a/cli/assets/fig.ts
+++ b/cli/assets/fig.ts
@@ -562,7 +562,7 @@ const completionSpec: Fig.Spec = {
     {
       name: "sponsors",
       description:
-        "Show the companies sponsoring usage and the en.dev project family",
+        "Show the companies sponsoring usage and the jdx.dev open source tools",
     },
     {
       name: "zsh",

--- a/cli/assets/usage.1
+++ b/cli/assets/usage.1
@@ -79,7 +79,7 @@ Lint a usage spec file for common issues
 Execute a shell script with the specified shell
 .TP
 \fBsponsors\fR
-Show the companies sponsoring usage and the en.dev project family
+Show the companies sponsoring usage and the jdx.dev open source tools
 .TP
 \fBzsh\fR
 Execute a shell script with the specified shell

--- a/cli/src/cli/sponsors.rs
+++ b/cli/src/cli/sponsors.rs
@@ -1,11 +1,11 @@
-/// Show the companies sponsoring usage and the en.dev project family
+/// Show the companies sponsoring usage and the jdx.dev open source tools
 #[derive(clap::Args)]
 pub struct Sponsors;
 
 impl Sponsors {
     pub fn run(&self) -> miette::Result<()> {
         println!(
-            "usage and the en.dev project family are sponsored by:\n\n  37signals - https://37signals.com\n\nView all sponsors: https://en.dev/sponsors.html"
+            "usage and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n  CodeRabbit - https://coderabbit.link/mise\n  Supabase - https://supabase.com\n\nView all sponsors: https://jdx.dev/sponsors.html"
         );
         Ok(())
     }

--- a/cli/src/cli/sponsors.rs
+++ b/cli/src/cli/sponsors.rs
@@ -5,7 +5,7 @@ pub struct Sponsors;
 impl Sponsors {
     pub fn run(&self) -> miette::Result<()> {
         println!(
-            "usage and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n  CodeRabbit - https://coderabbit.link/mise\n  Supabase - https://supabase.com\n\nView all sponsors: https://jdx.dev/sponsors.html"
+            "usage and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n  CodeRabbit - https://coderabbit.link/mise\n\nView all sponsors: https://jdx.dev/sponsors.html"
         );
         Ok(())
     }

--- a/cli/src/cli/sponsors.rs
+++ b/cli/src/cli/sponsors.rs
@@ -5,7 +5,7 @@ pub struct Sponsors;
 impl Sponsors {
     pub fn run(&self) -> miette::Result<()> {
         println!(
-            "usage and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n  CodeRabbit - https://coderabbit.link/mise\n\nView all sponsors: https://jdx.dev/sponsors.html"
+            "usage and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n\nView all sponsors: https://jdx.dev/sponsors.html"
         );
         Ok(())
     }

--- a/cli/usage.usage.kdl
+++ b/cli/usage.usage.kdl
@@ -216,7 +216,7 @@ to properly escape and quote values with spaces in them.
     arg <SCRIPT>
     arg "[ARGS]…" help="Arguments to pass to script" required=#false var=#true
 }
-cmd sponsors help="Show the companies sponsoring usage and the en.dev project family"
+cmd sponsors help="Show the companies sponsoring usage and the jdx.dev open source tools"
 cmd zsh help="Execute a shell script using zsh" {
     long_help #"""
 Execute a shell script with the specified shell

--- a/docs/.vitepress/theme/EndevFooter.vue
+++ b/docs/.vitepress/theme/EndevFooter.vue
@@ -4,15 +4,15 @@
     <span aria-hidden="true">·</span>
     <span>Copyright © {{ year }}</span>
     <span aria-hidden="true">·</span>
-    <a class="EndevFooterLink" href="https://en.dev">
+    <a class="EndevFooterLink" href="https://jdx.dev">
       <img
         alt=""
         class="EndevFooterLogo"
         height="28"
-        src="https://github.com/endevco.png?size=96"
+        src="https://github.com/jdx.png?size=96"
         width="28"
       />
-      <span>en.dev</span>
+      <span>jdx.dev</span>
     </a>
   </footer>
 </template>

--- a/docs/.vitepress/theme/EndevSponsors.vue
+++ b/docs/.vitepress/theme/EndevSponsors.vue
@@ -35,7 +35,7 @@ import { onMounted, ref } from "vue";
 
 const sponsors = ref([]);
 const error = ref(false);
-const footerTiers = new Set(["anchor", "premier", "partner"]);
+const footerTiers = new Set(["title", "premier", "partner"]);
 const sponsorFeedTimeoutMs = 5000;
 
 const sponsorItems = (items) => (Array.isArray(items) ? items : []);

--- a/docs/.vitepress/theme/EndevSponsors.vue
+++ b/docs/.vitepress/theme/EndevSponsors.vue
@@ -23,7 +23,7 @@
           <img :alt="sponsor.name" :src="sponsor.logo" loading="lazy" decoding="async" />
         </a>
       </div>
-      <a class="EndevSponsorsCta" href="https://en.dev/sponsors.html">
+      <a class="EndevSponsorsCta" href="https://jdx.dev/sponsors.html">
         View all sponsors
       </a>
     </div>
@@ -61,7 +61,7 @@ onMounted(async () => {
   const timeout = window.setTimeout(() => controller.abort(), sponsorFeedTimeoutMs);
 
   try {
-    const res = await fetch("https://en.dev/sponsors.json", {
+    const res = await fetch("https://jdx.dev/sponsors.json", {
       headers: { Accept: "application/json" },
       signal: controller.signal,
     });

--- a/docs/cli/reference/commands.json
+++ b/docs/cli/reference/commands.json
@@ -976,7 +976,7 @@
         "flags": [],
         "mounts": [],
         "hide": false,
-        "help": "Show the companies sponsoring usage and the en.dev project family",
+        "help": "Show the companies sponsoring usage and the jdx.dev open source tools",
         "name": "sponsors",
         "aliases": [],
         "hidden_aliases": [],

--- a/docs/cli/reference/sponsors.md
+++ b/docs/cli/reference/sponsors.md
@@ -5,4 +5,4 @@
 - **Usage**: `usage sponsors`
 - **Source code**: [`cli/src/cli/sponsors.rs`](https://github.com/jdx/usage/blob/main/cli/src/cli/sponsors.rs)
 
-Show the companies sponsoring usage and the en.dev project family
+Show the companies sponsoring usage and the jdx.dev open source tools


### PR DESCRIPTION
## Summary
- list Entire first in the README and sponsors command
- point sponsor feed/page links at jdx.dev
- update docs sponsor/footer copy and generated CLI assets

## Tests
- git diff --check
- npm run docs:build with --legacy-peer-deps install
- mise x rust@1.95.0 -- cargo run -q -p usage-cli -- sponsors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy, URL, and generated-doc updates only; no runtime logic beyond sponsor feed tier naming.
> 
> **Overview**
> Repoints **sponsor branding** from **en.dev** to **jdx.dev** across README, CLI, docs, and release automation.
> 
> The **`usage sponsors`** command and matching usage spec / generated assets now describe the **jdx.dev** open source tools, list **entire.io** first (with 37signals), and link to `https://jdx.dev/sponsors.html`. Docs footer and sponsor widgets load **`jdx.dev/sponsors.json`**, use **title** tier (replacing **anchor**), and show **jdx.dev** in the footer link and avatar.
> 
> GitHub release notes appended after publish now use the **jdx.dev** sponsor blurb and CTA; the publish workflow also bumps the **dtolnay/rust-toolchain** action pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d56da440148c5284ea3d9662b11f36029d839dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->