### PR TITLE
feat(spec): support flag relationships

### DIFF
--- a/docs/spec/reference/flag.md
+++ b/docs/spec/reference/flag.md
@@ -23,14 +23,13 @@ flag "--color" negate="--no-color" default=#true // $usage_color=#true by defaul
                                                  // --no-color will set $usage_color=#false
 
 flag "--color" env="MYCLI_COLOR" // flag can be backed by an env var
-flag "--color" config="ui.color" // flag can be backed by a config file
 
 flag "--file <file>"  // args named "<file>" will be completed as files
 flag "--dir <dir>"    // args named "<dir>" will be completed as directories
 
 flag "--file <file>" required_if="--dir"     // if --dir is set, --file must also be set
 flag "--file <file>" required_unless="--dir" // either --file or --dir must be present
-flag "--file <file>" overrides="--stdin"     // if --file is set, previous --stdin will be ignored
+flag "--file <file>" overrides="--stdin" // --file and --stdin override each other; the last one wins
 
 flag "--shell <shell>" {
   choices "bash" "zsh" "fish" // <shell> must be one of the choices

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -243,6 +243,11 @@ pub struct ParseOutput {
     pub cmds: Vec<SpecCommand>,
     pub args: IndexMap<Arc<SpecArg>, ParseValue>,
     pub flags: IndexMap<Arc<SpecFlag>, ParseValue>,
+    /// Flags removed because they lost an `overrides` relationship.
+    ///
+    /// These names are retained so defaults and environment values do not restore an
+    /// overridden flag after command-line parsing.
+    pub overridden_flags: HashSet<String>,
     /// Every flag the parser recognizes at this point, keyed by each of its aliases
     /// (`--long`, `-s`, negations).
     ///
@@ -415,7 +420,7 @@ impl<'a> Parser<'a> {
 
         // Apply env vars and defaults for flags
         for flag in out.available_flags.values() {
-            if out.flags.contains_key(flag) {
+            if out.flags.contains_key(flag) || out.overridden_flags.contains(&flag.name) {
                 continue;
             }
             if let Some(env_var) = flag.env.as_ref() {
@@ -557,6 +562,7 @@ fn parse_partial_with_env(
         cmds: vec![spec.cmd.clone()],
         args: IndexMap::new(),
         flags: IndexMap::new(),
+        overridden_flags: HashSet::new(),
         available_flags: gather_flags(&spec.cmd),
         flag_awaiting_value: vec![],
         errors: vec![],
@@ -792,6 +798,12 @@ fn parse_partial_with_env(
             grouped_flag = false;
             let (word, val) = w.split_once('=').unwrap_or_else(|| (&w, ""));
             if let Some(f) = binding.as_ref().or_else(|| out.available_flags.get(word)) {
+                apply_flag_overrides(
+                    f,
+                    &out.available_flags,
+                    &mut out.flags,
+                    &mut out.overridden_flags,
+                );
                 // Only push the embedded value back when the flag is known so that
                 // unknown --flag=value tokens fall through intact to positional arg
                 // handling without also injecting a stray "value" positional.
@@ -831,6 +843,12 @@ fn parse_partial_with_env(
                 .as_ref()
                 .or_else(|| out.available_flags.get(&format!("-{short}")))
             {
+                apply_flag_overrides(
+                    f,
+                    &out.available_flags,
+                    &mut out.flags,
+                    &mut out.overridden_flags,
+                );
                 if w.len() > 2 {
                     input.push_front(format!("-{}", &w[2..]));
                     prefix_bindings.push_front(None);
@@ -957,16 +975,22 @@ fn parse_partial_with_env(
     }
 
     for flag in unique_flags(out.available_flags.values()) {
-        if out.flags.contains_key(flag) {
+        if out.flags.contains_key(flag) || out.overridden_flags.contains(&flag.name) {
             continue;
         }
         let has_default =
             !flag.default.is_empty() || flag.arg.iter().any(|a| !a.default.is_empty());
-        // Check if there's an env var available (custom env map takes precedence)
-        let has_env = flag.env.as_ref().is_some_and(|e| {
-            custom_env.map(|env| env.contains_key(e)).unwrap_or(false) || std::env::var(e).is_ok()
-        });
-        if flag.required && !has_default && !has_env {
+        let has_env = flag_has_env(flag, custom_env);
+        let required_if = flag
+            .required_if
+            .iter()
+            .any(|selector| selector_is_explicit(selector, &out, custom_env));
+        let required_unless = !flag.required_unless.is_empty()
+            && !flag
+                .required_unless
+                .iter()
+                .any(|selector| selector_is_explicit(selector, &out, custom_env));
+        if (flag.required || required_if || required_unless) && !has_default && !has_env {
             out.errors.push(UsageErr::MissingFlag(flag.name.clone()));
         }
     }
@@ -1027,6 +1051,60 @@ fn parse_partial_with_env(
     }
 
     Ok(out)
+}
+
+fn flag_matches_selector(flag: &SpecFlag, selector: &str) -> bool {
+    flag.name == selector || flag_keys(flag).iter().any(|key| key == selector)
+}
+
+fn flags_override(overrider: &SpecFlag, overridden: &SpecFlag) -> bool {
+    overrider
+        .overrides
+        .iter()
+        .any(|selector| flag_matches_selector(overridden, selector))
+}
+
+fn flag_has_env(flag: &SpecFlag, custom_env: Option<&HashMap<String, String>>) -> bool {
+    flag.env.as_ref().is_some_and(|env_var| {
+        custom_env
+            .map(|env| env.contains_key(env_var))
+            .unwrap_or(false)
+            || std::env::var(env_var).is_ok()
+    })
+}
+
+fn selector_is_explicit(
+    selector: &str,
+    out: &ParseOutput,
+    custom_env: Option<&HashMap<String, String>>,
+) -> bool {
+    out.available_flags
+        .values()
+        .chain(out.flags.keys())
+        .any(|flag| {
+            flag_matches_selector(flag, selector)
+                && !out.overridden_flags.contains(&flag.name)
+                && (out.flags.contains_key(flag) || flag_has_env(flag, custom_env))
+        })
+}
+
+fn apply_flag_overrides(
+    flag: &Arc<SpecFlag>,
+    available_flags: &BTreeMap<String, Arc<SpecFlag>>,
+    parsed_flags: &mut IndexMap<Arc<SpecFlag>, ParseValue>,
+    overridden_flags: &mut HashSet<String>,
+) {
+    let overridden_names: HashSet<String> = available_flags
+        .values()
+        .chain(parsed_flags.keys())
+        .filter(|other| flags_override(flag, other) || flags_override(other, flag))
+        .map(|other| other.name.clone())
+        .collect();
+
+    parsed_flags.retain(|parsed, _| !overridden_names.contains(&parsed.name));
+    overridden_flags.extend(overridden_names);
+    // An explicit occurrence always restores this flag, including self-overrides.
+    overridden_flags.remove(&flag.name);
 }
 
 #[cfg(feature = "docs")]
@@ -1386,6 +1464,142 @@ mod tests {
         assert_eq!(parsed.args.len(), 1);
         assert_eq!(parsed.flags.len(), 1);
         assert_eq!(parsed.available_flags.len(), 1);
+    }
+
+    #[test]
+    fn test_flag_overrides_last_occurrence_wins() {
+        let spec: Spec = r#"
+flag "--stdin" default=#true
+flag "--file <file>" overrides="--stdin"
+        "#
+        .parse()
+        .unwrap();
+
+        let file_wins = parse(&spec, &input(&["test", "--stdin", "--file", "input.txt"])).unwrap();
+        assert_eq!(file_wins.flags.len(), 1);
+        assert_eq!(flag_string_value(&file_wins, "file"), "input.txt");
+        assert!(file_wins.overridden_flags.contains("stdin"));
+
+        let stdin_wins = parse(&spec, &input(&["test", "--file", "input.txt", "--stdin"])).unwrap();
+        assert_eq!(stdin_wins.flags.len(), 1);
+        assert!(stdin_wins.flags.keys().any(|flag| flag.name == "stdin"));
+        assert!(stdin_wins.overridden_flags.contains("file"));
+    }
+
+    #[test]
+    fn test_flag_override_suppresses_env_value() {
+        let spec: Spec = r#"
+flag "--stdin" env="USE_STDIN"
+flag "--file <file>" overrides="--stdin"
+        "#
+        .parse()
+        .unwrap();
+
+        let parsed = parse_with_env(
+            &spec,
+            &["test", "--file", "input.txt"],
+            &[("USE_STDIN", "true")],
+        )
+        .unwrap();
+        assert_eq!(parsed.flags.len(), 1);
+        assert_eq!(flag_string_value(&parsed, "file"), "input.txt");
+    }
+
+    #[test]
+    fn test_flag_override_suppresses_required_check() {
+        let spec: Spec = r#"
+flag "--stdin" required=#true
+flag "--file <file>" overrides="--stdin"
+        "#
+        .parse()
+        .unwrap();
+
+        let parsed = parse(&spec, &input(&["test", "--file", "input.txt"])).unwrap();
+        assert_eq!(parsed.flags.len(), 1);
+        assert_eq!(flag_string_value(&parsed, "file"), "input.txt");
+    }
+
+    #[test]
+    fn test_flag_required_if() {
+        let spec: Spec = r#"
+flag "--dir <dir>"
+flag "--file <file>" required_if="--dir"
+        "#
+        .parse()
+        .unwrap();
+
+        parse(&spec, &input(&["test"])).unwrap();
+        assert_parse_err(
+            parse(&spec, &input(&["test", "--dir", "src"])),
+            "Missing required flag: --file <file>",
+        );
+        parse(
+            &spec,
+            &input(&["test", "--dir", "src", "--file", "input.txt"]),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_flag_required_unless() {
+        let spec: Spec = r#"
+flag "--stdin"
+flag "--file <file>" required_unless="--stdin"
+        "#
+        .parse()
+        .unwrap();
+
+        assert_parse_err(
+            parse(&spec, &input(&["test"])),
+            "Missing required flag: --file <file>",
+        );
+        parse(&spec, &input(&["test", "--stdin"])).unwrap();
+        parse(&spec, &input(&["test", "--file", "input.txt"])).unwrap();
+    }
+
+    #[test]
+    fn test_conditional_requirements_treat_env_as_explicit() {
+        let spec: Spec = r#"
+flag "--dir <dir>" env="INPUT_DIR"
+flag "--stdin" env="USE_STDIN"
+flag "--file <file>" required_if="--dir" required_unless="--stdin"
+        "#
+        .parse()
+        .unwrap();
+
+        assert_parse_err(
+            parse_with_env(&spec, &["test"], &[("INPUT_DIR", "src")]),
+            "Missing required flag: --file <file>",
+        );
+        parse_with_env(&spec, &["test"], &[("USE_STDIN", "true")]).unwrap();
+    }
+
+    #[test]
+    fn test_conditional_requirements_ignore_defaults_on_condition_flags() {
+        let spec: Spec = r#"
+flag "--dir <dir>" default="src"
+flag "--file <file>" required_if="--dir"
+        "#
+        .parse()
+        .unwrap();
+
+        parse(&spec, &input(&["test"])).unwrap();
+    }
+
+    #[test]
+    fn test_conditional_requirements_see_overridden_flags_as_absent() {
+        let spec: Spec = r#"
+flag "--stdin"
+flag "--dir <dir>" overrides="--stdin"
+flag "--file <file>" required_unless="--stdin"
+        "#
+        .parse()
+        .unwrap();
+
+        assert_parse_err(
+            parse(&spec, &input(&["test", "--stdin", "--dir", "src"])),
+            "Missing required flag: --file <file>",
+        );
     }
 
     #[test]

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -243,11 +243,6 @@ pub struct ParseOutput {
     pub cmds: Vec<SpecCommand>,
     pub args: IndexMap<Arc<SpecArg>, ParseValue>,
     pub flags: IndexMap<Arc<SpecFlag>, ParseValue>,
-    /// Flags removed because they lost an `overrides` relationship.
-    ///
-    /// These names are retained so defaults and environment values do not restore an
-    /// overridden flag after command-line parsing.
-    pub overridden_flags: HashSet<String>,
     /// Every flag the parser recognizes at this point, keyed by each of its aliases
     /// (`--long`, `-s`, negations).
     ///
@@ -356,7 +351,7 @@ impl<'a> Parser<'a> {
     /// Returns the parsed arguments and flags, with defaults and env vars applied.
     pub fn parse(self, input: &[String]) -> Result<ParseOutput, miette::Error> {
         let custom_env = self.env.as_ref();
-        let mut out = parse_partial_with_env(self.spec, input, custom_env)?;
+        let (mut out, overridden_flags) = parse_partial_with_env(self.spec, input, custom_env)?;
         trace!("{out:?}");
 
         let get_env = |key: &str| -> Option<String> {
@@ -420,7 +415,7 @@ impl<'a> Parser<'a> {
 
         // Apply env vars and defaults for flags
         for flag in out.available_flags.values() {
-            if out.flags.contains_key(flag) || out.overridden_flags.contains(&flag.name) {
+            if out.flags.contains_key(flag) || overridden_flags.contains(&flag.name) {
                 continue;
             }
             if let Some(env_var) = flag.env.as_ref() {
@@ -544,7 +539,7 @@ pub fn parse(spec: &Spec, input: &[String]) -> Result<ParseOutput, miette::Error
 /// Use this for help text generation or when you need the raw parsed values.
 #[must_use = "parsing result should be used"]
 pub fn parse_partial(spec: &Spec, input: &[String]) -> Result<ParseOutput, miette::Error> {
-    parse_partial_with_env(spec, input, None)
+    parse_partial_with_env(spec, input, None).map(|(out, _)| out)
 }
 
 /// Internal version of parse_partial that accepts an optional custom env map.
@@ -552,7 +547,7 @@ fn parse_partial_with_env(
     spec: &Spec,
     input: &[String],
     custom_env: Option<&HashMap<String, String>>,
-) -> Result<ParseOutput, miette::Error> {
+) -> Result<(ParseOutput, HashSet<String>), miette::Error> {
     trace!("parse_partial: {input:?}");
     let mut input = input.iter().cloned().collect::<VecDeque<_>>();
     input.pop_front();
@@ -562,13 +557,15 @@ fn parse_partial_with_env(
         cmds: vec![spec.cmd.clone()],
         args: IndexMap::new(),
         flags: IndexMap::new(),
-        overridden_flags: HashSet::new(),
         available_flags: gather_flags(&spec.cmd),
         flag_awaiting_value: vec![],
         errors: vec![],
         next_arg: None,
         double_dash_seen: false,
     };
+    // Keep this internal so adding relationship support remains semver-compatible. The full
+    // parser uses it to prevent defaults and environment values from restoring overridden flags.
+    let mut overridden_flags = HashSet::new();
 
     // Phase 1: Scan for subcommands and collect global flags
     //
@@ -582,7 +579,7 @@ fn parse_partial_with_env(
     // We only collect global flags for mounts because:
     // - Non-global flags are specific to the current command, not subcommands
     // - Global flags affect all commands and should be passed to mount points
-    let mut prefix_words: Vec<String> = vec![];
+    let mut prefix_flags: Vec<(Arc<SpecFlag>, Vec<String>)> = vec![];
     // Which flag each word skipped here belongs to, aligned with the leading words left in
     // `input`: `Some(flag)` for a flag word, `None` for its value (or anything unresolved).
     //
@@ -600,7 +597,7 @@ fn parse_partial_with_env(
         if let Some(subcommand) = out.cmd.find_subcommand(&input[idx]) {
             let mut subcommand = subcommand.clone();
             // Pass prefix words (global flags before this subcommand) to mount
-            subcommand.mount(&prefix_words)?;
+            subcommand.mount(&mount_prefix_words(&prefix_flags))?;
             // Only the *boundary* is a mount crossing: below it, the mounted program's own
             // commands are ordinary commands relative to each other.
             let crossing_mount = subcommand.mounted && !out.cmd.mounted;
@@ -613,7 +610,7 @@ fn parse_partial_with_env(
             input.remove(idx);
             out.cmds.push(subcommand.clone());
             out.cmd = subcommand.clone();
-            prefix_words.clear();
+            prefix_flags.clear();
             // Continue from current position (don't reset to 0)
             // After remove(), idx now points to the next element
         } else if input[idx].starts_with('-') {
@@ -630,9 +627,7 @@ fn parse_partial_with_env(
                 // Only globals are forwarded to mounts: a non-global flag belongs to the
                 // command that declared it, not to what is mounted below it.
                 prefix_bindings.push_back(Some(Arc::clone(&f)));
-                if f.global {
-                    prefix_words.push(word.clone());
-                }
+                let mut forwarded = f.global.then(|| vec![word.clone()]);
                 idx += 1;
 
                 // Only consume next word if flag takes an argument AND value isn't embedded
@@ -642,11 +637,15 @@ fn parse_partial_with_env(
                     && idx < input.len()
                     && !input[idx].starts_with('-')
                 {
-                    if f.global {
-                        prefix_words.push(input[idx].clone());
+                    if let Some(words) = forwarded.as_mut() {
+                        words.push(input[idx].clone());
                     }
                     prefix_bindings.push_back(None);
                     idx += 1;
+                }
+                if let Some(words) = forwarded {
+                    apply_prefix_flag_overrides(&mut prefix_flags, Arc::clone(&f));
+                    prefix_flags.push((f, words));
                 }
             } else {
                 // Unknown flag - stop looking for subcommands
@@ -661,7 +660,7 @@ fn parse_partial_with_env(
                     if let Some(subcommand) = out.cmd.find_subcommand(default_name) {
                         let mut subcommand = subcommand.clone();
                         // Pass prefix words (global flags before this) to mount
-                        subcommand.mount(&prefix_words)?;
+                        subcommand.mount(&mount_prefix_words(&prefix_flags))?;
                         let crossing_mount = subcommand.mounted && !out.cmd.mounted;
                         merge_subcommand_flags(
                             &mut out.available_flags,
@@ -670,7 +669,7 @@ fn parse_partial_with_env(
                         );
                         out.cmds.push(subcommand.clone());
                         out.cmd = subcommand.clone();
-                        prefix_words.clear();
+                        prefix_flags.clear();
                         used_default_subcommand = true;
                         // Continue the loop to check if this word is a subcommand of the
                         // default subcommand (e.g., a task name added via mount).
@@ -788,7 +787,7 @@ fn parse_partial_with_env(
             )?;
             if should_return {
                 record_cursor(&mut out, next_arg_idx, seen_double_dash);
-                return Ok(out);
+                return Ok((out, overridden_flags));
             }
             continue;
         }
@@ -802,7 +801,8 @@ fn parse_partial_with_env(
                     f,
                     &out.available_flags,
                     &mut out.flags,
-                    &mut out.overridden_flags,
+                    &mut out.flag_awaiting_value,
+                    &mut overridden_flags,
                 );
                 // Only push the embedded value back when the flag is known so that
                 // unknown --flag=value tokens fall through intact to positional arg
@@ -832,7 +832,7 @@ fn parse_partial_with_env(
                 out.errors
                     .push(render_help_err(spec, &out.cmd, w.len() > 2));
                 record_cursor(&mut out, next_arg_idx, seen_double_dash);
-                return Ok(out);
+                return Ok((out, overridden_flags));
             }
         }
 
@@ -847,7 +847,8 @@ fn parse_partial_with_env(
                     f,
                     &out.available_flags,
                     &mut out.flags,
-                    &mut out.overridden_flags,
+                    &mut out.flag_awaiting_value,
+                    &mut overridden_flags,
                 );
                 if w.len() > 2 {
                     input.push_front(format!("-{}", &w[2..]));
@@ -875,7 +876,7 @@ fn parse_partial_with_env(
                 out.errors
                     .push(render_help_err(spec, &out.cmd, w.len() > 2));
                 record_cursor(&mut out, next_arg_idx, seen_double_dash);
-                return Ok(out);
+                return Ok((out, overridden_flags));
             }
             if grouped_flag {
                 grouped_flag = false;
@@ -895,7 +896,7 @@ fn parse_partial_with_env(
             )?;
             if should_return {
                 record_cursor(&mut out, next_arg_idx, seen_double_dash);
-                return Ok(out);
+                return Ok((out, overridden_flags));
             }
             continue;
         }
@@ -921,7 +922,7 @@ fn parse_partial_with_env(
                 custom_env,
             )? {
                 record_cursor(&mut out, next_arg_idx, seen_double_dash);
-                return Ok(out);
+                return Ok((out, overridden_flags));
             }
             if arg.var {
                 let arr = out
@@ -945,7 +946,7 @@ fn parse_partial_with_env(
             out.errors
                 .push(render_help_err(spec, &out.cmd, w.len() > 2));
             record_cursor(&mut out, next_arg_idx, seen_double_dash);
-            return Ok(out);
+            return Ok((out, overridden_flags));
         }
         bail!("unexpected word: {w}");
     }
@@ -964,10 +965,10 @@ fn parse_partial_with_env(
         }
         if arg.required && arg.default.is_empty() {
             // Check if there's an env var available (custom env map takes precedence)
-            let has_env = arg.env.as_ref().is_some_and(|e| {
-                custom_env.map(|env| env.contains_key(e)).unwrap_or(false)
-                    || std::env::var(e).is_ok()
-            });
+            let has_env = arg
+                .env
+                .as_ref()
+                .is_some_and(|env_var| env_contains(custom_env, env_var));
             if !has_env {
                 out.errors.push(UsageErr::MissingArg(arg.name.clone()));
             }
@@ -975,7 +976,7 @@ fn parse_partial_with_env(
     }
 
     for flag in unique_flags(out.available_flags.values()) {
-        if out.flags.contains_key(flag) || out.overridden_flags.contains(&flag.name) {
+        if out.flags.contains_key(flag) || overridden_flags.contains(&flag.name) {
             continue;
         }
         let has_default =
@@ -984,12 +985,11 @@ fn parse_partial_with_env(
         let required_if = flag
             .required_if
             .iter()
-            .any(|selector| selector_is_explicit(selector, &out, custom_env));
+            .any(|selector| selector_is_explicit(selector, &out, &overridden_flags, custom_env));
         let required_unless = !flag.required_unless.is_empty()
-            && !flag
-                .required_unless
-                .iter()
-                .any(|selector| selector_is_explicit(selector, &out, custom_env));
+            && !flag.required_unless.iter().any(|selector| {
+                selector_is_explicit(selector, &out, &overridden_flags, custom_env)
+            });
         if (flag.required || required_if || required_unless) && !has_default && !has_env {
             out.errors.push(UsageErr::MissingFlag(flag.name.clone()));
         }
@@ -1050,7 +1050,7 @@ fn parse_partial_with_env(
         }
     }
 
-    Ok(out)
+    Ok((out, overridden_flags))
 }
 
 fn flag_matches_selector(flag: &SpecFlag, selector: &str) -> bool {
@@ -1064,18 +1064,38 @@ fn flags_override(overrider: &SpecFlag, overridden: &SpecFlag) -> bool {
         .any(|selector| flag_matches_selector(overridden, selector))
 }
 
+fn apply_prefix_flag_overrides(
+    prefix_flags: &mut Vec<(Arc<SpecFlag>, Vec<String>)>,
+    flag: Arc<SpecFlag>,
+) {
+    prefix_flags
+        .retain(|(other, _)| !(flags_override(&flag, other) || flags_override(other, &flag)));
+}
+
+fn mount_prefix_words(prefix_flags: &[(Arc<SpecFlag>, Vec<String>)]) -> Vec<String> {
+    prefix_flags
+        .iter()
+        .flat_map(|(_, words)| words.iter().cloned())
+        .collect()
+}
+
+fn env_contains(custom_env: Option<&HashMap<String, String>>, env_var: &str) -> bool {
+    match custom_env {
+        Some(env) => env.contains_key(env_var),
+        None => std::env::var(env_var).is_ok(),
+    }
+}
+
 fn flag_has_env(flag: &SpecFlag, custom_env: Option<&HashMap<String, String>>) -> bool {
-    flag.env.as_ref().is_some_and(|env_var| {
-        custom_env
-            .map(|env| env.contains_key(env_var))
-            .unwrap_or(false)
-            || std::env::var(env_var).is_ok()
-    })
+    flag.env
+        .as_ref()
+        .is_some_and(|env_var| env_contains(custom_env, env_var))
 }
 
 fn selector_is_explicit(
     selector: &str,
     out: &ParseOutput,
+    overridden_flags: &HashSet<String>,
     custom_env: Option<&HashMap<String, String>>,
 ) -> bool {
     out.available_flags
@@ -1083,7 +1103,7 @@ fn selector_is_explicit(
         .chain(out.flags.keys())
         .any(|flag| {
             flag_matches_selector(flag, selector)
-                && !out.overridden_flags.contains(&flag.name)
+                && !overridden_flags.contains(&flag.name)
                 && (out.flags.contains_key(flag) || flag_has_env(flag, custom_env))
         })
 }
@@ -1092,6 +1112,7 @@ fn apply_flag_overrides(
     flag: &Arc<SpecFlag>,
     available_flags: &BTreeMap<String, Arc<SpecFlag>>,
     parsed_flags: &mut IndexMap<Arc<SpecFlag>, ParseValue>,
+    pending_flags: &mut Vec<Arc<SpecFlag>>,
     overridden_flags: &mut HashSet<String>,
 ) {
     let overridden_names: HashSet<String> = available_flags
@@ -1102,6 +1123,7 @@ fn apply_flag_overrides(
         .collect();
 
     parsed_flags.retain(|parsed, _| !overridden_names.contains(&parsed.name));
+    pending_flags.retain(|pending| !overridden_names.contains(&pending.name));
     overridden_flags.extend(overridden_names);
     // An explicit occurrence always restores this flag, including self-overrides.
     overridden_flags.remove(&flag.name);
@@ -1478,12 +1500,54 @@ flag "--file <file>" overrides="--stdin"
         let file_wins = parse(&spec, &input(&["test", "--stdin", "--file", "input.txt"])).unwrap();
         assert_eq!(file_wins.flags.len(), 1);
         assert_eq!(flag_string_value(&file_wins, "file"), "input.txt");
-        assert!(file_wins.overridden_flags.contains("stdin"));
+        assert!(!file_wins.flags.keys().any(|flag| flag.name == "stdin"));
 
         let stdin_wins = parse(&spec, &input(&["test", "--file", "input.txt", "--stdin"])).unwrap();
         assert_eq!(stdin_wins.flags.len(), 1);
         assert!(stdin_wins.flags.keys().any(|flag| flag.name == "stdin"));
-        assert!(stdin_wins.overridden_flags.contains("file"));
+        assert!(!stdin_wins.flags.keys().any(|flag| flag.name == "file"));
+    }
+
+    #[test]
+    fn test_flag_override_clears_pending_value() {
+        let spec: Spec = r#"
+flag "--file <file>" overrides="--stdin"
+flag "--stdin"
+arg "[input]"
+        "#
+        .parse()
+        .unwrap();
+
+        let parsed = parse(&spec, &input(&["test", "--file", "--stdin", "input.txt"])).unwrap();
+        assert_eq!(parsed.flags.len(), 1);
+        assert!(parsed.flags.keys().any(|flag| flag.name == "stdin"));
+        assert_eq!(first_string_value(&parsed), "input.txt");
+    }
+
+    #[test]
+    fn test_mount_prefix_applies_flag_overrides() {
+        let stdin = Arc::new(
+            SpecFlag::builder()
+                .name("stdin")
+                .long("stdin")
+                .global(true)
+                .build(),
+        );
+        let file = Arc::new(
+            SpecFlag::builder()
+                .name("file")
+                .long("file")
+                .arg(SpecArg::builder().name("file").build())
+                .global(true)
+                .overrides_with(vec!["--stdin".to_string()])
+                .build(),
+        );
+        let mut prefix_flags = vec![(stdin, vec!["--stdin".to_string()])];
+
+        apply_prefix_flag_overrides(&mut prefix_flags, Arc::clone(&file));
+        prefix_flags.push((file, vec!["--file".to_string(), "input.txt".to_string()]));
+
+        assert_eq!(mount_prefix_words(&prefix_flags), ["--file", "input.txt"]);
     }
 
     #[test]
@@ -1572,6 +1636,17 @@ flag "--file <file>" required_if="--dir" required_unless="--stdin"
             "Missing required flag: --file <file>",
         );
         parse_with_env(&spec, &["test"], &[("USE_STDIN", "true")]).unwrap();
+    }
+
+    #[test]
+    fn test_custom_env_does_not_fall_back_to_process_env() {
+        assert!(std::env::var("PATH").is_ok());
+        let spec: Spec = r#"flag "--file <file>" env="PATH" required=#true"#.parse().unwrap();
+
+        assert_parse_err(
+            parse_with_env(&spec, &["test"], &[]),
+            "Missing required flag: --file <file>",
+        );
     }
 
     #[test]

--- a/lib/src/spec/builder.rs
+++ b/lib/src/spec/builder.rs
@@ -145,6 +145,42 @@ impl SpecFlagBuilder {
         self
     }
 
+    /// Add a flag whose presence makes this flag required
+    pub fn required_if(mut self, flag: impl Into<String>) -> Self {
+        self.inner.required_if.push(flag.into());
+        self
+    }
+
+    /// Add flags whose presence makes this flag required
+    pub fn required_if_any<I, S>(mut self, flags: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.inner
+            .required_if
+            .extend(flags.into_iter().map(Into::into));
+        self
+    }
+
+    /// Add a flag whose absence makes this flag required
+    pub fn required_unless(mut self, flag: impl Into<String>) -> Self {
+        self.inner.required_unless.push(flag.into());
+        self
+    }
+
+    /// Add flags where the absence of all of them makes this flag required
+    pub fn required_unless_any<I, S>(mut self, flags: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.inner
+            .required_unless
+            .extend(flags.into_iter().map(Into::into));
+        self
+    }
+
     /// Set as global (available to subcommands)
     pub fn global(mut self, is_global: bool) -> Self {
         self.inner.global = is_global;
@@ -190,6 +226,24 @@ impl SpecFlagBuilder {
     /// Set negate string
     pub fn negate(mut self, negate: impl Into<String>) -> Self {
         self.inner.negate = Some(negate.into());
+        self
+    }
+
+    /// Add a flag that this flag mutually overrides
+    pub fn override_with(mut self, flag: impl Into<String>) -> Self {
+        self.inner.overrides.push(flag.into());
+        self
+    }
+
+    /// Add flags that this flag mutually overrides
+    pub fn overrides_with<I, S>(mut self, flags: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.inner
+            .overrides
+            .extend(flags.into_iter().map(Into::into));
         self
     }
 

--- a/lib/src/spec/cmd.rs
+++ b/lib/src/spec/cmd.rs
@@ -1003,6 +1003,14 @@ cmd "hidden" hide=#true
         // Equality is only meaningful if the fixture actually populated the
         // fields, so guard against a future edit quietly emptying it out.
         let install = &original["cmd"]["subcommands"]["install"];
+        let purge = install["flags"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|flag| flag["name"] == "purge")
+            .unwrap();
+        assert_eq!(purge["overrides"], serde_json::json!(["-f"]));
+        assert_eq!(purge["required_unless"], serde_json::json!(["--keep"]));
         for key in [
             "help_long",
             "help_md",

--- a/lib/src/spec/cmd.rs
+++ b/lib/src/spec/cmd.rs
@@ -977,7 +977,7 @@ cmd "install" help="Install a package" subcommand_required=#false {
     arg "<pkg>" help="Package to install"
     arg "[dest]" effect="write"
     flag "-f --force" help="Overwrite"
-    flag "--purge" effect="destructive"
+    flag "--purge" effect="destructive" overrides="-f" required_unless="--keep"
     complete "pkg" run="mycli list --available" descriptions=#true
     example "mycli install foo" header="Install foo" help="Installs foo" lang="sh"
     example "mycli install bar"

--- a/lib/src/spec/flag.rs
+++ b/lib/src/spec/flag.rs
@@ -57,6 +57,12 @@ pub struct SpecFlag {
     /// Whether this flag must be provided
     #[serde(skip_serializing_if = "is_false")]
     pub required: bool,
+    /// Flags whose presence makes this flag required
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub required_if: Vec<String>,
+    /// Flags whose absence makes this flag required
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub required_unless: Vec<String>,
     /// Deprecation message if this flag is deprecated
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deprecated: Option<String>,
@@ -85,6 +91,9 @@ pub struct SpecFlag {
     /// Negation prefix (e.g., "no-" for --no-verbose)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub negate: Option<String>,
+    /// Flags that this flag mutually overrides; the last one provided wins
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub overrides: Vec<String>,
     /// Raises the effect of the command when this flag is supplied.
     /// See [`crate::spec::effect::SpecCommandEffect`]; never lowers it.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -110,6 +119,8 @@ impl SpecFlag {
                 "help_long" => flag.help_long = Some(v.ensure_string()?),
                 "help_md" => flag.help_md = Some(v.ensure_string()?),
                 "required" => flag.required = v.ensure_bool()?,
+                "required_if" => flag.required_if = vec![v.ensure_string()?],
+                "required_unless" => flag.required_unless = vec![v.ensure_string()?],
                 "var" => flag.var = v.ensure_bool()?,
                 "var_min" => flag.var_min = v.ensure_usize().map(Some)?,
                 "var_max" => flag.var_max = v.ensure_usize().map(Some)?,
@@ -133,6 +144,7 @@ impl SpecFlag {
                     flag.default = vec![default_value];
                 }
                 "negate" => flag.negate = v.ensure_string().map(Some)?,
+                "overrides" => flag.overrides = vec![v.ensure_string()?],
                 "effect" => {
                     let raw = v.ensure_string()?;
                     match raw.parse() {
@@ -159,6 +171,20 @@ impl SpecFlag {
                 "help_long" => flag.help_long = Some(child.arg(0)?.ensure_string()?),
                 "help_md" => flag.help_md = Some(child.arg(0)?.ensure_string()?),
                 "required" => flag.required = child.arg(0)?.ensure_bool()?,
+                "required_if" => {
+                    flag.required_if = child
+                        .ensure_arg_len(1..)?
+                        .args()
+                        .map(|arg| arg.ensure_string())
+                        .collect::<Result<Vec<_>>>()?;
+                }
+                "required_unless" => {
+                    flag.required_unless = child
+                        .ensure_arg_len(1..)?
+                        .args()
+                        .map(|arg| arg.ensure_string())
+                        .collect::<Result<Vec<_>>>()?;
+                }
                 "var" => flag.var = child.arg(0)?.ensure_bool()?,
                 "var_min" => flag.var_min = child.arg(0)?.ensure_usize().map(Some)?,
                 "var_max" => flag.var_max = child.arg(0)?.ensure_usize().map(Some)?,
@@ -208,6 +234,13 @@ impl SpecFlag {
                     }
                 }
                 "env" => flag.env = child.arg(0)?.ensure_string().map(Some)?,
+                "overrides" => {
+                    flag.overrides = child
+                        .ensure_arg_len(1..)?
+                        .args()
+                        .map(|arg| arg.ensure_string())
+                        .collect::<Result<Vec<_>>>()?;
+                }
                 "choices" => {
                     if let Some(arg) = &mut flag.arg {
                         arg.choices = Some(SpecChoices::parse(ctx, &child)?);
@@ -309,6 +342,8 @@ impl From<&SpecFlag> for KdlNode {
         if flag.required {
             node.push(KdlEntry::new_prop("required", true));
         }
+        serialize_flag_list(&mut node, "required_if", &flag.required_if);
+        serialize_flag_list(&mut node, "required_unless", &flag.required_unless);
         if flag.var {
             node.push(KdlEntry::new_prop("var", true));
         }
@@ -332,6 +367,16 @@ impl From<&SpecFlag> for KdlNode {
         }
         if let Some(negate) = &flag.negate {
             node.push(string_entry(Some("negate"), negate));
+        }
+        if flag.overrides.len() == 1 {
+            node.push(string_entry(Some("overrides"), &flag.overrides[0]));
+        } else if !flag.overrides.is_empty() {
+            let children = node.children_mut().get_or_insert_with(KdlDocument::new);
+            let mut overrides = KdlNode::new("overrides");
+            for target in &flag.overrides {
+                overrides.push(string_entry(None, target));
+            }
+            children.nodes_mut().push(overrides);
         }
         if let Some(env) = &flag.env {
             node.push(string_entry(Some("env"), env));
@@ -373,6 +418,19 @@ impl From<&SpecFlag> for KdlNode {
             }
         }
         node
+    }
+}
+
+fn serialize_flag_list(node: &mut KdlNode, name: &str, flags: &[String]) {
+    if flags.len() == 1 {
+        node.push(string_entry(Some(name), &flags[0]));
+    } else if !flags.is_empty() {
+        let children = node.children_mut().get_or_insert_with(KdlDocument::new);
+        let mut list = KdlNode::new(name);
+        for flag in flags {
+            list.push(string_entry(None, flag));
+        }
+        children.nodes_mut().push(list);
     }
 }
 
@@ -479,6 +537,8 @@ impl From<&clap::Arg> for SpecFlag {
             short,
             long,
             required,
+            required_if: vec![],
+            required_unless: vec![],
             help,
             help_long,
             help_md: None,
@@ -493,6 +553,7 @@ impl From<&clap::Arg> for SpecFlag {
             default,
             deprecated: None,
             negate: None,
+            overrides: vec![],
             // clap has no way to express this; consumers set it on the derived
             // spec (see the effect docs).
             effect: None,
@@ -645,6 +706,51 @@ flag "--verbose" {
 
         let verbose_flag = spec.cmd.flags.iter().find(|f| f.name == "verbose").unwrap();
         assert_eq!(verbose_flag.env, Some("MYCLI_VERBOSE".to_string()));
+    }
+
+    #[test]
+    fn test_flag_with_overrides() {
+        let spec = Spec::parse(
+            &Default::default(),
+            r#"
+flag "--file <file>" overrides="--stdin"
+flag "--format <format>" {
+    overrides "--json" "--yaml"
+}
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(spec.cmd.flags[0].overrides, ["--stdin"]);
+        assert_eq!(spec.cmd.flags[1].overrides, ["--json", "--yaml"]);
+
+        let reparsed: Spec = spec.to_string().parse().unwrap();
+        assert_eq!(reparsed.cmd.flags[0].overrides, ["--stdin"]);
+        assert_eq!(reparsed.cmd.flags[1].overrides, ["--json", "--yaml"]);
+    }
+
+    #[test]
+    fn test_flag_with_conditional_requirements() {
+        let spec = Spec::parse(
+            &Default::default(),
+            r#"
+flag "--file <file>" required_if="--dir"
+flag "--output <output>" {
+    required_unless "--stdout" "--check"
+}
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(spec.cmd.flags[0].required_if, ["--dir"]);
+        assert_eq!(spec.cmd.flags[1].required_unless, ["--stdout", "--check"]);
+
+        let reparsed: Spec = spec.to_string().parse().unwrap();
+        assert_eq!(reparsed.cmd.flags[0].required_if, ["--dir"]);
+        assert_eq!(
+            reparsed.cmd.flags[1].required_unless,
+            ["--stdout", "--check"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add `overrides`, `required_if`, and `required_unless` to the flag spec model, KDL parser, serializer, and builder
- apply mutual, last-occurrence-wins override semantics during argument parsing
- enforce presence-based conditional requirements after overrides are resolved
- account for command-line flags, environment values, and defaults consistently
- remove the remaining unsupported `config` example from the flag reference

Relationship targets may use a flag's spec name or any short, long, or negated alias. Each property accepts one target, while child nodes support multiple targets.

`required_if` activates when any target is explicitly supplied. `required_unless` requires the flag unless any target is explicitly supplied. Environment-backed targets count as explicit; defaults do not activate conditions, though a default still satisfies the conditionally required flag itself.

## Root cause

The flag reference documented these relationship keys, but `SpecFlag` had no corresponding fields and the KDL parser rejected them before argument parsing began.

Closes #792.

## Validation

- `cargo test --all --all-features`
- `cargo clippy --all --all-features -- -D warnings`
- `mise run lint:prettier`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core CLI parsing (defaults, env, required flags, mount prefix forwarding); behavior is well-tested but any consumer relying on old override/env semantics could see different outcomes.
> 
> **Overview**
> Implements **flag relationships** that were documented but not wired through the spec or parser: `overrides`, `required_if`, and `required_unless` on `SpecFlag`, with KDL parse/serialize, builder helpers, and reference doc tweaks (mutual override semantics; drops unsupported `config` example).
> 
> **Parsing** applies **mutual, last-wins** overrides when a flag is seen: conflicting flags are removed from parsed state and pending value queues; an internal `overridden_flags` set stops env/defaults from reviving losers and feeds conditional requirement checks. **Mount prefix** scanning applies the same override rules so globals forwarded to mounts stay consistent (`--file` dropping `--stdin`).
> 
> **Conditional requirements** extend the missing-flag pass: `required_if` when any selector is explicitly present (CLI or env, not defaults); `required_unless` when none of the selectors are explicit. Overridden flags count as absent for those selectors. Custom env maps no longer fall back to process env when checking env-backed flags/args.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00ca1b0af1dda378bb0df366d461d5ac7927b415. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for defining mutually overriding flags, including single or multiple overrides.
  * Explicitly selected flags now take precedence over overridden flags, preventing conflicting defaults, environment values, and required-flag errors.
  * Added conditional requirements and exceptions for flags.
  * Added support for reading and writing flag override and conditional requirement settings in specifications.

* **Documentation**
  * Updated override examples to clarify that the last-used flag takes precedence.
  * Removed outdated configuration and flag relationship examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->