### PR TITLE
chore(release): skip ai reviews for release prs

### DIFF
--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,4 @@
+{
+  "disabledLabels": ["release", "autorelease: pending"],
+  "ignoreKeywords": "chore: release\nchore(main): release\nThis PR was generated with release-plz\nThis PR was generated with Release Please"
+}


### PR DESCRIPTION
## Summary
- add Greptile filters for mechanical release PR titles and release labels

## Notes
- CodeRabbit title filtering is handled in the companion `jdx/coderabbit` PR.
- No Cursor Bugbot rules are included.

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change with no runtime or application logic impact.
> 
> **Overview**
> Adds **`greptile.json`** so Greptile skips automated reviews on mechanical release PRs.
> 
> **`disabledLabels`** ignores PRs labeled `release` or `autorelease: pending`. **`ignoreKeywords`** matches common release-plz / Release Please titles and boilerplate in the PR body. CodeRabbit filtering is handled separately in the companion `jdx/coderabbit` PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c70a98b571e7ce92221795d9260643766c468602. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->