### PR TITLE
perf: split measuring from reporting, and drop the dead dispatch trigger

### DIFF
--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -16,7 +16,6 @@ name: perf-pr
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -30,9 +29,8 @@ env:
   CARGO_INCREMENTAL: "0"
 
 jobs:
-  compare:
+  measure:
     name: Compare instruction counts
-    if: github.event_name == 'pull_request'
     # Same runner class as perf.yml and perf-backfill.yml. Absolute counts shift
     # between machine types by more than a real regression does, so a comparison
     # across runner classes is not a comparison — tak refuses to make one, and
@@ -40,8 +38,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     permissions:
+      # Read only. This job builds and runs code from the pull request, so it
+      # must not hold a token that can write anything — see the `report` job.
       contents: read
-      pull-requests: write # the sticky comment
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -104,54 +103,91 @@ jobs:
           cat /tmp/tak-report.md
           cat /tmp/tak-report.md >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Package the report
+        if: always()
+        env:
+          BASE_SHA: ${{ steps.base.outputs.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          mkdir -p /tmp/tak-out
+          # A missing report means an earlier step died. Say so, rather than
+          # letting the reporting job find nothing and infer a pass.
+          if [ -f /tmp/tak-report.md ]; then
+            cp /tmp/tak-report.md /tmp/tak-out/report.md
+          else
+            echo "The comparison never ran — an earlier step failed." > /tmp/tak-out/report.md
+          fi
+          cat /tmp/tak-gate-status 2>/dev/null > /tmp/tak-out/status || echo 1 > /tmp/tak-out/status
+          printf '%s %s\n' "${HEAD_SHA:0:12}" "${BASE_SHA:0:12}" > /tmp/tak-out/shas
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: always()
+        with:
+          name: tak-report
+          path: /tmp/tak-out
+          retention-days: 1
+          if-no-files-found: error
+
+  # A separate job so the write token is never in scope while code from the
+  # pull request is executing. This one checks out nothing and runs no project
+  # code: it reads an artifact and talks to the API.
+  report:
+    name: Report and gate
+    needs: measure
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pull-requests: write # the sticky comment, and nothing else
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: tak-report
+          path: /tmp/tak-out
+
       # Skipped for pull requests from forks, which get a read-only token. The
       # comparison and the gate still run there; only the comment is missing.
       - name: Comment on the pull request
         if: github.event.pull_request.head.repo.full_name == github.repository
         env:
           GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
+          GH_usage: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          BASE_SHA: ${{ steps.base.outputs.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           marker='<!-- usage-perf-pr -->'
+          read -r head_sha base_sha < /tmp/tak-out/shas
           # The backticks below are markdown, not command substitution, and
           # single quotes are what keeps them literal.
           # shellcheck disable=SC2016
           {
             printf '%s\n' "$marker"
             printf '### Instruction counts\n\n'
-            cat /tmp/tak-report.md
-            printf '\n<sub>`%s` vs `%s` · measured on this runner, not pushed to the history.</sub>\n' \
-              "${HEAD_SHA:0:12}" "${BASE_SHA:0:12}"
+            cat /tmp/tak-out/report.md
+            printf '\n<sub>`%s` vs `%s` · measured on the runner, not pushed to the history.</sub>\n' \
+              "$head_sha" "$base_sha"
           } > /tmp/tak-comment.md
 
           # One comment per pull request, edited in place. A new comment on
           # every push buries the conversation under numbers.
-          existing="$(gh api "repos/$GH_REPO/issues/$PR_NUMBER/comments" --paginate \
+          existing="$(gh api "repos/$GH_usage/issues/$PR_NUMBER/comments" --paginate \
             --jq ".[] | select(.body | contains(\"$marker\")) | .id" | tail -n1)"
           if [ -n "$existing" ]; then
-            gh api --method PATCH "repos/$GH_REPO/issues/comments/$existing" \
+            gh api --method PATCH "repos/$GH_usage/issues/comments/$existing" \
               --field body="$(cat /tmp/tak-comment.md)"
           else
-            gh api --method POST "repos/$GH_REPO/issues/$PR_NUMBER/comments" \
+            gh api --method POST "repos/$GH_usage/issues/$PR_NUMBER/comments" \
               --field body="$(cat /tmp/tak-comment.md)"
           fi
 
-      # `always()` because a step that fails stops the ones after it, and the
-      # gate is the reason this workflow exists. Without it, a `gh api` hiccup
-      # in the comment step would skip the gate entirely: the job would still go
-      # red, but for the wrong reason and with no regression error to read.
+      # `always()` on both this step and the job: a failed step stops the ones
+      # after it, and the gate is the reason this workflow exists. Without it a
+      # `gh api` hiccup would skip the gate — red for the wrong reason, and with
+      # no regression error to read.
       - name: Fail on a regression
         if: always()
         run: |
-          if [ ! -f /tmp/tak-gate-status ]; then
-            echo "::error::the comparison never ran — nothing was gated"
-            exit 1
-          fi
-          status=$(cat /tmp/tak-gate-status)
+          status=$(cat /tmp/tak-out/status)
           if [ "$status" -ne 0 ]; then
-            echo "::error::an instruction count rose beyond the gate — see the table in the comment or the job summary"
+            echo "::error::an instruction count rose beyond the gate — see the comment or the job summary"
             exit "$status"
           fi

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -117,7 +117,10 @@ jobs:
           else
             echo "The comparison never ran — an earlier step failed." > /tmp/tak-out/report.md
           fi
-          cat /tmp/tak-gate-status 2>/dev/null > /tmp/tak-out/status || echo 1 > /tmp/tak-out/status
+          # 2, not 1: a missing status means the comparison never ran, which is
+          # a different failure from a regression and must not be reported as
+          # one. The gate below maps them to different messages.
+          cp /tmp/tak-gate-status /tmp/tak-out/status 2>/dev/null || echo 2 > /tmp/tak-out/status
           printf '%s %s\n' "${HEAD_SHA:0:12}" "${BASE_SHA:0:12}" > /tmp/tak-out/shas
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -187,7 +190,14 @@ jobs:
         if: always()
         run: |
           status=$(cat /tmp/tak-out/status)
-          if [ "$status" -ne 0 ]; then
-            echo "::error::an instruction count rose beyond the gate — see the comment or the job summary"
-            exit "$status"
-          fi
+          case "$status" in
+            0) ;;
+            2)
+              echo "::error::the comparison never ran — an earlier step failed, so nothing was gated"
+              exit 1
+              ;;
+            *)
+              echo "::error::an instruction count rose beyond the gate — see the comment or the job summary"
+              exit "$status"
+              ;;
+          esac


### PR DESCRIPTION
Two review findings from #748, which merged before I pushed the fixes.

**The measure job held `pull-requests: write` while running pull-request code.** A same-repo pull request could persist state through the runner environment files and reach a token able to write comments elsewhere in the repository. Measuring now runs with `contents: read` and hands its report over as an artifact; a second job holds the write token, checks out nothing, and runs no project code.

**`workflow_dispatch` was dead.** It was listed as a trigger while the only job required `github.event_name == 'pull_request'`, so a manual run skipped everything and reported success without measuring. Removed rather than made to work — there is no pull request to compare against on a manual run.

The gate survives both. A missing report is written out as an explicit failure rather than left for the reporting job to find nothing and infer a pass, and `always()` on the job and the step keeps a comment failure from skipping it.

zizmor at `--persona=pedantic` and actionlint are clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI-only change with a security win (write token isolated from PR code), but a probable `GH_usage` typo could break PR comments until corrected.
> 
> **Overview**
> **Splits `perf-pr` into `measure` and `report` jobs** so PR code runs only under `contents: read`; the sticky comment and regression gate move to a second job that downloads a `tak-report` artifact, never checks out the repo, and alone holds `pull-requests: write`.
> 
> The measure job **packages** report markdown, gate exit code (default **2** when compare never ran), and short SHAs, then **uploads** them. The report job posts the comment from the artifact and **fails the workflow** via a `case` on status (0 pass, 2 = earlier failure, other = regression).
> 
> **Removes** `workflow_dispatch` and the job guard that required `pull_request` (dispatch could succeed without measuring). Drops the redundant `if: github.event_name == 'pull_request'` on the measure job.
> 
> **Note:** the comment step renames `GH_REPO` to `GH_usage` in env and `gh api` paths — likely unintentional and would break API URLs unless fixed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da7492764bce0be8578b3dffa38a9a7a3307041b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated pull request performance checks to run automatically on pull request events (no manual dispatch).
  * Improved performance reporting by separating measurement and comment/reporting steps.
  * Added more reliable artifact packaging and status handling, even when comparison output is missing.
  * Automatically updates a single pull request comment with instruction-count results.
  * Workflow now fails when instruction counts exceed the configured threshold.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->