### PR TITLE
fix(help): render the page for the mount the words reached

### DIFF
--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -1189,8 +1189,9 @@ pub fn render(spec: &Spec<'_>, cmd: &Command<'_>, long: bool) -> Option<String> 
 /// The parse is deterministic, so walking the same argv reaches the same place.
 ///
 /// `ex help config set` asks about a command *deeper* than the parse reached, so the route is
-/// extended by matching each remaining word among the children of where it got to — the same
-/// descent the parser made, and unambiguous at every step.
+/// extended over [`Parser::help_span`](crate::Parser::help_span) — the words the parser itself
+/// resolved as a command path, which is the only reading that cannot mistake a flag's value for
+/// a command name.
 ///
 /// `None` where the command is not below this spec at all, which a caller should treat as a
 /// reason to fall back rather than a failure.
@@ -1205,34 +1206,31 @@ pub fn route_to<'t>(
             break;
         }
     }
-    let walked = parser.command_path();
-    let from = walked.last().map(|(_, start)| *start).unwrap_or(0);
-    let mut route: Vec<&Command<'_>> = walked.into_iter().map(|(c, _)| c).collect();
+    let (help_from, help_to) = parser.help_span();
+    let mut route: Vec<&Command<'_>> = parser.command_path().into_iter().map(|(c, _)| c).collect();
     if route.is_empty() {
         route.push(root);
     }
 
-    // Already there for `--help`. For the `help` word the parse stopped at the command that
-    // *saw* it, so the rest of the way is walked the way the parser walked it: by name, over
-    // the words that follow, among the children of wherever it has got to.
+    // Already there for `--help`, whose span is empty. For the `help` word the parse stopped at
+    // the command that *saw* it, and the words naming the one being asked about are exactly the
+    // span — which the parser resolved itself, one subcommand at a time.
     //
-    // By name and not by address, because the address is exactly what cannot be trusted here:
-    // looking for a child that *contains* the target picked whichever mount came first, which
-    // is the bug this function exists for.
-    if !core::ptr::eq(*route.last()?, cmd) {
-        for token in argv.iter().skip(from) {
-            let here = *route.last()?;
-            let word = token.as_encoded_bytes();
-            let Some(next) = here.subcommands.iter().copied().find(|sub| {
-                sub.name.as_bytes() == word || sub.aliases.iter().any(|a| a.as_bytes() == word)
-            }) else {
-                continue;
-            };
-            route.push(next);
-            if core::ptr::eq(next, cmd) {
-                break;
-            }
-        }
+    // Taken from the parser rather than re-scanned out of `argv`, because only the parser knows
+    // which tokens were in command position. Scanning every token from where the parse stopped
+    // read `ex --config alpha help beta shared` as a descent into `alpha`, since a flag's
+    // detached value is just a word — and the wrong mount's page passed the arrival check
+    // below, both mounts being one address.
+    //
+    // By name and not by address for the same reason: looking for a child that *contains* the
+    // target picks whichever mount comes first, which is the bug this function exists for.
+    for token in argv.get(help_from..help_to).unwrap_or_default() {
+        let here = *route.last()?;
+        let word = token.as_encoded_bytes();
+        let next = here.subcommands.iter().copied().find(|sub| {
+            sub.name.as_bytes() == word || sub.aliases.iter().any(|a| a.as_bytes() == word)
+        })?;
+        route.push(next);
     }
     // Only if the walk actually arrived: a caller should fall back rather than be handed a
     // page about some other command.

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -1181,3 +1181,91 @@ pub fn render(spec: &Spec<'_>, cmd: &Command<'_>, long: bool) -> Option<String> 
         short_help(spec, &path, &chain)
     })
 }
