### PR TITLE
fix(config): give a deprecation notice from anywhere along a rename chain

### DIFF
--- a/config/src/explain.rs
+++ b/config/src/explain.rs
@@ -14,7 +14,7 @@
 
 use std::fmt::Write as _;
 
-use crate::registry::{PropId, Registry};
+use crate::registry::PropId;
 use crate::resolve::Resolved;
 use crate::source::SourceKind;
 use crate::value::{one_line, shown};
@@ -121,32 +121,12 @@ pub fn explain(resolved: &Resolved, key: &str) -> Option<String> {
     // reading it off the setting that replaced it printed nothing at all for the one case where it
     // matters — and following the renames from there, because a notice can sit anywhere along a
     // chain: `a` renamed to `b`, and `b` the one carrying the notice that says to use `c`.
-    let deprecated = deprecation_along(registry, found.renamed_from.unwrap_or(meta.key));
+    let deprecated = registry.deprecation(found.renamed_from.unwrap_or(meta.key));
     if let Some(why) = deprecated {
         let _ = writeln!(out, "\n  deprecated: {}", one_line(why));
     }
 
     Some(out)
-}
-
-/// The first deprecation notice along the rename chain that starts at `key`.
-///
-/// Bounded by the number of settings there are, so a registry whose renames form a cycle stops
-/// rather than following them forever — the same guard [`Registry::lookup`] uses, and for the same
-/// reason: this is an authoring mistake, and hanging is a worse way to report one than nothing at
-/// all. `usage-config-build` refuses such a registry outright.
-fn deprecation_along(registry: Registry, key: &str) -> Option<&'static str> {
-    let mut current = registry.lookup_exact(key)?;
-    for _ in 0..registry.props.len() {
-        let meta = registry.get(current);
-        if let Some(why) = meta.deprecated {
-            return Some(why);
-        }
-        current = meta
-            .renamed_to
-            .and_then(|next| registry.lookup_exact(next))?;
-    }
-    None
 }
 
 /// Every warning the resolution produced, as lines.

--- a/config/src/registry.rs
+++ b/config/src/registry.rs
@@ -254,6 +254,28 @@ impl Registry {
             .map(|index| PropId(index as u16))
     }
 
+    /// The first deprecation notice along the rename chain that starts at `key`.
+    ///
+    /// The chain, not the declaration named: `a` renamed to `b`, and `b` the one carrying the notice
+    /// that says to use `c`. A user who wrote `a` is being told the same thing either way, and which
+    /// release the notice was attached in is not something they can see.
+    ///
+    /// Bounded by the number of settings there are, so a registry whose renames form a cycle stops
+    /// rather than following them forever — the same guard [`Registry::lookup`] uses, and for the
+    /// same reason: this is an authoring mistake, and hanging is a worse way to report one than
+    /// nothing at all. `usage-config-build` refuses such a registry outright.
+    pub fn deprecation(&self, key: &str) -> Option<&'static str> {
+        let mut current = self.lookup_exact(key)?;
+        for _ in 0..self.props.len() {
+            let meta = self.get(current);
+            if let Some(why) = meta.deprecated {
+                return Some(why);
+            }
+            current = meta.renamed_to.and_then(|next| self.lookup_exact(next))?;
+        }
+        None
+    }
+
     /// The settings an environment variable sets, and the variable that set them.
     ///
     /// Several names per setting are aliases in descending precedence, which the env layer

