### PR TITLE
feat(argv): answer `--version`, which an adopter loses on the way from clap

### DIFF
--- a/argv/src/diagnostic.rs
+++ b/argv/src/diagnostic.rs
@@ -378,7 +378,8 @@ fn resolve<'a>(
 /// Render `error` the way a user should read it.
 ///
 /// `argv` is what was being parsed, which is how the message finds the command to show a usage
-/// line for. A [`Error::Help`] renders as nothing: it is not a failure, and a caller that has not
+/// line for. [`Error::Help`] and [`Error::Version`] render as nothing: neither is a failure, and a
+/// caller that has not
 /// handled it before reaching here has a bug this cannot paper over.
 pub fn render(
     spec: &Spec<'_>,
@@ -621,7 +622,9 @@ pub fn render(
         }
         // Not a failure. A caller reaching here with one has skipped handling it, and inventing a
         // message would hide that rather than help.
-        Error::Help { .. } => return String::new(),
+        // Neither is a failure, and a caller that has not handled them before reaching here
+        // has a bug this cannot paper over.
+        Error::Help { .. } | Error::Version => return String::new(),
     }
 
     if with_usage {

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -156,6 +156,13 @@ pub struct Command<'a> {
     /// What an unrecognized flag-like token means here. Already resolved — see
     /// [`UnknownFlags`].
     pub unknown_flags: UnknownFlags,
+    /// Whether this command answers to `--version` and `-V`.
+    ///
+    /// Set on the root, and only when the CLI declares a version: clap adds the flag exactly
+    /// then, and a `--version` that answers with nothing is worse than one that is not there.
+    /// A field rather than a rule about depth, so a CLI that wants it on a subcommand — clap's
+    /// `propagate_version` — has somewhere to say so.
+    pub version: bool,
     /// Caller-assigned identifier, echoed back in [`Event::Command`].
     ///
     /// Wide enough for a derive to make these unique without coordination: two
@@ -177,6 +184,7 @@ impl Command<'_> {
         subcommands: &[],
         default_subcommand: ::core::option::Option::None,
         unknown_flags: UnknownFlags::Value,
+        version: false,
         key: 0,
     };
 }
@@ -428,6 +436,11 @@ pub enum Error<'t, 'v> {
     /// clap has them. The caller renders — this crate does not print, because a library that
     /// writes to stdout on its own is one an adopter cannot embed.
     Help { cmd: &'t Command<'t>, long: bool },
+    /// `--version` was asked for. Not a failure either — the caller prints and leaves.
+    ///
+    /// Carries nothing: the version string lives in the spec rather than the parse tables,
+    /// and the caller that answers this has it.
+    Version,
 }
 
 /// The high half of every key one declaration's items get.
@@ -609,6 +622,30 @@ pub static HELP_LONG: Flag<'static> = Flag {
     ..Flag::BOOL
 };
 
+/// See [`HELP_LONG_KEY`].
+pub const VERSION_LONG_KEY: u64 = u64::MAX - 2;
+/// See [`HELP_LONG_KEY`].
+pub const VERSION_SHORT_KEY: u64 = u64::MAX - 3;
+
+/// `--version`, where the CLI declared one.
+///
+/// In the parse table and not in the metadata, exactly as `--help` is: a spec does not declare
+/// `--version`, so listing one would make the rendered page disagree with the spec it came from.
+pub static VERSION_LONG: Flag<'static> = Flag {
+    key: VERSION_LONG_KEY,
+    name: "version",
+    longs: &["version"],
+    ..Flag::BOOL
+};
+
+/// `-V`, which clap also supplies.
+pub static VERSION_SHORT: Flag<'static> = Flag {
+    key: VERSION_SHORT_KEY,
+    name: "version",
+    shorts: b"V",
+    ..Flag::BOOL
+};
+
 /// `-h`, which prints the shorter form.
 pub static HELP_SHORT: Flag<'static> = Flag {
     key: HELP_SHORT_KEY,
@@ -631,6 +668,11 @@ fn find_named<'t>(cmd: &'t Command<'t>, name: &[u8]) -> Option<&'t Command<'t>> 
 /// Whether a flag is one of the two the parser supplies rather than the CLI declaring it.
 pub fn is_help_flag(flag: &Flag<'_>) -> bool {
     flag.key == HELP_LONG_KEY || flag.key == HELP_SHORT_KEY
+}
+
+/// Whether a flag is one of the two the parser supplies for `--version`.
+pub fn is_version_flag(flag: &Flag<'_>) -> bool {
+    flag.key == VERSION_LONG_KEY || flag.key == VERSION_SHORT_KEY
 }
 
 /// Resolve a subcommand by name or alias, at compile time.
@@ -1043,6 +1085,16 @@ impl<'t, 'v> Parser<'t, 'v> {
             });
         }
 
