### PR TITLE
fix(derive): three more descriptions a spec keeps and the derive lost

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -272,7 +272,14 @@ tasks --usage"`, so task names are meant to come from running that. usage-argv d
       Holding it to parity found six more things a spec could say that the derive could not —
       value names, required collections, `var` on a count, the spec's own `about`, `hide` on a
       command, and help text whose line breaks matter — plus a bug in usage-lib, which printed
-      everything marked `hide`.
+      everything marked `hide`. Then three more, found while starting on `--help`: a variant's short
+      description was hiding the struct's long one, which is the shape every generated CLI has;
+      a doc comment's lines were trimmed one by one, flattening every indented example in help;
+      and a program could not describe itself twice over, since a comment's long form always
+      contains its short one where a spec keeps the two independent. `--help`'s own layout is
+      written and not yet at parity — 123 of 211 pages differ, each remaining cause a metadata
+      path where the shadow's description is not the spec's — so it is held back rather than
+      shipped wrong.
 - [ ] **Completions, self-contained** — `<bin> completion <shell>` emits the
       script; a hidden `<bin> complete-word` serves requests from the binary's own
       embedded spec. Same dispatch shape usage-cli uses today, without requiring

--- a/benches/shadows/mise-clap/src/lib.rs
+++ b/benches/shadows/mise-clap/src/lib.rs
@@ -5476,9 +5476,6 @@ pub struct WhichArgs {
     pub bin_name: Option<String>,
 }
 
-/// Dev tools, env vars, and tasks in one CLI
-///
-/// mise prepares your development environment before each command runs. https://github.com/jdx/mise
 #[derive(Parser)]
 #[command(name = "mise")]
 pub struct Cli {

--- a/benches/shadows/mise-clap/src/lib.rs
+++ b/benches/shadows/mise-clap/src/lib.rs
@@ -5477,7 +5477,11 @@ pub struct WhichArgs {
 }
 
 #[derive(Parser)]
-#[command(name = "mise")]
+#[command(
+    name = "mise",
+    about = "Dev tools, env vars, and tasks in one CLI",
+    long_about = "mise prepares your development environment before each command runs. https://github.com/jdx/mise"
+)]
 pub struct Cli {
     /// Continue running tasks even if one fails
     #[arg(long = "continue-on-error", short = 'c', hide = true)]

--- a/benches/shadows/mise/src/lib.rs
+++ b/benches/shadows/mise/src/lib.rs
@@ -5759,11 +5759,13 @@ pub struct WhichArgs {
     pub bin_name: ::std::option::Option<::std::string::String>,
 }
 
-/// Dev tools, env vars, and tasks in one CLI
-///
-/// mise prepares your development environment before each command runs. https://github.com/jdx/mise
 #[derive(Cli)]
-#[usage(bin = "mise", default_subcommand = "run")]
+#[usage(
+    bin = "mise",
+    about = "Dev tools, env vars, and tasks in one CLI",
+    long_about = "mise prepares your development environment before each command runs. https://github.com/jdx/mise",
+    default_subcommand = "run"
+)]
 pub struct Cli {
     /// Continue running tasks even if one fails
     #[usage(long = "continue-on-error", short = 'c', hide)]

--- a/conformance/tests/metadata.rs
+++ b/conformance/tests/metadata.rs
@@ -253,3 +253,98 @@ fn a_command_can_be_hidden() {
     };
     assert!(shims.shims);
 }
