### PR TITLE
test(windows): make the suite runnable on Windows

### DIFF
--- a/cli/tests/complete_word.rs
+++ b/cli/tests/complete_word.rs
@@ -2,6 +2,7 @@ use assert_cmd::assert::Assert;
 use assert_cmd::cargo;
 use std::env;
 use std::fs;
+use std::path::PathBuf;
 use std::process::Command;
 
 use assert_cmd::prelude::*;
@@ -20,20 +21,46 @@ use predicates::str::contains;
 /// The probe runs a script and checks that it exited cleanly, rather than only that something
 /// spawned. On Windows `sh` can resolve to a program that starts and then fails, which would
 /// otherwise read as a working shell and put the tests back in the confusing state above.
+///
+/// `sh` starting is necessary but not sufficient, so a fixture is run as well. Its shebang is
+/// `usage bash`, and on Windows the two need not be the same family: `sh` can be Git Bash while
+/// a bare `bash` is the WSL launcher that System32 puts ahead of `PATH`, which cannot open the
+/// absolute path `sh` hands its shebang. Probing only `sh` reported such a machine as usable
+/// and left these tests failing rather than skipping. `USAGE_SHELL_BASH` is the way out, and
+/// the probe sees it because the fixture runs through `usage bash` too.
 fn skip_if_posix_shell_missing() -> bool {
-    let usable = Command::new("sh")
+    let sh_runs = Command::new("sh")
         .arg("-c")
         .arg("exit 0")
         .output()
         .is_ok_and(|out| out.status.success());
-    if usable {
+    if sh_runs && mount_fixture_runs() {
         return false;
     }
     if env::var("CI").is_ok_and(|v| !v.is_empty()) {
-        panic!("no usable POSIX shell (`sh`) but CI is set — refusing to skip");
+        panic!("no shell that can run the mount fixtures but CI is set — refusing to skip");
     }
-    eprintln!("Skipping test - no usable POSIX shell (`sh`)");
+    eprintln!("Skipping test - no shell that can run the mount fixtures");
     true
+}
+
+/// Whether a mount fixture actually runs, given as the absolute path `sh` would hand it.
+fn mount_fixture_runs() -> bool {
+    // Built from `CARGO_MANIFEST_DIR`, not `fs::canonicalize`. On Windows canonicalize returns
+    // a `\\?\`-prefixed path, which usage cannot open — the probe would then fail on the shape
+    // of the path rather than on the shell, and every mount test would skip on a machine where
+    // they work perfectly well.
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("examples")
+        .join("mounted.sh");
+    Command::new(cargo::cargo_bin!("usage"))
+        .arg("bash")
+        .arg(fixture)
+        .arg("--mount")
+        .output()
+        .is_ok_and(|out| out.status.success())
 }
 
 #[test]

--- a/cli/tests/examples.rs
+++ b/cli/tests/examples.rs
@@ -1,26 +1,18 @@
 use assert_cmd::cargo;
 use assert_cmd::prelude::*;
 use predicates::str::contains;
-use std::{env, process::Command};
+use std::process::Command;
 
 /// Test that examples/test-empty-defaults.sh runs successfully and demonstrates
 /// the correct behavior of default="" vs no default
 #[test]
 fn test_empty_defaults_example() {
-    // Set up PATH to include the usage binary
-    let mut path = env::split_paths(&env::var("PATH").unwrap()).collect::<Vec<_>>();
-    path.insert(
-        0,
-        env::current_dir()
-            .unwrap()
-            .join("..")
-            .join("target")
-            .join("debug"),
-    );
-    path.insert(0, env::current_dir().unwrap().join("..").join("examples"));
-
-    let mut cmd = Command::new("../examples/test-empty-defaults.sh");
-    cmd.env("PATH", env::join_paths(path).unwrap());
+    // Through `usage bash`, like every other test here, rather than spawning the script and
+    // letting its `#!/usr/bin/env -S usage bash` shebang do the work. Windows cannot execute a
+    // `.sh` at all — the spawn fails with os error 193 before the shebang is ever read — and
+    // going through the binary also drops the PATH juggling that let the shebang find `usage`.
+    let mut cmd = Command::new(cargo::cargo_bin!("usage"));
+    cmd.args(["bash", "../examples/test-empty-defaults.sh"]);
 
     let assert = cmd.assert().success();
 

--- a/cli/tests/shell_completions_integration.rs
+++ b/cli/tests/shell_completions_integration.rs
@@ -1,21 +1,144 @@
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
-/// Returns `true` if the test should be skipped because the shell is not
-/// installed. Panics under `CI=1` (or any non-empty `CI`) to prevent silent
-/// false-positives in CI: if a shell is missing in CI it's a configuration
-/// bug, not an excuse to skip the test.
+/// The program to run for `shell`, honouring the same `USAGE_SHELL_<SHELL>` override the CLI
+/// itself reads (`shell_program_override` in `cli/src/env.rs`).
+///
+/// It matters on Windows, where the executable search order puts the system directory ahead of
+/// `PATH` and installing WSL puts `bash.exe` there — so a bare `bash` is the WSL launcher,
+/// which cannot open the Windows paths these tests write. Pointing the variable at a real bash
+/// is what makes them runnable. Unset, which is every other platform, means the bare name.
+fn shell_program(shell: &str) -> String {
+    env::var(format!("USAGE_SHELL_{}", shell.to_ascii_uppercase()))
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| shell.to_string())
+}
+
+/// A path as a POSIX shell will read it.
+///
+/// These tests interpolate paths into script bodies — `source "{}"`, `export PATH="{}:$PATH"` —
+/// where a Windows `\` is an escape character rather than a separator, so `C:\Users\x` arrives
+/// as `C:Usersx`. Every shell that can run these scripts accepts `/` instead, and on Unix this
+/// changes nothing.
+fn sh_path(path: &Path) -> String {
+    path.display().to_string().replace('\\', "/")
+}
+
+/// A path as it must appear inside the shell's `$PATH`.
+///
+/// `$PATH` is colon-separated, so a Windows `C:/Users/…` splits into `C` and `/Users/…` and
+/// neither resolves — a test that puts a directory there would silently look somewhere else.
+/// The POSIX-flavoured shells that can run these scripts on Windows (Git Bash, MSYS2, Cygwin)
+/// all ship `cygpath`, and only they know whether the answer is `/c/…`, `/cygdrive/c/…` or a
+/// mount point set in fstab. Asking through `shell` rather than spawning `cygpath` directly
+/// finds the one that belongs to the shell actually in use, which need not be on Windows' own
+/// `PATH`.
+///
+/// Off Windows, and if the conversion is unavailable, the path is already what `$PATH` wants.
+fn path_var_entry(shell: &str, path: &Path) -> String {
+    if !cfg!(windows) {
+        return sh_path(path);
+    }
+    Command::new(shell_program(shell))
+        .args(["-c", "cygpath -u \"$1\"", "--"])
+        .arg(sh_path(path))
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .map(|out| String::from_utf8_lossy(&out.stdout).trim().to_string())
+        .filter(|converted| !converted.is_empty())
+        .unwrap_or_else(|| sh_path(path))
+}
+
+/// Run `script` under `shell`, giving up after `secs` seconds.
+///
+/// `timeout` is spelled the same wherever these shells live, but spawning it directly walks
+/// into the trap this whole file is about: Windows keeps an unrelated `timeout.exe` in the
+/// system directory — a sleep, not a watchdog — and the search order puts it first. Going
+/// through the shell resolves the one on *its* `PATH`, and reuses the program the guard
+/// probed rather than a second, possibly different one.
+fn run_with_timeout(shell: &str, secs: u32, script: &Path) -> std::io::Result<Output> {
+    let program = shell_program(shell);
+    Command::new(&program)
+        .arg("-c")
+        .arg(format!("timeout {secs} \"$0\" \"$1\""))
+        .arg(&program)
+        .arg(sh_path(script))
+        .output()
+}
+
+/// Returns `true` if the test should be skipped because the shell cannot run a script.
+///
+/// Not "is it installed": a WSL `bash` on Windows answers `--version` perfectly well and then
+/// fails to open the very files these tests hand it, which is how five bash tests came to fail
+/// there rather than skip. Running a script from a temp directory is the precondition every
+/// test in this file actually needs, so that is what gets checked.
+///
+/// It probes `shell_program(shell)`, which is also what every test here spawns — the guard and
+/// the thing it guards must be the same executable, or an override would be honoured by one and
+/// not the other.
+///
+/// Panics under `CI=1` (or any non-empty `CI`) to prevent silent false-positives in CI: if a
+/// shell is unusable in CI it's a configuration bug, not an excuse to skip the test.
 fn skip_if_shell_missing(shell: &str) -> bool {
-    if Command::new(shell).arg("--version").output().is_ok() {
+    if shell_can_run_a_script(shell) {
         return false;
     }
     if env::var("CI").is_ok_and(|v| !v.is_empty()) {
-        panic!("shell `{shell}` not installed but CI is set — refusing to skip");
+        panic!("shell `{shell}` cannot run a script but CI is set — refusing to skip");
     }
-    eprintln!("Skipping {shell} test - {shell} shell not installed");
+    eprintln!(
+        "Skipping {shell} test - `{}` cannot run a script from {}",
+        shell_program(shell),
+        env::temp_dir().display()
+    );
     true
+}
+
+fn shell_can_run_a_script(shell: &str) -> bool {
+    static NEXT: AtomicUsize = AtomicUsize::new(0);
+    let dir = env::temp_dir().join(format!(
+        "usage_shell_probe_{}_{}",
+        std::process::id(),
+        NEXT.fetch_add(1, Ordering::Relaxed)
+    ));
+    if fs::create_dir_all(&dir).is_err() {
+        return false;
+    }
+    // `echo ok` is the one thing bash, zsh, fish and pwsh all spell the same way. pwsh is the
+    // only one that insists on the extension.
+    let script = dir.join(if shell == "pwsh" {
+        "probe.ps1"
+    } else {
+        "probe"
+    });
+    let usable = fs::write(&script, "echo ok\n").is_ok()
+        && script_command(shell, &script).output().is_ok_and(|out| {
+            out.status.success() && String::from_utf8_lossy(&out.stdout).trim() == "ok"
+        });
+    let _ = fs::remove_dir_all(&dir);
+    usable
+}
+
+/// The command that runs `script` under `shell`.
+///
+/// One place, because the probe above and the tests it guards have to agree on more than the
+/// program: a guard that invokes the shell differently can call a working shell unusable, or
+/// miss one that is. pwsh is where they would have diverged — it needs `-File` to take a script
+/// path at all, and `-NoProfile -NonInteractive` so a developer's profile cannot add output or
+/// a prompt to a run whose stdout is being compared.
+fn script_command(shell: &str, script: &Path) -> Command {
+    let mut cmd = Command::new(shell_program(shell));
+    if shell == "pwsh" {
+        cmd.args(["-NoProfile", "-NonInteractive", "-File"]);
+    }
+    cmd.arg(sh_path(script));
+    cmd
 }
 
 /// Path to a checked-in generated completion under `cli/assets/completions/`.
@@ -196,17 +319,16 @@ end
 
 echo "COMPLETION_TEST_DONE"
 "#,
-        usage_bin.parent().unwrap().to_str().unwrap(),
-        comp_file.to_str().unwrap(),
-        temp_dir.to_str().unwrap()
+        sh_path(usage_bin.parent().unwrap()),
+        sh_path(&comp_file),
+        sh_path(&temp_dir)
     );
 
     let script_file = temp_dir.join("test.fish");
     fs::write(&script_file, &test_script).unwrap();
 
     // Execute the test in fish
-    let result = Command::new("fish")
-        .arg(script_file.to_str().unwrap())
+    let result = script_command("fish", &script_file)
         .output()
         .expect("Failed to run fish test");
 
@@ -384,17 +506,16 @@ fi
 
 echo "COMPLETION_TEST_DONE"
 "#,
-        usage_bin.parent().unwrap().to_str().unwrap(),
-        comp_file.to_str().unwrap(),
-        temp_dir.to_str().unwrap()
+        path_var_entry("bash", usage_bin.parent().unwrap()),
+        sh_path(&comp_file),
+        sh_path(&temp_dir)
     );
 
     let script_file = temp_dir.join("test.sh");
     fs::write(&script_file, &test_script).unwrap();
 
     // Execute the test
