### PR TITLE
test: invoke typescript compiler through npx package

### DIFF
--- a/lib/tests/sdk_compile.rs
+++ b/lib/tests/sdk_compile.rs
@@ -203,7 +203,7 @@ fn test_typescript_sdk_typechecks() {
     fs::write(dir.path().join("tsconfig.json"), tsconfig).unwrap();
 
     let result = Command::new("npx")
-        .args(["--yes", "typescript", "tsc", "--project"])
+        .args(["--yes", "--package", "typescript", "tsc", "--project"])
         .arg(dir.path().join("tsconfig.json"))
         .output()
         .expect("Failed to run tsc");


### PR DESCRIPTION
## Summary

- invoke `tsc` from the explicitly selected `typescript` npm package
- prevent `npx` from treating `tsc` as a source-file argument

## Root cause

The SDK compile test ran `npx --yes typescript tsc --project ...`. With the CI runner's `npx` behavior, the extra `tsc` token was forwarded to the compiler as a source file, which cannot be combined with `--project` and caused TS5042 in the test and coverage jobs.

## Validation

- `rustup run stable cargo test -p usage-lib --test sdk_compile`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to the `npx` argument list; no production or SDK generation behavior is modified.
> 
> **Overview**
> Fixes the TypeScript SDK compile test on CI by changing how **`tsc`** is launched through **`npx`**.
> 
> The test now passes **`--package`, `typescript`** before **`tsc`**, so **`npx`** runs the compiler from the **`typescript`** package instead of forwarding a stray **`tsc`** token as a source file (which conflicted with **`--project`** and triggered **TS5042**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c6ae85dcf50a320d896a3e508e339f4c3c96ac1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->