### PR TITLE
fix(complete): skip unreadable files in fish shebang completion scan

### DIFF
--- a/lib/src/complete/fish.rs
+++ b/lib/src/complete/fish.rs
@@ -113,6 +113,10 @@ function __usage_register_shebang_completions
         test -d $dir; or continue
         for file in $dir/*
             test -f $file -a -x $file; or continue
+            # Skip files we can't read (e.g. setuid/execute-only binaries like
+            # macOS's sudo/visudo) — reading them below would make fish print
+            # a redirection warning on every shell startup.
+            test -r $file; or continue
             # `string replace` works on every supported fish version; `path
             # basename` requires fish 3.5+ which excludes Ubuntu 22.04 LTS.
             set -l name (string replace -r '^.*/' '' -- $file)

--- a/lib/src/complete/snapshots/usage__complete__fish__tests__complete_fish_init.snap
+++ b/lib/src/complete/snapshots/usage__complete__fish__tests__complete_fish_init.snap
@@ -23,6 +23,10 @@ function __usage_register_shebang_completions
         test -d $dir; or continue
         for file in $dir/*
             test -f $file -a -x $file; or continue
+            # Skip files we can't read (e.g. setuid/execute-only binaries like
+            # macOS's sudo/visudo) — reading them below would make fish print
+            # a redirection warning on every shell startup.
+            test -r $file; or continue
             # `string replace` works on every supported fish version; `path
             # basename` requires fish 3.5+ which excludes Ubuntu 22.04 LTS.
             set -l name (string replace -r '^.*/' '' -- $file)


### PR DESCRIPTION
## Summary
- The conf.d-sourced fish init script (`usage g completion-init fish`) scans every executable on `$PATH` to detect a `usage` shebang, peek-reading the first 128 bytes of each file.
- Files that are executable but not readable by the current user (e.g. macOS's setuid-root `sudo`, or execute-only `visudo`) make fish's own redirection layer print a warning on every shell startup, since the existing `read ... 2>/dev/null` only silences the `read` builtin's stderr, not fish's own redirection-setup warning.
- This adds a `test -r $file; or continue` guard alongside the existing executability check, so unreadable files are skipped before the peek-read is attempted.

Fixes #706

## Test plan
- [x] `cargo test -p usage-lib --lib complete::fish` passes, snapshot updated via `INSTA_UPDATE=always`
- [x] `cargo fmt --check -p usage-lib` clean
- [x] Manually verified on macOS: applying the equivalent one-line patch to a locally generated `~/.config/fish/conf.d/usage.fish` eliminates the `/usr/bin/sudo` / `/usr/sbin/visudo` warnings on new fish shells, with `fish g completion-init fish` output otherwise unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell startup behavior by skipping unreadable `PATH` entries during fish initialization.
  * Reduced warning messages for execute-only or setuid-like binaries, especially in macOS-related command setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->