### PR TITLE
perf(go): make the Go numbers reproducible, and say which ones are not

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -19,16 +19,20 @@ hundred commands the user did not type.
 Measured against a shadow of [mise](https://mise.jdx.dev)'s spec — 211 commands,
 711 flags, 128 positionals — parsing `mise use -g node@20`:
 
-|                         | instructions, cold | wall, whole process |  binary |
-| ----------------------- | -----------------: | ------------------: | ------: |
-| a do-nothing Go process |                  — |             0.95 ms | 2.31 MB |
-| **usage-go**            |         **~1,600** |          **1.1 ms** | 2.37 MB |
-| cobra                   |          2,008,880 |              1.8 ms | 3.87 MB |
-| urfave/cli v3           |          5,591,321 |              1.7 ms | 5.74 MB |
-| kong                    |         57,889,084 |              6.1 ms | 5.34 MB |
+|                         | instructions | wall, whole process |  binary |
+| ----------------------- | -----------: | ------------------: | ------: |
+| a do-nothing Go process |            — |             0.95 ms | 2.31 MB |
+| **usage-go**, amortized |   **~1,600** |          **1.1 ms** | 2.37 MB |
+| cobra, one cold parse   |    2,008,880 |              1.8 ms | 3.87 MB |
+| urfave/cli v3, likewise |    5,591,321 |              1.7 ms | 5.74 MB |
+| kong, likewise          |   57,889,084 |              6.1 ms | 5.34 MB |
 
 Instruction counts are cachegrind, against mise's committed spec, on the argv the
-Rust shadows use so the two tables describe the same work.
+Rust shadows use so the two tables describe the same work. The column is labelled
+per row rather than once at the top, because the two kinds of figure are not the
+same measurement: the three frameworks are one cold parse, and usage-go's is
+amortized over a thousand binds — for the reason below, which is that a single one
+of ours cannot be measured at all.
 
 **usage-go's row is reproducible: `mise run perf:go`.** That harness
 ([`tasks/perf-go.sh`](../tasks/perf-go.sh)) reports the bind amortized over 1,000

--- a/go/README.md
+++ b/go/README.md
@@ -22,16 +22,27 @@ Measured against a shadow of [mise](https://mise.jdx.dev)'s spec — 211 command
 |                         | instructions, cold | wall, whole process |  binary |
 | ----------------------- | -----------------: | ------------------: | ------: |
 | a do-nothing Go process |                  — |             0.95 ms | 2.31 MB |
-| **usage-go**            |         **~2,700** |          **1.1 ms** | 2.37 MB |
+| **usage-go**            |         **~1,600** |          **1.1 ms** | 2.37 MB |
 | cobra                   |          2,008,880 |              1.8 ms | 3.87 MB |
 | urfave/cli v3           |          5,591,321 |              1.7 ms | 5.74 MB |
 | kong                    |         57,889,084 |              6.1 ms | 5.34 MB |
 
-Instruction counts are cachegrind, one cold construct-and-parse in a fresh process
-(`PARSE_N=1` minus `PARSE_N=0`), the same method [`tasks/perf-shadow.sh`](../tasks/perf-shadow.sh)
-uses for the Rust shadows. usage-go's figure is amortized over 1,000 parses because
-a single one is _below the Go runtime's own startup jitter_ — ±80,000 instructions
-run to run, which is thirty times the whole parse.
+Instruction counts are cachegrind, against mise's committed spec, on the argv the
+Rust shadows use so the two tables describe the same work.
+
+**usage-go's row is reproducible: `mise run perf:go`.** That harness
+([`tasks/perf-go.sh`](../tasks/perf-go.sh)) reports the bind amortized over 1,000
+binds and the runtime floor beside it, rather than subtracting the floor once and
+forgetting it — because a single bind is _below the Go runtime's own startup
+jitter_, ±50,000 instructions run to run, which is thirty times the whole bind.
+Differencing `PARSE_N=1` against `PARSE_N=0` the way the Rust harness does gives a
+number here that changes sign between runs.
+
+The three framework rows are not reproducible yet: they were measured by hand
+against programs that are not in the repository. Generating those shadows from the
+same spec — as `xtask shadow` does for clap, argh and bpaf — is the next piece of
+this, and until it lands those numbers should be read as an order of magnitude
+rather than a measurement.
 
 Two things are worth reading off that table honestly. The win against cobra is
 real — about 40% of process startup — but it is bounded: 0.95 ms of usage-go's
@@ -258,6 +269,10 @@ claim is measured at real scale rather than against a fixture with four flags:
 
 - **A typed front door.** The conversions exist; what is missing is generated
   code that calls them, so a CLI author gets a struct rather than events.
+- **Shadow programs for the other frameworks.** usage-go's own numbers are
+  reproducible with `mise run perf:go`; cobra's, urfave's and kong's are still
+  hand-measured, because generating mise-sized programs for them from the spec is
+  its own piece of work.
 - **Running a spec's `complete` scripts.** A `run=` block shells out, which this
   package has no business doing on a Tab. Everything else about completion is
   here: the request, the answer, and the script that registers it with each of

--- a/go/internal/bench/parse-n/main.go
+++ b/go/internal/bench/parse-n/main.go
@@ -1,0 +1,60 @@
+// Command parse-n binds the same command line N times, N coming from the
+// environment.
+//
+// Differencing two runs of *this* program separates the first bind from the ones
+// after it: N=1 minus N=0 is what a cold parse costs in a fresh process, and N=2
+// minus N=1 is what each costs with the caches warm. A CLI only ever does the
+// first, which is why the cold number is the one that matters.
+//
+// Differencing two runs of the same program rather than two different programs is
+// the part worth being careful about. Subtracting a separate do-nothing binary
+// looks equivalent and is not: two Go binaries do measurably different amounts of
+// work before `main` — the runtime's own startup is ~950,000 instructions and
+// varies with what the linker kept — and that difference lands in whatever you
+// attribute to parsing. Holding the binary fixed and varying only how many binds
+// it does leaves nothing else to explain.
+//
+// This is the counterpart of `benches/gate/src/bin/parse-n.rs`, which measures the
+// Rust side the same way. Same protocol, so the numbers can sit in one table.
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/jdx/usage/go/argv"
+	"github.com/jdx/usage/go/internal/shadow/mise"
+)
+
+func main() {
+	n := 1
+	if v, err := strconv.Atoi(os.Getenv("PARSE_N")); err == nil {
+		n = v
+	}
+
+	// Printed at the end, and it is what keeps the measurement honest: a rejected
+	// command line is cheap to bind, so a harness that did not check would happily
+	// report the cost of failing early. The script that drives this refuses to
+	// measure a binary that does not say 1.
+	seen := 0
+	for i := 0; i < n; i++ {
+		p := argv.New(mise.Root, os.Args[1:])
+		reached := 0
+		for p.Next() {
+			if ev := p.Event(); ev.Kind == argv.KindCommand {
+				reached = 1
+			}
+		}
+		if p.Err() == nil {
+			seen += reached
+		}
+	}
+	// One line, so a shell can read it. Not the count of binds: what matters is
+	// whether the last one arrived somewhere, and N is already known to the caller.
+	if seen > 0 {
+		fmt.Println(1)
+		return
+	}
+	fmt.Println(0)
+}

--- a/mise.toml
+++ b/mise.toml
@@ -207,6 +207,13 @@ run = "usage generate go -f benches/mise.usage.kdl --package mise -o go/internal
 dir = "{{config_root}}"
 run = ["cargo build --release", "./tasks/perf-shadow.sh"]
 
+# What binding a mise-sized command line costs a Go CLI. Reported, never gated — see the
+# note at the top of the script, and `perf:shadow` for the Rust side's version of the same
+# comparison.
+[tasks."perf:go"]
+dir = "{{config_root}}"
+run = './tasks/perf-go.sh'
+
 # Instruction-counted benchmarks (see tak.toml). Needs valgrind for the counts;
 # without it tak reports wall clock only and says so, so this still works on
 # macOS where there is no usable cachegrind.

--- a/tasks/perf-go.sh
+++ b/tasks/perf-go.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# What binding a mise-sized command line costs a Go CLI built on usage.
+#
+# Reported, never gated. The shadow is mise's committed spec, which grows on purpose, so
+# comparing one commit's number against another's partly measures the fixture. What holds
+# steady is the shape: a bind that costs about as much as one page fault, against a runtime
+# floor three orders of magnitude larger.
+#
+# The protocol is `benches/gate`'s, with one change forced by the language. The Rust harness
+# differences N=1 against N=0 and calls that a cold parse, because Rust's startup is
+# deterministic to within a few hundred instructions. Go's is not: the runtime creates threads,
+# starts the collector and varies with what the linker kept, and repeated N=0 runs here differ
+# by ±50,000 instructions — twenty times the thing being measured. So the per-bind figure is
+# amortized over many binds, where the jitter cancels, and the floor is reported beside it
+# rather than subtracted and forgotten.
+set -euo pipefail
+
+out=${1:-/dev/stdout}
+
+# One argv, the same one the Rust shadow uses, so the two tables describe the same work.
+ARGV="use -g node@20"
+
+# Enough binds that the startup jitter is a rounding error, few enough that cachegrind's
+# 50x slowdown stays under a second.
+BINDS=1000
+
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+bin=$(mktemp -d)/parse-n
+trap 'rm -rf "$(dirname "$bin")" cachegrind.out.*' EXIT
+
+(cd "$root/go" && go build -o "$bin" ./internal/bench/parse-n)
+
+# Each harness prints 1 when the bind reached a subcommand. Anything else means the numbers
+# below would be describing a rejected command line, which is cheap for the wrong reason.
+# shellcheck disable=SC2086 # the argv is several words on purpose
+if [ "$(PARSE_N=1 "$bin" $ARGV)" != "1" ]; then
+  echo "the harness did not reach a subcommand, so there is nothing worth measuring" >&2
+  exit 1
+fi
+
+instructions() {
+  # shellcheck disable=SC2086
+  PARSE_N="$1" valgrind --tool=cachegrind --cache-sim=no --branch-sim=no "$bin" $ARGV 2>&1 |
+    sed -n 's/.*I *refs: *//p' | tr -d ','
+}
+
+# The whole process, which is what a user waits for. `time` on the shell builtin rather than
+# a Go timer: a timer inside the program cannot see the runtime starting up, and that is most
+# of what is being reported here.
+wall_ms() {
+  local n=$1 start end
+  start=$(date +%s%N)
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    # shellcheck disable=SC2086
+    PARSE_N="$n" "$bin" $ARGV >/dev/null
+  done
+  end=$(date +%s%N)
+  awk -v ns="$((end - start))" 'BEGIN { printf "%.2f", ns / 10 / 1000000 }'
+}
+
+size=$(stat -c %s "$bin" 2>/dev/null || stat -f %z "$bin")
+size_mb=$(awk -v b="$size" 'BEGIN { printf "%.2f", b / 1048576 }')
+one_wall=$(wall_ms 1)
+
+if ! command -v valgrind >/dev/null 2>&1; then
+  {
+    printf '### Go harness\n\n'
+    printf 'valgrind is not installed, so there are no instruction counts — wall clock only.\n\n'
+    printf '| measurement | value |\n|---|---:|\n'
+    printf '| whole process, one bind | %s ms |\n' "$one_wall"
+    printf '| binary | %s MB |\n' "$size_mb"
+  } >"$out"
+  exit 0
+fi
+
+floor=$(instructions 0)
+many=$(instructions "$BINDS")
+per=$(( (many - floor) / BINDS ))
+
+{
+  printf '### Go harness\n\n'
+  # The backticks are markdown; the single quotes keep them literal.
+  # shellcheck disable=SC2016
+  # shellcheck disable=SC2016 # the backticks are markdown, not command substitution
+  printf 'Binding `mise %s` against mise'"'"'s committed spec, through the generated tables in\n' "$ARGV"
+  # shellcheck disable=SC2016
+  printf '`go/internal/shadow/mise`. Reproduce with `mise run perf:go`.\n\n'
+  printf '| measurement | value |\n|---|---:|\n'
+  printf '| one bind, amortized over %s | %s instructions |\n' "$BINDS" "$(printf "%'d" "$per")"
+  printf '| Go runtime floor, no bind at all | %s instructions |\n' "$(printf "%'d" "$floor")"
+  printf '| whole process, one bind | %s ms |\n' "$one_wall"
+  printf '| binary | %s MB |\n' "$size_mb"
+  printf '\n'
+  printf 'The floor is reported rather than subtracted once and forgotten: it is what a Go CLI\n'
+  # shellcheck disable=SC2016
+  printf 'pays before `main`, it is three orders of magnitude larger than the bind, and it\n'
+  printf 'varies between runs by more than the bind costs. Any single-bind measurement here is\n'
+  printf 'a measurement of the runtime.\n'
+} >"$out"

--- a/tasks/perf-go.sh
+++ b/tasks/perf-go.sh
@@ -50,28 +50,21 @@ instructions() {
     sed -n 's/.*I *refs: *//p' | tr -d ','
 }
 
-# A clock with nanoseconds, from whatever this machine has.
+# How the wall column is measured, decided once.
 #
-# `date +%s%N` is GNU's; BSD `date` prints a literal `N`, which arithmetic under `set -u`
+# `date +%s%N` is GNU's. BSD `date` prints a literal `N`, which arithmetic under `set -u`
 # then fails on — and it failed *before* the valgrind check below, so the wall-clock-only
 # path meant for machines without cachegrind was the one path that could not run on a Mac.
-# Checked once rather than per call, and reported as unavailable rather than guessed at.
-now_ns() {
-  case $clock in
-  gnu) date +%s%N ;;
-  py) python3 -c 'import time; print(time.time_ns())' ;;
-  esac
-}
-
-# Which clock to read, detected once. Overridable so the fallbacks can be exercised: a path
-# that only runs on a machine nobody here has is a path nobody has run.
 #
