### PR TITLE
docs(plan): define fleet adoption experiments

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1165,7 +1165,7 @@ including telling you to delete the label afterwards.
       `Error::DuplicateFlag` is constructed only in `derive/src/codegen.rs`, never by
       usage-argv's parser, so a derive-generated binary still rejects a repeated flag as clap
       does. Separately, `Spec::to_kdl` validates `duplicate_flag_form` at the spec boundary so
-      two declarations cannot claim the same spelling. Unknown flags are intentionally different: every parser
+      two declarations cannot claim the same spelling. Unknown flags are intentionally different: usage parsers
       is permissive by default and a command opts into `unknown_flags="error"` when it owns the
       whole grammar. That is what fleet adopters should declare for clap parity, while forwarding
       commands such as `mise run` keep the default. `differential.rs` carries a named test so

--- a/PLAN.md
+++ b/PLAN.md
@@ -1166,7 +1166,7 @@ including telling you to delete the label afterwards.
       usage-argv's parser, so a derive-generated binary still rejects a repeated flag as clap
       does. Separately, `Spec::to_kdl` validates `duplicate_flag_form` at the spec boundary so
       two declarations cannot claim the same spelling. Unknown flags are intentionally different: usage parsers
-      is permissive by default and a command opts into `unknown_flags="error"` when it owns the
+      are permissive by default and a command opts into `unknown_flags="error"` when it owns the
       whole grammar. That is what fleet adopters should declare for clap parity, while forwarding
       commands such as `mise run` keep the default. `differential.rs` carries a named test so
       tightening usage-lib fails with the reason attached.

--- a/PLAN.md
+++ b/PLAN.md
@@ -721,14 +721,17 @@ looking at the clap surface, not only at the spec.
       command) and the same manpage. usage-cli's own
       `render:usage-cli-completions` already does this for `usage`; the gate
       now asks it of a clap CLI.
-- [ ] **A typed rewrite of one small CLI, not a String shadow.** `gen-shadow`
+- [ ] **Typed rewrites of communique, tak, aube, hk, and fnox, not String
+      shadows.** `gen-shadow`
       types every field as `String`. The derive already holds `PathBuf`,
       `OsString`, `ValueEnum`, `FromStr`, `flatten`, `Option`/`Vec`. usage-cli
-      proves that for usage's own types. communique or tak would prove it for a
-      clap CLI rewritten in place: real field types, skip-fields or the split
-      they force, and a binary that still answers `--help` / `--usage-spec` the
-      same way. That is the experiment that tells you whether the rest of the
-      fleet is a rewrite or a blocked rewrite.
+      proves that for usage's own types. These five will prove it across real
+      clap CLIs rewritten in place: real field types, skip-fields or the split
+      they force, and binaries that still answer `--help` / `--usage-spec` the
+      same way. Each experiment is a ready-for-review PR whose `Cargo.toml`
+      deliberately points at usage's git revision; the PR is evidence for the
+      6.x gate, not something to merge before usage 6.x is published. Together
+      they tell us whether the fleet is a rewrite or a set of blocked rewrites.
 - [x] **The clap-only validation behaviour the fleet actually uses.** Portable
       `validate` expressions cover numeric ranges in the typed rewrite. Arbitrary clap
       parser functions remain opaque to `clap_usage`, but they no longer require a
@@ -770,9 +773,12 @@ a prerequisite for trying a CLI.
       `usage-rs`, emits its spec from the same tables, and feeds that spec to
       the markdown, manpage and completion generators. The remaining items in
       **Trying the fleet** are about the _other_ CLIs, not this one.
