### PR TITLE
feat(spec): bind a default when another flag is given

### DIFF
--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -627,6 +627,8 @@ pub struct FlagMeta<'a> {
     pub requires: &'a [&'a str],
     /// Value-triggered requirements declared by this flag.
     pub requires_if: &'a [RequiresIf<'a>],
+    /// Defaults that apply when another flag is given.
+    pub default_if: &'a [DefaultIf<'a>],
     /// Flags that make this one necessary.
     pub required_if: &'a [&'a str],
     /// Flags that make this one unnecessary.
@@ -662,6 +664,7 @@ impl FlagMeta<'_> {
         exclusive: false,
         requires: &[],
         requires_if: &[],
+        default_if: &[],
         required_if: &[],
         required_unless: &[],
         help_heading: None,
@@ -674,6 +677,17 @@ impl FlagMeta<'_> {
 pub struct RequiresIf<'a> {
     pub value: &'a str,
     pub requires: &'a str,
+}
+
+/// A default that applies when another flag is given.
+///
+/// Two-argument form (`when` is `None`) is clap's `ArgPredicate::IsPresent`.
+/// Three-argument form is `Equals`.
+#[derive(Debug, Clone, Copy)]
+pub struct DefaultIf<'a> {
+    pub selector: &'a str,
+    pub when: Option<&'a str>,
+    pub value: &'a str,
 }
 
 /// What a positional argument knows about itself beyond how it parses.
