### PR TITLE
fix(cli): recognize about as root command help

### DIFF
--- a/cli/src/cli/lint.rs
+++ b/cli/src/cli/lint.rs
@@ -150,12 +150,17 @@ pub fn lint_spec(spec: &Spec) -> Vec<LintIssue> {
     }
 
     // Lint the root command
-    lint_command(&spec.cmd, &[], &mut issues);
+    lint_command(&spec.cmd, &[], spec.about.is_some(), &mut issues);
 
     issues
 }
 
-fn lint_command(cmd: &SpecCommand, path: &[&str], issues: &mut Vec<LintIssue>) {
+fn lint_command(
+    cmd: &SpecCommand,
+    path: &[&str],
+    has_root_about: bool,
+    issues: &mut Vec<LintIssue>,
+) {
     let cmd_path = if path.is_empty() {
         cmd.name.clone()
     } else {
@@ -163,7 +168,7 @@ fn lint_command(cmd: &SpecCommand, path: &[&str], issues: &mut Vec<LintIssue>) {
     };
 
     // Check for missing command help
-    if cmd.help.is_none() && !cmd.name.is_empty() {
+    if cmd.help.is_none() && !has_root_about && !cmd.name.is_empty() {
         issues.push(LintIssue {
             severity: Severity::Info,
             code: "missing-cmd-help".to_string(),
@@ -282,7 +287,7 @@ fn lint_command(cmd: &SpecCommand, path: &[&str], issues: &mut Vec<LintIssue>) {
         .chain(std::iter::once(cmd.name.as_str()))
         .collect();
     for subcmd in cmd.subcommands.values() {
-        lint_command(subcmd, &new_path, issues);
+        lint_command(subcmd, &new_path, false, issues);
     }
 }
 
@@ -454,6 +459,7 @@ arg "<required>" help="required arg"
         let spec: Spec = r#"
 name "test"
 bin "test"
+about "A test CLI"
 flag "-v --verbose" help="Enable verbose output"
 arg "<input>" help="Input file"
 cmd "sub" help="A subcommand" {
@@ -464,8 +470,29 @@ cmd "sub" help="A subcommand" {
         .unwrap();
 
         let issues = lint_spec(&spec);
-        // Should only have info-level issues (missing-cmd-help for root)
-        assert!(issues.iter().all(|i| i.severity == Severity::Info));
+        assert!(issues.is_empty());
+    }
+
+    #[test]
+    fn test_lint_uses_about_as_root_command_help() {
+        let spec: Spec = r#"
+name "test"
+about "A test CLI"
+cmd "documented" help="A documented subcommand"
+cmd "undocumented"
+        "#
+        .parse()
+        .unwrap();
+
+        let missing_help: Vec<_> = lint_spec(&spec)
+            .into_iter()
+            .filter(|issue| issue.code == "missing-cmd-help")
+            .collect();
+        assert_eq!(missing_help.len(), 1);
+        assert_eq!(
+            missing_help[0].location.as_deref(),
+            Some("cmd test undocumented")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- treat top-level `about` as the root command's help text during linting
- continue reporting undocumented subcommands independently
- add regression coverage for root and subcommand help handling

## Root cause

KDL stores the root CLI description in `Spec.about`, while the generic command linter only inspected `SpecCommand.help`. As a result, the synthetic root command always reported `missing-cmd-help` even when the spec provided `about`.

Closes #790.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p usage-cli cli::lint`
- `cargo clippy -p usage-cli --all-features -- -D warnings`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only behavior change with regression tests; no runtime CLI or security impact.
> 
> **Overview**
> Fixes false **`missing-cmd-help`** info on the root command when a spec defines top-level **`about`** instead of root **`help`** (KDL stores the CLI description in `Spec.about`).
> 
> **`lint_command`** now takes **`has_root_about`**: the root lint passes **`spec.about.is_some()`**, and the missing-help rule is skipped only for that synthetic root. Subcommands still require their own **`help`**.
> 
> Tests expect a clean spec with **`about`** to lint with no issues, and assert only undocumented subcommands still get **`missing-cmd-help`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d2b01cf156e45a695fd8c57a70af59e39d8608e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated linting to recognize root-level descriptive text as valid command help.
  * Prevented false missing-help warnings for documented root commands.
  * Continued reporting missing help for undocumented subcommands.

* **Tests**
  * Added coverage for root-level descriptions and undocumented subcommands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->