### PR TITLE
docs: fix sponsor logo sizing

### DIFF
--- a/docs/.vitepress/theme/EndevSponsors.vue
+++ b/docs/.vitepress/theme/EndevSponsors.vue
@@ -136,8 +136,10 @@ onMounted(async () => {
 
 .EndevSponsorsLogo img {
   display: block;
-  max-height: 22px;
+  height: 22px;
   max-width: 120px;
+  object-fit: contain;
+  width: auto;
 }
 
 .EndevSponsorsCta {


### PR DESCRIPTION
## Summary

- give sponsor logos an explicit height while preserving their aspect ratio
- contain logos within the existing footer tile width

## Why

The new Entire logo SVG declares a `viewBox` but no intrinsic `width` or `height`. The footer previously set only maximum dimensions, so the image can collapse or render as an empty sponsor tile. Explicit sizing matches the working implementation already used by the mise and hk docs.

## Validation

- built the VitePress documentation site successfully

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only CSS in the VitePress theme footer; no runtime, auth, or data changes.
> 
> **Overview**
> **Fixes sponsor logos that lack intrinsic dimensions** (e.g. SVGs with only a `viewBox`) so they no longer collapse to empty tiles in the docs footer.
> 
> Sponsor images in `EndevSponsors.vue` now use a fixed **22px height** with `object-fit: contain` and `width: auto`, replacing `max-height` alone so aspect ratio is preserved within the existing **120px** max width.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c167e09e592bcd02d3376cde133ab10f14f5dd71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated sponsor logos to use consistent 22px-high sizing while preserving their original proportions.
  * Improved logo display so varying logo dimensions fit neatly within the layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->