### PR TITLE
docs(parse): record repeated separator behavior

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -743,10 +743,10 @@ including telling you to delete the label afterwards.
       not `parse_partial`, since a half-typed flag is exactly what a completion is
       asked about.
 - [x] `=` is kept in attached short values, so `-j=8` binds `=8`.
-- [ ] A repeated `--` is eaten, so a forwarded command line containing its own
-      separator is altered in transit. **Needs a decision**: an existing test
-      asserts this, and `double_dash="preserve"` is the declared way to keep
-      separators, which may make it intentional.
+- [x] A repeated `--` was eaten, altering a forwarded command line containing
+      its own separator. Only the first `--` is parser syntax; later separators
+      are data and are preserved. `double_dash="preserve"` has the narrower role
+      of preserving the first separator too. Fixed in #809.
 - [x] `--jobs=` binds nothing rather than the empty string.
 - [x] A flag with a variadic argument rejects its second value, though
       [the flag reference](https://usage.jdx.dev/spec/reference/flag) documents the


### PR DESCRIPTION
## Summary

- mark the repeated `--` parser audit item complete
- document that only the first separator is consumed
- clarify that `double_dash="preserve"` preserves the first separator too

## Why

The plan entry still described repeated separators as an unresolved decision, but #809 already fixed the behavior and added coverage. This keeps the plan aligned with the parser contract and avoids suggesting that forwarded command lines are still altered in transit.

## Impact

Documentation only; parser behavior is unchanged.

## Validation

- `git diff --check`

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update to PLAN.md; no runtime or parser behavior changes.
> 
> **Overview**
> Updates **PLAN.md** so the repeated `--` audit item matches shipped parser behavior (**#809**), not an open decision.
> 
> The **Known usage-lib divergences** entry is marked complete and now states that only the first `--` is syntax; any later `--` stays in forwarded argv. It also narrows **`double_dash="preserve"`** to meaning the first separator is kept as data, not “handle all separators.”
> 
> Docs only — no code or parser changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23ca586a5ac4105b01dfc4988bf88a456cd925b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of repeated `--` separators.
  * Preserves subsequent separators as forwarded data while retaining the first separator when configured to do so.
* **Documentation**
  * Updated the documented behavior to reflect the corrected separator handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->