### PR TITLE
feat(spec): bind a value when a flag is given with none

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -381,13 +381,17 @@ Groups are the opposite case: `Command::get_groups`, `ArgGroup::get_args` and
       recorded a split default and dropped the delimiter. Regenerating them
       against this crate is the item under **Trying the fleet**, not another
       parser feature.
-- [~] **`default_missing_value`, and optional-value flags** — the metadata and
-  help-rendering half has landed (`--bump [BUMP]`), but binding still requires
-  a value. Accepting bare `--color` as distinct from `--color=always` still
-  needs an `Option<Option<T>>`-shaped partial and default-missing semantics.
-  **Used by the fleet:** mise `watch` (`default_missing_value = "clear"` /
-  `"30s"`) and `generate bootstrap`, hk `-W/--fail-fast` with `num_args=0..=1`,
-  aube `--color` / `--inspect` / audit `--omit`.
+- [x] **`default_missing_value`, and optional-value flags** — `--color` versus
+      `--color=always`. Spec `default_missing="always"`, usage-lib, usage-argv
+      (`Flag::default_missing`), and `#[usage(default_missing = "always")]`.
+      Absent stays absent (or takes `default`); `--color` binds the missing
+      value; `--color=never` binds `never`. Combined with `require_equals`, a
+      following word is still refused. `value_optional` remains help-only unless
+      `default_missing` is also set, which makes help show the value as optional.
+      clap 4 has the setter and no getter, so the bridge cannot read it — same
+      hole as `requires`. **Used by the fleet:** mise `watch`, `generate bootstrap`,
+      hk `-W/--fail-fast`, aube `--color` / `--inspect` / audit `--omit` — once
+      those CLIs declare in usage rather than through clap.
 - [ ] **`default_value_if` / `default_value_ifs`** — a default that depends on
       another flag. Ours are unconditional. **Used by:** mise `bin_paths`
       (`default_value_if("json", IsPresent, "true")`).
@@ -464,7 +468,8 @@ completions for four shells, `flatten`, `global`, `count`, `env`, `negate`
 (clap's `SetFalse`), `value_enum`, `num_args` via `var_min`/`var_max`, clap's
 `last` via `double_dash`, `help_heading`, `subcommand_required`, declaration
 order, non-UTF-8 `OsString`/`PathBuf` values, `requires`, `group`/`exclusive`,
-and `delimiter`, `#[usage(skip)]`, `allow_hyphen_values`, and `require_equals`.
+and `delimiter`, `#[usage(skip)]`, `allow_hyphen_values`, `require_equals`, and
+`default_missing`.
 
 And the other direction: `mount`, `restart_token`, `default_subcommand` and
 `effect` are things a spec says that clap cannot hear, and `gen-shadow` counts
@@ -609,19 +614,19 @@ looking at the clap surface, not only at the spec.
 - [ ] **The clap-only behaviour the fleet actually uses**, from the list above,
       in the order it would change a command line rather than a compile.
 
-| gap                                            | who                                                                                       | what breaks without it                                              |
-| ---------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| `default_missing_value` / optional-value flags | mise `watch` / `generate bootstrap`, hk `-W`, aube `--color`/`--inspect` / audit `--omit` | `--color` and `--color=always` stop being two spellings of one flag |
-| `external_subcommand`                          | aube, pitchfork                                                                           | unknown words at the root stop being forwarded                      |
-| `default_value_if`                             | mise `bin_paths`                                                                          | `--json` no longer implies the matching default                     |
-| `value_parser` ranges                          | unknown until the typed rewrite                                                           | `FromStr` accepts out-of-range numbers clap would refuse            |
+| gap                   | who             | what breaks without it                                          |
+| --------------------- | --------------- | --------------------------------------------------------------- |
+| `external_subcommand` | aube, pitchfork | unknown words at the root stop being forwarded                  |
+| `default_value_if`    | mise `bin_paths` | `--json` no longer implies the matching default                 |
+| `value_parser` ranges | unknown until the typed rewrite | `FromStr` accepts out-of-range numbers clap would refuse |
 
-`value_delimiter`, `requires`, `allow_hyphen_values`, and `require_equals` are
-not in that table because the _parser_ can say them. They are lost only on the
-clap → spec round trip (and a non-ASCII delimiter is dropped even then), and a
-rewrite that declares in usage keeps them. `#[usage(skip)]` is a compile-time
-field, not a command-line shape. Trailing argv is already `double_dash=automatic`
-in every fleet spec that has one.
+`value_delimiter`, `requires`, `allow_hyphen_values`, `require_equals`, and
+`default_missing` are not in that table because the _parser_ can say them. They
+are lost only on the clap → spec round trip (and a non-ASCII delimiter is
+dropped even then; `default_missing_value` has no clap getter), and a rewrite
+that declares in usage keeps them. `#[usage(skip)]` is a compile-time field, not
+a command-line shape. Trailing argv is already `double_dash=automatic` in every
+fleet spec that has one.
 
 - [ ] **Grammar decisions that would change mise at run time**, not just at
       completion time. Unrecognized flags falling through to positionals is how

--- a/PLAN.md
+++ b/PLAN.md
@@ -614,10 +614,10 @@ looking at the clap surface, not only at the spec.
 - [ ] **The clap-only behaviour the fleet actually uses**, from the list above,
       in the order it would change a command line rather than a compile.
 
-| gap                   | who             | what breaks without it                                          |
-| --------------------- | --------------- | --------------------------------------------------------------- |
-| `external_subcommand` | aube, pitchfork | unknown words at the root stop being forwarded                  |
-| `default_value_if`    | mise `bin_paths` | `--json` no longer implies the matching default                 |
+| gap                   | who                             | what breaks without it                                   |
+| --------------------- | ------------------------------- | -------------------------------------------------------- |
+| `external_subcommand` | aube, pitchfork                 | unknown words at the root stop being forwarded           |
+| `default_value_if`    | mise `bin_paths`                | `--json` no longer implies the matching default          |
 | `value_parser` ranges | unknown until the typed rewrite | `FromStr` accepts out-of-range numbers clap would refuse |
 
 `value_delimiter`, `requires`, `allow_hyphen_values`, `require_equals`, and

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -279,6 +279,12 @@ pub struct Flag<'a> {
     /// attached form (`-i9229`, `-i=9229`) still binds: only the following word
     /// is refused.
     pub require_equals: bool,
+    /// Value used when the flag is present but no value is given.
+    ///
+    /// clap's `default_missing_value` and the spec's `default_missing`. `--color`
+    /// binds this, `--color=never` binds `never`, and an absent flag is not bound.
+    /// Combined with [`Self::require_equals`], a following word is still refused.
+    pub default_missing: ::core::option::Option<&'a [u8]>,
     /// Whether the flag is recognized by every command beneath the one that
     /// declares it.
     pub global: bool,
@@ -298,6 +304,7 @@ impl Flag<'_> {
         delimiter: ::core::option::Option::None,
         allow_hyphen_values: false,
         require_equals: false,
+        default_missing: ::core::option::Option::None,
         global: false,
     };
 
@@ -1000,7 +1007,7 @@ pub struct Parser<'t, 'v> {
     help_span: (usize, usize),
 }
 
-impl<'t, 'v> Parser<'t, 'v> {
+impl<'t: 'v, 'v> Parser<'t, 'v> {
     /// Begin parsing `argv` against `root`.
     ///
     /// `argv` excludes the program name.
@@ -1371,14 +1378,21 @@ impl<'t, 'v> Parser<'t, 'v> {
     /// the next token is taken whatever it looks like, including `--`.
     fn take_detached_value(&mut self, flag: &'t Flag<'t>) -> Result<&'v [u8], Error<'t, 'v>> {
         if flag.require_equals {
-            return Err(Error::MissingFlagValue { flag });
+            return self.missing_or_default(flag);
         }
         match self.argv.get(self.pos) {
             Some(next) if flag.allow_hyphen_values || !is_flag_like(bytes(next)) => {
                 self.pos += 1;
                 Ok(bytes(next))
             }
-            _ => Err(Error::MissingFlagValue { flag }),
+            _ => self.missing_or_default(flag),
+        }
+    }
+
+    fn missing_or_default(&self, flag: &'t Flag<'t>) -> Result<&'v [u8], Error<'t, 'v>> {
+        match flag.default_missing {
+            Some(value) => Ok(value),
+            None => Err(Error::MissingFlagValue { flag }),
         }
     }
 
