### PR TITLE
feat(spec): forward unmatched words as an external subcommand

### DIFF
--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -2232,6 +2232,13 @@ mod tests {
             parse(&CATCH, &a),
             Err(Error::UnknownFlag { token: b"--wat" })
         );
+
+        // A negative number is a value, not a flag, so it can be the unmatched word.
+        let a = argv(["-1", "rest"]);
+        assert_eq!(
+            parse(&CATCH, &a).unwrap(),
+            vec![Event::External { values: &a[..] }]
+        );
     }
 
     #[test]

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -168,6 +168,13 @@ pub struct Command<'a> {
     /// Resolve it with [`find_subcommand`], which turns a name that no subcommand answers to
     /// into a compile error.
     pub default_subcommand: ::core::option::Option<&'a Command<'a>>,
+    /// Whether an unmatched word is forwarded as an external command plus the rest of argv.
+    ///
+    /// clap's `allow_external_subcommands`. Known subcommands still win; a
+    /// [`default_subcommand`](Self::default_subcommand) still catches first. Once the
+    /// unmatched word is taken, remaining tokens — including `--help` — are not parsed
+    /// as this command's flags.
+    pub external_subcommand: bool,
     /// What an unrecognized flag-like token means here, or `None` to keep whatever the
     /// enclosing command said. See [`UnknownFlags`].
     ///
@@ -208,6 +215,7 @@ impl Command<'_> {
         args: &[],
         subcommands: &[],
         default_subcommand: ::core::option::Option::None,
+        external_subcommand: false,
         unknown_flags: ::core::option::Option::None,
         version: false,
         key: 0,
@@ -411,6 +419,9 @@ pub enum Event<'t, 'v> {
     /// A word was bound to a positional argument. A variadic argument produces
     /// one event per value.
     Arg { arg: &'t Arg<'t>, value: &'v [u8] },
+    /// An unmatched word was forwarded as an external command: the name, then
+    /// every remaining token, including flags.
+    External { values: &'v [&'v OsStr] },
 }
 
 /// A binding failure.
@@ -1462,6 +1473,21 @@ impl<'t: 'v, 'v> Parser<'t, 'v> {
                     return Ok(Event::Command(default));
                 }
             }
+
+            // An unmatched word that names no subcommand is forwarded as an external
+            // command: this word, then every token after it, including flags. Known
+            // subcommands already won above, and a default_subcommand already caught.
+            if self.cmd.external_subcommand
+                && !is_flag_like(token)
+                && token != b"--"
+                && token != b"-"
+            {
+                let from = self.pos - 1;
+                self.pos = self.argv.len();
+                return Ok(Event::External {
+                    values: &self.argv[from..],
+                });
+            }
         }
 
         let Some(arg) = self.next_arg() else {
@@ -2166,6 +2192,67 @@ mod tests {
         assert_eq!(
             parse(&DEFAULTING, &a).unwrap(),
             vec![Event::Command(&INSTALL)]
+        );
+    }
+
+    #[test]
+    fn an_unmatched_word_is_forwarded_when_external_subcommand_is_set() {
+        static CATCH: Command = Command {
+            name: "ex",
+            flags: &[&VERBOSE],
+            subcommands: &[&INSTALL],
+            external_subcommand: true,
+            unknown_flags: Some(UnknownFlags::Error),
+            ..Command::EMPTY
+        };
+        let a = argv(["foo", "--help", "bar"]);
+        assert_eq!(
+            parse(&CATCH, &a).unwrap(),
+            vec![Event::External { values: &a[..] }]
+        );
+
+        let a = argv(["install"]);
+        assert_eq!(parse(&CATCH, &a).unwrap(), vec![Event::Command(&INSTALL)]);
+
+        let a = argv(["--verbose", "foo", "--verbose"]);
+        assert_eq!(
+            parse(&CATCH, &a).unwrap(),
+            vec![
+                Event::Flag {
+                    flag: &VERBOSE,
+                    value: None,
+                    negated: false
+                },
+                Event::External { values: &a[1..] }
+            ]
+        );
+
+        let a = argv(["--wat"]);
+        assert_eq!(
+            parse(&CATCH, &a),
+            Err(Error::UnknownFlag { token: b"--wat" })
+        );
+    }
+
+    #[test]
+    fn a_default_subcommand_outranks_an_external_one() {
+        static CATCH_DEFAULT: Command = Command {
+            name: "ex",
+            subcommands: &[&RUN],
+            default_subcommand: Some(&RUN),
+            external_subcommand: true,
+            ..Command::EMPTY
+        };
+        let a = argv(["build"]);
+        assert_eq!(
+            parse(&CATCH_DEFAULT, &a).unwrap(),
+            vec![
+                Event::Command(&RUN),
+                Event::Arg {
+                    arg: &RUN_TASK,
+                    value: b"build"
+                }
+            ]
         );
     }
 

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -826,6 +826,9 @@ impl Spec<'_> {
         if let Some(default_subcommand) = self.default_subcommand {
             prop(out, "default_subcommand", default_subcommand)?;
         }
+        if self.root.cmd.external_subcommand {
+            writeln!(out, "external_subcommand #true")?;
+        }
         // A `complete` block for every completer this CLI declares, naming the command that
         // asks the binary itself. Written rather than declared, so there is one place a
         // completer is said to exist: the Rust function. Everything that reads a spec — the
@@ -1021,6 +1024,9 @@ fn write_command(
     // demand one, and the spec's own reader treats the pair as a mistake.
     if meta.subcommand_required && !meta.cmd.subcommands.is_empty() {
         out.push_str(" subcommand_required=#true");
+    }
+    if meta.cmd.external_subcommand {
+        out.push_str(" external_subcommand=#true");
     }
     out.push_str(" {\n");
 
@@ -1661,10 +1667,24 @@ pub trait Subcommands: Sized {
     /// The metadata for the variants, in the same order.
     const METAS: &'static [&'static CommandMeta<'static>];
 
+    /// Whether one of these variants is an [`external_subcommand`](Command::external_subcommand).
+    const HAS_EXTERNAL: bool = false;
+
+    /// The variant index of the catch-all, if any. Not a position in [`COMMANDS`]:
+    /// an external variant is not a named command.
+    const EXTERNAL: Option<usize> = None;
+
+    /// Maps a position in [`COMMANDS`] to a variant index.
+    ///
+    /// Identity when there is no catch-all. When [`HAS_EXTERNAL`] is set, the named
+    /// commands sit in `COMMANDS` without the external variant, so a table position
+    /// is not a variant index and this is how the two are tied together.
+    const VARIANT_OF: &'static [usize] = &[];
+
     /// Take one event, and say whether it belonged to the selected command.
     ///
-    /// `selected` is a position in [`Subcommands::COMMANDS`], or `None` before any of them
-    /// has been reached — in which case the event cannot be theirs and nothing is asked.
+    /// `selected` is a variant index, or `None` before any of them has been reached —
+    /// in which case the event cannot be theirs and nothing is asked.
     ///
     /// Only the selected one is asked, which is both cheaper and *necessary*. Cheaper because
     /// a CLI with a hundred subcommands would otherwise offer every event to all hundred.

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -1761,15 +1761,22 @@ pub trait Subcommands: Sized {
     /// A flag that `install` requires says nothing about an invocation that ran
     /// `run`, so only the command that was actually reached is judged.
     ///
-    /// Identified by its position in [`Subcommands::COMMANDS`] rather than by its
-    /// key: the position is found from the table's own address, so two commands whose
-    /// keys happen to collide still cannot be confused for one another.
+    /// `selected` is a variant index, the same value [`apply`] is given — mapped
+    /// through [`VARIANT_OF`] when [`HAS_EXTERNAL`] is set, so it is not a
+    /// position in [`COMMANDS`]. Two commands whose keys happen to collide still
+    /// cannot be confused for one another: the index names the variant, not a
+    /// table slot.
     fn check<'t, 'v>(
         partial: &mut Self::Partial,
         selected: usize,
     ) -> Result<(), crate::Error<'t, 'v>>;
 
-    /// Build the variant at `selected`, a position in [`Subcommands::COMMANDS`].
+    /// Build the variant at `selected`, a variant index.
+    ///
+    /// The same index [`apply`] and [`check`] take — mapped through [`VARIANT_OF`]
+    /// when [`HAS_EXTERNAL`] is set, so it is not a position in [`COMMANDS`]. An
+    /// external variant is not in that table, and a caller that indexed `COMMANDS`
+    /// by this value would read the wrong command or go out of bounds.
     ///
     /// `None` when no variant was selected, which a caller reads as "no subcommand
     /// was given". An `Err` comes from building the variant that *was* selected.

--- a/argv/tests/no_alloc.rs
+++ b/argv/tests/no_alloc.rs
@@ -164,7 +164,9 @@ fn drain(argv: &[&OsStr]) -> usize {
     let mut seen = 0;
     while let Some(event) = parser.next_event() {
         match event {
-            Ok(Event::Command(_) | Event::Flag { .. } | Event::Arg { .. }) => seen += 1,
+            Ok(
+                Event::Command(_) | Event::Flag { .. } | Event::Arg { .. } | Event::External { .. },
+            ) => seen += 1,
             Err(_) => seen += 1,
         }
     }

--- a/conformance/src/argv.rs
+++ b/conformance/src/argv.rs
@@ -148,11 +148,27 @@ pub fn run(vector: &Vector) -> Outcome {
                     args.insert(name, Value::Str(string(value)));
                 }
             }
+            Ok(Event::External { values }) => {
+                return Outcome::Parsed(Parsed {
+                    cmd,
+                    flags,
+                    args,
+                    external: values
+                        .iter()
+                        .map(|v| v.to_str().expect("corpus values are UTF-8").to_string())
+                        .collect(),
+                });
+            }
             Err(e) => return Outcome::Failed(code(e)),
         }
     }
 
-    Outcome::Parsed(Parsed { cmd, flags, args })
+    Outcome::Parsed(Parsed {
+        cmd,
+        flags,
+        args,
+        external: Vec::new(),
+    })
 }
 
 fn string(value: &[u8]) -> String {

--- a/conformance/src/lib.rs
+++ b/conformance/src/lib.rs
@@ -117,6 +117,10 @@ pub struct Parsed {
     pub flags: BTreeMap<String, Value>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub args: BTreeMap<String, Value>,
+    /// Remaining argv captured when an unmatched word was forwarded as an
+    /// external subcommand: the command name first, then every token after it.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub external: Vec<String>,
 }
 
 /// A bound value.

--- a/conformance/src/reference.rs
+++ b/conformance/src/reference.rs
@@ -79,7 +79,12 @@ pub fn run(vector: &Vector) -> Observed {
                 .iter()
                 .map(|(arg, value)| (arg.name.clone(), convert(value)))
                 .collect();
-            Observed::Parsed(Parsed { cmd, flags, args })
+            Observed::Parsed(Parsed {
+                cmd,
+                flags,
+                args,
+                external: out.external.unwrap_or_default(),
+            })
         }
         Err(e) => classify(&e.to_string()),
     }

--- a/conformance/src/tables.rs
+++ b/conformance/src/tables.rs
@@ -105,6 +105,7 @@ pub fn build(
         default_subcommand: None,
         version: false,
         unknown_flags,
+        external_subcommand: cmd.external_subcommand,
         key: 0,
     }));
 

--- a/conformance/tests/subcommands.rs
+++ b/conformance/tests/subcommands.rs
@@ -442,3 +442,99 @@ fn a_boxed_command_can_be_named_through_a_path() {
     };
     assert!(deep.quiet);
 }
