### PR TITLE
docs(spec): stop quoting a corpus vector count

### DIFF
--- a/docs/spec/argv.md
+++ b/docs/spec/argv.md
@@ -12,7 +12,7 @@ and the [conformance corpus](#the-conformance-corpus) makes it executable.
 
 ::: tip Both implementations answer every vector
 
-usage-lib and usage-argv agree with all 176 vectors today. That is a
+usage-lib and usage-argv agree with every vector today. That is a
 measurement, checked on every run rather than asserted here — see
 [Where the reference implementation differs](#where-the-reference-implementation-differs).
 
@@ -412,7 +412,7 @@ fails if a label is wrong in either direction. A recorded divergence that gets
 fixed shows up as a test failure telling you to delete the label, so the list
 cannot rot.
 
-**Today it does not: usage-lib agrees with all 176 vectors.** The list is empty
+**Today it does not: usage-lib agrees with every vector.** The list is empty
 for the first time, and the five entries it used to hold were what writing the
 grammar down was for. Each was a real defect that only a second reading found:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The argv grammar page quoted how many corpus vectors usage-lib agrees with. That count goes stale on every new vector file.

Agreement is already measured on each run (`conformance/tests/reference.rs`) rather than asserted in prose, so the page now says "every vector" instead of a number.

_This comment was generated by Claude Code._
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4de7e59e-aa2e-4ad0-a1d0-1c2e69c166db?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4de7e59e-aa2e-4ad0-a1d0-1c2e69c166db&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

