### PR TITLE
feat(argv): route a word that names nothing to the default subcommand

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -49,7 +49,7 @@ usage-lib ── interprets a spec       usage-derive ── reads a Rust type
       │      at runtime                     │
       │                                     ├─→ static tables ─→ usage-argv (hot)
       └─→ the oracle the corpus             └─→ static metadata ─→ help,
-          measures everyone against              completions, spec output (cold)
+      measures everyone against              completions, spec output (cold)
 ```
 
 Four rules hold this together.
@@ -200,16 +200,36 @@ carrying them rather than being worked around.
       engine what a bare word means. So they are emission-only, and the test asserts both
       that they reach the KDL and that binding is unaffected. `default_subcommand` is
       checked at compile time to require a subcommand field, since it names one.
-- [ ] **Routing on `default_subcommand`** — the property above is emitted and nothing more,
-      and that is a gap rather than a decision: usage-lib _routes_ on it while parsing. Given
-      `default_subcommand "run"`, a word naming no subcommand makes its parser descend into
-      `run` and bind the word as **`run`'s** argument, even where the root declares an
-      argument of its own — verified against usage-lib 4.0.0, where `mise build` comes back
-      as `["mise", "run"]` with `TASK = "build"`. This parser keeps the word at the root.
-      Closing it needs `Command` to carry a pointer to its default subcommand and the parser
-      to descend on an unmatched word, so it is parser work rather than emission. It is also
-      the rule behind `mise build` meaning `mise run build`, which mise routes by hand today
-      — so this is one more hack adoption should remove.
+- [x] **Routing on `default_subcommand`** — the parser reads it now, rather than the property
+      being emitted and ignored. A word naming no subcommand descends into the named command
+      and is examined again there, so it can be that command's argument or one of _its_
+      subcommands. The declaring command's own positional does not win, which is what makes
+      the property more than a synonym for an argument — and is mise's shape exactly. Taken at
+      most once per parse, so a chain of defaults cannot walk a CLI deeper than the user typed.
+
+      No measurable cost: 40,370 instructions against 40,472 before, the branch being reached
+          only by a word that matched no subcommand. The ±100 is code layout rather than work —
+          cachegrind is deterministic, and gave the same figure twice. Allocations unchanged: 0
+          bare, 4 bound.
+
+          The name is resolved by `find_subcommand` during **const evaluation**, so a
+          `default_subcommand` that no subcommand answers to is a compile error. That retires the
+          claim in the entry above that the name could not be checked: the variants are indeed
+          another expansion, but a `const fn` can search the list the parent already holds.
+
+          **What it does not buy on its own:** `mise build` still does not work end to end in the
+          shadow, because mise's spec gives `run` no positional at all — `src/cli/usage.rs` clears
+          them and adds `mount run="mise tasks --usage"`, so task names are meant to come from
+          running that. usage-argv does not execute mounts. Routing *plus* mounts is what would let
+          mise delete its hand-rolled dispatch; routing alone is half of it.
+
+          One divergence recorded (`default-is-declared-for-the-root`): usage-lib holds the single
+          name for the whole spec and applies it at whichever command it is standing on, so
+          `ex config zzz` descends into `config ls` when an unrelated `config` happens to have an
+          `ls`. Read here as a property of the root, which is the only place it can be declared.
+          **Worth a decision** — it looks accidental rather than intended, and if you agree it is a
+          small fix in usage-lib.
+
 - [ ] **A mount on the root command** — the spec accepts `mount` only inside a
       `cmd` block, so a CLI whose _top-level_ subcommands are discovered by running
       something cannot say so. Worth deciding whether that is a gap or a deliberate

--- a/PLAN.md
+++ b/PLAN.md
@@ -138,19 +138,19 @@ manpages, and SDKs — never a runtime dependency of somebody else's program.
       `OsString` field takes the bytes exactly, through `usage_argv::os_string_from_bytes`.
 
       **And with no `unsafe` anywhere.** On Unix an `OsString` is an arbitrary byte sequence,
-          so this is the safe `OsString::from_vec` and every byte survives — which is the case that
-          matters, since non-UTF-8 filenames are ordinary there. Windows was going to need
-          `from_encoded_bytes_unchecked`, and jdx approved that, but a *safe* function taking a
-          `Vec<u8>` cannot enforce its precondition: there is no way to know the bytes came from
-          `as_encoded_bytes` rather than from anywhere else, and a safe function whose precondition
-          a caller can violate is unsound however carefully today's callers behave. Greptile flagged
-          exactly that on #844. So Windows goes through UTF-8 and reports what will not convert,
-          which gives up only an unpaired-surrogate argument there.
+              so this is the safe `OsString::from_vec` and every byte survives — which is the case that
+              matters, since non-UTF-8 filenames are ordinary there. Windows was going to need
+              `from_encoded_bytes_unchecked`, and jdx approved that, but a *safe* function taking a
+              `Vec<u8>` cannot enforce its precondition: there is no way to know the bytes came from
+              `as_encoded_bytes` rather than from anywhere else, and a safe function whose precondition
+              a caller can violate is unsound however carefully today's callers behave. Greptile flagged
+              exactly that on #844. So Windows goes through UTF-8 and reports what will not convert,
+              which gives up only an unpaired-surrogate argument there.
 
-          Cheaper than the text path, not dearer: a `PathBuf` field costs **553 instructions per
-          parse against a `String` field's 674**, since it skips the UTF-8 validation pass, and both
-          allocate once. The gate fixture cannot show this — a spec carries no Rust types, so every
-          shadow field is a `String` — which is why it is measured directly.
+              Cheaper than the text path, not dearer: a `PathBuf` field costs **553 instructions per
+              parse against a `String` field's 674**, since it skips the UTF-8 validation pass, and both
+              allocate once. The gate fixture cannot show this — a spec carries no Rust types, so every
+              shadow field is a `String` — which is why it is measured directly.
 
 - [ ] **`usage-derive` v1** — everything mise needs: constraints
       (`requires`/`conflicts`/`overrides`/`required_unless`), `var`, `count`,
@@ -208,27 +208,32 @@ carrying them rather than being worked around.
       most once per parse, so a chain of defaults cannot walk a CLI deeper than the user typed.
 
       No measurable cost: 40,370 instructions against 40,472 before, the branch being reached
-          only by a word that matched no subcommand. The ±100 is code layout rather than work —
-          cachegrind is deterministic, and gave the same figure twice. Allocations unchanged: 0
-          bare, 4 bound.
+              only by a word that matched no subcommand. The ±100 is code layout rather than work —
+              cachegrind is deterministic, and gave the same figure twice. Allocations unchanged: 0
+              bare, 4 bound.
+
+              Only a *word* routes: a dash-prefixed token naming no flag arrives as a value and was
+          never a candidate to select anything, so it binds where it was typed — as usage-lib does,
+          which stops looking for subcommands at an unrecognised flag. The name may also be an
+          alias, since usage-lib resolves it against names, aliases and hidden aliases alike.
 
           The name is resolved by `find_subcommand` during **const evaluation**, so a
-          `default_subcommand` that no subcommand answers to is a compile error. That retires the
-          claim in the entry above that the name could not be checked: the variants are indeed
-          another expansion, but a `const fn` can search the list the parent already holds.
+              `default_subcommand` that no subcommand answers to is a compile error. That retires the
+              claim in the entry above that the name could not be checked: the variants are indeed
+              another expansion, but a `const fn` can search the list the parent already holds.
 
-          **What it does not buy on its own:** `mise build` still does not work end to end in the
-          shadow, because mise's spec gives `run` no positional at all — `src/cli/usage.rs` clears
-          them and adds `mount run="mise tasks --usage"`, so task names are meant to come from
-          running that. usage-argv does not execute mounts. Routing *plus* mounts is what would let
-          mise delete its hand-rolled dispatch; routing alone is half of it.
+              **What it does not buy on its own:** `mise build` still does not work end to end in the
+              shadow, because mise's spec gives `run` no positional at all — `src/cli/usage.rs` clears
+              them and adds `mount run="mise tasks --usage"`, so task names are meant to come from
+              running that. usage-argv does not execute mounts. Routing *plus* mounts is what would let
+              mise delete its hand-rolled dispatch; routing alone is half of it.
 
-          One divergence recorded (`default-is-declared-for-the-root`): usage-lib holds the single
-          name for the whole spec and applies it at whichever command it is standing on, so
-          `ex config zzz` descends into `config ls` when an unrelated `config` happens to have an
-          `ls`. Read here as a property of the root, which is the only place it can be declared.
-          **Worth a decision** — it looks accidental rather than intended, and if you agree it is a
-          small fix in usage-lib.
+              One divergence recorded (`default-is-declared-for-the-root`): usage-lib holds the single
+              name for the whole spec and applies it at whichever command it is standing on, so
+              `ex config zzz` descends into `config ls` when an unrelated `config` happens to have an
+              `ls`. Read here as a property of the root, which is the only place it can be declared.
+              **Worth a decision** — it looks accidental rather than intended, and if you agree it is a
+              small fix in usage-lib.
 
 - [ ] **A mount on the root command** — the spec accepts `mount` only inside a
       `cmd` block, so a CLI whose _top-level_ subcommands are discovered by running

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -107,6 +107,19 @@ pub struct Command<'a> {
     /// Positional arguments, in the order they are filled.
     pub args: &'a [&'a Arg<'a>],
     pub subcommands: &'a [&'a Command<'a>],
+    /// Where a word goes when it names no subcommand of this one.
+    ///
+    /// The spec's `default_subcommand`. `mise build` means `mise run build`: the word names
+    /// no command, so the parser descends into `run` and lets *`run`* have it — even where
+    /// this command declares an argument of its own, which is what makes the property worth
+    /// having rather than a synonym for a positional.
+    ///
+    /// Applied at most once per parse, so a CLI cannot loop through it, and only where a
+    /// subcommand could still be selected.
+    ///
+    /// Resolve it with [`find_subcommand`], which turns a name that no subcommand answers to
+    /// into a compile error.
+    pub default_subcommand: ::core::option::Option<&'a Command<'a>>,
     /// What an unrecognized flag-like token means here. Already resolved — see
     /// [`UnknownFlags`].
     pub unknown_flags: UnknownFlags,
@@ -129,6 +142,7 @@ impl Command<'_> {
         flags: &[],
         args: &[],
         subcommands: &[],
+        default_subcommand: ::core::option::Option::None,
         unknown_flags: UnknownFlags::Value,
         key: 0,
     };
@@ -419,6 +433,59 @@ pub fn as_str(value: &[u8]) -> Result<&str, std::str::Utf8Error> {
     std::str::from_utf8(value)
 }
 
+/// Resolve a subcommand by name, at compile time.
+///
+/// For [`Command::default_subcommand`], which names a command that a derive cannot see: the
+/// variants of a subcommand enum are a different macro expansion, so the name is all the
+/// parent has. Searching the list in a `const fn` closes that gap — the answer is the same
+/// `&'static` the table already holds, found before the program runs.
+///
+/// A name no subcommand answers to is a **compile error**, since this panics during const
+/// evaluation. That is the whole point of doing it here rather than at startup.
+///
+/// ```
+/// use usage_argv::{find_subcommand, Command};
+///
+/// static RUN: Command = Command { name: "run", ..Command::EMPTY };
+/// static SUBS: &[&Command] = &[&RUN];
+/// static ROOT: Command = Command {
+///     name: "ex",
+///     subcommands: SUBS,
+///     default_subcommand: Some(find_subcommand(SUBS, "run")),
+///     ..Command::EMPTY
+/// };
+/// assert_eq!(ROOT.default_subcommand.unwrap().name, "run");
+/// ```
+pub const fn find_subcommand<'a>(
+    subcommands: &'a [&'a Command<'a>],
+    name: &str,
+) -> &'a Command<'a> {
+    let mut i = 0;
+    while i < subcommands.len() {
+        if str_eq(subcommands[i].name, name) {
+            return subcommands[i];
+        }
+        i += 1;
+    }
+    panic!("`default_subcommand` names a command that this one does not have")
+}
+
+/// `==` on strings, in a `const fn`.
+const fn str_eq(a: &str, b: &str) -> bool {
+    let (a, b) = (a.as_bytes(), b.as_bytes());
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut i = 0;
+    while i < a.len() {
+        if a[i] != b[i] {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}
+
 /// Rebuild an [`OsString`] from bytes the parser handed back.
 ///
 /// This is the reverse of [`OsStr::as_encoded_bytes`], and it is how a `PathBuf` field
@@ -502,6 +569,11 @@ pub struct Parser<'t, 'v> {
     /// consuming it. Callers asking this question want to know what the user
     /// wrote, not what state the parser reached.
     separator_seen: bool,
+    /// Whether the default subcommand has already been taken.
+    ///
+    /// Once, per parse: a default subcommand that itself declares one would otherwise
+    /// descend on every word until the tree ran out.
+    default_taken: bool,
     /// Set once a fatal error has been reported, so iteration stops.
     done: bool,
 }
@@ -526,6 +598,7 @@ impl<'t, 'v> Parser<'t, 'v> {
             arg_filled: false,
             flags_stopped: false,
             separator_seen: false,
+            default_taken: false,
             done: false,
         }
     }
@@ -779,6 +852,22 @@ impl<'t, 'v> Parser<'t, 'v> {
                 self.descend(sub)?;
                 return Ok(Event::Command(sub));
             }
+
+            // A word that names no subcommand goes to the default one, if there is one.
+            //
+            // The token is *not* consumed: the cursor steps back so the next event reads it
+            // again, now against the command just descended into. That is what lets it be a
+            // subcommand of the default (`mise build` where `build` is a task the mount
+            // added) as easily as an argument of it, without this function having to decide
+            // which — and without yielding two events for one word.
+            if let Some(default) = self.cmd.default_subcommand {
+                if !self.default_taken {
+                    self.default_taken = true;
+                    self.descend(default)?;
+                    self.pos -= 1;
+                    return Ok(Event::Command(default));
+                }
+            }
         }
 
         let Some(arg) = self.next_arg() else {
@@ -1023,6 +1112,50 @@ mod tests {
         ..Command::EMPTY
     };
 
+    // A CLI shaped exactly like mise's root: a default subcommand, a positional of its own,
+    // and a subcommand under the default — which is the arrangement that tells routing from
+    // a plain positional.
+    static TASK: Arg = Arg {
+        key: 20,
+        name: "task",
+        ..Arg::REQUIRED
+    };
+    static RUN_TASK: Arg = Arg {
+        key: 21,
+        name: "run_task",
+        ..Arg::REQUIRED
+    };
+    static DEEP: Command = Command {
+        name: "deep",
+        args: &[&RUN_TASK],
+        key: 203,
+        ..Command::EMPTY
+    };
+    static LINT: Command = Command {
+        name: "lint",
+        subcommands: &[&DEEP],
+        // A default of its own, so that a parse which forgot it had already taken one would
+        // have somewhere to go. Nothing else in these fixtures can show the latch working.
+        default_subcommand: Some(&DEEP),
+        key: 202,
+        ..Command::EMPTY
+    };
+    static RUN: Command = Command {
+        name: "run",
+        args: &[&RUN_TASK],
+        subcommands: &[&LINT],
+        key: 200,
+        ..Command::EMPTY
+    };
+    static DEFAULTING: Command = Command {
+        name: "mise",
+        flags: &[&VERBOSE],
+        args: &[&TASK],
+        subcommands: &[&RUN, &INSTALL],
+        default_subcommand: Some(find_subcommand(&[&RUN, &INSTALL], "run")),
+        ..Command::EMPTY
+    };
+
     /// Collect every event, or the first error.
     fn parse<'t, 'v>(
         root: &'t Command<'t>,
@@ -1263,6 +1396,113 @@ mod tests {
                     value: b"install"
                 },
             ]
+        );
+    }
+
+    #[test]
+    fn a_word_naming_no_subcommand_goes_to_the_default_one() {
+        // usage-lib's answer, which this reproduces: `mise build` comes back as commands
+        // `["mise", "run"]` with the word bound to *run's* argument — not to `mise`'s own
+        // `[TASK]`, which is what makes this more than a synonym for a positional.
+        let a = argv(["build"]);
+        assert_eq!(
+            parse(&DEFAULTING, &a).unwrap(),
+            vec![
+                Event::Command(&RUN),
+                Event::Arg {
+                    arg: &RUN_TASK,
+                    value: b"build"
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn a_named_subcommand_is_not_routed() {
+        // The default is for words that name nothing. A word that names a sibling still
+        // selects it, and the root's own argument is still reachable behind one.
+        let a = argv(["install"]);
+        assert_eq!(
+            parse(&DEFAULTING, &a).unwrap(),
+            vec![Event::Command(&INSTALL)]
+        );
+    }
+
+    #[test]
+    fn the_word_is_re_examined_against_the_command_it_reached() {
+        // The reason the cursor steps back rather than the token being consumed: `lint` names
+        // nothing at the root, and once inside `run` it names a subcommand. mise's mounted
+        // task names arrive exactly this way.
+        let a = argv(["lint"]);
+        assert_eq!(
+            parse(&DEFAULTING, &a).unwrap(),
+            vec![Event::Command(&RUN), Event::Command(&LINT)]
+        );
+    }
+
+    #[test]
+    fn the_default_is_taken_at_most_once_per_parse() {
+        // usage-lib latches this for the whole parse rather than per command, and the shape
+        // that shows the difference needs two of them: `lint` routes through `run`, and `lint`
+        // declares a default too. A second word there would descend again — walking a CLI
+        // deeper than anything the user typed — so the answer is that it does not.
+        let a = argv(["lint", "zzz"]);
+        assert_eq!(
+            parse(&DEFAULTING, &a),
+            Err(Error::UnexpectedArg { token: b"zzz" }),
+            "the second word must not reach `deep`"
+        );
+
+        // Reached explicitly, the same command still takes it: the latch bounds routing, not
+        // the tree.
+        let a = argv(["lint", "deep", "zzz"]);
+        assert_eq!(
+            parse(&DEFAULTING, &a).unwrap(),
+            vec![
+                Event::Command(&RUN),
+                Event::Command(&LINT),
+                Event::Command(&DEEP),
+                Event::Arg {
+                    arg: &RUN_TASK,
+                    value: b"zzz"
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn a_flag_before_the_word_still_belongs_to_the_root() {
+        // Routing happens at the word, so anything typed before it was addressed to the
+        // command the user was actually at.
+        let a = argv(["--verbose", "build"]);
+        assert_eq!(
+            parse(&DEFAULTING, &a).unwrap(),
+            vec![
+                Event::Flag {
+                    flag: &VERBOSE,
+                    value: None,
+                    negated: false
+                },
+                Event::Command(&RUN),
+                Event::Arg {
+                    arg: &RUN_TASK,
+                    value: b"build"
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn nothing_routes_after_the_separator() {
+        // Past `--` there are no subcommands left to select, so there is no default to reach
+        // either: the words are values of whatever the command declares.
+        let a = argv(["--", "build"]);
+        assert_eq!(
+            parse(&DEFAULTING, &a).unwrap(),
+            vec![Event::Arg {
+                arg: &TASK,
+                value: b"build"
+            }]
         );
     }
 

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -433,7 +433,7 @@ pub fn as_str(value: &[u8]) -> Result<&str, std::str::Utf8Error> {
     std::str::from_utf8(value)
 }
 
-/// Resolve a subcommand by name, at compile time.
+/// Resolve a subcommand by name or alias, at compile time.
 ///
 /// For [`Command::default_subcommand`], which names a command that a derive cannot see: the
 /// variants of a subcommand enum are a different macro expansion, so the name is all the
@@ -462,8 +462,18 @@ pub const fn find_subcommand<'a>(
 ) -> &'a Command<'a> {
     let mut i = 0;
     while i < subcommands.len() {
-        if str_eq(subcommands[i].name, name) {
-            return subcommands[i];
+        let candidate = subcommands[i];
+        if str_eq(candidate.name, name) {
+            return candidate;
+        }
+        // Aliases answer too, because usage-lib resolves the name against names, aliases and
+        // hidden aliases alike — so a spec may point `default_subcommand` at any of them.
+        let mut a = 0;
+        while a < candidate.aliases.len() {
+            if str_eq(candidate.aliases[a], name) {
+                return candidate;
+            }
+            a += 1;
         }
         i += 1;
     }
@@ -855,13 +865,20 @@ impl<'t, 'v> Parser<'t, 'v> {
 
             // A word that names no subcommand goes to the default one, if there is one.
             //
+            // Only a word, though. A dash-prefixed token that named no flag arrives here as a
+            // value — that is what `unknown_flags = value` means — and it was never a
+            // candidate to *select* anything, so it binds where it was typed. usage-lib stops
+            // looking for subcommands at an unrecognised flag for the same reason. `--` is
+            // excluded on the same grounds: it reaches this function only when a `preserve`
+            // argument wants it as a value.
+            //
             // The token is *not* consumed: the cursor steps back so the next event reads it
             // again, now against the command just descended into. That is what lets it be a
             // subcommand of the default (`mise build` where `build` is a task the mount
             // added) as easily as an argument of it, without this function having to decide
             // which — and without yielding two events for one word.
             if let Some(default) = self.cmd.default_subcommand {
-                if !self.default_taken {
+                if !self.default_taken && !is_flag_like(token) && token != b"--" {
                     self.default_taken = true;
                     self.descend(default)?;
                     self.pos -= 1;
@@ -1418,6 +1435,26 @@ mod tests {
     }
 
     #[test]
+    fn an_unknown_flag_is_not_routed() {
+        // A dash-prefixed token that names no flag becomes a value here (the default for
+        // `unknown_flags`), and it must not thereby become a *subcommand* word: usage-lib
+        // stops looking for subcommands at an unrecognised flag, and binds it to the command
+        // still in scope. Verified against usage-lib, where `ex --wat` comes back as commands
+        // `["ex"]` with `ROOT_TASK = "--wat"`.
+        for token in ["--wat", "-x"] {
+            let a = argv([token]);
+            assert_eq!(
+                parse(&DEFAULTING, &a).unwrap(),
+                vec![Event::Arg {
+                    arg: &TASK,
+                    value: token.as_bytes()
+                }],
+                "{token} should bind where it was typed, not in the default subcommand"
+            );
+        }
+    }
+
+    #[test]
     fn a_named_subcommand_is_not_routed() {
         // The default is for words that name nothing. A word that names a sibling still
         // selects it, and the root's own argument is still reachable behind one.
@@ -1426,6 +1463,24 @@ mod tests {
             parse(&DEFAULTING, &a).unwrap(),
             vec![Event::Command(&INSTALL)]
         );
+    }
+
+    #[test]
+    fn the_default_can_be_named_by_an_alias() {
+        // usage-lib resolves the name against subcommand names, aliases and hidden aliases
+        // alike, so a spec may point `default_subcommand` at any of them.
+        static BY_ALIAS: Command = Command {
+            name: "mise",
+            args: &[&TASK],
+            subcommands: &[&INSTALL],
+            // `INSTALL` answers to "i" as well as to its name.
+            default_subcommand: Some(find_subcommand(&[&INSTALL], "i")),
+            ..Command::EMPTY
+        };
+        assert!(::core::ptr::eq(
+            BY_ALIAS.default_subcommand.expect("declared"),
+            &INSTALL
+        ));
     }
 
     #[test]

--- a/benches/gate/tests/parse.rs
+++ b/benches/gate/tests/parse.rs
@@ -54,18 +54,45 @@ fn a_task_runs_with_arguments_after_a_separator() {
 }
 
 #[test]
-fn a_bare_task_lands_on_the_root_positional() {
-    // `mise build -- --verbose` fills the root's own `[TASK]`, with the words after the
-    // separator kept apart.
+fn a_bare_task_routes_through_run_and_then_needs_the_mount() {
+    // `mise build` used to fill the root's own `[TASK]` here, because the derive could not
+    // declare `default_subcommand`. Now it can, so the shadow does what mise's spec says:
+    // `build` names no subcommand, so the parser descends into `run`.
     //
-    // Real mise routes this through `run`, because its spec sets `default_subcommand
-    // run` — which the derive cannot declare, so the shadow answers at the root
-    // instead. One of the differences `gen-shadow` counts rather than one it hides.
+    // And there it stops, because mise's spec gives `run` no positional arguments at all —
+    // `src/cli/usage.rs` clears them and adds `mount run="mise tasks --usage"`, so the task
+    // names are supposed to come from running that. usage-argv does not execute mounts (a
+    // subprocess mid-parse is not something a hot path should do), so there is nothing for
+    // the word to bind to.
+    //
+    // Worth being plain about, because it bounds what routing alone buys: `mise build`
+    // working end to end needs the mount as well, and mise's own hand-rolled routing cannot
+    // be deleted on the strength of this rule by itself.
+    let a = argv(["build"]);
+    match Cli::parse_from(&a) {
+        Err(usage_argv::Error::UnexpectedArg { token }) => {
+            assert_eq!(
+                token, b"build",
+                "descended into `run`, which has no argument"
+            );
+        }
+        Err(other) => panic!("wrong error: {other:?}"),
+        Ok(_) => panic!("`run` has no positional in mise's spec, so this cannot bind"),
+    }
+
+    // The separator behaves the same way: routing happens at the word, and the words after
+    // `--` were never candidates for it.
     let a = argv(["build", "--", "--verbose"]);
-    let cli = Cli::parse_from(&a).expect("should parse");
-    assert_eq!(cli.task.as_deref(), Some("build"));
-    assert_eq!(cli.task_args_last, ["--verbose"]);
-    assert!(cli.command.is_none(), "`build` is not a subcommand");
+    assert!(matches!(
+        Cli::parse_from(&a),
+        Err(usage_argv::Error::UnexpectedArg { .. })
+    ));
+
+    // A word that *does* name a command is unaffected, which is the case that matters for
+    // every other invocation in this file.
+    let a = argv(["ls"]);
+    let cli = Cli::parse_from(&a).expect("`ls` names a command");
+    assert!(cli.command.is_some());
 }
 
 #[test]
@@ -126,9 +153,9 @@ fn a_command_that_requires_a_subcommand_refuses_to_stand_alone() {
     let a = argv(["bootstrap", "accounts", "status"]);
     Cli::parse_from(&a).expect("`accounts status` should parse");
 
-    // And the root does not require one, because `mise <task>` is a whole invocation.
-    let a = argv(["build"]);
-    Cli::parse_from(&a).expect("a bare task should parse");
+    // And the root does not require one: `mise` alone is a whole invocation.
+    let a: [&std::ffi::OsStr; 0] = [];
+    Cli::parse_from(&a).expect("a bare `mise` should parse");
 }
 
 #[test]

--- a/conformance/src/argv.rs
+++ b/conformance/src/argv.rs
@@ -66,6 +66,24 @@ pub fn run(vector: &Vector) -> Outcome {
         &spec.cmd,
         convert_unknown_flags(spec.unknown_flags.unwrap_or_default()),
     );
+    // `default_subcommand` is a property of the spec rather than of a command, so it is
+    // resolved once, here, against the root's own subcommands. A name that answers to
+    // nothing is left as None: the spec is what it is, and a vector that expects routing
+    // will fail loudly rather than this guessing.
+    let root: &'static Command<'static> = match spec.default_subcommand.as_deref() {
+        Some(name) => {
+            let default = root
+                .subcommands
+                .iter()
+                .copied()
+                .find(|sub| sub.name == name || sub.aliases.contains(&name));
+            Box::leak(Box::new(Command {
+                default_subcommand: default,
+                ..*root
+            }))
+        }
+        None => root,
+    };
     let argv: Vec<&'static OsStr> = vector
         .argv
         .iter()
@@ -293,6 +311,8 @@ fn build(
         flags: Box::leak(flags.into_boxed_slice()),
         args: Box::leak(args.into_boxed_slice()),
         subcommands: Box::leak(subcommands.into_boxed_slice()),
+        // Filled in by the caller for the root, which is the only place a spec declares one.
+        default_subcommand: None,
         unknown_flags,
         key: 0,
     }))

--- a/conformance/tests/root_grammar.rs
+++ b/conformance/tests/root_grammar.rs
@@ -9,10 +9,9 @@
 //! to completions, which is the cold path, and a restart token is read by whoever splits an
 //! invocation into several.
 //!
-//! `default_subcommand` is *not* in that category, though this derive currently treats it as
-//! if it were — usage-lib routes on it while parsing. See
-//! `a_default_subcommand_does_not_route_yet`, which records the difference rather than
-//! asserting the gap is intended.
+//! `default_subcommand` is not in that category: it decides where a word goes, so the parser
+//! reads it. `mise build` means `mise run build`, and the word binds to *run's* argument even
+//! where the root declares one of its own.
 
 use usage::Spec as LibSpec;
 use usage_derive::{Args, Cli, Subcommands};
@@ -24,6 +23,9 @@ struct Run {
     /// Do not actually run anything
     #[usage(long)]
     dry_run: bool,
+    /// The task to run
+    #[usage(arg, name = "TASK")]
+    task: Option<String>,
 }
 
 /// List things
@@ -103,28 +105,49 @@ fn a_mount_is_not_consulted_while_parsing() {
 }
 
 #[test]
-fn a_default_subcommand_does_not_route_yet() {
+fn a_default_subcommand_routes_a_word_that_names_nothing() {
     use std::ffi::OsStr;
 
-    // **A recorded divergence, not the intended end state.** usage-lib routes here: given
-    // `default_subcommand "run"`, a word that names no subcommand makes its parser descend
-    // into `run` and bind the word as *`run`'s* argument, even when the root declares an
-    // argument of its own. Verified against usage-lib 4.0.0 directly — `mise build` comes
-    // back as commands `["mise", "run"]` with `TASK = "build"`.
-    //
-    // This parser keeps the word at the root, so `default_subcommand` reaches the spec and
-    // nothing more. That is a gap in the derive rather than a decision: routing needs the
-    // table to carry a pointer to the default subcommand and the parser to descend on a word
-    // that matches none, which is more than emitting a property. Asserted as it stands so
-    // the difference is visible and cannot be mistaken for intent.
-    //
-    // It matters to mise: `mise build` meaning `mise run build` is exactly this rule, and
-    // mise routes it by hand today.
+    // What `default_subcommand` is for, and what mise routes by hand today: `mise build`
+    // means `mise run build`. The word names no subcommand, so the parser descends into
+    // `run` and the word is re-examined there — landing on **run's** argument, not the
+    // root's, even though the root declares one. Matches usage-lib, which is where the
+    // behaviour was read from rather than invented.
     let argv = [OsStr::new("build")];
     let parsed = Cli_::parse_from(&argv).expect("should parse");
-    assert_eq!(parsed.task.as_deref(), Some("build"), "bound at the root");
+    let Some(Commands::Run(run)) = parsed.command else {
+        panic!("a word naming nothing should have reached `run`")
+    };
+    assert_eq!(run.task.as_deref(), Some("build"), "bound by `run`");
     assert!(
-        parsed.command.is_none(),
-        "usage-lib would have descended into `run` here"
+        parsed.task.is_none(),
+        "the root's own argument must not have taken it"
+    );
+
+    // A word that does name a command still selects it: the default is only for the words
+    // that name nothing.
+    let argv = [OsStr::new("ls"), OsStr::new("--all")];
+    let parsed = Cli_::parse_from(&argv).expect("should parse");
+    let Some(Commands::Ls(ls)) = parsed.command else {
+        panic!("expected ls")
+    };
+    assert!(ls.all);
+}
+
+#[test]
+fn the_name_is_resolved_when_the_program_is_compiled() {
+    // `default_subcommand` names a command whose declaration is in another macro expansion,
+    // so the derive cannot look it up — but a `const fn` can search the subcommand list
+    // during const evaluation, which makes a name that answers to nothing a compile error.
+    // Nothing to assert at run time beyond the resolution having happened: the pointer is
+    // the same static the subcommand list holds.
+    let root = Cli_::command();
+    let default = root.default_subcommand.expect("declared");
+    assert_eq!(default.name, "run");
+    assert!(
+        root.subcommands
+            .iter()
+            .any(|sub| ::core::ptr::eq(*sub, default)),
+        "resolved to the table's own entry rather than a copy of it"
     );
 }

--- a/corpus/09-default-subcommand.json
+++ b/corpus/09-default-subcommand.json
@@ -1,0 +1,58 @@
+{
+  "section": "default-subcommand",
+  "about": "Where a word goes when it names no subcommand. `default_subcommand` makes `mise build` mean `mise run build`: the word selects nothing, so the parser descends into the named command and the word is re-examined there. It is declared once, for the whole spec.",
+  "vectors": [
+    {
+      "id": "default-route",
+      "doc": "A word naming no subcommand descends into the default one and binds as its argument.",
+      "spec": "name \"ex\"\nbin \"ex\"\ndefault_subcommand \"run\"\ncmd \"run\" {\n  arg \"[TASK]\"\n}\n",
+      "argv": ["build"],
+      "expect": { "ok": { "cmd": ["run"], "args": { "TASK": "build" } } }
+    },
+    {
+      "id": "default-beats-the-root-own-arg",
+      "doc": "The declaring command's own positional does not win. This is what makes the property more than a synonym for an argument, and it is mise's shape exactly: the root has `[TASK]` and `run` has one too.",
+      "spec": "name \"ex\"\nbin \"ex\"\ndefault_subcommand \"run\"\narg \"[ROOT_TASK]\"\ncmd \"run\" {\n  arg \"[TASK]\"\n}\n",
+      "argv": ["build"],
+      "expect": { "ok": { "cmd": ["run"], "args": { "TASK": "build" } } }
+    },
+    {
+      "id": "default-not-used-when-named",
+      "doc": "A word that does name a subcommand selects it; the default is only for words that name nothing.",
+      "spec": "name \"ex\"\nbin \"ex\"\ndefault_subcommand \"run\"\ncmd \"run\" {\n  arg \"[TASK]\"\n}\ncmd \"install\"\n",
+      "argv": ["install"],
+      "expect": { "ok": { "cmd": ["install"] } }
+    },
+    {
+      "id": "default-word-reexamined",
+      "doc": "The word is examined again against the command it reached, so it can name one of *its* subcommands. mise's mounted task names arrive this way.",
+      "spec": "name \"ex\"\nbin \"ex\"\ndefault_subcommand \"run\"\ncmd \"run\" {\n  cmd \"lint\"\n}\n",
+      "argv": ["lint"],
+      "expect": { "ok": { "cmd": ["run", "lint"] } }
+    },
+    {
+      "id": "default-flag-before-the-word",
+      "doc": "Routing happens at the word, so a flag typed before it was addressed to the command the user was at.",
+      "spec": "name \"ex\"\nbin \"ex\"\ndefault_subcommand \"run\"\nflag \"--verbose\"\ncmd \"run\" {\n  arg \"[TASK]\"\n}\n",
+      "argv": ["--verbose", "build"],
+      "expect": { "ok": { "cmd": ["run"], "args": { "TASK": "build" }, "flags": { "verbose": true } } }
+    },
+    {
+      "id": "default-after-separator",
+      "doc": "Past `--` no subcommand can be selected, so there is no default to reach either: the word is a value of whatever the command declares.",
+      "spec": "name \"ex\"\nbin \"ex\"\ndefault_subcommand \"run\"\narg \"[ROOT_TASK]\"\ncmd \"run\" {\n  arg \"[TASK]\"\n}\n",
+      "argv": ["--", "build"],
+      "expect": { "ok": { "cmd": [], "args": { "ROOT_TASK": "build" } } }
+    },
+    {
+      "id": "default-is-declared-for-the-root",
+      "doc": "`default_subcommand` names one command for the whole program. A nested command that happens to have a subcommand of that name does not thereby acquire a default of its own.",
+      "spec": "name \"ex\"\nbin \"ex\"\ndefault_subcommand \"ls\"\ncmd \"ls\"\ncmd \"config\" {\n  cmd \"ls\" {\n    arg \"[WHAT]\"\n  }\n}\n",
+      "argv": ["config", "zzz"],
+      "expect": { "error": "unexpected_arg" },
+      "reference": {
+        "diverges": "usage-lib holds the one name for the whole spec and applies it at whichever command it is standing on, so `ex config zzz` descends into `config ls` and binds `zzz` there. That makes an unrelated command acquire a default because a name happened to match one level down, which reads as accidental rather than declared — the property is written once, at the top, and nothing says it applies anywhere else."
+      }
+    }
+  ]
+}

--- a/corpus/09-default-subcommand.json
+++ b/corpus/09-default-subcommand.json
@@ -7,51 +7,134 @@
       "doc": "A word naming no subcommand descends into the default one and binds as its argument.",
       "spec": "name \"ex\"\nbin \"ex\"\ndefault_subcommand \"run\"\ncmd \"run\" {\n  arg \"[TASK]\"\n}\n",
       "argv": ["build"],
-      "expect": { "ok": { "cmd": ["run"], "args": { "TASK": "build" } } }
+      "expect": {
+        "ok": {
+          "cmd": ["run"],
+          "args": {
+            "TASK": "build"
+          }
+        }
+      }
     },
     {
       "id": "default-beats-the-root-own-arg",
       "doc": "The declaring command's own positional does not win. This is what makes the property more than a synonym for an argument, and it is mise's shape exactly: the root has `[TASK]` and `run` has one too.",
       "spec": "name \"ex\"\nbin \"ex\"\ndefault_subcommand \"run\"\narg \"[ROOT_TASK]\"\ncmd \"run\" {\n  arg \"[TASK]\"\n}\n",
       "argv": ["build"],
-      "expect": { "ok": { "cmd": ["run"], "args": { "TASK": "build" } } }
+      "expect": {
+        "ok": {
+          "cmd": ["run"],
+          "args": {
+            "TASK": "build"
+          }
+        }
+      }
     },
     {
       "id": "default-not-used-when-named",
       "doc": "A word that does name a subcommand selects it; the default is only for words that name nothing.",
       "spec": "name \"ex\"\nbin \"ex\"\ndefault_subcommand \"run\"\ncmd \"run\" {\n  arg \"[TASK]\"\n}\ncmd \"install\"\n",
       "argv": ["install"],
-      "expect": { "ok": { "cmd": ["install"] } }
+      "expect": {
+        "ok": {
+          "cmd": ["install"]
+        }
+      }
     },
     {
       "id": "default-word-reexamined",
       "doc": "The word is examined again against the command it reached, so it can name one of *its* subcommands. mise's mounted task names arrive this way.",
       "spec": "name \"ex\"\nbin \"ex\"\ndefault_subcommand \"run\"\ncmd \"run\" {\n  cmd \"lint\"\n}\n",
       "argv": ["lint"],
-      "expect": { "ok": { "cmd": ["run", "lint"] } }
+      "expect": {
+        "ok": {
+          "cmd": ["run", "lint"]
+        }
+      }
     },
     {
       "id": "default-flag-before-the-word",
       "doc": "Routing happens at the word, so a flag typed before it was addressed to the command the user was at.",
       "spec": "name \"ex\"\nbin \"ex\"\ndefault_subcommand \"run\"\nflag \"--verbose\"\ncmd \"run\" {\n  arg \"[TASK]\"\n}\n",
       "argv": ["--verbose", "build"],
-      "expect": { "ok": { "cmd": ["run"], "args": { "TASK": "build" }, "flags": { "verbose": true } } }
+      "expect": {
+        "ok": {
+          "cmd": ["run"],
+          "args": {
+            "TASK": "build"
+          },
+          "flags": {
+            "verbose": true
+          }
+        }
+      }
     },
     {
       "id": "default-after-separator",
       "doc": "Past `--` no subcommand can be selected, so there is no default to reach either: the word is a value of whatever the command declares.",
       "spec": "name \"ex\"\nbin \"ex\"\ndefault_subcommand \"run\"\narg \"[ROOT_TASK]\"\ncmd \"run\" {\n  arg \"[TASK]\"\n}\n",
       "argv": ["--", "build"],
-      "expect": { "ok": { "cmd": [], "args": { "ROOT_TASK": "build" } } }
+      "expect": {
+        "ok": {
+          "cmd": [],
+          "args": {
+            "ROOT_TASK": "build"
+          }
+        }
+      }
     },
     {
       "id": "default-is-declared-for-the-root",
       "doc": "`default_subcommand` names one command for the whole program. A nested command that happens to have a subcommand of that name does not thereby acquire a default of its own.",
       "spec": "name \"ex\"\nbin \"ex\"\ndefault_subcommand \"ls\"\ncmd \"ls\"\ncmd \"config\" {\n  cmd \"ls\" {\n    arg \"[WHAT]\"\n  }\n}\n",
       "argv": ["config", "zzz"],
-      "expect": { "error": "unexpected_arg" },
+      "expect": {
+        "error": "unexpected_arg"
+      },
       "reference": {
-        "diverges": "usage-lib holds the one name for the whole spec and applies it at whichever command it is standing on, so `ex config zzz` descends into `config ls` and binds `zzz` there. That makes an unrelated command acquire a default because a name happened to match one level down, which reads as accidental rather than declared — the property is written once, at the top, and nothing says it applies anywhere else."
+        "diverges": "usage-lib holds the one name for the whole spec and applies it at whichever command it is standing on, so `ex config zzz` descends into `config ls` and binds `zzz` there. That makes an unrelated command acquire a default because a name happened to match one level down, which reads as accidental rather than declared \u2014 the property is written once, at the top, and nothing says it applies anywhere else."
+      }
+    },
+    {
+      "id": "default-not-taken-by-an-unknown-flag",
+      "doc": "A dash-prefixed token naming no flag is a value, and was never a candidate to select a command \u2014 so it binds where it was typed rather than in the default subcommand. usage-lib stops looking for subcommands at an unrecognised flag for the same reason.",
+      "spec": "name \"ex\"\nbin \"ex\"\ndefault_subcommand \"run\"\narg \"[ROOT_TASK]\"\ncmd \"run\" {\n  arg \"[TASK]\"\n}\n",
+      "argv": ["--wat"],
+      "expect": {
+        "ok": {
+          "cmd": [],
+          "args": {
+            "ROOT_TASK": "--wat"
+          }
+        }
+      }
+    },
+    {
+      "id": "default-not-taken-by-an-unknown-short",
+      "doc": "The same for a short form, which reaches the positional by a different route through the parser.",
+      "spec": "name \"ex\"\nbin \"ex\"\ndefault_subcommand \"run\"\narg \"[ROOT_TASK]\"\ncmd \"run\" {\n  arg \"[TASK]\"\n}\n",
+      "argv": ["-x"],
+      "expect": {
+        "ok": {
+          "cmd": [],
+          "args": {
+            "ROOT_TASK": "-x"
+          }
+        }
+      }
+    },
+    {
+      "id": "default-named-by-an-alias",
+      "doc": "`default_subcommand` may name an alias rather than the canonical name, which usage-lib resolves against names, aliases and hidden aliases alike.",
+      "spec": "name \"ex\"\nbin \"ex\"\ndefault_subcommand \"r\"\ncmd \"run\" {\n  alias \"r\"\n  arg \"[TASK]\"\n}\n",
+      "argv": ["build"],
+      "expect": {
+        "ok": {
+          "cmd": ["run"],
+          "args": {
+            "TASK": "build"
+          }
+        }
       }
     }
   ]

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -73,6 +73,10 @@ pub fn emit(cli: &Cli) -> TokenStream {
         .as_ref()
         .map(|p| p.commands.clone())
         .unwrap_or_default();
+    let sub_default = parts
+        .as_ref()
+        .map(|p| p.default.clone())
+        .unwrap_or_default();
     let sub_metas = parts.as_ref().map(|p| p.metas.clone()).unwrap_or_default();
     let sub_build = parts.as_ref().map(|p| p.build.clone()).unwrap_or_default();
 
@@ -115,6 +119,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
                 flags: &[#(#flag_refs),*],
                 args: &[#(#arg_refs),*],
                 #sub_commands
+                #sub_default
                 ..Command::EMPTY
             };
 
@@ -1047,6 +1052,8 @@ fn apply_fn(cli: &Cli) -> TokenStream {
 struct SubcommandParts {
     /// `subcommands:` for the `Command` table.
     commands: TokenStream,
+    /// `default_subcommand:` for the `Command` table, when one is declared.
+    default: TokenStream,
     /// `subcommands:` for the `CommandMeta`.
     metas: TokenStream,
     /// Fields the partial needs to carry.
@@ -1098,6 +1105,21 @@ fn subcommand_parts(cli: &Cli) -> Option<SubcommandParts> {
 
     Some(SubcommandParts {
         commands: quote!(subcommands: <#in_mod as ::usage_argv::spec::Subcommands>::COMMANDS,),
+        // Resolved from the name at compile time. The variants are another expansion, so the
+        // name is all there is to go on here — but `find_subcommand` searches the list during
+        // const evaluation, which means a name no subcommand answers to fails to compile
+        // rather than being emitted into a spec that nothing checks.
+        default: match cli.default_subcommand.as_deref() {
+            ::std::option::Option::Some(name) => quote! {
+                default_subcommand: ::std::option::Option::Some(
+                    ::usage_argv::find_subcommand(
+                        <#in_mod as ::usage_argv::spec::Subcommands>::COMMANDS,
+                        #name,
+                    ),
+                ),
+            },
+            ::std::option::Option::None => TokenStream::new(),
+        },
         metas: quote!(subcommands: <#in_mod as ::usage_argv::spec::Subcommands>::METAS,),
         partial_fields: quote! {
             pub __usage_sub: <#in_mod as ::usage_argv::spec::Subcommands>::Partial,

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -228,6 +228,8 @@ pub fn derive_cli(input: TokenStream) -> TokenStream {
 #[proc_macro_derive(Args, attributes(usage))]
 pub fn derive_args(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
+    // `restart_token` and `mount` are per-command and belong here; `default_subcommand` is
+    // declared once for the whole spec and does not.
     let parsed = model::Cli::from_input(&input)
         .and_then(|cli| cli.check_position(&input.ident, false).map(|()| cli));
     match parsed {

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -249,6 +249,10 @@ impl Cli {
     /// attribute is required at the root and a mistake below it, or the reverse. Called with
     /// `is_root` from each derive.
     ///
+    /// The *name* a `default_subcommand` gives is not checked here. It is resolved by
+    /// `usage_argv::find_subcommand` during const evaluation, so a name no subcommand answers
+    /// to fails to compile there.
+    ///
     /// Every rule here exists because the *spec* cannot express the thing anywhere else.
     /// Without them a declaration is accepted, dropped on the way to the KDL, and missed —
     /// or, for a root `mount`, trips a `debug_assert!` in the writer, which is a poor way to


### PR DESCRIPTION
`default_subcommand` was emitted into the spec and ignored by the parser, which the
previous commit recorded as a gap rather than a decision. usage-lib routes on it, and
this is the rule behind `mise build` meaning `mise run build`.

A word naming no subcommand now descends into the named one, and the cursor steps back so
the word is examined again against the command it reached — which lets it be that
command's argument or one of *its* subcommands, without this deciding which and without
two events for one word. The declaring command's own positional does not win, which is
what makes the property more than a synonym for an argument, and is mise's shape exactly:
the root has `[TASK]` and so does `run`.

Taken at most once per parse, as usage-lib does, so a chain of defaults cannot walk a CLI
deeper than anything the user typed.

The name is resolved by `find_subcommand` during const evaluation, so a name no
subcommand answers to is a compile error. The previous commit said the name could not be
checked because the variants are another expansion; that is true of the macro and not of
const eval, which can search the list the parent already holds.

Seven corpus vectors, six agreeing with usage-lib and one recording where it does not:
usage-lib holds the single name spec-wide and applies it at whichever command it stands
on, so `ex config zzz` descends into `config ls` when an unrelated command happens to
have a subcommand of that name. Read here as a property of the root, which is the only
place a spec can declare it.

`default_subcommand` on a nested `Args` is now refused outright instead of being dropped
in silence. Both derives share one parse, so the rule moved to where the context is
known — before, a nested struct got whichever check ran first, which named the wrong
problem.

No measurable cost: 40,370 instructions against 40,472, the branch being reached only by
a word that matched no subcommand. Allocations unchanged — 0 bare, 4 bound.

One thing this does not buy: `mise build` still fails in the shadow, because mise's spec
gives `run` no positional — its arguments are cleared and a mount supplies task names,
which usage-argv does not execute. Routing plus mounts is what lets mise delete its
hand-rolled dispatch; the gate test now says so rather than asserting the old answer.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core subcommand routing and argv binding semantics (default descent, once-per-parse latch, token rewind), which can alter how bare words and edge cases parse across CLIs that declare `default_subcommand`.
> 
> **Overview**
> **Implements `default_subcommand` in the hot-path parser** so a bare word like `build` can mean “descend into `run` and bind there,” matching usage-lib and mise’s `mise build` → `mise run build` shape.
> 
> `Command` gains `default_subcommand` plus **`find_subcommand`** (const-time name/alias lookup, compile error if the name is missing). In `word()`, after a failed subcommand match, the parser may descend once per parse (`default_taken`), **rewind the argv cursor**, and re-read the same token under the default command. Routing is skipped for flag-like tokens, after `--`, and when a positional already filled; unknown flags still bind at the current command.
> 
> **Derive and conformance** wire the root-level spec property into static tables; nested `default_subcommand` on `Args` is rejected. **Corpus** adds `09-default-subcommand.json` (including one recorded usage-lib divergence: root-only vs spec-wide default). **Gate shadow** now expects `mise build` to route into `run` then fail with `UnexpectedArg` until mounts exist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46fff423795cb879f7789aaa1c29d638bb8286c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## The decision behind this

Investigating `flatten` turned up that five of mise's ten `#[clap(flatten)]` sites are a
subcommand field beside a flatten of *the same type the `Ls` variant holds* — `config`,
`tasks`, `settings`, `deps`, `tool` all hand-rolling "with no subcommand, behave as `ls`".
Which raised the question of what `default_subcommand` actually means, and the answer was that
#842 got it wrong: usage-lib routes on it while parsing.

```
["mise", "build"] -> cmds ["mise", "run"], args [("TASK", String("build"))]
```

Even though the root declares its own `arg "[TASK]"`. So the property is a binding rule, and
#842's test asserting otherwise was corrected in its own commit before this one.

## Cost

| | before | after |
|---|---:|---:|
| instructions, cold parse | 40,472 | 40,370 |
| allocations, bare / bound | 0 / 4 | 0 / 4 |

No measurable cost. The branch is reached only by a word that already failed a subcommand
lookup, and the ±100 is code layout rather than work done — cachegrind is deterministic and
gave the same figure on repeated runs.

## The name is now checked at compile time

#842 said "which command it names cannot be checked here — the enum's variants are in another
expansion". True of the macro, not of const evaluation: `find_subcommand` searches the list the
parent already holds, so

```
error[E0080]: evaluation panicked: `default_subcommand` names a command that this one does not have
```

A wrong name is a compile error rather than a spec property nothing validates.

## What this does not buy

`mise build` still does not work end to end in the shadow, and it is worth being plain about
why: mise's spec gives `run` **no positional at all** — `src/cli/usage.rs` clears them and adds
`mount run="mise tasks --usage"`, so task names are meant to come from running that.
usage-argv does not execute mounts, so after descending there is nothing to bind to. Routing
*plus* mounts is what would let mise delete its hand-rolled dispatch; this is half of it. The
gate test now records that instead of asserting the old answer.

## Verification

- Seven corpus vectors. Six agree with usage-lib — checked automatically, since an absent
  `reference` label is an assertion the reference test enforces in both directions.
- Six parser unit tests: routing, a named subcommand not routed, re-examination against the
  reached command, the once-per-parse latch, a flag before the word, and nothing routing past
  `--`.
- Mutation-checked: removing the latch fails the latch test; removing the cursor rewind fails
  four.
- End-to-end through the derive, plus a test that the resolved pointer is the table's own entry
  rather than a copy.

## One divergence, and a question

`default-is-declared-for-the-root` records it: usage-lib holds the single name for the whole
spec and applies it at **whichever command it is standing on**, so with `default_subcommand
"ls"` declared at the top, `ex config zzz` descends into `config ls` — an unrelated command
acquiring a default because a name happened to match one level down.

```
["config", "zzz"] -> cmds ["ex", "config", "ls"], args [("WHAT", String("zzz"))]
```

This parser reads it as a property of the root, which is the only place a spec can declare one.
That looks like the intended meaning and usage-lib's looks accidental — but it is your call,
and if you agree it is a small fix in `lib/src/parse.rs`. The corpus label makes the difference
fail loudly the moment it changes either way.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*
