### PR TITLE
feat(derive): reuse args across commands

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -593,12 +593,12 @@ feature list is not an exhaustive audit.
       computed version pairs with `version_spec`, and a typed default pairs with
       `default`; the expression drives runtime behavior while the explicit literal
       keeps emitted KDL deterministic and portable.
-- [ ] **One Args type used by more than one command.** tak's `push` and `init`
-      have the same `--remote` shape. The derive rejects two variants wrapping
-      one `Args` type because collection is attached to the declaring struct,
-      forcing two identical structs. `flatten` solves shared fields within a
-      command but not a whole command body shared under two names. Either support
-      this directly or document the duplication as an architectural constraint.
+- [x] **One Args type used by more than one command.** Static tables belong to
+      the Args type and command routing belongs to each mounting enum variant,
+      so one declaration can back multiple commands without duplicate symbols
+      or cross-command binding. Facade coverage mounts one `SharedArgs` under
+      two commands, parses both routes, and verifies each emitted command owns
+      exactly one copy of the shared flag metadata.
 - [x] **Inline struct-style subcommand variants.** aube and hk use clap enums
       whose variants declare fields directly. usage requires every non-bare
       variant to wrap one dedicated Args struct, turning a mechanical migration
@@ -1144,10 +1144,11 @@ repeated here.
       fnox's test helpers in the rewrite experiment. `parse_from` remains the
       allocation-free words-only primitive; `parse_from_argv` is the explicit
       clap-shaped, argv0-taking variant and preserves multicall selection.
-- [ ] **Shared `Args` under multiple commands need wrapper types** in the
-      derive, where clap lets one struct serve several parents directly.
-      flatten covers the mise `ConfigLs` shape; the fnox shape is the same
-      struct as a full command body in two places.
+- [x] **Shared `Args` under multiple commands do not need wrapper types.** Keys
+      are checked per command because that is their routing scope, while each
+      subcommand variant selects the shared `CommandArgs` table independently.
+      The same facade regression covers the fnox full-command shape; mise's
+      flattened `ConfigLs` reuse remains covered by the fleet shadow.
 - [ ] **Relationships across a flatten boundary.** A flag in the parent
       conflicting with a flag in the flattened group has no spelling; hk and
       aube both hit it and enforce post-bind by hand.

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -840,12 +840,12 @@ fn overlay_at_cursor<'o>(
             })
         })
     } else if let Some(flag) = position.awaiting_value {
-        flag_meta_owner(spec.root, flag)
+        flag_meta_owner_on_route(spec, position, flag)
             .map(|(owner, field)| (owner, field.value_name.unwrap_or(field.flag.name), false))
     } else {
         position
             .next_arg
-            .and_then(|arg| arg_meta_owner(spec.root, arg))
+            .and_then(|arg| arg_meta_owner_on_route(spec, position, arg))
             .map(|(owner, field)| {
                 (
                     owner,
@@ -874,6 +874,36 @@ fn overlay_at_cursor<'o>(
     })
 }
 
+fn flag_meta_owner_on_route<'a>(
+    spec: &'a Spec<'a>,
+    position: &Position<'_>,
+    flag: &Flag<'_>,
+) -> Option<(&'a CommandMeta<'a>, &'a FlagMeta<'a>)> {
+    let (_, chain) = crate::help::find(spec, position.cmd)?;
+    chain.iter().rev().find_map(|owner| {
+        owner
+            .flags
+            .iter()
+            .find(|field| core::ptr::eq(field.flag, flag))
+            .map(|field| (*owner, field))
+    })
+}
+
+fn arg_meta_owner_on_route<'a>(
+    spec: &'a Spec<'a>,
+    position: &Position<'_>,
+    arg: &Arg<'_>,
+) -> Option<(&'a CommandMeta<'a>, &'a ArgMeta<'a>)> {
+    let (_, chain) = crate::help::find(spec, position.cmd)?;
+    chain.iter().rev().find_map(|owner| {
+        owner
+            .args
+            .iter()
+            .find(|field| core::ptr::eq(field.arg, arg))
+            .map(|field| (*owner, field))
+    })
+}
+
 fn default_subcommand_arg<'a>(
     spec: &'a Spec<'a>,
     split: &Split,
