### PR TITLE
chore(ci): do not read a superseded perf run as a failed gate

### DIFF
--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -139,12 +139,14 @@ jobs:
   report:
     name: Report and gate
     needs: measure
-    # `always()` would run this after a *cancelled* measurement too, and then the
-    # artifact download fails and a superseded run reads as a failed gate. Pushing twice
-    # to a branch is enough to cause it, which on a stack is most pushes. Success or
-    # failure both have something to report; cancelled and skipped do not.
+    # A failed measurement still has something to report — that is the regression case —
+    # so `always()` stays: without a status-check function this job is skipped whenever
+    # `measure` fails, which is precisely when its comment matters. What has to go is the
+    # *cancelled* case: pushing twice to a branch cancels the run in progress, the
+    # artifact was never uploaded, and a superseded run reads as a failed gate.
     if: >-
-      (needs.measure.result == 'success' || needs.measure.result == 'failure')
+      always() && needs.measure.result != 'cancelled'
+      && needs.measure.result != 'skipped'
       && github.event.pull_request.user.login == 'jdx'
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -139,7 +139,13 @@ jobs:
   report:
     name: Report and gate
     needs: measure
-    if: always() && github.event.pull_request.user.login == 'jdx'
+    # `always()` would run this after a *cancelled* measurement too, and then the
+    # artifact download fails and a superseded run reads as a failed gate. Pushing twice
+    # to a branch is enough to cause it, which on a stack is most pushes. Success or
+    # failure both have something to report; cancelled and skipped do not.
+    if: >-
+      (needs.measure.result == 'success' || needs.measure.result == 'failure')
+      && github.event.pull_request.user.login == 'jdx'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
Independent of the parser stack — this is why #826 shows a red gate.

The `Report and gate` job runs under `always()`, so it also runs when the measurement it depends on was **cancelled**. `download-artifact` then fails, because a cancelled job uploaded nothing, and a superseded run reads as a failed gate:

```
X Canceling since a higher priority waiting request for perf-pr-826 exists
X Process completed with exit code 1.
```

Two pushes to the same branch is enough to trigger it — the workflow cancels the run in progress on purpose — so on a stack it happens on most pushes, and it says "regression" when it means "superseded". Success and failure both have something to report; cancelled and skipped do not.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow condition only; no application or security impact.
> 
> **Overview**
> Fixes **false red gates** on the perf PR workflow when a run is **superseded** by a newer push (`cancel-in-progress` cancels `measure` before the artifact exists).
> 
> The **`Report and gate`** job still uses **`always()`** so a failed **`measure`** (real regression) still posts the comment and fails the check. It now **does not run** when **`needs.measure.result`** is **`cancelled`** or **`skipped`**, avoiding a doomed **`download-artifact`** and a misleading failed gate. The **`jdx`** author filter is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2354728116062f1a8f2f6a5c2bea69c1dbc4a93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved pull request performance reporting reliability.
  * Reports now run after performance measurements succeed or fail.
  * Reports are skipped when measurements are cancelled or skipped.
  * Reporting is limited to eligible pull requests, reducing unnecessary or misleading results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->