### PR TITLE
test(spec): import the argv questions clap's suite answers and ours did not

### DIFF
--- a/corpus/01-long-flags.json
+++ b/corpus/01-long-flags.json
@@ -38,6 +38,13 @@
       "expect": { "ok": { "flags": { "set": "a=b" } } }
     },
     {
+      "id": "long-value-attached-leading-equals",
+      "doc": "Only the first `=` separates, seen from the other side: `--set==a` is a value of `=a` rather than an empty value followed by junk.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--set <kv>\"\n",
+      "argv": ["--set==a"],
+      "expect": { "ok": { "flags": { "set": "=a" } } }
+    },
+    {
       "id": "long-value-attached-empty",
       "doc": "`--flag=` binds the empty string. Present-but-empty is a different state from absent, and only the attached form can express it.",
       "spec": "name \"ex\"\nbin \"ex\"\nflag \"--jobs <n>\"\n",
@@ -52,6 +59,13 @@
       "expect": { "ok": { "flags": { "force": true } } }
     },
     {
+      "id": "long-boolean-with-attached-value",
+      "doc": "`--force=yes` on a flag that holds no value sets the flag and drops the value. Handing the leftover to the positionals would re-split one token into two, filling an argument the caller never typed a word for; clap rejects the token outright, which a spec parsing a command line it does not own cannot do.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--force\"\narg \"[file]\"\n",
+      "argv": ["--force=yes"],
+      "expect": { "ok": { "flags": { "force": true } } }
+    },
+    {
       "id": "long-value-attached-flaglike",
       "doc": "An attached value binds even when it looks like a flag: `=` has already settled where the value came from.",
       "spec": "name \"ex\"\nbin \"ex\"\nflag \"--jobs <n>\"\nflag \"--force\"\n",
@@ -60,6 +74,20 @@
       "reference": {
         "diverges": "usage-lib binds `force` instead and leaves `jobs` unset, treating the attached value as a separate flag token."
       }
+    },
+    {
+      "id": "long-value-detached-empty",
+      "doc": "An empty token is not flag-like, so `--jobs \"\"` binds the empty string. The attached form is the only way to write an empty value in one token, not the only way to pass one.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--jobs <n>\"\n",
+      "argv": ["--jobs", ""],
+      "expect": { "ok": { "flags": { "jobs": "" } } }
+    },
+    {
+      "id": "long-value-is-one-token",
+      "doc": "A value is the token the shell produced, never re-split: `--include a,b` is one pattern containing a comma. Parsers that split on a delimiter make `,` unpassable, which is why clap stopped doing it by default in 4.0 and specs generated from clap assume it is off.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--include <pattern>\" var=#true\n",
+      "argv": ["--include", "a,b"],
+      "expect": { "ok": { "flags": { "include": ["a,b"] } } }
     },
     {
       "id": "long-value-missing",
@@ -74,6 +102,16 @@
       "spec": "name \"ex\"\nbin \"ex\"\nflag \"--jobs <n>\"\nflag \"--force\"\n",
       "argv": ["--jobs", "--force"],
       "expect": { "error": "missing_flag_value" }
+    },
+    {
+      "id": "long-value-rejects-the-separator",
+      "doc": "A `--` is flag-like too, so it cannot be swallowed as a detached value: the separator belongs to the command line, not to whichever flag happens to precede it.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--jobs <n>\"\narg \"[file]\"\n",
+      "argv": ["--jobs", "--", "x"],
+      "expect": { "error": "missing_flag_value" },
+      "reference": {
+        "diverges": "usage-lib skips the separator and gives `jobs` the word after it, so `ex --jobs -- x` silently means `ex --jobs=x` and the separator is lost."
+      }
     },
     {
       "id": "long-value-accepts-negative-number",
@@ -95,6 +133,34 @@
       "spec": "name \"ex\"\nbin \"ex\"\nflag \"--force\"\n",
       "argv": ["--for"],
       "expect": { "error": "unexpected_arg" }
+    },
+    {
+      "id": "long-many-dashes-names-nothing",
+      "doc": "A run of dashes is read as a long flag whose name happens to be dashes, matches nothing, and so becomes a word like any other unrecognized flag. There is no separate rule for `---`, and only a bare `--` is the separator.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"[file]\"\n",
+      "argv": ["-----"],
+      "expect": { "ok": { "args": { "file": "-----" } } }
+    },
+    {
+      "id": "long-alias-binds-the-flag-name",
+      "doc": "A flag may declare several long names; the extra ones are aliases, and every one of them binds under the flag's name. Renaming a flag is done by adding a name, not by breaking the old one.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--force --overwrite\"\n",
+      "argv": ["--overwrite"],
+      "expect": { "ok": { "flags": { "force": true } } }
+    },
+    {
+      "id": "long-repeated-keeps-the-last",
+      "doc": "A flag that is neither `var` nor `count` may still be given twice, and the later occurrence wins. A repeat is a correction — typically a wrapper appending to a command line it did not write — so the last word on the subject is the one that counts.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--jobs <n>\"\n",
+      "argv": ["--jobs", "1", "--jobs", "2"],
+      "expect": { "ok": { "flags": { "jobs": "2" } } }
+    },
+    {
+      "id": "long-boolean-repeated",
+      "doc": "The same for a flag holding no value: giving `--force` twice is not an error and not a count, just true.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--force\"\n",
+      "argv": ["--force", "--force"],
+      "expect": { "ok": { "flags": { "force": true } } }
     },
     {
       "id": "long-repeated-var",

--- a/corpus/01-long-flags.json
+++ b/corpus/01-long-flags.json
@@ -196,6 +196,13 @@
       "expect": { "ok": { "flags": { "color": false } } }
     },
     {
+      "id": "long-negation-with-attached-value",
+      "doc": "Dropping a value the flag cannot hold does not drop which form was typed: `--no-color=yes` still binds false. The two rules meet here, and reading the whole token to decide the form would make the negation depend on whether a value happened to be attached.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--color\" negate=\"--no-color\" default=#true\n",
+      "argv": ["--no-color=yes"],
+      "expect": { "ok": { "flags": { "color": false } } }
+    },
+    {
       "id": "long-negation-default",
       "doc": "With neither form given, a negatable flag takes its declared default.",
       "spec": "name \"ex\"\nbin \"ex\"\nflag \"--color\" negate=\"--no-color\" default=#true\n",

--- a/corpus/02-short-flags.json
+++ b/corpus/02-short-flags.json
@@ -38,6 +38,34 @@
       "expect": { "ok": { "flags": { "jobs": "8" } } }
     },
     {
+      "id": "short-value-equals-leading-equals",
+      "doc": "Only one `=` is a separator, so `-j==8` binds `=8`. A value that begins with `=` is reachable, rather than being eaten by a second round of separator-stripping.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-j --jobs <n>\"\n",
+      "argv": ["-j==8"],
+      "expect": { "ok": { "flags": { "jobs": "=8" } } }
+    },
+    {
+      "id": "short-value-equals-empty",
+      "doc": "`-j=` binds the empty string, matching `--jobs=`. Both attached forms can express present-but-empty.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-j --jobs <n>\"\n",
+      "argv": ["-j="],
+      "expect": { "ok": { "flags": { "jobs": "" } } }
+    },
+    {
+      "id": "short-value-detached-empty",
+      "doc": "An empty token is not flag-like, so it is an ordinary detached value here too.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-j --jobs <n>\"\n",
+      "argv": ["-j", ""],
+      "expect": { "ok": { "flags": { "jobs": "" } } }
+    },
+    {
+      "id": "short-value-detached-bare-dash",
+      "doc": "`-f -` binds `-`, the conventional name for stdin. A lone dash is not flag-like, so the rule refusing flag-like detached values does not reach it — without that, `sort -o -` could not be written.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-f --file <file>\"\n",
+      "argv": ["-f", "-"],
+      "expect": { "ok": { "flags": { "file": "-" } } }
+    },
+    {
       "id": "short-value-missing",
       "doc": "A value-taking short at the end of the command line is an error.",
       "spec": "name \"ex\"\nbin \"ex\"\nflag \"-j --jobs <n>\"\n",
@@ -73,6 +101,13 @@
       "expect": { "ok": { "args": { "file": "-az" } } }
     },
     {
+      "id": "short-boolean-with-attached-value-is-not-a-bundle",
+      "doc": "`=` is a separator only for a short that takes a value. After one that does not, it is just an unrecognized letter, so `-f=yes` is not a bundle and `-f` is not set — the whole token becomes a word, as `-az` does.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-f --force\"\narg \"[file]\"\n",
+      "argv": ["-f=yes"],
+      "expect": { "ok": { "args": { "file": "-f=yes" } } }
+    },
+    {
       "id": "short-count",
       "doc": "A `count` flag records how many times it appeared, so `-vvv` is three.",
       "spec": "name \"ex\"\nbin \"ex\"\nflag \"-v --verbose\" count=#true\n",
@@ -85,6 +120,13 @@
       "spec": "name \"ex\"\nbin \"ex\"\nflag \"-v --verbose\" count=#true\n",
       "argv": ["-v", "-v"],
       "expect": { "ok": { "flags": { "verbose": [true, true] } } }
+    },
+    {
+      "id": "short-bundle-with-count",
+      "doc": "A counting short keeps counting inside a bundle, so `-avv` is `-a` once and `-v` twice.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-a --all\"\nflag \"-v --verbose\" count=#true\n",
+      "argv": ["-avv"],
+      "expect": { "ok": { "flags": { "all": true, "verbose": [true, true] } } }
     },
     {
       "id": "bare-dash-is-positional",

--- a/corpus/03-positionals.json
+++ b/corpus/03-positionals.json
@@ -130,6 +130,20 @@
       }
     },
     {
+      "id": "arg-empty-word",
+      "doc": "An empty token is a word, so it fills an argument rather than being skipped. A shell that produced `\"\"` meant to pass something, and dropping it would shift every argument after it.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"[file]\"\n",
+      "argv": [""],
+      "expect": { "ok": { "args": { "file": "" } } }
+    },
+    {
+      "id": "arg-value-is-one-token",
+      "doc": "A variadic collects tokens, not fields: `a,b` is one value however many commas it holds. Splitting is the caller's business, as it is for a flag's value.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"<files>...\"\n",
+      "argv": ["a,b", "c"],
+      "expect": { "ok": { "args": { "files": ["a,b", "c"] } } }
+    },
+    {
       "id": "arg-value-looks-like-negative-number",
       "doc": "A negative number is a value, not an unknown flag. A leading `-` followed by a digit cannot begin a flag name, so the token is offered to the next argument.",
       "spec": "name \"ex\"\nbin \"ex\"\narg \"<offset>\"\n",

--- a/corpus/04-subcommands.json
+++ b/corpus/04-subcommands.json
@@ -52,6 +52,13 @@
       "expect": { "ok": { "args": { "target": "other" } } }
     },
     {
+      "id": "cmd-no-abbreviation",
+      "doc": "A unique prefix of a subcommand name does not select it, for the same reason `--for` does not match `--force`: adding a command would otherwise change what an existing command line means. The word falls through to the positionals instead.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"[target]\"\ncmd \"install\"\n",
+      "argv": ["inst"],
+      "expect": { "ok": { "args": { "target": "inst" } } }
+    },
+    {
       "id": "cmd-name-wins-over-arg",
       "doc": "When a word could be either a subcommand or a positional value, the subcommand wins. A CLI that declares both cannot be given a positional whose text equals a subcommand name \u2014 mise documents exactly this hazard for tasks that share a name with a command.",
       "spec": "name \"ex\"\nbin \"ex\"\narg \"[target]\"\ncmd \"install\"\n",

--- a/corpus/06-double-dash.json
+++ b/corpus/06-double-dash.json
@@ -32,6 +32,13 @@
       }
     },
     {
+      "id": "dd-subcommand-word-is-a-value",
+      "doc": "After the separator a word no longer routes, so `ex -- install` passes the string `install` to the argument instead of running the command. Stopping flag interpretation stops command selection with it: both are ways a token can mean something other than data.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"[file]\"\ncmd \"install\"\n",
+      "argv": ["--", "install"],
+      "expect": { "ok": { "args": { "file": "install" } } }
+    },
+    {
       "id": "dd-consumed-not-a-value",
       "doc": "The separator itself is consumed rather than bound to an argument.",
       "spec": "name \"ex\"\nbin \"ex\"\narg \"<a>\"\narg \"[b]\"\n",

--- a/corpus/07-env-and-defaults.json
+++ b/corpus/07-env-and-defaults.json
@@ -46,6 +46,58 @@
       "layer": "post-binding"
     },
     {
+      "id": "env-value-is-one-token",
+      "doc": "An environment value is one value, whatever whitespace or commas it contains. It is not a command line and is never split into several.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--include <pattern>\" env=\"EX_INCLUDE\"\n",
+      "argv": [],
+      "env": { "EX_INCLUDE": "a b,c" },
+      "expect": { "ok": { "flags": { "include": "a b,c" } } },
+      "layer": "post-binding"
+    },
+    {
+      "id": "env-does-not-add-to-a-flag-the-command-line-gave",
+      "doc": "The environment fills what argv left empty; it does not contribute another occurrence to a repeatable flag that was given. A wrapper exporting a default must not silently append it to what the caller typed.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--include <pattern>\" var=#true env=\"EX_INCLUDE\"\n",
+      "argv": ["--include", "a", "--include", "b"],
+      "env": { "EX_INCLUDE": "z" },
+      "expect": { "ok": { "flags": { "include": ["a", "b"] } } },
+      "layer": "post-binding"
+    },
+    {
+      "id": "env-sets-a-flag-that-holds-no-value",
+      "doc": "A flag with no argument is set by its env var when the value reads as true.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--verbose\" env=\"EX_VERBOSE\"\n",
+      "argv": [],
+      "env": { "EX_VERBOSE": "1" },
+      "expect": { "ok": { "flags": { "verbose": true } } },
+      "layer": "post-binding"
+    },
+    {
+      "id": "env-false-does-not-set-a-flag",
+      "doc": "`EX_VERBOSE=false` leaves the flag false rather than setting it because the variable exists. Presence cannot be the test: a variable exported as `false` by a parent process is the caller saying no.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--verbose\" env=\"EX_VERBOSE\"\n",
+      "argv": [],
+      "env": { "EX_VERBOSE": "false" },
+      "expect": { "ok": { "flags": { "verbose": false } } },
+      "layer": "post-binding"
+    },
+    {
+      "id": "env-zero-does-not-set-a-flag",
+      "doc": "`0` is false as well, matching `1` being true. The pair is what a shell script writes.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--verbose\" env=\"EX_VERBOSE\"\n",
+      "argv": [],
+      "env": { "EX_VERBOSE": "0" },
+      "expect": { "ok": { "flags": { "verbose": false } } },
+      "layer": "post-binding"
+    },
+    {
+      "id": "default-does-not-supply-a-missing-flag-value",
+      "doc": "A default fills a flag that was never given, not one that was given without its value. `ex --jobs` is still a missing value, since the two states differ and only the first is what a default is for.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--jobs <n>\" default=\"4\"\n",
+      "argv": ["--jobs"],
+      "expect": { "error": "missing_flag_value" }
+    },
+    {
       "id": "default-fills-absent-arg",
       "doc": "Defaults work the same way for positionals.",
       "spec": "name \"ex\"\nbin \"ex\"\narg \"[file]\" default=\"out.txt\"\n",

--- a/corpus/08-choices-and-required.json
+++ b/corpus/08-choices-and-required.json
@@ -49,6 +49,31 @@
       }
     },
     {
+      "id": "choice-checked-for-every-value-of-a-variadic",
+      "doc": "Each value a variadic collects is checked, not only the first. A list that is valid up to its last element is not a valid list.",
+      "spec": "name \"ex\"\nbin \"ex\"\narg \"<shell>...\" {\n  choices \"bash\" \"zsh\"\n}\n",
+      "argv": ["bash", "tcsh"],
+      "expect": { "error": "invalid_choice" },
+      "layer": "post-binding"
+    },
+    {
+      "id": "choice-checked-for-every-occurrence-of-a-flag",
+      "doc": "The same for a repeatable flag: every occurrence carries a value, and every value is checked.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--shell <shell>\" var=#true {\n  choices \"bash\" \"zsh\"\n}\n",
+      "argv": ["--shell", "bash", "--shell", "tcsh"],
+      "expect": { "error": "invalid_choice" },
+      "layer": "post-binding"
+    },
+    {
+      "id": "choice-checked-on-a-value-from-the-environment",
+      "doc": "Choices constrain the value, not the command line, so a value arriving from `env` is checked like any other. Otherwise the environment would be a way around the declaration.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--shell <shell>\" env=\"EX_SHELL\" {\n  choices \"bash\" \"zsh\"\n}\n",
+      "argv": [],
+      "env": { "EX_SHELL": "tcsh" },
+      "expect": { "error": "invalid_choice" },
+      "layer": "post-binding"
+    },
+    {
       "id": "required-flag-present",
       "doc": "A required flag that is given parses normally.",
       "spec": "name \"ex\"\nbin \"ex\"\nflag \"--file <file>\" required=#true\n",

--- a/docs/spec/argv.md
+++ b/docs/spec/argv.md
@@ -348,7 +348,7 @@ fails if a label is wrong in either direction. A recorded divergence that gets
 fixed shows up as a test failure telling you to delete the label, so the list
 cannot rot.
 
-Today usage-lib diverges on 5 of 151 vectors:
+Today usage-lib diverges on 5 of 152 vectors:
 
 **An attached value that looks like a flag is read as one.** `--jobs=--force`
 binds `force` and leaves `jobs` unset, although the `=` has already settled where

--- a/docs/spec/argv.md
+++ b/docs/spec/argv.md
@@ -77,14 +77,27 @@ For a flag that takes a value, the value comes from one of two forms:
 | `--jobs 8` | the following token                                   |
 
 `--jobs=` binds the empty string. Present-but-empty is a distinct state from
-absent, and the attached form is the only way to express it.
+absent, and the attached form is the only way to express it in one token.
+
+A value attached to a flag that takes none is dropped: `--force=yes` sets `force`
+and nothing else. Handing the leftover to the positionals would re-split one
+token into two and fill an argument the caller never typed a word for.
 
 A detached value **must not be flag-like**. `--jobs --force` is a missing value,
 not a `jobs` of `"--force"`, because the overwhelmingly likely reading is that
 the value was forgotten. To pass a value that begins with a dash, attach it:
-`--jobs=--force`. The negative-number exception means `--offset -1` still works.
+`--jobs=--force`. The negative-number exception means `--offset -1` still works,
+and a lone `-` is a value too, so `--file -` reaches the flag. A `--` is
+flag-like, so it stays the separator rather than becoming the value of whatever
+flag precedes it.
 
 A flag needing a value that ends the command line is an error.
+
+A flag may declare **several long names**; the extra ones are aliases, and every
+one of them binds under the flag's name. A flag given **more than once** keeps
+the last value, unless it is `var` or `count`, which is what those declare
+instead. A repeat is a correction — usually a wrapper appending to a command line
+it did not write — so the last word on the subject is the one that counts.
 
 ### Flags that take several values
 
@@ -249,6 +262,16 @@ short: **command line, then environment, then default.**
 An environment variable set to the empty string is set. Treating empty as unset
 would make `EX_JOBS=` mean something no other empty value in the grammar means.
 
+A variable's value is one value, however much whitespace or however many commas
+it contains. It is not a command line, and is never split into several.
+
+For a flag that holds no value there is nothing to bind, so the variable's text
+is read as a boolean: `1`, `true`, `True`, and `TRUE` set it, and anything else —
+`0` and `false` included — leaves it false. Presence cannot be the test, since a
+parent process that exports `EX_VERBOSE=false` is saying no. Note that this is
+narrower than clap's falsey parser, where any value that is not falsey is true,
+so `yes` sets the flag there and not here.
+
 None of this changes which token binds where. It only fills what the command line
 left empty, which is why it is described last: an implementation can do all of it
 after the single pass is over.
@@ -325,23 +348,23 @@ fails if a label is wrong in either direction. A recorded divergence that gets
 fixed shows up as a test failure telling you to delete the label, so the list
 cannot rot.
 
-Today usage-lib diverges on 11 of 87 vectors, from three causes:
+Today usage-lib diverges on 5 of 151 vectors:
 
-**Unrecognized flags fall through to positionals.** `ex --wat` binds `--wat` to
-an argument if one is free, and reports `unexpected_arg` if not. This accounts
-for most of the divergences, including the ones where the grammar and usage-lib
-agree a flag is out of scope but disagree about which error to report.
+**An attached value that looks like a flag is read as one.** `--jobs=--force`
+binds `force` and leaves `jobs` unset, although the `=` has already settled where
+the value came from.
 
-**Repeated `--` is eaten.** A second separator is dropped rather than kept as a
-value, so a forwarded command line containing `--` is altered in transit. Note
-that `double_dash="preserve"` exists precisely to keep separators, which makes
-this arguably a deliberate design choice rather than a bug — see
-[Open questions](#open-questions).
+**A flag with a variadic argument takes only one value.** `--include a b` gives
+`include` just `a`, and reports `unexpected_arg` for the second, even though the
+[flag reference](/spec/reference/flag) documents `--include <pattern>...` as the
+form that collects. Bounding such a flag with `var_max` diverges for the same
+reason.
 
-Three smaller gaps: `--jobs=` binds nothing rather than the empty string; a flag
-with a variadic argument (`--include <pattern>...`, which the
-[flag reference](/spec/reference/flag) documents) rejects its second value; and
-`double_dash="automatic"` is not enforced, which the
+**A separator can be eaten as a flag's value.** `ex --jobs -- x` gives `jobs` the
+word after the separator, so the command line silently means `ex --jobs=x` and
+the `--` is lost.
+
+**`double_dash="automatic"` is not enforced**, which the
 [arg reference](/spec/reference/arg) already says outright.
 
 Where the grammar and usage-lib disagree, the grammar is the intent and the

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -958,8 +958,12 @@ fn parse_partial_with_env(
                     arr.push(true);
                 } else {
                     let negate = f.negate.clone().unwrap_or_default();
+                    // Which form was typed is a question about the name, so it is
+                    // asked of `word` rather than the whole token: the attached value
+                    // is dropped just above, and comparing `--no-color=yes` against
+                    // `--no-color` would take the negation down with it.
                     out.flags
-                        .insert(Arc::clone(f), ParseValue::Bool(w != negate));
+                        .insert(Arc::clone(f), ParseValue::Bool(word != negate));
                 }
                 continue;
             }

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -231,9 +231,10 @@ fn get_flag_key(word: &str) -> &str {
     if word.starts_with("--") {
         // Long flag: strip =value if present
         word.split_once('=').map(|(k, _)| k).unwrap_or(word)
-    } else if word.len() >= 2 {
-        // Short flag: first two chars (-X)
-        &word[0..2]
+    } else if let Some((end, _)) = word.char_indices().nth(2) {
+        // Short flag: the dash and one letter, which is one character and not
+        // necessarily one byte.
+        &word[0..end]
     } else {
         word
     }
@@ -935,12 +936,13 @@ fn parse_partial_with_env(
                 // Only push the embedded value back when the flag is known so that
                 // unknown --flag=value tokens fall through intact to positional arg
                 // handling without also injecting a stray "value" positional.
-                // An empty value only means something to a flag that takes one:
-                // `--jobs=` is an empty string, while `--force=` has nothing to give
-                // a flag that holds no value, and queueing it would leave a stray
-                // empty word to be read as a positional. A non-empty value on such a
-                // flag is left as it was, which is its own question.
-                if (split.is_some() && f.arg.is_some()) || !val.is_empty() {
+                // An attached value only means something to a flag that takes one:
+                // `--jobs=` is an empty string, while `--force=yes` has nothing to
+                // give a flag that holds no value. Queueing it there would re-split
+                // one token into two, and the leftover would be read as a positional
+                // — so `ex --force=yes` would fill an argument the caller never
+                // typed a word for.
+                if split.is_some() && f.arg.is_some() {
                     input.push_front(val.to_string());
                     prefix_bindings.push_front(None);
                 }
@@ -1002,8 +1004,9 @@ fn parse_partial_with_env(
                     &mut out.flag_awaiting_value,
                     &mut overridden_flags,
                 );
-                if w.len() > 2 {
-                    input.push_front(format!("-{}", &w[2..]));
+                let rest = &w[1 + short.len_utf8()..];
+                if !rest.is_empty() {
+                    input.push_front(format!("-{rest}"));
                     prefix_bindings.push_front(None);
                     grouped_flag = true;
                 }
@@ -2137,6 +2140,28 @@ flag "--file <file>" required_unless="--stdin"
             parse(&spec, &input(&["test", "--stdin", "--dir", "src"])),
             "Missing required flag: --file <file>",
         );
+    }
+
+    #[test]
+    fn short_flag_is_one_character_not_one_byte() {
+        // A short is declared and read by character. Counting bytes instead either
+        // refuses the declaration or slices the token inside the character, and clap
+        // — which many specs are generated from — accepts shorts like this one.
+        let spec = spec_with_flag(
+            SpecFlag::builder()
+                .short('磨')
+                .long("polish")
+                .arg(SpecArg::builder().name("opt").build())
+                .build(),
+        );
+        let attached = Parser::new(&spec)
+            .parse(&input(&["test", "-磨VALUE"]))
+            .unwrap();
+        assert_eq!(flag_string_value(&attached, "polish"), "VALUE");
+        let detached = Parser::new(&spec)
+            .parse(&input(&["test", "-磨", "V"]))
+            .unwrap();
+        assert_eq!(flag_string_value(&detached, "polish"), "V");
     }
 
     #[test]

--- a/lib/src/spec/flag.rs
+++ b/lib/src/spec/flag.rs
@@ -486,7 +486,7 @@ impl FromStr for SpecFlag {
             } else if let Some(long) = part.strip_prefix("--") {
                 flag.long.push(long.to_string());
             } else if let Some(short) = part.strip_prefix('-') {
-                if short.len() != 1 {
+                if short.chars().count() != 1 {
                     return Err(InvalidFlag {
                         token: format!("-{short}"),
                         reason: "short flags must be a single character (use -- for long flags)"


### PR DESCRIPTION
Read clap's `tests/builder` — 47 files, 23k lines — for cases that are questions about [the argv grammar](https://usage.jdx.dev/spec/argv), and imported the 28 our corpus had no answer for. Each was measured against both usage-lib and usage-argv with the oracle before its expectation was written, per `corpus/README.md`.

**Corpus: 123 → 151 vectors, 5 declared divergences, 0 mislabeled.**

## What came in

- **Long flags** — `--set==a` is `=a`; `--jobs ""` binds empty; `--jobs -- x` may not eat the separator; `--include a,b` is one token; `-----` names nothing; extra long names are aliases; a repeat keeps the last value.
- **Short flags** — `-j==8`, `-j=`, `-j ""`, and `-f -` (clap's `stdin_char`); `-f=yes` is not a bundle, so the whole token becomes a word; `-avv` counts inside a bundle.
- **Positionals, subcommands, `--`** — an empty token is a word; a value is never re-split; no prefix inference for command names, mirroring `long-no-abbreviation`; `ex -- install` passes `install` as data rather than routing.
- **Env and defaults** — an env value is one value; env does not append to a repeatable flag the command line already gave; a `default` does not rescue `--jobs` given without its value.
- **Choices** — every value of a variadic, every occurrence of a `var` flag, and a value arriving from `env` are all checked.

## Rules the grammar was silent on

A repeated flag keeps the last value. Extra long names are aliases. An env value is one value however much whitespace it holds. And a value-less flag reads its env var as a boolean: `1`/`true` set it, `0`/`false` do not — narrower than clap's falsey parser, where `yes` would set it. That last one is a migration hazard for specs generated from clap, so it is written down rather than left to be discovered.

## Two fixes the import caught

- **A value a flag cannot hold was read as a word.** `ex --force=yes` filled a positional the caller never typed a word for. `--force=` already dropped its value; re-splitting one token into two is not something the grammar does anywhere else.
- **Shorts were validated by byte length** while the error said "must be a single character", so `-磨` was refused. Accepting it exposed two byte-index assumptions that sliced inside a character.

## One new divergence

`ex --jobs -- x` gives `jobs` the word after the separator in usage-lib, so the command line silently means `ex --jobs=x` and the `--` is lost. usage-argv already reports `missing_flag_value`, which is what the grammar says, so this is recorded as a divergence and a bug to fix in `lib/src/parse.rs`.

## Also

The divergence section of `docs/spec/argv.md` claimed "11 of 87 vectors" and described two causes that no longer exist, one of them linking to a section that had been deleted. Rewritten against the five that are actually there.

## Reviewer notes

- **`--force=yes` was a judgment call.** The grammar was silent and the two implementations disagreed: usage-lib made the leftover a word, usage-argv dropped it. Pinned as "dropped" and usage-lib changed to match. clap errors on the token, which a spec parsing a command line it does not own cannot do.
- **The unicode-short vector is deliberately absent.** usage-argv's `Flag::shorts` is `&'a [u8]`, matched byte-by-byte so it can parse non-UTF-8 argv, and the conformance runner truncates with `*c as u8` — so a binding vector for `-磨` would red-fail the suite. The fix and a regression test live in usage-lib; widening usage-argv means changing a public type and the derive codegen that emits `shorts: b"f"`, which belongs in its own change.
- **Not imported**, for want of anything to map them onto: value delimiters, `require_equals`, `default_missing_value`, subcommand and flag inference, flag subcommands, groups, `allow_hyphen_values`, and the invalid-UTF-8 suites, which JSON vectors cannot express.

`cargo test --all --all-features`, `cargo clippy --all --all-features -- -D warnings`, `cargo fmt --all` and `prettier` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core argv parsing in `lib/src/parse.rs` (flag value attachment, negation, short bundles); behavior changes are corpus-backed but could affect wrappers relying on old `--force=yes` positional spill or byte-based short slicing.
> 
> **Overview**
> Adds **~28 argv conformance vectors** (corpus grows toward **152** cases, **5** recorded usage-lib divergences) covering long/short flag `=` edge cases, empty and comma-containing values, aliases, repeat-last-wins, subcommand prefix rules, `--` behavior, env/default/choice post-binding, and related cases drawn from gaps vs clap’s suite.
> 
> **usage-lib** (`parse.rs`, `spec/flag.rs`): boolean flags with attached values (e.g. `--force=yes`) no longer leak the suffix as a positional; negation uses the flag **name** token so `--no-color=yes` stays false; short-flag bundling and `get_flag_key` use **character** boundaries (Unicode short `-磨`); flag spec parsing validates short length by **character count**.
> 
> **docs/spec/argv.md** documents the new rules (attached values on value-less flags, aliases, repeat behavior, env boolean semantics vs clap, `--` as non-value) and refreshes the divergence list from stale “11 of 87” to **5 of 152**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94f5d96b578935907d29fbdcbcae0a3a11b21fab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Unicode short flags.
  - Improved handling of attached, detached, repeated, aliased, boolean, and bundled flag values.
  - Clarified environment-variable fallback and default-value behavior.
  - Strengthened choice validation across positional, repeated-flag, and environment-provided values.

- **Bug Fixes**
  - Prevented incorrect separator and subcommand interpretation.
  - Preserved comma-containing values and empty arguments correctly.
  - Improved handling of dash-only values and boolean flags with attached text.

- **Documentation**
  - Updated argument-parsing specifications and documented remaining compatibility differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->