### PR TITLE
fix(parse): don't leak the mounting CLI's flags into mounted commands; scan past non-global flags

### DIFF
--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -116,14 +116,17 @@ impl CompleteWord {
             .is_some_and(|rt| prev_token == Some(rt.as_str()));
 
         let mut has_explicit_choices = false;
+        // Not `available_flags`: inside a mounted command, the mounting CLI's flags stay
+        // recognized for parsing but are not accepted there, so they must not be offered.
+        let flags = parsed.completion_flags();
         let mut choices = if ctoken == "-" {
-            let shorts = self.complete_short_flag_names(&parsed.available_flags, "");
-            let longs = self.complete_long_flag_names(&parsed.available_flags, "");
+            let shorts = self.complete_short_flag_names(&flags, "");
+            let longs = self.complete_long_flag_names(&flags, "");
             shorts.into_iter().chain(longs).collect::<Vec<_>>()
         } else if ctoken.starts_with("--") {
-            self.complete_long_flag_names(&parsed.available_flags, &ctoken)
+            self.complete_long_flag_names(&flags, &ctoken)
         } else if ctoken.starts_with('-') {
-            self.complete_short_flag_names(&parsed.available_flags, &ctoken)
+            self.complete_short_flag_names(&flags, &ctoken)
         } else if after_restart_token {
             // After a restart_token, complete from the first arg of the current command
             // This must be checked after flag checks (to allow --flag after :::)

--- a/cli/tests/complete_word.rs
+++ b/cli/tests/complete_word.rs
@@ -327,6 +327,14 @@ fn complete_word_mounted_does_not_offer_mounting_cli_flags() {
     )
     .stdout("dev\nstage\nprod\n");
 
+    // Inside the mounted tree the mounted program's own commands are ordinary commands: a
+    // global it declares is still offered in its subcommands, while the mounting CLI's are not.
+    assert_cmd(
+        "mounted-global-flag-leak.sh",
+        &["--", "run", "grouped", "leaf", "--"],
+    )
+    .stdout("--group-wide\tApplies to the whole group\n--leaf-only\tOnly on the leaf\n");
+
     // A NON-global flag of `run` before the task name must not hide the mounted command either
     // (`mise run --force build <TAB>` used to fail with `unexpected word: build`).
     assert_cmd(

--- a/cli/tests/complete_word.rs
+++ b/cli/tests/complete_word.rs
@@ -259,6 +259,60 @@ fn complete_word_mounted_orphan_short_flag_choices() {
 }
 
 #[test]
+fn complete_word_mounted_does_not_offer_mounting_cli_flags() {
+    // Regression for jdx/mise#11282: the mounting CLI's global flags must not be offered
+    // inside a mounted command, and must not shadow the mounted command's own flags.
+    let mut path = env::split_paths(&env::var("PATH").unwrap()).collect::<Vec<_>>();
+    path.insert(
+        0,
+        env::current_dir()
+            .unwrap()
+            .join("..")
+            .join("target")
+            .join("debug"),
+    );
+    path.insert(0, env::current_dir().unwrap().join("..").join("examples"));
+    env::set_var("PATH", env::join_paths(path).unwrap());
+
+    // Only the mounted task's own flags are offered. Previously this also listed the root's
+    // `--env`/`--silent`, which the mounted program rejects.
+    assert_cmd("mounted-global-flag-leak.sh", &["--", "run", "mytask", "--"])
+        .stdout("--bump\tVersion bump\n--env\tEnvironment to deploy to\n--output-dir\tWhere to write output\n");
+
+    // Shorts of the mounting CLI's globals (`-E`) are not offered either, only the task's.
+    assert_cmd("mounted-global-flag-leak.sh", &["--", "run", "mytask", "-"])
+        .stdout("--bump\tVersion bump\n--env\tEnvironment to deploy to\n--output-dir\tWhere to write output\n");
+
+    // The task's `--env` wins over the root global of the same name, so its choices complete
+    // instead of the global's (previously: file completion from the global's `<ENV>` arg).
+    assert_cmd(
+        "mounted-global-flag-leak.sh",
+        &["--", "run", "mytask", "--env", ""],
+    )
+    .stdout("dev\nstage\nprod\n");
+
+    // A non-colliding task flag is unaffected.
+    assert_cmd(
+        "mounted-global-flag-leak.sh",
+        &["--", "run", "mytask", "--bump", ""],
+    )
+    .stdout("auto\nmajor\nminor\npatch\n");
+
+    // The mounting CLI's flags still complete *before* the mounted command.
+    assert_cmd("mounted-global-flag-leak.sh", &["--", "run", "--"]).stdout(
+        "--env\tSet the environment\n--force\tForce the tasks to run\n--silent\tSilent output\n",
+    );
+
+    // And a global before the task still parses: the task's arg choices complete after it,
+    // and the global's value reaches the mount (jdx/mise#10069 behavior is preserved).
+    assert_cmd(
+        "mounted-global-flag-leak.sh",
+        &["--", "-E", "prod", "run", "mytask", ""],
+    )
+    .stdout("alpha\nbeta\n");
+}
+
+#[test]
 fn complete_word_boolean_flags_dont_consume_subcommands() {
     let mut path = env::split_paths(&env::var("PATH").unwrap()).collect::<Vec<_>>();
     path.insert(

--- a/cli/tests/complete_word.rs
+++ b/cli/tests/complete_word.rs
@@ -310,6 +310,35 @@ fn complete_word_mounted_does_not_offer_mounting_cli_flags() {
         &["--", "-E", "prod", "run", "mytask", ""],
     )
     .stdout("alpha\nbeta\n");
+
+    // Even when the global's value would be rejected by the mounted flag of the same name, it
+    // keeps parsing as the global, because Phase 1 recorded which flag it was read as.
+    assert_cmd(
+        "mounted-global-flag-leak.sh",
+        &["--", "--env", "not-a-task-choice", "run", "mytask", ""],
+    )
+    .stdout("alpha\nbeta\n");
+
+    // ...and the mounted `--env` still owns the name after the mounted command, so its choices
+    // complete there rather than the global's file-path fallback.
+    assert_cmd(
+        "mounted-global-flag-leak.sh",
+        &["--", "--env", "prod", "run", "mytask", "--env", ""],
+    )
+    .stdout("dev\nstage\nprod\n");
+
+    // A NON-global flag of `run` before the task name must not hide the mounted command either
+    // (`mise run --force build <TAB>` used to fail with `unexpected word: build`).
+    assert_cmd(
+        "mounted-global-flag-leak.sh",
+        &["--", "run", "--force", "mytask", "--"],
+    )
+    .stdout("--bump\tVersion bump\n--env\tEnvironment to deploy to\n--output-dir\tWhere to write output\n");
+    assert_cmd(
+        "mounted-global-flag-leak.sh",
+        &["--", "run", "-f", "mytask", ""],
+    )
+    .stdout("alpha\nbeta\n");
 }
 
 #[test]
@@ -347,7 +376,7 @@ fn complete_word_boolean_flags_dont_consume_subcommands() {
 }
 
 #[test]
-fn complete_word_non_global_flags_stop_search() {
+fn complete_word_non_global_flags_do_not_stop_search() {
     let mut path = env::split_paths(&env::var("PATH").unwrap()).collect::<Vec<_>>();
     path.insert(
         0,
@@ -360,10 +389,18 @@ fn complete_word_non_global_flags_stop_search() {
     path.insert(0, env::current_dir().unwrap().join("..").join("examples"));
     env::set_var("PATH", env::join_paths(path).unwrap());
 
-    // Non-global flag --local should stop subcommand search
-    // The parser will fail to recognize 'run' as a subcommand and error
+    // A non-global flag before a subcommand is consumed like a global one, so the subcommand
+    // (and its mount) is still found. It used to stop the search, leaving `run` to be read as a
+    // positional: `unexpected word: run`, with no completions at all. Only the flag's scope
+    // differs — being non-global, it is not forwarded to the mount, so the mount still reports
+    // the default task rather than the `--verbose` one.
+    assert_cmd("test-boolean-flags.sh", &["--", "--local", "run", ""])
+        .stdout("task-default\tTask default\n");
+
+    // An *unknown* flag still stops the search: the parser can't know whether it takes a value,
+    // so `run` may well be that value.
     let mut cmd = cmd("test-boolean-flags.sh", Some("fish"));
-    cmd.args(["--", "--local", "run", ""]);
+    cmd.args(["--", "--nope", "run", ""]);
     cmd.assert().failure().stderr(contains("unexpected word"));
 }
 

--- a/docs/spec/reference/cmd.md
+++ b/docs/spec/reference/cmd.md
@@ -77,3 +77,31 @@ cmd "task2" {
 Now when using completion with usage, if the user types `mycli run <tab><tab>`, usage will then
 call `mycli mount-usage-tasks` and merge the emitted usage into the `run` command and display the
 task commands as if they were statically defined in the usage spec.
+
+### Global flags and mounted commands
+
+A mounted command describes a different program, so the flags of the commands it is mounted under
+are not part of it. Once a mounted command is reached, `global` flags declared above it are no
+longer offered in completions, and a flag the mounted command declares itself takes precedence over
+a global of the same name:
+
+```kdl
+flag "-E --env <ENV>" global=#true
+cmd "run" {
+	mount run="mycli mount-usage-tasks"
+}
+```
+
+```kdl
+# emitted by the mount
+cmd "task1" {
+  flag "--env <name>" {
+    choices "dev" "stage" "prod"
+  }
+}
+```
+
+`mycli run task1 --<tab>` offers only `task1`'s own flags, and `mycli run task1 --env <tab>` offers
+`dev stage prod` rather than the global's `<ENV>` value. Global flags are still recognized *before*
+the mounted command (`mycli --env prod run task1`), where they also propagate to the mount command
+itself.

--- a/docs/spec/reference/cmd.md
+++ b/docs/spec/reference/cmd.md
@@ -102,6 +102,6 @@ cmd "task1" {
 ```
 
 `mycli run task1 --<tab>` offers only `task1`'s own flags, and `mycli run task1 --env <tab>` offers
-`dev stage prod` rather than the global's `<ENV>` value. Global flags are still recognized *before*
+`dev stage prod` rather than the global's `<ENV>` value. Global flags are still recognized _before_
 the mounted command (`mycli --env prod run task1`), where they also propagate to the mount command
 itself.

--- a/docs/spec/reference/flag.md
+++ b/docs/spec/reference/flag.md
@@ -51,3 +51,15 @@ flag "--file <file>" {
     """#
 }
 ```
+
+## `global`
+
+A `global` flag is recognized by the command that declares it and by everything below it, so
+`mycli --verbose run task` and `mycli run task --verbose` both work. It is also passed to any
+[`mount`](/spec/reference/cmd#mounting-dynamic-commands) reached after it, so the mount command
+can take it into account, and it is not offered inside a mounted command — see
+[Global flags and mounted commands](/spec/reference/cmd#global-flags-and-mounted-commands).
+
+A non-global flag belongs to the command that declares it, but may still appear before one of
+that command's subcommands (`mycli run --force task`): it is parsed there, just not inherited
+and not passed to mounts.

--- a/examples/mounted-global-flag-leak.sh
+++ b/examples/mounted-global-flag-leak.sh
@@ -45,6 +45,12 @@ cmd "mytask" {
     choices "alpha" "beta"
   }
 }
+cmd "grouped" help="A mounted task with subcommands of its own" {
+  flag "--group-wide" help="Applies to the whole group" global=#true
+  cmd "leaf" help="Nested inside the mounted command" {
+    flag "--leaf-only" help="Only on the leaf"
+  }
+}
 EOF
 	exit
 fi

--- a/examples/mounted-global-flag-leak.sh
+++ b/examples/mounted-global-flag-leak.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env -S usage bash
+#
+# Test fixture for jdx/mise#11282: the flags of the mounting CLI must not leak into a
+# mounted command's completions.
+#
+# The root declares globals (`-E/--env <ENV>`, `--silent`) which are only accepted *before*
+# the mounted command — everything after a task name is forwarded to the task itself. Two
+# defects followed from inheriting those globals into the mounted command:
+#
+#   1. `run task <TAB>` offered `--env`/`--silent`, which the mounted program rejects.
+#   2. The mounted task's own `--env` (with choices) was shadowed by the root's `--env`,
+#      so completing its value fell back to file completion instead of the choices.
+#
+# Example usage:
+#   mounted-global-flag-leak.sh run mytask --<TAB>        # -> --bump --env --output-dir
+#   mounted-global-flag-leak.sh run mytask --env <TAB>    # -> dev stage prod
+#   mounted-global-flag-leak.sh -E prod run mytask <TAB>  # global before the task still parses
+#
+#USAGE bin "ex"
+#USAGE flag "-E --env <ENV>" help="Set the environment" global=#true
+#USAGE flag "--silent" help="Silent output" global=#true
+#USAGE flag "--mount" help="Display kdl spec for mounted tasks"
+#USAGE cmd "run" {
+#USAGE   flag "-f --force" help="Force the tasks to run"
+#USAGE   mount run="mounted-global-flag-leak.sh --mount"
+#USAGE }
+set -eo pipefail
+
+# Declare variables set by usage to avoid SC2154
+: "${usage_mount:=}"
+: "${usage_env:=}"
+
+if [ "${usage_mount:-}" = "true" ]; then
+	# `mytask` declares its own `--env`, colliding with the root global of the same name.
+	cat <<EOF
+cmd "mytask" {
+  flag "--env <name>" help="Environment to deploy to" {
+    choices "dev" "stage" "prod"
+  }
+  flag "--bump <type>" help="Version bump" {
+    choices "auto" "major" "minor" "patch"
+  }
+  flag "--output-dir <path>" help="Where to write output"
+  arg "[target]" {
+    choices "alpha" "beta"
+  }
+}
+EOF
+	exit
+fi
+
+echo "Running with env: ${usage_env:-default}"

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -28,40 +28,27 @@ use crate::{Spec, SpecArg, SpecChoices, SpecCommand, SpecFlag};
 /// Descending into a *mounted* subcommand (`crossing_mount`) is different: the mounted
 /// command describes another program, which does not accept the mounting CLI's globals.
 /// Those globals stay recognized (they may appear before the mounted command, and Phase 2
-/// re-parses them), but they are recorded in `inherited_only` so completions do not offer
-/// them, and the mounted command's own flags take precedence over them.
+/// re-parses them), but the mounted command's own flags take precedence over them, so its
+/// choices/completions are not replaced by a global's. Which flags a completion may offer
+/// there is a separate question, answered by [`ParseOutput::completion_flags`].
 fn merge_subcommand_flags(
     available: &mut BTreeMap<String, Arc<SpecFlag>>,
     new_flags: BTreeMap<String, Arc<SpecFlag>>,
-    inherited_only: &mut BTreeSet<String>,
     prefix_flag_keys: &BTreeSet<String>,
     crossing_mount: bool,
 ) {
     // Keep only inherited global flags from the parent.
-    available.retain(|key, f| {
-        if f.global {
-            true
-        } else {
-            inherited_only.remove(key);
-            false
-        }
-    });
+    available.retain(|_, f| f.global);
 
     if crossing_mount {
-        // Everything still available belongs to a command above the mount boundary.
-        inherited_only.extend(available.keys().cloned());
-        // A mounted command owns its flags outright: an inherited global with the same name
-        // is the mounting CLI's flag and must not shadow it (that would swap the mounted
-        // flag's choices/completions for the global's). Aliases the mounted command does not
-        // declare (e.g. a global's short) stay inherited so prefix tokens keep parsing.
+        // A mounted command owns its flags outright. Aliases it does not declare (e.g. a
+        // global's short) stay inherited so prefix tokens keep parsing.
         for (key, flag) in new_flags {
             // Exception: a token already consumed as an inherited global before the mounted
             // command (`mycli --env prod run task`) is still sitting in the input for Phase 2
-            // to re-parse, so that key has to keep resolving to the global. The name is
-            // offered either way, since the mounted command declares the same one.
+            // to re-parse, so that key has to keep resolving to the global.
             let shadows_consumed_global =
                 prefix_flag_keys.contains(&key) && available.get(&key).is_some_and(|f| f.global);
-            inherited_only.remove(&key);
             if !shadows_consumed_global {
                 available.insert(key, flag);
             }
@@ -80,7 +67,6 @@ fn merge_subcommand_flags(
     for (key, flag) in new_flags {
         if flag.global {
             // A child that re-declares (or adds) a global flag stays recognized everywhere.
-            inherited_only.remove(&key);
             available.insert(key, flag);
             continue;
         }
@@ -127,9 +113,6 @@ fn merge_subcommand_flags(
                     Arc::new(merged)
                 })
                 .clone();
-            // The child declares this flag, so it is offered again even if it was previously
-            // inherited-only (e.g. a subcommand of a mounted command re-declaring it).
-            inherited_only.remove(&key);
             available.insert(key, merged);
             continue;
         }
@@ -140,7 +123,6 @@ fn merge_subcommand_flags(
         if available.contains_key(&key) {
             continue;
         }
-        inherited_only.remove(&key);
         available.insert(key, flag);
     }
 }
@@ -195,9 +177,6 @@ pub struct ParseOutput {
     /// mounted command — see [`ParseOutput::completion_flags`] for the set a completion
     /// should offer.
     pub available_flags: BTreeMap<String, Arc<SpecFlag>>,
-    /// Keys of [`ParseOutput::available_flags`] that belong to a command above a mount
-    /// boundary, i.e. to the mounting CLI rather than to the mounted program.
-    pub inherited_flag_keys: BTreeSet<String>,
     pub flag_awaiting_value: Vec<Arc<SpecFlag>>,
     pub errors: Vec<UsageErr>,
 }
@@ -205,19 +184,30 @@ pub struct ParseOutput {
 impl ParseOutput {
     /// The flags a completion should offer for the parsed command.
     ///
-    /// Same as [`ParseOutput::available_flags`], minus the flags of commands above a mount
-    /// boundary: a mounted command describes another program, and the mounting CLI's flags
-    /// are not accepted after it (mise, for example, forwards everything after a task name
-    /// to the task itself). Without a mount in play the two are identical.
+    /// Usually every recognized flag, i.e. [`ParseOutput::available_flags`]. Once a mounted
+    /// command has been reached, though, the commands above it belong to the mounting CLI and
+    /// their flags are not accepted there — mise, for example, forwards everything after a task
+    /// name to the task itself — so only the flags declared from the mount boundary down are
+    /// offered. Those globals stay in `available_flags` because they may legitimately appear
+    /// *before* the mounted command.
     pub fn completion_flags(&self) -> BTreeMap<String, Arc<SpecFlag>> {
-        if self.inherited_flag_keys.is_empty() {
+        let Some(boundary) = self.cmds.iter().position(|cmd| cmd.mounted) else {
             return self.available_flags.clone();
+        };
+        // Re-run the descent from the mount boundary, which starts with no inherited flags.
+        let mut offered: BTreeMap<String, Arc<SpecFlag>> = BTreeMap::new();
+        for cmd in &self.cmds[boundary..] {
+            // Each descent drops the previous command's non-global flags, as in
+            // `merge_subcommand_flags`.
+            offered.retain(|_, f| f.global);
+            for flag in &cmd.flags {
+                let flag = Arc::new(flag.clone());
+                for key in flag_keys(&flag) {
+                    offered.insert(key, Arc::clone(&flag));
+                }
+            }
         }
-        self.available_flags
-            .iter()
-            .filter(|(key, _)| !self.inherited_flag_keys.contains(*key))
-            .map(|(key, flag)| (key.clone(), Arc::clone(flag)))
-            .collect()
+        offered
     }
 }
 
@@ -488,7 +478,6 @@ fn parse_partial_with_env(
         args: IndexMap::new(),
         flags: IndexMap::new(),
         available_flags: gather_flags(&spec.cmd),
-        inherited_flag_keys: BTreeSet::new(),
         flag_awaiting_value: vec![],
         errors: vec![],
     };
@@ -523,7 +512,6 @@ fn parse_partial_with_env(
             merge_subcommand_flags(
                 &mut out.available_flags,
                 gather_flags(&subcommand),
-                &mut out.inherited_flag_keys,
                 &prefix_flag_keys,
                 subcommand.mounted,
             );
@@ -586,7 +574,6 @@ fn parse_partial_with_env(
                         merge_subcommand_flags(
                             &mut out.available_flags,
                             gather_flags(&subcommand),
-                            &mut out.inherited_flag_keys,
                             &prefix_flag_keys,
                             subcommand.mounted,
                         );
@@ -2163,15 +2150,11 @@ mod tests {
         // Still recognized for parsing...
         assert!(parsed.available_flags.contains_key("--silent"));
         assert!(parsed.available_flags.contains_key("-E"));
-        // ...but marked as belonging to a command above the mount, so not offered.
+        // ...but belonging to a command above the mount, so not offered.
         assert_eq!(
             parsed.completion_flags().keys().collect::<Vec<_>>(),
             vec!["--bump", "--env"],
             "only the mounted command's own flags may be offered",
-        );
-        assert_eq!(
-            parsed.inherited_flag_keys.iter().collect::<Vec<_>>(),
-            vec!["--silent", "-E"],
         );
 
         // `run`'s own non-global flag is dropped on descent, as it always was.
@@ -2275,7 +2258,6 @@ mod tests {
         };
 
         let parsed = parse_partial(&spec, &input(&["test", "run", "nested"])).unwrap();
-        assert!(parsed.inherited_flag_keys.is_empty());
         assert_eq!(
             parsed.completion_flags().keys().collect::<Vec<_>>(),
             parsed.available_flags.keys().collect::<Vec<_>>(),

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -3,7 +3,7 @@ use indexmap::IndexMap;
 use itertools::Itertools;
 use log::trace;
 use miette::bail;
-use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::fmt::{Debug, Display, Formatter};
 use std::sync::Arc;
 use strum::EnumTryAs;
@@ -24,12 +24,50 @@ use crate::{Spec, SpecArg, SpecChoices, SpecCommand, SpecFlag};
 /// the inherited global flag, otherwise the next descent's `retain(global)` would drop it
 /// entirely and later parsing would treat the already-consumed global token as an
 /// unexpected positional/flag value.
+///
+/// Descending into a *mounted* subcommand (`crossing_mount`) is different: the mounted
+/// command describes another program, which does not accept the mounting CLI's globals.
+/// Those globals stay recognized (they may appear before the mounted command, and Phase 2
+/// re-parses them), but they are recorded in `inherited_only` so completions do not offer
+/// them, and the mounted command's own flags take precedence over them.
 fn merge_subcommand_flags(
     available: &mut BTreeMap<String, Arc<SpecFlag>>,
     new_flags: BTreeMap<String, Arc<SpecFlag>>,
+    inherited_only: &mut BTreeSet<String>,
+    prefix_flag_keys: &BTreeSet<String>,
+    crossing_mount: bool,
 ) {
     // Keep only inherited global flags from the parent.
-    available.retain(|_, f| f.global);
+    available.retain(|key, f| {
+        if f.global {
+            true
+        } else {
+            inherited_only.remove(key);
+            false
+        }
+    });
+
+    if crossing_mount {
+        // Everything still available belongs to a command above the mount boundary.
+        inherited_only.extend(available.keys().cloned());
+        // A mounted command owns its flags outright: an inherited global with the same name
+        // is the mounting CLI's flag and must not shadow it (that would swap the mounted
+        // flag's choices/completions for the global's). Aliases the mounted command does not
+        // declare (e.g. a global's short) stay inherited so prefix tokens keep parsing.
+        for (key, flag) in new_flags {
+            // Exception: a token already consumed as an inherited global before the mounted
+            // command (`mycli --env prod run task`) is still sitting in the input for Phase 2
+            // to re-parse, so that key has to keep resolving to the global. The name is
+            // offered either way, since the mounted command declares the same one.
+            let shadows_consumed_global =
+                prefix_flag_keys.contains(&key) && available.get(&key).is_some_and(|f| f.global);
+            inherited_only.remove(&key);
+            if !shadows_consumed_global {
+                available.insert(key, flag);
+            }
+        }
+        return;
+    }
 
     // Cache the merged (global ∪ orphan-alias) flag per re-declared child so every alias key of
     // that flag ends up sharing one `Arc`. Keyed by the child `Arc`'s identity.
@@ -42,6 +80,7 @@ fn merge_subcommand_flags(
     for (key, flag) in new_flags {
         if flag.global {
             // A child that re-declares (or adds) a global flag stays recognized everywhere.
+            inherited_only.remove(&key);
             available.insert(key, flag);
             continue;
         }
@@ -88,6 +127,9 @@ fn merge_subcommand_flags(
                     Arc::new(merged)
                 })
                 .clone();
+            // The child declares this flag, so it is offered again even if it was previously
+            // inherited-only (e.g. a subcommand of a mounted command re-declaring it).
+            inherited_only.remove(&key);
             available.insert(key, merged);
             continue;
         }
@@ -98,6 +140,7 @@ fn merge_subcommand_flags(
         if available.contains_key(&key) {
             continue;
         }
+        inherited_only.remove(&key);
         available.insert(key, flag);
     }
 }
@@ -145,9 +188,37 @@ pub struct ParseOutput {
     pub cmds: Vec<SpecCommand>,
     pub args: IndexMap<Arc<SpecArg>, ParseValue>,
     pub flags: IndexMap<Arc<SpecFlag>, ParseValue>,
+    /// Every flag the parser recognizes at this point, keyed by each of its aliases
+    /// (`--long`, `-s`, negations).
+    ///
+    /// This includes flags that only remain recognized because they may appear *before* a
+    /// mounted command — see [`ParseOutput::completion_flags`] for the set a completion
+    /// should offer.
     pub available_flags: BTreeMap<String, Arc<SpecFlag>>,
+    /// Keys of [`ParseOutput::available_flags`] that belong to a command above a mount
+    /// boundary, i.e. to the mounting CLI rather than to the mounted program.
+    pub inherited_flag_keys: BTreeSet<String>,
     pub flag_awaiting_value: Vec<Arc<SpecFlag>>,
     pub errors: Vec<UsageErr>,
+}
+
+impl ParseOutput {
+    /// The flags a completion should offer for the parsed command.
+    ///
+    /// Same as [`ParseOutput::available_flags`], minus the flags of commands above a mount
+    /// boundary: a mounted command describes another program, and the mounting CLI's flags
+    /// are not accepted after it (mise, for example, forwards everything after a task name
+    /// to the task itself). Without a mount in play the two are identical.
+    pub fn completion_flags(&self) -> BTreeMap<String, Arc<SpecFlag>> {
+        if self.inherited_flag_keys.is_empty() {
+            return self.available_flags.clone();
+        }
+        self.available_flags
+            .iter()
+            .filter(|(key, _)| !self.inherited_flag_keys.contains(*key))
+            .map(|(key, flag)| (key.clone(), Arc::clone(flag)))
+            .collect()
+    }
 }
 
 #[derive(Debug, EnumTryAs, Clone)]
@@ -417,6 +488,7 @@ fn parse_partial_with_env(
         args: IndexMap::new(),
         flags: IndexMap::new(),
         available_flags: gather_flags(&spec.cmd),
+        inherited_flag_keys: BTreeSet::new(),
         flag_awaiting_value: vec![],
         errors: vec![],
     };
@@ -434,6 +506,10 @@ fn parse_partial_with_env(
     // - Non-global flags are specific to the current command, not subcommands
     // - Global flags affect all commands and should be passed to mount points
     let mut prefix_words: Vec<String> = vec![];
+    // Flag keys consumed here, i.e. seen before a subcommand. Unlike `prefix_words` these are
+    // kept for the whole scan: the tokens stay in `input` for Phase 2, so a mounted command
+    // must not take over one of these keys (see `merge_subcommand_flags`).
+    let mut prefix_flag_keys: BTreeSet<String> = BTreeSet::new();
     let mut idx = 0;
     // Track whether we've already applied the default_subcommand to prevent
     // multiple switches (e.g., if default is "run" and there's a task named "run")
@@ -444,7 +520,13 @@ fn parse_partial_with_env(
             let mut subcommand = subcommand.clone();
             // Pass prefix words (global flags before this subcommand) to mount
             subcommand.mount(&prefix_words)?;
-            merge_subcommand_flags(&mut out.available_flags, gather_flags(&subcommand));
+            merge_subcommand_flags(
+                &mut out.available_flags,
+                gather_flags(&subcommand),
+                &mut out.inherited_flag_keys,
+                &prefix_flag_keys,
+                subcommand.mounted,
+            );
             // Remove subcommand from input
             input.remove(idx);
             out.cmds.push(subcommand.clone());
@@ -467,6 +549,7 @@ fn parse_partial_with_env(
                 // `available_flags` (see `merge_subcommand_flags`): Phase 2 consumes it as a
                 // flag instead of mistaking it for a positional argument.
                 if f.global {
+                    prefix_flag_keys.insert(flag_key.to_string());
                     prefix_words.push(input[idx].clone());
                     idx += 1;
 
@@ -500,7 +583,13 @@ fn parse_partial_with_env(
                         let mut subcommand = subcommand.clone();
                         // Pass prefix words (global flags before this) to mount
                         subcommand.mount(&prefix_words)?;
-                        merge_subcommand_flags(&mut out.available_flags, gather_flags(&subcommand));
+                        merge_subcommand_flags(
+                            &mut out.available_flags,
+                            gather_flags(&subcommand),
+                            &mut out.inherited_flag_keys,
+                            &prefix_flag_keys,
+                            subcommand.mounted,
+                        );
                         out.cmds.push(subcommand.clone());
                         out.cmd = subcommand.clone();
                         prefix_words.clear();
@@ -1980,6 +2069,218 @@ mod tests {
             .available_flags
             .get("--restrict")
             .is_some_and(|f| f.global));
+    }
+
+    /// Build a spec shaped like mise's post-mount structure for jdx/mise#11282: a root with
+    /// globals (`-E/--env <ENV>`, `--silent`), a `run` subcommand with a non-global flag, and a
+    /// MOUNTED task command that declares its own `--env` (with choices) plus `--bump`.
+    ///
+    /// The task command is marked `mounted` the same way `SpecCommand::mount()` marks the
+    /// commands it merges in, so the test stays hermetic (no mount subprocess).
+    fn mounted_task_flag_spec() -> Spec {
+        let mut task_cmd = SpecCommand::builder()
+            .name("mytask")
+            .flag(
+                SpecFlag::builder()
+                    .name("env")
+                    .long("env")
+                    .arg(
+                        SpecArg::builder()
+                            .name("name")
+                            .choices(["dev", "stage", "prod"])
+                            .build(),
+                    )
+                    .global(false)
+                    .build(),
+            )
+            .flag(
+                SpecFlag::builder()
+                    .name("bump")
+                    .long("bump")
+                    .arg(
+                        SpecArg::builder()
+                            .name("type")
+                            .choices(["auto", "major"])
+                            .build(),
+                    )
+                    .global(false)
+                    .build(),
+            )
+            .build();
+        task_cmd.mounted = true;
+
+        let mut run_cmd = SpecCommand::builder()
+            .name("run")
+            .flag(
+                SpecFlag::builder()
+                    .name("force")
+                    .short('f')
+                    .long("force")
+                    .global(false)
+                    .build(),
+            )
+            .build();
+        run_cmd.subcommands.insert("mytask".to_string(), task_cmd);
+
+        let mut cmd = SpecCommand::builder()
+            .name("test")
+            .flag(
+                SpecFlag::builder()
+                    .name("env")
+                    .short('E')
+                    .long("env")
+                    .arg(SpecArg::builder().name("ENV").build())
+                    .global(true)
+                    .build(),
+            )
+            .flag(
+                SpecFlag::builder()
+                    .name("silent")
+                    .long("silent")
+                    .global(true)
+                    .build(),
+            )
+            .build();
+        cmd.subcommands.insert("run".to_string(), run_cmd);
+
+        Spec {
+            name: "test".to_string(),
+            bin: "test".to_string(),
+            cmd,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_mounted_cmd_does_not_offer_mounting_cli_globals() {
+        // Regression for jdx/mise#11282. A mounted command describes another program, which
+        // does not accept the mounting CLI's globals (mise forwards everything after a task
+        // name to the task). They must stay recognized — they may appear before the mounted
+        // command — but must not be offered in completions there.
+        let spec = mounted_task_flag_spec();
+        let parsed = parse_partial(&spec, &input(&["test", "run", "mytask"])).unwrap();
+
+        // Still recognized for parsing...
+        assert!(parsed.available_flags.contains_key("--silent"));
+        assert!(parsed.available_flags.contains_key("-E"));
+        // ...but marked as belonging to a command above the mount, so not offered.
+        assert_eq!(
+            parsed.completion_flags().keys().collect::<Vec<_>>(),
+            vec!["--bump", "--env"],
+            "only the mounted command's own flags may be offered",
+        );
+        assert_eq!(
+            parsed.inherited_flag_keys.iter().collect::<Vec<_>>(),
+            vec!["--silent", "-E"],
+        );
+
+        // `run`'s own non-global flag is dropped on descent, as it always was.
+        assert!(!parsed.available_flags.contains_key("--force"));
+    }
+
+    #[test]
+    fn test_mounted_cmd_flag_wins_over_inherited_global() {
+        // Second half of jdx/mise#11282: the mounted `--env` (with choices) used to be shadowed
+        // by the root's `--env` global, so completing its value fell back to file completion.
+        let spec = mounted_task_flag_spec();
+        let parsed = parse_partial(&spec, &input(&["test", "run", "mytask", "--env"])).unwrap();
+
+        let awaiting = parsed
+            .flag_awaiting_value
+            .first()
+            .expect("--env should await a value");
+        assert_eq!(
+            awaiting
+                .arg
+                .as_ref()
+                .and_then(|a| a.choices.as_ref())
+                .map(|c| c.choices.clone()),
+            Some(vec![
+                "dev".to_string(),
+                "stage".to_string(),
+                "prod".to_string()
+            ]),
+            "the mounted command's own --env must win over the inherited global",
+        );
+
+        // The global's short is not declared by the mounted command, so it keeps pointing at
+        // the global and a value passed before the mounted command still parses.
+        let parsed =
+            parse_partial(&spec, &input(&["test", "-E", "anything", "run", "mytask"])).unwrap();
+        assert!(
+            parsed.args.is_empty(),
+            "prefix global tokens must not be consumed as positionals, got {:?}",
+            parsed.args
+        );
+        assert_eq!(
+            parsed.as_env().get("usage_env").map(String::as_str),
+            Some("anything"),
+        );
+    }
+
+    #[test]
+    fn test_mounted_cmd_does_not_take_over_consumed_prefix_flag() {
+        // A global consumed *before* the mounted command is left in the input for Phase 2, so
+        // that key has to keep resolving to the global even though the mounted command declares
+        // the same long name — otherwise the value would be validated against the mounted
+        // flag's choices and a legitimate global value would be rejected.
+        let spec = mounted_task_flag_spec();
+        let parsed = parse_partial(
+            &spec,
+            &input(&["test", "--env", "not-a-task-choice", "run", "mytask"]),
+        )
+        .unwrap();
+        assert!(
+            parsed.errors.is_empty(),
+            "prefix global value must not be validated against the mounted flag: {:?}",
+            parsed
+                .errors
+                .iter()
+                .map(|e| e.to_string())
+                .collect::<Vec<_>>(),
+        );
+        assert_eq!(
+            parsed.as_env().get("usage_env").map(String::as_str),
+            Some("not-a-task-choice"),
+        );
+        // The name is still offered, since the mounted command declares it too.
+        assert!(parsed.completion_flags().contains_key("--env"));
+    }
+
+    #[test]
+    fn test_non_mounted_subcommand_offers_inherited_globals() {
+        // Nothing changes for ordinary (non-mounted) subcommands: a global declared above is
+        // still both recognized and offered.
+        let mut run_cmd = SpecCommand::builder().name("run").build();
+        run_cmd.subcommands.insert(
+            "nested".to_string(),
+            SpecCommand::builder().name("nested").build(),
+        );
+        let mut cmd = SpecCommand::builder()
+            .name("test")
+            .flag(
+                SpecFlag::builder()
+                    .name("silent")
+                    .long("silent")
+                    .global(true)
+                    .build(),
+            )
+            .build();
+        cmd.subcommands.insert("run".to_string(), run_cmd);
+        let spec = Spec {
+            name: "test".to_string(),
+            bin: "test".to_string(),
+            cmd,
+            ..Default::default()
+        };
+
+        let parsed = parse_partial(&spec, &input(&["test", "run", "nested"])).unwrap();
+        assert!(parsed.inherited_flag_keys.is_empty());
+        assert_eq!(
+            parsed.completion_flags().keys().collect::<Vec<_>>(),
+            parsed.available_flags.keys().collect::<Vec<_>>(),
+        );
+        assert!(parsed.completion_flags().contains_key("--silent"));
     }
 
     #[test]

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -136,6 +136,20 @@ fn flag_keys(flag: &SpecFlag) -> Vec<String> {
     keys
 }
 
+/// The flags a command declares, keyed by each of their aliases.
+fn gather_flags(cmd: &SpecCommand) -> BTreeMap<String, Arc<SpecFlag>> {
+    cmd.flags
+        .iter()
+        .flat_map(|f| {
+            let f = Arc::new(f.clone()); // One clone per flag, then cheap Arc refs
+            flag_keys(&f)
+                .into_iter()
+                .map(|key| (key, Arc::clone(&f)))
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
 fn unique_flags<'a>(
     flags: impl IntoIterator<Item = &'a Arc<SpecFlag>>,
 ) -> impl Iterator<Item = &'a Arc<SpecFlag>> {
@@ -188,18 +202,19 @@ impl ParseOutput {
         let Some(boundary) = self.cmds.iter().position(|cmd| cmd.mounted) else {
             return self.available_flags.clone();
         };
-        // Re-run the descent from the mount boundary, which starts with no inherited flags.
-        let mut offered: BTreeMap<String, Arc<SpecFlag>> = BTreeMap::new();
-        for cmd in &self.cmds[boundary..] {
-            // Each descent drops the previous command's non-global flags, as in
-            // `merge_subcommand_flags`.
-            offered.retain(|_, f| f.global);
-            for flag in &cmd.flags {
-                let flag = Arc::new(flag.clone());
-                for key in flag_keys(&flag) {
-                    offered.insert(key, Arc::clone(&flag));
-                }
-            }
+        // A mount can also merge flags from its spec's root into the command it is mounted on
+        // (`SpecCommand::flags_from_mount`). Those describe the mounted program too, so the
+        // replay starts one level up to inherit its globals.
+        let start = match boundary.checked_sub(1) {
+            Some(prev) if self.cmds[prev].flags_from_mount => prev,
+            _ => boundary,
+        };
+        // Re-run the descent from there, which starts with no inherited flags. Below the
+        // boundary the mounted program's commands are ordinary commands, so the descents use
+        // the same merge as the real parse.
+        let mut offered = gather_flags(&self.cmds[start]);
+        for cmd in &self.cmds[start + 1..] {
+            merge_subcommand_flags(&mut offered, gather_flags(cmd), false);
         }
         offered
     }
@@ -453,19 +468,6 @@ fn parse_partial_with_env(
     let mut input = input.iter().cloned().collect::<VecDeque<_>>();
     input.pop_front();
 
-    let gather_flags = |cmd: &SpecCommand| {
-        cmd.flags
-            .iter()
-            .flat_map(|f| {
-                let f = Arc::new(f.clone()); // One clone per flag, then cheap Arc refs
-                flag_keys(&f)
-                    .into_iter()
-                    .map(|key| (key, Arc::clone(&f)))
-                    .collect::<Vec<_>>()
-            })
-            .collect()
-    };
-
     let mut out = ParseOutput {
         cmd: spec.cmd.clone(),
         cmds: vec![spec.cmd.clone()],
@@ -507,10 +509,13 @@ fn parse_partial_with_env(
             let mut subcommand = subcommand.clone();
             // Pass prefix words (global flags before this subcommand) to mount
             subcommand.mount(&prefix_words)?;
+            // Only the *boundary* is a mount crossing: below it, the mounted program's own
+            // commands are ordinary commands relative to each other.
+            let crossing_mount = subcommand.mounted && !out.cmd.mounted;
             merge_subcommand_flags(
                 &mut out.available_flags,
                 gather_flags(&subcommand),
-                subcommand.mounted,
+                crossing_mount,
             );
             // Remove subcommand from input
             input.remove(idx);
@@ -565,10 +570,11 @@ fn parse_partial_with_env(
                         let mut subcommand = subcommand.clone();
                         // Pass prefix words (global flags before this) to mount
                         subcommand.mount(&prefix_words)?;
+                        let crossing_mount = subcommand.mounted && !out.cmd.mounted;
                         merge_subcommand_flags(
                             &mut out.available_flags,
                             gather_flags(&subcommand),
-                            subcommand.mounted,
+                            crossing_mount,
                         );
                         out.cmds.push(subcommand.clone());
                         out.cmd = subcommand.clone();
@@ -2137,6 +2143,131 @@ mod tests {
             cmd,
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn test_mount_boundary_does_not_apply_inside_the_mounted_tree() {
+        // The mounted program's own commands are ordinary commands relative to each other, so
+        // descending *within* the mounted tree must follow the normal rules — including keeping
+        // an inherited global that a nested command re-declares as non-global (jdx/usage#649).
+        // Treating every level of the tree as a mount boundary let the re-declaration shadow the
+        // global, which the next descent's `retain(global)` then dropped entirely.
+        let deep = SpecCommand::builder().name("deep").build();
+        let mut sub = SpecCommand::builder()
+            .name("sub")
+            // Re-declares the mounted program's own global as non-global.
+            .flag(
+                SpecFlag::builder()
+                    .name("cd")
+                    .short('C')
+                    .long("cd")
+                    .arg(SpecArg::builder().name("dir").build())
+                    .global(false)
+                    .build(),
+            )
+            .build();
+        sub.subcommands.insert("deep".to_string(), deep);
+        let mut task = SpecCommand::builder()
+            .name("task")
+            .flag(
+                SpecFlag::builder()
+                    .name("cd")
+                    .short('C')
+                    .long("cd")
+                    .arg(SpecArg::builder().name("dir").build())
+                    .global(true)
+                    .build(),
+            )
+            .build();
+        task.subcommands.insert("sub".to_string(), sub);
+        task.mark_mounted();
+
+        let mut run_cmd = SpecCommand::builder().name("run").build();
+        run_cmd.subcommands.insert("task".to_string(), task);
+        let mut cmd = SpecCommand::builder().name("test").build();
+        cmd.subcommands.insert("run".to_string(), run_cmd);
+        let spec = Spec {
+            name: "test".to_string(),
+            bin: "test".to_string(),
+            cmd,
+            ..Default::default()
+        };
+
+        let parsed = parse_partial(&spec, &input(&["test", "run", "task", "sub", "deep"])).unwrap();
+        assert!(
+            parsed.available_flags.get("--cd").is_some_and(|f| f.global),
+            "the mounted program's own global must survive descents inside the mounted tree",
+        );
+        assert!(
+            parsed.completion_flags().contains_key("--cd"),
+            "and must still be offered there: it belongs to the mounted program",
+        );
+        assert!(
+            parsed.completion_flags().contains_key("-C"),
+            "including the short the nested command re-declared",
+        );
+    }
+
+    #[test]
+    fn test_mount_flags_merged_into_the_mounting_cmd_are_offered() {
+        // A mounted spec may declare flags on its own root, which `SpecCommand::merge` folds
+        // into the command the mount sits on. They belong to the mounted program, so they must
+        // be offered inside the mounted commands rather than filtered out with the mounting
+        // CLI's own flags.
+        let mut task = SpecCommand::builder()
+            .name("task")
+            .flag(
+                SpecFlag::builder()
+                    .name("bump")
+                    .long("bump")
+                    .global(false)
+                    .build(),
+            )
+            .build();
+        task.mark_mounted();
+
+        let mut run_cmd = SpecCommand::builder().name("run").build();
+        run_cmd.subcommands.insert("task".to_string(), task);
+        // What `mount()` leaves behind when the mounted spec's root declares flags.
+        run_cmd.flags = vec![
+            SpecFlag::builder()
+                .name("tglobal")
+                .long("tglobal")
+                .global(true)
+                .build(),
+            SpecFlag::builder()
+                .name("tlocal")
+                .long("tlocal")
+                .global(false)
+                .build(),
+        ];
+        run_cmd.flags_from_mount = true;
+
+        let mut cmd = SpecCommand::builder()
+            .name("test")
+            .flag(
+                SpecFlag::builder()
+                    .name("silent")
+                    .long("silent")
+                    .global(true)
+                    .build(),
+            )
+            .build();
+        cmd.subcommands.insert("run".to_string(), run_cmd);
+        let spec = Spec {
+            name: "test".to_string(),
+            bin: "test".to_string(),
+            cmd,
+            ..Default::default()
+        };
+
+        let parsed = parse_partial(&spec, &input(&["test", "run", "task"])).unwrap();
+        assert_eq!(
+            parsed.completion_flags().keys().collect::<Vec<_>>(),
+            vec!["--bump", "--tglobal"],
+            "the mounted spec's root global belongs to the mounted program; the mounting CLI's \
+             `--silent` does not, and the mount's non-global root flag is not inherited",
+        );
     }
 
     #[test]

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -3,7 +3,7 @@ use indexmap::IndexMap;
 use itertools::Itertools;
 use log::trace;
 use miette::bail;
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::fmt::{Debug, Display, Formatter};
 use std::sync::Arc;
 use strum::EnumTryAs;
@@ -34,24 +34,18 @@ use crate::{Spec, SpecArg, SpecChoices, SpecCommand, SpecFlag};
 fn merge_subcommand_flags(
     available: &mut BTreeMap<String, Arc<SpecFlag>>,
     new_flags: BTreeMap<String, Arc<SpecFlag>>,
-    prefix_flag_keys: &BTreeSet<String>,
     crossing_mount: bool,
 ) {
     // Keep only inherited global flags from the parent.
     available.retain(|_, f| f.global);
 
     if crossing_mount {
-        // A mounted command owns its flags outright. Aliases it does not declare (e.g. a
-        // global's short) stay inherited so prefix tokens keep parsing.
+        // A mounted command owns its flags outright, including names an inherited global also
+        // uses: a word after the mounted command belongs to the mounted program. Words before
+        // it keep resolving to the global they were read as, via `prefix_bindings`. Aliases the
+        // mounted command does not declare (e.g. a global's short) stay inherited.
         for (key, flag) in new_flags {
-            // Exception: a token already consumed as an inherited global before the mounted
-            // command (`mycli --env prod run task`) is still sitting in the input for Phase 2
-            // to re-parse, so that key has to keep resolving to the global.
-            let shadows_consumed_global =
-                prefix_flag_keys.contains(&key) && available.get(&key).is_some_and(|f| f.global);
-            if !shadows_consumed_global {
-                available.insert(key, flag);
-            }
+            available.insert(key, flag);
         }
         return;
     }
@@ -491,14 +485,18 @@ fn parse_partial_with_env(
     //   -> finds "run" subcommand, passes ["--verbose"] to its mount command
     //   -> then finds "task" as a subcommand of "run" (if it exists)
     //
-    // We only collect global flags because:
+    // We only collect global flags for mounts because:
     // - Non-global flags are specific to the current command, not subcommands
     // - Global flags affect all commands and should be passed to mount points
     let mut prefix_words: Vec<String> = vec![];
-    // Flag keys consumed here, i.e. seen before a subcommand. Unlike `prefix_words` these are
-    // kept for the whole scan: the tokens stay in `input` for Phase 2, so a mounted command
-    // must not take over one of these keys (see `merge_subcommand_flags`).
-    let mut prefix_flag_keys: BTreeSet<String> = BTreeSet::new();
+    // Which flag each word skipped here belongs to, aligned with the leading words left in
+    // `input`: `Some(flag)` for a flag word, `None` for its value (or anything unresolved).
+    //
+    // The words stay in `input` for Phase 2 to re-parse — that is how they reach `out.flags`
+    // and `as_env()` — but by then the recognized flags have changed, because each descent
+    // drops the parent's non-global flags and a mounted command may declare the same name as
+    // a global seen here. Recording the owner keeps a word bound to the flag it was read as.
+    let mut prefix_bindings: VecDeque<Option<Arc<SpecFlag>>> = VecDeque::new();
     let mut idx = 0;
     // Track whether we've already applied the default_subcommand to prevent
     // multiple switches (e.g., if default is "run" and there's a task named "run")
@@ -512,7 +510,6 @@ fn parse_partial_with_env(
             merge_subcommand_flags(
                 &mut out.available_flags,
                 gather_flags(&subcommand),
-                &prefix_flag_keys,
                 subcommand.mounted,
             );
             // Remove subcommand from input
@@ -523,39 +520,36 @@ fn parse_partial_with_env(
             // Continue from current position (don't reset to 0)
             // After remove(), idx now points to the next element
         } else if input[idx].starts_with('-') {
-            // Check if this is a known flag and if it's global
-            let word = &input[idx];
-            let flag_key = get_flag_key(word);
+            // Check if this is a known flag
+            let word = input[idx].clone();
+            let flag_key = get_flag_key(&word);
 
-            if let Some(f) = out.available_flags.get(flag_key) {
-                // Only collect global flags for mount execution.
+            if let Some(f) = out.available_flags.get(flag_key).cloned() {
+                // Skip the flag and keep scanning. Both global and non-global flags may precede
+                // a subcommand (`mycli --verbose run task`, `mycli run --force task`), and
+                // stopping at one would hide the subcommand — and any mount on it — from the
+                // parse, leaving the subcommand name to be mis-read as a positional argument.
                 //
-                // We deliberately leave the global flag (and its value) in `input` so that
-                // Phase 2 re-parses it and records it in `out.flags`. That is how global flags
-                // reach `as_env()` for normal execution and for the env passed to mount scripts.
-                // Re-parsing is harmless as long as the flag stays recognized in
-                // `available_flags` (see `merge_subcommand_flags`): Phase 2 consumes it as a
-                // flag instead of mistaking it for a positional argument.
+                // Only globals are forwarded to mounts: a non-global flag belongs to the
+                // command that declared it, not to what is mounted below it.
+                prefix_bindings.push_back(Some(Arc::clone(&f)));
                 if f.global {
-                    prefix_flag_keys.insert(flag_key.to_string());
-                    prefix_words.push(input[idx].clone());
-                    idx += 1;
+                    prefix_words.push(word.clone());
+                }
+                idx += 1;
 
-                    // Only consume next word if flag takes an argument AND value isn't embedded
-                    // Example: "--dir foo" consumes "foo", but "--dir=foo" or "--verbose" do not
-                    if f.arg.is_some()
-                        && !word.contains('=')
-                        && idx < input.len()
-                        && !input[idx].starts_with('-')
-                    {
+                // Only consume next word if flag takes an argument AND value isn't embedded
+                // Example: "--dir foo" consumes "foo", but "--dir=foo" or "--verbose" do not
+                if f.arg.is_some()
+                    && !word.contains('=')
+                    && idx < input.len()
+                    && !input[idx].starts_with('-')
+                {
+                    if f.global {
                         prefix_words.push(input[idx].clone());
-                        idx += 1;
                     }
-                } else {
-                    // Non-global flag encountered - stop subcommand search
-                    // This prevents incorrect parsing like: "cmd --local-flag run"
-                    // where "run" might be mistaken for a subcommand
-                    break;
+                    prefix_bindings.push_back(None);
+                    idx += 1;
                 }
             } else {
                 // Unknown flag - stop looking for subcommands
@@ -574,7 +568,6 @@ fn parse_partial_with_env(
                         merge_subcommand_flags(
                             &mut out.available_flags,
                             gather_flags(&subcommand),
-                            &prefix_flag_keys,
                             subcommand.mounted,
                         );
                         out.cmds.push(subcommand.clone());
@@ -604,6 +597,9 @@ fn parse_partial_with_env(
 
     while !input.is_empty() {
         let mut w = input.pop_front().unwrap();
+        // The flag this word was read as in Phase 1, if it skipped it (see `prefix_bindings`).
+        // Words pushed back below get a `None` so the two queues stay aligned.
+        let binding = prefix_bindings.pop_front().flatten();
 
         // Check for restart_token - resets argument parsing for multiple command invocations
         // e.g., `mise run lint ::: test ::: check` with restart_token=":::"
@@ -662,12 +658,13 @@ fn parse_partial_with_env(
         if enable_flags && w.starts_with("--") {
             grouped_flag = false;
             let (word, val) = w.split_once('=').unwrap_or_else(|| (&w, ""));
-            if let Some(f) = out.available_flags.get(word) {
+            if let Some(f) = binding.as_ref().or_else(|| out.available_flags.get(word)) {
                 // Only push the embedded value back when the flag is known so that
                 // unknown --flag=value tokens fall through intact to positional arg
                 // handling without also injecting a stray "value" positional.
                 if !val.is_empty() {
                     input.push_front(val.to_string());
+                    prefix_bindings.push_front(None);
                 }
                 if f.arg.is_some() {
                     out.flag_awaiting_value.push(Arc::clone(f));
@@ -696,9 +693,13 @@ fn parse_partial_with_env(
         // short flags
         if enable_flags && w.starts_with('-') && w.len() > 1 {
             let short = w.chars().nth(1).unwrap();
-            if let Some(f) = out.available_flags.get(&format!("-{short}")) {
+            if let Some(f) = binding
+                .as_ref()
+                .or_else(|| out.available_flags.get(&format!("-{short}")))
+            {
                 if w.len() > 2 {
                     input.push_front(format!("-{}", &w[2..]));
+                    prefix_bindings.push_front(None);
                     grouped_flag = true;
                 }
                 if f.arg.is_some() {
@@ -2202,11 +2203,11 @@ mod tests {
     }
 
     #[test]
-    fn test_mounted_cmd_does_not_take_over_consumed_prefix_flag() {
-        // A global consumed *before* the mounted command is left in the input for Phase 2, so
-        // that key has to keep resolving to the global even though the mounted command declares
-        // the same long name — otherwise the value would be validated against the mounted
-        // flag's choices and a legitimate global value would be rejected.
+    fn test_prefix_flag_keeps_the_flag_it_was_read_as() {
+        // A word before the mounted command is re-parsed by Phase 2, when the mounted command
+        // already owns the name. It has to stay bound to the flag Phase 1 read it as, or the
+        // global's value would be validated against the mounted flag's choices and a legitimate
+        // value would be rejected.
         let spec = mounted_task_flag_spec();
         let parsed = parse_partial(
             &spec,
@@ -2226,8 +2227,129 @@ mod tests {
             parsed.as_env().get("usage_env").map(String::as_str),
             Some("not-a-task-choice"),
         );
-        // The name is still offered, since the mounted command declares it too.
-        assert!(parsed.completion_flags().contains_key("--env"));
+
+        // The embedded-value form binds the same way.
+        let parsed = parse_partial(
+            &spec,
+            &input(&["test", "--env=not-a-task-choice", "run", "mytask"]),
+        )
+        .unwrap();
+        assert!(parsed.errors.is_empty());
+        assert_eq!(
+            parsed.as_env().get("usage_env").map(String::as_str),
+            Some("not-a-task-choice"),
+        );
+
+        // Meanwhile a word *after* the mounted command belongs to the mounted flag, even when
+        // the same name was already used before it.
+        let parsed = parse_partial(
+            &spec,
+            &input(&["test", "--env", "prod", "run", "mytask", "--env"]),
+        )
+        .unwrap();
+        let awaiting = parsed
+            .flag_awaiting_value
+            .first()
+            .expect("--env should await a value");
+        assert_eq!(
+            awaiting
+                .arg
+                .as_ref()
+                .and_then(|a| a.choices.as_ref())
+                .map(|c| c.choices.clone()),
+            Some(vec![
+                "dev".to_string(),
+                "stage".to_string(),
+                "prod".to_string()
+            ]),
+            "the mounted command's --env must own the name after the mounted command",
+        );
+    }
+
+    #[test]
+    fn test_non_global_flag_does_not_hide_subcommand() {
+        // A non-global flag may precede a subcommand (`mycli run --force task`). Phase 1 used to
+        // stop scanning at one, so the subcommand — and any mount on it — was never reached and
+        // its name was left to Phase 2 to mis-read as a positional: `unexpected word: mytask`.
+        let spec = mounted_task_flag_spec();
+
+        for words in [
+            // `run` declares `-f/--force` as non-global.
+            &["test", "run", "--force", "mytask"][..],
+            &["test", "run", "-f", "mytask"][..],
+            // Mixed with a global before the subcommand.
+            &["test", "-E", "prod", "run", "--force", "mytask"][..],
+        ] {
+            let parsed = parse_partial(&spec, &input(words)).unwrap();
+            assert_eq!(
+                parsed
+                    .cmds
+                    .iter()
+                    .map(|c| c.name.as_str())
+                    .collect::<Vec<_>>(),
+                vec!["test", "run", "mytask"],
+                "{words:?} should descend into the mounted command",
+            );
+            assert!(
+                parsed.args.is_empty(),
+                "{words:?} should not consume a positional, got {:?}",
+                parsed.args,
+            );
+            assert_eq!(
+                parsed.as_env().get("usage_force").map(String::as_str),
+                Some("true"),
+                "the non-global flag must still be recorded for {words:?}",
+            );
+        }
+
+        // A non-global flag that takes a value consumes it, rather than reading the value as the
+        // subcommand.
+        let mut run_cmd = SpecCommand::builder()
+            .name("run")
+            .flag(
+                SpecFlag::builder()
+                    .name("output")
+                    .short('o')
+                    .long("output")
+                    .arg(SpecArg::builder().name("mode").build())
+                    .global(false)
+                    .build(),
+            )
+            .build();
+        run_cmd.subcommands.insert(
+            "task".to_string(),
+            SpecCommand::builder().name("task").build(),
+        );
+        let mut cmd = SpecCommand::builder().name("test").build();
+        cmd.subcommands.insert("run".to_string(), run_cmd);
+        let spec = Spec {
+            name: "test".to_string(),
+            bin: "test".to_string(),
+            cmd,
+            ..Default::default()
+        };
+
+        let parsed =
+            parse_partial(&spec, &input(&["test", "run", "--output", "quiet", "task"])).unwrap();
+        assert_eq!(
+            parsed
+                .cmds
+                .iter()
+                .map(|c| c.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["test", "run", "task"],
+        );
+        assert_eq!(
+            parsed.as_env().get("usage_output").map(String::as_str),
+            Some("quiet"),
+        );
+
+        // An unknown flag still stops the scan: it may take a value, so the next word cannot be
+        // assumed to be a subcommand. `run` takes no positional, so this stays an error.
+        assert_parse_err(
+            parse_partial(&spec, &input(&["test", "run", "--nope", "task"])),
+            "unexpected word: --nope",
+        );
     }
 
     #[test]

--- a/lib/src/spec/cmd.rs
+++ b/lib/src/spec/cmd.rs
@@ -51,6 +51,17 @@ pub struct SpecCommand {
     pub deprecated: Option<String>,
     /// Whether to hide this command from help output
     pub hide: bool,
+    /// True when this command came from a [`SpecMount`], i.e. it describes another
+    /// program's CLI that was merged in at parse time.
+    ///
+    /// The flags of the commands *above* a mounted command belong to the mounting CLI,
+    /// not to the mounted program, so they are not offered in completions once a mounted
+    /// command has been reached. They stay recognized by the parser, since they may
+    /// legitimately appear *before* the mounted command on the command line.
+    ///
+    /// Runtime-only: it is derived from `mount` nodes and is not part of the spec syntax.
+    #[serde(skip)]
+    pub mounted: bool,
     /// Whether a subcommand must be provided
     #[serde(skip_serializing_if = "is_false")]
     pub subcommand_required: bool,
@@ -113,6 +124,7 @@ impl Default for SpecCommand {
             mounts: vec![],
             deprecated: None,
             hide: false,
+            mounted: false,
             subcommand_required: false,
             restart_token: None,
             help: None,
@@ -447,10 +459,23 @@ impl SpecCommand {
                 shell_words::join(tokens)
             };
             let output = sh(&cmd)?;
-            let spec: Spec = output.parse()?;
+            let mut spec: Spec = output.parse()?;
+            // The subcommands emitted by a mount describe another program, so mark them (and
+            // everything below them) as mounted. See `SpecCommand::mounted`.
+            for cmd in spec.cmd.subcommands.values_mut() {
+                cmd.mark_mounted();
+            }
             self.merge(spec.cmd);
         }
         Ok(())
+    }
+
+    /// Mark this command and all of its subcommands as coming from a mount.
+    fn mark_mounted(&mut self) {
+        self.mounted = true;
+        for cmd in self.subcommands.values_mut() {
+            cmd.mark_mounted();
+        }
     }
 }
 

--- a/lib/src/spec/cmd.rs
+++ b/lib/src/spec/cmd.rs
@@ -62,6 +62,14 @@ pub struct SpecCommand {
     /// Runtime-only: it is derived from `mount` nodes and is not part of the spec syntax.
     #[serde(skip)]
     pub mounted: bool,
+    /// True when a [`SpecMount`] brought flags of its own onto this command. A mounted spec's
+    /// root flags are merged into the command the mount sits on, *replacing* that command's
+    /// flags (see [`SpecCommand::merge`]), so when this is set every flag here describes the
+    /// mounted program and is offered inside the mounted commands accordingly.
+    ///
+    /// Runtime-only, like [`SpecCommand::mounted`].
+    #[serde(skip)]
+    pub flags_from_mount: bool,
     /// Whether a subcommand must be provided
     #[serde(skip_serializing_if = "is_false")]
     pub subcommand_required: bool,
@@ -125,6 +133,7 @@ impl Default for SpecCommand {
             deprecated: None,
             hide: false,
             mounted: false,
+            flags_from_mount: false,
             subcommand_required: false,
             restart_token: None,
             help: None,
@@ -465,13 +474,16 @@ impl SpecCommand {
             for cmd in spec.cmd.subcommands.values_mut() {
                 cmd.mark_mounted();
             }
+            // `merge` folds the mounted spec's root flags into this command; remember that they
+            // came from the mount. See `SpecCommand::flags_from_mount`.
+            self.flags_from_mount |= !spec.cmd.flags.is_empty();
             self.merge(spec.cmd);
         }
         Ok(())
     }
 
     /// Mark this command and all of its subcommands as coming from a mount.
-    fn mark_mounted(&mut self) {
+    pub(crate) fn mark_mounted(&mut self) {
         self.mounted = true;
         for cmd in self.subcommands.values_mut() {
             cmd.mark_mounted();


### PR DESCRIPTION
Fixes the parser-side causes of [jdx/mise#11282](https://github.com/jdx/mise/discussions/11282), plus the two follow-ups that turned up while fixing it. mise side: jdx/mise#11284.

Three related defects, all in how Phase 1's subcommand scan and Phase 2's re-parse interact with mounted commands.

## 1. The mounting CLI's globals leaked into mounted commands

A mounted command describes *another program*, but the flags of the commands it is mounted under were inherited into it on descent. For a CLI like mise — where everything after a task name is forwarded to the task — that meant:

- `mise run mytask --<TAB>` offered `--cd --env --jobs --locked --quiet --raw --silent --verbose --yes` (and via `mise tasks run`, `--all --extended --global --json …`). Using any of them fails: `mise run mytask --silent` → `ERROR unexpected word: --silent`.
- A flag the mounted command declares itself was shadowed by a global of the same name, so its choices were replaced by the global's: a task declaring `--env` with `choices "dev" "stage" "prod"` completed as *file names*. Renaming it to `--environment` worked — the reporter's workaround.

**Fix:** commands merged in by a `mount` are marked `SpecCommand::mounted` (runtime-only, propagated to their subcommands). Crossing *into* the mounted tree keeps the inherited globals in `available_flags` — they may legitimately appear *before* the mounted command — but the mounted command's own flags now take precedence for their own names. Only that crossing is a boundary: inside the mounted tree its commands are ordinary commands relative to each other, so descents there use the normal merge, including jdx/usage#649's rule. A mount can also merge flags from its spec's root onto the command it sits on; `SpecCommand::flags_from_mount` records that so those flags count as the mounted program's. New `ParseOutput::completion_flags()` returns what a completion should offer: everything recognized, or, once a mounted command is reached, only the flags declared from the mount boundary down. It needs no extra parse state (`ParseOutput::cmds` already records the descent chain), so the public API stays additive and `cargo semver-checks` passes. With no mount in play it returns `available_flags` unchanged.

## 2. A non-global flag hid the subcommand behind it

Phase 1 stopped scanning at the first non-global flag, so the subcommand — and any mount on it — was never reached, and its name fell through to Phase 2 as a positional:

```console
$ usage complete-word ... -- mise run --force build --bump ''
Error:   × unexpected word: build
```

That hit every non-global `run` flag in mise (`-f/--force`, `-n/--dry-run`, `-o/--output`, `-s/--shell`, `-t/--tool`, `--timeout`, …), and mise's `promote_orphan_shorts` workaround couldn't help: those flags have no root global to promote onto.

The old rationale was that `cmd --local-flag run` might read `run` as the flag's value — but that's what the existing "does this flag take an argument" check handles, and it already governs global flags in the same position. **Fix:** known non-global flags are consumed like globals and the scan continues; they are just not forwarded to mounts, since they're scoped to the command that declared them. An *unknown* flag still stops the scan, since its arity is unknown.

## 3. Re-parsed prefix words could bind to the wrong flag

Phase 1 deliberately leaves the words it skips in `input` so Phase 2 records them in `out.flags`/`as_env()`. But by then the recognized flags have changed — each descent drops non-globals, and (after fix 1) a mounted command can own a name a global used. **Fix:** Phase 1 records which flag each skipped word was read as, and Phase 2 resolves those words through that binding. This removed the special case I'd first written for it, so a mounted command's flag now always owns its own name:

```console
$ mycli --env prod run task --env <TAB>     # task's choices, and --env prod still parses as the global
```

## Verified against a real `mise usage` spec

| | before | after |
|---|---|---|
| `mise run mytask --<TAB>` | `--bump --cd --env --jobs --locked --output-dir --quiet --raw --silent --verbose --yes` | `--bump --env --output-dir` |
| `mise run mytask --env <TAB>` | `mise-tasks/ mise.toml …` (files) | `dev stage prod` |
| `mise tasks run mytask --<TAB>` | above + 10 `tasks` flags | `--bump --env --output-dir` |
| `mise mytask --<TAB>` (naked) | same leak | `--bump --env --output-dir` |
| `mise run --force mytask --bump <TAB>` | `Error: unexpected word: mytask` | `auto major minor patch` |
| `mise run -o interleave mytask --env <TAB>` | `Error: unexpected word: mytask` | `dev stage prod` |
| `mise --env prod run mytask --env <TAB>` | files | `dev stage prod` |
| `mise -C . run mytask --bump <TAB>` | `auto major minor patch` | unchanged |
| `mise run -r/-S mytask <TAB>` | works via mise's promotion | works without it |

## Tests

- `examples/mounted-global-flag-leak.sh` — new fixture: root globals `-E/--env`, `--silent`; `run` with a non-global `-f/--force` and a mount; mounted `mytask` declaring a colliding `--env` with choices.
- `complete_word_mounted_does_not_offer_mounting_cli_flags` — end-to-end through a real mount: the offered flag list, `--env`/`--bump` value completion, flags still offered *before* the mount, a prefix global still parsing, the rejected-by-choices prefix value, and `run --force mytask` / `run -f mytask`. Verified failing on `main`.
- `complete_word_non_global_flags_stop_search` → `..._do_not_stop_search`: now asserts the mounted task is found behind `--local`, and that an unknown flag still stops the scan.
- Parser unit tests: offered-vs-recognized split, mounted-flag precedence, prefix binding (spaced and `=` forms, plus the after-the-mount case), non-global flags not hiding a subcommand (boolean, short, value-taking, and unknown-flag control), and a non-mounted control asserting `completion_flags() == available_flags`.
- Two more from review, both failing without their fix: `test_mount_boundary_does_not_apply_inside_the_mounted_tree` (three levels, nested command re-declaring the mounted program's own global) and `test_mount_flags_merged_into_the_mounting_cmd_are_offered`.
- Existing #10069 / orphan-short tests unchanged and passing. `mise run lint` (incl. `cargo semver-checks`), `mise run render`, and the full suite are clean; the only failures locally are two pre-existing `node`-dependent cases in `tests/examples.rs`, which also fail on `main` in my sandbox.

*This PR was prepared by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core partial-parse and flag-merge logic used by shell completion and dynamic mounts; behavior changes are intentional but broad, with heavy test coverage rather than isolated call sites.
> 
> **Overview**
> Fixes mounted-command completion and partial-parse behavior (jdx/mise#11282 and related).
> 
> **Mounted commands:** Merged mount subcommands are marked `mounted` (and mount-root flags `flags_from_mount`). Crossing a mount boundary keeps parent globals *recognized* for tokens before the task, but mounted flags win on name collisions. New `ParseOutput::completion_flags()` is what completions should offer—only flags from the mount boundary down—while `complete-word` switches from `available_flags` to that API.
> 
> **Phase 1 subcommand scan:** Known non-global flags before a subcommand no longer stop the scan (e.g. `run --force mytask`), so mounts and task names are still found; only globals are forwarded to mount scripts. Unknown flags still stop the scan.
> 
> **Prefix re-parse:** Phase 1 records `prefix_bindings` so Phase 2 keeps early tokens bound to the flag they were first read as when a mounted command later owns the same name.
> 
> Docs cover global vs non-global flags around mounts; new example script and broad parser/integration tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eaaf535e65eeaf786c68848bf54bf8b6a111150. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed shell completion inside mounted commands so mounting CLI flags are no longer incorrectly suggested.
  * Mounted command flags now take precedence over inherited global flags with the same name.
  * Improved parsing of flags before and across mounted command boundaries, including aliases and inline values.
  * Preserved completion of global flags before entering a mounted command.

* **Documentation**
  * Added guidance and examples explaining global flag behavior and completion rules for mounted commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
