### PR TITLE
docs(config): write down what a resolution does

### DIFF
--- a/corpus/config/04-renames.kdl
+++ b/corpus/config/04-renames.kdl
@@ -78,3 +78,16 @@ vector "an-old-names-scope-is-the-new-ones" doc="A refusal is reported under the
     warning "out-of-scope"
   }
 }
+
+vector "a-chain-of-renames-resolves-to-its-end" doc="Two releases of renaming leave the first name still working: it resolves through the second to the setting that exists now." {
+  setting "jobs" type="uint" default=1
+  setting "concurrency" type="uint" renamed-to="jobs"
+  setting "threads" type="uint" renamed-to="concurrency"
+  layer "file" id="hk.toml" {
+    value "threads" "8"
+  }
+  expect {
+    value "jobs" 8
+    warning "renamed"
+  }
+}

--- a/corpus/config/05-types.kdl
+++ b/corpus/config/05-types.kdl
@@ -24,21 +24,38 @@ vector "the-boolean-spellings" doc="The spellings every registry in the fleet ac
   setting "d" type="bool"
   setting "e" type="bool"
   setting "f" type="bool"
+  setting "g" type="bool"
+  setting "h" type="bool"
+  setting "i" type="bool"
+  setting "j" type="bool"
+  setting "k" type="bool"
   layer "env" {
     value "a" "true"
     value "b" "1"
     value "c" "yes"
-    value "d" "false"
-    value "e" "0"
-    value "f" "off"
+    value "d" "y"
+    value "e" "on"
+    value "f" "false"
+    value "g" "0"
+    value "h" "no"
+    value "i" "n"
+    value "j" "off"
+    value "k" ""
   }
   expect {
     value "a" #true
     value "b" #true
     value "c" #true
-    value "d" #false
-    value "e" #false
+    value "d" #true
+    value "e" #true
     value "f" #false
+    value "g" #false
+    value "h" #false
+    value "i" #false
+    value "j" #false
+    // An emptied variable is how a user turns a declared default off, so it is `false` rather
+    // than nothing at all — the same rule that makes an empty list no items instead of one.
+    value "k" #false
   }
 }
 
@@ -67,13 +84,18 @@ vector "an-empty-string-is-no-items" doc="And an empty string is no items rather
 vector "a-named-parser-splits-before-the-type-reads" doc="A declared parser turns one string into several values, so no layer has to know that a setting is comma-separated." {
   setting "exclude" type="list<string>" parse="list_by_comma"
   setting "path" type="list<path>" parse="list_by_colon"
+  // The same split, into a set: one string can name the same thing twice, and a set is the
+  // declaration that it should not hold it twice.
+  setting "tags" type="set<string>" parse="set_by_comma"
   layer "env" {
     value "exclude" "target,vendor"
     value "path" "/usr/bin:/bin"
+    value "tags" "ci,fast,ci"
   }
   expect {
     list "exclude" "target" "vendor"
     list "path" "/usr/bin" "/bin"
+    list "tags" "ci" "fast"
   }
 }
 

