### PR TITLE
fix(ci): check the version the crates promise, and promise one that is true

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,15 +93,39 @@ jobs:
           persist-credentials: false
       - name: the matrix and the manifests agree
         run: |
-          # Or the job checks a version nobody promised. A crate that raises its floor without
-          # touching this file would otherwise be tested at the old one and pass.
+          # Both directions, because one of them alone is how a false floor survives.
+          #
+          # Every crate this row checks declares this row's version. Or the job checks a version
+          # nobody promised: a crate that raises its floor without touching this file would
+          # otherwise be tested at the old one and pass.
           for crate in ${{ matrix.crates }}; do
-            dir="$(grep -rl "^name = \"$crate\"" ./*/Cargo.toml | head -1)"
-            declared="$(grep '^rust-version' "$dir" | sed 's/.*"\(.*\)".*/\1/')"
+            manifest="$(git ls-files '*Cargo.toml' | xargs grep -l "^name = \"$crate\"$" | head -1)"
+            declared="$(sed -n 's/^rust-version *= *"\(.*\)".*/\1/p' "$manifest" | head -1)"
             if [ "$declared" != "${{ matrix.version }}" ]; then
               echo "::error::$crate declares $declared, checked here at ${{ matrix.version }}"
               exit 1
             fi
+          done
+          # And every published crate declaring this row's version is in this row. Without this
+          # half, a new crate — or one that was simply never listed — makes a floor promise that
+          # no toolchain ever tries. `usage-conformance` and `xtask` promised 1.91 for as long as
+          # this job existed while depending on a crate that needs 1.95; nothing noticed, because
+          # nothing looked from the manifests back to the matrix.
+          #
+          # Published only: a floor is a promise to whoever depends on the crate, so a
+          # `publish = false` member has nobody to make one to and should not declare one.
+          for manifest in $(git ls-files '*Cargo.toml'); do
+            declared="$(sed -n 's/^rust-version *= *"\(.*\)".*/\1/p' "$manifest" | head -1)"
+            [ "$declared" = "${{ matrix.version }}" ] || continue
+            grep -q '^publish *= *false' "$manifest" && continue
+            name="$(sed -n 's/^name *= *"\(.*\)".*/\1/p' "$manifest" | head -1)"
+            case " ${{ matrix.crates }} " in
+              *" $name "*) ;;
+              *)
+                echo "::error::$name declares $declared and is published, but no row checks it"
+                exit 1
+                ;;
+            esac
           done
       # `rustup` rather than an action: it is already on the runner, and this needs one
       # toolchain and no other behaviour — a pinned third-party action would be one more

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,3 +61,56 @@ jobs:
             exit 1
           fi
       - run: mise r lint
+
+  # The declared `rust-version` is a promise to anyone depending on these crates, and nothing
+  # was checking it. It said 1.80 — set in 2024 when `LazyLock` landed and never revisited —
+  # and usage-argv had not built at 1.80 for a long time. A promise nobody checks is a guess.
+  #
+  # Two floors, because the crates genuinely differ: usage-argv, usage-derive and usage-config
+  # take no dependency on KDL and hold mise's own 1.91, which is the floor that matters for the
+  # fleet. usage-lib and everything that reads a spec through it need 1.95, because `kdl` says
+  # so. Each crate is checked at the version *it* declares rather than at one shared guess,
+  # which is how a lower floor stays real instead of aspirational.
+  #
+  # `cargo check` rather than `cargo test`: dev-dependencies are not part of what an adopter
+  # compiles, and holding them to the MSRV would pin the toolchain past what the library needs.
+  msrv:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - version: "1.91"
+            crates: usage-argv usage-derive usage-config
+          - version: "1.95"
+            crates: usage-lib usage-config-build clap_usage usage-cli
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+          persist-credentials: false
+      - name: the matrix and the manifests agree
+        run: |
+          # Or the job checks a version nobody promised. A crate that raises its floor without
+          # touching this file would otherwise be tested at the old one and pass.
+          for crate in ${{ matrix.crates }}; do
+            dir="$(grep -rl "^name = \"$crate\"" ./*/Cargo.toml | head -1)"
+            declared="$(grep '^rust-version' "$dir" | sed 's/.*"\(.*\)".*/\1/')"
+            if [ "$declared" != "${{ matrix.version }}" ]; then
+              echo "::error::$crate declares $declared, checked here at ${{ matrix.version }}"
+              exit 1
+            fi
+          done
+      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb00c93b4c1006f9da8436 # stable
+        with:
+          toolchain: ${{ matrix.version }}
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          shared-key: msrv-${{ matrix.version }}
+      - name: they build at the version they claim
+        run: |
+          for crate in ${{ matrix.crates }}; do
+            cargo check --locked -p "$crate" --all-features
+          done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,14 +103,16 @@ jobs:
               exit 1
             fi
           done
