### PR TITLE
feat(derive): check what a parse cannot decide on its own

### DIFF
--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -268,7 +268,11 @@ pub enum Event<'t, 'v> {
 /// Carries the offending token so a caller can render a good message, but no
 /// message of its own: rendering belongs to a cold path, and building a string
 /// here would allocate on the way to reporting that nothing was allocated.
+///
+/// `non_exhaustive`, because an error enum grows: a caller matching on it needs a
+/// fallback arm so that recognizing a new failure is never a breaking change.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Error<'t, 'v> {
     /// A flag-like token matched no flag in scope. `token` is the whole token as
     /// typed, so a bundle containing an unrecognized letter reports `-fz` rather

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -284,6 +284,39 @@ pub enum Error<'t, 'v> {
     ArgRequiresDoubleDash { arg: &'t Arg<'t> },
     /// The command tree is deeper than [`MAX_DEPTH`].
     TooDeep,
+
+    // The rest are raised *after* the parse, by whoever owns the target type: they
+    // need to know a value's declared type, which the parser deliberately does not.
+    // They share this enum so that a caller has one error to handle rather than two.
+    /// Something the command requires was never given.
+    MissingRequired {
+        /// The flag or argument's name, as the spec calls it.
+        name: &'t str,
+    },
+    /// A value was given that is not among the declared choices.
+    ///
+    /// Carries the choices rather than the offending value: rendering the value means
+    /// owning it, and an error that allocates on a path this crate promises not to
+    /// allocate on would be a poor trade for a better message. Diagnostics are a
+    /// separate layer.
+    InvalidChoice {
+        name: &'t str,
+        choices: &'t [&'t str],
+    },
+    /// Fewer values than `var_min`.
+    VarTooFew {
+        name: &'t str,
+        min: usize,
+        got: usize,
+    },
+    /// More values than `var_max`.
+    VarTooMany {
+        name: &'t str,
+        max: usize,
+        got: usize,
+    },
+    /// A subcommand was required, and none was given.
+    MissingSubcommand,
 }
 
 /// Interpret a value as UTF-8.

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -778,7 +778,12 @@ pub trait CommandArgs: Sized {
     /// Separate from [`CommandArgs::build`] because only the command that was
     /// actually reached is judged — a flag that `install` requires says nothing
     /// about an invocation that ran `run`.
-    fn check<'t, 'v>(partial: &mut Self::Partial) -> Result<(), crate::Error<'t, 'v>>;
+    /// Defaulted, so a hand-written implementation with nothing to check is not
+    /// forced to say so — and adding a check to the derive does not break one.
+    fn check<'t, 'v>(partial: &mut Self::Partial) -> Result<(), crate::Error<'t, 'v>> {
+        let _ = partial;
+        Ok(())
+    }
 
     /// Build the struct from what was collected.
     fn build(partial: Self::Partial) -> Self;

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -772,6 +772,14 @@ pub trait CommandArgs: Sized {
     /// for whoever owns it rather than mistaken for a local field.
     fn apply(partial: &mut Self::Partial, event: &crate::Event<'_, '_>) -> bool;
 
+    /// Everything this command decides after the last token: required-ness,
+    /// choices, and how many values a variadic got.
+    ///
+    /// Separate from [`CommandArgs::build`] because only the command that was
+    /// actually reached is judged — a flag that `install` requires says nothing
+    /// about an invocation that ran `run`.
+    fn check<'t, 'v>(partial: &mut Self::Partial) -> Result<(), crate::Error<'t, 'v>>;
+
     /// Build the struct from what was collected.
     fn build(partial: Self::Partial) -> Self;
 }
@@ -792,6 +800,12 @@ pub trait Subcommands: Sized {
 
     /// Take one event, and say whether it belonged to one of these commands.
     fn apply(partial: &mut Self::Partial, event: &crate::Event<'_, '_>) -> bool;
+
+    /// Check the selected command's requirements, and nothing else's.
+    ///
+    /// A flag that `install` requires says nothing about an invocation that ran
+    /// `run`, so only the command that was actually reached is judged.
+    fn check<'t, 'v>(partial: &mut Self::Partial, key: u64) -> Result<(), crate::Error<'t, 'v>>;
 
     /// Build the variant whose command was selected, by its [`Command::key`].
     ///

--- a/conformance/src/argv.rs
+++ b/conformance/src/argv.rs
@@ -146,6 +146,16 @@ fn code(err: Error<'_, '_>) -> ErrorCode {
         Error::UnexpectedArg { .. } => ErrorCode::UnexpectedArg,
         Error::ArgRequiresDoubleDash { .. } => ErrorCode::ArgRequiresDoubleDash,
         Error::TooDeep => panic!("no corpus spec is anywhere near MAX_DEPTH"),
+        // The parser cannot raise these — they come from the layer above it, which
+        // this harness does not exercise: it builds tables from a spec rather than
+        // from a derived struct.
+        Error::MissingRequired { .. }
+        | Error::InvalidChoice { .. }
+        | Error::VarTooFew { .. }
+        | Error::VarTooMany { .. }
+        | Error::MissingSubcommand => {
+            unreachable!("a post-binding error cannot come out of the parser")
+        }
     }
 }
 

--- a/conformance/src/argv.rs
+++ b/conformance/src/argv.rs
@@ -149,13 +149,11 @@ fn code(err: Error<'_, '_>) -> ErrorCode {
         // The parser cannot raise these — they come from the layer above it, which
         // this harness does not exercise: it builds tables from a spec rather than
         // from a derived struct.
-        Error::MissingRequired { .. }
-        | Error::InvalidChoice { .. }
-        | Error::VarTooFew { .. }
-        | Error::VarTooMany { .. }
-        | Error::MissingSubcommand => {
-            unreachable!("a post-binding error cannot come out of the parser")
-        }
+        // Everything else comes from the layer above the parser, which this harness
+        // does not exercise: it builds tables from a spec rather than from a derived
+        // struct. A wildcard rather than a list, because `Error` is `non_exhaustive`
+        // — recognizing a new failure should not break this file.
+        other => unreachable!("the parser cannot raise {other:?}"),
     }
 }
 

