### PR TITLE
feat(spec): select a subcommand from argv0 when multicall

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -458,8 +458,14 @@ Groups are the opposite case: `Command::get_groups`, `ArgGroup::get_args` and
       `required_unless_present` all/any variants. The common single-selector
       forms exist, but a clap migration needs the complete truth table or an
       explicit non-goal for each omitted form.
-- [ ] **`multicall`** — busybox-style applets: argv[0]'s basename selects a
-      subcommand when it is not the dispatcher. clap's `Command::multicall`.
+- [x] **`multicall`** — busybox-style applets: argv[0]'s basename selects a
+      subcommand when it is not the dispatcher. Spec `multicall #true`,
+      usage-lib (which sees argv0), usage-argv / the derive `parse()` /
+      Go `RewriteMulticall` (which rewrite at process entry; `parse_from` /
+      `Parse` stay without argv0), and the clap bridge
+      (`Command::is_multicall_set`). Path components and a trailing `.exe`
+      are stripped. **Not used by the fleet today**; clap's own applets and
+      busybox-style binaries are the reason it exists.
 - [ ] **`no_binary_name`** — parsing an argv that has no `argv[0]`. usage-argv
       already takes argv without the program name; this is clap's setter that
       skips stripping it. Out of scope until a fleet CLI needs it.

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -222,6 +222,33 @@ impl Command<'_> {
     };
 }
 
+/// Basename of argv[0] for a multicall CLI: last path component, with a trailing
+/// `.exe` stripped so Windows and Unix agree.
+pub fn multicall_basename(argv0: &str) -> &str {
+    let name = argv0.rsplit(['/', '\\']).next().unwrap_or(argv0);
+    match name.get(name.len().saturating_sub(4)..) {
+        Some(ext) if ext.eq_ignore_ascii_case(".exe") => &name[..name.len() - 4],
+        _ => name,
+    }
+}
+
+/// The applet name to parse as the first word, when argv[0] is not the dispatcher.
+///
+/// `None` means a dispatcher invocation (`busybox ls`): skip argv[0] and parse the
+/// rest. `Some` is a symlink invocation (`ls -l`): inject the basename.
+pub fn multicall_applet<'a>(argv0: &'a str, name: &str, bin: Option<&str>) -> Option<&'a str> {
+    let base = multicall_basename(argv0);
+    if !name.is_empty() && base == name {
+        return None;
+    }
+    if let Some(bin) = bin {
+        if !bin.is_empty() && base == bin {
+            return None;
+        }
+    }
+    Some(base)
+}
+
 /// A flag, addressed by any of its long or short forms.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Flag<'a> {
@@ -3045,5 +3072,23 @@ mod tests {
 
         assert!(as_str(b"ok").is_ok());
         assert!(as_str(&[0xff, 0xfe]).is_err());
+    }
+
+    #[test]
+    fn a_multicall_applet_is_the_basename_unless_it_is_the_dispatcher() {
+        assert_eq!(multicall_basename("/usr/bin/ls"), "ls");
+        assert_eq!(multicall_basename(r"C:\busybox\ls.exe"), "ls");
+        assert_eq!(
+            multicall_applet("/usr/bin/ls", "busybox", Some("busybox")),
+            Some("ls")
+        );
+        assert_eq!(
+            multicall_applet("/usr/bin/busybox", "busybox", Some("busybox")),
+            None
+        );
+        assert_eq!(
+            multicall_applet("ls.exe", "busybox", Some("busybox")),
+            Some("ls")
+        );
     }
 }

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -296,6 +296,13 @@ pub struct Spec<'a> {
     /// Which command the root falls back to when a word matches no subcommand.
     /// mise uses this so `mise foo` completes as `mise run foo`.
     pub default_subcommand: Option<&'a str>,
+    /// Whether argv[0]'s basename selects a subcommand (busybox-style applets).
+    ///
+    /// clap's `multicall`. The dispatcher names (`name` / `bin`) are skipped; any
+    /// other basename is parsed as the first word. Path components and a trailing
+    /// `.exe` are stripped. The parser itself does not see argv[0]; [`crate::multicall_applet`]
+    /// is what a process entry applies before calling it.
+    pub multicall: bool,
     /// The root command, and the home of everything a spec declares at its top level.
     ///
     /// A KDL spec has one place for surrounding text and examples — the top level — and the
@@ -319,6 +326,7 @@ impl Spec<'_> {
         long_about: None,
         usage: None,
         default_subcommand: None,
+        multicall: false,
         root: &CommandMeta::EMPTY,
     };
 }
@@ -839,6 +847,9 @@ impl Spec<'_> {
         }
         if let Some(default_subcommand) = self.default_subcommand {
             prop(out, "default_subcommand", default_subcommand)?;
+        }
+        if self.multicall {
+            writeln!(out, "multicall #true")?;
         }
         if self.root.cmd.external_subcommand {
             writeln!(out, "external_subcommand #true")?;

--- a/cli/src/cli/lint.rs
+++ b/cli/src/cli/lint.rs
@@ -174,6 +174,15 @@ pub fn lint_spec(spec: &Spec, opts: LintOptions) -> Vec<LintIssue> {
         }
     }
 
+    if spec.multicall && spec.cmd.subcommands.is_empty() {
+        issues.push(LintIssue {
+            severity: Severity::Error,
+            code: "multicall-no-subcommands".to_string(),
+            message: "Spec has multicall=#true but no subcommands to select".to_string(),
+            location: None,
+        });
+    }
+
     // Lint the root command
     lint_command(&spec.cmd, &[], spec.about.is_some(), opts, &mut issues);
 
@@ -716,6 +725,20 @@ cmd "undocumented"
             missing_help[0].location.as_deref(),
             Some("cmd test undocumented")
         );
+    }
+
+    #[test]
+    fn test_lint_multicall_no_subcommands() {
+        let spec: Spec = r#"
+name "busybox"
+bin "busybox"
+multicall #true
+        "#
+        .parse()
+        .unwrap();
+
+        let issues = lint_spec(&spec, LintOptions::default());
+        assert!(issues.iter().any(|i| i.code == "multicall-no-subcommands"));
     }
 
     #[test]

--- a/conformance/src/argv.rs
+++ b/conformance/src/argv.rs
@@ -88,8 +88,14 @@ pub fn run(vector: &Vector) -> Outcome {
         }
         None => root,
     };
