### PR TITLE
perf(derive): hold one subcommand's partial, not every subcommand's

### DIFF
--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -1457,6 +1457,23 @@ pub trait Subcommands: Sized {
         event: &crate::Event<'_, '_>,
     ) -> bool;
 
+    /// Make room for the variant at `selected`, if it is not already the one being filled.
+    ///
+    /// Called when a command word selects a variant, before any event reaches it.
+    /// [`Subcommands::Partial`] holds *one* command's values rather than every command's, so
+    /// the storage for a variant comes into being here instead of at the start of the parse:
+    /// an invocation that reached `mise use` never materialises the other 209.
+    ///
+    /// Idempotent by contract. A second call naming the variant already being filled must
+    /// leave what has been collected alone — a restart token can re-announce the command
+    /// that is already selected, and re-starting it there would discard the parse so far.
+    ///
+    /// The default does nothing, which is correct for a `Partial` that has room for every
+    /// variant from the start.
+    fn begin(partial: &mut Self::Partial, selected: usize) {
+        let _ = (partial, selected);
+    }
+
     /// Every flag any of these commands reads into a setting, and the setting it sets.
     ///
     /// Every variant's, not the selected one's: a binding table says what the CLI *can* do, and

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -2232,6 +2232,13 @@ fn subcommand_parts(cli: &Cli) -> Option<SubcommandParts> {
                         .position(|candidate| ::core::ptr::eq(*candidate, *__usage_cmd))
                 {
                     partial.__usage_selected = ::std::option::Option::Some(__usage_at);
+                    // The one place the selection and the storage are tied together: from
+                    // here on, `__usage_selected` naming a position means `__usage_sub`
+                    // holds that variant. Everything downstream relies on it.
+                    <#ty as usage_argv::spec::Subcommands>::begin(
+                        &mut partial.__usage_sub,
+                        __usage_at,
+                    );
                 }
             }
             // Only the selected one is asked — see `Subcommands::apply`. The selection is
@@ -2530,24 +2537,43 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
         .collect::<Vec<_>>();
     let unit_structs = unit_structs.into_iter();
 
