### PR TITLE
test(go): answer the conformance corpus from Go, which is what it was for

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,8 @@ jobs:
           fi
       - run: mise r build
       - run: mise r test
+      # Run here rather than in a job of its own: the corpus vectors carry KDL
+      # specs, and lowering them needs the `usage` CLI this job has already built.
       - run: mise r test:go
       # `os_string_from_bytes` has a `cfg` branch per platform, and every test of it is
       # `#[cfg(unix)]` — so the Windows one is not compiled anywhere else in this pipeline.

--- a/corpus/README.md
+++ b/corpus/README.md
@@ -12,6 +12,10 @@ without reimplementing a test format. If you are writing a usage parser — for 
 for JavaScript, for Python, or as a second Rust implementation — this directory is
 the definition of correct, and passing it is what "compatible" means.
 
+[usage-go](../go/README.md) is the first parser to take that offer up: it answers
+the binding vectors from a Go test runner rather than a Rust one, which is the
+claim this format exists to make checkable.
+
 ## Format
 
 One file per area of the grammar. Each has a `section`, an `about` explaining what

--- a/docs/spec/argv.md
+++ b/docs/spec/argv.md
@@ -303,7 +303,10 @@ process environment, so no vector's result can depend on the machine running it.
 
 Any implementation in any language can run these. In this repository,
 `cargo test -p usage-conformance` runs them against both usage-lib and
