### PR TITLE
feat(argv): write the `run=` a declared completer answers

### DIFF
--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -1265,21 +1265,39 @@ mod tests {
         longs: &["only"],
         ..Flag::VALUE
     };
+    /// A flag whose completer is *not* the argument's, so which one answered is visible.
+    fn sources(_ctx: &CompleteCtx<'_>) -> Vec<Candidate<'static>> {
+        vec![Candidate::new("upstream")]
+    }
+    static SOURCE: Flag = Flag {
+        key: 17,
+        name: "source",
+        longs: &["source"],
+        ..Flag::VALUE
+    };
     static INSTALL: Command = Command {
         name: "install",
-        flags: &[&ONLY],
+        flags: &[&ONLY, &SOURCE],
         args: &[&TOOL_ARG],
         ..Command::EMPTY
     };
     static META_INSTALL: CommandMeta = CommandMeta {
         cmd: &INSTALL,
         about: Some("Install a tool"),
-        flags: &[FlagMeta {
-            flag: &ONLY,
-            help: Some("Just this one"),
-            complete: Some(tools),
-            ..FlagMeta::EMPTY
-        }],
+        flags: &[
+            FlagMeta {
+                flag: &ONLY,
+                help: Some("Just this one"),
+                complete: Some(tools),
+                ..FlagMeta::EMPTY
+            },
+            FlagMeta {
+                flag: &SOURCE,
+                help: Some("Where from"),
+                complete: Some(sources),
+                ..FlagMeta::EMPTY
+            },
+        ],
         args: &[ArgMeta {
             arg: &TOOL_ARG,
             help: Some("Which tool"),
@@ -2126,5 +2144,19 @@ mod tests {
         let a = answer("mise install zzz");
         assert!(a.candidates.is_empty());
         assert_eq!(a.files, Some(Files::Any));
+    }
+    #[test]
+    fn an_attached_value_is_not_answered_by_the_positional() {
+        // `--source=⌶` is a dash-prefixed token, so it is a *flag* position: the flag branches
+        // come first and the positional's completer is never reached. Worth pinning, because the
+        // word being completed is excluded from the walk — so the flag is not `awaiting_value`
+        // either, and the position could look like the argument's if the order changed.
+        assert!(!offered("mise install --source=").contains(&"node".to_string()));
+        assert!(!offered("mise install --source=").contains(&"upstream".to_string()));
+        assert!(!offered("mise install -s").contains(&"node".to_string()));
+
+        // Detached, the flag's own completer answers — which is the case that works.
+        assert_eq!(offered("mise install --source "), ["upstream"]);
+        assert_eq!(offered("mise install "), ["node", "python", "ruby"]);
     }
 }

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -124,6 +124,25 @@ pub fn for_name<'a>(
     name: &str,
     ctx: &CompleteCtx<'_>,
 ) -> Option<Vec<Candidate<'static>>> {
+    fn on(meta: &CommandMeta<'_>, name: &str) -> Option<Completer> {
+        for arg in meta.args {
+            if arg.arg.name.eq_ignore_ascii_case(name) {
+                if let Some(completer) = arg.complete {
+                    return Some(completer);
+                }
+            }
+        }
+        for flag in meta.flags {
+            let value = flag.value_name.unwrap_or(flag.flag.name);
+            if value.eq_ignore_ascii_case(name) {
+                if let Some(completer) = flag.complete {
+                    return Some(completer);
+                }
+            }
+        }
+        None
+    }
+
     fn find(meta: &CommandMeta<'_>, name: &str) -> Option<Completer> {
         for arg in meta.args {
             if arg.arg.name.eq_ignore_ascii_case(name) {
@@ -143,39 +162,40 @@ pub fn for_name<'a>(
         meta.subcommands.iter().find_map(|sub| find(sub, name))
     }
 
-    let completer = find(spec.root, name)?;
+    // The command the line reached first, and only then anywhere in the tree. Two sibling
+    // commands may take a `tool` and mean different things by it — a spec says so by writing the
+    // block inside the command rather than at the top — and answering with the first one found
+    // in tree order would be answering about a different command than the one being typed.
+    let reached = walk(spec.root.cmd, ctx.command_words_start());
+    let completer = crate::help::find(spec, reached.cmd)
+        .and_then(|(_, meta)| on(meta, name))
+        .or_else(|| find(spec.root, name))?;
     let mut found = completer(ctx);
     found.retain(|c| c.value.starts_with(ctx.prefix));
     Some(found)
 }
 
-/// Every completer a spec declares, as the names a `complete` block is written under.
+/// The completers one command declares, as the names a `complete` block is written under.
 ///
-/// Sorted and deduplicated, because two commands may take the same kind of value — mise's `tool`
-/// is an argument of six of them — and a spec declares one block for it.
+/// One command's own, not the tree's: a spec writes the block inside the command that declares
+/// it, so two siblings taking a `tool` and meaning different things by it each say so.
 #[cfg(feature = "spec")]
-pub fn declared_completers(spec: &Spec<'_>) -> Vec<String> {
-    fn walk(meta: &CommandMeta<'_>, out: &mut Vec<String>) {
-        for arg in meta.args {
-            if arg.complete.is_some() {
-                out.push(arg.arg.name.to_ascii_lowercase());
-            }
-        }
-        for flag in meta.flags {
-            if flag.complete.is_some() {
-                out.push(
-                    flag.value_name
-                        .unwrap_or(flag.flag.name)
-                        .to_ascii_lowercase(),
-                );
-            }
-        }
-        for sub in meta.subcommands {
-            walk(sub, out);
+pub fn completers_on(meta: &CommandMeta<'_>) -> Vec<String> {
+    let mut out = Vec::new();
+    for arg in meta.args {
+        if arg.complete.is_some() {
+            out.push(arg.arg.name.to_ascii_lowercase());
         }
     }
-    let mut out = Vec::new();
-    walk(spec.root, &mut out);
+    for flag in meta.flags {
+        if flag.complete.is_some() {
+            out.push(
+                flag.value_name
+                    .unwrap_or(flag.flag.name)
+                    .to_ascii_lowercase(),
+            );
+        }
+    }
     out.sort();
     out.dedup();
     out
@@ -200,6 +220,16 @@ pub struct CompleteCtx<'a> {
 }
 
 impl<'a> CompleteCtx<'a> {
+    /// The words a parser should walk to find the command this request is about.
+    ///
+    /// After the program name, before the word being completed — the same slice `walk` is given
+    /// for an ordinary request, so a `--candidates` request resolves the same command an
+    /// ordinary one would.
+    pub fn command_words_start(&self) -> &'a [String] {
+        let start = 1.min(self.cword);
+        self.words.get(start..self.cword).unwrap_or(&[])
+    }
+
     /// The word before the one being completed, which is what mise's `{{words[PREV]}}` means.
     pub fn previous(&self) -> Option<&'a str> {
         self.cword

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -109,6 +109,78 @@ pub fn walk<'t>(root: &'t Command<'t>, words: &[String]) -> Position<'t> {
     }
 }
 
+/// Answer for the completer a spec names, wherever in the tree it was declared.
+///
+/// The other half of what `to_kdl` writes. A spec says `complete "tool" run="mise
+/// __complete_word__ --candidates tool"`, and this is what answers that command — so the KDL is
+/// complete for the usage CLI, for another shell's generator, for anything that reads a spec,
+/// while the binary still answers itself when its own script asks.
+///
+/// Found by the name a spec uses, which is the lowercased argument name — the same rule the
+/// reference resolves a `complete` block by, so the two agree about which completer a `run=`
+/// belongs to. `None` when nothing of that name declares one.
+pub fn for_name<'a>(
+    spec: &'a Spec<'a>,
+    name: &str,
+    ctx: &CompleteCtx<'_>,
+) -> Option<Vec<Candidate<'static>>> {
+    fn find(meta: &CommandMeta<'_>, name: &str) -> Option<Completer> {
+        for arg in meta.args {
+            if arg.arg.name.eq_ignore_ascii_case(name) {
+                if let Some(completer) = arg.complete {
+                    return Some(completer);
+                }
+            }
+        }
+        for flag in meta.flags {
+            let value = flag.value_name.unwrap_or(flag.flag.name);
+            if value.eq_ignore_ascii_case(name) {
+                if let Some(completer) = flag.complete {
+                    return Some(completer);
+                }
+            }
+        }
+        meta.subcommands.iter().find_map(|sub| find(sub, name))
+    }
+
+    let completer = find(spec.root, name)?;
+    let mut found = completer(ctx);
+    found.retain(|c| c.value.starts_with(ctx.prefix));
+    Some(found)
+}
+
+/// Every completer a spec declares, as the names a `complete` block is written under.
+///
+/// Sorted and deduplicated, because two commands may take the same kind of value — mise's `tool`
+/// is an argument of six of them — and a spec declares one block for it.
+#[cfg(feature = "spec")]
+pub fn declared_completers(spec: &Spec<'_>) -> Vec<String> {
+    fn walk(meta: &CommandMeta<'_>, out: &mut Vec<String>) {
+        for arg in meta.args {
+            if arg.complete.is_some() {
+                out.push(arg.arg.name.to_ascii_lowercase());
+            }
+        }
+        for flag in meta.flags {
+            if flag.complete.is_some() {
+                out.push(
+                    flag.value_name
+                        .unwrap_or(flag.flag.name)
+                        .to_ascii_lowercase(),
+                );
+            }
+        }
+        for sub in meta.subcommands {
+            walk(sub, out);
+        }
+    }
+    let mut out = Vec::new();
+    walk(spec.root, &mut out);
+    out.sort();
+    out.dedup();
+    out
+}
+
 /// What a completion callback is told about the cursor.
 ///
 /// Everything a `run=` command is given through tera — the words, which one the cursor is in —

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -143,23 +143,36 @@ pub fn for_name<'a>(
         None
     }
 
-    fn find(meta: &CommandMeta<'_>, name: &str) -> Option<Completer> {
-        for arg in meta.args {
-            if arg.arg.name.eq_ignore_ascii_case(name) {
-                if let Some(completer) = arg.complete {
-                    return Some(completer);
-                }
-            }
-        }
-        for flag in meta.flags {
-            let value = flag.value_name.unwrap_or(flag.flag.name);
-            if value.eq_ignore_ascii_case(name) {
-                if let Some(completer) = flag.complete {
-                    return Some(completer);
-                }
-            }
+    fn find<'m, 's>(meta: &'m CommandMeta<'s>, name: &str) -> Option<&'m CommandMeta<'s>> {
+        if on(meta, name).is_some() {
+            return Some(meta);
         }
         meta.subcommands.iter().find_map(|sub| find(sub, name))
+    }
+
+    // A command can have two fields under one normalized completion name. Its emitted KDL has
+    // one name-keyed block, so the line that block passes back is what distinguishes them. Use
+    // the parser's position before falling back to declaration order for a stale or incomplete
+    // request whose line does not identify either field.
+    fn at_cursor(meta: &CommandMeta<'_>, name: &str, position: &Position<'_>) -> Option<Completer> {
+        if let Some(wanted) = position.awaiting_value {
+            let found = meta.flags.iter().find(|field| {
+                let value = field.value_name.unwrap_or(field.flag.name);
+                core::ptr::eq(field.flag, wanted) && value.eq_ignore_ascii_case(name)
+            });
+            if let Some(completer) = found.and_then(|field| field.complete) {
+                return Some(completer);
+            }
+        }
+        if let Some(wanted) = position.next_arg {
+            let found = meta.args.iter().find(|field| {
+                core::ptr::eq(field.arg, wanted) && field.arg.name.eq_ignore_ascii_case(name)
+            });
+            if let Some(completer) = found.and_then(|field| field.complete) {
+                return Some(completer);
+            }
+        }
+        None
     }
 
     // The root's own first, then the command the line reached, then anywhere in the tree.
@@ -172,9 +185,15 @@ pub fn for_name<'a>(
     // Tree order last, and only as a fallback: two sibling commands may take a `tool` and mean
     // different things by it, and the one the line reached is the one being asked about.
     let reached = walk(spec.root.cmd, ctx.command_words_start());
-    let completer = on(spec.root, name)
-        .or_else(|| crate::help::find(spec, reached.cmd).and_then(|(_, meta)| on(meta, name)))
-        .or_else(|| find(spec.root, name))?;
+    let reached_meta = crate::help::find(spec, reached.cmd).map(|(_, meta)| meta);
+    let owner = if on(spec.root, name).is_some() {
+        spec.root
+    } else if let Some(meta) = reached_meta.filter(|meta| on(meta, name).is_some()) {
+        meta
+    } else {
+        find(spec.root, name)?
+    };
+    let completer = at_cursor(owner, name, &reached).or_else(|| on(owner, name))?;
     let mut found = completer(ctx);
     found.retain(|c| c.value.starts_with(ctx.prefix));
     Some(found)

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -162,13 +162,18 @@ pub fn for_name<'a>(
         meta.subcommands.iter().find_map(|sub| find(sub, name))
     }
 
-    // The command the line reached first, and only then anywhere in the tree. Two sibling
-    // commands may take a `tool` and mean different things by it — a spec says so by writing the
-    // block inside the command rather than at the top — and answering with the first one found
-    // in tree order would be answering about a different command than the one being typed.
+    // The root's own first, then the command the line reached, then anywhere in the tree.
+    //
+    // The first two in that order because the reference resolves a `complete` block that way —
+    // `spec.complete.get(name).or(cmd.complete.get(name))` — and the root's completers are what
+    // a spec writes at the top level, which is `spec.complete`. Answering in a different order
+    // would mean this binary and the reference disagreed about a spec they both read.
+    //
+    // Tree order last, and only as a fallback: two sibling commands may take a `tool` and mean
+    // different things by it, and the one the line reached is the one being asked about.
     let reached = walk(spec.root.cmd, ctx.command_words_start());
-    let completer = crate::help::find(spec, reached.cmd)
-        .and_then(|(_, meta)| on(meta, name))
+    let completer = on(spec.root, name)
+        .or_else(|| crate::help::find(spec, reached.cmd).and_then(|(_, meta)| on(meta, name)))
         .or_else(|| find(spec.root, name))?;
     let mut found = completer(ctx);
     found.retain(|c| c.value.starts_with(ctx.prefix));

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -483,19 +483,6 @@ impl Spec<'_> {
         // completer is said to exist: the Rust function. Everything that reads a spec — the
         // usage CLI, another shell's generator, a doc page — gets a `run=` that works, and this
         // binary answers it without a second program in the way.
-        #[cfg(feature = "complete")]
-        for name in crate::complete::declared_completers(self) {
-            let bin = self.bin.unwrap_or(self.name);
-            write!(out, "complete {}", quoted(&name))?;
-            write!(
-                out,
-                " run={}",
-                quoted(&format!("{bin} __complete_word__ --candidates {name}"))
-            )?;
-            // The answers carry descriptions, which is what tells the reference to read one
-            // after a `:` rather than treating the whole line as a value.
-            writeln!(out, " descriptions=#true")?;
-        }
 
         // The text around the page. The root's nodes are written here rather than by
         // `write_body`, so these had to be repeated — and were not, which left a root's
@@ -538,7 +525,7 @@ impl Spec<'_> {
         for example in self.root.examples {
             write_example(out, example, 0)?;
         }
-        write_body(out, self.root, 0)
+        write_body(out, self.root, 0, self.bin.unwrap_or(self.name))
     }
 }
 
@@ -546,7 +533,12 @@ impl Spec<'_> {
 ///
 /// Separate from [`write_command`] because the root's contents sit at the top
 /// level of the document rather than inside a `cmd` node.
-fn write_body(out: &mut String, meta: &CommandMeta<'_>, depth: usize) -> core::fmt::Result {
+fn write_body(
+    out: &mut String,
+    meta: &CommandMeta<'_>,
+    depth: usize,
+    bin: &str,
+) -> core::fmt::Result {
     let enclosing_unknown_flags = meta.cmd.unknown_flags;
     // Indexing by metadata position below cannot see a table entry with no
     // metadata, which would be silently unwritten. Check the lengths first.
@@ -587,8 +579,10 @@ fn write_body(out: &mut String, meta: &CommandMeta<'_>, depth: usize) -> core::f
         );
         write_arg(out, arg, depth)?;
     }
+    #[cfg(feature = "complete")]
+    write_completers(out, meta, bin, depth)?;
     for sub in meta.subcommands {
-        write_command(out, sub, depth, enclosing_unknown_flags)?;
+        write_command(out, sub, depth, enclosing_unknown_flags, bin)?;
     }
     Ok(())
 }
@@ -598,6 +592,7 @@ fn write_command(
     meta: &CommandMeta<'_>,
     depth: usize,
     inherited_unknown_flags: UnknownFlags,
+    bin: &str,
 ) -> core::fmt::Result {
     indent(out, depth)?;
     write!(out, "cmd {}", quoted(meta.cmd.name))?;
@@ -662,7 +657,7 @@ fn write_command(
     for example in meta.examples {
         write_example(out, example, inner)?;
     }
-    write_body(out, meta, inner)?;
+    write_body(out, meta, inner, bin)?;
 
     indent(out, depth)?;
     out.push_str("}\n");
@@ -679,6 +674,42 @@ fn write_example(out: &mut String, example: &Example<'_>, depth: usize) -> core:
         write!(out, " help={}", quoted(help))?;
     }
     out.push('\n');
+    Ok(())
+}
+
+/// The `complete` blocks for one command, written where that command declares them.
+///
+/// Inside the `cmd` block rather than at the top level, because two sibling commands may take a
+/// `tool` and mean different things by it — the reference looks a completer up on the command
+/// first and only then on the spec, so this is what says which one a name belongs to.
+///
+/// The command line goes with the request. A caller that runs this is the *reference*, which
+/// interpolates `words` through tera before running it, so a completer reading the line sees the
+/// same line it would have seen natively — without it the answer would be computed against
+/// nothing, which for a completer that reads an earlier flag is a wrong answer rather than a
+/// missing one.
+#[cfg(feature = "complete")]
+fn write_completers(
+    out: &mut String,
+    meta: &CommandMeta<'_>,
+    bin: &str,
+    depth: usize,
+) -> core::fmt::Result {
+    for name in crate::complete::completers_on(meta) {
+        indent(out, depth)?;
+        write!(out, "complete {}", quoted(&name))?;
+        write!(
+            out,
+            " run={}",
+            quoted(&format!(
+                "{bin} __complete_word__ --candidates {name} --line '{{{{ words | join(sep=\" \") }}}}'"
+            ))
+        )?;
+        // No `descriptions=#true`: that tells the reference to read a description after an
+        // unescaped colon, and what this answers with is values. Claiming otherwise would split
+        // a value containing a colon — which mise's task names are full of.
+        writeln!(out)?;
+    }
     Ok(())
 }
 
@@ -1220,7 +1251,7 @@ mod tests {
         };
 
         let mut out = String::new();
-        write_body(&mut out, &ROOT_META, 0).unwrap();
+        write_body(&mut out, &ROOT_META, 0, "ex").unwrap();
 
         // Counted rather than checked with `contains`, which is how a duplicated
         // write survived review: `unknown_flags="value" unknown_flags="value"` contains

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -478,6 +478,25 @@ impl Spec<'_> {
         if let Some(default_subcommand) = self.default_subcommand {
             prop(out, "default_subcommand", default_subcommand)?;
         }
+        // A `complete` block for every completer this CLI declares, naming the command that
+        // asks the binary itself. Written rather than declared, so there is one place a
+        // completer is said to exist: the Rust function. Everything that reads a spec — the
+        // usage CLI, another shell's generator, a doc page — gets a `run=` that works, and this
+        // binary answers it without a second program in the way.
+        #[cfg(feature = "complete")]
+        for name in crate::complete::declared_completers(self) {
+            let bin = self.bin.unwrap_or(self.name);
+            write!(out, "complete {}", quoted(&name))?;
+            write!(
+                out,
+                " run={}",
+                quoted(&format!("{bin} __complete_word__ --candidates {name}"))
+            )?;
+            // The answers carry descriptions, which is what tells the reference to read one
+            // after a `:` rather than treating the whole line as a value.
+            writeln!(out, " descriptions=#true")?;
+        }
+
         // The text around the page. The root's nodes are written here rather than by
         // `write_body`, so these had to be repeated — and were not, which left a root's
         // preamble out of the spec that docs, manpages and completions read.

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -702,7 +702,7 @@ fn write_completers(
             out,
             " run={}",
             quoted(&format!(
-                "{bin} __complete_word__ --candidates {name} --line '{{{{ words | join(sep=\" \") }}}}'"
+                "{bin} __complete_word__ --candidates {name} --line '{{{{ words | join(sep=\" \") | replace(from=\"'\", to=\"'\\\"'\\\"'\") }}}}'"
             ))
         )?;
         // No `descriptions=#true`: that tells the reference to read a description after an

--- a/conformance/tests/spec_roundtrip.rs
+++ b/conformance/tests/spec_roundtrip.rs
@@ -804,6 +804,12 @@ fn local_tools(
     vec![usage_argv::complete::Candidate::new("installed")]
 }
 
+fn root_tools(
+    _ctx: &usage_argv::complete::CompleteCtx<'_>,
+) -> Vec<usage_argv::complete::Candidate<'static>> {
+    vec![usage_argv::complete::Candidate::new("root")]
+}
+
 fn remote_tools(
     _ctx: &usage_argv::complete::CompleteCtx<'_>,
 ) -> Vec<usage_argv::complete::Candidate<'static>> {
@@ -889,6 +895,53 @@ fn two_commands_can_mean_different_things_by_one_name() {
             "{expected} should declare its own: {kdl}"
         );
     }
