### PR TITLE
fix(parse): stop losing a flag that is missing its value

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -208,13 +208,18 @@ how a fix gets verified — including telling you to delete the label afterwards
 
 - [ ] Unrecognized flags fall through to positionals, so `ex --wat` binds `--wat`
       to an argument, or reports `unexpected_arg` when there is none. This is the
-      root of most of the recorded divergences.
-- [ ] A flag missing its value is dropped silently: `ex --jobs` parses fine and
-      binds nothing, so a forgotten value looks like a working command.
-- [ ] `=` is kept in attached short values, so `-j=8` binds `=8`.
+      root of most of the recorded divergences. **Needs a decision**: mise parses
+      task arguments with this parser at run time, so rejecting an undeclared flag
+      would change what a task accepts, not just what a completion offers.
+- [x] A flag missing its value is dropped silently — now an error, in `parse` but
+      not `parse_partial`, since a half-typed flag is exactly what a completion is
+      asked about.
+- [x] `=` is kept in attached short values, so `-j=8` binds `=8`.
 - [ ] A repeated `--` is eaten, so a forwarded command line containing its own
-      separator is altered in transit.
-- [ ] `--jobs=` binds nothing rather than the empty string.
+      separator is altered in transit. **Needs a decision**: an existing test
+      asserts this, and `double_dash="preserve"` is the declared way to keep
+      separators, which may make it intentional.
+- [x] `--jobs=` binds nothing rather than the empty string.
 - [ ] A flag with a variadic argument rejects its second value, though
       [the flag reference](https://usage.jdx.dev/spec/reference/flag) documents the
       form.

--- a/conformance/tests/argv.rs
+++ b/conformance/tests/argv.rs
@@ -77,11 +77,11 @@ fn agrees_where_usage_lib_does_not() {
         resolved += 1;
     }
 
-    assert!(
-        resolved >= 12,
-        "expected usage-argv to resolve at least a dozen recorded divergences, \
-         resolved {resolved}"
-    );
+    // No floor on `resolved`: every divergence fixed in usage-lib removes a label
+    // and shrinks this set, so an empty one would mean the reference has caught up
+    // entirely — a success, not a broken test. The per-vector assertion above is
+    // what carries the weight.
+    let _ = resolved;
 }
 
 #[test]

--- a/conformance/tests/argv.rs
+++ b/conformance/tests/argv.rs
@@ -13,7 +13,7 @@ use usage_conformance::argv::{run, Outcome};
 use usage_conformance::{load, Expect, Reference, Vector};
 
 /// Vectors that exercise binding, which is what usage-argv implements.
