### PR TITLE
docs(bench): clarify in-process timing

### DIFF
--- a/docs/.vitepress/theme/UsageBenches.vue
+++ b/docs/.vitepress/theme/UsageBenches.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import { onBeforeUnmount, onMounted } from "vue";
 
-// Rust wall clock from `time-sweep.rs`, which warms each parser and keeps the
-// fastest of many short rounds — steady-state and in-process, because a
-// whole-process measurement cannot resolve a 200ns parse. Values in nanoseconds,
+// Rust wall clock from `time-sweep.rs`, which runs each parser repeatedly in one
+// process and keeps the fastest of many short rounds — throughput rather than
+// whole-process latency, because process startup cannot resolve a 200ns parse.
+// Values in nanoseconds,
 // quoted to two significant figures: across twenty-two runs on two machines the
 // minima moved a few percent and their ratios by 10% — clap read 2,226x, 2,502x
 // and 2,419x on three occasions — so the ratios carry a `~`.
@@ -121,16 +122,16 @@ onBeforeUnmount(() => window.removeEventListener("resize", replace));
             @mouseenter="clamp"
             @focusin="clamp"
             aria-describedby="bench-tip-warmed"
-            >one warmed parse
+            >in-process parse throughput
             <span class="usage-bench-tip" id="bench-tip-warmed" role="tooltip">
               <strong>How this is measured</strong>
               <span>
-                In-process and warmed — the fastest of many short rounds, since a fresh
-                process cannot resolve a 200ns parse. Minima and their ratios drift a few
-                percent between runs and machines, hence the <code>~</code>. Instructions
-                for one cold parse, which do not drift: 4,155 · 6,295 · 5.89M · 21.9M,
-                agreeing across two machines to 0.15%. For scale, starting a process costs
-                ~1ms, so the first two bars are under anything a user feels.
+                Each parser runs repeatedly inside one process; process startup is excluded,
+                so these bars are not full CLI invocation times. The chart reports the fastest
+                per-parse time from many short rounds. Minima and their ratios drift a few
+                percent between runs and machines, hence the <code>~</code>. Instructions for
+                one cold parse, which do not drift: 4,155 · 6,295 · 5.89M · 21.9M,
+                agreeing across two machines to 0.15%.
               </span>
             </span>
           </span>


### PR DESCRIPTION
## Summary

- relabel the Rust chart as in-process parse throughput
- state explicitly that process startup is excluded
- explain that the bars are not full CLI invocation times

## Why

The 190 ns figure is a valid repeated in-process parser measurement, but the previous "one warmed parse" label could be read as full CLI latency. This keeps the comparison visible while making its scope clear.

## Validation

- `npx prettier --check docs/.vitepress/theme/UsageBenches.vue`
- `npm run docs:build`

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording in UsageBenches.vue; no runtime or benchmark logic changes.
> 
> **Overview**
> **Benchmarks copy** for the Rust parser chart is updated so readers do not treat ~190 ns as end-to-end CLI latency.
> 
> The visible metric label changes from **“one warmed parse”** to **“in-process parse throughput”**, and the inline comment above `rustRows` now describes repeated in-process rounds and throughput vs whole-process latency. The tooltip states that parsers run repeatedly in one process with startup excluded, that the bars are **not** full invocation times, and drops the prior “~1ms process startup” aside while keeping instruction-count methodology unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0199fe55d8719c0607022dd1a457f018e24ccea9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark methodology descriptions for Rust measurements.
  * Clarified that Rust timing represents repeated in-process throughput runs.
  * Improved tooltip explanations for fastest per-parse timing and ratio variability.
  * Removed the process-startup scale note.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->