### PR TITLE
feat(derive): support inline subcommand fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2508,6 +2508,7 @@ dependencies = [
 name = "usage-rs"
 version = "5.1.0"
 dependencies = [
+ "serde",
  "usage-argv",
  "usage-derive",
  "usage-lib",

--- a/PLAN.md
+++ b/PLAN.md
@@ -589,12 +589,14 @@ feature list is not an exhaustive audit.
       forcing two identical structs. `flatten` solves shared fields within a
       command but not a whole command body shared under two names. Either support
       this directly or document the duplication as an architectural constraint.
-- [ ] **Inline struct-style subcommand variants.** aube and hk use clap enums
+- [x] **Inline struct-style subcommand variants.** aube and hk use clap enums
       whose variants declare fields directly. usage requires every non-bare
       variant to wrap one dedicated Args struct, turning a mechanical migration
       into a broad public-type refactor before argv behavior can even be tested.
-      Accept inline variants or provide a migration lowering that preserves the
-      user's enum shape.
+      The Subcommands derive now lowers inline variants to hidden Args structs and
+      moves the bound fields back into the original enum shape. It accepts both
+      native `usage` field attributes and clap-shaped `arg` attributes in this
+      migration form.
 - [x] **ValueEnum must coexist with domain parsing and cfg.** aube and fnox enums
       already implement `FromStr`; deriving usage `ValueEnum` adds a conflicting
       implementation. fnox also cfg-gates individual variants, while usage's

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -2945,13 +2945,13 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
     let runtime = runtime_path();
     let derive = derive_path();
 
-    // The structs the bare variants imply, written here so everything downstream keeps
-    // speaking to a struct. `Args` is derived on them rather than the impl being written out:
-    // one description of what an empty command is, and it is the one adopters already use.
-    let unit_structs = subs
+    // The structs bare and inline variants imply, written here so everything downstream keeps
+    // speaking to one Args struct. Clap-shaped `arg` attributes are rewritten to the native
+    // spelling while copying inline fields, which lets a migration keep its enum layout.
+    let generated_structs = subs
         .variants
         .iter()
-        .filter(|v| v.unit)
+        .filter(|v| v.unit || v.inline_fields.is_some())
         .map(|v| {
             let name = &v.ty;
             // Whatever the variant said about the command, written where the command's
@@ -2961,15 +2961,30 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
                 .effect
                 .as_ref()
                 .map(|word| quote!(#[usage(effect = #word)]));
+            let fields = v.inline_fields.iter().flatten().cloned().map(|mut field| {
+                for attr in &mut field.attrs {
+                    let path = match &mut attr.meta {
+                        syn::Meta::Path(path) => path,
+                        syn::Meta::List(list) => &mut list.path,
+                        syn::Meta::NameValue(value) => &mut value.path,
+                    };
+                    if path.is_ident("arg") {
+                        *path = syn::parse_quote!(usage);
+                    }
+                }
+                field
+            });
             quote! {
                 #[doc(hidden)]
                 #[derive(#derive::Args)]
                 #effect
-                pub struct #name {}
+                pub struct #name {
+                    #(#fields),*
+                }
             }
         })
         .collect::<Vec<_>>();
-    let unit_structs = unit_structs.into_iter();
+    let generated_structs = generated_structs.into_iter();
 
     // One *variant* per subcommand, not one field: a parse fills exactly one of them, and a
     // struct with room for all of them is the whole CLI's accumulator whichever command ran —
@@ -3361,6 +3376,19 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
                     let _ = #built;
                     #ident::#variant
                 }}
+            } else if let Some(fields) = &v.inline_fields {
+                let names = fields.iter().map(|field| {
+                    field
+                        .ident
+                        .as_ref()
+                        .expect("named variant fields have names")
+                });
+                quote! {{
+                    let __usage_built = #built;
+                    #ident::#variant {
+                        #(#names: __usage_built.#names),*
+                    }
+                }}
             } else {
                 quote!(#ident::#variant(#built))
             };
@@ -3379,7 +3407,7 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
     quote! {
         // Beside the enum rather than inside the generated module: the variants name these
         // types, and a type a variant cannot see is no use to it.
-        #(#unit_structs)*
+        #(#generated_structs)*
 
         #[doc(hidden)]
         #[allow(

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -2940,6 +2940,32 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
 
 /// The enum a `subcommand` field holds: its variants' tables, and the trait a
 /// parent uses to route events into them.
+fn rewrite_inline_arg_meta(meta: &mut syn::Meta) {
+    let path = match meta {
+        syn::Meta::Path(path) => path,
+        syn::Meta::List(list) => &mut list.path,
+        syn::Meta::NameValue(value) => &mut value.path,
+    };
+    if path.is_ident("arg") {
+        *path = syn::parse_quote!(usage);
+        return;
+    }
+    if !path.is_ident("cfg_attr") {
+        return;
+    }
+    let syn::Meta::List(list) = meta else {
+        return;
+    };
+    let parser = syn::punctuated::Punctuated::<syn::Meta, syn::Token![,]>::parse_terminated;
+    let Ok(mut nested) = syn::parse::Parser::parse2(parser, list.tokens.clone()) else {
+        return;
+    };
+    for value in nested.iter_mut().skip(1) {
+        rewrite_inline_arg_meta(value);
+    }
+    list.tokens = quote!(#nested);
+}
+
 pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
     let ident = &subs.ident;
     let runtime = runtime_path();
@@ -2963,14 +2989,7 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
                 .map(|word| quote!(#[usage(effect = #word)]));
             let fields = v.inline_fields.iter().flatten().cloned().map(|mut field| {
                 for attr in &mut field.attrs {
-                    let path = match &mut attr.meta {
-                        syn::Meta::Path(path) => path,
-                        syn::Meta::List(list) => &mut list.path,
-                        syn::Meta::NameValue(value) => &mut value.path,
-                    };
-                    if path.is_ident("arg") {
-                        *path = syn::parse_quote!(usage);
-                    }
+                    rewrite_inline_arg_meta(&mut attr.meta);
                 }
                 field
             });

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -2970,6 +2970,39 @@ fn rewrite_inline_arg_meta(meta: &mut syn::Meta) {
     list.tokens = quote!(#nested);
 }
 
+fn inline_field_meta(meta: &syn::Meta) -> Option<syn::Meta> {
+    if meta.path().is_ident("arg") {
+        let mut meta = meta.clone();
+        rewrite_inline_arg_meta(&mut meta);
+        return Some(meta);
+    }
+    if meta.path().is_ident("usage") || meta.path().is_ident("doc") || meta.path().is_ident("cfg") {
+        return Some(meta.clone());
+    }
+    let syn::Meta::List(list) = meta else {
+        return None;
+    };
+    if !list.path.is_ident("cfg_attr") {
+        return None;
+    }
+    let parser = syn::punctuated::Punctuated::<syn::Meta, syn::Token![,]>::parse_terminated;
+    let nested = syn::parse::Parser::parse2(parser, list.tokens.clone()).ok()?;
+    let mut nested = nested.into_iter();
+    let condition = nested.next()?;
+    let kept = nested
+        .filter_map(|meta| inline_field_meta(&meta))
+        .collect::<Vec<_>>();
+    if kept.is_empty() {
+        return None;
+    }
+    syn::parse2(quote!(cfg_attr(#condition, #(#kept),*))).ok()
+}
+
+fn inline_field_attr(attr: syn::Attribute) -> Option<syn::Attribute> {
+    let meta = inline_field_meta(&attr.meta)?;
+    Some(syn::Attribute { meta, ..attr })
+}
+
 fn meta_controls_field_presence(meta: &syn::Meta) -> bool {
     if meta.path().is_ident("cfg") {
         return true;
@@ -3007,9 +3040,11 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
                 .as_ref()
                 .map(|word| quote!(#[usage(effect = #word)]));
             let fields = v.inline_fields.iter().flatten().cloned().map(|mut field| {
-                for attr in &mut field.attrs {
-                    rewrite_inline_arg_meta(&mut attr.meta);
-                }
+                field.attrs = field
+                    .attrs
+                    .into_iter()
+                    .filter_map(inline_field_attr)
+                    .collect();
                 field
             });
             quote! {

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -3431,6 +3431,10 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
                 });
                 quote! {{
                     let __usage_built = #built;
+                    // An empty named variant, or one whose fields were all removed by cfg,
+                    // still has to run `build` for the command's checks. Mark the result used
+                    // without changing the field moves below.
+                    let _ = &__usage_built;
                     #ident::#variant {
                         #(#assignments),*
                     }

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -2941,6 +2941,10 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
 /// The enum a `subcommand` field holds: its variants' tables, and the trait a
 /// parent uses to route events into them.
 fn rewrite_inline_arg_meta(meta: &mut syn::Meta) {
+    if matches!(meta, syn::Meta::Path(path) if path.is_ident("arg")) {
+        *meta = syn::parse_quote!(usage(arg));
+        return;
+    }
     let path = match meta {
         syn::Meta::Path(path) => path,
         syn::Meta::List(list) => &mut list.path,
@@ -2964,6 +2968,21 @@ fn rewrite_inline_arg_meta(meta: &mut syn::Meta) {
         rewrite_inline_arg_meta(value);
     }
     list.tokens = quote!(#nested);
+}
+
+fn meta_controls_field_presence(meta: &syn::Meta) -> bool {
+    if meta.path().is_ident("cfg") {
+        return true;
+    }
+    let syn::Meta::List(list) = meta else {
+        return false;
+    };
+    if !list.path.is_ident("cfg_attr") {
+        return false;
+    }
+    let parser = syn::punctuated::Punctuated::<syn::Meta, syn::Token![,]>::parse_terminated;
+    syn::parse::Parser::parse2(parser, list.tokens.clone())
+        .is_ok_and(|nested| nested.iter().skip(1).any(meta_controls_field_presence))
 }
 
 pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
@@ -3396,16 +3415,24 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
                     #ident::#variant
                 }}
             } else if let Some(fields) = &v.inline_fields {
-                let names = fields.iter().map(|field| {
-                    field
+                let assignments = fields.iter().map(|field| {
+                    let name = field
                         .ident
                         .as_ref()
-                        .expect("named variant fields have names")
+                        .expect("named variant fields have names");
+                    let cfg_attrs = field
+                        .attrs
+                        .iter()
+                        .filter(|attr| meta_controls_field_presence(&attr.meta));
+                    quote! {
+                        #(#cfg_attrs)*
+                        #name: __usage_built.#name
+                    }
                 });
                 quote! {{
                     let __usage_built = #built;
                     #ident::#variant {
-                        #(#names: __usage_built.#names),*
+                        #(#assignments),*
                     }
                 }}
             } else {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -344,10 +344,9 @@ pub fn derive_args(input: TokenStream) -> TokenStream {
 
 /// Compile an enum into a set of subcommands.
 ///
-/// Each variant wraps a struct deriving [`Args`], which is where that command's
-/// flags and arguments are declared. A field holding this enum is marked
-/// `#[usage(subcommand)]`.
-#[proc_macro_derive(Subcommands, attributes(usage))]
+/// Each variant may wrap a struct deriving [`Args`] or declare its fields inline,
+/// clap-style. A field holding this enum is marked `#[usage(subcommand)]`.
+#[proc_macro_derive(Subcommands, attributes(usage, arg))]
 pub fn derive_subcommands(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     match model::Subcommands::from_input(&input) {

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -2974,6 +2974,9 @@ pub struct Variant {
     /// Only the *construction* differs — `Command::Sponsors` rather than
     /// `Command::Sponsors(x)`. Everything else goes through the struct as usual.
     pub unit: bool,
+    /// Fields declared directly on a struct-style enum variant. They are copied
+    /// into a generated Args struct, then moved back into the enum after binding.
+    pub inline_fields: Option<Vec<syn::Field>>,
     /// The struct the variant wraps, with any `Box` taken off.
     ///
     /// Everything generated speaks to the struct — its tables, its partial, its `build` —
@@ -3024,7 +3027,7 @@ impl Subcommands {
             .map(|v| Variant::from_variant(v, &input.ident))
             .collect::<syn::Result<Vec<_>>>()?;
         for v in &variants {
-            if v.effect.is_some() && !v.unit {
+            if v.effect.is_some() && !v.unit && v.inline_fields.is_none() {
                 return Err(syn::Error::new_spanned(
                     &v.ident,
                     "`effect` belongs on the struct this variant wraps, where the command's \
@@ -3240,6 +3243,7 @@ impl Variant {
                 name,
                 effect: None,
                 unit: false,
+                inline_fields: None,
                 ty: held,
                 boxed: false,
                 external: true,
@@ -3251,14 +3255,14 @@ impl Variant {
             });
         }
 
-        // One unnamed field, holding the struct that declares the command's flags
-        // and arguments. A variant with no fields would have nothing to parse into,
-        // and named fields would make the variant itself the struct — which is a
-        // second way to say the same thing.
+        // One unnamed field can hold a separately declared Args struct. Named fields make
+        // the variant itself the command body; codegen lowers that form to a private Args
+        // struct and moves the built values back into the enum.
         // A bare variant is a command with nothing of its own — `Sponsors`, which clap also
         // allows. The struct it implies is written for it, so everything downstream keeps
         // speaking to a struct and only the construction differs.
         let mut unit = false;
+        let mut inline_fields = None;
         let held = match &variant.fields {
             Fields::Unnamed(unnamed) if unnamed.unnamed.len() == 1 => unnamed.unnamed[0].ty.clone(),
             Fields::Unit => {
@@ -3266,12 +3270,18 @@ impl Variant {
                 let ident = unit_struct_ident(enum_ident, &variant.ident);
                 syn::parse_quote!(#ident)
             }
+            Fields::Named(named) => {
+                let ident = unit_struct_ident(enum_ident, &variant.ident);
+                inline_fields = Some(named.named.iter().cloned().collect());
+                syn::parse_quote!(#ident)
+            }
             other => {
                 return Err(syn::Error::new_spanned(
                     other,
                     "a subcommand variant wraps one struct, as in `Install(Install)` or \
                      `Install(Box<Install>)` — that struct is where its flags and arguments \
-                     are declared — or holds nothing at all, for a command that has none",
+                     are declared — declares fields inline as `Install { force: bool }`, \
+                     or holds nothing at all, for a command that has none",
                 ));
             }
         };
@@ -3293,6 +3303,7 @@ impl Variant {
             name,
             effect,
             unit,
+            inline_fields,
             ty,
             boxed,
             external: false,

--- a/usage-rs/Cargo.toml
+++ b/usage-rs/Cargo.toml
@@ -34,4 +34,5 @@ shared-version = true
 release = true
 
 [dev-dependencies]
+serde = { version = "1", features = ["derive"] }
 usage-parser = { package = "usage-lib", path = "../lib" }

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -28,6 +28,8 @@ enum InlineCommand {
         bench: Option<String>,
         #[usage(long)]
         runs: Option<u32>,
+        #[cfg_attr(all(), arg(long))]
+        iterations: Option<u32>,
     },
 }
 
@@ -114,11 +116,18 @@ fn struct_style_subcommands_bind_fields_in_place() {
         OsStr::new("startup"),
         OsStr::new("--runs"),
         OsStr::new("5"),
+        OsStr::new("--iterations"),
+        OsStr::new("9"),
     ])
     .expect("inline fields should parse");
-    let InlineCommand::Run { bench, runs } = cli.command;
+    let InlineCommand::Run {
+        bench,
+        runs,
+        iterations,
+    } = cli.command;
     assert_eq!(bench.as_deref(), Some("startup"));
     assert_eq!(runs, Some(5));
+    assert_eq!(iterations, Some(9));
 
     let kdl = InlineEx::to_kdl();
     assert!(kdl.contains("cmd \"run\""), "{kdl}");
@@ -126,6 +135,7 @@ fn struct_style_subcommands_bind_fields_in_place() {
     assert!(kdl.contains("arg \"<BENCH>\""), "{kdl}");
     assert!(kdl.contains("flag \"--runs\""), "{kdl}");
     assert!(kdl.contains("arg \"<RUNS>\""), "{kdl}");
+    assert!(kdl.contains("flag \"--iterations\""), "{kdl}");
 }
 
 #[test]

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "spec")]
+#![deny(unused_variables)]
 
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
@@ -32,6 +33,12 @@ enum InlineCommand {
         iterations: Option<u32>,
         #[arg]
         label: Option<String>,
+        #[cfg(any())]
+        #[arg(long)]
+        platform_only: Option<String>,
+    },
+    Empty {},
+    PlatformOnly {
         #[cfg(any())]
         #[arg(long)]
         platform_only: Option<String>,
@@ -131,7 +138,10 @@ fn struct_style_subcommands_bind_fields_in_place() {
         runs,
         iterations,
         label,
-    } = cli.command;
+    } = cli.command
+    else {
+        panic!("run command should be selected");
+    };
     assert_eq!(bench.as_deref(), Some("startup"));
     assert_eq!(runs, Some(5));
     assert_eq!(iterations, Some(9));
@@ -145,6 +155,16 @@ fn struct_style_subcommands_bind_fields_in_place() {
     assert!(kdl.contains("arg \"<RUNS>\""), "{kdl}");
     assert!(kdl.contains("flag \"--iterations\""), "{kdl}");
     assert!(kdl.contains("arg \"[LABEL]\""), "{kdl}");
+}
+
+#[test]
+fn empty_struct_style_subcommands_do_not_emit_unused_bindings() {
+    let cli = InlineEx::parse_from(&[OsStr::new("empty")]).expect("empty command should parse");
+    assert!(matches!(cli.command, InlineCommand::Empty {}));
+
+    let cli = InlineEx::parse_from(&[OsStr::new("platform-only")])
+        .expect("a command whose fields are cfg'd out should parse");
+    assert!(matches!(cli.command, InlineCommand::PlatformOnly {}));
 }
 
 #[test]

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -21,10 +21,11 @@ enum Command {
     Version,
 }
 
-#[derive(Subcommands)]
+#[derive(Subcommands, serde::Deserialize)]
 enum InlineCommand {
     /// Run a named benchmark.
     Run {
+        #[serde(default)]
         #[arg(long)]
         bench: Option<String>,
         #[usage(long)]

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -20,6 +20,24 @@ enum Command {
     Version,
 }
 
+#[derive(Subcommands)]
+enum InlineCommand {
+    /// Run a named benchmark.
+    Run {
+        #[arg(long)]
+        bench: Option<String>,
+        #[usage(long)]
+        runs: Option<u32>,
+    },
+}
+
+#[derive(Cli)]
+#[usage(bin = "inline-ex")]
+struct InlineEx {
+    #[usage(subcommand)]
+    command: InlineCommand,
+}
+
 #[derive(ValueEnum)]
 #[usage(ignore_case)]
 enum Shell {
@@ -86,6 +104,28 @@ fn one_dependency_provides_derives_runtime_and_value_hints() {
 fn unit_subcommands_use_the_facade_derive() {
     let cli = Ex::parse_from(&[OsStr::new("version")]).expect("valid unit subcommand");
     assert!(matches!(cli.command, Command::Version));
+}
+
+#[test]
+fn struct_style_subcommands_bind_fields_in_place() {
+    let cli = InlineEx::parse_from(&[
+        OsStr::new("run"),
+        OsStr::new("--bench"),
+        OsStr::new("startup"),
+        OsStr::new("--runs"),
+        OsStr::new("5"),
+    ])
+    .expect("inline fields should parse");
+    let InlineCommand::Run { bench, runs } = cli.command;
+    assert_eq!(bench.as_deref(), Some("startup"));
+    assert_eq!(runs, Some(5));
+
+    let kdl = InlineEx::to_kdl();
+    assert!(kdl.contains("cmd \"run\""), "{kdl}");
+    assert!(kdl.contains("flag \"--bench\""), "{kdl}");
+    assert!(kdl.contains("arg \"<BENCH>\""), "{kdl}");
+    assert!(kdl.contains("flag \"--runs\""), "{kdl}");
+    assert!(kdl.contains("arg \"<RUNS>\""), "{kdl}");
 }
 
 #[test]

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -30,6 +30,11 @@ enum InlineCommand {
         runs: Option<u32>,
         #[cfg_attr(all(), arg(long))]
         iterations: Option<u32>,
+        #[arg]
+        label: Option<String>,
+        #[cfg(any())]
+        #[arg(long)]
+        platform_only: Option<String>,
     },
 }
 
@@ -118,16 +123,19 @@ fn struct_style_subcommands_bind_fields_in_place() {
         OsStr::new("5"),
         OsStr::new("--iterations"),
         OsStr::new("9"),
+        OsStr::new("nightly"),
     ])
     .expect("inline fields should parse");
     let InlineCommand::Run {
         bench,
         runs,
         iterations,
+        label,
     } = cli.command;
     assert_eq!(bench.as_deref(), Some("startup"));
     assert_eq!(runs, Some(5));
     assert_eq!(iterations, Some(9));
+    assert_eq!(label.as_deref(), Some("nightly"));
 
     let kdl = InlineEx::to_kdl();
     assert!(kdl.contains("cmd \"run\""), "{kdl}");
@@ -136,6 +144,7 @@ fn struct_style_subcommands_bind_fields_in_place() {
     assert!(kdl.contains("flag \"--runs\""), "{kdl}");
     assert!(kdl.contains("arg \"<RUNS>\""), "{kdl}");
     assert!(kdl.contains("flag \"--iterations\""), "{kdl}");
+    assert!(kdl.contains("arg \"[LABEL]\""), "{kdl}");
 }
 
 #[test]


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches macro expansion and subcommand binding for a new variant shape; mistakes could break parsing, cfg handling, or KDL/spec emission for migrated CLIs.
> 
> **Overview**
> **`Subcommands` can now use clap-style struct variants** (`Run { #[arg(long)] bench: Option<String> }`) instead of wrapping a separate `Args` type, which unblocks mechanical migrations from aube/hk-style enums.
> 
> The derive **lowers each inline variant to a hidden `#[derive(Args)]` struct**, runs parsing there, then **moves bound fields back into the original enum variant**. **`#[arg(...)]` is rewritten to `#[usage(...)]`** (including inside `cfg_attr`), and **`cfg`-gated fields** are handled when building the variant so empty or all-stripped variants still compile.
> 
> **`PLAN.md`** marks the inline-variant launch-gate item done. **Facade tests** cover parsing, KDL emission, and cfg-only-empty commands; **`usage-rs`** adds `serde` as a dev-dependency for those tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a43d1693d527d4cd3b55a1f02454573fecc1c3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->