### PR TITLE
fix(shadow): carry the program's own name and version

### DIFF
--- a/benches/shadows/mise/src/lib.rs
+++ b/benches/shadows/mise/src/lib.rs
@@ -6035,6 +6035,7 @@ pub struct WhichArgs {
 #[derive(Cli)]
 #[usage(
     bin = "mise",
+    name = "mise",
     about = "Dev tools, env vars, and tasks in one CLI",
     long_about = "mise prepares your development environment before each command runs. https://github.com/jdx/mise",
     default_subcommand = "run"

--- a/xtask/src/shadow.rs
+++ b/xtask/src/shadow.rs
@@ -132,6 +132,8 @@ fn render(spec: &Spec, spec_path: &Path, dialect: Dialect) -> (String, Skipped) 
         true,
         &mut Run {
             bin: &spec.bin,
+            name: &spec.name,
+            version: spec.version.as_deref(),
             default_subcommand: spec.default_subcommand.as_deref(),
             about: spec.about.as_deref(),
             about_long: spec.about_long.as_deref(),
@@ -242,6 +244,14 @@ impl Type {
 /// need a clippy exclusion. They belong together: none of them varies per command.
 struct Run<'a> {
     bin: &'a str,
+    /// What the program calls itself, which is not always what it is invoked as.
+    ///
+    /// usage-lib banners the root page `{name} {version}`, falling back to `{bin}` — so a
+    /// shadow that dropped this rendered a different first line than the spec it came from.
+    name: &'a str,
+    /// Only printed where there is one, which is why five of the fleet's seven have a banner
+    /// and mise does not.
+    version: Option<&'a str>,
     /// Only the root has one, and only it declares it.
     default_subcommand: Option<&'a str>,
     /// The spec's own description, which belongs to the root.
@@ -316,6 +326,17 @@ fn emit_command(out: &mut String, cmd: &SpecCommand, ty: &Type, is_root: bool, r
     let mut usage_opts: Vec<String> = Vec::new();
     if is_root {
         usage_opts.push(format!("bin = {bin:?}"));
+        // The program's own identity, which the shadow used to leave behind: the derive
+        // defaults `name` from the struct it is written on, so a generated `Cli` called itself
+        // `cli`, and a spec's `version` reached nothing at all. Both are on the root page —
+        // `hk 1.55.0` above the description — so dropping them changed the first line a user
+        // reads. mise's spec declares no version, which is why the gate over it never noticed.
+        if !run.name.is_empty() {
+            usage_opts.push(format!("name = {:?}", run.name));
+        }
+        if let Some(version) = run.version {
+            usage_opts.push(format!("version = {version:?}"));
+        }
         usage_opts.extend(declared_about.iter().cloned());
     }
     // Text around the rest of the page. clap spells the long forms the same way, so both
@@ -371,6 +392,10 @@ fn emit_command(out: &mut String, cmd: &SpecCommand, ty: &Type, is_root: bool, r
             // them left the clap shadow not describing the program at all — a fixture for
             // comparing two frameworks cannot have one of them missing the CLI's own about.
             let mut opts = vec![format!("name = {bin:?}")];
+            // clap spells this the same way, so the two shadows describe the same program.
+            if let Some(version) = run.version {
+                opts.push(format!("version = {version:?}"));
+            }
             opts.extend(declared_about.iter().cloned());
             out.push_str(&format!("#[command({})]\n", opts.join(", ")));
         }
@@ -1584,6 +1609,38 @@ mod tests {
             1,
             "only the root should declare it: {out}"
         );
+    }
+
+    #[test]
+    fn the_program_says_what_it_is_called_and_which_version() {
+        // usage-lib banners the root page `{name} {version}`. The shadow carried neither, so
+        // its first line was the description where the spec's was the banner — on five of the
+        // seven jdx CLIs. It went unseen because mise's spec declares no `version`, and mise's
+        // spec is what the parity gate reads.
+        let (out, _) = rendered("name \"hk\"\nbin \"hk\"\nversion \"1.55.0\"\n");
+        assert!(out.contains("name = \"hk\""), "{out}");
+        assert!(out.contains("version = \"1.55.0\""), "{out}");
+    }
+
+    #[test]
+    fn a_spec_with_no_version_declares_none() {
+        // mise's case, and the reason a missing banner looked correct: with nothing to print,
+        // both renderers agree either way. Emitting `version` regardless would have the shadow
+        // claim one the spec never gave.
+        let (out, _) = rendered("name \"mise\"\nbin \"mise\"\n");
+        assert!(!out.contains("version ="), "{out}");
+        assert!(out.contains("name = \"mise\""), "{out}");
+    }
+
+    #[test]
+    fn the_clap_dialect_carries_the_version_too() {
+        // Both shadows describe one program, so a fixture comparing them must not differ in
+        // what the program calls itself.
+        let (out, _) = rendered_as(
+            "name \"hk\"\nbin \"hk\"\nversion \"1.55.0\"\n",
+            Dialect::Clap,
+        );
+        assert!(out.contains("version = \"1.55.0\""), "{out}");
     }
 
     #[test]

--- a/xtask/src/shadow.rs
+++ b/xtask/src/shadow.rs
@@ -391,7 +391,11 @@ fn emit_command(out: &mut String, cmd: &SpecCommand, ty: &Type, is_root: bool, r
             // independent `about` and `long_about`, and skipping the comment without writing
             // them left the clap shadow not describing the program at all — a fixture for
             // comparing two frameworks cannot have one of them missing the CLI's own about.
-            let mut opts = vec![format!("name = {bin:?}")];
+            // The same fallback the usage dialect uses: a spec whose `name` differs from its
+            // `bin` would otherwise give the two shadows different root identities, and they
+            // exist to be the same CLI told to two frameworks.
+            let name = if run.name.is_empty() { bin } else { run.name };
+            let mut opts = vec![format!("name = {name:?}")];
             // clap spells this the same way, so the two shadows describe the same program.
             if let Some(version) = run.version {
                 opts.push(format!("version = {version:?}"));
@@ -1630,6 +1634,17 @@ mod tests {
         let (out, _) = rendered("name \"mise\"\nbin \"mise\"\n");
         assert!(!out.contains("version ="), "{out}");
         assert!(out.contains("name = \"mise\""), "{out}");
+    }
+
+    #[test]
+    fn both_dialects_agree_what_the_program_is_called() {
+        // Reported on #968: the clap root formatted its name from `bin` while the usage root had
+        // moved to the spec's `name`, so a spec where the two differ described two programs.
+        let spec = "name \"Fancy\"\nbin \"fancy\"\n";
+        let (usage, _) = rendered_as(spec, Dialect::Usage);
+        let (clap, _) = rendered_as(spec, Dialect::Clap);
+        assert!(usage.contains("name = \"Fancy\""), "{usage}");
+        assert!(clap.contains("name = \"Fancy\""), "{clap}");
     }
 
     #[test]


### PR DESCRIPTION
usage-lib banners the root page `{name} {version}`, falling back to the bin
name. The shadow generator declared neither, so a generated CLI's first line
was its description where the spec's was the banner — and the derive, which
defaults `name` from the struct it is written on, called every shadow `cli`.

Found by running the generator over all seven jdx CLIs rather than only mise.
It changed the front page of five of them: hk, fnox, pitchfork, aube and
communique. The parity gate could not have caught it, because mise's spec
declares no `version` at all — with nothing to print, both renderers agree
either way, and mise's spec is the only one the gate reads.

Emitted only when the spec gives one, so a shadow never claims a version its
source did not. The clap dialect carries it too, since the two shadows are a
fixture for comparing one program against itself.

hk, fnox and communique are now byte-identical to usage-lib across every
command. pitchfork and aube still differ for two unrelated reasons, each its
own change.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to xtask shadow generation, regenerated bench output, and tests—no runtime auth or data paths.
> 
> **Overview**
> **The shadow generator now emits the spec’s root `name` and optional `version`** on generated CLIs so help matches usage-lib’s `{name} {version}` banner instead of jumping straight to the description (and so usage roots no longer default to struct name `cli`).
> 
> **Usage and clap root attributes are aligned:** usage `#[usage(...)]` gets `name` / `version` when the spec provides them; clap `#[command(...)]` uses the same `name` fallback (not only `bin`) and adds `version` when set. **`version` is omitted** when the spec has none (e.g. mise). The checked-in **mise usage shadow** picks up `name = "mise"`. **Unit tests** cover banner fields, no-version specs, and cross-dialect identity parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 139e014c99c3eb26e65685685efbb7ec4eb04b8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Command-line help now displays the configured program name and version when available.
  * Generated usage information remains consistent across supported command-line formats.
  * When no program name is configured, the displayed name falls back to the executable’s name.
* **Bug Fixes**
  * Prevented empty or unavailable version details from appearing in command-line help.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->