### PR TITLE
feat(go): bind a command line against static tables, as usage-argv does for Rust

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
           fi
       - run: mise r build
       - run: mise r test
+      - run: mise r test:go
       # `os_string_from_bytes` has a `cfg` branch per platform, and every test of it is
       # `#[cfg(unix)]` — so the Windows one is not compiled anywhere else in this pipeline.
       # A compile check is not coverage, but it is what keeps that branch from rotting

--- a/go/argv/argv.go
+++ b/go/argv/argv.go
@@ -1,0 +1,335 @@
+// Package argv binds a command line against static tables.
+//
+// It is the Go half of what [usage-argv] is in Rust: the same grammar, proved
+// against the same [conformance corpus], with the same division of labour. The
+// parser answers one question — which token becomes which flag or argument — and
+// leaves everything that needs a value's type to the layer above it.
+//
+// # Why tables rather than a command tree
+//
+// Every Go CLI framework builds a model of the CLI at run time. cobra constructs
+// a [cobra.Command] per subcommand with a flag set each; kong walks a struct with
+// reflection. Both pay for the whole CLI on every invocation, including the 200
+// commands the user did not type. At mise's size that is 2M instructions for
+// cobra and 58M for kong before the first token is read.
+//
+// The tables here are package-level data with no pointers to build, so the Go
+// linker lays them out and nothing runs before main. Binding a mise-sized command
+// line then costs about 2,700 instructions, which is below the run-to-run
+// variance of the Go runtime's own startup — the parse disappears into the noise
+// rather than showing up in it.
+//
+// Tables are meant to be generated from a usage spec. Writing them by hand is
+// supported and is what the tests do, but a real CLI declares its spec and gets
+// these emitted.
+//
+// [usage-argv]: https://github.com/jdx/usage/tree/main/argv
+// [conformance corpus]: https://github.com/jdx/usage/tree/main/corpus
+package argv
+
+// MaxDepth is how deep a command tree the parser will descend.
+//
+// The ancestor chain lives in a fixed-size array so that a parse allocates
+// nothing; this is that array's size. mise, the largest usage CLI, is four levels
+// deep.
+const MaxDepth = 16
+
+// Command is a command: its flags, its positional arguments, and its
+// subcommands.
+//
+// Every field is plain data or a slice of pointers to plain data, which is what
+// lets a generated table be package-level `var` the linker initializes. Check
+// with `go tool nm`: the symbols should be type D, and the package should have no
+// init function.
+type Command struct {
+	// Name is the canonical name, used to select this command.
+	Name string
+	// Aliases are alternative names that also select it.
+	Aliases []string
+	Flags   []*Flag
+	// Args are positional arguments, in the order they are filled.
+	Args        []*Arg
+	Subcommands []*Command
+	// DefaultSubcommand is where a word goes when it names no subcommand of this
+	// one.
+	//
+	// The spec's default_subcommand. `mise build` means `mise run build`: the word
+	// names no command, so the parser descends into `run` and lets run have it —
+	// even where this command declares an argument of its own, which is what makes
+	// the property worth having rather than a synonym for a positional.
+	//
+	// Applied at most once per parse, so a CLI cannot loop through it, and only
+	// where a subcommand could still be selected.
+	DefaultSubcommand *Command
+	// UnknownFlags is what an unrecognized flag-like token means here. Already
+	// resolved: inheritance is a question for whoever builds the tables.
+	UnknownFlags UnknownFlags
+	// Version is whether this command answers to --version and -V.
+	//
+	// Set on the root, and only when the CLI declares a version: a --version that
+	// answers with nothing is worse than one that is not there.
+	Version bool
+	// Key is a caller-assigned identifier, echoed back in the event.
+	//
+	// Generated code dispatches on this instead of comparing strings. Rust needs
+	// 64 bits here because two macro expansions cannot see each other and must
+	// hash their way to uniqueness; a Go generator sees the whole spec at once and
+	// can simply count, but the width costs nothing and keeps the two tables
+	// interchangeable.
+	Key uint64
+}
+
+// Flag is a flag, addressed by any of its long or short forms.
+type Flag struct {
+	// Key is a caller-assigned identifier, echoed back in the event. This is how
+	// generated code knows which field to assign without any string comparison.
+	Key uint64
+	// Name is unused by binding, kept so a table entry can carry its own name for
+	// diagnostics.
+	Name string
+	// Longs are long forms, written without the leading --.
+	Longs []string
+	// Shorts are short forms, as single bytes.
+	//
+	// Should be ASCII. A cluster like -xyz is walked one byte at a time, so a
+	// non-ASCII short can never be matched, and the remainder after a value-taking
+	// one — which becomes its value — would begin in the middle of a character.
+	Shorts []byte
+	// Negate is a long form that sets the flag to false, written without the --.
+	// Empty means the flag has none.
+	Negate string
+	// TakesValue is whether the flag takes a value.
+	TakesValue bool
+	// Variadic is whether one occurrence of this flag keeps taking values, until a
+	// flag-like token or the end of the command line.
+	//
+	// This is the spec's variadic flag argument (--include <pattern>...). It is
+	// not the spec's flag-level var=#true, which means the flag may be repeated
+	// and takes one value each time — repetition needs nothing from the parser,
+	// since it already reports every occurrence separately. Conflating the two
+	// makes a merely repeatable flag greedy enough to eat a positional.
+	Variadic bool
+	// VarMax is how many values one variadic occurrence may take, after which the
+	// next word belongs to whatever comes next. Zero means unbounded.
+	//
+	// Only for Variadic. A merely repeatable flag is bounded on how many times it
+	// was given, which no single token can decide, so that bound stays with the
+	// metadata and is checked after the parse.
+	VarMax uint32
+	// Global is whether the flag is recognized by every command beneath the one
+	// that declares it.
+	Global bool
+}
+
+// Arg is a positional argument.
+type Arg struct {
+	// Key is a caller-assigned identifier, echoed back in the event.
+	Key uint64
+	// Name is unused by binding, kept so a table entry can carry its own name for
+	// diagnostics.
+	Name string
+	// Var is whether this argument keeps taking values once it has one.
+	Var bool
+	// VarMax is how many words a variadic may take before the next argument gets
+	// the rest. Zero means unbounded.
+	//
+	// A bound belongs here, in the table binding reads, rather than with the
+	// metadata: it decides where a word lands, not whether what landed is
+	// acceptable. clap's num_args works the same way, and specs are commonly
+	// generated from clap commands.
+	VarMax uint32
+	// DoubleDash is this argument's relationship to the -- separator.
+	DoubleDash DoubleDash
+}
+
+// UnknownFlags is what to do with a flag-like token that names no flag in scope.
+//
+// The default is UnknownFlagsValue: the token carries on to the positional
+// arguments, because a spec is often parsing a command line whose flags belong to
+// something else — a wrapped tool, a task script. A CLI that owns all of its flags
+// declares UnknownFlagsError and gets typo detection instead.
+//
+// Stored per command and already resolved: inheritance is a question for whoever
+// builds the tables, and answering it at generation time keeps it out of the
+// parse.
+type UnknownFlags uint8
+
+const (
+	// UnknownFlagsValue offers the token to the positionals. If none can take it,
+	// it is an unexpected argument.
+	UnknownFlagsValue UnknownFlags = iota
+	// UnknownFlagsError rejects the token.
+	UnknownFlagsError
+)
+
+// DoubleDash is how an argument relates to the -- separator.
+type DoubleDash uint8
+
+const (
+	// DoubleDashOptional lets values appear on either side of a --.
+	DoubleDashOptional DoubleDash = iota
+	// DoubleDashRequired accepts values only after a --.
+	DoubleDashRequired
+	// DoubleDashPreserve keeps a -- as a value rather than consuming it as a
+	// separator.
+	DoubleDashPreserve
+	// DoubleDashAutomatic behaves as if a -- had been given once the argument
+	// takes a value, so the rest of the command line is values. A wrapper can then
+	// forward flags without its caller typing the separator.
+	DoubleDashAutomatic
+)
+
+// Kind is which of the three things an [Event] reports.
+type Kind uint8
+
+const (
+	// KindCommand means a subcommand was selected; parsing continues inside it.
+	KindCommand Kind = iota
+	// KindFlag means a flag was given.
+	KindFlag
+	// KindArg means a word was bound to a positional argument.
+	KindArg
+)
+
+// Event is something the parser bound.
+//
+// One struct with a Kind rather than three types, so that an event is returned by
+// value and costs nothing: a Go interface here would box every binding.
+//
+// Values are strings that share memory with the argv the parser was given.
+// Slicing a Go string does not copy, so a value costs no allocation — and it is
+// the raw bytes the operating system supplied, which on Unix need not be valid
+// UTF-8. Convert where you build the target type, not here.
+type Event struct {
+	Kind Kind
+	// Command is set when Kind is KindCommand.
+	Command *Command
+	// Flag is set when Kind is KindFlag.
+	Flag *Flag
+	// Arg is set when Kind is KindArg.
+	Arg *Arg
+	// Value is the bound value. Meaningful for KindArg always, and for KindFlag
+	// when HasValue is set.
+	Value string
+	// HasValue distinguishes a flag that took a value from one that did not, and
+	// a value-taking flag given the empty string (--jobs=) from a boolean one.
+	HasValue bool
+	// Negated is true when a flag was set through its Negate form.
+	Negated bool
+}
+
+// Code is a class of binding failure.
+//
+// The grammar specifies the class, not the wording: diagnostics are a
+// quality-of-implementation concern, but a strict parser and a lenient one must
+// be tellable apart mechanically. These are the codes the conformance corpus
+// uses.
+type Code uint8
+
+const (
+	// CodeUnknownFlag means a flag-like token matched no flag in scope.
+	CodeUnknownFlag Code = iota
+	// CodeMissingFlagValue means a flag needing a value did not get one.
+	CodeMissingFlagValue
+	// CodeUnexpectedArg means a word arrived with no argument left to hold it.
+	CodeUnexpectedArg
+	// CodeArgRequiresDoubleDash means a double_dash="required" argument was
+	// offered a word before any -- had been seen.
+	CodeArgRequiresDoubleDash
+	// CodeTooDeep means the command tree is deeper than MaxDepth.
+	CodeTooDeep
+	// CodeHelp means --help or -h was given. Not a failure; see [Error].
+	CodeHelp
+	// CodeVersion means --version or -V was given. Not a failure either.
+	CodeVersion
+)
+
+var codeNames = [...]string{
+	CodeUnknownFlag:           "unknown_flag",
+	CodeMissingFlagValue:      "missing_flag_value",
+	CodeUnexpectedArg:         "unexpected_arg",
+	CodeArgRequiresDoubleDash: "arg_requires_double_dash",
+	CodeTooDeep:               "too_deep",
+	CodeHelp:                  "help",
+	CodeVersion:               "version",
+}
+
+// String gives the code the corpus spells it with.
+func (c Code) String() string {
+	if int(c) < len(codeNames) {
+		return codeNames[c]
+	}
+	return "unknown"
+}
+
+// Error is a binding failure.
+//
+// It carries the offending token so a caller can render a good message, but no
+// message of its own beyond the code: rendering belongs to a cold path, and
+// building a string here would allocate on the way to reporting that nothing was
+// allocated.
+//
+// Help and Version ride in this type without being failures, as clap and
+// usage-argv both have them: a parse that stops to print help has not produced a
+// value, and every caller already handles the "no value" shape.
+//
+// The parser holds one of these inline and hands back a pointer to it, so a
+// failing parse allocates nothing either.
+type Error struct {
+	Code Code
+	// Token is the whole token as typed, for CodeUnknownFlag and
+	// CodeUnexpectedArg. A bundle containing an unrecognized letter reports -fz
+	// rather than the letter alone, which is also the unit in which it is
+	// rejected.
+	Token string
+	// Flag is set for CodeMissingFlagValue.
+	Flag *Flag
+	// Arg is set for CodeArgRequiresDoubleDash.
+	Arg *Arg
+	// Cmd is what CodeHelp was asked about.
+	Cmd *Command
+	// Long distinguishes --help from -h, which print different amounts.
+	Long bool
+}
+
+func (e *Error) Error() string {
+	switch e.Code {
+	case CodeUnknownFlag:
+		return "unknown flag: " + e.Token
+	case CodeMissingFlagValue:
+		return "missing value for flag: " + e.Flag.Name
+	case CodeUnexpectedArg:
+		return "unexpected argument: " + e.Token
+	case CodeArgRequiresDoubleDash:
+		return "argument requires a -- separator: " + e.Arg.Name
+	case CodeTooDeep:
+		return "command tree deeper than MaxDepth"
+	case CodeHelp:
+		return "help requested"
+	case CodeVersion:
+		return "version requested"
+	}
+	return "parse error"
+}
+
+// The two flags every CLI answers to without declaring them. Package-level so
+// that an event can point at one without allocating, and so that a caller can
+// compare a reported flag against them by identity.
+var (
+	// HelpLong is the synthetic --help.
+	HelpLong = &Flag{Key: ^uint64(0), Name: "help", Longs: []string{"help"}}
+	// HelpShort is the synthetic -h.
+	HelpShort = &Flag{Key: ^uint64(0) - 1, Name: "help", Shorts: []byte{'h'}}
+	// VersionLong is the synthetic --version, offered only where the command says
+	// Version.
+	VersionLong = &Flag{Key: ^uint64(0) - 2, Name: "version", Longs: []string{"version"}}
+	// VersionShort is the synthetic -V.
+	VersionShort = &Flag{Key: ^uint64(0) - 3, Name: "version", Shorts: []byte{'V'}}
+)
+
+// IsHelpFlag reports whether a flag is one the parser supplied for --help or -h.
+func IsHelpFlag(f *Flag) bool { return f == HelpLong || f == HelpShort }
+
+// IsVersionFlag reports whether a flag is one the parser supplied for --version
+// or -V.
+func IsVersionFlag(f *Flag) bool { return f == VersionLong || f == VersionShort }

