### PR TITLE
feat(derive): say how an argument relates to `--`, all four ways

### DIFF
--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -85,6 +85,10 @@ fn duplicate_flag_form(cmd: &Command<'_>) -> Option<std::string::String> {
 /// because the separator ends the collecting, and a `var_max`, because a bounded variadic hands
 /// over the words past its bound. mise relies on the first on `run`, `exec` and `git`.
 ///
+/// The separator is good for one argument and only where it is still a separator. A variadic
+/// that already claimed it has spent it, and one declaring `preserve` takes it as a *value* —
+/// so in either case the argument waiting for a `--` waits forever.
+///
 /// `#[derive(Args)]` applies that rule to one struct's own arguments. It cannot apply it across
 /// a `#[usage(flatten)]`: the variadic may be on one side of the boundary and the argument that
 /// follows it on the other, and neither expansion can see the other's fields. Checked here for
@@ -98,7 +102,14 @@ fn unfillable_arg<'a>(cmd: &Command<'a>) -> Option<&'a str> {
         // one separator exists, so nothing can follow *that*.
         let stopped_by_separator = arg.double_dash == DoubleDash::Required;
         if let Some(before) = variadic {
-            if !stopped_by_separator || before.double_dash == DoubleDash::Required {
+            let separator_is_gone = matches!(
+                before.double_dash,
+                // Spent on the variadic itself.
+                DoubleDash::Required
+                // Or never a separator at all, because the variadic keeps it as a value.
+                    | DoubleDash::Preserve
+            );
+            if !stopped_by_separator || separator_is_gone {
                 return Some(arg.name);
             }
         }
@@ -573,8 +584,10 @@ impl Spec<'_> {
             "no word could ever reach the argument {:?}, because an unbounded variadic before \
              it takes every remaining one. With `flatten` this is the arrangement neither \
              expansion can see: the variadic and the argument after it were declared in \
-             different structs. Give the variadic a `var_max`, or make the later argument \
-             fillable only after a `--`.",
+             different structs. Give the variadic a `var_max` — or, if the variadic leaves the \
+             `--` alone, make the later argument fillable only after one. A variadic that \
+             already requires a separator has spent it, and one declaring `preserve` takes it \
+             as a value, so neither can be stopped that way.",
             unfillable_arg(self.root.cmd)
         );
         let mut out = String::new();
@@ -1419,6 +1432,37 @@ mod tests {
             ..Command::EMPTY
         };
         assert_eq!(unfillable_arg(&AFTER_THE_SEPARATOR), Some("after"));
+
+        // Nor a variadic that keeps the separator as one of its values: `preserve` means the
+        // `--` never ends anything, so the argument waiting for one waits forever. The derive
+        // refuses this within one struct; here is where the same layout is caught when the two
+        // halves are on either side of a `#[usage(flatten)]` and neither expansion can see it.
+        static KEEPS_SEPARATOR: Arg = Arg {
+            name: "kept",
+            double_dash: DoubleDash::Preserve,
+            ..Arg::VAR
+        };
+        static SEPARATOR_KEPT: Command = Command {
+            name: "ex",
+            args: &[&KEEPS_SEPARATOR, &PAST_SEPARATOR],
+            ..Command::EMPTY
+        };
+        assert_eq!(unfillable_arg(&SEPARATOR_KEPT), Some("args_last"));
+
+        // And a bound puts it back, `preserve` or not: the variadic hands over once it is full,
+        // so what follows is reachable without needing a separator at all.
+        static KEEPS_SEPARATOR_BOUNDED: Arg = Arg {
+            name: "kept",
+            double_dash: DoubleDash::Preserve,
+            var_max: Some(2),
+            ..Arg::VAR
+        };
+        static BOUNDED_KEEPER: Command = Command {
+            name: "ex",
+            args: &[&KEEPS_SEPARATOR_BOUNDED, &PAST_SEPARATOR],
+            ..Command::EMPTY
+        };
+        assert_eq!(unfillable_arg(&BOUNDED_KEEPER), None);
 
         // Found at any depth, since a flattened struct can be used by a nested command.
         static NESTED: Command = Command {

--- a/benches/shadows/mise/src/lib.rs
+++ b/benches/shadows/mise/src/lib.rs
@@ -160,7 +160,7 @@ pub enum ToolAliasCommands {
 #[derive(Args)]
 pub struct AsdfArgs {
     /// all arguments
-    #[usage(arg, name = "ARGS")]
+    #[usage(arg, name = "ARGS", double_dash = "automatic")]
     pub args: ::std::vec::Vec<::std::string::String>,
 }
 
@@ -5106,7 +5106,7 @@ pub struct ToolStubArgs {
     /// Arguments to pass to the tool
     ///
     /// All arguments after the stub file path will be forwarded to the underlying tool. Use '--' to separate mise arguments from tool arguments if needed.
-    #[usage(arg, name = "ARGS")]
+    #[usage(arg, name = "ARGS", double_dash = "automatic")]
     pub args: ::std::vec::Vec<::std::string::String>,
 }
 
@@ -5972,7 +5972,7 @@ pub struct WatchArgs {
     )]
     pub task: ::std::option::Option<::std::string::String>,
     /// Task and arguments to run
-    #[usage(arg, name = "ARGS")]
+    #[usage(arg, name = "ARGS", double_dash = "automatic")]
     pub args: ::std::vec::Vec<::std::string::String>,
 }
 