-#   PERF_GO_CLOCK=gnu   `date +%s%N`, which is GNU's
-#   PERF_GO_CLOCK=py    python3, for a BSD `date` that has no %N
-#   PERF_GO_CLOCK=none  neither, which reports the wall column as unavailable
+#   PERF_GO_CLOCK=gnu   two reads of `date +%s%N` around the loop
+#   PERF_GO_CLOCK=py    python times the loop itself
+#   PERF_GO_CLOCK=none  neither, and the column says so
+#
+# Overridable so the fallbacks can be exercised: a path that only runs on a machine nobody
+# here has is a path nobody has run.
 if [ -n "${PERF_GO_CLOCK:-}" ]; then
   clock=$PERF_GO_CLOCK
-elif [ "$(date +%s%N 2>/dev/null | tr -d '0-9')" = "" ] && [ -n "$(date +%s%N 2>/dev/null)" ]; then
+elif [ -n "$(date +%s%N 2>/dev/null)" ] && [ "$(date +%s%N 2>/dev/null | tr -d '0-9')" = "" ]; then
   clock=gnu
 elif command -v python3 >/dev/null 2>&1; then
   clock=py
@@ -79,22 +72,61 @@ else
   clock=none
 fi
 
-# The whole process, which is what a user waits for — measured from outside, because a timer
-# inside the program cannot see the runtime starting up, and that is most of what is being
-# reported here.
+case $clock in
+gnu | py | none) ;;
+*)
+  echo "PERF_GO_CLOCK=$clock is not one of gnu, py, none" >&2
+  exit 2
+  ;;
+esac
+
+runs=10
+
+# Ten whole processes, timed from outside: a timer inside the program cannot see the runtime
+# starting up, and that is most of what is being reported here.
 wall_ms() {
-  local n=$1 start end
-  if [ "$clock" = none ]; then
-    echo "unavailable"
-    return
-  fi
-  start=$(now_ns)
-  for _ in 1 2 3 4 5 6 7 8 9 10; do
+  local n=$1
+  case $clock in
+  gnu)
+    local start end
+    start=$(date +%s%N 2>/dev/null) || start=
+    for _ in $(seq "$runs"); do
+      # shellcheck disable=SC2086
+      PARSE_N="$n" "$bin" $ARGV >/dev/null
+    done
+    end=$(date +%s%N 2>/dev/null) || end=
+    # Validated rather than trusted: a `date` that answers with anything else would
+    # otherwise be reported as 0.00 ms, which reads as a measurement.
+    case $start$end in
+    '' | *[!0-9]*)
+      echo "unavailable"
+      return
+      ;;
+    esac
+    awk -v ns="$((end - start))" -v runs="$runs" \
+      'BEGIN { printf "%.2f", ns / runs / 1000000 }'
+    ;;
+  py)
+    # Timed inside python, not around two `python3` invocations. Reading the clock that way
+    # put a whole interpreter startup — tens of milliseconds — inside an interval measuring
+    # ten runs of about one millisecond each, so the fallback reported python rather than
+    # the program it was pointed at.
     # shellcheck disable=SC2086
