### PR TITLE
test(parse): add normative argv grammar and conformance corpus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2007,6 +2007,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "usage-conformance"
+version = "0.0.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "usage-lib",
+]
+
+[[package]]
 name = "usage-lib"
 version = "5.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "clap_usage",
     "cli",
+    "conformance",
     "lib",
 ]
 

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "usage-conformance"
+description = "Harness for the argv conformance corpus"
+publish = false
+version = "0.0.0"
+edition = "2021"
+rust-version = "1.80.0"
+homepage = { workspace = true }
+documentation = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+usage-lib = { workspace = true }
+
+[[bin]]
+name = "oracle"
+path = "src/bin/oracle.rs"

--- a/conformance/src/bin/oracle.rs
+++ b/conformance/src/bin/oracle.rs
@@ -1,0 +1,87 @@
+//! Report what usage-lib does with each corpus vector.
+//!
+//! Authoring aid, not a test. `cargo run -p usage-conformance --bin oracle` prints
+//! every vector's observed result next to its expectation, which is how the
+//! `reference` field on each vector gets filled in with a measurement rather than
+//! a guess. `--json` emits the same thing machine-readably.
+//!
+//! The test suite (`conformance/tests/reference.rs`) is what actually enforces
+//! agreement in CI.
+
+use usage_conformance::reference::run;
+use usage_conformance::{load, Reference};
+
+fn main() -> Result<(), String> {
+    let json = std::env::args().any(|a| a == "--json");
+    let filter = std::env::args()
+        .skip(1)
+        .find(|a| !a.starts_with("--"))
+        .unwrap_or_default();
+
+    let files = load(usage_conformance::corpus_dir())?;
+    let mut rows = Vec::new();
+
+    for file in &files {
+        for vector in &file.vectors {
+            if !filter.is_empty() && !vector.id.contains(&filter) {
+                continue;
+            }
+            let observed = run(vector);
+            let agrees = observed.matches(&vector.expect);
+            let declared_agrees = matches!(vector.reference, Reference::Agrees);
+            rows.push((
+                file.section.clone(),
+                vector.id.clone(),
+                agrees,
+                declared_agrees,
+                format!("{observed:?}"),
+                format!("{:?}", vector.expect),
+            ));
+        }
+    }
+
+    if json {
+        let out: Vec<_> = rows
+            .iter()
+            .map(|(section, id, agrees, declared, observed, expect)| {
+                serde_json::json!({
+                    "section": section,
+                    "id": id,
+                    "reference_agrees": agrees,
+                    "declared_agrees": declared,
+                    "observed": observed,
+                    "expected": expect,
+                })
+            })
+            .collect();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&out).map_err(|e| e.to_string())?
+        );
+        return Ok(());
+    }
+
+    let mut mismatched = 0;
+    for (section, id, agrees, declared, observed, expect) in &rows {
+        let mark = match (agrees, declared) {
+            (true, true) => "ok  ",
+            (false, false) => "div ",
+            _ => {
+                mismatched += 1;
+                "MISM"
+            }
+        };
+        println!("{mark} {section}/{id}");
+        if !agrees {
+            println!("       expected: {expect}");
+            println!("       observed: {observed}");
+        }
+    }
+
+    println!(
+        "\n{} vectors, {} declared divergences, {mismatched} mislabeled",
+        rows.len(),
+        rows.iter().filter(|r| !r.3).count()
+    );
+    Ok(())
+}

--- a/conformance/src/bin/oracle.rs
+++ b/conformance/src/bin/oracle.rs
@@ -72,7 +72,7 @@ fn main() -> Result<(), String> {
             }
         };
         println!("{mark} {section}/{id}");
-        if !agrees {
+        if agrees != declared {
             println!("       expected: {expect}");
             println!("       observed: {observed}");
         }

--- a/conformance/src/lib.rs
+++ b/conformance/src/lib.rs
@@ -16,7 +16,13 @@ use serde::{Deserialize, Serialize};
 pub mod reference;
 
 /// One `corpus/*.json` file: a themed group of vectors.
+///
+/// Unknown fields are rejected throughout the corpus types. A misspelled
+/// `reference` would otherwise default to [`Reference::Agrees`], and a misspelled
+/// `flags` would become an empty expectation — both of which would let a
+/// malformed vector load and pass while testing nothing.
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct VectorFile {
     /// Which part of the grammar this file covers, e.g. `"short-flags"`.
     pub section: String,
@@ -28,6 +34,7 @@ pub struct VectorFile {
 
 /// A single case: parse `argv` against `spec` and you must get `expect`.
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Vector {
     /// Stable identifier, unique across the corpus. Failures and
     /// cross-implementation reports quote it, so renaming one breaks anybody
@@ -71,6 +78,7 @@ pub enum Expect {
 /// token that set it, so `-j`, `--jobs`, and `JOBS=8` all land under `jobs`.
 /// Anything left unset is omitted rather than recorded as null.
 #[derive(Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct Parsed {
     /// The subcommand path selected, outermost first; empty for the root.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -140,10 +148,17 @@ pub enum Reference {
 /// Load every `*.json` file in a corpus directory, sorted by file name.
 pub fn load(dir: impl AsRef<Path>) -> Result<Vec<VectorFile>, String> {
     let dir = dir.as_ref();
+    // An unreadable entry is an error rather than something to skip: silently
+    // dropping one would let CI validate a partial corpus and still pass.
     let mut paths: Vec<_> = std::fs::read_dir(dir)
         .map_err(|e| format!("reading {}: {e}", dir.display()))?
-        .filter_map(Result::ok)
-        .map(|e| e.path())
+        .map(|entry| {
+            entry
+                .map(|e| e.path())
+                .map_err(|e| format!("reading an entry of {}: {e}", dir.display()))
+        })
+        .collect::<Result<Vec<_>, String>>()?
+        .into_iter()
         .filter(|p| p.extension().is_some_and(|x| x == "json"))
         .collect();
     paths.sort();

--- a/conformance/src/lib.rs
+++ b/conformance/src/lib.rs
@@ -1,0 +1,165 @@
+//! The argv conformance corpus: its format, a loader, and the reference runner.
+//!
+//! The corpus is the executable half of [the argv grammar]. Each vector pairs a
+//! spec and an `argv` with the result that parsing one against the other must
+//! produce. The files are plain JSON so implementations in other languages can
+//! run the same cases without reimplementing a test format, and so the grammar
+//! has a mechanical definition rather than only a prose one.
+//!
+//! [the argv grammar]: https://usage.jdx.dev/spec/argv
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+pub mod reference;
+
+/// One `corpus/*.json` file: a themed group of vectors.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct VectorFile {
+    /// Which part of the grammar this file covers, e.g. `"short-flags"`.
+    pub section: String,
+    /// What the group establishes, plus anything a reader needs in order to
+    /// judge whether these expectations are the right ones.
+    pub about: String,
+    pub vectors: Vec<Vector>,
+}
+
+/// A single case: parse `argv` against `spec` and you must get `expect`.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Vector {
+    /// Stable identifier, unique across the corpus. Failures and
+    /// cross-implementation reports quote it, so renaming one breaks anybody
+    /// tracking known failures.
+    pub id: String,
+    /// What behavior this pins down, in one sentence.
+    pub doc: String,
+    /// A complete spec, as KDL.
+    pub spec: String,
+    /// The command line, excluding the program name.
+    pub argv: Vec<String>,
+    /// The environment the parse sees. Only vectors about `env` fallback set it;
+    /// the harness never consults the real environment, so no vector's result
+    /// can depend on the machine running it.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub env: BTreeMap<String, String>,
+    pub expect: Expect,
+    /// Whether usage-lib, the reference implementation, agrees with `expect`.
+    ///
+    /// Recorded per vector rather than assumed. The corpus describes the grammar
+    /// the spec intends; usage-lib is one implementation of it, and where the two
+    /// differ that is worth writing down instead of hiding. These notes are the
+    /// compatibility matrix any new implementation has to read.
+    #[serde(default)]
+    pub reference: Reference,
+}
+
+/// The result of a parse: a binding, or a class of failure.
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Expect {
+    Ok(Parsed),
+    /// Only the *class* of error is pinned, never its wording. Message text is a
+    /// diagnostics concern and is expected to differ between implementations.
+    Error(ErrorCode),
+}
+
+/// What a successful parse binds.
+///
+/// Keyed by the name the spec gives each flag and argument rather than by the
+/// token that set it, so `-j`, `--jobs`, and `JOBS=8` all land under `jobs`.
+/// Anything left unset is omitted rather than recorded as null.
+#[derive(Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct Parsed {
+    /// The subcommand path selected, outermost first; empty for the root.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub cmd: Vec<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub flags: BTreeMap<String, Value>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub args: BTreeMap<String, Value>,
+}
+
+/// A bound value.
+///
+/// Deliberately small. The grammar decides which tokens bind where, not what
+/// they mean: turning `"8"` into a number is the caller's business, so the
+/// corpus records the string.
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum Value {
+    Bool(bool),
+    Str(String),
+    Bools(Vec<bool>),
+    Strs(Vec<String>),
+}
+
+/// The classes of failure the grammar distinguishes.
+///
+/// Coarse on purpose. An implementation should produce something far more
+/// specific; what the corpus pins is that a command line fails for a given
+/// *reason*, which is what lets a strict parser and a lenient one be told apart
+/// mechanically.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorCode {
+    /// A token looked like a flag, but no flag by that name is in scope here.
+    UnknownFlag,
+    /// A flag needing a value was last, or was followed by something that cannot
+    /// be its value.
+    MissingFlagValue,
+    /// A required flag never appeared.
+    MissingRequiredFlag,
+    /// A required positional was never filled.
+    MissingRequiredArg,
+    /// More positionals were given than the command accepts.
+    UnexpectedArg,
+    /// A value was given that is not among the declared choices.
+    InvalidChoice,
+    /// A positional declared `double_dash="required"` was given before `--`.
+    ArgRequiresDoubleDash,
+    /// A variadic got fewer values than `var_min`.
+    VarTooFew,
+    /// A variadic got more values than `var_max`.
+    VarTooMany,
+}
+
+/// Whether the reference implementation matches a vector's expectation.
+#[derive(Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Reference {
+    /// usage-lib produces exactly `expect`.
+    #[default]
+    Agrees,
+    /// usage-lib produces something else. The note says what, and why the corpus
+    /// keeps its own expectation regardless.
+    Diverges(String),
+}
+
+/// Load every `*.json` file in a corpus directory, sorted by file name.
+pub fn load(dir: impl AsRef<Path>) -> Result<Vec<VectorFile>, String> {
+    let dir = dir.as_ref();
+    let mut paths: Vec<_> = std::fs::read_dir(dir)
+        .map_err(|e| format!("reading {}: {e}", dir.display()))?
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|x| x == "json"))
+        .collect();
+    paths.sort();
+
+    paths
+        .iter()
+        .map(|p| {
+            let text =
+                std::fs::read_to_string(p).map_err(|e| format!("reading {}: {e}", p.display()))?;
+            serde_json::from_str(&text).map_err(|e| format!("parsing {}: {e}", p.display()))
+        })
+        .collect()
+}
+
+/// The corpus directory, resolved against this crate rather than the process's
+/// working directory.
+pub fn corpus_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../corpus")
+}

