### PR TITLE
feat(spec): add value-conditional requirements

### DIFF
--- a/docs/spec/reference/flag.md
+++ b/docs/spec/reference/flag.md
@@ -32,6 +32,9 @@ flag "--file <file>" required_unless="--dir" // either --file or --dir must be p
 flag "--file <file>" overrides="--stdin" // --file and --stdin override each other; the last one wins
 flag "--file <file>" conflicts="--stdin" // --file and --stdin cannot be given together
 flag "--out <path>" requires="--format"  // giving --out means --format must be given too
+flag "--config <file>" {
+  requires_if "special.toml" "--key" // this value also needs --key
+}
 flag "--dump" exclusive=#true            // --dump has to be given on its own
 flag "--tags <tag>" var=#true delimiter="," // --tags a,b,c is three values
 
@@ -94,6 +97,20 @@ is about, which is usually where a reader looks for it.
 A value from the environment or a default satisfies a requirement, on the same principle
 `conflicts` follows: the question is whether the other flag ended up with a value, not
 how it got one.
+
+`requires_if VALUE FLAG` makes the requirement conditional on the declaring flag's
+value. The node may be repeated when different values require different flags:
+
+```kdl
+flag "--config <file>" {
+  requires_if "special.toml" "--key"
+  requires_if "remote.toml" "--token"
+}
+```
+
+Command-line and environment values activate a conditional requirement; a default does
+not. If a flag collects several values, any matching value activates its requirement.
+This is the same source distinction clap's `requires_if` and `requires_ifs` make.
 
 ::: warning
 A spec generated from a clap command never carries this. clap has `Arg::requires` as a

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -9,7 +9,7 @@ pub use crate::spec::choices::SpecChoices;
 pub use crate::spec::cmd::SpecCommand;
 pub use crate::spec::complete::SpecComplete;
 pub use crate::spec::effect::SpecCommandEffect;
-pub use crate::spec::flag::SpecFlag;
+pub use crate::spec::flag::{SpecFlag, SpecRequiresIf};
 pub use crate::spec::group::SpecGroup;
 pub use crate::spec::mount::SpecMount;
 pub use crate::spec::unknown_flags::UnknownFlags;

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -1640,8 +1640,8 @@ fn explicit_flag_has_value(
         ParseValue::MultiBool(values) => values.iter().any(|value| value.to_string() == expected),
         ParseValue::MultiString(values) => values.iter().any(|value| value == expected),
     });
-    if parsed_matches {
-        return true;
+    if out.flags.contains_key(flag) {
+        return parsed_matches;
     }
 
     let Some(env) = flag.env.as_ref() else {
@@ -1654,6 +1654,9 @@ fn explicit_flag_has_value(
     value.is_some_and(
         |value| match flag.arg.as_ref().and_then(|arg| arg.delimiter) {
             Some(delimiter) => value.split(delimiter).any(|value| value == expected),
+            None if flag.arg.is_none() => {
+                matches!(value.as_str(), "1" | "true" | "True" | "TRUE").to_string() == expected
+            }
             None => value == expected,
         },
     )
@@ -3678,6 +3681,34 @@ flag "--file <file>" required_unless="--stdin"
             .unwrap();
         parse(&from_default, &input(&["ex"]))
             .expect("a default is not an explicit conditional value");
+    }
+
+    #[test]
+    fn command_line_values_override_env_for_conditional_requirements() {
+        let spec: Spec = "name \"ex\"\nbin \"ex\"\nflag \"--config <file>\" env=\"EX_CONFIG\" {\n  requires_if \"special.toml\" \"--key\"\n}\nflag \"--key <key>\"\n"
+            .parse()
+            .unwrap();
+
+        parse_with_env(
+            &spec,
+            &["ex", "--config", "ordinary.toml"],
+            &[("EX_CONFIG", "special.toml")],
+        )
+        .expect("the command-line value takes precedence over the environment");
+    }
+
+    #[test]
+    fn conditional_requirements_normalize_boolean_env_values() {
+        let spec: Spec = "name \"ex\"\nbin \"ex\"\nflag \"--feature\" env=\"EX_FEATURE\" {\n  requires_if \"true\" \"--key\"\n}\nflag \"--key <key>\"\n"
+            .parse()
+            .unwrap();
+
+        for value in ["1", "true", "True", "TRUE"] {
+            let err = parse_with_env(&spec, &["ex"], &[("EX_FEATURE", value)]).unwrap_err();
+            assert!(err.to_string().contains("key"), "{value}: {err}");
+        }
+        parse_with_env(&spec, &["ex"], &[("EX_FEATURE", "false")])
+            .expect("a false environment value does not activate a true condition");
     }
 
     #[test]

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -1379,6 +1379,20 @@ fn parse_partial_with_env(
                     out.errors.push(UsageErr::MissingFlag(name));
                 }
             }
+            for condition in &flag.requires_if {
+                if explicit_flag_has_value(flag, &condition.value, &out, custom_env)
+                    && !selector_is_satisfied(
+                        &condition.requires,
+                        &out,
+                        &overridden_flags,
+                        custom_env,
+                    )
+                {
+                    let name = selector_flag_name(&condition.requires, &out)
+                        .unwrap_or_else(|| condition.requires.clone());
+                    out.errors.push(UsageErr::MissingFlag(name));
+                }
+            }
         }
     }
 