-const IN_SCOPE: usize = 63;
+const IN_SCOPE: usize = 64;
 
 fn corpus() -> Vec<Vector> {
     let files = load(usage_conformance::corpus_dir()).expect("corpus should load");

--- a/corpus/01-long-flags.json
+++ b/corpus/01-long-flags.json
@@ -45,6 +45,13 @@
       "expect": { "ok": { "flags": { "jobs": "" } } }
     },
     {
+      "id": "long-boolean-with-empty-attached-value",
+      "doc": "`--force=` on a flag that holds no value leaves nothing behind. An empty value means something only to a flag that takes one, and a stray empty word would otherwise be read as a positional.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--force\"\narg \"[file]\"\n",
+      "argv": ["--force="],
+      "expect": { "ok": { "flags": { "force": true } } }
+    },
+    {
       "id": "long-value-attached-flaglike",
       "doc": "An attached value binds even when it looks like a flag: `=` has already settled where the value came from.",
       "spec": "name \"ex\"\nbin \"ex\"\nflag \"--jobs <n>\"\nflag \"--force\"\n",

--- a/corpus/01-long-flags.json
+++ b/corpus/01-long-flags.json
@@ -42,10 +42,7 @@
       "doc": "`--flag=` binds the empty string. Present-but-empty is a different state from absent, and only the attached form can express it.",
       "spec": "name \"ex\"\nbin \"ex\"\nflag \"--jobs <n>\"\n",
       "argv": ["--jobs="],
-      "expect": { "ok": { "flags": { "jobs": "" } } },
-      "reference": {
-        "diverges": "usage-lib binds nothing, collapsing `--jobs=` into the same result as omitting the flag."
-      }
+      "expect": { "ok": { "flags": { "jobs": "" } } }
     },
     {
       "id": "long-value-attached-flaglike",
@@ -62,20 +59,14 @@
       "doc": "A flag needing a value that ends the command line is an error.",
       "spec": "name \"ex\"\nbin \"ex\"\nflag \"--jobs <n>\"\n",
       "argv": ["--jobs"],
-      "expect": { "error": "missing_flag_value" },
-      "reference": {
-        "diverges": "usage-lib parses successfully and binds nothing, so `ex --jobs` silently does what `ex` does."
-      }
+      "expect": { "error": "missing_flag_value" }
     },
     {
       "id": "long-value-rejects-flaglike-next-word",
       "doc": "A detached value must not itself look like a flag, so a forgotten value is reported rather than swallowed. Use the attached form to pass a value that begins with a dash.",
       "spec": "name \"ex\"\nbin \"ex\"\nflag \"--jobs <n>\"\nflag \"--force\"\n",
       "argv": ["--jobs", "--force"],
-      "expect": { "error": "missing_flag_value" },
-      "reference": {
-        "diverges": "usage-lib binds `force` and leaves `jobs` unset without reporting anything."
-      }
+      "expect": { "error": "missing_flag_value" }
     },
     {
       "id": "long-value-accepts-negative-number",

--- a/corpus/02-short-flags.json
+++ b/corpus/02-short-flags.json
@@ -35,20 +35,14 @@
       "doc": "`-j=8` binds `8`, not `=8`. A single leading `=` is a separator, matching the long form.",
       "spec": "name \"ex\"\nbin \"ex\"\nflag \"-j --jobs <n>\"\n",
       "argv": ["-j=8"],
-      "expect": { "ok": { "flags": { "jobs": "8" } } },
-      "reference": {
-        "diverges": "usage-lib binds `=8`, keeping the separator as part of the value."
-      }
+      "expect": { "ok": { "flags": { "jobs": "8" } } }
     },
     {
       "id": "short-value-missing",
       "doc": "A value-taking short at the end of the command line is an error.",
       "spec": "name \"ex\"\nbin \"ex\"\nflag \"-j --jobs <n>\"\n",
       "argv": ["-j"],
-      "expect": { "error": "missing_flag_value" },
-      "reference": {
-        "diverges": "usage-lib parses successfully and binds nothing, as it does for the long form."
-      }
+      "expect": { "error": "missing_flag_value" }
     },
     {
       "id": "short-bundle",

--- a/docs/spec/argv.md
+++ b/docs/spec/argv.md
@@ -262,21 +262,18 @@ fails if a label is wrong in either direction. A recorded divergence that gets
 fixed shows up as a test failure telling you to delete the label, so the list
 cannot rot.
 
-Today usage-lib diverges on 16 of 87 vectors, from four causes:
+Today usage-lib diverges on 11 of 87 vectors, from three causes:
 
 **Unrecognized flags fall through to positionals.** `ex --wat` binds `--wat` to
 an argument if one is free, and reports `unexpected_arg` if not. This accounts
 for most of the divergences, including the ones where the grammar and usage-lib
 agree a flag is out of scope but disagree about which error to report.
 
-**A flag missing its value is dropped silently.** `ex --jobs` parses
-successfully with nothing bound, so a forgotten value looks like a working
-command. `ex --jobs --force` likewise binds `force` and leaves `jobs` unset.
-
-**`=` is kept in attached short values.** `-j=8` binds `=8` rather than `8`.
-
 **Repeated `--` is eaten.** A second separator is dropped rather than kept as a
-value, so a forwarded command line containing `--` is altered in transit.
+value, so a forwarded command line containing `--` is altered in transit. Note
+that `double_dash="preserve"` exists precisely to keep separators, which makes
+this arguably a deliberate design choice rather than a bug — see
+[Open questions](#open-questions).
 
 Three smaller gaps: `--jobs=` binds nothing rather than the empty string; a flag
 with a variadic argument (`--include <pattern>...`, which the

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -354,6 +354,32 @@ impl<'a> Parser<'a> {
         let (mut out, overridden_flags) = parse_partial_with_env(self.spec, input, custom_env)?;
         trace!("{out:?}");
 
+        // A flag still waiting for a value never got one, so the command line ended
+        // mid-flag. `parse_partial` leaves this for completions to look at — a
+        // half-typed `--jobs ` is exactly what a completion is asked about — but a
+        // full parse has nothing left to wait for, and dropping the flag silently
+        // made a forgotten value look like a working command.
+        if let Some(flag) = out.flag_awaiting_value.first() {
+            let token = flag
+                .long
+                .first()
+                .map(|l| format!("--{l}"))
+                .or_else(|| flag.short.first().map(|s| format!("-{s}")))
+                .unwrap_or_else(|| flag.name.clone());
+            let rendered = input.join(" ");
+            let span = rendered
+                .rfind(&token)
+                .map(|at| (at, token.len()))
+                .unwrap_or((0, 0));
+            return Err(UsageErr::InvalidFlag {
+                token,
+                reason: "requires an argument".to_string(),
+                span: span.into(),
+                input: rendered,
+            }
+            .into());
+        }
+
         let get_env = |key: &str| -> Option<String> {
             if let Some(env_map) = custom_env {
                 env_map.get(key).cloned()
@@ -795,7 +821,11 @@ fn parse_partial_with_env(
         // long flags
         if enable_flags && w.starts_with("--") {
             grouped_flag = false;
-            let (word, val) = w.split_once('=').unwrap_or_else(|| (&w, ""));
+            // `Some` only when an `=` was actually written, so `--jobs=` can supply
+            // an empty value while `--jobs` supplies none. Collapsing the two lost
+            // the flag entirely.
+            let split = w.split_once('=');
+            let (word, val) = split.unwrap_or((&w, ""));
             if let Some(f) = binding.as_ref().or_else(|| out.available_flags.get(word)) {
                 apply_flag_overrides(
                     f,
@@ -807,7 +837,7 @@ fn parse_partial_with_env(
                 // Only push the embedded value back when the flag is known so that
                 // unknown --flag=value tokens fall through intact to positional arg
                 // handling without also injecting a stray "value" positional.
-                if !val.is_empty() {
+                if split.is_some() {
                     input.push_front(val.to_string());
                     prefix_bindings.push_front(None);
                 }
@@ -881,6 +911,12 @@ fn parse_partial_with_env(
             if grouped_flag {
                 grouped_flag = false;
                 w.remove(0);
+                // What is left is a short flag's attached value, and one `=` between
+                // the letter and the value is a separator: `-j=8` means 8. Only one,
+                // so `-j==8` still means `=8`.
+                if !out.flag_awaiting_value.is_empty() && w.starts_with('=') {
+                    w.remove(0);
+                }
             }
         }
 

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -837,7 +837,12 @@ fn parse_partial_with_env(
                 // Only push the embedded value back when the flag is known so that
                 // unknown --flag=value tokens fall through intact to positional arg
                 // handling without also injecting a stray "value" positional.
-                if split.is_some() {
+                // An empty value only means something to a flag that takes one:
+                // `--jobs=` is an empty string, while `--force=` has nothing to give
+                // a flag that holds no value, and queueing it would leave a stray
+                // empty word to be read as a positional. A non-empty value on such a
+                // flag is left as it was, which is its own question.
+                if (split.is_some() && f.arg.is_some()) || !val.is_empty() {
                     input.push_front(val.to_string());
                     prefix_bindings.push_front(None);
                 }


### PR DESCRIPTION
First of the parser fixes, taking you at your word that these are bugs that went unnoticed because the parser is mostly used for completions.

Three divergences the corpus recorded, all of them the parser quietly discarding something:

**`ex --jobs` parsed fine and bound nothing.** A forgotten value looked like a working command, and `ex --jobs --force` bound `force` while dropping `jobs` silently. Now an error.

Worth noting where the check went: `parse`, not `parse_partial`. A half-typed `--jobs ` is exactly what a completion is asked about, so the pending flag stays in the partial output and only a full parse — which has nothing left to wait for — treats it as a failure. That distinction is why `ParseOutput::flag_awaiting_value` exists, so the fix is two lines and a comment rather than a new code path.

**`-j=8` bound `=8`.** The value was taken as everything after the letter. One `=` between letter and value is a separator, matching the long form; `-j==8` still means `=8`.

**`--jobs=` bound nothing**, collapsing "given empty" into "not given". The two are now told apart by whether an `=` was written rather than by whether anything followed it.

## The corpus did its job

Fixing these made the suite report **five labels as stale** — "you claimed usage-lib diverges here, it now agrees, delete the label" — which is the workflow the corpus was built for. Deleting them takes the recorded divergences from 16 to 11.

One test needed rethinking rather than updating: it asserted usage-argv resolves "at least a dozen" divergences, which was a floor that shrinks every time usage-lib gets fixed. An empty set would mean the reference caught up entirely, which is the goal, so the floor is gone and the per-vector assertion carries the weight.

## Two I did not touch, because they need your call

**Unrecognized flags fall through to positionals** (`ex --wat` binds `--wat` to an argument). This is the root of most remaining divergences, but mise parses *task* arguments with this parser at run time — `usage::Parser::new(&spec).parse(&args)` in `src/task/mod.rs` — so rejecting an undeclared flag changes what a task accepts, not just what a completion offers. That could break tasks that pass arbitrary flags through today.

**A repeated `--` is eaten.** The grammar says only the first is a separator. But `test_double_dashes_without_preserve` asserts the current behavior explicitly, and `double_dash="preserve"` exists precisely to keep separators — which makes "the default consumes them all" look like a deliberate design rather than an oversight. I reverted my fix for this one when that test failed. If your reading is that the spec's design wins, the corpus vector changes instead of the parser.

Both are marked **Needs a decision** in `PLAN.md`.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes real argv binding and errors for full parses (including mise task argument parsing), though completions stay on parse_partial; behavior is intentional and corpus-backed.
> 
> **Overview**
> Aligns **usage-lib** parsing with the argv grammar on three flag-binding bugs that previously showed up only in the conformance corpus.
> 
> **Missing flag values** now fail in full **`parse`** when a value-taking flag ends without a value (e.g. `ex --jobs`, `ex --jobs --force`), using **`flag_awaiting_value`** after partial parsing. **`parse_partial`** is unchanged so half-typed flags still work for completions.
> 
> **Attached `=` semantics** are fixed: long **`--jobs=`** binds an empty string (distinct from omitting the flag); boolean **`--force=`** no longer leaves a stray empty positional; short **`-j=8`** binds **`8`** by treating a single leading **`=`** as a separator (long-form parity).
> 
> The corpus drops stale **usage-lib** divergence labels on the affected vectors, adds coverage for **`--force=`**, bumps in-scope vector count, and relaxes the conformance test that required resolving “at least a dozen” divergences. **PLAN.md** and **docs/spec/argv.md** record remaining open decisions (unknown flags → positionals, repeated **`--`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22703a2971b236f8d780147e8c32815f7f083a0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->