### PR TITLE
fix(spec): rank a subcommand name above another command's alias

### DIFF
--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -525,11 +525,12 @@ pub fn candidates<'a>(spec: &'a Spec<'a>, split: &Split) -> Vec<Candidate<'a>> {
             if let Some(default) = spec.default_subcommand {
                 // By any name it answers to: `default_subcommand` names a command, and a
                 // spec may name it the way its author refers to it rather than canonically.
-                let target = spec
-                    .root
-                    .subcommands
-                    .iter()
-                    .find(|sub| sub.cmd.name == default || sub.cmd.aliases.contains(&default));
+                // Names before aliases, so the command whose first argument is offered here
+                // is the one the parser would actually route the word to.
+                let subcommands = || spec.root.subcommands.iter();
+                let target = subcommands()
+                    .find(|sub| sub.cmd.name == default)
+                    .or_else(|| subcommands().find(|sub| sub.cmd.aliases.contains(&default)));
                 if let Some(arg) = target.and_then(|sub| sub.args.first()) {
                     found.extend(positional(arg, &position, split, token));
                 }
@@ -1842,6 +1843,77 @@ mod tests {
         let found = offered("mise ");
         assert!(found.contains(&"node".to_string()), "{found:?}");
     }
+
+    #[test]
+    fn the_fallback_command_prefers_a_name_to_another_commands_alias() {
+        // Resolved the way a typed word is, so what a shell offers at the root is the first
+        // argument of the command the parser would actually route the word to. Matching name
+        // and alias in one pass offered `alpha`'s values for a line the parse sends to `run`.
+        static A_ARG: Arg = Arg {
+            key: 90,
+            name: "a",
+            ..Arg::REQUIRED
+        };
+        static B_ARG: Arg = Arg {
+            key: 91,
+            name: "b",
+            ..Arg::REQUIRED
+        };
+        static ALPHA: Command = Command {
+            name: "alpha",
+            aliases: &["run"],
+            args: &[&A_ARG],
+            ..Command::EMPTY
+        };
+        static PLAIN_RUN: Command = Command {
+            name: "run",
+            args: &[&B_ARG],
+            ..Command::EMPTY
+        };
+        static META_ALPHA: CommandMeta = CommandMeta {
+            cmd: &ALPHA,
+            args: &[ArgMeta {
+                arg: &A_ARG,
+                choices: &["from-alpha"],
+                ..ArgMeta::EMPTY
+            }],
+            ..CommandMeta::EMPTY
+        };
+        static META_PLAIN_RUN: CommandMeta = CommandMeta {
+            cmd: &PLAIN_RUN,
+            args: &[ArgMeta {
+                arg: &B_ARG,
+                choices: &["from-run"],
+                ..ArgMeta::EMPTY
+            }],
+            ..CommandMeta::EMPTY
+        };
+        static EX: Command = Command {
+            name: "ex",
+            subcommands: &[&ALPHA, &PLAIN_RUN],
+            ..Command::EMPTY
+        };
+        static META_EX: CommandMeta = CommandMeta {
+            cmd: &EX,
+            subcommands: &[&META_ALPHA, &META_PLAIN_RUN],
+            ..CommandMeta::EMPTY
+        };
+        static EX_SPEC: Spec = Spec {
+            name: "ex",
+            bin: Some("ex"),
+            root: &META_EX,
+            default_subcommand: Some("run"),
+            ..Spec::EMPTY
+        };
+
+        let found: Vec<String> = candidates(&EX_SPEC, &at_end("ex "))
+            .into_iter()
+            .map(|c| c.value)
+            .collect();
+        assert!(found.contains(&"from-run".to_string()), "{found:?}");
+        assert!(!found.contains(&"from-alpha".to_string()), "{found:?}");
+    }
+
     /// The whole answer for a line: what this CLI knows, and whether paths belong.
     fn answer(line: &str) -> Completions<'static> {
         complete(&SPEC, &at_end(line))

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -1227,9 +1227,11 @@ pub fn route_to<'t>(
     for token in argv.get(help_from..help_to).unwrap_or_default() {
         let here = *route.last()?;
         let word = token.as_encoded_bytes();
-        let next = here.subcommands.iter().copied().find(|sub| {
-            sub.name.as_bytes() == word || sub.aliases.iter().any(|a| a.as_bytes() == word)
-        })?;
+        // Through `find_named`, so this walk ranks names above aliases exactly as the parse
+        // that reached here did. Matching on name and alias together instead answered with
+        // whichever subcommand came first, which for a colliding word is a different command
+        // than the one the parser selected.
+        let next = crate::find_named(here, word)?;
         route.push(next);
     }
     // Only if the walk actually arrived: a caller should fall back rather than be handed a

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -688,11 +688,15 @@ pub static HELP_SHORT: Flag<'static> = Flag {
 ///
 /// Free rather than a method because `help` resolves a path *without* descending: the words
 /// after it are a question about a command rather than a walk into one.
-fn find_named<'t>(cmd: &'t Command<'t>, name: &[u8]) -> Option<&'t Command<'t>> {
-    cmd.subcommands
-        .iter()
-        .copied()
-        .find(|c| c.name.as_bytes() == name || c.aliases.iter().any(|a| a.as_bytes() == name))
+///
+/// Names across every subcommand before any alias, the precedence the grammar states — and
+/// the reason this is the only implementation of it on argv's side. `ex run` and `ex help run`
+/// selecting different commands would be exactly the divergence this rule was written to end.
+pub(crate) fn find_named<'t>(cmd: &'t Command<'t>, name: &[u8]) -> Option<&'t Command<'t>> {
+    let subcommands = || cmd.subcommands.iter().copied();
+    subcommands()
+        .find(|c| c.name.as_bytes() == name)
+        .or_else(|| subcommands().find(|c| c.aliases.iter().any(|a| a.as_bytes() == name)))
 }
 
 /// What a caller should print for a parse failure, and what to exit with.
@@ -1494,12 +1498,9 @@ impl<'t, 'v> Parser<'t, 'v> {
     }
 
     fn find_subcommand(&self, name: &[u8]) -> Option<&'t Command<'t>> {
-        // Names before aliases, for the reason given on the `find_subcommand` free function:
-        // a command's own name is never shadowed by another command's alias.
-        let subcommands = || self.cmd.subcommands.iter().copied();
-        subcommands()
-            .find(|c| c.name.as_bytes() == name)
-            .or_else(|| subcommands().find(|c| c.aliases.iter().any(|a| a.as_bytes() == name)))
+        // Shared with `help` rather than spelled out again, so descending into a command and
+        // asking about one cannot drift apart.
+        find_named(self.cmd, name)
     }
 }
 