-    let result = Command::new("bash")
-        .arg(script_file.to_str().unwrap())
+    let result = script_command("bash", &script_file)
         .output()
         .expect("Failed to run bash test");
 
@@ -539,21 +660,16 @@ zpty -d comptest
 
 echo "COMPLETION_TEST_DONE"
 "#,
-        usage_bin.parent().unwrap().to_str().unwrap(),
-        temp_dir.to_str().unwrap(),
-        comp_file.to_str().unwrap()
+        path_var_entry("zsh", usage_bin.parent().unwrap()),
+        sh_path(&temp_dir),
+        sh_path(&comp_file)
     );
 
     let script_file = temp_dir.join("test.zsh");
     fs::write(&script_file, &test_script).unwrap();
 
-    // Execute the test with a timeout
-    let result = Command::new("timeout")
-        .arg("5") // 5 second timeout
-        .arg("zsh")
-        .arg(script_file.to_str().unwrap())
-        .output()
-        .expect("Failed to run zsh test");
+    // Execute the test with a timeout: the script drives a pty, which can hang.
+    let result = run_with_timeout("zsh", 5, &script_file).expect("Failed to run zsh test");
 
     let stdout = String::from_utf8_lossy(&result.stdout);
     let stderr = String::from_utf8_lossy(&result.stderr);
