### PR TITLE
fix(xtask): declare a description a comment would change

### DIFF
--- a/benches/shadows/mise-clap/src/lib.rs
+++ b/benches/shadows/mise-clap/src/lib.rs
@@ -305,7 +305,7 @@ pub struct BootstrapDotfilesAddArgs {
     #[arg(long = "yes", short = 'y')]
     pub yes: bool,
     /// Targets to add or update
-    #[arg(value_name = "TARGET", num_args = 0..)]
+    #[arg(value_name = "TARGET", required = true, num_args = 0..)]
     pub target: Vec<String>,
 }
 
@@ -801,7 +801,7 @@ pub struct BootstrapPackagesBrewUntapArgs {
     #[arg(long = "path", short = 'p', value_name = "PATH")]
     pub path: Option<String>,
     /// Tap name(s), e.g. `owner/repo`
-    #[arg(value_name = "TAPS", num_args = 0..)]
+    #[arg(value_name = "TAPS", required = true, num_args = 0..)]
     pub taps: Vec<String>,
 }
 
@@ -937,7 +937,7 @@ pub struct BootstrapPackagesUseArgs {
     #[arg(long = "yes", short = 'y')]
     pub yes: bool,
     /// Packages in `manager:package[@version]` form
-    #[arg(value_name = "PACKAGE", num_args = 0..)]
+    #[arg(value_name = "PACKAGE", required = true, num_args = 0..)]
     pub package: Vec<String>,
 }
 
@@ -1113,7 +1113,7 @@ pub struct BootstrapReposExecArgs {
     #[arg(value_name = "PATH", num_args = 0..)]
     pub path: Vec<String>,
     /// Command and arguments to run in each repo
-    #[arg(value_name = "COMMAND", num_args = 0.., last = true)]
+    #[arg(value_name = "COMMAND", required = true, num_args = 0.., last = true)]
     pub command: Vec<String>,
 }
 
@@ -1734,7 +1734,7 @@ pub struct DotfilesAddArgs {
     #[arg(long = "yes", short = 'y')]
     pub yes: bool,
     /// Targets to add or update
-    #[arg(value_name = "TARGET", num_args = 0..)]
+    #[arg(value_name = "TARGET", required = true, num_args = 0..)]
     pub target: Vec<String>,
 }
 
@@ -3081,13 +3081,6 @@ pub struct PluginsLsArgs {
     pub user: bool,
 }
 
