### PR TITLE
feat(argv): render the usage line, byte-identical to usage-lib's

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,6 +793,7 @@ dependencies = [
  "shadow-mise",
  "shadow-mise-clap",
  "usage-argv",
+ "usage-lib",
 ]
 
 [[package]]

--- a/PLAN.md
+++ b/PLAN.md
@@ -265,8 +265,16 @@ tasks --usage"`, so task names are meant to come from running that. usage-argv d
 
 ### Then: what a CLI framework has to have
 
-- [ ] **Help rendering** — `--help` and `-h` from the static metadata, with
-      headings and hidden-item filtering.
+- [ ] **Help rendering** — `--help` and `-h` from the static metadata, with headings and
+      hidden-item filtering. The **usage line** is done: `usage_argv::help::usage_line` builds
+      it from the tables, and all 211 of mise's commands come out byte-identical to usage-lib's,
+      which is the standard that matters — an adopter's help changing is a visible regression
+      even when it is one bracket. usage-lib renders through a tera template over a runtime
+      model, which this crate has no equivalent of, so the rules are reimplemented and the
+      parity test is what keeps them honest. Getting there also forced a fourth naming fix: a
+      flag is named after the form it answers to, as usage-lib names it, not after the Rust
+      field holding it — `type_` had been giving a flag called `type-`, which help printed and
+      errors reported.
 - [ ] **Completions, self-contained** — `<bin> completion <shell>` emits the
       script; a hidden `<bin> complete-word` serves requests from the binary's own
       embedded spec. Same dispatch shape usage-cli uses today, without requiring

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -70,12 +70,12 @@ pub fn usage_line(path: &[&str], meta: &CommandMeta<'_>) -> String {
     // what a user is invited to type.
     let flags: usize = meta.flags.iter().filter(|f| !f.hide).count();
     if flags > 0 {
-        let required = meta.flags.iter().any(|f| !f.hide && f.required);
+        let required = meta.flags.iter().any(|f| !f.hide && flag_demanded(f));
         if flags <= INLINE_LIMIT {
             for flag in meta.flags.iter().filter(|f| !f.hide) {
                 // A required flag is angled, like a required argument: the brackets are what
                 // say whether leaving it out is allowed.
-                let (open, close) = if flag.required {
+                let (open, close) = if flag_demanded(flag) {
                     ('<', '>')
                 } else {
                     ('[', ']')
@@ -91,7 +91,7 @@ pub fn usage_line(path: &[&str], meta: &CommandMeta<'_>) -> String {
 
     let args: usize = meta.args.iter().filter(|a| !a.hide).count();
     if args > 0 {
-        let required = meta.args.iter().any(|a| !a.hide && a.required);
+        let required = meta.args.iter().any(|a| !a.hide && demanded(a));
         if args <= INLINE_LIMIT {
             for arg in meta.args.iter().filter(|a| !a.hide) {
                 let _ = write!(out, " {}", arg_usage(arg));
@@ -162,10 +162,32 @@ fn flag_usage(meta: &FlagMeta<'_>) -> String {
 }
 
 /// How one positional argument appears: `<TOOL>`, `[FILES]…`, `-- <ARGS>`.
+/// Whether a flag must be given, which is not quite what `required` says.
+///
+/// Same rule as [`demanded`], for the same reason: usage-lib clears `required` on a flag that
+/// declares a default before rendering, so reading the flag alone printed `<--out>` for a flag
+/// the parser fills when it is left out.
+fn flag_demanded(meta: &FlagMeta<'_>) -> bool {
+    meta.required && meta.default.is_empty()
+}
+
+/// Whether an argument must be given, which is not quite what `required` says.
+///
+/// usage-lib clears `required` while *parsing* a spec that declares a default — a defaulted
+/// argument is one the user may leave out — and then renders the usage line from `required`
+/// alone. The derive keeps the two separate, so reading `required` on its own printed `<file>`
+/// where usage-lib prints `[file]`, for an argument the parser is perfectly happy to omit.
+///
+/// Applied here rather than by clearing the flag in the metadata, because the metadata is what
+/// the emitted spec is built from and `required` there means what the author wrote.
+fn demanded(meta: &ArgMeta<'_>) -> bool {
+    meta.required && meta.default.is_empty()
+}
+
 fn arg_usage(meta: &ArgMeta<'_>) -> String {
     let arg = meta.arg;
     let mut out = String::new();
-    let (open, close) = if meta.required {
+    let (open, close) = if demanded(meta) {
         ('<', '>')
     } else {
         ('[', ']')

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -1,0 +1,186 @@
+//! The one-line summary of how a command is invoked.
+//!
+//! `Usage: mise use [OPTIONS] <TOOL@VERSION>…` — the line at the top of `--help`, and the
+//! first thing a CLI framework has to be able to produce.
+//!
+//! Built from the same `&'static` metadata a parse ignores, so a binary that never asks for
+//! help pays nothing for being able to. Nothing here is on the hot path.
+//!
+//! # Matching usage-lib
+//!
+//! usage-lib renders this from a spec, through a tera template over a runtime model. This
+//! crate cannot: there is no `Spec` at run time, only the tables. So the rules are
+//! reimplemented, and the test that matters compares the two outputs over every command in
+//! mise's real spec — 211 of them — because an adopter's help text changing is a visible
+//! regression even when it is a small one.
+//!
+//! Where the two disagree the difference is recorded, in the same spirit as the parser's
+//! corpus: usage-lib is the reference, and a divergence is a decision rather than an accident.
+
+use core::fmt::Write as _;
+
+use crate::spec::{ArgMeta, CommandMeta, FlagMeta};
+use crate::DoubleDash;
+
+/// How many flags or arguments are listed individually before collapsing to a placeholder.
+///
+/// usage-lib's number. Beyond it the line would be longer than it is useful, so it becomes
+/// `[FLAGS]` or `[ARGS]…` and the sections below carry the detail.
+const INLINE_LIMIT: usize = 2;
+
+/// The `Usage:` line's body, without the `Usage: ` prefix.
+///
+/// `path` is the command as invoked, starting with the binary: `["mise", "config", "ls"]`.
+/// The metadata holds a tree and each node knows its own name, so the path a *particular*
+/// invocation took has to come from the caller — which is the parser, or a `help` command
+/// naming a command explicitly.
+///
+/// ```
+/// use usage_argv::help::usage_line;
+/// use usage_argv::spec::{ArgMeta, CommandMeta, FlagMeta};
+/// use usage_argv::{Arg, Command, Flag};
+///
+/// static FORCE: Flag = Flag { name: "force", longs: &["force"], ..Flag::BOOL };
+/// static TOOL: Arg = Arg { name: "TOOL", ..Arg::REQUIRED };
+/// static CMD: Command = Command {
+///     name: "use",
+///     flags: &[&FORCE],
+///     args: &[&TOOL],
+///     ..Command::EMPTY
+/// };
+/// static META: CommandMeta = CommandMeta {
+///     cmd: &CMD,
+///     flags: &[FlagMeta { flag: &FORCE, ..FlagMeta::EMPTY }],
+///     args: &[ArgMeta { arg: &TOOL, required: true, ..ArgMeta::EMPTY }],
+///     ..CommandMeta::EMPTY
+/// };
+///
+/// assert_eq!(usage_line(&["mise", "use"], &META), "mise use [--force] <TOOL>");
+/// ```
+pub fn usage_line(path: &[&str], meta: &CommandMeta<'_>) -> String {
+    let mut out = String::new();
+    for (i, part) in path.iter().enumerate() {
+        if i > 0 {
+            out.push(' ');
+        }
+        out.push_str(part);
+    }
+
+    // Hidden entries are absent from the line as they are from the sections: help describes
+    // what a user is invited to type.
+    let flags: usize = meta.flags.iter().filter(|f| !f.hide).count();
+    if flags > 0 {
+        let required = meta.flags.iter().any(|f| !f.hide && f.required);
+        if flags <= INLINE_LIMIT {
+            for flag in meta.flags.iter().filter(|f| !f.hide) {
+                // A required flag is angled, like a required argument: the brackets are what
+                // say whether leaving it out is allowed.
+                let (open, close) = if flag.required {
+                    ('<', '>')
+                } else {
+                    ('[', ']')
+                };
+                let _ = write!(out, " {open}{}{close}", flag_usage(flag));
+            }
+        } else if required {
+            out.push_str(" <FLAGS>");
+        } else {
+            out.push_str(" [FLAGS]");
+        }
+    }
+
+    let args: usize = meta.args.iter().filter(|a| !a.hide).count();
+    if args > 0 {
+        let required = meta.args.iter().any(|a| !a.hide && a.required);
+        if args <= INLINE_LIMIT {
+            for arg in meta.args.iter().filter(|a| !a.hide) {
+                let _ = write!(out, " {}", arg_usage(arg));
+            }
+        } else if required {
+            out.push_str(" <ARGS>…");
+        } else {
+            out.push_str(" [ARGS]…");
+        }
+    }
+
+    if !meta.cmd.subcommands.is_empty() {
+        out.push_str(" <SUBCOMMAND>");
+    }
+    out
+}
+
+/// How one flag appears in the usage line: `-f --force`, plus its value if it takes one.
+fn flag_usage(meta: &FlagMeta<'_>) -> String {
+    let flag = meta.flag;
+    let mut out = String::new();
+
+    // The declared name, when it is not the one the forms would imply. A flag called
+    // `verbose` reachable only as `-v` has to say so, or help would name something the
+    // spec does not.
+    let implied = flag
+        .longs
+        .first()
+        .copied()
+        .or_else(|| flag.shorts.first().map(|_| ""));
+    let implied_matches = match (implied, flag.shorts.first()) {
+        (Some(long), _) if !long.is_empty() => long == flag.name,
+        (Some(_), Some(short)) => {
+            let mut buf = [0u8; 4];
+            (*short as char).encode_utf8(&mut buf) == flag.name
+        }
+        _ => false,
+    };
+    if !implied_matches {
+        let _ = write!(out, "{}:", flag.name);
+    }
+    if let Some(short) = flag.shorts.first() {
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        let _ = write!(out, "-{}", *short as char);
+    }
+    if let Some(long) = flag.longs.first() {
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        let _ = write!(out, "--{long}");
+    }
+
+    // A repeatable flag, which is the spec's `var=#true` — not one occurrence taking several
+    // values, which is the value's own business below.
+    if meta.repeatable {
+        out.push('…');
+    }
+    if flag.takes_value {
+        let name = meta.value_name.unwrap_or(flag.name);
+        let _ = write!(out, " <{name}>");
+        if flag.variadic {
+            out.push('…');
+        }
+    }
+    out
+}
+
+/// How one positional argument appears: `<TOOL>`, `[FILES]…`, `-- <ARGS>`.
+fn arg_usage(meta: &ArgMeta<'_>) -> String {
+    let arg = meta.arg;
+    let mut out = String::new();
+    let (open, close) = if meta.required {
+        ('<', '>')
+    } else {
+        ('[', ']')
+    };
+    // An argument that only takes what follows a `--` shows the separator, because typing the
+    // value without it does not reach this argument at all — and the brackets go *outside*
+    // it, as usage-lib writes it: `[-- COMMAND]…`, one optional thing rather than a literal
+    // `--` followed by an optional word.
+    if arg.double_dash == DoubleDash::Required {
+        let _ = write!(out, "{open}-- {}{close}", arg.name);
+    } else {
+        let _ = write!(out, "{open}{}{close}", arg.name);
+    }
+    if arg.var {
+        out.push('…');
+    }
+    out
+}

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -84,6 +84,8 @@
 use std::ffi::{OsStr, OsString};
 
 #[cfg(feature = "spec")]
+pub mod help;
+#[cfg(feature = "spec")]
 pub mod spec;
 
 /// How deep a command tree this parser will descend.

--- a/benches/gate/Cargo.toml
+++ b/benches/gate/Cargo.toml
@@ -13,5 +13,11 @@ publish = false
 clap = { version = "4", features = ["derive", "env"] }
 shadow-mise = { path = "../shadows/mise" }
 shadow-mise-clap = { path = "../shadows/mise-clap" }
-usage-argv = { path = "../../argv" }
+usage-argv = { path = "../../argv", features = ["spec"] }
+
+# The oracle for help rendering. A dev-dependency because nothing the gate *builds* needs it:
+# it is here so the shadow's rendered help can be compared against usage-lib's over mise's
+# whole spec, which is the only fixture big enough to be convincing.
+[dev-dependencies]
+usage-lib = { path = "../../lib" }
 

--- a/benches/gate/tests/help.rs
+++ b/benches/gate/tests/help.rs
@@ -1,0 +1,102 @@
+//! Does the rendered usage line match usage-lib's, at mise's scale?
+//!
+//! usage-lib builds this from a spec, through a tera template over a runtime model.
+//! usage-argv has no spec at run time — only `&'static` tables — so the rules are
+//! reimplemented there, and reimplemented rules drift. The check is to run both over mise's
+//! real spec and compare all 211 lines, because an adopter's help text changing is a visible
+//! regression even when the change is one bracket.
+//!
+//! The shadow is generated from the same `mise.usage.kdl` that usage-lib is given here, so
+//! the two sides describe the same CLI by construction rather than by a fixture kept in step
+//! by hand.
+
+use usage::{Spec as LibSpec, SpecCommand};
+use usage_argv::help::usage_line;
+use usage_argv::spec::CommandMeta;
+
+/// mise's committed spec, which the shadow was generated from.
+fn mise_spec() -> LibSpec {
+    let kdl = include_str!("../../mise.usage.kdl");
+    kdl.parse().expect("mise's spec should parse")
+}
+
+/// Every command in the tree, as (path, metadata) — the path being what a user types.
+fn walk<'a>(
+    path: Vec<&'a str>,
+    meta: &'a CommandMeta<'a>,
+    out: &mut Vec<(Vec<&'a str>, &'a CommandMeta<'a>)>,
+) {
+    out.push((path.clone(), meta));
+    for sub in meta.subcommands {
+        // Aliases live in the parse table beside the canonical name; help names the command.
+        let mut child = path.clone();
+        child.push(sub.cmd.name);
+        walk(child, sub, out);
+    }
+}
+
+/// usage-lib's line for the same command, found by following the same path.
+fn lib_command<'a>(spec: &'a LibSpec, path: &[&str]) -> Option<&'a SpecCommand> {
+    let mut cmd = &spec.cmd;
+    for name in path {
+        cmd = cmd.subcommands.get(*name)?;
+    }
+    Some(cmd)
+}
+
+#[test]
+fn every_usage_line_matches_the_reference() {
+    let spec = mise_spec();
+    let root = shadow_mise::Cli::spec().root;
+
+    let mut commands = Vec::new();
+    walk(vec!["mise"], root, &mut commands);
+    assert!(
+        commands.len() > 200,
+        "the shadow should cover mise's whole tree, found {}",
+        commands.len()
+    );
+
+    let mut differences = Vec::new();
+    for (path, meta) in &commands {
+        let ours = usage_line(path, meta);
+        // usage-lib's `usage()` omits the binary and starts at the command path, so the
+        // comparison puts it back — the same string the template writes after `Usage: `.
+        let theirs = match lib_command(&spec, &path[1..]) {
+            Some(cmd) => format!("mise {}", cmd.usage()).trim().to_string(),
+            None => {
+                differences.push(format!("{}: not found in the spec at all", path.join(" ")));
+                continue;
+            }
+        };
+        if ours != theirs {
+            differences.push(format!(
+                "{}\n     ours: {ours}\n      lib: {theirs}",
+                path.join(" ")
+            ));
+        }
+    }
+
+    assert!(
+        differences.is_empty(),
+        "{} of {} usage lines differ from usage-lib:\n  - {}",
+        differences.len(),
+        commands.len(),
+        differences.join("\n  - ")
+    );
+}
+
+#[test]
+fn the_root_line_is_what_a_user_would_recognise() {
+    // One case spelled out, so a reader can see what the parity test is asserting 211 times.
+    let root = shadow_mise::Cli::spec().root;
+    let line = usage_line(&["mise"], root);
+    assert!(
+        line.starts_with("mise "),
+        "the line should start with the binary: {line}"
+    );
+    assert!(
+        line.ends_with("<SUBCOMMAND>"),
+        "mise has subcommands, so the line should end by saying so: {line}"
+    );
+}

--- a/conformance/tests/derive.rs
+++ b/conformance/tests/derive.rs
@@ -373,6 +373,110 @@ fn the_spec_is_valid_and_says_what_was_declared() {
     assert!(!spec.cmd.args[1].required);
 }
 
+/// A positional that must be filled by the *type* and carries a default.
+#[derive(Cli, Debug)]
+#[usage(bin = "ex")]
+struct Defaulted {
+    /// Where to look
+    #[usage(arg, default = ".")]
+    dir: String,
+
+    /// Where to write
+    #[usage(long, default = "-")]
+    out: String,
+}
+
+/// Enough defaulted positionals that the usage line collapses them to one placeholder.
+#[derive(Cli, Debug)]
+#[usage(bin = "ex")]
+struct ManyDefaulted {
+    /// A defaulted flag
+    #[usage(long, default = "1")]
+    alpha: String,
+    /// Another
+    #[usage(long, default = "2")]
+    beta: String,
+    /// A third, past the point where the line collapses them
+    #[usage(long, default = "3")]
+    gamma: String,
+
+    /// First
+    #[usage(arg, default = "a")]
+    one: String,
+    /// Second
+    #[usage(arg, default = "b")]
+    two: String,
+    /// Third
+    #[usage(arg, default = "c")]
+    three: String,
+}
+
+#[test]
+fn a_defaulted_argument_reads_as_optional_in_both_renderers() {
+    // The two sides have to agree, and this is the case where they did not. usage-lib clears
+    // `required` while *parsing* a spec that declares a default, then renders from `required`
+    // alone — so it writes `[dir]`. usage-argv kept the two separate and read `required` on its
+    // own, writing `<dir>` for an argument the parser is perfectly happy to omit.
+    //
+    // mise's own spec does not catch this: every defaulted positional in it is written
+    // `required=#false default=…`, so there is nothing to normalize. A *derived* one is
+    // required by its type and defaulted by its attribute, which is exactly the shape that
+    // diverges.
+    let spec: LibSpec = Defaulted::to_kdl().parse().expect("valid spec");
+    let theirs = format!("ex {}", spec.cmd.usage()).trim().to_string();
+    let ours = usage_argv::help::usage_line(&["ex"], Defaulted::spec().root);
+    assert_eq!(ours, theirs, "the two renderers disagree");
+    assert!(
+        ours.contains("[dir]"),
+        "a defaulted argument is optional: {ours}"
+    );
+    // A flag says it the same way, and had the same bug: usage-lib clears `required` on a flag
+    // that declares a default too.
+    assert!(
+        ours.contains("[--out"),
+        "a defaulted flag is optional: {ours}"
+    );
+
+    // And an argument with no default still reads as required, so the assertion above is about
+    // the default rather than about everything being optional.
+    let plain: LibSpec = Ex::to_kdl().parse().expect("valid spec");
+    let plain_line = usage_argv::help::usage_line(&["ex"], Ex::spec().root);
+    assert_eq!(
+        plain_line,
+        format!("ex {}", plain.cmd.usage()).trim().to_string()
+    );
+    assert!(plain_line.contains("<file>"), "{plain_line}");
+
+    // Past the point where the line collapses them into one placeholder, the same signal
+    // decides whether it reads `<ARGS>…` or `[ARGS]…` — and all of these are omittable.
+    let many = usage_argv::help::usage_line(&["ex"], ManyDefaulted::spec().root);
+    assert!(
+        many.contains("[ARGS]…"),
+        "collapsed defaulted arguments are optional: {many}"
+    );
+    // Flags collapse by the same rule, from the same signal.
+    assert!(
+        many.contains("[FLAGS]"),
+        "collapsed defaulted flags are optional: {many}"
+    );
+
+    // And they really are omittable, which is the claim the brackets make: parsing nothing
+    // fills every one of them from its default.
+    let nothing = argv([]);
+    let filled = ManyDefaulted::parse_from(&nothing).expect("all defaulted");
+    assert_eq!(
+        (filled.one, filled.two, filled.three),
+        ("a".into(), "b".into(), "c".into())
+    );
+    assert_eq!(
+        (filled.alpha, filled.beta, filled.gamma),
+        ("1".into(), "2".into(), "3".into())
+    );
+    let dir = Defaulted::parse_from(&nothing).expect("defaulted");
+    assert_eq!(dir.dir, ".");
+    assert_eq!(dir.out, "-");
+}
+
 #[test]
 fn the_spec_renders_as_docs() {
     // The reason the spec exists: `usage g markdown|manpage` at build time.

--- a/conformance/tests/metadata.rs
+++ b/conformance/tests/metadata.rs
@@ -45,6 +45,31 @@ fn a_short_only_flag_keeps_a_descriptive_placeholder() {
     assert_eq!(parsed.jobs.as_deref(), Some("4"));
 }
 
+/// A flag whose long form differs from the Rust field holding it.
+#[derive(Cli)]
+#[usage(bin = "renamed")]
+struct Renamed {
+    /// What sort of thing
+    #[usage(long = "type", short = 't')]
+    type_: Option<String>,
+}
+
+#[test]
+fn a_renamed_flag_takes_its_placeholder_from_the_form_not_the_field() {
+    // The value name falls back to the flag's name, and the flag is named after its long form —
+    // so a field called `type_` must not drag its kebab-cased ident into the placeholder and
+    // render `--type <type->`.
+    let spec: LibSpec = Renamed::to_kdl().parse().expect("valid spec");
+    let flag = &spec.cmd.flags[0];
+    assert_eq!(flag.name, "type");
+    assert_eq!(flag.arg.as_ref().expect("takes a value").name, "type");
+
+    use std::ffi::OsStr;
+    let argv = [OsStr::new("--type"), OsStr::new("toml")];
+    let parsed = Renamed::parse_from(&argv).expect("should parse");
+    assert_eq!(parsed.type_.as_deref(), Some("toml"));
+}
+
 /// A CLI declaring all three.
 #[derive(Cli)]
 #[usage(bin = "ex")]

--- a/conformance/tests/metadata.rs
+++ b/conformance/tests/metadata.rs
@@ -12,6 +12,39 @@
 use usage::Spec as LibSpec;
 use usage_derive::Cli;
 
+/// A flag reachable only by its short form, whose value still needs a name.
+#[derive(Cli)]
+#[usage(bin = "shortonly")]
+struct ShortOnly {
+    /// How many at once
+    #[usage(short = 'j')]
+    jobs: Option<String>,
+}
+
+#[test]
+fn a_short_only_flag_keeps_a_descriptive_placeholder() {
+    // A flag is named after the form it answers to, and for a short-only flag that form is one
+    // character — right for the flag's name and useless as the name of its *value*, since help
+    // and the KDL both fall back to it. `-j <j>` for a field called `jobs`.
+    let spec: LibSpec = ShortOnly::to_kdl().parse().expect("valid spec");
+    let flag = &spec.cmd.flags[0];
+    assert_eq!(
+        flag.name, "j",
+        "named after the form, as usage-lib names it"
+    );
+    assert_eq!(
+        flag.arg.as_ref().expect("takes a value").name,
+        "jobs",
+        "but its value keeps the descriptive name"
+    );
+
+    // And it binds by the short form, which is the only form it has.
+    use std::ffi::OsStr;
+    let argv = [OsStr::new("-j"), OsStr::new("4")];
+    let parsed = ShortOnly::parse_from(&argv).expect("should parse");
+    assert_eq!(parsed.jobs.as_deref(), Some("4"));
+}
+
 /// A CLI declaring all three.
 #[derive(Cli)]
 #[usage(bin = "ex")]

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -1053,11 +1053,15 @@ impl Field {
         // Only where the field says nothing: an explicit `name` still wins, and a flag with
         // no long form keeps its short as the name, as usage-lib does.
         if is_flag && !name_given {
-            // The placeholder for the flag's value keeps the descriptive name, because the name
-            // about to be overwritten is the only descriptive one there is: help and the KDL
-            // both fall back to `flag.name` for it, so a short-only `-j` rendered `-j <j>` where
-            // the field is called `jobs`.
-            if value_name.is_none() && shape != Shape::Bool && shape != Shape::Count {
+            // Only where the name is about to become something that says nothing: a flag with
+            // no long form is named after its short one, and `-j <j>` is no use as a
+            // placeholder. Where a long form exists it *is* the descriptive name, and keeping
+            // the field ident instead would render `--type <type->` for a field called `type_`.
+            if longs.is_empty()
+                && value_name.is_none()
+                && shape != Shape::Bool
+                && shape != Shape::Count
+            {
                 value_name = Some(name.clone());
             }
             if let Some(long) = longs.first() {

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -676,6 +676,7 @@ impl Field {
         }
 
         let mut name = to_kebab(&ident.to_string());
+        let mut name_given = false;
         let mut longs: Vec<String> = Vec::new();
         let mut bare_longs = 0usize;
         let mut shorts: Vec<char> = Vec::new();
@@ -708,7 +709,10 @@ impl Field {
                 match ident_of(&path).as_str() {
                     // Stripped, so a dashed spelling cannot leak into the spec name
                     // or into a long form derived from it.
-                    "name" => name = strip_dashes(&string_value(&meta)?),
+                    "name" => {
+                        name = strip_dashes(&string_value(&meta)?);
+                        name_given = true;
+                    }
                     // Bare `long` takes the field name; `long = "x"` overrides it.
                     // A bare `long` is counted and resolved after the loop, so it
                     // picks up a `name` written later. Explicit ones are stored
@@ -1039,6 +1043,21 @@ impl Field {
                 "`required_unless` says this may be left out, so the field needs \
                  somewhere to put \"absent\": make it an `Option`",
             ));
+        }
+
+        // A flag is named after the form it answers to, not after the Rust field holding it.
+        // usage-lib derives the name the same way, so the two agree about what a flag is
+        // called — and the field name is often not a legal one: `type_` gave a flag called
+        // `type-`, which help printed as `type-: -t --type` and errors reported as `type-`.
+        //
+        // Only where the field says nothing: an explicit `name` still wins, and a flag with
+        // no long form keeps its short as the name, as usage-lib does.
+        if is_flag && !name_given {
+            if let Some(long) = longs.first() {
+                name = long.clone();
+            } else if let Some(short) = shorts.first() {
+                name = short.to_string();
+            }
         }
 
         // `required` is for the one case the type cannot express. Anywhere else it either

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -1053,6 +1053,13 @@ impl Field {
         // Only where the field says nothing: an explicit `name` still wins, and a flag with
         // no long form keeps its short as the name, as usage-lib does.
         if is_flag && !name_given {
+            // The placeholder for the flag's value keeps the descriptive name, because the name
+            // about to be overwritten is the only descriptive one there is: help and the KDL
+            // both fall back to `flag.name` for it, so a short-only `-j` rendered `-j <j>` where
+            // the field is called `jobs`.
+            if value_name.is_none() && shape != Shape::Bool && shape != Shape::Count {
+                value_name = Some(name.clone());
+            }
             if let Some(long) = longs.first() {
                 name = long.clone();
             } else if let Some(short) = shorts.first() {


### PR DESCRIPTION
`Usage: mise use [OPTIONS] <TOOL@VERSION>…` — the line at the top of `--help`, and the first
thing a CLI framework has to be able to produce. Built from the same `&'static` metadata a
parse ignores, so a binary that never asks for help pays nothing for being able to.

usage-lib renders this through a tera template over a runtime model. This crate has no `Spec`
at run time, only tables, so the rules are reimplemented — and reimplemented rules drift. The
test runs both over mise's real spec and compares all 211 lines, because an adopter's help
text changing is a visible regression even when the change is one bracket. The shadow is
generated from the same KDL usage-lib is handed, so the two describe the same CLI by
construction rather than by a fixture kept in step by hand.

Two things it caught:

An argument that only takes what follows a `--` is bracketed *around* the separator —
`[-- COMMAND]…`, one optional thing — where I had written `-- [COMMAND]…`, a literal `--`
followed by an optional word. Five of mise's commands read that way.

A flag is named after the form it answers to, not after the Rust field holding it. usage-lib
derives the name from the first long form, and the derive was kebab-casing the field ident —
so `type_` gave a flag called `type-`, which help printed as `type-: -t --type` and errors
reported as `type-`. An explicit `name` still wins, and a flag with no long form keeps its
short, as usage-lib does. Selectors resolve by form rather than by name, so nothing that
refers to a flag changes.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cold-path help formatting behind `spec`, with broad parity tests; derive naming changes align emitted KDL/help with usage-lib and do not alter parse-time selector matching.
> 
> **Overview**
> Adds **`usage_argv::help::usage_line`** behind the existing **`spec`** feature so the top-of-help invocation summary is built from static **`CommandMeta`** tables without a runtime spec model.
> 
> **Parity:** The gate bench compares every mise command’s line (211) against **usage-lib** from the same KDL; **PLAN.md** marks the usage line as done.
> 
> **Rendering fixes:** Defaulted flags/args render as optional (`required && default.is_empty()`), not raw `required`. **`--`** positionals use **`[-- NAME]…`** with brackets outside the separator. Flags/args collapse to **`[FLAGS]`** / **`[ARGS]…`** past an inline limit of 2.
> 
> **Derive:** Flags without an explicit **`name`** are named from the first long or short form (fixes **`type_` → `type-`**); short-only value flags keep the field ident as **`value_name`**.
> 
> **Tests:** Gate **`help.rs`**, conformance **`derive`** / **`metadata`** for defaulted and renamed flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32ff41b59316517f41e0d9ebaff5652f9a82fd1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## The standard

**All 211 of mise's commands render byte-identically to usage-lib.**

usage-lib builds this through a tera template over a runtime model. usage-argv has no `Spec` at
run time — only `&'static` tables — so the rules are reimplemented here, and reimplemented rules
drift. The test runs both over mise's real spec and compares every line, because an adopter's
help text changing is a visible regression even when the change is one bracket. The shadow is
generated from the same KDL usage-lib is handed, so the two describe the same CLI by
construction rather than by a fixture kept in step by hand.

The parity test is also what found the four metadata gaps: three in #853 below this, and one
here.

## What it caught here

**A `--` argument is bracketed around the separator.** usage-lib writes `[-- COMMAND]…` — one
optional thing — where I had `-- [COMMAND]…`, a literal `--` followed by an optional word. Five
of mise's commands read that way.

**A flag is named after the form it answers to, not the field holding it.** usage-lib derives
the name from the first long form; the derive was kebab-casing the Rust ident. So `type_` gave a
flag called `type-`, printed by help as `type-: -t --type` and reported by errors as `type-`.
An explicit `name` still wins, and a flag with no long keeps its short, as usage-lib does.
Selectors resolve by form rather than by name, so nothing that *refers* to a flag changes — and
error messages get better for free.

## Cost

None on the parse path: this reads the cold metadata a successful parse never touches, and lives
behind the existing `spec` feature. A binary that never renders help does not carry the
formatting code.

## Not yet

The line only. The sections below it — about, arguments, flags grouped by heading, subcommands,
examples — and the `--help`/`-h` wiring in the derive are the next two PRs. The line comes first
because everything else is arranged around it, and because it is the piece with an exact oracle.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*
