### PR TITLE
fix(spec): preserve clap value count bounds

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -409,8 +409,11 @@ Groups are the opposite case: `Command::get_groups`, `ArgGroup::get_args` and
       accepting only a negative number; the other two have no spelling at all.
 - [ ] **Fixed arity and distinct value names** — clap can say
       `num_args(2)` with `<START> <END>`. `var_min` / `var_max` express the bound,
-      but the derive has one display name for the collection and the clap bridge
-      does not preserve the bound.
+      and the clap bridge now preserves it for positionals and non-repeatable value
+      flags. Optional-value ranges beginning at zero and repeatable `Append` ranges
+      remain bridge-lossy because their per-occurrence semantics cannot be represented
+      as one accumulated bound. The derive also has one display name for the collection,
+      so distinct `<START> <END>` labels are still absent.
 - [x] **`allow_hyphen_values` on the derive path** — the spec said it and
       usage-lib honoured it (`lib/src/parse.rs`); usage-argv now has the same
       bit on `Flag`, so a detached value that looks like a flag binds when

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -1616,15 +1616,26 @@ fn parse_partial_with_env(
         }
     }
 
-    // Validate var_min/var_max constraints for variadic flags
+    // Validate var_min/var_max constraints for variadic flags. A flag's own bounds
+    // count repeated occurrences; the nested argument's bounds count the values one
+    // non-repeatable occurrence takes. The latter is clap's `num_args` shape and must
+    // not make the flag itself repeatable merely to reach this check.
     for (flag, value) in &out.flags {
-        if flag.var {
+        let bounds = if flag.var {
+            Some((flag.var_min, flag.var_max))
+        } else {
+            flag.arg
+                .as_ref()
+                .filter(|arg| arg.var)
+                .map(|arg| (arg.var_min, arg.var_max))
+        };
+        if let Some((var_min, var_max)) = bounds {
             let count = match value {
                 ParseValue::MultiString(values) => values.len(),
                 ParseValue::MultiBool(values) => values.len(),
                 _ => continue,
             };
-            if let Some(min) = flag.var_min {
+            if let Some(min) = var_min {
                 if count < min {
                     out.errors.push(UsageErr::VarFlagTooFew {
                         name: flag.name.clone(),
@@ -1633,7 +1644,7 @@ fn parse_partial_with_env(
                     });
                 }
             }
-            if let Some(max) = flag.var_max {
+            if let Some(max) = var_max {
                 if count > max {
                     out.errors.push(UsageErr::VarFlagTooMany {
                         name: flag.name.clone(),

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -1616,26 +1616,17 @@ fn parse_partial_with_env(
         }
     }
 
-    // Validate var_min/var_max constraints for variadic flags. A flag's own bounds
-    // count repeated occurrences; the nested argument's bounds count the values one
-    // non-repeatable occurrence takes. The latter is clap's `num_args` shape and must
-    // not make the flag itself repeatable merely to reach this check.
+    // Validate var_min/var_max constraints for variadic flags. These are bounds on
+    // repeated occurrences of the flag itself. Bounds on its nested argument are enforced
+    // by binding once per occurrence, where the per-occurrence count is still available.
     for (flag, value) in &out.flags {
-        let bounds = if flag.var {
-            Some((flag.var_min, flag.var_max))
-        } else {
-            flag.arg
-                .as_ref()
-                .filter(|arg| arg.var)
-                .map(|arg| (arg.var_min, arg.var_max))
-        };
-        if let Some((var_min, var_max)) = bounds {
+        if flag.var {
             let count = match value {
                 ParseValue::MultiString(values) => values.len(),
                 ParseValue::MultiBool(values) => values.len(),
                 _ => continue,
             };
-            if let Some(min) = var_min {
+            if let Some(min) = flag.var_min {
                 if count < min {
                     out.errors.push(UsageErr::VarFlagTooFew {
                         name: flag.name.clone(),
@@ -1644,7 +1635,7 @@ fn parse_partial_with_env(
                     });
                 }
             }
-            if let Some(max) = var_max {
+            if let Some(max) = flag.var_max {
                 if count > max {
                     out.errors.push(UsageErr::VarFlagTooMany {
                         name: flag.name.clone(),
@@ -2172,6 +2163,15 @@ fn collect_variadic_flag_values(
         .map(value_count)
         .unwrap_or(0)
         .saturating_sub(carried);
+    if let Some(min) = flag.arg.as_ref().and_then(|arg| arg.var_min) {
+        if taken < min {
+            errors.push(UsageErr::VarFlagTooFew {
+                name: flag.name.clone(),
+                min,
+                got: taken,
+            });
+        }
+    }
     if taken > max {
         errors.push(UsageErr::VarFlagTooMany {
             name: flag.name.clone(),
@@ -3459,6 +3459,27 @@ flag "--file <file>" required_unless="--stdin"
             &input(&["ex", "--include", "a,b", "--include", "c,d"]),
         )
         .expect("two per occurrence, twice, is within the bound");
+    }
+
+    #[test]
+    fn a_nested_minimum_is_checked_once_per_flag_occurrence() {
+        let spec: Spec = "name \"ex\"\nbin \"ex\"\nflag \"--pair <value>...\" {\n  arg \"<value>...\" var=#true var_min=2 var_max=2\n}\n"
+            .parse()
+            .unwrap();
+
+        parse(
+            &spec,
+            &input(&["ex", "--pair", "a", "b", "--pair", "c", "d"]),
+        )
+        .expect("each occurrence satisfies the bound independently");
+
+        let error = parse(&spec, &input(&["ex", "--pair", "a", "--pair", "b", "c"])).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("requires at least 2 value(s), got 1"),
+            "{error:?}"
+        );
     }
 
     #[test]

--- a/lib/src/spec/arg.rs
+++ b/lib/src/spec/arg.rs
@@ -393,6 +393,37 @@ pub(crate) fn default_values(arg: &clap::Arg) -> Vec<String> {
     }
 }
 
+/// Carry clap's value-count range into the spec where the two parsers mean the same thing.
+///
+/// A positional may accept zero values: its ordinary optionality already gives the binder a
+/// path that consumes nothing. A flag with `num_args(0..)` is different — a bare occurrence is
+/// itself valid — and needs optional-value binding, which the clap bridge cannot recover
+/// losslessly without `default_missing_value` (a setter with no getter). Leave that range absent
+/// rather than writing a bound that claims the bare flag is supported.
+#[cfg(feature = "clap")]
+pub(crate) fn value_bounds(source: &clap::Arg, target: &mut SpecArg, zero_values_supported: bool) {
+    // clap verifies num_args against raw command-line tokens and only splits each token on the
+    // delimiter afterward. Usage splits first and its bounds count the resulting values. Carrying
+    // the range would therefore change the contract (for example, two comma-separated tokens can
+    // become four Usage values), so leave it unmapped until the spec can distinguish both counts.
+    if source.get_value_delimiter().is_some() {
+        return;
+    }
+
+    let Some(range) = source.get_num_args() else {
+        return;
+    };
+    let min = range.min_values();
+    let max = range.max_values();
+    if max <= 1 || min == 0 && !zero_values_supported {
+        return;
+    }
+
+    target.var = true;
+    target.var_min = Some(min);
+    target.var_max = (max != usize::MAX).then_some(max);
+}
+
 #[cfg(feature = "clap")]
 pub(crate) fn choices_from_clap(arg: &clap::Arg) -> Option<SpecChoices> {
     let possible = arg.get_possible_values();
@@ -435,6 +466,7 @@ pub(crate) fn choices_from_clap(arg: &clap::Arg) -> Option<SpecChoices> {
 #[cfg(feature = "clap")]
 impl From<&clap::Arg> for SpecArg {
     fn from(arg: &clap::Arg) -> Self {
+        let source = arg;
         let required = arg.is_required_set();
         let help = arg.get_help().map(|s| s.to_string());
         let help_long = arg.get_long_help().map(|s| s.to_string());
@@ -485,6 +517,8 @@ impl From<&clap::Arg> for SpecArg {
             help_heading: arg.get_help_heading().map(|s| s.to_string()),
         };
         arg.choices = choices;
+
+        value_bounds(source, &mut arg, true);
 
         arg
     }

--- a/lib/src/spec/flag.rs
+++ b/lib/src/spec/flag.rs
@@ -820,6 +820,15 @@ impl From<&clap::Arg> for SpecFlag {
                 arg.var = true;
             }
 
+            // clap's range is per occurrence. A non-repeatable `Set` flag has one
+            // occurrence, so the spec's collecting bound says exactly the same thing.
+            // `Append` can occur several times; carrying its minimum as a total would let
+            // one long occurrence hide another short one, so leave that for an explicit
+            // per-occurrence model rather than weakening the rule silently.
+            if matches!(c.get_action(), clap::ArgAction::Set) {
+                crate::spec::arg::value_bounds(c, &mut arg, false);
+            }
+
             Some(arg)
         } else {
             None
@@ -1169,6 +1178,97 @@ mod tests {
             "clap exposes no getter for `default_missing_value`; if this now fails, \
              the bridge can carry it and `SpecFlag::default_missing` should say so"
         );
+    }
+
+    #[test]
+    fn value_count_bounds_survive_the_clap_bridge() {
+        let cmd = clap::Command::new("ex")
+            .arg(
+                clap::Arg::new("pair")
+                    .long("pair")
+                    .action(clap::ArgAction::Set)
+                    .num_args(2),
+            )
+            .arg(
+                clap::Arg::new("files")
+                    .value_name("FILES")
+                    .required(true)
+                    .num_args(2..=4),
+            );
+        let spec = Spec::from(&cmd);
+
+        let pair_flag = spec.cmd.flags.iter().find(|f| f.name == "pair").unwrap();
+        assert!(!pair_flag.var, "the flag itself is not repeatable");
+        assert_eq!(pair_flag.var_min, None);
+        assert_eq!(pair_flag.var_max, None);
+        let pair = pair_flag.arg.as_ref().unwrap();
+        assert!(pair.var);
+        assert_eq!(pair.var_min, Some(2));
+        assert_eq!(pair.var_max, Some(2));
+
+        let files = spec.cmd.args.iter().find(|a| a.name == "FILES").unwrap();
+        assert!(files.var);
+        assert_eq!(files.var_min, Some(2));
+        assert_eq!(files.var_max, Some(4));
+
+        let words = ["ex", "--pair", "a", "b", "one", "two"].map(str::to_string);
+        crate::parse(&spec, &words).expect("both clap value-count ranges are satisfied");
+
+        let words = ["ex", "--pair", "a", "--", "one", "two"].map(str::to_string);
+        let err = crate::parse(&spec, &words).unwrap_err();
+        assert!(
+            format!("{err:?}").contains("requires at least 2 value(s), got 1"),
+            "{err:?}"
+        );
+
+        let reparsed: Spec = spec.to_string().parse().unwrap();
+        let pair = reparsed.cmd.flags[0].arg.as_ref().unwrap();
+        assert_eq!((pair.var_min, pair.var_max), (Some(2), Some(2)));
+        assert_eq!(
+            (reparsed.cmd.args[0].var_min, reparsed.cmd.args[0].var_max),
+            (Some(2), Some(4))
+        );
+    }
+
+    #[test]
+    fn delimiter_value_count_bounds_are_not_mapped() {
+        let cmd = clap::Command::new("ex")
+            .arg(
+                clap::Arg::new("pairs")
+                    .long("pairs")
+                    .action(clap::ArgAction::Set)
+                    .value_delimiter(',')
+                    .num_args(2),
+            )
+            .arg(clap::Arg::new("items").value_delimiter(',').num_args(2..=3));
+        let spec = Spec::from(&cmd);
+
+        let pairs = spec.cmd.flags[0].arg.as_ref().unwrap();
+        assert!(pairs.var);
+        assert_eq!(pairs.delimiter, Some(','));
+        assert_eq!((pairs.var_min, pairs.var_max), (None, None));
+
+        let items = &spec.cmd.args[0];
+        assert!(items.var);
+        assert_eq!(items.delimiter, Some(','));
+        assert_eq!((items.var_min, items.var_max), (None, None));
+    }
+
+    #[test]
+    fn an_optional_flag_value_is_not_misreported_as_a_supported_bound() {
+        let cmd = clap::Command::new("ex").arg(
+            clap::Arg::new("values")
+                .long("values")
+                .action(clap::ArgAction::Set)
+                .num_args(0..=3),
+        );
+        let spec = Spec::from(&cmd);
+        let values = spec.cmd.flags[0].arg.as_ref().unwrap();
+
+        assert_eq!(values.var_min, None);
+        assert_eq!(values.var_max, None);
+        assert_eq!(spec.cmd.flags[0].var_min, None);
+        assert_eq!(spec.cmd.flags[0].var_max, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- carry clap `num_args` minimum and maximum into positional specs
- carry fixed and ranged counts for non-repeatable value flags
- preserve the bounds through emitted KDL
- explicitly leave optional zero-value flags and repeatable `Append` ranges unmapped where the semantics are not lossless

## Why

The clap bridge noticed that an argument was multi-valued but silently dropped its bounds. That made generated specs accept too few values and could let a variadic value consume following arguments.

clap defines `num_args` per occurrence. usage repeatable flags accumulate values, so mapping an `Append` minimum as one total could let one long occurrence hide another short one. This PR maps only the cases with equivalent semantics and records the remaining limitation in `PLAN.md`.

## Validation

- targeted `usage-lib` tests for fixed/ranged bounds and the excluded optional-value case
- `cargo clippy -p usage-lib --all-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

This PR is stacked on #1027.

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes clap-to-spec generation and argv validation for multi-value flags/positionals; incorrect mapping could reject valid CLI input or accept too many values, but scope is limited to mapped cases with targeted tests.
> 
> **Overview**
> Maps clap **`num_args`** into **`var_min` / `var_max`** on the spec when usage and clap mean the same thing: **positionals** and **non-repeatable `Set` flags** (fixed or ranged counts). Bounds survive **KDL round-trip** and are enforced at parse time.
> 
> **Intentionally unmapped:** arguments with a **value delimiter** (token vs split-value counting differs), **`num_args` starting at 0** on flags without lossless optional-value semantics, and **`Append`** flags (per-occurrence minima must not collapse into one total).
> 
> **Parser:** nested value **`var_min`** is checked **once per flag occurrence**, matching existing **`var_max`** behavior for multi-value flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ef91a53f77070d739bdc07c0968a833e575393c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->