### PR TITLE
feat(bench): count what a parse allocates, and stop allocating for commands nobody ran

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -212,15 +212,25 @@ checked-in `mise.usage.kdl` for both parsers.
 
 Runtime targets, which gate:
 
-| measurement                        | clap, measured | target | result           |
-| ---------------------------------- | -------------- | ------ | ---------------- |
-| instructions, route + parse        | 5.96M          | < 100k | 50.9k, 117×      |
-| wall time, argv to parsed struct   | 490µs          | < 50µs | 2.1µs, 238×      |
-| heap allocations, successful parse | thousands      | 0      | not yet measured |
+| measurement                        | clap, measured | target | result            |
+| ---------------------------------- | -------------- | ------ | ----------------- |
+| instructions, route + parse        | 5.96M          | < 100k | 50.9k, 117×       |
+| wall time, argv to parsed struct   | 490µs          | < 50µs | 2.1µs, 238×       |
+| heap allocations, successful parse | 6,560          | 0      | 0 bare, 3–4 bound |
 
-Both gating targets are met, and not narrowly. The one number still owed is
-allocations on the derive path — usage-argv's own are asserted at zero, but the derive
-allocates a `String` per value, and nothing counts them yet.
+All three gating targets are met, and not narrowly. Allocations were the last one owed:
+a parse with nothing to bind allocates **nothing at all** at mise's scale — 211 commands
+and 711 flags, and the allocator is never reached — while binding three or four words
+costs three or four allocations, one per value. clap's tree costs **6,560** every time,
+so this is about 2,000× fewer.
+
+Getting there needed one fix and one correction. Defaults were being applied in `start`,
+which builds the partial for _every_ command in the CLI rather than the selected one, so a
+bare `mise` was allocating 60 times for defaults it would never read; they now run in
+`check`, guarded on whether the flag was given. And the counter itself was wrong — armed
+per thread but counting into a global — so parallel tests were counting each other and a
+4-allocation parse read as 24, intermittently. usage-argv's own counter had the same
+latent flaw and now counts per thread too.
 
 An earlier draft of these numbers said 48–58× rather than 117×, because it subtracted a
 baseline measured in a _separate_ no-op binary. Two binaries do measurably different

--- a/argv/tests/no_alloc.rs
+++ b/argv/tests/no_alloc.rs
@@ -12,7 +12,6 @@
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::cell::Cell;
 use std::ffi::OsStr;
-use std::sync::atomic::{AtomicUsize, Ordering};
 
 use usage_argv::{Arg, Command, DoubleDash, Event, Flag, Parser};
 
@@ -28,9 +27,12 @@ thread_local! {
     /// `const`-initialized so reading it cannot allocate, which inside a global
     /// allocator would recurse.
     static ARMED: Cell<bool> = const { Cell::new(false) };
+    /// Counted per thread as well as armed per thread. One test file with one test does
+    /// not need that today, but a global counter and a per-thread flag disagree the moment
+    /// a second test is added — which is how the gate's version of this counter came to
+    /// report a parse allocating 24 times when it allocates 4.
+    static ALLOCATIONS: Cell<usize> = const { Cell::new(0) };
 }
-
-static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
 
 /// Whether the calling thread is the one being measured.
 ///
@@ -40,11 +42,15 @@ fn armed() -> bool {
     ARMED.try_with(Cell::get).unwrap_or(false)
 }
 
+fn tally() {
+    if armed() {
+        let _ = ALLOCATIONS.try_with(|n| n.set(n.get() + 1));
+    }
+}
+
 unsafe impl GlobalAlloc for Counting {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        if armed() {
-            ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
-        }
+        tally();
         unsafe { System.alloc(layout) }
     }
 
@@ -53,9 +59,7 @@ unsafe impl GlobalAlloc for Counting {
     }
 
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
-        if armed() {
-            ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
-        }
+        tally();
         unsafe { System.realloc(ptr, layout, new_size) }
     }
 }