@@ -727,16 +843,15 @@ words=(testcli "")
 CURRENT=2
 _testcli
 "#,
-        usage_dir = usage_bin.parent().unwrap().to_str().unwrap(),
-        tmp = temp_dir.to_str().unwrap(),
-        comp = comp_file.to_str().unwrap(),
+        usage_dir = path_var_entry("zsh", usage_bin.parent().unwrap()),
+        tmp = sh_path(&temp_dir),
+        comp = sh_path(&comp_file),
     );
 
     let script_file = temp_dir.join("test.zsh");
     fs::write(&script_file, &test_script).unwrap();
 
-    let result = Command::new("zsh")
-        .arg(script_file.to_str().unwrap())
+    let result = script_command("zsh", &script_file)
         .output()
         .expect("Failed to run zsh test");
     let stdout = String::from_utf8_lossy(&result.stdout);
@@ -815,16 +930,15 @@ words=(testcli d)
 CURRENT=2
 _testcli
 "#,
-        usage_dir = usage_bin.parent().unwrap().to_str().unwrap(),
-        tmp = temp_dir.to_str().unwrap(),
-        comp = comp_file.to_str().unwrap(),
+        usage_dir = path_var_entry("zsh", usage_bin.parent().unwrap()),
+        tmp = sh_path(&temp_dir),
+        comp = sh_path(&comp_file),
     );
 
     let script_file = temp_dir.join("test.zsh");
     fs::write(&script_file, &test_script).unwrap();
 
