### PR TITLE
feat(argv): read the cursor's position off a real parse

### DIFF
--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -15,6 +15,62 @@
 //! as argv had the line been run — the parser downstream should see exactly what it would see
 //! in a real invocation.
 
+use crate::{Arg, Command, Error, Flag, Parser};
+
+/// Where the cursor is, in the grammar rather than in the line.
+///
+/// What can be typed at a cursor is decided by everything to its left: which command the words
+/// reached, whether a flag is still waiting for its value, which positional comes next, and
+/// whether flag interpretation is still on at all. This is that state, read off a real parse
+/// of the words before the cursor rather than guessed at — so what is offered and what would
+/// be accepted are decided by the same tables.
+#[derive(Debug, Clone, Copy)]
+pub struct Position<'t> {
+    /// The command in scope: the deepest one the words selected.
+    pub cmd: &'t Command<'t>,
+    /// Whether a dash-prefixed word here would still be read as a flag.
+    ///
+    /// False past a `--`, and past the first value of an `automatic` argument — a wrapper
+    /// forwarding to another tool. There is no flag of *this* CLI to offer in either place.
+    pub flags_possible: bool,
+    /// A flag whose value the cursor is at, if the last word was one that takes a value.
+    pub awaiting_value: Option<&'t Flag<'t>>,
+    /// The positional a word here would fill, if any are left.
+    pub next_arg: Option<&'t Arg<'t>>,
+}
+
+/// Walk the words before the cursor, and report what the cursor is at.
+///
+/// Errors are not failures here. A line being completed is by definition unfinished — a flag
+/// with no value yet, a word that names nothing yet — so a parse error means "the grammar runs
+/// out here", which is exactly the position being asked about. The walk stops at the first one
+/// and reports the state it reached, rather than discarding it the way a real parse must.
+pub fn walk<'t>(root: &'t Command<'t>, words: &[String]) -> Position<'t> {
+    let argv: Vec<&std::ffi::OsStr> = words.iter().map(std::ffi::OsStr::new).collect();
+    let mut parser = Parser::new(root, &argv);
+    let mut awaiting_value = None;
+
+    while let Some(event) = parser.next_event() {
+        match event {
+            Ok(_) => {}
+            // The one error that says something about the cursor rather than about the line:
+            // the last word was a flag that takes a value, so the cursor is standing in it.
+            Err(Error::MissingFlagValue { flag }) => {
+                awaiting_value = Some(flag);
+                break;
+            }
+            Err(_) => break,
+        }
+    }
+
+    Position {
+        cmd: parser.command(),
+        flags_possible: !parser.flags_stopped(),
+        awaiting_value,
+        next_arg: parser.pending_arg(),
+    }
+}
+
 /// Which shell's quoting rules a line follows.
 ///
 /// Only two rule sets, not five: bash, zsh, fish and nushell all follow the POSIX shape
@@ -91,6 +147,17 @@ impl Split {
     /// not decide what can be typed at it.
     pub fn walked(&self) -> &[String] {
         &self.words[..=self.cword]
+    }
+
+    /// The words a parser should walk: after the program name, before the cursor's word.
+    ///
+    /// Two things dropped for two reasons. The program name, because argv does not contain it
+    /// and the parse tables describe what comes *after* it. The word being completed, because
+    /// it is half-typed by definition — feeding it in would ask what can follow a word the
+    /// user has not finished, when the question is what that word could be.
+    pub fn argv(&self) -> &[String] {
+        let start = 1.min(self.cword);
+        &self.words[start..self.cword]
     }
 }
 
