### PR TITLE
feat(derive): let a field name the function that completes it

### DIFF
--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -51,6 +51,12 @@ pub struct Position<'t> {
     pub help_topic: bool,
     /// Where the command in scope began, as an index into the words `walk` was given.
     pub command_start: usize,
+    /// Every command the words passed through, and where each one's own words begin.
+    ///
+    /// The deepest is not always the one being asked about: a global flag is declared on an
+    /// ancestor, and a completer for its value wants the words *that* command was given — the
+    /// ones before the subcommand name included.
+    pub path: Vec<(&'t Command<'t>, usize)>,
     /// The flags a word here could name: this command's own, then any ancestor's globals.
     ///
     /// Taken from the parser rather than gathered again, so what is offered is what would be
@@ -90,6 +96,7 @@ pub fn walk<'t>(root: &'t Command<'t>, words: &[String]) -> Position<'t> {
                     flags_possible: false,
                     awaiting_value: None,
                     next_arg: None,
+                    path: Vec::new(),
                     separator_seen: false,
                     command_start: 0,
                     help_topic: true,
@@ -101,6 +108,7 @@ pub fn walk<'t>(root: &'t Command<'t>, words: &[String]) -> Position<'t> {
     }
 
     Position {
+        path: parser.command_path(),
         cmd: parser.command(),
         flags_possible: !parser.flags_stopped(),
         // A variadic flag still claiming words is standing in the same place a flag waiting
@@ -677,11 +685,20 @@ fn declared<'a>(
     let Some(completer) = completer else {
         return Vec::new();
     };
+    // The words each command on the path was given, so a completer declared on an ancestor —
+    // which is what a global flag is — reads its own command's rather than the deepest one's.
+    let words = split.argv();
+    let path: Vec<(&Command<'_>, &[String])> = position
+        .path
+        .iter()
+        .map(|(cmd, start)| (*cmd, words.get(*start..).unwrap_or(&[])))
+        .collect();
     let ctx = CompleteCtx {
         words: &split.words,
         cword: split.cword,
         prefix: token,
         command_words: command_words(split, position),
+        command_path: &path,
     };
     let mut found = completer(&ctx);
     found.retain(|c| c.value.starts_with(token));

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -16,6 +16,7 @@
 //! in a real invocation.
 
 use crate::spec::{ArgMeta, CommandMeta, FlagMeta, Spec};
+pub use crate::spec::{Candidate, CompleteCtx, Completer};
 use crate::{Arg, Command, Error, Flag, Parser};
 
 /// Where the cursor is, in the grammar rather than in the line.
@@ -48,6 +49,8 @@ pub struct Position<'t> {
     /// True after `help`, where the only thing that belongs is a command name — not the
     /// arguments of whatever the root would otherwise fall back to.
     pub help_topic: bool,
+    /// Where the command in scope began, as an index into the words `walk` was given.
+    pub command_start: usize,
     /// The flags a word here could name: this command's own, then any ancestor's globals.
     ///
     /// Taken from the parser rather than gathered again, so what is offered is what would be
@@ -88,6 +91,7 @@ pub fn walk<'t>(root: &'t Command<'t>, words: &[String]) -> Position<'t> {
                     awaiting_value: None,
                     next_arg: None,
                     separator_seen: false,
+                    command_start: 0,
                     help_topic: true,
                     flags: Vec::new(),
                 }
@@ -104,6 +108,7 @@ pub fn walk<'t>(root: &'t Command<'t>, words: &[String]) -> Position<'t> {
         awaiting_value: awaiting_value.or_else(|| parser.collecting()),
         next_arg: parser.pending_arg(),
         separator_seen: parser.double_dash_seen(),
+        command_start: parser.command_start(),
         help_topic: false,
         flags: parser.flags_in_scope().collect(),
     }
@@ -223,81 +228,6 @@ pub fn completers_on(meta: &CommandMeta<'_>) -> Vec<String> {
     out.sort();
     out.dedup();
     out
-}
-
-/// What a completion callback is told about the cursor.
-///
-/// Everything a `run=` command is given through tera — the words, which one the cursor is in —
-/// plus the prefix, which the reference makes each script filter on and this filters for the
-/// callback. A completer that wants an earlier value on the line reads it from `words`; one that
-/// wants it *typed* gets it in the next stage, where the derive can hand over the command's own
-/// half-parsed struct.
-#[derive(Debug, Clone, Copy)]
-pub struct CompleteCtx<'a> {
-    /// The words of the line, unquoted, including the one being completed.
-    pub words: &'a [String],
-    /// Which of `words` the cursor is in.
-    pub cword: usize,
-    /// What has been typed of that word. Candidates are filtered by it afterwards, so a
-    /// completer may ignore it and answer with everything it knows.
-    pub prefix: &'a str,
-}
-
-impl<'a> CompleteCtx<'a> {
-    /// The words a parser should walk to find the command this request is about.
-    ///
-    /// After the program name, before the word being completed — the same slice `walk` is given
-    /// for an ordinary request, so a `--candidates` request resolves the same command an
-    /// ordinary one would.
-    pub fn command_words_start(&self) -> &'a [String] {
-        let start = 1.min(self.cword);
-        self.words.get(start..self.cword).unwrap_or(&[])
-    }
-
-    /// The word before the one being completed, which is what mise's `{{words[PREV]}}` means.
-    pub fn previous(&self) -> Option<&'a str> {
-        self.cword
-            .checked_sub(1)
-            .and_then(|i| self.words.get(i))
-            .map(String::as_str)
-    }
-}
-
-/// A function that answers for one argument or flag value.
-///
-/// The Rust counterpart of a spec's `run=`, and the reason it is a plain `fn` rather than a
-/// closure: it lives in a `&'static` table beside the parse tables, and a table entry cannot
-/// capture anything.
-pub type Completer = fn(&CompleteCtx<'_>) -> Vec<Candidate<'static>>;
-
-/// Something a shell could offer at the cursor.
-///
-/// The description is what fish, zsh, nu and PowerShell show beside a candidate; bash shows
-/// only the value. It is borrowed from the spec rather than built, because it is already
-/// there — the help text a page would print for the same thing.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Candidate<'a> {
-    pub value: String,
-    /// Borrowed from the spec where it is already there, owned where a callback made it.
-    pub description: Option<::std::borrow::Cow<'a, str>>,
-}
-
-impl Candidate<'_> {
-    /// A candidate with nothing to say about itself.
-    pub fn new(value: impl Into<String>) -> Self {
-        Self {
-            value: value.into(),
-            description: None,
-        }
-    }
-
-    /// A candidate and the line a shell shows beside it.
-    pub fn described(value: impl Into<String>, description: impl Into<String>) -> Self {
-        Self {
-            value: value.into(),
-            description: Some(::std::borrow::Cow::Owned(description.into())),
-        }
-    }
 }
 
 /// Paths a shell should offer, on top of whatever this crate knows about.
@@ -559,7 +489,7 @@ pub fn candidates<'a>(spec: &'a Spec<'a>, split: &Split) -> Vec<Candidate<'a>> {
             .unwrap_or_default()
     } else if let Some(flag) = position.awaiting_value {
         flag_meta(spec.root, flag)
-            .map(|m| declared(m.choices, m.complete, split, token))
+            .map(|m| declared(m.choices, m.complete, split, &position, token))
             .unwrap_or_default()
     } else {
         let mut found = Vec::new();
@@ -725,7 +655,7 @@ fn positional<'a>(
         }
         return Vec::new();
     }
-    declared(meta.choices, meta.complete, split, token)
+    declared(meta.choices, meta.complete, split, position, token)
 }
 
 /// What a position declares it takes: its choices, or the completer that answers for it.
@@ -738,6 +668,7 @@ fn declared<'a>(
     choices_declared: &'a [&'a str],
     completer: Option<Completer>,
     split: &Split,