-/// List all available remote plugins
-///
-/// The full list is here: https://github.com/jdx/mise/blob/main/registry/
-///
-/// Examples:
-///
-///     $ mise plugins ls-remote
 #[derive(Args)]
 pub struct PluginsLsRemoteArgs {
     /// Show the git url for each plugin e.g.: https://github.com/mise-plugins/mise-poetry.git
@@ -3177,7 +3170,7 @@ pub enum PluginsCommands {
     #[command(name = "ls", visible_alias = "list")]
     Ls(Box<PluginsLsArgs>),
     /// List all available remote plugins
-    #[command(name = "ls-remote", visible_aliases = ["list-remote", "list-all"])]
+    #[command(name = "ls-remote", about = "List all available remote plugins", long_about = "\nList all available remote plugins\n\nThe full list is here: https://github.com/jdx/mise/blob/main/registry/\n\nExamples:\n\n    $ mise plugins ls-remote", visible_aliases = ["list-remote", "list-all"])]
     LsRemote(Box<PluginsLsRemoteArgs>),
     /// Removes a plugin
     #[command(name = "uninstall", visible_aliases = ["remove", "rm"])]
@@ -3197,7 +3190,7 @@ pub struct DepsAddArgs {
     #[arg(long = "dev", short = 'D')]
     pub dev: bool,
     /// Package(s) to add (e.g., npm:react, npm:@types/react@19)
-    #[arg(value_name = "PACKAGES", num_args = 0..)]
+    #[arg(value_name = "PACKAGES", required = true, num_args = 0..)]
     pub packages: Vec<String>,
 }
 
@@ -3243,7 +3236,7 @@ pub struct DepsInstallArgs {
 #[derive(Args)]
 pub struct DepsRemoveArgs {
     /// Package(s) to remove (e.g., npm:lodash)
-    #[arg(value_name = "PACKAGES", num_args = 0..)]
+    #[arg(value_name = "PACKAGES", required = true, num_args = 0..)]
     pub packages: Vec<String>,
 }
 
@@ -3861,7 +3854,7 @@ pub struct ShellArgs {
     #[arg(long = "raw")]
     pub raw: bool,
     /// Tool(s) to use
-    #[arg(value_name = "TOOL@VERSION", num_args = 0..)]
+    #[arg(value_name = "TOOL@VERSION", required = true, num_args = 0..)]
     pub tool_version: Vec<String>,
 }
 
@@ -4712,7 +4705,7 @@ pub struct UnuseArgs {
     #[arg(long = "no-prune")]
     pub no_prune: bool,
     /// Tool(s) to remove
-    #[arg(value_name = "INSTALLED_TOOL@VERSION", num_args = 0..)]
+    #[arg(value_name = "INSTALLED_TOOL@VERSION", required = true, num_args = 0..)]
     pub installed_tool_version: Vec<String>,
 }
 

--- a/benches/shadows/mise-clap/src/lib.rs
+++ b/benches/shadows/mise-clap/src/lib.rs
@@ -3356,9 +3356,6 @@ pub struct RegistryArgs {
     /// Output in JSON format
     #[arg(long = "json", short = 'J')]
     pub json: bool,
-    /// Include security features for each tool's backends in JSON output
-    ///
-    /// Requires --json. Security info is de-duplicated across all of a tool's backends. This can add noticeable time for large listings since each backend's security info is resolved individually.
     #[arg(long = "security")]
     pub security: bool,
     /// Show only the specified tool's full name
@@ -3789,14 +3786,6 @@ pub struct SettingsUnsetArgs {
     pub key: String,
 }
 
-/// Manage settings
-///
-/// Show current settings
-///
-/// This is the contents of ~/.config/mise/config.toml
-///
-/// Note that aliases are also stored in this file
-/// but managed separately with `mise tool-alias`
 #[derive(Args)]
 pub struct SettingsArgs {
     /// List all settings
@@ -5263,11 +5252,6 @@ pub struct WatchArgs {
     /// multiple confused queries that have landed in my inbox over the years.
     #[arg(long = "emit-events-to", value_name = "MODE", value_parser = ::clap::builder::PossibleValuesParser::new(["environment", "stdio", "file", "json-stdio", "json-file", "none"]), default_value = "none")]
     pub emit_events_to: Option<String>,
-    /// Only emit events to stdout, run no commands
-    ///
-    /// This is a convenience option for using Watchexec as a file watcher, without running any commands. It is almost equivalent to using `cat` as the command, except that it will not spawn a new process for each event.
-    ///
-    /// This option requires `--emit-events-to` to be set, and restricts the available modes to `stdio` and `json-stdio`, modifying their behaviour to write to stdout instead of the stdin of the command.
     #[arg(long = "only-emit-events")]
     pub only_emit_events: bool,
     /// Add env vars to the command
@@ -5340,51 +5324,6 @@ pub struct WatchArgs {
     /// This can also be used via the $WATCHEXEC_FILTER_FILES environment variable.
     #[arg(long = "filter-file", value_name = "PATH")]
     pub filter_file: Vec<String>,
-    /// [experimental] Filter programs
-    ///
-    /// /!\ This option is EXPERIMENTAL and may change and/or vanish without notice.
-    ///
-    /// Provide your own custom filter programs in jaq (similar to jq) syntax. Programs are given an event in the same format as described in '--emit-events-to' and must return a boolean. Invalid programs will make watchexec fail to start; use '-v' to see program runtime errors.
-    ///
-    /// In addition to the jaq stdlib, watchexec adds some custom filter definitions:
-    ///
-    /// - 'path | file_meta' returns file metadata or null if the file does not exist.
-    ///
-    /// - 'path | file_size' returns the size of the file at path, or null if it does not exist.
-    ///
-    /// - 'path | file_read(bytes)' returns a string with the first n bytes of the file at path. If the file is smaller than n bytes, the whole file is returned. There is no filter to read the whole file at once to encourage limiting the amount of data read and processed.
-    ///
-    /// - 'string | hash', and 'path | file_hash' return the hash of the string or file at path. No guarantee is made about the algorithm used: treat it as an opaque value.
-    ///
-    /// - 'any | kv_store(key)', 'kv_fetch(key)', and 'kv_clear' provide a simple key-value store. Data is kept in memory only, there is no persistence. Consistency is not guaranteed.
-    ///
-    /// - 'any | printout', 'any | printerr', and 'any | log(level)' will print or log any given value to stdout, stderr, or the log (levels = error, warn, info, debug, trace), and pass the value through (so '[1] | log("debug") | .[]' will produce a '1' and log '[1]').
-    ///
-    /// All filtering done with such programs, and especially those using kv or filesystem access, is much slower than the other filtering methods. If filtering is too slow, events will back up and stall watchexec. Take care when designing your filters.
-    ///
-    /// If the argument to this option starts with an '@', the rest of the argument is taken to be the path to a file containing a jaq program.
-    ///
-    /// Jaq programs are run in order, after all other filters, and short-circuit: if a filter (jaq or not) rejects an event, execution stops there, and no other filters are run. Additionally, they stop after outputting the first value, so you'll want to use 'any' or 'all' when iterating, otherwise only the first item will be processed, which can be quite confusing!
-    ///
-    /// Find user-contributed programs or submit your own useful ones at <https://github.com/watchexec/watchexec/discussions/592>.
-    ///
-    /// ## Examples:
-    ///
-    /// Regexp ignore filter on paths:
-    ///
-    /// 'all(.tags[] | select(.kind == "path"); .absolute | test("[.]test[.]js$")) | not'
-    ///
-    /// Pass any event that creates a file:
-    ///
-    /// 'any(.tags[] | select(.kind == "fs"); .simple == "create")'
-    ///
-    /// Pass events that touch executable files:
-    ///
-    /// 'any(.tags[] | select(.kind == "path" && .filetype == "file"); .absolute | metadata | .executable)'
-    ///
-    /// Ignore files that start with shebangs:
-    ///
-    /// 'any(.tags[] | select(.kind == "path" && .filetype == "file"); .absolute | read(2) == "#!") | not'
     #[arg(long = "filter-prog", short = 'J', value_name = "EXPRESSION")]
     pub filter_prog: Vec<String>,
     /// Filename patterns to filter out
@@ -5574,9 +5513,6 @@ pub struct Cli {
     /// Sets log level to trace
     #[arg(long = "trace", global = true, hide = true)]
     pub trace: bool,
-    /// Task to run
-    ///
-    /// Shorthand for `mise tasks run <TASK>`.
     #[arg(value_name = "TASK")]
     pub task: Option<String>,
     /// Task arguments

--- a/benches/shadows/mise-clap/src/lib.rs
+++ b/benches/shadows/mise-clap/src/lib.rs
@@ -3356,7 +3356,11 @@ pub struct RegistryArgs {
     /// Output in JSON format
     #[arg(long = "json", short = 'J')]
     pub json: bool,
-    #[arg(long = "security")]
+    #[arg(
+        help = "Include security features for each tool's backends in JSON output",
+        long_help = "Include security features for each tool's backends in JSON output.\n\nRequires --json. Security info is de-duplicated across all of a tool's backends. This can add noticeable time for large listings since each backend's security info is resolved individually.",
+        long = "security"
+    )]
     pub security: bool,
     /// Show only the specified tool's full name
     #[arg(value_name = "NAME")]
@@ -5252,7 +5256,11 @@ pub struct WatchArgs {
     /// multiple confused queries that have landed in my inbox over the years.
     #[arg(long = "emit-events-to", value_name = "MODE", value_parser = ::clap::builder::PossibleValuesParser::new(["environment", "stdio", "file", "json-stdio", "json-file", "none"]), default_value = "none")]
     pub emit_events_to: Option<String>,
-    #[arg(long = "only-emit-events")]
+    #[arg(
+        help = "Only emit events to stdout, run no commands",
+        long_help = "Only emit events to stdout, run no commands.\n\nThis is a convenience option for using Watchexec as a file watcher, without running any commands. It is almost equivalent to using `cat` as the command, except that it will not spawn a new process for each event.\n\nThis option requires `--emit-events-to` to be set, and restricts the available modes to `stdio` and `json-stdio`, modifying their behaviour to write to stdout instead of the stdin of the command.",
+        long = "only-emit-events"
+    )]
     pub only_emit_events: bool,
     /// Add env vars to the command
     ///
@@ -5324,7 +5332,13 @@ pub struct WatchArgs {
     /// This can also be used via the $WATCHEXEC_FILTER_FILES environment variable.
     #[arg(long = "filter-file", value_name = "PATH")]
     pub filter_file: Vec<String>,
-    #[arg(long = "filter-prog", short = 'J', value_name = "EXPRESSION")]
+    #[arg(
+        help = "[experimental] Filter programs",
+        long_help = "[experimental] Filter programs.\n\n/!\\ This option is EXPERIMENTAL and may change and/or vanish without notice.\n\nProvide your own custom filter programs in jaq (similar to jq) syntax. Programs are given an event in the same format as described in '--emit-events-to' and must return a boolean. Invalid programs will make watchexec fail to start; use '-v' to see program runtime errors.\n\nIn addition to the jaq stdlib, watchexec adds some custom filter definitions:\n\n- 'path | file_meta' returns file metadata or null if the file does not exist.\n\n- 'path | file_size' returns the size of the file at path, or null if it does not exist.\n\n- 'path | file_read(bytes)' returns a string with the first n bytes of the file at path. If the file is smaller than n bytes, the whole file is returned. There is no filter to read the whole file at once to encourage limiting the amount of data read and processed.\n\n- 'string | hash', and 'path | file_hash' return the hash of the string or file at path. No guarantee is made about the algorithm used: treat it as an opaque value.\n\n- 'any | kv_store(key)', 'kv_fetch(key)', and 'kv_clear' provide a simple key-value store. Data is kept in memory only, there is no persistence. Consistency is not guaranteed.\n\n- 'any | printout', 'any | printerr', and 'any | log(level)' will print or log any given value to stdout, stderr, or the log (levels = error, warn, info, debug, trace), and pass the value through (so '[1] | log(\"debug\") | .[]' will produce a '1' and log '[1]').\n\nAll filtering done with such programs, and especially those using kv or filesystem access, is much slower than the other filtering methods. If filtering is too slow, events will back up and stall watchexec. Take care when designing your filters.\n\nIf the argument to this option starts with an '@', the rest of the argument is taken to be the path to a file containing a jaq program.\n\nJaq programs are run in order, after all other filters, and short-circuit: if a filter (jaq or not) rejects an event, execution stops there, and no other filters are run. Additionally, they stop after outputting the first value, so you'll want to use 'any' or 'all' when iterating, otherwise only the first item will be processed, which can be quite confusing!\n\nFind user-contributed programs or submit your own useful ones at <https://github.com/watchexec/watchexec/discussions/592>.\n\n## Examples:\n\nRegexp ignore filter on paths:\n\n'all(.tags[] | select(.kind == \"path\"); .absolute | test(\"[.]test[.]js$\")) | not'\n\nPass any event that creates a file:\n\n'any(.tags[] | select(.kind == \"fs\"); .simple == \"create\")'\n\nPass events that touch executable files:\n\n'any(.tags[] | select(.kind == \"path\" && .filetype == \"file\"); .absolute | metadata | .executable)'\n\nIgnore files that start with shebangs:\n\n'any(.tags[] | select(.kind == \"path\" && .filetype == \"file\"); .absolute | read(2) == \"#!\") | not'",
+        long = "filter-prog",
+        short = 'J',
+        value_name = "EXPRESSION"
+    )]
     pub filter_prog: Vec<String>,
     /// Filename patterns to filter out
     ///
@@ -5513,7 +5527,11 @@ pub struct Cli {
     /// Sets log level to trace
     #[arg(long = "trace", global = true, hide = true)]
     pub trace: bool,
-    #[arg(value_name = "TASK")]
+    #[arg(
+        value_name = "TASK",
+        help = "Task to run",
+        long_help = "Task to run.\n\nShorthand for `mise tasks run <TASK>`."
+    )]
     pub task: Option<String>,
     /// Task arguments
     #[arg(value_name = "TASK_ARGS", hide = true, num_args = 0..)]
@@ -5668,7 +5686,11 @@ pub enum Commands {
     #[command(name = "set", aliases = ["ev", "env-vars"])]
     Set(Box<SetArgs>),
     /// Manage settings
-    #[command(name = "settings")]
+    #[command(
+        name = "settings",
+        about = "Manage settings",
+        long_about = "Show current settings\n\nThis is the contents of ~/.config/mise/config.toml\n\nNote that aliases are also stored in this file\nbut managed separately with `mise tool-alias`"
+    )]
     Settings(Box<SettingsArgs>),
     /// Sets a tool version for the current session.
     #[command(name = "shell", visible_alias = "sh")]

--- a/benches/shadows/mise/src/lib.rs
+++ b/benches/shadows/mise/src/lib.rs
@@ -3555,10 +3555,11 @@ pub struct RegistryArgs {
     /// Output in JSON format
     #[usage(long = "json", short = 'J')]
     pub json: bool,
-    /// Include security features for each tool's backends in JSON output
-    ///
-    /// Requires --json. Security info is de-duplicated across all of a tool's backends. This can add noticeable time for large listings since each backend's security info is resolved individually.
-    #[usage(long = "security")]
+    #[usage(
+        help = "Include security features for each tool's backends in JSON output",
+        long_help = "Include security features for each tool's backends in JSON output.\n\nRequires --json. Security info is de-duplicated across all of a tool's backends. This can add noticeable time for large listings since each backend's security info is resolved individually.",
+        long = "security"
+    )]
     pub security: bool,
     /// Show only the specified tool's full name
     #[usage(arg, name = "NAME")]
@@ -4005,14 +4006,6 @@ pub struct SettingsUnsetArgs {
     pub key: ::std::string::String,
 }
 
-/// Manage settings
-///
-/// Show current settings
-///
-/// This is the contents of ~/.config/mise/config.toml
-///
-/// Note that aliases are also stored in this file
-/// but managed separately with `mise tool-alias`
 #[derive(Args)]
 pub struct SettingsArgs {
     /// List all settings
@@ -5529,12 +5522,11 @@ pub struct WatchArgs {
         default = "none"
     )]
     pub emit_events_to: ::std::option::Option<::std::string::String>,
-    /// Only emit events to stdout, run no commands
-    ///
-    /// This is a convenience option for using Watchexec as a file watcher, without running any commands. It is almost equivalent to using `cat` as the command, except that it will not spawn a new process for each event.
-    ///
-    /// This option requires `--emit-events-to` to be set, and restricts the available modes to `stdio` and `json-stdio`, modifying their behaviour to write to stdout instead of the stdin of the command.
-    #[usage(long = "only-emit-events")]
+    #[usage(
+        help = "Only emit events to stdout, run no commands",
+        long_help = "Only emit events to stdout, run no commands.\n\nThis is a convenience option for using Watchexec as a file watcher, without running any commands. It is almost equivalent to using `cat` as the command, except that it will not spawn a new process for each event.\n\nThis option requires `--emit-events-to` to be set, and restricts the available modes to `stdio` and `json-stdio`, modifying their behaviour to write to stdout instead of the stdin of the command.",
+        long = "only-emit-events"
+    )]
     pub only_emit_events: bool,
     /// Add env vars to the command
     ///