--- a/conformance/src/reference.rs
+++ b/conformance/src/reference.rs
@@ -1,0 +1,150 @@
+//! Running a vector against usage-lib, the reference implementation.
+//!
+//! usage-lib interprets a spec at runtime, which is precisely what the corpus
+//! describes, so it is the oracle every other implementation is measured
+//! against. This module is the adapter: it turns usage-lib's [`ParseOutput`]
+//! into the corpus's [`Parsed`] shape, and its errors into an [`ErrorCode`].
+//!
+//! [`ParseOutput`]: usage::parse::ParseOutput
+
+use std::collections::{BTreeMap, HashMap};
+
+use usage::parse::{ParseValue, Parser};
+use usage::Spec;
+
+use crate::{ErrorCode, Expect, Parsed, Value, Vector};
+
+/// What usage-lib did with a vector.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Observed {
+    /// A parse, translated into corpus terms.
+    Parsed(Parsed),
+    /// A failure classified into one of the grammar's error codes.
+    Failed(ErrorCode),
+    /// A failure that does not map onto any code the corpus defines. Kept
+    /// distinct from `Failed` so an unclassifiable error can never be mistaken
+    /// for agreement with an `Error` expectation.
+    Unclassified(String),
+    /// The spec itself would not load. Always a bug in the vector, not a finding
+    /// about the parser.
+    BadSpec(String),
+}
+
+impl Observed {
+    /// Whether this matches what the vector expects.
+    pub fn matches(&self, expect: &Expect) -> bool {
+        match (self, expect) {
+            (Observed::Parsed(got), Expect::Ok(want)) => got == want,
+            (Observed::Failed(got), Expect::Error(want)) => got == want,
+            _ => false,
+        }
+    }
+}
+
+/// Parse a vector with usage-lib.
+pub fn run(vector: &Vector) -> Observed {
+    let spec: Spec = match vector.spec.parse() {
+        Ok(spec) => spec,
+        Err(e) => return Observed::BadSpec(e.to_string()),
+    };
+
+    // Always an explicit map, even when empty: a vector that consulted the real
+    // environment would pass or fail depending on the machine.
+    let env: HashMap<String, String> = vector
+        .env
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+
+    // usage-lib expects argv to include the program name, and reports the
+    // selected command relative to it.
+    let mut input = vec![spec.bin.clone()];
+    input.extend(vector.argv.iter().cloned());
+
+    match Parser::new(&spec).with_env(env).parse(&input) {
+        Ok(out) => {
+            let cmd = out
+                .cmds
+                .iter()
+                .skip(1) // the root command is not part of the path
+                .map(|c| c.name.clone())
+                .collect();
+            let flags = out
+                .flags
+                .iter()
+                .map(|(flag, value)| (flag.name.clone(), convert(value)))
+                .collect();
+            let args = out
+                .args
+                .iter()
+                .map(|(arg, value)| (arg.name.clone(), convert(value)))
+                .collect();
+            Observed::Parsed(Parsed { cmd, flags, args })
+        }
+        Err(e) => classify(&e.to_string()),
+    }
+}
+
+fn convert(value: &ParseValue) -> Value {
+    match value {
+        ParseValue::Bool(b) => Value::Bool(*b),
+        ParseValue::String(s) => Value::Str(s.clone()),
+        ParseValue::MultiBool(b) => Value::Bools(b.clone()),
+        ParseValue::MultiString(s) => Value::Strs(s.clone()),
+    }
+}
+
+/// Map a usage-lib error onto one of the grammar's error codes.
+///
+/// Matching on the rendered message rather than on `UsageErr` variants: parsing
+/// returns a `miette::Error`, so the concrete type is erased by the time it gets
+/// here, and `InvalidFlag` would need its `reason` inspected anyway. The strings
+/// below are load-bearing and will need revisiting whenever usage-lib rewords a
+/// diagnostic — which is why an unrecognized message becomes
+/// [`Observed::Unclassified`] and fails loudly instead of quietly matching
+/// whatever the vector expected.
+fn classify(msg: &str) -> Observed {
+    let code = if msg.contains("Missing required flag") {
+        ErrorCode::MissingRequiredFlag
+    } else if msg.contains("Missing required arg") {
+        ErrorCode::MissingRequiredArg
+    } else if msg.contains("can only be set after a `--` separator") {
+        ErrorCode::ArgRequiresDoubleDash
+    } else if msg.contains("requires at least") {
+        // Both the arg and flag forms of "too few" say this; they differ only in
+        // whether the subject is rendered as <name> or --name, and the corpus
+        // does not distinguish subject.
+        ErrorCode::VarTooFew
+    } else if msg.contains("accepts at most") {
+        ErrorCode::VarTooMany
+    } else if msg.contains("Invalid flag") {
+        // usage-lib funnels several distinct situations through InvalidFlag, so
+        // the reason has to be read to tell them apart.
+        if msg.contains("requires an argument") || msg.contains("missing value") {
+            ErrorCode::MissingFlagValue
+        } else if msg.contains("Invalid choice") || msg.contains("expected one of") {
+            ErrorCode::InvalidChoice
+        } else {
+            ErrorCode::UnknownFlag
+        }
+    } else if msg.contains("Invalid choice") || msg.contains("expected one of") {
+        ErrorCode::InvalidChoice
+    } else if msg.contains("Unexpected argument") || msg.contains("unexpected") {
+        ErrorCode::UnexpectedArg
+    } else {
+        return Observed::Unclassified(msg.to_string());
+    };
+    Observed::Failed(code)
+}
+
+/// Every duplicate id in the corpus, so uniqueness can be asserted.
+pub fn duplicate_ids<'a>(vectors: impl Iterator<Item = &'a Vector>) -> Vec<String> {
+    let mut seen: BTreeMap<&str, usize> = BTreeMap::new();
+    for v in vectors {
+        *seen.entry(v.id.as_str()).or_default() += 1;
+    }
+    seen.into_iter()
+        .filter(|(_, n)| *n > 1)
+        .map(|(id, _)| id.to_string())
+        .collect()
+}

--- a/conformance/tests/reference.rs
+++ b/conformance/tests/reference.rs
@@ -1,0 +1,78 @@
+//! Checks the corpus against usage-lib.
+//!
+//! Two distinct things are enforced here. First, the corpus is well formed: it
+//! loads, ids are unique, every spec parses. Second, every vector's `reference`
+//! label is accurate — a vector claiming the reference agrees must actually
+//! agree, and one claiming a divergence must actually diverge.
+//!
+//! That second check is the point. It means a change in usage-lib's parsing
+//! shows up here as a failing label rather than as silent drift, and it keeps the
+//! recorded divergences from becoming stale folklore.
+
+use usage_conformance::reference::{duplicate_ids, run, Observed};
+use usage_conformance::{load, Reference, Vector};
+
+fn corpus() -> Vec<Vector> {
+    let files = load(usage_conformance::corpus_dir()).expect("corpus should load");
+    assert!(!files.is_empty(), "corpus directory should not be empty");
+    files.into_iter().flat_map(|f| f.vectors).collect()
+}
+
+#[test]
+fn ids_are_unique() {
+    let vectors = corpus();
+    let dupes = duplicate_ids(vectors.iter());
+    assert!(dupes.is_empty(), "duplicate vector ids: {dupes:?}");
+}
+
+#[test]
+fn specs_are_valid() {
+    for vector in corpus() {
+        if let Observed::BadSpec(e) = run(&vector) {
+            panic!("vector {} has an invalid spec: {e}", vector.id);
+        }
+    }
+}
+
+#[test]
+fn every_vector_has_a_doc_comment() {
+    // The corpus doubles as documentation of the grammar, so a vector without an
+    // explanation is only half of one.
+    for vector in corpus() {
+        assert!(
+            !vector.doc.trim().is_empty(),
+            "vector {} needs a doc string",
+            vector.id
+        );
+    }
+}
+
+#[test]
+fn reference_labels_are_accurate() {
+    let mut wrong = Vec::new();
+
+    for vector in corpus() {
+        let observed = run(&vector);
+        let agrees = observed.matches(&vector.expect);
+
+        match (&vector.reference, agrees) {
+            (Reference::Agrees, true) => {}
+            (Reference::Diverges(_), false) => {}
+            (Reference::Agrees, false) => wrong.push(format!(
+                "{}: labeled `agrees`, but usage-lib disagrees\n     expected: {:?}\n     observed: {observed:?}",
+                vector.id, vector.expect
+            )),
+            (Reference::Diverges(note), true) => wrong.push(format!(
+                "{}: labeled `diverges` ({note}), but usage-lib now agrees — delete the label",
+                vector.id
+            )),
+        }
+    }
+
+    assert!(
+        wrong.is_empty(),
+        "{} vector(s) mislabeled:\n  - {}",
+        wrong.len(),
+        wrong.join("\n  - ")
+    );
+}

