### PR TITLE
feat(derive): compile subcommands from an enum

### DIFF
--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -105,7 +105,14 @@ pub struct Command<'a> {
     /// [`UnknownFlags`].
     pub unknown_flags: UnknownFlags,
     /// Caller-assigned identifier, echoed back in [`Event::Command`].
-    pub key: u32,
+    ///
+    /// Wide enough for a derive to make these unique without coordination: two
+    /// macro expansions cannot see each other, so the generated keys carry a hash
+    /// of the type they came from in the high half and a per-type index in the low
+    /// half. A parse dispatches on this, so a collision would bind the wrong field
+    /// — [`Spec::to_kdl`](crate::spec::Spec::to_kdl) checks the tree for duplicates
+    /// in debug builds.
+    pub key: u64,
 }
 
 impl Command<'_> {
@@ -126,7 +133,8 @@ impl Command<'_> {
 pub struct Flag<'a> {
     /// Caller-assigned identifier, echoed back in [`Event::Flag`]. This is how
     /// generated code knows which field to assign without any string comparison.
-    pub key: u32,
+    /// See [`Command::key`] on why it is this wide.
+    pub key: u64,
     /// Unused by binding, kept so a table entry can carry its own name for
     /// diagnostics.
     pub name: &'a str,
@@ -175,8 +183,9 @@ impl Flag<'_> {
 /// A positional argument.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Arg<'a> {
-    /// Caller-assigned identifier, echoed back in [`Event::Arg`].
-    pub key: u32,
+    /// Caller-assigned identifier, echoed back in [`Event::Arg`]. See
+    /// [`Command::key`] on why it is this wide.
+    pub key: u64,
     /// Whether this argument keeps taking values once it has one.
     pub var: bool,
     /// This argument's relationship to the `--` separator.

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -26,6 +26,30 @@ use core::fmt::Write as _;
 use crate::UnknownFlags;
 use crate::{Arg, Command, DoubleDash, Flag};
 
+/// The first key that appears twice anywhere in a command tree, if any.
+///
+/// Keys are what a parse dispatches on, and a derive assigns them without being able
+/// to see other expansions — it hashes the type name to keep them apart. That makes
+/// a collision astronomically unlikely rather than impossible, so it is checked
+/// where a CLI is written out, which every adopter does in a test.
+fn duplicate_key(cmd: &Command<'_>) -> Option<u64> {
+    let mut keys = std::vec::Vec::new();
+    collect_keys(cmd, &mut keys);
+    keys.sort_unstable();
+    keys.windows(2)
+        .find(|pair| pair[0] == pair[1])
+        .map(|pair| pair[0])
+}
+
+fn collect_keys(cmd: &Command<'_>, keys: &mut std::vec::Vec<u64>) {
+    keys.push(cmd.key);
+    keys.extend(cmd.flags.iter().map(|f| f.key));
+    keys.extend(cmd.args.iter().map(|a| a.key));
+    for sub in cmd.subcommands {
+        collect_keys(sub, keys);
+    }
+}
+
 /// A whole CLI: the root command plus what describes the program itself.
 #[derive(Debug, Clone, Copy)]
 pub struct Spec<'a> {
