### PR TITLE
feat(spec): add rich choice metadata

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -439,7 +439,9 @@ Groups are the opposite case: `Command::get_groups`, `ArgGroup::get_args` and
 
 - [ ] **The full `PossibleValue` model** — `ignore_case`, aliases and their
       visibility, per-value help, and hidden values. Subcommand variants take
-      aliases; enumerated values are currently flattened to a list of strings.
+      aliases. The KDL model, usage-lib parser, and clap bridge now preserve this
+      metadata; generated Rust and Go tables still flatten choices to strings and are
+      the remaining work before this item is complete.
 - [ ] **`infer_subcommands` / `infer_long_args`** — unambiguous prefixes. We
       suggest what was probably meant but do not accept it.
 - [x] **`external_subcommand`** — an unmatched word is forwarded with the rest

--- a/docs/spec/reference/arg.md
+++ b/docs/spec/reference/arg.md
@@ -47,6 +47,17 @@ arg "<env>" {
   choices env="DEPLOY_ENVS" // values from $DEPLOY_ENVS, split on commas and/or whitespace
 }
 
+// Rich choices keep clap PossibleValue metadata portable in KDL.
+arg "<color>" {
+  choices ignore_case=#true {
+    choice "always" help="Always use color" {
+      alias "yes"
+      alias "on" hide=#true
+    }
+    choice "never" hide=#true
+  }
+}
+
 arg "<file>" help_heading="Input" // group this arg under a heading in help output
 
 arg "<file>" long_help="longer help for --help (as oppoosed to -h)"

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -5,7 +5,7 @@ extern crate log;
 pub use crate::parse::{available_flags, parse, Parser};
 pub use crate::spec::arg::{SpecArg, SpecDoubleDashChoices};
 pub use crate::spec::builder::{SpecArgBuilder, SpecCommandBuilder, SpecFlagBuilder};
