### PR TITLE
feat(spec): add help_heading, and render it

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -128,9 +128,9 @@ carrying them rather than being worked around.
 - [x] **`help_heading`** — grouping flags under a heading in help output. Now a
       spec field on both flags and arguments, and the clap bridge no longer drops
       it, which it had been doing for every CLI that groups its flags.
-- [ ] **Rendering headings** — the spec can express a heading and nothing displays
-      one yet. Grouping flags in help and markdown output needs the docs models and
-      the templates to change, which is its own PR.
+- [x] **Rendering headings** — help output and generated markdown both group by
+      heading now. Unheaded entries keep the default section and come first, and a
+      heading with nothing visible in it produces no section.
 - [ ] **A mount on the root command** — the spec accepts `mount` only inside a
       `cmd` block, so a CLI whose _top-level_ subcommands are discovered by running
       something cannot say so. Worth deciding whether that is a gap or a deliberate

--- a/PLAN.md
+++ b/PLAN.md
@@ -125,10 +125,12 @@ Each of these is a thing a CLI wants to say that the spec has no way to record.
 Per the canonicality rule the spec gets extended first, so these block the derive
 carrying them rather than being worked around.
 
-- [ ] **`help_heading`** — grouping flags under a heading in help output. clap has
-      it and mise uses it (in `watch`, for its vendored watchexec arguments), and
-      the metadata tree deliberately omits it rather than dropping it silently on
-      the way out.
+- [x] **`help_heading`** — grouping flags under a heading in help output. Now a
+      spec field on both flags and arguments, and the clap bridge no longer drops
+      it, which it had been doing for every CLI that groups its flags.
+- [ ] **Rendering headings** — the spec can express a heading and nothing displays
+      one yet. Grouping flags in help and markdown output needs the docs models and
+      the templates to change, which is its own PR.
 - [ ] **A mount on the root command** — the spec accepts `mount` only inside a
       `cmd` block, so a CLI whose _top-level_ subcommands are discovered by running
       something cannot say so. Worth deciding whether that is a gap or a deliberate

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -18,9 +18,8 @@
 //!
 //! Everything here lowers into the spec without loss, which is deliberate: a
 //! field the spec cannot express would make the emitted KDL a summary rather than
-//! a definition. Grouping flags under a heading in help output is the one thing a
-//! CLI might want that has no spec node today, so it is absent here rather than
-//! quietly dropped on the way out — the spec would have to gain it first.
+//! a definition. When something is missing the spec gains it first —
+//! `help_heading` went in that way.
 //!
 use core::fmt::Write as _;
 
@@ -121,6 +120,9 @@ pub struct FlagMeta<'a> {
     pub overrides: &'a [&'a str],
     /// Flags that make this one unnecessary.
     pub required_unless: &'a [&'a str],
+    /// Heading to list this flag under in help output. Presentational: it groups
+    /// a long flag list into sections and changes nothing about parsing.
+    pub help_heading: Option<&'a str>,
     pub effect: Option<Effect>,
 }
 
@@ -142,6 +144,7 @@ impl FlagMeta<'_> {
         var_max: None,
         overrides: &[],
         required_unless: &[],
+        help_heading: None,
         effect: None,
     };
 }
@@ -162,6 +165,8 @@ pub struct ArgMeta<'a> {
     pub hide: bool,
     pub var_min: Option<usize>,
     pub var_max: Option<usize>,
+    /// Heading to list this argument under in help output.
+    pub help_heading: Option<&'a str>,
 }
 
 impl ArgMeta<'_> {
@@ -177,6 +182,7 @@ impl ArgMeta<'_> {
         hide: false,
         var_min: None,
         var_max: None,
+        help_heading: None,
     };
 }
 
@@ -410,6 +416,9 @@ fn write_flag(out: &mut String, meta: &FlagMeta<'_>, depth: usize) -> core::fmt:
         // name, since that is what a token is matched against.
         write!(out, " negate={}", quoted(&format!("--{negate}")))?;
     }
+    if let Some(heading) = meta.help_heading {
+        write!(out, " help_heading={}", quoted(heading))?;
+    }
     if let Some(effect) = meta.effect {
         write!(out, " effect={}", quoted(effect.as_str()))?;
     }
@@ -493,6 +502,9 @@ fn write_arg(out: &mut String, meta: &ArgMeta<'_>, depth: usize) -> core::fmt::R
             DoubleDash::Optional => unreachable!("excluded by the branch above"),
         };
         write!(out, " double_dash={}", quoted(mode))?;