+        // Where the CLI declared a version, `--version` answers with it — asked after the
+        // command's own flags, so a CLI declaring its own keeps it.
+        if name == b"version" && self.cmd.version {
+            return Ok(Event::Flag {
+                flag: &VERSION_LONG,
+                value: None,
+                negated: false,
+            });
+        }
+
         // Every CLI answers to `--help`, and none of them declares it. Asked *after* the
         // command's own flags, so a CLI that declares its own `--help` keeps it.
         if name == b"help" {
@@ -1295,6 +1347,8 @@ impl<'t, 'v> Parser<'t, 'v> {
             // declared a `-h` of its own.
             .or(if byte == b'h' {
                 Some(&HELP_SHORT)
+            } else if byte == b'V' && self.cmd.version {
+                Some(&VERSION_SHORT)
             } else {
                 None
             })

--- a/conformance/src/argv.rs
+++ b/conformance/src/argv.rs
@@ -314,6 +314,9 @@ fn build(
         // Filled in by the caller for the root, which is the only place a spec declares one.
         default_subcommand: None,
         unknown_flags,
+        // The corpus describes argv parsing; `--version` is a question the *caller* answers,
+        // so no vector turns on it and the harness leaves it off.
+        version: false,
         key: 0,
     }))
 }

--- a/conformance/tests/version.rs
+++ b/conformance/tests/version.rs
@@ -1,0 +1,206 @@
+//! `--version`, which a CLI declaring one should answer to.
+//!
+//! Measured from clap 4 rather than remembered — three rules, and the third is the one that is
+//! easy to get wrong:
+//!
+//! ```text
+//! $ ex --version      ex 1.2.3
+//! $ ex -V             ex 1.2.3
+//! $ ex other --version    error: unexpected argument '--version' found
+//! ```
+//!
+//! The root only. clap propagates it to subcommands only when asked (`propagate_version`), and
+//! a subcommand that declares its own `-V` keeps it.
+//!
+//! Supplied by the parser and *not* listed in help, exactly as `--help` is: a spec does not
+//! declare either, so listing one would make the rendered page disagree with the spec it came
+//! from. That is this crate's existing answer for `--help` and there is no reason for the two
+//! to differ.
+
+use std::ffi::OsStr;
+
+use usage_argv::Error;
+use usage_derive::{Args, Cli, Subcommands};
+
+/// Do a thing
+#[derive(Args)]
+struct Go {
+    /// Its own `-V`, which is not a version request
+    #[usage(long, short = 'V')]
+    verbose: bool,
+}
+
+/// Something else
+#[derive(Args)]
+struct Other {}
+
+#[derive(Subcommands)]
+enum Command {
+    /// Do a thing
+    Go(Box<Go>),
+    /// Something else
+    Other(Box<Other>),
+}
+
+/// A tool that knows its version
+#[derive(Cli)]
+#[usage(bin = "ex", version = "1.2.3")]
+struct Versioned {
+    #[usage(subcommand)]
+    command: Option<Command>,
+}
+
+/// A tool that does not
+#[derive(Cli)]
+#[usage(bin = "plain")]
+struct Unversioned {
+    #[usage(long)]
+    quiet: bool,
+}
+
+/// A tool that wants `-V` for itself
+///
+/// clap refuses this outright — it panics at startup saying `-V` is in use by both, and points
+/// at `disable_version_flag`. Nothing has to break here: the CLI's own declaration wins for the
+/// spelling it declares, and the supplied flag fills in what is left, which is exactly how
+/// `--help` and `-h` already behave.
+#[derive(Cli)]
+#[usage(bin = "own", version = "9.9")]
+struct OwnShort {
+    /// Say more
+    #[usage(long = "verbose", short = 'V')]
+    verbose: bool,
+}
+
+/// A tool for which `--version` means something else
+///
+/// Not far-fetched: plenty of CLIs take a `--version <VERSION>` to select one. The declaration
+/// wins, and `-V` still answers the question nobody else claimed.
+#[derive(Cli)]
+#[usage(bin = "picker", version = "9.9")]
+struct OwnLong {
+    /// Which version to use
+    #[usage(long = "version")]
+    wanted: Option<String>,
+}
+
+fn argv<'a>(words: &'a [&'a str]) -> Vec<&'a OsStr> {
+    words.iter().map(|w| OsStr::new(*w)).collect()
+}
+
+#[test]
+fn a_version_is_answered_in_both_spellings() {
+    for word in ["--version", "-V"] {
+        let words = [word];
+        let a = argv(&words);
+        assert!(
+            matches!(Versioned::parse_from(&a), Err(Error::Version)),
+            "`{word}` should be a version request"
+        );
+    }
+}
+
+#[test]
+fn a_cli_with_no_version_has_no_flag_to_answer_with() {
+    // clap adds the flag exactly when a version is declared, and a `--version` that answers
+    // with nothing is worse than one that is not there. Here it is an ordinary unknown flag —
+    // and gets the ordinary treatment, tip and all.
+    let a = argv(&["--version"]);
+    assert!(matches!(
+        Unversioned::parse_from(&a),
+        Err(Error::UnknownFlag { .. }) | Err(Error::UnexpectedArg { .. })
+    ));
+}
+
+#[test]
+fn a_subcommand_does_not_inherit_it() {
+    // clap's default, and the reason is that a subcommand's version is the program's: asking
+    // `ex other --version` is asking a question the subcommand has no answer to.
+    let a = argv(&["other", "--version"]);
+    assert!(
+        !matches!(Versioned::parse_from(&a), Err(Error::Version)),
+        "a subcommand should not answer the root's question"
+    );
+}
+
+#[test]
+fn a_declared_short_wins_over_the_supplied_one() {
+    // On the *root*, where the supplied flag would otherwise be in scope — a subcommand never
+    // has one, so testing it there would prove nothing. The command's own flags are looked up
+    // first, the same rule that lets a CLI declare its own `-h`.
+    let a = argv(&["-V"]);
+    let parsed = OwnShort::parse_from(&a).expect("its own flag, not a version request");
+    assert!(parsed.verbose);
+
+    // And the spelling it did *not* take still answers, which is what makes this better than
+    // clap's answer of refusing to start: nothing is lost, only what was claimed is claimed.
+    let a = argv(&["--version"]);
+    assert!(matches!(OwnShort::parse_from(&a), Err(Error::Version)));
+}
+
+#[test]
+fn a_declared_long_takes_the_word_and_its_value() {
+    // The long half of the same rule. Nothing supplies a second `--version`, so the value binds.
+    let a = argv(&["--version", "20"]);
+    let parsed = OwnLong::parse_from(&a).expect("its own flag, which takes a value");
+    assert_eq!(parsed.wanted.as_deref(), Some("20"));
+
+    // And `-V`, unclaimed, still answers.
+    let a = argv(&["-V"]);
+    assert!(matches!(OwnLong::parse_from(&a), Err(Error::Version)));
+}
+
+#[test]
+fn a_declared_long_wins_too() {
+    // The other half of the same rule, on `go`'s parent: a CLI that wants `--version` for its
+    // own purposes takes it, and nothing supplies a second one.
+    let a = argv(&["go", "-V"]);
+    let parsed = Versioned::parse_from(&a).expect("the subcommand's own flag");
+    let Some(Command::Go(go)) = parsed.command else {
+        panic!("expected go")
+    };
+    assert!(
+        go.verbose,
+        "a subcommand's `-V` is its own; none is supplied there"
+    );
+}
+
+#[test]
+fn the_flag_is_not_in_the_help_page_or_the_spec() {
+    // Supplied rather than declared, exactly as `--help` is. A page listing a flag the spec
+    // does not declare is a page that disagrees with the spec it was rendered from.
+    let page = usage_argv::help::render(Versioned::spec(), Versioned::spec().root.cmd, true)
+        .expect("a page");
+    assert!(!page.contains("--version"), "{page}");
+
+    // Asserted on the metadata rather than by searching the page for `-V`: `go` declares one of
+    // its own, and it is listed — correctly — in the commands summary. What must be absent is a
+    // *root* flag nobody declared.
+    assert!(
+        !Versioned::spec()
+            .root
+            .flags
+            .iter()
+            .any(|f| f.flag.shorts.contains(&b'V') || f.flag.longs.contains(&"version")),
+        "the root lists a flag it does not declare"
+    );
+
+    let kdl = Versioned::to_kdl();
+    assert!(!kdl.contains("--version"), "{kdl}");
+    // But the version itself is declared, which is what the flag answers with.
+    assert!(kdl.contains(r#"version "1.2.3""#), "{kdl}");
+}
+
+#[test]
+fn the_fields_are_bound() {
+    let a = argv(&["--quiet"]);
+    assert!(Unversioned::parse_from(&a).expect("should parse").quiet);
+    // Destructured rather than matched with `_`, which leaves the payload unread and is a
+    // `dead_code` warning — an error in this workspace.
+    let a = argv(&["other"]);
+    let Some(Command::Other(other)) = Versioned::parse_from(&a).expect("should parse").command
+    else {
+        panic!("expected other")
+    };
+    let Other {} = *other;
+}

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -171,6 +171,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
         .collect();
 
     let min_usage_version = option_str(cli.min_usage_version.as_deref());
+    let has_version = cli.version.is_some();
     quote! {
         #[doc(hidden)]
         #[allow(
@@ -192,6 +193,9 @@ pub fn emit(cli: &Cli) -> TokenStream {
             #table_decls
 
             pub static ROOT: Command = Command {
+                // Only where a version was declared, which is when clap adds the flag: a
+                // `--version` that answers with nothing is worse than one that is not there.
+                version: #has_version,
                 unknown_flags: #unknown_flags,
                 name: #name,
                 key: #root_key,
@@ -285,6 +289,13 @@ pub fn emit(cli: &Cli) -> TokenStream {
                                 cmd: __usage_parser.command(),
                                 long: flag.key == ::usage_argv::HELP_LONG_KEY,
                             });
+                        }
+                        // Same shape, and for the same reason: a question rather than a
+                        // failure, answered by whoever knows the version string.
+                        if ::usage_argv::is_version_flag(flag) {
+                            return ::std::result::Result::Err(
+                                ::usage_argv::Error::Version,
+                            );
                         }
                     }
                     // `apply` handles this command's own fields and routes anything
@@ -380,6 +391,21 @@ pub fn emit(cli: &Cli) -> TokenStream {
                     // the process is the caller: print the page and leave successfully, which
                     // is what a user typing `--help` asked for. `parse_from` returns it
                     // instead, so a library embedding this decides for itself.
+                    // A question, not a failure — the same shape as help, and the one place
+                    // that knows the process is the caller.
+                    ::std::result::Result::Err(::usage_argv::Error::Version) => {
+                        match (Self::spec().bin.unwrap_or(Self::spec().name), Self::spec().version) {
+                            (bin, ::std::option::Option::Some(version)) => {
+                                ::std::println!("{bin} {version}");
+                                ::std::process::exit(0);
+                            }
+                            // Unreachable: the flag is only in the table when a version was
+                            // declared, and the same declaration fills this in.
+                            (_, ::std::option::Option::None) => ::std::result::Result::Err(
+                                "this program declares no version".into(),
+                            ),
+                        }
+                    }
                     ::std::result::Result::Err(::usage_argv::Error::Help { cmd, long }) => {
                         match ::usage_argv::help::render(Self::spec(), cmd, long) {
                             ::std::option::Option::Some(page) => {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -152,6 +152,11 @@
 //! The emitted spec gets a `run=` naming this binary, so everything that reads a spec still has
 //! one, generated from the function rather than declared beside it.
 //!
+//! Declaring a `version` also gives the CLI `--version` and `-V`, as clap does — supplied by
+//! the parser rather than listed in the spec, exactly as `--help` is, and yielding to either
+//! spelling the CLI declares for itself. clap refuses that collision by panicking at startup;
+//! here the declaration simply wins and the other spelling still answers.
+//!
 //! On the struct itself: `bin`, `version`, `about`, `long_about`, `before_help`, `after_help`,
 //! `default_subcommand`, `min_usage_version` — the oldest `usage` that can read the emitted
 //! spec, declared rather than worked out — `effect` — what running this command does to the world, on an `Args`


### PR DESCRIPTION
Found by porting [communique](https://github.com/jdx/communique). Declaring a version put it in the spec and nowhere a user could reach it:

```
$ communique --version
error: unexpected argument '--version' found

  tip: a similar argument exists: '--verbose'
```

where clap printed `communique 1.3.1`. A straight regression rather than a trade, so it is the first of the dogfood findings to fix. (The tip, at least, was doing its job.)

## Three rules, measured from clap 4

| | |
|---|---|
| both spellings answer | `--version` and `-V` |
| the root only | clap propagates to subcommands only when asked |
| no version declared, no flag | a `--version` answering with nothing is worse than not having one |

"Root only" is a **field on the table** rather than a rule about depth, so a CLI wanting clap's `propagate_version` has somewhere to say so later.

## Supplied, not listed

Exactly as `--help` is, and for the reason already written into this crate: a spec declares neither, and a page listing a flag its spec does not declare disagrees with the spec it was rendered from. clap does list both; that is the one place I did not follow it, because following it here would break something this codebase already decided.

## The collision clap refuses to start on

Where a CLI declares one of the spellings itself, the declaration wins and the other still answers — `-V` for `--verbose` leaves `--version` working; a `--version <VERSION>` that takes a value leaves `-V` working. clap panics at startup instead:

```
Command ex: Short option names must be unique for each argument, but '-V' is in use by
both 'verbose' and 'version' (call `cmd.disable_version_flag(true)` to remove ...)
```

Nothing has to break here, and the rule is the one `--help`/`-h` already follow.

## Verification

| mutation | result |
|---|---|
| `--version`/`-V` recognised regardless of the declaration | FAILED |
| the supplied `-V` wins over a declared one | FAILED |
| the supplied `--version` wins over a declared one | FAILED |
| the root never claims a version | FAILED |

The second and third **survived at first**: my precedence test used a subcommand, where the supplied flag is never in scope, so it proved nothing. Fixtures that declare `-V` and `--version` *on the root* replaced it.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*