### PR TITLE
feat(argv): take flag-like detached values when declared

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -396,16 +396,18 @@ Groups are the opposite case: `Command::get_groups`, `ArgGroup::get_args` and
 - [ ] **`value_parser`** — clap takes an arbitrary parser function and range
       validators (`value_parser!(u16).range(1..=65535)`). We are `T: FromStr` and
       nothing else, so there is no per-field validation and no bounded numeric.
-- [ ] **`allow_hyphen_values` on the derive path** — the spec says it and
-      usage-lib honours it (`lib/src/parse.rs`), but there is no derive attribute
-      and no mention in `argv/src/`. A spec-versus-derive asymmetry rather than a
-      plain absence, which makes it cheaper than the rest of this group.
+- [x] **`allow_hyphen_values` on the derive path** — the spec said it and
+      usage-lib honoured it (`lib/src/parse.rs`); usage-argv now has the same
+      bit on `Flag`, so a detached value that looks like a flag binds when
+      declared, including `--`. `#[usage(allow_hyphen_values)]` is the attribute,
+      and the emitted KDL is `allow_hyphen_values=#true`. A positional that needs
+      the same thing is already `double_dash = "automatic"`.
       **For the fleet this is mostly already spelled:** clap_usage encodes
       `allow_hyphen_values` on a trailing argument as `double_dash=automatic`,
       which the derive has. That is mise `run`/`exec`/`watch`/`asdf`, aube
       `run`/`exec`/`dlx`/`node`, fnox `exec`/`proxy`, pitchfork `daemons add`.
-      What is still missing is a hyphen-taking _flag value_ that is not also
-      trailing.
+      A hyphen-taking _flag value_ that is not also trailing is now the same
+      declaration on the flag.
 - [ ] **`require_equals`** — accept `--flag=value` and refuse `--flag value`.
       **Used by:** aube `run --inspect` / `--inspect-brk`.
 - [x] **`#[arg(skip)]`** — a field that is not an argument at all, filled from
@@ -461,7 +463,7 @@ completions for four shells, `flatten`, `global`, `count`, `env`, `negate`
 (clap's `SetFalse`), `value_enum`, `num_args` via `var_min`/`var_max`, clap's
 `last` via `double_dash`, `help_heading`, `subcommand_required`, declaration
 order, non-UTF-8 `OsString`/`PathBuf` values, `requires`, `group`/`exclusive`,
-and `delimiter`, and `#[usage(skip)]`.
+and `delimiter`, `#[usage(skip)]`, and `allow_hyphen_values`.
 
 And the other direction: `mount`, `restart_token`, `default_subcommand` and
 `effect` are things a spec says that clap cannot hear, and `gen-shadow` counts
@@ -614,12 +616,12 @@ looking at the clap surface, not only at the spec.
 | `default_value_if`                             | mise `bin_paths`                                                                          | `--json` no longer implies the matching default                     |
 | `value_parser` ranges                          | unknown until the typed rewrite                                                           | `FromStr` accepts out-of-range numbers clap would refuse            |
 
-`value_delimiter` and `requires` are not in that table because the _parser_ can
-say them. They are lost only on the clap → spec round trip (and a non-ASCII
-delimiter is dropped even then), and a rewrite that declares in usage keeps
-them. `#[usage(skip)]` is a compile-time field, not a command-line shape.
-`allow_hyphen_values` on trailing argv is already `double_dash=automatic`
-in every fleet spec that has one.
+`value_delimiter`, `requires`, and `allow_hyphen_values` are not in that table
+because the _parser_ can say them. They are lost only on the clap → spec round
+trip (and a non-ASCII delimiter is dropped even then), and a rewrite that
+declares in usage keeps them. `#[usage(skip)]` is a compile-time field, not a
+command-line shape. Trailing argv is already `double_dash=automatic` in every
+fleet spec that has one.
 
 - [ ] **Grammar decisions that would change mise at run time**, not just at
       completion time. Unrecognized flags falling through to positionals is how

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -263,6 +263,15 @@ pub struct Flag<'a> {
     /// two is already past its bound on the single word it was entitled to take. Binding
     /// cannot count without it.
     pub delimiter: ::core::option::Option<u8>,
+    /// Whether a detached value may itself look like a flag.
+    ///
+    /// The default is to refuse: `--jobs --force` is far more likely a forgotten
+    /// value than a jobs of `"--force"`. Declared, the next token is taken
+    /// whatever it looks like — including `--` — which is clap's
+    /// `allow_hyphen_values` and the spec's property of the same name. A variadic
+    /// occurrence still stops collecting at a later flag-like token, so a second
+    /// occurrence of the flag is not eaten as a value.
+    pub allow_hyphen_values: bool,
     /// Whether the flag is recognized by every command beneath the one that
     /// declares it.
     pub global: bool,
@@ -280,6 +289,7 @@ impl Flag<'_> {
         variadic: false,
         var_max: ::core::option::Option::None,
         delimiter: ::core::option::Option::None,
+        allow_hyphen_values: false,
         global: false,
     };
 
