### PR TITLE
feat(derive): support unit command structs

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -640,12 +640,12 @@ feature list is not an exhaustive audit.
       consumers can call `SpecView::omit_version()` without changing parser
       behavior; tak uses that view so release-plz version-only PRs do not dirty
       its checked-in spec and docs.
-- [ ] **Unit and tuple Args migration shapes.** fnox's bare command structs and
-      hk's one-field tuple Args are valid clap derive inputs. usage currently
-      requires named-field braces, so even a command with no arguments changes
-      from `Command;` to `Command {}` and a tuple wrapper needs a public shape
-      change. Support unit structs directly; either support tuple Args or emit a
-      diagnostic that identifies the named-field rewrite.
+- [x] **Unit and tuple Args migration shapes.** `Cli` and `Args` accept unit
+      structs directly, so a no-argument command keeps its `Command;` spelling.
+      Tuple structs remain ambiguous because an unnamed value may be positional
+      or a flattened Args wrapper; their targeted diagnostic explains the named
+      `#[usage(flatten)]` rewrite instead of reporting a generic unsupported
+      shape. Facade tests exercise unit roots and nested unit Args commands.
 - [ ] **Relationships through flatten and positional IDs.** Positional
       relationships are already a general gap above. The fleet exposed the
       second half: a field cannot name a flag contributed by a flattened Args

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -20,6 +20,25 @@ use crate::model::{
     rendered_path, Cli, ConditionalDefault, DoubleDash, Field, Kind, Shape, Subcommands, ValueEnum,
 };
 
+/// Construct the user's command type after its generated partial has been checked.
+///
+/// An empty named struct is `Self {}`, while a unit struct is just `Self`. Keeping
+/// that syntax decision here prevents the root, settings, and nested-command build
+/// paths from drifting apart.
+fn built_value(cli: &Cli, sub_build: &TokenStream, fields: &[TokenStream]) -> TokenStream {
+    if cli.unit {
+        debug_assert!(cli.fields.is_empty());
+        quote!(Self)
+    } else {
+        quote! {
+            Self {
+                #sub_build
+                #(#fields),*
+            }
+        }
+    }
+}
+
 /// The runtime as the adopter depended on it.
 ///
 /// A direct `usage-argv` dependency wins when both forms are present: a low-level adopter may