@@ -888,36 +918,6 @@ fn default_subcommand_arg<'a>(
         .find(|sub| sub.cmd.name == default)
         .or_else(|| subcommands().find(|sub| sub.cmd.aliases.contains(&default)))
         .and_then(|sub| sub.args.first().map(|field| (sub, field)))
-}
-
-fn flag_meta_owner<'a>(
-    meta: &'a CommandMeta<'a>,
-    flag: &Flag<'_>,
-) -> Option<(&'a CommandMeta<'a>, &'a FlagMeta<'a>)> {
-    meta.flags
-        .iter()
-        .find(|field| core::ptr::eq(field.flag, flag))
-        .map(|field| (meta, field))
-        .or_else(|| {
-            meta.subcommands
-                .iter()
-                .find_map(|sub| flag_meta_owner(sub, flag))
-        })
-}
-
-fn arg_meta_owner<'a>(
-    meta: &'a CommandMeta<'a>,
-    arg: &Arg<'_>,
-) -> Option<(&'a CommandMeta<'a>, &'a ArgMeta<'a>)> {
-    meta.args
-        .iter()
-        .find(|field| core::ptr::eq(field.arg, arg))
-        .map(|field| (meta, field))
-        .or_else(|| {
-            meta.subcommands
-                .iter()
-                .find_map(|sub| arg_meta_owner(sub, arg))
-        })
 }
 
 /// Just the candidates this CLI knows about, without the question of paths.

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -868,14 +868,29 @@ fn overlay_at_cursor<'o>(
         return None;
     }
     let chain = metadata_chain_on_route(spec, position)?;
-    let owner_at = chain
+    let path: Vec<&str> = if let Some(owner_at) = chain
         .iter()
