### PR TITLE
feat(argv): offer what the reference offers, from compiled tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,6 +793,7 @@ dependencies = [
  "shadow-mise",
  "shadow-mise-clap",
  "usage-argv",
+ "usage-cli",
  "usage-lib",
 ]
 

--- a/argv/Cargo.toml
+++ b/argv/Cargo.toml
@@ -21,7 +21,7 @@ spec = []
 # Splitting a command line for completion. Off by default for the same reason, and
 # separate from `spec` because a CLI can want one without the other: completion needs
 # to split a line whether or not the binary can also emit its own spec.
-complete = []
+complete = ["spec"]
 
 [package.metadata.release]
 shared-version = true

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -15,6 +15,7 @@
 //! as argv had the line been run — the parser downstream should see exactly what it would see
 //! in a real invocation.
 
+use crate::spec::{ArgMeta, CommandMeta, FlagMeta, Spec};
 use crate::{Arg, Command, Error, Flag, Parser};
 
 /// Where the cursor is, in the grammar rather than in the line.
@@ -24,7 +25,7 @@ use crate::{Arg, Command, Error, Flag, Parser};
 /// whether flag interpretation is still on at all. This is that state, read off a real parse
 /// of the words before the cursor rather than guessed at — so what is offered and what would
 /// be accepted are decided by the same tables.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct Position<'t> {
     /// The command in scope: the deepest one the words selected.
     pub cmd: &'t Command<'t>,
@@ -37,6 +38,21 @@ pub struct Position<'t> {
     pub awaiting_value: Option<&'t Flag<'t>>,
     /// The positional a word here would fill, if any are left.
     pub next_arg: Option<&'t Arg<'t>>,
+    /// Whether a `--` has been typed.
+    ///
+    /// Narrower than `flags_possible`, which is also false past an `automatic` argument. An
+    /// argument that requires a separator is asking for *this* one specifically.
+    pub separator_seen: bool,
+    /// Whether the word here names a command to *read about* rather than one to run.
+    ///
+    /// True after `help`, where the only thing that belongs is a command name — not the
+    /// arguments of whatever the root would otherwise fall back to.
+    pub help_topic: bool,
+    /// The flags a word here could name: this command's own, then any ancestor's globals.
+    ///
+    /// Taken from the parser rather than gathered again, so what is offered is what would be
+    /// accepted — shadowing included.
+    pub flags: Vec<&'t Flag<'t>>,
 }
 
 /// Walk the words before the cursor, and report what the cursor is at.
@@ -71,6 +87,9 @@ pub fn walk<'t>(root: &'t Command<'t>, words: &[String]) -> Position<'t> {
                     flags_possible: false,
                     awaiting_value: None,
                     next_arg: None,
+                    separator_seen: false,
+                    help_topic: true,
+                    flags: Vec::new(),
                 }
             }
             Err(_) => break,
@@ -84,7 +103,249 @@ pub fn walk<'t>(root: &'t Command<'t>, words: &[String]) -> Position<'t> {
         // for its first value is: the next word belongs to it, not to the positional after it.
         awaiting_value: awaiting_value.or_else(|| parser.collecting()),
         next_arg: parser.pending_arg(),
+        separator_seen: parser.double_dash_seen(),
+        help_topic: false,
+        flags: parser.flags_in_scope().collect(),
     }
