### PR TITLE
fix(ci): unblock releases by cutting usage-derive's dev-dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2029,7 +2029,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
- "usage-argv",
 ]
 
 [[package]]

--- a/conformance/tests/derive.rs
+++ b/conformance/tests/derive.rs
@@ -480,3 +480,45 @@ fn reaching_the_tables_is_free() {
         "the tables should be one static, not a build"
     );
 }
+
+/// The crate-level example from usage-derive's documentation, kept here because
+/// that crate cannot dev-depend on usage-argv without making itself unpublishable
+/// — see the note in `derive/Cargo.toml`. If this changes, change the docs too.
+mod docs_example {
+    use super::argv;
+    use usage_derive::Cli;
+
+    /// A tool that does things
+    #[derive(Cli)]
+    #[usage(bin = "ex", version = "1.0")]
+    struct Cli {
+        /// How many jobs to run at once
+        #[usage(short = 'j', long, env = "EX_JOBS", default = "4")]
+        jobs: Option<String>,
+
+        /// Print more
+        #[usage(short = 'v', long, count)]
+        verbose: u8,
+
+        /// Colorize output
+        #[usage(long, negate = "--no-color", default = "true")]
+        color: bool,
+
+        /// Files to process
+        files: Vec<String>,
+    }
+
+    #[test]
+    fn the_crate_level_example_from_the_docs() {
+        let a = argv(["-j8", "--no-color", "a.txt"]);
+        let cli = Cli::parse_from(&a).unwrap();
+        assert_eq!(cli.jobs.as_deref(), Some("8"));
+        assert!(!cli.color);
+        assert_eq!(cli.files, ["a.txt"]);
+        assert_eq!(cli.verbose, 0);
+
+        // The same declaration is also the spec, which is what generates docs,
+        // manpages, and completions.
+        assert!(Cli::to_kdl().contains(r#"flag "-j --jobs""#));
+    }
+}

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -24,7 +24,11 @@ quote = "1"
 # needs the newer API, and matching what is there avoids a second copy.
 syn = { version = "3", features = ["full"] }
 
-# The generated code refers to usage-argv, so the doc examples need it in scope to
-# compile. Not a real dependency: this crate emits tokens and links nothing.
-[dev-dependencies]
-usage-argv = { workspace = true, features = ["spec"] }
+# No dependency on usage-argv, not even for tests. This crate emits tokens and
+# links nothing, and dev-depending on the runtime it emits code for creates a cycle
+# at publish time: `cargo publish` resolves dev-dependencies against the registry,
+# so a feature added to usage-argv within a version makes this crate unpublishable
+# until the version bumps. serde_derive avoids the same trap the same way.
+#
+# The crate-level example is therefore `ignore`d here and compiled for real in
+# conformance/tests/derive.rs, which is where the derive is tested anyway.

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -7,7 +7,11 @@
 //! to build before a parse can start — and a successful parse touches only the
 //! first of the three.
 //!
-//! ```
+//! Not compiled here, because this crate deliberately does not depend on
+//! usage-argv — see the note in its `Cargo.toml`. The same example runs as a test
+//! in `conformance/tests/derive.rs`, as `the_crate_level_example_from_the_docs`.
+//!
+//! ```ignore
 //! # use usage_derive::Cli;
 //! /// A tool that does things
 //! #[derive(Cli)]


### PR DESCRIPTION
This is the failure you linked, and it's mine. The release job has failed on **every run** since usage-derive became publishable:

```
failed to select a version for `usage-argv`
  ... required by package `usage-derive v5.1.0`
package `usage-derive` depends on `usage-argv` with feature `spec`
  but `usage-argv` does not have that feature
```

## What happened

`usage-argv 5.1.0` was published in #798, **before** #801 added its `spec` feature. crates.io versions are immutable, so no crate at 5.1.0 can ever depend on that feature — and `cargo publish` resolves dev-dependencies against the registry, so usage-derive could not be packaged at all.

Worse than a delay: the failure happens in the catch-up publish, *before* the step that opens the release PR — so the version never bumps, and the pipeline stays stuck instead of fixing itself on the next run.

## The fix

The dev-dependency is gone, not worked around. A proc-macro that dev-depends on the runtime it emits code for recreates this cycle every time that runtime gains a feature mid-version, and `serde_derive` avoids it the same way. This crate emits tokens and links nothing, so it now depends on usage-argv not at all.

Its crate-level example would have become an `ignore` block nobody checks, so it moved to `conformance/tests/derive.rs` as a real test — compiled and run, with both sides pointing at each other so they cannot drift.

Verified the actual thing that was broken:

```
$ cargo publish -p usage-derive --dry-run
   Packaged 7 files, 49.6KiB
   Verifying usage-derive v5.1.0
    Finished
```

## Worth knowing for next time

The general trap is shared-version publishing plus "publish whatever is not yet on crates.io": a feature added to a crate after its version was published is invisible to the registry, so any dependent needing that feature is unpublishable until the version moves. It bit a dev-dependency this time, which is why cutting it is a complete fix — but a real dependency in the same position would need the bump.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit da8aa07572132da8cf2fbcc12105ad165958a05e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added conformance coverage for derived command-line interfaces, including jobs, verbosity, color options, positional files, and generated flag specifications.
  - Added validation for the crate-level documentation example through the conformance test suite.

- **Documentation**
  - Clarified that the documentation example is verified externally rather than compiled directly in the crate.
  - Documented dependency and publishing constraints affecting the example setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->