--- a/corpus/01-long-flags.json
+++ b/corpus/01-long-flags.json
@@ -1,0 +1,139 @@
+{
+  "section": "long-flags",
+  "about": "How `--name` tokens bind. Long names match exactly — there is no abbreviation inference — and a value may be attached with `=` or given as the following word.",
+  "vectors": [
+    {
+      "id": "long-boolean-present",
+      "doc": "A flag with no argument binds true when present.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--force\"\n",
+      "argv": ["--force"],
+      "expect": { "ok": { "flags": { "force": true } } }
+    },
+    {
+      "id": "long-boolean-absent",
+      "doc": "An absent boolean flag is not bound at all, rather than bound false.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--force\"\n",
+      "argv": [],
+      "expect": { "ok": {} }
+    },
+    {
+      "id": "long-value-attached",
+      "doc": "`--flag=value` binds the text after the first `=`.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--jobs <n>\"\n",
+      "argv": ["--jobs=8"],
+      "expect": { "ok": { "flags": { "jobs": "8" } } }
+    },
+    {
+      "id": "long-value-detached",
+      "doc": "`--flag value` binds the following word.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--jobs <n>\"\n",
+      "argv": ["--jobs", "8"],
+      "expect": { "ok": { "flags": { "jobs": "8" } } }
+    },
+    {
+      "id": "long-value-attached-keeps-later-equals",
+      "doc": "Only the first `=` separates; the rest belongs to the value, so `--set=a=b` yields `a=b`.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--set <kv>\"\n",
+      "argv": ["--set=a=b"],
+      "expect": { "ok": { "flags": { "set": "a=b" } } }
+    },
+    {
+      "id": "long-value-attached-empty",
+      "doc": "`--flag=` binds the empty string. Present-but-empty is a different state from absent, and only the attached form can express it.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--jobs <n>\"\n",
+      "argv": ["--jobs="],
+      "expect": { "ok": { "flags": { "jobs": "" } } },
+      "reference": {
+        "diverges": "usage-lib binds nothing, collapsing `--jobs=` into the same result as omitting the flag."
+      }
+    },
+    {
+      "id": "long-value-attached-flaglike",
+      "doc": "An attached value binds even when it looks like a flag: `=` has already settled where the value came from.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--jobs <n>\"\nflag \"--force\"\n",
+      "argv": ["--jobs=--force"],
+      "expect": { "ok": { "flags": { "jobs": "--force" } } },
+      "reference": {
+        "diverges": "usage-lib binds `force` instead and leaves `jobs` unset, treating the attached value as a separate flag token."
+      }
+    },
+    {
+      "id": "long-value-missing",
+      "doc": "A flag needing a value that ends the command line is an error.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--jobs <n>\"\n",
+      "argv": ["--jobs"],
+      "expect": { "error": "missing_flag_value" },
+      "reference": {
+        "diverges": "usage-lib parses successfully and binds nothing, so `ex --jobs` silently does what `ex` does."
+      }
+    },
+    {
+      "id": "long-value-rejects-flaglike-next-word",
+      "doc": "A detached value must not itself look like a flag, so a forgotten value is reported rather than swallowed. Use the attached form to pass a value that begins with a dash.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--jobs <n>\"\nflag \"--force\"\n",
+      "argv": ["--jobs", "--force"],
+      "expect": { "error": "missing_flag_value" },
+      "reference": {
+        "diverges": "usage-lib binds `force` and leaves `jobs` unset without reporting anything."
+      }
+    },
+    {
+      "id": "long-value-accepts-negative-number",
+      "doc": "A negative number is a value, not a flag, so it may be given detached. Without this exception no CLI could accept `--offset -1`.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--offset <n>\"\n",
+      "argv": ["--offset", "-1"],
+      "expect": { "ok": { "flags": { "offset": "-1" } } }
+    },
+    {
+      "id": "long-unknown",
+      "doc": "An unrecognized long flag is an error, even when the command has a positional that could have held it. Otherwise a typo becomes data.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--force\"\narg \"[file]\"\n",
+      "argv": ["--wat"],
+      "expect": { "error": "unknown_flag" },
+      "reference": {
+        "diverges": "usage-lib binds `--wat` to the positional `file`. This is the root of several other divergences here: unrecognized flags fall through to positionals, so they surface as `unexpected_arg` — or as no error at all — rather than as `unknown_flag`."
+      }
+    },
+    {
+      "id": "long-no-abbreviation",
+      "doc": "A unique prefix of a long name is not accepted. Abbreviation inference makes adding a flag a breaking change for anyone who typed a prefix that was unique until now, so the grammar has none.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--force\"\n",
+      "argv": ["--for"],
+      "expect": { "error": "unknown_flag" },
+      "reference": {
+        "diverges": "usage-lib also refuses the abbreviation, but reports `unexpected_arg`: `--for` becomes a positional, and the command has none."
+      }
+    },
+    {
+      "id": "long-repeated-var",
+      "doc": "A `var` flag collects each occurrence in order.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--include <pattern>\" var=#true\n",
+      "argv": ["--include", "a", "--include", "b"],
+      "expect": { "ok": { "flags": { "include": ["a", "b"] } } }
+    },
+    {
+      "id": "long-variadic-flag-arg",
+      "doc": "A flag whose argument is variadic takes several values from one occurrence, which is what the trailing ellipsis in `<pattern>...` declares.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--include <pattern>...\"\n",
+      "argv": ["--include", "a", "b"],
+      "expect": { "ok": { "flags": { "include": ["a", "b"] } } },
+      "reference": {
+        "diverges": "usage-lib reports `unexpected_arg` for the second value. The spec reference documents this form, so the gap is in the parser rather than in the declaration."
+      }
+    },
+    {
+      "id": "long-negation",
+      "doc": "A flag with `negate` binds false when the negating form is used.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--color\" negate=\"--no-color\" default=#true\n",
+      "argv": ["--no-color"],
+      "expect": { "ok": { "flags": { "color": false } } }
+    },
+    {
+      "id": "long-negation-default",
+      "doc": "With neither form given, a negatable flag takes its declared default.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--color\" negate=\"--no-color\" default=#true\n",
+      "argv": [],
+      "expect": { "ok": { "flags": { "color": true } } }
+    }
+  ]
+}

--- a/corpus/02-short-flags.json
+++ b/corpus/02-short-flags.json
@@ -1,0 +1,109 @@
+{
+  "section": "short-flags",
+  "about": "How `-x` tokens bind. A short flag taking a value accepts it attached, attached after `=`, or as the following word. Several value-less shorts may be bundled in one token.",
+  "vectors": [
+    {
+      "id": "short-boolean",
+      "doc": "A short alias sets the flag it belongs to, recorded under the flag's name.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-f --force\"\n",
+      "argv": ["-f"],
+      "expect": { "ok": { "flags": { "force": true } } }
+    },
+    {
+      "id": "short-value-detached",
+      "doc": "`-j 8` binds the following word.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-j --jobs <n>\"\n",
+      "argv": ["-j", "8"],
+      "expect": { "ok": { "flags": { "jobs": "8" } } }
+    },
+    {
+      "id": "short-value-attached",
+      "doc": "`-j8` binds the rest of the token. mise relies on this for `-C/tmp` and `-Edev`.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-j --jobs <n>\"\n",
+      "argv": ["-j8"],
+      "expect": { "ok": { "flags": { "jobs": "8" } } }
+    },
+    {
+      "id": "short-value-attached-path",
+      "doc": "An attached value keeps every character after the flag letter, including leading slashes and equals-free punctuation.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-C --cd <dir>\"\n",
+      "argv": ["-C/tmp/x"],
+      "expect": { "ok": { "flags": { "cd": "/tmp/x" } } }
+    },
+    {
+      "id": "short-value-equals",
+      "doc": "`-j=8` binds `8`, not `=8`. A single leading `=` is a separator, matching the long form.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-j --jobs <n>\"\n",
+      "argv": ["-j=8"],
+      "expect": { "ok": { "flags": { "jobs": "8" } } },
+      "reference": {
+        "diverges": "usage-lib binds `=8`, keeping the separator as part of the value."
+      }
+    },
+    {
+      "id": "short-value-missing",
+      "doc": "A value-taking short at the end of the command line is an error.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-j --jobs <n>\"\n",
+      "argv": ["-j"],
+      "expect": { "error": "missing_flag_value" },
+      "reference": {
+        "diverges": "usage-lib parses successfully and binds nothing, as it does for the long form."
+      }
+    },
+    {
+      "id": "short-bundle",
+      "doc": "Value-less shorts may share a token: `-ab` sets both.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-a --all\"\nflag \"-b --brief\"\n",
+      "argv": ["-ab"],
+      "expect": { "ok": { "flags": { "all": true, "brief": true } } }
+    },
+    {
+      "id": "short-bundle-then-value",
+      "doc": "A bundle may end with a value-taking short, which then consumes the remainder of the token.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-a --all\"\nflag \"-j --jobs <n>\"\n",
+      "argv": ["-aj8"],
+      "expect": { "ok": { "flags": { "all": true, "jobs": "8" } } }
+    },
+    {
+      "id": "short-bundle-unknown-letter",
+      "doc": "An unrecognized letter anywhere in a bundle fails the whole token.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-a --all\"\n",
+      "argv": ["-az"],
+      "expect": { "error": "unknown_flag" },
+      "reference": {
+        "diverges": "usage-lib reports `unexpected_arg`: the whole token falls through to positionals, so `-a` is not applied either."
+      }
+    },
+    {
+      "id": "short-count",
+      "doc": "A `count` flag records how many times it appeared, so `-vvv` is three.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-v --verbose\" count=#true\n",
+      "argv": ["-vvv"],
+      "expect": { "ok": { "flags": { "verbose": [true, true, true] } } }
+    },
+    {
+      "id": "short-count-separate-tokens",
+      "doc": "The same count reached through separate tokens gives the same result.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-v --verbose\" count=#true\n",
+      "argv": ["-v", "-v"],
+      "expect": { "ok": { "flags": { "verbose": [true, true] } } }
+    },
+    {
+      "id": "bare-dash-is-positional",
+      "doc": "A lone `-` is a value, conventionally meaning stdin, not a flag.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"<file>\"\n",
+      "argv": ["-"],
+      "expect": { "ok": { "args": { "file": "-" } } }
+    },
+    {
+      "id": "short-unknown",
+      "doc": "An unrecognized short flag is an error rather than a positional.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"[file]\"\n",
+      "argv": ["-z"],
+      "expect": { "error": "unknown_flag" },
+      "reference": {
+        "diverges": "usage-lib binds `-z` to the positional `file`, the same fall-through described in `long-unknown`."
+      }
+    }
+  ]
+}

