### PR TITLE
feat(config): carry a setting's choices into the generated registry

### DIFF
--- a/config-build/Cargo.toml
+++ b/config-build/Cargo.toml
@@ -14,6 +14,10 @@ license = { workspace = true }
 # parser lives here and `usage-config` carries none of it.
 [dependencies]
 usage-lib = { workspace = true }
+# For the *rules*, not for the generated code: a default has to be held to the same choices, and read
+# by the same coercion, that the runtime will apply — and a second implementation of those rules here
+# is exactly the drift this crate removes elsewhere. It carries no dependencies of its own.
+usage-config = { workspace = true }
 
 # The generated code is compiled and run in the tests, which is the only way to know it is code
 # rather than plausible text.

--- a/config-build/src/emit.rs
+++ b/config-build/src/emit.rs
@@ -136,6 +136,10 @@ fn prop_meta(key: &str, prop: &SpecConfigProp, problems: &mut Vec<String>) -> St
         }
         let _ = writeln!(fields, "        bindings: &[{}],", pairs.join(", "));
     }
+    if !prop.choices.is_empty() {
+        let values: Vec<String> = prop.choices.iter().map(|c| value_const(&c.value)).collect();
+        let _ = writeln!(fields, "        choices: &[{}],", values.join(", "));
+    }
     if prop.hide {
         let _ = writeln!(fields, "        hide: true,");
     }
@@ -248,15 +252,203 @@ fn default_const(key: &str, prop: &SpecConfigProp, problems: &mut Vec<String>) -
             "`{key}` declares a default twice, as `default=` and as a `default` node: keep one"
         ));
     }
