### PR TITLE
feat(spec): refuse a detached value when require_equals is set

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -408,8 +408,11 @@ Groups are the opposite case: `Command::get_groups`, `ArgGroup::get_args` and
       `run`/`exec`/`dlx`/`node`, fnox `exec`/`proxy`, pitchfork `daemons add`.
       A hyphen-taking _flag value_ that is not also trailing is now the same
       declaration on the flag.
-- [ ] **`require_equals`** — accept `--flag=value` and refuse `--flag value`.
-      **Used by:** aube `run --inspect` / `--inspect-brk`.
+- [x] **`require_equals`** — accept `--flag=value` and refuse `--flag value`.
+      Spec, usage-lib, usage-argv, the derive (`#[usage(require_equals)]`), and
+      the clap bridge (`Arg::is_require_equals_set`). A short's attached form
+      (`-i9229`, `-i=9229`) still binds. **Used by:** aube `run --inspect` /
+      `--inspect-brk`.
 - [x] **`#[arg(skip)]`** — a field that is not an argument at all, filled from
       `Default`. `#[usage(skip)]` is that: the field stays on the struct so a
       rewrite can keep computed state beside parsed state, and nothing about it
@@ -463,7 +466,7 @@ completions for four shells, `flatten`, `global`, `count`, `env`, `negate`
 (clap's `SetFalse`), `value_enum`, `num_args` via `var_min`/`var_max`, clap's
 `last` via `double_dash`, `help_heading`, `subcommand_required`, declaration
 order, non-UTF-8 `OsString`/`PathBuf` values, `requires`, `group`/`exclusive`,
-and `delimiter`, `#[usage(skip)]`, and `allow_hyphen_values`.
+and `delimiter`, `#[usage(skip)]`, `allow_hyphen_values`, and `require_equals`.
 
 And the other direction: `mount`, `restart_token`, `default_subcommand` and
 `effect` are things a spec says that clap cannot hear, and `gen-shadow` counts
@@ -611,17 +614,16 @@ looking at the clap surface, not only at the spec.
 | gap                                            | who                                                                                       | what breaks without it                                              |
 | ---------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
 | `default_missing_value` / optional-value flags | mise `watch` / `generate bootstrap`, hk `-W`, aube `--color`/`--inspect` / audit `--omit` | `--color` and `--color=always` stop being two spellings of one flag |
-| `require_equals`                               | aube `--inspect`                                                                          | `--inspect 9229` is accepted when it should be refused              |
 | `external_subcommand`                          | aube, pitchfork                                                                           | unknown words at the root stop being forwarded                      |
 | `default_value_if`                             | mise `bin_paths`                                                                          | `--json` no longer implies the matching default                     |
 | `value_parser` ranges                          | unknown until the typed rewrite                                                           | `FromStr` accepts out-of-range numbers clap would refuse            |
 
-`value_delimiter`, `requires`, and `allow_hyphen_values` are not in that table
-because the _parser_ can say them. They are lost only on the clap → spec round
-trip (and a non-ASCII delimiter is dropped even then), and a rewrite that
-declares in usage keeps them. `#[usage(skip)]` is a compile-time field, not a
-command-line shape. Trailing argv is already `double_dash=automatic` in every
-fleet spec that has one.
+`value_delimiter`, `requires`, `allow_hyphen_values`, and `require_equals` are
+not in that table because the _parser_ can say them. They are lost only on the
+clap → spec round trip (and a non-ASCII delimiter is dropped even then), and a
+rewrite that declares in usage keeps them. `#[usage(skip)]` is a compile-time
+field, not a command-line shape. Trailing argv is already `double_dash=automatic`
+in every fleet spec that has one.
 
 - [ ] **Grammar decisions that would change mise at run time**, not just at
       completion time. Unrecognized flags falling through to positionals is how

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -272,6 +272,13 @@ pub struct Flag<'a> {
     /// occurrence still stops collecting at a later flag-like token, so a second
     /// occurrence of the flag is not eaten as a value.
     pub allow_hyphen_values: bool,
+    /// Whether the value must be attached with `=`.
+    ///
+    /// `--flag=value` is accepted and `--flag value` is not, which is clap's
+    /// `require_equals` and the spec's property of the same name. A short's
+    /// attached form (`-i9229`, `-i=9229`) still binds: only the following word
+    /// is refused.
+    pub require_equals: bool,
     /// Whether the flag is recognized by every command beneath the one that
     /// declares it.
     pub global: bool,
@@ -290,6 +297,7 @@ impl Flag<'_> {
         var_max: ::core::option::Option::None,
         delimiter: ::core::option::Option::None,
         allow_hyphen_values: false,
+        require_equals: false,
         global: false,
     };
 
