### PR TITLE
refactor(spec): make missed SpecCommand fields a compile error, and fix the four that were already missed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,6 +1760,7 @@ dependencies = [
  "regex",
  "roff",
  "serde",
+ "serde_json",
  "shell-words",
  "strum",
  "tempfile",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -49,6 +49,7 @@ criterion = "0.8"
 ctor = "1"
 insta = "1"
 pretty_assertions = "1"
+serde_json = "1"
 shell-words = "1"
 tempfile = "3"
 

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -41,6 +41,7 @@ pub struct SpecCommand {
     pub effect: Option<SpecCommandEffect>,
     pub hide: bool,
     pub subcommand_required: bool,
+    pub restart_token: Option<String>,
     pub help: Option<String>,
     pub help_long: Option<String>,
     pub help_md: Option<String>,
@@ -238,10 +239,6 @@ impl From<&crate::SpecCommand> for SpecCommand {
             subcommand_lookup: _,
         } = cmd;
 
-        // NOTE: `restart_token` is intentionally dropped, preserving existing
-        // behavior; see the follow-up commit.
-        let _ = restart_token;
-
         Self {
             full_cmd: full_cmd.clone(),
             usage: usage.clone(),
@@ -255,6 +252,7 @@ impl From<&crate::SpecCommand> for SpecCommand {
             effect: *effect,
             hide: *hide,
             subcommand_required: *subcommand_required,
+            restart_token: restart_token.clone(),
             help: help.clone(),
             help_long: help_long.clone(),
             help_md: help_md.clone(),

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -204,35 +204,70 @@ impl From<&crate::SpecCommand> for SpecCommand {
             })
             .collect();
 
+        // Destructured exhaustively (no `..`) so that adding a field to the spec
+        // model fails to compile until this decides whether docs need it.
+        let crate::SpecCommand {
+            full_cmd,
+            usage,
+            subcommands,
+            deprecated,
+            effect,
+            hide,
+            subcommand_required,
+            help,
+            help_long,
+            help_md,
+            name,
+            aliases,
+            hidden_aliases,
+            before_help,
+            before_help_long,
+            before_help_md,
+            after_help,
+            after_help_long,
+            after_help_md,
+            examples,
+            restart_token,
+            // Rendered above, or deliberately absent from the docs model.
+            args: _,
+            flags: _,
+            mounts: _,
+            complete: _,
+            mounted: _,
+            flags_from_mount: _,
+            subcommand_lookup: _,
+        } = cmd;
+
+        // NOTE: `restart_token` is intentionally dropped, preserving existing
+        // behavior; see the follow-up commit.
+        let _ = restart_token;
+
         Self {
-            full_cmd: cmd.full_cmd.clone(),
-            usage: cmd.usage.clone(),
-            subcommands: cmd
-                .subcommands
+            full_cmd: full_cmd.clone(),
+            usage: usage.clone(),
+            subcommands: subcommands
                 .iter()
                 .map(|(k, v)| (k.clone(), SpecCommand::from(v)))
                 .collect(),
             args,
             flags,
-            // mounts: cmd.mounts.iter().map(SpecMount::from).collect(),
-            deprecated: cmd.deprecated.clone(),
-            effect: cmd.effect,
-            hide: cmd.hide,
-            subcommand_required: cmd.subcommand_required,
-            help: cmd.help.clone(),
-            help_long: cmd.help_long.clone(),
-            help_md: cmd.help_md.clone(),
-            name: cmd.name.clone(),
-            aliases: cmd.aliases.clone(),
-            hidden_aliases: cmd.hidden_aliases.clone(),
-            before_help: cmd.before_help.clone(),
-            before_help_long: cmd.before_help_long.clone(),
-            before_help_md: cmd.before_help_md.clone(),
-            after_help: cmd.after_help.clone(),
-            after_help_long: cmd.after_help_long.clone(),
-            after_help_md: cmd.after_help_md.clone(),
-            examples: cmd.examples.iter().map(SpecExample::from).collect(),
-            // complete: cmd.complete.clone(),
+            deprecated: deprecated.clone(),
+            effect: *effect,
+            hide: *hide,
+            subcommand_required: *subcommand_required,
+            help: help.clone(),
+            help_long: help_long.clone(),
+            help_md: help_md.clone(),
+            name: name.clone(),
+            aliases: aliases.clone(),
+            hidden_aliases: hidden_aliases.clone(),
+            before_help: before_help.clone(),
+            before_help_long: before_help_long.clone(),
+            before_help_md: before_help_md.clone(),
+            after_help: after_help.clone(),
+            after_help_long: after_help_long.clone(),
+            after_help_md: after_help_md.clone(),
+            examples: examples.iter().map(SpecExample::from).collect(),
             rendered: false,
         }
     }

--- a/lib/src/spec/cmd.rs
+++ b/lib/src/spec/cmd.rs
@@ -296,11 +296,18 @@ impl SpecCommand {
                 "long_help" => {
                     cmd.help_long = Some(child.ensure_arg_len(1..=1)?.arg(0)?.ensure_string()?);
                 }
+                "help_md" => {
+                    cmd.help_md = Some(child.ensure_arg_len(1..=1)?.arg(0)?.ensure_string()?);
+                }
                 "before_help" => {
                     cmd.before_help = Some(child.ensure_arg_len(1..=1)?.arg(0)?.ensure_string()?);
                 }
                 "before_long_help" => {
                     cmd.before_help_long =
+                        Some(child.ensure_arg_len(1..=1)?.arg(0)?.ensure_string()?);
+                }
+                "before_help_md" => {
+                    cmd.before_help_md =
                         Some(child.ensure_arg_len(1..=1)?.arg(0)?.ensure_string()?);
                 }
                 "after_help" => {
@@ -309,6 +316,9 @@ impl SpecCommand {
                 "after_long_help" => {
                     cmd.after_help_long =
                         Some(child.ensure_arg_len(1..=1)?.arg(0)?.ensure_string()?);
+                }
+                "after_help_md" => {
+                    cmd.after_help_md = Some(child.ensure_arg_len(1..=1)?.arg(0)?.ensure_string()?);
                 }
                 "subcommand_required" => {
                     cmd.subcommand_required = child.ensure_arg_len(1..=1)?.arg(0)?.ensure_bool()?

--- a/lib/src/spec/cmd.rs
+++ b/lib/src/spec/cmd.rs
@@ -701,9 +701,10 @@ impl From<&SpecCommand> for KdlNode {
             let children = node.children_mut().get_or_insert_with(KdlDocument::new);
             children.nodes_mut().push(cmd.into());
         }
-        // NOTE: `examples` is intentionally not serialized, preserving existing
-        // behavior; see the follow-up commit.
-        let _ = examples;
+        for example in examples {
+            let children = node.children_mut().get_or_insert_with(KdlDocument::new);
+            children.nodes_mut().push(example.into());
+        }
         for complete in complete.values() {
             let children = node.children_mut().get_or_insert_with(KdlDocument::new);
             children.nodes_mut().push(complete.into());

--- a/lib/src/spec/cmd.rs
+++ b/lib/src/spec/cmd.rs
@@ -121,9 +121,12 @@ pub struct SpecCommand {
     #[serde(skip_serializing_if = "IndexMap::is_empty")]
     pub complete: IndexMap<String, SpecComplete>,
 
-    /// Cache for subcommand name lookups (including aliases)
+    /// Cache for subcommand name lookups (including aliases).
+    ///
+    /// `pub(crate)` only so that other modules can destructure `SpecCommand`
+    /// exhaustively; it stays private to the crate.
     #[serde(skip)]
-    subcommand_lookup: OnceLock<HashMap<String, String>>,
+    pub(crate) subcommand_lookup: OnceLock<HashMap<String, String>>,
 }
 
 impl Default for SpecCommand {
@@ -391,66 +394,103 @@ impl SpecCommand {
         usage.trim().to_string()
     }
     pub(crate) fn merge(&mut self, other: Self) {
-        if !other.name.is_empty() {
-            self.name = other.name;
+        // Destructured exhaustively (no `..`) so that adding a field to
+        // SpecCommand fails to compile until this decides what merging it means.
+        // Runtime-derived fields are explicitly ignored rather than skipped.
+        let Self {
+            name,
+            help,
+            help_long,
+            help_md,
+            before_help,
+            before_help_long,
+            before_help_md,
+            after_help,
+            after_help_long,
+            after_help_md,
+            args,
+            flags,
+            mounts,
+            aliases,
+            hidden_aliases,
+            examples,
+            hide,
+            subcommand_required,
+            restart_token,
+            subcommands,
+            complete,
+            deprecated,
+            effect,
+            // Recomputed from the merged command, never carried over.
+            full_cmd: _,
+            usage: _,
+            mounted: _,
+            flags_from_mount: _,
+            subcommand_lookup: _,
+        } = other;
+        if !name.is_empty() {
+            self.name = name;
         }
-        if other.help.is_some() {
-            self.help = other.help;
+        if help.is_some() {
+            self.help = help;
         }
-        if other.help_long.is_some() {
-            self.help_long = other.help_long;
+        if help_long.is_some() {
+            self.help_long = help_long;
         }
-        if other.help_md.is_some() {
-            self.help_md = other.help_md;
+        if help_md.is_some() {
+            self.help_md = help_md;
         }
-        if other.before_help.is_some() {
-            self.before_help = other.before_help;
+        if before_help.is_some() {
+            self.before_help = before_help;
         }
-        if other.before_help_long.is_some() {
-            self.before_help_long = other.before_help_long;
+        if before_help_long.is_some() {
+            self.before_help_long = before_help_long;
         }
-        if other.before_help_md.is_some() {
-            self.before_help_md = other.before_help_md;
+        if before_help_md.is_some() {
+            self.before_help_md = before_help_md;
         }
-        if other.after_help.is_some() {
-            self.after_help = other.after_help;
+        if after_help.is_some() {
+            self.after_help = after_help;
         }
-        if other.after_help_long.is_some() {
-            self.after_help_long = other.after_help_long;
+        if after_help_long.is_some() {
+            self.after_help_long = after_help_long;
         }
-        if other.after_help_md.is_some() {
-            self.after_help_md = other.after_help_md;
+        if after_help_md.is_some() {
+            self.after_help_md = after_help_md;
         }
-        if !other.args.is_empty() {
-            self.args = other.args;
+        if !args.is_empty() {
+            self.args = args;
         }
-        if !other.flags.is_empty() {
-            self.flags = other.flags;
+        if !flags.is_empty() {
+            self.flags = flags;
         }
-        if !other.mounts.is_empty() {
-            self.mounts = other.mounts;
+        if !mounts.is_empty() {
+            self.mounts = mounts;
         }
-        if !other.aliases.is_empty() {
-            self.aliases = other.aliases;
+        if !aliases.is_empty() {
+            self.aliases = aliases;
         }
-        if !other.hidden_aliases.is_empty() {
-            self.hidden_aliases = other.hidden_aliases;
+        if !hidden_aliases.is_empty() {
+            self.hidden_aliases = hidden_aliases;
         }
-        if !other.examples.is_empty() {
-            self.examples = other.examples;
+        if !examples.is_empty() {
+            self.examples = examples;
         }
-        self.hide = other.hide;
-        self.subcommand_required = other.subcommand_required;
-        if other.effect.is_some() {
-            self.effect = other.effect;
+        self.hide = hide;
+        self.subcommand_required = subcommand_required;
+        if effect.is_some() {
+            self.effect = effect;
         }
-        if other.restart_token.is_some() {
-            self.restart_token = other.restart_token;
+        // NOTE: `deprecated` is intentionally left out to preserve existing
+        // behavior; see the follow-up commit.
+        let _ = deprecated;
+        if restart_token.is_some() {
+            self.restart_token = restart_token;
         }
-        for (name, cmd) in other.subcommands {
+        for (name, cmd) in subcommands {
             self.subcommands.insert(name, cmd);
         }
-        for (name, complete) in other.complete {
+        for (name, complete) in complete {
             self.complete.insert(name, complete);
         }
     }
@@ -525,108 +565,146 @@ impl SpecCommand {
 
 impl From<&SpecCommand> for KdlNode {
     fn from(cmd: &SpecCommand) -> Self {
+        // Destructured exhaustively (no `..`) so that adding a field to
+        // SpecCommand fails to compile until this decides how to serialize it.
+        let SpecCommand {
+            name,
+            hide,
+            subcommand_required,
+            restart_token,
+            aliases,
+            hidden_aliases,
+            help,
+            help_long,
+            help_md,
+            before_help,
+            before_help_long,
+            before_help_md,
+            after_help,
+            after_help_long,
+            after_help_md,
+            deprecated,
+            effect,
+            flags,
+            args,
+            mounts,
+            subcommands,
+            complete,
+            examples,
+            // Derived from the spec rather than written by it.
+            full_cmd: _,
+            usage: _,
+            mounted: _,
+            flags_from_mount: _,
+            subcommand_lookup: _,
+        } = cmd;
         let mut node = Self::new("cmd");
-        node.entries_mut().push(cmd.name.clone().into());
-        if cmd.hide {
+        node.entries_mut().push(name.clone().into());
+        if *hide {
             node.entries_mut().push(KdlEntry::new_prop("hide", true));
         }
-        if cmd.subcommand_required {
+        if *subcommand_required {
             node.entries_mut()
                 .push(KdlEntry::new_prop("subcommand_required", true));
         }
-        if let Some(restart_token) = &cmd.restart_token {
+        if let Some(restart_token) = &restart_token {
             node.entries_mut()
                 .push(KdlEntry::new_prop("restart_token", restart_token.clone()));
         }
-        if !cmd.aliases.is_empty() {
-            let mut aliases = KdlNode::new("alias");
-            for alias in &cmd.aliases {
-                aliases.entries_mut().push(alias.clone().into());
+        if !aliases.is_empty() {
+            let mut alias_node = KdlNode::new("alias");
+            for alias in aliases {
+                alias_node.entries_mut().push(alias.clone().into());
             }
             let children = node.children_mut().get_or_insert_with(KdlDocument::new);
-            children.nodes_mut().push(aliases);
+            children.nodes_mut().push(alias_node);
         }
-        if !cmd.hidden_aliases.is_empty() {
-            let mut aliases = KdlNode::new("alias");
-            for alias in &cmd.hidden_aliases {
-                aliases.entries_mut().push(alias.clone().into());
+        if !hidden_aliases.is_empty() {
+            let mut alias_node = KdlNode::new("alias");
+            for alias in hidden_aliases {
+                alias_node.entries_mut().push(alias.clone().into());
             }
-            aliases.entries_mut().push(KdlEntry::new_prop("hide", true));
+            alias_node
+                .entries_mut()
+                .push(KdlEntry::new_prop("hide", true));
             let children = node.children_mut().get_or_insert_with(KdlDocument::new);
-            children.nodes_mut().push(aliases);
+            children.nodes_mut().push(alias_node);
         }
-        if let Some(help) = &cmd.help {
+        if let Some(help) = &help {
             node.entries_mut().push(string_entry(Some("help"), help));
         }
-        if let Some(help) = &cmd.help_long {
+        if let Some(help) = &help_long {
             let children = node.children_mut().get_or_insert_with(KdlDocument::new);
             let mut node = KdlNode::new("long_help");
             node.push(string_entry(None, help));
             children.nodes_mut().push(node);
         }
-        if let Some(help) = &cmd.help_md {
+        if let Some(help) = &help_md {
             let children = node.children_mut().get_or_insert_with(KdlDocument::new);
             let mut node = KdlNode::new("help_md");
             node.push(string_entry(None, help));
             children.nodes_mut().push(node);
         }
-        if let Some(help) = &cmd.before_help {
+        if let Some(help) = &before_help {
             node.entries_mut()
                 .push(string_entry(Some("before_help"), help));
         }
-        if let Some(help) = &cmd.before_help_long {
+        if let Some(help) = &before_help_long {
             let children = node.children_mut().get_or_insert_with(KdlDocument::new);
             let mut node = KdlNode::new("before_long_help");
             node.push(string_entry(None, help));
             children.nodes_mut().push(node);
         }
-        if let Some(help) = &cmd.before_help_md {
+        if let Some(help) = &before_help_md {
             let children = node.children_mut().get_or_insert_with(KdlDocument::new);
             let mut node = KdlNode::new("before_help_md");
             node.push(string_entry(None, help));
             children.nodes_mut().push(node);
         }
-        if let Some(help) = &cmd.after_help {
+        if let Some(help) = &after_help {
             node.entries_mut()
                 .push(string_entry(Some("after_help"), help));
         }
-        if let Some(help) = &cmd.after_help_long {
+        if let Some(help) = &after_help_long {
             let children = node.children_mut().get_or_insert_with(KdlDocument::new);
             let mut node = KdlNode::new("after_long_help");
             node.push(string_entry(None, help));
             children.nodes_mut().push(node);
         }
-        if let Some(help) = &cmd.after_help_md {
+        if let Some(help) = &after_help_md {
             let children = node.children_mut().get_or_insert_with(KdlDocument::new);
             let mut node = KdlNode::new("after_help_md");
             node.push(string_entry(None, help));
             children.nodes_mut().push(node);
         }
-        if let Some(deprecated) = &cmd.deprecated {
+        if let Some(deprecated) = &deprecated {
             node.entries_mut()
                 .push(string_entry(Some("deprecated"), deprecated));
         }
-        if let Some(effect) = &cmd.effect {
+        if let Some(effect) = effect {
             node.entries_mut()
                 .push(string_entry(Some("effect"), effect.as_str()));
         }
-        for flag in &cmd.flags {
+        for flag in flags {
             let children = node.children_mut().get_or_insert_with(KdlDocument::new);
             children.nodes_mut().push(flag.into());
         }
-        for arg in &cmd.args {
+        for arg in args {
             let children = node.children_mut().get_or_insert_with(KdlDocument::new);
             children.nodes_mut().push(arg.into());
         }
-        for mount in &cmd.mounts {
+        for mount in mounts {
             let children = node.children_mut().get_or_insert_with(KdlDocument::new);
             children.nodes_mut().push(mount.into());
         }
-        for cmd in cmd.subcommands.values() {
+        for cmd in subcommands.values() {
             let children = node.children_mut().get_or_insert_with(KdlDocument::new);
             children.nodes_mut().push(cmd.into());
         }
-        for complete in cmd.complete.values() {
+        // NOTE: `examples` is intentionally not serialized, preserving existing
+        // behavior; see the follow-up commit.
+        let _ = examples;
+        for complete in complete.values() {
             let children = node.children_mut().get_or_insert_with(KdlDocument::new);
             children.nodes_mut().push(complete.into());
         }

--- a/lib/src/spec/cmd.rs
+++ b/lib/src/spec/cmd.rs
@@ -949,16 +949,24 @@ cmd "install" help="Install a package" subcommand_required=#false {
     long_help "The long help for install"
     help_md "The **markdown** help for install"
     before_help "before"
+    before_long_help "The long before-help for install"
+    before_help_md "The **markdown** before-help for install"
     after_help "after"
+    after_long_help "The long after-help for install"
+    after_help_md "The **markdown** after-help for install"
     arg "<pkg>" help="Package to install"
     flag "-f --force" help="Overwrite"
+    complete "pkg" run="mycli list --available" descriptions=#true
     example "mycli install foo" header="Install foo" help="Installs foo" lang="sh"
     example "mycli install bar"
     cmd "from" help="Install from a source" {
         arg "<src>"
     }
 }
-cmd "remove" help="Remove a package" deprecated="use `uninstall`"
+cmd "wrapped" help="Wraps another CLI" {
+    mount run="mycli plugin usage-spec"
+}
+cmd "remove" help="Remove a package" deprecated="use `uninstall`" effect="destructive"
 cmd "run" restart_token=":::" help="Run tasks"
 cmd "hidden" hide=#true
         "#;
@@ -969,5 +977,46 @@ cmd "hidden" hide=#true
         let original = serde_json::to_value(&original).unwrap();
         let reparsed = serde_json::to_value(&reparsed).unwrap();
         pretty_assertions::assert_eq!(original, reparsed);
+
+        // Equality is only meaningful if the fixture actually populated the
+        // fields, so guard against a future edit quietly emptying it out.
+        let install = &original["cmd"]["subcommands"]["install"];
+        for key in [
+            "help_long",
+            "help_md",
+            "before_help",
+            "before_help_long",
+            "before_help_md",
+            "after_help",
+            "after_help_long",
+            "after_help_md",
+            "deprecated",
+            "effect",
+            "restart_token",
+            "examples",
+            "complete",
+            "mounts",
+            "aliases",
+            "hidden_aliases",
+        ] {
+            let populated = match key {
+                // These sit on other commands in the fixture.
+                "deprecated" | "effect" => {
+                    original["cmd"]["subcommands"]["remove"].get(key).is_some()
+                }
+                "restart_token" => original["cmd"]["subcommands"]["run"].get(key).is_some(),
+                "mounts" => !original["cmd"]["subcommands"]["wrapped"]["mounts"]
+                    .as_array()
+                    .unwrap()
+                    .is_empty(),
+                _ => match install.get(key) {
+                    Some(serde_json::Value::Array(a)) => !a.is_empty(),
+                    Some(serde_json::Value::Object(o)) => !o.is_empty(),
+                    Some(_) => true,
+                    None => false,
+                },
+            };
+            assert!(populated, "fixture does not exercise `{key}`");
+        }
     }
 }

--- a/lib/src/spec/cmd.rs
+++ b/lib/src/spec/cmd.rs
@@ -918,3 +918,56 @@ mod merge_tests {
         assert_eq!(cmd.deprecated.as_deref(), Some("gone in v3"));
     }
 }
+
+#[cfg(test)]
+mod roundtrip_tests {
+    use crate::Spec;
+
+    /// Serializing a spec back to KDL and reparsing it must not lose anything.
+    ///
+    /// The parser is a match on node names, so exhaustive destructuring can't
+    /// catch a field the serializer knows about but the parser doesn't, or the
+    /// reverse. Comparing the serde representation covers every field without
+    /// this test having to enumerate them, so a new field is covered the day it
+    /// is added.
+    #[test]
+    fn test_spec_survives_a_kdl_roundtrip() {
+        let src = r#"
+name "My CLI"
+bin "mycli"
+about "does things"
+version "1.0.0"
+author "nobody"
+license "MIT"
+
+flag "-v --verbose" help="Verbose logging" global=#true count=#true
+arg "<dir>" help="Directory to use"
+
+cmd "install" help="Install a package" subcommand_required=#false {
+    alias "i"
+    alias "add" hide=#true
+    long_help "The long help for install"
+    help_md "The **markdown** help for install"
+    before_help "before"
+    after_help "after"
+    arg "<pkg>" help="Package to install"
+    flag "-f --force" help="Overwrite"
+    example "mycli install foo" header="Install foo" help="Installs foo" lang="sh"
+    example "mycli install bar"
+    cmd "from" help="Install from a source" {
+        arg "<src>"
+    }
+}
+cmd "remove" help="Remove a package" deprecated="use `uninstall`"
+cmd "run" restart_token=":::" help="Run tasks"
+cmd "hidden" hide=#true
+        "#;
+
+        let original = Spec::parse(&Default::default(), src).unwrap();
+        let reparsed = Spec::parse(&Default::default(), &original.to_string()).unwrap();
+
+        let original = serde_json::to_value(&original).unwrap();
+        let reparsed = serde_json::to_value(&reparsed).unwrap();
+        pretty_assertions::assert_eq!(original, reparsed);
+    }
+}

--- a/lib/src/spec/cmd.rs
+++ b/lib/src/spec/cmd.rs
@@ -481,9 +481,9 @@ impl SpecCommand {
         if effect.is_some() {
             self.effect = effect;
         }
-        // NOTE: `deprecated` is intentionally left out to preserve existing
-        // behavior; see the follow-up commit.
-        let _ = deprecated;
+        if deprecated.is_some() {
+            self.deprecated = deprecated;
+        }
         if restart_token.is_some() {
             self.restart_token = restart_token;
         }
@@ -875,5 +875,35 @@ cmd "ls" effect="readonly"
             err.to_string().contains("Invalid usage config"),
             "unexpected error: {err}"
         );
+    }
+}
+
+#[cfg(test)]
+mod merge_tests {
+    use crate::Spec;
+
+    fn uninstall(src: &str) -> crate::SpecCommand {
+        Spec::parse(&Default::default(), src)
+            .unwrap()
+            .cmd
+            .subcommands["uninstall"]
+            .clone()
+    }
+
+    /// An overlay that says nothing about deprecation must not un-deprecate a
+    /// command that already declared it.
+    #[test]
+    fn test_deprecated_survives_merge() {
+        let declared = uninstall(r#"cmd "uninstall" deprecated="use `remove`""#);
+        let silent = uninstall(r#"cmd "uninstall" help="Remove a tool""#);
+        let contradicting = uninstall(r#"cmd "uninstall" deprecated="gone in v3""#);
+
+        let mut cmd = declared.clone();
+        cmd.merge(silent);
+        assert_eq!(cmd.deprecated.as_deref(), Some("use `remove`"));
+
+        let mut cmd = declared;
+        cmd.merge(contradicting);
+        assert_eq!(cmd.deprecated.as_deref(), Some("gone in v3"));
     }
 }


### PR DESCRIPTION
Follow-up to the review on #739, where `effect` was dropped by `SpecCommand::merge` and by the docs model. Neither omission could have been caught by anything but a reviewer noticing.

## The problem

Adding a field to `SpecCommand` means updating seven places — the struct, `Default`, the prop-parse arm, the child-node-parse arm, the KDL serializer, `merge`, the builder, and `docs::models::SpecCommand` + its `From`. Nothing enforces any of them, and every omission fails silently.

Auditing every existing field against the three impls turned up **four fields already falling through**, all on `main`:

| field | gap | effect |
| --- | --- | --- |
| `deprecated` | not carried by `merge` | an included spec silently un-deprecates a command |
| `restart_token` | never reaches the docs model | no template can render it |
| `examples` | not written by the KDL serializer | `spec.to_string()` drops every example |
| `help_md`, `before_help_md`, `after_help_md` | accepted only as props, serialized as child nodes | **any spec with markdown help fails to reparse**: `Error: unsupported cmd key help_md` |

The last one is the worst and I only found it because of the test in the final commit.

## The fix

**`merge` and both `From` impls now destructure their source with no `..`.** Add a field and you get three compile errors pointing at exactly the places that owe it a decision. Runtime-derived fields are bound to `_` with a comment so the reason is visible rather than implied. No macros, no new machinery, no runtime cost.

**A round-trip test covers what the compiler can't.** The parser is a `match` on node names, not a struct pattern, so a field the serializer writes and the parser rejects still compiles — which is exactly how the `help_md` bug survived. The test parses a spec exercising every field, serializes it, reparses, and compares the two serde representations. Comparing serialized values rather than named fields means a field added later is covered without anyone remembering to extend the test.

## Commits

Each is reviewable on its own, and the refactor is behavior-neutral:

1. `refactor(spec):` exhaustive destructuring — no behavior change; the four gaps are bound with `NOTE` comments so they're visible before being fixed
2. `fix(spec):` carry `deprecated` through `merge`
3. `fix(docs):` pass `restart_token` to the docs model
4. `fix(spec):` serialize `examples` to KDL
5. `fix(spec):` accept `help_md` / `before_help_md` / `after_help_md` as child nodes
6. `test(spec):` assert a spec survives a KDL round-trip

## Considered and skipped

A `#[derive(SpecNode)]` macro generating parse/serialize/merge from field attributes would cover all of it, but the irregular fields are a real tax — `deprecated` accepts bool-or-string, `alias` splits into visible and hidden, the collection children each parse differently. Destructuring plus the round-trip test gets nearly the same coverage for a fraction of the machinery. Worth revisiting if the struct keeps growing.

## Notes

- Branched off `main` rather than `#739`, so it's independently mergeable. Whichever lands second gets a trivial conflict in the destructuring lists (one added binding for `effect`).
- `subcommand_lookup` became `pub(crate)` so other modules can name it in a pattern. Still private outside the crate.
- `serde_json` added as a dev-dependency for the round-trip comparison.

## Verified

`cargo test -p usage-lib` passes, 271 + doctests. `cargo test --workspace` has the same two pre-existing failures in `usage-cli --test examples` (`test_usage_double_slash_execution`, `..._old`) present on a clean `main`. `cargo clippy` has one pre-existing error in `choices.rs` under a feature-gated path, also present on `main` and untouched here.

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core spec merge, KDL parse/serialize, and docs mapping used when composing specs (includes/mounts), but fixes are narrow and guarded by new round-trip and merge tests.
> 
> **Overview**
> **`SpecCommand` maintenance is enforced at compile time** by replacing `..` skips with exhaustive destructuring in `merge`, KDL serialization (`From<&SpecCommand> for KdlNode`), and the docs `From` impl—new struct fields must be handled explicitly in each path.
> 
> **Behavior fixes** close four silent gaps: `deprecated` is merged like other optional metadata; `restart_token` is copied into the docs model; `examples` are emitted when serializing to KDL; and `help_md` / `before_help_md` / `after_help_md` are accepted as **child nodes** on reparse (matching how they are written), so round-tripped specs no longer fail with unsupported `help_md` keys.
> 
> **Tests** add `deprecated` merge coverage and a KDL parse → `to_string()` → reparse test that compares full `serde_json` snapshots, plus fixture guards so the round-trip exercise stays meaningful. `subcommand_lookup` is `pub(crate)` only so other modules can name it in destructuring patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53055a09cab9150f1c3ea3c567bd0fc0e992f41c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->