### PR TITLE
feat(complete): add async runtime overlays

### DIFF
--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -343,7 +343,7 @@ impl<'a> CompletionOverlay<'a> {
 /// A projection inserts a command path after argv0 before walking the base tables. That lets a
 /// multicall binary such as `aubr` expose `aube run` without cloning a command tree or losing the
 /// root's global flags.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct App<'a> {
     view: SpecView<'a>,
     overlays: &'a [CompletionOverlay<'a>],
@@ -590,12 +590,25 @@ fn declared_files_at_cursor(
     split: &Split,
     position: &Position<'_>,
 ) -> Option<Files> {
+    if split.cword == 0
+        || (position.awaiting_value.is_none()
+            && position.flags_possible
+            && split.prefix.starts_with('-'))
+    {
+        return None;
+    }
     let meta = crate::help::find(spec, position.cmd).and_then(|(_, chain)| chain.last().copied());
     let at_cursor = if restarted(meta, split) {
         meta.and_then(|m| m.args.first()).map(|m| m.arg)
     } else {
         position.next_arg
     };
+    if position.awaiting_value.is_none()
+        && at_cursor.is_some_and(|arg| arg.double_dash == crate::DoubleDash::Required)
+        && !position.separator_seen
+    {
+        return None;
+    }
     let (name, complete_type) = if let Some(flag) = position.awaiting_value {
         let meta = flag_meta(spec.root, flag);
         (
@@ -806,28 +819,52 @@ fn overlay_at_cursor<'o>(
     position: &Position<'_>,
     overlays: &'o [CompletionOverlay<'_>],
 ) -> Option<&'o CompletionOverlay<'o>> {
-    if position.awaiting_value.is_none() && position.flags_possible && split.prefix.starts_with('-')
+    if split.cword == 0
+        || (position.awaiting_value.is_none()
+            && position.flags_possible
+            && split.prefix.starts_with('-'))
     {
         return None;
     }
     let meta = crate::help::find(spec, position.cmd).and_then(|(_, chain)| chain.last().copied());
     let target = if restarted(meta, split) {
-        meta.and_then(|owner| owner.args.first().map(|field| (owner, field.arg.name)))
+        meta.and_then(|owner| {
+            owner.args.first().map(|field| {
+                (
+                    owner,
+                    field.arg.name,
+                    field.arg.double_dash == crate::DoubleDash::Required,
+                )
+            })
+        })
     } else if let Some(flag) = position.awaiting_value {
         flag_meta_owner(spec.root, flag)
-            .map(|(owner, field)| (owner, field.value_name.unwrap_or(field.flag.name)))
+            .map(|(owner, field)| (owner, field.value_name.unwrap_or(field.flag.name), false))
     } else {
         position
             .next_arg
-            .and_then(|arg| {
-                arg_meta_owner(spec.root, arg).map(|(owner, field)| (owner, field.arg.name))
+            .and_then(|arg| arg_meta_owner(spec.root, arg))
+            .map(|(owner, field)| {
+                (
+                    owner,
+                    field.arg.name,
+                    field.arg.double_dash == crate::DoubleDash::Required,
+                )
             })
             .or_else(|| {
-                default_subcommand_arg(spec, split, position)
-                    .map(|(owner, field)| (owner, field.arg.name))
+                default_subcommand_arg(spec, split, position).map(|(owner, field)| {
+                    (
+                        owner,
+                        field.arg.name,
+                        field.arg.double_dash == crate::DoubleDash::Required,
+                    )
+                })
             })
     };
-    let (owner, value) = target?;
+    let (owner, value, needs_separator) = target?;
+    if needs_separator && !position.separator_seen {
+        return None;
+    }
     let (_, chain) = crate::help::find(spec, owner.cmd)?;
     let path: Vec<&str> = chain.iter().skip(1).map(|meta| meta.cmd.name).collect();
     overlays.iter().rev().find(|overlay| {
@@ -1848,6 +1885,12 @@ mod tests {
             "file",
             runtime_tools,
         )];
+    static PIPE_RUNTIME_COMPLETIONS: [CompletionOverlay<'static>; 1] =
+        [CompletionOverlay::asynchronous(
+            "pipe",
+            "path",
+            runtime_tools,
+        )];
     static PLUGIN_RUNTIME_COMPLETIONS: [CompletionOverlay<'static>; 1] =
         [CompletionOverlay::asynchronous(
             "plugins",
@@ -1875,6 +1918,34 @@ mod tests {
             &FILE_RUNTIME_COMPLETIONS,
         ));
         assert_eq!(file.files, Some(Files::Any));
+
+        let before_separator = run_ready(complete_with(
+            &SPEC,
+            &at_end("mise pipe "),
+            &PIPE_RUNTIME_COMPLETIONS,
+        ));
+        assert!(
+            before_separator
+                .candidates
+                .iter()
+                .all(|candidate| candidate.value != "uby"),
+            "{before_separator:?}"
+        );
+        assert_eq!(before_separator.files, None);
+
+        let after_separator = run_ready(complete_with(
+            &SPEC,
+            &at_end("mise pipe -- "),
+            &PIPE_RUNTIME_COMPLETIONS,
+        ));
+        assert!(
+            after_separator
+                .candidates
+                .iter()
+                .any(|candidate| candidate.value == "uby"),
+            "{after_separator:?}"
+        );
+        assert_eq!(after_separator.files, Some(Files::Any));
 
         let flag = run_ready(complete_with(
             &SPEC,
@@ -1992,6 +2063,37 @@ mod tests {
                 .completion_request(&binary_argv),
         );
         assert_eq!(with_projection, without_projection);
+
+        static ROOT_ARG: Command = Command {
+            name: "root-arg",
+            args: &[&TOOL],
+            ..Command::EMPTY
+        };
+        static ROOT_ARG_META: CommandMeta = CommandMeta {
+            cmd: &ROOT_ARG,
+            args: &[ArgMeta {
+                arg: &TOOL,
+                ..ArgMeta::EMPTY
+            }],
+            ..CommandMeta::EMPTY
+        };
+        static ROOT_ARG_SPEC: Spec = Spec {
+            name: "root-arg",
+            root: &ROOT_ARG_META,
+            ..Spec::EMPTY
+        };
+        let argv0 = run_ready(complete_with(
+            &ROOT_ARG_SPEC,
+            &at_end("root"),
+            &GLOBAL_RUNTIME_COMPLETIONS,
+        ));
+        assert!(
+            argv0
+                .candidates
+                .iter()
+                .all(|candidate| candidate.value != "rootuby"),
+            "{argv0:?}"
+        );
 
         let unrelated = at_end("mise plugins ");
         let answer = run_ready(complete_with(&SPEC, &unrelated, &RUNTIME_COMPLETIONS));

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -15,9 +15,12 @@
 //! as argv had the line been run — the parser downstream should see exactly what it would see
 //! in a real invocation.
 
-use crate::spec::{ArgMeta, CommandMeta, FlagMeta, Spec};
+use crate::spec::{ArgMeta, CommandMeta, CommandSelector, FlagMeta, Spec, SpecView};
 pub use crate::spec::{Candidate, CompleteCtx, Completer};
 use crate::{Arg, Command, Error, Flag, Parser};
+use core::future::Future;
+use core::pin::Pin;
+use std::ffi::OsString;
 
 /// Where the cursor is, in the grammar rather than in the line.
 ///
@@ -267,6 +270,189 @@ pub struct Completions<'a> {
     pub files: Option<Files>,
 }
 
+/// A completion future supplied by an embedding CLI.
+///
+/// usage-argv does not choose an executor. The application awaits this future on the runtime it
+/// already owns; the allocation exists only after the shell asks for candidates.
+pub type CompletionFuture<'a> = Pin<Box<dyn Future<Output = Vec<Candidate<'static>>> + 'a>>;
+
+/// An async completion function. Taking the context by value lets the future borrow its line and
+/// command tables without requiring global state or a runtime-specific callback trait.
+pub type AsyncCompleter = for<'a> fn(CompleteCtx<'a>) -> CompletionFuture<'a>;
+
+/// A runtime completion callback added to a derive-generated field.
+#[derive(Clone, Copy)]
+pub enum CompletionHandler {
+    Sync(Completer),
+    Async(AsyncCompleter),
+}
+
+impl core::fmt::Debug for CompletionHandler {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(match self {
+            Self::Sync(_) => "Sync(..)",
+            Self::Async(_) => "Async(..)",
+        })
+    }
+}
+
+/// One sparse completion override, selected by declaring command and normalized value name.
+#[derive(Debug, Clone, Copy)]
+pub struct CompletionOverlay<'a> {
+    pub command: CommandSelector<'a>,
+    pub value: &'a str,
+    pub handler: CompletionHandler,
+}
+
+impl<'a> CompletionOverlay<'a> {
+    pub const fn sync_any(value: &'a str, completer: Completer) -> Self {
+        Self {
+            command: CommandSelector::Any,
+            value,
+            handler: CompletionHandler::Sync(completer),
+        }
+    }
+
+    pub const fn async_any(value: &'a str, completer: AsyncCompleter) -> Self {
+        Self {
+            command: CommandSelector::Any,
+            value,
+            handler: CompletionHandler::Async(completer),
+        }
+    }
+
+    pub const fn sync(path: &'a str, value: &'a str, completer: Completer) -> Self {
+        Self {
+            command: CommandSelector::Path(path),
+            value,
+            handler: CompletionHandler::Sync(completer),
+        }
+    }
+
+    pub const fn asynchronous(path: &'a str, value: &'a str, completer: AsyncCompleter) -> Self {
+        Self {
+            command: CommandSelector::Path(path),
+            value,
+            handler: CompletionHandler::Async(completer),
+        }
+    }
+}
+
+/// A self-contained completion surface over a borrowed [`SpecView`].
+///
+/// A projection inserts a command path after argv0 before walking the base tables. That lets a
+/// multicall binary such as `aubr` expose `aube run` without cloning a command tree or losing the
+/// root's global flags.
+#[derive(Debug, Clone, Copy)]
+pub struct App<'a> {
+    view: SpecView<'a>,
+    overlays: &'a [CompletionOverlay<'a>],
+    projection: Option<&'a str>,
+}
+
+impl<'a> App<'a> {
+    pub const fn new(view: SpecView<'a>) -> Self {
+        Self {
+            view,
+            overlays: &[],
+            projection: None,
+        }
+    }
+
+    pub const fn completions(mut self, overlays: &'a [CompletionOverlay<'a>]) -> Self {
+        self.overlays = overlays;
+        self
+    }
+
+    pub const fn project(mut self, command_path: &'a str) -> Self {
+        self.projection = Some(command_path);
+        self
+    }
+
+    pub fn completion_script(self, shell: Shell) -> String {
+        let spec = self.view.spec();
+        crate::script::script(spec.bin.unwrap_or(spec.name), shell)
+    }
+
+    /// Answer a hidden completion invocation, or return `None` for ordinary argv.
+    pub async fn completion_request(self, argv: &[OsString]) -> Option<String> {
+        let request = Request::parse(argv)?;
+        let mut split = request.split;
+        if let Some(path) = self.projection {
+            let projected: Vec<String> =
+                path.split_ascii_whitespace().map(str::to_string).collect();
+            let count = projected.len();
+            split.words.splice(1..1, projected);
+            split.cword += count;
+        }
+        let spec = self.view.spec();
+        let answer = if let Some(name) = request.candidates_for {
+            complete_named_with(&spec, &split, self.overlays, &name).await
+        } else {
+            complete_with(&spec, &split, self.overlays).await
+        };
+        Some(render(&answer, request.shell))
+    }
+}
+
+impl<'a> SpecView<'a> {
+    /// Add compiled completion callbacks and optional multicall projections to this view.
+    pub const fn completion_app(self) -> App<'a> {
+        App::new(self)
+    }
+}
+
+struct Request {
+    shell: Shell,
+    split: Split,
+    candidates_for: Option<String>,
+}
+
+impl Request {
+    fn parse(argv: &[OsString]) -> Option<Self> {
+        if argv.first()?.to_str()? != "__complete_word__" {
+            return None;
+        }
+        let mut shell = Shell::Bash;
+        let mut line = String::new();
+        let mut cursor = None;
+        let mut candidates_for = None;
+        let mut rest = argv[1..].iter();
+        while let Some(arg) = rest.next() {
+            match arg.to_str().unwrap_or_default() {
+                "--shell" => {
+                    if let Some(found) = rest
+                        .next()
+                        .and_then(|name| Shell::from_name(&name.to_string_lossy()))
+                    {
+                        shell = found;
+                    }
+                }
+                "--line" => {
+                    if let Some(value) = rest.next() {
+                        line = value.to_string_lossy().into_owned();
+                    }
+                }
+                "--cursor" => {
+                    cursor = rest
+                        .next()
+                        .and_then(|value| value.to_str().and_then(|v| v.parse().ok()));
+                }
+                "--candidates" => {
+                    candidates_for = rest.next().map(|v| v.to_string_lossy().into_owned());
+                }
+                _ => {}
+            }
+        }
+        let cursor = cursor.unwrap_or(line.len());
+        Some(Self {
+            shell,
+            split: split(&line, cursor, shell),
+            candidates_for,
+        })
+    }
+}
+
 /// The line a shell reads to mean "paths belong here too".
 ///
 /// A whole line rather than a flag on the protocol, because every one of the five shells can
@@ -479,6 +665,143 @@ pub fn complete<'a>(spec: &'a Spec<'a>, split: &Split) -> Completions<'a> {
     };
 
     Completions { candidates, files }
+}
+
+/// Complete from the static tables plus sparse sync or async runtime callbacks.
+///
+/// No future or callback is created until a completion request reaches a field with an overlay.
+pub async fn complete_with<'a>(
+    spec: &'a Spec<'a>,
+    split: &Split,
+    overlays: &[CompletionOverlay<'_>],
+) -> Completions<'a> {
+    let position = walk(spec.root.cmd, split.argv());
+    let Some(overlay) = overlay_at_cursor(spec, split, &position, overlays) else {
+        return complete(spec, split);
+    };
+
+    let words = split.argv();
+    let command_path: Vec<(&Command<'_>, &[String])> = position
+        .path
+        .iter()
+        .map(|(cmd, start)| (*cmd, words.get(*start..).unwrap_or(&[])))
+        .collect();
+    let ctx = CompleteCtx {
+        words: &split.words,
+        cword: split.cword,
+        prefix: &split.prefix,
+        command_words: command_words(split, &position),
+        command_path: &command_path,
+    };
+    let mut dynamic = match overlay.handler {
+        CompletionHandler::Sync(completer) => completer(&ctx),
+        CompletionHandler::Async(completer) => completer(ctx).await,
+    };
+    dynamic.retain(|candidate| candidate.value.starts_with(&split.prefix));
+
+    let mut answer = complete(spec, split);
+    answer.candidates.extend(dynamic);
+    answer.candidates.sort();
+    answer
+        .candidates
+        .dedup_by(|left, right| left.value == right.value);
+    // Even an empty callback is a declared answer, not an invitation to offer the cwd.
+    answer.files = None;
+    answer
+}
+
+async fn complete_named_with<'a>(
+    spec: &'a Spec<'a>,
+    split: &Split,
+    overlays: &[CompletionOverlay<'_>],
+    name: &str,
+) -> Completions<'a> {
+    let position = walk(spec.root.cmd, split.argv());
+    let words = split.argv();
+    let command_path: Vec<(&Command<'_>, &[String])> = position
+        .path
+        .iter()
+        .map(|(cmd, start)| (*cmd, words.get(*start..).unwrap_or(&[])))
+        .collect();
+    let ctx = CompleteCtx {
+        words: &split.words,
+        cword: split.cword,
+        prefix: &split.prefix,
+        command_words: command_words(split, &position),
+        command_path: &command_path,
+    };
+    let mut candidates = for_name(spec, name, &ctx).unwrap_or_default();
+    if let Some(overlay) = overlay_at_cursor(spec, split, &position, overlays)
+        .filter(|overlay| overlay.value.eq_ignore_ascii_case(name))
+    {
+        let mut dynamic = match overlay.handler {
+            CompletionHandler::Sync(completer) => completer(&ctx),
+            CompletionHandler::Async(completer) => completer(ctx).await,
+        };
+        candidates.append(&mut dynamic);
+    }
+    candidates.retain(|candidate| candidate.value.starts_with(&split.prefix));
+    candidates.sort();
+    candidates.dedup_by(|left, right| left.value == right.value);
+    Completions {
+        candidates,
+        files: None,
+    }
+}
+
+fn overlay_at_cursor<'o>(
+    spec: &Spec<'_>,
+    split: &Split,
+    position: &Position<'_>,
+    overlays: &'o [CompletionOverlay<'_>],
+) -> Option<&'o CompletionOverlay<'o>> {
+    let meta = crate::help::find(spec, position.cmd).and_then(|(_, chain)| chain.last().copied());
+    let target = if restarted(meta, split) {
+        meta.and_then(|owner| owner.args.first().map(|field| (owner, field.arg.name)))
+    } else if let Some(flag) = position.awaiting_value {
+        flag_meta_owner(spec.root, flag)
+            .map(|(owner, field)| (owner, field.value_name.unwrap_or(field.flag.name)))
+    } else {
+        position.next_arg.and_then(|arg| {
+            arg_meta_owner(spec.root, arg).map(|(owner, field)| (owner, field.arg.name))
+        })
+    };
+    let (owner, value) = target?;
+    let (_, chain) = crate::help::find(spec, owner.cmd)?;
+    let path: Vec<&str> = chain.iter().skip(1).map(|meta| meta.cmd.name).collect();
+    overlays.iter().rev().find(|overlay| {
+        overlay.value.eq_ignore_ascii_case(value) && overlay.command.matches(owner, &path)
+    })
+}
+
+fn flag_meta_owner<'a>(
+    meta: &'a CommandMeta<'a>,
+    flag: &Flag<'_>,
+) -> Option<(&'a CommandMeta<'a>, &'a FlagMeta<'a>)> {
+    meta.flags
+        .iter()
+        .find(|field| core::ptr::eq(field.flag, flag))
+        .map(|field| (meta, field))
+        .or_else(|| {
+            meta.subcommands
+                .iter()
+                .find_map(|sub| flag_meta_owner(sub, flag))
+        })
+}
+
+fn arg_meta_owner<'a>(
+    meta: &'a CommandMeta<'a>,
+    arg: &Arg<'_>,
+) -> Option<(&'a CommandMeta<'a>, &'a ArgMeta<'a>)> {
+    meta.args
+        .iter()
+        .find(|field| core::ptr::eq(field.arg, arg))
+        .map(|field| (meta, field))
+        .or_else(|| {
+            meta.subcommands
+                .iter()
+                .find_map(|sub| arg_meta_owner(sub, arg))
+        })
 }
 
 /// Just the candidates this CLI knows about, without the question of paths.
