### PR TITLE
fix(argv): stop a repeatable flag from eating a positional

### DIFF
--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -124,9 +124,15 @@ pub struct Flag<'a> {
     pub negate: Option<&'a str>,
     /// Whether the flag takes a value.
     pub takes_value: bool,
-    /// Whether the flag's value is variadic: one occurrence keeps taking values
-    /// until a flag-like token or the end of the command line.
-    pub var: bool,
+    /// Whether one occurrence of this flag keeps taking values, until a flag-like
+    /// token or the end of the command line.
+    ///
+    /// This is the spec's variadic flag *argument* (`--include <pattern>...`). It
+    /// is not the spec's flag-level `var=#true`, which means the flag may be
+    /// repeated and takes one value each time — repetition needs nothing from the
+    /// parser, since it already reports every occurrence separately. Conflating
+    /// the two makes a merely repeatable flag greedy enough to eat a positional.
+    pub variadic: bool,
     /// Whether the flag is recognized by every command beneath the one that
     /// declares it.
     pub global: bool,
@@ -141,7 +147,7 @@ impl Flag<'_> {
         shorts: &[],
         negate: None,
         takes_value: false,
-        var: false,
+        variadic: false,
         global: false,
     };
 
@@ -272,8 +278,17 @@ pub struct Parser<'t, 'v> {
     /// Whether any word has been bound to a positional of `cmd`. Once one has,
     /// no further word can select a subcommand.
     arg_filled: bool,
-    /// Whether a `--` has been consumed as a separator.
-    double_dash: bool,
+    /// Whether flag interpretation has stopped. A `--` does this, and so does an
+    /// `automatic` argument taking a value.
+    flags_stopped: bool,
+    /// Whether a `--` was actually consumed as a separator.
+    ///
+    /// Tracked apart from `flags_stopped` because the two can differ: an
+    /// `automatic` argument stops flag interpretation without any separator being
+    /// typed, and a `preserve` argument keeps one as a value rather than
+    /// consuming it. Callers asking this question want to know what the user
+    /// wrote, not what state the parser reached.
+    separator_seen: bool,
     /// Set once a fatal error has been reported, so iteration stops.
     done: bool,
 }
@@ -294,7 +309,8 @@ impl<'t, 'v> Parser<'t, 'v> {
             collecting: None,
             arg_pos: 0,
             arg_filled: false,
-            double_dash: false,
+            flags_stopped: false,
+            separator_seen: false,
             done: false,
         }
     }
@@ -304,9 +320,13 @@ impl<'t, 'v> Parser<'t, 'v> {
         self.cmd
     }
 
-    /// Whether a `--` has been consumed as a separator.
+    /// Whether a `--` was consumed as a separator.
+    ///
+    /// False when flag interpretation stopped for another reason, such as an
+    /// `automatic` argument taking a value, and false for a `--` that a
+    /// `preserve` argument kept as a value.
     pub fn double_dash_seen(&self) -> bool {
-        self.double_dash
+        self.separator_seen
     }
 
     /// Read the next event.
