### PR TITLE
docs(plan): record typed fleet adoption blockers

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -577,6 +577,15 @@ feature list is not an exhaustive audit.
       derive applies the default, but help, spec consumers and differential
       tooling see a required shape. A default satisfies a field; it must not
       make the user's token required in the static metadata.
+- [ ] **Keep emitted parser settings consumable by the documentation toolchain.**
+      The typed tak rewrite correctly opts into strict parsing with
+      `unknown_flags="error"`, but `Cli::to_kdl()` emits an `unknown_flags`
+      root node that the published usage 5.1 CLI rejects as an unsupported spec
+      key. Until every renderer in the 6.x toolchain reads the same schema, an
+      adopter cannot regenerate checked-in docs from its new canonical metadata.
+      Version the schema boundary, test derive output through usage-cli, and
+      either model parser settings in `Spec` or keep runtime-only settings out of
+      portable KDL.
 - [ ] **Rust expressions for compile-time metadata.** hk and fnox use constants
       for defaults, aube and hk use constants for long help, and all three use
       generated or computed version strings. Requiring every value to be copied

--- a/PLAN.md
+++ b/PLAN.md
@@ -570,6 +570,30 @@ feature list is not an exhaustive audit.
       such as `requires` and `default_missing_value`, where loss cannot be detected,
       the matrix and integration docs must say that the bridge is not a lossless
       migration verifier.
+- [ ] **Defaults must preserve optionality in metadata.** The typed tak rewrite
+      accepts an omitted defaulted `String`, but its emitted KDL spells the
+      argument `<REV>` and the flag `required=#true`, where clap_usage emitted
+      `[REV]` and an optional value-taking flag. Binding succeeds because the
+      derive applies the default, but help, spec consumers and differential
+      tooling see a required shape. A default satisfies a field; it must not
+      make the user's token required in the static metadata.
+- [ ] **Rust expressions for compile-time metadata.** hk and fnox use constants
+      for defaults, aube and hk use constants for long help, and all three use
+      generated or computed version strings. Requiring every value to be copied
+      into a string literal creates exactly the drift this project is meant to
+      remove. Define which attributes accept `expr`, evaluate what can remain in
+      static tables, and give an explicit escape hatch for emission-only values.
+- [ ] **One Args type used by more than one command.** tak's `push` and `init`
+      have the same `--remote` shape. The derive rejects two variants wrapping
+      one `Args` type because collection is attached to the declaring struct,
+      forcing two identical structs. `flatten` solves shared fields within a
+      command but not a whole command body shared under two names. Either support
+      this directly or document the duplication as an architectural constraint.
+- [ ] **Version omission and dynamic version policy.** tak intentionally removes
+      the package version from its generated spec so release-plz version-only PRs
+      do not dirty generated docs; hk computes a richer version string. Specify
+      static, expression-backed and omitted versions separately rather than
+      forcing a hard-coded literal into every `Cli` derive.
 - [ ] **Generated micro-conformance against clap.** One minimal CLI per matrix row,
       compared on accepted and rejected argv, typed values, error kind and exit
       status, stdout versus stderr, short and long help, usage/version output, and
@@ -724,7 +748,7 @@ looking at the clap surface, not only at the spec.
       command) and the same manpage. usage-cli's own
       `render:usage-cli-completions` already does this for `usage`; the gate
       now asks it of a clap CLI.
-- [ ] **Typed rewrites of communique, tak, aube, hk, and fnox, not String
+- [~] **Typed rewrites of communique, tak, aube, hk, and fnox, not String
       shadows.** `gen-shadow`
       types every field as `String`. The derive already holds `PathBuf`,
       `OsString`, `ValueEnum`, `FromStr`, `flatten`, `Option`/`Vec`. usage-cli
@@ -737,6 +761,11 @@ looking at the clap surface, not only at the spec.
       deliberately points at usage's git revision; the PR is evidence for the
       6.x gate, not something to merge before usage 6.x is published. Together
       they tell us whether the fleet is a rewrite or a set of blocked rewrites.