-- [ ] **communique or tak** — the smallest clap CLIs, and the typed rewrite the
-      section above asks for. tak cannot emit a spec today; adding a `usage`
-      subcommand (or `--usage-spec`) is part of trying it.
+- [ ] **communique, tak, aube, hk, and fnox** — five typed fleet rewrites, each
+      carried as a ready-for-review experimental PR on a git dependency until
+      usage 6.x exists. tak cannot emit a spec today; adding a `usage` subcommand
+      (or `--usage-spec`) is part of trying it. Every missing usage feature and
+      every general clap-compatibility gap found while converting them goes into
+      a stacked follow-up to this plan before 6.x is published.
 - [ ] **mise** — the largest and least forgiving adopter. Likely a router first, then
       commands lowered a few at a time, with mise's e2e argv corpus replayed against both
       parsers. Adoption is measured by what it lets mise delete, listed below.

--- a/PLAN.md
+++ b/PLAN.md
@@ -715,7 +715,10 @@ looking at the clap surface, not only at the spec.
       fixtures are regenerated from the CLIs linked to _this_ `clap_usage`, the
       shadows cannot see delimiter-split flags that mise, hk, pitchfork and aube
       all declare. tak currently has no `usage` subcommand at all, so it cannot
-      even produce a fresh spec without one.
+      even produce a fresh spec without one. The experiment may add `usage` or
+      `--usage-spec` solely to expose the new canonical metadata; that new entry
+      point has no clap-era behavior to preserve and is excluded from tak's
+      compatibility baseline.
 - [x] **Docs and manpages on a fleet spec.** communique's checked-in spec and
       the KDL its shadow emits render the same markdown (index and every
       command) and the same manpage. usage-cli's own
@@ -727,8 +730,10 @@ looking at the clap surface, not only at the spec.
       `OsString`, `ValueEnum`, `FromStr`, `flatten`, `Option`/`Vec`. usage-cli
       proves that for usage's own types. These five will prove it across real
       clap CLIs rewritten in place: real field types, skip-fields or the split
-      they force, and binaries that still answer `--help` / `--usage-spec` the
-      same way. Each experiment is a ready-for-review PR whose `Cargo.toml`
+      they force, and binaries that preserve every pre-existing `--help` and
+      spec-emission entry point. tak's experiment-only spec entry point is tested
+      as new behavior rather than compared with a nonexistent baseline. Each
+      experiment is a ready-for-review PR whose `Cargo.toml`
       deliberately points at usage's git revision; the PR is evidence for the
       6.x gate, not something to merge before usage 6.x is published. Together
       they tell us whether the fleet is a rewrite or a set of blocked rewrites.
@@ -776,16 +781,18 @@ a prerequisite for trying a CLI.
 - [ ] **communique, tak, aube, hk, and fnox** — five typed fleet rewrites, each
       carried as a ready-for-review experimental PR on a git dependency until
       usage 6.x exists. tak cannot emit a spec today; adding a `usage` subcommand
-      (or `--usage-spec`) is part of trying it. Every missing usage feature and
-      every general clap-compatibility gap found while converting them goes into
-      a stacked follow-up to this plan before 6.x is published.
+      (or `--usage-spec`) is experiment-only and outside its preserved CLI
+      contract. Every missing usage feature and every general clap-compatibility
+      gap found while converting them goes into a stacked follow-up to this plan
+      before 6.x is published.
 - [ ] **mise** — the largest and least forgiving adopter. Likely a router first, then
       commands lowered a few at a time, with mise's e2e argv corpus replayed against both
       parsers. Adoption is measured by what it lets mise delete, listed below.
       Do not start this until the clap-only rows in **Trying the fleet** that
       mise actually uses are either implemented or accepted as lost.
-- [ ] **hk, pitchfork, fnox, aube** — smaller than mise, all already generating
-      their spec from clap. Natural next adopters after one small CLI has moved.
+- [ ] **pitchfork** — not part of the five typed experiments, but already
+      generates its spec from clap. It is the next small adopter after those
+      experiment branches become mergeable.
 - [~] **Other languages** — Go now parses, validates, renders help and answers
   completions from generated static tables, verified against the shared corpus.
   JavaScript and Python implementations remain open.
