### PR TITLE
feat(config): read the command line as a layer

### DIFF
--- a/config/src/cli.rs
+++ b/config/src/cli.rs
@@ -1,0 +1,278 @@
+//! The command line as a layer.
+//!
+//! The highest layer there is, and the one the fleet gets least right. hk declares eighteen
+//! `sources.cli` bindings and reads five — the flags live in a second, hand-maintained struct and
+//! are consumed ad hoc. mise hand-copies thirteen flags into its settings in a forty-nine-line
+//! function, and `--jobs` bypasses even that by going through the environment. pitchfork's `--help`
+//! documents a CLI layer it does not have.
+//!
+//! What they are all writing is this: for each setting a flag was given for, one entry at the top of
+//! the merge. The part that is easy to get wrong is *given*, which is why this layer takes values
+//! rather than a struct — a `bool` field is `false` whether the flag was absent or explicitly
+//! negated, and a layer that cannot tell those apart makes `--no-colour` indistinguishable from
+//! saying nothing, which silently outranks every file on the machine.
+//!
+//! ```
+//! use usage_config::{resolve, CliLayer, Layers, PropMeta, Registry, Ty, Value};
+//!
+//! static PROPS: &[PropMeta] = &[PropMeta {
+//!     cli: &["--jobs", "-j"],
+//!     ..PropMeta::new("jobs", Ty::Uint)
+//! }];
+//! const REGISTRY: Registry = Registry::new(PROPS);
+//!
+//! // What a parser produces: the settings a flag was actually given for.
+//! let cli = CliLayer::new([("jobs", "8")]);
+//! let resolved = resolve(REGISTRY, Layers::new().then(&cli))?;
+//!
+//! assert_eq!(resolved.get_key("jobs"), Some(&Value::Int(8)));
+//! // Named as the flag rather than as "the command line", so an explanation is actionable.
+//! assert_eq!(
+//!     resolved.origin(REGISTRY.lookup("jobs").unwrap().id).unwrap().describe(),
+//!     "--jobs",
+//! );
+//! # Ok::<(), usage_config::LayerError>(())
+//! ```
+
+use crate::layer::{Layer, LayerCtx, LayerError, LayerOutput};
+use crate::registry::Registry;
+use crate::source::{Origin, SourceKind};
+use crate::value::Value;
+
+/// Settings given on the command line.
+pub struct CliLayer {
+    given: Vec<(String, Given)>,
+}
+
+/// One value a flag was given, as text or with a shape of its own.
+enum Given {
+    /// What a flag's argument is before anything types it, which is what a parser hands over.
+    Text(String),
+    /// A value a caller has already made: a `bool` from a switch, a count, a list it collected.
+    Shaped(Value),
+}
+
+impl CliLayer {
+    /// The settings a flag was given for, as text.
+    ///
+    /// Only what was *given*: a flag left off the command line is not an entry here, because the
+    /// command line outranks every other layer and an entry it did not earn would silently beat a
+    /// file the user did write.
+    pub fn new(given: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>) -> Self {
+        Self {
+            given: given
+                .into_iter()
+                .map(|(key, value)| (key.into(), Given::Text(value.into())))
+                .collect(),
+        }
+    }
+
+    /// A setting given as text, added to what this layer already has.
+    ///
+    /// Chained rather than collected, so a CLI can build the layer with one call per flag it has and
+    /// leave out the ones it has not — which is the shape a generated `to_settings_layer` wants.
+    pub fn with(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.given.push((key.into(), Given::Text(value.into())));
+        self
+    }
+
+    /// A setting given as a value that already has a shape.
+    ///
+    /// A switch is a `bool`, a `--verbose` count is a number, a repeated flag is a list: a caller
+    /// holding those has no reason to render them to text for this to read them back.
+    pub fn with_value(mut self, key: impl Into<String>, value: Value) -> Self {
+        self.given.push((key.into(), Given::Shaped(value)));
+        self
+    }
+
+    /// Whether a flag was given for anything at all.
+    ///
+    /// A CLI with no settings on its command line can leave this layer out of the plan rather than
+    /// adding an empty one, though adding one changes nothing.
+    pub fn is_empty(&self) -> bool {
+        self.given.is_empty()
+    }
+
+    /// What a report should call the flag that set `key`.
+    ///
+    /// The first spelling the setting declares, because that is the long one a spec lists first and
+    /// the one worth printing: "set by `--jobs`" is actionable in a way that "set by the command
+    /// line" is not. A setting whose registry declares no flag is named by its key, which is the
+    /// most that can be said about a CLI that bound something it never documented.
+    fn origin(&self, registry: Registry, key: &str) -> Origin {
+        let named = registry
+            .lookup(key)
+            .and_then(|found| registry.get(found.id).cli.first().copied());
+        Origin::new(SourceKind::CLI, named.unwrap_or(key))
+    }
+}
+
+impl Layer for CliLayer {
+    fn source(&self) -> SourceKind {
+        SourceKind::CLI
+    }
+
+    fn load(&self, ctx: &LayerCtx) -> Result<LayerOutput, LayerError> {
+        let mut out = LayerOutput::new();
+        for (key, given) in &self.given {
+            let origin = self.origin(ctx.registry(), key);
+            let entry = match given {
+                Given::Text(raw) => ctx.entry_for_key(key, raw, origin),
+                Given::Shaped(value) => ctx.entry_from_value(key, value.clone(), origin),
+            };
+            match entry {
+                Ok(entry) => out.push(entry),
+                // A flag the CLI bound to a setting nothing declares, or a value the declared type
+                // cannot read: reported like any other layer's, rather than a panic in the one layer
+                // whose contents are the CLI author's own doing. They will see it on their first run.
+                Err(warning) => out.warn(warning),
+            }
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::registry::{PropMeta, Scope};
+    use crate::resolve::{resolve, Layers};
+    use crate::ty::{Parser, Ty};
+    use crate::value::Const;
+
+    static PROPS: &[PropMeta] = &[
+        PropMeta {
+            default: Some(Const::Int(4)),
+            envs: &["HK_JOBS"],
+            cli: &["--jobs", "-j"],
+            ..PropMeta::new("jobs", Ty::Uint)
+        },
+        PropMeta {
+            cli: &["--colour", "--no-colour"],
+            ..PropMeta::new("colour", Ty::Bool)
+        },
+        PropMeta {
+            parse: Some(Parser::ListByComma),
+            cli: &["--exclude"],
+            ..PropMeta::new("exclude", Ty::List(&Ty::String))
+        },
+        // Settable from a checkout's own file is exactly what this is not, and the command line is
+        // the user's own — so a flag may set it.
+        PropMeta {
+            scope: Scope::Global,
+            cli: &["--trusted"],
+            ..PropMeta::new("trusted", Ty::Bool)
+        },
+        // No flag at all, which is most settings.
+        PropMeta::new("stash", Ty::String),
+    ];
+    const REGISTRY: Registry = Registry::new(PROPS);
+
+    #[test]
+    fn a_flag_that_was_given_sets_its_setting() {
+        let cli = CliLayer::new([("jobs", "8")]);
+        let resolved = resolve(REGISTRY, Layers::new().then(&cli)).expect("resolves");
+        assert_eq!(resolved.get_key("jobs"), Some(&Value::Int(8)));
+        // Named as the flag, not as "the command line": a user who does not like the answer needs to
+        // know what to stop passing.
+        assert_eq!(
+            resolved
+                .origin(REGISTRY.lookup("jobs").expect("declared").id)
+                .map(|o| o.describe()),
+            Some("--jobs")
+        );
+    }
+
+    #[test]
+    fn the_command_line_outranks_everything() {
+        let cli = CliLayer::new([("jobs", "8")]);
+        let env = crate::env::EnvLayer::new([("HK_JOBS".to_string(), "6".to_string())]);
+        let resolved = resolve(REGISTRY, Layers::new().then(&cli).then(&env)).expect("resolves");
+        assert_eq!(resolved.get_key("jobs"), Some(&Value::Int(8)));
+    }
+
+    #[test]
+    fn a_flag_that_was_not_given_is_not_an_entry() {
+        // The whole point of taking given values rather than a struct. A `bool` field is `false`
+        // whether the flag was absent or explicitly negated, so a layer built from the struct sets
+        // every switch on the command line — silently outranking every file on the machine.
+        let cli = CliLayer::new(Vec::<(String, String)>::new());
+        assert!(cli.is_empty());
+        let env = crate::env::EnvLayer::new([("HK_JOBS".to_string(), "6".to_string())]);
+        let resolved = resolve(REGISTRY, Layers::new().then(&cli).then(&env)).expect("resolves");
+        assert_eq!(
+            resolved.get_key("jobs"),
+            Some(&Value::Int(6)),
+            "the environment should still be what set it"
+        );
+        assert_eq!(resolved.get_key("colour"), None, "no flag, no value");
+    }
+
+    #[test]
+    fn a_value_that_already_has_a_shape_is_taken_as_it_is() {
+        // A switch is a `bool` and a repeated flag is a list. A caller holding those has no reason to
+        // render them to text for this to read them back.
+        let cli = CliLayer::new(Vec::<(String, String)>::new())
+            .with_value("colour", Value::Bool(false))
+            .with_value(
+                "exclude",
+                Value::List(vec![Value::from("target"), Value::from("dist")]),
+            );
+        let resolved = resolve(REGISTRY, Layers::new().then(&cli)).expect("resolves");
+        assert_eq!(resolved.get_key("colour"), Some(&Value::Bool(false)));
+        assert_eq!(
+            resolved.get_key("exclude"),
+            Some(&Value::List(vec![
+                Value::from("target"),
+                Value::from("dist")
+            ]))
+        );
+    }
+
+    #[test]
+    fn a_flag_may_set_a_setting_no_file_can() {
+        // `scope="global"` is about what a *checkout* can carry. The command line is the user's own.
+        let cli = CliLayer::new([("trusted", "true")]);
+        let resolved = resolve(REGISTRY, Layers::new().then(&cli)).expect("resolves");
+        assert_eq!(resolved.get_key("trusted"), Some(&Value::Bool(true)));
+        assert!(resolved.warnings.is_empty(), "{:?}", resolved.warnings);
+    }
+
+    #[test]
+    fn a_setting_with_no_declared_flag_is_named_by_its_key() {
+        // A CLI can bind a flag to a setting whose spec never mentioned one. That is worth reporting
+        // as best as it can be — the key — rather than refusing to resolve it.
+        let cli = CliLayer::new([("stash", "none")]);
+        let resolved = resolve(REGISTRY, Layers::new().then(&cli)).expect("resolves");
+        assert_eq!(resolved.get_key("stash"), Some(&Value::from("none")));
+        assert_eq!(
+            resolved
+                .origin(REGISTRY.lookup("stash").expect("declared").id)
+                .map(|o| o.describe()),
+            Some("stash")
+        );
+    }
+
+    #[test]
+    fn a_flag_bound_to_nothing_is_a_warning_rather_than_a_crash() {
+        // The CLI author's own mistake, found on their first run: a flag bound to a setting that does
+        // not exist, or a value the declared type cannot read. Reported like any other layer's,
+        // because a panic in the one layer whose contents are the author's doing is no more useful
+        // and much harder to see past.
+        let cli = CliLayer::new([("nonesuch", "1"), ("jobs", "lots")]);
+        let resolved = resolve(REGISTRY, Layers::new().then(&cli)).expect("resolves");
+        assert_eq!(
+            resolved.get_key("jobs"),
+            Some(&Value::Int(4)),
+            "the default"
+        );
+        let kinds: Vec<_> = resolved.warnings.iter().map(|w| w.kind).collect();
+        assert_eq!(
+            kinds,
+            vec![
+                crate::layer::WarningKind::UnknownSetting,
+                crate::layer::WarningKind::WrongType
+            ]
+        );
+    }
+}

--- a/config/src/cli.rs
+++ b/config/src/cli.rs
@@ -99,10 +99,15 @@ impl CliLayer {
     /// the one worth printing: "set by `--jobs`" is actionable in a way that "set by the command
     /// line" is not. A setting whose registry declares no flag is named by its key, which is the
     /// most that can be said about a CLI that bound something it never documented.
+    ///
+    /// Asked of the declaration the CLI bound to rather than of the setting that declaration ends
+    /// up meaning, which is the same distinction a deprecation warning makes. A flag bound to a
+    /// renamed key reads the replacement's flags through `lookup`, so `--old` was reported as
+    /// `--new`: a flag nobody typed, named as the thing to stop passing.
     fn origin(&self, registry: Registry, key: &str) -> Origin {
         let named = registry
-            .lookup(key)
-            .and_then(|found| registry.get(found.id).cli.first().copied());
+            .lookup_exact(key)
+            .and_then(|id| registry.get(id).cli.first().copied());
         Origin::new(SourceKind::CLI, named.unwrap_or(key))
     }
 }
@@ -165,6 +170,12 @@ mod tests {
         },
         // No flag at all, which is most settings.
         PropMeta::new("stash", Ty::String),
+        // An old name with a flag of its own, still bound by a CLI that has not dropped it yet.
+        PropMeta {
+            cli: &["--concurrency"],
+            renamed_to: Some("jobs"),
+            ..PropMeta::new("concurrency", Ty::Uint)
+        },
     ];
     const REGISTRY: Registry = Registry::new(PROPS);
 
@@ -250,6 +261,27 @@ mod tests {
                 .origin(REGISTRY.lookup("stash").expect("declared").id)
                 .map(|o| o.describe()),
             Some("stash")
+        );
+    }
+
+    #[test]
+    fn a_flag_bound_to_an_old_name_is_named_by_the_old_name() {
+        // `lookup` answers "which setting is this", which is what a *value* needs and what the merge
+        // does with it. A flag's name is a question about the declaration the CLI bound to: reading
+        // the replacement's flags through a rename reported `--old` as `--new`, naming a flag the
+        // user never typed as the thing to stop passing.
+        let cli = CliLayer::new([("concurrency", "8")]);
+        let resolved = resolve(REGISTRY, Layers::new().then(&cli)).expect("resolves");
+        assert_eq!(
+            resolved.get_key("jobs"),
+            Some(&Value::Int(8)),
+            "still folds"
+        );
+        assert_eq!(
+            resolved
+                .origin(REGISTRY.lookup("jobs").expect("declared").id)
+                .map(|o| o.describe()),
+            Some("--concurrency")
         );
     }
 

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -55,6 +55,7 @@
 //! # Ok::<(), usage_config::LayerError>(())
 //! ```
 