+
+    // A root that declares the same name wins over both, which is the order the reference
+    // resolves in — `spec.complete` before `cmd.complete` — and the root's completers are what a
+    // spec writes at the top level. Recorded here rather than assumed, because it is the one
+    // place this order is visible.
+    static ROOT_TOOL: Arg = Arg {
+        key: 93,
+        name: "TOOL",
+        ..Arg::REQUIRED
+    };
+    static ROOT_WITH_ARG: Command = Command {
+        name: "ex",
+        args: &[&ROOT_TOOL],
+        subcommands: &[&USE_CMD, &INSTALL_CMD],
+        ..Command::EMPTY
+    };
+    static ROOT_META_THREE: CommandMeta = CommandMeta {
+        cmd: &ROOT_WITH_ARG,
+        args: &[ArgMeta {
+            arg: &ROOT_TOOL,
+            complete: Some(root_tools),
+            ..ArgMeta::EMPTY
+        }],
+        subcommands: &[&USE_META, &INSTALL_META],
+        ..CommandMeta::EMPTY
+    };
+    static SPEC_THREE: Spec = Spec {
+        name: "ex",
+        bin: Some("ex"),
+        version: None,
+        about: None,
+        long_about: None,
+        default_subcommand: None,
+        root: &ROOT_META_THREE,
+    };
+    let words = ["ex".to_string(), "use".to_string(), String::new()];
+    let ctx = usage_argv::complete::CompleteCtx {
+        words: &words,
+        cword: 2,
+        prefix: "",
+    };
+    let found = usage_argv::complete::for_name(&SPEC_THREE, "tool", &ctx).expect("a completer");
+    assert_eq!(
+        found.iter().map(|c| c.value.as_str()).collect::<Vec<_>>(),
+        ["root"],
+        "the root's wins, as it does in the reference"
+    );
 
     // And the binary answers about the command the line reached, not the first one in the tree.
     for (line, expected) in [("ex use ", "installed"), ("ex install ", "available")] {

--- a/conformance/tests/spec_roundtrip.rs
+++ b/conformance/tests/spec_roundtrip.rs
@@ -759,7 +759,7 @@ fn a_declared_completer_becomes_a_run_the_reference_can_read() {
 
     let kdl = SPEC.to_kdl();
     assert!(
-        kdl.contains(r#"complete "tool" run="ex __complete_word__ --candidates tool""#),
+        kdl.contains(r#"complete "tool" run="ex __complete_word__ --candidates tool --line"#),
         "{kdl}"
     );
 
@@ -767,11 +767,21 @@ fn a_declared_completer_becomes_a_run_the_reference_can_read() {
     // the rule both sides resolve one by.
     let lib: LibSpec = kdl.parse().expect("valid spec");
     let complete = lib.complete.get("tool").expect("a complete block");
-    assert_eq!(
-        complete.run.as_deref(),
-        Some("ex __complete_word__ --candidates tool")
+    let run = complete.run.as_deref().expect("a run command");
+    assert!(
+        run.starts_with("ex __complete_word__ --candidates tool"),
+        "{run}"
     );
-    assert!(complete.descriptions, "the answers carry descriptions");
+    // The line goes with the request, interpolated by whoever runs it — without it a completer
+    // that reads an earlier flag answers against nothing, which is a wrong answer rather than a
+    // missing one.
+    assert!(
+        run.contains("--line '{{ words | join(sep=\" \") }}'"),
+        "{run}"
+    );
+    // And no `descriptions=#true`, which would tell the reference to read a description after an
+    // unescaped colon: what this answers with is values, and mise's task names are full of colons.
+    assert!(!complete.descriptions, "{run}");
 
     // The binary answers exactly that, filtered by whatever has been typed.
     let ctx = usage_argv::complete::CompleteCtx {
@@ -786,4 +796,113 @@ fn a_declared_completer_becomes_a_run_the_reference_can_read() {
     // A name nothing declares is an empty answer rather than a failure: a stale script should
     // complete nothing, not print into the prompt.
     assert!(usage_argv::complete::for_name(&SPEC, "nonesuch", &ctx).is_none());
+}
+
+fn local_tools(
+    _ctx: &usage_argv::complete::CompleteCtx<'_>,
+) -> Vec<usage_argv::complete::Candidate<'static>> {
+    vec![usage_argv::complete::Candidate::new("installed")]
+}
+
+fn remote_tools(
+    _ctx: &usage_argv::complete::CompleteCtx<'_>,
+) -> Vec<usage_argv::complete::Candidate<'static>> {
+    vec![usage_argv::complete::Candidate::new("available")]
+}
+
+#[test]
+fn two_commands_can_mean_different_things_by_one_name() {
+    // `ex use <TOOL>` and `ex install <TOOL>` take the same *kind* of thing under the same name
+    // and answer differently — the installed ones against the available ones. A single top-level
+    // block could not say that, and answering with whichever came first in tree order would be
+    // answering about the wrong command.
+    static USE_TOOL: Arg = Arg {
+        key: 91,
+        name: "TOOL",
+        ..Arg::REQUIRED
+    };
+    static INSTALL_TOOL: Arg = Arg {
+        key: 92,
+        name: "TOOL",
+        ..Arg::REQUIRED
+    };
+    static USE_CMD: Command = Command {
+        name: "use",
+        args: &[&USE_TOOL],
+        ..Command::EMPTY
+    };
+    static INSTALL_CMD: Command = Command {
+        name: "install",
+        args: &[&INSTALL_TOOL],
+        ..Command::EMPTY
+    };
+    static ROOT: Command = Command {
+        name: "ex",
+        subcommands: &[&USE_CMD, &INSTALL_CMD],
+        ..Command::EMPTY
+    };
+    static USE_META: CommandMeta = CommandMeta {
+        cmd: &USE_CMD,
+        args: &[ArgMeta {
+            arg: &USE_TOOL,
+            complete: Some(local_tools),
+            ..ArgMeta::EMPTY
+        }],
+        ..CommandMeta::EMPTY
+    };
+    static INSTALL_META: CommandMeta = CommandMeta {
+        cmd: &INSTALL_CMD,
+        args: &[ArgMeta {
+            arg: &INSTALL_TOOL,
+            complete: Some(remote_tools),
+            ..ArgMeta::EMPTY
+        }],
+        ..CommandMeta::EMPTY
+    };
+    static ROOT_META_TWO: CommandMeta = CommandMeta {
+        cmd: &ROOT,
+        subcommands: &[&USE_META, &INSTALL_META],
+        ..CommandMeta::EMPTY
+    };
+    static SPEC_TWO: Spec = Spec {
+        name: "ex",
+        bin: Some("ex"),
+        version: None,
+        about: None,
+        long_about: None,
+        default_subcommand: None,
+        root: &ROOT_META_TWO,
+    };
+
+    // Each block is written inside the command that declares it, which is where usage-lib looks
+    // for one first.
+    let kdl = SPEC_TWO.to_kdl();
+    let lib: LibSpec = kdl.parse().expect("valid spec");
+    assert!(
+        lib.complete.is_empty(),
+        "neither belongs at the top level: {kdl}"
+    );
+    for (name, expected) in [("use", "use"), ("install", "install")] {
+        let cmd = lib.cmd.subcommands.get(name).expect("the command");
+        assert!(
+            cmd.complete.contains_key("tool"),
+            "{expected} should declare its own: {kdl}"
+        );
+    }
+
+    // And the binary answers about the command the line reached, not the first one in the tree.
+    for (line, expected) in [("ex use ", "installed"), ("ex install ", "available")] {
+        let words: Vec<String> = line.split_whitespace().map(String::from).collect();
+        let ctx = usage_argv::complete::CompleteCtx {
+            words: &[words.clone(), vec![String::new()]].concat(),
+            cword: words.len(),
+            prefix: "",
+        };
+        let found = usage_argv::complete::for_name(&SPEC_TWO, "tool", &ctx).expect("a completer");
+        assert_eq!(
+            found.iter().map(|c| c.value.as_str()).collect::<Vec<_>>(),
+            [expected],
+            "{line}"
+        );
+    }
 }

--- a/conformance/tests/spec_roundtrip.rs
+++ b/conformance/tests/spec_roundtrip.rs
@@ -710,3 +710,80 @@ fn the_docs_pipeline_accepts_it() {
         "the manpage should name the program"
     );
 }
+
+/// What answers for a value the spec says a command runs for.
+fn tools(
+    ctx: &usage_argv::complete::CompleteCtx<'_>,
+) -> Vec<usage_argv::complete::Candidate<'static>> {
+    let _ = ctx;
+    vec![
+        usage_argv::complete::Candidate::described("node", "JavaScript"),
+        usage_argv::complete::Candidate::new("python"),
+    ]
+}
+
+#[test]
+fn a_declared_completer_becomes_a_run_the_reference_can_read() {
+    // The point of generating the `run=` rather than writing one: there is one place a completer
+    // is said to exist — the Rust function — and the spec still says something a reader can act
+    // on. What it says is a command asking *this binary*, which is the thing the binary answers.
+    static ARG: Arg = Arg {
+        key: 90,
+        name: "TOOL",
+        ..Arg::REQUIRED
+    };
+    static CMD: Command = Command {
+        name: "ex",
+        args: &[&ARG],
+        ..Command::EMPTY
+    };
+    static META: CommandMeta = CommandMeta {
+        cmd: &CMD,
+        args: &[ArgMeta {
+            arg: &ARG,
+            help: Some("Which tool"),
+            complete: Some(tools),
+            ..ArgMeta::EMPTY
+        }],
+        ..CommandMeta::EMPTY
+    };
+    static SPEC: Spec = Spec {
+        name: "ex",
+        bin: Some("ex"),
+        version: None,
+        about: None,
+        long_about: None,
+        default_subcommand: None,
+        root: &META,
+    };
+
+    let kdl = SPEC.to_kdl();
+    assert!(
+        kdl.contains(r#"complete "tool" run="ex __complete_word__ --candidates tool""#),
+        "{kdl}"
+    );
+
+    // And usage-lib reads it as a completer for that argument — by the lowercased name, which is
+    // the rule both sides resolve one by.
+    let lib: LibSpec = kdl.parse().expect("valid spec");
+    let complete = lib.complete.get("tool").expect("a complete block");
+    assert_eq!(
+        complete.run.as_deref(),
+        Some("ex __complete_word__ --candidates tool")
+    );
+    assert!(complete.descriptions, "the answers carry descriptions");
+
+    // The binary answers exactly that, filtered by whatever has been typed.
+    let ctx = usage_argv::complete::CompleteCtx {
+        words: &["ex".to_string(), "n".to_string()],
+        cword: 1,
+        prefix: "n",
+    };
+    let found = usage_argv::complete::for_name(&SPEC, "tool", &ctx).expect("a completer");
+    assert_eq!(found.len(), 1);
+    assert_eq!(found[0].value, "node");
+
+    // A name nothing declares is an empty answer rather than a failure: a stale script should
+    // complete nothing, not print into the prompt.
+    assert!(usage_argv::complete::for_name(&SPEC, "nonesuch", &ctx).is_none());
+}

--- a/conformance/tests/spec_roundtrip.rs
+++ b/conformance/tests/spec_roundtrip.rs
@@ -775,8 +775,12 @@ fn a_declared_completer_becomes_a_run_the_reference_can_read() {
     // The line goes with the request, interpolated by whoever runs it — without it a completer
     // that reads an earlier flag answers against nothing, which is a wrong answer rather than a
     // missing one.
+    assert!(run.contains("--line '{{ words | join(sep=\" \")"), "{run}");
+    // The interpolated line is one single-quoted shell argument. An apostrophe in an earlier
+    // word has to close that quote, write a quoted apostrophe, and reopen it; otherwise the
+    // completion command is split (or executes the rest of the line as shell syntax).
     assert!(
-        run.contains("--line '{{ words | join(sep=\" \") }}'"),
+        run.contains("replace(from=\"'\", to=\"'\\\"'\\\"'\") }}'"),
         "{run}"
     );
     // And no `descriptions=#true`, which would tell the reference to read a description after an

--- a/conformance/tests/spec_roundtrip.rs
+++ b/conformance/tests/spec_roundtrip.rs
@@ -963,3 +963,74 @@ fn two_commands_can_mean_different_things_by_one_name() {
         );
     }
 }
+
+#[test]
+fn two_fields_on_one_command_can_mean_different_things_by_one_name() {
+    // A spec has one `complete` block per normalized name, but the line sent back to the binary
+    // still says whether the cursor is in the positional or the flag. Dispatch by that position,
+    // not by whichever field happened to be declared first.
+    static TOOL: Arg = Arg {
+        key: 94,
+        name: "TOOL",
+        ..Arg::REQUIRED
+    };
+    static SOURCE: Flag = Flag {
+        key: 95,
+        name: "source",
+        longs: &["source"],
+        ..Flag::VALUE
+    };
+    static CMD: Command = Command {
+        name: "ex",
+        flags: &[&SOURCE],
+        args: &[&TOOL],
+        ..Command::EMPTY
+    };
+    static META: CommandMeta = CommandMeta {
+        cmd: &CMD,
+        flags: &[FlagMeta {
+            flag: &SOURCE,
+            value_name: Some("TOOL"),
+            complete: Some(remote_tools),
+            ..FlagMeta::EMPTY
+        }],
+        args: &[ArgMeta {
+            arg: &TOOL,
+            complete: Some(local_tools),
+            ..ArgMeta::EMPTY
+        }],
+        ..CommandMeta::EMPTY
+    };
+    static SPEC: Spec = Spec {
+        name: "ex",
+        bin: Some("ex"),
+        root: &META,
+        ..Spec::EMPTY
+    };
+
+    let kdl = SPEC.to_kdl();
+    assert_eq!(
+        kdl.matches("complete \"tool\"").count(),
+        1,
+        "one name-keyed block: {kdl}"
+    );
+
+    for (words, expected) in [
+        (vec!["ex".to_string(), String::new()], "installed"),
+        (
+            vec!["ex".to_string(), "--source".to_string(), String::new()],
+            "available",
+        ),
+    ] {
+        let ctx = usage_argv::complete::CompleteCtx {
+            cword: words.len() - 1,
+            words: &words,
+            prefix: "",
+        };
+        let found = usage_argv::complete::for_name(&SPEC, "tool", &ctx).expect("a completer");
+        assert_eq!(
+            found.iter().map(|c| c.value.as_str()).collect::<Vec<_>>(),
+            [expected]
+        );
+    }
+}

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -335,6 +335,8 @@ fn completion_fns(cli: &Cli) -> (TokenStream, TokenStream) {
             let mut shell = ::usage_argv::complete::Shell::Bash;
             let mut line = ::std::string::String::new();
             let mut cursor = ::std::option::Option::None;
+            let mut candidates_for: ::std::option::Option<::std::string::String> =
+                ::std::option::Option::None;
             let mut rest = argv[1..].iter();
             while let ::std::option::Option::Some(arg) = rest.next() {
                 match arg.to_str().unwrap_or_default() {
@@ -359,6 +361,13 @@ fn completion_fns(cli: &Cli) -> (TokenStream, TokenStream) {
                             .next()
                             .and_then(|value| value.to_str().and_then(|v| v.parse().ok()));
                     }
+                    // What the `run=` in this CLI's own emitted spec asks for: one named
+                    // completer's answers, rather than everything the cursor could take. That is
+                    // the shape a spec's `complete` block promises, so anything reading the KDL
+                    // gets what it expects from the binary the KDL names.
+                    "--candidates" => {
+                        candidates_for = rest.next().map(|v| v.to_string_lossy().into_owned());
+                    }
                     // Anything else is a shell passing something this version does not know
                     // about. Ignored rather than refused: a completion that errors out is a
                     // shell that beeps at every keystroke.
@@ -369,6 +378,23 @@ fn completion_fns(cli: &Cli) -> (TokenStream, TokenStream) {
             // no way to say — nushell, whose completer only ever sees the words.
             let cursor = cursor.unwrap_or(line.len());
             let split = ::usage_argv::complete::split(&line, cursor, shell);
+            if let ::std::option::Option::Some(name) = candidates_for {
+                let ctx = ::usage_argv::complete::CompleteCtx {
+                    words: &split.words,
+                    cword: split.cword,
+                    prefix: &split.prefix,
+                };
+                // Nothing of that name is an empty answer rather than an error: a spec written
+                // against a newer version of this CLI is a stale script, and a stale script
+                // should complete nothing rather than print a message into the user's prompt.
+                let found =
+                    ::usage_argv::complete::for_name(Self::spec(), &name, &ctx).unwrap_or_default();
+                let answer = ::usage_argv::complete::Completions {
+                    candidates: found,
+                    files: ::std::option::Option::None,
+                };
+                return ::std::option::Option::Some(::usage_argv::complete::render(&answer, shell));
+            }
             let answer = ::usage_argv::complete::complete(Self::spec(), &split);
             ::std::option::Option::Some(::usage_argv::complete::render(&answer, shell))
         }


### PR DESCRIPTION
A spec is what every other consumer reads — the usage CLI, another shell's
generator, a docs page — so a CLI whose completers live in Rust still has to say
what they are. It now writes them: `complete "tool" run="mise __complete_word__
--candidates tool"`, generated from the completer rather than declared beside it,
so there is one place a completer is said to exist and no second declaration to
keep in step.

And the binary answers exactly that command, so what the KDL promises is a thing
that works rather than a string that looks plausible. A name nothing declares
answers empty rather than failing: a script generated against a newer version of a
CLI is stale, and a stale script should complete nothing rather than print into
somebody's prompt.

Found by the name a spec uses — the lowercased argument name, or a flag's value
placeholder — which is the rule the reference resolves a `complete` block by, so
both sides agree about which completer a `run=` belongs to. Deduplicated, because
six of mise's commands take a `tool` and a spec declares one block for it.

The round trip is the test: emit the KDL, parse it back with usage-lib, and check
it reads a `run=` for that argument — then ask the binary the same question and get
the answer, filtered by what was typed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes completion protocol and spec output that external generators read; behavior is heavily covered by roundtrip and dispatch tests, but wrong resolution order would break mise-style multi-command `tool` completers.
> 
> **Overview**
> Declared Rust completers are now **written into emitted KDL** as `complete` blocks whose `run=` invokes the same binary with `__complete_word__ --candidates <name> --line '…'`, instead of leaving completion as a second hand-maintained declaration beside the Rust callbacks.
> 
> The binary **implements that contract** via new `for_name` resolution (aligned with usage-lib: root, then command reached on the line, then tree fallback; cursor-aware when one name maps to both a positional and a flag value) and derive support for **`--candidates`**, returning filtered candidates or an empty list when the name is unknown. Spec emission also adds **`completers_on`**, per-command `write_completers`, and shell-safe line interpolation (apostrophe escaping; no `descriptions=#true` so colon-heavy values are not split).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 968892b5b8b0de98faf0de2c7c469b39a0cc5e10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->