### PR TITLE
docs(spec): document when a root mount runs, and overrides_default

### DIFF
--- a/docs/spec/reference/cmd.md
+++ b/docs/spec/reference/cmd.md
@@ -95,10 +95,31 @@ cmd "install"
 mount run="mycli plugin-commands"
 ```
 
-The root's mount runs only when a _word_ matches nothing already declared, so
-`mycli install` costs nothing extra and only `mycli something-from-a-plugin` pays
-for discovery. Flags never trigger it — `mycli --help` does not run your mount
-command — so declaring the commands you know about keeps the common path free.
+Resolving a mount runs a process, so when the root's mount runs depends on what is
+asking for it:
+
+| asking                          | when it runs                                                                                                                                          |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| a completion, or rendering help | up front — both need the whole command list, and `mycli <tab>` has no word to go on                                                                   |
+| a parse                         | only when a word matches nothing already declared, so `mycli install` costs nothing extra and only `mycli something-from-a-plugin` pays for discovery |
+| a parse, for a flag             | never                                                                                                                                                 |
+
+Declaring the commands you know about therefore keeps ordinary invocations free,
+while completions still see everything.
+
+A `default_subcommand` outranks discovery, because it already says what an unmatched
+word means and costs nothing to consult. Without that, a CLI that routes unknown
+words to a task runner would spawn its discovery process once per task. A mount can
+ask to win anyway:
+
+```kdl
+mount run="mycli plugin-commands" overrides_default=#true
+```
+
+That setting applies to completions as much as to parses, and deliberately: a
+completion offering a command that running would hand to the default subcommand
+instead is worse than not offering it. So a root mount under a `default_subcommand`
+contributes nothing anywhere until it asks to outrank it.
 
 ### Global flags and mounted commands
 


### PR DESCRIPTION
Cleaning up after myself. The mount documentation on `main` describes only the first commit of #806 and missed everything the later ones changed:

- It claims **flags never trigger discovery**, which is untrue of completions and of rendering help — both resolve the mount up front, because both need the whole command list.
- **`overrides_default` is undocumented entirely**, despite shipping.
- Nothing says the default-subcommand gate applies to completions as well as parses, which is the part with a user-visible consequence.

## How it happened, since it is worth knowing

Both docs edits in that PR were string replacements against text prettier had already reformatted — rewrapped lines, and `*own*` turned into `_own_`. The replacements matched nothing and silently did nothing, and I asserted in a PR comment that the page had been corrected. It had not.

The lesson is mechanical: a `.replace()` that no-ops leaves no trace, so an edit made that way needs its diff checked rather than its exit code. This one is verified — `git diff --stat` shows 25 insertions, and the rendered diff is in the commit.

## What the page says now

A table for when the root's mount runs, since "lazily" was never the whole truth:

| asking | when it runs |
| --- | --- |
| a completion, or rendering help | up front — both need the whole command list |
| a parse | only when a word matches nothing already declared |
| a parse, for a flag | never |

Plus `overrides_default`, and why it governs completions too: a completion offering a command that running would hand to the default subcommand instead is worse than not offering it.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the mount reference; no runtime or security-sensitive code is modified.
> 
> **Overview**
> Corrects the root `mount` docs that previously claimed discovery never runs for flags and omitted later behavior.
> 
> Adds a table for **when a root mount runs**: up front for completions/help, lazily for unmatched parse words, and never for flags during parse. Also documents `overrides_default`, including that `default_subcommand` outranks discovery for both parses and completions unless a mount opts in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f942f04ef388192249ac32354ce38152201575c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->