-        .position(|candidate| core::ptr::eq(*candidate, owner))?;
-    let path: Vec<&str> = chain[..=owner_at]
-        .iter()
-        .skip(1)
-        .map(|meta| meta.cmd.name)
-        .collect();
+        .position(|candidate| core::ptr::eq(*candidate, owner))
+    {
+        chain[..=owner_at]
+            .iter()
+            .skip(1)
+            .map(|meta| meta.cmd.name)
+            .collect()
+    } else if core::ptr::eq(position.cmd, spec.root.cmd)
+        && spec
+            .root
+            .subcommands
+            .iter()
+            .any(|candidate| core::ptr::eq(*candidate, owner))
+    {
+        // A default subcommand can supply the root cursor's first argument without the
+        // parser descending into it. Its metadata identity is already unambiguous here;
+        // preserve that implied route instead of falling back to a tree-wide pointer search.
+        vec![owner.cmd.name]
+    } else {
+        return None;
+    };
     overlays.iter().rev().find(|overlay| {
         overlay.value.eq_ignore_ascii_case(value) && overlay.command.matches(owner, &path)
     })

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -597,7 +597,7 @@ fn declared_files_at_cursor(
     {
         return None;
     }
-    let meta = crate::help::find(spec, position.cmd).and_then(|(_, chain)| chain.last().copied());
+    let meta = metadata_chain_on_route(spec, position).and_then(|chain| chain.last().copied());
     let at_cursor = if restarted(meta, split) {
         meta.and_then(|m| m.args.first()).map(|m| m.arg)
     } else {
@@ -641,7 +641,7 @@ fn declared_files_at_cursor(
 /// for a word nothing is known about, and the `run=` completions a spec can declare.
 pub fn complete<'a>(spec: &'a Spec<'a>, split: &Split) -> Completions<'a> {
     let position = walk(spec.root.cmd, split.argv());
-    let meta = crate::help::find(spec, position.cmd).and_then(|(_, chain)| chain.last().copied());
+    let meta = metadata_chain_on_route(spec, &position).and_then(|chain| chain.last().copied());
     let token = split.prefix.as_str();
     let candidates = candidates(spec, split);
 
@@ -807,7 +807,7 @@ fn overlay_for_name<'o>(
     {
         return Some(overlay);
     }
-    let (_, chain) = crate::help::find(spec, position.cmd)?;
+    let chain = metadata_chain_on_route(spec, position)?;
     let owner = chain.last()?;
     let path: Vec<&str> = chain.iter().skip(1).map(|meta| meta.cmd.name).collect();
     overlays.iter().rev().find(|overlay| {
@@ -828,7 +828,7 @@ fn overlay_at_cursor<'o>(
     {
         return None;
     }
-    let meta = crate::help::find(spec, position.cmd).and_then(|(_, chain)| chain.last().copied());
+    let meta = metadata_chain_on_route(spec, position).and_then(|chain| chain.last().copied());
     let target = if restarted(meta, split) {
         meta.and_then(|owner| {
             owner.args.first().map(|field| {
@@ -867,8 +867,15 @@ fn overlay_at_cursor<'o>(
     if needs_separator && !position.separator_seen {
         return None;
     }
-    let (_, chain) = crate::help::find(spec, owner.cmd)?;
-    let path: Vec<&str> = chain.iter().skip(1).map(|meta| meta.cmd.name).collect();
+    let chain = metadata_chain_on_route(spec, position)?;
+    let owner_at = chain
+        .iter()
+        .position(|candidate| core::ptr::eq(*candidate, owner))?;
+    let path: Vec<&str> = chain[..=owner_at]
+        .iter()
+        .skip(1)
+        .map(|meta| meta.cmd.name)
+        .collect();
     overlays.iter().rev().find(|overlay| {
         overlay.value.eq_ignore_ascii_case(value) && overlay.command.matches(owner, &path)
     })
@@ -879,7 +886,7 @@ fn flag_meta_owner_on_route<'a>(
     position: &Position<'_>,
     flag: &Flag<'_>,
 ) -> Option<(&'a CommandMeta<'a>, &'a FlagMeta<'a>)> {
-    let (_, chain) = crate::help::find(spec, position.cmd)?;
+    let chain = metadata_chain_on_route(spec, position)?;
     chain.iter().rev().find_map(|owner| {
         owner
             .flags
@@ -894,7 +901,7 @@ fn arg_meta_owner_on_route<'a>(
     position: &Position<'_>,
     arg: &Arg<'_>,
 ) -> Option<(&'a CommandMeta<'a>, &'a ArgMeta<'a>)> {
-    let (_, chain) = crate::help::find(spec, position.cmd)?;
+    let chain = metadata_chain_on_route(spec, position)?;
     chain.iter().rev().find_map(|owner| {
         owner
             .args
@@ -920,10 +927,32 @@ fn default_subcommand_arg<'a>(
         .and_then(|sub| sub.args.first().map(|field| (sub, field)))
 }
 
+/// The metadata route selected by the parser, preserving parent identity even when two
+/// wrappers reuse the same nested command tables.
+fn metadata_chain_on_route<'a>(
+    spec: &'a Spec<'a>,
+    position: &Position<'_>,
+) -> Option<Vec<&'a CommandMeta<'a>>> {
+    if position.path.is_empty() {
+        return crate::help::find(spec, position.cmd).map(|(_, chain)| chain);
+    }
+    let mut chain = vec![spec.root];
+    let mut current = spec.root;
+    for (command, _) in position.path.iter().skip(1) {
+        current = current
+            .subcommands
+            .iter()
+            .copied()
+            .find(|meta| core::ptr::eq(meta.cmd, *command))?;
+        chain.push(current);
+    }
+    Some(chain)
+}
+
 /// Just the candidates this CLI knows about, without the question of paths.
 pub fn candidates<'a>(spec: &'a Spec<'a>, split: &Split) -> Vec<Candidate<'a>> {
     let position = walk(spec.root.cmd, split.argv());
-    let meta = crate::help::find(spec, position.cmd).and_then(|(_, chain)| chain.last().copied());
+    let meta = metadata_chain_on_route(spec, &position).and_then(|chain| chain.last().copied());
     let token = split.prefix.as_str();
 
     let mut out = if position.flags_possible && token == "-" {

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -3200,37 +3200,6 @@ impl Subcommands {
             }
         }
 
-        // Two variants cannot wrap the same struct. A command's values are collected
-        // into the struct that declares them, and its fields' keys come from that
-        // struct — so two commands sharing one would collect into whichever was
-        // reached first, and choosing between them would be a coin toss. Rejected
-        // rather than silently misbound.
-        //
-        // Compared as whole paths: `type_name` renders only the last segment, so
-        // `add::Op` and `remove::Op` looked identical and two perfectly good commands
-        // were refused.
-        let mut types: Vec<(String, Span)> = Vec::new();
-        for variant in &variants {
-            if variant.external {
-                continue;
-            }
-            let rendered = quote::ToTokens::to_token_stream(&variant.ty)
-                .to_string()
-                .replace(' ', "");
-            if let Some((_, first)) = types.iter().find(|(t, _)| *t == rendered) {
-                return Err(dup(
-                    variant.ty.span(),
-                    *first,
-                    &format!(
-                        "two variants both wrap `{rendered}`, and a command collects \
-                         into the struct that declares it — so give each command its \
-                         own struct, even if the fields are identical"
-                    ),
-                ));
-            }
-            types.push((rendered, variant.ty.span()));
-        }
-
         Ok(Subcommands {
             ident: input.ident.clone(),
             variants,

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -266,13 +266,7 @@ fn second_targets(
 
 #[cfg(feature = "completions")]
 fn run_ready<F: std::future::Future>(future: F) -> F::Output {
-    struct Ready;
-    impl std::task::Wake for Ready {
-        fn wake(self: std::sync::Arc<Self>) {}
-    }
-
-    let waker = std::task::Waker::from(std::sync::Arc::new(Ready));
-    let mut cx = std::task::Context::from_waker(&waker);
+    let mut cx = std::task::Context::from_waker(std::task::Waker::noop());
     let mut future = Box::pin(future);
     match future.as_mut().poll(&mut cx) {
         std::task::Poll::Ready(output) => output,

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -145,6 +145,41 @@ struct SharedArgsCli {
     command: SharedArgsCommand,
 }
 
+#[allow(dead_code)]
+#[derive(Args)]
+struct SharedNestedLeaf {
+    #[usage(long)]
+    target: Option<String>,
+}
+
+#[allow(dead_code)]
+#[derive(Subcommands)]
+enum SharedNestedCommand {
+    Inner(SharedNestedLeaf),
+}
+
+#[allow(dead_code)]
+#[derive(Args)]
+struct SharedNestedArgs {
+    #[usage(subcommand)]
+    command: SharedNestedCommand,
+}
+
+#[allow(dead_code)]
+#[derive(Subcommands)]
+enum SharedNestedRootCommand {
+    First(SharedNestedArgs),
+    Second(SharedNestedArgs),
+}
+
+#[allow(dead_code)]
+#[derive(Cli)]
+#[usage(bin = "shared-nested")]
+struct SharedNestedCli {
+    #[usage(subcommand)]
+    command: SharedNestedRootCommand,
+}
+
 const DEFAULT_RUNS: u32 = 7;
 const DYNAMIC_ABOUT: &str = "Metadata from a Rust constant.";
 const DYNAMIC_AFTER_HELP: &str = "More details from a Rust constant.";
@@ -292,6 +327,33 @@ fn shared_args_completion_overlays_stay_on_the_selected_command() {
         ];
         let rendered = run_ready(
             SharedArgsCli::app()
+                .completion_app()
+                .completions(&OVERLAYS)
+                .completion_request(&argv),
+        )
+        .expect("hidden completion request should be handled");
+        assert_eq!(rendered, format!("{expected}\n"));
+    }
+}
+
+#[cfg(feature = "completions")]
+#[test]
+fn shared_nested_completion_overlays_keep_the_parent_route() {
+    static OVERLAYS: [usage::complete::CompletionOverlay<'static>; 2] = [
+        usage::complete::CompletionOverlay::sync("first inner", "target", first_targets),
+        usage::complete::CompletionOverlay::sync("second inner", "target", second_targets),
+    ];
+
+    for (command, expected) in [("first", "first-target"), ("second", "second-target")] {
+        let argv = [
+            std::ffi::OsString::from("__complete_word__"),
+            std::ffi::OsString::from("--shell"),
+            std::ffi::OsString::from("bash"),
+            std::ffi::OsString::from("--line"),
+            std::ffi::OsString::from(format!("shared-nested {command} inner --target ")),
+        ];
+        let rendered = run_ready(
+            SharedNestedCli::app()
                 .completion_app()
                 .completions(&OVERLAYS)
                 .completion_request(&argv),

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -124,6 +124,25 @@ struct CompletionDedup {
     output: Option<PathBuf>,
 }
 
+#[derive(Args)]
+struct SharedArgs {
+    #[usage(long)]
+    verbose: bool,
+}
+
+#[derive(Subcommands)]
+enum SharedArgsCommand {
+    First(SharedArgs),
+    Second(SharedArgs),
+}
+
+#[derive(Cli)]
+#[usage(bin = "shared-args")]
+struct SharedArgsCli {
+    #[usage(subcommand)]
+    command: SharedArgsCommand,
+}
+
 const DEFAULT_RUNS: u32 = 7;
 const DYNAMIC_ABOUT: &str = "Metadata from a Rust constant.";
 const DYNAMIC_AFTER_HELP: &str = "More details from a Rust constant.";
@@ -210,6 +229,24 @@ fn identical_builtin_completers_are_emitted_once() {
         1,
         "{kdl}"
     );
+}
+
+#[test]
+fn one_args_type_can_back_multiple_commands() {
+    for command in ["first", "second"] {
+        let cli = SharedArgsCli::parse_from(&[OsStr::new(command), OsStr::new("--verbose")])
+            .expect("either command should route into the shared Args type");
+        match cli.command {
+            SharedArgsCommand::First(args) | SharedArgsCommand::Second(args) => {
+                assert!(args.verbose);
+            }
+        }
+    }
+
+    let kdl = SharedArgsCli::to_kdl();
+    assert!(kdl.contains("cmd \"first\""), "{kdl}");
+    assert!(kdl.contains("cmd \"second\""), "{kdl}");
+    assert_eq!(kdl.matches("flag \"--verbose\"").count(), 2, "{kdl}");
 }
 
 #[test]

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -128,6 +128,8 @@ struct CompletionDedup {
 struct SharedArgs {
     #[usage(long)]
     verbose: bool,
+    #[usage(long)]
+    target: Option<String>,
 }
 
 #[derive(Subcommands)]
@@ -239,6 +241,7 @@ fn one_args_type_can_back_multiple_commands() {
         match cli.command {
             SharedArgsCommand::First(args) | SharedArgsCommand::Second(args) => {
                 assert!(args.verbose);
+                assert!(args.target.is_none());
             }
         }
     }
@@ -247,6 +250,61 @@ fn one_args_type_can_back_multiple_commands() {
     assert!(kdl.contains("cmd \"first\""), "{kdl}");
     assert!(kdl.contains("cmd \"second\""), "{kdl}");
     assert_eq!(kdl.matches("flag \"--verbose\"").count(), 2, "{kdl}");
+}
+
+#[cfg(feature = "completions")]
+fn first_targets(_: &usage::complete::CompleteCtx<'_>) -> Vec<usage::complete::Candidate<'static>> {
+    vec![usage::complete::Candidate::new("first-target")]
+}
+
+#[cfg(feature = "completions")]
+fn second_targets(
+    _: &usage::complete::CompleteCtx<'_>,
+) -> Vec<usage::complete::Candidate<'static>> {
+    vec![usage::complete::Candidate::new("second-target")]
+}
+
+#[cfg(feature = "completions")]
+fn run_ready<F: std::future::Future>(future: F) -> F::Output {
+    struct Ready;
+    impl std::task::Wake for Ready {
+        fn wake(self: std::sync::Arc<Self>) {}
+    }
+
+    let waker = std::task::Waker::from(std::sync::Arc::new(Ready));
+    let mut cx = std::task::Context::from_waker(&waker);
+    let mut future = Box::pin(future);
+    match future.as_mut().poll(&mut cx) {
+        std::task::Poll::Ready(output) => output,
+        std::task::Poll::Pending => panic!("facade completion callback unexpectedly waited"),
+    }
+}
+
+#[cfg(feature = "completions")]
+#[test]
+fn shared_args_completion_overlays_stay_on_the_selected_command() {
+    static OVERLAYS: [usage::complete::CompletionOverlay<'static>; 2] = [
+        usage::complete::CompletionOverlay::sync("first", "target", first_targets),
+        usage::complete::CompletionOverlay::sync("second", "target", second_targets),
+    ];
+
+    for (command, expected) in [("first", "first-target"), ("second", "second-target")] {
+        let argv = [
+            std::ffi::OsString::from("__complete_word__"),
+            std::ffi::OsString::from("--shell"),
+            std::ffi::OsString::from("bash"),
+            std::ffi::OsString::from("--line"),
+            std::ffi::OsString::from(format!("shared-args {command} --target ")),
+        ];
+        let rendered = run_ready(
+            SharedArgsCli::app()
+                .completion_app()
+                .completions(&OVERLAYS)
+                .completion_request(&argv),
+        )
+        .expect("hidden completion request should be handled");
+        assert_eq!(rendered, format!("{expected}\n"));
+    }
 }
 
 #[test]


### PR DESCRIPTION
Removes the obsolete restriction that prevented two subcommand variants from wrapping the same `Args` type. Routing state is per selected variant and keys are scoped per command, so the existing generated architecture already isolates the mounts correctly.

A facade regression mounts one shared Args type under two command names, parses both, and verifies each emitted command owns one copy of the shared flag metadata. Both duplicate PLAN entries are marked complete.

Tests and clippy pass. Stacked on #1075.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches derive validation and completion routing; wrong metadata chains would mis-route overlays, but behavior is regression-tested for shared Args and nested reuse.
> 
> **Overview**
> **Subcommand enums can now mount the same `Args` struct on more than one variant** without a derive error. The old check that rejected two variants wrapping the same type is gone; routing and binding were already per variant, so duplicate field tables were the main migration pain (e.g. tak `push` / `init`).
> 
> **Completion metadata follows the parser’s route** instead of walking the spec tree by `Command` pointer identity. New `metadata_chain_on_route` and route-scoped flag/arg lookup fix overlays and KDL-backed completion when two commands reuse the same nested tables—each command path gets the right `CompletionOverlay` (covered for flat and nested shared-args shapes).
> 
> **PLAN** marks both “one Args type used by more than one command” items done. **Facade tests** parse two commands from one `SharedArgs`, assert duplicated flag metadata in emitted KDL, and (with completions) that per-command runtime overlays stay on the selected route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a4d8a80f31eb39280a7f269ff047f47daa4184a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->