### PR TITLE
fix(derive): separate value metadata from parsing

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -595,12 +595,12 @@ feature list is not an exhaustive audit.
       into a broad public-type refactor before argv behavior can even be tested.
       Accept inline variants or provide a migration lowering that preserves the
       user's enum shape.
-- [ ] **ValueEnum must coexist with domain parsing and cfg.** aube and fnox enums
+- [x] **ValueEnum must coexist with domain parsing and cfg.** aube and fnox enums
       already implement `FromStr`; deriving usage `ValueEnum` adds a conflicting
       implementation. fnox also cfg-gates individual variants, while usage's
-      const word list refuses holes. ValueEnum should describe choices without
-      taking ownership of domain parsing, and cfg-gated variants need a sound
-      static-table representation.
+      const word list refused holes. ValueEnum now describes choices without
+      taking ownership of domain parsing, and copies variant `cfg`/`cfg_attr`
+      attributes onto the corresponding static-table entries.
 - [ ] **Flag aliases in the derive.** aube declares secondary flag spellings.
       Static metadata can carry aliases, but a usage field accepts neither
       `alias` nor clap's `visible_alias`, so the typed authoring surface cannot

--- a/cli/src/cli/lint.rs
+++ b/cli/src/cli/lint.rs
@@ -42,6 +42,18 @@ enum OutputFormat {
     Json,
 }
 
+impl std::str::FromStr for OutputFormat {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "text" => Ok(Self::Text),
+            "json" => Ok(Self::Json),
+            _ => Err(format!("`{value}` is not one of: text, json")),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Severity {

--- a/conformance/tests/typed.rs
+++ b/conformance/tests/typed.rs
@@ -266,6 +266,23 @@ enum Interpreter {
     PowerShell,
 }
 
+#[derive(usage_derive::ValueEnum)]
+enum DocumentedChoice {
+    #[cfg_attr(
+        all(),
+        doc = "Documentation belongs to the variant, not generated arrays"
+    )]
+    Visible,
+}
+
+#[test]
+fn non_gating_cfg_attr_stays_off_generated_choice_entries() {
+    use usage_argv::spec::ValueEnum as _;
+
+    let _ = DocumentedChoice::Visible;
+    assert_eq!(DocumentedChoice::CHOICES, ["visible"]);
+}
+
 impl std::str::FromStr for Interpreter {
     type Err = String;
 

--- a/conformance/tests/typed.rs
+++ b/conformance/tests/typed.rs
@@ -266,6 +266,26 @@ enum Interpreter {
     PowerShell,
 }
 
+impl std::str::FromStr for Interpreter {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if value.eq_ignore_ascii_case("bash") {
+            Ok(Self::Bash)
+        } else if value.eq_ignore_ascii_case("zsh") || value.eq_ignore_ascii_case("shell-z") {
+            Ok(Self::Zsh)
+        } else if value.eq_ignore_ascii_case("fish") {
+            Ok(Self::Fish)
+        } else if value.eq_ignore_ascii_case("pwsh") {
+            Ok(Self::PowerShell)
+        } else {
+            Err(format!(
+                "invalid interpreter {value:?}; expected one of bash, zsh, fish, pwsh"
+            ))
+        }
+    }
+}
+
 /// A CLI with an enumerated value
 #[derive(Cli)]
 #[usage(bin = "enumerated")]

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -4512,59 +4512,34 @@ fn post_binding(cli: &Cli) -> TokenStream {
     }
 }
 
-/// The word list and the conversion for a value enum.
+/// The word list for a value enum.
 ///
