### PR TITLE
feat(config): say what sort of thing each warning is

### DIFF
--- a/config/src/env.rs
+++ b/config/src/env.rs
@@ -13,7 +13,7 @@
 use std::collections::BTreeMap;
 use std::ffi::OsStr;
 
-use crate::layer::{Layer, LayerCtx, LayerError, LayerOutput, Warning};
+use crate::layer::{Layer, LayerCtx, LayerError, LayerOutput, Warning, WarningKind};
 use crate::registry::PropId;
 use crate::source::{Origin, SourceKind};
 
@@ -133,13 +133,16 @@ impl Layer for EnvLayer {
             for (id, set_as, raw) in candidates {
                 let origin = Origin::new(SourceKind::ENV, set_as);
                 if let Some(first) = read_by {
-                    out.warn(Warning::at(
-                        format!(
-                            "{set_as} was not read: {first} also sets {}",
-                            registry.get(target).key
-                        ),
-                        origin,
-                    ));
+                    out.warn(
+                        Warning::at(
+                            format!(
+                                "{set_as} was not read: {first} also sets {}",
+                                registry.get(target).key
+                            ),
+                            origin,
+                        )
+                        .of(WarningKind::NotRead),
+                    );
                     continue;
                 }
                 match ctx.entry(id, raw, origin) {
@@ -387,6 +390,18 @@ mod tests {
                 .iter()
                 .any(|w| w.starts_with("HK_THREADS was not read: HK_CONCURRENCY also sets jobs")),
             "{warnings:?}"
+        );
+        // Three kinds at once, which is what living through a rename actually produces: the name
+        // that was passed over, and — for the one that *was* read — that it is deprecated and what
+        // it was read as. A variable passed over is its own sort of thing: nothing is wrong with the
+        // value, and a `--strict` mode that stops for a bad one should not stop for this.
+        assert_eq!(
+            resolved.warnings.iter().map(|w| w.kind).collect::<Vec<_>>(),
+            vec![
+                WarningKind::NotRead,
+                WarningKind::Deprecated,
+                WarningKind::Renamed
+            ]
         );
 
         // And the current name still beats both of them.

--- a/config/src/layer.rs
+++ b/config/src/layer.rs
@@ -42,26 +42,76 @@ impl Entry {
 /// Returned rather than printed. mise queues these until its logging is up, and a library
 /// that writes to stderr on its own cannot be used by anything that has an opinion about
 /// output.
+///
+/// Built through [`Warning::new`] or [`Warning::at`] rather than as a literal: this has gained a
+/// field once already, and a warning is something a layer *reports* rather than a shape anything
+/// downstream should be pattern-matched against exhaustively. Reading the fields, and matching with
+/// `..`, are unaffected.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct Warning {
     pub message: String,
     /// Where the value that caused it came from, when there was one.
     pub origin: Option<Origin>,
+    /// What sort of thing happened, for a caller that wants to treat them differently.
+    pub kind: WarningKind,
+}
+
+/// The kinds of thing a resolution has to say.
+///
+/// The message is for a person and its wording is nobody's contract; this is what a *program* can
+/// act on. mise wants its deprecations queued and printed once its logging is up while a bad value
+/// goes to stderr immediately; a `--strict` mode wants to exit on anything but a deprecation; the
+/// conformance corpus wants to pin what happened without pinning how it was worded, since that is a
+/// quality-of-implementation concern and differs between implementations by design.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum WarningKind {
+    /// A key no setting declares. A config file written for a newer binary read by an older one.
+    UnknownSetting,
+    /// A value the declared type cannot read.
+    WrongType,
+    /// A value the declared `choice` nodes do not allow.
+    NotAllowed,
+    /// A place that may not set this setting: a `scope="global"` setting from a checkout.
+    OutOfScope,
+    /// A setting whose spec says not to use it any more.
+    Deprecated,
+    /// A value that arrived under an old name and was read as the setting that replaced it.
+    Renamed,
+    /// A value that was passed over because another name for the same setting won.
+    NotRead,
+    /// Something a layer of the CLI's own says, which this crate has no name for.
+    #[default]
+    Other,
 }
 
 impl Warning {
+    /// A warning of no particular kind, which is what a custom layer's own complaints are.
     pub fn new(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
             origin: None,
+            kind: WarningKind::Other,
         }
     }
 
+    /// The same, about a value that came from somewhere nameable.
     pub fn at(message: impl Into<String>, origin: Origin) -> Self {
         Self {
             message: message.into(),
             origin: Some(origin),
+            kind: WarningKind::Other,
         }
+    }
+
+    /// This warning, classified.
+    ///
+    /// Chained rather than an argument so the two constructors keep reading as they did, and so a
+    /// layer that has nothing useful to say about the kind is not made to invent one.
+    pub fn of(mut self, kind: WarningKind) -> Self {
+        self.kind = kind;
+        self
     }
 }
 
@@ -186,7 +236,8 @@ impl LayerCtx {
                 Err(Warning::at(
                     format!("{key} expected {} but has `{}`", err.expected, err.found),
                     origin,
-                ))
+                )
+                .of(WarningKind::WrongType))
             }
         }
     }