-pub use crate::spec::choices::SpecChoices;
+pub use crate::spec::choices::{SpecChoice, SpecChoiceAlias, SpecChoices};
 pub use crate::spec::cmd::SpecCommand;
 pub use crate::spec::complete::SpecComplete;
 pub use crate::spec::effect::SpecCommandEffect;

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -2285,7 +2285,7 @@ fn choice_error(
 ) -> Option<String> {
     let choices = choices?;
     let values = choices.values_with_env(custom_env);
-    if values.iter().any(|choice| choice == value) {
+    if choices.matches_with_env(value, custom_env) {
         return None;
     }
     if let Some(env) = choices.env() {
@@ -2314,12 +2314,7 @@ fn validate_choices(
     custom_env: Option<&HashMap<String, String>>,
 ) -> miette::Result<bool> {
     if is_help_arg(spec, value)
-        && choices.is_some_and(|choices| {
-            !choices
-                .values_with_env(custom_env)
-                .iter()
-                .any(|choice| choice == value)
-        })
+        && choices.is_some_and(|choices| !choices.matches_with_env(value, custom_env))
     {
         errors.push(render_help_err(spec, cmd, value.len() > 2));
         return Ok(true);

--- a/lib/src/spec/arg.rs
+++ b/lib/src/spec/arg.rs
@@ -10,7 +10,7 @@ use crate::spec::context::ParsingContext;
 use crate::spec::effect::{SpecCommandEffect, EFFECT_VALUES};
 use crate::spec::helpers::{string_entry, NodeHelper};
 use crate::spec::is_false;
-use crate::{string, SpecChoices};
+use crate::{string, SpecChoice, SpecChoiceAlias, SpecChoices};
 
 #[derive(Debug, Default, Clone, Serialize, PartialEq, Eq, strum::EnumString, strum::Display)]
 #[strum(serialize_all = "snake_case")]
@@ -394,6 +394,45 @@ pub(crate) fn default_values(arg: &clap::Arg) -> Vec<String> {
 }
 
 #[cfg(feature = "clap")]
+pub(crate) fn choices_from_clap(arg: &clap::Arg) -> Option<SpecChoices> {
+    let possible = arg.get_possible_values();
+    if possible.is_empty() {
+        return None;
+    }
+    let choices = possible
+        .iter()
+        .map(|value| value.get_name().to_string())
+        .collect();
+    let details = possible
+        .iter()
+        .filter_map(|value| {
+            let aliases: Vec<_> = value
+                .get_name_and_aliases()
+                .skip(1)
+                .map(|alias| SpecChoiceAlias {
+                    value: alias.to_string(),
+                    // clap PossibleValue aliases are always hidden.
+                    hide: true,
+                })
+                .collect();
+            let detail = SpecChoice {
+                value: value.get_name().to_string(),
+                help: value.get_help().map(ToString::to_string),
+                hide: value.is_hide_set(),
+                aliases,
+            };
+            (detail.help.is_some() || detail.hide || !detail.aliases.is_empty()).then_some(detail)
+        })
+        .collect();
+    Some(SpecChoices {
+        choices,
+        details,
+        ignore_case: arg.is_ignore_case_set(),
+        ..Default::default()
+    })
+}
+
+#[cfg(feature = "clap")]
 impl From<&clap::Arg> for SpecArg {
     fn from(arg: &clap::Arg) -> Self {
         let required = arg.is_required_set();
@@ -410,11 +449,7 @@ impl From<&clap::Arg> for SpecArg {
             arg.get_action(),
             clap::ArgAction::Count | clap::ArgAction::Append
         ) || delimiter.is_some();
-        let choices = arg
-            .get_possible_values()
-            .iter()
-            .flat_map(|v| v.get_name_and_aliases().map(|s| s.to_string()))
-            .collect::<Vec<_>>();
+        let choices = choices_from_clap(arg);
         let mut arg = Self {
             name: arg
                 .get_value_names()
@@ -449,12 +484,7 @@ impl From<&clap::Arg> for SpecArg {
             env: None,
             help_heading: arg.get_help_heading().map(|s| s.to_string()),
         };
-        if !choices.is_empty() {
-            arg.choices = Some(SpecChoices {
-                choices,
-                ..Default::default()
-            });
-        }
+        arg.choices = choices;
 
         arg
     }
@@ -620,6 +650,32 @@ mod delimiter_tests {
             .parse::<Spec>()
             .unwrap_err();
         assert!(format!("{err:?}").contains("one character"), "{err:?}");
+    }
+}
+
+#[cfg(test)]
+mod possible_value_tests {
+    use clap::builder::PossibleValue;
+
+    #[test]
+    fn clap_possible_value_metadata_survives_the_bridge() {
+        let command = clap::Command::new("ex").arg(
+            clap::Arg::new("color").ignore_case(true).value_parser([
+                PossibleValue::new("always")
+                    .help("Always use color")
+                    .alias("yes"),
+                PossibleValue::new("never").hide(true),
+            ]),
+        );
+        let spec = crate::Spec::from(&command);
+        let choices = spec.cmd.args[0].choices.as_ref().unwrap();
+        assert_eq!(choices.choices, ["always", "never"]);
+        assert!(choices.ignore_case);
+        assert!(choices.matches("YES"));
+        assert_eq!(choices.values(), ["always"]);
+        assert_eq!(choices.details[0].help.as_deref(), Some("Always use color"));
+        assert!(choices.details[0].aliases[0].hide);
+        assert!(choices.details[1].hide);
     }
 }
 

--- a/lib/src/spec/choices.rs
+++ b/lib/src/spec/choices.rs
@@ -1,6 +1,4 @@
-#[cfg(feature = "unstable_choices_env")]
-use kdl::KdlEntry;
-use kdl::KdlNode;
+use kdl::{KdlDocument, KdlEntry, KdlNode};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -12,9 +10,33 @@ use crate::spec::helpers::NodeHelper;
 #[non_exhaustive]
 pub struct SpecChoices {
     pub choices: Vec<String>,
+    /// Metadata for canonical values that need more than the shorthand string form.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub details: Vec<SpecChoice>,
+    /// Match canonical values and aliases without regard to ASCII case.
+    #[serde(default, skip_serializing_if = "crate::spec::is_false")]
+    pub ignore_case: bool,
     #[cfg(feature = "unstable_choices_env")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub env: Option<String>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SpecChoice {
+    pub value: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub help: Option<String>,
+    #[serde(default, skip_serializing_if = "crate::spec::is_false")]
+    pub hide: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub aliases: Vec<SpecChoiceAlias>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SpecChoiceAlias {
+    pub value: String,
+    #[serde(default, skip_serializing_if = "crate::spec::is_false")]
+    pub hide: bool,
 }
 
 impl SpecChoices {
@@ -46,20 +68,7 @@ impl SpecChoices {
     }
 
     pub(crate) fn parse(ctx: &ParsingContext, node: &NodeHelper) -> Result<Self, UsageErr> {
-        #[cfg(not(feature = "unstable_choices_env"))]
-        node.ensure_arg_len(1..)?;
-
-        #[cfg(feature = "unstable_choices_env")]
         let mut config = Self {
-            choices: node
-                .args()
-                .map(|e| e.ensure_string())
-                .collect::<Result<_, _>>()?,
-            ..Default::default()
-        };
-
-        #[cfg(not(feature = "unstable_choices_env"))]
-        let config = Self {
             choices: node
                 .args()
                 .map(|e| e.ensure_string())
@@ -71,8 +80,60 @@ impl SpecChoices {
             match k {
                 #[cfg(feature = "unstable_choices_env")]
                 "env" => config.set_env(Some(v.ensure_string()?)),
+                "ignore_case" => config.ignore_case = v.ensure_bool()?,
                 k => bail_parse!(ctx, v.entry.span(), "unsupported choices key {k}"),
             }
+        }
+
+        for choice in node.children() {
+            if choice.name() != "choice" {
+                bail_parse!(
+                    ctx,
+                    choice.node.name().span(),
+                    "a choices block holds `choice` nodes"
+                );
+            }
+            choice.ensure_arg_len(1..=1)?;
+            let value = choice.arg(0)?.ensure_string()?;
+            let mut detail = SpecChoice {
+                value: value.clone(),
+                ..Default::default()
+            };
+            for (key, entry) in choice.props() {
+                match key {
+                    "help" => detail.help = Some(entry.ensure_string()?),
+                    "hide" => detail.hide = entry.ensure_bool()?,
+                    key => bail_parse!(ctx, entry.entry.span(), "unsupported choice key {key}"),
+                }
+            }
+            for alias in choice.children() {
+                if alias.name() != "alias" {
+                    bail_parse!(
+                        ctx,
+                        alias.node.name().span(),
+                        "a choice block holds `alias` nodes"
+                    );
+                }
+                alias.ensure_arg_len(1..=1)?;
+                let mut parsed = SpecChoiceAlias {
+                    value: alias.arg(0)?.ensure_string()?,
+                    ..Default::default()
+                };
+                for (key, entry) in alias.props() {
+                    match key {
+                        "hide" => parsed.hide = entry.ensure_bool()?,
+                        key => bail_parse!(ctx, entry.entry.span(), "unsupported alias key {key}"),
+                    }
+                }
+                if !alias.children().is_empty() {
+                    bail_parse!(ctx, alias.span(), "an alias cannot have children");
+                }
+                detail.aliases.push(parsed);
+            }
+            if !config.choices.contains(&value) {
+                config.choices.push(value);
+            }
+            config.details.push(detail);
         }
 
         if config.choices.is_empty() {
@@ -95,12 +156,59 @@ impl SpecChoices {
         self.values_with_env(None)
     }
 
-    pub(crate) fn values_with_env(&self, env: Option<&HashMap<String, String>>) -> Vec<String> {
-        #[cfg(feature = "unstable_choices_env")]
-        let mut values = self.choices.clone();
+    pub fn matches(&self, value: &str) -> bool {
+        let equals = |candidate: &str| {
+            if self.ignore_case {
+                candidate.eq_ignore_ascii_case(value)
+            } else {
+                candidate == value
+            }
+        };
+        self.choices.iter().any(|choice| equals(choice))
+            || self
+                .details
+                .iter()
+                .flat_map(|choice| &choice.aliases)
+                .any(|alias| equals(&alias.value))
+    }
 
-        #[cfg(not(feature = "unstable_choices_env"))]
-        let values = self.choices.clone();
+    pub(crate) fn matches_with_env(
+        &self,
+        value: &str,
+        env: Option<&HashMap<String, String>>,
+    ) -> bool {
+        self.matches(value)
+            || self.values_with_env(env).iter().any(|candidate| {
+                if self.ignore_case {
+                    candidate.eq_ignore_ascii_case(value)
+                } else {
+                    candidate == value
+                }
+            })
+    }
+
+    pub(crate) fn values_with_env(&self, env: Option<&HashMap<String, String>>) -> Vec<String> {
+        let mut values: Vec<String> = self
+            .choices
+            .iter()
+            .filter(|value| {
+                !self
+                    .details
+                    .iter()
+                    .any(|detail| detail.value == (*value).as_str() && detail.hide)
+            })
+            .cloned()
+            .collect();
+        for alias in self
+            .details
+            .iter()
+            .flat_map(|detail| &detail.aliases)
+            .filter(|alias| !alias.hide)
+        {
+            if !values.contains(&alias.value) {
+                values.push(alias.value.clone());
+            }
+        }
 
         #[cfg(not(feature = "unstable_choices_env"))]
         let _ = env;
@@ -135,8 +243,42 @@ impl SpecChoices {
 impl From<&SpecChoices> for KdlNode {
     fn from(arg: &SpecChoices) -> Self {
         let mut node = KdlNode::new("choices");
-        for choice in &arg.choices {
-            node.push(choice.to_string());
+        if arg.details.is_empty() {
+            for choice in &arg.choices {
+                node.push(choice.to_string());
+            }
+        } else {
+            let mut children = KdlDocument::new();
+            for value in &arg.choices {
+                let detail = arg.details.iter().find(|detail| detail.value == *value);
+                let mut choice = KdlNode::new("choice");
+                choice.push(crate::spec::helpers::string_entry(None, value));
+                if let Some(detail) = detail {
+                    if let Some(help) = &detail.help {
+                        choice.push(crate::spec::helpers::string_entry(Some("help"), help));
+                    }
+                    if detail.hide {
+                        choice.push(KdlEntry::new_prop("hide", true));
+                    }
+                    if !detail.aliases.is_empty() {
+                        let mut aliases = KdlDocument::new();
+                        for item in &detail.aliases {
+                            let mut alias = KdlNode::new("alias");
+                            alias.push(crate::spec::helpers::string_entry(None, &item.value));
+                            if item.hide {
+                                alias.push(KdlEntry::new_prop("hide", true));
+                            }
+                            aliases.nodes_mut().push(alias);
+                        }
+                        choice.set_children(aliases);
+                    }
+                }
+                children.nodes_mut().push(choice);
+            }
+            node.set_children(children);
+        }
+        if arg.ignore_case {
+            node.push(KdlEntry::new_prop("ignore_case", true));
         }
         #[cfg(feature = "unstable_choices_env")]
         if let Some(env) = arg.env() {
@@ -152,6 +294,41 @@ mod tests {
     use super::SpecChoices;
     #[cfg(feature = "unstable_choices_env")]
     use std::collections::HashMap;
+
+    #[test]
+    fn rich_choices_round_trip_and_match_their_aliases() {
+        let source = r#"
+name "ex"
+bin "ex"
+arg "<color>" {
+  choices ignore_case=#true {
+    choice "always" help="Always use color" {
+      alias "yes"
+      alias "on" hide=#true
+    }
+    choice "never" hide=#true
+  }
+}
+"#;
+        let spec: crate::Spec = source.parse().unwrap();
+        let choices = spec.cmd.args[0].choices.as_ref().unwrap();
+        assert!(choices.matches("ALWAYS"));
+        assert!(choices.matches("YES"));
+        assert!(choices.matches("ON"));
+        assert_eq!(choices.values(), vec!["always", "yes"]);
+        crate::parse(&spec, &["ex".into(), "YES".into()]).unwrap();
+        crate::parse(&spec, &["ex".into(), "NEVER".into()]).unwrap();
+        assert!(crate::parse(&spec, &["ex".into(), "sometimes".into()]).is_err());
+
+        let rendered = spec.to_string();
+        let reparsed: crate::Spec = rendered.parse().unwrap();
+        let choices = reparsed.cmd.args[0].choices.as_ref().unwrap();
+        assert_eq!(
+            choices.details,
+            spec.cmd.args[0].choices.as_ref().unwrap().details
+        );
+        assert!(choices.ignore_case);
+    }
 
     #[cfg(feature = "unstable_choices_env")]
     #[test]

--- a/lib/src/spec/choices.rs
+++ b/lib/src/spec/choices.rs
@@ -157,6 +157,10 @@ impl SpecChoices {
     }
 
     pub fn matches(&self, value: &str) -> bool {
+        self.matches_static(value) || self.matches_values(value, self.values_with_env(None))
+    }
+
+    fn matches_static(&self, value: &str) -> bool {
         let equals = |candidate: &str| {
             if self.ignore_case {
                 candidate.eq_ignore_ascii_case(value)
@@ -177,14 +181,17 @@ impl SpecChoices {
         value: &str,
         env: Option<&HashMap<String, String>>,
     ) -> bool {
-        self.matches(value)
-            || self.values_with_env(env).iter().any(|candidate| {
-                if self.ignore_case {
-                    candidate.eq_ignore_ascii_case(value)
-                } else {
-                    candidate == value
-                }
-            })
+        self.matches_static(value) || self.matches_values(value, self.values_with_env(env))
+    }
+
+    fn matches_values(&self, value: &str, values: impl IntoIterator<Item = String>) -> bool {
+        values.into_iter().any(|candidate| {
+            if self.ignore_case {
+                candidate.eq_ignore_ascii_case(value)
+            } else {
+                candidate == value
+            }
+        })
     }
 
     pub(crate) fn values_with_env(&self, env: Option<&HashMap<String, String>>) -> Vec<String> {
@@ -376,5 +383,21 @@ arg "<color>" {
             choices.values_with_env(Some(&HashMap::new())),
             vec!["local"]
         );
+    }
+
+    #[cfg(feature = "unstable_choices_env")]
+    #[test]
+    fn matches_resolves_env_backed_choices() {
+        const KEY: &str = "USAGE_TEST_MATCHES_CHOICES_ENV_9C47C3C5";
+        let mut choices = SpecChoices {
+            ignore_case: true,
+            ..Default::default()
+        };
+        choices.set_env(Some(KEY.into()));
+        std::env::set_var(KEY, "staging");
+
+        assert!(choices.matches("STAGING"));
+
+        std::env::remove_var(KEY);
     }
 }

--- a/lib/src/spec/flag.rs
+++ b/lib/src/spec/flag.rs
@@ -790,17 +790,7 @@ impl From<&clap::Arg> for SpecFlag {
                     .as_str(),
             );
 
-            let choices = c
-                .get_possible_values()
-                .iter()
-                .flat_map(|v| v.get_name_and_aliases().map(|s| s.to_string()))
-                .collect::<Vec<_>>();
-            if !choices.is_empty() {
-                arg.choices = Some(SpecChoices {
-                    choices,
-                    ..Default::default()
-                });
-            }
+            arg.choices = crate::spec::arg::choices_from_clap(c);
 
             // The flag's argument is built from its value name rather than from the
             // clap `Arg`, so what the `Arg` says about the *value* has to be carried


### PR DESCRIPTION
## Summary

- add backward-compatible rich `choices` blocks with per-value help, hidden values, and visible or hidden aliases
- apply `ignore_case` and aliases in usage-lib while keeping hidden entries out of visible choice lists
- preserve clap `PossibleValue` metadata through the clap-to-spec bridge

## Follow-up

Generated Rust and Go tables still flatten choice metadata. A follow-up PR will stack on this one to carry the model through those runtimes.

## Test plan

- `cargo test -p usage-lib --all-features`
- `cargo clippy -p usage-lib --all-features -- -D warnings`

Ready for review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches argv choice validation for all enumerated args and flags; behavior is backward compatible for simple lists but new alias/case rules change acceptance for rich specs.
> 
> **Overview**
> Extends CLI **choices** beyond flat string lists so KDL and usage-lib can carry clap-style `PossibleValue` metadata: `ignore_case`, per-value help, hidden values, and visible or hidden aliases. Simple `choices "a" "b"` specs stay valid; rich blocks use nested `choice` / `alias` nodes as documented in `arg.md`.
> 
> **Parsing and validation** now resolve choices through `SpecChoices::matches` / `matches_with_env`, so argv accepts aliases and case-insensitive canonical names while **visible** choice lists omit hidden values and include non-hidden aliases. KDL round-trips the rich form when `details` is present.
> 
> The **clap → spec** path is centralized in `choices_from_clap` (args and flags), preserving help, hide, aliases, and `ignore_case` instead of flattening to strings. `SpecChoice` and `SpecChoiceAlias` are exported from the crate.
> 
> `PLAN.md` notes that generated Rust/Go tables still flatten choices; that codegen is explicitly out of scope here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfc50386c7654e16fa80d8c9156a55d5ce9895ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->