+      **The experiment PRs now exist:** communique#265 and tak#47 are typed
+      rewrites; aube#1336, hk#1211 and fnox#725 are compileable static-table
+      shadows plus inventories of their real typed surfaces. The latter three
+      still need their clap dispatch replaced before this box closes. All five
+      pin `jdx/usage` at `cc60dcb7`.
 - [x] **The clap-only validation behaviour the fleet actually uses.** Portable
       `validate` expressions cover numeric ranges in the typed rewrite. Arbitrary clap
       parser functions remain opaque to `clap_usage`, but they no longer require a
@@ -778,12 +807,15 @@ a prerequisite for trying a CLI.
       `usage-rs`, emits its spec from the same tables, and feeds that spec to
       the markdown, manpage and completion generators. The remaining items in
       **Trying the fleet** are about the _other_ CLIs, not this one.
-- [ ] **communique, tak, aube, hk, and fnox** — five typed fleet rewrites, each
+- [~] **communique, tak, aube, hk, and fnox** — five fleet experiment PRs now
+      exist, each
       carried as a ready-for-review experimental PR on a git dependency until
-      usage 6.x exists. tak cannot emit a spec today; adding a `usage` subcommand
-      (or `--usage-spec`) is experiment-only and outside its preserved CLI
-      contract. Every missing usage feature and every general clap-compatibility
-      gap found while converting them goes into a stacked follow-up to this plan
+      usage 6.x exists. communique and tak parse their real typed commands with
+      usage and compile; tak's added spec endpoint is experiment-only and outside
+      its preserved CLI contract. aube, hk and fnox have their real derives and
+      dependencies converted, not shadows, but do not compile against the current
+      usage revision. The gaps found are recorded in the general launch gate
+      above; closing them and finishing those three typed rewrites is required
       before 6.x is published.
 - [ ] **mise** — the largest and least forgiving adopter. Likely a router first, then
       commands lowered a few at a time, with mise's e2e argv corpus replayed against both

--- a/PLAN.md
+++ b/PLAN.md
@@ -577,15 +577,6 @@ feature list is not an exhaustive audit.
       derive applies the default, but help, spec consumers and differential
       tooling see a required shape. A default satisfies a field; it must not
       make the user's token required in the static metadata.
-- [ ] **Keep emitted parser settings consumable by the documentation toolchain.**
-      The typed tak rewrite correctly opts into strict parsing with
-      `unknown_flags="error"`, but `Cli::to_kdl()` emits an `unknown_flags`
-      root node that the published usage 5.1 CLI rejects as an unsupported spec
-      key. Until every renderer in the 6.x toolchain reads the same schema, an
-      adopter cannot regenerate checked-in docs from its new canonical metadata.
-      Version the schema boundary, test derive output through usage-cli, and
-      either model parser settings in `Spec` or keep runtime-only settings out of
-      portable KDL.
 - [ ] **Rust expressions for compile-time metadata.** hk and fnox use constants
       for defaults, aube and hk use constants for long help, and all three use
       generated or computed version strings. Requiring every value to be copied

--- a/PLAN.md
+++ b/PLAN.md
@@ -589,6 +589,26 @@ feature list is not an exhaustive audit.
       forcing two identical structs. `flatten` solves shared fields within a
       command but not a whole command body shared under two names. Either support
       this directly or document the duplication as an architectural constraint.
+- [ ] **Inline struct-style subcommand variants.** aube and hk use clap enums
+      whose variants declare fields directly. usage requires every non-bare
+      variant to wrap one dedicated Args struct, turning a mechanical migration
+      into a broad public-type refactor before argv behavior can even be tested.
+      Accept inline variants or provide a migration lowering that preserves the
+      user's enum shape.
+- [ ] **ValueEnum must coexist with domain parsing and cfg.** aube and fnox enums
+      already implement `FromStr`; deriving usage `ValueEnum` adds a conflicting
+      implementation. fnox also cfg-gates individual variants, while usage's
+      const word list refuses holes. ValueEnum should describe choices without
+      taking ownership of domain parsing, and cfg-gated variants need a sound
+      static-table representation.
+- [ ] **Flag aliases in the derive.** aube declares secondary flag spellings.
+      Static metadata can carry aliases, but a usage field accepts neither
+      `alias` nor clap's `visible_alias`, so the typed authoring surface cannot
+      express the spec it is meant to define.
+- [ ] **Command-with-arguments completion hints.** fnox uses
+      `ValueHint::CommandWithArguments` for forwarded argv. usage accepts only
+      file, path and directory hints today. Add the command/argv cases or record
+      them as an explicit completion non-goal before claiming clap coverage.
 - [ ] **Version omission and dynamic version policy.** tak intentionally removes
       the package version from its generated spec so release-plz version-only PRs
       do not dirty generated docs; hk computes a richer version string. Specify