-    // One partial per variant, since a parse can only fill one but does not know
-    // which until the word arrives.
-    let partial_fields = subs.variants.iter().enumerate().map(|(i, v)| {
-        let field = format_ident!("v{i}");
+    // One *variant* per subcommand, not one field: a parse fills exactly one of them, and a
+    // struct with room for all of them is the whole CLI's accumulator whichever command ran —
+    // 11KB of it at mise's scale, of which 210 commands' worth is never touched. The variant
+    // comes into being when a command word selects it, in `begin`.
+    let partial_variants = subs.variants.iter().enumerate().map(|(i, v)| {
+        let variant = format_ident!("V{i}");
         let ty = &v.ty;
-        quote!(pub #field: <#ty as usage_argv::spec::CommandArgs>::Partial,)
+        quote!(#variant(<#ty as usage_argv::spec::CommandArgs>::Partial),)
     });
-    let partial_starts = subs.variants.iter().enumerate().map(|(i, v)| {
-        let field = format_ident!("v{i}");
+    // Idempotent, as the trait requires: a restart token can re-announce the command that is
+    // already selected, and starting it again there would throw away the parse so far.
+    let begins = subs.variants.iter().enumerate().map(|(i, v)| {
+        let variant = format_ident!("V{i}");
         let ty = &v.ty;
-        quote!(#field: <#ty as usage_argv::spec::CommandArgs>::start(),)
+        quote! {
+            #i => {
+                if !::std::matches!(partial, Partial::#variant(_)) {
+                    *partial = Partial::#variant(
+                        <#ty as usage_argv::spec::CommandArgs>::start(),
+                    );
+                }
+            }
+        }
     });
     let applies = subs.variants.iter().enumerate().map(|(i, v)| {
-        let field = format_ident!("v{i}");
+        let variant = format_ident!("V{i}");
         let ty = &v.ty;
         quote! {
             ::std::option::Option::Some(#i) => {
-                <#ty as usage_argv::spec::CommandArgs>::apply(&mut partial.#field, event)
+                if let Partial::#variant(__usage_p) = partial {
+                    <#ty as usage_argv::spec::CommandArgs>::apply(__usage_p, event)
+                } else {
+                    // `begin` put this variant here on the event that selected it, so the
+                    // partial always matches the selection. An event with nowhere to go was
+                    // not this command's.
+                    false
+                }
             }
         }
     });
@@ -2642,10 +2668,16 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
     // Matched on the command's key rather than its name, so selecting a variant is
     // an integer comparison and cannot be confused by an alias.
     let checks = subs.variants.iter().enumerate().map(|(i, v)| {
-        let field = format_ident!("v{i}");
+        let variant = format_ident!("V{i}");
         let ty = &v.ty;
         quote! {
-            #i => <#ty as usage_argv::spec::CommandArgs>::check(&mut partial.#field),
+            #i => match partial {
+                Partial::#variant(__usage_p) => {
+                    <#ty as usage_argv::spec::CommandArgs>::check(__usage_p)
+                }
+                // Selected but unfilled cannot happen — see `Subcommands::begin`.
+                _ => ::std::result::Result::Ok(()),
+            },
         }
     });
     // Every variant's bindings, because a table says what the CLI *can* do and is compared
@@ -2657,21 +2689,25 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
     });
     let binding_lens = binding_parts.clone().map(|part| quote!(+ #part.len()));
     let givens = subs.variants.iter().enumerate().map(|(i, v)| {
-        let field = format_ident!("v{i}");
+        let variant = format_ident!("V{i}");
         let ty = &v.ty;
         quote! {
             ::std::option::Option::Some(#i) => {
-                <#ty as usage_argv::spec::CommandArgs>::settings_given(&partial.#field)
+                if let Partial::#variant(__usage_p) = partial {
+                    <#ty as usage_argv::spec::CommandArgs>::settings_given(__usage_p)
+                } else {
+                    ::std::vec::Vec::new()
+                }
             }
         }
     });
     let selects = subs.variants.iter().enumerate().map(|(i, v)| {
-        let field = format_ident!("v{i}");
+        let held = format_ident!("V{i}");
         let variant = &v.ident;
         let ty = &v.ty;
         // The one place the box matters: everything else — tables, partial, `build` —
         // speaks to the struct itself.
-        let built = quote!(<#ty as usage_argv::spec::CommandArgs>::build(partial.#field)?);
+        let built = quote!(<#ty as usage_argv::spec::CommandArgs>::build(__usage_p)?);
         let built = if v.boxed {
             quote!(::std::boxed::Box::new(#built))
         } else {
@@ -2688,7 +2724,13 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
             quote!(#ident::#variant(#built))
         };
         quote! {
-            #i => ::std::result::Result::Ok(::std::option::Option::Some(#made)),
+            #i => match partial {
+                Partial::#held(__usage_p) => {
+                    ::std::result::Result::Ok(::std::option::Option::Some(#made))
+                }
+                // Selected but unfilled cannot happen — see `Subcommands::begin`.
+                _ => ::std::result::Result::Ok(::std::option::Option::None),
+            },
         }
     });
 
@@ -2710,13 +2752,15 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
         const _: () = {
             use #runtime as usage_argv;
 
-            pub struct Partial {
-                #(#partial_fields)*
+            pub enum Partial {
+                /// No command word has selected a variant yet, so there is nothing to fill.
+                Unselected,
+                #(#partial_variants)*
             }
 
             impl ::std::default::Default for Partial {
                 fn default() -> Self {
-                    Self { #(#partial_starts)* }
+                    Partial::Unselected
                 }
             }
 
@@ -2743,6 +2787,15 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
                         // Nothing selected yet, or a position that cannot be produced: the event
                         // is not one of these commands'.
                         _ => false,
+                    }
+                }
+
+                fn begin(partial: &mut Self::Partial, selected: usize) {
+                    match selected {
+                        #(#begins)*
+                        // Not a position `COMMANDS` can produce, so there is no variant to
+                        // make room for.
+                        _ => {}
                     }
                 }
 


### PR DESCRIPTION
`Subcommands::Partial` was a struct with a field per variant, so it was the whole
CLI's accumulator whichever command ran: 11KB at mise's scale, of which 210
commands' worth was never touched. Constructing it materialised every command's
partial, and that construction was the last big memcpy in a parse.

It is an enum now — `Unselected`, or the one variant being filled. Nothing read
across variants to begin with: `apply`, `check`, `select` and `settings_given`
all already dispatched on `selected`, so the struct was storing 209 partials
that were unreachable by construction.

Where the variant comes from is the one thing this adds. `Subcommands::begin`
makes room for a variant, and the parent calls it in the same place it records
the selection, so `__usage_selected` naming a position means `__usage_sub` holds
that variant — one transition, one invariant, and the arms downstream that would
contradict it are unreachable. `begin` is idempotent as its contract says,
because a restart token can re-announce the command already selected. It has a
default body that does nothing, which is right for any `Partial` with room for
every variant, so no implementor outside this repo has to change.

Against the mise shadow (211 commands, 711 flags), one cold parse of
`mise use -g node@20`, cachegrind:

    before this stack   63,822 instructions      81x fewer than clap
    after &mut          18,490 instructions     281x fewer than clap
    after this          4,155 instructions    1,251x fewer than clap

    Subcommands::Partial   11,000 -> 824 bytes
    data refs             116,742 -> 1,889

No memcpy is left in a parse; the largest thing in one is now the parse itself.
Allocations are unchanged — 0 for a bare `mise`, 4 to bind `use -g node@20` —
so the tables are still static and nothing was traded to the heap.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Core parsing path and generated `Partial` shape change for every CLI with subcommands; behavior should be equivalent but regressions would show up as wrong subcommand binding or lost parse state.
> 
> **Overview**
> **Lazy subcommand partials** replace the old struct-with-a-field-per-variant layout. `Subcommands::Partial` is now `Unselected` or a single variant; default startup no longer constructs every subcommand's accumulator (the main win on large CLIs like mise).
> 
> **`Subcommands::begin`** is added on the trait with a no-op default for custom impls. The derive calls it when a command word selects a variant (same place as `__usage_selected`), idempotently switching storage to that variant's `CommandArgs::start()` without wiping an in-progress parse on restart tokens.
> 
> **Codegen** updates `apply`, `check`, `select`, and `settings_given` to match on the enum, and wires `begin` from the parent's subcommand routing in `subcommand_parts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8138830a8be5de6b33244fc892493a30dc26a53e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->