@@ -1154,13 +1161,15 @@ including telling you to delete the label afterwards.
       ("a repeat is a correction… the later occurrence wins") and `long-unknown` ("more likely
       data in transit than a mistake", with `unknown_flags "error"` as the opt-in). Acting on
       the wrong reading got as far as three failing conformance vectors.
-      The refusals come from a different layer: `Error::DuplicateFlag` is constructed only in
-      `derive/src/codegen.rs`, never by usage-argv's parser. So a derive-generated binary is
-      strict and agrees with clap, which is what an adopter compares; a spec-driven parse is
-      conformant and lax, which is what mise runs _task_ arguments through, where a wrapper
-      appending to a command line it did not write is the documented case. Both correct in
-      their own domain, and `differential.rs` now carries a named test so tightening usage-lib
-      fails with the reason attached.
+      One refusal comes from a different layer: for repeated command-line occurrences,
+      `Error::DuplicateFlag` is constructed only in `derive/src/codegen.rs`, never by
+      usage-argv's parser, so a derive-generated binary still rejects a repeated flag as clap
+      does. Separately, `Spec::to_kdl` validates `duplicate_flag_form` at the spec boundary so
+      two declarations cannot claim the same spelling. Unknown flags are intentionally different: every parser
+      is permissive by default and a command opts into `unknown_flags="error"` when it owns the
+      whole grammar. That is what fleet adopters should declare for clap parity, while forwarding
+      commands such as `mise run` keep the default. `differential.rs` carries a named test so
+      tightening usage-lib fails with the reason attached.
 - [x] Unrecognized flags fall through to positionals, so `ex --wat` binds `--wat`
       to an argument, or reports `unexpected_arg` when there is none. **Decided
       (2026-08-19): lax is the default everywhere — both parsers — and strict is


### PR DESCRIPTION
## Summary

- settle unknown-flag handling as permissive by default with explicit strict opt-in
- expand the typed fleet experiment to communique, tak, aube, hk, and fnox
- record that each conversion will be a ready-for-review git-dependency PR used as 6.x evidence
- require a stacked follow-up plan update for fleet and general clap gaps

## Validation

- `git diff --check`

This PR records the decisions for the fleet-adoption experiment; it does not change runtime behavior.

_This PR was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to PLAN.md; no code, tests, or release behavior change.
> 
> **Overview**
> **PLAN.md** only — no runtime changes. It records how the jdx fleet will prove **usage 6.x** readiness.
> 
> **Trying the fleet** expands the typed experiment from one small CLI to **communique, tak, aube, hk, and fnox**: in-place rewrites with real field types (not `gen-shadow` `String` shadows), preserved `--help` and spec emission, and **ready-for-review PRs on a git `usage` dependency** as merge evidence after 6.x ships. **tak** may add `usage` / `--usage-spec` only for metadata; that path is **new behavior**, outside its clap compatibility baseline. Fixture refresh notes the same optional entry point for tak.
> 
> **After the gate** mirrors that five-CLI list, requires a **stacked plan update** for every usage and general clap gap found during conversion, and moves **pitchfork** to the next adopter after those experiment branches are mergeable (not one of the five).
> 
> **Known usage-lib divergences** reframes parity: derive-generated binaries still reject repeated non-repeatable flags like clap; **`Spec::to_kdl`** catches duplicate flag spellings; **unknown flags stay permissive by default** with **`unknown_flags="error"`** for strict/clap-like adopters while forwarding commands (e.g. **`mise run`**) keep lax defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45ea031142e5ab000cf93984b57bb2ef940f56e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded planning for five typed CLI experiments and their specification-generation workflows.
  - Documented an experiment-only specification-emission entry point.
  - Clarified that established tools retain their existing help and specification output.
  - Clarified unknown-option handling, including optional strict validation.
  - Documented rejection of repeated flags and validation of duplicate spellings.
  - Reordered adoption tracking, deferred pitchfork integration, and added a roadmap for removing workarounds and expanding coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->