### PR TITLE
perf: track instruction counts, and gate pull requests on them

### DIFF
--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -1,0 +1,157 @@
+name: perf-pr
+
+# Measures this pull request and compares it against the commit it branched
+# from, then says so in a comment and fails if an instruction count rose beyond
+# the gate.
+#
+# The gate is the point. A chart on a dashboard is something nobody opens; a
+# failing check on the pull request that caused the regression is read by the
+# person who can still do something about it.
+#
+# Nothing here writes to refs/notes/tak. A pull request's measurements are
+# recorded locally, used for the comparison, and discarded with the runner. Only
+# main contributes to the history — a branch's numbers are not the trunk's, and
+# a series that mixes them cannot be read.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+
+jobs:
+  compare:
+    name: Compare instruction counts
+    if: github.event_name == 'pull_request'
+    # Same runner class as perf.yml and perf-backfill.yml. Absolute counts shift
+    # between machine types by more than a real regression does, so a comparison
+    # across runner classes is not a comparison — tak refuses to make one, and
+    # the report would say "nothing was compared" instead of anything useful.
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    permissions:
+      contents: read
+      pull-requests: write # the sticky comment
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # The branch commit, not the merge commit actions/checkout defaults to
+          # for a pull_request event. That default is synthetic: it exists only
+          # for the run, changes whenever main advances, and measuring it would
+          # attribute a number to a commit nobody can check out. It would also
+          # make the footer below name a commit the measurement is not of.
+          ref: ${{ github.event.pull_request.head.sha }}
+          # Needed twice over: to find the merge base, and for the sparkline,
+          # which walks twenty commits of trunk history.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          cache: false
+        env:
+          MISE_LOCKED: "1"
+
+      - name: Install valgrind
+        run: |
+          command -v valgrind || {
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends valgrind
+          }
+          valgrind --version
+
+      # `--record` writes a git note locally and nothing more. There is no
+      # `tak push` in this workflow and there should never be one.
+      - name: Measure this pull request
+        run: mise run perf:record
+
+      - name: Find the base commit
+        id: base
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git fetch --quiet origin "$BASE_REF"
+          # The merge base, not the branch tip: comparing against a moving
+          # target attributes other people's commits to this pull request.
+          base=$(git merge-base "origin/$BASE_REF" HEAD)
+          echo "sha=$base" >> "$GITHUB_OUTPUT"
+          echo "comparing against $base on $BASE_REF"
+
+      # Deliberately not `continue-on-error`. That would hide a compare that
+      # died for an unrelated reason behind a green check. The exit code is
+      # captured, the comment is posted either way, and a later step re-raises
+      # it — so a regression always arrives with the table that explains it.
+      - name: Compare against the base
+        env:
+          BASE_SHA: ${{ steps.base.outputs.sha }}
+        run: |
+          set +e
+          tak compare "$BASE_SHA" > /tmp/tak-report.md
+          echo $? > /tmp/tak-gate-status
+          set -e
+          cat /tmp/tak-report.md
+          cat /tmp/tak-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      # Skipped for pull requests from forks, which get a read-only token. The
+      # comparison and the gate still run there; only the comment is missing.
+      - name: Comment on the pull request
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ steps.base.outputs.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          marker='<!-- usage-perf-pr -->'
+          # The backticks below are markdown, not command substitution, and
+          # single quotes are what keeps them literal.
+          # shellcheck disable=SC2016
+          {
+            printf '%s\n' "$marker"
+            printf '### Instruction counts\n\n'
+            cat /tmp/tak-report.md
+            printf '\n<sub>`%s` vs `%s` · measured on this runner, not pushed to the history.</sub>\n' \
+              "${HEAD_SHA:0:12}" "${BASE_SHA:0:12}"
+          } > /tmp/tak-comment.md
+
+          # One comment per pull request, edited in place. A new comment on
+          # every push buries the conversation under numbers.
+          existing="$(gh api "repos/$GH_REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq ".[] | select(.body | contains(\"$marker\")) | .id" | tail -n1)"
+          if [ -n "$existing" ]; then
+            gh api --method PATCH "repos/$GH_REPO/issues/comments/$existing" \
+              --field body="$(cat /tmp/tak-comment.md)"
+          else
+            gh api --method POST "repos/$GH_REPO/issues/$PR_NUMBER/comments" \
+              --field body="$(cat /tmp/tak-comment.md)"
+          fi
+
+      # `always()` because a step that fails stops the ones after it, and the
+      # gate is the reason this workflow exists. Without it, a `gh api` hiccup
+      # in the comment step would skip the gate entirely: the job would still go
+      # red, but for the wrong reason and with no regression error to read.
+      - name: Fail on a regression
+        if: always()
+        run: |
+          if [ ! -f /tmp/tak-gate-status ]; then
+            echo "::error::the comparison never ran — nothing was gated"
+            exit 1
+          fi
+          status=$(cat /tmp/tak-gate-status)
+          if [ "$status" -ne 0 ]; then
+            echo "::error::an instruction count rose beyond the gate — see the table in the comment or the job summary"
+            exit "$status"
+          fi

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,89 @@
+name: perf
+
+# Records usage's startup cost for every commit that lands on main, into the
+# git-notes ref `refs/notes/tak`. The data lives in this repository — there is
+# no external service holding it, and `git fetch origin refs/notes/tak:refs/notes/tak`
+# gets you the whole history.
+#
+# Only runs post-merge. A PR-time gate is the eventual goal, but a gate needs a
+# baseline series to compare against, and right now there is none. This builds
+# that baseline.
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions: {}
+
+# Never two at once. Concurrent runs race the notes push; tak retries with a
+# cat_sort_uniq merge so nothing is lost, but serialising avoids the churn.
+# cancel-in-progress is off deliberately: every commit gets a measurement, and
+# a cancelled run is a hole in the series.
+concurrency:
+  group: perf
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+
+jobs:
+  measure:
+    name: Measure
+    # Pinned to one runner class on purpose. Absolute instruction counts shift
+    # between machine types by more than a real regression does, so a series
+    # that wanders between runners is unreadable.
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write # pushing refs/notes/tak is a write to this repository
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          cache: false
+        env:
+          MISE_LOCKED: "1"
+
+      # cachegrind is the whole point: it counts instructions, which reproduce
+      # to ~0.02% run-to-run where wall clock on this same hardware moves by
+      # 4-20%. Without it tak still records timing, but the series stops being
+      # precise enough to detect anything.
+      - name: Install valgrind
+        run: |
+          command -v valgrind || {
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends valgrind
+          }
+          valgrind --version
+
+      - name: Measure and record
+        run: mise run perf:record
+
+      # persist-credentials: false means the push needs its own auth. Same
+      # pattern as bench-refresh.yml: re-point origin rather than pushing to a
+      # one-shot URL, so tak's retry path has a remote to fetch from when it
+      # loses a race.
+      #
+      # Only main publishes. workflow_dispatch can be pointed at any branch or
+      # tag, and refs/notes/tak is a shared baseline that should hold main's
+      # history and nothing else. Gating the push rather than the whole job
+      # means a dispatch on a branch still measures and still prints its
+      # numbers in the summary — it just keeps them local.
+      - name: Push measurements
+        if: github.ref == 'refs/heads/main'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
+          tak push
+
+      - name: Summary
+        run: tak history >> "$GITHUB_STEP_SUMMARY"