@@ -2108,6 +2109,20 @@ mod tests {
             // The alias still reaches its own command by every name it does not share.
             let a = argv(["alpha"]);
             assert_eq!(parse(&root, &a).unwrap(), vec![Event::Command(&ALPHA)]);
+            // `ex help run` asks about the command `ex run` selects. These are separate
+            // lookups — help resolves a path without descending — and answering differently
+            // for a colliding word is the divergence this rule exists to end.
+            let a = argv(["help", "run"]);
+            match parse(&root, &a) {
+                Err(Error::Help { cmd, .. }) => {
+                    assert!(
+                        ::core::ptr::eq(cmd, &PLAIN_RUN),
+                        "got help for {}",
+                        cmd.name
+                    )
+                }
+                other => panic!("expected a help request, got {other:?}"),
+            }
         }
     }
 

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -759,14 +759,22 @@ pub const fn find_subcommand<'a>(
     subcommands: &'a [&'a Command<'a>],
     name: &str,
 ) -> &'a Command<'a> {
+    // Names first, then aliases: a command's own name outranks another command's alias, so
+    // the answer does not depend on the order the table happens to list them in. Checking
+    // each candidate's name *and* aliases in one pass instead let whichever command came
+    // first win, and usage-lib resolved the same spec to the last one.
+    let mut i = 0;
+    while i < subcommands.len() {
+        if str_eq(subcommands[i].name, name) {
+            return subcommands[i];
+        }
+        i += 1;
+    }
+    // Aliases answer too, because usage-lib resolves the name against names, aliases and
+    // hidden aliases alike — so a spec may point `default_subcommand` at any of them.
     let mut i = 0;
     while i < subcommands.len() {
         let candidate = subcommands[i];
-        if str_eq(candidate.name, name) {
-            return candidate;
-        }
-        // Aliases answer too, because usage-lib resolves the name against names, aliases and
-        // hidden aliases alike — so a spec may point `default_subcommand` at any of them.
         let mut a = 0;
         while a < candidate.aliases.len() {
             if str_eq(candidate.aliases[a], name) {
@@ -1486,11 +1494,12 @@ impl<'t, 'v> Parser<'t, 'v> {
     }
 
     fn find_subcommand(&self, name: &[u8]) -> Option<&'t Command<'t>> {
-        self.cmd
-            .subcommands
-            .iter()
-            .copied()
-            .find(|c| c.name.as_bytes() == name || c.aliases.iter().any(|a| a.as_bytes() == name))
+        // Names before aliases, for the reason given on the `find_subcommand` free function:
+        // a command's own name is never shadowed by another command's alias.
+        let subcommands = || self.cmd.subcommands.iter().copied();
+        subcommands()
+            .find(|c| c.name.as_bytes() == name)
+            .or_else(|| subcommands().find(|c| c.aliases.iter().any(|a| a.as_bytes() == name)))
     }
 }
 
@@ -2064,6 +2073,42 @@ mod tests {
             BY_ALIAS.default_subcommand.expect("declared"),
             &INSTALL
         ));
+    }
+
+    #[test]
+    fn a_name_outranks_another_commands_alias() {
+        // A spec `assert_unique_subcommand_names` would reject, resolved anyway: a parser
+        // handed a table nothing validated still has to answer, and the answer is the
+        // command whose own name it is. Both orders, because taking the first candidate
+        // that matched on either name or alias made this depend on which was listed first
+        // — and usage-lib, building a map, took the last.
+        static ALPHA: Command = Command {
+            name: "alpha",
+            aliases: &["run"],
+            key: 300,
+            ..Command::EMPTY
+        };
+        static PLAIN_RUN: Command = Command {
+            name: "run",
+            key: 301,
+            ..Command::EMPTY
+        };
+        for subcommands in [&[&ALPHA, &PLAIN_RUN] as &[&Command], &[&PLAIN_RUN, &ALPHA]] {
+            assert!(::core::ptr::eq(
+                find_subcommand(subcommands, "run"),
+                &PLAIN_RUN
+            ));
+            let root: Command = Command {
+                name: "ex",
+                subcommands,
+                ..Command::EMPTY
+            };
+            let a = argv(["run"]);
+            assert_eq!(parse(&root, &a).unwrap(), vec![Event::Command(&PLAIN_RUN)]);
+            // The alias still reaches its own command by every name it does not share.
+            let a = argv(["alpha"]);
+            assert_eq!(parse(&root, &a).unwrap(), vec![Event::Command(&ALPHA)]);
+        }
     }
 
     #[test]

--- a/cli/src/cli/lint.rs
+++ b/cli/src/cli/lint.rs
@@ -151,7 +151,11 @@ pub fn lint_spec(spec: &Spec, opts: LintOptions) -> Vec<LintIssue> {
 
     // Check default_subcommand reference
     if let Some(default_subcmd) = &spec.default_subcommand {
-        if !spec.cmd.subcommands.contains_key(default_subcmd) {
+        // Resolved the way a typed word is, rather than by canonical key alone: the name may
+        // be any the command answers to, aliases and hidden aliases included, so a spec
+        // declaring `default_subcommand "r"` against `cmd "run" { alias "r" }` is valid and
+        // was being reported as naming a command that does not exist.
+        if spec.cmd.find_subcommand(default_subcmd).is_none() {
             let valid: Vec<&str> = spec.cmd.subcommands.keys().map(|s| s.as_str()).collect();
             let valid_list = if valid.is_empty() {
                 "no subcommands defined".to_string()
@@ -566,6 +570,33 @@ flag "-v --very" help="very"
 
         let issues = lint_spec(&spec, LintOptions::default());
         assert!(issues.iter().any(|i| i.code == "duplicate-flag"));
+    }
+
+    #[test]
+    fn test_lint_default_subcommand_may_name_an_alias() {
+        // `default_subcommand` is resolved the way a typed word is, so any name the command
+        // answers to is valid. Checking canonical keys alone called this spec broken.
+        for alias in [r#"alias "r""#, r#"alias "r" hide=#true"#] {
+            let spec: Spec = format!(
+                r#"
+name "test"
+default_subcommand "r"
+cmd "run" help="run" {{
+    {alias}
+}}
+"#
+            )
+            .parse()
+            .unwrap();
+
+            let issues = lint_spec(&spec, LintOptions::default());
+            assert!(
+                !issues
+                    .iter()
+                    .any(|i| i.code == "invalid-default-subcommand"),
+                "{alias}: {issues:?}"
+            );
+        }
     }
 
     #[test]

--- a/cli/src/cli/lint.rs
+++ b/cli/src/cli/lint.rs
@@ -209,6 +209,37 @@ fn lint_command(
         });
     }
 
+    // Check for subcommands that answer to the same word
+    //
+    // One command's alias equal to another command's name leaves one of the two
+    // unreachable however it is resolved, so the spec is a mistake rather than
+    // something with a right answer. The grammar still picks the name over the
+    // alias, for a parser handed a spec nothing validated; a derive rejects the
+    // same shape outright, via `usage_argv::assert_unique_subcommand_names`.
+    let mut seen_subcommands: std::collections::HashMap<&str, &str> =
+        std::collections::HashMap::new();
+    for sub in cmd.subcommands.values() {
+        for word in std::iter::once(&sub.name)
+            .chain(&sub.aliases)
+            .chain(&sub.hidden_aliases)
+        {
+            match seen_subcommands.get(word.as_str()) {
+                Some(existing) => issues.push(LintIssue {
+                    severity: Severity::Error,
+                    code: "duplicate-subcommand".to_string(),
+                    message: format!(
+                        "Subcommands '{}' and '{}' both answer to '{}'",
+                        existing, sub.name, word
+                    ),
+                    location: Some(format!("cmd {}", cmd_path)),
+                }),
+                None => {
+                    seen_subcommands.insert(word.as_str(), &sub.name);
+                }
+            }
+        }
+    }
+
     // Check for duplicate flag names
     let mut seen_flags: std::collections::HashMap<String, &SpecFlag> =
         std::collections::HashMap::new();
@@ -535,6 +566,41 @@ flag "-v --very" help="very"
 
         let issues = lint_spec(&spec, LintOptions::default());
         assert!(issues.iter().any(|i| i.code == "duplicate-flag"));
+    }
+
+    #[test]
+    fn test_lint_duplicate_subcommand() {
+        // One command's alias equal to another's name. The grammar resolves it —
+        // the name wins — but the alias is then unreachable, so the spec is still
+        // a mistake worth reporting.
+        let spec: Spec = r#"
+name "test"
+cmd "alpha" help="alpha" {
+    alias "run"
+}
+cmd "run" help="run"
+        "#
+        .parse()
+        .unwrap();
+
+        let issues = lint_spec(&spec, LintOptions::default());
+        assert!(issues.iter().any(|i| i.code == "duplicate-subcommand"));
+    }
+
+    #[test]
+    fn test_lint_allows_an_alias_that_collides_with_nothing() {
+        let spec: Spec = r#"
+name "test"
+cmd "install" help="install" {
+    alias "i"
+}
+cmd "run" help="run"
+        "#
+        .parse()
+        .unwrap();
+
+        let issues = lint_spec(&spec, LintOptions::default());
+        assert!(!issues.iter().any(|i| i.code == "duplicate-subcommand"));
     }
 
     #[test]

--- a/conformance/src/argv.rs
+++ b/conformance/src/argv.rs
@@ -71,11 +71,14 @@ pub fn run(vector: &Vector) -> Outcome {
     // will fail loudly rather than this guessing.
     let root: &'static Command<'static> = match spec.default_subcommand.as_deref() {
         Some(name) => {
-            let default = root
-                .subcommands
-                .iter()
-                .copied()
-                .find(|sub| sub.name == name || sub.aliases.contains(&name));
+            // Names before aliases, the rule `usage_argv::find_subcommand` implements for
+            // generated code. Spelled out again rather than called because that one panics
+            // on a name nothing answers to — a compile error where it runs, but here the
+            // vector should fail on its own terms instead.
+            let subcommands = || root.subcommands.iter().copied();
+            let default = subcommands()
+                .find(|sub| sub.name == name)
+                .or_else(|| subcommands().find(|sub| sub.aliases.contains(&name)));
             Box::leak(Box::new(Command {
                 default_subcommand: default,
                 ..*root

--- a/corpus/04-subcommands.json
+++ b/corpus/04-subcommands.json
@@ -17,6 +17,20 @@
       "expect": { "ok": { "cmd": ["install"] } }
     },
     {
+      "id": "cmd-name-outranks-other-alias",
+      "doc": "A command's own name outranks another command's alias: the word is matched against every subcommand's name before any alias is considered. Such a spec is a mistake — `usage lint` reports `duplicate-subcommand` — but the resolution is pinned so that a parser handed an unvalidated spec answers like every other one.",
+      "spec": "name \"ex\"\nbin \"ex\"\ncmd \"alpha\" {\n  alias \"run\"\n  arg \"[a]\"\n}\ncmd \"run\" {\n  arg \"[b]\"\n}\n",
+      "argv": ["run", "x"],
+      "expect": { "ok": { "cmd": ["run"], "args": { "b": "x" } } }
+    },
+    {
+      "id": "cmd-name-outranks-other-alias-reordered",
+      "doc": "The same spec with the two `cmd` blocks swapped selects the same command, which is the point of ranking names above aliases rather than taking the first or last declaration: reordering declarations cannot change what a command line means.",
+      "spec": "name \"ex\"\nbin \"ex\"\ncmd \"run\" {\n  arg \"[b]\"\n}\ncmd \"alpha\" {\n  alias \"run\"\n  arg \"[a]\"\n}\n",
+      "argv": ["run", "x"],
+      "expect": { "ok": { "cmd": ["run"], "args": { "b": "x" } } }
+    },
+    {
       "id": "cmd-nested",
       "doc": "Descent continues as long as words keep matching subcommands.",
       "spec": "name \"ex\"\nbin \"ex\"\ncmd \"settings\" {\n  cmd \"set\"\n}\n",

--- a/corpus/09-default-subcommand.json
+++ b/corpus/09-default-subcommand.json
@@ -42,6 +42,13 @@
       }
     },
     {
+      "id": "default-name-outranks-other-alias",
+      "doc": "`default_subcommand` names a command by the same rule a typed word selects one, so a command's own name outranks another command's alias here too.",
+      "spec": "name \"ex\"\nbin \"ex\"\ndefault_subcommand \"run\"\ncmd \"alpha\" {\n  alias \"run\"\n  arg \"[a]\"\n}\ncmd \"run\" {\n  arg \"[b]\"\n}\n",
+      "argv": ["build"],
+      "expect": { "ok": { "cmd": ["run"], "args": { "b": "build" } } }
+    },
+    {
       "id": "default-word-reexamined",
       "doc": "The word is examined again against the command it reached, so it can name one of *its* subcommands. mise's mounted task names arrive this way.",
       "spec": "name \"ex\"\nbin \"ex\"\ndefault_subcommand \"run\"\ncmd \"run\" {\n  cmd \"lint\"\n}\n",

--- a/docs/spec/argv.md
+++ b/docs/spec/argv.md
@@ -213,6 +213,19 @@ A word is matched against the subcommands of the command in scope, by name and b
 alias. A match descends: parsing continues against the subcommand, and the
 selected path records the canonical name even when an alias was typed.
 
+**A name outranks an alias.** The word is matched against every subcommand's
+name first; only if none answers is it matched against their aliases. So
+declaration order never decides which command a word selects — reordering `cmd`
+blocks cannot change what a command line means — and no command's own name can
+be shadowed by another command's alias.
+
+That precedence only ever comes up in a spec that should not exist: one command's
+alias equal to another's name leaves one of the two unreachable whichever way it
+is resolved. `usage lint` reports it as `duplicate-subcommand`, and a derive
+rejects it at compile time. The rule is stated because a parser handed a spec it
+did not validate still has to answer, and every implementation should answer the
+same way.
+
 **A subcommand name wins over a positional value.** A CLI that declares both
 cannot receive a positional whose text equals one of its subcommand names — mise
 documents exactly this hazard for tasks that share a name with a command.

--- a/go/argv/parser.go
+++ b/go/argv/parser.go
@@ -606,11 +606,17 @@ func (p *Parser) findSubcommand(name string) *Command {
 }
 
 // findNamed resolves a word against a command's subcommands, by name or alias.
+//
+// Names are checked across every subcommand before any alias is, so a command's
+// own name outranks another command's alias and the answer does not depend on
+// the order the table lists them in.
 func findNamed(cmd *Command, name string) *Command {
 	for _, sub := range cmd.Subcommands {
 		if sub.Name == name {
 			return sub
 		}
+	}
+	for _, sub := range cmd.Subcommands {
 		for _, a := range sub.Aliases {
 			if a == name {
 				return sub

--- a/go/argv/parser_test.go
+++ b/go/argv/parser_test.go
@@ -222,6 +222,29 @@ func TestParseAllocatesNothing(t *testing.T) {
 	}
 }
 
+// A command's own name beats another command's alias, whichever order the table
+// lists them in. Checking each subcommand's name and aliases together made this
+// depend on which came first — and usage-lib, building a map, answered with the
+// last. Neither was a rule anyone had picked, so the grammar picked this one.
+func TestNameOutranksAnotherCommandsAlias(t *testing.T) {
+	alpha := &Command{Name: "alpha", Aliases: []string{"run"}, Key: 300}
+	plainRun := &Command{Name: "run", Key: 301}
+
+	for _, subs := range [][]*Command{
+		{alpha, plainRun},
+		{plainRun, alpha},
+	} {
+		cmd := &Command{Name: "ex", Subcommands: subs}
+		if got := findNamed(cmd, "run"); got != plainRun {
+			t.Errorf("findNamed(%q) = %v, want the command named run", "run", got)
+		}
+		// The alias's own command is still reachable by every name it does not share.
+		if got := findNamed(cmd, "alpha"); got != alpha {
+			t.Errorf("findNamed(%q) = %v, want alpha", "alpha", got)
+		}
+	}
+}
+
 func BenchmarkParse(b *testing.B) {
 	args := []string{"install", "--verbose", "-f", "a", "b", "c"}
 	b.ReportAllocs()

--- a/go/internal/spec/spec.go
+++ b/go/internal/spec/spec.go
@@ -175,11 +175,22 @@ func (s *Spec) Build() (*argv.Command, argv.Metadata) {
 	// is resolved once, here, against the root's own subcommands. A name that
 	// answers to nothing is left unset: the spec is what it is, and a vector or a
 	// build that expects routing should fail loudly rather than have this guess.
+	// Names before aliases, the same precedence a typed word gets: a command's own
+	// name outranks another command's alias, so this does not depend on the order
+	// the spec declares them in.
 	if s.DefaultSubcommand != "" {
 		for _, sub := range root.Subcommands {
-			if sub.Name == s.DefaultSubcommand || contains(sub.Aliases, s.DefaultSubcommand) {
+			if sub.Name == s.DefaultSubcommand {
 				root.DefaultSubcommand = sub
 				break
+			}
+		}
+		if root.DefaultSubcommand == nil {
+			for _, sub := range root.Subcommands {
+				if contains(sub.Aliases, s.DefaultSubcommand) {
+					root.DefaultSubcommand = sub
+					break
+				}
 			}
 		}
 	}

--- a/lib/src/go/mod.rs
+++ b/lib/src/go/mod.rs
@@ -278,14 +278,16 @@ impl<'a> Emitter<'a> {
         // descended into a command that is not the root's child at all. A name
         // nothing answers to is left unset rather than guessed at.
         let default_subcommand = self.spec.default_subcommand.as_ref().and_then(|name| {
-            commands[0]
-                .subcommands
-                .iter()
-                .map(|at| &commands[*at])
-                .find(|e| {
-                    &e.cmd.name == name
-                        || e.cmd.aliases.contains(name)
-                        || e.cmd.hidden_aliases.contains(name)
+            let direct = || commands[0].subcommands.iter().map(|at| &commands[*at]);
+            // Names before aliases, as the grammar says: a command's own name outranks
+            // another command's alias, so which one this resolves to does not depend on
+            // the order the spec declares them in.
+            direct()
+                .find(|e| &e.cmd.name == name)
+                .or_else(|| {
+                    direct().find(|e| {
+                        e.cmd.aliases.contains(name) || e.cmd.hidden_aliases.contains(name)
+                    })
                 })
                 .map(|e| e.named.var.clone())
         });
@@ -853,6 +855,31 @@ cmd "run" {
             out.contains("DefaultSubcommand: cmdRun,"),
             "should point at the root's own `run`, got:\n{out}"
         );
+    }
+
+    /// A command's own name outranks another command's alias, so which command the
+    /// emitted `DefaultSubcommand` points at does not depend on declaration order.
+    #[test]
+    fn a_default_subcommand_prefers_a_name_to_another_commands_alias() {
+        let ordered = |first: &str, second: &str| {
+            go(&format!(
+                r#"
+name "ex"
+bin "ex"
+default_subcommand "run"
+{first}
+{second}
+"#
+            ))
+        };
+        let alpha = "cmd \"alpha\" {\n    alias \"run\"\n}";
+        let run = "cmd \"run\" {\n    arg \"[args]...\" var=#true\n}";
+        for out in [ordered(alpha, run), ordered(run, alpha)] {
+            assert!(
+                out.contains("DefaultSubcommand: cmdRun,"),
+                "should point at the command named `run`, got:\n{out}"
+            );
+        }
     }
 
     /// A subcommand actually named `root` wants the constant the root has.

--- a/lib/src/spec/cmd.rs
+++ b/lib/src/spec/cmd.rs
@@ -587,13 +587,19 @@ impl SpecCommand {
     pub fn find_subcommand(&self, name: &str) -> Option<&SpecCommand> {
         let sl = self.subcommand_lookup.get_or_init(|| {
             let mut map = HashMap::new();
-            for (name, cmd) in &self.subcommands {
+            // Names first, then aliases only where nothing answers already: a
+            // command's own name outranks another command's alias, so reordering
+            // `cmd` blocks cannot change which command a word selects.
+            //
+            // Inserting both in one pass instead let the *last* declaration win,
+            // which was the opposite of what usage-argv did with the same spec —
+            // it takes the first. Neither was a rule anyone had chosen.
+            for name in self.subcommands.keys() {
                 map.insert(name.clone(), name.clone());
-                for alias in &cmd.aliases {
-                    map.insert(alias.clone(), name.clone());
-                }
-                for alias in &cmd.hidden_aliases {
-                    map.insert(alias.clone(), name.clone());
+            }
+            for (name, cmd) in &self.subcommands {
+                for alias in cmd.aliases.iter().chain(&cmd.hidden_aliases) {
+                    map.entry(alias.clone()).or_insert_with(|| name.clone());
                 }
             }
             map


### PR DESCRIPTION
## The divergence

usage-lib and usage-argv resolved a subcommand word differently when one command's alias equalled another command's canonical name:

```kdl
name "ex"
bin "ex"
cmd "alpha" { alias "run"; arg "[a]" }
cmd "run" { arg "[b]" }
```

Found while reviewing #931; it predates that work and is independent of it.

It is not, as it first appeared, a canonical-vs-alias disagreement. Probing **both declaration orders** through the conformance harness shows both implementations were order-dependent, in opposite directions:

| declaration order | usage-lib | usage-argv / go |
| --- | --- | --- |
| `alpha{alias run}` then `run` | → `run` | → `alpha` |
| `run` then `alpha{alias run}` | → `alpha` | → `run` |

`SpecCommand::find_subcommand` built a `HashMap` over an `IndexMap` in declaration order, inserting `name → name` then `alias → name`, so the **last** declaration overwrote. usage-argv scanned candidates checking name *and* aliases together, so the **first** won. The spec above only reads as "canonical wins" because `alpha` happens to be declared first — swap the two `cmd` blocks and each implementation flips.

So neither side implemented a rule anyone had picked, and "keep one implementation, fix the other" was never available.

## The rule

`docs/spec/argv.md` now states: a word is matched against every subcommand's **name** first; only if none answers is it matched against their aliases.

This is order-independent, which is the point. Reordering `cmd` blocks cannot change what a command line means — declaration order stays presentational, as it is everywhere else in the spec — and no command's own name can be shadowed by another command's alias. The alternative (first-or-last declaration wins) would have made block order load-bearing for routing.

## Rejecting the spec

Such a spec is a mistake however it resolves, since one of the two commands is unreachable either way. `usage lint` now reports `duplicate-subcommand` at `Severity::Error`, beside the existing `duplicate-flag` and `duplicate-arg`, covering names, aliases and hidden aliases.

This mirrors for hand-written KDL what a derive already rejects at compile time via `usage_argv::assert_unique_subcommand_names`. **No spec checked into this repository trips the rule** — all 21 `*.usage.kdl` files including mise's were scanned.

The precedence is still written down rather than left undefined, because a parser handed a spec nothing validated still has to answer, and every implementation should answer the same way.

## What changed

The rule turned out to be spelled out in **eight** places, not the five this PR originally claimed — review caught three more, and that undercount is itself the argument for consolidating rather than patching:

Resolution proper:

- `SpecCommand::find_subcommand` (`lib/src/spec/cmd.rs`) — names into the map first, aliases only via `or_insert`
- `usage_argv::find_subcommand`, the `const fn` used for `default_subcommand`
- `find_named` (`argv/src/lib.rs`) — **now the single implementation on argv's side**, shared by `Parser::find_subcommand` and by the `help` route walk in `help.rs`, which each had their own copy. `ex run` and `ex help run` could select different commands.
- the `default_subcommand` lookup on the completion path (`argv/src/complete.rs`), which offered the positional values of a command the parser would not have routed to
- `findNamed` (`go/argv/parser.go`), already shared by both Go paths

Emission and harnesses:

- the Go emitter's `default_subcommand` lookup (`lib/src/go/mod.rs`)
- `conformance/src/argv.rs` and `go/internal/spec/spec.go` — the two harnesses, which cannot call `find_subcommand` since it panics on a name nothing answers to, and a harness wants `None` there. This is what kept the `default_subcommand` vector red after the parsers were fixed.

## A pre-existing bug fixed next door

`usage lint` validated `default_subcommand` with `spec.cmd.subcommands.contains_key`, so a spec naming the command by an alias — `default_subcommand "r"` against `cmd "run" { alias "r" }` — was reported as `invalid-default-subcommand`. It resolves through `SpecCommand::find_subcommand` now, which accepts hidden aliases too. The corpus already pins that `default_subcommand` resolves by alias, so the lint was contradicting the grammar.

## Tests

Three corpus vectors, including **the same spec with its two `cmd` blocks swapped** — that pair is what pins order-independence rather than only the happy case. No `reference.diverges` note is needed: both implementations now agree with the grammar, so `conformance/tests/reference.rs` keeps the absent label honest from here.

Unit tests alongside: precedence in both declaration orders in usage-argv and go/argv, `ex help run`, the completion fallback, the Go emitter's `default_subcommand`, and lint coverage for `duplicate-subcommand` plus both alias kinds on `default_subcommand`. **Each new test was confirmed to fail against the previous lookups** rather than only passing against the new ones.

Green: full Rust suite (`--all --all-features`), clippy clean, all four Go packages, all 157 corpus vectors answered by both parsers.

## One structural note

`conformance/tests/reference.rs::specs_are_valid` asserts every corpus spec parses, so the corpus structurally cannot express "this spec is rejected". The rejection is therefore a lint test, and the corpus vectors pin only the fallback resolution. Worth knowing if the parse-time hard error is ever wanted — that would need a home outside the argv corpus, and would be a breaking change where this is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core CLI routing, completion, help paths, and spec lint across Rust and Go; behavior changes only for invalid collision specs, but every parser must stay aligned with the harness copies that cannot call panicking helpers.
> 
> **Overview**
> **Subcommand words now resolve with a single rule:** match every subcommand **name** first, then aliases. That replaces order-dependent behavior where usage-lib (last map insert) and usage-argv/Go (first combined name+alias hit) disagreed when one command's alias equaled another's name.
> 
> The shared **`find_named`** in usage-argv drives parsing, `help` route walking, root **default_subcommand** completion lookup, and the const **`find_subcommand`** / **`SpecCommand::find_subcommand`** / Go **`findNamed`** / spec **Build** / Go emitter paths use the same two-pass pattern. **`docs/spec/argv.md`** documents the precedence; corpus cases pin it with swapped `cmd` block order.
> 
> **Lint:** `default_subcommand` is validated via **`find_subcommand`** (aliases/hidden aliases count); new **`duplicate-subcommand`** errors flag name/alias collisions. Tests cover precedence, completion at the root fallback, and lint positive/negative cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d08a95346a5bf0767618310a182b1d4680d375c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->