### PR TITLE
chore: resume v5 release after partial publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,7 +336,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clap_usage"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "clap",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ authors = ["Jeff Dickey @jdx"]
 license = "MIT"
 
 [workspace.dependencies]
-clap_usage = { path = "./clap_usage", version = "4.0.0" }
+clap_usage = { path = "./clap_usage", version = "5.0.0" }
 usage-cli = { path = "./cli" }
 usage-lib = { path = "./lib", version = "5.0.0", features = ["clap"] }
 

--- a/clap_usage/Cargo.toml
+++ b/clap_usage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clap_usage"
 edition = "2021"
-version = "4.0.0"
+version = "5.0.0"
 include = [
     "/Cargo.toml",
     "/Cargo.lock",

--- a/tasks/release-plz
+++ b/tasks/release-plz
@@ -9,16 +9,27 @@ set -euxo pipefail
 # It depends on usage-lib at the workspace version, so it can only be published
 # once that version is on crates.io — hence a function called in dependency
 # order rather than a block at the top of the script.
-publish_clap_usage_if_needed() {
-  local version
-  version="$(cargo pkgid clap_usage | cut -d# -f2 | cut -d@ -f2)"
-  if curl -fsS https://index.crates.io/cl/ap/clap_usage |
-    grep -q "\"vers\":\"$version\""; then
+crate_version_is_published() {
+  local crate="$1" version="$2" index_path
+  case "${#crate}" in
+  1) index_path="1/$crate" ;;
+  2) index_path="2/$crate" ;;
+  3) index_path="3/${crate:0:1}/$crate" ;;
+  *) index_path="${crate:0:2}/${crate:2:2}/$crate" ;;
+  esac
+  curl -fsS "https://index.crates.io/$index_path" |
+    grep -q "\"vers\":\"$version\""
+}
+
+publish_crate_if_needed() {
+  local crate="$1" version
+  version="$(cargo pkgid "$crate" | cut -d# -f2 | cut -d@ -f2)"
+  if crate_version_is_published "$crate" "$version"; then
     return
   fi
-  echo "Releasing clap_usage $version"
+  echo "Releasing $crate $version"
   if [ "${usage_dry_run:-}" != 1 ]; then
-    cargo publish -p clap_usage
+    cargo publish -p "$crate"
   fi
 }
 
@@ -27,9 +38,9 @@ cur_version="$(cargo pkgid usage-lib | cut -d# -f2 | cut -d@ -f2)"
 if ! echo "$released_versions" | grep -q "^v$cur_version$"; then
   echo "Releasing $cur_version"
   if [ "${usage_dry_run:-}" != 1 ]; then
-    cargo publish -p usage-lib
-    publish_clap_usage_if_needed
-    cargo publish -p usage-cli
+    publish_crate_if_needed usage-lib
+    publish_crate_if_needed clap_usage
+    publish_crate_if_needed usage-cli
     git tag "v$cur_version"
     git push --tags
   fi
@@ -38,7 +49,7 @@ fi
 
 # usage-lib's current version is already released, so clap_usage's dependency
 # is satisfied; catch it up if it is behind.
-publish_clap_usage_if_needed
+publish_crate_if_needed clap_usage
 
 version="$(git cliff --bumped-version --include-path 'lib/**' --include-path 'cli/**')"
 


### PR DESCRIPTION
## Summary

- bump `clap_usage` to 5.0.0 so `usage-cli` resolves a single `usage-lib` major
- make crate publishing idempotent by skipping versions already present in the crates.io sparse index
- allow the v5 release workflow to resume after `usage-lib 5.0.0` was published but CLI verification failed

## Root cause

The first v5 publish uploaded `usage-lib 5.0.0`, then packaged `usage-cli` against published `clap_usage 4.0.0`. That crate depends on `usage-lib 4.x`, so the package contained incompatible `usage::Spec` types from v4 and v5.

## Validation

- `cargo check --workspace`
- `cargo package -p clap_usage --allow-dirty`
- `shellcheck tasks/release-plz`
- `mise run lint`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release automation and crate versioning on the critical path to crates.io; logic is straightforward but a mistake could skip or duplicate publishes.
> 
> **Overview**
> **Resumes the v5 release** after `usage-lib 5.0.0` was already on crates.io but the CLI publish failed: published `clap_usage 4.0.0` still pulled `usage-lib 4.x`, so `usage-cli` mixed incompatible `usage::Spec` types.
> 
> **Bumps `clap_usage` to 5.0.0** in the workspace and crate manifests so `usage-cli` resolves a single `usage-lib` major alongside the workspace.
> 
> **Refactors `tasks/release-plz`** so publishing is idempotent: `crate_version_is_published` checks the crates.io sparse index (correct path layout for any crate name), and `publish_crate_if_needed` skips versions already published. The main release path now calls that helper for `usage-lib`, `clap_usage`, and `usage-cli` in dependency order instead of only special-casing `clap_usage`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d7d106c1c54df7b7467bea6dc8fc47a873385a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `clap_usage` dependency to version 5.0.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->