### PR TITLE
feat(spec): say that one flag needs another, which nothing here could

### DIFF
--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -462,6 +462,12 @@ pub struct FlagMeta<'a> {
     /// flag win, this reports it: the combination has no meaning, so honouring one
     /// side silently would hide a mistake.
     pub conflicts: &'a [&'a str],
+    /// Flags that must also be given when this one is.
+    ///
+    /// The positive form of [`conflicts`](Self::conflicts), and the mirror image of
+    /// [`required_if`](Self::required_if): the same rule written on the flag that
+    /// imposes it rather than on the flag it lands on.
+    pub requires: &'a [&'a str],
     /// Flags that make this one necessary.
     pub required_if: &'a [&'a str],
     /// Flags that make this one unnecessary.
@@ -491,6 +497,7 @@ impl FlagMeta<'_> {
         var_max: None,
         overrides: &[],
         conflicts: &[],
+        requires: &[],
         required_if: &[],
         required_unless: &[],
         help_heading: None,
@@ -911,6 +918,7 @@ fn write_flag(out: &mut String, meta: &FlagMeta<'_>, depth: usize) -> core::fmt:
     write_single_default(out, meta.default)?;
     write_single_list(out, "overrides", meta.overrides)?;
     write_single_list(out, "conflicts", meta.conflicts)?;
+    write_single_list(out, "requires", meta.requires)?;
     write_single_list(out, "required_if", meta.required_if)?;
     write_single_list(out, "required_unless", meta.required_unless)?;
 
@@ -920,6 +928,7 @@ fn write_flag(out: &mut String, meta: &FlagMeta<'_>, depth: usize) -> core::fmt:
         || meta.default.len() > 1
         || meta.overrides.len() > 1
         || meta.conflicts.len() > 1
+        || meta.requires.len() > 1
         || meta.required_if.len() > 1
         || meta.required_unless.len() > 1;
     if !has_children {
@@ -936,6 +945,7 @@ fn write_flag(out: &mut String, meta: &FlagMeta<'_>, depth: usize) -> core::fmt:
     write_many_defaults(out, meta.default, inner)?;
     write_many_list(out, "overrides", meta.overrides, inner)?;
     write_many_list(out, "conflicts", meta.conflicts, inner)?;
+    write_many_list(out, "requires", meta.requires, inner)?;
     write_many_list(out, "required_if", meta.required_if, inner)?;
     write_many_list(out, "required_unless", meta.required_unless, inner)?;
     if meta.flag.takes_value {

--- a/conformance/tests/derive.rs
+++ b/conformance/tests/derive.rs
@@ -730,6 +730,15 @@ struct Related {
     /// Where to write
     #[usage(long, required_if = "--stdin")]
     out: Option<String>,
+    /// Sign the output
+    #[usage(long, requires("--key", "--identity"))]
+    sign: bool,
+    /// The signing key
+    #[usage(long)]
+    key: Option<String>,
+    /// Who is signing
+    #[usage(long)]
+    identity: Option<String>,
 }
 
 #[test]
@@ -749,6 +758,13 @@ fn flag_relationships_reach_the_spec() {
         vec!["--file".to_string(), "--url".to_string()]
     );
     assert_eq!(flag("out").required_if, vec!["--stdin".to_string()]);
+    // Two selectors, so the emitted KDL takes the child-node spelling rather than the
+    // property one — the same pair of shapes `conflicts` has, and both have to survive
+    // being parsed back by usage-lib.
+    assert_eq!(
+        flag("sign").requires,
+        vec!["--key".to_string(), "--identity".to_string()]
+    );
     assert_eq!(flag("color").overrides, vec!["--plain".to_string()]);
     assert_eq!(
         flag("file").required_unless,
@@ -762,12 +778,19 @@ fn flag_relationships_reach_the_spec() {
         "{}",
         Related::to_kdl()
     );
+    assert!(
+        Related::to_kdl().contains(r#"requires "--key" "--identity""#),
+        "{}",
+        Related::to_kdl()
+    );
 
     // And the same declaration still parses: a satisfied set of relationships is
     // invisible, which is the point.
     let a = argv(["--stdin", "--out", "o"]);
     let rel = Related::parse_from(&a).expect("should parse");
     assert!(rel.stdin);
+    // `--sign` was not given, so what it requires is not asked for.
+    assert!(!rel.sign);
     assert!(rel.color && !rel.plain);
     assert_eq!(rel.out.as_deref(), Some("o"));
     assert!(rel.file.is_none());

--- a/conformance/tests/derive.rs
+++ b/conformance/tests/derive.rs
@@ -791,6 +791,8 @@ fn flag_relationships_reach_the_spec() {
     assert!(rel.stdin);
     // `--sign` was not given, so what it requires is not asked for.
     assert!(!rel.sign);
+    assert!(rel.key.is_none());
+    assert!(rel.identity.is_none());
     assert!(rel.color && !rel.plain);
     assert_eq!(rel.out.as_deref(), Some("o"));
     assert!(rel.file.is_none());

--- a/conformance/tests/post_binding.rs
+++ b/conformance/tests/post_binding.rs
@@ -224,6 +224,12 @@ struct Rel {
     /// How many at once
     #[usage(long, default = "4", required_if = "--stdin")]
     jobs: Option<String>,
+    /// Sign the output
+    #[usage(long, requires("--key"))]
+    sign: bool,
+    /// The key to sign with
+    #[usage(long)]
+    key: Option<String>,
 }
 
 #[test]
@@ -256,6 +262,32 @@ fn conflicting_flags_cannot_both_be_given() {
         Rel::parse_from(&a).expect("should parse").file.as_deref(),
         Some("f")
     );
+}
+
+#[test]
+fn a_requirement_names_the_flag_that_was_not_given() {
+    // Reported as the *other* flag missing rather than as something wrong with
+    // `--sign`, which is what clap says for an unmet `requires` and the thing a user
+    // can act on: the fix is to type `--key`, not to delete `--sign`.
+    let a = argv(["--file", "f", "--sign"]);
+    assert!(matches!(
+        Rel::parse_from(&a),
+        Err(Error::MissingRequired { name: "key" })
+    ));
+
+    // Satisfied.
+    let a = argv(["--file", "f", "--sign", "--key", "k"]);
+    let rel = Rel::parse_from(&a).expect("should parse");
+    assert!(rel.sign);
+    assert_eq!(rel.key.as_deref(), Some("k"));
+
+    // Nothing is imposed when the flag that declares the requirement is absent, which
+    // is what makes this different from plain required-ness: `--key` is optional until
+    // `--sign` asks for it.
+    let a = argv(["--file", "f"]);
+    let rel = Rel::parse_from(&a).expect("should parse");
+    assert!(!rel.sign);
+    assert!(rel.key.is_none());
 }
 
 #[test]

--- a/conformance/tests/post_binding.rs
+++ b/conformance/tests/post_binding.rs
@@ -227,6 +227,9 @@ struct Rel {
     /// Sign the output
     #[usage(long, requires("--key"))]
     sign: bool,
+    /// Tag the output, which needs a job count — and one is always there
+    #[usage(long, requires("--jobs"))]
+    tag: bool,
     /// The key to sign with
     #[usage(long)]
     key: Option<String>,
@@ -288,6 +291,17 @@ fn a_requirement_names_the_flag_that_was_not_given() {
     let rel = Rel::parse_from(&a).expect("should parse");
     assert!(!rel.sign);
     assert!(rel.key.is_none());
+}
+
+#[test]
+fn a_default_on_the_required_flag_satisfies_the_requirement() {
+    // The check is not emitted at all when the flag a requirement names has a default,
+    // because such a flag can never be missing — the same rule plain required-ness
+    // follows, and usage-lib agrees.
+    let a = argv(["--file", "f", "--tag"]);
+    let rel = Rel::parse_from(&a).expect("the defaulted flag is not missing");
+    assert!(rel.tag);
+    assert_eq!(rel.jobs.as_deref(), Some("4"));
 }
 
 #[test]

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -2829,11 +2829,20 @@ fn post_binding(cli: &Cli) -> TokenStream {
     // one that named it, which is what clap says: an unmet `requires` is a required
     // argument that was not provided. That also means no new `Error` variant — the hot
     // path's `Result` does not grow to carry a check that only ever fires on the cold one.
+    //
+    // A target with a default is skipped outright, since it can never be missing.
     let requirement_checks = cli.fields.iter().flat_map(move |f| {
         let given = format_ident!("__given_{}", f.ident);
         f.requires.iter().filter_map(move |selector| {
             // Resolved in the model, which rejects a selector naming nothing.
             let other = cli.field_for_selector(selector)?;
+            // A flag with a default always has a value, so the requirement it satisfies
+            // can never fail — the same reason plain required-ness skips such a field.
+            // Decided at compile time, so the check is not merely always-true at run
+            // time, it is not there.
+            if !other.default.is_empty() {
+                return None;
+            }
             let other_given = format_ident!("__given_{}", other.ident);
             let other_name = &other.name;
             Some(quote! {

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -741,6 +741,7 @@ fn flag_meta(i: usize, field: &Field, owner: &syn::Ident) -> TokenStream {
     // the struct says.
     let overrides = &field.overrides;
     let conflicts = &field.conflicts;
+    let requires = &field.requires;
     let required_if = &field.required_if;
     let required_unless = &field.required_unless;
 
@@ -773,6 +774,7 @@ fn flag_meta(i: usize, field: &Field, owner: &syn::Ident) -> TokenStream {
             var_max: #var_max,
             overrides: &[#(#overrides),*],
             conflicts: &[#(#conflicts),*],
+            requires: &[#(#requires),*],
             required_if: &[#(#required_if),*],
             required_unless: &[#(#required_unless),*],
             ..FlagMeta::EMPTY
@@ -2819,6 +2821,31 @@ fn post_binding(cli: &Cli) -> TokenStream {
         })
     });
 
+    // The positive form, and the same `__given_*` reading for the same reasons: a `bool`
+    // given as `false` is still a flag the user asked for, and env fallback has already
+    // run, so a requirement satisfied from the environment is satisfied.
+    //
+    // Reported as the *other* flag being missing rather than as something wrong with the
+    // one that named it, which is what clap says: an unmet `requires` is a required
+    // argument that was not provided. That also means no new `Error` variant — the hot
+    // path's `Result` does not grow to carry a check that only ever fires on the cold one.
+    let requirement_checks = cli.fields.iter().flat_map(move |f| {
+        let given = format_ident!("__given_{}", f.ident);
+        f.requires.iter().filter_map(move |selector| {
+            // Resolved in the model, which rejects a selector naming nothing.
+            let other = cli.field_for_selector(selector)?;
+            let other_given = format_ident!("__given_{}", other.ident);
+            let other_name = &other.name;
+            Some(quote! {
+                if partial.#given && !partial.#other_given {
+                    return ::std::result::Result::Err(
+                        ::usage_argv::Error::MissingRequired { name: #other_name },
+                    );
+                }
+            })
+        })
+    });
+
     // `required_if` and `required_unless` are the same question asked two ways: which
     // other flags decide whether this one had to be given. Neither needs to know the
     // order they arrived in — only whether they arrived — so both are answered here,
@@ -2883,6 +2910,7 @@ fn post_binding(cli: &Cli) -> TokenStream {
         // more useful of the two answers when a conflict has also left something
         // unfilled, and it is the one usage-lib reports.
         #(#conflict_checks)*
+        #(#requirement_checks)*
         #(#flattened_checks)*
         #(#required_checks)*
         #(#relationship_required_checks)*

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -193,6 +193,7 @@
 //! | `arg` | force a field to be positional |
 //! | `overrides = "--other"` | a flag this one displaces, the last given winning |
 //! | `conflicts = "--other"` | a flag this one cannot be given with |
+//! | `requires = "--other"` | a flag that must also be given when this one is |
 //! | `required_if = "--other"` | a flag whose presence makes this one necessary |
 //! | `required_unless = "--other"` | a flag whose presence makes this one unnecessary |
 //!

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -159,6 +159,14 @@ pub struct Field {
     /// Flags this one cannot be given with. Checked after the parse: whether a flag
     /// is unwelcome depends on the whole command line, not on the token itself.
     pub conflicts: Vec<String>,
+    /// Flags that must also be given when this one is. Checked after the parse for the
+    /// same reason `conflicts` is: the flag that satisfies the requirement may still be
+    /// ahead of the one that imposes it.
+    ///
+    /// The same rule `required_if` states from the other end, and worth having both: this
+    /// one lives on the flag the rule is about, which is where clap puts it and where a
+    /// reader looks for it.
+    pub requires: Vec<String>,
     /// Flags whose presence makes this one necessary.
     pub required_if: Vec<String>,
     /// Flags whose presence makes this one unnecessary.
@@ -712,6 +720,7 @@ impl Cli {
             for (option, selectors) in [
                 ("overrides", &field.overrides),
                 ("conflicts", &field.conflicts),
+                ("requires", &field.requires),
                 ("required_if", &field.required_if),
                 ("required_unless", &field.required_unless),
             ] {
@@ -834,6 +843,7 @@ impl Field {
             var_max: None,
             overrides: Vec::new(),
             conflicts: Vec::new(),
+            requires: Vec::new(),
             required_if: Vec::new(),
             required_unless: Vec::new(),
             hide: false,
@@ -925,6 +935,7 @@ impl Field {
             var_max: None,
             overrides: Vec::new(),
             conflicts: Vec::new(),
+            requires: Vec::new(),
             required_if: Vec::new(),
             required_unless: Vec::new(),
             hide: false,
@@ -980,6 +991,7 @@ impl Field {
         let mut var_max: Option<usize> = None;
         let mut overrides: Vec<String> = Vec::new();
         let mut conflicts: Vec<String> = Vec::new();
+        let mut requires: Vec<String> = Vec::new();
         let mut required_if: Vec<String> = Vec::new();
         let mut required_unless: Vec<String> = Vec::new();
 
@@ -1066,6 +1078,7 @@ impl Field {
                     // there is nothing to lose by accepting the shorter form.
                     "overrides" => overrides = selectors(&meta)?,
                     "conflicts" => conflicts = selectors(&meta)?,
+                    "requires" => requires = selectors(&meta)?,
                     "required_if" => required_if = selectors(&meta)?,
                     "required_unless" => required_unless = selectors(&meta)?,
                     "value_enum" => value_enum = flag_value(&meta)?,
@@ -1108,7 +1121,7 @@ impl Field {
                                  `short`, `negate`, `global`, `var`, `variadic`, \
                                  `count`, `hide`, `arg`, `env`, `default`, `choices`, \
                                  `var_min`, `var_max`, `value_enum`, `overrides`, \
-                                 `conflicts`, `required_if`, \
+                                 `conflicts`, `requires`, `required_if`, \
                                  `required_unless`, `help_heading`, `value_name`, \
                                  `required`, and `double_dash`"
                             ),
@@ -1334,6 +1347,7 @@ impl Field {
         for (option, selectors) in [
             ("overrides", &overrides),
             ("conflicts", &conflicts),
+            ("requires", &requires),
             ("required_if", &required_if),
             ("required_unless", &required_unless),
         ] {
@@ -1614,6 +1628,7 @@ impl Field {
             var_max,
             overrides,
             conflicts,
+            requires,
             required_if,
             required_unless,
             hide,

--- a/docs/spec/integrations/clap.md
+++ b/docs/spec/integrations/clap.md
@@ -53,6 +53,18 @@ mycli --usage-spec | usage generate md --out-file docs.md
 mycli --usage-spec | usage generate manpage --out-file mycli.1
 ```
 
+## What a generated spec cannot carry
+
+The spec is produced by reading a `clap::Command` back, so it can only carry what clap
+exposes a getter for. [`requires`](/spec/reference/flag#requires) is the notable one it
+does not: `Arg::requires`, `requires_if`, `requires_ifs` and `requires_all` are setters
+with no reader, so a flag declared with them arrives in the spec with no requirement on
+it, and everything downstream — help, docs, completions — describes a CLI without that
+constraint.
+
+Declaring it in the spec is the way to have it. A CLI that keeps its source of truth in
+clap can add the node to a hand-written overlay spec merged with the generated one.
+
 ## Links
 
 - [crate on crates.io](https://crates.io/crates/clap_usage)

--- a/docs/spec/reference/flag.md
+++ b/docs/spec/reference/flag.md
@@ -31,9 +31,14 @@ flag "--file <file>" required_if="--dir"     // if --dir is set, --file must als
 flag "--file <file>" required_unless="--dir" // either --file or --dir must be present
 flag "--file <file>" overrides="--stdin" // --file and --stdin override each other; the last one wins
 flag "--file <file>" conflicts="--stdin" // --file and --stdin cannot be given together
+flag "--out <path>" requires="--format"  // giving --out means --format must be given too
 
 flag "--stdin" {
   conflicts "--file" "--url" // several, one per argument
+}
+
+flag "--sign" {
+  requires "--key" "--identity" // several, and all of them are needed
 }
 
 flag "--shell <shell>" {
@@ -68,6 +73,28 @@ mistake, and silently honouring one of them hides it.
 
 A conflict holds in either direction, so declaring it once is enough; it applies to flags
 that were actually given, not to defaults.
+
+## `requires`
+
+The positive form: giving this flag means the flags it names must be given too. Every
+selector has to be satisfied, so `requires "--key" "--identity"` means both. Nothing
+happens when the declaring flag is absent — a requirement is a consequence of using the
+flag, not a rule about the command line as a whole.
+
+`required_if` says the same thing from the other end, and both exist because they are
+written in different places. `--out` needing `--format` is `requires="--format"` on
+`--out`, or `required_if="--out"` on `--format`; the first keeps the rule on the flag it
+is about, which is usually where a reader looks for it.
+
+A value from the environment or a default satisfies a requirement, on the same principle
+`conflicts` follows: the question is whether the other flag ended up with a value, not
+how it got one.
+
+::: warning
+A spec generated from a clap command never carries this. clap has `Arg::requires` as a
+setter with no getter, so [the clap integration](/spec/integrations/clap) cannot read it
+back out — a CLI that wants the constraint in its spec has to declare it here.
+:::
 
 ## `global`
 

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -1160,6 +1160,22 @@ fn parse_partial_with_env(
                 });
             }
         }
+        // The positive form, checked in the same pass and under the same rule: a value
+        // from the environment satisfies a requirement, because the question is whether
+        // the other flag has a value rather than how it got one. A flag that was
+        // overridden away has not been given, so it cannot satisfy anything either —
+        // which is what `selector_is_explicit` already accounts for.
+        //
+        // Reported as the missing flag rather than as something wrong with the flag that
+        // named it, which is what clap says too: an unmet `requires` is a required
+        // argument that was not provided. Named by its own name, resolved through the
+        // same matcher, so a `requires="-f"` reports `--force` rather than the selector.
+        for other in &flag.requires {
+            if !selector_is_explicit(other, &out, &overridden_flags, custom_env) {
+                let name = selector_flag_name(other, &out).unwrap_or_else(|| other.clone());
+                out.errors.push(UsageErr::MissingFlag(name));
+            }
+        }
     }
 
     for flag in unique_flags(out.available_flags.values()) {
@@ -1293,6 +1309,19 @@ fn selector_is_explicit(
                 && !overridden_flags.contains(&flag.name)
                 && (out.flags.contains_key(flag) || flag_has_env(flag, custom_env))
         })
+}
+
+/// The name of the flag a selector points at, for an error that has to name it.
+///
+/// `selector_is_explicit` only answers yes or no, which is all a check needs; a message
+/// about a flag that is *missing* has to say which one, and the selector may be a short
+/// form or an alias rather than the name.
+fn selector_flag_name(selector: &str, out: &ParseOutput) -> Option<String> {
+    out.available_flags
+        .values()
+        .chain(out.flags.keys())
+        .find(|flag| flag_matches_selector(flag, selector))
+        .map(|flag| flag.name.clone())
 }
 
 fn apply_flag_overrides(
@@ -2563,6 +2592,49 @@ flag "--file <file>" required_unless="--stdin"
             let parsed = parse(&spec, &input(&["test"])).unwrap();
             assert_eq!(first_string_value(&parsed), "dev");
         }
+    }
+
+    #[test]
+    fn a_requirement_names_the_flag_that_is_missing() {
+        // Reported as the missing flag rather than as something wrong with `--out`,
+        // which is what clap says for an unmet `requires` and what a user can act on.
+        let spec: Spec = "name \"ex\"\nbin \"ex\"\nflag \"--out <p>\" requires=\"--format\"\nflag \"--format <f>\"\n"
+            .parse()
+            .unwrap();
+
+        let err = parse(&spec, &input(&["ex", "--out", "a.txt"])).unwrap_err();
+        assert!(
+            err.to_string().contains("format"),
+            "the missing flag should be named: {err}"
+        );
+
+        // Satisfied, in either order.
+        for words in [
+            &["ex", "--out", "a.txt", "--format", "json"][..],
+            &["ex", "--format", "json", "--out", "a.txt"][..],
+        ] {
+            parse(&spec, &input(words)).unwrap_or_else(|e| panic!("{words:?}: {e}"));
+        }
+
+        // Nothing happens when the flag that imposes the rule is absent: a requirement
+        // is a consequence of using the flag, not a rule about the command line.
+        parse(&spec, &input(&["ex"])).expect("a bare invocation requires nothing");
+    }
+
+    #[test]
+    fn a_requirement_is_satisfied_by_a_short_form() {
+        // The selector may spell the other flag any way it answers to, so the check
+        // resolves it the way every other selector is resolved rather than matching
+        // text. The error names the flag, not the selector.
+        let spec: Spec =
+            "name \"ex\"\nbin \"ex\"\nflag \"--sign\" requires=\"-k\"\nflag \"-k --key <k>\"\n"
+                .parse()
+                .unwrap();
+
+        parse(&spec, &input(&["ex", "--sign", "--key", "x"])).expect("--key satisfies -k");
+
+        let err = parse(&spec, &input(&["ex", "--sign"])).unwrap_err();
+        assert!(err.to_string().contains("key"), "{err}");
     }
 
     #[test]

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -1171,7 +1171,7 @@ fn parse_partial_with_env(
         // argument that was not provided. Named by its own name, resolved through the
         // same matcher, so a `requires="-f"` reports `--force` rather than the selector.
         for other in &flag.requires {
-            if !selector_is_explicit(other, &out, &overridden_flags, custom_env) {
+            if !selector_is_satisfied(other, &out, &overridden_flags, custom_env) {
                 let name = selector_flag_name(other, &out).unwrap_or_else(|| other.clone());
                 out.errors.push(UsageErr::MissingFlag(name));
             }
@@ -1322,6 +1322,34 @@ fn selector_flag_name(selector: &str, out: &ParseOutput) -> Option<String> {
         .chain(out.flags.keys())
         .find(|flag| flag_matches_selector(flag, selector))
         .map(|flag| flag.name.clone())
+}
+
+/// Whether a selector's flag ended up with a value, however it got one.
+///
+/// The rule for a *positive* relationship, and the difference from
+/// [`selector_is_explicit`] is deliberate. A negative rule — `conflicts`, or a group's
+/// exclusivity — has to count only what was given, or a flag with a default would
+/// conflict with everything and no command line would parse. A positive one asks whether
+/// the flag it names has a value, and a default is a value: that is already how plain
+/// `required`, `required_if` and `required_unless` read a default, and `requires` saying
+/// otherwise would have made the same flag missing here and present ten lines below.
+fn selector_is_satisfied(
+    selector: &str,
+    out: &ParseOutput,
+    overridden_flags: &HashSet<String>,
+    custom_env: Option<&HashMap<String, String>>,
+) -> bool {
+    if selector_is_explicit(selector, out, overridden_flags, custom_env) {
+        return true;
+    }
+    out.available_flags
+        .values()
+        .chain(out.flags.keys())
+        .filter(|flag| flag_matches_selector(flag, selector))
+        .any(|flag| {
+            !overridden_flags.contains(&flag.name)
+                && (!flag.default.is_empty() || flag.arg.iter().any(|a| !a.default.is_empty()))
+        })
 }
 
 fn apply_flag_overrides(
@@ -2619,6 +2647,30 @@ flag "--file <file>" required_unless="--stdin"
         // Nothing happens when the flag that imposes the rule is absent: a requirement
         // is a consequence of using the flag, not a rule about the command line.
         parse(&spec, &input(&["ex"])).expect("a bare invocation requires nothing");
+    }
+
+    #[test]
+    fn a_default_satisfies_a_requirement() {
+        // The flag it names has a value, which is the question a requirement asks. Read
+        // any other way, `--format` would be missing here and present ten lines further
+        // down, where plain required-ness reads the same default as filling it.
+        let spec: Spec = "name \"ex\"\nbin \"ex\"\nflag \"--out <p>\" requires=\"--format\"\nflag \"--format <f>\" default=\"json\"\n"
+            .parse()
+            .unwrap();
+
+        parse(&spec, &input(&["ex", "--out", "a.txt"]))
+            .expect("a defaulted flag is not a missing one");
+    }
+
+    #[test]
+    fn an_environment_value_satisfies_a_requirement() {
+        let spec: Spec = "name \"ex\"\nbin \"ex\"\nflag \"--out <p>\" requires=\"--format\"\nflag \"--format <f>\" env=\"EX_FORMAT\"\n"
+            .parse()
+            .unwrap();
+
+        assert!(parse(&spec, &input(&["ex", "--out", "a.txt"])).is_err());
+        parse_with_env(&spec, &["ex", "--out", "a.txt"], &[("EX_FORMAT", "json")])
+            .expect("the environment supplies it");
     }
 
     #[test]

--- a/lib/src/spec/builder.rs
+++ b/lib/src/spec/builder.rs
@@ -247,6 +247,24 @@ impl SpecFlagBuilder {
         self
     }
 
+    /// Add a flag that must also be given when this one is
+    pub fn require(mut self, flag: impl Into<String>) -> Self {
+        self.inner.requires.push(flag.into());
+        self
+    }
+
+    /// Add flags that must also be given when this one is
+    pub fn requires<I, S>(mut self, flags: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.inner
+            .requires
+            .extend(flags.into_iter().map(Into::into));
+        self
+    }
+
     /// Set environment variable name
     /// Heading to list this under in help output.
     pub fn help_heading(mut self, help_heading: impl Into<String>) -> Self {

--- a/lib/src/spec/flag.rs
+++ b/lib/src/spec/flag.rs
@@ -102,6 +102,20 @@ pub struct SpecFlag {
     /// generated from a clap command was losing it.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub conflicts: Vec<String>,
+    /// Flags that must also be given when this one is.
+    ///
+    /// The positive form of [`SpecFlag::conflicts`], and not the same statement as
+    /// [`SpecFlag::required_if`] read backwards: `required_if` lives on the flag that
+    /// becomes required, so declaring `--out` needs `--format` means editing `--format`,
+    /// away from the flag the rule is about. `requires` lives on the flag that imposes
+    /// the rule, which is where clap puts it and where a reader looks for it.
+    ///
+    /// Nothing generated from a clap command can carry this: clap 4.6 has `Arg::requires`
+    /// and its variants as setters with no getter, so a `Command` cannot be asked what it
+    /// requires. A CLI that declares it here gains a constraint its generated spec never
+    /// had.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub requires: Vec<String>,
     /// Raises the effect of the command when this flag is supplied.
     /// See [`crate::spec::effect::SpecCommandEffect`]; never lowers it.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -162,6 +176,7 @@ impl SpecFlag {
                 "negate" => flag.negate = v.ensure_string().map(Some)?,
                 "overrides" => flag.overrides = vec![v.ensure_string()?],
                 "conflicts" => flag.conflicts = vec![v.ensure_string()?],
+                "requires" => flag.requires = vec![v.ensure_string()?],
                 "effect" => {
                     let raw = v.ensure_string()?;
                     match raw.parse() {
@@ -264,6 +279,13 @@ impl SpecFlag {
                 }
                 "overrides" => {
                     flag.overrides = child
+                        .ensure_arg_len(1..)?
+                        .args()
+                        .map(|arg| arg.ensure_string())
+                        .collect::<Result<Vec<_>>>()?;
+                }
+                "requires" => {
+                    flag.requires = child
                         .ensure_arg_len(1..)?
                         .args()
                         .map(|arg| arg.ensure_string())
@@ -415,6 +437,16 @@ impl From<&SpecFlag> for KdlNode {
                 conflicts.push(string_entry(None, target));
             }
             children.nodes_mut().push(conflicts);
+        }
+        if flag.requires.len() == 1 {
+            node.push(string_entry(Some("requires"), &flag.requires[0]));
+        } else if !flag.requires.is_empty() {
+            let children = node.children_mut().get_or_insert_with(KdlDocument::new);
+            let mut requires = KdlNode::new("requires");
+            for target in &flag.requires {
+                requires.push(string_entry(None, target));
+            }
+            children.nodes_mut().push(requires);
         }
         if let Some(env) = &flag.env {
             node.push(string_entry(Some("env"), env));
@@ -577,6 +609,11 @@ impl From<&clap::Arg> for SpecFlag {
             required_if: vec![],
             required_unless: vec![],
             conflicts: vec![],
+            // clap 4.6 has `Arg::requires` and its variants as setters with no getter, so
+            // there is nothing to read here however the `Arg` was built. Left empty rather
+            // than guessed at, and counted by `gen-shadow` as a thing the clap dialect
+            // cannot carry.
+            requires: vec![],
             help,
             help_long,
             help_md: None,
@@ -714,6 +751,43 @@ mod tests {
 
         let reparsed: Spec = spec.to_string().parse().unwrap();
         assert_eq!(reparsed.cmd.flags[1].conflicts.len(), 2, "{spec}");
+    }
+
+    #[test]
+    fn requires_round_trips_in_both_spellings() {
+        // The same two spellings `conflicts` has, because it is the same shape of
+        // statement: a property for one selector, a child node for several.
+        let spec: Spec = "flag \"--out <p>\" requires=\"--format\"\nflag \"--sign\" {\n  requires \"--key\" \"--identity\"\n}\nflag \"--format <f>\"\nflag \"--key <k>\"\nflag \"--identity <i>\"\n"
+            .parse()
+            .unwrap();
+        assert_eq!(spec.cmd.flags[0].requires, vec!["--format".to_string()]);
+        assert_eq!(
+            spec.cmd.flags[1].requires,
+            vec!["--key".to_string(), "--identity".to_string()]
+        );
+
+        let reparsed: Spec = spec.to_string().parse().unwrap();
+        assert_eq!(reparsed.cmd.flags[0].requires, vec!["--format".to_string()]);
+        assert_eq!(reparsed.cmd.flags[1].requires.len(), 2, "{spec}");
+    }
+
+    #[test]
+    fn requires_cannot_come_across_from_clap() {
+        // Not an oversight to be fixed later: clap 4 has `Arg::requires` as a setter
+        // with no getter and keeps the field private, so there is nothing here to read.
+        // Asserted rather than left implied, because an empty vector otherwise looks
+        // like a bug in the bridge — and because a future clap that *does* expose it
+        // should fail this test rather than pass silently.
+        let cmd = clap::Command::new("ex")
+            .arg(clap::Arg::new("out").long("out").requires("format"))
+            .arg(clap::Arg::new("format").long("format"));
+        let spec = Spec::from(&cmd);
+        let out = spec.cmd.flags.iter().find(|f| f.name == "out").unwrap();
+        assert!(
+            out.requires.is_empty(),
+            "clap exposes no getter for `requires`; if this now fails, the bridge can \
+             carry it and `SpecFlag::requires` should say so"
+        );
     }
 
     #[cfg(feature = "clap")]

--- a/xtask/src/shadow.rs
+++ b/xtask/src/shadow.rs
@@ -650,6 +650,9 @@ fn usage_flag_opts(
     if !flag.conflicts.is_empty() {
         opts.push(selector_list("conflicts", &flag.conflicts));
     }
+    if !flag.requires.is_empty() {
+        opts.push(selector_list("requires", &flag.requires));
+    }
     if !flag.required_if.is_empty() {
         opts.push(selector_list("required_if", &flag.required_if));
     }
@@ -776,6 +779,14 @@ fn clap_flag_opts(
     }
     // A relationship names the field it points at, so a selector the struct does not
     // declare is dropped rather than guessed at.
+    // `requires` is the one asymmetric entry: clap has the setter, so the shadow can write
+    // it, and clap exposes no getter, so a spec regenerated from that command comes back
+    // without it. Counted rather than emitted, because the shadow's job is to say what the
+    // clap dialect can carry *round trip* — writing it and silently losing it on the way
+    // back would make the clap side look more faithful than it is.
+    if !flag.requires.is_empty() {
+        skipped.note("`requires` on a flag");
+    }
     for (option, selectors) in [
         ("overrides_with", &flag.overrides),
         ("conflicts_with", &flag.conflicts),


### PR DESCRIPTION
Stacked on #919 — review that first; this PR's diff is the second commit.

The spec could say `conflicts`, `overrides`, `required_if` and `required_unless`, and had no way to say the positive form. `requires` is the last blocker in PLAN.md's derive-v1 list.

```kdl
flag "--out <path>" requires="--format"
flag "--sign" {
  requires "--key" "--identity"   // several, and all of them are needed
}
```

```rust
#[usage(long, requires("--key", "--identity"))]
sign: bool,
```

### Why not just `required_if`

It states the same rule from the other end, and both stay. `--out` needing `--format` is `requires="--format"` on `--out`, or `required_if="--out"` on `--format`. Only the first keeps the rule beside the flag it is about, which is usually where a reader looks for it — and it is the spelling anyone arriving from clap already knows.

### Wired the whole way through

A constraint only one parser enforces is worse than none, so: the KDL node in both spellings (property for one selector, child node for several), usage-lib's check, the derive attribute with its selectors resolved at **compile time**, usage-argv's cold metadata, and the emitted KDL that docs, manpages and completions read.

An unmet requirement is reported as the **other flag missing** rather than as something wrong with the flag that named it — which is what clap says, and what a user can act on: the fix is to type `--key`, not to delete `--sign`. That also means no new `Error` variant, so the hot path's `Result` does not grow for a check that only ever fires on the cold one.

A value from the environment or a default satisfies a requirement, matching `conflicts`: the question is whether the other flag ended up with a value, not how it got one.

### The bridge does not carry it

`clap_usage` reads a `clap::Command` back through public getters, and clap 4.6 has `Arg::requires`, `requires_if`, `requires_ifs` and `requires_all` as setters with no reader, with the field `pub(crate)`. So there is nothing to read, whatever the `Arg` was built with.

`requires_cannot_come_across_from_clap` asserts that, rather than leaving the empty vector looking like a bug in the bridge — and it will fail if a future clap exposes a getter, which is when we would want to know.

`gen-shadow` counts `requires` against the clap dialect for a related reason: clap *can be written* with `requires`, so the shadow could emit it, and a spec regenerated from that command would come back without it. Counting it keeps the clap side from looking more faithful than it is.

`docs/spec/integrations/clap.md` now says this out loud, since a CLI generating its spec from clap silently loses the constraint everywhere downstream.

### Tests

- `requires_round_trips_in_both_spellings` — property and child-node forms, through `to_string()` and back
- `requires_cannot_come_across_from_clap` — the bridge limit, asserted
- `a_requirement_names_the_flag_that_is_missing` / `a_requirement_is_satisfied_by_a_short_form` — usage-lib, including a selector spelled `-k` resolving to `--key`
- `a_requirement_names_the_flag_that_was_not_given` — the derive, plus the absent-flag case that makes this different from plain required-ness
- `flag_relationships_reach_the_spec` — the emitted KDL takes the child-node spelling for two selectors, and usage-lib parses it back

`cargo test --all --all-features` and `cargo clippy --all --all-features -- -D warnings` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches post-parse validation in usage-lib and derive-generated checks; behavior is well-tested but wrong satisfaction rules (defaults/env/overrides) would change CLI acceptance for derived binaries.
> 
> **Overview**
> Adds **`requires`** so a flag can declare that other flags must be present when it is used — the positive counterpart to **`conflicts`** and the mirror of **`required_if`** on the imposing flag.
> 
> **Spec & metadata:** `requires` is on `FlagMeta` / `SpecFlag`, parsed and emitted in KDL (single property or child node for multiple selectors), with builder helpers and argv spec serialization.
> 
> **Parsing:** usage-lib validates requirements after binding (alongside conflicts), using **`selector_is_satisfied`** so defaults and env values count; failures report the **missing target flag** (`MissingFlag` / derive `MissingRequired`), not the flag that declared the rule. The derive emits post-parse checks and skips targets that have defaults.
> 
> **Derive:** `#[usage(requires = "--other")]` with compile-time selector validation; flag-only, like other inter-flag relationships.
> 
> **Clap gap:** Generated clap specs cannot round-trip `requires` (no getter); docs and `gen-shadow` document/count this instead of silently emitting it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89866b8b37ba0f2060b2d788a362067f0a58e1af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->