### PR TITLE
fix(parse): allow hyphen-prefixed flag values

### DIFF
--- a/cli/usage.usage.kdl
+++ b/cli/usage.usage.kdl
@@ -33,7 +33,7 @@ This is used internally by shell completion scripts to provide intelligent compl
     flag "-s --spec" help="Raw string spec input" {
         arg <SPEC>
     }
-    flag --cword help="Current word index" {
+    flag --cword help="Current word index" allow_hyphen_values=#true {
         arg <CWORD>
     }
     flag --shell default=bash {

--- a/docs/cli/reference/commands.json
+++ b/docs/cli/reference/commands.json
@@ -123,10 +123,9 @@
               "name": "CWORD",
               "usage": "<CWORD>",
               "required": true,
-              "double_dash": "Optional",
+              "double_dash": "Automatic",
               "hide": false
-            },
-            "allow_hyphen_values": true
+            }
           },
           {
             "name": "shell",

--- a/docs/cli/reference/commands.json
+++ b/docs/cli/reference/commands.json
@@ -125,7 +125,8 @@
               "required": true,
               "double_dash": "Optional",
               "hide": false
-            }
+            },
+            "allow_hyphen_values": true
           },
           {
             "name": "shell",

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -561,36 +561,23 @@ fn parse_partial_with_env(
             }
         }
 