@@ -220,6 +244,13 @@ impl Effect {
 impl Spec<'_> {
     /// Write this CLI as a usage spec, in KDL.
     pub fn to_kdl(&self) -> String {
+        debug_assert!(
+            duplicate_key(self.root.cmd).is_none(),
+            "two things in this CLI share a key ({:?}), so a parse would bind the \
+             wrong one. A derive builds keys from a hash of the type they came from, \
+             so this means two type names collided.",
+            duplicate_key(self.root.cmd)
+        );
         let mut out = String::new();
         // Unwrap-free: writing into a String cannot fail, and `write!` returning
         // Result is an artifact of the trait rather than a real outcome.
@@ -705,6 +736,68 @@ fn quoted(value: &str) -> String {
     }
     out.push('"');
     out
+}
+
+/// A struct that describes one command's flags and arguments.
+///
+/// Implemented by the derive on a subcommand's argument struct. The root's
+/// generated parse needs to name the type that accumulates a subcommand's values
+/// while parsing, and cannot know which module the derive put it in — an
+/// associated type is how it names it regardless.
+pub trait CommandArgs: Sized {
+    /// Values collected so far. Partly-filled by construction, since a parse can
+    /// stop early.
+    type Partial: Default;
+
+    /// The parse tables for this command.
+    ///
+    /// A const rather than a method, because a parent splices it into its own
+    /// `static` tables and a method call is not allowed there. That is the whole
+    /// reason this trait exists: the tables stay static all the way down, so
+    /// nothing is built at run time to start a parse.
+    const COMMAND: &'static Command<'static>;
+
+    /// The metadata for this command.
+    const META: &'static CommandMeta<'static>;
+
+    /// A partial with any declared defaults already in place.
+    ///
+    /// Not `Default::default()`, because a default has to be there before parsing
+    /// starts: nothing afterwards distinguishes it from what the user typed.
+    fn start() -> Self::Partial;
+
+    /// Take one event, and say whether it belonged to this command.
+    ///
+    /// Keys are unique across a CLI, so an event that is not this command's is left
+    /// for whoever owns it rather than mistaken for a local field.
+    fn apply(partial: &mut Self::Partial, event: &crate::Event<'_, '_>) -> bool;
+
+    /// Build the struct from what was collected.
+    fn build(partial: Self::Partial) -> Self;
+}
+
+/// An enum whose variants are a command's subcommands.
+///
+/// Implemented by the derive on the enum a `subcommand` field holds.
+pub trait Subcommands: Sized {
+    /// Values collected for whichever variant is being filled.
+    type Partial: Default;
+
+    /// The parse tables for the variants, to splice into the parent command's
+    /// `static` tables — hence a const. See [`CommandArgs::COMMAND`].
+    const COMMANDS: &'static [&'static Command<'static>];
+
+    /// The metadata for the variants, in the same order.
+    const METAS: &'static [&'static CommandMeta<'static>];
+
+    /// Take one event, and say whether it belonged to one of these commands.
+    fn apply(partial: &mut Self::Partial, event: &crate::Event<'_, '_>) -> bool;
+
+    /// Build the variant whose command was selected, by its [`Command::key`].
+    ///
+    /// `None` when no variant was selected, which a caller reads as "no subcommand
+    /// was given".
+    fn select(partial: Self::Partial, key: u64) -> Option<Self>;
 }
 
 #[cfg(test)]

--- a/conformance/tests/snapshots/subcommands__the_emitted_spec_reads_the_way_a_handwritten_one_would.snap
+++ b/conformance/tests/snapshots/subcommands__the_emitted_spec_reads_the_way_a_handwritten_one_would.snap
@@ -1,0 +1,19 @@
+---
+source: conformance/tests/subcommands.rs
+expression: "Ex::to_kdl()"
+---
+name "ex"
+bin "ex"
+version "1.0"
+about "A tool that does things"
+flag "-v --verbose" help="Say more" global=#true
+cmd "install" help="Install a tool" {
+    flag "-f --force" help="Overwrite an existing install"
+    flag "-j --jobs" help="How many at once" default="4" {
+        arg "<jobs>"
+    }
+    arg "[tools]..." help="What to install"
+}
+cmd "run" help="Run a task" {
+    arg "<task>" help="The task to run"
+}

--- a/conformance/tests/subcommands.rs
+++ b/conformance/tests/subcommands.rs
@@ -46,6 +46,79 @@ struct Run {
     task: String,
 }
 
+/// A second CLI where the variant's name and the struct's differ, and where one
+/// argument struct is shared by two variants. The first version passed its tests by
+/// coincidence: `RunTask(Run)` named its command `run` either way.
+#[derive(Cli)]
+#[usage(bin = "two")]
+struct Two {
+    #[usage(subcommand)]
+    command: Option<TwoCommands>,
+}
+
+#[derive(Subcommands)]
+enum TwoCommands {
+    /// Add a thing
+    #[usage(name = "add")]
+    Install(AddArgs),
+    /// Remove a thing
+    #[usage(name = "remove")]
+    Uninstall(RemoveArgs),
+}
+
+/// The struct's description, which the variant's overrides
+#[derive(Args)]
+struct AddArgs {
+    /// What to add
+    target: String,
+}
+
+/// Also overridden
+#[derive(Args)]
+struct RemoveArgs {
+    /// What to remove
+    target: String,
+}
+
+#[test]
+fn the_variant_names_the_command_not_the_struct() {
+    let a = argv(["add", "x"]);
+    let two = Two::parse_from(&a).expect("`add` should route");
+    assert!(matches!(two.command, Some(TwoCommands::Install(_))));
+
+    // And the struct's own name is not a command at all.
+    let a = argv(["shared", "x"]);
+    assert!(
+        Two::parse_from(&a).is_err(),
+        "the struct's name should not select anything"
+    );
+
+    let spec: LibSpec = Two::to_kdl().parse().expect("valid spec");
+    let mut names: Vec<&str> = spec.cmd.subcommands.keys().map(String::as_str).collect();
+    names.sort();
+    assert_eq!(names, ["add", "remove"]);
+}
+
+#[test]
+fn each_command_collects_into_its_own_struct() {
+    // Two variants wrapping one struct is refused at compile time, because a
+    // command's values go into the struct that declares them: sharing one would
+    // collect into whichever command was reached first. Each here has its own.
+    let a = argv(["remove", "y"]);
+    let two = Two::parse_from(&a).expect("`remove` should route");
+    let Some(TwoCommands::Uninstall(args)) = two.command else {
+        panic!("expected the remove command");
+    };
+    assert_eq!(args.target, "y");
+
+    let a = argv(["add", "x"]);
+    let two = Two::parse_from(&a).expect("`add` should route");
+    let Some(TwoCommands::Install(args)) = two.command else {
+        panic!("expected the add command");
+    };
+    assert_eq!(args.target, "x");
+}
+
 fn argv<const N: usize>(tokens: [&str; N]) -> [&OsStr; N] {
     tokens.map(OsStr::new)
 }

--- a/conformance/tests/subcommands.rs
+++ b/conformance/tests/subcommands.rs
@@ -1,0 +1,165 @@
+//! Subcommands, end to end: routing, per-command values, and the emitted spec.
+
+use std::ffi::OsStr;
+
+use usage::Spec as LibSpec;
+use usage_derive::{Args, Cli, Subcommands};
+
+/// A tool that does things
+#[derive(Cli)]
+#[usage(bin = "ex", version = "1.0")]
+struct Ex {
+    /// Say more
+    #[usage(short = 'v', long, global)]
+    verbose: bool,
+    /// What to do
+    #[usage(subcommand)]
+    command: Option<Commands>,
+}
+
+#[derive(Subcommands)]
+enum Commands {
+    /// Install a tool
+    Install(Install),
+    /// Run a task
+    #[usage(name = "run")]
+    RunTask(Run),
+}
+
+/// The struct's own description, which the variant's overrides
+#[derive(Args)]
+struct Install {
+    /// Overwrite an existing install
+    #[usage(short = 'f', long)]
+    force: bool,
+    /// How many at once
+    #[usage(short = 'j', long, default = "4")]
+    jobs: Option<String>,
+    /// What to install
+    tools: Vec<String>,
+}
+
+/// Run a task
+#[derive(Args)]
+struct Run {
+    /// The task to run
+    task: String,
+}
+
+fn argv<const N: usize>(tokens: [&str; N]) -> [&OsStr; N] {
+    tokens.map(OsStr::new)
+}
+
+#[test]
+fn a_word_selects_a_command_and_its_own_fields_are_filled() {
+    let a = argv(["install", "--force", "node@20", "go@1.22"]);
+    let ex = Ex::parse_from(&a).expect("should parse");
+
+    let Some(Commands::Install(install)) = ex.command else {
+        panic!("expected the install command");
+    };
+    assert!(install.force);
+    assert_eq!(install.tools, ["node@20", "go@1.22"]);
+    // A declared default is in place before parsing starts, so an untouched flag
+    // still has it.
+    assert_eq!(install.jobs.as_deref(), Some("4"));
+}
+
+#[test]
+fn another_variant_routes_by_its_own_name() {
+    // `run` rather than `run-task`: the variant renames itself.
+    let a = argv(["run", "build"]);
+    let ex = Ex::parse_from(&a).expect("should parse");
+    let Some(Commands::RunTask(run)) = ex.command else {
+        panic!("expected the run command");
+    };
+    assert_eq!(run.task, "build");
+}
+
+#[test]
+fn no_subcommand_leaves_the_field_empty() {
+    let a = argv(["--verbose"]);
+    let ex = Ex::parse_from(&a).expect("should parse");
+    assert!(ex.verbose);
+    assert!(ex.command.is_none());
+}
+
+#[test]
+fn a_global_flag_works_on_either_side_of_the_command() {
+    for tokens in [["--verbose", "run", "build"], ["run", "build", "--verbose"]] {
+        let a = argv(tokens);
+        let ex = Ex::parse_from(&a).expect("should parse");
+        assert!(ex.verbose, "{tokens:?}");
+        assert!(
+            matches!(ex.command, Some(Commands::RunTask(_))),
+            "{tokens:?}"
+        );
+    }
+}
+
+#[test]
+fn one_command_does_not_see_another_ones_flag() {
+    // `--force` belongs to `install`, so `run` does not answer to it. Leniently it
+    // becomes a word, and `run` has one argument to hold it.
+    let a = argv(["run", "--force"]);
+    let ex = Ex::parse_from(&a).expect("should parse");
+    let Some(Commands::RunTask(run)) = ex.command else {
+        panic!("expected the run command");
+    };
+    assert_eq!(run.task, "--force");
+}
+
+#[test]
+fn the_spec_carries_the_commands() {
+    let kdl = Ex::to_kdl();
+    let spec: LibSpec = kdl.parse().unwrap_or_else(|e| panic!("{e}\n\n{kdl}"));
+
+    assert_eq!(spec.bin, "ex");
+    let mut names: Vec<&str> = spec.cmd.subcommands.keys().map(String::as_str).collect();
+    names.sort();
+    assert_eq!(names, ["install", "run"]);
+
+    let install = &spec.cmd.subcommands["install"];
+    // The variant's doc comment wins: it is where a reader of the enum expects to
+    // describe the command, and ignoring it would lose the description silently.
+    assert_eq!(install.help.as_deref(), Some("Install a tool"));
+    assert_eq!(install.flags.len(), 2);
+    assert_eq!(install.args.len(), 1);
+    assert!(install.args[0].var, "`tools` is a Vec, so it takes several");
+
+    let run = &spec.cmd.subcommands["run"];
+    assert_eq!(run.help.as_deref(), Some("Run a task"));
+    assert_eq!(run.args[0].name, "task");
+}
+
+#[test]
+fn keys_are_unique_across_independently_expanded_types() {
+    // Each derive assigns keys without seeing the others, so a collision would bind
+    // the wrong field. Checked here rather than trusted.
+    let mut keys = vec![Ex::command().key];
+    for cmd in Ex::command().subcommands {
+        keys.push(cmd.key);
+        for flag in cmd.flags {
+            keys.push(flag.key);
+        }
+        for arg in cmd.args {
+            keys.push(arg.key);
+        }
+    }
+    for flag in Ex::command().flags {
+        keys.push(flag.key);
+    }
+
+    let mut sorted = keys.clone();
+    sorted.sort_unstable();
+    sorted.dedup();
+    assert_eq!(sorted.len(), keys.len(), "duplicate keys in {keys:?}");
+}
+
+#[test]
+fn the_emitted_spec_reads_the_way_a_handwritten_one_would() {
+    // The whole point of emitting KDL: what comes out is what a person would have
+    // written, and `usage g markdown|manpage` reads it without knowing a derive was
+    // involved.
+    insta::assert_snapshot!(Ex::to_kdl());
+}

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -90,11 +90,14 @@ pub fn emit(cli: &Cli) -> TokenStream {
                     let mut __usage_sub =
                         <<#ty as ::usage_argv::spec::Subcommands>::Partial as
                             ::std::default::Default>::default();
-                    let mut __usage_selected: u64 = 0;
+                    // `None` rather than a reserved key: nothing has to be true about
+                    // the number space for "no subcommand was given" to be sayable.
+                    let mut __usage_selected: ::std::option::Option<u64> =
+                        ::std::option::Option::None;
                 },
                 quote! {
                     if let ::usage_argv::Event::Command(__usage_cmd) = &__usage_event {
-                        __usage_selected = __usage_cmd.key;
+                        __usage_selected = ::std::option::Option::Some(__usage_cmd.key);
                     }
                     <#ty as ::usage_argv::spec::Subcommands>::apply(
                         &mut __usage_sub,
@@ -102,10 +105,15 @@ pub fn emit(cli: &Cli) -> TokenStream {
                     );
                 },
                 quote! {
-                    #ident: <#ty as ::usage_argv::spec::Subcommands>::select(
-                        __usage_sub,
-                        __usage_selected,
-                    ),
+                    #ident: match __usage_selected {
+                        ::std::option::Option::Some(__usage_key) => {
+                            <#ty as ::usage_argv::spec::Subcommands>::select(
+                                __usage_sub,
+                                __usage_key,
+                            )
+                        }
+                        ::std::option::Option::None => ::std::option::Option::None,
+                    },
                 },
             )
         }