+    position: &Position<'_>,
     token: &str,
 ) -> Vec<Candidate<'a>> {
     if !choices_declared.is_empty() {
@@ -750,10 +681,21 @@ fn declared<'a>(
         words: &split.words,
         cword: split.cword,
         prefix: token,
+        command_words: command_words(split, position),
     };
     let mut found = completer(&ctx);
     found.retain(|c| c.value.starts_with(token));
     found
+}
+
+/// The words the command in scope was given, out of the whole line.
+///
+/// `walk` was handed the words after the program name and before the cursor's, and reported
+/// where the command in scope began within them — so this is the tail of that, which is what
+/// that command would have been given had the line been run.
+fn command_words<'s>(split: &'s Split, position: &Position<'_>) -> &'s [String] {
+    let words = split.argv();
+    words.get(position.command_start..).unwrap_or(&[])
 }
 
 /// The declared values of a flag or argument, filtered by what has been typed.

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -757,6 +757,8 @@ pub struct Parser<'t, 'v> {
     bundle_token: &'v [u8],
     /// A variadic flag that is still collecting values.
     collecting: Option<&'t Flag<'t>>,
+    /// Where the command in scope began, as an index into `argv`.
+    cmd_start: usize,
     /// How many values it has taken, so a bound can stop it.
     collected: u32,
     /// Which of `cmd.args` is next to fill.
@@ -800,6 +802,7 @@ impl<'t, 'v> Parser<'t, 'v> {
             bundle: &[],
             bundle_token: &[],
             collecting: None,
+            cmd_start: 0,
             collected: 0,
             arg_pos: 0,
             arg_taken: 0,
@@ -823,6 +826,14 @@ impl<'t, 'v> Parser<'t, 'v> {
     /// `preserve` argument kept as a value.
     pub fn double_dash_seen(&self) -> bool {
         self.separator_seen
+    }
+
+    /// Where the command in scope began: the index in `argv` just after its name.
+    ///
+    /// `argv[command_start()..]` is what that command was given, which is what a completion
+    /// callback needs to be handed its own command's half-parsed struct rather than the root's.
+    pub fn command_start(&self) -> usize {
+        self.cmd_start
     }
 
     /// Whether flag interpretation has stopped, for any reason.
@@ -1195,6 +1206,9 @@ impl<'t, 'v> Parser<'t, 'v> {
         self.ancestors[self.depth] = Some(self.cmd);
         self.depth += 1;
         self.cmd = sub;
+        // Where this command's own words start, which is what lets a completion hand a callback
+        // the half-parsed struct of the command it was declared on rather than of the root.
+        self.cmd_start = self.pos;
         self.arg_pos = 0;
         self.arg_taken = 0;
         self.arg_filled = false;

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -759,6 +759,8 @@ pub struct Parser<'t, 'v> {
     collecting: Option<&'t Flag<'t>>,
     /// Where the command in scope began, as an index into `argv`.
     cmd_start: usize,
+    /// Where each ancestor's own words began, in step with `ancestors`.
+    starts: [usize; MAX_DEPTH],
     /// How many values it has taken, so a bound can stop it.
     collected: u32,
     /// Which of `cmd.args` is next to fill.
@@ -803,6 +805,7 @@ impl<'t, 'v> Parser<'t, 'v> {
             bundle_token: &[],
             collecting: None,
             cmd_start: 0,
+            starts: [0; MAX_DEPTH],
             collected: 0,
             arg_pos: 0,
             arg_taken: 0,
@@ -826,6 +829,24 @@ impl<'t, 'v> Parser<'t, 'v> {
     /// `preserve` argument kept as a value.
     pub fn double_dash_seen(&self) -> bool {
         self.separator_seen
+    }
+
+    /// Every command entered so far, and where each one's own words begin.
+    ///
+    /// The ancestors are already kept for flag scoping; this is the same chain with the offsets,
+    /// which is what lets a completion hand a callback the words of *its* command rather than of
+    /// the deepest one — a global flag is declared on an ancestor.
+    pub fn command_path(&self) -> Vec<(&'t Command<'t>, usize)> {
+        let mut out = Vec::with_capacity(self.depth + 1);
+        for (i, ancestor) in self.ancestors[..self.depth].iter().enumerate() {
+            if let Some(cmd) = ancestor {
+                // An ancestor's own words start where the one before it descended, and the
+                // root's start at the beginning.
+                out.push((*cmd, self.starts[i]));
+            }
+        }
+        out.push((self.cmd, self.cmd_start));
+        out
     }
 
     /// Where the command in scope began: the index in `argv` just after its name.
@@ -1204,6 +1225,7 @@ impl<'t, 'v> Parser<'t, 'v> {
             return Err(Error::TooDeep);
         }
         self.ancestors[self.depth] = Some(self.cmd);
+        self.starts[self.depth] = self.cmd_start;
         self.depth += 1;
         self.cmd = sub;
         // Where this command's own words start, which is what lets a completion hand a callback

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -109,6 +109,87 @@ fn unfillable_arg<'a>(cmd: &Command<'a>) -> Option<&'a str> {
     cmd.subcommands.iter().find_map(|sub| unfillable_arg(sub))
 }
 
+/// What a completion callback is told about the cursor.
+///
+/// Everything a `run=` command is given through tera — the words, which one the cursor is in —
+/// plus the prefix, which the reference makes each script filter on and this filters for the
+/// callback. A completer that wants an earlier value on the line reads it from `words`; one that
+/// wants it *typed* gets it in the next stage, where the derive can hand over the command's own
+/// half-parsed struct.
+#[derive(Debug, Clone, Copy)]
+pub struct CompleteCtx<'a> {
+    /// The words of the line, unquoted, including the one being completed.
+    pub words: &'a [String],
+    /// Which of `words` the cursor is in.
+    pub cword: usize,
+    /// What has been typed of that word. Candidates are filtered by it afterwards, so a
+    /// completer may ignore it and answer with everything it knows.
+    pub prefix: &'a str,
+    /// The words the command in scope was given: after its own name, before the cursor's word.
+    ///
+    /// What a callback needs to reconstruct its command's half-parsed struct — `mise task ls
+    /// --file other.toml ⌶` is `["--file", "other.toml"]` here, whatever the words before `ls`
+    /// were.
+    pub command_words: &'a [String],
+}
+
+impl<'a> CompleteCtx<'a> {
+    /// The words a parser should walk to find the command this request is about.
+    ///
+    /// After the program name, before the word being completed — the same slice `walk` is given
+    /// for an ordinary request, so a `--candidates` request resolves the same command an
+    /// ordinary one would.
+    pub fn command_words_start(&self) -> &'a [String] {
+        let start = 1.min(self.cword);
+        self.words.get(start..self.cword).unwrap_or(&[])
+    }
+
+    /// The word before the one being completed, which is what mise's `{{words[PREV]}}` means.
+    pub fn previous(&self) -> Option<&'a str> {
+        self.cword
+            .checked_sub(1)
+            .and_then(|i| self.words.get(i))
+            .map(String::as_str)
+    }
+}
+
+/// A function that answers for one argument or flag value.
+///
+/// The Rust counterpart of a spec's `run=`, and the reason it is a plain `fn` rather than a
+/// closure: it lives in a `&'static` table beside the parse tables, and a table entry cannot
+/// capture anything.
+pub type Completer = fn(&CompleteCtx<'_>) -> Vec<Candidate<'static>>;
+
+/// Something a shell could offer at the cursor.
+///
+/// The description is what fish, zsh, nu and PowerShell show beside a candidate; bash shows
+/// only the value. It is borrowed from the spec rather than built, because it is already
+/// there — the help text a page would print for the same thing.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Candidate<'a> {
+    pub value: String,
+    /// Borrowed from the spec where it is already there, owned where a callback made it.
+    pub description: Option<::std::borrow::Cow<'a, str>>,
+}
+
+impl Candidate<'_> {
+    /// A candidate with nothing to say about itself.
+    pub fn new(value: impl Into<String>) -> Self {
+        Self {
+            value: value.into(),
+            description: None,
+        }
+    }
+
+    /// A candidate and the line a shell shows beside it.
+    pub fn described(value: impl Into<String>, description: impl Into<String>) -> Self {
+        Self {
+            value: value.into(),
+            description: Some(::std::borrow::Cow::Owned(description.into())),
+        }
+    }
+}
+
 /// A whole CLI: the root command plus what describes the program itself.
 #[derive(Debug, Clone, Copy)]
 pub struct Spec<'a> {
@@ -297,8 +378,7 @@ pub struct FlagMeta<'a> {
     /// The Rust counterpart of a spec's `run=`: it is written into the emitted KDL as a command
     /// that asks *this binary*, so a spec stays complete for every other consumer while the
     /// binary answers itself.
-    #[cfg(feature = "complete")]
-    pub complete: Option<crate::complete::Completer>,
+    pub complete: Option<Completer>,
     /// Whether the flag may be given more than once. Distinct from
     /// [`Flag::variadic`], which is one occurrence taking several values.
     pub repeatable: bool,
@@ -325,7 +405,6 @@ pub struct FlagMeta<'a> {
 impl FlagMeta<'_> {
     /// Metadata for a flag with nothing declared, for struct update syntax.
     pub const EMPTY: FlagMeta<'static> = FlagMeta {
-        #[cfg(feature = "complete")]
         complete: None,
         flag: &Flag::BOOL,
         help: None,
@@ -368,14 +447,12 @@ pub struct ArgMeta<'a> {
     /// Heading to list this argument under in help output.
     pub help_heading: Option<&'a str>,
     /// What answers for this argument when a shell asks. See [`FlagMeta::complete`].
-    #[cfg(feature = "complete")]
-    pub complete: Option<crate::complete::Completer>,
+    pub complete: Option<Completer>,
 }
 
 impl ArgMeta<'_> {
     /// Metadata for an argument with nothing declared, for struct update syntax.
     pub const EMPTY: ArgMeta<'static> = ArgMeta {