+
+/// A command whose short description is on the enum and whose long one is on the struct.
+///
+/// The shape every generated CLI has, and mise's own: the variant says what the command is for
+/// in a line, and the struct's comment carries the detail.
+#[derive(Args)]
+/// Initializes mise in the current shell session
+///
+/// This should go into your shell's rc file.
+/// Otherwise, it will only take effect in the current session.
+///
+///     echo 'eval "$(mise activate zsh)"' >> ~/.zshrc
+struct ActivateArgs {
+    /// Use shims instead of modifying PATH
+    #[usage(long)]
+    shims: bool,
+}
+
+#[derive(Subcommands)]
+enum SplitCommands {
+    /// Initializes mise in the current shell session
+    Activate(Box<ActivateArgs>),
+}
+
+#[derive(Cli)]
+#[usage(
+    bin = "split",
+    about = "Dev tools, env vars, and tasks in one CLI",
+    long_about = "split prepares your development environment before each command runs."
+)]
+struct Split {
+    #[usage(subcommand)]
+    command: Option<SplitCommands>,
+}
+
+#[test]
+fn a_variants_short_description_does_not_hide_the_structs_long_one() {
+    // Each falls back on its own. A variant that gave a short description was suppressing the
+    // struct's long one, so the long form went missing from help for every command written the
+    // way generated CLIs are written.
+    let spec: LibSpec = Split::to_kdl().parse().expect("valid spec");
+    let activate = spec.cmd.subcommands.get("activate").expect("activate");
+    assert_eq!(
+        activate.help.as_deref(),
+        Some("Initializes mise in the current shell session"),
+        "the variant's line"
+    );
+    let long = activate.help_long.as_deref().expect("the struct's detail");
+    assert!(long.contains("rc file"), "{long}");
+}
+
+#[test]
+fn an_indented_example_in_help_keeps_its_indentation() {
+    // A doc comment's lines were trimmed one by one, which flattened every indented block in a
+    // CLI's help — and an indented block is how a spec shows a command to type. mise's help is
+    // full of them.
+    let spec: LibSpec = Split::to_kdl().parse().expect("valid spec");
+    let activate = spec.cmd.subcommands.get("activate").expect("activate");
+    let long = activate.help_long.as_deref().expect("long help");
+    assert!(
+        long.contains("\n    echo 'eval"),
+        "the example should still be indented:\n{long}"
+    );
+}
+
+#[test]
+fn a_program_can_describe_itself_twice_over() {
+    // A comment's long form always contains its short one, because the short form *is* its
+    // first paragraph. A spec keeps the two independent, and mise's differ entirely — so there
+    // is no comment that says both.
+    let spec: LibSpec = Split::to_kdl().parse().expect("valid spec");
+    assert_eq!(
+        spec.about.as_deref(),
+        Some("Dev tools, env vars, and tasks in one CLI")
+    );
+    assert_eq!(
+        spec.about_long.as_deref(),
+        Some("split prepares your development environment before each command runs.")
+    );
+}
+
+#[test]
+fn the_split_description_cli_still_parses() {
+    // Reading what the fixture declares, which is also how these structs avoid being dead
+    // code: a test CLI nobody parses is a warning, and CI denies warnings.
+    use std::ffi::OsStr;
+
+    let argv = [OsStr::new("activate"), OsStr::new("--shims")];
+    let Some(SplitCommands::Activate(activate)) =
+        Split::parse_from(&argv).expect("should parse").command
+    else {
+        panic!("expected activate")
+    };
+    assert!(activate.shims);
+}

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -1615,15 +1615,17 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
         // A doc comment on the variant wins over the struct's, since that is where a
         // reader of the enum expects to describe the command. Absent one, the
         // struct's own description carries through.
