### PR TITLE
feat(help): line the flag column up, and give the short page a column at all

### DIFF
--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -252,28 +252,55 @@ pub fn short_help(spec: &Spec<'_>, path: &[&str], meta: &CommandMeta<'_>) -> Str
     // `tool-alias get <TOOL>` under `mise tool-alias`, the whole path from the root rather
     // than the child's own name.
     commands_section(&mut out, &path[1.min(path.len())..], meta);
+
+    // The short page lines its columns up too. It did not: every description began directly
+    // after the name it belonged to, so nothing in `-h` lined up with anything — and `-h` is
+    // the form most people type. One column per section over its visible entries, which is
+    // the rule the long page already follows.
+    let args: Vec<&ArgMeta<'_>> = meta.args.iter().filter(|a| !a.hide).collect();
+    let arg_col = args
+        .iter()
+        .map(|a| arg_usage(a).chars().count())
+        .max()
+        .unwrap_or(0);
     groups_section(
         &mut out,
         "Arguments",
-        meta.args.iter().filter(|a| !a.hide),
+        args.iter().copied(),
         |a| a.help_heading,
         |out, a| {
-            let _ = write!(out, "  {}", arg_usage(a));
-            if let Some(help) = a.help {
-                let _ = write!(out, "  {help}");
+            let usage = arg_usage(a);
+            match a.help.filter(|h| !h.trim().is_empty()) {
+                Some(help) => {
+                    let _ = write!(out, "  {usage:<arg_col$}  {help}");
+                }
+                None => {
+                    let _ = write!(out, "  {usage}");
+                }
             }
             annotations(out, a.choices, a.env, a.default);
         },
     );
+    let flags: Vec<&FlagMeta<'_>> = meta.flags.iter().filter(|f| !f.hide).collect();
+    let flag_col = flags
+        .iter()
+        .map(|f| column_usage(f).chars().count())
+        .max()
+        .unwrap_or(0);
     groups_section(
         &mut out,
         "Flags",
-        meta.flags.iter().filter(|f| !f.hide),
+        flags.iter().copied(),
         |f| f.help_heading,
         |out, f| {
-            let _ = write!(out, "  {}", display_usage(f));
-            if let Some(help) = f.help {
-                let _ = write!(out, "  {help}");
+            let usage = column_usage(f);
+            match f.help.filter(|h| !h.trim().is_empty()) {
+                Some(help) => {
+                    let _ = write!(out, "  {usage:<flag_col$}  {help}");
+                }
+                None => {
+                    let _ = write!(out, "  {usage}");
+                }
             }
             annotations(out, f.choices, f.env, &[]);
         },
@@ -410,6 +437,45 @@ fn display_usage(meta: &FlagMeta<'_>) -> String {
     }
 }
 
+/// The width of the short column: `-x, `, or the blank that stands in for it.
+///
+/// Fixed, because a short form is one character. clap's, measured.
+const SHORT_COL: usize = 4;
+
+/// A flag as the *flags section* lists it, with its long form in a column of its own.
+///
+/// Separate from [`flag_usage`], which feeds the usage line — `Usage: ex [-f --force]` must
+/// not be padded, and this must be. clap's shape, measured from clap 4:
+///
+/// ```text
+///       --github-release
+///   -n, --dry-run
+///   -o, --output <OUTPUT>
+///   -j <JOBS>
+/// ```
+///
+/// Two rules in there worth stating. The short column is only spent where there is a long form
+/// to line up *with*: a flag with no long one writes `-j <JOBS>` and does not pad, which is
+/// what clap does. And a flag with neither — usage can name one the forms do not imply,
+/// `verbose: -v`, which clap has no equivalent for — takes the same path as short-only.
+fn column_usage(meta: &FlagMeta<'_>) -> String {
+    let rest = display_usage(meta);
+    let Some(long) = meta.flag.longs.first() else {
+        return rest;
+    };
+    // Only when the text actually begins with the long form. The `name:` prefix case does not,
+    // and splitting it would put `verbose:` in a column meant for `-v, `.
+    let Some(at) = rest.find(&format!("--{long}")) else {
+        return rest;
+    };
+    let (before, after) = rest.split_at(at);
+    let short = match before.trim() {
+        "" => String::new(),
+        s => format!("{s},"),
+    };
+    format!("{short:<SHORT_COL$}{after}")
+}
+
 fn examples_section(out: &mut String, spec: &Spec<'_>, meta: &CommandMeta<'_>) {
     let examples = page_examples(spec, meta);
     if examples.is_empty() {
@@ -520,7 +586,7 @@ pub fn long_help(spec: &Spec<'_>, path: &[&str], meta: &CommandMeta<'_>) -> Stri
     let flags: Vec<&FlagMeta<'_>> = meta.flags.iter().filter(|f| !f.hide).collect();
     let flag_col = flags
         .iter()
-        .map(|f| display_usage(f).chars().count())
+        .map(|f| column_usage(f).chars().count())
         .max()
         .unwrap_or(0);
     groups_section(
@@ -530,7 +596,7 @@ pub fn long_help(spec: &Spec<'_>, path: &[&str], meta: &CommandMeta<'_>) -> Stri
         |f| f.help_heading,
         |out, f| {
             let text = f.long_help.or(f.help);
-            entry(out, &display_usage(f), text, flag_col, width);
+            entry(out, &column_usage(f), text, flag_col, width);
             long_annotations(out, f.choices, f.env, &[]);
         },
     );

--- a/conformance/tests/flag_column.rs
+++ b/conformance/tests/flag_column.rs
@@ -1,0 +1,133 @@
+//! Where a flag's name sits in the flags section.
+//!
+//! Measured from clap 4 rather than remembered. This is the whole rule, in five lines:
+//!
+//! ```text
+//! Options:
+//!   -j <JOBS>
+//!       --github-release
+//!   -n, --dry-run
+//!   -o, --output <OUTPUT>
+//!   -h, --help             Print help
+//! ```
+//!
+//! A four-character column holds `-x, ` or the blank standing in for it — but *only* where
+//! there is a long form to line up with. `-j <JOBS>` has none, so it does not pad; that is
+//! clap's behaviour and not an oversight in it.
+
+use usage_argv::help;
+use usage_derive::Cli;
+
+/// A tool with one of each shape
+#[derive(Cli)]
+#[usage(bin = "ex")]
+struct Ex {
+    /// Short only, so nothing to align with
+    #[usage(short = 'j')]
+    jobs: Option<String>,
+    /// Long only
+    #[usage(long)]
+    github_release: bool,
+    /// Both
+    #[usage(long, short = 'n')]
+    dry_run: bool,
+    /// Both, and takes a value
+    #[usage(long, short)]
+    output: Option<String>,
+    /// Its description is long enough to need wrapping at any sane width
+    #[usage(long)]
+    describe: bool,
+}
+
+fn page(long: bool) -> String {
+    help::render(Ex::spec(), Ex::spec().root.cmd, long).expect("a page")
+}
+
+#[test]
+fn a_long_form_starts_in_the_same_column_whatever_precedes_it() {
+    for long in [false, true] {
+        let page = page(long);
+        for line in [
+            "      --github-release",
+            "  -n, --dry-run",
+            "  -o, --output <OUTPUT>",
+        ] {
+            assert!(
+                page.lines().any(|l| l.starts_with(line)),
+                "long={long}: no line starts `{line}`:\n{page}"
+            );
+        }
+        // A comma, which is the near-universal convention and what clap prints.
+        assert!(!page.contains("-n --dry-run"), "long={long}: {page}");
+    }
+}
+
+#[test]
+fn a_flag_with_no_long_form_does_not_pay_for_the_column() {
+    // clap writes `-j <JOBS>` at the indent, not padded out to where the long forms begin:
+    // there is nothing to line it up with, and the padding would only push it away from its
+    // own description.
+    for long in [false, true] {
+        let page = page(long);
+        assert!(
+            page.lines().any(|l| l.starts_with("  -j <JOBS>")),
+            "long={long}: {page}"
+        );
+    }
+}
+
+#[test]
+fn the_short_page_lines_its_descriptions_up_too() {
+    // It did not. Every description began directly after the name it belonged to, so nothing
+    // in `-h` lined up with anything — and `-h` is the form most people type. One column per
+    // section, which is the rule the long page already followed.
+    let page = page(false);
+    // Where each description begins, for three flags whose names are three different lengths.
+    // If the column is real they are equal; before this they were 2 + the length of the name.
+    let column_of = |needle: &str, help: &str| -> usize {
+        let line = page
+            .lines()
+            .find(|l| l.contains(needle))
+            .unwrap_or_else(|| panic!("no line for {needle}:\n{page}"));
+        line.find(help)
+            .unwrap_or_else(|| panic!("no help on {line:?}"))
+    };
+    let a = column_of("--github-release", "Long only");
+    let b = column_of("--dry-run", "Both");
+    let c = column_of("--describe", "Its description");
+    assert!(
+        a == b && b == c,
+        "descriptions should start in one column, got {a}, {b}, {c}:\n{page}"
+    );
+}
+
+#[test]
+fn the_usage_line_is_not_padded() {
+    // `column_usage` is separate from the usage line's own rendering for this reason: a
+    // `Usage: ex [    --describe]` would be absurd.
+    let page = page(true);
+    let usage = page
+        .lines()
+        .find(|l| l.starts_with("Usage:"))
+        .expect("a usage line");
+    assert!(!usage.contains("  --"), "padded usage line: {usage}");
+}
+
+#[test]
+fn the_fields_are_bound() {
+    use std::ffi::OsStr;
+    let argv = [
+        "-j",
+        "4",
+        "--github-release",
+        "-n",
+        "--output",
+        "o",
+        "--describe",
+    ]
+    .map(OsStr::new);
+    let ex = Ex::parse_from(&argv).expect("should parse");
+    assert_eq!(ex.jobs.as_deref(), Some("4"));
+    assert!(ex.github_release && ex.dry_run && ex.describe);
+    assert_eq!(ex.output.as_deref(), Some("o"));
+}

--- a/lib/src/docs/cli/mod.rs
+++ b/lib/src/docs/cli/mod.rs
@@ -102,7 +102,7 @@ cmd sneaky hide=#true help="a hidden command"
         // `SpecCommand::usage` — so before this, `ex --help` listed a `--secret` the line
         // above it did not mention. A heading whose every entry is hidden produces no
         // section, which is the rule markdown rendering already followed.
-        assert_snapshot!(render_help(&spec, &spec.cmd, false), @r"
+        assert_snapshot!(render_help(&spec, &spec.cmd, false), @"
         Usage: ex [--visible] [SHOWN] <SUBCOMMAND>
 
         Commands:
@@ -113,7 +113,7 @@ cmd sneaky hide=#true help="a hidden command"
           [SHOWN]  an arg
 
         Flags:
-          --visible  shown
+              --visible  shown
         ");
     }
 
@@ -132,7 +132,7 @@ arg "<mode>" help="How to run" help_heading="Behaviour"
 
         // Unheaded entries keep the default title and come first; each heading
         // then gets its own section, in the order the headings first appear.
-        assert_snapshot!(render_help(&spec, &spec.cmd, false), @r"
+        assert_snapshot!(render_help(&spec, &spec.cmd, false), @"
         Usage: testcli [FLAGS] <file> <mode>
 
         Arguments:
@@ -142,14 +142,14 @@ arg "<mode>" help="How to run" help_heading="Behaviour"
           <mode>  How to run
 
         Flags:
-          --verbose  Verbose output
+              --verbose            Verbose output
 
         Filtering:
-          --filter <pattern>  Only matching
-          --exclude <pattern>  Skip matching
+              --filter <pattern>   Only matching
+              --exclude <pattern>  Skip matching
 
         Performance:
-          --jobs <n>  How many at once
+              --jobs <n>           How many at once
         ");
     }
 
@@ -163,11 +163,11 @@ flag "--filter <pattern>" help="Only matching" help_heading="Filtering"
         "# }
         .unwrap();
 
-        assert_snapshot!(render_help(&spec, &spec.cmd, false), @r"
+        assert_snapshot!(render_help(&spec, &spec.cmd, false), @"
         Usage: testcli [--filter <pattern>]
 
         Filtering:
-          --filter <pattern>  Only matching
+              --filter <pattern>  Only matching
         ");
     }
 
@@ -181,24 +181,24 @@ flag "--debug" help="Debug mode"
         "# }
         .unwrap();
 
-        assert_snapshot!(render_help(&spec, &spec.cmd, false), @r"
+        assert_snapshot!(render_help(&spec, &spec.cmd, false), @"
         Usage: testcli [FLAGS]
 
         Flags:
-          --color  Enable color output [env: MYCLI_COLOR]
-          --verbose  Verbose output [env: MYCLI_VERBOSE]
-          --debug  Debug mode
+              --color    Enable color output [env: MYCLI_COLOR]
+              --verbose  Verbose output [env: MYCLI_VERBOSE]
+              --debug    Debug mode
         ");
 
-        assert_snapshot!(render_help(&spec, &spec.cmd, true), @r"
+        assert_snapshot!(render_help(&spec, &spec.cmd, true), @"
         Usage: testcli [FLAGS]
 
         Flags:
-          --color    Enable color output
+              --color    Enable color output
             [env: MYCLI_COLOR]
-          --verbose  Verbose output
+              --verbose  Verbose output
             [env: MYCLI_VERBOSE]
-          --debug    Debug mode
+              --debug    Debug mode
         ");
     }
 
@@ -213,13 +213,13 @@ arg "[default]" help="Arg with default value" default="default value"
         "# }
         .unwrap();
 
-        assert_snapshot!(render_help(&spec, &spec.cmd, false), @r"
+        assert_snapshot!(render_help(&spec, &spec.cmd, false), @"
         Usage: testcli <ARGS>…
 
         Arguments:
-          <input>  Input file [env: MY_INPUT]
-          <output>  Output file [env: MY_OUTPUT]
-          <extra>  Extra arg without env
+          <input>    Input file [env: MY_INPUT]
+          <output>   Output file [env: MY_OUTPUT]
+          <extra>    Extra arg without env
           [default]  Arg with default value (default: default value)
         ");
 
@@ -246,20 +246,20 @@ flag "--verbose" help="Verbose output"
         "# }
         .unwrap();
 
-        assert_snapshot!(render_help(&spec, &spec.cmd, false), @r"
+        assert_snapshot!(render_help(&spec, &spec.cmd, false), @"
         Usage: testcli [--compress] [--verbose]
 
         Flags:
-          --compress / --no-compress  Compress output
-          --verbose  Verbose output
+              --compress / --no-compress  Compress output
+              --verbose                   Verbose output
         ");
 
-        assert_snapshot!(render_help(&spec, &spec.cmd, true), @r"
+        assert_snapshot!(render_help(&spec, &spec.cmd, true), @"
         Usage: testcli [--compress] [--verbose]
 
         Flags:
-          --compress / --no-compress  Compress output
-          --verbose                   Verbose output
+              --compress / --no-compress  Compress output
+              --verbose                   Verbose output
         ");
     }
 
@@ -273,13 +273,13 @@ flag "--verbose" help="Enable verbose output"
         "# }
         .unwrap();
 
-        assert_snapshot!(render_help(&spec, &spec.cmd, false), @r"
+        assert_snapshot!(render_help(&spec, &spec.cmd, false), @"
         This text appears before the help
 
         Usage: testcli [--verbose]
 
         Flags:
-          --verbose  Enable verbose output
+              --verbose  Enable verbose output
 
         This text appears after the help
         ");
@@ -297,24 +297,24 @@ flag "--verbose" help="Enable verbose output"
         "# }
         .unwrap();
 
-        assert_snapshot!(render_help(&spec, &spec.cmd, false), @r"
+        assert_snapshot!(render_help(&spec, &spec.cmd, false), @"
         short before
 
         Usage: testcli [--verbose]
 
         Flags:
-          --verbose  Enable verbose output
+              --verbose  Enable verbose output
 
         short after
         ");
 
-        assert_snapshot!(render_help(&spec, &spec.cmd, true), @r"
+        assert_snapshot!(render_help(&spec, &spec.cmd, true), @"
         This is the long version of before help
 
         Usage: testcli [--verbose]
 
         Flags:
-          --verbose  Enable verbose output
+              --verbose  Enable verbose output
 
         This is the long version of after help
         ");
@@ -330,11 +330,11 @@ example "testcli" header="Run normally" help="Just runs the tool"
         "# }
         .unwrap();
 
-        assert_snapshot!(render_help(&spec, &spec.cmd, false), @r"
+        assert_snapshot!(render_help(&spec, &spec.cmd, false), @"
         Usage: testcli [--verbose]
 
         Flags:
-          --verbose  Enable verbose output
+              --verbose  Enable verbose output
 
         Examples:
           Run with verbose output:
@@ -343,11 +343,11 @@ example "testcli" header="Run normally" help="Just runs the tool"
             $ testcli
         ");
 
-        assert_snapshot!(render_help(&spec, &spec.cmd, true), @r"
+        assert_snapshot!(render_help(&spec, &spec.cmd, true), @"
         Usage: testcli [--verbose]
 
         Flags:
-          --verbose  Enable verbose output
+              --verbose  Enable verbose output
 
         Examples:
           Run with verbose output:
@@ -368,12 +368,12 @@ flag "--verbose" help="Enable verbose output"
         "# }
         .unwrap();
 
-        assert_snapshot!(render_help(&spec, &spec.cmd, false), @r"
+        assert_snapshot!(render_help(&spec, &spec.cmd, false), @"
         TestCLI 1.2.3
         Usage: testcli [--verbose]
 
         Flags:
-          --verbose  Enable verbose output
+              --verbose  Enable verbose output
         ");
     }
 
@@ -388,19 +388,19 @@ flag "--verbose" help="Enable verbose output"
         .unwrap();
 
         // Short help should not show author/license
-        assert_snapshot!(render_help(&spec, &spec.cmd, false), @r"
+        assert_snapshot!(render_help(&spec, &spec.cmd, false), @"
         Usage: testcli [--verbose]
 
         Flags:
-          --verbose  Enable verbose output
+              --verbose  Enable verbose output
         ");
 
         // Long help should show author/license at the bottom
-        assert_snapshot!(render_help(&spec, &spec.cmd, true), @r"
+        assert_snapshot!(render_help(&spec, &spec.cmd, true), @"
         Usage: testcli [--verbose]
 
         Flags:
-          --verbose  Enable verbose output
+              --verbose  Enable verbose output
 
         Author: Test Author
         License: MIT

--- a/lib/src/docs/cli/templates/spec_template_long.tera
+++ b/lib/src/docs/cli/templates/spec_template_long.tera
@@ -82,7 +82,7 @@ Commands:
 
 {%- endif %}
 {%- else %}
-  {{ flag.display_usage | trim }}
+  {{ flag.display_usage }}
 {%- if flag.aliases %}  [aliases: {{ flag.aliases | join(sep=", ") }}]{% endif %}
 {%- set help = flag.help_long | default(value=flag.help | default(value='')) %}
 {%- if help %}

--- a/lib/src/docs/cli/templates/spec_template_short.tera
+++ b/lib/src/docs/cli/templates/spec_template_short.tera
@@ -33,8 +33,7 @@ Commands:
 
 {{ group.heading | default(value="Arguments") }}:
 {%- for arg in group.items %}
-  {{ arg.usage | trim }}
-{%- if arg.help %}  {{ arg.help }}{%- endif %}
+  {% if arg.help %}{{ arg.usage | trim | ljust(width=arg.usage_col_width) }}  {{ arg.help }}{% else %}{{ arg.usage | trim }}{% endif %}
 {%- if arg.choices and arg.choices.choices %} [{{ arg.choices.choices | join(sep=", ") }}]{%- endif %}
 {%- if arg.choices and arg.choices.env %} [choices env: {{ arg.choices.env }}]{%- endif %}
 {%- if arg.env %} [env: {{ arg.env }}]{%- endif %}
@@ -46,9 +45,7 @@ Commands:
 
 {{ group.heading | default(value="Flags") }}:
 {%- for flag in group.items %}
-  {{ flag.display_usage | trim }}
-{%- if flag.aliases %}  [aliases: {{ flag.aliases | join(sep=", ") }}]{% endif %}
-{%- if flag.help %}  {{ flag.help }}{%- endif %}
+  {% if flag.help %}{{ flag.display_usage | ljust(width=flag.usage_col_width) }}{% if flag.aliases %}  [aliases: {{ flag.aliases | join(sep=", ") }}]{% endif %}  {{ flag.help }}{% else %}{{ flag.display_usage }}{% if flag.aliases %}  [aliases: {{ flag.aliases | join(sep=", ") }}]{% endif %}{% endif %}
 {%- if flag.arg.choices and flag.arg.choices.choices %} [{{ flag.arg.choices.choices | join(sep=", ") }}]{%- endif %}
 {%- if flag.arg.choices and flag.arg.choices.env %} [choices env: {{ flag.arg.choices.env }}]{%- endif %}
 {%- if flag.env %} [env: {{ flag.env }}]{%- endif %}

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -521,16 +521,59 @@ impl From<&crate::SpecCommand> for SpecCommand {
     }
 }
 
+/// The width of the short column: `-x, `, or the blank that stands in for it.
+///
+/// Fixed, because a short form is one character. clap's, measured.
+const SHORT_COL: usize = 4;
+
+/// A flag as the *flags section* lists it, with its long form in a column of its own.
+///
+/// Separate from `SpecFlag::usage`, which feeds the usage line and the markdown and manpage
+/// renderers — `Usage: ex [-f --force]` must not be padded, and this must be. clap's shape,
+/// measured from clap 4:
+///
+/// ```text
+///       --github-release
+///   -n, --dry-run
+///   -o, --output <OUTPUT>
+///   -j <JOBS>
+/// ```
+///
+/// The short column is only spent where there is a long form to line up *with*: a flag with no
+/// long one writes `-j <JOBS>` and does not pad, which is what clap does. A flag whose declared
+/// name the forms do not imply — `verbose: -v`, which clap has no equivalent for — takes the
+/// same path.
+///
+/// The twin of `column_usage` in `usage-argv`'s `help` module; the two must agree, and the gate
+/// over mise's spec is what says they do.
+fn column_usage(flag: &crate::SpecFlag) -> String {
+    let rest = flag.negate.as_ref().map_or_else(
+        || flag.usage.trim().to_string(),
+        |negate| format!("{} / {}", flag.usage.trim(), negate.trim()),
+    );
+    let Some(long) = flag.long.first() else {
+        return rest;
+    };
+    // The dashes matter: `long` is stored bare, and searching for `cd` finds the `cd` inside
+    // `--cd` — which split `-C --cd` into `-C --` and `cd`, and rendered `-C --,cd`.
+    let Some(at) = rest.find(&format!("--{long}")) else {
+        return rest;
+    };
+    let (before, after) = rest.split_at(at);
+    let short = match before.trim() {
+        "" => String::new(),
+        s => format!("{s},"),
+    };
+    format!("{short:<SHORT_COL$}{after}")
+}
+
 impl From<&crate::SpecFlag> for SpecFlag {
     fn from(flag: &crate::SpecFlag) -> Self {
         Self {
             name: flag.name.clone(),
             effect: flag.effect,
             usage: flag.usage.clone(),
-            display_usage: flag.negate.as_ref().map_or_else(
-                || flag.usage.trim().to_string(),
-                |negate| format!("{} / {}", flag.usage.trim(), negate.trim()),
-            ),
+            display_usage: column_usage(flag),
             help: flag.help.clone(),
             help_long: flag.help_long.clone(),
             help_md: flag.help_md.clone(),

--- a/lib/tests/parse.rs
+++ b/lib/tests/parse.rs
@@ -139,7 +139,7 @@ flag_choices_help_short:
     expected=r#"Usage: [--shell <shell>]
 
 Flags:
-  --shell <shell>  shorthelp [bash, fish, zsh]
+      --shell <shell>  shorthelp [bash, fish, zsh]
 "#,
 
 flag_choices_help_long:
@@ -150,7 +150,7 @@ flag_choices_help_long:
     expected=r#"Usage: [--shell <shell>]
 
 Flags:
-  --shell <shell>
+      --shell <shell>
     help
     fooo
     bar


### PR DESCRIPTION
PR 1 of the help plan. Two findings from putting communique's help next to clap's.

## The long forms did not line up

Everything started at column 2:

```
Flags:
  --github-release           Push editorialized notes to the GitHub release
  -n --dry-run               Generate notes without updating GitHub
  --repo <REPO>              GitHub repo in owner/repo format
```

clap spends a four-character column on `-n, ` — or the blank standing in for it:

```
Flags:
      --github-release           Push editorialized notes to the GitHub release
  -n, --dry-run                  Generate notes without updating GitHub
      --repo <REPO>              GitHub repo in owner/repo format
```

Measured from clap 4, including the two rules that are easy to get wrong:

- **The column is only spent where there is a long form to line up with.** `-j <JOBS>` writes at the indent and does not pad — that is clap's behaviour, not an oversight in it.
- A flag whose declared name the forms do not imply — `verbose: -v`, which clap has no equivalent for — takes that same path.

## The short page had no column at all

This is the one I did not plan for and think matters more. `-h` was:

```
Flags:
  --github-release  Push editorialized notes to the GitHub release
  --changelog  Update CHANGELOG.md with the generated changelog entry
  -n --dry-run  Generate notes without updating GitHub or verifying links
```

Every description began directly after the name it belonged to, so **nothing in `-h` lined up with anything** — and `-h` is the form most people type. It now computes one column per section over its visible entries, the rule the long page already followed.

## Result

`communique generate -h` is now byte-for-byte clap's output except the word `Flags:`, which is the difference we chose to keep:

```
Arguments:
  <TAG>       Git tag to generate release notes for
  [PREV_TAG]  Previous tag (auto-detected if omitted)

Flags:
      --github-release           Push editorialized notes to the GitHub release
  -n, --dry-run                  Generate notes without updating GitHub or verifying links
      --max-tokens <MAX_TOKENS>  Max response tokens
```

## Notes

Built as `column_usage`, separate from `flag_usage` which feeds the usage line — `Usage: ex [    --describe]` would be absurd, and a test says so. In usage-lib the same split lives beside `display_usage`, which only the two CLI help templates read; `SpecFlag::usage()` is untouched, so markdown and manpage are unaffected.

Landed in **both** renderers, so the gate still holds them byte-identical over mise's 211 commands.

## Verification

| mutation | result |
|---|---|
| no short column | FAILED |
| a short-only flag pays for the column | FAILED |
| no comma | FAILED |
| the short page stops padding | FAILED |

Snapshots accepted where the change is the intended one (descriptions moving into a column); two `lib/tests/parse.rs` expectations updated for the same reason. Workspace suite green, clippy clean.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only help formatting in two renderers; parsing and spec `usage()` for markdown/man are unchanged aside from aligned CLI help text.
> 
> **Overview**
> **Help output** is updated so flag sections match **clap 4** layout: a fixed four-character short column (`-n, ` or blank), long `--` options starting in one column, and **short-only** flags like `-j <JOBS>` left unpadded. That logic lives in new **`column_usage`**, separate from usage-line **`flag_usage`** so `Usage:` stays compact.
> 
> **Short help (`-h`)** now pads **Arguments** and **Flags** into per-section columns (max visible entry width + two spaces before help), matching what long help already did. Empty help text skips padding.
> 
> **usage-lib** applies the same **`column_usage`** for `SpecFlag::display_usage`, uses it for column-width math, and updates short/long Tera templates (`ljust` on args/flags). Snapshots and parse help expectations reflect the new spacing.
> 
> **Conformance** adds `flag_column.rs` tests (alignment, comma, short-only, short-page columns, unpadded usage line).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a8febfbb7fdc2f3ad5c808c033efbf4d1191abe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->