@@ -1347,12 +1357,13 @@ impl<'t, 'v> Parser<'t, 'v> {
 
     /// Take the following token as a flag's value.
     ///
-    /// Refuses a flag-like token: `--jobs --force` is far more likely a forgotten
-    /// value than a deliberate one, and the attached form is available for the
-    /// deliberate case.
+    /// Refuses a flag-like token unless [`Flag::allow_hyphen_values`] is set:
+    /// `--jobs --force` is far more likely a forgotten value than a deliberate
+    /// one, and the attached form is available for the deliberate case. Declared,
+    /// the next token is taken whatever it looks like, including `--`.
     fn take_detached_value(&mut self, flag: &'t Flag<'t>) -> Result<&'v [u8], Error<'t, 'v>> {
         match self.argv.get(self.pos) {
-            Some(next) if !is_flag_like(bytes(next)) => {
+            Some(next) if flag.allow_hyphen_values || !is_flag_like(bytes(next)) => {
                 self.pos += 1;
                 Ok(bytes(next))
             }
@@ -2347,6 +2358,58 @@ mod tests {
             })
             .collect();
         assert_eq!(values, vec![&b"a"[..], &b"--"[..], &b"b"[..]]);
+    }
+
+    #[test]
+    fn allow_hyphen_values_takes_a_flaglike_detached_value() {
+        static ARGS: Flag = Flag {
+            key: 6,
+            name: "args",
+            longs: &["args"],
+            shorts: b"a",
+            takes_value: true,
+            allow_hyphen_values: true,
+            ..Flag::BOOL
+        };
+        static DIR: Flag = Flag {
+            key: 7,
+            name: "working-dir",
+            longs: &["working-dir"],
+            shorts: b"d",
+            ..Flag::VALUE
+        };
+        static HYPHEN: Command = Command {
+            name: "ex",
+            flags: &[&ARGS, &DIR],
+            args: &[&REST],
+            ..Command::EMPTY
+        };
+
+        let a = argv(["-a", "-destroy"]);
+        assert_eq!(
+            parse(&HYPHEN, &a).unwrap(),
+            vec![Event::Flag {
+                flag: &ARGS,
+                value: Some(b"-destroy"),
+                negated: false
+            }]
+        );
+
+        let a = argv(["--args", "--", "-x"]);
+        assert_eq!(
+            parse(&HYPHEN, &a).unwrap(),
+            vec![
+                Event::Flag {
+                    flag: &ARGS,
+                    value: Some(b"--"),
+                    negated: false
+                },
+                Event::Arg {
+                    arg: &REST,
+                    value: b"-x"
+                },
+            ]
+        );
     }
 
     #[test]

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -1180,6 +1180,9 @@ fn write_flag(out: &mut String, meta: &FlagMeta<'_>, depth: usize) -> core::fmt:
     if let Some(delimiter) = meta.delimiter {
         write!(out, " delimiter={}", quoted(&delimiter.to_string()))?;
     }
+    if meta.flag.allow_hyphen_values {
+        out.push_str(" allow_hyphen_values=#true");
+    }
     write_single_list(out, "requires", meta.requires)?;
     write_single_list(out, "required_if", meta.required_if)?;
     write_single_list(out, "required_unless", meta.required_unless)?;

--- a/conformance/src/tables.rs
+++ b/conformance/src/tables.rs
@@ -268,6 +268,7 @@ fn build_flag(f: &SpecFlag) -> &'static Flag<'static> {
             .and_then(|a| a.delimiter)
             .filter(char::is_ascii)
             .map(|d| d as u8),
+        allow_hyphen_values: f.allow_hyphen_values(),
         global: f.global,
     }))
 }

--- a/conformance/tests/derive.rs
+++ b/conformance/tests/derive.rs
@@ -904,3 +904,37 @@ fn a_skipped_field_is_defaulted_and_absent_from_the_spec() {
         "a skipped field must not reach the spec: {kdl}"
     );
 }
