### PR TITLE
fix(parse): keep a re-declared global's aliases on one flag

### DIFF
--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -104,9 +104,9 @@ fn merge_subcommand_flags(
             }) {
                 continue;
             }
-            let merged = merged_cache
-                .entry(Arc::as_ptr(&flag) as usize)
-                .or_insert_with(|| {
+            let merged = match merged_cache.get(&(Arc::as_ptr(&flag) as usize)) {
+                Some(merged) => merged.clone(),
+                None => {
                     let mut merged = (*global_flag).clone();
                     for s in &flag.short {
                         if !merged.short.contains(s) {
@@ -118,10 +118,22 @@ fn merge_subcommand_flags(
                             merged.long.push(l.clone());
                         }
                     }
-                    Arc::new(merged)
-                })
-                .clone();
-            merged_origin.insert(Arc::as_ptr(&merged) as usize, global_origin);
+                    let merged = Arc::new(merged);
+                    merged_cache.insert(Arc::as_ptr(&flag) as usize, Arc::clone(&merged));
+                    merged_origin.insert(Arc::as_ptr(&merged) as usize, global_origin);
+                    // Rebind the global's *other* aliases onto the merged flag. The loop only
+                    // visits keys the child declared, so an alias the child left out (the `-y` of
+                    // a `-y --yes` global re-declared as just `--yes`) would otherwise keep
+                    // pointing at the pre-merge flag and miss the aliases just unioned in. One
+                    // logical flag must be one object under every key it answers to.
+                    for existing in available.values_mut() {
+                        if origin_of(&merged_origin, existing) == global_origin {
+                            *existing = Arc::clone(&merged);
+                        }
+                    }
+                    merged
+                }
+            };
             available.insert(key, merged);
             continue;
         }