-    let argv: Vec<&'static OsStr> = vector
-        .argv
+    let mut words = vector.argv.clone();
+    if spec.multicall {
+        let argv0 = vector.argv0.as_deref().unwrap_or(spec.bin.as_str());
+        if let Some(applet) = usage_argv::multicall_applet(argv0, &spec.name, Some(&spec.bin)) {
+            words.insert(0, applet.to_string());
+        }
+    }
+    let argv: Vec<&'static OsStr> = words
         .iter()
         .map(|a| -> &'static OsStr { OsStr::new(leak(a)) })
         .collect();

--- a/conformance/src/lib.rs
+++ b/conformance/src/lib.rs
@@ -51,6 +51,13 @@ pub struct Vector {
     pub spec: String,
     /// The command line, excluding the program name.
     pub argv: Vec<String>,
+    /// argv[0] as the process saw it, when that is the question.
+    ///
+    /// Absent means the spec's `bin`, which is what usage-lib prepends for every
+    /// other vector. A `multicall` applet is selected by this basename rather than
+    /// by a word in `argv`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub argv0: Option<String>,
     /// The environment the parse sees. Only vectors about `env` fallback set it;
     /// the harness never consults the real environment, so no vector's result
     /// can depend on the machine running it.

--- a/conformance/src/reference.rs
+++ b/conformance/src/reference.rs
@@ -57,8 +57,9 @@ pub fn run(vector: &Vector) -> Observed {
         .collect();
 
     // usage-lib expects argv to include the program name, and reports the
-    // selected command relative to it.
-    let mut input = vec![spec.bin.clone()];
+    // selected command relative to it. A multicall vector that cares about the
+    // process's argv[0] supplies it; everyone else is the spec's bin.
+    let mut input = vec![vector.argv0.clone().unwrap_or_else(|| spec.bin.clone())];
     input.extend(vector.argv.iter().cloned());
 
     match Parser::new(&spec).with_env(env).parse(&input) {

--- a/conformance/src/tables.rs
+++ b/conformance/src/tables.rs
@@ -212,6 +212,7 @@ pub fn build_spec(spec: &Spec) -> &'static usage_argv::spec::Spec<'static> {
         about: opt(&spec.about),
         long_about: opt(&spec.about_long),
         default_subcommand: opt(&spec.default_subcommand),
+        multicall: spec.multicall,
         // An exact synopsis the spec declares, which replaces the generated line on the root's
         // page. usage-lib's manpage renderer honours it and its help renderer does not, so a
         // spec that declares one is a case the two disagree about; `render/03-sections.json`

--- a/conformance/tests/spec_roundtrip.rs
+++ b/conformance/tests/spec_roundtrip.rs
@@ -327,6 +327,7 @@ static SPEC: Spec = Spec {
     long_about: Some("Does things, at length."),
     usage: Some("Usage: ex <COMMAND>\n       ex --version \"quoted\""),
     default_subcommand: Some("run"),
+    multicall: false,
     root: &ROOT_META,
 };
 
@@ -345,6 +346,7 @@ fn the_program_itself_survives() {
     assert_eq!(spec.about.as_deref(), Some("does things"));
     assert_eq!(spec.about_long.as_deref(), Some("Does things, at length."));
     assert_eq!(spec.default_subcommand.as_deref(), Some("run"));
+    assert!(!spec.multicall);
     assert_eq!(
         spec.usage,
         "Usage: ex <COMMAND>\n       ex --version \"quoted\""
@@ -762,6 +764,7 @@ fn a_declared_completer_becomes_a_run_the_reference_can_read() {
         long_about: None,
         usage: None,
         default_subcommand: None,
+        multicall: false,
         root: &META,
     };
 
@@ -894,6 +897,7 @@ fn two_commands_can_mean_different_things_by_one_name() {
         long_about: None,
         usage: None,
         default_subcommand: None,
+        multicall: false,
         root: &ROOT_META_TWO,
     };
 
@@ -947,6 +951,7 @@ fn two_commands_can_mean_different_things_by_one_name() {
         long_about: None,
         usage: None,
         default_subcommand: None,
+        multicall: false,
         root: &ROOT_META_THREE,
     };
     let words = ["ex".to_string(), "use".to_string(), String::new()];
@@ -1054,4 +1059,38 @@ fn two_fields_on_one_command_can_mean_different_things_by_one_name() {
             [expected]
         );
     }
+}
+
+#[test]
+fn multicall_survives_the_round_trip() {
+    static LS: Command = Command {
+        name: "ls",
+        ..Command::EMPTY
+    };
+    static ROOT: Command = Command {
+        name: "busybox",
+        subcommands: &[&LS],
+        ..Command::EMPTY
+    };
+    static ROOT_META: CommandMeta = CommandMeta {
+        cmd: &ROOT,
+        ..CommandMeta::EMPTY
+    };
+    static SPEC: Spec = Spec {
+        name: "busybox",
+        bin: Some("busybox"),
+        multicall: true,
+        root: &ROOT_META,
+        ..Spec::EMPTY
+    };
+
+    let kdl = SPEC.to_kdl();
+    assert!(
+        kdl.contains("multicall #true"),
+        "lost on the way out: {kdl}"
+    );
+    let spec: LibSpec = kdl
+        .parse()
+        .unwrap_or_else(|e| panic!("usage-lib could not parse the emitted spec: {e}\n\n{kdl}"));
+    assert!(spec.multicall);
 }

--- a/conformance/tests/spec_roundtrip.rs
+++ b/conformance/tests/spec_roundtrip.rs
@@ -1063,24 +1063,11 @@ fn two_fields_on_one_command_can_mean_different_things_by_one_name() {
 
 #[test]
 fn multicall_survives_the_round_trip() {
-    static LS: Command = Command {
-        name: "ls",
-        ..Command::EMPTY
-    };
-    static ROOT: Command = Command {
-        name: "busybox",
-        subcommands: &[&LS],
-        ..Command::EMPTY
-    };
-    static ROOT_META: CommandMeta = CommandMeta {
-        cmd: &ROOT,
-        ..CommandMeta::EMPTY
-    };
     static SPEC: Spec = Spec {
         name: "busybox",
         bin: Some("busybox"),
         multicall: true,
-        root: &ROOT_META,
+        root: &CommandMeta::EMPTY,
         ..Spec::EMPTY
     };
 

--- a/corpus/12-multicall.json
+++ b/corpus/12-multicall.json
@@ -1,0 +1,98 @@
+{
+  "section": "multicall",
+  "about": "argv[0]'s basename selects a subcommand when the spec declares multicall. clap's busybox-style applets: the dispatcher names (name and bin) are skipped, any other basename is the first word, and a trailing .exe plus path components are stripped so /usr/bin/ls and ls.exe select the same applet.",
+  "vectors": [
+    {
+      "id": "multicall-applet-selects",
+      "doc": "A symlink invocation: argv[0]'s basename is the applet, and the rest of argv belongs to it.",
+      "spec": "name \"busybox\"\nbin \"busybox\"\nmulticall #true\ncmd \"ls\" {\n  arg \"[ARGS]...\"\n}\ncmd \"cat\"\n",
+      "argv0": "/usr/bin/ls",
+      "argv": ["-l"],
+      "expect": {
+        "ok": {
+          "cmd": ["ls"],
+          "args": { "ARGS": ["-l"] }
+        }
+      }
+    },
+    {
+      "id": "multicall-dispatcher-skips",
+      "doc": "A dispatcher invocation still skips argv[0], so busybox ls is the ls applet.",
+      "spec": "name \"busybox\"\nbin \"busybox\"\nmulticall #true\ncmd \"ls\" {\n  arg \"[ARGS]...\"\n}\n",
+      "argv0": "/usr/bin/busybox",
+      "argv": ["ls", "-l"],
+      "expect": {
+        "ok": {
+          "cmd": ["ls"],
+          "args": { "ARGS": ["-l"] }
+        }
+      }
+    },
+    {
+      "id": "multicall-strips-exe",
+      "doc": "A trailing .exe is stripped so Windows and Unix agree on the applet name.",
+      "spec": "name \"busybox\"\nbin \"busybox\"\nmulticall #true\ncmd \"ls\"\n",
+      "argv0": "ls.exe",
+      "argv": [],
+      "expect": {
+        "ok": {
+          "cmd": ["ls"]
+        }
+      }
+    },
+    {
+      "id": "multicall-unknown-is-unexpected",
+      "doc": "An unknown applet is the same error as an unmatched word: nothing can hold it.",
+      "spec": "name \"busybox\"\nbin \"busybox\"\nmulticall #true\ncmd \"ls\"\n",
+      "argv0": "wat",
+      "argv": [],
+      "expect": { "error": "unexpected_arg" }
+    },
+    {
+      "id": "multicall-unknown-can-be-external",
+      "doc": "An unknown applet is forwarded when the root declares external_subcommand, including flags after it.",
+      "spec": "name \"busybox\"\nbin \"busybox\"\nmulticall #true\nunknown_flags \"error\"\nexternal_subcommand #true\ncmd \"ls\"\n",
+      "argv0": "/usr/bin/git",
+      "argv": ["--help"],
+      "expect": {
+        "ok": {
+          "external": ["git", "--help"]
+        }
+      }
+    },
+    {
+      "id": "multicall-name-or-bin-is-dispatcher",
+      "doc": "Either dispatcher name skips argv[0]: `bin` matching is enough even when `name` differs.",
+      "spec": "name \"BusyBox\"\nbin \"busybox\"\nmulticall #true\ncmd \"ls\" {\n  arg \"[ARGS]...\"\n}\n",
+      "argv0": "/usr/bin/busybox",
+      "argv": ["ls", "-l"],
+      "expect": {
+        "ok": {
+          "cmd": ["ls"],
+          "args": { "ARGS": ["-l"] }
+        }
+      }
+    },
+    {
+      "id": "multicall-default-subcommand-catches-unknown-applet",
+      "doc": "An unknown applet is an unmatched word, so default_subcommand still catches it.",
+      "spec": "name \"busybox\"\nbin \"busybox\"\nmulticall #true\ndefault_subcommand \"ls\"\ncmd \"ls\" {\n  arg \"[ARGS]...\"\n}\n",
+      "argv0": "wat",
+      "argv": [],
+      "expect": {
+        "ok": {
+          "cmd": ["ls"],
+          "args": { "ARGS": ["wat"] }
+        }
+      }
+    },
+    {
+      "id": "multicall-empty-dispatcher-stays-at-root",
+      "doc": "Invoking the dispatcher with no further words stays at the root; it does not invent an applet.",
+      "spec": "name \"busybox\"\nbin \"busybox\"\nmulticall #true\ncmd \"ls\"\n",
+      "argv0": "busybox",
+      "argv": [],
+      "expect": { "ok": {} }
+    }
+  ]
+}

--- a/corpus/README.md
+++ b/corpus/README.md
@@ -32,15 +32,16 @@ the group establishes, and `vectors`:
 }
 ```
 
-| field       | meaning                                                                                                         |
-| ----------- | --------------------------------------------------------------------------------------------------------------- |
-| `id`        | unique across the corpus, and stable — reports quote it, so renaming one breaks anybody tracking known failures |
-| `doc`       | what this vector pins down, in one sentence                                                                     |
-| `spec`      | a complete spec, as KDL                                                                                         |
-| `argv`      | the command line, excluding the program name                                                                    |
-| `env`       | the environment the parse sees; absent means empty                                                              |
-| `expect`    | `{"ok": {...}}` or `{"error": "code"}`                                                                          |
-| `reference` | whether usage-lib agrees; see below                                                                             |
+| field       | meaning                                                                                                                                                            |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `id`        | unique across the corpus, and stable — reports quote it, so renaming one breaks anybody tracking known failures                                                    |
+| `doc`       | what this vector pins down, in one sentence                                                                                                                        |
+| `spec`      | a complete spec, as KDL                                                                                                                                            |
+| `argv`      | the command line, excluding the program name                                                                                                                       |
+| `argv0`     | the process's argv[0], when that is the question; absent means the spec's `bin`. A `multicall` applet is selected by this basename rather than by a word in `argv` |
+| `env`       | the environment the parse sees; absent means empty                                                                                                                 |
+| `expect`    | `{"ok": {...}}` or `{"error": "code"}`                                                                                                                             |
+| `reference` | whether usage-lib agrees; see below                                                                                                                                |
 
 `expect.ok` holds `cmd` (the selected subcommand path, outermost first, omitted
 for the root), `flags`, and `args`. Both maps are keyed by the name the spec gives

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -88,6 +88,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
     let unknown_flags = unknown_flags_tokens(cli);
 
     let default_subcommand = option_str(cli.default_subcommand.as_deref());
+    let multicall = cli.multicall;
     let usage = option_str(cli.usage.as_deref());
     let restart_token = option_str(cli.restart_token.as_deref());
     let mount = option_str(cli.mount.as_deref());
@@ -440,6 +441,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
                 long_about: #long_about,
                 usage: #usage,
                 default_subcommand: #default_subcommand,
+                multicall: #multicall,
                 root: &ROOT_META,
             };
 
@@ -485,8 +487,26 @@ pub fn emit(cli: &Cli) -> TokenStream {
 
                 pub fn parse() -> Self {
                     #completion_intercept
-                    let __usage_raw: ::std::vec::Vec<::std::ffi::OsString> =
-                        ::std::env::args_os().skip(1).collect();
+                    let __usage_raw: ::std::vec::Vec<::std::ffi::OsString> = if SPEC.multicall {
+                        let mut __usage_all: ::std::vec::Vec<::std::ffi::OsString> =
+                            ::std::env::args_os().collect();
+                        if !__usage_all.is_empty() {
+                            let __usage_argv0 = __usage_all.remove(0);
+                            if let ::std::option::Option::Some(__usage_word) =
+                                __usage_argv0.to_str().and_then(|s| {
+                                    usage_argv::multicall_applet(s, SPEC.name, SPEC.bin)
+                                })
+                            {
+                                __usage_all.insert(
+                                    0,
+                                    ::std::ffi::OsString::from(__usage_word),
+                                );
+                            }
+                        }
+                        __usage_all
+                    } else {
+                        ::std::env::args_os().skip(1).collect()
+                    };
                     let __usage_argv: ::std::vec::Vec<&::std::ffi::OsStr> =
                         __usage_raw.iter().map(|a| a.as_os_str()).collect();
                     // This is the entry point that *is* the process — it already exits for a help

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -180,7 +180,8 @@
 //!
 //! On the struct itself: `bin`, `version`, `about`, `long_about`, `before_help`, `after_help`,
 //! `verbatim_doc_comment` — preserve doc-comment line breaks and whitespace —
-//! `default_subcommand`, `min_usage_version` — the oldest `usage` that can read the emitted
+//! `default_subcommand`, `multicall` — argv[0]'s basename selects a subcommand —
+//! `min_usage_version` — the oldest `usage` that can read the emitted
 //! spec, declared rather than worked out — `effect` — what running this command does to the world, on an `Args`
 //! rather than on the root, which does nothing itself — `completion`, which adds the hidden command a generated shell
 //! script calls, and needs usage-argv's `complete` feature enabled where it is depended on —

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -78,6 +78,12 @@ pub struct Cli {
     ///
     /// Only the root has one, and it is what mise sets by hand on the emitted spec today.
     pub default_subcommand: Option<String>,
+    /// Whether argv[0]'s basename selects a subcommand (busybox-style applets).
+    ///
+    /// clap's `multicall`. Only the root has one: a spec declares it once, for the
+    /// whole program. `parse()` rewrites the process's argv[0]; `parse_from` is
+    /// unchanged, because the caller already decided the words.
+    pub multicall: bool,
     /// Declared descriptions, for the case a doc comment cannot express: a long form that does
     /// not contain the short one.
     pub about_attr: Option<String>,
@@ -464,6 +470,7 @@ impl Cli {
             long_about: None,
             unknown_flags: None,
             default_subcommand: None,
+            multicall: false,
             about_attr: None,
             long_about_attr: None,
             before_help: None,
@@ -538,6 +545,7 @@ impl Cli {
                     "default_subcommand" => {
                         cli.default_subcommand = Some(strip_dashes(&string_value(&meta)?))
                     }
+                    "multicall" => cli.multicall = flag_value(&meta)?,
                     "restart_token" => cli.restart_token = Some(string_value(&meta)?),
                     "mount" => cli.mount = Some(string_value(&meta)?),
                     "group" => cli.groups.push(group_decl(&meta)?),
@@ -547,7 +555,7 @@ impl Cli {
                             format!(
                                 "unknown option `{other}` on a struct; usage::Cli takes \
                                  `name`, `bin`, `version`, `usage`, `verbatim_doc_comment`, `unknown_flags`, \
-                                 `default_subcommand`, `restart_token`, `mount` and \
+                                 `default_subcommand`, `multicall`, `restart_token`, `mount` and \
                                  `group` here, and the description comes from the doc \
                                  comment"
                             ),
@@ -673,6 +681,13 @@ impl Cli {
                      spec declares one for the whole program, not one per command",
                 ));
             }
+            if self.multicall {
+                return Err(self.misplaced(
+                    ident,
+                    "`multicall` belongs on the root, where `#[derive(Cli)]` is: a spec \
+                     declares it once for the whole program, not one per command",
+                ));
+            }
             return Ok(());
         }
 
@@ -731,6 +746,18 @@ impl Cli {
                 ident,
                 "`default_subcommand` names the command a bare invocation means, and this \
                  one has no subcommands to name",
+            ));
+        }
+        if self.multicall
+            && !self
+                .fields
+                .iter()
+                .any(|f| matches!(f.kind, Kind::Subcommand { .. }))
+        {
+            return Err(self.misplaced(
+                ident,
+                "`multicall` treats argv[0] as a subcommand, and this one has no \
+                 subcommands to select",
             ));
         }
         Ok(())