-        #[cfg(feature = "complete")]
         complete: None,
         arg: &Arg::REQUIRED,
         help: None,

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -140,7 +140,7 @@ pub struct CompleteCtx<'a> {
 }
 
 impl<'a> CompleteCtx<'a> {
-    /// The words `command` was given, or the deepest command's if it is not on the path.
+    /// The command in the active path that owns `declaration`, and the words it was given.
     ///
     /// Matched by key, not by address: a `Subcommands` variant builds its own table entry for
     /// the command it names — it may rename it, or give it aliases the type knows nothing about
@@ -149,13 +149,40 @@ impl<'a> CompleteCtx<'a> {
     /// tables of the same command agree on. Not the name, which a variant can change and two
     /// commands can share.
     ///
+    /// A flattened group's command is not itself on the path: its fields were spliced into the
+    /// parent's table. In that case the command containing all of the group's declarations is
+    /// the owner. Returning that actual command matters as well as returning its words, because
+    /// reparsing against the flattened table alone would stop at a parent subcommand name and
+    /// miss a global flag written after it.
+    pub fn command_for(
+        &self,
+        declaration: &crate::Command<'_>,
+    ) -> Option<(&'a crate::Command<'a>, &'a [String])> {
+        self.command_path
+            .iter()
+            .find(|(cmd, _)| cmd.key == declaration.key)
+            .or_else(|| {
+                let has_fields = !declaration.flags.is_empty() || !declaration.args.is_empty();
+                self.command_path.iter().find(|(cmd, _)| {
+                    has_fields
+                        && declaration.flags.iter().all(|field| {
+                            cmd.flags.iter().any(|candidate| candidate.key == field.key)
+                        })
+                        && declaration.args.iter().all(|field| {
+                            cmd.args.iter().any(|candidate| candidate.key == field.key)
+                        })
+                })
+            })
+            .map(|(cmd, words)| (*cmd, *words))
+    }
+
+    /// The words `command` was given, or the deepest command's if it is not on the path.
+    ///
     /// The fallback is for a completer reached by name rather than by a cursor position, where
     /// there may be no path at all.
     pub fn words_for(&self, command: &crate::Command<'_>) -> &'a [String] {
-        self.command_path
-            .iter()
-            .find(|(cmd, _)| cmd.key == command.key)
-            .map(|(_, words)| *words)
+        self.command_for(command)
+            .map(|(_, words)| words)
             .unwrap_or(self.command_words)
     }
 

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -125,6 +125,12 @@ pub struct CompleteCtx<'a> {
     /// What has been typed of that word. Candidates are filtered by it afterwards, so a
     /// completer may ignore it and answer with everything it knows.
     pub prefix: &'a str,
+    /// Every command the words passed through, and the words each one was given.
+    ///
+    /// A completer is declared on some command, which is not always the deepest one the line
+    /// reached — a global flag belongs to an ancestor — so a caller that wants its own command's
+    /// words asks for them by that command.
+    pub command_path: &'a [(&'a crate::Command<'a>, &'a [String])],
     /// The words the command in scope was given: after its own name, before the cursor's word.
     ///
     /// What a callback needs to reconstruct its command's half-parsed struct — `mise task ls
@@ -134,6 +140,25 @@ pub struct CompleteCtx<'a> {
 }
 
 impl<'a> CompleteCtx<'a> {
+    /// The words `command` was given, or the deepest command's if it is not on the path.
+    ///
+    /// Matched by key, not by address: a `Subcommands` variant builds its own table entry for
+    /// the command it names — it may rename it, or give it aliases the type knows nothing about
+    /// — so the entry the parse walked is a *copy* of the one the type declares. The key is a
+    /// hash of the type it came from and survives the copying, which makes it the identity two
+    /// tables of the same command agree on. Not the name, which a variant can change and two
+    /// commands can share.
+    ///
+    /// The fallback is for a completer reached by name rather than by a cursor position, where
+    /// there may be no path at all.
+    pub fn words_for(&self, command: &crate::Command<'_>) -> &'a [String] {
+        self.command_path
+            .iter()
+            .find(|(cmd, _)| cmd.key == command.key)
+            .map(|(_, words)| *words)
+            .unwrap_or(self.command_words)
+    }
+
     /// The words a parser should walk to find the command this request is about.
     ///
     /// After the program name, before the word being completed — the same slice `walk` is given

--- a/conformance/tests/completion.rs
+++ b/conformance/tests/completion.rs
@@ -529,6 +529,98 @@ fn a_global_flags_completer_reads_the_command_it_was_declared_on() {
     assert_eq!(tk_g("g outer leaf --profile "), "default\n");
 }
 
+/// A flattened group has fields of its own, but no command of its own on the active path.
+#[derive(Args)]
+struct FlattenedGlobals {
+    /// Where to work
+    #[usage(long = "workspace", value_name = "DIR", global)]
+    workspace: Option<String>,
+    /// Which profile, answered against `--workspace`
+    #[usage(
+        long = "flat-profile",
+        value_name = "PROFILE",
+        global,
+        complete = flattened_profiles
+    )]
+    profile: Option<String>,
+}
+
+#[derive(Args)]
+struct FlattenedOuter {
+    #[usage(flatten)]
+    globals: FlattenedGlobals,
+    #[usage(subcommand)]
+    command: Option<GlobalCommands>,
+}
+
+#[derive(Subcommands)]
+enum FlattenedCommands {
+    /// The command containing the flattened globals
+    Outer(Box<FlattenedOuter>),
+}
+
+#[derive(Cli)]
+#[usage(bin = "fg", completion)]
+struct FG {
+    #[usage(subcommand)]
+    command: Option<FlattenedCommands>,
+}
+
+fn flattened_profiles(
+    partial: &<FlattenedGlobals as usage_argv::spec::CommandArgs>::Partial,
+    _ctx: &usage_argv::complete::CompleteCtx<'_>,
+) -> Vec<usage_argv::complete::Candidate<'static>> {
+    let workspace = partial
+        .workspace
+        .as_deref()
+        .map(|bytes| String::from_utf8_lossy(bytes).into_owned());
+    vec![usage_argv::complete::Candidate::new(
+        workspace.unwrap_or_else(|| "default".to_string()),
+    )]
+}
+
+#[test]
+fn a_flattened_global_completer_reads_its_parent_commands_words() {
+    // The flattened type's command key is not on the path. Its fields are in `outer`, so that
+    // command and its complete word slice are what the wrapper must reparse.
+    assert_eq!(
+        tk_fg("fg outer --workspace before leaf --flat-profile "),
+        "before\n"
+    );
+
+    // Reparse the actual parent command as well as its words: the flattened type does not know
+    // `leaf`, so reparsing only its own table would stop there and miss this later global.
+    assert_eq!(
+        tk_fg("fg outer leaf --workspace after --flat-profile "),
+        "after\n"
+    );
+
+    // The declarations used for completion are still the ones an ordinary parse fills.
+    let argv = [
+        OsStr::new("outer"),
+        OsStr::new("leaf"),
+        OsStr::new("--workspace"),
+        OsStr::new("after"),
+        OsStr::new("--flat-profile"),
+        OsStr::new("selected"),
+    ];
+    let parsed = FG::parse_from(&argv).expect("an ordinary parse");
+    let Some(FlattenedCommands::Outer(outer)) = parsed.command else {
+        panic!("expected outer")
+    };
+    assert_eq!(outer.globals.workspace.as_deref(), Some("after"));
+    assert_eq!(outer.globals.profile.as_deref(), Some("selected"));
+    assert!(matches!(outer.command, Some(GlobalCommands::Leaf(_))));
+}
+
+fn tk_fg(line: &str) -> String {
+    let argv: Vec<OsString> = ["__complete_word__", "--shell", "bash", "--line", line]
+        .iter()
+        .map(OsString::from)
+        .collect();
+    FG::completion_request(&argv).expect("a completion request")
+}
+
 fn tk_g(line: &str) -> String {
     let argv: Vec<OsString> = ["__complete_word__", "--shell", "bash", "--line", line]
         .iter()

--- a/conformance/tests/completion.rs
+++ b/conformance/tests/completion.rs
@@ -230,3 +230,148 @@ fn the_script_calls_the_command_this_cli_answers() {
     .collect();
     assert_eq!(Ex::completion_request(&argv).as_deref(), Some("install\n"));
 }
+
+/// A CLI whose task list depends on a file named earlier on the same line.
+///
+/// This is the case a `run=` cannot answer: `mise tasks ls --complete` is a fixed command, so it
+/// reads whatever config the shell happens to be standing in, not the one being typed about.
+#[derive(Args)]
+struct Tasks {
+    /// Which config to read
+    #[usage(long = "file")]
+    file: Option<String>,
+    /// Only tasks in this group
+    #[usage(long = "group", value_name = "GROUP", complete = groups)]
+    group: Option<String>,
+    /// Which task
+    #[usage(arg, name = "TASK", complete = tasks_in_file)]
+    task: Option<String>,
+}
+
+/// What answers for `TASK`, given what the command has been told so far.
+fn tasks_in_file(
+    partial: &<Tasks as usage_argv::spec::CommandArgs>::Partial,
+    _ctx: &usage_argv::complete::CompleteCtx<'_>,
+) -> Vec<usage_argv::complete::Candidate<'static>> {
+    // The parser already decided what `--file` means; this reads the decision rather than
+    // scraping the line for it again. The partial holds the bytes as typed, since a word that is
+    // not valid UTF-8 is still a word somebody wrote.
+    let file = partial
+        .file
+        .as_deref()
+        .map(|bytes| String::from_utf8_lossy(bytes).into_owned());
+    match file.as_deref() {
+        Some("other.toml") => vec![usage_argv::complete::Candidate::new("other-task")],
+        Some(_) => vec![],
+        None => vec![
+            usage_argv::complete::Candidate::described("build", "Build it"),
+            usage_argv::complete::Candidate::new("test"),
+        ],
+    }
+}
+
+/// What answers for `--group`, to show a flag's value is completed the same way.
+fn groups(
+    _partial: &<Tasks as usage_argv::spec::CommandArgs>::Partial,
+    _ctx: &usage_argv::complete::CompleteCtx<'_>,
+) -> Vec<usage_argv::complete::Candidate<'static>> {
+    vec![
+        usage_argv::complete::Candidate::new("ci"),
+        usage_argv::complete::Candidate::new("local"),
+    ]
+}
+
+#[derive(Subcommands)]
+enum WithTasks {
+    /// List tasks
+    Tasks(Box<Tasks>),
+}
+
+#[derive(Cli)]
+#[usage(bin = "tk", completion)]
+struct Tk {
+    #[usage(subcommand)]
+    command: Option<WithTasks>,
+}
+
+fn tk(line: &str) -> String {
+    let argv: Vec<OsString> = ["__complete_word__", "--shell", "bash", "--line", line]
+        .iter()
+        .map(OsString::from)
+        .collect();
+    Tk::completion_request(&argv).expect("a completion request")
+}
+
+#[test]
+fn a_completer_reads_its_own_commands_half_parsed_struct() {
+    // Without a flag, the defaults.
+    assert_eq!(tk("tk tasks "), "build\ntest\n");
+    assert_eq!(tk("tk tasks bu"), "build\n");
+
+    // A flag's value is answered the same way as an argument's.
+    assert_eq!(tk("tk tasks --group "), "ci\nlocal\n");
+    assert_eq!(tk("tk tasks --group c"), "ci\n");
+
+    // And with one given earlier on the same line, the answer changes — which is the thing a
+    // fixed `run=` command cannot do, because it never sees the line it is being asked about.
+    assert_eq!(tk("tk tasks --file other.toml "), "other-task\n");
+    // A file it knows nothing about: no candidates, and the position stays open — so what comes
+    // back is the marker asking the shell for paths, not an empty answer claiming there is
+    // nothing here.
+    assert_eq!(
+        tk("tk tasks --file nothing.toml "),
+        format!("{}\n", usage_argv::complete::FILES_MARKER)
+    );
+}
+
+#[test]
+fn the_cli_that_declares_completers_still_parses() {
+    // The fields the completers describe are the fields a parse fills, which is the whole claim:
+    // one declaration, read by both.
+    let argv = [
+        OsStr::new("tasks"),
+        OsStr::new("--file"),
+        OsStr::new("other.toml"),
+        OsStr::new("--group"),
+        OsStr::new("ci"),
+        OsStr::new("build"),
+    ];
+    let parsed = Tk::parse_from(&argv).expect("an ordinary parse");
+    let Some(WithTasks::Tasks(tasks)) = parsed.command else {
+        panic!("expected tasks")
+    };
+    assert_eq!(tasks.file.as_deref(), Some("other.toml"));
+    assert_eq!(tasks.group.as_deref(), Some("ci"));
+    assert_eq!(tasks.task.as_deref(), Some("build"));
+}
+
+#[test]
+fn the_spec_names_a_completer_the_binary_answers() {
+    // What the KDL promises and what the binary does, checked against each other.
+    let kdl = Tk::to_kdl();
+    // Inside the command that declares it, and carrying the line, so that whoever runs it asks
+    // about the same thing a native request would.
+    assert!(
+        kdl.contains(r#"complete "task" run="tk __complete_word__ --candidates task --line"#),
+        "{kdl}"
+    );
+    assert!(kdl.contains(r#"complete "group""#), "{kdl}");
+
+    let argv: Vec<OsString> = [
+        "__complete_word__",
+        "--shell",
+        "bash",
+        "--candidates",
+        "task",
+        "--line",
+        "tk tasks --file other.toml ",
+    ]
+    .iter()
+    .map(OsString::from)
+    .collect();
+    assert_eq!(
+        Tk::completion_request(&argv).as_deref(),
+        Some("other-task\n"),
+        "the command the spec names has to answer, and to see the same line"
+    );
+}

--- a/conformance/tests/completion.rs
+++ b/conformance/tests/completion.rs
@@ -375,3 +375,87 @@ fn the_spec_names_a_completer_the_binary_answers() {
         "the command the spec names has to answer, and to see the same line"
     );
 }
+
+/// Completers reached by every spelling a user might write one with.
+mod completers {
+    use usage_argv::complete::{Candidate, CompleteCtx};
+
+    pub fn absolute(
+        _partial: &<super::Qualified as usage_argv::spec::CommandArgs>::Partial,
+        _ctx: &CompleteCtx<'_>,
+    ) -> Vec<Candidate<'static>> {
+        vec![Candidate::new("from-crate")]
+    }
+
+    pub fn relative(
+        _partial: &<super::Qualified as usage_argv::spec::CommandArgs>::Partial,
+        _ctx: &CompleteCtx<'_>,
+    ) -> Vec<Candidate<'static>> {
+        vec![Candidate::new("from-self")]
+    }
+}
+
+#[derive(Args)]
+struct Qualified {
+    /// Named by a path rooted at the crate
+    #[usage(arg, name = "ONE", complete = crate::completers::absolute)]
+    one: Option<String>,
+    /// Named by a path relative to this module
+    #[usage(long = "two", value_name = "TWO", complete = self::completers::relative)]
+    two: Option<String>,
+}
+
+#[derive(Subcommands)]
+enum QualifiedCommands {
+    /// Take both
+    Both(Box<Qualified>),
+}
+
+#[derive(Cli)]
+#[usage(bin = "q", completion)]
+struct Q {
+    #[usage(subcommand)]
+    command: Option<QualifiedCommands>,
+}
+
+#[test]
+fn a_completer_can_be_named_however_a_path_is_written() {
+    // A path is rewritten the way a field's *type* is, because the generated module sits one
+    // level below where the user wrote it — and `crate::…` or `self::…` mean something already,
+    // so prefixing them produced a path that did not resolve. This test is mostly the fact that
+    // it compiles; the assertions are what makes it worth reading.
+    let argv: Vec<OsString> = ["__complete_word__", "--shell", "bash", "--line", "q both "]
+        .iter()
+        .map(OsString::from)
+        .collect();
+    assert_eq!(
+        Q::completion_request(&argv).as_deref(),
+        Some("from-crate\n")
+    );
+
+    let argv: Vec<OsString> = [
+        "__complete_word__",
+        "--shell",
+        "bash",
+        "--line",
+        "q both --two ",
+    ]
+    .iter()
+    .map(OsString::from)
+    .collect();
+    assert_eq!(Q::completion_request(&argv).as_deref(), Some("from-self\n"));
+
+    // The fields the completers describe are the fields a parse fills.
+    let argv = [
+        OsStr::new("both"),
+        OsStr::new("--two"),
+        OsStr::new("b"),
+        OsStr::new("a"),
+    ];
+    let parsed = Q::parse_from(&argv).expect("an ordinary parse");
+    let Some(QualifiedCommands::Both(both)) = parsed.command else {
+        panic!("expected both")
+    };
+    assert_eq!(both.one.as_deref(), Some("a"));
+    assert_eq!(both.two.as_deref(), Some("b"));
+}

