### PR TITLE
docs(parse): update fleet grammar gate

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -628,12 +628,11 @@ that declares in usage keeps them. `#[usage(skip)]` is a compile-time field, not
 a command-line shape. Trailing argv is already `double_dash=automatic` in every
 fleet spec that has one.
 
-- [ ] **Grammar decisions that would change mise at run time**, not just at
+- [ ] **The grammar decision that would change mise at run time**, not just at
       completion time. Unrecognized flags falling through to positionals is how
       mise parses task arguments; tightening it is a behaviour change to every
-      `mise run`. A repeated `--` being eaten is the other. Both are marked
-      _needs a decision_ under **Known usage-lib divergences**. They should be
-      decided before a rewrite, not discovered by it.
+      `mise run`. Decide that before a rewrite, rather than discovering it in
+      one. Repeated `--` handling was settled and fixed in #809.
 
 **Not on this list, on purpose.** Config is a second project: the four CLIs
 would keep their generated `Settings` through an argv-only move. Mounts are
@@ -705,8 +704,8 @@ Checked against mise rather than assumed, and two of them do not survive contact
 ## Known usage-lib divergences
 
 **The corpus records none today**: usage-lib answers all 154 vectors, and so do
-usage-argv and the Go runner. What is left below is the history, plus the two
-items marked _needs a decision_ — which are not divergences but questions about
+usage-argv and the Go runner. What is left below is the history, plus the one
+item marked _needs a decision_ — which is not a divergence but a question about
 what the grammar should say.
 
 They were bugs to fix or decisions to revisit, not settled behavior. Each was a


### PR DESCRIPTION
## Summary

- remove the settled repeated-`--` question from the fleet grammar gate
- retain unknown-flag handling as the one remaining runtime grammar decision
- point to #809 for the resolved separator behavior

## Why

#1019 updated the detailed divergence entry, but the fleet-readiness section still described repeated separators as unresolved. This follow-up keeps both sections consistent.

## Impact

Documentation only; parser behavior is unchanged.

## Validation

- `git diff --check`

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to `PLAN.md`; no parser or runtime code changes.
> 
> **Overview**
> **`PLAN.md` only** — brings the **Trying the fleet** grammar checklist in line with **Known usage-lib divergences** after #809.
> 
> The gate no longer treats repeated `--` as an unresolved runtime grammar question. It now calls out **unrecognized flags falling through to positionals** as the single decision that would change `mise run` at run time, and points to **#809** for repeated-separator behavior. Wording shifts from “two items marked _needs a decision_” to **one**, matching the checked-off repeated-`--` entry elsewhere in the doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aa5658524f3ca2066215c66c9a0ec13737d03ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the fleet adoption checklist to clarify the remaining grammar decision for unrecognized flags.
  * Removed the already-resolved `--` handling item from the pending decisions.
  * Revised the divergence history to reflect one remaining decision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->