### PR TITLE
docs: remove slop phrasing from landing page copy

### DIFF
--- a/docs/.vitepress/theme/UsageBenches.vue
+++ b/docs/.vitepress/theme/UsageBenches.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
-// Measured numbers, not marketing: Rust figures from PLAN.md's gated perf
-// report; Go figures from go/README.md. Wall time is parser overhead — what
-// the framework adds on top of a process that parses nothing. The Go values
-// subtract the ~0.95ms a do-nothing Go process costs, so they are
-// deliberately approximate.
+// Rust figures from PLAN.md's gated perf report; Go figures from
+// go/README.md. Wall time is parser overhead — what the framework adds on
+// top of a process that parses nothing. The Go values subtract the ~0.95ms
+// a do-nothing Go process costs, so they are deliberately approximate.
 const rustRows = [
   { name: "usage-rs", value: 2.1, label: "2.1µs", note: "~230× less", us: true },
   { name: "clap", value: 490, label: "490µs", us: false },
@@ -27,10 +26,10 @@ function width(value: number, max: number): string {
 <template>
   <section class="usage-bench">
     <p class="usage-hero-label">Benchmarks</p>
-    <h2 class="usage-bench-title">Measured, not claimed.</h2>
+    <h2 class="usage-bench-title">Parser overhead</h2>
     <p class="usage-bench-sub">
-      Parser overhead — wall time the framework adds on top of a process that parses
-      nothing — for <code>mise use -g node@20</code> against a shadow of
+      Wall time each framework adds to a process that parses nothing, measured on
+      <code>mise use -g node@20</code> against a shadow of
       <a href="https://mise.jdx.dev">mise</a>'s CLI: 211 commands, 711 flags, cold.
     </p>
 

--- a/docs/.vitepress/theme/UsageHero.vue
+++ b/docs/.vitepress/theme/UsageHero.vue
@@ -25,9 +25,9 @@ const javascriptPath =
         <p class="usage-hero-desc">
           Usage is a toolkit for building command-line tools. Define your CLI's commands,
           flags, and args once in a KDL spec — get argument parsing, shell completions,
-          <code>--help</code>, docs, and manpages everywhere it runs. Reference frameworks
-          for Rust and Go build your CLI straight from the spec, with Python and JavaScript
-          on the way.
+          <code>--help</code>, docs, and manpages from that one definition. Reference
+          frameworks for Rust and Go build your CLI from the spec, with Python and
+          JavaScript planned.
         </p>
 
         <p class="usage-hero-label">Frameworks</p>
@@ -42,7 +42,7 @@ const javascriptPath =
             <span>Rust</span>
             <div class="usage-tile-tooltip">
               <strong>Rust framework</strong>
-              <p>Derive your CLI from Rust types — parsing, help, and completions powered by the usage spec.</p>
+              <p>Derive your CLI from Rust types — parsing, help, and completions generated from the usage spec.</p>
             </div>
           </a>
           <a
@@ -55,7 +55,7 @@ const javascriptPath =
             <span>Go</span>
             <div class="usage-tile-tooltip">
               <strong>Go framework</strong>
-              <p>Build Go CLIs on the usage spec with the same parsing and completion behavior everywhere.</p>
+              <p>Build Go CLIs on the usage spec, with parsing behavior verified against the same conformance corpus as the Rust implementation.</p>
             </div>
           </a>
           <span class="usage-tile usage-tile-soon">
@@ -74,7 +74,7 @@ const javascriptPath =
           </span>
         </div>
 
-        <p class="usage-hero-label">Powered by the spec</p>
+        <p class="usage-hero-label">Spec &amp; tooling</p>
         <div class="usage-hero-tiles">
           <a href="/cli/completions" class="usage-tile usage-tile-feature">
             <svg class="usage-tile-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -84,7 +84,7 @@ const javascriptPath =
             <span>Completions</span>
             <div class="usage-tile-tooltip">
               <strong>Shell completions</strong>
-              <p>Tab completions for bash, zsh, fish, PowerShell, and nushell — every shell, one spec.</p>
+              <p>Tab completions for bash, zsh, fish, PowerShell, and nushell, generated from the spec.</p>
             </div>
           </a>
           <a href="/cli/markdown" class="usage-tile usage-tile-feature">
@@ -95,7 +95,7 @@ const javascriptPath =
             <span>Docs &amp; manpages</span>
             <div class="usage-tile-tooltip">
               <strong>Auto-generated docs</strong>
-              <p>--help output, markdown docs, and manpages that stay in sync automatically.</p>
+              <p>--help output, markdown docs, and manpages, all generated from the same spec.</p>
             </div>
           </a>
           <a href="/cli/scripts" class="usage-tile usage-tile-feature">
@@ -108,7 +108,7 @@ const javascriptPath =
             <span>Scripts</span>
             <div class="usage-tile-tooltip">
               <strong>Bash scripts</strong>
-              <p>Write bash scripts with modern arg parsing, validation, and completions built in.</p>
+              <p>Declare a script's interface in a USAGE comment and get arg parsing, validation, and completions.</p>
             </div>
           </a>
           <a href="/spec/" class="usage-tile usage-tile-feature">
@@ -119,7 +119,7 @@ const javascriptPath =
             <span>KDL spec</span>
             <div class="usage-tile-tooltip">
               <strong>KDL specification</strong>
-              <p>Define your CLI once in human-readable KDL. One spec powers everything.</p>
+              <p>Define your CLI once in KDL. Completions, docs, and parsers are all generated from it.</p>
             </div>
           </a>
           <a href="/cli/" class="usage-tile usage-tile-feature">

--- a/docs/.vitepress/theme/UsageHero.vue
+++ b/docs/.vitepress/theme/UsageHero.vue
@@ -18,9 +18,7 @@ const javascriptPath =
       <div class="usage-hero-text">
         <h1 class="usage-hero-title"><span class="accent">--</span>usage</h1>
 
-        <p class="usage-hero-tagline">
-          Fastest frameworks. Most features. One spec.<span class="cursor"></span>
-        </p>
+        <p class="usage-hero-tagline">Define your CLI once.<span class="cursor"></span></p>
 
         <p class="usage-hero-desc">
           Usage is a toolkit for building command-line tools. Define your CLI's commands,

--- a/docs/cli/scripts.md
+++ b/docs/cli/scripts.md
@@ -1,6 +1,6 @@
 # Usage Scripts
 
-Scripts can be used with the Usage CLI to display help, powerful arg parsing, and autocompletion in
+Scripts can be used with the Usage CLI to display help, parse args, and autocomplete in
 any language.
 For this to work, we add comments to the script that describe the flags and arguments that the
 script accepts.


### PR DESCRIPTION
## Summary

Copy audit of the landing page (and one pre-existing docs line) for sloganized, AI-flavored phrasing. Every replacement states what the thing actually does instead of how it wants to sound. Follows up on #944.

| Before | After |
|---|---|
| **Measured, not claimed.** (bench heading) | **Parser overhead** |
| Define your CLI once in human-readable KDL. **One spec powers everything.** | Define your CLI once in KDL. Completions, docs, and parsers are all generated from it. |
| Tab completions for bash, zsh, fish, PowerShell, and nushell — **every shell, one spec.** | …and nushell, generated from the spec. |
| manpages that **stay in sync automatically** | manpages, all generated from the same spec |
| parsing, help, and completions **powered by** the usage spec | …generated from the usage spec |
| same parsing and completion behavior **everywhere** | parsing behavior verified against the same conformance corpus as the Rust implementation |
| bash scripts with **modern** arg parsing … **built in** | Declare a script's interface in a USAGE comment and get arg parsing, validation, and completions. |
| **Powered by the spec** (section label) | Spec & tooling |
| get … manpages **everywhere it runs** | get … manpages from that one definition |
| Python and JavaScript **on the way** | Python and JavaScript planned |
| scripts.md: **powerful arg parsing** | parse args |

Deliberately left alone:
- ~~The tagline~~ — now also changed: "Fastest frameworks. Most features. One spec." → "Define your CLI once." The speed claim lives in the benchmark section, where it has evidence.
- "runtime startup no parser can touch" in the bench footnote — it quotes go/README.md's own phrasing.
- argv.md's "simply sets it" — reads as ordinary spec prose, not slop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and marketing copy only; no runtime, API, or build behavior changes.
> 
> **Overview**
> **Landing page copy** is rewritten to describe what Usage actually does instead of slogan-style claims. The hero tagline becomes **“Define your CLI once.”**; body text and tile tooltips emphasize outputs **generated from the KDL spec** (completions, help, docs, manpages) and, for Go, **conformance with the Rust corpus**. The section label **“Powered by the spec”** is renamed **“Spec & tooling”**; Scripts copy now points at **USAGE comments** rather than “modern” built-in parsing.
> 
> **Benchmarks** (`UsageBenches.vue`): the heading **“Measured, not claimed.”** becomes **“Parser overhead”**, with a tightened subtitle on wall-time methodology; source comments drop the “not marketing” line.
> 
> **`docs/cli/scripts.md`**: “powerful arg parsing” becomes **“parse args”**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4974880b70d220eb38680fe62c29201c9c517bb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified benchmark explanations, including data sources, parser overhead, and approximate value adjustments.
  - Renamed the benchmark section to “Parser overhead” with a shorter subtitle.
  - Updated usage messaging to highlight spec-generated parsing, completions, documentation, manpages, and conformance verification.
  - Renamed “Powered by the spec” to “Spec & tooling.”
  - Refined CLI script descriptions for help, argument parsing, and autocompletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