--- a/corpus/03-positionals.json
+++ b/corpus/03-positionals.json
@@ -1,0 +1,98 @@
+{
+  "section": "positionals",
+  "about": "How words that are not flags bind to declared arguments. Arguments fill in declaration order; a variadic takes everything left over.",
+  "vectors": [
+    {
+      "id": "arg-required-filled",
+      "doc": "A required argument takes the first non-flag word.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"<file>\"\n",
+      "argv": ["a.txt"],
+      "expect": { "ok": { "args": { "file": "a.txt" } } }
+    },
+    {
+      "id": "arg-required-missing",
+      "doc": "A required argument with nothing to fill it is an error.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"<file>\"\n",
+      "argv": [],
+      "expect": { "error": "missing_required_arg" }
+    },
+    {
+      "id": "arg-optional-absent",
+      "doc": "An optional argument left unfilled is simply absent.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"[file]\"\n",
+      "argv": [],
+      "expect": { "ok": {} }
+    },
+    {
+      "id": "arg-order",
+      "doc": "Two arguments fill in declaration order, regardless of what the values look like.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"<src>\"\narg \"<dst>\"\n",
+      "argv": ["from", "to"],
+      "expect": { "ok": { "args": { "src": "from", "dst": "to" } } }
+    },
+    {
+      "id": "arg-interleaved-with-flags",
+      "doc": "Flags and positionals may interleave; a flag between two words does not change which argument each word fills.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-f --force\"\narg \"<src>\"\narg \"<dst>\"\n",
+      "argv": ["from", "-f", "to"],
+      "expect": {
+        "ok": {
+          "flags": { "force": true },
+          "args": { "src": "from", "dst": "to" }
+        }
+      }
+    },
+    {
+      "id": "arg-too-many",
+      "doc": "More words than there are arguments to hold them is an error, not silent truncation.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"<file>\"\n",
+      "argv": ["a", "b"],
+      "expect": { "error": "unexpected_arg" }
+    },
+    {
+      "id": "arg-variadic-collects-rest",
+      "doc": "A variadic argument collects every remaining word.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"<files>...\"\n",
+      "argv": ["a", "b", "c"],
+      "expect": { "ok": { "args": { "files": ["a", "b", "c"] } } }
+    },
+    {
+      "id": "arg-variadic-after-fixed",
+      "doc": "A fixed argument is filled before a following variadic starts collecting.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"<cmd>\"\narg \"[rest]...\"\n",
+      "argv": ["run", "a", "b"],
+      "expect": { "ok": { "args": { "cmd": "run", "rest": ["a", "b"] } } }
+    },
+    {
+      "id": "arg-variadic-empty",
+      "doc": "An optional variadic given nothing is absent rather than an empty list.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"[rest]...\"\n",
+      "argv": [],
+      "expect": { "ok": {} }
+    },
+    {
+      "id": "arg-variadic-min",
+      "doc": "`var_min` is enforced: too few values is an error.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"<files>\" var=#true var_min=2\n",
+      "argv": ["a"],
+      "expect": { "error": "var_too_few" }
+    },
+    {
+      "id": "arg-variadic-max",
+      "doc": "`var_max` is enforced: too many values is an error.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"<files>\" var=#true var_max=2\n",
+      "argv": ["a", "b", "c"],
+      "expect": { "error": "var_too_many" },
+      "reference": {
+        "diverges": "usage-lib reports `unexpected_arg`. The outcome is the same rejection; the distinct code is what tells a caller the limit was a `var_max` rather than an absent argument."
+      }
+    },
+    {
+      "id": "arg-value-looks-like-negative-number",
+      "doc": "A negative number is a value, not an unknown flag. A leading `-` followed by a digit cannot begin a flag name, so the token is offered to the next argument.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"<offset>\"\n",
+      "argv": ["-1"],
+      "expect": { "ok": { "args": { "offset": "-1" } } }
+    }
+  ]
+}

--- a/corpus/04-subcommands.json
+++ b/corpus/04-subcommands.json
@@ -1,0 +1,79 @@
+{
+  "section": "subcommands",
+  "about": "How a command is selected. The first word that is not a flag or a flag's value is matched against the current command's subcommands; a match descends, and parsing continues against the new command.",
+  "vectors": [
+    {
+      "id": "cmd-select",
+      "doc": "A word matching a subcommand name selects it.",
+      "spec": "name \"ex\"\nbin \"ex\"\ncmd \"install\"\n",
+      "argv": ["install"],
+      "expect": { "ok": { "cmd": ["install"] } }
+    },
+    {
+      "id": "cmd-alias",
+      "doc": "An alias selects the same command, and the path records the canonical name rather than the alias typed.",
+      "spec": "name \"ex\"\nbin \"ex\"\ncmd \"install\" {\n  alias \"i\"\n}\n",
+      "argv": ["i"],
+      "expect": { "ok": { "cmd": ["install"] } }
+    },
+    {
+      "id": "cmd-nested",
+      "doc": "Descent continues as long as words keep matching subcommands.",
+      "spec": "name \"ex\"\nbin \"ex\"\ncmd \"settings\" {\n  cmd \"set\"\n}\n",
+      "argv": ["settings", "set"],
+      "expect": { "ok": { "cmd": ["settings", "set"] } }
+    },
+    {
+      "id": "cmd-flag-after",
+      "doc": "A subcommand's own flags are recognized after it.",
+      "spec": "name \"ex\"\nbin \"ex\"\ncmd \"install\" {\n  flag \"-f --force\"\n}\n",
+      "argv": ["install", "--force"],
+      "expect": { "ok": { "cmd": ["install"], "flags": { "force": true } } }
+    },
+    {
+      "id": "cmd-flag-before",
+      "doc": "A parent's flag may appear before the subcommand word.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-q --quiet\"\ncmd \"install\"\n",
+      "argv": ["--quiet", "install"],
+      "expect": { "ok": { "cmd": ["install"], "flags": { "quiet": true } } }
+    },
+    {
+      "id": "cmd-arg-of-subcommand",
+      "doc": "Positionals declared on the subcommand are filled from the words after it.",
+      "spec": "name \"ex\"\nbin \"ex\"\ncmd \"install\" {\n  arg \"<tool>\"\n}\n",
+      "argv": ["install", "node@20"],
+      "expect": { "ok": { "cmd": ["install"], "args": { "tool": "node@20" } } }
+    },
+    {
+      "id": "cmd-unknown-is-arg-when-arg-declared",
+      "doc": "A word that matches no subcommand falls through to the command's own positionals. This is what lets a CLI accept both `ex install` and `ex ./some-file` when it declares an argument alongside its subcommands.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"[target]\"\ncmd \"install\"\n",
+      "argv": ["other"],
+      "expect": { "ok": { "args": { "target": "other" } } }
+    },
+    {
+      "id": "cmd-name-wins-over-arg",
+      "doc": "When a word could be either a subcommand or a positional value, the subcommand wins. A CLI that declares both cannot be given a positional whose text equals a subcommand name — mise documents exactly this hazard for tasks that share a name with a command.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"[target]\"\ncmd \"install\"\n",
+      "argv": ["install"],
+      "expect": { "ok": { "cmd": ["install"] } }
+    },
+    {
+      "id": "cmd-only-first-word-routes",
+      "doc": "Once a positional has consumed a word, a later word matching a subcommand name does not route: subcommand selection happens at the point of descent, not anywhere in the command line.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"<target>\"\narg \"[second]\"\ncmd \"install\"\n",
+      "argv": ["other", "install"],
+      "expect": { "ok": { "args": { "target": "other", "second": "install" } } }
+    },
+    {
+      "id": "cmd-parent-flag-not-inherited",
+      "doc": "A parent flag that is not `global` is not accepted after descending into a subcommand.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-q --quiet\"\ncmd \"install\"\n",
+      "argv": ["install", "--quiet"],
+      "expect": { "error": "unknown_flag" },
+      "reference": {
+        "diverges": "usage-lib agrees the flag is not inherited, but reports `unexpected_arg` because the unrecognized flag becomes a positional first."
+      }
+    }
+  ]
+}

