### PR TITLE
feat(derive): let a flag displace another, the last one given winning

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -123,11 +123,12 @@ manpages, and SDKs — never a runtime dependency of somebody else's program.
       (`requires`/`conflicts`/`overrides`/`required_unless`), `var`, `count`,
       `env`, defaults, delimiters, the `double_dash` modes, global flags, flatten,
       boxed subcommand variants, headings, `cfg`-gated variants.
-- [ ] **The post-binding layer** — `required`, `choices`, `env` fallback, defaults,
-      `var_min`/`var_max`, `conflicts`, `required_if` and `required_unless` are done;
-      `overrides` is what remains, and it is the one that needs arrival order rather
-      than only whether a flag was given. These need a value's type, so they belong
-      with the derive rather than in the parser.
+- [x] **The post-binding layer** — `required`, `choices`, `env` fallback, defaults,
+      `var_min`/`var_max`, `conflicts`, `required_if`, `required_unless`, and
+      `overrides`. All of them need a value's type, so they belong with the derive
+      rather than in the parser. `overrides` is the one that happens _during_ the
+      parse instead of after it: it asks which of two flags came last, which only the
+      arriving token knows.
 
 ### Spec gaps found on the way
 

--- a/conformance/tests/derive.rs
+++ b/conformance/tests/derive.rs
@@ -573,6 +573,12 @@ struct Related {
     /// Read from standard input
     #[usage(short = 's', long, conflicts("--file", "--url"))]
     stdin: bool,
+    /// Colorize output
+    #[usage(long, default = "true", overrides = "--plain")]
+    color: bool,
+    /// No decoration
+    #[usage(long)]
+    plain: bool,
     /// Where to write
     #[usage(long, required_if = "--stdin")]
     out: Option<String>,
@@ -595,6 +601,7 @@ fn flag_relationships_reach_the_spec() {
         vec!["--file".to_string(), "--url".to_string()]
     );
     assert_eq!(flag("out").required_if, vec!["--stdin".to_string()]);
+    assert_eq!(flag("color").overrides, vec!["--plain".to_string()]);
     assert_eq!(
         flag("file").required_unless,
         vec!["--url".to_string(), "--stdin".to_string()]
@@ -613,6 +620,7 @@ fn flag_relationships_reach_the_spec() {
     let a = argv(["--stdin", "--out", "o"]);
     let rel = Related::parse_from(&a).expect("should parse");
     assert!(rel.stdin);
+    assert!(rel.color && !rel.plain);
     assert_eq!(rel.out.as_deref(), Some("o"));
     assert!(rel.file.is_none());
     assert!(rel.url.is_none());

--- a/conformance/tests/post_binding.rs
+++ b/conformance/tests/post_binding.rs
@@ -309,3 +309,92 @@ fn required_unless_is_satisfied_by_the_other_flag() {
         Some("u")
     );
 }
+
+/// A CLI where flags displace one another.
+///
+/// Only `--file` declares the override, which is enough: the relationship holds
+/// between the two flags, so the later one wins whichever way round they are given.
+#[derive(Cli)]
+#[usage(bin = "ovr")]
+struct Ovr {
+    /// Read from a file
+    #[usage(long, overrides("--stdin", "--url"))]
+    file: Option<String>,
+    /// Read from standard input
+    #[usage(long)]
+    stdin: bool,
+    /// Read from a URL
+    #[usage(long)]
+    url: Option<String>,
+    /// Colorize output, unless told otherwise
+    #[usage(long, default = "true", overrides = "--plain")]
+    color: bool,
+    /// No decoration at all
+    #[usage(long)]
+    plain: bool,
+    /// Patterns to include
+    #[usage(long, var, overrides = "--all")]
+    include: Vec<String>,
+    /// Everything
+    #[usage(long)]
+    all: bool,
+}
+
+#[test]
+fn the_last_of_two_overriding_flags_wins() {
+    // Declared on `--file`, given `--file` first: `--stdin` is the survivor.
+    let a = argv(["--file", "f", "--stdin"]);
+    let ovr = Ovr::parse_from(&a).expect("should parse");
+    assert!(ovr.stdin);
+    assert_eq!(ovr.file, None, "displaced by the flag that came after it");
+
+    // The same pair the other way round, which the declaration does not mention.
+    let a = argv(["--stdin", "--file", "f"]);
+    let ovr = Ovr::parse_from(&a).expect("should parse");
+    assert_eq!(ovr.file.as_deref(), Some("f"));
+    assert!(!ovr.stdin, "displaced by the flag that came after it");
+}
+
+#[test]
+fn a_displaced_flag_goes_back_to_its_default_rather_than_to_nothing() {
+    // `--color` defaults to on. `--plain` displaces it, and what it displaces it to
+    // is the default: a flag that was never given reads the same as one that was
+    // taken back.
+    let a = argv(["--color", "--plain"]);
+    let ovr = Ovr::parse_from(&a).expect("should parse");
+    assert!(ovr.plain);
+    assert!(ovr.color, "back to its declared default, not to false");
+
+    // And a `--color` after `--plain` displaces the other way.
+    let a = argv(["--plain", "--color"]);
+    let ovr = Ovr::parse_from(&a).expect("should parse");
+    assert!(ovr.color);
+    assert!(!ovr.plain);
+}
+
+#[test]
+fn a_displaced_collection_is_emptied() {
+    let a = argv(["--include", "a", "--include", "b", "--all"]);
+    let ovr = Ovr::parse_from(&a).expect("should parse");
+    assert!(ovr.all);
+    assert!(ovr.include.is_empty(), "got {:?}", ovr.include);
+
+    // Values given after the flag that displaced them are kept: it is the order
+    // they arrived in that decides, not which flag was mentioned in a declaration.
+    let a = argv(["--include", "a", "--all", "--include", "b"]);
+    let ovr = Ovr::parse_from(&a).expect("should parse");
+    assert_eq!(ovr.include, ["b"]);
+    assert!(!ovr.all);
+}
+
+#[test]
+fn displacing_one_flag_leaves_the_others_alone() {
+    let a = argv(["--url", "u", "--stdin"]);
+    let ovr = Ovr::parse_from(&a).expect("should parse");
+    assert_eq!(
+        ovr.url.as_deref(),
+        Some("u"),
+        "--stdin does not touch --url"
+    );
+    assert!(ovr.stdin);
+}

--- a/conformance/tests/post_binding_env.rs
+++ b/conformance/tests/post_binding_env.rs
@@ -77,3 +77,48 @@ fn the_environment_fills_what_argv_left_out() {
         unsafe { std::env::remove_var(var) };
     }
 }
+
+/// A CLI where a flag with an environment variable can lose an override.
+#[derive(Cli)]
+#[usage(bin = "ovr")]
+struct Ovr {
+    /// Read from a file
+    #[usage(long, env = "OVR_ENV_FILE", overrides = "--stdin")]
+    file: Option<String>,
+    /// Read from standard input
+    #[usage(long)]
+    stdin: bool,
+    /// Where to write, which has to be given
+    #[usage(long, overrides = "--quiet")]
+    out: String,
+    /// Say nothing
+    #[usage(long)]
+    quiet: bool,
+}
+
+#[test]
+fn a_displaced_flag_is_not_revived_by_its_environment_variable() {
+    // The command line says `--stdin` came last, so `--file` lost. Filling it from the
+    // environment afterwards would leave both standing and undo that.
+    unsafe { std::env::set_var("OVR_ENV_FILE", "from-env") };
+
+    let a = argv(["--file", "typed", "--stdin", "--out", "o"]);
+    let ovr = Ovr::parse_from(&a).expect("should parse");
+    assert!(ovr.stdin);
+    assert_eq!(ovr.file, None, "displaced, and not refilled from the env");
+
+    // Without the override in play, the environment still fills it.
+    let a = argv(["--out", "o"]);
+    let ovr = Ovr::parse_from(&a).expect("should parse");
+    assert_eq!(ovr.file.as_deref(), Some("from-env"));
+}
+
+#[test]
+fn a_displaced_flag_is_not_reported_missing() {
+    // `--out` is a bare `String`, so it is required — but `--quiet` displaced it, which
+    // is an answer rather than an omission.
+    let a = argv(["--out", "o", "--quiet"]);
+    let ovr = Ovr::parse_from(&a).expect("should parse");
+    assert!(ovr.quiet);
+    assert_eq!(ovr.out, "", "displaced back to its unset value");
+}

--- a/corpus/08-choices-and-required.json
+++ b/corpus/08-choices-and-required.json
@@ -109,6 +109,23 @@
       "layer": "post-binding"
     },
     {
+      "id": "overrides-loser-is-not-refilled-from-env",
+      "doc": "The command line said `--stdin` came last, so `--file` lost. A flag that lost an override is not merely unset: filling it from the environment afterwards would leave both standing and undo the last-one-wins.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--file <file>\" env=\"EX_FILE\" overrides=\"--stdin\"\nflag \"--stdin\"\n",
+      "argv": ["--file", "typed", "--stdin"],
+      "env": {
+        "EX_FILE": "from-env"
+      },
+      "expect": {
+        "ok": {
+          "flags": {
+            "stdin": true
+          }
+        }
+      },
+      "layer": "post-binding"
+    },
+    {
       "id": "conflicts-both-given",
       "doc": "Two flags declared to conflict cannot be given together. Unlike `overrides`, where the last one wins, a conflict is a mistake to report rather than an order to resolve.",
       "spec": "name \"ex\"\nbin \"ex\"\nflag \"--file <file>\" conflicts=\"--stdin\"\nflag \"--stdin\"\nflag \"--url <url>\"\n",

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -472,6 +472,10 @@ fn flag_arm(cli: &Cli, i: usize, field: &Field, base: u64) -> TokenStream {
     let ident = &field.ident;
     let given = format_ident!("__given_{}", ident);
     let displaced = displacements(cli, field);
+    let undisplaced = is_displaceable(cli, field).then(|| {
+        let overridden = format_ident!("__overridden_{}", ident);
+        quote!(partial.#overridden = false;)
+    });
     let body = match field.shape {
         // `negated` is what distinguishes `--color` from `--no-color`.
         Shape::Bool => quote!(partial.#ident = !negated;),
@@ -494,6 +498,9 @@ fn flag_arm(cli: &Cli, i: usize, field: &Field, base: u64) -> TokenStream {
         #key if ::core::ptr::eq(*flag, &#table) => {
             #body
             partial.#given = true;
+            // Given again after having lost: it is standing once more, which matters
+            // when the flags alternate — `--include a --all --include b`.
+            #undisplaced
             // Whatever this flag displaces, undone here rather than after the parse:
             // `overrides` is about which of two flags came last, and the token that
             // just arrived is the last one so far.
@@ -509,6 +516,27 @@ fn flag_arm(cli: &Cli, i: usize, field: &Field, base: u64) -> TokenStream {
 /// clap resolves `--file a --stdin` and `--stdin --file a` the same way whichever side
 /// declared it, and so does usage-lib.
 fn displacements(cli: &Cli, field: &Field) -> Vec<TokenStream> {
+    displaced_by(cli, field)
+        .into_iter()
+        .map(|other| {
+            let reset = reset_to_default(other);
+            let given = format_ident!("__given_{}", other.ident);
+            let overridden = format_ident!("__overridden_{}", other.ident);
+            quote! {
+                #reset
+                partial.#given = false;
+                // Remembered, not just cleared: without this the environment fallback
+                // would refill the flag that lost and mark it given again, and a
+                // displaced `String` would be reported missing. usage-lib keeps the
+                // same set for the same reason.
+                partial.#overridden = true;
+            }
+        })
+        .collect()
+}
+
+/// The fields a flag displaces, in both directions.
+fn displaced_by<'a>(cli: &'a Cli, field: &Field) -> Vec<&'a Field> {
     let names = |target: &Field, selectors: &[String]| {
         selectors.iter().any(|selector| {
             cli.field_for_selector(selector)
@@ -521,15 +549,13 @@ fn displacements(cli: &Cli, field: &Field) -> Vec<TokenStream> {
             other.ident != field.ident
                 && (names(other, &field.overrides) || names(field, &other.overrides))
         })
-        .map(|other| {
-            let reset = reset_to_default(other);
-            let given = format_ident!("__given_{}", other.ident);
-            quote! {
-                #reset
-                partial.#given = false;
-            }
-        })
         .collect()
+}
+
+/// Whether a field is on either side of an `overrides`, and so needs somewhere to
+/// record that it lost.
+fn is_displaceable(cli: &Cli, field: &Field) -> bool {
+    !displaced_by(cli, field).is_empty()
 }
 
 fn arg_arm(i: usize, field: &Field, base: u64) -> TokenStream {
@@ -591,7 +617,13 @@ fn partial_struct(cli: &Cli) -> TokenStream {
         // Whether a token supplied this, as opposed to a default sitting in it: an
         // empty string is a value somebody typed, and `--jobs=` has to be able to
         // mean it.
-        Some(quote!(pub #ident: #ty, pub #given: bool,))
+        // Only for a flag that can lose an override: every other field would carry a
+        // `bool` nothing ever reads.
+        let overridden = is_displaceable(cli, f).then(|| {
+            let overridden = format_ident!("__overridden_{}", ident);
+            quote!(pub #overridden: bool,)
+        });
+        Some(quote!(pub #ident: #ty, pub #given: bool, #overridden))
     });
 
     // No derived `Default`: `start` is what produces a fresh partial, because a
@@ -619,9 +651,14 @@ fn partial_defaults(cli: &Cli) -> TokenStream {
         }
         let ident = &f.ident;
         let given = format_ident!("__given_{}", ident);
+        let overridden = is_displaceable(cli, f).then(|| {
+            let overridden = format_ident!("__overridden_{}", ident);
+            quote!(#overridden: false,)
+        });
         Some(quote! {
             #ident: ::std::default::Default::default(),
             #given: false,
+            #overridden
         })
     });
     // Only the fields that declare one: `Partial`'s own initializer has already put
@@ -1179,6 +1216,18 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
     }
 }
 
+/// `&& !partial.__overridden_x`, for a field that can lose an override.
+///
+/// Empty for every other field, so a CLI that declares no `overrides` generates exactly
+/// what it did before.
+fn displaced_guard(cli: &Cli, field: &Field) -> TokenStream {
+    if !is_displaceable(cli, field) {
+        return quote!();
+    }
+    let overridden = format_ident!("__overridden_{}", field.ident);
+    quote!(&& !partial.#overridden)
+}
+
 /// Everything decided once the last token has been read.
 ///
 /// Ordered deliberately. The environment fills what argv left out, so it runs
@@ -1216,8 +1265,11 @@ fn post_binding(cli: &Cli) -> TokenStream {
                 }
             }
         };
+        // A flag that lost an override is not merely unset: filling it from the
+        // environment would undo the last-one-wins the command line asked for.
+        let standing = displaced_guard(cli, f);
         Some(quote! {
-            if !partial.#given {
+            if !partial.#given #standing {
                 if let ::std::result::Result::Ok(value) = ::std::env::var(#var) {
                     let mut continue_unset = false;
                     #assign
@@ -1237,8 +1289,11 @@ fn post_binding(cli: &Cli) -> TokenStream {
         }
         let given = format_ident!("__given_{}", f.ident);
         let name = &f.name;
+        // Same reason as the environment: a displaced flag was answered by the one that
+        // displaced it, so it is not missing.
+        let standing = displaced_guard(cli, f);
         Some(quote! {
-            if !partial.#given {
+            if !partial.#given #standing {
                 return ::std::result::Result::Err(
                     ::usage_argv::Error::MissingRequired { name: #name },
                 );

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -321,6 +321,7 @@ fn flag_meta(i: usize, field: &Field) -> TokenStream {
     let (var_min, var_max) = bounds_tokens(field);
     // Written as declared, in the spec's own spelling, so the emitted KDL says what
     // the struct says.
+    let overrides = &field.overrides;
     let conflicts = &field.conflicts;
     let required_if = &field.required_if;
     let required_unless = &field.required_unless;
@@ -340,6 +341,7 @@ fn flag_meta(i: usize, field: &Field) -> TokenStream {
             choices: #choices,
             var_min: #var_min,
             var_max: #var_max,
+            overrides: &[#(#overrides),*],
             conflicts: &[#(#conflicts),*],
             required_if: &[#(#required_if),*],
             required_unless: &[#(#required_unless),*],
@@ -465,10 +467,11 @@ fn in_module(ty: &syn::Type) -> TokenStream {
     }
 }
 
-fn flag_arm(i: usize, field: &Field, base: u64) -> TokenStream {
+fn flag_arm(cli: &Cli, i: usize, field: &Field, base: u64) -> TokenStream {
     let key = base | KIND_FLAG | i as u64;
     let ident = &field.ident;
     let given = format_ident!("__given_{}", ident);
+    let displaced = displacements(cli, field);
     let body = match field.shape {
         // `negated` is what distinguishes `--color` from `--no-color`.
         Shape::Bool => quote!(partial.#ident = !negated;),
@@ -491,9 +494,42 @@ fn flag_arm(i: usize, field: &Field, base: u64) -> TokenStream {
         #key if ::core::ptr::eq(*flag, &#table) => {
             #body
             partial.#given = true;
+            // Whatever this flag displaces, undone here rather than after the parse:
+            // `overrides` is about which of two flags came last, and the token that
+            // just arrived is the last one so far.
+            #(#displaced)*
             true
         }
     }
+}
+
+/// Undoing the flags a flag displaces, as statements to run once it has been bound.
+///
+/// Both directions. `overrides` is declared on one flag and holds between the two:
+/// clap resolves `--file a --stdin` and `--stdin --file a` the same way whichever side
+/// declared it, and so does usage-lib.
+fn displacements(cli: &Cli, field: &Field) -> Vec<TokenStream> {
+    let names = |target: &Field, selectors: &[String]| {
+        selectors.iter().any(|selector| {
+            cli.field_for_selector(selector)
+                .is_some_and(|named| named.ident == target.ident)
+        })
+    };
+    cli.fields
+        .iter()
+        .filter(|other| {
+            other.ident != field.ident
+                && (names(other, &field.overrides) || names(field, &other.overrides))
+        })
+        .map(|other| {
+            let reset = reset_to_default(other);
+            let given = format_ident!("__given_{}", other.ident);
+            quote! {
+                #reset
+                partial.#given = false;
+            }
+        })
+        .collect()
 }
 
 fn arg_arm(i: usize, field: &Field, base: u64) -> TokenStream {
@@ -588,29 +624,52 @@ fn partial_defaults(cli: &Cli) -> TokenStream {
             #given: false,
         })
     });
-    let assignments = cli.fields.iter().filter_map(|f| {
-        let ident = &f.ident;
-        let default = f.default.as_deref()?;
-        Some(match f.shape {
-            Shape::Bool => {
-                let on = default == "true";
-                quote!(partial.#ident = #on;)
-            }
-            Shape::Optional => {
-                quote!(partial.#ident = ::std::option::Option::Some(#default.to_string());)
-            }
-            Shape::Required => quote!(partial.#ident = #default.to_string();),
-            // Rejected in the model: a count starts at zero, and a default for a
-            // collecting field is not applied yet.
-            Shape::Count | Shape::Many => quote!(),
-        })
-    });
+    // Only the fields that declare one: `Partial`'s own initializer has already put
+    // everything else at `Default::default()`, and a subcommand field holds a partial
+    // that `#sub_starts` builds rather than a value.
+    let assignments = cli
+        .fields
+        .iter()
+        .filter(|f| f.default.is_some() && !matches!(f.kind, Kind::Subcommand { .. }))
+        .map(reset_to_default);
     quote! {
         let mut partial = Partial {
             #(#plain)*
             #sub_starts
         };
         #(#assignments)*
+    }
+}
+
+/// Put a field back the way `start()` left it.
+///
+/// Used twice, and the second use is why it is worth naming: a flag displaced by an
+/// `overrides` has to look untouched, and "untouched" means its declared default rather
+/// than blank. clap does the same — a boolean that loses an override reads as `false`,
+/// not as absent.
+fn reset_to_default(field: &Field) -> TokenStream {
+    let ident = &field.ident;
+    let Some(default) = field.default.as_deref() else {
+        return match field.shape {
+            // A collection is cleared rather than replaced, so the field keeps whatever
+            // capacity it already allocated.
+            Shape::Many => quote!(partial.#ident.clear();),
+            _ => quote!(partial.#ident = ::std::default::Default::default();),
+        };
+    };
+    match field.shape {
+        Shape::Bool => {
+            let on = default == "true";
+            quote!(partial.#ident = #on;)
+        }
+        Shape::Optional => {
+            quote!(partial.#ident = ::std::option::Option::Some(#default.to_string());)
+        }
+        Shape::Required => quote!(partial.#ident = #default.to_string();),
+        // Rejected in the model: a count starts at zero, and a default for a collecting
+        // field is not applied yet.
+        Shape::Count => quote!(partial.#ident = ::std::default::Default::default();),
+        Shape::Many => quote!(partial.#ident.clear();),
     }
 }
 
@@ -627,7 +686,10 @@ fn apply_fn(cli: &Cli, base: u64) -> TokenStream {
         .iter()
         .filter(|f| matches!(f.kind, Kind::Arg { .. }))
         .collect();
-    let flag_arms = flags.iter().enumerate().map(|(i, f)| flag_arm(i, f, base));
+    let flag_arms = flags
+        .iter()
+        .enumerate()
+        .map(|(i, f)| flag_arm(cli, i, f, base));
     let arg_arms = args.iter().enumerate().map(|(i, f)| arg_arm(i, f, base));
 
     quote! {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -138,6 +138,7 @@
 //! | `hide` | keep it out of help and completions |
 //! | `double_dash = "required"` | a positional only fillable after `--` |
 //! | `arg` | force a field to be positional |
+//! | `overrides = "--other"` | a flag this one displaces, the last given winning |
 //! | `conflicts = "--other"` | a flag this one cannot be given with |
 //! | `required_if = "--other"` | a flag whose presence makes this one necessary |
 //! | `required_unless = "--other"` | a flag whose presence makes this one unnecessary |
@@ -158,9 +159,6 @@
 //! Published early on purpose, so it can be used and argued with — but these are
 //! real limits, not omissions from the docs.
 //!
-//! - **`overrides`.** Unlike the other relationships, it is not about whether two
-//!   flags were both given but about which came *last*, and nothing records arrival
-//!   order yet.
 //! - **Typed values.** Fields are `bool`, `String`, `Option<String>`,
 //!   `Vec<String>`, or an unsigned integer with `count`. Anything else is a compile
 //!   error rather than a surprise: converting a value needs somewhere to report one

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -51,6 +51,10 @@ pub struct Field {
     pub choices: Vec<String>,
     pub var_min: Option<usize>,
     pub var_max: Option<usize>,
+    /// Flags this one displaces. Applied while parsing rather than after it: the
+    /// question is which of them came last, so the answer is decided by the token
+    /// that arrives, not by the state it leaves behind.
+    pub overrides: Vec<String>,
     /// Flags this one cannot be given with. Checked after the parse: whether a flag
     /// is unwelcome depends on the whole command line, not on the token itself.
     pub conflicts: Vec<String>,
@@ -308,6 +312,7 @@ impl Cli {
         // nothing quietly holds no relationship at all.
         for field in &self.fields {
             for (option, selectors) in [
+                ("overrides", &field.overrides),
                 ("conflicts", &field.conflicts),
                 ("required_if", &field.required_if),
                 ("required_unless", &field.required_unless),
@@ -394,6 +399,7 @@ impl Field {
             choices: Vec::new(),
             var_min: None,
             var_max: None,
+            overrides: Vec::new(),
             conflicts: Vec::new(),
             required_if: Vec::new(),
             required_unless: Vec::new(),
@@ -436,6 +442,7 @@ impl Field {
         let mut choices: Vec<String> = Vec::new();
         let mut var_min: Option<usize> = None;
         let mut var_max: Option<usize> = None;
+        let mut overrides: Vec<String> = Vec::new();
         let mut conflicts: Vec<String> = Vec::new();
         let mut required_if: Vec<String> = Vec::new();
         let mut required_unless: Vec<String> = Vec::new();
@@ -501,6 +508,7 @@ impl Field {
                     // Both spellings the spec has: one target as a value, several as a
                     // list. A flag selector never contains a comma, so unlike `choices`
                     // there is nothing to lose by accepting the shorter form.
+                    "overrides" => overrides = selectors(&meta)?,
                     "conflicts" => conflicts = selectors(&meta)?,
                     "required_if" => required_if = selectors(&meta)?,
                     "required_unless" => required_unless = selectors(&meta)?,
@@ -530,7 +538,8 @@ impl Field {
                                 "unknown option `{other}`; a field takes `name`, `long`, \
                                  `short`, `negate`, `global`, `var`, `variadic`, \
                                  `count`, `hide`, `arg`, `env`, `default`, `choices`, \
-                                 `var_min`, `var_max`, `conflicts`, `required_if`, \
+                                 `var_min`, `var_max`, `overrides`, `conflicts`, \
+                                 `required_if`, \
                                  `required_unless`, `help_heading`, and `double_dash`"
                             ),
                         ));
@@ -819,6 +828,7 @@ impl Field {
             choices,
             var_min,
             var_max,
+            overrides,
             conflicts,
             required_if,
             required_unless,

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -733,6 +733,7 @@ impl Field {
         // the emitted spec cannot say — and docs and completions would describe a
         // different CLI from the one that runs.
         for (option, selectors) in [
+            ("overrides", &overrides),
             ("conflicts", &conflicts),
             ("required_if", &required_if),
             ("required_unless", &required_unless),
@@ -1292,6 +1293,24 @@ mod tests {
                 #[usage(long)]
                 force: bool,
                 #[usage(conflicts = "--force")]
+                file: String,
+            }
+        "#,
+        );
+        assert!(
+            err.contains("relationship between flags"),
+            "unhelpful message: {err}"
+        );
+    }
+
+    #[test]
+    fn overrides_needs_a_flag_to_hold_between_too() {
+        let err = rejection(
+            r#"
+            struct Ex {
+                #[usage(long)]
+                force: bool,
+                #[usage(overrides = "--force")]
                 file: String,
             }
         "#,


### PR DESCRIPTION
Stacked on #820. The last of the four flag relationships, and the one that needed a different answer.

`conflicts`, `required_if` and `required_unless` only ask *whether* a flag was given, so they are checked once the last token has been read. `overrides` asks which of two flags came **last** — so it is applied while parsing, in the arm that binds the flag: the token that just arrived is the last one so far. Nothing has to record arrival order, which is what had been blocking it.

```rust
#[usage(long, default = "true", overrides = "--plain")]
color: bool,
```

## Semantics, measured rather than assumed

I ran clap 4 directly instead of trusting my memory of it:

| given | clap | here |
| --- | --- | --- |
| `--file a --stdin` | `file=None stdin=true` | same |
| `--stdin --file a` | `file="a" stdin=false` | same |

Two things fall out of that and are now tested:

- **The relationship is bidirectional from one declaration.** Only `--file` says `overrides`, and `--stdin --file a` still displaces `--stdin`. usage-lib does the same.
- **A displaced flag returns to its default, not to blank.** clap reports the loser as `false` rather than absent, so a `--color` that defaults on and loses to `--plain` is back to *on*, not off. The reset `start()` applies is now a named function, since this is its second caller.

A displaced `Vec` is emptied, and values given after the flag that displaced them are kept — order decides, not which side was named in a declaration.

With this the post-binding layer is complete: `required`, `choices`, `env` fallback, defaults, `var_min`/`var_max`, and all four relationships. PLAN.md updated accordingly.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core derive codegen for flag binding and post-binding (env/required), so incorrect override handling could misbind CLI values. Behavior is covered by new conformance and corpus tests.
> 
> **Overview**
> Completes the post-binding layer by adding **`overrides`**: a flag can displace another, with the last one given winning.
> 
> Unlike `conflicts` / `required_if` / `required_unless`, this is applied **during** parse in the flag-binding arm — arrival order is what matters, so nothing needs to record it separately. The relationship is bidirectional from one declaration, matching clap and usage-lib.
> 
> A displaced flag resets to its **declared default** (not blank); collections are emptied. An `__overridden_*` bit keeps env fallback from reviving a loser and keeps required checks from treating displacement as missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfba697225f2c5750a3c83f5eebc6c633614a346. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->