### PR TITLE
fix(parse)!: a command that needs a subcommand says so

### DIFF
--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -41,6 +41,14 @@ pub enum UsageErr {
     #[error("Missing required arg: <{0}>")]
     MissingArg(String),
 
+    /// A command that declares `subcommand_required` was given none.
+    ///
+    /// The spec could say this and the parser did not read it, so `mise generate` — which
+    /// declares it — parsed as though it were a complete invocation. usage-argv and clap both
+    /// refuse it.
+    #[error("`{0}` needs a subcommand: one of {1}")]
+    MissingSubcommand(String, String),
+
     #[error("Argument <{0}> can only be set after a `--` separator")]
     ArgRequiresDoubleDash(String),
 

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -1166,6 +1166,28 @@ fn parse_partial_with_env(
 
     record_cursor(&mut out, next_arg_idx, seen_double_dash);
 
+    // A command that says it needs a subcommand, given none. Checked on `out.cmd` and nowhere
+    // else, because `out.cmd` *is* the command the words reached: had a subcommand been taken,
+    // the child would be here instead. The spec has carried `subcommand_required` since it was
+    // added for the derive, and this parser never read it — so `mise generate` parsed as a
+    // complete invocation while usage-argv and clap both refused it.
+    if out.cmd.subcommand_required && !out.cmd.subcommands.is_empty() {
+        let mut names: Vec<&str> = out
+            .cmd
+            .subcommands
+            .iter()
+            // Aliases share a map entry with the name they point at; listing both would offer
+            // the same command twice under two spellings.
+            .filter(|(name, sub)| sub.name == **name && !sub.hide)
+            .map(|(name, _)| name.as_str())
+            .collect();
+        names.sort_unstable();
+        out.errors.push(UsageErr::MissingSubcommand(
+            out.cmd.name.clone(),
+            names.join(", "),
+        ));
+    }
+
     // Not `skip(out.args.len())`: a `--` may have jumped the cursor past an arg that stayed
     // empty, so position and fill count can disagree. Ask `out.args` which args it holds.
     for arg in out.cmd.args.iter() {
@@ -4947,6 +4969,51 @@ cmd "run" {
     }
 
     #[cfg(feature = "unstable_choices_env")]
+    /// argv as `parse` wants it, program name included.
+    fn words(of: &[&str]) -> Vec<String> {
+        of.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn a_command_that_needs_a_subcommand_says_so() {
+        // The spec has carried `subcommand_required` since the derive needed it, and this parser
+        // never read it — so `mise generate`, which declares it, parsed as a complete
+        // invocation while usage-argv and clap both refused. Found by the differential fuzzer.
+        let spec: Spec = r#"
+name "ex"
+bin "ex"
+cmd "gen" subcommand_required=#true {
+    cmd "two" {}
+    cmd "one" {}
+    cmd "secret" hide=#true {}
+    alias "g"
+}
+cmd "open" {
+    cmd "sub" {}
+}
+"#
+        .parse()
+        .unwrap();
+
+        let err = parse(&spec, &words(&["ex", "gen"])).unwrap_err();
+        // Sorted, so the message does not depend on map order; hidden commands left out,
+        // because a message telling someone to type a hidden name is worse than a vague one;
+        // and the alias not listed beside the name it points at.
+        assert_eq!(err.to_string(), "`gen` needs a subcommand: one of one, two");
+
+        // Reached through its alias, and still about the command rather than the spelling.
+        let err = parse(&spec, &words(&["ex", "g"])).unwrap_err();
+        assert!(err.to_string().starts_with("`gen` needs a subcommand"));
+
+        // Given one: fine.
+        parse(&spec, &words(&["ex", "gen", "one"])).unwrap();
+
+        // And a command that has subcommands without declaring them required is untouched —
+        // this is the half that keeps the check from being "any command with children".
+        parse(&spec, &words(&["ex", "open"])).unwrap();
+        parse(&spec, &words(&["ex", "open", "sub"])).unwrap();
+    }
+
     #[test]
     fn test_parser_arg_choices_from_custom_env() {
         let spec = spec_arg_choices_env("DEPLOY_ENVS");


### PR DESCRIPTION
usage-lib never read `subcommand_required`. The spec has carried it since the
derive needed it, so `mise generate` — which declares it — parsed as a complete
invocation, while usage-argv and clap both refused. Found by the differential
fuzzer, which compares all three.

BREAKING CHANGE: `usage::parse` now refuses a command that declares
`subcommand_required` and was given none. mise runs task arguments through this
parser and exits 1 on a parse error, so a task whose spec declares
`subcommand_required` and is invoked bare will now fail rather than run. That is
the point — the spec said it and nothing enforced it — but it is a behaviour
change for anyone relying on the old silence, which is why it lands in 6.0.

Checked on `out.cmd` and nowhere else, because `out.cmd` *is* the command the
words reached: had a subcommand been taken, the child would be there instead.

The message lists what would satisfy it, sorted so it does not depend on map
order, with hidden subcommands left out — telling someone to type a hidden name
is worse than being vague — and an alias not listed beside the name it points at.

Two behaviours in the same family remain lax and are still allow-listed in the
fuzzer: a variadic flag swallowing a following flag-shaped token as its value,
and a non-repeatable flag given twice. Each is its own change.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking parse behavior for any caller or mise task that invoked a `subcommand_required` command without a subcommand; change is intentional and localized to post-parse validation.
> 
> **Overview**
> **Breaking:** `usage::parse` now errors when the resolved command has `subcommand_required` and argv stops at that command with no child subcommand — matching clap and usage-argv instead of treating the invocation as complete (e.g. bare `mise generate`).
> 
> Adds **`UsageErr::MissingSubcommand`** with message `` `{cmd}` needs a subcommand: one of {names} ``. The check runs on **`out.cmd`** after Phase 2; eligible subcommand names are **sorted**, **non-hidden**, and **aliases are not duplicated** next to the canonical name.
> 
> Commands with subcommands but **without** `subcommand_required` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 689c97905aeb78a25f7ad640eb0af68ab231fc46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*