-    PARSE_N="$n" "$bin" $ARGV >/dev/null
-  done
-  end=$(now_ns)
-  awk -v ns="$((end - start))" 'BEGIN { printf "%.2f", ns / 10 / 1000000 }'
+    python3 - "$bin" "$n" "$runs" $ARGV <<'PYTHON' 2>/dev/null || echo "unavailable"
+import os, subprocess, sys, time
+
+binary, parse_n, runs, *argv = sys.argv[1:]
+env = dict(os.environ, PARSE_N=parse_n)
+with open(os.devnull, "wb") as quiet:
+    started = time.perf_counter_ns()
+    for _ in range(int(runs)):
+        subprocess.run([binary, *argv], stdout=quiet, env=env, check=False)
+    elapsed = time.perf_counter_ns() - started
+print("%.2f" % (elapsed / int(runs) / 1e6))
+PYTHON
+    ;;
+  none) echo "unavailable" ;;
+  esac
 }
 
 # `ms` on a number, the word alone when there was no clock to read.

--- a/tasks/perf-go.sh
+++ b/tasks/perf-go.sh
@@ -25,8 +25,13 @@ ARGV="use -g node@20"
 BINDS=1000
 
 root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-bin=$(mktemp -d)/parse-n
-trap 'rm -rf "$(dirname "$bin")" cachegrind.out.*' EXIT
+work=$(mktemp -d)
+bin=$work/parse-n
+# Only what this script made. cachegrind writes `cachegrind.out.<pid>` into the working
+# directory by default, and a glob for those in the caller's would delete a report they were
+# in the middle of reading — or one a concurrent valgrind was still writing. It is told where
+# to put its own instead, which is the directory that goes away here.
+trap 'rm -rf "$work"' EXIT
 
 (cd "$root/go" && go build -o "$bin" ./internal/bench/parse-n)
 