@@ -1362,6 +1370,9 @@ impl<'t, 'v> Parser<'t, 'v> {
     /// one, and the attached form is available for the deliberate case. Declared,
     /// the next token is taken whatever it looks like, including `--`.
     fn take_detached_value(&mut self, flag: &'t Flag<'t>) -> Result<&'v [u8], Error<'t, 'v>> {
+        if flag.require_equals {
+            return Err(Error::MissingFlagValue { flag });
+        }
         match self.argv.get(self.pos) {
             Some(next) if flag.allow_hyphen_values || !is_flag_like(bytes(next)) => {
                 self.pos += 1;
@@ -2409,6 +2420,50 @@ mod tests {
                     value: b"-x"
                 },
             ]
+        );
+    }
+
+    #[test]
+    fn require_equals_refuses_a_detached_value() {
+        static INSPECT: Flag = Flag {
+            key: 8,
+            name: "inspect",
+            longs: &["inspect"],
+            shorts: b"i",
+            takes_value: true,
+            require_equals: true,
+            ..Flag::BOOL
+        };
+        static EQ: Command = Command {
+            name: "ex",
+            flags: &[&INSPECT],
+            ..Command::EMPTY
+        };
+
+        let a = argv(["--inspect=9229"]);
+        assert_eq!(
+            parse(&EQ, &a).unwrap(),
+            vec![Event::Flag {
+                flag: &INSPECT,
+                value: Some(b"9229"),
+                negated: false
+            }]
+        );
+
+        let a = argv(["--inspect", "9229"]);
+        assert!(matches!(
+            parse(&EQ, &a),
+            Err(Error::MissingFlagValue { .. })
+        ));
+
+        let a = argv(["-i9229"]);
+        assert_eq!(
+            parse(&EQ, &a).unwrap(),
+            vec![Event::Flag {
+                flag: &INSPECT,
+                value: Some(b"9229"),
+                negated: false
+            }]
         );
     }
 

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -2465,6 +2465,24 @@ mod tests {
                 negated: false
             }]
         );
+
+        static ALL: Flag = Flag {
+            key: 9,
+            name: "all",
+            longs: &["all"],
+            shorts: b"a",
+            ..Flag::BOOL
+        };
+        static BUNDLE: Command = Command {
+            name: "ex",
+            flags: &[&ALL, &INSPECT],
+            ..Command::EMPTY
+        };
+        let a = argv(["-ai", "9229"]);
+        assert!(
+            matches!(parse(&BUNDLE, &a), Err(Error::MissingFlagValue { .. })),
+            "a require_equals short reached through a bundle still refuses the following word"
+        );
     }
 
     #[test]

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -1183,6 +1183,9 @@ fn write_flag(out: &mut String, meta: &FlagMeta<'_>, depth: usize) -> core::fmt:
     if meta.flag.allow_hyphen_values {
         out.push_str(" allow_hyphen_values=#true");
     }
+    if meta.flag.require_equals {
+        out.push_str(" require_equals=#true");
+    }
     write_single_list(out, "requires", meta.requires)?;
     write_single_list(out, "required_if", meta.required_if)?;
     write_single_list(out, "required_unless", meta.required_unless)?;

--- a/conformance/src/tables.rs
+++ b/conformance/src/tables.rs
@@ -269,6 +269,7 @@ fn build_flag(f: &SpecFlag) -> &'static Flag<'static> {
             .filter(char::is_ascii)
             .map(|d| d as u8),
         allow_hyphen_values: f.allow_hyphen_values(),
+        require_equals: f.require_equals,
         global: f.global,
     }))
 }

--- a/conformance/tests/derive.rs
+++ b/conformance/tests/derive.rs
@@ -938,3 +938,31 @@ fn a_hyphen_taking_flag_binds_a_flaglike_value() {
         "usage-lib has to read the emitted property the same way it reads a handwritten one"
     );
 }
+
+/// clap's `require_equals`: `--flag=value` yes, `--flag value` no.
+#[derive(Cli, Debug)]
+#[usage(bin = "equals")]
+struct WithEquals {
+    #[usage(short = 'i', long, require_equals)]
+    inspect: Option<String>,
+}
+
+#[test]
+fn a_require_equals_flag_refuses_a_detached_value() {
+    let a = argv(["--inspect=9229"]);
+    let got = WithEquals::parse_from(&a).expect("attached form");
+    assert_eq!(got.inspect.as_deref(), Some("9229"));
+
+    let a = argv(["--inspect", "9229"]);
+    let err = WithEquals::parse_from(&a).expect_err("detached form");
+    assert!(
+        matches!(err, usage_argv::Error::MissingFlagValue { .. }),
+        "{err:?}"
+    );
+
+    let kdl = WithEquals::to_kdl();
+    assert!(
+        kdl.contains("require_equals=#true"),
+        "the attribute has to reach the spec: {kdl}"
+    );
+}

--- a/corpus/01-long-flags.json
+++ b/corpus/01-long-flags.json
@@ -251,6 +251,27 @@
       "spec": "name \"ex\"\nbin \"ex\"\nflag \"-a --args <ARGS>\" var=#true allow_hyphen_values=#true\n",
       "argv": ["-a", "-val1", "-a", "-val2"],
       "expect": { "ok": { "flags": { "args": ["-val1", "-val2"] } } }