--- a/conformance/tests/post_binding.rs
+++ b/conformance/tests/post_binding.rs
@@ -1,0 +1,225 @@
+//! What a parse cannot decide until the last token has been read.
+//!
+//! The parser binds tokens; whether what it bound is *acceptable* needs to know the
+//! declared type — so required-ness, choices, and how many values a variadic got are
+//! checked here, by the code the derive generates. These are the corpus's
+//! `post-binding` vectors, exercised through a derived struct rather than through the
+//! harness's spec-built tables.
+
+use std::ffi::OsStr;
+
+use usage_argv::Error;
+use usage_derive::{Args, Cli, Subcommands};
+
+fn argv<const N: usize>(tokens: [&str; N]) -> [&OsStr; N] {
+    tokens.map(OsStr::new)
+}
+
+/// A CLI exercising each check
+#[derive(Cli)]
+#[usage(bin = "ex")]
+struct Ex {
+    /// Which shell
+    #[usage(long, choices("bash", "zsh", "fish"))]
+    shell: Option<String>,
+    /// Files to include
+    #[usage(long, var_min = 1, var_max = 2)]
+    include: Vec<String>,
+    /// Where to write
+    #[usage(long, env = "EX_OUT")]
+    out: Option<String>,
+    /// Colorize
+    #[usage(long, env = "EX_COLOR")]
+    color: bool,
+    /// What to act on
+    target: String,
+}
+
+#[test]
+fn a_required_argument_has_to_be_given() {
+    let a = argv([]);
+    assert!(matches!(
+        Ex::parse_from(&a),
+        Err(Error::MissingRequired { name: "target" })
+    ));
+
+    let a = argv(["x"]);
+    assert_eq!(Ex::parse_from(&a).expect("should parse").target, "x");
+}
+
+#[test]
+fn an_empty_value_still_counts_as_given() {
+    // `--out=` supplies an empty string, which is a value somebody typed — the check
+    // is whether a token arrived, not whether it was non-empty.
+    let a = argv(["--out=", "x"]);
+    let ex = Ex::parse_from(&a).expect("should parse");
+    assert_eq!(ex.out.as_deref(), Some(""));
+}
+
+#[test]
+fn a_value_outside_the_choices_is_refused() {
+    let a = argv(["--shell", "csh", "x"]);
+    assert!(matches!(
+        Ex::parse_from(&a),
+        Err(Error::InvalidChoice { name: "shell", .. })
+    ));
+
+    let a = argv(["--shell", "zsh", "x"]);
+    assert_eq!(
+        Ex::parse_from(&a).expect("should parse").shell.as_deref(),
+        Some("zsh")
+    );
+}
+
+#[test]
+fn variadic_bounds_are_counted() {
+    let a = argv(["--include", "a", "x"]);
+    assert_eq!(Ex::parse_from(&a).expect("one is enough").include, ["a"]);
+
+    // Three, where two is the most: the flag is repeatable, so each occurrence adds.
+    let a = argv(["--include", "a", "--include", "b", "--include", "c", "x"]);
+    assert!(matches!(
+        Ex::parse_from(&a),
+        Err(Error::VarTooMany {
+            name: "include",
+            max: 2,
+            got: 3
+        })
+    ));
+}
+
+#[test]
+fn a_bound_is_only_checked_when_the_flag_was_used() {
+    // `var_min` counts the values a flag was given, not whether it was given at all —
+    // an absent optional flag is absent, not a violation.
+    let a = argv(["x"]);
+    let ex = Ex::parse_from(&a).expect("an unused flag has no values to count");
+    assert!(ex.include.is_empty());
+}
+
+#[test]
+fn the_environment_fills_what_argv_left_out() {
+    // Serialized by construction: these run in one test because the environment is
+    // process-wide, and a sibling test setting the same variable would race.
+    unsafe { std::env::set_var("EX_OUT", "from-env") };
+    let a = argv(["x"]);
+    let ex = Ex::parse_from(&a).expect("should parse");
+    assert_eq!(ex.out.as_deref(), Some("from-env"));
+
+    // What argv says wins over the environment.
+    let a = argv(["--out", "from-argv", "x"]);
+    let ex = Ex::parse_from(&a).expect("should parse");
+    assert_eq!(ex.out.as_deref(), Some("from-argv"));
+
+    // A switch reads as on for anything but a spelling of "off".
+    unsafe { std::env::set_var("EX_COLOR", "1") };
+    let a = argv(["x"]);
+    assert!(Ex::parse_from(&a).expect("should parse").color);
+
+    unsafe { std::env::set_var("EX_COLOR", "false") };
+    let a = argv(["x"]);
+    assert!(!Ex::parse_from(&a).expect("should parse").color);
+
+    unsafe { std::env::remove_var("EX_OUT") };
+    unsafe { std::env::remove_var("EX_COLOR") };
+}
+
+/// A CLI whose subcommand is required
+#[derive(Cli)]
+#[usage(bin = "req")]
+struct Req {
+    /// What to do
+    #[usage(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommands)]
+enum Commands {
+    /// Install something
+    Install(Install),
+    /// Do nothing in particular
+    Noop(Noop),
+}
+
+/// Install something
+#[derive(Args)]
+struct Install {
+    /// Which tool
+    tool: String,
+    /// How
+    #[usage(long, choices("fast", "careful"))]
+    how: Option<String>,
+}
+
+/// Do nothing
+#[derive(Args)]
+struct Noop {
+    /// Unused
+    #[usage(long)]
+    quiet: bool,
+}
+
+#[test]
+fn a_bare_subcommand_field_requires_one() {
+    let a = argv([]);
+    assert!(matches!(Req::parse_from(&a), Err(Error::MissingSubcommand)));
+
+    let a = argv(["install", "node"]);
+    let req = Req::parse_from(&a).expect("should parse");
+    let Commands::Install(install) = req.command else {
+        panic!("expected install");
+    };
+    assert_eq!(install.tool, "node");
+}
+
+#[test]
+fn only_the_command_that_ran_is_judged() {
+    // `install` requires a tool. Running `noop` must not be held to that.
+    let a = argv(["noop"]);
+    let Commands::Noop(noop) = Req::parse_from(&a).expect("noop takes nothing").command else {
+        panic!("expected noop");
+    };
+    assert!(!noop.quiet, "nothing was given, so nothing is set");
+
+    let a = argv(["install"]);
+    assert!(matches!(
+        Req::parse_from(&a),
+        Err(Error::MissingRequired { name: "tool" })
+    ));
+}
+
+#[test]
+fn a_subcommands_own_choices_are_checked() {
+    let a = argv(["install", "node", "--how", "sideways"]);
+    assert!(matches!(
+        Req::parse_from(&a),
+        Err(Error::InvalidChoice { name: "how", .. })
+    ));
+
+    let a = argv(["install", "node", "--how", "careful"]);
+    let req = Req::parse_from(&a).expect("should parse");
+    let Commands::Install(install) = req.command else {
+        panic!("expected install");
+    };
+    assert_eq!(install.how.as_deref(), Some("careful"));
+}
+
+#[test]
+fn the_checks_reach_the_spec_too() {
+    let spec: usage::Spec = Ex::to_kdl().parse().expect("valid spec");
+    let shell = spec.cmd.flags.iter().find(|f| f.name == "shell").unwrap();
+    let choices = shell.arg.as_ref().and_then(|a| a.choices.as_ref());
+    assert_eq!(
+        choices.map(|c| c.choices.clone()),
+        Some(vec!["bash".into(), "zsh".into(), "fish".into()]),
+        "a declared choice list has to be in the spec, or docs and completions \
+         cannot offer it"
+    );
+
+    let include = spec.cmd.flags.iter().find(|f| f.name == "include").unwrap();
+    assert_eq!(include.var_min, Some(1));
+    assert_eq!(include.var_max, Some(2));
+
+    let target = spec.cmd.args.iter().find(|a| a.name == "target").unwrap();
+    assert!(target.required);
+}

--- a/conformance/tests/post_binding.rs
+++ b/conformance/tests/post_binding.rs
@@ -26,11 +26,8 @@ struct Ex {
     #[usage(long, var_min = 1, var_max = 2)]
     include: Vec<String>,
     /// Where to write
-    #[usage(long, env = "EX_OUT")]
+    #[usage(long)]
     out: Option<String>,
-    /// Colorize
-    #[usage(long, env = "EX_COLOR")]
-    color: bool,
     /// What to act on
     target: String,
 }
@@ -54,6 +51,13 @@ fn an_empty_value_still_counts_as_given() {
     let a = argv(["--out=", "x"]);
     let ex = Ex::parse_from(&a).expect("should parse");
     assert_eq!(ex.out.as_deref(), Some(""));
+}
+
+#[test]
+fn a_field_with_no_env_is_unaffected_by_the_environment() {
+    // The environment cases live in their own test binary; nothing here reads it.
+    let a = argv(["x"]);
+    assert!(Ex::parse_from(&a).expect("should parse").out.is_none());
 }
 
 #[test]
@@ -95,33 +99,6 @@ fn a_bound_is_only_checked_when_the_flag_was_used() {
     let a = argv(["x"]);
     let ex = Ex::parse_from(&a).expect("an unused flag has no values to count");
     assert!(ex.include.is_empty());
-}
-
-#[test]
-fn the_environment_fills_what_argv_left_out() {
-    // Serialized by construction: these run in one test because the environment is
-    // process-wide, and a sibling test setting the same variable would race.
-    unsafe { std::env::set_var("EX_OUT", "from-env") };
-    let a = argv(["x"]);
-    let ex = Ex::parse_from(&a).expect("should parse");
-    assert_eq!(ex.out.as_deref(), Some("from-env"));
-
-    // What argv says wins over the environment.
-    let a = argv(["--out", "from-argv", "x"]);
-    let ex = Ex::parse_from(&a).expect("should parse");
-    assert_eq!(ex.out.as_deref(), Some("from-argv"));
-
-    // A switch reads as on for anything but a spelling of "off".
-    unsafe { std::env::set_var("EX_COLOR", "1") };
-    let a = argv(["x"]);
-    assert!(Ex::parse_from(&a).expect("should parse").color);
-
-    unsafe { std::env::set_var("EX_COLOR", "false") };
-    let a = argv(["x"]);
-    assert!(!Ex::parse_from(&a).expect("should parse").color);
-
-    unsafe { std::env::remove_var("EX_OUT") };
-    unsafe { std::env::remove_var("EX_COLOR") };
 }
 
 /// A CLI whose subcommand is required

--- a/conformance/tests/post_binding_env.rs
+++ b/conformance/tests/post_binding_env.rs
@@ -1,0 +1,79 @@
+//! Where the environment fills in what argv left out.
+//!
+//! Its own test binary, and that is the point. Environment variables are
+//! process-wide, so a test that sets one races every other test in the same binary
+//! that reads it — including one that only reads it *implicitly*, by parsing a CLI
+//! with an `env` field. Consolidating the cases into a single `#[test]` fixes the
+//! race between those cases and not the race with their neighbours. A separate file
+//! is a separate process, which does fix it.
+
+use std::ffi::OsStr;
+
+use usage_derive::Cli;
+
+fn argv<const N: usize>(tokens: [&str; N]) -> [&OsStr; N] {
+    tokens.map(OsStr::new)
+}
+
+/// A CLI whose values can come from the environment
+#[derive(Cli)]
+#[usage(bin = "ex")]
+struct Ex {
+    /// Where to write
+    #[usage(long, env = "EX_ENV_OUT")]
+    out: Option<String>,
+    /// Colorize
+    #[usage(long, env = "EX_ENV_COLOR")]
+    color: bool,
+    /// How loud
+    #[usage(short = 'v', long, count, env = "EX_ENV_VERBOSE")]
+    verbose: u8,
+    /// What to act on
+    target: String,
+}
+
+#[test]
+fn the_environment_fills_what_argv_left_out() {
+    // One test, in one process, so the order of these is the order they read.
+    unsafe { std::env::set_var("EX_ENV_OUT", "from-env") };
+    let a = argv(["x"]);
+    let ex = Ex::parse_from(&a).expect("should parse");
+    assert_eq!(ex.out.as_deref(), Some("from-env"));
+
+    // What argv says wins.
+    let a = argv(["--out", "from-argv", "x"]);
+    let ex = Ex::parse_from(&a).expect("should parse");
+    assert_eq!(ex.out.as_deref(), Some("from-argv"));
+
+    // A switch reads as on for anything but a spelling of "off".
+    unsafe { std::env::set_var("EX_ENV_COLOR", "1") };
+    let a = argv(["x"]);
+    assert!(Ex::parse_from(&a).expect("should parse").color);
+
+    unsafe { std::env::set_var("EX_ENV_COLOR", "false") };
+    let a = argv(["x"]);
+    assert!(!Ex::parse_from(&a).expect("should parse").color);
+
+    // A counting field takes a number, since the environment cannot repeat a flag.
+    unsafe { std::env::set_var("EX_ENV_VERBOSE", "3") };
+    let a = argv(["x"]);
+    assert_eq!(Ex::parse_from(&a).expect("should parse").verbose, 3);
+
+    // And something that is not a number leaves it alone rather than counting as
+    // given — which was the bug: the value was discarded but the field was marked
+    // filled.
+    unsafe { std::env::set_var("EX_ENV_VERBOSE", "loud") };
+    let a = argv(["x"]);
+    assert_eq!(Ex::parse_from(&a).expect("should parse").verbose, 0);
+
+    // An occurrence on the command line still wins.
+    let a = argv(["-vv", "x"]);
+    let ex = Ex::parse_from(&a).expect("should parse");
+    assert_eq!(ex.verbose, 2);
+    // The environment fills flags, not positionals that were given.
+    assert_eq!(ex.target, "x");
+
+    for var in ["EX_ENV_OUT", "EX_ENV_COLOR", "EX_ENV_VERBOSE"] {
+        unsafe { std::env::remove_var(var) };
+    }
+}

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -85,6 +85,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
     let (sub_init, sub_route, sub_build) = match subcommand {
         Some((field, ty)) => {
             let ident = &field.ident;
+            let optional = matches!(&field.kind, Kind::Subcommand { optional: true, .. });
             (
                 quote! {
                     let mut __usage_sub =
@@ -104,16 +105,38 @@ pub fn emit(cli: &Cli) -> TokenStream {
                         &__usage_event,
                     );
                 },
-                quote! {
-                    #ident: match __usage_selected {
-                        ::std::option::Option::Some(__usage_key) => {
-                            <#ty as ::usage_argv::spec::Subcommands>::select(
-                                __usage_sub,
-                                __usage_key,
-                            )
+                {
+                    // Only the command that was reached is judged, and a command that
+                    // was required has to be reported if it was not.
+                    let selected = quote! {
+                        match __usage_selected {
+                            ::std::option::Option::Some(__usage_key) => {
+                                <#ty as ::usage_argv::spec::Subcommands>::check(
+                                    &mut __usage_sub,
+                                    __usage_key,
+                                )?;
+                                <#ty as ::usage_argv::spec::Subcommands>::select(
+                                    __usage_sub,
+                                    __usage_key,
+                                )
+                            }
+                            ::std::option::Option::None => ::std::option::Option::None,
                         }
-                        ::std::option::Option::None => ::std::option::Option::None,
-                    },
+                    };
+                    if optional {
+                        quote!(#ident: #selected,)
+                    } else {
+                        quote! {
+                            #ident: match #selected {
+                                ::std::option::Option::Some(__usage_cmd) => __usage_cmd,
+                                ::std::option::Option::None => {
+                                    return ::std::result::Result::Err(
+                                        ::usage_argv::Error::MissingSubcommand,
+                                    );
+                                }
+                            },
+                        }
+                    }
                 },
             )
         }