+
+/// The route the words took to a command, for rendering its page unambiguously.
+///
+/// Rebuilt by re-parsing, because [`Error::Help`](crate::Error::Help) carries the command and
+/// not the way there — putting a route in it would put an allocation in every parser error.
+/// The parse is deterministic, so walking the same argv reaches the same place.
+///
+/// `ex help config set` asks about a command *deeper* than the parse reached, so the route is
+/// extended by matching each remaining word among the children of where it got to — the same
+/// descent the parser made, and unambiguous at every step.
+///
+/// `None` where the command is not below this spec at all, which a caller should treat as a
+/// reason to fall back rather than a failure.
+pub fn route_to<'t>(
+    root: &'t Command<'t>,
+    argv: &[&std::ffi::OsStr],
+    cmd: &Command<'_>,
+) -> Option<Vec<&'t Command<'t>>> {
+    let mut parser = crate::Parser::new(root, argv);
+    while let Some(event) = parser.next_event() {
+        if event.is_err() {
+            break;
+        }
+    }
+    let walked = parser.command_path();
+    let from = walked.last().map(|(_, start)| *start).unwrap_or(0);
+    let mut route: Vec<&Command<'_>> = walked.into_iter().map(|(c, _)| c).collect();
+    if route.is_empty() {
+        route.push(root);
+    }
+
+    // Already there for `--help`. For the `help` word the parse stopped at the command that
+    // *saw* it, so the rest of the way is walked the way the parser walked it: by name, over
+    // the words that follow, among the children of wherever it has got to.
+    //
+    // By name and not by address, because the address is exactly what cannot be trusted here:
+    // looking for a child that *contains* the target picked whichever mount came first, which
+    // is the bug this function exists for.
+    if !core::ptr::eq(*route.last()?, cmd) {
+        for token in argv.iter().skip(from) {
+            let here = *route.last()?;
+            let word = token.as_encoded_bytes();
+            let Some(next) = here.subcommands.iter().copied().find(|sub| {
+                sub.name.as_bytes() == word || sub.aliases.iter().any(|a| a.as_bytes() == word)
+            }) else {
+                continue;
+            };
+            route.push(next);
+            if core::ptr::eq(next, cmd) {
+                break;
+            }
+        }
+    }
+    // Only if the walk actually arrived: a caller should fall back rather than be handed a
+    // page about some other command.
+    core::ptr::eq(*route.last()?, cmd).then_some(route)
+}
+
+/// The same page, for a command reached by a known route.
+///
+/// [`render`] has only a `&Command` to go on and finds it by address. That is enough until one
+/// `Subcommands` type is mounted under two parents: both splice the same `&'static [Command]`,
+/// so the two mounts *are* one address and the search returns whichever comes first. A page for
+/// the second one then carried the first one's path and the first one's globals.
+///
+/// The route tells them apart, and the parser has it — `Parser::command_path` is the sequence of
+/// commands the words actually went through. Callers holding only a command keep [`render`] and
+/// its answer; callers that parsed something should prefer this.
+pub fn render_at(spec: &Spec<'_>, route: &[&Command<'_>], long: bool) -> Option<String> {
+    let mut names = vec![spec.bin.unwrap_or(spec.name)];
+    let mut chain = vec![spec.root];
+    for cmd in route.iter().skip(1) {
+        // Matched among *this* command's children, which is unambiguous even when the child is
+        // shared: a parent's own list is its own.
+        let here = chain.last()?;
+        let next = here
+            .subcommands
+            .iter()
+            .find(|sub| core::ptr::eq(sub.cmd, *cmd))?;
+        names.push(next.cmd.name);
+        chain.push(next);
+    }
+    Some(if long {
+        long_help(spec, &names, &chain)
+    } else {
+        short_help(spec, &names, &chain)
+    })
+}

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -859,6 +859,14 @@ pub struct Parser<'t, 'v> {
     default_taken: bool,
     /// Set once a fatal error has been reported, so iteration stops.
     done: bool,
+    /// The `argv` range the `help` *word* resolved as a command path, if one was typed.
+    ///
+    /// Empty for `--help`, which asks about wherever the parse had got to. For the word, the
+    /// question is about a command deeper than the parse reached, and only this walk knows
+    /// which tokens named it: a caller re-scanning `argv` would count a flag's detached value
+    /// that happens to spell a sibling's name. Two indices rather than the commands
+    /// themselves, so the parser keeps allocating nothing.
+    help_span: (usize, usize),
 }
 
 impl<'t, 'v> Parser<'t, 'v> {
@@ -885,6 +893,7 @@ impl<'t, 'v> Parser<'t, 'v> {
             separator_seen: false,
             default_taken: false,
             done: false,
+            help_span: (0, 0),
         }
     }
 
@@ -918,6 +927,14 @@ impl<'t, 'v> Parser<'t, 'v> {
         }
         out.push((self.cmd, self.cmd_start));
         out
+    }
+
+    /// The `argv` range the `help` word resolved as a command path.
+    ///
+    /// Empty unless the word was typed. Every token in it named a subcommand of the one before
+    /// it — the parser resolved them itself, so nothing here is a flag or a flag's value.
+    pub fn help_span(&self) -> (usize, usize) {
+        self.help_span
     }
 
     /// Where the command in scope began: the index in `argv` just after its name.