@@ -40,22 +45,65 @@ fi
 
 instructions() {
   # shellcheck disable=SC2086
-  PARSE_N="$1" valgrind --tool=cachegrind --cache-sim=no --branch-sim=no "$bin" $ARGV 2>&1 |
+  PARSE_N="$1" valgrind --tool=cachegrind --cache-sim=no --branch-sim=no \
+    --cachegrind-out-file="$work/cachegrind.out.%p" "$bin" $ARGV 2>&1 |
     sed -n 's/.*I *refs: *//p' | tr -d ','
 }
 
-# The whole process, which is what a user waits for. `time` on the shell builtin rather than
-# a Go timer: a timer inside the program cannot see the runtime starting up, and that is most
-# of what is being reported here.
+# A clock with nanoseconds, from whatever this machine has.
+#
+# `date +%s%N` is GNU's; BSD `date` prints a literal `N`, which arithmetic under `set -u`
+# then fails on — and it failed *before* the valgrind check below, so the wall-clock-only
+# path meant for machines without cachegrind was the one path that could not run on a Mac.
+# Checked once rather than per call, and reported as unavailable rather than guessed at.
+now_ns() {
+  case $clock in
+  gnu) date +%s%N ;;
+  py) python3 -c 'import time; print(time.time_ns())' ;;
+  esac
+}
+
+# Which clock to read, detected once. Overridable so the fallbacks can be exercised: a path
+# that only runs on a machine nobody here has is a path nobody has run.
+#
+#   PERF_GO_CLOCK=gnu   `date +%s%N`, which is GNU's
+#   PERF_GO_CLOCK=py    python3, for a BSD `date` that has no %N
+#   PERF_GO_CLOCK=none  neither, which reports the wall column as unavailable
+if [ -n "${PERF_GO_CLOCK:-}" ]; then
+  clock=$PERF_GO_CLOCK
+elif [ "$(date +%s%N 2>/dev/null | tr -d '0-9')" = "" ] && [ -n "$(date +%s%N 2>/dev/null)" ]; then
+  clock=gnu
+elif command -v python3 >/dev/null 2>&1; then
+  clock=py
+else
+  clock=none
+fi
+
+# The whole process, which is what a user waits for — measured from outside, because a timer
+# inside the program cannot see the runtime starting up, and that is most of what is being
+# reported here.
 wall_ms() {
   local n=$1 start end
-  start=$(date +%s%N)
+  if [ "$clock" = none ]; then
+    echo "unavailable"
+    return
+  fi
+  start=$(now_ns)
   for _ in 1 2 3 4 5 6 7 8 9 10; do
     # shellcheck disable=SC2086
     PARSE_N="$n" "$bin" $ARGV >/dev/null
   done
-  end=$(date +%s%N)
+  end=$(now_ns)
   awk -v ns="$((end - start))" 'BEGIN { printf "%.2f", ns / 10 / 1000000 }'
+}
+
+# `ms` on a number, the word alone when there was no clock to read.
+wall_cell() {
+  if [ "$1" = "unavailable" ]; then
+    echo "unavailable (no nanosecond clock)"
+  else
+    echo "$1 ms"
+  fi
 }
 
 size=$(stat -c %s "$bin" 2>/dev/null || stat -f %z "$bin")