--- a/config/src/resolve.rs
+++ b/config/src/resolve.rs
@@ -180,10 +180,6 @@ pub fn resolve(registry: Registry, layers: Layers<'_>) -> Result<Resolved, Layer
             // key up and `LayerCtx` folded it, or as a raw id this loop folded just now.
             // Keyed on the fold alone, a file layer's deprecated key was folded in silence.
             let written_key = entry.renamed_from.unwrap_or(written.key);
-            let as_written = registry
-                .lookup_exact(written_key)
-                .map(|id| registry.get(id))
-                .unwrap_or(written);
             if let Some(refusal) = refuse(meta.scope, &entry.origin) {
                 // `written_key`, like the two warnings below it: after `LayerCtx` folds a
                 // rename, `written.key` is the *replacement's* name, so a refused value was
@@ -195,7 +191,11 @@ pub fn resolve(registry: Registry, layers: Layers<'_>) -> Result<Resolved, Layer
                 );
                 continue;
             }
-            if let Some(why) = as_written.deprecated {
+            // Along the chain rather than off the declaration written, which is what `explain` has
+            // always done: a notice can sit on a name further along, and reading only the one the
+            // user wrote meant `config explain` told them to stop using a key that running the CLI
+            // said nothing about.
+            if let Some(why) = registry.deprecation(written_key) {
                 resolved.warnings.push(
                     Warning::at(
                         format!("{written_key} is deprecated: {why}"),
@@ -1054,6 +1054,57 @@ mod tests {
         assert!(
             messages.contains(&"renamed_jobs was read as jobs".to_string()),
             "{messages:?}"
+        );
+    }
+
+    #[test]
+    fn a_notice_further_along_a_chain_of_renames_is_still_given() {
+        // Two releases of renaming: `threads` became `concurrency`, which became `jobs` and carries
+        // the notice. `explain` walked the chain for it and the merge read only the declaration
+        // written, so `config explain threads` told a user to stop using a key that running the CLI
+        // said nothing about — one rule, two implementations, and the quieter one was the one a CLI
+        // actually surfaces.
+        static PROPS: &[PropMeta] = &[
+            PropMeta {
+                default: Some(Const::Int(1)),
+                ..PropMeta::new("jobs", Ty::Uint)
+            },
+            PropMeta {
+                renamed_to: Some("jobs"),
+                deprecated: Some("Use jobs instead."),
+                ..PropMeta::new("concurrency", Ty::Uint)
+            },
+            PropMeta {
+                renamed_to: Some("concurrency"),
+                ..PropMeta::new("threads", Ty::Uint)
+            },
+        ];
+        const CHAINED: Registry = Registry::new(PROPS);
+
+        struct Wrote;
+        impl Layer for Wrote {
+            fn source(&self) -> SourceKind {
+                SourceKind::FILE
+            }
+            fn load(&self, ctx: &LayerCtx) -> Result<LayerOutput, LayerError> {
+                let mut out = LayerOutput::new();
+                let origin = Origin::file("hk.toml", FileScope::Project);
+                match ctx.entry_for_key("threads", "8", origin) {
+                    Ok(entry) => out.push(entry),
+                    Err(warning) => out.warn(warning),
+                }
+                Ok(out)
+            }
+        }
+        let resolved = resolve(CHAINED, Layers::new().then(&Wrote)).expect("should resolve");
+        assert_eq!(resolved.get_key("jobs"), Some(&Value::Int(8)));
+        let kinds: Vec<_> = resolved.warnings.iter().map(|w| w.kind).collect();
+        assert_eq!(kinds, vec![WarningKind::Deprecated, WarningKind::Renamed]);
+        // Named by what the user wrote, since that is the line in the file they would go and edit.
+        assert!(
+            resolved.warnings[0].message == "threads is deprecated: Use jobs instead.",
+            "{:?}",
+            resolved.warnings[0].message
         );
     }
 

--- a/corpus/config/04-renames.kdl
+++ b/corpus/config/04-renames.kdl
@@ -91,3 +91,17 @@ vector "a-chain-of-renames-resolves-to-its-end" doc="Two releases of renaming le
     warning "renamed"
   }
 }
+
+vector "a-notice-anywhere-along-a-chain-is-reported" doc="A deprecation notice may sit on a name further along than the one that was written, and it is still what the user is told." {
+  setting "jobs" type="uint" default=1
+  setting "concurrency" type="uint" renamed-to="jobs" deprecated="Use jobs instead."
+  setting "threads" type="uint" renamed-to="concurrency"
+  layer "file" id="hk.toml" {
+    value "threads" "8"
+  }
+  expect {
+    value "jobs" 8
+    warning "deprecated"
+    warning "renamed"
+  }
+}


### PR DESCRIPTION
A bug found by writing the corpus vector for a rule [#882](https://github.com/jdx/usage/pull/882) already
stated on the page.

`explain` walked the chain of renames looking for a deprecation notice — `a` renamed to `b`, and `b`
the one carrying the notice that says to use `c` — with a comment explaining why. The merge read the
notice off the declaration the user wrote. So:

```
$ hk config explain threads
threads = 8
  deprecated: Use jobs instead.

$ hk check          # nothing at all
```

The quieter of the two is the one a CLI actually surfaces, so the user is told to stop using the key
only if they happen to ask about it.

Same shape as most of this stack's findings: one rule, two implementations. Fixed by moving the
walker onto `Registry` and having both callers ask it, rather than teaching the second one to agree.

The message still names the key that was written — `threads is deprecated: Use jobs instead.` —
because that is the line in the file they would go and edit, not the one the notice happens to be
attached to.

## Verification

A test at the merge and the corpus vector that found it. Mutating the walk back to "read the
declaration written" fails both.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted behavior fix in config resolution and explain output; covered by new tests and corpus vectors, with no auth or security surface.
> 
> **Overview**
> **Unifies deprecation discovery** so `config explain` and config merge behave the same when a notice sits on an intermediate rename (e.g. `threads` → `concurrency` → `jobs`, with deprecation on `concurrency`).
> 
> The rename-chain walker moves from a private helper in `explain` to **`Registry::deprecation`**. **`explain`** and **`resolve`** both call it. Merge no longer reads `deprecated` only off the declaration for the key the user wrote, which meant CLIs could stay silent while `config explain` still showed a deprecation.
> 
> Warnings still use the **written** key (`threads is deprecated: …`) so messages point at the line in the file users would edit.
> 
> Adds a merge unit test and corpus vector **`a-notice-anywhere-along-a-chain-is-reported`** in `04-renames.kdl`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a09162b05813035923b75038f99f8b575460334e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->