@@ -1607,6 +1621,42 @@ fn flag_has_env(flag: &SpecFlag, custom_env: Option<&HashMap<String, String>>) -
     flag.env
         .as_ref()
         .is_some_and(|env_var| env_contains(custom_env, env_var))
+}
+
+/// Whether an explicitly supplied value of `flag` equals `expected`.
+///
+/// clap treats command-line and environment values as explicit for `requires_if`, but
+/// not defaults. Keep that source distinction here instead of consulting the flag's
+/// defaults through `selector_is_satisfied`.
+fn explicit_flag_has_value(
+    flag: &SpecFlag,
+    expected: &str,
+    out: &ParseOutput,
+    custom_env: Option<&HashMap<String, String>>,
+) -> bool {
+    let parsed_matches = out.flags.get(flag).is_some_and(|value| match value {
+        ParseValue::Bool(value) => value.to_string() == expected,
+        ParseValue::String(value) => value == expected,
+        ParseValue::MultiBool(values) => values.iter().any(|value| value.to_string() == expected),
+        ParseValue::MultiString(values) => values.iter().any(|value| value == expected),
+    });
+    if parsed_matches {
+        return true;
+    }
+
+    let Some(env) = flag.env.as_ref() else {
+        return false;
+    };
+    let value = match custom_env {
+        Some(values) => values.get(env).cloned(),
+        None => std::env::var(env).ok(),
+    };
+    value.is_some_and(
+        |value| match flag.arg.as_ref().and_then(|arg| arg.delimiter) {
+            Some(delimiter) => value.split(delimiter).any(|value| value == expected),
+            None => value == expected,
+        },
+    )
 }
 
 fn selector_is_explicit(
@@ -3592,6 +3642,42 @@ flag "--file <file>" required_unless="--stdin"
         // Nothing happens when the flag that imposes the rule is absent: a requirement
         // is a consequence of using the flag, not a rule about the command line.
         parse(&spec, &input(&["ex"])).expect("a bare invocation requires nothing");
+    }
+
+    #[test]
+    fn a_value_activates_only_its_conditional_requirement() {
+        let spec: Spec = "name \"ex\"\nbin \"ex\"\nflag \"--config <file>\" {\n  requires_if \"special.toml\" \"--key\"\n  requires_if \"remote.toml\" \"--token\"\n}\nflag \"--key <key>\"\nflag \"--token <token>\"\n"
+            .parse()
+            .unwrap();
+
+        parse(&spec, &input(&["ex", "--config", "ordinary.toml"]))
+            .expect("an unrelated value requires nothing");
+
+        let key = parse(&spec, &input(&["ex", "--config", "special.toml"])).unwrap_err();
+        assert!(key.to_string().contains("key"), "{key}");
+        parse(
+            &spec,
+            &input(&["ex", "--config", "special.toml", "--key", "secret"]),
+        )
+        .expect("the matching requirement is satisfied");
+
+        let token = parse(&spec, &input(&["ex", "--config", "remote.toml"])).unwrap_err();
+        assert!(token.to_string().contains("token"), "{token}");
+    }
+
+    #[test]
+    fn conditional_requirements_read_explicit_env_but_not_defaults() {
+        let from_env: Spec = "name \"ex\"\nbin \"ex\"\nflag \"--config <file>\" env=\"EX_CONFIG\" {\n  requires_if \"special.toml\" \"--key\"\n}\nflag \"--key <key>\"\n"
+            .parse()
+            .unwrap();
+        let err = parse_with_env(&from_env, &["ex"], &[("EX_CONFIG", "special.toml")]).unwrap_err();
+        assert!(err.to_string().contains("key"), "{err}");
+
+        let from_default: Spec = "name \"ex\"\nbin \"ex\"\nflag \"--config <file>\" default=\"special.toml\" {\n  requires_if \"special.toml\" \"--key\"\n}\nflag \"--key <key>\"\n"
+            .parse()
+            .unwrap();
+        parse(&from_default, &input(&["ex"]))
+            .expect("a default is not an explicit conditional value");
     }
 
     #[test]