+    }
+    if let Some(heading) = meta.help_heading {
+        write!(out, " help_heading={}", quoted(heading))?;
     }
     if let Some(env) = meta.env {
         write!(out, " env={}", quoted(env))?;

--- a/conformance/tests/snapshots/spec_roundtrip__the_emitted_spec_is_stable.snap
+++ b/conformance/tests/snapshots/spec_roundtrip__the_emitted_spec_is_stable.snap
@@ -9,7 +9,7 @@ about "does things"
 long_about "Does things, at length."
 default_subcommand "run"
 example "ex a.txt" header="Basic" help="the simplest thing"
-flag "-j --jobs" help="how many jobs, and a quote: \"" global=#true env="EX_JOBS" default="4" {
+flag "-j --jobs" help="how many jobs, and a quote: \"" global=#true help_heading="Performance" env="EX_JOBS" default="4" {
     long_help "More about jobs.\nOn two lines."
     arg "<n>"
 }
@@ -35,7 +35,7 @@ flag "--paths" {
     }
     arg "<path>"
 }
-arg "[file]" help="the file" env="EX_FILE" default="a.txt"
+arg "[file]" help="the file" help_heading="Input" env="EX_FILE" default="a.txt"
 cmd "install" help="install a tool" effect="write" {
     alias "i"
     alias "add" hide=#true

--- a/conformance/tests/spec_roundtrip.rs
+++ b/conformance/tests/spec_roundtrip.rs
@@ -241,6 +241,7 @@ static ROOT_META: CommandMeta = CommandMeta {
             value_name: Some("n"),
             env: Some("EX_JOBS"),
             default: &["4"],
+            help_heading: Some("Performance"),
             ..FlagMeta::EMPTY
         },
         FlagMeta {
@@ -299,6 +300,7 @@ static ROOT_META: CommandMeta = CommandMeta {
         env: Some("EX_FILE"),
         default: &["a.txt"],
         required: false,
+        help_heading: Some("Input"),
         ..ArgMeta::EMPTY
     }],
     subcommands: &[
@@ -522,6 +524,21 @@ fn effects_mounts_restart_tokens_and_examples_survive() {
     let run = spec.cmd.subcommands.get("run").unwrap();
     assert_eq!(run.restart_token.as_deref(), Some(":::"));
     assert_eq!(run.mounts.len(), 1, "run should declare a mount");
+}
+
+#[test]
+fn a_help_heading_survives() {
+    let spec = parsed();
+    let jobs = spec
+        .cmd
+        .flags
+        .iter()
+        .find(|f| f.name == "jobs")
+        .expect("--jobs should be in the spec");
+    assert_eq!(jobs.help_heading.as_deref(), Some("Performance"));
+
+    // Positionals can be grouped too, since the spec field is on both.
+    assert_eq!(spec.cmd.args[0].help_heading.as_deref(), Some("Input"));
 }
 
 #[test]

--- a/docs/spec/reference/arg.md
+++ b/docs/spec/reference/arg.md
@@ -47,6 +47,8 @@ arg "<env>" {
   choices env="DEPLOY_ENVS" // values from $DEPLOY_ENVS, split on commas and/or whitespace
 }
 
+arg "<file>" help_heading="Input" // group this arg under a heading in help output
+
 arg "<file>" long_help="longer help for --help (as oppoosed to -h)"
 
 // double-dash behavior

--- a/docs/spec/reference/flag.md
+++ b/docs/spec/reference/flag.md
@@ -39,6 +39,8 @@ flag "--env <env>" {
   choices env="DEPLOY_ENVS" // values from $DEPLOY_ENVS, split on commas and/or whitespace
 }
 
+flag "--filter <pattern>" help_heading="Filtering" // group this flag under a heading in help output
+
 flag "--file <file>" long_help="longer help for --help (as opposed to -h)"
 // this is equivalent to the above but preferred when a lot of space is needed
 flag "--file <file>" {

--- a/lib/src/docs/cli/mod.rs
+++ b/lib/src/docs/cli/mod.rs
@@ -62,6 +62,60 @@ mod tests {
     use insta::assert_snapshot;
 
     #[test]
+    fn test_render_help_groups_by_heading() {
+        let spec = crate::spec! { r#"
+bin "testcli"
+flag "--verbose" help="Verbose output"
+flag "--filter <pattern>" help="Only matching" help_heading="Filtering"
+flag "--exclude <pattern>" help="Skip matching" help_heading="Filtering"
+flag "--jobs <n>" help="How many at once" help_heading="Performance"
+arg "<file>" help="The file"
+arg "<mode>" help="How to run" help_heading="Behaviour"
+        "# }
+        .unwrap();
+
+        // Unheaded entries keep the default title and come first; each heading
+        // then gets its own section, in the order the headings first appear.
+        assert_snapshot!(render_help(&spec, &spec.cmd, false), @r"
+        Usage: testcli [FLAGS] <file> <mode>
+
+        Arguments:
+          <file>  The file
+
+        Behaviour:
+          <mode>  How to run
+
+        Flags:
+          --verbose  Verbose output
+
+        Filtering:
+          --filter <pattern>  Only matching
+          --exclude <pattern>  Skip matching
+
+        Performance:
+          --jobs <n>  How many at once
+        ");
+    }
+
+    #[test]
+    fn test_render_help_with_only_headed_flags() {
+        // No default section when nothing lands in it: a CLI that gives every
+        // flag a heading should not get an empty "Flags:".
+        let spec = crate::spec! { r#"
+bin "testcli"
+flag "--filter <pattern>" help="Only matching" help_heading="Filtering"
+        "# }
+        .unwrap();
+
+        assert_snapshot!(render_help(&spec, &spec.cmd, false), @r"
+        Usage: testcli [--filter <pattern>]
+
+        Filtering:
+          --filter <pattern>  Only matching
+        ");
+    }
+
+    #[test]
     fn test_render_help_with_env() {
         let spec = crate::spec! { r#"
 bin "testcli"

--- a/lib/src/docs/cli/templates/spec_template_long.tera
+++ b/lib/src/docs/cli/templates/spec_template_long.tera
@@ -33,10 +33,10 @@ Commands:
     Print this message or the help of the given subcommand(s)
 {%- endif %}
 
-{%- if cmd.args %}
+{%- for group in cmd.arg_groups %}
 
-Arguments:
-{%- for arg in cmd.args %}
+{{ group.heading | default(value="Arguments") }}:
+{%- for arg in group.items %}
 {%- if arg.help_rendered %}
   {{ arg.usage | ljust(width=arg.usage_col_width) }}  {{ arg.help_rendered }}
 {%- if arg.help_is_multiline %}
@@ -62,12 +62,12 @@ Arguments:
     (default: {{ arg.default | join(sep=", ") }})
 {%- endif %}
 {%- endfor %}
-{%- endif %}
+{%- endfor %}
 
-{%- if cmd.flags %}
+{%- for group in cmd.flag_groups %}
 
-Flags:
-{%- for flag in cmd.flags %}
+{{ group.heading | default(value="Flags") }}:
+{%- for flag in group.items %}
 {%- if flag.help_rendered %}
   {{ flag.display_usage | ljust(width=flag.usage_col_width) }}  {{ flag.help_rendered }}
 {%- if flag.help_is_multiline %}
@@ -91,7 +91,7 @@ Flags:
     [env: {{ flag.env }}]
 {%- endif %}
 {%- endfor %}
-{%- endif %}
+{%- endfor %}
 
 {%- if cmd.examples %}
 

--- a/lib/src/docs/cli/templates/spec_template_short.tera
+++ b/lib/src/docs/cli/templates/spec_template_short.tera
@@ -23,10 +23,10 @@ Commands:
   help  Print this message or the help of the given subcommand(s)
 {%- endif %}
 
-{%- if cmd.args %}
+{%- for group in cmd.arg_groups %}
 
-Arguments:
-{%- for arg in cmd.args %}
+{{ group.heading | default(value="Arguments") }}:
+{%- for arg in group.items %}
   {{ arg.usage | trim }}
 {%- if arg.help %}  {{ arg.help }}{%- endif %}
 {%- if arg.choices and arg.choices.choices %} [{{ arg.choices.choices | join(sep=", ") }}]{%- endif %}
@@ -34,12 +34,12 @@ Arguments:
 {%- if arg.env %} [env: {{ arg.env }}]{%- endif %}
 {%- if arg.default %} (default: {{ arg.default | join(sep=", ") }}){%- endif %}
 {%- endfor %}
-{%- endif %}
+{%- endfor %}
 
-{%- if cmd.flags %}
+{%- for group in cmd.flag_groups %}
 
-Flags:
-{%- for flag in cmd.flags %}
+{{ group.heading | default(value="Flags") }}:
+{%- for flag in group.items %}
   {{ flag.display_usage | trim }}
 {%- if flag.aliases %}  [aliases: {{ flag.aliases | join(sep=", ") }}]{% endif %}
 {%- if flag.help %}  {{ flag.help }}{%- endif %}
@@ -47,7 +47,7 @@ Flags:
 {%- if flag.arg.choices and flag.arg.choices.env %} [choices env: {{ flag.arg.choices.env }}]{%- endif %}
 {%- if flag.env %} [env: {{ flag.env }}]{%- endif %}
 {%- endfor %}
-{%- endif %}
+{%- endfor %}
 
 {%- if cmd.examples %}
 

--- a/lib/src/docs/markdown/cmd.rs
+++ b/lib/src/docs/markdown/cmd.rs
@@ -167,4 +167,51 @@ cmd "version" help="Show the version"
         Show the version
         ");
     }
+
+    #[test]
+    fn test_render_markdown_groups_by_heading() {
+        let spec: Spec = r#"
+bin "mycli"
+flag "--verbose" help="Verbose output"
+flag "--filter <pattern>" help="Only matching" help_heading="Filtering"
+flag "--hidden-one" help="Not shown" help_heading="Filtering" hide=#true
+arg "<file>" help="The file"
+arg "<mode>" help="How to run" help_heading="Behaviour"
+"#
+        .parse()
+        .unwrap();
+        let ctx = MarkdownRenderer::new(spec.clone()).with_multi(true);
+
+        // Each heading becomes its own section, hidden entries stay out, and a
+        // heading whose every entry is hidden produces no section at all.
+        assert_snapshot!(ctx.render_cmd(&spec.cmd).unwrap(), @"
+        # `mycli`
+
+        - **Usage**: `mycli [--verbose] [--filter <pattern>] <file> <mode>`
+
+        ## Arguments
+
+        ### `<file>`
+
+        The file
+
+        ## Behaviour
+
+        ### `<mode>`
+
+        How to run
+
+        ## Flags
+
+        ### `--verbose`
+
+        Verbose output
+
+        ## Filtering
+
+        ### `--filter <pattern>`
+
+        Only matching
+        ");
+    }
 }

--- a/lib/src/docs/markdown/cmd.rs
+++ b/lib/src/docs/markdown/cmd.rs
@@ -214,4 +214,48 @@ arg "<mode>" help="How to run" help_heading="Behaviour"
         Only matching
         ");
     }
+
+    #[test]
+    fn test_render_markdown_groups_global_flags_too() {
+        // Global flags are rendered in their own section, which used to come from
+        // the flat list and so ignored headings that help output honored.
+        let spec: Spec = r#"
+bin "mycli"
+flag "--verbose" help="Verbose output" global=#true
+flag "--filter <pattern>" help="Only matching" help_heading="Filtering" global=#true
+flag "--local-one" help="Not global"
+cmd "sub" help="a subcommand"
+"#
+        .parse()
+        .unwrap();
+        let ctx = MarkdownRenderer::new(spec.clone()).with_multi(true);
+
+        assert_snapshot!(ctx.render_cmd(&spec.cmd).unwrap(), @"
+        # `mycli`
+
+        - **Usage**: `mycli [FLAGS] <SUBCOMMAND>`
+
+        ## Global Flags
+
+        ### `--verbose`
+
+        Verbose output
+
+        ## Filtering
+
+        ### `--filter <pattern>`
+
+        Only matching
+
+        ## Flags
+
+        ### `--local-one`
+
+        Not global
+
+        ## Subcommands
+
+        - [`mycli sub`](/sub.md)
+        ");
+    }
 }

--- a/lib/src/docs/markdown/templates/cmd_template.md.tera
+++ b/lib/src/docs/markdown/templates/cmd_template.md.tera
@@ -34,16 +34,19 @@
 {%- set global_flags = [] %}
 {%- endif %}
 
-{%- if args %}
+{%- for arg_group in cmd.arg_groups %}
+{%- set group_args = arg_group.items | filter(attribute="hide", value=false) %}
+{%- if group_args %}
 
-{{ "#" | repeat(count=header_level) }}# Arguments
+{{ "#" | repeat(count=header_level) }}# {{ arg_group.heading | default(value="Arguments") }}
 
-{%- for arg in args %}
+{%- for arg in group_args %}
 
 {{ "#" | repeat(count=header_level) }}## `{{ arg.usage }}`
 {%- include "arg_template.md.tera" %}
 {%- endfor %}
 {%- endif %}
+{%- endfor %}
 
 {%- if global_flags %}
 
@@ -56,16 +59,23 @@
 {%- endfor %}
 {%- endif %}
 
-{%- if local_flags %}
+{%- for flag_group in cmd.flag_groups %}
+{%- set visible = flag_group.items | filter(attribute="hide", value=false) %}
+{%- set group_flags = visible | filter(attribute="global", value=false) %}
+{%- if not cmd.subcommands %}
+{%- set group_flags = visible %}
+{%- endif %}
+{%- if group_flags %}
 
-{{ "#" | repeat(count=header_level) }}# Flags
+{{ "#" | repeat(count=header_level) }}# {{ flag_group.heading | default(value="Flags") }}
 
-{%- for flag in local_flags %}
+{%- for flag in group_flags %}
 
 {{ "#" | repeat(count=header_level) }}## `{{ flag.usage }}`
 {%- include "flag_template.md.tera" %}
 {%- endfor %}
 {%- endif %}
+{%- endfor %}
 
 {%- if cmd.examples %}
 

--- a/lib/src/docs/markdown/templates/cmd_template.md.tera
+++ b/lib/src/docs/markdown/templates/cmd_template.md.tera
@@ -48,16 +48,22 @@
 {%- endif %}
 {%- endfor %}
 
-{%- if global_flags %}
+{%- for flag_group in cmd.flag_groups %}
+{%- set visible = flag_group.items | filter(attribute="hide", value=false) %}
+{%- set group_globals = visible | filter(attribute="global", value=true) %}
+{#- A heading beats the default title, so a grouped global flag lands in the same
+    section it does in help output rather than in a generic "Global Flags". #}
+{%- if cmd.subcommands and group_globals %}
 
-{{ "#" | repeat(count=header_level) }}# Global Flags
+{{ "#" | repeat(count=header_level) }}# {{ flag_group.heading | default(value="Global Flags") }}
 
-{%- for flag in global_flags %}
+{%- for flag in group_globals %}
 
 {{ "#" | repeat(count=header_level) }}## `{{ flag.usage }}`
 {%- include "flag_template.md.tera" %}
 {%- endfor %}
 {%- endif %}
+{%- endfor %}
 
 {%- for flag_group in cmd.flag_groups %}
 {%- set visible = flag_group.items | filter(attribute="hide", value=false) %}

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -37,6 +37,10 @@ pub struct SpecCommand {
     pub subcommands: IndexMap<String, SpecCommand>,
     pub args: Vec<SpecArg>,
     pub flags: Vec<SpecFlag>,
+    /// `flags`, partitioned by `help_heading`. Same flags, same order.
+    pub flag_groups: Vec<Group<SpecFlag>>,
+    /// `args`, partitioned by `help_heading`.
+    pub arg_groups: Vec<Group<SpecArg>>,
     // pub mounts: Vec<SpecMount>,
     pub deprecated: Option<String>,
     pub effect: Option<SpecCommandEffect>,
@@ -84,11 +88,49 @@ pub struct SpecFlag {
     pub default: Vec<String>,
     pub negate: Option<String>,
     pub env: Option<String>,
+    pub help_heading: Option<String>,
     pub rendered: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub help_rendered: Option<String>,
     pub help_is_multiline: bool,
     pub usage_col_width: usize,
+}
+
+/// Flags or arguments that share a heading, in the order the headings first
+/// appear.
+///
+/// Grouping happens here rather than in a template because the template language
+/// cannot do it: Tera can filter by an attribute's value but not partition on one,
+/// and "everything without a heading" is not expressible as a filter. The
+/// ungrouped entries come first with `heading` unset, which is what a renderer
+/// shows under its default title.
+#[derive(Debug, Default, Serialize, Clone)]
+pub struct Group<T> {
+    pub heading: Option<String>,
+    pub items: Vec<T>,
+}
+
+/// Partition by heading, keeping declaration order within each group and putting
+/// the unheaded entries first.
+fn group_by_heading<T: Clone>(
+    items: &[T],
+    heading_of: impl Fn(&T) -> Option<&str>,
+) -> Vec<Group<T>> {
+    let mut groups: Vec<Group<T>> = Vec::new();
+    // The unheaded group exists only if something lands in it, so a CLI that
+    // gives every flag a heading does not render an empty default section.
+    for item in items {
+        let heading = heading_of(item).map(|h| h.to_string());
+        match groups.iter_mut().find(|g| g.heading == heading) {
+            Some(group) => group.items.push(item.clone()),
+            None => groups.push(Group {
+                heading,
+                items: vec![item.clone()],
+            }),
+        }
+    }
+    groups.sort_by_key(|g| g.heading.is_some());
+    groups
 }
 
 #[derive(Debug, Default, Serialize, Clone)]
@@ -116,6 +158,7 @@ pub struct SpecArg {
     pub default: Vec<String>,
     pub choices: Option<SpecChoices>,
     pub env: Option<String>,
+    pub help_heading: Option<String>,
     pub rendered: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub help_rendered: Option<String>,
@@ -249,6 +292,8 @@ impl From<&crate::SpecCommand> for SpecCommand {
                 .iter()
                 .map(|(k, v)| (k.clone(), SpecCommand::from(v)))
                 .collect(),
+            flag_groups: group_by_heading(&flags, |f| f.help_heading.as_deref()),
+            arg_groups: group_by_heading(&args, |a| a.help_heading.as_deref()),
             args,
             flags,
             deprecated: deprecated.clone(),
@@ -302,6 +347,7 @@ impl From<&crate::SpecFlag> for SpecFlag {
             default: flag.default.clone(),
             negate: flag.negate.clone(),
             env: flag.env.clone(),
+            help_heading: flag.help_heading.clone(),
             rendered: false,
             help_rendered: None,
             help_is_multiline: false,
@@ -339,6 +385,7 @@ impl From<&crate::SpecArg> for SpecArg {
             default: arg.default.clone(),
             choices: arg.choices.clone(),
             env: arg.env.clone(),
+            help_heading: arg.help_heading.clone(),
             rendered: false,
             help_rendered: None,
             help_is_multiline: false,
@@ -402,9 +449,21 @@ impl SpecCommand {
         for example in &mut self.examples {
             example.render_md(renderer);
         }
+        // Regroup from the freshly rendered lists. The groups hold clones, so
+        // grouping before this point would publish copies without their rendered
+        // markdown — which is exactly what happened the first time.
+        self.regroup();
         for cmd in self.subcommands.values_mut() {
             cmd.render_md(renderer);
         }
+    }
+
+    /// Rebuild the grouped views from `flags` and `args`.
+    ///
+    /// Anything that mutates either list has to call this, or the groups go stale.
+    fn regroup(&mut self) {
+        self.flag_groups = group_by_heading(&self.flags, |f| f.help_heading.as_deref());
+        self.arg_groups = group_by_heading(&self.args, |a| a.help_heading.as_deref());
     }
 }
 

--- a/lib/src/spec/arg.rs
+++ b/lib/src/spec/arg.rs
@@ -89,6 +89,10 @@ pub struct SpecArg {
     /// Environment variable that can provide this argument's value
     #[serde(skip_serializing_if = "Option::is_none")]
     pub env: Option<String>,
+    /// Heading this argument is listed under in help output. Presentational only,
+    /// like the flag field of the same name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub help_heading: Option<String>,
 }
 
 impl SpecArg {
@@ -124,6 +128,7 @@ impl SpecArg {
                     }
                 }
                 "env" => arg.env = v.ensure_string().map(Some)?,
+                "help_heading" => arg.help_heading = v.ensure_string().map(Some)?,
                 k => bail_parse!(ctx, v.entry.span(), "unsupported arg key {k}"),
             }
         }
@@ -146,6 +151,9 @@ impl SpecArg {
                     }
                 }
                 "env" => arg.env = child.arg(0)?.ensure_string().map(Some)?,
+                "help_heading" => {
+                    arg.help_heading = child.arg(0)?.ensure_string().map(Some)?;
+                }
                 "default" => {
                     // Support both single value and multiple values
                     // default "bar"            -> vec!["bar"]
@@ -258,6 +266,9 @@ impl From<&SpecArg> for KdlNode {
         }
         if let Some(env) = &arg.env {
             node.push(string_entry(Some("env"), env));
+        }
+        if let Some(help_heading) = &arg.help_heading {
+            node.push(string_entry(Some("help_heading"), help_heading));
         }
         if let Some(effect) = &arg.effect {
             node.push(string_entry(Some("effect"), effect.as_str()));
@@ -373,6 +384,7 @@ impl From<&clap::Arg> for SpecArg {
             choices: None,
             effect: None,
             env: None,
+            help_heading: arg.get_help_heading().map(|s| s.to_string()),
         };
         if !choices.is_empty() {
             arg.choices = Some(SpecChoices {

--- a/lib/src/spec/builder.rs
+++ b/lib/src/spec/builder.rs
@@ -248,6 +248,12 @@ impl SpecFlagBuilder {
     }
 
     /// Set environment variable name
+    /// Heading to list this under in help output.
+    pub fn help_heading(mut self, help_heading: impl Into<String>) -> Self {
+        self.inner.help_heading = Some(help_heading.into());
+        self
+    }
+
     pub fn env(mut self, env: impl Into<String>) -> Self {
         self.inner.env = Some(env.into());
         self
@@ -387,6 +393,12 @@ impl SpecArgBuilder {
     }
 
     /// Set environment variable name
+    /// Heading to list this under in help output.
+    pub fn help_heading(mut self, help_heading: impl Into<String>) -> Self {
+        self.inner.help_heading = Some(help_heading.into());
+        self
+    }
+
     pub fn env(mut self, env: impl Into<String>) -> Self {
         self.inner.env = Some(env.into());
         self

--- a/lib/src/spec/flag.rs
+++ b/lib/src/spec/flag.rs
@@ -101,6 +101,14 @@ pub struct SpecFlag {
     /// Environment variable that can set this flag's value
     #[serde(skip_serializing_if = "Option::is_none")]
     pub env: Option<String>,
+    /// Heading this flag is listed under in help output.
+    ///
+    /// Purely presentational: it groups a long flag list into sections rather
+    /// than changing how anything parses. A CLI with dozens of flags — mise
+    /// groups its `watch` passthrough arguments this way — is unreadable without
+    /// it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub help_heading: Option<String>,
 }
 
 impl SpecFlag {
@@ -157,6 +165,7 @@ impl SpecFlag {
                     }
                 }
                 "env" => flag.env = v.ensure_string().map(Some)?,
+                "help_heading" => flag.help_heading = v.ensure_string().map(Some)?,
                 k => bail_parse!(ctx, v.entry.span(), "unsupported flag key {k}"),
             }
         }
@@ -234,6 +243,9 @@ impl SpecFlag {
                     }
                 }
                 "env" => flag.env = child.arg(0)?.ensure_string().map(Some)?,
+                "help_heading" => {
+                    flag.help_heading = child.arg(0)?.ensure_string().map(Some)?;
+                }
                 "overrides" => {
                     flag.overrides = child
                         .ensure_arg_len(1..)?
@@ -380,6 +392,9 @@ impl From<&SpecFlag> for KdlNode {
         }
         if let Some(env) = &flag.env {
             node.push(string_entry(Some("env"), env));
+        }
+        if let Some(help_heading) = &flag.help_heading {
+            node.push(string_entry(Some("help_heading"), help_heading));
         }
         if let Some(effect) = &flag.effect {
             node.push(string_entry(Some("effect"), effect.as_str()));
@@ -558,6 +573,7 @@ impl From<&clap::Arg> for SpecFlag {
             // spec (see the effect docs).
             effect: None,
             env: None,
+            help_heading: c.get_help_heading().map(|s| s.to_string()),
         };
         if c.is_allow_hyphen_values_set() {
             if let Some(arg) = &mut flag.arg {
@@ -683,6 +699,62 @@ mod tests {
             vec!["--keep".to_string(), "--dry-run".to_string()]
         );
         assert_eq!(flag.help_long.as_deref(), Some("Colored.\u{1b}[0m Text."));
+    }
+
+    #[test]
+    fn help_heading_round_trips() {
+        // Both spellings: a property, and a child node for when the text is long.
+        let spec: Spec = r#"
+flag "--filter <pattern>" help_heading="Filtering"
+flag "--exclude <pattern>" {
+  help_heading "Filtering"
+}
+arg "<file>" help_heading="Input"
+"#
+        .parse()
+        .unwrap();
+        assert_eq!(spec.cmd.flags[0].help_heading.as_deref(), Some("Filtering"));
+        assert_eq!(spec.cmd.flags[1].help_heading.as_deref(), Some("Filtering"));
+        assert_eq!(spec.cmd.args[0].help_heading.as_deref(), Some("Input"));
+
+        // And it survives being written back out.
+        let reparsed: Spec = spec.to_string().parse().unwrap();
+        assert_eq!(
+            reparsed.cmd.flags[0].help_heading.as_deref(),
+            Some("Filtering")
+        );
+        assert_eq!(reparsed.cmd.args[0].help_heading.as_deref(), Some("Input"));
+    }
+
+    #[cfg(feature = "clap")]
+    #[test]
+    fn help_heading_comes_across_from_clap() {
+        // clap has had help_heading for years and the bridge was dropping it, so
+        // a CLI that grouped its flags lost the grouping on the way into a spec.
+        let cmd = clap::Command::new("ex")
+            .arg(
+                clap::Arg::new("filter")
+                    .long("filter")
+                    .help_heading("Filtering"),
+            )
+            .arg(clap::Arg::new("plain").long("plain"));
+        let spec: Spec = (&cmd).into();
+
+        let filter = spec
+            .cmd
+            .flags
+            .iter()
+            .find(|f| f.name == "filter")
+            .expect("--filter should be in the spec");
+        assert_eq!(filter.help_heading.as_deref(), Some("Filtering"));
+
+        let plain = spec
+            .cmd
+            .flags
+            .iter()
+            .find(|f| f.name == "plain")
+            .expect("--plain should be in the spec");
+        assert_eq!(plain.help_heading, None);
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #801 — review that first; this PR's diff will include it until it merges.

Closes the gap #801 turned up: writing the spec emitter, I reached for `help_heading` and found the spec has no such field.

## Why it matters more than it looks

A CLI with dozens of flags is unreadable without sections, and clap has had `help_heading` for years. Because the spec could not record one, **`From<&clap::Arg>` was silently dropping it** — so every CLI in the fleet that groups its flags has been losing the grouping on the way into its spec. mise groups its entire `watch` passthrough set that way (31 uses, all in one file).

That is the part worth noting: this was not a missing feature so much as a leak that was invisible because nothing downstream could have shown it.

## The spec side

- `help_heading` on `SpecFlag` and `SpecArg`, as a property (`help_heading="Filtering"`) or a child node for longer text, written back out.
- Mapped from clap's `get_help_heading()` for both flags and positionals.
- Builder setters, docs in the flag and arg references, tests for the round trip and the clap conversion.
- `usage-argv` carries it in both `FlagMeta` and `ArgMeta`, which is what prompted this: the derive cannot emit what the spec cannot express, so per the canonicality rule the spec went first.

## The rendering side

Help output and generated markdown both group by heading now — a field nothing displays is half a feature.

Grouping happens in the docs models, not in a template: Tera can filter on an attribute's *value* but cannot partition on one, and "everything without a heading" is not expressible as a filter. Behaviour:

- Unheaded entries keep the default section title (`Flags:` / `Arguments:`) and come **first**.
- Each heading gets its own section, in the order the headings first appear.
- A heading with nothing *visible* in it produces no section, and a CLI that heads every flag gets no empty `Flags:`.
- Positionals group too, since the spec field is on both.

One thing worth knowing if you touch this: the groups hold clones, and `render_md` mutates the flag and arg lists *after* the model is built — so grouping at construction published copies without their rendered markdown. That cost me a debugging round; groups are rebuilt at the end of `render_md` and the method that does it says why.

**Every existing snapshot is unchanged** — output is byte-identical when nothing has a heading — and four new ones cover the grouped case across both renderers, including hidden entries. `mise run render` produces no diff.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentational metadata and docs/help rendering only; parsing behavior is unchanged and output without headings remains identical.
> 
> **Overview**
> Adds **`help_heading`** to flags and positionals in the usage spec (KDL parse/serialize, builders, reference docs) and threads it through **`usage-argv`** metadata and KDL emission so derive output can record section titles losslessly.
> 
> **Clap bridge fix:** `From<&clap::Arg>` now maps `get_help_heading()`, so grouped flags are no longer dropped when converting to a spec.
> 
> **Rendering:** CLI help (short/long templates) and generated markdown partition flags and args by heading via `flag_groups` / `arg_groups` in the docs models. Unheaded items stay under default **Arguments** / **Flags** and appear first; custom headings follow in first-seen order; sections with only hidden entries are omitted. Markdown regroups after `render_md` so grouped clones keep rendered help text.
> 
> Conformance roundtrip tests and new snapshot tests cover grouped help and global flags; existing output stays byte-identical when no headings are set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da412c73921f96714b8cdcf0cfd492228d086eef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable help headings for flags and arguments.
  * Help and Markdown output now groups entries under their headings while preserving declaration order.
  * Empty sections and hidden entries are omitted from generated documentation.
  * Global and local flags are displayed in separate grouped sections.
* **Documentation**
  * Added specification examples and reference documentation for configuring help headings.
* **Bug Fixes**
  * Improved consistency between generated help output and Markdown documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->