### PR TITLE
fix(help): a description ending in a break adds no blank line

### DIFF
--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -346,7 +346,9 @@ pub fn short_help(spec: &Spec<'_>, path: &[&str], chain: &[&CommandMeta<'_>]) ->
     }
     let about = if root { spec.about } else { meta.about };
     if let Some(about) = about {
-        let _ = writeln!(out, "{about}\n");
+        // Trimmed for the same reason the entries below are: the blank line after the
+        // description is written here, so one already in the text doubles it.
+        let _ = writeln!(out, "{}\n", about.trim_end());
     }
     usage_section(&mut out, spec, path, meta);
 
@@ -687,7 +689,9 @@ pub fn long_help(spec: &Spec<'_>, path: &[&str], chain: &[&CommandMeta<'_>]) -> 
         meta.long_about.or(meta.about)
     };
     if let Some(about) = about {
-        let _ = writeln!(out, "{about}\n");
+        // Trimmed for the same reason the entries below are: the blank line after the
+        // description is written here, so one already in the text doubles it.
+        let _ = writeln!(out, "{}\n", about.trim_end());
     }
     usage_section(&mut out, spec, path, meta);
 
@@ -910,7 +914,11 @@ fn long_commands_section(out: &mut String, path: &[&str], meta: &CommandMeta<'_>
         }
         out.push('\n');
         if let Some(about) = sub.long_about.or(sub.about) {
-            write_indented(out, about, 4);
+            // Trailing whitespace trimmed: the blank line after each entry is written below, and
+            // a description that happens to end in a newline — which clap's `long_about` often
+            // does, reaching the spec verbatim — added a second one and left a stray blank in
+            // the middle of the list.
+            write_indented(out, about.trim_end(), 4);
         }
         // A blank line between entries, which the wider layout can afford and which keeps a
         // multi-line description from running into the next command's name.

--- a/cli/tests/snapshots/manpage__generate_manpage_with_flags.snap
+++ b/cli/tests/snapshots/manpage__generate_manpage_with_flags.snap
@@ -1314,7 +1314,6 @@ The full list is here: https://github.com/jdx/mise/blob/main/registry.toml
 Examples:
 
     $ mise plugins ls\-remote
-
 .PP
 \fBUsage:\fR mise plugins ls\-remote [OPTIONS]
 .PP