-    let result = Command::new("zsh")
-        .arg(script_file.to_str().unwrap())
+    let result = script_command("zsh", &script_file)
         .output()
         .expect("Failed to run zsh test");
     let stdout = String::from_utf8_lossy(&result.stdout);
@@ -949,19 +1063,17 @@ if ($flagStr -match "verbose" -or $flagStr -match "-v") {{
 
 Write-Host "COMPLETION_TEST_DONE"
 "#,
-        usage_bin.parent().unwrap().to_str().unwrap(),
-        temp_dir.to_str().unwrap(),
-        comp_file.to_str().unwrap(),
-        spec_file.to_str().unwrap()
+        sh_path(usage_bin.parent().unwrap()),
+        sh_path(&temp_dir),
+        sh_path(&comp_file),
+        sh_path(&spec_file)
     );
 
     let script_file = temp_dir.join("test.ps1");
     fs::write(&script_file, &test_script).unwrap();
 
     // Execute the test in PowerShell
-    let result = Command::new("pwsh")
-        .args(["-NoProfile", "-NonInteractive", "-File"])
-        .arg(script_file.to_str().unwrap())
+    let result = script_command("pwsh", &script_file)
         .output()
         .expect("Failed to run pwsh - PowerShell Core must be installed for this test");
 
@@ -1099,15 +1211,14 @@ run_case empty 1 ex ""
 run_case dashes 1 ex "--"
 run_case foo 1 ex "--f"
 "#,
-        bin_dir = bin_dir.display(),
-        usage_dir = usage_bin.parent().unwrap().display(),
-        init_script = init_script.display(),
+        bin_dir = path_var_entry("bash", &bin_dir),
+        usage_dir = path_var_entry("bash", usage_bin.parent().unwrap()),
+        init_script = sh_path(&init_script),
     );
     let script_file = temp_dir.join("test.sh");
     fs::write(&script_file, &test_script).unwrap();
 
-    let result = Command::new("bash")
-        .arg(script_file.to_str().unwrap())
+    let result = script_command("bash", &script_file)
         .output()
         .expect("Failed to run bash init test");
     let stdout = String::from_utf8_lossy(&result.stdout);
@@ -1177,15 +1288,14 @@ words=(plain "")
 CURRENT=2
 _usage_default_complete
 "#,
-        bin_dir = bin_dir.display(),
-        usage_dir = usage_bin.parent().unwrap().display(),
-        init_script = init_script.display(),
+        bin_dir = path_var_entry("zsh", &bin_dir),
+        usage_dir = path_var_entry("zsh", usage_bin.parent().unwrap()),
+        init_script = sh_path(&init_script),
     );
     let script_file = temp_dir.join("test.zsh");
     fs::write(&script_file, &test_script).unwrap();
 
-    let result = Command::new("zsh")
-        .arg(script_file.to_str().unwrap())
+    let result = script_command("zsh", &script_file)
         .output()
         .expect("Failed to run zsh init test");
     let stdout = String::from_utf8_lossy(&result.stdout);
@@ -1281,17 +1391,16 @@ words=(testcli "")
 CURRENT=2
 _usage_default_complete
 "#,
-        bin_dir = bin_dir.to_str().unwrap(),
-        usage_dir = usage_bin.parent().unwrap().to_str().unwrap(),
-        tmp = temp_dir.to_str().unwrap(),
-        init = init_script.to_str().unwrap(),
+        bin_dir = path_var_entry("zsh", &bin_dir),
+        usage_dir = path_var_entry("zsh", usage_bin.parent().unwrap()),
+        tmp = sh_path(&temp_dir),
+        init = sh_path(&init_script),
     );
 
     let script_file = temp_dir.join("test.zsh");
     fs::write(&script_file, &test_script).unwrap();
 
-    let result = Command::new("zsh")
-        .arg(script_file.to_str().unwrap())
+    let result = script_command("zsh", &script_file)
         .output()
         .expect("Failed to run zsh init test");
     let stdout = String::from_utf8_lossy(&result.stdout);
@@ -1346,15 +1455,14 @@ echo "[registered] ex"
 echo "[empty]" (complete -C 'ex ')
 echo "[foo]" (complete -C 'ex --f')
 "#,
-        bin_dir = bin_dir.display(),
-        usage_dir = usage_bin.parent().unwrap().display(),
-        init_script = init_script.display(),
+        bin_dir = sh_path(&bin_dir),
+        usage_dir = sh_path(usage_bin.parent().unwrap()),
+        init_script = sh_path(&init_script),
     );
     let script_file = temp_dir.join("test.fish");
     fs::write(&script_file, &test_script).unwrap();
 
-    let result = Command::new("fish")
-        .arg(script_file.to_str().unwrap())
+    let result = script_command("fish", &script_file)
         .output()
         .expect("Failed to run fish init test");
     let stdout = String::from_utf8_lossy(&result.stdout);
@@ -1433,13 +1541,12 @@ source "{comp}"
 _testcli testcli "" testcli 1
 echo "GUARD_EXIT=$?"
 "#,
-        comp = comp_file.display(),
+        comp = sh_path(&comp_file),
     );
     let script_file = temp_dir.join("test.sh");
     fs::write(&script_file, &test_script).unwrap();
 
