### PR TITLE
docs: publish clap migration guide

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -516,19 +516,20 @@ Groups are the opposite case: `Command::get_groups`, `ArgGroup::get_args` and
 **API surface**
 
 - [ ] **`update_from` / `try_update_from`** — merge a parse into an existing struct.
-- [ ] **The builder** — `Command::new`, `augment_args`, `CommandFactory`,
+- [x] **The builder** — `Command::new`, `augment_args`, `CommandFactory`,
       `ArgMatches::get_one`, hand-written `FromArgMatches`. Architectural, and
       deliberate: usage-lib interprets a spec at run time and covers the dynamic
       case from the other side. This is an explicit non-goal: the usage metadata
       API does not need to reproduce clap's `Command` surface or be fully source
-      compatible with it.
-- [ ] **Public `CommandFactory` migration.** A library can expose
+      compatible with it. The migration guide and compatibility matrix publish
+      that boundary rather than leaving the missing API implicit.
+- [x] **Public `CommandFactory` migration.** A library can expose
       `pub fn command() -> clap::Command` as part of its supported API, as aube
       does. The 6.x transition may intentionally break that API and return a
       first-party usage metadata/spec view instead; it does not need to preserve
-      the complete clap builder contract. Document the semver expectation and any
-      separately named, opt-in compatibility entry point an adopter chooses to
-      retain.
+      the complete clap builder contract. The migration guide documents the
+      major-version break and the choices to retain a clap adapter or expose a
+      separately named usage spec/view API.
 
 **What is _not_ a gap**, checked rather than assumed, because two of these were
 recorded as gaps here and had quietly been closed: flag aliases (several `long`

--- a/PLAN.md
+++ b/PLAN.md
@@ -747,7 +747,7 @@ feature list is not an exhaustive audit.
       different shapes: a derive-heavy CLI, a builder-heavy CLI, and one using
       custom validation/completions. Record every unsupported feature they expose;
       do not silently narrow the sample to what already works.
-- [ ] **Migration and non-goal documentation.** Publish an attribute mapping guide,
+- [x] **Migration and non-goal documentation.** The Rust migration guide publishes an attribute mapping guide,
       examples for the common `Parser` / `Args` / `Subcommand` / `ValueEnum`
       rewrites, compile-fail examples for unsupported combinations, the clap
       compatibility baseline, and the parser-behavior semver policy. State which

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -65,6 +65,8 @@ export default defineConfig({
         items: [
           { text: "Args and Flags", link: "/rust/args-and-flags" },
           { text: "Subcommands", link: "/rust/subcommands" },
+          { text: "Migrating from clap", link: "/rust/migrating-from-clap" },
+          { text: "clap Compatibility", link: "/rust/clap-compatibility" },
           { text: "Validation", link: "/rust/validation" },
           { text: "Help and Errors", link: "/rust/help" },
           { text: "Performance", link: "/rust/performance" },

--- a/docs/rust/clap-compatibility.md
+++ b/docs/rust/clap-compatibility.md
@@ -22,74 +22,74 @@ not only from generated KDL, when a row says **usage only**.
 
 ## Types and declarations
 
-| clap                                             | usage       | clap → spec    | Notes                                                                                                     |
-| ------------------------------------------------ | ----------- | -------------- | --------------------------------------------------------------------------------------------------------- |
-| `Parser`                                         | Supported   | Supported      | `#[derive(usage::Cli)]`                                                                                   |
-| `Args`                                           | Supported   | Supported      | `#[derive(usage::Args)]`, including `flatten`                                                             |
-| `Subcommand`                                     | Supported   | Supported      | Nested and boxed variants are supported.                                                                  |
-| `ValueEnum`                                      | Partial     | Partial        | Bare values and names work; aliases, hidden values, per-value help, and case-insensitive matching do not. |
-| `#[arg(skip)]`                                   | Supported   | Not applicable | `#[usage(skip)]`; skipped fields do not belong in a spec.                                                 |
-| arbitrary `Command` / `Arg` builder code         | Non-goal    | Partial        | `usage-lib` is the dynamic spec interpreter; usage derive does not reproduce clap's builder API.          |
-| `ArgMatches`, `FromArgMatches`, `CommandFactory` | Non-goal    | Not applicable | Typed structs are built directly from static tables.                                                      |
-| `update_from` / `try_update_from`                | Unsupported | Not applicable | A parse currently constructs a new value.                                                                 |
+| clap                                             | usage       | clap → spec    | Notes                                                                                                                                                 |
+| ------------------------------------------------ | ----------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Parser`                                         | Supported   | Supported      | `#[derive(usage::Cli)]`                                                                                                                               |
+| `Args`                                           | Supported   | Supported      | `#[derive(usage::Args)]`, including `flatten`                                                                                                         |
+| `Subcommand`                                     | Supported   | Supported      | Nested and boxed variants are supported.                                                                                                              |
+| `ValueEnum`                                      | Partial     | Partial        | Names, aliases, cfg-gated variants, and case-insensitive matching work; per-value help and hidden values are not yet carried by Rust static metadata. |
+| `#[arg(skip)]`                                   | Supported   | Not applicable | `#[usage(skip)]`; skipped fields do not belong in a spec.                                                                                             |
+| arbitrary `Command` / `Arg` builder code         | Non-goal    | Partial        | `usage-lib` is the dynamic spec interpreter; usage derive does not reproduce clap's builder API.                                                      |
+| `ArgMatches`, `FromArgMatches`, `CommandFactory` | Non-goal    | Not applicable | Typed structs are built directly from static tables.                                                                                                  |
+| `update_from` / `try_update_from`                | Unsupported | Not applicable | A parse currently constructs a new value.                                                                                                             |
 
 ## Arguments and values
 
-| clap                                      | usage       | clap → spec    | Notes                                                                                                             |
-| ----------------------------------------- | ----------- | -------------- | ----------------------------------------------------------------------------------------------------------------- |
-| long and short flags                      | Supported   | Supported      | Multiple visible aliases are supported. Hidden flag aliases are bridge-lossy.                                     |
-| positional arguments                      | Supported   | Supported      | Required, optional, and variadic positionals are supported.                                                       |
-| `Option<T>`, `Vec<T>`, `Option<Vec<T>>`   | Supported   | Not applicable | Values use `FromStr`; Unix `PathBuf` and `OsString` also accept non-UTF-8 bytes.                                  |
-| `ArgAction::SetTrue`, `SetFalse`, `Count` | Supported   | Supported      | `SetFalse` is `#[usage(negate)]`.                                                                                 |
-| `default_value`                           | Supported   | Supported      | Defaults are applied after argv and environment values.                                                           |
-| `default_missing_value`                   | Usage only  | Unsupported    | `#[usage(default_missing = "…")]`; clap has no getter.                                                            |
-| `default_value_if(s)`                     | Usage only  | Unsupported    | `#[usage(default_if(...))]`; clap has no getter.                                                                  |
-| `env`                                     | Supported   | Partial        | Environment fallback works, but the current bridge can lose the binding.                                          |
-| `value_delimiter`                         | Supported   | Supported      | ASCII delimiters round-trip.                                                                                      |
-| `num_args`                                | Partial     | Partial        | `var_min` / `var_max` cover ranges; fixed arity, distinct value names, and bridge preservation remain incomplete. |
-| `allow_hyphen_values`                     | Supported   | Supported      | Available on value-taking flags; trailing positionals use `double_dash = "automatic"`.                            |
-| `allow_negative_numbers`                  | Unsupported | Unsupported    | `allow_hyphen_values` is broader, not equivalent.                                                                 |
-| `require_equals`                          | Supported   | Supported      | Detached values are refused.                                                                                      |
-| `value_terminator`                        | Unsupported | Unsupported    | No spec spelling yet.                                                                                             |
-| `dont_delimit_trailing_values`            | Unsupported | Unsupported    | No spec spelling yet.                                                                                             |
-| possible-values parser                    | Supported   | Supported      | Use `ValueEnum` or `choices`.                                                                                     |
-| arbitrary `value_parser` / numeric ranges | Unsupported | Unsupported    | `FromStr` validates conversion, but there is no per-field validator or declarative range yet.                     |
-| `ValueHint`                               | Partial     | Partial        | Path hints used by completions work; the full clap vocabulary does not.                                           |
+| clap                                      | usage       | clap → spec    | Notes                                                                                                                                             |
+| ----------------------------------------- | ----------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| long and short flags                      | Supported   | Partial        | Multiple visible and hidden aliases are supported directly; clap spelling and alias visibility are not all bridge-lossless.                       |
+| positional arguments                      | Supported   | Supported      | Required, optional, and variadic positionals are supported.                                                                                       |
+| `Option<T>`, `Vec<T>`, `Option<Vec<T>>`   | Supported   | Not applicable | Values use `FromStr`; Unix `PathBuf` and `OsString` also accept non-UTF-8 bytes.                                                                  |
+| `ArgAction::SetTrue`, `SetFalse`, `Count` | Supported   | Supported      | `SetFalse` is `#[usage(negate)]`.                                                                                                                 |
+| `default_value`                           | Supported   | Supported      | Defaults are applied after argv and environment values.                                                                                           |
+| `default_missing_value`                   | Usage only  | Unsupported    | `#[usage(default_missing = "…")]`; clap has no getter.                                                                                            |
+| `default_value_if(s)`                     | Usage only  | Unsupported    | `#[usage(default_if(...))]`; clap has no getter.                                                                                                  |
+| `env`                                     | Supported   | Partial        | Environment fallback works, but the current bridge can lose the binding.                                                                          |
+| `value_delimiter`                         | Supported   | Supported      | ASCII delimiters round-trip.                                                                                                                      |
+| `num_args`                                | Partial     | Partial        | `var_min` / `var_max` cover ranges; fixed arity, distinct value names, and bridge preservation remain incomplete.                                 |
+| `allow_hyphen_values`                     | Supported   | Supported      | Available on value-taking flags; trailing positionals use `double_dash = "automatic"`.                                                            |
+| `allow_negative_numbers`                  | Unsupported | Unsupported    | `allow_hyphen_values` is broader, not equivalent.                                                                                                 |
+| `require_equals`                          | Supported   | Supported      | Detached values are refused.                                                                                                                      |
+| `value_terminator`                        | Unsupported | Unsupported    | No spec spelling yet.                                                                                                                             |
+| `dont_delimit_trailing_values`            | Unsupported | Unsupported    | No spec spelling yet.                                                                                                                             |
+| possible-values parser                    | Supported   | Supported      | Use `ValueEnum` or `choices`.                                                                                                                     |
+| arbitrary `value_parser` / numeric ranges | Usage only  | Unsupported    | `FromStr` validates conversion; portable `validate` expressions cover declarative rules, but Rust callbacks cannot enter a language-neutral spec. |
+| `ValueHint`                               | Partial     | Partial        | Path hints used by completions work; the full clap vocabulary does not.                                                                           |
 
 ## Relationships and command routing
 
-| clap                                                      | usage       | clap → spec | Notes                                                                                                      |
-| --------------------------------------------------------- | ----------- | ----------- | ---------------------------------------------------------------------------------------------------------- |
-| `required`, `conflicts_with`, `overrides_with`            | Supported   | Supported   | Environment values participate in post-binding checks.                                                     |
-| `requires`                                                | Usage only  | Unsupported | clap exposes setters but no getter.                                                                        |
-| `requires_if(s)`                                          | Usage only  | Unsupported | Presence and value-conditional forms are supported in usage.                                               |
-| `required_if_eq`, `required_unless_present`               | Partial     | Partial     | Common single-selector forms work; the complete all/any families do not.                                   |
-| `ArgGroup`, required groups, `exclusive`                  | Supported   | Supported   | Positional group members are not represented yet.                                                          |
-| positional conflicts and relationships                    | Unsupported | Unsupported | Spec selectors currently name flags.                                                                       |
-| global flags                                              | Supported   | Supported   | A global may occur once per selected command scope.                                                        |
-| `allow_external_subcommands`                              | Supported   | Supported   | Use an `#[usage(external_subcommand)]` catch-all variant.                                                  |
-| `multicall`                                               | Supported   | Supported   | `parse()` routes on the executable basename.                                                               |
-| `no_binary_name`                                          | Unsupported | Unsupported | Low-level usage-argv already receives argv without argv0; no clap-compatible setter exists.                |
-| `infer_subcommands`, `infer_long_args`                    | Unsupported | Unsupported | Diagnostics suggest likely names but do not accept prefixes.                                               |
-| `arg_required_else_help` and subcommand/argument policies | Unsupported | Unsupported | No command-policy vocabulary yet.                                                                          |
-| unknown flags                                             | Different   | Different   | The spec can choose strict errors; the reference parser may forward unknown flag-like data to positionals. |
+| clap                                                      | usage       | clap → spec | Notes                                                                                                    |
+| --------------------------------------------------------- | ----------- | ----------- | -------------------------------------------------------------------------------------------------------- |
+| `required`, `conflicts_with`, `overrides_with`            | Supported   | Supported   | Environment values participate in post-binding checks.                                                   |
+| `requires`                                                | Usage only  | Unsupported | clap exposes setters but no getter.                                                                      |
+| `requires_if(s)`                                          | Usage only  | Unsupported | Presence and value-conditional forms are supported in usage.                                             |
+| `required_if_eq`, `required_unless_present`               | Partial     | Partial     | Common single-selector forms work; the complete all/any families do not.                                 |
+| `ArgGroup`, required groups, `exclusive`                  | Supported   | Supported   | Positional group members are not represented yet.                                                        |
+| positional conflicts and relationships                    | Unsupported | Unsupported | Spec selectors currently name flags.                                                                     |
+| global flags                                              | Supported   | Supported   | A global may occur once per selected command scope.                                                      |
+| `allow_external_subcommands`                              | Supported   | Supported   | Use an `#[usage(external_subcommand)]` catch-all variant.                                                |
+| `multicall`                                               | Supported   | Supported   | `parse()` routes on the executable basename.                                                             |
+| `no_binary_name`                                          | Supported   | Supported   | `parse_from` is words-only; `try_parse_from` and `parse_from_argv` honor the clap-shaped command policy. |
+| `infer_subcommands`, `infer_long_args`                    | Unsupported | Unsupported | Diagnostics suggest likely names but do not accept prefixes.                                             |
+| `arg_required_else_help` and subcommand/argument policies | Unsupported | Unsupported | No command-policy vocabulary yet.                                                                        |
+| unknown flags                                             | Different   | Different   | Parsing is permissive by default. Opt into clap-like rejection with `#[usage(unknown_flags = "error")]`. |
 
 ## Help, version, and generated artifacts
 
-| clap                                              | usage       | clap → spec    | Notes                                                                                |
-| ------------------------------------------------- | ----------- | -------------- | ------------------------------------------------------------------------------------ |
-| short and long help                               | Supported   | Supported      | The compiled renderer is checked against usage-lib across the jdx CLI fleet.         |
-| help headings                                     | Supported   | Supported      | Flags and arguments are grouped by heading.                                          |
-| hidden commands, flags, and arguments             | Supported   | Supported      | Granular hides for defaults, env, and possible values are unsupported.               |
-| doc comments and long help                        | Supported   | Supported      | First paragraph is short help; the full block is long help.                          |
-| `verbatim_doc_comment`                            | Unsupported | Not applicable | Doc comments are normalized.                                                         |
-| `help_template`, `next_line_help`, `flatten_help` | Unsupported | Unsupported    | No equivalent yet.                                                                   |
-| `term_width`, `max_term_width`                    | Unsupported | Unsupported    | Help wraps using `COLUMNS`.                                                          |
-| help styles and color                             | Partial     | Unsupported    | Diagnostics are styled; help output is not.                                          |
-| built-in help/version flag control                | Unsupported | Unsupported    | Custom help/version actions and disabling built-ins are not represented.             |
-| `--version` / `-V`                                | Supported   | Supported      | Version propagation is supported.                                                    |
-| completions                                       | Partial     | Supported      | Self-contained bash, fish, PowerShell, and zsh scripts are available; Elvish is not. |
-| KDL, markdown, and manpages                       | Supported   | Supported      | Emitted KDL feeds the existing generators without a runtime dependency.              |
+| clap                                              | usage       | clap → spec    | Notes                                                                                                               |
+| ------------------------------------------------- | ----------- | -------------- | ------------------------------------------------------------------------------------------------------------------- |
+| short and long help                               | Supported   | Supported      | The compiled renderer is checked against usage-lib across the jdx CLI fleet.                                        |
+| help headings                                     | Supported   | Supported      | Flags and arguments are grouped by heading.                                                                         |
+| hidden commands, flags, and arguments             | Supported   | Supported      | Granular hides for defaults, env, and possible values are unsupported.                                              |
+| doc comments and long help                        | Supported   | Supported      | First paragraph is short help; the full block is long help.                                                         |
+| `verbatim_doc_comment`                            | Unsupported | Not applicable | Doc comments are normalized.                                                                                        |
+| `help_template`, `next_line_help`, `flatten_help` | Unsupported | Unsupported    | No equivalent yet.                                                                                                  |
+| `term_width`, `max_term_width`                    | Unsupported | Unsupported    | Help wraps using `COLUMNS`.                                                                                         |
+| help styles and color                             | Partial     | Unsupported    | Diagnostics are styled; help output is not.                                                                         |
+| built-in help/version flag control                | Unsupported | Unsupported    | Custom help/version actions and disabling built-ins are not represented.                                            |
+| `--version` / `-V`                                | Supported   | Supported      | Version propagation is supported.                                                                                   |
+| completions                                       | Partial     | Supported      | Self-contained bash, fish, Nushell, PowerShell, and zsh scripts plus runtime overlays are available; Elvish is not. |
+| KDL, markdown, and manpages                       | Supported   | Supported      | Emitted KDL feeds the existing generators without a runtime dependency.                                             |
 
 ## Usage extensions
 

--- a/docs/rust/index.md
+++ b/docs/rust/index.md
@@ -49,7 +49,7 @@ One dependency. Add `usage-rs` to your `Cargo.toml`, aliased to `usage`:
 
 ```toml
 [dependencies]
-usage = { package = "usage-rs", version = "5" }
+usage = { package = "usage-rs", version = "6" }
 ```
 
 That is the whole install: derives, the argv runtime, help, and clap-shaped errors come with the
@@ -139,6 +139,7 @@ See [Spec output](/rust/spec) for the round-trip guarantees and what the emitted
 - [Help, version, and errors](/rust/help) — what the parser renders and how to hook it
 - [Completions](/rust/completions) — static scripts and runtime completion
 - [Spec output](/rust/spec) — the emitted KDL and usage-cli integration
+- [Migrating from clap](/rust/migrating-from-clap) — mechanical rewrites and intentional API breaks
 - [clap compatibility](/rust/clap-compatibility) — supported behavior, bridge losses, and non-goals
 
 ## Current limitations
@@ -148,9 +149,10 @@ equivalent yet:
 
 - `example` nodes exist in the spec format but cannot be declared from the derive — put an
   Examples section in `after_long_help` instead (mise does this).
-- `value_optional` affects help output only; the parser still requires a value for the flag.
-- There is no per-field `value_parser`-style validation — values are built with `FromStr`, and a
-  conversion failure becomes an `InvalidValue` error.
+- `value_optional` alone affects help. Pair it with `default_missing` to define what a bare flag
+  binds; arbitrary zero-or-one value ranges from clap are not inferred.
+- Rust `value_parser` functions are not portable metadata. Values use `FromStr`; use
+  `validate` for a portable expression rule and `validate_error` for its diagnostic.
 - Prefix matching (`infer_long_args`) is suggested in error messages but never accepted.
 - On Unix, `PathBuf` and `OsString` fields accept non-UTF-8 argv without changing a byte. String
   fields still report invalid UTF-8 precisely rather than replacing it; on Windows, values that

--- a/docs/rust/migrating-from-clap.md
+++ b/docs/rust/migrating-from-clap.md
@@ -1,0 +1,205 @@
+# Migrating from clap
+
+usage 6 is a typed parser with static metadata, not a compatibility layer around clap. Most
+derive-based CLIs migrate mechanically. Builder APIs and `ArgMatches` are intentional API
+breaks: move their behavior into typed declarations or keep clap at that boundary.
+
+Use the [compatibility matrix](/rust/clap-compatibility) as the audited baseline. It separates
+behavior supported by usage itself from metadata that `clap_usage` can recover from an existing
+`clap::Command`.
+
+## Dependencies
+
+Depend on the facade rather than on `usage-derive` or `usage-argv` separately:
+
+```toml
+[dependencies]
+usage = { package = "usage-rs", version = "6", features = ["completions"] }
+```
+
+The defaults include the derive, help, and clap-shaped diagnostics. Add `validation` for portable
+validation expressions and `completions` when the binary generates or answers completion
+requests.
+
+During a prerelease migration, pin every producer and consumer to one revision. In particular,
+the `usage-rs` dependency that emits KDL and any installed `usage-cli` that renders that KDL must
+use the same 6.x revision. A 5.x CLI reading a 6.x spec is unsupported.
+
+## Derive mapping
+
+| clap                    | usage                                                   |
+| ----------------------- | ------------------------------------------------------- |
+| `#[derive(Parser)]`     | `#[derive(usage::Cli)]`                                 |
+| `#[derive(Args)]`       | `#[derive(usage::Args)]`                                |
+| `#[derive(Subcommand)]` | `#[derive(usage::Subcommands)]`                         |
+| `#[derive(ValueEnum)]`  | `#[derive(usage::ValueEnum)]`                           |
+| `#[command(...)]`       | `#[usage(...)]`                                         |
+| `#[arg(...)]`           | `#[usage(...)]`, or keep a supported migration spelling |
+| `#[value(...)]`         | `#[usage(...)]`, or keep supported names and aliases    |
+
+`#[arg(long)]` is accepted on fields and inline subcommand variants, so the first pass can keep
+small diffs. Prefer `#[usage(...)]` for usage-only behavior and for the final declaration.
+
+```rust
+use usage::{Cli, Subcommands};
+
+#[derive(Cli)]
+#[usage(bin = "tak", version, unknown_flags = "error")]
+struct Cli {
+    #[usage(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommands)]
+enum Command {
+    /// Benchmark a command.
+    Run {
+        #[arg(long)]
+        bench: Option<String>,
+        #[arg(long)]
+        runs: Option<u32>,
+    },
+    Version,
+}
+```
+
+Unknown flags are values by default, which is useful for wrapper CLIs. Add
+`unknown_flags = "error"` on each command where unknown flag-like words must be rejected.
+
+## Fields
+
+Common mappings retain their meaning:
+
+```rust
+#[derive(usage::Args)]
+struct Options {
+    #[usage(short = 'v', long, count)]
+    verbose: u8,
+
+    #[usage(long, env = "APP_COLOR", default = "auto")]
+    color: String,
+
+    #[usage(long, delimiter = ',')]
+    tags: Vec<String>,
+
+    #[usage(long, value_enum)]
+    shell: Shell,
+
+    #[usage(skip)]
+    computed: bool,
+}
+```
+
+Defaults make a field optional in the generated grammar. `Option<T>` is also optional; `T`
+without a default is required. A bare optional-value flag needs an explicit meaning:
+
+```rust
+#[usage(long, default_missing = "always", require_equals)]
+color: Option<String>,
+```
+
+That accepts `--color` and `--color=never`, while refusing a detached value. usage does not
+guess clap's per-occurrence `num_args(0..=1)` semantics.
+
+For validation that must survive KDL emission, use a portable expression instead of a Rust
+`value_parser` callback:
+
+```rust
+#[usage(
+    long,
+    validate = "int(value) >= 1 && int(value) <= 65535",
+    validate_error = "must be a valid port"
+)]
+port: Option<u16>,
+```
+
+## Subcommands and shared arguments
+
+Unit commands, inline struct variants, nested enums, flattened groups, and one `Args` type mounted
+under more than one command are supported:
+
+```rust
+#[derive(usage::Args)]
+struct RemoteArgs {
+    #[usage(long, default = "origin")]
+    remote: String,
+}
+
+#[derive(usage::Subcommands)]
+enum Command {
+    Push(RemoteArgs),
+    Init(RemoteArgs),
+    Doctor,
+}
+```
+
+Tuple `Cli` and `Args` structs are not inferred. Name the field and say whether it is flattened:
+
+```compile_fail
+#[derive(usage::Args)]
+struct Ambiguous(CommonArgs);
+```
+
+```rust
+#[derive(usage::Args)]
+struct Explicit {
+    #[usage(flatten)]
+    common: CommonArgs,
+}
+```
+
+Relationships that cross a flattened boundary or name a positional are not supported yet. Keep
+the check after parsing until the compatibility matrix marks that row supported; the derive
+rejects selectors it can prove invalid instead of silently weakening them.
+
+## Parse entry points
+
+clap tests usually include argv0. Choose the matching entry point explicitly:
+
+| Need                                       | Entry point                         |
+| ------------------------------------------ | ----------------------------------- |
+| process argv, including help/version exits | `Cli::parse()`                      |
+| words after argv0                          | `Cli::parse_from(&[&OsStr])`        |
+| full argv with argv0, returning errors     | `Cli::parse_from_argv(&[OsString])` |
+| clap-shaped call sites                     | `Cli::try_parse_from(iter)`         |
+
+`parse_from` is the allocation-free primitive. `parse_from_argv` also applies multicall basename
+routing. Handle `usage::Error::Help` and `usage::Error::Version` before dispatch when an embedder
+must intercept those built-ins.
+
+## Help, specs, and completions
+
+Doc comments remain the source of short and long help. `Cli::to_kdl()` emits the portable spec;
+`Cli::spec().view()` provides cold-path identity and metadata overlays without moving normal
+parsing onto a dynamic command graph.
+
+With the `completions` feature, prefer the built-in completion surface:
+
+```rust
+let script = Cli::completion_script(usage::complete::Shell::Zsh);
+```
+
+Use `Cli::app().completion_app()` for projections and sync or async runtime candidates. Async
+callbacks return a future and run on the application's executor; usage does not bundle one.
+
+## Intentional non-goals
+
+usage does not reproduce `Command::new`, `augment_args`, `ArgMatches`, `FromArgMatches`, or the
+complete public `CommandFactory` builder surface. A library that publicly returns
+`clap::Command` must make a major-version API change, retain a clap-specific adapter, or expose a
+separately named usage spec/view API.
+
+These are architectural boundaries, not temporarily undocumented compatibility promises. The
+static typed path is what keeps normal parsing allocation-free; `usage-lib` remains the dynamic
+interpreter for applications that genuinely construct a CLI at runtime.
+
+## Compatibility policy
+
+Within usage 6.x, changes to accepted argv, typed binding, exit status, stdout versus stderr, or
+the portable spec dialect are parser behavior and follow semver. New clap spellings may be added
+compatibly when they map to existing behavior. A spelling whose clap behavior cannot be carried
+losslessly is rejected or documented as partial; it is not silently accepted with weaker
+semantics.
+
+The compatibility matrix is versioned against the clap releases named at its top. Updating clap
+requires re-auditing that matrix; compiling with a new clap is not by itself a parity claim.


### PR DESCRIPTION
## Summary

- publish a mechanical clap-to-usage derive migration guide
- document argv entry points, strictness, facade features, shared Args, and matching 6.x tooling
- state builder and ArgMatches APIs as architectural non-goals
- refresh the audited compatibility matrix and stale Rust overview claims
- close the migration and non-goal documentation item in PLAN.md

## Validation

- mise run lint:prettier
- git diff --check

_AI-generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or parser behavior; risk is limited to outdated matrix claims if they drift from the code.
> 
> **Overview**
> **Publishes clap migration documentation** for usage 6: a new [Migrating from clap](/rust/migrating-from-clap) guide with derive/attribute mapping, argv entry points, `unknown_flags`, portable `validate` vs `value_parser`, shared `Args`, completions/spec overlays, semver policy, and explicit **non-goals** (`Command`/`ArgMatches`/`CommandFactory`).
> 
> **Refreshes the audited [clap compatibility matrix](/rust/clap-compatibility)** — e.g. `ValueEnum` aliases/case-insensitivity, `no_binary_name`, permissive unknown flags vs `unknown_flags = "error"`, `validate` as usage-only, completion shells including Nushell, and bridge-loss notes on flags.
> 
> **Wires docs navigation** (Vitepress sidebar, Rust index links) and bumps the install snippet to **`usage-rs` version `6`**, with clearer limitations on `value_optional`/`default_missing` and non-UTF-8 paths.
> 
> **PLAN.md** marks migration/non-goal documentation and related builder/`CommandFactory` items as done, pointing readers at the guide and matrix instead of implicit gaps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec9aebc06b9b4e9bba9ae26748abc5a187776eca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->