### PR TITLE
feat(derive): let `parse()` answer a failure the way a program does

### DIFF
--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -665,6 +665,33 @@ fn find_named<'t>(cmd: &'t Command<'t>, name: &[u8]) -> Option<&'t Command<'t>> 
         .find(|c| c.name.as_bytes() == name || c.aliases.iter().any(|a| a.as_bytes() == name))
 }
 
+/// What a caller should print for a parse failure, and what to exit with.
+///
+/// The one entry point a generated `parse()` reaches for, and the reason it exists here rather
+/// than in the derive: whether the good rendering is available is a *feature of this crate* in
+/// the adopter's dependency graph, and a `#[cfg]` written into generated code is evaluated in
+/// the adopter's crate, where the feature is not theirs to see. That is how a metadata field
+/// once got silently dropped; the answer is that the cfg lives beside the thing it gates.
+///
+/// With `diagnostics` on, this is the clap-shaped message. Without it, the error's `Debug`
+/// form — which is still better than nothing and is what a parser-only build asked for.
+///
+/// [`Error::Help`] and [`Error::Version`] are not failures and must be handled before this.
+#[cfg(feature = "diagnostics")]
+pub fn render_failure(spec: &spec::Spec<'_>, argv: &[&OsStr], error: &Error<'_, '_>) -> String {
+    diagnostic::render(spec, argv, error, diagnostic::Style::auto())
+}
+
+/// What a caller should print for a parse failure, without the renderer that makes it readable.
+///
+/// See the other half. A caller that wants the clap-shaped message turns on `diagnostics`;
+/// this is what a parser-only build asked for, and it still says which error it was.
+#[cfg(all(feature = "spec", not(feature = "diagnostics")))]
+pub fn render_failure(spec: &spec::Spec<'_>, argv: &[&OsStr], error: &Error<'_, '_>) -> String {
+    let _ = (spec, argv);
+    ::std::format!("error: {error:?}\n")
+}
+
 /// Whether a flag is one of the two the parser supplies rather than the CLI declaring it.
 pub fn is_help_flag(flag: &Flag<'_>) -> bool {
     flag.key == HELP_LONG_KEY || flag.key == HELP_SHORT_KEY

--- a/conformance/tests/version.rs
+++ b/conformance/tests/version.rs
@@ -204,3 +204,24 @@ fn the_fields_are_bound() {
     };
     let Other {} = *other;
 }
+
+#[test]
+fn a_failure_renders_the_way_a_user_should_read_it() {
+    // What `parse()` prints. It exits the process, so this checks the function it calls —
+    // which is the point of that function existing: whether the good rendering is available is
+    // a feature of usage-argv in the *adopter's* graph, and a `#[cfg]` in generated code is
+    // evaluated in the adopter's crate, where the feature is not theirs to see.
+    let a = argv(&["--nope"]);
+    let Err(err) = Unversioned::parse_from(&a) else {
+        panic!("no such flag")
+    };
+    let message = usage_argv::render_failure(Unversioned::spec(), &a, &err);
+    assert!(
+        message.starts_with("error: unexpected argument '--nope' found"),
+        "{message}"
+    );
+    assert!(
+        message.contains("For more information, try '--help'."),
+        "{message}"
+    );
+}

--- a/conformance/tests/version.rs
+++ b/conformance/tests/version.rs
@@ -84,6 +84,27 @@ struct OwnLong {
     wanted: Option<String>,
 }
 