@@ -2125,6 +2137,49 @@ cmd "run" {
         assert_eq!(
             parsed.available_flags["-y"].effect,
             Some(crate::SpecCommandEffect::Write),
+        );
+    }
+
+    #[test]
+    fn test_partially_redeclared_global_keeps_all_aliases_on_one_flag() {
+        // Same one-flag-one-object requirement as above, but the child re-declares only ONE of
+        // the global's three aliases (`--yes`, not `-y`/`--confirm`) while adding a new one. The
+        // aliases the child omits are never visited by the merge loop, so they must be rebound to
+        // the merged flag explicitly — otherwise `-y` and `--confirm` keep pointing at the
+        // pre-merge global and miss the added `assume-yes`.
+        let spec = r#"
+flag "-y --yes --confirm" global=#true
+cmd "run" {
+    flag "--yes --assume-yes"
+}
+"#
+        .parse::<Spec>()
+        .unwrap();
+
+        let parsed = parse_partial(&spec, &input(&["test", "run"])).unwrap();
+
+        for key in ["-y", "--yes", "--confirm", "--assume-yes"] {
+            let flag = parsed
+                .available_flags
+                .get(key)
+                .unwrap_or_else(|| panic!("{key} must be recognized after the descent"));
+            assert!(flag.global, "{key} must stay global after the descent");
+            assert_eq!(
+                flag.long,
+                vec![
+                    "yes".to_string(),
+                    "confirm".to_string(),
+                    "assume-yes".to_string()
+                ],
+                "{key} must resolve to the flag carrying every alias",
+            );
+        }
+
+        assert_eq!(
+            unique_flags(parsed.available_flags.values()).count(),
+            1,
+            "all aliases must point at one flag object, got {:?}",
+            parsed.available_flags,
         );
     }
 

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -53,6 +53,15 @@ fn merge_subcommand_flags(
     // Cache the merged (global ∪ orphan-alias) flag per re-declared child so every alias key of
     // that flag ends up sharing one `Arc`. Keyed by the child `Arc`'s identity.
     let mut merged_cache: HashMap<usize, Arc<SpecFlag>> = HashMap::new();
+    // Maps each merged flag produced below back to the inherited global it was merged from, so
+    // the collision check can compare *origins*: a flag this loop already merged is not a
+    // different global, even though it is a different `Arc`.
+    let mut merged_origin: HashMap<usize, usize> = HashMap::new();
+    // The inherited global a flag stands for: itself, or — for a merged flag — its source global.
+    fn origin_of(merged_origin: &HashMap<usize, usize>, flag: &Arc<SpecFlag>) -> usize {
+        let ptr = Arc::as_ptr(flag) as usize;
+        *merged_origin.get(&ptr).unwrap_or(&ptr)
+    }
 
     // Iterate the *flattened* child map directly (one entry per alias key). This preserves the
     // map's existing intra-subcommand collision resolution: when two flags in the same command
@@ -84,10 +93,15 @@ fn merge_subcommand_flags(
             // orphan alias (e.g. `-r`) is already owned by some other global (e.g. an unrelated
             // `-r --restrict`), that is a genuine collision: keep the existing global, as global
             // precedence dictates, instead of stealing the alias for the merged flag.
-            if available
-                .get(&key)
-                .is_some_and(|existing| existing.global && !Arc::ptr_eq(existing, &global_flag))
-            {
+            //
+            // Compare origins, not `Arc`s: when the global has several aliases of its own, an
+            // earlier key of this same child already replaced some of them with the merged flag,
+            // which the lookups above may now resolve to. That is the same logical flag, so it
+            // must not read as a collision and leave this key on the pre-merge global.
+            let global_origin = origin_of(&merged_origin, &global_flag);
+            if available.get(&key).is_some_and(|existing| {
+                existing.global && origin_of(&merged_origin, existing) != global_origin
+            }) {
                 continue;
             }
             let merged = merged_cache
@@ -107,6 +121,7 @@ fn merge_subcommand_flags(
                     Arc::new(merged)
                 })
                 .clone();
+            merged_origin.insert(Arc::as_ptr(&merged) as usize, global_origin);
             available.insert(key, merged);
             continue;
         }
@@ -2063,6 +2078,54 @@ mod tests {
             .available_flags
             .get("--restrict")
             .is_some_and(|f| f.global));
+    }
+
+    #[test]
+    fn test_redeclared_global_aliases_share_one_flag() {
+        // A global declared with BOTH a short and a long, re-declared non-globally by a
+        // subcommand that adds a third alias. Every alias key must resolve to the SAME merged
+        // flag: the child's keys iterate in BTreeMap order (`--assume-yes`, `--yes`, `-y`), so by
+        // the time `-y` is reached the long already points at the merged flag. That merged flag is
+        // not a *different* inherited global, so the collision guard must not skip `-y` and leave
+        // it pointing at the pre-merge global (which lacks the added `assume-yes` alias).
+        let spec = r#"
+flag "-y --yes" global=#true effect="write"
+cmd "run" {
+    flag "-y --yes --assume-yes"
+}
+"#
+        .parse::<Spec>()
+        .unwrap();
+
+        let parsed = parse_partial(&spec, &input(&["test", "run"])).unwrap();
+
+        for key in ["-y", "--yes", "--assume-yes"] {
+            let flag = parsed
+                .available_flags
+                .get(key)
+                .unwrap_or_else(|| panic!("{key} must be recognized after the descent"));
+            assert!(flag.global, "{key} must stay global after the descent");
+            assert_eq!(
+                flag.long,
+                vec!["yes".to_string(), "assume-yes".to_string()],
+                "{key} must resolve to the flag carrying every alias",
+            );
+            assert_eq!(flag.short, vec!['y'], "{key} must keep the global's short");
+        }
+
+        // One logical flag means one object: all three keys share a single `Arc`.
+        assert_eq!(
+            unique_flags(parsed.available_flags.values()).count(),
+            1,
+            "all aliases must point at one flag object, got {:?}",
+            parsed.available_flags,
+        );
+
+        // The global's effect survives the merge, so `-y` still marks the command as writing.
+        assert_eq!(
+            parsed.available_flags["-y"].effect,
+            Some(crate::SpecCommandEffect::Write),
+        );
     }
 
     /// Build a spec shaped like mise's post-mount structure for jdx/mise#11282: a root with


### PR DESCRIPTION
## What

