### PR TITLE
feat(derive): let a command answer to more than one name

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -188,7 +188,7 @@ checked-in `mise.usage.kdl` for both parsers.
 - [x] **Shadow generation** — `xtask gen-shadow` turns any `.usage.kdl` into a crate
       of derived types. mise's committed 5,592-line spec compiles: 211 commands, 711
       flags, 128 arguments, four levels deep, in 2.6s. What it cannot express, it
-      counts: 91 command aliases (67 visible, 24 hidden), 13 secondary flag aliases, 3
+      counts: 13 secondary flag aliases, 3
       `double_dash="automatic"`, 2 mounts, 2 restart tokens, 1 `default_subcommand`, 1
       default on a collecting flag. Aliases are the largest gap and the next thing the
       derive needs for mise; `default_subcommand` is the one that changes the _root's_
@@ -205,6 +205,17 @@ checked-in `mise.usage.kdl` for both parsers.
       does, so nothing but the parse varies. clap's 490µs is 305µs building its command
       tree, ~160µs validating it, and ~24µs actually parsing — so even against clap's
       parse alone, with the tree already built and paid for, this is 12× faster.
+- [ ] **A sentinel the fixture cannot trip** — the three `gate-*` benchmarks measure the
+      mise shadow, and tak gates everything in `tak.toml` at 1%. But the shadow is
+      _designed_ to grow: teaching the derive command aliases added 91 names to it and cost
+      1.52%, which the gate reported as a regression when it was the fixture getting
+      bigger. A regression sentinel has to be a fixed fixture — a small hand-written CLI
+      that never changes — with the shadow benches reported but not gated. Until then a
+      red gate on a PR that grows the shadow is expected, and the PR should say why.
+- [ ] **A subcommand lookup that is not linear** — the 1.52% above is real work: finding a
+      command scans the parent's list, and each candidate now checks its aliases too. At
+      mise's ~100 top-level commands that is worth a sorted table or a hash, and it is the
+      largest remaining item in the parse.
 - [ ] **Differential fuzzing** — proptest over argv against usage-lib on the mise
       spec, to find disagreements the corpus did not think of.
 - [ ] **Perf report** — published honestly, whichever way it goes.

--- a/benches/gate/tests/parse.rs
+++ b/benches/gate/tests/parse.rs
@@ -130,3 +130,20 @@ fn a_command_that_requires_a_subcommand_refuses_to_stand_alone() {
     let a = argv(["build"]);
     Cli::parse_from(&a).expect("a bare task should parse");
 }
+
+#[test]
+fn a_command_answers_to_its_alias() {
+    // 91 of mise's commands have a second name, and until the derive could declare one
+    // the shadow rejected invocations the real thing accepts. `mise i` is `mise install`.
+    let a = argv(["i", "node@20"]);
+    let cli = Cli::parse_from(&a).expect("`mise i` should parse");
+    let Some(Commands::Install(install)) = cli.command else {
+        panic!("`i` should have selected install")
+    };
+    assert_eq!(install.tool_version, ["node@20"]);
+
+    // And a hidden one, which is matched but kept out of help.
+    let a = argv(["x", "--", "node", "-e", "1"]);
+    let cli = Cli::parse_from(&a).expect("`mise x` should parse");
+    assert!(matches!(cli.command, Some(Commands::Exec(_))));
+}

--- a/benches/shadows/mise-clap/src/lib.rs
+++ b/benches/shadows/mise-clap/src/lib.rs
@@ -134,13 +134,13 @@ pub enum ToolAliasCommands {
     /// List tool version aliases
     /// Shows the aliases that can be specified.
     /// These can come from user config or from plugins in `bin/list-aliases`.
-    #[command(name = "ls")]
+    #[command(name = "ls", visible_alias = "list")]
     Ls(ToolAliasLsArgs),
     /// Add/update an alias for a tool/backend
-    #[command(name = "set")]
+    #[command(name = "set", visible_aliases = ["add", "create"])]
     Set(ToolAliasSetArgs),
     /// Clears an alias for a tool/backend
-    #[command(name = "unset")]
+    #[command(name = "unset", visible_aliases = ["rm", "remove", "delete", "del"])]
     Unset(ToolAliasUnsetArgs),
 }
 
