### PR TITLE
fix(ci): stop clap_usage changes from majoring usage-lib and usage-cli

### DIFF
--- a/tasks/release-plz
+++ b/tasks/release-plz
@@ -2,6 +2,18 @@
 # shellcheck shell=bash
 set -euxo pipefail
 
+# clap_usage is versioned by hand and released on its own cadence, so check it
+# separately: the usage-lib release cycle below would otherwise never publish it.
+# It sat unpublished at 2.0.3 from 2025-01 to 2026-07 for exactly this reason.
+clap_usage_version="$(cargo pkgid clap_usage | cut -d# -f2 | cut -d@ -f2)"
+if ! curl -fsS https://index.crates.io/cl/ap/clap_usage |
+  grep -q "\"vers\":\"$clap_usage_version\""; then
+  echo "Releasing clap_usage $clap_usage_version"
+  if [ "${usage_dry_run:-}" != 1 ]; then
+    cargo publish -p clap_usage
+  fi
+fi
+
 released_versions="$(git tag --list | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$')"
 cur_version="$(cargo pkgid usage-lib | cut -d# -f2 | cut -d@ -f2)"
 if ! echo "$released_versions" | grep -q "^v$cur_version$"; then
@@ -15,11 +27,16 @@ if ! echo "$released_versions" | grep -q "^v$cur_version$"; then
   exit 0
 fi
 
-version="$(git cliff --bumped-version)"
+version="$(git cliff --bumped-version --include-path 'lib/**' --include-path 'cli/**')"
+
+if [ "v$cur_version" == "$version" ]; then
+  echo "No usage-lib/usage-cli changes since $version; nothing to release"
+  exit 0
+fi
 
 if [ "${usage_dry_run:-}" == 1 ]; then
   echo "version: $version"
-  changelog="$(git cliff --bump --unreleased --strip all)"
+  changelog="$(git cliff --bump --unreleased --strip all --include-path 'lib/**' --include-path 'cli/**')"
   echo "changelog: $changelog"
   exit 0
 fi

--- a/tasks/release-plz
+++ b/tasks/release-plz
@@ -2,17 +2,25 @@
 # shellcheck shell=bash
 set -euxo pipefail
 
-# clap_usage is versioned by hand and released on its own cadence, so check it
-# separately: the usage-lib release cycle below would otherwise never publish it.
-# It sat unpublished at 2.0.3 from 2025-01 to 2026-07 for exactly this reason.
-clap_usage_version="$(cargo pkgid clap_usage | cut -d# -f2 | cut -d@ -f2)"
-if ! curl -fsS https://index.crates.io/cl/ap/clap_usage |
-  grep -q "\"vers\":\"$clap_usage_version\""; then
-  echo "Releasing clap_usage $clap_usage_version"
+# clap_usage is versioned by hand and released on its own cadence, so it needs
+# its own check: the usage-lib release cycle below would otherwise never publish
+# it. That omission is why it sat unpublished at 2.0.3 from 2025-01 to 2026-07.
+#
+# It depends on usage-lib at the workspace version, so it can only be published
+# once that version is on crates.io — hence a function called in dependency
+# order rather than a block at the top of the script.
+publish_clap_usage_if_needed() {
+  local version
+  version="$(cargo pkgid clap_usage | cut -d# -f2 | cut -d@ -f2)"
+  if curl -fsS https://index.crates.io/cl/ap/clap_usage |
+    grep -q "\"vers\":\"$version\""; then
+    return
+  fi
+  echo "Releasing clap_usage $version"
   if [ "${usage_dry_run:-}" != 1 ]; then
     cargo publish -p clap_usage
   fi
-fi
+}
 
 released_versions="$(git tag --list | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$')"
 cur_version="$(cargo pkgid usage-lib | cut -d# -f2 | cut -d@ -f2)"
@@ -20,12 +28,17 @@ if ! echo "$released_versions" | grep -q "^v$cur_version$"; then
   echo "Releasing $cur_version"
   if [ "${usage_dry_run:-}" != 1 ]; then
     cargo publish -p usage-lib
+    publish_clap_usage_if_needed
     cargo publish -p usage-cli
     git tag "v$cur_version"
     git push --tags
   fi
   exit 0
 fi
