### PR TITLE
feat(derive): nest commands to any depth

### DIFF
--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -747,7 +747,11 @@ fn quoted(value: &str) -> String {
 pub trait CommandArgs: Sized {
     /// Values collected so far. Partly-filled by construction, since a parse can
     /// stop early.
-    type Partial: Default;
+    ///
+    /// No `Default` bound: [`CommandArgs::start`] is what produces a fresh one,
+    /// because a command with subcommands of its own has nested state that a derived
+    /// `Default` cannot set up.
+    type Partial;
 
     /// The parse tables for this command.
     ///
@@ -786,7 +790,10 @@ pub trait CommandArgs: Sized {
     }
 
     /// Build the struct from what was collected.
-    fn build(partial: Self::Partial) -> Self;
+    ///
+    /// Fallible because a command can require a subcommand of its own, and "none was
+    /// given" is only knowable here — at the point where the value has to exist.
+    fn build<'t, 'v>(partial: Self::Partial) -> Result<Self, crate::Error<'t, 'v>>;
 }
 
 /// An enum whose variants are a command's subcommands.
@@ -815,8 +822,11 @@ pub trait Subcommands: Sized {
     /// Build the variant whose command was selected, by its [`Command::key`].
     ///
     /// `None` when no variant was selected, which a caller reads as "no subcommand
-    /// was given".
-    fn select(partial: Self::Partial, key: u64) -> Option<Self>;
+    /// was given". An `Err` comes from building the variant that *was* selected.
+    fn select<'t, 'v>(
+        partial: Self::Partial,
+        key: u64,
+    ) -> Result<Option<Self>, crate::Error<'t, 'v>>;
 }
 
 #[cfg(test)]

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -817,15 +817,22 @@ pub trait Subcommands: Sized {
     ///
     /// A flag that `install` requires says nothing about an invocation that ran
     /// `run`, so only the command that was actually reached is judged.
-    fn check<'t, 'v>(partial: &mut Self::Partial, key: u64) -> Result<(), crate::Error<'t, 'v>>;
+    ///
+    /// Identified by its position in [`Subcommands::COMMANDS`] rather than by its
+    /// key: the position is found from the table's own address, so two commands whose
+    /// keys happen to collide still cannot be confused for one another.
+    fn check<'t, 'v>(
+        partial: &mut Self::Partial,
+        selected: usize,
+    ) -> Result<(), crate::Error<'t, 'v>>;
 
-    /// Build the variant whose command was selected, by its [`Command::key`].
+    /// Build the variant at `selected`, a position in [`Subcommands::COMMANDS`].
     ///
     /// `None` when no variant was selected, which a caller reads as "no subcommand
     /// was given". An `Err` comes from building the variant that *was* selected.
     fn select<'t, 'v>(
         partial: Self::Partial,
-        key: u64,
+        selected: usize,
     ) -> Result<Option<Self>, crate::Error<'t, 'v>>;
 }
 

--- a/conformance/tests/nesting.rs
+++ b/conformance/tests/nesting.rs
@@ -1,0 +1,169 @@
+//! Commands inside commands, to any depth.
+//!
+//! mise is four levels deep in places (`mise bootstrap macos launchd-agents apply`),
+//! so one level was never going to be enough. A nested command is not a special case
+//! here: an `Args` struct carries a `subcommand` field exactly as the root does, and
+//! generates the same code for it.
+
+use std::ffi::OsStr;
+
+use usage::Spec as LibSpec;
+use usage_argv::Error;
+use usage_derive::{Args, Cli, Subcommands};
+
+fn argv<const N: usize>(tokens: [&str; N]) -> [&OsStr; N] {
+    tokens.map(OsStr::new)
+}
+
+/// A tool with commands inside commands
+#[derive(Cli)]
+#[usage(bin = "ex")]
+struct Ex {
+    /// Say more
+    #[usage(short = 'v', long, global)]
+    verbose: bool,
+    /// What to do
+    #[usage(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommands)]
+enum Commands {
+    /// Manage settings
+    Settings(Settings),
+    /// Install a tool
+    Install(Install),
+}
+
+/// Manage settings
+#[derive(Args)]
+struct Settings {
+    /// Which settings file
+    #[usage(long)]
+    file: Option<String>,
+    /// What to do with them
+    #[usage(subcommand)]
+    command: SettingsCommands,
+}
+
+#[derive(Subcommands)]
+enum SettingsCommands {
+    /// Set a value
+    Set(SettingsSet),
+    /// Show every value
+    Ls(SettingsLs),
+}
+
+/// Set a value
+#[derive(Args)]
+struct SettingsSet {
+    /// Which setting
+    key: String,
+    /// The value
+    value: String,
+}
+
+/// Show every value
+#[derive(Args)]
+struct SettingsLs {
+    /// As JSON
+    #[usage(long)]
+    json: bool,
+}
+
+/// Install a tool
+#[derive(Args)]
+struct Install {
+    /// What to install
+    tool: String,
+}
+
+#[test]
+fn three_levels_route_to_the_deepest_command() {
+    let a = argv(["settings", "set", "jobs", "8"]);
+    let ex = Ex::parse_from(&a).expect("should parse");
+
+    let Commands::Settings(settings) = ex.command else {
+        panic!("expected settings");
+    };
+    let SettingsCommands::Set(set) = settings.command else {
+        panic!("expected settings set");
+    };
+    assert_eq!((set.key.as_str(), set.value.as_str()), ("jobs", "8"));
+}
+
+#[test]
+fn each_level_keeps_its_own_flags() {
+    // `--file` belongs to `settings`, `--json` to `settings ls`, `--verbose` to the
+    // root and inherited by both.
+    let a = argv(["--verbose", "settings", "--file", "a.toml", "ls", "--json"]);
+    let ex = Ex::parse_from(&a).expect("should parse");
+    assert!(ex.verbose, "a global reaches any depth");
+
+    let Commands::Settings(settings) = ex.command else {
+        panic!("expected settings");
+    };
+    assert_eq!(settings.file.as_deref(), Some("a.toml"));
+    let SettingsCommands::Ls(ls) = settings.command else {
+        panic!("expected settings ls");
+    };
+    assert!(ls.json);
+}
+
+#[test]
+fn a_global_works_after_the_deepest_command_too() {
+    let a = argv(["settings", "ls", "--verbose"]);
+    let ex = Ex::parse_from(&a).expect("should parse");
+    assert!(ex.verbose);
+}
+
+#[test]
+fn a_middle_command_can_require_one_of_its_own() {
+    // `settings` alone is incomplete: its `subcommand` field is not an `Option`.
+    let a = argv(["settings"]);
+    assert!(matches!(Ex::parse_from(&a), Err(Error::MissingSubcommand)));
+}
+
+#[test]
+fn a_deep_commands_requirements_are_its_own() {
+    // `set` needs two arguments; reaching it without them is its failure, not the
+    // root's, and running a sibling is not held to it.
+    let a = argv(["settings", "set", "jobs"]);
+    assert!(matches!(
+        Ex::parse_from(&a),
+        Err(Error::MissingRequired { name: "value" })
+    ));
+
+    let a = argv(["settings", "ls"]);
+    assert!(Ex::parse_from(&a).is_ok(), "ls requires nothing");
+}
+
+#[test]
+fn a_sibling_at_the_top_still_works() {
+    let a = argv(["install", "node"]);
+    let ex = Ex::parse_from(&a).expect("should parse");
+    let Commands::Install(install) = ex.command else {
+        panic!("expected install");
+    };
+    assert_eq!(install.tool, "node");
+}
+
+#[test]
+fn the_spec_nests_the_same_way() {
+    let kdl = Ex::to_kdl();
+    let spec: LibSpec = kdl.parse().unwrap_or_else(|e| panic!("{e}\n\n{kdl}"));
+
+    let settings = &spec.cmd.subcommands["settings"];
+    let mut inner: Vec<&str> = settings.subcommands.keys().map(String::as_str).collect();
+    inner.sort();
+    assert_eq!(inner, ["ls", "set"]);
+
+    let set = &settings.subcommands["set"];
+    assert_eq!(set.args.len(), 2);
+    assert_eq!(set.help.as_deref(), Some("Set a value"));
+}
+
+#[test]
+fn the_emitted_spec_reads_like_a_handwritten_one() {
+    insta::assert_snapshot!(Ex::to_kdl());
+}

--- a/conformance/tests/nesting.rs
+++ b/conformance/tests/nesting.rs
@@ -167,3 +167,67 @@ fn the_spec_nests_the_same_way() {
 fn the_emitted_spec_reads_like_a_handwritten_one() {
     insta::assert_snapshot!(Ex::to_kdl());
 }
+
+/// Two commands whose argument structs share a Rust type *name*, in different
+/// modules. Keys are derived from the whole declaration rather than the name, so
+/// these do not collide — hashing the name alone gave both structs the same key and
+/// selected the wrong command.
+mod add {
+    /// Add something
+    #[derive(usage_derive::Args)]
+    pub struct Op {
+        /// What to add
+        pub target: String,
+    }
+}
+
+mod remove {
+    /// Remove something
+    #[derive(usage_derive::Args)]
+    pub struct Op {
+        /// What to remove
+        pub target: String,
+        /// Whether to force it
+        #[usage(long)]
+        pub force: bool,
+    }
+}
+
+#[derive(Cli)]
+#[usage(bin = "same")]
+struct Same {
+    #[usage(subcommand)]
+    command: SameCommands,
+}
+
+#[derive(Subcommands)]
+enum SameCommands {
+    /// Add something
+    #[usage(name = "add")]
+    Add(add::Op),
+    /// Remove something
+    #[usage(name = "remove")]
+    Remove(remove::Op),
+}
+
+#[test]
+fn same_named_structs_in_different_modules_do_not_collide() {
+    let a = argv(["remove", "x", "--force"]);
+    let same = Same::parse_from(&a).expect("should parse");
+    let SameCommands::Remove(op) = same.command else {
+        panic!("expected remove, which means the keys collided");
+    };
+    assert_eq!(op.target, "x");
+    assert!(op.force);
+
+    let a = argv(["add", "y"]);
+    let same = Same::parse_from(&a).expect("should parse");
+    let SameCommands::Add(op) = same.command else {
+        panic!("expected add");
+    };
+    assert_eq!(op.target, "y");
+
+    // `to_kdl` asserts the tree holds no duplicate keys, so this would panic in debug
+    // if the two still shared one.
+    assert!(Same::to_kdl().contains(r#"cmd "remove""#));
+}

--- a/conformance/tests/snapshots/nesting__the_emitted_spec_reads_like_a_handwritten_one.snap
+++ b/conformance/tests/snapshots/nesting__the_emitted_spec_reads_like_a_handwritten_one.snap
@@ -1,0 +1,23 @@
+---
+source: conformance/tests/nesting.rs
+expression: "Ex::to_kdl()"
+---
+name "ex"
+bin "ex"
+about "A tool with commands inside commands"
+flag "-v --verbose" help="Say more" global=#true
+cmd "settings" help="Manage settings" {
+    flag "--file" help="Which settings file" {
+        arg "<file>"
+    }
+    cmd "set" help="Set a value" {
+        arg "<key>" help="Which setting"
+        arg "<value>" help="The value"
+    }
+    cmd "ls" help="Show every value" {
+        flag "--json" help="As JSON"
+    }
+}
+cmd "install" help="Install a tool" {
+    arg "<tool>" help="What to install"
+}

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -406,8 +406,14 @@ const KIND_COMMAND: u64 = 2 << 30;
 /// Two macro expansions cannot see each other, so a shared counter is not available:
 /// keys carry a hash of the declaration they came from instead. The whole item, not
 /// just its name — a macro cannot see a module path, so two same-named structs in
-/// different modules would otherwise hash alike. Two types now have to be identical
-/// to collide, and `Spec::to_kdl` asserts the tree holds no duplicates either way.
+/// different modules would otherwise hash alike.
+///
+/// Two byte-identical declarations in different modules still hash alike, and that
+/// residue is deliberately harmless rather than fixed: a key only chooses which arm
+/// to jump to, and each arm then checks that the event came from *its* table. So a
+/// collision means an event goes unclaimed, never misbound. `Spec::to_kdl` also
+/// asserts the tree holds no duplicates, which turns it into a failed test rather
+/// than a puzzle.
 fn key_base(fingerprint: &str) -> u64 {
     // FNV-1a, spelled out rather than taken from a `Hasher`, which is not guaranteed
     // to be stable between compilations — and these end up baked into generated code.
@@ -467,8 +473,18 @@ fn flag_arm(i: usize, field: &Field, base: u64) -> TokenStream {
         Shape::Required => quote!(partial.#ident = __usage_value_text(value);),
         Shape::Many => quote!(partial.#ident.push(__usage_value_text(value));),
     };
+    let table = format_ident!("FLAG_{i}");
     quote! {
-        #key => { #body partial.#given = true; true }
+        // The key gets us to the right arm in one jump; the identity check makes a
+        // collision harmless rather than wrong. Two identical declarations in
+        // different modules hash alike — a macro cannot see a module path — and
+        // without this, one command's flag would fill another's field. `static` items
+        // have distinct addresses, so this is exact.
+        #key if ::core::ptr::eq(*flag, &#table) => {
+            #body
+            partial.#given = true;
+            true
+        }
     }
 }
 
@@ -483,8 +499,13 @@ fn arg_arm(i: usize, field: &Field, base: u64) -> TokenStream {
         },
         _ => quote!(partial.#ident = __usage_text(value);),
     };
+    let table = format_ident!("ARG_{i}");
     quote! {
-        #key => { #body partial.#given = true; true }
+        #key if ::core::ptr::eq(*arg, &#table) => {
+            #body
+            partial.#given = true;
+            true
+        }
     }
 }
 

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -66,82 +66,15 @@ pub fn emit(cli: &Cli) -> TokenStream {
     let about = option_str(cli.about.as_deref());
     let long_about = option_str(cli.long_about.as_deref());
 
-    // The field holding this command's subcommands, if it declares any. Its type is
-    // reached through the `Subcommands` trait, since the derive cannot see the enum.
-    let subcommand = cli.fields.iter().find_map(|f| match &f.kind {
-        Kind::Subcommand { ty, .. } => Some((f, ty)),
-        _ => None,
-    });
-    let (sub_commands, sub_metas) = match subcommand {
-        Some((_, ty)) => {
-            let ty = in_module(ty);
-            (
-                quote!(subcommands: <#ty as ::usage_argv::spec::Subcommands>::COMMANDS,),
-                quote!(subcommands: <#ty as ::usage_argv::spec::Subcommands>::METAS,),
-            )
-        }
-        None => (quote!(), quote!()),
-    };
-    let (sub_init, sub_route, sub_build) = match subcommand {
-        Some((field, ty)) => {
-            let ident = &field.ident;
-            let optional = matches!(&field.kind, Kind::Subcommand { optional: true, .. });
-            (
-                quote! {
-                    let mut __usage_sub =
-                        <<#ty as ::usage_argv::spec::Subcommands>::Partial as
-                            ::std::default::Default>::default();
-                    // `None` rather than a reserved key: nothing has to be true about
-                    // the number space for "no subcommand was given" to be sayable.
-                    let mut __usage_selected: ::std::option::Option<u64> =
-                        ::std::option::Option::None;
-                },
-                quote! {
-                    if let ::usage_argv::Event::Command(__usage_cmd) = &__usage_event {
-                        __usage_selected = ::std::option::Option::Some(__usage_cmd.key);
-                    }
-                    <#ty as ::usage_argv::spec::Subcommands>::apply(
-                        &mut __usage_sub,
-                        &__usage_event,
-                    );
-                },
-                {
-                    // Only the command that was reached is judged, and a command that
-                    // was required has to be reported if it was not.
-                    let selected = quote! {
-                        match __usage_selected {
-                            ::std::option::Option::Some(__usage_key) => {
-                                <#ty as ::usage_argv::spec::Subcommands>::check(
-                                    &mut __usage_sub,
-                                    __usage_key,
-                                )?;
-                                <#ty as ::usage_argv::spec::Subcommands>::select(
-                                    __usage_sub,
-                                    __usage_key,
-                                )
-                            }
-                            ::std::option::Option::None => ::std::option::Option::None,
-                        }
-                    };
-                    if optional {
-                        quote!(#ident: #selected,)
-                    } else {
-                        quote! {
-                            #ident: match #selected {
-                                ::std::option::Option::Some(__usage_cmd) => __usage_cmd,
-                                ::std::option::Option::None => {
-                                    return ::std::result::Result::Err(
-                                        ::usage_argv::Error::MissingSubcommand,
-                                    );
-                                }
-                            },
-                        }
-                    }
-                },
-            )
-        }
-        None => (quote!(), quote!(), quote!()),
-    };
+    // The same wiring a nested command uses: the root differs only in how it is
+    // entered, so it does not get its own copy.
+    let parts = subcommand_parts(cli);
+    let sub_commands = parts
+        .as_ref()
+        .map(|p| p.commands.clone())
+        .unwrap_or_default();
+    let sub_metas = parts.as_ref().map(|p| p.metas.clone()).unwrap_or_default();
+    let sub_build = parts.as_ref().map(|p| p.build.clone()).unwrap_or_default();
 
     let partial = partial_struct(cli);
     let defaults = partial_defaults(cli);
@@ -217,6 +150,18 @@ pub fn emit(cli: &Cli) -> TokenStream {
             #partial
             #apply
 
+            /// Everything decided after the last token.
+            ///
+            /// In the module rather than beside the parse, so every reference it makes
+            /// to the user's own types sits at one consistent scope — the root and a
+            /// nested command generate the same code here.
+            pub fn check<'t, 'v>(
+                partial: &mut Partial,
+            ) -> ::std::result::Result<(), ::usage_argv::Error<'t, 'v>> {
+                #post
+                ::std::result::Result::Ok(())
+            }
+
             pub static SPEC: Spec = Spec {
                 name: #name,
                 bin: #bin,
@@ -257,21 +202,18 @@ pub fn emit(cli: &Cli) -> TokenStream {
                 use #module::Partial;
 
                 #defaults
-                #sub_init
 
                 let mut __usage_parser = ::usage_argv::Parser::new(Self::command(), argv);
                 while let ::std::option::Option::Some(__usage_event) =
                     __usage_parser.next_event()
                 {
-                    let __usage_event = __usage_event?;
-                    // This command's own fields first. Keys are unique across the
-                    // CLI, so anything it does not claim belongs to a subcommand.
-                    if !#module::apply(&mut partial, &__usage_event) {
-                        #sub_route
-                    }
+                    // `apply` handles this command's own fields and routes anything
+                    // else into its subcommands, which is why a nested command needs
+                    // nothing extra here.
+                    #module::apply(&mut partial, &__usage_event?);
                 }
 
-                #post
+                #module::check(&mut partial)?;
 
                 ::std::result::Result::Ok(Self {
                     #sub_build
@@ -556,6 +498,9 @@ fn option_str(value: Option<&str>) -> TokenStream {
 /// subcommand cannot use locals in the root's parse function, because the root
 /// cannot see its fields.
 fn partial_struct(cli: &Cli) -> TokenStream {
+    let sub = subcommand_parts(cli)
+        .map(|p| p.partial_fields)
+        .unwrap_or_default();
     let fields = cli.fields.iter().filter_map(|f| {
         if matches!(f.kind, Kind::Subcommand { .. }) {
             // Its values live in the enum's own partial.
@@ -581,10 +526,12 @@ fn partial_struct(cli: &Cli) -> TokenStream {
 
     // `Default` rather than a generated `new`: every accumulator type has one, and
     // a default that says "nothing was given" is what a partial starts as.
+    // `Default` is not derived once a subcommand is in play: the nested partial has
+    // its own starting values, which `start` puts in place.
     quote! {
-        #[derive(Default)]
         pub struct Partial {
             #(#fields)*
+            #sub
         }
     }
 }
@@ -594,6 +541,20 @@ fn partial_struct(cli: &Cli) -> TokenStream {
 /// A declared `default` has to be in place before parsing starts, since nothing
 /// later distinguishes "the default" from "what the user typed".
 fn partial_defaults(cli: &Cli) -> TokenStream {
+    let sub_starts = subcommand_parts(cli)
+        .map(|p| p.partial_starts)
+        .unwrap_or_default();
+    let plain = cli.fields.iter().filter_map(|f| {
+        if matches!(f.kind, Kind::Subcommand { .. }) {
+            return None;
+        }
+        let ident = &f.ident;
+        let given = format_ident!("__given_{}", ident);
+        Some(quote! {
+            #ident: ::std::default::Default::default(),
+            #given: false,
+        })
+    });
     let assignments = cli.fields.iter().filter_map(|f| {
         let ident = &f.ident;
         let default = f.default.as_deref()?;
@@ -612,13 +573,17 @@ fn partial_defaults(cli: &Cli) -> TokenStream {
         })
     });
     quote! {
-        let mut partial = Partial::default();
+        let mut partial = Partial {
+            #(#plain)*
+            #sub_starts
+        };
         #(#assignments)*
     }
 }
 
 /// Take one event and say whether it belonged to this command.
 fn apply_fn(cli: &Cli, base: u64) -> TokenStream {
+    let route = subcommand_parts(cli).map(|p| p.route).unwrap_or_default();
     let flags: Vec<&Field> = cli
         .fields
         .iter()
@@ -638,6 +603,7 @@ fn apply_fn(cli: &Cli, base: u64) -> TokenStream {
             event: &::usage_argv::Event<'_, '_>,
         ) -> bool {
             use ::usage_argv::Event;
+            #route
             // Each arm evaluates to whether it claimed the event, rather than
             // returning: a command with no flags of its own would otherwise have every
             // arm diverge, leaving an unreachable tail.
@@ -665,6 +631,110 @@ fn apply_fn(cli: &Cli, base: u64) -> TokenStream {
             }
         }
     }
+}
+
+/// What a command with subcommands needs, wherever it sits in the tree.
+///
+/// The root and a nested command differ only in how they are entered, so they share
+/// this: the tables to splice, the state to carry, how an event is routed, and how
+/// the field is finally built.
+struct SubcommandParts {
+    /// `subcommands:` for the `Command` table.
+    commands: TokenStream,
+    /// `subcommands:` for the `CommandMeta`.
+    metas: TokenStream,
+    /// Fields the partial needs to carry.
+    partial_fields: TokenStream,
+    /// Their starting values.
+    partial_starts: TokenStream,
+    /// Routing an event that this command did not claim.
+    route: TokenStream,
+    /// Checking whichever subcommand was selected.
+    check: TokenStream,
+    /// Building the field.
+    build: TokenStream,
+}
+
+fn subcommand_parts(cli: &Cli) -> Option<SubcommandParts> {
+    let (field, ty) = cli.fields.iter().find_map(|f| match &f.kind {
+        Kind::Subcommand { ty, .. } => Some((f, ty)),
+        _ => None,
+    })?;
+    let ident = &field.ident;
+    let optional = matches!(&field.kind, Kind::Subcommand { optional: true, .. });
+    let in_mod = in_module(ty);
+
+    let selected = quote! {
+        match partial.__usage_selected {
+            ::std::option::Option::Some(__usage_key) => {
+                <#ty as ::usage_argv::spec::Subcommands>::select(
+                    partial.__usage_sub,
+                    __usage_key,
+                )?
+            }
+            ::std::option::Option::None => ::std::option::Option::None,
+        }
+    };
+    let build = if optional {
+        quote!(#ident: #selected,)
+    } else {
+        quote! {
+            #ident: match #selected {
+                ::std::option::Option::Some(__usage_cmd) => __usage_cmd,
+                ::std::option::Option::None => {
+                    return ::std::result::Result::Err(
+                        ::usage_argv::Error::MissingSubcommand,
+                    );
+                }
+            },
+        }
+    };
+
+    Some(SubcommandParts {
+        commands: quote!(subcommands: <#in_mod as ::usage_argv::spec::Subcommands>::COMMANDS,),
+        metas: quote!(subcommands: <#in_mod as ::usage_argv::spec::Subcommands>::METAS,),
+        partial_fields: quote! {
+            pub __usage_sub: <#in_mod as ::usage_argv::spec::Subcommands>::Partial,
+            /// Which of this command's subcommands was reached, if any.
+            pub __usage_selected: ::std::option::Option<u64>,
+        },
+        partial_starts: quote! {
+            __usage_sub: ::std::default::Default::default(),
+            __usage_selected: ::std::option::Option::None,
+        },
+        // `route` and `check` are emitted inside the generated module, so they name
+        // the user's enum through `super::`; `build` sits in the impl beside it and
+        // names it directly.
+        route: quote! {
+            // A command word only counts as *this* command's if one of its own
+            // subcommands answers to it: a deeper descent belongs to whoever owns
+            // that command, and recording it here would make the wrong variant look
+            // selected.
+            if let ::usage_argv::Event::Command(__usage_cmd) = event {
+                if <#in_mod as ::usage_argv::spec::Subcommands>::COMMANDS
+                    .iter()
+                    .any(|candidate| candidate.key == __usage_cmd.key)
+                {
+                    partial.__usage_selected = ::std::option::Option::Some(__usage_cmd.key);
+                }
+            }
+            if <#in_mod as ::usage_argv::spec::Subcommands>::apply(
+                &mut partial.__usage_sub,
+                event,
+            ) {
+                return true;
+            }
+        },
+        check: quote! {
+            if let ::std::option::Option::Some(__usage_key) = partial.__usage_selected {
+                <#in_mod as ::usage_argv::spec::Subcommands>::check(
+                    &mut partial.__usage_sub,
+                    __usage_key,
+                )?;
+            }
+        },
+        build,
+    })
 }
 
 /// A subcommand's argument struct: tables, metadata, and the trait that lets a
@@ -711,10 +781,21 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
     let defaults = partial_defaults(cli);
     let apply = apply_fn(cli, base);
     let post = post_binding(cli);
-    let field_finals = cli.fields.iter().map(|f| {
-        let ident = &f.ident;
-        quote!(#ident: partial.#ident)
-    });
+    let parts = subcommand_parts(cli);
+    let sub_commands = parts
+        .as_ref()
+        .map(|p| p.commands.clone())
+        .unwrap_or_default();
+    let sub_metas = parts.as_ref().map(|p| p.metas.clone()).unwrap_or_default();
+    let sub_build = parts.as_ref().map(|p| p.build.clone()).unwrap_or_default();
+    let field_finals = cli
+        .fields
+        .iter()
+        .filter(|f| !matches!(f.kind, Kind::Subcommand { .. }))
+        .map(|f| {
+            let ident = &f.ident;
+            quote!(#ident: partial.#ident)
+        });
 
     quote! {
         #[doc(hidden)]
@@ -739,6 +820,7 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
                 key: #command_key,
                 flags: &[#(#flag_refs),*],
                 args: &[#(#arg_refs),*],
+                #sub_commands
                 ..Command::EMPTY
             };
 
@@ -751,6 +833,7 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
                 long_about: #long_about,
                 flags: &[#(#flag_meta_refs),*],
                 args: &[#(#arg_meta_refs),*],
+                #sub_metas
                 ..CommandMeta::EMPTY
             };
 
@@ -809,8 +892,13 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
                 #module::check(partial)
             }
 
-            fn build(partial: Self::Partial) -> Self {
-                Self { #(#field_finals),* }
+            fn build<'t, 'v>(
+                partial: Self::Partial,
+            ) -> ::std::result::Result<Self, ::usage_argv::Error<'t, 'v>> {
+                ::std::result::Result::Ok(Self {
+                    #sub_build
+                    #(#field_finals),*
+                })
             }
         }
     }
@@ -914,9 +1002,11 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
         let ty = &v.ty;
         quote! {
             if key == <#ty as ::usage_argv::spec::CommandArgs>::COMMAND.key {
-                return ::std::option::Option::Some(
-                    #ident::#variant(<#ty as ::usage_argv::spec::CommandArgs>::build(partial.#field)),
-                );
+                return ::std::result::Result::Ok(::std::option::Option::Some(
+                    #ident::#variant(
+                        <#ty as ::usage_argv::spec::CommandArgs>::build(partial.#field)?,
+                    ),
+                ));
             }
         }
     });
@@ -971,9 +1061,15 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
                 ::std::result::Result::Ok(())
             }
 
-            fn select(partial: Self::Partial, key: u64) -> ::std::option::Option<Self> {
+            fn select<'t, 'v>(
+                partial: Self::Partial,
+                key: u64,
+            ) -> ::std::result::Result<
+                ::std::option::Option<Self>,
+                ::usage_argv::Error<'t, 'v>,
+            > {
                 #(#selects)*
-                ::std::option::Option::None
+                ::std::result::Result::Ok(::std::option::Option::None)
             }
         }
     }
@@ -986,6 +1082,7 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
 /// come last, because they judge a value however it arrived, including one that came
 /// from the environment or a default.
 fn post_binding(cli: &Cli) -> TokenStream {
+    let sub_check = subcommand_parts(cli).map(|p| p.check).unwrap_or_default();
     let env_fallbacks = cli.fields.iter().filter_map(|f| {
         let ident = &f.ident;
         let given = format_ident!("__given_{}", ident);
@@ -1118,5 +1215,27 @@ fn post_binding(cli: &Cli) -> TokenStream {
         #(#required_checks)*
         #(#choice_checks)*
         #(#bound_checks)*
+        #sub_check
+    }
+}
+
+#[cfg(test)]
+mod in_module_tests {
+    use super::in_module;
+
+    fn rendered(ty: &str) -> String {
+        in_module(&syn::parse_str::<syn::Type>(ty).unwrap())
+            .to_string()
+            .replace(' ', "")
+    }
+
+    #[test]
+    fn a_path_is_qualified_for_the_generated_module() {
+        assert_eq!(rendered("Commands"), "super::Commands");
+        assert_eq!(rendered("cmds::Commands"), "super::cmds::Commands");
+        assert_eq!(rendered("crate::cmds::Commands"), "crate::cmds::Commands");
+        assert_eq!(rendered("::other::Commands"), "::other::Commands");
+        assert_eq!(rendered("self::Commands"), "super::Commands");
+        assert_eq!(rendered("super::Commands"), "super::super::Commands");
     }
 }

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -691,10 +691,10 @@ fn subcommand_parts(cli: &Cli) -> Option<SubcommandParts> {
 
     let selected = quote! {
         match partial.__usage_selected {
-            ::std::option::Option::Some(__usage_key) => {
+            ::std::option::Option::Some(__usage_at) => {
                 <#ty as ::usage_argv::spec::Subcommands>::select(
                     partial.__usage_sub,
-                    __usage_key,
+                    __usage_at,
                 )?
             }
             ::std::option::Option::None => ::std::option::Option::None,
@@ -720,8 +720,10 @@ fn subcommand_parts(cli: &Cli) -> Option<SubcommandParts> {
         metas: quote!(subcommands: <#in_mod as ::usage_argv::spec::Subcommands>::METAS,),
         partial_fields: quote! {
             pub __usage_sub: <#in_mod as ::usage_argv::spec::Subcommands>::Partial,
-            /// Which of this command's subcommands was reached, if any.
-            pub __usage_selected: ::std::option::Option<u64>,
+            /// Which of this command's subcommands was reached, as a position in
+            /// `COMMANDS`. Found from the table's own address, so it cannot be
+            /// confused by a key collision.
+            pub __usage_selected: ::std::option::Option<usize>,
         },
         partial_starts: quote! {
             __usage_sub: ::std::default::Default::default(),
@@ -736,11 +738,12 @@ fn subcommand_parts(cli: &Cli) -> Option<SubcommandParts> {
             // that command, and recording it here would make the wrong variant look
             // selected.
             if let ::usage_argv::Event::Command(__usage_cmd) = event {
-                if <#in_mod as ::usage_argv::spec::Subcommands>::COMMANDS
-                    .iter()
-                    .any(|candidate| candidate.key == __usage_cmd.key)
+                if let ::std::option::Option::Some(__usage_at) =
+                    <#in_mod as ::usage_argv::spec::Subcommands>::COMMANDS
+                        .iter()
+                        .position(|candidate| ::core::ptr::eq(*candidate, *__usage_cmd))
                 {
-                    partial.__usage_selected = ::std::option::Option::Some(__usage_cmd.key);
+                    partial.__usage_selected = ::std::option::Option::Some(__usage_at);
                 }
             }
             if <#in_mod as ::usage_argv::spec::Subcommands>::apply(
@@ -751,10 +754,10 @@ fn subcommand_parts(cli: &Cli) -> Option<SubcommandParts> {
             }
         },
         check: quote! {
-            if let ::std::option::Option::Some(__usage_key) = partial.__usage_selected {
+            if let ::std::option::Option::Some(__usage_at) = partial.__usage_selected {
                 <#in_mod as ::usage_argv::spec::Subcommands>::check(
                     &mut partial.__usage_sub,
-                    __usage_key,
+                    __usage_at,
                 )?;
             }
         },
@@ -1020,9 +1023,7 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
         let field = format_ident!("v{i}");
         let ty = &v.ty;
         quote! {
-            if key == <#ty as ::usage_argv::spec::CommandArgs>::COMMAND.key {
-                return <#ty as ::usage_argv::spec::CommandArgs>::check(&mut partial.#field);
-            }
+            #i => <#ty as ::usage_argv::spec::CommandArgs>::check(&mut partial.#field),
         }
     });
     let selects = subs.variants.iter().enumerate().map(|(i, v)| {
@@ -1030,13 +1031,11 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
         let variant = &v.ident;
         let ty = &v.ty;
         quote! {
-            if key == <#ty as ::usage_argv::spec::CommandArgs>::COMMAND.key {
-                return ::std::result::Result::Ok(::std::option::Option::Some(
-                    #ident::#variant(
-                        <#ty as ::usage_argv::spec::CommandArgs>::build(partial.#field)?,
-                    ),
-                ));
-            }
+            #i => ::std::result::Result::Ok(::std::option::Option::Some(
+                #ident::#variant(
+                    <#ty as ::usage_argv::spec::CommandArgs>::build(partial.#field)?,
+                ),
+            )),
         }
     });
 
@@ -1084,21 +1083,27 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
 
             fn check<'t, 'v>(
                 partial: &mut Self::Partial,
-                key: u64,
+                selected: usize,
             ) -> ::std::result::Result<(), ::usage_argv::Error<'t, 'v>> {
-                #(#checks)*
-                ::std::result::Result::Ok(())
+                match selected {
+                    #(#checks)*
+                    // A position that is not one of these cannot be produced: it comes
+                    // from finding a table's own address in COMMANDS.
+                    _ => ::std::result::Result::Ok(()),
+                }
             }
 
             fn select<'t, 'v>(
                 partial: Self::Partial,
-                key: u64,
+                selected: usize,
             ) -> ::std::result::Result<
                 ::std::option::Option<Self>,
                 ::usage_argv::Error<'t, 'v>,
             > {
-                #(#selects)*
-                ::std::result::Result::Ok(::std::option::Option::None)
+                match selected {
+                    #(#selects)*
+                    _ => ::std::result::Result::Ok(::std::option::Option::None),
+                }
             }
         }
     }

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -39,7 +39,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
         _ => quote!(::usage_argv::UnknownFlags::Value),
     };
 
-    let base = key_base(&ident.to_string());
+    let base = key_base(&cli.fingerprint);
     let root_key = base | KIND_COMMAND;
     let flag_tables = flags
         .iter()
@@ -158,6 +158,10 @@ pub fn emit(cli: &Cli) -> TokenStream {
             pub fn check<'t, 'v>(
                 partial: &mut Partial,
             ) -> ::std::result::Result<(), ::usage_argv::Error<'t, 'v>> {
+                // Read unconditionally: a command that declares nothing to check would
+                // otherwise leave the parameter unused in the user's crate, where
+                // nobody can silence it.
+                let _ = &partial;
                 #post
                 ::std::result::Result::Ok(())
             }
@@ -400,14 +404,15 @@ const KIND_COMMAND: u64 = 2 << 30;
 /// The high half of every key a type's fields get.
 ///
 /// Two macro expansions cannot see each other, so a shared counter is not available:
-/// keys carry a hash of the type they came from instead. A parse dispatches on the
-/// key, so two type names would have to collide in 32 bits to bind the wrong field,
-/// and `Spec::to_kdl` asserts the tree has no duplicates.
-fn key_base(type_name: &str) -> u64 {
+/// keys carry a hash of the declaration they came from instead. The whole item, not
+/// just its name — a macro cannot see a module path, so two same-named structs in
+/// different modules would otherwise hash alike. Two types now have to be identical
+/// to collide, and `Spec::to_kdl` asserts the tree holds no duplicates either way.
+fn key_base(fingerprint: &str) -> u64 {
     // FNV-1a, spelled out rather than taken from a `Hasher`, which is not guaranteed
     // to be stable between compilations — and these end up baked into generated code.
     let mut hash: u32 = 0x811c_9dc5;
-    for byte in type_name.as_bytes() {
+    for byte in fingerprint.as_bytes() {
         hash ^= *byte as u32;
         hash = hash.wrapping_mul(0x0100_0193);
     }
@@ -524,10 +529,9 @@ fn partial_struct(cli: &Cli) -> TokenStream {
         Some(quote!(pub #ident: #ty, pub #given: bool,))
     });
 
-    // `Default` rather than a generated `new`: every accumulator type has one, and
-    // a default that says "nothing was given" is what a partial starts as.
-    // `Default` is not derived once a subcommand is in play: the nested partial has
-    // its own starting values, which `start` puts in place.
+    // No derived `Default`: `start` is what produces a fresh partial, because a
+    // declared default has to be in place before parsing begins and nested state has
+    // its own starting values.
     quote! {
         pub struct Partial {
             #(#fields)*
@@ -742,7 +746,7 @@ fn subcommand_parts(cli: &Cli) -> Option<SubcommandParts> {
 pub fn emit_args(cli: &Cli) -> TokenStream {
     let ident = &cli.ident;
     let module = format_ident!("__usage_args_{}", ident.to_string().to_lowercase());
-    let base = key_base(&ident.to_string());
+    let base = key_base(&cli.fingerprint);
     let command_key = base | KIND_COMMAND;
 
     let flags: Vec<&Field> = cli
@@ -863,6 +867,10 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
             pub fn check<'t, 'v>(
                 partial: &mut Partial,
             ) -> ::std::result::Result<(), ::usage_argv::Error<'t, 'v>> {
+                // Read unconditionally: a command that declares nothing to check would
+                // otherwise leave the parameter unused in the user's crate, where
+                // nobody can silence it.
+                let _ = &partial;
                 #post
                 ::std::result::Result::Ok(())
             }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -85,8 +85,11 @@
 //! `subcommand` field exactly as the root does, to any depth, and generates the same
 //! code for it. mise reaches four levels, so one was never going to be enough.
 //!
-//! Keys carry a hash of the type they came from, which is how independently
-//! expanded macros avoid handing two fields the same one. `Spec::to_kdl` asserts the
+//! Keys carry a hash of the declaration they came from, which is how independently
+//! expanded macros avoid handing two fields the same one. A key chooses which arm to
+//! jump to and the arm then verifies the event came from its own table, so even two
+//! identical declarations in different modules cannot misbind — the event simply goes
+//! unclaimed, and `Spec::to_kdl` asserts the tree holds no duplicate keys. `Spec::to_kdl` asserts the
 //! tree has no duplicates, so a collision fails a test rather than binding the wrong
 //! field.
 //!

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -81,6 +81,10 @@
 //! [`usage_argv::spec::Subcommands`], whose associated consts a parent splices into
 //! its own `static` tables. Nothing is assembled at run time.
 //!
+//! A command inside a command is not a special case: an `Args` struct carries a
+//! `subcommand` field exactly as the root does, to any depth, and generates the same
+//! code for it. mise reaches four levels, so one was never going to be enough.
+//!
 //! Keys carry a hash of the type they came from, which is how independently
 //! expanded macros avoid handing two fields the same one. `Spec::to_kdl` asserts the
 //! tree has no duplicates, so a collision fails a test rather than binding the wrong
@@ -138,8 +142,6 @@
 //! Published early on purpose, so it can be used and argued with — but these are
 //! real limits, not omissions from the docs.
 //!
-//! - **Nesting deeper than one level.** A subcommand's own subcommands need the
-//!   `Args` struct to carry a `subcommand` field too, which it does not yet.
 //! - **`overrides` and `required_unless`.** Both are about one flag's effect on
 //!   another, which needs to know the order they arrived in; nothing records that
 //!   yet.

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -89,9 +89,8 @@
 //! expanded macros avoid handing two fields the same one. A key chooses which arm to
 //! jump to and the arm then verifies the event came from its own table, so even two
 //! identical declarations in different modules cannot misbind — the event simply goes
-//! unclaimed, and `Spec::to_kdl` asserts the tree holds no duplicate keys. `Spec::to_kdl` asserts the
-//! tree has no duplicates, so a collision fails a test rather than binding the wrong
-//! field.
+//! unclaimed, and `Spec::to_kdl` asserts the tree holds no duplicate keys, so a
+//! collision fails a test rather than quietly doing the wrong thing.
 //!
 //! # What is decided after the parse
 //!

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -11,6 +11,13 @@ use syn::{Attribute, Data, DeriveInput, Expr, ExprLit, Fields, Lit, Meta, Type};
 /// A CLI, as declared by a struct.
 pub struct Cli {
     pub ident: syn::Ident,
+    /// What this type's keys are derived from.
+    ///
+    /// The whole item rather than its name: two same-named structs in different
+    /// modules would otherwise hash alike, and a macro cannot see a module path. Two
+    /// types now have to be *identical* to collide, which the duplicate-key assertion
+    /// still catches.
+    pub fingerprint: String,
     pub name: String,
     pub bin: Option<String>,
     pub version: Option<String>,
@@ -134,6 +141,7 @@ impl Cli {
         let (about, long_about) = doc_comment(&input.attrs)?;
         let mut cli = Cli {
             ident: input.ident.clone(),
+            fingerprint: quote::ToTokens::to_token_stream(input).to_string(),
             name: to_kebab(&input.ident.to_string()),
             bin: None,
             version: None,
@@ -987,9 +995,15 @@ impl Subcommands {
         // struct — so two commands sharing one would collect into whichever was
         // reached first, and choosing between them would be a coin toss. Rejected
         // rather than silently misbound.
+        //
+        // Compared as whole paths: `type_name` renders only the last segment, so
+        // `add::Op` and `remove::Op` looked identical and two perfectly good commands
+        // were refused.
         let mut types: Vec<(String, Span)> = Vec::new();
         for variant in &variants {
-            let rendered = type_name(&variant.ty);
+            let rendered = quote::ToTokens::to_token_stream(&variant.ty)
+                .to_string()
+                .replace(' ', "");
             if let Some((_, first)) = types.iter().find(|(t, _)| *t == rendered) {
                 return Err(dup(
                     variant.ty.span(),


### PR DESCRIPTION
Third of the stack. mise reaches four levels — `mise bootstrap macos launchd-agents apply` — so #816's one-level limit had to go.

## A nested command is not a special case

An `Args` struct carries a `subcommand` field exactly as the root does:

```rust
#[derive(Args)]
struct Settings {
    #[usage(long)]
    file: Option<String>,
    #[usage(subcommand)]
    command: SettingsCommands,   // and these can nest again
}
```

What made that cheap was pulling the wiring out of the root's emitter into one place both use — the tables to splice, the state to carry, how an event is routed, how the field is built. **The root now differs from a nested command only in how it is entered.**

## Two consequences worth flagging

**`build` and `select` are fallible.** A command can require a subcommand of its own, and "none was given" is only knowable where the value has to exist.

**Every generated reference to a user type now sits at one scope.** The root's post-binding checks were emitted beside the parse rather than inside the generated module — harmless until a *nested* command's check referred to the user's enum from there and `super::` escaped the crate root:

```
error[E0433]: too many leading `super` keywords
```

That was worth more than the fix: two emitters had drifted into putting the same code at different scopes, and the bug only appeared once the two met. Both now put the checks in the module and call them, so there is one answer to "where does this code live". A unit test pins `in_module`'s behaviour for plain, `crate::`, `::absolute`, `self::`, and `super::` paths, since I had reasoned about it twice and been wrong once.

## Verified

Eight tests on a three-level CLI: routing to the deepest command, each level keeping its own flags, a global reaching any depth *and* working after the deepest command, a middle command requiring one of its own, a deep command's requirements being its own rather than its parent's (`settings set jobs` → `MissingRequired { name: "value" }` while `settings ls` is fine), and the spec:

```kdl
cmd "settings" help="Manage settings" {
    flag "--file" help="Which settings file" {
        arg "<file>"
    }
    cmd "set" help="Set a value" {
        arg "<key>" help="Which setting"
        arg "<value>" help="The value"
    }
    cmd "ls" help="Show every value" {
        flag "--json" help="As JSON"
    }
}
```

## What is left before a mise-shaped CLI is expressible

`flatten`, and the `conflicts`/`requires`/`overrides` family — which need the order flags arrived in, so they want a small ordering record. Then the bench harness and the gate.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-fable-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core derive codegen and trait APIs (`CommandArgs`/`Subcommands`), including fallible `build`/`select` and selection-by-position instead of key. Well covered by new nesting conformance tests, but hand-written trait impls would break.
> 
> **Overview**
> **Enables arbitrarily nested subcommands** — an `Args` struct can carry a `subcommand` field exactly as the root does, to any depth (needed for mise's four-level trees).
> 
> Root and nested commands now share one `subcommand_parts` wiring path for tables, routing, checks, and builds. `CommandArgs::build` and `Subcommands::select` become fallible so a middle command can require its own subcommand. Selection uses table position (via pointer identity) instead of command keys, so key collisions cannot pick the wrong variant.
> 
> Also hardens key assignment: fingerprints hash the whole declaration (not just the type name), and flag/arg match arms verify table identity so same-named structs in different modules cannot misbind. Post-binding checks move into the generated module so root and nested code share one scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7822d16cd85d2e28721db4eb24896327794ef66e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for arbitrarily nested subcommands, including command-specific and global options.
  * Added support for required nested subcommands and arguments.
  * Improved routing, validation, and error reporting during nested command construction.

* **Bug Fixes**
  * Resolved naming collisions for same-named arguments in different modules, ensuring commands route correctly.

* **Documentation**
  * Updated documentation to reflect deep subcommand nesting support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->