### PR TITLE
fix(xtask): keep every name a flag answers to

### DIFF
--- a/benches/gate/tests/complete.rs
+++ b/benches/gate/tests/complete.rs
@@ -6,8 +6,8 @@
 //! rules drift. Here both are asked the same question about mise's real spec and their answers
 //! compared.
 //!
-//! Of eighteen lines tried across mise's tree, thirteen agree exactly — including sets of
-//! forty and twenty-one candidates. The five that do not are here rather than quietly dropped,
+//! Of eighteen lines tried across mise's tree, fifteen agree exactly — including sets of forty
+//! and twenty-one candidates. The three that do not are here rather than quietly dropped,
 //! because a parity test that only lists what passes is a test that says nothing:
 //!
 //! - `mise ⌶` — the reference runs the `run=` completion mise's root declares for `[TASK]`,
@@ -15,11 +15,11 @@
 //!   later stage answers those in-process; nothing here can produce them.
 //! - `mise settings ⌶` — the reference offers all 273 settings from a `type="config_keys"`
 //!   completion. Also a later stage: the reserved `type=` vocabulary is not read here yet.
-//! - `mise use --⌶` and `mise use -⌶` — the reference offers `--file`, which is the second
-//!   long form of `flag "-p --path --file"`. The derive has no vocabulary for a second long
-//!   form, so `gen-shadow` drops it — one of the thirteen it reports dropping. Worth knowing:
-//!   this gap is invisible in the help comparison, which renders one long form per flag, and
-//!   shows up here because a completion offers every name a flag answers to.
+//!
+//! A fourth was a real gap, now closed: `flag "-p --path --file"` has a second long form that
+//! `gen-shadow` dropped, so `mise use --⌶` was missing `--file`. The derive could express it
+//! all along. The gap was invisible in the help comparison, which renders one long form per
+//! flag, and showed up here because a completion offers every name a flag answers to.
 //!
 //! Each one is a difference between the *shadow* and the spec rather than between the two
 //! completion implementations, which is the same standard the help comparison holds.
