### PR TITLE
fix(ci): anchor release bump at current version

### DIFF
--- a/tasks/release-plz
+++ b/tasks/release-plz
@@ -51,7 +51,11 @@ fi
 # is satisfied; catch it up if it is behind.
 publish_crate_if_needed clap_usage
 
-version="$(git cliff --bumped-version --include-path 'lib/**' --include-path 'cli/**')"
+# Anchor the range before filtering paths. A release tag may point at a commit that only
+# changes root release files; letting the path filter hide that tag can make cliff propose
+# a version lower than the one already published.
+release_range="v$cur_version..HEAD"
+version="$(git cliff "$release_range" --bumped-version --include-path 'lib/**' --include-path 'cli/**')"
 
 if [ "v$cur_version" == "$version" ]; then
   echo "No usage-lib/usage-cli changes since $version; nothing to release"
@@ -60,17 +64,17 @@ fi
 
 if [ "${usage_dry_run:-}" == 1 ]; then
   echo "version: $version"
-  changelog="$(git cliff --bump --unreleased --strip all --include-path 'lib/**' --include-path 'cli/**')"
+  changelog="$(git cliff "$release_range" --tag "$version" --strip all --include-path 'lib/**' --include-path 'cli/**')"
   echo "changelog: $changelog"
   exit 0
 fi
 
 # Generate changelog using git-cliff (LLM editorialization happens in release.yml after merge)
-git cliff --bump -o CHANGELOG.md --include-path 'lib/**' --include-path 'cli/**'
+git cliff "$release_range" --tag "$version" --prepend CHANGELOG.md --include-path 'lib/**' --include-path 'cli/**'
 
 # Get the unreleased notes for PR body
 # Strip version header since PR title already has version
-PR_BODY="$(git cliff --bump --unreleased --strip all --include-path 'lib/**' --include-path 'cli/**' | tail -n +3)"
+PR_BODY="$(git cliff "$release_range" --tag "$version" --strip all --include-path 'lib/**' --include-path 'cli/**' | tail -n +3)"
 
 cargo set-version "${version#v}" --exclude clap_usage
 mise run render


### PR DESCRIPTION
## Summary
- anchor git-cliff at the workspace's current published version before applying path filters
- generate release notes from the explicit current-tag-to-HEAD range
- prepend the new release section instead of regenerating history from a path-filtered tag view

## Root cause
The release task filtered commits to `lib/**` and `cli/**` before git-cliff selected its version baseline. The `v5.0.0` recovery tag points at a commit that changed only root release files, so the filter hid that tag and git-cliff fell back to `v4.1.0`. It proposed `v4.2.0`, and `cargo set-version` rejected the attempted downgrade from `5.0.0`.

Using `v$cur_version..HEAD` preserves the intended path filtering while making the release baseline explicit.

## Validation
- `shellcheck tasks/release-plz`
- `mise run lint`
- `usage_dry_run=1 ./tasks/release-plz`
  - computes `v5.1.0`
  - generates only changes from `v5.0.0..HEAD`
  - exits before mutating release state
- verified the prepend flow retains exactly one `5.0.0` section and adds exactly one `5.1.0` section

Fixes the repeated `release-plz` failures, including [run 31299892428](https://github.com/jdx/usage/actions/runs/31299892428) and [run 31318073261](https://github.com/jdx/usage/actions/runs/31318073261).

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the release automation path that sets versions and changelog content; wrong range or cliff flags could still mis-version or corrupt changelog, but the change is narrowly scoped and was dry-run validated.
> 
> **Overview**
> **Fixes `release-plz` proposing a version downgrade** when the latest release tag sits on a commit that only touches root release files and disappears under `lib/**` / `cli/**` path filters—git-cliff was effectively basing off an older tag (e.g. `v4.1.0` instead of `v5.0.0`) and suggesting `v4.2.0`, which `cargo set-version` rejects.
> 
> The script now sets `release_range="v$cur_version..HEAD"` and passes that range into every `git cliff` call for bumped version, dry-run output, `CHANGELOG.md`, and PR body. Changelog steps drop `--bump` / `--unreleased` in favor of `--tag "$version"` with **`--prepend CHANGELOG.md`**, so notes come from the anchored range while path filters still limit which commits count.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c57d22639abe4647cf8d76202fc9a3bef033898. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release changelog and version calculations to consistently include changes since the current release tag.
  * Updated dry-run and release PR generation to produce more accurate results when filtering changes by path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->