### PR TITLE
chore: keep prettier out of the machine-local .claude directory

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,3 +9,9 @@ pnpm-lock.yaml
 
 # aube-generated lockfile (not prettier-formatted)
 **/aube-lock.yaml
+
+# Machine-local Claude Code state. Nothing under here is tracked: it holds
+# per-developer settings, and with the worktree workflow it holds whole checkouts
+# of this repo, which prettier should neither walk nor rewrite. Without this,
+# `mise run lint` fails for anyone who has ever opened the project in Claude Code.
+.claude/


### PR DESCRIPTION
Running `mise run lint` fails on any machine where this project has been opened in Claude Code. It writes `.claude/settings.local.json`, and prettier walks and reformats it even though git never sees the file — it is ignored globally (`~/.config/git/ignore`) rather than by this repo, so `.gitignore` was never the thing keeping it out of prettier’s way.

```
$ mise run lint:prettier
[warn] .claude/settings.local.json
[warn] Code style issues found in the above file.
```

The directory holds two kinds of thing and prettier should skip both:

- **`settings.local.json`** is per-developer, so any formatting prettier applies is a diff nobody can commit.
- **`.claude/worktrees/`** holds entire checkouts of this repo under the worktree workflow. Prettier walking a nested copy of the tree on every lint run is both slow and wrong.

Nothing under `.claude/` is tracked, so ignoring the directory costs nothing today. If a shared `.claude/agents/*.md` is ever checked in, that is the moment to narrow this to `settings.local.json` and `worktrees/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint configuration only; no runtime, auth, or tracked source changes.
> 
> **Overview**
> **Prettier** now skips the entire **`.claude/`** directory so `mise run lint` / `lint:prettier` no longer walks or reformats Claude Code’s local files (e.g. `settings.local.json`) or nested worktree checkouts under `.claude/worktrees/`.
> 
> The change is a **`.prettierignore`** entry plus a short comment explaining why. The existing `**/aube-lock.yaml` ignore is unchanged aside from a proper trailing newline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2302ace4cbdb4263a5c5ee346c2cde1812ba460. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->