### PR TITLE
docs(plan): close version policy gap

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -634,11 +634,12 @@ feature list is not an exhaustive audit.
       `ValueHint::CommandWithArguments` for forwarded argv. usage accepts only
       file, path and directory hints today. Add the command/argv cases or record
       them as an explicit completion non-goal before claiming clap coverage.
-- [ ] **Version omission and dynamic version policy.** tak intentionally removes
-      the package version from its generated spec so release-plz version-only PRs
-      do not dirty generated docs; hk computes a richer version string. Specify
-      static, expression-backed and omitted versions separately rather than
-      forcing a hard-coded literal into every `Cli` derive.
+- [x] **Version omission and dynamic version policy.** A literal `version`
+      remains compile-time metadata, while `version = expression` evaluates a
+      computed runtime string for hk-style build information. Cold metadata
+      consumers can call `SpecView::omit_version()` without changing parser
+      behavior; tak uses that view so release-plz version-only PRs do not dirty
+      its checked-in spec and docs.
 - [ ] **Unit and tuple Args migration shapes.** fnox's bare command structs and
       hk's one-field tuple Args are valid clap derive inputs. usage currently
       requires named-field braces, so even a command with no arguments changes


### PR DESCRIPTION
Marks the fleet version-policy gap complete: static literals remain compile-time metadata, expression-backed versions support richer runtime strings, and `SpecView::omit_version()` gives checked-in artifacts a stable versionless view without changing parser behavior.

Stacked on #1069. Fleet proof: jdx/tak#47 and jdx/hk#1211.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `PLAN.md`; no code or runtime behavior is modified.
> 
> **Overview**
> **Closes the “Version omission and dynamic version policy” row** in the general clap launch gate checklist in `PLAN.md` (unchecked → checked).
> 
> The added text records the intended split: **literal `version`** stays compile-time metadata; **`version = expression`** supplies runtime strings (e.g. hk build info); **`SpecView::omit_version()`** strips version from cold emitted metadata without affecting parser or `--version` behavior—**tak** uses that for stable checked-in spec/docs under release-plz.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 152cfa672543fadb1e3d19cd78e5df8ffa2c4c14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->