### PR TITLE
feat(spec): parse usage comments from strings

### DIFF
--- a/lib/src/spec/mod.rs
+++ b/lib/src/spec/mod.rs
@@ -130,7 +130,9 @@ impl Spec {
     ///
     /// Extracts the spec from comment lines marked with `#USAGE`, `//USAGE`,
     /// `::USAGE`, or their `[USAGE]` variants. Unlike [`Self::parse_script`],
-    /// this function cannot infer `bin` or `name` from a filename.
+    /// this function cannot infer `bin` or `name` from a filename. Relative
+    /// `include` paths are rejected because there is no source path to resolve
+    /// them against; absolute `include` paths remain supported.
     #[must_use = "parsing result should be used"]
     pub fn parse_script_str(input: &str) -> Result<Spec, UsageErr> {
         Self::parse_script_with_path(input, Path::new(""))
@@ -239,10 +241,12 @@ impl Spec {
                             .file
                             .parent()
                             .ok_or_else(|| {
-                                ctx.build_err(
-                                    format!("cannot get parent of {}", ctx.file.display()),
-                                    node.span(),
-                                )
+                                let msg = if ctx.file.as_os_str().is_empty() {
+                                    "relative includes require a source file".to_string()
+                                } else {
+                                    format!("cannot get parent of {}", ctx.file.display())
+                                };
+                                ctx.build_err(msg, node.span())
                             })?
                             .join(file),
                         false => file.to_path_buf(),
@@ -1014,5 +1018,18 @@ echo "hello"
         assert_eq!(spec.name, "test");
         assert_eq!(spec.cmd.flags.len(), 1);
         assert_eq!(spec.cmd.flags[0].long, ["foo"]);
+    }
+
+    #[test]
+    fn test_parse_script_str_rejects_relative_includes() {
+        let err = Spec::parse_script_str(r#"#USAGE include file="relative.usage.kdl""#)
+            .expect_err("relative includes need a source path");
+
+        match err {
+            UsageErr::InvalidInput(msg, _, _) => {
+                assert_eq!(msg, "relative includes require a source file");
+            }
+            err => panic!("unexpected error: {err:?}"),
+        }
     }
 }

--- a/lib/src/spec/mod.rs
+++ b/lib/src/spec/mod.rs
@@ -85,7 +85,7 @@ impl Spec {
     ///
     /// Automatically detects whether the file is:
     /// - A `.kdl` or `.usage.kdl` file containing a raw spec
-    /// - A script file with embedded `# USAGE:` comments
+    /// - A script file with embedded `#USAGE` comments
     ///
     /// If `bin` is not specified in the spec, it defaults to the filename.
     #[must_use = "parsing result should be used"]
@@ -107,13 +107,12 @@ impl Spec {
     }
     /// Parse a spec from a script file's embedded USAGE comments.
     ///
-    /// Extracts the spec from comment lines starting with `# USAGE:` or `// USAGE:`.
+    /// Extracts the spec from comment lines marked with `#USAGE`, `//USAGE`,
+    /// `::USAGE`, or their `[USAGE]` variants.
     /// If `bin` is not specified in the spec, it defaults to the filename.
     #[must_use = "parsing result should be used"]
     pub fn parse_script(file: &Path) -> Result<Spec, UsageErr> {
-        let raw = extract_usage_from_comments(&file::read_to_string(file)?);
-        let ctx = ParsingContext::new(file, &raw);
-        let mut spec = Self::parse(&ctx, &raw)?;
+        let mut spec = Self::parse_script_with_path(&file::read_to_string(file)?, file)?;
         if spec.bin.is_empty() {
             spec.bin = file
                 .file_name()
@@ -125,6 +124,22 @@ impl Spec {
             spec.name.clone_from(&spec.bin);
         }
         Ok(spec)
+    }
+
+    /// Parse a spec from a script string's embedded USAGE comments.
+    ///
+    /// Extracts the spec from comment lines marked with `#USAGE`, `//USAGE`,
+    /// `::USAGE`, or their `[USAGE]` variants. Unlike [`Self::parse_script`],
+    /// this function cannot infer `bin` or `name` from a filename.
+    #[must_use = "parsing result should be used"]
+    pub fn parse_script_str(input: &str) -> Result<Spec, UsageErr> {
+        Self::parse_script_with_path(input, Path::new(""))
+    }
+
+    fn parse_script_with_path(input: &str, file: &Path) -> Result<Spec, UsageErr> {
+        let raw = extract_usage_from_comments(input);
+        let ctx = ParsingContext::new(file, &raw);
+        Self::parse(&ctx, &raw)
     }
 
     #[deprecated]
@@ -981,5 +996,23 @@ example "demo --version"
             output.contains("example \"demo --help\" header=\"Getting help\" help=\"Show help\"")
         );
         assert!(output.contains("example \"demo --version\""));
+    }
+
+    #[test]
+    fn test_parse_script_str() {
+        let spec = Spec::parse_script_str(
+            r#"
+#!/bin/bash
+#USAGE bin "test"
+#USAGE flag "--foo" help="test"
+echo "hello"
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(spec.bin, "test");
+        assert_eq!(spec.name, "test");
+        assert_eq!(spec.cmd.flags.len(), 1);
+        assert_eq!(spec.cmd.flags[0].long, ["foo"]);
     }
 }


### PR DESCRIPTION
## Summary

- add `Spec::parse_script_str` for parsing embedded USAGE comments from an in-memory script
- preserve file-backed parsing diagnostics and filename inference
- correct the documented supported USAGE comment markers
- add coverage for parsing a complete script string

This gives embedders a direct Rust API without requiring a temporary file or deserializing `Spec`.

Closes #781.

## Validation

- `cargo test -p usage-lib --all-features`
- `cargo clippy -p usage-lib --all-features -- -D warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public API and clearer errors in spec parsing only; no auth, I/O, or runtime behavior changes beyond new entry points.
> 
> **Overview**
> Adds **`Spec::parse_script_str`** so embedders can turn a script body into a `Spec` without writing a temp file or hand-parsing KDL. File-based **`parse_script`** now shares **`parse_script_with_path`** with the string API; only the file path still drives default **`bin`/`name`** inference.
> 
> String parsing uses an empty source path, so **relative `include` paths fail** with *"relative includes require a source file"* instead of a parent-directory error. Docs now describe the real markers (`#USAGE`, `//USAGE`, `::USAGE`, and `[USAGE]` variants) rather than `# USAGE:`.
> 
> Tests cover a full embedded script and the relative-include rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cc4e7421706496e12840b066727a76ac5506a0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for extracting usage specifications from `#USAGE`, `//USAGE`, `::USAGE`, and `[USAGE]` markers.
  * Added a public API for parsing embedded usage specifications directly from strings.
  * String-based parsing now supports absolute includes without requiring filename-based defaults.

* **Bug Fixes**
  * Improved script parsing consistency across supported usage-marker formats.
  * Added validation to reject unsupported relative includes when parsing strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->