### PR TITLE
fix(spec): avoid inferred metadata from included specs

### DIFF
--- a/cli/src/cli/lint.rs
+++ b/cli/src/cli/lint.rs
@@ -128,16 +128,6 @@ impl Lint {
 pub fn lint_spec(spec: &Spec) -> Vec<LintIssue> {
     let mut issues = Vec::new();
 
-    // Check spec-level issues
-    if spec.bin.is_empty() && spec.name.is_empty() {
-        issues.push(LintIssue {
-            severity: Severity::Warning,
-            code: "missing-name".to_string(),
-            message: "Spec has no name or bin defined".to_string(),
-            location: None,
-        });
-    }
-
     // Check default_subcommand reference
     if let Some(default_subcmd) = &spec.default_subcommand {
         if !spec.cmd.subcommands.contains_key(default_subcmd) {
@@ -392,6 +382,14 @@ arg "<input>"
         let issues = lint_spec(&spec);
         assert!(issues.iter().any(|i| i.code == "missing-flag-help"));
         assert!(issues.iter().any(|i| i.code == "missing-arg-help"));
+    }
+
+    #[test]
+    fn test_lint_allows_missing_name_and_bin() {
+        let spec: Spec = r#"arg "<file>" help="The file to process""#.parse().unwrap();
+
+        let issues = lint_spec(&spec);
+        assert!(issues.is_empty());
     }
 
     #[test]

--- a/lib/src/spec/mod.rs
+++ b/lib/src/spec/mod.rs
@@ -90,10 +90,17 @@ impl Spec {
     /// If `bin` is not specified in the spec, it defaults to the filename.
     #[must_use = "parsing result should be used"]
     pub fn parse_file(file: &Path) -> Result<Spec, UsageErr> {
+        Self::parse_file_with_metadata_inference(file, true)
+    }
+
+    fn parse_file_with_metadata_inference(
+        file: &Path,
+        infer_metadata_from_filename: bool,
+    ) -> Result<Spec, UsageErr> {
         let spec = split_script(file)?;
         let ctx = ParsingContext::new(file, &spec);
         let mut schema = Self::parse(&ctx, &spec)?;
-        if schema.bin.is_empty() {
+        if infer_metadata_from_filename && schema.bin.is_empty() {
             schema.bin = file
                 .file_name()
                 .and_then(|n| n.to_str())
@@ -252,7 +259,7 @@ impl Spec {
                         false => file.to_path_buf(),
                     };
                     info!("include: {}", file.display());
-                    let other = Self::parse_file(&file)?;
+                    let other = Self::parse_file_with_metadata_inference(&file, false)?;
                     schema.merge(other);
                 }
                 k => bail_parse!(ctx, node.node.name().span(), "unsupported spec key {k}"),
@@ -1031,5 +1038,20 @@ echo "hello"
             }
             err => panic!("unexpected error: {err:?}"),
         }
+    }
+
+    #[test]
+    fn test_include_does_not_infer_metadata_from_included_filename() {
+        let dir = tempfile::tempdir().unwrap();
+        let included = dir.path().join("overrides.usage.kdl");
+        let root = dir.path().join("my-script.usage.kdl");
+        std::fs::write(&included, "").unwrap();
+        std::fs::write(&root, "include file=\"./overrides.usage.kdl\"\n").unwrap();
+
+        let spec = Spec::parse_file(&root).unwrap();
+
+        assert_eq!(spec.name, "my-script.usage.kdl");
+        assert_eq!(spec.bin, "my-script.usage.kdl");
+        assert!(spec.cmd.name.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- keep filename-derived `name` and `bin` metadata limited to the top-level spec
- parse included fragments without inferring metadata from their filenames
- remove the unreachable `missing-name` lint and accept omitted metadata consistently for files and stdin
- add regression coverage for both behaviors

## Root cause
`Spec::parse_file()` intentionally derives a missing `bin` from the filename and then derives `name` from `bin`. This caused two related inconsistencies:

- file-based linting could never trigger `missing-name`, while stdin linting could because it has no filename
- `include` also called `parse_file()`, so an empty included fragment acquired its own filename as metadata and overwrote the parent spec, producing a spurious `missing-cmd-help`

The fallback now applies only to the top-level file. Explicit metadata in included specs still merges normally.

Closes #784.
Closes #785.

## Validation
- `cargo fmt --all -- --check`
- `cargo test --all --all-features`
- `cargo clippy --all --all-features -- -D warnings`
- reproduced both reported cases with metadata-free file/stdin input and an empty included override

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed an unnecessary lint warning for specifications that omit both a name and a binary.
  - Such specifications are now accepted without lint issues.
  - Prevented included specification files from incorrectly inheriting their filenames as names or binary identifiers.
  - Preserved metadata inferred from the primary specification file while ignoring metadata from included files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->