--- a/corpus/05-globals.json
+++ b/corpus/05-globals.json
@@ -1,0 +1,53 @@
+{
+  "section": "global-flags",
+  "about": "A `global` flag is recognized by the command that declares it and by everything beneath it, so it may appear before or after any subcommand word.",
+  "vectors": [
+    {
+      "id": "global-before-subcommand",
+      "doc": "A global flag declared at the root works before the subcommand.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-v --verbose\" global=#true\ncmd \"install\"\n",
+      "argv": ["--verbose", "install"],
+      "expect": { "ok": { "cmd": ["install"], "flags": { "verbose": true } } }
+    },
+    {
+      "id": "global-after-subcommand",
+      "doc": "The same flag works after the subcommand.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-v --verbose\" global=#true\ncmd \"install\"\n",
+      "argv": ["install", "--verbose"],
+      "expect": { "ok": { "cmd": ["install"], "flags": { "verbose": true } } }
+    },
+    {
+      "id": "global-with-value-after-subcommand",
+      "doc": "A global flag that takes a value binds it the same way at any depth.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-C --cd <dir>\" global=#true\ncmd \"install\"\n",
+      "argv": ["install", "-C", "/tmp"],
+      "expect": { "ok": { "cmd": ["install"], "flags": { "cd": "/tmp" } } }
+    },
+    {
+      "id": "global-at-depth-two",
+      "doc": "Inheritance is not limited to one level.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-v --verbose\" global=#true\ncmd \"settings\" {\n  cmd \"set\"\n}\n",
+      "argv": ["settings", "set", "--verbose"],
+      "expect": {
+        "ok": { "cmd": ["settings", "set"], "flags": { "verbose": true } }
+      }
+    },
+    {
+      "id": "global-declared-on-subcommand-not-visible-at-root",
+      "doc": "`global` propagates downward only. A flag declared global on a subcommand is not accepted before that subcommand is reached.",
+      "spec": "name \"ex\"\nbin \"ex\"\ncmd \"install\" {\n  flag \"-f --force\" global=#true\n}\n",
+      "argv": ["--force", "install"],
+      "expect": { "error": "unknown_flag" },
+      "reference": {
+        "diverges": "usage-lib agrees the flag is not visible here, but reports `unexpected_arg` for the same fall-through reason."
+      }
+    },
+    {
+      "id": "global-shadowed-by-subcommand-flag",
+      "doc": "A subcommand may declare its own flag with the same name as an inherited global; below that point the subcommand's flag is the one that binds. mise does this deliberately, redeclaring several root globals on `run` with different shorts.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-j --jobs <n>\" global=#true\ncmd \"run\" {\n  flag \"-j --jobs <n>\"\n}\n",
+      "argv": ["run", "--jobs", "4"],
+      "expect": { "ok": { "cmd": ["run"], "flags": { "jobs": "4" } } }
+    }
+  ]
+}

--- a/corpus/06-double-dash.json
+++ b/corpus/06-double-dash.json
@@ -67,10 +67,20 @@
     },
     {
       "id": "dd-preserve-keeps-separator-as-value",
-      "doc": "With `double_dash=\"preserve\"`, the separator is kept as a value instead of being consumed — needed by CLIs that pass along command lines containing their own separators.",
+      "doc": "With `double_dash=\"preserve\"`, the separator is kept as a value instead of being consumed \u2014 needed by CLIs that pass along command lines containing their own separators.",
       "spec": "name \"ex\"\nbin \"ex\"\narg \"<args>...\" double_dash=\"preserve\"\n",
       "argv": ["a", "--", "b"],
       "expect": { "ok": { "args": { "args": ["a", "--", "b"] } } }
+    },
+    {
+      "id": "dd-automatic-behaves-as-if-separated",
+      "doc": "With `double_dash=\"automatic\"`, the first value an argument takes stops flag interpretation for everything after it, so a wrapper can forward flags without the caller typing `--`.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-f --force\"\narg \"<files>...\" double_dash=\"automatic\"\n",
+      "argv": ["a", "--force"],
+      "expect": { "ok": { "args": { "files": ["a", "--force"] } } },
+      "reference": {
+        "diverges": "usage-lib binds `force` as a flag and gives the argument only `a`. The spec reference documents this mode as not yet enforced by the parser, so this vector describes the intent it will be held to."
+      }
     }
   ]
 }

--- a/corpus/06-double-dash.json
+++ b/corpus/06-double-dash.json
@@ -1,0 +1,76 @@
+{
+  "section": "double-dash",
+  "about": "A bare `--` stops flag interpretation: everything after it is a value, however much it looks like a flag. Arguments can also require, or preserve, the separator.",
+  "vectors": [
+    {
+      "id": "dd-protects-flaglike-value",
+      "doc": "After `--`, a flag-looking word binds as a value.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-f --force\"\narg \"<file>\"\n",
+      "argv": ["--", "--force"],
+      "expect": { "ok": { "args": { "file": "--force" } } }
+    },
+    {
+      "id": "dd-flags-before-still-parse",
+      "doc": "Flags before the separator parse normally.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-f --force\"\narg \"<file>\"\n",
+      "argv": ["--force", "--", "-x"],
+      "expect": {
+        "ok": { "flags": { "force": true }, "args": { "file": "-x" } }
+      }
+    },
+    {
+      "id": "dd-consumed-not-a-value",
+      "doc": "The separator itself is consumed rather than bound to an argument.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"<a>\"\narg \"[b]\"\n",
+      "argv": ["--", "one"],
+      "expect": { "ok": { "args": { "a": "one" } } }
+    },
+    {
+      "id": "dd-second-is-a-value",
+      "doc": "Only the first `--` separates; a later one is an ordinary value, since flag interpretation has already stopped.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"<rest>...\"\n",
+      "argv": ["--", "a", "--", "b"],
+      "expect": { "ok": { "args": { "rest": ["a", "--", "b"] } } },
+      "reference": {
+        "diverges": "usage-lib drops the second separator, yielding `[\"a\", \"b\"]`. A CLI forwarding a command line that contains its own `--` would have it silently removed."
+      }
+    },
+    {
+      "id": "dd-variadic-collects-everything-after",
+      "doc": "A variadic after the separator collects the whole tail verbatim, which is how a wrapper CLI forwards an inner command line untouched.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-f --force\"\narg \"<cmd>...\"\n",
+      "argv": ["--", "npm", "run", "test", "--force"],
+      "expect": {
+        "ok": { "args": { "cmd": ["npm", "run", "test", "--force"] } }
+      }
+    },
+    {
+      "id": "dd-required-satisfied",
+      "doc": "An argument declared `double_dash=\"required\"` accepts a value once the separator has been given.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"<-- cmd>\"\n",
+      "argv": ["--", "ls"],
+      "expect": { "ok": { "args": { "cmd": "ls" } } }
+    },
+    {
+      "id": "dd-required-rejected-without-separator",
+      "doc": "The same argument rejects a value given before the separator.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"<-- cmd>\"\n",
+      "argv": ["ls"],
+      "expect": { "error": "arg_requires_double_dash" }
+    },
+    {
+      "id": "dd-optional-accepts-either-side",
+      "doc": "The default, `double_dash=\"optional\"`, accepts a value on either side of the separator.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"<file>\"\n",
+      "argv": ["a.txt"],
+      "expect": { "ok": { "args": { "file": "a.txt" } } }
+    },
+    {
+      "id": "dd-preserve-keeps-separator-as-value",
+      "doc": "With `double_dash=\"preserve\"`, the separator is kept as a value instead of being consumed — needed by CLIs that pass along command lines containing their own separators.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"<args>...\" double_dash=\"preserve\"\n",
+      "argv": ["a", "--", "b"],
+      "expect": { "ok": { "args": { "args": ["a", "--", "b"] } } }
+    }
+  ]
+}