-        let (about, long_about) = match &v.help {
-            Some(_) => (
-                option_str(v.help.as_deref()),
-                option_str(v.long_help.as_deref()),
-            ),
-            None => (
-                quote!(<#ty as ::usage_argv::spec::CommandArgs>::META.about),
-                quote!(<#ty as ::usage_argv::spec::CommandArgs>::META.long_about),
-            ),
+        // Each falls back on its own. A variant that gives a short description was suppressing
+        // the struct's long one, which is exactly how a generated CLI is shaped: the enum says
+        // what the command is for in a line, and the struct's own comment carries the rest. The
+        // long form went missing from help for every command written that way.
+        let about = match v.help.as_deref() {
+            Some(help) => option_str(Some(help)),
+            None => quote!(<#ty as ::usage_argv::spec::CommandArgs>::META.about),
+        };
+        let long_about = match v.long_help.as_deref() {
+            Some(long) => option_str(Some(long)),
+            None => quote!(<#ty as ::usage_argv::spec::CommandArgs>::META.long_about),
         };
         // Which of the table's aliases are hidden. The visible ones are not listed
         // anywhere: `cmd.aliases` minus these is what help and completions show.

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -31,6 +31,10 @@ pub struct Cli {
     ///
     /// Only the root has one, and it is what mise sets by hand on the emitted spec today.
     pub default_subcommand: Option<String>,
+    /// Declared descriptions, for the case a doc comment cannot express: a long form that does
+    /// not contain the short one.
+    pub about_attr: Option<String>,
+    pub long_about_attr: Option<String>,
     /// The word that starts another invocation of the same command: mise's `:::`.
     pub restart_token: Option<String>,
     /// A command to run for subcommands discovered at completion time.
@@ -212,6 +216,8 @@ impl Cli {
             long_about,
             unknown_flags: None,
             default_subcommand: None,
+            about_attr: None,
+            long_about_attr: None,
             restart_token: None,
             mount: None,
             fields: Vec::new(),
@@ -224,6 +230,14 @@ impl Cli {
                     "name" => cli.name = string_value(&meta)?,
                     "bin" => cli.bin = Some(string_value(&meta)?),
                     "version" => cli.version = Some(string_value(&meta)?),
+                    // A doc comment's long form always contains its short one — the short form
+                    // *is* the comment's first paragraph. A spec keeps `about` and `about_long`
+                    // independent, and mise's differ entirely: "Dev tools, env vars, and tasks
+                    // in one CLI" against "mise prepares your development environment before
+                    // each command runs." There is no comment that says both, so they can be
+                    // declared.
+                    "about" => cli.about_attr = Some(string_value(&meta)?),
+                    "long_about" => cli.long_about_attr = Some(string_value(&meta)?),
                     // A Rust CLI usually owns every flag it accepts, which is the
                     // case the stricter reading is for — but it is still opt-in,
                     // since a wrapper forwarding options wants the default.
@@ -259,6 +273,14 @@ impl Cli {
                     }
                 }
             }
+        }
+
+        // Declared descriptions win over the comment, which is the point of declaring them.
+        if let Some(about) = cli.about_attr.take() {
+            cli.about = Some(about);
+        }
+        if let Some(long) = cli.long_about_attr.take() {
+            cli.long_about = Some(long);
         }
 
         for field in &named.named {
@@ -1562,7 +1584,12 @@ fn doc_comment(attrs: &[Attribute]) -> syn::Result<(Option<String>, Option<Strin
                 lit: Lit::Str(s), ..
             }) = &nv.value
             {
-                lines.push(s.value().trim().to_string());
+                // Only the one space `///` conventionally adds, and trailing space. Trimming
+                // each line outright flattened every indented example in a CLI's help — and
+                // mise's help is full of them, since an indented block is how a spec shows a
+                // command to type.
+                let raw = s.value();
+                lines.push(raw.strip_prefix(' ').unwrap_or(&raw).trim_end().to_string());
             }
         }
     }

--- a/xtask/src/shadow.rs
+++ b/xtask/src/shadow.rs
@@ -280,7 +280,28 @@ fn emit_command(out: &mut String, cmd: &SpecCommand, ty: &Type, is_root: bool, r
     // The root's own description is the *spec's* `about`, not the root command's help — a
     // spec puts it at the top level, and the root command usually has none. Taken from the
     // command first all the same, since a spec may say both.
-    let (about, about_long) = if is_root {
+    // A comment's long form always contains its short one, because the short form *is* its
+    // first paragraph. Where a spec's two are independent — mise's are entirely different
+    // sentences — no comment can say both, so the root declares them instead.
+    let root_declares_about = is_root
+        && match (run.about, run.about_long) {
+            (Some(a), Some(l)) => !l.trim_start().starts_with(a.trim()),
+            _ => false,
+        };
+    let declared_about: Vec<String> = if root_declares_about {
+        [
+            run.about.map(|a| format!("about = {:?}", a.trim())),
+            run.about_long
+                .map(|l| format!("long_about = {:?}", l.trim_end())),
+        ]
+        .into_iter()
+        .flatten()
+        .collect()
+    } else {
+        Vec::new()
+    };
+
+    let (about, about_long) = if is_root && !root_declares_about {
         (
             cmd.help.as_deref().or(run.about),
             cmd.help_long.as_deref().or(run.about_long),
@@ -295,6 +316,7 @@ fn emit_command(out: &mut String, cmd: &SpecCommand, ty: &Type, is_root: bool, r
     let mut usage_opts: Vec<String> = Vec::new();
     if is_root {
         usage_opts.push(format!("bin = {bin:?}"));
+        usage_opts.extend(declared_about.iter().cloned());
     }
     for (present, declaration, what) in [
         (

--- a/xtask/src/shadow.rs
+++ b/xtask/src/shadow.rs
@@ -353,7 +353,13 @@ fn emit_command(out: &mut String, cmd: &SpecCommand, ty: &Type, is_root: bool, r
         }
         (true, Dialect::Clap) => {
             out.push_str("#[derive(Parser)]\n");
-            out.push_str(&format!("#[command(name = {bin:?})]\n"));
+            // The descriptions go here too when a comment cannot carry them. clap takes an
+            // independent `about` and `long_about`, and skipping the comment without writing
+            // them left the clap shadow not describing the program at all — a fixture for
+            // comparing two frameworks cannot have one of them missing the CLI's own about.
+            let mut opts = vec![format!("name = {bin:?}")];
+            opts.extend(declared_about.iter().cloned());
+            out.push_str(&format!("#[command({})]\n", opts.join(", ")));
         }
         (false, Dialect::Usage) => {
             out.push_str("#[derive(Args)]\n");


### PR DESCRIPTION
Found while starting on `--help`, which reads the long forms the short one does not.

A variant's short description was hiding the struct's long one. `meta_overrides` chose both
from the variant when the variant had *either*, so the shape every generated CLI has — the enum
says what a command is for in a line, the struct's own comment carries the detail — lost the
detail entirely. Each falls back on its own now.

A doc comment's lines were trimmed one by one, which flattened every indented block in a CLI's
help. An indented block is how a spec shows a command to type, and mise's help is full of them.
Only the single space `///` conventionally adds is stripped now, and trailing space.

A program could not describe itself twice over. A comment's long form always contains its short
one, because the short form *is* the comment's first paragraph — where a spec keeps `about` and
`about_long` independent, and mise's are entirely different sentences. `#[usage(about = …,
long_about = …)]` declares them, and the generator uses it when a comment cannot say both.

The `--help` layout these were found by is written but not yet at parity — 123 of 211 pages
still differ, each remaining cause another metadata path where the shadow's description is not
the spec's. It is held back rather than shipped wrong, and the plan says so.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cold-path help/spec metadata and test fixtures only; parsing and `-h` parity (211/211) are unchanged.
> 
> **Overview**
> Fixes three **metadata round-trip gaps** in `usage-derive` that showed up while chasing `--help` parity with usage-lib (still held back at 123/211 pages).
> 
> **Subcommand help:** `meta_overrides` no longer drops a struct’s long description when the enum variant only supplies a short one—short and long now fall back independently, matching the usual “variant line + struct detail” layout.
> 
> **Doc comments:** `doc_comment` stops trimming each `///` line, so indented examples in long help keep their spacing.
> 
> **Root `about` / `about_long`:** Adds `#[usage(about = …, long_about = …)]` when the two strings are not the first-paragraph relationship doc comments force. Shadow generation (`xtask`) emits the same attributes for usage and clap fixtures; mise shadows pick up explicit about text.
> 
> Conformance tests cover the split-description fixture; **PLAN.md** records the fixes and that full `--help` layout is not shipped yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c6fc19c6a782f248947ef8f6223ddbc93cddff2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## How these were found

By starting on `--help`. The wider layout reads the *long* form of every description, which the
short form never touches — so three more places where a spec says something the derive could not
keep surfaced at once.

| | what happened |
|---|---|
| a variant's short description hid the struct's long one | `meta_overrides` chose *both* from the variant when it had either. That is the shape every generated CLI has — the enum names the command in a line, the struct's comment carries the detail — so the detail was lost for all of them |
| a doc comment's lines were trimmed one by one | which flattened every indented block in help. An indented block is how a spec shows a command to type, and mise's help is full of them |
| a program could not describe itself twice over | a comment's long form always *contains* its short one, since the short form is the comment's first paragraph. A spec keeps `about` and `about_long` independent, and mise's are entirely different sentences |

## What is not here

The `--help` renderer itself. It is written, and it is at **123 of 211 pages differing** — each
remaining cause another metadata path where the shadow's description is not the spec's. Shipping
a public `long_help` that is wrong on more than half of a real CLI's pages would be worse than
not shipping it, so it is held back and the plan records the count rather than the intention.

The three fixes above stand on their own: they are round-trip fidelity, which docs, manpages,
completions and the SDK generators all read.

## Verification

- Three tests on a fixture shaped like a generated CLI — short description on the variant, long
  on the struct, an indented example inside it, and a program whose two descriptions differ.
- All three mutation-checked: restoring each old behaviour fails exactly its own test.
- `-h` parity is unaffected and still 211 of 211, which is the guard against these fixes
  changing the short form.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*