--- a/conformance/tests/trailing_whitespace.rs
+++ b/conformance/tests/trailing_whitespace.rs
@@ -1,0 +1,115 @@
+//! A description that ends in a newline should not add a blank line to the page.
+//!
+//! clap's `long_about` often ends with one — a `///` block whose last line is empty, or an
+//! examples section written with a trailing break — and it reaches the spec verbatim. Both
+//! renderers write their own blank line after a description, so one already in the text doubled
+//! it: a stray blank in the middle of `Commands:`, and a second gap under the program's own
+//! description.
+//!
+//! Found on pitchfork's `daemons add` and mise's `plugins ls-remote`, which is why the fix is in
+//! both renderers rather than one — trimming either side alone traded one CLI's divergence for
+//! another's. Recorded as a decision: the page loses whitespace nobody wrote on purpose, rather
+//! than one renderer reproducing it faithfully.
+
+use usage::Spec as LibSpec;
+use usage_argv::help;
+use usage_derive::{Args, Cli, Subcommands};
+
+/// Short one
+///
+/// First.
+///
+/// Second.
+#[derive(Args)]
+struct One {
+    #[usage(long)]
+    thing: bool,
+}
+
+/// Short two
+#[derive(Args)]
+struct Two {
+    #[usage(long)]
+    other: bool,
+}
+
+#[derive(Subcommands)]
+enum Commands {
+    /// Short one
+    ///
+    /// A doc comment cannot carry a trailing break — Rust drops it — so the case has to be
+    /// declared. This is also the shape `gen-shadow` emits when a spec's two descriptions are
+    /// independent, which is how pitchfork's reached the fixture at all.
+    #[usage(name = "one", help = "Short one", long_help = "First.\n\nSecond.\n")]
+    One(One),
+    /// Short two
+    Two(Two),
+}
+
+/// A tool
+///
+/// The program's own description, which also ends in a break.
+#[derive(Cli)]
+#[usage(
+    bin = "ex",
+    about = "A tool",
+    long_about = "A tool\n\nThe program's own description, which ends in a break.\n"
+)]
+struct Ex {
+    #[usage(subcommand)]
+    command: Option<Commands>,
+}
+
+#[test]
+fn a_description_ending_in_a_break_adds_no_blank_line() {
+    // Two blanks in a row would mean the trailing newline reached the page. One is the
+    // separator each entry gets; two is the bug.
+    let page = help::render(Ex::spec(), Ex::command(), true).expect("a page");
+    assert!(
+        !page.contains("\n\n\n"),
+        "no run of blank lines should survive:\n{page:?}"
+    );
+}
+
+#[test]
+fn the_two_renderers_agree_about_it() {
+    // The invariant: whatever the rule is, both sides hold it. Trimming one alone is what
+    // turned pitchfork green and mise red.
+    let spec: LibSpec = Ex::to_kdl().parse().expect("valid spec");
+    for long in [false, true] {
+        let ours = help::render(Ex::spec(), Ex::command(), long).expect("a page");
+        let theirs = usage::docs::cli::render_help(&spec, &spec.cmd, long);
+        assert_eq!(ours, theirs, "long={long}");
+    }
+}
+
+#[test]
+fn the_commands_still_parse() {
+    // Also what keeps the fixture's fields read: these tests only render, and an unread field
+    // in a generated CLI is a warning the adopter cannot silence.
+    let argv = [std::ffi::OsStr::new("one"), std::ffi::OsStr::new("--thing")];
+    let parsed = Ex::parse_from(&argv).expect("parses");
+    match parsed.command {
+        Some(Commands::One(one)) => assert!(one.thing),
+        _ => panic!("routed to one"),
+    }
+
+    let argv = [std::ffi::OsStr::new("two"), std::ffi::OsStr::new("--other")];
+    let parsed = Ex::parse_from(&argv).expect("parses");
+    match parsed.command {
+        Some(Commands::Two(two)) => assert!(two.other),
+        _ => panic!("routed to two"),
+    }
+}
+
+#[test]
+fn the_entries_still_have_one_blank_between_them() {
+    // Trimming must not run the entries together: the separator is written by the renderer and
+    // stays whether or not the text ended in a break.
+    let page = help::render(Ex::spec(), Ex::command(), true).expect("a page");
+    let commands = page
+        .split_once("Commands:\n")
+        .expect("a commands section")
+        .1;
+    assert!(commands.contains("\n\n  two"), "{commands:?}");
+}

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -379,7 +379,9 @@ impl From<crate::Spec> for Spec {
             source_code_link_template: spec.source_code_link_template,
             repository: spec.repository,
             about: spec.about,
-            about_long: spec.about_long,
+            // The program's own description, trimmed for the reason a command's is: the blank
+            // line under it is the renderer's to write.
+            about_long: spec.about_long.as_deref().map(|a| a.trim_end().to_string()),
             about_md: spec.about_md,
             author: spec.author,
             license: spec.license,
@@ -507,7 +509,13 @@ impl From<&crate::SpecCommand> for SpecCommand {
             subcommand_required: *subcommand_required,
             restart_token: restart_token.clone(),
             help: help.clone(),
-            help_long: help_long.clone(),
+            // Trailing whitespace trimmed, matching `long_commands_section` in usage-argv.
+            // Never intent, and it showed: pitchfork's `daemons add` ends its examples block
+            // with a newline, which put a stray blank line in the middle of `Commands:`.
+            //
+            // A decision, recorded: both renderers move together, so the page loses whitespace
+            // no one wrote on purpose rather than one side reproducing it faithfully.
+            help_long: help_long.as_deref().map(|h| h.trim_end().to_string()),
             help_md: help_md.clone(),
             name: name.clone(),
             aliases: aliases.clone(),


### PR DESCRIPTION
clap's `long_about` often ends with a newline — a `///` block whose last line
is empty, an examples section written with a trailing break — and it reaches
the spec verbatim. Both renderers write their own blank line after a
description, so one already in the text doubled it: a stray blank in the
middle of `Commands:`, and a second gap under the program's own description.

Trimmed in both, in all three places it shows: a command entry's description,
the page's own, and the spec-level `long_about`. Only trailing whitespace —
leading is layout and belongs to the author.

A decision rather than a match, and recorded as one: usage-lib reproduced the
whitespace faithfully and usage-argv did in some places and not others, so
there was no side to defer to. The page now loses whitespace nobody wrote on
purpose.

Trimming one side alone traded one CLI's divergence for another's — pitchfork
went green and mise red, twice, from two different call sites. That is what
says this had to land as one change across both renderers.

The manpage renderer reads the same model and loses a blank line with it,
which its snapshot records.

With this, all seven jdx CLIs render byte-identically to usage-lib across
every command in both help forms: hk, fnox, pitchfork, aube, tak, communique
and mise — 492 commands.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only trimming of trailing whitespace in help/manpage output; conformance tests lock behavior across both renderers.
> 
> **Overview**
> **Fixes extra blank lines in CLI help** when `long_about` / program descriptions end with a trailing newline (common from clap `///` blocks or example sections). Renderers already insert a blank line after each description; text that kept that newline produced double gaps under the program summary and stray blanks between **Commands:** entries (e.g. mise `plugins ls-remote`, pitchfork `daemons add`).
> 
> **usage-argv** applies `trim_end()` when printing root `about` / `long_about` in short and long help, and when indenting subcommand `long_about` in the long **Commands:** section. **usage-lib** trims `about_long` and per-command `help_long` when building the docs `Spec` model so Tera/manpage output matches the same rule.
> 
> Adds **conformance tests** (`trailing_whitespace.rs`) asserting no `\n\n\n`, parity between usage-argv and usage-lib for short/long help, and that command entries still have a single blank line between them. Updates the **manpage snapshot** for the removed blank under `plugins ls-remote`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd0ba49c1787acb4ebc3cbeab96bcf9dc3c419e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*