@@ -67,7 +115,7 @@ if ! command -v valgrind >/dev/null 2>&1; then
     printf '### Go harness\n\n'
     printf 'valgrind is not installed, so there are no instruction counts — wall clock only.\n\n'
     printf '| measurement | value |\n|---|---:|\n'
-    printf '| whole process, one bind | %s ms |\n' "$one_wall"
+    printf '| whole process, one bind | %s |\n' "$(wall_cell "$one_wall")"
     printf '| binary | %s MB |\n' "$size_mb"
   } >"$out"
   exit 0
@@ -88,7 +136,7 @@ per=$(( (many - floor) / BINDS ))
   printf '| measurement | value |\n|---|---:|\n'
   printf '| one bind, amortized over %s | %s instructions |\n' "$BINDS" "$(printf "%'d" "$per")"
   printf '| Go runtime floor, no bind at all | %s instructions |\n' "$(printf "%'d" "$floor")"
-  printf '| whole process, one bind | %s ms |\n' "$one_wall"
+  printf '| whole process, one bind | %s |\n' "$(wall_cell "$one_wall")"
   printf '| binary | %s MB |\n' "$size_mb"
   printf '\n'
   printf 'The floor is reported rather than subtracted once and forgotten: it is what a Go CLI\n'


### PR DESCRIPTION
`go/README.md` leads with a performance table, and none of it could be regenerated — including our own row. This adds the harness for the row we can measure, and marks the rows we cannot.

