### PR TITLE
fix(lib): remove needless borrows in format args

### DIFF
--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -945,7 +945,7 @@ impl Debug for ParseOutput {
                 &self
                     .args
                     .iter()
-                    .map(|(a, w)| format!("{}: {w}", &a.name))
+                    .map(|(a, w)| format!("{}: {w}", a.name))
                     .collect_vec(),
             )
             .field(
@@ -961,7 +961,7 @@ impl Debug for ParseOutput {
                 &self
                     .flags
                     .iter()
-                    .map(|(f, w)| format!("{}: {w}", &f.name))
+                    .map(|(f, w)| format!("{}: {w}", f.name))
                     .collect_vec(),
             )
             .field("flag_awaiting_value", &self.flag_awaiting_value)

--- a/lib/src/spec/mount.rs
+++ b/lib/src/spec/mount.rs
@@ -37,7 +37,7 @@ impl SpecMount {
         Ok(mount)
     }
     pub fn usage(&self) -> String {
-        format!("mount:{}", &self.run)
+        format!("mount:{}", self.run)
     }
 }
 


### PR DESCRIPTION
## Problem

The `test` workflow is failing on `main` and on every open PR (including the lockfile-maintenance one). It's not any PR's changes — it's the CI toolchain.

CI runs `mise r render`, which calls `mise run lint-fix` → `cargo clippy --all --all-features --fix ...`. The CI toolchain recently moved to **clippy 1.97.0**, which now flags needless `&` borrows in `format!` arguments. `clippy --fix` auto-rewrites the offending lines, leaving the working tree dirty, and the `assert render produces no diff` step fails:

```
-  .map(|(a, w)| format!("{}: {w}", &a.name))   →   a.name
-  .map(|(f, w)| format!("{}: {w}", &f.name))   →   f.name      (lib/src/parse.rs)
-  format!("mount:{}", &self.run)               →   self.run    (lib/src/spec/mount.rs)
```

Nothing pins the Rust version, so CI floats to latest stable and this hit every branch at once.

## Fix

Apply the three edits clippy wanted directly in source, so clippy 1.97 is a no-op and `render` produces no diff. Purely mechanical; no behavior change.

_This PR was generated by Claude Code._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical Clippy-driven edits in debug formatting and a usage string helper only; no logic or API changes.
> 
> **Overview**
> Removes **needless `&` borrows** in `format!` arguments so **Clippy 1.97** (`needless_borrow` in format args) no longer auto-fixes the tree during CI `lint-fix` / `render`.
> 
> In `ParseOutput`'s `Debug` impl, arg and flag debug lines now pass `a.name` and `f.name` by value instead of `&a.name` / `&f.name`. `SpecMount::usage` uses `self.run` instead of `&self.run` in `format!("mount:{}", ...)`.
> 
> No parsing, mount behavior, or output semantics change—only style to keep `assert render produces no diff` green.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edb6690b1dc94956cb28c7d533464319aeb09afd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->