### PR TITLE
docs: add clap compatibility matrix

### DIFF
--- a/docs/rust/clap-compatibility.md
+++ b/docs/rust/clap-compatibility.md
@@ -1,0 +1,103 @@
+# clap compatibility
+
+This matrix describes compatibility with `clap` 4.6.6 and `clap_derive` 4.6.4, the
+versions audited in this workspace. It distinguishes what a CLI can declare directly with
+`usage` from what [`clap_usage`](/spec/integrations/clap) can recover from an existing
+`clap::Command`.
+
+The bridge is not a lossless migration verifier. clap exposes some settings only through
+setters, so `clap_usage` cannot detect that they were present. Migrate from the Rust declaration,
+not only from generated KDL, when a row says **usage only**.
+
+## Status
+
+| Status          | Meaning                                                                                    |
+| --------------- | ------------------------------------------------------------------------------------------ |
+| **Supported**   | The derive, compiled parser, spec, and reference parser carry the behavior.                |
+| **Usage only**  | A usage declaration carries it, but clap exposes no getter or the bridge loses part of it. |
+| **Partial**     | The common form works; the note names the unsupported part.                                |
+| **Different**   | usage intentionally has different parsing behavior.                                        |
+| **Unsupported** | No equivalent is available yet.                                                            |
+| **Non-goal**    | The API shape is outside the static-parser architecture.                                   |
+
+## Types and declarations
+
+| clap                                             | usage       | clap → spec    | Notes                                                                                                     |
+| ------------------------------------------------ | ----------- | -------------- | --------------------------------------------------------------------------------------------------------- |
+| `Parser`                                         | Supported   | Supported      | `#[derive(usage::Cli)]`                                                                                   |
+| `Args`                                           | Supported   | Supported      | `#[derive(usage::Args)]`, including `flatten`                                                             |
+| `Subcommand`                                     | Supported   | Supported      | Nested and boxed variants are supported.                                                                  |
+| `ValueEnum`                                      | Partial     | Partial        | Bare values and names work; aliases, hidden values, per-value help, and case-insensitive matching do not. |
+| `#[arg(skip)]`                                   | Supported   | Not applicable | `#[usage(skip)]`; skipped fields do not belong in a spec.                                                 |
+| arbitrary `Command` / `Arg` builder code         | Non-goal    | Partial        | `usage-lib` is the dynamic spec interpreter; usage derive does not reproduce clap's builder API.          |
+| `ArgMatches`, `FromArgMatches`, `CommandFactory` | Non-goal    | Not applicable | Typed structs are built directly from static tables.                                                      |
+| `update_from` / `try_update_from`                | Unsupported | Not applicable | A parse currently constructs a new value.                                                                 |
+
+## Arguments and values
+
+| clap                                      | usage       | clap → spec    | Notes                                                                                                             |
+| ----------------------------------------- | ----------- | -------------- | ----------------------------------------------------------------------------------------------------------------- |
+| long and short flags                      | Supported   | Supported      | Multiple visible aliases are supported. Hidden flag aliases are bridge-lossy.                                     |
+| positional arguments                      | Supported   | Supported      | Required, optional, and variadic positionals are supported.                                                       |
+| `Option<T>`, `Vec<T>`, `Option<Vec<T>>`   | Supported   | Not applicable | Values use `FromStr`; Unix `PathBuf` and `OsString` also accept non-UTF-8 bytes.                                  |
+| `ArgAction::SetTrue`, `SetFalse`, `Count` | Supported   | Supported      | `SetFalse` is `#[usage(negate)]`.                                                                                 |
+| `default_value`                           | Supported   | Supported      | Defaults are applied after argv and environment values.                                                           |
+| `default_missing_value`                   | Usage only  | Unsupported    | `#[usage(default_missing = "…")]`; clap has no getter.                                                            |
+| `default_value_if(s)`                     | Usage only  | Unsupported    | `#[usage(default_if(...))]`; clap has no getter.                                                                  |
+| `env`                                     | Supported   | Partial        | Environment fallback works, but the current bridge can lose the binding.                                          |
+| `value_delimiter`                         | Supported   | Supported      | ASCII delimiters round-trip.                                                                                      |
+| `num_args`                                | Partial     | Partial        | `var_min` / `var_max` cover ranges; fixed arity, distinct value names, and bridge preservation remain incomplete. |
+| `allow_hyphen_values`                     | Supported   | Supported      | Available on value-taking flags; trailing positionals use `double_dash = "automatic"`.                            |
+| `allow_negative_numbers`                  | Unsupported | Unsupported    | `allow_hyphen_values` is broader, not equivalent.                                                                 |
+| `require_equals`                          | Supported   | Supported      | Detached values are refused.                                                                                      |
+| `value_terminator`                        | Unsupported | Unsupported    | No spec spelling yet.                                                                                             |
+| `dont_delimit_trailing_values`            | Unsupported | Unsupported    | No spec spelling yet.                                                                                             |
+| possible-values parser                    | Supported   | Supported      | Use `ValueEnum` or `choices`.                                                                                     |
+| arbitrary `value_parser` / numeric ranges | Unsupported | Unsupported    | `FromStr` validates conversion, but there is no per-field validator or declarative range yet.                     |
+| `ValueHint`                               | Partial     | Partial        | Path hints used by completions work; the full clap vocabulary does not.                                           |
+
+## Relationships and command routing
+
+| clap                                                      | usage       | clap → spec | Notes                                                                                                      |
+| --------------------------------------------------------- | ----------- | ----------- | ---------------------------------------------------------------------------------------------------------- |
+| `required`, `conflicts_with`, `overrides_with`            | Supported   | Supported   | Environment values participate in post-binding checks.                                                     |
+| `requires`                                                | Usage only  | Unsupported | clap exposes setters but no getter.                                                                        |
+| `requires_if(s)`                                          | Usage only  | Unsupported | Presence and value-conditional forms are supported in usage.                                               |
+| `required_if_eq`, `required_unless_present`               | Partial     | Partial     | Common single-selector forms work; the complete all/any families do not.                                   |
+| `ArgGroup`, required groups, `exclusive`                  | Supported   | Supported   | Positional group members are not represented yet.                                                          |
+| positional conflicts and relationships                    | Unsupported | Unsupported | Spec selectors currently name flags.                                                                       |
+| global flags                                              | Supported   | Supported   | A global may occur once per selected command scope.                                                        |
+| `allow_external_subcommands`                              | Supported   | Supported   | Use an `#[usage(external_subcommand)]` catch-all variant.                                                  |
+| `multicall`                                               | Supported   | Supported   | `parse()` routes on the executable basename.                                                               |
+| `no_binary_name`                                          | Unsupported | Unsupported | Low-level usage-argv already receives argv without argv0; no clap-compatible setter exists.                |
+| `infer_subcommands`, `infer_long_args`                    | Unsupported | Unsupported | Diagnostics suggest likely names but do not accept prefixes.                                               |
+| `arg_required_else_help` and subcommand/argument policies | Unsupported | Unsupported | No command-policy vocabulary yet.                                                                          |
+| unknown flags                                             | Different   | Different   | The spec can choose strict errors; the reference parser may forward unknown flag-like data to positionals. |
+
+## Help, version, and generated artifacts
+
+| clap                                              | usage       | clap → spec    | Notes                                                                                |
+| ------------------------------------------------- | ----------- | -------------- | ------------------------------------------------------------------------------------ |
+| short and long help                               | Supported   | Supported      | The compiled renderer is checked against usage-lib across the jdx CLI fleet.         |
+| help headings                                     | Supported   | Supported      | Flags and arguments are grouped by heading.                                          |
+| hidden commands, flags, and arguments             | Supported   | Supported      | Granular hides for defaults, env, and possible values are unsupported.               |
+| doc comments and long help                        | Supported   | Supported      | First paragraph is short help; the full block is long help.                          |
+| `verbatim_doc_comment`                            | Unsupported | Not applicable | Doc comments are normalized.                                                         |
+| `help_template`, `next_line_help`, `flatten_help` | Unsupported | Unsupported    | No equivalent yet.                                                                   |
+| `term_width`, `max_term_width`                    | Unsupported | Unsupported    | Help wraps using `COLUMNS`.                                                          |
+| help styles and color                             | Partial     | Unsupported    | Diagnostics are styled; help output is not.                                          |
+| built-in help/version flag control                | Unsupported | Unsupported    | Custom help/version actions and disabling built-ins are not represented.             |
+| `--version` / `-V`                                | Supported   | Supported      | Version propagation is supported.                                                    |
+| completions                                       | Partial     | Supported      | Self-contained bash, fish, PowerShell, and zsh scripts are available; Elvish is not. |
+| KDL, markdown, and manpages                       | Supported   | Supported      | Emitted KDL feeds the existing generators without a runtime dependency.              |
+
+## Usage extensions
+
+These are not clap compatibility gaps. usage additionally supports `mount`, `restart_token`,
+`default_subcommand`, command and flag `effect`, Nushell completions, and a language-neutral
+conformance corpus. clap cannot express those properties, so a clap-generated spec cannot carry
+them without an overlay.
+
+This page is the compatibility baseline, not a claim that every clap builder method is covered.
+When clap is updated, audit new public derive attributes and relevant `Command`, `Arg`, and
+`PossibleValue` methods here before treating the update as migration-neutral.

