### PR TITLE
feat(spec): the config vocabulary

### DIFF
--- a/docs/cli/reference/commands.json
+++ b/docs/cli/reference/commands.json
@@ -1153,7 +1153,9 @@
     "examples": []
   },
   "config": {
-    "props": {}
+    "props": {},
+    "sources": {},
+    "files": []
   },
   "version": "5.1.0",
   "usage": "Usage: usage-cli [OPTIONS] [COMPLETIONS] <COMMAND>",

--- a/docs/spec/reference/config.md
+++ b/docs/spec/reference/config.md
@@ -108,7 +108,7 @@ And as child nodes, for anything multi-valued or long:
 | `cli "--jobs" "-j"`               | flags that set it                                             |
 | `env "A" "B"`                     | environment variables, highest precedence first               |
 | `source "git" "a.b"`              | its keys in a declared source kind                            |
-| `default "a" "b"`                 | a list default                                                |
+| `default "a" "b"`                 | a list default, values typed as written (`default 80 443`)    |
 | `long_help "…"`                   | the long form, when a raw string reads better than a property |
 | `example "…"`                     | one invocation worth showing                                  |
 | `choices { choice "a" help="…" }` | the values it accepts, each with its own help                 |

--- a/docs/spec/reference/config.md
+++ b/docs/spec/reference/config.md
@@ -1,53 +1,172 @@
 # Configuration
 
-The default priority for configuration properties in usage is the following:
-
-- CLI flag (e.g. `--user alice`)
-- Environment variable (e.g. `MYCLI_USER=alice`)
-- Config file (e.g. `~/.mycli.toml`)
-- Default value
-
-## Environment Variables
-
-TODO
-
-## Config Files
+A `config` block describes a CLI's settings: what they are called, what they hold, where a
+value can come from, and what to say about them in documentation. It is what
+`usage g markdown` renders as a settings reference, what a JSON schema for the config file
+is generated from, and what a runtime resolves values against.
 
 ```kdl
 config {
-    // system
-    file "/etc/mycli.toml"
-    file "/etc/mycli.json"
-
-    // global
-    file "~/.config/mycli.toml"
-    file "~/.config/mycli.json"
-
-    // local
-    file ".config/mycli.toml" findup=#true
-    file ".config/mycli.json" findup=#true
-    file ".mycli.dist.toml" findup=#true
-    file ".mycli.dist.json" findup=#true
-    file ".mycli.toml" findup=#true
-    file ".mycli.json" findup=#true
-    file ".myclirc" findup=#true format="ini"
-
-    // e.g.: .mycli.dev.toml, .mycli.prod.toml
-    file ".mycli.$MYCLI_ENV.toml" findup=#true
-
-    default "user" "admin"
-    default "work_dir" "/tmp"
-    default "yes" false
-
-    alias "user" "username"
+    prop "jobs" type="uint" default=0 help="Number of parallel jobs" {
+        cli "--jobs" "-j"
+        env "MYCLI_JOBS"
+    }
 }
 ```
 
-## Alias Config Keys
+Keys are dotted paths. `prop` blocks do not nest — write `prop "status.missing_tools"`
+rather than a `status` block containing a `missing_tools` one — because one spelling keeps
+merging, ordering and round-tripping unambiguous, and a schema generator can always
+re-nest on the dots.
 
-Config keys can be aliased to other keys. This is useful for backwards compatibility.
+## Where values come from
+
+Highest precedence first, and only the layers a CLI actually has:
+
+- the command line
+- the environment
+- config files, nearest first, with a `.local` variant outranking its base
+- the user's own configuration
+- files installed for the whole machine
+- the default a `prop` declares
+
+A property can name its sources explicitly; the order they are written in is the order they
+are consulted.
 
 ```kdl
-config_file ".mycli.toml" findup=#true
-config_alias "user" "username"
+prop "check" type="bool" {
+    cli "--check"              // flags that set it, as declared elsewhere in this spec
+    env "HK_CHECK" "HK_LINT"   // several: aliases, highest precedence first
+    source "git" "hk.check"    // a source kind declared below
+}
 ```
+
+## `source` — kinds usage does not know about
+
+usage reads the command line, the environment, and config files. Everything else — a git
+config, a pkl file, an `.npmrc` — is a _kind_ the CLI reads itself and declares here so
+documentation can describe it. `{key}` and `{value}` are substituted.
+
+```kdl
+config {
+    source "git" name="git config" doc_hint="git config `{key}`" \
+        set_hint="git config {key} {value}"
+    source "pkl" name="hk.pkl"
+}
+```
+
+Docs then render a property bound to that kind as "settable with `git config hk.check`",
+without usage having any idea what git is.
+
+## `file` — where config files live
+
+In ascending precedence: the last one named wins. This is the chain that rc-style merging
+walks, and writing it down is what lets documentation describe it accurately.
+
+```kdl
+config {
+    file "/etc/mycli/config.toml" scope="system"
+    file "~/.config/mycli/config.toml" scope="global"
+    file "mycli.toml" findup=#true
+    file "mycli.local.toml" findup=#true
+    file ".myclirc" format="ini"
+}
+```
+
+| property | meaning                                                      |
+| -------- | ------------------------------------------------------------ |
+| `findup` | look for this name in the current directory and every parent |
+| `scope`  | `project` (default), `global`, or `system`                   |
+| `format` | when the extension does not say: `toml`, `json`, `ini`       |
+
+`scope` is not decoration: a `prop` marked `scope="global"` refuses values from `project`
+files, so a setting a repository must not be able to change can say so.
+
+## `prop` — the settings
+
+| property                                     | meaning                                                                                                      |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `type`                                       | the type, see [below](#types). Defaults to `string`                                                          |
+| `default`                                    | the value when nothing supplies one — a typed KDL value: `4`, `#true`, `"x"`                                 |
+| `default_note`                               | what to print instead of the default, when the real one needs explaining                                     |
+| `help`, `long_help`                          | one line, and the whole markdown story                                                                       |
+| `help_heading`                               | the section to list it under in generated docs                                                               |
+| `merge`                                      | `replace` (default), `union` for collections, `deep` for maps                                                |
+| `scope`                                      | `any` (default), `global` (never from a project file), `env` (never from a file)                             |
+| `deprecated`                                 | why not to use it any more                                                                                   |
+| `deprecated_warn_at`, `deprecated_remove_at` | versions, for a tool that warns then removes                                                                 |
+| `renamed_to`                                 | the property that replaces this one, so an old key folds into the new                                        |
+| `hide`                                       | keep it out of docs and completions                                                                          |
+| `since`                                      | the version that introduced it                                                                               |
+| `parse`                                      | a named parser for one string: `list_by_comma`, `list_by_colon`, `list_by_os_path_separator`, `set_by_comma` |
+| `writes_to`                                  | where `config set` should write it, when that is not the usual file                                          |
+
+And as child nodes, for anything multi-valued or long:
+
+| node                              | meaning                                                       |
+| --------------------------------- | ------------------------------------------------------------- |
+| `cli "--jobs" "-j"`               | flags that set it                                             |
+| `env "A" "B"`                     | environment variables, highest precedence first               |
+| `source "git" "a.b"`              | its keys in a declared source kind                            |
+| `default "a" "b"`                 | a list default                                                |
+| `long_help "…"`                   | the long form, when a raw string reads better than a property |
+| `example "…"`                     | one invocation worth showing                                  |
+| `choices { choice "a" help="…" }` | the values it accepts, each with its own help                 |
+| `x "ns.key" value`                | see [extensions](#extensions)                                 |
+
+## Types
+
+```
+base  := bool | string | int | uint | float | path | url | duration | object
+type  := base | list<type> | set<type> | map<base, type> | option<type> | type "|" type
+```
+
+`option<T>` means absent is a legitimate state with no default standing in. A union —
+`bool|string` — records that a setting takes either; nothing here validates which.
+
+A name this version of usage does not know is kept as written rather than refused, so a
+spec can name a type only its own tool understands and still load everywhere else. Anything
+consuming a type it cannot interpret treats it as a string.
+
+For compatibility, `data_type` is still read as a spelling of `type`, and the older names
+(`boolean`, `integer`, `number`, `usize`, `array<…>`, `optional<…>`) are accepted.
+
+## Extensions
+
+A tool often needs to carry something usage has no opinion about — which Rust type a
+setting deserializes into, which file a write should be routed to, an enterprise policy.
+`x` nodes hold it: preserved in order, written back out unchanged, present in
+`usage g json`, and interpreted by nothing in usage.
+
+```kdl
+prop "python.uv_venv_auto" type="bool|string" {
+    x "mise.rust_type" "PythonUvVenvAuto"
+    x "mise.parse_env" "bool_string"
+}
+```
+
+This is the seam that lets a CLI with special rules describe its settings here without
+usage having to model those rules.
+
+## Splitting it out
+
+A CLI with many settings does not want them inline. `include` reads another file, resolved
+relative to the one naming it:
+
+```kdl
+name "mise"
+bin "mise"
+include file="./settings.usage.kdl"
+```
+
+## Compatibility
+
+The parser refuses vocabulary it does not know, so a spec using anything on this page must
+say which version of usage it needs:
+
+```kdl
+min_usage_version "2.0"
+```
+
+Without it, an older `usage` fails to read the whole spec rather than quietly ignoring the
+part it cannot understand.

--- a/lib/src/spec/config.rs
+++ b/lib/src/spec/config.rs
@@ -4,9 +4,10 @@ use kdl::{KdlDocument, KdlEntry, KdlNode};
 use serde::Serialize;
 
 use crate::error::UsageErr;
+use crate::spec::config_type::SpecConfigType;
 use crate::spec::context::ParsingContext;
 use crate::spec::data_types::SpecDataTypes;
-use crate::spec::helpers::{string_entry, NodeHelper};
+use crate::spec::helpers::{string_entry, NodeHelper, ParseEntry};
 
 /// A config property's value, as declared.
 ///
@@ -95,6 +96,16 @@ impl SpecConfigValue {
         }
     }
 
+    /// This value as a bare node argument.
+    fn to_kdl_arg(&self) -> KdlEntry {
+        match self {
+            Self::Bool(b) => KdlEntry::new(*b),
+            Self::Int(i) => KdlEntry::new(kdl::KdlValue::Integer(*i as i128)),
+            Self::Float(f) => KdlEntry::new(*f),
+            Self::String(s) => string_entry(None, s),
+        }
+    }
+
     /// The same value read as the type the prop declares.
     ///
     /// A spec may write the value as a string and the type as a number —
@@ -175,10 +186,133 @@ impl From<String> for SpecConfigValue {
     }
 }
 
