### PR TITLE
chore: exclude aube-lock.yaml from prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,6 @@ lib/bash-completion
 examples/docs
 lefthook.yml
 pnpm-lock.yaml
+
+# aube-generated lockfile (not prettier-formatted)
+**/aube-lock.yaml


### PR DESCRIPTION
## Why

The shared `aube-lock` workflow ([jdx/renovate-config](https://github.com/jdx/renovate-config)) commits aube-regenerated lockfiles on `renovate/**` branches. But aube's generated `aube-lock.yaml` is **not** prettier-formatted, and this repo prettier-checks `**/*.yaml`, so those auto-fix commits would fail the prettier lint step.

Generated lockfiles shouldn't be prettier-checked (this repo already ignores other lockfiles). Add `aube-lock.yaml` to `.prettierignore`.

Discovered while fixing the equivalent issue in [jdx/hk#1095](https://github.com/jdx/hk/pull/1095).

*This PR was generated by Claude Code.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates `.prettierignore`; no runtime, auth, or application logic changes.
> 
> **Overview**
> Adds **`**/aube-lock.yaml`** to `.prettierignore`, matching how other generated lockfiles (e.g. `pnpm-lock.yaml`) are already excluded.
> 
> This stops prettier from reformatting or failing on **aube-generated** lockfiles committed by the shared `aube-lock` Renovate workflow, which are not prettier-formatted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8426ca96a85ec20c320d6677e84fa46dfbdcaee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->