@@ -203,14 +254,17 @@ impl LayerCtx {
     fn refused(&self, id: PropId, value: &Value, key: &str, origin: &Origin) -> Option<Warning> {
         let meta = self.registry.get(id);
         let refused = meta.refuses(value)?;
-        Some(Warning::at(
-            format!(
-                "{key} expected one of {} but has `{}`",
-                meta.allowed(),
-                crate::value::shown(refused)
-            ),
-            origin.clone(),
-        ))
+        Some(
+            Warning::at(
+                format!(
+                    "{key} expected one of {} but has `{}`",
+                    meta.allowed(),
+                    crate::value::shown(refused)
+                ),
+                origin.clone(),
+            )
+            .of(WarningKind::NotAllowed),
+        )
     }
 
     /// An entry for a dotted key, which is what a layer reading a file has in hand.
@@ -221,7 +275,8 @@ impl LayerCtx {
     /// do, and the reason a deprecated key in somebody's config file gets reported at all.
     pub fn entry_for_key(&self, key: &str, raw: &str, origin: Origin) -> Result<Entry, Warning> {
         let Some(found) = self.prop(key) else {
-            return Err(Warning::at(format!("unknown setting `{key}`"), origin));
+            return Err(Warning::at(format!("unknown setting `{key}`"), origin)
+                .of(WarningKind::UnknownSetting));
         };
         let mut entry = self.entry(found.id, raw, origin)?;
         // `lookup` already folded, so `entry` had nothing left to fold and nothing to report;
@@ -244,7 +299,8 @@ impl LayerCtx {
         origin: Origin,
     ) -> Result<Entry, Warning> {
         let Some(found) = self.prop(key) else {
-            return Err(Warning::at(format!("unknown setting `{key}`"), origin));
+            return Err(Warning::at(format!("unknown setting `{key}`"), origin)
+                .of(WarningKind::UnknownSetting));
         };
         let meta = self.registry.get(found.id);
         match meta.ty.coerce(value) {
@@ -266,7 +322,8 @@ impl LayerCtx {
                     err.found
                 ),
                 origin,
-            )),
+            )
+            .of(WarningKind::WrongType)),
         }
     }
 }
