### PR TITLE
refactor(complete): drop redundant -d guard before mkdir in cache dir setup

### DIFF
--- a/cli/assets/completions/_usage
+++ b/cli/assets/completions/_usage
@@ -25,7 +25,7 @@ _usage() {
   fi
 
   local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
-  [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
+  mkdir -p -m 700 "$spec_dir"
   local spec_file="$spec_dir/usage__usage_spec_usage.spec"
   usage --usage-spec >| "$spec_file"
   local -a values=() descs=() inserts=()

--- a/cli/assets/completions/usage.bash
+++ b/cli/assets/completions/usage.bash
@@ -10,7 +10,7 @@ _usage() {
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
-    [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
+    mkdir -p -m 700 "$spec_dir"
     local spec_file="$spec_dir/usage__usage_spec_usage.spec"
     usage --usage-spec >| "$spec_file"
     # shellcheck disable=SC2207

--- a/cli/assets/completions/usage.fish
+++ b/cli/assets/completions/usage.fish
@@ -8,7 +8,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l spec_dir (if set -q XDG_CACHE_HOME; echo $XDG_CACHE_HOME; else; echo $HOME/.cache; end)/usage
-test -d "$spec_dir"; or mkdir -p -m 700 "$spec_dir"
+mkdir -p -m 700 "$spec_dir"
 set -l spec_file "$spec_dir/usage__usage_spec_usage.spec"
 usage --usage-spec | string collect > "$spec_file"
 

--- a/lib/src/complete/bash.rs
+++ b/lib/src/complete/bash.rs
@@ -78,7 +78,7 @@ fi"#
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     local spec_dir="${{XDG_CACHE_HOME:-$HOME/.cache}}/usage"
-    [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
+    mkdir -p -m 700 "$spec_dir"
     local spec_file="$spec_dir/usage_{spec_variable}.spec"
     {file_write_logic}
     # shellcheck disable=SC2207

--- a/lib/src/complete/fish.rs
+++ b/lib/src/complete/fish.rs
@@ -77,7 +77,7 @@ end"#
     out.push(format!(
         r#"
 set -l spec_dir (if set -q XDG_CACHE_HOME; echo $XDG_CACHE_HOME; else; echo $HOME/.cache; end)/usage
-test -d "$spec_dir"; or mkdir -p -m 700 "$spec_dir"
+mkdir -p -m 700 "$spec_dir"
 set -l spec_file "$spec_dir/usage_{spec_variable}.spec"
 {file_write_logic}
 

--- a/lib/src/complete/snapshots/usage__complete__bash__tests__complete_bash-2.snap
+++ b/lib/src/complete/snapshots/usage__complete__bash__tests__complete_bash-2.snap
@@ -14,7 +14,7 @@ _mycli() {
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
-    [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
+    mkdir -p -m 700 "$spec_dir"
     local spec_file="$spec_dir/usage__usage_spec_mycli_1_2_3.spec"
     if [[ ! -f "$spec_file" ]]; then
         find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mycli_*.spec' -type f -mtime +30 -delete 2>/dev/null

--- a/lib/src/complete/snapshots/usage__complete__bash__tests__complete_bash-3.snap
+++ b/lib/src/complete/snapshots/usage__complete__bash__tests__complete_bash-3.snap
@@ -14,7 +14,7 @@ _mycli() {
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
-    [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
+    mkdir -p -m 700 "$spec_dir"
     local spec_file="$spec_dir/usage__usage_spec_mycli.spec"
     cat >| "$spec_file" <<'__USAGE_EOF__'
 name mycli

--- a/lib/src/complete/snapshots/usage__complete__bash__tests__complete_bash.snap
+++ b/lib/src/complete/snapshots/usage__complete__bash__tests__complete_bash.snap
@@ -14,7 +14,7 @@ _mycli() {
 	local cur prev words cword was_split comp_args
     _comp_initialize -n : -- "$@" || return
     local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
-    [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
+    mkdir -p -m 700 "$spec_dir"
     local spec_file="$spec_dir/usage__usage_spec_mycli.spec"
     mycli complete --usage >| "$spec_file"
     # shellcheck disable=SC2207

--- a/lib/src/complete/snapshots/usage__complete__fish__tests__complete_fish-2.snap
+++ b/lib/src/complete/snapshots/usage__complete__fish__tests__complete_fish-2.snap
@@ -12,7 +12,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l spec_dir (if set -q XDG_CACHE_HOME; echo $XDG_CACHE_HOME; else; echo $HOME/.cache; end)/usage
-test -d "$spec_dir"; or mkdir -p -m 700 "$spec_dir"
+mkdir -p -m 700 "$spec_dir"
 set -l spec_file "$spec_dir/usage__usage_spec_mycli_1_2_3.spec"
 if not test -f "$spec_file"
     find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mycli_*.spec' -type f -mtime +30 -delete 2>/dev/null

--- a/lib/src/complete/snapshots/usage__complete__fish__tests__complete_fish-3.snap
+++ b/lib/src/complete/snapshots/usage__complete__fish__tests__complete_fish-3.snap
@@ -74,7 +74,7 @@ cmd plugin {
 }
 '
 set -l spec_dir (if set -q XDG_CACHE_HOME; echo $XDG_CACHE_HOME; else; echo $HOME/.cache; end)/usage
-test -d "$spec_dir"; or mkdir -p -m 700 "$spec_dir"
+mkdir -p -m 700 "$spec_dir"
 set -l spec_file "$spec_dir/usage__usage_spec_mycli.spec"
 echo $_usage_spec_mycli > "$spec_file"
 

--- a/lib/src/complete/snapshots/usage__complete__fish__tests__complete_fish.snap
+++ b/lib/src/complete/snapshots/usage__complete__fish__tests__complete_fish.snap
@@ -12,7 +12,7 @@ if ! type -p usage &> /dev/null
     return 1
 end
 set -l spec_dir (if set -q XDG_CACHE_HOME; echo $XDG_CACHE_HOME; else; echo $HOME/.cache; end)/usage
-test -d "$spec_dir"; or mkdir -p -m 700 "$spec_dir"
+mkdir -p -m 700 "$spec_dir"
 set -l spec_file "$spec_dir/usage__usage_spec_mycli.spec"
 mycli complete --usage | string collect > "$spec_file"
 

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-2.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-2.snap
@@ -29,7 +29,7 @@ _mycli() {
   fi
 
   local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
-  [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
+  mkdir -p -m 700 "$spec_dir"
   local spec_file="$spec_dir/usage__usage_spec_mycli_1_2_3.spec"
   if [[ ! -f "$spec_file" ]]; then
     find "$spec_dir" -maxdepth 1 -name 'usage__usage_spec_mycli_*.spec' -type f -mtime +30 -delete 2>/dev/null

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-3.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-3.snap
@@ -19,7 +19,7 @@ _mycli() {
   fi
 
   local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
-  [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
+  mkdir -p -m 700 "$spec_dir"
   local spec_file="$spec_dir/usage__usage_spec_mycli.spec"
   cat >| "$spec_file" <<'__USAGE_EOF__'
 name mycli

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh.snap
@@ -29,7 +29,7 @@ _mycli() {
   fi
 
   local spec_dir="${XDG_CACHE_HOME:-$HOME/.cache}/usage"
-  [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
+  mkdir -p -m 700 "$spec_dir"
   local spec_file="$spec_dir/usage__usage_spec_mycli.spec"
   mycli complete --usage >| "$spec_file"
   local -a values=() descs=() inserts=()

--- a/lib/src/complete/zsh.rs
+++ b/lib/src/complete/zsh.rs
@@ -158,7 +158,7 @@ fi"#
     out.push(format!(
         r#"
   local spec_dir="${{XDG_CACHE_HOME:-$HOME/.cache}}/usage"
-  [[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"
+  mkdir -p -m 700 "$spec_dir"
   local spec_file="$spec_dir/usage_{spec_variable}.spec"
   {file_write_logic}
 {completion_loop}


### PR DESCRIPTION
## Summary

Follow-up to #727 addressing @scop's [review comment](https://github.com/jdx/usage/pull/727#pullrequestreview-4738518469).

The completion generators guarded cache-dir creation with an existence test:

```sh
[[ -d "$spec_dir" ]] || mkdir -p -m 700 "$spec_dir"   # bash / zsh
test -d "$spec_dir"; or mkdir -p -m 700 "$spec_dir"   # fish
```

As @scop noted, that guard is effectively a no-op:

- `mkdir -p` already returns success when the directory exists, so the guard changes nothing on the common path.
- It doesn't add safety either — if `$spec_dir` exists as a *non-directory*, `-d` is false, so it falls through to `mkdir -p` (which then fails), and the later `>| "$spec_file"` fails regardless. The guard protects nothing.

The only thing the test saved was an occasional `mkdir` fork, but every completion already forks `usage complete-word`, so that's noise.

This removes the guard across **bash, zsh, and fish** so all four generators create the cache dir the same way (nu already did an unconditional `mkdir`). The `-m 700` mode is kept — that's the actual #722 fix.

## Testing

- `cargo insta test --accept -p usage-lib` — regenerated per-shell snapshots.
- `mise run render` — regenerated the bundled `usage` completion assets (`usage.bash`, `usage.fish`, `_usage`).
- `cargo test -p usage-lib --lib` (257) and `cargo test -p usage-cli --test shell_completions_integration` (13) pass; `cargo fmt --check` clean.

_This PR was generated by Claude Code._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic shell-script simplification in completion cache setup; behavior is unchanged because `mkdir -p` is idempotent when the directory already exists.
> 
> **Overview**
> Completion scripts for **bash**, **zsh**, and **fish** no longer test whether the usage spec cache directory exists before creating it. They always run `mkdir -p -m 700` on `$XDG_CACHE_HOME/usage` (or `~/.cache/usage`), matching **nu** and dropping patterns like `[[ -d "$spec_dir" ]] || mkdir …` and fish’s `test -d …; or mkdir …`.
> 
> The change is in the Rust generators (`bash.rs`, `zsh.rs`, `fish.rs`), regenerated **usage** completion assets, and insta snapshots. **`mkdir -p -m 700` is unchanged** — only the redundant existence check is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae17a894c9ab3210be3c0473ccbfe2e2e895b1e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->