-#[derive(Debug, Default, Clone, Serialize)]
+#[derive(Debug, Default, Clone, PartialEq, Serialize)]
 #[non_exhaustive]
 pub struct SpecConfig {
     pub props: BTreeMap<String, SpecConfigProp>,
+    /// Source kinds this CLI reads that usage knows nothing about — a git config, a pkl
+    /// file, an `.npmrc`. Declared so docs can say where a setting comes from without
+    /// usage having to understand the source itself.
+    pub sources: BTreeMap<String, SpecConfigSource>,
+    /// Config file locations, in ascending precedence: the last one named wins. This is
+    /// the rc-style chain that docs have to describe and a resolver has to walk.
+    pub files: Vec<SpecConfigFile>,
+}
+
+/// A source kind's display metadata.
+///
+/// usage never reads a git config or an `.npmrc`; it renders what the spec says about
+/// them. `{key}` and `{value}` in a hint are substituted with the setting's key in that
+/// source and the value being set.
+#[derive(Debug, Default, Clone, PartialEq, Serialize)]
+#[non_exhaustive]
+pub struct SpecConfigSource {
+    /// What to call it in prose: "git config", "hk.pkl".
+    pub name: Option<String>,
+    /// How to describe reading a setting from it: "git config `{key}`".
+    pub doc_hint: Option<String>,
+    /// How to describe writing one: "git config {key} {value}".
+    pub set_hint: Option<String>,
+}
+
+/// Where a config file lives, and how it is found.
+#[derive(Debug, Default, Clone, PartialEq, Serialize)]
+#[non_exhaustive]
+pub struct SpecConfigFile {
+    pub path: String,
+    /// Whether to look for this name in the current directory and every parent.
+    pub findup: bool,
+    /// Which class of file this is. `Project` files are the ones a repository can carry,
+    /// and so the ones a `scope="global"` setting refuses to be read from.
+    pub scope: SpecConfigFileScope,
+    /// The format, when the extension does not say: "toml", "json", "ini".
+    pub format: Option<String>,
+}
+
+/// Which class of file a location belongs to.
+#[derive(
+    Debug,
+    Default,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    strum::Display,
+    strum::EnumString,
+    strum::VariantNames,
+    Serialize,
+)]
+#[strum(serialize_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum SpecConfigFileScope {
+    /// Somewhere a repository can carry — the least trusted.
+    #[default]
+    Project,
+    /// The user's own configuration.
+    Global,
+    /// Installed by whoever administers the machine.
+    System,
+}
+
+/// How values for one property combine across sources.
+#[derive(
+    Debug,
+    Default,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    strum::Display,
+    strum::EnumString,
+    strum::VariantNames,
+    Serialize,
+)]
+#[strum(serialize_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum SpecConfigMerge {
+    /// The highest-precedence source wins outright.
+    #[default]
+    Replace,
+    /// Collections from every source are concatenated, keeping first position.
+    Union,
+    /// Maps are merged key by key.
+    Deep,
+}
+
+/// Which sources a property may be read from.
+#[derive(
+    Debug,
+    Default,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    strum::Display,
+    strum::EnumString,
+    strum::VariantNames,
+    Serialize,
+)]
+#[strum(serialize_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum SpecConfigScope {
+    /// Any declared source.
+    #[default]
+    Any,
+    /// Only files a repository cannot supply, and the environment or command line.
+    ///
+    /// mise treats this as a security property — a checked-in file must not be able to
+    /// change it — which is why it is declared here rather than left to each tool.
+    Global,
+    /// Never from a file: the environment or the command line only.
+    Env,
+}
+
+/// One of a property's allowed values.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[non_exhaustive]
+pub struct SpecConfigChoice {
+    pub value: SpecConfigValue,
+    pub help: Option<String>,
 }
 
 impl SpecConfig {
@@ -186,6 +320,7 @@ impl SpecConfig {
     pub fn new(props: impl IntoIterator<Item = (String, SpecConfigProp)>) -> Self {
         Self {
             props: props.into_iter().collect(),
+            ..Default::default()
         }
     }
 }
@@ -194,53 +329,46 @@ impl SpecConfig {
     pub(crate) fn parse(ctx: &ParsingContext, node: &NodeHelper) -> Result<Self, UsageErr> {
         let mut config = Self::default();
         for node in node.children() {
-            node.ensure_arg_len(1..=1)?;
             match node.name() {
                 "prop" => {
-                    let key = node.arg(0)?;
-                    let key = key.ensure_string()?.to_string();
-                    // A `prop` with children used to parse and lose them: the loop below
-                    // reads properties only, so `prop "a" { prop "b" }` kept `a` and
-                    // dropped `b` without a word. Nesting is spelled with a dotted key.
-                    if let Some(children) = node.node.children() {
-                        if let Some(child) = children.nodes().first() {
-                            bail_parse!(
-                                ctx,
-                                child.name().span(),
-                                "config props cannot nest; write the key as \"a.b\""
-                            );
-                        }
-                    }
-                    let mut prop = SpecConfigProp::default();
+                    node.ensure_arg_len(1..=1)?;
+                    let key = node.arg(0)?.ensure_string()?.to_string();
+                    let prop = SpecConfigProp::parse(ctx, &node)?;
+                    config.props.insert(key, prop);
+                }
+                "source" => {
+                    node.ensure_arg_len(1..=1)?;
+                    let kind = node.arg(0)?.ensure_string()?.to_string();
+                    let mut source = SpecConfigSource::default();
                     for (k, v) in node.props() {
                         match k {
-                            "default" => {
-                                prop.default = match SpecConfigValue::from_kdl(v.value) {
-                                    Ok(value) => value,
-                                    Err(err) => {
-                                        bail_parse!(ctx, v.entry.span(), "{}", err.describe())
-                                    }
-                                }
+                            "name" => source.name = Some(v.ensure_string()?),
+                            "doc_hint" => source.doc_hint = Some(v.ensure_string()?),
+                            "set_hint" => source.set_hint = Some(v.ensure_string()?),
+                            k => {
+                                bail_parse!(ctx, node.span(), "unsupported config source key {k}")
                             }
-                            "default_note" => prop.default_note = Some(v.ensure_string()?),
-                            "data_type" => prop.data_type = v.ensure_string()?.parse()?,
-                            "env" => prop.env = v.ensure_string()?.to_string().into(),
-                            "help" => prop.help = v.ensure_string()?.to_string().into(),
-                            "long_help" => prop.long_help = v.ensure_string()?.to_string().into(),
-                            k => bail_parse!(ctx, node.span(), "unsupported config prop key {k}"),
                         }
                     }
-                    // After the loop, not inside it: `data_type` may be written after
-                    // `default` on the same node, and the declared type is what decides how
-                    // the value is read.
-                    prop.default = match prop.default.map(|v| v.coerced_to(prop.data_type)) {
-                        None => None,
-                        Some(Ok(value)) => Some(value),
-                        Some(Err(err)) => {
-                            bail_parse!(ctx, node.span(), "{}", err.describe())
-                        }
+                    refuse_children(ctx, &node, "source")?;
+                    config.sources.insert(kind, source);
+                }
+                "file" => {
+                    node.ensure_arg_len(1..=1)?;
+                    let mut file = SpecConfigFile {
+                        path: node.arg(0)?.ensure_string()?.to_string(),
+                        ..Default::default()
                     };
-                    config.props.insert(key, prop);
+                    for (k, v) in node.props() {
+                        match k {
+                            "findup" => file.findup = v.ensure_bool()?,
+                            "scope" => file.scope = parse_enum(ctx, &node, "scope", &v)?,
+                            "format" => file.format = Some(v.ensure_string()?),
+                            k => bail_parse!(ctx, node.span(), "unsupported config file key {k}"),
+                        }
+                    }
+                    refuse_children(ctx, &node, "file")?;
+                    config.files.push(file);
                 }
                 k => bail_parse!(ctx, node.node.name().span(), "unsupported config key {k}"),
             }
@@ -266,15 +394,56 @@ impl SpecConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[non_exhaustive]
 pub struct SpecConfigProp {
     pub default: Option<SpecConfigValue>,
     pub default_note: Option<String>,
+    /// The old five-value type, kept so a spec written against it still means what it said.
+    ///
+    /// `type` is the one to write now; this is set from it where the two overlap, so a
+    /// consumer reading either sees the same thing.
     pub data_type: SpecDataTypes,
+    /// The type, in the expression grammar: `list<string>`, `option<path>`, `bool|string`.
+    pub value_type: Option<SpecConfigType>,
+    /// The first environment variable, kept for the specs that wrote `env=`.
     pub env: Option<String>,
+    /// Every environment variable that sets this, highest precedence first.
+    pub envs: Vec<String>,
+    /// Flags that set this, as declared elsewhere in the spec.
+    pub cli: Vec<String>,
+    /// Keys this setting has in a custom source kind, by kind name.
+    pub bindings: BTreeMap<String, Vec<String>>,
     pub help: Option<String>,
     pub long_help: Option<String>,
+    /// The section to list this under in generated docs.
+    pub help_heading: Option<String>,
+    pub choices: Vec<SpecConfigChoice>,
+    pub merge: SpecConfigMerge,
+    pub scope: SpecConfigScope,
+    pub deprecated: Option<String>,
+    pub deprecated_warn_at: Option<String>,
+    pub deprecated_remove_at: Option<String>,
+    /// The property that replaces this one, so a value arriving under the old name can be
+    /// folded into the new one rather than ignored.
+    pub renamed_to: Option<String>,
+    /// Keep it out of docs and completions.
+    pub hide: bool,
+    /// The version that introduced it.
+    pub since: Option<String>,
+    /// A named parser for turning one string into this type — `list_by_comma` and friends.
+    /// Vocabulary rather than code, so any implementation can honor it.
+    pub parse: Option<String>,
+    /// Where `config set` should write this, when it is not the usual file.
+    pub writes_to: Option<String>,
+    pub examples: Vec<String>,
+    /// A list-valued default, which cannot be written as a single property.
+    pub default_list: Vec<String>,
+    /// Anything a tool needs to carry that usage does not interpret.
+    ///
+    /// Preserved in order and written back out, so a registry with tool-private metadata
+    /// (`mise.rust_type`, `aube.npm_shared`) round-trips through the spec untouched.
+    pub extensions: Vec<(String, SpecConfigValue)>,
 }
 
 impl SpecConfigProp {
@@ -311,16 +480,26 @@ impl SpecConfigProp {
         if let Some(default) = &self.default {
             node.push(default.to_kdl_entry("default"));
         }
-        // Written, unlike before: a type that is parsed and not serialized is a type that
-        // survives exactly one hop.
-        if self.data_type != SpecDataTypes::Null {
-            node.push(string_entry(Some("data_type"), &self.data_type.to_string()));
+        // The grammar spelling when there is one, the old five-value name otherwise: a
+        // spec that said `data_type` keeps saying it, and one that says `type` keeps the
+        // richer type it declared. Either way it is written, unlike before — a type parsed
+        // and not serialized survives exactly one hop.
+        match &self.value_type {
+            Some(ty) => node.push(string_entry(Some("type"), &ty.to_string())),
+            None if self.data_type != SpecDataTypes::Null => {
+                node.push(string_entry(Some("data_type"), &self.data_type.to_string()));
+            }
+            None => {}
         }
         if let Some(default_note) = &self.default_note {
             node.push(string_entry(Some("default_note"), default_note));
         }
-        if let Some(env) = &self.env {
-            node.push(string_entry(Some("env"), env));
+        // Only when it is the whole story: several go in a child node, and writing both
+        // would say it twice.
+        if self.envs.len() <= 1 {
+            if let Some(env) = &self.env {
+                node.push(string_entry(Some("env"), env));
+            }
         }
         if let Some(help) = &self.help {
             node.push(string_entry(Some("help"), help));
@@ -328,8 +507,323 @@ impl SpecConfigProp {
         if let Some(long_help) = &self.long_help {
             node.push(string_entry(Some("long_help"), long_help));
         }
+        if let Some(heading) = &self.help_heading {
+            node.push(string_entry(Some("help_heading"), heading));
+        }
+        if self.merge != SpecConfigMerge::default() {
+            node.push(string_entry(Some("merge"), &self.merge.to_string()));
+        }
+        if self.scope != SpecConfigScope::default() {
+            node.push(string_entry(Some("scope"), &self.scope.to_string()));
+        }
+        if let Some(deprecated) = &self.deprecated {
+            node.push(string_entry(Some("deprecated"), deprecated));
+        }
+        if let Some(at) = &self.deprecated_warn_at {
+            node.push(string_entry(Some("deprecated_warn_at"), at));
+        }
+        if let Some(at) = &self.deprecated_remove_at {
+            node.push(string_entry(Some("deprecated_remove_at"), at));
+        }
+        if let Some(renamed) = &self.renamed_to {
+            node.push(string_entry(Some("renamed_to"), renamed));
+        }
+        if self.hide {
+            node.push(KdlEntry::new_prop("hide", true));
+        }
+        if let Some(since) = &self.since {
+            node.push(string_entry(Some("since"), since));
+        }
+        if let Some(parse) = &self.parse {
+            node.push(string_entry(Some("parse"), parse));
+        }
+        if let Some(writes_to) = &self.writes_to {
+            node.push(string_entry(Some("writes_to"), writes_to));
+        }
+
+        let mut children = KdlDocument::new();
+        if self.envs.len() > 1 {
+            children.nodes_mut().push(string_list("env", &self.envs));
+        }
+        if !self.cli.is_empty() {
+            children.nodes_mut().push(string_list("cli", &self.cli));
+        }
+        if !self.default_list.is_empty() {
+            children
+                .nodes_mut()
+                .push(string_list("default", &self.default_list));
+        }
+        for (kind, keys) in &self.bindings {
+            let mut node = KdlNode::new("source");
+            node.push(string_entry(None, kind));
+            for key in keys {
+                node.push(string_entry(None, key));
+            }
+            children.nodes_mut().push(node);
+        }
+        if !self.choices.is_empty() {
+            let mut block = KdlNode::new("choices");
+            let mut inner = KdlDocument::new();
+            for choice in &self.choices {
+                let mut node = KdlNode::new("choice");
+                node.push(choice.value.to_kdl_arg());
+                if let Some(help) = &choice.help {
+                    node.push(string_entry(Some("help"), help));
+                }
+                inner.nodes_mut().push(node);
+            }
+            block.set_children(inner);
+            children.nodes_mut().push(block);
+        }
+        for example in &self.examples {
+            children
+                .nodes_mut()
+                .push(string_list("example", std::slice::from_ref(example)));
+        }
+        for (key, value) in &self.extensions {
+            let mut node = KdlNode::new("x");
+            node.push(string_entry(None, key));
+            node.push(value.to_kdl_arg());
+            children.nodes_mut().push(node);
+        }
+        if !children.nodes().is_empty() {
+            node.set_children(children);
+        }
         node
     }
+}
+
+/// The old five-value type a grammar type corresponds to, where one does.
+///
+/// A composite — `list<string>`, `map<…>` — has no counterpart, so it reads as `Null`:
+/// truthful about what the old vocabulary could say.
+fn data_type_of(ty: &SpecConfigType) -> SpecDataTypes {
+    use crate::spec::config_type::Base;
+    // A union has no counterpart among the old five values, so it gets `Null` like every
+    // other composite. Running it through `simplified()` made `bool|string` claim to be
+    // `Boolean`, and that legacy field drives how a default is read — so a `bool|string`
+    // whose default was the string `"true"` came back as a boolean, contradicting the very
+    // `value_type` that produced it.
+    if matches!(ty, SpecConfigType::Union(_)) {
+        return SpecDataTypes::Null;
+    }
+    match ty.simplified() {
+        SpecConfigType::Base(Base::Bool) => SpecDataTypes::Boolean,
+        SpecConfigType::Base(Base::String) => SpecDataTypes::String,
+        SpecConfigType::Base(Base::Int | Base::Uint) => SpecDataTypes::Integer,
+        SpecConfigType::Base(Base::Float) => SpecDataTypes::Float,
+        _ => SpecDataTypes::Null,
+    }
+}
+
+/// Refuse a child block on a node that has no children in its vocabulary.
+///
+/// `source` and `file` are properties only. They checked their properties and never looked at
+/// their children, so a nested block was dropped in silence — which contradicts the rule the
+/// rest of this block follows, and `prop` already enforces: vocabulary this version does not
+/// know is refused rather than half-read, because half-read is how a spec means one thing here
+/// and another somewhere else.
+fn refuse_children(
+    ctx: &ParsingContext,
+    node: &NodeHelper,
+    name: &'static str,
+) -> Result<(), UsageErr> {
+    if let Some(child) = node.children().into_iter().next() {
+        bail_parse!(
+            ctx,
+            child.node.name().span(),
+            "a config {name} takes properties, not a block"
+        );
+    }
+    Ok(())
+}
+
+/// A node whose arguments are strings: `cli "--jobs" "-j"`.
+fn string_list(name: &str, values: &[String]) -> KdlNode {
+    let mut node = KdlNode::new(name);
+    for value in values {
+        node.push(string_entry(None, value));
+    }
+    node
+}
+
+impl SpecConfigProp {
+    fn parse(ctx: &ParsingContext, node: &NodeHelper) -> Result<Self, UsageErr> {
+        let mut prop = Self::default();
+        for (k, v) in node.props() {
+            match k {
+                "default" => {
+                    prop.default = match SpecConfigValue::from_kdl(v.value) {
+                        Ok(value) => value,
+                        Err(err) => bail_parse!(ctx, v.entry.span(), "{}", err.describe()),
+                    }
+                }
+                "default_note" => prop.default_note = Some(v.ensure_string()?),
+                // `data_type` was the old spelling and stays readable; `type` is the
+                // grammar, and setting either fills the other in where they overlap.
+                "data_type" | "type" => {
+                    let ty: SpecConfigType = v.ensure_string()?.parse()?;
+                    // From the parsed type rather than its text: the grammar spells a
+                    // boolean `bool` and the old enum spells it `boolean`, so reading the
+                    // text twice loses it on the way back out.
+                    prop.data_type = data_type_of(&ty);
+                    prop.value_type = Some(ty);
+                }
+                "env" => prop.env = Some(v.ensure_string()?),
+                "help" => prop.help = Some(v.ensure_string()?),
+                "long_help" => prop.long_help = Some(v.ensure_string()?),
+                "help_heading" => prop.help_heading = Some(v.ensure_string()?),
+                "merge" => prop.merge = parse_enum(ctx, node, "merge", &v)?,
+                "scope" => prop.scope = parse_enum(ctx, node, "scope", &v)?,
+                "deprecated" => prop.deprecated = Some(v.ensure_string()?),
+                "deprecated_warn_at" => prop.deprecated_warn_at = Some(v.ensure_string()?),
+                "deprecated_remove_at" => prop.deprecated_remove_at = Some(v.ensure_string()?),
+                "renamed_to" => prop.renamed_to = Some(v.ensure_string()?),
+                "hide" => prop.hide = v.ensure_bool()?,
+                "since" => prop.since = Some(v.ensure_string()?),
+                "parse" => prop.parse = Some(v.ensure_string()?),
+                "writes_to" => prop.writes_to = Some(v.ensure_string()?),
+                k => bail_parse!(ctx, node.span(), "unsupported config prop key {k}"),
+            }
+        }
+
+        for child in node.children() {
+            match child.name() {
+                // The mistake worth naming: it used to parse and lose the inner prop.
+                "prop" => bail_parse!(
+                    ctx,
+                    child.node.name().span(),
+                    "config props cannot nest; write the key as \"a.b\""
+                ),
+                // Where several values, or prose, would not fit on the node.
+                "env" => prop.envs = string_args(&child)?,
+                "cli" => prop.cli = string_args(&child)?,
+                "example" => prop.examples.extend(string_args(&child)?),
+                "long_help" => {
+                    child.ensure_arg_len(1..=1)?;
+                    prop.long_help = Some(child.arg(0)?.ensure_string()?.to_string());
+                }
+                "default" => {
+                    // A list default, which cannot be written as one property.
+                    prop.default_list = string_args(&child)?;
+                }
+                "source" => {
+                    // `source "git" "hk.jobs" "hk.check"` — this setting's keys in a kind
+                    // declared at the top of the block.
+                    child.ensure_arg_len(1..)?;
+                    let mut args = string_args(&child)?;
+                    let kind = args.remove(0);
+                    prop.bindings.entry(kind).or_default().extend(args);
+                }
+                "choices" => {
+                    for choice in child.children() {
+                        if choice.name() != "choice" {
+                            bail_parse!(
+                                ctx,
+                                choice.node.name().span(),
+                                "a choices block holds `choice` nodes"
+                            );
+                        }
+                        choice.ensure_arg_len(1..=1)?;
+                        let value = match SpecConfigValue::from_kdl(choice.arg(0)?.value) {
+                            Ok(Some(value)) => value,
+                            Ok(None) => bail_parse!(ctx, choice.span(), "a choice needs a value"),
+                            // Same reasons, said about a choice rather than a default: a
+                            // number too large to carry, or one nothing can render.
+                            Err(err) => {
+                                bail_parse!(ctx, choice.span(), "choice: {}", err.describe())
+                            }
+                        };
+                        let mut help = None;
+                        for (k, v) in choice.props() {
+                            match k {
+                                "help" => help = Some(v.ensure_string()?),
+                                k => bail_parse!(ctx, choice.span(), "unsupported choice key {k}"),
+                            }
+                        }
+                        prop.choices.push(SpecConfigChoice { value, help });
+                    }
+                }
+                "x" => {
+                    // The escape hatch: kept in order, written back out, interpreted by
+                    // nobody here.
+                    child.ensure_arg_len(2..=2)?;
+                    let key = child.arg(0)?.ensure_string()?.to_string();
+                    let value = match SpecConfigValue::from_kdl(child.arg(1)?.value) {
+                        Ok(Some(value)) => value,
+                        Ok(None) => SpecConfigValue::String(String::new()),
+                        Err(err) => {
+                            bail_parse!(ctx, child.span(), "extension value: {}", err.describe())
+                        }
+                    };
+                    prop.extensions.push((key, value));
+                }
+                k => bail_parse!(
+                    ctx,
+                    child.node.name().span(),
+                    "unsupported config prop node {k}"
+                ),
+            }
+        }
+
+        // After both loops: `type` may be written after `default`, and the declared type is
+        // what decides how the value is read.
+        let declared = prop.data_type;
+        prop.default = match prop.default.map(|v| v.coerced_to(declared)) {
+            None => None,
+            Some(Ok(value)) => Some(value),
+            Some(Err(err)) => bail_parse!(ctx, node.span(), "{}", err.describe()),
+        };
+        // One env spelling, two ways to write it, and they must never disagree. `env=` is
+        // shorthand for a one-element list, so both forms feed `envs` in the order they were
+        // written and `env` is always its first entry.
+        //
+        // Syncing only when one side was empty left a prop that wrote *both* with two fields
+        // saying different things — `usage g json` exposing the pair, and a writer that picks
+        // between them by list length, so one of the values disappeared on a round trip.
+        if let Some(env) = prop.env.take() {
+            if !prop.envs.contains(&env) {
+                prop.envs.insert(0, env);
+            }
+        }
+        prop.env = prop.envs.first().cloned();
+        Ok(prop)
+    }
+}
+
+/// Every argument of a node, as strings.
+fn string_args(node: &NodeHelper) -> Result<Vec<String>, UsageErr> {
+    node.node
+        .entries()
+        .iter()
+        .filter(|e| e.name().is_none())
+        .map(|e| match e.value() {
+            kdl::KdlValue::String(s) => Ok(s.clone()),
+            other => Ok(other.to_string()),
+        })
+        .collect()
+}
+
+/// An enum-valued property, with the accepted spellings in the error.
+fn parse_enum<T>(
+    ctx: &ParsingContext,
+    node: &NodeHelper,
+    key: &str,
+    value: &ParseEntry<'_>,
+) -> Result<T, UsageErr>
+where
+    T: std::str::FromStr + strum::VariantNames,
+{
+    let text = value.ensure_string()?;
+    text.parse().map_err(|_| {
+        ctx.build_err(
+            format!(
+                "`{text}` is not a {key}; the choices are {}",
+                T::VARIANTS.join(", ")
+            ),
+            (node.span().offset(), node.span().len()).into(),
+        )
+    })
 }
 
 impl Default for SpecConfigProp {
@@ -338,9 +832,28 @@ impl Default for SpecConfigProp {
             default: None,
             default_note: None,
             data_type: SpecDataTypes::Null,
+            value_type: None,
             env: None,
+            envs: Vec::new(),
+            cli: Vec::new(),
+            bindings: BTreeMap::new(),
             help: None,
             long_help: None,
+            help_heading: None,
+            choices: Vec::new(),
+            merge: SpecConfigMerge::default(),
+            scope: SpecConfigScope::default(),
+            deprecated: None,
+            deprecated_warn_at: None,
+            deprecated_remove_at: None,
+            renamed_to: None,
+            hide: false,
+            since: None,
+            parse: None,
+            writes_to: None,
+            examples: Vec::new(),
+            default_list: Vec::new(),
+            extensions: Vec::new(),
         }
     }
 }
@@ -348,8 +861,39 @@ impl Default for SpecConfigProp {
 impl From<&SpecConfig> for KdlNode {
     fn from(config: &SpecConfig) -> Self {
         let mut node = KdlNode::new("config");
+        let doc = node.children_mut().get_or_insert_with(KdlDocument::new);
+        // Declarations first, then locations, then the settings — the order the reference
+        // page describes them in, so a written file reads like the documentation.
+        for (kind, source) in &config.sources {
+            let mut node = KdlNode::new("source");
+            node.push(string_entry(None, kind));
+            if let Some(name) = &source.name {
+                node.push(string_entry(Some("name"), name));
+            }
+            if let Some(hint) = &source.doc_hint {
+                node.push(string_entry(Some("doc_hint"), hint));
+            }
+            if let Some(hint) = &source.set_hint {
+                node.push(string_entry(Some("set_hint"), hint));
+            }
+            doc.nodes_mut().push(node);
+        }
+        // In order: a file list is a precedence chain, so the order is the meaning.
+        for file in &config.files {
+            let mut node = KdlNode::new("file");
+            node.push(string_entry(None, &file.path));
+            if file.findup {
+                node.push(KdlEntry::new_prop("findup", true));
+            }
+            if file.scope != SpecConfigFileScope::default() {
+                node.push(string_entry(Some("scope"), &file.scope.to_string()));
+            }
+            if let Some(format) = &file.format {
+                node.push(string_entry(Some("format"), format));
+            }
+            doc.nodes_mut().push(node);
+        }
         for (key, prop) in &config.props {
-            let doc = node.children_mut().get_or_insert_with(KdlDocument::new);
             doc.nodes_mut().push(prop.to_kdl_node(key.to_string()));
         }
         node
@@ -371,7 +915,7 @@ mod tests {
         }
     }
 
-    use super::SpecConfigValue;
+    use super::{SpecConfigMerge, SpecConfigScope, SpecConfigValue};
     use crate::Spec;
     use insta::assert_snapshot;
 
@@ -631,6 +1175,150 @@ config {
             spec.config.props["shell"].default,
             Some(SpecConfigValue::String("true".into()))
         );
+    }
+
+    /// Every node kind the vocabulary has, written and read back.
+    ///
+    /// The spec is the interchange between authoring and everything that consumes it, so
+    /// anything it cannot write out is something a tool would lose by saving its own file.
+    #[test]
+    fn the_whole_vocabulary_survives_a_round_trip() {
+        let spec: Spec = r##"
+name "hk"
+bin "hk"
+config {
+    source "git" name="git config" doc_hint="git config `{key}`" set_hint="git config {key} {value}"
+    source "pkl" name="hk.pkl"
+    file "/etc/hk/config.pkl" scope="system"
+    file "~/.config/hk/config.pkl" scope="global"
+    file "hk.pkl" findup=#true
+    file ".hkrc" format="ini"
+    prop "jobs" type="uint" default=0 default_note="0 = auto-detect" \
+        help="Number of parallel jobs" since="1.0.0" help_heading="Performance" {
+        cli "--jobs" "-j"
+        env "HK_JOBS" "HK_JOB"
+        source "git" "hk.jobs"
+        source "pkl" "jobs" "defaults.jobs"
+        example "hk check --jobs 4"
+    }
+    prop "exclude" type="list<string>" merge="union" {
+        default "target" "node_modules"
+        env "HK_EXCLUDE"
+    }
+    prop "stash" type="string" {
+        choices {
+            choice "git" help="Use `git stash`"
+            choice "none" help="No stashing"
+        }
+    }
+    prop "trusted" type="bool" scope="global"
+    prop "ci" type="bool" hide=#true scope="env" {
+        env "CI"
+        x "mise.rust_type" "BoolOrString"
+        x "mise.rc" #true
+    }
+    prop "old.key" deprecated="Use new.key" renamed_to="new.key" \
+        deprecated_warn_at="2026.12.0" deprecated_remove_at="2027.12.0"
+    prop "urls" type="map<string, url>" parse="list_by_comma" writes_to="npmrc"
+}
+"##
+        .parse()
+        .unwrap();
+
+        let written = spec.to_string();
+        let back: Spec = written
+            .parse()
+            .unwrap_or_else(|e| panic!("re-reading what we wrote: {e}\n{written}"));
+
+        assert_eq!(back.config.sources, spec.config.sources, "{written}");
+        assert_eq!(back.config.files, spec.config.files, "{written}");
+        assert_eq!(
+            back.config.props.keys().collect::<Vec<_>>(),
+            spec.config.props.keys().collect::<Vec<_>>(),
+            "{written}"
+        );
+        for (key, before) in &spec.config.props {
+            let after = &back.config.props[key];
+            assert_eq!(after, before, "{key} changed on the way out:\n{written}");
+        }
+
+        // And the pieces that are easy to write and forget to read.
+        let jobs = &spec.config.props["jobs"];
+        assert_eq!(jobs.cli, ["--jobs", "-j"]);
+        assert_eq!(jobs.envs, ["HK_JOBS", "HK_JOB"]);
+        assert_eq!(
+            jobs.env.as_deref(),
+            Some("HK_JOBS"),
+            "the first of the list"
+        );
+        assert_eq!(jobs.bindings["pkl"], ["jobs", "defaults.jobs"]);
+        assert_eq!(jobs.examples, ["hk check --jobs 4"]);
+        assert_eq!(jobs.help_heading.as_deref(), Some("Performance"));
+        assert_eq!(spec.config.props["exclude"].merge, SpecConfigMerge::Union);
+        assert_eq!(
+            spec.config.props["exclude"].default_list,
+            ["target", "node_modules"]
+        );
+        assert_eq!(spec.config.props["stash"].choices.len(), 2);
+        assert_eq!(
+            spec.config.props["stash"].choices[0].help.as_deref(),
+            Some("Use `git stash`")
+        );
+        assert_eq!(spec.config.props["trusted"].scope, SpecConfigScope::Global);
+        assert_eq!(spec.config.props["ci"].scope, SpecConfigScope::Env);
+        assert!(spec.config.props["ci"].hide);
+        assert_eq!(
+            spec.config.props["ci"].extensions,
+            [
+                (
+                    "mise.rust_type".to_string(),
+                    SpecConfigValue::String("BoolOrString".into())
+                ),
+                ("mise.rc".to_string(), SpecConfigValue::Bool(true)),
+            ]
+        );
+        assert_eq!(
+            spec.config.props["old.key"].renamed_to.as_deref(),
+            Some("new.key")
+        );
+        assert_eq!(
+            spec.config.props["urls"]
+                .value_type
+                .as_ref()
+                .map(|t| t.to_string()),
+            Some("map<string, url>".to_string())
+        );
+        assert_eq!(
+            spec.config.props["urls"].parse.as_deref(),
+            Some("list_by_comma")
+        );
+        assert_eq!(
+            spec.config.props["urls"].writes_to.as_deref(),
+            Some("npmrc")
+        );
+
+        // The serialized model, committed: this is what `usage g json` hands to a docs
+        // pipeline, a schema generator, or an implementation in another language, and it is
+        // the artifact a port can diff against rather than reading this file.
+        assert_snapshot!(serde_json::to_string_pretty(&spec.config).unwrap());
+    }
+
+    #[test]
+    fn an_unknown_word_in_the_config_block_is_refused() {
+        // Strict, deliberately: a spec using vocabulary this version does not have should
+        // say so rather than half-load. That is what `min_usage_version` is for.
+        for src in [
+            "config {\n  prop \"a\" nonsense=1\n}\n",
+            "config {\n  nonsense \"a\"\n}\n",
+            "config {\n  prop \"a\" {\n    nonsense \"b\"\n  }\n}\n",
+            "config {\n  prop \"a\" merge=\"sideways\"\n}\n",
+            "config {\n  file \"x\" scope=\"elsewhere\"\n}\n",
+        ] {
+            assert!(
+                Spec::parse(&Default::default(), src).is_err(),
+                "should be refused: {src}"
+            );
+        }
     }
 
     #[test]

--- a/lib/src/spec/config.rs
+++ b/lib/src/spec/config.rs
@@ -385,12 +385,27 @@ impl SpecConfig {
         for (key, prop) in &other.props {
             self.props.insert(key.to_string(), prop.clone());
         }
+        // Source kinds are a set, so they merge per kind like props do.
+        for (kind, source) in &other.sources {
+            self.sources.insert(kind.to_string(), source.clone());
+        }
+        // Files are not a set but an ordered precedence chain, and there is no meaningful
+        // way to interleave two of them — so a spec that declares any replaces the chain
+        // whole rather than appending to one it never saw. In the case `include` exists for,
+        // only one of the two declares files at all.
+        if !other.files.is_empty() {
+            self.files = other.files.clone();
+        }
     }
 }
 
 impl SpecConfig {
+    /// Whether there is nothing to write out.
+    ///
+    /// All three, not just props: a `config` block that declares only where files live is a
+    /// perfectly good one, and reporting it empty made the writer drop it.
     pub fn is_empty(&self) -> bool {
-        self.props.is_empty()
+        self.props.is_empty() && self.sources.is_empty() && self.files.is_empty()
     }
 }
 
@@ -438,7 +453,10 @@ pub struct SpecConfigProp {
     pub writes_to: Option<String>,
     pub examples: Vec<String>,
     /// A list-valued default, which cannot be written as a single property.
-    pub default_list: Vec<String>,
+    ///
+    /// Typed like the scalar `default`, so `default 1 2 3` for a `list<int>` stays three
+    /// numbers all the way to the JSON schema instead of becoming three strings.
+    pub default_list: Vec<SpecConfigValue>,
     /// Anything a tool needs to carry that usage does not interpret.
     ///
     /// Preserved in order and written back out, so a registry with tool-private metadata
@@ -452,9 +470,19 @@ impl SpecConfigProp {
         Self::default()
     }
 
-    /// Environment variable that sets this property.
+    /// An environment variable that sets this property.
+    ///
+    /// Call it more than once for aliases, highest precedence first, the way
+    /// `env "HK_JOBS" "HK_JOB"` reads in a spec. Both `env` and `envs` are maintained, so a
+    /// consumer can read either — the parser holds the same invariant, and a builder that
+    /// left `envs` empty meant a programmatically built spec serialized without the variable
+    /// every reader of `envs` looks for.
     pub fn env(mut self, env: impl Into<String>) -> Self {
-        self.env = Some(env.into());
+        let env = env.into();
+        if self.env.is_none() {
+            self.env = Some(env.clone());
+        }
+        self.envs.push(env);
         self
     }
 
@@ -549,9 +577,11 @@ impl SpecConfigProp {
             children.nodes_mut().push(string_list("cli", &self.cli));
         }
         if !self.default_list.is_empty() {
-            children
-                .nodes_mut()
-                .push(string_list("default", &self.default_list));
+            let mut node = KdlNode::new("default");
+            for value in &self.default_list {
+                node.push(value.to_kdl_arg());
+            }
+            children.nodes_mut().push(node);
         }
         for (kind, keys) in &self.bindings {
             let mut node = KdlNode::new("source");
@@ -696,16 +726,36 @@ impl SpecConfigProp {
                     "config props cannot nest; write the key as \"a.b\""
                 ),
                 // Where several values, or prose, would not fit on the node.
-                "env" => prop.envs = string_args(&child)?,
-                "cli" => prop.cli = string_args(&child)?,
+                // Extended, not assigned: `example` and `source` already accumulate, and a
+                // second `env` line is the natural parallel — assigning silently dropped the
+                // aliases on the first one.
+                "env" => prop.envs.extend(string_args(&child)?),
+                "cli" => prop.cli.extend(string_args(&child)?),
                 "example" => prop.examples.extend(string_args(&child)?),
                 "long_help" => {
                     child.ensure_arg_len(1..=1)?;
                     prop.long_help = Some(child.arg(0)?.ensure_string()?.to_string());
                 }
                 "default" => {
-                    // A list default, which cannot be written as one property.
-                    prop.default_list = string_args(&child)?;
+                    // A list default, which cannot be written as one property. Accumulated
+                    // across nodes like `env`, `cli` and `example`, rather than assigned —
+                    // clearing the list first meant a second `default` line silently dropped
+                    // everything the first one declared.
+                    for arg in child.args() {
+                        match SpecConfigValue::from_kdl(arg.value) {
+                            Ok(Some(value)) => prop.default_list.push(value),
+                            // `#null` in a list of defaults says nothing at all; a list
+                            // whose default is "one of these is absent" has no meaning.
+                            Ok(None) => bail_parse!(
+                                ctx,
+                                arg.entry.span(),
+                                "a default list holds values, not #null"
+                            ),
+                            Err(err) => {
+                                bail_parse!(ctx, arg.entry.span(), "{}", err.describe())
+                            }
+                        }
+                    }
                 }
                 "source" => {
                     // `source "git" "hk.jobs" "hk.check"` — this setting's keys in a kind
@@ -741,6 +791,7 @@ impl SpecConfigProp {
                                 k => bail_parse!(ctx, choice.span(), "unsupported choice key {k}"),
                             }
                         }
+                        refuse_children(ctx, &choice, "choice")?;
                         prop.choices.push(SpecConfigChoice { value, help });
                     }
                 }
@@ -751,7 +802,14 @@ impl SpecConfigProp {
                     let key = child.arg(0)?.ensure_string()?.to_string();
                     let value = match SpecConfigValue::from_kdl(child.arg(1)?.value) {
                         Ok(Some(value)) => value,
-                        Ok(None) => SpecConfigValue::String(String::new()),
+                        // An extension promises to come back out exactly as it went in, and
+                        // there is no `#null` to come back to — it used to be stored as `""`
+                        // and written as `""`, which is tool-private metadata altered on save.
+                        Ok(None) => bail_parse!(
+                            ctx,
+                            child.span(),
+                            "an extension value cannot be #null; it would not round-trip"
+                        ),
                         Err(err) => {
                             bail_parse!(ctx, child.span(), "extension value: {}", err.describe())
                         }
@@ -792,16 +850,14 @@ impl SpecConfigProp {
 }
 
 /// Every argument of a node, as strings.
+/// The string arguments of a node, refusing anything that is not one.
+///
+/// An environment variable, a flag and a source key are names, so a non-string is a mistake
+/// rather than something to render. Converting instead — which this used to do — turned
+/// `env #true` into a variable named `#true` and wrote it back out quoted, looking for all
+/// the world like somebody had meant it.
 fn string_args(node: &NodeHelper) -> Result<Vec<String>, UsageErr> {
-    node.node
-        .entries()
-        .iter()
-        .filter(|e| e.name().is_none())
-        .map(|e| match e.value() {
-            kdl::KdlValue::String(s) => Ok(s.clone()),
-            other => Ok(other.to_string()),
-        })
-        .collect()
+    node.args().map(|arg| arg.ensure_string()).collect()
 }
 
 /// An enum-valued property, with the accepted spellings in the error.
@@ -1257,7 +1313,10 @@ config {
         assert_eq!(spec.config.props["exclude"].merge, SpecConfigMerge::Union);
         assert_eq!(
             spec.config.props["exclude"].default_list,
-            ["target", "node_modules"]
+            [
+                SpecConfigValue::String("target".into()),
+                SpecConfigValue::String("node_modules".into()),
+            ]
         );
         assert_eq!(spec.config.props["stash"].choices.len(), 2);
         assert_eq!(
@@ -1366,5 +1425,230 @@ config {
         );
         assert_eq!(spec.config.props["jobs"].help.as_deref(), Some("second"));
         assert!(spec.config.props.contains_key("color"));
+    }
+
+    #[test]
+    fn an_included_file_can_declare_sources_and_files() {
+        // The case `include` exists for: a spec with many settings keeps them in their own
+        // file, and that file is where the whole block lives — the source kinds and the file
+        // chain included. Merging only props dropped both, so a settings file could describe
+        // where values come from and have it silently discarded.
+        let mut spec = Spec::parse(&Default::default(), "name \"hk\"\nbin \"hk\"\n").unwrap();
+        let included = Spec::parse(
+            &Default::default(),
+            r#"
+config {
+    source "git" name="git config"
+    file "/etc/hk/config.pkl" scope="system"
+    file "hk.pkl" findup=#true
+    prop "jobs" type="uint"
+}
+"#,
+        )
+        .unwrap();
+
+        spec.merge(included);
+        assert_eq!(
+            spec.config.sources["git"].name.as_deref(),
+            Some("git config")
+        );
+        assert_eq!(spec.config.files.len(), 2);
+        assert_eq!(spec.config.files[1].path, "hk.pkl");
+        assert!(spec.config.files[1].findup);
+    }
+
+    #[test]
+    fn a_block_of_only_files_is_not_empty() {
+        // `is_empty` decides whether the writer emits the block at all, so counting only
+        // props meant a config block that declared just where files live vanished on a round
+        // trip — the same class of loss as the defaults this stack started with.
+        let spec = Spec::parse(
+            &Default::default(),
+            "name \"x\"\nbin \"x\"\nconfig {\n  file \"x.toml\" findup=#true\n}\n",
+        )
+        .unwrap();
+        assert!(!spec.config.is_empty());
+        // Unquoted: the writer only quotes what KDL requires it to.
+        assert!(spec.to_string().contains("file x.toml"), "{spec}");
+    }
+
+    #[test]
+    fn a_name_that_is_not_a_string_is_refused() {
+        // These are all names — an environment variable, a flag, a key in another source.
+        // Rendering a non-string instead of refusing it produced a variable called `#true`
+        // and wrote it back out quoted, as though somebody had meant it.
+        for body in [
+            "prop \"a\" {\n  env #true\n}",
+            "prop \"a\" {\n  cli 42\n}",
+            "prop \"a\" {\n  source \"git\" 1\n}",
+            "prop \"a\" {\n  example #false\n}",
+        ] {
+            let src = format!("name \"x\"\nbin \"x\"\nconfig {{\n{body}\n}}\n");
+            assert!(
+                Spec::parse(&Default::default(), &src).is_err(),
+                "should not parse:\n{src}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_union_has_no_legacy_type_and_does_not_claim_one() {
+        // `data_type` is the old five-value field and a union is not one of the five. Mapping
+        // it through `simplified()` made `bool|string` say `Boolean` — and that field decides
+        // how a default is read, so the string default came back as a boolean, contradicting
+        // the `value_type` it was derived from.
+        let spec = Spec::parse(
+            &Default::default(),
+            "name \"x\"\nbin \"x\"\nconfig {\n  prop \"a\" type=\"bool|string\" default=\"true\"\n}\n",
+        )
+        .expect("should parse");
+        let prop = &spec.config.props["a"];
+        assert_eq!(prop.data_type, crate::spec::data_types::SpecDataTypes::Null);
+        assert_eq!(
+            prop.default,
+            Some(SpecConfigValue::String("true".into())),
+            "a union's default is left as written"
+        );
+        // The plain boolean it is not the same as still reads as one.
+        let spec = Spec::parse(
+            &Default::default(),
+            "name \"x\"\nbin \"x\"\nconfig {\n  prop \"a\" type=\"bool\" default=\"true\"\n}\n",
+        )
+        .expect("should parse");
+        assert_eq!(
+            spec.config.props["a"].default,
+            Some(SpecConfigValue::Bool(true))
+        );
+    }
+
+    #[test]
+    fn an_extension_that_could_not_round_trip_is_refused() {
+        // `x` nodes promise to come back out exactly as they went in. `#null` had nowhere to
+        // come back to: it was stored as an empty string and written as `""`, which is
+        // tool-private metadata quietly altered by saving the file.
+        let err = Spec::parse(
+            &Default::default(),
+            "config {\n  prop \"a\" {\n    x \"mise.thing\" #null\n  }\n}\n",
+        )
+        .expect_err("should not parse");
+        assert!(
+            detail_of(&err).contains("round-trip"),
+            "refused for the wrong reason: {}",
+            detail_of(&err)
+        );
+    }
+
+    #[test]
+    fn a_second_default_node_adds_to_the_first() {
+        // The same reason `env` and `cli` accumulate: clearing the list first meant a prop
+        // that wrote its default over two lines kept only the second.
+        let spec = Spec::parse(
+            &Default::default(),
+            "name \"x\"\nbin \"x\"\nconfig {\n  prop \"a\" type=\"list<string>\" {\n    default \"one\"\n    default \"two\"\n  }\n}\n",
+        )
+        .expect("should parse");
+        assert_eq!(
+            spec.config.props["a"].default_list,
+            [
+                SpecConfigValue::String("one".into()),
+                SpecConfigValue::String("two".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_second_env_or_cli_node_adds_to_the_first() {
+        // `example` and `source` already accumulate across nodes; `env` and `cli` assigned, so
+        // a spec that wrote them on two lines lost the first line's values without a word.
+        let spec = Spec::parse(
+            &Default::default(),
+            "name \"x\"\nbin \"x\"\nconfig {\n  prop \"a\" {\n    env \"FIRST\"\n    env \"SECOND\"\n    cli \"--one\"\n    cli \"--two\"\n  }\n}\n",
+        )
+        .expect("should parse");
+        let prop = &spec.config.props["a"];
+        assert_eq!(prop.envs, ["FIRST", "SECOND"]);
+        assert_eq!(prop.cli, ["--one", "--two"]);
+    }
+
+    #[test]
+    fn a_block_on_a_node_that_takes_none_is_refused() {
+        // `source` and `file` are properties only, and checked only their properties — so a
+        // nested block was dropped in silence, which is the one thing this vocabulary is
+        // strict about not doing.
+        for src in [
+            "config {\n  source \"git\" {\n    name \"git config\"\n  }\n}\n",
+            "config {\n  file \"x.toml\" {\n    scope \"global\"\n  }\n}\n",
+            // A `choice` is properties-only too, and read its own the same way.
+            "config {\n  prop \"a\" {\n    choices {\n      choice \"x\" {\n        help \"why\"\n      }\n    }\n  }\n}\n",
+        ] {
+            let err = Spec::parse(&Default::default(), src).expect_err(src);
+            assert!(
+                detail_of(&err).contains("not a block"),
+                "refused for the wrong reason: {}",
+                detail_of(&err)
+            );
+        }
+    }
+
+    #[test]
+    fn both_env_spellings_leave_the_same_prop_however_it_was_built() {
+        // Two ways to write one thing — `env="X"` and `env "A" "B"` — so `env` and `envs`
+        // have to agree whichever way a prop arrived. They did after parsing and did not
+        // after building, so a spec assembled in Rust serialized with an empty `envs` and
+        // every consumer that reads that field saw a setting no variable could set.
+        let built = super::SpecConfigProp::new().env("HK_JOBS").env("HK_JOB");
+        assert_eq!(built.env.as_deref(), Some("HK_JOBS"));
+        assert_eq!(built.envs, ["HK_JOBS", "HK_JOB"]);
+
+        // Both spellings at once. The sync only ran when one side was empty, so this left
+        // `env` and `envs` asserting different things — `usage g json` exposing the pair, and
+        // a writer that chooses between them by list length, so a round trip dropped a value.
+        let both = Spec::parse(
+            &Default::default(),
+            "name \"x\"\nbin \"x\"\nconfig {\n  prop \"a\" env=\"FIRST\" {\n    env \"SECOND\"\n  }\n}\n",
+        )
+        .unwrap();
+        assert_eq!(both.config.props["a"].envs, ["FIRST", "SECOND"]);
+        assert_eq!(both.config.props["a"].env.as_deref(), Some("FIRST"));
+        // And both values survive being written out and read back.
+        let round_tripped: Spec = both.to_string().parse().expect("should reparse");
+        assert_eq!(round_tripped.config.props["a"].envs, ["FIRST", "SECOND"]);
+
+        // The property spelling, parsed.
+        let one = Spec::parse(
+            &Default::default(),
+            "name \"x\"\nbin \"x\"\nconfig {\n  prop \"a\" env=\"A\"\n}\n",
+        )
+        .unwrap();
+        let one = &one.config.props["a"];
+        assert_eq!(one.env.as_deref(), Some("A"));
+        assert_eq!(one.envs, ["A"]);
+
+        // The list spelling, parsed.
+        let many = Spec::parse(
+            &Default::default(),
+            "name \"x\"\nbin \"x\"\nconfig {\n  prop \"a\" {\n    env \"A\" \"B\"\n  }\n}\n",
+        )
+        .unwrap();
+        let many = &many.config.props["a"];
+        assert_eq!(many.env.as_deref(), Some("A"));
+        assert_eq!(many.envs, ["A", "B"]);
+    }
+
+    #[test]
+    fn a_list_default_keeps_the_type_it_was_written_as() {
+        // `default 1 2 3` for a `list<int>` is three numbers, and a schema or an SDK that
+        // received three strings would describe the setting wrongly.
+        let spec = Spec::parse(
+            &Default::default(),
+            "name \"x\"\nbin \"x\"\nconfig {\n  prop \"ports\" type=\"list<int>\" {\n    default 80 443\n  }\n}\n",
+        )
+        .unwrap();
+        assert_eq!(
+            spec.config.props["ports"].default_list,
+            [SpecConfigValue::Int(80), SpecConfigValue::Int(443)]
+        );
+        // And it says so again when written back out, rather than gaining quotes.
+        assert!(spec.to_string().contains("default 80 443"), "{spec}");
     }
 }

--- a/lib/src/spec/config_type.rs
+++ b/lib/src/spec/config_type.rs
@@ -1,0 +1,318 @@
+//! The type a config property's values take.
+//!
+//! A small expression grammar rather than an enum of names, because the fleet's registries
+//! need composition — `list<string>`, `map<string,string>`, `option<path>`, and the
+//! occasional union like `bool|string`. Anything unrecognized parses as
+//! [`Base::Custom`] and is preserved verbatim: a spec written for a newer usage, or one
+//! naming a type only its own tool understands, keeps working rather than failing to load.
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::Serialize;
+
+use crate::error::UsageErr;
+
+/// A named, non-composite type.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Base {
+    Bool,
+    String,
+    Int,
+    Uint,
+    Float,
+    Path,
+    Url,
+    Duration,
+    /// A free-form table: keys and values the spec does not describe.
+    Object,
+    /// A name this version does not know.
+    ///
+    /// Not an error: `data_type` used to be five values and a spec that names a sixth
+    /// should load. Consumers that need a type they understand treat it as a string, which
+    /// is what a schema generator can always do.
+    Custom(String),
+}
+
+impl fmt::Display for Base {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            Self::Bool => "bool",
+            Self::String => "string",
+            Self::Int => "int",
+            Self::Uint => "uint",
+            Self::Float => "float",
+            Self::Path => "path",
+            Self::Url => "url",
+            Self::Duration => "duration",
+            Self::Object => "object",
+            Self::Custom(name) => name,
+        };
+        f.write_str(name)
+    }
+}
+
+impl From<&str> for Base {
+    fn from(name: &str) -> Self {
+        match name {
+            "bool" | "boolean" => Self::Bool,
+            "string" | "str" => Self::String,
+            "int" | "integer" => Self::Int,
+            "uint" | "usize" => Self::Uint,
+            "float" | "number" => Self::Float,
+            "path" => Self::Path,
+            "url" => Self::Url,
+            "duration" => Self::Duration,
+            "object" | "table" => Self::Object,
+            other => Self::Custom(other.to_string()),
+        }
+    }
+}
+
+/// A config property's type, as written.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case", tag = "kind", content = "of")]
+pub enum SpecConfigType {
+    Base(Base),
+    /// `list<T>` — ordered, duplicates kept.
+    List(Box<SpecConfigType>),
+    /// `set<T>` — deduplicated.
+    Set(Box<SpecConfigType>),
+    /// `map<K, V>` — the key is always a base type.
+    Map(Base, Box<SpecConfigType>),
+    /// `option<T>` — may be absent, with no default standing in.
+    Option(Box<SpecConfigType>),
+    /// `a|b` — one of several. Only what a spec can express; nothing validates which.
+    Union(Vec<SpecConfigType>),
+}
+
+impl Default for SpecConfigType {
+    fn default() -> Self {
+        Self::Base(Base::String)
+    }
+}
+
+impl SpecConfigType {
+    /// The type this collapses to for a consumer that only handles one shape.
+    ///
+    /// A union's first member, an option's inner type: what a schema generator writes when
+    /// it has to pick. Kept here rather than in each generator so they agree.
+    pub fn simplified(&self) -> &SpecConfigType {
+        match self {
+            Self::Option(inner) => inner.simplified(),
+            Self::Union(members) => members.first().map_or(self, |m| m.simplified()),
+            other => other,
+        }
+    }
+
+    /// Whether a value may be absent with nothing standing in for it.
+    pub fn is_optional(&self) -> bool {
+        matches!(self, Self::Option(_))
+    }
+}
+
+impl fmt::Display for SpecConfigType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Base(base) => write!(f, "{base}"),
+            Self::List(inner) => write!(f, "list<{inner}>"),
+            Self::Set(inner) => write!(f, "set<{inner}>"),
+            Self::Map(key, value) => write!(f, "map<{key}, {value}>"),
+            Self::Option(inner) => write!(f, "option<{inner}>"),
+            Self::Union(members) => {
+                let rendered: Vec<String> = members.iter().map(|m| m.to_string()).collect();
+                f.write_str(&rendered.join("|"))
+            }
+        }
+    }
+}
+
+impl FromStr for SpecConfigType {
+    type Err = UsageErr;
+
+    fn from_str(text: &str) -> Result<Self, Self::Err> {
+        parse_union(text.trim())
+    }
+}
+
+fn invalid(text: &str, why: &str) -> UsageErr {
+    UsageErr::InvalidInput(
+        format!("`{text}` is not a config type: {why}"),
+        (0, 0).into(),
+        miette::NamedSource::new("", String::new()),
+    )
+}
+
+/// `a|b|c`, splitting only on bars outside angle brackets.
+fn parse_union(text: &str) -> Result<SpecConfigType, UsageErr> {
+    let members = split_top_level(text, '|');
+    match members.as_slice() {
+        [] => Err(invalid(text, "it is empty")),
+        [one] => parse_single(one),
+        many => Ok(SpecConfigType::Union(
+            many.iter()
+                .map(|m| parse_single(m))
+                .collect::<Result<Vec<_>, _>>()?,
+        )),
+    }
+}
+
+fn parse_single(text: &str) -> Result<SpecConfigType, UsageErr> {
+    let text = text.trim();
+    if text.is_empty() {
+        return Err(invalid(text, "it is empty"));
+    }
+    let Some(open) = text.find('<') else {
+        return Ok(SpecConfigType::Base(Base::from(text)));
+    };
+    if !text.ends_with('>') {
+        return Err(invalid(text, "a `<` without a closing `>`"));
+    }
+    let name = text[..open].trim();
+    let inner = &text[open + 1..text.len() - 1];
+    match name {
+        "list" | "array" => Ok(SpecConfigType::List(Box::new(parse_union(inner)?))),
+        "set" => Ok(SpecConfigType::Set(Box::new(parse_union(inner)?))),
+        "option" | "optional" => Ok(SpecConfigType::Option(Box::new(parse_union(inner)?))),
+        "map" | "table" => {
+            let parts = split_top_level(inner, ',');
+            match parts.as_slice() {
+                // `map<string>` is a map from strings to that type, which is what every
+                // registry in the fleet means by a one-argument map.
+                [value] => Ok(SpecConfigType::Map(
+                    Base::String,
+                    Box::new(parse_union(value)?),
+                )),
+                [key, value] => {
+                    let key = key.trim();
+                    if key.contains('<') {
+                        return Err(invalid(text, "a map's key is a plain type"));
+                    }
+                    Ok(SpecConfigType::Map(
+                        Base::from(key),
+                        Box::new(parse_union(value)?),
+                    ))
+                }
+                _ => Err(invalid(text, "a map takes a key and a value")),
+            }
+        }
+        other => Err(invalid(
+            text,
+            &format!("`{other}` does not take a type argument"),
+        )),
+    }
+}
+
+/// Split on `sep`, ignoring separators nested inside `<…>`.
+fn split_top_level(text: &str, sep: char) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut depth = 0usize;
+    let mut start = 0usize;
+    for (i, c) in text.char_indices() {
+        match c {
+            '<' => depth += 1,
+            '>' => depth = depth.saturating_sub(1),
+            c if c == sep && depth == 0 => {
+                parts.push(text[start..i].trim());
+                start = i + c.len_utf8();
+            }
+            _ => {}
+        }
+    }
+    let last = text[start..].trim();
+    if !last.is_empty() || !parts.is_empty() {
+        parts.push(last);
+    }
+    parts.retain(|p| !p.is_empty());
+    parts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parsed(text: &str) -> SpecConfigType {
+        text.parse().unwrap_or_else(|e| panic!("{text}: {e}"))
+    }
+
+    #[test]
+    fn every_shape_round_trips_through_its_own_spelling() {
+        // The written form is the interchange, so parsing and displaying have to agree —
+        // otherwise a spec changes meaning by being saved.
+        for text in [
+            "bool",
+            "string",
+            "uint",
+            "path",
+            "duration",
+            "object",
+            "list<string>",
+            "set<path>",
+            "map<string, string>",
+            "option<int>",
+            "list<map<string, list<string>>>",
+            "bool|string",
+            "option<list<string>>",
+        ] {
+            assert_eq!(parsed(text).to_string(), text, "{text}");
+        }
+    }
+
+    #[test]
+    fn familiar_spellings_are_accepted() {
+        // The registries being migrated say `boolean`, `ListString`-ish `array<…>`,
+        // `usize`, `number`. Accepting the synonyms costs nothing and normalizes them.
+        assert_eq!(parsed("boolean"), SpecConfigType::Base(Base::Bool));
+        assert_eq!(parsed("usize"), SpecConfigType::Base(Base::Uint));
+        assert_eq!(parsed("number"), SpecConfigType::Base(Base::Float));
+        assert_eq!(
+            parsed("array<string>"),
+            SpecConfigType::List(Box::new(SpecConfigType::Base(Base::String)))
+        );
+        assert_eq!(
+            parsed("optional<path>"),
+            SpecConfigType::Option(Box::new(SpecConfigType::Base(Base::Path)))
+        );
+        // A one-argument map is keyed by strings, which is what the fleet means by it.
+        assert_eq!(
+            parsed("map<string>"),
+            SpecConfigType::Map(Base::String, Box::new(SpecConfigType::Base(Base::String)))
+        );
+    }
+
+    #[test]
+    fn an_unknown_name_is_kept_rather_than_refused() {
+        // The escape hatch: a tool may name a type only it understands, and a spec written
+        // for a newer usage must still load.
+        let ty = parsed("crate::PythonUvVenvAuto");
+        assert_eq!(
+            ty,
+            SpecConfigType::Base(Base::Custom("crate::PythonUvVenvAuto".into()))
+        );
+        assert_eq!(ty.to_string(), "crate::PythonUvVenvAuto");
+        // Including inside a composite.
+        assert_eq!(parsed("list<Weird>").to_string(), "list<Weird>");
+    }
+
+    #[test]
+    fn a_malformed_type_is_an_error() {
+        for text in ["list<string", "list<>", "map<string, int, extra>", "int<x>"] {
+            assert!(
+                text.parse::<SpecConfigType>().is_err(),
+                "`{text}` should not parse"
+            );
+        }
+    }
+
+    #[test]
+    fn simplified_picks_what_a_generator_can_write() {
+        assert_eq!(
+            parsed("option<list<string>>").simplified(),
+            &parsed("list<string>")
+        );
+        assert_eq!(parsed("bool|string").simplified(), &parsed("bool"));
+        assert!(parsed("option<int>").is_optional());
+        assert!(!parsed("int").is_optional());
+    }
+}

--- a/lib/src/spec/config_type.rs
+++ b/lib/src/spec/config_type.rs
@@ -53,6 +53,13 @@ impl fmt::Display for Base {
     }
 }
 
+/// The characters the grammar itself uses, which therefore cannot appear in a name.
+///
+/// Without this check a typo keeps the delimiter and becomes a [`Base::Custom`] named after
+/// it — `int>` loads as a type called `int>`, and every consumer treats it as a string. The
+/// escape hatch is for names a newer usage understands, not for text that failed to parse.
+const DELIMITERS: [char; 4] = ['<', '>', ',', '|'];
+
 impl From<&str> for Base {
     fn from(name: &str) -> Self {
         match name {
@@ -136,6 +143,24 @@ impl FromStr for SpecConfigType {
     }
 }
 
+/// A base type, refusing a name that still holds a delimiter.
+///
+/// `Base::from` cannot do this itself: it is infallible on purpose, so a name usage does not
+/// know survives a load. What it must not do is swallow a malformed *expression* as a name.
+fn base(text: &str) -> Result<Base, UsageErr> {
+    if text.is_empty() {
+        // `map<,string>`: a name is missing, not merely unrecognized.
+        return Err(invalid(text, "it is empty"));
+    }
+    if let Some(delimiter) = text.chars().find(|c| DELIMITERS.contains(c)) {
+        return Err(invalid(
+            text,
+            &format!("a stray `{delimiter}` — check the brackets"),
+        ));
+    }
+    Ok(Base::from(text))
+}
+
 fn invalid(text: &str, why: &str) -> UsageErr {
     UsageErr::InvalidInput(
         format!("`{text}` is not a config type: {why}"),
@@ -164,7 +189,7 @@ fn parse_single(text: &str) -> Result<SpecConfigType, UsageErr> {
         return Err(invalid(text, "it is empty"));
     }
     let Some(open) = text.find('<') else {
-        return Ok(SpecConfigType::Base(Base::from(text)));
+        return Ok(SpecConfigType::Base(base(text)?));
     };
     if !text.ends_with('>') {
         return Err(invalid(text, "a `<` without a closing `>`"));
@@ -184,16 +209,10 @@ fn parse_single(text: &str) -> Result<SpecConfigType, UsageErr> {
                     Base::String,
                     Box::new(parse_union(value)?),
                 )),
-                [key, value] => {
-                    let key = key.trim();
-                    if key.contains('<') {
-                        return Err(invalid(text, "a map's key is a plain type"));
-                    }
-                    Ok(SpecConfigType::Map(
-                        Base::from(key),
-                        Box::new(parse_union(value)?),
-                    ))
-                }
+                [key, value] => Ok(SpecConfigType::Map(
+                    base(key.trim())?,
+                    Box::new(parse_union(value)?),
+                )),
                 _ => Err(invalid(text, "a map takes a key and a value")),
             }
         }
@@ -221,10 +240,12 @@ fn split_top_level(text: &str, sep: char) -> Vec<&str> {
         }
     }
     let last = text[start..].trim();
+    // An empty tail only counts when a separator put it there: `"bool"` is one part, while
+    // `"bool|"` is two, the second of which is empty and fails to parse. Dropping empties
+    // here instead made `bool|`, `bool||string` and `map<string,>` load as something else.
     if !last.is_empty() || !parts.is_empty() {
         parts.push(last);
     }
-    parts.retain(|p| !p.is_empty());
     parts
 }
 
@@ -297,7 +318,28 @@ mod tests {
 
     #[test]
     fn a_malformed_type_is_an_error() {
-        for text in ["list<string", "list<>", "map<string, int, extra>", "int<x>"] {
+        for text in [
+            "list<string",
+            "list<>",
+            "map<string, int, extra>",
+            "int<x>",
+            // A missing member, rather than a missing bracket. Each of these used to load as
+            // something else: `bool|` as plain `bool`, `bool||string` as the two-member
+            // union, `map<string,>` as a map to strings — a typo quietly changing what a
+            // setting holds, which the type is the interchange for precisely to avoid.
+            "bool|",
+            "|bool",
+            "bool||string",
+            "map<string,>",
+            "map<,string>",
+            // A stray delimiter is a broken expression, not the name of a type only this
+            // tool knows: `int>` used to become `Custom("int>")` and every consumer treated
+            // it as a string.
+            "int>",
+            "list<string>>",
+            "map<string>, int>",
+            "bool|>",
+        ] {
             assert!(
                 text.parse::<SpecConfigType>().is_err(),
                 "`{text}` should not parse"

--- a/lib/src/spec/mod.rs
+++ b/lib/src/spec/mod.rs
@@ -4,6 +4,7 @@ pub mod choices;
 pub mod cmd;
 pub mod complete;
 pub mod config;
+pub mod config_type;
 mod context;
 pub mod data_types;
 pub mod effect;

--- a/lib/src/spec/snapshots/usage__spec__config__tests__the_whole_vocabulary_survives_a_round_trip.snap
+++ b/lib/src/spec/snapshots/usage__spec__config__tests__the_whole_vocabulary_survives_a_round_trip.snap
@@ -1,0 +1,303 @@
+---
+source: lib/src/spec/config.rs
+expression: "serde_json::to_string_pretty(&spec.config).unwrap()"
+---
+{
+  "props": {
+    "ci": {
+      "default": null,
+      "default_note": null,
+      "data_type": "boolean",
+      "value_type": {
+        "kind": "base",
+        "of": "bool"
+      },
+      "env": "CI",
+      "envs": [
+        "CI"
+      ],
+      "cli": [],
+      "bindings": {},
+      "help": null,
+      "long_help": null,
+      "help_heading": null,
+      "choices": [],
+      "merge": "replace",
+      "scope": "env",
+      "deprecated": null,
+      "deprecated_warn_at": null,
+      "deprecated_remove_at": null,
+      "renamed_to": null,
+      "hide": true,
+      "since": null,
+      "parse": null,
+      "writes_to": null,
+      "examples": [],
+      "default_list": [],
+      "extensions": [
+        [
+          "mise.rust_type",
+          "BoolOrString"
+        ],
+        [
+          "mise.rc",
+          true
+        ]
+      ]
+    },
+    "exclude": {
+      "default": null,
+      "default_note": null,
+      "data_type": "null",
+      "value_type": {
+        "kind": "list",
+        "of": {
+          "kind": "base",
+          "of": "string"
+        }
+      },
+      "env": "HK_EXCLUDE",
+      "envs": [
+        "HK_EXCLUDE"
+      ],
+      "cli": [],
+      "bindings": {},
+      "help": null,
+      "long_help": null,
+      "help_heading": null,
+      "choices": [],
+      "merge": "union",
+      "scope": "any",
+      "deprecated": null,
+      "deprecated_warn_at": null,
+      "deprecated_remove_at": null,
+      "renamed_to": null,
+      "hide": false,
+      "since": null,
+      "parse": null,
+      "writes_to": null,
+      "examples": [],
+      "default_list": [
+        "target",
+        "node_modules"
+      ],
+      "extensions": []
+    },
+    "jobs": {
+      "default": 0,
+      "default_note": "0 = auto-detect",
+      "data_type": "integer",
+      "value_type": {
+        "kind": "base",
+        "of": "uint"
+      },
+      "env": "HK_JOBS",
+      "envs": [
+        "HK_JOBS",
+        "HK_JOB"
+      ],
+      "cli": [
+        "--jobs",
+        "-j"
+      ],
+      "bindings": {
+        "git": [
+          "hk.jobs"
+        ],
+        "pkl": [
+          "jobs",
+          "defaults.jobs"
+        ]
+      },
+      "help": "Number of parallel jobs",
+      "long_help": null,
+      "help_heading": "Performance",
+      "choices": [],
+      "merge": "replace",
+      "scope": "any",
+      "deprecated": null,
+      "deprecated_warn_at": null,
+      "deprecated_remove_at": null,
+      "renamed_to": null,
+      "hide": false,
+      "since": "1.0.0",
+      "parse": null,
+      "writes_to": null,
+      "examples": [
+        "hk check --jobs 4"
+      ],
+      "default_list": [],
+      "extensions": []
+    },
+    "old.key": {
+      "default": null,
+      "default_note": null,
+      "data_type": "null",
+      "value_type": null,
+      "env": null,
+      "envs": [],
+      "cli": [],
+      "bindings": {},
+      "help": null,
+      "long_help": null,
+      "help_heading": null,
+      "choices": [],
+      "merge": "replace",
+      "scope": "any",
+      "deprecated": "Use new.key",
+      "deprecated_warn_at": "2026.12.0",
+      "deprecated_remove_at": "2027.12.0",
+      "renamed_to": "new.key",
+      "hide": false,
+      "since": null,
+      "parse": null,
+      "writes_to": null,
+      "examples": [],
+      "default_list": [],
+      "extensions": []
+    },
+    "stash": {
+      "default": null,
+      "default_note": null,
+      "data_type": "string",
+      "value_type": {
+        "kind": "base",
+        "of": "string"
+      },
+      "env": null,
+      "envs": [],
+      "cli": [],
+      "bindings": {},
+      "help": null,
+      "long_help": null,
+      "help_heading": null,
+      "choices": [
+        {
+          "value": "git",
+          "help": "Use `git stash`"
+        },
+        {
+          "value": "none",
+          "help": "No stashing"
+        }
+      ],
+      "merge": "replace",
+      "scope": "any",
+      "deprecated": null,
+      "deprecated_warn_at": null,
+      "deprecated_remove_at": null,
+      "renamed_to": null,
+      "hide": false,
+      "since": null,
+      "parse": null,
+      "writes_to": null,
+      "examples": [],
+      "default_list": [],
+      "extensions": []
+    },
+    "trusted": {
+      "default": null,
+      "default_note": null,
+      "data_type": "boolean",
+      "value_type": {
+        "kind": "base",
+        "of": "bool"
+      },
+      "env": null,
+      "envs": [],
+      "cli": [],
+      "bindings": {},
+      "help": null,
+      "long_help": null,
+      "help_heading": null,
+      "choices": [],
+      "merge": "replace",
+      "scope": "global",
+      "deprecated": null,
+      "deprecated_warn_at": null,
+      "deprecated_remove_at": null,
+      "renamed_to": null,
+      "hide": false,
+      "since": null,
+      "parse": null,
+      "writes_to": null,
+      "examples": [],
+      "default_list": [],
+      "extensions": []
+    },
+    "urls": {
+      "default": null,
+      "default_note": null,
+      "data_type": "null",
+      "value_type": {
+        "kind": "map",
+        "of": [
+          "string",
+          {
+            "kind": "base",
+            "of": "url"
+          }
+        ]
+      },
+      "env": null,
+      "envs": [],
+      "cli": [],
+      "bindings": {},
+      "help": null,
+      "long_help": null,
+      "help_heading": null,
+      "choices": [],
+      "merge": "replace",
+      "scope": "any",
+      "deprecated": null,
+      "deprecated_warn_at": null,
+      "deprecated_remove_at": null,
+      "renamed_to": null,
+      "hide": false,
+      "since": null,
+      "parse": "list_by_comma",
+      "writes_to": "npmrc",
+      "examples": [],
+      "default_list": [],
+      "extensions": []
+    }
+  },
+  "sources": {
+    "git": {
+      "name": "git config",
+      "doc_hint": "git config `{key}`",
+      "set_hint": "git config {key} {value}"
+    },
+    "pkl": {
+      "name": "hk.pkl",
+      "doc_hint": null,
+      "set_hint": null
+    }
+  },
+  "files": [
+    {
+      "path": "/etc/hk/config.pkl",
+      "findup": false,
+      "scope": "system",
+      "format": null
+    },
+    {
+      "path": "~/.config/hk/config.pkl",
+      "findup": false,
+      "scope": "global",
+      "format": null
+    },
+    {
+      "path": "hk.pkl",
+      "findup": true,
+      "scope": "project",
+      "format": null
+    },
+    {
+      "path": ".hkrc",
+      "findup": false,
+      "scope": "project",
+      "format": "ini"
+    }
+  ]
+}

--- a/lib/tests/docs_examples.rs
+++ b/lib/tests/docs_examples.rs
@@ -1,0 +1,114 @@
+//! Every KDL example on the config reference page parses.
+//!
+//! That page used to document a vocabulary which had never existed — `file`, `findup`,
+//! `default "k" "v"`, `alias`, `config_file` — while the parser accepted only `prop`, which
+//! the page never mentioned. Nobody noticed because nothing checked. This checks.
+//!
+//! Only that page, for now. The other reference pages are *catalogues*: a block lists half
+//! a dozen alternative spellings of an `arg` or a `flag`, which is not a spec and does not
+//! parse as one (one of them puts an argument after a variadic, which the parser refuses
+//! for good reason). Covering those means checking a catalogue line by line, which is worth
+//! doing and is not this change. Running this test against them today reports five
+//! failures, one of which — `flag "flag1"` in `cmd.md`, missing its dashes — is a real
+//! documentation bug of exactly the kind this test exists to catch.
+
+use std::path::Path;
+
+/// A fenced block, and what has to be true of it.
+enum Example {
+    /// A whole spec: parse it as-is.
+    Spec(String),
+    /// The inside of a `config` block: wrap it before parsing.
+    ConfigBody(String),
+    /// Top-level nodes shown without the `name`/`bin` a real spec carries.
+    Fragment(String),
+    /// Reads another file, so it cannot be parsed from a string. Named so the reason is
+    /// recorded rather than the block quietly skipped.
+    NeedsAFileOnDisk,
+}
+
+fn classify(block: &str) -> Example {
+    let first = block
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty() && !l.starts_with("//"))
+        .unwrap_or_default();
+    if block.contains("include file=") {
+        Example::NeedsAFileOnDisk
+    } else if first.starts_with("prop ")
+        || first.starts_with("source ")
+        || first.starts_with("file ")
+    {
+        Example::ConfigBody(block.to_string())
+    } else if first.starts_with("name ") || first.starts_with("bin ") {
+        Example::Spec(block.to_string())
+    } else {
+        // A fragment: nodes that belong at the top level of a spec, shown without the
+        // `name`/`bin` a real file would have.
+        Example::Fragment(block.to_string())
+    }
+}
+
+/// The ```kdl blocks of a markdown file.
+fn kdl_blocks(markdown: &str) -> Vec<String> {
+    let mut blocks = Vec::new();
+    let mut current: Option<String> = None;
+    for line in markdown.lines() {
+        match (&mut current, line.trim()) {
+            (None, "```kdl") => current = Some(String::new()),
+            (Some(block), "```") => blocks.push(std::mem::take(block)),
+            (Some(block), _) => {
+                block.push_str(line);
+                block.push('\n');
+            }
+            (None, _) => {}
+        }
+        if matches!((&current, line.trim()), (Some(b), "```") if b.is_empty()) {
+            current = None;
+        }
+    }
+    blocks
+}
+
+#[test]
+fn every_kdl_example_on_the_config_page_parses() {
+    let pages = [Path::new(env!("CARGO_MANIFEST_DIR")).join("../docs/spec/reference/config.md")];
+    let mut checked = 0;
+    let mut failures = Vec::new();
+
+    for page in pages {
+        let name = page
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
+        for (i, block) in kdl_blocks(&std::fs::read_to_string(&page).expect("readable"))
+            .iter()
+            .enumerate()
+        {
+            let source = match classify(block) {
+                Example::NeedsAFileOnDisk => continue,
+                Example::Spec(spec) => spec,
+                Example::ConfigBody(body) => {
+                    format!("name \"ex\"\nbin \"ex\"\nconfig {{\n{body}}}\n")
+                }
+                Example::Fragment(body) => format!("name \"ex\"\nbin \"ex\"\n{body}"),
+            };
+            checked += 1;
+            if let Err(err) = source.parse::<usage::Spec>() {
+                failures.push(format!("{name} block {i}: {err}\n{source}"));
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{} example(s) in the reference do not parse:\n\n{}",
+        failures.len(),
+        failures.join("\n---\n")
+    );
+    // A lower bound rather than a count: pages gain examples, and a test that fails when
+    // somebody documents something is worse than useless. Zero would mean the extractor
+    // broke.
+    assert!(checked >= 5, "only found {checked} examples to check");
+}


### PR DESCRIPTION
Stacked on #832. What a `config` block can say — so docs, a JSON schema, completions and a resolver come from one declaration instead of the five hand-written copies the fleet has now.

## Three node kinds

```kdl
config {
    // Kinds usage knows nothing about, with the metadata docs need to describe them.
    source "git" name="git config" doc_hint="git config `{key}`" set_hint="git config {key} {value}"
    source "pkl" name="hk.pkl"

    // The rc-style chain, ascending precedence.
    file "~/.config/hk/config.pkl" scope="global"
    file "hk.pkl" findup=#true

    prop "jobs" type="uint" default=0 default_note="0 = auto-detect" help="…" since="1.0.0" {
        cli "--jobs" "-j"
        env "HK_JOBS" "HK_JOB"        // aliases, highest first
        source "git" "hk.jobs"        // its key in a declared kind
        example "hk check --jobs 4"
    }
    prop "exclude" type="list<string>" merge="union" { default "target" "node_modules" }
    prop "stash" type="string" { choices { choice "git" help="Use `git stash`" } }
    prop "trusted" type="bool" scope="global"       // never from a project file
    prop "ci" type="bool" hide=#true scope="env" { x "mise.rust_type" "BoolOrString" }
    prop "old.key" deprecated="Use new.key" renamed_to="new.key" \
        deprecated_warn_at="2026.12.0" deprecated_remove_at="2027.12.0"
}
```

`source` is what lets docs say "settable with `git config hk.check`" without usage having any idea what git is. `scope="global"` is not decoration — mise treats "a checked-in file must not be able to change this" as a security property, so it is declared rather than left to each tool.

## Types

```
base := bool | string | int | uint | float | path | url | duration | object
type := base | list<type> | set<type> | map<base, type> | option<type> | type "|" type
```

An unknown name is **kept verbatim** rather than refused — that's the type-level escape hatch, so a spec naming a type only its own tool understands still loads everywhere. Old spellings (`data_type=`, `boolean`, `integer`, `number`, `usize`, `array<…>`, `optional<…>`) are accepted and normalized.

## `x` extensions

`x "ns.key" value`: preserved in order, written back out, in `usage g json`, interpreted by nothing here. Where `mise.rust_type`, `mise.parse_env` and `aube.npm_shared` live. This is the seam that lets a CLI with special rules describe its settings without usage having to model those rules.

## Verification

- **The whole vocabulary round-trips**, field by field, in one test — anything the spec cannot write out is something a tool would lose by saving its own file.
- **The parsed model is committed as a snapshot** — the artifact `usage g json` hands downstream, and what a port in another language diffs against.
- **Every KDL example on the reference page is parsed by a test.** That page previously documented `file`, `findup`, `default "k" "v"`, `alias` and `config_file` — *none of which the parser has ever accepted* — while never mentioning `prop`, the one thing it did. It's in the site nav. It cannot drift like that again.
- Unknown vocabulary is refused rather than half-read (five cases tested), which is what `min_usage_version` is for.

One finding for elsewhere: running that docs test against the other reference pages reports five failures. Four are catalogue blocks — lists of alternative spellings that aren't specs (one even puts an argument after a variadic, which the parser rightly refuses). The fifth is real: **`flag "flag1"` in `cmd.md` is missing its dashes** and the parser rejects it. Left for its own change rather than smuggled in here.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large expansion of the spec parser and serialized config shape; behavior changes (strict errors, merge rules for files/sources) could break hand-written specs that relied on old permissive or undocumented behavior, though compatibility aliases and tests aim to limit that.
> 
> **Overview**
> Adds a full **config** vocabulary to usage specs so settings, file chains, and external source kinds can be declared once for docs, JSON export, and resolvers.
> 
> **`config` block** now supports **`source`** (opaque kinds like git/pkl with doc hints), **`file`** (precedence chain with `findup`, `scope`, `format`), and richer **`prop`** nodes: `type` grammar, `cli`/`env` aliases, bindings, `choices`, `merge`/`scope`, deprecation/renames, `x` extensions, and list defaults.
> 
> Introduces **`SpecConfigType`** (`list<>`, `map<>`, unions, legacy synonym normalization) alongside the old five-value `data_type`, with stricter parsing (unknown keys refused, no silent child drops, union defaults not coerced via legacy type).
> 
> **`docs/spec/reference/config.md`** is rewritten to match the parser; **`lib/tests/docs_examples.rs`** parses every KDL example on that page. Generated CLI JSON gains empty `sources`/`files` on `config`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ae32fe0ed7596b9554551b4d110cb402b5ab5cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->