### PR TITLE
feat(derive): a default a collecting field can hold

### DIFF
--- a/benches/mise.usage.kdl
+++ b/benches/mise.usage.kdl
@@ -5386,7 +5386,7 @@ This can also be used via the $WATCHEXEC_IGNORE_FILES environment variable.
 """#
         arg <PATH>
     }
-    flag --fs-events help="Filesystem events to filter to" var=#true default=create,remove,rename,modify,metadata {
+    flag --fs-events help="Filesystem events to filter to" var=#true {
         long_help #"""
 Filesystem events to filter to
 
@@ -5394,6 +5394,13 @@ This is a quick filter to only emit events for the given types of filesystem cha
 
 This may apply filtering at the kernel level when possible, which can be more efficient, but may be more confusing when reading the logs.
 """#
+        default {
+            create
+            remove
+            rename
+            modify
+            metadata
+        }
         arg <EVENTS> {
             choices access create remove rename modify metadata
         }

--- a/benches/shadows/mise-clap/src/lib.rs
+++ b/benches/shadows/mise-clap/src/lib.rs
@@ -5356,7 +5356,7 @@ pub struct WatchArgs {
     /// This is a quick filter to only emit events for the given types of filesystem changes. Choose from 'access', 'create', 'remove', 'rename', 'modify', 'metadata'. Multiple types can be given by repeating the option or by separating them with commas. By default, this is all types except for 'access'.
     ///
     /// This may apply filtering at the kernel level when possible, which can be more efficient, but may be more confusing when reading the logs.
-    #[arg(long = "fs-events", value_name = "EVENTS", value_parser = ::clap::builder::PossibleValuesParser::new(["access", "create", "remove", "rename", "modify", "metadata"]), default_value = "create,remove,rename,modify,metadata")]
+    #[arg(long = "fs-events", value_name = "EVENTS", value_parser = ::clap::builder::PossibleValuesParser::new(["access", "create", "remove", "rename", "modify", "metadata"]), default_value = "create")]
     pub fs_events: Vec<String>,
     /// Don't emit fs events for metadata changes
     ///

--- a/benches/shadows/mise/src/lib.rs
+++ b/benches/shadows/mise/src/lib.rs
@@ -5945,6 +5945,11 @@ pub struct WatchArgs {
         long = "fs-events",
         value_name = "EVENTS",
         choices("access", "create", "remove", "rename", "modify", "metadata"),
+        default = "create",
+        default = "remove",
+        default = "rename",
+        default = "modify",
+        default = "metadata",
         var
     )]
     pub fs_events: ::std::vec::Vec<::std::string::String>,

--- a/conformance/tests/post_binding.rs
+++ b/conformance/tests/post_binding.rs
@@ -430,3 +430,75 @@ fn each_occurrence_of_a_bounded_flag_counts_for_itself() {
     assert_eq!(bounded.include, ["a", "b"]);
     assert_eq!(bounded.out.as_deref(), Some("c"));
 }
+
+/// A watcher whose filter starts out set
+///
+/// mise's `mise watch --fs-events`, which is where this came from: a `Vec` flag that already
+/// holds something when nobody gives it one. Its spec said so and the derive could not, so it
+/// was the last thing mise's 211-command spec could express that the derive could not.
+#[derive(Cli)]
+#[usage(bin = "ex")]
+struct Defaulted {
+    /// Filesystem events to filter to
+    #[usage(long, var, default = "create", default = "remove", default = "modify")]
+    fs_events: Vec<String>,
+    /// Watch everything again
+    #[usage(long, overrides = "--fs-events")]
+    all_events: bool,
+    /// One value, and it may be given once
+    #[usage(long, default = "4")]
+    jobs: Option<String>,
+}
+
+#[test]
+fn a_collecting_flag_starts_out_holding_its_defaults() {
+    // Absent: all of them, in the order written. A `Vec` is the one shape that can hold
+    // several, so it is the one shape that may be given several.
+    let a = argv([]);
+    let d = Defaulted::parse_from(&a).expect("should parse");
+    assert_eq!(d.fs_events, ["create", "remove", "modify"]);
+    assert_eq!(d.jobs.as_deref(), Some("4"));
+
+    // Given: *replaced*, not added to. A default says what the flag means when nobody said
+    // anything, so appending would make `--fs-events access` mean four events, three of which
+    // the user asked to filter out.
+    let a = argv(["--fs-events", "access"]);
+    let d = Defaulted::parse_from(&a).expect("should parse");
+    assert_eq!(d.fs_events, ["access"]);
+}
+
+#[test]
+fn the_defaults_reach_the_spec_in_order() {
+    // The spec is the interface: a default the parser applies and the spec omits is a CLI whose
+    // help, completions and manpage describe different behaviour from the binary.
+    let spec: usage::Spec = Defaulted::to_kdl().parse().expect("valid spec");
+    let flag = spec
+        .cmd
+        .flags
+        .iter()
+        .find(|f| f.name == "fs-events")
+        .expect("the flag");
+    let defaults = if flag.default.is_empty() {
+        &flag.arg.as_ref().expect("takes a value").default
+    } else {
+        &flag.default
+    };
+    assert_eq!(defaults, &["create", "remove", "modify"]);
+}
+
+#[test]
+fn a_displaced_collecting_flag_goes_back_to_its_defaults() {
+    // The other half of "replaced, not added to", and the half the guard on `__given_*` hides:
+    // when the flag *was* given, the defaults are never reached — except here. `--all-events`
+    // displaces `--fs-events`, and what a displaced flag reads as is its declared default, so
+    // the values the user gave have to go. Appending would leave `access` standing beside the
+    // three it was meant to replace, in a flag the user asked to be overridden.
+    let a = argv(["--fs-events", "access", "--all-events"]);
+    let d = Defaulted::parse_from(&a).expect("should parse");
+    assert!(d.all_events);
+    assert_eq!(
+        d.fs_events,
+        ["create", "remove", "modify"],
+        "back to its declared defaults, and only those"
+    );
+}

--- a/conformance/tests/post_binding.rs
+++ b/conformance/tests/post_binding.rs
@@ -448,6 +448,15 @@ struct Defaulted {
     /// One value, and it may be given once
     #[usage(long, default = "4")]
     jobs: Option<String>,
+    /// Read from the environment when nobody says otherwise
+    #[usage(long, var, default = "one", default = "two", env = "EX_FROM_ENV")]
+    from_env: Vec<String>,
+    /// Never `None`, because it always has something
+    #[usage(long, var, default = "x", default = "y")]
+    maybe: Option<Vec<String>>,
+    /// `None` until it is given, because it declares nothing
+    #[usage(long, var)]
+    plain: Option<Vec<String>>,
 }
 
 #[test]
@@ -501,4 +510,45 @@ fn a_displaced_collecting_flag_goes_back_to_its_defaults() {
         ["create", "remove", "modify"],
         "back to its declared defaults, and only those"
     );
+}
+
+#[test]
+fn the_environment_replaces_a_collections_defaults() {
+    // Every other shape assigns, so the environment overrides a default. A collection pushed,
+    // so it ended up holding both — three events when the variable named one, and the extra two
+    // are the ones the user's variable was chosen instead of.
+    //
+    // Serialized against the other environment test by reading a variable of its own.
+    unsafe { std::env::set_var("EX_FROM_ENV", "three") };
+    let a = argv([]);
+    let d = Defaulted::parse_from(&a).expect("should parse");
+    assert_eq!(d.from_env, ["three"]);
+    unsafe { std::env::remove_var("EX_FROM_ENV") };
+
+    // And with the variable unset the defaults stand, which is the other half of "replaces".
+    let a = argv([]);
+    let d = Defaulted::parse_from(&a).expect("should parse");
+    assert_eq!(d.from_env, ["one", "two"]);
+}
+
+#[test]
+fn an_optional_collection_with_defaults_is_never_none() {
+    // `Option<Vec<T>>` says `None` for "never given", and a default is a value — so a field that
+    // declares one always has something to hold. Seeding it left `__given_*` alone (the
+    // environment still has to be able to replace it), so `None` came back and every declared
+    // default was discarded on the way out of the partial.
+    let a = argv([]);
+    let d = Defaulted::parse_from(&a).expect("should parse");
+    assert_eq!(
+        d.maybe.as_deref(),
+        Some(&["x".to_string(), "y".to_string()][..])
+    );
+
+    // Given, it is what was given.
+    let a = argv(["--maybe", "z"]);
+    let d = Defaulted::parse_from(&a).expect("should parse");
+    assert_eq!(d.maybe.as_deref(), Some(&["z".to_string()][..]));
+
+    // And one that declares no default still tells "never given" from "given nothing".
+    assert_eq!(d.plain, None);
 }

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -697,10 +697,8 @@ fn flag_meta(i: usize, field: &Field, owner: &syn::Ident) -> TokenStream {
     let env = option_str(field.env.as_deref());
     let help_heading = option_str(field.help_heading.as_deref());
     let value_name = option_str(field.value_name.as_deref());
-    let default = match field.default.as_deref() {
-        Some(d) => quote!(&[#d]),
-        None => quote!(&[]),
-    };
+    let defaults = &field.default;
+    let default = quote!(&[#(#defaults),*]);
     let hide = field.hide;
     let count = field.shape == Shape::Count;
     let repeatable = field.repeatable;
@@ -755,10 +753,8 @@ fn arg_meta(i: usize, field: &Field, owner: &syn::Ident) -> TokenStream {
     let long_help = option_str(field.long_help.as_deref());
     let env = option_str(field.env.as_deref());
     let help_heading = option_str(field.help_heading.as_deref());
-    let default = match field.default.as_deref() {
-        Some(d) => quote!(&[#d]),
-        None => quote!(&[]),
-    };
+    let defaults = &field.default;
+    let default = quote!(&[#(#defaults),*]);
     let hide = field.hide;
     // `String` must be filled; `Option` and `Vec` need not be.
     // A collecting field's type cannot say whether one value is needed, so `required` may
@@ -1824,27 +1820,36 @@ fn field_final(field: &Field) -> TokenStream {
 /// not as absent.
 fn reset_to_default(field: &Field) -> TokenStream {
     let ident = &field.ident;
-    let Some(default) = field.default.as_deref() else {
-        return match field.shape {
-            // A collection is cleared rather than replaced, so the field keeps whatever
-            // capacity it already allocated.
-            Shape::Many => quote!(partial.#ident.clear();),
-            _ => quote!(partial.#ident = ::std::default::Default::default();),
-        };
+    // A collection is cleared rather than replaced, so the field keeps whatever capacity it
+    // already allocated — and clearing is also the first half of seeding it, since a default
+    // means *these values and no others* however many were bound before.
+    let cleared = match field.shape {
+        Shape::Many => quote!(partial.#ident.clear();),
+        _ => quote!(partial.#ident = ::std::default::Default::default();),
     };
+    if field.default.is_empty() {
+        return cleared;
+    }
+    // Every shape but a collection was checked in the model to have at most one.
+    let first = &field.default[0];
     match field.shape {
         Shape::Bool => {
-            let on = default == "true";
+            let on = first == "true";
             quote!(partial.#ident = #on;)
         }
         Shape::Optional => quote! {
-            partial.#ident = ::std::option::Option::Some(#default.as_bytes().to_vec());
+            partial.#ident = ::std::option::Option::Some(#first.as_bytes().to_vec());
         },
-        Shape::Required => quote!(partial.#ident = #default.as_bytes().to_vec();),
-        // Rejected in the model: a count starts at zero, and a default for a collecting
-        // field is not applied yet.
-        Shape::Count => quote!(partial.#ident = ::std::default::Default::default();),
-        Shape::Many => quote!(partial.#ident.clear();),
+        Shape::Required => quote!(partial.#ident = #first.as_bytes().to_vec();),
+        // Rejected in the model: a count starts at zero, so a default has nothing to say.
+        Shape::Count => cleared,
+        Shape::Many => {
+            let defaults = &field.default;
+            quote! {
+                #cleared
+                #(partial.#ident.push(#defaults.as_bytes().to_vec());)*
+            }
+        }
     }
 }
 
@@ -2540,7 +2545,7 @@ fn post_binding(cli: &Cli) -> TokenStream {
     // Guarded on `__given_*`, which is what makes this safe to move: a negation that set a
     // defaulted `bool` to false during the parse must not be undone here.
     let declared_defaults = cli.fields.iter().filter_map(|f| {
-        if f.default.is_none() || matches!(f.kind, Kind::Subcommand { .. }) {
+        if f.default.is_empty() || matches!(f.kind, Kind::Subcommand { .. }) {
             return None;
         }
         let given = format_ident!("__given_{}", f.ident);
@@ -2609,7 +2614,7 @@ fn post_binding(cli: &Cli) -> TokenStream {
         // meant a `Vec` marked `required` was reported as one-or-more by the spec, the help, the
         // manpage and the completions, and accepted zero values from the CLI that actually ran.
         // One expression cannot disagree with itself.
-        if !(f.shape == Shape::Required || f.required_collection) || f.default.is_some() {
+        if !(f.shape == Shape::Required || f.required_collection) || !f.default.is_empty() {
             return None;
         }
         let given = format_ident!("__given_{}", f.ident);
@@ -2770,7 +2775,7 @@ fn post_binding(cli: &Cli) -> TokenStream {
         }
         // A field with a default is already filled, so no condition can make it
         // missing. Plain required-ness skips these too, and so does usage-lib.
-        if f.default.is_some() {
+        if !f.default.is_empty() {
             return None;
         }
         let given = format_ident!("__given_{}", f.ident);

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -1703,10 +1703,11 @@ fn field_final(field: &Field) -> TokenStream {
                 }};
                 if field.optional_collection {
                     let given = format_ident!("__given_{}", ident);
+                    let defaulted = !field.default.is_empty();
                     // Same as below: whether anything arrived is what tells "never given"
                     // from "given nothing", which the `Vec` itself cannot.
                     quote! {
-                        #ident: if partial.#given {
+                        #ident: if partial.#given || #defaulted {
                             ::std::option::Option::Some(#collected)
                         } else {
                             ::std::option::Option::None
@@ -1796,10 +1797,14 @@ fn field_final(field: &Field) -> TokenStream {
             }};
             if field.optional_collection {
                 let given = format_ident!("__given_{}", ident);
+                // A declared default is a value, so a field that has one is never `None`. It
+                // does not set `__given_*` — the environment still has to be able to replace it
+                // — so the answer has to come from the declaration rather than from the partial.
+                let defaulted = !field.default.is_empty();
                 // `Option<Vec<T>>` distinguishes "never given" from "given nothing", which
                 // no `Vec` can — so the answer comes from whether anything arrived.
                 quote! {
-                    #ident: if partial.#given {
+                    #ident: if partial.#given || #defaulted {
                         ::std::option::Option::Some(#collected)
                     } else {
                         ::std::option::Option::None
@@ -2568,7 +2573,15 @@ fn post_binding(cli: &Cli) -> TokenStream {
                 partial.#ident = ::std::option::Option::Some(value.into_bytes());
             },
             Shape::Required => quote!(partial.#ident = value.into_bytes();),
-            Shape::Many => quote!(partial.#ident.push(value.into_bytes());),
+            // Cleared first, so the environment *replaces* a declared default instead of
+            // adding to it — which is what every other shape does by assigning, and what the
+            // order here means: a default says what the value is when nobody said anything,
+            // and the environment is somebody saying something. Nothing else can be in the
+            // collection at this point: argv sets `__given_*`, which this is guarded on.
+            Shape::Many => quote! {
+                partial.#ident.clear();
+                partial.#ident.push(value.into_bytes());
+            },
             // A switch reads as on for anything but the spellings of "off", which is
             // what every tool that takes a boolean from the environment settles on.
             Shape::Bool => quote! {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -171,7 +171,7 @@
 //! | `var_max = n` | how many values a variadic takes before the next field gets the rest |
 //! | `global` | subcommands inherit the flag |
 //! | `env = "X"` | an environment variable that can supply the value |
-//! | `default = "x"` | the value when the command line does not supply one |
+//! | `default = "x"` | the value when the command line does not supply one; a `Vec` may be given several, and starts out holding all of them |
 //! | `help_heading = "x"` | the section to list this under in help output |
 //! | `hide` | keep it out of help and completions |
 //! | `double_dash = "…"` | how a positional relates to `--`: `optional` (the default), `required` (fillable only after one), `preserve` (the `--` is a value), `automatic` (filling it ends flag parsing, so a wrapper forwards) |

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -104,7 +104,12 @@ pub struct Field {
     /// this is the executable one; `Registry::drift` compares them, which is what hk's eighteen
     /// declared and five read `sources.cli` lines needed and never had.
     pub setting: Option<String>,
-    pub default: Option<String>,
+    /// The values the field takes when the command line supplies none.
+    ///
+    /// A list, because the spec's is: a collecting field can be given several, each `default`
+    /// one item, in the order they are written. Every other shape holds at most one, which the
+    /// model checks — a `String` has one place to put a value.
+    pub default: Vec<String>,
     pub help_heading: Option<String>,
     /// Whether a collecting argument needs at least one value.
     ///
@@ -753,7 +758,7 @@ impl Field {
             long_help: None,
             env: None,
             setting: None,
-            default: None,
+            default: Vec::new(),
             help_heading: None,
             value_name: None,
             required_collection: false,
@@ -822,7 +827,7 @@ impl Field {
             long_help: None,
             env: None,
             setting: None,
-            default: None,
+            default: Vec::new(),
             help_heading: None,
             value_name: None,
             required_collection: false,
@@ -871,7 +876,7 @@ impl Field {
         let mut double_dash = DoubleDash::Optional;
         let mut env = None;
         let mut setting = None;
-        let mut default = None;
+        let mut default: Vec<String> = Vec::new();
         let mut help_heading = None;
         let mut value_name = None;
         let mut required_collection = false;
@@ -977,7 +982,7 @@ impl Field {
                     "value_enum" => value_enum = flag_value(&meta)?,
                     "var_min" => var_min = Some(int_value(&meta)?),
                     "var_max" => var_max = Some(int_value(&meta)?),
-                    "default" => default = Some(string_value(&meta)?),
+                    "default" => default.push(string_value(&meta)?),
                     "help_heading" => help_heading = Some(string_value(&meta)?),
                     "value_name" => value_name = Some(string_value(&meta)?),
                     // Help text a doc comment cannot carry. A comment's first paragraph is
@@ -1114,7 +1119,18 @@ impl Field {
         } = ValueKind::from_type(&field.ty, count, span)?;
         // The spec records a default and the generated code applies it; anything it
         // cannot apply would be documented and then ignored.
-        if let Some(value) = &default {
+        //
+        // Several is a collection's privilege. Every other shape has one place to put a value,
+        // so a second `default` is a contradiction rather than a list — and silently keeping
+        // the last would be a declaration the author cannot see being ignored.
+        if default.len() > 1 && shape != Shape::Many {
+            return Err(syn::Error::new(
+                span,
+                "this field holds one value, so it takes one `default`; several is for a \
+                 `Vec`, which starts out holding all of them",
+            ));
+        }
+        for value in &default {
             match shape {
                 Shape::Bool if value != "true" && value != "false" => {
                     return Err(syn::Error::new(
@@ -1130,13 +1146,6 @@ impl Field {
                         span,
                         "a `count` field starts at zero, so a default has nothing to \
                          say",
-                    ));
-                }
-                Shape::Many => {
-                    return Err(syn::Error::new(
-                        span,
-                        "a default for a collecting field is not applied yet, so it \
-                         would be documented and then ignored",
                     ));
                 }
                 _ => {}
@@ -1179,8 +1188,10 @@ impl Field {
                 "`var_min` and `var_max` count values, so the field has to be a `Vec`",
             ));
         }
-        if let Some(default) = &default {
-            if !choices.is_empty() && !choices.iter().any(|c| c == default) {
+        if !choices.is_empty() {
+            // Each of them, not the first: a collection's second default is as unusable as its
+            // first if the choices do not allow it.
+            if let Some(default) = default.iter().find(|d| !choices.contains(d)) {
                 return Err(syn::Error::new(
                     span,
                     format!(
@@ -2261,6 +2272,37 @@ mod tests {
         "#,
         );
         assert!(err.contains("names no flag"), "unhelpful message: {err}");
+    }
+
+    #[test]
+    fn only_a_collection_takes_more_than_one_default() {
+        // Several defaults is a `Vec`'s privilege, because a `Vec` is the only shape with
+        // somewhere to put them. Keeping the last silently would leave the others declared,
+        // emitted into the spec, and never applied.
+        let err = rejection(
+            r#"
+            struct Ex {
+                #[usage(long, default = "a", default = "b")]
+                out: Option<String>,
+            }
+        "#,
+        );
+        assert!(err.contains("one `default`"), "unhelpful message: {err}");
+    }
+
+    #[test]
+    fn every_default_has_to_be_one_of_the_choices() {
+        // Each of them, not the first: a collection's second default is as unusable as its
+        // first if the choices do not allow it.
+        let err = rejection(
+            r#"
+            struct Ex {
+                #[usage(long, var, choices("a", "b"), default = "a", default = "z")]
+                out: Vec<String>,
+            }
+        "#,
+        );
+        assert!(err.contains("the default `z`"), "unhelpful message: {err}");
     }
 
     #[test]

--- a/xtask/src/shadow.rs
+++ b/xtask/src/shadow.rs
@@ -670,13 +670,17 @@ fn usage_flag_opts(
         if let Some(choices) = &arg.choices {
             opts.push(format!("choices({})", quoted_list(&choices.choices)));
         }
-        // Not on a collecting field: the derive refuses a default it would write into the
-        // spec and then never apply.
         let defaults = flag_defaults(flag);
-        if flag.var || arg.var {
-            if !defaults.is_empty() {
-                skipped.note("a default on a flag that collects values");
-            }
+        let collects = flag.var || arg.var;
+        // A collecting flag starts out holding all of them, in the order written; every other
+        // shape has one place to put a value, so only its first survives.
+        for default in defaults.iter().take(if collects { usize::MAX } else { 1 }) {
+            opts.push(format!("default = {default:?}"));
+        }
+        if !collects && defaults.len() > 1 {
+            skipped.note("a flag's second and later defaults");
+        }
+        if collects {
             if flag.var {
                 opts.push("var".into());
             }
@@ -706,13 +710,6 @@ fn usage_flag_opts(
                 || (flag.var_max.is_some() && arg.var_max.is_some())
             {
                 skipped.note("a bound on both a flag and its argument");
-            }
-        } else {
-            if let Some(default) = defaults.first() {
-                opts.push(format!("default = {default:?}"));
-            }
-            if defaults.len() > 1 {
-                skipped.note("a flag's second and later defaults");
             }
         }
     }


### PR DESCRIPTION
The last thing mise's 211-command spec could say that the derive could not. `mise watch --fs-events` starts out filtering to five event kinds; the derive refused a default on a `Vec` with *"not applied yet, so it would be documented and then ignored"* — true then, not now.

`default` becomes a list, because the spec's is. A `Vec` may be given several and starts out holding all of them, in the order written; every other shape has one place to put a value, so a second `default` is refused rather than silently kept — a declaration the author cannot see being ignored is what the old rule was avoiding.

**Replaced, not added to.** A default says what a flag means when nobody said anything, so `--fs-events access` means one event and not four. That matters twice: where the flag was given, and where it was *displaced* by an overriding flag and has to read as untouched — which is the path that actually reaches the code, since the declared-default path is guarded on `__given_*` and never sees a filled collection. Both are tested; the second was found by mutation, when clearing turned out to be free.

Every default is checked against the choices, not the first. A collection's second is as unusable as its first if the choices do not allow it.

## The milestone

```
generated benches/shadows/mise/src/lib.rs (211 commands, 711 flags, 128 args)
  nothing dropped: usage expressed the whole spec
```

The clap shadow still drops nine declarations — `default_subcommand`, three `double_dash = "automatic"`, two mounts, two restart tokens, and a flag's second default. That is the same list mise patches into its own spec by hand today.

## Verification

| mutation | result |
|---|---|
| a collection's defaults declared but not seeded | FAILED |
| only the first default seeded | FAILED |
| defaults appended rather than replacing | FAILED (after the override test was added — see below) |
| only the first default checked against the choices | FAILED |

The third mutation initially **survived**: the clear is unreachable on the declared-default path, so only an override on a collecting flag with defaults can see it, and nothing covered that. `a_displaced_collecting_flag_goes_back_to_its_defaults` covers it now, and the mutation fails.

Workspace suite green, clippy clean with no exclusions.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core CLI parsing and default/env/override semantics for all fields using `default`, though behavior is heavily tested; incorrect replacement vs append logic would change real CLIs like `mise watch --fs-events`.
> 
> **Overview**
> **Collecting fields (`Vec`) can declare several `default` values** (repeated `default = "…"` / KDL `default { … }`), matching the usage spec. Non-collection fields still allow at most one default; extra defaults are a compile error.
> 
> **Runtime behavior:** absent argv, the collection starts with all declared defaults in order. Explicit `--flag` values **replace** the whole collection (not merge). Env vars on collecting fields **clear then set** one value, replacing defaults. `Option<Vec<_>>` with defaults is always `Some(…)` when defaults exist. Flags displaced by `overrides` reset to the declared default list via `reset_to_default`.
> 
> **Emitted metadata** (KDL/spec, shadow codegen) carries every default for variadic flags; `xtask` shadow translation no longer skips defaults on collecting flags.
> 
> Conformance tests cover parsing, spec emission, override displacement, env override, and `Option<Vec>` behavior. Benchmark shadows (`mise`) update `--fs-events` to the new multi-default form.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66e0643f3857bf0ebd0ec2c7bc5584fb1833b31c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Collection-based CLI options can now define and apply multiple default values.
  * Optional collection options are populated from declared defaults.
  * Environment-provided values replace collection defaults consistently.
  * Filesystem event options now support clearer multi-value default declarations.

* **Bug Fixes**
  * Defaults are correctly restored after overrides and preserve their declared order.
  * Invalid or excessive defaults now produce clearer validation errors.

* **Documentation**
  * Updated CLI option documentation to explain multiple defaults for collection options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->