### PR TITLE
fix(argv): show choices when a subcommand is required

### DIFF
--- a/argv/src/diagnostic.rs
+++ b/argv/src/diagnostic.rs
@@ -508,6 +508,13 @@ pub fn render(
             );
         }
         Error::MissingSubcommand => {
+            // A bare command that can do nothing on its own is a request for orientation.
+            // clap prints the command's help page here, including the available subcommands,
+            // while keeping exit 2; an error plus only `<SUBCOMMAND>` tells the reader what is
+            // missing and withholds the list they need to fix it.
+            if let Some(help) = crate::help::render_at(spec, &taken, false) {
+                return help;
+            }
             with_usage = true;
             let _ = writeln!(
                 out,
@@ -809,6 +816,15 @@ mod tests {
             .find_map(|l| l.strip_prefix("Usage: "))
             .expect("a usage line");
         assert_eq!(line, crate::help::usage_line(&["ex", "use"], &USE_META));
+    }
+
+    #[test]
+    fn a_missing_subcommand_prints_the_choices() {
+        let message = rendered(&[], Error::MissingSubcommand);
+        assert!(message.contains("Commands:"), "{message}");
+        assert!(message.contains("use"), "{message}");
+        assert!(message.contains("user"), "{message}");
+        assert!(!message.contains("requires a subcommand"), "{message}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- render the command's short help page when a required subcommand is missing
- keep the parse failure and exit status unchanged
- add diagnostic coverage for the command list

This restores the discoverability users expect from Clap: running a command that requires a subcommand shows the available choices instead of only saying that a subcommand is missing.

## Stack

Targets the duplicate-flag PR and is the new direct base for #936.

## Checks

- `cargo test -p usage-argv --features diagnostics`
- `cargo test -p usage-conformance --test help_request --test subcommand_required`
- full stacked `cargo test --all --all-features`
- full stacked Clippy with warnings denied

_This PR was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing stderr text only on a parse-error path; parse failure and exit status stay the same, with a safe fallback if help rendering fails.
> 
> **Overview**
> When parsing stops with **`Error::MissingSubcommand`**, diagnostics now try **`help::render_at`** for the current command path and return that **short help** (including the **Commands:** list) instead of the old **“requires a subcommand”** line plus a usage block.
> 
> If help cannot be rendered, behavior falls back to the previous error message. A unit test asserts the new output lists subcommands like `use` and `user` and omits the old wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae19f7bbca20bfd71ada8fa13860e1579283e365. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Experience**
  * When a required subcommand is omitted, the command now displays its help page with available subcommands.
  * The previous “requires a subcommand” error and usage block are no longer shown in this case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->