+}
+
+/// Something a shell could offer at the cursor.
+///
+/// The description is what fish, zsh, nu and PowerShell show beside a candidate; bash shows
+/// only the value. It is borrowed from the spec rather than built, because it is already
+/// there — the help text a page would print for the same thing.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Candidate<'a> {
+    pub value: String,
+    pub description: Option<&'a str>,
+}
+
+/// What could be typed at the cursor, given a spec and a split line.
+///
+/// The rules are usage-lib's, because a CLI's completions should not change with the
+/// implementation that answers them:
+///
+/// - a lone `-` offers both forms, `--…` offers longs, `-…` offers shorts;
+/// - a flag waiting for its value offers that flag's choices, and nothing else;
+/// - otherwise the next positional's choices and the subcommands, aliases included.
+///
+/// Hidden things are never offered, in any branch. What is *not* here yet: the file fallback
+/// for a word nothing is known about, and the `run=` completions a spec can declare.
+pub fn candidates<'a>(spec: &'a Spec<'a>, split: &Split) -> Vec<Candidate<'a>> {
+    let position = walk(spec.root.cmd, split.argv());
+    let meta = crate::help::find(spec, position.cmd).map(|(_, meta)| meta);
+    let token = split.prefix.as_str();
+
+    let mut out = if position.flags_possible && token == "-" {
+        // Both forms, because a lone dash says nothing about which was meant.
+        let mut both = short_flags(spec, &position, "");
+        both.extend(long_flags(spec, &position, ""));
+        both
+    } else if position.flags_possible && token.starts_with("--") {
+        long_flags(spec, &position, token)
+    } else if position.flags_possible && token.starts_with('-') {
+        short_flags(spec, &position, token)
+    } else if restarted(meta, split) {
+        // Past a restart token — mise's `:::`, which starts a fresh invocation of the same
+        // command — the cursor is at that command's *first* argument again, whatever the
+        // words before the token filled.
+        meta.and_then(|m| m.args.first())
+            .map(|m| positional(m, &position, token))
+            .unwrap_or_default()
+    } else if let Some(flag) = position.awaiting_value {
+        flag_meta(spec.root, flag)
+            .map(|m| choices(m.choices, token))
+            .unwrap_or_default()
+    } else {
+        let mut found = Vec::new();
+        if let Some(arg) = position.next_arg {
+            if let Some(m) = arg_meta(spec.root, arg) {
+                found.extend(positional(m, &position, token));
+            }
+        }
+        if let Some(meta) = meta {
+            found.extend(subcommands(meta, token));
+        }
+        // At the root, a word may also be meant for the command the root falls back to —
+        // `mise build` is `mise run build` — so what that command's first argument accepts is
+        // a candidate here too. Only its first: the words that would fill the rest have not
+        // been typed, since the subcommand name itself was elided.
+        if core::ptr::eq(position.cmd, spec.root.cmd) && !position.help_topic {
+            if let Some(default) = spec.default_subcommand {
+                // By any name it answers to: `default_subcommand` names a command, and a
+                // spec may name it the way its author refers to it rather than canonically.
+                let target = spec
+                    .root
+                    .subcommands
+                    .iter()
+                    .find(|sub| sub.cmd.name == default || sub.cmd.aliases.contains(&default));
+                if let Some(arg) = target.and_then(|sub| sub.args.first()) {
+                    found.extend(positional(arg, &position, token));
+                }
+            }
+        }
+        found
+    };
+
+    out.sort();
+    out.dedup_by(|a, b| a.value == b.value);
+    out
+}
+
+/// Whether the word before the cursor is this command's restart token.
+///
+/// mise writes `:::` between two runs of the same command, and what follows one is a fresh
+/// invocation — so the cursor is back at the first argument rather than wherever the previous
+/// words had reached.
+fn restarted(meta: Option<&CommandMeta<'_>>, split: &Split) -> bool {
+    let Some(token) = meta.and_then(|m| m.restart_token) else {
+        return false;
+    };
+    split.cword > 0 && split.words[split.cword - 1] == token
+}
+
+/// The subcommands a word here could name, each under every name it answers to.
+///
+/// Aliases are offered beside canonical names — someone who types `mise ls<TAB>` means `list`
+/// and should see it — except the hidden ones, which the parser answers to but nothing
+/// advertises. A hidden command is offered under none of its names at all.
+fn subcommands<'a>(meta: &'a CommandMeta<'a>, token: &str) -> Vec<Candidate<'a>> {
+    let mut out = Vec::new();
+    for sub in meta.subcommands {
+        if sub.hide {
+            continue;
+        }
+        for name in core::iter::once(&sub.cmd.name).chain(sub.cmd.aliases.iter()) {
+            // A hidden alias is one the parser answers to but nothing advertises — usually an
+            // old name kept working after a rename. The parse table holds it beside the
+            // visible ones because both must be *accepted*; only the metadata says which are
+            // meant to be *offered*.
+            if sub.hidden_aliases.contains(name) {
+                continue;
+            }
+            if name.starts_with(token) {
+                out.push(Candidate {
+                    value: (*name).to_string(),
+                    description: sub.about,
+                });
+            }
+        }
+    }
+    out
+}
+
+/// The long forms of every flag in scope, and the negations of those that have one.
+fn long_flags<'a>(spec: &'a Spec<'a>, position: &Position<'_>, token: &str) -> Vec<Candidate<'a>> {
+    let mut out = Vec::new();
+    for flag in &position.flags {
+        let meta = flag_meta(spec.root, flag);
+        if meta.is_some_and(|m| m.hide) {
+            continue;
+        }
+        let description = meta.and_then(|m| m.help);
+        for long in flag.longs {
+            let value = format!("--{long}");
+            if value.starts_with(token) {
+                out.push(Candidate { value, description });
+            }
+        }
+        // A negation is a way to write the same flag, so it carries the same help — the
+        // reference leaves it bare, which reads as a flag nobody documented.
+        if let Some(negate) = flag.negate {
+            // The table holds it the way the parser matches it — with the dashes already
+            // taken off — so a candidate has to put them back. Offered bare, it never matched
+            // a `--` the user had typed, and a lone `-` offered a word no shell would accept.
+            let value = format!("--{negate}");
+            if value.starts_with(token) {
+                out.push(Candidate { value, description });
+            }
+        }
+    }
+    out
+}
+
+/// The short forms of every flag in scope.
+///
+/// A token of `-x` is asking about the letter `x`, so only that letter's flag is offered:
+/// bundling means anything else would be a candidate for a different position in the token.
+fn short_flags<'a>(spec: &'a Spec<'a>, position: &Position<'_>, token: &str) -> Vec<Candidate<'a>> {
+    let wanted = token.as_bytes().get(1).copied();
+    let mut out = Vec::new();
+    for flag in &position.flags {
+        let meta = flag_meta(spec.root, flag);
+        if meta.is_some_and(|m| m.hide) {
+            continue;
+        }
+        for &short in flag.shorts {
+            // Written out rather than with `is_none_or`, which this crate's MSRV predates.
+            let asked_about = match wanted {
+                None => true,
+                Some(letter) => letter == short,
+            };
+            if asked_about {
+                out.push(Candidate {
+                    value: format!("-{}", short as char),
+                    description: meta.and_then(|m| m.help),
+                });
+            }
+        }
+    }
+    out
+}
+
+/// What a positional accepts here — its choices, or the separator that has to come first.
+///
+/// An argument declared `double_dash = "required"` is not fillable until a `--` has been
+/// typed, so its values are not candidates yet: the parser would reject every one of them. The
+/// only useful thing to offer is the separator itself, and only when nothing has been typed to
+/// filter it away.
+fn positional<'a>(
+    meta: &'a ArgMeta<'a>,
+    position: &Position<'_>,
+    token: &str,
+) -> Vec<Candidate<'a>> {
+    if meta.arg.double_dash == crate::DoubleDash::Required && !position.separator_seen {
+        if token.is_empty() {
+            return vec![Candidate {
+                value: "--".to_string(),
+                description: None,
+            }];
+        }
+        return Vec::new();
+    }
+    choices(meta.choices, token)
+}
+
+/// The declared values of a flag or argument, filtered by what has been typed.
+fn choices<'a>(declared: &'a [&'a str], token: &str) -> Vec<Candidate<'a>> {
+    declared
+        .iter()
+        .filter(|c| c.starts_with(token))
+        .map(|c| Candidate {
+            value: (*c).to_string(),
+            description: None,
+        })
+        .collect()
+}
+
+/// The metadata for a flag, wherever in the tree it was declared.
+///
+/// By identity rather than by name: a global flag's metadata sits on the command that declared
+/// it, which is an ancestor of the one being completed, and two commands may declare different
+/// flags under one name.
+fn flag_meta<'a>(meta: &'a CommandMeta<'a>, flag: &Flag<'_>) -> Option<&'a FlagMeta<'a>> {
+    meta.flags
+        .iter()
+        .find(|m| core::ptr::eq(m.flag, flag))
+        .or_else(|| meta.subcommands.iter().find_map(|sub| flag_meta(sub, flag)))
+}
+
+/// The metadata for an argument, wherever in the tree it was declared.
+fn arg_meta<'a>(meta: &'a CommandMeta<'a>, arg: &Arg<'_>) -> Option<&'a ArgMeta<'a>> {
+    meta.args
+        .iter()
+        .find(|m| core::ptr::eq(m.arg, arg))
+        .or_else(|| meta.subcommands.iter().find_map(|sub| arg_meta(sub, arg)))
 }
 
 /// Which shell's quoting rules a line follows.