@@ -2482,6 +2496,131 @@ mod tests {
         assert!(
             matches!(parse(&BUNDLE, &a), Err(Error::MissingFlagValue { .. })),
             "a require_equals short reached through a bundle still refuses the following word"
+        );
+    }
+
+    #[test]
+    fn default_missing_binds_when_the_value_is_left_off() {
+        static COLOR: Flag = Flag {
+            key: 9,
+            name: "color",
+            longs: &["color"],
+            takes_value: true,
+            default_missing: Some(b"always"),
+            ..Flag::BOOL
+        };
+        static VERBOSE: Flag = Flag {
+            key: 10,
+            name: "verbose",
+            longs: &["verbose"],
+            ..Flag::BOOL
+        };
+        static MISSING: Command = Command {
+            name: "ex",
+            flags: &[&COLOR, &VERBOSE],
+            ..Command::EMPTY
+        };
+
+        let a = argv(["--color"]);
+        assert_eq!(
+            parse(&MISSING, &a).unwrap(),
+            vec![Event::Flag {
+                flag: &COLOR,
+                value: Some(b"always"),
+                negated: false
+            }]
+        );
+
+        let a = argv(["--color=never"]);
+        assert_eq!(
+            parse(&MISSING, &a).unwrap(),
+            vec![Event::Flag {
+                flag: &COLOR,
+                value: Some(b"never"),
+                negated: false
+            }]
+        );
+
+        let a = argv(["--color", "--verbose"]);
+        assert_eq!(
+            parse(&MISSING, &a).unwrap(),
+            vec![
+                Event::Flag {
+                    flag: &COLOR,
+                    value: Some(b"always"),
+                    negated: false
+                },
+                Event::Flag {
+                    flag: &VERBOSE,
+                    value: None,
+                    negated: false
+                },
+            ]
+        );
+
+        let a = argv(["--color="]);
+        assert_eq!(
+            parse(&MISSING, &a).unwrap(),
+            vec![Event::Flag {
+                flag: &COLOR,
+                value: Some(b""),
+                negated: false
+            }]
+        );
+    }
+
+    #[test]
+    fn default_missing_with_require_equals_leaves_the_following_word() {
+        static INSPECT: Flag = Flag {
+            key: 11,
+            name: "inspect",
+            longs: &["inspect"],
+            takes_value: true,
+            require_equals: true,
+            default_missing: Some(b"9229"),
+            ..Flag::BOOL
+        };
+        static BOTH: Command = Command {
+            name: "ex",
+            flags: &[&INSPECT],
+            args: &[&REST],
+            ..Command::EMPTY
+        };
+
+        let a = argv(["--inspect"]);
+        assert_eq!(
+            parse(&BOTH, &a).unwrap(),
+            vec![Event::Flag {
+                flag: &INSPECT,
+                value: Some(b"9229"),
+                negated: false
+            }]
+        );
+
+        let a = argv(["--inspect", "80"]);
+        assert_eq!(
+            parse(&BOTH, &a).unwrap(),
+            vec![
+                Event::Flag {
+                    flag: &INSPECT,
+                    value: Some(b"9229"),
+                    negated: false
+                },
+                Event::Arg {
+                    arg: &REST,
+                    value: b"80"
+                },
+            ]
+        );
+
+        let a = argv(["--inspect="]);
+        assert_eq!(
+            parse(&BOTH, &a).unwrap(),
+            vec![Event::Flag {
+                flag: &INSPECT,
+                value: Some(b""),
+                negated: false
+            }]
         );
     }
 

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -1797,7 +1797,7 @@ mod tests {
     };
 
     /// Collect every event, or the first error.
-    fn parse<'t, 'v>(
+    fn parse<'t: 'v, 'v>(
         root: &'t Command<'t>,
         argv: &'v [&'v OsStr],
     ) -> Result<Vec<Event<'t, 'v>>, Error<'t, 'v>> {

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -1186,6 +1186,13 @@ fn write_flag(out: &mut String, meta: &FlagMeta<'_>, depth: usize) -> core::fmt:
     if meta.flag.require_equals {
         out.push_str(" require_equals=#true");
     }
+    if let Some(missing) = meta.flag.default_missing {
+        write!(
+            out,
+            " default_missing={}",
+            quoted(::core::str::from_utf8(missing).unwrap_or_default())
+        )?;
+    }
     write_single_list(out, "requires", meta.requires)?;
     write_single_list(out, "required_if", meta.required_if)?;
     write_single_list(out, "required_unless", meta.required_unless)?;

--- a/conformance/src/tables.rs
+++ b/conformance/src/tables.rs
@@ -270,6 +270,7 @@ fn build_flag(f: &SpecFlag) -> &'static Flag<'static> {
             .map(|d| d as u8),
         allow_hyphen_values: f.allow_hyphen_values(),
         require_equals: f.require_equals,
+        default_missing: f.default_missing.as_deref().map(|s| leak(s).as_bytes()),
         global: f.global,
     }))
 }

--- a/conformance/tests/derive.rs
+++ b/conformance/tests/derive.rs
@@ -966,3 +966,35 @@ fn a_require_equals_flag_refuses_a_detached_value() {
         "the attribute has to reach the spec: {kdl}"
     );
 }
+
+/// clap's `default_missing_value`: `--color` binds a value, `--color=never` another.
+#[derive(Cli, Debug)]
+#[usage(bin = "color")]
+struct WithMissing {
+    #[usage(long, default_missing = "always")]
+    color: Option<String>,
+    #[usage(long)]
+    verbose: bool,
+}
+
+#[test]
+fn a_default_missing_flag_binds_when_the_value_is_left_off() {
+    let a = argv(["--color"]);
+    let got = WithMissing::parse_from(&a).expect("bare form");
+    assert_eq!(got.color.as_deref(), Some("always"));
+
+    let a = argv(["--color=never"]);
+    let got = WithMissing::parse_from(&a).expect("attached form");
+    assert_eq!(got.color.as_deref(), Some("never"));
+
+    let a = argv(["--color", "--verbose"]);
+    let got = WithMissing::parse_from(&a).expect("next token is a flag");
+    assert_eq!(got.color.as_deref(), Some("always"));
+    assert!(got.verbose);
+
+    let kdl = WithMissing::to_kdl();
+    assert!(
+        kdl.contains("default_missing="),
+        "the attribute has to reach the spec: {kdl}"
+    );
+}

--- a/conformance/tests/post_binding.rs
+++ b/conformance/tests/post_binding.rs
@@ -75,6 +75,36 @@ fn a_value_outside_the_choices_is_refused() {
     );
 }
 
+/// A missing default is a bound value, so `choices` has to accept it the same
+/// way it accepts `--color=always`.
+#[derive(Cli, Debug)]
+#[usage(bin = "color")]
+struct ColorWhen {
+    #[usage(long, default_missing = "always", choices("auto", "always", "never"))]
+    color: Option<String>,
+}
+
+#[test]
+fn a_default_missing_value_has_to_be_a_choice() {
+    let a = argv(["--color"]);
+    assert_eq!(
+        ColorWhen::parse_from(&a)
+            .expect("always is on the list")
+            .color
+            .as_deref(),
+        Some("always")
+    );
+
+    let a = argv(["--color=never"]);
+    assert_eq!(
+        ColorWhen::parse_from(&a)
+            .expect("an attached choice still binds")
+            .color
+            .as_deref(),
+        Some("never")
+    );
+}
+
 #[test]
 fn variadic_bounds_are_counted() {
     let a = argv(["--include", "a", "x"]);

--- a/corpus/01-long-flags.json
+++ b/corpus/01-long-flags.json
@@ -272,6 +272,41 @@
       "spec": "name \"ex\"\nbin \"ex\"\nflag \"--inspect <PORT>\" require_equals=#true\n",
       "argv": ["--inspect="],
       "expect": { "ok": { "flags": { "inspect": "" } } }
+    },
+    {
+      "id": "long-value-default-missing-bare",
+      "doc": "`default_missing` is the value when the flag is given with none: `--color` binds `always`. clap's `default_missing_value`.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--color <WHEN>\" default_missing=\"always\"\n",
+      "argv": ["--color"],
+      "expect": { "ok": { "flags": { "color": "always" } } }
+    },
+    {
+      "id": "long-value-default-missing-attached",
+      "doc": "An attached value still wins: `--color=never` is `never`, not the missing default.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--color <WHEN>\" default_missing=\"always\"\n",
+      "argv": ["--color=never"],
+      "expect": { "ok": { "flags": { "color": "never" } } }
+    },
+    {
+      "id": "long-value-default-missing-detached",
+      "doc": "Without `require_equals`, a following word is still the value: `--color never` binds `never`.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--color <WHEN>\" default_missing=\"always\"\n",
+      "argv": ["--color", "never"],
+      "expect": { "ok": { "flags": { "color": "never" } } }
+    },
+    {
+      "id": "long-value-default-missing-next-is-flag",
+      "doc": "A flag-like next token is not taken as the value, so `--color --verbose` colours with the missing default and still sets verbose.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--color <WHEN>\" default_missing=\"always\"\nflag \"--verbose\"\n",
+      "argv": ["--color", "--verbose"],
+      "expect": { "ok": { "flags": { "color": "always", "verbose": true } } }
+    },
+    {
+      "id": "long-value-default-missing-with-require-equals",
+      "doc": "Combined with `require_equals`, a following word is not the value: `--inspect 80` binds the missing default and leaves `80` for a positional.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--inspect <PORT>\" require_equals=#true default_missing=\"9229\"\narg \"[rest]\"\n",
+      "argv": ["--inspect", "80"],
+      "expect": { "ok": { "flags": { "inspect": "9229" }, "args": { "rest": "80" } } }
     }
   ]
 }