--- a/mise.lock
+++ b/mise.lock
@@ -329,6 +329,46 @@ checksum = "sha256:b36c0d3b8bd64ff78bfe6904525c5f7d8eafe56a5cd45b0d94793d8072500
 url = "https://github.com/crate-ci/cargo-release/releases/download/v1.1.2/cargo-release-v1.1.2-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/crate-ci/cargo-release/releases/assets/380570010"
 
+[[tools."github:jdx/tak"]]
+version = "0.0.4"
+backend = "github:jdx/tak"
+
+[tools."github:jdx/tak"."platforms.linux-arm64"]
+checksum = "sha256:76361a7d8820c9b955b7393d960e5e3744816d020904bd142ca9103cc70616d5"
+url = "https://github.com/jdx/tak/releases/download/v0.0.4/tak-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/490853625"
+provenance = "github-attestations"
+
+[tools."github:jdx/tak"."platforms.linux-arm64-musl"]
+checksum = "sha256:8a171779ea86d82c327dc407f8330d98da593751982c718bed3d5aca2c2bb958"
+url = "https://github.com/jdx/tak/releases/download/v0.0.4/tak-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/490853627"
+provenance = "github-attestations"
+
+[tools."github:jdx/tak"."platforms.linux-x64"]
+checksum = "sha256:4d5a6c20c4c088f9771f5ba3f138b9e336a53a37b6d59b1dda1d4291294ed4db"
+url = "https://github.com/jdx/tak/releases/download/v0.0.4/tak-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/490853634"
+provenance = "github-attestations"
+
+[tools."github:jdx/tak"."platforms.linux-x64-musl"]
+checksum = "sha256:c2bc482ff5010b084e50ad9d6435ca988a743b8303519a38a3801cf1f82ae8b1"
+url = "https://github.com/jdx/tak/releases/download/v0.0.4/tak-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/490853633"
+provenance = "github-attestations"
+
+[tools."github:jdx/tak"."platforms.macos-arm64"]
+checksum = "sha256:3bf2c09c461ed4db66f58e9d6ce31400e9d57cfe8132c104ca56313b881bd300"
+url = "https://github.com/jdx/tak/releases/download/v0.0.4/tak-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/490853626"
+provenance = "github-attestations"
+
+[tools."github:jdx/tak"."platforms.windows-x64"]
+checksum = "sha256:e6669edcde51625a637a7d3f90b26f3737ca113f8188f6e0f6872b421f51e49e"
+url = "https://github.com/jdx/tak/releases/download/v0.0.4/tak-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/tak/releases/assets/490853632"
+provenance = "github-attestations"
+
 [[tools."github:obi1kenobi/cargo-semver-checks"]]
 version = "0.48.0"
 backend = "github:obi1kenobi/cargo-semver-checks"

