### PR TITLE
feat(config): carry the flags a setting declares into its registry

### DIFF
--- a/config-build/src/emit.rs
+++ b/config-build/src/emit.rs
@@ -131,6 +131,10 @@ fn prop_meta(key: &str, prop: &SpecConfigProp, problems: &mut Vec<String>) -> St
         let list: Vec<String> = envs.iter().map(|env| rust_str(env)).collect();
         let _ = writeln!(fields, "        envs: &[{}],", list.join(", "));
     }
+    if !prop.cli.is_empty() {
+        let flags: Vec<String> = prop.cli.iter().map(|flag| rust_str(flag)).collect();
+        let _ = writeln!(fields, "        cli: &[{}],", flags.join(", "));
+    }
     if !prop.bindings.is_empty() {
         let mut pairs = Vec::new();
         for (kind, keys) in &prop.bindings {

--- a/config-build/tests/generated.rs
+++ b/config-build/tests/generated.rs
@@ -109,6 +109,15 @@ fn what_the_spec_said_about_each_setting_is_what_the_registry_holds() {
     );
     assert!(!meta(prop::JOBS).hide);
 
+    // The flags that set it, which the spec declares beside the environment variables and which the
+    // generator used to read and drop — leaving the registry unable to say a setting is settable from
+    // the command line at all.
+    assert_eq!(meta(prop::JOBS).cli, &["--jobs", "-j"]);
+    assert!(
+        meta(prop::EXCLUDE).cli.is_empty(),
+        "most settings have no flag"
+    );
+
     // The environment in precedence order, and help as the spec wrote it — quotes and all.
     assert_eq!(meta(prop::JOBS).envs, &["HK_JOBS", "HK_JOB"]);
     assert_eq!(meta(prop::CI).envs, &["CI"]);

--- a/config-build/tests/golden/settings.rs
+++ b/config-build/tests/golden/settings.rs
@@ -30,6 +30,7 @@ pub static SETTINGS_PROPS: &[::usage_config::PropMeta] = &[
     ::usage_config::PropMeta {
         default: Some(::usage_config::Const::Int(4)),
         envs: &["HK_JOBS", "HK_JOB"],
+        cli: &["--jobs", "-j"],
         bindings: &[("git", "hk.jobs")],
         help: Some("How many jobs to run at once"),
         ..::usage_config::PropMeta::new("jobs", ::usage_config::Ty::Uint)

--- a/config/src/explain.rs
+++ b/config/src/explain.rs
@@ -98,8 +98,13 @@ pub fn explain(resolved: &Resolved, key: &str) -> Option<String> {
     // The blank line opens whichever of these comes first, rather than belonging to the
     // environment: a setting with git or pkl bindings and no environment variables had its
     // `also` line jammed against the type or the help above it, reading as part of them.
-    if !meta.envs.is_empty() || !meta.bindings.is_empty() {
+    if !meta.envs.is_empty() || !meta.cli.is_empty() || !meta.bindings.is_empty() {
         let _ = writeln!(out);
+    }
+    if !meta.cli.is_empty() {
+        // Before the environment, because it is the way a user is most likely to reach for next: an
+        // explanation that listed the variables and not the flag answered half the question.
+        let _ = writeln!(out, "  command line {}", one_line(&meta.cli.join(", ")));
     }
     if !meta.envs.is_empty() {
         let _ = writeln!(out, "  environment  {}", one_line(&meta.envs.join(", ")));
@@ -203,6 +208,7 @@ mod tests {
         PropMeta {
             default: Some(Const::Int(4)),
             envs: &["HK_JOBS", "HK_JOB"],
+            cli: &["--jobs", "-j"],
             bindings: &[("git", "hk.jobs")],
             help: Some("How many jobs to run at once"),
             ..PropMeta::new("jobs", Ty::Uint)
@@ -287,6 +293,10 @@ mod tests {
         for line in text.lines() {
             assert_eq!(line, line.trim_end(), "trailing space:\n{text}");
         }
+        // The flag, before the variables: a user reading an explanation because they do not like the
+        // answer reaches for the command line first, and listing the variables alone answered half
+        // the question they asked.
+        assert!(text.contains("command line --jobs, -j"), "{text}");
         // And where else it could come from, which is the other half of the question.
         assert!(text.contains("environment  HK_JOBS, HK_JOB"), "{text}");
         assert!(text.contains("also         git hk.jobs"), "{text}");

--- a/config/src/explain.rs
+++ b/config/src/explain.rs
@@ -296,10 +296,15 @@ mod tests {
         // The flag, before the variables: a user reading an explanation because they do not like the
         // answer reaches for the command line first, and listing the variables alone answered half
         // the question they asked.
-        assert!(text.contains("command line --jobs, -j"), "{text}");
-        // And where else it could come from, which is the other half of the question.
-        assert!(text.contains("environment  HK_JOBS, HK_JOB"), "{text}");
-        assert!(text.contains("also         git hk.jobs"), "{text}");
+        // And where else it could come from, which is the other half of the question. Their
+        // positions rather than their presence: an explanation that lists the same three lines in
+        // the other order is a different answer to "what do I change", and `contains` cannot tell.
+        let cli = text.find("command line --jobs, -j").expect(text.as_str());
+        let env = text
+            .find("environment  HK_JOBS, HK_JOB")
+            .expect(text.as_str());
+        let also = text.find("also         git hk.jobs").expect(text.as_str());
+        assert!(cli < env && env < also, "{text}");
     }
 
     #[test]

--- a/config/src/registry.rs
+++ b/config/src/registry.rs
@@ -72,6 +72,13 @@ pub struct PropMeta {
     pub parse: Option<Parser>,
     /// Environment variables that set it, highest precedence first.
     pub envs: &'static [&'static str],
+    /// The flags that set it, as the spec's `cli` node declares them: `["--jobs", "-j"]`.
+    ///
+    /// Documentation for the most part — an explanation that lists the environment variables and not
+    /// the flag is answering half the question a user asked. It is also what a generated test can
+    /// hold the *executable* binding against, since a spec that declares `--jobs` and a CLI that
+    /// never reads it into the setting is the shape of hk's thirteen dead `sources.cli` lines.
+    pub cli: &'static [&'static str],
     /// Its keys in sources usage does not know about: `[("git", "hk.jobs")]`. A custom layer
     /// asks the registry for its own kind and iterates what it finds, which is the whole
     /// mechanism behind hk's git and pkl layers and aube's `.npmrc`.
@@ -103,6 +110,7 @@ impl PropMeta {
             scope: Scope::Any,
             parse: None,
             envs: &[],
+            cli: &[],
             bindings: &[],
             choices: &[],
             hide: false,

--- a/conformance/src/config.rs
+++ b/conformance/src/config.rs
@@ -684,6 +684,10 @@ fn registry_of(settings: &[Setting]) -> Result<Registry, String> {
                 None => None,
             },
             envs: &[],
+            // No flags: a corpus vector describes what reaches a *resolution*, and which flag a
+            // setting declares does not change one. It is documentation, and the drift test that
+            // holds it against a CLI's own binding is that CLI's test rather than this corpus's.
+            cli: &[],
             bindings: &[],
             choices: Box::leak(
                 setting


### PR DESCRIPTION
First of a stack closing the config items the plan still lists.

A spec says `cli "--jobs" "-j"` beside `env "HK_JOBS"`, and the generator read it and **threw it
away**. So the registry could say a setting was settable from the environment, from a git config,
from a pkl file — and not that it was settable from the command line.

```
jobs = 8
  set by  HK_JOBS
  type    uint
          How many jobs to run at once

  command line --jobs, -j        # this line did not exist
  environment  HK_JOBS, HK_JOB
  also         git hk.jobs
```

`explain` names it first, because the command line is what somebody who dislikes the answer reaches
for next, and listing the variables alone answered half the question.

The other reason it matters is the next PR but one: this is what a generated test can hold the
*executable* binding against. A spec that declares `--jobs` and a CLI that never reads it into the
setting is the shape of hk's thirteen dead `sources.cli` lines, and nothing could have noticed while
the registry did not know the declaration existed.

Two mutations, two dead tests: the flags read and dropped again (caught by the regenerate-and-diff
test), and `explain` omitting the line.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata and explain-text only; no merge or resolution behavior changes, with broad test coverage for ordering and generation.
> 
> **Overview**
> **Spec-declared CLI flags are no longer dropped at codegen** — they land on `PropMeta::cli` in generated registries (e.g. `jobs` gets `&["--jobs", "-j"]`), with generator tests and golden output updated so a regenerate-and-diff run catches regressions.
> 
> **`config explain` now surfaces those flags** when present, in a `command line …` line **before** environment variables and git/pkl bindings, so “what can I change?” includes the flag path. Settings without flags stay unchanged; conformance harness registries still use empty `cli` because resolution vectors are not about declared flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cf7bfc1902f84fdf3a61aa156899179e206e3ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration explanations now display available command-line options alongside setting details.
  * Command-line options appear before environment variable references for clearer guidance.
  * The jobs setting supports both `--jobs` and `-j` aliases.

* **Bug Fixes**
  * Improved configuration metadata so command-line bindings are accurately reflected in generated explanations.
  * Settings without command-line options no longer display misleading CLI information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->