### PR TITLE
docs(help): document post-parse interception

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1124,11 +1124,12 @@ repeated here.
       that help, completions and docs all read, with the derive lowering an
       attribute into it. Not a derive-only emission, and not a blessed
       transform API: the spec defines.
-- [ ] **No home for post-parse hooks.** aube reimplements `--version` because
-      the built-in exits before its async update notifier can run; hk strips
-      `--cd` and re-execs by hand. `parse_from` returning `Error::Help` and
-      version instead of exiting is the derive's answer in principle — confirm
-      the pattern covers both cases and document it, or add the hook.
+- [x] **Post-parse hooks stay application-owned.** `parse_from` and
+      `parse_from_argv` return `Error::Help` and `Error::Version` instead of
+      exiting, so aube can run its notifier or customize version output before
+      rendering. A successful value likewise lets hk handle `--cd` before
+      dispatch. The help guide documents these interception points explicitly;
+      `parse()` remains the immediate print-and-exit convenience path.
 - [ ] **MSRV.** usage-lib is on Rust 1.95 while the fleet floors are 1.88 and
       1.91, so a CLI that links it for spec generation inherits the bump. The
       argv/derive tier is dependency-free by design; keeping a low-MSRV path to

--- a/docs/rust/help.md
+++ b/docs/rust/help.md
@@ -38,6 +38,14 @@ match Ex::parse_from(&argv) {
 
 `Error` is `#[non_exhaustive]` — always keep a fallback arm.
 
+That match is also the post-parse interception point. An application that must
+run an update notifier, rewrite output, or re-exec before answering help or
+version does that work in the corresponding arm and then renders or returns.
+Work that depends on a successfully built CLI value belongs after the `Ok(cli)`
+arm and before command dispatch. There is no hidden callback lifecycle: the
+embedding application owns the order explicitly, and `parse()` remains the
+convenience entry point for CLIs that want immediate print-and-exit behavior.
+
 ### Customizing the page
 
 - `usage = "…"` on the root replaces the generated synopsis line(s) verbatim.


### PR DESCRIPTION
Documents `parse_from`/`parse_from_argv` as the explicit interception point for applications that need work before rendering help or version output, and the successful-value path for work before dispatch. This confirms the existing API covers Aube’s customized version handling and hk’s pre-dispatch re-exec without adding a hidden hook lifecycle.

Marks the corresponding PLAN gap complete. Stacked on #1072.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and planning updates only; no runtime or API changes in this diff.
> 
> **Overview**
> **Documents** that post-parse behavior is intentionally application-owned: `parse_from` / `parse_from_argv` return `Error::Help` and `Error::Version` instead of exiting, and successful parses hand back a value so embedders can run notifiers, customize version output, or re-exec (e.g. hk `--cd`) before dispatch. The help guide now calls out the `match` on those errors as the interception point and states there is no hidden hook lifecycle—`parse()` stays the print-and-exit shortcut.
> 
> **PLAN** marks the “no home for post-parse hooks” gap **done**, replacing the open question with the decided pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ec5460a94b734863c6b73efd2b7ebb4b30931eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->