@@ -69,11 +73,11 @@ static ALLOCATOR: Counting = Counting;
 /// Only this thread is counted, so neither a sibling test nor the harness itself
 /// can contribute — both of which have produced phantom allocations here.
 fn count_allocations(f: impl FnOnce()) -> usize {
-    ALLOCATIONS.store(0, Ordering::Relaxed);
+    ALLOCATIONS.with(|n| n.set(0));
     ARMED.with(|a| a.set(true));
     f();
     ARMED.with(|a| a.set(false));
-    ALLOCATIONS.load(Ordering::Relaxed)
+    ALLOCATIONS.with(Cell::get)
 }
 
 static QUIET: Flag = Flag {

--- a/benches/gate/Cargo.toml
+++ b/benches/gate/Cargo.toml
@@ -14,3 +14,4 @@ clap = { version = "4", features = ["derive", "env"] }
 shadow-mise = { path = "../shadows/mise" }
 shadow-mise-clap = { path = "../shadows/mise-clap" }
 usage-argv = { path = "../../argv" }
+

--- a/benches/gate/tests/allocations.rs
+++ b/benches/gate/tests/allocations.rs
@@ -1,0 +1,152 @@
+//! How many times a parse reaches the allocator, at mise's scale.
+//!
+//! usage-argv's own test proves it allocates *nothing*; this is the layer above, where a
+//! value becomes a `String` and a command becomes a struct. That layer has to allocate, so
+//! the numbers here are a measurement rather than a zero — but the shape of them is a
+//! property worth pinning: a parse should cost what the *invocation* binds, and nothing
+//! for the 210 commands it did not go near.
+//!
+//! Run with `--nocapture` for the numbers.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+use std::ffi::OsStr;
+
+use clap::Parser as _;
+use shadow_mise::Cli;
+
+struct Counting;
+
+thread_local! {
+    /// Armed per thread, and counted per thread with it.
+    ///
+    /// Both halves have to be thread-local: the harness runs tests in parallel, so a
+    /// global count picked up whatever another test was allocating at the time. That read
+    /// as a parse allocating 24 times when it allocates 4, intermittently, depending on
+    /// which tests overlapped.
+    ///
+    /// `const`-initialized so reading them cannot allocate, which inside a global
+    /// allocator would recurse.
+    static ARMED: Cell<bool> = const { Cell::new(false) };
+    static ALLOCATIONS: Cell<usize> = const { Cell::new(0) };
+}
+
+/// Whether the calling thread is the one being measured.
+///
+/// `try_with` rather than `with`: during thread teardown the local is gone, and an
+/// allocation then must not panic.
+fn armed() -> bool {
+    ARMED.try_with(Cell::get).unwrap_or(false)
+}
+
+fn tally() {
+    if armed() {
+        let _ = ALLOCATIONS.try_with(|n| n.set(n.get() + 1));
+    }
+}
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        tally();
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        tally();
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static ALLOC: Counting = Counting;
+
+/// Allocations made while `f` runs, on this thread.
+fn count(f: impl FnOnce()) -> usize {
+    ALLOCATIONS.with(|n| n.set(0));
+    ARMED.with(|a| a.set(true));
+    f();
+    ARMED.with(|a| a.set(false));
+    ALLOCATIONS.with(Cell::get)
+}
+
+/// The fewest allocations a parse of these words was seen to make.
+///
+/// Warmed first and then measured several times, taking the least. The first parse on a
+/// fresh thread also pays for whatever the standard library and the allocator set up on
+/// first use — enough to read as 60 allocations rather than 3, which is what an earlier
+/// version of this test reported before it warmed up. None of that is the parser's, and
+/// none of it is paid twice.
+fn parsing(words: &[&str]) -> usize {
+    let argv: Vec<&OsStr> = words.iter().map(OsStr::new).collect();
+    let once = |argv: &Vec<&OsStr>| {
+        Cli::parse_from(argv).expect("should parse");
+    };
+    for _ in 0..3 {
+        count(|| once(&argv));
+    }
+    (0..3).map(|_| count(|| once(&argv))).min().unwrap_or(0)
+}
+
+#[test]
+fn nothing_bound_allocates_nothing() {
+    // The strongest form of the property: 211 commands, 711 flags, and a command line with
+    // no words in it costs the allocator nothing at all. The tables are `&'static`, so
+    // there is no tree to build and no per-command state to fill in.
+    let bare = parsing(&[]);
+    println!("allocations, bare `mise`: {bare}");
+    assert_eq!(
+        bare, 0,
+        "a parse with nothing to bind should allocate nothing"
+    );
+}
+
+#[test]
+fn a_parse_costs_what_it_binds() {
+    // Two invocations of different depth, so what is measured is the words rather than how
+    // far into the command tree they reach.
+    let shallow = parsing(&["use", "-g", "node@20"]);
+    let deep = parsing(&["settings", "set", "experimental", "true"]);
+    println!("allocations: `use -g node@20` {shallow}, `settings set …` {deep}");
+
+    // Loose on purpose: what this catches is a clone-per-flag or a per-command
+    // allocation creeping in, not a change of one or two in how a value is stored.
+    for (what, n) in [("use", shallow), ("settings set", deep)] {
+        assert!(
+            n <= 16,
+            "{n} allocations to bind a handful of words in `{what}` is more than that needs"
+        );
+    }
+}
+
+#[test]
+fn clap_pays_for_the_whole_cli() {
+    // The comparison the gate is for. clap builds its command tree on the way to parsing,
+    // and the tree is the CLI: 211 commands' worth of `String`s and `Vec`s, every time.
+    let words = ["mise", "use", "-g", "node@20"];
+    let argv: Vec<std::ffi::OsString> = words.iter().map(std::ffi::OsString::from).collect();
+    let once = |argv: &Vec<std::ffi::OsString>| {
+        shadow_mise_clap::Cli::try_parse_from(argv).expect("should parse");
+    };
+    for _ in 0..3 {
+        count(|| once(&argv));
+    }
+    let clap = (0..3)
+        .map(|_| count(|| once(&argv)))
+        .min()
+        .expect("three runs");
+    println!("allocations, clap `use -g node@20`: {clap}");
+
+    // No upper bound worth asserting: the number is what it is, and the point is its order
+    // of magnitude against the handful above. The lower bound keeps this test honest if
+    // the shadow ever stops building its tree at runtime, which would make the comparison
+    // meaningless rather than favourable.
+    assert!(
+        clap > 1_000,
+        "{clap} allocations is too few for a tree of 211 commands — is this measuring what \
+         it claims to?"
+    );
+}

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -715,17 +715,11 @@ fn partial_defaults(cli: &Cli) -> TokenStream {
     // Only the fields that declare one: `Partial`'s own initializer has already put
     // everything else at `Default::default()`, and a subcommand field holds a partial
     // that `#sub_starts` builds rather than a value.
-    let assignments = cli
-        .fields
-        .iter()
-        .filter(|f| f.default.is_some() && !matches!(f.kind, Kind::Subcommand { .. }))
-        .map(reset_to_default);
     quote! {
         let mut partial = Partial {
             #(#plain)*
             #sub_starts
         };
-        #(#assignments)*
     }
 }
 
@@ -1296,6 +1290,27 @@ fn displaced_guard(cli: &Cli, field: &Field) -> TokenStream {
 /// from the environment or a default.
 fn post_binding(cli: &Cli) -> TokenStream {
     let sub_check = subcommand_parts(cli).map(|p| p.check).unwrap_or_default();
+    // Applied here rather than in `start`, and this is not a detail: `start` builds the
+    // partial for *every* command in the CLI, selected or not, so a declared default was
+    // costing a `String` per default per command — 60 allocations to parse a bare `mise`,
+    // which is the CLI's size leaking into the invocation. `check` runs for the selected
+    // command only.
+    //
+    // Guarded on `__given_*`, which is what makes this safe to move: a negation that set a
+    // defaulted `bool` to false during the parse must not be undone here.
+    let declared_defaults = cli.fields.iter().filter_map(|f| {
+        if f.default.is_none() || matches!(f.kind, Kind::Subcommand { .. }) {
+            return None;
+        }
+        let given = format_ident!("__given_{}", f.ident);
+        let assign = reset_to_default(f);
+        Some(quote! {
+            if !partial.#given {
+                #assign
+            }
+        })
+    });
+
     let env_fallbacks = cli.fields.iter().filter_map(|f| {
         let ident = &f.ident;
         let given = format_ident!("__given_{}", ident);
@@ -1527,6 +1542,9 @@ fn post_binding(cli: &Cli) -> TokenStream {
     });
 
     quote! {
+        // Before the environment, which overrides a default when the flag was not given —
+        // the order `start` used to give them.
+        #(#declared_defaults)*
         #(#env_fallbacks)*
         // Before required-ness: "you gave two flags that cannot go together" is the
         // more useful of the two answers when a conflict has also left something


### PR DESCRIPTION
Stacked on #828. The last number the gate owed, and it turned up a real inefficiency on the way.

## The result

| invocation | usage | clap |
| --- | --- | --- |
| bare `mise` | **0** | — |
| `mise use -g node@20` | **3** | **6,560** |
| `mise settings set experimental true` | **4** | — |

At mise's scale — 211 commands, 711 flags — a parse with nothing to bind never reaches the allocator, and binding three or four words costs one allocation per value. clap builds its tree on the way to parsing and the tree is the CLI, every time. About **2,000× fewer**.

## The inefficiency it found

Declared defaults were applied in `start()`, which builds the partial for **every** command in the CLI rather than the selected one. So a bare `mise` allocated **60 `String`s** for defaults it would never read — the CLI's size leaking into the invocation, which is the one thing this design exists to avoid.

They run in `check()` now, which runs for the selected command only, guarded on `__given_*` so a negation that turned a defaulted `bool` off during the parse is not undone afterwards. That is what takes the bare parse from 60 allocations to 0.

## Two corrections to the instrument, which are the interesting part

- **The counter was wrong.** Armed per thread but counting into a *global*, so tests running in parallel counted each other's allocations: a 4-allocation parse read as 24, and a 0-allocation one as 3, intermittently, depending on which tests overlapped. Both halves are thread-local now. **usage-argv's own zero-alloc counter had the same latent flaw** — harmless with one test, wrong the moment a second is added — so it counts per thread too.
- **First-use costs are not the parser's.** The first parse on a fresh thread pays for standard-library setup; that alone read as 60 allocations rather than 3. The measurement warms up and takes the least of several runs, and says so.

I also dropped a property I had written and could not defend: comparing the mise shadow against a hand-written one-command CLI and asserting the counts were *equal*. They differ for reasons that have nothing to do with size, so the assertion was wrong even though the property it was reaching for is real. `bare mise == 0` states that property exactly, on the CLI that matters.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when defaults are applied in generated parse code (behavior should match for real invocations but affects every derived CLI); allocation tests rely on global allocator hooks and warmed measurements.
> 
> **Overview**
> Closes the gate’s **heap allocation** target with new `benches/gate/tests/allocations.rs` tests: bare `mise` at full shadow scale must allocate **0**, typical invocations only a handful (one per bound value), and clap stays **>1,000** on the same argv. **PLAN.md** records the results (0 / 3–4 vs clap’s 6,560) as all three runtime gates met.
> 
> **usage-derive** no longer applies field **defaults in `start()`** (which ran for every command’s partial). Defaults run in **`check()`** for the selected command only, guarded on `__given_*` so negated booleans stay correct—fixing ~60 spurious `String` allocations on an empty argv.
> 
> Allocation instrumentation in **`argv/tests/no_alloc.rs`** and the new gate tests uses **thread-local** armed flags and counters (not a global atomic), avoiding parallel-test flakiness; measurements **warm up** and take the minimum run to exclude first-use stdlib/allocator noise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bda275a7728f27850e426a762694fc948f3e6ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->