-/// Two impls and nothing else: the words as a `const` the spec can read, and the `FromStr`
-/// that every typed field already goes through. Deliberately not a bespoke path — a value
-/// enum is a type whose values happen to be listed, so it converts the way any other type
-/// does, and the check that rejects a wrong word is the same `choices` check as a
-/// hand-written list.
+/// Conversion remains the type's own `FromStr` implementation, like every other typed
+/// field. This derive owns only CLI metadata, so it can coexist with a domain parser whose
+/// accepted syntax or error type is broader than the choices presented in help.
 pub fn emit_value_enum(value_enum: &ValueEnum) -> TokenStream {
     let ident = &value_enum.ident;
     let runtime = runtime_path();
-    let words: Vec<&String> = value_enum
-        .variants
-        .iter()
-        .map(|value| &value.name)
-        .collect();
-    let accepted: Vec<&String> = value_enum
-        .variants
-        .iter()
-        .flat_map(|value| ::std::iter::once(&value.name).chain(value.aliases.iter()))
-        .collect();
+    let words = value_enum.variants.iter().map(|value| {
+        let word = &value.name;
+        let cfg = &value.cfg_attrs;
+        quote!(#(#cfg)* #word)
+    });
+    let accepted = value_enum.variants.iter().flat_map(|value| {
+        let cfg = &value.cfg_attrs;
+        ::std::iter::once(&value.name)
+            .chain(value.aliases.iter())
+            .map(move |word| quote!(#(#cfg)* #word))
+    });
     let aliases = value_enum.variants.iter().flat_map(|value| {
         let canonical = &value.name;
+        let cfg = &value.cfg_attrs;
         value
             .aliases
             .iter()
-            .map(move |alias| quote!((#canonical, #alias)))
+            .map(move |alias| quote!(#(#cfg)* (#canonical, #alias)))
     });
     let ignore_case = value_enum.ignore_case;
-    let arms = value_enum.variants.iter().map(|value| {
-        let variant = &value.ident;
-        let names = ::std::iter::once(&value.name).chain(value.aliases.iter());
-        if ignore_case {
-            quote! {
-                if [#(#names),*].iter().any(|word| word.eq_ignore_ascii_case(value)) {
-                    return ::std::result::Result::Ok(#ident::#variant);
-                }
-            }
-        } else {
-            quote! {
-                if [#(#names),*].contains(&value) {
-                    return ::std::result::Result::Ok(#ident::#variant);
-                }
-            }
-        }
-    });
-    // Listed in the message because a wrong word is the common mistake, and the words are
-    // right here. The `choices` check usually reports this first, with the same list; this
-    // is what a caller sees who converts one by hand.
-    let expected = words
-        .iter()
-        .map(|w| w.as_str())
-        .collect::<::std::vec::Vec<_>>()
-        .join(", ");
 
     quote! {
         #[doc(hidden)]
@@ -4576,18 +4551,6 @@ pub fn emit_value_enum(value_enum: &ValueEnum) -> TokenStream {
                 const ACCEPTED_CHOICES: &'static [&'static str] = &[#(#accepted),*];
                 const ALIASES: &'static [(&'static str, &'static str)] = &[#(#aliases),*];
                 const IGNORE_CASE: bool = #ignore_case;
-            }
-
-            impl ::std::str::FromStr for #ident {
-                type Err = ::std::string::String;
-
-                fn from_str(value: &str) -> ::std::result::Result<Self, Self::Err> {
-                    #(#arms)*
-                    ::std::result::Result::Err(::std::format!(
-                        "`{value}` is not one of: {}",
-                        #expected
-                    ))
-                }
             }
         };
     }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -374,9 +374,9 @@ pub fn derive_subcommands(input: TokenStream) -> TokenStream {
 ///
 /// `#[usage(ignore_case)]` on the enum applies to canonical words and aliases.
 ///
-/// A variant cannot be `cfg`-ed out: the words are a `const` list, and a list with holes
-/// in it would either offer a word nothing answers to or name a variant that is not there.
-/// `cfg` the whole enum instead.
+/// The enum must implement [`FromStr`](std::str::FromStr); this derive owns only its CLI
+/// word metadata and does not replace domain parsing. Variant `cfg` and `cfg_attr`
+/// attributes are copied to their entries in the static word tables.
 ///
 /// A field holding one says `value_enum`, which is what puts the words in the spec — so
 /// help, completions and the check that rejects a wrong word all read the same list, and

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -3319,6 +3319,59 @@ pub struct ValueVariant {
     pub cfg_attrs: Vec<syn::Attribute>,
 }
 
+fn cfg_variants_are_disjoint(left: &[Attribute], right: &[Attribute]) -> bool {
+    let left = left
+        .iter()
+        .filter(|attr| attr.path().is_ident("cfg"))
+        .filter_map(|attr| attr.parse_args::<Meta>().ok())
+        .collect::<Vec<_>>();
+    let right = right
+        .iter()
+        .filter(|attr| attr.path().is_ident("cfg"))
+        .filter_map(|attr| attr.parse_args::<Meta>().ok())
+        .collect::<Vec<_>>();
+
+    left.iter()
+        .any(|a| right.iter().any(|b| cfg_predicates_are_disjoint(a, b)))
+}
+
+fn cfg_predicates_are_disjoint(left: &Meta, right: &Meta) -> bool {
+    let tokens_equal = |a: &Meta, b: &Meta| {
+        quote::ToTokens::to_token_stream(a).to_string()
+            == quote::ToTokens::to_token_stream(b).to_string()
+    };
+    let negates = |outer: &Meta, inner: &Meta| {
+        let Meta::List(list) = outer else {
+            return false;
+        };
+        list.path.is_ident("not")
+            && list
+                .parse_args::<Meta>()
+                .is_ok_and(|value| tokens_equal(&value, inner))
+    };
+    if negates(left, right) || negates(right, left) {
+        return true;
+    }
+    if matches!((left, right), (Meta::Path(a), Meta::Path(b)) if
+        (a.is_ident("unix") && b.is_ident("windows"))
+            || (a.is_ident("windows") && b.is_ident("unix")))
+    {
+        return true;
+    }
+    match (left, right) {
+        (Meta::NameValue(a), Meta::NameValue(b))
+            if a.path
+                .get_ident()
+                .zip(b.path.get_ident())
+                .is_some_and(|(a, b)| a == b && a.to_string().starts_with("target_")) =>
+        {
+            quote::ToTokens::to_token_stream(&a.value).to_string()
+                != quote::ToTokens::to_token_stream(&b.value).to_string()
+        }
+        _ => false,
+    }
+}
+
 impl ValueEnum {
     pub fn from_input(input: &DeriveInput) -> syn::Result<Self> {
         let Data::Enum(data) = &input.data else {
@@ -3414,19 +3467,20 @@ impl ValueEnum {
             ));
         }
 
-        let mut seen: Vec<(&str, Span)> = Vec::new();
+        let mut seen: Vec<(&str, Span, &[Attribute])> = Vec::new();
         for variant in &variants {
             for word in ::std::iter::once(variant.name.as_str())
                 .chain(variant.aliases.iter().map(String::as_str))
             {
-                let collision = seen.iter().find(|(seen, _)| {
-                    if ignore_case {
+                let collision = seen.iter().find(|(seen, _, cfg)| {
+                    let same = if ignore_case {
                         seen.eq_ignore_ascii_case(word)
                     } else {
                         *seen == word
-                    }
+                    };
+                    same && !cfg_variants_are_disjoint(cfg, &variant.cfg_attrs)
                 });
-                if let Some((_, first_span)) = collision {
+                if let Some((_, first_span, _)) = collision {
                     return Err(dup(
                         variant.ident.span(),
                         *first_span,
@@ -3440,7 +3494,7 @@ impl ValueEnum {
                         ),
                     ));
                 }
-                seen.push((word, variant.ident.span()));
+                seen.push((word, variant.ident.span(), &variant.cfg_attrs));
             }
         }
 
@@ -4123,6 +4177,23 @@ mod tests {
         .expect("conditional variants should compile");
         assert!(value.variants[0].cfg_attrs.is_empty());
         assert_eq!(value.variants[1].cfg_attrs.len(), 1);
+    }
+
+    #[test]
+    fn cfg_disjoint_values_may_reuse_one_cli_word() {
+        value_enum(
+            r#"
+            enum Shell {
+                #[cfg(windows)]
+                #[usage(name = "native")]
+                Windows,
+                #[cfg(not(windows))]
+                #[usage(name = "native")]
+                Unix,
+            }
+        "#,
+        )
+        .expect("only one cfg-disjoint word exists on any target");
     }
 
     /// The position rules, which each derive applies for the place it stands in.

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -6,6 +6,7 @@
 
 use proc_macro2::Span;
 use syn::ext::IdentExt as _;
+use syn::parse::Parser as _;
 use syn::spanned::Spanned;
 use syn::{Attribute, Data, DeriveInput, Expr, ExprLit, Fields, Lit, Meta, Type};
 
@@ -3319,6 +3320,51 @@ pub struct ValueVariant {
     pub cfg_attrs: Vec<syn::Attribute>,
 }
 
+fn cfg_gate_meta(meta: &Meta) -> syn::Result<Option<Meta>> {
+    if meta.path().is_ident("cfg") {
+        return Ok(Some(meta.clone()));
+    }
+    if !meta.path().is_ident("cfg_attr") {
+        return Ok(None);
+    }
+    let Meta::List(list) = meta else {
+        return Ok(None);
+    };
+    let nested = syn::punctuated::Punctuated::<Meta, syn::Token![,]>::parse_terminated
+        .parse2(list.tokens.clone())?;
+    let mut nested = nested.into_iter();
+    let Some(condition) = nested.next() else {
+        return Ok(None);
+    };
+    let gates = nested
+        .map(|meta| cfg_gate_meta(&meta))
+        .collect::<syn::Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    if gates.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(syn::parse2(quote::quote!(
+        cfg_attr(#condition, #(#gates),*)
+    ))?))
+}
+
+fn cfg_gate_attrs(attrs: &[Attribute]) -> syn::Result<Vec<Attribute>> {
+    attrs
+        .iter()
+        .filter_map(|attr| match cfg_gate_meta(&attr.meta) {
+            Ok(Some(meta)) => {
+                let mut attr = attr.clone();
+                attr.meta = meta;
+                Some(Ok(attr))
+            }
+            Ok(None) => None,
+            Err(err) => Some(Err(err)),
+        })
+        .collect()
+}
+
 fn cfg_variants_are_disjoint(left: &[Attribute], right: &[Attribute]) -> bool {
     let left = left
         .iter()
@@ -3426,12 +3472,7 @@ impl ValueEnum {
                      fields would have nothing to build them from",
                 ));
             }
-            let cfg_attrs = variant
-                .attrs
-                .iter()
-                .filter(|a| a.path().is_ident("cfg") || a.path().is_ident("cfg_attr"))
-                .cloned()
-                .collect();
+            let cfg_attrs = cfg_gate_attrs(&variant.attrs)?;
             let mut name = to_kebab(&variant.ident.unraw().to_string());
             let mut aliases = Vec::new();
             for attr in attrs(&variant.attrs) {
@@ -4191,6 +4232,27 @@ mod tests {
         .expect("conditional variants should compile");
         assert!(value.variants[0].cfg_attrs.is_empty());
         assert_eq!(value.variants[1].cfg_attrs.len(), 1);
+    }
+
+    #[test]
+    fn cfg_attr_keeps_only_variant_gates_for_static_emission() {
+        let value = value_enum(
+            r#"
+            enum Shell {
+                #[cfg_attr(windows, cfg(target_pointer_width = "64"), doc = "Windows shell")]
+                PowerShell,
+                #[cfg_attr(all(), doc = "Unix shell")]
+                Bash,
+            }
+        "#,
+        )
+        .expect("non-gating cfg_attr metadata should be ignored");
+        assert_eq!(value.variants[0].cfg_attrs.len(), 1);
+        let emitted = quote::ToTokens::to_token_stream(&value.variants[0].cfg_attrs[0]).to_string();
+        assert!(emitted.contains("cfg_attr"));
+        assert!(emitted.contains("target_pointer_width"));
+        assert!(!emitted.contains("doc"));
+        assert!(value.variants[1].cfg_attrs.is_empty());
     }
 
     #[test]

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -3363,7 +3363,21 @@ fn cfg_predicates_are_disjoint(left: &Meta, right: &Meta) -> bool {
             if a.path
                 .get_ident()
                 .zip(b.path.get_ident())
-                .is_some_and(|(a, b)| a == b && a.to_string().starts_with("target_")) =>
+                .is_some_and(|(a, b)| {
+                    a == b
+                        && [
+                            "target_abi",
+                            "target_arch",
+                            "target_endian",
+                            "target_env",
+                            "target_os",
+                            "target_pointer_width",
+                            "target_vendor",
+                            "panic",
+                        ]
+                        .iter()
+                        .any(|exclusive| a == exclusive)
+                }) =>
         {
             quote::ToTokens::to_token_stream(&a.value).to_string()
                 != quote::ToTokens::to_token_stream(&b.value).to_string()
@@ -4194,6 +4208,30 @@ mod tests {
         "#,
         )
         .expect("only one cfg-disjoint word exists on any target");
+    }
+
+    #[test]
+    fn independently_true_target_cfgs_may_not_reuse_one_cli_word() {
+        let result = value_enum(
+            r#"
+            enum AtomicWidth {
+                #[cfg(target_has_atomic = "8")]
+                #[usage(name = "native")]
+                Eight,
+                #[cfg(target_has_atomic = "16")]
+                #[usage(name = "native")]
+                Sixteen,
+            }
+        "#,
+        );
+        let Err(err) = result else {
+            panic!("a target may support both atomic widths")
+        };
+        let err = err.to_string();
+        assert!(
+            err.contains("names two of these values"),
+            "unhelpful: {err}"
+        );
     }
 
     /// The position rules, which each derive applies for the place it stands in.

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -3316,6 +3316,7 @@ pub struct ValueVariant {
     pub ident: syn::Ident,
     pub name: String,
     pub aliases: Vec<String>,
+    pub cfg_attrs: Vec<syn::Attribute>,
 }
 
 impl ValueEnum {
@@ -3358,22 +3359,12 @@ impl ValueEnum {
                      fields would have nothing to build them from",
                 ));
             }
-            // A variant that may not exist cannot be listed. `CHOICES` is a `const` array and
-            // an array literal takes no attributes on its elements, so a `cfg`-ed-out
-            // variant would either leave a word in the list that nothing answers to, or an
-            // arm referring to a variant that is not there. Refused rather than
-            // miscompiled; `cfg` the whole enum, or keep the words and map them yourself.
-            if let Some(cfg) = variant
+            let cfg_attrs = variant
                 .attrs
                 .iter()
-                .find(|a| a.path().is_ident("cfg") || a.path().is_ident("cfg_attr"))
-            {
-                return Err(syn::Error::new_spanned(
-                    cfg,
-                    "a value's variants are a `const` list of words, which cannot have holes \
-                     in it: `cfg` the whole enum instead",
-                ));
-            }
+                .filter(|a| a.path().is_ident("cfg") || a.path().is_ident("cfg_attr"))
+                .cloned()
+                .collect();
             let mut name = to_kebab(&variant.ident.unraw().to_string());
             let mut aliases = Vec::new();
             for attr in attrs(&variant.attrs) {
@@ -3413,6 +3404,7 @@ impl ValueEnum {
                 ident: variant.ident.clone(),
                 name,
                 aliases,
+                cfg_attrs,
             });
         }
         if variants.is_empty() {
@@ -4118,10 +4110,8 @@ mod tests {
     }
 
     #[test]
-    fn a_conditional_value_is_refused_rather_than_miscompiled() {
-        // The word list is a `const` array, so a variant that may not exist would leave
-        // either a word nothing answers to or an arm naming a variant that is not there.
-        let err = match value_enum(
+    fn a_conditional_value_keeps_its_cfg_for_static_emission() {
+        let value = value_enum(
             r#"
             enum Shell {
                 Bash,
@@ -4129,14 +4119,10 @@ mod tests {
                 PowerShell,
             }
         "#,
-        ) {
-            Ok(_) => panic!("should not have compiled"),
-            Err(e) => e.to_string(),
-        };
-        assert!(
-            err.contains("cannot have holes"),
-            "unhelpful message: {err}"
-        );
+        )
+        .expect("conditional variants should compile");
+        assert!(value.variants[0].cfg_attrs.is_empty());
+        assert_eq!(value.variants[1].cfg_attrs.len(), 1);
     }
 
     /// The position rules, which each derive applies for the place it stands in.

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -26,6 +26,22 @@ enum Shell {
     Bash,
     #[usage(alias = "shell-z")]
     Zsh,
+    #[cfg(windows)]
+    PowerShell,
+}
+
+impl std::str::FromStr for Shell {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if value.eq_ignore_ascii_case("bash") {
+            Ok(Self::Bash)
+        } else if value.eq_ignore_ascii_case("zsh") || value.eq_ignore_ascii_case("shell-z") {
+            Ok(Self::Zsh)
+        } else {
+            Err(format!("unsupported shell: {value}"))
+        }
+    }
 }
 
 #[derive(Cli)]
@@ -95,6 +111,8 @@ fn emitted_specs_preserve_value_enum_aliases_and_case_policy() {
     let kdl = ChoiceEx::to_kdl();
     assert!(kdl.contains("choices ignore_case=#true"), "{kdl}");
     assert!(kdl.contains("alias \"shell-z\" hide=#true"), "{kdl}");
+    #[cfg(not(windows))]
+    assert!(!kdl.contains("power-shell"), "{kdl}");
 }
 
 #[test]

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -34,6 +34,10 @@ impl std::str::FromStr for Shell {
     type Err = String;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
+        #[cfg(windows)]
+        if value.eq_ignore_ascii_case("power-shell") {
+            return Ok(Self::PowerShell);
+        }
         if value.eq_ignore_ascii_case("bash") {
             Ok(Self::Bash)
         } else if value.eq_ignore_ascii_case("zsh") || value.eq_ignore_ascii_case("shell-z") {

--- a/usage-rs/tests/fixtures/workspace-inheritance/src/main.rs
+++ b/usage-rs/tests/fixtures/workspace-inheritance/src/main.rs
@@ -8,6 +8,18 @@ enum Shell {
     Zsh,
 }
 
+impl std::str::FromStr for Shell {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "bash" => Ok(Self::Bash),
+            "zsh" => Ok(Self::Zsh),
+            _ => Err(format!("unsupported shell: {value}")),
+        }
+    }
+}
+
 #[derive(Cli)]
 #[usage(bin = "ex")]
 struct Ex {


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes for enums that relied on derived `FromStr` without an explicit impl (compile failures until fixed); cfg-aware duplicate detection is heuristic and could mis-allow or mis-reject edge cases.
> 
> **Overview**
> **`ValueEnum` is metadata-only.** The derive no longer emits `impl FromStr`; types must supply their own parser, like other typed fields. Help, completions, and choice checks still read the static `CHOICES` / alias tables from the `ValueEnum` trait impl.
> 
> **Cfg-gated variants are allowed.** Variant `cfg` / `cfg_attr` gates are copied onto static table entries instead of being rejected, and duplicate CLI words are permitted when the variants’ cfg predicates are disjoint (e.g. `#[cfg(windows)]` vs `#[cfg(not(windows))]`).
> 
> Call sites and tests add hand-written `FromStr` implementations (`lint`’s `OutputFormat`, conformance `Interpreter`, facade `Shell`, etc.). **PLAN.md** marks the fleet launch-gate item for ValueEnum + domain parsing as done.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 704bc20743e90a5aa34c982384d2a2f8b2b31e0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->