### PR TITLE
docs(plan): close fleet msrv gap

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1130,10 +1130,12 @@ repeated here.
       rendering. A successful value likewise lets hk handle `--cd` before
       dispatch. The help guide documents these interception points explicitly;
       `parse()` remains the immediate print-and-exit convenience path.
-- [ ] **MSRV.** usage-lib is on Rust 1.95 while the fleet floors are 1.88 and
-      1.91, so a CLI that links it for spec generation inherits the bump. The
-      argv/derive tier is dependency-free by design; keeping a low-MSRV path to
-      spec emission — without usage-lib — is what lets a conservative CLI adopt.
+- [x] **MSRV tiers stay separate.** `usage-lib` remains on Rust 1.95, while
+      `usage-argv`, `usage-derive`, `usage-validation`, and the `usage-rs`
+      facade remain on Rust 1.91. The facade emits specs, help, diagnostics, and
+      compiled completions without linking usage-lib, so the fnox rewrite keeps
+      its 1.91 floor. Higher-MSRV docs tooling remains a separate installed
+      `usage-cli` process rather than raising the embedding CLI's requirement.
 - [x] **The `parse_from` argv0 contract.** It differs from clap's, which broke
       fnox's test helpers in the rewrite experiment. `parse_from` remains the
       allocation-free words-only primitive; `parse_from_argv` is the explicit


### PR DESCRIPTION
Records the stabilized MSRV split: the compiled facade/runtime/derive/validation tier remains Rust 1.91 and emits specs, help, diagnostics, and completions without linking the Rust 1.95 usage-lib tier. Fnox’s migration proves the 1.91 adopter path, while docs generation uses a separately installed matching usage-cli.

Stacked on #1073.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to PLAN.md; no code or dependency behavior is modified in this diff.
> 
> **Overview**
> **Closes the “fleet MSRV gap” checklist item** in `PLAN.md` by flipping it from open to done and replacing the old “usage-lib bumps adopters” wording with the **stabilized two-tier model**.
> 
> The plan now states that **`usage-lib` remains Rust 1.95**, while **`usage-argv`, `usage-derive`, `usage-validation`, and the `usage-rs` facade stay on 1.91**. The facade is documented as able to emit specs, help, diagnostics, and compiled completions **without linking `usage-lib`**, so rewrites like fnox can keep a 1.91 floor. Docs generation is explicitly **out-of-process** via a separately installed matching `usage-cli`, rather than raising the embedding CLI’s MSRV.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 530620575a87dc09339d36030812d9cab0bd0e84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->