@@ -1237,6 +1254,7 @@ impl<'t, 'v> Parser<'t, 'v> {
             // descending would bind them, and they are a question rather than an invocation.
             if token == b"help" && !self.cmd.subcommands.is_empty() {
                 let mut cmd = self.cmd;
+                let from = self.pos;
                 while let Some(next) = self.argv.get(self.pos) {
                     let Some(sub) = find_named(cmd, bytes(next)) else {
                         break;
@@ -1244,6 +1262,9 @@ impl<'t, 'v> Parser<'t, 'v> {
                     cmd = sub;
                     self.pos += 1;
                 }
+                // Kept for `help::route_to`: which mount was asked about is not recoverable
+                // from `cmd`, since two mounts of one `Subcommands` type are one address.
+                self.help_span = (from, self.pos);
                 // The long form, as `ex config --help` gives: someone who typed a whole word to
                 // ask for help wants the fuller answer.
                 return Err(Error::Help { cmd, long: true });

--- a/conformance/tests/shared_subcommand.rs
+++ b/conformance/tests/shared_subcommand.rs
@@ -164,3 +164,46 @@ fn the_fields_are_bound_under_either_parent() {
     assert!(alpha.alphaglobal);
     assert!(matches!(alpha.command, Some(Both::Shared(_))));
 }
+
+#[test]
+fn a_page_follows_the_route_the_words_took() {
+    // The half the diagnostics fixed and help did not. `render` has only a `&Command` to go on
+    // and finds it by address — and both mounts *are* one address, so it returned whichever
+    // came first. `ex beta shared --help` printed `Usage: ex alpha shared`, with alpha's
+    // globals, for as long as this crate has had help.
+    //
+    // Both spellings of a help request, because they reach it differently: `--help` stops
+    // where the parse got to, and `help beta shared` asks about a command deeper than that.
+    for words in [
+        vec!["beta", "shared", "--help"],
+        vec!["help", "beta", "shared"],
+    ] {
+        let owned: Vec<&OsStr> = words.iter().map(|s| OsStr::new(*s)).collect();
+        let Err(usage_argv::Error::Help { cmd, long }) = Ex::parse_from(&owned) else {
+            panic!("{words:?} should ask for help")
+        };
+        let route = usage_argv::help::route_to(Ex::command(), &owned, cmd)
+            .unwrap_or_else(|| panic!("{words:?}: no route"));
+        let page = usage_argv::help::render_at(Ex::spec(), &route, long).expect("a page");
+
+        assert!(page.contains("Usage: ex beta shared"), "{words:?}: {page}");
+        assert!(page.contains("--betaglobal"), "{words:?}: {page}");
+        assert!(!page.contains("alphaglobal"), "{words:?}: {page}");
+    }
+}
+
+#[test]
+fn the_first_mount_is_still_its_own() {
+    // The other half: resolving by route must not make every page beta's.
+    let owned: Vec<&OsStr> = ["alpha", "shared", "--help"]
+        .iter()
+        .map(|s| OsStr::new(*s))
+        .collect();
+    let Err(usage_argv::Error::Help { cmd, long }) = Ex::parse_from(&owned) else {
+        panic!("should ask for help")
+    };
+    let route = usage_argv::help::route_to(Ex::command(), &owned, cmd).expect("a route");
+    let page = usage_argv::help::render_at(Ex::spec(), &route, long).expect("a page");
+    assert!(page.contains("Usage: ex alpha shared"), "{page}");
+    assert!(page.contains("--alphaglobal"), "{page}");
+}

--- a/conformance/tests/shared_subcommand.rs
+++ b/conformance/tests/shared_subcommand.rs
@@ -59,6 +59,9 @@ enum Top {
 #[derive(Cli)]
 #[usage(bin = "ex", unknown_flags = "error")]
 struct Ex {
+    /// Takes a value, which may be spelled like a subcommand
+    #[usage(long, global)]
+    config: Option<String>,
     #[usage(subcommand)]
     command: Option<Top>,
 }
@@ -206,4 +209,51 @@ fn the_first_mount_is_still_its_own() {
     let page = usage_argv::help::render_at(Ex::spec(), &route, long).expect("a page");
     assert!(page.contains("Usage: ex alpha shared"), "{page}");
     assert!(page.contains("--alphaglobal"), "{page}");
+}
+
+#[test]
+fn a_flag_value_is_not_a_step_on_the_route() {
+    // `route_to` first extended the route by scanning every token after the parse stopped and
+    // skipping what did not match. A flag's detached value is just a word, so
+    // `--config alpha help beta shared` descended into `alpha` on the way past — and the wrong
+    // page passed the arrival check, both mounts being one address.
+    //
+    // The words that name the command asked about are the ones the *parser* resolved, and it is
+    // the only thing that knows which tokens were in command position. Both directions, so a
+    // fix that simply preferred the later match would not pass.
+    for (words, want_usage, want_global, not_global) in [
+        (
+            vec!["--config", "alpha", "help", "beta", "shared"],
+            "Usage: ex beta shared",
+            "--betaglobal",
+            "alphaglobal",
+        ),
+        (
+            vec!["--config", "beta", "help", "alpha", "shared"],
+            "Usage: ex alpha shared",
+            "--alphaglobal",
+            "betaglobal",
+        ),
+    ] {
+        let owned: Vec<&OsStr> = words.iter().map(|s| OsStr::new(*s)).collect();
+        let Err(usage_argv::Error::Help { cmd, long }) = Ex::parse_from(&owned) else {
+            panic!("{words:?} should ask for help")
+        };
+        let route = usage_argv::help::route_to(Ex::command(), &owned, cmd)
+            .unwrap_or_else(|| panic!("{words:?}: no route"));
+        let page = usage_argv::help::render_at(Ex::spec(), &route, long).expect("a page");
+
+        assert!(page.contains(want_usage), "{words:?}: {page}");
+        assert!(page.contains(want_global), "{words:?}: {page}");
+        assert!(!page.contains(not_global), "{words:?}: {page}");
+    }
+
+    // And the flag really does take that word as its value — which is what made it a hazard,
+    // and what keeps the field read.
+    let argv: Vec<&OsStr> = ["--config", "alpha", "beta", "shared"]
+        .iter()
+        .map(|s| OsStr::new(*s))
+        .collect();
+    let parsed = Ex::parse_from(&argv).expect("parses");
+    assert_eq!(parsed.config.as_deref(), Some("alpha"));
 }

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -406,7 +406,23 @@ pub fn emit(cli: &Cli) -> TokenStream {
                         }
                     }
                     ::std::result::Result::Err(::usage_argv::Error::Help { cmd, long }) => {
-                        match ::usage_argv::help::render(Self::spec(), cmd, long) {
+                        // By the route the words took, not by the command's address: one
+                        // `Subcommands` type mounted under two parents is one address, and a
+                        // page found by searching for it carries the first mount's path and
+                        // globals. Falls back where the route cannot be rebuilt.
+                        let __usage_page = match ::usage_argv::help::route_to(
+                            Self::command(),
+                            &__usage_argv,
+                            cmd,
+                        ) {
+                            ::std::option::Option::Some(route) => {
+                                ::usage_argv::help::render_at(Self::spec(), &route, long)
+                            }
+                            ::std::option::Option::None => {
+                                ::usage_argv::help::render(Self::spec(), cmd, long)
+                            }
+                        };
+                        match __usage_page {
                             ::std::option::Option::Some(page) => {
                                 ::std::print!("{page}");
                                 ::std::process::exit(0);


### PR DESCRIPTION
A `Subcommands` type mounted under two parents is one `Command` at one
address, so `help::find` — which located a command by `core::ptr::eq` over
the whole tree — returned whichever mount came first. `ex beta shared
--help` printed `Usage: ex alpha shared`, with alpha's globals, for as long
as this crate has had help. Diagnostics fixed their half of this by
resolving the route rather than the command; help kept the pointer.

A `&Command` cannot distinguish the mounts, so it cannot be the input.
`route_to` builds the route from the argv the derive already has: it takes
the path the parser walked, and for the `help beta shared` spelling — where
the parse stops at the command that *saw* the word, short of the one being
asked about — walks the remaining words by name among the children of
wherever it has got to. By name, because the address is the thing that
cannot be trusted here. `render_at` then resolves the metadata chain the
same way, matching each step among that command's own children.

`parse()` prefers the route and falls back to `render`, so a caller that
reaches help by some other path still gets a page.

Both spellings are tested, and so is the first mount — resolving by route
must not make every page beta's.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches help rendering and generated `parse()` exit paths; behavior change is intentional for shared mounts, with fallback preserving old `render` when routing fails.
> 
> **Overview**
> **Fixes wrong help for shared subcommands mounted under multiple parents.** When the same `Subcommands` type is wired under two parents, both mounts share one `Command` pointer, so `help::render` / `find` picked the first mount—e.g. `ex beta shared --help` showed `Usage: ex alpha shared` and alpha’s globals.
> 
> The parser records **`help_span`**: the `argv` slice where the `help` *word* walked subcommand names (not flag values). **`help::route_to`** re-parses argv, builds the command path from `command_path` + that span, and **`help::render_at`** builds usage/metadata from that route by matching children per parent. Generated **`parse()`** uses route + `render_at` on `Error::Help`, falling back to **`render`** when the route can’t be rebuilt.
> 
> Conformance tests cover `--help`, `help beta shared`, both mounts, and **`--config <name>`** so a global flag value isn’t mistaken for a route step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e00424ac9e2d09b02ee77d6a4ac98a9a7097a8e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*