@@ -358,7 +378,7 @@ impl<'t, 'v> Parser<'t, 'v> {
         let token = bytes(self.argv.get(self.pos)?);
         self.pos += 1;
 
-        if self.double_dash {
+        if self.flags_stopped {
             return Some(self.word(token));
         }
 
@@ -371,7 +391,8 @@ impl<'t, 'v> Parser<'t, 'v> {
             {
                 return Some(self.word(token));
             }
-            self.double_dash = true;
+            self.flags_stopped = true;
+            self.separator_seen = true;
             // An explicit separator unlocks any argument that required one, even
             // if earlier arguments are still unfilled.
             if let Some(idx) = self.cmd.args[self.arg_pos..]
@@ -418,7 +439,7 @@ impl<'t, 'v> Parser<'t, 'v> {
             } else {
                 None
             };
-            if flag.var {
+            if flag.variadic {
                 self.collecting = Some(flag);
             }
             return Ok(Event::Flag {
@@ -489,7 +510,7 @@ impl<'t, 'v> Parser<'t, 'v> {
         } else {
             rest
         };
-        if flag.var {
+        if flag.variadic {
             self.collecting = Some(flag);
         }
         Ok(Event::Flag {
@@ -518,7 +539,7 @@ impl<'t, 'v> Parser<'t, 'v> {
         // Subcommands are only matched where descent is still possible: once a
         // positional of this command has taken a word, a later word that happens
         // to equal a subcommand name is just a value.
-        if !self.arg_filled && !self.double_dash {
+        if !self.arg_filled && !self.flags_stopped {
             if let Some(sub) = self.find_subcommand(token) {
                 self.descend(sub)?;
                 return Ok(Event::Command(sub));
@@ -529,7 +550,7 @@ impl<'t, 'v> Parser<'t, 'v> {
             return Err(Error::UnexpectedArg { token });
         };
 
-        if arg.double_dash == DoubleDash::Required && !self.double_dash {
+        if arg.double_dash == DoubleDash::Required && !self.separator_seen {
             return Err(Error::ArgRequiresDoubleDash { arg });
         }
 
@@ -537,7 +558,7 @@ impl<'t, 'v> Parser<'t, 'v> {
         // An `automatic` argument stops flag interpretation from here on, as
         // though the caller had typed the separator themselves.
         if arg.double_dash == DoubleDash::Automatic {
-            self.double_dash = true;
+            self.flags_stopped = true;
         }
         // A variadic keeps taking values, so the cursor stays put.
         if !arg.var {
@@ -924,6 +945,99 @@ mod tests {
             })
             .collect();
         assert_eq!(values, vec![&b"a"[..], &b"--"[..], &b"b"[..]]);
+    }
+
+    #[test]
+    fn variadic_flag_collects_until_a_flaglike_token() {
+        static INCLUDE: Flag = Flag {
+            key: 5,
+            name: "include",
+            longs: &["include"],
+            shorts: b"i",
+            takes_value: true,
+            variadic: true,
+            ..Flag::BOOL
+        };
+        static GREEDY: Command = Command {
+            name: "ex",
+            flags: &[&INCLUDE, &FORCE],
+            args: &[&FILE],
+            ..Command::EMPTY
+        };
+
+        let a = argv(["--include", "x", "y", "--force"]);
+        assert_eq!(
+            parse(&GREEDY, &a).unwrap(),
+            vec![
+                Event::Flag {
+                    flag: &INCLUDE,
+                    value: Some(b"x"),
+                    negated: false
+                },
+                Event::Flag {
+                    flag: &INCLUDE,
+                    value: Some(b"y"),
+                    negated: false
+                },
+                Event::Flag {
+                    flag: &FORCE,
+                    value: None,
+                    negated: false
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn a_non_variadic_flag_leaves_the_next_word_alone() {
+        // The counterpart to the test above: a flag that takes one value must not
+        // swallow the word after it, which would silently steal a positional.
+        let a = argv(["--jobs", "8", "keep-me"]);
+        assert_eq!(
+            parse(&ROOT, &a).unwrap(),
+            vec![
+                Event::Flag {
+                    flag: &JOBS,
+                    value: Some(b"8"),
+                    negated: false
+                },
+                Event::Arg {
+                    arg: &FILE,
+                    value: b"keep-me"
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn double_dash_seen_means_a_separator_was_typed() {
+        static FILES: Arg = Arg {
+            key: 23,
+            name: "files",
+            double_dash: DoubleDash::Automatic,
+            ..Arg::VAR
+        };
+        static AUTO: Command = Command {
+            name: "ex",
+            flags: &[&FORCE],
+            args: &[&FILES],
+            ..Command::EMPTY
+        };
+
+        let a = argv(["--", "x"]);
+        let mut parser = Parser::new(&ROOT, &a);
+        while parser.next_event().is_some() {}
+        assert!(parser.double_dash_seen(), "a real separator was consumed");
+
+        // `automatic` stops flag interpretation without a separator being typed,
+        // and reporting one would be a lie to any caller that forwards argv.
+        let a = argv(["x", "--force"]);
+        let mut parser = Parser::new(&AUTO, &a);
+        while parser.next_event().is_some() {}
+        assert!(
+            !parser.double_dash_seen(),
+            "automatic mode must not claim a separator was given"
+        );
     }
 
     #[test]

--- a/conformance/src/argv.rs
+++ b/conformance/src/argv.rs
@@ -253,7 +253,10 @@ fn build(cmd: &SpecCommand) -> &'static Command<'static> {
                 // the bare name.
                 negate: f.negate.as_ref().map(|n| leak(n.trim_start_matches('-'))),
                 takes_value: f.arg.is_some(),
-                var: f.var || f.arg.as_ref().is_some_and(|a| a.var),
+                // Only a variadic *argument* is greedy. A `var` flag with a
+                // single-value argument is repeatable instead: one value per
+                // occurrence, which the parser gets by not collecting.
+                variadic: f.arg.as_ref().is_some_and(|a| a.var),
                 global: f.global,
             }))
         })

--- a/conformance/tests/argv.rs
+++ b/conformance/tests/argv.rs
@@ -13,7 +13,7 @@ use usage_conformance::argv::{run, Outcome};
 use usage_conformance::{load, Expect, Reference, Vector};
 
 /// Vectors that exercise binding, which is what usage-argv implements.
-const IN_SCOPE: usize = 62;
+const IN_SCOPE: usize = 63;
 
 fn corpus() -> Vec<Vector> {
     let files = load(usage_conformance::corpus_dir()).expect("corpus should load");

--- a/corpus/01-long-flags.json
+++ b/corpus/01-long-flags.json
@@ -1,6 +1,6 @@
 {
   "section": "long-flags",
-  "about": "How `--name` tokens bind. Long names match exactly — there is no abbreviation inference — and a value may be attached with `=` or given as the following word.",
+  "about": "How `--name` tokens bind. Long names match exactly \u2014 there is no abbreviation inference \u2014 and a value may be attached with `=` or given as the following word.",
   "vectors": [
     {
       "id": "long-boolean-present",
@@ -91,7 +91,7 @@
       "argv": ["--wat"],
       "expect": { "error": "unknown_flag" },
       "reference": {
-        "diverges": "usage-lib binds `--wat` to the positional `file`. This is the root of several other divergences here: unrecognized flags fall through to positionals, so they surface as `unexpected_arg` — or as no error at all — rather than as `unknown_flag`."
+        "diverges": "usage-lib binds `--wat` to the positional `file`. This is the root of several other divergences here: unrecognized flags fall through to positionals, so they surface as `unexpected_arg` \u2014 or as no error at all \u2014 rather than as `unknown_flag`."
       }
     },
     {
@@ -119,6 +119,15 @@
       "expect": { "ok": { "flags": { "include": ["a", "b"] } } },
       "reference": {
         "diverges": "usage-lib reports `unexpected_arg` for the second value. The spec reference documents this form, so the gap is in the parser rather than in the declaration."
+      }
+    },
+    {
+      "id": "long-repeatable-flag-is-not-greedy",
+      "doc": "A `var` flag whose argument is not variadic takes exactly one value per occurrence. It is repetition, not greed, so the word after its value is still available to a positional.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--include <pattern>\" var=#true\narg \"[target]\"\n",
+      "argv": ["--include", "a", "b"],
+      "expect": {
+        "ok": { "flags": { "include": ["a"] }, "args": { "target": "b" } }
       }
     },
     {

--- a/docs/spec/argv.md
+++ b/docs/spec/argv.md
@@ -90,7 +90,8 @@ quirk of this grammar; the way to end the run explicitly is `--`.
 
 A flag declared `var` without a variadic argument is the other shape: it takes
 one value per occurrence and may be repeated, so `--include a --include b`
-collects two.
+collects two. The distinction matters — `--include a b` gives a _repeatable_ flag
+only `a`, leaving `b` to a positional, while a _variadic_ one takes both.
 
 ## Short flags
 
@@ -245,7 +246,7 @@ Any implementation in any language can run these. In this repository,
 `cargo test -p usage-conformance` runs them against both usage-lib and
 [usage-argv](https://github.com/jdx/usage/tree/main/argv).
 
-usage-argv answers 62 of the 86 vectors. The other 24 turn on something decided
+usage-argv answers 63 of the 87 vectors. The other 24 turn on something decided
 after the last token is read — `required`, `choices`, `env` fallback, defaults,
 `var_min` and `var_max`, `overrides` — which needs to know a value's type and so
 belongs to the layer above a binding parser. Those are reported as out of scope
@@ -261,7 +262,7 @@ fails if a label is wrong in either direction. A recorded divergence that gets
 fixed shows up as a test failure telling you to delete the label, so the list
 cannot rot.
 
-Today usage-lib diverges on 16 of 86 vectors, from four causes:
+Today usage-lib diverges on 16 of 87 vectors, from four causes:
 
 **Unrecognized flags fall through to positionals.** `ex --wat` binds `--wat` to
 an argument if one is free, and reports `unexpected_arg` if not. This accounts


### PR DESCRIPTION
Two findings from the review of #798, both real.

## A repeatable flag was greedy

The spec has two similar-looking declarations that mean different things:

- `flag "--include <pattern>" var=#true` — **repeatable**: one value per occurrence
- `flag "--include <pattern>..."` — **variadic**: one occurrence takes several values

The conformance harness set the parser's greedy flag from either, so `--include a b` gave a merely repeatable flag both values — and silently stole the positional that `b` should have filled. The grammar already drew the distinction; nothing tested it. There is now a vector that does, and usage-lib agrees with it, so this was ours alone.

The field name invited the mistake — `Flag.var` sat next to the spec's flag-level `var`, which means the other thing — so it is now `Flag.variadic` with a doc comment saying what it is *not*. Free to rename today, since no release has published the crate.

## `double_dash_seen()` could lie

`automatic` mode stops flag interpretation by setting the same field the accessor reads, so it reported a separator that the user never typed. Now two pieces of state: `flags_stopped` for the parser, `separator_seen` for the question callers actually ask. usage-lib draws the same line for `preserve`, where a `--` is kept as a value rather than consumed.

Three unit tests cover the pair, including the counterpart case — a non-variadic flag must leave the next word alone.

87 vectors, 63 answered by usage-argv, 16 recorded usage-lib divergences.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes argv binding semantics for specs that relied on the old greedy `var` mapping; API rename on unreleased `Flag` field and behavior change for `double_dash_seen()` in edge cases.
> 
> **Overview**
> Fixes **usage-argv** conflating spec **repeatable** flags (`var=#true`, one value per occurrence) with **variadic** flag arguments (`<pattern>...`, greedy until a flag-like token). The conformance bridge no longer sets parser greed from flag-level `var`; only a variadic argument enables value collection. **`Flag.var` is renamed to `variadic`** with docs clarifying it is not flag-level `var`.
> 
> **`double_dash_seen()`** is corrected by splitting parser state: `flags_stopped` (flag interpretation off, including `automatic` args) vs `separator_seen` (a real `--` was consumed). Required-arg checks use `separator_seen` so `preserve` / `automatic` do not lie to callers.
> 
> Adds corpus vector **`long-repeatable-flag-is-not-greedy`**, unit tests, and doc/corpus count updates (63 in-scope vectors).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ef1ff20770286294188f8b5964db37a219fbb38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repeatable flags now consume exactly one value per occurrence, leaving subsequent values available to positional arguments.
  * Variadic flags correctly consume multiple values from a single occurrence.
  * Improved handling and reporting of explicit `--` separators, including positional arguments and subcommands.

* **Documentation**
  * Clarified flag value consumption rules and updated command-line conformance statistics.
  * Added coverage for repeatable, variadic, and separator-handling scenarios.

* **Refactor**
  * Renamed the public flag property from `var` to `variadic` for clearer behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->