-[usage-argv](https://github.com/jdx/usage/tree/main/argv).
+[usage-argv](https://github.com/jdx/usage/tree/main/argv), and `mise run test:go`
+runs them against [usage-go](https://github.com/jdx/usage/tree/main/go), which is a
+second implementation of this page in another language — the thing the corpus was
+made to make possible.
 
 Each vector says which layer of a parser it is a question for. Most are
 `binding` — which token becomes which flag or argument — and a parser that reads

--- a/go/README.md
+++ b/go/README.md
@@ -1,0 +1,123 @@
+# usage-go
+
+A CLI framework for Go, built the way [usage-argv](../argv) is built for Rust: the
+command line is bound against **static tables** instead of a command tree
+assembled at run time.
+
+> **Status: the binder.** `argv` implements the [argv grammar](../docs/spec/argv.md)
+> and passes every binding vector in the [conformance corpus](../corpus). The code
+> generator that emits tables from a spec, and the layer above binding that fills a
+> typed struct, are not written yet. See [what is missing](#what-is-missing).
+
+## Why
+
+Every Go CLI framework builds a model of the CLI at run time. cobra constructs a
+`cobra.Command` per subcommand, each with its own flag set; kong walks a struct
+with reflection. Both pay for the whole CLI on every invocation, including the two
+hundred commands the user did not type.
+
+Measured against a shadow of [mise](https://mise.jdx.dev)'s spec — 211 commands,
+711 flags, 128 positionals — parsing `mise use -g node@20`:
+
+|                         | instructions, cold | wall, whole process |  binary |
+| ----------------------- | -----------------: | ------------------: | ------: |
+| a do-nothing Go process |                  — |             0.95 ms | 2.31 MB |
+| **usage-go**            |         **~2,700** |          **1.1 ms** | 2.37 MB |
+| cobra                   |          2,008,880 |              1.8 ms | 3.87 MB |
+| urfave/cli v3           |          5,591,321 |              1.7 ms | 5.74 MB |
+| kong                    |         57,889,084 |              6.1 ms | 5.34 MB |
+
+Instruction counts are cachegrind, one cold construct-and-parse in a fresh process
+(`PARSE_N=1` minus `PARSE_N=0`), the same method [`tasks/perf-shadow.sh`](../tasks/perf-shadow.sh)
+uses for the Rust shadows. usage-go's figure is amortized over 1,000 parses because
+a single one is _below the Go runtime's own startup jitter_ — ±80,000 instructions
+run to run, which is thirty times the whole parse.
+
+Two things are worth reading off that table honestly. The win against cobra is
+real — about 40% of process startup — but it is bounded: 0.95 ms of usage-go's
+1.1 ms is Go runtime startup that no parser can touch. And the framework that
+gives Go the ergonomics people actually want, kong's struct tags, costs 29× cobra
+to do it, because reflection is the only way to get them without a build step.
+Generated tables are the way to have both.
+
+## The design
+
+Three properties, each of which is tested rather than claimed:
+
+**Nothing is built before `main`.** The tables are package-level `var` holding
+plain data, so the Go linker lays them out. `go tool nm` reports them as type `D`
+and the package has no `init` function — a 211-command table costs 47 KB of
+initialized data and zero instructions.
+
+**A parse allocates nothing.** The parser holds its state, its ancestor chain and
+its error inline; a bound value is a slice of the argv string rather than a copy.
+`TestParseAllocatesNothing` measures this with `testing.AllocsPerRun`, on the
+failure paths as well as the success ones. A mise-sized binding runs in 57 ns.
+
+**Binding only.** The parser answers one question — which token becomes which flag
+or argument — and reports each occurrence as an event. Everything that needs to
+know a value's _type_ (`required`, `choices`, `env` fallback, defaults, `var_min`,
+`overrides`) belongs to the layer that owns the target struct, exactly as it does
+in Rust. That is why the corpus's 22 post-binding vectors are skipped here rather
+than failed.
+
+## Using it
+
+```go
+p := argv.New(root, os.Args[1:])
+for p.Next() {
+    switch ev := p.Event(); ev.Kind {
+    case argv.KindCommand:
+        // ev.Command was selected
+    case argv.KindFlag:
+        // ev.Flag was given, with ev.Value if ev.HasValue
+    case argv.KindArg:
+        // ev.Value filled ev.Arg
+    }
+}
+if err := p.Err(); err != nil {
+    // binding failed, or --help was asked for
+}
+```
+
+Tables are meant to be generated. Writing them by hand is supported, and is what
+[`argv/parser_test.go`](argv/parser_test.go) does:
+
+```go
+var (
+    force = &argv.Flag{Name: "force", Longs: []string{"force"}, Shorts: []byte{'f'}}
+    root  = &argv.Command{Name: "ex", Flags: []*argv.Flag{force}}
+)
+```
+
+Dispatch on `Key` rather than `Name` in generated code: it is what the field
+identifiers are for, and it costs no string comparison.
+
+## Conformance
+
+The [corpus](../corpus) is the definition of correct, and it is plain JSON so that
+an implementation in any language can run it. `go/conformance` runs all of it:
+
+```sh
+mise run test:go
+```
+
+101 binding vectors pass; the 22 post-binding ones are skipped with the reason
+recorded. A vector's spec is KDL, and this module deliberately has no KDL parser —
+`usage generate json` does the lowering, which is why the suite needs the CLI
+built. That split is the same one an adopter gets: tables are generated once at
+build time by a maintainer who has the usage CLI, and the shipped binary never
+sees a spec.
+
+## What is missing
+
+- **The generator.** `usage generate go`, emitting the tables above from a spec.
+  Until it exists, tables are written by hand or built at run time from a lowered
+  spec via `internal/spec`.
+- **The typed layer.** Binding produces events; something has to turn them into a
+  struct with `int` and `time.Duration` fields, and apply the post-binding rules.
+  This is where the corpus's 22 skipped vectors get answered.
+- **Help and errors.** A cold table of help text, and rendering worth reading.
+- **Completions.** The Rust side serves these from the parser's own scope rules so
+  that what is offered and what is accepted cannot disagree; the hooks for it
+  (`Collecting`, `PendingArg`, `FlagsInScope`, `CommandStart`) are already here.

--- a/go/conformance/conformance_test.go
+++ b/go/conformance/conformance_test.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -281,6 +282,15 @@ func load(t *testing.T) []Vector {
 			t.Fatalf("decoding %s: %v\n"+
 				"If the corpus has grown a field, teach Vector about it rather than "+
 				"relaxing this check.", p, err)
+		}
+		// A Decoder stops at the end of the first value, where json.Unmarshal
+		// refuses trailing content — so reaching for one to get
+		// DisallowUnknownFields gave up a check that was already there. A second
+		// value in the file would otherwise be dropped silently, which for a corpus
+		// file means vectors that never run and a suite that passes for it.
+		if err := dec.Decode(new(json.RawMessage)); err != io.EOF {
+			t.Fatalf("%s: content after the top-level object; the whole file should "+
+				"be one JSON object, and anything past it would not be run", p)
 		}
 		out = append(out, f.Vectors...)
 	}

--- a/go/conformance/conformance_test.go
+++ b/go/conformance/conformance_test.go
@@ -1,0 +1,299 @@
+// Package conformance runs the shared corpus against the Go parser.
+//
+// The corpus is the definition of correct. It is plain JSON precisely so that an
+// implementation in any language can run it without reimplementing a test format,
+// and the corpus README says as much: passing it is what "compatible" means. This
+// file is that claim, made executable for Go.
+//
+// A vector's spec is KDL, and this module has no KDL parser by design — see
+// [github.com/jdx/usage/go/internal/spec]. The `usage` CLI does the lowering, so
+// these tests need it built. `mise run test:go` builds it first.
+package conformance
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/jdx/usage/go/argv"
+	"github.com/jdx/usage/go/internal/spec"
+)
+
+// Vector is one corpus case. Fields the Go parser does not consult — doc,
+// reference — are read anyway so that an unknown field can be spotted.
+type Vector struct {
+	ID     string            `json:"id"`
+	Doc    string            `json:"doc"`
+	Spec   string            `json:"spec"`
+	Argv   []string          `json:"argv"`
+	Env    map[string]string `json:"env"`
+	Expect Expect            `json:"expect"`
+	// Layer says which layer of a parser the vector is a question for. Absent
+	// means binding, which is the default and most of them.
+	Layer string `json:"layer"`
+	// Reference records whether usage-lib agrees with the grammar. It is a note
+	// about the Rust reference implementation, not about this one, and is read
+	// only so that a failure can mention it: a vector usage-lib diverges on is one
+	// where copying usage-lib's behavior would have been the wrong move.
+	Reference *struct {
+		Diverges string `json:"diverges"`
+	} `json:"reference"`
+}
+
+// Expect is the result a vector requires: a binding, or a class of failure.
+type Expect struct {
+	OK    *Parsed `json:"ok"`
+	Error string  `json:"error"`
+}
+
+// Parsed is what a successful parse must produce. Both maps are keyed by the name
+// the spec gives each flag or argument, never by the token that set it, so -j,
+// --jobs and an env var all land under `jobs`.
+type Parsed struct {
+	Cmd   []string               `json:"cmd"`
+	Flags map[string]interface{} `json:"flags"`
+	Args  map[string]interface{} `json:"args"`
+}
+
+type file struct {
+	Section string   `json:"section"`
+	About   string   `json:"about"`
+	Vectors []Vector `json:"vectors"`
+}
+
+func TestCorpus(t *testing.T) {
+	usageBin := findUsage(t)
+	vectors := load(t)
+
+	// Lowering shells out, and vectors share specs, so this saves most of the
+	// subprocesses.
+	lowered := map[string]*spec.Spec{}
+
+	var ran, skipped int
+	for _, v := range vectors {
+		v := v
+		t.Run(v.ID, func(t *testing.T) {
+			// usage-argv answers binding vectors. The rest are decided once the last
+			// token has been read — required, choices, env fallback, defaults, var_min,
+			// overrides — and need to know a value's type, so they belong to the layer
+			// that owns the target struct. The Go parser draws the line in the same
+			// place.
+			if v.Layer == "post-binding" {
+				skipped++
+				t.Skip("post-binding: belongs to the layer that owns the target struct")
+			}
+			ran++
+
+			s, ok := lowered[v.Spec]
+			if !ok {
+				s = lower(t, usageBin, v.Spec)
+				lowered[v.Spec] = s
+			}
+
+			got, gotErr := run(s, v.Argv)
+
+			switch {
+			case v.Expect.Error != "":
+				if gotErr == nil {
+					t.Fatalf("expected error %q, parsed %s%s", v.Expect.Error, show(got), note(v))
+				}
+				if gotErr.Code.String() != v.Expect.Error {
+					t.Fatalf("expected error %q, got %q%s", v.Expect.Error, gotErr.Code, note(v))
+				}
+			case v.Expect.OK != nil:
+				if gotErr != nil {
+					t.Fatalf("expected a parse, got error %q%s", gotErr.Code, note(v))
+				}
+				want := normalizeExpected(v.Expect.OK)
+				if !reflect.DeepEqual(got, want) {
+					t.Fatalf("mismatch%s\n  want %s\n  got  %s", note(v), show(want), show(got))
+				}
+			default:
+				t.Fatalf("vector expects neither a parse nor an error")
+			}
+		})
+	}
+
+	t.Logf("%d vectors: %d binding, %d post-binding left to the layer above",
+		len(vectors), ran, skipped)
+}
+
+// note quotes the vector's own explanation on failure, and flags the ones where
+// usage-lib diverges from the grammar: those are the cases where matching the
+// reference implementation instead of the corpus would be the bug.
+func note(v Vector) string {
+	s := "\n  " + v.Doc
+	if v.Reference != nil {
+		s += "\n  usage-lib diverges here: " + v.Reference.Diverges
+	}
+	return s
+}
+
+// run binds a command line and accumulates the events the way the corpus records
+// them.
+//
+// How a value accumulates depends on the declaration, which the parser
+// deliberately does not know: it reports each occurrence and lets the caller
+// decide. Generated code assigns to a field or appends to a slice; here the spec
+// says which of the two to do.
+func run(s *spec.Spec, args []string) (*Parsed, *argv.Error) {
+	multi := s.MultiFlags()
+	out := &Parsed{
+		Cmd:   []string{},
+		Flags: map[string]interface{}{},
+		Args:  map[string]interface{}{},
+	}
+
+	p := argv.New(s.Tables(), args)
+	for p.Next() {
+		ev := p.Event()
+		switch ev.Kind {
+		case argv.KindCommand:
+			out.Cmd = append(out.Cmd, ev.Command.Name)
+		case argv.KindFlag:
+			name := ev.Flag.Name
+			switch {
+			case multi[name] == spec.MultiCount:
+				// A count flag records one entry per occurrence.
+				out.Flags[name] = append(bools(out.Flags[name]), true)
+			case multi[name] == spec.MultiVar && ev.HasValue:
+				out.Flags[name] = append(strs(out.Flags[name]), ev.Value)
+			case ev.HasValue:
+				out.Flags[name] = ev.Value
+			default:
+				out.Flags[name] = !ev.Negated
+			}
+		case argv.KindArg:
+			name := ev.Arg.Name
+			if ev.Arg.Var {
+				out.Args[name] = append(strs(out.Args[name]), ev.Value)
+			} else {
+				out.Args[name] = ev.Value
+			}
+		}
+	}
+	if err := p.Err(); err != nil {
+		e, ok := err.(*argv.Error)
+		if !ok {
+			panic("the parser returns only *argv.Error")
+		}
+		return nil, e
+	}
+	return out, nil
+}
+
+func strs(v interface{}) []interface{} {
+	if v == nil {
+		return nil
+	}
+	return v.([]interface{})
+}
+
+func bools(v interface{}) []interface{} { return strs(v) }
+
+// normalizeExpected puts the JSON expectation into the shape run produces, so the
+// two can be compared directly.
+//
+// Absent and empty mean the same thing here: some vectors omit `cmd` when nothing
+// was selected and others write `"cmd": []`, and both say the parse stayed at the
+// root. Likewise for the two maps. The corpus is the definition of correct about
+// bindings, not about which of two spellings of "nothing" a decoder produces.
+func normalizeExpected(p *Parsed) *Parsed {
+	out := &Parsed{Cmd: p.Cmd, Flags: p.Flags, Args: p.Args}
+	if out.Cmd == nil {
+		out.Cmd = []string{}
+	}
+	if out.Flags == nil {
+		out.Flags = map[string]interface{}{}
+	}
+	if out.Args == nil {
+		out.Args = map[string]interface{}{}
+	}
+	return out
+}
+
+func show(p *Parsed) string {
+	if p == nil {
+		return "<nothing>"
+	}
+	b, err := json.Marshal(p)
+	if err != nil {
+		return fmt.Sprintf("%+v", p)
+	}
+	return string(b)
+}
+
+// lower turns a vector's KDL spec into the JSON the tables are built from.
+func lower(t *testing.T, usageBin, kdl string) *spec.Spec {
+	t.Helper()
+	out, err := exec.Command(usageBin, "generate", "json", "--spec", kdl).Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			t.Fatalf("lowering the spec failed: %v\n%s", err, ee.Stderr)
+		}
+		t.Fatalf("lowering the spec failed: %v", err)
+	}
+	var s spec.Spec
+	if err := json.Unmarshal(out, &s); err != nil {
+		t.Fatalf("the lowered spec would not decode: %v", err)
+	}
+	return &s
+}
+
+func load(t *testing.T) []Vector {
+	t.Helper()
+	dir := filepath.Join("..", "..", "corpus")
+	paths, err := filepath.Glob(filepath.Join(dir, "*.json"))
+	if err != nil || len(paths) == 0 {
+		t.Fatalf("no corpus files under %s (err: %v)", dir, err)
+	}
+	sort.Strings(paths)
+
+	var out []Vector
+	for _, p := range paths {
+		b, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("reading %s: %v", p, err)
+		}
+		var f file
+		if err := json.Unmarshal(b, &f); err != nil {
+			t.Fatalf("decoding %s: %v", p, err)
+		}
+		out = append(out, f.Vectors...)
+	}
+	return out
+}
+
+// findUsage locates the CLI that lowers a spec.
+//
+// Not skipped when it is missing. A conformance suite that quietly passes because
+// it could not find its oracle is worse than one that fails: the whole point of
+// the corpus is that agreement is measured rather than assumed.
+func findUsage(t *testing.T) string {
+	t.Helper()
+	if bin := os.Getenv("USAGE_BIN"); bin != "" {
+		return bin
+	}
+	for _, p := range []string{
+		filepath.Join("..", "..", "target", "release", "usage"),
+		filepath.Join("..", "..", "target", "debug", "usage"),
+	} {
+		if _, err := os.Stat(p); err == nil {
+			abs, err := filepath.Abs(p)
+			if err == nil {
+				return abs
+			}
+		}
+	}
+	if p, err := exec.LookPath("usage"); err == nil {
+		return p
+	}
+	t.Fatal("the `usage` CLI is needed to lower each vector's spec, and was not found.\n" +
+		"Build it with `cargo build --release -p usage-cli`, or point USAGE_BIN at one.")
+	return ""
+}

