### PR TITLE
feat(derive): parse full argv with program name

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -719,11 +719,11 @@ feature list is not an exhaustive audit.
       help and diagnostics still use the static name. Support a runtime identity
       source with an explicit portable `name`/`bin` value, analogous to computed
       version plus `version_spec`.
-- [ ] **Test parsing with argv0.** `parse_from` intentionally takes words after
+- [x] **Test parsing with argv0.** `parse_from` intentionally takes words after
       the binary, while clap tests commonly call `try_parse_from(["tool", ...])`.
-      Fleet ports needed local wrappers just to preserve their parser tests.
-      Add an explicit argv0-taking helper rather than making every migration
-      hand-roll `skip(1)` and accidentally obscure multicall semantics.
+      `parse_from_argv` is the explicit full-argv helper: it strips the binary
+      for ordinary CLIs and applies the same basename-selected applet rewrite as
+      `parse()` for multicall CLIs, while returning errors for tests and embedders.
 - [ ] **Generated micro-conformance against clap.** One minimal CLI per matrix row,
       compared on accepted and rejected argv, typed values, error kind and exit
       status, stdout versus stderr, short and long help, usage/version output, and
@@ -1130,9 +1130,10 @@ repeated here.
       1.91, so a CLI that links it for spec generation inherits the bump. The
       argv/derive tier is dependency-free by design; keeping a low-MSRV path to
       spec emission — without usage-lib — is what lets a conservative CLI adopt.
-- [ ] **The `parse_from` argv0 contract.** It differs from clap's, which broke
-      fnox's test helpers in the rewrite experiment. Decide it, document it,
-      and provide a clap-shaped variant if the difference stays.
+- [x] **The `parse_from` argv0 contract.** It differs from clap's, which broke
+      fnox's test helpers in the rewrite experiment. `parse_from` remains the
+      allocation-free words-only primitive; `parse_from_argv` is the explicit
+      clap-shaped, argv0-taking variant and preserves multicall selection.
 - [ ] **Shared `Args` under multiple commands need wrapper types** in the
       derive, where clap lets one struct serve several parents directly.
       flatten covers the mise `ConfigLs` shape; the fnox shape is the same

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -433,7 +433,7 @@ pub enum DoubleDash {
 
 /// Something the parser bound.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Event<'t, 'v> {
+pub enum Event<'t, 'a, 'v> {
     /// A subcommand was selected; parsing continues inside it.
     Command(&'t Command<'t>),
     /// A flag was given. `value` is `Some` for a flag that takes one, and
@@ -448,7 +448,7 @@ pub enum Event<'t, 'v> {
     Arg { arg: &'t Arg<'t>, value: &'v [u8] },
     /// An unmatched word was forwarded as an external command: the name, then
     /// every remaining token, including flags.
-    External { values: &'v [&'v OsStr] },
+    External { values: &'a [&'v OsStr] },
 }
 
 /// A binding failure.
@@ -981,8 +981,8 @@ pub fn os_string_from_bytes(value: Vec<u8>) -> Result<OsString, Vec<u8>> {
 /// A single-pass parse over `argv`.
 ///
 /// Created with [`Parser::new`] and driven with [`Parser::next_event`].
-pub struct Parser<'t, 'v> {
-    argv: &'v [&'v OsStr],
+pub struct Parser<'t, 'a, 'v> {
+    argv: &'a [&'v OsStr],
     /// Index of the next token to read.
     pos: usize,
     /// The command currently in scope.
@@ -1045,11 +1045,11 @@ pub struct Parser<'t, 'v> {
     help_span: (usize, usize),
 }
 
-impl<'t: 'v, 'v> Parser<'t, 'v> {
+impl<'t: 'v, 'a, 'v> Parser<'t, 'a, 'v> {
     /// Begin parsing `argv` against `root`.
     ///
     /// `argv` excludes the program name.
