### PR TITLE
feat(derive): a command that takes nothing can be written that way

### DIFF
--- a/conformance/tests/unit_variants.rs
+++ b/conformance/tests/unit_variants.rs
@@ -1,0 +1,168 @@
+//! A command that takes nothing.
+//!
+//! clap lets one be a bare variant — `Sponsors,` — and the derive needed
+//! `Sponsors(Box<Sponsors>)` plus an empty struct plus, at the call site, a destructure to
+//! keep the payload from reading as dead code. communique carries all three today.
+//!
+//! Everything generated speaks to a struct — its tables, its metadata, its `build` — so rather
+//! than teach all of that about a variant with no struct, the derive writes the empty struct
+//! such a variant implies. Only the construction differs.
+
+use usage::Spec as LibSpec;
+use usage_argv::help;
+use usage_derive::{Args, Cli, Subcommands};
+
+/// Set things up
+#[derive(Args)]
+struct Init {
+    /// Overwrite what is there
+    #[usage(long)]
+    force: bool,
+}
+
+#[derive(Subcommands)]
+enum Command {
+    /// Set things up
+    Init(Box<Init>),
+    /// Show who pays for this
+    #[usage(effect = "read")]
+    Sponsors,
+    /// Kept out of help, and still a command
+    #[usage(hide)]
+    Secret,
+    /// Answers to another name too
+    #[usage(name = "licence", alias = "license")]
+    Licence,
+}
+
+/// A second set, with a bare variant spelled the same as the first's
+///
+/// The implied structs are named after the enum as well as the variant for exactly this: two
+/// of one name in a module is a worse error than the one being avoided, and it would land in
+/// the adopter's crate pointing at a struct they never wrote.
+#[derive(Subcommands)]
+enum Other {
+    /// A different command that happens to share a name
+    Sponsors,
+}
+
+/// A second tool sharing the module
+#[derive(Cli)]
+#[usage(bin = "other")]
+struct OtherCli {
+    #[usage(subcommand)]
+    command: Option<Other>,
+}
+
+/// A tool with commands that take nothing
+#[derive(Cli)]
+#[usage(bin = "ex")]
+struct Ex {
+    #[usage(subcommand)]
+    command: Option<Command>,
+}
+
+#[test]
+fn a_bare_variant_is_a_command() {
+    use std::ffi::OsStr;
+    let argv = [OsStr::new("sponsors")];
+    let parsed = Ex::parse_from(&argv).expect("should parse");
+    assert!(
+        matches!(parsed.command, Some(Command::Sponsors)),
+        "a bare variant is built without a payload, which is the only thing that differs"
+    );
+}
+
+#[test]
+fn it_reaches_the_spec_like_any_other_command() {
+    let spec: LibSpec = Ex::to_kdl().parse().expect("valid spec");
+    let sponsors = spec.cmd.subcommands.get("sponsors").expect("sponsors");
+    assert_eq!(sponsors.help.as_deref(), Some("Show who pays for this"));
+    // Nothing of its own, which is the point — and it still declares itself.
+    assert!(sponsors.flags.is_empty());
+    assert!(sponsors.args.is_empty());
+}
+
+#[test]
+fn the_attributes_a_variant_takes_still_work() {
+    let spec: LibSpec = Ex::to_kdl().parse().expect("valid spec");
+    // `hide` is a variant's own business and does not need a struct to say it.
+    assert!(spec.cmd.subcommands.get("secret").expect("secret").hide);
+    // As are `name` and `alias`.
+    let licence = spec.cmd.subcommands.get("licence").expect("licence");
+    assert!(licence.aliases.contains(&"license".to_string()));
+
+    use std::ffi::OsStr;
+    let argv = [OsStr::new("license")];
+    assert!(
+        matches!(
+            Ex::parse_from(&argv).expect("should parse").command,
+            Some(Command::Licence)
+        ),
+        "the alias reaches the same command"
+    );
+}
+
+#[test]
+fn it_is_listed_where_it_should_be_and_not_where_it_should_not() {
+    let page = help::render(Ex::spec(), Ex::spec().root.cmd, false).expect("a page");
+    assert!(page.contains("sponsors"), "{page}");
+    assert!(page.contains("Show who pays for this"), "{page}");
+    assert!(!page.contains("secret"), "hidden means hidden: {page}");
+
+    // And it has a page of its own, which says what it does and offers nothing to give it.
+    let sponsors = Ex::spec()
+        .root
+        .cmd
+        .subcommands
+        .iter()
+        .find(|c| c.name == "sponsors")
+        .expect("sponsors");
+    let page = help::render(Ex::spec(), sponsors, false).expect("a page");
+    assert!(page.starts_with("Show who pays for this"), "{page}");
+}
+
+#[test]
+fn the_struct_it_wraps_is_still_bound() {
+    // The other variants are unaffected: a bare one costs its siblings nothing.
+    use std::ffi::OsStr;
+    let argv = ["init", "--force"].map(OsStr::new);
+    let parsed = Ex::parse_from(&argv).expect("should parse");
+    let Some(Command::Init(init)) = parsed.command else {
+        panic!("expected init")
+    };
+    assert!(init.force);
+}
+
+#[test]
+fn two_enums_may_each_have_one_of_the_same_name() {
+    // Both compile, which is the assertion — an implied struct named only after the variant
+    // would collide here, in the adopter's crate, pointing at something they never wrote.
+    use std::ffi::OsStr;
+    let argv = [OsStr::new("sponsors")];
+    assert!(matches!(
+        Ex::parse_from(&argv).expect("should parse").command,
+        Some(Command::Sponsors)
+    ));
+    assert!(matches!(
+        OtherCli::parse_from(&argv).expect("should parse").command,
+        Some(Other::Sponsors)
+    ));
+}
+
+#[test]
+fn a_bare_variant_can_say_what_it_does_to_the_world() {
+    // `effect` is otherwise an `Args` attribute, because that is where a command declares
+    // itself — and a bare variant has no `Args`. The variant *is* the whole declaration, so it
+    // says it there and the struct written for it carries it. Without this, moving a command
+    // to a bare variant silently dropped its effect, which is how communique lost `sponsors`.
+    let spec: LibSpec = Ex::to_kdl().parse().expect("valid spec");
+    assert_eq!(
+        spec.cmd
+            .subcommands
+            .get("sponsors")
+            .expect("sponsors")
+            .effect,
+        Some(usage::SpecCommandEffect::Read)
+    );
+}