--- a/corpus/07-env-and-defaults.json
+++ b/corpus/07-env-and-defaults.json
@@ -1,0 +1,68 @@
+{
+  "section": "env-and-defaults",
+  "about": "Where a value comes from when the command line does not supply one. The command line wins, then the environment, then the declared default. None of these change which tokens bind where — they only fill what argv left empty.",
+  "vectors": [
+    {
+      "id": "env-fills-absent-flag",
+      "doc": "A flag backed by an env var takes its value when the flag is absent.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--jobs <n>\" env=\"EX_JOBS\"\n",
+      "argv": [],
+      "env": { "EX_JOBS": "4" },
+      "expect": { "ok": { "flags": { "jobs": "4" } } }
+    },
+    {
+      "id": "argv-beats-env",
+      "doc": "An explicit flag wins over the environment.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--jobs <n>\" env=\"EX_JOBS\"\n",
+      "argv": ["--jobs", "8"],
+      "env": { "EX_JOBS": "4" },
+      "expect": { "ok": { "flags": { "jobs": "8" } } }
+    },
+    {
+      "id": "env-unset-falls-to-default",
+      "doc": "With the env var unset, the declared default applies.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--jobs <n>\" env=\"EX_JOBS\" default=\"1\"\n",
+      "argv": [],
+      "expect": { "ok": { "flags": { "jobs": "1" } } }
+    },
+    {
+      "id": "env-beats-default",
+      "doc": "The environment wins over the default.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--jobs <n>\" env=\"EX_JOBS\" default=\"1\"\n",
+      "argv": [],
+      "env": { "EX_JOBS": "4" },
+      "expect": { "ok": { "flags": { "jobs": "4" } } }
+    },
+    {
+      "id": "env-empty-string-counts-as-set",
+      "doc": "An env var set to the empty string is set. Treating empty as unset would make `EX_JOBS=` mean something different from every other empty value in the grammar.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--jobs <n>\" env=\"EX_JOBS\" default=\"1\"\n",
+      "argv": [],
+      "env": { "EX_JOBS": "" },
+      "expect": { "ok": { "flags": { "jobs": "" } } }
+    },
+    {
+      "id": "default-fills-absent-arg",
+      "doc": "Defaults work the same way for positionals.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"[file]\" default=\"out.txt\"\n",
+      "argv": [],
+      "expect": { "ok": { "args": { "file": "out.txt" } } }
+    },
+    {
+      "id": "env-fills-absent-arg",
+      "doc": "An env-backed positional is filled from the environment when no word reaches it.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"[file]\" env=\"EX_FILE\"\n",
+      "argv": [],
+      "env": { "EX_FILE": "from-env.txt" },
+      "expect": { "ok": { "args": { "file": "from-env.txt" } } }
+    },
+    {
+      "id": "env-does-not-satisfy-required-arg-position",
+      "doc": "An env-backed required positional is satisfied by the environment, so the command line need not supply it.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"<file>\" env=\"EX_FILE\"\n",
+      "argv": [],
+      "env": { "EX_FILE": "x.txt" },
+      "expect": { "ok": { "args": { "file": "x.txt" } } }
+    }
+  ]
+}

--- a/corpus/08-choices-and-required.json
+++ b/corpus/08-choices-and-required.json
@@ -1,6 +1,6 @@
 {
   "section": "choices-and-required",
-  "about": "Constraints checked after binding: declared choices, required flags, and the relationships between flags. These do not affect which token binds where, only whether the result is accepted.",
+  "about": "Constraints checked after binding: declared choices, required flags, variadic bounds, and the relationships between flags. These do not affect which token binds where, only whether the result is accepted.",
   "vectors": [
     {
       "id": "choice-valid",
@@ -64,6 +64,20 @@
       "spec": "name \"ex\"\nbin \"ex\"\nflag \"--file <file>\" overrides=\"--stdin\"\nflag \"--stdin\" overrides=\"--file\"\n",
       "argv": ["--stdin", "--file", "a.txt"],
       "expect": { "ok": { "flags": { "file": "a.txt" } } }
+    },
+    {
+      "id": "flag-var-too-few",
+      "doc": "`var_min` is enforced for a repeatable flag, not only for positionals.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--include <pattern>\" var=#true var_min=2\n",
+      "argv": ["--include", "a"],
+      "expect": { "error": "var_too_few" }
+    },
+    {
+      "id": "flag-var-too-many",
+      "doc": "`var_max` is likewise enforced for a repeatable flag.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--include <pattern>\" var=#true var_max=1\n",
+      "argv": ["--include", "a", "--include", "b"],
+      "expect": { "error": "var_too_many" }
     }
   ]
 }

--- a/corpus/08-choices-and-required.json
+++ b/corpus/08-choices-and-required.json
@@ -1,0 +1,69 @@
+{
+  "section": "choices-and-required",
+  "about": "Constraints checked after binding: declared choices, required flags, and the relationships between flags. These do not affect which token binds where, only whether the result is accepted.",
+  "vectors": [
+    {
+      "id": "choice-valid",
+      "doc": "A value among the declared choices is accepted.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--shell <shell>\" {\n  choices \"bash\" \"zsh\" \"fish\"\n}\n",
+      "argv": ["--shell", "zsh"],
+      "expect": { "ok": { "flags": { "shell": "zsh" } } }
+    },
+    {
+      "id": "choice-invalid",
+      "doc": "A value outside the declared choices is rejected.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--shell <shell>\" {\n  choices \"bash\" \"zsh\" \"fish\"\n}\n",
+      "argv": ["--shell", "csh"],
+      "expect": { "error": "invalid_choice" }
+    },
+    {
+      "id": "choice-is-case-sensitive",
+      "doc": "Choices match exactly. Case-insensitive matching would have to be declared, not assumed.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--shell <shell>\" {\n  choices \"bash\" \"zsh\"\n}\n",
+      "argv": ["--shell", "ZSH"],
+      "expect": { "error": "invalid_choice" }
+    },
+    {
+      "id": "choice-on-arg",
+      "doc": "Positionals carry choices too.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"<shell>\" {\n  choices \"bash\" \"zsh\"\n}\n",
+      "argv": ["bash"],
+      "expect": { "ok": { "args": { "shell": "bash" } } }
+    },
+    {
+      "id": "required-flag-present",
+      "doc": "A required flag that is given parses normally.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--file <file>\" required=#true\n",
+      "argv": ["--file", "a.txt"],
+      "expect": { "ok": { "flags": { "file": "a.txt" } } }
+    },
+    {
+      "id": "required-flag-missing",
+      "doc": "A required flag that is absent is an error.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--file <file>\" required=#true\n",
+      "argv": [],
+      "expect": { "error": "missing_required_flag" }
+    },
+    {
+      "id": "required-unless-satisfied-by-other",
+      "doc": "`required_unless` is satisfied when the named alternative is present.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--file <file>\" required_unless=\"--stdin\"\nflag \"--stdin\"\n",
+      "argv": ["--stdin"],
+      "expect": { "ok": { "flags": { "stdin": true } } }
+    },
+    {
+      "id": "required-unless-unsatisfied",
+      "doc": "With neither flag present, the requirement stands.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--file <file>\" required_unless=\"--stdin\"\nflag \"--stdin\"\n",
+      "argv": [],
+      "expect": { "error": "missing_required_flag" }
+    },
+    {
+      "id": "overrides-last-wins",
+      "doc": "Two flags that override each other leave only the last one given.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--file <file>\" overrides=\"--stdin\"\nflag \"--stdin\" overrides=\"--file\"\n",
+      "argv": ["--stdin", "--file", "a.txt"],
+      "expect": { "ok": { "flags": { "file": "a.txt" } } }
+    }
+  ]
+}