-    let result = Command::new("bash")
-        .arg(script_file.to_str().unwrap())
+    let result = script_command("bash", &script_file)
         .output()
         .expect("Failed to run bash guard test");
     let stdout = String::from_utf8_lossy(&result.stdout);
@@ -1484,15 +1591,14 @@ _usage usage "" usage 1
 echo "SPEC_BEGIN"
 cat "$XDG_CACHE_HOME/usage/usage__usage_spec_usage.spec"
 "#,
-        usage_dir = usage_bin.parent().unwrap().display(),
-        cache = temp_dir.display(),
-        asset = checked_in_completion("usage.bash").display(),
+        usage_dir = path_var_entry("bash", usage_bin.parent().unwrap()),
+        cache = sh_path(&temp_dir),
+        asset = sh_path(&checked_in_completion("usage.bash")),
     );
     let script_file = temp_dir.join("test.sh");
     fs::write(&script_file, &test_script).unwrap();
 
-    let result = Command::new("bash")
-        .arg(script_file.to_str().unwrap())
+    let result = script_command("bash", &script_file)
         .output()
         .expect("Failed to run bash shadow test");
     let stdout = String::from_utf8_lossy(&result.stdout);
@@ -1537,14 +1643,13 @@ COMPREPLY=()
 _usage_default_complete ex "" ex
 echo "INIT_EXIT=$?"
 "#,
-        bin_dir = bin_dir.display(),
-        init_script = init_script.display(),
+        bin_dir = path_var_entry("bash", &bin_dir),
+        init_script = sh_path(&init_script),
     );
     let script_file = temp_dir.join("test.sh");
     fs::write(&script_file, &test_script).unwrap();
 
-    let result = Command::new("bash")
-        .arg(script_file.to_str().unwrap())
+    let result = script_command("bash", &script_file)
         .output()
         .expect("Failed to run bash init guard test");
     let stdout = String::from_utf8_lossy(&result.stdout);
@@ -1596,13 +1701,12 @@ end
 source "{comp}"
 echo "[completions]" (complete -c testcli | string collect)
 "#,
-        comp = comp_file.display(),
+        comp = sh_path(&comp_file),
     );
     let script_file = temp_dir.join("test.fish");
     fs::write(&script_file, &test_script).unwrap();
 
-    let result = Command::new("fish")
-        .arg(script_file.to_str().unwrap())
+    let result = script_command("fish", &script_file)
         .output()
         .expect("Failed to run fish guard test");
     let stdout = String::from_utf8_lossy(&result.stdout);
@@ -1641,15 +1745,14 @@ source "{asset}"
 echo "SPEC_BEGIN"
 cat "$XDG_CACHE_HOME/usage/usage__usage_spec_usage.spec"
 "#,
-        usage_dir = usage_bin.parent().unwrap().display(),
-        cache = temp_dir.display(),
-        asset = checked_in_completion("usage.fish").display(),
+        usage_dir = sh_path(usage_bin.parent().unwrap()),
+        cache = sh_path(&temp_dir),
+        asset = sh_path(&checked_in_completion("usage.fish")),
     );
     let script_file = temp_dir.join("test.fish");
     fs::write(&script_file, &test_script).unwrap();
 
-    let result = Command::new("fish")
-        .arg(script_file.to_str().unwrap())
+    let result = script_command("fish", &script_file)
         .output()
         .expect("Failed to run fish shadow test");
     let stdout = String::from_utf8_lossy(&result.stdout);
@@ -1688,14 +1791,13 @@ end
 source "{init_script}"
 echo "[registered]" (complete -c ex | string collect)
 "#,
-        bin_dir = bin_dir.display(),
-        init_script = init_script.display(),
+        bin_dir = sh_path(&bin_dir),
+        init_script = sh_path(&init_script),
     );
     let script_file = temp_dir.join("test.fish");
     fs::write(&script_file, &test_script).unwrap();
 
-    let result = Command::new("fish")
-        .arg(script_file.to_str().unwrap())
+    let result = script_command("fish", &script_file)
         .output()
         .expect("Failed to run fish init guard test");
     let stdout = String::from_utf8_lossy(&result.stdout);

--- a/cli/tests/shell_override.rs
+++ b/cli/tests/shell_override.rs
@@ -1,81 +1,123 @@
 //! `USAGE_SHELL_<SHELL>` replaces the program `usage <shell>` runs.
 //!
-//! Unix-only because they pin the substitute to a real path (`/bin/echo`, `/bin/sh`). The
-//! variable itself is not Unix-specific — it exists for Windows, where `bash` resolves to the
-//! WSL launcher ahead of `PATH` — but the CI that runs these is Linux.
-
-#![cfg(unix)]
+//! Runs on every platform, Windows above all: that is where `bash` resolves to the WSL
+//! launcher ahead of `PATH`, which is the reason the variable exists. Nothing here assumes the
+//! default shell works, because on the platform this feature is for, it may well not.
 
 use assert_cmd::cargo;
 use assert_cmd::prelude::*;
-use predicates::prelude::*;
 use predicates::str::contains;
