### PR TITLE
fix(spec): deduplicate derived completers

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -708,7 +708,9 @@ feature list is not an exhaustive audit.
       tree after a usage-lib parse/serialize round trip, and repeated identical
       `complete "path"` nodes that the round trip collapsed. Make direct emission
       canonical and deduplicate composed completers so adopters do not need the
-      expensive round trip merely for stable generated artifacts.
+      expensive round trip merely for stable generated artifacts. Identical
+      built-in completion nodes are now emitted once per command; broader
+      parse/serialize canonicalization remains.
 - [x] **Keep generated-spec producers and consumers on one dialect.** The 6.x
       migration is a coordinated epoch, not a promise that a 5.1 CLI can consume
       a 6.x-derived spec. Fleet docs tasks install `usage-cli` from the same git

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -1206,19 +1206,20 @@ fn write_body<'a>(
 }
 
 /// Built-in completion types declared by this command, written in the spec's vocabulary.
-fn write_completion_types(
+fn write_completion_types<'a>(
     out: &mut String,
-    meta: &CommandMeta<'_>,
+    meta: &CommandMeta<'a>,
     depth: usize,
 ) -> core::fmt::Result {
+    let mut written: Vec<(String, &'a str)> = Vec::new();
     for arg in meta.args {
         if let Some(type_) = arg.complete_type {
-            indent(out, depth)?;
-            writeln!(
+            write_completion_type(
                 out,
-                "complete {} type={}",
-                quoted(&arg.arg.name.to_ascii_lowercase()),
-                quoted(type_)
+                &mut written,
+                arg.arg.name.to_ascii_lowercase(),
+                type_,
+                depth,
             )?;
         }
     }
@@ -1228,10 +1229,28 @@ fn write_completion_types(
                 .value_name
                 .unwrap_or(flag.flag.name)
                 .to_ascii_lowercase();
-            indent(out, depth)?;
-            writeln!(out, "complete {} type={}", quoted(&name), quoted(type_))?;
+            write_completion_type(out, &mut written, name, type_, depth)?;
         }
     }
+    Ok(())
+}
+
+fn write_completion_type<'a>(
+    out: &mut String,
+    written: &mut Vec<(String, &'a str)>,
+    name: String,
+    type_: &'a str,
+    depth: usize,
+) -> core::fmt::Result {
+    if written
+        .iter()
+        .any(|(written_name, written_type)| written_name == &name && *written_type == type_)
+    {
+        return Ok(());
+    }
+    indent(out, depth)?;
+    writeln!(out, "complete {} type={}", quoted(&name), quoted(type_))?;
+    written.push((name, type_));
     Ok(())
 }
 

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -115,6 +115,15 @@ struct UnitArgsCli {
     command: UnitArgsCommand,
 }
 
+#[derive(Cli)]
+#[usage(bin = "completion-dedup")]
+struct CompletionDedup {
+    #[usage(long, value_name = "PATH", value_hint = usage::ValueHint::FilePath)]
+    input: Option<PathBuf>,
+    #[usage(long, value_name = "PATH", value_hint = usage::ValueHint::FilePath)]
+    output: Option<PathBuf>,
+}
+
 const DEFAULT_RUNS: u32 = 7;
 const DYNAMIC_ABOUT: &str = "Metadata from a Rust constant.";
 const DYNAMIC_AFTER_HELP: &str = "More details from a Rust constant.";
@@ -181,6 +190,26 @@ fn unit_cli_and_args_structs_parse_without_shape_rewrites() {
         UnitArgsCli::parse_from(&[OsStr::new("empty")]).expect("unit Args command should parse");
     assert!(matches!(cli.command, UnitArgsCommand::Empty(UnitArgs)));
     assert!(UnitArgsCli::to_kdl().contains("cmd \"empty\""));
+}
+
+#[test]
+fn identical_builtin_completers_are_emitted_once() {
+    let parsed = CompletionDedup::parse_from(&[
+        OsStr::new("--input"),
+        OsStr::new("in.txt"),
+        OsStr::new("--output"),
+        OsStr::new("out.txt"),
+    ])
+    .expect("both path flags should parse");
+    assert_eq!(parsed.input.as_deref(), Some(Path::new("in.txt")));
+    assert_eq!(parsed.output.as_deref(), Some(Path::new("out.txt")));
+
+    let kdl = CompletionDedup::to_kdl();
+    assert_eq!(
+        kdl.matches("complete \"path\" type=\"path\"").count(),
+        1,
+        "{kdl}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Emits each identical built-in completion node only once per command. Multiple fields sharing a completion name and type (for example path-valued flags with `value_name = "PATH"`) no longer produce repeated `complete "path"` nodes. Distinct names or types retain declaration order.

The parser and facade test suites pass, including a regression that parses both fields and asserts one emitted completer. PLAN now records this portion of the broader canonical-KDL gap as complete.

Stacked on #1071.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cold-path spec emission and tests only; parsing and binding behavior are unchanged.
> 
> **Overview**
> **Derived KDL emission** now writes each identical built-in `complete` node only once per command. When several flags or arguments share the same completion name and type (for example two `value_name = "PATH"` fields with a path hint), `write_completion_types` tracks what was already emitted instead of repeating `complete "path" type="path"`.
> 
> A facade regression test (`CompletionDedup`) parses both flags and asserts a single matching completer line in `to_kdl()`. **PLAN.md** records that this slice of the broader canonical-KDL work is done; full parse/serialize canonicalization is still open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cda8d65d4b6527a68afb20ccdb18830dbc70d0fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->