+    },
+    {
+      "id": "long-value-require-equals-attached",
+      "doc": "`require_equals` accepts the attached form: `--inspect=9229` binds. aube's `--inspect` is the fleet case.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--inspect <PORT>\" require_equals=#true\n",
+      "argv": ["--inspect=9229"],
+      "expect": { "ok": { "flags": { "inspect": "9229" } } }
+    },
+    {
+      "id": "long-value-require-equals-refuses-detached",
+      "doc": "`require_equals` refuses the following word: `--inspect 9229` is a missing value, not a port of 9229.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--inspect <PORT>\" require_equals=#true\n",
+      "argv": ["--inspect", "9229"],
+      "expect": { "error": "missing_flag_value" }
+    },
+    {
+      "id": "long-value-require-equals-still-takes-empty-attached",
+      "doc": "`--inspect=` is still present-but-empty: the `=` settled that a value was given, even though it is empty.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--inspect <PORT>\" require_equals=#true\n",
+      "argv": ["--inspect="],
+      "expect": { "ok": { "flags": { "inspect": "" } } }
     }
   ]
 }

--- a/corpus/02-short-flags.json
+++ b/corpus/02-short-flags.json
@@ -190,6 +190,27 @@
       "spec": "name \"ex\"\nbin \"ex\"\nflag \"-d --working-dir <DIR>\"\nflag \"-a --args <ARGS>\" allow_hyphen_values=#true\n",
       "argv": ["-a", "-destroy"],
       "expect": { "ok": { "flags": { "args": "-destroy" } } }
