### PR TITLE
fix(docs): link every command to the file that implements it

### DIFF
--- a/cli/assets/usage-extra.usage.kdl
+++ b/cli/assets/usage-extra.usage.kdl
@@ -1,3 +1,15 @@
 repository "https://github.com/jdx/usage"
-// command names are hyphenated, the files that implement them are snake_case
-source_code_link_template "https://github.com/jdx/usage/blob/main/cli/src/cli/{{ path | replace(from='-', to='_') }}.rs"
+// The command path is not the file path: command names are hyphenated where the files
+// that implement them are snake_case, a command with subcommands lives in its directory's
+// `mod.rs`, and the four shell commands are all served by a single `shell.rs`.
+source_code_link_template #"""
+{%- set path = path | replace(from='-', to='_') -%}
+{%- if cmd.subcommands | length > 0 -%}
+{%- set path = path ~ "/mod.rs" -%}
+{%- elif path in ["bash", "fish", "powershell", "zsh"] -%}
+{%- set path = "shell.rs" -%}
+{%- else -%}
+{%- set path = path ~ ".rs" -%}
+{%- endif -%}
+https://github.com/jdx/usage/blob/main/cli/src/cli/{{path}}
+"""#

--- a/cli/tests/markdown.rs
+++ b/cli/tests/markdown.rs
@@ -251,9 +251,11 @@ fn test_markdown_out_file_dash_writes_no_file() {
 }
 
 #[test]
-fn test_source_code_links_for_multi_word_commands_exist() {
-    // A hyphenated command like `complete-word` lives in `complete_word.rs`; linking it as
-    // `complete-word.rs` is a 404 on GitHub, and nothing but the file system can catch it.
+fn test_source_code_links_exist() {
+    // A command's path is not its file's path: `complete-word` lives in `complete_word.rs`,
+    // `generate` in `generate/mod.rs`, and `bash` in `shell.rs`, which it shares with the
+    // three other shells. Each of those is a 404 on GitHub when the template gets it wrong,
+    // and nothing but the file system can catch it.
     let repo_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .unwrap()
@@ -290,27 +292,31 @@ fn test_source_code_links_for_multi_word_commands_exist() {
             continue;
         };
         let path = rest.split_once("`]").expect("malformed source code link").0;
-        // Single-word commands are linked from the same template, but several of them
-        // legitimately live elsewhere (`usage bash` is served by `shell.rs`), so only the
-        // hyphen-to-underscore mapping is asserted here.
-        let is_multi_word = cur_cmd
-            .split_whitespace()
-            .next_back()
-            .unwrap_or("")
-            .contains('-');
-        if !is_multi_word {
-            continue;
-        }
         assert!(
             repo_root.join(path).is_file(),
             "`{cur_cmd}` links to {path}, which does not exist"
         );
-        checked.push(cur_cmd.clone());
+        checked.push((cur_cmd.clone(), path.to_string()));
     }
+    // Every command carries a link, so a scrape that suddenly matches almost nothing means
+    // the document changed shape and the assertions above went blind.
     assert!(
-        checked.len() >= 2,
-        "expected to check several multi-word commands, checked {checked:?}"
+        checked.len() >= 10,
+        "expected a link for every command, checked {checked:?}"
     );
+    // Existence alone can't tell a correct mapping from a coincidence, and each of the three
+    // rules in the template is currently carried by only part of the spec. Name one command
+    // per rule so that dropping a rule fails here rather than in a reader's browser.
+    for (cmd, file) in [
+        ("usage complete-word", "cli/src/cli/complete_word.rs"),
+        ("usage generate", "cli/src/cli/generate/mod.rs"),
+        ("usage bash", "cli/src/cli/shell.rs"),
+    ] {
+        assert!(
+            checked.contains(&(cmd.to_string(), file.to_string())),
+            "expected `{cmd}` to link to {file}, checked {checked:?}"
+        );
+    }
 
     fs::remove_file(&out_file).unwrap();
 }

--- a/cli/usage.usage.kdl
+++ b/cli/usage.usage.kdl
@@ -249,5 +249,17 @@ to properly escape and quote values with spaces in them.
 }
 
 repository "https://github.com/jdx/usage"
-// command names are hyphenated, the files that implement them are snake_case
-source_code_link_template "https://github.com/jdx/usage/blob/main/cli/src/cli/{{ path | replace(from='-', to='_') }}.rs"
+// The command path is not the file path: command names are hyphenated where the files
+// that implement them are snake_case, a command with subcommands lives in its directory's
+// `mod.rs`, and the four shell commands are all served by a single `shell.rs`.
+source_code_link_template #"""
+{%- set path = path | replace(from='-', to='_') -%}
+{%- if cmd.subcommands | length > 0 -%}
+{%- set path = path ~ "/mod.rs" -%}
+{%- elif path in ["bash", "fish", "powershell", "zsh"] -%}
+{%- set path = "shell.rs" -%}
+{%- else -%}
+{%- set path = path ~ ".rs" -%}
+{%- endif -%}
+https://github.com/jdx/usage/blob/main/cli/src/cli/{{path}}
+"""#

--- a/docs/cli/reference/bash.md
+++ b/docs/cli/reference/bash.md
@@ -3,7 +3,7 @@
 # `usage bash`
 
 - **Usage**: `usage bash [-h] [--help] <SCRIPT> [ARGS]…`
-- **Source code**: [`cli/src/cli/bash.rs`](https://github.com/jdx/usage/blob/main/cli/src/cli/bash.rs)
+- **Source code**: [`cli/src/cli/shell.rs`](https://github.com/jdx/usage/blob/main/cli/src/cli/shell.rs)
 
 Execute a shell script with the specified shell
 

--- a/docs/cli/reference/commands.json
+++ b/docs/cli/reference/commands.json
@@ -1158,7 +1158,7 @@
   "version": "5.1.0",
   "usage": "Usage: usage-cli [OPTIONS] [COMPLETIONS] <COMMAND>",
   "complete": {},
-  "source_code_link_template": "https://github.com/jdx/usage/blob/main/cli/src/cli/{{ path | replace(from='-', to='_') }}.rs",
+  "source_code_link_template": "{%- set path = path | replace(from='-', to='_') -%}\n{%- if cmd.subcommands | length > 0 -%}\n{%- set path = path ~ \"/mod.rs\" -%}\n{%- elif path in [\"bash\", \"fish\", \"powershell\", \"zsh\"] -%}\n{%- set path = \"shell.rs\" -%}\n{%- else -%}\n{%- set path = path ~ \".rs\" -%}\n{%- endif -%}\nhttps://github.com/jdx/usage/blob/main/cli/src/cli/{{path}}",
   "repository": "https://github.com/jdx/usage",
   "about": "CLI for working with usage-based CLIs",
   "min_usage_version": "4.0",

--- a/docs/cli/reference/fish.md
+++ b/docs/cli/reference/fish.md
@@ -3,7 +3,7 @@
 # `usage fish`
 
 - **Usage**: `usage fish [-h] [--help] <SCRIPT> [ARGS]…`
-- **Source code**: [`cli/src/cli/fish.rs`](https://github.com/jdx/usage/blob/main/cli/src/cli/fish.rs)
+- **Source code**: [`cli/src/cli/shell.rs`](https://github.com/jdx/usage/blob/main/cli/src/cli/shell.rs)
 
 Execute a shell script with the specified shell
 

--- a/docs/cli/reference/generate.md
+++ b/docs/cli/reference/generate.md
@@ -5,7 +5,7 @@
 - **Usage**: `usage generate <SUBCOMMAND>`
 - **Aliases**: `g`
 - **Effect**: read-only
-- **Source code**: [`cli/src/cli/generate.rs`](https://github.com/jdx/usage/blob/main/cli/src/cli/generate.rs)
+- **Source code**: [`cli/src/cli/generate/mod.rs`](https://github.com/jdx/usage/blob/main/cli/src/cli/generate/mod.rs)
 
 Generate completions, documentation, and other artifacts from usage specs
 

--- a/docs/cli/reference/powershell.md
+++ b/docs/cli/reference/powershell.md
@@ -3,7 +3,7 @@
 # `usage powershell`
 
 - **Usage**: `usage powershell [-h] [--help] <SCRIPT> [ARGS]…`
-- **Source code**: [`cli/src/cli/powershell.rs`](https://github.com/jdx/usage/blob/main/cli/src/cli/powershell.rs)
+- **Source code**: [`cli/src/cli/shell.rs`](https://github.com/jdx/usage/blob/main/cli/src/cli/shell.rs)
 
 Execute a shell script with the specified shell
 

--- a/docs/cli/reference/zsh.md
+++ b/docs/cli/reference/zsh.md
@@ -3,7 +3,7 @@
 # `usage zsh`
 
 - **Usage**: `usage zsh [-h] [--help] <SCRIPT> [ARGS]…`
-- **Source code**: [`cli/src/cli/zsh.rs`](https://github.com/jdx/usage/blob/main/cli/src/cli/zsh.rs)
+- **Source code**: [`cli/src/cli/shell.rs`](https://github.com/jdx/usage/blob/main/cli/src/cli/shell.rs)
 
 Execute a shell script with the specified shell
 


### PR DESCRIPTION
## What

The generated CLI reference had five **Source code** links that 404 on GitHub, separate from the hyphenated-command 404s fixed by the PR below this one in the stack:

| Command | Linked at | Actually lives in |
| --- | --- | --- |
| `usage bash` / `zsh` / `fish` / `powershell` | `cli/src/cli/bash.rs`, … | `cli/src/cli/shell.rs` |
| `usage generate` | `cli/src/cli/generate.rs` | `cli/src/cli/generate/mod.rs` |

`source_code_link_template` in `cli/assets/usage-extra.usage.kdl` spelled each command's file after the command itself, which is only true for the commands that happen to be one word implemented in one file.

## How

A command's path is not its file's path, and the mapping between them is project-specific — a Node CLI may well ship `complete-word.js` — so the two remaining rules join the hyphen-to-underscore step inside the template rather than in the markdown generator:

```kdl
{%- set path = path | replace(from='-', to='_') -%}
{%- if cmd.subcommands | length > 0 -%}
{%- set path = path ~ "/mod.rs" -%}
{%- elif path in ["bash", "fish", "powershell", "zsh"] -%}
{%- set path = "shell.rs" -%}
{%- else -%}
{%- set path = path ~ ".rs" -%}
{%- endif -%}
```

The `mod.rs` branch is the idiom `examples/mise.usage.kdl` already uses, with one deliberate difference: mise's version is `path | split(pat="/") | slice(end=1) | concat(with="mod.rs")`, which hardcodes the parent as the first path segment and would mislink a *nested* parent command. `path ~ "/mod.rs"` is correct at any depth and renders `generate` identically.

The four shells are a genuine special case — one file serves four commands — so the alternative was a new per-command override in the spec vocabulary. That felt like a lot of surface area (parse, KDL emit, docs model, tera precedence, snapshots, spec docs) for a mapping the template can already express.

## Tests

`test_source_code_links_for_multi_word_commands_exist` is now `test_source_code_links_exist`: the `is_multi_word` skip is gone, so all 17 links are stat'd against the file system. The single-word commands were exactly the broken ones, and the old skip is what let them stay broken.

Existence alone can't tell a correct mapping from a coincidence, and each template rule is currently carried by only part of the spec, so the test also asserts one named command per rule — `complete-word`→`complete_word.rs`, `generate`→`generate/mod.rs`, `bash`→`shell.rs`. Dropping a rule now fails the test instead of a reader's browser.

Checked negatively: run against the pre-change spec it fails with `` `usage bash` links to cli/src/cli/bash.rs, which does not exist ``. `cargo test --all --all-features`, clippy, `cargo fmt --check` and prettier all pass.

## For the reviewer

- `cli/usage.usage.kdl` and everything under `docs/cli/reference/` are regenerated by `mise run render`; only `cli/assets/usage-extra.usage.kdl` and `cli/tests/markdown.rs` are hand-edited.
- The template is now a multi-line raw KDL string. It round-trips through `usage --usage-spec` verbatim (the asset is appended raw) and JSON-escapes cleanly into `commands.json`.
- **Stacked** on `fix/docs-source-links`, which needs the hyphen-to-underscore step present for the every-command assertion to pass. That branch has no PR of its own yet — base this on `main` instead if you'd rather land the two together.

_This PR description was generated by Claude Code._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and spec-template changes only; no runtime CLI behavior.
> 
> **Overview**
> Fixes **Source code** links in the generated CLI reference that pointed at non-existent paths (e.g. `bash.rs` instead of `shell.rs`, `generate.rs` instead of `generate/mod.rs`).
> 
> **`source_code_link_template`** in `usage-extra.usage.kdl` is expanded from a single hyphen→underscore URL into a Tera template: parent commands with subcommands map to `{path}/mod.rs`, `bash`/`fish`/`powershell`/`zsh` map to `shell.rs`, and everything else keeps `{path}.rs`. Regenerated `usage.usage.kdl`, `docs/cli/reference/*`, and `commands.json` pick up the corrected links.
> 
> **`test_source_code_links_exist`** now validates every command’s link on disk (not only multi-word commands) and pins one example per template rule so removing a branch fails in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d769773a1c439b6fd7c633d67f948012c004de7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI source-code links to point to the correct implementation locations.
  * Added consistent path mapping for hyphenated commands, subcommands, and shell commands.
  * Corrected links for `generate` and shell-related commands.

* **Tests**
  * Expanded link validation to cover all commands and key command mappings.
  * Added a minimum link-count check to improve coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->