### PR TITLE
fix(spec): make the config block survive being written out

### DIFF
--- a/lib/src/sdk/mod.rs
+++ b/lib/src/sdk/mod.rs
@@ -52,14 +52,38 @@ pub(crate) fn escape_py_docstring(s: &str) -> String {
     s.replace('\\', r"\\").replace(r#"""""#, r#"\"\"\""#)
 }
 
-/// Escape backslashes and double quotes for Python string literals.
-pub(crate) fn escape_py_string(s: &str) -> String {
-    s.replace('\\', r"\\").replace('"', r#"\""#)
+/// Escape a string for a double-quoted literal.
+///
+/// Backslashes, quotes, and control characters — the last of these because neither language
+/// can carry one literally inside a quoted string, so a value with a newline in it wrote a
+/// module that fails to import rather than one that says something wrong. Help text and
+/// config defaults both really do contain them.
+///
+/// Python and TypeScript spell all of these the same way, so one function serves both.
+fn escape_string_literal(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str(r"\\"),
+            '"' => out.push_str(r#"\""#),
+            '\n' => out.push_str(r"\n"),
+            '\r' => out.push_str(r"\r"),
+            '\t' => out.push_str(r"\t"),
+            c if c.is_control() => out.push_str(&format!("\\x{:02x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out
 }
 
-/// Escape backslashes and double quotes for TypeScript string literals.
+/// Escape a string for a Python literal.
+pub(crate) fn escape_py_string(s: &str) -> String {
+    escape_string_literal(s)
+}
+
+/// Escape a string for a TypeScript literal.
 pub(crate) fn escape_ts_string(s: &str) -> String {
-    s.replace('\\', r"\\").replace('"', r#"\""#)
+    escape_string_literal(s)
 }
 
 /// A simple code writer with indentation management.

--- a/lib/src/sdk/python/mod.rs
+++ b/lib/src/sdk/python/mod.rs
@@ -138,22 +138,24 @@ fn render_types(spec: &Spec, package_name: &str, source_file: &Option<String>) -
             // none is declared — a spec may say `data_type=float default="1.5"`, and the
             // declaration is what the generated field is typed as. No `#true`-spelling or
             // quote-stripping to undo any more: the spec keeps values, not source text.
-            let default = match (&prop.default, prop.data_type) {
-                (None, _) => String::new(),
-                (Some(v), SpecDataTypes::Boolean) => match v {
-                    SpecConfigValue::Bool(false) => " = False".to_string(),
-                    SpecConfigValue::String(s) if s == "false" => " = False".to_string(),
-                    _ => " = True".to_string(),
-                },
-                (Some(v), SpecDataTypes::Integer | SpecDataTypes::Float) => {
-                    format!(" = {}", v.display())
-                }
-                (Some(SpecConfigValue::Bool(b)), SpecDataTypes::Null) => {
+            // A bare Python literal only for a value that *is* one. Anything else is a
+            // quoted string, escaped.
+            //
+            // This is generated code that gets imported, so text from the spec must never
+            // reach it unquoted: a `data_type="integer"` whose default is the string
+            // `__import__("os").system(…)` would otherwise be written as an expression and
+            // run on import. Numeric strings are read as numbers when the spec parses, so
+            // by here a `String` is a string.
+            let default = match &prop.default {
+                None => String::new(),
+                Some(SpecConfigValue::Bool(b)) => {
                     format!(" = {}", if *b { "True" } else { "False" })
                 }
-                (Some(SpecConfigValue::Int(i)), SpecDataTypes::Null) => format!(" = {i}"),
-                (Some(SpecConfigValue::Float(f)), SpecDataTypes::Null) => format!(" = {f}"),
-                (Some(v), _) => format!(" = \"{}\"", escape_py_string(&v.display())),
+                Some(SpecConfigValue::Int(i)) => format!(" = {i}"),
+                Some(SpecConfigValue::Float(f)) => format!(" = {f:?}"),
+                Some(SpecConfigValue::String(s)) => {
+                    format!(" = \"{}\"", escape_py_string(s))
+                }
             };
             if let Some(help) = &prop.help {
                 w.line(&format!("# {}", sanitize_py_comment(help)));
@@ -1034,6 +1036,55 @@ mod tests {
         let types = get_file(&output, "types.py");
         assert!(types.contains("class MyappConfig"));
         insta::assert_snapshot!(types);
+    }
+
+    /// A default whose text is not the type it claims to be must not become an expression.
+    #[test]
+    fn test_python_config_default_is_never_an_expression() {
+        // types.py is imported, so anything written into it unquoted runs.
+        //
+        // The route this test was written for — `data_type=integer` beside a default of
+        // arbitrary text — no longer parses at all; see
+        // `a_default_the_declared_type_cannot_read_is_refused`. But a *string*-typed default
+        // legitimately holds arbitrary text, which is the surface that still exists and the
+        // one the generator has to quote. Two defences, and this is the second.
+        let spec: Spec = r##"
+            bin "myapp"
+            config {
+                prop "cmd" data_type=string default="__import__('os').system('touch /tmp/pwned')"
+                prop "quoteful" data_type=string default="he said \"hi\""
+                prop "multiline" data_type=string default="two\nlines"
+            }
+        "##
+        .parse()
+        .unwrap();
+        let output = crate::sdk::generate(&spec, &make_opts());
+        let types = get_file(&output, "types.py");
+
+        assert!(
+            !types.contains("= __import__"),
+            "a string default must not be emitted as an expression:\n{types}"
+        );
+        assert!(
+            types.contains(r#"= "__import__('os').system('touch /tmp/pwned')""#),
+            "it should be a quoted string:\n{types}"
+        );
+        // And a string containing quotes stays escaped rather than closing the literal.
+        assert!(
+            types.contains(r#"= "he said \"hi\"""#),
+            "quotes inside a default should be escaped:\n{types}"
+        );
+        // A control character cannot be carried literally inside a Python literal at all: a
+        // newline in a default wrote a module that fails to *import*, which is a worse failure
+        // than one that says something wrong.
+        assert!(
+            types.contains(r#"= "two\nlines""#),
+            "a newline in a default must be escaped:\n{types}"
+        );
+        assert!(
+            !types.lines().any(|line| line.trim() == "lines\""),
+            "the literal was split across lines:\n{types}"
+        );
     }
 
     /// Hidden command, hidden arg/flag — covers early-return and empty dataclass paths.

--- a/lib/src/sdk/python/mod.rs
+++ b/lib/src/sdk/python/mod.rs
@@ -8,7 +8,7 @@ use crate::sdk::{
 };
 use crate::spec::arg::SpecDoubleDashChoices;
 use crate::spec::cmd::SpecCommand;
-use crate::spec::config::SpecConfigProp;
+use crate::spec::config::{SpecConfigProp, SpecConfigValue};
 use crate::spec::data_types::SpecDataTypes;
 use crate::{Spec, SpecArg, SpecFlag};
 
@@ -134,21 +134,26 @@ fn render_types(spec: &Spec, package_name: &str, source_file: &Option<String>) -
 
         for (name, prop) in required.iter().chain(optional.iter()) {
             let py_type = config_prop_type(prop);
-            let default = if let Some(d) = &prop.default {
-                match prop.data_type {
-                    SpecDataTypes::Boolean => match d.as_str() {
-                        "#true" | "true" => " = True".to_string(),
-                        "#false" | "false" => " = False".to_string(),
-                        other => format!(" = {other}"),
-                    },
-                    SpecDataTypes::Integer | SpecDataTypes::Float => {
-                        let numeric = d.trim_matches('"');
-                        format!(" = {numeric}")
-                    }
-                    _ => format!(" = \"{}\"", escape_py_string(d)),
+            // Rendered by the *declared* type, falling back to the literal's own when
+            // none is declared — a spec may say `data_type=float default="1.5"`, and the
+            // declaration is what the generated field is typed as. No `#true`-spelling or
+            // quote-stripping to undo any more: the spec keeps values, not source text.
+            let default = match (&prop.default, prop.data_type) {
+                (None, _) => String::new(),
+                (Some(v), SpecDataTypes::Boolean) => match v {
+                    SpecConfigValue::Bool(false) => " = False".to_string(),
+                    SpecConfigValue::String(s) if s == "false" => " = False".to_string(),
+                    _ => " = True".to_string(),
+                },
+                (Some(v), SpecDataTypes::Integer | SpecDataTypes::Float) => {
+                    format!(" = {}", v.display())
                 }
-            } else {
-                String::new()
+                (Some(SpecConfigValue::Bool(b)), SpecDataTypes::Null) => {
+                    format!(" = {}", if *b { "True" } else { "False" })
+                }
+                (Some(SpecConfigValue::Int(i)), SpecDataTypes::Null) => format!(" = {i}"),
+                (Some(SpecConfigValue::Float(f)), SpecDataTypes::Null) => format!(" = {f}"),
+                (Some(v), _) => format!(" = \"{}\"", escape_py_string(&v.display())),
             };
             if let Some(help) = &prop.help {
                 w.line(&format!("# {}", sanitize_py_comment(help)));

--- a/lib/src/spec/config.rs
+++ b/lib/src/spec/config.rs
@@ -23,23 +23,114 @@ pub enum SpecConfigValue {
     String(String),
 }
 
+/// What a KDL value could not be read as.
+pub(crate) enum ValueError {
+    /// An integer KDL accepts (it parses `i128`) that does not fit the spec's `i64`.
+    IntegerOutOfRange,
+    /// `#inf`, `#-inf` or `#nan`, which KDL accepts and nothing downstream can carry.
+    NotFinite,
+    /// A string default that the declared type cannot read — `data_type="integer"` beside
+    /// `default="lots"`. Carries the type it should have been.
+    DoesNotFitType(SpecDataTypes),
+}
+
+impl ValueError {
+    /// What to tell whoever wrote the spec.
+    pub(crate) fn describe(&self) -> String {
+        match self {
+            Self::IntegerOutOfRange => "config default does not fit in a 64-bit integer".into(),
+            Self::NotFinite => {
+                "config default must be a finite number: `#inf` and `#nan` cannot be written \
+                 back out, rendered, or carried in JSON"
+                    .into()
+            }
+            Self::DoesNotFitType(ty) => {
+                format!("config default cannot be read as the declared type `{ty}`")
+            }
+        }
+    }
+}
+
 impl SpecConfigValue {
-    fn from_kdl(value: &kdl::KdlValue) -> Option<Self> {
-        match value {
+    /// `None` only for an explicit `#null`.
+    ///
+    /// An out-of-range integer is an error rather than a `None`: returning "absent" for a
+    /// number somebody wrote loses their default silently, and every consumer downstream —
+    /// the writer, the SDKs — then reports the property as having none.
+    pub(crate) fn from_kdl(value: &kdl::KdlValue) -> Result<Option<Self>, ValueError> {
+        Ok(match value {
             kdl::KdlValue::Bool(b) => Some(Self::Bool(*b)),
-            kdl::KdlValue::Integer(i) => i64::try_from(*i).ok().map(Self::Int),
+            kdl::KdlValue::Integer(i) => Some(Self::Int(
+                i64::try_from(*i).map_err(|_| ValueError::IntegerOutOfRange)?,
+            )),
+            // Not merely unusual: `serde_json` writes a non-finite float as `null`, so
+            // `usage g json` silently reported the property as having no default at all,
+            // and the Python generator emitted a bare `inf` — which is a `NameError`, not a
+            // number. There is nowhere for this value to go, so it is refused where it is
+            // written rather than lost three consumers later.
+            kdl::KdlValue::Float(f) if !f.is_finite() => return Err(ValueError::NotFinite),
             kdl::KdlValue::Float(f) => Some(Self::Float(*f)),
             kdl::KdlValue::String(s) => Some(Self::String(s.clone())),
             kdl::KdlValue::Null => None,
+        })
+    }
+
+    /// A KDL entry for this value.
+    ///
+    /// No special handling for a whole float: `KdlValue::Float(1.0)` is written `1.0` and
+    /// read back as a float. (Reviewed as a risk — that a `1.0` would render as `1` and
+    /// reparse as an integer — and measured not to happen, including `1e3` normalizing to
+    /// `1000.0`. `a_whole_float_stays_a_float` pins it.)
+    fn to_kdl_entry(&self, key: &str) -> KdlEntry {
+        match self {
+            // Through `string_entry`, like every other string this crate writes: the kdl
+            // crate renders a control character literally and the result cannot be read
+            // back. Building the entry by hand here meant a default containing one — help
+            // text with a colour escape in it, say — wrote a spec that failed to reparse,
+            // which is the exact failure this change exists to fix.
+            Self::String(s) => string_entry(Some(key), s),
+            Self::Bool(b) => KdlEntry::new_prop(key, kdl::KdlValue::Bool(*b)),
+            Self::Int(i) => KdlEntry::new_prop(key, kdl::KdlValue::Integer(*i as i128)),
+            Self::Float(f) => KdlEntry::new_prop(key, kdl::KdlValue::Float(*f)),
         }
     }
 
-    fn to_kdl(&self) -> kdl::KdlValue {
-        match self {
-            Self::Bool(b) => kdl::KdlValue::Bool(*b),
-            Self::Int(i) => kdl::KdlValue::Integer(*i as i128),
-            Self::Float(f) => kdl::KdlValue::Float(*f),
-            Self::String(s) => kdl::KdlValue::String(s.clone()),
+    /// The same value read as the type the prop declares.
+    ///
+    /// A spec may write the value as a string and the type as a number —
+    /// `data_type="float" default="1.5"` — and reading it as declared means every consumer
+    /// downstream sees a number.
+    ///
+    /// A string the declared type *cannot* read is an error. It used to stay a string, which
+    /// kept it away from anything that would treat its text as a number but left the spec
+    /// saying two contradictory things: the Python generator then emitted an `int` field
+    /// whose default is `"lots"`, and a 20-digit number written in quotes bypassed the
+    /// range check that the same number unquoted would have hit. Refusing it is both safe
+    /// and honest, and across mise's 280 settings — the largest registry in the fleet —
+    /// there is not one string default that fails to read as its declared type.
+    fn coerced_to(self, data_type: SpecDataTypes) -> Result<Self, ValueError> {
+        let Self::String(text) = &self else {
+            // The other direction, which only matters for a declared `string`: an unquoted
+            // `default=4` on a string-typed prop left the value a number, so the generated
+            // Python field was typed `str` and defaulted to `4`. Every other declared type is
+            // a number or a boolean, and one of *those* written as a bare value is already the
+            // right shape.
+            return Ok(match data_type {
+                SpecDataTypes::String => Self::String(self.display()),
+                _ => self,
+            });
+        };
+        let mismatch = || ValueError::DoesNotFitType(data_type);
+        match data_type {
+            SpecDataTypes::Integer => text.parse().map(Self::Int).map_err(|_| mismatch()),
+            SpecDataTypes::Float => match text.parse::<f64>() {
+                // The same reason as above, by the other road: `default="inf"` for a float.
+                Ok(f) if !f.is_finite() => Err(ValueError::NotFinite),
+                Ok(f) => Ok(Self::Float(f)),
+                Err(_) => Err(mismatch()),
+            },
+            SpecDataTypes::Boolean => text.parse().map(Self::Bool).map_err(|_| mismatch()),
+            _ => Ok(self),
         }
     }
 
@@ -123,7 +214,14 @@ impl SpecConfig {
                     let mut prop = SpecConfigProp::default();
                     for (k, v) in node.props() {
                         match k {
-                            "default" => prop.default = SpecConfigValue::from_kdl(v.value),
+                            "default" => {
+                                prop.default = match SpecConfigValue::from_kdl(v.value) {
+                                    Ok(value) => value,
+                                    Err(err) => {
+                                        bail_parse!(ctx, v.entry.span(), "{}", err.describe())
+                                    }
+                                }
+                            }
                             "default_note" => prop.default_note = Some(v.ensure_string()?),
                             "data_type" => prop.data_type = v.ensure_string()?.parse()?,
                             "env" => prop.env = v.ensure_string()?.to_string().into(),
@@ -132,6 +230,16 @@ impl SpecConfig {
                             k => bail_parse!(ctx, node.span(), "unsupported config prop key {k}"),
                         }
                     }
+                    // After the loop, not inside it: `data_type` may be written after
+                    // `default` on the same node, and the declared type is what decides how
+                    // the value is read.
+                    prop.default = match prop.default.map(|v| v.coerced_to(prop.data_type)) {
+                        None => None,
+                        Some(Ok(value)) => Some(value),
+                        Some(Err(err)) => {
+                            bail_parse!(ctx, node.span(), "{}", err.describe())
+                        }
+                    };
                     config.props.insert(key, prop);
                 }
                 k => bail_parse!(ctx, node.node.name().span(), "unsupported config key {k}"),
@@ -197,9 +305,11 @@ impl SpecConfigProp {
 impl SpecConfigProp {
     fn to_kdl_node(&self, key: String) -> KdlNode {
         let mut node = KdlNode::new("prop");
-        node.push(KdlEntry::new(key));
+        // The key too: a dotted path is unlikely to hold anything exotic, but "unlikely"
+        // is not the standard the rest of the writer holds itself to.
+        node.push(string_entry(None, &key));
         if let Some(default) = &self.default {
-            node.push(KdlEntry::new_prop("default", default.to_kdl()));
+            node.push(default.to_kdl_entry("default"));
         }
         // Written, unlike before: a type that is parsed and not serialized is a type that
         // survives exactly one hop.
@@ -248,6 +358,19 @@ impl From<&SpecConfig> for KdlNode {
 
 #[cfg(test)]
 mod tests {
+    /// The reason inside a parse error.
+    ///
+    /// `UsageErr::InvalidInput` renders as "Invalid usage config" whatever went wrong — the
+    /// specifics are the diagnostic's label. Asserting on that matters here: a test that only
+    /// checks `is_err()` passes just as happily when the spec was refused for some unrelated
+    /// reason, which is how a check gets credit for work it is not doing.
+    fn detail_of(err: &crate::error::UsageErr) -> String {
+        match err {
+            crate::error::UsageErr::InvalidInput(detail, _, _) => detail.clone(),
+            other => other.to_string(),
+        }
+    }
+
     use super::SpecConfigValue;
     use crate::Spec;
     use insta::assert_snapshot;
@@ -279,6 +402,125 @@ config {
             prop user default=admin env=USER help="User to run as"
         }
         "##);
+    }
+
+    #[test]
+    fn a_default_the_declared_type_cannot_read_is_refused() {
+        // It used to stay a string. That kept it away from anything treating its text as a
+        // number — the point of the original fix — but left the spec asserting two
+        // contradictory things, and the Python generator then wrote an `int` field defaulting
+        // to `"__import__('os')"` in quotes. Refusing it is safe *and* honest.
+        //
+        // Not a theoretical strictness: across mise's 280 settings, the largest registry in
+        // the fleet, every string default reads as its declared type.
+        for src in [
+            "prop \"nope\" data_type=\"integer\" default=\"__import__('os')\"",
+            "prop \"nope\" data_type=\"boolean\" default=\"perhaps\"",
+            // The quoted road to the range error the unquoted number already hit.
+            "prop \"nope\" data_type=\"integer\" default=\"99999999999999999999\"",
+        ] {
+            let spec = format!("name \"ex\"\nbin \"ex\"\nconfig {{\n  {src}\n}}\n");
+            let err = Spec::parse(&Default::default(), &spec)
+                .expect_err(&format!("should not parse: {src}"));
+            let detail = detail_of(&err);
+            assert!(
+                detail.contains("declared type") || detail.contains("64-bit integer"),
+                "refused for the wrong reason: {detail}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_declared_string_holds_a_string_however_it_was_written() {
+        // `type="string" default=4` left the value a number, so the generated Python field was
+        // typed `str` and defaulted to `4` — the declared type and the emitted literal
+        // disagreeing, which is the whole thing this pass is about.
+        let spec = Spec::parse(
+            &Default::default(),
+            "name \"x\"\nbin \"x\"\nconfig {\n  prop \"a\" data_type=\"string\" default=4\n  prop \"b\" data_type=\"string\" default=#true\n}\n",
+        )
+        .expect("should parse");
+        assert_eq!(
+            spec.config.props["a"].default,
+            Some(SpecConfigValue::String("4".into()))
+        );
+        assert_eq!(
+            spec.config.props["b"].default,
+            Some(SpecConfigValue::String("true".into()))
+        );
+    }
+
+    #[test]
+    fn a_default_that_is_not_a_finite_number_is_refused() {
+        // KDL accepts `#inf` and `#nan`; nothing downstream can carry one. `serde_json`
+        // writes a non-finite float as `null`, so `usage g json` reported the property as
+        // having no default at all, and the Python generator emitted a bare `inf`, which is a
+        // `NameError` rather than a number. Measured, not assumed: both were the behaviour
+        // before this check.
+        for value in ["#inf", "#-inf", "#nan", "\"inf\" data_type=\"float\""] {
+            let spec =
+                format!("name \"ex\"\nbin \"ex\"\nconfig {{\n  prop \"a\" default={value}\n}}\n");
+            let err = Spec::parse(&Default::default(), &spec)
+                .expect_err(&format!("should not parse: default={value}"));
+            let detail = detail_of(&err);
+            assert!(
+                detail.contains("finite"),
+                "refused for the wrong reason: {detail}"
+            );
+        }
+        // A finite float is untouched.
+        let spec = Spec::parse(
+            &Default::default(),
+            "name \"ex\"\nbin \"ex\"\nconfig {\n  prop \"a\" default=1.5\n}\n",
+        )
+        .expect("should parse");
+        assert_eq!(
+            spec.config.props["a"].default,
+            Some(SpecConfigValue::Float(1.5))
+        );
+    }
+
+    #[test]
+    fn a_default_a_reader_cannot_render_is_still_written_readably() {
+        // `string_entry` exists because the kdl crate writes some values in a form this
+        // crate cannot read back: a control character goes out literally, and the result
+        // fails to reparse. Help text really does contain them — a CLI that colours its
+        // help has an escape character in the middle of it — and so, therefore, does a
+        // default. The typed-default writer built its entry by hand and skipped that
+        // protection, so the one hop this whole change is about broke again for exactly
+        // one shape of value.
+        let spec: Spec =
+            "name \"ex\"\nbin \"ex\"\nconfig {\n  prop \"prompt\" default=\"a\\u{1b}[0mb\"\n}\n"
+                .parse()
+                .expect("should parse");
+        assert_eq!(
+            spec.config.props["prompt"].default,
+            Some(SpecConfigValue::String("a\u{1b}[0mb".to_string()))
+        );
+
+        let written = spec.to_string();
+        let reparsed: Spec = written
+            .parse()
+            .unwrap_or_else(|e| panic!("written spec does not parse: {e}\n{written}"));
+        assert_eq!(
+            reparsed.config.props["prompt"].default,
+            spec.config.props["prompt"].default,
+        );
+
+        // The key travels the same road. Nothing sensible puts a control character in a
+        // dotted path, but the writer's job is to write back what it was given whatever that
+        // was, and "nothing sensible would" is not a guarantee about what a spec holds.
+        let spec: Spec = "name \"ex\"\nbin \"ex\"\nconfig {\n  prop \"a\\u{1b}b\" default=1\n}\n"
+            .parse()
+            .expect("should parse");
+        let written = spec.to_string();
+        let reparsed: Spec = written
+            .parse()
+            .unwrap_or_else(|e| panic!("written spec does not parse: {e}\n{written}"));
+        assert_eq!(
+            reparsed.config.props.keys().collect::<Vec<_>>(),
+            spec.config.props.keys().collect::<Vec<_>>(),
+        );
     }
 
     #[test]
@@ -317,6 +559,76 @@ config {
         // difference between keeping a value and keeping its spelling.
         assert_eq!(
             round_tripped.config.props["shell"].default,
+            Some(SpecConfigValue::String("true".into()))
+        );
+    }
+
+    #[test]
+    fn a_whole_float_stays_a_float() {
+        // A pin rather than a fix: review raised that `Float(1.0)` might render as `1` and
+        // come back an integer. It does not — kdl writes `1.0` — and this keeps it that way.
+        let spec: Spec = "name \"ex\"\nbin \"ex\"\nconfig {\n  prop \"rate\" default=1.0\n}\n"
+            .parse()
+            .unwrap();
+        assert_eq!(
+            spec.config.props["rate"].default,
+            Some(SpecConfigValue::Float(1.0))
+        );
+
+        let written = spec.to_string();
+        let round_tripped: Spec = written.parse().unwrap();
+        assert_eq!(
+            round_tripped.config.props["rate"].default,
+            Some(SpecConfigValue::Float(1.0)),
+            "a whole float should not come back an integer: {written}"
+        );
+    }
+
+    #[test]
+    fn a_default_too_large_for_an_i64_is_an_error() {
+        // KDL parses integers as `i128`. Reading one that does not fit as "no default" loses
+        // a number somebody wrote, and every consumer downstream then reports the property
+        // as having none.
+        let err = Spec::parse(
+            &Default::default(),
+            "config {\n  prop \"big\" default=99999999999999999999\n}\n",
+        )
+        .expect_err("an out-of-range default should not be silently dropped");
+        match err {
+            crate::error::UsageErr::InvalidInput(msg, _, _) => {
+                assert!(msg.contains("64-bit integer"), "unhelpful message: {msg}");
+            }
+            err => panic!("unexpected error: {err:?}"),
+        }
+    }
+
+    #[test]
+    fn a_declared_type_decides_how_a_default_is_read() {
+        // A spec may write the value as a string and the type as a number. Reading it as
+        // declared means consumers see a number — and, just as important, that a string
+        // which is *not* a number stays a string rather than being handed to something that
+        // will treat its text as one.
+        let spec: Spec = r#"
+name "ex"
+bin "ex"
+config {
+    prop "rate" data_type="float" default="1.5"
+    prop "jobs" data_type="integer" default="4"
+    prop "shell" data_type="string" default="true"
+}
+"#
+        .parse()
+        .unwrap();
+        assert_eq!(
+            spec.config.props["rate"].default,
+            Some(SpecConfigValue::Float(1.5))
+        );
+        assert_eq!(
+            spec.config.props["jobs"].default,
+            Some(SpecConfigValue::Int(4))
+        );
+        assert_eq!(
+            spec.config.props["shell"].default,
             Some(SpecConfigValue::String("true".into()))
         );
     }

--- a/lib/src/spec/config.rs
+++ b/lib/src/spec/config.rs
@@ -8,6 +8,82 @@ use crate::spec::context::ParsingContext;
 use crate::spec::data_types::SpecDataTypes;
 use crate::spec::helpers::{string_entry, NodeHelper};
 
+/// A config property's value, as declared.
+///
+/// Typed rather than a `String` because the previous version stored the KDL *source* form
+/// — `KdlValue::to_string()` — so a `default="4"` was read back as the four characters
+/// `"4"` with its quotes, and writing it out again added another pair. Each round trip
+/// added a layer. Keeping the value means the writer can render it once, correctly.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum SpecConfigValue {
+    Bool(bool),
+    Int(i64),
+    Float(f64),
+    String(String),
+}
+
+impl SpecConfigValue {
+    fn from_kdl(value: &kdl::KdlValue) -> Option<Self> {
+        match value {
+            kdl::KdlValue::Bool(b) => Some(Self::Bool(*b)),
+            kdl::KdlValue::Integer(i) => i64::try_from(*i).ok().map(Self::Int),
+            kdl::KdlValue::Float(f) => Some(Self::Float(*f)),
+            kdl::KdlValue::String(s) => Some(Self::String(s.clone())),
+            kdl::KdlValue::Null => None,
+        }
+    }
+
+    fn to_kdl(&self) -> kdl::KdlValue {
+        match self {
+            Self::Bool(b) => kdl::KdlValue::Bool(*b),
+            Self::Int(i) => kdl::KdlValue::Integer(*i as i128),
+            Self::Float(f) => kdl::KdlValue::Float(*f),
+            Self::String(s) => kdl::KdlValue::String(s.clone()),
+        }
+    }
+
+    /// The value as a human would read it, for docs and help output.
+    pub fn display(&self) -> String {
+        match self {
+            Self::Bool(b) => b.to_string(),
+            Self::Int(i) => i.to_string(),
+            Self::Float(f) => f.to_string(),
+            Self::String(s) => s.clone(),
+        }
+    }
+}
+
+impl From<bool> for SpecConfigValue {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<i64> for SpecConfigValue {
+    fn from(value: i64) -> Self {
+        Self::Int(value)
+    }
+}
+
+impl From<f64> for SpecConfigValue {
+    fn from(value: f64) -> Self {
+        Self::Float(value)
+    }
+}
+
+impl From<&str> for SpecConfigValue {
+    fn from(value: &str) -> Self {
+        Self::String(value.to_string())
+    }
+}
+
+impl From<String> for SpecConfigValue {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
 #[derive(Debug, Default, Clone, Serialize)]
 #[non_exhaustive]
 pub struct SpecConfig {
@@ -32,10 +108,22 @@ impl SpecConfig {
                 "prop" => {
                     let key = node.arg(0)?;
                     let key = key.ensure_string()?.to_string();
+                    // A `prop` with children used to parse and lose them: the loop below
+                    // reads properties only, so `prop "a" { prop "b" }` kept `a` and
+                    // dropped `b` without a word. Nesting is spelled with a dotted key.
+                    if let Some(children) = node.node.children() {
+                        if let Some(child) = children.nodes().first() {
+                            bail_parse!(
+                                ctx,
+                                child.name().span(),
+                                "config props cannot nest; write the key as \"a.b\""
+                            );
+                        }
+                    }
                     let mut prop = SpecConfigProp::default();
                     for (k, v) in node.props() {
                         match k {
-                            "default" => prop.default = v.value.to_string().into(),
+                            "default" => prop.default = SpecConfigValue::from_kdl(v.value),
                             "default_note" => prop.default_note = Some(v.ensure_string()?),
                             "data_type" => prop.data_type = v.ensure_string()?.parse()?,
                             "env" => prop.env = v.ensure_string()?.to_string().into(),
@@ -52,11 +140,14 @@ impl SpecConfig {
         Ok(config)
     }
 
+    /// Later declarations win, whole prop at a time.
+    ///
+    /// `Spec::merge` is other-wins for everything else (`merge_opt!`), and config was the
+    /// one place an included file could add a prop but never correct one. Field-wise
+    /// refinement is deliberately not offered until something needs it.
     pub(crate) fn merge(&mut self, other: &Self) {
         for (key, prop) in &other.props {
-            self.props
-                .entry(key.to_string())
-                .or_insert_with(|| prop.clone());
+            self.props.insert(key.to_string(), prop.clone());
         }
     }
 }
@@ -70,7 +161,7 @@ impl SpecConfig {
 #[derive(Debug, Clone, Serialize)]
 #[non_exhaustive]
 pub struct SpecConfigProp {
-    pub default: Option<String>,
+    pub default: Option<SpecConfigValue>,
     pub default_note: Option<String>,
     pub data_type: SpecDataTypes,
     pub env: Option<String>,
@@ -97,7 +188,7 @@ impl SpecConfigProp {
     }
 
     /// Default value, rendered in docs.
-    pub fn default_value(mut self, default: impl Into<String>) -> Self {
+    pub fn default_value(mut self, default: impl Into<SpecConfigValue>) -> Self {
         self.default = Some(default.into());
         self
     }
@@ -108,7 +199,12 @@ impl SpecConfigProp {
         let mut node = KdlNode::new("prop");
         node.push(KdlEntry::new(key));
         if let Some(default) = &self.default {
-            node.push(string_entry(Some("default"), default));
+            node.push(KdlEntry::new_prop("default", default.to_kdl()));
+        }
+        // Written, unlike before: a type that is parsed and not serialized is a type that
+        // survives exactly one hop.
+        if self.data_type != SpecDataTypes::Null {
+            node.push(string_entry(Some("data_type"), &self.data_type.to_string()));
         }
         if let Some(default_note) = &self.default_note {
             node.push(string_entry(Some("default_note"), default_note));
@@ -152,6 +248,7 @@ impl From<&SpecConfig> for KdlNode {
 
 #[cfg(test)]
 mod tests {
+    use super::SpecConfigValue;
     use crate::Spec;
     use insta::assert_snapshot;
 
@@ -171,13 +268,103 @@ config {
         )
         .unwrap();
 
+        // The values, not their KDL source text: the old snapshot recorded
+        // `default="#true"` and `default="4"`, which is what a stringly default looks
+        // like once it has been through the writer.
         assert_snapshot!(spec, @r##"
         config {
-            prop color default="#true" env=COLOR help="Enable color output"
-            prop jobs default="4" env=JOBS help="Number of jobs to run"
-            prop timeout default="1.5" env=TIMEOUT help="Timeout in seconds" long_help="Timeout in seconds, can be fractional"
+            prop color default=#true env=COLOR help="Enable color output"
+            prop jobs default=4 env=JOBS help="Number of jobs to run"
+            prop timeout default=1.5 env=TIMEOUT help="Timeout in seconds" long_help="Timeout in seconds, can be fractional"
             prop user default=admin env=USER help="User to run as"
         }
         "##);
+    }
+
+    #[test]
+    fn a_config_block_survives_being_written_out() {
+        // Each of these was lost or corrupted by one hop through the writer.
+        let spec: Spec = r#"
+name "ex"
+bin "ex"
+config {
+    prop "jobs" data_type="integer" default=4 env="EX_JOBS" help="How many"
+    prop "color" data_type="boolean" default=#true
+    prop "shell" data_type="string" default="true"
+}
+"#
+        .parse()
+        .unwrap();
+
+        let written = spec.to_string();
+        let round_tripped: Spec = written.parse().unwrap();
+        for (key, before) in &spec.config.props {
+            let after = round_tripped
+                .config
+                .props
+                .get(key)
+                .unwrap_or_else(|| panic!("{key} should survive"));
+            assert_eq!(
+                after.data_type, before.data_type,
+                "{key}'s type should survive: {written}"
+            );
+            assert_eq!(
+                after.default, before.default,
+                "{key}'s default should survive unchanged: {written}"
+            );
+        }
+        // `"true"` is a string whose text looks like a boolean — the case that shows the
+        // difference between keeping a value and keeping its spelling.
+        assert_eq!(
+            round_tripped.config.props["shell"].default,
+            Some(SpecConfigValue::String("true".into()))
+        );
+    }
+
+    #[test]
+    fn a_nested_prop_is_refused_rather_than_dropped() {
+        let err = Spec::parse(
+            &Default::default(),
+            r#"
+config {
+    prop "status" {
+        prop "missing_tools"
+    }
+}
+"#,
+        )
+        .expect_err("nesting should not be silently accepted");
+        // The message is in the diagnostic rather than the summary line, which is where
+        // this crate keeps parse detail.
+        match err {
+            crate::error::UsageErr::InvalidInput(msg, _, _) => {
+                assert!(msg.contains("cannot nest"), "unhelpful message: {msg}");
+            }
+            err => panic!("unexpected error: {err:?}"),
+        }
+    }
+
+    #[test]
+    fn a_later_declaration_of_a_prop_wins() {
+        // What `include` needs: everything else in a spec is other-wins, and config was
+        // the one place a later file could add a prop but never correct one.
+        let mut spec = Spec::parse(
+            &Default::default(),
+            "config {\n  prop \"jobs\" default=1 help=\"first\"\n}\n",
+        )
+        .unwrap();
+        let other = Spec::parse(
+            &Default::default(),
+            "config {\n  prop \"jobs\" default=8 help=\"second\"\n  prop \"color\"\n}\n",
+        )
+        .unwrap();
+
+        spec.merge(other);
+        assert_eq!(
+            spec.config.props["jobs"].default,
+            Some(SpecConfigValue::Int(8))
+        );
+        assert_eq!(spec.config.props["jobs"].help.as_deref(), Some("second"));
+        assert!(spec.config.props.contains_key("color"));
     }
 }

--- a/lib/src/spec/data_types.rs
+++ b/lib/src/spec/data_types.rs
@@ -1,8 +1,14 @@
 use serde::Serialize;
-use strum::EnumString;
+use strum::{Display, EnumString};
 
-#[derive(Debug, Copy, Clone, EnumString, Serialize, Default)]
+/// The type a config property's values take.
+///
+/// `Display` is the KDL spelling, so a parsed spec can be written back out — without it
+/// `data_type` was read and then silently dropped by the serializer, which is how a
+/// `data_type="integer"` came back as `Null` after one round trip.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Display, EnumString, Serialize, Default)]
 #[strum(serialize_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum SpecDataTypes {
     #[default]
     Null,


### PR DESCRIPTION
First of the config v2 stack. Four defects in `config { prop … }`, all in the ground v2 builds on.

Nothing renders the block into docs yet (`lib/src/docs/models.rs:12` has `// pub config: SpecConfig,` commented out), but **the SDK generators do consume it** — and their workarounds are the evidence for two of these.

## `data_type` was parsed and never written

It survived exactly one hop:

```
prop "jobs" data_type="integer"   →  parse → Integer → write → (nothing) → parse → Null
```

`SpecDataTypes` gains a `Display` (the KDL spelling) and the writer emits it.

## `default` stored KDL source text, not a value

It kept `KdlValue::to_string()`, so `default=#true` was read as the five characters `#true` and `default="4"` as `"4"` *with* its quotes — and writing it out added another pair, one layer per round trip. The old snapshot in this file recorded exactly that (`default="#true"`, `default="4"`), which is how the bug stayed.

It's a typed `SpecConfigValue` now (bool/int/float/string), which is also what the v2 vocabulary needs for typed defaults. The **Python SDK generator had been undoing the damage by hand**:

```rust
SpecDataTypes::Boolean => match d.as_str() {
    "#true" | "true" => " = True".to_string(),      // the leaked KDL spelling
    …
SpecDataTypes::Integer | SpecDataTypes::Float => {
    let numeric = d.trim_matches('"');              // the added quotes
```

Both gone; it reads the value and renders by the declared `data_type` where there is one — which keeps the `data_type=float default="1.5"` case rendering as `1.5` rather than `"1.5"` (my first attempt at this regressed that, caught by its snapshot).

## A nested `prop` block parsed and lost its children

`prop "status" { prop "missing_tools" }` kept `status` and silently dropped the rest — the property loop reads properties only. Refused now, naming the dotted spelling to use instead.

## `merge` was first-wins per prop

Everything else in `Spec::merge` is other-wins (`merge_opt!`); config was the one place an `include` could add a prop but never correct one. Last-wins now, whole prop at a time.

## Verification

A test per defect, and **I checked each one fails when its fix is reverted** (four mutations, four failures). Full workspace green, clippy clean, `mise run render` produces no diff.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes spec parsing, serialization, and generated SDK code paths where bad defaults could previously break imports or silently corrupt values; new validation may reject previously tolerated specs.
> 
> **Overview**
> **Config `prop` defaults are typed values now**, not KDL source strings, so parse → write → parse keeps booleans, numbers, and strings without extra quoting layers. The writer also emits **`data_type`** again (via `Display` on `SpecDataTypes`), and defaults go out through typed KDL entries with **`string_entry`** for strings so control characters still reparse.
> 
> **Parsing is stricter:** nested `prop { … }` is rejected, defaults must fit the declared type (and finite floats / i64 range), with coercion after all props on the node are read. **`SpecConfig::merge`** is last-wins per prop, matching other `Spec::merge` behavior.
> 
> **SDK output:** shared **`escape_string_literal`** escapes control characters for Python/TS; the Python config dataclass renders defaults from **`SpecConfigValue`** (quoted strings only) instead of `#true`/quote-stripping hacks, with a test that malicious string defaults cannot become import-time code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 706e618de5dfa06d86c94291af850b85366969e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Configuration defaults now preserve native types, including booleans, integers, decimals, and strings.
  * Generated Python configuration values use correctly typed, safely formatted defaults.
  * String values are safely escaped across generated Python and TypeScript output.
  * Configuration serialization and round trips are more consistent and reliable.
  * Invalid nested configuration properties are rejected with clearer parse errors.
  * Repeated configuration properties now use the latest declaration.
  * Integer ranges and declared configuration types are validated more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->