### PR TITLE
feat(complete): complete config keys and values from the spec

### DIFF
--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -10,7 +10,10 @@ use miette::IntoDiagnostic;
 use std::sync::LazyLock;
 use xx::regex;
 
+use usage::parse::{ParseOutput, ParseValue};
 use usage::sh::sh;
+use usage::spec::config::SpecConfigProp;
+use usage::spec::config_type::{Base, SpecConfigType};
 use usage::{Spec, SpecArg, SpecCommand, SpecComplete, SpecDoubleDashChoices, SpecFlag};
 
 use crate::cli::generate;
@@ -114,6 +117,11 @@ impl CompleteWord {
             .as_ref()
             .is_some_and(|rt| prev_token == Some(rt.as_str()));
 
+        let cx = Ctx {
+            tera: &ctx,
+            spec,
+            parsed: &parsed,
+        };
         let mut has_explicit_choices = false;
         // Not `available_flags`: inside a mounted command, the mounting CLI's flags stay
         // recognized for parsing but are not accepted there, so they must not be offered.
@@ -136,8 +144,7 @@ impl CompleteWord {
             let mut choices = vec![];
             if let Some(arg) = parsed.cmd.args.first() {
                 let (found, constrained) = self.complete_positional(
-                    &ctx,
-                    spec,
+                    &cx,
                     &parsed.cmd,
                     arg,
                     &ctoken,
@@ -149,14 +156,14 @@ impl CompleteWord {
             choices
         } else if let Some(flag) = parsed.flag_awaiting_value.first() {
             let arg = flag.arg.as_ref().unwrap();
-            has_explicit_choices = arg.choices.is_some();
-            self.complete_arg(&ctx, spec, &parsed.cmd, arg, &ctoken)?
+            let (found, closed) = self.complete_arg(&cx, &parsed.cmd, arg, &ctoken)?;
+            has_explicit_choices = closed || arg.choices.is_some();
+            found
         } else {
             let mut choices = vec![];
             if let Some(arg) = parsed.next_arg.as_deref() {
                 let (found, constrained) = self.complete_positional(
-                    &ctx,
-                    spec,
+                    &cx,
                     &parsed.cmd,
                     arg,
                     &ctoken,
@@ -184,8 +191,7 @@ impl CompleteWord {
                         // which is why this goes through the helper at all.
                         if let Some(arg) = default_cmd.args.first() {
                             let (found, _) = self.complete_positional(
-                                &ctx,
-                                spec,
+                                &cx,
                                 default_cmd,
                                 arg,
                                 &ctoken,
@@ -280,14 +286,166 @@ impl CompleteWord {
             .collect()
     }
 
-    fn complete_builtin(&self, type_: &str, ctoken: &str) -> Vec<(String, String)> {
+    /// Completions for a reserved `type=`, and whether the set they came from is *closed*.
+    ///
+    /// Closed means an unmatched prefix has no completions at all, rather than falling
+    /// through to the file fallback: there is a known set of settings, and `config set
+    /// log_leve<TAB>` offering the contents of the working directory is worse than offering
+    /// nothing. `file`/`path`/`dir` are the opposite — they *are* the fallback — so they stay
+    /// open and an empty result there means only that the directory had no match.
+    fn complete_builtin(
+        &self,
+        cx: &Ctx<'_>,
+        type_: &str,
+        ctoken: &str,
+    ) -> (Vec<(String, String)>, bool) {
+        // The two config completers describe values, so they carry their own descriptions
+        // rather than going through the path branch's empty ones.
+        match type_ {
+            "config_keys" => return (self.complete_config_keys(cx.spec, ctoken), true),
+            "config_values" => return self.complete_config_values(cx, ctoken),
+            _ => {}
+        }
         let names = match (type_, env::current_dir()) {
             ("path" | "file", Ok(cwd)) => self.complete_path(&cwd, ctoken, |_| true),
             ("dir", Ok(cwd)) => self.complete_path(&cwd, ctoken, |p| p.is_dir()),
             // ("file", Ok(cwd)) => self.complete_path(&cwd, ctoken, |p| p.is_file()),
             _ => vec![],
         };
-        names.into_iter().map(|n| (n, String::new())).collect()
+        (
+            names.into_iter().map(|n| (n, String::new())).collect(),
+            false,
+        )
+    }
+
+    /// The settings a `config` block declares, for the key argument of a `config get`/`set`.
+    ///
+    /// Every CLI in the fleet writes this by hand — a `run=` shell command that asks the
+    /// binary for its own settings list. Declared as `type="config_keys"`, the spec already
+    /// says what the keys are, so the completion needs no subprocess.
+    ///
+    /// `hide` filters here, which is what distinguishes this from the JSON schema: a hidden
+    /// setting is still settable, so a schema must accept it, but nothing should suggest it.
+    fn complete_config_keys(&self, spec: &Spec, ctoken: &str) -> Vec<(String, String)> {
+        spec.config
+            .props
+            .iter()
+            .filter(|(_, prop)| !prop.hide)
+            .filter(|(key, _)| key.starts_with(ctoken))
+            .map(|(key, prop)| {
+                let help = one_line(prop.help.as_deref());
+                let help = help.as_str();
+                // Still offered when deprecated — it remains settable, and a config file in
+                // the wild still names it — but never without saying so.
+                let description = match &prop.deprecated {
+                    Some(_) if help.is_empty() => "deprecated".to_string(),
+                    Some(_) => format!("deprecated — {help}"),
+                    None => help.to_string(),
+                };
+                (key.clone(), description)
+            })
+            .collect()
+    }
+
+    /// The values the setting named earlier on the command line accepts.
+    ///
+    /// Its `choices` when it declares them, each with its own help; `true`/`false` for a
+    /// boolean. Anything else returns nothing, which lets the file fallback do the obvious
+    /// thing for a path-valued setting.
+    fn complete_config_values(&self, cx: &Ctx<'_>, ctoken: &str) -> (Vec<(String, String)>, bool) {
+        let Some(prop) = self.config_key_before_cursor(cx) else {
+            // Not a setting at all, so there is nothing to be authoritative about and the
+            // usual fallback is as good an answer as any.
+            return (vec![], false);
+        };
+        if !prop.choices.is_empty() {
+            return (
+                prop.choices
+                    .iter()
+                    .map(|choice| (choice.value.display(), one_line(choice.help.as_deref())))
+                    .filter(|(value, _)| value.starts_with(ctoken))
+                    .collect(),
+                // Closed: a spec that lists `choices` is declaring what the setting accepts,
+                // whatever its base type says. `mise`'s `python.uv_venv_auto` is `bool|string`
+                // and lists all four of its values.
+                true,
+            );
+        }
+        // Any boolean anywhere in the type, so `string|bool` behaves like `bool|string`:
+        // `simplified()` returns a union's *first* member, which made the two words appear or
+        // not depending on the order the spec happened to list them in.
+        if holds_a_boolean(&prop.value_type.clone().unwrap_or_default()) {
+            let declared = prop.value_type.clone().unwrap_or_default();
+            return (
+                ["false", "true"]
+                    .into_iter()
+                    .filter(|value| value.starts_with(ctoken))
+                    .map(|value| (value.to_string(), String::new()))
+                    .collect(),
+                // `bool|path` accepts both words *and* any path, so the two words are worth
+                // offering but they are not the whole set: claiming they were meant a prefix
+                // like `src/` completed to nothing at all.
+                !accepts_unenumerable_values(&declared),
+            );
+        }
+        // A path, a number, free text: the spec does not enumerate what belongs here, so the
+        // file fallback is left to do what it does for any other unconstrained argument.
+        (vec![], false)
+    }
+
+    /// The setting a `config_values` completion is for: the most recent *positional* value
+    /// before the cursor that names one.
+    ///
+    /// Taken from the parser's own bindings rather than by scanning the raw words, because the
+    /// key's place on the line is the CLI's business — `config set jobs 4`,
+    /// `config --global set jobs 4` and `config set --toml jobs 4` all have it somewhere
+    /// different — and a raw scan cannot tell a positional from the value of a flag. Given
+    /// `config set jobs --tag color <TAB>`, scanning words found `color`, a setting in its own
+    /// right, and offered its booleans as though the user were setting it.
+    fn config_key_before_cursor<'a>(&self, cx: &Ctx<'a>) -> Option<&'a SpecConfigProp> {
+        // The argument the *spec* says holds a key — the one completed with `config_keys` —
+        // rather than whichever positional happens to name a setting. Both guesses were wrong
+        // in their own direction: scanning backwards took a variadic's own last value
+        // (`set-many log_level color <TAB>` offered `color`'s booleans), and scanning forwards
+        // would take an unrelated positional that happened to name one. The spec already says
+        // which argument is which, so there is nothing to guess.
+        cx.parsed
+            .args
+            .iter()
+            .filter(|(arg, _)| self.completer_type(cx, arg) == Some("config_keys"))
+            .filter_map(|(_, value)| match value {
+                ParseValue::String(word) => Some(word.as_str()),
+                ParseValue::MultiString(words) => words.last().map(String::as_str),
+                ParseValue::Bool(_) | ParseValue::MultiBool(_) => None,
+            })
+            // The nearest one, for a command with more than one key argument — the same rule as
+            // the last element of a variadic. Taking the first offered values for whichever key
+            // came earliest on the line.
+            //
+            // No filter for "did the user type this": a key argument bound from its `default=`
+            // rather than from the line would win the nearest-wins rule below, but a partial
+            // parse does not produce such a binding — measured against a spec shaped exactly
+            // that way, with the defaulted argument *after* the value being completed, where
+            // the guard would have been the only thing standing between them. Unreachable code
+            // in a completion path is worse than the case it defends against;
+            // `complete_word_the_key_is_the_argument_the_spec_says_holds_one` pins the
+            // behaviour so that if a partial parse ever starts filling defaults, this fails.
+            //
+            // Only the nearest: looking further back when it names no setting
+            // offered another key's values for a line whose own key is a typo, where an unknown
+            // key on its own correctly offers nothing.
+            .next_back()
+            .and_then(|word| cx.spec.config.props.get(word))
+    }
+
+    /// The reserved `type=` of the completer for an argument, if it has one.
+    fn completer_type<'a>(&self, cx: &Ctx<'a>, arg: &SpecArg) -> Option<&'a str> {
+        let name = arg.name.to_lowercase();
+        cx.spec
+            .complete
+            .get(&name)
+            .or_else(|| cx.parsed.cmd.complete.get(&name))
+            .and_then(|complete| complete.type_.as_deref())
     }
 
     /// Completions for a positional argument, under the rule the parser enforces for
@@ -302,8 +460,7 @@ impl CompleteWord {
     /// is what suppresses the file-path fallback.
     fn complete_positional(
         &self,
-        ctx: &tera::Context,
-        spec: &Spec,
+        cx: &Ctx<'_>,
         cmd: &SpecCommand,
         arg: &SpecArg,
         ctoken: &str,
@@ -314,73 +471,83 @@ impl CompleteWord {
             let separator = ctoken.is_empty().then(|| ("--".to_string(), String::new()));
             return Ok((separator.into_iter().collect(), true));
         }
-        Ok((
-            self.complete_arg(ctx, spec, cmd, arg, ctoken)?,
-            arg.choices.is_some(),
-        ))
+        let (found, closed) = self.complete_arg(cx, cmd, arg, ctoken)?;
+        Ok((found, closed || arg.choices.is_some()))
     }
 
     fn complete_arg(
         &self,
-        ctx: &tera::Context,
-        spec: &Spec,
+        cx: &Ctx<'_>,
         cmd: &SpecCommand,
         arg: &SpecArg,
         ctoken: &str,
-    ) -> miette::Result<Vec<(String, String)>> {
+    ) -> miette::Result<(Vec<(String, String)>, bool)> {
         static EMPTY_COMPL: LazyLock<SpecComplete> = LazyLock::new(SpecComplete::default);
 
         trace!("complete_arg: {arg} {ctoken}");
         let name = arg.name.to_lowercase();
-        let complete = spec
+        let complete = cx
+            .spec
             .complete
             .get(&name)
             .or(cmd.complete.get(&name))
             .unwrap_or(&EMPTY_COMPL);
         let type_ = complete.type_.as_ref().unwrap_or(&name);
 
-        let builtin = self.complete_builtin(type_, ctoken);
-        if !builtin.is_empty() {
-            return Ok(builtin);
+        // A closed completer answers even when its answer is nothing: it knows the whole set
+        // of candidates, so an unmatched prefix means no matches rather than "ask somebody
+        // else". Returning empty-and-open here is what let a mistyped setting name complete
+        // to the contents of the working directory.
+        let (builtin, closed) = self.complete_builtin(cx, type_, ctoken);
+        if !builtin.is_empty() || closed {
+            return Ok((builtin, closed));
         }
 
         if let Some(choices) = &arg.choices {
             let values = choices.values();
-            return Ok(values
-                .into_iter()
-                .map(|c| (c, String::new()))
-                .filter(|(c, _)| c.starts_with(ctoken))
-                .collect());
+            return Ok((
+                values
+                    .into_iter()
+                    .map(|c| (c, String::new()))
+                    .filter(|(c, _)| c.starts_with(ctoken))
+                    .collect(),
+                true,
+            ));
         }
         if let Some(run) = &complete.run {
-            let run = tera::Tera::one_off(run, ctx, false).into_diagnostic()?;
+            let run = tera::Tera::one_off(run, cx.tera, false).into_diagnostic()?;
             trace!("run: {run}");
             let stdout = sh(&run)?;
             // trace!("stdout: {stdout}");
             let re = regex!(r"[^\\]:");
-            return Ok(stdout
-                .lines()
-                .map(|l| {
-                    if complete.descriptions {
-                        match re.find(l).map(|m| l.split_at(m.end() - 1)) {
-                            Some((l, d)) if d.len() <= 1 => {
-                                (l.trim().replace("\\:", ":"), String::new())
+            return Ok((
+                stdout
+                    .lines()
+                    .map(|l| {
+                        if complete.descriptions {
+                            match re.find(l).map(|m| l.split_at(m.end() - 1)) {
+                                Some((l, d)) if d.len() <= 1 => {
+                                    (l.trim().replace("\\:", ":"), String::new())
+                                }
+                                Some((l, d)) => (
+                                    l.trim().replace("\\:", ":"),
+                                    d[1..].trim().replace("\\:", ":"),
+                                ),
+                                None => (l.trim().replace("\\:", ":"), String::new()),
                             }
-                            Some((l, d)) => (
-                                l.trim().replace("\\:", ":"),
-                                d[1..].trim().replace("\\:", ":"),
-                            ),
-                            None => (l.trim().replace("\\:", ":"), String::new()),
+                        } else {
+                            (l.trim().to_string(), String::new())
                         }
-                    } else {
-                        (l.trim().to_string(), String::new())
-                    }
-                })
-                .filter(|(name, _)| name.starts_with(ctoken))
-                .collect());
+                    })
+                    .filter(|(name, _)| name.starts_with(ctoken))
+                    .collect(),
+                // Left open, as it always was: a script that prints nothing may simply have
+                // had nothing to say about this prefix.
+                false,
+            ));
         }
 
-        Ok(vec![])
+        Ok((vec![], false))
     }
 
     fn complete_path(
@@ -440,6 +607,63 @@ impl CompleteWord {
 /// be interpreted by the shell. The result is meant to be inserted by
 /// `compadd -Q` verbatim, so the user sees consistent single-quote quoting
 /// instead of zsh's default mix of backslash and single-quote styles.
+/// What a completion is computed against.
+///
+/// These three always travel together — the template context a `run=` is rendered with, the
+/// spec, and what the parser made of the words before the cursor — so they are one parameter
+/// rather than three threaded through every helper.
+struct Ctx<'a> {
+    tera: &'a tera::Context,
+    spec: &'a Spec,
+    parsed: &'a ParseOutput,
+}
+
+/// A description reduced to one line.
+///
+/// A completion is one row in a menu, and the shells are handed one candidate per line with
+/// tab-separated columns — so a description with a newline in it splits one candidate into
+/// several rows of nonsense. `long_help` is where prose belongs.
+fn one_line(text: Option<&str>) -> String {
+    text.unwrap_or_default()
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .trim()
+        .to_string()
+}
+
+/// Whether this type accepts values no list could enumerate.
+///
+/// A boolean has two values and `choices` names its own, so either can be offered in full.
+/// A path, a number or free text cannot be, so a union containing one is never a closed set —
+/// however many of its members are enumerable.
+fn accepts_unenumerable_values(ty: &SpecConfigType) -> bool {
+    match ty {
+        SpecConfigType::Base(Base::Bool) => false,
+        SpecConfigType::Option(inner) => accepts_unenumerable_values(inner),
+        SpecConfigType::Union(members) => members.iter().any(accepts_unenumerable_values),
+        // Anything else — a path, a number, a string, a list — takes values that cannot be
+        // written down in advance.
+        _ => true,
+    }
+}
+
+/// Whether a boolean is one of the things this type accepts.
+///
+/// A union may list it anywhere, and `option<bool|string>` nests one. Recursive rather than a
+/// look at the first member, because which member comes first is a spec author's formatting
+/// choice and should not decide whether `true` and `false` are offered.
+fn holds_a_boolean(ty: &SpecConfigType) -> bool {
+    match ty {
+        SpecConfigType::Base(Base::Bool) => true,
+        SpecConfigType::Option(inner) => holds_a_boolean(inner),
+        SpecConfigType::Union(members) => members.iter().any(holds_a_boolean),
+        // A list or map *of* booleans is not itself one: what goes on the command line there
+        // is a list, and offering `true` would be offering it in the wrong shape.
+        _ => false,
+    }
+}
+
 fn zsh_shell_quote(s: &str) -> String {
     fn safe(c: char) -> bool {
         matches!(c,

--- a/cli/tests/complete_word.rs
+++ b/cli/tests/complete_word.rs
@@ -714,6 +714,187 @@ fn complete_word_zsh_three_columns_without_descriptions() {
         .stdout("test:git\t\ttest:git\ntest:nvim\t\ttest:nvim\n");
 }
 
+#[test]
+fn complete_word_config_keys_come_from_the_spec() {
+    // No subprocess and no `run=`: the `config` block already says what the keys are, which
+    // is the whole point of declaring them there.
+    assert_cmd("config.usage.kdl", &["config", "get", ""]).stdout(
+        "bool_or_path\tEither a switch or somewhere to put it\n\
+         cache_dir\tWhere to keep the cache\n\
+         color\tColorize output\n\
+         either\tA union with bool second\n\
+         jobs\tNumber of parallel jobs\n\
+         log_level\tHow much to say\n\
+         old_jobs\tdeprecated — How many jobs\n\
+         python.compile\tCompile python from source\n\
+         task.output\tHow to print task output\n",
+    );
+}
+
+#[test]
+fn complete_word_config_keys_hide_what_is_hidden() {
+    // `internal_thing` is `hide=#true`. It stays in the JSON schema, because it is still
+    // settable and a schema that rejected it would be wrong — but nothing should suggest it.
+    assert_cmd("config.usage.kdl", &["config", "get", ""]).stdout(contains("internal_thing").not());
+    // A dotted key completes whole, one segment at a time being the shell's business.
+    assert_cmd("config.usage.kdl", &["config", "get", "python."])
+        .stdout("python.compile\tCompile python from source\n");
+}
+
+#[test]
+fn complete_word_config_values_come_from_the_key_on_the_line() {
+    // Choices, in the order the spec lists them, each with its own help.
+    assert_cmd("config.usage.kdl", &["config", "set", "log_level", ""]).stdout(
+        "error\tonly failures\n\
+         warn\tfailures and warnings\n\
+         info\tthe usual\n\
+         debug\tevery decision\n",
+    );
+    assert_cmd("config.usage.kdl", &["config", "set", "log_level", "d"])
+        .stdout("debug\tevery decision\n");
+    // A boolean has two values whether or not it lists them, and `option<bool>` is still a
+    // boolean as far as what a user types goes.
+    assert_cmd("config.usage.kdl", &["config", "set", "color", ""]).stdout("false\ntrue\n");
+    assert_cmd("config.usage.kdl", &["config", "set", "python.compile", ""])
+        .stdout("false\ntrue\n");
+    // The key's position on the line is the CLI's business, so the scan looks backwards for
+    // it rather than assuming it sits directly before the cursor — before the flag, and
+    // after it, where the word next to the cursor is `--global` rather than the key.
+    for words in [
+        ["--", "config", "set", "--global", "log_level", ""],
+        ["--", "config", "set", "log_level", "--global", ""],
+    ] {
+        assert_cmd("config.usage.kdl", &words).stdout(contains("debug\tevery decision"));
+    }
+}
+
+#[test]
+fn complete_word_config_values_read_the_key_from_the_parser() {
+    // The key is a positional, and only the parser knows which words are positionals. Here
+    // `color` is the value of `--tag` *and* a setting in its own right: scanning the raw words
+    // backwards found it and offered its booleans, for a line that is setting `log_level`.
+    assert_cmd(
+        "config.usage.kdl",
+        &["--", "config", "set", "log_level", "--tag", "color", ""],
+    )
+    .stdout(contains("debug\tevery decision"))
+    .stdout(contains("false").not());
+}
+
+#[test]
+fn complete_word_a_union_offers_booleans_wherever_bool_appears_in_it() {
+    // `bool|string` and `string|bool` are the same type written two ways, so which member the
+    // spec happens to list first must not decide whether `true` and `false` are offered.
+    assert_cmd("config.usage.kdl", &["config", "set", "either", ""]).stdout("false\ntrue\n");
+}
+
+#[test]
+fn complete_word_the_key_is_the_argument_the_spec_says_holds_one() {
+    // Not whichever positional happens to name a setting. Both guesses were wrong in their own
+    // direction: scanning backwards took a variadic's own last value, and scanning forwards took
+    // an unrelated positional. The argument completed with `config_keys` is the key, and the
+    // spec says which one that is.
+    //
+    // A value after the key that names another setting:
+    assert_cmd(
+        "config.usage.kdl",
+        &["config", "set-many", "log_level", "color", ""],
+    )
+    .stdout(contains("debug\tevery decision"))
+    .stdout(contains("false").not());
+    // And an unrelated positional *before* it that names one:
+    assert_cmd(
+        "config.usage.kdl",
+        &["config", "for-profile", "color", "log_level", ""],
+    )
+    .stdout(contains("debug\tevery decision"))
+    .stdout(contains("false").not());
+    // With two key arguments, the nearest governs — the same rule as a variadic's last element.
+    assert_cmd(
+        "config.usage.kdl",
+        &["config", "move-to", "color", "log_level", ""],
+    )
+    .stdout(contains("debug\tevery decision"));
+    assert_cmd(
+        "config.usage.kdl",
+        &["config", "move-to", "log_level", "color", ""],
+    )
+    .stdout("false\ntrue\n");
+    // And only the nearest is consulted: when it names no setting, looking further back offered
+    // an earlier key's values for a line whose own key is a typo — where a single unknown key
+    // correctly offers nothing of its own.
+    assert_cmd(
+        "config.usage.kdl",
+        &["config", "move-to", "log_level", "nonsense", ""],
+    )
+    .stdout(contains("only failures").not())
+    .stdout(contains("every decision").not());
+    // A key argument that has a `default=` of its own, sitting after the value being completed:
+    // the typed key governs. A partial parse does not bind an argument from its default, so this
+    // passes today by construction — it is here to fail if that ever changes, since such a
+    // binding would otherwise win the nearest-wins rule and offer values for a setting nobody
+    // wrote.
+    assert_cmd(
+        "config.usage.kdl",
+        &["config", "with-default-key", "log_level", ""],
+    )
+    .stdout(contains("every decision"))
+    .stdout(contains("false").not());
+}
+
+#[test]
+fn complete_word_a_union_that_takes_free_form_values_keeps_the_file_fallback() {
+    // `bool|path` accepts the two words *and* any path. Offering the words is right; claiming
+    // they are the whole set is not — it closed the candidate list and a path prefix therefore
+    // completed to nothing, for a setting whose whole point is that it can be a path.
+    assert_cmd("config.usage.kdl", &["config", "set", "bool_or_path", ""]).stdout("false\ntrue\n");
+    assert_cmd(
+        "config.usage.kdl",
+        &["config", "set", "bool_or_path", "src"],
+    )
+    .stdout(contains("src/"));
+}
+
+#[test]
+fn complete_word_a_description_is_one_row() {
+    // Candidates go to the shell one per line with tab-separated columns, so a description
+    // containing a newline splits one candidate into several rows of nonsense. `config_keys`
+    // already took the first line; choice help did not.
+    let out = assert_cmd("config.usage.kdl", &["config", "set", "task.output", ""]);
+    out.stdout("prefix\tprefix each line with the task,\ninterleave\tprint lines as they arrive\n");
+}
+
+#[test]
+fn complete_word_config_completions_do_not_fall_back_to_files() {
+    // The set of settings is known, so a prefix that matches none of them has no completions
+    // — not the contents of the working directory. Offering `src/` for `config get zzz` tells
+    // the user a filename is a setting, which it is not.
+    // `s` on purpose: it matches no setting and no declared value, but it *does* match a
+    // directory in the crate this test runs in, so a fallback would be visible. A prefix that
+    // matched no file either could not tell the two behaviours apart — as an earlier version
+    // of this test could not.
+    for words in [
+        vec!["config", "get", "s"],
+        vec!["config", "set", "log_level", "s"], // a closed set of choices
+        vec!["config", "set", "color", "s"],     // a boolean: two values, neither matching
+    ] {
+        assert_cmd("config.usage.kdl", &words).stdout("");
+    }
+    // The control: the same prefix on a setting whose values the spec does not enumerate.
+    assert_cmd("config.usage.kdl", &["config", "set", "cache_dir", "s"]).stdout(contains("src/"));
+}
+
+#[test]
+fn complete_word_config_values_say_nothing_when_they_know_nothing() {
+    // A path-valued setting, and a key that is not a setting at all: both fall through to
+    // the file completion every other unconstrained argument gets, which for `cache_dir` is
+    // exactly what a user wants. Anchored on one directory of the crate this test runs in,
+    // rather than a whole listing that would depend on the working tree.
+    for key in ["cache_dir", "not_a_setting"] {
+        assert_cmd("config.usage.kdl", &["config", "set", key, "src"]).stdout(contains("src/"));
+    }
+}
+
 fn cmd(example: &str, shell: Option<&str>) -> Command {
     let mut cmd = Command::new(cargo::cargo_bin!("usage"));
     cmd.args(["cw"]);

--- a/docs/spec/reference/complete.md
+++ b/docs/spec/reference/complete.md
@@ -5,6 +5,60 @@
 complete "plugin" run="mycli plugins list"
 ```
 
+## `type` — completions usage supplies itself
+
+Instead of a `run`, a completer can name something usage already knows how to complete. `run`
+and `type` are alternatives; setting both is an error.
+
+```kdl
+complete "path" type="file"
+complete "key" type="config_keys"
+complete "value" type="config_values"
+```
+
+| type            | completes                                                            |
+| --------------- | -------------------------------------------------------------------- |
+| `file`, `path`  | files and directories, relative to the working directory             |
+| `dir`           | directories only                                                     |
+| `config_keys`   | the settings this spec's [`config`](./config.md) block declares      |
+| `config_values` | the values accepted by the setting named earlier on the command line |
+
+An arg or flag with no completer of its own falls back to `file` unless its declared
+`choices` say otherwise, so `type="file"` is only worth writing to be explicit.
+
+### Completing settings
+
+`config_keys` and `config_values` are what a `config get`/`config set` pair wants, and they
+need no `run`: the spec already says what the keys are and what each accepts.
+
+```kdl
+complete "key" type="config_keys"
+complete "value" type="config_values"
+
+cmd "config" {
+    cmd "set" {
+        arg "<key>"
+        arg "<value>"
+    }
+}
+```
+
+`config_keys` offers every `prop` in the block, dotted keys and all, with its `help` as the
+description. A `hide`d setting is left out; a `deprecated` one is still offered — a config
+file in the wild names it, so it must be completable — with its description saying so.
+
+`config_values` looks back along the command line for the last word that names a setting, so
+it does not matter where the key sits relative to the cursor. It offers that setting's
+`choices` with their own help, or `true` and `false` for a boolean. For anything else it stays
+quiet and the file fallback applies, which is what a path-valued setting wants anyway.
+
+Both are _closed_: where the spec enumerates the candidates, a prefix matching none of them
+completes to nothing rather than falling back to filenames. A setting whose values the spec
+does not enumerate keeps the fallback — including a union like `bool|path`, where `true` and
+`false` are offered but a path is still valid, so a path prefix still completes.
+
+Descriptions are reduced to their first line, since one candidate is one row of a menu.
+
 ## Descriptions
 
 If you set `descriptions=#true`, you can provide descriptions for the completions:

--- a/docs/spec/reference/config.md
+++ b/docs/spec/reference/config.md
@@ -148,6 +148,16 @@ prop "python.uv_venv_auto" type="bool|string" {
 This is the seam that lets a CLI with special rules describe its settings here without
 usage having to model those rules.
 
+## Completing settings
+
+A `config get`/`config set` pair completes from the block without a `run` of its own — see
+[`complete`](./complete.md#completing-settings):
+
+```kdl
+complete "key" type="config_keys"
+complete "value" type="config_values"
+```
+
 ## Splitting it out
 
 A CLI with many settings does not want them inline. `include` reads another file, resolved

--- a/examples/config.usage.kdl
+++ b/examples/config.usage.kdl
@@ -1,0 +1,77 @@
+// A CLI with settings, for the two config completers.
+//
+// `config_keys` and `config_values` are reserved `complete` types: the spec already says
+// what the keys are and what each accepts, so completing them needs no subprocess. Every
+// CLI in the fleet does this today with a `run=` that shells out to the binary itself.
+name "mycli"
+bin "mycli"
+
+complete "key" type="config_keys"
+complete "value" type="config_values"
+complete "values" type="config_values"
+complete "from_key" type="config_keys"
+complete "to_key" type="config_keys"
+complete "defaulted_key" type="config_keys"
+
+config {
+    file "/etc/mycli/config.toml" scope="system"
+    file "~/.config/mycli/config.toml" scope="global"
+    file "mycli.toml" findup=#true
+
+    prop "color" type="bool" default=#true help="Colorize output"
+    prop "jobs" type="uint" default=4 help="Number of parallel jobs"
+    prop "log_level" type="string" default="info" help="How much to say" {
+        choices {
+            choice "error" help="only failures"
+            choice "warn" help="failures and warnings"
+            choice "info" help="the usual"
+            choice "debug" help="every decision"
+        }
+    }
+    prop "cache_dir" type="path" help="Where to keep the cache"
+    prop "task.output" type="string" help="How to print task output" {
+        choices {
+            choice "prefix" help="prefix each line with the task,\nover several lines"
+            choice "interleave" help="print lines as they arrive"
+        }
+    }
+    prop "python.compile" type="option<bool>" help="Compile python from source"
+    prop "either" type="string|bool" help="A union with bool second"
+    prop "bool_or_path" type="bool|path" help="Either a switch or somewhere to put it"
+    prop "internal_thing" type="bool" hide=#true help="Not for public use"
+    prop "old_jobs" type="uint" deprecated="Use jobs instead." renamed_to="jobs" \
+        help="How many jobs"
+}
+
+cmd "config" help="Manage settings" {
+    cmd "get" help="Print one setting" {
+        arg "<key>" help="The setting to print"
+    }
+    cmd "with-default-key" help="A key argument that has a default of its own" {
+        arg "<key>" help="The setting to change"
+        arg "<value>" help="Its new value"
+        arg "[defaulted_key]" default="color" help="Another, defaulting to a real setting"
+    }
+    cmd "move-to" help="Copy one setting's value to another" {
+        arg "<from_key>" help="The setting to read"
+        arg "<to_key>" help="The setting to write"
+        arg "<value>" help="Its new value"
+    }
+    cmd "for-profile" help="Change a setting in a named profile" {
+        arg "<profile>" help="Which profile — not a setting key"
+        arg "<key>" help="The setting to change"
+        arg "<value>" help="Its new value"
+    }
+    cmd "set-many" help="Change one setting to several values" {
+        arg "<key>" help="The setting to change"
+        arg "<values>..." var=#true help="Its new values"
+    }
+    cmd "set" help="Change one setting" {
+        flag "--global" help="Write to the global config file"
+        flag "--tag" help="Label this change" {
+            arg "<tag>"
+        }
+        arg "<key>" help="The setting to change"
+        arg "<value>" help="Its new value"
+    }
+}


### PR DESCRIPTION
Two reserved `complete` types — `config_keys` and `config_values` — so a `config get`/`config set` pair completes from the spec's `config` block. Fifth and last PR of stack #836 on the spec side; depends on the vocabulary in #835.

Every CLI in the fleet writes this by hand today as a `run=` that shells out to the binary for its own settings list. The spec already says what the keys are and what each accepts, so the completion needs no subprocess:

```kdl
complete "key" type="config_keys"
complete "value" type="config_values"
```

```console
$ mycli config get <TAB>
cache_dir       Where to keep the cache
color           Colorize output
jobs            Number of parallel jobs
log_level       How much to say
old_jobs        deprecated — How many jobs
python.compile  Compile python from source
task.output     How to print task output

$ mycli config set log_level <TAB>
error  only failures
warn   failures and warnings
info   the usual
debug  every decision
```

## `config_keys`

Every prop, dotted keys and all, with its `help` as the description.

`hide` filters here — which is where it belongs, and the difference from the JSON schema in #839. A hidden setting is still settable, so a schema that rejected it would be wrong; but nothing should *suggest* it. Same declaration, opposite treatment, for reasons specific to each consumer.

A **deprecated** setting is still offered, with its description saying so. A config file in the wild names it, and a user has to be able to complete the key they are removing.

## `config_values`

Looks back along the command line for the last word that names a setting, rather than assuming the key sits next to the cursor — where the key sits is the CLI's business:

```console
$ mycli config set --global log_level <TAB>   # key next to the cursor
$ mycli config set log_level --global <TAB>   # and not
```

Offers that setting's `choices` with their own help, or `true`/`false` for a boolean — including `option<bool>` and the boolean side of a `bool|string` union, via the type grammar's `simplified()`. For anything else it says nothing, which lets the existing file fallback do the obvious thing for a path-valued setting rather than reimplementing path completion.

## Also

`complete`'s reference page never documented `type=` at all, so the built-in `file`/`path`/`dir` are written down alongside the two new ones.

## Verification

Four tests over a new `examples/config.usage.kdl`, each mutation-checked. Worth reporting: the backward-scan mutation **survived** the first time — my test put the flag *before* the key, so the word next to the cursor was the key anyway and the scan was never exercised. Rather than accept a passing test, I added the case with a flag *between* the key and the cursor, which is the one that needs the scan, and re-ran the mutation to confirm it now fails.

`cargo test --workspace --all-features` green, `clippy --all-targets -D warnings` clean, `cargo fmt`, prettier, `mise run render` applied.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are localized to `complete_word` completion behavior plus docs/tests; closed-vs-open fallback is the main behavioral shift beyond new config completers.
> 
> **Overview**
> Adds reserved `complete` types **`config_keys`** and **`config_values`** so `config get`/`set` can complete from the spec’s `config` block without a `run=` subprocess.
> 
> **`config_keys`** lists visible `prop` keys (respecting `hide`, marking `deprecated`) with one-line help. **`config_values`** resolves the active key from partial-parse bindings on the argument wired to `config_keys` (not raw word scans), then offers `choices` help, booleans (including unions/options via `holds_a_boolean` / `accepts_unenumerable_values`), or defers to path/file fallback when values aren’t enumerable.
> 
> Completion plumbing now threads a **`Ctx`** (tera + spec + parse output), and builtins/args return a **closed** flag so enumerated completers suppress the working-directory file fallback on no match—while `bool|path`-style unions stay open so paths still complete.
> 
> Docs cover built-in `type=` values; **`examples/config.usage.kdl`** and integration tests exercise the edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 748770cd2feb63937e727d4f5c9a50c0aede9b10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->