@@ -267,6 +334,126 @@ fn floor_char_boundary(s: &str, index: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A small tree with the shapes that make a cursor's position non-obvious: a global flag,
+    /// a flag that takes a value, a subcommand of a subcommand, and a wrapper that forwards.
+    static GLOBAL: Flag = Flag {
+        key: 1,
+        name: "verbose",
+        longs: &["verbose"],
+        shorts: b"v",
+        global: true,
+        ..Flag::BOOL
+    };
+    static JOBS: Flag = Flag {
+        key: 2,
+        name: "jobs",
+        longs: &["jobs"],
+        ..Flag::VALUE
+    };
+    static TOOL: Arg = Arg {
+        key: 3,
+        name: "TOOL",
+        ..Arg::REQUIRED
+    };
+    static USE: Command = Command {
+        name: "use",
+        flags: &[&JOBS],
+        args: &[&TOOL],
+        ..Command::EMPTY
+    };
+    static FORWARDED: Arg = Arg {
+        key: 4,
+        name: "ARGS",
+        double_dash: crate::DoubleDash::Automatic,
+        ..Arg::VAR
+    };
+    static EXEC: Command = Command {
+        name: "exec",
+        args: &[&FORWARDED],
+        ..Command::EMPTY
+    };
+    static LS: Command = Command {
+        name: "ls",
+        ..Command::EMPTY
+    };
+    static PLUGINS: Command = Command {
+        name: "plugins",
+        subcommands: &[&LS],
+        ..Command::EMPTY
+    };
+    static ROOT: Command = Command {
+        name: "mise",
+        flags: &[&GLOBAL],
+        subcommands: &[&USE, &EXEC, &PLUGINS],
+        ..Command::EMPTY
+    };
+
+    /// The position at the cursor of a line, which is what a completion asks about.
+    fn position_at(line: &str) -> Position<'static> {
+        let s = at_end(line);
+        walk(&ROOT, s.argv())
+    }
+
+    #[test]
+    fn the_cursor_is_in_the_command_the_words_reached() {
+        assert_eq!(position_at("mise ").cmd.name, "mise");
+        assert_eq!(position_at("mise plugins ").cmd.name, "plugins");
+        assert_eq!(position_at("mise plugins ls ").cmd.name, "ls");
+        // A half-typed word names nothing yet, so it is not descended into: the cursor is
+        // still in the command before it.
+        assert_eq!(position_at("mise plug").cmd.name, "mise");
+    }
+
+    #[test]
+    fn a_flag_that_takes_a_value_puts_the_cursor_in_it() {
+        // The parser calls this a missing value; to a completion it is the question being
+        // asked, and the flag is what decides the answer.
+        let p = position_at("mise use --jobs ");
+        assert_eq!(p.awaiting_value.map(|f| f.name), Some("jobs"));
+
+        // A flag that takes none does not, and neither does one already given its value.
+        assert!(position_at("mise use --jobs 4 ").awaiting_value.is_none());
+        assert!(position_at("mise --verbose ").awaiting_value.is_none());
+    }
+
+    #[test]
+    fn the_next_positional_is_the_one_a_word_would_fill() {
+        assert_eq!(
+            position_at("mise use ").next_arg.map(|a| a.name),
+            Some("TOOL")
+        );
+        // Filled, so there is nothing left for a second word to go into.
+        assert!(position_at("mise use node ").next_arg.is_none());
+        // A variadic keeps taking values, so it is still the answer.
+        assert_eq!(
+            position_at("mise exec a b ").next_arg.map(|a| a.name),
+            Some("ARGS")
+        );
+    }
+
+    #[test]
+    fn flags_stop_being_possible_where_the_parser_stops_reading_them() {
+        assert!(position_at("mise use ").flags_possible);
+        assert!(!position_at("mise use -- ").flags_possible);
+        // And past an `automatic` argument's first value, which is a wrapper forwarding to
+        // another tool: the flags there are the other tool's, and this CLI has none to offer.
+        assert!(!position_at("mise exec node ").flags_possible);
+        assert!(position_at("mise exec ").flags_possible);
+    }
+
+    #[test]
+    fn a_global_flag_is_in_scope_inside_a_subcommand() {
+        // What the parser would accept there is what should be offered there — one rule, read
+        // from the same tables, rather than two that can disagree.
+        let names: Vec<_> = {
+            let argv = [std::ffi::OsStr::new("plugins")];
+            let mut parser = Parser::new(&ROOT, &argv);
+            while parser.next_event().is_some() {}
+            parser.flags_in_scope().map(|f| f.name).collect()
+        };
+        assert!(names.contains(&"verbose"), "{names:?}");
+    }
 
     fn at_end(line: &str) -> Split {
         split(line, line.len(), Shell::Bash)

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -59,6 +59,20 @@ pub fn walk<'t>(root: &'t Command<'t>, words: &[String]) -> Position<'t> {
                 awaiting_value = Some(flag);
                 break;
             }
+            // `ex help config ⌶` is asking which command to read about, and the answer is a
+            // command under `config` — the one the help request already resolved. The parser
+            // never descended into it, on purpose (a topic is a question, not an invocation),
+            // so the position has to be taken from the request rather than from the parser.
+            //
+            // Nothing else can be typed there: a topic takes no flags and fills no argument.
+            Err(Error::Help { cmd, .. }) => {
+                return Position {
+                    cmd,
+                    flags_possible: false,
+                    awaiting_value: None,
+                    next_arg: None,
+                }
+            }
             Err(_) => break,
         }
     }