+
+/// clap's `allow_hyphen_values`: a flag's detached value may look like a flag.
+#[derive(Cli, Debug)]
+#[usage(bin = "hyphen")]
+struct WithHyphen {
+    #[usage(short = 'd', long)]
+    working_dir: Option<String>,
+    #[usage(short = 'a', long, allow_hyphen_values)]
+    args: Option<String>,
+}
+
+#[test]
+fn a_hyphen_taking_flag_binds_a_flaglike_value() {
+    let a = argv(["-a", "-destroy"]);
+    let got = WithHyphen::parse_from(&a).expect("should parse");
+    assert_eq!(got.args.as_deref(), Some("-destroy"));
+    assert_eq!(got.working_dir.as_deref(), None);
+
+    let kdl = WithHyphen::to_kdl();
+    assert!(
+        kdl.contains("allow_hyphen_values=#true"),
+        "the attribute has to reach the spec: {kdl}"
+    );
+    let spec: LibSpec = kdl.parse().expect("valid spec");
+    assert!(
+        spec.cmd
+            .flags
+            .iter()
+            .find(|f| f.name == "args")
+            .expect("args")
+            .allow_hyphen_values(),
+        "usage-lib has to read the emitted property the same way it reads a handwritten one"
+    );
+}

--- a/corpus/01-long-flags.json
+++ b/corpus/01-long-flags.json
@@ -221,6 +221,34 @@
       "spec": "name \"ex\"\nbin \"ex\"\nunknown_flags \"error\"\narg \"[offset]\"\n",
       "argv": ["-1"],
       "expect": { "ok": { "args": { "offset": "-1" } } }
+    },
+    {
+      "id": "long-value-allow-hyphen-takes-flaglike",
+      "doc": "A flag declared `allow_hyphen_values` takes a detached value that looks like a flag, which is the only way `--args -destroy` can bind `-destroy` rather than reading `-d` as a short.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-d --working-dir <DIR>\"\nflag \"-a --args <ARGS>\" allow_hyphen_values=#true\n",
+      "argv": ["--args", "-destroy"],
+      "expect": { "ok": { "flags": { "args": "-destroy" } } }
+    },
+    {
+      "id": "long-value-allow-hyphen-takes-the-separator",
+      "doc": "A `--` is flag-like too, so an `allow_hyphen_values` flag takes it as the value rather than ending flag interpretation. `ex -a -- -x` then binds `--` and leaves `-x` for the argument, matching clap.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--args <ARGS>\" allow_hyphen_values=#true\narg \"[rest]...\"\n",
+      "argv": ["--args", "--", "-x"],
+      "expect": { "ok": { "flags": { "args": "--" }, "args": { "rest": ["-x"] } } }
+    },
+    {
+      "id": "long-variadic-allow-hyphen-first-value",
+      "doc": "A variadic flag's first value may be hyphenated when `allow_hyphen_values` is set. Later values still stop at a flag-like token, so a second occurrence of the flag is not eaten.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--args <ARGS>...\" allow_hyphen_values=#true\n",
+      "argv": ["--args", "-x", "b", "c"],
+      "expect": { "ok": { "flags": { "args": ["-x", "b", "c"] } } }
+    },
+    {
+      "id": "long-repeatable-allow-hyphen-each-occurrence",
+      "doc": "A repeatable flag takes one hyphenated value per occurrence, so `-a -val1 -a -val2` is two values rather than one occurrence eating the second `-a`.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-a --args <ARGS>\" var=#true allow_hyphen_values=#true\n",
+      "argv": ["-a", "-val1", "-a", "-val2"],
+      "expect": { "ok": { "flags": { "args": ["-val1", "-val2"] } } }
     }
   ]
 }

--- a/corpus/01-long-flags.json
+++ b/corpus/01-long-flags.json
@@ -234,7 +234,9 @@
       "doc": "A `--` is flag-like too, so an `allow_hyphen_values` flag takes it as the value rather than ending flag interpretation. `ex -a -- -x` then binds `--` and leaves `-x` for the argument, matching clap.",
       "spec": "name \"ex\"\nbin \"ex\"\nflag \"--args <ARGS>\" allow_hyphen_values=#true\narg \"[rest]...\"\n",
       "argv": ["--args", "--", "-x"],
