### PR TITLE
fix(derive): let a `--`-only argument follow a variadic

### DIFF
--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -333,6 +333,30 @@ pub enum Error<'t, 'v> {
     MissingSubcommand,
 }
 
+/// The high half of every key one declaration's items get.
+///
+/// A derive cannot see other expansions, so it cannot hand out keys from a shared
+/// counter: it hashes the declaration it was given instead. It cannot see a module path
+/// either, which is why the module is mixed in *here* — `module_path!()` is available to
+/// the generated code as a compile-time string, so two byte-identical declarations in
+/// different modules end up with different keys rather than colliding.
+///
+/// `declaration` is a hash the derive computed over the item's own tokens.
+pub const fn key_base(module: &str, declaration: u32) -> u64 {
+    // FNV-1a, continuing from the declaration's hash rather than starting over, so both
+    // halves contribute. Spelled out rather than taken from a `Hasher`, which is not
+    // guaranteed to be stable between compilations — and these are baked into a binary.
+    let mut hash: u32 = declaration;
+    let bytes = module.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        hash ^= bytes[i] as u32;
+        hash = hash.wrapping_mul(0x0100_0193);
+        i += 1;
+    }
+    (hash as u64) << 32
+}
+
 /// Interpret a value as UTF-8.
 ///
 /// The parser hands back bytes borrowed from `argv`; this is the conversion most

--- a/conformance/tests/derive.rs
+++ b/conformance/tests/derive.rs
@@ -625,3 +625,47 @@ fn flag_relationships_reach_the_spec() {
     assert!(rel.file.is_none());
     assert!(rel.url.is_none());
 }
