### PR TITLE
fix(docs): link multi-word commands to their real source files

### DIFF
--- a/cli/assets/usage-extra.usage.kdl
+++ b/cli/assets/usage-extra.usage.kdl
@@ -1,2 +1,3 @@
 repository "https://github.com/jdx/usage"
-source_code_link_template "https://github.com/jdx/usage/blob/main/cli/src/cli/{{path}}.rs"
+// command names are hyphenated, the files that implement them are snake_case
+source_code_link_template "https://github.com/jdx/usage/blob/main/cli/src/cli/{{ path | replace(from='-', to='_') }}.rs"

--- a/cli/tests/markdown.rs
+++ b/cli/tests/markdown.rs
@@ -249,3 +249,68 @@ fn test_markdown_out_file_dash_writes_no_file() {
 
     fs::remove_dir_all(&dir).unwrap();
 }
+
+#[test]
+fn test_source_code_links_for_multi_word_commands_exist() {
+    // A hyphenated command like `complete-word` lives in `complete_word.rs`; linking it as
+    // `complete-word.rs` is a 404 on GitHub, and nothing but the file system can catch it.
+    let repo_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    let spec = repo_root.join("cli").join("usage.usage.kdl");
+    let out_file =
+        std::env::temp_dir().join(format!("usage_md_src_links_{}.md", std::process::id()));
+    let _ = fs::remove_file(&out_file);
+
+    let mut cmd = usage_cmd();
+    cmd.args([
+        "generate",
+        "markdown",
+        "-f",
+        spec.to_str().unwrap(),
+        "--out-file",
+        out_file.to_str().unwrap(),
+    ]);
+    cmd.assert().success();
+
+    let content = fs::read_to_string(&out_file).unwrap();
+    let mut cur_cmd = String::new();
+    let mut checked = vec![];
+    for line in content.lines() {
+        if line.starts_with('#') {
+            cur_cmd = line
+                .trim_start_matches('#')
+                .trim()
+                .trim_matches('`')
+                .to_string();
+            continue;
+        }
+        let Some(rest) = line.trim().strip_prefix("- **Source code**: [`") else {
+            continue;
+        };
+        let path = rest.split_once("`]").expect("malformed source code link").0;
+        // Single-word commands are linked from the same template, but several of them
+        // legitimately live elsewhere (`usage bash` is served by `shell.rs`), so only the
+        // hyphen-to-underscore mapping is asserted here.
+        let is_multi_word = cur_cmd
+            .split_whitespace()
+            .next_back()
+            .unwrap_or("")
+            .contains('-');
+        if !is_multi_word {
+            continue;
+        }
+        assert!(
+            repo_root.join(path).is_file(),
+            "`{cur_cmd}` links to {path}, which does not exist"
+        );
+        checked.push(cur_cmd.clone());
+    }
+    assert!(
+        checked.len() >= 2,
+        "expected to check several multi-word commands, checked {checked:?}"
+    );
+
+    fs::remove_file(&out_file).unwrap();
+}

--- a/cli/usage.usage.kdl
+++ b/cli/usage.usage.kdl
@@ -249,4 +249,5 @@ to properly escape and quote values with spaces in them.
 }
 
 repository "https://github.com/jdx/usage"
-source_code_link_template "https://github.com/jdx/usage/blob/main/cli/src/cli/{{path}}.rs"
+// command names are hyphenated, the files that implement them are snake_case
+source_code_link_template "https://github.com/jdx/usage/blob/main/cli/src/cli/{{ path | replace(from='-', to='_') }}.rs"

--- a/docs/cli/reference/commands.json
+++ b/docs/cli/reference/commands.json
@@ -1158,7 +1158,7 @@
   "version": "5.1.0",
   "usage": "Usage: usage-cli [OPTIONS] [COMPLETIONS] <COMMAND>",
   "complete": {},
-  "source_code_link_template": "https://github.com/jdx/usage/blob/main/cli/src/cli/{{path}}.rs",
+  "source_code_link_template": "https://github.com/jdx/usage/blob/main/cli/src/cli/{{ path | replace(from='-', to='_') }}.rs",
   "repository": "https://github.com/jdx/usage",
   "about": "CLI for working with usage-based CLIs",
   "min_usage_version": "4.0",

--- a/docs/cli/reference/complete-word.md
+++ b/docs/cli/reference/complete-word.md
@@ -5,7 +5,7 @@
 - **Usage**: `usage complete-word [FLAGS] [WORDS]…`
 - **Aliases**: `cw`
 - **Effect**: read-only
