### PR TITLE
feat(argv): a flag whose value may be left off

### DIFF
--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -247,7 +247,14 @@ fn flag_usage_masked(meta: &FlagMeta<'_>, show: &Shown) -> String {
     }
     if flag.takes_value {
         let name = meta.value_name.unwrap_or(flag.name);
-        let _ = write!(out, " <{name}>");
+        // Angled where the value must be given, squared where it need not — the same brackets
+        // an argument uses, and for the same reason. pitchfork's `--bump` is the fleet's case.
+        let (open, close) = if meta.value_optional {
+            ('[', ']')
+        } else {
+            ('<', '>')
+        };
+        let _ = write!(out, " {open}{name}{close}");
         if flag.variadic {
             out.push('…');
         }

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -480,6 +480,13 @@ pub struct FlagMeta<'a> {
     pub default: &'a [&'a str],
     pub choices: &'a [&'a str],
     pub required: bool,
+    /// Whether the flag's value may be left off, as in `--bump` or `--bump 5`.
+    ///
+    /// Help only, and deliberately: usage-lib's parser refuses a bare `--bump` exactly as it
+    /// refuses a bare `--port`, so this changes no binding — it changes the brackets, `[BUMP]`
+    /// rather than `<BUMP>`, which is what a spec's `arg "[BUMP]" required=#false` says. In
+    /// [`FlagMeta`] and not in [`Flag`] for that reason: a parse never reads it.
+    pub value_optional: bool,
     pub hide: bool,
     /// Whether repetition is counted rather than collected, as in `-vvv`.
     pub count: bool,
@@ -533,6 +540,7 @@ impl FlagMeta<'_> {
         default: &[],
         choices: &[],
         required: false,
+        value_optional: false,
         hide: false,
         count: false,
         repeatable: false,