+
+/// clap's `external_subcommand`: an unmatched word plus the rest of argv.
+#[derive(Cli)]
+#[usage(bin = "ex", unknown_flags = "error")]
+struct Catch {
+    /// Say more
+    #[usage(short = 'v', long, global)]
+    verbose: bool,
+    #[usage(subcommand)]
+    command: Option<CatchCommands>,
+}
+
+#[derive(Subcommands)]
+enum CatchCommands {
+    /// Install a tool
+    Install(CatchInstall),
+    #[usage(external_subcommand)]
+    External(Vec<String>),
+}
+
+#[derive(Args)]
+struct CatchInstall {}
+
+#[derive(Cli)]
+#[usage(bin = "need", unknown_flags = "error")]
+struct Need {
+    #[usage(subcommand)]
+    command: NeedCommands,
+}
+
+#[derive(Subcommands)]
+enum NeedCommands {
+    Install(CatchInstall),
+    #[usage(external_subcommand)]
+    External(Vec<String>),
+}
+
+#[test]
+fn an_unmatched_word_is_forwarded_as_an_external_subcommand() {
+    let a = argv(["foo", "--help", "bar"]);
+    let catch = Catch::parse_from(&a).expect("forwards the rest");
+    match catch.command {
+        Some(CatchCommands::External(values)) => {
+            assert_eq!(values, vec!["foo", "--help", "bar"]);
+        }
+        _ => panic!("expected the catch-all, got a named command"),
+    }
+
+    let a = argv(["install"]);
+    let catch = Catch::parse_from(&a).expect("known commands still win");
+    assert!(matches!(catch.command, Some(CatchCommands::Install(_))));
+
+    let a = argv(["-v", "foo", "--verbose"]);
+    let catch = Catch::parse_from(&a).expect("a global before the word still binds");
+    assert!(catch.verbose);
+    match catch.command {
+        Some(CatchCommands::External(values)) => {
+            assert_eq!(values, vec!["foo", "--verbose"]);
+        }
+        _ => panic!("expected the catch-all, got a named command"),
+    }
+
+    let a = argv(["--wat"]);
+    assert!(
+        Catch::parse_from(&a).is_err(),
+        "an unknown flag on the parent is still an error"
+    );
+
+    let spec = Catch::to_kdl();
+    assert!(
+        spec.contains("external_subcommand #true"),
+        "the catch-all is emitted: {spec}"
+    );
+    assert!(
+        !spec.contains("cmd \"external\""),
+        "the catch-all is not a named command: {spec}"
+    );
+}
+
+#[test]
+fn an_external_subcommand_satisfies_a_required_command() {
+    let a = argv(["foo", "--help"]);
+    let need = Need::parse_from(&a).expect("the catch-all counts as a command");
+    match need.command {
+        NeedCommands::External(values) => {
+            assert_eq!(values, vec!["foo", "--help"]);
+        }
+        _ => panic!("expected the catch-all, got a named command"),
+    }
+
+    let a = argv([]);
+    assert!(
+        Need::parse_from(&a).is_err(),
+        "with nothing typed, a required command is still missing"
+    );
+}

--- a/corpus/10-external-subcommand.json
+++ b/corpus/10-external-subcommand.json
@@ -1,0 +1,71 @@
+{
+  "section": "external-subcommand",
+  "about": "An unmatched word forwarded as an external command plus the rest of argv. clap's allow_external_subcommands: known subcommands still win, default_subcommand still catches first, and a flag-like token on the parent is still an unknown flag rather than a forwarded name.",
+  "vectors": [
+    {
+      "id": "external-forwards-the-rest",
+      "doc": "Once an unmatched word is taken as the external name, every token after it is forwarded with it, including flags.",
+      "spec": "name \"ex\"\nbin \"ex\"\nunknown_flags \"error\"\nexternal_subcommand #true\ncmd \"install\"\n",
+      "argv": ["foo", "--help", "bar"],
+      "expect": {
+        "ok": {
+          "external": ["foo", "--help", "bar"]
+        }
+      }
+    },
+    {
+      "id": "external-known-command-still-wins",
+      "doc": "A word that names a declared subcommand selects it; the catch-all is only for words that name nothing.",
+      "spec": "name \"ex\"\nbin \"ex\"\nunknown_flags \"error\"\nexternal_subcommand #true\ncmd \"install\"\n",
+      "argv": ["install"],
+      "expect": {
+        "ok": {
+          "cmd": ["install"]
+        }
+      }
+    },
+    {
+      "id": "external-unknown-flag-still-errors",
+      "doc": "A flag-like token on the parent is still an unknown flag. This is clap's allow_external_subcommands, not unknown_flags=value.",
+      "spec": "name \"ex\"\nbin \"ex\"\nunknown_flags \"error\"\nexternal_subcommand #true\ncmd \"install\"\n",
+      "argv": ["--wat"],
+      "expect": { "error": "unknown_flag" }
+    },
+    {
+      "id": "external-global-before-the-word",
+      "doc": "A global flag typed before the unmatched word still binds on the parent; flags after it are forwarded.",
+      "spec": "name \"ex\"\nbin \"ex\"\nunknown_flags \"error\"\nexternal_subcommand #true\nflag \"-v --verbose\" global=#true\ncmd \"install\"\n",
+      "argv": ["-v", "foo", "--verbose"],
+      "expect": {
+        "ok": {
+          "external": ["foo", "--verbose"],
+          "flags": { "verbose": true }
+        }
+      }
+    },
+    {
+      "id": "external-default-outranks",
+      "doc": "A declared default_subcommand already says what an unmatched word means, so it catches before the external forwarding.",
+      "spec": "name \"ex\"\nbin \"ex\"\ndefault_subcommand \"run\"\nexternal_subcommand #true\ncmd \"run\" {\n  arg \"[TASK]\"\n}\n",
+      "argv": ["build"],
+      "expect": {
+        "ok": {
+          "cmd": ["run"],
+          "args": { "TASK": "build" }
+        }
+      }
+    },
+    {
+      "id": "external-nested-forwards",
+      "doc": "The property is per command: a nested cmd can forward while the root still owns its flags.",
+      "spec": "name \"ex\"\nbin \"ex\"\nunknown_flags \"error\"\ncmd \"exec\" external_subcommand=#true {\n  cmd \"install\"\n}\n",
+      "argv": ["exec", "git", "--help"],
+      "expect": {
+        "ok": {
+          "cmd": ["exec"],
+          "external": ["git", "--help"]
+        }
+      }
+    }
+  ]
+}