@@ -761,11 +781,13 @@ looking at the clap surface, not only at the spec.
       deliberately points at usage's git revision; the PR is evidence for the
       6.x gate, not something to merge before usage 6.x is published. Together
       they tell us whether the fleet is a rewrite or a set of blocked rewrites.
-      **The experiment PRs now exist:** communique#265 and tak#47 are typed
-      rewrites; aube#1336, hk#1211 and fnox#725 are compileable static-table
-      shadows plus inventories of their real typed surfaces. The latter three
-      still need their clap dispatch replaced before this box closes. All five
-      pin `jdx/usage` at `cc60dcb7`.
+      **The experiment PRs now exist and all five modify the real CLI:**
+      jdx/communique#265 and jdx/tak#47 compile (tak's full suite passes);
+      jdx/aube#1336, jdx/hk#1211 and jdx/fnox#725 remove the clap dependency and
+      convert the real derives, but stop on 194, 490 and 326 compiler diagnostics
+      respectively, including cascades. Their migration-status files group those
+      failures into the launch-gate rows above. All five pin `jdx/usage` at
+      `cc60dcb7`.
 - [x] **The clap-only validation behaviour the fleet actually uses.** Portable
       `validate` expressions cover numeric ranges in the typed rewrite. Arbitrary clap
       parser functions remain opaque to `clap_usage`, but they no longer require a

--- a/PLAN.md
+++ b/PLAN.md
@@ -778,25 +778,25 @@ looking at the clap surface, not only at the spec.
       `render:usage-cli-completions` already does this for `usage`; the gate
       now asks it of a clap CLI.
 - [~] **Typed rewrites of communique, tak, aube, hk, and fnox, not String
-      shadows.** `gen-shadow`
-      types every field as `String`. The derive already holds `PathBuf`,
-      `OsString`, `ValueEnum`, `FromStr`, `flatten`, `Option`/`Vec`. usage-cli
-      proves that for usage's own types. These five will prove it across real
-      clap CLIs rewritten in place: real field types, skip-fields or the split
-      they force, and binaries that preserve every pre-existing `--help` and
-      spec-emission entry point. tak's experiment-only spec entry point is tested
-      as new behavior rather than compared with a nonexistent baseline. Each
-      experiment is a ready-for-review PR whose `Cargo.toml`
-      deliberately points at usage's git revision; the PR is evidence for the
-      6.x gate, not something to merge before usage 6.x is published. Together
-      they tell us whether the fleet is a rewrite or a set of blocked rewrites.
-      **The experiment PRs now exist and all five modify the real CLI:**
-      jdx/communique#265 and jdx/tak#47 compile (tak's full suite passes);
-      jdx/aube#1336, jdx/hk#1211 and jdx/fnox#725 remove the clap dependency and
-      convert the real derives, but stop on 194, 490 and 326 compiler diagnostics
-      respectively, including cascades. Their migration-status files group those
-      failures into the launch-gate rows above. All five pin `jdx/usage` at
-      `cc60dcb7`.
+  shadows.** `gen-shadow`
+  types every field as `String`. The derive already holds `PathBuf`,
+  `OsString`, `ValueEnum`, `FromStr`, `flatten`, `Option`/`Vec`. usage-cli
+  proves that for usage's own types. These five will prove it across real
+  clap CLIs rewritten in place: real field types, skip-fields or the split
+  they force, and binaries that preserve every pre-existing `--help` and
+  spec-emission entry point. tak's experiment-only spec entry point is tested
+  as new behavior rather than compared with a nonexistent baseline. Each
+  experiment is a ready-for-review PR whose `Cargo.toml`
+  deliberately points at usage's git revision; the PR is evidence for the
+  6.x gate, not something to merge before usage 6.x is published. Together
+  they tell us whether the fleet is a rewrite or a set of blocked rewrites.
+  **The experiment PRs now exist and all five modify the real CLI:**
+  jdx/communique#265 and jdx/tak#47 compile (tak's full suite passes);
+  jdx/aube#1336, jdx/hk#1211 and jdx/fnox#725 remove the clap dependency and
+  convert the real derives, but stop on 194, 490 and 326 compiler diagnostics
+  respectively, including cascades. Their migration-status files group those
+  failures into the launch-gate rows above. All five pin `jdx/usage` at
+  `cc60dcb7`.
 - [x] **The clap-only validation behaviour the fleet actually uses.** Portable
       `validate` expressions cover numeric ranges in the typed rewrite. Arbitrary clap
       parser functions remain opaque to `clap_usage`, but they no longer require a
