### PR TITLE
chore: regenerate aube-lock.yaml on renovate branches

### DIFF
--- a/.github/workflows/aube-lock.yml
+++ b/.github/workflows/aube-lock.yml
@@ -1,0 +1,20 @@
+name: aube-lock
+
+# Regenerates aube-lock.yaml on Renovate branches. Renovate's npm manager
+# updates package.json but has no aube support, leaving the lockfile stale
+# and breaking `aube install --frozen-lockfile` in CI. See
+# jdx/renovate-config for the workflow implementation.
+
+on:
+  push:
+    branches: ["renovate/**"]
+
+permissions:
+  contents: write
+
+jobs:
+  aube-lock:
+    uses: jdx/renovate-config/.github/workflows/aube-lock.yml@d619510c737e7ebf8a8ad25f8268120bf01f4976 # main
+    secrets:
+      AUBE_LOCK_APP_ID: ${{ secrets.AUBE_LOCK_APP_ID }}
+      AUBE_LOCK_APP_PRIVATE_KEY: ${{ secrets.AUBE_LOCK_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Problem

Renovate has no native aube manager: its npm manager updates `package.json` but leaves `aube-lock.yaml` stale, so `aube install --frozen-lockfile` in CI fails on JS dependency bumps.

## Fix

Add a caller for the shared `aube-lock` reusable workflow ([jdx/renovate-config](https://github.com/jdx/renovate-config)). On pushes to `renovate/**` branches (gated to renovate[bot]), it runs `aube install --no-frozen-lockfile` and commits the regenerated `aube-lock.yaml` back. Pinned to the merged renovate-config SHA `d619510`.

Requires repo secrets `AUBE_LOCK_APP_ID` / `AUBE_LOCK_APP_PRIVATE_KEY` (GitHub App, `contents: write`) for the fix push to retrigger CI; without them it falls back to `GITHUB_TOKEN` (lockfile still fixed, checks need a manual re-run).

*This PR was generated by Claude Code.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only automation with no application or runtime code changes; main operational risk is workflow permissions and optional secrets setup.
> 
> **Overview**
> Adds a new GitHub Actions workflow **aube-lock** that runs on pushes to `renovate/**` branches so `aube-lock.yaml` stays in sync when Renovate bumps npm deps in `package.json`.
> 
> The job calls the reusable workflow from `jdx/renovate-config` (pinned SHA), grants `contents: write`, and passes optional GitHub App secrets so the bot can commit the regenerated lockfile and retrigger CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2e4747aa94f3faf5e2e93a1b8df4cd6b1607eb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->