-use std::process::Command;
+use std::process::{Command, Output};
 
 const SCRIPT: &str = "../examples/test-new-usage-syntax.sh";
 
-/// `usage bash <script> --foo`, with every `USAGE_SHELL_*` this test cares about cleared so a
-/// developer's own environment cannot change the result.
+/// A program that exists wherever these tests run and is not a shell.
+///
+/// Cargo sets `$CARGO` for the processes it spawns, so this is the one executable a test can
+/// name without knowing the platform — `/bin/echo` has no Windows counterpart. Handed a script
+/// path it does not recognize, cargo repeats it back (`no such subcommand \`…\``), which is
+/// what makes the substitution observable.
+///
+/// Not the `usage` binary itself: its top level has a positional argument, so a path lands
+/// there and never reaches the error message.
+fn substitute_program() -> String {
+    std::env::var("CARGO").expect("cargo sets $CARGO for the processes it spawns")
+}
+
+/// `usage bash <script> --foo`, with every `USAGE_SHELL_*` cleared so a developer's own
+/// environment cannot change the result.
 fn usage_bash() -> Command {
     let mut cmd = Command::new(cargo::cargo_bin!("usage"));
     cmd.env_remove("USAGE_SHELL_BASH")
         .env_remove("USAGE_SHELL_ZSH")
+        .env_remove("USAGE_SHELL_FISH")
+        .env_remove("USAGE_SHELL_PWSH")
         .args(["bash", SCRIPT, "--foo"]);
     cmd
 }
 
+/// What the same invocation does with nothing overridden.
+///
+/// The fallback tests compare against this rather than asserting the script's output, because
+/// whether the default `bash` can run the script is a property of the machine — on Windows it
+/// depends on whether one is installed ahead of the WSL launcher. "Same as unset" is the
+/// property those tests are actually about, and it holds either way.
+fn baseline() -> Output {
+    usage_bash().output().unwrap()
+}
+
 #[test]
 fn the_override_replaces_the_program() {
-    // `/bin/echo` prints the argv it was handed, which shows both that a different program ran
-    // and that the script path and arguments reached it untouched.
-    usage_bash()
-        .env("USAGE_SHELL_BASH", "/bin/echo")
-        .assert()
-        .success()
-        .stdout(contains(SCRIPT))
-        .stdout(contains("foo: true").not());
+    let out = usage_bash()
+        .env("USAGE_SHELL_BASH", substitute_program())
+        .output()
+        .unwrap();
+
+    // The substitute names the script back, so argv reached it untouched...
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains(SCRIPT), "{stderr}");
+    // ...and the script itself never ran.
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(!stdout.contains("foo: true"), "{stdout}");
 }
 
 #[test]
 fn a_blank_override_runs_the_default_shell() {
-    usage_bash()
-        .env("USAGE_SHELL_BASH", "")
-        .assert()
-        .success()
-        .stdout(contains("foo: true"));
+    let base = baseline();
+    for blank in ["", "   ", "\t"] {
+        let out = usage_bash()
+            .env("USAGE_SHELL_BASH", blank)
+            .output()
+            .unwrap();
+        assert_eq!(out.status.code(), base.status.code(), "blank {blank:?}");
+        assert_eq!(out.stdout, base.stdout, "blank {blank:?}");
+        assert_eq!(out.stderr, base.stderr, "blank {blank:?}");
+    }
 }
 
 #[test]
 fn the_override_may_name_a_program_on_path() {
-    // The value does not have to be an absolute path — a name resolved through PATH works
-    // too, which is what the docs promise. `bash` names the same shell that would have run
-    // anyway, so the script's output must be unchanged.
+    // The value does not have to be an absolute path — a name resolved through PATH works too,
+    // which is what the docs promise. `bash` names the same shell that would have run anyway,
+    // so the outcome must be unchanged.
     //
-    // Not a different shell: every fixture here uses `set -o pipefail`, so a stand-in has to
-    // be one that understands it.
-    let expected = usage_bash().output().unwrap().stdout;
-    usage_bash()
+    // Not a different shell: every fixture here uses `set -o pipefail`, so a stand-in has to be
+    // one that understands it.
+    //
+    // stderr is left out of the comparison on purpose. Naming a program makes the run an
+    // overridden one, and `wsl_path_hint` only fires when nothing was overridden — so on a
+    // Windows machine where the default `bash` fails, the two runs differ by that hint alone.
+    let base = baseline();
+    let out = usage_bash()
         .env("USAGE_SHELL_BASH", "bash")
-        .assert()
-        .success()
-        .stdout(String::from_utf8(expected).unwrap());
+        .output()
+        .unwrap();
+
+    assert_eq!(out.status.code(), base.status.code());
+    assert_eq!(out.stdout, base.stdout);
 }
 
 #[test]
 fn a_program_that_cannot_be_started_names_itself_and_the_variable() {
+    // A bare name rather than a path, so it fails the same way on every platform: nothing
+    // resolves it on PATH, and no filesystem layout can accidentally make it exist.
     usage_bash()
-        .env("USAGE_SHELL_BASH", "/nonexistent/bash-xyz")
+        .env("USAGE_SHELL_BASH", "usage-no-such-shell-xyz")
         .assert()
         .failure()
-        .stderr(contains("/nonexistent/bash-xyz"))
+        .stderr(contains("usage-no-such-shell-xyz"))
         .stderr(contains("USAGE_SHELL_BASH"));
 }
 
 #[test]
 fn another_shells_variable_is_ignored() {
-    usage_bash()
-        .env("USAGE_SHELL_ZSH", "/bin/echo")
-        .assert()
-        .success()
-        .stdout(contains("foo: true"));
+    let base = baseline();
+    let out = usage_bash()
+        .env("USAGE_SHELL_ZSH", substitute_program())
+        .output()
+        .unwrap();
+
+    assert_eq!(out.status.code(), base.status.code());
+    assert_eq!(out.stdout, base.stdout);
+    assert_eq!(out.stderr, base.stderr);
 }

