### PR TITLE
fix(windows): run `run=` scripts with sh when available

### DIFF
--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -2,17 +2,16 @@ use std::collections::BTreeMap;
 use std::env;
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::sync::Arc;
 
 use clap::Args;
 use itertools::Itertools;
 use miette::IntoDiagnostic;
 use std::sync::LazyLock;
-use xx::process::check_status;
-use xx::{regex, XXError, XXResult};
+use xx::regex;
 
 use usage::parse::{ParseOutput, ParseValue};
+use usage::sh::sh;
 use usage::{Spec, SpecArg, SpecCommand, SpecComplete, SpecFlag};
 
 use crate::cli::generate;
@@ -409,20 +408,4 @@ fn zsh_shell_quote(s: &str) -> String {
     // Wrap in single quotes; close-open dance escapes any internal apostrophes.
     let escaped = s.replace('\'', "'\\''");
     format!("'{escaped}'")
-}
-
-fn sh(script: &str) -> XXResult<String> {
-    let output = Command::new("sh")
-        .arg("-c")
-        .arg(script)
-        .stdin(std::process::Stdio::null())
-        .stderr(std::process::Stdio::inherit())
-        .env("__USAGE", env!("CARGO_PKG_VERSION"))
-        .output()
-        .map_err(|err| XXError::ProcessError(err, format!("sh -c {script}")))?;
-
-    check_status(output.status)
-        .map_err(|err| XXError::ProcessError(err, format!("sh -c {script}")))?;
-    let stdout = String::from_utf8(output.stdout).expect("stdout is not utf-8");
-    Ok(stdout)
 }

--- a/cli/tests/complete_word.rs
+++ b/cli/tests/complete_word.rs
@@ -7,6 +7,34 @@ use assert_cmd::prelude::*;
 use predicates::prelude::*;
 use predicates::str::contains;
 