@@ -407,9 +415,28 @@ fn key_base(type_name: &str) -> u64 {
 /// type has to say `super::`. An absolute path already resolves from anywhere and is
 /// left alone.
 fn in_module(ty: &syn::Type) -> TokenStream {
-    match ty {
-        syn::Type::Path(path) if path.path.leading_colon.is_none() => quote!(super::#ty),
-        _ => quote!(#ty),
+    let syn::Type::Path(path) = ty else {
+        return quote!(#ty);
+    };
+    // Already absolute, or rooted at the crate: resolves the same from anywhere.
+    if path.path.leading_colon.is_some() {
+        return quote!(#ty);
+    }
+    let mut segments = path.path.segments.iter();
+    match segments.next().map(|s| s.ident.to_string()).as_deref() {
+        Some("crate") => quote!(#ty),
+        // `self` and `super` are relative to where the user wrote them, which is one
+        // level out from the generated module — so each shifts by one.
+        Some("self") => {
+            let rest = segments;
+            quote!(super::#(#rest)::*)
+        }
+        Some("super") => {
+            let rest = segments;
+            quote!(super::super::#(#rest)::*)
+        }
+        // A relative path, which the generated module is one level below.
+        _ => quote!(super::#ty),
     }
 }
 
@@ -429,7 +456,7 @@ fn flag_arm(i: usize, field: &Field, base: u64) -> TokenStream {
         Shape::Many => quote!(partial.#ident.push(__usage_value_text(value));),
     };
     quote! {
-        #key => { #body }
+        #key => { #body true }
     }
 }
 
@@ -444,7 +471,7 @@ fn arg_arm(i: usize, field: &Field, base: u64) -> TokenStream {
         _ => quote!(partial.#ident = __usage_text(value);),
     };
     quote! {
-        #key => { #body }
+        #key => { #body true }
     }
 }
 
@@ -541,6 +568,9 @@ fn apply_fn(cli: &Cli, base: u64) -> TokenStream {
             event: &::usage_argv::Event<'_, '_>,
         ) -> bool {
             use ::usage_argv::Event;
+            // Each arm evaluates to whether it claimed the event, rather than
+            // returning: a command with no flags of its own would otherwise have every
+            // arm diverge, leaving an unreachable tail.
             match event {
                 Event::Flag { flag, value, negated } => {
                     let (value, negated) = (*value, *negated);
@@ -548,7 +578,7 @@ fn apply_fn(cli: &Cli, base: u64) -> TokenStream {
                     match flag.key {
                         #(#flag_arms)*
                         // Another command's flag, left for whoever owns it.
-                        _ => return false,
+                        _ => false,
                     }
                 }
                 Event::Arg { arg, value } => {
@@ -556,14 +586,13 @@ fn apply_fn(cli: &Cli, base: u64) -> TokenStream {
                     let _ = value;
                     match arg.key {
                         #(#arg_arms)*
-                        _ => return false,
+                        _ => false,
                     }
                 }
                 // Descending is the caller's business: it is what decides which
                 // command's fields the following events belong to.
-                Event::Command(_) => return false,
+                Event::Command(_) => false,
             }
-            true
         }
     }
 }
@@ -717,39 +746,59 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
             }
         }
     });
-    let commands = subs.variants.iter().map(|v| {
-        let ty = &v.ty;
-        quote!(<#ty as ::usage_argv::spec::CommandArgs>::COMMAND)
+    // The enum is where the command set is declared, so the variant names the
+    // command — its own kebab-case name, or whatever `name` says. Splicing the
+    // struct's table unchanged would have used the *struct's* name instead, which
+    // only looks right when the two happen to match.
+    let command_overrides = subs.variants.iter().enumerate().map(|(i, v)| {
+        let name = format_ident!("COMMAND_{i}");
+        let ty = in_module(&v.ty);
+        let cmd_name = &v.name;
+        quote! {
+            pub static #name: ::usage_argv::Command = ::usage_argv::Command {
+                name: #cmd_name,
+                ..*<#ty as ::usage_argv::spec::CommandArgs>::COMMAND
+            };
+        }
+    });
+    let commands = (0..subs.variants.len()).map(|i| {
+        let name = format_ident!("COMMAND_{i}");
+        quote!(&#module::#name)
     });
     // A doc comment on the variant wins over the struct's, since that is where a
     // reader of the enum expects to describe the command — and ignoring it would lose
     // the description without saying so. Overriding one field of the struct's
     // metadata is possible in a const, so the tables stay static.
-    let meta_overrides = subs.variants.iter().enumerate().filter_map(|(i, v)| {
+    let meta_overrides = subs.variants.iter().enumerate().map(|(i, v)| {
         let name = format_ident!("META_{i}");
+        let cmd = format_ident!("COMMAND_{i}");
         let ty = in_module(&v.ty);
-        let about = option_str(v.help.as_deref());
-        let long_about = option_str(v.long_help.as_deref());
-        v.help.as_ref().map(|_| {
-            quote! {
-                pub static #name: ::usage_argv::spec::CommandMeta =
-                    ::usage_argv::spec::CommandMeta {
-                        about: #about,
-                        long_about: #long_about,
-                        ..*<#ty as ::usage_argv::spec::CommandArgs>::META
-                    };
-            }
-        })
-    });
-    let metas = subs.variants.iter().enumerate().map(|(i, v)| {
-        let ty = &v.ty;
-        match v.help {
-            Some(_) => {
-                let name = format_ident!("META_{i}");
-                quote!(&#module::#name)
-            }
-            None => quote!(<#ty as ::usage_argv::spec::CommandArgs>::META),
+        // A doc comment on the variant wins over the struct's, since that is where a
+        // reader of the enum expects to describe the command. Absent one, the
+        // struct's own description carries through.
+        let (about, long_about) = match &v.help {
+            Some(_) => (
+                option_str(v.help.as_deref()),
+                option_str(v.long_help.as_deref()),
+            ),
+            None => (
+                quote!(<#ty as ::usage_argv::spec::CommandArgs>::META.about),
+                quote!(<#ty as ::usage_argv::spec::CommandArgs>::META.long_about),
+            ),
+        };
+        quote! {
+            pub static #name: ::usage_argv::spec::CommandMeta =
+                ::usage_argv::spec::CommandMeta {
+                    cmd: &#cmd,
+                    about: #about,
+                    long_about: #long_about,
+                    ..*<#ty as ::usage_argv::spec::CommandArgs>::META
+                };
         }
+    });
+    let metas = (0..subs.variants.len()).map(|i| {
+        let name = format_ident!("META_{i}");
+        quote!(&#module::#name)
     });
     // Matched on the command's key rather than its name, so selecting a variant is
     // an integer comparison and cannot be confused by an alias.
@@ -780,6 +829,7 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
                 }
             }
 
+            #(#command_overrides)*
             #(#meta_overrides)*
         }
 

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -15,7 +15,7 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
-use crate::model::{Cli, Field, Kind, Shape};
+use crate::model::{Cli, Field, Kind, Shape, Subcommands};
 
 pub fn emit(cli: &Cli) -> TokenStream {
     let ident = &cli.ident;
@@ -39,8 +39,13 @@ pub fn emit(cli: &Cli) -> TokenStream {
         _ => quote!(::usage_argv::UnknownFlags::Value),
     };
 
-    let flag_tables = flags.iter().enumerate().map(|(i, f)| flag_table(i, f));
-    let arg_tables = args.iter().enumerate().map(|(i, f)| arg_table(i, f));
+    let base = key_base(&ident.to_string());
+    let root_key = base | KIND_COMMAND;
+    let flag_tables = flags
+        .iter()
+        .enumerate()
+        .map(|(i, f)| flag_table(i, f, base));
+    let arg_tables = args.iter().enumerate().map(|(i, f)| arg_table(i, f, base));
     let flag_metas = flags.iter().enumerate().map(|(i, f)| flag_meta(i, f));
     let arg_metas = args.iter().enumerate().map(|(i, f)| arg_meta(i, f));
 
@@ -61,17 +66,66 @@ pub fn emit(cli: &Cli) -> TokenStream {
     let about = option_str(cli.about.as_deref());
     let long_about = option_str(cli.long_about.as_deref());
 
-    let field_inits = cli.fields.iter().map(field_init);
-    let flag_arms = flags.iter().enumerate().map(|(i, f)| flag_arm(i, f));
-    let arg_arms = args.iter().enumerate().map(|(i, f)| arg_arm(i, f));
+    // The field holding this command's subcommands, if it declares any. Its type is
+    // reached through the `Subcommands` trait, since the derive cannot see the enum.
+    let subcommand = cli.fields.iter().find_map(|f| match &f.kind {
+        Kind::Subcommand { ty, .. } => Some((f, ty)),
+        _ => None,
+    });
+    let (sub_commands, sub_metas) = match subcommand {
+        Some((_, ty)) => {
+            let ty = in_module(ty);
+            (
+                quote!(subcommands: <#ty as ::usage_argv::spec::Subcommands>::COMMANDS,),
+                quote!(subcommands: <#ty as ::usage_argv::spec::Subcommands>::METAS,),
+            )
+        }
+        None => (quote!(), quote!()),
+    };
+    let (sub_init, sub_route, sub_build) = match subcommand {
+        Some((field, ty)) => {
+            let ident = &field.ident;
+            (
+                quote! {
+                    let mut __usage_sub =
+                        <<#ty as ::usage_argv::spec::Subcommands>::Partial as
+                            ::std::default::Default>::default();
+                    let mut __usage_selected: u64 = 0;
+                },
+                quote! {
+                    if let ::usage_argv::Event::Command(__usage_cmd) = &__usage_event {
+                        __usage_selected = __usage_cmd.key;
+                    }
+                    <#ty as ::usage_argv::spec::Subcommands>::apply(
+                        &mut __usage_sub,
+                        &__usage_event,
+                    );
+                },
+                quote! {
+                    #ident: <#ty as ::usage_argv::spec::Subcommands>::select(
+                        __usage_sub,
+                        __usage_selected,
+                    ),
+                },
+            )
+        }
+        None => (quote!(), quote!(), quote!()),
+    };
+
+    let partial = partial_struct(cli);
+    let defaults = partial_defaults(cli);
+    let apply = apply_fn(cli, base);
     // `field: local` rather than the shorthand, because the locals are prefixed:
     // a field called `text` or `parser` would otherwise collide with something the
     // generated code needs.
-    let field_finals = cli.fields.iter().map(|f| {
-        let ident = &f.ident;
-        let local = local_ident(f);
-        quote!(#ident: #local)
-    });
+    let field_finals = cli
+        .fields
+        .iter()
+        .filter(|f| !matches!(f.kind, Kind::Subcommand { .. }))
+        .map(|f| {
+            let ident = &f.ident;
+            quote!(#ident: partial.#ident)
+        });
 
     quote! {
         #[doc(hidden)]
@@ -86,8 +140,10 @@ pub fn emit(cli: &Cli) -> TokenStream {
             pub static ROOT: Command = Command {
                 unknown_flags: #unknown_flags,
                 name: #name,
+                key: #root_key,
                 flags: &[#(#flag_refs),*],
                 args: &[#(#arg_refs),*],
+                #sub_commands
                 ..Command::EMPTY
             };
 
@@ -100,8 +156,26 @@ pub fn emit(cli: &Cli) -> TokenStream {
                 long_about: #long_about,
                 flags: &[#(#flag_meta_refs),*],
                 args: &[#(#arg_meta_refs),*],
+                #sub_metas
                 ..CommandMeta::EMPTY
             };
+
+            // Values arrive as the bytes that were on the command line. This version
+            // holds them as `String`, and converts lossily, which is what mise
+            // already does with its own argv. Rejecting a non-UTF-8 value needs an
+            // error type for value conversion, and that arrives with typed fields.
+            pub fn __usage_text(value: &[u8]) -> ::std::string::String {
+                ::std::string::String::from_utf8_lossy(value).into_owned()
+            }
+
+            pub fn __usage_value_text(
+                value: ::std::option::Option<&[u8]>,
+            ) -> ::std::string::String {
+                value.map(__usage_text).unwrap_or_default()
+            }
+
+            #partial
+            #apply
 
             pub static SPEC: Spec = Spec {
                 name: #name,
@@ -140,52 +214,27 @@ pub fn emit(cli: &Cli) -> TokenStream {
             ) -> ::std::result::Result<Self, ::usage_argv::Error<'static, 'v>> {
                 use ::usage_argv::Event;
 
-                // Values arrive as the bytes that were on the command line. This
-                // version holds them as `String`, and converts lossily, which is
-                // what mise already does with its own argv. Rejecting a non-UTF-8
-                // value needs an error type for value conversion, and that arrives
-                // with typed fields.
-                fn __usage_text(value: &[u8]) -> ::std::string::String {
-                    ::std::string::String::from_utf8_lossy(value).into_owned()
-                }
-                fn __usage_value_text(
-                    value: ::std::option::Option<&[u8]>,
-                ) -> ::std::string::String {
-                    value.map(__usage_text).unwrap_or_default()
-                }
+                use #module::Partial;
 
-                #(#field_inits)*
+                #defaults
+                #sub_init
 
                 let mut __usage_parser = ::usage_argv::Parser::new(Self::command(), argv);
                 while let ::std::option::Option::Some(__usage_event) =
                     __usage_parser.next_event()
                 {
-                    match __usage_event? {
-                        Event::Flag { flag, value, negated } => {
-                            // Both are `Copy`, and a CLI with no boolean flag would
-                            // otherwise leave one of them unread.
-                            let _ = (value, negated);
-                            match flag.key {
-                            #(#flag_arms)*
-                            // Unreachable: every table entry above was emitted
-                            // from a field, and the parser only reports entries
-                            // it was given.
-                            _ => {}
-                            }
-                        }
-                        Event::Arg { arg, value } => {
-                            let _ = value;
-                            match arg.key {
-                            #(#arg_arms)*
-                            _ => {}
-                            }
-                        }
-                        // This version has no subcommands to descend into.
-                        Event::Command(_) => {}
+                    let __usage_event = __usage_event?;
+                    // This command's own fields first. Keys are unique across the
+                    // CLI, so anything it does not claim belongs to a subcommand.
+                    if !#module::apply(&mut partial, &__usage_event) {
+                        #sub_route
                     }
                 }
 
-                ::std::result::Result::Ok(Self { #(#field_finals),* })
+                ::std::result::Result::Ok(Self {
+                    #sub_build
+                    #(#field_finals),*
+                })
             }
 
             /// Parse the process's own arguments.
@@ -203,9 +252,9 @@ pub fn emit(cli: &Cli) -> TokenStream {
     }
 }
 
-fn flag_table(i: usize, field: &Field) -> TokenStream {
+fn flag_table(i: usize, field: &Field, base: u64) -> TokenStream {
     let name = format_ident!("FLAG_{i}");
-    let key = i as u32;
+    let key = base | KIND_FLAG | i as u64;
     let field_name = &field.name;
     let Kind::Flag {
         longs,
@@ -235,11 +284,9 @@ fn flag_table(i: usize, field: &Field) -> TokenStream {
     }
 }
 
-fn arg_table(i: usize, field: &Field) -> TokenStream {
+fn arg_table(i: usize, field: &Field, base: u64) -> TokenStream {
     let name = format_ident!("ARG_{i}");
-    // Keys are separate spaces for flags and arguments, since the parser reports
-    // which of the two it bound.
-    let key = i as u32;
+    let key = base | KIND_ARG | i as u64;
     let field_name = &field.name;
     let var = field.shape == Shape::Many;
     let Kind::Arg {
@@ -325,76 +372,76 @@ fn arg_meta(i: usize, field: &Field) -> TokenStream {
     }
 }
 
-/// The name of the local a field accumulates into.
+/// Which kind of thing a key belongs to, in the bits above its index.
 ///
-/// Prefixed, so a field called `text`, `parser`, or `argv` cannot shadow anything
-/// the generated code relies on.
-fn local_ident(field: &Field) -> proc_macro2::Ident {
-    format_ident!("__usage_field_{}", field.ident)
+/// A command, a flag, and an argument each get their own space, so no two things in
+/// one type can share a key even though each counts its own from zero. The parser
+/// says which kind it bound, so this is not needed in order to *dispatch* — it is
+/// needed so that "every key in the tree is distinct" is true, which is what makes a
+/// collision between two types detectable at all.
+const KIND_FLAG: u64 = 0;
+const KIND_ARG: u64 = 1 << 30;
+const KIND_COMMAND: u64 = 2 << 30;
+
+/// The high half of every key a type's fields get.
+///
+/// Two macro expansions cannot see each other, so a shared counter is not available:
+/// keys carry a hash of the type they came from instead. A parse dispatches on the
+/// key, so two type names would have to collide in 32 bits to bind the wrong field,
+/// and `Spec::to_kdl` asserts the tree has no duplicates.
+fn key_base(type_name: &str) -> u64 {
+    // FNV-1a, spelled out rather than taken from a `Hasher`, which is not guaranteed
+    // to be stable between compilations — and these end up baked into generated code.
+    let mut hash: u32 = 0x811c_9dc5;
+    for byte in type_name.as_bytes() {
+        hash ^= *byte as u32;
+        hash = hash.wrapping_mul(0x0100_0193);
+    }
+    (hash as u64) << 32
 }
 
-/// The local each field accumulates into while parsing.
-fn field_init(field: &Field) -> TokenStream {
-    let ident = local_ident(field);
-    match field.shape {
-        Shape::Bool => {
-            // A negatable flag's default is whatever `default` says, since
-            // `--no-x` has to be able to turn something off.
-            let start = field.default.as_deref() == Some("true");
-            quote!(let mut #ident = #start;)
-        }
-        Shape::Count => {
-            // Typed, so `saturating_add` below resolves to the field's own integer.
-            let ty = &field.ty;
-            quote!(let mut #ident: #ty = 0;)
-        }
-        Shape::Optional => {
-            let default = match field.default.as_deref() {
-                Some(d) => quote!(::std::option::Option::Some(#d.to_string())),
-                None => quote!(::std::option::Option::None),
-            };
-            quote!(let mut #ident = #default;)
-        }
-        Shape::Required => {
-            let default = match field.default.as_deref() {
-                Some(d) => quote!(#d.to_string()),
-                None => quote!(::std::string::String::new()),
-            };
-            quote!(let mut #ident = #default;)
-        }
-        Shape::Many => quote!(let mut #ident = ::std::vec::Vec::new();),
+/// A user's type, named from inside a generated module.
+///
+/// The generated `mod` is a child of wherever the derive was written, and a name
+/// from the parent scope is not in scope inside it — so a reference to the user's own
+/// type has to say `super::`. An absolute path already resolves from anywhere and is
+/// left alone.
+fn in_module(ty: &syn::Type) -> TokenStream {
+    match ty {
+        syn::Type::Path(path) if path.path.leading_colon.is_none() => quote!(super::#ty),
+        _ => quote!(#ty),
     }
 }
 
-fn flag_arm(i: usize, field: &Field) -> TokenStream {
-    let key = i as u32;
-    let ident = local_ident(field);
+fn flag_arm(i: usize, field: &Field, base: u64) -> TokenStream {
+    let key = base | KIND_FLAG | i as u64;
+    let ident = &field.ident;
     let body = match field.shape {
         // `negated` is what distinguishes `--color` from `--no-color`.
-        Shape::Bool => quote!(#ident = !negated;),
+        Shape::Bool => quote!(partial.#ident = !negated;),
         // Saturating, because a `u8` field given 256 occurrences would otherwise
         // panic in debug and wrap to zero in release.
-        Shape::Count => quote!(#ident = #ident.saturating_add(1);),
+        Shape::Count => quote!(partial.#ident = partial.#ident.saturating_add(1);),
         Shape::Optional => quote! {
-            #ident = ::std::option::Option::Some(__usage_value_text(value));
+            partial.#ident = ::std::option::Option::Some(__usage_value_text(value));
         },
-        Shape::Required => quote!(#ident = __usage_value_text(value);),
-        Shape::Many => quote!(#ident.push(__usage_value_text(value));),
+        Shape::Required => quote!(partial.#ident = __usage_value_text(value);),
+        Shape::Many => quote!(partial.#ident.push(__usage_value_text(value));),
     };
     quote! {
         #key => { #body }
     }
 }
 
-fn arg_arm(i: usize, field: &Field) -> TokenStream {
-    let key = i as u32;
-    let ident = local_ident(field);
+fn arg_arm(i: usize, field: &Field, base: u64) -> TokenStream {
+    let key = base | KIND_ARG | i as u64;
+    let ident = &field.ident;
     let body = match field.shape {
-        Shape::Many => quote!(#ident.push(__usage_text(value));),
+        Shape::Many => quote!(partial.#ident.push(__usage_text(value));),
         Shape::Optional => quote! {
-            #ident = ::std::option::Option::Some(__usage_text(value));
+            partial.#ident = ::std::option::Option::Some(__usage_text(value));
         },
-        _ => quote!(#ident = __usage_text(value);),
+        _ => quote!(partial.#ident = __usage_text(value);),
     };
     quote! {
         #key => { #body }
@@ -405,5 +452,357 @@ fn option_str(value: Option<&str>) -> TokenStream {
     match value {
         Some(v) => quote!(::std::option::Option::Some(#v)),
         None => quote!(::std::option::Option::None),
+    }
+}
+
+/// The struct that collects values while parsing.
+///
+/// One field per declared field, of the type that accumulates it: a `bool` for a
+/// switch, a `Vec` for something repeatable, and so on. It exists so the same
+/// generated `apply` serves a root command and a subcommand's arguments — a
+/// subcommand cannot use locals in the root's parse function, because the root
+/// cannot see its fields.
+fn partial_struct(cli: &Cli) -> TokenStream {
+    let fields = cli.fields.iter().filter_map(|f| {
+        if matches!(f.kind, Kind::Subcommand { .. }) {
+            // Its values live in the enum's own partial.
+            return None;
+        }
+        let ident = &f.ident;
+        let ty = match f.shape {
+            Shape::Bool => quote!(bool),
+            Shape::Count => {
+                let ty = &f.ty;
+                quote!(#ty)
+            }
+            Shape::Optional => quote!(::std::option::Option<::std::string::String>),
+            Shape::Required => quote!(::std::string::String),
+            Shape::Many => quote!(::std::vec::Vec<::std::string::String>),
+        };
+        Some(quote!(pub #ident: #ty,))
+    });
+
+    // `Default` rather than a generated `new`: every accumulator type has one, and
+    // a default that says "nothing was given" is what a partial starts as.
+    quote! {
+        #[derive(Default)]
+        pub struct Partial {
+            #(#fields)*
+        }
+    }
+}
+
+/// The defaults a partial cannot express as `Default::default()`.
+///
+/// A declared `default` has to be in place before parsing starts, since nothing
+/// later distinguishes "the default" from "what the user typed".
+fn partial_defaults(cli: &Cli) -> TokenStream {
+    let assignments = cli.fields.iter().filter_map(|f| {
+        let ident = &f.ident;
+        let default = f.default.as_deref()?;
+        Some(match f.shape {
+            Shape::Bool => {
+                let on = default == "true";
+                quote!(partial.#ident = #on;)
+            }
+            Shape::Optional => {
+                quote!(partial.#ident = ::std::option::Option::Some(#default.to_string());)
+            }
+            Shape::Required => quote!(partial.#ident = #default.to_string();),
+            // Rejected in the model: a count starts at zero, and a default for a
+            // collecting field is not applied yet.
+            Shape::Count | Shape::Many => quote!(),
+        })
+    });
+    quote! {
+        let mut partial = Partial::default();
+        #(#assignments)*
+    }
+}
+
+/// Take one event and say whether it belonged to this command.
+fn apply_fn(cli: &Cli, base: u64) -> TokenStream {
+    let flags: Vec<&Field> = cli
+        .fields
+        .iter()
+        .filter(|f| matches!(f.kind, Kind::Flag { .. }))
+        .collect();
+    let args: Vec<&Field> = cli
+        .fields
+        .iter()
+        .filter(|f| matches!(f.kind, Kind::Arg { .. }))
+        .collect();
+    let flag_arms = flags.iter().enumerate().map(|(i, f)| flag_arm(i, f, base));
+    let arg_arms = args.iter().enumerate().map(|(i, f)| arg_arm(i, f, base));
+
+    quote! {
+        pub fn apply(
+            partial: &mut Partial,
+            event: &::usage_argv::Event<'_, '_>,
+        ) -> bool {
+            use ::usage_argv::Event;
+            match event {
+                Event::Flag { flag, value, negated } => {
+                    let (value, negated) = (*value, *negated);
+                    let _ = (value, negated);
+                    match flag.key {
+                        #(#flag_arms)*
+                        // Another command's flag, left for whoever owns it.
+                        _ => return false,
+                    }
+                }
+                Event::Arg { arg, value } => {
+                    let value = *value;
+                    let _ = value;
+                    match arg.key {
+                        #(#arg_arms)*
+                        _ => return false,
+                    }
+                }
+                // Descending is the caller's business: it is what decides which
+                // command's fields the following events belong to.
+                Event::Command(_) => return false,
+            }
+            true
+        }
+    }
+}
+
+/// A subcommand's argument struct: tables, metadata, and the trait that lets a
+/// parent reach them.
+pub fn emit_args(cli: &Cli) -> TokenStream {
+    let ident = &cli.ident;
+    let module = format_ident!("__usage_args_{}", ident.to_string().to_lowercase());
+    let base = key_base(&ident.to_string());
+    let command_key = base | KIND_COMMAND;
+
+    let flags: Vec<&Field> = cli
+        .fields
+        .iter()
+        .filter(|f| matches!(f.kind, Kind::Flag { .. }))
+        .collect();
+    let args: Vec<&Field> = cli
+        .fields
+        .iter()
+        .filter(|f| matches!(f.kind, Kind::Arg { .. }))
+        .collect();
+
+    let flag_tables = flags
+        .iter()
+        .enumerate()
+        .map(|(i, f)| flag_table(i, f, base));
+    let arg_tables = args.iter().enumerate().map(|(i, f)| arg_table(i, f, base));
+    let flag_metas = flags.iter().enumerate().map(|(i, f)| flag_meta(i, f));
+    let arg_metas = args.iter().enumerate().map(|(i, f)| arg_meta(i, f));
+    let flag_refs = (0..flags.len()).map(|i| {
+        let name = format_ident!("FLAG_{i}");
+        quote!(&#name)
+    });
+    let arg_refs = (0..args.len()).map(|i| {
+        let name = format_ident!("ARG_{i}");
+        quote!(&#name)
+    });
+    let flag_meta_refs = (0..flags.len()).map(|i| format_ident!("FLAG_META_{i}"));
+    let arg_meta_refs = (0..args.len()).map(|i| format_ident!("ARG_META_{i}"));
+
+    let name = &cli.name;
+    let about = option_str(cli.about.as_deref());
+    let long_about = option_str(cli.long_about.as_deref());
+    let partial = partial_struct(cli);
+    let defaults = partial_defaults(cli);
+    let apply = apply_fn(cli, base);
+    let field_finals = cli.fields.iter().map(|f| {
+        let ident = &f.ident;
+        quote!(#ident: partial.#ident)
+    });
+
+    quote! {
+        #[doc(hidden)]
+        #[allow(non_upper_case_globals, non_snake_case, unused_imports)]
+        mod #module {
+            use ::usage_argv::spec::{ArgMeta, CommandMeta, FlagMeta};
+            use ::usage_argv::{Arg, Command, DoubleDash, Flag};
+
+            #(#flag_tables)*
+            #(#arg_tables)*
+
+            pub static COMMAND: Command = Command {
+                name: #name,
+                key: #command_key,
+                flags: &[#(#flag_refs),*],
+                args: &[#(#arg_refs),*],
+                ..Command::EMPTY
+            };
+
+            #(#flag_metas)*
+            #(#arg_metas)*
+
+            pub static COMMAND_META: CommandMeta = CommandMeta {
+                cmd: &COMMAND,
+                about: #about,
+                long_about: #long_about,
+                flags: &[#(#flag_meta_refs),*],
+                args: &[#(#arg_meta_refs),*],
+                ..CommandMeta::EMPTY
+            };
+
+            pub fn __usage_text(value: &[u8]) -> ::std::string::String {
+                ::std::string::String::from_utf8_lossy(value).into_owned()
+            }
+
+            pub fn __usage_value_text(
+                value: ::std::option::Option<&[u8]>,
+            ) -> ::std::string::String {
+                value.map(__usage_text).unwrap_or_default()
+            }
+
+            #partial
+            #apply
+
+            pub fn start() -> Partial {
+                #defaults
+                partial
+            }
+        }
+
+        impl ::usage_argv::spec::CommandArgs for #ident {
+            type Partial = #module::Partial;
+
+            const COMMAND: &'static ::usage_argv::Command<'static> = &#module::COMMAND;
+            const META: &'static ::usage_argv::spec::CommandMeta<'static> =
+                &#module::COMMAND_META;
+
+            fn start() -> Self::Partial {
+                #module::start()
+            }
+
+            fn apply(
+                partial: &mut Self::Partial,
+                event: &::usage_argv::Event<'_, '_>,
+            ) -> bool {
+                #module::apply(partial, event)
+            }
+
+            fn build(partial: Self::Partial) -> Self {
+                Self { #(#field_finals),* }
+            }
+        }
+    }
+}
+
+/// The enum a `subcommand` field holds: its variants' tables, and the trait a
+/// parent uses to route events into them.
+pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
+    let ident = &subs.ident;
+    let module = format_ident!("__usage_subs_{}", ident.to_string().to_lowercase());
+
+    // One partial per variant, since a parse can only fill one but does not know
+    // which until the word arrives.
+    let partial_fields = subs.variants.iter().enumerate().map(|(i, v)| {
+        let field = format_ident!("v{i}");
+        let ty = in_module(&v.ty);
+        quote!(pub #field: <#ty as ::usage_argv::spec::CommandArgs>::Partial,)
+    });
+    let partial_starts = subs.variants.iter().enumerate().map(|(i, v)| {
+        let field = format_ident!("v{i}");
+        let ty = in_module(&v.ty);
+        quote!(#field: <#ty as ::usage_argv::spec::CommandArgs>::start(),)
+    });
+    let applies = subs.variants.iter().enumerate().map(|(i, v)| {
+        let field = format_ident!("v{i}");
+        let ty = &v.ty;
+        quote! {
+            if <#ty as ::usage_argv::spec::CommandArgs>::apply(&mut partial.#field, event) {
+                return true;
+            }
+        }
+    });
+    let commands = subs.variants.iter().map(|v| {
+        let ty = &v.ty;
+        quote!(<#ty as ::usage_argv::spec::CommandArgs>::COMMAND)
+    });
+    // A doc comment on the variant wins over the struct's, since that is where a
+    // reader of the enum expects to describe the command — and ignoring it would lose
+    // the description without saying so. Overriding one field of the struct's
+    // metadata is possible in a const, so the tables stay static.
+    let meta_overrides = subs.variants.iter().enumerate().filter_map(|(i, v)| {
+        let name = format_ident!("META_{i}");
+        let ty = in_module(&v.ty);
+        let about = option_str(v.help.as_deref());
+        let long_about = option_str(v.long_help.as_deref());
+        v.help.as_ref().map(|_| {
+            quote! {
+                pub static #name: ::usage_argv::spec::CommandMeta =
+                    ::usage_argv::spec::CommandMeta {
+                        about: #about,
+                        long_about: #long_about,
+                        ..*<#ty as ::usage_argv::spec::CommandArgs>::META
+                    };
+            }
+        })
+    });
+    let metas = subs.variants.iter().enumerate().map(|(i, v)| {
+        let ty = &v.ty;
+        match v.help {
+            Some(_) => {
+                let name = format_ident!("META_{i}");
+                quote!(&#module::#name)
+            }
+            None => quote!(<#ty as ::usage_argv::spec::CommandArgs>::META),
+        }
+    });
+    // Matched on the command's key rather than its name, so selecting a variant is
+    // an integer comparison and cannot be confused by an alias.
+    let selects = subs.variants.iter().enumerate().map(|(i, v)| {
+        let field = format_ident!("v{i}");
+        let variant = &v.ident;
+        let ty = &v.ty;
+        quote! {
+            if key == <#ty as ::usage_argv::spec::CommandArgs>::COMMAND.key {
+                return ::std::option::Option::Some(
+                    #ident::#variant(<#ty as ::usage_argv::spec::CommandArgs>::build(partial.#field)),
+                );
+            }
+        }
+    });
+
+    quote! {
+        #[doc(hidden)]
+        #[allow(non_upper_case_globals, non_snake_case, unused_imports)]
+        mod #module {
+            pub struct Partial {
+                #(#partial_fields)*
+            }
+
+            impl ::std::default::Default for Partial {
+                fn default() -> Self {
+                    Self { #(#partial_starts)* }
+                }
+            }
+
+            #(#meta_overrides)*
+        }
+
+        impl ::usage_argv::spec::Subcommands for #ident {
+            type Partial = #module::Partial;
+
+            const COMMANDS: &'static [&'static ::usage_argv::Command<'static>] =
+                &[#(#commands),*];
+            const METAS: &'static [&'static ::usage_argv::spec::CommandMeta<'static>] =
+                &[#(#metas),*];
+
+            fn apply(
+                partial: &mut Self::Partial,
+                event: &::usage_argv::Event<'_, '_>,
+            ) -> bool {
+                #(#applies)*
+                false
+            }
+
+            fn select(partial: Self::Partial, key: u64) -> ::std::option::Option<Self> {
+                #(#selects)*
+                ::std::option::Option::None
+            }
+        }
     }
 }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -44,6 +44,48 @@
 //! assert!(Cli::to_kdl().contains(r#"flag "-j --jobs""#));
 //! ```
 //!
+//! # Subcommands
+//!
+//! A field marked `subcommand` holds an enum whose variants each wrap a struct:
+//!
+//! ```ignore
+//! #[derive(Cli)]
+//! #[usage(bin = "ex")]
+//! struct Ex {
+//!     #[usage(short = 'v', long, global)]
+//!     verbose: bool,
+//!     #[usage(subcommand)]
+//!     command: Option<Commands>,
+//! }
+//!
+//! #[derive(Subcommands)]
+//! enum Commands {
+//!     /// Install a tool
+//!     Install(Install),
+//!     /// Run a task
+//!     #[usage(name = "run")]
+//!     RunTask(Run),
+//! }
+//!
+//! /// Install a tool
+//! #[derive(Args)]
+//! struct Install {
+//!     #[usage(short = 'f', long)]
+//!     force: bool,
+//!     tools: Vec<String>,
+//! }
+//! ```
+//!
+//! The three derives cannot see each other — a macro sees one item — so the tables
+//! are joined through two traits, [`usage_argv::spec::CommandArgs`] and
+//! [`usage_argv::spec::Subcommands`], whose associated consts a parent splices into
+//! its own `static` tables. Nothing is assembled at run time.
+//!
+//! Keys carry a hash of the type they came from, which is how independently
+//! expanded macros avoid handing two fields the same one. `Spec::to_kdl` asserts the
+//! tree has no duplicates, so a collision fails a test rather than binding the wrong
+//! field.
+//!
 //! # Declaring
 //!
 //! A field with `long` or `short` is a flag; anything else is a positional
@@ -72,7 +114,11 @@
 //! Published early on purpose, so it can be used and argued with — but these are
 //! real limits, not omissions from the docs.
 //!
-//! - **Subcommands.** One command per struct for now.
+//! - **A required subcommand.** A `subcommand` field has to be `Option<T>`:
+//!   reporting that one was needed is a required-ness question, and that layer does
+//!   not exist yet.
+//! - **Nesting deeper than one level.** A subcommand's own subcommands need the
+//!   `Args` struct to carry a `subcommand` field too, which it does not yet.
 //! - **Typed values.** Fields are `bool`, `String`, `Option<String>`,
 //!   `Vec<String>`, or an unsigned integer with `count`. Anything else is a
 //!   compile error rather than a surprise, because converting a value is also
@@ -96,6 +142,35 @@ pub fn derive_cli(input: TokenStream) -> TokenStream {
         Ok(cli) => codegen::emit(&cli).into(),
         // Reporting the error as tokens rather than panicking is what puts it on
         // the offending line instead of on the derive.
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+/// Compile a struct into one subcommand's flags and arguments.
+///
+/// Used on the struct a [`Subcommands`] variant wraps. It generates the same
+/// tables and metadata as [`Cli`], minus the program-level parts a subcommand does
+/// not have — a name, a version, an entry point — plus the trait a parent uses to
+/// route events into it.
+#[proc_macro_derive(Args, attributes(usage))]
+pub fn derive_args(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    match model::Cli::from_input(&input) {
+        Ok(cli) => codegen::emit_args(&cli).into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+/// Compile an enum into a set of subcommands.
+///
+/// Each variant wraps a struct deriving [`Args`], which is where that command's
+/// flags and arguments are declared. A field holding this enum is marked
+/// `#[usage(subcommand)]`.
+#[proc_macro_derive(Subcommands, attributes(usage))]
+pub fn derive_subcommands(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    match model::Subcommands::from_input(&input) {
+        Ok(subs) => codegen::emit_subcommands(&subs).into(),
         Err(e) => e.to_compile_error().into(),
     }
 }

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -898,6 +898,28 @@ impl Subcommands {
             seen.push((&variant.name, variant.ty.span()));
         }
 
+        // Two variants cannot wrap the same struct. A command's values are collected
+        // into the struct that declares them, and its fields' keys come from that
+        // struct — so two commands sharing one would collect into whichever was
+        // reached first, and choosing between them would be a coin toss. Rejected
+        // rather than silently misbound.
+        let mut types: Vec<(String, Span)> = Vec::new();
+        for variant in &variants {
+            let rendered = type_name(&variant.ty);
+            if let Some((_, first)) = types.iter().find(|(t, _)| *t == rendered) {
+                return Err(dup(
+                    variant.ty.span(),
+                    *first,
+                    &format!(
+                        "two variants both wrap `{rendered}`, and a command collects \
+                         into the struct that declares it — so give each command its \
+                         own struct, even if the fields are identical"
+                    ),
+                ));
+            }
+            types.push((rendered, variant.ty.span()));
+        }
+
         Ok(Subcommands {
             ident: input.ident.clone(),
             variants,

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -64,6 +64,17 @@ pub enum Kind {
         /// A `--` is required before this argument's value.
         double_dash_required: bool,
     },
+    /// Holds the enum whose variants are this command's subcommands.
+    ///
+    /// The type is carried rather than resolved, because the derive cannot see the
+    /// enum's definition: the generated code names it through the
+    /// [`Subcommands`](usage_argv::spec::Subcommands) trait, which is also how it
+    /// reaches the type that accumulates a subcommand's values.
+    Subcommand {
+        /// The enum's type, as written. Always reached through `Option<T>` for now,
+        /// so there is nothing to record about optionality.
+        ty: syn::Type,
+    },
 }
 
 /// What the field's Rust type says about how many values it holds.
@@ -174,6 +185,7 @@ impl Cli {
         let mut seen_long: Vec<(&str, Span)> = Vec::new();
         let mut seen_short: Vec<(char, Span)> = Vec::new();
         let mut variadic_arg: Option<Span> = None;
+        let mut subcommand_field: Option<Span> = None;
 
         for field in &self.fields {
             match &field.kind {
@@ -222,6 +234,19 @@ impl Cli {
                         variadic_arg = Some(field.span);
                     }
                 }
+                Kind::Subcommand { .. } => {
+                    // At most one: two would each claim the word that selects a
+                    // command, and only the first could ever be filled.
+                    if let Some(first) = subcommand_field {
+                        return Err(dup(
+                            field.span,
+                            first,
+                            "a command has one set of subcommands, so only one field \
+                             can hold them",
+                        ));
+                    }
+                    subcommand_field = Some(field.span);
+                }
             }
         }
         Ok(())
@@ -235,6 +260,69 @@ fn dup(span: Span, first: Span, message: &str) -> syn::Error {
 }
 
 impl Field {
+    /// A field marked `#[usage(subcommand)]`, if this is one.
+    fn subcommand(
+        field: &syn::Field,
+        ident: &syn::Ident,
+        span: proc_macro2::Span,
+    ) -> syn::Result<Option<Self>> {
+        let mut is_subcommand = false;
+        for attr in attrs(&field.attrs) {
+            for meta in nested(attr)? {
+                if ident_of(&meta.path().clone()) == "subcommand" {
+                    if !matches!(meta, Meta::Path(_)) {
+                        return Err(syn::Error::new_spanned(
+                            meta.path(),
+                            "`subcommand` takes no value: the enum it holds is the \
+                             field's type",
+                        ));
+                    }
+                    is_subcommand = true;
+                }
+            }
+        }
+        if !is_subcommand {
+            return Ok(None);
+        }
+
+        // `Option<T>` says the subcommand may be left out. A bare `T` cannot be
+        // satisfied by this version — nothing yet reports "a subcommand is
+        // required", which is a post-binding question.
+        let name = type_name(&field.ty);
+        let (ty, _optional) = match name
+            .strip_prefix("Option<")
+            .and_then(|rest| rest.strip_suffix('>'))
+        {
+            Some(inner) => (syn::parse_str::<Type>(inner)?, true),
+            None => {
+                return Err(syn::Error::new(
+                    span,
+                    "a `subcommand` field has to be `Option<T>` for now: a missing \
+                     subcommand is a required-ness question, and that layer does not \
+                     exist yet",
+                ));
+            }
+        };
+
+        Ok(Some(Field {
+            ident: ident.clone(),
+            ty: field.ty.clone(),
+            name: to_kebab(&ident.to_string()),
+            kind: Kind::Subcommand { ty },
+            // A subcommand field holds a command, not a value, so none of what
+            // describes a value applies to it.
+            shape: Shape::Bool,
+            help: None,
+            long_help: None,
+            env: None,
+            default: None,
+            help_heading: None,
+            hide: false,
+            repeatable: false,
+            span,
+        }))
+    }
+
     fn from_field(field: &syn::Field) -> syn::Result<Self> {
         let ident = field
             .ident
@@ -242,6 +330,12 @@ impl Field {
             .expect("named fields were checked by the caller");
         let span = field.span();
         let (help, long_help) = doc_comment(&field.attrs)?;
+
+        // A subcommand field is neither a flag nor an argument, and shares none of
+        // their options, so it is recognized before any of them are read.
+        if let Some(subcommand) = Self::subcommand(field, &ident, span)? {
+            return Ok(subcommand);
+        }
 
         let mut name = to_kebab(&ident.to_string());
         let mut longs: Vec<String> = Vec::new();
@@ -750,4 +844,113 @@ fn to_kebab(s: &str) -> String {
 
 fn strip_dashes(s: &str) -> String {
     s.trim_start_matches('-').to_string()
+}
+
+/// An enum whose variants are a command's subcommands.
+pub struct Subcommands {
+    pub ident: syn::Ident,
+    pub variants: Vec<Variant>,
+}
+
+/// One variant: a command name and the struct holding its flags and arguments.
+pub struct Variant {
+    pub ident: syn::Ident,
+    /// The command name, which is the variant name in kebab-case unless `name`
+    /// says otherwise.
+    pub name: String,
+    /// The struct the variant wraps.
+    pub ty: Type,
+    pub help: Option<String>,
+    pub long_help: Option<String>,
+}
+
+impl Subcommands {
+    pub fn from_input(input: &DeriveInput) -> syn::Result<Self> {
+        let Data::Enum(data) = &input.data else {
+            return Err(syn::Error::new_spanned(
+                &input.ident,
+                "usage::Subcommands describes a set of subcommands, so it needs an enum",
+            ));
+        };
+        if !input.generics.params.is_empty() {
+            return Err(syn::Error::new_spanned(
+                &input.generics,
+                "usage::Subcommands does not support generic parameters: the generated \
+                 tables are `static`",
+            ));
+        }
+
+        let variants = data
+            .variants
+            .iter()
+            .map(Variant::from_variant)
+            .collect::<syn::Result<Vec<_>>>()?;
+
+        let mut seen: Vec<(&str, Span)> = Vec::new();
+        for variant in &variants {
+            if let Some((_, first)) = seen.iter().find(|(n, _)| *n == variant.name) {
+                return Err(dup(
+                    variant.ty.span(),
+                    *first,
+                    &format!("two variants are both called `{}`", variant.name),
+                ));
+            }
+            seen.push((&variant.name, variant.ty.span()));
+        }
+
+        Ok(Subcommands {
+            ident: input.ident.clone(),
+            variants,
+        })
+    }
+}
+
+impl Variant {
+    fn from_variant(variant: &syn::Variant) -> syn::Result<Self> {
+        let (help, long_help) = doc_comment(&variant.attrs)?;
+        let mut name = to_kebab(&variant.ident.to_string());
+
+        for attr in attrs(&variant.attrs) {
+            for meta in nested(attr)? {
+                let path = meta.path().clone();
+                match ident_of(&path).as_str() {
+                    "name" => name = strip_dashes(&string_value(&meta)?),
+                    other => {
+                        return Err(syn::Error::new_spanned(
+                            path,
+                            format!(
+                                "unknown option `{other}` on a variant; a subcommand \
+                                 variant takes `name` here, and its description comes \
+                                 from the doc comment"
+                            ),
+                        ));
+                    }
+                }
+            }
+        }
+
+        // One unnamed field, holding the struct that declares the command's flags
+        // and arguments. A variant with no fields would have nothing to parse into,
+        // and named fields would make the variant itself the struct — which is a
+        // second way to say the same thing.
+        let ty = match &variant.fields {
+            Fields::Unnamed(unnamed) if unnamed.unnamed.len() == 1 => unnamed.unnamed[0].ty.clone(),
+            other => {
+                return Err(syn::Error::new_spanned(
+                    other,
+                    "a subcommand variant wraps exactly one struct, as in \
+                     `Install(Install)`: that struct is where its flags and arguments \
+                     are declared",
+                ));
+            }
+        };
+
+        Ok(Variant {
+            ident: variant.ident.clone(),
+            name,
+            ty,
+            help,
+            long_help,
+        })
+    }
 }


### PR DESCRIPTION
First of the next stack, and the largest gap in the derive: it could describe **one** command, so nothing with subcommands could use it — which is every CLI it is meant for.

## Shape

```rust
#[derive(Cli)]
#[usage(bin = "ex")]
struct Ex {
    #[usage(short = 'v', long, global)]
    verbose: bool,
    #[usage(subcommand)]
    command: Option<Commands>,
}

#[derive(Subcommands)]
enum Commands {
    /// Install a tool
    Install(Install),
    /// Run a task
    #[usage(name = "run")]
    RunTask(Run),
}

/// Install a tool
#[derive(Args)]
struct Install {
    #[usage(short = 'f', long)]
    force: bool,
    tools: Vec<String>,
}
```

## Two problems worth explaining, because they shaped the design

**A macro sees one item.** The three derives cannot share a counter or read each other's fields, so keys carry a **hash of the type they came from** in the high half, the index in the low half, and a tag for command/flag/argument. Independently expanded macros therefore cannot hand two fields the same key — which matters because a parse dispatches on it. Two type names would have to collide in 32 bits, and `Spec::to_kdl` now asserts the tree holds no duplicates, so a collision fails a test instead of binding the wrong field. A test checks that invariant directly.

**A `static` cannot call a method.** The parent splices its children's tables into its own `static`, so the traits expose them as **associated consts**, not functions. That keeps the tables static all the way down — nothing is assembled at run time, which was the whole point.

## Restructuring that fell out

Every derived struct now collects into a generated `Partial` rather than into locals, since a subcommand's values cannot live in the root's parse function. That replaced the prefixed-locals machinery from #803 entirely, and made `apply` shared between a root and a subcommand.

A doc comment on a **variant** overrides the struct's, because that is where a reader of the enum expects to describe the command — ignoring it would lose the description silently. Overriding one field of the struct's metadata is possible in a const, so this costs nothing at run time.

## Verified

Eight tests: routing by name and by a renamed variant, per-command fields with defaults, a global flag on either side of the command word, one command not answering to another's flag, an absent subcommand, key uniqueness across separately expanded types, and a snapshot of the emitted spec:

```kdl
name "ex"
bin "ex"
flag "-v --verbose" help="Say more" global=#true
cmd "install" help="Install a tool" {
    flag "-f --force" help="Overwrite an existing install"
    flag "-j --jobs" help="How many at once" default="4" {
        arg "<jobs>"
    }
    arg "[tools]..." help="What to install"
}
cmd "run" help="Run a task" {
    arg "<task>" help="The task to run"
}
```

Nested `cmd` blocks that read like something a person would have written, which is what `usage g markdown|manpage` needs.

## Stated limits

- A `subcommand` field must be `Option<T>`: reporting that one was *required* is a required-ness question, and that layer lands in the next PR of this stack.
- Nesting stops at one level — a subcommand's own subcommands need `Args` to carry a `subcommand` field too.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large derive/codegen refactor plus a public key-type change (`u32` → `u64`) that affects parse dispatch. Mitigated by conformance tests and debug duplicate-key checks, but wrong keys would bind the wrong fields.
> 
> **Overview**
> Enables declaring **subcommands** with the derive: a `#[usage(subcommand)]` field holds an enum (`Subcommands`), and each variant wraps an `Args` struct for that command's flags and arguments.
> 
> Independently expanded macros cannot share a counter, so keys widen from `u32` to **`u64`** and carry a type-name hash. New `CommandArgs` / `Subcommands` traits expose associated consts so parents splice children's tables into `static` parse tables with no runtime assembly. `Spec::to_kdl` debug-asserts the tree has no duplicate keys.
> 
> Codegen now accumulates into a generated `Partial` (shared `apply`) instead of parse-local variables, which is what lets a root route events into subcommands it cannot see. Variant doc comments override the wrapped struct's help; nesting and required subcommands remain out of scope for now.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5373abbdc400e8da7dabaa3b86769bc782648466. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for defining and parsing CLI subcommands, including nested structures, command-specific options, global flags, defaults, and optional subcommands.
  * Added `Args` and `Subcommands` derive macros for generating command-line parsers and metadata.
  * Expanded command keys to support larger values and improved uniqueness checks.

* **Bug Fixes**
  * Added validation and diagnostics for duplicate command keys and subcommand names.
  * Improved error reporting for invalid subcommand definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->