@@ -4439,6 +4466,42 @@ mod tests {
         let err = position_error(
             r#"
             #[usage(default_subcommand = "inner")]
+            struct Nested {
+                #[usage(subcommand)]
+                command: Option<Commands>,
+            }
+        "#,
+            false,
+        );
+        assert!(
+            err.contains("belongs on the root"),
+            "unhelpful message: {err}"
+        );
+    }
+
+    #[test]
+    fn multicall_needs_subcommands_to_select() {
+        let err = position_error(
+            r#"
+            #[usage(bin = "ex", multicall)]
+            struct Ex {
+                #[usage(arg)]
+                task: Option<String>,
+            }
+        "#,
+            true,
+        );
+        assert!(
+            err.contains("no subcommands to select"),
+            "unhelpful message: {err}"
+        );
+    }
+
+    #[test]
+    fn multicall_is_refused_below_the_root() {
+        let err = position_error(
+            r#"
+            #[usage(multicall)]
             struct Nested {
                 #[usage(subcommand)]
                 command: Option<Commands>,

--- a/docs/go/generated-code.md
+++ b/docs/go/generated-code.md
@@ -43,6 +43,19 @@ type InstallCmd struct { /* … */ }  // and one per command
 func Parse(args []string) (*Cli, error)
 ```
 
+`Parse` takes the tokens after the program name. A spec that declares
+`multicall` needs argv[0] rewritten first, because a symlink `ls -> busybox`
+has no `ls` word in `os.Args[1:]`:
+
+```go
+args := argv.RewriteMulticall(os.Args[0], os.Args[1:], HelpMeta.Name, HelpMeta.Bin)
+cli, err := Parse(args)
+```
+
+`RewriteMulticall` prepends argv[0]'s basename when it is an applet rather than
+the dispatcher (`name` / `bin`). Path components and a trailing `.exe` are
+stripped. A dispatcher invocation is a no-op.
+
 The three tables are separate on purpose: reference only `Root` and the linker drops the
 validation metadata and help text. On mise's spec that's the difference between a 2.60MB and a
 2.82MB contribution to the binary. Dispatch on the key constants, never on `Name` strings — a

--- a/docs/rust/args-and-flags.md
+++ b/docs/rust/args-and-flags.md
@@ -182,6 +182,7 @@ On the root `#[derive(Cli)]` struct:
 | `before_help` / `after_help`        | Extra text around the help page (`*_long_help` variants too)   |
 | `unknown_flags = "value"\|"error"`  | Treat unknown flags as values instead of errors                |
 | `default_subcommand = "run"`        | Command to assume when argv names none                         |
+| `multicall`                         | Treat argv[0]'s basename as a subcommand (busybox-style)       |
 | `completion`                        | Generate completion support ([Completions](/rust/completions)) |
 | `settings`                          | Generate config-settings bindings                              |
 | `min_usage_version = "…"`           | Declare the minimum usage version the spec needs               |

--- a/docs/rust/subcommands.md
+++ b/docs/rust/subcommands.md
@@ -68,6 +68,24 @@ struct Ex { /* … */ }
 When argv selects no command, `run` is assumed. Naming a command that doesn't exist fails the
 **build**, not the run.
 
+## Multicall
+
+clap's `#[command(multicall = true)]` is busybox-style applets: argv[0]'s basename
+selects a subcommand. `parse()` rewrites the process's argv[0]; `parse_from` is
+unchanged, because the caller already decided the words.
+
+```rust
+#[derive(Cli)]
+#[usage(bin = "busybox", multicall)]
+struct Busybox {
+    #[usage(subcommand)]
+    command: Commands,
+}
+```
+
+A symlink `ls -> busybox` runs the `ls` variant. `busybox ls` still does too: the
+dispatcher name is skipped. Path components and a trailing `.exe` are stripped.
+
 ## External subcommands
 
 clap's `#[command(external_subcommand)]` is a catch-all variant that holds the unmatched

--- a/docs/spec/argv.md
+++ b/docs/spec/argv.md
@@ -27,6 +27,12 @@ already done.
 A **command line** is the tokens after the program name. `mycli install -f x`
 has three.
 
+When the spec declares `multicall`, argv[0]'s basename is itself a word: a
+symlink `ls -> busybox` is parsed as if the first token were `ls`. The
+dispatcher names (`name` and `bin`) are skipped, so `busybox ls` still has two
+words after the program name. Path components and a trailing `.exe` are
+stripped so `/usr/bin/ls` and `ls.exe` select the same applet.
+
 A token is **flag-like** when it begins with `-`, is longer than one character,
 and is not a negative number. So `--force`, `-f`, and `-abc` are flag-like; `-`,
 `-1`, `-2.5`, and `-1e5` are not.
@@ -279,6 +285,21 @@ cmd "exec" external_subcommand=#true {
   cmd "install"
 }
 ```
+
+### Multicall
+
+A spec may declare `multicall`. argv[0]'s basename is then a word: a symlink
+`ls -> busybox` is parsed as if the first token were `ls`. The dispatcher names
+(`name` and `bin`) are skipped, so `busybox ls` still selects `ls`. Path
+components and a trailing `.exe` are stripped, so `/usr/bin/ls` and `ls.exe`
+select the same applet.
+
+An unknown applet is an unmatched word: it errors, or is forwarded if the root
+declares `external_subcommand`. Invoking the dispatcher with no further words
+stays at the root.
+
+This is clap's `Command::multicall`. Corpus vectors that care about argv[0]
+carry it as `argv0`; everyone else is the spec's `bin`.
 
 ### Flag scope
 

--- a/docs/spec/integrations/clap.md
+++ b/docs/spec/integrations/clap.md
@@ -63,6 +63,9 @@ it, and everything downstream — help, docs, completions — describes a CLI wi
 constraint. `Arg::default_value_if` is the same hole: a generated spec never carries
 [`default_if`](/spec/reference/flag#default_if).
 
+[`multicall`](/spec/reference/#multicall) is one clap _does_ expose:
+`Command::is_multicall_set` reaches the spec as `multicall #true`.
+
 Declaring it in the spec is the way to have it. A CLI that keeps its source of truth in
 clap can add the node to a hand-written overlay spec merged with the generated one.
 

--- a/docs/spec/reference/index.md
+++ b/docs/spec/reference/index.md
@@ -31,6 +31,24 @@ source_code_link_template "https://github.com/me/myproj/blob/main/src/cli/{{path
 include file="./my_overrides.usage.kdl" // include another spec, will be merged and override existing values
 ```
 
+## Multicall
+
+`multicall #true` is clap's busybox-style applets: argv[0]'s basename selects a
+subcommand. The dispatcher names (`name` and `bin`) are skipped, so
+`busybox ls` still runs the `ls` applet. A symlink `ls -> busybox` does too,
+because the basename is `ls`. Path components and a trailing `.exe` are stripped.
+
+```kdl
+name "busybox"
+bin "busybox"
+multicall #true
+cmd "ls"
+cmd "cat"
+```
+
+clap exposes this as `Command::multicall` / `#[command(multicall = true)]`, and
+the bridge reads `is_multicall_set`.
+
 ## Repository
 
 The URL of the CLI's source repository:

--- a/go/argv/multicall.go
+++ b/go/argv/multicall.go
@@ -1,0 +1,42 @@
+package argv
+
+import "strings"
+
+// MulticallBasename is the last path component of argv0, with a trailing .exe
+// stripped so Windows and Unix agree.
+func MulticallBasename(argv0 string) string {
+	name := argv0
+	if i := strings.LastIndexAny(name, `/\`); i >= 0 {
+		name = name[i+1:]
+	}
+	if len(name) >= 4 && strings.EqualFold(name[len(name)-4:], ".exe") {
+		return name[:len(name)-4]
+	}
+	return name
+}
+
+// AppletFromArgv0 is the applet name to parse as the first word, when argv0 is
+// not the dispatcher. ok is false for a dispatcher invocation (busybox ls):
+// skip argv0 and parse the rest. ok is true for a symlink invocation (ls -l):
+// inject the basename.
+func AppletFromArgv0(argv0, name, bin string) (applet string, ok bool) {
+	base := MulticallBasename(argv0)
+	if name != "" && base == name {
+		return "", false
+	}
+	if bin != "" && base == bin {
+		return "", false
+	}
+	return base, true
+}
+
+// RewriteMulticall prepends argv0's basename when it is an applet rather than
+// the dispatcher. args are the tokens after the program name.
+func RewriteMulticall(argv0 string, args []string, name, bin string) []string {
+	applet, ok := AppletFromArgv0(argv0, name, bin)
+	if !ok {
+		return args
+	}
+	out := make([]string, 0, 1+len(args))
+	return append(append(out, applet), args...)
+}

--- a/go/argv/multicall_test.go
+++ b/go/argv/multicall_test.go
@@ -1,0 +1,30 @@
+package argv
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMulticallBasename(t *testing.T) {
+	if got := MulticallBasename("/usr/bin/ls"); got != "ls" {
+		t.Fatalf("path: got %q", got)
+	}
+	if got := MulticallBasename(`C:\busybox\ls.exe`); got != "ls" {
+		t.Fatalf("exe: got %q", got)
+	}
+	if got := MulticallBasename("LS.EXE"); got != "LS" {
+		t.Fatalf("case: got %q", got)
+	}
+}
+
+func TestRewriteMulticall(t *testing.T) {
+	args := []string{"-l"}
+	got := RewriteMulticall("/usr/bin/ls", args, "busybox", "busybox")
+	if !reflect.DeepEqual(got, []string{"ls", "-l"}) {
+		t.Fatalf("applet: got %q", got)
+	}
+	got = RewriteMulticall("/usr/bin/busybox", []string{"ls", "-l"}, "busybox", "busybox")
+	if !reflect.DeepEqual(got, []string{"ls", "-l"}) {
+		t.Fatalf("dispatcher: got %q", got)
+	}
+}

--- a/go/conformance/conformance_test.go
+++ b/go/conformance/conformance_test.go
@@ -39,6 +39,7 @@ type Vector struct {
 	Doc    string            `json:"doc"`
 	Spec   string            `json:"spec"`
 	Argv   []string          `json:"argv"`
+	Argv0  string            `json:"argv0"`
 	Env    map[string]string `json:"env"`
 	Expect Expect            `json:"expect"`
 	// Layer says which layer of a parser the vector is a question for. Absent
@@ -99,7 +100,7 @@ func TestCorpus(t *testing.T) {
 				lowered[v.Spec] = s
 			}
 
-			got, gotErr := run(s, v.Argv, v.Env)
+			got, gotErr := run(s, v.Argv, v.Argv0, v.Env)
 
 			switch {
 			case v.Expect.Error != "":
@@ -170,9 +171,18 @@ func note(v Vector) string {
 // deliberately does not know: it reports each occurrence and lets the caller
 // decide. Generated code assigns to a field or appends to a slice; here the spec
 // says which of the two to do.
-func run(s *spec.Spec, args []string, env map[string]string) (*Parsed, *argv.Error) {
+func run(s *spec.Spec, args []string, argv0 string, env map[string]string) (*Parsed, *argv.Error) {
 	root, meta := s.Build()
 	multi := s.MultiFlags()
+	if s.Multicall {
+		if argv0 == "" {
+			argv0 = s.Bin
+			if argv0 == "" {
+				argv0 = s.Name
+			}
+		}
+		args = argv.RewriteMulticall(argv0, args, s.Name, s.Bin)
+	}
 
 	// Accumulated by key rather than by name, because the post-binding rules are
 	// keyed that way and two commands in one path may declare the same name — a

--- a/go/internal/spec/spec.go
+++ b/go/internal/spec/spec.go
@@ -38,9 +38,13 @@ type Spec struct {
 	// DefaultSubcommand is declared once, at the top, and names a subcommand of
 	// the root.
 	DefaultSubcommand string `json:"default_subcommand"`
-	Version           string `json:"version"`
-	About             string `json:"about"`
-	AboutLong         string `json:"about_long"`
+	// Multicall is whether argv[0]'s basename selects a subcommand (busybox-style
+	// applets). clap's multicall. The dispatcher names (Name / Bin) are skipped;
+	// any other basename is parsed as the first word.
+	Multicall bool   `json:"multicall"`
+	Version   string `json:"version"`
+	About     string `json:"about"`
+	AboutLong string `json:"about_long"`
 	// Complete is the completers a spec declares, keyed by the lowercased name of
 	// the argument or flag value they belong to — which is how usage-lib keys
 	// them, and how a lookup has to be spelled.

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -565,17 +565,15 @@ pub fn multicall_basename(argv0: &str) -> &str {
 /// rest. `Some` is a symlink invocation (`ls -l`): inject the basename.
 pub fn multicall_applet<'a>(argv0: &'a str, name: &str, bin: Option<&str>) -> Option<&'a str> {
     let base = multicall_basename(argv0);
-    if dispatcher_name(name, bin).any(|dispatcher| dispatcher == base) {
-        None
-    } else {
-        Some(base)
+    if !name.is_empty() && base == name {
+        return None;
     }
-}
-
-fn dispatcher_name(name: &str, bin: Option<&str>) -> impl Iterator<Item = &str> {
-    [name, bin.unwrap_or("")]
-        .into_iter()
-        .filter(|s| !s.is_empty())
+    if let Some(bin) = bin {
+        if !bin.is_empty() && base == bin {
+            return None;
+        }
+    }
+    Some(base)
 }
 
 /// Internal version of parse_partial that accepts an optional custom env map.

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -549,6 +549,35 @@ pub fn parse_partial(spec: &Spec, input: &[String]) -> Result<ParseOutput, miett
     parse_partial_with_env(spec, input, None, MountTiming::Eager).map(|(out, _)| out)
 }
 
+/// Basename of argv[0] for a multicall CLI: last path component, with a trailing
+/// `.exe` stripped so Windows and Unix agree.
+pub fn multicall_basename(argv0: &str) -> &str {
+    let name = argv0.rsplit(['/', '\\']).next().unwrap_or(argv0);
+    match name.get(name.len().saturating_sub(4)..) {
+        Some(ext) if ext.eq_ignore_ascii_case(".exe") => &name[..name.len() - 4],
+        _ => name,
+    }
+}
+
+/// The applet name to parse as the first word, when argv[0] is not the dispatcher.
+///
+/// `None` means a dispatcher invocation (`busybox ls`): skip argv[0] and parse the
+/// rest. `Some` is a symlink invocation (`ls -l`): inject the basename.
+pub fn multicall_applet<'a>(argv0: &'a str, name: &str, bin: Option<&str>) -> Option<&'a str> {
+    let base = multicall_basename(argv0);
+    if dispatcher_name(name, bin).any(|dispatcher| dispatcher == base) {
+        None
+    } else {
+        Some(base)
+    }
+}
+
+fn dispatcher_name(name: &str, bin: Option<&str>) -> impl Iterator<Item = &str> {
+    [name, bin.unwrap_or("")]
+        .into_iter()
+        .filter(|s| !s.is_empty())
+}
+
 /// Internal version of parse_partial that accepts an optional custom env map.
 /// When a command's own `mount` runs, for the root — which nothing descends into.
 ///
@@ -571,7 +600,14 @@ fn parse_partial_with_env(
 ) -> Result<(ParseOutput, HashSet<String>), miette::Error> {
     trace!("parse_partial: {input:?}");
     let mut input = input.iter().cloned().collect::<VecDeque<_>>();
-    input.pop_front();
+    let argv0 = input.pop_front();
+    if spec.multicall {
+        if let Some(raw) = argv0 {
+            if let Some(applet) = multicall_applet(&raw, &spec.name, Some(spec.bin.as_str())) {
+                input.push_front(applet.to_string());
+            }
+        }
+    }
 
     let mut out = ParseOutput {
         cmd: spec.cmd.clone(),
@@ -6082,6 +6118,72 @@ cmd "run" {
         assert_eq!(parsed.cmd.name, "run");
         assert!(parsed.external.is_none());
         assert_eq!(first_string_value(&parsed), "build");
+    }
+
+    #[test]
+    fn multicall_basename_strips_a_path_and_exe() {
+        assert_eq!(multicall_basename("/usr/bin/ls"), "ls");
+        assert_eq!(multicall_basename(r"C:\busybox\ls.exe"), "ls");
+        assert_eq!(multicall_basename("LS.EXE"), "LS");
+        assert_eq!(multicall_basename("busybox"), "busybox");
+    }
+
+    #[test]
+    fn a_multicall_applet_is_the_first_word() {
+        let spec: Spec = r#"
+name "busybox"
+bin "busybox"
+multicall #true
+cmd "ls" {
+    arg "[ARGS]" var=#true
+}
+cmd "cat"
+"#
+        .parse()
+        .unwrap();
+
+        // A symlink: argv[0] is the applet.
+        let parsed = parse(&spec, &input(&["/usr/bin/ls", "-l"])).unwrap();
+        assert_eq!(parsed.cmd.name, "ls");
+        match parsed.args.values().next() {
+            Some(ParseValue::MultiString(values)) => assert_eq!(values, &["-l".to_string()]),
+            other => panic!("expected ARGS to collect -l, got {other:?}"),
+        }
+
+        // A dispatcher invocation still skips argv[0].
+        let parsed = parse(&spec, &input(&["/usr/bin/busybox", "ls", "-l"])).unwrap();
+        assert_eq!(parsed.cmd.name, "ls");
+
+        // `.exe` is stripped so Windows and Unix agree.
+        let parsed = parse(&spec, &input(&["ls.exe"])).unwrap();
+        assert_eq!(parsed.cmd.name, "ls");
+
+        // Without the property, argv[0] is discarded as usual.
+        let mut plain = spec.clone();
+        plain.multicall = false;
+        let parsed = parse(&plain, &input(&["/usr/bin/ls", "ls"])).unwrap();
+        assert_eq!(parsed.cmd.name, "ls");
+    }
+
+    #[test]
+    fn a_multicall_unknown_applet_can_be_external() {
+        let spec: Spec = r#"
+name "busybox"
+bin "busybox"
+multicall #true
+unknown_flags "error"
+external_subcommand #true
+cmd "ls"
+"#
+        .parse()
+        .unwrap();
+
+        let parsed = parse(&spec, &input(&["/usr/bin/git", "--help"])).unwrap();
+        assert_eq!(parsed.external, Some(vec!["git".into(), "--help".into()]));
+
+        let mut closed = spec.clone();
+        closed.cmd.external_subcommand = false;
+        assert!(parse(&closed, &input(&["wat"])).is_err());
     }
 
     #[test]

--- a/lib/src/spec/mod.rs
+++ b/lib/src/spec/mod.rs
@@ -91,6 +91,14 @@ pub struct Spec {
     /// This enables "naked" command syntax like `mise foo` instead of `mise run foo`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_subcommand: Option<String>,
+    /// Whether argv[0]'s basename selects a subcommand (busybox-style applets).
+    ///
+    /// clap's `multicall`. The dispatcher names ([`Self::name`] and [`Self::bin`])
+    /// are skipped; any other basename is parsed as the first word, so a symlink
+    /// `ls -> busybox` runs the `ls` applet. Path components and a trailing `.exe`
+    /// are stripped.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub multicall: bool,
     /// What to do with a flag-like token that names no declared flag, for the whole
     /// CLI. A command may override it; see [`SpecCommand::unknown_flags`].
     pub unknown_flags: Option<crate::spec::unknown_flags::UnknownFlags>,
@@ -276,6 +284,7 @@ impl Spec {
                 "default_subcommand" => {
                     schema.default_subcommand = Some(node.arg(0)?.ensure_string()?)
                 }
+                "multicall" => schema.multicall = node.arg(0)?.ensure_bool()?,
                 "external_subcommand" => {
                     schema.cmd.external_subcommand = node.arg(0)?.ensure_bool()?;
                 }
@@ -372,6 +381,9 @@ impl Spec {
         merge_opt!(disable_help);
         merge_opt!(min_usage_version);
         merge_opt!(default_subcommand);
+        if other.multicall {
+            self.multicall = true;
+        }
         merge_opt!(unknown_flags);
         merge_extend!(complete);
         merge_extend!(examples);
@@ -543,6 +555,11 @@ impl Display for Spec {
             node.push(string_entry(None, default_subcommand));
             nodes.push(node);
         }
+        if self.multicall {
+            let mut node = KdlNode::new("multicall");
+            node.push(KdlEntry::new(true));
+            nodes.push(node);
+        }
         if self.cmd.external_subcommand {
             let mut node = KdlNode::new("external_subcommand");
             node.push(KdlEntry::new(true));
@@ -609,6 +626,7 @@ impl From<&clap::Command> for Spec {
             // The root is a command too, and its own answer has nowhere else to go: a spec says
             // this at the top level, which is the field a reader puts it back into.
             unknown_flags: crate::spec::cmd::SpecCommand::from(cmd).unknown_flags,
+            multicall: cmd.is_multicall_set(),
             ..Default::default()
         };
         // The same pass the KDL parser makes, and for the same reason: a command has to know
@@ -778,6 +796,48 @@ source_code_link_template "https://github.com/jdx/mise/blob/main/src/cli/{{path}
         let spec = Spec::from(&cmd);
         let flag = spec.cmd.flags.iter().find(|f| f.name == "events").unwrap();
         assert_eq!(flag.default, ["a,b"]);
+    }
+
+    #[test]
+    fn multicall_round_trips() {
+        let spec = Spec::parse(
+            &Default::default(),
+            r#"
+name "busybox"
+bin "busybox"
+multicall #true
+cmd "ls"
+cmd "cat"
+        "#,
+        )
+        .unwrap();
+        assert!(spec.multicall);
+        let emitted = spec.to_string();
+        assert!(
+            emitted.contains("multicall #true"),
+            "lost on the way out: {emitted}"
+        );
+        let again: Spec = emitted.parse().unwrap();
+        assert!(again.multicall);
+    }
+
+    #[test]
+    #[cfg(feature = "clap")]
+    fn multicall_comes_across_from_clap() {
+        let cmd = clap::Command::new("busybox")
+            .multicall(true)
+            .subcommand(clap::Command::new("ls"))
+            .subcommand(clap::Command::new("cat"));
+        let spec = Spec::from(&cmd);
+        assert!(spec.multicall);
+        assert!(
+            spec.to_string().contains("multicall #true"),
+            "{}",
+            spec.to_string()
+        );
+
+        let plain = clap::Command::new("ex").subcommand(clap::Command::new("ls"));
+        assert!(!Spec::from(&plain).multicall);
     }
 
     macro_rules! extract_usage_tests {

--- a/xtask/src/shadow.rs
+++ b/xtask/src/shadow.rs
@@ -2211,14 +2211,16 @@ mod tests {
         assert!(usage.contains("multicall"), "{usage}");
         assert!(
             !skipped.counts.keys().any(|k| k.contains("multicall")),
-            "{skipped:?}"
+            "{:?}",
+            skipped.counts
         );
 
         let (clap, clap_skipped) = rendered_as(spec, Dialect::Clap);
         assert!(clap.contains("multicall = true"), "{clap}");
         assert!(
             !clap_skipped.counts.keys().any(|k| k.contains("multicall")),
-            "{clap_skipped:?}"
+            "{:?}",
+            clap_skipped.counts
         );
     }
 

--- a/xtask/src/shadow.rs
+++ b/xtask/src/shadow.rs
@@ -166,6 +166,7 @@ fn render(spec: &Spec, spec_path: &Path, dialect: Dialect) -> (String, Skipped) 
             name: &spec.name,
             version: spec.version.as_deref(),
             default_subcommand: spec.default_subcommand.as_deref(),
+            multicall: spec.multicall,
             about: spec.about.as_deref(),
             about_long: spec.about_long.as_deref(),
             dialect,
@@ -287,6 +288,8 @@ struct Run<'a> {
     version: Option<&'a str>,
     /// Only the root has one, and only it declares it.
     default_subcommand: Option<&'a str>,
+    /// Busybox-style applets: argv[0]'s basename selects a subcommand.
+    multicall: bool,
     /// The spec's own description, which belongs to the root.
     about: Option<&'a str>,
     about_long: Option<&'a str>,
@@ -431,6 +434,9 @@ fn emit_command(out: &mut String, cmd: &SpecCommand, ty: &Type, is_root: bool, r
     if is_root && cmd.effect.is_some() {
         run.skipped.note("`effect` on the root command");
     }
+    if is_root && run.multicall {
+        usage_opts.push("multicall".into());
+    }
     match (is_root, dialect) {
         (true, Dialect::Usage) => {
             out.push_str("#[derive(Cli)]\n");
@@ -450,6 +456,9 @@ fn emit_command(out: &mut String, cmd: &SpecCommand, ty: &Type, is_root: bool, r
             // clap spells this the same way, so the two shadows describe the same program.
             if let Some(version) = run.version {
                 opts.push(format!("version = {version:?}"));
+            }
+            if run.multicall {
+                opts.push("multicall = true".into());
             }
             opts.extend(declared_about.iter().cloned());
             out.push_str(&format!("#[command({})]\n", opts.join(", ")));
@@ -2192,6 +2201,24 @@ mod tests {
             out.matches("default_subcommand").count(),
             1,
             "only the root should declare it: {out}"
+        );
+    }
+
+    #[test]
+    fn both_dialects_carry_multicall() {
+        let spec = "name \"busybox\"\nbin \"busybox\"\nmulticall #true\ncmd \"ls\"\n";
+        let (usage, skipped) = rendered_as(spec, Dialect::Usage);
+        assert!(usage.contains("multicall"), "{usage}");
+        assert!(
+            !skipped.counts.keys().any(|k| k.contains("multicall")),
+            "{skipped:?}"
+        );
+
+        let (clap, clap_skipped) = rendered_as(spec, Dialect::Clap);
+        assert!(clap.contains("multicall = true"), "{clap}");
+        assert!(
+            !clap_skipped.counts.keys().any(|k| k.contains("multicall")),
+            "{clap_skipped:?}"
         );
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacked on #1027. Adds clap's `Command::multicall` as spec-level `multicall #true`.

## Semantics

argv[0]'s basename is a word unless it is the dispatcher (`name` or `bin`). A symlink `ls -> busybox` is parsed as if the first token were `ls`. `busybox ls` still selects `ls`: the dispatcher name is skipped. Path components and a trailing `.exe` are stripped so `/usr/bin/ls` and `ls.exe` agree.

An unknown applet is an unmatched word: it errors, is forwarded when the root declares `external_subcommand`, or is caught by `default_subcommand`. Invoking the dispatcher with no further words stays at the root.

## Where argv0 is rewritten

- **usage-lib** `parse` includes the program name. After `pop_front`, a non-dispatcher basename is pushed back.
- **usage-argv / derive `parse_from` / Go `Parse`** take argv without the program name. `parse()` and the corpus adapters rewrite at process entry; `parse_from` stays unchanged because the caller already decided the words.
- Helpers: `multicall_basename` / `multicall_applet` in usage-lib and usage-argv; Go `RewriteMulticall`.

## Surfaces

- Spec parse/emit/merge, clap `is_multicall_set`
- Derive `#[usage(multicall)]` on the root (refused below it, and without subcommands)
- Go JSON `multicall`, `argv.RewriteMulticall`
- Corpus `12-multicall.json` (`argv0` on `Vector`; absent means the spec's `bin`)
- `usage lint` reports `multicall-no-subcommands`
- Shadows emit `multicall` for both usage and clap dialects

`no_binary_name` stays out of scope.

_This comment was generated by Claude Code._
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4de7e59e-aa2e-4ad0-a1d0-1c2e69c166db?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4de7e59e-aa2e-4ad0-a1d0-1c2e69c166db&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