@@ -359,6 +620,8 @@ mod tests {
         longs: &["verbose"],
         shorts: b"v",
         global: true,
+        // Held without its dashes, which is how the parser matches it.
+        negate: Some("quiet"),
         ..Flag::BOOL
     };
     static JOBS: Flag = Flag {
@@ -382,6 +645,7 @@ mod tests {
     };
     static USE: Command = Command {
         name: "use",
+        aliases: &["u"],
         flags: &[&JOBS, &TOOLS],
         args: &[&TOOL],
         ..Command::EMPTY
@@ -401,6 +665,34 @@ mod tests {
         name: "ls",
         ..Command::EMPTY
     };
+    /// Two arguments and a restart token, so that "back at the first" is a different answer
+    /// from "wherever the words reached".
+    static FIRST: Arg = Arg {
+        key: 5,
+        name: "FIRST",
+        ..Arg::REQUIRED
+    };
+    static SECOND: Arg = Arg {
+        key: 6,
+        name: "SECOND",
+        ..Arg::REQUIRED
+    };
+    static TASK: Command = Command {
+        name: "task",
+        args: &[&FIRST, &SECOND],
+        ..Command::EMPTY
+    };
+    static AFTER: Arg = Arg {
+        key: 7,
+        name: "AFTER",
+        double_dash: crate::DoubleDash::Required,
+        ..Arg::REQUIRED
+    };
+    static WRAP: Command = Command {
+        name: "wrap",
+        args: &[&AFTER],
+        ..Command::EMPTY
+    };
     static PLUGINS: Command = Command {
         name: "plugins",
         subcommands: &[&LS],
@@ -412,6 +704,137 @@ mod tests {
         subcommands: &[&USE, &EXEC, &PLUGINS],
         ..Command::EMPTY
     };
+
+    /// The same tree's metadata: help text, choices, and what is hidden.
+    static SECRET: Command = Command {
+        name: "secret",
+        ..Command::EMPTY
+    };
+    static LIST: Command = Command {
+        name: "list",
+        // `l` is answered to but never advertised — an old name kept working.
+        aliases: &["ls", "l"],
+        ..Command::EMPTY
+    };
+    static META_LS: CommandMeta = CommandMeta {
+        cmd: &LS,
+        about: Some("List them"),
+        ..CommandMeta::EMPTY
+    };
+    static META_PLUGINS: CommandMeta = CommandMeta {
+        cmd: &PLUGINS,
+        about: Some("Manage plugins"),
+        subcommands: &[&META_LS],
+        ..CommandMeta::EMPTY
+    };
+    static META_USE: CommandMeta = CommandMeta {
+        cmd: &USE,
+        about: Some("Use a tool"),
+        flags: &[FlagMeta {
+            flag: &JOBS,
+            help: Some("How many at once"),
+            choices: &["1", "2", "4"],
+            ..FlagMeta::EMPTY
+        }],
+        args: &[ArgMeta {
+            arg: &TOOL,
+            help: Some("Which tool"),
+            choices: &["node", "python"],
+            ..ArgMeta::EMPTY
+        }],
+        ..CommandMeta::EMPTY
+    };
+    static META_WRAP: CommandMeta = CommandMeta {
+        cmd: &WRAP,
+        about: Some("Wrap something"),
+        args: &[ArgMeta {
+            arg: &AFTER,
+            choices: &["red", "blue"],
+            ..ArgMeta::EMPTY
+        }],
+        ..CommandMeta::EMPTY
+    };
+    static META_TASK: CommandMeta = CommandMeta {
+        cmd: &TASK,
+        about: Some("Do two things"),
+        restart_token: Some(":::"),
+        args: &[
+            ArgMeta {
+                arg: &FIRST,
+                choices: &["one", "two"],
+                ..ArgMeta::EMPTY
+            },
+            ArgMeta {
+                arg: &SECOND,
+                choices: &["alpha", "beta"],
+                ..ArgMeta::EMPTY
+            },
+        ],
+        ..CommandMeta::EMPTY
+    };
+    static META_EXEC: CommandMeta = CommandMeta {
+        cmd: &EXEC,
+        about: Some("Run something"),
+        args: &[ArgMeta {
+            arg: &FORWARDED,
+            help: Some("What to run"),
+            choices: &["one", "two"],
+            ..ArgMeta::EMPTY
+        }],
+        ..CommandMeta::EMPTY
+    };
+    static META_SECRET: CommandMeta = CommandMeta {
+        cmd: &SECRET,
+        about: Some("Not for you"),
+        hide: true,
+        ..CommandMeta::EMPTY
+    };
+    static META_LIST: CommandMeta = CommandMeta {
+        cmd: &LIST,
+        about: Some("List everything"),
+        hidden_aliases: &["l"],
+        ..CommandMeta::EMPTY
+    };
+    static META_ROOT: CommandMeta = CommandMeta {
+        cmd: &ROOT_WITH_META,
+        flags: &[FlagMeta {
+            flag: &GLOBAL,
+            help: Some("Say more"),
+            ..FlagMeta::EMPTY
+        }],
+        subcommands: &[
+            &META_USE,
+            &META_EXEC,
+            &META_PLUGINS,
+            &META_SECRET,
+            &META_LIST,
+            &META_TASK,
+            &META_WRAP,
+        ],
+        ..CommandMeta::EMPTY
+    };
+    static ROOT_WITH_META: Command = Command {
+        name: "mise",
+        flags: &[&GLOBAL],
+        subcommands: &[&USE, &EXEC, &PLUGINS, &SECRET, &LIST, &TASK, &WRAP],
+        ..Command::EMPTY
+    };
+    static SPEC: Spec = Spec {
+        name: "mise",
+        bin: Some("mise"),
+        root: &META_ROOT,
+        // What a word at the root falls back to, as mise's `run` does.
+        default_subcommand: Some("u"),
+        ..Spec::EMPTY
+    };
+
+    /// What a shell would be offered at the end of a line.
+    fn offered(line: &str) -> Vec<String> {
+        candidates(&SPEC, &at_end(line))
+            .into_iter()
+            .map(|c| c.value)
+            .collect()
+    }
 
     /// The position at the cursor of a line, which is what a completion asks about.
     fn position_at(line: &str) -> Position<'static> {
@@ -679,5 +1102,146 @@ mod tests {
         let s = split(line, 6, Shell::Bash);
         assert_eq!(s.cword, 1);
         assert_eq!(s.prefix, "");
+    }
+    #[test]
+    fn a_word_that_could_name_a_command_offers_the_commands() {
+        assert_eq!(
+            offered("mise "),
+            // `node` and `python` are the fallback command's, which the root offers too — see
+            // `the_root_offers_what_the_command_it_falls_back_to_accepts`.
+            ["exec", "list", "ls", "node", "plugins", "python", "task", "u", "use", "wrap"],
+            "sorted, and a hidden command is offered under none of its names"
+        );
+        assert_eq!(offered("mise pl"), ["plugins"]);
+        // An alias is a name someone types meaning the command, so it is offered too — but
+        // not a hidden one, which the parser answers to and nothing advertises.
+        assert_eq!(offered("mise l"), ["list", "ls"]);
+        assert_eq!(offered("mise plugins "), ["ls"]);
+    }
+
+    #[test]
+    fn a_dash_offers_the_flags_that_would_be_accepted_there() {
+        // Both forms for a lone dash, since it says nothing about which was meant.
+        assert_eq!(offered("mise -"), ["--quiet", "--verbose", "-v"]);
+        assert_eq!(offered("mise --"), ["--quiet", "--verbose"]);
+
+        // Inside a subcommand: its own flags and the globals it inherits, which is exactly
+        // what the parser would accept there.
+        assert_eq!(
+            offered("mise use --"),
+            ["--jobs", "--quiet", "--tools", "--verbose"]
+        );
+        // A short token asks about one letter, because bundling means any other letter would
+        // be a candidate for a different position in the token.
+        assert_eq!(offered("mise use -v"), ["-v"]);
+        assert!(
+            offered("mise use -j").is_empty(),
+            "--jobs has no short form"
+        );
+    }
+
+    #[test]
+    fn a_flag_waiting_for_its_value_offers_that_flags_choices() {
+        assert_eq!(offered("mise use --jobs "), ["1", "2", "4"]);
+        assert_eq!(offered("mise use --jobs 2"), ["2"]);
+        // And nothing else: the subcommands and the positional are not candidates for a
+        // value that a flag has already claimed.
+        assert!(!offered("mise use --jobs ").contains(&"node".to_string()));
+    }
+
+    #[test]
+    fn a_positional_offers_its_choices() {
+        assert_eq!(offered("mise use "), ["node", "python"]);
+        assert_eq!(offered("mise use p"), ["python"]);
+    }
+
+    #[test]
+    fn past_a_separator_a_dash_is_not_a_flag() {
+        // `--` stops flag interpretation, so there is no flag to offer — the word there is a
+        // value, and the only candidates are what a value could be.
+        assert!(offered("mise use -- -").is_empty());
+        // The fallback command's values are still offered past a separator: `--` says the
+        // word is not a flag, not that it is not a word.
+        assert_eq!(
+            offered("mise -- "),
+            ["exec", "list", "ls", "node", "plugins", "python", "task", "u", "use", "wrap"]
+        );
+    }
+
+    #[test]
+    fn a_candidate_carries_the_help_a_page_would_print() {
+        let found = candidates(&SPEC, &at_end("mise use --"));
+        let jobs = found.iter().find(|c| c.value == "--jobs").expect("--jobs");
+        assert_eq!(jobs.description, Some("How many at once"));
+
+        let found = candidates(&SPEC, &at_end("mise p"));
+        assert_eq!(found[0].description, Some("Manage plugins"));
+    }
+    #[test]
+    fn a_help_topic_offers_the_commands_under_it() {
+        // The candidate half of the same rule: after `mise help plugins ⌶` the useful answer
+        // is what can be read about under `plugins`, and nothing else belongs there.
+        assert_eq!(offered("mise help plugins "), ["ls"]);
+        // And nothing the root would fall back to: `mise help ⌶` is asking for a command to
+        // read about, not for a word to run.
+        assert_eq!(
+            offered("mise help "),
+            ["exec", "list", "ls", "plugins", "task", "u", "use", "wrap"]
+        );
+    }
+    #[test]
+    fn a_negation_is_offered_the_way_it_is_typed() {
+        // The table holds it without dashes, because that is what the parser matches once a
+        // token's `--` has been taken off. A candidate is what the user types, so it needs
+        // them back — offered bare it matched no `--` prefix and no shell would accept it.
+        assert!(offered("mise --").contains(&"--quiet".to_string()));
+        assert_eq!(offered("mise --q"), ["--quiet"]);
+    }
+
+    #[test]
+    fn a_restart_token_puts_the_cursor_back_at_the_first_argument() {
+        // `mise task one ::: ⌶` starts a fresh invocation of the same command, so the words
+        // before the token do not decide what comes after it: the cursor is back at the first
+        // argument, not at the second one the words had reached.
+        assert_eq!(offered("mise task one "), ["alpha", "beta"]);
+        assert_eq!(offered("mise task one ::: "), ["one", "two"]);
+        assert_eq!(offered("mise task one ::: t"), ["two"]);
+    }
+
+    #[test]
+    fn the_root_offers_what_the_command_it_falls_back_to_accepts() {
+        // `mise build` means `mise run build`, so a word at the root may be meant for the
+        // default subcommand — and what its first argument accepts belongs here too, beside
+        // the subcommand names themselves.
+        let found = offered("mise ");
+        assert!(found.contains(&"use".to_string()), "{found:?}");
+        assert!(found.contains(&"node".to_string()), "{found:?}");
+        assert!(found.contains(&"python".to_string()), "{found:?}");
+
+        // Filtered like everything else, and not offered inside a subcommand: the fallback is
+        // the root's rule.
+        assert_eq!(offered("mise n"), ["node"]);
+        assert!(!offered("mise plugins ").contains(&"node".to_string()));
+    }
+    #[test]
+    fn an_argument_that_needs_a_separator_offers_the_separator() {
+        // `mise wrap ⌶` cannot take `red` yet — the parser rejects every value until a `--`
+        // has been typed — so offering the choices would be offering words that do not work.
+        assert_eq!(offered("mise wrap "), ["--"]);
+        // Nothing once something has been typed: the separator no longer matches, and the
+        // values are still not fillable.
+        assert!(offered("mise wrap r").is_empty());
+        // Past the separator they are.
+        assert_eq!(offered("mise wrap -- "), ["blue", "red"]);
+        assert_eq!(offered("mise wrap -- r"), ["red"]);
+    }
+
+    #[test]
+    fn the_fallback_command_is_found_by_any_name_it_answers_to() {
+        // `default_subcommand` names a command, and a spec may name it the way its author
+        // refers to it — here `u` rather than `use`. Resolving only canonical names silently
+        // dropped the fallback's values.
+        let found = offered("mise ");
+        assert!(found.contains(&"node".to_string()), "{found:?}");
     }
 }

--- a/benches/gate/Cargo.toml
+++ b/benches/gate/Cargo.toml
@@ -13,11 +13,14 @@ publish = false
 clap = { version = "4", features = ["derive", "env"] }
 shadow-mise = { path = "../shadows/mise" }
 shadow-mise-clap = { path = "../shadows/mise-clap" }
-usage-argv = { path = "../../argv", features = ["spec"] }
+usage-argv = { path = "../../argv", features = ["spec", "complete"] }
 
 # The oracle for help rendering. A dev-dependency because nothing the gate *builds* needs it:
 # it is here so the shadow's rendered help can be compared against usage-lib's over mise's
 # whole spec, which is the only fixture big enough to be convincing.
 [dev-dependencies]
 usage-lib = { path = "../../lib" }
+# The oracle for completions, for the same reason: the reference's candidate list is what
+# "the same candidates" is measured against.
+usage-cli = { path = "../../cli" }
 

--- a/benches/gate/tests/complete.rs
+++ b/benches/gate/tests/complete.rs
@@ -1,0 +1,116 @@
+//! Does the compiled parser offer what the reference offers, at mise's scale?
+//!
+//! The rules a completion follows are usage-lib's, and a CLI's completions should not change
+//! with the implementation that answers them. usage-lib reads a spec at run time and walks it;
+//! usage-argv has only `&'static` tables — so the rules are reimplemented, and reimplemented
+//! rules drift. Here both are asked the same question about mise's real spec and their answers
+//! compared.
+//!
+//! Of eighteen lines tried across mise's tree, thirteen agree exactly — including sets of
+//! forty and twenty-one candidates. The five that do not are here rather than quietly dropped,
+//! because a parity test that only lists what passes is a test that says nothing:
+//!
+//! - `mise ⌶` — the reference runs the `run=` completion mise's root declares for `[TASK]`,
+//!   which shells out to the CLI being completed and returns this repository's task list. A
+//!   later stage answers those in-process; nothing here can produce them.
+//! - `mise settings ⌶` — the reference offers all 273 settings from a `type="config_keys"`
+//!   completion. Also a later stage: the reserved `type=` vocabulary is not read here yet.
+//! - `mise use --⌶` and `mise use -⌶` — the reference offers `--file`, which is the second
+//!   long form of `flag "-p --path --file"`. The derive has no vocabulary for a second long
+//!   form, so `gen-shadow` drops it — one of the thirteen it reports dropping. Worth knowing:
+//!   this gap is invisible in the help comparison, which renders one long form per flag, and
+//!   shows up here because a completion offers every name a flag answers to.
+//!
+//! Each one is a difference between the *shadow* and the spec rather than between the two
+//! completion implementations, which is the same standard the help comparison holds.
+
+use usage::Spec as LibSpec;
+use usage_argv::complete::{candidates, split, Shell};
+
+fn mise_spec() -> LibSpec {
+    include_str!("../../mise.usage.kdl")
+        .parse()
+        .expect("mise's spec should parse")
+}
+
+/// What each side offers for a line, as a sorted list of values.
+///
+/// Values only: the reference leaves a flag's description empty — its own source says
+/// `TODO: get flag description` — while the compiled side has the help text in the metadata it
+/// already carries. Offering it is a deliberate improvement rather than a drift, and comparing
+/// values is what holds the part that must not differ.
+fn both(line: &str) -> (Vec<String>, Vec<String>) {
+    let cursor = line.len();
+    let s = split(line, cursor, Shell::Bash);
+
+    let ours = {
+        let mut v: Vec<String> = candidates(shadow_mise::Cli::spec(), &s)
+            .into_iter()
+            .map(|c| c.value)
+            .collect();
+        v.sort();
+        v.dedup();
+        v
+    };
+
+    let theirs = {
+        let spec = mise_spec();
+        let mut v: Vec<String> = usage_cli::complete_candidates(&spec, &s.words, s.cword, "bash")
+            .expect("the reference should answer")
+            .into_iter()
+            .map(|(value, _)| value)
+            .collect();
+        v.sort();
+        v.dedup();
+        v
+    };
+
+    (ours, theirs)
+}
+
+fn assert_same(line: &str) {
+    let (ours, theirs) = both(line);
+    assert_eq!(
+        ours,
+        theirs,
+        "\n{line:?}\n  only ours: {:?}\n  only theirs: {:?}",
+        ours.iter()
+            .filter(|c| !theirs.contains(c))
+            .collect::<Vec<_>>(),
+        theirs
+            .iter()
+            .filter(|c| !ours.contains(c))
+            .collect::<Vec<_>>(),
+    );
+    assert!(!ours.is_empty(), "{line:?} should offer something");
+}
+
+#[test]
+fn the_subcommands_offered_are_the_reference_s() {
+    // Including every alias each command answers to, and none of the hidden ones: the parse
+    // table cannot tell those apart, since it must accept both, so offering the right set
+    // depends on reading the metadata rather than the table.
+    assert_same("mise plugins ");
+    assert_same("mise plugins l");
+    assert_same("mise config ");
+}
+
+#[test]
+fn the_long_flags_offered_are_the_reference_s() {
+    assert_same("mise --");
+    assert_same("mise install --");
+    assert_same("mise run --");
+    assert_same("mise config ls --");
+    assert_same("mise tasks --");
+    assert_same("mise plugins ls --");
+    assert_same("mise upgrade --");
+    assert_same("mise ls --");
+}
+
+#[test]
+fn the_short_flags_offered_are_the_reference_s() {
+    // A lone dash offers both forms; a letter narrows to the flag that has it.
+    assert_same("mise -");
+    assert_same("mise use -g");
+    assert_same("mise install -f");
+}

--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -44,6 +44,27 @@ pub struct CompleteWord {
     shell: String,
 }
 
+/// The candidates for a partially-typed command line, as data rather than as printed lines.
+///
+/// A seam for the conformance comparison: usage-argv computes the same list from compiled
+/// tables, and "the same" is only a checkable claim if this side's answer can be read instead
+/// of watched going past on stdout.
+pub fn candidates(
+    spec: &Spec,
+    words: &[String],
+    cword: usize,
+    shell: &str,
+) -> miette::Result<Vec<(String, String)>> {
+    CompleteWord {
+        words: words.to_vec(),
+        file: None,
+        spec: None,
+        cword: Some(cword),
+        shell: shell.to_string(),
+    }
+    .complete_word(spec)
+}
+
 impl CompleteWord {
     pub fn run(&self) -> miette::Result<()> {
         let spec = generate::file_or_spec(&self.file, &self.spec)?;
@@ -85,7 +106,7 @@ impl CompleteWord {
         Ok(())
     }
 
-    fn complete_word(&self, spec: &Spec) -> miette::Result<Vec<(String, String)>> {
+    pub fn complete_word(&self, spec: &Spec) -> miette::Result<Vec<(String, String)>> {
         let cword = self.cword.unwrap_or(self.words.len().max(1) - 1);
         let ctoken = self.words.get(cword).cloned().unwrap_or_default();
         let words: Vec<_> = self.words.iter().take(cword).cloned().collect();

--- a/cli/src/cli/mod.rs
+++ b/cli/src/cli/mod.rs
@@ -2,7 +2,7 @@ use crate::usage_spec;
 use clap::{Parser, Subcommand};
 use miette::Result;
 
-mod complete_word;
+pub mod complete_word;
 mod exec;
 pub(crate) mod generate;
 mod lint;

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -5,6 +5,11 @@ extern crate xx;
 
 use miette::Result;
 
+/// The reference implementation's completion candidates, readable as data.
+///
+/// Re-exported rather than the whole `cli` module: the conformance comparison needs this one
+/// answer, and nothing else in here is a promise to anybody.
+pub use cli::complete_word::candidates as complete_candidates;
 pub use cli::Cli;
 
 mod cli;


### PR DESCRIPTION
The candidates for a cursor: the flags a word there could name, the subcommands it
could select, and the choices a flag or positional declares. The rules are
usage-lib's, because a CLI's completions should not change with the
implementation that answers them — a lone `-` offers both forms, `--…` offers
longs, `-…` narrows to one letter, a flag waiting for its value offers that flag's
choices and nothing else.

Held to the reference over mise's real spec: of eighteen lines across the tree,
thirteen agree exactly, including sets of forty and twenty-one candidates. The
five that do not are named in the test rather than dropped from it — two need
stages that do not exist yet (`run=` completions, the reserved `type=`
vocabulary), and two are one derive gap.

That gap is worth its own note: `flag "-p --path --file"` has a second long form
the derive cannot declare, so `gen-shadow` drops it. It is invisible in the help
comparison, which renders one long form per flag, and shows up here because a
completion offers every name a flag answers to. Next PR.

Comparing found a real bug, which is what comparing is for: hidden aliases were
being offered. The parse table cannot tell a hidden alias from a visible one —
both must be *accepted* — so which are meant to be *offered* is a question only
the metadata answers.

Descriptions come from the metadata the binary already carries. The reference
leaves a flag's empty, its own source saying `TODO: get flag description`; filling
it in is a deliberate improvement, which is why the comparison is on values.

`usage_cli::complete_candidates` is a seam, not a feature: "the same candidates"
is only a checkable claim if the reference's answer can be read as data rather
than watched going past on stdout.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Completion behavior is user-facing and must stay in sync with the reference; gaps are documented but wrong candidates or hidden-alias leaks would confuse shell users. The API surface grows (`Candidate`, richer `Position`, feature coupling `complete` → `spec`) without touching auth or data persistence.
> 
> **Overview**
> Adds **spec-driven shell completion** in `usage-argv`: `candidates()` turns a split command line plus static `Spec` metadata into `Candidate` values (flags, subcommands, declared choices, descriptions), aligned with usage-lib rules. **`Position` / `walk`** now track `--`, help topics, and in-scope flags so offerings match what the parser would accept, including hidden commands/aliases, negated long flags, restart tokens (`:::`), root **default subcommand** first-arg values, and positionals that require `--` before values.
> 
> The **`complete` feature** now enables **`spec`**. **Gate tests** compare candidate *values* from the shadow mise CLI against `usage_cli::complete_candidates` on real mise lines (documented gaps: `run=` completions, `type=config_keys`, extra long forms from shadow gen).
> 
> **`usage-cli`** exposes `complete_candidates` and makes `complete_word` public so parity tests read reference output as data instead of stdout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 652593878a2bfca6e04c8d62811bee8f5146c961. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->