### PR TITLE
chore: lint test and bench targets with clippy

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -69,7 +69,7 @@ run = 'actionlint'
 [tasks."lint:prettier"]
 run = "prettier -c ."
 [tasks."lint:clippy"]
-run = 'cargo clippy --all --all-features -- -D warnings'
+run = 'cargo clippy --all --all-features --all-targets -- -D warnings'
 [tasks."lint:fmt"]
 run = 'cargo fmt --all -- --check'
 [tasks."lint:semver"]


### PR DESCRIPTION
Follow-up to #763, which fixed the lint but deliberately left the gate alone.

## Problem

`lint:clippy` runs

```
cargo clippy --all --all-features -- -D warnings
```

which covers lib and bin targets only. **Tests and benches have never been linted.** Nothing was watching them, so lint quietly accumulated: adding `--all-targets` surfaced 17 findings — 13 deprecated `criterion::black_box` calls in `lib/benches/parse.rs`, two `clippy::unnecessary_get_then_check` and two `clippy::manual_contains` in tests. #763 fixed all of them, but the same drift starts again the moment someone writes a test.

The `#[cfg(test)] mod tests` blocks are the sharpest case: the lib target does not enable `cfg(test)`, so unit tests are invisible to the current command no matter which crate they live in.

## Fix

One flag:

```diff
 [tasks."lint:clippy"]
-run = 'cargo clippy --all --all-features -- -D warnings'
+run = 'cargo clippy --all --all-features --all-targets -- -D warnings'
```

Newly covered: `lib/benches/parse.rs`, the integration tests under `lib/tests/`, `cli/tests/` and `clap_usage/tests/`, and every `#[cfg(test)] mod tests` in the workspace.

That is the entire diff — the current `main` already passes `--all-targets` clean, so this changes no source.

## Precedent

mise runs both forms in CI (`.github/workflows/test.yml`):

```yaml
- name: Run Clippy
  run: |
    cargo clippy -- -D warnings
    cargo clippy --all-features --all-targets -- -D warnings
```

and its `AGENTS.md` states it as a rule: refactor until `cargo clippy --workspace --all-features --all-targets -- -D warnings` passes, without `#[allow(clippy::…)]` exclusions. This brings usage to the same bar.

## `lint-fix` left alone, on purpose

`render:usage-cli-completions` ends with `mise run lint-fix`, and what render needs from it is `cargo fmt` and `prettier -w` — the `clippy --fix` is along for the ride. Widening it would add a full test and criterion build to every `mise run render`, including the CI step that follows it with a no-diff assertion, for nothing render cares about. `cargo fix` also has a known habit of bailing with "file has changed on disk" when one file is compiled as both a lib and a test target.

mise makes the same split: `xtasks/lint-fix.ps1` is `cargo clippy --fix --allow-staged --allow-dirty -- -Dwarnings`, without `--all-targets` or even `--all-features`. Check wide, fix narrow.

## Cost

`mise r lint` is the last step of the test job, after `mise r build` and `mise r test`. Clippy does not share fingerprints with `cargo build`/`cargo test`, so the extra targets are compiled rather than reused. The genuinely new dependency is criterion, for the bench — `coverage.yml` already builds it via `cargo test --all-features --all-targets` in `tasks/coverage.sh`, but that is a different job with a different cache.

Measured locally: 14 s warm on Windows, 1 m 22 s on Linux from a cache without criterion.

## Verified

That the widened gate actually catches something, by planting a `clippy::clone_on_copy` in `cli/tests/clap_sort.rs`:

```
# before — passes
$ cargo clippy --all --all-features -- -D warnings
0 errors

# after — fails
$ cargo clippy --all --all-features --all-targets -- -D warnings
error: using `clone` on type `i32` which implements the `Copy` trait
  --> cli\tests\clap_sort.rs:12:17
```

Reverted afterwards. `mise run lint:clippy` and `mise run lint:fmt` pass on the unmodified tree, on Windows and on Linux.

## Possible follow-up

mise runs a second, bare `cargo clippy -- -D warnings` alongside the `--all-features` one, which catches code that only compiles with a feature enabled. usage has three features on `usage-lib`, so the same gap exists here. Left out because it is a question about features rather than targets.

---

_This pull request was generated by Claude Code._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded lint checks to cover all project targets, improving consistency and code quality validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->