### PR TITLE
fix(test): snapshot the exempt vectors instead of counting them

### DIFF
--- a/conformance/tests/argv.rs
+++ b/conformance/tests/argv.rs
@@ -1,19 +1,18 @@
 //! Checks usage-argv against the corpus.
 //!
-//! This is the point of writing the grammar down. usage-argv is expected to match
-//! every binding vector — including the fifteen where usage-lib does not, since
-//! those record the grammar's intent rather than the reference's behavior.
+//! This is the point of writing the grammar down: usage-argv is expected to match
+//! every vector it answers, including the ones where usage-lib does not, since those
+//! record the grammar's intent rather than the reference's behavior.
 //!
-//! Vectors that turn on something decided after the last token (`required`,
-//! `choices`, `env`, defaults, `var_min`/`var_max`, `overrides`) are out of scope
-//! for this crate by design. Their count is asserted below so the exempt set
-//! cannot quietly grow.
+//! Vectors that turn on something decided after the last token — `required`,
+//! `choices`, `env`, defaults, `var_min`/`var_max`, `overrides` — are out of scope
+//! for this crate by design, and [`the_exempt_vectors`] is the record of which.
+//!
+//! Corpus well-formedness is checked once, in `reference.rs`, rather than again
+//! here.
 
 use usage_conformance::argv::{run, Outcome};