+/// Returns `true` if the test should be skipped because there is no usable POSIX shell.
+/// Panics under `CI` (any non-empty value) so a missing shell there is a configuration bug
+/// rather than a silent pass.
+///
+/// The mount fixtures are `#!/usr/bin/env -S usage bash` scripts, so `mount run=` can only
+/// work where `sh` can start them. Without this guard, Windows machines with no POSIX shell
+/// fall through to the `cmd /c` path, which hands a `.sh` to whatever program is registered
+/// for the extension — an editor window per test rather than a failure.
+///
+/// The probe runs a script and checks that it exited cleanly, rather than only that something
+/// spawned. On Windows `sh` can resolve to a program that starts and then fails, which would
+/// otherwise read as a working shell and put the tests back in the confusing state above.
+fn skip_if_posix_shell_missing() -> bool {
+    let usable = Command::new("sh")
+        .arg("-c")
+        .arg("exit 0")
+        .output()
+        .is_ok_and(|out| out.status.success());
+    if usable {
+        return false;
+    }
+    if env::var("CI").is_ok_and(|v| !v.is_empty()) {
+        panic!("no usable POSIX shell (`sh`) but CI is set — refusing to skip");
+    }
+    eprintln!("Skipping test - no usable POSIX shell (`sh`)");
+    true
+}
+
 #[test]
 fn complete_word_completer() {
     assert_cmd("basic.usage.kdl", &["plugins", "install", "pl"])
@@ -132,6 +160,9 @@ fn complete_word_arg_completer() {
 
 #[test]
 fn complete_word_mounted() {
+    if skip_if_posix_shell_missing() {
+        return;
+    }
     let mut path = env::split_paths(&env::var("PATH").unwrap()).collect::<Vec<_>>();
     path.insert(
         0,
@@ -150,6 +181,9 @@ fn complete_word_mounted() {
 
 #[test]
 fn complete_word_mounted_with_global_flags() {
+    if skip_if_posix_shell_missing() {
+        return;
+    }
     let mut path = env::split_paths(&env::var("PATH").unwrap()).collect::<Vec<_>>();
     path.insert(
         0,
@@ -191,6 +225,9 @@ fn complete_word_mounted_global_flag_choices() {
     // Regression for the parser-side root cause referenced by jdx/mise#10069:
     // a value-taking global flag placed before a mounted subcommand must not leak its
     // consumed tokens into the mounted task's `choices` positional arg.
+    if skip_if_posix_shell_missing() {
+        return;
+    }
     let mut path = env::split_paths(&env::var("PATH").unwrap()).collect::<Vec<_>>();
     path.insert(
         0,
@@ -242,6 +279,9 @@ fn complete_word_mounted_orphan_short_flag_choices() {
     // Completing a mounted task with the short in front must return the task's choices rather
     // than bailing with "unexpected word" / "Invalid choice" (which mise worked around by
     // promoting the short back to global).
+    if skip_if_posix_shell_missing() {
+        return;
+    }
     let mut path = env::split_paths(&env::var("PATH").unwrap()).collect::<Vec<_>>();
     path.insert(
         0,
@@ -287,6 +327,9 @@ fn complete_word_mounted_orphan_short_flag_choices() {
 fn complete_word_mounted_does_not_offer_mounting_cli_flags() {
     // Regression for jdx/mise#11282: the mounting CLI's global flags must not be offered
     // inside a mounted command, and must not shadow the mounted command's own flags.
+    if skip_if_posix_shell_missing() {
+        return;
+    }
     let mut path = env::split_paths(&env::var("PATH").unwrap()).collect::<Vec<_>>();
     path.insert(
         0,
@@ -376,6 +419,9 @@ fn complete_word_mounted_does_not_offer_mounting_cli_flags() {
 
 #[test]
 fn complete_word_boolean_flags_dont_consume_subcommands() {
+    if skip_if_posix_shell_missing() {
+        return;
+    }
     let mut path = env::split_paths(&env::var("PATH").unwrap()).collect::<Vec<_>>();
     path.insert(
         0,
@@ -410,6 +456,9 @@ fn complete_word_boolean_flags_dont_consume_subcommands() {
 
 #[test]
 fn complete_word_non_global_flags_do_not_stop_search() {
+    if skip_if_posix_shell_missing() {
+        return;
+    }
     let mut path = env::split_paths(&env::var("PATH").unwrap()).collect::<Vec<_>>();
     path.insert(
         0,
@@ -439,6 +488,9 @@ fn complete_word_non_global_flags_do_not_stop_search() {
 
 #[test]
 fn complete_word_mixed_global_flags() {
+    if skip_if_posix_shell_missing() {
+        return;
+    }
     let mut path = env::split_paths(&env::var("PATH").unwrap()).collect::<Vec<_>>();
     path.insert(
         0,

--- a/docs/spec/reference/cmd.md
+++ b/docs/spec/reference/cmd.md
@@ -78,6 +78,11 @@ Now when using completion with usage, if the user types `mycli run <tab><tab>`, 
 call `mycli mount-usage-tasks` and merge the emitted usage into the `run` command and display the
 task commands as if they were statically defined in the usage spec.
 
+`mount run` is executed the same way as [`complete`'s `run`](./complete.md#which-shell-runs-run):
+`sh -c`, falling back to `cmd /c` on Windows when there is no `sh` on `PATH`. A mount pointing at
+a shebang script therefore needs a POSIX shell to be available; one that invokes a program
+directly, like `mycli mount-usage-tasks` above, works either way.
+
 ### Global flags and mounted commands
 
 A mounted command describes a different program, so the flags of the commands it is mounted under

--- a/docs/spec/reference/complete.md
+++ b/docs/spec/reference/complete.md
@@ -51,3 +51,16 @@ complete "four" run="echo {{ words | slice(start=-4) | join(sep='\"\n\"') }}"
 ```
 
 Here we just use simple commands like `ls` and `echo` but these words could be passed to any command.
+
+## Which shell runs `run`
+
+`run` is executed with `sh -c`, so it is a POSIX shell command line: pipelines, `;` sequences
+and shell builtins all work.
+
+On Windows a POSIX shell is not guaranteed. usage still runs `sh -c` when `sh` is on `PATH`
+(Git for Windows provides it), and falls back to `cmd /c` when it is not. `cmd` cannot run any
+of the above — it only handles a plain command invocation — so a spec that targets Windows
+should either keep `run` to a single command or state that it needs a POSIX shell.
+
+The script is run with stdin closed and stderr inherited, and with `__USAGE` set to the usage
+version so a script can tell it was invoked by usage.

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -26,7 +26,7 @@ pub use error::Result;
 pub mod docs;
 pub mod parse;
 pub mod sdk;
-pub(crate) mod sh;
+pub mod sh;
 pub(crate) mod string;
 #[cfg(test)]
 mod test;

--- a/lib/src/sh.rs
+++ b/lib/src/sh.rs
@@ -1,25 +1,214 @@
+//! Running the shell scripts a spec embeds in `run=`.
+
+use std::io;
 use std::process::Command;
+use std::string::FromUtf8Error;
 use xx::process::check_status;
-use xx::{XXError, XXResult};
+use xx::XXError;
 
-pub(crate) fn sh(script: &str) -> XXResult<String> {
-    #[cfg(unix)]
-    let (shell, flag) = ("sh", "-c");
+use crate::error::Result;
 
-    #[cfg(windows)]
-    let (shell, flag) = ("cmd", "/c");
+/// The interpreter a `run=` script is handed to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ShellKind {
+    /// `sh -c`, what `run=` is written for everywhere in the spec format.
+    Posix,
+    /// `cmd /c`. Windows only, and only when there is no POSIX shell to be had:
+    /// it cannot run a shebang script, a pipeline, or `a; b`.
+    Cmd,
+}
 
-    let output = Command::new(shell)
+fn shell_argv(kind: ShellKind) -> (&'static str, &'static str) {
+    match kind {
+        ShellKind::Posix => ("sh", "-c"),
+        ShellKind::Cmd => ("cmd", "/c"),
+    }
+}
+
+/// Which interpreter to try next after `kind` failed to start, if any.
+///
+/// Only a missing executable falls back. Anything else — a `sh` that exists but cannot be
+/// executed, say — is reported as-is: quietly demoting a broken shell to a different one is
+/// the same class of silent wrong behavior this fallback exists to get rid of.
+fn fallback_for(kind: ShellKind, err: io::ErrorKind) -> Option<ShellKind> {
+    match (kind, err) {
+        (ShellKind::Posix, io::ErrorKind::NotFound) if cfg!(windows) => Some(ShellKind::Cmd),
+        _ => None,
+    }
+}
+
+/// The first line of a script, for putting in an error message.
+///
+/// A `run=` can be a whole multi-line `case … esac`, and these messages surface in a shell
+/// completion, where a wall of text buries the prompt.
+fn script_excerpt(script: &str) -> String {
+    let first_line = script.lines().next().unwrap_or_default();
+    match script.lines().nth(1) {
+        Some(_) => format!("{first_line} …"),
+        None => first_line.to_string(),
+    }
+}
+
+fn no_shell_message(script: &str) -> String {
+    format!(
+        "failed to run `run=` script: neither `sh` nor `cmd` could be started\n  \
+         script: {}\n  \
+         `run=` is executed with `sh -c`, falling back to `cmd /c` on Windows. \
+         Install a POSIX shell (Git for Windows ships sh.exe) and make sure it is on PATH.",
+        script_excerpt(script)
+    )
+}
+
+fn non_utf8_message(shell: &str, flag: &str, script: &str, err: &FromUtf8Error) -> String {
+    format!(
+        "`run=` script produced output that is not valid UTF-8: {err}\n  \
+         script: {}\n  \
+         shell: {shell} {flag}",
+        script_excerpt(script)
+    )
+}
+
+/// Run a `run=` script and return its stdout.
+///
+/// Executed with `sh -c`, which is the language the spec format's `run=` is written in — the
+/// reference examples use pipelines, `;` sequences and shebang scripts. On Windows, where a
+/// POSIX shell is not guaranteed, a missing `sh` falls back to `cmd /c`; that runs a plain
+/// command invocation but none of the above, so a spec meant to work there should keep `run=`
+/// to a single command.
+///
+/// stdin is closed and stderr is inherited, so a script cannot stall a completion waiting for
+/// input but can still say why it failed. `__USAGE` is set to the usage version, letting a
+/// script tell that it was invoked by usage.
+///
+/// Output that is not valid UTF-8 is an error, not a panic and not a lossy conversion. The
+/// `cmd /c` fallback in particular emits the console code page, which is not UTF-8 outside
+/// English locales, and a mount's output is parsed as a spec — replacement characters there
+/// would resurface as a baffling KDL syntax error instead of an encoding one.
+pub fn sh(script: &str) -> Result<String> {
+    let mut kind = ShellKind::Posix;
+    let output = loop {
+        let (shell, flag) = shell_argv(kind);
+        let err = match run(shell, flag, script) {
+            Ok(output) => break output,
+            Err(err) => err,
+        };
+        match fallback_for(kind, err.kind()) {
+            Some(next) => kind = next,
+            None if err.kind() == io::ErrorKind::NotFound && cfg!(windows) => {
+                return Err(XXError::Error(no_shell_message(script)).into());
+            }
+            None => {
+                return Err(XXError::ProcessError(err, format!("{shell} {flag} {script}")).into());
+            }
+        }
+    };
+
+    let (shell, flag) = shell_argv(kind);
+    check_status(output.status)
+        .map_err(|err| XXError::ProcessError(err, format!("{shell} {flag} {script}")))?;
+    String::from_utf8(output.stdout)
+        .map_err(|err| XXError::Error(non_utf8_message(shell, flag, script, &err)).into())
+}
+
+fn run(shell: &str, flag: &str, script: &str) -> io::Result<std::process::Output> {
+    Command::new(shell)
         .arg(flag)
         .arg(script)
         .stdin(std::process::Stdio::null())
         .stderr(std::process::Stdio::inherit())
         .env("__USAGE", env!("CARGO_PKG_VERSION"))
         .output()
-        .map_err(|err| XXError::ProcessError(err, format!("{shell} {flag} {script}")))?;
+}
 
-    check_status(output.status)
-        .map_err(|err| XXError::ProcessError(err, format!("{shell} {flag} {script}")))?;
-    let stdout = String::from_utf8(output.stdout).expect("stdout is not utf-8");
-    Ok(stdout)
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shell_argv_maps_each_kind() {
+        assert_eq!(shell_argv(ShellKind::Posix), ("sh", "-c"));
+        assert_eq!(shell_argv(ShellKind::Cmd), ("cmd", "/c"));
+    }
+
+    #[test]
+    fn a_missing_posix_shell_falls_back_only_on_windows() {
+        let fallback = fallback_for(ShellKind::Posix, io::ErrorKind::NotFound);
+        if cfg!(windows) {
+            assert_eq!(fallback, Some(ShellKind::Cmd));
+        } else {
+            assert_eq!(fallback, None);
+        }
+    }
+
+    #[test]
+    fn a_shell_that_exists_but_fails_is_not_demoted() {
+        // Falling back here would hide a broken `sh` behind a shell that silently
+        // mis-executes the script, which is the failure mode this is meant to remove.
+        assert_eq!(
+            fallback_for(ShellKind::Posix, io::ErrorKind::PermissionDenied),
+            None
+        );
+    }
+
+    #[test]
+    fn cmd_is_the_last_resort() {
+        assert_eq!(fallback_for(ShellKind::Cmd, io::ErrorKind::NotFound), None);
+    }
+
+    #[test]
+    fn no_shell_message_names_both_shells_and_the_script() {
+        let msg = no_shell_message("echo hello");
+        assert!(msg.contains("`sh`"), "{msg}");
+        assert!(msg.contains("`cmd`"), "{msg}");
+        assert!(msg.contains("echo hello"), "{msg}");
+    }
+
+    #[test]
+    fn no_shell_message_truncates_a_multi_line_script() {
+        let msg = no_shell_message("case $cur in\n  a) echo a ;;\nesac");
+        assert!(msg.contains("case $cur in …"), "{msg}");
+        assert!(!msg.contains("esac"), "{msg}");
+    }
+
+    #[test]
+    fn non_utf8_message_names_the_script_and_the_shell() {
+        let err = String::from_utf8(vec![0xff]).unwrap_err();
+        let msg = non_utf8_message("cmd", "/c", "chcp 932 && dir", &err);
+        assert!(msg.contains("chcp 932 && dir"), "{msg}");
+        assert!(msg.contains("cmd /c"), "{msg}");
+        assert!(msg.contains("not valid UTF-8"), "{msg}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sh_reports_non_utf8_output_instead_of_panicking() {
+        // A `run=` that emits raw bytes used to take the whole process down. `cmd /c` on a
+        // non-English Windows reaches this through its console code page.
+        let err = sh(r"printf '\377'").unwrap_err();
+        assert!(
+            err.to_string().contains("not valid UTF-8"),
+            "{}",
+            err.to_string()
+        );
+    }
+
+    #[test]
+    fn sh_returns_stdout() {
+        // `echo` behaves the same under `sh -c` and `cmd /c`, so this runs anywhere.
+        assert!(sh("echo hello").unwrap().contains("hello"));
+    }
+
+    #[test]
+    fn sh_fails_on_a_nonzero_exit() {
+        assert!(sh("exit 1").is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sh_exposes_the_usage_version() {
+        assert_eq!(
+            sh("echo $__USAGE").unwrap().trim(),
+            env!("CARGO_PKG_VERSION")
+        );
+    }
 }


### PR DESCRIPTION
## Compatibility first

There is no (OS, PATH) combination where this is worse than today. The `cmd /c` path is preserved byte for byte and is still used whenever `sh` cannot be found, so a Windows machine without a POSIX shell behaves exactly as it does now — `mount run="mise tasks --usage"` and other plain command invocations keep working. Where `sh` *is* available, shebang mounts and POSIX one-liners start working instead of silently doing the wrong thing. Unix is untouched.

## Problem

Executing a spec's `run=` is split across two nearly identical private functions:

| | Runs | Windows |
| --- | --- | --- |
| `lib/src/sh.rs` | `mount run=` (via `SpecCommand::mount`) | `cmd /c` |
| `cli/src/cli/complete_word.rs:414` | `complete run=` | **`sh -c`, no platform branch** |

Everything else about them is identical — stdin closed, stderr inherited, `__USAGE` set, same error handling. The cli copy exists only because `lib/src/lib.rs` declares `pub(crate) mod sh`. The result is that **the same `run=` syntax runs under a different shell depending on which KDL node it was written in**.

`run=` is a POSIX command line. The reference docs' own examples are `ls modules/{{words[PREV]}}/controllers` and `echo {{ words | slice(start=-4) | join(...) }}`. `examples/mise.usage.kdl:1163` is `mise alias ls {{words[PREV]}} | awk '{print $2}'`, and `:1177-1215` is a multi-line `case $cur in … esac` with `cut` and `sed`. `cmd /c` cannot run any of that:

```
> cmd /c "printf 'cmd \"task-a\"\ncmd \"task-b\"\n'"
'printf' is not recognized as an internal or external command
```

Worse, for the shebang-script case it does not fail at all. `cmd /c ./mounted.sh --mount` hands the `.sh` to whatever program is registered for the extension — on my machine that opened an editor window — and then returns **exit code 0 with empty stdout**. That empty string goes straight to the spec parser, which accepts it as a spec with nothing in it. A mounted command silently completes to nothing.

`cmd /c` arrived in v2.16.0, "(windows) add Windows binaries and fix completion support (#472)". That PR was about shipping Windows binaries; which shell interprets `run=` does not look like it was the question being answered.

## Fix

`lib/src/sh.rs` becomes the only implementation, exposed as `usage::sh::sh` (`pub(crate) mod sh` → `pub mod sh`; additive, `cargo semver-checks check-release` reports `no semver update required`). The cli copy is deleted and its call site now uses the shared one.

Shell selection: run `sh -c`; on Windows, if that fails with `ErrorKind::NotFound`, retry with `cmd /c`; if neither can start, return an explicit error naming both. Any other spawn failure is reported as-is rather than falling back — quietly demoting a broken `sh` to a different shell is the same class of silent wrongness this is meant to remove.

The platform branch lives in one pure function (`fallback_for`) behind `cfg!(windows)` rather than `#[cfg(windows)]`, so the fallback logic is still compiled, linted and unit-tested on the Linux CI. On Unix it returns `None`, so the syscall sequence is identical to today's.

`bash` is deliberately not searched for. `C:\Windows\System32\bash.exe` is the WSL launcher and wins over PATH on any machine with WSL installed, which would run completion scripts against a different filesystem. Git for Windows ships `sh.exe` and `bash.exe` side by side, so looking for `bash` would not widen coverage anyway. No `which`-style probe either: a pre-flight spawn costs a process on the completion hot path and races the real call, while a failed `CreateProcess` already answers the question using the OS's own resolution rules.

Also fixed in passing: the cli copy hardcoded `format!("sh -c {script}")` as the error context, so Windows users were told about a shell that had not actually run.

## Verified

Windows 11, `sh` on PATH via Git for Windows.

A `mount run=` holding a POSIX one-liner — the case `cmd /c` cannot run at all:

```
$ usage cw --shell fish -f mount-posix.usage.kdl mycli -- exec-task ""
task-a
task-b
```

`cargo test -p usage-cli --test complete_word` went from **82 seconds for a single test, with an editor window opening per fixture**, to 2.7 seconds for the whole file with none. The eight mount tests still fail on this particular machine, but for an unrelated reason that this change makes visible instead of hiding: the fixtures are `#!/usr/bin/env -S usage bash` scripts, and `usage bash` resolves to WSL's bash here, which cannot open a `C:/…` path. Previously that surfaced as exit 0 and an empty spec; now it is `exited with code 127 — sh -c mounted.sh --mount`. On a Windows machine without WSL those eight would pass.

Also run: `cargo test -p usage-lib --all-features` (311 pass), `cargo clippy --all --all-features -- -D warnings`, `cargo fmt --all -- --check`, `prettier -c` on the touched docs.

## Tests

`lib/src/sh.rs` gets its first unit tests. The shell-selection and message-building functions are pure, so they run on every platform — including that `PermissionDenied` does *not* fall back, and that the message names both shells and truncates a multi-line script to its first line.

`cli/tests/complete_word.rs` gains a `skip_if_posix_shell_missing` guard on the eight mount tests, mirroring `skip_if_shell_missing` in `shell_completions_integration.rs` including the `panic!` under `CI`. Those fixtures are shebang scripts and cannot work without a POSIX shell; without the guard, a Windows machine lacking one falls into the `cmd /c` path and gets an editor window per test rather than a failure. The Linux CI is unaffected — `sh` is always there, and a missing one under `CI` still fails loudly.

## Deliberately not doing

- Adding a Windows CI runner. `test.yml` is `ubuntu-latest` only, so the fallback's real behaviour is not covered here; that belongs to a separate CI discussion.
- Adding a `UsageErr` variant for "no shell". That would be a major semver bump (as #762 is currently discovering), so the message rides on the existing `XXError::Error`.
- A way to point usage at a specific shell binary. Worth having, but it is a design question rather than a bug fix.

## Non-UTF-8 output (added after review)

`String::from_utf8(...).expect(...)` used to panic on non-UTF-8 stdout. I had this down as a follow-up, but it belongs here: the `cmd /c` fallback emits the console code page, which is not UTF-8 outside English locales, so on a Japanese or Cyrillic Windows a single `run=` script could take the whole process down. It is now an error naming the script and the shell that ran it.

Reported rather than converted lossily: a mount's output is parsed as a spec, and replacement characters there would resurface as a baffling KDL syntax error instead of an encoding one. No new `UsageErr` variant — the message rides on the existing `XXError::Error`, so the public API is unchanged.

---

_This pull request was generated by Claude Code._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shell-based commands now run consistently through POSIX shells, with a Windows fallback when unavailable.
  * Shell execution is available for broader integrations.
  * Command output, status, standard input, error output, and usage context remain supported.

* **Bug Fixes**
  * Improved diagnostics for shell startup failures and multiline scripts.
  * Invalid command output is reported safely without unexpected crashes.
  * Shell-dependent tests now skip appropriately when the required shell is unavailable.

* **Documentation**
  * Documented shell selection, fallback behavior, script limitations, input handling, and environment details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->