@@ -123,6 +146,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
     let partial = partial_struct(cli);
     let defaults = partial_defaults(cli);
     let apply = apply_fn(cli, base);
+    let post = post_binding(cli);
     // `field: local` rather than the shorthand, because the locals are prefixed:
     // a field called `text` or `parser` would otherwise collide with something the
     // generated code needs.
@@ -137,7 +161,15 @@ pub fn emit(cli: &Cli) -> TokenStream {
 
     quote! {
         #[doc(hidden)]
-        #[allow(non_upper_case_globals, non_snake_case, unused_imports)]
+        #[allow(
+            non_upper_case_globals,
+            non_snake_case,
+            unused_imports,
+            // Fires when a metadata struct happens to be fully specified. `..EMPTY`
+            // is kept on purpose: it is what lets usage-argv gain a metadata field
+            // without breaking every crate that derives.
+            clippy::needless_update
+        )]
         mod #module {
             use ::usage_argv::spec::{ArgMeta, CommandMeta, FlagMeta, Spec};
             use ::usage_argv::{Arg, Command, DoubleDash, Flag};
@@ -239,6 +271,8 @@ pub fn emit(cli: &Cli) -> TokenStream {
                     }
                 }
 
+                #post
+
                 ::std::result::Result::Ok(Self {
                     #sub_build
                     #(#field_finals),*
@@ -333,6 +367,8 @@ fn flag_meta(i: usize, field: &Field) -> TokenStream {
     let hide = field.hide;
     let count = field.shape == Shape::Count;
     let repeatable = field.repeatable;
+    let choices = choices_tokens(field);
+    let (var_min, var_max) = bounds_tokens(field);
 
     quote! {
         pub static #name: FlagMeta = FlagMeta {
@@ -345,6 +381,9 @@ fn flag_meta(i: usize, field: &Field) -> TokenStream {
             hide: #hide,
             count: #count,
             repeatable: #repeatable,
+            choices: #choices,
+            var_min: #var_min,
+            var_max: #var_max,
             ..FlagMeta::EMPTY
         };
     }
@@ -364,6 +403,8 @@ fn arg_meta(i: usize, field: &Field) -> TokenStream {
     let hide = field.hide;
     // `String` must be filled; `Option` and `Vec` need not be.
     let required = field.shape == Shape::Required;
+    let choices = choices_tokens(field);
+    let (var_min, var_max) = bounds_tokens(field);
 
     quote! {
         pub static #name: ArgMeta = ArgMeta {
@@ -375,9 +416,27 @@ fn arg_meta(i: usize, field: &Field) -> TokenStream {
             help_heading: #help_heading,
             hide: #hide,
             required: #required,
+            choices: #choices,
+            var_min: #var_min,
+            var_max: #var_max,
             ..ArgMeta::EMPTY
         };
     }
+}
+
+/// A field's declared choices, as the metadata holds them.
+fn choices_tokens(field: &Field) -> TokenStream {
+    let choices = &field.choices;
+    quote!(&[#(#choices),*])
+}
+
+/// A field's declared bounds, as the metadata holds them.
+fn bounds_tokens(field: &Field) -> (TokenStream, TokenStream) {
+    let render = |bound: Option<usize>| match bound {
+        Some(n) => quote!(::std::option::Option::Some(#n)),
+        None => quote!(::std::option::Option::None),
+    };
+    (render(field.var_min), render(field.var_max))
 }
 
 /// Which kind of thing a key belongs to, in the bits above its index.
@@ -443,6 +502,7 @@ fn in_module(ty: &syn::Type) -> TokenStream {
 fn flag_arm(i: usize, field: &Field, base: u64) -> TokenStream {
     let key = base | KIND_FLAG | i as u64;
     let ident = &field.ident;
+    let given = format_ident!("__given_{}", ident);
     let body = match field.shape {
         // `negated` is what distinguishes `--color` from `--no-color`.
         Shape::Bool => quote!(partial.#ident = !negated;),
@@ -456,13 +516,14 @@ fn flag_arm(i: usize, field: &Field, base: u64) -> TokenStream {
         Shape::Many => quote!(partial.#ident.push(__usage_value_text(value));),
     };
     quote! {
-        #key => { #body true }
+        #key => { #body partial.#given = true; true }
     }
 }
 
 fn arg_arm(i: usize, field: &Field, base: u64) -> TokenStream {
     let key = base | KIND_ARG | i as u64;
     let ident = &field.ident;
+    let given = format_ident!("__given_{}", ident);
     let body = match field.shape {
         Shape::Many => quote!(partial.#ident.push(__usage_text(value));),
         Shape::Optional => quote! {
@@ -471,7 +532,7 @@ fn arg_arm(i: usize, field: &Field, base: u64) -> TokenStream {
         _ => quote!(partial.#ident = __usage_text(value);),
     };
     quote! {
-        #key => { #body true }
+        #key => { #body partial.#given = true; true }
     }
 }
 
@@ -506,7 +567,11 @@ fn partial_struct(cli: &Cli) -> TokenStream {
             Shape::Required => quote!(::std::string::String),
             Shape::Many => quote!(::std::vec::Vec<::std::string::String>),
         };
-        Some(quote!(pub #ident: #ty,))
+        let given = format_ident!("__given_{}", ident);
+        // Whether a token supplied this, as opposed to a default sitting in it: an
+        // empty string is a value somebody typed, and `--jobs=` has to be able to
+        // mean it.
+        Some(quote!(pub #ident: #ty, pub #given: bool,))
     });
 
     // `Default` rather than a generated `new`: every accumulator type has one, and
@@ -640,6 +705,7 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
     let partial = partial_struct(cli);
     let defaults = partial_defaults(cli);
     let apply = apply_fn(cli, base);
+    let post = post_binding(cli);
     let field_finals = cli.fields.iter().map(|f| {
         let ident = &f.ident;
         quote!(#ident: partial.#ident)
@@ -647,7 +713,15 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
 
     quote! {
         #[doc(hidden)]
-        #[allow(non_upper_case_globals, non_snake_case, unused_imports)]
+        #[allow(
+            non_upper_case_globals,
+            non_snake_case,
+            unused_imports,
+            // Fires when a metadata struct happens to be fully specified. `..EMPTY`
+            // is kept on purpose: it is what lets usage-argv gain a metadata field
+            // without breaking every crate that derives.
+            clippy::needless_update
+        )]
         mod #module {
             use ::usage_argv::spec::{ArgMeta, CommandMeta, FlagMeta};
             use ::usage_argv::{Arg, Command, DoubleDash, Flag};
@@ -692,6 +766,18 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
                 #defaults
                 partial
             }
+
+            /// Everything decided after the last token, for this command.
+            ///
+            /// Separate from `build` because only the *selected* command's
+            /// requirements apply: a flag that `install` requires says nothing about
+            /// an invocation that ran `run`.
+            pub fn check<'t, 'v>(
+                partial: &mut Partial,
+            ) -> ::std::result::Result<(), ::usage_argv::Error<'t, 'v>> {
+                #post
+                ::std::result::Result::Ok(())
+            }
         }
 
         impl ::usage_argv::spec::CommandArgs for #ident {
@@ -710,6 +796,12 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
                 event: &::usage_argv::Event<'_, '_>,
             ) -> bool {
                 #module::apply(partial, event)
+            }
+
+            fn check<'t, 'v>(
+                partial: &mut Self::Partial,
+            ) -> ::std::result::Result<(), ::usage_argv::Error<'t, 'v>> {
+                #module::check(partial)
             }
 
             fn build(partial: Self::Partial) -> Self {
@@ -802,6 +894,15 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
     });
     // Matched on the command's key rather than its name, so selecting a variant is
     // an integer comparison and cannot be confused by an alias.
+    let checks = subs.variants.iter().enumerate().map(|(i, v)| {
+        let field = format_ident!("v{i}");
+        let ty = &v.ty;
+        quote! {
+            if key == <#ty as ::usage_argv::spec::CommandArgs>::COMMAND.key {
+                return <#ty as ::usage_argv::spec::CommandArgs>::check(&mut partial.#field);
+            }
+        }
+    });
     let selects = subs.variants.iter().enumerate().map(|(i, v)| {
         let field = format_ident!("v{i}");
         let variant = &v.ident;
@@ -817,7 +918,15 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
 
     quote! {
         #[doc(hidden)]
-        #[allow(non_upper_case_globals, non_snake_case, unused_imports)]
+        #[allow(
+            non_upper_case_globals,
+            non_snake_case,
+            unused_imports,
+            // Fires when a metadata struct happens to be fully specified. `..EMPTY`
+            // is kept on purpose: it is what lets usage-argv gain a metadata field
+            // without breaking every crate that derives.
+            clippy::needless_update
+        )]
         mod #module {
             pub struct Partial {
                 #(#partial_fields)*
@@ -849,10 +958,148 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
                 false
             }
 
+            fn check<'t, 'v>(
+                partial: &mut Self::Partial,
+                key: u64,
+            ) -> ::std::result::Result<(), ::usage_argv::Error<'t, 'v>> {
+                #(#checks)*
+                ::std::result::Result::Ok(())
+            }
+
             fn select(partial: Self::Partial, key: u64) -> ::std::option::Option<Self> {
                 #(#selects)*
                 ::std::option::Option::None
             }
         }
+    }
+}
+
+/// Everything decided once the last token has been read.
+///
+/// Ordered deliberately. The environment fills what argv left out, so it runs
+/// before required-ness — a flag with `env` set is not missing. Choices and bounds
+/// come last, because they judge a value however it arrived, including one that came
+/// from the environment or a default.
+fn post_binding(cli: &Cli) -> TokenStream {
+    let env_fallbacks = cli.fields.iter().filter_map(|f| {
+        let ident = &f.ident;
+        let given = format_ident!("__given_{}", ident);
+        let var = f.env.as_deref()?;
+        let assign = match f.shape {
+            Shape::Optional => quote!(partial.#ident = ::std::option::Option::Some(value);),
+            Shape::Required => quote!(partial.#ident = value;),
+            Shape::Many => quote!(partial.#ident.push(value);),
+            // A switch reads as on for anything but the spellings of "off", which is
+            // what every tool that takes a boolean from the environment settles on.
+            Shape::Bool => quote! {
+                partial.#ident = !matches!(
+                    value.as_str(),
+                    "" | "0" | "false" | "no" | "off"
+                );
+            },
+            // A count from the environment would be a number, not an occurrence
+            // count; nothing needs it yet.
+            Shape::Count => quote!(let _ = value;),
+        };
+        Some(quote! {
+            if !partial.#given {
+                if let ::std::result::Result::Ok(value) = ::std::env::var(#var) {
+                    #assign
+                    partial.#given = true;
+                }
+            }
+        })
+    });
+
+    let required_checks = cli.fields.iter().filter_map(|f| {
+        // A `String` has nowhere to put "absent", so the type is the declaration.
+        // Anything with a default or an environment variable is already filled.
+        if f.shape != Shape::Required || f.default.is_some() {
+            return None;
+        }
+        let given = format_ident!("__given_{}", f.ident);
+        let name = &f.name;
+        Some(quote! {
+            if !partial.#given {
+                return ::std::result::Result::Err(
+                    ::usage_argv::Error::MissingRequired { name: #name },
+                );
+            }
+        })
+    });
+
+    let choice_checks = cli.fields.iter().filter_map(|f| {
+        if f.choices.is_empty() {
+            return None;
+        }
+        let ident = &f.ident;
+        let name = &f.name;
+        let choices = &f.choices;
+        let values = match f.shape {
+            Shape::Optional => quote!(partial.#ident.iter()),
+            Shape::Required => quote!(::std::iter::once(&partial.#ident)),
+            Shape::Many => quote!(partial.#ident.iter()),
+            // Rejected in the model: there is no value to check.
+            Shape::Bool | Shape::Count => return None,
+        };
+        Some(quote! {
+            for value in #values {
+                if ![#(#choices),*].contains(&value.as_str()) {
+                    return ::std::result::Result::Err(
+                        ::usage_argv::Error::InvalidChoice {
+                            name: #name,
+                            choices: &[#(#choices),*],
+                        },
+                    );
+                }
+            }
+        })
+    });
+
+    let bound_checks = cli.fields.iter().filter_map(|f| {
+        if f.var_min.is_none() && f.var_max.is_none() {
+            return None;
+        }
+        let ident = &f.ident;
+        let name = &f.name;
+        let min = match f.var_min {
+            Some(min) => quote! {
+                if got < #min {
+                    return ::std::result::Result::Err(
+                        ::usage_argv::Error::VarTooFew { name: #name, min: #min, got },
+                    );
+                }
+            },
+            None => quote!(),
+        };
+        let max = match f.var_max {
+            Some(max) => quote! {
+                if got > #max {
+                    return ::std::result::Result::Err(
+                        ::usage_argv::Error::VarTooMany { name: #name, max: #max, got },
+                    );
+                }
+            },
+            None => quote!(),
+        };
+        let given = format_ident!("__given_{}", ident);
+        Some(quote! {
+            // Only when the field was used. A bound says "if you give values, give
+            // this many" — reading an unused optional flag as a violation would make
+            // `var_min` a second way to spell required-ness, and there would then be
+            // no way to say "at least two, if you use it at all".
+            if partial.#given {
+                let got = partial.#ident.len();
+                #min
+                #max
+            }
+        })
+    });
+
+    quote! {
+        #(#env_fallbacks)*
+        #(#required_checks)*
+        #(#choice_checks)*
+        #(#bound_checks)*
     }
 }

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -367,6 +367,10 @@ fn flag_meta(i: usize, field: &Field) -> TokenStream {
     let hide = field.hide;
     let count = field.shape == Shape::Count;
     let repeatable = field.repeatable;
+    // Same rule as an argument: a `String` has nowhere to put "absent". The runtime
+    // check already enforced it; the spec has to say it too, or docs and completions
+    // describe a different CLI from the one that runs.
+    let required = field.shape == Shape::Required;
     let choices = choices_tokens(field);
     let (var_min, var_max) = bounds_tokens(field);
 
@@ -381,6 +385,7 @@ fn flag_meta(i: usize, field: &Field) -> TokenStream {
             hide: #hide,
             count: #count,
             repeatable: #repeatable,
+            required: #required,
             choices: #choices,
             var_min: #var_min,
             var_max: #var_max,
@@ -997,15 +1002,27 @@ fn post_binding(cli: &Cli) -> TokenStream {
                     "" | "0" | "false" | "no" | "off"
                 );
             },
-            // A count from the environment would be a number, not an occurrence
-            // count; nothing needs it yet.
-            Shape::Count => quote!(let _ = value;),
+            // A number, since the environment cannot repeat a flag: `EX_VERBOSE=3`
+            // is how you say `-vvv`. An unparseable value leaves the field alone
+            // rather than being counted as given.
+            Shape::Count => {
+                let ty = &f.ty;
+                quote! {
+                    match value.parse::<#ty>() {
+                        ::std::result::Result::Ok(count) => partial.#ident = count,
+                        ::std::result::Result::Err(_) => continue_unset = true,
+                    }
+                }
+            }
         };
         Some(quote! {
             if !partial.#given {
                 if let ::std::result::Result::Ok(value) = ::std::env::var(#var) {
+                    let mut continue_unset = false;
                     #assign
-                    partial.#given = true;
+                    if !continue_unset {
+                        partial.#given = true;
+                    }
                 }
             }
         })

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -86,6 +86,30 @@
 //! tree has no duplicates, so a collision fails a test rather than binding the wrong
 //! field.
 //!
+//! # What is decided after the parse
+//!
+//! The parser binds tokens. Whether what it bound is *acceptable* needs to know the
+//! declared type, so the generated code checks that once the last token has been
+//! read, in an order that is deliberate:
+//!
+//! 1. **The environment** fills what argv left out, for a field with `env`.
+//! 2. **Required-ness**, which the type states: a `String` has nowhere to put
+//!    "absent", so it must be given — unless a default or the environment already
+//!    filled it.
+//! 3. **`choices`** and **`var_min`/`var_max`**, which judge a value however it
+//!    arrived, including from the environment or a default.
+//!
+//! Only the command that actually ran is judged. A flag that `install` requires says
+//! nothing about an invocation of `run`.
+//!
+//! Bounds constrain the values a field was *given*: an unused optional flag is
+//! absent, not a violation, or `var_min` would be a second way to spell
+//! required-ness and there would be no way to say "at least two, if you use it".
+//!
+//! Contradictions are refused at compile time rather than at run time — `choices` on
+//! a `bool`, a `var_min` above its `var_max`, a bound on something that is not a
+//! `Vec`, or a default that is not one of the choices.
+//!
 //! # Declaring
 //!
 //! A field with `long` or `short` is a flag; anything else is a positional
@@ -114,11 +138,14 @@
 //! Published early on purpose, so it can be used and argued with — but these are
 //! real limits, not omissions from the docs.
 //!
-//! - **A required subcommand.** A `subcommand` field has to be `Option<T>`:
-//!   reporting that one was needed is a required-ness question, and that layer does
-//!   not exist yet.
 //! - **Nesting deeper than one level.** A subcommand's own subcommands need the
 //!   `Args` struct to carry a `subcommand` field too, which it does not yet.
+//! - **`overrides` and `required_unless`.** Both are about one flag's effect on
+//!   another, which needs to know the order they arrived in; nothing records that
+//!   yet.
+//! - **Typed values.** Everything is text: a field is a `String`, an
+//!   `Option<String>`, a `Vec<String>`, a `bool`, or a counting integer. Parsing
+//!   into a richer type needs an error for a value that will not convert.
 //! - **Typed values.** Fields are `bool`, `String`, `Option<String>`,
 //!   `Vec<String>`, or an unsigned integer with `count`. Anything else is a
 //!   compile error rather than a surprise, because converting a value is also

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -39,6 +39,11 @@ pub struct Field {
     pub env: Option<String>,
     pub default: Option<String>,
     pub help_heading: Option<String>,
+    /// The values this may take. Checked after the parse, since a choice list is
+    /// about what a value *means* rather than which token it came from.
+    pub choices: Vec<String>,
+    pub var_min: Option<usize>,
+    pub var_max: Option<usize>,
     pub hide: bool,
     /// Whether the flag may be given more than once, taking one value each time.
     ///
@@ -71,9 +76,12 @@ pub enum Kind {
     /// [`Subcommands`](usage_argv::spec::Subcommands) trait, which is also how it
     /// reaches the type that accumulates a subcommand's values.
     Subcommand {
-        /// The enum's type, as written. Always reached through `Option<T>` for now,
-        /// so there is nothing to record about optionality.
+        /// The enum's type, as written.
         ty: syn::Type,
+        /// Whether the field is `Option<T>`, and so may be left unfilled. A bare `T`
+        /// says a subcommand is required, which is reported once the last token has
+        /// been read.
+        optional: bool,
     },
 }
 
@@ -288,27 +296,21 @@ impl Field {
         // `Option<T>` says the subcommand may be left out. A bare `T` cannot be
         // satisfied by this version — nothing yet reports "a subcommand is
         // required", which is a post-binding question.
+        // `Option<T>` may be left unfilled; a bare `T` requires one.
         let name = type_name(&field.ty);
-        let (ty, _optional) = match name
+        let (ty, optional) = match name
             .strip_prefix("Option<")
             .and_then(|rest| rest.strip_suffix('>'))
         {
             Some(inner) => (syn::parse_str::<Type>(inner)?, true),
-            None => {
-                return Err(syn::Error::new(
-                    span,
-                    "a `subcommand` field has to be `Option<T>` for now: a missing \
-                     subcommand is a required-ness question, and that layer does not \
-                     exist yet",
-                ));
-            }
+            None => (field.ty.clone(), false),
         };
 
         Ok(Some(Field {
             ident: ident.clone(),
             ty: field.ty.clone(),
             name: to_kebab(&ident.to_string()),
-            kind: Kind::Subcommand { ty },
+            kind: Kind::Subcommand { ty, optional },
             // A subcommand field holds a command, not a value, so none of what
             // describes a value applies to it.
             shape: Shape::Bool,
@@ -317,6 +319,9 @@ impl Field {
             env: None,
             default: None,
             help_heading: None,
+            choices: Vec::new(),
+            var_min: None,
+            var_max: None,
             hide: false,
             repeatable: false,
             span,
@@ -353,6 +358,9 @@ impl Field {
         let mut help_heading = None;
         let mut hide = false;
         let mut is_arg = false;
+        let mut choices: Vec<String> = Vec::new();
+        let mut var_min: Option<usize> = None;
+        let mut var_max: Option<usize> = None;
 
         for attr in attrs(&field.attrs) {
             for meta in nested(attr)? {
@@ -389,6 +397,31 @@ impl Field {
                     "hide" => hide = flag_value(&meta)?,
                     "arg" => is_arg = flag_value(&meta)?,
                     "env" => env = Some(string_value(&meta)?),
+                    // `choices("a", "b")` rather than one comma-joined string, so a
+                    // value containing a comma is expressible.
+                    "choices" => {
+                        let Meta::List(list) = &meta else {
+                            return Err(syn::Error::new_spanned(
+                                meta.path(),
+                                "`choices` takes a list, as in `choices(\"bash\", \"zsh\")`",
+                            ));
+                        };
+                        choices = list
+                            .parse_args_with(
+                                syn::punctuated::Punctuated::<syn::LitStr, syn::Token![,]>::parse_terminated,
+                            )?
+                            .into_iter()
+                            .map(|lit| lit.value())
+                            .collect();
+                        if choices.is_empty() {
+                            return Err(syn::Error::new_spanned(
+                                meta.path(),
+                                "`choices` with nothing in it would accept nothing",
+                            ));
+                        }
+                    }
+                    "var_min" => var_min = Some(int_value(&meta)?),
+                    "var_max" => var_max = Some(int_value(&meta)?),
                     "default" => default = Some(string_value(&meta)?),
                     "help_heading" => help_heading = Some(string_value(&meta)?),
                     "double_dash" => {
@@ -531,6 +564,41 @@ impl Field {
                 _ => {}
             }
         }
+        if !choices.is_empty() && matches!(shape, Shape::Bool | Shape::Count) {
+            return Err(syn::Error::new(
+                span,
+                "a `bool` or counting field has no value to check against `choices`",
+            ));
+        }
+        if let (Some(min), Some(max)) = (var_min, var_max) {
+            if min > max {
+                return Err(syn::Error::new(
+                    span,
+                    format!(
+                        "`var_min = {min}` is more than `var_max = {max}`, so nothing \
+                             could satisfy both"
+                    ),
+                ));
+            }
+        }
+        if (var_min.is_some() || var_max.is_some()) && shape != Shape::Many {
+            return Err(syn::Error::new(
+                span,
+                "`var_min` and `var_max` count values, so the field has to be a `Vec`",
+            ));
+        }
+        if let Some(default) = &default {
+            if !choices.is_empty() && !choices.iter().any(|c| c == default) {
+                return Err(syn::Error::new(
+                    span,
+                    format!(
+                        "the default `{default}` is not one of this field's choices, so \
+                         it could never be valid"
+                    ),
+                ));
+            }
+        }
+
         let is_flag = !longs.is_empty() || !shorts.is_empty();
         if is_flag && is_arg {
             return Err(syn::Error::new(
@@ -634,6 +702,9 @@ impl Field {
             env,
             default,
             help_heading,
+            choices,
+            var_min,
+            var_max,
             hide,
             repeatable,
             span,
@@ -736,6 +807,19 @@ fn string_value(meta: &Meta) -> syn::Result<String> {
         other => Err(syn::Error::new_spanned(
             other,
             "expected a string, as in `long = \"jobs\"`",
+        )),
+    }
+}
+
+fn int_value(meta: &Meta) -> syn::Result<usize> {
+    let value = &meta.require_name_value()?.value;
+    match value {
+        Expr::Lit(ExprLit {
+            lit: Lit::Int(i), ..
+        }) => i.base10_parse(),
+        other => Err(syn::Error::new_spanned(
+            other,
+            "expected a whole number, as in `var_min = 1`",
         )),
     }
 }


### PR DESCRIPTION
Second of the stack (#816 merged while this was in flight, so it targets `main`). The parser binds tokens and stops there, which left required-ness, `choices`, variadic bounds, and `env` fallback unimplemented — the 18 corpus vectors the harness reports as **post-binding**, and the reason a `subcommand` field had to be `Option<T>`.

## Order matters, so it is stated

1. **The environment** fills what argv left out.
2. **Required-ness** — which the type declares: a `String` has nowhere to put "absent". After the environment, so a flag with `env` set is not reported missing.
3. **`choices` and bounds**, which judge a value however it arrived, including from the environment or a default.

Only the command that actually ran is judged. A flag that `install` requires says nothing about an invocation of `run` — which is why the check hangs off the `CommandArgs` trait and the enum forwards it to the selected variant only. A bare `subcommand` field now means one is required and says so when absent, removing #816's stated limit.

## Two decisions worth arguing with

**A field remembers whether a token supplied it**, rather than inferring that from an empty value. `--out=` is a value somebody typed, and treating `""` as unset would make it unsayable — the same distinction #810 fixed in the parser, carried through to the checks.

**Bounds constrain the values a field was given.** An unused optional flag is absent, not a violation. Otherwise `var_min = 1` becomes a second spelling of required-ness, and there is no way left to say "at least two, *if* you use it at all". My own test caught this: I put `var_min = 1` on an optional flag and every unrelated test in the file started failing with `VarTooFew`.

## Contradictions are compile errors

```
error: a `bool` or counting field has no value to check against `choices`
error: `var_min = 3` is more than `var_max = 2`, so nothing could satisfy both
error: `var_min` and `var_max` count values, so the field has to be a `Vec`
error: the default `z` is not one of this field's choices, so it could never be valid
```

Consistent with the rest of this crate: the derive's job is refusing what cannot round-trip or cannot mean anything.

## The declarations reach the spec

A test pins that, because a choice list the parser enforces but the spec omits would be invisible to docs and completions — exactly the kind of half-implemented feature this project keeps turning up.

10 tests: each check, the empty-value case, per-command judging, and a required subcommand.

## Still missing, and now stated in the crate docs

`overrides` and `required_unless` (both need the order flags arrived in, which nothing records yet), nesting past one level, and typed values.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches public `Error` and trait APIs and adds substantial generated validation/env logic that changes how CLIs accept or reject input. Well-tested, but incorrect checks would mis-parse real command lines.
> 
> **Overview**
> Implements the **post-binding** layer the parser deliberately left out: after tokens are bound, generated code now checks required-ness, `choices`, `var_min`/`var_max`, and fills from `env` when argv left a field unset.
> 
> **Validation order** is fixed: env fallback → required checks → choices/bounds. Only the selected subcommand is judged. A bare `subcommand: T` field is now allowed and reports `MissingSubcommand` when absent (previously had to be `Option<T>`).
> 
> Extends `Error` with `MissingRequired`, `InvalidChoice`, `VarTooFew`, `VarTooMany`, and `MissingSubcommand`, and marks it `non_exhaustive`. Adds `check` to `CommandArgs`/`Subcommands`. Declarations also flow into the emitted spec so docs and completions see the same constraints.
> 
> Contradictions (`choices` on bool, `var_min > var_max`, default outside choices) are compile errors. New conformance tests cover each check, empty values counting as given, and env precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bc52c746c9f9799d4f3e7079b3c64070162fd53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added post-parse validation for required values, allowed choices, variable-length arguments, and required subcommands.
  * Added environment-value fallback and clear precedence when command-line values are provided.
  * Added support for validating only the selected subcommand.
  * Expanded generated command specifications with choices and argument bounds.

* **Bug Fixes**
  * Improved handling of boolean environment values and invalid defaults.

* **Documentation**
  * Documented validation order, scope, supported constraints, and current limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->