### PR TITLE
feat(derive): share declarations between commands with flatten

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -169,7 +169,11 @@ manpages, and SDKs — never a runtime dependency of somebody else's program.
       still cause — a parent and the struct it flattens both declaring `--quiet` — is invisible to
       both expansions, so `Spec::to_kdl` grew a duplicate-form check beside the key one, where the
       whole tree is visible. `Option<T>` flatten is refused rather than guessed at: it needs a rule
-      for when the group counts as given, and nothing in the fleet asks for one.
+      for when the group counts as given, and nothing in the fleet asks for one. Two more checks live
+      in `Spec::to_kdl` for the same reason as the duplicate-form one: an argument no word can reach —
+      an unbounded variadic on one side of a flatten and a later positional on the other — and the
+      flag-form collision. Both are invisible to either expansion and visible where the tables are
+      joined.
 - [ ] **`usage-derive` v1** — everything mise needs: constraints
       (`requires`/`conflicts`/`overrides`/`required_unless`), `var`, `count`,
       `env`, defaults, delimiters, the `double_dash` modes, global flags, flatten,

--- a/PLAN.md
+++ b/PLAN.md
@@ -148,6 +148,28 @@ manpages, and SDKs — never a runtime dependency of somebody else's program.
       since it skips the UTF-8 validation pass, and both allocate once. The gate fixture cannot show
       this — a spec carries no Rust types, so every shadow field is a `String` — which is why it is
       measured directly.
+- [x] **`flatten`** — one struct's declarations belonging to another command, which mise does
+      ten times: `ConfigLs` is written once and given to both `config` and `config ls`. The tables are
+      joined at compile time by `concat_flags`/`concat_args`, so the parser walks one flat slice and
+      flatten costs nothing at run time; a flattened group lands at the field's position, which
+      positional arguments require. Everything else is delegation through `CommandArgs` — partial,
+      `start`, `apply`, `check`, `build` — which is also why nesting works without anything extra.
+      Nothing new in the spec: the emitted KDL lists the flags inline, exactly as a hand-written
+      command would. It turned up a bug worth more than the feature. `Subcommands::apply` offered
+      every event to _every_ variant and took the first that claimed it, which was harmless only
+      because keys were unique per command — and flatten breaks that, since two commands sharing a
+      declaration share its key. So `config --no-header` bound the flag on the unselected `config ls`.
+      Now only the _selected_ variant is asked, which is both correct and much cheaper: at mise's
+      scale the root had ~100 variants, each asked per event. **29,850 instructions and 822 ns, from
+      40,179 and 1,893 ns** — 26% fewer instructions and 57% less wall time, measured against the
+      parent branch on one machine. 176× clap's instruction count. Allocations unchanged: 0 bare, 4
+      bound. `duplicate_key` had to change with it: it asserted no key appeared twice in the whole
+      tree, and sharing one across commands is now ordinary rather than suspect. Checked per command
+      instead, which is the level a key actually decides anything at. The collision flatten _can_
+      still cause — a parent and the struct it flattens both declaring `--quiet` — is invisible to
+      both expansions, so `Spec::to_kdl` grew a duplicate-form check beside the key one, where the
+      whole tree is visible. `Option<T>` flatten is refused rather than guessed at: it needs a rule
+      for when the group counts as given, and nothing in the fleet asks for one.
 - [ ] **`usage-derive` v1** — everything mise needs: constraints
       (`requires`/`conflicts`/`overrides`/`required_unless`), `var`, `count`,
       `env`, defaults, delimiters, the `double_dash` modes, global flags, flatten,

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -78,6 +78,37 @@ fn duplicate_flag_form(cmd: &Command<'_>) -> Option<std::string::String> {
         .find_map(|sub| duplicate_flag_form(sub))
 }
 
+/// An argument that no word could ever reach, if any.
+///
+/// An unbounded variadic takes every remaining word, so what follows it can never be filled —
+/// unless something stops the variadic. Two things do: an argument only fillable after a `--`,
+/// because the separator ends the collecting, and a `var_max`, because a bounded variadic hands
+/// over the words past its bound. mise relies on the first on `run`, `exec` and `git`.
+///
+/// `#[derive(Args)]` applies that rule to one struct's own arguments. It cannot apply it across
+/// a `#[usage(flatten)]`: the variadic may be on one side of the boundary and the argument that
+/// follows it on the other, and neither expansion can see the other's fields. Checked here for
+/// the same reason the duplicate checks are — this is where the joined table is visible.
+///
+/// Returns the name of the unreachable argument.
+fn unfillable_arg<'a>(cmd: &Command<'a>) -> Option<&'a str> {
+    let mut variadic: Option<&Arg<'_>> = None;
+    for arg in cmd.args {
+        // A `--` stops the collecting, so an argument behind one is still reachable — but only
+        // one separator exists, so nothing can follow *that*.
+        let stopped_by_separator = arg.double_dash == DoubleDash::Required;
+        if let Some(before) = variadic {
+            if !stopped_by_separator || before.double_dash == DoubleDash::Required {
+                return Some(arg.name);
+            }
+        }
+        if arg.var && arg.var_max.is_none() {
+            variadic = Some(arg);
+        }
+    }
+    cmd.subcommands.iter().find_map(|sub| unfillable_arg(sub))
+}
+
 /// A whole CLI: the root command plus what describes the program itself.
 #[derive(Debug, Clone, Copy)]
 pub struct Spec<'a> {
@@ -358,6 +389,15 @@ impl Spec<'_> {
              be reached. With `flatten` this is the collision neither expansion can see: \
              the parent and the struct it flattens each declared it.",
             duplicate_flag_form(self.root.cmd)
+        );
+        debug_assert!(
+            unfillable_arg(self.root.cmd).is_none(),
+            "no word could ever reach the argument {:?}, because an unbounded variadic before \
+             it takes every remaining one. With `flatten` this is the arrangement neither \
+             expansion can see: the variadic and the argument after it were declared in \
+             different structs. Give the variadic a `var_max`, or make the later argument \
+             fillable only after a `--`.",
+            unfillable_arg(self.root.cmd)
         );
         let mut out = String::new();
         // Unwrap-free: writing into a String cannot fail, and `write!` returning
