### PR TITLE
schedule releases for Monday morning

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -1,0 +1,37 @@
+name: auto-merge-release
+
+on:
+  schedule:
+    # 10:00 UTC = 4am CST (winter) / 5am CDT (summer)
+    - cron: "0 10 * * 1"
+  workflow_dispatch:
+
+jobs:
+  merge:
+    if: github.repository == 'jdx/usage'
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Merge release into main
+        run: |
+          PR_NUMBER=$(gh pr list -R jdx/usage --base main --head release --state open --json number --jq '.[0].number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open PR from release to main"
+            exit 0
+          fi
+
+          BODY=$(gh pr view "$PR_NUMBER" -R jdx/usage --json body --jq '.body // ""')
+          TRIMMED_BODY=$(echo "$BODY" | tr -d '[:space:]')
+          if [ -z "$TRIMMED_BODY" ]; then
+            echo "Skipping merge: PR #$PR_NUMBER has an empty body; will retry on the next scheduled run"
+            exit 0
+          fi
+
+          echo "PR #$PR_NUMBER is ready for the Monday morning release window"
+
+          gh pr merge "$PR_NUMBER" -R jdx/usage --squash --auto || {
+            echo "Merge failed or PR not ready, will retry on the next run"
+            exit 0
+          }
+        env:
+          GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}

--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -19,7 +19,10 @@ jobs:
     steps:
       - name: Merge release into main
         run: |
-          PR_NUMBER=$(gh pr list -R jdx/usage --base main --head release --state open --json number --jq '.[0].number // empty')
+          set -euo pipefail
+
+          PR_NUMBER=$(gh pr list -R jdx/usage --base main --head release --state open --limit 100 --json number,headRefName,headRepositoryOwner \
+            --jq '[.[] | select(.headRefName == "release") | select(.headRepositoryOwner.login == "jdx")][0].number // empty')
           if [ -z "$PR_NUMBER" ]; then
             echo "No open PR from release to main"
             exit 0

--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -6,11 +6,16 @@ on:
     - cron: "0 10 * * 1"
   workflow_dispatch:
 
+permissions: {}
+
+concurrency:
+  group: auto-merge-release
+  cancel-in-progress: false
+
 jobs:
   merge:
     if: github.repository == 'jdx/usage'
     runs-on: ubuntu-latest
-    permissions: {}
     steps:
       - name: Merge release into main
         run: |
@@ -28,10 +33,6 @@ jobs:
           fi
 
           echo "PR #$PR_NUMBER is ready for the Monday morning release window"
-
-          gh pr merge "$PR_NUMBER" -R jdx/usage --squash --auto || {
-            echo "Merge failed or PR not ready, will retry on the next run"
-            exit 0
-          }
+          gh pr merge "$PR_NUMBER" -R jdx/usage --squash --auto
         env:
           GH_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
## Summary

- Add an auto-merge workflow for release PRs.
- Run it Monday morning only at `0 10 * * 1` UTC.
- Target the existing `release` branch PR created by the release-plz task.

## Validation

- `actionlint -stdin-filename .github/workflows/auto-merge-release.yml -`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds release-timing automation only; merge is gated on a non-empty PR body and uses an existing release token.
> 
> **Overview**
> Adds **`auto-merge-release`** GitHub Actions workflow to land the existing **`release` → `main`** PR on a fixed schedule instead of merging it manually.
> 
> The job runs **Mondays at 10:00 UTC** (and via **`workflow_dispatch`**), only on **`jdx/usage`**. It looks up the open PR whose head is **`release`**, exits quietly if none exists, and **skips merge when the PR body is empty** so release-plz can finish filling changelog text before the next run. When ready, it runs **`gh pr merge --squash --auto`** using **`MY_RELEASE_PLEASE_TOKEN`**. Concurrency is serialized with **`cancel-in-progress: false`** so overlapping runs do not fight each other.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03acc4c9927c9e994e5e9f8c41dd5e494917e35d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->