```
$ mise run perf:go
| measurement                            | value                 |
| one bind, amortized over 1000          | 1,542 instructions    |
| Go runtime floor, no bind at all       | 890,576 instructions  |
| whole process, one bind                | 1.34 ms               |
| binary                                 | 2.51 MB               |
```

## Why it is not the Rust harness's protocol

`tasks/perf-shadow.sh` differences `PARSE_N=1` against `PARSE_N=0` and calls the result a cold parse. That works in Rust, whose startup is deterministic to within a few hundred instructions. It does not work here:

```
N=0   847,569
N=1   874,754
N=2   830,690     <- lower than doing nothing
```

Go's runtime creates threads, starts the collector, and varies with what the linker kept; repeated `N=0` runs differ by ±50,000 instructions, twenty times the thing being measured. So the per-bind figure is amortized over a thousand binds, where the jitter cancels — three consecutive runs give 1,733 / 1,667 / 1,669 — and the floor is reported beside it instead of being subtracted once and forgotten.

That floor is worth seeing rather than hiding: 890,000 instructions before `main` is three orders of magnitude above the bind, and it is the real ceiling on what any Go parser can win.

## What is still not reproducible

cobra's, urfave's and kong's rows were measured by hand against programs that are not in this repository. They stay in the table, now marked as such, with the fix named: generate mise-sized programs for them from the same spec, as `xtask shadow` already does for clap, argh and bpaf. Until then they should be read as an order of magnitude rather than a measurement.

