### PR TITLE
docs: correct current Rust limitations

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -293,18 +293,11 @@
 //!
 //! A word is held as the bytes it arrived as and converted once, where the struct is built.
 //! So a value that is not valid UTF-8 is **reported** rather than quietly replaced with
-//! `U+FFFD` — which for a `PathBuf` meant a different file, silently. What is still missing
-//! is *accepting* such a value: recovering an `OsString` from those bytes needs
-//! `OsStr::from_encoded_bytes_unchecked`, which is `unsafe`, and this crate has none.
+//! `U+FFFD` — which for a `PathBuf` meant a different file, silently. On Unix, `PathBuf` and
+//! `OsString` fields accept the bytes exactly through the safe `OsStringExt::from_vec`; on
+//! Windows, a value that cannot be converted safely is reported rather than reconstructed with
+//! `OsString::from_encoded_bytes_unchecked`.
 //!
-//! # What this version does not do
-//!
-//! Published early on purpose, so it can be used and argued with — but these are
-//! real limits, not omissions from the docs.
-//!
-//! - **Flattening.** A struct cannot yet borrow another struct's flags, so a set of
-//!   options shared by several commands has to be repeated.
-
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};
 

--- a/docs/rust/index.md
+++ b/docs/rust/index.md
@@ -151,6 +151,6 @@ equivalent yet:
 - There is no per-field `value_parser`-style validation — values are built with `FromStr`, and a
   conversion failure becomes an `InvalidValue` error.
 - Prefix matching (`infer_long_args`) is suggested in error messages but never accepted.
-- Non-UTF-8 argv values are reported precisely in errors rather than lossily replaced, but cannot
-  currently be _accepted_ into fields (the crates forbid the `unsafe` needed to reconstruct an
-  `OsString`).
+- On Unix, `PathBuf` and `OsString` fields accept non-UTF-8 argv without changing a byte. String
+  fields still report invalid UTF-8 precisely rather than replacing it; on Windows, values that
+  cannot be converted safely are reported instead of using an unchecked reconstruction.

--- a/docs/spec/integrations/clap.md
+++ b/docs/spec/integrations/clap.md
@@ -6,7 +6,7 @@
 
 ```toml
 [dependencies]
-clap_usage = "2"
+clap_usage = "5"
 ```
 
 ## Quick Start


### PR DESCRIPTION
## Summary

- recommend the current `clap_usage` major version
- document Unix non-UTF-8 `PathBuf` and `OsString` support accurately
- remove the obsolete claim that `flatten` is unsupported

## Why

These limitations remained in the public documentation after the corresponding features landed, which could incorrectly discourage migration from clap.

## Validation

- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo test -p usage-derive --doc`

This PR is stacked on #1027 so its diff is limited to the documentation corrections.

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API impact.
> 
> **Overview**
> **Brings public Rust documentation in line with behavior that already shipped**, so migration guidance is not misleading.
> 
> **Non-UTF-8 argv:** Crate-level and site docs now say that on Unix, `PathBuf` and `OsString` fields take argv bytes via safe `OsStringExt::from_vec`, while `String` fields still surface invalid UTF-8 in errors; on Windows, values that cannot be converted safely are reported instead of using unchecked reconstruction. The old wording that non-UTF-8 values could only be reported, not accepted, is removed.
> 
> **Obsolete limits:** The derive crate doc drops the “What this version does not do” section that still claimed **flatten** was unsupported (flatten is documented elsewhere on the site).
> 
> **Integration docs:** `docs/spec/integrations/clap.md` updates the example dependency from `clap_usage = "2"` to **`"5"`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 742dd0d79f14039d1c5a2357464a1e9dc9ddafaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->