-        if out
-            .flag_awaiting_value
-            .last()
-            .is_some_and(|flag| flag.allow_hyphen_values)
+        if w.starts_with('-')
+            && out
+                .flag_awaiting_value
+                .last()
+                .is_some_and(|flag| flag.allow_hyphen_values)
         {
-            while let Some(flag) = out.flag_awaiting_value.pop() {
-                let arg = flag.arg.as_ref().unwrap();
-                if validate_choices(
-                    spec,
-                    &out.cmd,
-                    &mut out.errors,
-                    ChoiceTarget::option(&flag),
-                    &w,
-                    arg.choices.as_ref(),
-                    custom_env,
-                )? {
-                    return Ok(out);
-                }
-                if flag.var {
-                    let arr = out
-                        .flags
-                        .entry(flag)
-                        .or_insert_with(|| ParseValue::MultiString(vec![]))
-                        .try_as_multi_string_mut()
-                        .unwrap();
-                    arr.push(w);
-                } else {
-                    out.flags.insert(flag, ParseValue::String(w));
-                }
-                w = "".to_string();
+            let should_return = drain_pending_flag_values(
+                spec,
+                &out.cmd,
+                &mut out.errors,
+                &mut out.flags,
+                &mut out.flag_awaiting_value,
+                &mut w,
+                custom_env,
+            )?;
+            if should_return {
+                return Ok(out);
             }
             continue;
         }
@@ -667,31 +654,17 @@ fn parse_partial_with_env(
         }
 
         if !out.flag_awaiting_value.is_empty() {
-            while let Some(flag) = out.flag_awaiting_value.pop() {
-                let arg = flag.arg.as_ref().unwrap();
-                if validate_choices(
-                    spec,
-                    &out.cmd,
-                    &mut out.errors,
-                    ChoiceTarget::option(&flag),
-                    &w,
-                    arg.choices.as_ref(),
-                    custom_env,
-                )? {
-                    return Ok(out);
-                }
-                if flag.var {
-                    let arr = out
-                        .flags
-                        .entry(flag)
-                        .or_insert_with(|| ParseValue::MultiString(vec![]))
-                        .try_as_multi_string_mut()
-                        .unwrap();
-                    arr.push(w);
-                } else {
-                    out.flags.insert(flag, ParseValue::String(w));
-                }
-                w = "".to_string();
+            let should_return = drain_pending_flag_values(
+                spec,
+                &out.cmd,
+                &mut out.errors,
+                &mut out.flags,
+                &mut out.flag_awaiting_value,
+                &mut w,
+                custom_env,
+            )?;
+            if should_return {
+                return Ok(out);
             }
             continue;
         }
@@ -850,6 +823,43 @@ impl<'a> ChoiceTarget<'a> {
             name: &flag.name,
         }
     }
+}
+
+fn drain_pending_flag_values(
+    spec: &Spec,
+    cmd: &SpecCommand,
+    errors: &mut Vec<UsageErr>,
+    flags: &mut IndexMap<Arc<SpecFlag>, ParseValue>,
+    flag_awaiting_value: &mut Vec<Arc<SpecFlag>>,
+    word: &mut String,
+    custom_env: Option<&HashMap<String, String>>,
+) -> miette::Result<bool> {
+    while let Some(flag) = flag_awaiting_value.pop() {
+        let arg = flag.arg.as_ref().unwrap();
+        if validate_choices(
+            spec,
+            cmd,
+            errors,
+            ChoiceTarget::option(&flag),
+            word,
+            arg.choices.as_ref(),
+            custom_env,
+        )? {
+            return Ok(true);
+        }
+        let value = std::mem::take(word);
+        if flag.var {
+            let arr = flags
+                .entry(flag)
+                .or_insert_with(|| ParseValue::MultiString(vec![]))
+                .try_as_multi_string_mut()
+                .unwrap();
+            arr.push(value);
+        } else {
+            flags.insert(flag, ParseValue::String(value));
+        }
+    }
+    Ok(false)
 }
 
 fn choice_error(
@@ -2767,6 +2777,30 @@ flag "-a --args <ARGS>" allow_hyphen_values=#true
 
         assert_eq!(parsed.flags.len(), 1);
         assert_eq!(flag_string_value(&parsed, "args"), "-destroy");
+    }
+
+    #[test]
+    fn test_variadic_allow_hyphen_values_consumes_repeated_flag_values() {
+        let spec = r#"
+flag "-a --args <ARGS>" var=#true allow_hyphen_values=#true
+"#
+        .parse::<Spec>()
+        .unwrap();
+
+        let parsed = parse(&spec, &input(&["test", "-a", "-val1", "-a", "-val2"])).unwrap();
+
+        let flag = parsed
+            .flags
+            .keys()
+            .find(|flag| flag.name == "args")
+            .expect("expected args flag");
+        let value = parsed.flags.get(flag).expect("expected args value");
+        match value {
+            ParseValue::MultiString(values) => {
+                assert_eq!(values, &vec!["-val1".to_string(), "-val2".to_string()]);
+            }
+            _ => panic!("expected MultiString, got {value:?}"),
+        }
     }
 
     #[test]

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -565,7 +565,7 @@ fn parse_partial_with_env(
             && out
                 .flag_awaiting_value
                 .last()
-                .is_some_and(|flag| flag.allow_hyphen_values)
+                .is_some_and(|flag| flag.allow_hyphen_values())
         {
             let should_return = drain_pending_flag_values(
                 spec,

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -561,6 +561,40 @@ fn parse_partial_with_env(
             }
         }
 
+        if out
+            .flag_awaiting_value
+            .last()
+            .is_some_and(|flag| flag.allow_hyphen_values)
+        {
+            while let Some(flag) = out.flag_awaiting_value.pop() {
+                let arg = flag.arg.as_ref().unwrap();
+                if validate_choices(
+                    spec,
+                    &out.cmd,
+                    &mut out.errors,
+                    ChoiceTarget::option(&flag),
+                    &w,
+                    arg.choices.as_ref(),
+                    custom_env,
+                )? {
+                    return Ok(out);
+                }
+                if flag.var {
+                    let arr = out
+                        .flags
+                        .entry(flag)
+                        .or_insert_with(|| ParseValue::MultiString(vec![]))
+                        .try_as_multi_string_mut()
+                        .unwrap();
+                    arr.push(w);
+                } else {
+                    out.flags.insert(flag, ParseValue::String(w));
+                }
+                w = "".to_string();
+            }
+            continue;
+        }
+
         // long flags
         if enable_flags && w.starts_with("--") {
             grouped_flag = false;
@@ -1018,6 +1052,22 @@ mod tests {
             return value;
         }
         panic!("expected first parsed value to be ParseValue::String");
+    }
+
+    fn flag_string_value<'a>(parsed: &'a ParseOutput, name: &str) -> &'a str {
+        let flag = parsed
+            .flags
+            .keys()
+            .find(|flag| flag.name == name)
+            .unwrap_or_else(|| panic!("expected flag {name}"));
+        let value = parsed
+            .flags
+            .get(flag)
+            .unwrap_or_else(|| panic!("expected value for flag {name}"));
+        match value {
+            ParseValue::String(value) => value,
+            _ => panic!("expected flag {name} to be ParseValue::String"),
+        }
     }
 
     fn assert_parse_err(result: Result<ParseOutput, miette::Error>, expected: &str) {
@@ -2687,5 +2737,49 @@ mod tests {
             "expected positional args and intact flag token, got {:?}",
             env3.get("usage_other_args"),
         );
+    }
+
+    #[test]
+    fn test_allow_hyphen_values_consumes_short_flag_collision() {
+        let spec = r#"
+flag "-d --working-dir <DIR>"
+flag "-a --args <ARGS>" allow_hyphen_values=#true
+"#
+        .parse::<Spec>()
+        .unwrap();
+
+        let parsed = parse(&spec, &input(&["test", "-a", "-destroy"])).unwrap();
+
+        assert_eq!(parsed.flags.len(), 1);
+        assert_eq!(flag_string_value(&parsed, "args"), "-destroy");
+    }
+
+    #[test]
+    fn test_allow_hyphen_values_consumes_embedded_long_value() {
+        let spec = r#"
+flag "-d --working-dir <DIR>"
+flag "-a --args <ARGS>" allow_hyphen_values=#true
+"#
+        .parse::<Spec>()
+        .unwrap();
+
+        let parsed = parse(&spec, &input(&["test", "--args=-destroy"])).unwrap();
+
+        assert_eq!(parsed.flags.len(), 1);
+        assert_eq!(flag_string_value(&parsed, "args"), "-destroy");
+    }
+
+    #[test]
+    fn test_hyphen_values_still_default_to_short_flag_parsing() {
+        let spec = r#"
+flag "-d --working-dir <DIR>"
+flag "-a --args <ARGS>"
+"#
+        .parse::<Spec>()
+        .unwrap();
+
+        let parsed = parse(&spec, &input(&["test", "-a", "-destroy"])).unwrap();
+
+        assert_eq!(flag_string_value(&parsed, "working-dir"), "estroy");
     }
 }

