### PR TITLE
docs(bench): nudge a tip inside its card rather than parking it under the card

### DIFF
--- a/docs/.vitepress/theme/UsageBenches.vue
+++ b/docs/.vitepress/theme/UsageBenches.vue
@@ -38,6 +38,38 @@ const goMax = Math.max(...goRows.map((r) => r.value));
 function width(value: number, max: number): string {
   return `${Math.max((value / max) * 100, 0.5)}%`;
 }
+
+// A tip is centred on the phrase it explains, and where that phrase sits on the line
+// depends on where the text wrapped — so on a narrow card a tip can hang off the
+// edge, and which edge it hangs off is not knowable when the CSS is written. Nudge
+// it back inside as it opens. Measuring here rather than guessing in a media query
+// is what lets the tip stay under its own phrase at every width.
+const GUTTER = 8;
+
+function clamp(event: Event) {
+  const hint = event.currentTarget as HTMLElement;
+  const tip = hint.querySelector(".usage-bench-tip") as HTMLElement | null;
+  const card = hint.closest(".usage-bench-card") as HTMLElement | null;
+  if (!tip || !card) return;
+
+  // Where the tip sits with no nudge: centred on the phrase, per the CSS. Derived
+  // from layout rather than read off the tip's own rect, which reports wherever the
+  // last nudge is mid-transition to and would clamp against the wrong position.
+  const h = hint.getBoundingClientRect();
+  const c = card.getBoundingClientRect();
+  const left = h.left + h.width / 2 - tip.offsetWidth / 2;
+  const right = left + tip.offsetWidth;
+
+  // Inside the card, and inside the window: at 320px the card is itself wider than
+  // the screen, so the card alone is not the bound that matters there.
+  const min = Math.max(c.left, 0) + GUTTER;
+  const max = Math.min(c.right, window.innerWidth) - GUTTER;
+
+  let shift = 0;
+  if (left < min) shift = min - left;
+  else if (right > max) shift = max - right;
+  tip.style.setProperty("--tip-shift", `${Math.round(shift)}px`);
+}
 </script>
 
 <template>