-      "expect": { "ok": { "flags": { "args": "--" }, "args": { "rest": ["-x"] } } }
+      "expect": {
+        "ok": { "flags": { "args": "--" }, "args": { "rest": ["-x"] } }
+      }
     },
     {
       "id": "long-variadic-allow-hyphen-first-value",

--- a/corpus/02-short-flags.json
+++ b/corpus/02-short-flags.json
@@ -183,6 +183,13 @@
       "spec": "name \"ex\"\nbin \"ex\"\nunknown_flags \"error\"\narg \"[offset]\"\n",
       "argv": ["-1e"],
       "expect": { "error": "unknown_flag" }
+    },
+    {
+      "id": "short-value-allow-hyphen-takes-flaglike",
+      "doc": "The short form of `allow_hyphen_values`: `-a -destroy` binds `-destroy` rather than reading `-d` as a different short and attaching `estroy`.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-d --working-dir <DIR>\"\nflag \"-a --args <ARGS>\" allow_hyphen_values=#true\n",
+      "argv": ["-a", "-destroy"],
+      "expect": { "ok": { "flags": { "args": "-destroy" } } }
     }
   ]
 }

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -764,6 +764,7 @@ fn flag_table(i: usize, field: &Field) -> TokenStream {
     };
 
     let table_delimiter = table_delimiter(field);
+    let allow_hyphen_values = field.allow_hyphen_values;
     quote! {
         pub static #name: usage_argv::Flag = usage_argv::Flag {
             key: #key,
@@ -775,6 +776,7 @@ fn flag_table(i: usize, field: &Field) -> TokenStream {
             variadic: #variadic,
             var_max: #var_max,
             delimiter: #table_delimiter,
+            allow_hyphen_values: #allow_hyphen_values,
             global: #global,
         };
     }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -218,6 +218,7 @@
 //! | `group = "input"` | the group this flag is one of; see below |
 //! | `exclusive` | this flag has to be given on its own, positionals included |
 //! | `delimiter = ','` | one word becomes several values; the field has to be a `Vec` |