--- a/corpus/01-long-flags.json
+++ b/corpus/01-long-flags.json
@@ -306,7 +306,9 @@
       "doc": "Combined with `require_equals`, a following word is not the value: `--inspect 80` binds the missing default and leaves `80` for a positional.",
       "spec": "name \"ex\"\nbin \"ex\"\nflag \"--inspect <PORT>\" require_equals=#true default_missing=\"9229\"\narg \"[rest]\"\n",
       "argv": ["--inspect", "80"],
-      "expect": { "ok": { "flags": { "inspect": "9229" }, "args": { "rest": "80" } } }
+      "expect": {
+        "ok": { "flags": { "inspect": "9229" }, "args": { "rest": "80" } }
+      }
     }
   ]
 }

--- a/corpus/02-short-flags.json
+++ b/corpus/02-short-flags.json
@@ -211,6 +211,27 @@
       "spec": "name \"ex\"\nbin \"ex\"\nflag \"-i --inspect <PORT>\" require_equals=#true\n",
       "argv": ["-i", "9229"],
       "expect": { "error": "missing_flag_value" }
+    },
+    {
+      "id": "short-value-default-missing-bare",
+      "doc": "The short form of `default_missing`: `-c` with no following word binds the missing default.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-c --color <WHEN>\" default_missing=\"always\"\n",
+      "argv": ["-c"],
+      "expect": { "ok": { "flags": { "color": "always" } } }
+    },
+    {
+      "id": "short-value-default-missing-attached",
+      "doc": "A short's attached form still binds: `-cnever` is `never`.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-c --color <WHEN>\" default_missing=\"always\"\n",
+      "argv": ["-cnever"],
+      "expect": { "ok": { "flags": { "color": "never" } } }
+    },
+    {
+      "id": "short-value-default-missing-next-is-flag",
+      "doc": "`-c -v` colours with the missing default and still sets verbose.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"-c --color <WHEN>\" default_missing=\"always\"\nflag \"-v --verbose\"\n",
+      "argv": ["-c", "-v"],
+      "expect": { "ok": { "flags": { "color": "always", "verbose": true } } }
     }
   ]
 }

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -766,6 +766,10 @@ fn flag_table(i: usize, field: &Field) -> TokenStream {
     let table_delimiter = table_delimiter(field);
     let allow_hyphen_values = field.allow_hyphen_values;
     let require_equals = field.require_equals;
+    let default_missing = match field.default_missing.as_deref() {
+        Some(value) => quote!(::core::option::Option::Some(#value.as_bytes())),
+        None => quote!(::core::option::Option::None),
+    };
     quote! {
         pub static #name: usage_argv::Flag = usage_argv::Flag {
             key: #key,
@@ -779,6 +783,7 @@ fn flag_table(i: usize, field: &Field) -> TokenStream {
             delimiter: #table_delimiter,
             allow_hyphen_values: #allow_hyphen_values,
             require_equals: #require_equals,
+            default_missing: #default_missing,
             global: #global,
         };
     }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -220,6 +220,7 @@
 //! | `delimiter = ','` | one word becomes several values; the field has to be a `Vec` |
 //! | `allow_hyphen_values` | a flag's detached value may look like a flag, including `--` |
 //! | `require_equals` | `--flag=value` is accepted and `--flag value` is not |
+//! | `default_missing = "always"` | the value when the flag is given with none |
 //! | `required_if = "--other"` | a flag whose presence makes this one necessary |
 //! | `required_unless = "--other"` | a flag whose presence makes this one unnecessary |
 //!

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -1748,6 +1748,18 @@ impl Field {
                     ),
                 ));
             }
+            if let Some(missing) = default_missing
+                .as_ref()
+                .filter(|missing| !choices.contains(missing))
+            {
+                return Err(syn::Error::new(
+                    span,
+                    format!(
+                        "the default_missing `{missing}` is not one of this field's \
+                         choices, so it could never be valid"
+                    ),
+                ));
+            }
         }
 
         let is_flag = !longs.is_empty() || !shorts.is_empty();
@@ -3350,6 +3362,22 @@ mod tests {
         "#,
         );
         assert!(err.contains("the default `z`"), "unhelpful message: {err}");