-    pub fn new(root: &'t Command<'t>, argv: &'v [&'v OsStr]) -> Self {
+    pub fn new(root: &'t Command<'t>, argv: &'a [&'v OsStr]) -> Self {
         Parser {
             argv,
             pos: 0,
@@ -1173,7 +1173,7 @@ impl<'t: 'v, 'v> Parser<'t, 'v> {
     /// bundle containing an unrecognized letter yields the error *instead of*, not
     /// after, the letters that did match.
     #[allow(clippy::should_implement_trait)] // not an Iterator: items borrow from self's tables
-    pub fn next_event(&mut self) -> Option<Result<Event<'t, 'v>, Error<'t, 'v>>> {
+    pub fn next_event(&mut self) -> Option<Result<Event<'t, 'a, 'v>, Error<'t, 'v>>> {
         if self.done {
             return None;
         }
@@ -1184,7 +1184,7 @@ impl<'t: 'v, 'v> Parser<'t, 'v> {
         event
     }
 
-    fn step(&mut self) -> Option<Result<Event<'t, 'v>, Error<'t, 'v>>> {
+    fn step(&mut self) -> Option<Result<Event<'t, 'a, 'v>, Error<'t, 'v>>> {
         // A partly-read short bundle takes priority: its remaining bytes are
         // still part of the token being processed.
         if !self.bundle.is_empty() {
@@ -1287,7 +1287,7 @@ impl<'t: 'v, 'v> Parser<'t, 'v> {
         Some(self.word(token))
     }
 
-    fn long_flag(&mut self, token: &'v [u8]) -> Result<Event<'t, 'v>, Error<'t, 'v>> {
+    fn long_flag(&mut self, token: &'v [u8]) -> Result<Event<'t, 'a, 'v>, Error<'t, 'v>> {
         let body = &token[2..];
         let (name, attached) = match body.iter().position(|&b| b == b'=') {
             Some(i) => (&body[..i], Some(&body[i + 1..])),
@@ -1365,7 +1365,7 @@ impl<'t: 'v, 'v> Parser<'t, 'v> {
         Ok(())
     }
 
-    fn short_flag(&mut self) -> Result<Event<'t, 'v>, Error<'t, 'v>> {
+    fn short_flag(&mut self) -> Result<Event<'t, 'a, 'v>, Error<'t, 'v>> {
         let byte = self.bundle[0];
         let rest = &self.bundle[1..];
 
@@ -1434,7 +1434,7 @@ impl<'t: 'v, 'v> Parser<'t, 'v> {
         }
     }
 
-    fn word(&mut self, token: &'v [u8]) -> Result<Event<'t, 'v>, Error<'t, 'v>> {
+    fn word(&mut self, token: &'v [u8]) -> Result<Event<'t, 'a, 'v>, Error<'t, 'v>> {
         // Subcommands are only matched where descent is still possible: once a
         // positional of this command has taken a word, a later word that happens
         // to equal a subcommand name is just a value.
@@ -1660,7 +1660,7 @@ impl<'t: 'v, 'v> Parser<'t, 'v> {
 /// `as_encoded_bytes` is a plain accessor with no conversion and no allocation.
 /// The reverse direction is the one with a cost — see [`os_string_from_bytes`] —
 /// which is why values come back as bytes.
-fn bytes<'v>(s: &'v &'v OsStr) -> &'v [u8] {
+fn bytes<'v>(s: &&'v OsStr) -> &'v [u8] {
     s.as_encoded_bytes()
 }
 
@@ -1853,7 +1853,7 @@ mod tests {
     fn parse<'t: 'v, 'v>(
         root: &'t Command<'t>,
         argv: &'v [&'v OsStr],
-    ) -> Result<Vec<Event<'t, 'v>>, Error<'t, 'v>> {
+    ) -> Result<Vec<Event<'t, 'v, 'v>>, Error<'t, 'v>> {
         let mut parser = Parser::new(root, argv);
         let mut events = Vec::new();
         while let Some(event) = parser.next_event() {

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -1954,7 +1954,7 @@ pub trait CommandArgs: Sized {
     ///
     /// Keys are unique across a CLI, so an event that is not this command's is left
     /// for whoever owns it rather than mistaken for a local field.
-    fn apply(partial: &mut Self::Partial, event: &crate::Event<'_, '_>) -> bool;
+    fn apply(partial: &mut Self::Partial, event: &crate::Event<'_, '_, '_>) -> bool;
 
     /// Every flag this command reads into a setting, and the setting it sets.
     ///
@@ -2074,7 +2074,7 @@ pub trait Subcommands: Sized {
     fn apply(
         partial: &mut Self::Partial,
         selected: Option<usize>,
-        event: &crate::Event<'_, '_>,
+        event: &crate::Event<'_, '_, '_>,
     ) -> bool;
 
     /// Make room for the variant at `selected`, if it is not already the one being filled.

--- a/conformance/tests/program_identity.rs
+++ b/conformance/tests/program_identity.rs
@@ -4,7 +4,7 @@
 //! or get an answer they did not mean.
 
 use usage::Spec as LibSpec;
-use usage_derive::Cli;
+use usage_derive::{Cli, Subcommands};
 
 /// A tool named after its binary
 ///
@@ -23,6 +23,18 @@ struct Cli_ {
 struct Renamed {
     #[usage(long)]
     plain: bool,
+}
+
+#[derive(Cli)]
+#[usage(name = "busy", bin = "busy", multicall)]
+struct Busy {
+    #[usage(subcommand)]
+    command: Option<BusyCommand>,
+}
+
+#[derive(Subcommands)]
+enum BusyCommand {
+    Run,
 }
 
 #[test]
@@ -76,4 +88,32 @@ fn the_fields_are_bound() {
     let argv = [OsStr::new("--plain")];
     assert!(Cli_::parse_from(&argv).expect("should parse").plain);
     assert!(Renamed::parse_from(&argv).expect("should parse").plain);
+}
+
+#[test]
+fn a_full_argv_helper_matches_clap_shaped_tests_and_multicall() {
+    use std::ffi::OsStr;
+
+    let ordinary = [OsStr::new("communique"), OsStr::new("--plain")];
+    assert!(
+        Cli_::parse_from_argv(&ordinary)
+            .expect("should parse")
+            .plain
+    );
+
+    let dispatcher = [OsStr::new("busy"), OsStr::new("run")];
+    assert!(matches!(
+        Busy::parse_from_argv(&dispatcher)
+            .expect("dispatcher form should parse")
+            .command,
+        Some(BusyCommand::Run)
+    ));
+
+    let applet = [OsStr::new("/usr/local/bin/run")];
+    assert!(matches!(
+        Busy::parse_from_argv(&applet)
+            .expect("applet form should parse")
+            .command,
+        Some(BusyCommand::Run)
+    ));
 }

--- a/conformance/tests/program_identity.rs
+++ b/conformance/tests/program_identity.rs
@@ -28,12 +28,15 @@ struct Renamed {
 #[derive(Cli)]
 #[usage(name = "busy", bin = "busy", multicall)]
 struct Busy {
+    #[usage(long, global)]
+    verbose: bool,
     #[usage(subcommand)]
     command: Option<BusyCommand>,
 }
 
 #[derive(Subcommands)]
 enum BusyCommand {
+    #[usage(alias = "r")]
     Run,
 }
 
@@ -109,11 +112,8 @@ fn a_full_argv_helper_matches_clap_shaped_tests_and_multicall() {
         Some(BusyCommand::Run)
     ));
 
-    let applet = [OsStr::new("/usr/local/bin/run")];
-    assert!(matches!(
-        Busy::parse_from_argv(&applet)
-            .expect("applet form should parse")
-            .command,
-        Some(BusyCommand::Run)
-    ));
+    let applet = [OsStr::new("/usr/local/bin/r"), OsStr::new("--verbose")];
+    let parsed = Busy::parse_from_argv(&applet).expect("applet form should parse");
+    assert!(matches!(parsed.command, Some(BusyCommand::Run)));
+    assert!(parsed.verbose, "root globals remain in scope for applets");
 }

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -559,6 +559,51 @@ pub fn emit(cli: &Cli) -> TokenStream {
                     })
                 }
 
+                /// Parse a full argv, including the program name.
+                ///
+                /// This is the test- and embedding-friendly counterpart to
+                /// [`Self::parse`]: it strips argv0 for an ordinary CLI and
+                /// applies the same basename-based applet selection for a
+                /// multicall CLI, while returning errors instead of exiting.
+                pub fn parse_from_argv<'v>(
+                    argv: &'v [&'v ::std::ffi::OsStr],
+                ) -> ::std::result::Result<Self, usage_argv::Error<'static, 'v>> {
+                    let ::std::option::Option::Some((__usage_argv0, __usage_words)) =
+                        argv.split_first()
+                    else {
+                        return Self::parse_from(&[]);
+                    };
+                    if SPEC.multicall {
+                        if let ::std::option::Option::Some(__usage_word) =
+                            __usage_argv0.to_str().and_then(|s| {
+                                usage_argv::multicall_applet(s, SPEC.name, SPEC.bin)
+                            })
+                        {
+                            let ::std::option::Option::Some(__usage_command) =
+                                Self::command().subcommands.iter().copied().find(|command| {
+                                    command.name == __usage_word
+                                        || command.aliases.contains(&__usage_word)
+                                })
+                            else {
+                                return ::std::result::Result::Err(
+                                    usage_argv::Error::MissingSubcommand,
+                                );
+                            };
+                            #defaults
+                            apply(
+                                &mut partial,
+                                &usage_argv::Event::Command(__usage_command),
+                            );
+                            read_into(__usage_command, __usage_words, &mut partial)?;
+                            return ::std::result::Result::Ok(Self {
+                                #sub_build
+                                #(#field_finals),*
+                            });
+                        }
+                    }
+                    Self::parse_from(__usage_words)
+                }
+
                 /// Parse the process's own arguments.
                 #completion
 

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -241,7 +241,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
             /// struct consumes it — and because a value the struct refuses is one this never
             /// returns, the layer going with it.
             pub fn parse_from_with_settings<'v>(
-                argv: &'v [&'v ::std::ffi::OsStr],
+                argv: &[&'v ::std::ffi::OsStr],
             ) -> ::std::result::Result<
                 (Self, ::usage_config::CliLayer),
                 usage_argv::Error<'static, 'v>,
@@ -415,7 +415,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
             /// outranks every other and name it after a flag nobody typed.
             pub fn read_argv<'v>(
                 command: &'static usage_argv::Command<'static>,
-                argv: &'v [&'v ::std::ffi::OsStr],
+                argv: &[&'v ::std::ffi::OsStr],
             ) -> ::std::result::Result<Partial, usage_argv::Error<'static, 'v>> {
                 #defaults
                 read_argv_into(command, argv, &mut partial)?;
@@ -433,7 +433,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
             /// frame that will consume it, leaving only the one copy that builds it.
             pub fn read_argv_into<'v>(
                 command: &'static usage_argv::Command<'static>,
-                argv: &'v [&'v ::std::ffi::OsStr],
+                argv: &[&'v ::std::ffi::OsStr],
                 partial: &mut Partial,
             ) -> ::std::result::Result<(), usage_argv::Error<'static, 'v>> {
                 let mut __usage_parser = usage_argv::Parser::new(command, argv);
@@ -478,7 +478,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
             /// the two halves apart instead.
             pub fn read<'v>(
                 command: &'static usage_argv::Command<'static>,
-                argv: &'v [&'v ::std::ffi::OsStr],
+                argv: &[&'v ::std::ffi::OsStr],
             ) -> ::std::result::Result<Partial, usage_argv::Error<'static, 'v>> {
                 #defaults
                 read_into(command, argv, &mut partial)?;
@@ -488,7 +488,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
             /// `read`, filling a partial the caller already owns. See `read_argv_into`.
             pub fn read_into<'v>(
                 command: &'static usage_argv::Command<'static>,
-                argv: &'v [&'v ::std::ffi::OsStr],
+                argv: &[&'v ::std::ffi::OsStr],
                 partial: &mut Partial,
             ) -> ::std::result::Result<(), usage_argv::Error<'static, 'v>> {
                 read_argv_into(command, argv, partial)?;
@@ -547,7 +547,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
 
                 /// Parse a command line, excluding the program name.
                 pub fn parse_from<'v>(
-                    argv: &'v [&'v ::std::ffi::OsStr],
+                    argv: &[&'v ::std::ffi::OsStr],
                 ) -> ::std::result::Result<Self, usage_argv::Error<'static, 'v>> {
                     // The partial is built here and filled through `&mut`, rather than
                     // returned up the chain: see `read_argv_into`.
@@ -566,7 +566,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
                 /// applies the same basename-based applet selection for a
                 /// multicall CLI, while returning errors instead of exiting.
                 pub fn parse_from_argv<'v>(
-                    argv: &'v [&'v ::std::ffi::OsStr],
+                    argv: &[&'v ::std::ffi::OsStr],
                 ) -> ::std::result::Result<Self, usage_argv::Error<'static, 'v>> {
                     let ::std::option::Option::Some((__usage_argv0, __usage_words)) =
                         argv.split_first()
@@ -579,26 +579,11 @@ pub fn emit(cli: &Cli) -> TokenStream {
                                 usage_argv::multicall_applet(s, SPEC.name, SPEC.bin)
                             })
                         {
-                            let ::std::option::Option::Some(__usage_command) =
-                                Self::command().subcommands.iter().copied().find(|command| {
-                                    command.name == __usage_word
-                                        || command.aliases.contains(&__usage_word)
-                                })
-                            else {
-                                return ::std::result::Result::Err(
-                                    usage_argv::Error::MissingSubcommand,
-                                );
-                            };
-                            #defaults
-                            apply(
-                                &mut partial,
-                                &usage_argv::Event::Command(__usage_command),
-                            );
-                            read_into(__usage_command, __usage_words, &mut partial)?;
-                            return ::std::result::Result::Ok(Self {
-                                #sub_build
-                                #(#field_finals),*
-                            });
+                            let mut __usage_rewritten =
+                                ::std::vec::Vec::with_capacity(argv.len());
+                            __usage_rewritten.push(::std::ffi::OsStr::new(__usage_word));
+                            __usage_rewritten.extend_from_slice(__usage_words);
+                            return Self::parse_from(&__usage_rewritten);
                         }
                     }
                     Self::parse_from(__usage_words)
@@ -2576,7 +2561,7 @@ fn apply_fn(cli: &Cli) -> TokenStream {
     quote! {
         pub fn apply(
             partial: &mut Partial,
-            event: &usage_argv::Event<'_, '_>,
+            event: &usage_argv::Event<'_, '_, '_>,
         ) -> bool {
             use usage_argv::Event;
             #route
@@ -3014,7 +2999,7 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
 
                 fn apply(
                     partial: &mut Self::Partial,
-                    event: &usage_argv::Event<'_, '_>,
+                    event: &usage_argv::Event<'_, '_, '_>,
                 ) -> bool {
                     apply(partial, event)
                 }
@@ -3680,7 +3665,7 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
                 fn apply(
                     partial: &mut Self::Partial,
                     selected: ::std::option::Option<usize>,
-                    event: &usage_argv::Event<'_, '_>,
+                    event: &usage_argv::Event<'_, '_, '_>,
                 ) -> bool {
                     match selected {
                         #(#applies)*


### PR DESCRIPTION
Adds `Cli::parse_from_argv` for clap-shaped tests and embedders that retain argv0.

Ordinary CLIs strip the program name; multicall CLIs apply the same basename-selected applet behavior as `parse()` while returning errors instead of exiting. The existing `parse_from` contract remains words-only and allocation-free.

Updates the corresponding PLAN items and adds ordinary, dispatcher, and applet conformance coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Public derive API addition plus internal lifetime signature updates on parser types; behavior is additive with tests and no change to words-only `parse_from` semantics.
> 
> **Overview**
> **Adds `Cli::parse_from_argv`** so tests and embedders can pass a full argv like clap’s `try_parse_from(["tool", ...])`. For normal CLIs it drops argv0 and delegates to **`parse_from`**; for **multicall** specs it applies the same basename applet rewrite as **`parse()`**, then parses and **returns errors** instead of exiting. **`parse_from`** is unchanged as the allocation-free, post-binary-name entry point.
> 
> **Parser API:** `Event` and `Parser` gain a separate lifetime on the argv slice (`'a`) so **`Event::External`** can borrow the full argv array without tying it to value lifetimes; generated **`parse_from` / `read_argv`** signatures use `&[&OsStr]` accordingly.
> 
> **Docs/tests:** PLAN items for argv0 testing and the `parse_from` contract are marked done; conformance covers ordinary CLI, multicall dispatcher, and applet paths with root globals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37ae133f6e3c14ae44a1fdca525d244678279a87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->