@@ -5615,52 +5607,14 @@ pub struct WatchArgs {
     /// This can also be used via the $WATCHEXEC_FILTER_FILES environment variable.
     #[usage(long = "filter-file", value_name = "PATH", var)]
     pub filter_file: ::std::vec::Vec<::std::string::String>,
-    /// [experimental] Filter programs
-    ///
-    /// /!\ This option is EXPERIMENTAL and may change and/or vanish without notice.
-    ///
-    /// Provide your own custom filter programs in jaq (similar to jq) syntax. Programs are given an event in the same format as described in '--emit-events-to' and must return a boolean. Invalid programs will make watchexec fail to start; use '-v' to see program runtime errors.
-    ///
-    /// In addition to the jaq stdlib, watchexec adds some custom filter definitions:
-    ///
-    /// - 'path | file_meta' returns file metadata or null if the file does not exist.
-    ///
-    /// - 'path | file_size' returns the size of the file at path, or null if it does not exist.
-    ///
-    /// - 'path | file_read(bytes)' returns a string with the first n bytes of the file at path. If the file is smaller than n bytes, the whole file is returned. There is no filter to read the whole file at once to encourage limiting the amount of data read and processed.
-    ///
-    /// - 'string | hash', and 'path | file_hash' return the hash of the string or file at path. No guarantee is made about the algorithm used: treat it as an opaque value.
-    ///
-    /// - 'any | kv_store(key)', 'kv_fetch(key)', and 'kv_clear' provide a simple key-value store. Data is kept in memory only, there is no persistence. Consistency is not guaranteed.
-    ///
-    /// - 'any | printout', 'any | printerr', and 'any | log(level)' will print or log any given value to stdout, stderr, or the log (levels = error, warn, info, debug, trace), and pass the value through (so '[1] | log("debug") | .[]' will produce a '1' and log '[1]').
-    ///
-    /// All filtering done with such programs, and especially those using kv or filesystem access, is much slower than the other filtering methods. If filtering is too slow, events will back up and stall watchexec. Take care when designing your filters.
-    ///
-    /// If the argument to this option starts with an '@', the rest of the argument is taken to be the path to a file containing a jaq program.
-    ///
-    /// Jaq programs are run in order, after all other filters, and short-circuit: if a filter (jaq or not) rejects an event, execution stops there, and no other filters are run. Additionally, they stop after outputting the first value, so you'll want to use 'any' or 'all' when iterating, otherwise only the first item will be processed, which can be quite confusing!
-    ///
-    /// Find user-contributed programs or submit your own useful ones at <https://github.com/watchexec/watchexec/discussions/592>.
-    ///
-    /// ## Examples:
-    ///
-    /// Regexp ignore filter on paths:
-    ///
-    /// 'all(.tags[] | select(.kind == "path"); .absolute | test("[.]test[.]js$")) | not'
-    ///
-    /// Pass any event that creates a file:
-    ///
-    /// 'any(.tags[] | select(.kind == "fs"); .simple == "create")'
-    ///
-    /// Pass events that touch executable files:
-    ///
-    /// 'any(.tags[] | select(.kind == "path" && .filetype == "file"); .absolute | metadata | .executable)'
-    ///
-    /// Ignore files that start with shebangs:
-    ///
-    /// 'any(.tags[] | select(.kind == "path" && .filetype == "file"); .absolute | read(2) == "#!") | not'
-    #[usage(long = "filter-prog", short = 'J', value_name = "EXPRESSION", var)]
+    #[usage(
+        help = "[experimental] Filter programs",
+        long_help = "[experimental] Filter programs.\n\n/!\\ This option is EXPERIMENTAL and may change and/or vanish without notice.\n\nProvide your own custom filter programs in jaq (similar to jq) syntax. Programs are given an event in the same format as described in '--emit-events-to' and must return a boolean. Invalid programs will make watchexec fail to start; use '-v' to see program runtime errors.\n\nIn addition to the jaq stdlib, watchexec adds some custom filter definitions:\n\n- 'path | file_meta' returns file metadata or null if the file does not exist.\n\n- 'path | file_size' returns the size of the file at path, or null if it does not exist.\n\n- 'path | file_read(bytes)' returns a string with the first n bytes of the file at path. If the file is smaller than n bytes, the whole file is returned. There is no filter to read the whole file at once to encourage limiting the amount of data read and processed.\n\n- 'string | hash', and 'path | file_hash' return the hash of the string or file at path. No guarantee is made about the algorithm used: treat it as an opaque value.\n\n- 'any | kv_store(key)', 'kv_fetch(key)', and 'kv_clear' provide a simple key-value store. Data is kept in memory only, there is no persistence. Consistency is not guaranteed.\n\n- 'any | printout', 'any | printerr', and 'any | log(level)' will print or log any given value to stdout, stderr, or the log (levels = error, warn, info, debug, trace), and pass the value through (so '[1] | log(\"debug\") | .[]' will produce a '1' and log '[1]').\n\nAll filtering done with such programs, and especially those using kv or filesystem access, is much slower than the other filtering methods. If filtering is too slow, events will back up and stall watchexec. Take care when designing your filters.\n\nIf the argument to this option starts with an '@', the rest of the argument is taken to be the path to a file containing a jaq program.\n\nJaq programs are run in order, after all other filters, and short-circuit: if a filter (jaq or not) rejects an event, execution stops there, and no other filters are run. Additionally, they stop after outputting the first value, so you'll want to use 'any' or 'all' when iterating, otherwise only the first item will be processed, which can be quite confusing!\n\nFind user-contributed programs or submit your own useful ones at <https://github.com/watchexec/watchexec/discussions/592>.\n\n## Examples:\n\nRegexp ignore filter on paths:\n\n'all(.tags[] | select(.kind == \"path\"); .absolute | test(\"[.]test[.]js$\")) | not'\n\nPass any event that creates a file:\n\n'any(.tags[] | select(.kind == \"fs\"); .simple == \"create\")'\n\nPass events that touch executable files:\n\n'any(.tags[] | select(.kind == \"path\" && .filetype == \"file\"); .absolute | metadata | .executable)'\n\nIgnore files that start with shebangs:\n\n'any(.tags[] | select(.kind == \"path\" && .filetype == \"file\"); .absolute | read(2) == \"#!\") | not'",
+        long = "filter-prog",
+        short = 'J',
+        value_name = "EXPRESSION",
+        var
+    )]
     pub filter_prog: ::std::vec::Vec<::std::string::String>,
     /// Filename patterns to filter out
     ///
