### PR TITLE
feat(derive): let a field be the type it means

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -115,10 +115,17 @@ manpages, and SDKs — never a runtime dependency of somebody else's program.
 - [x] **Subcommands in the derive** — an enum of variants, each holding the struct
       that declares its flags, nested to any depth. A command is selected by its
       position in the parent's table, found from the address the parser hands back.
-- [ ] **Typed values** — fields are text today (`String`, `Option<String>`,
-      `Vec<String>`, `bool`, counting integers). Parsing into other types needs an
-      error type for value conversion, which is also where `env`, required-ness,
-      and `choices` get enforced — see the post-binding layer below.
+- [x] **Typed values** — a field is any `T: FromStr`, plus `Option<T>`, `Vec<T>` and
+      `Option<Vec<T>>`, which is what lets a command struct hold the `PathBuf` mise names
+      227 times and the tool-version type it names 83 times. Binding still collects text;
+      the conversion happens where the struct is built, and a value that will not convert
+      reports the text and the type's own message. `Error` grew one boxed variant and lost
+      `Copy`, and stayed 40 bytes, so nothing on the hot path grew.
+- [ ] **Values that are not valid UTF-8** — a word reaches a field through
+      `from_utf8_lossy`, so a `PathBuf` holding a non-UTF-8 path gets replacement
+      characters instead of bytes. The partial should hold `OsString` and let `build`
+      decide: exact for `PathBuf` and `OsString`, an error for `String` rather than a
+      silent mangling. Small, and the next thing.
 - [ ] **`usage-derive` v1** — everything mise needs: constraints
       (`requires`/`conflicts`/`overrides`/`required_unless`), `var`, `count`,
       `env`, defaults, delimiters, the `double_dash` modes, global flags, flatten,
@@ -247,15 +254,40 @@ down and stop. Nothing gets integrated into mise before this point.
 
 ### After the gate
 