--- a/conformance/tests/completion.rs
+++ b/conformance/tests/completion.rs
@@ -459,3 +459,105 @@ fn a_completer_can_be_named_however_a_path_is_written() {
     assert_eq!(both.one.as_deref(), Some("a"));
     assert_eq!(both.two.as_deref(), Some("b"));
 }
+
+/// A command that declares a global flag with a completer, completed inside its *child*.
+///
+/// The case a wrapper gets wrong if it reparses the deepest command's words: a global belongs to
+/// an ancestor, and the words that reached the child are not the words the ancestor was given.
+#[derive(Args)]
+struct Leaf {
+    /// Something of the leaf's own
+    #[usage(arg, name = "WHAT")]
+    what: Option<String>,
+}
+
+#[derive(Subcommands)]
+enum GlobalCommands {
+    /// A subcommand
+    Leaf(Box<Leaf>),
+}
+
+#[derive(Args)]
+struct Outer {
+    /// Where to work
+    #[usage(long = "cd", value_name = "DIR", global)]
+    cd: Option<String>,
+    /// Which profile, answered against `--cd`
+    #[usage(long = "profile", value_name = "PROFILE", global, complete = profiles)]
+    profile: Option<String>,
+    #[usage(subcommand)]
+    command: Option<GlobalCommands>,
+}
+
+#[derive(Subcommands)]
+enum OuterCommands {
+    /// The command that declares the globals
+    Outer(Box<Outer>),
+}
+
+#[derive(Cli)]
+#[usage(bin = "g", completion)]
+struct G {
+    #[usage(subcommand)]
+    command: Option<OuterCommands>,
+}
+
+/// What answers for `--profile`: `Outer`'s own partial, which is where `--cd` landed.
+fn profiles(
+    partial: &<Outer as usage_argv::spec::CommandArgs>::Partial,
+    _ctx: &usage_argv::complete::CompleteCtx<'_>,
+) -> Vec<usage_argv::complete::Candidate<'static>> {
+    let cd = partial
+        .cd
+        .as_deref()
+        .map(|bytes| String::from_utf8_lossy(bytes).into_owned());
+    match cd.as_deref() {
+        Some(dir) => vec![usage_argv::complete::Candidate::new(format!("in-{dir}"))],
+        None => vec![usage_argv::complete::Candidate::new("default")],
+    }
+}
+
+#[test]
+fn a_global_flags_completer_reads_the_command_it_was_declared_on() {
+    // `--cd here` was given to `outer`, and the cursor is inside `outer leaf` — so the words that
+    // reached the deepest command do not contain it. A wrapper reparsing those would have found
+    // nothing and answered as though the flag had never been typed.
+    assert_eq!(tk_g("g outer --cd here leaf --profile "), "in-here\n");
+
+    // And where the two coincide, the same answer.
+    assert_eq!(tk_g("g outer --cd there --profile "), "in-there\n");
+    assert_eq!(tk_g("g outer leaf --profile "), "default\n");
+}
+
+fn tk_g(line: &str) -> String {
+    let argv: Vec<OsString> = ["__complete_word__", "--shell", "bash", "--line", line]
+        .iter()
+        .map(OsString::from)
+        .collect();
+    G::completion_request(&argv).expect("a completion request")
+}
+
+#[test]
+fn the_cli_with_globals_still_parses_them() {
+    // The fields those completers read are the fields a parse fills — one declaration, read by
+    // both, which is the whole point of the completer living on the field.
+    let argv = [
+        OsStr::new("outer"),
+        OsStr::new("--cd"),
+        OsStr::new("here"),
+        OsStr::new("leaf"),
+        OsStr::new("--profile"),
+        OsStr::new("work"),
+        OsStr::new("thing"),
+    ];
+    let parsed = G::parse_from(&argv).expect("an ordinary parse");
+    let Some(OuterCommands::Outer(outer)) = parsed.command else {
+        panic!("expected outer")
+    };
+    assert_eq!(outer.cd.as_deref(), Some("here"));
+    assert_eq!(outer.profile.as_deref(), Some("work"));
+    let Some(GlobalCommands::Leaf(leaf)) = outer.command else {
+        panic!("expected leaf")
+    };
+    assert_eq!(leaf.what.as_deref(), Some("thing"));
+}