--- a/corpus/config/README.md
+++ b/corpus/config/README.md
@@ -4,9 +4,9 @@ Test vectors for configuration resolution. Each one pairs a set of settings with
 the layers that supply values, and the resolution the two must produce.
 
 The [`config` block](https://usage.jdx.dev/spec/reference/config) is how a spec
-_declares_ settings. What a resolution does with them has no prose page yet, so
-until it has one these vectors are the definition — which is the wrong way round,
-and the page is worth writing.
+_declares_ settings; [resolution](https://usage.jdx.dev/spec/resolution) is what
+happens to them. That page is the prose and these vectors are the same rules made
+executable, the way the argv grammar and its corpus sit together.
 
 The vectors are KDL because KDL is usage's canonical format. If you are writing a
 usage config resolver in another language, this directory is the definition of

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -74,6 +74,7 @@ export default defineConfig({
         link: "/spec/",
         items: [
           { text: "argv grammar", link: "/spec/argv" },
+          { text: "config resolution", link: "/spec/resolution" },
           {
             text: "Reference",
             link: "/spec/reference/",

--- a/docs/spec/resolution.md
+++ b/docs/spec/resolution.md
@@ -168,8 +168,16 @@ binary must still work with an older one.
 
 [`corpus/config/`](https://github.com/jdx/usage/tree/main/corpus/config) pairs a set
 of settings with the layers that supply values and the resolution the two must
-produce. Every rule on this page has vectors, and a second implementation — in Go, in
-TypeScript, as a second Rust one — passes them or does not.
+produce. A second implementation — in Go, in TypeScript, as a second Rust one — passes
+them or does not.
+
+Two rules on this page have none, both for the same reason: a vector says what a
+resolution produces, and neither of these is one. `list_by_os_path_separator` splits on
+a character that depends on the machine running the test, and a corpus whose answers
+differ by platform stops being the definition of correct. `not-read` is a layer's choice
+between two of its own variables, which a vector describing what a layer _supplies_
+cannot express — [`EnvLayer`'s own tests](https://github.com/jdx/usage/blob/main/config/src/env.rs)
+hold it instead.
 
 Vectors describe a **registry** rather than a spec, because resolution is a question
 about keys and types rather than about KDL, and warnings are pinned by kind rather

--- a/docs/spec/resolution.md
+++ b/docs/spec/resolution.md
@@ -1,0 +1,189 @@
+# Configuration resolution
+
+A [`config` block](/spec/reference/config) says what a CLI's settings are. This page
+says how a value is arrived at: which place wins when several have something to say,
+what a declared type does to a value on its way in, which places are allowed to set
+which settings, and what a resolution has to report about the values it refused.
+
+It exists because that behavior was previously written down nowhere. Every CLI in the
+jdx fleet resolved its own settings by hand, and every copy differed — not through
+carelessness, but because the declaration of a setting and the code that resolved it
+were two separate things kept in step by hand. The rules here are normative, and
+[the conformance corpus](#the-conformance-corpus) makes them executable.
+
+## Terms
+
+A **setting** is one entry in the registry: a key, a type, and what the spec says
+about it. Keys are dotted paths — `task.output` — and dots are the only nesting.
+
+A **layer** is one place values come from: the command line, the environment, a
+config file, a git config, a `.npmrc`. A layer produces **entries**, each one a
+setting and a value it supplies.
+
+A **resolution** is the result of merging every layer: a value per setting, the
+**origin** each value came from, and the **warnings** the merge produced.
+
+An **origin** names the exact place, not the kind of place: `MISE_JOBS`, `--jobs`,
+`./hk.toml`, `git hk.jobs`. "The environment" is not an origin, because a user who
+wants to change the answer needs to know which variable to unset.
+
+## Precedence
+
+Layers are ordered, and the order is not negotiable:
+
+1. the command line
+2. the environment
+3. config files, nearest first
+4. anything else the CLI puts below them
+5. the declared default
+
+Which layers a CLI _has_ is its own business. Their relative order is not: a
+resolution where a project's file outranks the flag the user just typed is a bug,
+not a configuration choice.
+
+A layer that supplies nothing for a setting is not a layer that clears it. A higher
+layer with no value leaves the lower one alone.
+
+A declared default is the **bottom layer**, not a floor applied afterwards. The
+difference shows up in [merging](#merging): a `union` list with a default and one
+file gets both, because the default took part in the merge rather than filling in
+what nothing had set.
+
+## Merging
+
+Each setting declares how values from several layers combine.
+
+| policy              | what happens                                                    |
+| ------------------- | --------------------------------------------------------------- |
+| `replace` (default) | the highest layer wins outright                                 |
+| `union`             | the items from every layer, lowest first                        |
+| `deep`              | tables merged key by key, the higher layer winning a shared key |
+
+`union` concatenates: a `list` keeps duplicates, because that is what distinguishes
+a list from a `set`, and a `set` drops them — within one layer's value as much as
+across two. First occurrence keeps its position.
+
+An empty value is a value. `HK_EXCLUDE=` is how a user turns a declared default
+off, and a union then has nothing left to add to.
+
+## Types
+
+Every layer that reads text — an environment, a git config, an `.npmrc` — hands over
+a string. The declared type is the only thing that says whether `1` is the number
+one, the string `1`, or a list of one.
+
+- A bare value for a `list` setting is a list of one, which is what `MISE_ENV=production`
+  relies on. An empty string is _no_ items rather than one empty item.
+- Booleans read `true`/`1`/`yes`/`y`/`on` and `false`/`0`/`no`/`n`/`off`/empty.
+  Deliberately not "anything non-empty is true": `FOO=false` meaning true is the
+  kind of surprise a config system exists to prevent.
+- A number written where text is expected is text that happens to look like a
+  number. A _collection_ written there is not: rendering one would produce a value
+  nobody wrote.
+- `duration` and `url` are text here. What makes a string a URL is what the CLI does
+  with it, and the crate that owns the duration type owns its spelling.
+- A union, or a type name usage does not know, coerces nothing at all: the spec has
+  said usage cannot decide what belongs there.
+
+A **named parser** splits one string into several values before the type reads it —
+`list_by_comma`, `list_by_colon`, `list_by_os_path_separator`, `set_by_comma` — so no
+layer has to know that a setting is comma-separated.
+
+A value the declared type cannot read **costs its own key and nothing else**. A typo
+in a system-wide file must not stop a CLI from starting for every user on the
+machine.
+
+## Choices
+
+A setting may name the values it takes. Those reach the docs, the JSON schema and
+the completions, and they reach resolution too: a CLI that documents three values
+and accepts a fourth in silence has lied to its user.
+
+Choices on a collection mean each **item** is one of them, which is the rule
+`usage g json-schema` follows by putting the enum on every value position rather
+than on the container.
+
+A choice is read as the declared type before it is compared, so `choice "yes"` under
+`type="bool"` is the same value as `#true`. The type is asked first: a value that is
+not a boolean at all is reported as that, because there is nothing useful to say
+about which choice it is not.
+
+## Scope
+
+Which places may set which settings. mise treats this as a security property rather
+than a preference: a setting that decides whether code runs must not be settable by
+a file a pull request can add.
+
+| scope           | settable from                            |
+| --------------- | ---------------------------------------- |
+| `any` (default) | anywhere                                 |
+| `global`        | not from anything a repository can carry |
+| `env`           | never from a file at all                 |
+
+The question the merge asks is how far a place is **trusted**, not what kind of place
+it is. A pkl file or a git config inside a checkout is exactly as much a thing a
+repository carries as a TOML file is, and a source usage does not recognize gets the
+least trusting answer until its layer says otherwise — because a check every new
+layer has to remember is one a new layer will forget.
+
+A refusal costs that value alone, and is reported under the name the user wrote.
+
+## Renames
+
+An old name keeps working. An upgrade that silently changed what a machine's config
+meant would be worse than the rename itself.
+
+A value written under a renamed key lands on the setting that replaced it, at the
+same precedence it was written at, and the user is told what it was read as. The old
+name is not a second setting: it has no value of its own, and every read of it
+answers about its replacement.
+
+A deprecation notice may sit anywhere along a chain of renames — `a` renamed to `b`,
+and `b` the one carrying the notice that says to use `c` — and the first one found is
+the one reported.
+
+## Warnings
+
+A resolution reports rather than prints. A library that writes to stderr cannot be
+used by anything with an opinion about output, and mise queues its deprecations until
+its logging is up.
+
+Each has a **kind**, because the wording is for a person and the kind is what a
+program acts on:
+
+| kind              | what happened                                      |
+| ----------------- | -------------------------------------------------- |
+| `unknown-setting` | a key no setting declares                          |
+| `wrong-type`      | a value the declared type cannot read              |
+| `not-allowed`     | a value the declared choices do not allow          |
+| `out-of-scope`    | a place that may not set this setting              |
+| `deprecated`      | a setting whose spec says not to use it            |
+| `renamed`         | a value read as the setting that replaced its name |
+| `not-read`        | a value passed over because another name won       |
+
+An unknown key is a warning and never an error: a config file written for a newer
+binary must still work with an older one.
+
+## The conformance corpus
+
+[`corpus/config/`](https://github.com/jdx/usage/tree/main/corpus/config) pairs a set
+of settings with the layers that supply values and the resolution the two must
+produce. Every rule on this page has vectors, and a second implementation — in Go, in
+TypeScript, as a second Rust one — passes them or does not.
+
+Vectors describe a **registry** rather than a spec, because resolution is a question
+about keys and types rather than about KDL, and warnings are pinned by kind rather
+than by message: wording is expected to differ between implementations.
+
+```sh
+cargo test -p usage-conformance --test config
+```
+
+## Implementations
+
+[`usage-config`](https://github.com/jdx/usage/tree/main/config) resolves; it carries
+no spec parser, so a CLI ships a resolver rather than a KDL reader.
+[`usage-config-build`](https://github.com/jdx/usage/tree/main/config-build) reads the
+spec at build time and emits the registry as consts, along with the typed `Settings`
+struct a CLI reads — so a setting that is declared is a setting that resolves, with
+no second declaration to keep in step.


### PR DESCRIPTION
The [`config` block reference](https://usage.jdx.dev/spec/reference/config) says how a CLI *declares*
settings. What happens to them was written down nowhere — precedence, coercion, scope, renames,
warnings existed only as the merge's implementation and the corpus that pins it. Which is why the
corpus README I wrote in #875 had to say, in as many words, "these vectors are the definition, which
is the wrong way round".

Now it is prose first and vectors second, the way `/spec/argv` and the argv corpus sit together, and
the page is normative rather than descriptive: an implementation in Go or TypeScript has something to
read before it starts, instead of reverse-engineering 46 JSON vectors.

It states the things a reader would otherwise have to infer from a test:

- a declared default is the **bottom layer**, not a floor applied afterwards — which is why a `union`
  list with a default and one file gets both
- `union` concatenates, so a `list` keeps duplicates and a `set` drops them, because that is what
  distinguishes the two
- an empty value **is** a value: `HK_EXCLUDE=` is how a default gets turned off
- a value the type cannot read costs its own key and nothing else
- scope asks how far a place is **trusted**, not what kind of place it is, so a pkl file in a checkout
  is as much a thing a repository carries as a TOML file
- an origin names the place (`MISE_JOBS`, `--jobs`, `./hk.toml`) and never the kind, because a user who
  wants a different answer needs to know what to unset

The corpus README now points at it instead of standing in for it, and it is in the sidebar under the
argv grammar.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and conformance vectors only; no resolver or library code changes in the diff.
> 
> **Overview**
> Adds a normative **config resolution** spec at `docs/spec/resolution.md` (precedence, merging, types, scope, renames, warnings, corpus relationship) and links it from the VitePress sidebar next to the argv grammar.
> 
> Updates `corpus/config/README.md` so vectors are explicitly secondary to that prose. **Corpus** gains coverage for multi-hop rename chains (`threads` → `concurrency` → `jobs`), expanded boolean env spellings (`y`, `on`, `n`, empty → false), and `set_by_comma` on `set<string>` with deduplication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 216d124909e861b2491c6647c8b38d0a8eb3baed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->