### PR TITLE
feat(argv): render `-h`, byte-identical to usage-lib's

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -265,16 +265,14 @@ tasks --usage"`, so task names are meant to come from running that. usage-argv d
 
 ### Then: what a CLI framework has to have
 
-- [ ] **Help rendering** — `--help` and `-h` from the static metadata, with headings and
-      hidden-item filtering. The **usage line** is done: `usage_argv::help::usage_line` builds
-      it from the tables, and all 211 of mise's commands come out byte-identical to usage-lib's,
-      which is the standard that matters — an adopter's help changing is a visible regression
-      even when it is one bracket. usage-lib renders through a tera template over a runtime
-      model, which this crate has no equivalent of, so the rules are reimplemented and the
-      parity test is what keeps them honest. Getting there also forced a fourth naming fix: a
-      flag is named after the form it answers to, as usage-lib names it, not after the Rust
-      field holding it — `type_` had been giving a flag called `type-`, which help printed and
-      errors reported.
+- [ ] **Help rendering** — `-h` is done and matches usage-lib byte for byte across all 211 of
+      mise's commands: the usage line, the about, the commands list, arguments and flags grouped
+      by heading, examples, hidden-item filtering. `--help`'s wider layout, which aligns help
+      into a column and wraps to `COLUMNS`, is next, then the `--help`/`-h` wiring in the derive.
+      Holding it to parity found six more things a spec could say that the derive could not —
+      value names, required collections, `var` on a count, the spec's own `about`, `hide` on a
+      command, and help text whose line breaks matter — plus a bug in usage-lib, which printed
+      everything marked `hide`.
 - [ ] **Completions, self-contained** — `<bin> completion <shell>` emits the
       script; a hidden `<bin> complete-word` serves requests from the binary's own
       embedded spec. Same dispatch shape usage-cli uses today, without requiring

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -19,7 +19,7 @@
 
 use core::fmt::Write as _;
 
-use crate::spec::{ArgMeta, CommandMeta, FlagMeta};
+use crate::spec::{ArgMeta, CommandMeta, FlagMeta, Spec};
 use crate::DoubleDash;
 
 /// How many flags or arguments are listed individually before collapsing to a placeholder.
@@ -205,4 +205,183 @@ fn arg_usage(meta: &ArgMeta<'_>) -> String {
         out.push('…');
     }
     out