--- a/conformance/tests/spec_roundtrip.rs
+++ b/conformance/tests/spec_roundtrip.rs
@@ -794,6 +794,7 @@ fn a_declared_completer_becomes_a_run_the_reference_can_read() {
         cword: 1,
         prefix: "n",
         command_words: &[],
+        command_path: &[],
     };
     let found = usage_argv::complete::for_name(&SPEC, "tool", &ctx).expect("a completer");
     assert_eq!(found.len(), 1);
@@ -941,6 +942,8 @@ fn two_commands_can_mean_different_things_by_one_name() {
         words: &words,
         cword: 2,
         prefix: "",
+        command_words: &[],
+        command_path: &[],
     };
     let found = usage_argv::complete::for_name(&SPEC_THREE, "tool", &ctx).expect("a completer");
     assert_eq!(
@@ -957,6 +960,7 @@ fn two_commands_can_mean_different_things_by_one_name() {
             cword: words.len(),
             prefix: "",
             command_words: &[],
+            command_path: &[],
         };
         let found = usage_argv::complete::for_name(&SPEC_TWO, "tool", &ctx).expect("a completer");
         assert_eq!(

--- a/conformance/tests/spec_roundtrip.rs
+++ b/conformance/tests/spec_roundtrip.rs
@@ -788,10 +788,12 @@ fn a_declared_completer_becomes_a_run_the_reference_can_read() {
     assert!(!complete.descriptions, "{run}");
 
     // The binary answers exactly that, filtered by whatever has been typed.
+    let words = ["ex".to_string(), "n".to_string()];
     let ctx = usage_argv::complete::CompleteCtx {
-        words: &["ex".to_string(), "n".to_string()],
+        words: &words,
         cword: 1,
         prefix: "n",
+        command_words: &[],
     };
     let found = usage_argv::complete::for_name(&SPEC, "tool", &ctx).expect("a completer");
     assert_eq!(found.len(), 1);
@@ -954,6 +956,7 @@ fn two_commands_can_mean_different_things_by_one_name() {
             words: &[words.clone(), vec![String::new()]].concat(),
             cword: words.len(),
             prefix: "",
+            command_words: &[],
         };
         let found = usage_argv::complete::for_name(&SPEC_TWO, "tool", &ctx).expect("a completer");
         assert_eq!(

--- a/conformance/tests/spec_roundtrip.rs
+++ b/conformance/tests/spec_roundtrip.rs
@@ -1033,6 +1033,8 @@ fn two_fields_on_one_command_can_mean_different_things_by_one_name() {
             cword: words.len() - 1,
             words: &words,
             prefix: "",
+            command_words: &[],
+            command_path: &[],
         };
         let found = usage_argv::complete::for_name(&SPEC, "tool", &ctx).expect("a completer");
         assert_eq!(

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -50,8 +50,14 @@ pub fn emit(cli: &Cli) -> TokenStream {
     let keys = key_consts(&cli.fingerprint, flags.len(), args.len());
     let flag_tables = flags.iter().enumerate().map(|(i, f)| flag_table(i, f));
     let arg_tables = args.iter().enumerate().map(|(i, f)| arg_table(i, f));
-    let flag_metas = flags.iter().enumerate().map(|(i, f)| flag_meta(i, f));
-    let arg_metas = args.iter().enumerate().map(|(i, f)| arg_meta(i, f));
+    let flag_metas = flags
+        .iter()
+        .enumerate()
+        .map(|(i, f)| flag_meta(i, f, &cli.ident));
+    let arg_metas = args
+        .iter()
+        .enumerate()
+        .map(|(i, f)| arg_meta(i, f, &cli.ident));
 
     // Both the plain slices and, when a field is flattened, the joined arrays.
     let tables = tables(cli);
@@ -379,10 +385,19 @@ fn completion_fns(cli: &Cli) -> (TokenStream, TokenStream) {
             let cursor = cursor.unwrap_or(line.len());
             let split = ::usage_argv::complete::split(&line, cursor, shell);
             if let ::std::option::Option::Some(name) = candidates_for {
+                // Walked here as well, because a `--candidates` request names a completer and
+                // says nothing about where the cursor is — and the completer still wants the
+                // words its own command was given.
+                let position =
+                    ::usage_argv::complete::walk(Self::spec().root.cmd, split.argv());
+                let __usage_words = split.argv();
                 let ctx = ::usage_argv::complete::CompleteCtx {
                     words: &split.words,
                     cword: split.cword,
                     prefix: &split.prefix,
+                    command_words: __usage_words
+                        .get(position.command_start..)
+                        .unwrap_or(&[]),
                 };
                 // Nothing of that name is an empty answer rather than an error: a spec written
                 // against a newer version of this CLI is a stale script, and a stale script
@@ -497,7 +512,63 @@ fn arg_table(i: usize, field: &Field) -> TokenStream {
     }
 }
 
-fn flag_meta(i: usize, field: &Field) -> TokenStream {
+/// The completer entry for a field, and the wrapper that gives it a typed partial.
+///
+/// A table entry has one uniform signature, and the function a CLI writes has the signature that
+/// is useful — its own command's half-parsed struct, and the context. The wrapper is what turns
+/// the first into the second: it reparses the words that command was given, which the position
+/// reports, and hands over the result. So `mise task ls --file other.toml ⌶` can be completed
+/// against that file, which is exactly what a `run=` shelling out to `mise tasks ls --complete`
+/// cannot see.
+fn completer_tokens(
+    i: usize,
+    field: &Field,
+    kind: &str,
+    owner: &syn::Ident,
+) -> (TokenStream, TokenStream) {
+    let Some(path) = &field.complete else {
+        return (TokenStream::new(), quote!(::std::option::Option::None));
+    };
+    let wrapper = format_ident!("__usage_complete_{kind}_{i}");
+    let decl = quote! {
+        fn #wrapper(
+            ctx: &::usage_argv::complete::CompleteCtx<'_>,
+        ) -> ::std::vec::Vec<::usage_argv::complete::Candidate<'static>> {
+            // The words this command was given, parsed against this command's own tables — so
+            // what the callback reads is what the parser would have bound, rather than a slice
+            // of the line it has to interpret itself.
+            let __usage_owned: ::std::vec::Vec<::std::ffi::OsString> = ctx
+                .command_words
+                .iter()
+                .map(|w| ::std::ffi::OsString::from(w))
+                .collect();
+            let __usage_argv: ::std::vec::Vec<&::std::ffi::OsStr> =
+                __usage_owned.iter().map(|a| a.as_os_str()).collect();
+            let mut partial = <super::#owner as ::usage_argv::spec::CommandArgs>::start();
+            let mut parser = ::usage_argv::Parser::new(
+                <super::#owner as ::usage_argv::spec::CommandArgs>::COMMAND,
+                &__usage_argv,
+            );
+            // A line being completed is unfinished by definition, so an error means the grammar
+            // ran out — the partial holds what was understood before that, which is the point.
+            while let ::std::option::Option::Some(event) = parser.next_event() {
+                match event {
+                    ::std::result::Result::Ok(event) => {
+                        let _ = <super::#owner as ::usage_argv::spec::CommandArgs>::apply(
+                            &mut partial,
+                            &event,
+                        );
+                    }
+                    ::std::result::Result::Err(_) => break,
+                }
+            }
+            super::#path(&partial, ctx)
+        }
+    };
+    (decl, quote!(::std::option::Option::Some(#wrapper)))
+}
+
+fn flag_meta(i: usize, field: &Field, owner: &syn::Ident) -> TokenStream {
     let name = format_ident!("FLAG_META_{i}");
     let table = format_ident!("FLAG_{i}");
     let help = option_str(field.help.as_deref());
@@ -527,8 +598,12 @@ fn flag_meta(i: usize, field: &Field) -> TokenStream {
     let required_if = &field.required_if;
     let required_unless = &field.required_unless;
 
+    let (completer_decl, completer) = completer_tokens(i, field, "flag", owner);
+
     quote! {
+        #completer_decl
         pub static #name: FlagMeta = FlagMeta {
+            complete: #completer,
             flag: &#table,
             help: #help,
             long_help: #long_help,
@@ -552,7 +627,7 @@ fn flag_meta(i: usize, field: &Field) -> TokenStream {
     }
 }
 
-fn arg_meta(i: usize, field: &Field) -> TokenStream {
+fn arg_meta(i: usize, field: &Field, owner: &syn::Ident) -> TokenStream {
     let name = format_ident!("ARG_META_{i}");
     let table = format_ident!("ARG_{i}");
     let help = option_str(field.help.as_deref());
@@ -570,9 +645,12 @@ fn arg_meta(i: usize, field: &Field) -> TokenStream {
     let required = field.shape == Shape::Required || field.required_collection;
     let choices = choices_tokens(field);
     let (var_min, var_max) = bounds_tokens(field);
+    let (completer_decl, completer) = completer_tokens(i, field, "arg", owner);
 
     quote! {
+        #completer_decl
         pub static #name: ArgMeta = ArgMeta {
+            complete: #completer,
             arg: &#table,
             help: #help,
             long_help: #long_help,
@@ -1577,8 +1655,14 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
     let keys = key_consts(&cli.fingerprint, flags.len(), args.len());
     let flag_tables = flags.iter().enumerate().map(|(i, f)| flag_table(i, f));
     let arg_tables = args.iter().enumerate().map(|(i, f)| arg_table(i, f));
-    let flag_metas = flags.iter().enumerate().map(|(i, f)| flag_meta(i, f));
-    let arg_metas = args.iter().enumerate().map(|(i, f)| arg_meta(i, f));
+    let flag_metas = flags
+        .iter()
+        .enumerate()
+        .map(|(i, f)| flag_meta(i, f, &cli.ident));
+    let arg_metas = args
+        .iter()
+        .enumerate()
+        .map(|(i, f)| arg_meta(i, f, &cli.ident));
     // Both the plain slices and, when a field is flattened, the joined arrays.
     let tables = tables(cli);
     let table_decls = &tables.decls;

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -96,11 +96,14 @@ pub fn emit(cli: &Cli) -> TokenStream {
     // `field: local` rather than the shorthand, because the locals are prefixed:
     // a field called `text` or `parser` would otherwise collide with something the
     // generated code needs.
-    let field_finals = cli
+    // Collected rather than left lazy: it is used by both the inherent `build` and the trait
+    // impl beside it, and an iterator cannot be walked twice.
+    let field_finals: Vec<_> = cli
         .fields
         .iter()
         .filter(|f| !matches!(f.kind, Kind::Subcommand { .. }))
-        .map(field_final);
+        .map(field_final)
+        .collect();
 
     quote! {
         #[doc(hidden)]
@@ -391,6 +394,14 @@ fn completion_fns(cli: &Cli) -> (TokenStream, TokenStream) {
                 let position =
                     ::usage_argv::complete::walk(Self::spec().root.cmd, split.argv());
                 let __usage_words = split.argv();
+                let __usage_path: ::std::vec::Vec<(
+                    &::usage_argv::Command<'_>,
+                    &[::std::string::String],
+                )> = position
+                    .path
+                    .iter()
+                    .map(|(cmd, start)| (*cmd, __usage_words.get(*start..).unwrap_or(&[])))
+                    .collect();
                 let ctx = ::usage_argv::complete::CompleteCtx {
                     words: &split.words,
                     cword: split.cword,
@@ -398,6 +409,7 @@ fn completion_fns(cli: &Cli) -> (TokenStream, TokenStream) {
                     command_words: __usage_words
                         .get(position.command_start..)
                         .unwrap_or(&[]),
+                    command_path: &__usage_path,
                 };
                 // Nothing of that name is an empty answer rather than an error: a spec written
                 // against a newer version of this CLI is a stale script, and a stale script
@@ -542,10 +554,16 @@ fn completer_tokens(
             // The words this command was given, parsed against this command's own tables — so
             // what the callback reads is what the parser would have bound, rather than a slice
             // of the line it has to interpret itself.
-            let __usage_owned: ::std::vec::Vec<::std::ffi::OsString> = ctx
-                .command_words
+            // This command's own words, asked for by this command — not the deepest one the
+            // line reached. A global flag is declared on an ancestor, and reparsing the
+            // subcommand's words against the ancestor's tables would drop everything the
+            // ancestor was given before the subcommand's name.
+            let __usage_words = ctx.words_for(
+                <super::#owner as ::usage_argv::spec::CommandArgs>::COMMAND,
+            );
+            let __usage_owned: ::std::vec::Vec<::std::ffi::OsString> = __usage_words
                 .iter()
-                .map(|w| ::std::ffi::OsString::from(w))
+                .map(::std::ffi::OsString::from)
                 .collect();
             let __usage_argv: ::std::vec::Vec<&::std::ffi::OsStr> =
                 __usage_owned.iter().map(|a| a.as_os_str()).collect();

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -530,6 +530,11 @@ fn completer_tokens(
         return (TokenStream::new(), quote!(::std::option::Option::None));
     };
     let wrapper = format_ident!("__usage_complete_{kind}_{i}");
+    // Through the same rewriting a field's *type* goes through: the generated module is one
+    // level below where the user wrote the path, so a bare name shifts by one — while
+    // `crate::…`, a leading `::` and `self::…` mean something already, and prefixing those
+    // produced a path that does not resolve.
+    let completer_path = path_in_module(path);
     let decl = quote! {
         fn #wrapper(
             ctx: &::usage_argv::complete::CompleteCtx<'_>,
@@ -562,7 +567,7 @@ fn completer_tokens(
                     ::std::result::Result::Err(_) => break,
                 }
             }
-            super::#path(&partial, ctx)
+            #completer_path(&partial, ctx)
         }
     };
     (decl, quote!(::std::option::Option::Some(#wrapper)))
@@ -910,15 +915,24 @@ fn in_module(ty: &syn::Type) -> TokenStream {
     let syn::Type::Path(path) = ty else {
         return quote!(#ty);
     };
-    // Already absolute, or rooted at the crate: resolves the same from anywhere.
-    if path.path.leading_colon.is_some() {
-        return quote!(#ty);
+    path_in_module(&path.path)
+}
+
+/// The same rewriting for a path that names a function rather than a type.
+///
+/// Extracted rather than repeated, because getting it wrong is not a compile error in this
+/// crate: it is one in the user's, at a line they did not write.
+fn path_in_module(path: &syn::Path) -> TokenStream {
+    // Already absolute: resolves the same from anywhere.
+    if path.leading_colon.is_some() {
+        return quote!(#path);
     }
-    let mut segments = path.path.segments.iter();
+    let mut segments = path.segments.iter();
     match segments.next().map(|s| s.ident.to_string()).as_deref() {
-        Some("crate") => quote!(#ty),
-        // `self` and `super` are relative to where the user wrote them, which is one
-        // level out from the generated module — so each shifts by one.
+        // Rooted at the crate, so it resolves the same from anywhere too.
+        Some("crate") => quote!(#path),
+        // `self` and `super` are relative to where the user wrote them, which is one level out
+        // from the generated module — so each shifts by one.
         Some("self") => {
             let rest = segments;
             quote!(super::#(#rest)::*)
@@ -928,7 +942,7 @@ fn in_module(ty: &syn::Type) -> TokenStream {
             quote!(super::super::#(#rest)::*)
         }
         // A relative path, which the generated module is one level below.
-        _ => quote!(super::#ty),
+        _ => quote!(super::#path),
     }
 }
 

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -558,9 +558,11 @@ fn completer_tokens(
             // line reached. A global flag is declared on an ancestor, and reparsing the
             // subcommand's words against the ancestor's tables would drop everything the
             // ancestor was given before the subcommand's name.
-            let __usage_words = ctx.words_for(
-                <super::#owner as ::usage_argv::spec::CommandArgs>::COMMAND,
-            );
+            let __usage_declaration =
+                <super::#owner as ::usage_argv::spec::CommandArgs>::COMMAND;
+            let (__usage_command, __usage_words) = ctx
+                .command_for(__usage_declaration)
+                .unwrap_or((__usage_declaration, ctx.command_words));
             let __usage_owned: ::std::vec::Vec<::std::ffi::OsString> = __usage_words
                 .iter()
                 .map(::std::ffi::OsString::from)
@@ -569,7 +571,7 @@ fn completer_tokens(
                 __usage_owned.iter().map(|a| a.as_os_str()).collect();
             let mut partial = <super::#owner as ::usage_argv::spec::CommandArgs>::start();
             let mut parser = ::usage_argv::Parser::new(
-                <super::#owner as ::usage_argv::spec::CommandArgs>::COMMAND,
+                __usage_command,
                 &__usage_argv,
             );
             // A line being completed is unfinished by definition, so an error means the grammar

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -141,6 +141,17 @@
 //! that will not convert becomes [`Error::InvalidValue`](usage_argv::Error::InvalidValue),
 //! carrying the offending text and whatever the type's own conversion said about it.
 //!
+//! A completer is written as
+//!
+//! ```ignore
+//! fn tasks(partial: &<Tasks as CommandArgs>::Partial, ctx: &CompleteCtx<'_>) -> Vec<Candidate<'static>>
+//! ```
+//!
+//! and is handed its *own command's* half-parsed struct, so `tk tasks --file other.toml <TAB>`
+//! can be answered against that file — which a `run=` shelling out to a fixed command cannot see.
+//! The emitted spec gets a `run=` naming this binary, so everything that reads a spec still has
+//! one, generated from the function rather than declared beside it.
+//!
 //! On the struct itself: `bin`, `version`, `about`, `long_about`, `before_help`, `after_help`,
 //! `default_subcommand`, and `completion` — which adds the hidden command a generated shell
 //! script calls, and needs usage-argv's `complete` feature enabled where it is depended on.
@@ -161,6 +172,7 @@
 //! | `help_heading = "x"` | the section to list this under in help output |
 //! | `hide` | keep it out of help and completions |
 //! | `double_dash = "required"` | a positional only fillable after `--` |
+//! | `complete = my_fn` | a function that answers for this value when a shell asks |
 //! | `value_enum` | the words come from the field's type, which derives [`ValueEnum`] |
 //! | `arg` | force a field to be positional |
 //! | `overrides = "--other"` | a flag this one displaces, the last given winning |

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -104,6 +104,11 @@ pub struct Field {
     /// The values this may take. Checked after the parse, since a choice list is
     /// about what a value *means* rather than which token it came from.
     pub choices: Vec<String>,
+    /// A Rust function that answers for this value when a shell asks.
+    ///
+    /// The counterpart of a spec's `run=`, and the source it is generated from: declaring the
+    /// function is the only place a completer is said to exist.
+    pub complete: Option<syn::Path>,
     pub var_min: Option<usize>,
     pub var_max: Option<usize>,
     /// Flags this one displaces. Applied while parsing rather than after it: the
@@ -624,6 +629,7 @@ impl Field {
             kind: Kind::Flatten {
                 ty: field.ty.clone(),
             },
+            complete: None,
             // A flattened field holds declarations, not a value, so none of what describes a
             // value applies — the same as a subcommand field.
             shape: Shape::Bool,
@@ -691,6 +697,7 @@ impl Field {
             ty: field.ty.clone(),
             name: to_kebab(&ident.to_string()),
             kind: Kind::Subcommand { ty, optional },
+            complete: None,
             // A subcommand field holds a command, not a value, so none of what
             // describes a value applies to it.
             shape: Shape::Bool,
@@ -756,6 +763,7 @@ impl Field {
         let mut hide = false;
         let mut is_arg = false;
         let mut choices: Vec<String> = Vec::new();
+        let mut complete: Option<syn::Path> = None;
         let mut value_enum = false;
         let mut var_min: Option<usize> = None;
         let mut var_max: Option<usize> = None;
@@ -804,6 +812,19 @@ impl Field {
                     "env" => env = Some(string_value(&meta)?),
                     // `choices("a", "b")` rather than one comma-joined string, so a
                     // value containing a comma is expressible.
+                    // A path, not a string: it names a function in the user's crate, and a
+                    // name that does not resolve should be a compile error where it is written
+                    // rather than a completion that silently answers nothing.
+                    "complete" => {
+                        let value = &meta.require_name_value()?.value;
+                        let Expr::Path(path) = value else {
+                            return Err(syn::Error::new_spanned(
+                                value,
+                                "`complete` takes a function, as in `complete = my_completer`",
+                            ));
+                        };
+                        complete = Some(path.path.clone());
+                    }
                     "choices" => {
                         let Meta::List(list) = &meta else {
                             return Err(syn::Error::new_spanned(
@@ -1323,6 +1344,7 @@ impl Field {
             value_name,
             required_collection,
             choices,
+            complete,
             value_enum,
             var_min,
             var_max,


### PR DESCRIPTION
`#[usage(arg, name = "TASK", complete = tasks)]`, where `tasks` is handed its own
command's half-parsed struct and the context:

    fn tasks(partial: &<Tasks as CommandArgs>::Partial, ctx: &CompleteCtx) -> Vec<Candidate>

That is the thing a `run=` cannot do. `mise tasks ls --complete` is a fixed command
that reads whatever config the shell happens to be standing in, not the one being
typed about; a completer that can read `--file` off the line being completed
answers `tk tasks --file other.toml ⌶` with that file's tasks. The test asserts
exactly that, and asserts the same CLI still parses those fields, since it is one
declaration read by both.

The wrapper is what makes the table entry uniform: a completer in a `&'static`
table has one signature, and the useful signature is per-command, so the generated
wrapper reparses the words that command was given — which the position now reports —
and hands over the result.

A path rather than a string, so a name that does not resolve is a compile error
where it is written rather than a completion that silently answers nothing.

One thing worth knowing for anything else generated into a user's crate: the
metadata field cannot sit behind `#[cfg(feature = "complete")]`, because a `cfg` in
generated code is read against the *user's* features, not this crate's. It compiled
and quietly dropped the field, and the completer was never called. The types moved
beside the metadata they belong to instead.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches parser descent tracking and completion wiring used by generated code; behavior changes for dynamic completers and global/flattened flags, though covered by new conformance tests.
> 
> **Overview**
> **Field completers** — `#[usage(complete = my_fn)]` wires Rust callbacks into completion metadata (and emitted `run=` specs). Generated wrappers reparse the **owning command's** argv slice into that type's `Partial`, then call `fn(partial, ctx) -> Vec<Candidate>`, so answers can depend on earlier flags like `--file` on the same line—unlike a fixed external `run=` command.
> 
> **Richer completion context** — `CompleteCtx` moves to `spec` with `command_words` and `command_path`; `Parser`/`Position` record where each command on the path starts. Completers on **global** or **flattened** flags resolve the declaring command via `command_for` instead of only the deepest subcommand's words.
> 
> **Spec/metadata** — `FlagMeta`/`ArgMeta::complete` is always present (not `cfg(feature = "complete")`), avoiding silent drops in user crates. Completer paths use the same module rewriting as types (`crate::`, `self::`, etc.).
> 
> Conformance tests cover file-dependent tasks, global `--profile`/`--cd`, flattened globals, `--candidates` round-trips, and completer path spelling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df950e02ff2946688f04475cd603d529b0906348. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->