--- a/docs/rust/index.md
+++ b/docs/rust/index.md
@@ -139,6 +139,7 @@ See [Spec output](/rust/spec) for the round-trip guarantees and what the emitted
 - [Help, version, and errors](/rust/help) — what the parser renders and how to hook it
 - [Completions](/rust/completions) — static scripts and runtime completion
 - [Spec output](/rust/spec) — the emitted KDL and usage-cli integration
+- [clap compatibility](/rust/clap-compatibility) — supported behavior, bridge losses, and non-goals
 
 ## Current limitations
 

--- a/docs/spec/integrations/clap.md
+++ b/docs/spec/integrations/clap.md
@@ -68,5 +68,6 @@ constraint. `Arg::default_value_if` is the same hole: a generated spec never car
 
 ## Links
 
+- [clap compatibility matrix](/rust/clap-compatibility)
 - [crate on crates.io](https://crates.io/crates/clap_usage)
 - [source code](https://github.com/jdx/usage/tree/main/clap_usage)


### PR DESCRIPTION
## Summary

- add a clap compatibility matrix pinned to clap 4.6.6 and clap_derive 4.6.4
- distinguish direct usage support from clap-to-spec bridge fidelity
- record partial support, intentional differences, unsupported features, and architectural non-goals
- link the matrix from the Rust and clap integration documentation

## Why

A clap user needs to know whether behavior survives before changing parsers. The existing plan audits gaps, but it is not presented as a migration-facing, versioned reference and does not clearly separate usage-native support from bridge loss.

This establishes the first public baseline. It intentionally does not close the plan item yet: an exhaustive inventory of every forwarded builder method still remains.

## Validation

- `git diff --check`
- `prettier --check docs/rust/clap-compatibility.md docs/rust/index.md docs/spec/integrations/clap.md`

This PR is stacked on #1027.

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, parser, or bridge code changes.
> 
> **Overview**
> Adds a **versioned clap compatibility matrix** (`clap` 4.6.6 / `clap_derive` 4.6.4) at `/rust/clap-compatibility`, aimed at migration and `clap_usage` bridge expectations.
> 
> The page defines status labels (Supported, Usage only, Partial, Different, Unsupported, Non-goal) and tables for derives/types, arguments, relationships/routing, and help/generated artifacts. It separates **native `usage` declarations** from **`clap::Command` → spec** fidelity and calls out bridge losses (e.g. setter-only clap APIs) and usage-only extensions.
> 
> **Rust docs** and **clap integration** pages now link to the matrix from “Where to go next” and “Links”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6296f8819c54cd04ff9f01f5bd287839b47c3fc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->