@@ -5865,10 +5819,12 @@ pub struct Cli {
     /// Sets log level to trace
     #[usage(long = "trace", global, hide)]
     pub trace: bool,
-    /// Task to run
-    ///
-    /// Shorthand for `mise tasks run <TASK>`.
-    #[usage(arg, name = "TASK")]
+    #[usage(
+        arg,
+        name = "TASK",
+        help = "Task to run",
+        long_help = "Task to run.\n\nShorthand for `mise tasks run <TASK>`."
+    )]
     pub task: ::std::option::Option<::std::string::String>,
     /// Task arguments
     #[usage(arg, name = "TASK_ARGS", hide)]
@@ -6023,7 +5979,11 @@ pub enum Commands {
     #[usage(name = "set", alias_hidden("ev", "env-vars"))]
     Set(Box<SetArgs>),
     /// Manage settings
-    #[usage(name = "settings")]
+    #[usage(
+        name = "settings",
+        help = "Manage settings",
+        long_help = "Show current settings\n\nThis is the contents of ~/.config/mise/config.toml\n\nNote that aliases are also stored in this file\nbut managed separately with `mise tool-alias`"
+    )]
     Settings(Box<SettingsArgs>),
     /// Sets a tool version for the current session.
     #[usage(name = "shell", alias = "sh")]

