### PR TITLE
docs(bench): read the go card the same way round as the rust one

### DIFF
--- a/docs/.vitepress/theme/UsageBenches.vue
+++ b/docs/.vitepress/theme/UsageBenches.vue
@@ -20,11 +20,16 @@ const rustRows = [
 
 // Go figures from go/README.md are whole-process wall time and subtract the
 // ~0.95ms a do-nothing Go process costs, so they are deliberately approximate.
+//
+// Ratios read the same way as the Rust card's: what each framework costs against
+// usage-go, on the row that costs it. Whole multiples, because every figure here is
+// a difference between two numbers already rounded to two significant figures — a
+// ratio of those does not deserve a decimal place.
 const goRows = [
-  { name: "usage-go", value: 0.15, label: "~0.15ms", note: "~6× less", us: true },
-  { name: "urfave/cli v3", value: 0.75, label: "~0.75ms", us: false },
-  { name: "cobra", value: 0.85, label: "~0.85ms", us: false },
-  { name: "kong", value: 5.2, label: "~5.2ms", us: false },
+  { name: "usage-go", value: 0.15, label: "~0.15ms", us: true },
+  { name: "urfave/cli v3", value: 0.75, label: "~0.75ms", note: "~5× more", us: false },
+  { name: "cobra", value: 0.85, label: "~0.85ms", note: "~6× more", us: false },
+  { name: "kong", value: 5.2, label: "~5.2ms", note: "~35× more", us: false },
 ];
 
 const rustMax = Math.max(...rustRows.map((r) => r.value));


### PR DESCRIPTION
The two benchmark cards asked to be read in opposite directions. The Rust card puts a ratio on the row that costs it — clap is `~2,500× more` — while the Go card put its ratio on usage-go's own row, `~6× less`, against a framework it did not name. (It was cobra.)

Now each Go row carries what it costs against usage-go:

| | | |
|---|---:|---:|
| usage-go | ~0.15ms | — |
| urfave/cli v3 | ~0.75ms | ~5× more |
| cobra | ~0.85ms | ~6× more |
| kong | ~5.2ms | ~35× more |

Whole multiples rather than the one decimal `tasks/perf-shadow.sh` uses below 10×: every figure on this card is a whole-process measurement minus the ~0.95 ms of Go runtime startup, so each is a difference between two numbers already rounded to two significant figures. `~5.7×` would read firmer than the inputs are — the `~` and a whole number say what is actually known.

Numbers unchanged, and still the ones in [go/README.md](https://github.com/jdx/usage/blob/main/go/README.md): 1.1, 1.7, 1.8 and 6.1 ms whole-process against a 0.95 ms do-nothing Go process.

`npx vitepress build docs` passes; rendered and checked at 1240px and 430px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only copy and display notes in the VitePress benchmark component; no runtime or measurement logic changes.
> 
> **Overview**
> **Aligns how the Go parser benchmark card presents ratios** with the Rust card in `UsageBenches.vue`.
> 
> Previously the Go card showed `~6× less` on the **usage-go** baseline row, which pointed at an unnamed competitor. It now puts **~N× more** on each framework row (urfave/cli ~5×, cobra ~6×, kong ~35×), matching the Rust pattern where clap/bpaf carry `~2,500× more` on their own rows. Timings are unchanged; only labels and inline comments were updated, including a note that whole multiples fit the approximate, two-significant-figure Go measurements better than one-decimal ratios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0625d2bb3aad246ea06d27e46b76b5bcc2ca791f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->