### PR TITLE
chore: remove dtolnay/rust-toolchain action, use runner default rust

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -94,7 +94,6 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - name: Install Rust target
         if: ${{ matrix.target != 'universal-apple-darwin' }}
         run: rustup target add ${{ matrix.target }}


### PR DESCRIPTION
## What

Removes the `dtolnay/rust-toolchain@stable` step from `publish-cli.yml`.

## Why

GitHub-hosted runners (`ubuntu-latest`, `windows-latest`, `macos-latest`) ship with `rustup` and a stable toolchain preinstalled. The very next step, `rustup target add ${{ matrix.target }}`, uses that same preinstalled `rustup`, so it keeps working without the action.

This also matches how the rest of CI already works:
- `test.yml` has no toolchain action at all — it builds against the runner's default Rust.
- `coverage.yml` uses a plain `rustup update stable` run step.

Dropping the action here unifies the approach and eliminates the recurring Renovate digest-bump PRs for it (supersedes #721).

## Note

The runner-image toolchain can lag latest stable by up to ~a couple weeks. For release builds that's effectively never an issue, and `cross`-built targets use their own toolchain regardless. If we ever need guaranteed-latest stable, we can add `rustup update stable` like `coverage.yml` does.

_This PR was generated by Claude Code._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow tweak with no application or security logic changes; runner Rust may lag latest stable slightly, as noted in the PR.
> 
> **Overview**
> The **`publish-cli`** release workflow no longer installs Rust via **`dtolnay/rust-toolchain@stable`**. **`build-and-publish`** now relies on the GitHub-hosted runner’s preinstalled **`rustup`** / stable toolchain, with the existing **`rustup target add`** step unchanged.
> 
> This aligns CLI publishing with other workflows (e.g. **`test.yml`** and **`coverage.yml`’s** plain **`rustup`** steps) and avoids ongoing Renovate digest bumps for that action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fea1f637fa89f2e3b8e4d65fdae9c7aa5505ea9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->