--- a/mise.toml
+++ b/mise.toml
@@ -3,6 +3,10 @@ CARGO_TERM_COLOR = 'always'
 _.path = ["./target/debug"]
 
 [tools]
+# Pinned rather than "latest" because tak is the measuring instrument: an
+# upgrade that changes how it samples would land in the series as a step change
+# in usage's numbers, indistinguishable from a real regression. Bump deliberately.
+"github:jdx/tak" = "0.0.4"
 actionlint = "latest"
 aube = "latest"
 communique = "latest"
@@ -127,3 +131,17 @@ includes = ['tasks']
 
 [tasks.install-dev]
 run = "cargo install --path cli --debug"
+
+# Instruction-counted benchmarks (see tak.toml). Needs valgrind for the counts;
+# without it tak reports wall clock only and says so, so this still works on
+# macOS where there is no usable cachegrind.
+[tasks.perf]
+dir = "{{config_root}}"
+run = ["cargo build --release", "tak run"]
+
+# Same measurement, appended to refs/notes/tak for this commit. Run by the
+# `perf` workflow on every push to main; the notes are the history. Safe to run
+# locally — nothing leaves the machine until `tak push`.
+[tasks."perf:record"]
+dir = "{{config_root}}"
+run = ["cargo build --release", "tak run --record"]