@@ -230,11 +249,13 @@ pub fn emit(cli: &Cli) -> TokenStream {
     // as well as the struct, which is the whole reason it exists.
     let settings_parse = settings_bindings.as_ref().map(|_| {
         let sub_build = sub_build.clone();
-        let field_finals = cli
+        let field_finals: Vec<_> = cli
             .fields
             .iter()
             .filter(|f| !matches!(f.kind, Kind::Subcommand { .. }))
-            .map(field_final);
+            .map(field_final)
+            .collect();
+        let built = built_value(cli, &sub_build, &field_finals);
         quote! {
             /// Parse a command line, and the settings it gave values for.
             ///
@@ -256,10 +277,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
                 read_argv_into(Self::command(), argv, &mut partial)?;
                 let __usage_settings = settings_layer(&partial);
                 check(&mut partial)?;
-                let __usage_built = Self {
-                    #sub_build
-                    #(#field_finals),*
-                };
+                let __usage_built = #built;
                 ::std::result::Result::Ok((__usage_built, __usage_settings))
             }
         }
@@ -278,6 +296,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
         .filter(|f| !matches!(f.kind, Kind::Subcommand { .. }))
         .map(field_final)
         .collect();
+    let built = built_value(cli, &sub_build, &field_finals);
 
     let min_usage_version = option_str(cli.min_usage_version.as_deref());
     let has_version = cli.version.is_some();
@@ -554,10 +573,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
                     // returned up the chain: see `read_argv_into`.
                     #defaults
                     read_into(Self::command(), argv, &mut partial)?;
-                    ::std::result::Result::Ok(Self {
-                        #sub_build
-                        #(#field_finals),*
-                    })
+                    ::std::result::Result::Ok(#built)
                 }
 
                 /// Parse a full argv, including the program name.
@@ -2896,11 +2912,13 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
     // The same conversion the root gets. Two emitters producing one `build` is what let
     // this diverge: a typed field on a subcommand compiled here and not there, which is
     // every command mise has.
-    let field_finals = cli
+    let field_finals: Vec<_> = cli
         .fields
         .iter()
         .filter(|f| !matches!(f.kind, Kind::Subcommand { .. }))
-        .map(field_final);
+        .map(field_final)
+        .collect();
+    let built = built_value(cli, &sub_build, &field_finals);
 
     // The root cannot carry one — the spec writer asserts it — so this is the non-root
     // path's alone, which is also the only path a command's own declaration reaches.
@@ -3042,10 +3060,7 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
                 fn build<'t, 'v>(
                     partial: Self::Partial,
                 ) -> ::std::result::Result<Self, usage_argv::Error<'t, 'v>> {
-                    ::std::result::Result::Ok(Self {
-                        #sub_build
-                        #(#field_finals),*
-                    })
+                    ::std::result::Result::Ok(#built)
                 }
             }
         };

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -97,6 +97,17 @@
 //! `effect` goes on the variant there because there is no struct to put it on; everywhere else
 //! it belongs to the `Args`, and declaring it in both places is refused.
 //!
+//! A command type with no fields may keep Rust's unit-struct spelling:
+//!
+//! ```ignore
+//! #[derive(Args)]
+//! struct Sponsors;
+//! ```
+//!
+//! Tuple structs remain ambiguous: a derive cannot infer whether their unnamed field is a
+//! positional value or a flattened `Args` type. The diagnostic points wrapper migrations to a
+//! named field with `#[usage(flatten)]`.
+//!
 //! A command inside a command is not a special case: an `Args` struct carries a
 //! `subcommand` field exactly as the root does, to any depth, and generates the same
 //! code for it. mise reaches four levels, so one was never going to be enough.

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -14,6 +14,11 @@ use syn::{Attribute, Data, DeriveInput, Expr, ExprLit, Fields, Lit, Meta, Type};
 /// A CLI, as declared by a struct.
 pub struct Cli {
     pub ident: syn::Ident,
+    /// Whether the declaration is a unit struct (`struct Command;`).
+    ///
+    /// Unit structs have the same empty command metadata as `{}` structs, but
+    /// code generation must construct them without braces.
+    pub unit: bool,
     /// What this type's keys are derived from.
     ///
     /// The whole item rather than its name: two same-named structs in different
@@ -439,17 +444,20 @@ impl Cli {
         let Data::Struct(data) = &input.data else {
             return Err(syn::Error::new_spanned(
                 &input.ident,
-                "usage::Cli describes a command's flags and arguments, so it needs a \
-                 struct with named fields",
+                "usage::Cli describes a command's flags and arguments, so it needs a struct",
             ));
         };
-        let Fields::Named(named) = &data.fields else {
-            return Err(syn::Error::new_spanned(
-                &data.fields,
-                "usage::Cli needs named fields: the field name is what a flag or \
-                 argument is called",
-            ));
-        };
+        match &data.fields {
+            Fields::Named(_) | Fields::Unit => {}
+            Fields::Unnamed(_) => {
+                return Err(syn::Error::new_spanned(
+                    &data.fields,
+                    "usage derives do not infer whether a tuple field is a positional or a \
+                     flattened Args type; rewrite it as a named field, using \
+                     `#[usage(flatten)]` for an Args wrapper",
+                ));
+            }
+        }
 
         if !input.generics.params.is_empty() {
             return Err(syn::Error::new_spanned(
@@ -466,6 +474,7 @@ impl Cli {
         let mut version_needs_spec = false;
         let mut cli = Cli {
             ident: input.ident.clone(),
+            unit: matches!(&data.fields, Fields::Unit),
             fingerprint: quote::ToTokens::to_token_stream(input).to_string(),
             name: to_kebab(&input.ident.to_string()),
             bin: None,
@@ -630,7 +639,7 @@ impl Cli {
             seen_aliases.push((alias, alias_span));
         }
 
-        for field in &named.named {
+        for field in data.fields.iter() {
             cli.fields.push(Field::from_field(field)?);
         }
         // A program is called what its binary is called, unless it says otherwise. The name
@@ -3790,6 +3799,20 @@ mod tests {
             Ok(_) => panic!("should not have compiled"),
             Err(e) => e.to_string(),
         }
+    }
+
+    #[test]
+    fn unit_structs_are_empty_commands() {
+        let cli = cli("struct Empty;").expect("unit commands should compile");
+        assert!(cli.unit);
+        assert!(cli.fields.is_empty());
+    }
+
+    #[test]
+    fn tuple_structs_explain_the_named_flatten_rewrite() {
+        let err = rejection("struct Wrapper(InnerArgs);");
+        assert!(err.contains("tuple field"), "unhelpful: {err}");
+        assert!(err.contains("#[usage(flatten)]"), "unhelpful: {err}");
     }
 
     #[test]

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -96,6 +96,25 @@ struct ChoiceEx {
 #[usage(bin = "strict-ex", unknown_flags = "error")]
 struct StrictEx {}
 
+#[derive(Cli)]
+#[usage(bin = "unit-root")]
+struct UnitRoot;
+
+#[derive(Args)]
+struct UnitArgs;
+
+#[derive(Subcommands)]
+enum UnitArgsCommand {
+    Empty(UnitArgs),
+}
+
+#[derive(Cli)]
+#[usage(bin = "unit-args")]
+struct UnitArgsCli {
+    #[usage(subcommand)]
+    command: UnitArgsCommand,
+}
+
 const DEFAULT_RUNS: u32 = 7;
 const DYNAMIC_ABOUT: &str = "Metadata from a Rust constant.";
 const DYNAMIC_AFTER_HELP: &str = "More details from a Rust constant.";
@@ -150,6 +169,18 @@ fn one_dependency_provides_derives_runtime_and_value_hints() {
 fn unit_subcommands_use_the_facade_derive() {
     let cli = Ex::parse_from(&[OsStr::new("version")]).expect("valid unit subcommand");
     assert!(matches!(cli.command, Command::Version));
+}
+
+#[test]
+fn unit_cli_and_args_structs_parse_without_shape_rewrites() {
+    let root = UnitRoot::parse_from(&[]).expect("unit root should parse");
+    let UnitRoot = root;
+    assert!(UnitRoot::to_kdl().contains("name \"unit-root\""));
+
+    let cli =
+        UnitArgsCli::parse_from(&[OsStr::new("empty")]).expect("unit Args command should parse");
+    assert!(matches!(cli.command, UnitArgsCommand::Empty(UnitArgs)));
+    assert!(UnitArgsCli::to_kdl().contains("cmd \"empty\""));
 }
 
 #[test]


### PR DESCRIPTION
Allows `Cli` and `Args` derives on unit structs so no-argument commands can retain `struct Command;`. All construction paths share the same shape-aware builder, including root parsing, nested `CommandArgs`, and settings parsing. Tuple structs now receive a targeted diagnostic explaining the named `#[usage(flatten)]` rewrite.

Tests cover unit roots, nested unit Args, metadata emission, and tuple diagnostics. The PLAN migration-shape gap is marked complete.

Stacked on #1070.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Derive-only parsing/codegen changes for empty commands; behavior for existing named-field CLIs is unchanged aside from shared construction helper.
> 
> **Overview**
> **Unit structs** for `Cli` and `Args` no longer force `struct Command {}`. The model records `unit: true`, accepts `Fields::Unit`, and codegen uses a shared **`built_value`** helper so root `parse_from`, settings parsing, and nested `CommandArgs::build` all construct `Self` instead of `Self { ... }` when there are no fields.
> 
> **Tuple structs** are rejected with a diagnostic that points at the **`#[usage(flatten)]` named-field rewrite** instead of a generic “named fields only” error.
> 
> Docs in `derive/src/lib.rs`, **PLAN.md** (migration item marked done), **model/codegen tests**, and **facade tests** (`UnitRoot`, nested `UnitArgs` subcommands, KDL) cover the new shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12b6598cf5ceb54621180958ebf8cb69862c99ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->