@@ -440,6 +454,20 @@ mod tests {
         // another tool: the flags there are the other tool's, and this CLI has none to offer.
         assert!(!position_at("mise exec node ").flags_possible);
         assert!(position_at("mise exec ").flags_possible);
+    }
+
+    #[test]
+    fn a_help_topic_puts_the_cursor_under_the_command_it_named() {
+        // `mise help plugins ⌶` asks which command to read about, and the candidates are
+        // `plugins`'s own — not the root's, which is where the parser stayed, since a topic is
+        // resolved without being descended into.
+        let p = position_at("mise help plugins ");
+        assert_eq!(p.cmd.name, "plugins");
+        assert!(!p.flags_possible, "a topic takes no flags");
+        assert!(p.next_arg.is_none(), "and fills no argument");
+
+        // And with no topic yet, the cursor is under the command `help` was typed in.
+        assert_eq!(position_at("mise help ").cmd.name, "mise");
     }
 
     #[test]

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -80,7 +80,9 @@ pub fn walk<'t>(root: &'t Command<'t>, words: &[String]) -> Position<'t> {
     Position {
         cmd: parser.command(),
         flags_possible: !parser.flags_stopped(),
-        awaiting_value,
+        // A variadic flag still claiming words is standing in the same place a flag waiting
+        // for its first value is: the next word belongs to it, not to the positional after it.
+        awaiting_value: awaiting_value.or_else(|| parser.collecting()),
         next_arg: parser.pending_arg(),
     }
 }
@@ -365,6 +367,14 @@ mod tests {
         longs: &["jobs"],
         ..Flag::VALUE
     };
+    /// A flag that keeps claiming words once it has one.
+    static TOOLS: Flag = Flag {
+        key: 8,
+        name: "tools",
+        longs: &["tools"],
+        variadic: true,
+        ..Flag::VALUE
+    };
     static TOOL: Arg = Arg {
         key: 3,
         name: "TOOL",
@@ -372,7 +382,7 @@ mod tests {
     };
     static USE: Command = Command {
         name: "use",
-        flags: &[&JOBS],
+        flags: &[&JOBS, &TOOLS],
         args: &[&TOOL],
         ..Command::EMPTY
     };
@@ -429,6 +439,20 @@ mod tests {
         // A flag that takes none does not, and neither does one already given its value.
         assert!(position_at("mise use --jobs 4 ").awaiting_value.is_none());
         assert!(position_at("mise --verbose ").awaiting_value.is_none());
+    }
+
+    #[test]
+    fn a_variadic_flag_still_claiming_words_holds_the_cursor() {
+        // `mise use --tools node ⌶` — the next word is another tool, because the parser would
+        // bind it to the flag rather than to the positional after it. The state saying so is
+        // cleared by the very call that ends the walk, so it has to be read on the way.
+        let p = position_at("mise use --tools node ");
+        assert_eq!(p.awaiting_value.map(|f| f.name), Some("tools"));
+
+        // Until something that could not be a value comes along, which is when the parser
+        // stops claiming too.
+        let p = position_at("mise use --tools node -- ");
+        assert!(p.awaiting_value.is_none());
     }
 
     #[test]

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -807,6 +807,15 @@ impl<'t, 'v> Parser<'t, 'v> {
         self.flags_stopped
     }
 
+    /// A variadic flag that is still claiming words.
+    ///
+    /// Asked *between* events, because the answer is gone by the end: the call that finds argv
+    /// exhausted is the one that clears it. A completion needs it — the next word after
+    /// `--tools a ⌶` is another tool, not the positional that follows.
+    pub fn collecting(&self) -> Option<&'t Flag<'t>> {
+        self.collecting
+    }
+
     /// The positional the next word would fill, if there is one left.
     ///
     /// A variadic stays here until it reaches its bound, which is what makes it the answer to
@@ -872,7 +881,12 @@ impl<'t, 'v> Parser<'t, 'v> {
                         negated: false,
                     }));
                 }
