### PR TITLE
feat(derive): add skip for fields that are not arguments

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -408,11 +408,12 @@ Groups are the opposite case: `Command::get_groups`, `ArgGroup::get_args` and
       trailing.
 - [ ] **`require_equals`** — accept `--flag=value` and refuse `--flag value`.
       **Used by:** aube `run --inspect` / `--inspect-brk`.
-- [ ] **`#[arg(skip)]`** — a field that is not an argument at all, filled from
-      `Default`. Every field is currently a flag or a positional. **Used by:**
-      mise `run`/`install`/`doctor`/`bootstrap`, hk `hook_options`, aube
-      `update`. A rewrite that keeps the clap structs needs this; a rewrite that
-      splits "parsed" from "computed" can just omit the field.
+- [x] **`#[arg(skip)]`** — a field that is not an argument at all, filled from
+      `Default`. `#[usage(skip)]` is that: the field stays on the struct so a
+      rewrite can keep computed state beside parsed state, and nothing about it
+      reaches the spec, the parse tables, or help. Combining it with `long` or
+      `arg` is a compile error. **Used by:** mise `run`/`install`/`doctor`/
+      `bootstrap`, hk `hook_options`, aube `update`.
 
 **Changes what a CLI accepts, less sharply**
 
@@ -460,7 +461,7 @@ completions for four shells, `flatten`, `global`, `count`, `env`, `negate`
 (clap's `SetFalse`), `value_enum`, `num_args` via `var_min`/`var_max`, clap's
 `last` via `double_dash`, `help_heading`, `subcommand_required`, declaration
 order, non-UTF-8 `OsString`/`PathBuf` values, `requires`, `group`/`exclusive`,
-and `delimiter`.
+and `delimiter`, and `#[usage(skip)]`.
 
 And the other direction: `mount`, `restart_token`, `default_subcommand` and
 `effect` are things a spec says that clap cannot hear, and `gen-shadow` counts
@@ -609,7 +610,6 @@ looking at the clap surface, not only at the spec.
 | ---------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
 | `default_missing_value` / optional-value flags | mise `watch` / `generate bootstrap`, hk `-W`, aube `--color`/`--inspect` / audit `--omit` | `--color` and `--color=always` stop being two spellings of one flag |
 | `require_equals`                               | aube `--inspect`                                                                          | `--inspect 9229` is accepted when it should be refused              |
-| `#[arg(skip)]`                                 | mise, hk, aube                                                                            | a struct-for-struct rewrite will not compile                        |
 | `external_subcommand`                          | aube, pitchfork                                                                           | unknown words at the root stop being forwarded                      |
 | `default_value_if`                             | mise `bin_paths`                                                                          | `--json` no longer implies the matching default                     |
 | `value_parser` ranges                          | unknown until the typed rewrite                                                           | `FromStr` accepts out-of-range numbers clap would refuse            |
@@ -617,7 +617,8 @@ looking at the clap surface, not only at the spec.
 `value_delimiter` and `requires` are not in that table because the _parser_ can
 say them. They are lost only on the clap → spec round trip (and a non-ASCII
 delimiter is dropped even then), and a rewrite that declares in usage keeps
-them. `allow_hyphen_values` on trailing argv is already `double_dash=automatic`
+them. `#[usage(skip)]` is a compile-time field, not a command-line shape.
+`allow_hyphen_values` on trailing argv is already `double_dash=automatic`
 in every fleet spec that has one.
 
 - [ ] **Grammar decisions that would change mise at run time**, not just at

--- a/conformance/tests/derive.rs
+++ b/conformance/tests/derive.rs
@@ -879,3 +879,28 @@ fn a_bound_hands_the_rest_to_the_next_argument() {
         Bounded::to_kdl()
     );
 }