-- [ ] **mise** — the largest and least forgiving adopter. Likely a router first
-      (which also retires mise's two hand-maintained flag tables), then commands
-      lowered a few at a time, with mise's e2e argv corpus replayed against both
-      parsers.
+- [ ] **mise** — the largest and least forgiving adopter. Likely a router first, then
+      commands lowered a few at a time, with mise's e2e argv corpus replayed against both
+      parsers. Adoption is measured by what it lets mise delete, listed below.
 - [ ] **hk, pitchfork, fnox** — smaller, and all three already generate their
       spec from clap, so they are the natural second adopters.
 - [ ] **Other languages** — the grammar and corpus are language-neutral on
       purpose. A Go, JavaScript, or Python implementation is verified by running
       the corpus, not by reading this repository's Rust.
+
+### What adoption should let mise delete
+
+Checked against mise rather than assumed, and two of them do not survive contact.
+
+- `GLOBAL_FLAGS_WITH_VALUES` and `first_non_global_arg_idx` (`src/cli/mod.rs`) — a
+  hand-maintained copy of the root's value-taking flags, plus a test asserting it still
+  matches clap. Its own comment says why it exists: `env.rs` needs it from `Lazy` statics at
+  startup, and deriving it means building clap's tree, "which costs ~3.1M instructions… what
+  made every mise command ~6.3M instructions more expensive". With `&'static` tables there is
+  no tree to build, so that code can read the real thing. **This is the one that should
+  disappear outright, list and guard test together.**
+- `src/cli/usage.rs` — post-processes the emitted spec: clears `run`'s arguments, adds a
+  mount and a restart token. Those become declarations once the derive can express `mount`,
+  `restart_token` and `default_subcommand`; the file should end up near empty. It already
+  records one hack that went away when jdx/usage#738 landed.
+- `src/cli/command_effects.rs` — 451 lines classifying each command as read, write or
+  destructive, "because mise's usage spec is derived from clap, and clap has no way to
+  express this". The derive can express `effect` inline, so the _workaround_ reason goes —
+  but the file also argues that a safety classification is easier to review as one list than
+  as annotations over sixty files, and that argument survives any framework. Offer the
+  annotation; do not assume the table should go.
+- `Run(Box<run::Run>)` — boxed to stay out of trouble with clap at that size. The clap reason
+  goes; the stack-size reason is real, and boxing stays supported.
+- `src/assets/mise-extra.usage.kdl` — **not** a clap workaround. It is mostly a
+  `source_code_link_template` for the docs, which a spec is the right home for.
 
 ## Not covered by the corpus yet
 

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -288,7 +288,9 @@ pub enum Event<'t, 'v> {
 ///
 /// `non_exhaustive`, because an error enum grows: a caller matching on it needs a
 /// fallback arm so that recognizing a new failure is never a breaking change.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+// No `Copy`: one variant owns its message. `Clone` stays, and the enum is still 40 bytes
+// because that variant is boxed, so nothing on the hot path grew.
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Error<'t, 'v> {
     /// A flag-like token matched no flag in scope. `token` is the whole token as
@@ -346,6 +348,14 @@ pub enum Error<'t, 'v> {
         /// The flag it cannot be given with, as the declaration spells it.
         other: &'t str,
     },
+    /// A value was given that the field's type could not be built from.
+    ///
+    /// Boxed, and the only error here that owns anything. Everything else borrows the
+    /// tables or argv, which is what keeps a *successful* parse allocation-free — and the
+    /// box keeps `Error` the size it was, so the `Result` this rides in on the hot path
+    /// does not grow. A value that will not convert has already failed, and a message
+    /// worth reading is worth one allocation.
+    InvalidValue(::std::boxed::Box<InvalidValue<'t>>),
     /// A subcommand was required, and none was given.
     MissingSubcommand,
 }
@@ -372,6 +382,19 @@ pub const fn key_base(module: &str, declaration: u32) -> u64 {
         i += 1;
     }
     (hash as u64) << 32
+}
+
+/// Why a value would not convert into the type its field holds.
+///
+/// Separate from [`Error`] so that the enum stays small: this is reached through a `Box`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidValue<'t> {
+    /// The flag or argument's name, as the spec calls it.
+    pub name: &'t str,
+    /// The text that would not convert.
+    pub value: ::std::string::String,
+    /// What the type's own conversion complained about.
+    pub reason: ::std::string::String,
 }
 
 /// Interpret a value as UTF-8.

--- a/conformance/tests/typed.rs
+++ b/conformance/tests/typed.rs
@@ -1,0 +1,250 @@
+//! Fields that are not text.
+//!
+//! The parse binds words; this is the layer where a word becomes the thing the field holds.
+//! What matters here is that it covers the types a real CLI is written with — mise names
+//! `PathBuf` 227 times and a tool-version type 83 times in its command structs — and that a
+//! value which will not convert says which value and why.
+
+use std::ffi::OsStr;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use usage_argv::Error;
+use usage_derive::Cli;
+
+fn argv<const N: usize>(tokens: [&str; N]) -> [&OsStr; N] {
+    tokens.map(OsStr::new)
+}
+
+/// A type of the adopter's own, as `ToolArg` is in mise.
+#[derive(Debug, PartialEq)]
+struct Tool {
+    name: String,
+    version: Option<String>,
+}
+
+impl FromStr for Tool {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Err("a tool needs a name".into());
+        }
+        let (name, version) = match s.split_once('@') {
+            Some((name, version)) => (name, Some(version.to_string())),
+            None => (s, None),
+        };
+        Ok(Tool {
+            name: name.to_string(),
+            version,
+        })
+    }
+}
+
+/// A CLI whose fields are the types a real one uses.
+#[derive(Cli)]
+#[usage(bin = "typed")]
+struct Typed {
+    /// How many at once
+    #[usage(short = 'j', long)]
+    jobs: Option<usize>,
+    /// Where to write
+    #[usage(long)]
+    out: Option<PathBuf>,
+    /// A number that must be given
+    ///
+    /// Bare rather than `Option`, which is how a required value is declared: the type says
+    /// there is nowhere to put "absent".
+    #[usage(long)]
+    port: u16,
+    /// Tools to use
+    #[usage(long, var)]
+    tool: Vec<Tool>,
+    /// Directories to search, absent when the flag was never given
+    #[usage(long, var)]
+    search: Option<Vec<PathBuf>>,
+    /// What to act on
+    #[usage(arg, name = "TARGET")]
+    target: String,
+}
+
+#[test]
+fn values_arrive_as_the_types_the_fields_hold() {
+    let a = argv([
+        "-j", "4", "--out", "/tmp/x", "--port", "8080", "--tool", "node@20", "--tool", "python",
+        "--search", "/a", "--search", "/b", "thing",
+    ]);
+    let typed = Typed::parse_from(&a).expect("should parse");
+
+    assert_eq!(typed.jobs, Some(4));
+    assert_eq!(typed.out, Some(PathBuf::from("/tmp/x")));
+    assert_eq!(typed.port, 8080);
+    assert_eq!(
+        typed.tool,
+        [
+            Tool {
+                name: "node".into(),
+                version: Some("20".into())
+            },
+            Tool {
+                name: "python".into(),
+                version: None
+            },
+        ]
+    );
+    assert_eq!(
+        typed.search,
+        Some(vec![PathBuf::from("/a"), PathBuf::from("/b")])
+    );
+    assert_eq!(typed.target, "thing");
+}
+
+#[test]
+fn an_optional_collection_tells_absent_from_empty() {
+    // What `Option<Vec<T>>` is for, and what a `Vec` cannot say. mise's root draws this
+    // distinction three times.
+    let a = argv(["--port", "1", "thing"]);
+    let typed = Typed::parse_from(&a).expect("should parse");
+    assert_eq!(typed.search, None, "never given");
+    assert!(typed.tool.is_empty(), "a plain Vec is simply empty");
+}
+
+#[test]
+fn a_value_that_will_not_convert_says_which_and_why() {
+    let a = argv(["--port", "1", "--jobs", "lots", "thing"]);
+    match Typed::parse_from(&a) {
+        Err(Error::InvalidValue(bad)) => {
+            assert_eq!(bad.name, "jobs");
+            assert_eq!(bad.value, "lots");
+            // Whatever the type itself said, rather than a message of ours that would be
+            // worse: `usize` explains this better than "invalid value" would.
+            assert!(
+                bad.reason.contains("invalid digit"),
+                "unhelpful reason: {}",
+                bad.reason
+            );
+        }
+        Err(other) => panic!("wrong error: {other:?}"),
+        Ok(_) => panic!("this should not have parsed"),
+    }
+}
+
+#[test]
+fn a_custom_types_own_error_is_what_the_user_sees() {
+    let a = argv(["--port", "1", "--tool", "", "thing"]);
+    match Typed::parse_from(&a) {
+        Err(Error::InvalidValue(bad)) => {
+            assert_eq!(bad.name, "tool");
+            assert_eq!(bad.reason, "a tool needs a name");
+        }
+        Err(other) => panic!("wrong error: {other:?}"),
+        Ok(_) => panic!("this should not have parsed"),
+    }
+}
+
+#[test]
+fn a_number_out_of_range_is_the_types_business() {
+    // `u16` rejects 99999 and says so; nothing in the derive needs to know the range.
+    let a = argv(["--port", "99999", "thing"]);
+    match Typed::parse_from(&a) {
+        Err(Error::InvalidValue(bad)) => {
+            assert_eq!(bad.name, "port");
+            assert!(bad.reason.contains("too large"), "{}", bad.reason);
+        }
+        Err(other) => panic!("wrong error: {other:?}"),
+        Ok(_) => panic!("this should not have parsed"),
+    }
+}
+
+#[test]
+fn the_spec_is_unchanged_by_a_fields_type() {
+    // A type is a Rust-side matter: the spec describes what a CLI accepts, and `--jobs <n>`
+    // accepts a word either way. Nothing about `usize` belongs in the KDL.
+    let kdl = Typed::to_kdl();
+    // The writer puts a flag's argument in a child block rather than in the placeholder.
+    assert!(kdl.contains(r#"flag "-j --jobs""#), "{kdl}");
+    assert!(kdl.contains(r#"arg "<jobs>""#), "{kdl}");
+    assert!(!kdl.contains("usize"), "{kdl}");
+    assert!(!kdl.contains("PathBuf"), "{kdl}");
+}
+
+mod newtype {
+    use std::str::FromStr;
+
+    /// A type whose last path segment is `String` and which is not one.
+    ///
+    /// The conversion takes `String` as the identity case; matching that on the last segment
+    /// alone would hand this field a `std::string::String` and fail to compile.
+    #[derive(Debug, PartialEq)]
+    pub struct String(pub usize);
+
+    impl FromStr for String {
+        type Err = std::num::ParseIntError;
+
+        fn from_str(s: &str) -> Result<Self, Self::Err> {
+            s.parse().map(String)
+        }
+    }
+}
+
+/// Values on a subcommand, which is where every real command lives.
+#[derive(usage_derive::Args)]
+struct Deeply {
+    /// Where to write
+    #[usage(long)]
+    out: Option<PathBuf>,
+    /// How many
+    #[usage(long)]
+    count: Option<u8>,
+    /// Not the standard `String`
+    #[usage(long)]
+    width: Option<newtype::String>,
+    /// Tools
+    #[usage(long, var)]
+    tool: Vec<Tool>,
+}
+
+#[derive(usage_derive::Subcommands)]
+enum NestedCommands {
+    /// Do the thing
+    Deeply(Box<Deeply>),
+}
+
+/// A tool whose commands hold typed values
+#[derive(Cli)]
+#[usage(bin = "nested")]
+struct Nested {
+    #[usage(subcommand)]
+    command: Option<NestedCommands>,
+}
+
+#[test]
+fn a_subcommands_fields_are_converted_too() {
+    // Two emitters produce `build`, and only the root's was converting: a typed field on a
+    // subcommand compiled in the tests and not in an adopter's crate, which is every
+    // command mise has.
+    let a = argv([
+        "deeply", "--out", "/tmp/y", "--count", "3", "--width", "80", "--tool", "node@22",
+    ]);
+    let Some(NestedCommands::Deeply(deeply)) = Nested::parse_from(&a).expect("parses").command
+    else {
+        panic!("expected `deeply`")
+    };
+    assert_eq!(deeply.out, Some(PathBuf::from("/tmp/y")));
+    assert_eq!(deeply.count, Some(3));
+    assert_eq!(deeply.width, Some(newtype::String(80)));
+    assert_eq!(deeply.tool.len(), 1);
+}
+
+#[test]
+fn a_conversion_failure_on_a_subcommand_names_the_field() {
+    let a = argv(["deeply", "--count", "300"]);
+    match Nested::parse_from(&a) {
+        Err(Error::InvalidValue(bad)) => {
+            assert_eq!(bad.name, "count");
+            assert_eq!(bad.value, "300");
+        }
+        Err(other) => panic!("wrong error: {other:?}"),
+        Ok(_) => panic!("300 does not fit in a u8"),
+    }
+}

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -15,7 +15,7 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
-use crate::model::{Cli, Field, Kind, Shape, Subcommands};
+use crate::model::{rendered_path, Cli, Field, Kind, Shape, Subcommands};
 
 pub fn emit(cli: &Cli) -> TokenStream {
     let ident = &cli.ident;
@@ -84,10 +84,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
         .fields
         .iter()
         .filter(|f| !matches!(f.kind, Kind::Subcommand { .. }))
-        .map(|f| {
-            let ident = &f.ident;
-            quote!(#ident: partial.#ident)
-        });
+        .map(field_final);
 
     quote! {
         #[doc(hidden)]
@@ -723,6 +720,97 @@ fn partial_defaults(cli: &Cli) -> TokenStream {
     }
 }
 
+/// One field of the finished struct, converted from the text the parse collected.
+///
+/// The partial holds words, because binding decides where a word lands and not what it
+/// means. This is where meaning arrives: a `String` field takes the text as it is, and
+/// anything else is built with `FromStr` — which is what lets a field be a `PathBuf`, a
+/// number, or a type of the adopter's own.
+fn field_final(field: &Field) -> TokenStream {
+    let ident = &field.ident;
+    let name = &field.name;
+    let Some(ty) = field.value_ty.as_ref() else {
+        // A switch or a count: nothing was parsed from a word.
+        return quote!(#ident: partial.#ident);
+    };
+
+    // `String` is the identity conversion, and writing it out as one would make every
+    // adopter pay an allocation to get back what they already had. Matched on the whole
+    // written path rather than its last segment: someone's own `my::String` is not this one,
+    // and handing it a `std::string::String` would fail to compile in their crate.
+    let is_std_string = matches!(
+        rendered_path(ty).as_str(),
+        "String" | "std::string::String" | "::std::string::String" | "alloc::string::String"
+    );
+    let converted = |value: TokenStream| {
+        if is_std_string {
+            quote!(#value)
+        } else {
+            quote! {
+                match ::std::str::FromStr::from_str(&#value) {
+                    ::std::result::Result::Ok(parsed) => parsed,
+                    ::std::result::Result::Err(reason) => {
+                        return ::std::result::Result::Err(
+                            ::usage_argv::Error::InvalidValue(::std::boxed::Box::new(
+                                ::usage_argv::InvalidValue {
+                                    name: #name,
+                                    value: #value,
+                                    reason: ::std::string::ToString::to_string(&reason),
+                                },
+                            )),
+                        );
+                    }
+                }
+            }
+        }
+    };
+
+    match field.shape {
+        Shape::Bool | Shape::Count => quote!(#ident: partial.#ident),
+        Shape::Required => {
+            let one = converted(quote!(partial.#ident));
+            quote!(#ident: #one)
+        }
+        Shape::Optional => {
+            let one = converted(quote!(__usage_value));
+            quote! {
+                #ident: match partial.#ident {
+                    ::std::option::Option::Some(__usage_value) => {
+                        ::std::option::Option::Some(#one)
+                    }
+                    ::std::option::Option::None => ::std::option::Option::None,
+                }
+            }
+        }
+        Shape::Many => {
+            let one = converted(quote!(__usage_value));
+            // Built by hand rather than with `collect`, so the error can carry the value
+            // that failed rather than only that one did.
+            let collected = quote! {{
+                let mut __usage_values = ::std::vec::Vec::with_capacity(partial.#ident.len());
+                for __usage_value in partial.#ident {
+                    __usage_values.push(#one);
+                }
+                __usage_values
+            }};
+            if field.optional_collection {
+                let given = format_ident!("__given_{}", ident);
+                // `Option<Vec<T>>` distinguishes "never given" from "given nothing", which
+                // no `Vec` can — so the answer comes from whether anything arrived.
+                quote! {
+                    #ident: if partial.#given {
+                        ::std::option::Option::Some(#collected)
+                    } else {
+                        ::std::option::Option::None
+                    }
+                }
+            } else {
+                quote!(#ident: #collected)
+            }
+        }
+    }
+}
+
 /// Put a field back the way `start()` left it.
 ///
 /// Used twice, and the second use is why it is worth naming: a flag displaced by an
@@ -962,14 +1050,14 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
         .unwrap_or_default();
     let sub_metas = parts.as_ref().map(|p| p.metas.clone()).unwrap_or_default();
     let sub_build = parts.as_ref().map(|p| p.build.clone()).unwrap_or_default();
+    // The same conversion the root gets. Two emitters producing one `build` is what let
+    // this diverge: a typed field on a subcommand compiled here and not there, which is
+    // every command mise has.
     let field_finals = cli
         .fields
         .iter()
         .filter(|f| !matches!(f.kind, Kind::Subcommand { .. }))
-        .map(|f| {
-            let ident = &f.ident;
-            quote!(#ident: partial.#ident)
-        });
+        .map(field_final);
 
     quote! {
         #[doc(hidden)]

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -734,10 +734,17 @@ fn field_final(field: &Field) -> TokenStream {
         return quote!(#ident: partial.#ident);
     };
 
-    // `String` is the identity conversion, and writing it out as one would make every
-    // adopter pay an allocation to get back what they already had. Matched on the whole
-    // written path rather than its last segment: someone's own `my::String` is not this one,
-    // and handing it a `std::string::String` would fail to compile in their crate.
+    // `String` is the identity conversion, and writing it out as one costs an allocation
+    // per value to get back what we already had: 3 allocations become 5 and the parse grows
+    // 2.3% on a three-word invocation, measured.
+    //
+    // Matched on the whole written path rather than its last segment, so someone's own
+    // `my::String` is not mistaken for this one. What remains is an adopter who *shadows*
+    // the name — `use my_crate::String` — whose field would be handed a
+    // `std::string::String` and fail to compile. A macro cannot resolve a name, so the
+    // choice is this narrow hazard or the allocation for everyone. It stops being a choice
+    // once the partial holds bytes rather than text: a `String` field converts like any
+    // other then, and there is no identity case left to recognise.
     let is_std_string = matches!(
         rendered_path(ty).as_str(),
         "String" | "std::string::String" | "::std::string::String" | "alloc::string::String"
@@ -786,13 +793,23 @@ fn field_final(field: &Field) -> TokenStream {
             let one = converted(quote!(__usage_value));
             // Built by hand rather than with `collect`, so the error can carry the value
             // that failed rather than only that one did.
-            let collected = quote! {{
-                let mut __usage_values = ::std::vec::Vec::with_capacity(partial.#ident.len());
-                for __usage_value in partial.#ident {
-                    __usage_values.push(#one);
-                }
-                __usage_values
-            }};
+            // A `Vec<String>` is moved whole. Rebuilding it element by element allocated a
+            // second `Vec` to hold what the first already held, which is one allocation per
+            // collecting field — and mise's commands collect a lot.
+            let collected = if is_std_string {
+                quote!(partial.#ident)
+            } else {
+                // Built by hand rather than with `collect`, so the error can carry the value
+                // that failed rather than only that one did.
+                quote! {{
+                    let mut __usage_values =
+                        ::std::vec::Vec::with_capacity(partial.#ident.len());
+                    for __usage_value in partial.#ident {
+                        __usage_values.push(#one);
+                    }
+                    __usage_values
+                }}
+            };
             if field.optional_collection {
                 let given = format_ident!("__given_{}", ident);
                 // `Option<Vec<T>>` distinguishes "never given" from "given nothing", which

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -122,6 +122,25 @@
 //! argument. Help text comes from the doc comment: the first paragraph is the
 //! short form, and the whole comment is the long form.
 //!
+//! A field's **type** says how many values it takes and what they become. `bool` is a
+//! switch and an unsigned integer with `count` counts occurrences; everything else holds
+//! values, built with `FromStr`:
+//!
+//! | type | means |
+//! | --- | --- |
+//! | `T` | one value, required — the type has nowhere to put "absent" |
+//! | `Option<T>` | one value, or nothing |
+//! | `Vec<T>` | several, empty when none arrived |
+//! | `Option<Vec<T>>` | several, and `None` when the flag was never given at all |
+//!
+//! So `Option<PathBuf>`, `Vec<ToolArg>` and `Option<usize>` all work, and a type that no
+//! single word could become is a compile error naming that type. The conversion's error
+//! type has to implement `Display`, since what it says is what the user reads — a type
+//! whose error does not is also a compile error, and also names the type. The parse itself still
+//! binds text — a word's meaning is decided once, where the struct is built — and a value
+//! that will not convert becomes [`Error::InvalidValue`](usage_argv::Error::InvalidValue),
+//! carrying the offending text and whatever the type's own conversion said about it.
+//!
 //! | option | meaning |
 //! | --- | --- |
 //! | `long`, `long = "x"` | a long form, defaulting to the field name |
@@ -170,10 +189,10 @@
 //! Published early on purpose, so it can be used and argued with — but these are
 //! real limits, not omissions from the docs.
 //!
-//! - **Typed values.** Fields are `bool`, `String`, `Option<String>`,
-//!   `Vec<String>`, or an unsigned integer with `count`. Anything else is a compile
-//!   error rather than a surprise: converting a value needs somewhere to report one
-//!   that will not convert, and that is a layer this version does not have.
+//! - **Values that are not valid UTF-8.** A word reaches a field through
+//!   `String::from_utf8_lossy`, so a `PathBuf` field holding a path that is not UTF-8
+//!   gets the replacement character rather than the bytes. Rare, and wrong when it
+//!   happens; holding what was typed rather than a lossy copy of it is the next change.
 //! - **Flattening.** A struct cannot yet borrow another struct's flags, so a set of
 //!   options shared by several commands has to be repeated.
 

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -189,6 +189,11 @@
 //! Published early on purpose, so it can be used and argued with — but these are
 //! real limits, not omissions from the docs.
 //!
+//! - **A field whose type shadows the name `String`.** A word reaching a `String` field is
+//!   moved rather than converted, which costs nothing; the type is recognised by how it is
+//!   written, because a macro cannot resolve a name. So `use my_crate::String` followed by
+//!   a `String` field of that type fails to compile. The same change that fixes the next
+//!   item removes this one.
 //! - **Values that are not valid UTF-8.** A word reaches a field through
 //!   `String::from_utf8_lossy`, so a `PathBuf` field holding a path that is not UTF-8
 //!   gets the replacement character rather than the bytes. Rare, and wrong when it

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -41,6 +41,13 @@ pub struct Field {
     pub name: String,
     pub kind: Kind,
     pub shape: Shape,
+    /// What one value converts into, absent for a switch or a count.
+    ///
+    /// The partial holds text either way — binding decides where a word lands, not what it
+    /// means — and this is what `build` converts it with.
+    pub value_ty: Option<Type>,
+    /// Written as `Option<Vec<T>>`, so "never given" and "given nothing" differ.
+    pub optional_collection: bool,
     pub help: Option<String>,
     pub long_help: Option<String>,
     pub env: Option<String>,
@@ -417,6 +424,8 @@ impl Field {
             // A subcommand field holds a command, not a value, so none of what
             // describes a value applies to it.
             shape: Shape::Bool,
+            value_ty: None,
+            optional_collection: false,
             help: None,
             long_help: None,
             env: None,
@@ -653,7 +662,11 @@ impl Field {
             ));
         }
 
-        let shape = Shape::from_type(&field.ty, count, span)?;
+        let ValueKind {
+            shape,
+            ty: value_ty,
+            optional_collection,
+        } = ValueKind::from_type(&field.ty, count, span)?;
         // The spec records a default and the generated code applies it; anything it
         // cannot apply would be documented and then ignored.
         if let Some(value) = &default {
@@ -847,6 +860,8 @@ impl Field {
             name,
             kind,
             shape,
+            value_ty,
+            optional_collection,
             help,
             long_help,
             env,
@@ -871,12 +886,33 @@ impl Field {
     }
 }
 
-impl Shape {
+/// What a field's type says about the values that reach it.
+pub struct ValueKind {
+    pub shape: Shape,
+    /// What one value converts into: the `T` in `T`, `Option<T>` or `Vec<T>`.
+    ///
+    /// Absent for a switch and for a count, which are decided by how many times the flag
+    /// was given rather than by anything a word says.
+    pub ty: Option<Type>,
+    /// Whether a collection was written as `Option<Vec<T>>`.
+    ///
+    /// The difference from `Vec<T>` is "never given" against "given nothing", which is a
+    /// distinction mise's root draws three times. Values collect the same way; only the
+    /// field it is finally put into differs.
+    pub optional_collection: bool,
+}
+
+impl ValueKind {
     fn from_type(ty: &Type, count: bool, span: Span) -> syn::Result<Self> {
+        let plain = |shape| ValueKind {
+            shape,
+            ty: None,
+            optional_collection: false,
+        };
         let name = type_name(ty);
         if count {
             return match name.as_str() {
-                "u8" | "u16" | "u32" | "u64" | "usize" => Ok(Shape::Count),
+                "u8" | "u16" | "u32" | "u64" | "usize" => Ok(plain(Shape::Count)),
                 other => Err(syn::Error::new(
                     span,
                     format!(
@@ -886,22 +922,35 @@ impl Shape {
                 )),
             };
         }
-        match name.as_str() {
-            "bool" => Ok(Shape::Bool),
-            "String" => Ok(Shape::Required),
-            "Option<String>" => Ok(Shape::Optional),
-            "Vec<String>" => Ok(Shape::Many),
-            other => Err(syn::Error::new(
-                span,
-                format!(
-                    "`{other}` is not supported yet. This version binds values as the \
-                     text they arrive as, so a field is `bool`, `String`, \
-                     `Option<String>`, `Vec<String>`, or an unsigned integer with \
-                     `count`. Parsing into other types arrives with the layer that also \
-                     applies defaults and validates choices"
-                ),
-            )),
+        if name == "bool" {
+            return Ok(plain(Shape::Bool));
         }
+        // Peeled in this order because `Option<Vec<T>>` is both, and reading it as an
+        // optional whose value is a `Vec` would ask `Vec<T>` to parse from one word.
+        if let Some(inner) = peel(ty, "Option").as_ref().and_then(|o| peel(o, "Vec")) {
+            return Ok(ValueKind {
+                shape: Shape::Many,
+                ty: Some(inner),
+                optional_collection: true,
+            });
+        }
+        for (wrapper, shape) in [("Option", Shape::Optional), ("Vec", Shape::Many)] {
+            if let Some(inner) = peel(ty, wrapper) {
+                return Ok(ValueKind {
+                    shape,
+                    ty: Some(inner),
+                    optional_collection: false,
+                });
+            }
+        }
+        // Anything else is one value, converted with `FromStr` — which is where a type
+        // that cannot hold a command-line word finally reports itself, naming the user's
+        // type rather than ours.
+        Ok(ValueKind {
+            shape: Shape::Required,
+            ty: Some(ty.clone()),
+            optional_collection: false,
+        })
     }
 }
 
@@ -914,11 +963,21 @@ impl Shape {
 /// reason about, and is left as the type it is — which then fails to implement the trait,
 /// with an error naming the type the user wrote.
 fn unbox(ty: &Type) -> Option<Type> {
+    peel(ty, "Box")
+}
+
+/// The `T` in a written `Wrapper<T>`, path and all.
+///
+/// Only the last path segment is inspected, so `std::boxed::Box<T>` reads as `Box<T>` and
+/// `std::option::Option<T>` as `Option<T>`. One type argument is required: `Box<T, A>`
+/// names an allocator this cannot reason about, and is left as the type the user wrote so
+/// the error names theirs rather than ours.
+fn peel(ty: &Type, wrapper: &str) -> Option<Type> {
     let Type::Path(path) = ty else {
         return None;
     };
     let last = path.path.segments.last()?;
-    if last.ident != "Box" {
+    if last.ident != wrapper {
         return None;
     }
     let syn::PathArguments::AngleBracketed(args) = &last.arguments else {
@@ -930,7 +989,18 @@ fn unbox(ty: &Type) -> Option<Type> {
     }
 }
 
-fn type_name(ty: &Type) -> String {
+/// A type as written, path and all, with the spaces `quote` leaves out.
+///
+/// Distinct from [`type_name`], which keeps only the last segment: telling
+/// `std::string::String` from somebody's own `my::String` needs the whole path, and
+/// mistaking the two hands a `String` to a field that cannot hold one.
+pub fn rendered_path(ty: &Type) -> String {
+    quote::ToTokens::to_token_stream(ty)
+        .to_string()
+        .replace(' ', "")
+}
+
+pub fn type_name(ty: &Type) -> String {
     match ty {
         Type::Path(path) => {
             let Some(last) = path.path.segments.last() else {


### PR DESCRIPTION
The largest thing standing between the derive and mise. Independent of #827–#829, so it can go in either order.

mise names `PathBuf` **227 times** and its tool-version type **83 times** in `src/cli/`. A derive that only holds `String` cannot hold mise's commands, however faithfully it expresses mise's spec.

```rust
#[usage(short = 'j', long)] jobs: Option<usize>,
#[usage(long)]              out: Option<PathBuf>,
#[usage(long)]              port: u16,          // bare: the type says it is required
#[usage(long, var)]         tool: Vec<Tool>,    // any FromStr of your own
#[usage(long, var)]         search: Option<Vec<PathBuf>>,
```

`Option<Vec<T>>` earns its place: "never given" and "given nothing" are different answers, and mise's root asks for that distinction three times.

## What keeps it cheap

The layering does not move. **Binding still collects text** — a word's meaning is not a question about where it lands — and conversion happens once, where the struct is built. So defaults, `env`, `choices` and the variadic bounds all keep working on text, untouched.

**Measured on the same fixture as main: 40,129 instructions against 39,963.** +166, or 0.4%, nearly all of it bookkeeping the identity conversion cannot avoid.

That comparison is worth a note. On #827/#828 this parse measures ~50.9k, and I nearly reported this branch's 40k as a 20% win — it is not, it is a *smaller shadow*, because main has neither those branches' 91 aliases nor their boxed variants. Same trap the informative-benchmark change was made for; the honest number needs the same fixture on both sides.

## Errors say what the type says

```rust
Err(Error::InvalidValue(bad)) => {
    bad.name;    // "jobs"
    bad.value;   // "lots"
    bad.reason;  // "invalid digit found in string"
}
```

Better than anything this crate could invent about someone else's type: `u16` explains "number too large than can fit", and a tool argument explains itself. `Error` gained one variant and **lost `Copy`**, since that variant owns two strings — but the payload is boxed, so `Error` is still **40 bytes** and the `Result` it rides in on the hot path did not grow. I checked that rather than assuming it.

A type no word could become is a compile error naming *that* type:

```
error[E0277]: the trait bound `HashMap<String, String>: FromStr` is not satisfied
```

## One gap, deliberate and documented

A word reaches a field through `from_utf8_lossy`, so a `PathBuf` holding a path that is not UTF-8 gets replacement characters rather than bytes. Rare, and wrong when it happens. The fix is for the partial to hold `OsString` and let `build` decide — exact for `PathBuf` and `OsString`, an error for `String` rather than a silent mangling — which is the next PR rather than a bigger one now.

Also in here, from jdx's note that mise carries hacks purely to work around clap: PLAN.md now lists what adoption should let mise **delete**, checked against mise rather than assumed. Two of the five do not survive contact — `command_effects.rs` argues its own case for staying one central list, and `mise-extra.usage.kdl` turns out to be a docs link template rather than a workaround.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public `usage_argv::Error` API changes (`Copy` removed, new variant) and derive codegen affects all parsers, but behavior is covered by new conformance tests and conversion stays off the successful parse hot path.
> 
> **Overview**
> **Typed CLI fields** move beyond string-only binding: a field can be any `T: FromStr`, plus `Option<T>`, `Vec<T>`, and `Option<Vec<T>>` (so “flag never given” vs “given but empty” stays distinct). The argv layer still binds text; **`usage-derive` converts when building the struct**, with a fast path that moves `std::string::String` without re-parsing.
> 
> Failed conversions surface as **`Error::InvalidValue`** (boxed **`InvalidValue`** with field name, raw text, and the type’s `Display` message). **`Error` no longer implements `Copy`**; the new variant is boxed so the enum stays **40 bytes**.
> 
> **Subcommand `Args` builds** use the same **`field_final`** logic as the root CLI (fixing typed fields on nested commands).
> 
> **`PLAN.md`** marks typed values done, notes the next step (non–UTF-8 via `OsString` in partials), and adds a mise adoption section on what clap workarounds can be removed vs what should stay.
> 
> **`conformance/tests/typed.rs`** covers numeric/path/custom types, `Option<Vec<_>>`, spec/KDL unchanged by Rust types, and subcommand conversion errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0501bb551c09766e5075e0df8938ff6fa1fcc03c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added type-driven conversion for CLI values, supporting numeric, path, custom `FromStr`, optional, and repeated fields.
  * Added support for optional collections, distinguishing absent values from empty collections.
  * Conversion failures now report the field, rejected value, and reason.

* **Documentation**
  * Updated documentation for supported typed-value patterns and current non-UTF-8 handling limitations.

* **Tests**
  * Added comprehensive coverage for typed fields, collections, conversion errors, and numeric validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->