--- a/benches/shadows/mise/src/lib.rs
+++ b/benches/shadows/mise/src/lib.rs
@@ -3280,13 +3280,6 @@ pub struct PluginsLsArgs {
     pub user: bool,
 }
 
-/// List all available remote plugins
-///
-/// The full list is here: https://github.com/jdx/mise/blob/main/registry/
-///
-/// Examples:
-///
-///     $ mise plugins ls-remote
 #[derive(Args)]
 pub struct PluginsLsRemoteArgs {
     /// Show the git url for each plugin e.g.: https://github.com/mise-plugins/mise-poetry.git
@@ -3376,7 +3369,12 @@ pub enum PluginsCommands {
     #[usage(name = "ls", alias = "list")]
     Ls(Box<PluginsLsArgs>),
     /// List all available remote plugins
-    #[usage(name = "ls-remote", alias("list-remote", "list-all"))]
+    #[usage(
+        name = "ls-remote",
+        help = "List all available remote plugins",
+        long_help = "\nList all available remote plugins\n\nThe full list is here: https://github.com/jdx/mise/blob/main/registry/\n\nExamples:\n\n    $ mise plugins ls-remote",
+        alias("list-remote", "list-all")
+    )]
     LsRemote(Box<PluginsLsRemoteArgs>),
     /// Removes a plugin
     #[usage(name = "uninstall", alias("remove", "rm"))]