+    // Anything declared here that the declared type cannot read is a value nothing can ever hold: a
+    // `choice` nobody can pick — `choice 1` under `type="bool"`, which reads booleans and their
+    // spellings and not numbers — or a default that is seeded straight into the resolution and then
+    // read by nothing, since a seeded default passes through no coercion at all.
+    let scalar = scalar_ty(prop.value_type.as_ref());
+    let mut unreadable = Vec::new();
+    for (what, value) in prop
+        .default
+        .iter()
+        .chain(prop.default_list.iter())
+        .map(|value| ("defaults to", value))
+        .chain(prop.choices.iter().map(|c| ("has a choice", &c.value)))
+    {
+        if scalar.coerce(runtime_value(value)).is_err() {
+            unreadable.push(what);
+            problems.push(format!(
+                "`{key}` {what} `{}`, which is not {}",
+                display(value),
+                scalar.describe()
+            ));
+        }
+    }
+
+    // A declared default the declared choices do not allow. At run time it is seeded as the bottom
+    // layer and read by whatever holds it, so this is the only place it can be caught at all.
+    //
+    // Compared only when every choice is one a value could be: against a choice nothing can read,
+    // "not one of the values it allows" is a second message for the same mistake, and it blames the
+    // wrong end of it.
+    if !prop.choices.is_empty() && unreadable.is_empty() {
+        // Read the way the run time will read them — through the same `Ty::coerce` — because that is
+        // the only comparison that means anything: a spec writes `default="1"` beside `choice 1`, or
+        // `choice "yes"` under `type="bool"`, and neither is a mismatch once both are the declared
+        // type. Comparing spec literals refused those; comparing only same-shaped literals let
+        // `default="3"` beside `choice 1` through, and a *seeded* default never passes the check a
+        // supplied value does, so it would have become the effective value with nothing said.
+        let allowed = |value: &SpecConfigValue| {
+            let target = scalar.coerce(runtime_value(value));
+            prop.choices.iter().any(|choice| {
+                match (&target, scalar.coerce(runtime_value(&choice.value))) {
+                    (Ok(value), Ok(coerced)) if *value == coerced => true,
+                    // Coercion did not settle it: compare what the two are written as, exactly as the
+                    // run time does. `any` is where that matters — it coerces nothing, so a union's
+                    // `choice 1` and a `default="1"` stay an integer and a string, and stopping at
+                    // the arm above would refuse a spec the run time accepts.
+                    _ => display(value) == display(&choice.value),
+                }
+            })
+        };
+        // A list default under a type that declares no items is one value, not several: `any` takes
+        // a list perfectly well, and a scalar choice is not one however many items it has. Checked
+        // item by item, `default 1 2` beside `choice 1` and `choice 2` passed — and then the whole
+        // list is what a seeded default *is*, refused by its own choices and never checked again.
+        let declares_items = declares_items(prop.value_type.as_ref());
+        if !declares_items && !prop.default_list.is_empty() {
+            let written = prop
+                .default_list
+                .iter()
+                .map(display)
+                .collect::<Vec<_>>()
+                .join(",");
+            problems.push(format!(
+                "`{key}` defaults to `{written}`, which is not one of the values it allows: {}",
+                prop.choices
+                    .iter()
+                    .map(|c| display(&c.value))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+        let items = match declares_items {
+            true => prop.default_list.as_slice(),
+            false => &[],
+        };
+        for value in prop.default.iter().chain(items.iter()) {
+            if !allowed(value) {
+                problems.push(format!(
+                    "`{key}` defaults to `{}`, which is not one of the values it allows: {}",
+                    display(value),
+                    prop.choices
+                        .iter()
+                        .map(|c| display(&c.value))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+            }
+        }
+    }
     // A list default is a child node rather than a value, and either may be the one that is there.
     if !prop.default_list.is_empty() {
-        let items: Vec<String> = prop.default_list.iter().map(value_const).collect();
+        let items: Vec<String> = prop
+            .default_list
+            .iter()
+            .map(|value| coerced_const(scalar, value))
+            .collect();
         return Some(format!(
             "::usage_config::Const::List(&[{}])",
             items.join(", ")
         ));
     }
-    prop.default.as_ref().map(value_const)
+    prop.default
+        .as_ref()
+        .map(|value| coerced_const(scalar, value))
+}
+
+/// A declared default as the value its type says it is.
+///
+/// Emitted *coerced*, because a default is seeded straight into the resolution and passes through no
+/// coercion on the way: `default "yes"` under `list<bool>` is a boolean by the time anything reads
+/// it, and emitted as the string it was written as, the read fails on a registry this crate had just
+/// accepted. A value the type cannot read is refused above, so this only ever converts what the run
+/// time would have converted itself.
+///
+/// A *scalar* default arrives already converted — the spec's own parser reads it as the declared
+/// type — so for that one this is belt and braces, and only the list form is observably fixed by it.
+/// Applied to both because which of them the parser happens to cover is not something this should
+/// depend on.
+///
+/// Choices are *not* put through this: they are documentation as much as values — the message says
+/// "one of yes, no" because that is what a user may write — and the comparison coerces them at the
+/// moment it needs them.
+fn coerced_const(ty: usage_config::Ty, value: &SpecConfigValue) -> String {
+    match ty.coerce(runtime_value(value)) {
+        Ok(usage_config::Value::Bool(b)) => format!("::usage_config::Const::Bool({b})"),
+        Ok(usage_config::Value::Int(i)) => format!("::usage_config::Const::Int({i})"),
+        Ok(usage_config::Value::Float(f)) => format!("::usage_config::Const::Float({f:?})"),
+        Ok(usage_config::Value::String(s)) => {
+            format!("::usage_config::Const::Str({})", rust_str(&s))
+        }
+        // A collection cannot come out of coercing a scalar, and a value the type cannot read is
+        // already a refusal — either way the generation does not survive to be emitted.
+        _ => value_const(value),
+    }
+}
+
+/// Whether the type this emits has items of its own, which is what makes an item-wise check right.
+///
+/// Asked of the type that is *emitted*, not of the one the spec wrote: `simplified` collapses a union
+/// to its first member, so a `list<string>|string` looked like a list — while what is emitted for any
+/// union is `Ty::Any`, which compares a value whole and would refuse the very default this had just
+/// accepted. `option<T>` is looked through for the same reason the runtime looks through it.
+fn declares_items(declared: Option<&SpecConfigType>) -> bool {
+    match declared {
+        Some(SpecConfigType::List(_) | SpecConfigType::Set(_) | SpecConfigType::Map(..)) => true,
+        Some(SpecConfigType::Option(inner)) => declares_items(Some(inner)),
+        _ => false,
+    }
+}
+
+/// The type a *scalar* of this setting is read as.
+///
+/// Defaults and choices are scalars, so a collection is asked about what is in it. Every base type is
+/// `const`-constructible without a reference, which is what makes this possible at build time at all:
+/// the composite `Ty`s borrow, and nothing here can hand out a `&'static Ty`.
+fn scalar_ty(declared: Option<&SpecConfigType>) -> usage_config::Ty {
+    fn of(ty: &SpecConfigType) -> usage_config::Ty {
+        match ty {
+            SpecConfigType::Base(base) => match base {
+                Base::Bool => usage_config::Ty::Bool,
+                Base::String => usage_config::Ty::String,
+                Base::Int => usage_config::Ty::Int,
+                Base::Uint => usage_config::Ty::Uint,
+                Base::Float => usage_config::Ty::Float,
+                Base::Path => usage_config::Ty::Path,
+                Base::Url => usage_config::Ty::Url,
+                Base::Duration => usage_config::Ty::Duration,
+                Base::Object => usage_config::Ty::Object,
+                Base::Custom(_) => usage_config::Ty::Any,
+            },
+            SpecConfigType::List(inner) | SpecConfigType::Set(inner) => of(inner),
+            SpecConfigType::Map(_, value) => of(value),
+            SpecConfigType::Option(inner) => of(inner),
+            // A union coerces nothing, and neither does this.
+            SpecConfigType::Union(_) => usage_config::Ty::Any,
+        }
+    }
+    declared.map_or(usage_config::Ty::String, of)
+}
+
+/// A spec value as the runtime holds one, for the coercion above.
+fn runtime_value(value: &SpecConfigValue) -> usage_config::Value {
+    match value {
+        SpecConfigValue::Bool(b) => usage_config::Value::Bool(*b),
+        SpecConfigValue::Int(i) => usage_config::Value::Int(*i),
+        SpecConfigValue::Float(f) => usage_config::Value::Float(*f),
+        SpecConfigValue::String(s) => usage_config::Value::String(s.clone()),
+    }
+}
+
+/// A spec value as a user would have written it, for a message and for the comparison that falls
+/// back to one.
+///
+/// Through the *runtime's* renderer, which is the only way the two can agree about anything: written
+/// here as well, they drifted the moment one of them learned that a whole-number float is `1.0` and
+/// not `1` — and this side would then have accepted a default the generated registry refuses.
+fn display(value: &SpecConfigValue) -> String {
+    runtime_value(value).display()
 }
 
 fn value_const(value: &SpecConfigValue) -> String {

--- a/config-build/tests/fixtures/hk.usage.kdl
+++ b/config-build/tests/fixtures/hk.usage.kdl
@@ -36,6 +36,17 @@ config {
         }
     }
 
+    // Choices written as numbers under a `string` type, which is as ordinary a thing to write as
+    // quoting them — and which the registry has to accept once the value is coerced to text.
+    // The default written as a number under a `string` type, which is the shape a default has to be
+    // *coerced* for: it is seeded straight into the resolution and read by whatever holds it.
+    prop "log_format" type="string" default=1 help="Which log format to use" {
+        choices {
+            choice 1 help="The old one"
+            choice 2 help="The one with colour"
+        }
+    }
+
     prop "url_replacements" type="map<string, string>" merge="deep" \
         help="Rewrite these URL prefixes"
 

--- a/config-build/tests/generated.rs
+++ b/config-build/tests/generated.rs
@@ -26,10 +26,15 @@ fn every_declared_default_resolves_as_its_type() {
     let output: Option<String> = fold.required(prop::TASK_OUTPUT);
     let ports: Option<Vec<u64>> = fold.required(prop::PORTS);
     let timeout: Option<String> = fold.optional(prop::TIMEOUT);
+    let format: Option<String> = fold.required(prop::LOG_FORMAT);
     fold.finish().expect("every default fits its type");
 
     assert_eq!(jobs, Some(4));
     assert_eq!(stash, Some("git".to_string()));
+    // Written `default=1` under a `string` type, and seeded with no coercion on the way — so it has
+    // to have been *emitted* as the string it is, or this read fails on a registry the generator
+    // accepted.
+    assert_eq!(format, Some("1".to_string()));
     assert_eq!(trusted, Some(false));
     assert_eq!(output, Some("prefix".to_string()));
     // A list default is a child node in the spec and stays typed all the way here: three numbers,
@@ -87,6 +92,21 @@ fn what_the_spec_said_about_each_setting_is_what_the_registry_holds() {
     assert_eq!(meta(prop::PATH).parse, Some(Parser::ListByOsPathSeparator));
     assert_eq!(meta(prop::JOBS).parse, None);
     assert!(meta(prop::CI).hide);
+
+    // What the spec says a setting will take, which until now reached the docs and the schema and
+    // nothing that resolved a value.
+    assert_eq!(
+        meta(prop::STASH).choices,
+        &[
+            usage_config::Const::Str("git"),
+            usage_config::Const::Str("patch-file"),
+            usage_config::Const::Str("none")
+        ]
+    );
+    assert!(
+        meta(prop::JOBS).choices.is_empty(),
+        "most settings say nothing"
+    );
     assert!(!meta(prop::JOBS).hide);
 
     // The environment in precedence order, and help as the spec wrote it — quotes and all.
@@ -115,6 +135,44 @@ fn what_the_spec_said_about_each_setting_is_what_the_registry_holds() {
             (prop::EXCLUDE, "defaults.exclude")
         ]
     );
+}
+
+#[test]
+fn a_value_the_spec_does_not_allow_is_refused_through_the_generated_registry() {
+    // End to end for the choices: declared as `choice` nodes in the spec, carried into the registry
+    // by the generator, and enforced by the merge — the three places that used to disagree.
+    let dir =
+        std::env::temp_dir().join(format!("usage_config_build_choice_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("dir");
+    let path = dir.join("hk.toml");
+    std::fs::write(&path, "stash = \"svn\"\n").expect("write");
+
+    let layer = FileLayer::at(&path, FileScope::Project);
+    let resolved = resolve(SETTINGS_REGISTRY, Layers::new().then(&layer)).expect("resolves");
+    // The declared default stands, because a refused value costs its own key and nothing else.
+    assert_eq!(resolved.get_key("stash"), Some(&Value::from("git")));
+    let warnings = usage_config::explain::warnings(&resolved);
+    assert!(
+        warnings
+            .iter()
+            .any(|w| w.starts_with("stash expected one of git, patch-file, none but has `svn`")),
+        "{warnings:?}"
+    );
+
+    // And a choice written as a number under a `string` type is the value it names once the value
+    // has been coerced: comparing the shapes refused a value the spec plainly allows.
+    let path = dir.join("formats.toml");
+    std::fs::write(&path, "log_format = 2\n").expect("write");
+    let layer = FileLayer::at(&path, FileScope::Project);
+    let resolved = resolve(SETTINGS_REGISTRY, Layers::new().then(&layer)).expect("resolves");
+    assert_eq!(resolved.get_key("log_format"), Some(&Value::from("2")));
+    assert!(
+        usage_config::explain::warnings(&resolved).is_empty(),
+        "{:?}",
+        usage_config::explain::warnings(&resolved)
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[test]

--- a/config-build/tests/golden/settings.rs
+++ b/config-build/tests/golden/settings.rs
@@ -35,6 +35,12 @@ pub static SETTINGS_PROPS: &[::usage_config::PropMeta] = &[
         ..::usage_config::PropMeta::new("jobs", ::usage_config::Ty::Uint)
     },
     ::usage_config::PropMeta {
+        default: Some(::usage_config::Const::Str("1")),
+        choices: &[::usage_config::Const::Int(1), ::usage_config::Const::Int(2)],
+        help: Some("Which log format to use"),
+        ..::usage_config::PropMeta::new("log_format", ::usage_config::Ty::String)
+    },
+    ::usage_config::PropMeta {
         default: Some(::usage_config::Const::Str("info")),
         envs: &["HK_LOG_LEVEL"],
         ..::usage_config::PropMeta::new("log_level", ::usage_config::Ty::String)
@@ -55,6 +61,7 @@ pub static SETTINGS_PROPS: &[::usage_config::PropMeta] = &[
     },
     ::usage_config::PropMeta {
         default: Some(::usage_config::Const::Str("git")),
+        choices: &[::usage_config::Const::Str("git"), ::usage_config::Const::Str("patch-file"), ::usage_config::Const::Str("none")],
         help: Some("How to stash before a run"),
         ..::usage_config::PropMeta::new("stash", ::usage_config::Ty::String)
     },
@@ -97,24 +104,26 @@ pub mod prop {
     pub const EXCLUDE: PropId = PropId(3);
     /// `jobs` — How many jobs to run at once
     pub const JOBS: PropId = PropId(4);
+    /// `log_format` — Which log format to use
+    pub const LOG_FORMAT: PropId = PropId(5);
     /// `log_level`
-    pub const LOG_LEVEL: PropId = PropId(5);
+    pub const LOG_LEVEL: PropId = PropId(6);
     /// `match` — Which files to match
-    pub const MATCH: PropId = PropId(6);
+    pub const MATCH: PropId = PropId(7);
     /// `path`
-    pub const PATH: PropId = PropId(7);
+    pub const PATH: PropId = PropId(8);
     /// `ports`
-    pub const PORTS: PropId = PropId(8);
+    pub const PORTS: PropId = PropId(9);
     /// `stash` — How to stash before a run
-    pub const STASH: PropId = PropId(9);
+    pub const STASH: PropId = PropId(10);
     /// `task.output` — How task output is interleaved
-    pub const TASK_OUTPUT: PropId = PropId(10);
+    pub const TASK_OUTPUT: PropId = PropId(11);
     /// `timeout` — How long to wait, if at all
-    pub const TIMEOUT: PropId = PropId(11);
+    pub const TIMEOUT: PropId = PropId(12);
     /// `trusted` — Whether this checkout may run its own hooks
-    pub const TRUSTED: PropId = PropId(12);
+    pub const TRUSTED: PropId = PropId(13);
     /// `url_replacements` — Rewrite these URL prefixes
-    pub const URL_REPLACEMENTS: PropId = PropId(13);
+    pub const URL_REPLACEMENTS: PropId = PropId(14);
 }
 
 /// Every setting, as the types a CLI holds them in.
@@ -135,6 +144,9 @@ pub struct Settings {
     /// How many jobs to run at once
     /// (`jobs`)
     pub jobs: u64,
+    /// Which log format to use
+    /// (`log_format`)
+    pub log_format: String,
     /// (`log_level`)
     pub log_level: String,
     /// Which files to match
@@ -180,6 +192,7 @@ impl Settings {
         let read_either: Option<::usage_config::Value> = fold.optional(prop::EITHER);
         let read_exclude: Option<Vec<String>> = fold.optional(prop::EXCLUDE);
         let read_jobs: Option<u64> = fold.required(prop::JOBS);
+        let read_log_format: Option<String> = fold.required(prop::LOG_FORMAT);
         let read_log_level: Option<String> = fold.required(prop::LOG_LEVEL);
         let read_match: Option<String> = fold.required(prop::MATCH);
         let read_path: Option<Vec<::std::path::PathBuf>> = fold.optional(prop::PATH);
@@ -197,6 +210,7 @@ impl Settings {
             either: read_either,
             exclude: read_exclude,
             jobs: read_jobs.expect("`jobs` has a declared default, so the fold has already reported any absence"),
+            log_format: read_log_format.expect("`log_format` has a declared default, so the fold has already reported any absence"),
             log_level: read_log_level.expect("`log_level` has a declared default, so the fold has already reported any absence"),
             r#match: read_match.expect("`match` has a declared default, so the fold has already reported any absence"),
             path: read_path,

--- a/config-build/tests/refusals.rs
+++ b/config-build/tests/refusals.rs
@@ -128,6 +128,222 @@ fn an_old_name_with_a_list_default_is_refused_too() {
 }
 
 #[test]
+fn a_default_the_choices_do_not_allow_is_refused() {
+    // At run time this is seeded as the bottom layer and then refused by the same check every other
+    // value goes through — a warning on every run of a shipped binary, for a mistake only the author
+    // of the spec can fix. So it is refused where the author will see it.
+    assert_eq!(
+        problems(
+            "    prop \"stash\" type=\"string\" default=\"svn\" {\n        \
+             choices {\n            choice \"git\"\n            choice \"none\"\n        }\n    }"
+        ),
+        vec!["`stash` defaults to `svn`, which is not one of the values it allows: git, none"]
+    );
+
+    // And a list default is held to them item by item, the way the values themselves are.
+    assert_eq!(
+        problems(
+            "    prop \"skip\" type=\"list<string>\" {\n        default \"lint\" \"deploy\"\n        \
+             choices {\n            choice \"lint\"\n            choice \"test\"\n        }\n    }"
+        ),
+        vec!["`skip` defaults to `deploy`, which is not one of the values it allows: lint, test"]
+    );
+}
+
+#[test]
+fn a_value_the_declared_type_cannot_read_is_refused_wherever_it_is_declared() {
+    // `choice 1` under `type="bool"`, which reads booleans and their spellings and not numbers: a
+    // choice nobody can ever pick, so *every* value the setting is given would be refused at run
+    // time. It was caught only by accident, through the default not matching those choices — a
+    // message that blames the wrong end of the mistake.
+    assert_eq!(
+        problems(
+            "    prop \"colour\" type=\"bool\" default=#true {\n        \
+             choices {\n            choice 1\n            choice 0\n        }\n    }"
+        ),
+        vec![
+            "`colour` has a choice `1`, which is not a boolean",
+            "`colour` has a choice `0`, which is not a boolean"
+        ]
+    );
+
+    // And a *default* the type cannot read, which nothing else catches at all: it is seeded straight
+    // into the resolution, passing through no coercion, and then read by whatever holds it.
+    assert_eq!(
+        problems("    prop \"colour\" type=\"bool\" default=1"),
+        vec!["`colour` defaults to `1`, which is not a boolean"]
+    );
+
+    // A choice that is merely unreachable is the same mistake in a quieter form: it appears in the
+    // docs as a value one may set, and no value can ever be it.
+    assert_eq!(
+        problems(
+            "    prop \"jobs\" type=\"uint\" default=1 {\n        \
+             choices {\n            choice 1\n            choice \"lots\"\n        }\n    }"
+        ),
+        vec!["`jobs` has a choice `lots`, which is not a non-negative integer"]
+    );
+}
+
+#[test]
+fn the_spec_and_the_runtime_write_a_value_the_same_way() {
+    // Three crates render a value and all three have to agree, because a default is coerced by the
+    // *spec's* parser and its choices are read by the *runtime's* — so one character of difference
+    // refused a `default=1.0` beside a `choice 1.0`, written identically. usage-lib cannot depend on
+    // usage-config, so the rule exists in both; this is the one place that can see them at once, and
+    // it is here so that a change to either is a failure rather than a surprise.
+    for value in [
+        0.0_f64,
+        1.0,
+        -1.0,
+        0.5,
+        1.25,
+        1e3,
+        1e300,
+        f64::MIN,
+        f64::MAX,
+    ] {
+        assert_eq!(
+            usage::spec::config::SpecConfigValue::Float(value).display(),
+            usage_config::Value::Float(value).display(),
+            "the two crates write {value} differently"
+        );
+    }
+}
+
+#[test]
+fn a_list_default_under_a_type_with_no_items_is_one_value() {
+    // `any` takes a list perfectly well, and a scalar choice is not one however many items it has.
+    // Checked item by item — which is right only where the type declares items — `default 1 2` beside
+    // `choice 1` and `choice 2` passed, and the whole list is what a seeded default *is*: refused by
+    // its own choices at run time, and never checked again.
+    assert_eq!(
+        problems(
+            "    prop \"level\" type=\"int|string\" {\n        default 1 2\n        \
+             choices {\n            choice 1\n            choice 2\n        }\n    }"
+        ),
+        vec!["`level` defaults to `1,2`, which is not one of the values it allows: 1, 2"]
+    );
+
+    // A union whose *first arm* is a list is still a union: what is emitted for it is `Ty::Any`,
+    // which compares a value whole — so asking the spec's `simplified` type, which collapses a union
+    // to that first arm, accepted a default the generated registry would refuse.
+    assert_eq!(
+        problems(
+            "    prop \"level\" type=\"list<uint>|uint\" {\n        default 1 2\n        \
+             choices {\n            choice 1\n            choice 2\n        }\n    }"
+        ),
+        vec!["`level` defaults to `1,2`, which is not one of the values it allows: 1, 2"]
+    );
+
+    // Where the type *does* declare items, each of them is one of the choices, as before — including
+    // through an `option`, which the runtime looks through as well.
+    for ty in ["list<uint>", "set<uint>", "option<list<uint>>"] {
+        source_of_spec(
+            &spec(&format!(
+                "    prop \"ports\" type=\"{ty}\" {{\n        default 1 2\n        \
+                 choices {{\n            choice 1\n            choice 2\n        }}\n    }}"
+            )),
+            "mycli.usage.kdl",
+        )
+        .unwrap_or_else(|err| panic!("each item is one of them, for `{ty}`: {err}"));
+    }
+}
+
+#[test]
+fn a_value_reads_here_the_way_it_reads_at_run_time() {
+    // The generator and the runtime have to agree about what a value *is*, or this crate accepts a
+    // registry the registry itself refuses. They drifted the moment one of them learned that a
+    // whole-number float is `1.0` and not `1`: `default="1"` beside `choice 1.0` was accepted here
+    // and refused there — and a seeded default is never checked again, so it would simply have been
+    // the effective value.
+    assert_eq!(
+        problems(
+            "    prop \"scale\" type=\"string\" default=\"1\" {\n        \
+             choices {\n            choice 1.0\n        }\n    }"
+        ),
+        vec!["`scale` defaults to `1`, which is not one of the values it allows: 1.0"]
+    );
+    // And the spelling the spec wrote is the one that is one of them.
+    source_of_spec(
+        &spec(
+            "    prop \"scale\" type=\"string\" default=\"1.0\" {\n        \
+             choices {\n            choice 1.0\n        }\n    }",
+        ),
+        "mycli.usage.kdl",
+    )
+    .expect("`1.0` is `1.0`");
+}
+
+#[test]
+fn a_default_no_choice_can_be_is_refused_however_it_is_written() {
+    // `default="3"` beside `choice 1`: written differently, and still not one of them once both are
+    // read as the declared type. Skipping the pair because their literals differ let this through on
+    // the assumption that resolution would refuse it later — and a *seeded* default never passes the
+    // check a supplied value does, so it would have become the effective value with nothing said.
+    assert_eq!(
+        problems(
+            "    prop \"level\" type=\"int\" default=\"3\" {\n        \
+             choices {\n            choice 1\n            choice 2\n        }\n    }"
+        ),
+        vec!["`level` defaults to `3`, which is not one of the values it allows: 1, 2"]
+    );
+}
+
+#[test]
+fn a_default_written_unlike_its_choices_is_still_one_of_them() {
+    // `choice "yes"` under `type="bool"`: read as the declared type — through the same `Ty::coerce`
+    // the run time uses — `#true` *is* one of them, and refusing a spec that resolves perfectly well
+    // would be the worse mistake of the two.
+    let generated = source_of_spec(
+        &spec(
+            "    prop \"colour\" type=\"bool\" default=#true {\n        \
+             choices {\n            choice \"yes\"\n            choice \"no\"\n        }\n    }",
+        ),
+        "mycli.usage.kdl",
+    )
+    .expect("should generate");
+    assert!(generated.contains("Const::Bool(true)"), "{generated}");
+    assert!(generated.contains("Const::Str(\"yes\")"), "{generated}");
+
+    // A union coerces nothing, so its choice and its default stay an integer and a string — and only
+    // what they are written as can say whether they are the same. Refusing here would refuse a spec
+    // the run time accepts, which is the worse way round to be wrong.
+    source_of_spec(
+        &spec(
+            "    prop \"level\" type=\"int|string\" default=\"1\" {\n        \
+             choices {\n            choice 1\n            choice 2\n        }\n    }",
+        ),
+        "mycli.usage.kdl",
+    )
+    .expect("a union takes what it is given");
+
+    // And inside a list it is the *item's* type that reads them: read as the list, `yes` is a
+    // one-item list and matches nothing.
+    let generated = source_of_spec(
+        &spec(
+            "    prop \"flags\" type=\"list<bool>\" {\n        default \"yes\"\n        \
+             choices {\n            choice #true\n            choice #false\n        }\n    }",
+        ),
+        "mycli.usage.kdl",
+    )
+    .expect("`yes` is `true` once an item is read as a bool");
+    // And it is emitted as the boolean it *is*: a default is seeded straight into the resolution
+    // with no coercion, so emitting the string it was written as would fail the first read of a
+    // registry this crate had just accepted.
+    assert!(
+        generated.contains("Const::List(&[::usage_config::Const::Bool(true)])"),
+        "{generated}"
+    );
+    // The choices keep the spelling the spec gave them: they are documentation as much as values,
+    // and the comparison reads them when it needs to.
+    assert!(
+        generated.contains("choices: &[::usage_config::Const::Bool(true)"),
+        "{generated}"
+    );
+}
+
+#[test]
 fn a_default_declared_twice_is_refused() {
     // `default=1` beside a `default 80 443` node. The spec takes both — I checked, rather than
     // trusting the comment I had written saying it did not — and there is no reading of a property

--- a/config/src/layer.rs
+++ b/config/src/layer.rs
@@ -293,6 +293,19 @@ mod tests {
             parse: Some(Parser::ListByComma),
             ..PropMeta::new("exclude", Ty::List(&Ty::String))
         },
+        // A `bool` whose choices are written the way a person says them, which the coercion turns
+        // into the same two values.
+        PropMeta {
+            choices: &[Const::Str("yes"), Const::Str("no")],
+            ..PropMeta::new("colour", Ty::Bool)
+        },
+        // A type usage cannot know — a union — with its choices written as numbers. Nothing is
+        // coerced here by declaration, so a value out of a file stays a string and the choice stays
+        // an integer, and only their written forms can answer whether they are the same.
+        PropMeta {
+            choices: &[Const::Int(1), Const::Int(2)],
+            ..PropMeta::new("level", Ty::Any)
+        },
         // A setting the spec limits to three values, which is hk's `stash` and mise's nine
         // enum-valued settings.
         PropMeta {
@@ -302,6 +315,15 @@ mod tests {
                 Const::Str("none"),
             ],
             ..PropMeta::new("stash", Ty::String)
+        },
+        // A list whose *items* are booleans, with the choices written as words. Unusual, and the one
+        // shape where the item's own type is the only thing that makes the comparison work: read as
+        // the list it is in, `yes` becomes a one-item list and matches nothing, and read as text it
+        // is `yes` against `true`.
+        PropMeta {
+            parse: Some(Parser::ListByComma),
+            choices: &[Const::Str("yes"), Const::Str("no")],
+            ..PropMeta::new("flags", Ty::List(&Ty::Bool))
         },
         // Choices on a list: each *item* is one of them, the way the JSON schema reads it.
         PropMeta {
@@ -343,6 +365,115 @@ mod tests {
             "skip expected one of lint, test but has `fmt`"
         );
         assert!(ctx.entry_for_key("skip", "lint,test", origin).is_ok());
+    }
+
+    #[test]
+    fn a_choice_is_read_the_way_the_declared_type_reads_it() {
+        // `choice "yes"` under `type="bool"`: the value `yes` is coerced to `true` on its way in, so
+        // comparing the two as written refused a value the spec plainly allows. The choice is read
+        // the same way the value was, which is the same question the coercion already answered.
+        let ctx = LayerCtx::new(REGISTRY);
+        let origin = Origin::new(SourceKind::ENV, "HK_COLOUR");
+        assert_eq!(
+            ctx.entry_for_key("colour", "yes", origin.clone())
+                .map(|entry| entry.value),
+            Ok(Value::Bool(true))
+        );
+        // `no` is the other declared choice, and `true` is neither of them written down — but it is
+        // what `yes` reads as, so it is allowed for the same reason.
+        assert_eq!(
+            ctx.entry_for_key("colour", "no", origin.clone())
+                .map(|entry| entry.value),
+            Ok(Value::Bool(false))
+        );
+        assert_eq!(
+            ctx.entry_for_key("colour", "true", origin.clone())
+                .map(|entry| entry.value),
+            Ok(Value::Bool(true))
+        );
+
+        // And inside a collection it is the *item's* type that reads the choice, not the list's:
+        // read as the list, `yes` becomes a one-item list and matches nothing at all.
+        assert_eq!(
+            ctx.entry_for_key("flags", "yes,no", origin.clone())
+                .map(|entry| entry.value),
+            Ok(Value::List(vec![Value::Bool(true), Value::Bool(false)]))
+        );
+        // The type is asked first, which is why this says what it says: `maybe` is not a boolean, and
+        // there is nothing useful to say about which *choice* it is not. With both spellings of a
+        // boolean declared as choices, every boolean is one of them — so for this setting the choices
+        // can only refuse what the type has already refused.
+        let warning = ctx
+            .entry_for_key("flags", "yes,maybe", origin)
+            .expect_err("`maybe` is not a boolean");
+        assert_eq!(warning.message, "flags expected a boolean but has `maybe`");
+    }
+
+    #[test]
+    fn a_float_choice_is_the_number_the_spec_wrote() {
+        // Rendered without its point, a whole-number float was the same text as an integer — so a
+        // `choice 1.0` under a *string* type accepted `1` and refused the `1.0` the spec had written.
+        static PROPS: &[PropMeta] = &[
+            PropMeta {
+                choices: &[Const::Float(1.0), Const::Float(1.5)],
+                ..PropMeta::new("scale", Ty::String)
+            },
+            // And where the type *is* a float, the coercion settles it before any text is compared.
+            PropMeta {
+                choices: &[Const::Int(1), Const::Float(1.5)],
+                ..PropMeta::new("ratio", Ty::Float)
+            },
+        ];
+        const REGISTRY: Registry = Registry::new(PROPS);
+        let ctx = LayerCtx::new(REGISTRY);
+        let origin = Origin::new(SourceKind::ENV, "HK_SCALE");
+
+        assert_eq!(
+            ctx.entry_for_key("scale", "1.0", origin.clone())
+                .map(|entry| entry.value),
+            Ok(Value::from("1.0"))
+        );
+        let warning = ctx
+            .entry_for_key("scale", "1", origin.clone())
+            .expect_err("`1` is not `1.0`");
+        assert_eq!(
+            warning.message,
+            "scale expected one of 1.0, 1.5 but has `1`"
+        );
+
+        // `choice 1` under `type="float"` is the float one, because that is what the type reads it
+        // as — the case the point-less rendering used to settle by accident.
+        assert_eq!(
+            ctx.entry_for_key("ratio", "1", origin)
+                .map(|entry| entry.value),
+            Ok(Value::Float(1.0))
+        );
+    }
+
+    #[test]
+    fn a_type_nothing_coerces_compares_its_choices_as_written() {
+        // `any` coerces nothing, by declaration — so a value arrives as the string a file or an
+        // environment variable wrote, the choice stays the integer the spec wrote, and comparing them
+        // after a coercion that did nothing refuses a value the spec allows.
+        let ctx = LayerCtx::new(REGISTRY);
+        let origin = Origin::new(SourceKind::ENV, "HK_LEVEL");
+        assert_eq!(
+            ctx.entry_for_key("level", "2", origin.clone())
+                .map(|entry| entry.value),
+            Ok(Value::from("2"))
+        );
+        let warning = ctx
+            .entry_for_key("level", "3", origin.clone())
+            .expect_err("not one of them");
+        assert_eq!(warning.message, "level expected one of 1, 2 but has `3`");
+
+        // And a *list* of them is not one of them. Nothing declared this setting to have items, so
+        // there is nothing to walk into: following the value's shape instead, `[1]` was accepted for
+        // `choice 1` — and for a type the spec left open, a value's shape is whatever a file wrote.
+        let warning = ctx
+            .entry_from_value("level", Value::List(vec![Value::Int(1)]), origin)
+            .expect_err("a list of one choice is not that choice");
+        assert_eq!(warning.message, "level expected one of 1, 2 but has `1`");
     }
 
     #[test]

--- a/config/src/registry.rs
+++ b/config/src/registry.rs
@@ -139,12 +139,29 @@ impl PropMeta {
         if self.choices.is_empty() {
             return None;
         }
-        match value {
-            Value::List(items) => items.iter().find_map(|item| self.refuses(item)),
-            Value::Map(entries) => entries.values().find_map(|item| self.refuses(item)),
-            scalar => match self.choices.iter().any(|choice| choice.matches(scalar)) {
+        self.refuses_as(self.ty, value)
+    }
+
+    /// The same, for the type this level of the value is held to.
+    ///
+    /// Threaded down through a collection because a choice is compared *as the declared type reads
+    /// it*, and the declared type of an item is not the declared type of the list it is in.
+    fn refuses_as<'v>(&self, ty: Ty, value: &'v Value) -> Option<&'v Value> {
+        // On the *declared* type, not on the shape of what arrived. Following the value instead, a
+        // scalar-choiced setting the spec left open — `any`, a union — accepted `[1]` for `choice 1`,
+        // because the walk went looking for items in something that was never declared to have any.
+        match (ty.inner(), value) {
+            (Ty::List(item) | Ty::Set(item), Value::List(items)) => {
+                items.iter().find_map(|value| self.refuses_as(*item, value))
+            }
+            (Ty::Map(item), Value::Map(entries)) => entries
+                .values()
+                .find_map(|value| self.refuses_as(*item, value)),
+            // Anything else is compared whole, and a scalar choice is not a list however many items
+            // it has: `Const::matches` says as much, and this is where that is asked.
+            _ => match self.choices.iter().any(|choice| allows(ty, choice, value)) {
                 true => None,
-                false => Some(scalar),
+                false => Some(value),
             },
         }
     }
@@ -156,6 +173,25 @@ impl PropMeta {
             .map(|choice| choice.to_value().display())
             .collect::<Vec<_>>()
             .join(", ")
+    }
+}
+
+/// Whether `choice` is `value`, read the way the declared type reads them both.
+///
+/// The value arrived here through `Ty::coerce`, and the choice has not: a spec writes `choice "yes"`
+/// under `type="bool"` and the value `yes` becomes `Bool(true)`, so comparing them as written refuses
+/// a value the spec plainly allows. Reading the choice the same way is what makes the two comparable
+/// — it is the same question the coercion already answered.
+fn allows(ty: Ty, choice: &Const, value: &Value) -> bool {
+    match ty.coerce(choice.to_value()) {
+        Ok(coerced) if coerced == *value => true,
+        // Coercion did not settle it, so the question falls back to what the two are written as.
+        // `any` is where that matters most — a union coerces *nothing*, so a `choice 4` and the
+        // string `4` a file supplied stay an integer and a string — and I had this as the `Err` arm,
+        // which `any` never takes, since coercing there succeeds by doing nothing at all. It is also
+        // the arm for a choice the declared type cannot read, which is one nothing can supply
+        // either.
+        _ => choice.matches(value),
     }
 }
 

--- a/config/src/value.rs
+++ b/config/src/value.rs
@@ -89,7 +89,17 @@ impl Value {
         match self {
             Self::Bool(b) => b.to_string(),
             Self::Int(i) => i.to_string(),
-            Self::Float(f) => f.to_string(),
+            // With its point, because `1` is how an *integer* is written and this is not one. Left
+            // as `f64::to_string` gives it, a whole-number float and an integer were the same text —
+            // so a `choice 1.0` accepted `1` and refused the `1.0` the spec had written, and the
+            // list of what a setting allows said `1` back to an author who had not typed that.
+            Self::Float(f) => {
+                let text = f.to_string();
+                match f.is_finite() && !text.contains(['.', 'e', 'E']) {
+                    true => format!("{text}.0"),
+                    false => text,
+                }
+            }
             Self::String(s) => s.clone(),
             Self::List(items) => items
                 .iter()
@@ -157,20 +167,32 @@ pub enum Const {
 }
 
 impl Const {
-    /// Whether `value` is this constant.
+    /// Whether `value` is this constant, or is written the same way.
     ///
-    /// Without building the `Value` it stands for: this runs once per declared choice for every
-    /// value a layer supplies, and a setting with choices is usually a string, where the comparison
-    /// would otherwise allocate a copy of the choice to throw away.
+    /// The same shape compares directly, without building the `Value` this stands for: the strict
+    /// case is the common one, it runs once per declared choice for every value supplied, and a
+    /// setting with choices is usually a string — where the comparison would otherwise allocate a
+    /// copy of the choice to throw away.
+    ///
+    /// The shapes differing is not a mismatch, though, and this is the part worth explaining. A spec
+    /// writes `choice 4` under `type="string"` as readily as `choice "4"`, and by the time a value
+    /// reaches here it has been coerced to the *declared* type — so the choice is an integer and the
+    /// value is the string `4`, and a strict comparison refuses a value the spec plainly allows.
+    /// Comparing what they are written as is the same question the coercion already answered:
+    /// `Ty::String` turns `4` into `"4"`, and `Ty::Float` turns `1` into `1.0`, whose text is `1`
+    /// either way. Only scalars get here — [`PropMeta::refuses`](crate::PropMeta::refuses) walks a
+    /// list or a table item by item first — so there is no way for `a,b` the string to be mistaken
+    /// for `[a, b]` the list.
     pub fn matches(self, value: &Value) -> bool {
         match (self, value) {
             (Self::Bool(a), Value::Bool(b)) => a == *b,
             (Self::Int(a), Value::Int(b)) => a == *b,
             (Self::Float(a), Value::Float(b)) => a == *b,
             (Self::Str(a), Value::String(b)) => a == b,
-            // A list or a table is not something a `choice` node can hold, and comparing one to a
-            // scalar is not a near miss to be generous about.
-            _ => false,
+            // A list or a table is not something a `choice` node can hold, and one of those is not a
+            // scalar written differently.
+            (Self::List(_) | Self::Map(_), _) | (_, Value::List(_) | Value::Map(_)) => false,
+            (choice, value) => choice.to_value().display() == value.display(),
         }
     }
 
@@ -250,6 +272,37 @@ mod tests {
             )),
             "k="
         );
+    }
+
+    #[test]
+    fn a_choice_and_a_value_written_the_same_way_are_the_same_choice() {
+        // A spec writes `choice 4` under `type="string"` as readily as `choice "4"`, and by the time
+        // a value reaches the check it has been coerced to the *declared* type — so the choice is an
+        // integer, the value is the string `4`, and comparing shapes refused a value the spec plainly
+        // allows.
+        assert!(Const::Int(4).matches(&Value::from("4")));
+        assert!(Const::Str("4").matches(&Value::Int(4)));
+        assert!(Const::Bool(true).matches(&Value::from("true")));
+        // A float and an integer are *not* the same text, and should not be: `1.0` is a float and
+        // `1` is not one. The pair that matters — `type="float"` with `choice 1` — is settled before
+        // this by the coercion, which reads the choice as a float, and `PropMeta::refuses` has a test
+        // for that.
+        assert!(!Const::Int(1).matches(&Value::Float(1.0)));
+        assert_eq!(Value::Float(1.0).display(), "1.0");
+        assert_eq!(Value::Float(0.5).display(), "0.5");
+        assert_eq!(Value::Int(1).display(), "1");
+
+        // The same shape still compares as itself, and different values are still different.
+        assert!(Const::Str("git").matches(&Value::from("git")));
+        assert!(!Const::Str("git").matches(&Value::from("svn")));
+        assert!(!Const::Int(4).matches(&Value::Int(5)));
+
+        // A collection is never compared to a scalar: `PropMeta::refuses` walks one item by item
+        // first, so `a,b` the string cannot be mistaken for `[a, b]` the list.
+        const ITEMS: &[Const] = &[Const::Str("a"), Const::Str("b")];
+        let list = Value::List(vec![Value::from("a"), Value::from("b")]);
+        assert!(!Const::Str("a,b").matches(&list));
+        assert!(!Const::List(ITEMS).matches(&Value::from("a,b")));
     }
 
     #[test]

--- a/lib/src/spec/config.rs
+++ b/lib/src/spec/config.rs
@@ -150,7 +150,18 @@ impl SpecConfigValue {
         match self {
             Self::Bool(b) => b.to_string(),
             Self::Int(i) => i.to_string(),
-            Self::Float(f) => f.to_string(),
+            // With its point, because `1` is how an *integer* is written and this is not one. This
+            // is also what `usage-config` writes a float as, and the two have to agree: a spec's
+            // `default=1.0` on a string-typed prop is coerced *here* and its `choice 1.0` is read
+            // *there*, so a difference of one character refused a default and a choice that were
+            // written identically. `usage-config-build` has a test that holds the two together.
+            Self::Float(f) => {
+                let text = f.to_string();
+                match f.is_finite() && !text.contains(['.', 'e', 'E']) {
+                    true => format!("{text}.0"),
+                    false => text,
+                }
+            }
             Self::String(s) => s.clone(),
         }
     }


### PR DESCRIPTION
The step between #868's enforcement and the spec that declares it: `choice` nodes become `Const`s in
the generated registry, so the values a CLI documents are the values it accepts. The end-to-end test
runs a config file through the *generated* registry and watches the merge refuse `stash = "svn"`
while the declared default stands — the three places that used to disagree (docs, schema, resolution)
now come from one declaration.

**A default the choices do not allow is refused here.** At run time it is seeded as the bottom layer
and then goes through the same check as every other value, so it would be a warning on every run of a
shipped binary — for a mistake only the author of the spec can fix:

```
`stash` defaults to `svn`, which is not one of the values it allows: git, none
```

A list default is held to them item by item, the way the values themselves are.

Two mutations: not emitting the choices (caught by the regenerate-and-diff test, which is how any
emitter change is caught here), and checking only the scalar default and not the list one.

Still deliberately out: generating an *enum* per choice-bearing setting. It needs variant naming,
a `FromValue` impl and its own error, and none of that is needed for the values to be enforced —
`String` plus a refusal at the boundary is the smaller thing that makes the declaration true.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches config resolution, codegen defaults, and value display/coercion across three crates; mistakes could change which values are accepted or what defaults ship, though coverage is heavy.
> 
> **Overview**
> **Choices in the generated registry** — `config-build` now emits `choices` on each `PropMeta` and depends on `usage-config` so validation uses the same `Ty::coerce` the runtime uses.
> 
> **Build-time spec validation** — The generator rejects defaults and choices the declared type cannot read, defaults outside the allowed set (including list defaults checked per-item or as a whole for scalar/`any` types), and emits defaults via `coerced_const` so seeded values match what resolution expects (e.g. `default "yes"` on `list<bool>` becomes bool literals).
> 
> **Runtime choice matching** — `PropMeta::refuses` walks collections using the **declared** type (not value shape), and `allows` coerces each choice before comparing. `Const::matches` falls back to matching `display()` text so cross-shaped literals (e.g. `choice 4` vs string `"4"`, `choice "yes"` vs bool) agree with coercion.
> 
> **Shared float rendering** — `usage-config` and `usage-lib` format whole-number floats with a decimal point (`1.0` vs `1`) so default/choice comparisons and error messages stay consistent across spec parse, codegen, and merge warnings.
> 
> **Tests** — Fixture `log_format`, golden output, end-to-end resolve for invalid `stash`, and broad refusal tests in `config-build/tests/refusals.rs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 964d72b619d41a9577c158e2b23eb3e349fbe8a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration settings now expose their permitted values.
  * Added the `log_format` setting with supported values `1` and `2`.
  * Compatible scalar values are recognized across textual and numeric representations.

* **Bug Fixes**
  * Invalid scalar and list defaults are rejected with clear messages showing invalid and allowed values.
  * Invalid setting values fall back to the effective default and generate a warning.
  * Configuration validation messages now format values more clearly, including whole-number decimals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->