### PR TITLE
style: fix clippy and deprecation warnings in test and bench targets

### DIFF
--- a/cli/tests/shell_completions_integration.rs
+++ b/cli/tests/shell_completions_integration.rs
@@ -1012,14 +1012,12 @@ cmd other help="Another subcommand"
     let lines: Vec<&str> = output.lines().collect();
 
     assert!(
-        lines.iter().any(|l| *l == "sub\tA subcommand\tsub"),
+        lines.contains(&"sub\tA subcommand\tsub"),
         "Expected 'sub\\tA subcommand\\tsub' in zsh output, got: {:?}",
         lines
     );
     assert!(
-        lines
-            .iter()
-            .any(|l| *l == "other\tAnother subcommand\tother"),
+        lines.contains(&"other\tAnother subcommand\tother"),
         "Expected 'other\\tAnother subcommand\\tother' in zsh output, got: {:?}",
         lines
     );

--- a/lib/benches/parse.rs
+++ b/lib/benches/parse.rs
@@ -1,4 +1,5 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::hint::black_box;
 use usage::{parse, Spec, SpecArg, SpecCommand, SpecFlag};
 
 fn build_small_spec() -> Spec {

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -2048,11 +2048,11 @@ mod tests {
         // (d) Negative case: a purely-local flag that shares nothing with a global is NOT
         // promoted/merged — it is correctly dropped when descending into the mount.
         assert!(
-            parsed.available_flags.get("-f").is_none(),
+            !parsed.available_flags.contains_key("-f"),
             "purely-local -f must not be promoted onto a global",
         );
         assert!(
-            parsed.available_flags.get("--force").is_none(),
+            !parsed.available_flags.contains_key("--force"),
             "purely-local --force must not be promoted onto a global",
         );
 


### PR DESCRIPTION
`lint:clippy` runs `cargo clippy --all --all-features -- -D warnings`, which does not cover test, bench or example targets. Nothing has been linting them, so they had drifted — `--all-targets` currently reports 17 errors on `main`. This PR fixes all of them. No behaviour changes.

| File | Count | Lint |
| --- | --- | --- |
| `lib/benches/parse.rs` | 13 | `criterion::black_box` is deprecated in favour of `std::hint::black_box` |
| `lib/src/parse.rs` (test module) | 2 | `clippy::unnecessary_get_then_check` |
| `cli/tests/shell_completions_integration.rs` | 2 | `clippy::manual_contains` |

The bench fix is a one-line import change — `use std::hint::black_box;` — so all 13 call sites stay as they are.

After this, `cargo clippy --all --all-features --all-targets -- -D warnings` is clean.

I deliberately left `mise.toml` alone: adding `--all-targets` to `lint:clippy` would keep this from drifting again, but that is a CI policy change and felt like a separate conversation. Happy to send it as a follow-up if you want it.

Verified with `cargo test -p usage-lib --all-features`, `cargo bench -p usage-lib --no-run` (the bench builds and links), and `cargo fmt --all -- --check`. The shell-completion integration tests only compile-check locally — they need Unix shells — so CI is the real check there.

---

_This pull request was generated by Claude Code._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved shell completion and mount-related regression test assertions without changing test behavior.

* **Chores**
  * Updated benchmark utilities to use the standard library’s recommended optimization helper.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->