+
+# usage-lib's current version is already released, so clap_usage's dependency
+# is satisfied; catch it up if it is behind.
+publish_clap_usage_if_needed
 
 version="$(git cliff --bumped-version --include-path 'lib/**' --include-path 'cli/**')"
 
@@ -42,11 +55,11 @@ if [ "${usage_dry_run:-}" == 1 ]; then
 fi
 
 # Generate changelog using git-cliff (LLM editorialization happens in release.yml after merge)
-git cliff --bump -o CHANGELOG.md
+git cliff --bump -o CHANGELOG.md --include-path 'lib/**' --include-path 'cli/**'
 
 # Get the unreleased notes for PR body
 # Strip version header since PR title already has version
-PR_BODY="$(git cliff --bump --unreleased --strip all | tail -n +3)"
+PR_BODY="$(git cliff --bump --unreleased --strip all --include-path 'lib/**' --include-path 'cli/**' | tail -n +3)"
 
 cargo set-version "${version#v}" --exclude clap_usage
 mise run render


### PR DESCRIPTION
#744 proposes **v5.0.0 for `usage-lib` and `usage-cli` — hours after v4.0.0 shipped, with no source change in either crate.** This fixes the cause, so it stops being regenerated.

## Why v5

[`tasks/release-plz`](https://github.com/jdx/usage/blob/main/tasks/release-plz) computes one version for the whole repo:

```bash
version="$(git cliff --bumped-version)"                  # reads every commit
cargo set-version "${version#v}" --exclude clap_usage    # applies to all but clap_usage
```

#743 was `feat(clap_usage)!:`. git-cliff saw the `!` and majored the repo; `set-version` then applied 5.0.0 to every crate *except* the one that actually broke. So the two crates that didn't change get a major, and `clap_usage` gets nothing.

Scoped to the crates the version is actually set on, there is nothing to bump:

```
$ git cliff --bumped-version --include-path 'lib/**' --include-path 'cli/**'
WARN git_cliff > There is nothing to bump
v4.0.0

$ git log --oneline v4.0.0..HEAD -- lib cli
(empty)
```

Which is correct — neither crate has changed since v4.0.0.

## Three changes

**Scope the bump and changelog to `lib/` and `cli/`.** The version now reflects the crates it's set on.

**Exit before opening a release PR when the bumped version equals the current one.** Without this the corrected calculation would keep reopening a PR that bumps nothing — and it's why #744 can't just be closed today: the next run recreates it. With this, closing it sticks.

**Publish `clap_usage` when its manifest is ahead of crates.io.** The publish path only ever ran:

```bash
cargo publish -p usage-lib
cargo publish -p usage-cli
```

`clap_usage` isn't there, which is why it sat unpublished at **2.0.3 from 2025-01 until now** while the workspace built against a far newer version — and why the trusted-publisher config for it has never been exercised. Its version stays hand-managed, so the check is against the crates.io index rather than the usage-lib tag, and it publishes in dependency order (`usage-lib` → `clap_usage` → `usage-cli`).

`breaking_always_bump_major = true` is deliberately left alone. The policy is right; it was being applied to the wrong crates.

## Dry run

```
$ usage_dry_run=1 mise run release-plz
Releasing clap_usage 4.0.0
No usage-lib/usage-cli changes since v4.0.0; nothing to release
```

Exactly the two intended outcomes: `clap_usage` 4.0.0 finally ships, and no spurious v5.

## After merging

The next release-plz run will not recreate #744, so it can be closed. `clap_usage` 4.0.0 publishes through trusted publishing on that run.

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release tagging, changelog generation, and crates.io publish order; mistakes could skip needed releases or publish the wrong crate version.
> 
> **Overview**
> Fixes **release automation** so breaking `clap_usage` commits no longer force a major bump on `usage-lib` / `usage-cli` when those crates did not change.
> 
> **Version and changelog** from `git cliff` are now limited to `lib/**` and `cli/**`, matching where `cargo set-version` applies. If the bumped version equals the current `usage-lib` version, the script **exits without opening a release PR**, so empty v5-style bumps stop recurring.
> 
> Adds **`publish_clap_usage_if_needed`**: compares the manifest version to crates.io and publishes `clap_usage` after `usage-lib` (and again on the tag path when the workspace is already released), since that crate was previously never published by this script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cee8990ef904a384be15e0de46507f49e68ccd32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->