+//! | `allow_hyphen_values` | a flag's detached value may look like a flag, including `--` |
 //! | `required_if = "--other"` | a flag whose presence makes this one necessary |
 //! | `required_unless = "--other"` | a flag whose presence makes this one unnecessary |
 //!

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -213,6 +213,11 @@ pub struct Field {
     /// compile time, since a delimiter on a single-value field would drop everything
     /// after the first separator.
     pub delimiter: Option<char>,
+    /// Whether a detached value may itself look like a flag.
+    ///
+    /// clap's `allow_hyphen_values`, and the spec's property of the same name. Only
+    /// a flag that takes a value can declare it: there is nothing to take otherwise.
+    pub allow_hyphen_values: bool,
     /// Whether this flag must be given on its own — clap's `exclusive`.
     pub exclusive: bool,
     /// The group this flag belongs to, if any. Properties live on the group's own
@@ -1091,6 +1096,7 @@ impl Field {
             requires: Vec::new(),
             requires_if: Vec::new(),
             delimiter: None,
+            allow_hyphen_values: false,
             exclusive: false,
             group: None,
             required_if: Vec::new(),
@@ -1195,6 +1201,7 @@ impl Field {
             requires: Vec::new(),
             requires_if: Vec::new(),
             delimiter: None,
+            allow_hyphen_values: false,
             exclusive: false,
             group: None,
             required_if: Vec::new(),
@@ -1293,6 +1300,7 @@ impl Field {
             requires: Vec::new(),
             requires_if: Vec::new(),
             delimiter: None,
+            allow_hyphen_values: false,
             exclusive: false,
             group: None,
             required_if: Vec::new(),
@@ -1362,6 +1370,7 @@ impl Field {
         let mut group: Option<String> = None;
         let mut exclusive = false;
         let mut delimiter: Option<char> = None;
+        let mut allow_hyphen_values = false;
         let mut required_if: Vec<String> = Vec::new();
         let mut required_unless: Vec<String> = Vec::new();
 
@@ -1458,6 +1467,7 @@ impl Field {
                     "requires_ifs" => requires_if.extend(requirements_if(&meta)?),
                     "group" => group = Some(string_value(&meta)?),
                     "exclusive" => exclusive = flag_value(&meta)?,
+                    "allow_hyphen_values" => allow_hyphen_values = flag_value(&meta)?,
                     "delimiter" => {
                         let c = char_value(&meta)?;
                         if !c.is_ascii() {
@@ -1515,7 +1525,7 @@ impl Field {
                                  `count`, `hide`, `arg`, `env`, `default`, `choices`, \
                                  `var_min`, `var_max`, `value_enum`, `value_hint`, `overrides`, \
                                  `conflicts`, `requires`, `group`, `exclusive`, \
-                                 `delimiter`, \
+                                 `delimiter`, `allow_hyphen_values`, \
                                  `required_if`, \
                                  `required_unless`, `help_heading`, `value_name`, \
                                  `verbatim_doc_comment`, \
@@ -2008,6 +2018,28 @@ impl Field {
             ));
         }
 
+        // clap's `allow_hyphen_values`: a flag's detached value may look like a flag.
+        // A positional that needs the same thing already has `double_dash = "automatic"`,
+        // which is how trailing argv is spelled. A flag that takes no value has nothing
+        // to take, matching the spec's refusal.
+        if allow_hyphen_values {
+            if !matches!(kind, Kind::Flag { .. }) {
+                return Err(syn::Error::new(
+                    span,
+                    "`allow_hyphen_values` is for a flag's detached value; a positional \
+                     that should take flag-like words after it declares \
+                     `double_dash = \"automatic\"` instead",
+                ));
+            }
+            if matches!(shape, Shape::Bool | Shape::Count) {
+                return Err(syn::Error::new(
+                    span,
+                    "`allow_hyphen_values` takes the next token as a value, and this flag \
+                     takes none",
+                ));
+            }
+        }
+
         // `value_name` names the placeholder a *flag's value* gets in help — `--out <FILE>`.
         // A positional argument is named by `name`, and a `bool` or `count` flag has no value
         // to put a placeholder in, so `arg_meta` never emits it and a valueless flag has nowhere
@@ -2083,6 +2115,7 @@ impl Field {
             requires,
             requires_if,
             delimiter,
+            allow_hyphen_values,
             exclusive,
             group,
             required_if,
@@ -3785,6 +3818,50 @@ mod tests {
         assert!(
             err.contains("cannot be combined with `long`"),
             "unhelpful message: {err}"
+        );
+    }
+
+    #[test]
+    fn allow_hyphen_values_is_a_flag_that_takes_a_value() {
+        let cli = cli(r#"
+            struct Ex {
+                #[usage(long, allow_hyphen_values)]
+                args: Option<String>,
+            }
+        "#)
+        .expect("should compile");
+        assert!(
+            cli.fields.iter().any(|f| f.allow_hyphen_values),
+            "the attribute has to reach the field the table is built from"
+        );
+    }
+
+    #[test]
+    fn allow_hyphen_values_cannot_sit_on_a_switch() {
+        let err = rejection(
+            r#"
+            struct Ex {
+                #[usage(long, allow_hyphen_values)]
+                force: bool,
+            }
+        "#,
+        );
+        assert!(err.contains("takes none"), "unhelpful message: {err}");
+    }
+
+    #[test]
+    fn allow_hyphen_values_cannot_sit_on_a_positional() {
+        let err = rejection(
+            r#"
+            struct Ex {
+                #[usage(arg, allow_hyphen_values)]
+                rest: Vec<String>,
+            }
+        "#,
+        );
+        assert!(
+            err.contains("double_dash"),
+            "should point at the positional spelling: {err}"
         );
     }
 

--- a/docs/rust/args-and-flags.md
+++ b/docs/rust/args-and-flags.md
@@ -74,6 +74,7 @@ jobs: Option<u32>,
 | `choices("a", "b")`                     | Restrict values to a fixed set                                                          |
 | `value_enum`                            | Take choices from a `#[derive(ValueEnum)]` type                                         |
 | `delimiter = ','`                       | Split one word into several values ([Validation](/rust/validation#delimiters))          |
+| `allow_hyphen_values`                   | Detached flag value may look like a flag, including `--`                                |
 | `group = "name"`                        | Join a flag group ([Validation](/rust/validation#groups))                               |
 | `exclusive`                             | Must be given alone ([Validation](/rust/validation#exclusive-flags))                    |
 | `conflicts(…)` / `requires(…)`          | Relations to other flags ([Validation](/rust/validation))                               |
@@ -97,6 +98,11 @@ jobs: Option<u32>,
 computed state beside parsed state, and nothing about it reaches the spec, the parse tables, or
 help. Combining it with `long`, `arg`, or any other field option is a compile error. The type
 has to implement `Default`.
+
+`#[usage(allow_hyphen_values)]` is clap's attribute of the same name: `--args -destroy` binds
+`-destroy` instead of reading `-d` as a short. The flag has to take a value; a positional that
+needs the same thing already has `double_dash = "automatic"`. Emitted KDL:
+`flag "--args <ARGS>" allow_hyphen_values=#true`.
 
 Flag relations (`conflicts`, `requires`, `overrides`, `required_if`, `required_unless`) name
 their target the way the KDL spec does — `"--long"` or `"-s"`, one value or a list:

--- a/docs/rust/spec.md
+++ b/docs/rust/spec.md
@@ -92,7 +92,6 @@ help pages through both.
 A few spec nodes have no derive attribute yet:
 
 - `example` nodes — declare examples in `after_long_help` instead
-- `allow_hyphen_values`
 - `forwards` / external subcommands
 
 If you need these today, maintain a KDL spec alongside the derive or generate docs from a

--- a/docs/spec/argv.md
+++ b/docs/spec/argv.md
@@ -12,7 +12,7 @@ and the [conformance corpus](#the-conformance-corpus) makes it executable.
 
 ::: tip Both implementations answer every vector
 
-usage-lib and usage-argv agree with all 154 vectors today. That is a
+usage-lib and usage-argv agree with all 162 vectors today. That is a
 measurement, checked on every run rather than asserted here — see
 [Where the reference implementation differs](#where-the-reference-implementation-differs).
 
@@ -83,13 +83,19 @@ A value attached to a flag that takes none is dropped: `--force=yes` sets `force
 and nothing else. Handing the leftover to the positionals would re-split one
 token into two and fill an argument the caller never typed a word for.
 
-A detached value **must not be flag-like**. `--jobs --force` is a missing value,
-not a `jobs` of `"--force"`, because the overwhelmingly likely reading is that
-the value was forgotten. To pass a value that begins with a dash, attach it:
-`--jobs=--force`. The negative-number exception means `--offset -1` still works,
-and a lone `-` is a value too, so `--file -` reaches the flag. A `--` is
-flag-like, so it stays the separator rather than becoming the value of whatever
-flag precedes it.
+A detached value **must not be flag-like**, unless the flag declares
+`allow_hyphen_values`. `--jobs --force` is a missing value, not a `jobs` of
+`"--force"`, because the overwhelmingly likely reading is that the value was
+forgotten. To pass a value that begins with a dash, attach it: `--jobs=--force`.
+The negative-number exception means `--offset -1` still works, and a lone `-` is
+a value too, so `--file -` reaches the flag. A `--` is flag-like, so it stays the
+separator rather than becoming the value of whatever flag precedes it.
+
+A flag declared `allow_hyphen_values` takes the following token whatever it looks
+like, including `--` and tokens that name other flags. The attached form is then
+no longer the only way to pass a dash-prefixed value. A variadic occurrence still
+stops collecting at a later flag-like token, so a second occurrence of the same
+flag is not eaten as a value.
 
 A flag needing a value that ends the command line is an error.
 
@@ -366,7 +372,7 @@ fails if a label is wrong in either direction. A recorded divergence that gets
 fixed shows up as a test failure telling you to delete the label, so the list
 cannot rot.
 
-**Today it does not: usage-lib agrees with all 154 vectors.** The list is empty
+**Today it does not: usage-lib agrees with all 162 vectors.** The list is empty
 for the first time, and the five entries it used to hold were what writing the
 grammar down was for. Each was a real defect that only a second reading found:
 

--- a/docs/spec/reference/flag.md
+++ b/docs/spec/reference/flag.md
@@ -37,6 +37,7 @@ flag "--config <file>" {
 }
 flag "--dump" exclusive=#true            // --dump has to be given on its own
 flag "--tags <tag>" var=#true delimiter="," // --tags a,b,c is three values
+flag "--args <ARGS>" allow_hyphen_values=#true // --args -destroy binds "-destroy"
 
 flag "--stdin" {
   conflicts "--file" "--url" // several, one per argument
@@ -146,6 +147,21 @@ the words they typed.
 A delimiter needs somewhere to put what it splits, so it goes with `var=#true` — on a
 single-value flag everything after the first separator would be dropped, and that is
 refused where it is written rather than at a prompt.
+
+## `allow_hyphen_values`
+
+A flag's detached value may look like a flag: `--args -destroy` binds `-destroy`
+instead of reading `-d` as a short. clap spells this `allow_hyphen_values`, and a spec
+generated from a clap command carries it.
+
+The attached form already binds a dash-prefixed value (`--args=-destroy`), so this is
+only about the following word. A `--` is flag-like too, so a flag declared this way
+takes the separator as its value rather than ending flag interpretation —
+`ex -a -- -x` binds `--` and leaves `-x` for whatever follows. A variadic occurrence
+still stops collecting at a later flag-like token, so a second occurrence of the same
+flag is not eaten as a value.
+
+A flag that takes no value cannot declare it: there is nothing to take.
 
 ## `global`
 

--- a/go/argv/argv.go
+++ b/go/argv/argv.go
@@ -116,6 +116,15 @@ type Flag struct {
 	// was given, which no single token can decide, so that bound stays with the
 	// metadata and is checked after the parse.
 	VarMax uint32
+	// AllowHyphenValues is whether a detached value may itself look like a flag.
+	//
+	// The default is to refuse: `--jobs --force` is far more likely a forgotten
+	// value than a jobs of `"--force"`. Declared, the next token is taken
+	// whatever it looks like — including `--` — which is clap's
+	// allow_hyphen_values and the spec's property of the same name. A variadic
+	// occurrence still stops collecting at a later flag-like token, so a second
+	// occurrence of the flag is not eaten as a value.
+	AllowHyphenValues bool
 	// Global is whether the flag is recognized by every command beneath the one
 	// that declares it.
 	Global bool

--- a/go/argv/parser.go
+++ b/go/argv/parser.go
@@ -395,11 +395,13 @@ func (p *Parser) shortFlag() bool {
 
 // takeDetachedValue takes the following token as a flag's value.
 //
-// It refuses a flag-like token: `--jobs --force` is far more likely a forgotten
-// value than a deliberate one, and the attached form is available for the
-// deliberate case. The negative-number exception means `--offset -1` still works.
+// It refuses a flag-like token unless AllowHyphenValues is set: `--jobs --force`
+// is far more likely a forgotten value than a deliberate one, and the attached
+// form is available for the deliberate case. Declared, the next token is taken
+// whatever it looks like, including `--`. The negative-number exception means
+// `--offset -1` still works.
 func (p *Parser) takeDetachedValue(flag *Flag, long string, short byte) (string, bool) {
-	if p.pos < len(p.argv) && !isFlagLike(p.argv[p.pos]) {
+	if p.pos < len(p.argv) && (flag.AllowHyphenValues || !isFlagLike(p.argv[p.pos])) {
 		v := p.argv[p.pos]
 		p.pos++
 		return v, true

--- a/go/argv/parser_test.go
+++ b/go/argv/parser_test.go
@@ -245,6 +245,22 @@ func TestNameOutranksAnotherCommandsAlias(t *testing.T) {
 	}
 }
 
+func TestAllowHyphenValues(t *testing.T) {
+	args := &Flag{Key: 6, Name: "args", Longs: []string{"args"}, Shorts: []byte{'a'},
+		TakesValue: true, AllowHyphenValues: true}
+	dir := &Flag{Key: 7, Name: "working-dir", Longs: []string{"working-dir"}, Shorts: []byte{'d'},
+		TakesValue: true}
+	rest := &Arg{Key: 11, Name: "rest", Var: true}
+	cmd := &Command{Name: "ex", Flags: []*Flag{args, dir}, Args: []*Arg{rest}}
+
+	if got := collect(cmd, "-a", "-destroy"); got != "flag:args=-destroy" {
+		t.Errorf("-a -destroy: got %s", got)
+	}
+	if got := collect(cmd, "--args", "--", "-x"); got != "flag:args=-- arg:rest=-x" {
+		t.Errorf("--args -- -x: got %s", got)
+	}
+}
+
 func BenchmarkParse(b *testing.B) {
 	args := []string{"install", "--verbose", "-f", "a", "b", "c"}
 	b.ReportAllocs()

--- a/go/internal/spec/spec.go
+++ b/go/internal/spec/spec.go
@@ -690,7 +690,11 @@ func (b *builder) flag(f *Flag) *argv.Flag {
 		Longs:      f.Long,
 		Negate:     strings.TrimLeft(f.Negate, "-"),
 		TakesValue: f.Arg != nil,
-		Global:     f.Global,
+		// Stored on the nested arg as double_dash=automatic, the same place
+		// usage-lib keeps allow_hyphen_values. Trailing positionals use Arg.DoubleDash
+		// on the command, not here.
+		AllowHyphenValues: f.Arg != nil && strings.EqualFold(f.Arg.DoubleDash, "automatic"),
+		Global:            f.Global,
 	}
 	b.recordNegation(out.Key, f.Negate)
 	for _, s := range f.Short {

--- a/go/internal/spec/spec_test.go
+++ b/go/internal/spec/spec_test.go
@@ -484,3 +484,23 @@ func TestTheTableCarriesHowAFlagIsTyped(t *testing.T) {
 		}
 	}
 }
+
+func TestAllowHyphenValuesCarriesFromNestedArg(t *testing.T) {
+	root, _ := build(&Spec{
+		Name: "ex", Bin: "ex",
+		Cmd: Cmd{Name: "ex", Flags: []Flag{
+			{Name: "args", Long: []string{"args"}, Arg: &Arg{Name: "ARGS", DoubleDash: "Automatic"}},
+			{Name: "jobs", Long: []string{"jobs"}, Arg: &Arg{Name: "N"}},
+		}},
+	})
+	byName := map[string]*argv.Flag{}
+	for _, f := range root.Flags {
+		byName[f.Name] = f
+	}
+	if !byName["args"].AllowHyphenValues {
+		t.Error("allow_hyphen_values should come from the nested arg's double_dash=automatic")
+	}
+	if byName["jobs"].AllowHyphenValues {
+		t.Error("a flag without double_dash=automatic should not take hyphen values")
+	}
+}

--- a/lib/src/go/mod.rs
+++ b/lib/src/go/mod.rs
@@ -1046,6 +1046,9 @@ fn flag_literal(flag: &SpecFlag, named: &Named) -> String {
             fields.push(format!("VarMax: {}", clamp_var_max(max)));
         }
     }
+    if flag.allow_hyphen_values() {
+        fields.push("AllowHyphenValues: true".to_string());
+    }
     if flag.global {
         fields.push("Global: true".to_string());
     }
@@ -1592,6 +1595,19 @@ flag "--tag <t>" var=#true var_max=1
         );
         let tag = out.lines().find(|l| l.contains("\"tag\"")).unwrap();
         assert!(!tag.contains("VarMax"), "occurrence bound leaked: {tag}");
+    }
+
+    #[test]
+    fn allow_hyphen_values_reaches_the_table() {
+        let out = go(r#"
+name "ex"
+bin "ex"
+flag "--args <ARGS>" allow_hyphen_values=#true
+"#);
+        assert!(
+            out.contains("Name: \"args\", Longs: []string{\"args\"}, TakesValue: true, AllowHyphenValues: true"),
+            "{out}"
+        );
     }
 
     /// A relationship names a flag by any spelling that reaches it, and from

--- a/xtask/src/shadow.rs
+++ b/xtask/src/shadow.rs
@@ -848,6 +848,9 @@ fn usage_flag_opts(
     if let Some(delimiter) = flag.arg.as_ref().and_then(|a| a.delimiter) {
         opts.push(format!("delimiter = {delimiter:?}"));
     }
+    if flag.allow_hyphen_values() {
+        opts.push("allow_hyphen_values".into());
+    }
     if !flag.required_if.is_empty() {
         opts.push(selector_list("required_if", &flag.required_if));
     }
@@ -968,6 +971,9 @@ fn clap_flag_opts(
     }
     if let Some(delimiter) = flag.arg.as_ref().and_then(|a| a.delimiter) {
         opts.push(format!("value_delimiter = {delimiter:?}"));
+    }
+    if flag.allow_hyphen_values() {
+        opts.push("allow_hyphen_values = true".into());
     }
     if flag.global {
         opts.push("global = true".into());


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacked on #1009.

The spec already said `allow_hyphen_values` and usage-lib honoured it. usage-argv now has the same bit on `Flag`, so `--args -destroy` binds `-destroy` and `--args -- -x` takes the separator as the value. `#[usage(allow_hyphen_values)]` is the derive attribute; emitted KDL is `allow_hyphen_values=#true`.

A variadic occurrence still stops collecting at a later flag-like token, so a second occurrence of the same flag is not eaten as a value. A positional that needs the same thing is already `double_dash = "automatic"`.

Corpus vectors cover the long form, the short form, the separator, a variadic first value, and a repeatable flag's per-occurrence hyphenated values.

_This comment was generated by Claude Code._
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4de7e59e-aa2e-4ad0-a1d0-1c2e69c166db?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4de7e59e-aa2e-4ad0-a1d0-1c2e69c166db&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