--- a/corpus/README.md
+++ b/corpus/README.md
@@ -1,0 +1,97 @@
+# The argv conformance corpus
+
+Test vectors for [the argv grammar](https://usage.jdx.dev/spec/argv). Each one
+pairs a spec with a command line and the result parsing them must produce.
+
+These are plain JSON so that an implementation in any language can run them
+without reimplementing a test format. If you are writing a usage parser — for Go,
+for JavaScript, for Python, or as a second Rust implementation — this directory is
+the definition of correct, and passing it is what "compatible" means.
+
+## Format
+
+One file per area of the grammar. Each has a `section`, an `about` explaining what
+the group establishes, and `vectors`:
+
+```json
+{
+  "id": "long-value-attached",
+  "doc": "`--flag=value` binds the text after the first `=`.",
+  "spec": "name \"ex\"\nbin \"ex\"\nflag \"--jobs <n>\"\n",
+  "argv": ["--jobs=8"],
+  "expect": { "ok": { "flags": { "jobs": "8" } } }
+}
+```
+
+| field       | meaning                                                                                                         |
+| ----------- | --------------------------------------------------------------------------------------------------------------- |
+| `id`        | unique across the corpus, and stable — reports quote it, so renaming one breaks anybody tracking known failures |
+| `doc`       | what this vector pins down, in one sentence                                                                     |
+| `spec`      | a complete spec, as KDL                                                                                         |
+| `argv`      | the command line, excluding the program name                                                                    |
+| `env`       | the environment the parse sees; absent means empty                                                              |
+| `expect`    | `{"ok": {...}}` or `{"error": "code"}`                                                                          |
+| `reference` | whether usage-lib agrees; see below                                                                             |
+
+`expect.ok` holds `cmd` (the selected subcommand path, outermost first, omitted
+for the root), `flags`, and `args`. Both maps are keyed by the name the spec gives
+each flag or argument, never by the token that set it, so `-j`, `--jobs`, and an
+`env` var all land under `jobs`. Anything unset is omitted rather than null.
+
+Values are strings, lists of strings, booleans, or lists of booleans — a list of
+booleans being how a `count` flag records its occurrences. The grammar decides
+which token binds where, not what it means, so `"8"` stays a string and
+converting it is the caller's business.
+
+`expect.error` names a class of failure, never a message. Wording is a
+quality-of-implementation concern; the class is what the corpus pins, so that a
+strict parser and a lenient one differ visibly. The codes are listed in
+[the grammar](https://usage.jdx.dev/spec/argv#errors).
+
+Vectors that need an environment carry it. Nothing here reads the process
+environment, so no vector's result depends on the machine running it.
+
+## The `reference` field
+
+The grammar is the intent; usage-lib is one implementation of it. Where they
+differ, the vector says so:
+
+```json
+"reference": {
+  "diverges": "usage-lib parses successfully and binds nothing, so `ex --jobs` silently does what `ex` does."
+}
+```
+
+Absent means usage-lib agrees. `conformance/tests/reference.rs` checks every
+label in both directions: a vector claiming agreement must agree, and a vector
+claiming divergence must still diverge. So a divergence that gets fixed fails the
+suite with an instruction to delete the label, and the list cannot quietly rot
+into folklore.
+
+If you are implementing the grammar elsewhere, treat `expect` as the target and
+read the `diverges` notes as the compatibility risks you inherit if you copy
+usage-lib's behavior instead.
+
+## Running them
+
+In this repository:
+
+```sh
+cargo test -p usage-conformance
+```
+
+To see what usage-lib actually does with each vector, rather than only whether it
+matches:
+
+```sh
+cargo run -p usage-conformance --bin oracle          # human-readable
+cargo run -p usage-conformance --bin oracle -- --json
+cargo run -p usage-conformance --bin oracle short-   # ids containing "short-"
+```
+
+## Adding a vector
+
+Write the case with the result the grammar says it should have — not the result
+you observe. Then run the oracle: if usage-lib agrees, leave `reference` out; if
+it does not, record what it does instead. The note is the deliverable, since that
+is what a migration reads.

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -73,6 +73,7 @@ export default defineConfig({
         text: "Spec",
         link: "/spec/",
         items: [
+          { text: "argv grammar", link: "/spec/argv" },
           {
             text: "Reference",
             link: "/spec/reference/",

--- a/docs/spec/argv.md
+++ b/docs/spec/argv.md
@@ -1,0 +1,278 @@
+# The argv grammar
+
+A usage spec says what a CLI accepts. This page says how a command line is
+matched against it: which token binds to which flag or argument, when a word
+selects a subcommand, and what counts as an error.
+
+It exists because that behavior was previously defined only by
+[usage-lib](https://github.com/jdx/usage/tree/main/lib)'s implementation. A
+second implementation — in Rust, in Go, in a shell completion — had no way to
+know whether it agreed, and no way to prove it. The grammar here is normative,
+and the [conformance corpus](#the-conformance-corpus) makes it executable.
+
+::: warning Being written down changes nothing on its own
+
+usage-lib does not implement every rule below, and the differences are recorded
+per case in the corpus rather than smoothed over. See
+[Where the reference implementation differs](#where-the-reference-implementation-differs).
+
+:::
+
+## Terms
+
+A **token** is one element of `argv`, after the shell has finished with it. The
+grammar never re-splits a token on whitespace: quoting is the shell's job and is
+already done.
+
+A **command line** is the tokens after the program name. `mycli install -f x`
+has three.
+
+A token is **flag-like** when it begins with `-`, is longer than one character,
+and is not a negative number (`-` followed by a digit). So `--force`, `-f`, and
+`-abc` are flag-like; `-`, `-1`, and `-2.5` are not.
+
+## Reading a command line
+
+Tokens are read once, left to right. There is no backtracking, no reordering, and
+no second pass: what a token binds to is decided when it is read, from the
+command in scope at that moment. This is what makes the grammar implementable as
+a single loop, and it is also why a `--` or a subcommand word changes the meaning
+of everything after it but nothing before it.
+
+At each token, in order:
+
+1. If flag interpretation has stopped (a `--` was consumed), the token is a
+   value.
+2. If the token is exactly `--`, flag interpretation stops. The token is consumed
+   and is not itself a value.
+3. If the token is flag-like, it is matched as a flag ([long](#long-flags) or
+   [short](#short-flags)). No match is an error.
+4. Otherwise the token is a word: it selects a [subcommand](#subcommands) if one
+   matches, and is otherwise offered to the command's
+   [positional arguments](#positional-arguments).
+
+## Long flags
+
+A token beginning with `--` is a long flag. The name is the text up to the first
+`=`, or the whole token if there is none.
+
+**Names match exactly.** `--for` does not match `--force`. Abbreviation
+inference is deliberately absent: it makes adding a flag a breaking change for
+anyone who typed a prefix that was unique until the new flag arrived.
+
+For a flag that takes a value, the value comes from one of two forms:
+
+| form       | value                                                 |
+| ---------- | ----------------------------------------------------- |
+| `--jobs=8` | the text after the first `=`, so `--set=a=b` is `a=b` |
+| `--jobs 8` | the following token                                   |
+
+`--jobs=` binds the empty string. Present-but-empty is a distinct state from
+absent, and the attached form is the only way to express it.
+
+A detached value **must not be flag-like**. `--jobs --force` is a missing value,
+not a `jobs` of `"--force"`, because the overwhelmingly likely reading is that
+the value was forgotten. To pass a value that begins with a dash, attach it:
+`--jobs=--force`. The negative-number exception means `--offset -1` still works.
+
+A flag needing a value that ends the command line is an error.
+
+## Short flags
+
+A token beginning with a single `-` is one or more short flags. Letters are read
+left to right.
+
+A letter whose flag takes no value simply sets it, and reading continues with the
+next letter — so `-ab` sets both `a` and `b`.
+
+A letter whose flag takes a value ends the token. Its value is:
+
+| form   | value                                       |
+| ------ | ------------------------------------------- |
+| `-j8`  | the rest of the token                       |
+| `-j=8` | the rest of the token after one leading `=` |
+| `-j 8` | the following token                         |
+
+So `-aj8` sets `a` and gives `jobs` the value `8`. The attached form is what
+makes `-C/tmp` and `-Edev` work.
+
+One `=` immediately after the letter is a separator, matching the long form. Only
+one: `-j==8` is a value of `=8`.
+
+An unrecognized letter fails the whole token, including any letters before it. A
+partially applied bundle would be worse than a rejected one.
+
+`-` alone is not a flag. It is a value, conventionally meaning stdin.
+
+## Positional arguments
+
+A word that does not select a subcommand is offered to the command's arguments in
+declaration order. Each argument takes one word, except a variadic (`var=#true`,
+or a trailing `...`), which collects every word still available.
+
+- A word offered when no argument can hold it is an error, not silently dropped.
+- `var_min` and `var_max` are enforced.
+- An unfilled required argument is an error. An unfilled optional one is absent.
+
+Flags and words may interleave freely: `ex from -f to` fills the same arguments
+as `ex -f from to`. A flag between two words does not affect which argument each
+word fills.
+
+## Subcommands
+
+A word is matched against the subcommands of the command in scope, by name and by
+alias. A match descends: parsing continues against the subcommand, and the
+selected path records the canonical name even when an alias was typed.
+
+**A subcommand name wins over a positional value.** A CLI that declares both
+cannot receive a positional whose text equals one of its subcommand names — mise
+documents exactly this hazard for tasks that share a name with a command.
+
+**Only the descent position routes.** Once a word has been consumed by a
+positional argument, a later word matching a subcommand name is just a value.
+`ex other install` does not run `install`.
+
+### Flag scope
+
+A flag belongs to the command that declares it and may appear anywhere that
+command is in scope, which includes before one of its own subcommand words:
+`ex --quiet install` works for a root `--quiet`.
+
+A flag declared `global=#true` is additionally inherited by every command
+beneath it, so it may appear after any subcommand word at any depth.
+
+Scope only ever runs downward. A flag declared on a subcommand is not accepted
+before that subcommand is reached, `global` or not. A subcommand may redeclare a
+name it would otherwise inherit, and below that point its own declaration is the
+one that binds — mise does this deliberately, redeclaring several root globals on
+`run` with different shorts.
+
+## The `--` separator
+
+A bare `--` stops flag interpretation. Every token after it is a value, however
+flag-like it looks. The separator is consumed and is not itself a value.
+
+Only the first `--` is a separator. A later one is an ordinary value, since flag
+interpretation has already stopped — which is what lets a CLI forward a command
+line that itself contains `--`.
+
+An argument may say more about its relationship to the separator, with
+`double_dash`:
+
+| mode        | meaning                                                             |
+| ----------- | ------------------------------------------------------------------- |
+| `optional`  | the default: values may appear on either side                       |
+| `required`  | values are accepted only after a `--`; a word before it is an error |
+| `preserve`  | the separator is kept as a value instead of being consumed          |
+| `automatic` | once the argument takes a value, behave as if `--` had been given   |
+
+## Values not from argv
+
+When the command line does not supply a value, it is taken from the environment
+if the flag or argument declares `env`, and otherwise from its `default`. In
+short: **command line, then environment, then default.**
+
+An environment variable set to the empty string is set. Treating empty as unset
+would make `EX_JOBS=` mean something no other empty value in the grammar means.
+
+None of this changes which token binds where. It only fills what the command line
+left empty, which is why it is described last: an implementation can do all of it
+after the single pass is over.
+
+## Errors
+
+The grammar distinguishes these classes of failure. Wording is not specified —
+diagnostics are a quality-of-implementation concern and should be much better
+than these names — but the class is, so a strict parser and a lenient one can be
+told apart mechanically.
+
+| code                       | when                                                      |
+| -------------------------- | --------------------------------------------------------- |
+| `unknown_flag`             | a flag-like token matched no flag in scope                |
+| `missing_flag_value`       | a flag needing a value did not get one                    |
+| `missing_required_flag`    | a required flag never appeared                            |
+| `missing_required_arg`     | a required argument was never filled                      |
+| `unexpected_arg`           | more words than the command can hold                      |
+| `invalid_choice`           | a value outside the declared `choices`                    |
+| `arg_requires_double_dash` | a `double_dash="required"` argument got a value too early |
+| `var_too_few`              | fewer values than `var_min`                               |
+| `var_too_many`             | more values than `var_max`                                |
+
+Choices match exactly; case-insensitive matching would have to be declared rather
+than assumed.
+
+## The conformance corpus
+
+[`corpus/`](https://github.com/jdx/usage/tree/main/corpus) holds the executable
+form of this page: JSON vectors pairing a spec and a command line with the
+expected result.
+
+```json
+{
+  "id": "long-value-attached",
+  "doc": "`--flag=value` binds the text after the first `=`.",
+  "spec": "name \"ex\"\nbin \"ex\"\nflag \"--jobs <n>\"\n",
+  "argv": ["--jobs=8"],
+  "expect": { "ok": { "flags": { "jobs": "8" } } }
+}
+```
+
+Bindings are keyed by the name the spec gives each flag and argument, never by
+the token that set them, so `-j`, `--jobs`, and `EX_JOBS` all land under `jobs`.
+Values are recorded as strings: the grammar decides which token binds where, not
+what it means, so turning `"8"` into a number is the caller's business. Failures
+record only the error code.
+
+Vectors that set `env` carry their own environment. The harness never reads the
+process environment, so no vector's result can depend on the machine running it.
+
+Any implementation in any language can run these. In this repository,
+`cargo test -p usage-conformance` does.
+
+## Where the reference implementation differs
+
+Each vector records whether usage-lib agrees with it, as a measurement rather
+than an assumption, and
+[`conformance/tests/reference.rs`](https://github.com/jdx/usage/blob/main/conformance/tests/reference.rs)
+fails if a label is wrong in either direction. A recorded divergence that gets
+fixed shows up as a test failure telling you to delete the label, so the list
+cannot rot.
+
+Today usage-lib diverges on 15 of 83 vectors, from four causes:
+
+**Unrecognized flags fall through to positionals.** `ex --wat` binds `--wat` to
+an argument if one is free, and reports `unexpected_arg` if not. This accounts
+for most of the divergences, including the ones where the grammar and usage-lib
+agree a flag is out of scope but disagree about which error to report.
+
+**A flag missing its value is dropped silently.** `ex --jobs` parses
+successfully with nothing bound, so a forgotten value looks like a working
+command. `ex --jobs --force` likewise binds `force` and leaves `jobs` unset.
+
+**`=` is kept in attached short values.** `-j=8` binds `=8` rather than `8`.
+
+**Repeated `--` is eaten.** A second separator is dropped rather than kept as a
+value, so a forwarded command line containing `--` is altered in transit.
+
+Two smaller gaps: `--jobs=` binds nothing rather than the empty string, and a
+flag with a variadic argument (`--include <pattern>...`, which the
+[flag reference](/spec/reference/flag) documents) rejects its second value.
+
+Where the grammar and usage-lib disagree, the grammar is the intent and the
+divergence is a bug to fix or a decision to revisit — not a description of
+settled behavior. Each one is a small, self-contained change to
+`lib/src/parse.rs`, and the corpus is how a fix gets verified.
+
+## Not yet covered
+
+- **Restart tokens.** `restart_token` (mise's `:::`) makes one command line
+  describe several invocations, which the vector format cannot express: `expect`
+  holds a single result. Supporting it needs a multi-invocation shape, and until
+  then usage-lib's behavior — rewind, and let the last invocation's bindings
+  stand — is untested here.
+- **Mounts.** `mount` resolves a sub-spec by running a command during the parse.
+  That makes a vector depend on an external process, so it needs a stubbing
+  mechanism first.
+- **Completion parsing.** `parse_partial` deliberately accepts incomplete input
+  to drive completions. It is a different contract with different expectations,
+  and deserves its own corpus.

--- a/docs/spec/argv.md
+++ b/docs/spec/argv.md
@@ -238,7 +238,7 @@ fails if a label is wrong in either direction. A recorded divergence that gets
 fixed shows up as a test failure telling you to delete the label, so the list
 cannot rot.
 
-Today usage-lib diverges on 15 of 83 vectors, from four causes:
+Today usage-lib diverges on 16 of 86 vectors, from four causes:
 
 **Unrecognized flags fall through to positionals.** `ex --wat` binds `--wat` to
 an argument if one is free, and reports `unexpected_arg` if not. This accounts
@@ -254,9 +254,11 @@ command. `ex --jobs --force` likewise binds `force` and leaves `jobs` unset.
 **Repeated `--` is eaten.** A second separator is dropped rather than kept as a
 value, so a forwarded command line containing `--` is altered in transit.
 
-Two smaller gaps: `--jobs=` binds nothing rather than the empty string, and a
-flag with a variadic argument (`--include <pattern>...`, which the
-[flag reference](/spec/reference/flag) documents) rejects its second value.
+Three smaller gaps: `--jobs=` binds nothing rather than the empty string; a flag
+with a variadic argument (`--include <pattern>...`, which the
+[flag reference](/spec/reference/flag) documents) rejects its second value; and
+`double_dash="automatic"` is not enforced, which the
+[arg reference](/spec/reference/arg) already says outright.
 
 Where the grammar and usage-lib disagree, the grammar is the intent and the
 divergence is a bug to fix or a decision to revisit — not a description of


### PR DESCRIPTION
## Why

How `argv` binds against a spec is currently defined only by `lib/src/parse.rs`. That is fine while usage-lib is the only parser, and a problem as soon as it is not: a second implementation — a Rust parser, a Go port, a completion script doing its own matching — has no way to know whether it agrees, and no way to prove it.

This writes the grammar down and makes it executable, so "compatible with usage" becomes a thing you can run rather than a thing you assert.

## What's here

**`docs/spec/argv.md`** — the normative grammar, published at `/spec/argv`. Token classification, the single left-to-right pass, long and short flag forms (attached, `=`-attached, detached), positional filling, subcommand routing and flag scope, the `--` separator and the `double_dash` modes, where values come from when argv doesn't supply them, and the error classes.

**`corpus/`** — 83 JSON vectors covering the same ground. Deliberately language-neutral: a Go, JS, or Python implementation can run these without reimplementing a test format. `corpus/README.md` documents the format for exactly that audience.

**`conformance/`** — the harness (`publish = false`). `cargo test -p usage-conformance` checks the corpus is well formed and that every vector's reference label is accurate. `cargo run -p usage-conformance --bin oracle` reports what usage-lib actually does with each vector, which is how the labels got filled in.

## The interesting part: 15 of 83 vectors diverge

Every vector records whether usage-lib agrees, as a **measurement**, and the suite fails if a label is wrong *in either direction* — so a divergence that gets fixed reports itself as "delete this label" rather than rotting into folklore.

Four causes, all in `lib/src/parse.rs`:

1. **Unrecognized flags fall through to positionals.** `ex --wat` binds `--wat` to a free argument, or reports `unexpected_arg` if there isn't one. This accounts for most of the divergences, including the cases where the grammar and usage-lib agree a flag is out of scope but disagree on which error to report.
2. **A flag missing its value is dropped silently.** `ex --jobs` parses successfully with nothing bound, so a forgotten value looks like a working command. `ex --jobs --force` likewise binds `force` and leaves `jobs` unset.
3. **`=` is kept in attached short values.** `-j=8` binds `=8`.
4. **A repeated `--` is eaten**, so a forwarded command line containing its own separator is altered in transit.

Plus two smaller gaps: `--jobs=` binds nothing rather than the empty string, and a flag with a variadic argument (`--include <pattern>...`, which `/spec/reference/flag` documents) rejects its second value.

I've written the grammar as the intent and left usage-lib's behavior labeled, rather than describing current behavior as correct — several of these look like bugs worth fixing, and the corpus is how a fix would be verified. Happy to flip any of them the other way if you'd rather the grammar match the implementation; that's a one-line change per vector.

## Not covered yet

`restart_token` (mise's `:::`) needs a multi-invocation expectation shape, `mount` needs process stubbing, and `parse_partial` is a different contract that deserves its own corpus. All three are noted in the doc.

## Context

Groundwork for a compiled Rust parser (`usage-rs`), but it stands on its own: it makes usage-lib a *verified* reference implementation rather than an assumed one, and it is the artifact any other-language port would be built against.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New test/documentation and a non-published conformance crate; production parsing in `lib` is unchanged, with divergences recorded rather than fixed here.
> 
> **Overview**
> Introduces a **normative argv grammar** (`docs/spec/argv.md`, linked from the spec nav) so parsing behavior is defined outside `usage-lib` alone, and backs it with an **executable conformance corpus** (`corpus/*.json`) of spec/`argv`/expected-result vectors across flags, positionals, subcommands, globals, `--`, env/defaults, and post-bind constraints.
> 
> Adds workspace crate **`usage-conformance`**: loads corpus JSON with strict typing, runs each vector through **usage-lib** via a reference adapter (including error-class mapping from diagnostics), **`cargo test -p usage-conformance`** for corpus integrity and accurate per-vector `reference` labels (`agrees` vs `diverges`), and an **`oracle`** binary to report observed vs expected when authoring vectors. Vectors that intentionally disagree with current usage-lib behavior are **explicitly labeled** so CI catches fixed divergences; the doc summarizes known gaps (e.g. unknown flags falling through to positionals) without changing the parser in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38b4b7527f54f926c39f5d32e14e105da8a7b2ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added command-line argument conformance testing and reference reporting.
  * Added coverage for flags, positionals, subcommands, globals, `--`, environment variables, defaults, choices, and required values.
  * Added machine-readable and human-readable result formats.

* **Documentation**
  * Added the normative argv grammar specification and corpus usage guidance.
  * Added argv grammar documentation to the navigation.

* **Tests**
  * Added validation for corpus integrity, specifications, unique identifiers, and reference results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->