### PR TITLE
docs(plan): close facade validation gap

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -657,12 +657,12 @@ feature list is not an exhaustive audit.
       fields but discards that struct-level heading, so a migration can preserve
       parsing while silently degrading help. Define heading inheritance for a
       flattened Args type and cover short/long help ordering in conformance.
-- [ ] **Facade-owned derive validation.** A direct `usage-derive` adopter can
-      compile generated code only after separately adding `usage-validation`;
-      the implementation dependency leaks into every converted manifest. The
-      supported facade should own or re-export this path so the documented
-      dependency set is sufficient and generated code does not require users to
-      discover an internal crate from a compiler error.
+- [x] **Facade-owned derive validation.** `usage-rs` exposes portable expression
+      validation through its `validation` feature and the derive resolves that
+      facade path when an application does not depend on `usage-validation`
+      directly. Facade tests cover both `Cli` and flattened `Args` derives. The
+      aube rewrite enables the facade feature, compiles its validation rules, and
+      removes the direct implementation dependency and cargo-machete workaround.
 - [x] **Central metadata overlays without an MSRV or performance jump.** aube
       keeps a centrally audited command-effect table rather than scattering the
       policy across command types. Applying that table currently means parsing


### PR DESCRIPTION
Marks facade-owned validation complete now that `usage-rs` exposes validation behind its facade feature, derives resolve through that facade, and the Aube migration proves the direct `usage-validation` dependency and cargo-machete workaround are unnecessary.

Stacked on #1067. Fleet proof: jdx/aube#1336.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to PLAN.md; no code, dependencies, or behavior are modified in this PR.
> 
> **Overview**
> **Closes the facade-validation launch-gate item in `PLAN.md`** by flipping **Facade-owned derive validation** from open to complete and replacing the gap description with the delivered behavior.
> 
> The plan now records that portable expression validation is exposed through **`usage-rs`'s `validation` feature**, that **`usage-derive` resolves validation through that facade** when apps do not depend on `usage-validation` directly, that **facade tests cover `Cli` and flattened `Args` derives**, and that the **aube rewrite** enables the facade, compiles validation rules, and drops the direct implementation dependency plus the **cargo-machete** workaround.
> 
> No runtime or crate code changes in this diff—status documentation only, aligned with stacked implementation work (e.g. #1067, jdx/aube#1336).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e31d8f8652987e68c6a87fc55c24bd9fe22c5815. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->