--- a/tak.toml
+++ b/tak.toml
@@ -1,0 +1,28 @@
+# Instruction-counted benchmarks, measured by tak (https://github.com/jdx/tak).
+#
+# usage is the one tool here whose real work is a pure function: read a KDL
+# spec, generate output. That makes it the most representative subject of the
+# family — no network, no state, and the thing being measured is what the tool
+# is for. Hermeticity was checked with the proxy pointed at a dead port.
+#
+# `--version` is deliberately absent. It measures clap rather than usage.
+
+# The fixed cost of any invocation. Reading the generators against this
+# separates "usage got slower to start" from "generation got slower".
+[bench.startup]
+cmd = ["./target/release/usage", "--help"]
+
+# Generate the docs for usage's own committed spec: parse ~10KB of KDL, walk the
+# command tree, render markdown. This is the hot path for every project that
+# runs `usage g` in its docs build.
+[bench.markdown]
+cmd = [
+  "./target/release/usage",
+  "g",
+  "markdown",
+  "-mf",
+  "cli/usage.usage.kdl",
+  "--out-dir",
+  "/tmp/tak-usage-docs",
+]
+runs = 10


### PR DESCRIPTION
Adds [tak](https://github.com/jdx/tak) — the same setup now running in [jdx/aube](https://github.com/jdx/aube) and [jdx/hk](https://github.com/jdx/hk/pull/1125). Every push to main records instruction counts into `refs/notes/tak`; every pull request is compared against the commit it branched from and **fails if a count rose beyond 1%**.

## Why instruction counts

They reproduce to ~0.02% run to run. Wall clock on identical hardware moves 4-20%, so it is reported beside them and never gated.

aube's first real run, on a pull request that changed **one YAML file and no Rust**:

```
instructions   +0.02%  -0.01%  -0.01%  -0.01%
wall clock    -30.21% -19.17% -10.39% -17.89%
```

A wall-clock gate would have called that a 30% win.

## The subjects

`usage --help` and `usage g markdown on its own committed spec` — both pure CPU over usage's own definitions, no network and no state.

**Checked, not assumed:** both run unchanged with the proxy pointed at a dead port, and both outputs are byte-identical across runs. Verified here against a real release build.

`--version` is deliberately absent — it measures clap rather than usage, and in aube's case it turned out to check for updates, which makes the count depend on the network.

usage is the one tool here whose real work is a pure function — read a KDL spec, generate output — which makes it the most representative subject of the family.

## What lands

- **`tak.toml`** — the benchmarks.
- **`.github/workflows/perf.yml`** — records on push to main, pushes the notes.
- **`.github/workflows/perf-pr.yml`** — measures the PR, comments the table, fails on a regression.
- **`mise.toml` / `mise.lock`** — `github:jdx/tak` pinned to `0.0.4`, plus `perf` and `perf:record` tasks.

Pinned rather than `latest` because tak is the measuring instrument: an upgrade that changes how it samples would land as a step change indistinguishable from a real regression.

## Notes

- **Nothing in the PR workflow writes to `refs/notes/tak`.** A branch's measurements are recorded locally and discarded with the runner. Only main contributes to the history.
- The gate has nothing to compare against until `perf.yml` has recorded on main a few times. Until then tak says "nothing was compared, and so nothing was gated" and passes — visible rather than a silent green.
- actionlint and zizmor at `--persona=pedantic` are clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI, benchmark config, and dev tooling; no application runtime or auth/data paths are modified.
> 
> **Overview**
> Adds **instruction-count performance tracking** with [tak](https://github.com/jdx/tak), using valgrind/cachegrind on `ubuntu-latest` so regressions are gated on stable counts rather than noisy wall clock.
> 
> **`tak.toml`** defines two hermetic benches: `usage --help` (startup) and `usage g markdown` on the repo’s own KDL spec (docs-generation hot path).
> 
> **`.github/workflows/perf.yml`** runs on every push to `main`, records via `mise run perf:record`, and pushes measurements to `refs/notes/tak` (serial concurrency, main-only publish).
> 
> **`.github/workflows/perf-pr.yml`** measures the PR head (not the merge commit), compares against the merge base with `tak compare`, posts/updates a sticky PR comment, and **fails the check** when instruction counts exceed the gate. PR workflows do not push notes.
> 
> **`mise.toml` / `mise.lock`** pin `github:jdx/tak` at `0.0.4` and add `perf` / `perf:record` tasks (release build + `tak run`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c12dc81914efe657ed6cfb9ebc46d67a4791bf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->