### PR TITLE
docs(bench): time the rust frameworks in nanoseconds, and move the caveats into tooltips

### DIFF
--- a/docs/.vitepress/theme/UsageBenches.vue
+++ b/docs/.vitepress/theme/UsageBenches.vue
@@ -56,11 +56,11 @@ function width(value: number, max: number): string {
             <span class="usage-bench-tip" role="tooltip">
               <strong>How this is measured</strong>
               <span>
-                In-process and warmed, the fastest of many short rounds — a fresh process
-                cannot resolve a 200ns parse. Minima and their ratios move a few percent
-                between runs and machines, which is why the ratios are approximate. The
-                deterministic measure is instructions for one cold parse: 4,155 · 6,295 ·
-                5.89M · 21.9M, which two machines agreed on to within 0.15%.
+                In-process and warmed — the fastest of many short rounds, since a fresh
+                process cannot resolve a 200ns parse. Minima and their ratios drift a few
+                percent between runs and machines, hence the <code>~</code>. Instructions
+                for one cold parse, which do not drift: 4,155 · 6,295 · 5.89M · 21.9M,
+                agreeing across two machines to 0.15%.
               </span>
             </span>
           </span>

--- a/docs/.vitepress/theme/UsageBenches.vue
+++ b/docs/.vitepress/theme/UsageBenches.vue
@@ -51,9 +51,9 @@ function width(value: number, max: number): string {
         <h3>usage-rs <span>vs clap, argh, bpaf</span></h3>
         <p class="usage-bench-metric">
           wall time,
-          <span class="usage-bench-hint" tabindex="0"
+          <span class="usage-bench-hint" tabindex="0" aria-describedby="bench-tip-warmed"
             >one warmed parse
-            <span class="usage-bench-tip" role="tooltip">
+            <span class="usage-bench-tip" id="bench-tip-warmed" role="tooltip">
               <strong>How this is measured</strong>
               <span>
                 In-process and warmed — the fastest of many short rounds, since a fresh
@@ -86,9 +86,9 @@ function width(value: number, max: number): string {
           usage-rs and argh are the two bars you cannot see, and neither is a number anyone
           could feel — starting a process costs ~1ms. The gap that matters is to clap and
           bpaf, which
-          <span class="usage-bench-hint" tabindex="0"
+          <span class="usage-bench-hint" tabindex="0" aria-describedby="bench-tip-build"
             >build a parser before they can use one
-            <span class="usage-bench-tip" role="tooltip">
+            <span class="usage-bench-tip" id="bench-tip-build" role="tooltip">
               <strong>Where their time goes</strong>
               <span>
                 Most of clap's is constructing and validating its command tree. bpaf's is
@@ -98,9 +98,9 @@ function width(value: number, max: number): string {
             </span></span
           >. Heap allocations for a bare parse: <strong>zero</strong> vs clap's 6,280. argh
           and bpaf are also doing less: the generator counts
-          <span class="usage-bench-hint" tabindex="0"
+          <span class="usage-bench-hint" tabindex="0" aria-describedby="bench-tip-express"
             >what they cannot express
-            <span class="usage-bench-tip" role="tooltip">
+            <span class="usage-bench-tip" id="bench-tip-express" role="tooltip">
               <strong>Missing from the argh and bpaf shadows</strong>
               <span>
                 Aliases, hidden commands, global flags, and a positional beside a
@@ -117,9 +117,9 @@ function width(value: number, max: number): string {
         <h3>usage-go <span>vs cobra, urfave/cli, kong</span></h3>
         <p class="usage-bench-metric">
           wall time,
-          <span class="usage-bench-hint" tabindex="0"
+          <span class="usage-bench-hint" tabindex="0" aria-describedby="bench-tip-cold"
             >one cold parse
-            <span class="usage-bench-tip" role="tooltip">
+            <span class="usage-bench-tip" id="bench-tip-cold" role="tooltip">
               <strong>How this is measured</strong>
               <span>
                 Whole-process, with the ~0.95ms of Go runtime startup a do-nothing process

--- a/docs/.vitepress/theme/UsageBenches.vue
+++ b/docs/.vitepress/theme/UsageBenches.vue
@@ -60,7 +60,8 @@ function width(value: number, max: number): string {
                 process cannot resolve a 200ns parse. Minima and their ratios drift a few
                 percent between runs and machines, hence the <code>~</code>. Instructions
                 for one cold parse, which do not drift: 4,155 · 6,295 · 5.89M · 21.9M,
-                agreeing across two machines to 0.15%.
+                agreeing across two machines to 0.15%. For scale, starting a process costs
+                ~1ms, so the first two bars are under anything a user feels.
               </span>
             </span>
           </span>
@@ -83,9 +84,7 @@ function width(value: number, max: number): string {
           </div>
         </div>
         <p class="usage-bench-foot">
-          usage-rs and argh are the two bars you cannot see, and neither is a number anyone
-          could feel — starting a process costs ~1ms. The gap that matters is to clap and
-          bpaf, which
+          clap and bpaf
           <span class="usage-bench-hint" tabindex="0" aria-describedby="bench-tip-build"
             >build a parser before they can use one
             <span class="usage-bench-tip" id="bench-tip-build" role="tooltip">
@@ -96,10 +95,10 @@ function width(value: number, max: number): string {
                 reusing the parser across parses only halves.
               </span>
             </span></span
-          >. Heap allocations for a bare parse: <strong>zero</strong> vs clap's 6,280. argh
-          and bpaf are also doing less: the generator counts
+          >. Heap allocations for a bare parse: <strong>zero</strong>, against clap's 6,280.
+          argh and bpaf also
           <span class="usage-bench-hint" tabindex="0" aria-describedby="bench-tip-express"
-            >what they cannot express
+            >express less
             <span class="usage-bench-tip" id="bench-tip-express" role="tooltip">
               <strong>Missing from the argh and bpaf shadows</strong>
               <span>
@@ -108,8 +107,7 @@ function width(value: number, max: number): string {
                 when it runs.
               </span>
             </span></span
-          >
-          and prints it when it runs.
+          >.
         </p>
       </div>
 

--- a/docs/.vitepress/theme/UsageBenches.vue
+++ b/docs/.vitepress/theme/UsageBenches.vue
@@ -1,24 +1,21 @@
 <script setup lang="ts">
-// Rust figures from the `perf-pr` workflow's pinned runner, which runs
-// `tasks/perf-shadow.sh`.
+// Rust wall clock from `time-sweep.rs`, which warms each parser and keeps the
+// fastest of many short rounds — steady-state and in-process, because a
+// whole-process measurement cannot resolve a 200ns parse. Values in nanoseconds,
+// quoted to two significant figures: across twenty-two runs on two machines the
+// minima moved a few percent and their ratios by 10% — clap read 2,226x, 2,502x
+// and 2,419x on three occasions — so the ratios carry a `~`.
 //
-// The bars are instruction counts, because that is the measure that holds still:
-// deterministic for a given binary, and a developer machine and the runner agreed
-// on them to within 0.15%. They are also genuinely one *cold* parse — `parse-n` is differenced
-// against the same binary parsing nothing, so the figure is a single parse in a
-// fresh process.
-//
-// Wall clock lives in the footnote instead, and is deliberately vaguer. It comes
-// from `time-sweep.rs`, which warms each parser and keeps the fastest of many
-// short rounds, so it is steady-state rather than cold. Across twenty-two runs on
-// two machines the minima moved a few percent and their ratios by 10% — clap read
-// 2,226x, 2,502x and 2,419x on three occasions — which is a range worth quoting
-// loosely and not a number worth putting on a bar.
+// The instruction counts in the tooltip are the firm measure, from the `perf-pr`
+// workflow's pinned runner running `tasks/perf-shadow.sh`: deterministic for a
+// given binary, agreeing to within 0.15% between a developer machine and the
+// runner, and genuinely one *cold* parse — `parse-n` is differenced against the
+// same binary parsing nothing.
 const rustRows = [
-  { name: "usage-rs", value: 4155, label: "4,155", us: true },
-  { name: "argh", value: 6295, label: "6,295", note: "1.5× more", us: false },
-  { name: "clap", value: 5894561, label: "5.89M", note: "1,418× more", us: false },
-  { name: "bpaf", value: 21917918, label: "21.9M", note: "5,275× more", us: false },
+  { name: "usage-rs", value: 194, label: "190 ns", us: true },
+  { name: "argh", value: 268, label: "270 ns", note: "1.4× more", us: false },
+  { name: "clap", value: 479605, label: "480 µs", note: "~2,500× more", us: false },
+  { name: "bpaf", value: 1597028, label: "1.6 ms", note: "~8,200× more", us: false },
 ];
 
 // Go figures from go/README.md are whole-process wall time and subtract the
@@ -52,7 +49,22 @@ function width(value: number, max: number): string {
     <div class="usage-bench-cards">
       <div class="usage-bench-card">
         <h3>usage-rs <span>vs clap, argh, bpaf</span></h3>
-        <p class="usage-bench-metric">instructions, one cold parse</p>
+        <p class="usage-bench-metric">
+          wall time,
+          <span class="usage-bench-hint" tabindex="0"
+            >one warmed parse
+            <span class="usage-bench-tip" role="tooltip">
+              <strong>How this is measured</strong>
+              <span>
+                In-process and warmed, the fastest of many short rounds — a fresh process
+                cannot resolve a 200ns parse. Minima and their ratios move a few percent
+                between runs and machines, which is why the ratios are approximate. The
+                deterministic measure is instructions for one cold parse: 4,155 · 6,295 ·
+                5.89M · 21.9M, which two machines agreed on to within 0.15%.
+              </span>
+            </span>
+          </span>
+        </p>
         <div class="usage-bench-rows">
           <div v-for="row in rustRows" :key="row.name" class="usage-bench-row">
             <span class="usage-bench-name">{{ row.name }}</span>
@@ -72,24 +84,51 @@ function width(value: number, max: number): string {
         </div>
         <p class="usage-bench-foot">
           usage-rs and argh are the two bars you cannot see, and neither is a number anyone
-          could feel — a process costs ~1ms to start. The gap that matters is to the two
-          that build a parser before they can use one: most of clap's is constructing and
-          validating its command tree, and bpaf's is larger because it assembles a
-          combinator tree per run, which reusing the parser across parses only halves.
-          Instructions rather than time because they hold still: deterministic per binary,
-          agreeing to within 0.15% across two machines, and genuinely one parse in a fresh
-          process. In time, warmed and on one machine, the same four are roughly
-          <strong>0.2µs</strong> · 0.3µs · 480µs · 1.6ms — loosely, since those minima and
-          their ratios move several percent between runs and between machines. Heap allocations for a
-          bare parse: <strong>zero</strong> vs clap's 6,280. What argh and bpaf cannot
-          express — aliases, hidden commands, global flags, a positional beside a
-          subcommand — is counted by the generator and printed when it runs.
+          could feel — starting a process costs ~1ms. The gap that matters is to clap and
+          bpaf, which
+          <span class="usage-bench-hint" tabindex="0"
+            >build a parser before they can use one
+            <span class="usage-bench-tip" role="tooltip">
+              <strong>Where their time goes</strong>
+              <span>
+                Most of clap's is constructing and validating its command tree. bpaf's is
+                larger because it assembles a combinator tree per run as well, which
+                reusing the parser across parses only halves.
+              </span>
+            </span></span
+          >. Heap allocations for a bare parse: <strong>zero</strong> vs clap's 6,280. argh
+          and bpaf are also doing less: the generator counts
+          <span class="usage-bench-hint" tabindex="0"
+            >what they cannot express
+            <span class="usage-bench-tip" role="tooltip">
+              <strong>Missing from the argh and bpaf shadows</strong>
+              <span>
+                Aliases, hidden commands, global flags, and a positional beside a
+                subcommand — the generator drops them, counts them, and prints the count
+                when it runs.
+              </span>
+            </span></span
+          >
+          and prints it when it runs.
         </p>
       </div>
 
       <div class="usage-bench-card">
         <h3>usage-go <span>vs cobra, urfave/cli, kong</span></h3>
-        <p class="usage-bench-metric">wall time, one cold parse</p>
+        <p class="usage-bench-metric">
+          wall time,
+          <span class="usage-bench-hint" tabindex="0"
+            >one cold parse
+            <span class="usage-bench-tip" role="tooltip">
+              <strong>How this is measured</strong>
+              <span>
+                Whole-process, with the ~0.95ms of Go runtime startup a do-nothing process
+                costs subtracted — approximate, and the reason the Rust card is timed
+                in-process instead.
+              </span>
+            </span>
+          </span>
+        </p>
         <div class="usage-bench-rows">
           <div v-for="row in goRows" :key="row.name" class="usage-bench-row">
             <span class="usage-bench-name">{{ row.name }}</span>
@@ -108,9 +147,8 @@ function width(value: number, max: number): string {
           </div>
         </div>
         <p class="usage-bench-foot">
-          A do-nothing Go process costs ~0.95ms of runtime startup no parser can
-          touch; these subtract it. Instructions: <strong>~2.7k</strong> vs cobra's
-          2.0M, urfave/cli's 5.6M, kong's 57.9M.
+          Instructions for the same parse: <strong>~2.7k</strong> vs cobra's 2.0M,
+          urfave/cli's 5.6M, kong's 57.9M.
         </p>
       </div>
     </div>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -541,6 +541,7 @@
 }
 
 .usage-bench-card {
+  position: relative;
   background: rgba(21, 8, 54, 0.7);
   border: 1px solid var(--vw-purple-soft);
   border-radius: 12px;
@@ -664,7 +665,9 @@
   left: 50%;
   transform: translateX(-50%) translateY(6px);
   width: max-content;
-  max-width: min(300px, 74vw);
+  /* 280 rather than 300: at the widths where a card is ~650px, a wider tip
+     centred on the first footnote phrase hangs off the card's left edge. */
+  max-width: 280px;
   margin-top: 0.5rem;
   padding: 0.8rem 1rem;
   background: rgba(13, 2, 33, 0.97);
@@ -688,6 +691,8 @@
 }
 
 .usage-bench-hint:hover .usage-bench-tip,
+/* :focus as well as :focus-visible, so a tap on a touch screen opens the tip. */
+.usage-bench-hint:focus .usage-bench-tip,
 .usage-bench-hint:focus-visible .usage-bench-tip {
   opacity: 1;
   visibility: visible;
@@ -701,12 +706,42 @@
   margin-bottom: 0.35rem;
 }
 
+.usage-bench-tip code {
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.9em;
+  color: var(--vw-mint);
+}
+
 /* A span rather than a p: the tips live inside paragraphs, and a nested p would
    be closed early by the browser parsing the server-rendered HTML. */
 .usage-bench-tip span {
   display: block;
   color: rgba(245, 240, 255, 0.75);
   line-height: 1.55;
+}
+
+/* Narrow enough that a 300px tip centred on a phrase would hang off the card, and
+   which side it hangs off depends on where the line wrapped. Pin it to the card
+   instead: the hint stops being the positioning context, so the tip lands under the
+   card at its full width and cannot be clipped wherever the phrase ended up. */
+@media (max-width: 620px) {
+  .usage-bench-hint {
+    position: static;
+  }
+
+  .usage-bench-tip {
+    left: 1rem;
+    right: 1rem;
+    width: auto;
+    max-width: none;
+    transform: translateY(6px);
+  }
+
+  .usage-bench-hint:hover .usage-bench-tip,
+  .usage-bench-hint:focus .usage-bench-tip,
+  .usage-bench-hint:focus-visible .usage-bench-tip {
+    transform: translateY(0);
+  }
 }
 
 @media (max-width: 860px) {

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -648,6 +648,67 @@
   margin: 1.75rem 0 0;
 }
 
+/* The caveats a bar chart cannot carry: how a figure was measured, and what the
+   comparison leaves out. Hover or focus, so a keyboard reaches them too. */
+.usage-bench-hint {
+  position: relative;
+  display: inline-block;
+  color: rgba(245, 240, 255, 0.8);
+  border-bottom: 1px dotted rgba(1, 205, 254, 0.7);
+  cursor: help;
+}
+
+.usage-bench-tip {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%) translateY(6px);
+  width: max-content;
+  max-width: min(300px, 74vw);
+  margin-top: 0.5rem;
+  padding: 0.8rem 1rem;
+  background: rgba(13, 2, 33, 0.97);
+  border: 1px solid var(--vw-cyan);
+  border-radius: 10px;
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.5),
+    0 0 20px var(--vw-cyan-glow);
+  opacity: 0;
+  visibility: hidden;
+  transition: all 0.2s ease;
+  pointer-events: none;
+  z-index: 100;
+  /* The metric line is uppercase mono; a tooltip inside it is prose. */
+  font-family: var(--vp-font-family-base);
+  font-size: 0.78rem;
+  letter-spacing: normal;
+  text-transform: none;
+  text-align: left;
+  white-space: normal;
+}
+
+.usage-bench-hint:hover .usage-bench-tip,
+.usage-bench-hint:focus-visible .usage-bench-tip {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0);
+}
+
+.usage-bench-tip strong {
+  display: block;
+  color: var(--vw-cyan);
+  font-size: 0.82rem;
+  margin-bottom: 0.35rem;
+}
+
+/* A span rather than a p: the tips live inside paragraphs, and a nested p would
+   be closed early by the browser parsing the server-rendered HTML. */
+.usage-bench-tip span {
+  display: block;
+  color: rgba(245, 240, 255, 0.75);
+  line-height: 1.55;
+}
+
 @media (max-width: 860px) {
   .usage-bench-cards {
     grid-template-columns: 1fr;


### PR DESCRIPTION
The rust card's bars were instruction counts. Those are the measure that holds still, but nobody has a feel for 5.89M instructions. They are wall time now, from `time-sweep`'s minima on one machine, in nanoseconds for the two that are fast enough to want them:

| | | |
|---|---:|---:|
| usage-rs | 190 ns | — |
| argh | 270 ns | 1.4× more |
| clap | 480 µs | ~2,500× more |
| bpaf | 1.6 ms | ~8,200× more |

Ratios carry a `~` because these minima and their ratios move a few percent between runs and between machines, which is exactly why the instruction counts were on the bars before. They are still on the card — in the tooltip, where they can say what makes them firm.

## Simplification

The footnote was one paragraph carrying every caveat the bars could not. Three of them are hover/focus tooltips now:

- **one warmed parse** → in-process and warmed, best of many short rounds, because a fresh process cannot resolve a 200 ns parse; and the deterministic instruction counts, 4,155 · 6,295 · 5.89M · 21.9M, agreeing to within 0.15% across two machines.
- **build a parser before they can use one** → most of clap's is constructing and validating its command tree; bpaf's is larger for the combinator tree it assembles per run.
- **what they cannot express** → aliases, hidden commands, global flags, a positional beside a subcommand.

What is left visible is the shape of the result: two bars you cannot see, a ~1 ms process start that dwarfs both, the gap to the two frameworks that build a parser first, and zero heap allocations against clap's 6,280.

The go card gets a tooltip on its metric line too. Both cards now say "wall time", and they do not mean the same thing by it — go is whole-process and cold minus ~0.95 ms of runtime startup, rust is in-process and warmed — so each says which it is.

## Notes

- Numbers are from `./target/release/time-sweep` on this machine (`194 / 268 / 479,605 / 1,597,028 ns`), quoted to two significant figures as `time-sweep.rs` recommends.
- Tooltip bodies are `<span>`, not `<p>`: the tips sit inside paragraphs, and SSR'd HTML would have the browser close the outer paragraph early.
- `npx vitepress build docs` passes; the rendered markup was checked. `docs/.vitepress` is prettier-ignored, so no formatting pass applies.
- Not visually verified in a browser — the Chrome extension is not connected in this session. The tooltip is a copy of the existing `.usage-tile-tooltip` pattern in cyan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-site UI only (benchmark copy, numbers, and tooltip CSS); no runtime or API behavior changes.
> 
> **Overview**
> The Rust benchmark card now drives bar lengths from **warmed in-process wall time** (`time-sweep` minima in ns/µs/ms) instead of instruction counts, with approximate ratios (`~2,500×`, `~8,200×`) where run-to-run variance matters. The firm cold-parse instruction figures move into a **“one warmed parse”** tooltip on the metric line.
> 
> Long footnotes shrink into **hover/focus tooltips** for methodology (Rust vs Go “wall time”), where clap/bpaf spend time, and what the argh/bpaf shadows omit. The Go card labels **whole-process cold** parse the same way. **`custom.css`** adds `.usage-bench-hint` / `.usage-bench-tip` styling (cyan, keyboard/touch focus, narrow-viewport positioning on the card).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72fbf1cad5a3251fb599d46ccfd7138d59b4bcee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark metrics to use warmed wall-clock measurements and clarified comparison ratios.
  * Added tooltips explaining measurement methodology, parser startup costs, allocations, unsupported features, and runtime overhead.
  * Retained cold instruction-count comparisons in the Go benchmark notes.
* **Style**
  * Improved benchmark caveat tooltips with responsive, hover-, focus-, and keyboard-accessible designs.
  * Prevented tooltip clipping on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->