--- a/corpus/10-external-subcommand.json
+++ b/corpus/10-external-subcommand.json
@@ -56,6 +56,17 @@
       }
     },
     {
+      "id": "external-numeric-token",
+      "doc": "A negative number is a value, not a flag, so it can be the unmatched word the catch-all forwards. usage-lib used to treat every token that starts with `-` as a flag and skip this path.",
+      "spec": "name \"ex\"\nbin \"ex\"\nunknown_flags \"error\"\nexternal_subcommand #true\ncmd \"install\"\n",
+      "argv": ["-1", "rest"],
+      "expect": {
+        "ok": {
+          "external": ["-1", "rest"]
+        }
+      }
+    },
+    {
       "id": "external-nested-forwards",
       "doc": "The property is per command: a nested cmd can forward while the root still owns its flags.",
       "spec": "name \"ex\"\nbin \"ex\"\nunknown_flags \"error\"\ncmd \"exec\" external_subcommand=#true {\n  cmd \"install\"\n}\n",

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -3125,6 +3125,7 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
         let held = format_ident!("V{i}");
         let variant = &v.ident;
         if v.external {
+            let name = &v.name;
             let collected = if v.external_os {
                 quote! {{
                     let mut __usage_values = ::std::vec::Vec::with_capacity(__usage_p.len());
@@ -3137,7 +3138,7 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
                                 return ::std::result::Result::Err(
                                     usage_argv::Error::InvalidValue(::std::boxed::Box::new(
                                         usage_argv::InvalidValue {
-                                            name: "EXTERNAL",
+                                            name: #name,
                                             value: ::std::string::String::from_utf8_lossy(
                                                 &__usage_bytes,
                                             )
@@ -3165,7 +3166,7 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
                                 return ::std::result::Result::Err(
                                     usage_argv::Error::InvalidValue(::std::boxed::Box::new(
                                         usage_argv::InvalidValue {
-                                            name: "EXTERNAL",
+                                            name: #name,
                                             value: ::std::string::String::from_utf8_lossy(
                                                 __usage_bad.as_bytes(),
                                             )
@@ -3182,11 +3183,7 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
                     __usage_values
                 }}
             };
-            let made = if v.boxed {
-                quote!(#ident::#variant(::std::boxed::Box::new(#collected)))
-            } else {
-                quote!(#ident::#variant(#collected))
-            };
+            let made = quote!(#ident::#variant(#collected));
             quote! {
                 #i => match partial {
                     Partial::#held(__usage_p) => {

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -149,6 +149,10 @@ pub fn emit(cli: &Cli) -> TokenStream {
         .as_ref()
         .map(|p| p.default.clone())
         .unwrap_or_default();
+    let sub_external = parts
+        .as_ref()
+        .map(|p| p.external.clone())
+        .unwrap_or_default();
     let sub_metas = parts.as_ref().map(|p| p.metas.clone()).unwrap_or_default();
     let sub_build = parts.as_ref().map(|p| p.build.clone()).unwrap_or_default();
 
@@ -268,6 +272,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
                 args: #arg_table_ref,
                 #sub_commands
                 #sub_default
+                #sub_external
                 ..usage_argv::Command::EMPTY
             };
 
@@ -2358,6 +2363,9 @@ fn apply_fn(cli: &Cli) -> TokenStream {
                     #per_level_resets
                     false
                 }
+                // Forwarded argv belongs to the catch-all variant, which the
+                // subcommand route claims; this command's own flags do not.
+                Event::External { .. } => false,
             }
         }
     }
@@ -2373,6 +2381,8 @@ struct SubcommandParts {
     commands: TokenStream,
     /// `default_subcommand:` for the `Command` table, when one is declared.
     default: TokenStream,
+    /// `external_subcommand:` for the `Command` table.
+    external: TokenStream,
     /// `subcommands:` for the `CommandMeta`.
     metas: TokenStream,
     /// Fields the partial needs to carry.
@@ -2423,6 +2433,9 @@ fn subcommand_parts(cli: &Cli) -> Option<SubcommandParts> {
 
     Some(SubcommandParts {
         commands: quote!(subcommands: <#ty as usage_argv::spec::Subcommands>::COMMANDS,),
+        external: quote!(
+            external_subcommand: <#ty as usage_argv::spec::Subcommands>::HAS_EXTERNAL,
+        ),
         // Resolved from the name at compile time. The variants are another expansion, so the
         // name is all there is to go on here — but `find_subcommand` searches the list during
         // const evaluation, which means a name no subcommand answers to fails to compile
@@ -2441,9 +2454,9 @@ fn subcommand_parts(cli: &Cli) -> Option<SubcommandParts> {
         metas: quote!(subcommands: <#ty as usage_argv::spec::Subcommands>::METAS,),
         partial_fields: quote! {
             pub __usage_sub: <#ty as usage_argv::spec::Subcommands>::Partial,
-            /// Which of this command's subcommands was reached, as a position in
-            /// `COMMANDS`. Found from the table's own address, so it cannot be
-            /// confused by a key collision.
+            /// Which of this command's subcommands was reached, as a variant index.
+            /// Found from the table's own address, then mapped through `VARIANT_OF`
+            /// when a catch-all sits among the named commands.
             pub __usage_selected: ::std::option::Option<usize>,
         },
         partial_starts: quote! {
@@ -2454,17 +2467,34 @@ fn subcommand_parts(cli: &Cli) -> Option<SubcommandParts> {
             // A command word only counts as *this* command's if one of its own
             // subcommands answers to it: a deeper descent belongs to whoever owns
             // that command, and recording it here would make the wrong variant look
-            // selected.
+            // selected. `COMMANDS` holds named commands only, so the position is
+            // mapped through `VARIANT_OF` when a catch-all variant sits beside them.
             if let usage_argv::Event::Command(__usage_cmd) = event {
-                if let ::std::option::Option::Some(__usage_at) =
+                if let ::std::option::Option::Some(__usage_named) =
                     <#ty as usage_argv::spec::Subcommands>::COMMANDS
                         .iter()
                         .position(|candidate| ::core::ptr::eq(*candidate, *__usage_cmd))
                 {
+                    let __usage_at = if <#ty as usage_argv::spec::Subcommands>::HAS_EXTERNAL {
+                        <#ty as usage_argv::spec::Subcommands>::VARIANT_OF[__usage_named]
+                    } else {
+                        __usage_named
+                    };
                     partial.__usage_selected = ::std::option::Option::Some(__usage_at);
                     // The one place the selection and the storage are tied together: from
-                    // here on, `__usage_selected` naming a position means `__usage_sub`
+                    // here on, `__usage_selected` naming a variant means `__usage_sub`
                     // holds that variant. Everything downstream relies on it.
+                    <#ty as usage_argv::spec::Subcommands>::begin(
+                        &mut partial.__usage_sub,
+                        __usage_at,
+                    );
+                }
+            }
+            if let usage_argv::Event::External { .. } = event {
+                if let ::std::option::Option::Some(__usage_at) =
+                    <#ty as usage_argv::spec::Subcommands>::EXTERNAL
+                {
+                    partial.__usage_selected = ::std::option::Option::Some(__usage_at);
                     <#ty as usage_argv::spec::Subcommands>::begin(
                         &mut partial.__usage_sub,
                         __usage_at,
@@ -2592,6 +2622,10 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
         .as_ref()
         .map(|p| p.commands.clone())
         .unwrap_or_default();
+    let sub_external = parts
+        .as_ref()
+        .map(|p| p.external.clone())
+        .unwrap_or_default();
     let sub_metas = parts.as_ref().map(|p| p.metas.clone()).unwrap_or_default();
     let sub_build = parts.as_ref().map(|p| p.build.clone()).unwrap_or_default();
     // The same conversion the root gets. Two emitters producing one `build` is what let
@@ -2637,6 +2671,7 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
                 flags: #flag_table_ref,
                 args: #arg_table_ref,
                 #sub_commands
+                #sub_external
                 ..usage_argv::Command::EMPTY
             };
 
@@ -2790,36 +2825,69 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
     // comes into being when a command word selects it, in `begin`.
     let partial_variants = subs.variants.iter().enumerate().map(|(i, v)| {
         let variant = format_ident!("V{i}");
-        let ty = &v.ty;
-        quote!(#variant(<#ty as usage_argv::spec::CommandArgs>::Partial),)
+        if v.external {
+            quote!(#variant(::std::vec::Vec<::std::vec::Vec<u8>>),)
+        } else {
+            let ty = &v.ty;
+            quote!(#variant(<#ty as usage_argv::spec::CommandArgs>::Partial),)
+        }
     });
     // Idempotent, as the trait requires: a restart token can re-announce the command that is
     // already selected, and starting it again there would throw away the parse so far.
     let begins = subs.variants.iter().enumerate().map(|(i, v)| {
         let variant = format_ident!("V{i}");
-        let ty = &v.ty;
-        quote! {
-            #i => {
-                if !::std::matches!(partial, Partial::#variant(_)) {
-                    *partial = Partial::#variant(
-                        <#ty as usage_argv::spec::CommandArgs>::start(),
-                    );
+        if v.external {
+            quote! {
+                #i => {
+                    if !::std::matches!(partial, Partial::#variant(_)) {
+                        *partial = Partial::#variant(::std::vec::Vec::new());
+                    }
+                }
+            }
+        } else {
+            let ty = &v.ty;
+            quote! {
+                #i => {
+                    if !::std::matches!(partial, Partial::#variant(_)) {
+                        *partial = Partial::#variant(
+                            <#ty as usage_argv::spec::CommandArgs>::start(),
+                        );
+                    }
                 }
             }
         }
     });
     let applies = subs.variants.iter().enumerate().map(|(i, v)| {
         let variant = format_ident!("V{i}");
-        let ty = &v.ty;
-        quote! {
-            ::std::option::Option::Some(#i) => {
-                if let Partial::#variant(__usage_p) = partial {
-                    <#ty as usage_argv::spec::CommandArgs>::apply(__usage_p, event)
-                } else {
-                    // `begin` put this variant here on the event that selected it, so the
-                    // partial always matches the selection. An event with nowhere to go was
-                    // not this command's.
-                    false
+        if v.external {
+            quote! {
+                ::std::option::Option::Some(#i) => {
+                    if let Partial::#variant(__usage_p) = partial {
+                        if let usage_argv::Event::External { values } = event {
+                            __usage_p.extend(
+                                values.iter().map(|v| v.as_encoded_bytes().to_vec()),
+                            );
+                            true
+                        } else {
+                            false
+                        }
+                    } else {
+                        false
+                    }
+                }
+            }
+        } else {
+            let ty = &v.ty;
+            quote! {
+                ::std::option::Option::Some(#i) => {
+                    if let Partial::#variant(__usage_p) = partial {
+                        <#ty as usage_argv::spec::CommandArgs>::apply(__usage_p, event)
+                    } else {
+                        // `begin` put this variant here on the event that selected it, so the
+                        // partial always matches the selection. An event with nowhere to go was
+                        // not this command's.
+                        false
+                    }
                 }
             }
         }
@@ -2828,122 +2896,170 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
     // command — its own kebab-case name, or whatever `name` says. Splicing the
     // struct's table unchanged would have used the *struct's* name instead, which
     // only looks right when the two happen to match.
-    let command_overrides = subs.variants.iter().enumerate().map(|(i, v)| {
-        let name = format_ident!("COMMAND_{i}");
-        let alias_groups = format_ident!("ALIAS_GROUPS_{i}");
-        let aliases_name = format_ident!("ALIASES_{i}");
-        let ty = &v.ty;
-        let cmd_name = &v.name;
-        // Both kinds of alias go in the table, because the parser matches both; which of
-        // them help and completions mention is the metadata's business, below.
-        let aliases = v.aliases.iter().chain(&v.hidden_aliases);
-        quote! {
-            const #alias_groups: &[&[&str]] = &[
-                <#ty as usage_argv::spec::CommandArgs>::COMMAND.aliases,
-                &[#(#aliases),*],
-            ];
-            static #aliases_name: [&str; usage_argv::table_len(#alias_groups)] =
-                usage_argv::spec::concat_aliases(#alias_groups);
-            pub static #name: usage_argv::Command = usage_argv::Command {
-                name: #cmd_name,
-                aliases: &#aliases_name,
-                ..*<#ty as usage_argv::spec::CommandArgs>::COMMAND
-            };
-        }
-    });
-    let commands = (0..subs.variants.len()).map(|i| {
-        let name = format_ident!("COMMAND_{i}");
-        quote!(&#name)
-    });
-    let unique_commands = (0..subs.variants.len()).map(|i| {
-        let name = format_ident!("COMMAND_{i}");
-        quote!(&#name)
-    });
+    let command_overrides = subs
+        .variants
+        .iter()
+        .enumerate()
+        .filter(|(_, v)| !v.external)
+        .map(|(i, v)| {
+            let name = format_ident!("COMMAND_{i}");
+            let alias_groups = format_ident!("ALIAS_GROUPS_{i}");
+            let aliases_name = format_ident!("ALIASES_{i}");
+            let ty = &v.ty;
+            let cmd_name = &v.name;
+            // Both kinds of alias go in the table, because the parser matches both; which of
+            // them help and completions mention is the metadata's business, below.
+            let aliases = v.aliases.iter().chain(&v.hidden_aliases);
+            quote! {
+                const #alias_groups: &[&[&str]] = &[
+                    <#ty as usage_argv::spec::CommandArgs>::COMMAND.aliases,
+                    &[#(#aliases),*],
+                ];
+                static #aliases_name: [&str; usage_argv::table_len(#alias_groups)] =
+                    usage_argv::spec::concat_aliases(#alias_groups);
+                pub static #name: usage_argv::Command = usage_argv::Command {
+                    name: #cmd_name,
+                    aliases: &#aliases_name,
+                    ..*<#ty as usage_argv::spec::CommandArgs>::COMMAND
+                };
+            }
+        });
+    let commands = subs
+        .variants
+        .iter()
+        .enumerate()
+        .filter(|(_, v)| !v.external)
+        .map(|(i, _)| {
+            let name = format_ident!("COMMAND_{i}");
+            quote!(&#name)
+        });
+    let unique_commands = subs
+        .variants
+        .iter()
+        .enumerate()
+        .filter(|(_, v)| !v.external)
+        .map(|(i, _)| {
+            let name = format_ident!("COMMAND_{i}");
+            quote!(&#name)
+        });
+    let variant_of = subs
+        .variants
+        .iter()
+        .enumerate()
+        .filter(|(_, v)| !v.external)
+        .map(|(i, _)| quote!(#i));
+    let has_external = subs.variants.iter().any(|v| v.external);
+    let external_const = match subs.variants.iter().position(|v| v.external) {
+        Some(i) => quote!(::std::option::Option::Some(#i)),
+        None => quote!(::std::option::Option::None),
+    };
     // A doc comment on the variant wins over the struct's, since that is where a
     // reader of the enum expects to describe the command — and ignoring it would lose
     // the description without saying so. Overriding one field of the struct's
     // metadata is possible in a const, so the tables stay static.
-    let meta_overrides = subs.variants.iter().enumerate().map(|(i, v)| {
-        let name = format_ident!("META_{i}");
-        let cmd = format_ident!("COMMAND_{i}");
-        let hidden_groups = format_ident!("HIDDEN_ALIAS_GROUPS_{i}");
-        let hidden_name = format_ident!("HIDDEN_ALIASES_{i}");
-        let ty = &v.ty;
-        // A doc comment on the variant wins over the struct's, since that is where a
-        // reader of the enum expects to describe the command. Absent one, the
-        // struct's own description carries through.
-        // Each falls back on its own. A variant that gives a short description was suppressing
-        // the struct's long one, which is exactly how a generated CLI is shaped: the enum says
-        // what the command is for in a line, and the struct's own comment carries the rest. The
-        // long form went missing from help for every command written that way.
-        let about = match v.help.as_deref() {
-            Some(help) => option_str(Some(help)),
-            None => quote!(<#ty as usage_argv::spec::CommandArgs>::META.about),
-        };
-        let long_about = match v.long_help.as_deref() {
-            Some(long) => option_str(Some(long)),
-            None => quote!(<#ty as usage_argv::spec::CommandArgs>::META.long_about),
-        };
-        // Which of the table's aliases are hidden. The visible ones are not listed
-        // anywhere: `cmd.aliases` minus these is what help and completions show.
-        let hidden = &v.hidden_aliases;
-        // A hidden command still answers to its name; it is simply not offered. Declared on
-        // the variant, which is where the command itself is declared.
-        let hide = v.hide;
-        quote! {
-            const #hidden_groups: &[&[&str]] = &[
-                <#ty as usage_argv::spec::CommandArgs>::META.hidden_aliases,
-                &[#(#hidden),*],
-            ];
-            static #hidden_name: [&str; usage_argv::table_len(#hidden_groups)] =
-                usage_argv::spec::concat_aliases(#hidden_groups);
-            pub static #name: usage_argv::spec::CommandMeta =
-                usage_argv::spec::CommandMeta {
-                    cmd: &#cmd,
-                    about: #about,
-                    long_about: #long_about,
-                    hide: #hide,
-                    hidden_aliases: &#hidden_name,
-                    ..*<#ty as usage_argv::spec::CommandArgs>::META
-                };
-        }
-    });
-    let metas = (0..subs.variants.len()).map(|i| {
-        let name = format_ident!("META_{i}");
-        quote!(&#name)
-    });
+    let meta_overrides = subs
+        .variants
+        .iter()
+        .enumerate()
+        .filter(|(_, v)| !v.external)
+        .map(|(i, v)| {
+            let name = format_ident!("META_{i}");
+            let cmd = format_ident!("COMMAND_{i}");
+            let hidden_groups = format_ident!("HIDDEN_ALIAS_GROUPS_{i}");
+            let hidden_name = format_ident!("HIDDEN_ALIASES_{i}");
+            let ty = &v.ty;
+            // A doc comment on the variant wins over the struct's, since that is where a
+            // reader of the enum expects to describe the command. Absent one, the
+            // struct's own description carries through.
+            // Each falls back on its own. A variant that gives a short description was suppressing
+            // the struct's long one, which is exactly how a generated CLI is shaped: the enum says
+            // what the command is for in a line, and the struct's own comment carries the rest. The
+            // long form went missing from help for every command written that way.
+            let about = match v.help.as_deref() {
+                Some(help) => option_str(Some(help)),
+                None => quote!(<#ty as usage_argv::spec::CommandArgs>::META.about),
+            };
+            let long_about = match v.long_help.as_deref() {
+                Some(long) => option_str(Some(long)),
+                None => quote!(<#ty as usage_argv::spec::CommandArgs>::META.long_about),
+            };
+            // Which of the table's aliases are hidden. The visible ones are not listed
+            // anywhere: `cmd.aliases` minus these is what help and completions show.
+            let hidden = &v.hidden_aliases;
+            // A hidden command still answers to its name; it is simply not offered. Declared on
+            // the variant, which is where the command itself is declared.
+            let hide = v.hide;
+            quote! {
+                const #hidden_groups: &[&[&str]] = &[
+                    <#ty as usage_argv::spec::CommandArgs>::META.hidden_aliases,
+                    &[#(#hidden),*],
+                ];
+                static #hidden_name: [&str; usage_argv::table_len(#hidden_groups)] =
+                    usage_argv::spec::concat_aliases(#hidden_groups);
+                pub static #name: usage_argv::spec::CommandMeta =
+                    usage_argv::spec::CommandMeta {
+                        cmd: &#cmd,
+                        about: #about,
+                        long_about: #long_about,
+                        hide: #hide,
+                        hidden_aliases: &#hidden_name,
+                        ..*<#ty as usage_argv::spec::CommandArgs>::META
+                    };
+            }
+        });
+    let metas = subs
+        .variants
+        .iter()
+        .enumerate()
+        .filter(|(_, v)| !v.external)
+        .map(|(i, _)| {
+            let name = format_ident!("META_{i}");
+            quote!(&#name)
+        });
     // Matched on the command's key rather than its name, so selecting a variant is
     // an integer comparison and cannot be confused by an alias.
     let checks = subs.variants.iter().enumerate().map(|(i, v)| {
         let variant = format_ident!("V{i}");
-        let ty = &v.ty;
-        quote! {
-            #i => match partial {
-                Partial::#variant(__usage_p) => {
-                    <#ty as usage_argv::spec::CommandArgs>::check(__usage_p)
-                }
-                // Selected but unfilled cannot happen — see `Subcommands::begin`.
-                _ => ::std::result::Result::Ok(()),
-            },
+        if v.external {
+            quote! {
+                #i => ::std::result::Result::Ok(()),
+            }
+        } else {
+            let ty = &v.ty;
+            quote! {
+                #i => match partial {
+                    Partial::#variant(__usage_p) => {
+                        <#ty as usage_argv::spec::CommandArgs>::check(__usage_p)
+                    }
+                    // Selected but unfilled cannot happen — see `Subcommands::begin`.
+                    _ => ::std::result::Result::Ok(()),
+                },
+            }
         }
     });
     // Every variant's bindings, because a table says what the CLI *can* do and is compared
     // against a spec that documents all of them — but only the selected variant's values, since
     // those are about one invocation. A command nobody ran did not give anything.
-    let binding_parts = subs.variants.iter().map(|v| {
+    let binding_parts = subs.variants.iter().filter(|v| !v.external).map(|v| {
         let ty = &v.ty;
         quote!(<#ty as usage_argv::spec::CommandArgs>::SETTINGS_BINDINGS)
     });
     let binding_lens = binding_parts.clone().map(|part| quote!(+ #part.len()));
     let givens = subs.variants.iter().enumerate().map(|(i, v)| {
         let variant = format_ident!("V{i}");
-        let ty = &v.ty;
-        quote! {
-            ::std::option::Option::Some(#i) => {
-                if let Partial::#variant(__usage_p) = partial {
-                    <#ty as usage_argv::spec::CommandArgs>::settings_given(__usage_p)
-                } else {
-                    ::std::vec::Vec::new()
+        if v.external {
+            quote! {
+                ::std::option::Option::Some(#i) => ::std::vec::Vec::new(),
+            }
+        } else {
+            let ty = &v.ty;
+            quote! {
+                ::std::option::Option::Some(#i) => {
+                    if let Partial::#variant(__usage_p) = partial {
+                        <#ty as usage_argv::spec::CommandArgs>::settings_given(__usage_p)
+                    } else {
+                        ::std::vec::Vec::new()
+                    }
                 }
             }
         }
@@ -2952,37 +3068,55 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
     // variant rather than a field: an unselected arm has nothing to have been given.
     let any_givens = subs.variants.iter().enumerate().map(|(i, v)| {
         let variant = format_ident!("V{i}");
-        let ty = &v.ty;
-        quote! {
-            ::std::option::Option::Some(#i) => {
-                if let Partial::#variant(__usage_p) = partial {
-                    <#ty as usage_argv::spec::CommandArgs>::any_given(__usage_p)
-                } else {
-                    ::std::option::Option::None
+        if v.external {
+            quote! {
+                ::std::option::Option::Some(#i) => ::std::option::Option::None,
+            }
+        } else {
+            let ty = &v.ty;
+            quote! {
+                ::std::option::Option::Some(#i) => {
+                    if let Partial::#variant(__usage_p) = partial {
+                        <#ty as usage_argv::spec::CommandArgs>::any_given(__usage_p)
+                    } else {
+                        ::std::option::Option::None
+                    }
                 }
             }
         }
     });
     let exclusive_givens = subs.variants.iter().enumerate().map(|(i, v)| {
         let variant = format_ident!("V{i}");
-        let ty = &v.ty;
-        quote! {
-            ::std::option::Option::Some(#i) => {
-                if let Partial::#variant(__usage_p) = partial {
-                    <#ty as usage_argv::spec::CommandArgs>::exclusive_given(__usage_p)
-                } else {
-                    ::std::option::Option::None
+        if v.external {
+            quote! {
+                ::std::option::Option::Some(#i) => ::std::option::Option::None,
+            }
+        } else {
+            let ty = &v.ty;
+            quote! {
+                ::std::option::Option::Some(#i) => {
+                    if let Partial::#variant(__usage_p) = partial {
+                        <#ty as usage_argv::spec::CommandArgs>::exclusive_given(__usage_p)
+                    } else {
+                        ::std::option::Option::None
+                    }
                 }
             }
         }
     });
     let apply_envs = subs.variants.iter().enumerate().map(|(i, v)| {
         let variant = format_ident!("V{i}");
-        let ty = &v.ty;
-        quote! {
-            ::std::option::Option::Some(#i) => {
-                if let Partial::#variant(__usage_p) = partial {
-                    <#ty as usage_argv::spec::CommandArgs>::apply_env(__usage_p);
+        if v.external {
+            quote! {
+                ::std::option::Option::Some(#i) => {}
+            }
+        } else {
+            let ty = &v.ty;
+            quote! {
+                ::std::option::Option::Some(#i) => {
+                    if let Partial::#variant(__usage_p) = partial {
+                        <#ty as usage_argv::spec::CommandArgs>::apply_env(__usage_p);
+                    }
                 }
             }
         }
@@ -2990,33 +3124,106 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
     let selects = subs.variants.iter().enumerate().map(|(i, v)| {
         let held = format_ident!("V{i}");
         let variant = &v.ident;
-        let ty = &v.ty;
-        // The one place the box matters: everything else — tables, partial, `build` —
-        // speaks to the struct itself.
-        let built = quote!(<#ty as usage_argv::spec::CommandArgs>::build(__usage_p)?);
-        let built = if v.boxed {
-            quote!(::std::boxed::Box::new(#built))
+        if v.external {
+            let collected = if v.external_os {
+                quote! {{
+                    let mut __usage_values = ::std::vec::Vec::with_capacity(__usage_p.len());
+                    for __usage_item in __usage_p {
+                        match usage_argv::os_string_from_bytes(__usage_item) {
+                            ::std::result::Result::Ok(__usage_os) => {
+                                __usage_values.push(__usage_os)
+                            }
+                            ::std::result::Result::Err(__usage_bytes) => {
+                                return ::std::result::Result::Err(
+                                    usage_argv::Error::InvalidValue(::std::boxed::Box::new(
+                                        usage_argv::InvalidValue {
+                                            name: "EXTERNAL",
+                                            value: ::std::string::String::from_utf8_lossy(
+                                                &__usage_bytes,
+                                            )
+                                            .into_owned(),
+                                            reason: ::std::string::ToString::to_string(
+                                                &"this platform cannot hold these bytes",
+                                            ),
+                                        },
+                                    )),
+                                );
+                            }
+                        }
+                    }
+                    __usage_values
+                }}
+            } else {
+                quote! {{
+                    let mut __usage_values = ::std::vec::Vec::with_capacity(__usage_p.len());
+                    for __usage_item in __usage_p {
+                        match ::std::string::String::from_utf8(__usage_item) {
+                            ::std::result::Result::Ok(__usage_text) => {
+                                __usage_values.push(__usage_text)
+                            }
+                            ::std::result::Result::Err(__usage_bad) => {
+                                return ::std::result::Result::Err(
+                                    usage_argv::Error::InvalidValue(::std::boxed::Box::new(
+                                        usage_argv::InvalidValue {
+                                            name: "EXTERNAL",
+                                            value: ::std::string::String::from_utf8_lossy(
+                                                __usage_bad.as_bytes(),
+                                            )
+                                            .into_owned(),
+                                            reason: ::std::string::ToString::to_string(
+                                                &__usage_bad.utf8_error(),
+                                            ),
+                                        },
+                                    )),
+                                );
+                            }
+                        }
+                    }
+                    __usage_values
+                }}
+            };
+            let made = if v.boxed {
+                quote!(#ident::#variant(::std::boxed::Box::new(#collected)))
+            } else {
+                quote!(#ident::#variant(#collected))
+            };
+            quote! {
+                #i => match partial {
+                    Partial::#held(__usage_p) => {
+                        ::std::result::Result::Ok(::std::option::Option::Some(#made))
+                    }
+                    _ => ::std::result::Result::Ok(::std::option::Option::None),
+                },
+            }
         } else {
-            built
-        };
-        // A bare variant has nowhere to put what was built, and nothing was declared to go in
-        // it — but the build still runs, because that is where the command's own checks live.
-        let made = if v.unit {
-            quote! {{
-                let _ = #built;
-                #ident::#variant
-            }}
-        } else {
-            quote!(#ident::#variant(#built))
-        };
-        quote! {
-            #i => match partial {
-                Partial::#held(__usage_p) => {
-                    ::std::result::Result::Ok(::std::option::Option::Some(#made))
-                }
-                // Selected but unfilled cannot happen — see `Subcommands::begin`.
-                _ => ::std::result::Result::Ok(::std::option::Option::None),
-            },
+            let ty = &v.ty;
+            // The one place the box matters: everything else — tables, partial, `build` —
+            // speaks to the struct itself.
+            let built = quote!(<#ty as usage_argv::spec::CommandArgs>::build(__usage_p)?);
+            let built = if v.boxed {
+                quote!(::std::boxed::Box::new(#built))
+            } else {
+                built
+            };
+            // A bare variant has nowhere to put what was built, and nothing was declared to go in
+            // it — but the build still runs, because that is where the command's own checks live.
+            let made = if v.unit {
+                quote! {{
+                    let _ = #built;
+                    #ident::#variant
+                }}
+            } else {
+                quote!(#ident::#variant(#built))
+            };
+            quote! {
+                #i => match partial {
+                    Partial::#held(__usage_p) => {
+                        ::std::result::Result::Ok(::std::option::Option::Some(#made))
+                    }
+                    // Selected but unfilled cannot happen — see `Subcommands::begin`.
+                    _ => ::std::result::Result::Ok(::std::option::Option::None),
+                },
+            }
         }
     });
 
@@ -3062,6 +3269,9 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
                     &[#(#commands),*];
                 const METAS: &'static [&'static usage_argv::spec::CommandMeta<'static>] =
                     &[#(#metas),*];
+                const HAS_EXTERNAL: bool = #has_external;
+                const EXTERNAL: ::std::option::Option<usize> = #external_const;
+                const VARIANT_OF: &'static [usize] = &[#(#variant_of),*];
 
                 fn apply(
                     partial: &mut Self::Partial,

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -2983,6 +2983,20 @@ impl Variant {
                     "`effect` belongs on a command; `external_subcommand` forwards to one",
                 ));
             }
+            if hide {
+                return Err(syn::Error::new_spanned(
+                    &variant.ident,
+                    "`external_subcommand` is a catch-all rather than a command help lists, \
+                     so there is nothing for `hide` to keep out of help",
+                ));
+            }
+            if help.is_some() || long_help.is_some() {
+                return Err(syn::Error::new_spanned(
+                    &variant.ident,
+                    "a catch-all has no page of its own, so a description here would be \
+                     dropped; describe the forwarding on the command that declares it",
+                ));
+            }
             let held = match &variant.fields {
                 Fields::Unnamed(unnamed) if unnamed.unnamed.len() == 1 => {
                     unnamed.unnamed[0].ty.clone()
@@ -3017,7 +3031,7 @@ impl Variant {
             };
             return Ok(Variant {
                 ident: variant.ident.clone(),
-                hide,
+                hide: false,
                 name,
                 effect: None,
                 unit: false,
@@ -3027,8 +3041,8 @@ impl Variant {
                 external_os,
                 aliases,
                 hidden_aliases,
-                help,
-                long_help,
+                help: None,
+                long_help: None,
             });
         }
 
@@ -3609,7 +3623,7 @@ mod tests {
         assert!(subs.variants[1].external);
         assert!(!subs.variants[1].external_os);
 
-        let subs = subcommands(
+        let err = enum_rejection(
             r#"
             enum Commands {
                 #[usage(external_subcommand)]
@@ -3617,7 +3631,7 @@ mod tests {
             }
         "#,
         );
-        assert!(subs.is_err());
+        assert!(err.contains("Vec<String>"), "{err}");
 
         let err = enum_rejection(
             r#"
@@ -3640,6 +3654,30 @@ mod tests {
         "#,
         );
         assert!(err.contains("only one variant"), "{err}");
+
+        let err = enum_rejection(
+            r#"
+            enum Commands {
+                #[usage(hide, external_subcommand)]
+                External(Vec<String>),
+            }
+        "#,
+        );
+        assert!(err.contains("hide"), "{err}");
+
+        let err = enum_rejection(
+            r#"
+            enum Commands {
+                /// forwarded argv
+                #[usage(external_subcommand)]
+                External(Vec<String>),
+            }
+        "#,
+        );
+        assert!(
+            err.contains("description") || err.contains("catch-all"),
+            "{err}"
+        );
     }
 
     fn value_enum(body: &str) -> syn::Result<ValueEnum> {

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -2781,6 +2781,11 @@ pub struct Variant {
     /// keeps its command enum from being as large as its biggest variant — clap struggles
     /// at that size, and `clippy::large_enum_variant` says so about the rest.
     pub boxed: bool,
+    /// Whether this variant is clap's `external_subcommand`: an unmatched word plus
+    /// the rest of argv, held as `Vec<String>` or `Vec<OsString>`.
+    pub external: bool,
+    /// Whether the captured argv is `Vec<OsString>` rather than `Vec<String>`.
+    pub external_os: bool,
     /// Other names this command answers to.
     ///
     /// Kept apart from [`hidden_aliases`](Self::hidden_aliases) only for the spec: the
@@ -2824,11 +2829,22 @@ impl Subcommands {
             }
         }
 
+        let externals: Vec<_> = variants.iter().filter(|v| v.external).collect();
+        if externals.len() > 1 {
+            return Err(syn::Error::new_spanned(
+                &externals[1].ident,
+                "a command has one catch-all: only one variant may be `external_subcommand`",
+            ));
+        }
+
         // Every name a command answers to, its aliases included: the parser takes the
         // first table entry that matches, so a name claimed twice means one of the two
         // commands can never be reached and nothing would have said so.
         let mut seen: Vec<(&str, Span)> = Vec::new();
         for variant in &variants {
+            if variant.external {
+                continue;
+            }
             for name in std::iter::once(&variant.name)
                 .chain(&variant.aliases)
                 .chain(&variant.hidden_aliases)
@@ -2858,6 +2874,9 @@ impl Subcommands {
         // were refused.
         let mut types: Vec<(String, Span)> = Vec::new();
         for variant in &variants {
+            if variant.external {
+                continue;
+            }
             let rendered = quote::ToTokens::to_token_stream(&variant.ty)
                 .to_string()
                 .replace(' ', "");
@@ -2892,6 +2911,7 @@ impl Variant {
         let mut hidden_aliases: Vec<String> = Vec::new();
         let mut effect = None;
         let mut hide = false;
+        let mut external = false;
         let mut help_attr: Option<String> = None;
         let mut long_help_attr: Option<String> = None;
 
@@ -2904,6 +2924,7 @@ impl Variant {
                     "alias" => aliases.extend(selectors(&meta)?),
                     "alias_hidden" => hidden_aliases.extend(selectors(&meta)?),
                     "hide" => hide = flag_value(&meta)?,
+                    "external_subcommand" => external = flag_value(&meta)?,
                     "effect" => {
                         // Checked where it is written, and checked again by the struct's own
                         // derive, which is where it is read — one definition of the word.
@@ -2921,8 +2942,8 @@ impl Variant {
                             path,
                             format!(
                                 "unknown option `{other}` on a variant; a subcommand \
-                                 variant takes `name`, `alias`, `alias_hidden` and \
-                                 `verbatim_doc_comment` here, \
+                                 variant takes `name`, `alias`, `alias_hidden`, \
+                                 `external_subcommand` and `verbatim_doc_comment` here, \
                                  and its description comes from the doc comment"
                             ),
                         ));
@@ -2944,6 +2965,71 @@ impl Variant {
                     format!("`{alias}` is this command's own name, not another name for it"),
                 ));
             }
+        }
+
+        let (help, long_help) = (help_attr.or(help), long_help_attr.or(long_help));
+
+        if external {
+            if !aliases.is_empty() || !hidden_aliases.is_empty() {
+                return Err(syn::Error::new_spanned(
+                    &variant.ident,
+                    "`external_subcommand` is a catch-all, not a named command, so it \
+                     takes no alias",
+                ));
+            }
+            if effect.is_some() {
+                return Err(syn::Error::new_spanned(
+                    &variant.ident,
+                    "`effect` belongs on a command; `external_subcommand` forwards to one",
+                ));
+            }
+            let held = match &variant.fields {
+                Fields::Unnamed(unnamed) if unnamed.unnamed.len() == 1 => {
+                    unnamed.unnamed[0].ty.clone()
+                }
+                other => {
+                    return Err(syn::Error::new_spanned(
+                        other,
+                        "`external_subcommand` holds the unmatched name plus the rest of \
+                         argv, as `External(Vec<String>)` or `External(Vec<OsString>)`",
+                    ));
+                }
+            };
+            let Some(inner) = peel(&held, "Vec") else {
+                return Err(syn::Error::new_spanned(
+                    &held,
+                    "`external_subcommand` holds `Vec<String>` or `Vec<OsString>`",
+                ));
+            };
+            let inner_name = type_name(&inner);
+            let external_os = match inner_name.as_str() {
+                "String" => false,
+                "OsString" => true,
+                other => {
+                    return Err(syn::Error::new_spanned(
+                        &inner,
+                        format!(
+                            "`external_subcommand` holds `Vec<String>` or `Vec<OsString>`, \
+                             not `Vec<{other}>`"
+                        ),
+                    ));
+                }
+            };
+            return Ok(Variant {
+                ident: variant.ident.clone(),
+                hide,
+                name,
+                effect: None,
+                unit: false,
+                ty: held,
+                boxed: false,
+                external: true,
+                external_os,
+                aliases,
+                hidden_aliases,
+                help,
+                long_help,
+            });
         }
 
         // One unnamed field, holding the struct that declares the command's flags
@@ -2982,7 +3068,6 @@ impl Variant {
             None => (held, false),
         };
 
-        let (help, long_help) = (help_attr.or(help), long_help_attr.or(long_help));
         Ok(Variant {
             ident: variant.ident.clone(),
             hide,
@@ -2991,6 +3076,8 @@ impl Variant {
             unit,
             ty,
             boxed,
+            external: false,
+            external_os: false,
             aliases,
             hidden_aliases,
             help,
@@ -3505,6 +3592,54 @@ mod tests {
             Ok(_) => panic!("should not have compiled"),
             Err(e) => e.to_string(),
         }
+    }
+
+    #[test]
+    fn an_external_subcommand_holds_a_vec_of_strings() {
+        let subs = subcommands(
+            r#"
+            enum Commands {
+                Install(Install),
+                #[usage(external_subcommand)]
+                External(Vec<String>),
+            }
+        "#,
+        )
+        .expect("should compile");
+        assert!(subs.variants[1].external);
+        assert!(!subs.variants[1].external_os);
+
+        let subs = subcommands(
+            r#"
+            enum Commands {
+                #[usage(external_subcommand)]
+                Extra(::std::ffi::OsString),
+            }
+        "#,
+        );
+        assert!(subs.is_err());
+
+        let err = enum_rejection(
+            r#"
+            enum Commands {
+                #[usage(external_subcommand)]
+                Extra(Vec<u8>),
+            }
+        "#,
+        );
+        assert!(err.contains("Vec<String>"), "{err}");
+
+        let err = enum_rejection(
+            r#"
+            enum Commands {
+                #[usage(external_subcommand)]
+                A(Vec<String>),
+                #[usage(external_subcommand)]
+                B(Vec<String>),
+            }
+        "#,
+        );
+        assert!(err.contains("only one variant"), "{err}");
     }
 
     fn value_enum(body: &str) -> syn::Result<ValueEnum> {

--- a/docs/go/parser.md
+++ b/docs/go/parser.md
@@ -18,6 +18,8 @@ for p.Next() {
 		// ev.Flag; ev.Value if ev.HasValue; ev.Negated for --no-* spellings
 	case argv.KindArg:
 		// ev.Value filled ev.Arg
+	case argv.KindExternal:
+		// ev.Values is the unmatched name, then the rest of argv
 	}
 }
 if err := p.Err(); err != nil {

--- a/docs/rust/spec.md
+++ b/docs/rust/spec.md
@@ -92,7 +92,6 @@ help pages through both.
 A few spec nodes have no derive attribute yet:
 
 - `example` nodes — declare examples in `after_long_help` instead
-- `forwards` / external subcommands
 
 If you need these today, maintain a KDL spec alongside the derive or generate docs from a
 post-processed spec.

--- a/docs/rust/subcommands.md
+++ b/docs/rust/subcommands.md
@@ -51,7 +51,8 @@ struct Install {
   `#[usage(subcommand)]` field, up to a maximum depth of 16.
 
 Variant attributes: `name`, `alias`, `alias_hidden`, `hide`, `effect`, `help`, `long_help`,
-`verbatim_doc_comment`. Aliases declared on the variant and on the `Args` struct are joined.
+`verbatim_doc_comment`, `external_subcommand`. Aliases declared on the variant and on the `Args`
+struct are joined.
 
 Two variants wrapping the _same_ struct is a compile error — each command needs its own
 declaration (two byte-identical structs in different modules are fine).
@@ -66,6 +67,32 @@ struct Ex { /* … */ }
 
 When argv selects no command, `run` is assumed. Naming a command that doesn't exist fails the
 **build**, not the run.
+
+## External subcommands
+
+clap's `#[command(external_subcommand)]` is a catch-all variant that holds the unmatched
+name plus the rest of argv:
+
+```rust
+#[derive(Cli)]
+#[usage(bin = "ex", unknown_flags = "error")]
+struct Ex {
+    #[usage(subcommand)]
+    command: Option<Commands>,
+}
+
+#[derive(Subcommands)]
+enum Commands {
+    Install(Install),
+    #[usage(external_subcommand)]
+    External(Vec<String>),
+}
+```
+
+The variant must hold `Vec<String>` or `Vec<OsString>`. Only one such variant is allowed.
+Known subcommands still win; a `default_subcommand` still catches first. `ex git --help`
+becomes `Commands::External(vec!["git", "--help".into()])`. `ex --wat` is still an unknown
+flag. The emitted spec carries `external_subcommand #true`.
 
 ## Sharing declarations with `flatten`
 

--- a/docs/spec/argv.md
+++ b/docs/spec/argv.md
@@ -56,8 +56,9 @@ At each token, in order:
    [short](#short-flags)). If nothing matches, see
    [unrecognized flags](#unrecognized-flags).
 4. Otherwise the token is a word: it selects a [subcommand](#subcommands) if one
-   matches, and is otherwise offered to the command's
-   [positional arguments](#positional-arguments).
+   matches; otherwise it is forwarded as an [external subcommand](#external-subcommands)
+   if the command declares `external_subcommand`; otherwise it is offered to the
+   command's [positional arguments](#positional-arguments).
 
 ## Long flags
 
@@ -250,6 +251,34 @@ documents exactly this hazard for tasks that share a name with a command.
 **Only the descent position routes.** Once a word has been consumed by a
 positional argument, a later word matching a subcommand name is just a value.
 `ex other install` does not run `install`.
+
+### External subcommands
+
+A command may declare `external_subcommand`. An unmatched word that names no
+subcommand is then the name of an external command, and every token after it is
+forwarded with it — including flags. Known subcommands still win. A
+`default_subcommand` still catches first. A flag-like token on the parent is
+still an unknown flag, not a forwarded name: `ex git --help` forwards
+`git --help`; `ex --wat` errors.
+
+This is clap's `allow_external_subcommands`. It is not `unknown_flags=value`,
+which is the reading a wrapper uses when hyphen-taking tokens should bind as
+values of *this* command.
+
+```kdl
+unknown_flags "error"
+external_subcommand #true
+cmd "install"
+```
+
+The property is per command, so a nested `cmd` can forward while the root still
+owns its flags:
+
+```kdl
+cmd "exec" external_subcommand=#true {
+  cmd "install"
+}
+```
 
 ### Flag scope
 

--- a/docs/spec/argv.md
+++ b/docs/spec/argv.md
@@ -263,7 +263,7 @@ still an unknown flag, not a forwarded name: `ex git --help` forwards
 
 This is clap's `allow_external_subcommands`. It is not `unknown_flags=value`,
 which is the reading a wrapper uses when hyphen-taking tokens should bind as
-values of *this* command.
+values of _this_ command.
 
 ```kdl
 unknown_flags "error"

--- a/docs/spec/reference/cmd.md
+++ b/docs/spec/reference/cmd.md
@@ -137,6 +137,25 @@ Unlike [`effect`](#effect), this is inherited: it describes how a command line i
 read rather than what a command does. See
 [the argv grammar](../argv.md#unrecognized-flags) for the reasoning and the cost.
 
+### External subcommands
+
+An unmatched word that names no subcommand can be forwarded as an external
+command plus the rest of argv. This is clap's `allow_external_subcommands`, not
+`unknown_flags=value`: known subcommands still win, a `default_subcommand` still
+catches first, and a flag-like token on the parent is still an unknown flag.
+
+```kdl
+unknown_flags "error"
+external_subcommand #true            // the whole CLI
+cmd "exec" external_subcommand=#true // or one command
+```
+
+`ex git --help` forwards `git --help`. `ex --wat` is still an error. Once the
+unmatched word is taken, remaining tokens — including `--help` — are not parsed
+as this command's flags.
+
+See [the argv grammar](../argv.md#external-subcommands).
+
 ### Global flags and mounted commands
 
 A mounted command describes a different program, so the flags of the commands it is mounted under

--- a/go/README.md
+++ b/go/README.md
@@ -82,6 +82,8 @@ for p.Next() {
         // ev.Flag was given, with ev.Value if ev.HasValue
     case argv.KindArg:
         // ev.Value filled ev.Arg
+    case argv.KindExternal:
+        // ev.Values is the unmatched name, then the rest of argv
     }
 }
 if err := p.Err(); err != nil {

--- a/go/argv/argv.go
+++ b/go/argv/argv.go
@@ -61,6 +61,13 @@ type Command struct {
 	// Applied at most once per parse, so a CLI cannot loop through it, and only
 	// where a subcommand could still be selected.
 	DefaultSubcommand *Command
+	// ExternalSubcommand is whether an unmatched word is forwarded as an external
+	// command plus the rest of argv.
+	//
+	// clap's allow_external_subcommands. Known subcommands still win; a
+	// DefaultSubcommand still catches first. Once the unmatched word is taken,
+	// remaining tokens — including --help — are not parsed as this command's flags.
+	ExternalSubcommand bool
 	// UnknownFlags is what an unrecognized flag-like token means here. Already
 	// resolved: inheritance is a question for whoever builds the tables.
 	UnknownFlags UnknownFlags
@@ -202,7 +209,7 @@ const (
 	DoubleDashAutomatic
 )
 
-// Kind is which of the three things an [Event] reports.
+// Kind is which of the things an [Event] reports.
 type Kind uint8
 
 const (
@@ -212,6 +219,9 @@ const (
 	KindFlag
 	// KindArg means a word was bound to a positional argument.
 	KindArg
+	// KindExternal means an unmatched word was forwarded as an external command:
+	// the name, then every remaining token, including flags.
+	KindExternal
 )
 
 // Event is something the parser bound.
@@ -239,6 +249,10 @@ type Event struct {
 	HasValue bool
 	// Negated is true when a flag was set through its Negate form.
 	Negated bool
+	// Values is the remaining argv when Kind is KindExternal: the unmatched name
+	// first, then every token after it. Shares memory with the argv the parser
+	// was given.
+	Values []string
 }
 
 // Code is a class of binding failure.

--- a/go/argv/parser.go
+++ b/go/argv/parser.go
@@ -18,6 +18,8 @@ package argv
 //			// ev.Flag was given, with ev.Value if ev.HasValue
 //		case argv.KindArg:
 //			// ev.Value filled ev.Arg
+//		case argv.KindExternal:
+//			// ev.Values is the unmatched name, then the rest of argv
 //		}
 //	}
 //	if err := p.Err(); err != nil {
@@ -492,6 +494,16 @@ func (p *Parser) word(token string) bool {
 			}
 			p.pos--
 			return p.emit(Event{Kind: KindCommand, Command: d})
+		}
+
+		// An unmatched word that names no subcommand is forwarded as an external
+		// command: this word, then every token after it, including flags. Known
+		// subcommands already won above, and a default subcommand already caught.
+		if p.cmd.ExternalSubcommand && !isFlagLike(token) && token != "--" && token != "-" {
+			from := p.pos - 1
+			values := p.argv[from:]
+			p.pos = len(p.argv)
+			return p.emit(Event{Kind: KindExternal, Values: values})
 		}
 	}
 

--- a/go/argv/parser_test.go
+++ b/go/argv/parser_test.go
@@ -376,6 +376,9 @@ func TestExternalSubcommand(t *testing.T) {
 	if got := collect(catch, "--wat"); got != "err:unknown_flag" {
 		t.Errorf("unknown flag: got %s", got)
 	}
+	if got := collect(catch, "-1", "rest"); got != "external:-1,rest" {
+		t.Errorf("numeric token: got %s", got)
+	}
 
 	run := &Command{Name: "run", Args: []*Arg{{Key: 10, Name: "task"}}}
 	both := &Command{

--- a/go/argv/parser_test.go
+++ b/go/argv/parser_test.go
@@ -70,6 +70,8 @@ func collect(cmd *Command, args ...string) string {
 			out = append(out, s)
 		case KindArg:
 			out = append(out, "arg:"+ev.Arg.Name+"="+ev.Value)
+		case KindExternal:
+			out = append(out, "external:"+strings.Join(ev.Values, ","))
 		}
 	}
 	if err := p.Err(); err != nil {
@@ -350,6 +352,40 @@ func TestDefaultMissingWithRequireEquals(t *testing.T) {
 	}
 	if got := collect(cmd, "--inspect="); got != "flag:inspect=" {
 		t.Errorf("--inspect=: got %s", got)
+	}
+}
+
+func TestExternalSubcommand(t *testing.T) {
+	install := &Command{Name: "install", Key: 100}
+	catch := &Command{
+		Name:               "ex",
+		Flags:              []*Flag{verbose},
+		Subcommands:        []*Command{install},
+		ExternalSubcommand: true,
+		UnknownFlags:       UnknownFlagsError,
+	}
+	if got := collect(catch, "foo", "--help", "bar"); got != "external:foo,--help,bar" {
+		t.Errorf("forward: got %s", got)
+	}
+	if got := collect(catch, "install"); got != "cmd:install" {
+		t.Errorf("known command: got %s", got)
+	}
+	if got := collect(catch, "--verbose", "foo", "--verbose"); got != "flag:verbose external:foo,--verbose" {
+		t.Errorf("global before the word: got %s", got)
+	}
+	if got := collect(catch, "--wat"); got != "err:unknown_flag" {
+		t.Errorf("unknown flag: got %s", got)
+	}
+
+	run := &Command{Name: "run", Args: []*Arg{{Key: 10, Name: "task"}}}
+	both := &Command{
+		Name:               "ex",
+		Subcommands:        []*Command{run},
+		DefaultSubcommand:  run,
+		ExternalSubcommand: true,
+	}
+	if got := collect(both, "build"); got != "cmd:run arg:task=build" {
+		t.Errorf("default outranks: got %s", got)
 	}
 }
 

--- a/go/conformance/conformance_test.go
+++ b/go/conformance/conformance_test.go
@@ -63,9 +63,10 @@ type Expect struct {
 // the spec gives each flag or argument, never by the token that set it, so -j,
 // --jobs and an env var all land under `jobs`.
 type Parsed struct {
-	Cmd   []string               `json:"cmd"`
-	Flags map[string]interface{} `json:"flags"`
-	Args  map[string]interface{} `json:"args"`
+	Cmd      []string               `json:"cmd"`
+	Flags    map[string]interface{} `json:"flags"`
+	Args     map[string]interface{} `json:"args"`
+	External []string               `json:"external,omitempty"`
 }
 
 type file struct {
@@ -199,6 +200,7 @@ func run(s *spec.Spec, args []string, env map[string]string) (*Parsed, *argv.Err
 	// The commands whose declarations are in scope. A required flag on a command
 	// nobody selected is not missing; it is simply not this invocation's.
 	path := []*argv.Command{root}
+	var external []string
 
 	p := argv.New(root, args)
 	for p.Next() {
@@ -222,6 +224,8 @@ func run(s *spec.Spec, args []string, env map[string]string) (*Parsed, *argv.Err
 			b.occurrences++
 			b.at = seen
 			b.values = append(b.values, ev.Value)
+		case argv.KindExternal:
+			external = append(external, ev.Values...)
 		}
 	}
 	if err := p.Err(); err != nil {
@@ -233,9 +237,10 @@ func run(s *spec.Spec, args []string, env map[string]string) (*Parsed, *argv.Err
 	}
 
 	out := &Parsed{
-		Cmd:   []string{},
-		Flags: map[string]interface{}{},
-		Args:  map[string]interface{}{},
+		Cmd:      []string{},
+		Flags:    map[string]interface{}{},
+		Args:     map[string]interface{}{},
+		External: external,
 	}
 	for _, cmd := range path[1:] {
 		out.Cmd = append(out.Cmd, cmd.Name)
@@ -434,7 +439,7 @@ func bools(v interface{}) []interface{} { return strs(v) }
 // root. Likewise for the two maps. The corpus is the definition of correct about
 // bindings, not about which of two spellings of "nothing" a decoder produces.
 func normalizeExpected(p *Parsed) *Parsed {
-	out := &Parsed{Cmd: p.Cmd, Flags: p.Flags, Args: p.Args}
+	out := &Parsed{Cmd: p.Cmd, Flags: p.Flags, Args: p.Args, External: p.External}
 	if out.Cmd == nil {
 		out.Cmd = []string{}
 	}

--- a/go/internal/spec/spec.go
+++ b/go/internal/spec/spec.go
@@ -77,22 +77,23 @@ type Completer struct {
 
 // Cmd is one command in the lowered spec.
 type Cmd struct {
-	Name           string      `json:"name"`
-	Hide           bool        `json:"hide"`
-	Help           string      `json:"help"`
-	HelpLong       string      `json:"help_long"`
-	Usage          string      `json:"usage"`
-	BeforeHelp     string      `json:"before_help"`
-	AfterHelp      string      `json:"after_help"`
-	BeforeHelpLong string      `json:"before_help_long"`
-	AfterHelpLong  string      `json:"after_help_long"`
-	Examples       []Example   `json:"examples"`
-	Aliases        []string    `json:"aliases"`
-	HiddenAliases  []string    `json:"hidden_aliases"`
-	Subcommands    Subcommands `json:"subcommands"`
-	Args           []Arg       `json:"args"`
-	Flags          []Flag      `json:"flags"`
-	UnknownFlags   *string     `json:"unknown_flags"`
+	Name               string      `json:"name"`
+	Hide               bool        `json:"hide"`
+	Help               string      `json:"help"`
+	HelpLong           string      `json:"help_long"`
+	Usage              string      `json:"usage"`
+	BeforeHelp         string      `json:"before_help"`
+	AfterHelp          string      `json:"after_help"`
+	BeforeHelpLong     string      `json:"before_help_long"`
+	AfterHelpLong      string      `json:"after_help_long"`
+	Examples           []Example   `json:"examples"`
+	Aliases            []string    `json:"aliases"`
+	HiddenAliases      []string    `json:"hidden_aliases"`
+	Subcommands        Subcommands `json:"subcommands"`
+	Args               []Arg       `json:"args"`
+	Flags              []Flag      `json:"flags"`
+	UnknownFlags       *string     `json:"unknown_flags"`
+	ExternalSubcommand bool        `json:"external_subcommand"`
 }
 
 // Subcommands is a command's children, in the order the spec declared them.
@@ -508,9 +509,10 @@ func (b *builder) command(c *Cmd, inherited argv.UnknownFlags) *argv.Command {
 	}
 
 	out := &argv.Command{
-		Name:         c.Name,
-		UnknownFlags: unknown,
-		Key:          b.next(),
+		Name:               c.Name,
+		UnknownFlags:       unknown,
+		ExternalSubcommand: c.ExternalSubcommand,
+		Key:                b.next(),
 	}
 	examples := make([]argv.Example, 0, len(c.Examples))
 	for _, e := range c.Examples {

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -479,6 +479,7 @@ impl From<&crate::SpecCommand> for SpecCommand {
             restart_token,
             // How a command line is read, which no rendered page shows.
             unknown_flags: _,
+            external_subcommand: _,
             // Rendered above, or deliberately absent from the docs model.
             args: _,
             flags: _,

--- a/lib/src/go/mod.rs
+++ b/lib/src/go/mod.rs
@@ -371,6 +371,10 @@ impl<'a> Emitter<'a> {
                 ));
             }
 
+            if e.cmd.external_subcommand {
+                lines.push(Line::Field("ExternalSubcommand".into(), "true".into()));
+            }
+
             if e.root {
                 if let Some(var) = &default_subcommand {
                     lines.push(Line::Field("DefaultSubcommand".into(), var.clone()));
@@ -1557,6 +1561,37 @@ default_subcommand "run"
                 "should point at the command named `run`, got:\n{out}"
             );
         }
+    }
+
+    #[test]
+    fn an_external_subcommand_is_emitted_on_the_command_that_declares_it() {
+        let out = go(r#"
+name "ex"
+bin "ex"
+external_subcommand #true
+cmd "install"
+cmd "exec" external_subcommand=#true
+"#);
+        assert!(
+            out.contains("ExternalSubcommand: true"),
+            "the root should forward unmatched words, got:\n{out}"
+        );
+        let exec = out
+            .lines()
+            .find(|l| l.contains("Name: \"exec\""))
+            .expect("exec is emitted");
+        assert!(
+            exec.contains("ExternalSubcommand: true"),
+            "a nested command can forward too: {exec}"
+        );
+        let install = out
+            .lines()
+            .find(|l| l.contains("Name: \"install\""))
+            .expect("install is emitted");
+        assert!(
+            !install.contains("ExternalSubcommand"),
+            "a command that does not declare it should not carry it: {install}"
+        );
     }
 
     /// A subcommand actually named `root` wants the constant the root has.

--- a/lib/src/go/mod.rs
+++ b/lib/src/go/mod.rs
@@ -1577,7 +1577,10 @@ cmd "exec" external_subcommand=#true
                 .find(&format!("var {var} ="))
                 .unwrap_or_else(|| panic!("{var} should be emitted, got:\n{out}"));
             let rest = &out[start..];
-            let end = rest[1..].find("\nvar ").map(|i| i + 1).unwrap_or(rest.len());
+            let end = rest[1..]
+                .find("\nvar ")
+                .map(|i| i + 1)
+                .unwrap_or(rest.len());
             &rest[..end]
         };
         assert!(

--- a/lib/src/go/mod.rs
+++ b/lib/src/go/mod.rs
@@ -1572,25 +1572,28 @@ external_subcommand #true
 cmd "install"
 cmd "exec" external_subcommand=#true
 "#);
+        let block = |var: &str| {
+            let start = out
+                .find(&format!("var {var} ="))
+                .unwrap_or_else(|| panic!("{var} should be emitted, got:\n{out}"));
+            let rest = &out[start..];
+            let end = rest[1..].find("\nvar ").map(|i| i + 1).unwrap_or(rest.len());
+            &rest[..end]
+        };
         assert!(
-            out.contains("ExternalSubcommand: true"),
-            "the root should forward unmatched words, got:\n{out}"
+            block("Root").contains("ExternalSubcommand: true"),
+            "the root should forward unmatched words:\n{}",
+            block("Root")
         );
-        let exec = out
-            .lines()
-            .find(|l| l.contains("Name: \"exec\""))
-            .expect("exec is emitted");
         assert!(
-            exec.contains("ExternalSubcommand: true"),
-            "a nested command can forward too: {exec}"
+            block("cmdExec").contains("ExternalSubcommand: true"),
+            "a nested command can forward too:\n{}",
+            block("cmdExec")
         );
-        let install = out
-            .lines()
-            .find(|l| l.contains("Name: \"install\""))
-            .expect("install is emitted");
         assert!(
-            !install.contains("ExternalSubcommand"),
-            "a command that does not declare it should not carry it: {install}"
+            !block("cmdInstall").contains("ExternalSubcommand"),
+            "a command that does not declare it should not carry it:\n{}",
+            block("cmdInstall")
         );
     }
 

--- a/lib/src/macros.rs
+++ b/lib/src/macros.rs
@@ -290,6 +290,9 @@ macro_rules! __spec_cmd_attr {
     ($builder:expr, subcommand_required, $value:expr) => {
         $builder.subcommand_required($value)
     };
+    ($builder:expr, external_subcommand, $value:expr) => {
+        $builder.external_subcommand($value)
+    };
     ($builder:expr, aliases, $value:expr) => {
         $builder.aliases($value)
     };

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -274,6 +274,11 @@ pub struct ParseOutput {
     /// of the variadic argument collecting it, not a separator, so it does not unlock a
     /// `double_dash="required"` argument.
     pub double_dash_seen: bool,
+    /// Remaining argv captured when an unmatched word was forwarded as an external
+    /// subcommand: the command name first, then every token after it.
+    ///
+    /// Absent when no external command was selected. See [`SpecCommand::external_subcommand`].
+    pub external: Option<Vec<String>>,
 }
 
 impl ParseOutput {
@@ -617,6 +622,7 @@ fn parse_partial_with_env(
         errors: vec![],
         next_arg: None,
         double_dash_seen: false,
+        external: None,
     };
     // Keep this internal so adding relationship support remains semver-compatible. The full
     // parser uses it to prevent defaults and environment values from restoring overridden flags.
@@ -813,6 +819,15 @@ fn parse_partial_with_env(
                         continue;
                     }
                 }
+            }
+            // An unmatched word that names no subcommand is forwarded as an external
+            // command: this word, then every token after it, including flags. Known
+            // subcommands already won above, and a default_subcommand already caught.
+            // clap's `allow_external_subcommands` is this, not `unknown_flags=value`.
+            if out.cmd.external_subcommand {
+                let rest: Vec<String> = input.drain(idx..).collect();
+                out.external = Some(rest);
+                break;
             }
             // This could be a positional argument, so stop subcommand search
             break;
@@ -1349,7 +1364,7 @@ fn parse_partial_with_env(
     // the child would be here instead. The spec has carried `subcommand_required` since it was
     // added for the derive, and this parser never read it — so `mise generate` parsed as a
     // complete invocation while usage-argv and clap both refused it.
-    if out.cmd.subcommand_required && !out.cmd.subcommands.is_empty() {
+    if out.cmd.subcommand_required && !out.cmd.subcommands.is_empty() && out.external.is_none() {
         let mut names: Vec<&str> = out
             .cmd
             .subcommands
@@ -2351,6 +2366,7 @@ impl Debug for ParseOutput {
             )
             .field("flag_awaiting_value", &self.flag_awaiting_value)
             .field("errors", &self.errors)
+            .field("external", &self.external)
             .finish()
     }
 }
@@ -5804,6 +5820,79 @@ cmd "open" {
         // this is the half that keeps the check from being "any command with children".
         parse(&spec, &words(&["ex", "open"])).unwrap();
         parse(&spec, &words(&["ex", "open", "sub"])).unwrap();
+    }
+
+    #[test]
+    fn an_unmatched_word_is_forwarded_when_external_subcommand_is_set() {
+        let spec: Spec = r#"
+name "ex"
+bin "ex"
+unknown_flags "error"
+external_subcommand #true
+cmd "install"
+flag "-v --verbose" global=#true
+"#
+        .parse()
+        .unwrap();
+
+        let parsed = parse(&spec, &input(&["ex", "foo", "--help", "bar"])).unwrap();
+        assert_eq!(
+            parsed.external,
+            Some(vec!["foo".into(), "--help".into(), "bar".into()])
+        );
+        assert!(parsed.flags.is_empty());
+
+        // Known subcommands still win.
+        let parsed = parse(&spec, &input(&["ex", "install"])).unwrap();
+        assert_eq!(parsed.cmd.name, "install");
+        assert!(parsed.external.is_none());
+
+        // A global flag before the unmatched word still binds on the parent.
+        let parsed = parse(&spec, &input(&["ex", "-v", "foo", "--verbose"])).unwrap();
+        assert_eq!(
+            parsed.external,
+            Some(vec!["foo".into(), "--verbose".into()])
+        );
+        assert!(parsed.flags.keys().any(|flag| flag.name == "verbose"));
+
+        // An unknown flag on the parent is still an error, which is what clap does.
+        assert!(parse(&spec, &input(&["ex", "--wat"])).is_err());
+    }
+
+    #[test]
+    fn an_external_subcommand_satisfies_subcommand_required() {
+        let mut spec: Spec = r#"
+name "ex"
+bin "ex"
+external_subcommand #true
+cmd "install"
+"#
+        .parse()
+        .unwrap();
+        spec.cmd.subcommand_required = true;
+
+        parse(&spec, &input(&["ex", "foo", "--help"])).unwrap();
+        assert!(parse(&spec, &input(&["ex"])).is_err());
+    }
+
+    #[test]
+    fn a_default_subcommand_outranks_an_external_one() {
+        let spec: Spec = r#"
+name "ex"
+bin "ex"
+default_subcommand "run"
+external_subcommand #true
+cmd "run" {
+    arg "[task]"
+}
+"#
+        .parse()
+        .unwrap();
+
+        let parsed = parse(&spec, &input(&["ex", "build"])).unwrap();
+        assert_eq!(parsed.cmd.name, "run");
+        assert!(parsed.external.is_none());
+        assert_eq!(first_string_value(&parsed), "build");
     }
 
     #[test]

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -700,7 +700,7 @@ fn parse_partial_with_env(
         if !mounts_resolved
             && !out.cmd.mounts.is_empty()
             && !default_catches_it
-            && !input[idx].starts_with('-')
+            && is_command_word(&input[idx])
             && out.cmd.find_subcommand(&input[idx]).is_none()
         {
             mounts_resolved = true;
@@ -733,7 +733,7 @@ fn parse_partial_with_env(
             prefix_flags.clear();
             // Continue from current position (don't reset to 0)
             // After remove(), idx now points to the next element
-        } else if input[idx].starts_with('-') {
+        } else if !is_command_word(&input[idx]) {
             // Check if this is a known flag
             let word = input[idx].clone();
             let flag_key = get_flag_key(&word);
@@ -767,7 +767,7 @@ fn parse_partial_with_env(
                 if f.arg.is_some()
                     && !word.contains('=')
                     && idx < input.len()
-                    && !input[idx].starts_with('-')
+                    && !is_flag_like(&input[idx])
                 {
                     if let Some(words) = forwarded.as_mut() {
                         words.push(input[idx].clone());
@@ -1910,6 +1910,17 @@ fn is_flag_like(token: &str) -> bool {
         None | Some("") => false,
         Some(rest) => !is_number(rest),
     }
+}
+
+/// A token that can select a subcommand, trigger a mount, or be forwarded as an
+/// external command.
+///
+/// Flag-like tokens are not words. A lone `-` is a value — conventionally stdin —
+/// so it was never a candidate to *select* anything either. usage-argv uses the
+/// same rule; without it, `-1` skipped the external-subcommand path because Phase 1
+/// treated every token that `starts_with('-')` as a flag.
+fn is_command_word(token: &str) -> bool {
+    !is_flag_like(token) && token != "-"
 }
 
 /// Digits, at most one `.`, and an optional exponent.
@@ -5857,6 +5868,12 @@ flag "-v --verbose" global=#true
 
         // An unknown flag on the parent is still an error, which is what clap does.
         assert!(parse(&spec, &input(&["ex", "--wat"])).is_err());
+
+        // A negative number is a value, not a flag, so it can be the unmatched word.
+        // usage-argv already forwarded `-1`; Phase 1 used to treat every `starts_with('-')`
+        // token as a flag and never reach the catch-all.
+        let parsed = parse(&spec, &input(&["ex", "-1", "rest"])).unwrap();
+        assert_eq!(parsed.external, Some(vec!["-1".into(), "rest".into()]));
     }
 
     #[test]

--- a/lib/src/spec/builder.rs
+++ b/lib/src/spec/builder.rs
@@ -633,6 +633,12 @@ impl SpecCommandBuilder {
         self
     }
 
+    /// Forward an unmatched word as an external command plus the rest of argv
+    pub fn external_subcommand(mut self, enabled: bool) -> Self {
+        self.inner.external_subcommand = enabled;
+        self
+    }
+
     /// Set what running this command does to the world
     pub fn effect(mut self, effect: SpecCommandEffect) -> Self {
         self.inner.effect = Some(effect);

--- a/lib/src/spec/cmd.rs
+++ b/lib/src/spec/cmd.rs
@@ -94,6 +94,14 @@ pub struct SpecCommand {
     /// Whether a subcommand must be provided
     #[serde(skip_serializing_if = "is_false")]
     pub subcommand_required: bool,
+    /// Whether an unmatched word is forwarded as an external command plus the rest of argv.
+    ///
+    /// clap's `allow_external_subcommands` / `#[command(external_subcommand)]`. Known
+    /// subcommands still win; a `default_subcommand` still catches first. Once the
+    /// unmatched word is taken, remaining tokens — including `--help` — are not parsed
+    /// as this command's flags.
+    #[serde(skip_serializing_if = "is_false")]
+    pub external_subcommand: bool,
     /// Token that resets argument parsing, allowing multiple command invocations.
     /// e.g., `mise run lint ::: test ::: check` with restart_token=":::"
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -162,6 +170,7 @@ impl Default for SpecCommand {
             mounted: false,
             flags_from_mount: false,
             subcommand_required: false,
+            external_subcommand: false,
             restart_token: None,
             help: None,
             help_long: None,
@@ -267,6 +276,7 @@ impl SpecCommand {
                 }
                 "after_help_md" => cmd.after_help_md = Some(v.ensure_string()?),
                 "subcommand_required" => cmd.subcommand_required = v.ensure_bool()?,
+                "external_subcommand" => cmd.external_subcommand = v.ensure_bool()?,
                 "hide" => cmd.hide = v.ensure_bool()?,
                 "unknown_flags" => {
                     let raw = v.ensure_string()?;
@@ -388,6 +398,9 @@ impl SpecCommand {
                 "subcommand_required" => {
                     cmd.subcommand_required = child.ensure_arg_len(1..=1)?.arg(0)?.ensure_bool()?
                 }
+                "external_subcommand" => {
+                    cmd.external_subcommand = child.ensure_arg_len(1..=1)?.arg(0)?.ensure_bool()?
+                }
                 "hide" => cmd.hide = child.ensure_arg_len(1..=1)?.arg(0)?.ensure_bool()?,
                 "effect" => {
                     let arg = child.ensure_arg_len(1..=1)?.arg(0)?;
@@ -497,6 +510,7 @@ impl SpecCommand {
             examples,
             hide,
             subcommand_required,
+            external_subcommand,
             restart_token,
             subcommands,
             complete,
@@ -569,6 +583,7 @@ impl SpecCommand {
         }
         self.hide = hide;
         self.subcommand_required = subcommand_required;
+        self.external_subcommand = external_subcommand;
         if effect.is_some() {
             self.effect = effect;
         }
@@ -671,6 +686,7 @@ impl From<&SpecCommand> for KdlNode {
             name,
             hide,
             subcommand_required,
+            external_subcommand,
             restart_token,
             unknown_flags,
             aliases,
@@ -708,6 +724,10 @@ impl From<&SpecCommand> for KdlNode {
         if *subcommand_required {
             node.entries_mut()
                 .push(KdlEntry::new_prop("subcommand_required", true));
+        }
+        if *external_subcommand {
+            node.entries_mut()
+                .push(KdlEntry::new_prop("external_subcommand", true));
         }
         if let Some(restart_token) = &restart_token {
             node.entries_mut()
@@ -849,14 +869,19 @@ impl From<&clap::Command> for SpecCommand {
         // of them said `unknown_flags`, so `mise use --globa` became a tool named `--globa`
         // rather than the error clap gives.
         //
-        // Which commands forward is clap's own knowledge: an argument that accepts hyphen values,
-        // or a command that takes external subcommands. In mise that is five commands — `run`,
-        // `watch`, `asdf`, `tool-stub` and the root's implicit task arguments — and the other two
-        // hundred get the stricter reading back.
-        let forwards = cmd.is_allow_external_subcommands_set()
-            || cmd
-                .get_arguments()
-                .any(|arg| arg.is_allow_hyphen_values_set() || arg.is_trailing_var_arg_set());
+        // Which commands forward unknown *flags* is clap's own knowledge: an argument that
+        // accepts hyphen values, or a trailing var arg. In mise that is five commands —
+        // `run`, `watch`, `asdf`, `tool-stub` and the root's implicit task arguments — and
+        // the other two hundred get the stricter reading back.
+        //
+        // An external subcommand is a different shape: an unmatched *word* is forwarded with
+        // the rest of argv. clap still rejects an unknown flag on such a command (`x --wat`),
+        // so mapping `allow_external_subcommands` onto `unknown_flags=value` silently loosened
+        // every clap CLI that allowed one.
+        spec.external_subcommand = cmd.is_allow_external_subcommands_set();
+        let forwards = cmd
+            .get_arguments()
+            .any(|arg| arg.is_allow_hyphen_values_set() || arg.is_trailing_var_arg_set());
         spec.unknown_flags = Some(if forwards {
             UnknownFlags::Value
         } else {
@@ -1166,6 +1191,7 @@ cmd "wrapped" help="Wraps another CLI" {
 }
 cmd "remove" help="Remove a package" deprecated="use `uninstall`" effect="destructive"
 cmd "run" restart_token=":::" help="Run tasks"
+cmd "exec" external_subcommand=#true help="Run an external command"
 cmd "hidden" hide=#true
         "#;
 
@@ -1278,11 +1304,12 @@ cmd "hidden" hide=#true
         let spec: SpecCommand = (&trailing).into();
         assert_eq!(spec.unknown_flags, Some(UnknownFlags::Value));
 
-        // And a command that takes whatever subcommand it is given, which is the other shape of
-        // the same thing.
+        // And a command that takes whatever subcommand it is given, which is a different
+        // shape from forwarding unknown flags: clap still rejects `x --wat`.
         let external = clap::Command::new("x").allow_external_subcommands(true);
         let spec: SpecCommand = (&external).into();
-        assert_eq!(spec.unknown_flags, Some(UnknownFlags::Value));
+        assert_eq!(spec.unknown_flags, Some(UnknownFlags::Error));
+        assert!(spec.external_subcommand);
     }
 
     #[cfg(feature = "clap")]

--- a/lib/src/spec/mod.rs
+++ b/lib/src/spec/mod.rs
@@ -276,6 +276,9 @@ impl Spec {
                 "default_subcommand" => {
                     schema.default_subcommand = Some(node.arg(0)?.ensure_string()?)
                 }
+                "external_subcommand" => {
+                    schema.cmd.external_subcommand = node.arg(0)?.ensure_bool()?;
+                }
                 "example" => {
                     let code = node.ensure_arg_len(1..=1)?.arg(0)?.ensure_string()?;
                     let mut example = SpecExample::new(code.trim().to_string());
@@ -538,6 +541,11 @@ impl Display for Spec {
         if let Some(default_subcommand) = &self.default_subcommand {
             let mut node = KdlNode::new("default_subcommand");
             node.push(string_entry(None, default_subcommand));
+            nodes.push(node);
+        }
+        if self.cmd.external_subcommand {
+            let mut node = KdlNode::new("external_subcommand");
+            node.push(KdlEntry::new(true));
             nodes.push(node);
         }
         if !self.usage.is_empty() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds clap's `allow_external_subcommands` as a first-class spec property instead of mapping it onto `unknown_flags=value`.

An unmatched word that names no subcommand is forwarded as an external command plus the rest of argv, including flags. Known subcommands still win. A `default_subcommand` still catches first. A flag-like token on the parent is still an unknown flag: `ex git --help` forwards `git --help`; `ex --wat` errors. A negative number such as `-1` is a word, not a flag, so it can be the unmatched name.

Covered in usage-lib, usage-argv, the derive (`#[usage(external_subcommand)]` on a `Vec<String>` / `Vec<OsString>` variant), Go tables, and the shared corpus (`corpus/10-external-subcommand.json`).

This is the bottom of a stack; `default_if` and `multicall` follow on top.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4de7e59e-aa2e-4ad0-a1d0-1c2e69c166db?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4de7e59e-aa2e-4ad0-a1d0-1c2e69c166db&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added external subcommand support for forwarding unmatched command-line words and remaining arguments.
  * Supported across Rust and Go parsers, generated commands, specifications, and conformance output.
  * Known and default subcommands retain precedence, while global flags remain supported.
  * External commands can capture arguments as strings or OS-specific values.
  * Forwarding can satisfy required-subcommand configurations.

* **Documentation**
  * Added configuration guidance, precedence rules, flag handling details, parser events, and examples.

* **Bug Fixes**
  * Unknown flags before an external command continue to produce errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->