### PR TITLE
chore(ci): time out every job instead of waiting six hours

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -15,6 +15,7 @@ jobs:
   merge:
     if: github.repository == 'jdx/usage'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,6 +17,7 @@ env:
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:
@@ -30,6 +31,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@4c7e9f3bb4ca35f54341be8fc8d3608f71e4d24e # zizmor: ignore[impostor-commit] cargo-llvm-cov (tag-only ref by design)
       - name: Install shells for completion integration tests
+        timeout-minutes: 3
         run: |
           sudo apt-get update
           sudo apt-get install -y zsh fish

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,7 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
     steps:
@@ -55,6 +56,7 @@ jobs:
       id-token: write # to verify the deployment originates from an appropriate source
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     name: Deploy
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -66,6 +66,7 @@ jobs:
           MISE_LOCKED: "1"
 
       - name: Install valgrind
+        timeout-minutes: 3
         run: |
           command -v valgrind || {
             sudo apt-get update

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -57,6 +57,7 @@ jobs:
       # 4-20%. Without it tak still records timing, but the series stops being
       # precise enough to detect anything.
       - name: Install valgrind
+        timeout-minutes: 3
         run: |
           command -v valgrind || {
             sudo apt-get update

--- a/.github/workflows/pr-closer.yml
+++ b/.github/workflows/pr-closer.yml
@@ -12,6 +12,7 @@ concurrency:
 jobs:
   pr-closer:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -20,6 +20,7 @@ env:
 jobs:
   create-release:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
     steps:
@@ -87,6 +88,7 @@ jobs:
             os: windows-latest
             build-tool: cargo
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
     permissions:
       contents: write
     steps:
@@ -122,6 +124,7 @@ jobs:
           CARGO_PROFILE_RELEASE_LTO: true
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [build-and-publish]
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     permissions:
@@ -138,6 +141,7 @@ jobs:
         if: ${{ github.event_name != 'workflow_dispatch' }}
   enhance-release:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: [release]
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     permissions:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -22,6 +22,7 @@ concurrency:
 jobs:
   release-plz:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # Without this, a hung step sits until GitHub's 6-hour job limit.
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:
@@ -29,6 +31,7 @@ jobs:
           shared-key: test
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
       - name: Install shells for completion integration tests
+        timeout-minutes: 3
         run: |
           sudo apt-get update
           sudo apt-get install -y zsh fish
@@ -82,6 +85,7 @@ jobs:
   # compiles, and holding them to the MSRV would pin the toolchain past what the library needs.
   msrv:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -10,6 +10,7 @@ permissions: {}
 jobs:
   zizmor:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
GitHub’s default job timeout is six hours. A hung `apt-get` has already sat that long on `test` and `coverage`. Most other jobs had no cap at all.

Every job now times out well above a healthy run. `apt-get` / snap install steps (zsh/fish, valgrind) time out at 3 minutes.

| job | timeout |
| --- | ---: |
| `test` / `coverage` | 30m |
| `msrv` | 15m |
| `zizmor`, `pr-closer`, `auto-merge-release`, `docs` deploy, `publish-cli` release | 10m |
| `docs` build, `publish-cli` enhance-release | 20m |
| `release-plz`, `perf` measure | 30m |
| `publish-cli` build-and-publish (cross), `perf-pr` measure | 40m |
| `perf-pr` report | 10m (already set) |
| `publish-cli` create-release | 15m |

`aube-lock` is a reusable workflow call. GitHub does not allow `timeout-minutes` on the caller; a cap would have to live in `jdx/renovate-config`.

This overlaps the `test`/`coverage` caps already on the jdx-readiness stack. Those PRs can drop their copies once this lands, or this can wait until they do — the values match.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4de7e59e-aa2e-4ad0-a1d0-1c2e69c166db?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4de7e59e-aa2e-4ad0-a1d0-1c2e69c166db&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added execution time limits across automated testing, coverage, performance checks, documentation builds, releases, and publishing workflows.
  * Added shorter time limits for dependency installation steps used by integration and performance checks.
  * Helps prevent stalled automation and improves workflow reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->