--- a/lib/src/spec/builder.rs
+++ b/lib/src/spec/builder.rs
@@ -32,7 +32,9 @@
 
 use crate::spec::cmd::SpecExample;
 use crate::spec::effect::SpecCommandEffect;
-use crate::{spec::arg::SpecDoubleDashChoices, SpecArg, SpecChoices, SpecCommand, SpecFlag};
+use crate::{
+    spec::arg::SpecDoubleDashChoices, SpecArg, SpecChoices, SpecCommand, SpecFlag, SpecRequiresIf,
+};
 
 /// Builder for SpecFlag
 #[derive(Debug, Default, Clone)]
@@ -262,6 +264,35 @@ impl SpecFlagBuilder {
         self.inner
             .requires
             .extend(flags.into_iter().map(Into::into));
+        self
+    }
+
+    /// Add a flag required when this flag is explicitly given `value`
+    pub fn requires_if(mut self, value: impl Into<String>, flag: impl Into<String>) -> Self {
+        self.inner.requires_if.push(SpecRequiresIf {
+            value: value.into(),
+            requires: flag.into(),
+        });
+        self
+    }
+
+    /// Add value-conditional flag requirements
+    pub fn requires_ifs<I, V, S>(mut self, requirements: I) -> Self
+    where
+        I: IntoIterator<Item = (V, S)>,
+        V: Into<String>,
+        S: Into<String>,
+    {
+        self.inner
+            .requires_if
+            .extend(
+                requirements
+                    .into_iter()
+                    .map(|(value, requires)| SpecRequiresIf {
+                        value: value.into(),
+                        requires: requires.into(),
+                    }),
+            );
         self
     }
 
@@ -727,6 +758,33 @@ mod tests {
         assert!(flag.var);
         assert_eq!(flag.var_min, Some(1));
         assert_eq!(flag.var_max, Some(10));
+    }
+
+    #[test]
+    fn test_flag_builder_conditional_requirements() {
+        let flag = SpecFlagBuilder::new()
+            .long("config")
+            .requires_if("special.toml", "--key")
+            .requires_ifs([("remote.toml", "--token"), ("signed.toml", "--identity")])
+            .build();
+
+        assert_eq!(
+            flag.requires_if,
+            [
+                SpecRequiresIf {
+                    value: "special.toml".into(),
+                    requires: "--key".into(),
+                },
+                SpecRequiresIf {
+                    value: "remote.toml".into(),
+                    requires: "--token".into(),
+                },
+                SpecRequiresIf {
+                    value: "signed.toml".into(),
+                    requires: "--identity".into(),
+                },
+            ]
+        );
     }
 
     #[test]

--- a/lib/src/spec/flag.rs
+++ b/lib/src/spec/flag.rs
@@ -15,6 +15,19 @@ use crate::spec::helpers::{string_entry, NodeHelper};
 use crate::spec::is_false;
 use crate::{string, SpecArg, SpecChoices};
 
+/// A requirement activated by one of a flag's values.
+///
+/// `flag "--config <file>" { requires_if "special.toml" "--key" }`
+/// means `--key` is required only when `--config` was explicitly given the
+/// value `special.toml`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SpecRequiresIf {
+    /// The declaring flag's value that activates the requirement.
+    pub value: String,
+    /// The flag selector that must then be satisfied.
+    pub requires: String,
+}
+
 /// A CLI flag/option specification.
 ///
 /// Flags are optional arguments that start with `-` (short) or `--` (long).