@@ -985,6 +1025,69 @@ mod tests {
         assert_eq!(quoted(r#"say "hi""#), r#""say \"hi\"""#);
         assert_eq!(quoted("a\\b"), r#""a\\b""#);
         assert_eq!(quoted("one\ntwo"), r#""one\ntwo""#);
+    }
+
+    #[test]
+    fn an_argument_no_word_can_reach_is_caught_where_the_table_is_joined() {
+        // The arrangement `flatten` makes possible and neither expansion can see: an
+        // unbounded variadic declared in one struct and an argument after it in another. The
+        // derive checks this within a struct; across the boundary it has no way to.
+        static FILES: Arg = Arg {
+            name: "files",
+            ..Arg::VAR
+        };
+        static AFTER: Arg = Arg {
+            name: "after",
+            ..Arg::REQUIRED
+        };
+        static BROKEN: Command = Command {
+            name: "ex",
+            args: &[&FILES, &AFTER],
+            ..Command::EMPTY
+        };
+        assert_eq!(unfillable_arg(&BROKEN), Some("after"));
+
+        // A bound stops the variadic, so what follows is reachable.
+        static BOUNDED: Arg = Arg {
+            name: "files",
+            var_max: Some(2),
+            ..Arg::VAR
+        };
+        static WITH_BOUND: Command = Command {
+            name: "ex",
+            args: &[&BOUNDED, &AFTER],
+            ..Command::EMPTY
+        };
+        assert_eq!(unfillable_arg(&WITH_BOUND), None);
+
+        // So does a `--`, which is what mise's `run`, `exec` and `git` rely on.
+        static PAST_SEPARATOR: Arg = Arg {
+            name: "args_last",
+            double_dash: DoubleDash::Required,
+            ..Arg::VAR
+        };
+        static WITH_SEPARATOR: Command = Command {
+            name: "ex",
+            args: &[&FILES, &PAST_SEPARATOR],
+            ..Command::EMPTY
+        };
+        assert_eq!(unfillable_arg(&WITH_SEPARATOR), None);
+
+        // But only one separator exists, so nothing can follow the variadic behind it.
+        static AFTER_THE_SEPARATOR: Command = Command {
+            name: "ex",
+            args: &[&PAST_SEPARATOR, &AFTER],
+            ..Command::EMPTY
+        };
+        assert_eq!(unfillable_arg(&AFTER_THE_SEPARATOR), Some("after"));
+
+        // Found at any depth, since a flattened struct can be used by a nested command.
+        static NESTED: Command = Command {
+            name: "outer",
+            subcommands: &[&BROKEN],
+            ..Command::EMPTY
+        };
+        assert_eq!(unfillable_arg(&NESTED), Some("after"));
     }
 
     #[test]

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -32,22 +32,50 @@ use crate::{Arg, Command, DoubleDash, Flag};
 /// to see other expansions — it hashes the type name to keep them apart. That makes
 /// a collision astronomically unlikely rather than impossible, so it is checked
 /// where a CLI is written out, which every adopter does in a test.
+///
+/// Checked *per command*, not across the tree. A key only ever decides between the flags of
+/// the one command in scope, and `#[usage(flatten)]` makes sharing one across commands
+/// ordinary rather than suspect: mise gives a single `ConfigLs` to both `config` and
+/// `config ls`, so that declaration — and its key — is in both tables by design. An earlier
+/// version of this check looked at the whole tree and called that an error.
 fn duplicate_key(cmd: &Command<'_>) -> Option<u64> {
-    let mut keys = std::vec::Vec::new();
-    collect_keys(cmd, &mut keys);
+    let mut keys: std::vec::Vec<u64> = cmd
+        .flags
+        .iter()
+        .map(|f| f.key)
+        .chain(cmd.args.iter().map(|a| a.key))
+        .collect();
     keys.sort_unstable();
-    keys.windows(2)
-        .find(|pair| pair[0] == pair[1])
-        .map(|pair| pair[0])
+    if let Some(pair) = keys.windows(2).find(|pair| pair[0] == pair[1]) {
+        return Some(pair[0]);
+    }
+    cmd.subcommands.iter().find_map(|sub| duplicate_key(sub))
 }
 
-fn collect_keys(cmd: &Command<'_>, keys: &mut std::vec::Vec<u64>) {
-    keys.push(cmd.key);
-    keys.extend(cmd.flags.iter().map(|f| f.key));
-    keys.extend(cmd.args.iter().map(|a| a.key));
-    for sub in cmd.subcommands {
-        collect_keys(sub, keys);
+/// A long or short form that two flags on the same command both answer to, if any.
+///
+/// Within one struct the derive catches this, but `#[usage(flatten)]` joins declarations from
+/// two expansions that cannot see each other — so `--quiet` on a parent and `--quiet` on the
+/// struct it flattens compiles, and then only the first is ever reached. Checked here for the
+/// same reason keys are: this is where the whole tree is visible, and writing a spec out is
+/// something every adopter does in a test.
+fn duplicate_flag_form(cmd: &Command<'_>) -> Option<std::string::String> {
+    let mut forms: std::vec::Vec<std::string::String> = std::vec::Vec::new();
+    for flag in cmd.flags {
+        for long in flag.longs.iter().chain(flag.negate.iter()) {
+            forms.push(std::format!("--{long}"));
+        }
+        for short in flag.shorts {
+            forms.push(std::format!("-{}", *short as char));
+        }
     }
+    forms.sort_unstable();
+    if let Some(pair) = forms.windows(2).find(|pair| pair[0] == pair[1]) {
+        return Some(pair[0].clone());
+    }
+    cmd.subcommands
+        .iter()
+        .find_map(|sub| duplicate_flag_form(sub))
 }
 
 /// A whole CLI: the root command plus what describes the program itself.
@@ -318,10 +346,18 @@ impl Spec<'_> {
     pub fn to_kdl(&self) -> String {
         debug_assert!(
             duplicate_key(self.root.cmd).is_none(),
-            "two things in this CLI share a key ({:?}), so a parse would bind the \
-             wrong one. A derive builds keys from a hash of the type they came from, \
-             so this means two type names collided.",
+            "two things on the same command share a key ({:?}), so a parse would bind the \
+             wrong one. A derive builds keys from a hash of the type they came from, so this \
+             means two type names collided — or one struct was flattened into the same \
+             command twice.",
             duplicate_key(self.root.cmd)
+        );
+        debug_assert!(
+            duplicate_flag_form(self.root.cmd).is_none(),
+            "two flags on the same command answer to {:?}, so only one of them could ever \
+             be reached. With `flatten` this is the collision neither expansion can see: \
+             the parent and the struct it flattens each declared it.",
+            duplicate_flag_form(self.root.cmd)
         );
         let mut out = String::new();
         // Unwrap-free: writing into a String cannot fail, and `write!` returning
@@ -899,8 +935,22 @@ pub trait Subcommands: Sized {
     /// The metadata for the variants, in the same order.
     const METAS: &'static [&'static CommandMeta<'static>];
 
-    /// Take one event, and say whether it belonged to one of these commands.
-    fn apply(partial: &mut Self::Partial, event: &crate::Event<'_, '_>) -> bool;
+    /// Take one event, and say whether it belonged to the selected command.
+    ///
+    /// `selected` is a position in [`Subcommands::COMMANDS`], or `None` before any of them
+    /// has been reached — in which case the event cannot be theirs and nothing is asked.
+    ///
+    /// Only the selected one is asked, which is both cheaper and *necessary*. Cheaper because
+    /// a CLI with a hundred subcommands would otherwise offer every event to all hundred.
+    /// Necessary because two commands can legitimately hold the same declaration once
+    /// `#[usage(flatten)]` exists: mise gives one `ConfigLs` to both `config` and `config ls`,
+    /// so the same key is in both tables, and whichever was asked first would claim the event
+    /// — including a command the user never named.
+    fn apply(
+        partial: &mut Self::Partial,
+        selected: Option<usize>,
+        event: &crate::Event<'_, '_>,
+    ) -> bool;
 
     /// Check the selected command's requirements, and nothing else's.
     ///

--- a/conformance/tests/flatten.rs
+++ b/conformance/tests/flatten.rs
@@ -1,0 +1,200 @@
+//! Sharing declarations between commands.
+//!
+//! mise writes `ConfigLs` once and gives it to both `config` and `config ls`, so that
+//! `mise config --no-header` and `mise config ls --no-header` accept the same flags. Ten
+//! commands do this. It is a Rust-side device with no counterpart in the spec: the emitted
+//! KDL lists the flags inline, exactly as a hand-written command would, because a spec
+//! describes what a CLI accepts and not how the declarations were organised.
+//!
+//! The tables are joined at compile time, so the parser walks one flat slice and flatten
+//! costs nothing at run time.
+
+use std::ffi::OsStr;
+
+use usage::Spec as LibSpec;
+use usage_argv::Error;
+use usage_derive::{Args, Cli, Subcommands};
+
+fn argv<const N: usize>(tokens: [&str; N]) -> [&OsStr; N] {
+    tokens.map(OsStr::new)
+}
+
+/// The shared declarations, as mise's `ConfigLs` is.
+#[derive(Args)]
+struct Listing {
+    /// Do not print a header
+    #[usage(long)]
+    no_header: bool,
+    /// Output format
+    #[usage(long, choices("json", "table"))]
+    format: Option<String>,
+    /// What to list
+    #[usage(arg, name = "WHAT")]
+    what: Option<String>,
+}
+
+/// The subcommand, which holds them directly.
+#[derive(Args)]
+struct ConfigLs {
+    #[usage(flatten)]
+    listing: Listing,
+}
+
+#[derive(Subcommands)]
+enum ConfigCommands {
+    /// List config
+    Ls(Box<ConfigLs>),
+}
+
+/// The parent, which flattens the same struct so a bare `config` behaves like `config ls`.
+#[derive(Args)]
+struct Config {
+    /// Only this file
+    #[usage(long, short = 'f')]
+    file: Option<String>,
+    #[usage(subcommand)]
+    command: Option<ConfigCommands>,
+    #[usage(flatten)]
+    listing: Listing,
+}
+
+#[derive(Subcommands)]
+enum Commands {
+    /// Manage config
+    Config(Box<Config>),
+}
+
+#[derive(Cli)]
+#[usage(bin = "ex")]
+struct Ex {
+    #[usage(subcommand)]
+    command: Option<Commands>,
+}
+
+fn config_of(tokens: &[&OsStr]) -> Config {
+    let Some(Commands::Config(config)) = Ex::parse_from(tokens).expect("should parse").command
+    else {
+        panic!("expected `config`")
+    };
+    *config
+}
+
+#[test]
+fn a_flattened_flag_binds_on_the_command_that_flattened_it() {
+    let a = argv(["config", "--no-header", "--format", "json"]);
+    let config = config_of(&a);
+    assert!(config.listing.no_header);
+    assert_eq!(config.listing.format.as_deref(), Some("json"));
+
+    // And the parent's own flags still work beside them.
+    let a = argv(["config", "-f", "mise.toml", "--no-header"]);
+    let config = config_of(&a);
+    assert_eq!(config.file.as_deref(), Some("mise.toml"));
+    assert!(config.listing.no_header);
+}
+
+#[test]
+fn the_same_struct_serves_two_commands() {
+    // The point of flatten: `config` and `config ls` accept the same flags, declared once.
+    let a = argv(["config", "ls", "--no-header", "keys"]);
+    let config = config_of(&a);
+    let Some(ConfigCommands::Ls(ls)) = config.command else {
+        panic!("expected `ls`")
+    };
+    assert!(ls.listing.no_header);
+    assert_eq!(ls.listing.what.as_deref(), Some("keys"));
+
+    // The parent's copy is untouched: two commands, two sets of values.
+    assert!(!config.listing.no_header);
+}
+
+#[test]
+fn a_flattened_positional_takes_its_declared_place() {
+    let a = argv(["config", "keys"]);
+    let config = config_of(&a);
+    assert_eq!(config.listing.what.as_deref(), Some("keys"));
+}
+
+#[test]
+fn a_flattened_declaration_is_still_checked() {
+    // `choices` lives in the flattened struct, and only its own derive knows about it — so
+    // this proves the delegation runs rather than the flags merely binding.
+    let a = argv(["config", "--format", "yaml"]);
+    match Ex::parse_from(&a) {
+        Err(Error::InvalidChoice { name, choices }) => {
+            assert_eq!(name, "format");
+            assert_eq!(choices, ["json", "table"]);
+        }
+        Err(other) => panic!("wrong error: {other:?}"),
+        Ok(_) => panic!("`yaml` is not one of the choices"),
+    }
+}
+
+#[test]
+fn the_spec_shows_the_flags_inline() {
+    // A spec has no idea of flattening, and does not need one: what reaches the KDL is the
+    // command with every flag it accepts, indistinguishable from one written out by hand.
+    let kdl = Ex::to_kdl();
+    let spec: LibSpec = kdl.parse().expect("valid spec");
+    let config = spec.cmd.subcommands.get("config").expect("config");
+
+    let mut flags: Vec<&str> = config
+        .flags
+        .iter()
+        .flat_map(|f| f.long.iter().map(|l| l.as_str()))
+        .collect();
+    flags.sort_unstable();
+    assert_eq!(flags, ["file", "format", "no-header"], "{kdl}");
+
+    assert_eq!(
+        config
+            .args
+            .iter()
+            .map(|a| a.name.as_str())
+            .collect::<Vec<_>>(),
+        ["WHAT"],
+        "{kdl}"
+    );
+
+    // Help text travels with the declaration, so the shared flags are documented on both.
+    let ls = config.subcommands.get("ls").expect("ls");
+    assert_eq!(
+        ls.flags
+            .iter()
+            .find(|f| f.long.iter().any(|l| l == "no-header"))
+            .and_then(|f| f.help.as_deref()),
+        Some("Do not print a header")
+    );
+
+    // Nothing about the Rust-side arrangement leaks in.
+    assert!(!kdl.contains("flatten"), "{kdl}");
+    assert!(!kdl.contains("listing"), "{kdl}");
+}
+
+/// A struct that flattens something which itself flattens.
+#[derive(Args)]
+struct Outer {
+    /// Whether to be loud
+    #[usage(long)]
+    verbose: bool,
+    #[usage(flatten)]
+    inner: ConfigLs,
+}
+
+#[derive(Cli)]
+#[usage(bin = "nested")]
+struct Nested {
+    #[usage(flatten)]
+    outer: Outer,
+}
+
+#[test]
+fn flattening_nests() {
+    // Nothing special makes this work: every level is the same delegation, so a flatten of a
+    // flatten joins three tables into one.
+    let a = argv(["--verbose", "--no-header", "keys"]);
+    let nested = Nested::parse_from(&a).expect("should parse");
+    assert!(nested.outer.verbose);
+    assert!(nested.outer.inner.listing.no_header);
+    assert_eq!(nested.outer.inner.listing.what.as_deref(), Some("keys"));
+}

--- a/conformance/tests/flatten.rs
+++ b/conformance/tests/flatten.rs
@@ -171,6 +171,65 @@ fn the_spec_shows_the_flags_inline() {
     assert!(!kdl.contains("listing"), "{kdl}");
 }
 
+/// A parent with a required flag of its own, to pit against a flattened rule.
+#[derive(Args)]
+struct Strict {
+    /// Which file — a bare `String`, so it is required
+    #[usage(long)]
+    file: String,
+    #[usage(flatten)]
+    listing: Listing,
+}
+
+#[derive(Subcommands)]
+enum StrictCommands {
+    /// Be strict
+    Strict(Box<Strict>),
+}
+
+#[derive(Cli)]
+#[usage(bin = "strict")]
+struct StrictCli {
+    #[usage(subcommand)]
+    command: Option<StrictCommands>,
+}
+
+#[test]
+fn a_flattened_rule_is_reported_before_the_parent_notices_something_missing() {
+    // Both fail: `yaml` is not a choice, and `--file` was never given. The choice error is
+    // the useful one — it is about a word the user typed, where the other is about one they
+    // did not. Same principle that already puts conflicts before required-ness.
+    //
+    // Asserted because the ordering is easy to get wrong by moving one line, and a comment
+    // claiming it is not the same as a test holding it: the first version of this splice ran
+    // the flattened checks last while its comment said otherwise.
+    let a = argv(["strict", "--format", "yaml"]);
+    match StrictCli::parse_from(&a) {
+        Err(Error::InvalidChoice { name, .. }) => assert_eq!(name, "format"),
+        Err(other) => panic!("the choice error should come first, got: {other:?}"),
+        Ok(_) => panic!("neither rule was satisfied"),
+    }
+
+    // And with nothing typed wrong, the missing flag is still reported.
+    let a = argv(["strict"]);
+    assert!(matches!(
+        StrictCli::parse_from(&a),
+        Err(Error::MissingRequired { .. })
+    ));
+
+    // Satisfying both gives both: a required flag of the parent's own alongside the group it
+    // flattened, which is the arrangement the two rules were competing over.
+    let a = argv(["strict", "--file", "mise.toml", "--format", "json"]);
+    let Some(StrictCommands::Strict(strict)) = StrictCli::parse_from(&a)
+        .expect("both rules satisfied")
+        .command
+    else {
+        panic!("expected `strict`")
+    };
+    assert_eq!(strict.file, "mise.toml");
+    assert_eq!(strict.listing.format.as_deref(), Some("json"));
+}
+
 /// A struct that flattens something which itself flattens.
 #[derive(Args)]
 struct Outer {

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -1761,8 +1761,15 @@ fn displaced_guard(cli: &Cli, field: &Field) -> TokenStream {
 fn post_binding(cli: &Cli) -> TokenStream {
     let sub_check = subcommand_parts(cli).map(|p| p.check).unwrap_or_default();
     // A flattened struct declares its own required-ness and choices, and only it knows them.
-    // Run before this command's own checks, in field order, so the first thing reported is
-    // the first thing declared.
+    //
+    // Run before this command's own required-ness, on the same principle that puts conflicts
+    // first: what the user typed wrong is more useful to hear about than what they left out.
+    // `config --format yaml` should say `yaml` is not one of the choices, even if `--file` is
+    // also missing.
+    //
+    // No finer promise than that. These checks are grouped by kind rather than by field, so
+    // there is no "in declaration order" to offer — a flattened group's errors interleave with
+    // this command's by kind, not by where the field was written.
     let flattened_checks = cli.fields.iter().filter_map(|f| {
         let Kind::Flatten { ty } = &f.kind else {
             return None;
@@ -2061,11 +2068,11 @@ fn post_binding(cli: &Cli) -> TokenStream {
         // more useful of the two answers when a conflict has also left something
         // unfilled, and it is the one usage-lib reports.
         #(#conflict_checks)*
+        #(#flattened_checks)*
         #(#required_checks)*
         #(#relationship_required_checks)*
         #(#choice_checks)*
         #(#bound_checks)*
-        #(#flattened_checks)*
         #sub_check
     }
 }

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -49,16 +49,14 @@ pub fn emit(cli: &Cli) -> TokenStream {
     let flag_metas = flags.iter().enumerate().map(|(i, f)| flag_meta(i, f));
     let arg_metas = args.iter().enumerate().map(|(i, f)| arg_meta(i, f));
 
-    let flag_refs = (0..flags.len()).map(|i| {
-        let name = format_ident!("FLAG_{i}");
-        quote!(&#name)
-    });
-    let arg_refs = (0..args.len()).map(|i| {
-        let name = format_ident!("ARG_{i}");
-        quote!(&#name)
-    });
-    let flag_meta_refs = (0..flags.len()).map(|i| format_ident!("FLAG_META_{i}"));
-    let arg_meta_refs = (0..args.len()).map(|i| format_ident!("ARG_META_{i}"));
+    // Both the plain slices and, when a field is flattened, the joined arrays.
+    let tables = tables(cli);
+    let table_decls = &tables.decls;
+    let meta_table_decls = &tables.meta_decls;
+    let flag_table_ref = &tables.flags;
+    let arg_table_ref = &tables.args;
+    let flag_meta_table_ref = &tables.flag_metas;
+    let arg_meta_table_ref = &tables.arg_metas;
 
     let name = &cli.name;
     let bin = option_str(cli.bin.as_deref());
@@ -81,7 +79,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
     let sub_build = parts.as_ref().map(|p| p.build.clone()).unwrap_or_default();
 
     let partial = partial_struct(cli);
-    let defaults = partial_defaults(cli);
+    let defaults = partial_defaults(cli, false);
     let apply = apply_fn(cli);
     let post = post_binding(cli);
     // `field: local` rather than the shorthand, because the locals are prefixed:
@@ -111,13 +109,14 @@ pub fn emit(cli: &Cli) -> TokenStream {
             #keys
             #(#flag_tables)*
             #(#arg_tables)*
+            #table_decls
 
             pub static ROOT: Command = Command {
                 unknown_flags: #unknown_flags,
                 name: #name,
                 key: #root_key,
-                flags: &[#(#flag_refs),*],
-                args: &[#(#arg_refs),*],
+                flags: #flag_table_ref,
+                args: #arg_table_ref,
                 #sub_commands
                 #sub_default
                 ..Command::EMPTY
@@ -125,6 +124,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
 
             #(#flag_metas)*
             #(#arg_metas)*
+            #meta_table_decls
 
             pub static ROOT_META: CommandMeta = CommandMeta {
                 cmd: &ROOT,
@@ -132,8 +132,8 @@ pub fn emit(cli: &Cli) -> TokenStream {
                 long_about: #long_about,
                 restart_token: #restart_token,
                 mount: #mount,
-                flags: &[#(#flag_meta_refs),*],
-                args: &[#(#arg_meta_refs),*],
+                flags: #flag_meta_table_ref,
+                args: #arg_meta_table_ref,
                 #sub_metas
                 ..CommandMeta::EMPTY
             };
@@ -505,6 +505,154 @@ fn key_ident(kind: &str, index: Option<usize>) -> proc_macro2::Ident {
 /// from the parent scope is not in scope inside it — so a reference to the user's own
 /// type has to say `super::`. An absolute path already resolves from anywhere and is
 /// left alone.
+/// The table expressions for one command, and whatever has to be declared to build them.
+///
+/// Without a `flatten` these are the plain slices the derive has always emitted, so nothing
+/// about an existing CLI's generated code changes. With one, the flattened struct's tables
+/// have to appear inside the parent's — at the position the field was written, because for
+/// positional arguments the position is the meaning — which needs the const-concat helpers
+/// and a `static` to hold each joined array.
+struct Tables {
+    /// Declared before the `Command`: the parse-table groups and their joined arrays.
+    decls: TokenStream,
+    /// Declared after the per-field metadata, which it reads — so it cannot share `decls`.
+    meta_decls: TokenStream,
+    flags: TokenStream,
+    args: TokenStream,
+    flag_metas: TokenStream,
+    arg_metas: TokenStream,
+}
+
+/// Build the four expressions, splicing any flattened groups into place.
+///
+/// Used by both emitters. The first version of the typed-value conversion was wired into only
+/// one of them, which compiled in the tests and not in an adopter's crate — so anything that
+/// belongs to "what a command's tables are" goes here, once.
+fn tables(cli: &Cli) -> Tables {
+    // What a group is: a run of this struct's own declarations, or one flattened struct's
+    // whole table. Walked in field order so the runs and the splices interleave correctly.
+    let mut flag_groups: Vec<TokenStream> = Vec::new();
+    let mut arg_groups: Vec<TokenStream> = Vec::new();
+    let mut flag_meta_groups: Vec<TokenStream> = Vec::new();
+    let mut arg_meta_groups: Vec<TokenStream> = Vec::new();
+    let mut own_flags: Vec<usize> = Vec::new();
+    let mut own_args: Vec<usize> = Vec::new();
+    let (mut flag_at, mut arg_at) = (0usize, 0usize);
+    let mut flattened = false;
+
+    // Flush the runs collected so far, so that what follows lands after them.
+    fn flush_flags(
+        own: &mut Vec<usize>,
+        groups: &mut Vec<TokenStream>,
+        metas: &mut Vec<TokenStream>,
+    ) {
+        if own.is_empty() {
+            return;
+        }
+        let refs = own.iter().map(|i| {
+            let name = format_ident!("FLAG_{i}");
+            quote!(&#name)
+        });
+        groups.push(quote!(&[#(#refs),*]));
+        let meta_refs = own.iter().map(|i| format_ident!("FLAG_META_{i}"));
+        metas.push(quote!(&[#(#meta_refs),*]));
+        own.clear();
+    }
+    fn flush_args(
+        own: &mut Vec<usize>,
+        groups: &mut Vec<TokenStream>,
+        metas: &mut Vec<TokenStream>,
+    ) {
+        if own.is_empty() {
+            return;
+        }
+        let refs = own.iter().map(|i| {
+            let name = format_ident!("ARG_{i}");
+            quote!(&#name)
+        });
+        groups.push(quote!(&[#(#refs),*]));
+        let meta_refs = own.iter().map(|i| format_ident!("ARG_META_{i}"));
+        metas.push(quote!(&[#(#meta_refs),*]));
+        own.clear();
+    }
+
+    for field in &cli.fields {
+        match &field.kind {
+            Kind::Flag { .. } => {
+                own_flags.push(flag_at);
+                flag_at += 1;
+            }
+            Kind::Arg { .. } => {
+                own_args.push(arg_at);
+                arg_at += 1;
+            }
+            Kind::Flatten { ty } => {
+                flattened = true;
+                flush_flags(&mut own_flags, &mut flag_groups, &mut flag_meta_groups);
+                flush_args(&mut own_args, &mut arg_groups, &mut arg_meta_groups);
+                let ty = in_module(ty);
+                flag_groups.push(quote!(<#ty as ::usage_argv::spec::CommandArgs>::COMMAND.flags));
+                arg_groups.push(quote!(<#ty as ::usage_argv::spec::CommandArgs>::COMMAND.args));
+                flag_meta_groups.push(quote!(<#ty as ::usage_argv::spec::CommandArgs>::META.flags));
+                arg_meta_groups.push(quote!(<#ty as ::usage_argv::spec::CommandArgs>::META.args));
+            }
+            Kind::Subcommand { .. } => {}
+        }
+    }
+    flush_flags(&mut own_flags, &mut flag_groups, &mut flag_meta_groups);
+    flush_args(&mut own_args, &mut arg_groups, &mut arg_meta_groups);
+
+    if !flattened {
+        // The shape every CLI without a flatten already had.
+        let flag_refs = (0..flag_at).map(|i| {
+            let name = format_ident!("FLAG_{i}");
+            quote!(&#name)
+        });
+        let arg_refs = (0..arg_at).map(|i| {
+            let name = format_ident!("ARG_{i}");
+            quote!(&#name)
+        });
+        let flag_meta_refs = (0..flag_at).map(|i| format_ident!("FLAG_META_{i}"));
+        let arg_meta_refs = (0..arg_at).map(|i| format_ident!("ARG_META_{i}"));
+        return Tables {
+            decls: TokenStream::new(),
+            meta_decls: TokenStream::new(),
+            flags: quote!(&[#(#flag_refs),*]),
+            args: quote!(&[#(#arg_refs),*]),
+            flag_metas: quote!(&[#(#flag_meta_refs),*]),
+            arg_metas: quote!(&[#(#arg_meta_refs),*]),
+        };
+    }
+
+    Tables {
+        decls: quote! {
+            const FLAG_GROUPS: &[&[&::usage_argv::Flag<'static>]] = &[#(#flag_groups),*];
+            const ARG_GROUPS: &[&[&::usage_argv::Arg<'static>]] = &[#(#arg_groups),*];
+            static FLAGS: [&::usage_argv::Flag<'static>;
+                ::usage_argv::table_len(FLAG_GROUPS)] =
+                ::usage_argv::concat_flags(FLAG_GROUPS);
+            static ARGS: [&::usage_argv::Arg<'static>; ::usage_argv::table_len(ARG_GROUPS)] =
+                ::usage_argv::concat_args(ARG_GROUPS);
+        },
+        meta_decls: quote! {
+            const FLAG_META_GROUPS: &[&[::usage_argv::spec::FlagMeta<'static>]] =
+                &[#(#flag_meta_groups),*];
+            const ARG_META_GROUPS: &[&[::usage_argv::spec::ArgMeta<'static>]] =
+                &[#(#arg_meta_groups),*];
+            static FLAG_METAS: [::usage_argv::spec::FlagMeta<'static>;
+                ::usage_argv::table_len(FLAG_META_GROUPS)] =
+                ::usage_argv::spec::concat_flag_metas(FLAG_META_GROUPS);
+            static ARG_METAS: [::usage_argv::spec::ArgMeta<'static>;
+                ::usage_argv::table_len(ARG_META_GROUPS)] =
+                ::usage_argv::spec::concat_arg_metas(ARG_META_GROUPS);
+        },
+        flags: quote!(&FLAGS),
+        args: quote!(&ARGS),
+        flag_metas: quote!(&FLAG_METAS),
+        arg_metas: quote!(&ARG_METAS),
+    }
+}
+
 fn in_module(ty: &syn::Type) -> TokenStream {
     let syn::Type::Path(path) = ty else {
         return quote!(#ty);
@@ -666,6 +814,15 @@ fn partial_struct(cli: &Cli) -> TokenStream {
             // Its values live in the enum's own partial.
             return None;
         }
+        // A flattened struct accumulates into its own partial, whose shape only its derive
+        // knows — reached through the trait, like everything else about it.
+        if let Kind::Flatten { ty } = &f.kind {
+            let ident = &f.ident;
+            let ty = in_module(ty);
+            return Some(quote! {
+                pub #ident: <#ty as ::usage_argv::spec::CommandArgs>::Partial,
+            });
+        }
         let ident = &f.ident;
         let ty = match f.shape {
             Shape::Bool => quote!(bool),
@@ -709,13 +866,32 @@ fn partial_struct(cli: &Cli) -> TokenStream {
 ///
 /// A declared `default` has to be in place before parsing starts, since nothing
 /// later distinguishes "the default" from "what the user typed".
-fn partial_defaults(cli: &Cli) -> TokenStream {
+/// `inside_module` says where this will be spliced, which changes how a flattened struct's
+/// type has to be named: the root's defaults are built in `parse_from`, in the impl beside the
+/// user's struct, while a nested command's are built by `start()` inside the generated module —
+/// where the same path needs a `super::`. Nothing else in here cares, and getting it wrong is a
+/// compile error in the adopter's crate rather than here, so it is a parameter rather than a
+/// guess.
+fn partial_defaults(cli: &Cli, inside_module: bool) -> TokenStream {
     let sub_starts = subcommand_parts(cli)
         .map(|p| p.partial_starts)
         .unwrap_or_default();
     let plain = cli.fields.iter().filter_map(|f| {
         if matches!(f.kind, Kind::Subcommand { .. }) {
             return None;
+        }
+        // `start()` rather than `Default`, so the flattened struct's own defaults are in
+        // place before parsing — the same reason this function exists at all.
+        if let Kind::Flatten { ty } = &f.kind {
+            let ident = &f.ident;
+            let ty = if inside_module {
+                in_module(ty)
+            } else {
+                quote!(#ty)
+            };
+            return Some(quote! {
+                #ident: <#ty as ::usage_argv::spec::CommandArgs>::start(),
+            });
         }
         let ident = &f.ident;
         let given = format_ident!("__given_{}", ident);
@@ -749,6 +925,17 @@ fn partial_defaults(cli: &Cli) -> TokenStream {
 fn field_final(field: &Field) -> TokenStream {
     let ident = &field.ident;
     let name = &field.name;
+    if let Kind::Flatten { ty } = &field.kind {
+        // Built by its own derive, which is also what makes a nested flatten work: this is
+        // the same call at every level.
+        //
+        // Named directly rather than through `in_module`: `build` is emitted in the impl
+        // beside the user's struct, not inside the generated module, so a `super::` here
+        // would climb one level too far.
+        return quote! {
+            #ident: <#ty as ::usage_argv::spec::CommandArgs>::build(partial.#ident)?
+        };
+    }
     let Some(ty) = field.value_ty.as_ref() else {
         // A switch or a count: nothing was parsed from a word.
         return quote!(#ident: partial.#ident);
@@ -995,6 +1182,21 @@ fn reset_to_default(field: &Field) -> TokenStream {
 /// Take one event and say whether it belonged to this command.
 fn apply_fn(cli: &Cli) -> TokenStream {
     let route = subcommand_parts(cli).map(|p| p.route).unwrap_or_default();
+    // A flattened struct's flags are in this command's table, but its *keys* were minted in
+    // its own expansion — so they cannot be matched here. Its `apply` recognises them, and
+    // says whether it took the event.
+    let flattened = cli.fields.iter().filter_map(|f| {
+        let Kind::Flatten { ty } = &f.kind else {
+            return None;
+        };
+        let ident = &f.ident;
+        let ty = in_module(ty);
+        Some(quote! {
+            if <#ty as ::usage_argv::spec::CommandArgs>::apply(&mut partial.#ident, event) {
+                return true;
+            }
+        })
+    });
     let flags: Vec<&Field> = cli
         .fields
         .iter()
@@ -1015,6 +1217,7 @@ fn apply_fn(cli: &Cli) -> TokenStream {
         ) -> bool {
             use ::usage_argv::Event;
             #route
+            #(#flattened)*
             // Each arm evaluates to whether it claimed the event, rather than
             // returning: a command with no flags of its own would otherwise have every
             // arm diverge, leaving an unreachable tail.
@@ -1149,8 +1352,12 @@ fn subcommand_parts(cli: &Cli) -> Option<SubcommandParts> {
                     partial.__usage_selected = ::std::option::Option::Some(__usage_at);
                 }
             }
+            // Only the selected one is asked — see `Subcommands::apply`. The selection is
+            // set just above, so a command word reaches the command it named on the same
+            // event that selected it.
             if <#in_mod as ::usage_argv::spec::Subcommands>::apply(
                 &mut partial.__usage_sub,
+                partial.__usage_selected,
                 event,
             ) {
                 return true;
@@ -1193,22 +1400,20 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
     let arg_tables = args.iter().enumerate().map(|(i, f)| arg_table(i, f));
     let flag_metas = flags.iter().enumerate().map(|(i, f)| flag_meta(i, f));
     let arg_metas = args.iter().enumerate().map(|(i, f)| arg_meta(i, f));
-    let flag_refs = (0..flags.len()).map(|i| {
-        let name = format_ident!("FLAG_{i}");
-        quote!(&#name)
-    });
-    let arg_refs = (0..args.len()).map(|i| {
-        let name = format_ident!("ARG_{i}");
-        quote!(&#name)
-    });
-    let flag_meta_refs = (0..flags.len()).map(|i| format_ident!("FLAG_META_{i}"));
-    let arg_meta_refs = (0..args.len()).map(|i| format_ident!("ARG_META_{i}"));
+    // Both the plain slices and, when a field is flattened, the joined arrays.
+    let tables = tables(cli);
+    let table_decls = &tables.decls;
+    let meta_table_decls = &tables.meta_decls;
+    let flag_table_ref = &tables.flags;
+    let arg_table_ref = &tables.args;
+    let flag_meta_table_ref = &tables.flag_metas;
+    let arg_meta_table_ref = &tables.arg_metas;
 
     let name = &cli.name;
     let about = option_str(cli.about.as_deref());
     let long_about = option_str(cli.long_about.as_deref());
     let partial = partial_struct(cli);
-    let defaults = partial_defaults(cli);
+    let defaults = partial_defaults(cli, true);
     let apply = apply_fn(cli);
     let post = post_binding(cli);
     let parts = subcommand_parts(cli);
@@ -1245,18 +1450,20 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
             #keys
             #(#flag_tables)*
             #(#arg_tables)*
+            #table_decls
 
             pub static COMMAND: Command = Command {
                 name: #name,
                 key: #command_key,
-                flags: &[#(#flag_refs),*],
-                args: &[#(#arg_refs),*],
+                flags: #flag_table_ref,
+                args: #arg_table_ref,
                 #sub_commands
                 ..Command::EMPTY
             };
 
             #(#flag_metas)*
             #(#arg_metas)*
+            #meta_table_decls
 
             pub static COMMAND_META: CommandMeta = CommandMeta {
                 cmd: &COMMAND,
@@ -1264,8 +1471,8 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
                 long_about: #long_about,
                 restart_token: #restart_token,
                 mount: #mount,
-                flags: &[#(#flag_meta_refs),*],
-                args: &[#(#arg_meta_refs),*],
+                flags: #flag_meta_table_ref,
+                args: #arg_meta_table_ref,
                 #sub_metas
                 ..CommandMeta::EMPTY
             };
@@ -1363,8 +1570,8 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
         let field = format_ident!("v{i}");
         let ty = &v.ty;
         quote! {
-            if <#ty as ::usage_argv::spec::CommandArgs>::apply(&mut partial.#field, event) {
-                return true;
+            ::std::option::Option::Some(#i) => {
+                <#ty as ::usage_argv::spec::CommandArgs>::apply(&mut partial.#field, event)
             }
         }
     });
@@ -1494,10 +1701,15 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
 
             fn apply(
                 partial: &mut Self::Partial,
+                selected: ::std::option::Option<usize>,
                 event: &::usage_argv::Event<'_, '_>,
             ) -> bool {
-                #(#applies)*
-                false
+                match selected {
+                    #(#applies)*
+                    // Nothing selected yet, or a position that cannot be produced: the event
+                    // is not one of these commands'.
+                    _ => false,
+                }
             }
 
             fn check<'t, 'v>(
@@ -1548,6 +1760,19 @@ fn displaced_guard(cli: &Cli, field: &Field) -> TokenStream {
 /// from the environment or a default.
 fn post_binding(cli: &Cli) -> TokenStream {
     let sub_check = subcommand_parts(cli).map(|p| p.check).unwrap_or_default();
+    // A flattened struct declares its own required-ness and choices, and only it knows them.
+    // Run before this command's own checks, in field order, so the first thing reported is
+    // the first thing declared.
+    let flattened_checks = cli.fields.iter().filter_map(|f| {
+        let Kind::Flatten { ty } = &f.kind else {
+            return None;
+        };
+        let ident = &f.ident;
+        let ty = in_module(ty);
+        Some(quote! {
+            <#ty as ::usage_argv::spec::CommandArgs>::check(&mut partial.#ident)?;
+        })
+    });
     // Applied here rather than in `start`, and this is not a detail: `start` builds the
     // partial for *every* command in the CLI, selected or not, so a declared default was
     // costing a `String` per default per command — 60 allocations to parse a bare `mise`,
@@ -1840,6 +2065,7 @@ fn post_binding(cli: &Cli) -> TokenStream {
         #(#relationship_required_checks)*
         #(#choice_checks)*
         #(#bound_checks)*
+        #(#flattened_checks)*
         #sub_check
     }
 }

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -116,6 +116,21 @@ pub enum Kind {
     /// enum's definition: the generated code names it through the
     /// [`Subcommands`](usage_argv::spec::Subcommands) trait, which is also how it
     /// reaches the type that accumulates a subcommand's values.
+    /// Holds a struct whose flags and arguments belong to *this* command.
+    ///
+    /// A Rust-side device for sharing declarations between commands — mise writes one
+    /// `ConfigLs` and gives it to both `config` and `config ls`. The spec has no such idea,
+    /// and does not need one: the emitted KDL lists the flags inline, exactly as a
+    /// hand-written command would.
+    ///
+    /// The type is carried rather than resolved, as for a subcommand: the derive cannot see
+    /// the other struct's fields, so everything goes through
+    /// [`CommandArgs`](usage_argv::spec::CommandArgs) — including the tables, which are
+    /// joined into the parent's at compile time.
+    Flatten {
+        /// The struct's type, as written.
+        ty: syn::Type,
+    },
     Subcommand {
         /// The enum's type, as written.
         ty: syn::Type,
@@ -370,6 +385,12 @@ impl Cli {
                         seen_short.push((*short, field.span));
                     }
                 }
+                // Nothing to check here: the flattened struct's own derive checked its
+                // declarations, and a collision *across* the two is invisible from either
+                // side — both expansions see a type name and no fields. That case is caught
+                // where the whole tree is visible, by the duplicate-form check in
+                // `Spec::to_kdl`.
+                Kind::Flatten { .. } => {}
                 Kind::Arg {
                     double_dash_required,
                 } => {
@@ -465,6 +486,95 @@ fn dup(span: Span, first: Span, message: &str) -> syn::Error {
 }
 
 impl Field {
+    /// A field marked `#[usage(flatten)]`, if this is one.
+    ///
+    /// Recognized before flags and arguments for the same reason a subcommand is: the field
+    /// holds a whole command's worth of declarations, so none of what describes a single
+    /// value applies to it. A doc comment on it describes nothing that reaches the spec,
+    /// since the flattened struct's own fields carry their own help.
+    fn flatten(
+        field: &syn::Field,
+        ident: &syn::Ident,
+        span: proc_macro2::Span,
+    ) -> syn::Result<Option<Self>> {
+        let mut found = false;
+        for attr in attrs(&field.attrs) {
+            for meta in nested(attr)? {
+                if ident_of(&meta.path().clone()) != "flatten" {
+                    continue;
+                }
+                if !matches!(meta, Meta::Path(_)) {
+                    return Err(syn::Error::new_spanned(
+                        meta.path(),
+                        "`flatten` takes no value: the struct it holds is the field's type",
+                    ));
+                }
+                found = true;
+            }
+        }
+        if !found {
+            return Ok(None);
+        }
+
+        // Nothing else may be declared beside it. `#[usage(flatten, long)]` reads as though
+        // the flattening were also a flag, and there is no such thing.
+        for attr in attrs(&field.attrs) {
+            for meta in nested(attr)? {
+                let name = ident_of(&meta.path().clone());
+                if name != "flatten" {
+                    return Err(syn::Error::new_spanned(
+                        meta.path(),
+                        format!(
+                            "`flatten` cannot be combined with `{name}`: the flattened \
+                             struct's own fields declare what they are"
+                        ),
+                    ));
+                }
+            }
+        }
+
+        // `Option<T>` would mean "the whole group, or nothing" — which needs a rule for what
+        // makes it present, and clap's answer (any of its fields given) is not obviously the
+        // right one. Refused for now rather than guessed at; nothing in the fleet uses it.
+        if type_name(&field.ty).starts_with("Option<") {
+            return Err(syn::Error::new_spanned(
+                &field.ty,
+                "`flatten` on an `Option` is not supported: it would have to decide when the \
+                 group counts as given. Hold the struct directly",
+            ));
+        }
+
+        Ok(Some(Field {
+            ident: ident.clone(),
+            ty: field.ty.clone(),
+            name: to_kebab(&ident.to_string()),
+            kind: Kind::Flatten {
+                ty: field.ty.clone(),
+            },
+            // A flattened field holds declarations, not a value, so none of what describes a
+            // value applies — the same as a subcommand field.
+            shape: Shape::Bool,
+            value_ty: None,
+            optional_collection: false,
+            help: None,
+            long_help: None,
+            env: None,
+            default: None,
+            help_heading: None,
+            choices: Vec::new(),
+            value_enum: false,
+            var_min: None,
+            var_max: None,
+            overrides: Vec::new(),
+            conflicts: Vec::new(),
+            required_if: Vec::new(),
+            required_unless: Vec::new(),
+            hide: false,
+            repeatable: false,
+            span,
+        }))
+    }
+
     /// A field marked `#[usage(subcommand)]`, if this is one.
     fn subcommand(
         field: &syn::Field,
@@ -542,6 +652,9 @@ impl Field {
         // their options, so it is recognized before any of them are read.
         if let Some(subcommand) = Self::subcommand(field, &ident, span)? {
             return Ok(subcommand);
+        }
+        if let Some(flattened) = Self::flatten(field, &ident, span)? {
+            return Ok(flattened);
         }
 
         let mut name = to_kebab(&ident.to_string());
@@ -1816,6 +1929,53 @@ mod tests {
         "#,
         );
         assert!(err.contains("is not ASCII"), "unhelpful message: {err}");
+    }
+
+    #[test]
+    fn flatten_cannot_be_combined_with_a_flag() {
+        // `#[usage(flatten, long)]` reads as though the flattening were also a flag, and
+        // there is no such thing — the flattened struct's own fields say what they are.
+        let err = rejection(
+            r#"
+            struct Ex {
+                #[usage(flatten, long)]
+                shared: Shared,
+            }
+        "#,
+        );
+        assert!(
+            err.contains("cannot be combined with `long`"),
+            "unhelpful message: {err}"
+        );
+    }
+
+    #[test]
+    fn flatten_takes_no_value() {
+        let err = rejection(
+            r#"
+            struct Ex {
+                #[usage(flatten = "shared")]
+                shared: Shared,
+            }
+        "#,
+        );
+        assert!(err.contains("takes no value"), "unhelpful message: {err}");
+    }
+
+    #[test]
+    fn flatten_on_an_option_is_refused_rather_than_guessed_at() {
+        // `Option<T>` would mean "the whole group, or nothing", which needs a rule for when
+        // the group counts as given. clap's answer is "any of its fields" — defensible, not
+        // obviously right, and nothing in the fleet asks for it. Refused until something does.
+        let err = rejection(
+            r#"
+            struct Ex {
+                #[usage(flatten)]
+                shared: Option<Shared>,
+            }
+        "#,
+        );
+        assert!(err.contains("not supported"), "unhelpful message: {err}");
     }
 
     #[test]


### PR DESCRIPTION
mise writes `ConfigLs` once and gives it to both `config` and `config ls`, so that
`mise config --no-header` and `mise config ls --no-header` accept the same flags. Ten
commands do that. `#[usage(flatten)]` is how the derive expresses it.

The tables are joined at compile time, so the parser walks one flat slice and flatten costs
nothing at run time. A flattened group lands at the field's position rather than the end,
which positional arguments require: position is their identity. Everything else is
delegation through `CommandArgs` — the partial, `start`, `apply`, `check`, `build` — which
is also why a flatten of a flatten needs nothing extra.

Nothing new in the spec. Flattening is a Rust-side arrangement, and the emitted KDL lists
the flags inline exactly as a hand-written command would, because a spec describes what a
CLI accepts and not how the declarations were organised.

`Option<T>` flatten is refused rather than guessed at: it needs a rule for when the group
counts as given, clap's answer is not obviously the right one, and nothing in the fleet
asks for it.

## The bug this found

`Subcommands::apply` offered every event to *every* variant and took the first that claimed
it. That was harmless only because keys were unique per command — and flatten breaks that,
since two commands sharing a declaration share its key. So `config --no-header` bound the
flag on the unselected `config ls`, and the value vanished.

Only the selected variant is asked now, which is correct and much cheaper: at mise's scale
the root had about a hundred variants, each asked for every event. Measured against the
parent branch, same machine and fixture:

    instructions   40,179 -> 29,850   -26%
    wall            1,893ns -> 822ns  -57%

176x clap's instruction count. Allocations unchanged: 0 for a bare `mise`, 4 bound. The
wall-clock gain outruns the instruction count because what disappeared was calls, not
arithmetic.

`duplicate_key` asserted that no key appeared twice in the whole tree, and sharing one
across commands is now ordinary rather than suspect — so it checks per command, which is
the level a key decides anything at. The collision flatten *can* cause is the opposite one:
a parent and the struct it flattens both declaring `--quiet`, which neither expansion can
see. `Spec::to_kdl` grew a duplicate-form check beside the key one, where the whole tree is
visible.

`partial_defaults` now takes whether it is being spliced inside the generated module,
because a flattened type is named differently either side of that boundary and getting it
wrong is a compile error in the adopter's crate rather than here.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core parse routing (`Subcommands::apply`) and codegen for all commands with flatten; behavior change is intentional and tested, but any code implementing `Subcommands` manually must adopt the new `apply` signature.
> 
> **Overview**
> **`#[usage(flatten)]`** lets one `Args` struct’s flags and positionals be merged into a parent command at **compile time** via `concat_flags` / `concat_args`, so the parser still walks a single flat table with no runtime cost. Wiring is delegation through `CommandArgs` (partial, `start`, `apply`, `check`, `build`); nested flatten is the same pattern. Emitted KDL inlines the flags with no “flatten” in the spec. **`Option<T>` flatten** is rejected at derive time.
> 
> **`Subcommands::apply`** now takes `selected: Option<usize>` and only forwards events to the **chosen** subcommand. Previously every variant was tried and the first match won, which broke flatten (shared keys) — e.g. `config --no-header` binding on unselected `config ls` — and was expensive at mise scale (~26% fewer instructions, ~57% less wall time in the PR notes).
> 
> **`Spec::to_kdl`** debug checks were tightened for flatten: **`duplicate_key`** is per-command (shared keys across commands are OK); new **`duplicate_flag_form`** (same `--long` on parent + flattened child) and **`unfillable_arg`** (unbounded variadic before a later positional across a flatten boundary).
> 
> Conformance tests cover mise-style `config` / `config ls` sharing, KDL output, nested flatten, and post-bind error ordering (flattened `choices` before parent `required`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cea70a21e70762c115abd5ca4cea085438ae9df1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## The bug this found, and the 26% it was costing

`Subcommands::apply` offered every event to **every** variant and took the first that claimed
it. That was harmless only because keys were unique per command — and flatten breaks that
premise, since two commands sharing a declaration share its key. So `config --no-header` bound
the flag on the *unselected* `config ls`, and the value vanished from the command the user named.

Only the selected variant is asked now. That is the correct rule, and at mise's scale it is also
where a quarter of the parse was going: the root has about a hundred variants, each asked for
every event.

| | parent (#851) | this branch |
|---|---:|---:|
| instructions, cold parse | 40,179 | **29,850** (−26%) |
| wall, in-process | 1,893 ns | **822 ns** (−57%) |
| allocations, bare / bound | 0 / 4 | 0 / 4 |

Measured on one machine, same fixture, differencing `PARSE_N=0`/`1` runs of the same binary.
**176× clap's instruction count**, against 448.94 µs of clap wall time. The wall gain outruns
the instruction count because what disappeared was calls, not arithmetic — a hundred
non-inlined calls per event costs more in branch prediction and icache than cachegrind's
count suggests.

## Design

- **Tables joined at compile time** (#851), so the parser walks one flat slice and flatten
  costs nothing at run time. A flattened group lands at the field's declared position, which
  positionals require.
- **Everything else is delegation** through `CommandArgs`: the partial, `start`, `apply`,
  `check`, `build`. That is also why a flatten of a flatten needs nothing extra — every level
  is the same call.
- **Nothing new in the spec.** Flattening is a Rust-side arrangement; the emitted KDL lists the
  flags inline exactly as a hand-written command would. A test asserts neither `flatten` nor
  the field name appears anywhere in the output.
- **`Option<T>` flatten is refused**, not guessed at: it needs a rule for when the group counts
  as given, clap's answer ("any field given") is defensible rather than obviously right, and
  nothing in the fleet asks for it.

## Two invariants that had to move

`duplicate_key` asserted no key appeared twice in the whole tree. Sharing one across commands
is now ordinary rather than suspect, so it checks **per command** — the level at which a key
actually decides anything.

The collision flatten *can* cause is the opposite one: a parent and the struct it flattens both
declaring `--quiet`, which neither expansion can see. `Spec::to_kdl` grew a duplicate-form check
beside the key one, where the whole tree is visible and which every adopter runs in a test.

## Verification

- Six tests on mise's real shape: one `Listing` flattened into both `config` and `config ls`,
  the parent's own flags beside them, a flattened positional in its declared place, a flattened
  `choices` still enforced (which proves the `check` delegation runs rather than the flags
  merely binding), the emitted spec, and a nested flatten.
- Mutation-checked: restoring "ask every variant" fails three of them.
- Three compile-time refusals tested — `flatten` with another attribute, with a value, and on
  an `Option`.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*