`merge_subcommand_flags` in [`lib/src/parse.rs`](https://github.com/jdx/usage/blob/main/lib/src/parse.rs) could leave one logical flag registered under two different `Arc<SpecFlag>`s in `available_flags`. The collision guard now compares flag *origins* instead of `Arc` identity.

## Why

Reproduction: a global declared with both a short and a long (`flag "-y --yes" global=#true`), re-declared non-globally by a subcommand (`flag "-y --yes"`).

The child's flag keys iterate in `BTreeMap` order, so `--yes` comes before `-y`:

1. Key `--yes`: `inherited_global` resolves to the original global `A`. `available["--yes"]` is also `A`, so `Arc::ptr_eq` holds and the skip guard doesn't fire. A merged flag `M` is built and inserted at `--yes`.
2. Key `-y`: `inherited_global` now resolves via `available["--yes"]`, which is `M`. The guard checks `available["-y"]` — still `A` — and `A.global && !Arc::ptr_eq(A, M)` is true, so it `continue`s. The `-y` key keeps pointing at the pre-merge `A`.

The guard's stated intent is "never clobber a *different* inherited global's alias", but `M` isn't a different global — it was derived from `A` in this same loop, so the identity comparison misfires.

Impact is mild but real. Parsing itself still works because lookups are by key, so this only shows up in code that reads the flag *objects* rather than the keys. When the re-declaration adds a third alias (global `-y --yes`, child `-y --yes --assume-yes`), the flag reachable via `-y` is missing `assume-yes` from its `long` list.

## How

Track which inherited global each merged flag was derived from (`merged_origin`), and resolve a flag to its origin — itself, or for a merged flag its source global — before comparing. The guard now skips only when the existing key's origin differs from the incoming global's origin, so a flag this loop just merged is no longer mistaken for a colliding global.

Chained merges are handled too: a new merged flag inherits `global_origin` rather than pointing at its immediate base, so if the global has further aliases still to be processed they all resolve back to the same origin.

## Reviewer notes

- New test `test_redeclared_global_aliases_share_one_flag` covers the three-alias case and asserts all three keys resolve to a flag whose `long` contains every alias, that `unique_flags` sees exactly one object, and that the global's `effect="write"` survives the merge. Confirmed it fails on the pre-fix code with exactly the reported symptom (`-y` → `long: ["yes"]`) and passes after.
- The genuine-collision behavior is unchanged and still covered by the existing `test_orphan_short_does_not_clobber_unrelated_global`: an unrelated global (`-r --restrict`) keeps its alias, as global precedence dictates.
- 296 `usage-lib` tests pass; `cargo clippy --all --all-features -- -D warnings` and `cargo fmt --all --check` are clean. Two failures in `usage-cli --test examples` (`test_usage_double_slash_execution{,_old}`) are pre-existing and environmental — they fail identically on clean `main`.
- Follow-up, not in this PR: `usage::available_flags` on `feat/usage-mcp` (#746) works around this by collapsing duplicates by name after the pointer dedup. That branch isn't an ancestor of `main`, so I left it alone; its workaround can be simplified when it next rebases onto this fix.

_This PR was generated by Claude Code._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subcommand descent flag-merging in the parser (`available_flags`), which affects completions and metadata on flag objects; behavior is narrow and covered by new tests, with existing collision tests unchanged.
> 
> **Overview**
> Fixes **`merge_subcommand_flags`** so a subcommand that re-declares an inherited global no longer leaves different alias keys (`-y`, `--yes`, etc.) pointing at different `Arc<SpecFlag>` objects with inconsistent merged metadata.
> 
> The collision guard now compares **flag origins** (via `merged_origin` / `origin_of`) instead of `Arc` pointer identity, so a merged flag from an earlier loop iteration is not treated as a competing global. On the first merge for a child re-declaration, **all existing map entries** for that global’s aliases are rebound to the single merged flag—covering cases where the child only re-declares a subset of the global’s aliases.
> 
> Adds regression tests for full and partial re-declaration; unrelated global short collisions are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae7be7f1c8708279c93a26446174a053a231ed6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed alias handling for inherited global options when subcommands redefine those options.
  * Ensured all aliases consistently resolve to one option and preserve the complete alias set.
  * Corrected behavior when a subcommand adds a new alias or omits an existing alias during redefinition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->