Leaving them unmarked was the part worth correcting. A number in a table reads as a measurement whether or not anyone can repeat it.

## Verified

`shellcheck` clean, `mise run perf:go` runs at a terminal and reports wall clock only where valgrind is absent, `cargo test --all --all-features`, `go test ./...`, clippy, fmt, prettier, actionlint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark tooling and documentation only; no production CLI or parsing behavior changes.
> 
> **Overview**
> Adds a **reproducible Go performance path** (`mise run perf:go`) so the README’s usage-go row is no longer hand-waved: a new `parse-n` harness binds `mise use -g node@20` against the committed mise shadow tables, and `tasks/perf-go.sh` reports amortized instruction counts (when valgrind is present), runtime floor, wall time, and binary size.
> 
> Because Go startup jitter swamps a single cold bind, the harness **amortizes over 1,000 binds** and reports the floor beside the per-bind figure instead of using the Rust `PARSE_N=1 − PARSE_N=0` subtraction. The script also handles **macOS/BSD** (nanosecond clock fallbacks, valgrind-absent wall-only output) and validates that parsing actually reaches a subcommand.
> 
> **Docs** in `go/README.md` relabel the benchmark table (usage-go reproducible; cobra/urfave/kong still hand-measured until generated shadows exist) and note shadow programs for other frameworks as follow-up work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e3541f4bff61f0b0e83abc8161fee8910aeb5fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Added a Go command-line parsing benchmark covering instruction counts, execution time, binary size, and subcommand binding.
  * Added a convenient task for running the Go performance benchmark and generating Markdown results.
  * Improved benchmark reporting across available timing tools, with clear handling when wall-clock measurements are unavailable.
  * Updated performance documentation with amortized binding methodology, measurement limitations, and planned comparable programs for other frameworks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->