@@ -282,6 +339,7 @@ pub trait Layer {
 
 #[cfg(test)]
 mod tests {
+    use super::WarningKind;
     use super::*;
     use crate::registry::PropMeta;
     use crate::ty::{Parser, Ty};
@@ -347,6 +405,15 @@ mod tests {
         assert_eq!(
             warning.message,
             "stash expected one of git, patch-file, none but has `svn`"
+        );
+        // Which is a different sort of thing from a value of the wrong *type*, and a caller that
+        // treats them differently needs to be able to tell.
+        assert_eq!(warning.kind, WarningKind::NotAllowed);
+        assert_eq!(
+            ctx.entry_for_key("jobs", "lots", origin.clone())
+                .expect_err("not a number")
+                .kind,
+            WarningKind::WrongType
         );
         // And a value that is one of them is just a value.
         assert_eq!(

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -71,7 +71,7 @@ pub use env::EnvLayer;
 pub use explain::explain;
 #[cfg(any(feature = "toml", feature = "json"))]
 pub use files::{FileLayer, Format};
-pub use layer::{Entry, Layer, LayerCtx, LayerError, LayerOutput, Warning};
+pub use layer::{Entry, Layer, LayerCtx, LayerError, LayerOutput, Warning, WarningKind};
 pub use read::{Fold, FromValue, ReadError, ReadErrorKind, ReadErrors};
 pub use registry::{Lookup, Merge, PropId, PropMeta, Registry, Scope};
 pub use resolve::{resolve, Layers, Resolved};

--- a/config/src/resolve.rs
+++ b/config/src/resolve.rs
@@ -11,7 +11,7 @@
 
 use std::collections::BTreeMap;
 
-use crate::layer::{Layer, LayerCtx, LayerError, Warning};
+use crate::layer::{Layer, LayerCtx, LayerError, Warning, WarningKind};
 use crate::registry::{Merge, PropId, Registry, Scope};
 use crate::source::{Origin, SourceKind, Trust};
 use crate::value::Value;
@@ -189,24 +189,30 @@ pub fn resolve(registry: Registry, layers: Layers<'_>) -> Result<Resolved, Layer
                 // rename, `written.key` is the *replacement's* name, so a refused value was
                 // reported under a key that does not appear in the file the user would go and
                 // edit.
-                resolved.warnings.push(Warning::at(
-                    format!("{written_key} {refusal}"),
-                    entry.origin,
-                ));
+                resolved.warnings.push(
+                    Warning::at(format!("{written_key} {refusal}"), entry.origin)
+                        .of(WarningKind::OutOfScope),
+                );
                 continue;
             }
             if let Some(why) = as_written.deprecated {
-                resolved.warnings.push(Warning::at(
-                    format!("{written_key} is deprecated: {why}"),
-                    entry.origin.clone(),
-                ));
+                resolved.warnings.push(
+                    Warning::at(
+                        format!("{written_key} is deprecated: {why}"),
+                        entry.origin.clone(),
+                    )
+                    .of(WarningKind::Deprecated),
+                );
             }
             if written_key != meta.key {
                 // Both names: the key the user wrote, and the one it was read as.
-                resolved.warnings.push(Warning::at(
-                    format!("{written_key} was read as {}", meta.key),
-                    entry.origin.clone(),
-                ));
+                resolved.warnings.push(
+                    Warning::at(
+                        format!("{written_key} was read as {}", meta.key),
+                        entry.origin.clone(),
+                    )
+                    .of(WarningKind::Renamed),
+                );
             }
             let index = prop.index();
             let merged = match meta.merge {
@@ -383,6 +389,60 @@ mod tests {
         PropMeta::new("undeclared_default", Ty::String),
     ];
     const REGISTRY: Registry = Registry::new(PROPS);
+
+    #[test]
+    fn every_warning_says_what_sort_of_thing_it_is() {
+        // The message is for a person and its wording is nobody's contract. This is what a program
+        // acts on: mise queues its deprecations until logging is up while a bad value goes to stderr
+        // at once, a `--strict` mode exits on everything but a deprecation, and the conformance
+        // corpus pins what happened without pinning how it was said.
+        let ctx = LayerCtx::new(REGISTRY);
+        let file = Origin::file("hk.toml", FileScope::Project);
+
+        // Every kind this crate produces, from the place that produces it.
+        let unknown = ctx
+            .entry_for_key("nonesuch", "1", file.clone())
+            .expect_err("no such setting");
+        assert_eq!(unknown.kind, WarningKind::UnknownSetting);
+        let wrong = ctx
+            .entry_for_key("jobs", "lots", file.clone())
+            .expect_err("not a number");
+        assert_eq!(wrong.kind, WarningKind::WrongType);
+        let shaped = ctx
+            .entry_from_value("jobs", Value::from("lots"), file.clone())
+            .expect_err("still not a number");
+        assert_eq!(shaped.kind, WarningKind::WrongType);
+
+        // And the three the *merge* adds, which no layer can know about on its own: whether a place
+        // is allowed to set a setting, and what its name turned out to mean.
+        let layer = Fixed {
+            kind: SourceKind::FILE,
+            entries: vec![
+                Entry::new(id("trusted"), Value::Bool(true), file.clone()),
+                // The *unfolded* id, which is what a layer reading `Registry::ids` hands over —
+                // `lookup` folds a rename, so going through it could not reproduce the case.
+                Entry::new(raw_id("renamed_jobs"), Value::Int(8), file),
+            ],
+        };
+        let resolved = resolve(REGISTRY, Layers::new().then(&layer)).expect("resolves");
+        let kinds: Vec<WarningKind> = resolved.warnings.iter().map(|w| w.kind).collect();
+        assert_eq!(
+            kinds,
+            vec![
+                WarningKind::OutOfScope,
+                WarningKind::Deprecated,
+                WarningKind::Renamed
+            ],
+            "{:?}",
+            resolved.warnings
+        );
+
+        // A layer of the CLI's own says whatever it likes, and is not made to invent a kind for it.
+        assert_eq!(
+            Warning::new("the git config could not be read").kind,
+            WarningKind::Other
+        );
+    }
 
     /// A layer holding whatever a test hands it.
     struct Fixed {


### PR DESCRIPTION
Groundwork for the config conformance corpus, and useful on its own.

A warning's *wording* is for a person and is nobody's contract. What a program acts on is the kind,
and until now there wasn't one — `Warning` was a string and an origin, so every consumer that wanted
to treat deprecations differently from bad values had to match on text.

```rust
for warning in &resolved.warnings {
    match warning.kind {
        WarningKind::Deprecated => queued.push(warning),      // mise prints these once logging is up
        WarningKind::NotRead => debug!("{}", warning.message),
        _ => eprintln!("{}", warning.message),
    }
}
```

Seven kinds, one per thing this crate can report — a key nothing declares, a value the type cannot
read, a value the choices do not allow, a place that may not set the setting, a deprecation, a value
read as the setting that replaced it, and a value passed over because another name won — plus
`Other`, which is what a CLI's own layer says. A git or pkl layer complaining that it could not reach
its source is not something this crate should make it invent a kind for, so `Warning::new`/`at` keep
their signatures and `of(kind)` is chained where a kind is known.

**Why now:** the corpus has to pin *what happened* without pinning how it was worded — the same line
the argv corpus holds, where a vector names an error class and never a message. Without kinds, a
config vector would either assert exact English (which no second implementation could pass) or assert
nothing about warnings at all, which would leave the scope strips, the rename folding and the type
refusals — much of what the merge does — untested by the corpus.

## Verification

112 tests. One new test walks every kind back to the place that produces it, including the three the
*merge* adds that no layer can know on its own, and asserts a custom layer's warning stays `Other`.
The env test now pins all three kinds a rename produces at once, which is what living through one
actually looks like. Three mutations — the scope refusal, the fold, and the choices refusal each left
unclassified — kill the right tests.

Next: `corpus/config/*.json` and its runner, which is what this is for.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API change (`#[non_exhaustive]` on Warning and WarningKind); behavior is classification only—messages and resolution logic are unchanged aside from the new field.
> 
> **Overview**
> Adds **`WarningKind`** so callers can treat warnings by category instead of parsing message text. Each **`Warning`** now carries a **`kind`** field; **`Warning::new`** / **`Warning::at`** still default to **`Other`**, and known cases use **`.of(WarningKind::…)`**.
> 
> Resolution paths are tagged end-to-end: unknown keys, wrong types, and disallowed choices in **`LayerCtx`**; scope refusals, deprecations, and rename notices in **`resolve`**; env aliases that lose to another variable as **`NotRead`**. **`WarningKind`** is re-exported from the crate root.
> 
> Tests assert kinds at the producers (including merge-only warnings) and pin the three kinds produced when two old env names compete during a rename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a1b1a671ca1a20b63e4b21b7dd34b82c9751a36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added warning classifications for unknown settings, invalid types, disallowed values, scope issues, deprecated or renamed settings, unread values, and other warnings.
  * Exposed warning categories through the public configuration interface.

* **Bug Fixes**
  * Corrected warning categorization for skipped variables and deprecated or renamed settings.

* **Tests**
  * Expanded coverage to verify warning categories across configuration and resolution scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->