@@ -56,7 +88,12 @@ function width(value: number, max: number): string {
         <h3>usage-rs <span>vs clap, argh, bpaf</span></h3>
         <p class="usage-bench-metric">
           wall time,
-          <span class="usage-bench-hint" tabindex="0" aria-describedby="bench-tip-warmed"
+          <span
+            class="usage-bench-hint"
+            tabindex="0"
+            @mouseenter="clamp"
+            @focusin="clamp"
+            aria-describedby="bench-tip-warmed"
             >one warmed parse
             <span class="usage-bench-tip" id="bench-tip-warmed" role="tooltip">
               <strong>How this is measured</strong>
@@ -90,7 +127,12 @@ function width(value: number, max: number): string {
         </div>
         <p class="usage-bench-foot">
           clap and bpaf
-          <span class="usage-bench-hint" tabindex="0" aria-describedby="bench-tip-build"
+          <span
+            class="usage-bench-hint"
+            tabindex="0"
+            @mouseenter="clamp"
+            @focusin="clamp"
+            aria-describedby="bench-tip-build"
             >build a parser before they can use one
             <span class="usage-bench-tip" id="bench-tip-build" role="tooltip">
               <strong>Where their time goes</strong>
@@ -102,7 +144,12 @@ function width(value: number, max: number): string {
             </span></span
           >. Heap allocations for a bare parse: <strong>zero</strong>, against clap's 6,280.
           argh and bpaf also
-          <span class="usage-bench-hint" tabindex="0" aria-describedby="bench-tip-express"
+          <span
+            class="usage-bench-hint"
+            tabindex="0"
+            @mouseenter="clamp"
+            @focusin="clamp"
+            aria-describedby="bench-tip-express"
             >express less
             <span class="usage-bench-tip" id="bench-tip-express" role="tooltip">
               <strong>Missing from the argh and bpaf shadows</strong>
@@ -120,7 +167,12 @@ function width(value: number, max: number): string {
         <h3>usage-go <span>vs cobra, urfave/cli, kong</span></h3>
         <p class="usage-bench-metric">
           wall time,
-          <span class="usage-bench-hint" tabindex="0" aria-describedby="bench-tip-cold"
+          <span
+            class="usage-bench-hint"
+            tabindex="0"
+            @mouseenter="clamp"
+            @focusin="clamp"
+            aria-describedby="bench-tip-cold"
             >one cold parse
             <span class="usage-bench-tip" id="bench-tip-cold" role="tooltip">
               <strong>How this is measured</strong>

--- a/docs/.vitepress/theme/UsageBenches.vue
+++ b/docs/.vitepress/theme/UsageBenches.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { onBeforeUnmount, onMounted } from "vue";
+
 // Rust wall clock from `time-sweep.rs`, which warms each parser and keeps the
 // fastest of many short rounds — steady-state and in-process, because a
 // whole-process measurement cannot resolve a 200ns parse. Values in nanoseconds,
@@ -46,30 +48,55 @@ function width(value: number, max: number): string {
 // is what lets the tip stay under its own phrase at every width.
 const GUTTER = 8;
 
-function clamp(event: Event) {
-  const hint = event.currentTarget as HTMLElement;
+function place(hint: HTMLElement) {
   const tip = hint.querySelector(".usage-bench-tip") as HTMLElement | null;
   const card = hint.closest(".usage-bench-card") as HTMLElement | null;
   if (!tip || !card) return;
 
-  // Where the tip sits with no nudge: centred on the phrase, per the CSS. Derived
-  // from layout rather than read off the tip's own rect, which reports wherever the
-  // last nudge is mid-transition to and would clamp against the wrong position.
   const h = hint.getBoundingClientRect();
   const c = card.getBoundingClientRect();
-  const left = h.left + h.width / 2 - tip.offsetWidth / 2;
-  const right = left + tip.offsetWidth;
 
   // Inside the card, and inside the window: at 320px the card is itself wider than
   // the screen, so the card alone is not the bound that matters there.
   const min = Math.max(c.left, 0) + GUTTER;
   const max = Math.min(c.right, window.innerWidth) - GUTTER;
+  const room = max - min;
+
+  // A tip too wide for that interval cannot be nudged into it — moving it to clear
+  // one edge only pushes it past the other — so cap the width to the room there is
+  // and let it wrap. This is why the width lives here and not only in the CSS, where
+  // it would have to guess the same interval a second time.
+  tip.style.maxWidth = "";
+  if (tip.offsetWidth > room) tip.style.maxWidth = `${Math.floor(room)}px`;
+
+  // Where the tip sits with no nudge: centred on the phrase, per the CSS. Derived
+  // from layout rather than read off the tip's own rect, which reports wherever the
+  // last nudge is mid-transition to and would clamp against the wrong position.
+  const left = h.left + h.width / 2 - tip.offsetWidth / 2;
+  const right = left + tip.offsetWidth;
 
   let shift = 0;
   if (left < min) shift = min - left;
   else if (right > max) shift = max - right;
   tip.style.setProperty("--tip-shift", `${Math.round(shift)}px`);
 }
+
+function clamp(event: Event) {
+  place(event.currentTarget as HTMLElement);
+}
+
+// A tip open across a resize, a zoom, a rotation or the 860px reflow was measured
+// against a layout that no longer exists. Whichever hint is still under the pointer
+// or holding focus is the one showing a tip, so that is the one to measure again.
+function replace() {
+  const open = document.querySelector(
+    ".usage-bench-hint:hover, .usage-bench-hint:focus",
+  ) as HTMLElement | null;
+  if (open) place(open);
+}
+
+onMounted(() => window.addEventListener("resize", replace, { passive: true }));
+onBeforeUnmount(() => window.removeEventListener("resize", replace));
 </script>
 
 <template>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -685,7 +685,13 @@
     0 0 20px var(--vw-cyan-glow);
   opacity: 0;
   visibility: hidden;
-  transition: all 0.2s ease;
+  /* Named properties rather than `all`: the component reads the tip's width back to
+     decide whether it has to cap it, and a width the browser is busy animating
+     reports the value it is animating from. */
+  transition:
+    opacity 0.2s ease,
+    visibility 0.2s ease,
+    transform 0.2s ease;
   pointer-events: none;
   z-index: 100;
   /* The metric line is uppercase mono; a tooltip inside it is prose. */

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -497,6 +497,11 @@
   margin: 0 auto;
   padding: 3.5rem 1.5rem 4.5rem;
   text-align: center;
+  /* A closed tip still takes part in layout, at the position it would open at, so on
+     a narrow screen it can widen the page even though nobody can see it. Clip that
+     horizontally; vertical stays visible, since an open tip hangs below its card. */
+  overflow-x: clip;
+  overflow-y: visible;
 }
 
 .usage-bench-title {
@@ -663,11 +668,13 @@
   position: absolute;
   top: 100%;
   left: 50%;
-  transform: translateX(-50%) translateY(6px);
+  /* --tip-shift is measured by the component as the tip opens: how far it has to
+     move to sit inside its card. Zero until then, and zero if scripting is off,
+     which leaves the tip centred on its phrase as it was. */
+  transform: translateX(calc(-50% + var(--tip-shift, 0px))) translateY(6px);
   width: max-content;
-  /* 280 rather than 300: at the widths where a card is ~650px, a wider tip
-     centred on the first footnote phrase hangs off the card's left edge. */
-  max-width: 280px;
+  /* Never wider than the viewport it has to fit into, gutters included. */
+  max-width: min(280px, calc(100vw - 2.5rem));
   margin-top: 0.5rem;
   padding: 0.8rem 1rem;
   background: rgba(13, 2, 33, 0.97);
@@ -696,7 +703,7 @@
 .usage-bench-hint:focus-visible .usage-bench-tip {
   opacity: 1;
   visibility: visible;
-  transform: translateX(-50%) translateY(0);
+  transform: translateX(calc(-50% + var(--tip-shift, 0px))) translateY(0);
 }
 
 .usage-bench-tip strong {
@@ -718,30 +725,6 @@
   display: block;
   color: rgba(245, 240, 255, 0.75);
   line-height: 1.55;
-}
-
-/* Narrow enough that a 300px tip centred on a phrase would hang off the card, and
-   which side it hangs off depends on where the line wrapped. Pin it to the card
-   instead: the hint stops being the positioning context, so the tip lands under the
-   card at its full width and cannot be clipped wherever the phrase ended up. */
-@media (max-width: 620px) {
-  .usage-bench-hint {
-    position: static;
-  }
-
-  .usage-bench-tip {
-    left: 1rem;
-    right: 1rem;
-    width: auto;
-    max-width: none;
-    transform: translateY(6px);
-  }
-
-  .usage-bench-hint:hover .usage-bench-tip,
-  .usage-bench-hint:focus .usage-bench-tip,
-  .usage-bench-hint:focus-visible .usage-bench-tip {
-    transform: translateY(0);
-  }
 }
 
 @media (max-width: 860px) {


### PR DESCRIPTION
Addresses the open P1 Greptile left on #994 after it merged.

## The finding

Below 620px the fix for tooltip overflow made the hint `position: static`, so the card became the tip's containing block while `top: 100%` still applied — putting the tip under the *whole card*. For the two footnote hints that reads fine (they sit near the card's bottom anyway), but the metric-line hint is at the card's top, so its tip opened a card's height away from the phrase it explains, over the methodology line below. Real, and worth fixing rather than resolving.

## The fix

Measure instead of guess. On open, the component works out where a tip centred on its phrase would land, and sets `--tip-shift` to whatever puts it back inside the card and inside the window:

```ts
const left = h.left + h.width / 2 - tip.offsetWidth / 2;
const min = Math.max(c.left, 0) + GUTTER;
const max = Math.min(c.right, window.innerWidth) - GUTTER;
```

That holds at every width, so the `620px` breakpoint is gone and a tip is always under its own phrase.

Two details worth flagging:

- **Position comes from layout, not from the tip's rect.** The tip transitions `transform`, so reading its `getBoundingClientRect()` on open returns wherever a previous nudge is animating to, and the clamp corrects against the wrong position. This cost me a debugging round: an early version silently computed `shift: 0` for tips that were 20px off the card.
- **The window is a bound too.** At 320px the card is itself wider than the screen, so clamping to the card alone still left a tip cut off.

Without script the tip stays centred, as the CSS puts it, and `.usage-bench` now clips horizontally — a closed tip still takes part in layout at the position it would open at, which was widening the page by up to 39px at narrow widths even though nobody could see it.

## Verification

Hovered all four tips at eleven viewport widths (320, 360, 380, 430, 500, 560, 620, 700, 860, 1000, 1240), checking each tip's box against its card, against the viewport, and against the phrase it belongs to:

```
all tips inside their card, under their phrase, no page overflow
```

Before this change the same sweep reported 15 problems, including a tip 55px off-screen at 360px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only VitePress UI for benchmark tooltips; no auth, data, or runtime product behavior.
> 
> **Overview**
> Replaces the **620px CSS breakpoint** that pinned benchmark footnote tooltips under the whole card (which misplaced metric-line tips) with **runtime positioning** in `UsageBenches.vue`.
> 
> On **mouseenter/focus**, `place()` measures the hint and card (and viewport) bounds, caps tip width when needed, and sets **`--tip-shift`** so each tooltip stays under its phrase and inside the card and window. A **resize** listener re-runs placement for the open hint. CSS uses that variable on `transform`, drops the narrow-screen media-query rules, adds **`overflow-x: clip`** on `.usage-bench` to stop hidden tips from widening the page, and limits transitions to opacity/visibility/transform so width reads are stable during open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96880c39f589445f5b5357a97f154aef6b21bd8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved benchmark tooltip positioning to keep tooltips within their cards and the viewport.
  * Updated tooltip behavior for mouse and keyboard interactions.
  * Prevented horizontal overflow while preserving access to vertically displayed tooltips.
  * Adjusted tooltip sizing dynamically for narrow screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->