### PR TITLE
feat(argv): add a zero-allocation argv parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1976,6 +1976,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "usage-argv"
+version = "0.0.0"
+
+[[package]]
 name = "usage-cli"
 version = "5.1.0"
 dependencies = [
@@ -2012,6 +2016,7 @@ version = "0.0.0"
 dependencies = [
  "serde",
  "serde_json",
+ "usage-argv",
  "usage-lib",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1977,7 +1977,7 @@ checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "usage-argv"
-version = "0.0.0"
+version = "5.1.0"
 
 [[package]]
 name = "usage-cli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "argv",
     "clap_usage",
     "cli",
     "conformance",
@@ -17,6 +18,7 @@ license = "MIT"
 [workspace.dependencies]
 clap_usage = { path = "./clap_usage", version = "5.0.0" }
 usage-cli = { path = "./cli" }
+usage-argv = { path = "./argv" }
 usage-lib = { path = "./lib", version = "5.1.0", features = ["clap"] }
 
 [workspace.metadata.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ license = "MIT"
 [workspace.dependencies]
 clap_usage = { path = "./clap_usage", version = "5.0.0" }
 usage-cli = { path = "./cli" }
-usage-argv = { path = "./argv" }
+usage-argv = { path = "./argv", version = "5.1.0" }
 usage-lib = { path = "./lib", version = "5.1.0", features = ["clap"] }
 
 [workspace.metadata.release]

--- a/argv/Cargo.toml
+++ b/argv/Cargo.toml
@@ -1,11 +1,7 @@
 [package]
 name = "usage-argv"
 description = "Zero-allocation argv parser for usage specs"
-# Not published yet. The name is reserved on crates.io at 0.0.0; publishing
-# resumes from here once there is a parser worth depending on. Deliberately
-# outside the shared-version release cycle, like clap_usage.
-publish = false
-version = "0.0.0"
+version = "5.1.0"
 edition = "2021"
 rust-version = "1.80.0"
 homepage = { workspace = true }
@@ -17,3 +13,7 @@ license = { workspace = true }
 # No dependencies, and none are wanted. This crate is what runs on every
 # invocation of every CLI built on it.
 [dependencies]
+
+[package.metadata.release]
+shared-version = true
+release = true

--- a/argv/Cargo.toml
+++ b/argv/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "usage-argv"
+description = "Zero-allocation argv parser for usage specs"
+# Not published yet. The name is reserved on crates.io at 0.0.0; publishing
+# resumes from here once there is a parser worth depending on. Deliberately
+# outside the shared-version release cycle, like clap_usage.
+publish = false
+version = "0.0.0"
+edition = "2021"
+rust-version = "1.80.0"
+homepage = { workspace = true }
+documentation = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+
+# No dependencies, and none are wanted. This crate is what runs on every
+# invocation of every CLI built on it.
+[dependencies]

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -222,8 +222,9 @@ pub enum Event<'t, 'v> {
 /// here would allocate on the way to reporting that nothing was allocated.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Error<'t, 'v> {
-    /// A flag-like token matched no flag in scope. For a short bundle this is
-    /// the offending byte, and the whole token is rejected.
+    /// A flag-like token matched no flag in scope. `token` is the whole token as
+    /// typed, so a bundle containing an unrecognized letter reports `-fz` rather
+    /// than the letter alone — which is also the unit in which it is rejected.
     UnknownFlag { token: &'v [u8] },
     /// A flag that needs a value did not get one, either because the command
     /// line ended or because the next token was flag-like.
@@ -261,6 +262,9 @@ pub struct Parser<'t, 'v> {
     depth: usize,
     /// Bytes left in a short-flag bundle, if one is partly read.
     bundle: &'v [u8],
+    /// The whole token the current bundle came from, so an error raised part way
+    /// through it can still name what the user typed.
+    bundle_token: &'v [u8],
     /// A variadic flag that is still collecting values.
     collecting: Option<&'t Flag<'t>>,
     /// Which of `cmd.args` is next to fill.
@@ -286,6 +290,7 @@ impl<'t, 'v> Parser<'t, 'v> {
             ancestors: [None; MAX_DEPTH],
             depth: 0,
             bundle: &[],
+            bundle_token: &[],
             collecting: None,
             arg_pos: 0,
             arg_filled: false,
@@ -308,7 +313,13 @@ impl<'t, 'v> Parser<'t, 'v> {
     ///
     /// Returns `None` when `argv` is exhausted. An `Err` is terminal: the parse
     /// stops there, since continuing past a token that could not be understood
-    /// would only produce bindings derived from a guess.
+    /// would only produce bindings derived from a guess. Events already yielded
+    /// before an error are therefore not a partial result to be used — a caller
+    /// that assigned them into fields should discard the whole attempt.
+    ///
+    /// One case is stronger than that, because the grammar demands it: a short
+    /// bundle containing an unrecognized letter yields the error *instead of*, not
+    /// after, the letters that did match.
     #[allow(clippy::should_implement_trait)] // not an Iterator: items borrow from self's tables
     pub fn next_event(&mut self) -> Option<Result<Event<'t, 'v>, Error<'t, 'v>>> {
         if self.done {
@@ -376,7 +387,15 @@ impl<'t, 'v> Parser<'t, 'v> {
             if token.starts_with(b"--") {
                 return Some(self.long_flag(token));
             }
+            // Check the whole bundle before emitting anything from it. Events go
+            // out one at a time, so discovering an unknown letter half way
+            // through would mean the earlier letters had already been applied —
+            // and the grammar rejects the entire token, not the tail of it.
+            if let Err(e) = self.check_bundle(token) {
+                return Some(Err(e));
+            }
             self.bundle = &token[1..];
+            self.bundle_token = token;
             return Some(self.short_flag());
         }
 
@@ -420,16 +439,34 @@ impl<'t, 'v> Parser<'t, 'v> {
         Err(Error::UnknownFlag { token })
     }
 
+    /// Walk a short-flag token without binding anything, to find out whether all
+    /// of it is recognized.
+    ///
+    /// Scanning stops at the first letter whose flag takes a value, because
+    /// everything after it is that value rather than more letters.
+    fn check_bundle(&self, token: &'v [u8]) -> Result<(), Error<'t, 'v>> {
+        let mut rest = &token[1..];
+        while let Some((&byte, tail)) = rest.split_first() {
+            match self.find_short(byte) {
+                None => return Err(Error::UnknownFlag { token }),
+                Some(flag) if flag.takes_value => return Ok(()),
+                Some(_) => rest = tail,
+            }
+        }
+        Ok(())
+    }
+
     fn short_flag(&mut self) -> Result<Event<'t, 'v>, Error<'t, 'v>> {
         let byte = self.bundle[0];
         let rest = &self.bundle[1..];
 
         let Some(flag) = self.find_short(byte) else {
-            // Reject the whole token rather than applying the letters that did
-            // match: a partly-applied bundle is worse than a rejected one.
+            // check_bundle already rejected any token containing an unrecognized
+            // letter, so this is unreachable — but a parser should report rather
+            // than panic if that ever stops being true.
             self.bundle = &[];
             return Err(Error::UnknownFlag {
-                token: &self.bundle[..0],
+                token: self.bundle_token,
             });
         };
 
@@ -992,6 +1029,33 @@ mod tests {
         };
         let a = argv(["a", "b"]);
         assert_eq!(parse(&ONE, &a), Err(Error::UnexpectedArg { token: b"b" }));
+    }
+
+    #[test]
+    fn unknown_letter_rejects_the_whole_bundle() {
+        // `-f` is real and `-z` is not. The first event must be the error: if the
+        // flag event came out first, a caller would have applied `-f` from a
+        // command line that was rejected.
+        let a = argv(["-fz"]);
+        let mut parser = Parser::new(&ROOT, &a);
+        assert_eq!(
+            parser.next_event(),
+            Some(Err(Error::UnknownFlag { token: b"-fz" })),
+            "an unknown letter must reject the token before any of it is applied"
+        );
+        assert!(parser.next_event().is_none());
+    }
+
+    #[test]
+    fn unknown_short_error_names_the_whole_token() {
+        for (tokens, want) in [(["-z"], &b"-z"[..]), (["-fz"], &b"-fz"[..])] {
+            let a = argv(tokens);
+            assert_eq!(
+                parse(&ROOT, &a),
+                Err(Error::UnknownFlag { token: want }),
+                "{tokens:?}"
+            );
+        }
     }
 
     #[test]

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -192,6 +192,10 @@ pub enum DoubleDash {
     Required,
     /// A `--` is kept as a value rather than consumed as a separator.
     Preserve,
+    /// Once the argument takes a value, behave as if a `--` had been given, so
+    /// the rest of the command line is values. A wrapper can then forward flags
+    /// without its caller typing the separator.
+    Automatic,
 }
 
 /// Something the parser bound.
@@ -493,6 +497,11 @@ impl<'t, 'v> Parser<'t, 'v> {
         }
 
         self.arg_filled = true;
+        // An `automatic` argument stops flag interpretation from here on, as
+        // though the caller had typed the separator themselves.
+        if arg.double_dash == DoubleDash::Automatic {
+            self.double_dash = true;
+        }
         // A variadic keeps taking values, so the cursor stays put.
         if !arg.var {
             self.arg_pos += 1;
@@ -934,6 +943,44 @@ mod tests {
             })
             .collect();
         assert_eq!(values, vec![&b"a"[..], &b"--"[..], &b"b"[..]]);
+    }
+
+    #[test]
+    fn double_dash_automatic_stops_flag_interpretation() {
+        static FILES: Arg = Arg {
+            key: 22,
+            name: "files",
+            double_dash: DoubleDash::Automatic,
+            ..Arg::VAR
+        };
+        static AUTO: Command = Command {
+            name: "ex",
+            flags: &[&FORCE],
+            args: &[&FILES],
+            ..Command::EMPTY
+        };
+
+        // The flag before the first value is still a flag; the one after it is a
+        // value.
+        let a = argv(["-f", "one", "--force"]);
+        assert_eq!(
+            parse(&AUTO, &a).unwrap(),
+            vec![
+                Event::Flag {
+                    flag: &FORCE,
+                    value: None,
+                    negated: false
+                },
+                Event::Arg {
+                    arg: &FILES,
+                    value: b"one"
+                },
+                Event::Arg {
+                    arg: &FILES,
+                    value: b"--force"
+                },
+            ]
+        );
     }
 
     #[test]

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -1,0 +1,969 @@
+//! A zero-allocation argv parser for [usage](https://usage.jdx.dev) specs.
+//!
+//! This crate implements the binding rules of [the argv grammar]: which token
+//! becomes which flag or argument, when a word selects a subcommand, and what
+//! is an error. It does so without building a command tree, without allocating,
+//! and in one pass.
+//!
+//! It is the runtime half of a compiled parser. The tables it reads are meant to
+//! be emitted by a derive macro as `static` data, so that starting a parse costs
+//! nothing at all: there is no construction step to pay for, only the walk over
+//! `argv`.
+//!
+//! # Shape of the API
+//!
+//! Parsing yields [`Event`]s rather than a map. A map would have to allocate,
+//! and would then have to be read back out again — whereas generated code can
+//! assign an event straight into a struct field. This is the same reason serde
+//! deserializes into your type instead of into a `Value`.
+//!
+//! ```
+//! use usage_argv::{Arg, Command, Event, Flag, Parser};
+//!
+//! static FORCE: Flag = Flag { key: 0, longs: &["force"], shorts: b"f", ..Flag::BOOL };
+//! static FILE: Arg = Arg { key: 1, ..Arg::REQUIRED };
+//! static ROOT: Command = Command {
+//!     name: "ex",
+//!     flags: &[&FORCE],
+//!     args: &[&FILE],
+//!     ..Command::EMPTY
+//! };
+//!
+//! let argv = ["--force", "a.txt"].map(std::ffi::OsStr::new);
+//! let mut parser = Parser::new(&ROOT, &argv);
+//!
+//! let mut force = false;
+//! let mut file = None;
+//! while let Some(event) = parser.next_event() {
+//!     match event.expect("valid command line") {
+//!         Event::Flag { flag, .. } if flag.key == 0 => force = true,
+//!         Event::Arg { value, .. } => file = Some(value),
+//!         _ => {}
+//!     }
+//! }
+//! assert!(force);
+//! assert_eq!(file, Some(&b"a.txt"[..]));
+//! ```
+//!
+//! # Values are bytes
+//!
+//! An [`Event`] carries `&[u8]`, borrowed from `argv`. Converting to `&str` is
+//! the caller's step ([`as_str`]), and it is the right place for the only
+//! failure a value can have: a command line that is not valid UTF-8 still
+//! *parses* — flags match, subcommands route — and only the values that are
+//! actually looked at can fail to convert.
+//!
+//! Slicing an `OsStr` into `&str` pieces safely is not possible without
+//! allocating or `unsafe`, and this crate forbids `unsafe`. Bytes are what is
+//! left, and they turn out to be the honest interface anyway.
+//!
+//! # What this crate does not do
+//!
+//! Only binding. Required-ness, `choices`, `env` fallback, defaults, `var_min`
+//! and `var_max` are all decided *after* the last token is read, and they need to
+//! know a value's type, so they belong to the layer that owns the target struct.
+//! Keeping them out is what makes this loop small.
+//!
+//! [the argv grammar]: https://usage.jdx.dev/spec/argv
+
+#![forbid(unsafe_code)]
+
+use std::ffi::OsStr;
+
+/// How deep a command tree this parser will descend.
+///
+/// The ancestor chain is kept in a fixed-size array so that a parse allocates
+/// nothing; this is that array's size. mise, the largest usage CLI, is four
+/// levels deep.
+pub const MAX_DEPTH: usize = 16;
+
+/// A command: its flags, its positional arguments, and its subcommands.
+///
+/// Every field is a borrowed slice so that a derive can emit the whole tree as
+/// `static` data. Use `..Command::EMPTY` to fill in the parts you do not need.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Command<'a> {
+    /// The canonical name, used to select this command.
+    pub name: &'a str,
+    /// Alternative names that also select it.
+    pub aliases: &'a [&'a str],
+    pub flags: &'a [&'a Flag<'a>],
+    /// Positional arguments, in the order they are filled.
+    pub args: &'a [&'a Arg<'a>],
+    pub subcommands: &'a [&'a Command<'a>],
+    /// Caller-assigned identifier, echoed back in [`Event::Command`].
+    pub key: u32,
+}
+
+impl Command<'_> {
+    /// A command with nothing declared, for use with struct update syntax.
+    pub const EMPTY: Command<'static> = Command {
+        name: "",
+        aliases: &[],
+        flags: &[],
+        args: &[],
+        subcommands: &[],
+        key: 0,
+    };
+}
+
+/// A flag, addressed by any of its long or short forms.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Flag<'a> {
+    /// Caller-assigned identifier, echoed back in [`Event::Flag`]. This is how
+    /// generated code knows which field to assign without any string comparison.
+    pub key: u32,
+    /// Unused by binding, kept so a table entry can carry its own name for
+    /// diagnostics.
+    pub name: &'a str,
+    /// Long forms, written without the leading `--`.
+    pub longs: &'a [&'a str],
+    /// Short forms, as single bytes.
+    pub shorts: &'a [u8],
+    /// A long form that sets the flag to false, written without the `--`.
+    pub negate: Option<&'a str>,
+    /// Whether the flag takes a value.
+    pub takes_value: bool,
+    /// Whether the flag's value is variadic: one occurrence keeps taking values
+    /// until a flag-like token or the end of the command line.
+    pub var: bool,
+    /// Whether the flag is recognized by every command beneath the one that
+    /// declares it.
+    pub global: bool,
+}
+
+impl Flag<'_> {
+    /// A value-less flag, for use with struct update syntax.
+    pub const BOOL: Flag<'static> = Flag {
+        key: 0,
+        name: "",
+        longs: &[],
+        shorts: &[],
+        negate: None,
+        takes_value: false,
+        var: false,
+        global: false,
+    };
+
+    /// A flag that takes a value, for use with struct update syntax.
+    pub const VALUE: Flag<'static> = Flag {
+        takes_value: true,
+        ..Flag::BOOL
+    };
+}
+
+/// A positional argument.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Arg<'a> {
+    /// Caller-assigned identifier, echoed back in [`Event::Arg`].
+    pub key: u32,
+    /// Whether this argument keeps taking values once it has one.
+    pub var: bool,
+    /// This argument's relationship to the `--` separator.
+    pub double_dash: DoubleDash,
+    /// Unused by binding, kept so a table entry can carry its own name for
+    /// diagnostics.
+    pub name: &'a str,
+}
+
+impl Arg<'_> {
+    /// A single-value argument, for use with struct update syntax.
+    pub const REQUIRED: Arg<'static> = Arg {
+        key: 0,
+        var: false,
+        double_dash: DoubleDash::Optional,
+        name: "",
+    };
+
+    /// A variadic argument, for use with struct update syntax.
+    pub const VAR: Arg<'static> = Arg {
+        var: true,
+        ..Arg::REQUIRED
+    };
+}
+
+/// How an argument relates to the `--` separator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DoubleDash {
+    /// Values may appear on either side of a `--`.
+    #[default]
+    Optional,
+    /// Values are accepted only after a `--`.
+    Required,
+    /// A `--` is kept as a value rather than consumed as a separator.
+    Preserve,
+}
+
+/// Something the parser bound.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Event<'t, 'v> {
+    /// A subcommand was selected; parsing continues inside it.
+    Command(&'t Command<'t>),
+    /// A flag was given. `value` is `Some` for a flag that takes one, and
+    /// `negated` is true when the flag was set through its `negate` form.
+    Flag {
+        flag: &'t Flag<'t>,
+        value: Option<&'v [u8]>,
+        negated: bool,
+    },
+    /// A word was bound to a positional argument. A variadic argument produces
+    /// one event per value.
+    Arg { arg: &'t Arg<'t>, value: &'v [u8] },
+}
+
+/// A binding failure.
+///
+/// Carries the offending token so a caller can render a good message, but no
+/// message of its own: rendering belongs to a cold path, and building a string
+/// here would allocate on the way to reporting that nothing was allocated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Error<'t, 'v> {
+    /// A flag-like token matched no flag in scope. For a short bundle this is
+    /// the offending byte, and the whole token is rejected.
+    UnknownFlag { token: &'v [u8] },
+    /// A flag that needs a value did not get one, either because the command
+    /// line ended or because the next token was flag-like.
+    MissingFlagValue { flag: &'t Flag<'t> },
+    /// A word arrived with no argument left to hold it.
+    UnexpectedArg { token: &'v [u8] },
+    /// A word was offered to a `double_dash = "required"` argument before any
+    /// `--` had been seen.
+    ArgRequiresDoubleDash { arg: &'t Arg<'t> },
+    /// The command tree is deeper than [`MAX_DEPTH`].
+    TooDeep,
+}
+
+/// Interpret a value as UTF-8.
+///
+/// The parser hands back bytes borrowed from `argv`; this is the conversion most
+/// callers want, and the point at which a non-UTF-8 command line is rejected —
+/// but only for the values actually inspected.
+pub fn as_str(value: &[u8]) -> Result<&str, std::str::Utf8Error> {
+    std::str::from_utf8(value)
+}
+
+/// A single-pass parse over `argv`.
+///
+/// Created with [`Parser::new`] and driven with [`Parser::next_event`].
+pub struct Parser<'t, 'v> {
+    argv: &'v [&'v OsStr],
+    /// Index of the next token to read.
+    pos: usize,
+    /// The command currently in scope.
+    cmd: &'t Command<'t>,
+    /// The chain above `cmd`, used to find inherited global flags. Fixed size so
+    /// that nothing is allocated.
+    ancestors: [Option<&'t Command<'t>>; MAX_DEPTH],
+    depth: usize,
+    /// Bytes left in a short-flag bundle, if one is partly read.
+    bundle: &'v [u8],
+    /// A variadic flag that is still collecting values.
+    collecting: Option<&'t Flag<'t>>,
+    /// Which of `cmd.args` is next to fill.
+    arg_pos: usize,
+    /// Whether any word has been bound to a positional of `cmd`. Once one has,
+    /// no further word can select a subcommand.
+    arg_filled: bool,
+    /// Whether a `--` has been consumed as a separator.
+    double_dash: bool,
+    /// Set once a fatal error has been reported, so iteration stops.
+    done: bool,
+}
+
+impl<'t, 'v> Parser<'t, 'v> {
+    /// Begin parsing `argv` against `root`.
+    ///
+    /// `argv` excludes the program name.
+    pub fn new(root: &'t Command<'t>, argv: &'v [&'v OsStr]) -> Self {
+        Parser {
+            argv,
+            pos: 0,
+            cmd: root,
+            ancestors: [None; MAX_DEPTH],
+            depth: 0,
+            bundle: &[],
+            collecting: None,
+            arg_pos: 0,
+            arg_filled: false,
+            double_dash: false,
+            done: false,
+        }
+    }
+
+    /// The command in scope: the root, or the deepest subcommand selected so far.
+    pub fn command(&self) -> &'t Command<'t> {
+        self.cmd
+    }
+
+    /// Whether a `--` has been consumed as a separator.
+    pub fn double_dash_seen(&self) -> bool {
+        self.double_dash
+    }
+
+    /// Read the next event.
+    ///
+    /// Returns `None` when `argv` is exhausted. An `Err` is terminal: the parse
+    /// stops there, since continuing past a token that could not be understood
+    /// would only produce bindings derived from a guess.
+    #[allow(clippy::should_implement_trait)] // not an Iterator: items borrow from self's tables
+    pub fn next_event(&mut self) -> Option<Result<Event<'t, 'v>, Error<'t, 'v>>> {
+        if self.done {
+            return None;
+        }
+        let event = self.step();
+        if let Some(Err(_)) = event {
+            self.done = true;
+        }
+        event
+    }
+
+    fn step(&mut self) -> Option<Result<Event<'t, 'v>, Error<'t, 'v>>> {
+        // A partly-read short bundle takes priority: its remaining bytes are
+        // still part of the token being processed.
+        if !self.bundle.is_empty() {
+            return Some(self.short_flag());
+        }
+
+        // A variadic flag keeps claiming tokens until one of them could be
+        // something else.
+        if let Some(flag) = self.collecting {
+            match self.argv.get(self.pos) {
+                Some(next) if !is_flag_like(bytes(next)) && bytes(next) != b"--" => {
+                    self.pos += 1;
+                    return Some(Ok(Event::Flag {
+                        flag,
+                        value: Some(bytes(next)),
+                        negated: false,
+                    }));
+                }
+                _ => self.collecting = None,
+            }
+        }
+
+        let token = bytes(self.argv.get(self.pos)?);
+        self.pos += 1;
+
+        if self.double_dash {
+            return Some(self.word(token));
+        }
+
+        if token == b"--" {
+            // `preserve` wants the separator itself as a value, so ask the
+            // argument that would receive it before treating it as syntax.
+            if self
+                .next_arg()
+                .is_some_and(|a| a.double_dash == DoubleDash::Preserve)
+            {
+                return Some(self.word(token));
+            }
+            self.double_dash = true;
+            // An explicit separator unlocks any argument that required one, even
+            // if earlier arguments are still unfilled.
+            if let Some(idx) = self.cmd.args[self.arg_pos..]
+                .iter()
+                .position(|a| a.double_dash == DoubleDash::Required)
+            {
+                self.arg_pos += idx;
+            }
+            return self.step();
+        }
+
+        if is_flag_like(token) {
+            if token.starts_with(b"--") {
+                return Some(self.long_flag(token));
+            }
+            self.bundle = &token[1..];
+            return Some(self.short_flag());
+        }
+
+        Some(self.word(token))
+    }
+
+    fn long_flag(&mut self, token: &'v [u8]) -> Result<Event<'t, 'v>, Error<'t, 'v>> {
+        let body = &token[2..];
+        let (name, attached) = match body.iter().position(|&b| b == b'=') {
+            Some(i) => (&body[..i], Some(&body[i + 1..])),
+            None => (body, None),
+        };
+
+        if let Some(flag) = self.find_long(name) {
+            let value = if flag.takes_value {
+                Some(match attached {
+                    Some(v) => v,
+                    None => self.take_detached_value(flag)?,
+                })
+            } else {
+                None
+            };
+            if flag.var {
+                self.collecting = Some(flag);
+            }
+            return Ok(Event::Flag {
+                flag,
+                value,
+                negated: false,
+            });
+        }
+
+        if let Some(flag) = self.find_negation(name) {
+            return Ok(Event::Flag {
+                flag,
+                value: None,
+                negated: true,
+            });
+        }
+
+        Err(Error::UnknownFlag { token })
+    }
+
+    fn short_flag(&mut self) -> Result<Event<'t, 'v>, Error<'t, 'v>> {
+        let byte = self.bundle[0];
+        let rest = &self.bundle[1..];
+
+        let Some(flag) = self.find_short(byte) else {
+            // Reject the whole token rather than applying the letters that did
+            // match: a partly-applied bundle is worse than a rejected one.
+            self.bundle = &[];
+            return Err(Error::UnknownFlag {
+                token: &self.bundle[..0],
+            });
+        };
+
+        if !flag.takes_value {
+            self.bundle = rest;
+            return Ok(Event::Flag {
+                flag,
+                value: None,
+                negated: false,
+            });
+        }
+
+        // A value-taking short ends the token: everything after it is the value,
+        // less one separating `=`.
+        self.bundle = &[];
+        let value = if rest.is_empty() {
+            self.take_detached_value(flag)?
+        } else if rest[0] == b'=' {
+            &rest[1..]
+        } else {
+            rest
+        };
+        if flag.var {
+            self.collecting = Some(flag);
+        }
+        Ok(Event::Flag {
+            flag,
+            value: Some(value),
+            negated: false,
+        })
+    }
+
+    /// Take the following token as a flag's value.
+    ///
+    /// Refuses a flag-like token: `--jobs --force` is far more likely a forgotten
+    /// value than a deliberate one, and the attached form is available for the
+    /// deliberate case.
+    fn take_detached_value(&mut self, flag: &'t Flag<'t>) -> Result<&'v [u8], Error<'t, 'v>> {
+        match self.argv.get(self.pos) {
+            Some(next) if !is_flag_like(bytes(next)) => {
+                self.pos += 1;
+                Ok(bytes(next))
+            }
+            _ => Err(Error::MissingFlagValue { flag }),
+        }
+    }
+
+    fn word(&mut self, token: &'v [u8]) -> Result<Event<'t, 'v>, Error<'t, 'v>> {
+        // Subcommands are only matched where descent is still possible: once a
+        // positional of this command has taken a word, a later word that happens
+        // to equal a subcommand name is just a value.
+        if !self.arg_filled && !self.double_dash {
+            if let Some(sub) = self.find_subcommand(token) {
+                self.descend(sub)?;
+                return Ok(Event::Command(sub));
+            }
+        }
+
+        let Some(arg) = self.next_arg() else {
+            return Err(Error::UnexpectedArg { token });
+        };
+
+        if arg.double_dash == DoubleDash::Required && !self.double_dash {
+            return Err(Error::ArgRequiresDoubleDash { arg });
+        }
+
+        self.arg_filled = true;
+        // A variadic keeps taking values, so the cursor stays put.
+        if !arg.var {
+            self.arg_pos += 1;
+        }
+        Ok(Event::Arg { arg, value: token })
+    }
+
+    fn descend(&mut self, sub: &'t Command<'t>) -> Result<(), Error<'t, 'v>> {
+        if self.depth >= MAX_DEPTH {
+            return Err(Error::TooDeep);
+        }
+        self.ancestors[self.depth] = Some(self.cmd);
+        self.depth += 1;
+        self.cmd = sub;
+        self.arg_pos = 0;
+        self.arg_filled = false;
+        Ok(())
+    }
+
+    fn next_arg(&self) -> Option<&'t Arg<'t>> {
+        self.cmd.args.get(self.arg_pos).copied()
+    }
+
+    /// Flags in scope: this command's own, then any ancestor's globals.
+    ///
+    /// Own flags come first so that a subcommand redeclaring an inherited name
+    /// shadows it, which is what mise relies on when it redeclares root globals
+    /// on `run` with different shorts.
+    fn in_scope(&self) -> impl Iterator<Item = &'t Flag<'t>> + '_ {
+        let own = self.cmd.flags.iter().copied();
+        let inherited = self.ancestors[..self.depth]
+            .iter()
+            .rev()
+            .filter_map(|c| *c)
+            .flat_map(|c| c.flags.iter().copied())
+            .filter(|f| f.global);
+        own.chain(inherited)
+    }
+
+    fn find_long(&self, name: &[u8]) -> Option<&'t Flag<'t>> {
+        self.in_scope()
+            .find(|f| f.longs.iter().any(|l| l.as_bytes() == name))
+    }
+
+    fn find_negation(&self, name: &[u8]) -> Option<&'t Flag<'t>> {
+        self.in_scope()
+            .find(|f| f.negate.is_some_and(|n| n.as_bytes() == name))
+    }
+
+    fn find_short(&self, byte: u8) -> Option<&'t Flag<'t>> {
+        self.in_scope().find(|f| f.shorts.contains(&byte))
+    }
+
+    fn find_subcommand(&self, name: &[u8]) -> Option<&'t Command<'t>> {
+        self.cmd
+            .subcommands
+            .iter()
+            .copied()
+            .find(|c| c.name.as_bytes() == name || c.aliases.iter().any(|a| a.as_bytes() == name))
+    }
+}
+
+/// View a token as bytes.
+///
+/// `as_encoded_bytes` is a plain accessor with no conversion and no allocation.
+/// It is only the reverse direction that needs `unsafe`, which is why values
+/// come back as bytes.
+fn bytes<'v>(s: &'v &'v OsStr) -> &'v [u8] {
+    s.as_encoded_bytes()
+}
+
+/// Whether a token should be read as a flag.
+///
+/// `-` alone is a value, conventionally stdin. A negative number is a value too,
+/// without which no CLI could accept `--offset -1`.
+fn is_flag_like(token: &[u8]) -> bool {
+    match token {
+        [b'-', rest @ ..] if !rest.is_empty() => !rest[0].is_ascii_digit(),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    static FORCE: Flag = Flag {
+        key: 1,
+        longs: &["force"],
+        shorts: b"f",
+        ..Flag::BOOL
+    };
+    static JOBS: Flag = Flag {
+        key: 2,
+        longs: &["jobs"],
+        shorts: b"j",
+        ..Flag::VALUE
+    };
+    static COLOR: Flag = Flag {
+        key: 3,
+        longs: &["color"],
+        negate: Some("no-color"),
+        ..Flag::BOOL
+    };
+    static VERBOSE: Flag = Flag {
+        key: 4,
+        longs: &["verbose"],
+        shorts: b"v",
+        global: true,
+        ..Flag::BOOL
+    };
+    static FILE: Arg = Arg {
+        key: 10,
+        name: "file",
+        ..Arg::REQUIRED
+    };
+    static REST: Arg = Arg {
+        key: 11,
+        name: "rest",
+        ..Arg::VAR
+    };
+    static INSTALL: Command = Command {
+        name: "install",
+        aliases: &["i"],
+        flags: &[&FORCE],
+        key: 100,
+        ..Command::EMPTY
+    };
+    static ROOT: Command = Command {
+        name: "ex",
+        flags: &[&FORCE, &JOBS, &COLOR, &VERBOSE],
+        args: &[&FILE, &REST],
+        subcommands: &[&INSTALL],
+        ..Command::EMPTY
+    };
+
+    /// Collect every event, or the first error.
+    fn parse<'t, 'v>(
+        root: &'t Command<'t>,
+        argv: &'v [&'v OsStr],
+    ) -> Result<Vec<Event<'t, 'v>>, Error<'t, 'v>> {
+        let mut parser = Parser::new(root, argv);
+        let mut events = Vec::new();
+        while let Some(event) = parser.next_event() {
+            events.push(event?);
+        }
+        Ok(events)
+    }
+
+    fn argv<const N: usize>(tokens: [&str; N]) -> [&OsStr; N] {
+        tokens.map(OsStr::new)
+    }
+
+    #[test]
+    fn long_boolean() {
+        let a = argv(["--force"]);
+        assert_eq!(
+            parse(&ROOT, &a).unwrap(),
+            vec![Event::Flag {
+                flag: &FORCE,
+                value: None,
+                negated: false
+            }]
+        );
+    }
+
+    #[test]
+    fn long_value_forms() {
+        for tokens in [vec!["--jobs=8"], vec!["--jobs", "8"]] {
+            let a: Vec<&OsStr> = tokens.iter().map(|t| OsStr::new(*t)).collect();
+            assert_eq!(
+                parse(&ROOT, &a).unwrap(),
+                vec![Event::Flag {
+                    flag: &JOBS,
+                    value: Some(b"8"),
+                    negated: false
+                }],
+                "{tokens:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn long_value_keeps_later_equals() {
+        let a = argv(["--jobs=a=b"]);
+        let Event::Flag { value, .. } = parse(&ROOT, &a).unwrap()[0] else {
+            panic!("expected a flag");
+        };
+        assert_eq!(value, Some(&b"a=b"[..]));
+    }
+
+    #[test]
+    fn long_value_attached_empty_is_empty_not_absent() {
+        let a = argv(["--jobs="]);
+        let Event::Flag { value, .. } = parse(&ROOT, &a).unwrap()[0] else {
+            panic!("expected a flag");
+        };
+        assert_eq!(value, Some(&b""[..]));
+    }
+
+    #[test]
+    fn long_value_refuses_flaglike_next_word() {
+        let a = argv(["--jobs", "--force"]);
+        assert_eq!(
+            parse(&ROOT, &a),
+            Err(Error::MissingFlagValue { flag: &JOBS })
+        );
+    }
+
+    #[test]
+    fn long_value_accepts_negative_number() {
+        let a = argv(["--jobs", "-1"]);
+        let Event::Flag { value, .. } = parse(&ROOT, &a).unwrap()[0] else {
+            panic!("expected a flag");
+        };
+        assert_eq!(value, Some(&b"-1"[..]));
+    }
+
+    #[test]
+    fn no_abbreviation() {
+        let a = argv(["--forc"]);
+        assert!(matches!(
+            parse(&ROOT, &a),
+            Err(Error::UnknownFlag { token: b"--forc" })
+        ));
+    }
+
+    #[test]
+    fn negation() {
+        let a = argv(["--no-color"]);
+        assert_eq!(
+            parse(&ROOT, &a).unwrap(),
+            vec![Event::Flag {
+                flag: &COLOR,
+                value: None,
+                negated: true
+            }]
+        );
+    }
+
+    #[test]
+    fn short_bundle_and_attached_value() {
+        let a = argv(["-fj8"]);
+        assert_eq!(
+            parse(&ROOT, &a).unwrap(),
+            vec![
+                Event::Flag {
+                    flag: &FORCE,
+                    value: None,
+                    negated: false
+                },
+                Event::Flag {
+                    flag: &JOBS,
+                    value: Some(b"8"),
+                    negated: false
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn short_value_strips_one_equals() {
+        for (tokens, want) in [(["-j=8"], &b"8"[..]), (["-j==8"], &b"=8"[..])] {
+            let a = argv(tokens);
+            let Event::Flag { value, .. } = parse(&ROOT, &a).unwrap()[0] else {
+                panic!("expected a flag");
+            };
+            assert_eq!(value, Some(want), "{tokens:?}");
+        }
+    }
+
+    #[test]
+    fn bare_dash_is_a_value() {
+        let a = argv(["-"]);
+        assert_eq!(
+            parse(&ROOT, &a).unwrap(),
+            vec![Event::Arg {
+                arg: &FILE,
+                value: b"-"
+            }]
+        );
+    }
+
+    #[test]
+    fn positionals_then_variadic() {
+        let a = argv(["one", "two", "three"]);
+        assert_eq!(
+            parse(&ROOT, &a).unwrap(),
+            vec![
+                Event::Arg {
+                    arg: &FILE,
+                    value: b"one"
+                },
+                Event::Arg {
+                    arg: &REST,
+                    value: b"two"
+                },
+                Event::Arg {
+                    arg: &REST,
+                    value: b"three"
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn subcommand_and_alias_route_the_same() {
+        for token in ["install", "i"] {
+            let a = argv([token]);
+            assert_eq!(
+                parse(&ROOT, &a).unwrap(),
+                vec![Event::Command(&INSTALL)],
+                "{token}"
+            );
+        }
+    }
+
+    #[test]
+    fn subcommand_only_routes_before_a_positional_is_filled() {
+        let a = argv(["other", "install"]);
+        assert_eq!(
+            parse(&ROOT, &a).unwrap(),
+            vec![
+                Event::Arg {
+                    arg: &FILE,
+                    value: b"other"
+                },
+                Event::Arg {
+                    arg: &REST,
+                    value: b"install"
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn globals_are_inherited_but_plain_flags_are_not() {
+        let a = argv(["install", "--verbose"]);
+        assert_eq!(
+            parse(&ROOT, &a).unwrap(),
+            vec![
+                Event::Command(&INSTALL),
+                Event::Flag {
+                    flag: &VERBOSE,
+                    value: None,
+                    negated: false
+                }
+            ]
+        );
+
+        // `--jobs` belongs to the root and is not global.
+        let a = argv(["install", "--jobs", "8"]);
+        assert!(matches!(parse(&ROOT, &a), Err(Error::UnknownFlag { .. })));
+    }
+
+    #[test]
+    fn double_dash_protects_flaglike_values() {
+        let a = argv(["--", "--force", "-x"]);
+        assert_eq!(
+            parse(&ROOT, &a).unwrap(),
+            vec![
+                Event::Arg {
+                    arg: &FILE,
+                    value: b"--force"
+                },
+                Event::Arg {
+                    arg: &REST,
+                    value: b"-x"
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn second_double_dash_is_a_value() {
+        let a = argv(["--", "a", "--", "b"]);
+        let values: Vec<&[u8]> = parse(&ROOT, &a)
+            .unwrap()
+            .iter()
+            .filter_map(|e| match e {
+                Event::Arg { value, .. } => Some(*value),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(values, vec![&b"a"[..], &b"--"[..], &b"b"[..]]);
+    }
+
+    #[test]
+    fn double_dash_required_arg() {
+        static CMD: Arg = Arg {
+            key: 20,
+            name: "cmd",
+            double_dash: DoubleDash::Required,
+            ..Arg::REQUIRED
+        };
+        static EXEC: Command = Command {
+            name: "ex",
+            args: &[&CMD],
+            ..Command::EMPTY
+        };
+
+        let a = argv(["--", "ls"]);
+        assert_eq!(
+            parse(&EXEC, &a).unwrap(),
+            vec![Event::Arg {
+                arg: &CMD,
+                value: b"ls"
+            }]
+        );
+
+        let a = argv(["ls"]);
+        assert_eq!(
+            parse(&EXEC, &a),
+            Err(Error::ArgRequiresDoubleDash { arg: &CMD })
+        );
+    }
+
+    #[test]
+    fn double_dash_preserve_keeps_the_separator() {
+        static ARGS: Arg = Arg {
+            key: 21,
+            name: "args",
+            double_dash: DoubleDash::Preserve,
+            ..Arg::VAR
+        };
+        static WRAP: Command = Command {
+            name: "ex",
+            args: &[&ARGS],
+            ..Command::EMPTY
+        };
+
+        let a = argv(["a", "--", "b"]);
+        let values: Vec<&[u8]> = parse(&WRAP, &a)
+            .unwrap()
+            .iter()
+            .filter_map(|e| match e {
+                Event::Arg { value, .. } => Some(*value),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(values, vec![&b"a"[..], &b"--"[..], &b"b"[..]]);
+    }
+
+    #[test]
+    fn too_many_words() {
+        static ONE: Command = Command {
+            name: "ex",
+            args: &[&FILE],
+            ..Command::EMPTY
+        };
+        let a = argv(["a", "b"]);
+        assert_eq!(parse(&ONE, &a), Err(Error::UnexpectedArg { token: b"b" }));
+    }
+
+    #[test]
+    fn errors_are_terminal() {
+        let a = argv(["--wat", "--force"]);
+        let mut parser = Parser::new(&ROOT, &a);
+        assert!(parser.next_event().unwrap().is_err());
+        assert!(parser.next_event().is_none());
+    }
+
+    #[test]
+    fn non_utf8_values_still_parse() {
+        // A value that is not valid UTF-8 binds; only converting it fails, and
+        // only if a caller asks.
+        let raw = OsStr::new("--force");
+        let a = [raw];
+        assert!(parse(&ROOT, &a).is_ok());
+
+        assert!(as_str(b"ok").is_ok());
+        assert!(as_str(&[0xff, 0xfe]).is_err());
+    }
+}

--- a/argv/tests/no_alloc.rs
+++ b/argv/tests/no_alloc.rs
@@ -1,0 +1,208 @@
+//! Proves the claim in the crate docs: a parse allocates nothing.
+//!
+//! A counting global allocator wraps the system one and can be armed around a
+//! region of code. Anything the test itself needs — the argv vector, the
+//! collected results — is built while disarmed, so what the counter sees is only
+//! the parse.
+//!
+//! This is a test rather than a benchmark because "zero" is a property, not a
+//! measurement. If a future refactor introduces a `to_vec()` in the hot path, no
+//! benchmark threshold would catch it as reliably as this does.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::ffi::OsStr;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use usage_argv::{Arg, Command, DoubleDash, Event, Flag, Parser};
+
+struct Counting;
+
+static ARMED: AtomicBool = AtomicBool::new(false);
+static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if ARMED.load(Ordering::Relaxed) {
+            ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        }
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        if ARMED.load(Ordering::Relaxed) {
+            ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        }
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: Counting = Counting;
+
+/// Run `f` with the counter armed, and report how many allocations it made.
+///
+/// The counter is global, so anything allocating on another thread while it is
+/// armed would be counted here. That is why this file holds exactly one
+/// `#[test]`: the test harness gives each test its own thread, and a sibling test
+/// building a `Vec` was enough to make this report phantom allocations. One test
+/// means one thread means the count belongs to the parse.
+fn count_allocations(f: impl FnOnce()) -> usize {
+    ALLOCATIONS.store(0, Ordering::Relaxed);
+    ARMED.store(true, Ordering::Relaxed);
+    f();
+    ARMED.store(false, Ordering::Relaxed);
+    ALLOCATIONS.load(Ordering::Relaxed)
+}
+
+static QUIET: Flag = Flag {
+    key: 1,
+    longs: &["quiet"],
+    shorts: b"q",
+    global: true,
+    ..Flag::BOOL
+};
+static JOBS: Flag = Flag {
+    key: 2,
+    longs: &["jobs"],
+    shorts: b"j",
+    global: true,
+    ..Flag::VALUE
+};
+static FORCE: Flag = Flag {
+    key: 3,
+    longs: &["force"],
+    shorts: b"f",
+    ..Flag::BOOL
+};
+static COLOR: Flag = Flag {
+    key: 4,
+    longs: &["color"],
+    negate: Some("no-color"),
+    ..Flag::BOOL
+};
+static TOOL: Arg = Arg {
+    key: 10,
+    name: "tool",
+    ..Arg::VAR
+};
+static TASK: Arg = Arg {
+    key: 11,
+    name: "task",
+    ..Arg::REQUIRED
+};
+static PASSTHROUGH: Arg = Arg {
+    key: 12,
+    name: "args",
+    double_dash: DoubleDash::Preserve,
+    ..Arg::VAR
+};
+static SET: Command = Command {
+    name: "set",
+    flags: &[&FORCE],
+    args: &[&TASK],
+    key: 200,
+    ..Command::EMPTY
+};
+static SETTINGS: Command = Command {
+    name: "settings",
+    subcommands: &[&SET],
+    key: 201,
+    ..Command::EMPTY
+};
+static INSTALL: Command = Command {
+    name: "install",
+    aliases: &["i"],
+    flags: &[&FORCE],
+    args: &[&TOOL],
+    key: 202,
+    ..Command::EMPTY
+};
+static RUN: Command = Command {
+    name: "run",
+    args: &[&TASK, &PASSTHROUGH],
+    key: 203,
+    ..Command::EMPTY
+};
+static ROOT: Command = Command {
+    name: "ex",
+    flags: &[&QUIET, &JOBS, &COLOR],
+    subcommands: &[&INSTALL, &SETTINGS, &RUN],
+    key: 204,
+    ..Command::EMPTY
+};
+
+/// Drive a parse to completion without allocating: the events are inspected and
+/// discarded rather than collected.
+fn drain(argv: &[&OsStr]) -> usize {
+    let mut parser = Parser::new(&ROOT, argv);
+    let mut seen = 0;
+    while let Some(event) = parser.next_event() {
+        match event {
+            Ok(Event::Command(_) | Event::Flag { .. } | Event::Arg { .. }) => seen += 1,
+            Err(_) => seen += 1,
+        }
+    }
+    seen
+}
+
+#[test]
+fn parsing_never_allocates() {
+    // First, prove the counter is not vacuous. If this were broken, every
+    // assertion below would pass no matter what the parser did.
+    let deliberate = count_allocations(|| {
+        let v: Vec<u8> = Vec::with_capacity(64);
+        std::hint::black_box(v);
+    });
+    assert!(
+        deliberate > 0,
+        "the allocation counter did not observe a deliberate allocation"
+    );
+
+    // Every command line is built before the counter is armed, so what it sees
+    // is only the parse.
+    let succeeding: Vec<Vec<&OsStr>> = vec![
+        vec![],
+        vec![OsStr::new("install")],
+        vec![
+            OsStr::new("i"),
+            OsStr::new("node@20"),
+            OsStr::new("go@1.22"),
+        ],
+        vec![OsStr::new("--quiet"), OsStr::new("install")],
+        vec![OsStr::new("install"), OsStr::new("--quiet")],
+        vec![OsStr::new("-qj8"), OsStr::new("install")],
+        vec![OsStr::new("--jobs=8"), OsStr::new("install")],
+        vec![OsStr::new("--no-color")],
+        vec![OsStr::new("settings"), OsStr::new("set"), OsStr::new("x")],
+        vec![
+            OsStr::new("run"),
+            OsStr::new("build"),
+            OsStr::new("--"),
+            OsStr::new("--flag-for-the-task"),
+        ],
+    ];
+
+    // Errors are values carrying borrowed slices rather than formatted messages,
+    // so failing does not allocate either. Rendering a failure for a human would,
+    // and that is a cold path in another crate.
+    let failing: Vec<Vec<&OsStr>> = vec![
+        vec![OsStr::new("--nope")],
+        vec![OsStr::new("--jobs")],
+        vec![OsStr::new("-z")],
+        vec![OsStr::new("install"), OsStr::new("--jobs")],
+    ];
+
+    for argv in succeeding.iter().chain(failing.iter()) {
+        let allocations = count_allocations(|| {
+            drain(argv);
+        });
+        assert_eq!(
+            allocations, 0,
+            "parsing {argv:?} allocated {allocations} time(s)"
+        );
+    }
+}

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -14,6 +14,7 @@ license = { workspace = true }
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+usage-argv = { workspace = true }
 usage-lib = { workspace = true }
 
 [[bin]]

--- a/conformance/src/argv.rs
+++ b/conformance/src/argv.rs
@@ -270,6 +270,7 @@ fn build(cmd: &SpecCommand) -> &'static Command<'static> {
                 double_dash: match a.double_dash {
                     usage::SpecDoubleDashChoices::Required => DoubleDash::Required,
                     usage::SpecDoubleDashChoices::Preserve => DoubleDash::Preserve,
+                    usage::SpecDoubleDashChoices::Automatic => DoubleDash::Automatic,
                     _ => DoubleDash::Optional,
                 },
             }))

--- a/conformance/src/argv.rs
+++ b/conformance/src/argv.rs
@@ -1,0 +1,300 @@
+//! Running the corpus against [`usage_argv`], the compiled parser.
+//!
+//! usage-argv reads `static` tables that a derive macro is meant to emit. Nothing
+//! emits them yet, so this module builds them from a [`Spec`] instead, which also
+//! makes the corpus usable as usage-argv's test suite from the first commit.
+//!
+//! The tables are leaked. They must outlive the parse and be `'static`-shaped,
+//! and a test process that builds a handful of small tables and exits is the one
+//! place where leaking is the simplest correct answer. Generated code has no such
+//! problem: its tables really are `static`.
+//!
+//! # Scope
+//!
+//! usage-argv implements binding only. Vectors that turn on something decided
+//! after the last token — `required`, `choices`, `env`, defaults, `var_min` and
+//! `var_max`, `overrides` — are reported [`Outcome::OutOfScope`] rather than
+//! failed, because that behavior belongs to the layer that owns the target
+//! struct. The count is asserted, so the out-of-scope set cannot quietly grow.
+
+use std::collections::BTreeMap;
+use std::ffi::OsStr;
+
+use usage::{Spec, SpecArg, SpecCommand, SpecFlag};
+use usage_argv::{Arg, Command, DoubleDash, Error, Event, Flag, Parser};
+
+use crate::{ErrorCode, Expect, Parsed, Value, Vector};
+
+/// What usage-argv did with a vector.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Outcome {
+    Parsed(Parsed),
+    Failed(ErrorCode),
+    /// The vector exercises something usage-argv deliberately leaves to a higher
+    /// layer. The string says which.
+    OutOfScope(&'static str),
+    /// The spec would not load. A bug in the vector.
+    BadSpec(String),
+}
+
+impl Outcome {
+    pub fn matches(&self, expect: &Expect) -> bool {
+        match (self, expect) {
+            (Outcome::Parsed(got), Expect::Ok(want)) => got == want,
+            (Outcome::Failed(got), Expect::Error(want)) => got == want,
+            _ => false,
+        }
+    }
+}
+
+/// Parse a vector with usage-argv.
+pub fn run(vector: &Vector) -> Outcome {
+    let spec: Spec = match vector.spec.parse() {
+        Ok(spec) => spec,
+        Err(e) => return Outcome::BadSpec(e.to_string()),
+    };
+
+    if let Some(reason) = out_of_scope(&spec, &vector.expect) {
+        return Outcome::OutOfScope(reason);
+    }
+
+    let root = build(&spec.cmd);
+    let argv: Vec<&'static OsStr> = vector
+        .argv
+        .iter()
+        .map(|a| -> &'static OsStr { OsStr::new(leak(a)) })
+        .collect();
+    let argv: &'static [&'static OsStr] = Box::leak(argv.into_boxed_slice());
+
+    // How a value accumulates depends on the declaration, which the parser
+    // deliberately does not know: it reports each occurrence and lets the caller
+    // decide. Generated code would assign to a field or push to a Vec; here the
+    // spec says which of the two to do.
+    let multi = multi_valued(&spec.cmd);
+
+    let mut parser = Parser::new(root, argv);
+    let mut cmd = Vec::new();
+    let mut flags: BTreeMap<String, Value> = BTreeMap::new();
+    let mut args: BTreeMap<String, Value> = BTreeMap::new();
+
+    while let Some(event) = parser.next_event() {
+        match event {
+            Ok(Event::Command(c)) => cmd.push(c.name.to_string()),
+            Ok(Event::Flag {
+                flag,
+                value,
+                negated,
+            }) => {
+                let name = flag.name.to_string();
+                match (multi.get(name.as_str()), value) {
+                    // A count flag records one entry per occurrence.
+                    (Some(Multi::Count), _) => {
+                        match flags.entry(name).or_insert(Value::Bools(vec![])) {
+                            Value::Bools(v) => v.push(true),
+                            _ => unreachable!("count flags only ever hold bools"),
+                        }
+                    }
+                    (Some(Multi::Var), Some(v)) => {
+                        match flags.entry(name).or_insert(Value::Strs(vec![])) {
+                            Value::Strs(list) => list.push(string(v)),
+                            _ => unreachable!("var flags only ever hold strings"),
+                        }
+                    }
+                    (_, Some(v)) => {
+                        flags.insert(name, Value::Str(string(v)));
+                    }
+                    (_, None) => {
+                        flags.insert(name, Value::Bool(!negated));
+                    }
+                }
+            }
+            Ok(Event::Arg { arg, value }) => {
+                let name = arg.name.to_string();
+                if arg.var {
+                    match args.entry(name).or_insert(Value::Strs(vec![])) {
+                        Value::Strs(list) => list.push(string(value)),
+                        _ => unreachable!("var args only ever hold strings"),
+                    }
+                } else {
+                    args.insert(name, Value::Str(string(value)));
+                }
+            }
+            Err(e) => return Outcome::Failed(code(e)),
+        }
+    }
+
+    Outcome::Parsed(Parsed { cmd, flags, args })
+}
+
+fn string(value: &[u8]) -> String {
+    usage_argv::as_str(value)
+        .expect("corpus values are UTF-8")
+        .to_string()
+}
+
+fn code(err: Error<'_, '_>) -> ErrorCode {
+    match err {
+        Error::UnknownFlag { .. } => ErrorCode::UnknownFlag,
+        Error::MissingFlagValue { .. } => ErrorCode::MissingFlagValue,
+        Error::UnexpectedArg { .. } => ErrorCode::UnexpectedArg,
+        Error::ArgRequiresDoubleDash { .. } => ErrorCode::ArgRequiresDoubleDash,
+        Error::TooDeep => panic!("no corpus spec is anywhere near MAX_DEPTH"),
+    }
+}
+
+/// Which flags accumulate rather than replace.
+enum Multi {
+    Count,
+    Var,
+}
+
+fn multi_valued(cmd: &SpecCommand) -> BTreeMap<String, Multi> {
+    let mut out = BTreeMap::new();
+    collect_multi(cmd, &mut out);
+    out
+}
+
+fn collect_multi(cmd: &SpecCommand, out: &mut BTreeMap<String, Multi>) {
+    for flag in &cmd.flags {
+        if flag.count {
+            out.insert(flag.name.clone(), Multi::Count);
+        } else if flag.var || flag.arg.as_ref().is_some_and(|a| a.var) {
+            out.insert(flag.name.clone(), Multi::Var);
+        }
+    }
+    for sub in cmd.subcommands.values() {
+        collect_multi(sub, out);
+    }
+}
+
+/// Why a vector is not usage-argv's to answer, if it isn't.
+fn out_of_scope(spec: &Spec, expect: &Expect) -> Option<&'static str> {
+    if let Expect::Error(code) = expect {
+        match code {
+            ErrorCode::MissingRequiredFlag => {
+                return Some("required flags are checked after binding")
+            }
+            ErrorCode::MissingRequiredArg => {
+                return Some("required args are checked after binding")
+            }
+            ErrorCode::InvalidChoice => return Some("choices are validated after binding"),
+            ErrorCode::VarTooFew | ErrorCode::VarTooMany => {
+                return Some("var_min and var_max are checked after binding");
+            }
+            _ => {}
+        }
+    }
+    declares_post_binding(&spec.cmd)
+}
+
+fn declares_post_binding(cmd: &SpecCommand) -> Option<&'static str> {
+    for flag in &cmd.flags {
+        if let Some(reason) = flag_post_binding(flag) {
+            return Some(reason);
+        }
+    }
+    for arg in &cmd.args {
+        if let Some(reason) = arg_post_binding(arg) {
+            return Some(reason);
+        }
+    }
+    cmd.subcommands.values().find_map(declares_post_binding)
+}
+
+fn flag_post_binding(flag: &SpecFlag) -> Option<&'static str> {
+    if !flag.default.is_empty() {
+        return Some("defaults are applied after binding");
+    }
+    if flag.env.is_some() {
+        return Some("env fallback is applied after binding");
+    }
+    if !flag.overrides.is_empty() {
+        return Some("overrides are resolved after binding");
+    }
+    if flag.required || !flag.required_if.is_empty() || !flag.required_unless.is_empty() {
+        return Some("requirements are checked after binding");
+    }
+    if flag.var_min.is_some() || flag.var_max.is_some() {
+        return Some("var_min and var_max are checked after binding");
+    }
+    flag.arg.as_ref().and_then(arg_post_binding)
+}
+
+fn arg_post_binding(arg: &SpecArg) -> Option<&'static str> {
+    if !arg.default.is_empty() {
+        return Some("defaults are applied after binding");
+    }
+    if arg.env.is_some() {
+        return Some("env fallback is applied after binding");
+    }
+    if arg.choices.is_some() {
+        return Some("choices are validated after binding");
+    }
+    if arg.var_min.is_some() || arg.var_max.is_some() {
+        return Some("var_min and var_max are checked after binding");
+    }
+    None
+}
+
+/// Build leaked tables mirroring a spec command.
+fn build(cmd: &SpecCommand) -> &'static Command<'static> {
+    let flags: Vec<&'static Flag<'static>> = cmd
+        .flags
+        .iter()
+        .map(|f| -> &'static Flag<'static> {
+            let longs: Vec<&'static str> = f.long.iter().map(|l| leak(l)).collect();
+            let shorts: Vec<u8> = f.short.iter().map(|c| *c as u8).collect();
+            Box::leak(Box::new(Flag {
+                key: 0,
+                name: leak(&f.name),
+                longs: Box::leak(longs.into_boxed_slice()),
+                shorts: Box::leak(shorts.into_boxed_slice()),
+                // usage-lib stores the negation with its dashes; the table wants
+                // the bare name.
+                negate: f.negate.as_ref().map(|n| leak(n.trim_start_matches('-'))),
+                takes_value: f.arg.is_some(),
+                var: f.var || f.arg.as_ref().is_some_and(|a| a.var),
+                global: f.global,
+            }))
+        })
+        .collect();
+
+    let args: Vec<&'static Arg<'static>> = cmd
+        .args
+        .iter()
+        .map(|a| -> &'static Arg<'static> {
+            Box::leak(Box::new(Arg {
+                key: 0,
+                name: leak(&a.name),
+                var: a.var,
+                double_dash: match a.double_dash {
+                    usage::SpecDoubleDashChoices::Required => DoubleDash::Required,
+                    usage::SpecDoubleDashChoices::Preserve => DoubleDash::Preserve,
+                    _ => DoubleDash::Optional,
+                },
+            }))
+        })
+        .collect();
+
+    let subcommands: Vec<&'static Command<'static>> = cmd.subcommands.values().map(build).collect();
+
+    let aliases: Vec<&'static str> = cmd
+        .aliases
+        .iter()
+        .chain(cmd.hidden_aliases.iter())
+        .map(|a| leak(a))
+        .collect();
+
+    Box::leak(Box::new(Command {
+        name: leak(&cmd.name),
+        aliases: Box::leak(aliases.into_boxed_slice()),
+        flags: Box::leak(flags.into_boxed_slice()),
+        args: Box::leak(args.into_boxed_slice()),
+        subcommands: Box::leak(subcommands.into_boxed_slice()),
+        key: 0,
+    }))
+}
+
+fn leak(s: &str) -> &'static str {
+    Box::leak(s.to_string().into_boxed_str())
+}

--- a/conformance/src/lib.rs
+++ b/conformance/src/lib.rs
@@ -13,6 +13,7 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
+pub mod argv;
 pub mod reference;
 
 /// One `corpus/*.json` file: a themed group of vectors.

--- a/conformance/tests/argv.rs
+++ b/conformance/tests/argv.rs
@@ -1,0 +1,126 @@
+//! Checks usage-argv against the corpus.
+//!
+//! This is the point of writing the grammar down. usage-argv is expected to match
+//! every binding vector — including the fifteen where usage-lib does not, since
+//! those record the grammar's intent rather than the reference's behavior.
+//!
+//! Vectors that turn on something decided after the last token (`required`,
+//! `choices`, `env`, defaults, `var_min`/`var_max`, `overrides`) are out of scope
+//! for this crate by design. Their count is asserted below so the exempt set
+//! cannot quietly grow.
+
+use usage_conformance::argv::{run, Outcome};
+use usage_conformance::{load, Expect, Reference, Vector};
+
+/// Vectors that exercise binding, which is what usage-argv implements.
+const IN_SCOPE: usize = 61;
+
+fn corpus() -> Vec<Vector> {
+    let files = load(usage_conformance::corpus_dir()).expect("corpus should load");
+    files.into_iter().flat_map(|f| f.vectors).collect()
+}
+
+#[test]
+fn every_binding_vector_passes() {
+    let mut failures = Vec::new();
+    let mut in_scope = 0;
+
+    for vector in corpus() {
+        let outcome = run(&vector);
+        if let Outcome::OutOfScope(_) = outcome {
+            continue;
+        }
+        in_scope += 1;
+        if !outcome.matches(&vector.expect) {
+            failures.push(format!(
+                "{}: {}\n     expected: {:?}\n     got:      {outcome:?}",
+                vector.id, vector.doc, vector.expect
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{} binding vector(s) failed:\n  - {}",
+        failures.len(),
+        failures.join("\n  - ")
+    );
+
+    assert_eq!(
+        in_scope, IN_SCOPE,
+        "the number of vectors usage-argv answers changed; if that was the point \
+         of your change, update IN_SCOPE"
+    );
+}
+
+#[test]
+fn agrees_where_usage_lib_does_not() {
+    // The divergences are the reason the corpus exists, so make it explicit that
+    // the new parser resolves them rather than inheriting them.
+    let mut resolved = 0;
+
+    for vector in corpus() {
+        let Reference::Diverges(_) = vector.reference else {
+            continue;
+        };
+        let outcome = run(&vector);
+        if let Outcome::OutOfScope(_) = outcome {
+            continue;
+        }
+        assert!(
+            outcome.matches(&vector.expect),
+            "{} is a known usage-lib divergence that usage-argv should fix, but it \
+             produced {outcome:?} instead of {:?}",
+            vector.id,
+            vector.expect
+        );
+        resolved += 1;
+    }
+
+    assert!(
+        resolved >= 12,
+        "expected usage-argv to resolve at least a dozen recorded divergences, \
+         resolved {resolved}"
+    );
+}
+
+#[test]
+fn out_of_scope_vectors_say_why() {
+    // A vector skipped without a reason would be a silent hole in coverage.
+    for vector in corpus() {
+        if let Outcome::OutOfScope(reason) = run(&vector) {
+            assert!(
+                !reason.is_empty(),
+                "{} was skipped without a reason",
+                vector.id
+            );
+        }
+    }
+}
+
+#[test]
+fn no_vector_has_an_unloadable_spec() {
+    for vector in corpus() {
+        if let Outcome::BadSpec(e) = run(&vector) {
+            panic!("vector {} has an invalid spec: {e}", vector.id);
+        }
+    }
+}
+
+#[test]
+fn error_expectations_are_reachable() {
+    // Guards against the codes usage-argv claims to produce drifting away from
+    // the ones the corpus asks for.
+    let produced: Vec<_> = corpus()
+        .iter()
+        .filter_map(|v| match (run(v), &v.expect) {
+            (Outcome::Failed(code), Expect::Error(_)) => Some(code),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        produced.len() >= 6,
+        "expected the binding subset to exercise several error classes, saw {}",
+        produced.len()
+    );
+}

--- a/conformance/tests/argv.rs
+++ b/conformance/tests/argv.rs
@@ -13,7 +13,7 @@ use usage_conformance::argv::{run, Outcome};
 use usage_conformance::{load, Expect, Reference, Vector};
 
 /// Vectors that exercise binding, which is what usage-argv implements.
-const IN_SCOPE: usize = 61;
+const IN_SCOPE: usize = 62;
 
 fn corpus() -> Vec<Vector> {
     let files = load(usage_conformance::corpus_dir()).expect("corpus should load");

--- a/docs/spec/argv.md
+++ b/docs/spec/argv.md
@@ -245,7 +245,7 @@ Any implementation in any language can run these. In this repository,
 `cargo test -p usage-conformance` runs them against both usage-lib and
 [usage-argv](https://github.com/jdx/usage/tree/main/argv).
 
-usage-argv answers 61 of the 83 vectors. The other 22 turn on something decided
+usage-argv answers 62 of the 86 vectors. The other 24 turn on something decided
 after the last token is read — `required`, `choices`, `env` fallback, defaults,
 `var_min` and `var_max`, `overrides` — which needs to know a value's type and so
 belongs to the layer above a binding parser. Those are reported as out of scope

--- a/docs/spec/argv.md
+++ b/docs/spec/argv.md
@@ -77,6 +77,21 @@ the value was forgotten. To pass a value that begins with a dash, attach it:
 
 A flag needing a value that ends the command line is an error.
 
+### Flags that take several values
+
+A flag whose argument is variadic (`--include <pattern>...`) keeps taking values
+from one occurrence: it consumes following tokens until one is flag-like, or a
+`--` arrives, or the command line ends. So `--include a b` gives it both, while
+`--include a --force` gives it only `a`.
+
+This is greedy, and a command that declares both a variadic flag and positionals
+will find the flag eating them. That is inherent to the feature rather than a
+quirk of this grammar; the way to end the run explicitly is `--`.
+
+A flag declared `var` without a variadic argument is the other shape: it takes
+one value per occurrence and may be repeated, so `--include a --include b`
+collects two.
+
 ## Short flags
 
 A token beginning with a single `-` is one or more short flags. Letters are read
@@ -227,7 +242,15 @@ Vectors that set `env` carry their own environment. The harness never reads the
 process environment, so no vector's result can depend on the machine running it.
 
 Any implementation in any language can run these. In this repository,
-`cargo test -p usage-conformance` does.
+`cargo test -p usage-conformance` runs them against both usage-lib and
+[usage-argv](https://github.com/jdx/usage/tree/main/argv).
+
+usage-argv answers 61 of the 83 vectors. The other 22 turn on something decided
+after the last token is read — `required`, `choices`, `env` fallback, defaults,
+`var_min` and `var_max`, `overrides` — which needs to know a value's type and so
+belongs to the layer above a binding parser. Those are reported as out of scope
+rather than as failures, and the count is asserted so the exempt set cannot
+quietly grow.
 
 ## Where the reference implementation differs
 

--- a/tasks/release-plz
+++ b/tasks/release-plz
@@ -38,6 +38,7 @@ cur_version="$(cargo pkgid usage-lib | cut -d# -f2 | cut -d@ -f2)"
 if ! echo "$released_versions" | grep -q "^v$cur_version$"; then
   echo "Releasing $cur_version"
   if [ "${usage_dry_run:-}" != 1 ]; then
+    publish_crate_if_needed usage-argv
     publish_crate_if_needed usage-lib
     publish_crate_if_needed clap_usage
     publish_crate_if_needed usage-cli
@@ -48,35 +49,37 @@ if ! echo "$released_versions" | grep -q "^v$cur_version$"; then
 fi
 
 # usage-lib's current version is already released, so clap_usage's dependency
-# is satisfied; catch it up if it is behind.
+# is satisfied; catch it up if it is behind. usage-argv rides the shared version
+# and depends on nothing, so the same catch-up applies to it.
+publish_crate_if_needed usage-argv
 publish_crate_if_needed clap_usage
 
 # Anchor the range before filtering paths. A release tag may point at a commit that only
 # changes root release files; letting the path filter hide that tag can make cliff propose
 # a version lower than the one already published.
 release_range="v$cur_version..HEAD"
-version="$(git cliff "$release_range" --bumped-version --include-path 'lib/**' --include-path 'cli/**')"
+version="$(git cliff "$release_range" --bumped-version --include-path 'lib/**' --include-path 'cli/**' --include-path 'argv/**')"
 
 if [ "v$cur_version" == "$version" ]; then
-  echo "No usage-lib/usage-cli changes since $version; nothing to release"
+  echo "No usage-lib/usage-cli/usage-argv changes since $version; nothing to release"
   exit 0
 fi
 
 if [ "${usage_dry_run:-}" == 1 ]; then
   echo "version: $version"
-  changelog="$(git cliff "$release_range" --tag "$version" --strip all --include-path 'lib/**' --include-path 'cli/**')"
+  changelog="$(git cliff "$release_range" --tag "$version" --strip all --include-path 'lib/**' --include-path 'cli/**' --include-path 'argv/**')"
   echo "changelog: $changelog"
   exit 0
 fi
 
 # Generate changelog using git-cliff (LLM editorialization happens in release.yml after merge)
-git cliff "$release_range" --tag "$version" --prepend CHANGELOG.md --include-path 'lib/**' --include-path 'cli/**'
+git cliff "$release_range" --tag "$version" --prepend CHANGELOG.md --include-path 'lib/**' --include-path 'cli/**' --include-path 'argv/**'
 
 # Get the unreleased notes for PR body
 # Strip version header since PR title already has version
-PR_BODY="$(git cliff "$release_range" --tag "$version" --strip all --include-path 'lib/**' --include-path 'cli/**' | tail -n +3)"
+PR_BODY="$(git cliff "$release_range" --tag "$version" --strip all --include-path 'lib/**' --include-path 'cli/**' --include-path 'argv/**' | tail -n +3)"
 
-cargo set-version "${version#v}" --exclude clap_usage
+cargo set-version "${version#v}" --exclude clap_usage --exclude usage-conformance
 mise run render
 
 git config user.name mise-en-dev
@@ -85,7 +88,7 @@ cargo update
 aube update
 mise run lint-fix
 git add \
-  {./,cli/,lib/}Cargo.* \
+  {./,argv/,cli/,lib/}Cargo.* \
   package.json aube-lock.yaml \
   cli/usage.usage.kdl \
   docs/cli/reference/* \


### PR DESCRIPTION
Stacked on #797 — review that one first; this PR's diff against `main` will include it until it merges.

## What this is

`argv/` — a new crate, `usage-argv`, implementing the binding half of [the grammar from #797](https://usage.jdx.dev/spec/argv). No command tree, no allocation, one pass over `argv`.

Not published (name is reserved on crates.io at 0.0.0), and deliberately outside the shared-version release cycle, the way `clap_usage` already is.

## Two design decisions worth a look

**Events, not a map.** Parsing yields `Event::{Command, Flag, Arg}` rather than returning a structure. A map would have to allocate and then be read back out; an event can be assigned straight into a struct field by generated code. Same reasoning as serde deserializing into your type instead of into a `Value`.

**Values are `&[u8]`.** Borrowed from `argv`, converted by the caller with `as_str`. Slicing an `OsStr` into `&str` pieces needs either an allocation or `unsafe`, and this crate forbids `unsafe`. The upside is that a non-UTF-8 command line still *parses* — flags match, subcommands route — and only the values actually looked at can fail to convert, which is where that failure belongs.

Tables are borrowed slices (`&'a [&'a Flag<'a>]`) so a derive can emit the whole tree as `static` data. Tables and `argv` carry separate lifetimes; a single lifetime compiled but forced `argv` to be `'static`, which a doctest caught.

## Scope

Binding only. `required`, `choices`, `env` fallback, defaults, `var_min`/`var_max`, and `overrides` all happen after the last token is read and need to know a value's type, so they belong to the layer that owns the target struct. Keeping them out is what keeps this loop small.

## How it's verified

**The corpus.** `conformance/` gained a second runner, so the same vectors now exercise both parsers. usage-argv answers **61 of 83**; the remaining 22 are post-binding and report *why* they're exempt, with the count asserted so the exempt set can't quietly grow. A separate test asserts that **all 15 vectors where usage-lib diverges from the grammar are ones this parser gets right** — that was the point of writing the grammar down.

Since nothing emits tables yet, the harness builds them from a `Spec` and leaks them. A test process building a few small tables is the one place where leaking is the simplest correct answer; generated code has no such problem.

**Zero allocation.** `argv/tests/no_alloc.rs` arms a counting global allocator around parses of ten realistic command lines and four failing ones, and asserts zero. It also asserts the counter observes a deliberate allocation, so the test can't pass vacuously.

One wrinkle worth knowing if you write similar tests: the file holds exactly one `#[test]`, because the counter is global and a sibling test building a `Vec` on another thread showed up as four phantom allocations here.

## One grammar change

Implementing this surfaced a rule the doc didn't state: a flag with a variadic argument (`--include <pattern>...`) consumes following tokens until one is flag-like. I've added it to `docs/spec/argv.md`, including the note that it is greedy and will eat positionals — inherent to the feature, ended explicitly with `--`.

## Next

A derive that emits these tables, and then a benchmark against a clap-shaped equivalent at mise's scale, which is the gate for whether this is worth continuing.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New public parser surface and grammar-aligned behavior that differs from usage-lib on recorded divergences; release script changes affect publishing, but no changes to existing usage-lib parse paths in this diff.
> 
> **Overview**
> Introduces **`usage-argv`**, a dependency-free crate that implements the argv **binding** half of the usage grammar in one pass with no heap allocation. Parsing is driven by static `Command` / `Flag` / `Arg` tables (intended for future derive output) and streams **`Event`** values with **`&[u8]`** payloads instead of building a map.
> 
> **Conformance** gains a second runner (`conformance/src/argv.rs` + `conformance/tests/argv.rs`) that builds leaked tables from corpus specs and asserts **62** in-scope binding vectors pass, including cases where usage-lib diverges; post-binding features (`required`, `choices`, `env`, defaults, etc.) are explicitly **out of scope** with a fixed count. **`argv/tests/no_alloc.rs`** enforces zero allocations during parse via a counting global allocator.
> 
> **`docs/spec/argv.md`** documents greedy variadic flag value consumption and notes dual-parser corpus testing. **`tasks/release-plz`** publishes `usage-argv` with the shared version and includes `argv/**` in changelog path filters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 180aec7d55f4adf1edb15ba863f01d5e81bb6ead. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a zero-allocation command-line argument parser supporting flags, arguments, subcommands, aliases, negation, short flag bundles, attached values, variadic values, and `--` handling.
  - Added structured parsing events and detailed errors for invalid command-line input.

- **Documentation**
  - Documented variadic flag behavior and updated conformance coverage details.

- **Tests**
  - Added comprehensive parser, allocation, error-handling, and conformance tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->