--- a/conformance/tests/unit_variants.rs
+++ b/conformance/tests/unit_variants.rs
@@ -35,6 +35,46 @@ enum Command {
     Licence,
 }
 
+/// Names that would collide if the two halves were run together
+///
+/// `Ambiguous::PairTwo` and the enum below spell `AmbiguousPairTwo` either way round, which is
+/// why the pieces are separated. And `r#type` is a keyword a CLI may well want as a command:
+/// its raw form prints as `r#type`, and `Ident::new` panics on the `#`.
+// Every Rust keyword is lower case, so a variant named after one is lower case too — there is
+// no way to write this fixture without the lint firing on the *fixture*. Nothing generated
+// needs it; that is what the length-prefixed struct name is for.
+#[allow(non_camel_case_types)]
+#[derive(Subcommands)]
+enum Ambiguous {
+    /// One
+    PairTwo,
+    /// A command named after a keyword
+    r#type,
+}
+
+/// A tool whose names are awkward
+#[derive(Cli)]
+#[usage(bin = "awkward")]
+struct AwkwardCli {
+    #[usage(subcommand)]
+    command: Option<Ambiguous>,
+}
+
+/// The other half of the collision
+#[derive(Subcommands)]
+enum AmbiguousPair {
+    /// Two
+    Two,
+}
+
+/// A tool sharing the module with it
+#[derive(Cli)]
+#[usage(bin = "pair")]
+struct PairCli {
+    #[usage(subcommand)]
+    command: Option<AmbiguousPair>,
+}
+
 /// A second set, with a bare variant spelled the same as the first's
 ///
 /// The implied structs are named after the enum as well as the variant for exactly this: two