-      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb00c93b4c1006f9da8436 # stable
-        with:
-          toolchain: ${{ matrix.version }}
+      # `rustup` rather than an action: it is already on the runner, and this needs one
+      # toolchain and no other behaviour — a pinned third-party action would be one more
+      # thing to keep current for no gain.
+      - name: install the toolchain under test
+        run: rustup toolchain install ${{ matrix.version }} --profile minimal
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: msrv-${{ matrix.version }}
       - name: they build at the version they claim
         run: |
           for crate in ${{ matrix.crates }}; do
-            cargo check --locked -p "$crate" --all-features
+            cargo +${{ matrix.version }} check --locked -p "$crate" --all-features
           done

--- a/argv/Cargo.toml
+++ b/argv/Cargo.toml
@@ -3,7 +3,7 @@ name = "usage-argv"
 description = "Zero-allocation argv parser for usage specs"
 version = "5.1.0"
 edition = "2021"
-rust-version = "1.80.0"
+rust-version = "1.91"
 homepage = { workspace = true }
 documentation = { workspace = true }
 repository = { workspace = true }

--- a/clap_usage/Cargo.toml
+++ b/clap_usage/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "clap_usage"
 edition = "2021"
+rust-version = "1.95"
 version = "5.0.0"
 include = [
     "/Cargo.toml",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "usage-cli"
 edition = "2021"
+rust-version = "1.95"
 version = "5.1.0"
 description = "CLI for working with usage-based CLIs"
 license = { workspace = true }

--- a/config-build/Cargo.toml
+++ b/config-build/Cargo.toml
@@ -3,7 +3,7 @@ name = "usage-config-build"
 description = "Generates a usage-config settings registry from a usage spec, at build time"
 version = "5.1.0"
 edition = "2021"
-rust-version = "1.80.0"
+rust-version = "1.95"
 homepage = { workspace = true }
 documentation = { workspace = true }
 repository = { workspace = true }

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -3,7 +3,7 @@ name = "usage-config"
 description = "Layered configuration resolution for usage specs, with provenance"
 version = "5.1.0"
 edition = "2021"
-rust-version = "1.80.0"
+rust-version = "1.91"
 homepage = { workspace = true }
 documentation = { workspace = true }
 repository = { workspace = true }

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -4,7 +4,7 @@ description = "Harness for the argv conformance corpus"
 publish = false
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.80.0"
+rust-version = "1.91"
 homepage = { workspace = true }
 documentation = { workspace = true }
 repository = { workspace = true }

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -4,7 +4,9 @@ description = "Harness for the argv conformance corpus"
 publish = false
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.91"
+# No `rust-version`: nobody can depend on this, so it has nobody to promise. It declared 1.91
+# while depending on `usage-lib` and `kdl`, which need 1.95 — a floor that was never reachable
+# and that no job checked, because the matrix only covers what is published.
 homepage = { workspace = true }
 documentation = { workspace = true }
 repository = { workspace = true }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -3,7 +3,7 @@ name = "usage-derive"
 description = "Derive macro that compiles a CLI definition into parse tables and a usage spec"
 version = "5.1.0"
 edition = "2021"
-rust-version = "1.80.0"
+rust-version = "1.91"
 homepage = { workspace = true }
 documentation = { workspace = true }
 repository = { workspace = true }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -2,7 +2,7 @@
 name = "usage-lib"
 edition = "2021"
 version = "5.1.0"
-rust-version = "1.80.0"
+rust-version = "1.95"
 include = [
     "/Cargo.toml",
     "/Cargo.lock",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -2,7 +2,7 @@
 name = "xtask"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.80.0"
+rust-version = "1.91"
 license.workspace = true
 publish = false
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -2,7 +2,8 @@
 name = "xtask"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.91"
+# No `rust-version`, for the reason in `conformance/Cargo.toml`: unpublished, and its 1.91 was
+# contradicted by its own dependency on `usage-lib`.
 license.workspace = true
 publish = false
 


### PR DESCRIPTION
The MSRV said 1.80 and nothing checked it. The first run of a job that actually tries it:

```
error[E0658]: referencing statics in constant functions is unstable
 --> argv/src/lib.rs:550:21
```

**usage-argv has not built at its declared floor for a long time.** 1.80 was set in 2024 when `LazyLock` landed and never revisited — about two years of drift. A promise nobody checks is a guess.

I came to this from the other direction: a `use<..>` capture (Rust 1.82) got into usage-argv earlier in this stack and CodeRabbit caught it by reading, not by building. That is not a check.

## Two floors, because the crates genuinely differ

| | version | why |
|---|---|---|
| usage-argv, usage-derive, usage-config | **1.91** | no KDL dependency; mise's own floor, which is the one that matters for the fleet |
| usage-lib, usage-config-build, clap_usage, usage-cli | **1.95** | `kdl` declares 1.95, and there is no arguing with a dependency |

`clap_usage` and `usage-cli` are published and declared **nothing at all**, which is the same gap without the drift.

Each crate is checked at the version *it* declares rather than at one shared guess — that is what keeps the lower floor real rather than aspirational, and usage-argv's low floor is a genuine feature of a crate with no dependencies. The job also asserts the matrix and the manifests agree, so a crate that raises its floor without touching the workflow fails instead of being quietly tested at the old one.

## Verification

Installed both toolchains and checked at the exact versions, not at stable:

```
### at 1.91          ### at 1.95
  usage-argv    ok     usage-lib           ok
  usage-derive  ok     usage-config-build  ok
  usage-config  ok     clap_usage          ok
                       usage-cli           ok
```

The matrix/manifest guard was run under `bash` locally — my shell is zsh, which does not word-split unquoted expansions, so the first version of that check silently passed on nothing.

**Worth a look:** the workspace is on edition 2021 while mise is on 2024. With a 1.91 floor, 2024 is available. Not in this PR.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are CI guards and Cargo.toml MSRV metadata only; no runtime or library behavior changes.
> 
> **Overview**
> Adds a CI **`msrv`** job that actually builds published crates at the Rust versions they declare, instead of leaving stale **1.80** promises unchecked.
> 
> **Manifest updates:** KDL-free crates (`usage-argv`, `usage-derive`, `usage-config`) move to **1.91**; KDL-backed crates (`usage-lib`, `usage-config-build`, `clap_usage`, `usage-cli`) use **1.95**. **`clap_usage`** and **`usage-cli`** gain a `rust-version` for the first time. Unpublished **`usage-conformance`** and **`xtask`** drop `rust-version` so they are not treated as MSRV promises to dependents.
> 
> The workflow runs a **two-row matrix** (1.91 vs 1.95), bidirectional checks that each row’s crate list matches every published manifest at that version, then **`cargo check --locked --all-features`** on the pinned toolchain (library surface only, not dev-deps).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b35b1ec9810557e9b61e08401c8b27c327652c92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->