### PR TITLE
feat(derive): accept runtime metadata expressions

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -577,12 +577,14 @@ feature list is not an exhaustive audit.
       derive applies the default, but help, spec consumers and differential
       tooling see a required shape. A default satisfies a field; it must not
       make the user's token required in the static metadata.
-- [ ] **Rust expressions for compile-time metadata.** hk and fnox use constants
+- [x] **Rust expressions for compile-time metadata.** hk and fnox use constants
       for defaults, aube and hk use constants for long help, and all three use
       generated or computed version strings. Requiring every value to be copied
       into a string literal creates exactly the drift this project is meant to
-      remove. Define which attributes accept `expr`, evaluate what can remain in
-      static tables, and give an explicit escape hatch for emission-only values.
+      remove. `version` and `default_value_t` now accept Rust expressions. A
+      computed version pairs with `version_spec`, and a typed default pairs with
+      `default`; the expression drives runtime behavior while the explicit literal
+      keeps emitted KDL deterministic and portable.
 - [ ] **One Args type used by more than one command.** tak's `push` and `init`
       have the same `--remote` shape. The derive rejects two variants wrapping
       one `Args` type because collection is attached to the declaring struct,

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -2377,7 +2377,14 @@ fn reset_to_default(field: &Field) -> TokenStream {
         return cleared;
     }
     if let Some(value) = &field.default_value_t {
-        let bytes = quote!(::std::string::ToString::to_string(&(#value)).into_bytes());
+        let value_ty = field
+            .value_ty
+            .as_ref()
+            .expect("a typed default belongs to a value-taking field");
+        let bytes = quote!({
+            let __usage_default: #value_ty = #value;
+            ::std::string::ToString::to_string(&__usage_default).into_bytes()
+        });
         return match field.shape {
             Shape::Optional => quote! {
                 partial.#ident = ::std::option::Option::Some(#bytes);

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -133,10 +133,10 @@ pub fn emit(cli: &Cli) -> TokenStream {
             }
         )
     });
-    let before_help = option_str(cli.before_help.as_deref());
-    let before_long_help = option_str(cli.before_long_help.as_deref());
-    let after_help = option_str(cli.after_help.as_deref());
-    let after_long_help = option_str(cli.after_long_help.as_deref());
+    let before_help = option_expr(cli.before_help.as_ref());
+    let before_long_help = option_expr(cli.before_long_help.as_ref());
+    let after_help = option_expr(cli.after_help.as_ref());
+    let after_long_help = option_expr(cli.after_long_help.as_ref());
     let root_key = key_ident("COMMAND", None);
     let keys = key_consts(&cli.fingerprint, flags.len(), args.len());
     let flag_tables = flags.iter().enumerate().map(|(i, f)| flag_table(i, f));
@@ -166,8 +166,16 @@ pub fn emit(cli: &Cli) -> TokenStream {
         Some(tokens) => quote!(::core::option::Option::Some(#tokens)),
         None => quote!(::core::option::Option::None),
     };
-    let about = option_str(cli.about.as_deref());
-    let long_about = option_str(cli.long_about.as_deref());
+    let about = cli
+        .about_attr
+        .as_ref()
+        .map(|value| option_expr(Some(value)))
+        .unwrap_or_else(|| option_str(cli.about.as_deref()));
+    let long_about = cli
+        .long_about_attr
+        .as_ref()
+        .map(|value| option_expr(Some(value)))
+        .unwrap_or_else(|| option_str(cli.long_about.as_deref()));
 
     // The same wiring a nested command uses: the root differs only in how it is
     // entered, so it does not get its own copy.
@@ -272,6 +280,12 @@ pub fn emit(cli: &Cli) -> TokenStream {
 
     let min_usage_version = option_str(cli.min_usage_version.as_deref());
     let has_version = cli.version.is_some();
+    let runtime_version = cli
+        .runtime_version
+        .as_ref()
+        .or(cli.version.as_ref())
+        .cloned()
+        .unwrap_or_else(|| quote!(""));
     quote! {
         #[doc(hidden)]
         #[allow(
@@ -554,17 +568,10 @@ pub fn emit(cli: &Cli) -> TokenStream {
                         ::std::result::Result::Ok(parsed) => parsed,
                         // Not failures: someone asked a question, and the answer goes to stdout.
                         ::std::result::Result::Err(usage_argv::Error::Version) => {
-                            match (Self::spec().bin.unwrap_or(Self::spec().name), Self::spec().version) {
-                                (bin, ::std::option::Option::Some(version)) => {
-                                    ::std::println!("{bin} {version}");
-                                    ::std::process::exit(0);
-                                }
-                                // Unreachable: the flag is only in the table when a version was
-                                // declared, and the same declaration fills this in.
-                                (_, ::std::option::Option::None) => {
-                                    ::std::process::exit(0);
-                                }
-                            }
+                            let __usage_bin = Self::spec().bin.unwrap_or(Self::spec().name);
+                            let __usage_version = #runtime_version;
+                            ::std::println!("{__usage_bin} {__usage_version}");
+                            ::std::process::exit(0);
                         }
                         ::std::result::Result::Err(usage_argv::Error::Help { cmd, long }) => {
                             // By the route the words took, not by the command's address: one
@@ -1588,6 +1595,13 @@ fn option_str(value: Option<&str>) -> TokenStream {
     }
 }
 
+fn option_expr(value: Option<&TokenStream>) -> TokenStream {
+    match value {
+        Some(v) => quote!(::std::option::Option::Some(#v)),
+        None => quote!(::std::option::Option::None),
+    }
+}
+
 /// The presence summaries a parent needs to enforce exclusivity across a flattened
 /// `CommandArgs` boundary.
 fn presence_methods(cli: &Cli) -> TokenStream {
@@ -2362,6 +2376,17 @@ fn reset_to_default(field: &Field) -> TokenStream {
     if field.default.is_empty() {
         return cleared;
     }
+    if let Some(value) = &field.default_value_t {
+        let bytes = quote!(::std::string::ToString::to_string(&(#value)).into_bytes());
+        return match field.shape {
+            Shape::Optional => quote! {
+                partial.#ident = ::std::option::Option::Some(#bytes);
+            },
+            Shape::Required => quote!(partial.#ident = #bytes;),
+            // The model rejects these shapes before codegen.
+            _ => cleared,
+        };
+    }
     // Every shape but a collection was checked in the model to have at most one.
     assign_literal(field, &field.default[0], field.default.as_slice())
 }
@@ -2722,10 +2747,10 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
         )
     });
     let unknown_flags = unknown_flags_tokens(cli);
-    let before_help = option_str(cli.before_help.as_deref());
-    let before_long_help = option_str(cli.before_long_help.as_deref());
-    let after_help = option_str(cli.after_help.as_deref());
-    let after_long_help = option_str(cli.after_long_help.as_deref());
+    let before_help = option_expr(cli.before_help.as_ref());
+    let before_long_help = option_expr(cli.before_long_help.as_ref());
+    let after_help = option_expr(cli.after_help.as_ref());
+    let after_long_help = option_expr(cli.after_long_help.as_ref());
 
     let flags: Vec<&Field> = cli
         .fields
@@ -2762,8 +2787,16 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
     let name = &cli.name;
     let aliases = cli.aliases.iter().chain(&cli.hidden_aliases);
     let hidden_aliases = &cli.hidden_aliases;
-    let about = option_str(cli.about.as_deref());
-    let long_about = option_str(cli.long_about.as_deref());
+    let about = cli
+        .about_attr
+        .as_ref()
+        .map(|value| option_expr(Some(value)))
+        .unwrap_or_else(|| option_str(cli.about.as_deref()));
+    let long_about = cli
+        .long_about_attr
+        .as_ref()
+        .map(|value| option_expr(Some(value)))
+        .unwrap_or_else(|| option_str(cli.long_about.as_deref()));
     let partial = partial_struct(cli);
     let defaults = partial_defaults(cli);
     let apply = apply_fn(cli);
@@ -3215,14 +3248,40 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
             // the struct's long one, which is exactly how a generated CLI is shaped: the enum says
             // what the command is for in a line, and the struct's own comment carries the rest. The
             // long form went missing from help for every command written that way.
-            let about = match v.help.as_deref() {
-                Some(help) => option_str(Some(help)),
+            let about = match v.help.as_ref() {
+                Some(help) => option_expr(Some(help)),
                 None => quote!(<#ty as usage_argv::spec::CommandArgs>::META.about),
             };
-            let long_about = match v.long_help.as_deref() {
-                Some(long) => option_str(Some(long)),
+            let long_about = match v.long_help.as_ref() {
+                Some(long) => option_expr(Some(long)),
                 None => quote!(<#ty as usage_argv::spec::CommandArgs>::META.long_about),
             };
+            let before_help = v
+                .before_help
+                .as_ref()
+                .map(|value| option_expr(Some(value)))
+                .unwrap_or_else(
+                    || quote!(<#ty as usage_argv::spec::CommandArgs>::META.before_help),
+                );
+            let before_long_help = v
+                .before_long_help
+                .as_ref()
+                .map(|value| option_expr(Some(value)))
+                .unwrap_or_else(
+                    || quote!(<#ty as usage_argv::spec::CommandArgs>::META.before_long_help),
+                );
+            let after_help = v
+                .after_help
+                .as_ref()
+                .map(|value| option_expr(Some(value)))
+                .unwrap_or_else(|| quote!(<#ty as usage_argv::spec::CommandArgs>::META.after_help));
+            let after_long_help = v
+                .after_long_help
+                .as_ref()
+                .map(|value| option_expr(Some(value)))
+                .unwrap_or_else(
+                    || quote!(<#ty as usage_argv::spec::CommandArgs>::META.after_long_help),
+                );
             // Which of the table's aliases are hidden. The visible ones are not listed
             // anywhere: `cmd.aliases` minus these is what help and completions show.
             let hidden = &v.hidden_aliases;
@@ -3241,6 +3300,10 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
                         cmd: &#cmd,
                         about: #about,
                         long_about: #long_about,
+                        before_help: #before_help,
+                        before_long_help: #before_long_help,
+                        after_help: #after_help,
+                        after_long_help: #after_long_help,
                         hide: #hide,
                         hidden_aliases: &#hidden_name,
                         ..*<#ty as usage_argv::spec::CommandArgs>::META

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -286,6 +286,24 @@ pub fn emit(cli: &Cli) -> TokenStream {
         .or(cli.version.as_ref())
         .cloned()
         .unwrap_or_else(|| quote!(""));
+    let help_spec = if cli.runtime_version.is_some() {
+        quote! {
+            // The portable spec keeps `version_spec`; this process's help must agree with
+            // the computed version printed by `--version`. The owned string lives for the
+            // whole render and is allocated only on this cold help path.
+            let __usage_runtime_version =
+                ::std::string::ToString::to_string(&(#runtime_version));
+            let __usage_runtime_spec = usage_argv::spec::Spec {
+                version: ::std::option::Option::Some(__usage_runtime_version.as_str()),
+                ..*Self::spec()
+            };
+            let __usage_spec = &__usage_runtime_spec;
+        }
+    } else {
+        quote! {
+            let __usage_spec = Self::spec();
+        }
+    };
     quote! {
         #[doc(hidden)]
         #[allow(
@@ -574,6 +592,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
                             ::std::process::exit(0);
                         }
                         ::std::result::Result::Err(usage_argv::Error::Help { cmd, long }) => {
+                            #help_spec
                             // By the route the words took, not by the command's address: one
                             // `Subcommands` type mounted under two parents is one address, and a
                             // page found by searching for it carries the first mount's path and
@@ -584,10 +603,10 @@ pub fn emit(cli: &Cli) -> TokenStream {
                                 cmd,
                             ) {
                                 ::std::option::Option::Some(route) => {
-                                    usage_argv::help::render_at(Self::spec(), &route, long)
+                                    usage_argv::help::render_at(__usage_spec, &route, long)
                                 }
                                 ::std::option::Option::None => {
-                                    usage_argv::help::render(Self::spec(), cmd, long)
+                                    usage_argv::help::render(__usage_spec, cmd, long)
                                 }
                             };
                             match __usage_page {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -161,6 +161,12 @@
 //! that will not convert becomes [`Error::InvalidValue`](usage_argv::Error::InvalidValue),
 //! carrying the offending text and whatever the type's own conversion said about it.
 //!
+//! Metadata that already has a Rust source of truth may remain an expression. Command help
+//! fields such as `about` and `after_long_help` accept expressions usable as `&'static str`.
+//! A computed `version` additionally declares `version_spec = "..."`, and a typed field
+//! default declares both `default_value_t = EXPR` and `default = "..."`: runtime behavior
+//! evaluates the expression while portable KDL uses the explicit literal.
+//!
 //! A completer is written as
 //!
 //! ```ignore

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -29,6 +29,9 @@ pub struct Cli {
     /// its own version and it is not the answer. clap's bare `#[command(version)]` reads it the
     /// same way.
     pub version: Option<proc_macro2::TokenStream>,
+    /// The expression printed for `--version` when the portable spec uses an
+    /// explicitly supplied literal.
+    pub runtime_version: Option<proc_macro2::TokenStream>,
     /// Whether this CLI answers a completion request.
     ///
     /// Opt in rather than supplied like `--help`: it is a hidden command a binary carries and a
@@ -87,15 +90,15 @@ pub struct Cli {
     pub multicall: bool,
     /// Declared descriptions, for the case a doc comment cannot express: a long form that does
     /// not contain the short one.
-    pub about_attr: Option<String>,
-    pub long_about_attr: Option<String>,
+    pub about_attr: Option<proc_macro2::TokenStream>,
+    pub long_about_attr: Option<proc_macro2::TokenStream>,
     /// Text around the rest of the help page. mise puts an Examples section in
     /// `after_long_help` on 115 commands, and a page without it is missing what a reader came
     /// for. Nothing derives these from the code, so they are declared.
-    pub before_help: Option<String>,
-    pub before_long_help: Option<String>,
-    pub after_help: Option<String>,
-    pub after_long_help: Option<String>,
+    pub before_help: Option<proc_macro2::TokenStream>,
+    pub before_long_help: Option<proc_macro2::TokenStream>,
+    pub after_help: Option<proc_macro2::TokenStream>,
+    pub after_long_help: Option<proc_macro2::TokenStream>,
     /// The word that starts another invocation of the same command: mise's `:::`.
     pub restart_token: Option<String>,
     /// A command to run for subcommands discovered at completion time.
@@ -158,6 +161,9 @@ pub struct Field {
     /// one item, in the order they are written. Every other shape holds at most one, which the
     /// model checks — a `String` has one place to put a value.
     pub default: Vec<String>,
+    /// A typed Rust default evaluated when parsing starts. `default` remains
+    /// the explicit portable spelling emitted in static metadata.
+    pub default_value_t: Option<proc_macro2::TokenStream>,
     pub help_heading: Option<String>,
     /// What supplying this flag does to the world, when it says.
     ///
@@ -453,6 +459,8 @@ impl Cli {
 
         let mut name_given = false;
         let mut verbatim_doc_comment = false;
+        let mut version_spec_given = false;
+        let mut version_needs_spec = false;
         let mut cli = Cli {
             ident: input.ident.clone(),
             fingerprint: quote::ToTokens::to_token_stream(input).to_string(),
@@ -471,6 +479,7 @@ impl Cli {
                 .find(|a| a.path().is_ident("usage"))
                 .map(|a| a.path().span()),
             version: None,
+            runtime_version: None,
             about: None,
             long_about: None,
             unknown_flags: None,
@@ -509,14 +518,32 @@ impl Cli {
                     "min_usage_version" => cli.min_usage_version = Some(string_value(&meta)?),
                     "usage" => cli.usage = Some(string_value(&meta)?),
                     "version" => {
-                        cli.version = Some(match &meta {
+                        let value = match &meta {
                             // `version` on its own: whatever the adopter's package says.
                             Meta::Path(_) => quote::quote!(env!("CARGO_PKG_VERSION")),
-                            _ => {
-                                let literal = string_value(&meta)?;
-                                quote::quote!(#literal)
+                            Meta::NameValue(value) => {
+                                quote::ToTokens::to_token_stream(&value.value)
                             }
-                        })
+                            Meta::List(_) => {
+                                return Err(syn::Error::new_spanned(
+                                    &meta,
+                                    "`version` is a Rust expression, as in `version = build::VERSION`, or is written on its own for the package version",
+                                ));
+                            }
+                        };
+                        cli.runtime_version = Some(value.clone());
+                        if let Meta::NameValue(value) = &meta {
+                            version_needs_spec =
+                                matches!(value.value, Expr::Call(_) | Expr::MethodCall(_));
+                        }
+                        if !version_spec_given {
+                            cli.version = Some(value);
+                        }
+                    }
+                    "version_spec" => {
+                        let literal = string_value(&meta)?;
+                        cli.version = Some(quote::quote!(#literal));
+                        version_spec_given = true;
                     }
                     // A doc comment's long form always contains its short one — the short form
                     // *is* the comment's first paragraph. A spec keeps `about` and `about_long`
@@ -524,12 +551,12 @@ impl Cli {
                     // in one CLI" against "mise prepares your development environment before
                     // each command runs." There is no comment that says both, so they can be
                     // declared.
-                    "about" => cli.about_attr = Some(string_value(&meta)?),
-                    "long_about" => cli.long_about_attr = Some(string_value(&meta)?),
-                    "before_help" => cli.before_help = Some(string_value(&meta)?),
-                    "before_long_help" => cli.before_long_help = Some(string_value(&meta)?),
-                    "after_help" => cli.after_help = Some(string_value(&meta)?),
-                    "after_long_help" => cli.after_long_help = Some(string_value(&meta)?),
+                    "about" => cli.about_attr = Some(metadata_expr(&meta)?),
+                    "long_about" => cli.long_about_attr = Some(metadata_expr(&meta)?),
+                    "before_help" => cli.before_help = Some(metadata_expr(&meta)?),
+                    "before_long_help" => cli.before_long_help = Some(metadata_expr(&meta)?),
+                    "after_help" => cli.after_help = Some(metadata_expr(&meta)?),
+                    "after_long_help" => cli.after_long_help = Some(metadata_expr(&meta)?),
                     // A Rust CLI usually owns every flag it accepts, which is the
                     // case the stricter reading is for — but it is still opt-in,
                     // since a wrapper forwarding options wants the default.
@@ -559,7 +586,7 @@ impl Cli {
                             path,
                             format!(
                                 "unknown option `{other}` on a struct; usage::Cli takes \
-                                 `name`, `bin`, `version`, `usage`, `verbatim_doc_comment`, `unknown_flags`, \
+                                 `name`, `bin`, `version`, `version_spec`, `usage`, `verbatim_doc_comment`, `unknown_flags`, \
                                  `default_subcommand`, `multicall`, `restart_token`, `mount` and \
                                  `group` here, and the description comes from the doc \
                                  comment"
@@ -572,12 +599,11 @@ impl Cli {
 
         (cli.about, cli.long_about) = doc_comment(&input.attrs, verbatim_doc_comment)?;
 
-        // Declared descriptions win over the comment, which is the point of declaring them.
-        if let Some(about) = cli.about_attr.take() {
-            cli.about = Some(about);
-        }
-        if let Some(long) = cli.long_about_attr.take() {
-            cli.long_about = Some(long);
+        if version_needs_spec && !version_spec_given {
+            return Err(syn::Error::new_spanned(
+                &input.ident,
+                "a computed `version` needs `version_spec = \"...\"`: the expression is evaluated for `--version`, while the literal is emitted into the portable spec",
+            ));
         }
 
         let alias_span = cli.attr_span.unwrap_or_else(Span::call_site);
@@ -1156,6 +1182,7 @@ impl Field {
             env: None,
             setting: None,
             default: Vec::new(),
+            default_value_t: None,
             help_heading: None,
             value_name: None,
             required_collection: false,
@@ -1266,6 +1293,7 @@ impl Field {
             env: None,
             setting: None,
             default: Vec::new(),
+            default_value_t: None,
             help_heading: None,
             value_name: None,
             required_collection: false,
@@ -1370,6 +1398,7 @@ impl Field {
             env: None,
             setting: None,
             default: Vec::new(),
+            default_value_t: None,
             help_heading: None,
             value_name: None,
             required_collection: false,
@@ -1435,6 +1464,7 @@ impl Field {
         let mut env = None;
         let mut setting = None;
         let mut default: Vec<String> = Vec::new();
+        let mut default_value_t = None;
         let mut help_heading = None;
         let mut effect = None;
         let mut value_name = None;
@@ -1585,6 +1615,22 @@ impl Field {
                     "var_min" => var_min = Some(int_value(&meta)?),
                     "var_max" => var_max = Some(int_value(&meta)?),
                     "default" => default.push(string_value(&meta)?),
+                    "default_value_t" => {
+                        default_value_t = Some(match &meta {
+                            Meta::Path(_) => {
+                                quote::quote!(::std::default::Default::default())
+                            }
+                            Meta::NameValue(value) => {
+                                quote::ToTokens::to_token_stream(&value.value)
+                            }
+                            Meta::List(_) => {
+                                return Err(syn::Error::new_spanned(
+                                    &meta,
+                                    "`default_value_t` is a Rust expression or is written on its own for `Default::default()`",
+                                ));
+                            }
+                        });
+                    }
                     "help_heading" => help_heading = Some(string_value(&meta)?),
                     "effect" => effect = Some(effect_value(&meta)?),
                     "value_name" => value_name = Some(string_value(&meta)?),
@@ -1620,7 +1666,7 @@ impl Field {
                             format!(
                                 "unknown option `{other}`; a field takes `name`, `long`, \
                                  `short`, `negate`, `global`, `var`, `variadic`, \
-                                 `count`, `hide`, `arg`, `env`, `default`, `choices`, `validate`, \
+                                 `count`, `hide`, `arg`, `env`, `default`, `default_value_t`, `choices`, `validate`, \
                                  `validate_error`, \
                                  `var_min`, `var_max`, `value_enum`, `value_hint`, `overrides`, \
                                  `conflicts`, `requires`, `group`, `exclusive`, \
@@ -1740,6 +1786,20 @@ impl Field {
                 "this field holds one value, so it takes one `default`; several is for a \
                  `Vec`, which starts out holding all of them",
             ));
+        }
+        if default_value_t.is_some() {
+            if default.len() != 1 {
+                return Err(syn::Error::new(
+                    span,
+                    "`default_value_t` needs exactly one `default = \"...\"` beside it: the Rust expression supplies the runtime value and the literal is emitted into the portable spec",
+                ));
+            }
+            if matches!(shape, Shape::Bool | Shape::Count | Shape::Many) {
+                return Err(syn::Error::new(
+                    span,
+                    "`default_value_t` is for one value-taking field; switches, counts, and collections declare their portable defaults directly",
+                ));
+            }
         }
         for value in &default {
             match shape {
@@ -2285,6 +2345,7 @@ impl Field {
             env,
             setting,
             default,
+            default_value_t,
             help_heading,
             effect,
             value_name,
@@ -2492,6 +2553,14 @@ fn string_value(meta: &Meta) -> syn::Result<String> {
             "expected a string, as in `long = \"jobs\"`",
         )),
     }
+}
+
+/// A Rust expression whose result must be usable as `&'static str` in the
+/// generated metadata table. Type and const checking belong to rustc; retaining
+/// the tokens here is what lets constants and `env!` remain the source of truth.
+fn metadata_expr(meta: &Meta) -> syn::Result<proc_macro2::TokenStream> {
+    let value = &meta.require_name_value()?.value;
+    Ok(quote::ToTokens::to_token_stream(value))
 }
 
 /// One flag selector as a value, or several as a list.
@@ -3001,8 +3070,12 @@ pub struct Variant {
     /// them. mise has 67 of the first and 24 of the second.
     pub aliases: Vec<String>,
     pub hidden_aliases: Vec<String>,
-    pub help: Option<String>,
-    pub long_help: Option<String>,
+    pub help: Option<proc_macro2::TokenStream>,
+    pub long_help: Option<proc_macro2::TokenStream>,
+    pub before_help: Option<proc_macro2::TokenStream>,
+    pub before_long_help: Option<proc_macro2::TokenStream>,
+    pub after_help: Option<proc_macro2::TokenStream>,
+    pub after_long_help: Option<proc_macro2::TokenStream>,
 }
 
 impl Subcommands {
@@ -3120,8 +3193,12 @@ impl Variant {
         let mut effect = None;
         let mut hide = false;
         let mut external = false;
-        let mut help_attr: Option<String> = None;
-        let mut long_help_attr: Option<String> = None;
+        let mut help_attr: Option<proc_macro2::TokenStream> = None;
+        let mut long_help_attr: Option<proc_macro2::TokenStream> = None;
+        let mut before_help = None;
+        let mut before_long_help = None;
+        let mut after_help = None;
+        let mut after_long_help = None;
 
         for attr in attrs(&variant.attrs) {
             for meta in nested(attr)? {
@@ -3142,8 +3219,12 @@ impl Variant {
                     }
                     // As on a field: a comment's paragraph is flowed, so text whose line
                     // breaks matter is declared instead.
-                    "help" => help_attr = Some(string_value(&meta)?),
-                    "long_help" => long_help_attr = Some(string_value(&meta)?),
+                    "help" => help_attr = Some(metadata_expr(&meta)?),
+                    "long_help" => long_help_attr = Some(metadata_expr(&meta)?),
+                    "before_help" => before_help = Some(metadata_expr(&meta)?),
+                    "before_long_help" => before_long_help = Some(metadata_expr(&meta)?),
+                    "after_help" => after_help = Some(metadata_expr(&meta)?),
+                    "after_long_help" => after_long_help = Some(metadata_expr(&meta)?),
                     "verbatim_doc_comment" => verbatim_doc_comment = flag_value(&meta)?,
                     other => {
                         return Err(syn::Error::new_spanned(
@@ -3151,7 +3232,8 @@ impl Variant {
                             format!(
                                 "unknown option `{other}` on a variant; a subcommand \
                                  variant takes `name`, `alias`, `alias_hidden`, \
-                                 `external_subcommand` and `verbatim_doc_comment` here, \
+                                 `external_subcommand`, `help`, `long_help`, `before_help`, \
+                                 `before_long_help`, `after_help`, `after_long_help`, and `verbatim_doc_comment` here, \
                                  and its description comes from the doc comment"
                             ),
                         ));
@@ -3175,7 +3257,8 @@ impl Variant {
             }
         }
 
-        let (help, long_help) = (help_attr.or(help), long_help_attr.or(long_help));
+        let help = help_attr.or_else(|| help.map(|value| quote::quote!(#value)));
+        let long_help = long_help_attr.or_else(|| long_help.map(|value| quote::quote!(#value)));
 
         if external {
             if !aliases.is_empty() || !hidden_aliases.is_empty() {
@@ -3198,7 +3281,13 @@ impl Variant {
                      so there is nothing for `hide` to keep out of help",
                 ));
             }
-            if help.is_some() || long_help.is_some() {
+            if help.is_some()
+                || long_help.is_some()
+                || before_help.is_some()
+                || before_long_help.is_some()
+                || after_help.is_some()
+                || after_long_help.is_some()
+            {
                 return Err(syn::Error::new_spanned(
                     &variant.ident,
                     "a catch-all has no page of its own, so a description here would be \
@@ -3252,6 +3341,10 @@ impl Variant {
                 hidden_aliases,
                 help: None,
                 long_help: None,
+                before_help: None,
+                before_long_help: None,
+                after_help: None,
+                after_long_help: None,
             });
         }
 
@@ -3312,6 +3405,10 @@ impl Variant {
             hidden_aliases,
             help,
             long_help,
+            before_help,
+            before_long_help,
+            after_help,
+            after_long_help,
         })
     }
 }

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -7,6 +7,8 @@ use std::path::{Path, PathBuf};
 use usage_rs as usage;
 use usage_rs::{Args, Cli, Subcommands, ValueEnum};
 
+const INLINE_AFTER_HELP: &str = "Inline command details from a Rust constant.";
+
 #[derive(Cli)]
 #[usage(bin = "ex")]
 struct Ex {
@@ -24,6 +26,7 @@ enum Command {
 #[derive(Subcommands, serde::Deserialize)]
 enum InlineCommand {
     /// Run a named benchmark.
+    #[usage(after_long_help = INLINE_AFTER_HELP)]
     Run {
         #[serde(default)]
         #[arg(long)]
@@ -92,6 +95,27 @@ struct ChoiceEx {
 #[usage(bin = "strict-ex", unknown_flags = "error")]
 struct StrictEx {}
 
+const DEFAULT_RUNS: u32 = 7;
+const DYNAMIC_ABOUT: &str = "Metadata from a Rust constant.";
+const DYNAMIC_AFTER_HELP: &str = "More details from a Rust constant.";
+
+fn computed_version() -> &'static str {
+    "1.2.3+runtime"
+}
+
+#[derive(Cli)]
+#[usage(
+    bin = "dynamic-ex",
+    version = computed_version(),
+    version_spec = "1.2.3",
+    about = DYNAMIC_ABOUT,
+    after_long_help = DYNAMIC_AFTER_HELP
+)]
+struct DynamicEx {
+    #[usage(long, default_value_t = DEFAULT_RUNS, default = "7")]
+    runs: u32,
+}
+
 /// Show one file
 #[derive(Args)]
 struct Show {
@@ -156,6 +180,7 @@ fn struct_style_subcommands_bind_fields_in_place() {
     assert!(kdl.contains("arg \"<RUNS>\""), "{kdl}");
     assert!(kdl.contains("flag \"--iterations\""), "{kdl}");
     assert!(kdl.contains("arg \"[LABEL]\""), "{kdl}");
+    assert!(kdl.contains(INLINE_AFTER_HELP), "{kdl}");
 }
 
 #[test]
@@ -214,4 +239,19 @@ fn emitted_parser_settings_are_portable_spec_metadata() {
         Some(usage_parser::UnknownFlags::Error),
         "the portable spec should retain the runtime setting"
     );
+}
+
+#[test]
+fn runtime_metadata_expressions_have_explicit_portable_values() {
+    let _parse_entry = DynamicEx::parse as fn() -> DynamicEx;
+    let cli = DynamicEx::parse_from(&[]).expect("the typed default should be evaluated");
+    assert_eq!(cli.runs, DEFAULT_RUNS);
+
+    let kdl = DynamicEx::to_kdl();
+    assert!(kdl.contains("version \"1.2.3\""), "{kdl}");
+    assert!(kdl.contains("default=\"7\""), "{kdl}");
+    assert!(kdl.contains(DYNAMIC_ABOUT), "{kdl}");
+    assert!(kdl.contains(DYNAMIC_AFTER_HELP), "{kdl}");
+    let spec: usage_parser::Spec = kdl.parse().expect("the static values should be portable");
+    assert_eq!(spec.version.as_deref(), Some("1.2.3"));
 }

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -114,6 +114,8 @@ fn computed_version() -> &'static str {
 struct DynamicEx {
     #[usage(long, default_value_t = DEFAULT_RUNS, default = "7")]
     runs: u32,
+    #[usage(long, default_value_t, default = "0")]
+    retries: u16,
 }
 
 /// Show one file
@@ -246,10 +248,12 @@ fn runtime_metadata_expressions_have_explicit_portable_values() {
     let _parse_entry = DynamicEx::parse as fn() -> DynamicEx;
     let cli = DynamicEx::parse_from(&[]).expect("the typed default should be evaluated");
     assert_eq!(cli.runs, DEFAULT_RUNS);
+    assert_eq!(cli.retries, 0);
 
     let kdl = DynamicEx::to_kdl();
     assert!(kdl.contains("version \"1.2.3\""), "{kdl}");
     assert!(kdl.contains("default=\"7\""), "{kdl}");
+    assert!(kdl.contains("default=\"0\""), "{kdl}");
     assert!(kdl.contains(DYNAMIC_ABOUT), "{kdl}");
     assert!(kdl.contains(DYNAMIC_AFTER_HELP), "{kdl}");
     let spec: usage_parser::Spec = kdl.parse().expect("the static values should be portable");


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes derive codegen for version/help/default paths used by every `Cli`/`Args` consumer; mistakes could desync runtime `--version`/help from emitted KDL or break default seeding, though validation rules and new tests narrow the blast radius.
> 
> **Overview**
> **CLI metadata can stay as Rust expressions** instead of duplicating everything into string literals. Command-level `about`, `long_about`, and the `before_*` / `after_*` help slots now take arbitrary expressions (constants, `env!`, etc.) and codegen emits them into static tables via `option_expr`. Subcommand variants gain the same `before_help` / `after_help` expression attributes, with per-variant overrides falling back to the wrapped `Args` type’s `META` when omitted.
> 
> **Computed `version` is split from portable spec output.** `version` may be a Rust expression (or bare for `CARGO_PKG_VERSION`); non-literal computed versions must pair with **`version_spec = "..."`** so KDL stays deterministic. Runtime **`--version`** and help rendering use the evaluated expression; emitted KDL keeps the explicit literal.
> 
> **Typed field defaults use `default_value_t`.** Value-taking fields can set **`default_value_t`** (or bare for `Default::default()`), but must also declare exactly one **`default = "..."`** for the portable spec. Parse-time seeding evaluates the expression and stringifies it into the partial; KDL still emits the literal.
> 
> Integration tests in `usage-rs/tests/facade.rs` cover dynamic CLI metadata, computed version + spec, and typed defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b0e7292e5735b5905bc5b8f05bc74140c882db6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->