### PR TITLE
chore: add repository-managed Cloud Agent development environment

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,68 @@
+# Cloud Agent base image for jdx/usage.
+#
+# Provides the stable system layer: OS packages, the Rust toolchain, mise, and
+# the shells the completion integration tests exercise. Repo-pinned tools
+# (declared in mise.toml) are installed after checkout by .cursor/install.sh,
+# because mise.toml is only available once the repository is cloned.
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# System packages:
+# - ca-certificates/curl/git/xz-utils/unzip: fetch + unpack toolchains and tools
+# - build-essential/pkg-config/libssl-dev: compile cargo-installed tools (cargo-edit)
+# - zsh/fish: shell-completion integration tests (they panic rather than skip under CI=1)
+# - libicu74: required by the PowerShell runtime
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        xz-utils \
+        unzip \
+        build-essential \
+        pkg-config \
+        libssl-dev \
+        zsh \
+        fish \
+        libicu74 \
+    && rm -rf /var/lib/apt/lists/*
+
+# PowerShell (pwsh) from the official tarball — the fourth shell the completion
+# integration tests drive. Not packaged for Ubuntu 24.04, so install from release.
+RUN PWSH_VERSION=7.6.5 \
+    && curl -fsSL -o /tmp/pwsh.tar.gz \
+        "https://github.com/PowerShell/PowerShell/releases/download/v${PWSH_VERSION}/powershell-${PWSH_VERSION}-linux-x64.tar.gz" \
+    && mkdir -p /opt/microsoft/powershell/7 \
+    && tar zxf /tmp/pwsh.tar.gz -C /opt/microsoft/powershell/7 \
+    && chmod +x /opt/microsoft/powershell/7/pwsh \
+    && ln -sf /opt/microsoft/powershell/7/pwsh /usr/local/bin/pwsh \
+    && rm -f /tmp/pwsh.tar.gz \
+    && pwsh --version
+
+# Run as the non-root `ubuntu` user (uid 1000) that ships with the base image.
+# The Rust toolchain and mise live under this user's home so the agent can write
+# to the cargo registry cache and install tools without permission workarounds.
+USER ubuntu
+ENV HOME=/home/ubuntu
+ENV RUSTUP_HOME=/home/ubuntu/.rustup \
+    CARGO_HOME=/home/ubuntu/.cargo \
+    PATH=/home/ubuntu/.local/bin:/home/ubuntu/.cargo/bin:$PATH
+
+# Rust toolchain via rustup. usage-lib declares MSRV 1.95; install current stable
+# (which satisfies it) with clippy + rustfmt for the lint tasks.
+RUN curl -fsSL https://sh.rustup.rs \
+        | sh -s -- -y --profile default --default-toolchain stable \
+    && rustc --version \
+    && cargo --version
+
+# mise — the repository's tool manager. The pinned tools themselves are installed
+# from mise.toml at bootstrap time by .cursor/install.sh.
+RUN curl -fsSL https://mise.run | sh \
+    && "$HOME/.local/bin/mise" --version
+
+# Activate mise and expose the Rust toolchain in interactive shells.
+RUN printf '%s\n' \
+    'export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"' \
+    'command -v mise >/dev/null 2>&1 && eval "$(mise activate bash)"' \
+    >> "$HOME/.bashrc"

--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -8,6 +8,14 @@ FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Default to a UTF-8 locale. The base image boots with the C/POSIX locale, under
+# which bash reports the completion cursor (COMP_POINT) in bytes rather than
+# characters; usage-argv has a test that asserts character-based cutting and
+# fails without UTF-8. C.UTF-8 is built into glibc, so no locale generation is
+# needed.
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
+
 # System packages:
 # - ca-certificates/curl/git/xz-utils/unzip: fetch + unpack toolchains and tools
 # - build-essential/pkg-config/libssl-dev: compile cargo-installed tools (cargo-edit)

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,8 @@
+{
+  "name": "usage",
+  "user": "ubuntu",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "install": "./.cursor/install.sh"
+}

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "usage",
+  "install": "./.cursor/install.sh"
+}

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,4 +1,0 @@
-{
-  "name": "usage",
-  "install": "./.cursor/install.sh"
-}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,20 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# The Rust toolchain is managed by rustup (not mise). rustup stores its default
-# toolchain under RUSTUP_HOME, so pin these to the base image's locations in case
-# the container-level env vars are not inherited. mise lives in ~/.local/bin.
-export RUSTUP_HOME="${RUSTUP_HOME:-/usr/local/rustup}"
-export CARGO_HOME="${CARGO_HOME:-/usr/local/cargo}"
-export PATH="$HOME/.local/bin:$CARGO_HOME/bin:$PATH"
+# Make mise and the Rust toolchain discoverable even in a non-login shell. The
+# Dockerfile installs mise into ~/.local/bin and Rust (via rustup) into ~/.cargo;
+# rustup's own defaults (~/.rustup, ~/.cargo) match, so no RUSTUP_HOME/CARGO_HOME
+# overrides are needed.
+export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
 
-# Trust the repo's mise config and ensure every pinned tool (go, node, python,
-# prettier, actionlint, insta, shellcheck, ...) is installed. Idempotent: when
-# booting from the prebuilt environment the tools already exist and this is fast.
+# Trust the repo's mise config and install every pinned tool from mise.toml
+# (go, node, python, prettier, actionlint, insta, shellcheck, ...). Idempotent:
+# already-present tools are a fast no-op.
 mise trust --yes
 mise install
 
-# Build the workspace so target/debug/usage exists. mise puts ./target/debug on
-# PATH, and both the Go corpus tests (`mise run test:go`) and the shell
-# completion integration tests invoke `usage` from PATH.
+# Build the workspace so target/debug/usage is on PATH (mise adds ./target/debug).
+# The Go corpus tests (`mise run test:go`) and the shell-completion integration
+# tests both invoke `usage` from PATH.
 mise exec -- cargo build --all

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# The Rust toolchain is managed by rustup (not mise). rustup stores its default
+# toolchain under RUSTUP_HOME, so pin these to the base image's locations in case
+# the container-level env vars are not inherited. mise lives in ~/.local/bin.
+export RUSTUP_HOME="${RUSTUP_HOME:-/usr/local/rustup}"
+export CARGO_HOME="${CARGO_HOME:-/usr/local/cargo}"
+export PATH="$HOME/.local/bin:$CARGO_HOME/bin:$PATH"
+
+# Trust the repo's mise config and ensure every pinned tool (go, node, python,
+# prettier, actionlint, insta, shellcheck, ...) is installed. Idempotent: when
+# booting from the prebuilt environment the tools already exist and this is fast.
+mise trust --yes
+mise install
+
+# Build the workspace so target/debug/usage exists. mise puts ./target/debug on
+# PATH, and both the Go corpus tests (`mise run test:go`) and the shell
+# completion integration tests invoke `usage` from PATH.
+mise exec -- cargo build --all


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a fully **repository-managed** Cursor Cloud Agent environment for `jdx/usage`, so future agents boot with the repo's pinned toolchain and can build, test, lint, and render. The setup is versioned with the code and reproducible from a `Dockerfile` — no dependency on a personal snapshot.

## Files

- `.cursor/environment.json` — repo-managed config: runs as user `ubuntu`, builds `.cursor/Dockerfile`, and wires `install` → `.cursor/install.sh`.
- `.cursor/Dockerfile` — Ubuntu 24.04 base with the stable system layer: Rust stable (`rustup`), `mise`, `zsh`/`fish`/`pwsh`, build deps, and a `C.UTF-8` locale.
- `.cursor/install.sh` — idempotent post-checkout bootstrap: `mise trust` → `mise install` (pinned tools from `mise.toml`) → `cargo build --all` (puts `target/debug/usage` on `PATH`).

## Why a Dockerfile (base-image layer) vs. install (repo layer)

- The stock Cloud Agent image ships Rust `1.83`; `usage-lib` declares MSRV `1.95`, so a newer toolchain must be provisioned. The Dockerfile installs Rust stable (`1.97.x`).
- `mise`, the four shells, and system libraries are stable and go in the image.
- Pinned tools live in `mise.toml`, which only exists after checkout, so `mise install` runs in `install.sh` (the repo layer), not the image.

## Validation (all via builds + fresh Cloud Agents booted from them)

- Docker image builds cleanly: `pwsh 7.6.5`, `rustc 1.97.1`, `mise` — then `install.sh` installs all pinned tools and `cargo build` finishes (`INSTALL Exit code: 0`).
- Fresh Cloud Agent booted from the build reports: user `ubuntu`, `rustc 1.97.1`, all `mise.toml` tools (`go 1.26`, `node 24`, `python`, `prettier`, `actionlint`, `insta`, `shellcheck`, ...), and all four shells (`bash`/`zsh`/`fish`/`pwsh`).
- `CI=1 mise run test` — passes out of the box (all 19 bash/zsh/fish/powershell completion integration tests included; these panic rather than skip under `CI=1` if a shell is missing).
- `mise run test:go` — Go corpus/shadow suite passes.
- `mise run lint` — clippy/fmt/prettier/actionlint/go clean.
- End-to-end CLI: a sample spec generates bash completions and resolves `complete-word` subcommands and choices.

## Review notes

- **Bugbot ("missing agent environment config")**: resolved — this revision adds `.cursor/environment.json` wiring `install.sh`. (An earlier revision intentionally omitted `environment.json` while the environment was dashboard/snapshot-managed; this PR is now fully repo-managed.)
- **CodeRabbit (`mise trust --yes`)**: kept intentionally. It's mise's documented non-interactive path (`MISE_YES`), the script only ever trusts *this* repo's own `mise.toml` (the same file the agent already uses for every dev command), and the project's own CI drives the identical config non-interactively via `jdx/mise-action`. If preferred, this can instead be a platform-level trust via `MISE_TRUSTED_CONFIG_PATHS` set in the Dockerfile.

## Locale fix

The `ubuntu:24.04` base boots in the `C`/`POSIX` locale, under which `bash` reports the completion cursor in bytes rather than characters, failing one `usage-argv` test. The Dockerfile sets `LANG=LC_ALL=C.UTF-8` (built into glibc), and a fresh agent confirms the full suite is green with no override.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a32876a1-5477-4c9b-9cca-025301577383?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a32876a1-5477-4c9b-9cca-025301577383&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a standardized cloud development environment based on Ubuntu 24.04.
  * Added automated setup for Rust, Cargo, mise, PowerShell, and required project tooling.
  * Automatically configures development paths and installs tools from the project configuration.
  * Builds the complete workspace during environment setup to verify readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->