### PR TITLE
feat(docs): render the config block

### DIFF
--- a/cli/src/cli/generate/markdown.rs
+++ b/cli/src/cli/generate/markdown.rs
@@ -65,6 +65,22 @@ impl Markdown {
         }
         if self.multi {
             ctx = ctx.with_multi(true);
+            // Before anything is written, so a refusal does not leave a half-built directory.
+            //
+            // Refused rather than warned about: writing anyway destroys the command's own
+            // documentation, and a warning printed into a docs build is a warning nobody reads.
+            // No CLI in the fleet has a `configuration` command — they call it `config` — so
+            // this asks the one author who ever hits it to pick a name, rather than quietly
+            // losing a page for everybody who does not.
+            if !ctx.render_config()?.trim().is_empty() {
+                if let Some(cmd) = ctx.config_page_collision() {
+                    miette::bail!(
+                        "the `{cmd}` command's page and the settings page would both be written \
+                         to {}; rename the command, or hide it, to generate both",
+                        ctx.config_page()
+                    );
+                }
+            }
             let commands = spec.cmd.all_subcommands().into_iter().filter(|c| !c.hide);
             for cmd in commands {
                 let md = ctx.render_cmd(cmd)?;
@@ -86,6 +102,15 @@ impl Markdown {
             let md_idx = ctx.render_index()?;
             let path_idx = self.out_dir.as_ref().unwrap().join("index.md");
             write(&path_idx, &md_idx)?;
+            // Its own page, and only when there is something to put on it: a CLI with no
+            // settings should not gain an empty file in its docs directory.
+            let md_config = ctx.render_config()?;
+            if !md_config.trim().is_empty() {
+                // The same call the index links by, so the two cannot disagree about where the
+                // page went.
+                let path = self.out_dir.as_ref().unwrap().join(ctx.config_page());
+                write(&path, &md_config)?;
+            }
         } else {
             let md = ctx.render_spec()?;
             write_or_stdout(self.out_file.as_deref(), &render(&md))?;

--- a/cli/tests/markdown.rs
+++ b/cli/tests/markdown.rs
@@ -320,3 +320,55 @@ fn test_source_code_links_exist() {
 
     fs::remove_file(&out_file).unwrap();
 }
+
+#[test]
+fn a_page_collision_is_refused_before_anything_is_written() {
+    // A CLI with a literal `configuration` command: its page and the settings page want the same
+    // file. Writing anyway destroys the command's documentation, so the build stops — and stops
+    // *before* writing, so a refused run does not leave a half-built directory behind.
+    let dir = std::env::temp_dir().join(format!("usage_md_collision_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+
+    let specs = std::env::temp_dir().join(format!("usage_md_specs_{}", std::process::id()));
+    fs::create_dir_all(&specs).unwrap();
+    let clashing = specs.join("clash.usage.kdl");
+    fs::write(
+        &clashing,
+        "name \"ex\"\nbin \"ex\"\nconfig {\n  prop \"jobs\" type=\"uint\"\n}\ncmd \"configuration\" help=\"Odd\"\n",
+    )
+    .unwrap();
+    let ordinary = specs.join("ok.usage.kdl");
+    fs::write(
+        &ordinary,
+        "name \"ex\"\nbin \"ex\"\nconfig {\n  prop \"jobs\" type=\"uint\"\n}\ncmd \"settings\" help=\"Manage\"\n",
+    )
+    .unwrap();
+
+    usage_cmd()
+        .args(["generate", "markdown", "-f"])
+        .arg(&clashing)
+        .args(["--multi", "--out-dir", dir.to_str().unwrap()])
+        .assert()
+        .failure()
+        // A fragment miette does not wrap: it hard-wraps the message across lines.
+        .stderr(predicates::str::contains("rename the command"));
+    assert!(
+        !dir.exists() || fs::read_dir(&dir).unwrap().count() == 0,
+        "a refused run wrote files into {}",
+        dir.display()
+    );
+
+    // And the ordinary case — including a `settings` command, which no longer collides — still
+    // writes both pages.
+    usage_cmd()
+        .args(["generate", "markdown", "-f"])
+        .arg(&ordinary)
+        .args(["--multi", "--out-dir", dir.to_str().unwrap()])
+        .assert()
+        .success();
+    assert!(dir.join("configuration.md").exists());
+    assert!(dir.join("settings.md").exists(), "the command's own page");
+
+    let _ = fs::remove_dir_all(&dir);
+    let _ = fs::remove_dir_all(&specs);
+}

--- a/lib/src/docs/manpage/renderer.rs
+++ b/lib/src/docs/manpage/renderer.rs
@@ -78,6 +78,9 @@ impl ManpageRenderer {
             }
         }
 
+        // CONFIGURATION section
+        self.render_configuration(&mut roff);
+
         // AUTHOR section (if present)
         if let Some(author) = &self.spec.author {
             roff.control("SH", ["AUTHOR"]);
@@ -85,6 +88,98 @@ impl ManpageRenderer {
         }
 
         Ok(roff.to_roff())
+    }
+
+    /// The settings, where a man page conventionally describes them: after the commands and
+    /// before the author.
+    ///
+    /// Deliberately terser than the markdown: a man page is read in a terminal, so each
+    /// setting gets its type, its default and how to set it, and the long-form prose stays
+    /// on the web page.
+    fn render_configuration(&self, roff: &mut Roff) {
+        let config = &self.spec.config;
+        // The same predicate the markdown page uses: a block that declares only where files
+        // live is worth a CONFIGURATION section, and gating on props alone meant the same
+        // spec documented its file chain in one output format and not the other.
+        if config.is_empty() {
+            return;
+        }
+        roff.control("SH", ["CONFIGURATION"]);
+        if !config.files.is_empty() {
+            roff.text([roman("Read from the following, in ascending precedence:")]);
+            roff.control("RS", ["4"]);
+            for file in &config.files {
+                let mut line = file.path.clone();
+                if file.findup {
+                    line.push_str(" (and in every parent directory)");
+                }
+                roff.control("PP", [] as [&str; 0]);
+                roff.text([roman(line)]);
+            }
+            roff.control("RE", [] as [&str; 0]);
+        }
+        // By heading group, like the markdown page: the docs model already partitions the
+        // settings so the two formats stay aligned, and walking the flat list dropped every
+        // `help_heading` and interleaved headed settings with unheaded ones.
+        for group in &config.prop_groups {
+            if let Some(heading) = &group.heading {
+                roff.control("SS", [heading.as_str()]);
+            }
+            for prop in &group.items {
+                self.render_prop(roff, prop);
+            }
+        }
+    }
+
+    /// One setting: a paragraph, its help, and its facts on one line.
+    fn render_prop(&self, roff: &mut Roff, prop: &crate::docs::models::SpecConfigProp) {
+        {
+            roff.control("PP", [] as [&str; 0]);
+            roff.text([bold(&prop.key)]);
+            roff.control("RS", ["4"]);
+            if let Some(help) = prop.help.as_deref() {
+                roff.text([roman(help)]);
+            }
+            let mut facts = Vec::new();
+            if let Some(ty) = &prop.type_ {
+                facts.push(format!("type: {ty}"));
+            }
+            if let Some(default) = &prop.default {
+                facts.push(format!("default: {default}"));
+            }
+            if !prop.sources.is_empty() {
+                // The markdown's backticks would be literal here.
+                let plain: Vec<String> = prop
+                    .sources
+                    .iter()
+                    .map(|source| source.replace('`', ""))
+                    .collect();
+                facts.push(format!("set with: {}", plain.join(", ")));
+            }
+            // What the setting accepts, which for a constrained one is the fact a reader most
+            // needs and the manpage did not carry at all. Values only: a choice's own help
+            // belongs on the page, where there is room for it.
+            if !prop.choices.is_empty() {
+                let values: Vec<&str> = prop.choices.iter().map(|c| c.value.as_str()).collect();
+                facts.push(format!("one of: {}", values.join(", ")));
+            }
+            if !facts.is_empty() {
+                roff.control("PP", [] as [&str; 0]);
+                roff.text([roman(facts.join("; "))]);
+            }
+            if let Some(deprecated) = &prop.deprecated {
+                roff.control("PP", [] as [&str; 0]);
+                // With the version it goes away in, as the markdown page says: a deprecation
+                // notice without the date leaves the reader with nothing to plan around, and
+                // the terminal is the one place this is *supposed* to surface.
+                let mut notice = format!("Deprecated: {deprecated}");
+                if let Some(remove_at) = &prop.deprecated_remove_at {
+                    notice.push_str(&format!(" Removed in {remove_at}."));
+                }
+                roff.text([roman(notice)]);
+            }
+            roff.control("RE", [] as [&str; 0]);
+        }
     }
 
     fn render_name(&self, roff: &mut Roff) {
@@ -412,6 +507,118 @@ impl ManpageRenderer {
 mod tests {
     use super::*;
     use crate::Spec;
+
+    #[test]
+    fn the_settings_get_a_section_of_their_own() {
+        let spec: Spec = r##"
+name "hk"
+bin "hk"
+config {
+    source "git" name="git config" doc_hint="git config `{key}`"
+    file "hk.toml" findup=#true
+    prop "jobs" type="uint" default=4 help="Number of parallel jobs" {
+        cli "--jobs" "-j"
+        env "HK_JOBS"
+        source "git" "hk.jobs"
+    }
+    prop "old" deprecated="Use jobs instead." deprecated_remove_at="2027.12.0" help="Old"
+    prop "stash" type="string" help="How to stash" {
+        choices {
+            choice "git" help="Use `git stash`"
+            choice "none" help="No stashing"
+        }
+    }
+    prop "secret" hide=#true help="Not in the page"
+}
+"##
+        .parse()
+        .unwrap();
+        let page = ManpageRenderer::new(spec).render().unwrap();
+
+        assert!(page.contains(".SH CONFIGURATION"), "{page}");
+        assert!(
+            page.contains("hk.toml (and in every parent directory)"),
+            "{page}"
+        );
+        assert!(page.contains("jobs"), "{page}");
+        // Facts on one line. Hyphens arrive as `\-`, which is how roff spells them.
+        assert!(
+            page.contains(
+                "type: uint; default: 4; set with: \\-\\-jobs, \\-j, HK_JOBS, git config hk.jobs"
+            ),
+            "{page}"
+        );
+        // With the version it goes away in, which is the part a reader can plan around.
+        assert!(
+            page.contains("Deprecated: Use jobs instead. Removed in 2027.12.0."),
+            "{page}"
+        );
+        // And what a constrained setting accepts, which is the fact a reader most needs.
+        assert!(page.contains("one of: git, none"), "{page}");
+        assert!(
+            !page.contains("secret"),
+            "a hidden prop should not be here:\n{page}"
+        );
+        assert!(!page.contains('`'), "no backticks in a man page:\n{page}");
+    }
+
+    #[test]
+    fn the_manpage_groups_settings_by_heading_like_the_page_does() {
+        // The docs model already partitions settings by `help_heading` so the two formats stay
+        // aligned. The manpage walked the flat list instead, dropping every heading and
+        // interleaving headed settings with unheaded ones in one alphabetical run.
+        let spec: Spec = r##"
+name "hk"
+bin "hk"
+config {
+    prop "jobs" type="uint" help="How many" help_heading="Performance"
+    prop "cache" type="bool" help="Cache things" help_heading="Performance"
+    prop "colour" type="bool" help="Colourize"
+}
+"##
+        .parse()
+        .unwrap();
+        let page = ManpageRenderer::new(spec).render().unwrap();
+        assert!(page.contains(".SS Performance"), "{page}");
+        // The unheaded setting comes first, as the markdown page also orders it, and the two
+        // headed ones sit together under the heading rather than either side of it.
+        let colour = page.find("colour").expect("colour");
+        let heading = page.find(".SS Performance").expect("heading");
+        let jobs = page.find("jobs").expect("jobs");
+        let cache = page.find("cache").expect("cache");
+        assert!(colour < heading, "unheaded settings come first:\n{page}");
+        assert!(heading < cache && heading < jobs, "{page}");
+    }
+
+    #[test]
+    fn a_cli_with_no_settings_has_no_configuration_section() {
+        let spec: Spec = "name \"ex\"\nbin \"ex\"\n".parse().unwrap();
+        let page = ManpageRenderer::new(spec).render().unwrap();
+        assert!(!page.contains("CONFIGURATION"), "{page}");
+    }
+
+    #[test]
+    fn where_the_files_live_is_documented_even_with_nothing_to_put_in_them() {
+        // A CLI can describe its config file chain before it declares a single setting —
+        // usefully, since the chain is the part a reader cannot guess. Gating the section on
+        // props meant this spec documented its files on the markdown page and nowhere else.
+        let spec: Spec = r##"
+name "ex"
+bin "ex"
+config {
+    file "/etc/ex/config.toml" scope="system"
+    file "ex.toml" findup=#true
+}
+"##
+        .parse()
+        .unwrap();
+        let page = ManpageRenderer::new(spec).render().unwrap();
+        assert!(page.contains(".SH CONFIGURATION"), "{page}");
+        assert!(
+            page.contains("ex.toml (and in every parent directory)"),
+            "{page}"
+        );
+    }
 
     #[test]
     fn test_basic_manpage() {

--- a/lib/src/docs/markdown/config.rs
+++ b/lib/src/docs/markdown/config.rs
@@ -1,0 +1,267 @@
+use crate::docs::markdown::renderer::MarkdownRenderer;
+use crate::docs::models::SpecConfig;
+use crate::error::UsageErr;
+
+impl MarkdownRenderer {
+    /// The settings reference for a spec's `config` block.
+    ///
+    /// Empty string when there is nothing to say, so a caller can concatenate it without
+    /// checking — a CLI with no settings should not grow a blank section.
+    pub fn render_config(&self) -> Result<String, UsageErr> {
+        // From the raw block, not from `self.spec.config`: that one was rendered by `new`
+        // before the builder options were set, and rendering is once-only, so taking it would
+        // silently ignore `replace_pre_with_code_fences`. Same reason `render_cmd` converts
+        // from the raw command it is given.
+        let mut config = SpecConfig::from(&self.raw_config);
+        if config.is_empty() {
+            return Ok(String::new());
+        }
+        config.render_md(self);
+        let mut ctx = self.clone();
+        ctx.insert("config", &config);
+        ctx.render("config_template.md.tera")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::docs::markdown::renderer::MarkdownRenderer;
+    use insta::assert_snapshot;
+
+    fn rendered(src: &str) -> String {
+        let spec: crate::Spec = src.parse().unwrap();
+        MarkdownRenderer::new(spec)
+            .with_replace_pre_with_code_fences(true)
+            .render_config()
+            .unwrap()
+    }
+
+    #[test]
+    fn a_cli_with_no_settings_renders_nothing() {
+        assert_eq!(rendered("name \"ex\"\nbin \"ex\"\n"), "");
+    }
+
+    #[test]
+    fn the_facts_list_starts_on_its_own_line_whatever_its_first_item_is() {
+        // The blank line that opens the list was emitted inside the `type_` branch, so a prop
+        // with a default and no declared type put its first list item straight against the
+        // heading — and a deprecated one put it against the admonition's closing `:::`, where
+        // some renderers read it as part of the admonition rather than as a list.
+        let page = rendered(
+            r##"
+name "ex"
+bin "ex"
+config {
+    prop "untyped" default=1 help="No declared type"
+    prop "gone" default=2 deprecated="Use untyped." help="Also no declared type"
+}
+"##,
+        );
+        assert!(
+            page.contains("## `untyped`\n\n- **default**: `1`"),
+            "the list item is against the heading:\n{page:?}"
+        );
+        assert!(
+            page.contains(":::\n\n- **default**: `2`"),
+            "the list item is against the admonition:\n{page:?}"
+        );
+    }
+
+    #[test]
+    fn the_settings_section_sits_under_the_title_on_the_single_file_page() {
+        // Two things were wrong here at once, and the second hid the first: `{%- include %}`
+        // stripped the blank line before the section, so its heading was glued onto the last
+        // line of the command above it — `Run# Configuration` — and a `header_level` decrement
+        // put that heading at level 1, beside the document's own title.
+        let spec: crate::Spec = r##"
+name "ex"
+bin "ex"
+config {
+    prop "jobs" type="uint" help="How many"
+}
+cmd "run" help="Run"
+"##
+        .parse()
+        .unwrap();
+        let page = MarkdownRenderer::new(spec).render_spec().unwrap();
+        assert!(
+            page.contains("\n\n## Configuration\n"),
+            "the heading is glued to the line above it, or at the wrong level:\n{page}"
+        );
+        // And the settings sit below it, a level deeper than the commands' own level.
+        assert!(page.contains("### `jobs`"), "{page}");
+    }
+
+    #[test]
+    fn a_setting_s_long_help_gets_the_rendering_options_it_was_asked_for() {
+        // `MarkdownRenderer::new` renders the whole docs model eagerly — before the builder
+        // methods that set the options — and rendering marks each item done, so a second pass
+        // no-ops. Taking the already-rendered config meant `replace_pre_with_code_fences` did
+        // nothing at all to a setting's long help, silently, while doing its job everywhere
+        // else on the same page.
+        let src = r##"
+name "ex"
+bin "ex"
+config {
+    prop "shell" help="Which shell" {
+        long_help "Run it like this:\n\n    ex --shell bash\n"
+    }
+}
+"##;
+        let spec: crate::Spec = src.parse().unwrap();
+        let with_fences = MarkdownRenderer::new(spec.clone())
+            .with_replace_pre_with_code_fences(true)
+            .render_config()
+            .unwrap();
+        assert!(
+            with_fences.contains("```"),
+            "the option did not reach the setting's help:\n{with_fences}"
+        );
+        // And without it the block stays indented, so the assertion above is about the option
+        // rather than about something else in the pipeline.
+        let without = MarkdownRenderer::new(spec.clone()).render_config().unwrap();
+        assert!(!without.contains("```"), "{without}");
+        assert!(without.contains("    ex --shell bash"), "{without}");
+
+        // The single-file page renders the same model by its own path, and had the same bug.
+        let whole = MarkdownRenderer::new(spec)
+            .with_replace_pre_with_code_fences(true)
+            .render_spec()
+            .unwrap();
+        assert!(
+            whole.contains("```"),
+            "the option did not reach the settings section of the whole-spec page:\n{whole}"
+        );
+    }
+
+    #[test]
+    fn the_index_links_the_settings_page_beside_it() {
+        // `--multi` writes settings.md next to index.md, and a reader who starts at the
+        // index — which is what an index is for — has to be able to get there.
+        let with_settings: crate::Spec = r##"
+name "ex"
+bin "ex"
+config {
+    prop "jobs" type="uint"
+}
+cmd "run" help="Run"
+"##
+        .parse()
+        .unwrap();
+        let renderer = MarkdownRenderer::new(with_settings);
+        let index = renderer.render_index().unwrap();
+        assert!(
+            index.contains(&format!("[Settings](/{})", renderer.config_page())),
+            "{index}"
+        );
+
+        // The page name does not move when a `settings` command appears — mise has exactly that
+        // command, and `settings.md` would have been its page. A name that switched would leave
+        // the abandoned one behind as a stale page on the next run.
+        let collides: crate::Spec = r##"
+name "ex"
+bin "ex"
+config {
+    prop "jobs" type="uint"
+}
+cmd "settings" help="Manage settings"
+"##
+        .parse()
+        .unwrap();
+        let renderer = MarkdownRenderer::new(collides);
+        assert_eq!(renderer.config_page(), "configuration.md");
+        assert_eq!(renderer.config_page_collision(), None);
+
+        // And the one collision left is reported rather than silent.
+        let clash: crate::Spec = r##"
+name "ex"
+bin "ex"
+config {
+    prop "jobs" type="uint"
+}
+cmd "configuration" help="Somebody really did this"
+"##
+        .parse()
+        .unwrap();
+        assert_eq!(
+            MarkdownRenderer::new(clash).config_page_collision(),
+            Some("configuration")
+        );
+
+        // And a CLI with no settings gets no link, because there is no page: the two are
+        // gated on the same condition so the index cannot point at a file nothing wrote.
+        let without: crate::Spec = "name \"ex\"\nbin \"ex\"\ncmd \"run\" help=\"Run\"\n"
+            .parse()
+            .unwrap();
+        let renderer = MarkdownRenderer::new(without);
+        let index = renderer.render_index().unwrap();
+        // Against the name the page is actually written under, not a name nothing uses any
+        // more: asserting the absence of `settings.md` passed happily while a broken gate
+        // emitted a link to `configuration.md`.
+        assert!(
+            !index.contains(&format!("[Settings](/{}", renderer.config_page())),
+            "{index}"
+        );
+    }
+
+    #[test]
+    fn a_block_of_only_files_reaches_every_output() {
+        // Where the config files live is the part a reader cannot guess, and a CLI may
+        // describe the chain before it declares its first setting. Three output paths render
+        // this model — its own page, the single-file page, and the manpage — and each had its
+        // own idea of when there was something to render: two gated on props, so the same
+        // spec documented its files in one place and not the others.
+        let src = r##"
+name "ex"
+bin "ex"
+config {
+    file "/etc/ex/config.toml" scope="system"
+    file "ex.toml" findup=#true
+}
+"##;
+        let spec: crate::Spec = src.parse().unwrap();
+        let renderer = MarkdownRenderer::new(spec);
+        let page = renderer.render_config().unwrap();
+        assert!(page.contains("ex.toml"), "{page}");
+        let whole = renderer.render_spec().unwrap();
+        assert!(
+            whole.contains("ex.toml"),
+            "the single-file page dropped the file chain:\n{whole}"
+        );
+    }
+
+    #[test]
+    fn every_part_of_a_prop_reaches_the_page() {
+        assert_snapshot!(rendered(
+            r##"
+name "hk"
+bin "hk"
+config {
+    source "git" name="git config" doc_hint="git config `{key}`"
+    file "~/.config/hk/config.toml" scope="global"
+    file "hk.toml" findup=#true
+    prop "jobs" type="uint" default=0 default_note="0 = auto-detect" \
+        help="Number of parallel jobs" since="1.0.0" help_heading="Performance" {
+        cli "--jobs" "-j"
+        env "HK_JOBS" "HK_JOB"
+        source "git" "hk.jobs"
+        example "hk check --jobs 4"
+    }
+    prop "exclude" type="list<string>" merge="union" help="Patterns to skip" {
+        default "target" "node_modules"
+        env "HK_EXCLUDE"
+    }
+    prop "stash" type="string" help="How to stash" {
+        choices {
+            choice "git" help="Use `git stash`"
+            choice "none" help="No stashing"
+        }
+    }
+    prop "trusted" type="bool" scope="global" help="Trust the config"
+    prop "old" deprecated="Use jobs instead." deprecated_remove_at="2027.12.0" help="Old"
+    prop "secret" hide=#true help="Not for the page"
+}
+"##
+        ));
+    }
+}

--- a/lib/src/docs/markdown/mod.rs
+++ b/lib/src/docs/markdown/mod.rs
@@ -1,5 +1,6 @@
 mod arg;
 mod cmd;
+mod config;
 mod flag;
 mod renderer;
 mod spec;

--- a/lib/src/docs/markdown/renderer.rs
+++ b/lib/src/docs/markdown/renderer.rs
@@ -50,6 +50,15 @@ fn escape_md(value: &str, html_encode: bool) -> String {
 #[derive(Debug, Clone)]
 pub struct MarkdownRenderer {
     pub(crate) spec: Spec,
+    /// The config block as the spec wrote it, before any rendering.
+    ///
+    /// `new` renders the whole docs model eagerly, which happens *before* the builder methods
+    /// that set `replace_pre_with_code_fences` and friends — and rendering marks each item
+    /// done, so a later pass no-ops. `render_cmd` avoids this by re-deriving from the raw
+    /// command its caller hands it; config has no such argument, so the raw form is kept here
+    /// instead. Without it, `--replace-pre-with-code-fences` silently did nothing to a
+    /// setting's long help.
+    pub(crate) raw_config: crate::spec::config::SpecConfig,
     pub(crate) header_level: usize,
     pub(crate) multi: bool,
     tera_ctx: tera::Context,
@@ -61,6 +70,7 @@ pub struct MarkdownRenderer {
 impl MarkdownRenderer {
     pub fn new(spec: crate::Spec) -> Self {
         let mut renderer = Self {
+            raw_config: spec.config.clone(),
             spec: spec.into(),
             header_level: 1,
             multi: false,
@@ -73,6 +83,36 @@ impl MarkdownRenderer {
         spec.render_md(&renderer);
         renderer.spec = spec;
         renderer
+    }
+
+    /// The file name the settings page gets in `--multi` mode.
+    ///
+    /// One name, always. `settings.md` was the obvious choice and the wrong one: mise has a
+    /// `settings` command, whose own page lands there, and config is written second — so for
+    /// the very CLI this feature is aimed at, the command's page was silently replaced and the
+    /// index linked both entries to the same file.
+    ///
+    /// Choosing between two names by whether a command is in the way would fix that and
+    /// introduce something worse: the name would move when a command is added or removed
+    /// between runs, leaving the abandoned one behind as a stale page nothing links but the
+    /// docs site still serves. A fixed name cannot do that, and `configuration` is a name CLIs
+    /// give to a *file*, not to a command — the command is called `config`.
+    pub fn config_page(&self) -> &'static str {
+        "configuration.md"
+    }
+
+    /// A visible top-level command whose own page would be written to [`Self::config_page`].
+    ///
+    /// Vanishingly unlikely, and silence is what made the `settings.md` collision hard to see,
+    /// so the one case left is reported rather than guessed at.
+    pub fn config_page_collision(&self) -> Option<&str> {
+        let stem = self.config_page().trim_end_matches(".md");
+        self.spec
+            .cmd
+            .subcommands
+            .values()
+            .find(|cmd| !cmd.hide && cmd.full_cmd == [stem])
+            .map(|cmd| cmd.name.as_str())
     }
 
     pub fn with_header_level(mut self, header_level: usize) -> Self {

--- a/lib/src/docs/markdown/snapshots/usage__docs__markdown__config__tests__every_part_of_a_prop_reaches_the_page.snap
+++ b/lib/src/docs/markdown/snapshots/usage__docs__markdown__config__tests__every_part_of_a_prop_reaches_the_page.snap
@@ -1,0 +1,61 @@
+---
+source: lib/src/docs/markdown/config.rs
+expression: "rendered(r##\"\nname \"hk\"\nbin \"hk\"\nconfig {\n    source \"git\" name=\"git config\" doc_hint=\"git config `{key}`\"\n    file \"~/.config/hk/config.toml\" scope=\"global\"\n    file \"hk.toml\" findup=#true\n    prop \"jobs\" type=\"uint\" default=0 default_note=\"0 = auto-detect\" \\\n        help=\"Number of parallel jobs\" since=\"1.0.0\" help_heading=\"Performance\" {\n        cli \"--jobs\" \"-j\"\n        env \"HK_JOBS\" \"HK_JOB\"\n        source \"git\" \"hk.jobs\"\n        example \"hk check --jobs 4\"\n    }\n    prop \"exclude\" type=\"list<string>\" merge=\"union\" help=\"Patterns to skip\" {\n        default \"target\" \"node_modules\"\n        env \"HK_EXCLUDE\"\n    }\n    prop \"stash\" type=\"string\" help=\"How to stash\" {\n        choices {\n            choice \"git\" help=\"Use `git stash`\"\n            choice \"none\" help=\"No stashing\"\n        }\n    }\n    prop \"trusted\" type=\"bool\" scope=\"global\" help=\"Trust the config\"\n    prop \"old\" deprecated=\"Use jobs instead.\" deprecated_remove_at=\"2027.12.0\" help=\"Old\"\n    prop \"secret\" hide=#true help=\"Not for the page\"\n}\n\"##)"
+---
+# Configuration
+
+Read from, in ascending precedence — the last one that names a setting wins:
+
+- `~/.config/hk/config.toml` (global)
+- `hk.toml` — and in every parent directory
+
+
+## `exclude`
+
+- **type**: `list<string>`
+- **default**: `target, node_modules`
+- **merged**: values from every source are combined
+- **set with**: `HK_EXCLUDE`
+
+Patterns to skip
+
+## `old`
+
+::: warning Deprecated
+Use jobs instead. Removed in 2027.12.0.
+:::
+
+Old
+
+## `stash`
+
+- **type**: `string`
+
+How to stash
+
+**Choices:**
+- `git` — Use `git stash`
+- `none` — No stashing
+
+
+## `trusted`
+
+- **type**: `bool`
+- **scope**: only from your own configuration, never from a project file
+
+Trust the config
+
+## Performance
+
+### `jobs`
+
+- **type**: `uint`
+- **default**: 0 = auto-detect
+- **since**: 1.0.0
+- **set with**: `--jobs`, `-j`, `HK_JOBS` (or `HK_JOB`), git config `hk.jobs`
+
+Number of parallel jobs
+
+```
+hk check --jobs 4
+```

--- a/lib/src/docs/markdown/spec.rs
+++ b/lib/src/docs/markdown/spec.rs
@@ -5,6 +5,11 @@ impl MarkdownRenderer {
     pub fn render_spec(&self) -> Result<String, UsageErr> {
         let mut ctx = self.clone();
         ctx.insert("all_commands", &self.spec.cmd.all_subcommands());
+        // From the raw block for the same reason `render_config` does: the copy on `self.spec`
+        // was rendered by `new` before the builder options existed, and rendering happens once.
+        let mut config = crate::docs::models::SpecConfig::from(&self.raw_config);
+        config.render_md(self);
+        ctx.insert("config", &config);
         ctx.render("spec_template.md.tera")
     }
 
@@ -12,6 +17,16 @@ impl MarkdownRenderer {
         let mut ctx = self.clone();
         ctx.multi = false;
         ctx.insert("all_commands", &self.spec.cmd.all_subcommands());
+        // So the index can link the settings page it sits beside. Without this the page was
+        // written and nothing pointed at it, which for a reader who starts at the index is
+        // the same as not writing it.
+        ctx.insert(
+            "config",
+            &crate::docs::models::SpecConfig::from(&self.raw_config),
+        );
+        // The name the page will actually be written under, so the link cannot point somewhere
+        // else than the file — including when a `settings` command has taken `settings.md`.
+        ctx.insert("config_page", &self.config_page());
         ctx.render("index_template.md.tera")
     }
 }

--- a/lib/src/docs/markdown/templates/config_template.md.tera
+++ b/lib/src/docs/markdown/templates/config_template.md.tera
@@ -1,0 +1,73 @@
+{{- "#" | repeat(count=header_level) }} Configuration
+{%- if config.files %}
+
+Read from, in ascending precedence — the last one that names a setting wins:
+
+{% for file in config.files -%}
+- `{{ file.path }}`{% if file.findup %} — and in every parent directory{% endif %}{% if file.scope != "project" %} ({{ file.scope }}){% endif %}{% if file.format %}, {{ file.format }}{% endif %}
+{% endfor -%}
+{%- endif %}
+{%- for group in config.prop_groups %}
+{%- if group.heading %}
+
+{{ "#" | repeat(count=header_level) }}# {{ group.heading }}
+{%- endif %}
+{#- A heading of its own means one level deeper; without one the props sit directly under
+    the section, so the levels never skip. #}
+{%- set prop_level = header_level + 2 if group.heading else header_level + 1 %}
+{%- for prop in group.items %}
+
+{{ "#" | repeat(count=prop_level) }} `{{ prop.key }}`
+{%- if prop.deprecated %}
+
+::: warning Deprecated
+{{ prop.deprecated }}{% if prop.deprecated_remove_at %} Removed in {{ prop.deprecated_remove_at }}.{% endif %}
+:::
+{%- endif %}
+{#- The blank line that opens the facts list, emitted once here rather than inside the `type_`
+    branch — a prop with a default but no declared type used to put its first list item
+    directly against the heading above (or against a deprecation admonition's closing `:::`),
+    which some markdown renderers read as part of that block rather than as a list. #}
+{%- if prop.type_ or prop.default or prop.merge or prop.scope == "global" or prop.scope == "env" or prop.since or prop.sources %}
+{% endif %}
+{%- if prop.type_ %}
+- **type**: `{{ prop.type_ }}`
+{%- endif %}
+{%- if prop.default %}
+- **default**: {% if prop.default_note %}{{ prop.default_note }}{% else %}`{{ prop.default }}`{% endif %}
+{%- endif %}
+{%- if prop.merge %}
+- **merged**: {% if prop.merge == "union" %}values from every source are combined{% else %}maps are merged key by key{% endif %}
+{%- endif %}
+{%- if prop.scope == "global" %}
+- **scope**: only from your own configuration, never from a project file
+{%- elif prop.scope == "env" %}
+- **scope**: only from the environment or the command line
+{%- endif %}
+{%- if prop.since %}
+- **since**: {{ prop.since }}
+{%- endif %}
+{%- if prop.sources %}
+- **set with**: {% for source in prop.sources %}{{ source }}{% if not loop.last %}, {% endif %}{% endfor %}
+{%- endif %}
+{%- if prop.help_md %}
+
+{{ prop.help_md | escape_md }}
+{%- endif %}
+{%- if prop.choices %}
+
+**Choices:**
+{% for choice in prop.choices -%}
+- `{{ choice.value }}`{% if choice.help %} — {{ choice.help }}{% endif %}
+{% endfor -%}
+{%- endif %}
+{%- if prop.examples %}
+
+{% for example in prop.examples -%}
+```
+{{ example }}
+```
+{% endfor -%}
+{%- endif %}
+{%- endfor %}
+{%- endfor -%}

--- a/lib/src/docs/markdown/templates/index_template.md.tera
+++ b/lib/src/docs/markdown/templates/index_template.md.tera
@@ -20,4 +20,13 @@
 {{ "#" | repeat(count=header_level) }} Subcommands
 {% endif %}
 - [`{{ (spec.bin ~ " " ~ cmd.usage) | trim }}`]({{ url_prefix }}/{{ cmd.full_cmd | join(sep="/") }}.md)
-{%- endfor -%}
+{%- endfor %}
+{#- The settings page, written beside this one in `--multi` mode by the same run. Gated on
+    the same condition that decides whether the page exists at all, so the index never links
+    a file that was not written. #}
+{%- if config.props or config.files %}
+
+{{ "#" | repeat(count=header_level) }} Configuration
+
+- [Settings]({{ url_prefix }}/{{ config_page }})
+{%- endif -%}

--- a/lib/src/docs/markdown/templates/spec_template.md.tera
+++ b/lib/src/docs/markdown/templates/spec_template.md.tera
@@ -40,4 +40,14 @@
 {{ "#" | repeat(count=header_level) }} `{{ (spec.bin ~ " " ~ full_cmd) | trim }}`
 
 {%- include "cmd_template.md.tera" %}
-{%- endfor -%}
+{%- endfor %}
+{#- Settings after the commands: a reader looking for a flag wants the command list first,
+    and a CLI with no settings renders nothing at all here. #}
+{#- A plain `include`, and the blank line before it kept: `{%- include %}` strips the whitespace
+    in *this* template, so the section's heading was glued onto the last line of the command
+    above it — `Run# Configuration`. And no decrement of `header_level`: the commands render at
+    level 2, so dropping to 1 put `# Configuration` beside the document's own title. -#}
+{%- if config.props or config.files %}
+
+{% include "config_template.md.tera" %}
+{%- endif -%}

--- a/lib/src/docs/markdown/tera.rs
+++ b/lib/src/docs/markdown/tera.rs
@@ -151,6 +151,10 @@ pub(crate) static TERA: LazyLock<Tera> = LazyLock::new(|| {
     tera.add_raw_templates([
         ("arg_template.md.tera", include_str!("templates/arg_template.md.tera")),
         ("cmd_template.md.tera", include_str!("templates/cmd_template.md.tera")),
+        (
+            "config_template.md.tera",
+            include_str!("templates/config_template.md.tera"),
+        ),
         ("flag_template.md.tera", include_str!("templates/flag_template.md.tera")),
         ("spec_template.md.tera", include_str!("templates/spec_template.md.tera")),
         ("index_template.md.tera", include_str!("templates/index_template.md.tera")),

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -9,7 +9,7 @@ pub struct Spec {
     pub name: String,
     pub bin: String,
     pub cmd: SpecCommand,
-    // pub config: SpecConfig,
+    pub config: SpecConfig,
     pub version: Option<String>,
     pub usage: String,
     // pub complete: IndexMap<String, SpecComplete>,
@@ -110,6 +110,206 @@ pub struct Group<T> {
     pub items: Vec<T>,
 }
 
+/// A CLI's settings, as documentation sees them.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SpecConfig {
+    /// Every property, hidden ones already removed.
+    pub props: Vec<SpecConfigProp>,
+    /// `props`, partitioned by `help_heading`. Same props, same order.
+    pub prop_groups: Vec<Group<SpecConfigProp>>,
+    /// Config file locations, in the precedence order the spec declared.
+    pub files: Vec<SpecConfigFile>,
+    rendered: bool,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SpecConfigFile {
+    pub path: String,
+    pub findup: bool,
+    pub scope: String,
+    pub format: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SpecConfigProp {
+    pub key: String,
+    /// The type as written, or nothing when the spec did not say.
+    pub type_: Option<String>,
+    pub default: Option<String>,
+    pub default_note: Option<String>,
+    pub help: Option<String>,
+    pub help_long: Option<String>,
+    pub help_md: Option<String>,
+    pub help_heading: Option<String>,
+    /// One line per way of setting it, already worded: "`--jobs`, `-j`",
+    /// "`HK_JOBS` (or `HK_JOB`)", "git config `hk.jobs`". Built here rather than in the
+    /// template so every renderer says it the same way.
+    pub sources: Vec<String>,
+    pub choices: Vec<SpecConfigChoice>,
+    pub deprecated: Option<String>,
+    pub deprecated_remove_at: Option<String>,
+    pub since: Option<String>,
+    pub examples: Vec<String>,
+    /// `union`/`deep` when the spec said so, nothing for the default.
+    pub merge: Option<String>,
+    /// Where a value may come from, when the spec restricted it.
+    pub scope: Option<String>,
+    rendered: bool,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SpecConfigChoice {
+    pub value: String,
+    pub help: Option<String>,
+}
+
+impl SpecConfig {
+    pub fn render_md(&mut self, renderer: &MarkdownRenderer) {
+        if self.rendered {
+            return;
+        }
+        self.rendered = true;
+        for prop in &mut self.props {
+            prop.render_md(renderer);
+        }
+        for group in &mut self.prop_groups {
+            for prop in &mut group.items {
+                prop.render_md(renderer);
+            }
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.props.is_empty() && self.files.is_empty()
+    }
+}
+
+impl SpecConfigProp {
+    pub fn render_md(&mut self, renderer: &MarkdownRenderer) {
+        if self.rendered {
+            return;
+        }
+        self.rendered = true;
+        if let Some(help) = &mut self.help_md {
+            *help = renderer.replace_code_fences(help.to_string());
+        }
+    }
+}
+
+impl From<&crate::spec::config::SpecConfig> for SpecConfig {
+    fn from(config: &crate::spec::config::SpecConfig) -> Self {
+        // Hidden props are dropped here rather than in the template: every consumer of
+        // this model wants them gone, and a template that forgets the filter leaks them.
+        let props: Vec<SpecConfigProp> = config
+            .props
+            .iter()
+            .filter(|(_, prop)| !prop.hide)
+            .map(|(key, prop)| SpecConfigProp::new(key, prop, config))
+            .collect();
+        Self {
+            prop_groups: group_by_heading(&props, |p| p.help_heading.as_deref()),
+            props,
+            files: config
+                .files
+                .iter()
+                .map(|file| SpecConfigFile {
+                    path: file.path.clone(),
+                    findup: file.findup,
+                    scope: file.scope.to_string(),
+                    format: file.format.clone(),
+                })
+                .collect(),
+            rendered: false,
+        }
+    }
+}
+
+impl SpecConfigProp {
+    fn new(
+        key: &str,
+        prop: &crate::spec::config::SpecConfigProp,
+        config: &crate::spec::config::SpecConfig,
+    ) -> Self {
+        Self {
+            key: key.to_string(),
+            type_: prop.value_type.as_ref().map(|t| t.to_string()),
+            default: prop
+                .default_note
+                .clone()
+                .or_else(|| prop.default.as_ref().map(|d| d.display()))
+                .or_else(|| {
+                    (!prop.default_list.is_empty()).then(|| {
+                        prop.default_list
+                            .iter()
+                            .map(|value| value.display())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    })
+                }),
+            default_note: prop.default_note.clone(),
+            help: prop.help.clone(),
+            help_long: prop.long_help.clone(),
+            help_md: prop.long_help.clone().or_else(|| prop.help.clone()),
+            help_heading: prop.help_heading.clone(),
+            sources: describe_sources(prop, config),
+            choices: prop
+                .choices
+                .iter()
+                .map(|choice| SpecConfigChoice {
+                    value: choice.value.display(),
+                    help: choice.help.clone(),
+                })
+                .collect(),
+            deprecated: prop.deprecated.clone(),
+            deprecated_remove_at: prop.deprecated_remove_at.clone(),
+            since: prop.since.clone(),
+            examples: prop.examples.clone(),
+            merge: (prop.merge != crate::spec::config::SpecConfigMerge::default())
+                .then(|| prop.merge.to_string()),
+            scope: (prop.scope != crate::spec::config::SpecConfigScope::default())
+                .then(|| prop.scope.to_string()),
+            rendered: false,
+        }
+    }
+}
+
+/// Every way of setting one property, in words.
+///
+/// A custom source kind is rendered from what the spec said about it — `doc_hint` with
+/// `{key}` substituted — so a page can describe a git config or an `.npmrc` without usage
+/// knowing anything about either.
+fn describe_sources(
+    prop: &crate::spec::config::SpecConfigProp,
+    config: &crate::spec::config::SpecConfig,
+) -> Vec<String> {
+    let mut described = Vec::new();
+    if !prop.cli.is_empty() {
+        let flags: Vec<String> = prop.cli.iter().map(|f| format!("`{f}`")).collect();
+        described.push(flags.join(", "));
+    }
+    match prop.envs.as_slice() {
+        [] => {}
+        [one] => described.push(format!("`{one}`")),
+        [first, rest @ ..] => {
+            let aliases: Vec<String> = rest.iter().map(|e| format!("`{e}`")).collect();
+            described.push(format!("`{first}` (or {})", aliases.join(", ")));
+        }
+    }
+    for (kind, keys) in &prop.bindings {
+        let declared = config.sources.get(kind);
+        let name = declared
+            .and_then(|s| s.name.clone())
+            .unwrap_or_else(|| kind.clone());
+        for key in keys {
+            match declared.and_then(|s| s.doc_hint.as_ref()) {
+                Some(hint) => described.push(hint.replace("{key}", key)),
+                None => described.push(format!("{name} `{key}`")),
+            }
+        }
+    }
+    described
+}
+
 /// Partition by heading, keeping declaration order within each group and putting
 /// the unheaded entries first.
 fn group_by_heading<T: Clone>(
@@ -172,7 +372,7 @@ impl From<crate::Spec> for Spec {
             name: spec.name,
             bin: spec.bin,
             cmd: SpecCommand::from(&spec.cmd),
-            // config: SpecConfig::from(&spec.config),
+            config: SpecConfig::from(&spec.config),
             version: spec.version,
             usage: spec.usage,
             // complete: spec.complete,
@@ -409,6 +609,7 @@ impl Spec {
             example.render_md(renderer);
         }
         self.cmd.render_md(renderer);
+        self.config.render_md(renderer);
     }
 }
 


### PR DESCRIPTION
Stacked on #835. The settings a spec declares now reach documentation — `lib/src/docs/models.rs:12` had `// pub config: SpecConfig,` commented out, so a config block could be written, read, round-tripped, and never appear anywhere a user would look.

## What it looks like

```markdown
# Configuration

Read from, in ascending precedence — the last one that names a setting wins:

- `~/.config/hk/config.toml` (global)
- `hk.toml` — and in every parent directory

## `exclude`

- **type**: `list<string>`
- **default**: `target, node_modules`
- **merged**: values from every source are combined
- **set with**: `HK_EXCLUDE`

Patterns to skip

## `old`

::: warning Deprecated
Use jobs instead. Removed in 2027.12.0.
:::

## Performance

### `jobs`

- **type**: `uint`
- **default**: 0 = auto-detect
- **since**: 1.0.0
- **set with**: `--jobs`, `-j`, `HK_JOBS` (or `HK_JOB`), git config `hk.jobs`
```

That last line is the point of the `source` declarations: **"git config `hk.jobs`" is rendered from the kind's `doc_hint`**, so a page describes a git config, a pkl file or an `.npmrc` without usage knowing what any of them are.

## Decided in the model, not the templates

So that markdown, man pages and anything later all agree: hidden props are dropped once, props are grouped by `help_heading` (reusing the helper flags already use, unheaded first), and the "set with" line is worded in one place.

## Where it appears

- `usage g markdown`: after the commands in single-file mode; a `settings.md` page in `--multi` mode.
- `usage g manpage`: a `CONFIGURATION` section after the commands, before the author.

Both only when there is something to say — a CLI with no settings gains neither an empty section nor an empty file, and there's a test for each.

The man page is deliberately terser than the web page: type, default, how to set it, deprecation. Prose belongs on the web page, and markdown backticks would be literal in a terminal — a test asserts none survive. Heading levels never skip: a prop under a heading is one level deeper, a prop without one sits directly under the section.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to documentation generation and templates; no runtime CLI behavior or security-sensitive paths, with collision failures failing closed before partial writes.
> 
> **Overview**
> **Config blocks from usage specs now show up in generated docs** instead of being dropped from the docs model.
> 
> Markdown gets a **Configuration** section (single-file output after commands; dedicated `configuration.md` in `--multi` mode) with file precedence, grouped settings, facts, choices, and “set with” lines built from CLI/env/custom `doc_hint` sources. The multi-file index links to that page when config content exists. **`--multi` refuses to run** if a visible top-level `configuration` command would collide with `configuration.md`, and does so before writing any files.
> 
> Man pages gain a matching **CONFIGURATION** section (files-only configs included, props grouped by `help_heading`, terminal-friendly facts without markdown backticks).
> 
> Rendering fixes keep config in sync with other docs: config is re-derived from `raw_config` so options like `--replace-pre-with-code-fences` apply, and templates gate empty config so no blank sections or files appear.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d84af71a276464aca361df9b65b39d352a6033a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configuration documentation to generated Markdown and manpage output.
  - Documented configuration files, lookup precedence, property groups, types, defaults, sources, choices, scopes, and deprecation notices.
  - Added links to the generated configuration page when configuration details are available.
- **Bug Fixes**
  - Empty configurations no longer generate blank pages or configuration sections.
  - Hidden configuration properties remain excluded.
  - Configuration pages now take precedence when their path conflicts with a command page.
- **Documentation**
  - Improved formatting and heading structure for configuration content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->