### PR TITLE
ci: run perf jobs on bamboo

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,7 @@
 self-hosted-runner:
   # Labels of self-hosted runner in array of strings.
   labels:
+    - bamboo-perf
     - macos-14
     - buildjet-32vcpu-ubuntu-2204-arm
     - buildjet-16vcpu-ubuntu-2204-arm

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -27,7 +27,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  TAK_RUNNER: bamboo-v1-ubuntu24.04-x64-rust1.97.1
+  TAK_RUNNER: bamboo-v2-ubuntu24.04-x64-30vcpu-24gb-rust1.97.1
 
 jobs:
   measure:

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -32,6 +32,7 @@ env:
 jobs:
   measure:
     name: Compare instruction counts
+    if: github.event.pull_request.user.login == 'jdx'
     # Same runner class as perf.yml and perf-backfill.yml. Absolute counts shift
     # between machine types by more than a real regression does, so a comparison
     # across runner classes is not a comparison — tak refuses to make one, and
@@ -138,7 +139,7 @@ jobs:
   report:
     name: Report and gate
     needs: measure
-    if: always()
+    if: always() && github.event.pull_request.user.login == 'jdx'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -27,6 +27,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
+  TAK_RUNNER: bamboo-v1-ubuntu24.04-x64-rust1.97.1
 
 jobs:
   measure:
@@ -35,7 +36,7 @@ jobs:
     # between machine types by more than a real regression does, so a comparison
     # across runner classes is not a comparison — tak refuses to make one, and
     # the report would say "nothing was compared" instead of anything useful.
-    runs-on: ubuntu-latest
+    runs-on: bamboo-perf
     timeout-minutes: 40
     permissions:
       # Read only. This job builds and runs code from the pull request, so it

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -27,7 +27,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  TAK_RUNNER: bamboo-v1-ubuntu24.04-x64-rust1.97.1
+  TAK_RUNNER: bamboo-v2-ubuntu24.04-x64-30vcpu-24gb-rust1.97.1
 
 jobs:
   measure:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -27,6 +27,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
+  TAK_RUNNER: bamboo-v1-ubuntu24.04-x64-rust1.97.1
 
 jobs:
   measure:
@@ -34,7 +35,7 @@ jobs:
     # Pinned to one runner class on purpose. Absolute instruction counts shift
     # between machine types by more than a real regression does, so a series
     # that wanders between runners is unreadable.
-    runs-on: ubuntu-latest
+    runs-on: bamboo-perf
     timeout-minutes: 30
     permissions:
       contents: write # pushing refs/notes/tak is a write to this repository


### PR DESCRIPTION
## Summary

- run Tak measurement jobs on the isolated `bamboo-perf` runner
- identify the Bamboo image/toolchain as a distinct Tak runner class
- leave report and publish jobs on hosted runners

## Validation

- `actionlint` (with `bamboo-perf` registered as the expected custom label)
- `git diff --check`
- trusted `main` baseline queued on the disposable runner

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI infrastructure for performance baselines and PR gates—wrong runner or TAK_RUNNER mismatch could invalidate comparisons or block trusted perf signal until fixed.
> 
> **Overview**
> Moves **Tak instruction-count measurement** off GitHub-hosted `ubuntu-latest` onto the self-hosted **`bamboo-perf`** runner in `perf.yml` and `perf-pr.yml`, matching the existing comment that counts must stay on one machine class.
> 
> Both workflows set **`TAK_RUNNER`** to `bamboo-v2-ubuntu24.04-x64-30vcpu-24gb-rust1.97.1` so Tak can treat this Bamboo image as its own runner identity when recording and comparing notes. **`bamboo-perf`** is registered in **actionlint** as an allowed self-hosted label.
> 
> In **`perf-pr.yml`**, the `measure` and `report` jobs are additionally limited to PRs opened by **`jdx`** while rollout is tested; **`report`** still runs on **`ubuntu-latest`** (no change to that job’s runner).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f527bcccdcb35a9858caa0da8dd6647fc7d5e06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated performance testing to use a standardized, dedicated environment.
  * Improved consistency and reliability of performance measurements through a fixed runner configuration.
  * Limited automated performance checks and reporting to designated performance-testing pull requests.
  * Added the performance runner to the approved configuration for supported automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->