### PR TITLE
fix(docs): keep hidden entries out of help

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -408,6 +408,12 @@ The corpus records these; they are bugs to fix or decisions to revisit, not
 settled behavior. Each is a small change to `lib/src/parse.rs`, and the corpus is
 how a fix gets verified — including telling you to delete the label afterwards.
 
+- [x] Help printed everything marked `hide` — hidden flags, hidden arguments, hidden
+      subcommands. The usage _line_ filtered them already, through `SpecCommand::usage`, so
+      `ex --help` listed a `--secret` that the line above it did not mention; markdown and
+      manpage rendering filtered too. The help templates were the one place that did not.
+      Found while building usage-argv's renderer, which would otherwise have had to reproduce
+      it for parity.
 - [ ] Unrecognized flags fall through to positionals, so `ex --wat` binds `--wat`
       to an argument, or reports `unexpected_arg` when there is none. This is the
       root of most of the recorded divergences. **Needs a decision**: mise parses

--- a/lib/src/docs/cli/mod.rs
+++ b/lib/src/docs/cli/mod.rs
@@ -5,7 +5,7 @@ use tera::Tera;
 pub fn render_help(spec: &Spec, cmd: &SpecCommand, long: bool) -> String {
     // Convert to docs models to get layout calculations
     let docs_spec = crate::docs::models::Spec::from(spec.clone());
-    let docs_cmd = crate::docs::models::SpecCommand::from(cmd);
+    let docs_cmd = crate::docs::models::SpecCommand::from(&without_hidden(cmd));
 
     let mut ctx = tera::Context::new();
     ctx.insert("spec", &docs_spec);
@@ -17,6 +17,25 @@ pub fn render_help(spec: &Spec, cmd: &SpecCommand, long: bool) -> String {
         "spec_template_short.tera"
     };
     TERA.render(template, &ctx).unwrap().trim().to_string() + "\n"
+}
+
+/// The command without anything marked `hide`.
+///
+/// Help showed hidden flags, hidden arguments and hidden subcommands — everything `hide`
+/// exists to keep out of it. The usage *line* filtered them already, through
+/// `SpecCommand::usage`, so `ex --help` listed a `--secret` that the line above it did not
+/// mention. Markdown and manpage rendering filter too; the help templates were the one place
+/// that did not.
+///
+/// Filtered here rather than in the templates, and before the docs model builds its groups, so
+/// that a heading whose every entry is hidden produces no section — the same rule markdown
+/// already follows.
+fn without_hidden(cmd: &SpecCommand) -> SpecCommand {
+    let mut visible = cmd.clone();
+    visible.flags.retain(|flag| !flag.hide);
+    visible.args.retain(|arg| !arg.hide);
+    visible.subcommands.retain(|_, sub| !sub.hide);
+    visible
 }
 
 static TERA: LazyLock<Tera> = LazyLock::new(|| {
@@ -60,6 +79,39 @@ static TERA: LazyLock<Tera> = LazyLock::new(|| {
 mod tests {
     use super::*;
     use insta::assert_snapshot;
+
+    #[test]
+    fn test_render_help_omits_hidden_entries() {
+        let spec = crate::spec! { r#"
+bin "ex"
+flag "--visible" help="shown"
+flag "--secret" hide=#true help="hidden"
+flag "--filtered" hide=#true help="hidden" help_heading="Filtering"
+arg "[SHOWN]" help="an arg"
+arg "[HIDDEN]" hide=#true help="a hidden arg"
+cmd open help="a command"
+cmd sneaky hide=#true help="a hidden command"
+        "# }
+        .unwrap();
+
+        // `hide` keeps something out of help. The usage line filtered already — through
+        // `SpecCommand::usage` — so before this, `ex --help` listed a `--secret` the line
+        // above it did not mention. A heading whose every entry is hidden produces no
+        // section, which is the rule markdown rendering already followed.
+        assert_snapshot!(render_help(&spec, &spec.cmd, false), @r"
+        Usage: ex [--visible] [SHOWN] <SUBCOMMAND>
+
+        Commands:
+          open  a command
+          help  Print this message or the help of the given subcommand(s)
+
+        Arguments:
+          [SHOWN]  an arg
+
+        Flags:
+          --visible  shown
+        ");
+    }
 
     #[test]
     fn test_render_help_groups_by_heading() {


### PR DESCRIPTION
`hide` exists to keep something out of help, and help printed all of it: hidden flags,
hidden arguments, hidden subcommands. The usage *line* filtered them already, through
`SpecCommand::usage`, so `ex --help` listed a `--secret` that the line directly above it did
not mention. Markdown and manpage rendering filter too — the help templates were the one
place that did not.

Filtered before the docs model builds its groups, so a heading whose every entry is hidden
produces no section, which is the rule markdown already followed. Doing it in `render_help`
rather than in the templates keeps the two templates from having to agree about it.

Found while writing usage-argv's own help renderer, which is held to byte-parity with this
one over mise's whole spec — so without the fix it would have had to reproduce the bug to
pass.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Help text filtering only; no parsing, binding, or runtime behavior changes.
> 
> **Overview**
> **CLI `--help` now omits anything marked `hide`**, matching the usage line, markdown, and manpage output. Previously the Tera help templates still listed hidden flags, arguments, and subcommands, so help could show options the `Usage:` line did not mention.
> 
> `render_help` strips hidden entries via `without_hidden` **before** the docs model builds section groups, so a `help_heading` whose only flags are hidden does not render an empty section (same rule as markdown).
> 
> Adds an insta snapshot test and marks the known usage-lib divergence as fixed in `PLAN.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19e1534b16c0f0c4ec3764e8805a8e7128d9fdcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## What it looked like

`hide` exists to keep something out of help, and help printed all of it:

```
Usage: ex [--visible] [SHOWN] <SUBCOMMAND>     ← the line filters correctly

Commands:
  open  a command
  sneaky  a hidden command                     ← hidden
  help  Print this message or the help of the given subcommand(s)

Arguments:
  [SHOWN]  an arg
  [HIDDEN]  a hidden arg                       ← hidden

Flags:
  --visible  shown
  --secret  hidden                             ← hidden
```

The usage line above them filtered already, through `SpecCommand::usage`, so `ex --help`
listed a `--secret` that the line directly above it did not mention. Markdown rendering filters
(its own test asserts "hidden entries stay out") and manpage rendering filters subcommands. The
CLI help templates were the one place that did not.

## Where the fix goes

In `render_help`, before the docs model builds its groups — so a heading whose every entry is
hidden produces no section, which is the rule markdown already follows. Doing it there rather
than in the templates keeps the short and long forms from having to agree about it separately.

## How it was found

Building usage-argv's own help renderer, which is held to byte-parity with this one over mise's
whole spec. Without this fix that renderer would have had to reproduce the bug to pass — which
is the argument for having an independent implementation at all.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*
