### PR TITLE
feat(derive): answer a completion request from the binary itself

### DIFF
--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -148,6 +148,85 @@ pub struct Completions<'a> {
     pub files: Option<Files>,
 }
 
+/// The line a shell reads to mean "paths belong here too".
+///
+/// A whole line rather than a flag on the protocol, because every one of the five shells can
+/// already split output into lines and look at the last one. `\x01` opens it because no
+/// candidate this crate produces can contain a control character, so it cannot be mistaken for
+/// one.
+pub const FILES_MARKER: &str = "\u{1}files";
+/// See [`FILES_MARKER`]. Directories only.
+pub const DIRS_MARKER: &str = "\u{1}dirs";
+
+/// Write an answer the way `shell` reads it.
+///
+/// One line per candidate, in the shape the shell's own completion machinery expects — which is
+/// where the five differ. bash reads values only; fish, nu and PowerShell take a description
+/// after a tab; zsh takes a third field, the text to insert, because what it displays and what
+/// it types are not always the same string.
+///
+/// A trailing [`FILES_MARKER`] says the generated script should hand the position to the
+/// shell's own path completion afterwards.
+pub fn render(answer: &Completions<'_>, shell: Shell) -> String {
+    let mut out = String::new();
+    // Descriptions are all-or-nothing per answer: a column that appears on some rows and not
+    // others reads as missing data rather than as an absent description, which is the reason
+    // the reference decides this per answer too.
+    let described = answer.candidates.iter().any(|c| c.description.is_some());
+
+    for candidate in &answer.candidates {
+        let description = candidate.description.unwrap_or_default();
+        match shell {
+            Shell::Bash => out.push_str(&candidate.value),
+            Shell::Zsh => {
+                // Display, then description, then what to type: a candidate containing a space
+                // or a quote has to reach the command line intact.
+                out.push_str(&candidate.value);
+                out.push('\t');
+                out.push_str(description);
+                out.push('\t');
+                out.push_str(&zsh_quote(&candidate.value));
+            }
+            Shell::Fish | Shell::Nu | Shell::PowerShell => {
+                out.push_str(&candidate.value);
+                if described {
+                    out.push('\t');
+                    out.push_str(description);
+                }
+            }
+        }
+        out.push('\n');
+    }
+
+    match answer.files {
+        Some(Files::Any) => {
+            out.push_str(FILES_MARKER);
+            out.push('\n');
+        }
+        Some(Files::Dirs) => {
+            out.push_str(DIRS_MARKER);
+            out.push('\n');
+        }
+        None => {}
+    }
+    out
+}
+
+/// A candidate as zsh would have to see it typed.
+///
+/// The same rule the reference uses: left alone when every character is safe, and otherwise
+/// single-quoted with the close-open dance around any apostrophe.
+fn zsh_quote(value: &str) -> String {
+    let safe = |c: char| {
+        c.is_ascii_alphanumeric()
+            || matches!(c, '_' | '-' | '.' | '/' | ':' | '@' | '+' | '=' | '%' | ',')
+    };
+    if !value.is_empty() && value.chars().all(safe) {
+        return value.to_string();
+    }
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
 /// The paths an argument or value name asks for, by the name itself.
 ///
 /// The reference resolves a completer by the *lowercased name* and falls back to treating that
@@ -1594,5 +1673,79 @@ mod tests {
         let mistyped = answer("mise ship fast ::: zzz");
         assert!(mistyped.candidates.is_empty());
         assert_eq!(mistyped.files, None, "a mistyped choice is still a choice");
+    }
+
+    #[test]
+    fn each_shell_is_written_the_way_it_reads() {
+        let answer = complete(&SPEC, &at_end("mise pl"));
+
+        // bash shows values and nothing else.
+        assert_eq!(render(&answer, Shell::Bash), "plugins\n");
+
+        // fish, nu and PowerShell take a description after a tab.
+        assert_eq!(render(&answer, Shell::Fish), "plugins\tManage plugins\n");
+
+        // zsh takes a third field: what to type, which is not always what is shown.
+        assert_eq!(
+            render(&answer, Shell::Zsh),
+            "plugins\tManage plugins\tplugins\n"
+        );
+    }
+
+    #[test]
+    fn a_candidate_a_shell_could_not_read_is_quoted_for_zsh() {
+        static ODD: Command = Command {
+            name: "with space",
+            ..Command::EMPTY
+        };
+        static ODD_META: CommandMeta = CommandMeta {
+            cmd: &ODD,
+            about: Some("Odd"),
+            ..CommandMeta::EMPTY
+        };
+        static ODD_ROOT: Command = Command {
+            name: "ex",
+            subcommands: &[&ODD],
+            ..Command::EMPTY
+        };
+        static ODD_ROOT_META: CommandMeta = CommandMeta {
+            cmd: &ODD_ROOT,
+            subcommands: &[&ODD_META],
+            ..CommandMeta::EMPTY
+        };
+        static ODD_SPEC: Spec = Spec {
+            name: "ex",
+            bin: Some("ex"),
+            root: &ODD_ROOT_META,
+            ..Spec::EMPTY
+        };
+
+        let answer = complete(&ODD_SPEC, &split("ex ", 3, Shell::Zsh));
+        let line = render(&answer, Shell::Zsh);
+        // Shown as it is, typed as the shell needs it.
+        assert!(
+            line.starts_with("with space\tOdd\t'with space'"),
+            "{line:?}"
+        );
+    }
+
+    #[test]
+    fn the_marker_is_the_last_line_when_paths_belong() {
+        let answer = complete(&SPEC, &at_end("mise edit "));
+        let out = render(&answer, Shell::Bash);
+        assert_eq!(out.lines().last(), Some(FILES_MARKER));
+        // And the candidates are still there in front of it.
+        assert!(out.starts_with("mise.local.toml\nmise.toml\n"), "{out:?}");
+
+        let answer = complete(&SPEC, &at_end("mise edit --into "));
+        assert_eq!(
+            render(&answer, Shell::Fish).lines().last(),
+            Some(DIRS_MARKER)
+        );
+
+        // And absent where paths do not belong, rather than saying "none".
+        let answer = complete(&SPEC, &at_end("mise use "));
+        let out = render(&answer, Shell::Bash);
+        assert!(!out.contains('\u{1}'), "{out:?}");
     }
 }

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -175,7 +175,8 @@ pub fn render(answer: &Completions<'_>, shell: Shell) -> String {
     let described = answer.candidates.iter().any(|c| c.description.is_some());
 
     for candidate in &answer.candidates {
-        let description = candidate.description.unwrap_or_default();
+        let description = one_line(candidate.description.unwrap_or_default());
+        let description = description.as_str();
         match shell {
             Shell::Bash => out.push_str(&candidate.value),
             Shell::Zsh => {
@@ -208,6 +209,36 @@ pub fn render(answer: &Completions<'_>, shell: Shell) -> String {
             out.push('\n');
         }
         None => {}
+    }
+    out
+}
+
+/// A description with nothing in it that a line-based protocol would read as structure.
+///
+/// One line per candidate, fields separated by tabs — so a description containing either splits
+/// one candidate into several rows, or invents a field. mise declares multi-line `help` on 37 of
+/// its commands and flags, so this is the common case rather than a defensive one.
+///
+/// Collapsed rather than truncated at the first line: a description written across two lines is
+/// one sentence to a reader, and showing half of it is worse than showing it spaced.
+fn one_line(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut spaced = false;
+    for c in text.chars() {
+        if matches!(c, '\n' | '\r' | '\t') {
+            // One space for a run of them, and never a leading one.
+            if !spaced && !out.is_empty() {
+                out.push(' ');
+                spaced = true;
+            }
+        } else {
+            out.push(c);
+            spaced = false;
+        }
+    }
+    // A trailing break became a trailing space.
+    while out.ends_with(' ') {
+        out.pop();
     }
     out
 }
@@ -1747,5 +1778,45 @@ mod tests {
         let answer = complete(&SPEC, &at_end("mise use "));
         let out = render(&answer, Shell::Bash);
         assert!(!out.contains('\u{1}'), "{out:?}");
+    }
+    #[test]
+    fn a_description_written_across_lines_stays_one_row() {
+        // One line per candidate and tabs between fields, so a description containing either
+        // would split one candidate into several rows or invent a field. mise writes multi-line
+        // `help` on 37 of its commands and flags, so this is the ordinary case.
+        static WORDY: Command = Command {
+            name: "wordy",
+            ..Command::EMPTY
+        };
+        static WORDY_META: CommandMeta = CommandMeta {
+            cmd: &WORDY,
+            about: Some("First line\nsecond line\n\nand a\ttab"),
+            ..CommandMeta::EMPTY
+        };
+        static WORDY_ROOT: Command = Command {
+            name: "ex",
+            subcommands: &[&WORDY],
+            ..Command::EMPTY
+        };
+        static WORDY_ROOT_META: CommandMeta = CommandMeta {
+            cmd: &WORDY_ROOT,
+            subcommands: &[&WORDY_META],
+            ..CommandMeta::EMPTY
+        };
+        static WORDY_SPEC: Spec = Spec {
+            name: "ex",
+            bin: Some("ex"),
+            root: &WORDY_ROOT_META,
+            ..Spec::EMPTY
+        };
+
+        let answer = complete(&WORDY_SPEC, &split("ex w", 4, Shell::Fish));
+        let out = render(&answer, Shell::Fish);
+        assert_eq!(out, "wordy\tFirst line second line and a tab\n");
+        assert_eq!(out.lines().count(), 1, "one candidate, one row");
+
+        // zsh keeps its three fields, and no more.
+        let out = render(&answer, Shell::Zsh);
+        assert_eq!(out.matches('\t').count(), 2, "{out:?}");
     }
 }

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -85,6 +85,31 @@ use std::ffi::{OsStr, OsString};
 
 #[cfg(feature = "complete")]
 pub mod complete;
+
+/// Checks that the `complete` feature is on, with an explanation when it is not.
+///
+/// `#[usage(completion)]` generates code that reaches into [`complete`], which is behind a
+/// feature the *depending* crate enables — a derive cannot turn on a feature of another crate.
+/// Without this, the failure was `unresolved module complete`, which says nothing about the
+/// attribute that caused it.
+#[cfg(feature = "complete")]
+#[macro_export]
+macro_rules! __usage_needs_complete_feature {
+    () => {};
+}
+
+/// See [`__usage_needs_complete_feature`].
+#[cfg(not(feature = "complete"))]
+#[macro_export]
+macro_rules! __usage_needs_complete_feature {
+    () => {
+        ::core::compile_error!(
+            "`#[usage(completion)]` needs usage-argv's `complete` feature. Add it where \
+             usage-argv is depended on: usage-argv = { version = \"…\", features = \
+             [\"spec\", \"complete\"] }"
+        );
+    };
+}
 #[cfg(feature = "spec")]
 pub mod help;
 #[cfg(feature = "spec")]

--- a/conformance/tests/completion.rs
+++ b/conformance/tests/completion.rs
@@ -1,0 +1,154 @@
+//! The hidden command a shell calls, and what it answers.
+//!
+//! A completion request is a line and a cursor, and the answer comes from the same tables the
+//! parse uses. What is checked here is the part between: that a CLI which asks for completion
+//! recognizes the request, reads the three arguments a shell passes, and writes the answer the
+//! way that shell reads it — and that an ordinary invocation is untouched.
+
+use std::ffi::{OsStr, OsString};
+use usage_derive::{Args, Cli, Subcommands};
+
+#[derive(Args)]
+struct Install {
+    /// Which tool
+    #[usage(arg, name = "TOOL", choices("node", "python"))]
+    tool: Option<String>,
+}
+
+#[derive(Args)]
+struct Uninstall {
+    /// Which tool
+    #[usage(arg, name = "TOOL", choices("node", "python"))]
+    tool: Option<String>,
+}
+
+#[derive(Args)]
+struct Run {
+    /// Anything at all
+    #[usage(arg, name = "TASK")]
+    task: Option<String>,
+}
+
+#[derive(Subcommands)]
+enum Commands {
+    /// Run a task
+    Run(Box<Run>),
+    /// Install a tool
+    Install(Box<Install>),
+    /// Remove a tool
+    #[usage(alias = "rm")]
+    Uninstall(Box<Uninstall>),
+}
+
+/// A CLI that answers completions.
+#[derive(Cli)]
+#[usage(bin = "ex", completion)]
+struct Ex {
+    /// Say more
+    #[usage(long = "verbose", short = 'v')]
+    verbose: bool,
+    #[usage(subcommand)]
+    command: Option<Commands>,
+}
+
+fn ask(shell: &str, line: &str) -> String {
+    let argv: Vec<OsString> = ["__complete_word__", "--shell", shell, "--line", line]
+        .iter()
+        .map(OsString::from)
+        .collect();
+    Ex::completion_request(&argv).expect("this is a completion request")
+}
+
+#[test]
+fn a_request_is_answered_from_the_same_tables_the_parse_uses() {
+    assert_eq!(ask("bash", "ex "), "install\nrm\nrun\nuninstall\n");
+    assert_eq!(ask("bash", "ex ins"), "install\n");
+    assert_eq!(ask("bash", "ex install "), "node\npython\n");
+    assert_eq!(ask("bash", "ex --"), "--verbose\n");
+}
+
+#[test]
+fn each_shell_gets_the_shape_it_reads() {
+    // fish takes a description after a tab; bash does not; zsh takes what to type as well.
+    assert_eq!(ask("fish", "ex ins"), "install\tInstall a tool\n");
+    assert_eq!(ask("zsh", "ex ins"), "install\tInstall a tool\tinstall\n");
+    assert_eq!(ask("bash", "ex ins"), "install\n");
+}
+
+#[test]
+fn a_cursor_short_of_the_end_completes_the_word_it_is_in() {
+    let argv: Vec<OsString> = [
+        "__complete_word__",
+        "--shell",
+        "bash",
+        "--line",
+        "ex ins --verbose",
+        "--cursor",
+        "6",
+    ]
+    .iter()
+    .map(OsString::from)
+    .collect();
+    assert_eq!(
+        Ex::completion_request(&argv).expect("a request"),
+        "install\n"
+    );
+}
+
+#[test]
+fn an_ordinary_invocation_is_not_a_request() {
+    let argv: Vec<OsString> = ["install", "node"].iter().map(OsString::from).collect();
+    assert!(Ex::completion_request(&argv).is_none());
+    assert!(Ex::completion_request(&[]).is_none());
+
+    // And the CLI still parses what it always did — the hidden command is not in its grammar,
+    // so a positional that happens to be that word is still a positional.
+    let argv = [OsStr::new("run"), OsStr::new("__complete_word__")];
+    let parsed = Ex::parse_from(&argv).expect("an ordinary parse");
+    let Some(Commands::Run(run)) = parsed.command else {
+        panic!("expected run")
+    };
+    assert_eq!(run.task.as_deref(), Some("__complete_word__"));
+
+    // The choices still bind where they are declared, which is what makes the candidates above
+    // a description of this CLI rather than a list beside it.
+    let argv = [OsStr::new("install"), OsStr::new("node")];
+    let parsed = Ex::parse_from(&argv).expect("a declared choice");
+    let Some(Commands::Install(install)) = parsed.command else {
+        panic!("expected install")
+    };
+    assert_eq!(install.tool.as_deref(), Some("node"));
+
+    let argv = [OsStr::new("--verbose"), OsStr::new("run")];
+    let parsed = Ex::parse_from(&argv).expect("a flag the candidates offered");
+    assert!(parsed.verbose);
+
+    let argv = [OsStr::new("rm"), OsStr::new("python")];
+    let parsed = Ex::parse_from(&argv).expect("under its alias");
+    let Some(Commands::Uninstall(uninstall)) = parsed.command else {
+        panic!("expected uninstall")
+    };
+    assert_eq!(uninstall.tool.as_deref(), Some("python"));
+}
+
+#[test]
+fn a_shell_that_says_nothing_useful_still_gets_an_answer() {
+    // A completion that errors out is a shell that beeps at every keystroke, so an unknown
+    // argument is ignored and a missing cursor means the end of the line.
+    let argv: Vec<OsString> = [
+        "__complete_word__",
+        "--shell",
+        "klingon",
+        "--who-knows",
+        "x",
+        "--line",
+        "ex ins",
+    ]
+    .iter()
+    .map(OsString::from)
+    .collect();
+    assert_eq!(
+        Ex::completion_request(&argv).expect("a request"),
+        "install\n"
+    );
+}

--- a/conformance/tests/completion.rs
+++ b/conformance/tests/completion.rs
@@ -152,3 +152,41 @@ fn a_shell_that_says_nothing_useful_still_gets_an_answer() {
         "install\n"
     );
 }
