### PR TITLE
chore(perf): say when the clap ratio slides, and record why the derive is stricter

### DIFF
--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -1304,10 +1304,6 @@ fn flag_arm(cli: &Cli, i: usize, field: &Field) -> TokenStream {
     }
 }
 
-/// Whether another occurrence is a command-line mistake rather than another value.
-///
-/// Counts and collections repeat by definition, and `var` explicitly opts a value-taking flag
-/// into repetition. Every other flag matches clap's default of one occurrence.
 /// Whether a repeat of this flag is only a duplicate *within one command*.
 ///
 /// A `global` flag is in scope for every descendant, and clap lets it be given again on a
@@ -1331,6 +1327,26 @@ fn reset_per_level(cli: &Cli) -> TokenStream {
     quote!(#(#resets)*)
 }
 
+/// Whether another occurrence is a command-line mistake rather than another value.
+///
+/// Counts and collections repeat by definition, and `var` explicitly opts a value-taking flag
+/// into repetition. Every other flag matches clap's default of one occurrence.
+///
+/// **This is stricter than the grammar, deliberately.** The corpus specifies the opposite for a
+/// *spec-driven* parse — `long-repeated-keeps-the-last` says "a repeat is a correction, typically
+/// a wrapper appending to a command line it did not write" — and usage-argv's parser and
+/// usage-lib both honour that. The rule lives here, in the derive's post-binding layer, and
+/// nowhere else: `Error::DuplicateFlag` is constructed at one call site, in this file.
+///
+/// Kept, because the two cases are not the same case. A spec parsed at run time may well be
+/// describing someone else's command line, which is the wrapper the corpus has in mind. A
+/// derived CLI is an authored, fixed surface, where `--jobs 1 --jobs 2` is far likelier to be a
+/// mistake than an amendment — and it is what clap does, so an adopter replacing clap sees no
+/// change. Dropping it would make a derived binary quietly accept a line clap rejects today,
+/// which is the direction that costs an adopter rather than the one that helps.
+///
+/// Recorded because it looks like an inconsistency and is not one. `differential.rs` in the gate
+/// carries the same note from the other end.
 fn rejects_duplicate(field: &Field) -> bool {
     matches!(field.kind, Kind::Flag { .. })
         && !matches!(field.shape, Shape::Count | Shape::Many)

--- a/tasks/perf-shadow.sh
+++ b/tasks/perf-shadow.sh
@@ -66,6 +66,19 @@ verify() {
   fi
 }
 
+# The ratio against clap this file expects to hold, and below which it says so.
+#
+# Not a gate — the workflow runs this with `|| true`, and a shared runner is no place to fail a
+# build on an instruction count. It is an annotation, because the alternative turned out to be
+# nobody noticing: the number went from 117x to 97x across a run of feature work, unremarked,
+# because the only place it appeared was one line of a report nobody diffs. clap is flat, so the
+# movement was ours.
+#
+# 80 rather than 117: the point is to catch a slide, not to pin the current figure. A parse that
+# is only 80x cheaper than clap's has stopped being the thing this project claims, and that is
+# worth a sentence in the log before it is worth an argument about the target.
+CLAP_RATIO_FLOOR=80
+
 # Two significant figures either side of the decimal point, so a framework within a factor
 # of usage reads as 1.5x rather than 1x and one three orders away still reads cleanly.
 ratio() {
@@ -119,3 +132,20 @@ bpaf_cold=$(cold parse-n-bpaf)
 } >"$tmp"
 
 cat "$tmp" >"$out"
+
+# Said after the report is written, so a failure here cannot leave the comment truncated — the
+# same reason the table is built in a temporary file.
+#
+# `::warning::` when running under GitHub Actions, a plain line otherwise, so the same script is
+# useful at a terminal.
+clap_ratio=$(awk -v a="$clap_cold" -v b="$usage_cold" 'BEGIN { printf "%d", a / b }')
+if [ "$clap_ratio" -lt "$CLAP_RATIO_FLOOR" ]; then
+  message="the parse is ${clap_ratio}x cheaper than clap's, under the ${CLAP_RATIO_FLOOR}x this\
+ file expects. clap is flat, so a fall here is usage getting more expensive rather than clap\
+ getting cheaper. See tasks/perf-shadow.sh."
+  if [ -n "${GITHUB_ACTIONS:-}" ]; then
+    echo "::warning title=Shadow ratio below floor::$message"
+  else
+    echo "warning: $message" >&2
+  fi
+fi


### PR DESCRIPTION
Two loose ends from the differential-fuzzing work, both mine and both left as
open questions rather than decisions.

**The ratio had nobody watching it.** `tak.toml` explains at length why the
shadow benchmarks are not gated — the fixture grows on purpose, so an absolute
count fires on a bigger fixture rather than a slower parse — and then says what
*is* worth watching: "the ratio between the two frameworks, which is a property
of the parsers rather than of the fixture." Nothing acted on that. The number
went 117x to 97x across a run of feature work, unremarked, because the only
place it appeared was one line of a report nobody diffs, and clap is flat so the
movement was ours.

So `perf-shadow.sh` now says so: below 80x it emits a `::warning::` under
Actions and a stderr line at a terminal. Not a gate — the workflow runs this
with `|| true`, and a shared runner is no place to fail a build on an
instruction count — and 80 rather than 97 because the point is to catch a slide
rather than pin today's figure. Checked on both sides of the floor: quiet at
97x, fires at 73x.

**And the derive's duplicate rule is a decision, not an oversight.** The corpus
specifies the opposite for a spec-driven parse — a repeat is a correction, the
later occurrence wins — and usage-argv's parser and usage-lib both honour it.
The rule exists only in the derive's post-binding layer.

Kept, because the two cases differ. A spec parsed at run time may be describing
someone else's command line, which is the wrapper the corpus has in mind. A
derived CLI is an authored surface where `--jobs 1 --jobs 2` is likelier a
mistake than an amendment, and it is what clap does — so an adopter sees no
change, where dropping it would have a derived binary quietly accept a line clap
rejects today. That is the direction that costs an adopter rather than helping.

Written down because it reads as an inconsistency and is not one; the gate's
`differential.rs` carries the same note from the other end.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comments and non-failing CI warnings only; no runtime or parsing behavior changes.
> 
> **Overview**
> **Documentation and observability only** — no change to duplicate-flag behavior or parse logic.
> 
> `tasks/perf-shadow.sh` now defines **`CLAP_RATIO_FLOOR=80`**. After the shadow report is written, if the cold-parse ratio (clap vs usage) falls below that floor, the script emits a **`::warning::` on GitHub Actions** or a **stderr warning** locally. This is explicitly **not a gate** (`|| true` in CI); it flags parser-side regression when clap’s count stays flat.
> 
> In **`derive/src/codegen.rs`**, a long comment on **`rejects_duplicate`** was moved below **`reset_per_level`** and expanded. It records why the derive **rejects repeated non-repeatable flags** (clap-aligned, `Error::DuplicateFlag` from this layer) while **spec-driven** parsing treats repeats as “last wins,” and points readers to **`differential.rs`** for the other side of that story.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de2a01f167244c782f65643a461d29c9db0df134. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*