@@ -166,7 +166,7 @@ pub struct BackendsArgs {
 #[derive(Subcommand)]
 pub enum BackendsCommands {
     /// List built-in backends
-    #[command(name = "ls")]
+    #[command(name = "ls", visible_alias = "list")]
     Ls(BackendsLsArgs),
 }
 
@@ -423,7 +423,7 @@ pub enum BootstrapDotfilesCommands {
     #[command(name = "edit")]
     Edit(BootstrapDotfilesEditArgs),
     /// Show the status of dotfiles from `[dotfiles]`
-    #[command(name = "status")]
+    #[command(name = "status", visible_alias = "ls")]
     Status(BootstrapDotfilesStatusArgs),
     /// Remove dotfiles applied from `[dotfiles]`
     #[command(name = "unapply")]
@@ -602,7 +602,7 @@ pub struct BootstrapLinuxArgs {
 #[derive(Subcommand)]
 pub enum BootstrapLinuxCommands {
     /// Manage systemd user services from `[bootstrap.linux.systemd.units]`
-    #[command(name = "systemd-units")]
+    #[command(name = "systemd-units", alias = "systemd")]
     SystemdUnits(BootstrapLinuxSystemdUnitsArgs),
 }
 
@@ -697,7 +697,7 @@ pub enum BootstrapMacosCommands {
     #[command(name = "defaults")]
     Defaults(BootstrapMacosDefaultsArgs2),
     /// Manage macOS LaunchAgents from `[bootstrap.macos.launchd.agents]`
-    #[command(name = "launchd-agents")]
+    #[command(name = "launchd-agents", alias = "launchd")]
     LaunchdAgents(BootstrapMacosLaunchdAgentsArgs),
 }
 
@@ -861,7 +861,7 @@ pub enum BootstrapPackagesBrewCommands {
     #[command(name = "tap")]
     Tap(BootstrapPackagesBrewTapArgs),
     /// Remove Homebrew tap URLs from [bootstrap.brew.taps]
-    #[command(name = "untap")]
+    #[command(name = "untap", visible_aliases = ["remove", "rm"])]
     Untap(BootstrapPackagesBrewUntapArgs),
 }
 
@@ -991,7 +991,7 @@ pub struct BootstrapPackagesArgs {
 #[derive(Subcommand)]
 pub enum BootstrapPackagesCommands {
     /// Apply system packages from `[bootstrap.packages]`
-    #[command(name = "apply")]
+    #[command(name = "apply", visible_alias = "i", alias = "install")]
     Apply(BootstrapPackagesApplyArgs),
     /// Manage Homebrew taps used by bootstrap packages
     #[command(name = "brew")]
@@ -1003,13 +1003,13 @@ pub enum BootstrapPackagesCommands {
     #[command(name = "prune")]
     Prune(BootstrapPackagesPruneArgs),
     /// Show the status of system packages from `[bootstrap.packages]`
-    #[command(name = "status")]
+    #[command(name = "status", visible_alias = "ls")]
     Status(BootstrapPackagesStatusArgs),
     /// Upgrade installed bootstrap packages from `[bootstrap.packages]`
-    #[command(name = "upgrade")]
+    #[command(name = "upgrade", visible_alias = "up")]
     Upgrade(BootstrapPackagesUpgradeArgs),
     /// Add bootstrap packages to [bootstrap.packages] and install them
-    #[command(name = "use")]
+    #[command(name = "use", visible_alias = "u")]
     Use(BootstrapPackagesUseArgs),
 }
 
@@ -1495,7 +1495,7 @@ pub enum BootstrapCommands {
     #[command(name = "macos-defaults")]
     MacosDefaults(BootstrapMacosDefaultsArgs),
     /// Manage mise shell activation from `[bootstrap.mise_shell_activate]`
-    #[command(name = "mise-shell-activate")]
+    #[command(name = "mise-shell-activate", alias = "shell")]
     MiseShellActivate(BootstrapMiseShellActivateArgs),
     /// Manage bootstrap system packages from `[bootstrap.packages]`
     #[command(name = "packages")]
@@ -1519,7 +1519,7 @@ pub enum BootstrapCommands {
     #[command(name = "services")]
     Services(BootstrapServicesArgs),
     /// Show the aggregate bootstrap status
-    #[command(name = "status")]
+    #[command(name = "status", visible_alias = "ls")]
     Status(BootstrapStatusArgs),
     /// Manage systemd user services from `[bootstrap.linux.systemd.units]`
     #[command(name = "systemd")]
@@ -1587,13 +1587,13 @@ pub struct CacheArgs {
 #[derive(Subcommand)]
 pub enum CacheCommands {
     /// Deletes all cache files in mise
-    #[command(name = "clear")]
+    #[command(name = "clear", visible_alias = "c", alias = "clean")]
     Clear(CacheClearArgs),
     /// Show the cache directory path
-    #[command(name = "path")]
+    #[command(name = "path", visible_alias = "dir")]
     Path(CachePathArgs),
     /// Removes stale mise cache files
-    #[command(name = "prune")]
+    #[command(name = "prune", visible_alias = "p")]
     Prune(CachePruneArgs),
     /// Inspect output cache entries for a task
     #[command(name = "task")]
@@ -1697,7 +1697,7 @@ pub enum ConfigCommands {
     #[command(name = "get")]
     Get(ConfigGetArgs),
     /// List config files currently in use
-    #[command(name = "ls")]
+    #[command(name = "ls", visible_alias = "list")]
     Ls(ConfigLsArgs),
     /// Set the value of a setting in a mise.toml file
     #[command(name = "set")]
@@ -1907,7 +1907,7 @@ pub enum DotfilesCommands {
     #[command(name = "edit")]
     Edit(DotfilesEditArgs),
     /// Show the status of dotfiles from `[dotfiles]`
-    #[command(name = "status")]
+    #[command(name = "status", visible_alias = "ls")]
     Status(DotfilesStatusArgs),
     /// Remove dotfiles applied from `[dotfiles]`
     #[command(name = "unapply")]
@@ -1935,7 +1935,7 @@ pub struct DoctorArgs {
 #[derive(Subcommand)]
 pub enum DoctorCommands {
     /// Print the current PATH entries mise is providing
-    #[command(name = "path")]
+    #[command(name = "path", alias = "paths")]
     Path(DoctorPathArgs),
 }
 
@@ -2306,7 +2306,7 @@ pub enum GenerateCommands {
     #[command(name = "devcontainer")]
     Devcontainer(GenerateDevcontainerArgs),
     /// Generate a git pre-commit hook
-    #[command(name = "git-pre-commit")]
+    #[command(name = "git-pre-commit", visible_alias = "pre-commit")]
     GitPreCommit(GenerateGitPreCommitArgs),
     /// Generate a GitHub Action workflow file
     #[command(name = "github-action")]
@@ -3211,22 +3211,22 @@ pub struct PluginsArgs {
 #[derive(Subcommand)]
 pub enum PluginsCommands {
     /// Install a plugin
-    #[command(name = "install")]
+    #[command(name = "install", visible_aliases = ["i", "a", "add"])]
     Install(PluginsInstallArgs),
     /// Symlinks a plugin into mise
-    #[command(name = "link")]
+    #[command(name = "link", visible_alias = "ln")]
     Link(PluginsLinkArgs),
     /// List installed plugins
-    #[command(name = "ls")]
+    #[command(name = "ls", visible_alias = "list")]
     Ls(PluginsLsArgs),
     /// List all available remote plugins
-    #[command(name = "ls-remote")]
+    #[command(name = "ls-remote", visible_aliases = ["list-remote", "list-all"])]
     LsRemote(PluginsLsRemoteArgs),
     /// Removes a plugin
-    #[command(name = "uninstall")]
+    #[command(name = "uninstall", visible_aliases = ["remove", "rm"])]
     Uninstall(PluginsUninstallArgs),
     /// Updates a plugin to the latest version
-    #[command(name = "update")]
+    #[command(name = "update", visible_aliases = ["up", "upgrade"])]
     Update(PluginsUpdateArgs),
 }
 
@@ -3872,13 +3872,13 @@ pub enum SettingsCommands {
     #[command(name = "get")]
     Get(SettingsGetArgs),
     /// Show current settings
-    #[command(name = "ls")]
+    #[command(name = "ls", visible_alias = "list")]
     Ls(SettingsLsArgs),
     /// Add/update a setting
-    #[command(name = "set")]
+    #[command(name = "set", visible_alias = "create")]
     Set(SettingsSetArgs),
     /// Clears a setting
-    #[command(name = "unset")]
+    #[command(name = "unset", visible_aliases = ["rm", "remove", "delete", "del"])]
     Unset(SettingsUnsetArgs),
 }
 
@@ -3963,13 +3963,13 @@ pub enum ShellAliasCommands {
     #[command(name = "get")]
     Get(ShellAliasGetArgs),
     /// List shell aliases
-    #[command(name = "ls")]
+    #[command(name = "ls", visible_alias = "list")]
     Ls(ShellAliasLsArgs),
     /// Add/update a shell alias
-    #[command(name = "set")]
+    #[command(name = "set", visible_aliases = ["add", "create"])]
     Set(ShellAliasSetArgs),
     /// Removes a shell alias
-    #[command(name = "unset")]
+    #[command(name = "unset", visible_aliases = ["rm", "remove", "delete", "del"])]
     Unset(ShellAliasUnsetArgs),
 }
 
@@ -4471,7 +4471,7 @@ pub enum TasksCommands {
     #[command(name = "ls")]
     Ls(TasksLsArgs),
     /// Run task(s)
-    #[command(name = "run")]
+    #[command(name = "run", visible_alias = "r")]
     Run(TasksRunArgs),
     /// Validate tasks for common errors and issues
     #[command(name = "validate")]
@@ -5618,28 +5618,28 @@ pub enum Commands {
     #[command(name = "activate")]
     Activate(ActivateArgs),
     /// Manage tool version aliases.
-    #[command(name = "tool-alias")]
+    #[command(name = "tool-alias", aliases = ["alias", "aliases"])]
     ToolAlias(ToolAliasArgs),
     /// [internal] simulates asdf for plugins that call "asdf" internally
     #[command(name = "asdf")]
     Asdf(AsdfArgs),
     /// Manage backends
-    #[command(name = "backends")]
+    #[command(name = "backends", aliases = ["b", "backend", "backend-list"])]
     Backends(BackendsArgs),
     /// List all the active runtime bin paths
     #[command(name = "bin-paths")]
     BinPaths(BinPathsArgs),
     /// Set up a machine for the current config in one command
-    #[command(name = "bootstrap")]
+    #[command(name = "bootstrap", visible_alias = "bs")]
     Bootstrap(BootstrapArgs),
     /// Manage the mise cache
     #[command(name = "cache")]
     Cache(CacheArgs),
     /// Generate shell completions
-    #[command(name = "completion")]
+    #[command(name = "completion", aliases = ["complete", "completions"])]
     Completion(CompletionArgs),
     /// Manage config files
-    #[command(name = "config")]
+    #[command(name = "config", visible_alias = "cfg", alias = "toml")]
     Config(ConfigArgs),
     /// Shows current active and installed runtime versions
     #[command(name = "current")]
@@ -5654,22 +5654,22 @@ pub enum Commands {
     #[command(name = "dotfiles")]
     Dotfiles(DotfilesArgs),
     /// Check mise installation for possible problems
-    #[command(name = "doctor")]
+    #[command(name = "doctor", visible_alias = "dr")]
     Doctor(DoctorArgs),
     /// Starts a new shell with the mise environment built from the current configuration
     #[command(name = "en")]
     En(EnArgs),
     /// Exports env vars to activate mise a single time
-    #[command(name = "env")]
+    #[command(name = "env", visible_alias = "e")]
     Env(EnvArgs),
     /// Execute a command with tool(s) set
-    #[command(name = "exec")]
+    #[command(name = "exec", visible_alias = "x")]
     Exec(ExecArgs),
     /// Formats mise.toml
     #[command(name = "fmt")]
     Fmt(FmtArgs),
     /// Generate files for various tools/services
-    #[command(name = "generate")]
+    #[command(name = "generate", visible_alias = "gen", alias = "g")]
     Generate(GenerateArgs),
     /// GitHub related commands
     #[command(name = "github")]
@@ -5690,7 +5690,7 @@ pub enum Commands {
     #[command(name = "edit")]
     Edit(EditArgs),
     /// Install a tool version
-    #[command(name = "install")]
+    #[command(name = "install", visible_alias = "i")]
     Install(InstallArgs),
     /// Install a tool version to a specific path
     #[command(name = "install-into")]
@@ -5699,19 +5699,19 @@ pub enum Commands {
     #[command(name = "latest")]
     Latest(LatestArgs),
     /// Symlinks a tool version into mise
-    #[command(name = "link")]
+    #[command(name = "link", visible_alias = "ln")]
     Link(LinkArgs),
     /// Sets/gets tool version in local .tool-versions or mise.toml
-    #[command(name = "local")]
+    #[command(name = "local", alias = "l")]
     Local(LocalArgs),
     /// Update lockfile checksums and URLs for all specified platforms
     #[command(name = "lock")]
     Lock(LockArgs),
     /// List installed and active tool versions
-    #[command(name = "ls")]
+    #[command(name = "ls", visible_alias = "list")]
     Ls(LsArgs),
     /// List runtime versions available for install.
-    #[command(name = "ls-remote")]
+    #[command(name = "ls-remote", aliases = ["list-all", "list-remote"])]
     LsRemote(LsRemoteArgs),
     /// Run Model Context Protocol (MCP) server
     #[command(name = "mcp")]
@@ -5726,10 +5726,10 @@ pub enum Commands {
     #[command(name = "patrons")]
     Patrons(PatronsArgs),
     /// Manage plugins
-    #[command(name = "plugins")]
+    #[command(name = "plugins", visible_alias = "p", aliases = ["plugin", "plugin-list"])]
     Plugins(PluginsArgs),
     /// [experimental] Manage project dependencies
-    #[command(name = "deps")]
+    #[command(name = "deps", visible_alias = "dep", alias = "prepare")]
     Deps(DepsArgs),
     /// Delete unused versions of tools
     #[command(name = "prune")]
@@ -5744,7 +5744,7 @@ pub enum Commands {
     #[command(name = "reshim")]
     Reshim(ReshimArgs),
     /// Run task(s)
-    #[command(name = "run")]
+    #[command(name = "run", visible_alias = "r")]
     Run(RunArgs),
     /// Search for tools in the registry
     #[command(name = "search")]
@@ -5753,13 +5753,13 @@ pub enum Commands {
     #[command(name = "self-update")]
     SelfUpdate(SelfUpdateArgs),
     /// Set environment variables in mise.toml
-    #[command(name = "set")]
+    #[command(name = "set", aliases = ["ev", "env-vars"])]
     Set(SetArgs),
     /// Manage settings
     #[command(name = "settings")]
     Settings(SettingsArgs),
     /// Sets a tool version for the current session.
-    #[command(name = "shell")]
+    #[command(name = "shell", visible_alias = "sh")]
     Shell(ShellArgs),
     /// Manage shell aliases.
     #[command(name = "shell-alias")]
@@ -5771,7 +5771,7 @@ pub enum Commands {
     #[command(name = "sync")]
     Sync(SyncArgs),
     /// Manage tasks
-    #[command(name = "tasks")]
+    #[command(name = "tasks", visible_alias = "t", alias = "task")]
     Tasks(TasksArgs),
     /// Test a tool installs and executes
     #[command(name = "test-tool")]
@@ -5798,22 +5798,22 @@ pub enum Commands {
     #[command(name = "untrust")]
     Untrust(UntrustArgs),
     /// Removes installed tool versions from mise.toml
-    #[command(name = "unuse")]
+    #[command(name = "unuse", visible_aliases = ["rm", "remove"])]
     Unuse(UnuseArgs),
     /// Upgrades outdated tools
-    #[command(name = "upgrade")]
+    #[command(name = "upgrade", visible_alias = "up")]
     Upgrade(UpgradeArgs),
     /// Generate a usage CLI spec
     #[command(name = "usage")]
     Usage(UsageArgs),
     /// Installs a tool and adds the version to mise.toml.
-    #[command(name = "use")]
+    #[command(name = "use", visible_alias = "u")]
     Use(UseArgs),
     /// Display the version of mise
-    #[command(name = "version")]
+    #[command(name = "version", visible_alias = "v")]
     Version(VersionArgs),
     /// Run task(s) and watch for changes to rerun it
-    #[command(name = "watch")]
+    #[command(name = "watch", visible_alias = "w")]
     Watch(WatchArgs),
     /// Display the installation path for a tool
     #[command(name = "where")]

--- a/benches/shadows/mise/src/lib.rs
+++ b/benches/shadows/mise/src/lib.rs
@@ -143,13 +143,13 @@ pub enum ToolAliasCommands {
     /// List tool version aliases
     /// Shows the aliases that can be specified.
     /// These can come from user config or from plugins in `bin/list-aliases`.
-    #[usage(name = "ls")]
+    #[usage(name = "ls", alias = "list")]
     Ls(ToolAliasLsArgs),
     /// Add/update an alias for a tool/backend
-    #[usage(name = "set")]
+    #[usage(name = "set", alias("add", "create"))]
     Set(ToolAliasSetArgs),
     /// Clears an alias for a tool/backend
-    #[usage(name = "unset")]
+    #[usage(name = "unset", alias("rm", "remove", "delete", "del"))]
     Unset(ToolAliasUnsetArgs),
 }
 
@@ -175,7 +175,7 @@ pub struct BackendsArgs {
 #[derive(Subcommands)]
 pub enum BackendsCommands {
     /// List built-in backends
-    #[usage(name = "ls")]
+    #[usage(name = "ls", alias = "list")]
     Ls(BackendsLsArgs),
 }
 
@@ -432,7 +432,7 @@ pub enum BootstrapDotfilesCommands {
     #[usage(name = "edit")]
     Edit(BootstrapDotfilesEditArgs),
     /// Show the status of dotfiles from `[dotfiles]`
-    #[usage(name = "status")]
+    #[usage(name = "status", alias = "ls")]
     Status(BootstrapDotfilesStatusArgs),
     /// Remove dotfiles applied from `[dotfiles]`
     #[usage(name = "unapply")]
@@ -611,7 +611,7 @@ pub struct BootstrapLinuxArgs {
 #[derive(Subcommands)]
 pub enum BootstrapLinuxCommands {
     /// Manage systemd user services from `[bootstrap.linux.systemd.units]`
-    #[usage(name = "systemd-units")]
+    #[usage(name = "systemd-units", alias_hidden = "systemd")]
     SystemdUnits(BootstrapLinuxSystemdUnitsArgs),
 }
 
@@ -706,7 +706,7 @@ pub enum BootstrapMacosCommands {
     #[usage(name = "defaults")]
     Defaults(BootstrapMacosDefaultsArgs2),
     /// Manage macOS LaunchAgents from `[bootstrap.macos.launchd.agents]`
-    #[usage(name = "launchd-agents")]
+    #[usage(name = "launchd-agents", alias_hidden = "launchd")]
     LaunchdAgents(BootstrapMacosLaunchdAgentsArgs),
 }
 
@@ -870,7 +870,7 @@ pub enum BootstrapPackagesBrewCommands {
     #[usage(name = "tap")]
     Tap(BootstrapPackagesBrewTapArgs),
     /// Remove Homebrew tap URLs from [bootstrap.brew.taps]
-    #[usage(name = "untap")]
+    #[usage(name = "untap", alias("remove", "rm"))]
     Untap(BootstrapPackagesBrewUntapArgs),
 }
 
@@ -1000,7 +1000,7 @@ pub struct BootstrapPackagesArgs {
 #[derive(Subcommands)]
 pub enum BootstrapPackagesCommands {
     /// Apply system packages from `[bootstrap.packages]`
-    #[usage(name = "apply")]
+    #[usage(name = "apply", alias = "i", alias_hidden = "install")]
     Apply(BootstrapPackagesApplyArgs),
     /// Manage Homebrew taps used by bootstrap packages
     #[usage(name = "brew")]
@@ -1012,13 +1012,13 @@ pub enum BootstrapPackagesCommands {
     #[usage(name = "prune")]
     Prune(BootstrapPackagesPruneArgs),
     /// Show the status of system packages from `[bootstrap.packages]`
-    #[usage(name = "status")]
+    #[usage(name = "status", alias = "ls")]
     Status(BootstrapPackagesStatusArgs),
     /// Upgrade installed bootstrap packages from `[bootstrap.packages]`
-    #[usage(name = "upgrade")]
+    #[usage(name = "upgrade", alias = "up")]
     Upgrade(BootstrapPackagesUpgradeArgs),
     /// Add bootstrap packages to [bootstrap.packages] and install them
-    #[usage(name = "use")]
+    #[usage(name = "use", alias = "u")]
     Use(BootstrapPackagesUseArgs),
 }
 
@@ -1604,7 +1604,7 @@ pub enum BootstrapCommands {
     #[usage(name = "macos-defaults")]
     MacosDefaults(BootstrapMacosDefaultsArgs),
     /// Manage mise shell activation from `[bootstrap.mise_shell_activate]`
-    #[usage(name = "mise-shell-activate")]
+    #[usage(name = "mise-shell-activate", alias_hidden = "shell")]
     MiseShellActivate(BootstrapMiseShellActivateArgs),
     /// Manage bootstrap system packages from `[bootstrap.packages]`
     #[usage(name = "packages")]
@@ -1628,7 +1628,7 @@ pub enum BootstrapCommands {
     #[usage(name = "services")]
     Services(BootstrapServicesArgs),
     /// Show the aggregate bootstrap status
-    #[usage(name = "status")]
+    #[usage(name = "status", alias = "ls")]
     Status(BootstrapStatusArgs),
     /// Manage systemd user services from `[bootstrap.linux.systemd.units]`
     #[usage(name = "systemd")]
@@ -1696,13 +1696,13 @@ pub struct CacheArgs {
 #[derive(Subcommands)]
 pub enum CacheCommands {
     /// Deletes all cache files in mise
-    #[usage(name = "clear")]
+    #[usage(name = "clear", alias = "c", alias_hidden = "clean")]
     Clear(CacheClearArgs),
     /// Show the cache directory path
-    #[usage(name = "path")]
+    #[usage(name = "path", alias = "dir")]
     Path(CachePathArgs),
     /// Removes stale mise cache files
-    #[usage(name = "prune")]
+    #[usage(name = "prune", alias = "p")]
     Prune(CachePruneArgs),
     /// Inspect output cache entries for a task
     #[usage(name = "task")]
@@ -1816,7 +1816,7 @@ pub enum ConfigCommands {
     #[usage(name = "get")]
     Get(ConfigGetArgs),
     /// List config files currently in use
-    #[usage(name = "ls")]
+    #[usage(name = "ls", alias = "list")]
     Ls(ConfigLsArgs),
     /// Set the value of a setting in a mise.toml file
     #[usage(name = "set")]
@@ -2026,7 +2026,7 @@ pub enum DotfilesCommands {
     #[usage(name = "edit")]
     Edit(DotfilesEditArgs),
     /// Show the status of dotfiles from `[dotfiles]`
-    #[usage(name = "status")]
+    #[usage(name = "status", alias = "ls")]
     Status(DotfilesStatusArgs),
     /// Remove dotfiles applied from `[dotfiles]`
     #[usage(name = "unapply")]
@@ -2054,7 +2054,7 @@ pub struct DoctorArgs {
 #[derive(Subcommands)]
 pub enum DoctorCommands {
     /// Print the current PATH entries mise is providing
-    #[usage(name = "path")]
+    #[usage(name = "path", alias_hidden = "paths")]
     Path(DoctorPathArgs),
 }
 
@@ -2420,7 +2420,7 @@ pub enum GenerateCommands {
     #[usage(name = "devcontainer")]
     Devcontainer(GenerateDevcontainerArgs),
     /// Generate a git pre-commit hook
-    #[usage(name = "git-pre-commit")]
+    #[usage(name = "git-pre-commit", alias = "pre-commit")]
     GitPreCommit(GenerateGitPreCommitArgs),
     /// Generate a GitHub Action workflow file
     #[usage(name = "github-action")]
@@ -3328,22 +3328,22 @@ pub struct PluginsArgs {
 #[derive(Subcommands)]
 pub enum PluginsCommands {
     /// Install a plugin
-    #[usage(name = "install")]
+    #[usage(name = "install", alias("i", "a", "add"))]
     Install(PluginsInstallArgs),
     /// Symlinks a plugin into mise
-    #[usage(name = "link")]
+    #[usage(name = "link", alias = "ln")]
     Link(PluginsLinkArgs),
     /// List installed plugins
-    #[usage(name = "ls")]
+    #[usage(name = "ls", alias = "list")]
     Ls(PluginsLsArgs),
     /// List all available remote plugins
-    #[usage(name = "ls-remote")]
+    #[usage(name = "ls-remote", alias("list-remote", "list-all"))]
     LsRemote(PluginsLsRemoteArgs),
     /// Removes a plugin
-    #[usage(name = "uninstall")]
+    #[usage(name = "uninstall", alias("remove", "rm"))]
     Uninstall(PluginsUninstallArgs),
     /// Updates a plugin to the latest version
-    #[usage(name = "update")]
+    #[usage(name = "update", alias("up", "upgrade"))]
     Update(PluginsUpdateArgs),
 }
 
@@ -3998,13 +3998,13 @@ pub enum SettingsCommands {
     #[usage(name = "get")]
     Get(SettingsGetArgs),
     /// Show current settings
-    #[usage(name = "ls")]
+    #[usage(name = "ls", alias = "list")]
     Ls(SettingsLsArgs),
     /// Add/update a setting
-    #[usage(name = "set")]
+    #[usage(name = "set", alias = "create")]
     Set(SettingsSetArgs),
     /// Clears a setting
-    #[usage(name = "unset")]
+    #[usage(name = "unset", alias("rm", "remove", "delete", "del"))]
     Unset(SettingsUnsetArgs),
 }
 
@@ -4089,13 +4089,13 @@ pub enum ShellAliasCommands {
     #[usage(name = "get")]
     Get(ShellAliasGetArgs),
     /// List shell aliases
-    #[usage(name = "ls")]
+    #[usage(name = "ls", alias = "list")]
     Ls(ShellAliasLsArgs),
     /// Add/update a shell alias
-    #[usage(name = "set")]
+    #[usage(name = "set", alias("add", "create"))]
     Set(ShellAliasSetArgs),
     /// Removes a shell alias
-    #[usage(name = "unset")]
+    #[usage(name = "unset", alias("rm", "remove", "delete", "del"))]
     Unset(ShellAliasUnsetArgs),
 }
 
@@ -4601,7 +4601,7 @@ pub enum TasksCommands {
     #[usage(name = "ls")]
     Ls(TasksLsArgs),
     /// Run task(s)
-    #[usage(name = "run")]
+    #[usage(name = "run", alias = "r")]
     Run(TasksRunArgs),
     /// Validate tasks for common errors and issues
     #[usage(name = "validate")]
@@ -5755,28 +5755,28 @@ pub enum Commands {
     #[usage(name = "activate")]
     Activate(ActivateArgs),
     /// Manage tool version aliases.
-    #[usage(name = "tool-alias")]
+    #[usage(name = "tool-alias", alias_hidden("alias", "aliases"))]
     ToolAlias(ToolAliasArgs),
     /// [internal] simulates asdf for plugins that call "asdf" internally
     #[usage(name = "asdf")]
     Asdf(AsdfArgs),
     /// Manage backends
-    #[usage(name = "backends")]
+    #[usage(name = "backends", alias_hidden("b", "backend", "backend-list"))]
     Backends(BackendsArgs),
     /// List all the active runtime bin paths
     #[usage(name = "bin-paths")]
     BinPaths(BinPathsArgs),
     /// Set up a machine for the current config in one command
-    #[usage(name = "bootstrap")]
+    #[usage(name = "bootstrap", alias = "bs")]
     Bootstrap(BootstrapArgs),
     /// Manage the mise cache
     #[usage(name = "cache")]
     Cache(CacheArgs),
     /// Generate shell completions
-    #[usage(name = "completion")]
+    #[usage(name = "completion", alias_hidden("complete", "completions"))]
     Completion(CompletionArgs),
     /// Manage config files
-    #[usage(name = "config")]
+    #[usage(name = "config", alias = "cfg", alias_hidden = "toml")]
     Config(ConfigArgs),
     /// Shows current active and installed runtime versions
     #[usage(name = "current")]
@@ -5791,22 +5791,22 @@ pub enum Commands {
     #[usage(name = "dotfiles")]
     Dotfiles(DotfilesArgs),
     /// Check mise installation for possible problems
-    #[usage(name = "doctor")]
+    #[usage(name = "doctor", alias = "dr")]
     Doctor(DoctorArgs),
     /// Starts a new shell with the mise environment built from the current configuration
     #[usage(name = "en")]
     En(EnArgs),
     /// Exports env vars to activate mise a single time
-    #[usage(name = "env")]
+    #[usage(name = "env", alias = "e")]
     Env(EnvArgs),
     /// Execute a command with tool(s) set
-    #[usage(name = "exec")]
+    #[usage(name = "exec", alias = "x")]
     Exec(ExecArgs),
     /// Formats mise.toml
     #[usage(name = "fmt")]
     Fmt(FmtArgs),
     /// Generate files for various tools/services
-    #[usage(name = "generate")]
+    #[usage(name = "generate", alias = "gen", alias_hidden = "g")]
     Generate(GenerateArgs),
     /// GitHub related commands
     #[usage(name = "github")]
@@ -5827,7 +5827,7 @@ pub enum Commands {
     #[usage(name = "edit")]
     Edit(EditArgs),
     /// Install a tool version
-    #[usage(name = "install")]
+    #[usage(name = "install", alias = "i")]
     Install(InstallArgs),
     /// Install a tool version to a specific path
     #[usage(name = "install-into")]
@@ -5836,19 +5836,19 @@ pub enum Commands {
     #[usage(name = "latest")]
     Latest(LatestArgs),
     /// Symlinks a tool version into mise
-    #[usage(name = "link")]
+    #[usage(name = "link", alias = "ln")]
     Link(LinkArgs),
     /// Sets/gets tool version in local .tool-versions or mise.toml
-    #[usage(name = "local")]
+    #[usage(name = "local", alias_hidden = "l")]
     Local(LocalArgs),
     /// Update lockfile checksums and URLs for all specified platforms
     #[usage(name = "lock")]
     Lock(LockArgs),
     /// List installed and active tool versions
-    #[usage(name = "ls")]
+    #[usage(name = "ls", alias = "list")]
     Ls(LsArgs),
     /// List runtime versions available for install.
-    #[usage(name = "ls-remote")]
+    #[usage(name = "ls-remote", alias_hidden("list-all", "list-remote"))]
     LsRemote(LsRemoteArgs),
     /// Run Model Context Protocol (MCP) server
     #[usage(name = "mcp")]
@@ -5863,10 +5863,10 @@ pub enum Commands {
     #[usage(name = "patrons")]
     Patrons(PatronsArgs),
     /// Manage plugins
-    #[usage(name = "plugins")]
+    #[usage(name = "plugins", alias = "p", alias_hidden("plugin", "plugin-list"))]
     Plugins(PluginsArgs),
     /// [experimental] Manage project dependencies
-    #[usage(name = "deps")]
+    #[usage(name = "deps", alias = "dep", alias_hidden = "prepare")]
     Deps(DepsArgs),
     /// Delete unused versions of tools
     #[usage(name = "prune")]
@@ -5881,7 +5881,7 @@ pub enum Commands {
     #[usage(name = "reshim")]
     Reshim(ReshimArgs),
     /// Run task(s)
-    #[usage(name = "run")]
+    #[usage(name = "run", alias = "r")]
     Run(RunArgs),
     /// Search for tools in the registry
     #[usage(name = "search")]
@@ -5890,13 +5890,13 @@ pub enum Commands {
     #[usage(name = "self-update")]
     SelfUpdate(SelfUpdateArgs),
     /// Set environment variables in mise.toml
-    #[usage(name = "set")]
+    #[usage(name = "set", alias_hidden("ev", "env-vars"))]
     Set(SetArgs),
     /// Manage settings
     #[usage(name = "settings")]
     Settings(SettingsArgs),
     /// Sets a tool version for the current session.
-    #[usage(name = "shell")]
+    #[usage(name = "shell", alias = "sh")]
     Shell(ShellArgs),
     /// Manage shell aliases.
     #[usage(name = "shell-alias")]
@@ -5908,7 +5908,7 @@ pub enum Commands {
     #[usage(name = "sync")]
     Sync(SyncArgs),
     /// Manage tasks
-    #[usage(name = "tasks")]
+    #[usage(name = "tasks", alias = "t", alias_hidden = "task")]
     Tasks(TasksArgs),
     /// Test a tool installs and executes
     #[usage(name = "test-tool")]
@@ -5935,22 +5935,22 @@ pub enum Commands {
     #[usage(name = "untrust")]
     Untrust(UntrustArgs),
     /// Removes installed tool versions from mise.toml
-    #[usage(name = "unuse")]
+    #[usage(name = "unuse", alias("rm", "remove"))]
     Unuse(UnuseArgs),
     /// Upgrades outdated tools
-    #[usage(name = "upgrade")]
+    #[usage(name = "upgrade", alias = "up")]
     Upgrade(UpgradeArgs),
     /// Generate a usage CLI spec
     #[usage(name = "usage")]
     Usage(UsageArgs),
     /// Installs a tool and adds the version to mise.toml.
-    #[usage(name = "use")]
+    #[usage(name = "use", alias = "u")]
     Use(UseArgs),
     /// Display the version of mise
-    #[usage(name = "version")]
+    #[usage(name = "version", alias = "v")]
     Version(VersionArgs),
     /// Run task(s) and watch for changes to rerun it
-    #[usage(name = "watch")]
+    #[usage(name = "watch", alias = "w")]
     Watch(WatchArgs),
     /// Display the installation path for a tool
     #[usage(name = "where")]

--- a/conformance/tests/subcommands.rs
+++ b/conformance/tests/subcommands.rs
@@ -236,3 +236,91 @@ fn the_emitted_spec_reads_the_way_a_handwritten_one_would() {
     // involved.
     insta::assert_snapshot!(Ex::to_kdl());
 }
+
+/// Commands that answer to more than one name.
+///
+/// mise has 91 of these — `i` for `install`, `x` for `exec`, `r` for `tasks run` — and
+/// until now the derive could not declare one, so a shadow of mise rejected invocations
+/// the real thing accepts.
+#[derive(Subcommands)]
+enum AliasedCommands {
+    /// Install a tool
+    #[usage(alias = "i", alias_hidden = "add")]
+    Install(AliasedInstallArgs),
+    /// Remove a tool
+    #[usage(alias("rm", "uninstall"))]
+    Remove(AliasedRemoveArgs),
+}
+
+/// Install a tool
+#[derive(Args)]
+struct AliasedInstallArgs {
+    /// What to install
+    #[usage(arg, name = "TOOL")]
+    tool: Option<String>,
+}
+
+/// Remove a tool
+#[derive(Args)]
+struct AliasedRemoveArgs {
+    /// Say nothing
+    #[usage(long)]
+    quiet: bool,
+}
+
+/// A tool with aliased commands
+#[derive(Cli)]
+#[usage(bin = "al")]
+struct Aliased {
+    #[usage(subcommand)]
+    command: Option<AliasedCommands>,
+}
+
+#[test]
+fn a_command_answers_to_its_aliases() {
+    for word in ["install", "i", "add"] {
+        let a = argv([word, "node@20"]);
+        let Some(AliasedCommands::Install(install)) =
+            Aliased::parse_from(&a).expect("should parse").command
+        else {
+            panic!("`{word}` should have selected install")
+        };
+        assert_eq!(install.tool.as_deref(), Some("node@20"));
+    }
+
+    for word in ["remove", "rm", "uninstall"] {
+        let a = argv([word, "--quiet"]);
+        let Some(AliasedCommands::Remove(remove)) =
+            Aliased::parse_from(&a).expect("should parse").command
+        else {
+            panic!("`{word}` should have selected remove")
+        };
+        assert!(remove.quiet);
+    }
+}
+
+#[test]
+fn the_spec_says_which_aliases_are_hidden() {
+    let spec: LibSpec = Aliased::to_kdl().parse().expect("valid spec");
+    let install = spec.cmd.subcommands.get("install").expect("install");
+    assert_eq!(install.aliases, vec!["i".to_string()]);
+    assert_eq!(install.hidden_aliases, vec!["add".to_string()]);
+
+    let remove = spec.cmd.subcommands.get("remove").expect("remove");
+    assert_eq!(
+        remove.aliases,
+        vec!["rm".to_string(), "uninstall".to_string()]
+    );
+    assert!(remove.hidden_aliases.is_empty());
+
+    // And usage-lib resolves them, which is how completions follow an alias. Its
+    // `subcommands` map is keyed by name only — the aliases live in a lookup built
+    // alongside it.
+    for word in ["install", "i", "add"] {
+        assert_eq!(
+            spec.cmd.find_subcommand(word).map(|c| c.name.as_str()),
+            Some("install"),
+            "usage-lib should resolve `{word}`"
+        );
+    }
+}

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -1124,9 +1124,13 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
         let name = format_ident!("COMMAND_{i}");
         let ty = in_module(&v.ty);
         let cmd_name = &v.name;
+        // Both kinds of alias go in the table, because the parser matches both; which of
+        // them help and completions mention is the metadata's business, below.
+        let aliases = v.aliases.iter().chain(&v.hidden_aliases);
         quote! {
             pub static #name: ::usage_argv::Command = ::usage_argv::Command {
                 name: #cmd_name,
+                aliases: &[#(#aliases),*],
                 ..*<#ty as ::usage_argv::spec::CommandArgs>::COMMAND
             };
         }
@@ -1156,12 +1160,16 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
                 quote!(<#ty as ::usage_argv::spec::CommandArgs>::META.long_about),
             ),
         };
+        // Which of the table's aliases are hidden. The visible ones are not listed
+        // anywhere: `cmd.aliases` minus these is what help and completions show.
+        let hidden = &v.hidden_aliases;
         quote! {
             pub static #name: ::usage_argv::spec::CommandMeta =
                 ::usage_argv::spec::CommandMeta {
                     cmd: &#cmd,
                     about: #about,
                     long_about: #long_about,
+                    hidden_aliases: &[#(#hidden),*],
                     ..*<#ty as ::usage_argv::spec::CommandArgs>::META
                 };
         }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -155,6 +155,11 @@
 //! something else. `required_unless` also needs somewhere to put "absent", so it takes
 //! an `Option` rather than a bare `String`.
 //!
+//! A `Subcommands` variant takes `name`, and the two ways to give a command another
+//! name: `alias = "i"` for one it should advertise, `alias_hidden = "add"` for one it
+//! should answer to quietly, each accepting several as a list. The parser matches both;
+//! the difference is only whether help and completions mention them.
+//!
 //! # What this version does not do
 //!
 //! Published early on purpose, so it can be used and argued with — but these are

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -1130,6 +1130,13 @@ pub struct Variant {
     pub name: String,
     /// The struct the variant wraps.
     pub ty: Type,
+    /// Other names this command answers to.
+    ///
+    /// Kept apart from [`hidden_aliases`](Self::hidden_aliases) only for the spec: the
+    /// parser matches both, and the difference is whether help and completions mention
+    /// them. mise has 67 of the first and 24 of the second.
+    pub aliases: Vec<String>,
+    pub hidden_aliases: Vec<String>,
     pub help: Option<String>,
     pub long_help: Option<String>,
 }
@@ -1156,16 +1163,27 @@ impl Subcommands {
             .map(Variant::from_variant)
             .collect::<syn::Result<Vec<_>>>()?;
 
+        // Every name a command answers to, its aliases included: the parser takes the
+        // first table entry that matches, so a name claimed twice means one of the two
+        // commands can never be reached and nothing would have said so.
         let mut seen: Vec<(&str, Span)> = Vec::new();
         for variant in &variants {
-            if let Some((_, first)) = seen.iter().find(|(n, _)| *n == variant.name) {
-                return Err(dup(
-                    variant.ty.span(),
-                    *first,
-                    &format!("two variants are both called `{}`", variant.name),
-                ));
+            for name in std::iter::once(&variant.name)
+                .chain(&variant.aliases)
+                .chain(&variant.hidden_aliases)
+            {
+                if let Some((_, first)) = seen.iter().find(|(n, _)| n == name) {
+                    return Err(dup(
+                        variant.ty.span(),
+                        *first,
+                        &format!(
+                            "`{name}` names two of these commands, counting aliases, so one \
+                             of them could never be reached"
+                        ),
+                    ));
+                }
+                seen.push((name, variant.ty.span()));
             }
-            seen.push((&variant.name, variant.ty.span()));
         }
 
         // Two variants cannot wrap the same struct. A command's values are collected
@@ -1207,23 +1225,42 @@ impl Variant {
     fn from_variant(variant: &syn::Variant) -> syn::Result<Self> {
         let (help, long_help) = doc_comment(&variant.attrs)?;
         let mut name = to_kebab(&variant.ident.to_string());
+        let mut aliases: Vec<String> = Vec::new();
+        let mut hidden_aliases: Vec<String> = Vec::new();
 
         for attr in attrs(&variant.attrs) {
             for meta in nested(attr)? {
                 let path = meta.path().clone();
                 match ident_of(&path).as_str() {
                     "name" => name = strip_dashes(&string_value(&meta)?),
+                    // One as a value or several as a list, as the relationship options do.
+                    "alias" => aliases.extend(selectors(&meta)?),
+                    "alias_hidden" => hidden_aliases.extend(selectors(&meta)?),
                     other => {
                         return Err(syn::Error::new_spanned(
                             path,
                             format!(
                                 "unknown option `{other}` on a variant; a subcommand \
-                                 variant takes `name` here, and its description comes \
-                                 from the doc comment"
+                                 variant takes `name`, `alias` and `alias_hidden` here, \
+                                 and its description comes from the doc comment"
                             ),
                         ));
                     }
                 }
+            }
+        }
+        for alias in aliases.iter().chain(&hidden_aliases) {
+            if alias.is_empty() {
+                return Err(syn::Error::new_spanned(
+                    &variant.ident,
+                    "an alias with no name would answer to nothing",
+                ));
+            }
+            if *alias == name {
+                return Err(syn::Error::new_spanned(
+                    &variant.ident,
+                    format!("`{alias}` is this command's own name, not another name for it"),
+                ));
             }
         }
 
@@ -1247,6 +1284,8 @@ impl Variant {
             ident: variant.ident.clone(),
             name,
             ty,
+            aliases,
+            hidden_aliases,
             help,
             long_help,
         })
@@ -1255,7 +1294,7 @@ impl Variant {
 
 #[cfg(test)]
 mod tests {
-    use super::Cli;
+    use super::{Cli, Subcommands};
 
     fn cli(body: &str) -> syn::Result<Cli> {
         Cli::from_input(&syn::parse_str::<syn::DeriveInput>(body).expect("valid Rust"))
@@ -1347,6 +1386,66 @@ mod tests {
             err.contains("only separator there is"),
             "unhelpful message: {err}"
         );
+    }
+
+    fn subcommands(body: &str) -> syn::Result<Subcommands> {
+        Subcommands::from_input(&syn::parse_str::<syn::DeriveInput>(body).expect("valid Rust"))
+    }
+
+    /// The message a bad enum produces.
+    fn enum_rejection(body: &str) -> String {
+        match subcommands(body) {
+            Ok(_) => panic!("should not have compiled"),
+            Err(e) => e.to_string(),
+        }
+    }
+
+    #[test]
+    fn an_alias_cannot_name_a_sibling() {
+        // The parser takes the first table entry that matches, so a name claimed twice
+        // leaves one command unreachable — silently, which is the part worth refusing.
+        let err = enum_rejection(
+            r#"
+            enum Commands {
+                Install(Install),
+                #[usage(alias = "install")]
+                Add(Add),
+            }
+        "#,
+        );
+        assert!(
+            err.contains("names two of these"),
+            "unhelpful message: {err}"
+        );
+
+        // Including two aliases that collide with each other rather than with a name.
+        let err = enum_rejection(
+            r#"
+            enum Commands {
+                #[usage(alias = "rm")]
+                Remove(Remove),
+                #[usage(alias_hidden = "rm")]
+                Delete(Delete),
+            }
+        "#,
+        );
+        assert!(
+            err.contains("names two of these"),
+            "unhelpful message: {err}"
+        );
+
+        // Distinct names and aliases are fine.
+        subcommands(
+            r#"
+            enum Commands {
+                #[usage(alias = "i", alias_hidden = "add")]
+                Install(Install),
+                #[usage(alias("rm", "uninstall"))]
+                Remove(Remove),
+            }
+        "#,
+        )
+        .expect("distinct aliases should compile");
     }
 
     #[test]

--- a/xtask/src/shadow.rs
+++ b/xtask/src/shadow.rs
@@ -264,12 +264,6 @@ fn emit_command(
         .map(|(name, sub)| (name, sub, Type::child(ty, name, sub, names)))
         .collect();
     for (_, sub, _) in &children {
-        for _ in &sub.aliases {
-            skipped.note("a command alias");
-        }
-        for _ in &sub.hidden_aliases {
-            skipped.note("a hidden command alias");
-        }
         if !sub.mounts.is_empty() {
             skipped.note("a `mount` on a command");
         }
@@ -366,12 +360,43 @@ fn emit_command(
             // Written whenever the variant name is not the command name: both derives
             // would otherwise kebab-case the variant and mostly get it right, and
             // "mostly" is not a grammar.
+            let mut opts: Vec<String> = Vec::new();
             if variant != **name {
+                opts.push(format!("name = {name:?}"));
+            }
+            // Both frameworks can declare these, so both shadows carry them: 91 of mise's
+            // commands answer to a second name, and a shadow that rejected `mise i` would
+            // be measuring a smaller CLI than the one it claims to shadow.
+            match dialect {
+                Dialect::Usage => {
+                    if !sub.aliases.is_empty() {
+                        opts.push(alias_list("alias", &sub.aliases));
+                    }
+                    if !sub.hidden_aliases.is_empty() {
+                        opts.push(alias_list("alias_hidden", &sub.hidden_aliases));
+                    }
+                }
+                // clap spells one and several differently, and repeating the singular
+                // form is not the same as the plural one.
+                Dialect::Clap => {
+                    match sub.aliases.as_slice() {
+                        [] => {}
+                        [one] => opts.push(format!("visible_alias = {one:?}")),
+                        many => opts.push(format!("visible_aliases = [{}]", quoted_list(many))),
+                    }
+                    match sub.hidden_aliases.as_slice() {
+                        [] => {}
+                        [one] => opts.push(format!("alias = {one:?}")),
+                        many => opts.push(format!("aliases = [{}]", quoted_list(many))),
+                    }
+                }
+            }
+            if !opts.is_empty() {
                 let attr = match dialect {
-                    Dialect::Usage => format!("    #[usage(name = {name:?})]\n"),
-                    Dialect::Clap => format!("    #[command(name = {name:?})]\n"),
+                    Dialect::Usage => "usage",
+                    Dialect::Clap => "command",
                 };
-                out.push_str(&attr);
+                out.push_str(&format!("    #[{attr}({})]\n", opts.join(", ")));
             }
             out.push_str(&format!("    {variant}({}),\n", sub_ty.args));
         }
@@ -768,6 +793,14 @@ fn quoted_list(values: &[String]) -> String {
         .join(", ")
 }
 
+/// `alias("a", "b")`, or `alias = "a"` for one.
+fn alias_list(option: &str, aliases: &[String]) -> String {
+    if let [one] = aliases {
+        return format!("{option} = {one:?}");
+    }
+    format!("{option}({})", quoted_list(aliases))
+}
+
 /// `conflicts("--a", "--b")`, or `conflicts = "--a"` for one.
 fn selector_list(option: &str, selectors: &[String]) -> String {
     if let [one] = selectors {
@@ -1068,10 +1101,11 @@ mod tests {
         let (_, skipped) = rendered(
             "name \"ex\"\nbin \"ex\"\ndefault_subcommand \"go\"\ncmd \"go\" {\n  alias \"g\"\n}\n",
         );
-        assert_eq!(skipped.counts.get("a command alias"), Some(&1));
         assert_eq!(
             skipped.counts.get("`default_subcommand` on a command"),
             Some(&1)
         );
+        // The alias is expressible, so it is carried rather than counted.
+        assert!(!skipped.counts.contains_key("a command alias"));
     }
 }


### PR DESCRIPTION
Stacked on #826. Closes the largest gap the mise shadow was reporting.

**91 of mise's commands have a second name** — `i` for `install`, `x` for `exec`, `rm`/`remove`/`delete`/`del` for `unset` — and the derive could not declare one, so a shadow of mise rejected invocations the real thing accepts. `gen-shadow` was counting them all as dropped.

## Where the gap actually was

Everything below the derive already worked: usage-argv's `Command` carries `aliases` and `find_subcommand` matches them, and the KDL writer emits them. Only the *declaration* was missing.

It belongs on the variant, not the struct, because the enum is where a command is named — the wrapped struct has no idea what its parent called it. That's the same seam `#[usage(name = "...")]` already used.

```rust
#[derive(usage::Subcommands)]
enum Commands {
    /// Install a tool
    #[usage(alias = "i", alias_hidden = "add")]
    Install(InstallArgs),
    /// Remove a tool
    #[usage(alias("rm", "uninstall"))]
    Remove(RemoveArgs),
}
```

The table gets both kinds, because the parser matches both; the metadata records which are hidden, since that is the only thing the distinction affects — whether help and completions mention them. An alias equal to the command's own name, or an empty one, is a compile error rather than a line that quietly does nothing.

## The shadow carries them now

Both dialects, which took a detail: clap spells one alias and several differently (`visible_alias = "x"` vs `visible_aliases = [...]`), and repeating the singular form is not the same as the plural one. `mise i node@20` and `mise x -- node -e 1` now parse through the shadow, with a gate test for each.

## Cost

353 instructions of the 51.3k parse (clap's grew by 33k, so the 117× ratio holds), and the dropped-property list is 91 entries shorter — the remaining ones are `default_subcommand`, 2 mounts, 2 restart tokens, 13 secondary flag forms, 3 `double_dash="automatic"` and one default on a collecting flag.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core subcommand routing and codegen for all derived CLIs; behavior change is broad (91 mise commands) but covered by conformance and gate tests, with a known small parse-cost increase.
> 
> **Overview**
> **Subcommands can declare alternate names** via `alias` / `alias_hidden` on enum variants (single value or list). Codegen wires both into parse tables and records hidden aliases in metadata so help/completions only advertise the visible set. Compile-time checks reject duplicate names across variants and aliases.
> 
> **Shadow generation** no longer counts command aliases as unsupported—it emits matching `#[usage(...)]` / clap `visible_alias` / `alias` attributes for both mise shadows. **PLAN.md** drops aliases from the shadow gap list and adds follow-up items: a fixed perf sentinel (shadow growth tripped the 1% gate by ~1.52%) and non-linear subcommand lookup.
> 
> **Tests** cover alias parsing (`mise i`, hidden `x`), KDL/spec hidden-alias metadata, usage-lib resolution, and gate integration tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2def5d2282ebf46ff280e0340ae4354b5c64b776. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added visible and hidden aliases for commands and subcommands, including common shorthand forms.
  - Visible aliases now appear in help and completions, while hidden aliases remain available for compatibility.
  - Alias metadata is preserved across generated CLI integrations.

- **Bug Fixes**
  - Improved command alias routing, including aliases used with arguments after `--`.
  - Variadic argument handling now consistently processes subsequent values after the separator.

- **Documentation**
  - Updated command alias and variadic argument behavior documentation.

- **Tests**
  - Added coverage for alias resolution, hidden aliases, collisions, and separator handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->