+
+/// A CLI that says it does not want completions, in the spelling that would once have been read
+/// as wanting them.
+#[derive(Cli)]
+#[usage(bin = "off", completion = false)]
+struct Off {
+    /// Say more
+    #[usage(long = "verbose")]
+    verbose: bool,
+}
+
+/// The same name the derive would have generated, which is how the absence is asserted.
+///
+/// Rust refuses two inherent methods with one name on one type, so if `completion = false` were
+/// read as opting in, this impl would collide with the generated one and the crate would not
+/// build. A test can assert what is *there*; making it assert what is *not* takes a collision.
+impl Off {
+    fn completion_request(_argv: &[std::ffi::OsString]) -> Option<String> {
+        Some("written by hand".to_string())
+    }
+}
+
+#[test]
+fn saying_false_is_taken_as_false() {
+    // The attribute went through a path match, so any form carrying the word opted the CLI in —
+    // `completion = false` included, which is the one spelling whose whole point is not to.
+    assert_eq!(
+        Off::completion_request(&[]).as_deref(),
+        Some("written by hand"),
+        "the derive generated a completion request for a CLI that declined one"
+    );
+
+    let parsed = Off::parse_from(&[std::ffi::OsStr::new("--verbose")]).expect("an ordinary parse");
+    assert!(parsed.verbose);
+
+    // And the CLI that does ask for it still answers.
+    assert!(Ex::completion_request(&[std::ffi::OsString::from("__complete_word__")]).is_some());
+}

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -86,6 +86,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
     let defaults = partial_defaults(cli, false);
     let apply = apply_fn(cli);
     let post = post_binding(cli);