--- a/lib/src/spec/builder.rs
+++ b/lib/src/spec/builder.rs
@@ -161,6 +161,12 @@ impl SpecFlagBuilder {
         self
     }
 
+    /// Allow this flag's value to start with `-`
+    pub fn allow_hyphen_values(mut self, allow: bool) -> Self {
+        self.inner.allow_hyphen_values = allow;
+        self
+    }
+
     /// Set the argument spec for flags that take values
     pub fn arg(mut self, arg: SpecArg) -> Self {
         self.inner.arg = Some(arg);

--- a/lib/src/spec/builder.rs
+++ b/lib/src/spec/builder.rs
@@ -37,6 +37,7 @@ use crate::{spec::arg::SpecDoubleDashChoices, SpecArg, SpecChoices, SpecCommand,
 #[derive(Debug, Default, Clone)]
 pub struct SpecFlagBuilder {
     inner: SpecFlag,
+    allow_hyphen_values: bool,
 }
 
 impl SpecFlagBuilder {
@@ -163,13 +164,25 @@ impl SpecFlagBuilder {
 
     /// Allow this flag's value to start with `-`
     pub fn allow_hyphen_values(mut self, allow: bool) -> Self {
-        self.inner.allow_hyphen_values = allow;
+        self.allow_hyphen_values = allow;
+        if let Some(arg) = &mut self.inner.arg {
+            arg.double_dash = if allow {
+                crate::spec::arg::SpecDoubleDashChoices::Automatic
+            } else {
+                crate::spec::arg::SpecDoubleDashChoices::Optional
+            };
+        }
         self
     }
 
     /// Set the argument spec for flags that take values
     pub fn arg(mut self, arg: SpecArg) -> Self {
         self.inner.arg = Some(arg);
+        if self.allow_hyphen_values {
+            if let Some(arg) = &mut self.inner.arg {
+                arg.double_dash = crate::spec::arg::SpecDoubleDashChoices::Automatic;
+            }
+        }
         self
     }
 
@@ -194,6 +207,11 @@ impl SpecFlagBuilder {
     /// Build the final SpecFlag
     #[must_use]
     pub fn build(mut self) -> SpecFlag {
+        if self.allow_hyphen_values {
+            if let Some(arg) = &mut self.inner.arg {
+                arg.double_dash = crate::spec::arg::SpecDoubleDashChoices::Automatic;
+            }
+        }
         self.inner.usage = self.inner.usage();
         if self.inner.name.is_empty() {
             // Derive name from long or short flags

--- a/lib/src/spec/flag.rs
+++ b/lib/src/spec/flag.rs
@@ -76,6 +76,9 @@ pub struct SpecFlag {
     /// Argument specification if this flag takes a value
     #[serde(skip_serializing_if = "Option::is_none")]
     pub arg: Option<SpecArg>,
+    /// Whether this flag's value may start with `-`
+    #[serde(skip_serializing_if = "is_false")]
+    pub allow_hyphen_values: bool,
     /// Default value(s) if the flag is not provided
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub default: Vec<String>,
@@ -115,6 +118,7 @@ impl SpecFlag {
                 }
                 "global" => flag.global = v.ensure_bool()?,
                 "count" => flag.count = v.ensure_bool()?,
+                "allow_hyphen_values" => flag.allow_hyphen_values = v.ensure_bool()?,
                 "default" => {
                     // Support both string and boolean defaults
                     let default_value = match v.value.as_bool() {
@@ -152,6 +156,7 @@ impl SpecFlag {
                 }
                 "global" => flag.global = child.arg(0)?.ensure_bool()?,
                 "count" => flag.count = child.arg(0)?.ensure_bool()?,
+                "allow_hyphen_values" => flag.allow_hyphen_values = child.arg(0)?.ensure_bool()?,
                 "default" => {
                     // Support both single value and multiple values
                     // default "bar"            -> vec!["bar"]
@@ -260,6 +265,9 @@ impl From<&SpecFlag> for KdlNode {
         }
         if flag.count {
             node.push(KdlEntry::new_prop("count", true));
+        }
+        if flag.allow_hyphen_values {
+            node.push(KdlEntry::new_prop("allow_hyphen_values", true));
         }
         if let Some(negate) = &flag.negate {
             node.push(string_entry(Some("negate"), negate));
@@ -411,6 +419,7 @@ impl From<&clap::Arg> for SpecFlag {
             hide,
             global: c.is_global_set(),
             arg,
+            allow_hyphen_values: c.is_allow_hyphen_values_set(),
             count: matches!(c.get_action(), clap::ArgAction::Count),
             default,
             deprecated: None,

--- a/lib/src/spec/flag.rs
+++ b/lib/src/spec/flag.rs
@@ -7,6 +7,7 @@ use std::str::FromStr;
 
 use crate::error::UsageErr::InvalidFlag;
 use crate::error::{Result, UsageErr};
+use crate::spec::arg::SpecDoubleDashChoices;
 use crate::spec::builder::SpecFlagBuilder;
 use crate::spec::context::ParsingContext;
 use crate::spec::helpers::{string_entry, NodeHelper};
@@ -76,9 +77,6 @@ pub struct SpecFlag {
     /// Argument specification if this flag takes a value
     #[serde(skip_serializing_if = "Option::is_none")]
     pub arg: Option<SpecArg>,
-    /// Whether this flag's value may start with `-`
-    #[serde(skip_serializing_if = "is_false")]
-    pub allow_hyphen_values: bool,
     /// Default value(s) if the flag is not provided
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub default: Vec<String>,
@@ -98,6 +96,7 @@ impl SpecFlag {
 
     pub(crate) fn parse(ctx: &ParsingContext, node: &NodeHelper) -> Result<Self> {
         let mut flag: Self = node.arg(0)?.ensure_string()?.parse()?;
+        let mut allow_hyphen_values = false;
         for (k, v) in node.props() {
             match k {
                 "help" => flag.help = Some(v.ensure_string()?),
@@ -118,7 +117,7 @@ impl SpecFlag {
                 }
                 "global" => flag.global = v.ensure_bool()?,
                 "count" => flag.count = v.ensure_bool()?,
-                "allow_hyphen_values" => flag.allow_hyphen_values = v.ensure_bool()?,
+                "allow_hyphen_values" => allow_hyphen_values = v.ensure_bool()?,
                 "default" => {
                     // Support both string and boolean defaults
                     let default_value = match v.value.as_bool() {
@@ -156,7 +155,9 @@ impl SpecFlag {
                 }
                 "global" => flag.global = child.arg(0)?.ensure_bool()?,
                 "count" => flag.count = child.arg(0)?.ensure_bool()?,
-                "allow_hyphen_values" => flag.allow_hyphen_values = child.arg(0)?.ensure_bool()?,
+                "allow_hyphen_values" => {
+                    allow_hyphen_values = child.arg(0)?.ensure_bool()?;
+                }
                 "default" => {
                     // Support both single value and multiple values
                     // default "bar"            -> vec!["bar"]
@@ -192,10 +193,41 @@ impl SpecFlag {
                 k => bail_parse!(ctx, child.node.name().span(), "unsupported flag child {k}"),
             }
         }
+        if allow_hyphen_values {
+            flag.set_allow_hyphen_values(ctx, node.node.name().span(), true)?;
+        }
         flag.usage = flag.usage();
         flag.help_first_line = flag.help.as_ref().map(|s| string::first_line(s));
         Ok(flag)
     }
+    pub fn allow_hyphen_values(&self) -> bool {
+        self.arg
+            .as_ref()
+            .is_some_and(|arg| arg.double_dash == SpecDoubleDashChoices::Automatic)
+    }
+
+    pub(crate) fn set_allow_hyphen_values(
+        &mut self,
+        ctx: &ParsingContext,
+        span: miette::SourceSpan,
+        allow: bool,
+    ) -> Result<()> {
+        if let Some(arg) = &mut self.arg {
+            arg.double_dash = if allow {
+                SpecDoubleDashChoices::Automatic
+            } else if arg.double_dash == SpecDoubleDashChoices::Automatic {
+                SpecDoubleDashChoices::Optional
+            } else {
+                arg.double_dash.clone()
+            };
+            Ok(())
+        } else if allow {
+            bail_parse!(ctx, span, "flag must have value to allow hyphen values")
+        } else {
+            Ok(())
+        }
+    }
+
     pub fn usage(&self) -> String {
         let mut parts = vec![];
         let name = get_name_from_short_and_long(&self.short, &self.long).unwrap_or_default();
@@ -266,7 +298,7 @@ impl From<&SpecFlag> for KdlNode {
         if flag.count {
             node.push(KdlEntry::new_prop("count", true));
         }
-        if flag.allow_hyphen_values {
+        if flag.allow_hyphen_values() {
             node.push(KdlEntry::new_prop("allow_hyphen_values", true));
         }
         if let Some(negate) = &flag.negate {
@@ -300,7 +332,13 @@ impl From<&SpecFlag> for KdlNode {
         }
         if let Some(arg) = &flag.arg {
             let children = node.children_mut().get_or_insert_with(KdlDocument::new);
-            children.nodes_mut().push(arg.into());
+            if flag.allow_hyphen_values() {
+                let mut arg = arg.clone();
+                arg.double_dash = SpecDoubleDashChoices::Optional;
+                children.nodes_mut().push((&arg).into());
+            } else {
+                children.nodes_mut().push(arg.into());
+            }
         }
         node
     }
@@ -403,7 +441,7 @@ impl From<&clap::Arg> for SpecFlag {
         } else {
             None
         };
-        Self {
+        let mut flag = Self {
             name,
             usage: "".into(),
             short,
@@ -419,13 +457,18 @@ impl From<&clap::Arg> for SpecFlag {
             hide,
             global: c.is_global_set(),
             arg,
-            allow_hyphen_values: c.is_allow_hyphen_values_set(),
             count: matches!(c.get_action(), clap::ArgAction::Count),
             default,
             deprecated: None,
             negate: None,
             env: None,
+        };
+        if c.is_allow_hyphen_values_set() {
+            if let Some(arg) = &mut flag.arg {
+                arg.double_dash = SpecDoubleDashChoices::Automatic;
+            }
         }
+        flag
     }
 }
 


### PR DESCRIPTION
## Summary

- add `allow_hyphen_values` to flag specs and builders
- let opted-in value flags consume pending values before short/long flag parsing
- add regression coverage for `-a -destroy`, `--args=-destroy`, and the unchanged default behavior

Closes #713.

## Testing

- `cargo test -p usage-lib hyphen_values`
- `cargo test -p usage-lib --all-features`
- `cargo clippy --all --all-features -- -D warnings`

`cargo test --all --all-features` was also run; the Rust suites passed until existing Node-backed CLI example tests failed because `node` is not installed on PATH in this shell.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core CLI parsing order for all specs, but behavior changes only when `allow_hyphen_values` is enabled; regression tests cover the main cases.
> 
> **Overview**
> **Opt-in flag values that look like flags** — specs can set `allow_hyphen_values=#true` on value-taking flags (KDL, builders, and clap-derived specs). The parser treats the next `-…` token as that flag’s value **before** short/long flag parsing, including embedded forms like `--args=-destroy` and repeated variadic values.
> 
> Pending value handling is centralized in `drain_pending_flag_values`. **`complete-word`’s `--cword`** is regenerated with this setting so negative indices parse correctly. Flags without the option keep today’s behavior (e.g. `-a -destroy` still splits `-destroy` into other short flags).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89d5db09b514d11d689c31b8f32a22bc5f1a8cbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Flags and options can now accept values that start with a hyphen, improving support for inputs like `-value` and `--args=-value`.
  * Added a configurable setting to enable this behavior for specific options.
* **Bug Fixes**
  * Prevented hyphen-prefixed values from being misread as additional flags when this setting is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->