-                _ => self.collecting = None,
+                // A token that could be something else ends the run — but the *end of argv*
+                // decides nothing. Clearing there threw away the answer to "would the next
+                // word be claimed?", which is the question a completion asks and no parse
+                // ever does: once argv is exhausted there are no more events either way.
+                Some(_) => self.collecting = None,
+                None => {}
             }
         }
 

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -798,6 +798,32 @@ impl<'t, 'v> Parser<'t, 'v> {
         self.separator_seen
     }
 
+    /// Whether flag interpretation has stopped, for any reason.
+    ///
+    /// Wider than [`double_dash_seen`](Self::double_dash_seen), and the question completion
+    /// asks: past a separator *or* past the first value of an `automatic` argument, a
+    /// dash-prefixed word is a value, so there is no flag there to offer.
+    pub fn flags_stopped(&self) -> bool {
+        self.flags_stopped
+    }
+
+    /// The positional the next word would fill, if there is one left.
+    ///
+    /// A variadic stays here until it reaches its bound, which is what makes it the answer to
+    /// "what could go where the cursor is" as many times as it can be filled.
+    pub fn pending_arg(&self) -> Option<&'t Arg<'t>> {
+        self.next_arg()
+    }
+
+    /// Flags a word here could name: this command's own, then any ancestor's globals.
+    ///
+    /// The same set the parser itself would look in, so what is offered and what is accepted
+    /// cannot disagree — including the shadowing rule, where a subcommand redeclaring an
+    /// inherited name hides it.
+    pub fn flags_in_scope(&self) -> impl Iterator<Item = &'t Flag<'t>> + '_ {
+        self.in_scope()
+    }
+
     /// Read the next event.
     ///
     /// Returns `None` when `argv` is exhausted. An `Err` is terminal: the parse


### PR DESCRIPTION
What can be typed at a cursor is decided by everything to its left: which command
the words reached, whether a flag is still waiting for its value, which positional
comes next, and whether flag interpretation is still on. `walk` reads that state
off an actual parse of the words before the cursor, so what a completion offers
and what the parser would accept are decided by the same tables — including the
shadowing rule, where a subcommand redeclaring an inherited global hides it.

A parse error is not a failure here. A line being completed is unfinished by
definition, so "the grammar runs out here" is the position being asked about
rather than a reason to discard the attempt. One error says something more: a
missing flag value means the cursor is standing in that value, which is what
decides the candidates.

`flags_possible` asks the wider question than `double_dash_seen`: past a
separator *or* past the first value of an `automatic` argument, a dash-prefixed
word is a value, and the flags there belong to whatever the wrapper forwards to.

`Split::argv` keeps the index arithmetic in one place. Two words are dropped for
two reasons — the program name, because argv does not contain it, and the word
being completed, because feeding a half-typed word in asks what can follow it when
the question is what it could be.

Three small accessors on the parser rather than a second walker: `flags_stopped`,
`pending_arg`, `flags_in_scope`. Every rule here fails a test when inverted.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Completion-only API and a targeted parser state fix for EOF during variadic flags; behavior is covered by new tests and does not alter successful full-line parsing paths.
> 
> **Overview**
> Adds **shell completion positioning** in `complete`: `Position` and **`walk`** parse the words before the cursor (via `Split::argv`) and report the active command, whether flags are still allowed, any flag waiting for a value, and the next positional—using the same parser tables as a real invocation, including help-topic and variadic-flag edge cases.
> 
> Exposes **`flags_stopped`**, **`collecting`**, **`pending_arg`**, and **`flags_in_scope`** on `Parser` so completion can query state without duplicating binding logic.
> 
> Fixes variadic-flag **collecting** so reaching **end of argv** no longer clears `collecting`; only a following token that ends the run does, so completion can tell the next word still belongs to the flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abea8b716d0cbc0f1ef94166ee9e332f3a4b5d1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->