@@ -1019,6 +1342,24 @@ fn floor_char_boundary(s: &str, index: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+    use std::task::{Context, Poll, Wake, Waker};
+
+    struct NoopWake;
+
+    impl Wake for NoopWake {
+        fn wake(self: Arc<Self>) {}
+    }
+
+    fn run_ready<F: Future>(future: F) -> F::Output {
+        let waker = Waker::from(Arc::new(NoopWake));
+        let mut cx = Context::from_waker(&waker);
+        let mut future = std::pin::pin!(future);
+        match future.as_mut().poll(&mut cx) {
+            Poll::Ready(output) => output,
+            Poll::Pending => panic!("test completion unexpectedly needed an executor wakeup"),
+        }
+    }
 
     /// A small tree with the shapes that make a cursor's position non-obvious: a global flag,
     /// a flag that takes a value, a subcommand of a subcommand, and a wrapper that forwards.
@@ -1424,6 +1765,59 @@ mod tests {
             .into_iter()
             .map(|c| c.value)
             .collect()
+    }
+
+    fn runtime_tools(ctx: CompleteCtx<'_>) -> CompletionFuture<'_> {
+        Box::pin(async move {
+            vec![Candidate::described(
+                format!("{}uby", ctx.prefix),
+                "from async runtime state",
+            )]
+        })
+    }
+
+    static RUNTIME_COMPLETIONS: [CompletionOverlay<'static>; 1] =
+        [CompletionOverlay::asynchronous(
+            "use",
+            "tool",
+            runtime_tools,
+        )];
+
+    #[test]
+    fn async_overlays_run_only_for_the_field_and_projection_at_the_cursor() {
+        let split = at_end("mise use r");
+        let answer = run_ready(complete_with(&SPEC, &split, &RUNTIME_COMPLETIONS));
+        assert_eq!(
+            answer
+                .candidates
+                .iter()
+                .map(|candidate| candidate.value.as_str())
+                .collect::<Vec<_>>(),
+            ["ruby"]
+        );
+        assert_eq!(answer.files, None);
+
+        let argv = [
+            OsString::from("__complete_word__"),
+            OsString::from("--shell"),
+            OsString::from("bash"),
+            OsString::from("--line"),
+            OsString::from("miser r"),
+        ];
+        let rendered = run_ready(
+            SPEC.view()
+                .name("miser")
+                .bin("miser")
+                .completion_app()
+                .completions(&RUNTIME_COMPLETIONS)
+                .project("use")
+                .completion_request(&argv),
+        );
+        assert_eq!(rendered.as_deref(), Some("ruby\n"));
+
+        let unrelated = at_end("mise plugins ");
+        let answer = run_ready(complete_with(&SPEC, &unrelated, &RUNTIME_COMPLETIONS));
+        assert_eq!(answer.candidates[0].value, "ls");
     }
 
     /// The position at the cursor of a line, which is what a completion asks about.

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -601,7 +601,9 @@ fn declared_files_at_cursor(
     let at_cursor = if restarted(meta, split) {
         meta.and_then(|m| m.args.first()).map(|m| m.arg)
     } else {
-        position.next_arg
+        position
+            .next_arg
+            .or_else(|| default_subcommand_arg(spec, split, position).map(|(_, field)| field.arg))
     };
     if position.awaiting_value.is_none()
         && at_cursor.is_some_and(|arg| arg.double_dash == crate::DoubleDash::Required)
@@ -1971,6 +1973,20 @@ mod tests {
                 .any(|candidate| candidate.value == "ruby"),
             "{implied:?}"
         );
+
+        static FILE_DEFAULT_SPEC: Spec = Spec {
+            name: "mise",
+            bin: Some("mise"),
+            root: &META_ROOT,
+            default_subcommand: Some("edit"),
+            ..Spec::EMPTY
+        };
+        let implied_file = run_ready(complete_with(
+            &FILE_DEFAULT_SPEC,
+            &at_end("mise m"),
+            &FILE_RUNTIME_COMPLETIONS,
+        ));
+        assert_eq!(implied_file.files, Some(Files::Any));
 
         let named = run_ready(complete_named_with(
             &SPEC,

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -757,7 +757,12 @@ fn overlay_for_name<'o>(
     overlays.iter().rev().find(|overlay| {
         overlay.value.eq_ignore_ascii_case(name)
             && chain.iter().enumerate().rev().any(|(index, owner)| {
-                let path: Vec<&str> = chain[1..=index].iter().map(|meta| meta.cmd.name).collect();
+                let path: Vec<&str> = chain
+                    .iter()
+                    .take(index + 1)
+                    .skip(1)
+                    .map(|meta| meta.cmd.name)
+                    .collect();
                 overlay.command.matches(owner, &path)
             })
     })
@@ -1841,6 +1846,19 @@ mod tests {
                 .iter()
                 .any(|candidate| candidate.value == "uby"),
             "{named:?}"
+        );
+        let named_at_root = run_ready(complete_named_with(
+            &SPEC,
+            &at_end("mise "),
+            &GLOBAL_RUNTIME_COMPLETIONS,
+            "tool",
+        ));
+        assert!(
+            named_at_root
+                .candidates
+                .iter()
+                .any(|candidate| candidate.value == "uby"),
+            "{named_at_root:?}"
         );
 
         let argv = [

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -585,6 +585,34 @@ fn files_for(name: &str) -> Option<Files> {
     }
 }
 
+fn declared_files_at_cursor(
+    spec: &Spec<'_>,
+    split: &Split,
+    position: &Position<'_>,
+) -> Option<Files> {
+    let meta = crate::help::find(spec, position.cmd).and_then(|(_, chain)| chain.last().copied());
+    let at_cursor = if restarted(meta, split) {
+        meta.and_then(|m| m.args.first()).map(|m| m.arg)
+    } else {
+        position.next_arg
+    };
+    let (name, complete_type) = if let Some(flag) = position.awaiting_value {
+        let meta = flag_meta(spec.root, flag);
+        (
+            meta.and_then(|m| m.value_name).or(Some(flag.name)),
+            meta.and_then(|m| m.complete_type),
+        )
+    } else if let Some(arg) = at_cursor {
+        let meta = arg_meta(spec.root, arg);
+        (Some(arg.name), meta.and_then(|m| m.complete_type))
+    } else {
+        (None, None)
+    };
+    complete_type
+        .and_then(files_for)
+        .or_else(|| name.and_then(files_for))
+}
+
 /// What could be typed at the cursor, given a spec and a split line.
 ///
 /// The rules are usage-lib's, because a CLI's completions should not change with the
@@ -709,8 +737,9 @@ pub async fn complete_with<'a>(
     answer
         .candidates
         .dedup_by(|left, right| left.value == right.value);
-    // Even an empty callback is a declared answer, not an invitation to offer the cwd.
-    answer.files = None;
+    // Even an empty callback suppresses the cwd fallback, but a field that
+    // explicitly declares files or directories keeps that shell completion.
+    answer.files = declared_files_at_cursor(spec, split, &position);
     answer
 }
 
@@ -735,7 +764,7 @@ async fn complete_named_with<'a>(
         command_path: &command_path,
     };
     let mut candidates = for_name(spec, name, &ctx).unwrap_or_default();
-    if let Some(overlay) = overlay_for_name(spec, &position, overlays, name) {
+    if let Some(overlay) = overlay_for_name(spec, split, &position, overlays, name) {
         let mut dynamic = match overlay.handler {
             CompletionHandler::Sync(completer) => completer(&ctx),
             CompletionHandler::Async(completer) => completer(ctx).await,
@@ -753,22 +782,21 @@ async fn complete_named_with<'a>(
 
 fn overlay_for_name<'o>(
     spec: &Spec<'_>,
+    split: &Split,
     position: &Position<'_>,
     overlays: &'o [CompletionOverlay<'_>],
     name: &str,
 ) -> Option<&'o CompletionOverlay<'o>> {
+    if let Some(overlay) = overlay_at_cursor(spec, split, position, overlays)
+        .filter(|overlay| overlay.value.eq_ignore_ascii_case(name))
+    {
+        return Some(overlay);
+    }
     let (_, chain) = crate::help::find(spec, position.cmd)?;
+    let owner = chain.last()?;
+    let path: Vec<&str> = chain.iter().skip(1).map(|meta| meta.cmd.name).collect();
     overlays.iter().rev().find(|overlay| {
-        overlay.value.eq_ignore_ascii_case(name)
-            && chain.iter().enumerate().rev().any(|(index, owner)| {
-                let path: Vec<&str> = chain
-                    .iter()
-                    .take(index + 1)
-                    .skip(1)
-                    .map(|meta| meta.cmd.name)
-                    .collect();
-                overlay.command.matches(owner, &path)
-            })
+        overlay.value.eq_ignore_ascii_case(name) && overlay.command.matches(owner, &path)
     })
 }
 
@@ -1814,6 +1842,18 @@ mod tests {
         )];
     static GLOBAL_RUNTIME_COMPLETIONS: [CompletionOverlay<'static>; 1] =
         [CompletionOverlay::async_any("tool", runtime_tools)];
+    static FILE_RUNTIME_COMPLETIONS: [CompletionOverlay<'static>; 1] =
+        [CompletionOverlay::asynchronous(
+            "edit",
+            "file",
+            runtime_tools,
+        )];
+    static PLUGIN_RUNTIME_COMPLETIONS: [CompletionOverlay<'static>; 1] =
+        [CompletionOverlay::asynchronous(
+            "plugins",
+            "tool",
+            runtime_tools,
+        )];
 
     #[test]
     fn async_overlays_run_only_for_the_field_and_projection_at_the_cursor() {
@@ -1828,6 +1868,13 @@ mod tests {
             ["ruby"]
         );
         assert_eq!(answer.files, None);
+
+        let file = run_ready(complete_with(
+            &SPEC,
+            &at_end("mise edit "),
+            &FILE_RUNTIME_COMPLETIONS,
+        ));
+        assert_eq!(file.files, Some(Files::Any));
 
         let flag = run_ready(complete_with(
             &SPEC,
@@ -1879,6 +1926,33 @@ mod tests {
                 .iter()
                 .any(|candidate| candidate.value == "uby"),
             "{named_at_root:?}"
+        );
+
+        let named_on_owner = run_ready(complete_named_with(
+            &SPEC,
+            &at_end("mise plugins "),
+            &PLUGIN_RUNTIME_COMPLETIONS,
+            "tool",
+        ));
+        assert!(
+            named_on_owner
+                .candidates
+                .iter()
+                .any(|candidate| candidate.value == "uby"),
+            "{named_on_owner:?}"
+        );
+        let named_on_descendant = run_ready(complete_named_with(
+            &SPEC,
+            &at_end("mise plugins ls "),
+            &PLUGIN_RUNTIME_COMPLETIONS,
+            "tool",
+        ));
+        assert!(
+            named_on_descendant
+                .candidates
+                .iter()
+                .all(|candidate| candidate.value != "uby"),
+            "{named_on_descendant:?}"
         );
 
         let argv = [

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -731,9 +731,7 @@ async fn complete_named_with<'a>(
         command_path: &command_path,
     };
     let mut candidates = for_name(spec, name, &ctx).unwrap_or_default();
-    if let Some(overlay) = overlay_at_cursor(spec, split, &position, overlays)
-        .filter(|overlay| overlay.value.eq_ignore_ascii_case(name))
-    {
+    if let Some(overlay) = overlay_for_name(spec, &position, overlays, name) {
         let mut dynamic = match overlay.handler {
             CompletionHandler::Sync(completer) => completer(&ctx),
             CompletionHandler::Async(completer) => completer(ctx).await,
@@ -749,6 +747,22 @@ async fn complete_named_with<'a>(
     }
 }
 
+fn overlay_for_name<'o>(
+    spec: &Spec<'_>,
+    position: &Position<'_>,
+    overlays: &'o [CompletionOverlay<'_>],
+    name: &str,
+) -> Option<&'o CompletionOverlay<'o>> {
+    let (_, chain) = crate::help::find(spec, position.cmd)?;
+    overlays.iter().rev().find(|overlay| {
+        overlay.value.eq_ignore_ascii_case(name)
+            && chain.iter().enumerate().rev().any(|(index, owner)| {
+                let path: Vec<&str> = chain[1..=index].iter().map(|meta| meta.cmd.name).collect();
+                overlay.command.matches(owner, &path)
+            })
+    })
+}
+
 fn overlay_at_cursor<'o>(
     spec: &Spec<'_>,
     split: &Split,
@@ -762,9 +776,15 @@ fn overlay_at_cursor<'o>(
         flag_meta_owner(spec.root, flag)
             .map(|(owner, field)| (owner, field.value_name.unwrap_or(field.flag.name)))
     } else {
-        position.next_arg.and_then(|arg| {
-            arg_meta_owner(spec.root, arg).map(|(owner, field)| (owner, field.arg.name))
-        })
+        position
+            .next_arg
+            .and_then(|arg| {
+                arg_meta_owner(spec.root, arg).map(|(owner, field)| (owner, field.arg.name))
+            })
+            .or_else(|| {
+                default_subcommand_arg(spec, split, position)
+                    .map(|(owner, field)| (owner, field.arg.name))
+            })
     };
     let (owner, value) = target?;
     let (_, chain) = crate::help::find(spec, owner.cmd)?;
@@ -772,6 +792,22 @@ fn overlay_at_cursor<'o>(
     overlays.iter().rev().find(|overlay| {
         overlay.value.eq_ignore_ascii_case(value) && overlay.command.matches(owner, &path)
     })
+}
+
+fn default_subcommand_arg<'a>(
+    spec: &'a Spec<'a>,
+    split: &Split,
+    position: &Position<'_>,
+) -> Option<(&'a CommandMeta<'a>, &'a ArgMeta<'a>)> {
+    if !core::ptr::eq(position.cmd, spec.root.cmd) || position.help_topic || split.cword == 0 {
+        return None;
+    }
+    let default = spec.default_subcommand?;
+    let subcommands = || spec.root.subcommands.iter().copied();
+    subcommands()
+        .find(|sub| sub.cmd.name == default)
+        .or_else(|| subcommands().find(|sub| sub.cmd.aliases.contains(&default)))
+        .and_then(|sub| sub.args.first().map(|field| (sub, field)))
 }
 
 fn flag_meta_owner<'a>(
@@ -844,20 +880,8 @@ pub fn candidates<'a>(spec: &'a Spec<'a>, split: &Split) -> Vec<Candidate<'a>> {
         // `mise build` is `mise run build` — so what that command's first argument accepts is
         // a candidate here too. Only its first: the words that would fill the rest have not
         // been typed, since the subcommand name itself was elided.
-        if core::ptr::eq(position.cmd, spec.root.cmd) && !position.help_topic {
-            if let Some(default) = spec.default_subcommand {
-                // By any name it answers to: `default_subcommand` names a command, and a
-                // spec may name it the way its author refers to it rather than canonically.
-                // Names before aliases, so the command whose first argument is offered here
-                // is the one the parser would actually route the word to.
-                let subcommands = || spec.root.subcommands.iter();
-                let target = subcommands()
-                    .find(|sub| sub.cmd.name == default)
-                    .or_else(|| subcommands().find(|sub| sub.cmd.aliases.contains(&default)));
-                if let Some(arg) = target.and_then(|sub| sub.args.first()) {
-                    found.extend(positional(arg, &position, split, token));
-                }
-            }
+        if let Some((_, arg)) = default_subcommand_arg(spec, split, &position) {
+            found.extend(positional(arg, &position, split, token));
         }
         found
     };
@@ -1342,18 +1366,11 @@ fn floor_char_boundary(s: &str, index: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Arc;
-    use std::task::{Context, Poll, Wake, Waker};
-
-    struct NoopWake;
-
-    impl Wake for NoopWake {
-        fn wake(self: Arc<Self>) {}
-    }
+    use std::task::{Context, Poll, Waker};
 
     fn run_ready<F: Future>(future: F) -> F::Output {
-        let waker = Waker::from(Arc::new(NoopWake));
-        let mut cx = Context::from_waker(&waker);
+        let waker = Waker::noop();
+        let mut cx = Context::from_waker(waker);
         let mut future = std::pin::pin!(future);
         match future.as_mut().poll(&mut cx) {
             Poll::Ready(output) => output,
@@ -1782,6 +1799,8 @@ mod tests {
             "tool",
             runtime_tools,
         )];
+    static GLOBAL_RUNTIME_COMPLETIONS: [CompletionOverlay<'static>; 1] =
+        [CompletionOverlay::async_any("tool", runtime_tools)];
 
     #[test]
     fn async_overlays_run_only_for_the_field_and_projection_at_the_cursor() {
@@ -1796,6 +1815,33 @@ mod tests {
             ["ruby"]
         );
         assert_eq!(answer.files, None);
+
+        let implied = run_ready(complete_with(
+            &SPEC,
+            &at_end("mise r"),
+            &RUNTIME_COMPLETIONS,
+        ));
+        assert!(
+            implied
+                .candidates
+                .iter()
+                .any(|candidate| candidate.value == "ruby"),
+            "{implied:?}"
+        );
+
+        let named = run_ready(complete_named_with(
+            &SPEC,
+            &at_end("mise plugins "),
+            &GLOBAL_RUNTIME_COMPLETIONS,
+            "tool",
+        ));
+        assert!(
+            named
+                .candidates
+                .iter()
+                .any(|candidate| candidate.value == "uby"),
+            "{named:?}"
+        );
 
         let argv = [
             OsString::from("__complete_word__"),

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -774,6 +774,10 @@ fn overlay_at_cursor<'o>(
     position: &Position<'_>,
     overlays: &'o [CompletionOverlay<'_>],
 ) -> Option<&'o CompletionOverlay<'o>> {
+    if position.awaiting_value.is_none() && position.flags_possible && split.prefix.starts_with('-')
+    {
+        return None;
+    }
     let meta = crate::help::find(spec, position.cmd).and_then(|(_, chain)| chain.last().copied());
     let target = if restarted(meta, split) {
         meta.and_then(|owner| owner.args.first().map(|field| (owner, field.arg.name)))
@@ -1820,6 +1824,18 @@ mod tests {
             ["ruby"]
         );
         assert_eq!(answer.files, None);
+
+        let flag = run_ready(complete_with(
+            &SPEC,
+            &at_end("mise use -"),
+            &RUNTIME_COMPLETIONS,
+        ));
+        assert!(
+            flag.candidates
+                .iter()
+                .all(|candidate| candidate.value != "-uby"),
+            "{flag:?}"
+        );
 
         let implied = run_ready(complete_with(
             &SPEC,

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -383,7 +383,11 @@ impl<'a> App<'a> {
                 path.split_ascii_whitespace().map(str::to_string).collect();
             let count = projected.len();
             split.words.splice(1..1, projected);
-            split.cword += count;
+            // A projection lives after argv0. When the cursor is still editing
+            // argv0, inserting that path must not move the cursor into it.
+            if split.cword > 0 {
+                split.cword += count;
+            }
         }
         let spec = self.view.spec();
         let answer = if let Some(name) = request.candidates_for {
@@ -1894,6 +1898,26 @@ mod tests {
                 .completion_request(&argv),
         );
         assert_eq!(rendered.as_deref(), Some("ruby\n"));
+
+        let binary_argv = [
+            OsString::from("__complete_word__"),
+            OsString::from("--shell"),
+            OsString::from("bash"),
+            OsString::from("--line"),
+            OsString::from("mis"),
+        ];
+        let without_projection = run_ready(
+            SPEC.view()
+                .completion_app()
+                .completion_request(&binary_argv),
+        );
+        let with_projection = run_ready(
+            SPEC.view()
+                .completion_app()
+                .project("use")
+                .completion_request(&binary_argv),
+        );
+        assert_eq!(with_projection, without_projection);
 
         let unrelated = at_end("mise plugins ");
         let answer = run_ready(complete_with(&SPEC, &unrelated, &RUNTIME_COMPLETIONS));

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -319,13 +319,15 @@ pub struct Spec<'a> {
 /// when the command type is available and avoid coupling an overlay to its displayed spelling.
 #[derive(Debug, Clone, Copy)]
 pub enum CommandSelector<'a> {
+    Any,
     Path(&'a str),
     Key(u64),
 }
 
 impl CommandSelector<'_> {
-    fn matches(&self, meta: &CommandMeta<'_>, path: &[&str]) -> bool {
+    pub(crate) fn matches(&self, meta: &CommandMeta<'_>, path: &[&str]) -> bool {
         match self {
+            Self::Any => true,
             Self::Path(expected) => expected.split_ascii_whitespace().eq(path.iter().copied()),
             Self::Key(key) => meta.cmd.key == *key,
         }


### PR DESCRIPTION
## Summary

- add sparse sync and executor-agnostic async completion callbacks
- add a borrowed completion `App` over `SpecView`
- add multicall projections that insert a command path while retaining root globals
- centralize hidden completion-request parsing for embedders

Callbacks allocate only after a shell reaches the overlaid field. usage-rs does not bundle or select an async runtime; the embedding CLI awaits the returned future on its existing executor.

## Verification

- `cargo test -p usage-argv --all-features`
- `cargo test -p usage-rs --all-features`
- async overlay, unrelated-field, and projected-binary coverage
- the normal parser no-allocation test remains green

_This PR was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches completion cursor/overlay resolution and file-fallback behavior; async API is new but gated behind overlays and existing static path remains when no overlay matches.
> 
> **Overview**
> **Runtime completion overlays** let embedders attach sync or executor-agnostic async callbacks (`CompletionOverlay`, `CompletionHandler`, `AsyncCompleter`) keyed by command path and value name. `complete_with` and `complete_named_with` merge static candidates with overlay output only when the cursor matches that field; overlays suppress the cwd file fallback unless the field still declares file/dir completion via `declared_files_at_cursor`.
> 
> **`App` on `SpecView`** wires overlays, optional `project()` for multicall binaries (insert command path after argv0), `completion_script`, and async `completion_request` that parses `__complete_word__` argv (`Request::parse`) and renders shell-specific output.
> 
> **`CommandSelector::Any`** matches any command for global overlays; default-subcommand first-arg completion is refactored into `default_subcommand_arg` and reused by overlays and static `candidates`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ea5ba8f0adb2ce3d446bfd8665c94d1eea1e60d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->