### PR TITLE
ci: build perf binaries on bamboo

### DIFF
--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -57,8 +57,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-
+      # Compile inside this disposable VM. Restoring target/ can relabel a
+      # binary built on a different runner class as a Bamboo measurement.
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           cache: false

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -44,8 +44,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-
+      # Compile inside this disposable VM. Restoring target/ can relabel a
+      # binary built on a different runner class as a Bamboo measurement.
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           cache: false


### PR DESCRIPTION
## Summary

- compile benchmark binaries from scratch inside each disposable Bamboo VM
- prevent a cached `target/` built on Namespace from being measured and labeled as Bamboo
- document the runner-class integrity requirement beside the build setup

## Validation

- `actionlint` on the affected performance workflows
- `git diff --check`

Generated with AI assistance and manually validated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to perf workflows; slightly longer build times on Bamboo but improves measurement integrity with no app or security impact.
> 
> **Overview**
> **Perf CI** (`perf.yml`, `perf-pr.yml`) no longer restores `target/` via **Swatinem/rust-cache**. Benchmark binaries are built from scratch on each disposable **Bamboo** runner so instruction-count measurements are not attributed to the wrong runner class.
> 
> Comments beside the **mise** setup document that restoring a cache from another runner could label a non-Bamboo binary as a Bamboo measurement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c618f17b2f4c90b401850e2b3a1175ebe1271dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated performance workflows to compile directly in the temporary environment.
  * Removed restoration of cached build artifacts to improve consistency across runner types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->