--- a/conformance/tests/double_dash.rs
+++ b/conformance/tests/double_dash.rs
@@ -1,0 +1,139 @@
+//! The four ways an argument can relate to `--`, declared rather than patched in.
+//!
+//! The parser has understood all four since it was written; the derive could say only one of
+//! them, so a CLI wanting the others had to reach into the generated spec afterwards. mise does
+//! exactly that today — `src/cli/root_grammar.rs` sets `automatic` on the root's task by hand,
+//! because clap has nowhere to put it and the derive had nowhere either.
+//!
+//! `optional` and `required` are covered where they were built — the usage line, the completion
+//! walk, `only_one_argument_can_live_after_the_separator`. What is new here is that `preserve`
+//! and `automatic` can be *written*, so this file is about those two and about the one rule that
+//! distinguishes them from `required`.
+
+use std::ffi::OsStr;
+
+use usage::Spec as LibSpec;
+use usage_derive::Cli;
+
+/// A wrapper: the task's own flags are the task's
+///
+/// mise's shape, and the reason `automatic` exists. `mise run build --watch` gives `--watch` to
+/// the task; `mise run --dry-run build` is still mise's flag, because nothing had filled the
+/// argument yet.
+#[derive(Cli)]
+#[usage(bin = "ex")]
+struct Wrapper {
+    /// Do not actually run anything
+    #[usage(long)]
+    dry_run: bool,
+    /// The task to run
+    ///
+    /// It carries the mode too, and that is not redundant: the mode is per-argument, and it is
+    /// *filling this one* that ends mise's half of the line. mise's `root_grammar.rs` sets it on
+    /// both for the same reason.
+    #[usage(arg, name = "TASK", double_dash = "automatic")]
+    task: Option<String>,
+    /// Task and arguments to run
+    #[usage(arg, name = "ARGS", double_dash = "automatic")]
+    args: Vec<String>,
+}
+
+/// A tool that hands its argument the separator too
+#[derive(Cli)]
+#[usage(bin = "keep")]
+struct Keeper {
+    #[usage(long)]
+    verbose: bool,
+    /// Everything, `--` included
+    #[usage(arg, name = "REST", double_dash = "preserve")]
+    rest: Vec<String>,
+}
+
+#[test]
+fn a_mode_survives_the_round_trip_to_kdl() {
+    // The spec is the interface, so the mode has to be *written* as well as obeyed — a derive
+    // that parsed correctly and emitted nothing would leave `usage complete-word` and every
+    // other spec reader with the default.
+    let spec: LibSpec = Wrapper::to_kdl().parse().expect("valid spec");
+    let args = &spec.cmd.args;
+    assert_eq!(
+        args[1].double_dash,
+        usage::spec::arg::SpecDoubleDashChoices::Automatic
+    );
+    assert_eq!(
+        args[0].double_dash,
+        usage::spec::arg::SpecDoubleDashChoices::Automatic
+    );
+
+    let spec: LibSpec = Keeper::to_kdl().parse().expect("valid spec");
+    assert_eq!(
+        spec.cmd.args[0].double_dash,
+        usage::spec::arg::SpecDoubleDashChoices::Preserve
+    );
+
+    // And only where declared: a flag's own value argument is untouched by any of this.
+    assert!(spec.cmd.flags.iter().all(|f| f
+        .arg
+        .as_ref()
+        .is_none_or(|a| a.double_dash == usage::spec::arg::SpecDoubleDashChoices::Optional)));
+}
+
+#[test]
+fn automatic_stops_flags_where_the_argument_starts_filling() {
+    // Before: mise's flag, read by mise.
+    let argv = [OsStr::new("--dry-run"), OsStr::new("build")];
+    let parsed = Wrapper::parse_from(&argv).expect("should parse");
+    assert!(parsed.dry_run);
+    assert_eq!(parsed.task.as_deref(), Some("build"));
+    assert!(parsed.args.is_empty());
+
+    // After: the task's, handed over untouched — and *not* an unknown-flag error, which is the
+    // whole point of the mode.
+    let argv = [
+        OsStr::new("build"),
+        OsStr::new("--dry-run"),
+        OsStr::new("-x"),
+    ];
+    let parsed = Wrapper::parse_from(&argv).expect("should parse");
+    assert!(
+        !parsed.dry_run,
+        "a flag after the argument belongs to whatever the argument names"
+    );
+    assert_eq!(parsed.task.as_deref(), Some("build"));
+    assert_eq!(parsed.args, ["--dry-run", "-x"]);
+}
+
+#[test]
+fn preserve_gives_the_separator_to_the_argument() {
+    // `required` consumes the `--`; `preserve` keeps it, because the argument's holder wants the
+    // command line as it was typed. The two are opposite ends of the same question, and the
+    // derive could previously ask neither.
+    let argv = [
+        OsStr::new("--verbose"),
+        OsStr::new("a"),
+        OsStr::new("--"),
+        OsStr::new("b"),
+    ];
+    let parsed = Keeper::parse_from(&argv).expect("should parse");
+    assert!(parsed.verbose);
+    assert_eq!(parsed.rest, ["a", "--", "b"]);
+}
+
+#[test]
+fn only_required_stops_a_variadic() {
+    // The rule the ordering check turns on, and the one that is easy to get wrong: an argument
+    // after an unbounded variadic is reachable only if something ends the variadic, and only
+    // `required` does. `automatic` stops *flags*, which is a different thing, and `preserve`
+    // changes what a `--` means without ending anything — so a declaration of either behind an
+    // unbounded variadic is refused exactly as a plain one is.
+    //
+    // Checked here by parsing rather than by asserting on the compiler's message, which
+    // `derive::model`'s own tests do: this is the behaviour the rule protects.
+    let argv = [OsStr::new("build"), OsStr::new("one"), OsStr::new("two")];
+    let parsed = Wrapper::parse_from(&argv).expect("should parse");
+    assert_eq!(
+        parsed.args,
+        ["one", "two"],
+        "the unbounded variadic takes the rest, `automatic` or not"
+    );
+}

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -15,7 +15,7 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
-use crate::model::{rendered_path, Cli, Field, Kind, Shape, Subcommands, ValueEnum};
+use crate::model::{rendered_path, Cli, DoubleDash, Field, Kind, Shape, Subcommands, ValueEnum};
 
 pub fn emit(cli: &Cli) -> TokenStream {
     let ident = &cli.ident;
@@ -590,16 +590,14 @@ fn arg_table(i: usize, field: &Field) -> TokenStream {
     let key = key_ident("ARG", Some(i));
     let field_name = &field.name;
     let var = field.shape == Shape::Many;
-    let Kind::Arg {
-        double_dash_required,
-    } = &field.kind
-    else {
+    let Kind::Arg { double_dash } = &field.kind else {
         unreachable!("filtered by the caller");
     };
-    let double_dash = if *double_dash_required {
-        quote!(DoubleDash::Required)
-    } else {
-        quote!(DoubleDash::Optional)
+    let double_dash = match double_dash {
+        DoubleDash::Optional => quote!(DoubleDash::Optional),
+        DoubleDash::Required => quote!(DoubleDash::Required),
+        DoubleDash::Preserve => quote!(DoubleDash::Preserve),
+        DoubleDash::Automatic => quote!(DoubleDash::Automatic),
     };
     // A bound stops the variadic while binding, so the argument after it is reachable.
     let var_max = match field.var_max.filter(|_| var) {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -174,7 +174,7 @@
 //! | `default = "x"` | the value when the command line does not supply one |
 //! | `help_heading = "x"` | the section to list this under in help output |
 //! | `hide` | keep it out of help and completions |
-//! | `double_dash = "required"` | a positional only fillable after `--` |
+//! | `double_dash = "…"` | how a positional relates to `--`: `optional` (the default), `required` (fillable only after one), `preserve` (the `--` is a value), `automatic` (filling it ends flag parsing, so a wrapper forwards) |
 //! | `complete = my_fn` | a function that answers for this value when a shell asks |
 //! | `value_enum` | the words come from the field's type, which derives [`ValueEnum`] |
 //! | `arg` | force a field to be positional |

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -145,6 +145,27 @@ pub struct Field {
     pub span: Span,
 }
 
+/// How a positional argument relates to the `--` separator.
+///
+/// The spec's four modes, spelled as the spec spells them. Mirrors
+/// [`usage_argv::DoubleDash`] rather than being it, because the derive builds its model
+/// before it names the runtime — but the two must stay in step, which the round-trip test
+/// in `codegen` checks.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum DoubleDash {
+    /// Values may appear on either side of a `--`. The default.
+    Optional,
+    /// Values are accepted only after a `--`.
+    Required,
+    /// A `--` is kept as a value rather than consumed as a separator.
+    Preserve,
+    /// Once the argument takes a value, the rest of the command line is values.
+    ///
+    /// What a wrapper needs: `mise run build --watch` hands `--watch` to the task without
+    /// the user typing a separator, and `mise --watch build` is still a flag mise reads.
+    Automatic,
+}
+
 /// Whether a field is a flag or a positional, and how it is addressed.
 pub enum Kind {
     Flag {
@@ -157,8 +178,8 @@ pub enum Kind {
         variadic: bool,
     },
     Arg {
-        /// A `--` is required before this argument's value.
-        double_dash_required: bool,
+        /// How this argument relates to the `--` separator.
+        double_dash: DoubleDash,
     },
     /// Holds the enum whose variants are this command's subcommands.
     ///
@@ -496,16 +517,19 @@ impl Cli {
                 // where the whole tree is visible, by the duplicate-form check in
                 // `Spec::to_kdl`.
                 Kind::Flatten { .. } => {}
-                Kind::Arg {
-                    double_dash_required,
-                } => {
+                Kind::Arg { double_dash } => {
                     // A variadic takes every remaining word, so anything after it can
                     // never be filled — with two exceptions, both of which are something
                     // that stops the variadic. An argument only fillable after a `--`,
                     // because the separator ends the collecting; and any argument at all
                     // when the variadic is *bounded*, because it hands over the words past
                     // its bound. mise relies on the first on `run`, `exec` and `git`.
-                    if let Some(first) = variadic_arg.filter(|_| !*double_dash_required) {
+                    // Only `required` stops a variadic. `automatic` stops *flags*, which is a
+                    // different thing entirely, and `preserve` changes what a `--` means without
+                    // ending anything — an argument declaring either is as unreachable behind an
+                    // unbounded variadic as a plain one.
+                    let stops_the_variadic = *double_dash == DoubleDash::Required;
+                    if let Some(first) = variadic_arg.filter(|_| !stops_the_variadic) {
                         return Err(dup(
                             field.span,
                             first,
@@ -527,7 +551,7 @@ impl Cli {
                         ));
                     }
                     if field.shape == Shape::Many && field.var_max.is_none() {
-                        if *double_dash_required {
+                        if stops_the_variadic {
                             spent_separator = Some(field.span);
                         } else {
                             variadic_arg = Some(field.span);
@@ -781,7 +805,7 @@ impl Field {
         let mut repeatable = false;
         let mut variadic = false;
         let mut count = false;
-        let mut double_dash_required = false;
+        let mut double_dash = DoubleDash::Optional;
         let mut env = None;
         let mut setting = None;
         let mut default = None;
@@ -902,13 +926,17 @@ impl Field {
                     "double_dash" => {
                         let mode = string_value(&meta)?;
                         match mode.as_str() {
-                            "required" => double_dash_required = true,
+                            "optional" => double_dash = DoubleDash::Optional,
+                            "required" => double_dash = DoubleDash::Required,
+                            "preserve" => double_dash = DoubleDash::Preserve,
+                            "automatic" => double_dash = DoubleDash::Automatic,
                             other => {
                                 return Err(syn::Error::new_spanned(
                                     path,
                                     format!(
-                                        "`double_dash = \"{other}\"` is not supported yet; \
-                                         only \"required\" is"
+                                        "`double_dash = \"{other}\"` is not a mode; \
+                                         the spec has \"optional\", \"required\", \
+                                         \"preserve\" and \"automatic\""
                                     ),
                                 ));
                             }
@@ -1278,9 +1306,7 @@ impl Field {
                      use `String`",
                 ));
             }
-            Kind::Arg {
-                double_dash_required,
-            }
+            Kind::Arg { double_dash }
         };
 
         // `required` on a collection is the only way a `Vec` can say it, and it means *always*.
@@ -2172,6 +2198,45 @@ mod tests {
         "#,
         );
         assert!(err.contains("names no flag"), "unhelpful message: {err}");
+    }
+
+    #[test]
+    fn only_required_exempts_an_argument_from_the_variadic_rule() {
+        // `automatic` and `preserve` are about *flags* and about what a `--` means; neither ends
+        // a variadic, so neither buys an argument a place behind an unbounded one. Easy to get
+        // backwards now that all four modes can be written, and the cost of getting it backwards
+        // is a field that compiles and can never be filled.
+        for mode in ["automatic", "preserve"] {
+            let err = rejection(&format!(
+                r#"
+                struct Ex {{
+                    #[usage(arg)]
+                    args: Vec<String>,
+                    #[usage(arg, double_dash = "{mode}")]
+                    rest: Vec<String>,
+                }}
+            "#
+            ));
+            assert!(
+                err.contains("can never be filled"),
+                "`{mode}` should not exempt an argument: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_mode_the_spec_does_not_have_is_refused() {
+        let err = rejection(
+            r#"
+            struct Ex {
+                #[usage(arg, double_dash = "sometimes")]
+                rest: Vec<String>,
+            }
+        "#,
+        );
+        assert!(err.contains("is not a mode"), "unhelpful message: {err}");
+        // And the message lists them, because the four names are not guessable.
+        assert!(err.contains("preserve"), "unhelpful message: {err}");
     }
 
     #[test]

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -477,6 +477,7 @@ impl Cli {
         // A variadic that only takes what follows a `--`, which is the end of the line in
         // both senses: it holds the remaining words and the separator cannot come twice.
         let mut spent_separator: Option<Span> = None;
+        let mut separator_eating_variadic: Option<Span> = None;
         let mut subcommand_field: Option<Span> = None;
 
         for field in &self.fields {
@@ -529,6 +530,21 @@ impl Cli {
                     // ending anything — an argument declaring either is as unreachable behind an
                     // unbounded variadic as a plain one.
                     let stops_the_variadic = *double_dash == DoubleDash::Required;
+                    // Unless the variadic in front eats the separator. `preserve` takes the `--`
+                    // as one of its own values rather than letting it end anything, so the
+                    // argument that was going to be unlocked by one never is — and the exemption
+                    // that makes `run`'s layout legal would make this layout compile and be
+                    // unfillable, which is the exact thing the check exists to prevent.
+                    if let Some(first) = separator_eating_variadic {
+                        return Err(dup(
+                            field.span,
+                            first,
+                            "nothing can follow an unbounded variadic that keeps the `--` as a \
+                             value: `double_dash = \"preserve\"` means the separator never ends \
+                             anything, so not even an argument that waits for one can be filled \
+                             — give the variadic a `var_max`",
+                        ));
+                    }
                     if let Some(first) = variadic_arg.filter(|_| !stops_the_variadic) {
                         return Err(dup(
                             field.span,
@@ -555,6 +571,9 @@ impl Cli {
                             spent_separator = Some(field.span);
                         } else {
                             variadic_arg = Some(field.span);
+                            if *double_dash == DoubleDash::Preserve {
+                                separator_eating_variadic = Some(field.span);
+                            }
                         }
                     }
                 }
@@ -2222,6 +2241,42 @@ mod tests {
                 "`{mode}` should not exempt an argument: {err}"
             );
         }
+    }
+
+    #[test]
+    fn nothing_follows_a_variadic_that_keeps_the_separator() {
+        // The one exemption from the can-never-be-filled rule is an argument that waits for a
+        // `--`, on the grounds that the separator ends the variadic in front of it. A `preserve`
+        // variadic takes the `--` as a value instead, so it ends nothing and the exemption is
+        // false — the declaration compiled and the field could never hold anything.
+        let err = rejection(
+            r#"
+            struct Ex {
+                #[usage(arg, double_dash = "preserve")]
+                rest: Vec<String>,
+                #[usage(arg, double_dash = "required")]
+                after: Vec<String>,
+            }
+        "#,
+        );
+        assert!(
+            err.contains("keeps the `--` as a value"),
+            "unhelpful message: {err}"
+        );
+
+        // A bound puts it back: the variadic hands over once it is full, separator or not.
+        assert!(
+            cli(r#"
+            struct Ex {
+                #[usage(arg, double_dash = "preserve", var_max = 2)]
+                rest: Vec<String>,
+                #[usage(arg, double_dash = "required")]
+                after: Vec<String>,
+            }
+        "#)
+            .is_ok(),
+            "a bounded variadic hands over, so what follows is reachable"
+        );
     }
 
     #[test]

--- a/xtask/src/shadow.rs
+++ b/xtask/src/shadow.rs
@@ -886,9 +886,7 @@ fn usage_arg_opts(arg: &SpecArg, skipped: &mut Skipped) -> Vec<String> {
             opts.push(format!("var_max = {max}"));
         }
     }
-    double_dash(arg, skipped, |mode| {
-        opts.push(format!("double_dash = {mode:?}"))
-    });
+    double_dash(arg, |mode| opts.push(format!("double_dash = {mode:?}")));
     opts
 }
 
@@ -926,23 +924,37 @@ fn clap_arg_opts(arg: &SpecArg, skipped: &mut Skipped) -> Vec<String> {
             None => opts.push(format!("num_args = {least}..")),
         }
     }
-    // clap calls it `last`: the argument after the `--`.
-    double_dash(arg, skipped, |_| opts.push("last = true".into()));
+    // clap calls it `last`: the argument after the `--`. It has no name for the other three.
+    clap_double_dash(arg, skipped, || opts.push("last = true".into()));
     opts
 }
 
-/// The one `double_dash` mode both dialects can express, and notes for the rest.
-fn double_dash(arg: &SpecArg, skipped: &mut Skipped, mut required: impl FnMut(&str)) {
+/// A `double_dash` mode, in whichever of the two dialects can express it.
+///
+/// The usage dialect has all four. clap has one — `last`, which is `required` — so the other
+/// three are reported against the clap shadow rather than emitted. That asymmetry is the point of
+/// measuring the two side by side: it is a thing mise's spec says that clap cannot hear, which is
+/// why mise says it by patching the generated spec instead.
+fn double_dash(arg: &SpecArg, mut mode: impl FnMut(&str)) {
     match arg.double_dash {
         // The default: a `--` is allowed and changes nothing about where words land.
         usage::SpecDoubleDashChoices::Optional => {}
-        usage::SpecDoubleDashChoices::Required => required("required"),
-        usage::SpecDoubleDashChoices::Automatic => {
-            skipped.note("`double_dash = \"automatic\"` on an argument")
-        }
-        usage::SpecDoubleDashChoices::Preserve => {
-            skipped.note("`double_dash = \"preserve\"` on an argument")
-        }
+        usage::SpecDoubleDashChoices::Required => mode("required"),
+        usage::SpecDoubleDashChoices::Automatic => mode("automatic"),
+        usage::SpecDoubleDashChoices::Preserve => mode("preserve"),
+    }
+}
+
+/// The one mode clap can express, and a note for the rest.
+fn clap_double_dash(arg: &SpecArg, skipped: &mut Skipped, mut last: impl FnMut()) {
+    let mut unsayable = None;
+    double_dash(arg, |mode| match mode {
+        "required" => last(),
+        "automatic" => unsayable = Some("`double_dash = \"automatic\"` on an argument"),
+        _ => unsayable = Some("`double_dash = \"preserve\"` on an argument"),
+    });
+    if let Some(what) = unsayable {
+        skipped.note(what);
     }
 }
 


### PR DESCRIPTION
The parser has understood four `double_dash` modes since it was written. The derive could say one, so it modelled the question as a bool — `double_dash_required` — and a CLI wanting either of the other two had to reach into the generated spec afterwards.

mise does exactly that. Its root is two things at once: where its global flags live, and the shorthand for `mise run`. `mise --globa build` should be a misspelled flag; `mise build --globa` should hand `--globa` to the task. clap expresses the second with `allow_hyphen_values`, which says nothing about *where* on the line a dash-word may appear, so the whole root goes permissive and the typo is silently accepted as a task argument. `double_dash="automatic"` says what clap cannot: flag parsing ends when *that argument takes its first value*. mise's spec carries it on three arguments — `run`, `asdf`, `tool-stub` — and mise patches it in by hand.

`preserve` comes along because it is the same question from the other end: `required` consumes the `--`, `preserve` keeps it as a value, and the derive could ask neither.

**The rule worth stating**, because it is easy to get backwards now that all four can be written: only `required` exempts an argument from the can-never-be-filled check behind an unbounded variadic. `automatic` stops *flags*, which is a different thing, and `preserve` changes what a `--` means without ending anything. Both are refused there exactly as a plain argument is, per mode.

The shadow generator now reports each mode against the dialect that cannot hold it — the usage shadow drops none, and the clap shadow reports the three `automatic` declarations as clap's gap, which is the honest place for them.

## Verification

Four mutations, each failing a test that named the rule:

| mutation | result |
|---|---|
| `automatic` emitted as `Optional` | FAILED (2 tests) |
| `preserve` emitted as `Optional` | FAILED (2 tests) |
| `automatic`/`preserve` exempt an argument from the variadic rule | FAILED |
| an unknown mode silently reads as `optional` | FAILED |

Workspace suite green, clippy clean with no exclusions.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added expanded support for positional-argument `--` behavior, including optional, required, preserved, and automatic modes.
  - Automatic mode now hands off parsing after positional arguments begin, while preserve mode retains the separator.

- **Bug Fixes**
  - Improved variadic-argument handling when a `--` separator is present, including validation of unreachable arguments.

- **Documentation**
  - Updated usage documentation to describe all supported separator behaviors.

- **Tests**
  - Added conformance coverage for serialization, parsing, separator preservation, and variadic arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI parsing and compile-time validation for common mise-style wrappers; mistakes would surface as new derive errors or altered argv splitting, but behavior is heavily tested and limited to declarative metadata.
> 
> **Overview**
> **`#[usage(double_dash = …)]` now covers all four spec modes** (`optional`, `required`, `preserve`, `automatic`) instead of a single `required` boolean, and codegen emits the matching `DoubleDash` variant into specs so consumers like `usage complete-word` see the real mode without post-hoc patches.
> 
> **Variadic layout rules are tightened:** only `required` can unlock a positional behind an unbounded variadic; `preserve` variadics are treated as consuming the separator (so a later `--`-only arg is unreachable), with matching derive-time errors and `unfillable_arg` / debug_assert messaging for `#[usage(flatten)]` trees.
> 
> **mise shadow generated structs** set `double_dash = "automatic"` on `AsdfArgs`, `ToolStubArgs`, and `RunArgs` `ARGS` vectors; **xtask** emits all four modes into the usage shadow while still noting clap’s `last`-only gap for `automatic`/`preserve`.
> 
> **Conformance tests** in `double_dash.rs` cover KDL round-trip, `automatic` flag handoff, `preserve` keeping `--`, and that `automatic` does not stop an unbounded variadic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76ece68368ead3e8b6d375b2cc6f9c09f1ced433. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->