### PR TITLE
fix(spec): split a clap default by the delimiter clap splits it by

### DIFF
--- a/lib/src/spec/arg.rs
+++ b/lib/src/spec/arg.rs
@@ -334,6 +334,31 @@ impl FromStr for SpecArg {
     }
 }
 
+/// A clap argument's defaults, as the spec has to record them.
+///
+/// clap splits a value by the argument's `value_delimiter` before anyone sees it, defaults
+/// included — so `default_value = "a,b,c"` with `value_delimiter = ','` is three values, not one.
+/// The spec has no delimiter of its own; it has a list, which is the same statement. Recording the
+/// joined string instead described a CLI whose default is a single value that its own `choices`
+/// forbid, which is how mise's `--fs-events` reached the spec.
+#[cfg(feature = "clap")]
+pub(crate) fn default_values(arg: &clap::Arg) -> Vec<String> {
+    let raw = arg
+        .get_default_values()
+        .iter()
+        .map(|v| v.to_string_lossy().to_string());
+    match arg.get_value_delimiter() {
+        Some(delimiter) => raw
+            .flat_map(|v| {
+                v.split(delimiter)
+                    .map(|part| part.to_string())
+                    .collect::<Vec<_>>()
+            })
+            .collect(),
+        None => raw.collect(),
+    }
+}
+
 #[cfg(feature = "clap")]
 impl From<&clap::Arg> for SpecArg {
     fn from(arg: &clap::Arg) -> Self {
@@ -376,11 +401,7 @@ impl From<&clap::Arg> for SpecArg {
             var_max: None,
             var_min: None,
             hide,
-            default: arg
-                .get_default_values()
-                .iter()
-                .map(|v| v.to_string_lossy().to_string())
-                .collect(),
+            default: default_values(arg),
             choices: None,
             effect: None,
             env: None,

--- a/lib/src/spec/flag.rs
+++ b/lib/src/spec/flag.rs
@@ -535,11 +535,7 @@ impl From<&clap::Arg> for SpecFlag {
             c.get_action(),
             clap::ArgAction::Count | clap::ArgAction::Append
         );
-        let default: Vec<String> = c
-            .get_default_values()
-            .iter()
-            .map(|s| s.to_string_lossy().to_string())
-            .collect();
+        let default: Vec<String> = crate::spec::arg::default_values(c);
         let short = c.get_short_and_visible_aliases().unwrap_or_default();
         let long = c
             .get_long_and_visible_aliases()

--- a/lib/src/spec/mod.rs
+++ b/lib/src/spec/mod.rs
@@ -688,6 +688,37 @@ source_code_link_template "https://github.com/jdx/mise/blob/main/src/cli/{{path}
         "#);
     }
 
+    #[test]
+    #[cfg(feature = "clap")]
+    fn a_delimited_default_becomes_the_values_clap_would_split_it_into() {
+        // clap splits by the delimiter before anyone sees a value, defaults included, so the
+        // joined string is not something the CLI ever holds. The spec has no delimiter — it has
+        // a list, which says the same thing.
+        //
+        // mise's `--fs-events` is why: `default_value = "create,remove,rename,modify,metadata"`
+        // beside `value_parser` listing those as its choices, so the recorded default was a
+        // single value its own spec forbade.
+        let cmd = clap::Command::new("test").arg(
+            clap::Arg::new("events")
+                .long("events")
+                .value_delimiter(',')
+                .action(clap::ArgAction::Append)
+                .value_parser(["a", "b", "c"])
+                .default_value("a,b"),
+        );
+        let spec = Spec::from(&cmd);
+        let flag = spec.cmd.flags.iter().find(|f| f.name == "events").unwrap();
+        assert_eq!(flag.default, ["a", "b"]);
+
+        // And without a delimiter the value is whatever was written, commas and all: a path list
+        // is not every CLI's idea of a separator, so splitting on speculation would be worse.
+        let cmd = clap::Command::new("test")
+            .arg(clap::Arg::new("events").long("events").default_value("a,b"));
+        let spec = Spec::from(&cmd);
+        let flag = spec.cmd.flags.iter().find(|f| f.name == "events").unwrap();
+        assert_eq!(flag.default, ["a,b"]);
+    }
+
     macro_rules! extract_usage_tests {
         ($($name:ident: $input:expr, $expected:expr,)*) => {
         $(


### PR DESCRIPTION
`value_delimiter = ','` means clap splits every value before anyone sees it, defaults included — so `default_value = "a,b,c"` is three values and never the joined string. The conversion recorded the string.

mise's `--fs-events` is where it shows:

```rust
#[arg(long = "fs-events", default_value = "create,remove,rename,modify,metadata",
      value_delimiter = ',', value_name = "EVENTS")]
pub filter_fs_events: Vec<FsEvent>,
```

and the spec that came out:

```kdl
flag --fs-events var=#true default=create,remove,rename,modify,metadata {
    arg <EVENTS> { choices access create remove rename modify metadata }
}
```

A default its own `choices` node forbids. Nothing read it strictly enough to complain, which is the only reason it went unnoticed; a reader that does check — and the derive on top of this stack now does — refuses the CLI outright.

The spec has no delimiter of its own. It has a list, which says the same thing, so the fix is to write the list. Only where clap declares a delimiter: `"a,b"` without one is a value containing a comma, and splitting on speculation would corrupt every path list.

## Verification

Built mise against this branch and regenerated its spec; `--fs-events` comes out as

```kdl
default {
    create
    remove
    rename
    modify
    metadata
}
```

every word one of the declared choices. `benches/mise.usage.kdl` is updated to that, in the commit above it, since that is where the shadow reads it.

Mutation: ignoring the delimiter fails `a_delimited_default_becomes_the_values_clap_would_split_it_into`. 404 lib tests green.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to clap-to-spec metadata conversion with a targeted test; no runtime CLI parsing behavior in this PR.
> 
> **Overview**
> **Clap → spec conversion** now records defaults the way clap actually applies them: when an arg has a `value_delimiter`, default strings are split into multiple spec default entries instead of one joined string.
> 
> A shared **`default_values`** helper drives both **`SpecArg`** and **`SpecFlag`** clap bridges, fixing cases like delimited multi-value flags whose recorded default violated their own `choices` (e.g. mise `--fs-events`). **Without** a delimiter, defaults stay a single string (commas preserved).
> 
> A **regression test** covers delimited vs non-delimited behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cd20957094d3827041dea34cc96597922cca5d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->