### PR TITLE
feat(derive): add value-conditional requirements

### DIFF
--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -625,6 +625,8 @@ pub struct FlagMeta<'a> {
     /// [`required_if`](Self::required_if): the same rule written on the flag that
     /// imposes it rather than on the flag it lands on.
     pub requires: &'a [&'a str],
+    /// Value-triggered requirements declared by this flag.
+    pub requires_if: &'a [RequiresIf<'a>],
     /// Flags that make this one necessary.
     pub required_if: &'a [&'a str],
     /// Flags that make this one unnecessary.
@@ -659,11 +661,19 @@ impl FlagMeta<'_> {
         delimiter: None,
         exclusive: false,
         requires: &[],
+        requires_if: &[],
         required_if: &[],
         required_unless: &[],
         help_heading: None,
         effect: None,
     };
+}
+
+/// A flag required when the declaring flag is explicitly given `value`.
+#[derive(Debug, Clone, Copy)]
+pub struct RequiresIf<'a> {
+    pub value: &'a str,
+    pub requires: &'a str,
 }
 
 /// What a positional argument knows about itself beyond how it parses.
@@ -1181,6 +1191,7 @@ fn write_flag(out: &mut String, meta: &FlagMeta<'_>, depth: usize) -> core::fmt:
         || meta.overrides.len() > 1
         || meta.conflicts.len() > 1
         || meta.requires.len() > 1
+        || !meta.requires_if.is_empty()
         || meta.required_if.len() > 1
         || meta.required_unless.len() > 1;
     if !has_children {
@@ -1198,6 +1209,15 @@ fn write_flag(out: &mut String, meta: &FlagMeta<'_>, depth: usize) -> core::fmt:
     write_many_list(out, "overrides", meta.overrides, inner)?;
     write_many_list(out, "conflicts", meta.conflicts, inner)?;
     write_many_list(out, "requires", meta.requires, inner)?;
+    for condition in meta.requires_if {
+        indent(out, inner)?;
+        writeln!(
+            out,
+            "requires_if {} {}",
+            quoted(condition.value),
+            quoted(condition.requires)
+        )?;
+    }
     write_many_list(out, "required_if", meta.required_if, inner)?;
     write_many_list(out, "required_unless", meta.required_unless, inner)?;
     if meta.flag.takes_value {

--- a/conformance/src/tables.rs
+++ b/conformance/src/tables.rs
@@ -25,7 +25,7 @@
 
 use usage::spec::cmd::SpecExample;
 use usage::{Spec, SpecArg, SpecCommand, SpecComplete, SpecFlag, SpecGroup};
-use usage_argv::spec::{ArgMeta, CommandMeta, Effect, Example, FlagMeta, GroupMeta};
+use usage_argv::spec::{ArgMeta, CommandMeta, Effect, Example, FlagMeta, GroupMeta, RequiresIf};
 use usage_argv::{Arg, Command, DoubleDash, Flag, UnknownFlags as ArgvUnknownFlags};
 
 /// A command's two tables, built together so the metadata can borrow the parse table.
@@ -321,6 +321,16 @@ fn flag_meta(
         overrides: strs(&f.overrides),
         conflicts: strs(&f.conflicts),
         requires: strs(&f.requires),
+        requires_if: Box::leak(
+            f.requires_if
+                .iter()
+                .map(|condition| RequiresIf {
+                    value: leak(&condition.value),
+                    requires: leak(&condition.requires),
+                })
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        ),
         exclusive: f.exclusive,
         required_if: strs(&f.required_if),
         required_unless: strs(&f.required_unless),

--- a/conformance/tests/requires_if.rs
+++ b/conformance/tests/requires_if.rs
@@ -1,0 +1,82 @@
+//! Value-conditional requirements through the compiled derive path.
+
+use std::ffi::OsStr;
+
+use usage::Spec as LibSpec;
+use usage_argv::Error;
+use usage_derive::Cli;
+
+fn argv<const N: usize>(tokens: [&str; N]) -> [&OsStr; N] {
+    tokens.map(OsStr::new)
+}
+
+#[derive(Cli)]
+#[usage(bin = "conditional")]
+struct Conditional {
+    #[usage(
+        long,
+        requires_if("json", "--schema"),
+        requires_ifs(("signed", "--key"), ("remote", "--token"))
+    )]
+    format: Option<String>,
+    #[usage(long)]
+    schema: Option<String>,
+    #[usage(long)]
+    key: Option<String>,
+    #[usage(long)]
+    token: Option<String>,
+}
+
+#[test]
+fn each_value_activates_only_its_requirement() {
+    let unrelated = argv(["--format", "text"]);
+    Conditional::parse_from(&unrelated).expect("an unrelated value requires nothing");
+
+    for (value, missing) in [("json", "schema"), ("signed", "key"), ("remote", "token")] {
+        let words = argv(["--format", value]);
+        assert!(matches!(
+            Conditional::parse_from(&words),
+            Err(Error::MissingRequired { name }) if name == missing
+        ));
+    }
+
+    let satisfied = argv(["--format", "json", "--schema", "schema.json"]);
+    let parsed = Conditional::parse_from(&satisfied).expect("the matching flag satisfies it");
+    assert_eq!(parsed.format.as_deref(), Some("json"));
+    assert_eq!(parsed.schema.as_deref(), Some("schema.json"));
+    assert!(parsed.key.is_none());
+    assert!(parsed.token.is_none());
+}
+
+#[test]
+fn the_conditions_reach_the_emitted_spec() {
+    let spec: LibSpec = Conditional::to_kdl().parse().expect("valid emitted spec");
+    let format = spec
+        .cmd
+        .flags
+        .iter()
+        .find(|flag| flag.name == "format")
+        .expect("format flag");
+    assert_eq!(format.requires_if.len(), 3);
+    assert_eq!(format.requires_if[0].value, "json");
+    assert_eq!(format.requires_if[0].requires, "--schema");
+    assert_eq!(format.requires_if[2].value, "remote");
+    assert_eq!(format.requires_if[2].requires, "--token");
+}
+
+#[derive(Cli)]
+#[usage(bin = "defaulted")]
+struct Defaulted {
+    #[usage(long, default = "json", requires_if("json", "--schema"))]
+    format: Option<String>,
+    #[usage(long)]
+    schema: Option<String>,
+}
+
+#[test]
+fn a_default_does_not_activate_a_conditional_requirement() {
+    let empty = argv([]);
+    let parsed = Defaulted::parse_from(&empty).expect("defaults are not explicit");
+    assert_eq!(parsed.format.as_deref(), Some("json"));
+    assert!(parsed.schema.is_none());
+}

--- a/conformance/tests/requires_if.rs
+++ b/conformance/tests/requires_if.rs
@@ -80,3 +80,36 @@ fn a_default_does_not_activate_a_conditional_requirement() {
     assert_eq!(parsed.format.as_deref(), Some("json"));
     assert!(parsed.schema.is_none());
 }
+
+#[derive(Cli)]
+#[usage(bin = "counted")]
+struct Counted {
+    #[usage(
+        short = 'v',
+        long,
+        count,
+        requires_if("true", "--schema"),
+        requires_if("2", "--never")
+    )]
+    verbose: u8,
+    #[usage(long)]
+    schema: Option<String>,
+    #[usage(long)]
+    never: bool,
+}
+
+#[test]
+fn a_count_matches_the_canonical_boolean_value() {
+    let missing = argv(["-v"]);
+    assert!(matches!(
+        Counted::parse_from(&missing),
+        Err(Error::MissingRequired { name }) if name == "schema"
+    ));
+
+    let satisfied = argv(["-vv", "--schema", "schema.json"]);
+    let parsed = Counted::parse_from(&satisfied)
+        .expect("a numeric condition is not a count-value relationship");
+    assert_eq!(parsed.verbose, 2);
+    assert_eq!(parsed.schema.as_deref(), Some("schema.json"));
+    assert!(!parsed.never);
+}

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -930,6 +930,11 @@ fn flag_meta(i: usize, field: &Field, owner: &syn::Ident) -> TokenStream {
     let overrides = &field.overrides;
     let conflicts = &field.conflicts;
     let requires = &field.requires;
+    let requires_if = field.requires_if.iter().map(|condition| {
+        let value = &condition.value;
+        let requires = &condition.requires;
+        quote!(usage_argv::spec::RequiresIf { value: #value, requires: #requires })
+    });
     let exclusive = field.exclusive;
     let delimiter = match field.delimiter {
         Some(c) => quote!(::std::option::Option::Some(#c)),
@@ -970,6 +975,7 @@ fn flag_meta(i: usize, field: &Field, owner: &syn::Ident) -> TokenStream {
             overrides: &[#(#overrides),*],
             conflicts: &[#(#conflicts),*],
             requires: &[#(#requires),*],
+            requires_if: &[#(#requires_if),*],
             exclusive: #exclusive,
             delimiter: #delimiter,
             required_if: &[#(#required_if),*],
@@ -3699,6 +3705,48 @@ fn post_binding(cli: &Cli) -> TokenStream {
         })
     });
 
+    // Only an explicit matching value activates this form. Defaults are applied above
+    // without setting `__given_*`; argv and environment fallback set it. The partial
+    // still holds bytes, so matching does not parse or otherwise reinterpret a value.
+    let conditional_requirement_checks = cli.fields.iter().flat_map(move |f| {
+        let given = format_ident!("__given_{}", f.ident);
+        let ident = &f.ident;
+        f.requires_if.iter().filter_map(move |condition| {
+            let other = cli.field_for_selector(&condition.requires)?;
+            if !other.default.is_empty() {
+                return None;
+            }
+            let other_given = format_ident!("__given_{}", other.ident);
+            let other_name = &other.name;
+            let value = &condition.value;
+            let matches = match f.shape {
+                Shape::Optional => quote!(
+                    partial.#ident.as_deref().is_some_and(|v| v == #value.as_bytes())
+                ),
+                Shape::Required => quote!(partial.#ident.as_slice() == #value.as_bytes()),
+                Shape::Many => quote!(
+                    partial.#ident.iter().any(|v| v.as_slice() == #value.as_bytes())
+                ),
+                Shape::Bool => match value.as_str() {
+                    "true" => quote!(partial.#ident),
+                    "false" => quote!(!partial.#ident),
+                    _ => quote!(false),
+                },
+                Shape::Count => match value.parse::<usize>() {
+                    Ok(value) => quote!(partial.#ident == #value),
+                    Err(_) => quote!(false),
+                },
+            };
+            Some(quote! {
+                if partial.#given && #matches && !partial.#other_given {
+                    return ::std::result::Result::Err(
+                        usage_argv::Error::MissingRequired { name: #other_name },
+                    );
+                }
+            })
+        })
+    });
+
     // An exclusive flag is a conflict with the whole command rather than with a named
     // flag, so it is written as one check per *other* declaration — positionals included,
     // which is what makes it more than being in a group with every other flag.
@@ -3980,6 +4028,7 @@ fn post_binding(cli: &Cli) -> TokenStream {
         // and other validation still ran above; only errors about absent siblings are skipped.
         if !__usage_exclusive_present {
             #(#requirement_checks)*
+            #(#conditional_requirement_checks)*
             #(#required_checks)*
             #(#group_required_checks)*
             #(#relationship_required_checks)*

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -3732,9 +3732,10 @@ fn post_binding(cli: &Cli) -> TokenStream {
                     "false" => quote!(!partial.#ident),
                     _ => quote!(false),
                 },
-                Shape::Count => match value.parse::<usize>() {
-                    Ok(value) => quote!(partial.#ident == #value),
-                    Err(_) => quote!(false),
+                Shape::Count => match value.as_str() {
+                    "true" => quote!(partial.#ident > 0),
+                    "false" => quote!(partial.#ident == 0),
+                    _ => quote!(false),
                 },
             };
             Some(quote! {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -213,6 +213,8 @@
 //! | `overrides = "--other"` | a flag this one displaces, the last given winning |
 //! | `conflicts = "--other"` | a flag this one cannot be given with |
 //! | `requires = "--other"` | a flag that must also be given when this one is |
+//! | `requires_if("value", "--other")` | a flag required when this one explicitly has `value` |
+//! | `requires_ifs(("a", "--x"), ("b", "--y"))` | several value-conditional requirements |
 //! | `group = "input"` | the group this flag is one of; see below |
 //! | `exclusive` | this flag has to be given on its own, positionals included |
 //! | `delimiter = ','` | one word becomes several values; the field has to be a `Vec` |

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -205,6 +205,8 @@ pub struct Field {
     /// one lives on the flag the rule is about, which is where clap puts it and where a
     /// reader looks for it.
     pub requires: Vec<String>,
+    /// Requirements activated by one of this flag's explicit values.
+    pub requires_if: Vec<ConditionalRequirement>,
     /// The character a value is split on, making one word several values.
     ///
     /// Only where several can land, so the field has to be a collection — checked at
@@ -229,6 +231,12 @@ pub struct Field {
     /// enough to eat a positional — the same mistake the conformance harness made.
     pub repeatable: bool,
     pub span: Span,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConditionalRequirement {
+    pub value: String,
+    pub requires: String,
 }
 
 /// How a positional argument relates to the `--` separator.
@@ -970,6 +978,24 @@ impl Cli {
                     }
                 }
             }
+            for condition in &field.requires_if {
+                let selector = &condition.requires;
+                let Some(target) = self.field_for_selector(selector) else {
+                    return Err(syn::Error::new(
+                        field.span,
+                        format!(
+                            "`requires_if(_, \"{selector}\")` names no flag on this command; \
+                             write it as the spec does, `--long` or `-s`"
+                        ),
+                    ));
+                };
+                if target.ident == field.ident {
+                    return Err(syn::Error::new(
+                        field.span,
+                        format!("`requires_if(_, \"{selector}\")` names its own field"),
+                    ));
+                }
+            }
         }
         Ok(())
     }
@@ -1074,6 +1100,7 @@ impl Field {
             overrides: Vec::new(),
             conflicts: Vec::new(),
             requires: Vec::new(),
+            requires_if: Vec::new(),
             delimiter: None,
             exclusive: false,
             group: None,
@@ -1171,6 +1198,7 @@ impl Field {
             overrides: Vec::new(),
             conflicts: Vec::new(),
             requires: Vec::new(),
+            requires_if: Vec::new(),
             delimiter: None,
             exclusive: false,
             group: None,
@@ -1231,6 +1259,7 @@ impl Field {
         let mut overrides: Vec<String> = Vec::new();
         let mut conflicts: Vec<String> = Vec::new();
         let mut requires: Vec<String> = Vec::new();
+        let mut requires_if: Vec<ConditionalRequirement> = Vec::new();
         let mut group: Option<String> = None;
         let mut exclusive = false;
         let mut delimiter: Option<char> = None;
@@ -1326,6 +1355,8 @@ impl Field {
                     "overrides" => overrides = selectors(&meta)?,
                     "conflicts" => conflicts = selectors(&meta)?,
                     "requires" => requires = selectors(&meta)?,
+                    "requires_if" => requires_if.push(requirement_if(&meta)?),
+                    "requires_ifs" => requires_if.extend(requirements_if(&meta)?),
                     "group" => group = Some(string_value(&meta)?),
                     "exclusive" => exclusive = flag_value(&meta)?,
                     "delimiter" => {
@@ -1663,6 +1694,13 @@ impl Field {
                 ));
             }
         }
+        if !requires_if.is_empty() && !is_flag {
+            return Err(syn::Error::new(
+                span,
+                "`requires_if` describes a relationship between flags, so the field \
+                 needs a `long` or a `short`",
+            ));
+        }
         // Declared text wins over the comment, which is the point of declaring it. A comment's
         // first paragraph is read the way Rust reads one — line breaks inside it become spaces —
         // so help whose breaks are deliberate has to be given directly.
@@ -1944,6 +1982,7 @@ impl Field {
             overrides,
             conflicts,
             requires,
+            requires_if,
             delimiter,
             exclusive,
             group,
@@ -2237,6 +2276,77 @@ fn selectors(meta: &Meta) -> syn::Result<Vec<String>> {
         ));
     }
     Ok(found)
+}
+
+fn requirement_if(meta: &Meta) -> syn::Result<ConditionalRequirement> {
+    let Meta::List(list) = meta else {
+        return Err(syn::Error::new_spanned(
+            meta,
+            "`requires_if` takes a value and a flag, as in \
+             `requires_if(\"json\", \"--format\")`",
+        ));
+    };
+    let args = list.parse_args_with(
+        syn::punctuated::Punctuated::<syn::LitStr, syn::Token![,]>::parse_terminated,
+    )?;
+    if args.len() != 2 {
+        return Err(syn::Error::new_spanned(
+            meta,
+            "`requires_if` takes exactly a value and a flag, as in \
+             `requires_if(\"json\", \"--format\")`",
+        ));
+    }
+    let mut args = args.into_iter();
+    Ok(ConditionalRequirement {
+        value: args.next().expect("length checked").value(),
+        requires: args.next().expect("length checked").value(),
+    })
+}
+
+fn requirements_if(meta: &Meta) -> syn::Result<Vec<ConditionalRequirement>> {
+    let Meta::List(list) = meta else {
+        return Err(syn::Error::new_spanned(
+            meta,
+            "`requires_ifs` takes `(value, flag)` pairs",
+        ));
+    };
+    let pairs = list.parse_args_with(
+        syn::punctuated::Punctuated::<syn::ExprTuple, syn::Token![,]>::parse_terminated,
+    )?;
+    if pairs.is_empty() {
+        return Err(syn::Error::new_spanned(
+            meta,
+            "`requires_ifs` needs at least one `(value, flag)` pair",
+        ));
+    }
+    pairs
+        .into_iter()
+        .map(|pair| {
+            if pair.elems.len() != 2 {
+                return Err(syn::Error::new_spanned(
+                    pair,
+                    "each `requires_ifs` entry is `(value, flag)`",
+                ));
+            }
+            let mut elems = pair.elems.into_iter();
+            let value = string_expr(elems.next().expect("length checked"))?;
+            let requires = string_expr(elems.next().expect("length checked"))?;
+            Ok(ConditionalRequirement { value, requires })
+        })
+        .collect()
+}
+
+fn string_expr(expr: Expr) -> syn::Result<String> {
+    match expr {
+        Expr::Lit(ExprLit {
+            lit: Lit::Str(value),
+            ..
+        }) => Ok(value.value()),
+        other => Err(syn::Error::new_spanned(
+            other,
+            "a conditional requirement's value and flag must be string literals",
+        )),
+    }
 }
 
 fn int_value(meta: &Meta) -> syn::Result<usize> {
@@ -2988,6 +3098,41 @@ mod tests {
         "#,
         );
         assert!(err.contains("names no flag"), "unhelpful message: {err}");
+
+        let err = rejection(
+            r#"
+            struct Ex {
+                #[usage(long, requires_if("json", "--schema"))]
+                format: Option<String>,
+            }
+        "#,
+        );
+        assert!(err.contains("names no flag"), "unhelpful message: {err}");
+    }
+
+    #[test]
+    fn conditional_requirements_need_pairs_and_a_flag() {
+        let err = rejection(
+            r#"
+            struct Ex {
+                #[usage(long, requires_if("json"))]
+                format: Option<String>,
+            }
+        "#,
+        );
+        assert!(err.contains("exactly a value and a flag"), "{err}");
+
+        let err = rejection(
+            r#"
+            struct Ex {
+                #[usage(requires_if("json", "--schema"))]
+                format: Option<String>,
+                #[usage(long)]
+                schema: Option<String>,
+            }
+        "#,
+        );
+        assert!(err.contains("relationship between flags"), "{err}");
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- carry value-conditional requirements in cold `FlagMeta` tables and emitted KDL
- accept `requires_if(value, flag)` and `requires_ifs((value, flag), ...)` in the derive
- validate selectors at compile time
- enforce matching explicit values during post-binding checks
- cover parsing, defaults, metadata emission, and invalid declarations

## Why

This completes the compiled lowering for the canonical semantics introduced by the parent PR without adding work to the hot binding parser.

## Validation

- `cargo test -p usage-argv --all-features`
- `cargo test -p usage-conformance --all-features`
- `cargo test -p usage-derive --all-features`
- full workspace suite passes on the stack tip with `cargo test --all --all-features`

_This pull request was generated with Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI validation semantics for derive-built commands (new `MissingRequired` paths) but stays off the hot parser; edge cases around defaults, counts, and explicit-vs-implicit values are explicitly tested.
> 
> **Overview**
> Adds **value-conditional flag requirements** to the compiled `usage-derive` path: when a flag is explicitly given a matching value, another flag must also be present.
> 
> The derive accepts **`requires_if("value", "--other")`** and **`requires_ifs((...), ...)`**, validates target selectors at compile time, and emits rules into cold **`FlagMeta`** / KDL via new **`RequiresIf`** entries. Enforcement runs in generated post-binding checks (only when the declaring flag was **explicitly** given—not from defaults—and the partial value matches), with bool/count shapes using canonical `"true"` / `"false"` matching. Conformance mirrors spec `requires_if` into argv tables; new tests cover per-value activation, spec round-trip, defaults not triggering conditions, and count flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48e0af17ca7477ee256a493ce083095b8470b625. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->