--- a/go/conformance/conformance_test.go
+++ b/go/conformance/conformance_test.go
@@ -11,6 +11,7 @@
 package conformance
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -24,8 +25,14 @@ import (
 	"github.com/jdx/usage/go/internal/spec"
 )
 
-// Vector is one corpus case. Fields the Go parser does not consult — doc,
-// reference — are read anyway so that an unknown field can be spotted.
+// Vector is one corpus case.
+//
+// Every field the corpus can carry is declared here, including the ones binding
+// never consults, because the loader refuses unknown fields — see [load]. A
+// vector's meaning can be changed by a field this harness has not heard of:
+// `layer` is exactly that, and a Go suite that ignored it would answer
+// post-binding vectors it is not equipped for and report the wrong result with
+// confidence.
 type Vector struct {
 	ID     string            `json:"id"`
 	Doc    string            `json:"doc"`
@@ -260,9 +267,20 @@ func load(t *testing.T) []Vector {
 		if err != nil {
 			t.Fatalf("reading %s: %v", p, err)
 		}
+		// Unknown fields are an error rather than something to skip past. The
+		// corpus is shared, it grows, and a field added for everyone's benefit is
+		// no use to an implementation that silently drops it: `layer` decides
+		// whether a vector is this parser's to answer at all, so a suite that had
+		// ignored it when it arrived would have answered 22 vectors it cannot
+		// answer and called the results a pass. Failing to decode is how this
+		// harness finds out the corpus has moved.
+		dec := json.NewDecoder(bytes.NewReader(b))
+		dec.DisallowUnknownFields()
 		var f file
-		if err := json.Unmarshal(b, &f); err != nil {
-			t.Fatalf("decoding %s: %v", p, err)
+		if err := dec.Decode(&f); err != nil {
+			t.Fatalf("decoding %s: %v\n"+
+				"If the corpus has grown a field, teach Vector about it rather than "+
+				"relaxing this check.", p, err)
 		}
 		out = append(out, f.Vectors...)
 	}
@@ -271,17 +289,28 @@ func load(t *testing.T) []Vector {
 
 // findUsage locates the CLI that lowers a spec.
 //
-// Not skipped when it is missing. A conformance suite that quietly passes because
-// it could not find its oracle is worse than one that fails: the whole point of
-// the corpus is that agreement is measured rather than assumed.
+// Debug before release, which is the opposite of what looks natural. `mise run
+// test:go` depends on `build`, and `build` refreshes the *debug* binary — so on
+// any machine that has ever run `cargo build --release`, preferring release means
+// lowering every vector with a binary this run did not build and may be many
+// commits old. A stale oracle is the one failure mode a conformance suite cannot
+// afford, because it reports agreement with something nobody is shipping.
+//
+// PATH comes last for the same reason in reverse: an installed `usage` is the
+// least likely to match the working tree, so it is the fallback for running these
+// tests from outside the repo layout rather than the first choice.
+//
+// Not skipped when nothing is found. A conformance suite that quietly passes
+// because it could not find its oracle is worse than one that fails: the whole
+// point of the corpus is that agreement is measured rather than assumed.
 func findUsage(t *testing.T) string {
 	t.Helper()
 	if bin := os.Getenv("USAGE_BIN"); bin != "" {
 		return bin
 	}
 	for _, p := range []string{
-		filepath.Join("..", "..", "target", "release", "usage"),
 		filepath.Join("..", "..", "target", "debug", "usage"),
+		filepath.Join("..", "..", "target", "release", "usage"),
 	} {
 		if _, err := os.Stat(p); err == nil {
 			abs, err := filepath.Abs(p)
@@ -294,6 +323,7 @@ func findUsage(t *testing.T) string {
 		return p
 	}
 	t.Fatal("the `usage` CLI is needed to lower each vector's spec, and was not found.\n" +
-		"Build it with `cargo build --release -p usage-cli`, or point USAGE_BIN at one.")
+		"Run `mise run test:go`, which builds it first, or `cargo build -p usage-cli`,\n" +
+		"or point USAGE_BIN at one.")
 	return ""
 }

--- a/go/internal/spec/spec.go
+++ b/go/internal/spec/spec.go
@@ -1,0 +1,293 @@
+// Package spec reads a usage spec that has been lowered to JSON and builds the
+// static tables [argv] binds against.
+//
+// The spec's own format is KDL, and nothing here parses KDL: the `usage` CLI does
+// that, and `usage generate json` is the lowering. That division is deliberate.
+// A generated table is produced once, at build time, by a maintainer who already
+// has the usage CLI; a program that ships to end users carries the tables and
+// never sees a spec at all. Putting a KDL parser in this module would add a
+// dependency to every adopter's binary to solve a problem none of them have.
+//
+// So this package is used by two callers, both of them build-time: the code
+// generator, and the conformance suite, which builds tables per vector rather
+// than generating a package per vector.
+package spec
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/jdx/usage/go/argv"
+)
+
+// Spec is a usage spec as `usage generate json` writes it.
+//
+// Only the fields binding needs are described. The lowering carries much more —
+// help text, examples, completers, config — and leaving those out here is the
+// same split the hot path makes: this struct is the parse tables' source, and
+// help is a cold table generated separately.
+type Spec struct {
+	Name string `json:"name"`
+	Bin  string `json:"bin"`
+	Cmd  Cmd    `json:"cmd"`
+	// UnknownFlags is the CLI-wide default, which a command may override and
+	// which is otherwise inherited all the way down.
+	UnknownFlags string `json:"unknown_flags"`
+	// DefaultSubcommand is declared once, at the top, and names a subcommand of
+	// the root.
+	DefaultSubcommand string `json:"default_subcommand"`
+	Version           string `json:"version"`
+}
+
+// Cmd is one command in the lowered spec.
+type Cmd struct {
+	Name          string         `json:"name"`
+	Aliases       []string       `json:"aliases"`
+	HiddenAliases []string       `json:"hidden_aliases"`
+	Subcommands   map[string]Cmd `json:"subcommands"`
+	Args          []Arg          `json:"args"`
+	Flags         []Flag         `json:"flags"`
+	UnknownFlags  *string        `json:"unknown_flags"`
+}
+
+// Flag is one flag in the lowered spec.
+type Flag struct {
+	Name  string   `json:"name"`
+	Long  []string `json:"long"`
+	Short []string `json:"short"`
+	// Negate arrives with its dashes, as usage-lib stores it. The table wants the
+	// bare name.
+	Negate string `json:"negate"`
+	Global bool   `json:"global"`
+	// Var means the flag may be repeated, taking one value each time. It is not
+	// the same as a variadic argument, and the parser needs nothing for it: every
+	// occurrence is reported separately either way.
+	Var bool `json:"var"`
+	// Count means each occurrence is tallied rather than replacing the last.
+	Count bool `json:"count"`
+	// VarMax here bounds occurrences, which is a post-binding check. The bound
+	// binding cares about is the one on Arg.
+	VarMax int  `json:"var_max"`
+	Arg    *Arg `json:"arg"`
+}
+
+// Arg is one positional argument, or a flag's value, in the lowered spec.
+type Arg struct {
+	Name       string `json:"name"`
+	Required   bool   `json:"required"`
+	Var        bool   `json:"var"`
+	VarMax     int    `json:"var_max"`
+	VarMin     int    `json:"var_min"`
+	DoubleDash string `json:"double_dash"`
+}
+
+// Multi is how a flag accumulates when it is given more than once.
+type Multi uint8
+
+const (
+	// MultiNone means a later occurrence replaces an earlier one.
+	MultiNone Multi = iota
+	// MultiCount means occurrences are tallied.
+	MultiCount
+	// MultiVar means values are collected into a list.
+	MultiVar
+)
+
+// Tables builds the parse tables for a spec.
+//
+// Inheritance is resolved here rather than in the parser: each command's entry
+// holds the effective value, which is what a generated table would carry.
+func (s *Spec) Tables() *argv.Command {
+	b := &builder{}
+	root := b.command(&s.Cmd, unknownFlags(s.UnknownFlags, argv.UnknownFlagsValue))
+
+	// default_subcommand is a property of the spec rather than of a command, so it
+	// is resolved once, here, against the root's own subcommands. A name that
+	// answers to nothing is left unset: the spec is what it is, and a vector or a
+	// build that expects routing should fail loudly rather than have this guess.
+	if s.DefaultSubcommand != "" {
+		for _, sub := range root.Subcommands {
+			if sub.Name == s.DefaultSubcommand || contains(sub.Aliases, s.DefaultSubcommand) {
+				root.DefaultSubcommand = sub
+				break
+			}
+		}
+	}
+	return root
+}
+
+// MultiFlags reports which flags accumulate rather than replace, keyed by the
+// name the spec gives them.
+//
+// The parser deliberately does not know this: it reports each occurrence and lets
+// the caller decide what to do with it, because whether a second --tag replaces
+// the first or joins it is a question about the target type. Generated code
+// answers it by assigning to a field or appending to a slice; a harness with no
+// target type asks here.
+func (s *Spec) MultiFlags() map[string]Multi {
+	out := map[string]Multi{}
+	collectMulti(&s.Cmd, out)
+	return out
+}
+
+func collectMulti(c *Cmd, out map[string]Multi) {
+	for i := range c.Flags {
+		f := &c.Flags[i]
+		switch {
+		case f.Count:
+			out[f.Name] = MultiCount
+		case f.Var || (f.Arg != nil && f.Arg.Var):
+			out[f.Name] = MultiVar
+		}
+	}
+	for _, name := range sortedKeys(c.Subcommands) {
+		sub := c.Subcommands[name]
+		collectMulti(&sub, out)
+	}
+}
+
+type builder struct {
+	// key hands out identifiers. A Go generator sees the whole spec at once, so it
+	// can simply count where the Rust derive has to hash: two macro expansions
+	// cannot see each other, and two `go generate` runs over one spec can.
+	key uint64
+}
+
+func (b *builder) next() uint64 {
+	b.key++
+	return b.key
+}
+
+func (b *builder) command(c *Cmd, inherited argv.UnknownFlags) *argv.Command {
+	unknown := inherited
+	if c.UnknownFlags != nil {
+		unknown = unknownFlags(*c.UnknownFlags, inherited)
+	}
+
+	out := &argv.Command{
+		Name:         c.Name,
+		UnknownFlags: unknown,
+		Key:          b.next(),
+	}
+
+	if n := len(c.Aliases) + len(c.HiddenAliases); n > 0 {
+		out.Aliases = make([]string, 0, n)
+		out.Aliases = append(out.Aliases, c.Aliases...)
+		// A hidden alias selects a command just as a visible one does; hiding is
+		// about help output, which binding never reads.
+		out.Aliases = append(out.Aliases, c.HiddenAliases...)
+	}
+
+	for i := range c.Flags {
+		out.Flags = append(out.Flags, b.flag(&c.Flags[i]))
+	}
+	for i := range c.Args {
+		out.Args = append(out.Args, b.arg(&c.Args[i]))
+	}
+	for _, name := range sortedKeys(c.Subcommands) {
+		sub := c.Subcommands[name]
+		out.Subcommands = append(out.Subcommands, b.command(&sub, unknown))
+	}
+	return out
+}
+
+func (b *builder) flag(f *Flag) *argv.Flag {
+	out := &argv.Flag{
+		Key:        b.next(),
+		Name:       f.Name,
+		Longs:      f.Long,
+		Negate:     strings.TrimLeft(f.Negate, "-"),
+		TakesValue: f.Arg != nil,
+		Global:     f.Global,
+	}
+	for _, s := range f.Short {
+		if s != "" {
+			// One byte: a cluster is walked a byte at a time, so a multi-byte short
+			// could never be matched anyway.
+			out.Shorts = append(out.Shorts, s[0])
+		}
+	}
+	if f.Arg != nil && f.Arg.Var {
+		// Only a variadic argument is greedy. A var flag with a single-value argument
+		// is repeatable instead: one value per occurrence, which the parser gets by
+		// not collecting.
+		out.Variadic = true
+		// The bound on one occurrence's values, which is the argument's. A repeatable
+		// flag's own var_max counts occurrences and is checked after the parse, so it
+		// does not belong in this table.
+		out.VarMax = clampVarMax(f.Arg.VarMax)
+	}
+	return out
+}
+
+func (b *builder) arg(a *Arg) *argv.Arg {
+	out := &argv.Arg{
+		Key:        b.next(),
+		Name:       a.Name,
+		Var:        a.Var,
+		DoubleDash: doubleDash(a.DoubleDash),
+	}
+	if a.Var {
+		out.VarMax = clampVarMax(a.VarMax)
+	}
+	return out
+}
+
+// clampVarMax turns the spec's bound into the table's.
+//
+// Zero means unbounded in the table, which is also what an absent var_max lowers
+// to, so the two agree. A bound larger than a uint32 saturates rather than
+// wrapping: truncating four billion and one to one would read as "stop at once"
+// rather than "no real limit".
+func clampVarMax(n int) uint32 {
+	switch {
+	case n <= 0:
+		return 0
+	case n > int(^uint32(0)):
+		return ^uint32(0)
+	}
+	return uint32(n)
+}
+
+func unknownFlags(s string, fallback argv.UnknownFlags) argv.UnknownFlags {
+	switch strings.ToLower(s) {
+	case "error":
+		return argv.UnknownFlagsError
+	case "value":
+		return argv.UnknownFlagsValue
+	}
+	return fallback
+}
+
+func doubleDash(s string) argv.DoubleDash {
+	switch strings.ToLower(s) {
+	case "required":
+		return argv.DoubleDashRequired
+	case "preserve":
+		return argv.DoubleDashPreserve
+	case "automatic":
+		return argv.DoubleDashAutomatic
+	}
+	return argv.DoubleDashOptional
+}
+
+func contains(list []string, s string) bool {
+	for _, x := range list {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}
+
+// sortedKeys keeps table order stable. Go randomizes map iteration, and a
+// generator whose output reordered itself between runs would produce a diff on
+// every regeneration.
+func sortedKeys(m map[string]Cmd) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/mise.toml
+++ b/mise.toml
@@ -63,8 +63,12 @@ run = 'aube install && aube run docs:dev'
 alias = 't'
 run = 'cargo test --all --all-features'
 
+# The Go parser answers the same corpus the Rust one does, so its suite needs the
+# `usage` CLI: a vector's spec is KDL, and lowering it is the CLI's job rather than
+# something the Go module carries a parser for. `build` puts one on PATH.
 [tasks."test:go"]
 dir = 'go'
+depends = ['build']
 run = 'go test ./...'
 
 [tasks.lint]


### PR DESCRIPTION
The corpus has said from the start that it is plain JSON so an implementation in any language can run it, and that passing it is what "compatible" means. Nothing had taken that up: both runners were Rust, so the format's portability was a claim rather than a measurement.

This is a second implementation, in a second language, measured against the same vectors. **101 binding vectors pass.**

```
$ mise run test:go
ok  github.com/jdx/usage/go/argv
ok  github.com/jdx/usage/go/conformance
    123 vectors: 101 binding, 22 post-binding left to the layer above
```

The 22 post-binding vectors are skipped with the reason recorded, which is the same line usage-argv draws: they need to know a value's type, so they belong to the layer that owns the target struct. Skipping is per-vector from the `layer` field rather than inferred from the spec, so the exempt set cannot quietly grow.

## The three that failed first, and why none was the parser

Some vectors write `"cmd": []` where others omit `cmd`, and the harness was treating absent and empty as different answers. The corpus is the definition of correct about bindings, not about which spelling of "nothing" a JSON decoder produces, so the harness normalizes both.

## No KDL parser in the Go module, on purpose

A vector's spec is KDL, and `go/internal/spec` deliberately cannot read it — `usage generate json` does the lowering. That is the same split an adopter gets: tables are generated once at build time by a maintainer who has the usage CLI, and the shipped binary never sees a spec. Putting a KDL parser in this module would add a dependency to every adopter's binary to solve a problem none of them have. It is also why `test:go` now depends on `build`, and why the CI step runs in the job that already built the CLI.

The suite fails rather than skips when it cannot find that CLI. A conformance suite that quietly passes because it could not locate its oracle is worse than one that fails.

## Missing on purpose

Listed in `go/README.md`: the generator that emits tables from a spec, the typed layer that would answer those 22 vectors, help rendering, and completions. The hooks completions need — `Collecting`, `PendingArg`, `FlagsInScope`, `CommandStart` — are already on the parser from #921, since the whole point of them is that what is offered and what is accepted read the same scope rules.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test harness, docs, and CI task wiring only; no changes to Rust parsing or production CLI behavior beyond requiring a built `usage` binary for Go tests.
> 
> **Overview**
> Adds a **Go conformance runner** so the shared JSON corpus is exercised outside Rust: `go/conformance` loads corpus files, lowers each vector’s KDL spec via `usage generate json`, builds tables through **`go/internal/spec`**, and compares binding results to the expected JSON. **101 binding vectors pass**; **22 `post-binding` vectors are skipped** explicitly via the corpus `layer` field (same split as usage-argv).
> 
> The harness is strict about oracle and schema drift: it **fails if the `usage` CLI is missing** (prefers freshly built debug binary), **rejects unknown JSON fields**, and **normalizes empty vs omitted `cmd`/maps** so decoder spelling differences do not fail binding checks.
> 
> **CI and tasks** wire this in: `mise run test:go` now **depends on `build`**, and the main test workflow runs `test:go` in the job that already built the CLI (with a comment explaining why). Docs (`corpus/README.md`, `docs/spec/argv.md`, new `go/README.md`) document usage-go as the first non-Rust corpus consumer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30bdae0abf563babbb28a63b989db875aec6cb89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->