+
+/// clap's `#[arg(skip)]`: a field that is not an argument, filled from Default.
+#[derive(Cli, Debug)]
+#[usage(bin = "skip")]
+struct WithSkip {
+    #[usage(long)]
+    force: bool,
+    #[usage(skip)]
+    computed: usize,
+}
+
+#[test]
+fn a_skipped_field_is_defaulted_and_absent_from_the_spec() {
+    let a = argv(["--force"]);
+    let got = WithSkip::parse_from(&a).expect("should parse");
+    assert!(got.force);
+    assert_eq!(got.computed, 0, "filled from Default, not from argv");
+
+    let kdl = WithSkip::to_kdl();
+    assert!(kdl.contains(r#"flag "--force""#), "{kdl}");
+    assert!(
+        !kdl.contains("computed"),
+        "a skipped field must not reach the spec: {kdl}"
+    );
+}

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -1204,7 +1204,7 @@ fn tables(cli: &Cli) -> Tables {
                 flag_meta_groups.push(quote!(<#ty as usage_argv::spec::CommandArgs>::META.flags));
                 arg_meta_groups.push(quote!(<#ty as usage_argv::spec::CommandArgs>::META.args));
             }
-            Kind::Subcommand { .. } => {}
+            Kind::Subcommand { .. } | Kind::Skip => {}
         }
     }
     flush_flags(&mut own_flags, &mut flag_groups, &mut flag_meta_groups);
@@ -1489,7 +1489,10 @@ fn option_str(value: Option<&str>) -> TokenStream {
 /// `CommandArgs` boundary.
 fn presence_methods(cli: &Cli) -> TokenStream {
     let direct_given = cli.fields.iter().filter_map(|field| {
-        if matches!(field.kind, Kind::Flatten { .. } | Kind::Subcommand { .. }) {
+        if matches!(
+            field.kind,
+            Kind::Flatten { .. } | Kind::Subcommand { .. } | Kind::Skip
+        ) {
             return None;
         }
         let given = format_ident!("__given_{}", field.ident);
@@ -1594,8 +1597,9 @@ fn partial_struct(cli: &Cli) -> TokenStream {
         .map(|p| p.partial_fields)
         .unwrap_or_default();
     let fields = cli.fields.iter().filter_map(|f| {
-        if matches!(f.kind, Kind::Subcommand { .. }) {
-            // Its values live in the enum's own partial.
+        if matches!(f.kind, Kind::Subcommand { .. } | Kind::Skip) {
+            // Its values live in the enum's own partial. A skipped field is not parsed
+            // at all, so it has nothing to accumulate.
             return None;
         }
         // A flattened struct accumulates into its own partial, whose shape only its derive
@@ -1948,7 +1952,7 @@ fn partial_defaults(cli: &Cli) -> TokenStream {
         .map(|p| p.partial_starts)
         .unwrap_or_default();
     let plain = cli.fields.iter().filter_map(|f| {
-        if matches!(f.kind, Kind::Subcommand { .. }) {
+        if matches!(f.kind, Kind::Subcommand { .. } | Kind::Skip) {
             return None;
         }
         // `start()` rather than `Default`, so the flattened struct's own defaults are in
@@ -2006,6 +2010,10 @@ fn partial_defaults(cli: &Cli) -> TokenStream {
 fn field_final(field: &Field) -> TokenStream {
     let ident = &field.ident;
     let name = &field.name;
+    if matches!(field.kind, Kind::Skip) {
+        // clap's skip: not parsed, filled from Default when the struct is built.
+        return quote!(#ident: ::std::default::Default::default());
+    }
     if let Kind::Flatten { ty } = &field.kind {
         // Built by its own derive, which is also what makes a nested flatten work: this is
         // the same call at every level.
@@ -3294,7 +3302,7 @@ fn group_meta_table(cli: &Cli) -> (TokenStream, TokenStream) {
 /// without also asking it to report a missing sibling.
 fn declared_defaults(cli: &Cli) -> TokenStream {
     let own = cli.fields.iter().filter_map(|f| {
-        if f.default.is_empty() || matches!(f.kind, Kind::Subcommand { .. }) {
+        if f.default.is_empty() || matches!(f.kind, Kind::Subcommand { .. } | Kind::Skip) {
             return None;
         }
         let given = format_ident!("__given_{}", f.ident);
@@ -3766,7 +3774,10 @@ fn post_binding(cli: &Cli) -> TokenStream {
                 .iter()
                 .filter(move |other| other.ident != f.ident)
                 .filter(|other| {
-                    !matches!(other.kind, Kind::Subcommand { .. } | Kind::Flatten { .. })
+                    !matches!(
+                        other.kind,
+                        Kind::Subcommand { .. } | Kind::Flatten { .. } | Kind::Skip
+                    )
                 })
                 .map(move |other| {
                     let other_given = format_ident!("__given_{}", other.ident);
@@ -3793,7 +3804,12 @@ fn post_binding(cli: &Cli) -> TokenStream {
     let direct_given = cli
         .fields
         .iter()
-        .filter(|field| !matches!(field.kind, Kind::Flatten { .. } | Kind::Subcommand { .. }))
+        .filter(|field| {
+            !matches!(
+                field.kind,
+                Kind::Flatten { .. } | Kind::Subcommand { .. } | Kind::Skip
+            )
+        })
         .rev()
         .fold(quote!(::std::option::Option::None), |rest, field| {
             let given = format_ident!("__given_{}", field.ident);

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -1089,6 +1089,7 @@ impl Field {
             overrides: Vec::new(),
             conflicts: Vec::new(),
             requires: Vec::new(),
+            requires_if: Vec::new(),
             delimiter: None,
             exclusive: false,
             group: None,

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -353,6 +353,13 @@ pub enum Kind {
         /// The struct's type, as written.
         ty: syn::Type,
     },
+    /// A field that is not an argument at all, filled from `Default`.
+    ///
+    /// clap's `#[arg(skip)]`: the struct still holds the field so a rewrite can keep
+    /// computed state beside parsed state, and nothing about it reaches the spec, the
+    /// parse tables, or help. The type has to implement `Default`, which is also how
+    /// clap fills one.
+    Skip,
     Subcommand {
         /// The enum's type, as written.
         ty: syn::Type,
@@ -793,6 +800,7 @@ impl Cli {
                 // where the whole tree is visible, by the duplicate-form check in
                 // `Spec::to_kdl`.
                 Kind::Flatten { .. } => {}
+                Kind::Skip => {}
                 Kind::Arg { double_dash } => {
                     // A variadic takes every remaining word, so anything after it can
                     // never be filled — with two exceptions, both of which are something
@@ -1008,6 +1016,90 @@ fn dup(span: Span, first: Span, message: &str) -> syn::Error {
 }
 
 impl Field {
+    /// A field marked `#[usage(skip)]`, if this is one.
+    ///
+    /// clap's `#[arg(skip)]`: the field is not an argument, and is filled from `Default`
+    /// when the struct is built. Recognised before flags and arguments so a combination
+    /// like `#[usage(skip, long)]` is refused as a contradiction rather than parsed as a
+    /// flag that also happens to say skip — there is no such thing, and accepting it would
+    /// put a field in the tables that the build then ignored.
+    fn skip(
+        field: &syn::Field,
+        ident: &syn::Ident,
+        span: proc_macro2::Span,
+    ) -> syn::Result<Option<Self>> {
+        let mut found = false;
+        for attr in attrs(&field.attrs) {
+            for meta in nested(attr)? {
+                if ident_of(&meta.path().clone()) != "skip" {
+                    continue;
+                }
+                if !matches!(meta, Meta::Path(_)) {
+                    return Err(syn::Error::new_spanned(
+                        meta.path(),
+                        "`skip` takes no value: the field is filled from `Default`",
+                    ));
+                }
+                found = true;
+            }
+        }
+        if !found {
+            return Ok(None);
+        }
+
+        for attr in attrs(&field.attrs) {
+            for meta in nested(attr)? {
+                let name = ident_of(&meta.path().clone());
+                if name != "skip" {
+                    return Err(syn::Error::new_spanned(
+                        meta.path(),
+                        format!(
+                            "`skip` cannot be combined with `{name}`: a skipped field is \
+                             not a flag or an argument, so nothing that describes one applies"
+                        ),
+                    ));
+                }
+            }
+        }
+
+        Ok(Some(Field {
+            ident: ident.clone(),
+            ty: field.ty.clone(),
+            name: to_kebab(&ident.to_string()),
+            value_optional: false,
+            kind: Kind::Skip,
+            effect: None,
+            complete: None,
+            complete_type: None,
+            shape: Shape::Bool,
+            value_ty: None,
+            optional_collection: false,
+            help: None,
+            long_help: None,
+            env: None,
+            setting: None,
+            default: Vec::new(),
+            help_heading: None,
+            value_name: None,
+            required_collection: false,
+            choices: Vec::new(),
+            value_enum: false,
+            var_min: None,
+            var_max: None,
+            overrides: Vec::new(),
+            conflicts: Vec::new(),
+            requires: Vec::new(),
+            delimiter: None,
+            exclusive: false,
+            group: None,
+            required_if: Vec::new(),
+            required_unless: Vec::new(),
+            hide: false,
+            repeatable: false,
+            span,
+        }))
+    }
+
     /// A field marked `#[usage(flatten)]`, if this is one.
     ///
     /// Recognized before flags and arguments for the same reason a subcommand is: the field
@@ -1216,6 +1308,12 @@ impl Field {
             .clone()
             .expect("named fields were checked by the caller");
         let span = field.span();
+        // A skipped field is not a flag, an argument, or a subcommand: recognised
+        // first so `#[usage(skip, long)]` is refused as a combination rather than
+        // parsed as a flag that also happens to say skip.
+        if let Some(skipped) = Self::skip(field, &ident, span)? {
+            return Ok(skipped);
+        }
         // A subcommand field is neither a flag nor an argument, and shares none of
         // their options, so it is recognized before any of them are read.
         if let Some(subcommand) = Self::subcommand(field, &ident, span)? {
@@ -1420,7 +1518,7 @@ impl Field {
                                  `required_if`, \
                                  `required_unless`, `help_heading`, `value_name`, \
                                  `verbatim_doc_comment`, \
-                                 `required`, and `double_dash`"
+                                 `required`, `double_dash`, and `skip`"
                             ),
                         ));
                     }
@@ -3644,6 +3742,49 @@ mod tests {
         "#,
         );
         assert!(err.contains("takes no value"), "unhelpful message: {err}");
+    }
+
+    #[test]
+    fn skip_is_a_field_that_is_not_a_flag_or_an_argument() {
+        let cli = cli(r#"
+            struct Ex {
+                #[usage(long)]
+                force: bool,
+                #[usage(skip)]
+                computed: usize,
+            }
+        "#)
+        .expect("should compile");
+        assert!(
+            cli.fields
+                .iter()
+                .any(|f| matches!(f.kind, super::Kind::Skip) && f.ident == "computed"),
+            "skip should be a kind of its own, not a flag whose tables then ignore it"
+        );
+        assert_eq!(
+            cli.fields
+                .iter()
+                .filter(|f| matches!(f.kind, super::Kind::Flag { .. }))
+                .count(),
+            1,
+            "a skipped field must not appear as a flag"
+        );
+    }
+
+    #[test]
+    fn skip_cannot_be_combined_with_a_flag_option() {
+        let err = rejection(
+            r#"
+            struct Ex {
+                #[usage(skip, long)]
+                computed: usize,
+            }
+        "#,
+        );
+        assert!(
+            err.contains("cannot be combined with `long`"),
+            "unhelpful message: {err}"
+        );
     }
 
     #[test]

--- a/docs/rust/args-and-flags.md
+++ b/docs/rust/args-and-flags.md
@@ -91,6 +91,12 @@ jobs: Option<u32>,
 | `effect = "…"`                          | `"read"`, `"write"`, or `"destructive"` — see [command effects](/spec/#command-effects) |
 | `setting = "key"`                       | Bind to a config setting (generates `parse_from_with_settings`)                         |
 | `verbatim_doc_comment`                  | Keep the doc comment's line breaks in help                                              |
+| `skip`                                  | Not an argument; filled from `Default` when the struct is built                         |
+
+`#[usage(skip)]` is clap's `#[arg(skip)]`: the field stays on the struct so a rewrite can keep
+computed state beside parsed state, and nothing about it reaches the spec, the parse tables, or
+help. Combining it with `long`, `arg`, or any other field option is a compile error. The type
+has to implement `Default`.
 
 Flag relations (`conflicts`, `requires`, `overrides`, `required_if`, `required_unless`) name
 their target the way the KDL spec does — `"--long"` or `"-s"`, one value or a list:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacked on #1008.

Adds `#[usage(skip)]` (clap's `#[arg(skip)]`): the field stays on the struct, is `Default::default()` after parse, and never appears in argv or the spec.

This is compile-time only — it does not change argv behaviour for existing specs.

_This comment was generated by Claude Code._
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4de7e59e-aa2e-4ad0-a1d0-1c2e69c166db?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4de7e59e-aa2e-4ad0-a1d0-1c2e69c166db&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

