### PR TITLE
test(spec): verify portable parser settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,6 +2510,7 @@ version = "5.1.0"
 dependencies = [
  "usage-argv",
  "usage-derive",
+ "usage-lib",
  "usage-validation",
 ]
 

--- a/usage-rs/Cargo.toml
+++ b/usage-rs/Cargo.toml
@@ -32,3 +32,6 @@ validation = ["dep:usage-validation"]
 [package.metadata.release]
 shared-version = true
 release = true
+
+[dev-dependencies]
+usage-parser = { package = "usage-lib", path = "../lib" }

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -35,6 +35,10 @@ struct ChoiceEx {
     shell: Shell,
 }
 
+#[derive(Cli)]
+#[usage(bin = "strict-ex", unknown_flags = "error")]
+struct StrictEx {}
+
 /// Show one file
 #[derive(Args)]
 struct Show {
@@ -91,4 +95,21 @@ fn emitted_specs_preserve_value_enum_aliases_and_case_policy() {
     let kdl = ChoiceEx::to_kdl();
     assert!(kdl.contains("choices ignore_case=#true"), "{kdl}");
     assert!(kdl.contains("alias \"shell-z\" hide=#true"), "{kdl}");
+}
+
+#[test]
+fn emitted_parser_settings_are_portable_spec_metadata() {
+    let Err(_) = StrictEx::parse_from(&[OsStr::new("--wat")]) else {
+        panic!("strict parsing should reject an unknown flag");
+    };
+
+    let kdl = StrictEx::to_kdl();
+    assert!(kdl.contains("unknown_flags \"error\""), "{kdl}");
+
+    let spec: usage_parser::Spec = kdl.parse().expect("usage-lib should read derive output");
+    assert_eq!(
+        spec.unknown_flags,
+        Some(usage_parser::UnknownFlags::Error),
+        "the portable spec should retain the runtime setting"
+    );
 }


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes and a dev-dependency; no production parsing or spec behavior is modified.
> 
> **Overview**
> Adds an integration test on the `usage-rs` facade that **derive-emitted KDL keeps parser settings** such as `unknown_flags = "error"` as portable spec metadata, not just runtime behavior.
> 
> The test defines a strict CLI (`StrictEx`), asserts unknown flags fail at parse time, checks the generated KDL includes `unknown_flags "error"`, and round-trips that KDL through **`usage-lib`** to confirm `Spec.unknown_flags` is `Error`. **`usage-lib`** is wired in as a **dev-dependency** only for this assertion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40b369d49c56edec37cb524b9f053db282316820. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->