@@ -839,15 +839,15 @@ a prerequisite for trying a CLI.
       the markdown, manpage and completion generators. The remaining items in
       **Trying the fleet** are about the _other_ CLIs, not this one.
 - [~] **communique, tak, aube, hk, and fnox** — five fleet experiment PRs now
-      exist, each
-      carried as a ready-for-review experimental PR on a git dependency until
-      usage 6.x exists. communique and tak parse their real typed commands with
-      usage and compile; tak's added spec endpoint is experiment-only and outside
-      its preserved CLI contract. aube, hk and fnox have their real derives and
-      dependencies converted, not shadows, but do not compile against the current
-      usage revision. The gaps found are recorded in the general launch gate
-      above; closing them and finishing those three typed rewrites is required
-      before 6.x is published.
+  exist, each
+  carried as a ready-for-review experimental PR on a git dependency until
+  usage 6.x exists. communique and tak parse their real typed commands with
+  usage and compile; tak's added spec endpoint is experiment-only and outside
+  its preserved CLI contract. aube, hk and fnox have their real derives and
+  dependencies converted, not shadows, but do not compile against the current
+  usage revision. The gaps found are recorded in the general launch gate
+  above; closing them and finishing those three typed rewrites is required
+  before 6.x is published.
 - [ ] **mise** — the largest and least forgiving adopter. Likely a router first, then
       commands lowered a few at a time, with mise's e2e argv corpus replayed against both
       parsers. Adoption is measured by what it lets mise delete, listed below.


### PR DESCRIPTION
## Summary

- record results from real clap-to-usage conversions of communique, tak, aube, hk, and fnox
- distinguish the two compiling conversions from the three blocked typed conversions
- add 6.x blockers for default metadata, expression attributes, shared Args, inline variants, ValueEnum coexistence, flag aliases, completion hints, and version policy
- retain broader clap-compatibility findings even when they are not specific to the jdx fleet

## Fleet evidence

- communique#265: compiles
- tak#47: compiles and tests pass
- aube#1336: real conversion, blocked with 194 diagnostics including cascades
- hk#1211: real conversion, blocked with 490 diagnostics including cascades
- fnox#725: real conversion, blocked with 326 diagnostics including cascades

This PR is the second layer of GitHub Stack #1052 and is based on #1050.

## Validation

- `git diff --check`
- evidence copied from each conversion branch’s actual `cargo check` result

_This PR was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to PLAN.md; no runtime, API, or build behavior changes.
> 
> **Overview**
> **PLAN.md** now captures what the five fleet typed-rewrite experiment PRs proved, and turns their compiler failures into explicit **6.x launch-gate** work.
> 
> Under **General clap launch gate**, eight new unchecked items document gaps from tak, aube, hk, and fnox: defaults must not look required in emitted KDL metadata; derive attributes need **`expr`** for constants and computed versions; shared **`Args`** across subcommands; inline clap-style enum variants; **`ValueEnum`** without conflicting **`FromStr`** / cfg holes; flag **`alias`** on fields; **`CommandWithArguments`** completion hints; and static vs omitted vs dynamic **version** policy.
> 
> **Trying the fleet** and **After the gate** move the five-CLI typed rewrite from open **`[ ]`** to partial **`[~]`**: communique and tak compile on real derives (tak tests pass); aube, hk, and fnox have clap removed and real conversions in place but fail with 194 / 490 / 326 diagnostics, grouped in migration-status files and pinned to **`jdx/usage` `cc60dcb7`**. Finishing those three rewrites and closing the new gate rows is stated as required before **6.x**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd825327e1679194d0ec313bdf18531b5626bb97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->