### PR TITLE
refactor(lib)!: mark ParseOutput and UsageErr non_exhaustive

### DIFF
--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -2,6 +2,7 @@ use miette::{Diagnostic, NamedSource, SourceSpan};
 use thiserror::Error;
 
 #[derive(Error, Diagnostic, Debug)]
+#[non_exhaustive]
 pub enum UsageErr {
     #[error("Invalid flag `{token}`: {reason}")]
     InvalidFlag {

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -238,6 +238,7 @@ fn get_flag_key(word: &str) -> &str {
     }
 }
 
+#[non_exhaustive]
 pub struct ParseOutput {
     pub cmd: SpecCommand,
     pub cmds: Vec<SpecCommand>,


### PR DESCRIPTION
Two attributes, and a repair for the version signal #762 lost.

## The consistency part

Ten public types in `usage-lib` already carry `#[non_exhaustive]` — `Spec`, `SpecArg`, `SpecFlag`, `SpecCommand`'s `SpecExample`, `Parser`, and others. `ParseOutput` and `UsageErr` were missed, and #762 ran straight into the consequence: adding `next_arg` and `double_dash_seen` to one, and `ArgRequiresDoubleDash` to the other, were each reported as breaking on their own.

Neither is a type a caller builds or matches exhaustively:

- **`ParseOutput`** is what `parse()` returns. Its only struct literal is in `parse.rs` itself; nothing outside the crate constructs one.
- **`UsageErr`** is an error type, where a wildcard arm is the normal shape. Nothing in the workspace matches on it — `usage-cli` uses it as a return type and downcasts once, in `cli/src/lib.rs`.

`cargo build --all --all-features` passes untouched, which is the workspace-level check that neither pattern exists.

## The repair part

**main has been red since #762 merged**, and this fixes the cause.

The squash took its subject from the PR title, which had no `!`, so the `BREAKING CHANGE:` footer on the branch commit never reached main. What landed was:

```
fix(parse): enforce double_dash="required" for positional args (#762)
```

git-cliff therefore reads main as holding only a `fix:` since v4.1.0, and `--bumped-version` would compute **v4.1.1** — shipping two breaking API changes as a patch. Every PR opened against main is red in the meantime, because `lint:semver` compares Cargo.toml (4.1.0) against crates.io (4.1.0), calls it `no change; assume patch`, and any major finding fails.

Marking a type `#[non_exhaustive]` is itself a breaking change, so the `!` on this commit is the honest description of what it does, not a marker added to game the version. And it puts the major back within reach of `--bumped-version`, so the next release computes v5.0.0 and covers #762 as well.

## What `lint:semver` says now

Still two failures, but different — and better ones:

```
--- failure enum_marked_non_exhaustive ---
  enum UsageErr in lib/src/error.rs:6

--- failure struct_marked_non_exhaustive ---
  struct ParseOutput in lib/src/parse.rs:242

Summary  semver requires new major version: 2 major and 0 minor checks failed
```

`constructible_struct_adds_field` and `enum_variant_added` are gone: once a struct cannot be constructed externally and an enum cannot be matched exhaustively, adding to either is no longer separately breaking. The attribute replaces two one-off findings with the durable statement, and that is the point of adding it now rather than later.

**This PR does not turn `lint:semver` green.** It goes green when the release PR sets Cargo.toml to 5.0.0. Merging this makes that release *be* 5.0.0.

## Why the version is not bumped here

`tasks/release-plz` opens with

```bash
if ! echo "$released_versions" | grep -q "^v$cur_version$"; then
  cargo publish -p usage-lib
  ...
  git tag "v$cur_version"
```

which is the publish half of the release-PR flow. A hand-written bump in a feature PR is indistinguishable from a merged release branch, so it would publish to crates.io on the merge push — no CHANGELOG entry, no release PR, outside the cadence guard in `auto-merge-release.yml`. I tried exactly that on #762 and backed it out.

## Verified

`cargo build --all --all-features`, `cargo test --all --all-features`, `cargo fmt --all -- --check` and `cargo clippy --all --all-features --all-targets -- -D warnings` all pass on Linux. `cargo semver-checks check-release -p usage-lib` fails with the two findings above, which is the intended outcome.

## Three more types, if you want them

The same gap exists on `SpecCommand` (`lib/src/spec/cmd.rs`), `ParseValue` (`lib/src/parse.rs`) and `SpecDoubleDashChoices` (`lib/src/spec/arg.rs`). Since this release already spends a major, folding them in costs nothing extra — say the word and I will.

I left them out because one of them is not free. `ParseValue` is what consumers match to read a parsed value, so `#[non_exhaustive]` forces a wildcard arm on mise and anyone else doing the same. That is a judgement about downstream ergonomics rather than about semver hygiene, and it seemed yours to make. `SpecCommand` and `SpecDoubleDashChoices` carry no such cost.

---

_This pull request was generated by Claude Code._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved API forward compatibility by allowing additional usage error variants and parse output fields in future releases.
  * External integrations must avoid exhaustive matching or construction of these public types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->