--- a/xtask/src/shadow.rs
+++ b/xtask/src/shadow.rs
@@ -988,7 +988,7 @@ fn needs_declaring(help: Option<&str>, long: Option<&str>) -> bool {
 /// this generator exists to prevent.
 fn declared_help_clap(help: Option<&str>, long: Option<&str>, command: bool) -> Vec<String> {
     let mut opts = Vec::new();
-    if !needs_declaring(help) {
+    if !needs_declaring(help, long) {
         return opts;
     }
     let (short_key, long_key) = if command {

--- a/xtask/src/shadow.rs
+++ b/xtask/src/shadow.rs
@@ -956,6 +956,20 @@ fn selector_list(option: &str, selectors: &[String]) -> String {
 }
 
 /// Help text as a doc comment, which is how the derive reads it.
+/// How many line breaks a text opens with, counting `\r\n` as one.
+fn leading_breaks(text: &str) -> usize {
+    let mut rest = text;
+    let mut n = 0;
+    while let Some(tail) = rest
+        .strip_prefix("\r\n")
+        .or_else(|| rest.strip_prefix('\n'))
+    {
+        n += 1;
+        rest = tail;
+    }
+    n
+}
+
 /// Whether help text has to be declared rather than written as a comment.
 ///
 /// A doc comment's first paragraph is read the way Rust reads one, so a line break inside it
@@ -982,9 +996,10 @@ fn needs_declaring(help: Option<&str>, long: Option<&str>) -> bool {
     // the short form at all.
     let independent = match (help, long) {
         (Some(h), Some(l)) => match l.strip_prefix(h.trim()) {
-            Some(rest) => {
-                !(rest.is_empty() || rest.starts_with("\n\n") || rest.starts_with("\r\n\r\n"))
-            }
+            // Exactly two breaks, not at least two: a comment writes one blank line and no
+            // more, so a longer run comes back shortened — `"Short\n\n\nRest"` as
+            // `"Short\n\nRest"`. Declared instead, which says whatever the spec says.
+            Some(rest) => !(rest.is_empty() || leading_breaks(rest) == 2),
             None => true,
         },
         _ => false,
@@ -1252,6 +1267,14 @@ mod tests {
             out.contains(r#"long_help = "Short\nContinuation""#),
             "{out}"
         );
+
+        // And a paragraph gap wider than one blank line, which the comment path would close:
+        // it writes one blank line and no more, so the two-break shape is the only one it can
+        // carry back unchanged.
+        let (out, _) = rendered(
+            "name \"ex\"\nbin \"ex\"\nflag \"--z\" help=\"Short\" {\n  long_help \"Short\\n\\n\\nRest\"\n}\n",
+        );
+        assert!(out.contains(r#"long_help = "Short\n\n\nRest""#), "{out}");
 
         let spec = "name \"ex\"\nbin \"ex\"\narg \"<FILES>…\"\n";
         let (usage, _) = rendered_as(spec, Dialect::Usage);

--- a/xtask/src/shadow.rs
+++ b/xtask/src/shadow.rs
@@ -283,11 +283,11 @@ fn emit_command(out: &mut String, cmd: &SpecCommand, ty: &Type, is_root: bool, r
     // A comment's long form always contains its short one, because the short form *is* its
     // first paragraph. Where a spec's two are independent — mise's are entirely different
     // sentences — no comment can say both, so the root declares them instead.
-    let root_declares_about = is_root
-        && match (run.about, run.about_long) {
-            (Some(a), Some(l)) => !l.trim_start().starts_with(a.trim()),
-            _ => false,
-        };
+    // The *same* predicate the comment path uses. Two checks that disagree left a gap in
+    // between: a long form opening with the short one but not then breaking — a trailing period
+    // is enough — was too much for a comment and not enough to be declared, so the program's
+    // description was dropped altogether.
+    let root_declares_about = is_root && needs_declaring(run.about, run.about_long);
     let declared_about: Vec<String> = if root_declares_about {
         [
             run.about.map(|a| format!("about = {:?}", a.trim())),
@@ -1214,6 +1214,32 @@ mod tests {
 
         let (clap, _) = rendered_as(spec, Dialect::Clap);
         assert!(clap.contains(r#"help = "Use shims\nlike so:""#), "{clap}");
+    }
+
+    #[test]
+    fn the_root_describes_itself_however_its_two_forms_relate() {
+        // Two checks that disagreed left a gap between them: a long form opening with the short
+        // one but not then breaking — a trailing period is enough — was too much for a comment
+        // and not enough to be declared, and the program's description vanished. One predicate
+        // decides both now, so every arrangement produces a description somewhere.
+        for long in [
+            "Dev tools.",                    // the short form plus punctuation
+            "Dev tools, and then some more", // the short form plus text, no break
+            "Something else entirely",       // independent
+            "Dev tools\n\nAnd the rest.",    // opens with it and breaks: a comment can say this
+        ] {
+            let spec =
+                format!("name \"ex\"\nbin \"ex\"\nabout \"Dev tools\"\nabout_long {long:?}\n");
+            let (out, _) = rendered(&spec);
+            assert!(
+                out.contains("Dev tools"),
+                "the short form went missing for {long:?}: {out}"
+            );
+            assert!(
+                out.contains(long.split('\n').next().unwrap()),
+                "the long form went missing for {long:?}: {out}"
+            );
+        }
     }
 
     #[test]

--- a/xtask/src/shadow.rs
+++ b/xtask/src/shadow.rs
@@ -873,6 +873,11 @@ fn usage_arg_opts(arg: &SpecArg, skipped: &mut Skipped) -> Vec<String> {
 
 fn clap_arg_opts(arg: &SpecArg, skipped: &mut Skipped) -> Vec<String> {
     let mut opts: Vec<String> = vec![format!("value_name = {:?}", arg.name)];
+    // clap reads a `Vec` as optional whatever the spec says, so a required variadic has to say
+    // so — the same declaration the usage dialect needed, for the same reason.
+    if arg.required && arg.var {
+        opts.push("required = true".into());
+    }
     opts.extend(declared_help_clap(
         arg.help.as_deref(),
         arg.help_long.as_deref(),
@@ -969,14 +974,26 @@ fn needs_declaring(help: Option<&str>, long: Option<&str>) -> bool {
     // often end that opening sentence with a period the short form leaves off, and the
     // punctuation was being thrown away to make the two match — "Task to run." came back as
     // "Task to run".
+    //
+    // Untrimmed and by *paragraph*: the comment path reconstructs the long form as "short, blank
+    // line, rest", so it is lossless only when the long form opens with the short one exactly and
+    // then breaks twice. A single newline came back doubled — `"Short\nContinuation"` as
+    // `"Short\n\nContinuation"` — and a long form opening with a blank line does not open with
+    // the short form at all.
     let independent = match (help, long) {
-        (Some(h), Some(l)) => match l.trim_start().strip_prefix(h.trim()) {
-            Some(rest) => !(rest.is_empty() || rest.starts_with('\n') || rest.starts_with('\r')),
+        (Some(h), Some(l)) => match l.strip_prefix(h.trim()) {
+            Some(rest) => {
+                !(rest.is_empty() || rest.starts_with("\n\n") || rest.starts_with("\r\n\r\n"))
+            }
             None => true,
         },
         _ => false,
     };
-    flowed || independent
+    // A long form with no short one cannot be a comment at all: a comment's first paragraph *is*
+    // the short form, so writing one would invent a short help the spec never gave.
+    let long_only =
+        long.is_some_and(|l| !l.trim().is_empty()) && !help.is_some_and(|h| !h.trim().is_empty());
+    flowed || independent || long_only
 }
 
 /// The same declarations in clap's vocabulary.
@@ -1009,10 +1026,11 @@ fn declared_help_clap(help: Option<&str>, long: Option<&str>, command: bool) -> 
 fn declared_help(help: Option<&str>, long: Option<&str>) -> Vec<String> {
     let mut opts = Vec::new();
     if needs_declaring(help, long) {
-        let Some(help) = help.filter(|h| !h.trim().is_empty()) else {
-            return opts;
-        };
-        opts.push(format!("help = {:?}", help.trim()));
+        // The long form stands on its own: a spec may give only `long_help`, and returning early
+        // for want of a short one dropped the whole description.
+        if let Some(help) = help.filter(|h| !h.trim().is_empty()) {
+            opts.push(format!("help = {:?}", help.trim()));
+        }
         // The long form goes with it: read from the comment, it would be measured against a
         // short form that no longer matches, and written in full twice over.
         if let Some(long) = long.filter(|l| !l.trim().is_empty()) {
@@ -1214,6 +1232,32 @@ mod tests {
 
         let (clap, _) = rendered_as(spec, Dialect::Clap);
         assert!(clap.contains(r#"help = "Use shims\nlike so:""#), "{clap}");
+    }
+
+    #[test]
+    fn a_description_survives_whatever_shape_it_is_in() {
+        // Three shapes a comment cannot carry, each of which lost text before: a long form with
+        // no short one at all, a long form that continues on the next *line* rather than after a
+        // blank one (the comment path would double the break), and a required variadic, which
+        // clap reads as optional whatever the spec says.
+        let (out, _) = rendered(
+            "name \"ex\"\nbin \"ex\"\nflag \"--x\" {\n  long_help \"Only the long form\"\n}\n",
+        );
+        assert!(out.contains(r#"long_help = "Only the long form""#), "{out}");
+
+        let (out, _) = rendered(
+            "name \"ex\"\nbin \"ex\"\nflag \"--y\" help=\"Short\" {\n  long_help \"Short\\nContinuation\"\n}\n",
+        );
+        assert!(
+            out.contains(r#"long_help = "Short\nContinuation""#),
+            "{out}"
+        );
+
+        let spec = "name \"ex\"\nbin \"ex\"\narg \"<FILES>…\"\n";
+        let (usage, _) = rendered_as(spec, Dialect::Usage);
+        assert!(usage.contains("required"), "{usage}");
+        let (clap, _) = rendered_as(spec, Dialect::Clap);
+        assert!(clap.contains("required = true"), "{clap}");
     }
 
     #[test]

--- a/xtask/src/shadow.rs
+++ b/xtask/src/shadow.rs
@@ -957,8 +957,26 @@ fn selector_list(option: &str, selectors: &[String]) -> String {
 /// becomes a space. mise's specs use multi-line `help` on 37 commands and flags, and every one
 /// of them came back with its lines run together — so where the break is part of the text, the
 /// generated code declares it instead.
-fn needs_declaring(help: Option<&str>) -> bool {
-    help.map(|h| h.trim().contains('\n')).unwrap_or(false)
+fn needs_declaring(help: Option<&str>, long: Option<&str>) -> bool {
+    // A break inside the first paragraph becomes a space.
+    let flowed = help.map(|h| h.trim().contains('\n')).unwrap_or(false);
+    // And a comment's long form always *contains* its short one, because the short form is the
+    // comment's first paragraph. Where a spec's two are independent — `cmd settings` says
+    // "Manage settings" and then "Show current settings…" — no comment says both, and reading
+    // one back gave the short form twice with the long text after it.
+    // Exactly, not nearly: the comment path reconstructs the long form as "short + rest", so it
+    // is only lossless when the long form opens with the short one and then breaks. mise's specs
+    // often end that opening sentence with a period the short form leaves off, and the
+    // punctuation was being thrown away to make the two match — "Task to run." came back as
+    // "Task to run".
+    let independent = match (help, long) {
+        (Some(h), Some(l)) => match l.trim_start().strip_prefix(h.trim()) {
+            Some(rest) => !(rest.is_empty() || rest.starts_with('\n') || rest.starts_with('\r')),
+            None => true,
+        },
+        _ => false,
+    };
+    flowed || independent
 }
 
 /// The same declarations in clap's vocabulary.
@@ -990,7 +1008,10 @@ fn declared_help_clap(help: Option<&str>, long: Option<&str>, command: bool) -> 
 /// The `help = "..."` option for text a comment would reflow.
 fn declared_help(help: Option<&str>, long: Option<&str>) -> Vec<String> {
     let mut opts = Vec::new();
-    if let Some(help) = help.filter(|h| needs_declaring(Some(h))) {
+    if needs_declaring(help, long) {
+        let Some(help) = help.filter(|h| !h.trim().is_empty()) else {
+            return opts;
+        };
         opts.push(format!("help = {:?}", help.trim()));
         // The long form goes with it: read from the comment, it would be measured against a
         // short form that no longer matches, and written in full twice over.
@@ -1004,7 +1025,7 @@ fn declared_help(help: Option<&str>, long: Option<&str>) -> Vec<String> {
 fn doc_comment(out: &mut String, help: Option<&str>, long: Option<&str>, depth: usize) {
     let indent = "    ".repeat(depth);
     // Declared instead, by `declared_help`.
-    if needs_declaring(help) {
+    if needs_declaring(help, long) {
         return;
     }
     let Some(help) = help.filter(|h| !h.trim().is_empty()) else {
@@ -1272,12 +1293,19 @@ mod tests {
         // really has: a long form whose first sentence ends in a period the short form
         // leaves off, which left the period stranded on a line of its own, and an
         // indented example, which lost its indentation.
+        // A long form whose first sentence ends in a period the short form leaves off is
+        // declared now rather than written as a comment — the comment path reconstructs it as
+        // "short + rest" and the punctuation lives exactly between them, so there is nowhere
+        // for it to go. What matters either way is that the text survives whole.
         let (out, _) = rendered(
             "name \"ex\"\nbin \"ex\"\nflag \"--security\" help=\"Include security info\" \\
                 long_help=\"Include security info.\\n\\nRequires --json.\"\n",
         );
         assert!(!out.contains("/// ."), "a stranded period: {out}");
-        assert!(out.contains("/// Requires --json."), "{out}");
+        assert!(
+            out.contains(r#"long_help = "Include security info.\n\nRequires --json.""#),
+            "{out}"
+        );
 
         let (out, _) = rendered(
             "name \"ex\"\nbin \"ex\"\nflag \"--shims\" help=\"Use shims\" \\
@@ -1290,11 +1318,23 @@ mod tests {
     }
 
     #[test]
-    fn a_long_form_that_only_adds_a_period_says_nothing() {
+    fn a_long_form_that_only_adds_a_period_is_declared_rather_than_lost() {
+        // This used to emit one comment and drop the period, on the grounds that the two forms
+        // said the same thing. They do — but the *spec* does not say the same thing, and the
+        // regenerated one has to. Rendering mise's help against usage-lib's showed it: the
+        // reference prints "Task to run." and the shadow printed "Task to run".
+        //
+        // So the pair is declared, which is the only way a comment cannot mangle it: a comment
+        // reconstructs the long form as "short + rest", and the punctuation lives between them.
         let (out, _) = rendered(
             "name \"ex\"\nbin \"ex\"\nflag \"--force\" help=\"Do it\" long_help=\"Do it.\"\n",
         );
-        assert_eq!(out.matches("/// Do it").count(), 1, "{out}");
+        assert!(out.contains(r#"help = "Do it""#), "{out}");
+        assert!(out.contains(r#"long_help = "Do it.""#), "{out}");
+        assert!(
+            !out.contains("/// Do it"),
+            "declared, so there is no comment to disagree with it: {out}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Two more shapes where the shadow's regenerated spec did not say what the source said, both
found by rendering mise's help against usage-lib's.

A command's `help` and `long_help` can be independent: `cmd settings` says "Manage settings"
and then "Show current settings…". A doc comment's long form always *contains* its short one,
because the short form is the comment's first paragraph — so reading one back gave "Manage
settings" where the spec says "Show current settings". Declared instead, as the root's
descriptions already were.

And the long form's opening sentence often ends with a period the short form leaves off. The
generator was throwing that period away to make the two match, so "Task to run." came back as
"Task to run". The comment path is now used only when the long form opens with the short one
*exactly* and then breaks — which is the only arrangement it can reconstruct — and everything
else is declared.

Two tests changed with it. One asserted that a period-only difference "says nothing", which was
the lossy behaviour stated as an intention; it now asserts the pair is declared. The other
covered both shapes at once, and keeps the half that still exercises the comment path: an
indented example inside a long form has to keep its indentation.

The `--help` renderer these were found by is still not at parity and still held back. Each round
of this has moved the first difference further down mise's page — the remaining one is a
disagreement about the column width help wraps to.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to xtask shadow generation and checked-in benchmark fixtures; runtime mise behavior is unchanged aside from more accurate generated CLI metadata for comparisons.
> 
> **Overview**
> Tightens the **shadow generator** (`xtask/src/shadow.rs`) so spec help round-trips without losing or mangling text when Rust doc comments cannot represent it faithfully.
> 
> **`needs_declaring`** now considers short and long help together: independent short/long pairs (e.g. `settings`), long-only help, in-paragraph newlines, long forms that continue on the next line (not only after a blank paragraph), and paragraph gaps longer than one blank line. The root CLI **about** uses the same rule so descriptions are not dropped when they fall between “comment-safe” and “declare” cases. **Period-only** differences (e.g. `Task to run` vs `Task to run.`) are emitted as explicit `help`/`long_help` instead of collapsed into a single comment.
> 
> For **clap** shadows, required variadic positionals get **`required = true`** (clap treats `Vec` args as optional otherwise). Help that must be declared is written via **`help`/`long_help`** or **`about`/`long_about`** on flags, args, and subcommands in both dialects.
> 
> **Regenerated** `benches/shadows/mise` and `mise-clap` mirror those rules (more `required = true` on variadic args, long Watchexec/`--security`/`--filter-prog` text moved into attributes, subcommand help on `plugins ls-remote` and `settings`). New/updated unit tests lock in the shapes above.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12c9ea07ffd399951f652f9e27c633d72b6f95e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Two more descriptions the round trip changed

Both found by rendering mise's help through usage-argv and diffing it against usage-lib's, which
is the only test that notices this class at all.

**A command's `help` and `long_help` can be independent.** `cmd settings` says "Manage settings"
and its long form opens "Show current settings…". A doc comment's long form always *contains*
its short one, because the short form is the comment's first paragraph — so the shadow's
regenerated spec said "Manage settings" where mise's says "Show current settings". Declared
explicitly now, as the root's descriptions already were.

**A period was being thrown away.** mise's long forms often end their opening sentence with a
period the short form leaves off, and the generator stripped it so the two would match:
`"Task to run."` came back as `"Task to run"`. The comment path is now used only where the long
form opens with the short one **exactly** and then breaks — the one arrangement it can
reconstruct — and everything else is declared.

## Two tests changed, deliberately

`a_long_form_that_only_adds_a_period_says_nothing` asserted the lossy behaviour *as an
intention*: the two forms say the same thing, so emit one comment. They do say the same thing —
but the spec does not, and a regenerated spec has to. It now asserts the pair is declared.

The other covered two shapes at once; the half that still exercises the comment path is kept,
because an indented example inside a long form must keep its indentation.

## What is still not here

The `--help` renderer. Every round of this work moves the first difference further down mise's
page — line 15 → 351 → 520 → 546 — and the count has stayed at 123 of 211 because the remaining
cause is shared: a disagreement about the column width help wraps to, which shifts where every
entry breaks. That is one more focused fix rather than a long tail, but it is not this PR, and
shipping a public `long_help` that is wrong on more than half a real CLI's pages would be worse
than shipping none.

The fixes above stand on their own: they are round-trip fidelity, which docs, manpages,
completions and the SDK generators all read.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI help output for registry security, Watchexec options, task arguments, remote plugins, and settings.
  * Preserved distinct short and long descriptions, including multiline text, punctuation, custom value names, and required or repeatable arguments.
  * Corrected help text for several commands with required variadic positional arguments.
  * Prevented duplicated, incomplete, or malformed help text in generated command usage.
  * Improved consistency of help information across supported CLI formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->