### PR TITLE
feat(derive): accept clap value attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2470,6 +2470,7 @@ dependencies = [
 name = "usage-derive"
 version = "5.1.0"
 dependencies = [
+ "heck",
  "proc-macro2",
  "quote",
  "syn 3.0.3",

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -18,6 +18,7 @@ shared-version = true
 release = true
 
 [dependencies]
+heck = "0.5"
 proc-macro2 = "1"
 quote = "1"
 # syn 2 rather than 3, which is already in the tree via clap_derive: nothing here

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -370,9 +370,9 @@ pub fn derive_subcommands(input: TokenStream) -> TokenStream {
 /// #[derive(usage::ValueEnum)]
 /// enum Shell {
 ///     Bash,
-///     #[usage(alias = "shell-z")]
+///     #[value(alias = "shell-z")]
 ///     Zsh,
-///     #[usage(name = "pwsh")]
+///     #[value(name = "pwsh")]
 ///     PowerShell,
 /// }
 /// ```
@@ -386,7 +386,7 @@ pub fn derive_subcommands(input: TokenStream) -> TokenStream {
 /// A field holding one says `value_enum`, which is what puts the words in the spec — so
 /// help, completions and the check that rejects a wrong word all read the same list, and
 /// none of them can drift from the type.
-#[proc_macro_derive(ValueEnum, attributes(usage))]
+#[proc_macro_derive(ValueEnum, attributes(usage, value))]
 pub fn derive_value_enum(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     match model::ValueEnum::from_input(&input) {

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -3640,7 +3640,7 @@ impl ValueEnum {
         }
 
         let mut ignore_case = false;
-        let mut rename_all = CasingStyle::Kebab;
+        let mut rename_all = None;
         // Registering clap's `value` helper attribute means rustc accepts it at
         // either level. Parse it here too so unsupported enum-wide options fail
         // explicitly instead of being silently ignored.
@@ -3649,7 +3649,7 @@ impl ValueEnum {
                 let path = meta.path().clone();
                 match ident_of(&path).as_str() {
                     "ignore_case" => ignore_case = flag_value(&meta)?,
-                    "rename_all" => rename_all = CasingStyle::parse(&meta)?,
+                    "rename_all" => rename_all = Some(CasingStyle::parse(&meta)?),
                     other => {
                         return Err(syn::Error::new_spanned(
                             path,
@@ -3669,7 +3669,10 @@ impl ValueEnum {
                 ));
             }
             let cfg_attrs = cfg_gate_attrs(&variant.attrs)?;
-            let mut name = rename_all.apply(&variant.ident.unraw().to_string());
+            let rust_name = variant.ident.unraw().to_string();
+            let mut name = rename_all
+                .map(|style| style.apply(&rust_name))
+                .unwrap_or_else(|| to_kebab(&rust_name));
             let mut aliases = Vec::new();
             for attr in value_attrs(&variant.attrs) {
                 for meta in nested(attr)? {
@@ -4383,6 +4386,10 @@ mod tests {
 
     #[test]
     fn a_value_enum_accepts_clap_container_casing() {
+        let legacy = value_enum("enum Protocol { HTTPServer }")
+            .expect("the default naming policy should compile");
+        assert_eq!(legacy.variants[0].name, "h-t-t-p-server");
+
         for (style, expected) in [
             ("camelCase", "onePassword"),
             ("kebab-case", "one-password"),

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -2528,6 +2528,15 @@ fn attrs(attrs: &[Attribute]) -> impl Iterator<Item = &Attribute> {
     attrs.iter().filter(|a| a.path().is_ident("usage"))
 }
 
+/// Value metadata accepts clap's `#[value(...)]` spelling so an enum can keep its
+/// existing annotations while replacing the derive. `#[usage(...)]` remains accepted
+/// for code that does not need source compatibility.
+fn value_attrs(attrs: &[Attribute]) -> impl Iterator<Item = &Attribute> {
+    attrs
+        .iter()
+        .filter(|a| a.path().is_ident("usage") || a.path().is_ident("value"))
+}
+
 fn nested(attr: &Attribute) -> syn::Result<Vec<Meta>> {
     let list = attr.meta.require_list()?;
     let parsed = list
@@ -3583,7 +3592,7 @@ impl ValueEnum {
             let cfg_attrs = cfg_gate_attrs(&variant.attrs)?;
             let mut name = to_kebab(&variant.ident.unraw().to_string());
             let mut aliases = Vec::new();
-            for attr in attrs(&variant.attrs) {
+            for attr in value_attrs(&variant.attrs) {
                 for meta in nested(attr)? {
                     let path = meta.path().clone();
                     match ident_of(&path).as_str() {
@@ -4275,6 +4284,21 @@ mod tests {
             err.contains("names two of these values"),
             "unhelpful: {err}"
         );
+    }
+
+    #[test]
+    fn a_value_enum_accepts_clap_value_metadata() {
+        let ve = value_enum(
+            r#"
+            enum Provider {
+                #[value(name = "1password", alias = "op")]
+                OnePassword,
+            }
+        "#,
+        )
+        .expect("clap value metadata should remain usable");
+        assert_eq!(ve.variants[0].name, "1password");
+        assert_eq!(ve.variants[0].aliases, ["op"]);
     }
 
     #[test]

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -3597,22 +3597,23 @@ impl ValueEnum {
                     let path = meta.path().clone();
                     match ident_of(&path).as_str() {
                         "name" => name = string_value(&meta)?,
-                        "alias" => {
-                            let alias = string_value(&meta)?;
-                            if alias.is_empty() {
-                                return Err(syn::Error::new_spanned(
-                                    path,
-                                    "an alias with no name would answer to nothing",
-                                ));
+                        "alias" | "aliases" => {
+                            for alias in selectors(&meta)? {
+                                if alias.is_empty() {
+                                    return Err(syn::Error::new_spanned(
+                                        &path,
+                                        "an alias with no name would answer to nothing",
+                                    ));
+                                }
+                                aliases.push(alias);
                             }
-                            aliases.push(alias);
                         }
                         other => {
                             return Err(syn::Error::new_spanned(
                                 path,
                                 format!(
                                     "unknown option `{other}` on a value; a variant takes \
-                                     `name` or `alias` here"
+                                     `name`, `alias`, or `aliases` here"
                                 ),
                             ));
                         }

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -2653,16 +2653,25 @@ fn group_decl(meta: &Meta) -> syn::Result<GroupDecl> {
 }
 
 fn selectors(meta: &Meta) -> syn::Result<Vec<String>> {
-    let Meta::List(list) = meta else {
-        return Ok(vec![string_value(meta)?]);
+    let found: Vec<String> = match meta {
+        Meta::List(list) => {
+            if let Ok(array) = syn::parse2::<syn::ExprArray>(list.tokens.clone()) {
+                string_array(&array)?
+            } else {
+                list.parse_args_with(
+                    syn::punctuated::Punctuated::<syn::LitStr, syn::Token![,]>::parse_terminated,
+                )?
+                .into_iter()
+                .map(|lit| lit.value())
+                .collect()
+            }
+        }
+        Meta::NameValue(value) => match &value.value {
+            syn::Expr::Array(array) => string_array(array)?,
+            _ => vec![string_value(meta)?],
+        },
+        Meta::Path(_) => vec![string_value(meta)?],
     };
-    let found: Vec<String> = list
-        .parse_args_with(
-            syn::punctuated::Punctuated::<syn::LitStr, syn::Token![,]>::parse_terminated,
-        )?
-        .into_iter()
-        .map(|lit| lit.value())
-        .collect();
     // An empty list compiles into no relationship at all, which is a declaration that
     // reads as though it does something.
     if found.is_empty() {
@@ -2676,6 +2685,20 @@ fn selectors(meta: &Meta) -> syn::Result<Vec<String>> {
         ));
     }
     Ok(found)
+}
+
+fn string_array(array: &syn::ExprArray) -> syn::Result<Vec<String>> {
+    array
+        .elems
+        .iter()
+        .map(|expr| match expr {
+            syn::Expr::Lit(syn::ExprLit {
+                lit: syn::Lit::Str(value),
+                ..
+            }) => Ok(value.value()),
+            _ => Err(syn::Error::new_spanned(expr, "expected a string literal")),
+        })
+        .collect()
 }
 
 fn requirement_if(meta: &Meta) -> syn::Result<ConditionalRequirement> {

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -4,6 +4,7 @@
 //! [`crate::codegen`], which keeps the error messages — the part an author
 //! actually interacts with — in one place.
 
+use heck::{ToKebabCase, ToLowerCamelCase, ToShoutySnakeCase, ToSnakeCase, ToUpperCamelCase};
 use proc_macro2::Span;
 use syn::ext::IdentExt as _;
 use syn::parse::Parser as _;
@@ -3460,6 +3461,56 @@ pub struct ValueVariant {
     pub cfg_attrs: Vec<syn::Attribute>,
 }
 
+#[derive(Clone, Copy)]
+enum CasingStyle {
+    Camel,
+    Kebab,
+    Pascal,
+    ScreamingSnake,
+    Snake,
+    Lower,
+    Upper,
+    Verbatim,
+}
+
+impl CasingStyle {
+    fn parse(meta: &Meta) -> syn::Result<Self> {
+        let raw = string_value(meta)?;
+        let normalized = raw
+            .chars()
+            .filter(|ch| ch.is_ascii_alphanumeric())
+            .flat_map(char::to_lowercase)
+            .collect::<String>();
+        match normalized.as_str() {
+            "camel" | "camelcase" => Ok(Self::Camel),
+            "kebab" | "kebabcase" => Ok(Self::Kebab),
+            "pascal" | "pascalcase" => Ok(Self::Pascal),
+            "screamingsnake" | "screamingsnakecase" => Ok(Self::ScreamingSnake),
+            "snake" | "snakecase" => Ok(Self::Snake),
+            "lower" | "lowercase" => Ok(Self::Lower),
+            "upper" | "uppercase" => Ok(Self::Upper),
+            "verbatim" | "verbatimcase" => Ok(Self::Verbatim),
+            _ => Err(syn::Error::new_spanned(
+                meta,
+                format!("unsupported casing `{raw}`"),
+            )),
+        }
+    }
+
+    fn apply(self, name: &str) -> String {
+        match self {
+            Self::Camel => name.to_lower_camel_case(),
+            Self::Kebab => name.to_kebab_case(),
+            Self::Pascal => name.to_upper_camel_case(),
+            Self::ScreamingSnake => name.to_shouty_snake_case(),
+            Self::Snake => name.to_snake_case(),
+            Self::Lower => name.to_snake_case().replace('_', ""),
+            Self::Upper => name.to_shouty_snake_case().replace('_', ""),
+            Self::Verbatim => name.to_string(),
+        }
+    }
+}
+
 fn cfg_gate_meta(meta: &Meta) -> syn::Result<Option<Meta>> {
     if meta.path().is_ident("cfg") {
         return Ok(Some(meta.clone()));
@@ -3589,6 +3640,7 @@ impl ValueEnum {
         }
 
         let mut ignore_case = false;
+        let mut rename_all = CasingStyle::Kebab;
         // Registering clap's `value` helper attribute means rustc accepts it at
         // either level. Parse it here too so unsupported enum-wide options fail
         // explicitly instead of being silently ignored.
@@ -3597,6 +3649,7 @@ impl ValueEnum {
                 let path = meta.path().clone();
                 match ident_of(&path).as_str() {
                     "ignore_case" => ignore_case = flag_value(&meta)?,
+                    "rename_all" => rename_all = CasingStyle::parse(&meta)?,
                     other => {
                         return Err(syn::Error::new_spanned(
                             path,
@@ -3616,7 +3669,7 @@ impl ValueEnum {
                 ));
             }
             let cfg_attrs = cfg_gate_attrs(&variant.attrs)?;
-            let mut name = to_kebab(&variant.ident.unraw().to_string());
+            let mut name = rename_all.apply(&variant.ident.unraw().to_string());
             let mut aliases = Vec::new();
             for attr in value_attrs(&variant.attrs) {
                 for meta in nested(attr)? {
@@ -4329,21 +4382,38 @@ mod tests {
     }
 
     #[test]
-    fn a_value_enum_rejects_unsupported_clap_container_metadata() {
+    fn a_value_enum_accepts_clap_container_casing() {
+        for (style, expected) in [
+            ("camelCase", "onePassword"),
+            ("kebab-case", "one-password"),
+            ("PascalCase", "OnePassword"),
+            ("SCREAMING_SNAKE_CASE", "ONE_PASSWORD"),
+            ("snake_case", "one_password"),
+            ("lowercase", "onepassword"),
+            ("UPPERCASE", "ONEPASSWORD"),
+            ("verbatim", "OnePassword"),
+        ] {
+            let ve = value_enum(&format!(
+                r#"
+                #[value(rename_all = "{style}")]
+                enum Provider {{ OnePassword }}
+            "#
+            ))
+            .expect("clap container metadata should remain usable");
+            assert_eq!(ve.variants[0].name, expected, "style {style}");
+        }
+
         let err = match value_enum(
             r#"
-            #[value(rename_all = "snake_case")]
-            enum Provider {
-                OnePassword,
-            }
+            #[value(rename_all = "train-case")]
+            enum Provider { OnePassword }
         "#,
         ) {
-            Ok(_) => panic!("unsupported clap container metadata must not be ignored"),
+            Ok(_) => panic!("unsupported casing must be rejected"),
             Err(err) => err,
         };
         assert!(
-            err.to_string()
-                .contains("unknown value-enum option `rename_all`"),
+            err.to_string().contains("unsupported casing `train-case`"),
             "unhelpful error: {err}"
         );
     }

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -3589,7 +3589,10 @@ impl ValueEnum {
         }
 
         let mut ignore_case = false;
-        for attr in attrs(&input.attrs) {
+        // Registering clap's `value` helper attribute means rustc accepts it at
+        // either level. Parse it here too so unsupported enum-wide options fail
+        // explicitly instead of being silently ignored.
+        for attr in value_attrs(&input.attrs) {
             for meta in nested(attr)? {
                 let path = meta.path().clone();
                 match ident_of(&path).as_str() {
@@ -4323,6 +4326,26 @@ mod tests {
         .expect("clap value metadata should remain usable");
         assert_eq!(ve.variants[0].name, "1password");
         assert_eq!(ve.variants[0].aliases, ["op"]);
+    }
+
+    #[test]
+    fn a_value_enum_rejects_unsupported_clap_container_metadata() {
+        let err = match value_enum(
+            r#"
+            #[value(rename_all = "snake_case")]
+            enum Provider {
+                OnePassword,
+            }
+        "#,
+        ) {
+            Ok(_) => panic!("unsupported clap container metadata must not be ignored"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string()
+                .contains("unknown value-enum option `rename_all`"),
+            "unhelpful error: {err}"
+        );
     }
 
     #[test]

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -59,8 +59,9 @@ struct InlineEx {
 #[derive(ValueEnum)]
 #[usage(ignore_case)]
 enum Shell {
+    #[value(aliases(["bourne-again", "bash-shell"]))]
     Bash,
-    #[value(alias("shell-z"), aliases("z-shell", "zsh-shell"))]
+    #[value(aliases = ["shell-z", "z-shell", "zsh-shell"])]
     Zsh,
     #[cfg(windows)]
     PowerShell,
@@ -224,6 +225,7 @@ fn emitted_specs_preserve_value_enum_aliases_and_case_policy() {
     assert!(kdl.contains("alias \"shell-z\" hide=#true"), "{kdl}");
     assert!(kdl.contains("alias \"z-shell\" hide=#true"), "{kdl}");
     assert!(kdl.contains("alias \"zsh-shell\" hide=#true"), "{kdl}");
+    assert!(kdl.contains("alias \"bourne-again\" hide=#true"), "{kdl}");
     #[cfg(not(windows))]
     assert!(!kdl.contains("power-shell"), "{kdl}");
 }

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -60,7 +60,7 @@ struct InlineEx {
 #[usage(ignore_case)]
 enum Shell {
     Bash,
-    #[usage(alias = "shell-z")]
+    #[value(alias("shell-z"), aliases("z-shell", "zsh-shell"))]
     Zsh,
     #[cfg(windows)]
     PowerShell,
@@ -222,6 +222,8 @@ fn emitted_specs_preserve_value_enum_aliases_and_case_policy() {
     let kdl = ChoiceEx::to_kdl();
     assert!(kdl.contains("choices ignore_case=#true"), "{kdl}");
     assert!(kdl.contains("alias \"shell-z\" hide=#true"), "{kdl}");
+    assert!(kdl.contains("alias \"z-shell\" hide=#true"), "{kdl}");
+    assert!(kdl.contains("alias \"zsh-shell\" hide=#true"), "{kdl}");
     #[cfg(not(windows))]
     assert!(!kdl.contains("power-shell"), "{kdl}");
 }


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive derive parsing and compatibility shims for ValueEnum; behavior for existing `#[usage(...)]` users is unchanged aside from broader alias/rename support.
> 
> **Overview**
> Makes **`usage::ValueEnum`** accept clap’s **`#[value(...)]`** metadata alongside **`#[usage(...)]`**, so enums can swap **`clap::ValueEnum`** for **`usage::ValueEnum`** without rewriting annotations. The derive registers **`value`** as a helper attribute and reads enum/variant options from either path.
> 
> **Enum-wide:** adds **`rename_all`** with clap-style casing (camel, kebab, Pascal, snake, screaming snake, lower/upper, verbatim) via the new **`heck`** dependency; unknown enum-level **`value`** options now error instead of being ignored.
> 
> **Per-variant:** **`alias`** and **`aliases`** can supply multiple strings; **`selectors`** now parses list syntax and **`name = [...]`** array forms used by clap.
> 
> Docs and integration tests move sample enums to **`#[value(...)]`** and assert multi-alias emission in the portable spec.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fc1b66c1920ea7c3b20626070acbff8bc5b6bb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->