### PR TITLE
feat(derive): compile a struct into parse tables and a spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2018,7 +2018,18 @@ dependencies = [
  "serde",
  "serde_json",
  "usage-argv",
+ "usage-derive",
  "usage-lib",
+]
+
+[[package]]
+name = "usage-derive"
+version = "5.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "usage-argv",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "argv",
+    "derive",
     "clap_usage",
     "cli",
     "conformance",
@@ -19,6 +20,7 @@ license = "MIT"
 clap_usage = { path = "./clap_usage", version = "5.0.0" }
 usage-cli = { path = "./cli" }
 usage-argv = { path = "./argv", version = "5.1.0" }
+usage-derive = { path = "./derive" }
 usage-lib = { path = "./lib", version = "5.1.0", features = ["clap"] }
 
 [workspace.metadata.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ license = "MIT"
 clap_usage = { path = "./clap_usage", version = "5.0.0" }
 usage-cli = { path = "./cli" }
 usage-argv = { path = "./argv", version = "5.1.0" }
-usage-derive = { path = "./derive" }
+usage-derive = { path = "./derive", version = "5.1.0" }
 usage-lib = { path = "./lib", version = "5.1.0", features = ["clap"] }
 
 [workspace.metadata.release]

--- a/PLAN.md
+++ b/PLAN.md
@@ -107,9 +107,17 @@ manpages, and SDKs — never a runtime dependency of somebody else's program.
       no dependencies. Verified by parsing the output back with usage-lib and
       checking the resulting spec field by field, then rendering it through the
       markdown and manpage generators an adopter's docs build actually uses.
-- [ ] **`usage-derive` v0** — flags, positionals, subcommands, doc-comment help
-      (first paragraph short, whole block long), spec emission. Usage-native
-      attributes mirroring the KDL vocabulary rather than a clap dialect.
+- [x] **`usage-derive` v0** — flags, positionals, doc-comment help (first
+      paragraph short, whole block long), and spec emission, from usage-native
+      attributes. Unsupported field types are a compile error rather than a
+      surprise, and the messages point at the offending field.
+- [ ] **Subcommands in the derive** — one command per struct today. Needs an enum
+      of variants, cross-type table references, and a nested command path through
+      the parse function.
+- [ ] **Typed values** — fields are text today (`String`, `Option<String>`,
+      `Vec<String>`, `bool`, counting integers). Parsing into other types needs an
+      error type for value conversion, which is also where `env`, required-ness,
+      and `choices` get enforced — see the post-binding layer below.
 - [ ] **`usage-derive` v1** — everything mise needs: constraints
       (`requires`/`conflicts`/`overrides`/`required_unless`), `var`, `count`,
       `env`, defaults, delimiters, the `double_dash` modes, global flags, flatten,

--- a/PLAN.md
+++ b/PLAN.md
@@ -89,8 +89,9 @@ manpages, and SDKs — never a runtime dependency of somebody else's program.
       allocations on success _and_ failure, proved by a counting allocator rather
       than asserted. Answers the binding vectors, including every one where
       usage-lib diverges from the grammar.
-- [x] **Released on the shared version** (#798) — an ordinary member of the
-      workspace rather than a 0.0.0 curiosity outside the release cycle.
+- [x] **Released on the shared version** (#798, #803) — `usage-argv` and
+      `usage-derive` are ordinary members of the workspace at the shared version
+      rather than 0.0.0 curiosities outside the release cycle.
 - [x] **Repeatable vs. variadic flags, and `double_dash_seen`** (#799) — a
       repeatable flag was greedy enough to eat a positional, and `automatic` mode
       reported a separator nobody typed.

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -19,6 +19,7 @@ usage-lib = { workspace = true }
 
 [dev-dependencies]
 insta = "1"
+usage-derive = { workspace = true }
 
 [[bin]]
 name = "oracle"

--- a/conformance/tests/derive.rs
+++ b/conformance/tests/derive.rs
@@ -95,6 +95,58 @@ fn flags_bind_in_every_form() {
     assert_eq!(ex.file, "x.txt");
 }
 
+/// The distinction #799 fixed in the harness, now pinned in the derive: a
+/// repeatable flag takes one value per occurrence, and must not swallow the word
+/// after it. My first version of this derive got it wrong, and the original test
+/// missed it by always writing `--include` twice.
+#[derive(Cli)]
+struct Repeat {
+    /// Patterns, one per occurrence
+    #[usage(long, var)]
+    include: Vec<String>,
+    /// Patterns, several at once
+    #[usage(long, variadic)]
+    exclude: Vec<String>,
+    /// Where to work
+    target: String,
+}
+
+#[test]
+fn a_repeatable_flag_leaves_the_next_word_alone() {
+    let a = argv(["--include", "a", "b"]);
+    let cli = Repeat::parse_from(&a).expect("should parse");
+    assert_eq!(cli.include, ["a"], "one value per occurrence");
+    assert_eq!(cli.target, "b", "the next word is still the positional's");
+}
+
+#[test]
+fn a_variadic_flag_takes_several_values() {
+    let a = argv(["--exclude", "a", "b", "--", "t"]);
+    let cli = Repeat::parse_from(&a).expect("should parse");
+    assert_eq!(cli.exclude, ["a", "b"], "greedy until the separator");
+    assert_eq!(cli.target, "t");
+}
+
+#[test]
+fn a_repeatable_flag_still_repeats() {
+    let a = argv(["--include", "a", "--include=b", "t"]);
+    let cli = Repeat::parse_from(&a).expect("should parse");
+    assert_eq!(cli.include, ["a", "b"]);
+    assert_eq!(cli.target, "t");
+}
+
+#[test]
+fn a_count_saturates_rather_than_overflowing() {
+    // A `u8` given more than 255 occurrences would otherwise panic in debug and
+    // wrap to zero in release.
+    let tokens = vec!["-v"; 300];
+    let raw: Vec<&OsStr> = tokens.iter().map(|t| OsStr::new(*t)).collect();
+    let mut with_file = raw.clone();
+    with_file.push(OsStr::new("x.txt"));
+    let ex = Ex::parse_from(&with_file).expect("should parse");
+    assert_eq!(ex.verbose, u8::MAX);
+}
+
 #[test]
 fn a_hidden_flag_still_works() {
     // Hidden means absent from help and docs, not unusable.

--- a/conformance/tests/derive.rs
+++ b/conformance/tests/derive.rs
@@ -413,6 +413,61 @@ fn an_explicit_long_may_be_written_with_dashes() {
     assert_eq!(color.negate.as_deref(), Some("--no-color"));
 }
 
+/// Field names that collide with everything the generated code needs. A parser
+/// people actually use will meet a field called `text` or `argv` eventually.
+#[derive(Cli)]
+struct Hostile {
+    /// A field named after a helper
+    #[usage(long)]
+    text: bool,
+    /// And another
+    #[usage(long)]
+    value_text: bool,
+    /// And the parser itself
+    #[usage(long)]
+    parser: bool,
+    /// And the input
+    #[usage(long)]
+    argv: bool,
+    /// And the loop variable
+    #[usage(long)]
+    event: bool,
+    /// And the raw args
+    raw: String,
+}
+
+#[test]
+fn field_names_cannot_collide_with_generated_code() {
+    let a = argv(["--text", "--parser", "--event", "x"]);
+    let cli = Hostile::parse_from(&a).expect("should parse");
+    assert!(cli.text);
+    assert!(cli.parser);
+    assert!(cli.event);
+    assert!(!cli.value_text);
+    assert!(!cli.argv);
+    assert_eq!(cli.raw, "x");
+}
+
+/// A CamelCase struct name becomes a kebab-case command name, since that is what a
+/// CLI is called on a command line.
+#[derive(Cli)]
+struct MyLittleCli {
+    /// What to do
+    target: String,
+}
+
+#[test]
+fn a_camel_case_struct_name_is_kebab_cased() {
+    let spec: LibSpec = MyLittleCli::to_kdl().parse().expect("valid spec");
+    assert_eq!(spec.name, "my-little-cli");
+    assert_eq!(spec.bin, "my-little-cli");
+
+    // And it still parses, so the field is not just decoration.
+    let a = argv(["something"]);
+    let cli = MyLittleCli::parse_from(&a).expect("should parse");
+    assert_eq!(cli.target, "something");
+}
+
 #[test]
 fn reaching_the_tables_is_free() {
     // The point of the whole exercise: `command()` hands back a `static`, so there

--- a/conformance/tests/derive.rs
+++ b/conformance/tests/derive.rs
@@ -1,0 +1,270 @@
+//! Checks what the derive generates, end to end.
+//!
+//! Two claims are worth testing, and they are different claims. First, a derived
+//! CLI parses a command line the way [the grammar] says — which is really a test
+//! that the derive emits the tables it meant to. Second, the *same* declaration
+//! emits a spec that usage-lib accepts, so one Rust type is enough to get docs,
+//! manpages, and completions.
+//!
+//! [the grammar]: https://usage.jdx.dev/spec/argv
+
+use std::ffi::OsStr;
+
+use usage::Spec as LibSpec;
+use usage_derive::Cli;
+
+/// A tool that does things
+///
+/// With a second paragraph, so the long help differs from the short.
+#[derive(Cli, Debug)]
+#[usage(bin = "ex", version = "1.2.3")]
+struct Ex {
+    /// How many jobs to run at once
+    ///
+    /// Longer prose about jobs.
+    #[usage(
+        short = 'j',
+        long,
+        env = "EX_JOBS",
+        default = "4",
+        help_heading = "Performance"
+    )]
+    jobs: Option<String>,
+
+    /// Print more
+    #[usage(short = 'v', long, count)]
+    verbose: u8,
+
+    /// Colorize output
+    #[usage(long, negate = "--no-color", default = "true")]
+    color: bool,
+
+    /// Overwrite what is there
+    #[usage(short = 'f', long)]
+    force: bool,
+
+    /// Patterns to include
+    #[usage(long, var)]
+    include: Vec<String>,
+
+    /// An option nobody should see
+    #[usage(long, hide)]
+    secret: bool,
+
+    /// The file to work on
+    file: String,
+
+    /// Anything else
+    rest: Vec<String>,
+}
+
+fn argv<const N: usize>(tokens: [&str; N]) -> [&OsStr; N] {
+    tokens.map(OsStr::new)
+}
+
+#[test]
+fn defaults_apply_when_the_command_line_is_empty() {
+    let a = argv(["x.txt"]);
+    let ex = Ex::parse_from(&a).expect("should parse");
+    assert_eq!(ex.jobs.as_deref(), Some("4"), "the declared default");
+    assert!(ex.color, "a negatable flag starts at its default");
+    assert!(!ex.force);
+    assert_eq!(ex.verbose, 0);
+    assert_eq!(ex.file, "x.txt");
+    assert!(ex.rest.is_empty());
+    assert!(!ex.secret, "a hidden flag still parses like any other");
+}
+
+#[test]
+fn flags_bind_in_every_form() {
+    // Attached short, bundled shorts, attached long, and a repeated flag.
+    let a = argv([
+        "-j8",
+        "-fv",
+        "--include",
+        "a",
+        "--include=b",
+        "-vv",
+        "x.txt",
+    ]);
+    let ex = Ex::parse_from(&a).expect("should parse");
+    assert_eq!(ex.jobs.as_deref(), Some("8"));
+    assert!(ex.force);
+    assert_eq!(ex.verbose, 3, "-v once and -vv again");
+    assert_eq!(ex.include, ["a", "b"]);
+    assert_eq!(ex.file, "x.txt");
+}
+
+#[test]
+fn a_hidden_flag_still_works() {
+    // Hidden means absent from help and docs, not unusable.
+    let a = argv(["--secret", "x.txt"]);
+    let ex = Ex::parse_from(&a).expect("should parse");
+    assert!(ex.secret);
+}
+
+#[test]
+fn a_negation_turns_a_default_off() {
+    let a = argv(["--no-color", "x.txt"]);
+    let ex = Ex::parse_from(&a).expect("should parse");
+    assert!(!ex.color);
+}
+
+#[test]
+fn positionals_fill_in_order_and_the_variadic_takes_the_rest() {
+    let a = argv(["one", "two", "three"]);
+    let ex = Ex::parse_from(&a).expect("should parse");
+    assert_eq!(ex.file, "one");
+    assert_eq!(ex.rest, ["two", "three"]);
+}
+
+#[test]
+fn a_typo_is_reported_rather_than_bound() {
+    let a = argv(["--forse", "x.txt"]);
+    let err = Ex::parse_from(&a).expect_err("an unknown flag should not parse");
+    assert!(
+        matches!(err, usage_argv::Error::UnknownFlag { token } if token == b"--forse"),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn everything_after_a_separator_is_a_value() {
+    let a = argv(["--", "--not-a-flag", "-x"]);
+    let ex = Ex::parse_from(&a).expect("should parse");
+    assert_eq!(ex.file, "--not-a-flag");
+    assert_eq!(ex.rest, ["-x"]);
+}
+
+#[test]
+fn the_spec_is_valid_and_says_what_was_declared() {
+    let kdl = Ex::to_kdl();
+    let spec: LibSpec = kdl
+        .parse()
+        .unwrap_or_else(|e| panic!("usage-lib should parse the derived spec: {e}\n\n{kdl}"));
+
+    assert_eq!(spec.bin, "ex");
+    assert_eq!(spec.version.as_deref(), Some("1.2.3"));
+    // The struct's doc comment: first paragraph short, whole thing long.
+    assert_eq!(spec.about.as_deref(), Some("A tool that does things"));
+    assert!(
+        spec.about_long
+            .as_deref()
+            .is_some_and(|l| l.contains("second paragraph")),
+        "the long form should keep the rest of the comment"
+    );
+
+    let jobs = spec
+        .cmd
+        .flags
+        .iter()
+        .find(|f| f.name == "jobs")
+        .expect("--jobs should be in the spec");
+    assert_eq!(jobs.short, vec!['j']);
+    assert_eq!(jobs.long, vec!["jobs".to_string()]);
+    assert_eq!(jobs.env.as_deref(), Some("EX_JOBS"));
+    assert_eq!(jobs.default, vec!["4".to_string()]);
+    assert_eq!(jobs.help_heading.as_deref(), Some("Performance"));
+    assert_eq!(jobs.help.as_deref(), Some("How many jobs to run at once"));
+    assert_eq!(
+        jobs.help_long.as_deref(),
+        Some("How many jobs to run at once\n\nLonger prose about jobs.")
+    );
+    assert!(jobs.arg.is_some(), "an Option<String> flag takes a value");
+
+    let verbose = spec.cmd.flags.iter().find(|f| f.name == "verbose").unwrap();
+    assert!(verbose.count);
+    assert!(verbose.arg.is_none(), "a count flag takes no value");
+
+    let color = spec.cmd.flags.iter().find(|f| f.name == "color").unwrap();
+    assert_eq!(color.negate.as_deref(), Some("--no-color"));
+
+    let secret = spec.cmd.flags.iter().find(|f| f.name == "secret").unwrap();
+    assert!(secret.hide);
+
+    // A `String` positional must be filled; a `Vec<String>` need not be.
+    assert_eq!(spec.cmd.args[0].name, "file");
+    assert!(spec.cmd.args[0].required);
+    assert_eq!(spec.cmd.args[1].name, "rest");
+    assert!(spec.cmd.args[1].var);
+    assert!(!spec.cmd.args[1].required);
+}
+
+#[test]
+fn the_spec_renders_as_docs() {
+    // The reason the spec exists: `usage g markdown|manpage` at build time.
+    let spec: LibSpec = Ex::to_kdl().parse().unwrap();
+    let markdown = usage::docs::markdown::MarkdownRenderer::new(spec.clone())
+        .render_index()
+        .expect("should render markdown");
+    assert!(markdown.contains("--jobs"));
+    assert!(
+        !markdown.contains("--secret"),
+        "a hidden flag stays out of the docs"
+    );
+
+    let manpage = usage::docs::manpage::ManpageRenderer::new(spec)
+        .render()
+        .expect("should render a manpage");
+    assert!(manpage.contains("ex"));
+}
+
+#[test]
+fn help_output_groups_by_heading() {
+    let spec: LibSpec = Ex::to_kdl().parse().unwrap();
+    let help = usage::docs::cli::render_help(&spec, &spec.cmd, false);
+    assert!(help.contains("Performance:"), "got:\n{help}");
+    assert!(help.contains("Flags:"), "got:\n{help}");
+}
+
+/// A CLI with no flags at all still compiles: the generated code has to cope with
+/// empty tables, which is exactly where an unused variable or an empty `match`
+/// would break the build.
+#[derive(Cli)]
+struct Bare {
+    /// The only thing it takes
+    target: String,
+}
+
+#[test]
+fn a_cli_with_only_a_positional_works() {
+    let a = argv(["thing"]);
+    let bare = Bare::parse_from(&a).expect("should parse");
+    assert_eq!(bare.target, "thing");
+
+    let spec: LibSpec = Bare::to_kdl().parse().expect("should be a valid spec");
+    assert_eq!(spec.cmd.args.len(), 1);
+    assert!(spec.cmd.flags.is_empty());
+}
+
+/// And a CLI with no positionals, for the same reason.
+#[derive(Cli)]
+struct FlagsOnly {
+    /// Whether to hurry
+    #[usage(long)]
+    fast: bool,
+}
+
+#[test]
+fn a_cli_with_only_a_flag_works() {
+    let a = argv(["--fast"]);
+    let cli = FlagsOnly::parse_from(&a).expect("should parse");
+    assert!(cli.fast);
+
+    let spec: LibSpec = FlagsOnly::to_kdl().parse().expect("should be a valid spec");
+    assert!(spec.cmd.args.is_empty());
+    assert_eq!(spec.cmd.flags.len(), 1);
+}
+
+#[test]
+fn reaching_the_tables_is_free() {
+    // The point of the whole exercise: `command()` hands back a `static`, so there
+    // is nothing to build before parsing. This is a compile-time property, and the
+    // assertion is that the reference is the same one every time.
+    let first = Ex::command() as *const _;
+    let second = Ex::command() as *const _;
+    assert_eq!(
+        first, second,
+        "the tables should be one static, not a build"
+    );
+}

--- a/conformance/tests/derive.rs
+++ b/conformance/tests/derive.rs
@@ -308,6 +308,33 @@ fn a_cli_with_only_a_flag_works() {
     assert_eq!(spec.cmd.flags.len(), 1);
 }
 
+/// An explicit `long` written with its dashes is the natural mistake, and would
+/// have produced a flag no command line could reach.
+#[derive(Cli)]
+struct Dashed {
+    /// Colorize output
+    #[usage(long = "--color", negate = "--no-color", default = "true")]
+    color: bool,
+}
+
+#[test]
+fn an_explicit_long_may_be_written_with_dashes() {
+    let a = argv(["--no-color"]);
+    let cli = Dashed::parse_from(&a).expect("should parse");
+    assert!(!cli.color);
+
+    let a = argv(["--color"]);
+    let cli = Dashed::parse_from(&a).expect("should parse");
+    assert!(cli.color);
+
+    // And the spec records it the way a spec does, without the dashes on the long
+    // form and with them on the negation.
+    let spec: LibSpec = Dashed::to_kdl().parse().expect("should be a valid spec");
+    let color = &spec.cmd.flags[0];
+    assert_eq!(color.long, vec!["color".to_string()]);
+    assert_eq!(color.negate.as_deref(), Some("--no-color"));
+}
+
 #[test]
 fn reaching_the_tables_is_free() {
     // The point of the whole exercise: `command()` hands back a `static`, so there

--- a/conformance/tests/derive.rs
+++ b/conformance/tests/derive.rs
@@ -120,6 +120,62 @@ fn a_repeatable_flag_leaves_the_next_word_alone() {
 }
 
 #[test]
+fn a_bare_short_uses_the_renamed_name() {
+    // `short` is written before `name`, and the two names start with different
+    // letters — which is the only way to tell the bug from a coincidence.
+    #[derive(Cli)]
+    struct Renamed {
+        /// Say less
+        #[usage(short, name = "quiet", long)]
+        verbose: bool,
+    }
+
+    let a = argv(["-q"]);
+    assert!(
+        Renamed::parse_from(&a)
+            .expect("-q should be the short form")
+            .verbose,
+        "the short comes from the renamed name"
+    );
+
+    let a = argv(["-v"]);
+    assert!(
+        Renamed::parse_from(&a).is_err(),
+        "-v is the field's letter, which is not what was declared"
+    );
+
+    let spec: LibSpec = Renamed::to_kdl().parse().expect("valid spec");
+    assert_eq!(spec.cmd.flags[0].short, vec!['q']);
+    assert_eq!(spec.cmd.flags[0].long, vec!["quiet".to_string()]);
+}
+
+#[test]
+fn a_variadic_flag_is_not_also_repeatable() {
+    // Two different claims: `var` says the flag may be repeated, a variadic
+    // argument says one occurrence keeps taking values. Emitting both would
+    // contradict the grammar.
+    let spec: LibSpec = Repeat::to_kdl().parse().expect("valid spec");
+    let exclude = spec
+        .cmd
+        .flags
+        .iter()
+        .find(|f| f.name == "exclude")
+        .expect("--exclude should be in the spec");
+    assert!(!exclude.var, "a variadic flag is not marked repeatable");
+    assert!(
+        exclude.arg.as_ref().is_some_and(|a| a.var),
+        "its argument is the variadic one"
+    );
+
+    let include = spec.cmd.flags.iter().find(|f| f.name == "include").unwrap();
+    assert!(include.var, "a repeatable flag is marked repeatable");
+    assert!(
+        include.arg.as_ref().is_some_and(|a| !a.var),
+        "and its argument takes one value"
+    );
+}
+
+#[test]
 fn a_variadic_flag_takes_several_values() {
     let a = argv(["--exclude", "a", "b", "--", "t"]);
     let cli = Repeat::parse_from(&a).expect("should parse");

--- a/conformance/tests/derive.rs
+++ b/conformance/tests/derive.rs
@@ -317,6 +317,28 @@ struct Dashed {
     color: bool,
 }
 
+/// A dashed `name` with a bare `long` derived an unreachable long form, since a
+/// token has its dashes taken off before matching.
+#[derive(Cli)]
+struct DashedName {
+    /// Colorize output
+    #[usage(name = "--color", long)]
+    c: bool,
+}
+
+#[test]
+fn a_dashed_name_is_normalized_too() {
+    let a = argv(["--color"]);
+    let cli = DashedName::parse_from(&a).expect("should parse");
+    assert!(cli.c);
+
+    let spec: LibSpec = DashedName::to_kdl()
+        .parse()
+        .expect("should be a valid spec");
+    assert_eq!(spec.cmd.flags[0].name, "color");
+    assert_eq!(spec.cmd.flags[0].long, vec!["color".to_string()]);
+}
+
 #[test]
 fn an_explicit_long_may_be_written_with_dashes() {
     let a = argv(["--no-color"]);

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "usage-derive"
+description = "Derive macro that compiles a CLI definition into parse tables and a usage spec"
+# Not published yet: it cannot express subcommands, and a CLI framework that
+# cannot do that is not one anybody should depend on by accident. The version
+# tracks the workspace so it is ready to publish the moment it can.
+publish = false
+version = "5.1.0"
+edition = "2021"
+rust-version = "1.80.0"
+homepage = { workspace = true }
+documentation = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+# syn 2 rather than 3, which is already in the tree via clap_derive: nothing here
+# needs the newer API, and matching what is there avoids a second copy.
+syn = { version = "2", features = ["full"] }
+
+# The generated code refers to usage-argv, so the doc examples need it in scope to
+# compile. Not a real dependency: this crate emits tokens and links nothing.
+[dev-dependencies]
+usage-argv = { workspace = true, features = ["spec"] }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "usage-derive"
 description = "Derive macro that compiles a CLI definition into parse tables and a usage spec"
-# Not published yet: it cannot express subcommands, and a CLI framework that
-# cannot do that is not one anybody should depend on by accident. The version
-# tracks the workspace so it is ready to publish the moment it can.
-publish = false
 version = "5.1.0"
 edition = "2021"
 rust-version = "1.80.0"
@@ -16,6 +12,10 @@ license = { workspace = true }
 
 [lib]
 proc-macro = true
+
+[package.metadata.release]
+shared-version = true
+release = true
 
 [dependencies]
 proc-macro2 = "1"

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -1,0 +1,379 @@
+//! Turning a [`Cli`] into the code that parses for it.
+//!
+//! Three things are emitted, and the split is the whole point of the design:
+//!
+//! - `static` parse tables, which is all a successful parse reads.
+//! - `static` metadata, which spec emission and help reading read and a parse
+//!   never touches.
+//! - a `parse` function that is a `match` on table indices, assigning straight
+//!   into the struct's fields. No map, no intermediate value, nothing allocated
+//!   that does not end up in the result.
+//!
+//! Both trees are emitted into one hidden module per type so that a CLI's tables
+//! do not collide with anything, and so `cargo expand` shows them together.
+
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+
+use crate::model::{Cli, Field, Kind, Shape};
+
+pub fn emit(cli: &Cli) -> TokenStream {
+    let ident = &cli.ident;
+    let module = format_ident!("__usage_{}", ident.to_string().to_lowercase());
+
+    let flags: Vec<&Field> = cli
+        .fields
+        .iter()
+        .filter(|f| matches!(f.kind, Kind::Flag { .. }))
+        .collect();
+    let args: Vec<&Field> = cli
+        .fields
+        .iter()
+        .filter(|f| matches!(f.kind, Kind::Arg { .. }))
+        .collect();
+
+    let flag_tables = flags.iter().enumerate().map(|(i, f)| flag_table(i, f));
+    let arg_tables = args.iter().enumerate().map(|(i, f)| arg_table(i, f));
+    let flag_metas = flags.iter().enumerate().map(|(i, f)| flag_meta(i, f));
+    let arg_metas = args.iter().enumerate().map(|(i, f)| arg_meta(i, f));
+
+    let flag_refs = (0..flags.len()).map(|i| {
+        let name = format_ident!("FLAG_{i}");
+        quote!(&#name)
+    });
+    let arg_refs = (0..args.len()).map(|i| {
+        let name = format_ident!("ARG_{i}");
+        quote!(&#name)
+    });
+    let flag_meta_refs = (0..flags.len()).map(|i| format_ident!("FLAG_META_{i}"));
+    let arg_meta_refs = (0..args.len()).map(|i| format_ident!("ARG_META_{i}"));
+
+    let name = &cli.name;
+    let bin = option_str(cli.bin.as_deref());
+    let version = option_str(cli.version.as_deref());
+    let about = option_str(cli.about.as_deref());
+    let long_about = option_str(cli.long_about.as_deref());
+
+    let field_inits = cli.fields.iter().map(field_init);
+    let flag_arms = flags.iter().enumerate().map(|(i, f)| flag_arm(i, f));
+    let arg_arms = args.iter().enumerate().map(|(i, f)| arg_arm(i, f));
+    let field_finals = cli.fields.iter().map(|f| {
+        let ident = &f.ident;
+        quote!(#ident)
+    });
+
+    quote! {
+        #[doc(hidden)]
+        #[allow(non_upper_case_globals, non_snake_case, unused_imports)]
+        mod #module {
+            use ::usage_argv::spec::{ArgMeta, CommandMeta, FlagMeta, Spec};
+            use ::usage_argv::{Arg, Command, DoubleDash, Flag};
+
+            #(#flag_tables)*
+            #(#arg_tables)*
+
+            pub static ROOT: Command = Command {
+                name: #name,
+                flags: &[#(#flag_refs),*],
+                args: &[#(#arg_refs),*],
+                ..Command::EMPTY
+            };
+
+            #(#flag_metas)*
+            #(#arg_metas)*
+
+            pub static ROOT_META: CommandMeta = CommandMeta {
+                cmd: &ROOT,
+                about: #about,
+                long_about: #long_about,
+                flags: &[#(#flag_meta_refs),*],
+                args: &[#(#arg_meta_refs),*],
+                ..CommandMeta::EMPTY
+            };
+
+            pub static SPEC: Spec = Spec {
+                name: #name,
+                bin: #bin,
+                version: #version,
+                about: #about,
+                long_about: #long_about,
+                default_subcommand: None,
+                root: &ROOT_META,
+            };
+        }
+
+        impl #ident {
+            /// The parse tables for this CLI.
+            ///
+            /// `static`, so reaching them costs nothing: there is no command tree
+            /// to build before a parse can start.
+            pub fn command() -> &'static ::usage_argv::Command<'static> {
+                &#module::ROOT
+            }
+
+            /// This CLI's spec, for emitting, documenting, or completing.
+            pub fn spec() -> &'static ::usage_argv::spec::Spec<'static> {
+                &#module::SPEC
+            }
+
+            /// This CLI's spec as KDL, which is what `usage g markdown|manpage`
+            /// and the completion generators read.
+            pub fn to_kdl() -> ::std::string::String {
+                #module::SPEC.to_kdl()
+            }
+
+            /// Parse a command line, excluding the program name.
+            pub fn parse_from<'v>(
+                argv: &'v [&'v ::std::ffi::OsStr],
+            ) -> ::std::result::Result<Self, ::usage_argv::Error<'static, 'v>> {
+                use ::usage_argv::Event;
+
+                // Values arrive as the bytes that were on the command line. This
+                // version holds them as `String`, and converts lossily, which is
+                // what mise already does with its own argv. Rejecting a non-UTF-8
+                // value needs an error type for value conversion, and that arrives
+                // with typed fields.
+                fn text(value: &[u8]) -> ::std::string::String {
+                    ::std::string::String::from_utf8_lossy(value).into_owned()
+                }
+                fn value_text(value: ::std::option::Option<&[u8]>) -> ::std::string::String {
+                    value.map(text).unwrap_or_default()
+                }
+
+                #(#field_inits)*
+
+                let mut parser = ::usage_argv::Parser::new(Self::command(), argv);
+                while let ::std::option::Option::Some(event) = parser.next_event() {
+                    match event? {
+                        Event::Flag { flag, value, negated } => {
+                            // Both are `Copy`, and a CLI with no boolean flag would
+                            // otherwise leave one of them unread.
+                            let _ = (value, negated);
+                            match flag.key {
+                            #(#flag_arms)*
+                            // Unreachable: every table entry above was emitted
+                            // from a field, and the parser only reports entries
+                            // it was given.
+                            _ => {}
+                            }
+                        }
+                        Event::Arg { arg, value } => {
+                            let _ = value;
+                            match arg.key {
+                            #(#arg_arms)*
+                            _ => {}
+                            }
+                        }
+                        // This version has no subcommands to descend into.
+                        Event::Command(_) => {}
+                    }
+                }
+
+                ::std::result::Result::Ok(Self { #(#field_finals),* })
+            }
+
+            /// Parse the process's own arguments.
+            pub fn parse() -> ::std::result::Result<Self, ::std::string::String> {
+                let raw: ::std::vec::Vec<::std::ffi::OsString> =
+                    ::std::env::args_os().skip(1).collect();
+                let argv: ::std::vec::Vec<&::std::ffi::OsStr> =
+                    raw.iter().map(|a| a.as_os_str()).collect();
+                // The error borrows argv, so it cannot outlive this function;
+                // rendering it here is what makes the signature usable. Better
+                // diagnostics are a separate piece of work.
+                Self::parse_from(&argv).map_err(|e| ::std::format!("{e:?}"))
+            }
+        }
+    }
+}
+
+fn flag_table(i: usize, field: &Field) -> TokenStream {
+    let name = format_ident!("FLAG_{i}");
+    let key = i as u32;
+    let field_name = &field.name;
+    let Kind::Flag {
+        longs,
+        shorts,
+        negate,
+        global,
+        variadic,
+    } = &field.kind
+    else {
+        unreachable!("filtered by the caller");
+    };
+    let shorts: Vec<u8> = shorts.iter().map(|c| *c as u8).collect();
+    let negate = option_str(negate.as_deref());
+    let takes_value = field.takes_value();
+
+    quote! {
+        pub static #name: Flag = Flag {
+            key: #key,
+            name: #field_name,
+            longs: &[#(#longs),*],
+            shorts: &[#(#shorts),*],
+            negate: #negate,
+            takes_value: #takes_value,
+            variadic: #variadic,
+            global: #global,
+        };
+    }
+}
+
+fn arg_table(i: usize, field: &Field) -> TokenStream {
+    let name = format_ident!("ARG_{i}");
+    // Keys are separate spaces for flags and arguments, since the parser reports
+    // which of the two it bound.
+    let key = i as u32;
+    let field_name = &field.name;
+    let var = field.shape == Shape::Many;
+    let Kind::Arg {
+        double_dash_required,
+    } = &field.kind
+    else {
+        unreachable!("filtered by the caller");
+    };
+    let double_dash = if *double_dash_required {
+        quote!(DoubleDash::Required)
+    } else {
+        quote!(DoubleDash::Optional)
+    };
+
+    quote! {
+        pub static #name: Arg = Arg {
+            key: #key,
+            name: #field_name,
+            var: #var,
+            double_dash: #double_dash,
+        };
+    }
+}
+
+fn flag_meta(i: usize, field: &Field) -> TokenStream {
+    let name = format_ident!("FLAG_META_{i}");
+    let table = format_ident!("FLAG_{i}");
+    let help = option_str(field.help.as_deref());
+    let long_help = option_str(field.long_help.as_deref());
+    let env = option_str(field.env.as_deref());
+    let help_heading = option_str(field.help_heading.as_deref());
+    let default = match field.default.as_deref() {
+        Some(d) => quote!(&[#d]),
+        None => quote!(&[]),
+    };
+    let hide = field.hide;
+    let count = field.shape == Shape::Count;
+    let repeatable = field.shape == Shape::Many;
+
+    quote! {
+        pub static #name: FlagMeta = FlagMeta {
+            flag: &#table,
+            help: #help,
+            long_help: #long_help,
+            env: #env,
+            default: #default,
+            help_heading: #help_heading,
+            hide: #hide,
+            count: #count,
+            repeatable: #repeatable,
+            ..FlagMeta::EMPTY
+        };
+    }
+}
+
+fn arg_meta(i: usize, field: &Field) -> TokenStream {
+    let name = format_ident!("ARG_META_{i}");
+    let table = format_ident!("ARG_{i}");
+    let help = option_str(field.help.as_deref());
+    let long_help = option_str(field.long_help.as_deref());
+    let env = option_str(field.env.as_deref());
+    let help_heading = option_str(field.help_heading.as_deref());
+    let default = match field.default.as_deref() {
+        Some(d) => quote!(&[#d]),
+        None => quote!(&[]),
+    };
+    let hide = field.hide;
+    // `String` must be filled; `Option` and `Vec` need not be.
+    let required = field.shape == Shape::Required;
+
+    quote! {
+        pub static #name: ArgMeta = ArgMeta {
+            arg: &#table,
+            help: #help,
+            long_help: #long_help,
+            env: #env,
+            default: #default,
+            help_heading: #help_heading,
+            hide: #hide,
+            required: #required,
+            ..ArgMeta::EMPTY
+        };
+    }
+}
+
+/// The local each field accumulates into while parsing.
+fn field_init(field: &Field) -> TokenStream {
+    let ident = &field.ident;
+    match field.shape {
+        Shape::Bool => {
+            // A negatable flag's default is whatever `default` says, since
+            // `--no-x` has to be able to turn something off.
+            let start = field.default.as_deref() == Some("true");
+            quote!(let mut #ident = #start;)
+        }
+        Shape::Count => quote!(let mut #ident = 0;),
+        Shape::Optional => {
+            let default = match field.default.as_deref() {
+                Some(d) => quote!(::std::option::Option::Some(#d.to_string())),
+                None => quote!(::std::option::Option::None),
+            };
+            quote!(let mut #ident = #default;)
+        }
+        Shape::Required => {
+            let default = match field.default.as_deref() {
+                Some(d) => quote!(#d.to_string()),
+                None => quote!(::std::string::String::new()),
+            };
+            quote!(let mut #ident = #default;)
+        }
+        Shape::Many => quote!(let mut #ident = ::std::vec::Vec::new();),
+    }
+}
+
+fn flag_arm(i: usize, field: &Field) -> TokenStream {
+    let key = i as u32;
+    let ident = &field.ident;
+    let body = match field.shape {
+        // `negated` is what distinguishes `--color` from `--no-color`.
+        Shape::Bool => quote!(#ident = !negated;),
+        Shape::Count => quote!(#ident += 1;),
+        Shape::Optional => quote! {
+            #ident = ::std::option::Option::Some(value_text(value));
+        },
+        Shape::Required => quote!(#ident = value_text(value);),
+        Shape::Many => quote!(#ident.push(value_text(value));),
+    };
+    quote! {
+        #key => { #body }
+    }
+}
+
+fn arg_arm(i: usize, field: &Field) -> TokenStream {
+    let key = i as u32;
+    let ident = &field.ident;
+    let body = match field.shape {
+        Shape::Many => quote!(#ident.push(text(value));),
+        Shape::Optional => quote! {
+            #ident = ::std::option::Option::Some(text(value));
+        },
+        _ => quote!(#ident = text(value);),
+    };
+    quote! {
+        #key => { #body }
+    }
+}
+
+fn option_str(value: Option<&str>) -> TokenStream {
+    match value {
+        Some(v) => quote!(::std::option::Option::Some(#v)),
+        None => quote!(::std::option::Option::None),
+    }
+}

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -261,7 +261,7 @@ fn flag_meta(i: usize, field: &Field) -> TokenStream {
     };
     let hide = field.hide;
     let count = field.shape == Shape::Count;
-    let repeatable = field.shape == Shape::Many;
+    let repeatable = field.repeatable;
 
     quote! {
         pub static #name: FlagMeta = FlagMeta {
@@ -319,7 +319,11 @@ fn field_init(field: &Field) -> TokenStream {
             let start = field.default.as_deref() == Some("true");
             quote!(let mut #ident = #start;)
         }
-        Shape::Count => quote!(let mut #ident = 0;),
+        Shape::Count => {
+            // Typed, so `saturating_add` below resolves to the field's own integer.
+            let ty = &field.ty;
+            quote!(let mut #ident: #ty = 0;)
+        }
         Shape::Optional => {
             let default = match field.default.as_deref() {
                 Some(d) => quote!(::std::option::Option::Some(#d.to_string())),
@@ -344,7 +348,9 @@ fn flag_arm(i: usize, field: &Field) -> TokenStream {
     let body = match field.shape {
         // `negated` is what distinguishes `--color` from `--no-color`.
         Shape::Bool => quote!(#ident = !negated;),
-        Shape::Count => quote!(#ident += 1;),
+        // Saturating, because a `u8` field given 256 occurrences would otherwise
+        // panic in debug and wrap to zero in release.
+        Shape::Count => quote!(#ident = #ident.saturating_add(1);),
         Shape::Optional => quote! {
             #ident = ::std::option::Option::Some(value_text(value));
         },

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -57,9 +57,13 @@ pub fn emit(cli: &Cli) -> TokenStream {
     let field_inits = cli.fields.iter().map(field_init);
     let flag_arms = flags.iter().enumerate().map(|(i, f)| flag_arm(i, f));
     let arg_arms = args.iter().enumerate().map(|(i, f)| arg_arm(i, f));
+    // `field: local` rather than the shorthand, because the locals are prefixed:
+    // a field called `text` or `parser` would otherwise collide with something the
+    // generated code needs.
     let field_finals = cli.fields.iter().map(|f| {
         let ident = &f.ident;
-        quote!(#ident)
+        let local = local_ident(f);
+        quote!(#ident: #local)
     });
 
     quote! {
@@ -133,18 +137,22 @@ pub fn emit(cli: &Cli) -> TokenStream {
                 // what mise already does with its own argv. Rejecting a non-UTF-8
                 // value needs an error type for value conversion, and that arrives
                 // with typed fields.
-                fn text(value: &[u8]) -> ::std::string::String {
+                fn __usage_text(value: &[u8]) -> ::std::string::String {
                     ::std::string::String::from_utf8_lossy(value).into_owned()
                 }
-                fn value_text(value: ::std::option::Option<&[u8]>) -> ::std::string::String {
-                    value.map(text).unwrap_or_default()
+                fn __usage_value_text(
+                    value: ::std::option::Option<&[u8]>,
+                ) -> ::std::string::String {
+                    value.map(__usage_text).unwrap_or_default()
                 }
 
                 #(#field_inits)*
 
-                let mut parser = ::usage_argv::Parser::new(Self::command(), argv);
-                while let ::std::option::Option::Some(event) = parser.next_event() {
-                    match event? {
+                let mut __usage_parser = ::usage_argv::Parser::new(Self::command(), argv);
+                while let ::std::option::Option::Some(__usage_event) =
+                    __usage_parser.next_event()
+                {
+                    match __usage_event? {
                         Event::Flag { flag, value, negated } => {
                             // Both are `Copy`, and a CLI with no boolean flag would
                             // otherwise leave one of them unread.
@@ -174,14 +182,14 @@ pub fn emit(cli: &Cli) -> TokenStream {
 
             /// Parse the process's own arguments.
             pub fn parse() -> ::std::result::Result<Self, ::std::string::String> {
-                let raw: ::std::vec::Vec<::std::ffi::OsString> =
+                let __usage_raw: ::std::vec::Vec<::std::ffi::OsString> =
                     ::std::env::args_os().skip(1).collect();
-                let argv: ::std::vec::Vec<&::std::ffi::OsStr> =
-                    raw.iter().map(|a| a.as_os_str()).collect();
+                let __usage_argv: ::std::vec::Vec<&::std::ffi::OsStr> =
+                    __usage_raw.iter().map(|a| a.as_os_str()).collect();
                 // The error borrows argv, so it cannot outlive this function;
                 // rendering it here is what makes the signature usable. Better
                 // diagnostics are a separate piece of work.
-                Self::parse_from(&argv).map_err(|e| ::std::format!("{e:?}"))
+                Self::parse_from(&__usage_argv).map_err(|e| ::std::format!("{e:?}"))
             }
         }
     }
@@ -309,9 +317,17 @@ fn arg_meta(i: usize, field: &Field) -> TokenStream {
     }
 }
 
+/// The name of the local a field accumulates into.
+///
+/// Prefixed, so a field called `text`, `parser`, or `argv` cannot shadow anything
+/// the generated code relies on.
+fn local_ident(field: &Field) -> proc_macro2::Ident {
+    format_ident!("__usage_field_{}", field.ident)
+}
+
 /// The local each field accumulates into while parsing.
 fn field_init(field: &Field) -> TokenStream {
-    let ident = &field.ident;
+    let ident = local_ident(field);
     match field.shape {
         Shape::Bool => {
             // A negatable flag's default is whatever `default` says, since
@@ -344,7 +360,7 @@ fn field_init(field: &Field) -> TokenStream {
 
 fn flag_arm(i: usize, field: &Field) -> TokenStream {
     let key = i as u32;
-    let ident = &field.ident;
+    let ident = local_ident(field);
     let body = match field.shape {
         // `negated` is what distinguishes `--color` from `--no-color`.
         Shape::Bool => quote!(#ident = !negated;),
@@ -352,10 +368,10 @@ fn flag_arm(i: usize, field: &Field) -> TokenStream {
         // panic in debug and wrap to zero in release.
         Shape::Count => quote!(#ident = #ident.saturating_add(1);),
         Shape::Optional => quote! {
-            #ident = ::std::option::Option::Some(value_text(value));
+            #ident = ::std::option::Option::Some(__usage_value_text(value));
         },
-        Shape::Required => quote!(#ident = value_text(value);),
-        Shape::Many => quote!(#ident.push(value_text(value));),
+        Shape::Required => quote!(#ident = __usage_value_text(value);),
+        Shape::Many => quote!(#ident.push(__usage_value_text(value));),
     };
     quote! {
         #key => { #body }
@@ -364,13 +380,13 @@ fn flag_arm(i: usize, field: &Field) -> TokenStream {
 
 fn arg_arm(i: usize, field: &Field) -> TokenStream {
     let key = i as u32;
-    let ident = &field.ident;
+    let ident = local_ident(field);
     let body = match field.shape {
-        Shape::Many => quote!(#ident.push(text(value));),
+        Shape::Many => quote!(#ident.push(__usage_text(value));),
         Shape::Optional => quote! {
-            #ident = ::std::option::Option::Some(text(value));
+            #ident = ::std::option::Option::Some(__usage_text(value));
         },
-        _ => quote!(#ident = text(value);),
+        _ => quote!(#ident = __usage_text(value);),
     };
     quote! {
         #key => { #body }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,0 +1,93 @@
+//! A derive that compiles a CLI definition into parse tables and a spec.
+//!
+//! `#[derive(usage::Cli)]` reads a struct and emits three things: `static` parse
+//! tables for [usage-argv](https://docs.rs/usage-argv), `static` metadata for
+//! spec emission, and a parse function that assigns values straight into the
+//! struct's fields. Nothing is constructed at run time — there is no command tree
+//! to build before a parse can start — and a successful parse touches only the
+//! first of the three.
+//!
+//! ```
+//! # use usage_derive::Cli;
+//! /// A tool that does things
+//! #[derive(Cli)]
+//! #[usage(bin = "ex", version = "1.0")]
+//! struct Cli {
+//!     /// How many jobs to run at once
+//!     #[usage(short = 'j', long, env = "EX_JOBS", default = "4")]
+//!     jobs: Option<String>,
+//!
+//!     /// Print more
+//!     #[usage(short = 'v', long, count)]
+//!     verbose: u8,
+//!
+//!     /// Colorize output
+//!     #[usage(long, negate = "--no-color", default = "true")]
+//!     color: bool,
+//!
+//!     /// Files to process
+//!     files: Vec<String>,
+//! }
+//!
+//! let argv = ["-j8", "--no-color", "a.txt"].map(std::ffi::OsStr::new);
+//! let cli = Cli::parse_from(&argv).unwrap();
+//! assert_eq!(cli.jobs.as_deref(), Some("8"));
+//! assert!(!cli.color);
+//! assert_eq!(cli.files, ["a.txt"]);
+//!
+//! // The same declaration is also the spec, which is what generates docs,
+//! // manpages, and completions.
+//! assert!(Cli::to_kdl().contains(r#"flag "-j --jobs""#));
+//! ```
+//!
+//! # Declaring
+//!
+//! A field with `long` or `short` is a flag; anything else is a positional
+//! argument. Help text comes from the doc comment: the first paragraph is the
+//! short form, and the whole comment is the long form.
+//!
+//! | option | meaning |
+//! | --- | --- |
+//! | `long`, `long = "x"` | a long form, defaulting to the field name |
+//! | `short`, `short = 'x'` | a short form, defaulting to the field's first letter |
+//! | `name = "x"` | the name used in the spec and in help output |
+//! | `negate = "--no-x"` | a second long form that sets a `bool` false |
+//! | `count` | count occurrences instead of collecting values |
+//! | `var` | one occurrence keeps taking values |
+//! | `global` | subcommands inherit the flag |
+//! | `env = "X"` | an environment variable that can supply the value |
+//! | `default = "x"` | the value when the command line does not supply one |
+//! | `help_heading = "x"` | the section to list this under in help output |
+//! | `hide` | keep it out of help and completions |
+//! | `double_dash = "required"` | a positional only fillable after `--` |
+//! | `arg` | force a field to be positional |
+//!
+//! # What this version does not do
+//!
+//! - **Subcommands.** One command per struct for now.
+//! - **Typed values.** Fields are `bool`, `String`, `Option<String>`,
+//!   `Vec<String>`, or an unsigned integer with `count`. Anything else is a
+//!   compile error rather than a surprise, because converting a value is also
+//!   where required-ness, `choices`, and bounds get enforced, and that layer does
+//!   not exist yet.
+//! - **Enforce what it records.** `default` and `env` are written into the spec
+//!   and `default` is applied, but `env` is not read, and a missing required value
+//!   is not reported. Same reason.
+
+use proc_macro::TokenStream;
+use syn::{parse_macro_input, DeriveInput};
+
+mod codegen;
+mod model;
+
+/// Compile a struct into a parser and a spec. See the [crate docs](crate).
+#[proc_macro_derive(Cli, attributes(usage))]
+pub fn derive_cli(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    match model::Cli::from_input(&input) {
+        Ok(cli) => codegen::emit(&cli).into(),
+        // Reporting the error as tokens rather than panicking is what puts it on
+        // the offending line instead of on the derive.
+        Err(e) => e.to_compile_error().into(),
+    }
+}

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -53,7 +53,8 @@
 //! | `name = "x"` | the name used in the spec and in help output |
 //! | `negate = "--no-x"` | a second long form that sets a `bool` false |
 //! | `count` | count occurrences instead of collecting values |
-//! | `var` | one occurrence keeps taking values |
+//! | `var` | the flag may be repeated, taking one value each time |
+//! | `variadic` | one occurrence keeps taking values, until a flag-like token or `--` |
 //! | `global` | subcommands inherit the flag |
 //! | `env = "X"` | an environment variable that can supply the value |
 //! | `default = "x"` | the value when the command line does not supply one |

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -65,6 +65,9 @@
 //!
 //! # What this version does not do
 //!
+//! Published early on purpose, so it can be used and argued with — but these are
+//! real limits, not omissions from the docs.
+//!
 //! - **Subcommands.** One command per struct for now.
 //! - **Typed values.** Fields are `bool`, `String`, `Option<String>`,
 //!   `Vec<String>`, or an unsigned integer with `count`. Anything else is a

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -225,6 +225,7 @@ impl Field {
         let mut name = to_kebab(&ident.to_string());
         let mut longs: Vec<String> = Vec::new();
         let mut shorts: Vec<char> = Vec::new();
+        let mut bare_shorts = 0usize;
         let mut negate = None;
         let mut global = false;
         let mut repeatable = false;
@@ -256,12 +257,13 @@ impl Field {
                             explicit_long = true;
                         }
                     },
-                    "short" => shorts.push(match &meta {
-                        Meta::Path(_) => name.chars().next().ok_or_else(|| {
-                            syn::Error::new_spanned(&path, "the field name is empty")
-                        })?,
-                        _ => char_value(&meta)?,
-                    }),
+                    // Resolved after the loop, for the same reason a bare `long` is:
+                    // `short` written before `name = "…"` would otherwise take the
+                    // field's first letter rather than the renamed one's.
+                    "short" => match &meta {
+                        Meta::Path(_) => bare_shorts += 1,
+                        _ => shorts.push(char_value(&meta)?),
+                    },
                     "negate" => negate = Some(strip_dashes(&string_value(&meta)?)),
                     "global" => global = flag_value(&meta)?,
                     // Two different things, deliberately spelled the way a spec
@@ -305,12 +307,19 @@ impl Field {
             }
         }
 
-        // A bare `long` written before `name` would have captured the field name
-        // rather than the renamed one, so resolve it once everything is read.
+        // A bare `long` or `short` written before `name` would have captured the
+        // field name rather than the renamed one, so resolve both once everything
+        // has been read.
         if !explicit_long {
             for long in &mut longs {
                 *long = name.clone();
             }
+        }
+        for _ in 0..bare_shorts {
+            let first = name.chars().next().ok_or_else(|| {
+                syn::Error::new(span, "`short` needs a name to take its first letter from")
+            })?;
+            shorts.insert(0, first);
         }
 
         // A short form is matched as a single byte, so a multi-byte character
@@ -386,10 +395,20 @@ impl Field {
             ));
         }
 
-        // A `Vec` flag collects, so it is repeatable whether or not it says so.
-        let repeatable = repeatable || (is_flag && shape == Shape::Many);
+        // A `Vec` flag collects, so it is repeatable whether or not it says so —
+        // unless it is `variadic`, which is the other way of collecting. Emitting
+        // both would claim a flag is repeatable *and* that its argument is variadic,
+        // which the grammar treats as two different things.
+        let repeatable = repeatable || (is_flag && shape == Shape::Many && !variadic);
 
         let kind = if is_flag {
+            if variadic && shape != Shape::Many {
+                return Err(syn::Error::new(
+                    span,
+                    "a `variadic` flag takes several values from one occurrence, so the \
+                     field has to be a `Vec`; anything else would keep only the last",
+                ));
+            }
             if negate.is_some() && shape != Shape::Bool {
                 return Err(syn::Error::new(
                     span,

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -242,7 +242,9 @@ impl Field {
             for meta in nested(attr)? {
                 let path = meta.path().clone();
                 match ident_of(&path).as_str() {
-                    "name" => name = string_value(&meta)?,
+                    // Stripped, so a dashed spelling cannot leak into the spec name
+                    // or into a long form derived from it.
+                    "name" => name = strip_dashes(&string_value(&meta)?),
                     // Bare `long` takes the field name; `long = "x"` overrides it.
                     "long" => match &meta {
                         Meta::Path(_) => longs.push(name.clone()),

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -224,6 +224,7 @@ impl Field {
 
         let mut name = to_kebab(&ident.to_string());
         let mut longs: Vec<String> = Vec::new();
+        let mut bare_longs = 0usize;
         let mut shorts: Vec<char> = Vec::new();
         let mut bare_shorts = 0usize;
         let mut negate = None;
@@ -237,7 +238,6 @@ impl Field {
         let mut help_heading = None;
         let mut hide = false;
         let mut is_arg = false;
-        let mut explicit_long = false;
 
         for attr in attrs(&field.attrs) {
             for meta in nested(attr)? {
@@ -247,15 +247,14 @@ impl Field {
                     // or into a long form derived from it.
                     "name" => name = strip_dashes(&string_value(&meta)?),
                     // Bare `long` takes the field name; `long = "x"` overrides it.
+                    // A bare `long` is counted and resolved after the loop, so it
+                    // picks up a `name` written later. Explicit ones are stored
+                    // without dashes, because that is what a token is matched against
+                    // once its `--` has been taken off: left verbatim,
+                    // `long = "--no-color"` would be unreachable.
                     "long" => match &meta {
-                        Meta::Path(_) => longs.push(name.clone()),
-                        _ => {
-                            // Stored without dashes, because that is what a token is
-                            // matched against once its `--` has been taken off. Left
-                            // verbatim, `long = "--no-color"` would be unreachable.
-                            longs.push(strip_dashes(&string_value(&meta)?));
-                            explicit_long = true;
-                        }
+                        Meta::Path(_) => bare_longs += 1,
+                        _ => longs.push(strip_dashes(&string_value(&meta)?)),
                     },
                     // Resolved after the loop, for the same reason a bare `long` is:
                     // `short` written before `name = "…"` would otherwise take the
@@ -309,17 +308,32 @@ impl Field {
 
         // A bare `long` or `short` written before `name` would have captured the
         // field name rather than the renamed one, so resolve both once everything
-        // has been read.
-        if !explicit_long {
-            for long in &mut longs {
-                *long = name.clone();
-            }
+        // has been read. Counted rather than rewritten, so a field carrying both a
+        // bare and an explicit form keeps each.
+        for _ in 0..bare_longs {
+            longs.insert(0, name.clone());
         }
         for _ in 0..bare_shorts {
             let first = name.chars().next().ok_or_else(|| {
                 syn::Error::new(span, "`short` needs a name to take its first letter from")
             })?;
             shorts.insert(0, first);
+        }
+
+        if name.is_empty() {
+            return Err(syn::Error::new(
+                span,
+                "`name` is empty once its dashes are removed, and a flag needs \
+                 something to be called",
+            ));
+        }
+        if let Some(empty) = longs.iter().find(|l| l.is_empty()) {
+            let _ = empty;
+            return Err(syn::Error::new(
+                span,
+                "a `long` of only dashes leaves nothing to match: `--` ends flag \
+                 parsing, so it can never name a flag",
+            ));
         }
 
         // A short form is matched as a single byte, so a multi-byte character
@@ -372,6 +386,36 @@ impl Field {
         }
 
         let shape = Shape::from_type(&field.ty, count, span)?;
+        // The spec records a default and the generated code applies it; anything it
+        // cannot apply would be documented and then ignored.
+        if let Some(value) = &default {
+            match shape {
+                Shape::Bool if value != "true" && value != "false" => {
+                    return Err(syn::Error::new(
+                        span,
+                        format!(
+                            "a `bool` field is on or off, so `default = \"{value}\"` \
+                             cannot be applied; write \"true\" or \"false\""
+                        ),
+                    ));
+                }
+                Shape::Count => {
+                    return Err(syn::Error::new(
+                        span,
+                        "a `count` field starts at zero, so a default has nothing to \
+                         say",
+                    ));
+                }
+                Shape::Many => {
+                    return Err(syn::Error::new(
+                        span,
+                        "a default for a collecting field is not applied yet, so it \
+                         would be documented and then ignored",
+                    ));
+                }
+                _ => {}
+            }
+        }
         let is_flag = !longs.is_empty() || !shorts.is_empty();
         if is_flag && is_arg {
             return Err(syn::Error::new(
@@ -415,6 +459,14 @@ impl Field {
         let repeatable = repeatable || (is_flag && shape == Shape::Many && !variadic);
 
         let kind = if is_flag {
+            if variadic && repeatable {
+                return Err(syn::Error::new(
+                    span,
+                    "`var` and `variadic` are two different ways to collect values — \
+                     repeated occurrences, or one occurrence taking several — so a \
+                     flag declares one or the other",
+                ));
+            }
             if variadic && shape != Shape::Many {
                 return Err(syn::Error::new(
                     span,
@@ -441,6 +493,14 @@ impl Field {
                     span,
                     "`global` describes a flag that subcommands inherit; a positional \
                      argument belongs to one command",
+                ));
+            }
+            if shape == Shape::Bool {
+                return Err(syn::Error::new(
+                    span,
+                    "a positional argument holds the word it is given, so a `bool` \
+                     field has nowhere to put it; add a `long` to make it a flag, or \
+                     use `String`",
                 ));
             }
             Kind::Arg {
@@ -649,8 +709,22 @@ fn doc_comment(attrs: &[Attribute]) -> syn::Result<(Option<String>, Option<Strin
     Ok((short, long))
 }
 
+/// `my_flag` and `MyCli` both become `my-cli`-shaped names.
 fn to_kebab(s: &str) -> String {
-    s.replace('_', "-")
+    let mut out = String::with_capacity(s.len() + 4);
+    for (i, ch) in s.chars().enumerate() {
+        if ch == '_' {
+            out.push('-');
+        } else if ch.is_uppercase() {
+            if i > 0 {
+                out.push('-');
+            }
+            out.extend(ch.to_lowercase());
+        } else {
+            out.push(ch);
+        }
+    }
+    out
 }
 
 fn strip_dashes(s: &str) -> String {

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -1,0 +1,534 @@
+//! Reading a Rust type into a description of a CLI.
+//!
+//! Everything here is about *understanding* the input. Nothing is emitted until
+//! [`crate::codegen`], which keeps the error messages — the part an author
+//! actually interacts with — in one place.
+
+use proc_macro2::Span;
+use syn::spanned::Spanned;
+use syn::{Attribute, Data, DeriveInput, Expr, ExprLit, Fields, Lit, Meta, Type};
+
+/// A CLI, as declared by a struct.
+pub struct Cli {
+    pub ident: syn::Ident,
+    pub name: String,
+    pub bin: Option<String>,
+    pub version: Option<String>,
+    /// From the struct's doc comment: first paragraph, and the whole thing.
+    pub about: Option<String>,
+    pub long_about: Option<String>,
+    pub fields: Vec<Field>,
+}
+
+/// One field, resolved to the thing it declares.
+pub struct Field {
+    pub ident: syn::Ident,
+    /// The spec name, which is the field name with underscores turned into
+    /// dashes, unless `name` says otherwise.
+    pub name: String,
+    pub kind: Kind,
+    pub shape: Shape,
+    pub help: Option<String>,
+    pub long_help: Option<String>,
+    pub env: Option<String>,
+    pub default: Option<String>,
+    pub help_heading: Option<String>,
+    pub hide: bool,
+    pub span: Span,
+}
+
+/// Whether a field is a flag or a positional, and how it is addressed.
+pub enum Kind {
+    Flag {
+        longs: Vec<String>,
+        shorts: Vec<char>,
+        negate: Option<String>,
+        global: bool,
+        /// One occurrence takes several values.
+        variadic: bool,
+    },
+    Arg {
+        /// A `--` is required before this argument's value.
+        double_dash_required: bool,
+    },
+}
+
+/// What the field's Rust type says about how many values it holds.
+///
+/// Deliberately small. This version handles values as they arrive — as text —
+/// because converting them is where required-ness, `choices`, and defaults live,
+/// and that layer does not exist yet. A field of any other type is a compile
+/// error rather than a surprise at runtime.
+#[derive(PartialEq, Eq)]
+pub enum Shape {
+    /// `bool`: set or not.
+    Bool,
+    /// An integer counting occurrences, as in `-vvv`.
+    Count,
+    /// `Option<String>`: a value, or nothing.
+    Optional,
+    /// `String`: a value.
+    Required,
+    /// `Vec<String>`: every value given.
+    Many,
+}
+
+impl Cli {
+    pub fn from_input(input: &DeriveInput) -> syn::Result<Self> {
+        let Data::Struct(data) = &input.data else {
+            return Err(syn::Error::new_spanned(
+                &input.ident,
+                "usage::Cli describes a command's flags and arguments, so it needs a \
+                 struct with named fields",
+            ));
+        };
+        let Fields::Named(named) = &data.fields else {
+            return Err(syn::Error::new_spanned(
+                &data.fields,
+                "usage::Cli needs named fields: the field name is what a flag or \
+                 argument is called",
+            ));
+        };
+
+        let (about, long_about) = doc_comment(&input.attrs)?;
+        let mut cli = Cli {
+            ident: input.ident.clone(),
+            name: to_kebab(&input.ident.to_string()),
+            bin: None,
+            version: None,
+            about,
+            long_about,
+            fields: Vec::new(),
+        };
+
+        for attr in attrs(&input.attrs) {
+            for meta in nested(attr)? {
+                let path = meta.path().clone();
+                match ident_of(&path).as_str() {
+                    "name" => cli.name = string_value(&meta)?,
+                    "bin" => cli.bin = Some(string_value(&meta)?),
+                    "version" => cli.version = Some(string_value(&meta)?),
+                    other => {
+                        return Err(syn::Error::new_spanned(
+                            path,
+                            format!(
+                                "unknown option `{other}` on a struct; usage::Cli takes \
+                                 `name`, `bin`, and `version` here, and the description \
+                                 comes from the doc comment"
+                            ),
+                        ));
+                    }
+                }
+            }
+        }
+
+        for field in &named.named {
+            cli.fields.push(Field::from_field(field)?);
+        }
+        cli.check()?;
+        Ok(cli)
+    }
+
+    /// Reject declarations that would compile into a CLI nobody could use.
+    fn check(&self) -> syn::Result<()> {
+        let mut seen_long: Vec<(&str, Span)> = Vec::new();
+        let mut seen_short: Vec<(char, Span)> = Vec::new();
+        let mut variadic_arg: Option<Span> = None;
+
+        for field in &self.fields {
+            match &field.kind {
+                Kind::Flag { longs, shorts, .. } => {
+                    for long in longs {
+                        if let Some((_, first)) = seen_long.iter().find(|(l, _)| l == long) {
+                            return Err(dup(
+                                field.span,
+                                *first,
+                                &format!("--{long} is declared twice"),
+                            ));
+                        }
+                        seen_long.push((long, field.span));
+                    }
+                    for short in shorts {
+                        if let Some((_, first)) = seen_short.iter().find(|(s, _)| s == short) {
+                            return Err(dup(
+                                field.span,
+                                *first,
+                                &format!("-{short} is declared twice"),
+                            ));
+                        }
+                        seen_short.push((*short, field.span));
+                    }
+                }
+                Kind::Arg { .. } => {
+                    // A variadic takes everything left, so anything after it can
+                    // never be filled.
+                    if let Some(first) = variadic_arg {
+                        return Err(dup(
+                            field.span,
+                            first,
+                            "an argument after a variadic one can never be filled, \
+                             because the variadic takes every remaining word",
+                        ));
+                    }
+                    if field.shape == Shape::Many {
+                        variadic_arg = Some(field.span);
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn dup(span: Span, first: Span, message: &str) -> syn::Error {
+    let mut err = syn::Error::new(span, message);
+    err.combine(syn::Error::new(first, "first declared here"));
+    err
+}
+
+impl Field {
+    fn from_field(field: &syn::Field) -> syn::Result<Self> {
+        let ident = field
+            .ident
+            .clone()
+            .expect("named fields were checked by the caller");
+        let span = field.span();
+        let (help, long_help) = doc_comment(&field.attrs)?;
+
+        let mut name = to_kebab(&ident.to_string());
+        let mut longs: Vec<String> = Vec::new();
+        let mut shorts: Vec<char> = Vec::new();
+        let mut negate = None;
+        let mut global = false;
+        let mut variadic = false;
+        let mut count = false;
+        let mut double_dash_required = false;
+        let mut env = None;
+        let mut default = None;
+        let mut help_heading = None;
+        let mut hide = false;
+        let mut is_arg = false;
+        let mut explicit_long = false;
+
+        for attr in attrs(&field.attrs) {
+            for meta in nested(attr)? {
+                let path = meta.path().clone();
+                match ident_of(&path).as_str() {
+                    "name" => name = string_value(&meta)?,
+                    // Bare `long` takes the field name; `long = "x"` overrides it.
+                    "long" => match &meta {
+                        Meta::Path(_) => longs.push(name.clone()),
+                        _ => {
+                            longs.push(string_value(&meta)?);
+                            explicit_long = true;
+                        }
+                    },
+                    "short" => shorts.push(match &meta {
+                        Meta::Path(_) => name.chars().next().ok_or_else(|| {
+                            syn::Error::new_spanned(&path, "the field name is empty")
+                        })?,
+                        _ => char_value(&meta)?,
+                    }),
+                    "negate" => negate = Some(strip_dashes(&string_value(&meta)?)),
+                    "global" => global = flag_value(&meta)?,
+                    "var" => variadic = flag_value(&meta)?,
+                    "count" => count = flag_value(&meta)?,
+                    "hide" => hide = flag_value(&meta)?,
+                    "arg" => is_arg = flag_value(&meta)?,
+                    "env" => env = Some(string_value(&meta)?),
+                    "default" => default = Some(string_value(&meta)?),
+                    "help_heading" => help_heading = Some(string_value(&meta)?),
+                    "double_dash" => {
+                        let mode = string_value(&meta)?;
+                        match mode.as_str() {
+                            "required" => double_dash_required = true,
+                            other => {
+                                return Err(syn::Error::new_spanned(
+                                    path,
+                                    format!(
+                                        "`double_dash = \"{other}\"` is not supported yet; \
+                                         only \"required\" is"
+                                    ),
+                                ));
+                            }
+                        }
+                    }
+                    other => {
+                        return Err(syn::Error::new_spanned(
+                            path,
+                            format!(
+                                "unknown option `{other}`; a field takes `name`, `long`, \
+                                 `short`, `negate`, `global`, `var`, `count`, `hide`, \
+                                 `arg`, `env`, `default`, `help_heading`, and \
+                                 `double_dash`"
+                            ),
+                        ));
+                    }
+                }
+            }
+        }
+
+        // A bare `long` written before `name` would have captured the field name
+        // rather than the renamed one, so resolve it once everything is read.
+        if !explicit_long {
+            for long in &mut longs {
+                *long = name.clone();
+            }
+        }
+
+        let shape = Shape::from_type(&field.ty, count, span)?;
+        let is_flag = !longs.is_empty() || !shorts.is_empty();
+        if is_flag && is_arg {
+            return Err(syn::Error::new(
+                span,
+                "a field is either a flag or a positional argument, not both: it has \
+                 `long` or `short` as well as `arg`",
+            ));
+        }
+        if !is_flag && count {
+            return Err(syn::Error::new(
+                span,
+                "`count` counts how many times a flag was given, so the field needs a \
+                 `long` or a `short`",
+            ));
+        }
+        if !is_flag && negate.is_some() {
+            return Err(syn::Error::new(
+                span,
+                "`negate` names a second long form, so the field needs a `long`",
+            ));
+        }
+
+        let kind = if is_flag {
+            if negate.is_some() && shape != Shape::Bool {
+                return Err(syn::Error::new(
+                    span,
+                    "a negatable flag is on or off, so the field has to be `bool`",
+                ));
+            }
+            Kind::Flag {
+                longs,
+                shorts,
+                negate,
+                global,
+                variadic,
+            }
+        } else {
+            if global {
+                return Err(syn::Error::new(
+                    span,
+                    "`global` describes a flag that subcommands inherit; a positional \
+                     argument belongs to one command",
+                ));
+            }
+            Kind::Arg {
+                double_dash_required,
+            }
+        };
+
+        Ok(Field {
+            ident,
+            name,
+            kind,
+            shape,
+            help,
+            long_help,
+            env,
+            default,
+            help_heading,
+            hide,
+            span,
+        })
+    }
+
+    /// Whether this field's flag takes a value.
+    pub fn takes_value(&self) -> bool {
+        !matches!(self.shape, Shape::Bool | Shape::Count)
+    }
+}
+
+impl Shape {
+    fn from_type(ty: &Type, count: bool, span: Span) -> syn::Result<Self> {
+        let name = type_name(ty);
+        if count {
+            return match name.as_str() {
+                "u8" | "u16" | "u32" | "u64" | "usize" => Ok(Shape::Count),
+                other => Err(syn::Error::new(
+                    span,
+                    format!(
+                        "a `count` field holds how many times the flag was given, so it \
+                         has to be an unsigned integer, not `{other}`"
+                    ),
+                )),
+            };
+        }
+        match name.as_str() {
+            "bool" => Ok(Shape::Bool),
+            "String" => Ok(Shape::Required),
+            "Option<String>" => Ok(Shape::Optional),
+            "Vec<String>" => Ok(Shape::Many),
+            other => Err(syn::Error::new(
+                span,
+                format!(
+                    "`{other}` is not supported yet. This version binds values as the \
+                     text they arrive as, so a field is `bool`, `String`, \
+                     `Option<String>`, `Vec<String>`, or an unsigned integer with \
+                     `count`. Parsing into other types arrives with the layer that also \
+                     applies defaults and validates choices"
+                ),
+            )),
+        }
+    }
+}
+
+/// A type as a comparable string, with paths reduced to their last segment so
+/// `std::option::Option<String>` reads as `Option<String>`.
+fn type_name(ty: &Type) -> String {
+    match ty {
+        Type::Path(path) => {
+            let Some(last) = path.path.segments.last() else {
+                return String::new();
+            };
+            let base = last.ident.to_string();
+            match &last.arguments {
+                syn::PathArguments::AngleBracketed(args) => {
+                    let inner: Vec<String> = args
+                        .args
+                        .iter()
+                        .map(|arg| match arg {
+                            syn::GenericArgument::Type(t) => type_name(t),
+                            _ => String::new(),
+                        })
+                        .collect();
+                    format!("{base}<{}>", inner.join(", "))
+                }
+                _ => base,
+            }
+        }
+        other => other.span().source_text().unwrap_or_default(),
+    }
+}
+
+/// The `#[usage(...)]` attributes on an item.
+fn attrs(attrs: &[Attribute]) -> impl Iterator<Item = &Attribute> {
+    attrs.iter().filter(|a| a.path().is_ident("usage"))
+}
+
+fn nested(attr: &Attribute) -> syn::Result<Vec<Meta>> {
+    let list = attr.meta.require_list()?;
+    let parsed = list
+        .parse_args_with(syn::punctuated::Punctuated::<Meta, syn::Token![,]>::parse_terminated)?;
+    Ok(parsed.into_iter().collect())
+}
+
+fn ident_of(path: &syn::Path) -> String {
+    path.segments
+        .last()
+        .map(|s| s.ident.to_string())
+        .unwrap_or_default()
+}
+
+fn string_value(meta: &Meta) -> syn::Result<String> {
+    let value = &meta.require_name_value()?.value;
+    match value {
+        Expr::Lit(ExprLit {
+            lit: Lit::Str(s), ..
+        }) => Ok(s.value()),
+        other => Err(syn::Error::new_spanned(
+            other,
+            "expected a string, as in `long = \"jobs\"`",
+        )),
+    }
+}
+
+fn char_value(meta: &Meta) -> syn::Result<char> {
+    let value = &meta.require_name_value()?.value;
+    match value {
+        Expr::Lit(ExprLit {
+            lit: Lit::Char(c), ..
+        }) => Ok(c.value()),
+        // `short = "j"` is the mistake anyone would make, so say what to write.
+        Expr::Lit(ExprLit {
+            lit: Lit::Str(s), ..
+        }) => {
+            let text = s.value();
+            let mut chars = text.chars();
+            match (chars.next(), chars.next()) {
+                (Some(c), None) => Err(syn::Error::new_spanned(
+                    value,
+                    format!("a short flag is a character: write `short = '{c}'`"),
+                )),
+                _ => Err(syn::Error::new_spanned(
+                    value,
+                    "a short flag is exactly one character",
+                )),
+            }
+        }
+        other => Err(syn::Error::new_spanned(
+            other,
+            "expected a character, as in `short = 'j'`",
+        )),
+    }
+}
+
+/// A boolean option, where the bare word means true: `global` or `global = true`.
+fn flag_value(meta: &Meta) -> syn::Result<bool> {
+    match meta {
+        Meta::Path(_) => Ok(true),
+        _ => {
+            let value = &meta.require_name_value()?.value;
+            match value {
+                Expr::Lit(ExprLit {
+                    lit: Lit::Bool(b), ..
+                }) => Ok(b.value()),
+                other => Err(syn::Error::new_spanned(
+                    other,
+                    "expected `true`, `false`, or the option on its own",
+                )),
+            }
+        }
+    }
+}
+
+/// Split a doc comment into the short help and the long help.
+///
+/// The first paragraph is the short form, matching what every Rust CLI framework
+/// does and what an author expects from writing one; the whole comment is the long
+/// form, and is only reported when it says more than the short one.
+fn doc_comment(attrs: &[Attribute]) -> syn::Result<(Option<String>, Option<String>)> {
+    let mut lines: Vec<String> = Vec::new();
+    for attr in attrs.iter().filter(|a| a.path().is_ident("doc")) {
+        if let Meta::NameValue(nv) = &attr.meta {
+            if let Expr::Lit(ExprLit {
+                lit: Lit::Str(s), ..
+            }) = &nv.value
+            {
+                lines.push(s.value().trim().to_string());
+            }
+        }
+    }
+    if lines.is_empty() {
+        return Ok((None, None));
+    }
+
+    let full = lines.join("\n").trim().to_string();
+    let short = full
+        .split("\n\n")
+        .next()
+        .unwrap_or(&full)
+        .replace('\n', " ")
+        .trim()
+        .to_string();
+
+    let long = if full == short { None } else { Some(full) };
+    let short = if short.is_empty() { None } else { Some(short) };
+    Ok((short, long))
+}
+
+fn to_kebab(s: &str) -> String {
+    s.replace('_', "-")
+}
+
+fn strip_dashes(s: &str) -> String {
+    s.trim_start_matches('-').to_string()
+}

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -247,7 +247,10 @@ impl Field {
                     "long" => match &meta {
                         Meta::Path(_) => longs.push(name.clone()),
                         _ => {
-                            longs.push(string_value(&meta)?);
+                            // Stored without dashes, because that is what a token is
+                            // matched against once its `--` has been taken off. Left
+                            // verbatim, `long = "--no-color"` would be unreachable.
+                            longs.push(strip_dashes(&string_value(&meta)?));
                             explicit_long = true;
                         }
                     },
@@ -318,6 +321,29 @@ impl Field {
                      one byte. Use an ASCII letter, and give the long form the \
                      descriptive name"
                 ),
+            ));
+        }
+        // Some ASCII characters cannot reach a flag at all, because the grammar
+        // spends them on something else first.
+        if let Some(short) = shorts.iter().find(|c| c.is_ascii_digit()) {
+            return Err(syn::Error::new(
+                span,
+                format!(
+                    "`short = '{short}'` can never be given: `-{short}` reads as a \
+                     negative number, which the grammar treats as a value so that \
+                     `--offset -1` works"
+                ),
+            ));
+        }
+        if let Some(short) = shorts.iter().find(|c| matches!(c, '-' | '=')) {
+            let why = if *short == '-' {
+                "`--` is the separator that ends flag parsing"
+            } else {
+                "`=` separates a short flag from its value, as in `-j=8`"
+            };
+            return Err(syn::Error::new(
+                span,
+                format!("`short = '{short}'` can never be given: {why}"),
             ));
         }
 

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -346,6 +346,19 @@ impl Field {
                 ),
             ));
         }
+        // Whitespace and control characters cannot survive the round trip either:
+        // the spec writes a flag's forms as a space-delimited string, so `-\t`
+        // becomes an unreadable declaration rather than a flag.
+        if let Some(short) = shorts.iter().find(|c| c.is_whitespace() || c.is_control()) {
+            return Err(syn::Error::new(
+                span,
+                format!(
+                    "`short = {short:?}` cannot be written: a spec spells a flag's \
+                     forms as a space-delimited string, so whitespace and control \
+                     characters have nowhere to go"
+                ),
+            ));
+        }
         if let Some(short) = shorts.iter().find(|c| matches!(c, '-' | '=')) {
             let why = if *short == '-' {
                 "`--` is the separator that ends flag parsing"

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -23,6 +23,9 @@ pub struct Cli {
 /// One field, resolved to the thing it declares.
 pub struct Field {
     pub ident: syn::Ident,
+    /// The declared type, needed so a counting field's accumulator is the same
+    /// integer the struct holds rather than an inferred one.
+    pub ty: Type,
     /// The spec name, which is the field name with underscores turned into
     /// dashes, unless `name` says otherwise.
     pub name: String,
@@ -34,6 +37,12 @@ pub struct Field {
     pub default: Option<String>,
     pub help_heading: Option<String>,
     pub hide: bool,
+    /// Whether the flag may be given more than once, taking one value each time.
+    ///
+    /// Distinct from [`Kind::Flag::variadic`], which is one occurrence taking
+    /// several values. Conflating the two makes a merely repeatable flag greedy
+    /// enough to eat a positional — the same mistake the conformance harness made.
+    pub repeatable: bool,
     pub span: Span,
 }
 
@@ -44,7 +53,8 @@ pub enum Kind {
         shorts: Vec<char>,
         negate: Option<String>,
         global: bool,
-        /// One occurrence takes several values.
+        /// One occurrence keeps taking values, as `--include <pattern>...` does in
+        /// a spec. Greedy: it stops only at a flag-like token or `--`.
         variadic: bool,
     },
     Arg {
@@ -89,6 +99,15 @@ impl Cli {
                  argument is called",
             ));
         };
+
+        if !input.generics.params.is_empty() {
+            return Err(syn::Error::new_spanned(
+                &input.generics,
+                "usage::Cli does not support generic parameters: the generated tables \
+                 are `static` and every field has to be a concrete type it can bind a \
+                 command-line value to",
+            ));
+        }
 
         let (about, long_about) = doc_comment(&input.attrs)?;
         let mut cli = Cli {
@@ -137,8 +156,16 @@ impl Cli {
 
         for field in &self.fields {
             match &field.kind {
-                Kind::Flag { longs, shorts, .. } => {
-                    for long in longs {
+                Kind::Flag {
+                    longs,
+                    shorts,
+                    negate,
+                    ..
+                } => {
+                    // A negation is another long form, so it collides like one. Left
+                    // unchecked, two flags could answer to the same token and only
+                    // the first would ever be reached.
+                    for long in longs.iter().chain(negate.iter()) {
                         if let Some((_, first)) = seen_long.iter().find(|(l, _)| l == long) {
                             return Err(dup(
                                 field.span,
@@ -200,6 +227,7 @@ impl Field {
         let mut shorts: Vec<char> = Vec::new();
         let mut negate = None;
         let mut global = false;
+        let mut repeatable = false;
         let mut variadic = false;
         let mut count = false;
         let mut double_dash_required = false;
@@ -231,7 +259,11 @@ impl Field {
                     }),
                     "negate" => negate = Some(strip_dashes(&string_value(&meta)?)),
                     "global" => global = flag_value(&meta)?,
-                    "var" => variadic = flag_value(&meta)?,
+                    // Two different things, deliberately spelled the way a spec
+                    // spells them: `var` is a flag that may be repeated, `variadic`
+                    // is one occurrence that keeps taking values.
+                    "var" => repeatable = flag_value(&meta)?,
+                    "variadic" => variadic = flag_value(&meta)?,
                     "count" => count = flag_value(&meta)?,
                     "hide" => hide = flag_value(&meta)?,
                     "arg" => is_arg = flag_value(&meta)?,
@@ -258,9 +290,9 @@ impl Field {
                             path,
                             format!(
                                 "unknown option `{other}`; a field takes `name`, `long`, \
-                                 `short`, `negate`, `global`, `var`, `count`, `hide`, \
-                                 `arg`, `env`, `default`, `help_heading`, and \
-                                 `double_dash`"
+                                 `short`, `negate`, `global`, `var`, `variadic`, \
+                                 `count`, `hide`, `arg`, `env`, `default`, \
+                                 `help_heading`, and `double_dash`"
                             ),
                         ));
                     }
@@ -274,6 +306,19 @@ impl Field {
             for long in &mut longs {
                 *long = name.clone();
             }
+        }
+
+        // A short form is matched as a single byte, so a multi-byte character
+        // could never be recognized. Better to say so than to truncate it.
+        if let Some(short) = shorts.iter().find(|c| !c.is_ascii()) {
+            return Err(syn::Error::new(
+                span,
+                format!(
+                    "`short = '{short}'` is not ASCII, and a short flag is matched as \
+                     one byte. Use an ASCII letter, and give the long form the \
+                     descriptive name"
+                ),
+            ));
         }
 
         let shape = Shape::from_type(&field.ty, count, span)?;
@@ -292,12 +337,29 @@ impl Field {
                  `long` or a `short`",
             ));
         }
+        if !is_flag && repeatable {
+            return Err(syn::Error::new(
+                span,
+                "`var` describes a flag that may be repeated; a positional argument \
+                 that takes several values is a `Vec` field",
+            ));
+        }
+        if !is_flag && variadic {
+            return Err(syn::Error::new(
+                span,
+                "`variadic` describes a flag whose one occurrence keeps taking values; \
+                 a positional argument that takes several values is a `Vec` field",
+            ));
+        }
         if !is_flag && negate.is_some() {
             return Err(syn::Error::new(
                 span,
                 "`negate` names a second long form, so the field needs a `long`",
             ));
         }
+
+        // A `Vec` flag collects, so it is repeatable whether or not it says so.
+        let repeatable = repeatable || (is_flag && shape == Shape::Many);
 
         let kind = if is_flag {
             if negate.is_some() && shape != Shape::Bool {
@@ -328,6 +390,7 @@ impl Field {
 
         Ok(Field {
             ident,
+            ty: field.ty.clone(),
             name,
             kind,
             shape,
@@ -337,6 +400,7 @@ impl Field {
             default,
             help_heading,
             hide,
+            repeatable,
             span,
         })
     }

--- a/tasks/release-plz
+++ b/tasks/release-plz
@@ -88,7 +88,7 @@ cargo update
 aube update
 mise run lint-fix
 git add \
-  {./,argv/,cli/,lib/}Cargo.* \
+  {./,argv/,cli/,derive/,lib/}Cargo.* \
   package.json aube-lock.yaml \
   cli/usage.usage.kdl \
   docs/cli/reference/* \

--- a/tasks/release-plz
+++ b/tasks/release-plz
@@ -39,6 +39,7 @@ if ! echo "$released_versions" | grep -q "^v$cur_version$"; then
   echo "Releasing $cur_version"
   if [ "${usage_dry_run:-}" != 1 ]; then
     publish_crate_if_needed usage-argv
+    publish_crate_if_needed usage-derive
     publish_crate_if_needed usage-lib
     publish_crate_if_needed clap_usage
     publish_crate_if_needed usage-cli
@@ -52,32 +53,33 @@ fi
 # is satisfied; catch it up if it is behind. usage-argv rides the shared version
 # and depends on nothing, so the same catch-up applies to it.
 publish_crate_if_needed usage-argv
+publish_crate_if_needed usage-derive
 publish_crate_if_needed clap_usage
 
 # Anchor the range before filtering paths. A release tag may point at a commit that only
 # changes root release files; letting the path filter hide that tag can make cliff propose
 # a version lower than the one already published.
 release_range="v$cur_version..HEAD"
-version="$(git cliff "$release_range" --bumped-version --include-path 'lib/**' --include-path 'cli/**' --include-path 'argv/**')"
+version="$(git cliff "$release_range" --bumped-version --include-path 'lib/**' --include-path 'cli/**' --include-path 'argv/**' --include-path 'derive/**')"
 
 if [ "v$cur_version" == "$version" ]; then
-  echo "No usage-lib/usage-cli/usage-argv changes since $version; nothing to release"
+  echo "No library changes since $version; nothing to release"
   exit 0
 fi
 
 if [ "${usage_dry_run:-}" == 1 ]; then
   echo "version: $version"
-  changelog="$(git cliff "$release_range" --tag "$version" --strip all --include-path 'lib/**' --include-path 'cli/**' --include-path 'argv/**')"
+  changelog="$(git cliff "$release_range" --tag "$version" --strip all --include-path 'lib/**' --include-path 'cli/**' --include-path 'argv/**' --include-path 'derive/**')"
   echo "changelog: $changelog"
   exit 0
 fi
 
 # Generate changelog using git-cliff (LLM editorialization happens in release.yml after merge)
-git cliff "$release_range" --tag "$version" --prepend CHANGELOG.md --include-path 'lib/**' --include-path 'cli/**' --include-path 'argv/**'
+git cliff "$release_range" --tag "$version" --prepend CHANGELOG.md --include-path 'lib/**' --include-path 'cli/**' --include-path 'argv/**' --include-path 'derive/**'
 
 # Get the unreleased notes for PR body
 # Strip version header since PR title already has version
-PR_BODY="$(git cliff "$release_range" --tag "$version" --strip all --include-path 'lib/**' --include-path 'cli/**' --include-path 'argv/**' | tail -n +3)"
+PR_BODY="$(git cliff "$release_range" --tag "$version" --strip all --include-path 'lib/**' --include-path 'cli/**' --include-path 'argv/**' --include-path 'derive/**' | tail -n +3)"
 
 cargo set-version "${version#v}" --exclude clap_usage --exclude usage-conformance
 mise run render


### PR DESCRIPTION
Stacked on #802 (which is stacked on #801) — review those first; this diff includes them until they merge.

The piece the last three PRs were building toward: one Rust type in, a parser and a spec out.

```rust
/// A tool that does things
#[derive(usage::Cli)]
#[usage(bin = "ex", version = "1.0")]
struct Cli {
    /// How many jobs to run at once
    #[usage(short = 'j', long, env = "EX_JOBS", default = "4")]
    jobs: Option<String>,

    /// Colorize output
    #[usage(long, negate = "--no-color", default = "true")]
    color: bool,

    /// Files to process
    files: Vec<String>,
}
```

That gives you `Cli::parse_from(argv)`, `Cli::command()`, `Cli::spec()`, and `Cli::to_kdl()` — so the same declaration feeds `usage g markdown|manpage`, the completion generators, and grouped help output from #802.

## What's generated

Three things, and the split is the design:

- **`static` parse tables** — all a successful parse reads.
- **`static` metadata** — what spec emission and help need, which a parse never touches.
- **a parse function** — a `match` on table keys assigning straight into the struct's fields. No map to build and read back, nothing allocated that does not end up in the result.

`command()` returns a `&'static`, so there is no command tree to construct before parsing starts. A test asserts the pointer is the same every call, which is the property the whole project exists for.

A field with `long` or `short` is a flag; anything else is positional. Help comes from the doc comment — first paragraph short, whole comment long.

## Scope, stated plainly

**One command per struct.** Subcommands need an enum of variants, cross-type table references, and a nested path through the parse function; that is its own PR and a box in `PLAN.md`.

**Values are text** — `bool`, `String`, `Option<String>`, `Vec<String>`, or an unsigned integer with `count`. Converting to other types is also where `env`, required-ness, and `choices` get enforced, and that layer does not exist yet. So `Option<u32>` is a *compile error* explaining exactly that, rather than something that silently half-works.

## The error messages got real attention

They are the surface an author actually interacts with, so:

- `short = "j"` → *a short flag is a character: write `short = 'j'`*
- a duplicate `--flag` → points at both declarations, second first
- an argument after a variadic one → *can never be filled, because the variadic takes every remaining word*
- an unknown option → lists the ones that exist
- `count` on a `String` → says it has to be an unsigned integer

## Tests

Twelve, over a deliberately awkward CLI: attached and bundled shorts, `--flag=value`, repeated flags, a negation turning off a default, a hidden flag that still parses, `--` passthrough, and a typo reported rather than bound. Then the same declaration is checked to emit a spec usage-lib accepts field by field, render as markdown and a manpage, and group by heading. Two more CLIs cover the empty cases — no flags, no positionals — which is where generated code tends to break on an unused variable or an empty `match`.

Not published: a CLI framework that cannot express subcommands is not one to depend on by accident. The version tracks the workspace so it is ready the moment it can.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new proc-macro surface that defines CLI parsing behavior for adopters; mitigated by extensive conformance tests but still pre-v1 (no subcommands, limited types, env not enforced at parse time).
> 
> **Overview**
> Adds the **`usage-derive`** workspace crate and **`#[derive(Cli)]`**, so a single struct with `#[usage(...)]` attributes becomes a **`usage-argv` parser**, **static spec metadata**, and **KDL** for docs/completions.
> 
> Generated code exposes **`parse_from` / `parse`**, **`command()`** and **`spec()`** as `&'static` tables, and **`to_kdl()`**. Parsing is a direct `match` on flag/arg keys into prefixed locals (avoids field-name clashes). The model layer rejects invalid declarations at compile time (duplicate flags, `var` vs `variadic`, unsupported types, dashed long/name normalization, etc.) with targeted errors.
> 
> **v0 scope:** one command per struct; text-ish field types only (`bool`, `String`, `Option<String>`, `Vec<String>`, counting integers). Subcommands and typed value conversion are explicitly deferred in **PLAN.md**.
> 
> **Conformance** gains **`conformance/tests/derive.rs`** end-to-end tests (parsing, spec round-trip, markdown/manpage/help). Release tooling includes **`usage-derive`** in publish and git-cliff paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 973a60aed5ffb7395de5e43bc90eec71b8b40ba9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `usage-derive`, enabling CLI definitions through a `#[derive(Cli)]` macro.
  * Supports flags, positional arguments, defaults, aliases, repeatable values, negation, help text, environment settings, and generated command specifications.
  * Added parsing, help/documentation rendering, and KDL serialization for derived CLI types.
  * Added compile-time diagnostics for unsupported or invalid declarations.

* **Documentation**
  * Documented supported attributes, value types, limitations, and the current roadmap.

* **Tests**
  * Added comprehensive end-to-end coverage for parsing, help output, specifications, errors, and CLI configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->