### PR TITLE
fix(cli): avoid trailing semicolon in macro expression position

### DIFF
--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -74,7 +74,9 @@ impl CompleteWord {
                     let insert = zsh_shell_quote(&c);
                     println!("{c}\t{description}\t{insert}")
                 }
-                _ => miette::bail!("unsupported shell: {}", shell),
+                _ => {
+                    miette::bail!("unsupported shell: {}", shell);
+                }
             }
         }
 

--- a/cli/src/usage_spec.rs
+++ b/cli/src/usage_spec.rs
@@ -15,7 +15,9 @@ pub(crate) fn complete(shell: &str) -> Result<()> {
         "bash" => print!("{}", include_str!("../assets/completions/usage.bash")),
         "fish" => print!("{}", include_str!("../assets/completions/usage.fish")),
         "zsh" => print!("{}", include_str!("../assets/completions/_usage")),
-        _ => miette::bail!("unsupported shell: {}", shell),
+        _ => {
+            miette::bail!("unsupported shell: {}", shell);
+        }
     };
 
     Ok(())


### PR DESCRIPTION
## Goal

Get ahead of future Rust warnings. I ran the project under **nightly clippy (1.99.0 / clippy 0.1.99)** to surface anything that will bite on future toolchains.

## What nightly found

- **Clippy lints: none.** Zero new clippy warnings across the workspace.
- **One future-incompatibility lint in our own code:** `semicolon_in_expressions_from_macros` (rust-lang/rust#79813), already a *hard error* on nightly. It comes from `miette::bail!` (which expands to `return Err(..);`) used as a match-arm tail expression, at:
  - `cli/src/cli/complete_word.rs:77`
  - `cli/src/usage_spec.rs:18`
- **One instance in a dependency:** `nix v0.30.1` build script (transitive via `homedir` → `xx`). Out of scope here — it clears when `homedir`/`xx` bump `nix` to 0.31.x. Not fixable from this repo without an upstream bump.

## Fix

Wrap the two `bail!` call sites in a block with an explicit trailing semicolon, moving the macro into statement position. `miette` has no released fix (7.6.0 is latest and still expands with the trailing semicolon), so the fix belongs at the call sites.

## Verification

- `cargo +nightly clippy --all --all-features -- -D warnings` → clean (only the transitive `nix` note remains)
- `cargo clippy --all --all-features --fix ... -- -D warnings` on stable → no additional changes (CI's `mise run render` no-diff check stays green)
- `cargo build`/`cargo test -p usage-cli` → pass

_This PR was generated by Claude Code._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical control-flow formatting with no logic or behavior change beyond satisfying a future Rust lint.
> 
> **Overview**
> Prepares for Rust’s **`semicolon_in_expressions_from_macros`** lint (already an error on nightly) by fixing two **`miette::bail!`** call sites used as match-arm tail expressions.
> 
> In **`complete_word.rs`** and **`usage_spec.rs`**, the unsupported-shell arms now use a block `{ miette::bail!(...); }` so the macro expands in **statement** position instead of as an expression. **Runtime behavior is unchanged** — still bails with the same message for unknown shells.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e044698c6d7fee9080a1b13c6345f10688599d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->