+}
+
+/// Everything `-h` prints.
+///
+/// The short form: one line per entry, its help beside it. `--help` renders the same content
+/// through a wider layout, which is the next thing to build — the two differ in presentation
+/// and in which help text they prefer, not in what they cover.
+///
+/// `path` is the command as invoked, as for [`usage_line`].
+pub fn short_help(spec: &Spec<'_>, path: &[&str], meta: &CommandMeta<'_>) -> String {
+    let mut out = String::new();
+
+    // The program, then what it is for. usage-lib prints the name when the spec gives one and
+    // the binary otherwise, and only when there is a version to put beside it.
+    if let Some(version) = spec.version {
+        let name = if spec.name.is_empty() {
+            spec.bin.unwrap_or_default()
+        } else {
+            spec.name
+        };
+        let _ = writeln!(out, "{name} {version}");
+    }
+    if let Some(about) = spec.about {
+        let _ = writeln!(out, "{about}\n");
+    }
+    let _ = writeln!(out, "Usage: {}", usage_line(path, meta));
+
+    // The path without the binary, which is what a listed subcommand shows: usage-lib prints
+    // `tool-alias get <TOOL>` under `mise tool-alias`, the whole path from the root rather
+    // than the child's own name.
+    commands_section(&mut out, &path[1.min(path.len())..], meta);
+    groups_section(
+        &mut out,
+        "Arguments",
+        meta.args.iter().filter(|a| !a.hide),
+        |a| a.help_heading,
+        |out, a| {
+            let _ = write!(out, "  {}", arg_usage(a));
+            if let Some(help) = a.help {
+                let _ = write!(out, "  {help}");
+            }
+            annotations(out, a.choices, a.env, a.default);
+        },
+    );
+    groups_section(
+        &mut out,
+        "Flags",
+        meta.flags.iter().filter(|f| !f.hide),
+        |f| f.help_heading,
+        |out, f| {
+            let _ = write!(out, "  {}", display_usage(f));
+            if let Some(help) = f.help {
+                let _ = write!(out, "  {help}");
+            }
+            annotations(out, f.choices, f.env, &[]);
+        },
+    );
+    examples_section(&mut out, meta);
+
+    // usage-lib trims the whole document and puts back one newline, which is what keeps the
+    // blank lines between sections from becoming trailing ones.
+    let trimmed = out.trim();
+    let mut done = String::with_capacity(trimmed.len() + 1);
+    done.push_str(trimmed);
+    done.push('\n');
+    done
+}
+
+/// The list of subcommands, and the `help` command every CLI with subcommands has.
+fn commands_section(out: &mut String, path: &[&str], meta: &CommandMeta<'_>) {
+    let visible: Vec<&&CommandMeta<'_>> = meta.subcommands.iter().filter(|c| !c.hide).collect();
+    // Nothing visible, no section — `mise direnv` and `mise dotfiles` have subcommands and
+    // every one of them is hidden. The usage *line* still says `<SUBCOMMAND>`, because
+    // usage-lib computes it before filtering and stores it; matching the reference means
+    // matching that too, odd as the pair looks together.
+    if visible.is_empty() {
+        return;
+    }
+    let _ = writeln!(out, "\nCommands:");
+
+    // Sorted by the rendered usage rather than by name, as usage-lib sorts them — for a
+    // command with no flags or arguments the two agree, and where they differ this is the
+    // order a reader sees in the reference.
+    let mut lines: Vec<(String, &&CommandMeta<'_>)> = visible
+        .iter()
+        .map(|sub| {
+            let mut sub_path: Vec<&str> = path.to_vec();
+            sub_path.push(sub.cmd.name);
+            (usage_line(&sub_path, sub), *sub)
+        })
+        .collect();
+    lines.sort_by(|a, b| a.0.cmp(&b.0));
+
+    for (usage, sub) in &lines {
+        let _ = write!(out, "  {usage}");
+        // Visible aliases only: a hidden alias works and is not advertised, which is the
+        // whole of the distinction.
+        let visible_aliases: Vec<&str> = sub
+            .cmd
+            .aliases
+            .iter()
+            .copied()
+            .filter(|a| !sub.hidden_aliases.contains(a))
+            .collect();
+        if !visible_aliases.is_empty() {
+            let _ = write!(out, " [aliases: {}]", visible_aliases.join(", "));
+        }
+        if let Some(about) = sub.about {
+            let _ = write!(out, "  {about}");
+        }
+        out.push('\n');
+    }
+    let _ = writeln!(
+        out,
+        "  help  Print this message or the help of the given subcommand(s)"
+    );
+}
+
+/// One section per heading, unheaded first, in the order the headings first appear.
+fn groups_section<'m, T: 'm>(
+    out: &mut String,
+    default_title: &str,
+    items: impl Iterator<Item = &'m T> + Clone,
+    heading_of: impl Fn(&T) -> Option<&'m str>,
+    mut write_item: impl FnMut(&mut String, &T),
+) {
+    // Headings in first-seen order, with the unheaded group before them. Collected rather
+    // than sorted so that "first seen" means what it says.
+    let mut headings: Vec<Option<&str>> = Vec::new();
+    for item in items.clone() {
+        let heading = heading_of(item);
+        if !headings.contains(&heading) {
+            headings.push(heading);
+        }
+    }
+    headings.sort_by_key(|h| h.is_some());
+
+    for heading in headings {
+        let _ = writeln!(out, "\n{}:", heading.unwrap_or(default_title));
+        for item in items.clone().filter(|i| heading_of(i) == heading) {
+            write_item(out, item);
+        }
+    }
+}
+
+/// The bracketed notes after an entry's help: choices, environment, default.
+fn annotations(out: &mut String, choices: &[&str], env: Option<&str>, default: &[&str]) {
+    if !choices.is_empty() {
+        let _ = write!(out, " [{}]", choices.join(", "));
+    }
+    if let Some(env) = env {
+        let _ = write!(out, " [env: {env}]");
+    }
+    if !default.is_empty() {
+        let _ = write!(out, " (default: {})", default.join(", "));
+    }
+    out.push('\n');
+}
+
+/// A flag as the flags section lists it, which includes its negation.
+fn display_usage(meta: &FlagMeta<'_>) -> String {
+    let usage = flag_usage(meta);
+    match meta.flag.negate {
+        Some(negate) => format!("{usage} / --{negate}"),
+        None => usage,
+    }
+}
+
+fn examples_section(out: &mut String, meta: &CommandMeta<'_>) {
+    if meta.examples.is_empty() {
+        return;
+    }
+    let _ = writeln!(out, "\nExamples:");
+    for example in meta.examples {
+        if let Some(header) = example.header {
+            let _ = writeln!(out, "  {header}:");
+        }
+        let _ = writeln!(out, "    $ {}", example.code);
+    }
 }

--- a/benches/gate/tests/help.rs
+++ b/benches/gate/tests/help.rs
@@ -11,7 +11,7 @@
 //! by hand.
 
 use usage::{Spec as LibSpec, SpecCommand};
-use usage_argv::help::usage_line;
+use usage_argv::help::{short_help, usage_line};
 use usage_argv::spec::CommandMeta;
 
 /// mise's committed spec, which the shadow was generated from.
@@ -98,5 +98,67 @@ fn the_root_line_is_what_a_user_would_recognise() {
     assert!(
         line.ends_with("<SUBCOMMAND>"),
         "mise has subcommands, so the line should end by saying so: {line}"
+    );
+}
+
+/// The first line that differs, with a little context — a whole help page twice over is not
+/// something anyone reads.
+fn first_diff(ours: &str, theirs: &str) -> String {
+    let mine: Vec<&str> = ours.lines().collect();
+    let ref_: Vec<&str> = theirs.lines().collect();
+    for (i, (a, b)) in mine.iter().zip(ref_.iter()).enumerate() {
+        if a != b {
+            return format!("  line {}:\n    ours: {a:?}\n     lib: {b:?}", i + 1);
+        }
+    }
+    format!(
+        "  same for {} lines, then ours has {} and the reference {}",
+        mine.len().min(ref_.len()),
+        mine.len(),
+        ref_.len()
+    )
+}
+
+#[test]
+fn every_short_help_matches_the_reference() {
+    // The same standard as the usage line, over the whole document: `-h` for all 211 of
+    // mise's commands, byte for byte against usage-lib's. This is the test that decides
+    // whether an adopter's help output changes, so it compares the text rather than a
+    // summary of it.
+    let spec = mise_spec();
+    let root = shadow_mise::Cli::spec();
+
+    let mut commands = Vec::new();
+    walk(vec!["mise"], root.root, &mut commands);
+
+    let mut differences = Vec::new();
+    for (path, meta) in &commands {
+        let ours = short_help(root, path, meta);
+        let Some(cmd) = lib_command(&spec, &path[1..]) else {
+            differences.push(format!("{}: not in the spec", path.join(" ")));
+            continue;
+        };
+        let theirs = usage::docs::cli::render_help(&spec, cmd, false);
+        if ours != theirs {
+            differences.push(format!(
+                "{}\n{}",
+                path.join(" "),
+                first_diff(&ours, &theirs)
+            ));
+        }
+    }
+
+    assert!(
+        differences.is_empty(),
+        "{} of {} help pages differ:\n{}",
+        differences.len(),
+        commands.len(),
+        // Two is enough to work from, and the whole set would bury the count.
+        differences
+            .iter()
+            .take(2)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join("\n")
     );
 }

--- a/benches/shadows/mise-clap/src/lib.rs
+++ b/benches/shadows/mise-clap/src/lib.rs
@@ -36,13 +36,6 @@ pub struct ActivateArgs {
     /// This can be helpful for debugging mise. If you run `eval "$(mise activate --no-hook-env)"`, then you can call `mise hook-env` manually which will output the env vars to stdout without actually modifying the environment. That way you can do things like `mise hook-env --trace` to get more information or just see the values that hook-env is outputting.
     #[arg(long = "no-hook-env")]
     pub no_hook_env: bool,
-    /// Use shims instead of modifying PATH
-    /// Effectively the same as:
-    ///
-    ///     PATH="$HOME/.local/share/mise/shims:$PATH"
-    ///
-    /// `mise activate --shims` does not support all the features of `mise activate`.
-    /// See https://mise.jdx.dev/dev-tools/shims.html#shims-vs-path for more information
     #[arg(long = "shims")]
     pub shims: bool,
     /// Show "mise: <TOOL>@<VERSION>" message when changing directories
@@ -66,14 +59,6 @@ pub struct ToolAliasGetArgs {
     pub alias: String,
 }
 
-/// List tool version aliases
-/// Shows the aliases that can be specified.
-/// These can come from user config or from plugins in `bin/list-aliases`.
-///
-/// For user config, aliases are defined like the following in `~/.config/mise/config.toml`:
-///
-///     [tool_alias.node.versions]
-///     lts = "22.0.0"
 #[derive(Args)]
 pub struct ToolAliasLsArgs {
     /// Don't show table header
@@ -131,9 +116,6 @@ pub enum ToolAliasCommands {
     /// Show an alias for a tool
     #[command(name = "get")]
     Get(Box<ToolAliasGetArgs>),
-    /// List tool version aliases
-    /// Shows the aliases that can be specified.
-    /// These can come from user config or from plugins in `bin/list-aliases`.
     #[command(name = "ls", visible_alias = "list")]
     Ls(Box<ToolAliasLsArgs>),
     /// Add/update an alias for a tool/backend
@@ -179,33 +161,25 @@ pub struct BinPathsArgs {
     /// Output executable entries in JSON format (implies --bin-names)
     #[arg(long = "json", short = 'J')]
     pub json: bool,
-    /// Tool(s) to look up
-    /// e.g.: ruby@3
     #[arg(value_name = "TOOL@VERSION", num_args = 0..)]
     pub tool_version: Vec<String>,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapApplyAccountPlanArgs {}
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapApplyServicePlanArgs {}
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapApplyFirewallPlanArgs {}
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapApplySystemPlanArgs {}
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapInspectSystemFilesArgs {}
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapInspectFirewallPlanArgs {}
 
@@ -374,8 +348,6 @@ pub struct BootstrapDotfilesStatusArgs {
     /// Output in JSON format
     #[arg(long = "json", short = 'J')]
     pub json: bool,
-    /// Exit with code 1 if any configured dotfiles are not in their desired
-    /// state (missing, source missing, differs)
     #[arg(long = "missing")]
     pub missing: bool,
     /// Only show these targets
@@ -514,7 +486,6 @@ pub enum BootstrapFirewallCommands {
     Status(Box<BootstrapFirewallStatusArgs>),
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapLaunchdApplyArgs {
     /// Print the commands that would run without running them
@@ -525,7 +496,6 @@ pub struct BootstrapLaunchdApplyArgs {
     pub yes: bool,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapLaunchdStatusArgs {
     /// Output in JSON format
@@ -545,15 +515,12 @@ pub struct BootstrapLaunchdArgs {
 
 #[derive(Subcommand)]
 pub enum BootstrapLaunchdCommands {
-    /// Undocumented
     #[command(name = "apply")]
     Apply(Box<BootstrapLaunchdApplyArgs>),
-    /// Undocumented
     #[command(name = "status")]
     Status(Box<BootstrapLaunchdStatusArgs>),
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapLinuxSystemdUnitsApplyArgs {
     /// Print the commands that would run without running them
@@ -564,7 +531,6 @@ pub struct BootstrapLinuxSystemdUnitsApplyArgs {
     pub yes: bool,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapLinuxSystemdUnitsStatusArgs {
     /// Output in JSON format
@@ -584,10 +550,8 @@ pub struct BootstrapLinuxSystemdUnitsArgs {
 
 #[derive(Subcommand)]
 pub enum BootstrapLinuxSystemdUnitsCommands {
-    /// Undocumented
     #[command(name = "apply")]
     Apply(Box<BootstrapLinuxSystemdUnitsApplyArgs>),
-    /// Undocumented
     #[command(name = "status")]
     Status(Box<BootstrapLinuxSystemdUnitsStatusArgs>),
 }
@@ -606,7 +570,6 @@ pub enum BootstrapLinuxCommands {
     SystemdUnits(Box<BootstrapLinuxSystemdUnitsArgs>),
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapMacosDefaultsApplyArgs {
     /// Print the commands that would run without running them
@@ -617,7 +580,6 @@ pub struct BootstrapMacosDefaultsApplyArgs {
     pub yes: bool,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapMacosDefaultsStatusArgs {
     /// Output in JSON format
@@ -637,15 +599,12 @@ pub struct BootstrapMacosDefaultsArgs2 {
 
 #[derive(Subcommand)]
 pub enum BootstrapMacosDefaultsCommands2 {
-    /// Undocumented
     #[command(name = "apply")]
     Apply(Box<BootstrapMacosDefaultsApplyArgs>),
-    /// Undocumented
     #[command(name = "status")]
     Status(Box<BootstrapMacosDefaultsStatusArgs>),
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapMacosLaunchdAgentsApplyArgs {
     /// Print the commands that would run without running them
@@ -656,7 +615,6 @@ pub struct BootstrapMacosLaunchdAgentsApplyArgs {
     pub yes: bool,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapMacosLaunchdAgentsStatusArgs {
     /// Output in JSON format
@@ -676,10 +634,8 @@ pub struct BootstrapMacosLaunchdAgentsArgs {
 
 #[derive(Subcommand)]
 pub enum BootstrapMacosLaunchdAgentsCommands {
-    /// Undocumented
     #[command(name = "apply")]
     Apply(Box<BootstrapMacosLaunchdAgentsApplyArgs>),
-    /// Undocumented
     #[command(name = "status")]
     Status(Box<BootstrapMacosLaunchdAgentsStatusArgs>),
 }
@@ -701,7 +657,6 @@ pub enum BootstrapMacosCommands {
     LaunchdAgents(Box<BootstrapMacosLaunchdAgentsArgs>),
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapMacosDefaultsApplyArgs2 {
     /// Print the commands that would run without running them
@@ -712,7 +667,6 @@ pub struct BootstrapMacosDefaultsApplyArgs2 {
     pub yes: bool,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapMacosDefaultsStatusArgs2 {
     /// Output in JSON format
@@ -732,15 +686,12 @@ pub struct BootstrapMacosDefaultsArgs {
 
 #[derive(Subcommand)]
 pub enum BootstrapMacosDefaultsCommands {
-    /// Undocumented
     #[command(name = "apply")]
     Apply(Box<BootstrapMacosDefaultsApplyArgs2>),
-    /// Undocumented
     #[command(name = "status")]
     Status(Box<BootstrapMacosDefaultsStatusArgs2>),
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapMiseShellActivateApplyArgs {
     /// Print the actions that would run without writing anything
@@ -751,7 +702,6 @@ pub struct BootstrapMiseShellActivateApplyArgs {
     pub yes: bool,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapMiseShellActivateStatusArgs {
     /// Output in JSON format
@@ -771,10 +721,8 @@ pub struct BootstrapMiseShellActivateArgs {
 
 #[derive(Subcommand)]
 pub enum BootstrapMiseShellActivateCommands {
-    /// Undocumented
     #[command(name = "apply")]
     Apply(Box<BootstrapMiseShellActivateApplyArgs>),
-    /// Undocumented
     #[command(name = "status")]
     Status(Box<BootstrapMiseShellActivateStatusArgs>),
 }
@@ -1027,7 +975,6 @@ pub struct BootstrapPlanArgs {
     pub prompt_secrets: bool,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapPluginsApplyArgs {
     /// Print what would happen without installing plugins
@@ -1035,7 +982,6 @@ pub struct BootstrapPluginsApplyArgs {
     pub dry_run: bool,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapPluginsStatusArgs {
     /// Exit with code 1 if a declared plugin is missing
@@ -1052,10 +998,8 @@ pub struct BootstrapPluginsArgs {
 
 #[derive(Subcommand)]
 pub enum BootstrapPluginsCommands {
-    /// Undocumented
     #[command(name = "apply")]
     Apply(Box<BootstrapPluginsApplyArgs>),
-    /// Undocumented
     #[command(name = "status")]
     Status(Box<BootstrapPluginsStatusArgs>),
 }
@@ -1135,7 +1079,6 @@ pub struct BootstrapRemoteArgs {
     pub target: Vec<String>,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapReposApplyArgs {
     /// Print the commands that would run without running them
@@ -1146,7 +1089,6 @@ pub struct BootstrapReposApplyArgs {
     pub yes: bool,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapReposExecArgs {
     /// Continue running in other repos after a command fails
@@ -1163,7 +1105,6 @@ pub struct BootstrapReposExecArgs {
     pub command: Vec<String>,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapReposStatusArgs {
     /// Output in JSON format
@@ -1174,7 +1115,6 @@ pub struct BootstrapReposStatusArgs {
     pub missing: bool,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapReposUpdateArgs {
     /// Print the commands that would run without running them
@@ -1197,16 +1137,12 @@ pub struct BootstrapReposArgs {
 
 #[derive(Subcommand)]
 pub enum BootstrapReposCommands {
-    /// Undocumented
     #[command(name = "apply")]
     Apply(Box<BootstrapReposApplyArgs>),
-    /// Undocumented
     #[command(name = "exec")]
     Exec(Box<BootstrapReposExecArgs>),
-    /// Undocumented
     #[command(name = "status")]
     Status(Box<BootstrapReposStatusArgs>),
-    /// Undocumented
     #[command(name = "update")]
     Update(Box<BootstrapReposUpdateArgs>),
 }
@@ -1289,7 +1225,6 @@ pub struct BootstrapStatusArgs {
     pub prompt_secrets: bool,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapSystemdApplyArgs {
     /// Print the commands that would run without running them
@@ -1300,7 +1235,6 @@ pub struct BootstrapSystemdApplyArgs {
     pub yes: bool,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapSystemdStatusArgs {
     /// Output in JSON format
@@ -1320,15 +1254,12 @@ pub struct BootstrapSystemdArgs {
 
 #[derive(Subcommand)]
 pub enum BootstrapSystemdCommands {
-    /// Undocumented
     #[command(name = "apply")]
     Apply(Box<BootstrapSystemdApplyArgs>),
-    /// Undocumented
     #[command(name = "status")]
     Status(Box<BootstrapSystemdStatusArgs>),
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapUserApplyArgs {
     /// Print the commands that would run without running them
@@ -1339,7 +1270,6 @@ pub struct BootstrapUserApplyArgs {
     pub yes: bool,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapUserStatusArgs {
     /// Output in JSON format
@@ -1359,10 +1289,8 @@ pub struct BootstrapUserArgs {
 
 #[derive(Subcommand)]
 pub enum BootstrapUserCommands {
-    /// Undocumented
     #[command(name = "apply")]
     Apply(Box<BootstrapUserApplyArgs>),
-    /// Undocumented
     #[command(name = "status")]
     Status(Box<BootstrapUserStatusArgs>),
 }
@@ -1449,22 +1377,16 @@ pub struct BootstrapArgs {
 
 #[derive(Subcommand)]
 pub enum BootstrapCommands {
-    /// Undocumented
     #[command(name = "__apply-account-plan")]
     ApplyAccountPlan(Box<BootstrapApplyAccountPlanArgs>),
-    /// Undocumented
     #[command(name = "__apply-service-plan")]
     ApplyServicePlan(Box<BootstrapApplyServicePlanArgs>),
-    /// Undocumented
     #[command(name = "__apply-firewall-plan")]
     ApplyFirewallPlan(Box<BootstrapApplyFirewallPlanArgs>),
-    /// Undocumented
     #[command(name = "__apply-system-plan")]
     ApplySystemPlan(Box<BootstrapApplySystemPlanArgs>),
-    /// Undocumented
     #[command(name = "__inspect-system-files")]
     InspectSystemFiles(Box<BootstrapInspectSystemFilesArgs>),
-    /// Undocumented
     #[command(name = "__inspect-firewall-plan")]
     InspectFirewallPlan(Box<BootstrapInspectFirewallPlanArgs>),
     /// Manage Linux users and groups from `[bootstrap.users]` and `[bootstrap.groups]`
@@ -1612,12 +1534,6 @@ pub struct CompletionArgs {
     /// you may source it separately or enable this flag to enable it in the script.
     #[arg(long = "include-bash-completion-lib")]
     pub include_bash_completion_lib: bool,
-    /// Always use usage for completions.
-    /// Currently, usage is the default for fish and bash but not zsh since it has a few quirks
-    /// to work out first.
-    ///
-    /// This requires the `usage` CLI to be installed.
-    /// https://usage.jdx.dev
     #[arg(long = "usage", hide = true)]
     pub usage: bool,
     /// Shell type to generate completions for
@@ -1664,7 +1580,6 @@ pub struct ConfigSetArgs {
     /// If not provided, the nearest mise.toml file will be used
     #[arg(long = "file", short = 'f', value_name = "FILE")]
     pub file: Option<String>,
-    /// Undocumented
     #[arg(long = "type", short = 't', value_name = "TYPE", value_parser = ::clap::builder::PossibleValuesParser::new(["infer", "string", "integer", "float", "bool", "list", "set"]), default_value = "infer")]
     pub type_: Option<String>,
     /// The path of the config to display
@@ -1731,13 +1646,9 @@ pub struct DeactivateArgs {}
 #[derive(Args)]
 pub struct DirenvActivateArgs {}
 
-/// [internal] This is an internal command that writes an envrc file
-/// for direnv to consume.
 #[derive(Args)]
 pub struct DirenvEnvrcArgs {}
 
-/// [internal] This is an internal command that writes an envrc file
-/// for direnv to consume.
 #[derive(Args)]
 pub struct DirenvExecArgs {}
 
@@ -1759,12 +1670,8 @@ pub enum DirenvCommands {
     /// Output direnv function to use mise inside direnv
     #[command(name = "activate")]
     Activate(Box<DirenvActivateArgs>),
-    /// [internal] This is an internal command that writes an envrc file
-    /// for direnv to consume.
     #[command(name = "envrc")]
     Envrc(Box<DirenvEnvrcArgs>),
-    /// [internal] This is an internal command that writes an envrc file
-    /// for direnv to consume.
     #[command(name = "exec")]
     Exec(Box<DirenvExecArgs>),
 }
@@ -1856,8 +1763,6 @@ pub struct DotfilesStatusArgs {
     /// Output in JSON format
     #[arg(long = "json", short = 'J')]
     pub json: bool,
-    /// Exit with code 1 if any configured dotfiles are not in their desired
-    /// state (missing, source missing, differs)
     #[arg(long = "missing")]
     pub missing: bool,
     /// Only show these targets
@@ -1925,7 +1830,6 @@ pub struct DoctorPathArgs {
 /// Check mise installation for possible problems
 #[derive(Args)]
 pub struct DoctorArgs {
-    /// Undocumented
     #[arg(long = "json", short = 'J')]
     pub json: bool,
     #[command(subcommand)]
@@ -1999,16 +1903,10 @@ pub struct ExecArgs {
     /// Command string to execute
     #[arg(long = "command", short = 'c', value_name = "C")]
     pub command: Option<String>,
-    /// Number of jobs to run in parallel
-    /// [default: 4]
     #[arg(long = "jobs", short = 'j', value_name = "JOBS")]
     pub jobs: Option<String>,
-    /// Allow specific env var through (implies --deny-env for everything else)
-    /// Supports wildcards, e.g. --allow-env='MYAPP_*'
     #[arg(long = "allow-env", value_name = "VAR")]
     pub allow_env: Vec<String>,
-    /// Allow network to specific host (implies --deny-net for everything else)
-    /// macOS only in v1; on Linux falls back to allowing all network
     #[arg(long = "allow-net", value_name = "HOST")]
     pub allow_net: Vec<String>,
     /// Allow reads from specific path (implies --deny-read for everything else)
@@ -2190,7 +2088,6 @@ pub struct GenerateTaskDocsArgs {
     /// root directory to search for tasks
     #[arg(long = "root", short = 'r', value_name = "ROOT")]
     pub root: Option<String>,
-    /// Undocumented
     #[arg(long = "style", short = 's', value_name = "STYLE", value_parser = ::clap::builder::PossibleValuesParser::new(["simple", "detailed"]), default_value = "simple")]
     pub style: Option<String>,
 }
@@ -2371,25 +2268,16 @@ pub enum GithubCommands {
 /// Use `mise local` to set a tool version locally in the current directory.
 #[derive(Args)]
 pub struct GlobalArgs {
-    /// Save fuzzy version to `~/.tool-versions`
-    /// e.g.: `mise global --fuzzy node@20` will save `node 20` to ~/.tool-versions
-    /// this is the default behavior unless MISE_ASDF_COMPAT=1
     #[arg(long = "fuzzy")]
     pub fuzzy: bool,
     /// Get the path of the global config file
     #[arg(long = "path")]
     pub path: bool,
-    /// Save exact version to `~/.tool-versions`
-    /// e.g.: `mise global --pin node@20` will save `node 20.0.0` to ~/.tool-versions
     #[arg(long = "pin")]
     pub pin: bool,
     /// Remove the tool(s) from ~/.tool-versions
     #[arg(long = "remove", value_name = "TOOL")]
     pub remove: Vec<String>,
-    /// Tool(s) to add to .tool-versions
-    /// e.g.: node@20
-    /// If this is a single tool with no version, the current value of the global
-    /// .tool-versions will be displayed
     #[arg(value_name = "TOOL@VERSION", num_args = 0..)]
     pub tool_version: Vec<String>,
 }
@@ -2469,8 +2357,6 @@ pub struct InstallArgs {
     /// Force reinstall even if already installed
     #[arg(long = "force", short = 'f')]
     pub force: bool,
-    /// Number of jobs to run in parallel
-    /// [default: 4]
     #[arg(long = "jobs", short = 'j', value_name = "JOBS")]
     pub jobs: Option<String>,
     /// Show what would be installed without actually installing
@@ -2563,8 +2449,6 @@ pub struct LinkArgs {
     /// Tool name and version to create a symlink for
     #[arg(value_name = "TOOL@VERSION")]
     pub tool_version: String,
-    /// The local path to the tool version
-    /// e.g.: ~/.nvm/versions/node/v20.0.0
     #[arg(value_name = "PATH")]
     pub path: String,
 }
@@ -2577,8 +2461,6 @@ pub struct LinkArgs {
 /// is set. A future v2 release of mise will default to using `mise.toml`.
 #[derive(Args)]
 pub struct LocalArgs {
-    /// Recurse up to find a .tool-versions file rather than using the current directory only
-    /// by default this command will only set the tool in the current directory ("$PWD/.tool-versions")
     #[arg(long = "parent", short = 'p')]
     pub parent: bool,
     /// Save fuzzy version to `.tool-versions` e.g.: `mise local --fuzzy node@20` will save `node 20` to .tool-versions This is the default behavior unless MISE_ASDF_COMPAT=1
@@ -2587,17 +2469,11 @@ pub struct LocalArgs {
     /// Get the path of the config file
     #[arg(long = "path")]
     pub path: bool,
-    /// Save exact version to `.tool-versions`
-    /// e.g.: `mise local --pin node@20` will save `node 20.0.0` to .tool-versions
     #[arg(long = "pin")]
     pub pin: bool,
     /// Remove the tool(s) from .tool-versions
     #[arg(long = "remove", value_name = "TOOL")]
     pub remove: Vec<String>,
-    /// Tool(s) to add to .tool-versions/mise.toml
-    /// e.g.: node@20
-    /// if this is a single tool with no version,
-    /// the current value of .tool-versions/mise.toml will be displayed
     #[arg(value_name = "TOOL@VERSION", num_args = 0..)]
     pub tool_version: Vec<String>,
 }
@@ -2610,8 +2486,6 @@ pub struct LocalArgs {
 /// Operates on the lockfile in the current config root. Use TOOL arguments to target specific tools.
 #[derive(Args)]
 pub struct LockArgs {
-    /// Target only global config lockfiles (~/.config/mise/mise.lock and system config)
-    /// By default, only the active project config root is locked
     #[arg(long = "global", short = 'g')]
     pub global: bool,
     /// Number of jobs to run in parallel
@@ -2620,9 +2494,6 @@ pub struct LockArgs {
     /// Show what would be updated without making changes
     #[arg(long = "dry-run", short = 'n')]
     pub dry_run: bool,
-    /// Comma-separated list of platforms to target
-    /// e.g.: linux-x64,macos-arm64,windows-x64
-    /// If not specified, all platforms already in lockfile will be updated
     #[arg(long = "platform", short = 'p', value_name = "PLATFORM")]
     pub platform: Vec<String>,
     /// Re-resolve fuzzy version selectors against the latest available versions
@@ -2647,8 +2518,6 @@ pub struct LockArgs {
     /// detect available updates without writing the lockfile.
     #[arg(long = "json")]
     pub json: bool,
-    /// Update mise.local.lock instead of mise.lock
-    /// Use for tools defined in .local.toml configs
     #[arg(long = "local")]
     pub local: bool,
     /// Only lock versions released before this age or date
@@ -2659,9 +2528,6 @@ pub struct LockArgs {
     /// Existing matching lockfile entries are preserved and are not downgraded solely by this flag.
     #[arg(long = "minimum-release-age", value_name = "MINIMUM_RELEASE_AGE")]
     pub minimum_release_age: Option<String>,
-    /// Tool(s) to update in lockfile
-    /// e.g.: node python
-    /// If not specified, all tools in lockfile will be updated
     #[arg(value_name = "TOOL", num_args = 0..)]
     pub tool: Vec<String>,
 }
@@ -2696,7 +2562,6 @@ pub struct LsArgs {
     /// Don't fetch information such as outdated versions
     #[arg(long = "offline", short = 'o', hide = true)]
     pub offline: bool,
-    /// Undocumented
     #[arg(long = "plugin", short = 'p', hide = true, value_name = "TOOL_FLAG")]
     pub plugin: Option<String>,
     /// Display all tracked config sources for tools
@@ -2744,10 +2609,6 @@ pub struct LsRemoteArgs {
     /// Disable checking the mise-versions host
     #[arg(long = "no-versions-host")]
     pub no_versions_host: bool,
-    /// Include pre-release versions in the output for backends that report
-    /// upstream prerelease metadata or opt in to regex-based prerelease
-    /// detection. Equivalent to setting `MISE_PRERELEASES=1` or the
-    /// `prereleases` setting for the duration of this command.
     #[arg(long = "prerelease")]
     pub prerelease: bool,
     /// Fail if release metadata fetches fail
@@ -2761,8 +2622,6 @@ pub struct LsRemoteArgs {
     /// Tool to get versions for
     #[arg(value_name = "TOOL@VERSION")]
     pub tool_version: Option<String>,
-    /// The version prefix to use when querying the latest version
-    /// same as the first argument after the "@"
     #[arg(value_name = "PREFIX")]
     pub prefix: Option<String>,
 }
@@ -3026,9 +2885,6 @@ pub struct OutdatedArgs {
     /// Don't show table header
     #[arg(long = "no-header")]
     pub no_header: bool,
-    /// Tool(s) to show outdated versions for
-    /// e.g.: node@20 python@3.10
-    /// If not specified, all tools in global and local configs will be shown
     #[arg(value_name = "TOOL@VERSION", num_args = 0..)]
     pub tool_version: Vec<String>,
 }
@@ -3058,9 +2914,6 @@ pub struct PatronsArgs {
 /// This behavior can be modified in ~/.config/mise/config.toml
 #[derive(Args)]
 pub struct PluginsInstallArgs {
-    /// Install all missing plugins
-    /// This will only install plugins that have matching shorthands.
-    /// i.e.: they don't need the full git repo url
     #[arg(long = "all", short = 'a')]
     pub all: bool,
     /// Reinstall even if plugin exists
@@ -3072,15 +2925,11 @@ pub struct PluginsInstallArgs {
     /// Show installation output
     #[arg(long = "verbose", short = 'v', action = ::clap::ArgAction::Count)]
     pub verbose: u8,
-    /// The name of the plugin to install
-    /// e.g.: cmake, poetry
-    /// Can specify multiple plugins: `mise plugins install cmake poetry`
     #[arg(value_name = "NEW_PLUGIN")]
     pub new_plugin: Option<String>,
     /// The git url of the plugin
     #[arg(value_name = "GIT_URL")]
     pub git_url: Option<String>,
-    /// Undocumented
     #[arg(value_name = "REST", hide = true, num_args = 0..)]
     pub rest: Vec<String>,
 }
@@ -3093,12 +2942,8 @@ pub struct PluginsLinkArgs {
     /// Overwrite existing plugin
     #[arg(long = "force", short = 'f')]
     pub force: bool,
-    /// The name of the plugin
-    /// e.g.: cmake, poetry
     #[arg(value_name = "NAME")]
     pub name: String,
-    /// The local path to the plugin
-    /// e.g.: ./vfox-cmake
     #[arg(value_name = "DIR")]
     pub dir: Option<String>,
 }
@@ -3108,24 +2953,14 @@ pub struct PluginsLinkArgs {
 /// Can also show remotely available plugins to install.
 #[derive(Args)]
 pub struct PluginsLsArgs {
-    /// List all available remote plugins
-    /// Same as `mise plugins ls-remote`
     #[arg(long = "all", short = 'a', hide = true)]
     pub all: bool,
-    /// The built-in plugins only
-    /// Normally these are not shown
     #[arg(long = "core", short = 'c', hide = true)]
     pub core: bool,
-    /// Show plugins with available updates
-    /// Checks the remote for newer versions and only displays plugins that are outdated
     #[arg(long = "outdated", short = 'o')]
     pub outdated: bool,
-    /// Show the git url for each plugin
-    /// e.g.: https://github.com/mise-plugins/vfox-cmake.git
     #[arg(long = "urls", short = 'u')]
     pub urls: bool,
-    /// Show the git refs for each plugin
-    /// e.g.: main 1234abc
     #[arg(long = "refs", hide = true)]
     pub refs: bool,
     /// List installed plugins
@@ -3169,8 +3004,6 @@ pub struct PluginsUninstallArgs {
 /// note: this updates the plugin itself, not the runtime versions
 #[derive(Args)]
 pub struct PluginsUpdateArgs {
-    /// Number of jobs to run in parallel
-    /// Default: 4
     #[arg(long = "jobs", short = 'j', value_name = "JOBS")]
     pub jobs: Option<String>,
     /// Plugin(s) to update
@@ -3186,16 +3019,10 @@ pub struct PluginsArgs {
     /// same as `mise plugins ls-remote`
     #[arg(long = "all", short = 'a', hide = true)]
     pub all: bool,
-    /// The built-in plugins only
-    /// Normally these are not shown
     #[arg(long = "core", short = 'c')]
     pub core: bool,
-    /// Show the git url for each plugin
-    /// e.g.: https://github.com/mise-plugins/vfox-cmake.git
     #[arg(long = "urls", short = 'u')]
     pub urls: bool,
-    /// Show the git refs for each plugin
-    /// e.g.: main 1234abc
     #[arg(long = "refs", hide = true)]
     pub refs: bool,
     /// List installed plugins
@@ -3436,10 +3263,8 @@ pub struct ReshimArgs {
     /// Removes all shims before reshimming
     #[arg(long = "force", short = 'f')]
     pub force: bool,
-    /// Undocumented
     #[arg(value_name = "TOOL", hide = true)]
     pub tool: Option<String>,
-    /// Undocumented
     #[arg(value_name = "VERSION", hide = true)]
     pub version: Option<String>,
 }
@@ -3474,15 +3299,11 @@ pub struct RunArgs {
     /// Run matching tasks only for projects affected by Git changes
     #[arg(long = "affected")]
     pub affected: bool,
-    /// Git base revision for --affected
-    /// Defaults to MISE_AFFECTED_BASE, CI metadata, or HEAD~1
     #[arg(long = "affected-base", value_name = "REV")]
     pub affected_base: Option<String>,
     /// Explain why projects and tasks were selected by --affected
     #[arg(long = "affected-explain")]
     pub affected_explain: bool,
-    /// Git head revision for --affected
-    /// Defaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD
     #[arg(long = "affected-head", value_name = "REV")]
     pub affected_head: Option<String>,
     /// Output affected projects and tasks as JSON without running tasks
@@ -3497,9 +3318,6 @@ pub struct RunArgs {
     /// Force the tasks to run even if outputs are up to date
     #[arg(long = "force", short = 'f')]
     pub force: bool,
-    /// Number of tasks to run in parallel
-    /// [default: 4]
-    /// Configure with `jobs` config or `MISE_JOBS` env var
     #[arg(long = "jobs", short = 'j', value_name = "JOBS")]
     pub jobs: Option<String>,
     /// Don't actually run the task(s), just print them in order of execution
@@ -3519,9 +3337,6 @@ pub struct RunArgs {
     /// Don't show extra output
     #[arg(long = "quiet", short = 'q')]
     pub quiet: bool,
-    /// Read/write directly to stdin/stdout/stderr instead of by line
-    /// Redactions are not applied with this option
-    /// Configure with `raw` config or `MISE_RAW` env var
     #[arg(long = "raw", short = 'r')]
     pub raw: bool,
     /// Shell to use to run toml tasks
@@ -3537,8 +3352,6 @@ pub struct RunArgs {
     /// Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10
     #[arg(long = "tool", short = 't', value_name = "TOOL@VERSION")]
     pub tool: Vec<String>,
-    /// Allow specific env var through (implies --deny-env for everything else)
-    /// Supports wildcards, e.g. --allow-env='MYAPP_*'
     #[arg(long = "allow-env", value_name = "VAR")]
     pub allow_env: Vec<String>,
     /// Allow network to specific host (implies --deny-net for everything else)
@@ -3606,8 +3419,6 @@ pub struct RunArgs {
     /// Report task output cache hits, restored bytes, and time saved
     #[arg(long = "task-cache-stats")]
     pub task_cache_stats: bool,
-    /// Timeout for the task to complete
-    /// e.g.: 30s, 5m
     #[arg(long = "timeout", value_name = "TIMEOUT")]
     pub timeout: Option<String>,
     /// Shows elapsed time after each task completes
@@ -3724,8 +3535,6 @@ pub struct SetArgs {
     /// When using --stdin, provide a single key without a value. The value will be read from stdin until EOF.
     #[arg(long = "stdin")]
     pub stdin: bool,
-    /// Environment variable(s) to set
-    /// e.g.: NODE_ENV=production
     #[arg(value_name = "ENV_VAR", num_args = 0..)]
     pub env_var: Vec<String>,
 }
@@ -3890,8 +3699,6 @@ pub enum SettingsCommands {
 /// such as `MISE_NODE_VERSION=20` which is "eval"ed as a shell function created by `mise activate`.
 #[derive(Args)]
 pub struct ShellArgs {
-    /// Number of jobs to run in parallel
-    /// [default: 4]
     #[arg(long = "jobs", short = 'j', value_name = "JOBS")]
     pub jobs: Option<String>,
     /// Removes a previously set version
@@ -4092,7 +3899,6 @@ pub struct TasksAddArgs {
     /// Tasks name to add
     #[arg(value_name = "TASK")]
     pub task: String,
-    /// Undocumented
     #[arg(value_name = "RUN", num_args = 0.., last = true)]
     pub run: Vec<String>,
 }
@@ -4109,9 +3915,6 @@ pub struct TasksDepsArgs {
     /// Show hidden tasks
     #[arg(long = "hidden")]
     pub hidden: bool,
-    /// Tasks to show dependencies for
-    /// Can specify multiple tasks by separating with spaces
-    /// e.g.: mise tasks deps lint test check
     #[arg(value_name = "TASKS", num_args = 0..)]
     pub tasks: Vec<String>,
 }
@@ -4154,13 +3957,6 @@ pub struct TasksInfoArgs {
     pub task: String,
 }
 
-/// List available tasks to execute
-/// These may be included from the config file or from the project's .mise/tasks directory
-/// mise will merge all tasks from all parent directories into this list.
-///
-/// So if you have global tasks in `~/.config/mise/tasks/*` and project-specific tasks in
-/// ~/myproject/.mise/tasks/*, then they'll both be available but the project-specific
-/// tasks will override the global ones if they have the same name.
 #[derive(Args)]
 pub struct TasksLsArgs {
     /// Only show global tasks
@@ -4175,8 +3971,6 @@ pub struct TasksLsArgs {
     /// Show all columns
     #[arg(long = "extended", short = 'x')]
     pub extended: bool,
-    /// Load all tasks from the entire monorepo, including sibling directories.
-    /// By default, only tasks from the current directory hierarchy are loaded.
     #[arg(long = "all")]
     pub all: bool,
     /// Display tasks for usage completion
@@ -4197,7 +3991,6 @@ pub struct TasksLsArgs {
     /// Sort order. Default is asc.
     #[arg(long = "sort-order", value_name = "SORT_ORDER", value_parser = ::clap::builder::PossibleValuesParser::new(["asc", "desc"]))]
     pub sort_order: Option<String>,
-    /// Undocumented
     #[arg(long = "usage", hide = true)]
     pub usage: bool,
 }
@@ -4232,15 +4025,11 @@ pub struct TasksRunArgs {
     /// Run matching tasks only for projects affected by Git changes
     #[arg(long = "affected")]
     pub affected: bool,
-    /// Git base revision for --affected
-    /// Defaults to MISE_AFFECTED_BASE, CI metadata, or HEAD~1
     #[arg(long = "affected-base", value_name = "REV")]
     pub affected_base: Option<String>,
     /// Explain why projects and tasks were selected by --affected
     #[arg(long = "affected-explain")]
     pub affected_explain: bool,
-    /// Git head revision for --affected
-    /// Defaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD
     #[arg(long = "affected-head", value_name = "REV")]
     pub affected_head: Option<String>,
     /// Output affected projects and tasks as JSON without running tasks
@@ -4255,9 +4044,6 @@ pub struct TasksRunArgs {
     /// Force the tasks to run even if outputs are up to date
     #[arg(long = "force", short = 'f')]
     pub force: bool,
-    /// Number of tasks to run in parallel
-    /// [default: 4]
-    /// Configure with `jobs` config or `MISE_JOBS` env var
     #[arg(long = "jobs", short = 'j', value_name = "JOBS")]
     pub jobs: Option<String>,
     /// Don't actually run the task(s), just print them in order of execution
@@ -4277,9 +4063,6 @@ pub struct TasksRunArgs {
     /// Don't show extra output
     #[arg(long = "quiet", short = 'q')]
     pub quiet: bool,
-    /// Read/write directly to stdin/stdout/stderr instead of by line
-    /// Redactions are not applied with this option
-    /// Configure with `raw` config or `MISE_RAW` env var
     #[arg(long = "raw", short = 'r')]
     pub raw: bool,
     /// Shell to use to run toml tasks
@@ -4295,8 +4078,6 @@ pub struct TasksRunArgs {
     /// Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10
     #[arg(long = "tool", short = 't', value_name = "TOOL@VERSION")]
     pub tool: Vec<String>,
-    /// Allow specific env var through (implies --deny-env for everything else)
-    /// Supports wildcards, e.g. --allow-env='MYAPP_*'
     #[arg(long = "allow-env", value_name = "VAR")]
     pub allow_env: Vec<String>,
     /// Allow network to specific host (implies --deny-net for everything else)
@@ -4364,8 +4145,6 @@ pub struct TasksRunArgs {
     /// Report task output cache hits, restored bytes, and time saved
     #[arg(long = "task-cache-stats")]
     pub task_cache_stats: bool,
-    /// Timeout for the task to complete
-    /// e.g.: 30s, 5m
     #[arg(long = "timeout", value_name = "TIMEOUT")]
     pub timeout: Option<String>,
     /// Shows elapsed time after each task completes
@@ -4373,9 +4152,6 @@ pub struct TasksRunArgs {
     /// Default to always show with `MISE_TASK_TIMINGS=1`
     #[arg(long = "timings", hide = true)]
     pub timings: bool,
-    /// Tasks to run
-    /// Can specify multiple tasks by separating with `:::`
-    /// e.g.: mise run task1 arg1 arg2 ::: task2 arg1 arg2
     #[arg(value_name = "TASK", default_value = "default")]
     pub task: Option<String>,
     /// Arguments to pass to the tasks. Use ":::" to separate tasks
@@ -4395,8 +4171,6 @@ pub struct TasksValidateArgs {
     /// Output validation results in JSON format
     #[arg(long = "json")]
     pub json: bool,
-    /// Tasks to validate
-    /// If not specified, validates all tasks
     #[arg(value_name = "TASKS", num_args = 0..)]
     pub tasks: Vec<String>,
 }
@@ -4416,8 +4190,6 @@ pub struct TasksArgs {
     /// Show all columns
     #[arg(long = "extended", short = 'x')]
     pub extended: bool,
-    /// Load all tasks from the entire monorepo, including sibling directories.
-    /// By default, only tasks from the current directory hierarchy are loaded.
     #[arg(long = "all")]
     pub all: bool,
     /// Display tasks for usage completion
@@ -4438,7 +4210,6 @@ pub struct TasksArgs {
     /// Sort order. Default is asc.
     #[arg(long = "sort-order", value_name = "SORT_ORDER", value_parser = ::clap::builder::PossibleValuesParser::new(["asc", "desc"]))]
     pub sort_order: Option<String>,
-    /// Undocumented
     #[arg(long = "usage", hide = true)]
     pub usage: bool,
     /// Task name to get info of
@@ -4465,9 +4236,6 @@ pub enum TasksCommands {
     /// Get information about a task
     #[command(name = "info")]
     Info(Box<TasksInfoArgs>),
-    /// List available tasks to execute
-    /// These may be included from the config file or from the project's .mise/tasks directory
-    /// mise will merge all tasks from all parent directories into this list.
     #[command(name = "ls")]
     Ls(Box<TasksLsArgs>),
     /// Run task(s)
@@ -4484,8 +4252,6 @@ pub struct TestToolArgs {
     /// Test every tool specified in registry/
     #[arg(long = "all", short = 'a')]
     pub all: bool,
-    /// Number of tool tests to run in parallel
-    /// [default: 4]
     #[arg(long = "jobs", short = 'j', value_name = "JOBS")]
     pub jobs: Option<String>,
     /// Test all tools specified in config files
@@ -4653,8 +4419,6 @@ pub struct TrustArgs {
     /// Do not trust this config and ignore it in the future
     #[arg(long = "ignore")]
     pub ignore: bool,
-    /// Show the trusted status of config files from the current directory and its parents.
-    /// Does not trust or untrust any files.
     #[arg(long = "show")]
     pub show: bool,
     /// No longer trust this config, will prompt in the future
@@ -4701,8 +4465,6 @@ pub struct UnsetArgs {
     /// Use the global config file
     #[arg(long = "global", short = 'g')]
     pub global: bool,
-    /// Environment variable(s) to remove
-    /// e.g.: NODE_ENV
     #[arg(value_name = "ENV_KEY", num_args = 0..)]
     pub env_key: Vec<String>,
 }
@@ -4766,8 +4528,6 @@ pub struct UpgradeArgs {
     /// Display multiselect menu to choose which tools to upgrade
     #[arg(long = "interactive", short = 'i')]
     pub interactive: bool,
-    /// Number of jobs to run in parallel
-    /// [default: 4]
     #[arg(long = "jobs", short = 'j', value_name = "JOBS")]
     pub jobs: Option<String>,
     /// Upgrades to the latest version available, bumping the version in mise.toml
@@ -4782,8 +4542,6 @@ pub struct UpgradeArgs {
     /// Just print what would be done, don't actually do it
     #[arg(long = "dry-run", short = 'n')]
     pub dry_run: bool,
-    /// Tool(s) to exclude from upgrading
-    /// e.g.: go python
     #[arg(long = "exclude", short = 'x', value_name = "INSTALLED_TOOL")]
     pub exclude: Vec<String>,
     /// Like --dry-run but exits with code 1 if there are outdated tools
@@ -4822,9 +4580,6 @@ pub struct UpgradeArgs {
     /// Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1
     #[arg(long = "raw")]
     pub raw: bool,
-    /// Tool(s) to upgrade
-    /// e.g.: node@20 python@3.10
-    /// If not specified, all current tools will be upgraded
     #[arg(value_name = "INSTALLED_TOOL@VERSION", num_args = 0..)]
     pub installed_tool_version: Vec<String>,
 }
@@ -4865,8 +4620,6 @@ pub struct UseArgs {
     /// Use the global config file (`~/.config/mise/config.toml`) instead of the local one
     #[arg(long = "global", short = 'g')]
     pub global: bool,
-    /// Number of jobs to run in parallel
-    /// [default: 4]
     #[arg(long = "jobs", short = 'j', value_name = "JOBS")]
     pub jobs: Option<String>,
     /// Perform a dry run, showing what would be installed and modified without making changes
@@ -4893,12 +4646,6 @@ pub struct UseArgs {
     /// Supports absolute dates like "2024-06-01" and relative durations like "90d" or "1y".
     #[arg(long = "minimum-release-age", value_name = "MINIMUM_RELEASE_AGE")]
     pub minimum_release_age: Option<String>,
-    /// Save exact version to config file
-    /// e.g.: `mise use --pin node@20` will save 20.0.0 as the version
-    /// Set `MISE_PIN=1` to make this the default behavior
-    ///
-    /// Consider using mise.lock as a better alternative to pinning in mise.toml:
-    /// https://mise.jdx.dev/configuration/settings.html#lockfile
     #[arg(long = "pin")]
     pub pin: bool,
     /// Connect backend install command stdin/stdout/stderr directly to the terminal Implies `--jobs=1`
@@ -4943,8 +4690,6 @@ pub struct WatchArgs {
     /// Tasks to run
     #[arg(long = "task-flag", short = 't', hide = true, value_name = "TASK_FLAG")]
     pub task_flag: Vec<String>,
-    /// Files to watch
-    /// Defaults to sources from the task(s)
     #[arg(long = "glob", short = 'g', hide = true, value_name = "GLOB")]
     pub glob: Vec<String>,
     /// Run only the specified tasks skipping all dependencies
@@ -5446,9 +5191,6 @@ pub struct WatchArgs {
     /// This shows the manual page for Watchexec, if the output is a terminal and the 'man' program is available. If not, the manual page is printed to stdout in ROFF format (suitable for writing to a watchexec.1 file).
     #[arg(long = "manual")]
     pub manual: bool,
-    /// Tasks to run
-    /// Can specify multiple tasks by separating with `:::`
-    /// e.g.: `mise run task1 arg1 arg2 ::: task2 arg1 arg2`
     #[arg(value_name = "TASK")]
     pub task: Option<String>,
     /// Task and arguments to run
@@ -5461,16 +5203,8 @@ pub struct WatchArgs {
 /// The tool must be installed for this to work.
 #[derive(Args)]
 pub struct WhereArgs {
-    /// Tool(s) to look up
-    /// e.g.: ruby@3
-    /// if "@<PREFIX>" is specified, it will show the latest installed version
-    /// that matches the prefix
-    /// otherwise, it will show the current, active installed version
     #[arg(value_name = "TOOL@VERSION")]
     pub tool_version: String,
-    /// the version prefix to use when querying the latest version
-    /// same as the first argument after the "@"
-    /// used for asdf compatibility
     #[arg(value_name = "ASDF_VERSION", hide = true)]
     pub asdf_version: Option<String>,
 }
@@ -5480,11 +5214,8 @@ pub struct WhereArgs {
 /// Use this to figure out what version of a tool is currently active.
 #[derive(Args)]
 pub struct WhichArgs {
-    /// Use a specific tool@version
-    /// e.g.: `mise which npm --tool=node@20`
     #[arg(long = "tool", short = 't', value_name = "TOOL@VERSION")]
     pub tool: Option<String>,
-    /// Undocumented
     #[arg(long = "complete", hide = true)]
     pub complete: bool,
     /// Show the plugin name instead of the path
@@ -5498,7 +5229,9 @@ pub struct WhichArgs {
     pub bin_name: Option<String>,
 }
 
-/// Undocumented
+/// Dev tools, env vars, and tasks in one CLI
+///
+/// mise prepares your development environment before each command runs. https://github.com/jdx/mise
 #[derive(Parser)]
 #[command(name = "mise")]
 pub struct Cli {
@@ -5532,7 +5265,6 @@ pub struct Cli {
     /// Suppress non-error messages
     #[arg(long = "quiet", short = 'q', global = true)]
     pub quiet: bool,
-    /// Undocumented
     #[arg(long = "shell", short = 's', hide = true, value_name = "SHELL")]
     pub shell: Option<String>,
     /// Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10
@@ -5541,7 +5273,6 @@ pub struct Cli {
     /// Show extra output (use -vv for even more)
     #[arg(long = "verbose", short = 'v', global = true, action = ::clap::ArgAction::Count)]
     pub verbose: u8,
-    /// Undocumented
     #[arg(long = "version", short = 'V', hide = true)]
     pub version: bool,
     /// Answer yes to all confirmation prompts
@@ -5550,7 +5281,6 @@ pub struct Cli {
     /// Sets log level to debug
     #[arg(long = "debug", global = true, hide = true)]
     pub debug: bool,
-    /// Undocumented
     #[arg(long = "log-level", global = true, hide = true, value_name = "LEVEL", value_parser = ::clap::builder::PossibleValuesParser::new(["trace", "debug", "info", "warning", "error"]))]
     pub log_level: Option<String>,
     /// Do not load any config files
@@ -5573,7 +5303,6 @@ pub struct Cli {
     /// Default to always hide with `MISE_TASK_TIMINGS=0`
     #[arg(long = "no-timings", hide = true)]
     pub no_timings: bool,
-    /// Undocumented
     #[arg(long = "output", value_name = "OUTPUT")]
     pub output: Option<String>,
     /// Read/write directly to stdin/stdout/stderr instead of by line
@@ -5605,7 +5334,6 @@ pub struct Cli {
     /// Task arguments
     #[arg(value_name = "TASK_ARGS", hide = true, num_args = 0..)]
     pub task_args: Vec<String>,
-    /// Undocumented
     #[arg(value_name = "TASK_ARGS_LAST", hide = true, num_args = 0.., last = true)]
     pub task_args_last: Vec<String>,
     #[command(subcommand)]

--- a/benches/shadows/mise-clap/src/lib.rs
+++ b/benches/shadows/mise-clap/src/lib.rs
@@ -36,7 +36,11 @@ pub struct ActivateArgs {
     /// This can be helpful for debugging mise. If you run `eval "$(mise activate --no-hook-env)"`, then you can call `mise hook-env` manually which will output the env vars to stdout without actually modifying the environment. That way you can do things like `mise hook-env --trace` to get more information or just see the values that hook-env is outputting.
     #[arg(long = "no-hook-env")]
     pub no_hook_env: bool,
-    #[arg(long = "shims")]
+    #[arg(
+        help = "Use shims instead of modifying PATH\nEffectively the same as:",
+        long_help = "Use shims instead of modifying PATH\nEffectively the same as:\n\n    PATH=\"$HOME/.local/share/mise/shims:$PATH\"\n\n`mise activate --shims` does not support all the features of `mise activate`.\nSee https://mise.jdx.dev/dev-tools/shims.html#shims-vs-path for more information",
+        long = "shims"
+    )]
     pub shims: bool,
     /// Show "mise: <TOOL>@<VERSION>" message when changing directories
     #[arg(long = "status", hide = true)]
@@ -116,7 +120,12 @@ pub enum ToolAliasCommands {
     /// Show an alias for a tool
     #[command(name = "get")]
     Get(Box<ToolAliasGetArgs>),
-    #[command(name = "ls", visible_alias = "list")]
+    #[command(
+        name = "ls",
+        about = "List tool version aliases\nShows the aliases that can be specified.\nThese can come from user config or from plugins in `bin/list-aliases`.",
+        long_about = "List tool version aliases\nShows the aliases that can be specified.\nThese can come from user config or from plugins in `bin/list-aliases`.\n\nFor user config, aliases are defined like the following in `~/.config/mise/config.toml`:\n\n    [tool_alias.node.versions]\n    lts = \"22.0.0\"",
+        visible_alias = "list"
+    )]
     Ls(Box<ToolAliasLsArgs>),
     /// Add/update an alias for a tool/backend
     #[command(name = "set", visible_aliases = ["add", "create"])]
@@ -161,7 +170,7 @@ pub struct BinPathsArgs {
     /// Output executable entries in JSON format (implies --bin-names)
     #[arg(long = "json", short = 'J')]
     pub json: bool,
-    #[arg(value_name = "TOOL@VERSION", num_args = 0..)]
+    #[arg(value_name = "TOOL@VERSION", help = "Tool(s) to look up\ne.g.: ruby@3", num_args = 0..)]
     pub tool_version: Vec<String>,
 }
 
@@ -348,7 +357,10 @@ pub struct BootstrapDotfilesStatusArgs {
     /// Output in JSON format
     #[arg(long = "json", short = 'J')]
     pub json: bool,
-    #[arg(long = "missing")]
+    #[arg(
+        help = "Exit with code 1 if any configured dotfiles are not in their desired\nstate (missing, source missing, differs)",
+        long = "missing"
+    )]
     pub missing: bool,
     /// Only show these targets
     #[arg(value_name = "TARGET", num_args = 0..)]
@@ -1534,7 +1546,12 @@ pub struct CompletionArgs {
     /// you may source it separately or enable this flag to enable it in the script.
     #[arg(long = "include-bash-completion-lib")]
     pub include_bash_completion_lib: bool,
-    #[arg(long = "usage", hide = true)]
+    #[arg(
+        help = "Always use usage for completions.\nCurrently, usage is the default for fish and bash but not zsh since it has a few quirks\nto work out first.",
+        long_help = "Always use usage for completions.\nCurrently, usage is the default for fish and bash but not zsh since it has a few quirks\nto work out first.\n\nThis requires the `usage` CLI to be installed.\nhttps://usage.jdx.dev",
+        long = "usage",
+        hide = true
+    )]
     pub usage: bool,
     /// Shell type to generate completions for
     #[arg(value_name = "SHELL", value_parser = ::clap::builder::PossibleValuesParser::new(["bash", "fish", "powershell", "zsh"]))]
@@ -1670,9 +1687,15 @@ pub enum DirenvCommands {
     /// Output direnv function to use mise inside direnv
     #[command(name = "activate")]
     Activate(Box<DirenvActivateArgs>),
-    #[command(name = "envrc")]
+    #[command(
+        name = "envrc",
+        about = "[internal] This is an internal command that writes an envrc file\nfor direnv to consume."
+    )]
     Envrc(Box<DirenvEnvrcArgs>),
-    #[command(name = "exec")]
+    #[command(
+        name = "exec",
+        about = "[internal] This is an internal command that writes an envrc file\nfor direnv to consume."
+    )]
     Exec(Box<DirenvExecArgs>),
 }
 
@@ -1763,7 +1786,10 @@ pub struct DotfilesStatusArgs {
     /// Output in JSON format
     #[arg(long = "json", short = 'J')]
     pub json: bool,
-    #[arg(long = "missing")]
+    #[arg(
+        help = "Exit with code 1 if any configured dotfiles are not in their desired\nstate (missing, source missing, differs)",
+        long = "missing"
+    )]
     pub missing: bool,
     /// Only show these targets
     #[arg(value_name = "TARGET", num_args = 0..)]
@@ -1903,11 +1929,24 @@ pub struct ExecArgs {
     /// Command string to execute
     #[arg(long = "command", short = 'c', value_name = "C")]
     pub command: Option<String>,
-    #[arg(long = "jobs", short = 'j', value_name = "JOBS")]
+    #[arg(
+        help = "Number of jobs to run in parallel\n[default: 4]",
+        long = "jobs",
+        short = 'j',
+        value_name = "JOBS"
+    )]
     pub jobs: Option<String>,
-    #[arg(long = "allow-env", value_name = "VAR")]
+    #[arg(
+        help = "Allow specific env var through (implies --deny-env for everything else)\nSupports wildcards, e.g. --allow-env='MYAPP_*'",
+        long = "allow-env",
+        value_name = "VAR"
+    )]
     pub allow_env: Vec<String>,
-    #[arg(long = "allow-net", value_name = "HOST")]
+    #[arg(
+        help = "Allow network to specific host (implies --deny-net for everything else)\nmacOS only in v1; on Linux falls back to allowing all network",
+        long = "allow-net",
+        value_name = "HOST"
+    )]
     pub allow_net: Vec<String>,
     /// Allow reads from specific path (implies --deny-read for everything else)
     #[arg(long = "allow-read", value_name = "PATH")]
@@ -2268,17 +2307,23 @@ pub enum GithubCommands {
 /// Use `mise local` to set a tool version locally in the current directory.
 #[derive(Args)]
 pub struct GlobalArgs {
-    #[arg(long = "fuzzy")]
+    #[arg(
+        help = "Save fuzzy version to `~/.tool-versions`\ne.g.: `mise global --fuzzy node@20` will save `node 20` to ~/.tool-versions\nthis is the default behavior unless MISE_ASDF_COMPAT=1",
+        long = "fuzzy"
+    )]
     pub fuzzy: bool,
     /// Get the path of the global config file
     #[arg(long = "path")]
     pub path: bool,
-    #[arg(long = "pin")]
+    #[arg(
+        help = "Save exact version to `~/.tool-versions`\ne.g.: `mise global --pin node@20` will save `node 20.0.0` to ~/.tool-versions",
+        long = "pin"
+    )]
     pub pin: bool,
     /// Remove the tool(s) from ~/.tool-versions
     #[arg(long = "remove", value_name = "TOOL")]
     pub remove: Vec<String>,
-    #[arg(value_name = "TOOL@VERSION", num_args = 0..)]
+    #[arg(value_name = "TOOL@VERSION", help = "Tool(s) to add to .tool-versions\ne.g.: node@20\nIf this is a single tool with no version, the current value of the global\n.tool-versions will be displayed", num_args = 0..)]
     pub tool_version: Vec<String>,
 }
 
@@ -2357,7 +2402,12 @@ pub struct InstallArgs {
     /// Force reinstall even if already installed
     #[arg(long = "force", short = 'f')]
     pub force: bool,
-    #[arg(long = "jobs", short = 'j', value_name = "JOBS")]
+    #[arg(
+        help = "Number of jobs to run in parallel\n[default: 4]",
+        long = "jobs",
+        short = 'j',
+        value_name = "JOBS"
+    )]
     pub jobs: Option<String>,
     /// Show what would be installed without actually installing
     #[arg(long = "dry-run", short = 'n')]
@@ -2449,7 +2499,10 @@ pub struct LinkArgs {
     /// Tool name and version to create a symlink for
     #[arg(value_name = "TOOL@VERSION")]
     pub tool_version: String,
-    #[arg(value_name = "PATH")]
+    #[arg(
+        value_name = "PATH",
+        help = "The local path to the tool version\ne.g.: ~/.nvm/versions/node/v20.0.0"
+    )]
     pub path: String,
 }
 
@@ -2461,7 +2514,11 @@ pub struct LinkArgs {
 /// is set. A future v2 release of mise will default to using `mise.toml`.
 #[derive(Args)]
 pub struct LocalArgs {
-    #[arg(long = "parent", short = 'p')]
+    #[arg(
+        help = "Recurse up to find a .tool-versions file rather than using the current directory only\nby default this command will only set the tool in the current directory (\"$PWD/.tool-versions\")",
+        long = "parent",
+        short = 'p'
+    )]
     pub parent: bool,
     /// Save fuzzy version to `.tool-versions` e.g.: `mise local --fuzzy node@20` will save `node 20` to .tool-versions This is the default behavior unless MISE_ASDF_COMPAT=1
     #[arg(long = "fuzzy")]
@@ -2469,12 +2526,15 @@ pub struct LocalArgs {
     /// Get the path of the config file
     #[arg(long = "path")]
     pub path: bool,
-    #[arg(long = "pin")]
+    #[arg(
+        help = "Save exact version to `.tool-versions`\ne.g.: `mise local --pin node@20` will save `node 20.0.0` to .tool-versions",
+        long = "pin"
+    )]
     pub pin: bool,
     /// Remove the tool(s) from .tool-versions
     #[arg(long = "remove", value_name = "TOOL")]
     pub remove: Vec<String>,
-    #[arg(value_name = "TOOL@VERSION", num_args = 0..)]
+    #[arg(value_name = "TOOL@VERSION", help = "Tool(s) to add to .tool-versions/mise.toml\ne.g.: node@20\nif this is a single tool with no version,\nthe current value of .tool-versions/mise.toml will be displayed", num_args = 0..)]
     pub tool_version: Vec<String>,
 }
 
@@ -2486,7 +2546,11 @@ pub struct LocalArgs {
 /// Operates on the lockfile in the current config root. Use TOOL arguments to target specific tools.
 #[derive(Args)]
 pub struct LockArgs {
-    #[arg(long = "global", short = 'g')]
+    #[arg(
+        help = "Target only global config lockfiles (~/.config/mise/mise.lock and system config)\nBy default, only the active project config root is locked",
+        long = "global",
+        short = 'g'
+    )]
     pub global: bool,
     /// Number of jobs to run in parallel
     #[arg(long = "jobs", short = 'j', value_name = "JOBS")]
@@ -2494,7 +2558,12 @@ pub struct LockArgs {
     /// Show what would be updated without making changes
     #[arg(long = "dry-run", short = 'n')]
     pub dry_run: bool,
-    #[arg(long = "platform", short = 'p', value_name = "PLATFORM")]
+    #[arg(
+        help = "Comma-separated list of platforms to target\ne.g.: linux-x64,macos-arm64,windows-x64\nIf not specified, all platforms already in lockfile will be updated",
+        long = "platform",
+        short = 'p',
+        value_name = "PLATFORM"
+    )]
     pub platform: Vec<String>,
     /// Re-resolve fuzzy version selectors against the latest available versions
     ///
@@ -2518,7 +2587,10 @@ pub struct LockArgs {
     /// detect available updates without writing the lockfile.
     #[arg(long = "json")]
     pub json: bool,
-    #[arg(long = "local")]
+    #[arg(
+        help = "Update mise.local.lock instead of mise.lock\nUse for tools defined in .local.toml configs",
+        long = "local"
+    )]
     pub local: bool,
     /// Only lock versions released before this age or date
     ///
@@ -2528,7 +2600,7 @@ pub struct LockArgs {
     /// Existing matching lockfile entries are preserved and are not downgraded solely by this flag.
     #[arg(long = "minimum-release-age", value_name = "MINIMUM_RELEASE_AGE")]
     pub minimum_release_age: Option<String>,
-    #[arg(value_name = "TOOL", num_args = 0..)]
+    #[arg(value_name = "TOOL", help = "Tool(s) to update in lockfile\ne.g.: node python\nIf not specified, all tools in lockfile will be updated", num_args = 0..)]
     pub tool: Vec<String>,
 }
 
@@ -2609,7 +2681,10 @@ pub struct LsRemoteArgs {
     /// Disable checking the mise-versions host
     #[arg(long = "no-versions-host")]
     pub no_versions_host: bool,
-    #[arg(long = "prerelease")]
+    #[arg(
+        help = "Include pre-release versions in the output for backends that report\nupstream prerelease metadata or opt in to regex-based prerelease\ndetection. Equivalent to setting `MISE_PRERELEASES=1` or the\n`prereleases` setting for the duration of this command.",
+        long = "prerelease"
+    )]
     pub prerelease: bool,
     /// Fail if release metadata fetches fail
     ///
@@ -2622,7 +2697,10 @@ pub struct LsRemoteArgs {
     /// Tool to get versions for
     #[arg(value_name = "TOOL@VERSION")]
     pub tool_version: Option<String>,
-    #[arg(value_name = "PREFIX")]
+    #[arg(
+        value_name = "PREFIX",
+        help = "The version prefix to use when querying the latest version\nsame as the first argument after the \"@\""
+    )]
     pub prefix: Option<String>,
 }
 
@@ -2885,7 +2963,7 @@ pub struct OutdatedArgs {
     /// Don't show table header
     #[arg(long = "no-header")]
     pub no_header: bool,
-    #[arg(value_name = "TOOL@VERSION", num_args = 0..)]
+    #[arg(value_name = "TOOL@VERSION", help = "Tool(s) to show outdated versions for\ne.g.: node@20 python@3.10\nIf not specified, all tools in global and local configs will be shown", num_args = 0..)]
     pub tool_version: Vec<String>,
 }
 
@@ -2914,7 +2992,11 @@ pub struct PatronsArgs {
 /// This behavior can be modified in ~/.config/mise/config.toml
 #[derive(Args)]
 pub struct PluginsInstallArgs {
-    #[arg(long = "all", short = 'a')]
+    #[arg(
+        help = "Install all missing plugins\nThis will only install plugins that have matching shorthands.\ni.e.: they don't need the full git repo url",
+        long = "all",
+        short = 'a'
+    )]
     pub all: bool,
     /// Reinstall even if plugin exists
     #[arg(long = "force", short = 'f')]
@@ -2925,7 +3007,10 @@ pub struct PluginsInstallArgs {
     /// Show installation output
     #[arg(long = "verbose", short = 'v', action = ::clap::ArgAction::Count)]
     pub verbose: u8,
-    #[arg(value_name = "NEW_PLUGIN")]
+    #[arg(
+        value_name = "NEW_PLUGIN",
+        help = "The name of the plugin to install\ne.g.: cmake, poetry\nCan specify multiple plugins: `mise plugins install cmake poetry`"
+    )]
     pub new_plugin: Option<String>,
     /// The git url of the plugin
     #[arg(value_name = "GIT_URL")]
@@ -2942,9 +3027,15 @@ pub struct PluginsLinkArgs {
     /// Overwrite existing plugin
     #[arg(long = "force", short = 'f')]
     pub force: bool,
-    #[arg(value_name = "NAME")]
+    #[arg(
+        value_name = "NAME",
+        help = "The name of the plugin\ne.g.: cmake, poetry"
+    )]
     pub name: String,
-    #[arg(value_name = "DIR")]
+    #[arg(
+        value_name = "DIR",
+        help = "The local path to the plugin\ne.g.: ./vfox-cmake"
+    )]
     pub dir: Option<String>,
 }
 
@@ -2953,15 +3044,37 @@ pub struct PluginsLinkArgs {
 /// Can also show remotely available plugins to install.
 #[derive(Args)]
 pub struct PluginsLsArgs {
-    #[arg(long = "all", short = 'a', hide = true)]
+    #[arg(
+        help = "List all available remote plugins\nSame as `mise plugins ls-remote`",
+        long = "all",
+        short = 'a',
+        hide = true
+    )]
     pub all: bool,
-    #[arg(long = "core", short = 'c', hide = true)]
+    #[arg(
+        help = "The built-in plugins only\nNormally these are not shown",
+        long = "core",
+        short = 'c',
+        hide = true
+    )]
     pub core: bool,
-    #[arg(long = "outdated", short = 'o')]
+    #[arg(
+        help = "Show plugins with available updates\nChecks the remote for newer versions and only displays plugins that are outdated",
+        long = "outdated",
+        short = 'o'
+    )]
     pub outdated: bool,
-    #[arg(long = "urls", short = 'u')]
+    #[arg(
+        help = "Show the git url for each plugin\ne.g.: https://github.com/mise-plugins/vfox-cmake.git",
+        long = "urls",
+        short = 'u'
+    )]
     pub urls: bool,
-    #[arg(long = "refs", hide = true)]
+    #[arg(
+        help = "Show the git refs for each plugin\ne.g.: main 1234abc",
+        long = "refs",
+        hide = true
+    )]
     pub refs: bool,
     /// List installed plugins
     #[arg(long = "user", hide = true)]
@@ -3004,7 +3117,12 @@ pub struct PluginsUninstallArgs {
 /// note: this updates the plugin itself, not the runtime versions
 #[derive(Args)]
 pub struct PluginsUpdateArgs {
-    #[arg(long = "jobs", short = 'j', value_name = "JOBS")]
+    #[arg(
+        help = "Number of jobs to run in parallel\nDefault: 4",
+        long = "jobs",
+        short = 'j',
+        value_name = "JOBS"
+    )]
     pub jobs: Option<String>,
     /// Plugin(s) to update
     #[arg(value_name = "PLUGIN", num_args = 0..)]
@@ -3019,11 +3137,23 @@ pub struct PluginsArgs {
     /// same as `mise plugins ls-remote`
     #[arg(long = "all", short = 'a', hide = true)]
     pub all: bool,
-    #[arg(long = "core", short = 'c')]
+    #[arg(
+        help = "The built-in plugins only\nNormally these are not shown",
+        long = "core",
+        short = 'c'
+    )]
     pub core: bool,
-    #[arg(long = "urls", short = 'u')]
+    #[arg(
+        help = "Show the git url for each plugin\ne.g.: https://github.com/mise-plugins/vfox-cmake.git",
+        long = "urls",
+        short = 'u'
+    )]
     pub urls: bool,
-    #[arg(long = "refs", hide = true)]
+    #[arg(
+        help = "Show the git refs for each plugin\ne.g.: main 1234abc",
+        long = "refs",
+        hide = true
+    )]
     pub refs: bool,
     /// List installed plugins
     ///
@@ -3299,12 +3429,20 @@ pub struct RunArgs {
     /// Run matching tasks only for projects affected by Git changes
     #[arg(long = "affected")]
     pub affected: bool,
-    #[arg(long = "affected-base", value_name = "REV")]
+    #[arg(
+        help = "Git base revision for --affected\nDefaults to MISE_AFFECTED_BASE, CI metadata, or HEAD~1",
+        long = "affected-base",
+        value_name = "REV"
+    )]
     pub affected_base: Option<String>,
     /// Explain why projects and tasks were selected by --affected
     #[arg(long = "affected-explain")]
     pub affected_explain: bool,
-    #[arg(long = "affected-head", value_name = "REV")]
+    #[arg(
+        help = "Git head revision for --affected\nDefaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD",
+        long = "affected-head",
+        value_name = "REV"
+    )]
     pub affected_head: Option<String>,
     /// Output affected projects and tasks as JSON without running tasks
     #[arg(long = "affected-json")]
@@ -3318,7 +3456,12 @@ pub struct RunArgs {
     /// Force the tasks to run even if outputs are up to date
     #[arg(long = "force", short = 'f')]
     pub force: bool,
-    #[arg(long = "jobs", short = 'j', value_name = "JOBS")]
+    #[arg(
+        help = "Number of tasks to run in parallel\n[default: 4]\nConfigure with `jobs` config or `MISE_JOBS` env var",
+        long = "jobs",
+        short = 'j',
+        value_name = "JOBS"
+    )]
     pub jobs: Option<String>,
     /// Don't actually run the task(s), just print them in order of execution
     #[arg(long = "dry-run", short = 'n')]
@@ -3337,7 +3480,11 @@ pub struct RunArgs {
     /// Don't show extra output
     #[arg(long = "quiet", short = 'q')]
     pub quiet: bool,
-    #[arg(long = "raw", short = 'r')]
+    #[arg(
+        help = "Read/write directly to stdin/stdout/stderr instead of by line\nRedactions are not applied with this option\nConfigure with `raw` config or `MISE_RAW` env var",
+        long = "raw",
+        short = 'r'
+    )]
     pub raw: bool,
     /// Shell to use to run toml tasks
     ///
@@ -3352,7 +3499,11 @@ pub struct RunArgs {
     /// Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10
     #[arg(long = "tool", short = 't', value_name = "TOOL@VERSION")]
     pub tool: Vec<String>,
-    #[arg(long = "allow-env", value_name = "VAR")]
+    #[arg(
+        help = "Allow specific env var through (implies --deny-env for everything else)\nSupports wildcards, e.g. --allow-env='MYAPP_*'",
+        long = "allow-env",
+        value_name = "VAR"
+    )]
     pub allow_env: Vec<String>,
     /// Allow network to specific host (implies --deny-net for everything else)
     #[arg(long = "allow-net", value_name = "HOST")]
@@ -3419,7 +3570,11 @@ pub struct RunArgs {
     /// Report task output cache hits, restored bytes, and time saved
     #[arg(long = "task-cache-stats")]
     pub task_cache_stats: bool,
-    #[arg(long = "timeout", value_name = "TIMEOUT")]
+    #[arg(
+        help = "Timeout for the task to complete\ne.g.: 30s, 5m",
+        long = "timeout",
+        value_name = "TIMEOUT"
+    )]
     pub timeout: Option<String>,
     /// Shows elapsed time after each task completes
     ///
@@ -3535,7 +3690,7 @@ pub struct SetArgs {
     /// When using --stdin, provide a single key without a value. The value will be read from stdin until EOF.
     #[arg(long = "stdin")]
     pub stdin: bool,
-    #[arg(value_name = "ENV_VAR", num_args = 0..)]
+    #[arg(value_name = "ENV_VAR", help = "Environment variable(s) to set\ne.g.: NODE_ENV=production", num_args = 0..)]
     pub env_var: Vec<String>,
 }
 
@@ -3699,7 +3854,12 @@ pub enum SettingsCommands {
 /// such as `MISE_NODE_VERSION=20` which is "eval"ed as a shell function created by `mise activate`.
 #[derive(Args)]
 pub struct ShellArgs {
-    #[arg(long = "jobs", short = 'j', value_name = "JOBS")]
+    #[arg(
+        help = "Number of jobs to run in parallel\n[default: 4]",
+        long = "jobs",
+        short = 'j',
+        value_name = "JOBS"
+    )]
     pub jobs: Option<String>,
     /// Removes a previously set version
     #[arg(long = "unset", short = 'u')]
@@ -3915,7 +4075,7 @@ pub struct TasksDepsArgs {
     /// Show hidden tasks
     #[arg(long = "hidden")]
     pub hidden: bool,
-    #[arg(value_name = "TASKS", num_args = 0..)]
+    #[arg(value_name = "TASKS", help = "Tasks to show dependencies for\nCan specify multiple tasks by separating with spaces\ne.g.: mise tasks deps lint test check", num_args = 0..)]
     pub tasks: Vec<String>,
 }
 
@@ -3971,7 +4131,10 @@ pub struct TasksLsArgs {
     /// Show all columns
     #[arg(long = "extended", short = 'x')]
     pub extended: bool,
-    #[arg(long = "all")]
+    #[arg(
+        help = "Load all tasks from the entire monorepo, including sibling directories.\nBy default, only tasks from the current directory hierarchy are loaded.",
+        long = "all"
+    )]
     pub all: bool,
     /// Display tasks for usage completion
     #[arg(long = "complete", hide = true)]
@@ -4025,12 +4188,20 @@ pub struct TasksRunArgs {
     /// Run matching tasks only for projects affected by Git changes
     #[arg(long = "affected")]
     pub affected: bool,
-    #[arg(long = "affected-base", value_name = "REV")]
+    #[arg(
+        help = "Git base revision for --affected\nDefaults to MISE_AFFECTED_BASE, CI metadata, or HEAD~1",
+        long = "affected-base",
+        value_name = "REV"
+    )]
     pub affected_base: Option<String>,
     /// Explain why projects and tasks were selected by --affected
     #[arg(long = "affected-explain")]
     pub affected_explain: bool,
-    #[arg(long = "affected-head", value_name = "REV")]
+    #[arg(
+        help = "Git head revision for --affected\nDefaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD",
+        long = "affected-head",
+        value_name = "REV"
+    )]
     pub affected_head: Option<String>,
     /// Output affected projects and tasks as JSON without running tasks
     #[arg(long = "affected-json")]
@@ -4044,7 +4215,12 @@ pub struct TasksRunArgs {
     /// Force the tasks to run even if outputs are up to date
     #[arg(long = "force", short = 'f')]
     pub force: bool,
-    #[arg(long = "jobs", short = 'j', value_name = "JOBS")]
+    #[arg(
+        help = "Number of tasks to run in parallel\n[default: 4]\nConfigure with `jobs` config or `MISE_JOBS` env var",
+        long = "jobs",
+        short = 'j',
+        value_name = "JOBS"
+    )]
     pub jobs: Option<String>,
     /// Don't actually run the task(s), just print them in order of execution
     #[arg(long = "dry-run", short = 'n')]
@@ -4063,7 +4239,11 @@ pub struct TasksRunArgs {
     /// Don't show extra output
     #[arg(long = "quiet", short = 'q')]
     pub quiet: bool,
-    #[arg(long = "raw", short = 'r')]
+    #[arg(
+        help = "Read/write directly to stdin/stdout/stderr instead of by line\nRedactions are not applied with this option\nConfigure with `raw` config or `MISE_RAW` env var",
+        long = "raw",
+        short = 'r'
+    )]
     pub raw: bool,
     /// Shell to use to run toml tasks
     ///
@@ -4078,7 +4258,11 @@ pub struct TasksRunArgs {
     /// Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10
     #[arg(long = "tool", short = 't', value_name = "TOOL@VERSION")]
     pub tool: Vec<String>,
-    #[arg(long = "allow-env", value_name = "VAR")]
+    #[arg(
+        help = "Allow specific env var through (implies --deny-env for everything else)\nSupports wildcards, e.g. --allow-env='MYAPP_*'",
+        long = "allow-env",
+        value_name = "VAR"
+    )]
     pub allow_env: Vec<String>,
     /// Allow network to specific host (implies --deny-net for everything else)
     #[arg(long = "allow-net", value_name = "HOST")]
@@ -4145,14 +4329,22 @@ pub struct TasksRunArgs {
     /// Report task output cache hits, restored bytes, and time saved
     #[arg(long = "task-cache-stats")]
     pub task_cache_stats: bool,
-    #[arg(long = "timeout", value_name = "TIMEOUT")]
+    #[arg(
+        help = "Timeout for the task to complete\ne.g.: 30s, 5m",
+        long = "timeout",
+        value_name = "TIMEOUT"
+    )]
     pub timeout: Option<String>,
     /// Shows elapsed time after each task completes
     ///
     /// Default to always show with `MISE_TASK_TIMINGS=1`
     #[arg(long = "timings", hide = true)]
     pub timings: bool,
-    #[arg(value_name = "TASK", default_value = "default")]
+    #[arg(
+        value_name = "TASK",
+        help = "Tasks to run\nCan specify multiple tasks by separating with `:::`\ne.g.: mise run task1 arg1 arg2 ::: task2 arg1 arg2",
+        default_value = "default"
+    )]
     pub task: Option<String>,
     /// Arguments to pass to the tasks. Use ":::" to separate tasks
     #[arg(value_name = "ARGS", num_args = 0..)]
@@ -4171,7 +4363,7 @@ pub struct TasksValidateArgs {
     /// Output validation results in JSON format
     #[arg(long = "json")]
     pub json: bool,
-    #[arg(value_name = "TASKS", num_args = 0..)]
+    #[arg(value_name = "TASKS", help = "Tasks to validate\nIf not specified, validates all tasks", num_args = 0..)]
     pub tasks: Vec<String>,
 }
 
@@ -4190,7 +4382,10 @@ pub struct TasksArgs {
     /// Show all columns
     #[arg(long = "extended", short = 'x')]
     pub extended: bool,
-    #[arg(long = "all")]
+    #[arg(
+        help = "Load all tasks from the entire monorepo, including sibling directories.\nBy default, only tasks from the current directory hierarchy are loaded.",
+        long = "all"
+    )]
     pub all: bool,
     /// Display tasks for usage completion
     #[arg(long = "complete", hide = true)]
@@ -4236,7 +4431,11 @@ pub enum TasksCommands {
     /// Get information about a task
     #[command(name = "info")]
     Info(Box<TasksInfoArgs>),
-    #[command(name = "ls")]
+    #[command(
+        name = "ls",
+        about = "List available tasks to execute\nThese may be included from the config file or from the project's .mise/tasks directory\nmise will merge all tasks from all parent directories into this list.",
+        long_about = "List available tasks to execute\nThese may be included from the config file or from the project's .mise/tasks directory\nmise will merge all tasks from all parent directories into this list.\n\nSo if you have global tasks in `~/.config/mise/tasks/*` and project-specific tasks in\n~/myproject/.mise/tasks/*, then they'll both be available but the project-specific\ntasks will override the global ones if they have the same name."
+    )]
     Ls(Box<TasksLsArgs>),
     /// Run task(s)
     #[command(name = "run", visible_alias = "r")]
@@ -4252,7 +4451,12 @@ pub struct TestToolArgs {
     /// Test every tool specified in registry/
     #[arg(long = "all", short = 'a')]
     pub all: bool,
-    #[arg(long = "jobs", short = 'j', value_name = "JOBS")]
+    #[arg(
+        help = "Number of tool tests to run in parallel\n[default: 4]",
+        long = "jobs",
+        short = 'j',
+        value_name = "JOBS"
+    )]
     pub jobs: Option<String>,
     /// Test all tools specified in config files
     #[arg(long = "all-config")]
@@ -4419,7 +4623,10 @@ pub struct TrustArgs {
     /// Do not trust this config and ignore it in the future
     #[arg(long = "ignore")]
     pub ignore: bool,
-    #[arg(long = "show")]
+    #[arg(
+        help = "Show the trusted status of config files from the current directory and its parents.\nDoes not trust or untrust any files.",
+        long = "show"
+    )]
     pub show: bool,
     /// No longer trust this config, will prompt in the future
     #[arg(long = "untrust")]
@@ -4465,7 +4672,7 @@ pub struct UnsetArgs {
     /// Use the global config file
     #[arg(long = "global", short = 'g')]
     pub global: bool,
-    #[arg(value_name = "ENV_KEY", num_args = 0..)]
+    #[arg(value_name = "ENV_KEY", help = "Environment variable(s) to remove\ne.g.: NODE_ENV", num_args = 0..)]
     pub env_key: Vec<String>,
 }
 
@@ -4528,7 +4735,12 @@ pub struct UpgradeArgs {
     /// Display multiselect menu to choose which tools to upgrade
     #[arg(long = "interactive", short = 'i')]
     pub interactive: bool,
-    #[arg(long = "jobs", short = 'j', value_name = "JOBS")]
+    #[arg(
+        help = "Number of jobs to run in parallel\n[default: 4]",
+        long = "jobs",
+        short = 'j',
+        value_name = "JOBS"
+    )]
     pub jobs: Option<String>,
     /// Upgrades to the latest version available, bumping the version in mise.toml
     ///
@@ -4542,7 +4754,12 @@ pub struct UpgradeArgs {
     /// Just print what would be done, don't actually do it
     #[arg(long = "dry-run", short = 'n')]
     pub dry_run: bool,
-    #[arg(long = "exclude", short = 'x', value_name = "INSTALLED_TOOL")]
+    #[arg(
+        help = "Tool(s) to exclude from upgrading\ne.g.: go python",
+        long = "exclude",
+        short = 'x',
+        value_name = "INSTALLED_TOOL"
+    )]
     pub exclude: Vec<String>,
     /// Like --dry-run but exits with code 1 if there are outdated tools
     ///
@@ -4580,7 +4797,7 @@ pub struct UpgradeArgs {
     /// Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1
     #[arg(long = "raw")]
     pub raw: bool,
-    #[arg(value_name = "INSTALLED_TOOL@VERSION", num_args = 0..)]
+    #[arg(value_name = "INSTALLED_TOOL@VERSION", help = "Tool(s) to upgrade\ne.g.: node@20 python@3.10\nIf not specified, all current tools will be upgraded", num_args = 0..)]
     pub installed_tool_version: Vec<String>,
 }
 
@@ -4620,7 +4837,12 @@ pub struct UseArgs {
     /// Use the global config file (`~/.config/mise/config.toml`) instead of the local one
     #[arg(long = "global", short = 'g')]
     pub global: bool,
-    #[arg(long = "jobs", short = 'j', value_name = "JOBS")]
+    #[arg(
+        help = "Number of jobs to run in parallel\n[default: 4]",
+        long = "jobs",
+        short = 'j',
+        value_name = "JOBS"
+    )]
     pub jobs: Option<String>,
     /// Perform a dry run, showing what would be installed and modified without making changes
     #[arg(long = "dry-run", short = 'n')]
@@ -4646,7 +4868,11 @@ pub struct UseArgs {
     /// Supports absolute dates like "2024-06-01" and relative durations like "90d" or "1y".
     #[arg(long = "minimum-release-age", value_name = "MINIMUM_RELEASE_AGE")]
     pub minimum_release_age: Option<String>,
-    #[arg(long = "pin")]
+    #[arg(
+        help = "Save exact version to config file\ne.g.: `mise use --pin node@20` will save 20.0.0 as the version\nSet `MISE_PIN=1` to make this the default behavior",
+        long_help = "Save exact version to config file\ne.g.: `mise use --pin node@20` will save 20.0.0 as the version\nSet `MISE_PIN=1` to make this the default behavior\n\nConsider using mise.lock as a better alternative to pinning in mise.toml:\nhttps://mise.jdx.dev/configuration/settings.html#lockfile",
+        long = "pin"
+    )]
     pub pin: bool,
     /// Connect backend install command stdin/stdout/stderr directly to the terminal Implies `--jobs=1`
     #[arg(long = "raw")]
@@ -4690,7 +4916,13 @@ pub struct WatchArgs {
     /// Tasks to run
     #[arg(long = "task-flag", short = 't', hide = true, value_name = "TASK_FLAG")]
     pub task_flag: Vec<String>,
-    #[arg(long = "glob", short = 'g', hide = true, value_name = "GLOB")]
+    #[arg(
+        help = "Files to watch\nDefaults to sources from the task(s)",
+        long = "glob",
+        short = 'g',
+        hide = true,
+        value_name = "GLOB"
+    )]
     pub glob: Vec<String>,
     /// Run only the specified tasks skipping all dependencies
     #[arg(long = "skip-deps")]
@@ -5191,7 +5423,10 @@ pub struct WatchArgs {
     /// This shows the manual page for Watchexec, if the output is a terminal and the 'man' program is available. If not, the manual page is printed to stdout in ROFF format (suitable for writing to a watchexec.1 file).
     #[arg(long = "manual")]
     pub manual: bool,
-    #[arg(value_name = "TASK")]
+    #[arg(
+        value_name = "TASK",
+        help = "Tasks to run\nCan specify multiple tasks by separating with `:::`\ne.g.: `mise run task1 arg1 arg2 ::: task2 arg1 arg2`"
+    )]
     pub task: Option<String>,
     /// Task and arguments to run
     #[arg(value_name = "ARGS", num_args = 0..)]
@@ -5203,9 +5438,16 @@ pub struct WatchArgs {
 /// The tool must be installed for this to work.
 #[derive(Args)]
 pub struct WhereArgs {
-    #[arg(value_name = "TOOL@VERSION")]
+    #[arg(
+        value_name = "TOOL@VERSION",
+        help = "Tool(s) to look up\ne.g.: ruby@3\nif \"@<PREFIX>\" is specified, it will show the latest installed version\nthat matches the prefix\notherwise, it will show the current, active installed version"
+    )]
     pub tool_version: String,
-    #[arg(value_name = "ASDF_VERSION", hide = true)]
+    #[arg(
+        value_name = "ASDF_VERSION",
+        help = "the version prefix to use when querying the latest version\nsame as the first argument after the \"@\"\nused for asdf compatibility",
+        hide = true
+    )]
     pub asdf_version: Option<String>,
 }
 
@@ -5214,7 +5456,12 @@ pub struct WhereArgs {
 /// Use this to figure out what version of a tool is currently active.
 #[derive(Args)]
 pub struct WhichArgs {
-    #[arg(long = "tool", short = 't', value_name = "TOOL@VERSION")]
+    #[arg(
+        help = "Use a specific tool@version\ne.g.: `mise which npm --tool=node@20`",
+        long = "tool",
+        short = 't',
+        value_name = "TOOL@VERSION"
+    )]
     pub tool: Option<String>,
     #[arg(long = "complete", hide = true)]
     pub complete: bool,

--- a/benches/shadows/mise/src/lib.rs
+++ b/benches/shadows/mise/src/lib.rs
@@ -42,14 +42,11 @@ pub struct ActivateArgs {
     /// This can be helpful for debugging mise. If you run `eval "$(mise activate --no-hook-env)"`, then you can call `mise hook-env` manually which will output the env vars to stdout without actually modifying the environment. That way you can do things like `mise hook-env --trace` to get more information or just see the values that hook-env is outputting.
     #[usage(long = "no-hook-env")]
     pub no_hook_env: bool,
-    /// Use shims instead of modifying PATH
-    /// Effectively the same as:
-    ///
-    ///     PATH="$HOME/.local/share/mise/shims:$PATH"
-    ///
-    /// `mise activate --shims` does not support all the features of `mise activate`.
-    /// See https://mise.jdx.dev/dev-tools/shims.html#shims-vs-path for more information
-    #[usage(long = "shims")]
+    #[usage(
+        help = "Use shims instead of modifying PATH\nEffectively the same as:",
+        long_help = "shims",
+        long = "shims"
+    )]
     pub shims: bool,
     /// Show "mise: <TOOL>@<VERSION>" message when changing directories
     #[usage(long = "status", hide)]
@@ -76,14 +73,6 @@ pub struct ToolAliasGetArgs {
     pub alias: ::std::string::String,
 }
 
-/// List tool version aliases
-/// Shows the aliases that can be specified.
-/// These can come from user config or from plugins in `bin/list-aliases`.
-///
-/// For user config, aliases are defined like the following in `~/.config/mise/config.toml`:
-///
-///     [tool_alias.node.versions]
-///     lts = "22.0.0"
 #[derive(Args)]
 pub struct ToolAliasLsArgs {
     /// Don't show table header
@@ -141,10 +130,12 @@ pub enum ToolAliasCommands {
     /// Show an alias for a tool
     #[usage(name = "get")]
     Get(Box<ToolAliasGetArgs>),
-    /// List tool version aliases
-    /// Shows the aliases that can be specified.
-    /// These can come from user config or from plugins in `bin/list-aliases`.
-    #[usage(name = "ls", alias = "list")]
+    #[usage(
+        name = "ls",
+        help = "List tool version aliases\nShows the aliases that can be specified.\nThese can come from user config or from plugins in `bin/list-aliases`.",
+        long_help = "List tool version aliases\nShows the aliases that can be specified.\nThese can come from user config or from plugins in `bin/list-aliases`.\n\nFor user config, aliases are defined like the following in `~/.config/mise/config.toml`:\n\n    [tool_alias.node.versions]\n    lts = \"22.0.0\"",
+        alias = "list"
+    )]
     Ls(Box<ToolAliasLsArgs>),
     /// Add/update an alias for a tool/backend
     #[usage(name = "set", alias("add", "create"))]
@@ -189,33 +180,25 @@ pub struct BinPathsArgs {
     /// Output executable entries in JSON format (implies --bin-names)
     #[usage(long = "json", short = 'J')]
     pub json: bool,
-    /// Tool(s) to look up
-    /// e.g.: ruby@3
-    #[usage(arg, name = "TOOL@VERSION")]
+    #[usage(arg, name = "TOOL@VERSION", help = "Tool(s) to look up\ne.g.: ruby@3")]
     pub tool_version: ::std::vec::Vec<::std::string::String>,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapApplyAccountPlanArgs {}
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapApplyServicePlanArgs {}
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapApplyFirewallPlanArgs {}
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapApplySystemPlanArgs {}
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapInspectSystemFilesArgs {}
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapInspectFirewallPlanArgs {}
 
@@ -384,9 +367,11 @@ pub struct BootstrapDotfilesStatusArgs {
     /// Output in JSON format
     #[usage(long = "json", short = 'J')]
     pub json: bool,
-    /// Exit with code 1 if any configured dotfiles are not in their desired
-    /// state (missing, source missing, differs)
-    #[usage(long = "missing")]
+    #[usage(
+        help = "Exit with code 1 if any configured dotfiles are not in their desired\nstate (missing, source missing, differs)",
+        long_help = "missing",
+        long = "missing"
+    )]
     pub missing: bool,
     /// Only show these targets
     #[usage(arg, name = "TARGET")]
@@ -524,7 +509,6 @@ pub enum BootstrapFirewallCommands {
     Status(Box<BootstrapFirewallStatusArgs>),
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapLaunchdApplyArgs {
     /// Print the commands that would run without running them
@@ -535,7 +519,6 @@ pub struct BootstrapLaunchdApplyArgs {
     pub yes: bool,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapLaunchdStatusArgs {
     /// Output in JSON format
@@ -555,15 +538,12 @@ pub struct BootstrapLaunchdArgs {
 
 #[derive(Subcommands)]
 pub enum BootstrapLaunchdCommands {
-    /// Undocumented
     #[usage(name = "apply")]
     Apply(Box<BootstrapLaunchdApplyArgs>),
-    /// Undocumented
     #[usage(name = "status")]
     Status(Box<BootstrapLaunchdStatusArgs>),
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapLinuxSystemdUnitsApplyArgs {
     /// Print the commands that would run without running them
@@ -574,7 +554,6 @@ pub struct BootstrapLinuxSystemdUnitsApplyArgs {
     pub yes: bool,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapLinuxSystemdUnitsStatusArgs {
     /// Output in JSON format
@@ -594,10 +573,8 @@ pub struct BootstrapLinuxSystemdUnitsArgs {
 
 #[derive(Subcommands)]
 pub enum BootstrapLinuxSystemdUnitsCommands {
-    /// Undocumented
     #[usage(name = "apply")]
     Apply(Box<BootstrapLinuxSystemdUnitsApplyArgs>),
-    /// Undocumented
     #[usage(name = "status")]
     Status(Box<BootstrapLinuxSystemdUnitsStatusArgs>),
 }
@@ -616,7 +593,6 @@ pub enum BootstrapLinuxCommands {
     SystemdUnits(Box<BootstrapLinuxSystemdUnitsArgs>),
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapMacosDefaultsApplyArgs {
     /// Print the commands that would run without running them
@@ -627,7 +603,6 @@ pub struct BootstrapMacosDefaultsApplyArgs {
     pub yes: bool,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapMacosDefaultsStatusArgs {
     /// Output in JSON format
@@ -647,15 +622,12 @@ pub struct BootstrapMacosDefaultsArgs2 {
 
 #[derive(Subcommands)]
 pub enum BootstrapMacosDefaultsCommands2 {
-    /// Undocumented
     #[usage(name = "apply")]
     Apply(Box<BootstrapMacosDefaultsApplyArgs>),
-    /// Undocumented
     #[usage(name = "status")]
     Status(Box<BootstrapMacosDefaultsStatusArgs>),
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapMacosLaunchdAgentsApplyArgs {
     /// Print the commands that would run without running them
@@ -666,7 +638,6 @@ pub struct BootstrapMacosLaunchdAgentsApplyArgs {
     pub yes: bool,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapMacosLaunchdAgentsStatusArgs {
     /// Output in JSON format
@@ -686,10 +657,8 @@ pub struct BootstrapMacosLaunchdAgentsArgs {
 
 #[derive(Subcommands)]
 pub enum BootstrapMacosLaunchdAgentsCommands {
-    /// Undocumented
     #[usage(name = "apply")]
     Apply(Box<BootstrapMacosLaunchdAgentsApplyArgs>),
-    /// Undocumented
     #[usage(name = "status")]
     Status(Box<BootstrapMacosLaunchdAgentsStatusArgs>),
 }
@@ -711,7 +680,6 @@ pub enum BootstrapMacosCommands {
     LaunchdAgents(Box<BootstrapMacosLaunchdAgentsArgs>),
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapMacosDefaultsApplyArgs2 {
     /// Print the commands that would run without running them
@@ -722,7 +690,6 @@ pub struct BootstrapMacosDefaultsApplyArgs2 {
     pub yes: bool,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapMacosDefaultsStatusArgs2 {
     /// Output in JSON format
@@ -742,15 +709,12 @@ pub struct BootstrapMacosDefaultsArgs {
 
 #[derive(Subcommands)]
 pub enum BootstrapMacosDefaultsCommands {
-    /// Undocumented
     #[usage(name = "apply")]
     Apply(Box<BootstrapMacosDefaultsApplyArgs2>),
-    /// Undocumented
     #[usage(name = "status")]
     Status(Box<BootstrapMacosDefaultsStatusArgs2>),
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapMiseShellActivateApplyArgs {
     /// Print the actions that would run without writing anything
@@ -761,7 +725,6 @@ pub struct BootstrapMiseShellActivateApplyArgs {
     pub yes: bool,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapMiseShellActivateStatusArgs {
     /// Output in JSON format
@@ -781,10 +744,8 @@ pub struct BootstrapMiseShellActivateArgs {
 
 #[derive(Subcommands)]
 pub enum BootstrapMiseShellActivateCommands {
-    /// Undocumented
     #[usage(name = "apply")]
     Apply(Box<BootstrapMiseShellActivateApplyArgs>),
-    /// Undocumented
     #[usage(name = "status")]
     Status(Box<BootstrapMiseShellActivateStatusArgs>),
 }
@@ -1049,7 +1010,6 @@ pub struct BootstrapPlanArgs {
     pub prompt_secrets: bool,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapPluginsApplyArgs {
     /// Print what would happen without installing plugins
@@ -1057,7 +1017,6 @@ pub struct BootstrapPluginsApplyArgs {
     pub dry_run: bool,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapPluginsStatusArgs {
     /// Exit with code 1 if a declared plugin is missing
@@ -1074,10 +1033,8 @@ pub struct BootstrapPluginsArgs {
 
 #[derive(Subcommands)]
 pub enum BootstrapPluginsCommands {
-    /// Undocumented
     #[usage(name = "apply")]
     Apply(Box<BootstrapPluginsApplyArgs>),
-    /// Undocumented
     #[usage(name = "status")]
     Status(Box<BootstrapPluginsStatusArgs>),
 }
@@ -1211,7 +1168,6 @@ pub struct BootstrapRemoteArgs {
     pub target: ::std::vec::Vec<::std::string::String>,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapReposApplyArgs {
     /// Print the commands that would run without running them
@@ -1222,7 +1178,6 @@ pub struct BootstrapReposApplyArgs {
     pub yes: bool,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapReposExecArgs {
     /// Continue running in other repos after a command fails
@@ -1239,7 +1194,6 @@ pub struct BootstrapReposExecArgs {
     pub command: ::std::vec::Vec<::std::string::String>,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapReposStatusArgs {
     /// Output in JSON format
@@ -1250,7 +1204,6 @@ pub struct BootstrapReposStatusArgs {
     pub missing: bool,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapReposUpdateArgs {
     /// Print the commands that would run without running them
@@ -1273,16 +1226,12 @@ pub struct BootstrapReposArgs {
 
 #[derive(Subcommands)]
 pub enum BootstrapReposCommands {
-    /// Undocumented
     #[usage(name = "apply")]
     Apply(Box<BootstrapReposApplyArgs>),
-    /// Undocumented
     #[usage(name = "exec")]
     Exec(Box<BootstrapReposExecArgs>),
-    /// Undocumented
     #[usage(name = "status")]
     Status(Box<BootstrapReposStatusArgs>),
-    /// Undocumented
     #[usage(name = "update")]
     Update(Box<BootstrapReposUpdateArgs>),
 }
@@ -1365,7 +1314,6 @@ pub struct BootstrapStatusArgs {
     pub prompt_secrets: bool,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapSystemdApplyArgs {
     /// Print the commands that would run without running them
@@ -1376,7 +1324,6 @@ pub struct BootstrapSystemdApplyArgs {
     pub yes: bool,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapSystemdStatusArgs {
     /// Output in JSON format
@@ -1396,15 +1343,12 @@ pub struct BootstrapSystemdArgs {
 
 #[derive(Subcommands)]
 pub enum BootstrapSystemdCommands {
-    /// Undocumented
     #[usage(name = "apply")]
     Apply(Box<BootstrapSystemdApplyArgs>),
-    /// Undocumented
     #[usage(name = "status")]
     Status(Box<BootstrapSystemdStatusArgs>),
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapUserApplyArgs {
     /// Print the commands that would run without running them
@@ -1415,7 +1359,6 @@ pub struct BootstrapUserApplyArgs {
     pub yes: bool,
 }
 
-/// Undocumented
 #[derive(Args)]
 pub struct BootstrapUserStatusArgs {
     /// Output in JSON format
@@ -1435,10 +1378,8 @@ pub struct BootstrapUserArgs {
 
 #[derive(Subcommands)]
 pub enum BootstrapUserCommands {
-    /// Undocumented
     #[usage(name = "apply")]
     Apply(Box<BootstrapUserApplyArgs>),
-    /// Undocumented
     #[usage(name = "status")]
     Status(Box<BootstrapUserStatusArgs>),
 }
@@ -1579,23 +1520,17 @@ pub struct BootstrapArgs {
 
 #[derive(Subcommands)]
 pub enum BootstrapCommands {
-    /// Undocumented
-    #[usage(name = "__apply-account-plan")]
+    #[usage(name = "__apply-account-plan", hide)]
     ApplyAccountPlan(Box<BootstrapApplyAccountPlanArgs>),
-    /// Undocumented
-    #[usage(name = "__apply-service-plan")]
+    #[usage(name = "__apply-service-plan", hide)]
     ApplyServicePlan(Box<BootstrapApplyServicePlanArgs>),
-    /// Undocumented
-    #[usage(name = "__apply-firewall-plan")]
+    #[usage(name = "__apply-firewall-plan", hide)]
     ApplyFirewallPlan(Box<BootstrapApplyFirewallPlanArgs>),
-    /// Undocumented
-    #[usage(name = "__apply-system-plan")]
+    #[usage(name = "__apply-system-plan", hide)]
     ApplySystemPlan(Box<BootstrapApplySystemPlanArgs>),
-    /// Undocumented
-    #[usage(name = "__inspect-system-files")]
+    #[usage(name = "__inspect-system-files", hide)]
     InspectSystemFiles(Box<BootstrapInspectSystemFilesArgs>),
-    /// Undocumented
-    #[usage(name = "__inspect-firewall-plan")]
+    #[usage(name = "__inspect-firewall-plan", hide)]
     InspectFirewallPlan(Box<BootstrapInspectFirewallPlanArgs>),
     /// Manage Linux users and groups from `[bootstrap.users]` and `[bootstrap.groups]`
     #[usage(name = "accounts")]
@@ -1613,7 +1548,7 @@ pub enum BootstrapCommands {
     #[usage(name = "firewall")]
     Firewall(Box<BootstrapFirewallArgs>),
     /// Manage macOS LaunchAgents from `[bootstrap.macos.launchd.agents]`
-    #[usage(name = "launchd")]
+    #[usage(name = "launchd", hide)]
     Launchd(Box<BootstrapLaunchdArgs>),
     /// Manage Linux bootstrap config from `[bootstrap.linux]`
     #[usage(name = "linux")]
@@ -1622,7 +1557,7 @@ pub enum BootstrapCommands {
     #[usage(name = "macos")]
     Macos(Box<BootstrapMacosArgs>),
     /// Manage macOS defaults from `[bootstrap.macos.defaults]`
-    #[usage(name = "macos-defaults")]
+    #[usage(name = "macos-defaults", hide)]
     MacosDefaults(Box<BootstrapMacosDefaultsArgs>),
     /// Manage mise shell activation from `[bootstrap.mise_shell_activate]`
     #[usage(name = "mise-shell-activate", alias_hidden = "shell")]
@@ -1652,7 +1587,7 @@ pub enum BootstrapCommands {
     #[usage(name = "status", alias = "ls")]
     Status(Box<BootstrapStatusArgs>),
     /// Manage systemd user services from `[bootstrap.linux.systemd.units]`
-    #[usage(name = "systemd")]
+    #[usage(name = "systemd", hide)]
     Systemd(Box<BootstrapSystemdArgs>),
     /// Manage current-user bootstrap settings from `[bootstrap.user]`
     #[usage(name = "user")]
@@ -1748,13 +1683,12 @@ pub struct CompletionArgs {
     /// you may source it separately or enable this flag to enable it in the script.
     #[usage(long = "include-bash-completion-lib")]
     pub include_bash_completion_lib: bool,
-    /// Always use usage for completions.
-    /// Currently, usage is the default for fish and bash but not zsh since it has a few quirks
-    /// to work out first.
-    ///
-    /// This requires the `usage` CLI to be installed.
-    /// https://usage.jdx.dev
-    #[usage(long = "usage", hide)]
+    #[usage(
+        help = "Always use usage for completions.\nCurrently, usage is the default for fish and bash but not zsh since it has a few quirks\nto work out first.",
+        long_help = "usage",
+        long = "usage",
+        hide
+    )]
     pub usage: bool,
     /// Shell type to generate completions for
     #[usage(arg, name = "SHELL", choices("bash", "fish", "powershell", "zsh"))]
@@ -1800,7 +1734,6 @@ pub struct ConfigSetArgs {
     /// If not provided, the nearest mise.toml file will be used
     #[usage(long = "file", short = 'f', value_name = "FILE")]
     pub file: ::std::option::Option<::std::string::String>,
-    /// Undocumented
     #[usage(
         long = "type",
         short = 't',
@@ -1873,13 +1806,9 @@ pub struct DeactivateArgs {}
 #[derive(Args)]
 pub struct DirenvActivateArgs {}
 
-/// [internal] This is an internal command that writes an envrc file
-/// for direnv to consume.
 #[derive(Args)]
 pub struct DirenvEnvrcArgs {}
 
-/// [internal] This is an internal command that writes an envrc file
-/// for direnv to consume.
 #[derive(Args)]
 pub struct DirenvExecArgs {}
 
@@ -1899,15 +1828,19 @@ pub struct DirenvArgs {
 #[derive(Subcommands)]
 pub enum DirenvCommands {
     /// Output direnv function to use mise inside direnv
-    #[usage(name = "activate")]
+    #[usage(name = "activate", hide)]
     Activate(Box<DirenvActivateArgs>),
-    /// [internal] This is an internal command that writes an envrc file
-    /// for direnv to consume.
-    #[usage(name = "envrc")]
+    #[usage(
+        name = "envrc",
+        help = "[internal] This is an internal command that writes an envrc file\nfor direnv to consume.",
+        hide
+    )]
     Envrc(Box<DirenvEnvrcArgs>),
-    /// [internal] This is an internal command that writes an envrc file
-    /// for direnv to consume.
-    #[usage(name = "exec")]
+    #[usage(
+        name = "exec",
+        help = "[internal] This is an internal command that writes an envrc file\nfor direnv to consume.",
+        hide
+    )]
     Exec(Box<DirenvExecArgs>),
 }
 
@@ -1998,9 +1931,11 @@ pub struct DotfilesStatusArgs {
     /// Output in JSON format
     #[usage(long = "json", short = 'J')]
     pub json: bool,
-    /// Exit with code 1 if any configured dotfiles are not in their desired
-    /// state (missing, source missing, differs)
-    #[usage(long = "missing")]
+    #[usage(
+        help = "Exit with code 1 if any configured dotfiles are not in their desired\nstate (missing, source missing, differs)",
+        long_help = "missing",
+        long = "missing"
+    )]
     pub missing: bool,
     /// Only show these targets
     #[usage(arg, name = "TARGET")]
@@ -2040,19 +1975,19 @@ pub struct DotfilesArgs {
 #[derive(Subcommands)]
 pub enum DotfilesCommands {
     /// Add or update dotfiles in `[dotfiles]`
-    #[usage(name = "add")]
+    #[usage(name = "add", hide)]
     Add(Box<DotfilesAddArgs>),
     /// Apply dotfiles from `[dotfiles]`
-    #[usage(name = "apply")]
+    #[usage(name = "apply", hide)]
     Apply(Box<DotfilesApplyArgs>),
     /// Edit a managed dotfile source
-    #[usage(name = "edit")]
+    #[usage(name = "edit", hide)]
     Edit(Box<DotfilesEditArgs>),
     /// Show the status of dotfiles from `[dotfiles]`
-    #[usage(name = "status", alias = "ls")]
+    #[usage(name = "status", hide, alias = "ls")]
     Status(Box<DotfilesStatusArgs>),
     /// Remove dotfiles applied from `[dotfiles]`
-    #[usage(name = "unapply")]
+    #[usage(name = "unapply", hide)]
     Unapply(Box<DotfilesUnapplyArgs>),
 }
 
@@ -2067,7 +2002,6 @@ pub struct DoctorPathArgs {
 /// Check mise installation for possible problems
 #[derive(Args)]
 pub struct DoctorArgs {
-    /// Undocumented
     #[usage(long = "json", short = 'J')]
     pub json: bool,
     #[usage(subcommand)]
@@ -2146,17 +2080,29 @@ pub struct ExecArgs {
     /// Command string to execute
     #[usage(long = "command", short = 'c', value_name = "C")]
     pub command: ::std::option::Option<::std::string::String>,
-    /// Number of jobs to run in parallel
-    /// [default: 4]
-    #[usage(long = "jobs", short = 'j', value_name = "JOBS")]
+    #[usage(
+        help = "Number of jobs to run in parallel\n[default: 4]",
+        long_help = "jobs",
+        long = "jobs",
+        short = 'j',
+        value_name = "JOBS"
+    )]
     pub jobs: ::std::option::Option<::std::string::String>,
-    /// Allow specific env var through (implies --deny-env for everything else)
-    /// Supports wildcards, e.g. --allow-env='MYAPP_*'
-    #[usage(long = "allow-env", value_name = "VAR", var)]
+    #[usage(
+        help = "Allow specific env var through (implies --deny-env for everything else)\nSupports wildcards, e.g. --allow-env='MYAPP_*'",
+        long_help = "allow-env",
+        long = "allow-env",
+        value_name = "VAR",
+        var
+    )]
     pub allow_env: ::std::vec::Vec<::std::string::String>,
-    /// Allow network to specific host (implies --deny-net for everything else)
-    /// macOS only in v1; on Linux falls back to allowing all network
-    #[usage(long = "allow-net", value_name = "HOST", var)]
+    #[usage(
+        help = "Allow network to specific host (implies --deny-net for everything else)\nmacOS only in v1; on Linux falls back to allowing all network",
+        long_help = "allow-net",
+        long = "allow-net",
+        value_name = "HOST",
+        var
+    )]
     pub allow_net: ::std::vec::Vec<::std::string::String>,
     /// Allow reads from specific path (implies --deny-read for everything else)
     #[usage(long = "allow-read", value_name = "PATH", var)]
@@ -2337,7 +2283,6 @@ pub struct GenerateTaskDocsArgs {
     /// root directory to search for tasks
     #[usage(long = "root", short = 'r', value_name = "ROOT")]
     pub root: ::std::option::Option<::std::string::String>,
-    /// Undocumented
     #[usage(
         long = "style",
         short = 's',
@@ -2508,7 +2453,7 @@ pub struct GithubArgs {
 #[derive(Subcommands)]
 pub enum GithubCommands {
     /// Display the GitHub token mise will use for a given host
-    #[usage(name = "token")]
+    #[usage(name = "token", hide)]
     Token(Box<GithubTokenArgs>),
 }
 
@@ -2524,26 +2469,29 @@ pub enum GithubCommands {
 /// Use `mise local` to set a tool version locally in the current directory.
 #[derive(Args)]
 pub struct GlobalArgs {
-    /// Save fuzzy version to `~/.tool-versions`
-    /// e.g.: `mise global --fuzzy node@20` will save `node 20` to ~/.tool-versions
-    /// this is the default behavior unless MISE_ASDF_COMPAT=1
-    #[usage(long = "fuzzy")]
+    #[usage(
+        help = "Save fuzzy version to `~/.tool-versions`\ne.g.: `mise global --fuzzy node@20` will save `node 20` to ~/.tool-versions\nthis is the default behavior unless MISE_ASDF_COMPAT=1",
+        long_help = "fuzzy",
+        long = "fuzzy"
+    )]
     pub fuzzy: bool,
     /// Get the path of the global config file
     #[usage(long = "path")]
     pub path: bool,
-    /// Save exact version to `~/.tool-versions`
-    /// e.g.: `mise global --pin node@20` will save `node 20.0.0` to ~/.tool-versions
-    #[usage(long = "pin")]
+    #[usage(
+        help = "Save exact version to `~/.tool-versions`\ne.g.: `mise global --pin node@20` will save `node 20.0.0` to ~/.tool-versions",
+        long_help = "pin",
+        long = "pin"
+    )]
     pub pin: bool,
     /// Remove the tool(s) from ~/.tool-versions
     #[usage(long = "remove", value_name = "TOOL", var)]
     pub remove: ::std::vec::Vec<::std::string::String>,
-    /// Tool(s) to add to .tool-versions
-    /// e.g.: node@20
-    /// If this is a single tool with no version, the current value of the global
-    /// .tool-versions will be displayed
-    #[usage(arg, name = "TOOL@VERSION")]
+    #[usage(
+        arg,
+        name = "TOOL@VERSION",
+        help = "Tool(s) to add to .tool-versions\ne.g.: node@20\nIf this is a single tool with no version, the current value of the global\n.tool-versions will be displayed"
+    )]
     pub tool_version: ::std::vec::Vec<::std::string::String>,
 }
 
@@ -2637,9 +2585,13 @@ pub struct InstallArgs {
     /// Force reinstall even if already installed
     #[usage(long = "force", short = 'f')]
     pub force: bool,
-    /// Number of jobs to run in parallel
-    /// [default: 4]
-    #[usage(long = "jobs", short = 'j', value_name = "JOBS")]
+    #[usage(
+        help = "Number of jobs to run in parallel\n[default: 4]",
+        long_help = "jobs",
+        long = "jobs",
+        short = 'j',
+        value_name = "JOBS"
+    )]
     pub jobs: ::std::option::Option<::std::string::String>,
     /// Show what would be installed without actually installing
     #[usage(long = "dry-run", short = 'n')]
@@ -2731,9 +2683,11 @@ pub struct LinkArgs {
     /// Tool name and version to create a symlink for
     #[usage(arg, name = "TOOL@VERSION")]
     pub tool_version: ::std::string::String,
-    /// The local path to the tool version
-    /// e.g.: ~/.nvm/versions/node/v20.0.0
-    #[usage(arg, name = "PATH")]
+    #[usage(
+        arg,
+        name = "PATH",
+        help = "The local path to the tool version\ne.g.: ~/.nvm/versions/node/v20.0.0"
+    )]
     pub path: ::std::string::String,
 }
 
@@ -2745,9 +2699,12 @@ pub struct LinkArgs {
 /// is set. A future v2 release of mise will default to using `mise.toml`.
 #[derive(Args)]
 pub struct LocalArgs {
-    /// Recurse up to find a .tool-versions file rather than using the current directory only
-    /// by default this command will only set the tool in the current directory ("$PWD/.tool-versions")
-    #[usage(long = "parent", short = 'p')]
+    #[usage(
+        help = "Recurse up to find a .tool-versions file rather than using the current directory only\nby default this command will only set the tool in the current directory (\"$PWD/.tool-versions\")",
+        long_help = "parent",
+        long = "parent",
+        short = 'p'
+    )]
     pub parent: bool,
     /// Save fuzzy version to `.tool-versions` e.g.: `mise local --fuzzy node@20` will save `node 20` to .tool-versions This is the default behavior unless MISE_ASDF_COMPAT=1
     #[usage(long = "fuzzy")]
@@ -2755,18 +2712,20 @@ pub struct LocalArgs {
     /// Get the path of the config file
     #[usage(long = "path")]
     pub path: bool,
-    /// Save exact version to `.tool-versions`
-    /// e.g.: `mise local --pin node@20` will save `node 20.0.0` to .tool-versions
-    #[usage(long = "pin")]
+    #[usage(
+        help = "Save exact version to `.tool-versions`\ne.g.: `mise local --pin node@20` will save `node 20.0.0` to .tool-versions",
+        long_help = "pin",
+        long = "pin"
+    )]
     pub pin: bool,
     /// Remove the tool(s) from .tool-versions
     #[usage(long = "remove", value_name = "TOOL", var)]
     pub remove: ::std::vec::Vec<::std::string::String>,
-    /// Tool(s) to add to .tool-versions/mise.toml
-    /// e.g.: node@20
-    /// if this is a single tool with no version,
-    /// the current value of .tool-versions/mise.toml will be displayed
-    #[usage(arg, name = "TOOL@VERSION")]
+    #[usage(
+        arg,
+        name = "TOOL@VERSION",
+        help = "Tool(s) to add to .tool-versions/mise.toml\ne.g.: node@20\nif this is a single tool with no version,\nthe current value of .tool-versions/mise.toml will be displayed"
+    )]
     pub tool_version: ::std::vec::Vec<::std::string::String>,
 }
 
@@ -2778,9 +2737,12 @@ pub struct LocalArgs {
 /// Operates on the lockfile in the current config root. Use TOOL arguments to target specific tools.
 #[derive(Args)]
 pub struct LockArgs {
-    /// Target only global config lockfiles (~/.config/mise/mise.lock and system config)
-    /// By default, only the active project config root is locked
-    #[usage(long = "global", short = 'g')]
+    #[usage(
+        help = "Target only global config lockfiles (~/.config/mise/mise.lock and system config)\nBy default, only the active project config root is locked",
+        long_help = "global",
+        long = "global",
+        short = 'g'
+    )]
     pub global: bool,
     /// Number of jobs to run in parallel
     #[usage(long = "jobs", short = 'j', value_name = "JOBS")]
@@ -2788,10 +2750,14 @@ pub struct LockArgs {
     /// Show what would be updated without making changes
     #[usage(long = "dry-run", short = 'n')]
     pub dry_run: bool,
-    /// Comma-separated list of platforms to target
-    /// e.g.: linux-x64,macos-arm64,windows-x64
-    /// If not specified, all platforms already in lockfile will be updated
-    #[usage(long = "platform", short = 'p', value_name = "PLATFORM", var)]
+    #[usage(
+        help = "Comma-separated list of platforms to target\ne.g.: linux-x64,macos-arm64,windows-x64\nIf not specified, all platforms already in lockfile will be updated",
+        long_help = "platform",
+        long = "platform",
+        short = 'p',
+        value_name = "PLATFORM",
+        var
+    )]
     pub platform: ::std::vec::Vec<::std::string::String>,
     /// Re-resolve fuzzy version selectors against the latest available versions
     ///
@@ -2815,9 +2781,11 @@ pub struct LockArgs {
     /// detect available updates without writing the lockfile.
     #[usage(long = "json")]
     pub json: bool,
-    /// Update mise.local.lock instead of mise.lock
-    /// Use for tools defined in .local.toml configs
-    #[usage(long = "local")]
+    #[usage(
+        help = "Update mise.local.lock instead of mise.lock\nUse for tools defined in .local.toml configs",
+        long_help = "local",
+        long = "local"
+    )]
     pub local: bool,
     /// Only lock versions released before this age or date
     ///
@@ -2827,10 +2795,11 @@ pub struct LockArgs {
     /// Existing matching lockfile entries are preserved and are not downgraded solely by this flag.
     #[usage(long = "minimum-release-age", value_name = "MINIMUM_RELEASE_AGE")]
     pub minimum_release_age: ::std::option::Option<::std::string::String>,
-    /// Tool(s) to update in lockfile
-    /// e.g.: node python
-    /// If not specified, all tools in lockfile will be updated
-    #[usage(arg, name = "TOOL")]
+    #[usage(
+        arg,
+        name = "TOOL",
+        help = "Tool(s) to update in lockfile\ne.g.: node python\nIf not specified, all tools in lockfile will be updated"
+    )]
     pub tool: ::std::vec::Vec<::std::string::String>,
 }
 
@@ -2864,7 +2833,6 @@ pub struct LsArgs {
     /// Don't fetch information such as outdated versions
     #[usage(long = "offline", short = 'o', hide)]
     pub offline: bool,
-    /// Undocumented
     #[usage(long = "plugin", short = 'p', hide, value_name = "TOOL_FLAG")]
     pub plugin: ::std::option::Option<::std::string::String>,
     /// Display all tracked config sources for tools
@@ -2912,11 +2880,11 @@ pub struct LsRemoteArgs {
     /// Disable checking the mise-versions host
     #[usage(long = "no-versions-host")]
     pub no_versions_host: bool,
-    /// Include pre-release versions in the output for backends that report
-    /// upstream prerelease metadata or opt in to regex-based prerelease
-    /// detection. Equivalent to setting `MISE_PRERELEASES=1` or the
-    /// `prereleases` setting for the duration of this command.
-    #[usage(long = "prerelease")]
+    #[usage(
+        help = "Include pre-release versions in the output for backends that report\nupstream prerelease metadata or opt in to regex-based prerelease\ndetection. Equivalent to setting `MISE_PRERELEASES=1` or the\n`prereleases` setting for the duration of this command.",
+        long_help = "prerelease",
+        long = "prerelease"
+    )]
     pub prerelease: bool,
     /// Fail if release metadata fetches fail
     ///
@@ -2929,9 +2897,11 @@ pub struct LsRemoteArgs {
     /// Tool to get versions for
     #[usage(arg, name = "TOOL@VERSION")]
     pub tool_version: ::std::option::Option<::std::string::String>,
-    /// The version prefix to use when querying the latest version
-    /// same as the first argument after the "@"
-    #[usage(arg, name = "PREFIX")]
+    #[usage(
+        arg,
+        name = "PREFIX",
+        help = "The version prefix to use when querying the latest version\nsame as the first argument after the \"@\""
+    )]
     pub prefix: ::std::option::Option<::std::string::String>,
 }
 
@@ -3199,10 +3169,11 @@ pub struct OutdatedArgs {
     /// Don't show table header
     #[usage(long = "no-header")]
     pub no_header: bool,
-    /// Tool(s) to show outdated versions for
-    /// e.g.: node@20 python@3.10
-    /// If not specified, all tools in global and local configs will be shown
-    #[usage(arg, name = "TOOL@VERSION")]
+    #[usage(
+        arg,
+        name = "TOOL@VERSION",
+        help = "Tool(s) to show outdated versions for\ne.g.: node@20 python@3.10\nIf not specified, all tools in global and local configs will be shown"
+    )]
     pub tool_version: ::std::vec::Vec<::std::string::String>,
 }
 
@@ -3231,10 +3202,12 @@ pub struct PatronsArgs {
 /// This behavior can be modified in ~/.config/mise/config.toml
 #[derive(Args)]
 pub struct PluginsInstallArgs {
-    /// Install all missing plugins
-    /// This will only install plugins that have matching shorthands.
-    /// i.e.: they don't need the full git repo url
-    #[usage(long = "all", short = 'a')]
+    #[usage(
+        help = "Install all missing plugins\nThis will only install plugins that have matching shorthands.\ni.e.: they don't need the full git repo url",
+        long_help = "all",
+        long = "all",
+        short = 'a'
+    )]
     pub all: bool,
     /// Reinstall even if plugin exists
     #[usage(long = "force", short = 'f')]
@@ -3245,15 +3218,15 @@ pub struct PluginsInstallArgs {
     /// Show installation output
     #[usage(long = "verbose", short = 'v', count)]
     pub verbose: u8,
-    /// The name of the plugin to install
-    /// e.g.: cmake, poetry
-    /// Can specify multiple plugins: `mise plugins install cmake poetry`
-    #[usage(arg, name = "NEW_PLUGIN")]
+    #[usage(
+        arg,
+        name = "NEW_PLUGIN",
+        help = "The name of the plugin to install\ne.g.: cmake, poetry\nCan specify multiple plugins: `mise plugins install cmake poetry`"
+    )]
     pub new_plugin: ::std::option::Option<::std::string::String>,
     /// The git url of the plugin
     #[usage(arg, name = "GIT_URL")]
     pub git_url: ::std::option::Option<::std::string::String>,
-    /// Undocumented
     #[usage(arg, name = "REST", hide)]
     pub rest: ::std::vec::Vec<::std::string::String>,
 }
@@ -3266,13 +3239,17 @@ pub struct PluginsLinkArgs {
     /// Overwrite existing plugin
     #[usage(long = "force", short = 'f')]
     pub force: bool,
-    /// The name of the plugin
-    /// e.g.: cmake, poetry
-    #[usage(arg, name = "NAME")]
+    #[usage(
+        arg,
+        name = "NAME",
+        help = "The name of the plugin\ne.g.: cmake, poetry"
+    )]
     pub name: ::std::string::String,
-    /// The local path to the plugin
-    /// e.g.: ./vfox-cmake
-    #[usage(arg, name = "DIR")]
+    #[usage(
+        arg,
+        name = "DIR",
+        help = "The local path to the plugin\ne.g.: ./vfox-cmake"
+    )]
     pub dir: ::std::option::Option<::std::string::String>,
 }
 
@@ -3281,25 +3258,42 @@ pub struct PluginsLinkArgs {
 /// Can also show remotely available plugins to install.
 #[derive(Args)]
 pub struct PluginsLsArgs {
-    /// List all available remote plugins
-    /// Same as `mise plugins ls-remote`
-    #[usage(long = "all", short = 'a', hide)]
+    #[usage(
+        help = "List all available remote plugins\nSame as `mise plugins ls-remote`",
+        long_help = "all",
+        long = "all",
+        short = 'a',
+        hide
+    )]
     pub all: bool,
-    /// The built-in plugins only
-    /// Normally these are not shown
-    #[usage(long = "core", short = 'c', hide)]
+    #[usage(
+        help = "The built-in plugins only\nNormally these are not shown",
+        long_help = "core",
+        long = "core",
+        short = 'c',
+        hide
+    )]
     pub core: bool,
-    /// Show plugins with available updates
-    /// Checks the remote for newer versions and only displays plugins that are outdated
-    #[usage(long = "outdated", short = 'o')]
+    #[usage(
+        help = "Show plugins with available updates\nChecks the remote for newer versions and only displays plugins that are outdated",
+        long_help = "outdated",
+        long = "outdated",
+        short = 'o'
+    )]
     pub outdated: bool,
-    /// Show the git url for each plugin
-    /// e.g.: https://github.com/mise-plugins/vfox-cmake.git
-    #[usage(long = "urls", short = 'u')]
+    #[usage(
+        help = "Show the git url for each plugin\ne.g.: https://github.com/mise-plugins/vfox-cmake.git",
+        long_help = "urls",
+        long = "urls",
+        short = 'u'
+    )]
     pub urls: bool,
-    /// Show the git refs for each plugin
-    /// e.g.: main 1234abc
-    #[usage(long = "refs", hide)]
+    #[usage(
+        help = "Show the git refs for each plugin\ne.g.: main 1234abc",
+        long_help = "refs",
+        long = "refs",
+        hide
+    )]
     pub refs: bool,
     /// List installed plugins
     #[usage(long = "user", hide)]
@@ -3342,9 +3336,13 @@ pub struct PluginsUninstallArgs {
 /// note: this updates the plugin itself, not the runtime versions
 #[derive(Args)]
 pub struct PluginsUpdateArgs {
-    /// Number of jobs to run in parallel
-    /// Default: 4
-    #[usage(long = "jobs", short = 'j', value_name = "JOBS")]
+    #[usage(
+        help = "Number of jobs to run in parallel\nDefault: 4",
+        long_help = "jobs",
+        long = "jobs",
+        short = 'j',
+        value_name = "JOBS"
+    )]
     pub jobs: ::std::option::Option<::std::string::String>,
     /// Plugin(s) to update
     #[usage(arg, name = "PLUGIN")]
@@ -3359,17 +3357,26 @@ pub struct PluginsArgs {
     /// same as `mise plugins ls-remote`
     #[usage(long = "all", short = 'a', hide)]
     pub all: bool,
-    /// The built-in plugins only
-    /// Normally these are not shown
-    #[usage(long = "core", short = 'c')]
+    #[usage(
+        help = "The built-in plugins only\nNormally these are not shown",
+        long_help = "core",
+        long = "core",
+        short = 'c'
+    )]
     pub core: bool,
-    /// Show the git url for each plugin
-    /// e.g.: https://github.com/mise-plugins/vfox-cmake.git
-    #[usage(long = "urls", short = 'u')]
+    #[usage(
+        help = "Show the git url for each plugin\ne.g.: https://github.com/mise-plugins/vfox-cmake.git",
+        long_help = "urls",
+        long = "urls",
+        short = 'u'
+    )]
     pub urls: bool,
-    /// Show the git refs for each plugin
-    /// e.g.: main 1234abc
-    #[usage(long = "refs", hide)]
+    #[usage(
+        help = "Show the git refs for each plugin\ne.g.: main 1234abc",
+        long_help = "refs",
+        long = "refs",
+        hide
+    )]
     pub refs: bool,
     /// List installed plugins
     ///
@@ -3609,10 +3616,8 @@ pub struct ReshimArgs {
     /// Removes all shims before reshimming
     #[usage(long = "force", short = 'f')]
     pub force: bool,
-    /// Undocumented
     #[usage(arg, name = "TOOL", hide)]
     pub tool: ::std::option::Option<::std::string::String>,
-    /// Undocumented
     #[usage(arg, name = "VERSION", hide)]
     pub version: ::std::option::Option<::std::string::String>,
 }
@@ -3648,16 +3653,22 @@ pub struct RunArgs {
     /// Run matching tasks only for projects affected by Git changes
     #[usage(long = "affected")]
     pub affected: bool,
-    /// Git base revision for --affected
-    /// Defaults to MISE_AFFECTED_BASE, CI metadata, or HEAD~1
-    #[usage(long = "affected-base", value_name = "REV")]
+    #[usage(
+        help = "Git base revision for --affected\nDefaults to MISE_AFFECTED_BASE, CI metadata, or HEAD~1",
+        long_help = "affected-base",
+        long = "affected-base",
+        value_name = "REV"
+    )]
     pub affected_base: ::std::option::Option<::std::string::String>,
     /// Explain why projects and tasks were selected by --affected
     #[usage(long = "affected-explain")]
     pub affected_explain: bool,
-    /// Git head revision for --affected
-    /// Defaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD
-    #[usage(long = "affected-head", value_name = "REV")]
+    #[usage(
+        help = "Git head revision for --affected\nDefaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD",
+        long_help = "affected-head",
+        long = "affected-head",
+        value_name = "REV"
+    )]
     pub affected_head: ::std::option::Option<::std::string::String>,
     /// Output affected projects and tasks as JSON without running tasks
     #[usage(long = "affected-json")]
@@ -3671,10 +3682,13 @@ pub struct RunArgs {
     /// Force the tasks to run even if outputs are up to date
     #[usage(long = "force", short = 'f')]
     pub force: bool,
-    /// Number of tasks to run in parallel
-    /// [default: 4]
-    /// Configure with `jobs` config or `MISE_JOBS` env var
-    #[usage(long = "jobs", short = 'j', value_name = "JOBS")]
+    #[usage(
+        help = "Number of tasks to run in parallel\n[default: 4]\nConfigure with `jobs` config or `MISE_JOBS` env var",
+        long_help = "jobs",
+        long = "jobs",
+        short = 'j',
+        value_name = "JOBS"
+    )]
     pub jobs: ::std::option::Option<::std::string::String>,
     /// Don't actually run the task(s), just print them in order of execution
     #[usage(long = "dry-run", short = 'n')]
@@ -3693,10 +3707,12 @@ pub struct RunArgs {
     /// Don't show extra output
     #[usage(long = "quiet", short = 'q')]
     pub quiet: bool,
-    /// Read/write directly to stdin/stdout/stderr instead of by line
-    /// Redactions are not applied with this option
-    /// Configure with `raw` config or `MISE_RAW` env var
-    #[usage(long = "raw", short = 'r')]
+    #[usage(
+        help = "Read/write directly to stdin/stdout/stderr instead of by line\nRedactions are not applied with this option\nConfigure with `raw` config or `MISE_RAW` env var",
+        long_help = "raw",
+        long = "raw",
+        short = 'r'
+    )]
     pub raw: bool,
     /// Shell to use to run toml tasks
     ///
@@ -3711,9 +3727,13 @@ pub struct RunArgs {
     /// Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10
     #[usage(long = "tool", short = 't', value_name = "TOOL@VERSION", var)]
     pub tool: ::std::vec::Vec<::std::string::String>,
-    /// Allow specific env var through (implies --deny-env for everything else)
-    /// Supports wildcards, e.g. --allow-env='MYAPP_*'
-    #[usage(long = "allow-env", value_name = "VAR", var)]
+    #[usage(
+        help = "Allow specific env var through (implies --deny-env for everything else)\nSupports wildcards, e.g. --allow-env='MYAPP_*'",
+        long_help = "allow-env",
+        long = "allow-env",
+        value_name = "VAR",
+        var
+    )]
     pub allow_env: ::std::vec::Vec<::std::string::String>,
     /// Allow network to specific host (implies --deny-net for everything else)
     #[usage(long = "allow-net", value_name = "HOST", var)]
@@ -3785,9 +3805,12 @@ pub struct RunArgs {
     /// Report task output cache hits, restored bytes, and time saved
     #[usage(long = "task-cache-stats")]
     pub task_cache_stats: bool,
-    /// Timeout for the task to complete
-    /// e.g.: 30s, 5m
-    #[usage(long = "timeout", value_name = "TIMEOUT")]
+    #[usage(
+        help = "Timeout for the task to complete\ne.g.: 30s, 5m",
+        long_help = "timeout",
+        long = "timeout",
+        value_name = "TIMEOUT"
+    )]
     pub timeout: ::std::option::Option<::std::string::String>,
     /// Shows elapsed time after each task completes
     ///
@@ -3909,9 +3932,11 @@ pub struct SetArgs {
     /// When using --stdin, provide a single key without a value. The value will be read from stdin until EOF.
     #[usage(long = "stdin")]
     pub stdin: bool,
-    /// Environment variable(s) to set
-    /// e.g.: NODE_ENV=production
-    #[usage(arg, name = "ENV_VAR")]
+    #[usage(
+        arg,
+        name = "ENV_VAR",
+        help = "Environment variable(s) to set\ne.g.: NODE_ENV=production"
+    )]
     pub env_var: ::std::vec::Vec<::std::string::String>,
 }
 
@@ -4075,9 +4100,13 @@ pub enum SettingsCommands {
 /// such as `MISE_NODE_VERSION=20` which is "eval"ed as a shell function created by `mise activate`.
 #[derive(Args)]
 pub struct ShellArgs {
-    /// Number of jobs to run in parallel
-    /// [default: 4]
-    #[usage(long = "jobs", short = 'j', value_name = "JOBS")]
+    #[usage(
+        help = "Number of jobs to run in parallel\n[default: 4]",
+        long_help = "jobs",
+        long = "jobs",
+        short = 'j',
+        value_name = "JOBS"
+    )]
     pub jobs: ::std::option::Option<::std::string::String>,
     /// Removes a previously set version
     #[usage(long = "unset", short = 'u')]
@@ -4277,7 +4306,6 @@ pub struct TasksAddArgs {
     /// Tasks name to add
     #[usage(arg, name = "TASK")]
     pub task: ::std::string::String,
-    /// Undocumented
     #[usage(arg, name = "RUN", double_dash = "required")]
     pub run: ::std::vec::Vec<::std::string::String>,
 }
@@ -4294,10 +4322,11 @@ pub struct TasksDepsArgs {
     /// Show hidden tasks
     #[usage(long = "hidden")]
     pub hidden: bool,
-    /// Tasks to show dependencies for
-    /// Can specify multiple tasks by separating with spaces
-    /// e.g.: mise tasks deps lint test check
-    #[usage(arg, name = "TASKS")]
+    #[usage(
+        arg,
+        name = "TASKS",
+        help = "Tasks to show dependencies for\nCan specify multiple tasks by separating with spaces\ne.g.: mise tasks deps lint test check"
+    )]
     pub tasks: ::std::vec::Vec<::std::string::String>,
 }
 
@@ -4339,13 +4368,6 @@ pub struct TasksInfoArgs {
     pub task: ::std::string::String,
 }
 
-/// List available tasks to execute
-/// These may be included from the config file or from the project's .mise/tasks directory
-/// mise will merge all tasks from all parent directories into this list.
-///
-/// So if you have global tasks in `~/.config/mise/tasks/*` and project-specific tasks in
-/// ~/myproject/.mise/tasks/*, then they'll both be available but the project-specific
-/// tasks will override the global ones if they have the same name.
 #[derive(Args)]
 pub struct TasksLsArgs {
     /// Only show global tasks
@@ -4360,9 +4382,11 @@ pub struct TasksLsArgs {
     /// Show all columns
     #[usage(long = "extended", short = 'x')]
     pub extended: bool,
-    /// Load all tasks from the entire monorepo, including sibling directories.
-    /// By default, only tasks from the current directory hierarchy are loaded.
-    #[usage(long = "all")]
+    #[usage(
+        help = "Load all tasks from the entire monorepo, including sibling directories.\nBy default, only tasks from the current directory hierarchy are loaded.",
+        long_help = "all",
+        long = "all"
+    )]
     pub all: bool,
     /// Display tasks for usage completion
     #[usage(long = "complete", hide)]
@@ -4386,7 +4410,6 @@ pub struct TasksLsArgs {
     /// Sort order. Default is asc.
     #[usage(long = "sort-order", value_name = "SORT_ORDER", choices("asc", "desc"))]
     pub sort_order: ::std::option::Option<::std::string::String>,
-    /// Undocumented
     #[usage(long = "usage", hide)]
     pub usage: bool,
 }
@@ -4422,16 +4445,22 @@ pub struct TasksRunArgs {
     /// Run matching tasks only for projects affected by Git changes
     #[usage(long = "affected")]
     pub affected: bool,
-    /// Git base revision for --affected
-    /// Defaults to MISE_AFFECTED_BASE, CI metadata, or HEAD~1
-    #[usage(long = "affected-base", value_name = "REV")]
+    #[usage(
+        help = "Git base revision for --affected\nDefaults to MISE_AFFECTED_BASE, CI metadata, or HEAD~1",
+        long_help = "affected-base",
+        long = "affected-base",
+        value_name = "REV"
+    )]
     pub affected_base: ::std::option::Option<::std::string::String>,
     /// Explain why projects and tasks were selected by --affected
     #[usage(long = "affected-explain")]
     pub affected_explain: bool,
-    /// Git head revision for --affected
-    /// Defaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD
-    #[usage(long = "affected-head", value_name = "REV")]
+    #[usage(
+        help = "Git head revision for --affected\nDefaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD",
+        long_help = "affected-head",
+        long = "affected-head",
+        value_name = "REV"
+    )]
     pub affected_head: ::std::option::Option<::std::string::String>,
     /// Output affected projects and tasks as JSON without running tasks
     #[usage(long = "affected-json")]
@@ -4445,10 +4474,13 @@ pub struct TasksRunArgs {
     /// Force the tasks to run even if outputs are up to date
     #[usage(long = "force", short = 'f')]
     pub force: bool,
-    /// Number of tasks to run in parallel
-    /// [default: 4]
-    /// Configure with `jobs` config or `MISE_JOBS` env var
-    #[usage(long = "jobs", short = 'j', value_name = "JOBS")]
+    #[usage(
+        help = "Number of tasks to run in parallel\n[default: 4]\nConfigure with `jobs` config or `MISE_JOBS` env var",
+        long_help = "jobs",
+        long = "jobs",
+        short = 'j',
+        value_name = "JOBS"
+    )]
     pub jobs: ::std::option::Option<::std::string::String>,
     /// Don't actually run the task(s), just print them in order of execution
     #[usage(long = "dry-run", short = 'n')]
@@ -4467,10 +4499,12 @@ pub struct TasksRunArgs {
     /// Don't show extra output
     #[usage(long = "quiet", short = 'q')]
     pub quiet: bool,
-    /// Read/write directly to stdin/stdout/stderr instead of by line
-    /// Redactions are not applied with this option
-    /// Configure with `raw` config or `MISE_RAW` env var
-    #[usage(long = "raw", short = 'r')]
+    #[usage(
+        help = "Read/write directly to stdin/stdout/stderr instead of by line\nRedactions are not applied with this option\nConfigure with `raw` config or `MISE_RAW` env var",
+        long_help = "raw",
+        long = "raw",
+        short = 'r'
+    )]
     pub raw: bool,
     /// Shell to use to run toml tasks
     ///
@@ -4485,9 +4519,13 @@ pub struct TasksRunArgs {
     /// Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10
     #[usage(long = "tool", short = 't', value_name = "TOOL@VERSION", var)]
     pub tool: ::std::vec::Vec<::std::string::String>,
-    /// Allow specific env var through (implies --deny-env for everything else)
-    /// Supports wildcards, e.g. --allow-env='MYAPP_*'
-    #[usage(long = "allow-env", value_name = "VAR", var)]
+    #[usage(
+        help = "Allow specific env var through (implies --deny-env for everything else)\nSupports wildcards, e.g. --allow-env='MYAPP_*'",
+        long_help = "allow-env",
+        long = "allow-env",
+        value_name = "VAR",
+        var
+    )]
     pub allow_env: ::std::vec::Vec<::std::string::String>,
     /// Allow network to specific host (implies --deny-net for everything else)
     #[usage(long = "allow-net", value_name = "HOST", var)]
@@ -4559,19 +4597,24 @@ pub struct TasksRunArgs {
     /// Report task output cache hits, restored bytes, and time saved
     #[usage(long = "task-cache-stats")]
     pub task_cache_stats: bool,
-    /// Timeout for the task to complete
-    /// e.g.: 30s, 5m
-    #[usage(long = "timeout", value_name = "TIMEOUT")]
+    #[usage(
+        help = "Timeout for the task to complete\ne.g.: 30s, 5m",
+        long_help = "timeout",
+        long = "timeout",
+        value_name = "TIMEOUT"
+    )]
     pub timeout: ::std::option::Option<::std::string::String>,
     /// Shows elapsed time after each task completes
     ///
     /// Default to always show with `MISE_TASK_TIMINGS=1`
     #[usage(long = "timings", hide)]
     pub timings: bool,
-    /// Tasks to run
-    /// Can specify multiple tasks by separating with `:::`
-    /// e.g.: mise run task1 arg1 arg2 ::: task2 arg1 arg2
-    #[usage(arg, name = "TASK", default = "default")]
+    #[usage(
+        arg,
+        name = "TASK",
+        help = "Tasks to run\nCan specify multiple tasks by separating with `:::`\ne.g.: mise run task1 arg1 arg2 ::: task2 arg1 arg2",
+        default = "default"
+    )]
     pub task: ::std::option::Option<::std::string::String>,
     /// Arguments to pass to the tasks. Use ":::" to separate tasks
     #[usage(arg, name = "ARGS")]
@@ -4590,9 +4633,11 @@ pub struct TasksValidateArgs {
     /// Output validation results in JSON format
     #[usage(long = "json")]
     pub json: bool,
-    /// Tasks to validate
-    /// If not specified, validates all tasks
-    #[usage(arg, name = "TASKS")]
+    #[usage(
+        arg,
+        name = "TASKS",
+        help = "Tasks to validate\nIf not specified, validates all tasks"
+    )]
     pub tasks: ::std::vec::Vec<::std::string::String>,
 }
 
@@ -4611,9 +4656,11 @@ pub struct TasksArgs {
     /// Show all columns
     #[usage(long = "extended", short = 'x')]
     pub extended: bool,
-    /// Load all tasks from the entire monorepo, including sibling directories.
-    /// By default, only tasks from the current directory hierarchy are loaded.
-    #[usage(long = "all")]
+    #[usage(
+        help = "Load all tasks from the entire monorepo, including sibling directories.\nBy default, only tasks from the current directory hierarchy are loaded.",
+        long_help = "all",
+        long = "all"
+    )]
     pub all: bool,
     /// Display tasks for usage completion
     #[usage(long = "complete", hide)]
@@ -4637,7 +4684,6 @@ pub struct TasksArgs {
     /// Sort order. Default is asc.
     #[usage(long = "sort-order", value_name = "SORT_ORDER", choices("asc", "desc"))]
     pub sort_order: ::std::option::Option<::std::string::String>,
-    /// Undocumented
     #[usage(long = "usage", hide)]
     pub usage: bool,
     /// Task name to get info of
@@ -4664,10 +4710,11 @@ pub enum TasksCommands {
     /// Get information about a task
     #[usage(name = "info")]
     Info(Box<TasksInfoArgs>),
-    /// List available tasks to execute
-    /// These may be included from the config file or from the project's .mise/tasks directory
-    /// mise will merge all tasks from all parent directories into this list.
-    #[usage(name = "ls")]
+    #[usage(
+        name = "ls",
+        help = "List available tasks to execute\nThese may be included from the config file or from the project's .mise/tasks directory\nmise will merge all tasks from all parent directories into this list.",
+        long_help = "List available tasks to execute\nThese may be included from the config file or from the project's .mise/tasks directory\nmise will merge all tasks from all parent directories into this list.\n\nSo if you have global tasks in `~/.config/mise/tasks/*` and project-specific tasks in\n~/myproject/.mise/tasks/*, then they'll both be available but the project-specific\ntasks will override the global ones if they have the same name."
+    )]
     Ls(Box<TasksLsArgs>),
     /// Run task(s)
     #[usage(name = "run", alias = "r")]
@@ -4683,9 +4730,13 @@ pub struct TestToolArgs {
     /// Test every tool specified in registry/
     #[usage(long = "all", short = 'a')]
     pub all: bool,
-    /// Number of tool tests to run in parallel
-    /// [default: 4]
-    #[usage(long = "jobs", short = 'j', value_name = "JOBS")]
+    #[usage(
+        help = "Number of tool tests to run in parallel\n[default: 4]",
+        long_help = "jobs",
+        long = "jobs",
+        short = 'j',
+        value_name = "JOBS"
+    )]
     pub jobs: ::std::option::Option<::std::string::String>,
     /// Test all tools specified in config files
     #[usage(long = "all-config")]
@@ -4852,9 +4903,11 @@ pub struct TrustArgs {
     /// Do not trust this config and ignore it in the future
     #[usage(long = "ignore")]
     pub ignore: bool,
-    /// Show the trusted status of config files from the current directory and its parents.
-    /// Does not trust or untrust any files.
-    #[usage(long = "show")]
+    #[usage(
+        help = "Show the trusted status of config files from the current directory and its parents.\nDoes not trust or untrust any files.",
+        long_help = "show",
+        long = "show"
+    )]
     pub show: bool,
     /// No longer trust this config, will prompt in the future
     #[usage(long = "untrust")]
@@ -4900,9 +4953,11 @@ pub struct UnsetArgs {
     /// Use the global config file
     #[usage(long = "global", short = 'g')]
     pub global: bool,
-    /// Environment variable(s) to remove
-    /// e.g.: NODE_ENV
-    #[usage(arg, name = "ENV_KEY")]
+    #[usage(
+        arg,
+        name = "ENV_KEY",
+        help = "Environment variable(s) to remove\ne.g.: NODE_ENV"
+    )]
     pub env_key: ::std::vec::Vec<::std::string::String>,
 }
 
@@ -4965,9 +5020,13 @@ pub struct UpgradeArgs {
     /// Display multiselect menu to choose which tools to upgrade
     #[usage(long = "interactive", short = 'i')]
     pub interactive: bool,
-    /// Number of jobs to run in parallel
-    /// [default: 4]
-    #[usage(long = "jobs", short = 'j', value_name = "JOBS")]
+    #[usage(
+        help = "Number of jobs to run in parallel\n[default: 4]",
+        long_help = "jobs",
+        long = "jobs",
+        short = 'j',
+        value_name = "JOBS"
+    )]
     pub jobs: ::std::option::Option<::std::string::String>,
     /// Upgrades to the latest version available, bumping the version in mise.toml
     ///
@@ -4981,9 +5040,14 @@ pub struct UpgradeArgs {
     /// Just print what would be done, don't actually do it
     #[usage(long = "dry-run", short = 'n')]
     pub dry_run: bool,
-    /// Tool(s) to exclude from upgrading
-    /// e.g.: go python
-    #[usage(long = "exclude", short = 'x', value_name = "INSTALLED_TOOL", var)]
+    #[usage(
+        help = "Tool(s) to exclude from upgrading\ne.g.: go python",
+        long_help = "exclude",
+        long = "exclude",
+        short = 'x',
+        value_name = "INSTALLED_TOOL",
+        var
+    )]
     pub exclude: ::std::vec::Vec<::std::string::String>,
     /// Like --dry-run but exits with code 1 if there are outdated tools
     ///
@@ -5021,10 +5085,11 @@ pub struct UpgradeArgs {
     /// Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1
     #[usage(long = "raw")]
     pub raw: bool,
-    /// Tool(s) to upgrade
-    /// e.g.: node@20 python@3.10
-    /// If not specified, all current tools will be upgraded
-    #[usage(arg, name = "INSTALLED_TOOL@VERSION")]
+    #[usage(
+        arg,
+        name = "INSTALLED_TOOL@VERSION",
+        help = "Tool(s) to upgrade\ne.g.: node@20 python@3.10\nIf not specified, all current tools will be upgraded"
+    )]
     pub installed_tool_version: ::std::vec::Vec<::std::string::String>,
 }
 
@@ -5064,9 +5129,13 @@ pub struct UseArgs {
     /// Use the global config file (`~/.config/mise/config.toml`) instead of the local one
     #[usage(long = "global", short = 'g')]
     pub global: bool,
-    /// Number of jobs to run in parallel
-    /// [default: 4]
-    #[usage(long = "jobs", short = 'j', value_name = "JOBS")]
+    #[usage(
+        help = "Number of jobs to run in parallel\n[default: 4]",
+        long_help = "jobs",
+        long = "jobs",
+        short = 'j',
+        value_name = "JOBS"
+    )]
     pub jobs: ::std::option::Option<::std::string::String>,
     /// Perform a dry run, showing what would be installed and modified without making changes
     #[usage(long = "dry-run", short = 'n')]
@@ -5092,13 +5161,11 @@ pub struct UseArgs {
     /// Supports absolute dates like "2024-06-01" and relative durations like "90d" or "1y".
     #[usage(long = "minimum-release-age", value_name = "MINIMUM_RELEASE_AGE")]
     pub minimum_release_age: ::std::option::Option<::std::string::String>,
-    /// Save exact version to config file
-    /// e.g.: `mise use --pin node@20` will save 20.0.0 as the version
-    /// Set `MISE_PIN=1` to make this the default behavior
-    ///
-    /// Consider using mise.lock as a better alternative to pinning in mise.toml:
-    /// https://mise.jdx.dev/configuration/settings.html#lockfile
-    #[usage(long = "pin")]
+    #[usage(
+        help = "Save exact version to config file\ne.g.: `mise use --pin node@20` will save 20.0.0 as the version\nSet `MISE_PIN=1` to make this the default behavior",
+        long_help = "pin",
+        long = "pin"
+    )]
     pub pin: bool,
     /// Connect backend install command stdin/stdout/stderr directly to the terminal Implies `--jobs=1`
     #[usage(long = "raw")]
@@ -5142,9 +5209,15 @@ pub struct WatchArgs {
     /// Tasks to run
     #[usage(long = "task-flag", short = 't', hide, value_name = "TASK_FLAG", var)]
     pub task_flag: ::std::vec::Vec<::std::string::String>,
-    /// Files to watch
-    /// Defaults to sources from the task(s)
-    #[usage(long = "glob", short = 'g', hide, value_name = "GLOB", var)]
+    #[usage(
+        help = "Files to watch\nDefaults to sources from the task(s)",
+        long_help = "glob",
+        long = "glob",
+        short = 'g',
+        hide,
+        value_name = "GLOB",
+        var
+    )]
     pub glob: ::std::vec::Vec<::std::string::String>,
     /// Run only the specified tasks skipping all dependencies
     #[usage(long = "skip-deps")]
@@ -5675,10 +5748,11 @@ pub struct WatchArgs {
     /// This shows the manual page for Watchexec, if the output is a terminal and the 'man' program is available. If not, the manual page is printed to stdout in ROFF format (suitable for writing to a watchexec.1 file).
     #[usage(long = "manual")]
     pub manual: bool,
-    /// Tasks to run
-    /// Can specify multiple tasks by separating with `:::`
-    /// e.g.: `mise run task1 arg1 arg2 ::: task2 arg1 arg2`
-    #[usage(arg, name = "TASK")]
+    #[usage(
+        arg,
+        name = "TASK",
+        help = "Tasks to run\nCan specify multiple tasks by separating with `:::`\ne.g.: `mise run task1 arg1 arg2 ::: task2 arg1 arg2`"
+    )]
     pub task: ::std::option::Option<::std::string::String>,
     /// Task and arguments to run
     #[usage(arg, name = "ARGS")]
@@ -5690,17 +5764,18 @@ pub struct WatchArgs {
 /// The tool must be installed for this to work.
 #[derive(Args)]
 pub struct WhereArgs {
-    /// Tool(s) to look up
-    /// e.g.: ruby@3
-    /// if "@<PREFIX>" is specified, it will show the latest installed version
-    /// that matches the prefix
-    /// otherwise, it will show the current, active installed version
-    #[usage(arg, name = "TOOL@VERSION")]
+    #[usage(
+        arg,
+        name = "TOOL@VERSION",
+        help = "Tool(s) to look up\ne.g.: ruby@3\nif \"@<PREFIX>\" is specified, it will show the latest installed version\nthat matches the prefix\notherwise, it will show the current, active installed version"
+    )]
     pub tool_version: ::std::string::String,
-    /// the version prefix to use when querying the latest version
-    /// same as the first argument after the "@"
-    /// used for asdf compatibility
-    #[usage(arg, name = "ASDF_VERSION", hide)]
+    #[usage(
+        arg,
+        name = "ASDF_VERSION",
+        help = "the version prefix to use when querying the latest version\nsame as the first argument after the \"@\"\nused for asdf compatibility",
+        hide
+    )]
     pub asdf_version: ::std::option::Option<::std::string::String>,
 }
 
@@ -5709,11 +5784,14 @@ pub struct WhereArgs {
 /// Use this to figure out what version of a tool is currently active.
 #[derive(Args)]
 pub struct WhichArgs {
-    /// Use a specific tool@version
-    /// e.g.: `mise which npm --tool=node@20`
-    #[usage(long = "tool", short = 't', value_name = "TOOL@VERSION")]
+    #[usage(
+        help = "Use a specific tool@version\ne.g.: `mise which npm --tool=node@20`",
+        long_help = "tool",
+        long = "tool",
+        short = 't',
+        value_name = "TOOL@VERSION"
+    )]
     pub tool: ::std::option::Option<::std::string::String>,
-    /// Undocumented
     #[usage(long = "complete", hide)]
     pub complete: bool,
     /// Show the plugin name instead of the path
@@ -5727,7 +5805,9 @@ pub struct WhichArgs {
     pub bin_name: ::std::option::Option<::std::string::String>,
 }
 
-/// Undocumented
+/// Dev tools, env vars, and tasks in one CLI
+///
+/// mise prepares your development environment before each command runs. https://github.com/jdx/mise
 #[derive(Cli)]
 #[usage(bin = "mise", default_subcommand = "run")]
 pub struct Cli {
@@ -5762,7 +5842,6 @@ pub struct Cli {
     /// Suppress non-error messages
     #[usage(long = "quiet", short = 'q', global)]
     pub quiet: bool,
-    /// Undocumented
     #[usage(long = "shell", short = 's', hide, value_name = "SHELL")]
     pub shell: ::std::option::Option<::std::string::String>,
     /// Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10
@@ -5771,7 +5850,6 @@ pub struct Cli {
     /// Show extra output (use -vv for even more)
     #[usage(long = "verbose", short = 'v', global, count)]
     pub verbose: u8,
-    /// Undocumented
     #[usage(long = "version", short = 'V', hide)]
     pub version: bool,
     /// Answer yes to all confirmation prompts
@@ -5780,7 +5858,6 @@ pub struct Cli {
     /// Sets log level to debug
     #[usage(long = "debug", global, hide)]
     pub debug: bool,
-    /// Undocumented
     #[usage(
         long = "log-level",
         global,
@@ -5809,7 +5886,6 @@ pub struct Cli {
     /// Default to always hide with `MISE_TASK_TIMINGS=0`
     #[usage(long = "no-timings", hide)]
     pub no_timings: bool,
-    /// Undocumented
     #[usage(long = "output", value_name = "OUTPUT")]
     pub output: ::std::option::Option<::std::string::String>,
     /// Read/write directly to stdin/stdout/stderr instead of by line
@@ -5841,7 +5917,6 @@ pub struct Cli {
     /// Task arguments
     #[usage(arg, name = "TASK_ARGS", hide)]
     pub task_args: ::std::vec::Vec<::std::string::String>,
-    /// Undocumented
     #[usage(arg, name = "TASK_ARGS_LAST", hide, double_dash = "required")]
     pub task_args_last: ::std::vec::Vec<::std::string::String>,
     #[usage(subcommand)]
@@ -5857,7 +5932,7 @@ pub enum Commands {
     #[usage(name = "tool-alias", alias_hidden("alias", "aliases"))]
     ToolAlias(Box<ToolAliasArgs>),
     /// [internal] simulates asdf for plugins that call "asdf" internally
-    #[usage(name = "asdf")]
+    #[usage(name = "asdf", hide)]
     Asdf(Box<AsdfArgs>),
     /// Manage backends
     #[usage(name = "backends", alias_hidden("b", "backend", "backend-list"))]
@@ -5878,16 +5953,16 @@ pub enum Commands {
     #[usage(name = "config", alias = "cfg", alias_hidden = "toml")]
     Config(Box<ConfigArgs>),
     /// Shows current active and installed runtime versions
-    #[usage(name = "current")]
+    #[usage(name = "current", hide)]
     Current(Box<CurrentArgs>),
     /// Disable mise for current shell session
     #[usage(name = "deactivate")]
     Deactivate(Box<DeactivateArgs>),
     /// Output direnv function to use mise inside direnv
-    #[usage(name = "direnv")]
+    #[usage(name = "direnv", hide)]
     Direnv(Box<DirenvArgs>),
     /// Manage dotfiles from `[dotfiles]` (deprecated)
-    #[usage(name = "dotfiles")]
+    #[usage(name = "dotfiles", hide)]
     Dotfiles(Box<DotfilesArgs>),
     /// Check mise installation for possible problems
     #[usage(name = "doctor", alias = "dr")]
@@ -5908,16 +5983,16 @@ pub enum Commands {
     #[usage(name = "generate", alias = "gen", alias_hidden = "g")]
     Generate(Box<GenerateArgs>),
     /// GitHub related commands
-    #[usage(name = "github")]
+    #[usage(name = "github", hide)]
     Github(Box<GithubArgs>),
     /// Sets/gets the global tool version(s)
-    #[usage(name = "global")]
+    #[usage(name = "global", hide)]
     Global(Box<GlobalArgs>),
     /// [internal] called by activate hook to update env vars directory change
-    #[usage(name = "hook-env")]
+    #[usage(name = "hook-env", hide)]
     HookEnv(Box<HookEnvArgs>),
     /// [internal] called by shell when a command is not found
-    #[usage(name = "hook-not-found")]
+    #[usage(name = "hook-not-found", hide)]
     HookNotFound(Box<HookNotFoundArgs>),
     /// Removes mise CLI and all related data
     #[usage(name = "implode")]
@@ -5938,7 +6013,7 @@ pub enum Commands {
     #[usage(name = "link", alias = "ln")]
     Link(Box<LinkArgs>),
     /// Sets/gets tool version in local .tool-versions or mise.toml
-    #[usage(name = "local", alias_hidden = "l")]
+    #[usage(name = "local", hide, alias_hidden = "l")]
     Local(Box<LocalArgs>),
     /// Update lockfile checksums and URLs for all specified platforms
     #[usage(name = "lock")]
@@ -5974,7 +6049,7 @@ pub enum Commands {
     #[usage(name = "registry")]
     Registry(Box<RegistryArgs>),
     /// internal command to generate markdown from help
-    #[usage(name = "render-help")]
+    #[usage(name = "render-help", hide)]
     RenderHelp(Box<RenderHelpArgs>),
     /// Creates new shims based on bin paths from currently installed tools.
     #[usage(name = "reshim")]
@@ -6040,7 +6115,7 @@ pub enum Commands {
     #[usage(name = "upgrade", alias = "up")]
     Upgrade(Box<UpgradeArgs>),
     /// Generate a usage CLI spec
-    #[usage(name = "usage")]
+    #[usage(name = "usage", hide)]
     Usage(Box<UsageArgs>),
     /// Installs a tool and adds the version to mise.toml.
     #[usage(name = "use", alias = "u")]

--- a/benches/shadows/mise/src/lib.rs
+++ b/benches/shadows/mise/src/lib.rs
@@ -44,7 +44,7 @@ pub struct ActivateArgs {
     pub no_hook_env: bool,
     #[usage(
         help = "Use shims instead of modifying PATH\nEffectively the same as:",
-        long_help = "shims",
+        long_help = "Use shims instead of modifying PATH\nEffectively the same as:\n\n    PATH=\"$HOME/.local/share/mise/shims:$PATH\"\n\n`mise activate --shims` does not support all the features of `mise activate`.\nSee https://mise.jdx.dev/dev-tools/shims.html#shims-vs-path for more information",
         long = "shims"
     )]
     pub shims: bool,
@@ -369,7 +369,6 @@ pub struct BootstrapDotfilesStatusArgs {
     pub json: bool,
     #[usage(
         help = "Exit with code 1 if any configured dotfiles are not in their desired\nstate (missing, source missing, differs)",
-        long_help = "missing",
         long = "missing"
     )]
     pub missing: bool,
@@ -1685,7 +1684,7 @@ pub struct CompletionArgs {
     pub include_bash_completion_lib: bool,
     #[usage(
         help = "Always use usage for completions.\nCurrently, usage is the default for fish and bash but not zsh since it has a few quirks\nto work out first.",
-        long_help = "usage",
+        long_help = "Always use usage for completions.\nCurrently, usage is the default for fish and bash but not zsh since it has a few quirks\nto work out first.\n\nThis requires the `usage` CLI to be installed.\nhttps://usage.jdx.dev",
         long = "usage",
         hide
     )]
@@ -1933,7 +1932,6 @@ pub struct DotfilesStatusArgs {
     pub json: bool,
     #[usage(
         help = "Exit with code 1 if any configured dotfiles are not in their desired\nstate (missing, source missing, differs)",
-        long_help = "missing",
         long = "missing"
     )]
     pub missing: bool,
@@ -2082,7 +2080,6 @@ pub struct ExecArgs {
     pub command: ::std::option::Option<::std::string::String>,
     #[usage(
         help = "Number of jobs to run in parallel\n[default: 4]",
-        long_help = "jobs",
         long = "jobs",
         short = 'j',
         value_name = "JOBS"
@@ -2090,7 +2087,6 @@ pub struct ExecArgs {
     pub jobs: ::std::option::Option<::std::string::String>,
     #[usage(
         help = "Allow specific env var through (implies --deny-env for everything else)\nSupports wildcards, e.g. --allow-env='MYAPP_*'",
-        long_help = "allow-env",
         long = "allow-env",
         value_name = "VAR",
         var
@@ -2098,7 +2094,6 @@ pub struct ExecArgs {
     pub allow_env: ::std::vec::Vec<::std::string::String>,
     #[usage(
         help = "Allow network to specific host (implies --deny-net for everything else)\nmacOS only in v1; on Linux falls back to allowing all network",
-        long_help = "allow-net",
         long = "allow-net",
         value_name = "HOST",
         var
@@ -2471,7 +2466,6 @@ pub enum GithubCommands {
 pub struct GlobalArgs {
     #[usage(
         help = "Save fuzzy version to `~/.tool-versions`\ne.g.: `mise global --fuzzy node@20` will save `node 20` to ~/.tool-versions\nthis is the default behavior unless MISE_ASDF_COMPAT=1",
-        long_help = "fuzzy",
         long = "fuzzy"
     )]
     pub fuzzy: bool,
@@ -2480,7 +2474,6 @@ pub struct GlobalArgs {
     pub path: bool,
     #[usage(
         help = "Save exact version to `~/.tool-versions`\ne.g.: `mise global --pin node@20` will save `node 20.0.0` to ~/.tool-versions",
-        long_help = "pin",
         long = "pin"
     )]
     pub pin: bool,
@@ -2587,7 +2580,6 @@ pub struct InstallArgs {
     pub force: bool,
     #[usage(
         help = "Number of jobs to run in parallel\n[default: 4]",
-        long_help = "jobs",
         long = "jobs",
         short = 'j',
         value_name = "JOBS"
@@ -2701,7 +2693,6 @@ pub struct LinkArgs {
 pub struct LocalArgs {
     #[usage(
         help = "Recurse up to find a .tool-versions file rather than using the current directory only\nby default this command will only set the tool in the current directory (\"$PWD/.tool-versions\")",
-        long_help = "parent",
         long = "parent",
         short = 'p'
     )]
@@ -2714,7 +2705,6 @@ pub struct LocalArgs {
     pub path: bool,
     #[usage(
         help = "Save exact version to `.tool-versions`\ne.g.: `mise local --pin node@20` will save `node 20.0.0` to .tool-versions",
-        long_help = "pin",
         long = "pin"
     )]
     pub pin: bool,
@@ -2739,7 +2729,6 @@ pub struct LocalArgs {
 pub struct LockArgs {
     #[usage(
         help = "Target only global config lockfiles (~/.config/mise/mise.lock and system config)\nBy default, only the active project config root is locked",
-        long_help = "global",
         long = "global",
         short = 'g'
     )]
@@ -2752,7 +2741,6 @@ pub struct LockArgs {
     pub dry_run: bool,
     #[usage(
         help = "Comma-separated list of platforms to target\ne.g.: linux-x64,macos-arm64,windows-x64\nIf not specified, all platforms already in lockfile will be updated",
-        long_help = "platform",
         long = "platform",
         short = 'p',
         value_name = "PLATFORM",
@@ -2783,7 +2771,6 @@ pub struct LockArgs {
     pub json: bool,
     #[usage(
         help = "Update mise.local.lock instead of mise.lock\nUse for tools defined in .local.toml configs",
-        long_help = "local",
         long = "local"
     )]
     pub local: bool,
@@ -2882,7 +2869,6 @@ pub struct LsRemoteArgs {
     pub no_versions_host: bool,
     #[usage(
         help = "Include pre-release versions in the output for backends that report\nupstream prerelease metadata or opt in to regex-based prerelease\ndetection. Equivalent to setting `MISE_PRERELEASES=1` or the\n`prereleases` setting for the duration of this command.",
-        long_help = "prerelease",
         long = "prerelease"
     )]
     pub prerelease: bool,
@@ -3204,7 +3190,6 @@ pub struct PatronsArgs {
 pub struct PluginsInstallArgs {
     #[usage(
         help = "Install all missing plugins\nThis will only install plugins that have matching shorthands.\ni.e.: they don't need the full git repo url",
-        long_help = "all",
         long = "all",
         short = 'a'
     )]
@@ -3260,7 +3245,6 @@ pub struct PluginsLinkArgs {
 pub struct PluginsLsArgs {
     #[usage(
         help = "List all available remote plugins\nSame as `mise plugins ls-remote`",
-        long_help = "all",
         long = "all",
         short = 'a',
         hide
@@ -3268,7 +3252,6 @@ pub struct PluginsLsArgs {
     pub all: bool,
     #[usage(
         help = "The built-in plugins only\nNormally these are not shown",
-        long_help = "core",
         long = "core",
         short = 'c',
         hide
@@ -3276,21 +3259,18 @@ pub struct PluginsLsArgs {
     pub core: bool,
     #[usage(
         help = "Show plugins with available updates\nChecks the remote for newer versions and only displays plugins that are outdated",
-        long_help = "outdated",
         long = "outdated",
         short = 'o'
     )]
     pub outdated: bool,
     #[usage(
         help = "Show the git url for each plugin\ne.g.: https://github.com/mise-plugins/vfox-cmake.git",
-        long_help = "urls",
         long = "urls",
         short = 'u'
     )]
     pub urls: bool,
     #[usage(
         help = "Show the git refs for each plugin\ne.g.: main 1234abc",
-        long_help = "refs",
         long = "refs",
         hide
     )]
@@ -3338,7 +3318,6 @@ pub struct PluginsUninstallArgs {
 pub struct PluginsUpdateArgs {
     #[usage(
         help = "Number of jobs to run in parallel\nDefault: 4",
-        long_help = "jobs",
         long = "jobs",
         short = 'j',
         value_name = "JOBS"
@@ -3359,21 +3338,18 @@ pub struct PluginsArgs {
     pub all: bool,
     #[usage(
         help = "The built-in plugins only\nNormally these are not shown",
-        long_help = "core",
         long = "core",
         short = 'c'
     )]
     pub core: bool,
     #[usage(
         help = "Show the git url for each plugin\ne.g.: https://github.com/mise-plugins/vfox-cmake.git",
-        long_help = "urls",
         long = "urls",
         short = 'u'
     )]
     pub urls: bool,
     #[usage(
         help = "Show the git refs for each plugin\ne.g.: main 1234abc",
-        long_help = "refs",
         long = "refs",
         hide
     )]
@@ -3655,7 +3631,6 @@ pub struct RunArgs {
     pub affected: bool,
     #[usage(
         help = "Git base revision for --affected\nDefaults to MISE_AFFECTED_BASE, CI metadata, or HEAD~1",
-        long_help = "affected-base",
         long = "affected-base",
         value_name = "REV"
     )]
@@ -3665,7 +3640,6 @@ pub struct RunArgs {
     pub affected_explain: bool,
     #[usage(
         help = "Git head revision for --affected\nDefaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD",
-        long_help = "affected-head",
         long = "affected-head",
         value_name = "REV"
     )]
@@ -3684,7 +3658,6 @@ pub struct RunArgs {
     pub force: bool,
     #[usage(
         help = "Number of tasks to run in parallel\n[default: 4]\nConfigure with `jobs` config or `MISE_JOBS` env var",
-        long_help = "jobs",
         long = "jobs",
         short = 'j',
         value_name = "JOBS"
@@ -3709,7 +3682,6 @@ pub struct RunArgs {
     pub quiet: bool,
     #[usage(
         help = "Read/write directly to stdin/stdout/stderr instead of by line\nRedactions are not applied with this option\nConfigure with `raw` config or `MISE_RAW` env var",
-        long_help = "raw",
         long = "raw",
         short = 'r'
     )]
@@ -3729,7 +3701,6 @@ pub struct RunArgs {
     pub tool: ::std::vec::Vec<::std::string::String>,
     #[usage(
         help = "Allow specific env var through (implies --deny-env for everything else)\nSupports wildcards, e.g. --allow-env='MYAPP_*'",
-        long_help = "allow-env",
         long = "allow-env",
         value_name = "VAR",
         var
@@ -3807,7 +3778,6 @@ pub struct RunArgs {
     pub task_cache_stats: bool,
     #[usage(
         help = "Timeout for the task to complete\ne.g.: 30s, 5m",
-        long_help = "timeout",
         long = "timeout",
         value_name = "TIMEOUT"
     )]
@@ -4102,7 +4072,6 @@ pub enum SettingsCommands {
 pub struct ShellArgs {
     #[usage(
         help = "Number of jobs to run in parallel\n[default: 4]",
-        long_help = "jobs",
         long = "jobs",
         short = 'j',
         value_name = "JOBS"
@@ -4384,7 +4353,6 @@ pub struct TasksLsArgs {
     pub extended: bool,
     #[usage(
         help = "Load all tasks from the entire monorepo, including sibling directories.\nBy default, only tasks from the current directory hierarchy are loaded.",
-        long_help = "all",
         long = "all"
     )]
     pub all: bool,
@@ -4447,7 +4415,6 @@ pub struct TasksRunArgs {
     pub affected: bool,
     #[usage(
         help = "Git base revision for --affected\nDefaults to MISE_AFFECTED_BASE, CI metadata, or HEAD~1",
-        long_help = "affected-base",
         long = "affected-base",
         value_name = "REV"
     )]
@@ -4457,7 +4424,6 @@ pub struct TasksRunArgs {
     pub affected_explain: bool,
     #[usage(
         help = "Git head revision for --affected\nDefaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD",
-        long_help = "affected-head",
         long = "affected-head",
         value_name = "REV"
     )]
@@ -4476,7 +4442,6 @@ pub struct TasksRunArgs {
     pub force: bool,
     #[usage(
         help = "Number of tasks to run in parallel\n[default: 4]\nConfigure with `jobs` config or `MISE_JOBS` env var",
-        long_help = "jobs",
         long = "jobs",
         short = 'j',
         value_name = "JOBS"
@@ -4501,7 +4466,6 @@ pub struct TasksRunArgs {
     pub quiet: bool,
     #[usage(
         help = "Read/write directly to stdin/stdout/stderr instead of by line\nRedactions are not applied with this option\nConfigure with `raw` config or `MISE_RAW` env var",
-        long_help = "raw",
         long = "raw",
         short = 'r'
     )]
@@ -4521,7 +4485,6 @@ pub struct TasksRunArgs {
     pub tool: ::std::vec::Vec<::std::string::String>,
     #[usage(
         help = "Allow specific env var through (implies --deny-env for everything else)\nSupports wildcards, e.g. --allow-env='MYAPP_*'",
-        long_help = "allow-env",
         long = "allow-env",
         value_name = "VAR",
         var
@@ -4599,7 +4562,6 @@ pub struct TasksRunArgs {
     pub task_cache_stats: bool,
     #[usage(
         help = "Timeout for the task to complete\ne.g.: 30s, 5m",
-        long_help = "timeout",
         long = "timeout",
         value_name = "TIMEOUT"
     )]
@@ -4658,7 +4620,6 @@ pub struct TasksArgs {
     pub extended: bool,
     #[usage(
         help = "Load all tasks from the entire monorepo, including sibling directories.\nBy default, only tasks from the current directory hierarchy are loaded.",
-        long_help = "all",
         long = "all"
     )]
     pub all: bool,
@@ -4732,7 +4693,6 @@ pub struct TestToolArgs {
     pub all: bool,
     #[usage(
         help = "Number of tool tests to run in parallel\n[default: 4]",
-        long_help = "jobs",
         long = "jobs",
         short = 'j',
         value_name = "JOBS"
@@ -4905,7 +4865,6 @@ pub struct TrustArgs {
     pub ignore: bool,
     #[usage(
         help = "Show the trusted status of config files from the current directory and its parents.\nDoes not trust or untrust any files.",
-        long_help = "show",
         long = "show"
     )]
     pub show: bool,
@@ -5022,7 +4981,6 @@ pub struct UpgradeArgs {
     pub interactive: bool,
     #[usage(
         help = "Number of jobs to run in parallel\n[default: 4]",
-        long_help = "jobs",
         long = "jobs",
         short = 'j',
         value_name = "JOBS"
@@ -5042,7 +5000,6 @@ pub struct UpgradeArgs {
     pub dry_run: bool,
     #[usage(
         help = "Tool(s) to exclude from upgrading\ne.g.: go python",
-        long_help = "exclude",
         long = "exclude",
         short = 'x',
         value_name = "INSTALLED_TOOL",
@@ -5131,7 +5088,6 @@ pub struct UseArgs {
     pub global: bool,
     #[usage(
         help = "Number of jobs to run in parallel\n[default: 4]",
-        long_help = "jobs",
         long = "jobs",
         short = 'j',
         value_name = "JOBS"
@@ -5163,7 +5119,7 @@ pub struct UseArgs {
     pub minimum_release_age: ::std::option::Option<::std::string::String>,
     #[usage(
         help = "Save exact version to config file\ne.g.: `mise use --pin node@20` will save 20.0.0 as the version\nSet `MISE_PIN=1` to make this the default behavior",
-        long_help = "pin",
+        long_help = "Save exact version to config file\ne.g.: `mise use --pin node@20` will save 20.0.0 as the version\nSet `MISE_PIN=1` to make this the default behavior\n\nConsider using mise.lock as a better alternative to pinning in mise.toml:\nhttps://mise.jdx.dev/configuration/settings.html#lockfile",
         long = "pin"
     )]
     pub pin: bool,
@@ -5211,7 +5167,6 @@ pub struct WatchArgs {
     pub task_flag: ::std::vec::Vec<::std::string::String>,
     #[usage(
         help = "Files to watch\nDefaults to sources from the task(s)",
-        long_help = "glob",
         long = "glob",
         short = 'g',
         hide,
@@ -5786,7 +5741,6 @@ pub struct WhereArgs {
 pub struct WhichArgs {
     #[usage(
         help = "Use a specific tool@version\ne.g.: `mise which npm --tool=node@20`",
-        long_help = "tool",
         long = "tool",
         short = 't',
         value_name = "TOOL@VERSION"

--- a/conformance/tests/metadata.rs
+++ b/conformance/tests/metadata.rs
@@ -235,9 +235,21 @@ fn a_command_can_be_hidden() {
         "and its sibling is not"
     );
 
-    // Still reachable, which is the whole point of hidden rather than absent.
+    // Still reachable, which is the whole point of hidden rather than absent — and its flags
+    // bind as any other command's do.
     use std::ffi::OsStr;
     let argv = [OsStr::new("asdf"), OsStr::new("--force")];
     let parsed = Verbatim::parse_from(&argv).expect("a hidden command still parses");
-    assert!(matches!(parsed.command, Some(Commands::Asdf(_))));
+    let Some(Commands::Asdf(internal)) = parsed.command else {
+        panic!("expected the hidden command")
+    };
+    assert!(internal.force);
+
+    // And the visible sibling, whose declared help is the subject of the test above.
+    let argv = [OsStr::new("activate"), OsStr::new("--shims")];
+    let parsed = Verbatim::parse_from(&argv).expect("should parse");
+    let Some(Commands::Activate(shims)) = parsed.command else {
+        panic!("expected activate")
+    };
+    assert!(shims.shims);
 }

--- a/conformance/tests/metadata.rs
+++ b/conformance/tests/metadata.rs
@@ -10,7 +10,7 @@
 //! consumer is wrong about.
 
 use usage::Spec as LibSpec;
-use usage_derive::Cli;
+use usage_derive::{Args, Cli, Subcommands};
 
 /// A flag reachable only by its short form, whose value still needs a name.
 #[derive(Cli)]
@@ -170,4 +170,74 @@ fn a_required_collection_still_binds_like_a_collection() {
     // value name is a placeholder in help, and a counted flag counted before this too.
     assert_eq!(ex.jobs.as_deref(), Some("4"));
     assert_eq!(ex.verbose, 2);
+}
+
+/// A command whose help text has line breaks that matter, and a hidden sibling.
+#[derive(Args)]
+struct Shims {
+    /// Undocumented on purpose: the help is declared below, not commented.
+    #[usage(
+        long,
+        help = "Use shims instead of modifying PATH\nEffectively the same as:"
+    )]
+    shims: bool,
+}
+
+#[derive(Args)]
+struct Internal {
+    #[usage(long)]
+    force: bool,
+}
+
+#[derive(Subcommands)]
+enum Commands {
+    /// Activate the thing
+    Activate(Box<Shims>),
+    /// Simulate something for compatibility
+    #[usage(hide)]
+    Asdf(Box<Internal>),
+}
+
+#[derive(Cli)]
+#[usage(bin = "verbatim")]
+struct Verbatim {
+    #[usage(subcommand)]
+    command: Option<Commands>,
+}
+
+#[test]
+fn help_text_can_keep_line_breaks_a_comment_would_flow() {
+    // A doc comment's first paragraph is read the way Rust reads one, so a line break inside
+    // it becomes a space — which is right for prose and wrong for help whose shape is
+    // deliberate. 37 of mise's flags and commands declare multi-line help, and every one came
+    // back with its lines run together until this existed.
+    let spec: LibSpec = Verbatim::to_kdl().parse().expect("valid spec");
+    let activate = spec.cmd.subcommands.get("activate").expect("activate");
+    let shims = activate
+        .flags
+        .iter()
+        .find(|f| f.name == "shims")
+        .expect("--shims");
+    assert_eq!(
+        shims.help.as_deref(),
+        Some("Use shims instead of modifying PATH\nEffectively the same as:")
+    );
+}
+
+#[test]
+fn a_command_can_be_hidden() {
+    // `hide=#true` on a `cmd`. The command still answers to its name; it is not offered.
+    let spec: LibSpec = Verbatim::to_kdl().parse().expect("valid spec");
+    let asdf = spec.cmd.subcommands.get("asdf").expect("asdf");
+    assert!(asdf.hide, "declared hidden");
+    assert!(
+        !spec.cmd.subcommands.get("activate").expect("activate").hide,
+        "and its sibling is not"
+    );
+
+    // Still reachable, which is the whole point of hidden rather than absent.
+    use std::ffi::OsStr;
+    let argv = [OsStr::new("asdf"), OsStr::new("--force")];
+    let parsed = Verbatim::parse_from(&argv).expect("a hidden command still parses");
+    assert!(matches!(parsed.command, Some(Commands::Asdf(_))));
 }

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -1628,12 +1628,16 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
         // Which of the table's aliases are hidden. The visible ones are not listed
         // anywhere: `cmd.aliases` minus these is what help and completions show.
         let hidden = &v.hidden_aliases;
+        // A hidden command still answers to its name; it is simply not offered. Declared on
+        // the variant, which is where the command itself is declared.
+        let hide = v.hide;
         quote! {
             pub static #name: ::usage_argv::spec::CommandMeta =
                 ::usage_argv::spec::CommandMeta {
                     cmd: &#cmd,
                     about: #about,
                     long_about: #long_about,
+                    hide: #hide,
                     hidden_aliases: &[#(#hidden),*],
                     ..*<#ty as ::usage_argv::spec::CommandArgs>::META
                 };

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -692,6 +692,8 @@ impl Field {
         let mut help_heading = None;
         let mut value_name = None;
         let mut required_collection = false;
+        let mut help_attr: Option<String> = None;
+        let mut long_help_attr: Option<String> = None;
         let mut hide = false;
         let mut is_arg = false;
         let mut choices: Vec<String> = Vec::new();
@@ -777,6 +779,11 @@ impl Field {
                     "default" => default = Some(string_value(&meta)?),
                     "help_heading" => help_heading = Some(string_value(&meta)?),
                     "value_name" => value_name = Some(string_value(&meta)?),
+                    // Help text a doc comment cannot carry. A comment's first paragraph is
+                    // read the way Rust reads one — line breaks inside it are spaces — so
+                    // help whose breaks are meant literally has to be given directly.
+                    "help" => help_attr = Some(string_value(&meta)?),
+                    "long_help" => long_help_attr = Some(string_value(&meta)?),
                     "required" => required_collection = flag_value(&meta)?,
                     "double_dash" => {
                         let mode = string_value(&meta)?;
@@ -1044,6 +1051,9 @@ impl Field {
                  somewhere to put \"absent\": make it an `Option`",
             ));
         }
+
+        // Declared text wins over the comment, which is the point of declaring it.
+        let (help, long_help) = (help_attr.or(help), long_help_attr.or(long_help));
 
         // A flag is named after the form it answers to, not after the Rust field holding it.
         // usage-lib derives the name the same way, so the two agree about what a flag is
@@ -1580,6 +1590,12 @@ pub struct Subcommands {
 /// One variant: a command name and the struct holding its flags and arguments.
 pub struct Variant {
     pub ident: syn::Ident,
+    /// Whether the command is kept out of help and completions.
+    ///
+    /// A spec says `hide=#true` on a `cmd`; mise hides eight commands that way, `asdf` and
+    /// `dotfiles` among them. Without this the derive could declare the command but not that
+    /// it is unadvertised, so help listed things a user was not meant to be offered.
+    pub hide: bool,
     /// The command name, which is the variant name in kebab-case unless `name`
     /// says otherwise.
     pub name: String,
@@ -1692,6 +1708,9 @@ impl Variant {
         let mut name = to_kebab(&variant.ident.to_string());
         let mut aliases: Vec<String> = Vec::new();
         let mut hidden_aliases: Vec<String> = Vec::new();
+        let mut hide = false;
+        let mut help_attr: Option<String> = None;
+        let mut long_help_attr: Option<String> = None;
 
         for attr in attrs(&variant.attrs) {
             for meta in nested(attr)? {
@@ -1701,6 +1720,11 @@ impl Variant {
                     // One as a value or several as a list, as the relationship options do.
                     "alias" => aliases.extend(selectors(&meta)?),
                     "alias_hidden" => hidden_aliases.extend(selectors(&meta)?),
+                    "hide" => hide = flag_value(&meta)?,
+                    // As on a field: a comment's paragraph is flowed, so text whose line
+                    // breaks matter is declared instead.
+                    "help" => help_attr = Some(string_value(&meta)?),
+                    "long_help" => long_help_attr = Some(string_value(&meta)?),
                     other => {
                         return Err(syn::Error::new_spanned(
                             path,
@@ -1756,8 +1780,10 @@ impl Variant {
             None => (held, false),
         };
 
+        let (help, long_help) = (help_attr.or(help), long_help_attr.or(long_help));
         Ok(Variant {
             ident: variant.ident.clone(),
+            hide,
             name,
             ty,
             boxed,

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -1041,18 +1041,9 @@ impl Field {
                 ));
             }
         }
-        // `required_unless` says the field may be absent when another flag stands in for
-        // it. A bare `String` has nowhere to put absent, so its type would keep claiming
-        // the value is mandatory and the exception could never take effect.
-        if !required_unless.is_empty() && shape == Shape::Required {
-            return Err(syn::Error::new(
-                span,
-                "`required_unless` says this may be left out, so the field needs \
-                 somewhere to put \"absent\": make it an `Option`",
-            ));
-        }
-
-        // Declared text wins over the comment, which is the point of declaring it.
+        // Declared text wins over the comment, which is the point of declaring it. A comment's
+        // first paragraph is read the way Rust reads one — line breaks inside it become spaces —
+        // so help whose breaks are deliberate has to be given directly.
         let (help, long_help) = (help_attr.or(help), long_help_attr.or(long_help));
 
         // A flag is named after the form it answers to, not after the Rust field holding it.
@@ -1060,8 +1051,8 @@ impl Field {
         // called — and the field name is often not a legal one: `type_` gave a flag called
         // `type-`, which help printed as `type-: -t --type` and errors reported as `type-`.
         //
-        // Only where the field says nothing: an explicit `name` still wins, and a flag with
-        // no long form keeps its short as the name, as usage-lib does.
+        // Only where the field says nothing: an explicit `name` still wins, and a flag with no
+        // long form keeps its short as the name, as usage-lib does.
         if is_flag && !name_given {
             // Only where the name is about to become something that says nothing: a flag with
             // no long form is named after its short one, and `-j <j>` is no use as a
@@ -1079,6 +1070,17 @@ impl Field {
             } else if let Some(short) = shorts.first() {
                 name = short.to_string();
             }
+        }
+
+        // `required_unless` says the field may be absent when another flag stands in for
+        // it. A bare `String` has nowhere to put absent, so its type would keep claiming
+        // the value is mandatory and the exception could never take effect.
+        if !required_unless.is_empty() && shape == Shape::Required {
+            return Err(syn::Error::new(
+                span,
+                "`required_unless` says this may be left out, so the field needs \
+                 somewhere to put \"absent\": make it an `Option`",
+            ));
         }
 
         // `required` is for the one case the type cannot express. Anywhere else it either
@@ -1179,6 +1181,29 @@ impl Field {
         // And an `Option<Vec<_>>` is shaped like any other collection, so `required` was
         // accepted there too — after which the field can never be `None` and the `Option` means
         // nothing at all.
+        // `required` is for the one shape whose type cannot say it. Anywhere else it repeats
+        // what the type says or contradicts it, and a declaration that changes nothing is one
+        // someone will eventually trust. (This guard was lost while two fixes for the same
+        // review finding met in the middle; the test for it is what noticed.)
+        if required_collection && shape != Shape::Many {
+            return Err(syn::Error::new(
+                span,
+                match shape {
+                    Shape::Optional => {
+                        "`required` contradicts `Option`, which is how a field \
+                                        says a value may be left out — drop one or the other"
+                    }
+                    Shape::Required => {
+                        "a bare type is already required: `required` is only for \
+                                        a collecting field, where the type cannot say it"
+                    }
+                    _ => {
+                        "`required` is only for a collecting field, which is the one shape \
+                          whose type cannot say whether a value is needed"
+                    }
+                },
+            ));
+        }
         if required_collection {
             let contradiction = if optional_collection {
                 Some("an `Option<Vec<_>>` says the whole collection may be absent")

--- a/xtask/src/shadow.rs
+++ b/xtask/src/shadow.rs
@@ -133,6 +133,8 @@ fn render(spec: &Spec, spec_path: &Path, dialect: Dialect) -> (String, Skipped) 
         &mut Run {
             bin: &spec.bin,
             default_subcommand: spec.default_subcommand.as_deref(),
+            about: spec.about.as_deref(),
+            about_long: spec.about_long.as_deref(),
             dialect,
             skipped: &mut skipped,
             names: &mut names,
@@ -242,6 +244,9 @@ struct Run<'a> {
     bin: &'a str,
     /// Only the root has one, and only it declares it.
     default_subcommand: Option<&'a str>,
+    /// The spec's own description, which belongs to the root.
+    about: Option<&'a str>,
+    about_long: Option<&'a str>,
     dialect: Dialect,
     skipped: &'a mut Skipped,
     names: &'a mut Names,
@@ -272,7 +277,18 @@ fn emit_command(out: &mut String, cmd: &SpecCommand, ty: &Type, is_root: bool, r
         emit_command(out, sub, sub_ty, false, run);
     }
 
-    doc_comment(out, cmd.help.as_deref(), cmd.help_long.as_deref(), 0);
+    // The root's own description is the *spec's* `about`, not the root command's help — a
+    // spec puts it at the top level, and the root command usually has none. Taken from the
+    // command first all the same, since a spec may say both.
+    let (about, about_long) = if is_root {
+        (
+            cmd.help.as_deref().or(run.about),
+            cmd.help_long.as_deref().or(run.about_long),
+        )
+    } else {
+        (cmd.help.as_deref(), cmd.help_long.as_deref())
+    };
+    doc_comment(out, about, about_long, 0);
     // The command-level properties. The usage dialect declares them; clap has no way to say
     // any of them, so on that side they are counted as dropped — the shadow would otherwise
     // look more faithful than it is.
@@ -407,6 +423,13 @@ fn emit_command(out: &mut String, cmd: &SpecCommand, ty: &Type, is_root: bool, r
             // be measuring a smaller CLI than the one it claims to shadow.
             match dialect {
                 Dialect::Usage => {
+                    opts.extend(declared_help(sub.help.as_deref(), sub.help_long.as_deref()));
+                    // `hide=#true` on a `cmd`: the command works and is not advertised. mise
+                    // hides eight, `asdf` and `dotfiles` among them, and help listed every one
+                    // of them before the variant could say so.
+                    if sub.hide {
+                        opts.push("hide".into());
+                    }
                     if !sub.aliases.is_empty() {
                         opts.push(alias_list("alias", &sub.aliases));
                     }
@@ -537,7 +560,7 @@ fn usage_flag_opts(
     ty: &str,
     skipped: &mut Skipped,
 ) -> Vec<String> {
-    let mut opts: Vec<String> = Vec::new();
+    let mut opts: Vec<String> = declared_help(flag.help.as_deref(), long);
     // Written out rather than bare, because the field name may have been sanitized —
     // `--type` becomes `type_`, and a bare `long` would rename the flag.
     if let Some(long) = long {
@@ -760,6 +783,7 @@ fn emit_arg(out: &mut String, arg: &SpecArg, field: &str, dialect: Dialect, skip
 
 fn usage_arg_opts(arg: &SpecArg, skipped: &mut Skipped) -> Vec<String> {
     let mut opts: Vec<String> = vec!["arg".into(), format!("name = {:?}", arg.name)];
+    opts.extend(declared_help(arg.help.as_deref(), arg.help_long.as_deref()));
     if arg.hide {
         opts.push("hide".into());
     }
@@ -884,12 +908,41 @@ fn selector_list(option: &str, selectors: &[String]) -> String {
 }
 
 /// Help text as a doc comment, which is how the derive reads it.
+/// Whether help text has to be declared rather than written as a comment.
+///
+/// A doc comment's first paragraph is read the way Rust reads one, so a line break inside it
+/// becomes a space. mise's specs use multi-line `help` on 37 commands and flags, and every one
+/// of them came back with its lines run together — so where the break is part of the text, the
+/// generated code declares it instead.
+fn needs_declaring(help: Option<&str>) -> bool {
+    help.map(|h| h.trim().contains('\n')).unwrap_or(false)
+}
+
+/// The `help = "..."` option for text a comment would reflow.
+fn declared_help(help: Option<&str>, long: Option<&str>) -> Vec<String> {
+    let mut opts = Vec::new();
+    if let Some(help) = help.filter(|h| needs_declaring(Some(h))) {
+        opts.push(format!("help = {:?}", help.trim()));
+        // The long form goes with it: read from the comment, it would be measured against a
+        // short form that no longer matches, and written in full twice over.
+        if let Some(long) = long.filter(|l| !l.trim().is_empty()) {
+            opts.push(format!("long_help = {:?}", long.trim_end()));
+        }
+    }
+    opts
+}
+
 fn doc_comment(out: &mut String, help: Option<&str>, long: Option<&str>, depth: usize) {
     let indent = "    ".repeat(depth);
+    // Declared instead, by `declared_help`.
+    if needs_declaring(help) {
+        return;
+    }
     let Some(help) = help.filter(|h| !h.trim().is_empty()) else {
-        // Every generated item gets one, so the shadow does not depend on whether the
-        // derive requires help text.
-        writeln!(out, "{indent}/// Undocumented").expect("writing to a String");
+        // Nothing at all where the spec says nothing. A placeholder was standing in — the
+        // derive does not require help text — and it became *real* help: the shadow told a
+        // reader that `--output` was "Undocumented" where mise's spec leaves it bare, which a
+        // fixture for comparing help output cannot do.
         return;
     };
     for line in help.lines() {

--- a/xtask/src/shadow.rs
+++ b/xtask/src/shadow.rs
@@ -440,6 +440,11 @@ fn emit_command(out: &mut String, cmd: &SpecCommand, ty: &Type, is_root: bool, r
                 // clap spells one and several differently, and repeating the singular
                 // form is not the same as the plural one.
                 Dialect::Clap => {
+                    opts.extend(declared_help_clap(
+                        sub.help.as_deref(),
+                        sub.help_long.as_deref(),
+                        true,
+                    ));
                     match sub.aliases.as_slice() {
                         [] => {}
                         [one] => opts.push(format!("visible_alias = {one:?}")),
@@ -689,7 +694,8 @@ fn clap_flag_opts(
     ids: &BTreeMap<String, String>,
     skipped: &mut Skipped,
 ) -> Vec<String> {
-    let mut opts: Vec<String> = Vec::new();
+    let mut opts: Vec<String> =
+        declared_help_clap(flag.help.as_deref(), flag.help_long.as_deref(), false);
     if let Some(long) = long {
         opts.push(format!("long = {long:?}"));
     }
@@ -839,6 +845,11 @@ fn usage_arg_opts(arg: &SpecArg, skipped: &mut Skipped) -> Vec<String> {
 
 fn clap_arg_opts(arg: &SpecArg, skipped: &mut Skipped) -> Vec<String> {
     let mut opts: Vec<String> = vec![format!("value_name = {:?}", arg.name)];
+    opts.extend(declared_help_clap(
+        arg.help.as_deref(),
+        arg.help_long.as_deref(),
+        false,
+    ));
     if arg.hide {
         opts.push("hide = true".into());
     }
@@ -920,6 +931,32 @@ fn selector_list(option: &str, selectors: &[String]) -> String {
 /// generated code declares it instead.
 fn needs_declaring(help: Option<&str>) -> bool {
     help.map(|h| h.trim().contains('\n')).unwrap_or(false)
+}
+
+/// The same declarations in clap's vocabulary.
+///
+/// clap takes `help`/`long_help` on an argument and `about`/`long_about` on a command, so there
+/// is nothing it cannot say — but it does not read the *usage* attribute list. Skipping the
+/// comment without writing clap's own left the clap shadow with no text at all for every command
+/// and flag whose help a comment cannot carry, and *uncounted*, which is the silent-drop class
+/// this generator exists to prevent.
+fn declared_help_clap(help: Option<&str>, long: Option<&str>, command: bool) -> Vec<String> {
+    let mut opts = Vec::new();
+    if !needs_declaring(help) {
+        return opts;
+    }
+    let (short_key, long_key) = if command {
+        ("about", "long_about")
+    } else {
+        ("help", "long_help")
+    };
+    if let Some(help) = help.filter(|h| !h.trim().is_empty()) {
+        opts.push(format!("{short_key} = {:?}", help.trim()));
+    }
+    if let Some(long) = long.filter(|l| !l.trim().is_empty()) {
+        opts.push(format!("{long_key} = {:?}", long.trim_end()));
+    }
+    opts
 }
 
 /// The `help = "..."` option for text a comment would reflow.
@@ -1114,6 +1151,20 @@ mod tests {
         );
         assert!(out.contains(r#"env = "EX_FILE""#), "{out}");
         assert!(out.contains(r#"help_heading = "Input""#), "{out}");
+    }
+
+    #[test]
+    fn both_dialects_carry_help_a_comment_cannot() {
+        // Multi-line help is skipped as a comment for *both* dialects, and only one of them was
+        // writing it as an attribute — so the clap shadow had no text for those flags at all,
+        // uncounted. clap can say it: `help` and `long_help` on an argument.
+        let spec = "name \"ex\"\nbin \"ex\"\nflag \"--shims\" help=#\"\"\"\nUse shims\nlike so:\n\"\"\"#\n";
+
+        let (usage, _) = rendered_as(spec, Dialect::Usage);
+        assert!(usage.contains(r#"help = "Use shims\nlike so:""#), "{usage}");
+
+        let (clap, _) = rendered_as(spec, Dialect::Clap);
+        assert!(clap.contains(r#"help = "Use shims\nlike so:""#), "{clap}");
     }
 
     #[test]

--- a/xtask/src/shadow.rs
+++ b/xtask/src/shadow.rs
@@ -560,7 +560,11 @@ fn usage_flag_opts(
     ty: &str,
     skipped: &mut Skipped,
 ) -> Vec<String> {
-    let mut opts: Vec<String> = declared_help(flag.help.as_deref(), long);
+    // `flag.help_long`, not `long` — that is the flag's long *name*, which every other caller of
+    // this function gets right. Passing it here emitted `long_help = "shims"` for a flag called
+    // `--shims`, so the shadow dropped the real long help and its regenerated spec said the
+    // flag's own name where the source said a paragraph.
+    let mut opts: Vec<String> = declared_help(flag.help.as_deref(), flag.help_long.as_deref());
     // Written out rather than bare, because the field name may have been sanitized —
     // `--type` becomes `type_`, and a bare `long` would rename the flag.
     if let Some(long) = long {
@@ -1110,6 +1114,25 @@ mod tests {
         );
         assert!(out.contains(r#"env = "EX_FILE""#), "{out}");
         assert!(out.contains(r#"help_heading = "Input""#), "{out}");
+    }
+
+    #[test]
+    fn a_flags_long_help_is_its_long_help_and_not_its_name() {
+        // The long *name* was passed where the long *help* belongs, so a flag called `--shims`
+        // with a paragraph of extended help emitted `long_help = "shims"` — the shadow dropped
+        // the real text, and its regenerated spec said the flag's own name instead.
+        // The short help has to be *multi-line* to reach this path at all: a one-line help is
+        // written as a doc comment, and `declared_help` — where the bug lived — is only called
+        // for help a comment cannot carry. Without that, the mutation survived.
+        let (out, _) = rendered(
+            "name \"ex\"\nbin \"ex\"\nflag \"--shims\" help=\"Use shims\\nacross tools\" \\
+                long_help=\"Use shims\\nacross tools\\n\\nAnd here is why.\"\n",
+        );
+        assert!(
+            !out.contains(r#"long_help = "shims""#),
+            "the flag's name became its long help: {out}"
+        );
+        assert!(out.contains("And here is why."), "{out}");
     }
 
     #[test]


### PR DESCRIPTION
The whole short help page, not just the line above it: the program and version, the about,
the commands list, arguments and flags grouped by heading, examples, and the hidden-item
filtering. All 211 of mise's commands come out byte for byte identical to usage-lib's, which
is the standard that decides whether an adopter's help changes.

Holding it to that found four more things a spec could say that the derive could not, each
dropped by `gen-shadow` without being counted — the same class as the three in the PR below
this one, and found the same way:

- the spec's own `about`. The root's description lives at the top level, not on the root
  command, so the shadow's root said "Undocumented" where mise says what mise is.
- `hide` on a command. mise hides eight, `asdf` and `dotfiles` among them, and a
  `Subcommands` variant had no way to say so — help listed every one of them.
- help text whose line breaks are meant literally. A doc comment's first paragraph is read
  the way Rust reads one, so a break inside it becomes a space; 37 of mise's flags and
  commands have multi-line help and every one came back with its lines run together.
  `#[usage(help = "…")]` declares it instead, rather than changing what a comment means.
- the `Undocumented` placeholder the generator wrote where a spec says nothing. It became
  *real* help text: the shadow told a reader that `--output` was "Undocumented".

Two shapes the reference has that are worth knowing about, both matched rather than
improved: a listed subcommand shows its whole path from the root (`tool-alias get <TOOL>`,
not `get <TOOL>`), and a command whose subcommands are all hidden still says `<SUBCOMMAND>`
in its usage line while printing no commands section, because usage-lib computes that line
before filtering.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are help rendering and test/shadow fixtures only; no parser hot-path or binding behavior.
> 
> **Overview**
> Adds **`short_help`** in `usage_argv::help`, producing the full **`-h`** page from static metadata: version line, spec **`about`**, usage line, subcommands (full path, aliases, synthetic **`help`** entry), arguments and flags grouped by **`help_heading`** with choices/env/default annotations, and examples—with **hidden** items filtered like usage-lib.
> 
> A gate test walks all **211** mise commands and compares output to **`usage::docs::cli::render_help(..., false)`**, reporting the first differing line on failure.
> 
> The **mise clap shadow** is updated so generated help matches: root **`about`**, **`hide`** on subcommands, **`#[usage(help = "...")]`** (and **`long_help`**) where doc comments would collapse line breaks, and removal of **`Undocumented`** placeholders that had become visible help text. **PLAN.md** marks **`-h`** parity done and notes **`--help`** layout plus derive wiring as next.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f43d20a226b9b1b60ee1e711311f0d2c8473ba2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## The standard

**All 211 of mise's commands render byte-identically to usage-lib** — the whole `-h` page, not
just the line at the top: program and version, about, commands list, arguments and flags grouped
by heading, examples, hidden-item filtering.

usage-lib renders through a tera template over a runtime model. usage-argv has only `&'static`
tables, so the rules are reimplemented, and the parity test over mise's real spec is what keeps
them honest. It reports the **first differing line** rather than two walls of text, which is what
made working through 211 → 74 → 70 → 37 → 3 → 0 tractable.

## Four more gaps it found

Same class as the three in #853, found the same way, and each dropped by `gen-shadow` without
being counted:

| | what happened |
|---|---|
| the spec's own `about` | the root's description lives at the top level, not on the root command, so the shadow's root said **"Undocumented"** where mise says what mise is |
| `hide` on a command | mise hides eight (`asdf`, `dotfiles`, …) and a `Subcommands` variant had no way to say so — help listed every one |
| multi-line help | a doc comment's first paragraph is read the way Rust reads one, so a line break inside it becomes a space; **37** of mise's flags and commands have multi-line help and all came back run together |
| the `Undocumented` placeholder | written where a spec says nothing, it became *real* help text — the shadow told readers `--output` was "Undocumented" |

For the third I added `#[usage(help = "…")]` rather than changing what a doc comment means: a
comment's paragraph should still flow, as clap reads it too, but help whose line breaks are
deliberate now has a way to say so. Useful to adopters beyond the shadow.

## Two reference shapes matched rather than improved

- A listed subcommand shows its **whole path from the root** — `tool-alias get <TOOL>` under
  `mise tool-alias`, not `get <TOOL>`.
- A command whose subcommands are all hidden still says `<SUBCOMMAND>` in its usage line while
  printing no commands section, because usage-lib computes that line before filtering and
  stores it.

Both are odd; both are what the reference does, and parity is the point. Worth revisiting
together later, in usage-lib.

## Next

`--help`'s wider layout — help aligned into a column, wrapped to `COLUMNS`, `[possible values:]`
on its own line — then the `--help`/`-h` wiring in the derive: `Error::Help`, `-h` short and
`--help` long, and a real `help` subcommand for any CLI that has subcommands.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*
