### PR TITLE
fix: complete repeated variadic args

### DIFF
--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -12,6 +12,7 @@ use std::sync::LazyLock;
 use xx::process::check_status;
 use xx::{regex, XXError, XXResult};
 
+use usage::parse::{ParseOutput, ParseValue};
 use usage::{Spec, SpecArg, SpecCommand, SpecComplete, SpecFlag};
 
 use crate::cli::generate;
@@ -143,7 +144,7 @@ impl CompleteWord {
             self.complete_arg(&ctx, spec, &parsed.cmd, arg, &ctoken)?
         } else {
             let mut choices = vec![];
-            if let Some(arg) = parsed.cmd.args.get(parsed.args.len()) {
+            if let Some(arg) = next_arg_for_completion(&parsed) {
                 has_explicit_choices = arg.choices.is_some();
                 choices.extend(self.complete_arg(&ctx, spec, &parsed.cmd, arg, &ctoken)?);
             }
@@ -372,6 +373,22 @@ impl CompleteWord {
             .sorted()
             .collect()
     }
+}
+
+fn next_arg_for_completion(parsed: &ParseOutput) -> Option<&SpecArg> {
+    parsed.cmd.args.iter().find(|arg| {
+        let parsed_value = parsed.args.iter().find_map(|(parsed_arg, value)| {
+            (parsed_arg.name == arg.name).then_some(value)
+        });
+
+        match parsed_value {
+            Some(ParseValue::MultiString(values)) if arg.var => {
+                values.len() < arg.var_max.unwrap_or(usize::MAX)
+            }
+            Some(_) => false,
+            None => true,
+        }
+    })
 }
 
 /// Wrap a completion value in single quotes if any character would otherwise

--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -377,9 +377,10 @@ impl CompleteWord {
 
 fn next_arg_for_completion(parsed: &ParseOutput) -> Option<&SpecArg> {
     parsed.cmd.args.iter().find(|arg| {
-        let parsed_value = parsed.args.iter().find_map(|(parsed_arg, value)| {
-            (parsed_arg.name == arg.name).then_some(value)
-        });
+        let parsed_value = parsed
+            .args
+            .iter()
+            .find_map(|(parsed_arg, value)| (parsed_arg.name == arg.name).then_some(value));
 
         match parsed_value {
             Some(ParseValue::MultiString(values)) if arg.var => {

--- a/cli/tests/complete_word.rs
+++ b/cli/tests/complete_word.rs
@@ -17,18 +17,22 @@ fn complete_word_completer() {
 
 #[test]
 fn complete_word_variadic_arg_reuses_completer() {
-    assert_cmd("variadic-completion.usage.kdl", &["--", "variadic", ""])
-        .stdout("foo\nbar\n");
-    assert_cmd("variadic-completion.usage.kdl", &["--", "variadic", "foo", ""])
-        .stdout("foo\nbar\n");
+    assert_cmd("variadic-completion.usage.kdl", &["--", "variadic", ""]).stdout("foo\nbar\n");
+    assert_cmd(
+        "variadic-completion.usage.kdl",
+        &["--", "variadic", "foo", ""],
+    )
+    .stdout("foo\nbar\n");
 }
 
 #[test]
 fn complete_word_variadic_arg_respects_var_max() {
-    assert_cmd("variadic-completion.usage.kdl", &["--", "bounded", ""])
-        .stdout("foo\nbar\n");
-    assert_cmd("variadic-completion.usage.kdl", &["--", "bounded", "foo", ""])
-        .stdout("foo\nbar\n");
+    assert_cmd("variadic-completion.usage.kdl", &["--", "bounded", ""]).stdout("foo\nbar\n");
+    assert_cmd(
+        "variadic-completion.usage.kdl",
+        &["--", "bounded", "foo", ""],
+    )
+    .stdout("foo\nbar\n");
     assert_cmd(
         "variadic-completion.usage.kdl",
         &["--", "bounded", "foo", "bar", ""],

--- a/cli/tests/complete_word.rs
+++ b/cli/tests/complete_word.rs
@@ -16,6 +16,27 @@ fn complete_word_completer() {
 }
 
 #[test]
+fn complete_word_variadic_arg_reuses_completer() {
+    assert_cmd("variadic-completion.usage.kdl", &["--", "variadic", ""])
+        .stdout("foo\nbar\n");
+    assert_cmd("variadic-completion.usage.kdl", &["--", "variadic", "foo", ""])
+        .stdout("foo\nbar\n");
+}
+
+#[test]
+fn complete_word_variadic_arg_respects_var_max() {
+    assert_cmd("variadic-completion.usage.kdl", &["--", "bounded", ""])
+        .stdout("foo\nbar\n");
+    assert_cmd("variadic-completion.usage.kdl", &["--", "bounded", "foo", ""])
+        .stdout("foo\nbar\n");
+    assert_cmd(
+        "variadic-completion.usage.kdl",
+        &["--", "bounded", "foo", "bar", ""],
+    )
+    .stdout(contains("Cargo.toml"));
+}
+
+#[test]
 fn complete_word_subcommands() {
     assert_cmd("basic.usage.kdl", &["plugins", "install"]).stdout(contains("install"));
 }

--- a/examples/variadic-completion.usage.kdl
+++ b/examples/variadic-completion.usage.kdl
@@ -1,0 +1,9 @@
+cmd variadic {
+    arg "[ITEM]…" var=#true required=#false
+}
+
+cmd bounded {
+    arg "[ITEM]…" var=#true var_max=2 required=#false
+}
+
+complete "item" run="printf 'foo\nbar\n'"


### PR DESCRIPTION
## Summary

This fixes completions for repeated variadic positional arguments after the first value has already been entered.

`complete-word` used the number of parsed positional entries to decide which positional argument to complete next.
That works for normal positionals, but not for variadic args as all values for the repeated args are stored under single positional entry. After typing one value, the arg was incorrectly marked done and fell back to file completions.

The fix checks the parsed value for each positional arg instead. If the arg is variadic and has not reached `var_max`, it keeps using the same arg's completer. If `var_max` is reached, it moves on and normal fallback behavior applies.

Also added regression tests for the same.

## Related

- https://github.com/jdx/usage/discussions/458
- https://github.com/jdx/mise/discussions/4774
- https://github.com/jdx/mise/discussions/11393

## Validation

- `mise run test -- complete_word_variadic`
- `mise run test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI completion for variadic arguments.
  * Bounded variadic arguments now stop completing after reaching their maximum allowed items.
  * Completion correctly advances to subsequent arguments or file completion when appropriate.

* **Tests**
  * Added regression coverage for repeated and bounded variadic argument completion.

* **Documentation**
  * Added an example configuration demonstrating variadic and bounded argument completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->