+    },
+    {
+      "id": "short-value-require-equals-attached",
+      "doc": "A short's attached form still binds under `require_equals`: `-i9229` never needed a following word.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-i --inspect <PORT>\" require_equals=#true\n",
+      "argv": ["-i9229"],
+      "expect": { "ok": { "flags": { "inspect": "9229" } } }
+    },
+    {
+      "id": "short-value-require-equals-equals-form",
+      "doc": "`-i=9229` is attached too: the `=` is a separator, not a following word.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-i --inspect <PORT>\" require_equals=#true\n",
+      "argv": ["-i=9229"],
+      "expect": { "ok": { "flags": { "inspect": "9229" } } }
+    },
+    {
+      "id": "short-value-require-equals-refuses-detached",
+      "doc": "`-i 9229` is the following word, so `require_equals` refuses it the same way `--inspect 9229` is refused.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-i --inspect <PORT>\" require_equals=#true\n",
+      "argv": ["-i", "9229"],
+      "expect": { "error": "missing_flag_value" }
     }
   ]
 }

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -765,6 +765,7 @@ fn flag_table(i: usize, field: &Field) -> TokenStream {
 
     let table_delimiter = table_delimiter(field);
     let allow_hyphen_values = field.allow_hyphen_values;
+    let require_equals = field.require_equals;
     quote! {
         pub static #name: usage_argv::Flag = usage_argv::Flag {
             key: #key,
@@ -777,6 +778,7 @@ fn flag_table(i: usize, field: &Field) -> TokenStream {
             var_max: #var_max,
             delimiter: #table_delimiter,
             allow_hyphen_values: #allow_hyphen_values,
+            require_equals: #require_equals,
             global: #global,
         };
     }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -219,6 +219,7 @@
 //! | `exclusive` | this flag has to be given on its own, positionals included |
 //! | `delimiter = ','` | one word becomes several values; the field has to be a `Vec` |
 //! | `allow_hyphen_values` | a flag's detached value may look like a flag, including `--` |
+//! | `require_equals` | `--flag=value` is accepted and `--flag value` is not |
 //! | `required_if = "--other"` | a flag whose presence makes this one necessary |
 //! | `required_unless = "--other"` | a flag whose presence makes this one unnecessary |
 //!

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -218,6 +218,8 @@ pub struct Field {
     /// clap's `allow_hyphen_values`, and the spec's property of the same name. Only
     /// a flag that takes a value can declare it: there is nothing to take otherwise.
     pub allow_hyphen_values: bool,
+    /// Whether the value must be attached with `=`. clap's `require_equals`.
+    pub require_equals: bool,
     /// Whether this flag must be given on its own — clap's `exclusive`.
     pub exclusive: bool,
     /// The group this flag belongs to, if any. Properties live on the group's own
@@ -1097,6 +1099,7 @@ impl Field {
             requires_if: Vec::new(),
             delimiter: None,
             allow_hyphen_values: false,
+            require_equals: false,
             exclusive: false,
             group: None,
             required_if: Vec::new(),
@@ -1202,6 +1205,7 @@ impl Field {
             requires_if: Vec::new(),
             delimiter: None,
             allow_hyphen_values: false,
+            require_equals: false,
             exclusive: false,
             group: None,
             required_if: Vec::new(),
@@ -1301,6 +1305,7 @@ impl Field {
             requires_if: Vec::new(),
             delimiter: None,
             allow_hyphen_values: false,
+            require_equals: false,
             exclusive: false,
             group: None,
             required_if: Vec::new(),
@@ -1371,6 +1376,7 @@ impl Field {
         let mut exclusive = false;
         let mut delimiter: Option<char> = None;
         let mut allow_hyphen_values = false;
+        let mut require_equals = false;
         let mut required_if: Vec<String> = Vec::new();
         let mut required_unless: Vec<String> = Vec::new();
 
@@ -1468,6 +1474,7 @@ impl Field {
                     "group" => group = Some(string_value(&meta)?),
                     "exclusive" => exclusive = flag_value(&meta)?,
                     "allow_hyphen_values" => allow_hyphen_values = flag_value(&meta)?,
+                    "require_equals" => require_equals = flag_value(&meta)?,
                     "delimiter" => {
                         let c = char_value(&meta)?;
                         if !c.is_ascii() {
@@ -1525,7 +1532,7 @@ impl Field {
                                  `count`, `hide`, `arg`, `env`, `default`, `choices`, \
                                  `var_min`, `var_max`, `value_enum`, `value_hint`, `overrides`, \
                                  `conflicts`, `requires`, `group`, `exclusive`, \
-                                 `delimiter`, `allow_hyphen_values`, \
+                                 `delimiter`, `allow_hyphen_values`, `require_equals`, \
                                  `required_if`, \
                                  `required_unless`, `help_heading`, `value_name`, \
                                  `verbatim_doc_comment`, \
@@ -2040,6 +2047,21 @@ impl Field {
             }
         }
 
+        if require_equals {
+            if !matches!(kind, Kind::Flag { .. }) {
+                return Err(syn::Error::new(
+                    span,
+                    "`require_equals` is for a flag's value; a positional has no `=` form",
+                ));
+            }
+            if matches!(shape, Shape::Bool | Shape::Count) {
+                return Err(syn::Error::new(
+                    span,
+                    "`require_equals` requires `--flag=value`, and this flag takes none",
+                ));
+            }
+        }
+
         // `value_name` names the placeholder a *flag's value* gets in help — `--out <FILE>`.
         // A positional argument is named by `name`, and a `bool` or `count` flag has no value
         // to put a placeholder in, so `arg_meta` never emits it and a valueless flag has nowhere
@@ -2116,6 +2138,7 @@ impl Field {
             requires_if,
             delimiter,
             allow_hyphen_values,
+            require_equals,
             exclusive,
             group,
             required_if,
@@ -3863,6 +3886,34 @@ mod tests {
             err.contains("double_dash"),
             "should point at the positional spelling: {err}"
         );
+    }
+
+    #[test]
+    fn require_equals_is_a_flag_that_takes_a_value() {
+        let cli = cli(r#"
+            struct Ex {
+                #[usage(long, require_equals)]
+                inspect: Option<String>,
+            }
+        "#)
+        .expect("should compile");
+        assert!(
+            cli.fields.iter().any(|f| f.require_equals),
+            "the attribute has to reach the field the table is built from"
+        );
+    }
+
+    #[test]
+    fn require_equals_cannot_sit_on_a_switch() {
+        let err = rejection(
+            r#"
+            struct Ex {
+                #[usage(long, require_equals)]
+                force: bool,
+            }
+        "#,
+        );
+        assert!(err.contains("takes none"), "unhelpful message: {err}");
     }
 
     #[test]

--- a/docs/rust/args-and-flags.md
+++ b/docs/rust/args-and-flags.md
@@ -75,6 +75,7 @@ jobs: Option<u32>,
 | `value_enum`                            | Take choices from a `#[derive(ValueEnum)]` type                                         |
 | `delimiter = ','`                       | Split one word into several values ([Validation](/rust/validation#delimiters))          |
 | `allow_hyphen_values`                   | Detached flag value may look like a flag, including `--`                                |
+| `require_equals`                        | Accept `--flag=value` and refuse `--flag value`                                         |
 | `group = "name"`                        | Join a flag group ([Validation](/rust/validation#groups))                               |
 | `exclusive`                             | Must be given alone ([Validation](/rust/validation#exclusive-flags))                    |
 | `conflicts(…)` / `requires(…)`          | Relations to other flags ([Validation](/rust/validation))                               |
@@ -103,6 +104,10 @@ has to implement `Default`.
 `-destroy` instead of reading `-d` as a short. The flag has to take a value; a positional that
 needs the same thing already has `double_dash = "automatic"`. Emitted KDL:
 `flag "--args <ARGS>" allow_hyphen_values=#true`.
+
+`#[usage(require_equals)]` is clap's attribute of the same name: `--inspect=9229` binds
+and `--inspect 9229` is a missing value. The flag has to take a value. Emitted KDL:
+`flag "--inspect <PORT>" require_equals=#true`.
 
 Flag relations (`conflicts`, `requires`, `overrides`, `required_if`, `required_unless`) name
 their target the way the KDL spec does — `"--long"` or `"-s"`, one value or a list:

--- a/docs/spec/argv.md
+++ b/docs/spec/argv.md
@@ -12,7 +12,7 @@ and the [conformance corpus](#the-conformance-corpus) makes it executable.
 
 ::: tip Both implementations answer every vector
 
-usage-lib and usage-argv agree with all 162 vectors today. That is a
+usage-lib and usage-argv agree with all 168 vectors today. That is a
 measurement, checked on every run rather than asserted here — see
 [Where the reference implementation differs](#where-the-reference-implementation-differs).
 
@@ -96,6 +96,10 @@ like, including `--` and tokens that name other flags. The attached form is then
 no longer the only way to pass a dash-prefixed value. A variadic occurrence still
 stops collecting at a later flag-like token, so a second occurrence of the same
 flag is not eaten as a value.
+
+A flag declared `require_equals` accepts only the attached form: `--inspect=9229`
+binds and `--inspect 9229` is a missing value. A short's attached form
+(`-i9229`, `-i=9229`) still binds.
 
 A flag needing a value that ends the command line is an error.
 
@@ -372,7 +376,7 @@ fails if a label is wrong in either direction. A recorded divergence that gets
 fixed shows up as a test failure telling you to delete the label, so the list
 cannot rot.
 
-**Today it does not: usage-lib agrees with all 162 vectors.** The list is empty
+**Today it does not: usage-lib agrees with all 168 vectors.** The list is empty
 for the first time, and the five entries it used to hold were what writing the
 grammar down was for. Each was a real defect that only a second reading found:
 

--- a/docs/spec/reference/flag.md
+++ b/docs/spec/reference/flag.md
@@ -38,6 +38,7 @@ flag "--config <file>" {
 flag "--dump" exclusive=#true            // --dump has to be given on its own
 flag "--tags <tag>" var=#true delimiter="," // --tags a,b,c is three values
 flag "--args <ARGS>" allow_hyphen_values=#true // --args -destroy binds "-destroy"
+flag "--inspect <PORT>" require_equals=#true   // --inspect=9229 yes, --inspect 9229 no
 
 flag "--stdin" {
   conflicts "--file" "--url" // several, one per argument
@@ -162,6 +163,20 @@ still stops collecting at a later flag-like token, so a second occurrence of the
 flag is not eaten as a value.
 
 A flag that takes no value cannot declare it: there is nothing to take.
+
+## `require_equals`
+
+The value must be attached with `=`: `--inspect=9229` binds and `--inspect 9229`
+is a missing value. clap spells this `require_equals`, and a spec generated from
+a clap command carries it — aube's `--inspect` / `--inspect-brk` are the fleet
+case.
+
+A short's attached form still binds (`-i9229`, `-i=9229`); only the following
+word is refused. Combined with [`allow_hyphen_values`](#allow_hyphen_values),
+the attached form can still pass a dash-prefixed value (`--args=--force`);
+the detached form stays refused.
+
+A flag that takes no value cannot declare it.
 
 ## `global`
 

--- a/go/argv/argv.go
+++ b/go/argv/argv.go
@@ -125,6 +125,13 @@ type Flag struct {
 	// occurrence still stops collecting at a later flag-like token, so a second
 	// occurrence of the flag is not eaten as a value.
 	AllowHyphenValues bool
+	// RequireEquals is whether the value must be attached with `=`.
+	//
+	// `--flag=value` is accepted and `--flag value` is not, which is clap's
+	// require_equals and the spec's property of the same name. A short's
+	// attached form (`-i9229`, `-i=9229`) still binds: only the following word
+	// is refused.
+	RequireEquals bool
 	// Global is whether the flag is recognized by every command beneath the one
 	// that declares it.
 	Global bool

--- a/go/argv/parser.go
+++ b/go/argv/parser.go
@@ -398,14 +398,21 @@ func (p *Parser) shortFlag() bool {
 // It refuses a flag-like token unless AllowHyphenValues is set: `--jobs --force`
 // is far more likely a forgotten value than a deliberate one, and the attached
 // form is available for the deliberate case. Declared, the next token is taken
-// whatever it looks like, including `--`. The negative-number exception means
-// `--offset -1` still works.
+// whatever it looks like, including `--`. RequireEquals refuses the following
+// word either way. The negative-number exception means `--offset -1` still works.
 func (p *Parser) takeDetachedValue(flag *Flag, long string, short byte) (string, bool) {
+	if flag.RequireEquals {
+		return p.missingValue(flag, long, short)
+	}
 	if p.pos < len(p.argv) && (flag.AllowHyphenValues || !isFlagLike(p.argv[p.pos])) {
 		v := p.argv[p.pos]
 		p.pos++
 		return v, true
 	}
+	return p.missingValue(flag, long, short)
+}
+
+func (p *Parser) missingValue(flag *Flag, long string, short byte) (string, bool) {
 	// The form the user actually wrote, carried so the advice can use it. A flag
 	// answers to several spellings and the first is not always the one in front of
 	// them: with an inherited `--jobs --workers` whose `--jobs` a nearer command

--- a/go/argv/parser_test.go
+++ b/go/argv/parser_test.go
@@ -261,6 +261,26 @@ func TestAllowHyphenValues(t *testing.T) {
 	}
 }
 
+func TestRequireEquals(t *testing.T) {
+	inspect := &Flag{Key: 8, Name: "inspect", Longs: []string{"inspect"}, Shorts: []byte{'i'},
+		TakesValue: true, RequireEquals: true}
+	all := &Flag{Key: 9, Name: "all", Longs: []string{"all"}, Shorts: []byte{'a'}}
+	cmd := &Command{Name: "ex", Flags: []*Flag{inspect, all}}
+
+	if got := collect(cmd, "--inspect=9229"); got != "flag:inspect=9229" {
+		t.Errorf("--inspect=9229: got %s", got)
+	}
+	if got := collect(cmd, "--inspect", "9229"); got != "err:missing_flag_value" {
+		t.Errorf("--inspect 9229: got %s", got)
+	}
+	if got := collect(cmd, "-i9229"); got != "flag:inspect=9229" {
+		t.Errorf("-i9229: got %s", got)
+	}
+	if got := collect(cmd, "-ai", "9229"); got != "flag:all err:missing_flag_value" {
+		t.Errorf("-ai 9229: got %s", got)
+	}
+}
+
 func BenchmarkParse(b *testing.B) {
 	args := []string{"install", "--verbose", "-f", "a", "b", "c"}
 	b.ReportAllocs()

--- a/go/internal/spec/spec.go
+++ b/go/internal/spec/spec.go
@@ -208,6 +208,7 @@ type Flag struct {
 	RequiredIf     []string     `json:"required_if"`
 	RequiredUnless []string     `json:"required_unless"`
 	RequiresIf     []RequiresIf `json:"requires_if"`
+	RequireEquals  bool         `json:"require_equals"`
 	Arg            *Arg         `json:"arg"`
 }
 
@@ -694,6 +695,7 @@ func (b *builder) flag(f *Flag) *argv.Flag {
 		// usage-lib keeps allow_hyphen_values. Trailing positionals use Arg.DoubleDash
 		// on the command, not here.
 		AllowHyphenValues: f.Arg != nil && strings.EqualFold(f.Arg.DoubleDash, "automatic"),
+		RequireEquals:     f.RequireEquals,
 		Global:            f.Global,
 	}
 	b.recordNegation(out.Key, f.Negate)

--- a/go/internal/spec/spec_test.go
+++ b/go/internal/spec/spec_test.go
@@ -504,3 +504,15 @@ func TestAllowHyphenValuesCarriesFromNestedArg(t *testing.T) {
 		t.Error("a flag without double_dash=automatic should not take hyphen values")
 	}
 }
+
+func TestRequireEqualsCarries(t *testing.T) {
+	root, _ := build(&Spec{
+		Name: "ex", Bin: "ex",
+		Cmd: Cmd{Name: "ex", Flags: []Flag{
+			{Name: "inspect", Long: []string{"inspect"}, RequireEquals: true, Arg: &Arg{Name: "PORT"}},
+		}},
+	})
+	if !root.Flags[0].RequireEquals {
+		t.Error("require_equals should carry")
+	}
+}

--- a/lib/src/go/mod.rs
+++ b/lib/src/go/mod.rs
@@ -1049,6 +1049,9 @@ fn flag_literal(flag: &SpecFlag, named: &Named) -> String {
     if flag.allow_hyphen_values() {
         fields.push("AllowHyphenValues: true".to_string());
     }
+    if flag.require_equals {
+        fields.push("RequireEquals: true".to_string());
+    }
     if flag.global {
         fields.push("Global: true".to_string());
     }
@@ -1606,6 +1609,19 @@ flag "--args <ARGS>" allow_hyphen_values=#true
 "#);
         assert!(
             out.contains("Name: \"args\", Longs: []string{\"args\"}, TakesValue: true, AllowHyphenValues: true"),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn require_equals_reaches_the_table() {
+        let out = go(r#"
+name "ex"
+bin "ex"
+flag "--inspect <PORT>" require_equals=#true
+"#);
+        assert!(
+            out.contains("Name: \"inspect\", Longs: []string{\"inspect\"}, TakesValue: true, RequireEquals: true"),
             "{out}"
         );
     }

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -1067,8 +1067,11 @@ fn parse_partial_with_env(
                 if !rest.is_empty() {
                     input.push_front(format!("-{rest}"));
                     prefix_bindings.push_front(None);
-                    grouped_flag = true;
                 }
+                // A fully consumed short is no longer a grouped continuation.
+                // Leaving this set after `-ai` made `-i` skip `require_equals`
+                // and bind the following word.
+                grouped_flag = !rest.is_empty();
                 if f.arg.is_some() {
                     out.flag_awaiting_value.push(Arc::clone(f));
                 } else if f.count {
@@ -6085,6 +6088,23 @@ flag "--inspect <PORT>" require_equals=#true
         assert!(
             msg.contains("requires an argument") || msg.contains("inspect"),
             "detached value must be refused: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_require_equals_refuses_a_detached_value_after_a_short_bundle() {
+        let spec = r#"
+flag "-a --all"
+flag "-i --inspect <PORT>" require_equals=#true
+"#
+        .parse::<Spec>()
+        .unwrap();
+
+        let err = parse(&spec, &input(&["test", "-ai", "9229"])).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("requires an argument") || msg.contains("inspect"),
+            "bundled short must refuse the following word: {msg}"
         );
     }
 

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -843,6 +843,10 @@ fn parse_partial_with_env(
         // The flag this word was read as in Phase 1, if it skipped it (see `prefix_bindings`).
         // Words pushed back below get a `None` so the two queues stay aligned.
         let binding = prefix_bindings.pop_front().flatten();
+        // A short's attached value is re-queued with `grouped_flag` set, and that
+        // continuation is not a following word. `require_equals` refuses only the
+        // following word; `-i9229` and `-i=9229` still bind.
+        let attached_continuation = grouped_flag;
 
         // Check for restart_token - resets argument parsing for multiple command invocations
         // e.g., `mise run lint ::: test ::: check` with restart_token=":::"
@@ -874,7 +878,7 @@ fn parse_partial_with_env(
             && out
                 .flag_awaiting_value
                 .last()
-                .is_some_and(|flag| flag.allow_hyphen_values())
+                .is_some_and(|flag| flag.allow_hyphen_values() && !flag.require_equals)
         {
             // A variadic argument collects here too: which token supplied its first
             // value says nothing about how many it takes.
@@ -1106,6 +1110,35 @@ fn parse_partial_with_env(
         // where every token is data. Draining there gave `ex --jobs -- x` the word after
         // the separator, so the command line quietly meant `ex --jobs=x` and the `--`
         // was gone. Left waiting, it is reported as the missing value it is.
+        // `require_equals` refuses a detached value: `--flag value` is a missing
+        // value, not a flag of `"value"`. The attached form is still bound above.
+        // Reported here rather than left waiting until the end of the line: falling
+        // through would offer `value` to the positionals and call it an unexpected
+        // word, which is the wrong error and a different one from usage-argv.
+        if enable_flags
+            && !attached_continuation
+            && !out.flag_awaiting_value.is_empty()
+            && out
+                .flag_awaiting_value
+                .last()
+                .is_some_and(|flag| flag.require_equals)
+        {
+            let flag = out.flag_awaiting_value.last().unwrap();
+            let token = flag
+                .long
+                .first()
+                .map(|l| format!("--{l}"))
+                .or_else(|| flag.short.first().map(|s| format!("-{s}")))
+                .unwrap_or_else(|| flag.name.clone());
+            out.errors.push(UsageErr::InvalidFlag {
+                token: token.clone(),
+                reason: "requires an argument".to_string(),
+                span: (0, 0).into(),
+                input: format!("{token} {w}"),
+            });
+            record_cursor(&mut out, next_arg_idx, seen_double_dash);
+            return Ok((out, overridden_flags));
+        }
         if enable_flags && !out.flag_awaiting_value.is_empty() {
             // Held before the drain pops it: a flag whose argument is variadic keeps
             // taking values after this first one.
@@ -6034,6 +6067,25 @@ flag "-a --args <ARGS>" var=#true allow_hyphen_values=#true
             }
             _ => panic!("expected MultiString, got {value:?}"),
         }
+    }
+
+    #[test]
+    fn test_require_equals_accepts_attached_and_refuses_detached() {
+        let spec = r#"
+flag "--inspect <PORT>" require_equals=#true
+"#
+        .parse::<Spec>()
+        .unwrap();
+
+        let parsed = parse(&spec, &input(&["test", "--inspect=9229"])).unwrap();
+        assert_eq!(flag_string_value(&parsed, "inspect"), "9229");
+
+        let err = parse(&spec, &input(&["test", "--inspect", "9229"])).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("requires an argument") || msg.contains("inspect"),
+            "detached value must be refused: {msg}"
+        );
     }
 
     #[test]

--- a/lib/src/spec/builder.rs
+++ b/lib/src/spec/builder.rs
@@ -214,6 +214,12 @@ impl SpecFlagBuilder {
         self
     }
 
+    /// Require `--flag=value` and refuse `--flag value`.
+    pub fn require_equals(mut self, require: bool) -> Self {
+        self.inner.require_equals = require;
+        self
+    }
+
     /// Set the argument spec for flags that take values
     pub fn arg(mut self, arg: SpecArg) -> Self {
         self.inner.arg = Some(arg);

--- a/lib/src/spec/flag.rs
+++ b/lib/src/spec/flag.rs
@@ -143,6 +143,11 @@ pub struct SpecFlag {
     /// makes this different from being in a group with every other flag.
     #[serde(skip_serializing_if = "is_false")]
     pub exclusive: bool,
+    /// Whether the value must be attached with `=`: `--flag=value` is accepted
+    /// and `--flag value` is not. clap's `require_equals`. Aube's `--inspect`
+    /// is the fleet case.
+    #[serde(skip_serializing_if = "is_false")]
+    pub require_equals: bool,
     /// Raises the effect of the command when this flag is supplied.
     /// See [`crate::spec::effect::SpecCommandEffect`]; never lowers it.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -206,6 +211,7 @@ impl SpecFlag {
                 "conflicts" => flag.conflicts = vec![v.ensure_string()?],
                 "requires" => flag.requires = vec![v.ensure_string()?],
                 "exclusive" => flag.exclusive = v.ensure_bool()?,
+                "require_equals" => flag.require_equals = v.ensure_bool()?,
                 // Written on the flag and kept on its argument, as `allow_hyphen_values`
                 // is: the value is what gets split, and `flag "--tags <tag>"` is where a
                 // reader writes something about that value.
@@ -318,6 +324,7 @@ impl SpecFlag {
                         .collect::<Result<Vec<_>>>()?;
                 }
                 "exclusive" => flag.exclusive = child.arg(0)?.ensure_bool()?,
+                "require_equals" => flag.require_equals = child.arg(0)?.ensure_bool()?,
                 "requires" => {
                     flag.requires = child
                         .ensure_arg_len(1..)?
@@ -348,6 +355,13 @@ impl SpecFlag {
         }
         if allow_hyphen_values {
             flag.set_allow_hyphen_values(ctx, node.node.name().span(), true)?;
+        }
+        if flag.require_equals && flag.arg.is_none() {
+            bail_parse!(
+                ctx,
+                node.node.name().span(),
+                "flag must have value to require equals"
+            );
         }
         if let Some(raw) = delimiter {
             let mut chars = raw.chars();
@@ -544,6 +558,9 @@ impl From<&SpecFlag> for KdlNode {
         }
         if flag.exclusive {
             node.push(KdlEntry::new_prop("exclusive", true));
+        }
+        if flag.require_equals {
+            node.push(KdlEntry::new_prop("require_equals", true));
         }
         if let Some(env) = &flag.env {
             node.push(string_entry(Some("env"), env));
@@ -743,6 +760,7 @@ impl From<&clap::Arg> for SpecFlag {
             requires_if: vec![],
             // This one clap does expose, unlike `requires` just above.
             exclusive: c.is_exclusive_set(),
+            require_equals: c.is_require_equals_set(),
             help,
             help_long,
             help_md: None,
@@ -948,6 +966,27 @@ mod tests {
         assert!(dump.exclusive);
         let verbose = spec.cmd.flags.iter().find(|f| f.name == "verbose").unwrap();
         assert!(!verbose.exclusive);
+    }
+
+    #[test]
+    fn require_equals_round_trips_and_comes_across_from_clap() {
+        let spec: Spec = "flag \"--inspect <PORT>\" require_equals=#true\n"
+            .parse()
+            .unwrap();
+        assert!(spec.cmd.flags[0].require_equals);
+
+        let reparsed: Spec = spec.to_string().parse().unwrap();
+        assert!(reparsed.cmd.flags[0].require_equals, "{spec}");
+
+        let cmd = clap::Command::new("ex").arg(
+            clap::Arg::new("inspect")
+                .long("inspect")
+                .action(clap::ArgAction::Set)
+                .require_equals(true),
+        );
+        let spec = Spec::from(&cmd);
+        let inspect = spec.cmd.flags.iter().find(|f| f.name == "inspect").unwrap();
+        assert!(inspect.require_equals);
     }
 
     #[test]

--- a/xtask/src/shadow.rs
+++ b/xtask/src/shadow.rs
@@ -851,6 +851,9 @@ fn usage_flag_opts(
     if flag.allow_hyphen_values() {
         opts.push("allow_hyphen_values".into());
     }
+    if flag.require_equals {
+        opts.push("require_equals".into());
+    }
     if !flag.required_if.is_empty() {
         opts.push(selector_list("required_if", &flag.required_if));
     }
@@ -974,6 +977,9 @@ fn clap_flag_opts(
     }
     if flag.allow_hyphen_values() {
         opts.push("allow_hyphen_values = true".into());
+    }
+    if flag.require_equals {
+        opts.push("require_equals = true".into());
     }
     if flag.global {
         opts.push("global = true".into());


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacked on #1012.

Accept `--flag=value` and refuse `--flag value`, which is clap's `require_equals` and aube's `--inspect`. A short's attached form (`-i9229`, `-i=9229`) still binds.

Carried through the spec (`require_equals=#true`), usage-lib, usage-argv (`Flag::require_equals`), `#[usage(require_equals)]`, the clap bridge (`Arg::is_require_equals_set`), and `gen-shadow`.

_This comment was generated by Claude Code._
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4de7e59e-aa2e-4ad0-a1d0-1c2e69c166db?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4de7e59e-aa2e-4ad0-a1d0-1c2e69c166db&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