+pub mod cli;
 pub mod env;
 pub mod explain;
 #[cfg(any(feature = "toml", feature = "json"))]
@@ -67,6 +68,7 @@ pub mod source;
 pub mod ty;
 pub mod value;
 
+pub use cli::CliLayer;
 pub use env::EnvLayer;
 pub use explain::explain;
 #[cfg(any(feature = "toml", feature = "json"))]


### PR DESCRIPTION
The highest layer there is, and the one the fleet gets least right:

- hk declares eighteen `sources.cli` bindings and **reads five** — the flags live in a second,
  hand-maintained struct and are consumed ad hoc.
- mise hand-copies thirteen flags into its settings in a forty-nine-line function, and `--jobs`
  bypasses even that by going through the environment.
- pitchfork's `--help` documents a CLI layer it does not have.

What all of them are writing is this: for each setting a flag was given for, one entry at the top of
the merge.

```rust
let cli = CliLayer::new([("jobs", "8")]).with_value("colour", Value::Bool(false));
let resolved = resolve(SETTINGS_REGISTRY, Layers::new().then(&cli).then(&env).then(&files))?;
```

## Why it takes values and not a struct

Because the word that matters is **given**. A `bool` field is `false` whether the flag was absent or
explicitly negated, so a layer built by reading the parsed struct sets every switch on every run —
and the command line outranks every other layer, so it would silently beat a file the user did write.
Only what a parser actually saw becomes an entry, and there is a test for exactly that: with nothing
given, the environment is still what set the value.