-use usage_conformance::{load, Expect, Reference, Vector};
-
-/// Vectors that exercise binding, which is what usage-argv implements.
-const IN_SCOPE: usize = 64;
+use usage_conformance::{load, Reference, Vector};
 
 fn corpus() -> Vec<Vector> {
     let files = load(usage_conformance::corpus_dir()).expect("corpus should load");
@@ -23,14 +22,12 @@ fn corpus() -> Vec<Vector> {
 #[test]
 fn every_binding_vector_passes() {
     let mut failures = Vec::new();
-    let mut in_scope = 0;
 
     for vector in corpus() {
         let outcome = run(&vector);
         if let Outcome::OutOfScope(_) = outcome {
             continue;
         }
-        in_scope += 1;
         if !outcome.matches(&vector.expect) {
             failures.push(format!(
                 "{}: {}\n     expected: {:?}\n     got:      {outcome:?}",
@@ -45,20 +42,38 @@ fn every_binding_vector_passes() {
         failures.len(),
         failures.join("\n  - ")
     );
+}
 
-    assert_eq!(
-        in_scope, IN_SCOPE,
-        "the number of vectors usage-argv answers changed; if that was the point \
-         of your change, update IN_SCOPE"
-    );
+/// Which vectors usage-argv does not answer, and the reason each gives.
+///
+/// A snapshot rather than a count. A count asserts something nobody can check by
+/// reading it, and it collides whenever two changes touch the corpus — two pull
+/// requests each adding an ordinary vector both passed alone and broke `main`
+/// together, because each saw only its own increment. A list fails as a reviewable
+/// diff naming the vector that changed sides, which is the thing actually worth
+/// knowing, and adding an ordinary vector does not touch it at all.
+#[test]
+fn the_exempt_vectors() {
+    let mut exempt: Vec<String> = corpus()
+        .iter()
+        .filter_map(|vector| match run(vector) {
+            Outcome::OutOfScope(reason) => Some(format!("{}: {reason}", vector.id)),
+            _ => None,
+        })
+        .collect();
+    exempt.sort();
+
+    insta::assert_snapshot!(exempt.join("\n"));
 }
 
 #[test]
 fn agrees_where_usage_lib_does_not() {
-    // The divergences are the reason the corpus exists, so make it explicit that
-    // the new parser resolves them rather than inheriting them.
-    let mut resolved = 0;
-
+    // The divergences are the reason the corpus exists, so make it explicit that the
+    // new parser resolves them rather than inheriting them.
+    //
+    // No lower bound on how many: every divergence fixed in usage-lib deletes a
+    // label and shrinks this set, so an empty one would mean the reference has caught
+    // up entirely — a success, not a broken test.
     for vector in corpus() {
         let Reference::Diverges(_) = vector.reference else {
             continue;
@@ -74,53 +89,5 @@ fn agrees_where_usage_lib_does_not() {
             vector.id,
             vector.expect
         );
-        resolved += 1;
     }
-
-    // No floor on `resolved`: every divergence fixed in usage-lib removes a label
-    // and shrinks this set, so an empty one would mean the reference has caught up
-    // entirely — a success, not a broken test. The per-vector assertion above is
-    // what carries the weight.
-    let _ = resolved;
-}
-
-#[test]
-fn out_of_scope_vectors_say_why() {
-    // A vector skipped without a reason would be a silent hole in coverage.
-    for vector in corpus() {
-        if let Outcome::OutOfScope(reason) = run(&vector) {
-            assert!(
-                !reason.is_empty(),
-                "{} was skipped without a reason",
-                vector.id
-            );
-        }
-    }
-}
-
-#[test]
-fn no_vector_has_an_unloadable_spec() {
-    for vector in corpus() {
-        if let Outcome::BadSpec(e) = run(&vector) {
-            panic!("vector {} has an invalid spec: {e}", vector.id);
-        }
-    }
-}
-
-#[test]
-fn error_expectations_are_reachable() {
-    // Guards against the codes usage-argv claims to produce drifting away from
-    // the ones the corpus asks for.
-    let produced: Vec<_> = corpus()
-        .iter()
-        .filter_map(|v| match (run(v), &v.expect) {
-            (Outcome::Failed(code), Expect::Error(_)) => Some(code),
-            _ => None,
-        })
-        .collect();
-    assert!(
-        produced.len() >= 6,
-        "expected the binding subset to exercise several error classes, saw {}",
-        produced.len()
-    );
 }

--- a/conformance/tests/snapshots/argv__the_exempt_vectors.snap
+++ b/conformance/tests/snapshots/argv__the_exempt_vectors.snap
@@ -1,0 +1,28 @@
+---
+source: conformance/tests/argv.rs
+expression: "exempt.join(\"\\n\")"
+---
+arg-required-missing: required args are checked after binding
+arg-variadic-max: var_min and var_max are checked after binding
+arg-variadic-min: var_min and var_max are checked after binding
+argv-beats-env: env fallback is applied after binding
+choice-invalid: choices are validated after binding
+choice-is-case-sensitive: choices are validated after binding
+choice-on-arg: choices are validated after binding
+choice-valid: choices are validated after binding
+default-fills-absent-arg: defaults are applied after binding
+env-beats-default: defaults are applied after binding
+env-does-not-satisfy-required-arg-position: env fallback is applied after binding
+env-empty-string-counts-as-set: defaults are applied after binding
+env-fills-absent-arg: env fallback is applied after binding
+env-fills-absent-flag: env fallback is applied after binding
+env-unset-falls-to-default: defaults are applied after binding
+flag-var-too-few: var_min and var_max are checked after binding
+flag-var-too-many: var_min and var_max are checked after binding
+long-negation-default: defaults are applied after binding
+long-negation: defaults are applied after binding
+overrides-last-wins: overrides are resolved after binding
+required-flag-missing: required flags are checked after binding
+required-flag-present: requirements are checked after binding
+required-unless-satisfied-by-other: requirements are checked after binding
+required-unless-unsatisfied: required flags are checked after binding


### PR DESCRIPTION
**`main` is red**, and it is a tripwire I wrote that did it. #806 and #809 each added one ordinary corpus vector. Each was green alone — each saw only its own increment against a hardcoded count — and together they made 65 where the constant said 64.

## Counting was the mistake, not the number

Bumping it to 65 would have fixed today and guaranteed tomorrow. A count asserts something **nobody can verify by reading it**, and it collides whenever two changes touch the data it counts.

What the assertion was for — noticing when a vector changes sides — is better served by a snapshot of *which* vectors are exempt and why:

```
arg-required-missing: required args are checked after binding
arg-variadic-max: var_min and var_max are checked after binding
argv-beats-env: env fallback is applied after binding
choice-invalid: choices are validated after binding
...
```

- Fails as a **reviewable diff naming the vector that moved**, instead of a number to be guessed at.
- Adding an ordinary vector **does not touch it at all**, so concurrent PRs cannot collide.
- The list documents the post-binding boundary that the count obscured — which was the interesting information all along.

## The file had two magic numbers, not one

`error_expectations_are_reachable` asserted at least six error classes were exercised. Same problem, same fix: deleted, since the per-vector checks already cover it.

While there, `tests/argv.rs` is now only about the parser. `no_vector_has_an_unloadable_spec` was a duplicate of `specs_are_valid` in `reference.rs`, and `out_of_scope_vectors_say_why` is redundant now that the reasons are in the snapshot. Corpus well-formedness is checked in one place. 135 lines to 92, and no numbers.

Worth merging ahead of my other open PRs, since it unbreaks `main`.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to conformance harness; no production parser or runtime behavior.
> 
> **Overview**
> Fixes flaky **`main`** caused by a hardcoded **`IN_SCOPE`** count on binding vectors: concurrent corpus PRs each bumped the number locally and collided when merged.
> 
> **`the_exempt_vectors`** now **`insta`**-snapshots the sorted list of out-of-scope vector IDs with their skip reasons, so failures show *which* vector moved rather than a magic number. Ordinary new in-scope vectors no longer touch that snapshot.
> 
> **`argv.rs`** is trimmed to parser-focused checks: removed the in-scope count, the “≥6 error classes” floor, duplicate **`no_vector_has_an_unloadable_spec`**, and **`out_of_scope_vectors_say_why`** (reasons live in the snapshot). Module docs point exempt tracking at the new test and corpus validation at **`reference.rs`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3acd140bc8768f4a7d6067781051bb9e856398ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->