### PR TITLE
docs: publish parser performance report

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -814,7 +814,11 @@ checked-in `mise.usage.kdl` for both parsers.
       usage-lib resolves `mount run="mise tasks --usage"` by _running_ it, so the first
       draft spawned real `mise` processes that loaded config, fetched vfox metadata and
       shelled out to `apt-cache`. See `benches/gate/tests/differential.rs`.
-- [ ] **Perf report** — published honestly, whichever way it goes.
+- [x] **Published performance report.** The Rust guide now records the original
+      launch measurements, the later 19% instruction increase and reduced ratio,
+      the absolute gates, the measurement method, and what the comparison does
+      not include. It links the checked-in benchmark sources rather than
+      presenting the numbers without a reproducible path.
 
 Runtime targets, which gate:
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -67,6 +67,7 @@ export default defineConfig({
           { text: "Subcommands", link: "/rust/subcommands" },
           { text: "Validation", link: "/rust/validation" },
           { text: "Help and Errors", link: "/rust/help" },
+          { text: "Performance", link: "/rust/performance" },
           { text: "Completions", link: "/rust/completions" },
           { text: "Spec Output", link: "/rust/spec" }
         ]

--- a/docs/rust/performance.md
+++ b/docs/rust/performance.md
@@ -1,0 +1,53 @@
+# Parser performance
+
+usage's compiled Rust parser is designed so ordinary argv parsing reads static
+tables and writes directly into the result. Cold metadata for help, specs, and
+completions is not constructed on a successful parse.
+
+## Mise-scale result
+
+The gate uses generated usage and clap shadows of the same checked-in mise spec:
+211 commands, 711 flags, 128 positional arguments, and four command levels. A
+third binary performs the same startup work without parsing, which lets the
+instruction and wall-time measurements subtract startup from two runs of the
+same binary.
+
+| Measurement                                  | usage |  clap |                Result |
+| -------------------------------------------- | ----: | ----: | --------------------: |
+| Retired instructions, route and parse        | 50.9k | 5.96M |            117x fewer |
+| Wall time, argv to parsed value              | 2.1us | 490us |           238x faster |
+| Heap allocations, no values bound            |     0 | 6,560 | no parser allocations |
+| Heap allocations, three or four values bound |   3-4 | 6,560 |   one per owned value |
+
+The original launch targets were fewer than 100k retired instructions, less
+than 50us, and zero allocations when no value is bound. All three passed.
+
+A later measurement moved usage to 60.4k instructions while clap remained
+approximately flat at 5.90M, reducing the ratio from 117x to 97x. The parser is
+still comfortably under the absolute gate, but the change is reported because
+the ratio is useful evidence that vocabulary growth is not free.
+
+## What clap's number includes
+
+For this generated command tree, clap's approximately 490us consists of about
+305us constructing the tree, 160us validating it, and 24us parsing. usage's
+tables are compiled, so its 2.1us path has no equivalent construction or
+validation phase. Even compared only with clap's already-built parse phase,
+usage was about 12x faster in this measurement.
+
+## Method and limits
+
+- Instruction counts come from Cachegrind, whose run-to-run variation on the
+  benchmark host is much lower than wall-clock timing.
+- `tak` runs the release binaries repeatedly and reports the difference between
+  the no-parse and parse paths.
+- Both shadows are generated from the same spec and intentionally drop the same
+  unsupported properties.
+- This measures routing and parsing, not process startup, configuration loading,
+  command execution, help rendering, or completion generation.
+- The mise fixture grows over time. CI protects the absolute instruction target;
+  this report also records the parser-to-parser ratio so regressions remain
+  visible when the fixture changes.
+
+The benchmark sources live in `benches/gate`, with generated shadows under
+`benches/shadows`.


### PR DESCRIPTION
Publishes the mise-scale parser benchmark in the Rust guide, including original launch results, the later instruction-count increase and reduced ratio, allocation behavior, methodology, and explicit limits of the comparison. Adds the report to the Rust sidebar and marks the publication gate complete.

Formatting and diff checks pass. A local VitePress build was unavailable because the repository does not select a Node/pnpm tool version in this environment.

Stacked on #1074.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or parser behavior impact.
> 
> **Overview**
> **Publishes the mise-scale parser benchmark** in the Rust framework docs as `docs/rust/performance.md`, covering usage vs clap on the shared shadow spec (instructions, wall time, allocations), launch targets, the later ~19% instruction increase (117× → 97×), what clap’s timing includes, measurement limits, and pointers to `benches/gate` / `benches/shadows`.
> 
> **Docs navigation** gains a **Performance** entry under the Rust sidebar in `docs/.vitepress/config.mts`.
> 
> **PLAN.md** checks off the **Published performance report** gate item, noting the guide now documents original and follow-up measurements with a reproducible path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95afc924d91634663e4754aa4d546da5b8f71fac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->