-- **Source code**: [`cli/src/cli/complete-word.rs`](https://github.com/jdx/usage/blob/main/cli/src/cli/complete-word.rs)
+- **Source code**: [`cli/src/cli/complete_word.rs`](https://github.com/jdx/usage/blob/main/cli/src/cli/complete_word.rs)
 
 Generate shell completion candidates for a partial command line
 

--- a/docs/cli/reference/generate/completion-init.md
+++ b/docs/cli/reference/generate/completion-init.md
@@ -5,7 +5,7 @@
 - **Usage**: `usage generate completion-init [--usage-bin <USAGE_BIN>] <SHELL>`
 - **Aliases**: `ci`
 - **Effect**: read-only
-- **Source code**: [`cli/src/cli/generate/completion-init.rs`](https://github.com/jdx/usage/blob/main/cli/src/cli/generate/completion-init.rs)
+- **Source code**: [`cli/src/cli/generate/completion_init.rs`](https://github.com/jdx/usage/blob/main/cli/src/cli/generate/completion_init.rs)
 
 Generate a shell init script that auto-completes any usage shebang script on $PATH
 


### PR DESCRIPTION
## What

Every hyphenated command in the generated CLI reference linked at a source file that does not exist, and 404'd on GitHub:

- `docs/cli/reference/complete-word.md` → `cli/src/cli/complete-word.rs`, but the file is `complete_word.rs`
- `docs/cli/reference/generate/completion-init.md` → `generate/completion-init.rs`, but the file is `completion_init.rs`

The command path was interpolated into `source_code_link_template` verbatim, so `complete-word` never became `complete_word`.

## Why here

The link is not derived in `lib/src/docs/`. The `source_code_link` tera function in `lib/src/docs/markdown/tera.rs` only exposes `path` — the full command path joined by `/` — and the `blob/main` URL itself lives in the spec, `cli/assets/usage-extra.usage.kdl`. The fix goes in the template:

```kdl
source_code_link_template "https://github.com/jdx/usage/blob/main/cli/src/cli/{{ path | replace(from='-', to='_') }}.rs"
```

Underscoring `path` inside the generator would have been wrong: command-name → file-name is project-specific. usage's files are Rust snake_case, but a Node CLI could legitimately ship `complete-word.js`, and the change would have silently altered output for every downstream consumer. mise's own spec already does this same replacement in its template (`examples/mise.usage.kdl`), so this follows the established idiom.

## Test

`test_source_code_links_for_multi_word_commands_exist` in `cli/tests/markdown.rs` generates markdown from the checked-in spec, pairs each command heading with its source-code link, and asserts the file exists on disk for every hyphenated command. It asserts a floor of ≥2 commands checked, so a parsing regression can't make it pass vacuously.

Verified it catches the bug — reverting the template gives:

```
`usage complete-word` links to cli/src/cli/complete-word.rs, which does not exist
```

## For the reviewer

Some source-code links still 404, for a **different** reason, and are deliberately out of scope here:

- `bash.md` / `zsh.md` / `fish.md` / `powershell.md` link at `bash.rs` etc., but all four commands are implemented in `cli/src/cli/shell.rs`
- `generate.md` links at `generate.rs` rather than `generate/mod.rs` (mise's template handles this parent-command case with `{% if cmd.subcommands | length > 0 %}`)

That is why the new test is scoped to multi-word commands rather than asserting every link. It should be widened once those resolve.

Docs regenerated with `mise run render`. `cargo test --workspace --all-features`, `cargo clippy --workspace --all-features --all-targets -- -D warnings`, and `cargo fmt --all` all pass.

_This PR description was generated by Claude Code._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and spec-template changes only; no runtime CLI or generator logic changes beyond regenerated markdown/JSON.
> 
> **Overview**
> Generated CLI reference **source code** links for hyphenated commands (e.g. `complete-word`, `generate completion-init`) were built from the command path as-is, so they pointed at non-existent paths like `complete-word.rs` instead of `complete_word.rs` and 404’d on GitHub.
> 
> The fix updates `source_code_link_template` in the usage specs (`cli/assets/usage-extra.usage.kdl`, `cli/usage.usage.kdl`) to apply `{{ path | replace(from='-', to='_') }}` before appending `.rs`, keeping command-name → file-name mapping in the spec rather than hard-coding it in the markdown generator. Regenerated reference output (`docs/cli/reference/*`, `commands.json`) reflects the corrected links.
> 
> A new integration test in `cli/tests/markdown.rs` generates markdown from the checked-in spec and asserts that every **multi-word** command’s source link resolves to a real file on disk (with a minimum of two commands checked so the test can’t pass vacuously).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c53cc5480d4db8b8498442ed3a9aabdadb6d1a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected generated CLI source-code links for hyphenated commands so they now point to the corresponding Rust source files.

- **Documentation**
  - Updated CLI reference links to use the correct underscored filenames.
  - Added guidance documenting the command-to-source filename convention.

- **Tests**
  - Added coverage verifying that generated Markdown source links resolve correctly for multi-word commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->