+    }
+
+    #[test]
+    fn every_default_missing_has_to_be_one_of_the_choices() {
+        let err = rejection(
+            r#"
+            struct Ex {
+                #[usage(long, default_missing = "wat", choices("auto", "always", "never"))]
+                color: Option<String>,
+            }
+        "#,
+        );
+        assert!(
+            err.contains("the default_missing `wat`"),
+            "unhelpful message: {err}"
+        );
     }
 
     #[test]

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -220,6 +220,11 @@ pub struct Field {
     pub allow_hyphen_values: bool,
     /// Whether the value must be attached with `=`. clap's `require_equals`.
     pub require_equals: bool,
+    /// Value used when the flag is present but no value is given.
+    ///
+    /// clap's `default_missing_value`. `--color` binds this string; `--color=never`
+    /// binds `never`. The field has to take a value.
+    pub default_missing: Option<String>,
     /// Whether this flag must be given on its own — clap's `exclusive`.
     pub exclusive: bool,
     /// The group this flag belongs to, if any. Properties live on the group's own
@@ -1100,6 +1105,7 @@ impl Field {
             delimiter: None,
             allow_hyphen_values: false,
             require_equals: false,
+            default_missing: None,
             exclusive: false,
             group: None,
             required_if: Vec::new(),
@@ -1206,6 +1212,7 @@ impl Field {
             delimiter: None,
             allow_hyphen_values: false,
             require_equals: false,
+            default_missing: None,
             exclusive: false,
             group: None,
             required_if: Vec::new(),
@@ -1306,6 +1313,7 @@ impl Field {
             delimiter: None,
             allow_hyphen_values: false,
             require_equals: false,
+            default_missing: None,
             exclusive: false,
             group: None,
             required_if: Vec::new(),
@@ -1377,6 +1385,7 @@ impl Field {
         let mut delimiter: Option<char> = None;
         let mut allow_hyphen_values = false;
         let mut require_equals = false;
+        let mut default_missing = None;
         let mut required_if: Vec<String> = Vec::new();
         let mut required_unless: Vec<String> = Vec::new();
 
@@ -1475,6 +1484,7 @@ impl Field {
                     "exclusive" => exclusive = flag_value(&meta)?,
                     "allow_hyphen_values" => allow_hyphen_values = flag_value(&meta)?,
                     "require_equals" => require_equals = flag_value(&meta)?,
+                    "default_missing" => default_missing = Some(string_value(&meta)?),
                     "delimiter" => {
                         let c = char_value(&meta)?;
                         if !c.is_ascii() {
@@ -1533,6 +1543,7 @@ impl Field {
                                  `var_min`, `var_max`, `value_enum`, `value_hint`, `overrides`, \
                                  `conflicts`, `requires`, `group`, `exclusive`, \
                                  `delimiter`, `allow_hyphen_values`, `require_equals`, \
+                                 `default_missing`, \
                                  `required_if`, \
                                  `required_unless`, `help_heading`, `value_name`, \
                                  `verbatim_doc_comment`, \
@@ -2062,6 +2073,25 @@ impl Field {
             }
         }
 
+        if default_missing.is_some() {
+            if !matches!(kind, Kind::Flag { .. }) {
+                return Err(syn::Error::new(
+                    span,
+                    "`default_missing` is for a flag's value; a positional is filled \
+                     or it is not",
+                ));
+            }
+            if matches!(shape, Shape::Bool | Shape::Count) {
+                return Err(syn::Error::new(
+                    span,
+                    "`default_missing` is the value used when this flag is given \
+                     without one, and this flag takes none",
+                ));
+            }
+            // Help should show the value as optional: `--color` is a complete invocation.
+            value_optional = true;
+        }
+
         // `value_name` names the placeholder a *flag's value* gets in help — `--out <FILE>`.
         // A positional argument is named by `name`, and a `bool` or `count` flag has no value
         // to put a placeholder in, so `arg_meta` never emits it and a valueless flag has nowhere
@@ -2139,6 +2169,7 @@ impl Field {
             delimiter,
             allow_hyphen_values,
             require_equals,
+            default_missing,
             exclusive,
             group,
             required_if,
@@ -3909,6 +3940,39 @@ mod tests {
             r#"
             struct Ex {
                 #[usage(long, require_equals)]
+                force: bool,
+            }
+        "#,
+        );
+        assert!(err.contains("takes none"), "unhelpful message: {err}");
+    }
+
+    #[test]
+    fn default_missing_is_a_flag_that_takes_a_value() {
+        let cli = cli(r#"
+            struct Ex {
+                #[usage(long, default_missing = "always")]
+                color: Option<String>,
+            }
+        "#)
+        .expect("should compile");
+        assert_eq!(
+            cli.fields[0].default_missing.as_deref(),
+            Some("always"),
+            "the attribute has to reach the field the table is built from"
+        );
+        assert!(
+            cli.fields[0].value_optional,
+            "a flag that can be given without a value should show one as optional"
+        );
+    }
+
+    #[test]
+    fn default_missing_cannot_sit_on_a_switch() {
+        let err = rejection(
+            r#"
+            struct Ex {
+                #[usage(long, default_missing = "always")]
                 force: bool,
             }
         "#,

--- a/docs/rust/args-and-flags.md
+++ b/docs/rust/args-and-flags.md
@@ -76,6 +76,7 @@ jobs: Option<u32>,
 | `delimiter = ','`                       | Split one word into several values ([Validation](/rust/validation#delimiters))          |
 | `allow_hyphen_values`                   | Detached flag value may look like a flag, including `--`                                |
 | `require_equals`                        | Accept `--flag=value` and refuse `--flag value`                                         |
+| `default_missing = "…"`                 | Value when the flag is given with none (`--color` vs `--color=never`)                   |
 | `group = "name"`                        | Join a flag group ([Validation](/rust/validation#groups))                               |
 | `exclusive`                             | Must be given alone ([Validation](/rust/validation#exclusive-flags))                    |
 | `conflicts(…)` / `requires(…)`          | Relations to other flags ([Validation](/rust/validation))                               |
@@ -108,6 +109,12 @@ needs the same thing already has `double_dash = "automatic"`. Emitted KDL:
 `#[usage(require_equals)]` is clap's attribute of the same name: `--inspect=9229` binds
 and `--inspect 9229` is a missing value. The flag has to take a value. Emitted KDL:
 `flag "--inspect <PORT>" require_equals=#true`.
+
+`#[usage(default_missing = "always")]` is clap's `default_missing_value`: `--color`
+binds `always`, `--color=never` binds `never`, and an absent flag stays `None`.
+The flag has to take a value. Help shows the value as optional. Emitted KDL:
+`flag "--color <WHEN>" default_missing="always"`. Combined with `require_equals`,
+a following word is still refused.
 
 Flag relations (`conflicts`, `requires`, `overrides`, `required_if`, `required_unless`) name
 their target the way the KDL spec does — `"--long"` or `"-s"`, one value or a list:

--- a/docs/spec/argv.md
+++ b/docs/spec/argv.md
@@ -12,7 +12,7 @@ and the [conformance corpus](#the-conformance-corpus) makes it executable.
 
 ::: tip Both implementations answer every vector
 
-usage-lib and usage-argv agree with all 168 vectors today. That is a
+usage-lib and usage-argv agree with all 176 vectors today. That is a
 measurement, checked on every run rather than asserted here — see
 [Where the reference implementation differs](#where-the-reference-implementation-differs).
 
@@ -100,6 +100,13 @@ flag is not eaten as a value.
 A flag declared `require_equals` accepts only the attached form: `--inspect=9229`
 binds and `--inspect 9229` is a missing value. A short's attached form
 (`-i9229`, `-i=9229`) still binds.
+
+A flag declared `default_missing` binds that string when it is given with no
+value: `--color` is `always` if the spec says `default_missing="always"`. An
+attached or (unless `require_equals`) detached value still wins. A following
+flag-like token is not taken as the value, so `--color --verbose` colours with
+the missing default and still sets verbose. Combined with `require_equals`, a
+following word is a positional rather than the value.
 
 A flag needing a value that ends the command line is an error.
 
@@ -376,7 +383,7 @@ fails if a label is wrong in either direction. A recorded divergence that gets
 fixed shows up as a test failure telling you to delete the label, so the list
 cannot rot.
 
-**Today it does not: usage-lib agrees with all 168 vectors.** The list is empty
+**Today it does not: usage-lib agrees with all 176 vectors.** The list is empty
 for the first time, and the five entries it used to hold were what writing the
 grammar down was for. Each was a real defect that only a second reading found:
 

--- a/docs/spec/reference/flag.md
+++ b/docs/spec/reference/flag.md
@@ -39,6 +39,7 @@ flag "--dump" exclusive=#true            // --dump has to be given on its own
 flag "--tags <tag>" var=#true delimiter="," // --tags a,b,c is three values
 flag "--args <ARGS>" allow_hyphen_values=#true // --args -destroy binds "-destroy"
 flag "--inspect <PORT>" require_equals=#true   // --inspect=9229 yes, --inspect 9229 no
+flag "--color <WHEN>" default_missing="always" // --color is always; --color=never is never
 
 flag "--stdin" {
   conflicts "--file" "--url" // several, one per argument
@@ -175,6 +176,21 @@ A short's attached form still binds (`-i9229`, `-i=9229`); only the following
 word is refused. Combined with [`allow_hyphen_values`](#allow_hyphen_values),
 the attached form can still pass a dash-prefixed value (`--args=--force`);
 the detached form stays refused.
+
+A flag that takes no value cannot declare it.
+
+## `default_missing`
+
+The value used when the flag is given with none: `--color` binds `always` if the
+spec says `default_missing="always"`. `--color=never` and (unless
+[`require_equals`](#require_equals)) `--color never` still bind the word that was
+typed. A following flag-like token is not taken as the value.
+
+clap spells this `default_missing_value`. clap 4 has the setter and no getter, so
+a spec generated from a clap command never carries it — the same hole as
+[`requires`](#requires). A rewrite that declares in usage keeps it. Combined with
+`require_equals`, a following word is a positional rather than the value, which
+is aube's `--color` / `--inspect` shape.
 
 A flag that takes no value cannot declare it.
 

--- a/go/argv/argv.go
+++ b/go/argv/argv.go
@@ -132,6 +132,13 @@ type Flag struct {
 	// attached form (`-i9229`, `-i=9229`) still binds: only the following word
 	// is refused.
 	RequireEquals bool
+	// DefaultMissing is the value used when the flag is present but no value is
+	// given. Empty means unset: the flag then errors if a value is missing.
+	//
+	// clap's default_missing_value and the spec's default_missing. `--color`
+	// binds this, `--color=never` binds `never`, and an absent flag is not bound.
+	// Combined with RequireEquals, a following word is still refused.
+	DefaultMissing string
 	// Global is whether the flag is recognized by every command beneath the one
 	// that declares it.
 	Global bool

--- a/go/argv/parser.go
+++ b/go/argv/parser.go
@@ -402,17 +402,25 @@ func (p *Parser) shortFlag() bool {
 // word either way. The negative-number exception means `--offset -1` still works.
 func (p *Parser) takeDetachedValue(flag *Flag, long string, short byte) (string, bool) {
 	if flag.RequireEquals {
-		return p.missingValue(flag, long, short)
+		return p.missingOrDefault(flag, long, short)
 	}
 	if p.pos < len(p.argv) && (flag.AllowHyphenValues || !isFlagLike(p.argv[p.pos])) {
 		v := p.argv[p.pos]
 		p.pos++
 		return v, true
 	}
-	return p.missingValue(flag, long, short)
+	return p.missingOrDefault(flag, long, short)
 }
 
-func (p *Parser) missingValue(flag *Flag, long string, short byte) (string, bool) {
+// missingOrDefault is the value when a detached one is refused or absent.
+//
+// DefaultMissing binds without consuming the next token, so `--color --verbose`
+// still sets verbose and `--inspect 80` with RequireEquals leaves `80` for a
+// positional. Empty DefaultMissing is unset, and is then the missing-value error.
+func (p *Parser) missingOrDefault(flag *Flag, long string, short byte) (string, bool) {
+	if flag.DefaultMissing != "" {
+		return flag.DefaultMissing, true
+	}
 	// The form the user actually wrote, carried so the advice can use it. A flag
 	// answers to several spellings and the first is not always the one in front of
 	// them: with an inherited `--jobs --workers` whose `--jobs` a nearer command

--- a/go/argv/parser_test.go
+++ b/go/argv/parser_test.go
@@ -310,6 +310,32 @@ func TestDefaultMissing(t *testing.T) {
 	}
 }
 
+// Bind only: choices live in Check. A missing default that is not on the list
+// still binds, and Check is what refuses it — the same path as `--color=wat`.
+func TestDefaultMissingGoesThroughChoices(t *testing.T) {
+	color := &Flag{Key: 13, Name: "color", Longs: []string{"color"},
+		TakesValue: true, DefaultMissing: "always"}
+	cmd := &Command{Name: "ex", Flags: []*Flag{color}}
+	meta := &Meta{Name: "color", Flag: true, Choices: []string{"auto", "always", "never"}}
+
+	if got := collect(cmd, "--color"); got != "flag:color=always" {
+		t.Errorf("--color: got %s", got)
+	}
+	if err := Check(meta, []string{"always"}, 1); err != nil {
+		t.Errorf("always is a choice: %v", err)
+	}
+
+	bad := &Flag{Key: 14, Name: "color", Longs: []string{"color"},
+		TakesValue: true, DefaultMissing: "wat"}
+	if got := collect(&Command{Name: "ex", Flags: []*Flag{bad}}, "--color"); got != "flag:color=wat" {
+		t.Errorf("bind still happens: got %s", got)
+	}
+	err := Check(meta, []string{"wat"}, 1)
+	if err == nil || err.Code != CodeInvalidChoice {
+		t.Errorf("want invalid choice after bind, got %v", err)
+	}
+}
+
 func TestDefaultMissingWithRequireEquals(t *testing.T) {
 	inspect := &Flag{Key: 11, Name: "inspect", Longs: []string{"inspect"},
 		TakesValue: true, RequireEquals: true, DefaultMissing: "9229"}

--- a/go/argv/parser_test.go
+++ b/go/argv/parser_test.go
@@ -305,6 +305,9 @@ func TestDefaultMissing(t *testing.T) {
 	if got := collect(cmd, "-c"); got != "flag:color=always" {
 		t.Errorf("-c: got %s", got)
 	}
+	if got := collect(cmd, "-cnever"); got != "flag:color=never" {
+		t.Errorf("-cnever: got %s", got)
+	}
 }
 
 func TestDefaultMissingWithRequireEquals(t *testing.T) {

--- a/go/argv/parser_test.go
+++ b/go/argv/parser_test.go
@@ -281,6 +281,49 @@ func TestRequireEquals(t *testing.T) {
 	}
 }
 
+func TestDefaultMissing(t *testing.T) {
+	color := &Flag{Key: 9, Name: "color", Longs: []string{"color"}, Shorts: []byte{'c'},
+		TakesValue: true, DefaultMissing: "always"}
+	verbose := &Flag{Key: 10, Name: "verbose", Longs: []string{"verbose"}, Shorts: []byte{'v'}}
+	cmd := &Command{Name: "ex", Flags: []*Flag{color, verbose}}
+
+	if got := collect(cmd, "--color"); got != "flag:color=always" {
+		t.Errorf("--color: got %s", got)
+	}
+	if got := collect(cmd, "--color=never"); got != "flag:color=never" {
+		t.Errorf("--color=never: got %s", got)
+	}
+	if got := collect(cmd, "--color", "never"); got != "flag:color=never" {
+		t.Errorf("--color never: got %s", got)
+	}
+	if got := collect(cmd, "--color", "--verbose"); got != "flag:color=always flag:verbose" {
+		t.Errorf("--color --verbose: got %s", got)
+	}
+	if got := collect(cmd, "--color="); got != "flag:color=" {
+		t.Errorf("--color=: got %s", got)
+	}
+	if got := collect(cmd, "-c"); got != "flag:color=always" {
+		t.Errorf("-c: got %s", got)
+	}
+}
+
+func TestDefaultMissingWithRequireEquals(t *testing.T) {
+	inspect := &Flag{Key: 11, Name: "inspect", Longs: []string{"inspect"},
+		TakesValue: true, RequireEquals: true, DefaultMissing: "9229"}
+	rest := &Arg{Key: 12, Name: "rest"}
+	cmd := &Command{Name: "ex", Flags: []*Flag{inspect}, Args: []*Arg{rest}}
+
+	if got := collect(cmd, "--inspect"); got != "flag:inspect=9229" {
+		t.Errorf("--inspect: got %s", got)
+	}
+	if got := collect(cmd, "--inspect", "80"); got != "flag:inspect=9229 arg:rest=80" {
+		t.Errorf("--inspect 80: got %s", got)
+	}
+	if got := collect(cmd, "--inspect="); got != "flag:inspect=" {
+		t.Errorf("--inspect=: got %s", got)
+	}
+}
+
 func BenchmarkParse(b *testing.B) {
 	args := []string{"install", "--verbose", "-f", "a", "b", "c"}
 	b.ReportAllocs()

--- a/go/internal/spec/spec.go
+++ b/go/internal/spec/spec.go
@@ -209,7 +209,10 @@ type Flag struct {
 	RequiredUnless []string     `json:"required_unless"`
 	RequiresIf     []RequiresIf `json:"requires_if"`
 	RequireEquals  bool         `json:"require_equals"`
-	Arg            *Arg         `json:"arg"`
+	// Empty means unset: usage-lib stores Option, and a missing default of "" is
+	// not carried across the lowering. The corpus never uses one.
+	DefaultMissing string `json:"default_missing"`
+	Arg            *Arg   `json:"arg"`
 }
 
 // RequiresIf is one explicit value and the flag that value requires.
@@ -696,6 +699,7 @@ func (b *builder) flag(f *Flag) *argv.Flag {
 		// on the command, not here.
 		AllowHyphenValues: f.Arg != nil && strings.EqualFold(f.Arg.DoubleDash, "automatic"),
 		RequireEquals:     f.RequireEquals,
+		DefaultMissing:    f.DefaultMissing,
 		Global:            f.Global,
 	}
 	b.recordNegation(out.Key, f.Negate)

--- a/go/internal/spec/spec_test.go
+++ b/go/internal/spec/spec_test.go
@@ -516,3 +516,15 @@ func TestRequireEqualsCarries(t *testing.T) {
 		t.Error("require_equals should carry")
 	}
 }
+
+func TestDefaultMissingCarries(t *testing.T) {
+	root, _ := build(&Spec{
+		Name: "ex", Bin: "ex",
+		Cmd: Cmd{Name: "ex", Flags: []Flag{
+			{Name: "color", Long: []string{"color"}, DefaultMissing: "always", Arg: &Arg{Name: "WHEN"}},
+		}},
+	})
+	if root.Flags[0].DefaultMissing != "always" {
+		t.Errorf("default_missing: got %q", root.Flags[0].DefaultMissing)
+	}
+}

--- a/lib/src/go/mod.rs
+++ b/lib/src/go/mod.rs
@@ -1052,6 +1052,9 @@ fn flag_literal(flag: &SpecFlag, named: &Named) -> String {
     if flag.require_equals {
         fields.push("RequireEquals: true".to_string());
     }
+    if let Some(missing) = &flag.default_missing {
+        fields.push(format!("DefaultMissing: {}", go_string(missing)));
+    }
     if flag.global {
         fields.push("Global: true".to_string());
     }
@@ -1622,6 +1625,21 @@ flag "--inspect <PORT>" require_equals=#true
 "#);
         assert!(
             out.contains("Name: \"inspect\", Longs: []string{\"inspect\"}, TakesValue: true, RequireEquals: true"),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn default_missing_reaches_the_table() {
+        let out = go(r#"
+name "ex"
+bin "ex"
+flag "--color <WHEN>" default_missing="always"
+"#);
+        assert!(
+            out.contains(
+                "Name: \"color\", Longs: []string{\"color\"}, TakesValue: true, DefaultMissing: \"always\""
+            ),
             "{out}"
         );
     }

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -373,7 +373,7 @@ impl<'a> Parser<'a> {
         // half-typed `--jobs ` is exactly what a completion is asked about — but a
         // full parse has nothing left to wait for, and dropping the flag silently
         // made a forgotten value look like a working command.
-        while try_bind_default_missing(&mut out.flags, &mut out.flag_awaiting_value) {}
+        while try_bind_default_missing(&mut out.flags, &mut out.flag_awaiting_value, custom_env)? {}
         if let Some(flag) = out.flag_awaiting_value.first() {
             let token = flag
                 .long
@@ -915,7 +915,7 @@ fn parse_partial_with_env(
                     && (flag.require_equals || (is_flag_like(&w) && !flag.allow_hyphen_values()))
             })
         {
-            try_bind_default_missing(&mut out.flags, &mut out.flag_awaiting_value);
+            try_bind_default_missing(&mut out.flags, &mut out.flag_awaiting_value, custom_env)?;
         }
 
         // Only while flags are still being read. Once a `--` has done its job, a
@@ -2088,16 +2088,29 @@ fn value_count(value: &ParseValue) -> usize {
 /// half-typed `--color ` is a question about the value — so this is asked only
 /// once a full parse has decided the value is not coming, or once the next token
 /// has made that decision.
+///
+/// The missing string is a real value: if the flag names `choices`, it has to
+/// be one of them, the same way an env var or a `default` is checked. Binding
+/// first and failing later would leave the flag set to a value the spec forbids.
 fn try_bind_default_missing(
     flags: &mut IndexMap<Arc<SpecFlag>, ParseValue>,
     flag_awaiting_value: &mut Vec<Arc<SpecFlag>>,
-) -> bool {
+    custom_env: Option<&HashMap<String, String>>,
+) -> miette::Result<bool> {
     let Some(flag) = flag_awaiting_value.last() else {
-        return false;
+        return Ok(false);
     };
     let Some(value) = flag.default_missing.clone() else {
-        return false;
+        return Ok(false);
     };
+    if let Some(arg) = flag.arg.as_ref() {
+        validate_choice_value(
+            ChoiceTarget::option(flag),
+            &value,
+            arg.choices.as_ref(),
+            custom_env,
+        )?;
+    }
     let flag = flag_awaiting_value.pop().unwrap();
     let collecting = flag.var || flag.arg.as_ref().is_some_and(|arg| arg.var);
     if collecting {
@@ -2110,7 +2123,7 @@ fn try_bind_default_missing(
     } else {
         flags.insert(flag, ParseValue::String(value));
     }
-    true
+    Ok(true)
 }
 
 fn drain_pending_flag_values(
@@ -6220,6 +6233,61 @@ arg "[rest]"
 
         let parsed = parse(&spec, &input(&["test", "--inspect="])).unwrap();
         assert_eq!(flag_string_value(&parsed, "inspect"), "");
+    }
+
+    #[test]
+    fn test_default_missing_must_be_a_choice() {
+        let spec = r#"
+flag "--color <WHEN>" default_missing="always" {
+    choices "auto" "always" "never"
+}
+"#
+        .parse::<Spec>()
+        .unwrap();
+
+        let parsed = parse(&spec, &input(&["test", "--color"])).unwrap();
+        assert_eq!(flag_string_value(&parsed, "color"), "always");
+
+        let parsed = parse(&spec, &input(&["test", "--color=never"])).unwrap();
+        assert_eq!(flag_string_value(&parsed, "color"), "never");
+
+        let spec = r#"
+flag "--color <WHEN>" default_missing="wat" {
+    choices "auto" "always" "never"
+}
+"#
+        .parse::<Spec>()
+        .unwrap();
+
+        let err = parse(&spec, &input(&["test", "--color"])).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("Invalid choice for option color: wat"),
+            "missing default has to pass choices the same way a typed value does: {msg}"
+        );
+
+        let err = parse(&spec, &input(&["test", "--color=wat"])).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("Invalid choice for option color: wat"),
+            "an attached value that is not a choice is still refused: {msg}"
+        );
+
+        let spec = r#"
+flag "--inspect <PORT>" require_equals=#true default_missing="wat" {
+    choices "9229" "80"
+}
+arg "[rest]"
+"#
+        .parse::<Spec>()
+        .unwrap();
+
+        let err = parse(&spec, &input(&["test", "--inspect", "80"])).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("Invalid choice for option inspect: wat"),
+            "require_equals still binds the missing string, so the error is the choice: {msg}"
+        );
     }
 
     #[test]

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -846,7 +846,8 @@ fn parse_partial_with_env(
         let binding = prefix_bindings.pop_front().flatten();
         // A short's attached value is re-queued with `grouped_flag` set, and that
         // continuation is not a following word. `require_equals` refuses only the
-        // following word; `-i9229` and `-i=9229` still bind.
+        // following word; `-i9229` and `-i=9229` still bind. `default_missing` binds
+        // only when the value is actually missing, so `-cnever` is still `never`.
         let attached_continuation = grouped_flag;
 
         // Check for restart_token - resets argument parsing for multiple command invocations
@@ -907,6 +908,7 @@ fn parse_partial_with_env(
         // and `--inspect 9229` with `require_equals` binds the missing value rather
         // than treating 9229 as the port.
         if enable_flags
+            && !attached_continuation
             && !out.flag_awaiting_value.is_empty()
             && out.flag_awaiting_value.last().is_some_and(|flag| {
                 flag.default_missing.is_some()
@@ -6158,8 +6160,8 @@ flag "-i --inspect <PORT>" require_equals=#true
     #[test]
     fn test_default_missing_binds_when_the_value_is_left_off() {
         let spec = r#"
-flag "--color <WHEN>" default_missing="always"
-flag "--verbose"
+flag "-c --color <WHEN>" default_missing="always"
+flag "-v --verbose"
 "#
         .parse::<Spec>()
         .unwrap();
@@ -6179,6 +6181,13 @@ flag "--verbose"
 
         let parsed = parse(&spec, &input(&["test", "--color="])).unwrap();
         assert_eq!(flag_string_value(&parsed, "color"), "");
+
+        let parsed = parse(&spec, &input(&["test", "-cnever"])).unwrap();
+        assert_eq!(flag_string_value(&parsed, "color"), "never");
+
+        let parsed = parse(&spec, &input(&["test", "-c", "-v"])).unwrap();
+        assert_eq!(flag_string_value(&parsed, "color"), "always");
+        assert!(parsed.flags.keys().any(|f| f.name == "verbose"));
     }
 
     #[test]

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -373,6 +373,7 @@ impl<'a> Parser<'a> {
         // half-typed `--jobs ` is exactly what a completion is asked about — but a
         // full parse has nothing left to wait for, and dropping the flag silently
         // made a forgotten value look like a working command.
+        while try_bind_default_missing(&mut out.flags, &mut out.flag_awaiting_value) {}
         if let Some(flag) = out.flag_awaiting_value.first() {
             let token = flag
                 .long
@@ -898,6 +899,21 @@ fn parse_partial_with_env(
                 return Ok((out, overridden_flags));
             }
             continue;
+        }
+
+        // A flag with `default_missing` that cannot take this token as a detached
+        // value binds that string and leaves the token for whatever comes next:
+        // `--color --verbose` colours with the missing value and still sets verbose,
+        // and `--inspect 9229` with `require_equals` binds the missing value rather
+        // than treating 9229 as the port.
+        if enable_flags
+            && !out.flag_awaiting_value.is_empty()
+            && out.flag_awaiting_value.last().is_some_and(|flag| {
+                flag.default_missing.is_some()
+                    && (flag.require_equals || (is_flag_like(&w) && !flag.allow_hyphen_values()))
+            })
+        {
+            try_bind_default_missing(&mut out.flags, &mut out.flag_awaiting_value);
         }
 
         // Only while flags are still being read. Once a `--` has done its job, a
@@ -2062,6 +2078,37 @@ fn value_count(value: &ParseValue) -> usize {
         ParseValue::MultiBool(values) => values.len(),
         _ => 1,
     }
+}
+
+/// Bind [`SpecFlag::default_missing`] to a flag that was given with no value.
+///
+/// Returns whether anything was bound. Completions keep the flag waiting — a
+/// half-typed `--color ` is a question about the value — so this is asked only
+/// once a full parse has decided the value is not coming, or once the next token
+/// has made that decision.
+fn try_bind_default_missing(
+    flags: &mut IndexMap<Arc<SpecFlag>, ParseValue>,
+    flag_awaiting_value: &mut Vec<Arc<SpecFlag>>,
+) -> bool {
+    let Some(flag) = flag_awaiting_value.last() else {
+        return false;
+    };
+    let Some(value) = flag.default_missing.clone() else {
+        return false;
+    };
+    let flag = flag_awaiting_value.pop().unwrap();
+    let collecting = flag.var || flag.arg.as_ref().is_some_and(|arg| arg.var);
+    if collecting {
+        let arr = flags
+            .entry(flag)
+            .or_insert_with(|| ParseValue::MultiString(vec![]))
+            .try_as_multi_string_mut()
+            .unwrap();
+        arr.push(value);
+    } else {
+        flags.insert(flag, ParseValue::String(value));
+    }
+    true
 }
 
 fn drain_pending_flag_values(
@@ -6106,6 +6153,64 @@ flag "-i --inspect <PORT>" require_equals=#true
             msg.contains("requires an argument") || msg.contains("inspect"),
             "bundled short must refuse the following word: {msg}"
         );
+    }
+
+    #[test]
+    fn test_default_missing_binds_when_the_value_is_left_off() {
+        let spec = r#"
+flag "--color <WHEN>" default_missing="always"
+flag "--verbose"
+"#
+        .parse::<Spec>()
+        .unwrap();
+
+        let parsed = parse(&spec, &input(&["test", "--color"])).unwrap();
+        assert_eq!(flag_string_value(&parsed, "color"), "always");
+
+        let parsed = parse(&spec, &input(&["test", "--color=never"])).unwrap();
+        assert_eq!(flag_string_value(&parsed, "color"), "never");
+
+        let parsed = parse(&spec, &input(&["test", "--color", "never"])).unwrap();
+        assert_eq!(flag_string_value(&parsed, "color"), "never");
+
+        let parsed = parse(&spec, &input(&["test", "--color", "--verbose"])).unwrap();
+        assert_eq!(flag_string_value(&parsed, "color"), "always");
+        assert!(parsed.flags.keys().any(|f| f.name == "verbose"));
+
+        let parsed = parse(&spec, &input(&["test", "--color="])).unwrap();
+        assert_eq!(flag_string_value(&parsed, "color"), "");
+    }
+
+    #[test]
+    fn test_default_missing_with_require_equals_refuses_the_following_word() {
+        let spec = r#"
+flag "--inspect <PORT>" require_equals=#true default_missing="9229"
+arg "[rest]"
+"#
+        .parse::<Spec>()
+        .unwrap();
+
+        let parsed = parse(&spec, &input(&["test", "--inspect"])).unwrap();
+        assert_eq!(flag_string_value(&parsed, "inspect"), "9229");
+
+        let parsed = parse(&spec, &input(&["test", "--inspect=1234"])).unwrap();
+        assert_eq!(flag_string_value(&parsed, "inspect"), "1234");
+
+        // The following word is not the value; the missing value is, and 80 is a positional.
+        let parsed = parse(&spec, &input(&["test", "--inspect", "80"])).unwrap();
+        assert_eq!(flag_string_value(&parsed, "inspect"), "9229");
+        assert_eq!(
+            parsed
+                .args
+                .values()
+                .next()
+                .map(|v| v.to_string())
+                .as_deref(),
+            Some("80")
+        );
+
+        let parsed = parse(&spec, &input(&["test", "--inspect="])).unwrap();
+        assert_eq!(flag_string_value(&parsed, "inspect"), "");
     }
 
     #[test]

--- a/lib/src/spec/builder.rs
+++ b/lib/src/spec/builder.rs
@@ -352,6 +352,11 @@ impl SpecFlagBuilder {
                 arg.double_dash = crate::spec::arg::SpecDoubleDashChoices::Automatic;
             }
         }
+        if self.inner.default_missing.is_some() {
+            if let Some(arg) = &mut self.inner.arg {
+                arg.required = false;
+            }
+        }
         self.inner.usage = self.inner.usage();
         if self.inner.name.is_empty() {
             // Derive name from long or short flags

--- a/lib/src/spec/builder.rs
+++ b/lib/src/spec/builder.rs
@@ -220,6 +220,12 @@ impl SpecFlagBuilder {
         self
     }
 
+    /// Value used when the flag is present but no value is given.
+    pub fn default_missing(mut self, value: impl Into<String>) -> Self {
+        self.inner.default_missing = Some(value.into());
+        self
+    }
+
     /// Set the argument spec for flags that take values
     pub fn arg(mut self, arg: SpecArg) -> Self {
         self.inner.arg = Some(arg);

--- a/lib/src/spec/flag.rs
+++ b/lib/src/spec/flag.rs
@@ -148,6 +148,17 @@ pub struct SpecFlag {
     /// is the fleet case.
     #[serde(skip_serializing_if = "is_false")]
     pub require_equals: bool,
+    /// Value used when the flag is present but no value is given.
+    ///
+    /// clap's `default_missing_value`: `--color` binds this string, `--color=never`
+    /// binds `never`, and an absent flag stays absent (or takes [`Self::default`]).
+    /// Combined with [`Self::require_equals`], a following word is still refused
+    /// (`--inspect 9229`) while a bare `--inspect` binds this.
+    ///
+    /// clap 4 exposes this as a setter with no getter, so a spec generated from a
+    /// clap command never carries it — same hole as [`Self::requires`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_missing: Option<String>,
     /// Raises the effect of the command when this flag is supplied.
     /// See [`crate::spec::effect::SpecCommandEffect`]; never lowers it.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -212,6 +223,7 @@ impl SpecFlag {
                 "requires" => flag.requires = vec![v.ensure_string()?],
                 "exclusive" => flag.exclusive = v.ensure_bool()?,
                 "require_equals" => flag.require_equals = v.ensure_bool()?,
+                "default_missing" => flag.default_missing = Some(v.ensure_string()?),
                 // Written on the flag and kept on its argument, as `allow_hyphen_values`
                 // is: the value is what gets split, and `flag "--tags <tag>"` is where a
                 // reader writes something about that value.
@@ -325,6 +337,9 @@ impl SpecFlag {
                 }
                 "exclusive" => flag.exclusive = child.arg(0)?.ensure_bool()?,
                 "require_equals" => flag.require_equals = child.arg(0)?.ensure_bool()?,
+                "default_missing" => {
+                    flag.default_missing = Some(child.arg(0)?.ensure_string()?);
+                }
                 "requires" => {
                     flag.requires = child
                         .ensure_arg_len(1..)?
@@ -361,6 +376,13 @@ impl SpecFlag {
                 ctx,
                 node.node.name().span(),
                 "flag must have value to require equals"
+            );
+        }
+        if flag.default_missing.is_some() && flag.arg.is_none() {
+            bail_parse!(
+                ctx,
+                node.node.name().span(),
+                "flag must have value to have a default when missing"
             );
         }
         if let Some(raw) = delimiter {
@@ -562,6 +584,9 @@ impl From<&SpecFlag> for KdlNode {
         if flag.require_equals {
             node.push(KdlEntry::new_prop("require_equals", true));
         }
+        if let Some(missing) = &flag.default_missing {
+            node.push(string_entry(Some("default_missing"), missing));
+        }
         if let Some(env) = &flag.env {
             node.push(string_entry(Some("env"), env));
         }
@@ -761,6 +786,8 @@ impl From<&clap::Arg> for SpecFlag {
             // This one clap does expose, unlike `requires` just above.
             exclusive: c.is_exclusive_set(),
             require_equals: c.is_require_equals_set(),
+            // clap 4 has `Arg::default_missing_value` as a setter with no getter.
+            default_missing: None,
             help,
             help_long,
             help_md: None,
@@ -987,6 +1014,37 @@ mod tests {
         let spec = Spec::from(&cmd);
         let inspect = spec.cmd.flags.iter().find(|f| f.name == "inspect").unwrap();
         assert!(inspect.require_equals);
+    }
+
+    #[test]
+    fn default_missing_round_trips_and_cannot_come_across_from_clap() {
+        let spec: Spec = "flag \"--color <WHEN>\" default_missing=\"always\"\n"
+            .parse()
+            .unwrap();
+        assert_eq!(spec.cmd.flags[0].default_missing.as_deref(), Some("always"));
+
+        let reparsed: Spec = spec.to_string().parse().unwrap();
+        assert_eq!(
+            reparsed.cmd.flags[0].default_missing.as_deref(),
+            Some("always"),
+            "{spec}"
+        );
+
+        // Same hole as `requires`: clap 4 has the setter and keeps the field private.
+        let cmd = clap::Command::new("ex").arg(
+            clap::Arg::new("color")
+                .long("color")
+                .action(clap::ArgAction::Set)
+                .num_args(0..=1)
+                .default_missing_value("always"),
+        );
+        let spec = Spec::from(&cmd);
+        let color = spec.cmd.flags.iter().find(|f| f.name == "color").unwrap();
+        assert!(
+            color.default_missing.is_none(),
+            "clap exposes no getter for `default_missing_value`; if this now fails, \
+             the bridge can carry it and `SpecFlag::default_missing` should say so"
+        );
     }
 
     #[test]

--- a/lib/src/spec/flag.rs
+++ b/lib/src/spec/flag.rs
@@ -385,6 +385,13 @@ impl SpecFlag {
                 "flag must have value to have a default when missing"
             );
         }
+        // `--color` is a complete invocation, so help shows the value as optional.
+        // The same folding a nested `default` already does for `required`.
+        if flag.default_missing.is_some() {
+            if let Some(arg) = flag.arg.as_mut() {
+                arg.required = false;
+            }
+        }
         if let Some(raw) = delimiter {
             let mut chars = raw.chars();
             let Some(delimiter) = chars.next().filter(|_| chars.next().is_none()) else {
@@ -1022,6 +1029,16 @@ mod tests {
             .parse()
             .unwrap();
         assert_eq!(spec.cmd.flags[0].default_missing.as_deref(), Some("always"));
+        assert!(
+            !spec.cmd.flags[0].arg.as_ref().unwrap().required,
+            "a missing value is optional, so help should not demand it"
+        );
+        assert!(
+            spec.cmd.flags[0].usage.contains("[WHEN]")
+                && !spec.cmd.flags[0].usage.contains("<WHEN>"),
+            "help should show an optional value: {}",
+            spec.cmd.flags[0].usage
+        );
 
         let reparsed: Spec = spec.to_string().parse().unwrap();
         assert_eq!(

--- a/xtask/src/shadow.rs
+++ b/xtask/src/shadow.rs
@@ -864,6 +864,9 @@ fn usage_flag_opts(
     if flag.require_equals {
         opts.push("require_equals".into());
     }
+    if let Some(missing) = &flag.default_missing {
+        opts.push(format!("default_missing = {missing:?}"));
+    }
     if let Some(effect) = flag.effect {
         opts.push(format!("effect = {:?}", effect.as_str()));
     }
@@ -999,6 +1002,12 @@ fn clap_flag_opts(
     if flag.require_equals {
         opts.push("require_equals = true".into());
     }
+    if let Some(missing) = &flag.default_missing {
+        // clap's setter exists even though the getter does not, so the clap shadow
+        // can say this even though a spec regenerated from clap would drop it.
+        opts.push("num_args = 0..=1".into());
+        opts.push(format!("default_missing_value = {missing:?}"));
+    }
     if flag.effect.is_some() {
         skipped.note("`effect` on a flag");
     }
@@ -1071,15 +1080,19 @@ fn clap_flag_opts(
                 None => opts.push(format!("num_args = {least}..")),
             }
         } else if !arg.required {
-            // Noted, not emitted. `num_args = 0..=1` was the obvious translation and it is the
-            // wrong one: `value_optional` is help-only — usage-lib's parser refuses a bare
-            // `--bump` exactly as it refuses a bare `--port` — so declaring it in clap would
-            // make the clap shadow accept a line the usage shadow rejects, and the pair exists
-            // to be one grammar told to two frameworks.
-            //
-            // A real limitation, then, rather than a gap in this file: clap cannot print
-            // `[BUMP]` without also accepting `--bump` on its own.
-            skipped.note("a flag's value being optional in help only");
+            if flag.default_missing.is_some() {
+                // Already written as `num_args = 0..=1` beside `default_missing_value`.
+            } else {
+                // Noted, not emitted. `num_args = 0..=1` was the obvious translation and it is the
+                // wrong one: `value_optional` is help-only — usage-lib's parser refuses a bare
+                // `--bump` exactly as it refuses a bare `--port` — so declaring it in clap would
+                // make the clap shadow accept a line the usage shadow rejects, and the pair exists
+                // to be one grammar told to two frameworks.
+                //
+                // A real limitation, then, rather than a gap in this file: clap cannot print
+                // `[BUMP]` without also accepting `--bump` on its own.
+                skipped.note("a flag's value being optional in help only");
+            }
         }
         if flag.required {
             opts.push("required = true".into());
@@ -1222,6 +1235,9 @@ fn argh_flag_opts(flag: &SpecFlag, long: Option<&str>, skipped: &mut Skipped) ->
     if !flag.conflicts.is_empty() || !flag.requires.is_empty() {
         skipped.note("a relationship between flags");
     }
+    if flag.default_missing.is_some() {
+        skipped.note("`default_missing` on a flag");
+    }
     if flag.effect.is_some() {
         skipped.note("`effect` on a flag");
     }
@@ -1277,6 +1293,9 @@ fn bpaf_flag_opts(flag: &SpecFlag, long: Option<&str>, skipped: &mut Skipped) ->
     }
     if !flag.conflicts.is_empty() || !flag.requires.is_empty() {
         skipped.note("a relationship between flags");
+    }
+    if flag.default_missing.is_some() {
+        skipped.note("`default_missing` on a flag");
     }
     if flag.effect.is_some() {
         skipped.note("`effect` on a flag");
@@ -2143,6 +2162,24 @@ mod tests {
         let (clap, skipped) = rendered_as(spec, Dialect::Clap);
         assert_eq!(skipped.counts.get("`effect` on a flag"), Some(&1));
         assert!(!clap.contains("effect"), "{clap}");
+    }
+
+    #[test]
+    fn the_usage_dialect_carries_default_missing() {
+        let spec = "name \"ex\"\nbin \"ex\"\nflag \"--color <WHEN>\" default_missing=\"always\"\n";
+        let (out, skipped) = rendered_as(spec, Dialect::Usage);
+        assert!(out.contains(r#"default_missing = "always""#), "{out}");
+        assert!(
+            !skipped.counts.contains_key("`default_missing` on a flag"),
+            "expressible, so it should not be counted as dropped"
+        );
+
+        let (clap, _) = rendered_as(spec, Dialect::Clap);
+        assert!(
+            clap.contains(r#"default_missing_value = "always""#),
+            "{clap}"
+        );
+        assert!(clap.contains("num_args = 0..=1"), "{clap}");
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacked on #1014.

clap's `default_missing_value`: `--color` binds a value when none is given, `--color=never` still binds `never`, and an absent flag stays absent. Spec `default_missing="always"`, usage-lib, usage-argv (`Flag::default_missing`), `#[usage(default_missing = "always")]`, and the Go parser. Combined with `require_equals`, a following word is a positional rather than the value. A short's attached form (`-cnever`) still binds.

The missing string is a real value: if the flag names `choices`, it has to be one of them, the same way an env var or a `default` is checked. Binding first and failing later would leave the flag set to a value the spec forbids. Derive refuses a `default_missing` that is not a choice at compile time, matching `default`. usage-argv still only binds; Check is what refuses the bound string.

clap 4 has the setter and no getter, so a spec generated from a clap command never carries it — same hole as `requires`. A rewrite that declares in usage keeps it. Help shows the value as optional.

Go also learns `allow_hyphen_values` and `require_equals` so the corpus stays green through this stack.

_This comment was generated by Claude Code._
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4de7e59e-aa2e-4ad0-a1d0-1c2e69c166db?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4de7e59e-aa2e-4ad0-a1d0-1c2e69c166db&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