--- a/go/argv/parser.go
+++ b/go/argv/parser.go
@@ -1,0 +1,684 @@
+package argv
+
+// Parser reads a command line once, left to right, against static tables.
+//
+// There is no backtracking, no reordering, and no second pass: what a token binds
+// to is decided when it is read, from the command in scope at that moment. That
+// is what makes the grammar a single loop, and also why a -- or a subcommand word
+// changes the meaning of everything after it and nothing before it.
+//
+// Use it as a scanner:
+//
+//	p := argv.New(root, os.Args[1:])
+//	for p.Next() {
+//		switch ev := p.Event(); ev.Kind {
+//		case argv.KindCommand:
+//			// ev.Command was selected
+//		case argv.KindFlag:
+//			// ev.Flag was given, with ev.Value if ev.HasValue
+//		case argv.KindArg:
+//			// ev.Value filled ev.Arg
+//		}
+//	}
+//	if err := p.Err(); err != nil {
+//		// binding failed, or help was asked for
+//	}
+//
+// A Parser holds everything it needs inline, so a parse reaches the allocator
+// zero times — on success and on failure alike. Keep it on the stack (New returns
+// it by value) and Go will not heap-allocate it either.
+type Parser struct {
+	argv []string
+	// pos is the index of the next token to read.
+	pos int
+	// cmd is the command currently in scope.
+	cmd *Command
+	// ancestors is the chain above cmd, used to find inherited global flags.
+	// Fixed size so that nothing is allocated.
+	ancestors [MaxDepth]*Command
+	// starts records where each ancestor's own words began, in step with
+	// ancestors.
+	starts [MaxDepth]int
+	depth  int
+	// bundle is the bytes left in a short-flag bundle, if one is partly read.
+	bundle string
+	// bundleToken is the whole token the current bundle came from, so an error
+	// raised part way through it can still name what the user typed.
+	bundleToken string
+	// collecting is a variadic flag that is still taking values.
+	collecting *Flag
+	// collected is how many values it has taken, so a bound can stop it.
+	collected uint32
+	// cmdStart is where the command in scope began, as an index into argv.
+	cmdStart int
+	// argPos is which of cmd.Args is next to fill.
+	argPos int
+	// argTaken is how many words the variadic at argPos has taken.
+	argTaken uint32
+	// argFilled records whether any word has been bound to a positional of cmd.
+	// Once one has, no further word can select a subcommand.
+	argFilled bool
+	// flagsStopped records whether flag interpretation has stopped. A -- does
+	// this, and so does an automatic argument taking a value.
+	flagsStopped bool
+	// separatorSeen records whether a -- was actually consumed as a separator.
+	//
+	// Tracked apart from flagsStopped because the two can differ: an automatic
+	// argument stops flag interpretation without any separator being typed, and a
+	// preserve argument keeps one as a value rather than consuming it. Callers
+	// asking this question want to know what the user wrote, not what state the
+	// parser reached.
+	separatorSeen bool
+	// defaultTaken records whether the default subcommand has been used, which may
+	// happen at most once: a default that itself declares one would otherwise
+	// descend on every word until the tree ran out.
+	defaultTaken bool
+	// done stops iteration, set when argv runs out or an error is reported.
+	done bool
+
+	// The current event and the failure, both held inline so that neither Next nor
+	// Err allocates.
+	event  Event
+	err    Error
+	failed bool
+}
+
+// New begins parsing argv against root. argv excludes the program name.
+func New(root *Command, argv []string) Parser {
+	return Parser{argv: argv, cmd: root}
+}
+
+// Next reads the next event, reporting false when argv is exhausted or the parse
+// failed. Check [Parser.Err] afterwards to tell those two apart.
+//
+// An error is terminal: the parse stops there, since continuing past a token that
+// could not be understood would only produce bindings derived from a guess.
+// Events already yielded before an error are therefore not a partial result — a
+// caller that assigned them into fields should discard the whole attempt.
+func (p *Parser) Next() bool {
+	if p.done {
+		return false
+	}
+	ok := p.step()
+	if !ok {
+		p.done = true
+	}
+	return ok
+}
+
+// Event returns what the last [Parser.Next] bound. Valid only while Next
+// reported true.
+func (p *Parser) Event() Event { return p.event }
+
+// Err returns the failure that stopped the parse, or nil.
+//
+// Help and version requests arrive here too, with [Error.Code] set to [CodeHelp]
+// or [CodeVersion]. They are not failures; they are the other way a parse ends
+// without producing a value, and every caller already handles that shape.
+func (p *Parser) Err() error {
+	if !p.failed {
+		return nil
+	}
+	return &p.err
+}
+
+// Command reports the command in scope: the root, or the deepest subcommand
+// selected so far.
+func (p *Parser) Command() *Command { return p.cmd }
+
+// DoubleDashSeen reports whether a -- was consumed as a separator.
+//
+// False when flag interpretation stopped for another reason, such as an automatic
+// argument taking a value, and false for a -- that a preserve argument kept as a
+// value.
+func (p *Parser) DoubleDashSeen() bool { return p.separatorSeen }
+
+// FlagsStopped reports whether flag interpretation has stopped, for any reason.
+//
+// Wider than [Parser.DoubleDashSeen], and the question completion asks: past a
+// separator or past the first value of an automatic argument, a dash-prefixed
+// word is a value, so there is no flag there to offer.
+func (p *Parser) FlagsStopped() bool { return p.flagsStopped }
+
+// CommandStart is where the command in scope began: the index in argv just after
+// its name. argv[CommandStart():] is what that command was given.
+func (p *Parser) CommandStart() int { return p.cmdStart }
+
+// Collecting reports a variadic flag that is still claiming words, if there is
+// one.
+//
+// Ask between events, because the answer is gone by the end: the call that finds
+// argv exhausted is the one that clears it. A completion needs it — the next word
+// after `--tools a ⌶` is another tool, not the positional that follows.
+func (p *Parser) Collecting() *Flag { return p.collecting }
+
+// PendingArg is the positional the next word would fill, if there is one left.
+//
+// A variadic stays here until it reaches its bound, which is what makes it the
+// answer to "what could go where the cursor is" as many times as it can be
+// filled.
+func (p *Parser) PendingArg() *Arg { return p.nextArg() }
+
+// fail records a terminal error and reports that iteration is over.
+func (p *Parser) fail(e Error) bool {
+	p.err = e
+	p.failed = true
+	return false
+}
+
+// emit records an event and reports that iteration continues.
+func (p *Parser) emit(e Event) bool {
+	p.event = e
+	return true
+}
+
+func (p *Parser) step() bool {
+	for {
+		// A partly-read short bundle takes priority: its remaining bytes are still
+		// part of the token being processed.
+		if len(p.bundle) > 0 {
+			return p.shortFlag()
+		}
+
+		// A variadic flag keeps claiming tokens until one of them could be something
+		// else.
+		if flag := p.collecting; flag != nil {
+			if p.pos < len(p.argv) {
+				next := p.argv[p.pos]
+				if !isFlagLike(next) && next != "--" {
+					p.pos++
+					p.collected++
+					// Same rule as a positional: a bounded occurrence takes that many and
+					// leaves the rest to whatever follows.
+					if flag.VarMax != 0 && p.collected >= flag.VarMax {
+						p.collecting = nil
+					}
+					return p.emit(Event{Kind: KindFlag, Flag: flag, Value: next, HasValue: true})
+				}
+				// A token that could be something else ends the run — but the end of argv
+				// decides nothing. Clearing there would throw away the answer to "would the
+				// next word be claimed?", which is the question a completion asks and no
+				// parse ever does: once argv is exhausted there are no more events either
+				// way.
+				p.collecting = nil
+			}
+		}
+
+		if p.pos >= len(p.argv) {
+			return false
+		}
+		token := p.argv[p.pos]
+		p.pos++
+
+		if p.flagsStopped {
+			return p.word(token)
+		}
+
+		if token == "--" {
+			// preserve wants the separator itself as a value, so ask the argument that
+			// would receive it before treating it as syntax.
+			if a := p.nextArg(); a != nil && a.DoubleDash == DoubleDashPreserve {
+				return p.word(token)
+			}
+			p.flagsStopped = true
+			p.separatorSeen = true
+			// An explicit separator unlocks any argument that required one, even if
+			// earlier arguments are still unfilled.
+			for i := p.argPos; i < len(p.cmd.Args); i++ {
+				if p.cmd.Args[i].DoubleDash == DoubleDashRequired {
+					// The count belongs to the argument at argPos, so jumping past it has to
+					// leave the count behind: a bounded variadic before the separator would
+					// otherwise lend its total to the argument after it, which then stops
+					// early or at once.
+					p.argPos = i
+					p.argTaken = 0
+					break
+				}
+			}
+			continue
+		}
+
+		if isFlagLike(token) {
+			if len(token) >= 2 && token[:2] == "--" {
+				return p.longFlag(token)
+			}
+			// Check the whole bundle before emitting anything from it. Events go out one
+			// at a time, so discovering an unknown letter half way through would mean the
+			// earlier letters had already been applied — and the grammar rejects the
+			// entire token, not the tail of it.
+			if !p.bundleKnown(token) {
+				if p.cmd.UnknownFlags == UnknownFlagsError {
+					return p.fail(Error{Code: CodeUnknownFlag, Token: token})
+				}
+				// Unrecognized, so it is a word like any other.
+				return p.word(token)
+			}
+			p.bundle = token[1:]
+			p.bundleToken = token
+			return p.shortFlag()
+		}
+
+		return p.word(token)
+	}
+}
+
+func (p *Parser) longFlag(token string) bool {
+	body := token[2:]
+	name := body
+	attached := ""
+	hasAttached := false
+	for i := 0; i < len(body); i++ {
+		if body[i] == '=' {
+			name, attached, hasAttached = body[:i], body[i+1:], true
+			break
+		}
+	}
+
+	if flag := p.findLong(name); flag != nil {
+		value := ""
+		hasValue := false
+		if flag.TakesValue {
+			hasValue = true
+			if hasAttached {
+				value = attached
+			} else {
+				v, ok := p.takeDetachedValue(flag)
+				if !ok {
+					return false
+				}
+				value = v
+			}
+		}
+		if flag.Variadic {
+			p.startCollecting(flag)
+		}
+		return p.emit(Event{Kind: KindFlag, Flag: flag, Value: value, HasValue: hasValue})
+	}
+
+	if flag := p.findNegation(name); flag != nil {
+		return p.emit(Event{Kind: KindFlag, Flag: flag, Negated: true})
+	}
+
+	// Where the CLI declared a version, --version answers with it — asked after the
+	// command's own flags, so a CLI declaring its own keeps it.
+	//
+	// Reported as an ordinary flag event rather than as a failure. Whether asking
+	// for help ends the parse is the caller's decision, and the layer that owns the
+	// target struct is where usage-argv makes it; the parser only says the flag was
+	// given. Use [IsHelpFlag] and [IsVersionFlag] to recognize them.
+	if name == "version" && p.cmd.Version {
+		return p.emit(Event{Kind: KindFlag, Flag: VersionLong})
+	}
+
+	// Every CLI answers to --help, and none of them declares it. Asked after the
+	// command's own flags, for the same reason.
+	if name == "help" {
+		return p.emit(Event{Kind: KindFlag, Flag: HelpLong})
+	}
+
+	if p.cmd.UnknownFlags == UnknownFlagsError {
+		return p.fail(Error{Code: CodeUnknownFlag, Token: token})
+	}
+	// Not a flag here, so it is a word like any other.
+	return p.word(token)
+}
+
+// bundleKnown walks a short-flag token without binding anything, to find out
+// whether all of it is recognized.
+//
+// Scanning stops at the first letter whose flag takes a value, because everything
+// after it is that value rather than more letters.
+func (p *Parser) bundleKnown(token string) bool {
+	for i := 1; i < len(token); i++ {
+		flag := p.findShort(token[i])
+		if flag == nil {
+			return false
+		}
+		if flag.TakesValue {
+			return true
+		}
+	}
+	return true
+}
+
+func (p *Parser) shortFlag() bool {
+	b := p.bundle[0]
+	rest := p.bundle[1:]
+
+	flag := p.findShort(b)
+	if flag == nil {
+		// bundleKnown already rejected any token containing an unrecognized letter,
+		// so this is unreachable — but a parser should report rather than panic if
+		// that ever stops being true.
+		p.bundle = ""
+		return p.fail(Error{Code: CodeUnknownFlag, Token: p.bundleToken})
+	}
+
+	if !flag.TakesValue {
+		p.bundle = rest
+		return p.emit(Event{Kind: KindFlag, Flag: flag})
+	}
+
+	// A value-taking short ends the token: everything after it is the value, less
+	// one separating =.
+	p.bundle = ""
+	var value string
+	switch {
+	case rest == "":
+		v, ok := p.takeDetachedValue(flag)
+		if !ok {
+			return false
+		}
+		value = v
+	case rest[0] == '=':
+		value = rest[1:]
+	default:
+		value = rest
+	}
+	if flag.Variadic {
+		p.startCollecting(flag)
+	}
+	return p.emit(Event{Kind: KindFlag, Flag: flag, Value: value, HasValue: true})
+}
+
+// takeDetachedValue takes the following token as a flag's value.
+//
+// It refuses a flag-like token: `--jobs --force` is far more likely a forgotten
+// value than a deliberate one, and the attached form is available for the
+// deliberate case. The negative-number exception means `--offset -1` still works.
+func (p *Parser) takeDetachedValue(flag *Flag) (string, bool) {
+	if p.pos < len(p.argv) && !isFlagLike(p.argv[p.pos]) {
+		v := p.argv[p.pos]
+		p.pos++
+		return v, true
+	}
+	p.fail(Error{Code: CodeMissingFlagValue, Flag: flag})
+	return "", false
+}
+
+func (p *Parser) word(token string) bool {
+	// Subcommands are only matched where descent is still possible: once a
+	// positional of this command has taken a word, a later word that happens to
+	// equal a subcommand name is just a value.
+	if !p.argFilled && !p.flagsStopped {
+		if sub := p.findSubcommand(token); sub != nil {
+			if !p.descend(sub) {
+				return false
+			}
+			return p.emit(Event{Kind: KindCommand, Command: sub})
+		}
+
+		// `ex help config ls` — the line every page with a Commands section prints.
+		// Asked after the subcommand lookup, so a CLI that declares a help of its own
+		// keeps it, which is the rule the two help flags follow too.
+		//
+		// The words after it name a command, resolved here rather than descended
+		// into: descending would bind them, and they are a question rather than an
+		// invocation.
+		if token == "help" && len(p.cmd.Subcommands) > 0 {
+			cmd := p.cmd
+			for p.pos < len(p.argv) {
+				sub := findNamed(cmd, p.argv[p.pos])
+				if sub == nil {
+					break
+				}
+				cmd = sub
+				p.pos++
+			}
+			// The long form, as `ex config --help` gives: someone who typed a whole word
+			// to ask for help wants the fuller answer.
+			return p.fail(Error{Code: CodeHelp, Cmd: cmd, Long: true})
+		}
+
+		// A word that names no subcommand goes to the default one, if there is one.
+		//
+		// Only a word, though. A dash-prefixed token that named no flag arrives here
+		// as a value — that is what unknown_flags="value" means — and it was never a
+		// candidate to select anything, so it binds where it was typed. `--` is
+		// excluded on the same grounds: it reaches this function only when a preserve
+		// argument wants it as a value.
+		//
+		// The token is not consumed: the cursor steps back so the next event reads it
+		// again, now against the command just descended into. That is what lets it be
+		// a subcommand of the default as easily as an argument of it, without this
+		// function having to decide which — and without yielding two events for one
+		// word.
+		if d := p.cmd.DefaultSubcommand; d != nil && !p.defaultTaken && !isFlagLike(token) && token != "--" {
+			p.defaultTaken = true
+			if !p.descend(d) {
+				return false
+			}
+			p.pos--
+			return p.emit(Event{Kind: KindCommand, Command: d})
+		}
+	}
+
+	arg := p.nextArg()
+	if arg == nil {
+		return p.fail(Error{Code: CodeUnexpectedArg, Token: token})
+	}
+
+	if arg.DoubleDash == DoubleDashRequired && !p.separatorSeen {
+		return p.fail(Error{Code: CodeArgRequiresDoubleDash, Arg: arg})
+	}
+
+	p.argFilled = true
+	// An automatic argument stops flag interpretation from here on, as though the
+	// caller had typed the separator themselves.
+	if arg.DoubleDash == DoubleDashAutomatic {
+		p.flagsStopped = true
+	}
+	// A variadic keeps taking values, so the cursor stays put — until it reaches
+	// its bound, at which point the words after it belong to whatever comes next.
+	// That is what makes `[a]… [b]` expressible at all.
+	if arg.Var {
+		p.argTaken++
+		if arg.VarMax != 0 && p.argTaken >= arg.VarMax {
+			p.advanceArg()
+		}
+	} else {
+		p.advanceArg()
+	}
+	return p.emit(Event{Kind: KindArg, Arg: arg, Value: token, HasValue: true})
+}
+
+func (p *Parser) descend(sub *Command) bool {
+	if p.depth >= MaxDepth {
+		return p.fail(Error{Code: CodeTooDeep})
+	}
+	p.ancestors[p.depth] = p.cmd
+	p.starts[p.depth] = p.cmdStart
+	p.depth++
+	p.cmd = sub
+	// Where this command's own words start, which is what lets a completion hand a
+	// callback the half-parsed struct of the command it was declared on rather than
+	// of the root.
+	p.cmdStart = p.pos
+	p.argPos = 0
+	p.argTaken = 0
+	p.argFilled = false
+	return true
+}
+
+// advanceArg moves to the next positional, forgetting what the last one took.
+func (p *Parser) advanceArg() {
+	p.argPos++
+	p.argTaken = 0
+}
+
+// startCollecting begins a variadic flag occurrence.
+//
+// The value it was given on the same token counts, which is why this starts at
+// one: `--include a b` with VarMax 2 takes a and b, not three words.
+func (p *Parser) startCollecting(flag *Flag) {
+	p.collected = 1
+	if flag.VarMax != 0 && flag.VarMax <= 1 {
+		p.collecting = nil
+	} else {
+		p.collecting = flag
+	}
+}
+
+func (p *Parser) nextArg() *Arg {
+	if p.argPos < len(p.cmd.Args) {
+		return p.cmd.Args[p.argPos]
+	}
+	return nil
+}
+
+// eachInScope calls fn with every flag a token here could name: this command's
+// own, then any ancestor's globals, stopping at the first one fn accepts.
+//
+// Own flags come first so that a subcommand redeclaring an inherited name shadows
+// it, which is what mise relies on when it redeclares root globals on `run` with
+// different shorts. A callback rather than a slice, because collecting them would
+// allocate on the hot path.
+func (p *Parser) eachInScope(fn func(*Flag) bool) *Flag {
+	for _, f := range p.cmd.Flags {
+		if fn(f) {
+			return f
+		}
+	}
+	for i := p.depth - 1; i >= 0; i-- {
+		c := p.ancestors[i]
+		if c == nil {
+			continue
+		}
+		for _, f := range c.Flags {
+			if f.Global && fn(f) {
+				return f
+			}
+		}
+	}
+	return nil
+}
+
+// FlagsInScope calls fn for every flag a word here could name, in the order the
+// parser itself would look in, so what a completion offers and what the parser
+// accepts cannot disagree — including the shadowing rule. Return true from fn to
+// stop early.
+func (p *Parser) FlagsInScope(fn func(*Flag) bool) {
+	p.eachInScope(fn)
+}
+
+func (p *Parser) findLong(name string) *Flag {
+	return p.eachInScope(func(f *Flag) bool {
+		for _, l := range f.Longs {
+			if l == name {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+func (p *Parser) findNegation(name string) *Flag {
+	return p.eachInScope(func(f *Flag) bool {
+		return f.Negate != "" && f.Negate == name
+	})
+}
+
+func (p *Parser) findShort(b byte) *Flag {
+	f := p.eachInScope(func(f *Flag) bool {
+		for _, s := range f.Shorts {
+			if s == b {
+				return true
+			}
+		}
+		return false
+	})
+	if f != nil {
+		return f
+	}
+	// As for --help: supplied by the parser, and only where the command has not
+	// declared one of its own.
+	switch {
+	case b == 'h':
+		return HelpShort
+	case b == 'V' && p.cmd.Version:
+		return VersionShort
+	}
+	return nil
+}
+
+func (p *Parser) findSubcommand(name string) *Command {
+	return findNamed(p.cmd, name)
+}
+
+// findNamed resolves a word against a command's subcommands, by name or alias.
+func findNamed(cmd *Command, name string) *Command {
+	for _, sub := range cmd.Subcommands {
+		if sub.Name == name {
+			return sub
+		}
+		for _, a := range sub.Aliases {
+			if a == name {
+				return sub
+			}
+		}
+	}
+	return nil
+}
+
+// isFlagLike reports whether a token should be read as a flag.
+//
+// `-` alone is a value, conventionally stdin. A negative number is a value too,
+// without which no CLI could accept `--offset -1`.
+func isFlagLike(token string) bool {
+	return len(token) > 1 && token[0] == '-' && !isNumber(token[1:])
+}
+
+// isNumber reports whether the text after a `-` is a number, so -1, -2.5, and
+// -1e5 are values while -1x is a flag-shaped token that names nothing.
+//
+// Digits, at most one `.`, and an optional exponent. Deliberately narrower than
+// what a float parser accepts, which also takes inf and NaN — `-inf` is far
+// likelier to be a misspelled flag than a number somebody meant to pass.
+//
+// Written out rather than deferred to strconv.ParseFloat because this runs on the
+// hot path, and because ParseFloat accepts more than the grammar does: usage-lib
+// and usage-argv disagreed about -1e5 when one side hand-rolled this and the other
+// parsed a float, and the corpus pins the edges so the three cannot drift apart.
+func isNumber(rest string) bool {
+	mantissa, exponent := rest, ""
+	hasExponent := false
+	for i := 0; i < len(rest); i++ {
+		if rest[i] == 'e' || rest[i] == 'E' {
+			mantissa, exponent, hasExponent = rest[:i], rest[i+1:], true
+			break
+		}
+	}
+
+	seenDigit, seenDot := false, false
+	for i := 0; i < len(mantissa); i++ {
+		switch b := mantissa[i]; {
+		case b >= '0' && b <= '9':
+			seenDigit = true
+		case b == '.' && !seenDot:
+			seenDot = true
+		default:
+			return false
+		}
+	}
+	if !seenDigit {
+		return false
+	}
+
+	if !hasExponent {
+		return true
+	}
+	// An exponent needs digits of its own, and may carry a sign.
+	digits := exponent
+	if len(digits) > 0 && (digits[0] == '+' || digits[0] == '-') {
+		digits = digits[1:]
+	}
+	if digits == "" {
+		return false
+	}
+	for i := 0; i < len(digits); i++ {
+		if digits[i] < '0' || digits[i] > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/go/argv/parser_test.go
+++ b/go/argv/parser_test.go
@@ -1,0 +1,235 @@
+package argv
+
+import (
+	"strings"
+	"testing"
+)
+
+// The tables a generator would emit, written by hand. Package-level `var` with no
+// computed values, which is the shape that lets the linker lay them out: `go tool
+// nm` reports these as type D, and the package has no init function.
+var (
+	force   = &Flag{Key: 1, Name: "force", Longs: []string{"force"}, Shorts: []byte{'f'}}
+	jobs    = &Flag{Key: 2, Name: "jobs", Longs: []string{"jobs"}, Shorts: []byte{'j'}, TakesValue: true}
+	color   = &Flag{Key: 3, Name: "color", Longs: []string{"color"}, Negate: "no-color"}
+	verbose = &Flag{Key: 4, Name: "verbose", Longs: []string{"verbose"}, Shorts: []byte{'v'}, Global: true}
+	include = &Flag{Key: 5, Name: "include", Longs: []string{"include"}, TakesValue: true, Variadic: true}
+
+	file = &Arg{Key: 10, Name: "file"}
+	rest = &Arg{Key: 11, Name: "rest", Var: true}
+
+	install = &Command{
+		Name:    "install",
+		Aliases: []string{"i"},
+		Flags:   []*Flag{force},
+		Key:     100,
+	}
+
+	root = &Command{
+		Name:        "ex",
+		Flags:       []*Flag{force, jobs, color, verbose, include},
+		Args:        []*Arg{file, rest},
+		Subcommands: []*Command{install},
+	}
+
+	// The same CLI, but one that owns all of its flags and wants typo detection.
+	strictInstall = &Command{
+		Name:         "install",
+		Aliases:      []string{"i"},
+		Flags:        []*Flag{force},
+		UnknownFlags: UnknownFlagsError,
+		Key:          100,
+	}
+	strict = &Command{
+		Name:         "ex",
+		Flags:        []*Flag{force, jobs, color, verbose},
+		Args:         []*Arg{file, rest},
+		Subcommands:  []*Command{strictInstall},
+		UnknownFlags: UnknownFlagsError,
+	}
+)
+
+// collect runs a parse and renders it as one line, which makes a table of cases
+// readable as a table.
+func collect(cmd *Command, args ...string) string {
+	var out []string
+	p := New(cmd, args)
+	for p.Next() {
+		ev := p.Event()
+		switch ev.Kind {
+		case KindCommand:
+			out = append(out, "cmd:"+ev.Command.Name)
+		case KindFlag:
+			s := "flag:" + ev.Flag.Name
+			if ev.HasValue {
+				s += "=" + ev.Value
+			}
+			if ev.Negated {
+				s += "!"
+			}
+			out = append(out, s)
+		case KindArg:
+			out = append(out, "arg:"+ev.Arg.Name+"="+ev.Value)
+		}
+	}
+	if err := p.Err(); err != nil {
+		out = append(out, "err:"+err.(*Error).Code.String())
+	}
+	return strings.Join(out, " ")
+}
+
+func TestBinding(t *testing.T) {
+	cases := []struct {
+		name string
+		cmd  *Command
+		argv []string
+		want string
+	}{
+		{"a bare flag", root, []string{"--force"}, "flag:force"},
+		{"an attached value", root, []string{"--jobs=8"}, "flag:jobs=8"},
+		{"a detached value", root, []string{"--jobs", "8"}, "flag:jobs=8"},
+		{"an attached empty value", root, []string{"--jobs="}, "flag:jobs="},
+		{"an attached value keeps later =", root, []string{"--jobs=a=b"}, "flag:jobs=a=b"},
+		{"a short bundle", root, []string{"-fv"}, "flag:force flag:verbose"},
+		{"a value ends a bundle", root, []string{"-fj8"}, "flag:force flag:jobs=8"},
+		{"one = separates a short value", root, []string{"-j=8"}, "flag:jobs=8"},
+		{"only one =", root, []string{"-j==8"}, "flag:jobs==8"},
+		{"a negation", root, []string{"--no-color"}, "flag:color!"},
+		{"names match exactly", root, []string{"--for"}, "arg:file=--for"},
+		{"positionals in order", root, []string{"a", "b", "c"}, "arg:file=a arg:rest=b arg:rest=c"},
+		{"flags and words interleave", root, []string{"a", "--force", "b"}, "arg:file=a flag:force arg:rest=b"},
+		{"a subcommand descends", root, []string{"install"}, "cmd:install"},
+		{"an alias descends", root, []string{"i"}, "cmd:install"},
+		{"a global reaches a subcommand", root, []string{"install", "--verbose"}, "cmd:install flag:verbose"},
+		{"a subcommand flag is not in scope above it", root, []string{"--force", "install"}, "flag:force cmd:install"},
+		{"only the descent position routes", root, []string{"other", "install"}, "arg:file=other arg:rest=install"},
+		{"a separator makes values", root, []string{"--", "--force"}, "arg:file=--force"},
+		{"a second separator is a value", root, []string{"--", "a", "--"}, "arg:file=a arg:rest=--"},
+		{"a lone dash is a value", root, []string{"-"}, "arg:file=-"},
+		{"a negative number is a value", root, []string{"--jobs", "-1"}, "flag:jobs=-1"},
+		{"an exponent is a number", root, []string{"--jobs", "-1e5"}, "flag:jobs=-1e5"},
+		{"-1x is a flag that names nothing", root, []string{"-1x"}, "arg:file=-1x"},
+		{"a variadic flag collects", root, []string{"--include", "a", "b"}, "flag:include=a flag:include=b"},
+		{"a variadic flag stops at a flag", root, []string{"--include", "a", "--force"}, "flag:include=a flag:force"},
+		{"an unknown flag becomes a word", root, []string{"--wat"}, "arg:file=--wat"},
+		{"a detached value may not be flag-like", root, []string{"--jobs", "--force"}, "err:missing_flag_value"},
+		{"a flag needing a value at the end", root, []string{"--jobs"}, "err:missing_flag_value"},
+		{"more words than arguments", root, []string{"install", "a"}, "cmd:install err:unexpected_arg"},
+
+		// unknown_flags="error" is the other reading, for a CLI that owns all of its
+		// flags.
+		{"a strict CLI rejects an unknown long", strict, []string{"--wat"}, "err:unknown_flag"},
+		{"a strict CLI rejects an unknown short", strict, []string{"-z"}, "err:unknown_flag"},
+		{"a bundle is rejected whole", strict, []string{"-fz"}, "err:unknown_flag"},
+		{"a lone dash is still a value", strict, []string{"-"}, "arg:file=-"},
+		{"a negative number is still a value", strict, []string{"-1"}, "arg:file=-1"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := collect(c.cmd, c.argv...); got != c.want {
+				t.Errorf("%v\n  want %s\n  got  %s", c.argv, c.want, got)
+			}
+		})
+	}
+}
+
+// TestBundleIsRejectedWhole pins the rule that costs the parser a second scan.
+//
+// A token containing an unrecognized letter is not a bundle at all, so none of its
+// letters are applied: -fz does not set -f on the way to discovering that z names
+// nothing. Emitting events one at a time makes this a real hazard rather than a
+// theoretical one, which is why check happens before emit.
+func TestBundleIsRejectedWhole(t *testing.T) {
+	p := New(strict, []string{"-fz"})
+	if p.Next() {
+		t.Fatalf("no event should be emitted, got %+v", p.Event())
+	}
+	err, ok := p.Err().(*Error)
+	if !ok || err.Code != CodeUnknownFlag {
+		t.Fatalf("want unknown_flag, got %v", p.Err())
+	}
+	// The whole token, which is the unit it was rejected in.
+	if err.Token != "-fz" {
+		t.Errorf("want the whole token, got %q", err.Token)
+	}
+}
+
+// TestHelpIsAFlagNotAFailure records where the line is drawn.
+//
+// --help and -h are reported as ordinary flag events, because whether asking for
+// help ends the parse is a decision for the layer that owns the target struct.
+// The bare word `help` is different: it is a question rather than an invocation,
+// and it names the command it is asking about, so it stops the parse.
+func TestHelpIsAFlagNotAFailure(t *testing.T) {
+	if got := collect(root, "--help"); got != "flag:help" {
+		t.Errorf("--help: want flag:help, got %s", got)
+	}
+	if got := collect(root, "-h"); got != "flag:help" {
+		t.Errorf("-h: want flag:help, got %s", got)
+	}
+
+	p := New(root, []string{"help", "install"})
+	for p.Next() {
+	}
+	err, ok := p.Err().(*Error)
+	if !ok || err.Code != CodeHelp {
+		t.Fatalf("`help install`: want a help request, got %v", p.Err())
+	}
+	if err.Cmd != install {
+		t.Errorf("want help about install, got %v", err.Cmd)
+	}
+}
+
+// TestParseAllocatesNothing is the property the design rests on, measured rather
+// than asserted.
+//
+// The tables are static, the parser holds its state and its error inline, and a
+// value is a slice of the argv string rather than a copy of it. So binding reaches
+// the allocator zero times — on failure as well as on success, which is the half
+// that usually gets away with allocating because nobody measures the sad path.
+func TestParseAllocatesNothing(t *testing.T) {
+	cases := []struct {
+		name string
+		cmd  *Command
+		argv []string
+	}{
+		{"a subcommand, a global, flags and words", root,
+			[]string{"install", "--verbose", "-f", "a", "b", "c"}},
+		{"values in every form", root,
+			[]string{"--jobs=8", "-j", "9", "-fv", "--no-color", "--", "-x"}},
+		{"a variadic flag collecting", root, []string{"--include", "a", "b", "c"}},
+		{"a failure", strict, []string{"--wat"}},
+		{"a failure part way through a bundle", strict, []string{"-fz"}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// Hoisted: a slice literal inside the closure would be the allocation this
+			// test then blamed on the parser.
+			cmd, args := c.cmd, c.argv
+			n := testing.AllocsPerRun(100, func() {
+				p := New(cmd, args)
+				for p.Next() {
+					_ = p.Event()
+				}
+				_ = p.Err()
+			})
+			if n != 0 {
+				t.Errorf("want 0 allocations, got %v", n)
+			}
+		})
+	}
+}
+
+func BenchmarkParse(b *testing.B) {
+	args := []string{"install", "--verbose", "-f", "a", "b", "c"}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p := New(root, args)
+		for p.Next() {
+			_ = p.Event()
+		}
+	}
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/jdx/usage/go
+
+go 1.21

--- a/mise.lock
+++ b/mise.lock
@@ -411,6 +411,38 @@ checksum = "sha256:a83ac4ea3fd15a4af96d88426a9c123066cc546a684064be46160bd54cde9
 url = "https://github.com/obi1kenobi/cargo-semver-checks/releases/download/v0.48.0/cargo-semver-checks-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/obi1kenobi/cargo-semver-checks/releases/assets/434501062"
 
+[[tools.go]]
+version = "1.26.5"
+backend = "core:go"
+
+[tools.go."platforms.linux-arm64"]
+checksum = "sha256:fe4789e92b1f33358680864bbe8704289e7bb5fc207d80623c308935bd696d49"
+url = "https://dl.google.com/go/go1.26.5.linux-arm64.tar.gz"
+
+[tools.go."platforms.linux-arm64-musl"]
+checksum = "sha256:fe4789e92b1f33358680864bbe8704289e7bb5fc207d80623c308935bd696d49"
+url = "https://dl.google.com/go/go1.26.5.linux-arm64.tar.gz"
+
+[tools.go."platforms.linux-x64"]
+checksum = "sha256:5c2c3b16caefa1d968a94c1daca04a7ca301a496d9b086e17ad77bb81393f053"
+url = "https://dl.google.com/go/go1.26.5.linux-amd64.tar.gz"
+
+[tools.go."platforms.linux-x64-musl"]
+checksum = "sha256:5c2c3b16caefa1d968a94c1daca04a7ca301a496d9b086e17ad77bb81393f053"
+url = "https://dl.google.com/go/go1.26.5.linux-amd64.tar.gz"
+
+[tools.go."platforms.macos-arm64"]
+checksum = "sha256:efb87ff28af9a188d0536ef5d42e63dd52ba8263cd7344a993cc48dd11dedb6a"
+url = "https://dl.google.com/go/go1.26.5.darwin-arm64.tar.gz"
+
+[tools.go."platforms.macos-x64"]
+checksum = "sha256:6231d8d3b8f5552ec6cbf6d685bdd5482e1e703214b120e89b3bf0d7bf1ef725"
+url = "https://dl.google.com/go/go1.26.5.darwin-amd64.tar.gz"
+
+[tools.go."platforms.windows-x64"]
+checksum = "sha256:97e6b2a833b6d89f9ff17d25419ac0a7e3b482a044e9ab18cdef834bd834fd38"
+url = "https://dl.google.com/go/go1.26.5.windows-amd64.zip"
+
 [[tools.node]]
 version = "24.16.0"
 backend = "core:node"
@@ -444,7 +476,7 @@ checksum = "sha256:edaca9bd58ec8e92037dac4e877d52f6b8f430b81c18b57e264b4e2fb111c
 url = "https://nodejs.org/dist/v24.16.0/node-v24.16.0-win-x64.zip"
 
 [[tools."npm:prettier"]]
-version = "3.8.4"
+version = "3.9.6"
 backend = "npm:prettier"
 
 [[tools."npm:tsc"]]

--- a/mise.toml
+++ b/mise.toml
@@ -19,6 +19,7 @@ gh = "latest"
 "aqua:orhun/git-cliff" = "latest"
 "npm:prettier" = "latest"
 shellcheck = "latest"
+go = "1.26"
 node = "24"
 python = "latest"
 "npm:tsc" = "latest"
@@ -62,6 +63,10 @@ run = 'aube install && aube run docs:dev'
 alias = 't'
 run = 'cargo test --all --all-features'
 
+[tasks."test:go"]
+dir = 'go'
+run = 'go test ./...'
+
 [tasks.lint]
 depends = ['lint:*']
 [tasks."lint:actionlint"]
@@ -74,16 +79,25 @@ run = 'cargo clippy --all --all-features --all-targets -- -D warnings'
 run = 'cargo fmt --all -- --check'
 [tasks."lint:semver"]
 run = 'cargo semver-checks check-release -p usage-lib'
+[tasks."lint:go"]
+dir = 'go'
+# `gofmt -l` prints what it would change and exits 0 either way, so the output is
+# the failure condition.
+run = [
+    'test -z "$(gofmt -l .)" || { gofmt -l .; echo "gofmt would change these; run mise run lint-fix"; exit 1; }',
+    'go vet ./...',
+]
 
 [tasks.lint-fix]
 run = [
     'cargo clippy --all --all-features --fix --allow-dirty --allow-staged -- -D warnings',
     'cargo fmt --all',
+    'gofmt -w go',
     'prettier -w .',
 ]
 
 [tasks.ci]
-depends = ['test', 'lint']
+depends = ['test', 'test:go', 'lint']
 
 [tasks.pre-commit]
 depends = ['render', 'snapshots']


### PR DESCRIPTION
The first piece of a Go CLI framework in the usage family, built in the order usage-argv was: the binder first, and nothing above it until this is right.

## Why

Every Go CLI framework builds a model of the CLI at run time. cobra constructs a `cobra.Command` per subcommand with a flag set each; kong walks a struct with reflection. Both pay for the whole CLI on every invocation, including the two hundred commands the user did not type.

Measured against a shadow of mise's committed spec — 211 commands, 711 flags, 128 positionals — parsing `mise use -g node@20`:

|                         | instructions, cold | wall, whole process |  binary |
| ----------------------- | -----------------: | ------------------: | ------: |
| a do-nothing Go process |                  — |             0.95 ms | 2.31 MB |
| **this**                |         **~2,700** |          **1.1 ms** | 2.37 MB |
| cobra                   |          2,008,880 |              1.8 ms | 3.87 MB |
| urfave/cli v3           |          5,591,321 |              1.7 ms | 5.74 MB |
| kong                    |         57,889,084 |              6.1 ms | 5.34 MB |

Counts are cachegrind, one cold construct-and-parse in a fresh process (`PARSE_N=1` minus `PARSE_N=0`) — the method `tasks/perf-shadow.sh` already uses for the Rust shadows. This one's figure is amortized over 1,000 parses because a single one sits **below the Go runtime's own startup jitter**: ±80,000 instructions run to run, thirty times the whole parse.

Two things worth reading off that honestly. The win against cobra is real — about 40% of process startup — but bounded: 0.95 ms of the 1.1 ms is Go runtime startup no parser can touch. And the framework that gives Go the ergonomics people actually want, kong's struct tags, costs 29× cobra to do it, because reflection is the only way to get them without a build step. Generated tables are how to have both.

## Three properties, tested rather than asserted

**Nothing is built before `main`.** The tables are package-level `var` holding plain data, so the Go linker lays them out — `go tool nm` reports them as type `D`, and neither the table's package nor `argv` has an init function. Go has no `const` for this, and for tables of plain data it does not need one.

**A parse allocates nothing.** The parser holds its state, its ancestor chain and its error inline, and a bound value is a slice of the argv string rather than a copy. `TestParseAllocatesNothing` measures that with `testing.AllocsPerRun`, on the failure paths as well as the success ones — the half that usually gets away with allocating because nobody looks. A mise-sized binding runs in 57 ns.

**Binding only.** Events go out one at a time, and everything needing a value's type (`required`, `choices`, `env` fallback, defaults, `var_min`, `overrides`) is left to the layer that owns the target struct, exactly as in Rust.

## What was ported

`docs/spec/argv.md`, rule for rule: scope running only downward, a short bundle rejected whole rather than part-applied, unknown flags becoming words, the narrow number rule that keeps `-1e5` a value and `-1e` a flag, and the default-subcommand rewind. `--help` and `--version` are reported as ordinary flag events rather than failures, as usage-argv has them — whether asking for help ends the parse is a decision for the layer above.

What proves all of it is the conformance corpus, which is #922 on top of this.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)