@@ -165,4 +205,28 @@ fn a_bare_variant_can_say_what_it_does_to_the_world() {
             .effect,
         Some(usage::SpecCommandEffect::Read)
     );
+}
+
+#[test]
+fn awkward_names_do_not_collide_or_panic() {
+    // All four compile, which is the assertion. `Ambiguous::PairTwo` and
+    // `AmbiguousPair::Two` both read as `AmbiguousPairTwo` if the halves are simply run
+    // together, and `r#type` panics the macro outright if the raw prefix is not stripped —
+    // both landing in the adopter's crate, about a struct they never wrote.
+    use std::ffi::OsStr;
+    let argv = [OsStr::new("pair-two")];
+    assert!(matches!(
+        AwkwardCli::parse_from(&argv).expect("should parse").command,
+        Some(Ambiguous::PairTwo)
+    ));
+    let argv = [OsStr::new("type")];
+    assert!(matches!(
+        AwkwardCli::parse_from(&argv).expect("should parse").command,
+        Some(Ambiguous::r#type)
+    ));
+    let argv = [OsStr::new("two")];
+    assert!(matches!(
+        PairCli::parse_from(&argv).expect("should parse").command,
+        Some(AmbiguousPair::Two)
+    ));
 }

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -2317,6 +2317,32 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
     let ident = &subs.ident;
     let module = format_ident!("__usage_subs_{}", ident.to_string().to_lowercase());
 
+    // The structs the bare variants imply, written here so everything downstream keeps
+    // speaking to a struct. `Args` is derived on them rather than the impl being written out:
+    // one description of what an empty command is, and it is the one adopters already use.
+    let unit_structs = subs
+        .variants
+        .iter()
+        .filter(|v| v.unit)
+        .map(|v| {
+            let name = &v.ty;
+            // Whatever the variant said about the command, written where the command's
+            // metadata is actually built — and read there by the same code that reads it on
+            // any other `Args`.
+            let effect = v
+                .effect
+                .as_ref()
+                .map(|word| quote!(#[usage(effect = #word)]));
+            quote! {
+                #[doc(hidden)]
+                #[derive(::usage_derive::Args)]
+                #effect
+                pub struct #name {}
+            }
+        })
+        .collect::<Vec<_>>();
+    let unit_structs = unit_structs.into_iter();
+
     // One partial per variant, since a parse can only fill one but does not know
     // which until the word arrives.
     let partial_fields = subs.variants.iter().enumerate().map(|(i, v)| {
@@ -2444,14 +2470,26 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
         } else {
             built
         };
+        // A bare variant has nowhere to put what was built, and nothing was declared to go in
+        // it — but the build still runs, because that is where the command's own checks live.
+        let made = if v.unit {
+            quote! {{
+                let _ = #built;
+                #ident::#variant
+            }}
+        } else {
+            quote!(#ident::#variant(#built))
+        };
         quote! {
-            #i => ::std::result::Result::Ok(::std::option::Option::Some(
-                #ident::#variant(#built),
-            )),
+            #i => ::std::result::Result::Ok(::std::option::Option::Some(#made)),
         }
     });
 
     quote! {
+        // Beside the enum rather than inside the generated module: the variants name these
+        // types, and a type a variant cannot see is no use to it.
+        #(#unit_structs)*
+
         #[doc(hidden)]
         #[allow(
             non_upper_case_globals,

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -81,6 +81,22 @@
 //! [`usage_argv::spec::Subcommands`], whose associated consts a parent splices into
 //! its own `static` tables. Nothing is assembled at run time.
 //!
+//! A variant that holds nothing is a command with no flags and no arguments of its own:
+//!
+//! ```ignore
+//! #[derive(Subcommands)]
+//! enum Commands {
+//!     /// Install a tool
+//!     Install(Install),
+//!     /// Show who pays for this
+//!     #[usage(effect = "read")]
+//!     Sponsors,
+//! }
+//! ```
+//!
+//! `effect` goes on the variant there because there is no struct to put it on; everywhere else
+//! it belongs to the `Args`, and declaring it in both places is refused.
+//!
 //! A command inside a command is not a special case: an `Args` struct carries a
 //! `subcommand` field exactly as the root does, to any depth, and generates the same
 //! code for it. mise reaches four levels, so one was never going to be enough.

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -2007,6 +2007,14 @@ pub struct Subcommands {
     pub variants: Vec<Variant>,
 }
 
+/// The name of the struct a bare variant implies.
+///
+/// The enum's name is in it because two enums in one module may each declare a `Sponsors`, and
+/// two structs of one name is a worse error than the one this is avoiding.
+fn unit_struct_ident(enum_ident: &syn::Ident, variant: &syn::Ident) -> syn::Ident {
+    syn::Ident::new(&format!("__Usage{enum_ident}{variant}"), variant.span())
+}
+
 /// One variant: a command name and the struct holding its flags and arguments.
 pub struct Variant {
     pub ident: syn::Ident,
@@ -2019,6 +2027,20 @@ pub struct Variant {
     /// The command name, which is the variant name in kebab-case unless `name`
     /// says otherwise.
     pub name: String,
+    /// What running this command does to the world, for a variant that holds nothing.
+    ///
+    /// `effect` is otherwise an `Args` attribute, because that is where a command declares
+    /// itself. A bare variant has no `Args` to put it on, and the variant *is* the whole
+    /// declaration — so it says it here and the generated struct carries it.
+    /// Kept as the word rather than as tokens: it is written straight back out as an
+    /// attribute on the struct this variant implies, and parsed there by the same code that
+    /// reads every other one — so there is one definition of what the word may be.
+    pub effect: Option<String>,
+    /// Whether the variant holds nothing and had its struct written for it.
+    ///
+    /// Only the *construction* differs — `Command::Sponsors` rather than
+    /// `Command::Sponsors(x)`. Everything else goes through the struct as usual.
+    pub unit: bool,
     /// The struct the variant wraps, with any `Box` taken off.
     ///
     /// Everything generated speaks to the struct — its tables, its partial, its `build` —
@@ -2061,8 +2083,18 @@ impl Subcommands {
         let variants = data
             .variants
             .iter()
-            .map(Variant::from_variant)
+            .map(|v| Variant::from_variant(v, &input.ident))
             .collect::<syn::Result<Vec<_>>>()?;
+        for v in &variants {
+            if v.effect.is_some() && !v.unit {
+                return Err(syn::Error::new_spanned(
+                    &v.ident,
+                    "`effect` belongs on the struct this variant wraps, where the command's \
+                     other properties are declared — a variant may carry one only when it \
+                     holds nothing, because then there is no struct to put it on",
+                ));
+            }
+        }
 
         // Every name a command answers to, its aliases included: the parser takes the
         // first table entry that matches, so a name claimed twice means one of the two
@@ -2123,11 +2155,12 @@ impl Subcommands {
 }
 
 impl Variant {
-    fn from_variant(variant: &syn::Variant) -> syn::Result<Self> {
+    fn from_variant(variant: &syn::Variant, enum_ident: &syn::Ident) -> syn::Result<Self> {
         let (help, long_help) = doc_comment(&variant.attrs)?;
         let mut name = to_kebab(&variant.ident.to_string());
         let mut aliases: Vec<String> = Vec::new();
         let mut hidden_aliases: Vec<String> = Vec::new();
+        let mut effect = None;
         let mut hide = false;
         let mut help_attr: Option<String> = None;
         let mut long_help_attr: Option<String> = None;
@@ -2141,6 +2174,13 @@ impl Variant {
                     "alias" => aliases.extend(selectors(&meta)?),
                     "alias_hidden" => hidden_aliases.extend(selectors(&meta)?),
                     "hide" => hide = flag_value(&meta)?,
+                    "effect" => {
+                        // Checked where it is written, and checked again by the struct's own
+                        // derive, which is where it is read — one definition of the word.
+                        let word = string_value(&meta)?;
+                        effect_value(&meta)?;
+                        effect = Some(word);
+                    }
                     // As on a field: a comment's paragraph is flowed, so text whose line
                     // breaks matter is declared instead.
                     "help" => help_attr = Some(string_value(&meta)?),
@@ -2177,14 +2217,23 @@ impl Variant {
         // and arguments. A variant with no fields would have nothing to parse into,
         // and named fields would make the variant itself the struct — which is a
         // second way to say the same thing.
+        // A bare variant is a command with nothing of its own — `Sponsors`, which clap also
+        // allows. The struct it implies is written for it, so everything downstream keeps
+        // speaking to a struct and only the construction differs.
+        let mut unit = false;
         let held = match &variant.fields {
             Fields::Unnamed(unnamed) if unnamed.unnamed.len() == 1 => unnamed.unnamed[0].ty.clone(),
+            Fields::Unit => {
+                unit = true;
+                let ident = unit_struct_ident(enum_ident, &variant.ident);
+                syn::parse_quote!(#ident)
+            }
             other => {
                 return Err(syn::Error::new_spanned(
                     other,
-                    "a subcommand variant wraps exactly one struct, as in \
-                     `Install(Install)` or `Install(Box<Install>)`: that struct is where \
-                     its flags and arguments are declared",
+                    "a subcommand variant wraps one struct, as in `Install(Install)` or \
+                     `Install(Box<Install>)` — that struct is where its flags and arguments \
+                     are declared — or holds nothing at all, for a command that has none",
                 ));
             }
         };
@@ -2205,6 +2254,8 @@ impl Variant {
             ident: variant.ident.clone(),
             hide,
             name,
+            effect,
+            unit,
             ty,
             boxed,
             aliases,
@@ -2722,6 +2773,26 @@ mod tests {
             err.contains("`min_usage_version` belongs on the root"),
             "unhelpful: {err}"
         );
+    }
+
+    #[test]
+    fn only_a_bare_variant_declares_its_own_effect() {
+        // A variant that wraps a struct has somewhere to put it, and two places to say one
+        // thing is two answers waiting to disagree.
+        let input = syn::parse_str::<syn::DeriveInput>(
+            r#"
+            enum Commands {
+                #[usage(effect = "write")]
+                Install(Install),
+            }
+        "#,
+        )
+        .expect("valid Rust");
+        let Err(err) = Subcommands::from_input(&input) else {
+            panic!("should not have compiled")
+        };
+        let err = err.to_string();
+        assert!(err.contains("belongs on the struct"), "unhelpful: {err}");
     }
 
     #[test]

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -5,6 +5,7 @@
 //! actually interacts with — in one place.
 
 use proc_macro2::Span;
+use syn::ext::IdentExt as _;
 use syn::spanned::Spanned;
 use syn::{Attribute, Data, DeriveInput, Expr, ExprLit, Fields, Lit, Meta, Type};
 
@@ -2012,7 +2013,20 @@ pub struct Subcommands {
 /// The enum's name is in it because two enums in one module may each declare a `Sponsors`, and
 /// two structs of one name is a worse error than the one this is avoiding.
 fn unit_struct_ident(enum_ident: &syn::Ident, variant: &syn::Ident) -> syn::Ident {
-    syn::Ident::new(&format!("__Usage{enum_ident}{variant}"), variant.span())
+    // `unraw` first: a raw identifier prints as `r#type`, and `Ident::new` *panics* on the
+    // `#` — a proc-macro panic, which is the worst way for a CLI to learn it used a keyword
+    // for a command name.
+    let enum_name = enum_ident.unraw();
+    let variant_name = variant.unraw();
+    // Length-prefixed rather than separated: plain concatenation is ambiguous — `Foo::BarBaz`
+    // and `FooBar::Baz` both read as `FooBarBaz` — and an underscore between the parts would
+    // land a `non_camel_case_types` warning in the adopter's crate about a type they never
+    // wrote. A count is unambiguous and still spells a name Rust is happy with.
+    let n = enum_name.to_string().chars().count();
+    syn::Ident::new(
+        &format!("__Usage{n}{enum_name}{variant_name}"),
+        variant.span(),
+    )
 }
 
 /// One variant: a command name and the struct holding its flags and arguments.
@@ -2157,7 +2171,9 @@ impl Subcommands {
 impl Variant {
     fn from_variant(variant: &syn::Variant, enum_ident: &syn::Ident) -> syn::Result<Self> {
         let (help, long_help) = doc_comment(&variant.attrs)?;
-        let mut name = to_kebab(&variant.ident.to_string());
+        // `unraw` first: `r#type` is how a variant named after a keyword prints, and a command
+        // called `r#type` is one no user could type. `type` is what they meant.
+        let mut name = to_kebab(&variant.ident.unraw().to_string());
         let mut aliases: Vec<String> = Vec::new();
         let mut hidden_aliases: Vec<String> = Vec::new();
         let mut effect = None;
@@ -2314,7 +2330,7 @@ impl ValueEnum {
                      in it: `cfg` the whole enum instead",
                 ));
             }
-            let mut name = to_kebab(&variant.ident.to_string());
+            let mut name = to_kebab(&variant.ident.unraw().to_string());
             for attr in attrs(&variant.attrs) {
                 for meta in nested(attr)? {
                     let path = meta.path().clone();


### PR DESCRIPTION
The last of the communique follow-ups. clap lets a command with no options be a bare variant; the derive wanted three things to say the same:

```rust
// before
#[derive(Args)] struct Sponsors {}
enum Command { Sponsors(Box<Sponsors>) }
// ...and at the call site, because `_` leaves the payload unread and dead_code is an error in CI:
Command::Sponsors(args) => { let cli::Sponsors {} = *args; sponsors() }

// after
enum Command { #[usage(effect = "read")] Sponsors }
Command::Sponsors => sponsors(),
```

Everything generated speaks to a struct — its tables, its metadata, its `build` — so rather than teach all of that about a variant with no struct, **the derive writes the empty struct such a variant implies** and points the variant at it. Only the construction differs.

The struct is named after the enum as well as the variant: two enums in one module may each declare a `Sponsors`, and two structs of one name is a worse error than the one being avoided — it would land in the adopter's crate, pointing at something they never wrote. A test has two such enums.

## `effect` moves with it

This is the part I did not see coming. `effect` is an `Args` attribute, because that is where a command declares itself — and a bare variant has none. Porting communique's `sponsors` over dropped `effect=read` from its spec, silently. Its in-sync test caught it, which is the second time that test has paid for itself.

So a variant carries `effect` when it holds nothing, and the written struct receives it as the same attribute, read by the same code. **Refused on a variant that does wrap a struct**: two places to say one thing is two answers waiting to disagree.

## What communique deletes

```
 src/cli.rs  | 7 +------
 src/main.rs | 8 +-------
```

## Verification

| mutation | result |
|---|---|
| a bare variant still builds with a payload | generated code fails to compile |
| the implied struct is not written | generated code fails to compile |
| the struct name omits the enum | generated code fails to compile (two enums, one name) |
| `effect` on a struct-wrapping variant is accepted | FAILED |

The third **survived at first** — my fixture had only one enum, so nothing collided. Seven conformance tests, workspace suite green, clippy clean, gate green over mise's 211 commands.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `Subcommands` codegen and parsing/build paths for all unit variants; mistakes could break spec/help/effect metadata or cause name collisions, though coverage is broad in new conformance tests.
> 
> **Overview**
> **Subcommands can be written as bare unit variants** (e.g. `Sponsors,`) instead of `Sponsors(Box<Sponsors>)` plus a hand-written empty `Args` struct. The derive emits a hidden `#[derive(Args)]` empty struct per unit variant so parsing, spec, help, and `build` still go through the same `CommandArgs` path; only enum construction changes (`Command::Sponsors` vs wrapping a payload).
> 
> **`#[usage(effect = "...")]` on the variant** is allowed when the variant holds nothing (forwarded onto the generated struct). Putting `effect` on a variant that wraps a struct is a **compile error**.
> 
> **Naming hardening:** implied structs use length-prefixed `__Usage{n}{Enum}{Variant}` ids so two enums in one module can both have `Sponsors`; variant ids use `unraw()` so `r#type` becomes command name `type` and macro id generation does not panic.
> 
> Adds conformance tests in `unit_variants.rs` and crate docs for the pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99f2622ead3830fac47effaa52cccd25f3b12295. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->