@@ -116,6 +129,12 @@ pub struct SpecFlag {
     /// had.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub requires: Vec<String>,
+    /// Flags required when this flag is explicitly given a particular value.
+    ///
+    /// Defaults do not activate the condition; command-line and environment
+    /// values do. This matches clap's `requires_if`/`requires_ifs` semantics.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub requires_if: Vec<SpecRequiresIf>,
     /// Whether this flag must be given on its own.
     ///
     /// The whole-command form of [`SpecFlag::conflicts`]: `--version` and `--help` are
@@ -305,6 +324,13 @@ impl SpecFlag {
                         .args()
                         .map(|arg| arg.ensure_string())
                         .collect::<Result<Vec<_>>>()?;
+                }
+                "requires_if" => {
+                    child.ensure_arg_len(2..=2)?;
+                    flag.requires_if.push(SpecRequiresIf {
+                        value: child.arg(0)?.ensure_string()?,
+                        requires: child.arg(1)?.ensure_string()?,
+                    });
                 }
                 "choices" => {
                     if let Some(arg) = &mut flag.arg {
@@ -509,6 +535,13 @@ impl From<&SpecFlag> for KdlNode {
             }
             children.nodes_mut().push(requires);
         }
+        for condition in &flag.requires_if {
+            let children = node.children_mut().get_or_insert_with(KdlDocument::new);
+            let mut requires_if = KdlNode::new("requires_if");
+            requires_if.push(string_entry(None, &condition.value));
+            requires_if.push(string_entry(None, &condition.requires));
+            children.nodes_mut().push(requires_if);
+        }
         if flag.exclusive {
             node.push(KdlEntry::new_prop("exclusive", true));
         }
@@ -706,6 +739,8 @@ impl From<&clap::Arg> for SpecFlag {
             // than guessed at, and counted by `gen-shadow` as a thing the clap dialect
             // cannot carry.
             requires: vec![],
+            // The conditional forms are hidden behind the same clap API boundary.
+            requires_if: vec![],
             // This one clap does expose, unlike `requires` just above.
             exclusive: c.is_exclusive_set(),
             help,
@@ -863,6 +898,33 @@ mod tests {
         let reparsed: Spec = spec.to_string().parse().unwrap();
         assert_eq!(reparsed.cmd.flags[0].requires, vec!["--format".to_string()]);
         assert_eq!(reparsed.cmd.flags[1].requires.len(), 2, "{spec}");
+    }
+
+    #[test]
+    fn conditional_requirements_round_trip_in_order() {
+        let spec: Spec = "flag \"--config <file>\" {\n  requires_if \"special.toml\" \"--key\"\n  requires_if \"remote.toml\" \"--token\"\n}\nflag \"--key <key>\"\nflag \"--token <token>\"\n"
+            .parse()
+            .unwrap();
+        assert_eq!(
+            spec.cmd.flags[0].requires_if,
+            [
+                SpecRequiresIf {
+                    value: "special.toml".into(),
+                    requires: "--key".into(),
+                },
+                SpecRequiresIf {
+                    value: "remote.toml".into(),
+                    requires: "--token".into(),
+                },
+            ]
+        );
+
+        let emitted = spec.to_string();
+        let reparsed: Spec = emitted.parse().unwrap();
+        assert_eq!(
+            reparsed.cmd.flags[0].requires_if,
+            spec.cmd.flags[0].requires_if
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- add repeated `requires_if VALUE FLAG` relationships to the canonical KDL model
- round-trip the relationships through `SpecFlag` and its builder
- enforce explicit command-line and environment values in usage-lib while excluding defaults
- document the source semantics and public spec API

## Why

This is the remaining usage-derive v1 relationship that the spec could not express. The spec must define it before compiled tables and derives can lower into it without becoming lossy.

## Validation

- `cargo test -p usage-lib --all-features`
- full workspace suite passes on the stack tip with `cargo test --all --all-features`

_This pull request was generated with Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI validation behavior for specs that adopt `requires_if`; semantics are nuanced (defaults vs env vs CLI) but covered by new tests.
> 
> **Overview**
> Adds **`requires_if VALUE FLAG`** to the KDL flag spec so a flag can require other flags only when it is explicitly set to a given value (repeatable for different value→flag pairs).
> 
> **Spec & API:** New `SpecRequiresIf` type and `requires_if` on `SpecFlag`, with KDL parse/emit round-trip and `SpecFlagBuilder::requires_if` / `requires_ifs`. **`SpecRequiresIf` is re-exported** from the public crate surface.
> 
> **Parser:** After parse, when a declaring flag’s value matches (CLI or env, not defaults), the named flag must be satisfied or **`MissingFlag`** is reported—aligned with clap’s explicit-vs-default distinction, including multi-value flags, delimiter-split env values, and boolean env normalization.
> 
> **Docs:** `flag.md` documents semantics and notes clap-generated specs still cannot carry these constraints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5dd6dfd96421086c307e8fdb70149e285f2657b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added conditional flag requirements based on explicitly supplied command-line or environment values.
  - Added support for configuring single or multiple conditional requirements.
  - Added public access to conditional requirement definitions.
  - Conditions support scalar, boolean, variadic, and delimited values.
  - Command-line values take precedence over environment values.
  - Conditions do not activate when values come only from defaults.

- **Documentation**
  - Documented conditional requirements, repeated conditions, and value-matching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->