@@ -1050,8 +1058,13 @@ fn write_flag(out: &mut String, meta: &FlagMeta<'_>, depth: usize) -> core::fmt:
         write!(
             out,
             "arg {}",
-            quoted(&placeholder(name, meta.flag.variadic))
+            quoted(&placeholder(name, meta.flag.variadic, meta.value_optional))
         )?;
+        // Square brackets alone would round-trip as required, since usage-lib reads the
+        // brackets *and* the attribute: `[BUMP]` without it comes back `required=#true`.
+        if meta.value_optional {
+            out.push_str(" required=#false");
+        }
         if meta.choices.is_empty() {
             out.push('\n');
         } else {
@@ -1221,9 +1234,10 @@ fn flag_forms(flag: &Flag<'_>) -> String {
 }
 
 /// `<name>` or `<name>...`, the spec's way of writing a value placeholder.
-fn placeholder(name: &str, variadic: bool) -> String {
+fn placeholder(name: &str, variadic: bool, optional: bool) -> String {
     let ellipsis = if variadic { "..." } else { "" };
-    format!("<{name}>{ellipsis}")
+    let (open, close) = if optional { ('[', ']') } else { ('<', '>') };
+    format!("{open}{name}{close}{ellipsis}")
 }
 
 /// A positional's placeholder: angle brackets when required, square when not.
@@ -1699,7 +1713,8 @@ mod tests {
         };
         assert_eq!(arg_placeholder("file", &required), "<file>");
         assert_eq!(arg_placeholder("rest", &optional_var), "[rest]...");
-        assert_eq!(placeholder("n", false), "<n>");
-        assert_eq!(placeholder("pattern", true), "<pattern>...");
+        assert_eq!(placeholder("n", false, false), "<n>");
+        assert_eq!(placeholder("pattern", true, false), "<pattern>...");
+        assert_eq!(placeholder("BUMP", false, true), "[BUMP]");
     }
 }

--- a/conformance/tests/optional_flag_value.rs
+++ b/conformance/tests/optional_flag_value.rs
@@ -1,0 +1,77 @@
+//! A flag whose value may be left off: `[BUMP]` rather than `<BUMP>`.
+//!
+//! A spec says this with `arg "[BUMP]" required=#false` inside the flag, and pitchfork's
+//! `--bump` is the case that found it — usage-lib rendered `[BUMP]`, usage-argv `<BUMP>`, on
+//! three of pitchfork's pages.
+//!
+//! **Help only, and measured rather than assumed.** usage-lib's parser refuses a bare `--bump`
+//! exactly as it refuses a bare `--port`:
+//!
+//! ```text
+//! ["--bump"]        -> ERR Invalid flag `--bump`: requires an argument
+//! ["--bump", "5"]   -> OK  bump="5"
+//! ```
+//!
+//! So this changes no binding, which is why it lives in `FlagMeta` and not in `Flag`: a parse
+//! never reads it. It cannot be inferred from the type either — `Option<String>` already says
+//! the *flag* is optional and says nothing about its value — so it is declared.
+
+use std::ffi::OsStr;
+
+use usage::Spec as LibSpec;
+use usage_argv::help;
+use usage_derive::Cli;
+
+/// A tool with one of each
+#[derive(Cli)]
+#[usage(bin = "ex")]
+struct Ex {
+    /// Automatically find an available port if the expected port is in use
+    #[usage(long, value_name = "BUMP", value_optional)]
+    bump: Option<String>,
+    /// The port to listen on
+    #[usage(long, value_name = "PORT")]
+    port: Option<String>,
+}
+
+fn listing() -> String {
+    let page = help::render(Ex::spec(), Ex::command(), false).expect("a page");
+    page.split_once("\nFlags:")
+        .expect("a flags section")
+        .1
+        .to_string()
+}
+
+#[test]
+fn an_optional_value_is_squared_and_a_required_one_angled() {
+    let flags = listing();
+    assert!(flags.contains("--bump [BUMP]"), "{flags}");
+    assert!(flags.contains("--port <PORT>"), "{flags}");
+}
+
+#[test]
+fn the_reference_renders_it_the_same_way() {
+    // The invariant this area runs on: the two renderers agree byte for byte. Through the
+    // emitted spec, so the round trip is covered too — square brackets alone come back
+    // `required=#true`, since usage-lib reads the attribute as well as the name.
+    let spec: LibSpec = Ex::to_kdl().parse().expect("valid spec");
+    let theirs = usage::docs::cli::render_help(&spec, &spec.cmd, false);
+    let ours = help::render(Ex::spec(), Ex::command(), false).expect("a page");
+    assert_eq!(ours, theirs);
+}
+
+#[test]
+fn the_emitted_spec_says_both_halves() {
+    let kdl = Ex::to_kdl();
+    assert!(kdl.contains(r#"arg "[BUMP]" required=#false"#), "{kdl}");
+    assert!(kdl.contains(r#"arg "<PORT>""#), "{kdl}");
+}
+
+#[test]
+fn it_still_takes_its_value() {
+    // Nothing about binding changed: the value is read where it is given.
+    let argv = [OsStr::new("--bump"), OsStr::new("5")];
+    let parsed = Ex::parse_from(&argv).expect("parses");
+    assert_eq!(parsed.bump.as_deref(), Some("5"));
+    assert_eq!(parsed.port.as_deref(), None);
+}

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -866,6 +866,9 @@ fn flag_meta(i: usize, field: &Field, owner: &syn::Ident) -> TokenStream {
     // A collecting field's type cannot say whether one value is needed, so `required` may
     // declare it. Every other shape gets its answer from the type.
     let required = field.shape == Shape::Required || field.required_collection;
+    // Declared, not inferred: `Option<String>` already says the *flag* is optional and says
+    // nothing about whether its value is.
+    let value_optional = field.value_optional;
     let choices = choices_tokens(field);
     let (var_min, var_max) = bounds_tokens(field);
     // Written as declared, in the spec's own spelling, so the emitted KDL says what
@@ -901,6 +904,7 @@ fn flag_meta(i: usize, field: &Field, owner: &syn::Ident) -> TokenStream {
             count: #count,
             repeatable: #repeatable,
             required: #required,
+            value_optional: #value_optional,
             choices: #choices,
             var_min: #var_min,
             var_max: #var_max,

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -150,6 +150,13 @@ pub struct Field {
     /// way of saying "one or more" — could not be declared at all, and came back as
     /// `[TARGET]…`. This is the one place it has to be stated rather than inferred.
     pub required_collection: bool,
+    /// Whether the flag's value may be left off: `[BUMP]` rather than `<BUMP>`.
+    ///
+    /// Help and the emitted spec only. usage-lib's parser refuses a bare `--bump` exactly as it
+    /// refuses a bare `--port`, so this binds nothing differently — which is why it is stated
+    /// here and not inferred from the type, where `Option<String>` already means the *flag* is
+    /// optional and says nothing about its value.
+    pub value_optional: bool,
     /// The placeholder for a flag's value in help and in the emitted spec: `n` in
     /// `--jobs <n>`.
     ///
@@ -914,6 +921,7 @@ impl Field {
             ident: ident.clone(),
             ty: field.ty.clone(),
             name: to_kebab(&ident.to_string()),
+            value_optional: false,
             kind: Kind::Flatten {
                 ty: field.ty.clone(),
             },
@@ -1012,6 +1020,7 @@ impl Field {
             ident: ident.clone(),
             ty: field.ty.clone(),
             name: to_kebab(&ident.to_string()),
+            value_optional: false,
             kind: Kind::Subcommand { ty, optional },
             effect: None,
             complete: None,
@@ -1070,6 +1079,7 @@ impl Field {
         let mut repeatable = false;
         let mut variadic = false;
         let mut count = false;
+        let mut value_optional = false;
         let mut double_dash = DoubleDash::Optional;
         let mut env = None;
         let mut setting = None;
@@ -1130,6 +1140,10 @@ impl Field {
                     "var" => repeatable = flag_value(&meta)?,
                     "variadic" => variadic = flag_value(&meta)?,
                     "count" => count = flag_value(&meta)?,
+                    // Help only: the parser refuses a bare `--bump` either way. What this
+                    // changes is the brackets, which is the whole of what a spec's
+                    // `arg "[BUMP]" required=#false` says.
+                    "value_optional" => value_optional = flag_value(&meta)?,
                     "hide" => hide = flag_value(&meta)?,
                     "arg" => is_arg = flag_value(&meta)?,
                     "env" => env = Some(string_value(&meta)?),
@@ -1371,6 +1385,13 @@ impl Field {
             return Err(syn::Error::new(
                 span,
                 "`value_enum` describes what a value may be, and this field takes no value",
+            ));
+        }
+        if value_optional && matches!(shape, Shape::Bool | Shape::Count) {
+            return Err(syn::Error::new(
+                span,
+                "`value_optional` describes a value that may be left off, and this field \
+                 takes no value",
             ));
         }
         if !choices.is_empty() && matches!(shape, Shape::Bool | Shape::Count) {
@@ -1725,6 +1746,7 @@ impl Field {
             ident,
             ty: field.ty.clone(),
             name,
+            value_optional,
             kind,
             shape,
             value_ty,

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -1444,6 +1444,21 @@ impl Field {
         }
 
         let is_flag = !longs.is_empty() || !shorts.is_empty();
+        // Only a flag's value has a say in this. A positional's brackets come from its type
+        // already — `Option<T>` renders `[NAME]` and `T` renders `<NAME>` — so the attribute
+        // would be read by nothing, and a declaration nothing reads is worse than an error: the
+        // page would keep saying the opposite of what was asked for.
+        //
+        // Tested against `is_flag` and not `is_arg`: `is_arg` is only true where `arg` was
+        // written, and a field with no `long`, `short` or `arg` is a positional as well. That
+        // gap let `#[usage(value_optional)] out: Option<String>` compile and be dropped.
+        if value_optional && !is_flag {
+            return Err(syn::Error::new(
+                span,
+                "`value_optional` is for a flag's value; a positional says this with its \
+                 type, where `Option<T>` is already `[NAME]`",
+            ));
+        }
         if is_flag && is_arg {
             return Err(syn::Error::new(
                 span,
@@ -2623,6 +2638,48 @@ mod tests {
         "#)
         .expect("should compile");
         assert!(cli.fields[0].required_collection);
+    }
+
+    #[test]
+    fn value_optional_is_refused_where_nothing_would_read_it() {
+        // It says a *flag's* value may be left off. `arg_meta` never emits it, and a valueless
+        // flag has no value to make optional — so on a positional or a `bool`/`count` flag the
+        // declaration compiled and was dropped. Worse than an error: a positional's brackets
+        // come from its type, so the page went on saying the opposite of what was asked.
+        for (decl, word) in [
+            (
+                "#[usage(arg, value_optional)]\n                out: Option<String>,",
+                "type",
+            ),
+            // No `arg` either: a field with no `long`, `short` or `arg` is a positional too,
+            // and testing `is_arg` rather than `is_flag` let this one through.
+            (
+                "#[usage(value_optional)]\n                out: Option<String>,",
+                "type",
+            ),
+            (
+                "#[usage(long, value_optional)]\n                out: bool,",
+                "no value",
+            ),
+            (
+                "#[usage(long, count, value_optional)]\n                out: u8,",
+                "no value",
+            ),
+        ] {
+            let err = rejection(&format!(
+                "struct Ex {{\n                {decl}\n            }}"
+            ));
+            assert!(err.contains(word), "unhelpful message for `{decl}`: {err}");
+        }
+        // And where there is a flag value, it still works.
+        let cli = cli(r#"
+            struct Ex {
+                #[usage(long, value_optional)]
+                bump: Option<String>,
+            }
+        "#)
+        .expect("should compile");
+        assert!(cli.fields[0].value_optional);
     }
 
     #[test]

--- a/xtask/src/shadow.rs
+++ b/xtask/src/shadow.rs
@@ -699,6 +699,12 @@ fn usage_flag_opts(
         if arg.name != flag.name {
             opts.push(format!("value_name = {:?}", arg.name));
         }
+        // `arg "[BUMP]" required=#false`: the value may be left off. Dropping it rendered
+        // pitchfork's `--bump` as `<BUMP>` where its own spec says `[BUMP]`, and said nothing
+        // about having dropped anything.
+        if !arg.required {
+            opts.push("value_optional".into());
+        }
         if let Some(choices) = &arg.choices {
             opts.push(format!("choices({})", quoted_list(&choices.choices)));
         }

--- a/xtask/src/shadow.rs
+++ b/xtask/src/shadow.rs
@@ -862,6 +862,16 @@ fn clap_flag_opts(
                 Some(max) => opts.push(format!("num_args = {least}..={max}")),
                 None => opts.push(format!("num_args = {least}..")),
             }
+        } else if !arg.required {
+            // Noted, not emitted. `num_args = 0..=1` was the obvious translation and it is the
+            // wrong one: `value_optional` is help-only — usage-lib's parser refuses a bare
+            // `--bump` exactly as it refuses a bare `--port` — so declaring it in clap would
+            // make the clap shadow accept a line the usage shadow rejects, and the pair exists
+            // to be one grammar told to two frameworks.
+            //
+            // A real limitation, then, rather than a gap in this file: clap cannot print
+            // `[BUMP]` without also accepting `--bump` on its own.
+            skipped.note("a flag's value being optional in help only");
         }
         if flag.required {
             opts.push("required = true".into());
@@ -1662,6 +1672,33 @@ mod tests {
             Dialect::Clap,
         );
         assert!(out.contains("version = \"1.55.0\""), "{out}");
+    }
+
+    #[test]
+    fn the_clap_dialect_counts_an_optional_value_as_lost() {
+        // Reported twice on #969, in opposite directions, and the second one was right. Emitting
+        // `num_args = 0..=1` made clap accept `--bump` with no value where usage-lib rejects it,
+        // so the two shadows stopped describing one grammar. clap cannot show `[BUMP]` without
+        // accepting the bare form, which makes this a limitation to record rather than a
+        // translation to make.
+        let spec = "name \"ex\"\nbin \"ex\"\nflag --bump {\n  arg \"[BUMP]\" required=#false\n}\n";
+        let (out, skipped) = rendered_as(spec, Dialect::Clap);
+        assert!(
+            !out.contains("num_args"),
+            "the grammar must not change: {out}"
+        );
+        assert_eq!(
+            skipped
+                .counts
+                .get("a flag's value being optional in help only"),
+            Some(&1),
+            "{:?}",
+            skipped.counts
+        );
+
+        // The usage dialect still says it, since that is where it means something.
+        let (out, _) = rendered_as(spec, Dialect::Usage);
+        assert!(out.contains("value_optional"), "{out}");
     }
 
     #[test]


### PR DESCRIPTION
`arg "[BUMP]" required=#false` inside a flag says the value is optional, and
usage-argv had nowhere to put it: `Flag` carries `takes_value: bool` and
nothing finer. So pitchfork's `--bump` rendered `<BUMP>` where its own spec
says `[BUMP]`, on three of its pages.

Measured before deciding where it belongs. usage-lib's parser refuses a bare
`--bump` exactly as it refuses a bare `--port`:

    ["--bump"]      -> ERR Invalid flag `--bump`: requires an argument
    ["--bump", "5"] -> OK  bump="5"

So this binds nothing differently — it changes the brackets. That puts it in
`FlagMeta`, which a parse never reads, rather than in `Flag`, which is on the
hot path and gains no field.

Declared rather than inferred: `Option<String>` already says the *flag* is
optional and says nothing about its value, so `#[usage(value_optional)]` is
the only way to state it. Refused where the field takes no value, like
`choices` and `value_enum` beside it.

The emitted KDL writes both halves — `arg "[BUMP]" required=#false` — because
usage-lib reads the attribute as well as the name, so square brackets alone
round-trip as required.

With this and the version banner, six of the seven jdx CLIs now render
byte-identically to usage-lib across every command: hk, fnox, aube, tak,
communique and mise. pitchfork has two long pages left, from a blank-line
difference that is its own change.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Help and spec emission only; parsing behavior is explicitly unchanged and covered by conformance tests.
> 
> **Overview**
> Adds **`value_optional`** so flags whose spec says `arg "[NAME]" required=#false` show **`--flag [NAME]`** in help and KDL instead of **`<NAME>`**, without changing parsing (bare `--flag` still requires a value).
> 
> **`#[usage(value_optional)]`** on derive flags flows through **`FlagMeta`**, help rendering, and **`to_kdl`** (brackets plus **`required=#false`** for round-trip). The attribute is rejected on positionals and valueless flags.
> 
> **xtask** shadow maps optional spec args to **`value_optional`** for the usage dialect and records a clap limitation when help-only optionality cannot be expressed without diverging grammars.
> 
> Conformance tests lock help parity with usage-lib and emitted KDL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9560b0e79836b1b0e47fba7d1e40b89709105bcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*