@@ -98,6 +98,8 @@ fn the_subcommands_offered_are_the_reference_s() {
 #[test]
 fn the_long_flags_offered_are_the_reference_s() {
     assert_same("mise --");
+    // Every long form a flag answers to, including the second of `-p --path --file`.
+    assert_same("mise use --");
     assert_same("mise install --");
     assert_same("mise run --");
     assert_same("mise config ls --");
@@ -111,6 +113,7 @@ fn the_long_flags_offered_are_the_reference_s() {
 fn the_short_flags_offered_are_the_reference_s() {
     // A lone dash offers both forms; a letter narrows to the flag that has it.
     assert_same("mise -");
+    assert_same("mise use -");
     assert_same("mise use -g");
     assert_same("mise install -f");
 }

--- a/benches/shadows/mise-clap/src/lib.rs
+++ b/benches/shadows/mise-clap/src/lib.rs
@@ -296,7 +296,7 @@ pub struct BootstrapDotfilesAddArgs {
     #[arg(long = "no-apply")]
     pub no_apply: bool,
     /// Write to this config file or directory
-    #[arg(long = "path", short = 'p', value_name = "PATH")]
+    #[arg(long = "path", short = 'p', alias = "file", value_name = "PATH")]
     pub path: Option<String>,
     /// Source path to use for a single target
     #[arg(long = "source", short = 's', value_name = "PATH")]
@@ -778,7 +778,7 @@ pub struct BootstrapPackagesBrewTapArgs {
     #[arg(long = "dry-run", short = 'n')]
     pub dry_run: bool,
     /// Write to this config file or directory
-    #[arg(long = "path", short = 'p', value_name = "PATH")]
+    #[arg(long = "path", short = 'p', alias = "file", value_name = "PATH")]
     pub path: Option<String>,
     /// Tap name, e.g. `owner/repo`
     #[arg(value_name = "TAP")]
@@ -798,7 +798,7 @@ pub struct BootstrapPackagesBrewUntapArgs {
     #[arg(long = "dry-run", short = 'n')]
     pub dry_run: bool,
     /// Write to this config file or directory
-    #[arg(long = "path", short = 'p', value_name = "PATH")]
+    #[arg(long = "path", short = 'p', alias = "file", value_name = "PATH")]
     pub path: Option<String>,
     /// Tap name(s), e.g. `owner/repo`
     #[arg(value_name = "TAPS", required = true, num_args = 0..)]
@@ -848,7 +848,7 @@ pub struct BootstrapPackagesImportArgs {
     #[arg(long = "dry-run", short = 'n')]
     pub dry_run: bool,
     /// Write to this config file or directory
-    #[arg(long = "path", short = 'p', value_name = "PATH")]
+    #[arg(long = "path", short = 'p', alias = "file", value_name = "PATH")]
     pub path: Option<String>,
 }
 
@@ -931,7 +931,7 @@ pub struct BootstrapPackagesUseArgs {
     #[arg(long = "dry-run", short = 'n')]
     pub dry_run: bool,
     /// Write to this config file or directory
-    #[arg(long = "path", short = 'p', value_name = "PATH")]
+    #[arg(long = "path", short = 'p', alias = "file", value_name = "PATH")]
     pub path: Option<String>,
     /// Skip the confirmation prompt
     #[arg(long = "yes", short = 'y')]
@@ -1566,7 +1566,7 @@ pub struct ConfigGetArgs {
     /// Can be a file path or directory. If a directory is provided, the config file in that directory is used.
     ///
     /// If not provided, the nearest mise.toml file will be used
-    #[arg(long = "file", short = 'f', value_name = "FILE")]
+    #[arg(long = "file", short = 'f', alias = "path", value_name = "FILE")]
     pub file: Option<String>,
     /// The path of the config to display
     #[arg(value_name = "KEY")]
@@ -1595,7 +1595,7 @@ pub struct ConfigSetArgs {
     /// Can be a file path or directory. If a directory is provided, the config file in that directory is used.
     ///
     /// If not provided, the nearest mise.toml file will be used
-    #[arg(long = "file", short = 'f', value_name = "FILE")]
+    #[arg(long = "file", short = 'f', alias = "path", value_name = "FILE")]
     pub file: Option<String>,
     #[arg(long = "type", short = 't', value_name = "TYPE", value_parser = ::clap::builder::PossibleValuesParser::new(["infer", "string", "integer", "float", "bool", "list", "set"]), default_value = "infer")]
     pub type_: Option<String>,
@@ -1725,7 +1725,7 @@ pub struct DotfilesAddArgs {
     #[arg(long = "no-apply")]
     pub no_apply: bool,
     /// Write to this config file or directory
-    #[arg(long = "path", short = 'p', value_name = "PATH")]
+    #[arg(long = "path", short = 'p', alias = "file", value_name = "PATH")]
     pub path: Option<String>,
     /// Source path to use for a single target
     #[arg(long = "source", short = 's', value_name = "PATH")]
@@ -3666,7 +3666,7 @@ pub struct SetArgs {
     /// Can be a file path or directory. If a directory is provided, will create/use mise.toml in that directory.
     /// Defaults to [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) environment variable, or `mise.toml`.
     /// Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
-    #[arg(long = "file", value_name = "FILE")]
+    #[arg(long = "file", alias = "path", value_name = "FILE")]
     pub file: Option<String>,
     /// Show raw values instead of redacting secrets
     #[arg(long = "no-redact")]
@@ -3677,7 +3677,13 @@ pub struct SetArgs {
     /// Remove the environment variable from config file
     ///
     /// Can be used multiple times.
-    #[arg(long = "remove", hide = true, value_name = "ENV_KEY")]
+    #[arg(
+        long = "remove",
+        alias = "rm",
+        alias = "unset",
+        hide = true,
+        value_name = "ENV_KEY"
+    )]
     pub remove: Vec<String>,
     /// Read the value from stdin (for multiline input)
     ///
@@ -4653,7 +4659,7 @@ pub struct UnsetArgs {
     /// Can be a file path or directory. If a directory is provided, will create/use mise.toml in that directory.
     ///
     /// Defaults to [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) environment variable, or `mise.toml`. Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
-    #[arg(long = "file", short = 'f', value_name = "FILE")]
+    #[arg(long = "file", short = 'f', alias = "path", value_name = "FILE")]
     pub file: Option<String>,
     /// Use the global config file
     #[arg(long = "global", short = 'g')]
@@ -4699,7 +4705,7 @@ pub struct UnuseArgs {
     /// Specify a path to a config file or directory
     ///
     /// If a directory is specified, it will look for a config file in that directory following the rules above.
-    #[arg(long = "path", short = 'p', value_name = "PATH")]
+    #[arg(long = "path", short = 'p', alias = "file", value_name = "PATH")]
     pub path: Option<String>,
     /// Do not also prune the installed version
     #[arg(long = "no-prune")]
@@ -4836,7 +4842,7 @@ pub struct UseArgs {
     /// Specify a path to a config file or directory
     ///
     /// If a directory is specified, it will look for a config file in that directory following the rules above.
-    #[arg(long = "path", short = 'p', value_name = "PATH")]
+    #[arg(long = "path", short = 'p', alias = "file", value_name = "PATH")]
     pub path: Option<String>,
     /// Like --dry-run but exits with code 1 if there are changes to make
     ///

--- a/benches/shadows/mise/src/lib.rs
+++ b/benches/shadows/mise/src/lib.rs
@@ -326,7 +326,7 @@ pub struct BootstrapDotfilesAddArgs {
     #[usage(long = "no-apply")]
     pub no_apply: bool,
     /// Write to this config file or directory
-    #[usage(long = "path", short = 'p', value_name = "PATH")]
+    #[usage(long = "path", long = "file", short = 'p', value_name = "PATH")]
     pub path: ::std::option::Option<::std::string::String>,
     /// Source path to use for a single target
     #[usage(long = "source", short = 's', value_name = "PATH")]
@@ -826,7 +826,7 @@ pub struct BootstrapPackagesBrewTapArgs {
     #[usage(long = "dry-run", short = 'n')]
     pub dry_run: bool,
     /// Write to this config file or directory
-    #[usage(long = "path", short = 'p', value_name = "PATH")]
+    #[usage(long = "path", long = "file", short = 'p', value_name = "PATH")]
     pub path: ::std::option::Option<::std::string::String>,
     /// Tap name, e.g. `owner/repo`
     #[usage(arg, name = "TAP")]
@@ -849,7 +849,7 @@ pub struct BootstrapPackagesBrewUntapArgs {
     #[usage(long = "dry-run", short = 'n')]
     pub dry_run: bool,
     /// Write to this config file or directory
-    #[usage(long = "path", short = 'p', value_name = "PATH")]
+    #[usage(long = "path", long = "file", short = 'p', value_name = "PATH")]
     pub path: ::std::option::Option<::std::string::String>,
     /// Tap name(s), e.g. `owner/repo`
     #[usage(arg, name = "TAPS", required)]
@@ -908,7 +908,7 @@ pub struct BootstrapPackagesImportArgs {
     #[usage(long = "dry-run", short = 'n')]
     pub dry_run: bool,
     /// Write to this config file or directory
-    #[usage(long = "path", short = 'p', value_name = "PATH")]
+    #[usage(long = "path", long = "file", short = 'p', value_name = "PATH")]
     pub path: ::std::option::Option<::std::string::String>,
 }
 
@@ -1009,7 +1009,7 @@ pub struct BootstrapPackagesUseArgs {
     #[usage(long = "dry-run", short = 'n')]
     pub dry_run: bool,
     /// Write to this config file or directory
-    #[usage(long = "path", short = 'p', value_name = "PATH")]
+    #[usage(long = "path", long = "file", short = 'p', value_name = "PATH")]
     pub path: ::std::option::Option<::std::string::String>,
     /// Skip the confirmation prompt
     #[usage(long = "yes", short = 'y')]
@@ -1765,7 +1765,7 @@ pub struct ConfigGetArgs {
     /// Can be a file path or directory. If a directory is provided, the config file in that directory is used.
     ///
     /// If not provided, the nearest mise.toml file will be used
-    #[usage(long = "file", short = 'f', value_name = "FILE")]
+    #[usage(long = "file", long = "path", short = 'f', value_name = "FILE")]
     pub file: ::std::option::Option<::std::string::String>,
     /// The path of the config to display
     #[usage(arg, name = "KEY")]
@@ -1800,7 +1800,7 @@ pub struct ConfigSetArgs {
     /// Can be a file path or directory. If a directory is provided, the config file in that directory is used.
     ///
     /// If not provided, the nearest mise.toml file will be used
-    #[usage(long = "file", short = 'f', value_name = "FILE")]
+    #[usage(long = "file", long = "path", short = 'f', value_name = "FILE")]
     pub file: ::std::option::Option<::std::string::String>,
     #[usage(
         long = "type",
@@ -1951,7 +1951,7 @@ pub struct DotfilesAddArgs {
     #[usage(long = "no-apply")]
     pub no_apply: bool,
     /// Write to this config file or directory
-    #[usage(long = "path", short = 'p', value_name = "PATH")]
+    #[usage(long = "path", long = "file", short = 'p', value_name = "PATH")]
     pub path: ::std::option::Option<::std::string::String>,
     /// Source path to use for a single target
     #[usage(long = "source", short = 's', value_name = "PATH")]
@@ -4099,7 +4099,7 @@ pub struct SetArgs {
     /// Can be a file path or directory. If a directory is provided, will create/use mise.toml in that directory.
     /// Defaults to [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) environment variable, or `mise.toml`.
     /// Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
-    #[usage(long = "file", value_name = "FILE")]
+    #[usage(long = "file", long = "path", value_name = "FILE")]
     pub file: ::std::option::Option<::std::string::String>,
     /// Show raw values instead of redacting secrets
     #[usage(long = "no-redact")]
@@ -4110,7 +4110,14 @@ pub struct SetArgs {
     /// Remove the environment variable from config file
     ///
     /// Can be used multiple times.
-    #[usage(long = "remove", hide, value_name = "ENV_KEY", var)]
+    #[usage(
+        long = "remove",
+        long = "rm",
+        long = "unset",
+        hide,
+        value_name = "ENV_KEY",
+        var
+    )]
     pub remove: ::std::vec::Vec<::std::string::String>,
     /// Read the value from stdin (for multiline input)
     ///
@@ -5186,7 +5193,7 @@ pub struct UnsetArgs {
     /// Can be a file path or directory. If a directory is provided, will create/use mise.toml in that directory.
     ///
     /// Defaults to [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) environment variable, or `mise.toml`. Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
-    #[usage(long = "file", short = 'f', value_name = "FILE")]
+    #[usage(long = "file", long = "path", short = 'f', value_name = "FILE")]
     pub file: ::std::option::Option<::std::string::String>,
     /// Use the global config file
     #[usage(long = "global", short = 'g')]
@@ -5239,7 +5246,7 @@ pub struct UnuseArgs {
     /// Specify a path to a config file or directory
     ///
     /// If a directory is specified, it will look for a config file in that directory following the rules above.
-    #[usage(long = "path", short = 'p', value_name = "PATH")]
+    #[usage(long = "path", long = "file", short = 'p', value_name = "PATH")]
     pub path: ::std::option::Option<::std::string::String>,
     /// Do not also prune the installed version
     #[usage(long = "no-prune")]
@@ -5387,7 +5394,7 @@ pub struct UseArgs {
     /// Specify a path to a config file or directory
     ///
     /// If a directory is specified, it will look for a config file in that directory following the rules above.
-    #[usage(long = "path", short = 'p', value_name = "PATH")]
+    #[usage(long = "path", long = "file", short = 'p', value_name = "PATH")]
     pub path: ::std::option::Option<::std::string::String>,
     /// Like --dry-run but exits with code 1 if there are changes to make
     ///

--- a/xtask/src/shadow.rs
+++ b/xtask/src/shadow.rs
@@ -616,11 +616,15 @@ fn usage_flag_opts(
     if let Some(long) = long {
         opts.push(format!("long = {long:?}"));
     }
-    if let Some(short) = flag.short.first() {
-        opts.push(format!("short = {short:?}"));
+    // Every *other* long, in the order the spec gives them. The derive takes `long` more than
+    // once and the parse table holds a list, so a flag written `-p --path --file` is expressible
+    // exactly — it was being dropped here, and the drop was invisible in the help comparison
+    // (which renders one long form per flag) until a completion offered every name.
+    for extra in flag.long.iter().skip(1) {
+        opts.push(format!("long = {extra:?}"));
     }
-    if flag.long.len() > 1 || flag.short.len() > 1 {
-        skipped.note("a flag's second long or short form");
+    for short in &flag.short {
+        opts.push(format!("short = {short:?}"));
     }
     if let Some(negate) = &flag.negate {
         opts.push(format!("negate = {negate:?}"));
@@ -743,11 +747,15 @@ fn clap_flag_opts(
     if let Some(short) = flag.short.first() {
         opts.push(format!("short = {short:?}"));
     }
-    // Deliberately dropped on both sides: the usage derive cannot declare a second long
-    // form, and giving clap one would make it answer a larger grammar than the shadow it
-    // is being compared against.
-    if flag.long.len() > 1 || flag.short.len() > 1 {
-        skipped.note("a flag's second long or short form");
+    // clap spells the other forms as aliases of this argument rather than as more names on
+    // it. The grammar is the same either way — which is the point, since the two shadows are
+    // compared for the cost of parsing the same command line, and a name one side accepts and
+    // the other rejects is not the same command line.
+    for extra in flag.long.iter().skip(1) {
+        opts.push(format!("alias = {extra:?}"));
+    }
+    for extra in flag.short.iter().skip(1) {
+        opts.push(format!("short_alias = {extra:?}"));
     }
     // clap spells a negation as a second argument with `ArgAction::SetFalse`, not as a
     // property of this one, so it is out of reach of a field-by-field translation.
@@ -1262,6 +1270,24 @@ mod tests {
 
         let (clap, _) = rendered_as(spec, Dialect::Clap);
         assert!(clap.contains(r#"help = "Use shims\nlike so:""#), "{clap}");
+    }
+
+    #[test]
+    fn a_flag_keeps_every_name_it_answers_to() {
+        // `-p --path --file` is one flag with three names, and a shadow that answers to two of
+        // them is a different CLI. The derive takes `long` more than once, so the whole set is
+        // expressible — it was being dropped, and nothing noticed until a completion offered
+        // every name rather than the one help prints.
+        let spec = "name \"ex\"\nbin \"ex\"\nflag \"-p --path --file\" help=\"Where\" {\n  arg \"<path>\"\n}\n";
+        let (usage, _) = rendered_as(spec, Dialect::Usage);
+        assert!(usage.contains(r#"long = "path""#), "{usage}");
+        assert!(usage.contains(r#"long = "file""#), "{usage}");
+
+        // clap spells the rest as aliases of the same argument. Different spelling, same
+        // grammar — which is what the two shadows are compared for.
+        let (clap, _) = rendered_as(spec, Dialect::Clap);
+        assert!(clap.contains(r#"long = "path""#), "{clap}");
+        assert!(clap.contains(r#"alias = "file""#), "{clap}");
     }
 
     #[test]


### PR DESCRIPTION
`flag "-p --path --file"` is one flag with three names, and a shadow that answers
to two of them is a different CLI. The generator dropped the rest and counted them
as something the derive could not express — but the derive takes `long` more than
once and the parse table holds a list, so `#[usage(long = "path", long = "file")]`
emits exactly that spec back. Thirteen of mise's flags were affected.

The drop was invisible in the help comparison, which renders one long form per
flag, and surfaced in the completion comparison, where a candidate list offers
every name a flag answers to. That is the whole argument for holding a
reimplementation to the reference in more than one dimension.

clap spells the rest as aliases of the same argument rather than as more names on
it — different spelling, same grammar, which is what the two shadows are compared
for. Reported cost is unchanged at mise's scale: 29,952 instructions against
29,949, and clap grew by the tree it now has to build.

The two lines this was excluding from the completion parity test are back in it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bench/shadow generator and generated CLI mirrors only; no runtime mise CLI behavior change in application code.
> 
> **Overview**
> **Shadow generation** no longer drops extra long/short names on flags (e.g. `-p --path --file`). The usage derive gets repeated `long` / `short` attributes; the clap shadow gets `alias` / `short_alias` for the same grammar. The old “skipped second form” path is removed, with a unit test on that rendering.
> 
> **Regenerated** `benches/shadows/mise` and `mise-clap` so path/file pairs and hidden `remove`/`rm`/`unset` aliases match the spec.
> 
> **Completion parity** (`benches/gate/tests/complete.rs`) documents the closed `--file` gap and re-enables `mise use --` and `mise use -` against the reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 020f6420530076743da7afa4a34e2f60e59db7a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->