--- a/lib/tests/sdk_compile.rs
+++ b/lib/tests/sdk_compile.rs
@@ -118,14 +118,18 @@ fn test_python_sdk_imports() {
 
     // Validate syntax + imports for each module
     for module in &["types", "client", "runtime"] {
+        // The directory arrives as argv rather than inside the source. Interpolated into the
+        // string literal it used to sit in, a Windows path is read by Python's lexer first:
+        // `C:\Users\RUNNER~1\...` fails to even parse, because `\U` starts a unicode escape.
+        // Passing it as an argument keeps the path away from any escaping rules at all.
         let result = Command::new("python3")
             .args([
                 "-c",
                 &format!(
-                    "import sys; sys.path.insert(0, '{}'); from mytool_sdk.{module} import *",
-                    dir.path().display()
+                    "import sys; sys.path.insert(0, sys.argv[1]); from mytool_sdk.{module} import *"
                 ),
             ])
+            .arg(dir.path())
             .output()
             .expect("Failed to run python3");
 


### PR DESCRIPTION
Groundwork for running the test suite on Windows. Today it gives **15 failures and one file that never runs**, and every one of them is the test's own doing rather than a bug in `usage`.

Measured on a `windows-latest` runner after these changes: **538 passed, 0 failed, 0 skipped.**

## What was wrong

| Where | Failures | Cause |
| --- | --- | --- |
| `cli/tests/complete_word.rs` | 8 | the skip guard probes `sh`, but the fixtures need `bash` |
| `cli/tests/shell_completions_integration.rs` | 5 | `bash` is the WSL launcher, and Windows paths get eaten |
| `cli/tests/examples.rs` | 1 | spawns a `.sh` directly |
| `lib/tests/sdk_compile.rs` | 1 | a Windows path inside a Python string literal |
| `cli/tests/shell_override.rs` | — | `#![cfg(unix)]`, so 5 tests never run at all |

The last one is the sharpest: those are the tests for `USAGE_SHELL_<SHELL>` from #767, a feature that exists **for Windows**, and they only ever ran on Linux.

### `bash` on Windows is not a POSIX bash

The Win32 executable search order puts the system directory ahead of `PATH`, and installing WSL puts `bash.exe` there. So on such a machine `bash` is the WSL launcher no matter what else is installed, and it cannot open a Windows path:

```
/bin/bash: C:UsersJamAppDataLocalTempusage_bash_test_14636test.sh: No such file or directory
```

Two problems in one line. WSL cannot read `C:\…`, and the backslashes were already gone before it looked — the path was interpolated into a script body where `\` is an escape character, so `C:\Users\Jam` arrived as `C:UsersJam`.

**This is not exotic; a stock GitHub runner does it too.** On `windows-latest`:

```
> where bash
C:\Program Files\Git\bin\bash.exe
C:\Windows\System32\bash.exe
```

Git Bash is listed first, and yet `Command::new("bash")` reaches System32 — because `where` searches `PATH` while `CreateProcess` searches the system directory before it. Unset, `usage bash` there exits 1 with `Windows Subsystem for Linux has no installed distributions`. The two disagreeing is exactly what `USAGE_SHELL_<SHELL>` exists to settle.

### The skip guards were checking the wrong thing

`skip_if_shell_missing` asked whether `<shell> --version` spawns. WSL's bash answers that perfectly well and then fails at everything the tests need, which is why five bash tests **failed** where zsh and fish correctly skipped — those are simply absent on Windows.

`skip_if_posix_shell_missing` in `complete_word.rs` had the same shape of gap for a subtler reason: it probes `sh`, but the mount fixtures are `#!/usr/bin/env -S usage bash` scripts. On Windows the two need not be the same family — `sh` resolves to Git Bash while a bare `bash` is the WSL launcher — so `sh` starting proves nothing about whether the shebang will work.

## What changed

Tests only. No library or CLI source is touched.

**Guards now probe the precondition, not a proxy.** `skip_if_shell_missing` runs a script out of the temp directory and requires it to exit cleanly; `skip_if_posix_shell_missing` runs a real mount fixture through `usage bash` at the absolute path `sh` would hand its shebang. Both keep the existing rule of panicking under `CI` rather than skipping. On Linux nothing changes; on Windows an unusable shell now skips instead of failing.

The fixture path is built from `CARGO_MANIFEST_DIR` rather than `fs::canonicalize`, whose `\\?\` prefix `usage` cannot open — probing with one made the guard fail on the *shape of the path* rather than on the shell, and quietly skipped all eight mount tests on a machine where they run.

**Shell resolution goes through `USAGE_SHELL_<SHELL>`** — the same variable `shell_program_override` reads in `cli/src/env.rs`, so a developer configures one thing and the whole suite follows. Unset, which is every platform but Windows, means the bare name as before.

**One `script_command` builds every invocation**, so the guard and the tests it guards cannot drift apart — not in which program they run, nor in how. pwsh is where they would have: it needs `-File` to take a script path, and `-NoProfile -NonInteractive` so a developer's profile cannot add output to a run whose stdout is compared against a single token.

**Three places hand a Windows path to something that parses it, and each needed a different answer:**

- **Shell script bodies** — normalized to `/`, because `\` is an escape character there.
- **`$PATH` entries** — through `cygpath`, because `$PATH` is colon-separated, so `C:/Users/…` splits into `C` and `/Users/…` and neither resolves. Only the shell in use knows whether the answer is `/c/…`, `/cygdrive/c/…`, or a mount point from fstab, so the conversion is asked of it rather than of a `cygpath` that may not be on Windows' own `PATH`. Applies to bash and zsh; fish's `set -gx PATH a b` is space-separated and PowerShell's separator is `;`.
- **A Python string literal** — `sdk_compile.rs` put the SDK directory inside one, where `C:\Users\RUNNER~1\…` fails to parse at all: `\U` opens a unicode escape. That one now travels as argv, clear of any escaping rules rather than escaped around.

The zsh pty test's `timeout` wrapper also goes through the shell now. Spawning it directly walks into the same trap as `bash`: Windows keeps an unrelated `timeout.exe` — a sleep, not a watchdog — in the system directory.

**`test_empty_defaults_example` runs through `usage bash`**, like the nine other tests in its file. It was the only one relying on the shebang, and Windows cannot execute a `.sh` at all — the spawn fails with os error 193 before the shebang is read.

**`shell_override.rs` loses `#![cfg(unix)]`.** Two changes make it portable:

- The substitute program is `$CARGO` instead of `/bin/echo`, which has no Windows counterpart. Cargo sets the variable for the processes it spawns, so it is the one executable a test can name without knowing the platform, and handed a path it does not recognize it repeats it back — `no such subcommand \`…\`` — which is what makes the substitution observable. (Not the `usage` binary itself: its top level has a positional argument, so a path lands there and never reaches the error message.)
- The three fallback tests compare against a baseline run with nothing overridden, instead of asserting the script's output. Whether the default `bash` can run the script is a property of the machine, and on the platform this feature exists for it may well not — but "same as unset" is the property those tests are actually about, and it holds either way. The positive case is covered on every platform by `the_override_replaces_the_program`.

## Verified

**On a `windows-latest` runner**, with `USAGE_SHELL_BASH` naming Git Bash and `core.autocrlf` off: 538 passed, 0 failed, **0 skipped** — every shell-dependent test genuinely runs rather than skipping past.

**Locally on Windows**, with and without the override:

| | override set | unset |
| --- | --- | --- |
| `complete_word` | 34 pass, 0 skip | 26 pass, 8 skip |
| `shell_completions_integration` | 19 pass | 3 pass, 16 skip |
| `examples` | 10 pass | 10 pass |
| `shell_override` | 5 pass | 5 pass |

**Linux**: `cargo test --all --all-features` and `cargo clippy --all --all-features --all-targets -- -D warnings` unchanged.

## Follow-up: the Windows CI job

Deliberately not in this PR, but no longer guesswork — I ran it on the fork to find out what it needs, and all three of these are measured rather than assumed:

1. **`core.autocrlf false`, set before checkout.** git defaults it to `true` on Windows and the repo has no `.gitattributes`, so fixtures arrive with CRLF and seven help tests plus two markdown tests fail on an ending nobody can see — the printed diff showed identical text.
2. **`USAGE_SHELL_BASH` pointed at Git Bash**, for the `where` versus `CreateProcess` reason above.
3. **The `CI` panic in `skip_if_shell_missing` relaxed on Windows.** The rule exists because the Linux job installs zsh and fish on purpose; nothing installs them on Windows, so their absence is expected rather than a configuration bug. mise draws the same line — its Windows jobs install no POSIX shells at all. That is a one-line change I left out of this PR, since it is about CI policy rather than about the tests.

Happy to open that as a second PR whenever you want it.

---

_This pull request was generated by Claude Code._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved cross-platform coverage for shell completions, shell overrides, and example execution.
  * Added validation that configured shells can successfully run mounted fixtures.
  * Expanded support for Bash, Zsh, Fish, and PowerShell, including path and timeout handling.
  * Updated unavailable-shell handling: CI reports failures, while non-CI environments skip affected tests.
  * Added coverage for shell overrides, fallback behavior, argument passing, and ignored environment variables.
  * Improved Python SDK import testing on Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