`with_value` exists because a caller holding a `bool` from a switch, a count, or a list it collected
has no reason to render it to text for this to read back.

**The origin is the flag**, not "the command line" — `set by --jobs` is actionable in a way that
`set by the command line` is not. That is what the declared `cli` spellings from the previous commit
are for. A setting whose spec declared no flag is named by its key, which is the most that can be
said about a CLI that bound something it never documented.

**A flag bound to a setting that does not exist is a warning**, like any other layer's, rather than a
panic in the one layer whose contents are the author's own doing — they see it on their first run,
with the same `unknown-setting` kind everything else uses.

## Verification

119 tests in the crate. Three mutations, each killing the right test: naming the origin by the last
declared spelling instead of the first, dropping the flag name for "the command line", and swallowing
a bad binding. Clippy clean with no features, `toml`, and `json`.

Next in the stack: the derive attribute that generates this layer from a CLI struct, and the test
that holds the generated binding against the spec's declared one — which is what makes hk's thirteen
dead lines impossible.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core merge precedence and provenance for all CLI settings; behavior is heavily tested but mistakes here would change what users see at runtime.
> 
> **Overview**
> Introduces **`CliLayer`**, the top-precedence config source, wired into the same `resolve` / `Layers` pipeline as env and files. Callers pass **only settings a flag was given for** (text via `new`/`with` or typed values via `with_value`), so absent switches do not create entries that would silently beat lower layers.
> 
> Provenance is reported as the **registry’s primary CLI spelling** (e.g. `--jobs`), using the **bound key** for renames and the setting key when no flag is declared. Unknown keys and type errors become **warnings** instead of panics. **`CliLayer` is re-exported** from the crate root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 787f02415acafe59c61586b9920d7bb7ddea1a42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->