+    let (completion, completion_intercept) = completion_fns(cli);
     // `field: local` rather than the shorthand, because the locals are prefixed:
     // a field called `text` or `parser` would otherwise collide with something the
     // generated code needs.
@@ -253,7 +254,10 @@ pub fn emit(cli: &Cli) -> TokenStream {
             }
 
             /// Parse the process's own arguments.
+            #completion
+
             pub fn parse() -> ::std::result::Result<Self, ::std::string::String> {
+                #completion_intercept
                 let __usage_raw: ::std::vec::Vec<::std::ffi::OsString> =
                     ::std::env::args_os().skip(1).collect();
                 let __usage_argv: ::std::vec::Vec<&::std::ffi::OsStr> =
@@ -286,6 +290,86 @@ pub fn emit(cli: &Cli) -> TokenStream {
             }
         }
     }
+}
+
+/// The completion entry points, for a CLI that asked for them.
+///
+/// Two pieces: a function that answers a request, and the line in `parse` that notices one. Both
+/// empty without the opt-in, so a binary carries neither the hidden command nor the protocol —
+/// and `completion_script` cannot be called for a CLI whose binary would not answer it.
+fn completion_fns(cli: &Cli) -> (TokenStream, TokenStream) {
+    if !cli.completion {
+        return (TokenStream::new(), TokenStream::new());
+    }
+    let functions = quote! {
+        /// The word a shell is completing, answered from this CLI's own tables.
+        ///
+        /// `None` when argv is an ordinary invocation. The request is recognized before the
+        /// parse rather than inside it: a completion is not a command this CLI runs, and putting
+        /// it in the tables would make it one — visible to the grammar, the help and the spec.
+        pub fn completion_request(
+            argv: &[::std::ffi::OsString],
+        ) -> ::std::option::Option<::std::string::String> {
+            let first = argv.first()?.to_str()?;
+            if first != "__complete_word__" {
+                return ::std::option::Option::None;
+            }
+            // Its own flags, read by hand: three of them, and reading them with the parser
+            // would mean putting them in the tables this is deliberately outside of.
+            let mut shell = ::usage_argv::complete::Shell::Bash;
+            let mut line = ::std::string::String::new();
+            let mut cursor = ::std::option::Option::None;
+            let mut rest = argv[1..].iter();
+            while let ::std::option::Option::Some(arg) = rest.next() {
+                match arg.to_str().unwrap_or_default() {
+                    "--shell" => {
+                        if let ::std::option::Option::Some(name) = rest.next() {
+                            if let ::std::option::Option::Some(found) =
+                                ::usage_argv::complete::Shell::from_name(
+                                    &name.to_string_lossy(),
+                                )
+                            {
+                                shell = found;
+                            }
+                        }
+                    }
+                    "--line" => {
+                        if let ::std::option::Option::Some(value) = rest.next() {
+                            line = value.to_string_lossy().into_owned();
+                        }
+                    }
+                    "--cursor" => {
+                        cursor = rest
+                            .next()
+                            .and_then(|value| value.to_str().and_then(|v| v.parse().ok()));
+                    }
+                    // Anything else is a shell passing something this version does not know
+                    // about. Ignored rather than refused: a completion that errors out is a
+                    // shell that beeps at every keystroke.
+                    _ => {}
+                }
+            }
+            // No cursor means the end of the line, which is where a shell puts it when it has
+            // no way to say — nushell, whose completer only ever sees the words.
+            let cursor = cursor.unwrap_or(line.len());
+            let split = ::usage_argv::complete::split(&line, cursor, shell);
+            let answer = ::usage_argv::complete::complete(Self::spec(), &split);
+            ::std::option::Option::Some(::usage_argv::complete::render(&answer, shell))
+        }
+    };
+    let intercept = quote! {
+        // Before anything else, including the parse: a completion request is not this CLI's
+        // grammar and must not be measured against it.
+        {
+            let __usage_args: ::std::vec::Vec<::std::ffi::OsString> =
+                ::std::env::args_os().skip(1).collect();
+            if let ::std::option::Option::Some(answer) = Self::completion_request(&__usage_args) {
+                ::std::print!("{answer}");
+                ::std::process::exit(0);
+            }
+        }
+    };
+    (functions, intercept)
 }
 
 fn flag_table(i: usize, field: &Field) -> TokenStream {

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -302,6 +302,10 @@ fn completion_fns(cli: &Cli) -> (TokenStream, TokenStream) {
         return (TokenStream::new(), TokenStream::new());
     }
     let functions = quote! {
+        // Says what is missing, where the alternative is `unresolved module complete` — which
+        // names the symptom and not the attribute that asked for it.
+        ::usage_argv::__usage_needs_complete_feature!();
+
         /// The word a shell is completing, answered from this CLI's own tables.
         ///
         /// `None` when argv is an ordinary invocation. The request is recognized before the

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -141,6 +141,10 @@
 //! that will not convert becomes [`Error::InvalidValue`](usage_argv::Error::InvalidValue),
 //! carrying the offending text and whatever the type's own conversion said about it.
 //!
+//! On the struct itself: `bin`, `version`, `about`, `long_about`, `before_help`, `after_help`,
+//! `default_subcommand`, and `completion` — which adds the hidden command a generated shell
+//! script calls, and needs usage-argv's `complete` feature enabled where it is depended on.
+//!
 //! | option | meaning |
 //! | --- | --- |
 //! | `long`, `long = "x"` | a long form, defaulting to the field name |

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -248,7 +248,10 @@ impl Cli {
                 match ident_of(&path).as_str() {
                     "name" => cli.name = string_value(&meta)?,
                     "bin" => cli.bin = Some(string_value(&meta)?),
-                    "completion" => cli.completion = true,
+                    // Through the same helper as `global` and `var`, so `completion = false`
+                    // means false rather than being read as the bare word with something
+                    // decorative after it.
+                    "completion" => cli.completion = flag_value(&meta)?,
                     "version" => cli.version = Some(string_value(&meta)?),
                     // A doc comment's long form always contains its short one — the short form
                     // *is* the comment's first paragraph. A spec keeps `about` and `about_long`

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -21,6 +21,13 @@ pub struct Cli {
     pub name: String,
     pub bin: Option<String>,
     pub version: Option<String>,
+    /// Whether this CLI answers a completion request.
+    ///
+    /// Opt in rather than supplied like `--help`: it is a hidden command a binary carries and a
+    /// protocol a generated script depends on, so a CLI says when it wants both. The script
+    /// generator is emitted under the same flag, which makes a script that calls a command the
+    /// binary lacks a compile error rather than a puzzle at the prompt.
+    pub completion: bool,
     /// From the struct's doc comment: first paragraph, and the whole thing.
     pub about: Option<String>,
     pub long_about: Option<String>,
@@ -218,6 +225,7 @@ impl Cli {
             fingerprint: quote::ToTokens::to_token_stream(input).to_string(),
             name: to_kebab(&input.ident.to_string()),
             bin: None,
+            completion: false,
             version: None,
             about,
             long_about,
@@ -240,6 +248,7 @@ impl Cli {
                 match ident_of(&path).as_str() {
                     "name" => cli.name = string_value(&meta)?,
                     "bin" => cli.bin = Some(string_value(&meta)?),
+                    "completion" => cli.completion = true,
                     "version" => cli.version = Some(string_value(&meta)?),
                     // A doc comment's long form always contains its short one — the short form
                     // *is* the comment's first paragraph. A spec keeps `about` and `about_long`

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -334,6 +334,16 @@ impl Cli {
     /// learn that an attribute was in the wrong place.
     pub fn check_position(&self, ident: &syn::Ident, is_root: bool) -> syn::Result<()> {
         if !is_root {
+            // The completion command answers for the whole CLI, so it is declared where the
+            // whole CLI is. Accepted silently on an `Args`, it generated nothing and said
+            // nothing, which reads as a CLI that has completions and does not.
+            if self.completion {
+                return Err(syn::Error::new_spanned(
+                    ident,
+                    "`completion` belongs on the root, where `#[derive(Cli)]` is: the hidden \
+                     command it adds answers for the whole program, not for one of its commands",
+                ));
+            }
             // A spec declares one `default_subcommand`, at the top.
             if self.default_subcommand.is_some() {
                 return Err(syn::Error::new_spanned(


### PR DESCRIPTION
`ex __complete_word__ --shell zsh --line "ex ins" --cursor 6` — the hidden command
a generated script calls, answering from the same tables the parse uses. What this
deletes for an adopter is the reason it exists: mise's shipped completions today
hard-fail unless the separate `usage` CLI is installed, dump a spec into
`$XDG_CACHE_HOME` with `mise usage`, and shell out to `usage complete-word` on
every Tab. This is one process and no spec file.

Opt in with `#[usage(bin = "…", completion)]`, not supplied like `--help`: it is a
hidden command a binary carries and a protocol a script depends on, so a CLI says
when it wants both. The script generator will be emitted under the same flag, which
makes a script calling a command the binary lacks a compile error rather than a
puzzle at the prompt. A CLI that does not ask for it carries nothing — mise's
shadow does not, and the reported cost is unchanged at 29,962 instructions.

Recognized before the parse rather than inside it. A completion is not a command
this CLI runs, and putting it in the tables would make it one: visible to the
grammar, to the help, and to the emitted spec. So `ex run __complete_word__` still
binds that word to a positional, which a test holds.

Its three arguments are read by hand for the same reason, and read forgivingly —
an unknown one is ignored and a missing cursor means the end of the line, which is
where nushell's completer leaves it. A completion that errors out is a shell that
beeps at every keystroke.

Rendering is per shell, in `argv`: bash reads values, fish and nu and PowerShell
take a description after a tab, zsh takes a third field for what to *type*, since
a candidate with a space in it has to reach the command line intact.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New opt-in completion path touches `parse()` entry and stdout/exit(0) on completion; mistakes could affect normal runs only for CLIs that enable the attribute, but wrong interception would be user-visible at the shell.
> 
> **Overview**
> **In-process tab completion** replaces shelling out to an external `usage` CLI: opt in with **`#[usage(completion)]`** on the root `#[derive(Cli)]` ( **`completion = false`** is honored via `flag_value`).
> 
> The derive emits **`completion_request`** and intercepts **`parse()`** when argv starts with **`__complete_word__`**, manually reading `--shell`, `--line`, and optional `--cursor`, then answering from **`Self::spec()`** via **`complete::split`**, **`complete`**, and new **`render`**. Completion is **not** part of the parse grammar, so normal invocations (e.g. `run __complete_word__` as a positional) stay unchanged.
> 
> **`usage-argv::complete`** gains **`render`**, **`FILES_MARKER` / `DIRS_MARKER`**, **`one_line`** (multi-line help collapsed for line protocols), and **`zsh_quote`**. **`__usage_needs_complete_feature!`** gives a clear compile error when the `complete` feature is missing.
> 
> Conformance tests in **`completion.rs`** cover candidates, per-shell output shapes, cursor handling, forgiving unknown flags, and **`completion = false`** not generating a colliding method.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cf62132d2363dd6d7e55a2f908ccbfff4e82afa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->