+/// The text of a rendered message, without whatever the terminal asked for.
+///
+/// A tiny CSI stripper rather than a dependency: every escape this crate emits is `\x1b[`…`m`,
+/// and a test that reads words should not care which of them arrived.
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(i) = rest.find('\u{1b}') {
+        out.push_str(&rest[..i]);
+        match rest[i..].find('m') {
+            Some(end) => rest = &rest[i + end + 1..],
+            None => {
+                rest = "";
+                break;
+            }
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
 fn argv<'a>(words: &'a [&'a str]) -> Vec<&'a OsStr> {
     words.iter().map(|w| OsStr::new(*w)).collect()
 }
@@ -215,7 +236,11 @@ fn a_failure_renders_the_way_a_user_should_read_it() {
     let Err(err) = Unversioned::parse_from(&a) else {
         panic!("no such flag")
     };
-    let message = usage_argv::render_failure(Unversioned::spec(), &a, &err);
+    // Stripped of colour before reading, because `render_failure` styles for the terminal it
+    // finds itself in — under `CLICOLOR_FORCE=1`, or a TTY, the same words arrive wrapped in
+    // escapes and a plain `starts_with` fails on a message that is perfectly correct. What is
+    // asserted here is the wording; the colouring has its own tests.
+    let message = strip_ansi(&usage_argv::render_failure(Unversioned::spec(), &a, &err));
     assert!(
         message.starts_with("error: unexpected argument '--nope' found"),
         "{message}"

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -376,23 +376,19 @@ pub fn emit(cli: &Cli) -> TokenStream {
             /// Parse the process's own arguments.
             #completion
 
-            pub fn parse() -> ::std::result::Result<Self, ::std::string::String> {
+            pub fn parse() -> Self {
                 #completion_intercept
                 let __usage_raw: ::std::vec::Vec<::std::ffi::OsString> =
                     ::std::env::args_os().skip(1).collect();
                 let __usage_argv: ::std::vec::Vec<&::std::ffi::OsStr> =
                     __usage_raw.iter().map(|a| a.as_os_str()).collect();
-                // The error borrows argv, so it cannot outlive this function;
-                // rendering it here is what makes the signature usable. Better
-                // diagnostics are a separate piece of work.
+                // This is the entry point that *is* the process — it already exits for a help
+                // request — so it answers a failure the way a command-line program does:
+                // the message on stderr, and a non-zero status. `parse_from` hands the error
+                // back instead, for a library embedding this that wants to decide.
                 match Self::parse_from(&__usage_argv) {
-                    ::std::result::Result::Ok(parsed) => ::std::result::Result::Ok(parsed),
-                    // A help request is not a failure, and this is the one place that knows
-                    // the process is the caller: print the page and leave successfully, which
-                    // is what a user typing `--help` asked for. `parse_from` returns it
-                    // instead, so a library embedding this decides for itself.
-                    // A question, not a failure — the same shape as help, and the one place
-                    // that knows the process is the caller.
+                    ::std::result::Result::Ok(parsed) => parsed,
+                    // Not failures: someone asked a question, and the answer goes to stdout.
                     ::std::result::Result::Err(::usage_argv::Error::Version) => {
                         match (Self::spec().bin.unwrap_or(Self::spec().name), Self::spec().version) {
                             (bin, ::std::option::Option::Some(version)) => {
@@ -401,9 +397,9 @@ pub fn emit(cli: &Cli) -> TokenStream {
                             }
                             // Unreachable: the flag is only in the table when a version was
                             // declared, and the same declaration fills this in.
-                            (_, ::std::option::Option::None) => ::std::result::Result::Err(
-                                "this program declares no version".into(),
-                            ),
+                            (_, ::std::option::Option::None) => {
+                                ::std::process::exit(0);
+                            }
                         }
                     }
                     ::std::result::Result::Err(::usage_argv::Error::Help { cmd, long }) => {
@@ -413,13 +409,16 @@ pub fn emit(cli: &Cli) -> TokenStream {
                                 ::std::process::exit(0);
                             }
                             // Only reachable if the command came from another CLI's tables.
-                            ::std::option::Option::None => ::std::result::Result::Err(
-                                "help was asked for a command this program does not have".into(),
-                            ),
+                            ::std::option::Option::None => ::std::process::exit(0),
                         }
                     }
                     ::std::result::Result::Err(e) => {
-                        ::std::result::Result::Err(::std::format!("{e:?}"))
+                        ::std::eprint!(
+                            "{}",
+                            ::usage_argv::render_failure(Self::spec(), &__usage_argv, &e)
+                        );
+                        // clap's, so a script that checks for it keeps working.
+                        ::std::process::exit(2);
                     }
                 }
             }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -152,6 +152,11 @@
 //! The emitted spec gets a `run=` naming this binary, so everything that reads a spec still has
 //! one, generated from the function rather than declared beside it.
 //!
+//! `Cli::parse()` is the entry point that *is* the process: it prints a help page or a version
+//! and leaves, and on a failure it prints the message to stderr and exits 2 — clap's status, so a
+//! script checking for it keeps working. `Cli::parse_from(argv)` hands the error back instead,
+//! for a library embedding a CLI that wants to decide for itself.
+//!
 //! Declaring a `version` also gives the CLI `--version` and `-V`, as clap does — supplied by
 //! the parser rather than listed in the spec, exactly as `--help` is, and yielding to either
 //! spelling the CLI declares for itself. clap refuses that collision by panicking at startup;


### PR DESCRIPTION
The second regression from the communique port. `parse()` rendered a failure with `{:?}`:

```
UnknownFlag { token: [45, 45, 110, 111, 112, 101] }
```

while the clap-shaped rendering sat in this crate unused. communique's `main.rs` hand-rolled 34 lines to reach it, which is not something an adopter should have to work out.

`parse()` is the entry point that **is** the process — it already printed a help page and exited. It now prints the message to stderr and exits **2**, clap's status, so a script checking for it keeps working. `parse_from` still hands the error back, for a library embedding a CLI that wants to decide.

## Why the renderer is reached through a function rather than a `#[cfg]`

Not stylistic. Whether the good rendering exists is a feature of **usage-argv in the adopter's graph**, and a `cfg` written into generated code is evaluated in the *adopter's* crate, where the feature is not theirs to see — which is exactly how a metadata field got silently dropped earlier in this project. So the cfg lives beside the thing it gates: `render_failure` is the clap-shaped message with `diagnostics` on, and the Debug form without it, which is what a parser-only build asked for.

## What it buys the adopter

With this and #909, communique's port matches clap on `--version`, `-V`, every error message tested, and every exit code:

```
########## --version
  clap : communique 1.3.1 [exit 0]
  usage: communique 1.3.1 [exit 0]
########## badcmd
  clap : error: unrecognized subcommand 'badcmd' [exit 2]
  usage: error: unrecognized subcommand 'badcmd' [exit 2]
########## --fore
  clap : error: unexpected argument '--fore' found [exit 2]
  usage: error: unexpected argument '--fore' found [exit 2]
```

and `main.rs` is 34 lines shorter than the port needed before it.

**Breaking:** `parse()` returns `Self` rather than `Result<Self, String>`. Nothing is released yet.

## Verification

Mutation: making `render_failure` fall back to the Debug form with `diagnostics` on fails the new test. Both feature configurations — `spec` alone and `spec,diagnostics` — build clean.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking change to generated `parse()`’s return type and all failure/help/version exit paths; every derive adopter’s `main` must migrate from `Result` handling to the new process semantics.
> 
> **Overview**
> **`Cli::parse()` is now a process-style entry point:** it returns `Self` (breaking change from `Result<Self, String>`), prints help/version to stdout and exits 0, and on real parse failures prints a user-facing message to stderr and exits **2** (clap’s code). **`parse_from` still returns errors** for embedders that want control.
> 
> Adds **`usage_argv::render_failure`** in the argv crate with `#[cfg]` beside the gated renderer: with **`diagnostics`**, output matches clap-shaped diagnostics; without it, a minimal `Debug`-style line—so generated code does not need feature cfgs in the adopter crate.
> 
> Conformance adds **`strip_ansi`** and a test that **`render_failure`** wording matches clap for an unknown flag (e.g. `--nope`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a3201ee1abf5f28fb63e9d976ac4b3da9f0604a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->