@@ -1211,6 +1225,7 @@ fn write_flag(out: &mut String, meta: &FlagMeta<'_>, depth: usize) -> core::fmt:
         || meta.conflicts.len() > 1
         || meta.requires.len() > 1
         || !meta.requires_if.is_empty()
+        || !meta.default_if.is_empty()
         || meta.required_if.len() > 1
         || meta.required_unless.len() > 1;
     if !has_children {
@@ -1236,6 +1251,24 @@ fn write_flag(out: &mut String, meta: &FlagMeta<'_>, depth: usize) -> core::fmt:
             quoted(condition.value),
             quoted(condition.requires)
         )?;
+    }
+    for condition in meta.default_if {
+        indent(out, inner)?;
+        match condition.when {
+            None => writeln!(
+                out,
+                "default_if {} {}",
+                quoted(condition.selector),
+                quoted(condition.value)
+            )?,
+            Some(when) => writeln!(
+                out,
+                "default_if {} {} {}",
+                quoted(condition.selector),
+                quoted(when),
+                quoted(condition.value)
+            )?,
+        }
     }
     write_many_list(out, "required_if", meta.required_if, inner)?;
     write_many_list(out, "required_unless", meta.required_unless, inner)?;

--- a/conformance/src/tables.rs
+++ b/conformance/src/tables.rs
@@ -25,7 +25,9 @@
 
 use usage::spec::cmd::SpecExample;
 use usage::{Spec, SpecArg, SpecCommand, SpecComplete, SpecFlag, SpecGroup};
-use usage_argv::spec::{ArgMeta, CommandMeta, Effect, Example, FlagMeta, GroupMeta, RequiresIf};
+use usage_argv::spec::{
+    ArgMeta, CommandMeta, DefaultIf, Effect, Example, FlagMeta, GroupMeta, RequiresIf,
+};
 use usage_argv::{Arg, Command, DoubleDash, Flag, UnknownFlags as ArgvUnknownFlags};
 
 /// A command's two tables, built together so the metadata can borrow the parse table.
@@ -331,6 +333,17 @@ fn flag_meta(
                 .map(|condition| RequiresIf {
                     value: leak(&condition.value),
                     requires: leak(&condition.requires),
+                })
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        ),
+        default_if: Box::leak(
+            f.default_if
+                .iter()
+                .map(|condition| DefaultIf {
+                    selector: leak(&condition.selector),
+                    when: condition.when.as_deref().map(leak),
+                    value: leak(&condition.value),
                 })
                 .collect::<Vec<_>>()
                 .into_boxed_slice(),

--- a/conformance/tests/derive.rs
+++ b/conformance/tests/derive.rs
@@ -1024,6 +1024,7 @@ fn a_conditional_default_binds_when_the_other_flag_is_given() {
     let a = argv(["--output", "json"]);
     let got = BinPaths::parse_from(&a).expect("Equals");
     assert_eq!(got.style.as_deref(), Some("pretty"));
+    assert_eq!(got.output.as_deref(), Some("json"));
     assert!(!got.bin_names);
 
     let a = argv(["--json", "--bin-names"]);

--- a/conformance/tests/derive.rs
+++ b/conformance/tests/derive.rs
@@ -998,3 +998,41 @@ fn a_default_missing_flag_binds_when_the_value_is_left_off() {
         "the attribute has to reach the spec: {kdl}"
     );
 }
+
+/// clap's `default_value_if`: `--json` implies `--bin-names`.
+#[derive(Cli, Debug)]
+#[usage(bin = "paths")]
+struct BinPaths {
+    #[usage(long, default_if("--json", "true"))]
+    bin_names: bool,
+    #[usage(long)]
+    json: bool,
+    #[usage(long, default_if("--output", "json", "pretty"))]
+    style: Option<String>,
+    #[usage(long)]
+    output: Option<String>,
+}
+
+#[test]
+fn a_conditional_default_binds_when_the_other_flag_is_given() {
+    let a = argv(["--json"]);
+    let got = BinPaths::parse_from(&a).expect("IsPresent");
+    assert!(got.bin_names);
+    assert!(got.json);
+    assert!(got.style.is_none());
+
+    let a = argv(["--output", "json"]);
+    let got = BinPaths::parse_from(&a).expect("Equals");
+    assert_eq!(got.style.as_deref(), Some("pretty"));
+    assert!(!got.bin_names);
+
+    let a = argv(["--json", "--bin-names"]);
+    let got = BinPaths::parse_from(&a).expect("argv still wins");
+    assert!(got.bin_names);
+
+    let kdl = BinPaths::to_kdl();
+    assert!(
+        kdl.contains("default_if"),
+        "the attribute has to reach the spec: {kdl}"
+    );
+}

--- a/corpus/11-default-if.json
+++ b/corpus/11-default-if.json
@@ -97,6 +97,14 @@
       "layer": "post-binding"
     },
     {
+      "id": "default-if-equals-reads-negation",
+      "doc": "An Equals default_if on a bool reads the negate form as false, the same way requires_if does. `--no-json` is given, and its value is false.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--pretty\" {\n  default_if \"--json\" \"false\" \"true\"\n}\nflag \"--json\" negate=\"--no-json\"\n",
+      "argv": ["--no-json"],
+      "expect": { "ok": { "flags": { "pretty": true, "json": false } } },
+      "layer": "post-binding"
+    },
+    {
       "id": "default-if-choice-is-checked",
       "doc": "A bound default_if value is checked against choices the same way a default is.",
       "spec": "name \"ex\"\nbin \"ex\"\nflag \"--color <when>\" {\n  default_if \"--pretty\" \"rainbow\"\n  choices \"auto\" \"always\" \"never\"\n}\nflag \"--pretty\"\n",

--- a/corpus/11-default-if.json
+++ b/corpus/11-default-if.json
@@ -1,0 +1,108 @@
+{
+  "section": "default-if",
+  "about": "A default that depends on another flag. Lives on the target. Two arguments are presence; three are equality. First match wins. Command line and environment on the target suppress it. An applied default_if is a default, not an explicit value.",
+  "vectors": [
+    {
+      "id": "default-if-present-binds",
+      "doc": "`default_if \"--json\" \"true\"` binds when `--json` is given. clap's ArgPredicate::IsPresent.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--bin-names\" {\n  default_if \"--json\" \"true\"\n}\nflag \"--json\"\n",
+      "argv": ["--json"],
+      "expect": { "ok": { "flags": { "bin-names": true, "json": true } } },
+      "layer": "post-binding"
+    },
+    {
+      "id": "default-if-absent-does-nothing",
+      "doc": "With the selector absent, the target stays unset.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--bin-names\" {\n  default_if \"--json\" \"true\"\n}\nflag \"--json\"\n",
+      "argv": [],
+      "expect": { "ok": { "flags": {} } },
+      "layer": "post-binding"
+    },
+    {
+      "id": "default-if-equals-binds",
+      "doc": "Three arguments: bind when the selector has that explicit value.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--style <s>\" {\n  default_if \"--output\" \"json\" \"pretty\"\n}\nflag \"--output <fmt>\"\n",
+      "argv": ["--output", "json"],
+      "expect": { "ok": { "flags": { "style": "pretty", "output": "json" } } },
+      "layer": "post-binding"
+    },
+    {
+      "id": "default-if-equals-misses-other-values",
+      "doc": "An unrelated value on the selector does not bind the default.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--style <s>\" {\n  default_if \"--output\" \"json\" \"pretty\"\n}\nflag \"--output <fmt>\"\n",
+      "argv": ["--output", "yaml"],
+      "expect": { "ok": { "flags": { "output": "yaml" } } },
+      "layer": "post-binding"
+    },
+    {
+      "id": "default-if-first-match-wins",
+      "doc": "Conditions are tried in order; the first that matches binds.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--style <s>\" {\n  default_if \"--json\" \"compact\"\n  default_if \"--pretty\" \"pretty\"\n}\nflag \"--json\"\nflag \"--pretty\"\n",
+      "argv": ["--json", "--pretty"],
+      "expect": {
+        "ok": { "flags": { "style": "compact", "json": true, "pretty": true } }
+      },
+      "layer": "post-binding"
+    },
+    {
+      "id": "default-if-argv-suppresses",
+      "doc": "A value typed for the target wins over default_if.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--style <s>\" {\n  default_if \"--json\" \"compact\"\n}\nflag \"--json\"\n",
+      "argv": ["--json", "--style", "pretty"],
+      "expect": { "ok": { "flags": { "style": "pretty", "json": true } } },
+      "layer": "post-binding"
+    },
+    {
+      "id": "default-if-env-on-target-suppresses",
+      "doc": "The target's environment is a value, so it suppresses default_if.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--bin-names\" env=\"EX_BIN\" {\n  default_if \"--json\" \"true\"\n}\nflag \"--json\"\n",
+      "argv": ["--json"],
+      "env": { "EX_BIN": "false" },
+      "expect": { "ok": { "flags": { "bin-names": false, "json": true } } },
+      "layer": "post-binding"
+    },
+    {
+      "id": "default-if-sibling-env-activates",
+      "doc": "A selector filled from the environment is present, so default_if binds. Env is applied to every flag before any default_if, so declaration order does not matter.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--bin-names\" {\n  default_if \"--json\" \"true\"\n}\nflag \"--json\" env=\"EX_JSON\"\n",
+      "argv": [],
+      "env": { "EX_JSON": "1" },
+      "expect": { "ok": { "flags": { "bin-names": true, "json": true } } },
+      "layer": "post-binding"
+    },
+    {
+      "id": "default-if-does-not-activate-requires-if",
+      "doc": "An applied default_if is a default. requires_if only reads command-line and environment values.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--format <f>\" {\n  default_if \"--json\" \"json\"\n  requires_if \"json\" \"--schema\"\n}\nflag \"--schema <s>\"\nflag \"--json\"\n",
+      "argv": ["--json"],
+      "expect": { "ok": { "flags": { "format": "json", "json": true } } },
+      "layer": "post-binding"
+    },
+    {
+      "id": "default-if-satisfies-requires",
+      "doc": "A positive requirement asks whether the other flag ended up with a value. default_if is a value, the same as an unconditional default.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--out <p>\" requires=\"--format\"\nflag \"--format <f>\" {\n  default_if \"--json\" \"json\"\n}\nflag \"--json\"\n",
+      "argv": ["--out", "a.txt", "--json"],
+      "expect": {
+        "ok": { "flags": { "out": "a.txt", "format": "json", "json": true } }
+      },
+      "layer": "post-binding"
+    },
+    {
+      "id": "default-if-unconditional-default-when-no-match",
+      "doc": "When no condition matches, an unconditional default still applies.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--style <s>\" default=\"plain\" {\n  default_if \"--json\" \"compact\"\n}\nflag \"--json\"\n",
+      "argv": [],
+      "expect": { "ok": { "flags": { "style": "plain" } } },
+      "layer": "post-binding"
+    },
+    {
+      "id": "default-if-choice-is-checked",
+      "doc": "A bound default_if value is checked against choices the same way a default is.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--color <when>\" {\n  default_if \"--pretty\" \"rainbow\"\n  choices \"auto\" \"always\" \"never\"\n}\nflag \"--pretty\"\n",
+      "argv": ["--pretty"],
+      "expect": { "error": "invalid_choice" },
+      "layer": "post-binding"
+    }
+  ]
+}

--- a/corpus/11-default-if.json
+++ b/corpus/11-default-if.json
@@ -105,6 +105,14 @@
       "layer": "post-binding"
     },
     {
+      "id": "default-if-default-does-not-activate",
+      "doc": "A default on the selector is not an explicit value. default_if only reads the command line and the environment, matching Go Given() and the derive's __given_*.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--pretty\" {\n  default_if \"--json\" \"true\"\n}\nflag \"--json\" default=#true\n",
+      "argv": [],
+      "expect": { "ok": { "flags": { "json": true } } },
+      "layer": "post-binding"
+    },
+    {
       "id": "default-if-choice-is-checked",
       "doc": "A bound default_if value is checked against choices the same way a default is.",
       "spec": "name \"ex\"\nbin \"ex\"\nflag \"--color <when>\" {\n  default_if \"--pretty\" \"rainbow\"\n  choices \"auto\" \"always\" \"never\"\n}\nflag \"--pretty\"\n",

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -16,7 +16,9 @@ use proc_macro2::TokenStream;
 use proc_macro_crate::{crate_name, FoundCrate};
 use quote::{format_ident, quote};
 
-use crate::model::{rendered_path, Cli, DoubleDash, Field, Kind, Shape, Subcommands, ValueEnum};
+use crate::model::{
+    rendered_path, Cli, ConditionalDefault, DoubleDash, Field, Kind, Shape, Subcommands, ValueEnum,
+};
 
 /// The runtime as the adopter depended on it.
 ///
@@ -949,6 +951,15 @@ fn flag_meta(i: usize, field: &Field, owner: &syn::Ident) -> TokenStream {
         let requires = &condition.requires;
         quote!(usage_argv::spec::RequiresIf { value: #value, requires: #requires })
     });
+    let default_if = field.default_if.iter().map(|condition| {
+        let selector = &condition.selector;
+        let value = &condition.value;
+        let when = match &condition.when {
+            Some(when) => quote!(::core::option::Option::Some(#when)),
+            None => quote!(::core::option::Option::None),
+        };
+        quote!(usage_argv::spec::DefaultIf { selector: #selector, when: #when, value: #value })
+    });
     let exclusive = field.exclusive;
     let delimiter = match field.delimiter {
         Some(c) => quote!(::std::option::Option::Some(#c)),
@@ -990,6 +1001,7 @@ fn flag_meta(i: usize, field: &Field, owner: &syn::Ident) -> TokenStream {
             conflicts: &[#(#conflicts),*],
             requires: &[#(#requires),*],
             requires_if: &[#(#requires_if),*],
+            default_if: &[#(#default_if),*],
             exclusive: #exclusive,
             delimiter: #delimiter,
             required_if: &[#(#required_if),*],
@@ -2140,9 +2152,10 @@ fn field_final(field: &Field) -> TokenStream {
                     let given = format_ident!("__given_{}", ident);
                     let defaulted = !field.default.is_empty();
                     // Same as below: whether anything arrived is what tells "never given"
-                    // from "given nothing", which the `Vec` itself cannot.
+                    // from "given nothing", which the `Vec` itself cannot. A `default_if`
+                    // that fired has already pushed, so a non-empty vec is a value too.
                     quote! {
-                        #ident: if partial.#given || #defaulted {
+                        #ident: if partial.#given || #defaulted || !partial.#ident.is_empty() {
                             ::std::option::Option::Some(#collected)
                         } else {
                             ::std::option::Option::None
@@ -2235,11 +2248,13 @@ fn field_final(field: &Field) -> TokenStream {
                 // A declared default is a value, so a field that has one is never `None`. It
                 // does not set `__given_*` — the environment still has to be able to replace it
                 // — so the answer has to come from the declaration rather than from the partial.
+                // A `default_if` that matched has already pushed, which a leftover empty vec
+                // would not.
                 let defaulted = !field.default.is_empty();
                 // `Option<Vec<T>>` distinguishes "never given" from "given nothing", which
                 // no `Vec` can — so the answer comes from whether anything arrived.
                 quote! {
-                    #ident: if partial.#given || #defaulted {
+                    #ident: if partial.#given || #defaulted || !partial.#ident.is_empty() {
                         ::std::option::Option::Some(#collected)
                     } else {
                         ::std::option::Option::None
@@ -2271,26 +2286,83 @@ fn reset_to_default(field: &Field) -> TokenStream {
         return cleared;
     }
     // Every shape but a collection was checked in the model to have at most one.
-    let first = &field.default[0];
+    assign_literal(field, &field.default[0], field.default.as_slice())
+}
+
+/// Put `value` into the field the way a declared default does.
+fn assign_literal(field: &Field, first: &str, all: &[String]) -> TokenStream {
+    let ident = &field.ident;
+    let cleared = match field.shape {
+        Shape::Many => quote!(partial.#ident.clear();),
+        _ => quote!(),
+    };
     match field.shape {
         Shape::Bool => {
-            let on = first == "true";
+            let on = matches!(first, "1" | "true" | "True" | "TRUE");
             quote!(partial.#ident = #on;)
         }
         Shape::Optional => quote! {
             partial.#ident = ::std::option::Option::Some(#first.as_bytes().to_vec());
         },
         Shape::Required => quote!(partial.#ident = #first.as_bytes().to_vec();),
-        // Rejected in the model: a count starts at zero, so a default has nothing to say.
-        Shape::Count => cleared,
+        Shape::Count => quote!(partial.#ident = ::std::default::Default::default();),
         Shape::Many => {
-            let defaults = &field.default;
+            let defaults = all;
             quote! {
                 #cleared
                 #(partial.#ident.push(#defaults.as_bytes().to_vec());)*
             }
         }
     }
+}
+
+fn default_if_predicate(cli: &Cli, condition: &ConditionalDefault) -> TokenStream {
+    let Some(other) = cli.field_for_selector(&condition.selector) else {
+        return quote!(false);
+    };
+    let other_given = format_ident!("__given_{}", other.ident);
+    let ident = &other.ident;
+    match &condition.when {
+        None => quote!(partial.#other_given),
+        Some(when) => {
+            let matches = match other.shape {
+                Shape::Optional => quote!(
+                    partial.#ident.as_deref().is_some_and(|v| v == #when.as_bytes())
+                ),
+                Shape::Required => quote!(partial.#ident.as_slice() == #when.as_bytes()),
+                Shape::Many => quote!(
+                    partial.#ident.iter().any(|v| v.as_slice() == #when.as_bytes())
+                ),
+                Shape::Bool => {
+                    if matches!(when.as_str(), "1" | "true" | "True" | "TRUE") {
+                        quote!(partial.#ident)
+                    } else if matches!(when.as_str(), "0" | "false" | "False" | "FALSE") {
+                        quote!(!partial.#ident)
+                    } else {
+                        quote!(false)
+                    }
+                }
+                Shape::Count => match when.as_str() {
+                    "true" => quote!(partial.#ident > 0),
+                    "false" => quote!(partial.#ident == 0),
+                    _ => quote!(false),
+                },
+            };
+            quote!(partial.#other_given && #matches)
+        }
+    }
+}
+
+fn default_if_would_apply(cli: &Cli, field: &Field) -> Option<TokenStream> {
+    if field.default_if.is_empty() {
+        return None;
+    }
+    let preds: Vec<TokenStream> = field
+        .default_if
+        .iter()
+        .map(|condition| default_if_predicate(cli, condition))
+        .collect();
+    Some(quote!(#(#preds)||*))
 }
 
 /// Take one event and say whether it belonged to this command.
@@ -3518,14 +3590,37 @@ fn group_meta_table(cli: &Cli) -> (TokenStream, TokenStream) {
 /// without also asking it to report a missing sibling.
 fn declared_defaults(cli: &Cli) -> TokenStream {
     let own = cli.fields.iter().filter_map(|f| {
-        if f.default.is_empty() || matches!(f.kind, Kind::Subcommand { .. } | Kind::Skip) {
+        if matches!(f.kind, Kind::Subcommand { .. } | Kind::Skip) {
+            return None;
+        }
+        if f.default.is_empty() && f.default_if.is_empty() {
             return None;
         }
         let given = format_ident!("__given_{}", f.ident);
-        let assign = reset_to_default(f);
-        Some(quote! {
-            if !partial.#given {
+        let standing = displaced_guard(cli, f);
+        let mut fills: Vec<TokenStream> = f
+            .default_if
+            .iter()
+            .map(|condition| {
+                let pred = default_if_predicate(cli, condition);
+                let assign =
+                    assign_literal(f, &condition.value, std::slice::from_ref(&condition.value));
+                quote!(if !__usage_filled && (#pred) {
+                    #assign
+                    __usage_filled = true;
+                })
+            })
+            .collect();
+        if !f.default.is_empty() {
+            let assign = reset_to_default(f);
+            fills.push(quote!(if !__usage_filled {
                 #assign
+            }));
+        }
+        Some(quote! {
+            if !partial.#given #standing {
+                let mut __usage_filled = false;
+                #(#fills)*
             }
         })
     });
@@ -3919,12 +4014,22 @@ fn post_binding(cli: &Cli) -> TokenStream {
             }
             let other_given = format_ident!("__given_{}", other.ident);
             let other_name = &other.name;
-            Some(quote! {
-                if partial.#given && !partial.#other_given {
-                    return ::std::result::Result::Err(
-                        usage_argv::Error::MissingRequired { name: #other_name },
-                    );
-                }
+            let missing = quote! {
+                return ::std::result::Result::Err(
+                    usage_argv::Error::MissingRequired { name: #other_name },
+                );
+            };
+            Some(match default_if_would_apply(cli, other) {
+                Some(pred) => quote! {
+                    if partial.#given && !partial.#other_given && !(#pred) {
+                        #missing
+                    }
+                },
+                None => quote! {
+                    if partial.#given && !partial.#other_given {
+                        #missing
+                    }
+                },
             })
         })
     });
@@ -3962,8 +4067,12 @@ fn post_binding(cli: &Cli) -> TokenStream {
                     _ => quote!(false),
                 },
             };
+            let unless_default_if = match default_if_would_apply(cli, other) {
+                Some(pred) => quote!(&& !(#pred)),
+                None => quote!(),
+            };
             Some(quote! {
-                if partial.#given && #matches && !partial.#other_given {
+                if partial.#given && #matches && !partial.#other_given #unless_default_if {
                     return ::std::result::Result::Err(
                         usage_argv::Error::MissingRequired { name: #other_name },
                     );
@@ -4238,10 +4347,10 @@ fn post_binding(cli: &Cli) -> TokenStream {
     });
 
     quote! {
-        // Before the environment, which overrides a default when the flag was not given —
-        // the order `start` used to give them.
-        #declared_defaults
+        // Environment first, so a `default_if` can see a sibling filled from
+        // env, and so the environment still overrides an unconditional default.
         #env_fallbacks
+        #declared_defaults
         // Splitting before any check that counts or judges values, so `choices` sees a
         // value rather than the word that carried several, and the bounds count what the
         // user meant. After the environment, since `TAGS=a,b` is one word too.

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -2333,15 +2333,11 @@ fn default_if_predicate(cli: &Cli, condition: &ConditionalDefault) -> TokenStrea
                 Shape::Many => quote!(
                     partial.#ident.iter().any(|v| v.as_slice() == #when.as_bytes())
                 ),
-                Shape::Bool => {
-                    if matches!(when.as_str(), "1" | "true" | "True" | "TRUE") {
-                        quote!(partial.#ident)
-                    } else if matches!(when.as_str(), "0" | "false" | "False" | "FALSE") {
-                        quote!(!partial.#ident)
-                    } else {
-                        quote!(false)
-                    }
-                }
+                Shape::Bool => match when.as_str() {
+                    "true" => quote!(partial.#ident),
+                    "false" => quote!(!partial.#ident),
+                    _ => quote!(false),
+                },
                 Shape::Count => match when.as_str() {
                     "true" => quote!(partial.#ident > 0),
                     "false" => quote!(partial.#ident == 0),

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -207,6 +207,8 @@ pub struct Field {
     pub requires: Vec<String>,
     /// Requirements activated by one of this flag's explicit values.
     pub requires_if: Vec<ConditionalRequirement>,
+    /// Defaults that apply when another flag is given. First match wins.
+    pub default_if: Vec<ConditionalDefault>,
     /// The character a value is split on, making one word several values.
     ///
     /// Only where several can land, so the field has to be a collection — checked at
@@ -249,6 +251,16 @@ pub struct Field {
 pub struct ConditionalRequirement {
     pub value: String,
     pub requires: String,
+}
+
+/// A default that applies when another flag is given.
+///
+/// Two arguments are clap's `ArgPredicate::IsPresent`; three are `Equals`.
+#[derive(Debug, Clone)]
+pub struct ConditionalDefault {
+    pub selector: String,
+    pub when: Option<String>,
+    pub value: String,
 }
 
 /// How a positional argument relates to the `--` separator.
@@ -1016,6 +1028,24 @@ impl Cli {
                     ));
                 }
             }
+            for condition in &field.default_if {
+                let selector = &condition.selector;
+                let Some(target) = self.field_for_selector(selector) else {
+                    return Err(syn::Error::new(
+                        field.span,
+                        format!(
+                            "`default_if(\"{selector}\", _)` names no flag on this command; \
+                             write it as the spec does, `--long` or `-s`"
+                        ),
+                    ));
+                };
+                if target.ident == field.ident {
+                    return Err(syn::Error::new(
+                        field.span,
+                        format!("`default_if(\"{selector}\", _)` names its own field"),
+                    ));
+                }
+            }
         }
         Ok(())
     }
@@ -1102,6 +1132,7 @@ impl Field {
             conflicts: Vec::new(),
             requires: Vec::new(),
             requires_if: Vec::new(),
+            default_if: Vec::new(),
             delimiter: None,
             allow_hyphen_values: false,
             require_equals: false,
@@ -1209,6 +1240,7 @@ impl Field {
             conflicts: Vec::new(),
             requires: Vec::new(),
             requires_if: Vec::new(),
+            default_if: Vec::new(),
             delimiter: None,
             allow_hyphen_values: false,
             require_equals: false,
@@ -1310,6 +1342,7 @@ impl Field {
             conflicts: Vec::new(),
             requires: Vec::new(),
             requires_if: Vec::new(),
+            default_if: Vec::new(),
             delimiter: None,
             allow_hyphen_values: false,
             require_equals: false,
@@ -1380,6 +1413,7 @@ impl Field {
         let mut conflicts: Vec<String> = Vec::new();
         let mut requires: Vec<String> = Vec::new();
         let mut requires_if: Vec<ConditionalRequirement> = Vec::new();
+        let mut default_if: Vec<ConditionalDefault> = Vec::new();
         let mut group: Option<String> = None;
         let mut exclusive = false;
         let mut delimiter: Option<char> = None;
@@ -1480,6 +1514,8 @@ impl Field {
                     "requires" => requires = selectors(&meta)?,
                     "requires_if" => requires_if.push(requirement_if(&meta)?),
                     "requires_ifs" => requires_if.extend(requirements_if(&meta)?),
+                    "default_if" => default_if.push(default_if_attr(&meta)?),
+                    "default_ifs" => default_if.extend(default_ifs_attr(&meta)?),
                     "group" => group = Some(string_value(&meta)?),
                     "exclusive" => exclusive = flag_value(&meta)?,
                     "allow_hyphen_values" => allow_hyphen_values = flag_value(&meta)?,
@@ -1543,7 +1579,7 @@ impl Field {
                                  `var_min`, `var_max`, `value_enum`, `value_hint`, `overrides`, \
                                  `conflicts`, `requires`, `group`, `exclusive`, \
                                  `delimiter`, `allow_hyphen_values`, `require_equals`, \
-                                 `default_missing`, \
+                                 `default_missing`, `default_if`, \
                                  `required_if`, \
                                  `required_unless`, `help_heading`, `value_name`, \
                                  `verbatim_doc_comment`, \
@@ -1760,6 +1796,19 @@ impl Field {
                     ),
                 ));
             }
+            if let Some(value) = default_if
+                .iter()
+                .map(|condition| &condition.value)
+                .find(|value| !choices.contains(value))
+            {
+                return Err(syn::Error::new(
+                    span,
+                    format!(
+                        "the default_if value `{value}` is not one of this field's \
+                         choices, so it could never be valid"
+                    ),
+                ));
+            }
         }
 
         let is_flag = !longs.is_empty() || !shorts.is_empty();
@@ -1838,6 +1887,20 @@ impl Field {
                 span,
                 "`requires_if` describes a relationship between flags, so the field \
                  needs a `long` or a `short`",
+            ));
+        }
+        if !default_if.is_empty() && !is_flag {
+            return Err(syn::Error::new(
+                span,
+                "`default_if` describes a relationship between flags, so the field \
+                 needs a `long` or a `short`",
+            ));
+        }
+        if !default_if.is_empty() && shape == Shape::Count {
+            return Err(syn::Error::new(
+                span,
+                "`default_if` binds a value, and a `count` field holds how many times \
+                 the flag was given rather than a value",
             ));
         }
         // Declared text wins over the comment, which is the point of declaring it. A comment's
@@ -2178,6 +2241,7 @@ impl Field {
             conflicts,
             requires,
             requires_if,
+            default_if,
             delimiter,
             allow_hyphen_values,
             require_equals,
@@ -2530,6 +2594,87 @@ fn requirements_if(meta: &Meta) -> syn::Result<Vec<ConditionalRequirement>> {
             let value = string_expr(elems.next().expect("length checked"))?;
             let requires = string_expr(elems.next().expect("length checked"))?;
             Ok(ConditionalRequirement { value, requires })
+        })
+        .collect()
+}
+
+fn default_if_attr(meta: &Meta) -> syn::Result<ConditionalDefault> {
+    let Meta::List(list) = meta else {
+        return Err(syn::Error::new_spanned(
+            meta,
+            "`default_if` takes a flag and a value, as in `default_if(\"--json\", \"true\")`, \
+             or a flag, a value, and a default, as in `default_if(\"--output\", \"json\", \"pretty\")`",
+        ));
+    };
+    let args: Vec<_> = list
+        .parse_args_with(
+            syn::punctuated::Punctuated::<syn::LitStr, syn::Token![,]>::parse_terminated,
+        )?
+        .into_iter()
+        .collect();
+    match args.len() {
+        2 => Ok(ConditionalDefault {
+            selector: args[0].value(),
+            when: None,
+            value: args[1].value(),
+        }),
+        3 => Ok(ConditionalDefault {
+            selector: args[0].value(),
+            when: Some(args[1].value()),
+            value: args[2].value(),
+        }),
+        _ => Err(syn::Error::new_spanned(
+            meta,
+            "`default_if` takes two arguments (`--json`, `true`) or three \
+             (`--output`, `json`, `pretty`)",
+        )),
+    }
+}
+
+fn default_ifs_attr(meta: &Meta) -> syn::Result<Vec<ConditionalDefault>> {
+    let Meta::List(list) = meta else {
+        return Err(syn::Error::new_spanned(
+            meta,
+            "`default_ifs` takes tuples of two or three strings",
+        ));
+    };
+    let pairs = list.parse_args_with(
+        syn::punctuated::Punctuated::<syn::ExprTuple, syn::Token![,]>::parse_terminated,
+    )?;
+    if pairs.is_empty() {
+        return Err(syn::Error::new_spanned(
+            meta,
+            "`default_ifs` needs at least one tuple",
+        ));
+    }
+    pairs
+        .into_iter()
+        .map(|pair| {
+            let n = pair.elems.len();
+            if n != 2 && n != 3 {
+                return Err(syn::Error::new_spanned(
+                    pair,
+                    "each `default_ifs` entry is `(flag, value)` or `(flag, when, value)`",
+                ));
+            }
+            let mut elems = pair.elems.into_iter();
+            let selector = string_expr(elems.next().expect("length checked"))?;
+            if n == 2 {
+                let value = string_expr(elems.next().expect("length checked"))?;
+                Ok(ConditionalDefault {
+                    selector,
+                    when: None,
+                    value,
+                })
+            } else {
+                let when = string_expr(elems.next().expect("length checked"))?;
+                let value = string_expr(elems.next().expect("length checked"))?;
+                Ok(ConditionalDefault {
+                    selector,
+                    when: Some(when),
+                    value,
+                })
+            }
         })
         .collect()
 }
@@ -3432,6 +3577,78 @@ mod tests {
         "#,
         );
         assert!(err.contains("relationship between flags"), "{err}");
+    }
+
+    #[test]
+    fn conditional_defaults_need_a_flag_and_a_known_selector() {
+        let cli = cli(r#"
+            struct Ex {
+                #[usage(long, default_if("--json", "true"))]
+                bin_names: bool,
+                #[usage(long)]
+                json: bool,
+                #[usage(long, default_if("--output", "json", "pretty"))]
+                style: Option<String>,
+                #[usage(long)]
+                output: Option<String>,
+            }
+        "#)
+        .expect("should compile");
+        assert_eq!(cli.fields[0].default_if.len(), 1);
+        assert!(cli.fields[0].default_if[0].when.is_none());
+        assert_eq!(cli.fields[2].default_if[0].when.as_deref(), Some("json"));
+
+        let err = rejection(
+            r#"
+            struct Ex {
+                #[usage(long, default_if("--json", "true"))]
+                bin_names: bool,
+            }
+        "#,
+        );
+        assert!(err.contains("names no flag"), "{err}");
+
+        let err = rejection(
+            r#"
+            struct Ex {
+                #[usage(default_if("--json", "true"))]
+                bin_names: bool,
+                #[usage(long)]
+                json: bool,
+            }
+        "#,
+        );
+        assert!(err.contains("relationship between flags"), "{err}");
+
+        let err = rejection(
+            r#"
+            struct Ex {
+                #[usage(long, default_if("--json"))]
+                bin_names: bool,
+                #[usage(long)]
+                json: bool,
+            }
+        "#,
+        );
+        assert!(err.contains("two arguments"), "{err}");
+    }
+
+    #[test]
+    fn every_default_if_value_has_to_be_one_of_the_choices() {
+        let err = rejection(
+            r#"
+            struct Ex {
+                #[usage(long, default_if("--json", "wat"), choices("auto", "always", "never"))]
+                color: Option<String>,
+                #[usage(long)]
+                json: bool,
+            }
+        "#,
+        );
+        assert!(
+            err.contains("the default_if value `wat`"),
+            "unhelpful message: {err}"
+        );
     }
 
     #[test]

--- a/docs/go/binding.md
+++ b/docs/go/binding.md
@@ -11,12 +11,15 @@ when you never call the functions: they define what your users' command lines me
 
 ## Resolution order
 
-Each flag or arg resolves **argv → env → default**, matching
+Each flag or arg resolves **argv → env → default_if → default**, matching
 [config resolution](/spec/resolution):
 
 ```go
 values, source := argv.Fill(Meta.Lookup(key), given, argv.LookupEnv)
 ```
+
+Fill every entry first, then `argv.ApplyDefaultIf` so a `default_if` can see a
+sibling that came from argv or env. An applied `default_if` is `FromDefault`.
 
 `Source` tells you where the value came from: `FromArgv`, `FromEnv`, `FromDefault`, or `Unset`.
 `Source.Given()` is true only for the first two — a default is a fallback, not something the

--- a/docs/go/generated-code.md
+++ b/docs/go/generated-code.md
@@ -84,7 +84,7 @@ type InstallCmd struct {
 `Parse` walks the events, fills the structs, then — for the commands the words actually
 selected — applies fallbacks and checks:
 
-1. values resolve **argv → env → default**, per entry
+1. values resolve **argv → env → default_if → default**, per entry
 2. `required`, `choices`, `var_min`/`var_max` are checked
 3. `conflicts`, `required_if`, `required_unless` are checked across the selected commands
 

--- a/docs/rust/args-and-flags.md
+++ b/docs/rust/args-and-flags.md
@@ -77,6 +77,7 @@ jobs: Option<u32>,
 | `allow_hyphen_values`                   | Detached flag value may look like a flag, including `--`                                |
 | `require_equals`                        | Accept `--flag=value` and refuse `--flag value`                                         |
 | `default_missing = "…"`                 | Value when the flag is given with none (`--color` vs `--color=never`)                   |
+| `default_if("--json", "true")`          | Default when another flag is given (two args = present, three = equals)                 |
 | `group = "name"`                        | Join a flag group ([Validation](/rust/validation#groups))                               |
 | `exclusive`                             | Must be given alone ([Validation](/rust/validation#exclusive-flags))                    |
 | `conflicts(…)` / `requires(…)`          | Relations to other flags ([Validation](/rust/validation))                               |
@@ -116,6 +117,18 @@ The flag has to take a value. Help shows the value as optional. Emitted KDL:
 `flag "--color <WHEN>" default_missing="always"`. Combined with `require_equals`,
 a following word is still refused.
 
+`#[usage(default_if("--json", "true"))]` is clap's `default_value_if` with
+`ArgPredicate::IsPresent`. Three arguments (`default_if("--output", "json", "pretty")`)
+are `Equals`. First match wins. The target's own argv and env suppress it. An
+applied `default_if` is a default: it does not set `__given_*`, so it does not
+activate `requires_if`. Emitted KDL:
+
+```kdl
+flag "--bin-names" {
+  default_if "--json" "true"
+}
+```
+
 Flag relations (`conflicts`, `requires`, `overrides`, `required_if`, `required_unless`) name
 their target the way the KDL spec does — `"--long"` or `"-s"`, one value or a list:
 
@@ -134,7 +147,8 @@ After argv is parsed, each field resolves in this order — matching
 
 1. the value given on the command line
 2. the `env` variable, if set
-3. the `default`, if declared
+3. a matching `default_if`, if declared
+4. the `default`, if declared
 
 Then validation runs: required-ness (skipped for anything a default or env var filled),
 `choices`, and `var_min`/`var_max`. Only the command that actually ran is judged — a required

--- a/docs/spec/integrations/clap.md
+++ b/docs/spec/integrations/clap.md
@@ -60,7 +60,8 @@ exposes a getter for. [`requires`](/spec/reference/flag#requires) is the notable
 does not: `Arg::requires`, `requires_if`, `requires_ifs` and `requires_all` are setters
 with no reader, so a flag declared with them arrives in the spec with no requirement on
 it, and everything downstream — help, docs, completions — describes a CLI without that
-constraint.
+constraint. `Arg::default_value_if` is the same hole: a generated spec never carries
+[`default_if`](/spec/reference/flag#default_if).
 
 Declaring it in the spec is the way to have it. A CLI that keeps its source of truth in
 clap can add the node to a hand-written overlay spec merged with the generated one.

--- a/docs/spec/reference/flag.md
+++ b/docs/spec/reference/flag.md
@@ -40,6 +40,9 @@ flag "--tags <tag>" var=#true delimiter="," // --tags a,b,c is three values
 flag "--args <ARGS>" allow_hyphen_values=#true // --args -destroy binds "-destroy"
 flag "--inspect <PORT>" require_equals=#true   // --inspect=9229 yes, --inspect 9229 no
 flag "--color <WHEN>" default_missing="always" // --color is always; --color=never is never
+flag "--bin-names" {
+  default_if "--json" "true" // --json implies --bin-names
+}
 
 flag "--stdin" {
   conflicts "--file" "--url" // several, one per argument
@@ -119,6 +122,32 @@ This is the same source distinction clap's `requires_if` and `requires_ifs` make
 A spec generated from a clap command never carries this. clap has `Arg::requires` as a
 setter with no getter, so [the clap integration](/spec/integrations/clap) cannot read it
 back out — a CLI that wants the constraint in its spec has to declare it here.
+:::
+
+## `default_if`
+
+A default that depends on another flag. Lives on the _target_ — the flag that
+gets the value — which is the inverse of [`requires_if`](#requires_if):
+
+```kdl
+flag "--bin-names" {
+  default_if "--json" "true"            // --json is enough
+  default_if "--output" "json" "pretty" // --output json binds pretty
+}
+```
+
+Two arguments are clap's `ArgPredicate::IsPresent`; three are `Equals`. The node
+may be repeated; the first matching condition wins.
+
+Only considered when this flag was not on the command line and has no environment
+value. An applied `default_if` is a default, not an explicit value: it satisfies
+[`requires`](#requires) and does not activate `requires_if`.
+
+::: warning
+A spec generated from a clap command never carries this. clap has
+`Arg::default_value_if` as a setter with no getter, so
+[the clap integration](/spec/integrations/clap) cannot read it back out — the
+same hole as `requires`.
 :::
 
 ## `exclusive`

--- a/go/argv/post.go
+++ b/go/argv/post.go
@@ -205,7 +205,11 @@ func Fill(m *Meta, given []string, lookupEnv func(string) (string, bool)) ([]str
 // First matching DefaultIf wins; an unconditional Default applies only when
 // none did. Mutates `filled` and `sources` in place. A no-op when nothing
 // declares DefaultIf, so generated parsers can always call it.
-func ApplyDefaultIf(meta Metadata, scope []uint64, filled map[uint64][]string, sources map[uint64]Source) {
+//
+// `negated` is which flags arrived as their negate form (`--no-json`). An Equals
+// DefaultIf on a bool reads that as "false", the same way [RelationshipValues]
+// does for requires_if. A nil map is all false.
+func ApplyDefaultIf(meta Metadata, scope []uint64, filled map[uint64][]string, sources map[uint64]Source, negated map[uint64]bool) {
 	if filled == nil || sources == nil {
 		return
 	}
@@ -219,7 +223,7 @@ func ApplyDefaultIf(meta Metadata, scope []uint64, filled map[uint64][]string, s
 		}
 		applied := false
 		for i := range m.DefaultIf {
-			if defaultIfMatches(&m.DefaultIf[i], filled, sources, meta) {
+			if defaultIfMatches(&m.DefaultIf[i], filled, sources, meta, negated) {
 				filled[key] = []string{m.DefaultIf[i].Value}
 				sources[key] = FromDefault
 				applied = true
@@ -233,7 +237,7 @@ func ApplyDefaultIf(meta Metadata, scope []uint64, filled map[uint64][]string, s
 	}
 }
 
-func defaultIfMatches(cond *DefaultIf, filled map[uint64][]string, sources map[uint64]Source, meta Metadata) bool {
+func defaultIfMatches(cond *DefaultIf, filled map[uint64][]string, sources map[uint64]Source, meta Metadata, negated map[uint64]bool) bool {
 	src := sources[cond.Key]
 	if !src.Given() {
 		return false
@@ -241,7 +245,7 @@ func defaultIfMatches(cond *DefaultIf, filled map[uint64][]string, sources map[u
 	if cond.When == "" {
 		return true
 	}
-	values := explicitRelationshipValues(meta.Lookup(cond.Key), filled[cond.Key], src)
+	values := explicitRelationshipValues(meta.Lookup(cond.Key), filled[cond.Key], src, negated[cond.Key])
 	for _, value := range values {
 		if value == cond.When {
 			return true
@@ -250,12 +254,12 @@ func defaultIfMatches(cond *DefaultIf, filled map[uint64][]string, sources map[u
 	return false
 }
 
-func explicitRelationshipValues(m *Meta, values []string, source Source) []string {
+func explicitRelationshipValues(m *Meta, values []string, source Source, negated bool) []string {
 	if m != nil && m.Flag && m.ValueName == "" && len(m.Choices) == 0 {
-		return RelationshipValues(&Meta{RequiresIfBoolean: true}, values, source, false)
+		return RelationshipValues(&Meta{RequiresIfBoolean: true}, values, source, negated)
 	}
 	if len(values) == 0 && source.Given() && m != nil && m.Flag {
-		return RelationshipValues(&Meta{RequiresIfBoolean: true}, values, source, false)
+		return RelationshipValues(&Meta{RequiresIfBoolean: true}, values, source, negated)
 	}
 	return values
 }

--- a/go/argv/post.go
+++ b/go/argv/post.go
@@ -95,12 +95,23 @@ type Meta struct {
 	// RequiresIf names entries required when this entry explicitly has Value.
 	// Defaults do not activate the condition, but may satisfy the requirement.
 	RequiresIf []ValueRequirement
+	// DefaultIf binds Value when another entry matches. First match wins.
+	// Two-argument form (When empty) is presence; When set is equality.
+	// An applied DefaultIf is a default, not an explicit value.
+	DefaultIf []DefaultIf
 }
 
 // ValueRequirement is one value-conditional relationship.
 type ValueRequirement struct {
 	Value string
 	Key   uint64
+}
+
+// DefaultIf is one conditional default, resolved to the selector's key.
+type DefaultIf struct {
+	Key   uint64
+	When  string
+	Value string
 }
 
 // Metadata is the cold table, indexed by key.
@@ -177,10 +188,76 @@ func Fill(m *Meta, given []string, lookupEnv func(string) (string, bool)) ([]str
 			return []string{v}, FromEnv
 		}
 	}
+	// Conditional defaults need sibling state, which this function cannot see.
+	// Leave the entry unset so [ApplyDefaultIf] can choose, then fall back to
+	// Default there as well.
+	if len(m.DefaultIf) > 0 {
+		return nil, Unset
+	}
 	if len(m.Default) > 0 {
 		return m.Default, FromDefault
 	}
 	return nil, Unset
+}
+
+// ApplyDefaultIf fills entries still unset after [Fill], using sibling state.
+//
+// First matching DefaultIf wins; an unconditional Default applies only when
+// none did. Mutates `filled` and `sources` in place. A no-op when nothing
+// declares DefaultIf, so generated parsers can always call it.
+func ApplyDefaultIf(meta Metadata, scope []uint64, filled map[uint64][]string, sources map[uint64]Source) {
+	if filled == nil || sources == nil {
+		return
+	}
+	for _, key := range scope {
+		if sources[key] != Unset {
+			continue
+		}
+		m := meta.Lookup(key)
+		if m == nil {
+			continue
+		}
+		applied := false
+		for i := range m.DefaultIf {
+			if defaultIfMatches(&m.DefaultIf[i], filled, sources, meta) {
+				filled[key] = []string{m.DefaultIf[i].Value}
+				sources[key] = FromDefault
+				applied = true
+				break
+			}
+		}
+		if !applied && len(m.Default) > 0 {
+			filled[key] = m.Default
+			sources[key] = FromDefault
+		}
+	}
+}
+
+func defaultIfMatches(cond *DefaultIf, filled map[uint64][]string, sources map[uint64]Source, meta Metadata) bool {
+	src := sources[cond.Key]
+	if !src.Given() {
+		return false
+	}
+	if cond.When == "" {
+		return true
+	}
+	values := explicitRelationshipValues(meta.Lookup(cond.Key), filled[cond.Key], src)
+	for _, value := range values {
+		if value == cond.When {
+			return true
+		}
+	}
+	return false
+}
+
+func explicitRelationshipValues(m *Meta, values []string, source Source) []string {
+	if m != nil && m.Flag && m.ValueName == "" && len(m.Choices) == 0 {
+		return RelationshipValues(&Meta{RequiresIfBoolean: true}, values, source, false)
+	}
+	if len(values) == 0 && source.Given() && m != nil && m.Flag {
+		return RelationshipValues(&Meta{RequiresIfBoolean: true}, values, source, false)
+	}
+	return values
 }
 
 // Check applies the rules that judge what ended up bound.

--- a/go/argv/post_test.go
+++ b/go/argv/post_test.go
@@ -215,22 +215,43 @@ func TestApplyDefaultIf(t *testing.T) {
 	}
 	filled := map[uint64][]string{json: {}, bin: nil}
 	sources := map[uint64]Source{json: FromArgv, bin: Unset}
-	ApplyDefaultIf(meta, []uint64{json, bin}, filled, sources)
+	ApplyDefaultIf(meta, []uint64{json, bin}, filled, sources, nil)
 	if sources[bin] != FromDefault || !reflect.DeepEqual(filled[bin], []string{"true"}) {
 		t.Errorf("IsPresent should bind: %q from %v", filled[bin], sources[bin])
 	}
 
 	filled = map[uint64][]string{json: nil, bin: nil}
 	sources = map[uint64]Source{json: Unset, bin: Unset}
-	ApplyDefaultIf(meta, []uint64{json, bin}, filled, sources)
+	ApplyDefaultIf(meta, []uint64{json, bin}, filled, sources, nil)
 	if sources[bin] != FromDefault || !reflect.DeepEqual(filled[bin], []string{"false"}) {
 		t.Errorf("unconditional default when no match: %q from %v", filled[bin], sources[bin])
 	}
 
 	filled = map[uint64][]string{json: {}, bin: []string{"already"}}
 	sources = map[uint64]Source{json: FromArgv, bin: FromEnv}
-	ApplyDefaultIf(meta, []uint64{json, bin}, filled, sources)
+	ApplyDefaultIf(meta, []uint64{json, bin}, filled, sources, nil)
 	if sources[bin] != FromEnv || !reflect.DeepEqual(filled[bin], []string{"already"}) {
 		t.Errorf("env on the target suppresses: %q from %v", filled[bin], sources[bin])
+	}
+
+	pretty := uint64(2)
+	meta = Metadata{
+		{Key: json, Name: "json", Flag: true},
+		{Key: pretty, Name: "pretty", Flag: true, DefaultIf: []DefaultIf{
+			{Key: json, When: "false", Value: "true"},
+		}},
+	}
+	filled = map[uint64][]string{json: {}, pretty: nil}
+	sources = map[uint64]Source{json: FromArgv, pretty: Unset}
+	ApplyDefaultIf(meta, []uint64{json, pretty}, filled, sources, map[uint64]bool{json: true})
+	if sources[pretty] != FromDefault || !reflect.DeepEqual(filled[pretty], []string{"true"}) {
+		t.Errorf("--no-json should match when=false: %q from %v", filled[pretty], sources[pretty])
+	}
+
+	filled = map[uint64][]string{json: {}, pretty: nil}
+	sources = map[uint64]Source{json: FromArgv, pretty: Unset}
+	ApplyDefaultIf(meta, []uint64{json, pretty}, filled, sources, nil)
+	if sources[pretty] != Unset {
+		t.Errorf("--json should not match when=false: %q from %v", filled[pretty], sources[pretty])
 	}
 }

--- a/go/argv/post_test.go
+++ b/go/argv/post_test.go
@@ -203,3 +203,34 @@ func TestSourceGiven(t *testing.T) {
 		t.Error("a default is a fallback, not something the user said")
 	}
 }
+
+func TestApplyDefaultIf(t *testing.T) {
+	json := uint64(1)
+	bin := uint64(2)
+	meta := Metadata{
+		{Key: json, Name: "json", Flag: true},
+		{Key: bin, Name: "bin-names", Flag: true, DefaultIf: []DefaultIf{
+			{Key: json, Value: "true"},
+		}, Default: []string{"false"}},
+	}
+	filled := map[uint64][]string{json: {}, bin: nil}
+	sources := map[uint64]Source{json: FromArgv, bin: Unset}
+	ApplyDefaultIf(meta, []uint64{json, bin}, filled, sources)
+	if sources[bin] != FromDefault || !reflect.DeepEqual(filled[bin], []string{"true"}) {
+		t.Errorf("IsPresent should bind: %q from %v", filled[bin], sources[bin])
+	}
+
+	filled = map[uint64][]string{json: nil, bin: nil}
+	sources = map[uint64]Source{json: Unset, bin: Unset}
+	ApplyDefaultIf(meta, []uint64{json, bin}, filled, sources)
+	if sources[bin] != FromDefault || !reflect.DeepEqual(filled[bin], []string{"false"}) {
+		t.Errorf("unconditional default when no match: %q from %v", filled[bin], sources[bin])
+	}
+
+	filled = map[uint64][]string{json: {}, bin: []string{"already"}}
+	sources = map[uint64]Source{json: FromArgv, bin: FromEnv}
+	ApplyDefaultIf(meta, []uint64{json, bin}, filled, sources)
+	if sources[bin] != FromEnv || !reflect.DeepEqual(filled[bin], []string{"already"}) {
+		t.Errorf("env on the target suppresses: %q from %v", filled[bin], sources[bin])
+	}
+}

--- a/go/argv/post_test.go
+++ b/go/argv/post_test.go
@@ -254,4 +254,17 @@ func TestApplyDefaultIf(t *testing.T) {
 	if sources[pretty] != Unset {
 		t.Errorf("--json should not match when=false: %q from %v", filled[pretty], sources[pretty])
 	}
+
+	meta = Metadata{
+		{Key: json, Name: "json", Flag: true, Default: []string{"true"}},
+		{Key: pretty, Name: "pretty", Flag: true, DefaultIf: []DefaultIf{
+			{Key: json, Value: "true"},
+		}},
+	}
+	filled = map[uint64][]string{json: {"true"}, pretty: nil}
+	sources = map[uint64]Source{json: FromDefault, pretty: Unset}
+	ApplyDefaultIf(meta, []uint64{json, pretty}, filled, sources, nil)
+	if sources[pretty] != Unset {
+		t.Errorf("a default is not Given: %q from %v", filled[pretty], sources[pretty])
+	}
 }

--- a/go/conformance/conformance_test.go
+++ b/go/conformance/conformance_test.go
@@ -321,6 +321,20 @@ func run(s *spec.Spec, args []string, env map[string]string) (*Parsed, *argv.Err
 		}
 	}
 
+	filled := map[uint64][]string{}
+	sources := map[uint64]argv.Source{}
+	for _, key := range scope {
+		r := final[key]
+		filled[key] = r.values
+		sources[key] = r.source
+	}
+	argv.ApplyDefaultIf(meta, scope, filled, sources)
+	for _, key := range scope {
+		r := final[key]
+		r.values = filled[key]
+		r.source = sources[key]
+	}
+
 	// What one entry ended up with, judged on its own.
 	for _, key := range scope {
 		r := final[key]

--- a/go/conformance/conformance_test.go
+++ b/go/conformance/conformance_test.go
@@ -323,12 +323,14 @@ func run(s *spec.Spec, args []string, env map[string]string) (*Parsed, *argv.Err
 
 	filled := map[uint64][]string{}
 	sources := map[uint64]argv.Source{}
+	negated := map[uint64]bool{}
 	for _, key := range scope {
 		r := final[key]
 		filled[key] = r.values
 		sources[key] = r.source
+		negated[key] = r.negated
 	}
-	argv.ApplyDefaultIf(meta, scope, filled, sources)
+	argv.ApplyDefaultIf(meta, scope, filled, sources, negated)
 	for _, key := range scope {
 		r := final[key]
 		r.values = filled[key]

--- a/go/internal/shadow/mise/tables.go
+++ b/go/internal/shadow/mise/tables.go
@@ -10490,9 +10490,15 @@ func Parse(args []string) (*Cli, error) {
 		}
 	}
 	sources := map[uint64]argv.Source{}
+	filled := map[uint64][]string{}
 	for _, key := range scope {
 		values, source := argv.Fill(Meta.Lookup(key), given[key], argv.LookupEnv)
+		filled[key] = values
 		sources[key] = source
+	}
+	argv.ApplyDefaultIf(Meta, scope, filled, sources, nil)
+	for _, key := range scope {
+		values, source := filled[key], sources[key]
 		if err := argv.Check(Meta.Lookup(key), values, seen[key]); err != nil {
 			return nil, err
 		}

--- a/go/internal/spec/spec.go
+++ b/go/internal/spec/spec.go
@@ -209,6 +209,7 @@ type Flag struct {
 	RequiredIf     []string     `json:"required_if"`
 	RequiredUnless []string     `json:"required_unless"`
 	RequiresIf     []RequiresIf `json:"requires_if"`
+	DefaultIf      []DefaultIf  `json:"default_if"`
 	RequireEquals  bool         `json:"require_equals"`
 	// Empty means unset: usage-lib stores Option, and a missing default of "" is
 	// not carried across the lowering. The corpus never uses one.
@@ -220,6 +221,13 @@ type Flag struct {
 type RequiresIf struct {
 	Value    string `json:"value"`
 	Requires string `json:"requires"`
+}
+
+// DefaultIf is a default that applies when another flag is given.
+type DefaultIf struct {
+	Selector string `json:"selector"`
+	When     string `json:"when"`
+	Value    string `json:"value"`
 }
 
 // spelling is how a user types a flag: its first long form, else its first short.
@@ -611,6 +619,15 @@ func (b *builder) resolveRelationships(c *Cmd, out *argv.Command) {
 		}
 		return out
 	}
+	resolveDefaultIf := func(conditions []DefaultIf) []argv.DefaultIf {
+		var out []argv.DefaultIf
+		for _, condition := range conditions {
+			if key, ok := find(condition.Selector); ok {
+				out = append(out, argv.DefaultIf{Key: key, When: condition.When, Value: condition.Value})
+			}
+		}
+		return out
+	}
 
 	// `c.Flags` and `out.Flags` are built in step, so the index is the join.
 	for i := range c.Flags {
@@ -621,6 +638,7 @@ func (b *builder) resolveRelationships(c *Cmd, out *argv.Command) {
 		m.RequiredUnless = resolve(src.RequiredUnless)
 		m.RequiredIf = resolve(src.RequiredIf)
 		m.RequiresIf = resolveValues(src.RequiresIf)
+		m.DefaultIf = resolveDefaultIf(src.DefaultIf)
 	}
 }
 

--- a/go/internal/spec/spec_test.go
+++ b/go/internal/spec/spec_test.go
@@ -528,3 +528,29 @@ func TestDefaultMissingCarries(t *testing.T) {
 		t.Errorf("default_missing: got %q", root.Flags[0].DefaultMissing)
 	}
 }
+
+func TestDefaultIfResolves(t *testing.T) {
+	root, meta := build(&Spec{
+		Name: "ex", Bin: "ex",
+		Cmd: Cmd{Name: "ex", Flags: []Flag{
+			{Name: "bin-names", Long: []string{"bin-names"}, DefaultIf: []DefaultIf{
+				{Selector: "--json", Value: "true"},
+				{Selector: "--output", When: "json", Value: "pretty"},
+			}},
+			{Name: "json", Long: []string{"json"}},
+			{Name: "output", Long: []string{"output"}, Arg: &Arg{Name: "fmt"}},
+		}},
+	})
+	m := metaFor(t, meta, root, "bin-names")
+	if len(m.DefaultIf) != 2 {
+		t.Fatalf("default_if: %+v", m.DefaultIf)
+	}
+	jsonKey := metaFor(t, meta, root, "json").Key
+	outputKey := metaFor(t, meta, root, "output").Key
+	if m.DefaultIf[0].Key != jsonKey || m.DefaultIf[0].Value != "true" || m.DefaultIf[0].When != "" {
+		t.Errorf("IsPresent: %+v", m.DefaultIf[0])
+	}
+	if m.DefaultIf[1].Key != outputKey || m.DefaultIf[1].When != "json" || m.DefaultIf[1].Value != "pretty" {
+		t.Errorf("Equals: %+v", m.DefaultIf[1])
+	}
+}

--- a/lib/src/go/mod.rs
+++ b/lib/src/go/mod.rs
@@ -542,6 +542,29 @@ impl Emitter<'_> {
                 requires_if.join(", ")
             ));
         }
+        let default_if = flag
+            .default_if
+            .iter()
+            .filter_map(|condition| {
+                resolve_relationship(std::slice::from_ref(&condition.selector), owner, commands)
+                    .into_iter()
+                    .next()
+                    .map(|key| match &condition.when {
+                        None => format!("{{Key: {key}, Value: {}}}", go_string(&condition.value)),
+                        Some(when) => format!(
+                            "{{Key: {key}, When: {}, Value: {}}}",
+                            go_string(when),
+                            go_string(&condition.value)
+                        ),
+                    })
+            })
+            .collect::<Vec<_>>();
+        if !default_if.is_empty() {
+            fields.push(format!(
+                "DefaultIf: []argv.DefaultIf{{{}}}",
+                default_if.join(", ")
+            ));
+        }
 
         format!("{{{}}}", fields.join(", "))
     }
@@ -1734,6 +1757,33 @@ flag "--schema <file>"
         assert!(
             out.contains("argv.CheckRelationshipsWithValues"),
             "the emitted parser must enforce the metadata:\n{out}"
+        );
+    }
+
+    #[test]
+    fn a_conditional_default_reaches_go_metadata() {
+        let out = go(r#"
+name "ex"
+bin "ex"
+flag "--bin-names" {
+    default_if "--json" "true"
+    default_if "--output" "json" "pretty"
+}
+flag "--json"
+flag "--output <fmt>"
+"#);
+        assert!(
+            entry_of(&out, "bin-names")
+                .contains("DefaultIf: []argv.DefaultIf{{Key: FlagJson, Value: \"true\"}"),
+            "{out}"
+        );
+        assert!(
+            entry_of(&out, "bin-names").contains("When: \"json\""),
+            "{out}"
+        );
+        assert!(
+            out.contains("argv.ApplyDefaultIf"),
+            "the emitted parser must apply the metadata:\n{out}"
         );
     }
 

--- a/lib/src/go/mod.rs
+++ b/lib/src/go/mod.rs
@@ -1785,6 +1785,10 @@ flag "--output <fmt>"
             out.contains("argv.ApplyDefaultIf"),
             "the emitted parser must apply the metadata:\n{out}"
         );
+        assert!(
+            out.contains("negated[ev.Flag.Key] = ev.Negated"),
+            "Equals default_if needs the negate form:\n{out}"
+        );
     }
 
     /// The form is part of the name, and usage-lib resolves neither of the

--- a/lib/src/go/snapshots/usage__go__tests__a_default_subcommand_points_into_the_tree.snap
+++ b/lib/src/go/snapshots/usage__go__tests__a_default_subcommand_points_into_the_tree.snap
@@ -159,7 +159,7 @@ func Parse(args []string) (*Cli, error) {
 		filled[key] = values
 		sources[key] = source
 	}
-	argv.ApplyDefaultIf(Meta, scope, filled, sources)
+	argv.ApplyDefaultIf(Meta, scope, filled, sources, nil)
 	for _, key := range scope {
 		values, source := filled[key], sources[key]
 		if err := argv.Check(Meta.Lookup(key), values, seen[key]); err != nil {

--- a/lib/src/go/snapshots/usage__go__tests__a_default_subcommand_points_into_the_tree.snap
+++ b/lib/src/go/snapshots/usage__go__tests__a_default_subcommand_points_into_the_tree.snap
@@ -153,9 +153,15 @@ func Parse(args []string) (*Cli, error) {
 		}
 	}
 	sources := map[uint64]argv.Source{}
+	filled := map[uint64][]string{}
 	for _, key := range scope {
 		values, source := argv.Fill(Meta.Lookup(key), given[key], argv.LookupEnv)
+		filled[key] = values
 		sources[key] = source
+	}
+	argv.ApplyDefaultIf(Meta, scope, filled, sources)
+	for _, key := range scope {
+		values, source := filled[key], sources[key]
 		if err := argv.Check(Meta.Lookup(key), values, seen[key]); err != nil {
 			return nil, err
 		}

--- a/lib/src/go/snapshots/usage__go__tests__a_whole_cli.snap
+++ b/lib/src/go/snapshots/usage__go__tests__a_whole_cli.snap
@@ -258,7 +258,7 @@ func Parse(args []string) (*Cli, error) {
 		filled[key] = values
 		sources[key] = source
 	}
-	argv.ApplyDefaultIf(Meta, scope, filled, sources)
+	argv.ApplyDefaultIf(Meta, scope, filled, sources, nil)
 	for _, key := range scope {
 		values, source := filled[key], sources[key]
 		if err := argv.Check(Meta.Lookup(key), values, seen[key]); err != nil {

--- a/lib/src/go/snapshots/usage__go__tests__a_whole_cli.snap
+++ b/lib/src/go/snapshots/usage__go__tests__a_whole_cli.snap
@@ -252,9 +252,15 @@ func Parse(args []string) (*Cli, error) {
 		}
 	}
 	sources := map[uint64]argv.Source{}
+	filled := map[uint64][]string{}
 	for _, key := range scope {
 		values, source := argv.Fill(Meta.Lookup(key), given[key], argv.LookupEnv)
+		filled[key] = values
 		sources[key] = source
+	}
+	argv.ApplyDefaultIf(Meta, scope, filled, sources)
+	for _, key := range scope {
+		values, source := filled[key], sources[key]
 		if err := argv.Check(Meta.Lookup(key), values, seen[key]); err != nil {
 			return nil, err
 		}

--- a/lib/src/go/snapshots/usage__go__tests__colliding_names_get_distinct_identifiers.snap
+++ b/lib/src/go/snapshots/usage__go__tests__colliding_names_get_distinct_identifiers.snap
@@ -195,7 +195,7 @@ func Parse(args []string) (*Cli, error) {
 		filled[key] = values
 		sources[key] = source
 	}
-	argv.ApplyDefaultIf(Meta, scope, filled, sources)
+	argv.ApplyDefaultIf(Meta, scope, filled, sources, nil)
 	for _, key := range scope {
 		values, source := filled[key], sources[key]
 		if err := argv.Check(Meta.Lookup(key), values, seen[key]); err != nil {

--- a/lib/src/go/snapshots/usage__go__tests__colliding_names_get_distinct_identifiers.snap
+++ b/lib/src/go/snapshots/usage__go__tests__colliding_names_get_distinct_identifiers.snap
@@ -189,9 +189,15 @@ func Parse(args []string) (*Cli, error) {
 		}
 	}
 	sources := map[uint64]argv.Source{}
+	filled := map[uint64][]string{}
 	for _, key := range scope {
 		values, source := argv.Fill(Meta.Lookup(key), given[key], argv.LookupEnv)
+		filled[key] = values
 		sources[key] = source
+	}
+	argv.ApplyDefaultIf(Meta, scope, filled, sources)
+	for _, key := range scope {
+		values, source := filled[key], sources[key]
 		if err := argv.Check(Meta.Lookup(key), values, seen[key]); err != nil {
 			return nil, err
 		}

--- a/lib/src/go/snapshots/usage__go__tests__unknown_flags_are_inherited_and_overridable.snap
+++ b/lib/src/go/snapshots/usage__go__tests__unknown_flags_are_inherited_and_overridable.snap
@@ -199,7 +199,7 @@ func Parse(args []string) (*Cli, error) {
 		filled[key] = values
 		sources[key] = source
 	}
-	argv.ApplyDefaultIf(Meta, scope, filled, sources)
+	argv.ApplyDefaultIf(Meta, scope, filled, sources, nil)
 	for _, key := range scope {
 		values, source := filled[key], sources[key]
 		if err := argv.Check(Meta.Lookup(key), values, seen[key]); err != nil {

--- a/lib/src/go/snapshots/usage__go__tests__unknown_flags_are_inherited_and_overridable.snap
+++ b/lib/src/go/snapshots/usage__go__tests__unknown_flags_are_inherited_and_overridable.snap
@@ -193,9 +193,15 @@ func Parse(args []string) (*Cli, error) {
 		}
 	}
 	sources := map[uint64]argv.Source{}
+	filled := map[uint64][]string{}
 	for _, key := range scope {
 		values, source := argv.Fill(Meta.Lookup(key), given[key], argv.LookupEnv)
+		filled[key] = values
 		sources[key] = source
+	}
+	argv.ApplyDefaultIf(Meta, scope, filled, sources)
+	for _, key := range scope {
+		values, source := filled[key], sources[key]
 		if err := argv.Check(Meta.Lookup(key), values, seen[key]); err != nil {
 			return nil, err
 		}

--- a/lib/src/go/structs.rs
+++ b/lib/src/go/structs.rs
@@ -104,7 +104,12 @@ fn parse_fn(out: &mut String, commands: &[Emitted], assigned: &Fields) {
         .iter()
         .flat_map(|command| command.flags.iter())
         .any(|(flag, _)| !flag.requires_if.is_empty());
-    let conditional_state = if has_requires_if {
+    let has_default_if = commands
+        .iter()
+        .flat_map(|command| command.flags.iter())
+        .any(|(flag, _)| !flag.default_if.is_empty());
+    let needs_negated = has_requires_if || has_default_if;
+    let conditional_state = if needs_negated {
         "\tnegated := map[uint64]bool{}\n"
     } else {
         ""
@@ -173,7 +178,7 @@ fn parse_fn(out: &mut String, commands: &[Emitted], assigned: &Fields) {
         );
     }
 
-    let conditional_event = if has_requires_if {
+    let conditional_event = if needs_negated {
         "\t\t\tnegated[ev.Flag.Key] = ev.Negated\n"
     } else {
         ""
@@ -221,6 +226,7 @@ fn parse_fn(out: &mut String, commands: &[Emitted], assigned: &Fields) {
         }
     }
 
+    let negated_arg = if needs_negated { "negated" } else { "nil" };
     let _ = writeln!(
         out,
         "\t\t\t}}\n\t\t}}\n\t}}\n\
@@ -240,7 +246,7 @@ fn parse_fn(out: &mut String, commands: &[Emitted], assigned: &Fields) {
          \t\tfilled[key] = values\n\
          \t\tsources[key] = source\n\
          \t}}\n\
-         \targv.ApplyDefaultIf(Meta, scope, filled, sources)\n\
+         \targv.ApplyDefaultIf(Meta, scope, filled, sources, {negated_arg})\n\
          \tfor _, key := range scope {{\n\
          \t\tvalues, source := filled[key], sources[key]\n\
          {conditional_value}\

--- a/lib/src/go/structs.rs
+++ b/lib/src/go/structs.rs
@@ -233,10 +233,16 @@ fn parse_fn(out: &mut String, commands: &[Emitted], assigned: &Fields) {
          \t\tfor _, a := range cmd.Args {{\n\t\t\tscope = append(scope, a.Key)\n\t\t}}\n\
          \t}}\n\
          \tsources := map[uint64]argv.Source{{}}\n\
+         \tfilled := map[uint64][]string{{}}\n\
          {conditional_resolved}\
          \tfor _, key := range scope {{\n\
          \t\tvalues, source := argv.Fill(Meta.Lookup(key), given[key], argv.LookupEnv)\n\
+         \t\tfilled[key] = values\n\
          \t\tsources[key] = source\n\
+         \t}}\n\
+         \targv.ApplyDefaultIf(Meta, scope, filled, sources)\n\
+         \tfor _, key := range scope {{\n\
+         \t\tvalues, source := filled[key], sources[key]\n\
          {conditional_value}\
          \t\tif err := argv.Check(Meta.Lookup(key), values, seen[key]); err != nil {{\n\
          \t\t\treturn nil, err\n\t\t}}\n\

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -9,7 +9,7 @@ pub use crate::spec::choices::SpecChoices;
 pub use crate::spec::cmd::SpecCommand;
 pub use crate::spec::complete::SpecComplete;
 pub use crate::spec::effect::SpecCommandEffect;
-pub use crate::spec::flag::{SpecFlag, SpecRequiresIf};
+pub use crate::spec::flag::{SpecDefaultIf, SpecFlag, SpecRequiresIf};
 pub use crate::spec::group::SpecGroup;
 pub use crate::spec::mount::SpecMount;
 pub use crate::spec::unknown_flags::UnknownFlags;

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -459,8 +459,12 @@ impl<'a> Parser<'a> {
             }
         }
 
-        // Apply env vars and defaults for flags
-        for flag in out.available_flags.values() {
+        // Environment first, for every flag, so a `default_if` can see a sibling
+        // that was filled from env. Applying both in one pass would make the
+        // answer depend on declaration order: `--bin-names` before `--json`
+        // would miss `EX_JSON=1`.
+        let flags: Vec<Arc<SpecFlag>> = out.available_flags.values().cloned().collect();
+        for flag in &flags {
             if out.flags.contains_key(flag) || overridden_flags.contains(&flag.name) {
                 continue;
             }
@@ -476,86 +480,35 @@ impl<'a> Parser<'a> {
                         out.flags
                             .insert(Arc::clone(flag), ParseValue::String(env_value));
                     } else {
-                        // For boolean flags, check if env value is truthy
                         let is_true = matches!(env_value.as_str(), "1" | "true" | "True" | "TRUE");
                         out.flags
                             .insert(Arc::clone(flag), ParseValue::Bool(is_true));
                     }
-                    continue;
                 }
             }
-            // Apply flag default
+        }
+        for flag in &flags {
+            if out.flags.contains_key(flag) || overridden_flags.contains(&flag.name) {
+                continue;
+            }
+            if let Some(condition) = flag.default_if.iter().find(|condition| {
+                default_if_condition_matches(condition, &out, &overridden_flags, custom_env)
+            }) {
+                bind_flag_fallback(
+                    flag,
+                    std::slice::from_ref(&condition.value),
+                    &mut out,
+                    custom_env,
+                )?;
+                continue;
+            }
             if !flag.default.is_empty() {
-                // Consider var when deciding the type of default return value
-                if flag.var {
-                    // For var=true, always return a vec (MultiString for flags with args, MultiBool for boolean flags)
-                    if let Some(arg) = flag.arg.as_ref() {
-                        validate_choice_values(
-                            ChoiceTarget::option(flag),
-                            &flag.default,
-                            arg.choices.as_ref(),
-                            custom_env,
-                        )?;
-                        out.flags.insert(
-                            Arc::clone(flag),
-                            ParseValue::MultiString(flag.default.clone()),
-                        );
-                    } else {
-                        // For boolean flags with var=true, convert default strings to bools
-                        let bools: Vec<bool> = flag
-                            .default
-                            .iter()
-                            .map(|s| matches!(s.as_str(), "1" | "true" | "True" | "TRUE"))
-                            .collect();
-                        out.flags
-                            .insert(Arc::clone(flag), ParseValue::MultiBool(bools));
-                    }
-                } else {
-                    // For var=false, return the first default value
-                    if let Some(arg) = flag.arg.as_ref() {
-                        validate_choice_value(
-                            ChoiceTarget::option(flag),
-                            &flag.default[0],
-                            arg.choices.as_ref(),
-                            custom_env,
-                        )?;
-                        out.flags.insert(
-                            Arc::clone(flag),
-                            ParseValue::String(flag.default[0].clone()),
-                        );
-                    } else {
-                        // For boolean flags, convert default string to bool
-                        let is_true =
-                            matches!(flag.default[0].as_str(), "1" | "true" | "True" | "TRUE");
-                        out.flags
-                            .insert(Arc::clone(flag), ParseValue::Bool(is_true));
-                    }
-                }
+                bind_flag_fallback(flag, &flag.default, &mut out, custom_env)?;
+                continue;
             }
-            // Also check nested arg defaults (for flags like --foo <arg> where the arg has a default)
             if let Some(arg) = flag.arg.as_ref() {
-                if !out.flags.contains_key(flag) && !arg.default.is_empty() {
-                    if flag.var {
-                        validate_choice_values(
-                            ChoiceTarget::option(flag),
-                            &arg.default,
-                            arg.choices.as_ref(),
-                            custom_env,
-                        )?;
-                        out.flags.insert(
-                            Arc::clone(flag),
-                            ParseValue::MultiString(arg.default.clone()),
-                        );
-                    } else {
-                        validate_choice_value(
-                            ChoiceTarget::option(flag),
-                            &arg.default[0],
-                            arg.choices.as_ref(),
-                            custom_env,
-                        )?;
-                        out.flags
-                            .insert(Arc::clone(flag), ParseValue::String(arg.default[0].clone()));
-                    }
+                if !arg.default.is_empty() {
+                    bind_flag_fallback(flag, &arg.default, &mut out, custom_env)?;
                 }
             }
         }
@@ -1692,6 +1645,79 @@ fn flag_has_env(flag: &SpecFlag, custom_env: Option<&HashMap<String, String>>) -
         .is_some_and(|env_var| env_contains(custom_env, env_var))
 }
 
+fn fallback_is_true(value: &str) -> bool {
+    matches!(value, "1" | "true" | "True" | "TRUE")
+}
+
+/// Bind a fallback the way an unconditional `default` does: one value, or several
+/// for `var`, and choices checked the same way.
+fn bind_flag_fallback(
+    flag: &Arc<SpecFlag>,
+    values: &[String],
+    out: &mut ParseOutput,
+    custom_env: Option<&HashMap<String, String>>,
+) -> Result<(), miette::Error> {
+    if values.is_empty() {
+        return Ok(());
+    }
+    if flag.var {
+        if let Some(arg) = flag.arg.as_ref() {
+            validate_choice_values(
+                ChoiceTarget::option(flag),
+                values,
+                arg.choices.as_ref(),
+                custom_env,
+            )?;
+            out.flags
+                .insert(Arc::clone(flag), ParseValue::MultiString(values.to_vec()));
+        } else {
+            let bools: Vec<bool> = values.iter().map(|s| fallback_is_true(s)).collect();
+            out.flags
+                .insert(Arc::clone(flag), ParseValue::MultiBool(bools));
+        }
+    } else if let Some(arg) = flag.arg.as_ref() {
+        validate_choice_value(
+            ChoiceTarget::option(flag),
+            &values[0],
+            arg.choices.as_ref(),
+            custom_env,
+        )?;
+        out.flags
+            .insert(Arc::clone(flag), ParseValue::String(values[0].clone()));
+    } else {
+        out.flags.insert(
+            Arc::clone(flag),
+            ParseValue::Bool(fallback_is_true(&values[0])),
+        );
+    }
+    Ok(())
+}
+
+fn default_if_condition_matches(
+    condition: &crate::SpecDefaultIf,
+    out: &ParseOutput,
+    overridden_flags: &HashSet<String>,
+    custom_env: Option<&HashMap<String, String>>,
+) -> bool {
+    match &condition.when {
+        None => selector_is_explicit(&condition.selector, out, overridden_flags, custom_env),
+        Some(when) => {
+            let Some(flag) = out
+                .available_flags
+                .values()
+                .chain(out.flags.keys())
+                .find(|flag| flag_matches_selector(flag, &condition.selector))
+            else {
+                return false;
+            };
+            if overridden_flags.contains(&flag.name) {
+                return false;
+            }
+            explicit_flag_has_value(flag, when, out, custom_env)
+        }
+    }
+}
+
 /// Whether an explicitly supplied value of `flag` equals `expected`.
 ///
 /// clap treats command-line and environment values as explicit for `requires_if`, but
@@ -1784,7 +1810,11 @@ fn selector_is_satisfied(
         .filter(|flag| flag_matches_selector(flag, selector))
         .any(|flag| {
             !overridden_flags.contains(&flag.name)
-                && (!flag.default.is_empty() || flag.arg.iter().any(|a| !a.default.is_empty()))
+                && (!flag.default.is_empty()
+                    || flag.arg.iter().any(|a| !a.default.is_empty())
+                    || flag.default_if.iter().any(|condition| {
+                        default_if_condition_matches(condition, out, overridden_flags, custom_env)
+                    }))
         })
 }
 
@@ -3847,6 +3877,102 @@ flag "--file <file>" required_unless="--stdin"
 
         parse(&spec, &input(&["ex", "--out", "a.txt"]))
             .expect("a defaulted flag is not a missing one");
+    }
+
+    #[test]
+    fn a_present_flag_binds_a_conditional_default() {
+        let spec: Spec = "name \"ex\"\nbin \"ex\"\nflag \"--bin-names\" {\n  default_if \"--json\" \"true\"\n}\nflag \"--json\"\n"
+            .parse()
+            .unwrap();
+
+        let with = parse(&spec, &input(&["ex", "--json"])).unwrap();
+        assert_eq!(
+            with.as_env().get("usage_bin_names").map(String::as_str),
+            Some("true")
+        );
+
+        let without = parse(&spec, &input(&["ex"])).unwrap();
+        assert!(
+            without.as_env().get("usage_bin_names").is_none(),
+            "IsPresent does nothing when the selector is absent"
+        );
+    }
+
+    #[test]
+    fn an_equals_condition_binds_a_conditional_default() {
+        let spec: Spec = "name \"ex\"\nbin \"ex\"\nflag \"--style <s>\" {\n  default_if \"--output\" \"json\" \"pretty\"\n}\nflag \"--output <fmt>\"\n"
+            .parse()
+            .unwrap();
+
+        let json = parse(&spec, &input(&["ex", "--output", "json"])).unwrap();
+        assert_eq!(
+            json.as_env().get("usage_style").map(String::as_str),
+            Some("pretty")
+        );
+        let yaml = parse(&spec, &input(&["ex", "--output", "yaml"])).unwrap();
+        assert!(yaml.as_env().get("usage_style").is_none());
+    }
+
+    #[test]
+    fn the_first_matching_conditional_default_wins() {
+        let spec: Spec = "name \"ex\"\nbin \"ex\"\nflag \"--style <s>\" {\n  default_if \"--json\" \"compact\"\n  default_if \"--pretty\" \"pretty\"\n}\nflag \"--json\"\nflag \"--pretty\"\n"
+            .parse()
+            .unwrap();
+
+        let out = parse(&spec, &input(&["ex", "--json", "--pretty"])).unwrap();
+        assert_eq!(
+            out.as_env().get("usage_style").map(String::as_str),
+            Some("compact")
+        );
+    }
+
+    #[test]
+    fn argv_and_env_suppress_a_conditional_default() {
+        let spec: Spec = "name \"ex\"\nbin \"ex\"\nflag \"--bin-names\" env=\"EX_BIN\" {\n  default_if \"--json\" \"true\"\n}\nflag \"--json\"\n"
+            .parse()
+            .unwrap();
+
+        let from_env = parse_with_env(&spec, &["ex", "--json"], &[("EX_BIN", "false")]).unwrap();
+        assert_eq!(
+            from_env.as_env().get("usage_bin_names").map(String::as_str),
+            Some("false"),
+            "the target's environment wins over default_if"
+        );
+    }
+
+    #[test]
+    fn a_sibling_env_activates_a_conditional_default() {
+        let spec: Spec = "name \"ex\"\nbin \"ex\"\nflag \"--bin-names\" {\n  default_if \"--json\" \"true\"\n}\nflag \"--json\" env=\"EX_JSON\"\n"
+            .parse()
+            .unwrap();
+
+        let out = parse_with_env(&spec, &["ex"], &[("EX_JSON", "1")]).unwrap();
+        assert_eq!(
+            out.as_env().get("usage_bin_names").map(String::as_str),
+            Some("true")
+        );
+    }
+
+    #[test]
+    fn a_conditional_default_does_not_activate_requires_if() {
+        let spec: Spec = "name \"ex\"\nbin \"ex\"\nflag \"--format <f>\" {\n  default_if \"--json\" \"json\"\n  requires_if \"json\" \"--schema\"\n}\nflag \"--schema <s>\"\nflag \"--json\"\n"
+            .parse()
+            .unwrap();
+
+        parse(&spec, &input(&["ex", "--json"]))
+            .expect("a default_if value is not explicit for requires_if");
+        assert!(parse(&spec, &input(&["ex", "--format", "json"])).is_err());
+    }
+
+    #[test]
+    fn a_conditional_default_satisfies_a_requirement() {
+        let spec: Spec = "name \"ex\"\nbin \"ex\"\nflag \"--out <p>\" requires=\"--format\"\nflag \"--format <f>\" {\n  default_if \"--json\" \"json\"\n}\nflag \"--json\"\n"
+            .parse()
+            .unwrap();
+
+        parse(&spec, &input(&["ex", "--out", "a.txt", "--json"]))
+            .expect("default_if fills the required flag");
+        assert!(parse(&spec, &input(&["ex", "--out", "a.txt"])).is_err());
     }
 
     #[test]

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -3893,7 +3893,7 @@ flag "--file <file>" required_unless="--stdin"
 
         let without = parse(&spec, &input(&["ex"])).unwrap();
         assert!(
-            without.as_env().get("usage_bin_names").is_none(),
+            !without.as_env().contains_key("usage_bin_names"),
             "IsPresent does nothing when the selector is absent"
         );
     }
@@ -3910,7 +3910,7 @@ flag "--file <file>" required_unless="--stdin"
             Some("pretty")
         );
         let yaml = parse(&spec, &input(&["ex", "--output", "yaml"])).unwrap();
-        assert!(yaml.as_env().get("usage_style").is_none());
+        assert!(!yaml.as_env().contains_key("usage_style"));
     }
 
     #[test]
@@ -3926,7 +3926,7 @@ flag "--file <file>" required_unless="--stdin"
         );
         let on = parse(&spec, &input(&["ex", "--json"])).unwrap();
         assert!(
-            on.as_env().get("usage_pretty").is_none(),
+            !on.as_env().contains_key("usage_pretty"),
             "--json is true, so when=false should miss"
         );
     }

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -487,6 +487,12 @@ impl<'a> Parser<'a> {
                 }
             }
         }
+        // Decide every `default_if` against argv+env only. Binding as we go would put
+        // a default into `out.flags` and make the next flag's condition treat it as
+        // explicit — Go's `Given()` and the derive's `__given_*` both ignore defaults
+        // here, so an unconditional `default` on `--json` must not fire
+        // `default_if "--json"`.
+        let mut from_default_if: Vec<(Arc<SpecFlag>, String)> = Vec::new();
         for flag in &flags {
             if out.flags.contains_key(flag) || overridden_flags.contains(&flag.name) {
                 continue;
@@ -494,12 +500,14 @@ impl<'a> Parser<'a> {
             if let Some(condition) = flag.default_if.iter().find(|condition| {
                 default_if_condition_matches(condition, &out, &overridden_flags, custom_env)
             }) {
-                bind_flag_fallback(
-                    flag,
-                    std::slice::from_ref(&condition.value),
-                    &mut out,
-                    custom_env,
-                )?;
+                from_default_if.push((Arc::clone(flag), condition.value.clone()));
+            }
+        }
+        for (flag, value) in &from_default_if {
+            bind_flag_fallback(flag, std::slice::from_ref(value), &mut out, custom_env)?;
+        }
+        for flag in &flags {
+            if out.flags.contains_key(flag) || overridden_flags.contains(&flag.name) {
                 continue;
             }
             if !flag.default.is_empty() {
@@ -3968,6 +3976,26 @@ flag "--file <file>" required_unless="--stdin"
         assert_eq!(
             out.as_env().get("usage_bin_names").map(String::as_str),
             Some("true")
+        );
+    }
+
+    #[test]
+    fn a_default_does_not_activate_a_conditional_default() {
+        // `--json` sorts before `--pretty` in the available-flag map, so a one-pass
+        // bind would put json's default into `out.flags` and then treat it as
+        // explicit for pretty's `default_if`. Go and the derive ignore defaults.
+        let spec: Spec = "name \"ex\"\nbin \"ex\"\nflag \"--pretty\" {\n  default_if \"--json\" \"true\"\n}\nflag \"--json\" default=#true\n"
+            .parse()
+            .unwrap();
+
+        let out = parse(&spec, &input(&["ex"])).unwrap();
+        assert_eq!(
+            out.as_env().get("usage_json").map(String::as_str),
+            Some("true")
+        );
+        assert!(
+            !out.as_env().contains_key("usage_pretty"),
+            "a default is not an explicit value for default_if"
         );
     }
 

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -3914,6 +3914,24 @@ flag "--file <file>" required_unless="--stdin"
     }
 
     #[test]
+    fn an_equals_condition_reads_a_negated_flag() {
+        let spec: Spec = "name \"ex\"\nbin \"ex\"\nflag \"--pretty\" {\n  default_if \"--json\" \"false\" \"true\"\n}\nflag \"--json\" negate=\"--no-json\"\n"
+            .parse()
+            .unwrap();
+
+        let off = parse(&spec, &input(&["ex", "--no-json"])).unwrap();
+        assert_eq!(
+            off.as_env().get("usage_pretty").map(String::as_str),
+            Some("true")
+        );
+        let on = parse(&spec, &input(&["ex", "--json"])).unwrap();
+        assert!(
+            on.as_env().get("usage_pretty").is_none(),
+            "--json is true, so when=false should miss"
+        );
+    }
+
+    #[test]
     fn the_first_matching_conditional_default_wins() {
         let spec: Spec = "name \"ex\"\nbin \"ex\"\nflag \"--style <s>\" {\n  default_if \"--json\" \"compact\"\n  default_if \"--pretty\" \"pretty\"\n}\nflag \"--json\"\nflag \"--pretty\"\n"
             .parse()

--- a/lib/src/spec/builder.rs
+++ b/lib/src/spec/builder.rs
@@ -33,7 +33,8 @@
 use crate::spec::cmd::SpecExample;
 use crate::spec::effect::SpecCommandEffect;
 use crate::{
-    spec::arg::SpecDoubleDashChoices, SpecArg, SpecChoices, SpecCommand, SpecFlag, SpecRequiresIf,
+    spec::arg::SpecDoubleDashChoices, SpecArg, SpecChoices, SpecCommand, SpecDefaultIf, SpecFlag,
+    SpecRequiresIf,
 };
 
 /// Builder for SpecFlag
@@ -308,7 +309,44 @@ impl SpecFlagBuilder {
         self
     }
 
-    /// Set environment variable name
+    /// Bind `value` on this flag when `selector` is present.
+    ///
+    /// clap's `default_value_if(id, ArgPredicate::IsPresent, value)`.
+    pub fn default_if(mut self, selector: impl Into<String>, value: impl Into<String>) -> Self {
+        self.inner.default_if.push(SpecDefaultIf {
+            selector: selector.into(),
+            when: None,
+            value: value.into(),
+        });
+        self
+    }
+
+    /// Bind `value` on this flag when `selector` is explicitly `when`.
+    ///
+    /// clap's `default_value_if(id, ArgPredicate::Equals(when), value)`.
+    pub fn default_if_eq(
+        mut self,
+        selector: impl Into<String>,
+        when: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Self {
+        self.inner.default_if.push(SpecDefaultIf {
+            selector: selector.into(),
+            when: Some(when.into()),
+            value: value.into(),
+        });
+        self
+    }
+
+    /// Add several conditional defaults, in first-match-wins order.
+    pub fn default_ifs<I>(mut self, conditions: I) -> Self
+    where
+        I: IntoIterator<Item = SpecDefaultIf>,
+    {
+        self.inner.default_if.extend(conditions);
+        self
+    }
+
     /// Heading to list this under in help output.
     pub fn help_heading(mut self, help_heading: impl Into<String>) -> Self {
         self.inner.help_heading = Some(help_heading.into());
@@ -805,6 +843,31 @@ mod tests {
                 SpecRequiresIf {
                     value: "signed.toml".into(),
                     requires: "--identity".into(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_flag_builder_conditional_defaults() {
+        let flag = SpecFlagBuilder::new()
+            .long("bin-names")
+            .default_if("--json", "true")
+            .default_if_eq("--output", "json", "pretty")
+            .build();
+
+        assert_eq!(
+            flag.default_if,
+            [
+                SpecDefaultIf {
+                    selector: "--json".into(),
+                    when: None,
+                    value: "true".into(),
+                },
+                SpecDefaultIf {
+                    selector: "--output".into(),
+                    when: Some("json".into()),
+                    value: "pretty".into(),
                 },
             ]
         );

--- a/lib/src/spec/flag.rs
+++ b/lib/src/spec/flag.rs
@@ -28,6 +28,31 @@ pub struct SpecRequiresIf {
     pub requires: String,
 }
 
+/// A default that applies when another flag is given.
+///
+/// Lives on the *target* flag, the inverse of [`SpecRequiresIf`]:
+/// `flag "--bin-names" { default_if "--json" "true" }` binds `true` on
+/// `--bin-names` when `--json` was given. Two arguments are clap's
+/// `ArgPredicate::IsPresent`; three (`default_if "--output" "json" "pretty"`)
+/// are `Equals`. First match wins. Command-line and environment values on
+/// this flag suppress it; a `default_if` value is a default, not an explicit
+/// value, so it does not activate `requires_if`.
+///
+/// clap 4 has `Arg::default_value_if` as a setter with no getter, so a spec
+/// generated from a clap command never carries this — same hole as
+/// [`SpecFlag::requires`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SpecDefaultIf {
+    /// The other flag that decides whether this default applies (`"--json"`).
+    pub selector: String,
+    /// When set, the selector must have this explicit value (`Equals`).
+    /// When `None`, the selector only has to be present (`IsPresent`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub when: Option<String>,
+    /// The value to bind on this flag when the condition matches.
+    pub value: String,
+}
+
 /// A CLI flag/option specification.
 ///
 /// Flags are optional arguments that start with `-` (short) or `--` (long).
@@ -135,6 +160,14 @@ pub struct SpecFlag {
     /// values do. This matches clap's `requires_if`/`requires_ifs` semantics.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub requires_if: Vec<SpecRequiresIf>,
+    /// Defaults that apply when another flag is given.
+    ///
+    /// First match wins. Only considered when this flag was not on the command
+    /// line and has no environment value. An applied `default_if` is a default,
+    /// not an explicit value: it satisfies `requires` and does not activate
+    /// `requires_if`.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub default_if: Vec<SpecDefaultIf>,
     /// Whether this flag must be given on its own.
     ///
     /// The whole-command form of [`SpecFlag::conflicts`]: `--version` and `--help` are
@@ -352,6 +385,23 @@ impl SpecFlag {
                     flag.requires_if.push(SpecRequiresIf {
                         value: child.arg(0)?.ensure_string()?,
                         requires: child.arg(1)?.ensure_string()?,
+                    });
+                }
+                "default_if" => {
+                    child.ensure_arg_len(2..=3)?;
+                    let count = child.args().count();
+                    flag.default_if.push(if count == 2 {
+                        SpecDefaultIf {
+                            selector: child.arg(0)?.ensure_string()?,
+                            when: None,
+                            value: child.arg(1)?.ensure_string()?,
+                        }
+                    } else {
+                        SpecDefaultIf {
+                            selector: child.arg(0)?.ensure_string()?,
+                            when: Some(child.arg(1)?.ensure_string()?),
+                            value: child.arg(2)?.ensure_string()?,
+                        }
                     });
                 }
                 "choices" => {
@@ -585,6 +635,16 @@ impl From<&SpecFlag> for KdlNode {
             requires_if.push(string_entry(None, &condition.requires));
             children.nodes_mut().push(requires_if);
         }
+        for condition in &flag.default_if {
+            let children = node.children_mut().get_or_insert_with(KdlDocument::new);
+            let mut default_if = KdlNode::new("default_if");
+            default_if.push(string_entry(None, &condition.selector));
+            if let Some(when) = &condition.when {
+                default_if.push(string_entry(None, when));
+            }
+            default_if.push(string_entry(None, &condition.value));
+            children.nodes_mut().push(default_if);
+        }
         if flag.exclusive {
             node.push(KdlEntry::new_prop("exclusive", true));
         }
@@ -790,6 +850,8 @@ impl From<&clap::Arg> for SpecFlag {
             requires: vec![],
             // The conditional forms are hidden behind the same clap API boundary.
             requires_if: vec![],
+            // clap 4 has `Arg::default_value_if` as a setter with no getter.
+            default_if: vec![],
             // This one clap does expose, unlike `requires` just above.
             exclusive: c.is_exclusive_set(),
             require_equals: c.is_require_equals_set(),
@@ -976,6 +1038,61 @@ mod tests {
         assert_eq!(
             reparsed.cmd.flags[0].requires_if,
             spec.cmd.flags[0].requires_if
+        );
+    }
+
+    #[test]
+    fn conditional_defaults_round_trip_in_order_and_cannot_come_across_from_clap() {
+        let spec: Spec = "flag \"--bin-names\" {\n  default_if \"--json\" \"true\"\n  default_if \"--output\" \"json\" \"pretty\"\n}\nflag \"--json\"\nflag \"--output <fmt>\"\n"
+            .parse()
+            .unwrap();
+        assert_eq!(
+            spec.cmd.flags[0].default_if,
+            [
+                SpecDefaultIf {
+                    selector: "--json".into(),
+                    when: None,
+                    value: "true".into(),
+                },
+                SpecDefaultIf {
+                    selector: "--output".into(),
+                    when: Some("json".into()),
+                    value: "pretty".into(),
+                },
+            ]
+        );
+
+        let emitted = spec.to_string();
+        let reparsed: Spec = emitted.parse().unwrap();
+        assert_eq!(
+            reparsed.cmd.flags[0].default_if,
+            spec.cmd.flags[0].default_if
+        );
+
+        // Same hole as `requires`: clap 4 has the setter and keeps the field private.
+        let cmd = clap::Command::new("ex")
+            .arg(
+                clap::Arg::new("bin-names")
+                    .long("bin-names")
+                    .action(clap::ArgAction::SetTrue)
+                    .default_value_if("json", clap::builder::ArgPredicate::IsPresent, "true"),
+            )
+            .arg(
+                clap::Arg::new("json")
+                    .long("json")
+                    .action(clap::ArgAction::SetTrue),
+            );
+        let spec = Spec::from(&cmd);
+        let bin_names = spec
+            .cmd
+            .flags
+            .iter()
+            .find(|f| f.name == "bin-names")
+            .unwrap();
+        assert!(
+            bin_names.default_if.is_empty(),
+            "clap exposes no getter for `default_value_if`; if this now fails, \
+             the bridge can carry it and `SpecFlag::default_if` should say so"
         );
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacked on #1021 (`external_subcommand`). Adds clap's `default_value_if` / `default_value_ifs` as `default_if` on the **target** flag.

## Semantics

- Two KDL/attribute arguments are `ArgPredicate::IsPresent`; three are `Equals`.
- First matching condition wins.
- Applied only when the target was not on the command line and has no env value.
- Env is applied to every flag **before** any `default_if`, so a sibling env can activate the condition regardless of declaration order.
- An applied `default_if` is a default: it satisfies `requires` and does **not** activate `requires_if`.
- An Equals condition on a bool reads the negate form as `"false"` (`--no-json`), matching `requires_if`.
- clap 4 has the setter and no getter, so the clap bridge leaves `default_if` empty (same hole as `requires`).

```kdl
flag "--bin-names" {
  default_if "--json" "true"
  default_if "--output" "json" "pretty"
}
```

```rust
#[usage(long, default_if("--json", "true"))]
bin_names: bool,
```

## Surfaces

- Spec parse/emit, builder, usage-lib parse
- Derive (`default_if` / `default_ifs`) and usage-argv `FlagMeta`
- Go `Meta.DefaultIf`, `Fill` (skips unconditional default when `DefaultIf` is set), `ApplyDefaultIf` (takes the parser's negation map)
- Corpus `11-default-if.json` (`layer: "post-binding"`)

`value_parser` ranges remain deferred. Multicall is the next stacked PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4de7e59e-aa2e-4ad0-a1d0-1c2e69c166db?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4de7e59e-aa2e-4ad0-a1d0-1c2e69c166db&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

