### PR TITLE
chore: release v5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 # Changelog
 
-## [4.1.0](https://github.com/jdx/usage/compare/v4.0.0..v4.1.0) - 2026-07-28
+## [5.0.0](https://github.com/jdx/usage/compare/v4.1.0..v5.0.0) - 2026-08-02
+
+### 🚀 Features
+
+- **(cli)** allow overriding the shell program with USAGE_SHELL_<SHELL> by [@JamBalaya56562](https://github.com/JamBalaya56562) in [#767](https://github.com/jdx/usage/pull/767)
+
+### 🐛 Bug Fixes
+
+- **(cli)** forward parsed args to WSL bash via WSLENV on windows by [@JamBalaya56562](https://github.com/JamBalaya56562) in [#764](https://github.com/jdx/usage/pull/764)
+- **(cli)** let generate markdown write to stdout by [@JamBalaya56562](https://github.com/JamBalaya56562) in [#766](https://github.com/jdx/usage/pull/766)
+- **(complete)** use `type -P` so the CLI-presence guard ignores shell functions by [@JamBalaya56562](https://github.com/JamBalaya56562) in [#760](https://github.com/jdx/usage/pull/760)
+- **(parse)** enforce double_dash="required" for positional args by [@JamBalaya56562](https://github.com/JamBalaya56562) in [#762](https://github.com/jdx/usage/pull/762)
+- **(windows)** run `run=` scripts with sh when available by [@JamBalaya56562](https://github.com/JamBalaya56562) in [#765](https://github.com/jdx/usage/pull/765)
+
+### 🎨 Styling
+
+- fix clippy and deprecation warnings in test and bench targets by [@JamBalaya56562](https://github.com/JamBalaya56562) in [#763](https://github.com/jdx/usage/pull/763)
+
+## [4.1.0](https://github.com/jdx/usage/compare/v4.0.0..v4.1.0) - 2026-07-30
 
 ### 🚀 Features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -306,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -443,9 +443,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "ctor"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9bb72bb94fdc1bd619f4c18cc91ecf6302aeb333d31b3c6ec0bb841cd920209"
+checksum = "2d83cb7e7a873830708d6b02a78cd36a592c6fa14bf267b68725103b85c0d77f"
 dependencies = [
  "link-section",
  "linktime-proc-macro",
@@ -1000,15 +1000,15 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "link-section"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc98458dfe90986c5e2f6ddcf68360c7e5c4252600153e06aa4ee8176c0f8d1"
+checksum = "5ee1a0d6e252afe82e7bc2db42fba60e02ddf3b1accaf8cb21d96e34ba61f3d4"
 
 [[package]]
 name = "linktime-proc-macro"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c7b0a3383c2a1002d11349c92c85a666a5fb679e96c79d782cf0dbe557fd6ee"
+checksum = "348d0075b1fc163b26d72a7f75fc5141daf2fd1bdf128d873cbaf6785d495bdf"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1784,9 +1784,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",
@@ -1850,13 +1850,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1930,7 +1930,7 @@ checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "usage-cli"
-version = "4.1.0"
+version = "5.0.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1961,7 +1961,7 @@ dependencies = [
 
 [[package]]
 name = "usage-lib"
-version = "4.1.0"
+version = "5.0.0"
 dependencies = [
  "clap",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT"
 [workspace.dependencies]
 clap_usage = { path = "./clap_usage", version = "4.0.0" }
 usage-cli = { path = "./cli" }
-usage-lib = { path = "./lib", version = "4.1.0", features = ["clap"] }
+usage-lib = { path = "./lib", version = "5.0.0", features = ["clap"] }
 
 [workspace.metadata.release]
 allow-branch = ["main"]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-cli"
 edition = "2021"
-version = "4.1.0"
+version = "5.0.0"
 description = "CLI for working with usage-based CLIs"
 license = { workspace = true }
 authors = { workspace = true }

--- a/cli/usage.usage.kdl
+++ b/cli/usage.usage.kdl
@@ -2,7 +2,7 @@
 min_usage_version "4.0"
 name usage-cli
 bin usage
-version "4.1.0"
+version "5.0.0"
 about "CLI for working with usage-based CLIs"
 usage "Usage: usage-cli [OPTIONS] [COMPLETIONS] <COMMAND>"
 flag --usage-spec help="Outputs a `usage.kdl` spec for this CLI itself"

--- a/docs/cli/reference/commands.json
+++ b/docs/cli/reference/commands.json
@@ -1136,7 +1136,7 @@
   "config": {
     "props": {}
   },
-  "version": "4.1.0",
+  "version": "5.0.0",
   "usage": "Usage: usage-cli [OPTIONS] [COMPLETIONS] <COMMAND>",
   "complete": {},
   "source_code_link_template": "https://github.com/jdx/usage/blob/main/cli/src/cli/{{path}}.rs",

--- a/docs/cli/reference/index.md
+++ b/docs/cli/reference/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `usage [--usage-spec] [COMPLETIONS] <SUBCOMMAND>`
 
-**Version**: 4.1.0
+**Version**: 5.0.0
 
 - **Usage**: `usage [--usage-spec] [COMPLETIONS] <SUBCOMMAND>`
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-lib"
 edition = "2021"
-version = "4.1.0"
+version = "5.0.0"
 rust-version = "1.80.0"
 include = [
     "/Cargo.toml",


### PR DESCRIPTION
### 🚀 Features

- **(cli)** allow overriding the shell program with USAGE_SHELL_<SHELL> by [@JamBalaya56562](https://github.com/JamBalaya56562) in [#767](https://github.com/jdx/usage/pull/767)

### 🐛 Bug Fixes

- **(cli)** forward parsed args to WSL bash via WSLENV on windows by [@JamBalaya56562](https://github.com/JamBalaya56562) in [#764](https://github.com/jdx/usage/pull/764)
- **(cli)** let generate markdown write to stdout by [@JamBalaya56562](https://github.com/JamBalaya56562) in [#766](https://github.com/jdx/usage/pull/766)
- **(complete)** use `type -P` so the CLI-presence guard ignores shell functions by [@JamBalaya56562](https://github.com/JamBalaya56562) in [#760](https://github.com/jdx/usage/pull/760)
- **(parse)** enforce double_dash="required" for positional args by [@JamBalaya56562](https://github.com/JamBalaya56562) in [#762](https://github.com/jdx/usage/pull/762)
- **(windows)** run `run=` scripts with sh when available by [@JamBalaya56562](https://github.com/JamBalaya56562) in [#765](https://github.com/jdx/usage/pull/765)

### 🎨 Styling

- fix clippy and deprecation warnings in test and bench targets by [@JamBalaya56562](https://github.com/JamBalaya56562) in [#763](https://github.com/jdx/usage/pull/763)