+
+/// A command whose trailing words are only reachable after a `--`.
+///
+/// mise declares this on `run`, `exec` and `git`: `[ARGS]…` takes the words before the
+/// separator, `[-- ARGS_LAST]…` the ones after. It reads like an argument after a
+/// variadic, which usually cannot be filled — but the `--` is what stops the variadic,
+/// so this one can.
+#[derive(Cli, Debug)]
+#[usage(bin = "sep")]
+struct Separated {
+    /// Words before the separator
+    #[usage(arg, name = "ARGS")]
+    args: Vec<String>,
+    /// Words after it
+    #[usage(arg, name = "ARGS_LAST", double_dash = "required")]
+    args_last: Vec<String>,
+}
+
+#[test]
+fn a_double_dash_argument_can_follow_a_variadic() {
+    let a = argv(["a", "b", "--", "c", "d"]);
+    let sep = Separated::parse_from(&a).expect("should parse");
+    assert_eq!(sep.args, ["a", "b"]);
+    assert_eq!(sep.args_last, ["c", "d"]);
+
+    // Without the separator the first variadic keeps everything.
+    let a = argv(["a", "b", "c"]);
+    let sep = Separated::parse_from(&a).expect("should parse");
+    assert_eq!(sep.args, ["a", "b", "c"]);
+    assert!(sep.args_last.is_empty());
+
+    // And the spec says which is which, so docs and completions agree with the parse.
+    // usage-lib writes the mode as a property rather than in the placeholder; either
+    // spelling reads back the same, and this is the one the writer chose.
+    let kdl = Separated::to_kdl();
+    assert!(
+        kdl.contains(r#"arg "[ARGS_LAST]..." help="Words after it" double_dash="required""#),
+        "{kdl}"
+    );
+    let spec: LibSpec = kdl.parse().expect("valid spec");
+    let last = spec.cmd.args.last().expect("two args");
+    assert_eq!(last.double_dash, usage::SpecDoubleDashChoices::Required);
+    assert!(last.var);
+}

--- a/conformance/tests/identity.rs
+++ b/conformance/tests/identity.rs
@@ -14,7 +14,7 @@ use usage_derive::{Cli, Subcommands};
 mod add {
     use usage_derive::Args;
 
-    /// Add a thing
+    /// Operate on a thing
     #[derive(Args)]
     pub struct Op {
         /// Do it anyway
@@ -26,10 +26,12 @@ mod add {
 mod remove {
     use usage_derive::Args;
 
-    /// Remove a thing
-    ///
-    /// Declared byte-for-byte like `add::Op` above, doc comment included, which is what
-    /// makes the two hash alike.
+    // Byte-for-byte identical to `add::Op`, doc comment included — which is the whole
+    // point, and easy to get wrong: an earlier version of this test gave the two
+    // different doc comments, so their hashes differed and it passed with or without
+    // the fix. The declarations have to be indistinguishable for the module to be the
+    // only thing telling them apart.
+    /// Operate on a thing
     #[derive(Args)]
     pub struct Op {
         /// Do it anyway

--- a/conformance/tests/identity.rs
+++ b/conformance/tests/identity.rs
@@ -1,0 +1,87 @@
+//! Two commands that are declared identically in different modules.
+//!
+//! A derive cannot see a module path, so it hashes the declaration it was handed — and
+//! two byte-identical declarations hash alike. That used to be waved off as harmless,
+//! on the grounds that a key only chooses which `match` arm to jump to and each arm
+//! checks the event came from its own table. It was not harmless: `Spec::to_kdl`
+//! asserts no two things in a CLI share a key, so a perfectly good CLI failed the
+//! assertion. The module is now folded into the key where `module_path!()` can be read.
+
+use std::ffi::OsStr;
+
+use usage_derive::{Cli, Subcommands};
+
+mod add {
+    use usage_derive::Args;
+
+    /// Add a thing
+    #[derive(Args)]
+    pub struct Op {
+        /// Do it anyway
+        #[usage(long)]
+        pub force: bool,
+    }
+}
+
+mod remove {
+    use usage_derive::Args;
+
+    /// Remove a thing
+    ///
+    /// Declared byte-for-byte like `add::Op` above, doc comment included, which is what
+    /// makes the two hash alike.
+    #[derive(Args)]
+    pub struct Op {
+        /// Do it anyway
+        #[usage(long)]
+        pub force: bool,
+    }
+}
+
+#[derive(Subcommands)]
+enum Commands {
+    Add(add::Op),
+    Remove(remove::Op),
+}
+
+/// A tool with two identical commands
+#[derive(Cli)]
+#[usage(bin = "ex")]
+struct Ex {
+    #[usage(subcommand)]
+    command: Option<Commands>,
+}
+
+fn argv<const N: usize>(tokens: [&str; N]) -> [&OsStr; N] {
+    tokens.map(OsStr::new)
+}
+
+#[test]
+fn the_spec_holds_no_duplicate_keys() {
+    // `to_kdl` asserts it, in the debug build tests run in.
+    let kdl = Ex::to_kdl();
+    assert!(kdl.contains(r#"cmd "add""#), "{kdl}");
+    assert!(kdl.contains(r#"cmd "remove""#), "{kdl}");
+}
+
+#[test]
+fn each_command_still_binds_its_own_flag() {
+    let a = argv(["add", "--force"]);
+    let Some(Commands::Add(op)) = Ex::parse_from(&a).expect("should parse").command else {
+        panic!("expected `add`")
+    };
+    assert!(op.force);
+
+    let a = argv(["remove", "--force"]);
+    let Some(Commands::Remove(op)) = Ex::parse_from(&a).expect("should parse").command else {
+        panic!("expected `remove`")
+    };
+    assert!(op.force);
+
+    // And the flag is not silently unclaimed when it is absent.
+    let a = argv(["remove"]);
+    let Some(Commands::Remove(op)) = Ex::parse_from(&a).expect("should parse").command else {
+        panic!("expected `remove`")
+    };
+    assert!(!op.force);
+}

--- a/corpus/06-double-dash.json
+++ b/corpus/06-double-dash.json
@@ -7,7 +7,13 @@
       "doc": "After `--`, a flag-looking word binds as a value.",
       "spec": "name \"ex\"\nbin \"ex\"\nflag \"-f --force\"\narg \"<file>\"\n",
       "argv": ["--", "--force"],
-      "expect": { "ok": { "args": { "file": "--force" } } }
+      "expect": {
+        "ok": {
+          "args": {
+            "file": "--force"
+          }
+        }
+      }
     },
     {
       "id": "dd-flags-before-still-parse",
@@ -15,7 +21,14 @@
       "spec": "name \"ex\"\nbin \"ex\"\nflag \"-f --force\"\narg \"<file>\"\n",
       "argv": ["--force", "--", "-x"],
       "expect": {
-        "ok": { "flags": { "force": true }, "args": { "file": "-x" } }
+        "ok": {
+          "flags": {
+            "force": true
+          },
+          "args": {
+            "file": "-x"
+          }
+        }
       }
     },
     {
@@ -23,14 +36,26 @@
       "doc": "The separator itself is consumed rather than bound to an argument.",
       "spec": "name \"ex\"\nbin \"ex\"\narg \"<a>\"\narg \"[b]\"\n",
       "argv": ["--", "one"],
-      "expect": { "ok": { "args": { "a": "one" } } }
+      "expect": {
+        "ok": {
+          "args": {
+            "a": "one"
+          }
+        }
+      }
     },
     {
       "id": "dd-second-is-a-value",
       "doc": "Only the first `--` separates; a later one is an ordinary value, since flag interpretation has already stopped.",
       "spec": "name \"ex\"\nbin \"ex\"\narg \"<rest>...\"\n",
       "argv": ["--", "a", "--", "b"],
-      "expect": { "ok": { "args": { "rest": ["a", "--", "b"] } } }
+      "expect": {
+        "ok": {
+          "args": {
+            "rest": ["a", "--", "b"]
+          }
+        }
+      }
     },
     {
       "id": "dd-variadic-collects-everything-after",
@@ -38,7 +63,11 @@
       "spec": "name \"ex\"\nbin \"ex\"\nflag \"-f --force\"\narg \"<cmd>...\"\n",
       "argv": ["--", "npm", "run", "test", "--force"],
       "expect": {
-        "ok": { "args": { "cmd": ["npm", "run", "test", "--force"] } }
+        "ok": {
+          "args": {
+            "cmd": ["npm", "run", "test", "--force"]
+          }
+        }
       }
     },
     {
@@ -46,35 +75,61 @@
       "doc": "An argument declared `double_dash=\"required\"` accepts a value once the separator has been given.",
       "spec": "name \"ex\"\nbin \"ex\"\narg \"<-- cmd>\"\n",
       "argv": ["--", "ls"],
-      "expect": { "ok": { "args": { "cmd": "ls" } } }
+      "expect": {
+        "ok": {
+          "args": {
+            "cmd": "ls"
+          }
+        }
+      }
     },
     {
       "id": "dd-required-rejected-without-separator",
       "doc": "The same argument rejects a value given before the separator.",
       "spec": "name \"ex\"\nbin \"ex\"\narg \"<-- cmd>\"\n",
       "argv": ["ls"],
-      "expect": { "error": "arg_requires_double_dash" }
+      "expect": {
+        "error": "arg_requires_double_dash"
+      }
     },
     {
       "id": "dd-optional-accepts-either-side",
       "doc": "The default, `double_dash=\"optional\"`, accepts a value on either side of the separator.",
       "spec": "name \"ex\"\nbin \"ex\"\narg \"<file>\"\n",
       "argv": ["a.txt"],
-      "expect": { "ok": { "args": { "file": "a.txt" } } }
+      "expect": {
+        "ok": {
+          "args": {
+            "file": "a.txt"
+          }
+        }
+      }
     },
     {
       "id": "dd-preserve-keeps-separator-as-value",
       "doc": "With `double_dash=\"preserve\"`, the separator is kept as a value instead of being consumed \u2014 needed by CLIs that pass along command lines containing their own separators.",
       "spec": "name \"ex\"\nbin \"ex\"\narg \"<args>...\" double_dash=\"preserve\"\n",
       "argv": ["a", "--", "b"],
-      "expect": { "ok": { "args": { "args": ["a", "--", "b"] } } }
+      "expect": {
+        "ok": {
+          "args": {
+            "args": ["a", "--", "b"]
+          }
+        }
+      }
     },
     {
       "id": "dd-automatic-behaves-as-if-separated",
       "doc": "With `double_dash=\"automatic\"`, the first value an argument takes stops flag interpretation for everything after it, so a wrapper can forward flags without the caller typing `--`.",
       "spec": "name \"ex\"\nbin \"ex\"\nflag \"-f --force\"\narg \"<files>...\" double_dash=\"automatic\"\n",
       "argv": ["a", "--force"],
-      "expect": { "ok": { "args": { "files": ["a", "--force"] } } },
+      "expect": {
+        "ok": {
+          "args": {
+            "files": ["a", "--force"]
+          }
+        }
+      },
       "reference": {
         "diverges": "usage-lib binds `force` as a flag and gives the argument only `a`. The spec reference documents this mode as not yet enforced by the parser, so this vector describes the intent it will be held to."
       }
@@ -85,7 +140,38 @@
       "spec": "name \"ex\"\nbin \"ex\"\narg \"<args>...\"\n",
       "argv": ["--", "hello", "--", "goodbye", "--"],
       "expect": {
-        "ok": { "args": { "args": ["hello", "--", "goodbye", "--"] } }
+        "ok": {
+          "args": {
+            "args": ["hello", "--", "goodbye", "--"]
+          }
+        }
+      }
+    },
+    {
+      "id": "variadic-then-double-dash-variadic",
+      "doc": "A variadic takes every remaining word, so nothing can follow it \u2014 except an argument that requires a `--`, which is exactly what stops the variadic. mise declares this on `run`, `exec` and `git`.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"[args]\" var=#true\narg \"[-- rest]\" var=#true\n",
+      "argv": ["a", "b", "--", "c", "d"],
+      "expect": {
+        "ok": {
+          "args": {
+            "args": ["a", "b"],
+            "rest": ["c", "d"]
+          }
+        }
+      }
+    },
+    {
+      "id": "variadic-then-double-dash-variadic-without-separator",
+      "doc": "Without the `--`, the first variadic keeps everything and the second stays empty \u2014 which is why mise declares it optional.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"[args]\" var=#true\narg \"[-- rest]\" var=#true\n",
+      "argv": ["a", "b", "c"],
+      "expect": {
+        "ok": {
+          "args": {
+            "args": ["a", "b", "c"]
+          }
+        }
       }
     }
   ]

--- a/corpus/08-choices-and-required.json
+++ b/corpus/08-choices-and-required.json
@@ -218,6 +218,19 @@
         "error": "var_too_many"
       },
       "layer": "post-binding"
+    },
+    {
+      "id": "a-bound-does-not-stop-a-variadic",
+      "doc": "A variadic collects every word still available; `var_max` is a check on how many it got, not a limit that hands the extra words to the next argument. So an argument after a bounded variadic is as unreachable as one after an unbounded variadic, and giving two words here is too many rather than one each.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"[a]\" var=#true var_max=1\narg \"[b]\"\n",
+      "argv": ["x", "y"],
+      "expect": {
+        "error": "var_too_many"
+      },
+      "layer": "post-binding",
+      "reference": {
+        "diverges": "usage-lib stops the variadic at var_max while binding, so it fills [a] with x, [b] with y, and reports no error. clap's num_args behaves the way usage-lib does here, so which of the two is right is a question for the grammar rather than a bug either way."
+      }
     }
   ]
 }

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -39,13 +39,10 @@ pub fn emit(cli: &Cli) -> TokenStream {
         _ => quote!(::usage_argv::UnknownFlags::Value),
     };
 
-    let base = key_base(&cli.fingerprint);
-    let root_key = base | KIND_COMMAND;
-    let flag_tables = flags
-        .iter()
-        .enumerate()
-        .map(|(i, f)| flag_table(i, f, base));
-    let arg_tables = args.iter().enumerate().map(|(i, f)| arg_table(i, f, base));
+    let root_key = key_ident("COMMAND", None);
+    let keys = key_consts(&cli.fingerprint, flags.len(), args.len());
+    let flag_tables = flags.iter().enumerate().map(|(i, f)| flag_table(i, f));
+    let arg_tables = args.iter().enumerate().map(|(i, f)| arg_table(i, f));
     let flag_metas = flags.iter().enumerate().map(|(i, f)| flag_meta(i, f));
     let arg_metas = args.iter().enumerate().map(|(i, f)| arg_meta(i, f));
 
@@ -78,7 +75,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
 
     let partial = partial_struct(cli);
     let defaults = partial_defaults(cli);
-    let apply = apply_fn(cli, base);
+    let apply = apply_fn(cli);
     let post = post_binding(cli);
     // `field: local` rather than the shorthand, because the locals are prefixed:
     // a field called `text` or `parser` would otherwise collide with something the
@@ -107,6 +104,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
             use ::usage_argv::spec::{ArgMeta, CommandMeta, FlagMeta, Spec};
             use ::usage_argv::{Arg, Command, DoubleDash, Flag};
 
+            #keys
             #(#flag_tables)*
             #(#arg_tables)*
 
@@ -240,9 +238,9 @@ pub fn emit(cli: &Cli) -> TokenStream {
     }
 }
 
-fn flag_table(i: usize, field: &Field, base: u64) -> TokenStream {
+fn flag_table(i: usize, field: &Field) -> TokenStream {
     let name = format_ident!("FLAG_{i}");
-    let key = base | KIND_FLAG | i as u64;
+    let key = key_ident("FLAG", Some(i));
     let field_name = &field.name;
     let Kind::Flag {
         longs,
@@ -272,9 +270,9 @@ fn flag_table(i: usize, field: &Field, base: u64) -> TokenStream {
     }
 }
 
-fn arg_table(i: usize, field: &Field, base: u64) -> TokenStream {
+fn arg_table(i: usize, field: &Field) -> TokenStream {
     let name = format_ident!("ARG_{i}");
-    let key = base | KIND_ARG | i as u64;
+    let key = key_ident("ARG", Some(i));
     let field_name = &field.name;
     let var = field.shape == Shape::Many;
     let Kind::Arg {
@@ -411,28 +409,57 @@ const KIND_FLAG: u64 = 0;
 const KIND_ARG: u64 = 1 << 30;
 const KIND_COMMAND: u64 = 2 << 30;
 
-/// The high half of every key a type's fields get.
+/// A hash of the declaration a derive was handed, which is half of a key.
 ///
-/// Two macro expansions cannot see each other, so a shared counter is not available:
-/// keys carry a hash of the declaration they came from instead. The whole item, not
-/// just its name — a macro cannot see a module path, so two same-named structs in
-/// different modules would otherwise hash alike.
-///
-/// Two byte-identical declarations in different modules still hash alike, and that
-/// residue is deliberately harmless rather than fixed: a key only chooses which arm
-/// to jump to, and each arm then checks that the event came from *its* table. So a
-/// collision means an event goes unclaimed, never misbound. `Spec::to_kdl` also
-/// asserts the tree holds no duplicates, which turns it into a failed test rather
-/// than a puzzle.
-fn key_base(fingerprint: &str) -> u64 {
-    // FNV-1a, spelled out rather than taken from a `Hasher`, which is not guaranteed
-    // to be stable between compilations — and these end up baked into generated code.
+/// The other half is the module the declaration sits in, mixed in by
+/// [`usage_argv::key_base`] where `module_path!()` is available — a macro cannot see a
+/// module path, and without it two byte-identical declarations in different modules
+/// collide. They used to: `Spec::to_kdl` asserts the tree holds no duplicate keys, so a
+/// perfectly good CLI with an `add::Op` and a `remove::Op` failed that assertion.
+fn declaration_hash(fingerprint: &str) -> u32 {
+    // FNV-1a, spelled out rather than taken from a `Hasher`, which is not guaranteed to
+    // be stable between compilations — and this ends up baked into generated code.
     let mut hash: u32 = 0x811c_9dc5;
     for byte in fingerprint.as_bytes() {
         hash ^= *byte as u32;
         hash = hash.wrapping_mul(0x0100_0193);
     }
-    (hash as u64) << 32
+    hash
+}
+
+/// The `const` items a generated module needs before it can name a key.
+///
+/// One base, then one per flag, argument and command, because a key is used as a `match`
+/// pattern as well as a table field — and a pattern cannot be an expression, so
+/// `BASE | KIND_FLAG | 0` would parse as an or-pattern of three.
+fn key_consts(fingerprint: &str, flags: usize, args: usize) -> TokenStream {
+    let declaration = declaration_hash(fingerprint);
+    let command = key_ident("COMMAND", None);
+    let flag_keys = (0..flags).map(|i| {
+        let name = key_ident("FLAG", Some(i));
+        let index = i as u64;
+        quote!(const #name: u64 = __USAGE_KEY_BASE | #KIND_FLAG | #index;)
+    });
+    let arg_keys = (0..args).map(|i| {
+        let name = key_ident("ARG", Some(i));
+        let index = i as u64;
+        quote!(const #name: u64 = __USAGE_KEY_BASE | #KIND_ARG | #index;)
+    });
+    quote! {
+        const __USAGE_KEY_BASE: u64 =
+            ::usage_argv::key_base(::core::module_path!(), #declaration);
+        const #command: u64 = __USAGE_KEY_BASE | #KIND_COMMAND;
+        #(#flag_keys)*
+        #(#arg_keys)*
+    }
+}
+
+/// The name of the `const` holding one key.
+fn key_ident(kind: &str, index: Option<usize>) -> proc_macro2::Ident {
+    match index {
+        Some(i) => format_ident!("__USAGE_KEY_{kind}_{i}"),
+        None => format_ident!("__USAGE_KEY_{kind}"),
+    }
 }
 
 /// A user's type, named from inside a generated module.
@@ -467,8 +494,8 @@ fn in_module(ty: &syn::Type) -> TokenStream {
     }
 }
 
-fn flag_arm(cli: &Cli, i: usize, field: &Field, base: u64) -> TokenStream {
-    let key = base | KIND_FLAG | i as u64;
+fn flag_arm(cli: &Cli, i: usize, field: &Field) -> TokenStream {
+    let key = key_ident("FLAG", Some(i));
     let ident = &field.ident;
     let given = format_ident!("__given_{}", ident);
     let displaced = displacements(cli, field);
@@ -558,8 +585,8 @@ fn is_displaceable(cli: &Cli, field: &Field) -> bool {
     !displaced_by(cli, field).is_empty()
 }
 
-fn arg_arm(i: usize, field: &Field, base: u64) -> TokenStream {
-    let key = base | KIND_ARG | i as u64;
+fn arg_arm(i: usize, field: &Field) -> TokenStream {
+    let key = key_ident("ARG", Some(i));
     let ident = &field.ident;
     let given = format_ident!("__given_{}", ident);
     let body = match field.shape {
@@ -711,7 +738,7 @@ fn reset_to_default(field: &Field) -> TokenStream {
 }
 
 /// Take one event and say whether it belonged to this command.
-fn apply_fn(cli: &Cli, base: u64) -> TokenStream {
+fn apply_fn(cli: &Cli) -> TokenStream {
     let route = subcommand_parts(cli).map(|p| p.route).unwrap_or_default();
     let flags: Vec<&Field> = cli
         .fields
@@ -723,11 +750,8 @@ fn apply_fn(cli: &Cli, base: u64) -> TokenStream {
         .iter()
         .filter(|f| matches!(f.kind, Kind::Arg { .. }))
         .collect();
-    let flag_arms = flags
-        .iter()
-        .enumerate()
-        .map(|(i, f)| flag_arm(cli, i, f, base));
-    let arg_arms = args.iter().enumerate().map(|(i, f)| arg_arm(i, f, base));
+    let flag_arms = flags.iter().enumerate().map(|(i, f)| flag_arm(cli, i, f));
+    let arg_arms = args.iter().enumerate().map(|(i, f)| arg_arm(i, f));
 
     quote! {
         pub fn apply(
@@ -877,8 +901,7 @@ fn subcommand_parts(cli: &Cli) -> Option<SubcommandParts> {
 pub fn emit_args(cli: &Cli) -> TokenStream {
     let ident = &cli.ident;
     let module = format_ident!("__usage_args_{}", ident.to_string().to_lowercase());
-    let base = key_base(&cli.fingerprint);
-    let command_key = base | KIND_COMMAND;
+    let command_key = key_ident("COMMAND", None);
 
     let flags: Vec<&Field> = cli
         .fields
@@ -891,11 +914,9 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
         .filter(|f| matches!(f.kind, Kind::Arg { .. }))
         .collect();
 
-    let flag_tables = flags
-        .iter()
-        .enumerate()
-        .map(|(i, f)| flag_table(i, f, base));
-    let arg_tables = args.iter().enumerate().map(|(i, f)| arg_table(i, f, base));
+    let keys = key_consts(&cli.fingerprint, flags.len(), args.len());
+    let flag_tables = flags.iter().enumerate().map(|(i, f)| flag_table(i, f));
+    let arg_tables = args.iter().enumerate().map(|(i, f)| arg_table(i, f));
     let flag_metas = flags.iter().enumerate().map(|(i, f)| flag_meta(i, f));
     let arg_metas = args.iter().enumerate().map(|(i, f)| arg_meta(i, f));
     let flag_refs = (0..flags.len()).map(|i| {
@@ -914,7 +935,7 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
     let long_about = option_str(cli.long_about.as_deref());
     let partial = partial_struct(cli);
     let defaults = partial_defaults(cli);
-    let apply = apply_fn(cli, base);
+    let apply = apply_fn(cli);
     let post = post_binding(cli);
     let parts = subcommand_parts(cli);
     let sub_commands = parts
@@ -947,6 +968,7 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
             use ::usage_argv::spec::{ArgMeta, CommandMeta, FlagMeta};
             use ::usage_argv::{Arg, Command, DoubleDash, Flag};
 
+            #keys
             #(#flag_tables)*
             #(#arg_tables)*
 

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -298,6 +298,11 @@ impl Cli {
                     // A command line has one `--`, so the exemption is good for one
                     // argument. A second one after the separator would be as unreachable
                     // as the first case, and there is no third place to put it.
+                    //
+                    // A `var_max` does not change this: a bound is a check on how many
+                    // words a variadic ended up with, not a limit that hands the rest to
+                    // the next argument — see `a-bound-does-not-stop-a-variadic` in the
+                    // corpus, which also records that usage-lib disagrees.
                     if let Some(first) = spent_separator {
                         return Err(dup(
                             field.span,

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -275,15 +275,21 @@ impl Cli {
                         seen_short.push((*short, field.span));
                     }
                 }
-                Kind::Arg { .. } => {
-                    // A variadic takes everything left, so anything after it can
-                    // never be filled.
-                    if let Some(first) = variadic_arg {
+                Kind::Arg {
+                    double_dash_required,
+                } => {
+                    // A variadic takes everything left, so anything after it can never
+                    // be filled — unless it requires a `--`, which is precisely what
+                    // stops the variadic. mise declares that on `run`, `exec` and `git`:
+                    // `[ARGS]…` for the words before the separator and `[-- ARGS_LAST]…`
+                    // for the ones after.
+                    if let Some(first) = variadic_arg.filter(|_| !double_dash_required) {
                         return Err(dup(
                             field.span,
                             first,
                             "an argument after a variadic one can never be filled, \
-                             because the variadic takes every remaining word",
+                             because the variadic takes every remaining word — unless it \
+                             is only fillable after a `--`, which stops the variadic",
                         ));
                     }
                     if field.shape == Shape::Many {

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -241,6 +241,9 @@ impl Cli {
         let mut seen_long: Vec<(&str, Span)> = Vec::new();
         let mut seen_short: Vec<(char, Span)> = Vec::new();
         let mut variadic_arg: Option<Span> = None;
+        // A variadic that only takes what follows a `--`, which is the end of the line in
+        // both senses: it holds the remaining words and the separator cannot come twice.
+        let mut spent_separator: Option<Span> = None;
         let mut subcommand_field: Option<Span> = None;
 
         for field in &self.fields {
@@ -292,8 +295,24 @@ impl Cli {
                              is only fillable after a `--`, which stops the variadic",
                         ));
                     }
+                    // A command line has one `--`, so the exemption is good for one
+                    // argument. A second one after the separator would be as unreachable
+                    // as the first case, and there is no third place to put it.
+                    if let Some(first) = spent_separator {
+                        return Err(dup(
+                            field.span,
+                            first,
+                            "nothing can follow a variadic that takes the words after a \
+                             `--`: it has both the rest of the command line and the only \
+                             separator there is",
+                        ));
+                    }
                     if field.shape == Shape::Many {
-                        variadic_arg = Some(field.span);
+                        if *double_dash_required {
+                            spent_separator = Some(field.span);
+                        } else {
+                            variadic_arg = Some(field.span);
+                        }
                     }
                 }
                 Kind::Subcommand { .. } => {
@@ -1287,6 +1306,46 @@ mod tests {
         "#,
         );
         assert!(err.contains("names no flag"), "unhelpful message: {err}");
+    }
+
+    #[test]
+    fn only_one_argument_can_live_after_the_separator() {
+        // The exemption is good for one argument, because a command line has one `--`.
+        // A second variadic behind the separator would be as unreachable as an argument
+        // after a plain variadic.
+        let err = rejection(
+            r#"
+            struct Ex {
+                #[usage(arg)]
+                args: Vec<String>,
+                #[usage(arg, double_dash = "required")]
+                rest: Vec<String>,
+                #[usage(arg, double_dash = "required")]
+                more: Vec<String>,
+            }
+        "#,
+        );
+        assert!(
+            err.contains("only separator there is"),
+            "unhelpful message: {err}"
+        );
+
+        // Including a plain argument, which the variadic behind the separator would
+        // already have taken.
+        let err = rejection(
+            r#"
+            struct Ex {
+                #[usage(arg, double_dash = "required")]
+                rest: Vec<String>,
+                #[usage(arg)]
+                trailing: Option<String>,
+            }
+        "#,
+        );
+        assert!(
+            err.contains("only separator there is"),
+            "unhelpful message: {err}"
+        );
     }
 
     #[test]

--- a/docs/spec/argv.md
+++ b/docs/spec/argv.md
@@ -179,7 +179,10 @@ declaration order. Each argument takes one word, except a variadic (`var=#true`,
 or a trailing `...`), which collects every word still available.
 
 - A word offered when no argument can hold it is an error, not silently dropped.
-- `var_min` and `var_max` are enforced.
+- `var_min` and `var_max` are enforced. They are checks on how many words an argument
+  ended up with, not limits that stop it collecting: a bounded variadic still takes
+  every word available, so an argument after one is as unreachable as an argument after
+  an unbounded variadic.
 - An unfilled required argument is an error. An unfilled optional one is absent.
 
 Flags and words may interleave freely: `ex from -f to` fills the same arguments


### PR DESCRIPTION
Stacked on #821.

The derive refused any argument after a variadic, on the grounds that a variadic takes every remaining word. True except in the one case that matters: an argument only fillable after a `--`, since the `--` is what stops the variadic.

mise declares exactly that on `run`, `exec` and `git`:

```kdl
arg "[ARGS]…"      help="Arguments to pass to the tasks. Use \":::\" to separate tasks" var=#true
arg "[-- ARGS_LAST]…" var=#true hide=#true
```

So the check was refusing a shape three of mise's commands depend on. Both parsers were already right — usage-argv binds it, usage-lib binds it — only the derive's validation disagreed.

## How it was found

By generating a shadow CLI from mise's committed 5,592-line spec and trying to compile it. Four commands failed, and the parser was not at fault. That's what the shadow exercise is for, and it's the reason to do it before touching mise rather than after.

Two corpus vectors pin the behaviour, with and without the separator, and a derive test checks the emitted spec still says which argument is which — otherwise docs and completions would describe a different CLI from the one that runs.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches derive validation and key generation for all derived CLIs; behavior is corrective but key values change and incorrect validation could accept unreachable argument shapes.
> 
> **Overview**
> **Allows a `double_dash = "required"` argument to follow a variadic** in derive validation. The old rule rejected any argument after a variadic; the `--` that such an argument requires is exactly what stops the first variadic, which mise needs on `run`/`exec`/`git`. Anything after a separator-consuming variadic is still rejected.
> 
> **Folds `module_path!()` into generated keys** via a new `usage_argv::key_base`, so byte-identical declarations in different modules no longer collide. That collision used to fail `Spec::to_kdl`'s uniqueness assert on otherwise valid CLIs. Codegen now emits named key consts (needed for `match` patterns) instead of inlining the hash.
> 
> Adds corpus vectors and derive/identity tests for both behaviors, plus a note that `var_max` is a post-binding check and does not hand leftover words to the next argument.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd0436c3af6561012c3dece838eaef51d7bd9b52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->