### PR TITLE
feat(derive): preserve value enum metadata

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -444,13 +444,14 @@ Groups are the opposite case: `Command::get_groups`, `ArgGroup::get_args` and
 
 **Changes what a CLI accepts, less sharply**
 
-- [ ] **The full `PossibleValue` model** — `ignore_case`, aliases and their
+- [x] **The full `PossibleValue` model** — `ignore_case`, aliases and their
       visibility, per-value help, and hidden values. Subcommand variants take
       aliases. The KDL model, usage-lib parser, and clap bridge now preserve this
       metadata. Generated Go tables distinguish accepted aliases and hidden values from
-      the visible diagnostic/help list and honor `ignore_case`; Rust `ValueEnum` accepts
-      aliases and case-insensitive values. Carrying per-value help and visibility through
-      Rust's static metadata is the remaining work before this item is complete.
+      the visible diagnostic/help list and honor `ignore_case`; Rust `ValueEnum` now
+      carries doc-comment or explicit help, hidden canonical values, hidden `alias`,
+      visible `visible_alias`, and case-insensitive matching through its static metadata
+      and lossless KDL emission.
 - [ ] **`infer_subcommands` / `infer_long_args`** — unambiguous prefixes. We
       suggest what was probably meant but do not accept it.
 - [x] **`external_subcommand`** — an unmatched word is forwarded with the rest

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -988,7 +988,16 @@ pub fn candidates<'a>(spec: &'a Spec<'a>, split: &Split) -> Vec<Candidate<'a>> {
             .unwrap_or_default()
     } else if let Some(flag) = position.awaiting_value {
         flag_meta(spec.root, flag)
-            .map(|m| declared(m.choices, m.complete, split, &position, token))
+            .map(|m| {
+                declared(
+                    m.choices,
+                    m.choice_details,
+                    m.complete,
+                    split,
+                    &position,
+                    token,
+                )
+            })
             .unwrap_or_default()
     } else {
         let mut found = Vec::new();
@@ -1143,7 +1152,14 @@ fn positional<'a>(
         }
         return Vec::new();
     }
-    declared(meta.choices, meta.complete, split, position, token)
+    declared(
+        meta.choices,
+        meta.choice_details,
+        meta.complete,
+        split,
+        position,
+        token,
+    )
 }
 
 /// What a position declares it takes: its choices, or the completer that answers for it.
@@ -1154,13 +1170,14 @@ fn positional<'a>(
 /// the reference does with a `run=` command's output.
 fn declared<'a>(
     choices_declared: &'a [&'a str],
+    choice_details: &'a [crate::spec::ChoiceMeta<'a>],
     completer: Option<Completer>,
     split: &Split,
     position: &Position<'_>,
     token: &str,
 ) -> Vec<Candidate<'a>> {
     if !choices_declared.is_empty() {
-        return choices(choices_declared, token);
+        return choices(choices_declared, choice_details, token);
     }
     let Some(completer) = completer else {
         return Vec::new();
@@ -1196,13 +1213,23 @@ fn command_words<'s>(split: &'s Split, position: &Position<'_>) -> &'s [String] 
 }
 
 /// The declared values of a flag or argument, filtered by what has been typed.
-fn choices<'a>(declared: &'a [&'a str], token: &str) -> Vec<Candidate<'a>> {
+fn choices<'a>(
+    declared: &'a [&'a str],
+    details: &'a [crate::spec::ChoiceMeta<'a>],
+    token: &str,
+) -> Vec<Candidate<'a>> {
     declared
         .iter()
         .filter(|c| c.starts_with(token))
         .map(|c| Candidate {
             value: (*c).to_string(),
-            description: None,
+            description: details
+                .iter()
+                .find(|detail| {
+                    detail.value == *c || detail.aliases.iter().any(|alias| alias.value == *c)
+                })
+                .and_then(|detail| detail.help)
+                .map(::std::borrow::Cow::Borrowed),
         })
         .collect()
 }
@@ -1679,6 +1706,12 @@ mod tests {
             flag: &JOBS,
             help: Some("How many at once"),
             choices: &["1", "2", "4"],
+            choice_details: &[crate::spec::ChoiceMeta {
+                value: "2",
+                help: Some("Two workers"),
+                hide: false,
+                aliases: &[],
+            }],
             ..FlagMeta::EMPTY
         }],
         args: &[ArgMeta {
@@ -2506,6 +2539,10 @@ mod tests {
 
         let found = candidates(&SPEC, &at_end("mise pl"));
         assert_eq!(found[0].description.as_deref(), Some("Manage plugins"));
+
+        let found = candidates(&SPEC, &at_end("mise use --jobs "));
+        let two = found.iter().find(|c| c.value == "2").expect("choice 2");
+        assert_eq!(two.description.as_deref(), Some("Two workers"));
     }
     #[test]
     fn a_help_topic_offers_the_commands_under_it() {

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -665,14 +665,14 @@ pub fn complete<'a>(spec: &'a Spec<'a>, split: &Split) -> Completions<'a> {
         let meta = flag_meta(spec.root, flag);
         (
             meta.and_then(|m| m.value_name).or(Some(flag.name)),
-            meta.is_some_and(|m| !m.choices.is_empty()),
+            meta.is_some_and(|m| !m.choices.is_empty() || !m.accepted_choices.is_empty()),
             meta.and_then(|m| m.complete_type),
         )
     } else if let Some(arg) = at_cursor {
         let meta = arg_meta(spec.root, arg);
         (
             Some(arg.name),
-            meta.is_some_and(|m| !m.choices.is_empty()),
+            meta.is_some_and(|m| !m.choices.is_empty() || !m.accepted_choices.is_empty()),
             meta.and_then(|m| m.complete_type),
         )
     } else {
@@ -2727,6 +2727,39 @@ mod tests {
         assert_eq!(a.files, None);
         // Nor for a help topic, which is a command name and nothing else.
         assert_eq!(answer("mise help ").files, None);
+    }
+
+    #[test]
+    fn hidden_only_choices_still_close_the_position() {
+        static VALUE: Arg = Arg {
+            key: 90,
+            name: "VALUE",
+            ..Arg::REQUIRED
+        };
+        static ROOT: Command = Command {
+            name: "hidden",
+            args: &[&VALUE],
+            ..Command::EMPTY
+        };
+        static META: CommandMeta = CommandMeta {
+            cmd: &ROOT,
+            args: &[ArgMeta {
+                arg: &VALUE,
+                accepted_choices: &["secret"],
+                ..ArgMeta::EMPTY
+            }],
+            ..CommandMeta::EMPTY
+        };
+        static HIDDEN_SPEC: Spec = Spec {
+            name: "hidden",
+            bin: Some("hidden"),
+            root: &META,
+            ..Spec::EMPTY
+        };
+
+        let answer = complete(&HIDDEN_SPEC, &at_end("hidden sec"));
+        assert!(answer.candidates.is_empty());
+        assert_eq!(answer.files, None);
     }
 
     #[test]

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -772,6 +772,8 @@ pub struct FlagMeta<'a> {
     pub choices: &'a [&'a str],
     /// Canonical-to-alias pairs used when emitting a lossless spec.
     pub choice_aliases: &'a [(&'a str, &'a str)],
+    /// Per-canonical presentation metadata used when emitting a lossless spec.
+    pub choice_details: &'a [ChoiceMeta<'a>],
     pub ignore_case: bool,
     /// Portable expr expression evaluated for each raw value.
     pub validate: Option<&'a str>,
@@ -851,6 +853,7 @@ impl FlagMeta<'_> {
         accepted_choices: &[],
         choices: &[],
         choice_aliases: &[],
+        choice_details: &[],
         ignore_case: false,
         validate: None,
         validate_error: None,
@@ -906,6 +909,8 @@ pub struct ArgMeta<'a> {
     pub choices: &'a [&'a str],
     /// Canonical-to-alias pairs used when emitting a lossless spec.
     pub choice_aliases: &'a [(&'a str, &'a str)],
+    /// Per-canonical presentation metadata used when emitting a lossless spec.
+    pub choice_details: &'a [ChoiceMeta<'a>],
     pub ignore_case: bool,
     /// Portable expr expression evaluated for each raw value.
     pub validate: Option<&'a str>,
@@ -941,6 +946,7 @@ impl ArgMeta<'_> {
         accepted_choices: &[],
         choices: &[],
         choice_aliases: &[],
+        choice_details: &[],
         ignore_case: false,
         validate: None,
         validate_error: None,
@@ -1567,7 +1573,10 @@ fn write_flag(out: &mut String, meta: &FlagMeta<'_>, depth: usize) -> core::fmt:
                 write!(out, " validate_error={}", quoted(error))?;
             }
         }
-        if meta.choices.is_empty() {
+        if meta.choices.is_empty()
+            && meta.accepted_choices.is_empty()
+            && meta.choice_details.is_empty()
+        {
             out.push('\n');
         } else {
             out.push_str(" {\n");
@@ -1576,18 +1585,23 @@ fn write_flag(out: &mut String, meta: &FlagMeta<'_>, depth: usize) -> core::fmt:
                 meta.choices,
                 meta.accepted_choices,
                 meta.choice_aliases,
+                meta.choice_details,
                 meta.ignore_case,
                 inner + 1,
             )?;
             indent(out, inner)?;
             out.push_str("}\n");
         }
-    } else if !meta.choices.is_empty() {
+    } else if !meta.choices.is_empty()
+        || !meta.accepted_choices.is_empty()
+        || !meta.choice_details.is_empty()
+    {
         write_choices(
             out,
             meta.choices,
             meta.accepted_choices,
             meta.choice_aliases,
+            meta.choice_details,
             meta.ignore_case,
             inner,
         )?;
@@ -1646,8 +1660,11 @@ fn write_arg(out: &mut String, meta: &ArgMeta<'_>, depth: usize) -> core::fmt::R
     }
     write_single_default(out, meta.default)?;
 
-    let has_children =
-        meta.long_help.is_some() || !meta.choices.is_empty() || meta.default.len() > 1;
+    let has_children = meta.long_help.is_some()
+        || !meta.choices.is_empty()
+        || !meta.accepted_choices.is_empty()
+        || !meta.choice_details.is_empty()
+        || meta.default.len() > 1;
     if !has_children {
         out.push('\n');
         return Ok(());
@@ -1665,6 +1682,7 @@ fn write_arg(out: &mut String, meta: &ArgMeta<'_>, depth: usize) -> core::fmt::R
         meta.choices,
         meta.accepted_choices,
         meta.choice_aliases,
+        meta.choice_details,
         meta.ignore_case,
         inner,
     )?;
@@ -1737,16 +1755,80 @@ fn write_choices(
     choices: &[&str],
     accepted_choices: &[&str],
     aliases: &[(&str, &str)],
+    details: &[ChoiceMeta<'_>],
     ignore_case: bool,
     depth: usize,
 ) -> core::fmt::Result {
-    if choices.is_empty() && accepted_choices.is_empty() {
+    if choices.is_empty() && accepted_choices.is_empty() && details.is_empty() {
         return Ok(());
     }
     indent(out, depth)?;
     out.push_str("choices");
     if ignore_case {
         out.push_str(" ignore_case=#true");
+    }
+
+    if !details.is_empty() {
+        out.push_str(" {\n");
+        let is_alias = |value: &str| {
+            aliases.iter().any(|(_, alias)| *alias == value)
+                || details
+                    .iter()
+                    .flat_map(|choice| choice.aliases)
+                    .any(|alias| alias.value == value)
+        };
+        let mut canonicals = std::vec::Vec::new();
+        for value in choices
+            .iter()
+            .chain(aliases.iter().map(|(canonical, _)| canonical))
+            .chain(accepted_choices.iter())
+            .chain(details.iter().map(|choice| &choice.value))
+        {
+            if !is_alias(value) && !canonicals.contains(value) {
+                canonicals.push(*value);
+            }
+        }
+        for value in canonicals {
+            let detail = details.iter().find(|choice| choice.value == value);
+            indent(out, depth + 1)?;
+            write!(out, "choice {}", quoted(value))?;
+            if let Some(help) = detail.and_then(|choice| choice.help) {
+                write!(out, " help={}", quoted(help))?;
+            }
+            if detail.is_some_and(|choice| choice.hide) || !choices.contains(&value) {
+                out.push_str(" hide=#true");
+            }
+            let fallback_aliases: std::vec::Vec<ChoiceAliasMeta<'_>> = aliases
+                .iter()
+                .filter_map(|(canonical, alias)| {
+                    (*canonical == value).then_some(ChoiceAliasMeta {
+                        value: alias,
+                        hide: !choices.contains(alias),
+                    })
+                })
+                .collect();
+            let choice_aliases = detail
+                .map(|choice| choice.aliases)
+                .unwrap_or(&fallback_aliases);
+            if choice_aliases.is_empty() {
+                out.push('\n');
+                continue;
+            }
+            out.push_str(" {\n");
+            for alias in choice_aliases {
+                indent(out, depth + 2)?;
+                write!(out, "alias {}", quoted(alias.value))?;
+                if alias.hide {
+                    out.push_str(" hide=#true");
+                }
+                out.push('\n');
+            }
+            indent(out, depth + 1)?;
+            out.push_str("}\n");
+        }
+        indent(out, depth)?;
+        out.push_str("}\n");
+        return Ok(());
     }
 
     let has_hidden_accepted = accepted_choices
@@ -1904,7 +1986,23 @@ pub trait ValueEnum: Sized {
     const ACCEPTED_CHOICES: &'static [&'static str] = Self::CHOICES;
     /// Canonical-to-alias pairs, used by spec emission to retain the distinction.
     const ALIASES: &'static [(&'static str, &'static str)] = &[];
+    /// Presentation metadata for canonical values and aliases.
+    const DETAILS: &'static [ChoiceMeta<'static>] = &[];
     const IGNORE_CASE: bool = false;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChoiceMeta<'a> {
+    pub value: &'a str,
+    pub help: Option<&'a str>,
+    pub hide: bool,
+    pub aliases: &'a [ChoiceAliasMeta<'a>],
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChoiceAliasMeta<'a> {
+    pub value: &'a str,
+    pub hide: bool,
 }
 
 pub fn choice_matches(choices: &[&str], value: &str, ignore_case: bool) -> bool {
@@ -2222,6 +2320,7 @@ mod tests {
             &["shown", "short"],
             &["shown", "secret", "short", "secret-short"],
             &[("shown", "short"), ("shown", "secret-short")],
+            &[],
             false,
             0,
         )
@@ -2232,10 +2331,42 @@ mod tests {
         );
 
         out.clear();
-        write_choices(&mut out, &[], &["secret"], &[], false, 0).unwrap();
+        write_choices(&mut out, &[], &["secret"], &[], &[], false, 0).unwrap();
         assert_eq!(
             out, "choices {\n    choice \"secret\" hide=#true\n}\n",
             "an entirely hidden set must still be emitted"
+        );
+
+        out.clear();
+        write_choices(
+            &mut out,
+            &["plain", "shown", "short"],
+            &["plain", "shown", "short", "secret"],
+            &[("shown", "short")],
+            &[
+                ChoiceMeta {
+                    value: "shown",
+                    help: Some("Shown value"),
+                    hide: false,
+                    aliases: &[ChoiceAliasMeta {
+                        value: "short",
+                        hide: false,
+                    }],
+                },
+                ChoiceMeta {
+                    value: "secret",
+                    help: None,
+                    hide: true,
+                    aliases: &[],
+                },
+            ],
+            false,
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            out,
+            "choices {\n    choice \"plain\"\n    choice \"shown\" help=\"Shown value\" {\n        alias \"short\"\n    }\n    choice \"secret\" hide=#true\n}\n"
         );
     }
 

--- a/cli/usage.usage.kdl
+++ b/cli/usage.usage.kdl
@@ -207,7 +207,10 @@ cmd "generate" help="Generate completions, documentation, and other artifacts fr
 cmd "lint" help="Lint a usage spec file for common issues" effect="read" {
     flag "-f --format" help="Output format" default="text" {
         arg "<FORMAT>" {
-            choices "text" "json"
+            choices {
+                choice "text"
+                choice "json"
+            }
         }
     }
     flag "-W --warnings-as-errors" help="Treat warnings as errors"

--- a/conformance/src/tables.rs
+++ b/conformance/src/tables.rs
@@ -26,7 +26,8 @@
 use usage::spec::cmd::SpecExample;
 use usage::{Spec, SpecArg, SpecChoices, SpecCommand, SpecComplete, SpecFlag, SpecGroup};
 use usage_argv::spec::{
-    ArgMeta, CommandMeta, DefaultIf, Effect, Example, FlagMeta, GroupMeta, RequiresIf,
+    ArgMeta, ChoiceAliasMeta, ChoiceMeta, CommandMeta, DefaultIf, Effect, Example, FlagMeta,
+    GroupMeta, RequiresIf,
 };
 use usage_argv::{Arg, Command, DoubleDash, Flag, UnknownFlags as ArgvUnknownFlags};
 
@@ -316,6 +317,7 @@ fn flag_meta(
         accepted_choices: accepted_choices(choices),
         choices: visible_choices(choices),
         choice_aliases: choice_aliases(choices),
+        choice_details: choice_details(choices),
         ignore_case: choices.is_some_and(|c| c.ignore_case),
         validate: arg.and_then(|a| a.validate.as_deref()).map(leak),
         validate_error: arg.and_then(|a| a.validate_error.as_deref()).map(leak),
@@ -377,6 +379,7 @@ fn arg_meta(
         accepted_choices: accepted_choices(choices),
         choices: visible_choices(choices),
         choice_aliases: choice_aliases(choices),
+        choice_details: choice_details(choices),
         ignore_case: choices.is_some_and(|c| c.ignore_case),
         validate: a.validate.as_deref().map(leak),
         validate_error: a.validate_error.as_deref().map(leak),
@@ -520,6 +523,35 @@ fn choice_aliases(choices: Option<&SpecChoices>) -> &'static [(&'static str, &'s
                     .aliases
                     .iter()
                     .map(move |alias| (leak(&choice.value), leak(&alias.value)))
+            })
+            .collect::<Vec<_>>()
+            .into_boxed_slice(),
+    )
+}
+
+fn choice_details(choices: Option<&SpecChoices>) -> &'static [ChoiceMeta<'static>] {
+    let Some(choices) = choices else {
+        return &[];
+    };
+    Box::leak(
+        choices
+            .details
+            .iter()
+            .map(|choice| ChoiceMeta {
+                value: leak(&choice.value),
+                help: choice.help.as_deref().map(leak),
+                hide: choice.hide,
+                aliases: Box::leak(
+                    choice
+                        .aliases
+                        .iter()
+                        .map(|alias| ChoiceAliasMeta {
+                            value: leak(&alias.value),
+                            hide: alias.hide,
+                        })
+                        .collect::<Vec<_>>()
+                        .into_boxed_slice(),
+                ),
             })
             .collect::<Vec<_>>()
             .into_boxed_slice(),

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -1177,7 +1177,8 @@ fn flag_meta(i: usize, field: &Field, owner: &syn::Ident) -> TokenStream {
     // Declared, not inferred: `Option<String>` already says the *flag* is optional and says
     // nothing about whether its value is.
     let value_optional = field.value_optional;
-    let (choices, accepted_choices, choice_aliases, ignore_case) = choices_tokens(field);
+    let (choices, accepted_choices, choice_aliases, choice_details, ignore_case) =
+        choices_tokens(field);
     let validate = option_str(field.validate.as_deref());
     let validate_error = option_str(field.validate_error.as_deref());
     let (var_min, var_max) = bounds_tokens(field);
@@ -1237,6 +1238,7 @@ fn flag_meta(i: usize, field: &Field, owner: &syn::Ident) -> TokenStream {
             accepted_choices: #accepted_choices,
             choices: #choices,
             choice_aliases: #choice_aliases,
+            choice_details: #choice_details,
             ignore_case: #ignore_case,
             validate: #validate,
             validate_error: #validate_error,
@@ -1272,7 +1274,8 @@ fn arg_meta(i: usize, field: &Field, owner: &syn::Ident) -> TokenStream {
     // declare it. Every other shape gets its answer from the type.
     let required =
         (field.shape == Shape::Required || field.required_collection) && field.default.is_empty();
-    let (choices, accepted_choices, choice_aliases, ignore_case) = choices_tokens(field);
+    let (choices, accepted_choices, choice_aliases, choice_details, ignore_case) =
+        choices_tokens(field);
     let validate = option_str(field.validate.as_deref());
     let validate_error = option_str(field.validate_error.as_deref());
     let (var_min, var_max) = bounds_tokens(field);
@@ -1298,6 +1301,7 @@ fn arg_meta(i: usize, field: &Field, owner: &syn::Ident) -> TokenStream {
             accepted_choices: #accepted_choices,
             choices: #choices,
             choice_aliases: #choice_aliases,
+            choice_details: #choice_details,
             ignore_case: #ignore_case,
             validate: #validate,
             validate_error: #validate_error,
@@ -1310,7 +1314,15 @@ fn arg_meta(i: usize, field: &Field, owner: &syn::Ident) -> TokenStream {
 }
 
 /// A field's declared choices, as the metadata holds them.
-fn choices_tokens(field: &Field) -> (TokenStream, TokenStream, TokenStream, TokenStream) {
+fn choices_tokens(
+    field: &Field,
+) -> (
+    TokenStream,
+    TokenStream,
+    TokenStream,
+    TokenStream,
+    TokenStream,
+) {
     // From the type when the field says `value_enum`, so the spec, the help and the check
     // all read the list the type declares rather than a copy of it.
     if let (true, Some(ty)) = (field.value_enum, field.value_ty.as_ref()) {
@@ -1318,12 +1330,19 @@ fn choices_tokens(field: &Field) -> (TokenStream, TokenStream, TokenStream, Toke
             quote!(<#ty as usage_argv::spec::ValueEnum>::CHOICES),
             quote!(<#ty as usage_argv::spec::ValueEnum>::ACCEPTED_CHOICES),
             quote!(<#ty as usage_argv::spec::ValueEnum>::ALIASES),
+            quote!(<#ty as usage_argv::spec::ValueEnum>::DETAILS),
             quote!(<#ty as usage_argv::spec::ValueEnum>::IGNORE_CASE),
         );
     }
     let choices = &field.choices;
     let choices = quote!(&[#(#choices),*]);
-    (choices.clone(), choices, quote!(&[]), quote!(false))
+    (
+        choices.clone(),
+        choices,
+        quote!(&[]),
+        quote!(&[]),
+        quote!(false),
+    )
 }
 
 /// A field's declared bounds, as the metadata holds them.
@@ -4877,24 +4896,50 @@ fn post_binding(cli: &Cli) -> TokenStream {
 pub fn emit_value_enum(value_enum: &ValueEnum) -> TokenStream {
     let ident = &value_enum.ident;
     let runtime = runtime_path();
-    let words = value_enum.variants.iter().map(|value| {
-        let word = &value.name;
+    let words = value_enum.variants.iter().flat_map(|value| {
         let cfg = &value.cfg_attrs;
-        quote!(#(#cfg)* #word)
+        ::std::iter::once((!value.hide).then_some(&value.name))
+            .chain(
+                value
+                    .aliases
+                    .iter()
+                    .map(|alias| (!alias.hide).then_some(&alias.name)),
+            )
+            .flatten()
+            .map(move |word| quote!(#(#cfg)* #word))
     });
     let accepted = value_enum.variants.iter().flat_map(|value| {
         let cfg = &value.cfg_attrs;
         ::std::iter::once(&value.name)
-            .chain(value.aliases.iter())
+            .chain(value.aliases.iter().map(|alias| &alias.name))
             .map(move |word| quote!(#(#cfg)* #word))
     });
     let aliases = value_enum.variants.iter().flat_map(|value| {
         let canonical = &value.name;
         let cfg = &value.cfg_attrs;
-        value
-            .aliases
-            .iter()
-            .map(move |alias| quote!(#(#cfg)* (#canonical, #alias)))
+        value.aliases.iter().map(move |alias| {
+            let alias = &alias.name;
+            quote!(#(#cfg)* (#canonical, #alias))
+        })
+    });
+    let details = value_enum.variants.iter().map(|value| {
+        let canonical = &value.name;
+        let help = option_str(value.help.as_deref());
+        let hide = value.hide;
+        let cfg = &value.cfg_attrs;
+        let aliases = value.aliases.iter().map(|alias| {
+            let name = &alias.name;
+            let hide = alias.hide;
+            quote!(usage_argv::spec::ChoiceAliasMeta { value: #name, hide: #hide })
+        });
+        quote!(
+            #(#cfg)* usage_argv::spec::ChoiceMeta {
+                value: #canonical,
+                help: #help,
+                hide: #hide,
+                aliases: &[#(#aliases),*],
+            }
+        )
     });
     let ignore_case = value_enum.ignore_case;
 
@@ -4907,6 +4952,7 @@ pub fn emit_value_enum(value_enum: &ValueEnum) -> TokenStream {
                 const CHOICES: &'static [&'static str] = &[#(#words),*];
                 const ACCEPTED_CHOICES: &'static [&'static str] = &[#(#accepted),*];
                 const ALIASES: &'static [(&'static str, &'static str)] = &[#(#aliases),*];
+                const DETAILS: &'static [usage_argv::spec::ChoiceMeta<'static>] = &[#(#details),*];
                 const IGNORE_CASE: bool = #ignore_case;
             }
         };

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -380,15 +380,19 @@ pub fn derive_subcommands(input: TokenStream) -> TokenStream {
 /// ```ignore
 /// #[derive(usage::ValueEnum)]
 /// enum Shell {
+///     /// Bourne Again shell.
 ///     Bash,
 ///     #[value(alias = "shell-z")]
 ///     Zsh,
-///     #[value(name = "pwsh")]
+///     #[value(name = "pwsh", visible_alias = "powershell", hide = true)]
 ///     PowerShell,
 /// }
 /// ```
 ///
 /// `#[usage(ignore_case)]` on the enum applies to canonical words and aliases.
+/// A variant's doc comment becomes its per-value help. `help = "..."` overrides
+/// it, `hide` keeps the value accepted while omitting it from help and completion,
+/// `alias` is hidden, and `visible_alias` is advertised alongside the canonical word.
 ///
 /// The enum must implement [`FromStr`](std::str::FromStr); this derive owns only its CLI
 /// word metadata and does not replace domain parsing. Variant `cfg` and `cfg_attr`

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -3519,8 +3519,15 @@ pub struct ValueEnum {
 pub struct ValueVariant {
     pub ident: syn::Ident,
     pub name: String,
-    pub aliases: Vec<String>,
+    pub aliases: Vec<ValueAlias>,
+    pub help: Option<String>,
+    pub hide: bool,
     pub cfg_attrs: Vec<syn::Attribute>,
+}
+
+pub struct ValueAlias {
+    pub name: String,
+    pub hide: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -3736,6 +3743,9 @@ impl ValueEnum {
                 .map(|style| style.apply(&rust_name))
                 .unwrap_or_else(|| to_kebab(&rust_name));
             let mut aliases = Vec::new();
+            let (doc_help, _) = doc_comment(&variant.attrs, false)?;
+            let mut help = doc_help;
+            let mut hide = false;
             for attr in value_attrs(&variant.attrs) {
                 for meta in nested(attr)? {
                     let path = meta.path().clone();
@@ -3749,15 +3759,35 @@ impl ValueEnum {
                                         "an alias with no name would answer to nothing",
                                     ));
                                 }
-                                aliases.push(alias);
+                                aliases.push(ValueAlias {
+                                    name: alias,
+                                    hide: true,
+                                });
                             }
                         }
+                        "visible_alias" | "visible_aliases" => {
+                            for alias in selectors(&meta)? {
+                                if alias.is_empty() {
+                                    return Err(syn::Error::new_spanned(
+                                        &path,
+                                        "an alias with no name would answer to nothing",
+                                    ));
+                                }
+                                aliases.push(ValueAlias {
+                                    name: alias,
+                                    hide: false,
+                                });
+                            }
+                        }
+                        "help" => help = Some(string_value(&meta)?),
+                        "hide" => hide = flag_value(&meta)?,
                         other => {
                             return Err(syn::Error::new_spanned(
                                 path,
                                 format!(
                                     "unknown option `{other}` on a value; a variant takes \
-                                     `name`, `alias`, or `aliases` here"
+                                     `name`, `alias`, `aliases`, `visible_alias`, \
+                                     `visible_aliases`, `help`, or `hide` here"
                                 ),
                             ));
                         }
@@ -3774,6 +3804,8 @@ impl ValueEnum {
                 ident: variant.ident.clone(),
                 name,
                 aliases,
+                help,
+                hide,
                 cfg_attrs,
             });
         }
@@ -3787,7 +3819,7 @@ impl ValueEnum {
         let mut seen: Vec<(&str, Span, &[Attribute])> = Vec::new();
         for variant in &variants {
             for word in ::std::iter::once(variant.name.as_str())
-                .chain(variant.aliases.iter().map(String::as_str))
+                .chain(variant.aliases.iter().map(|alias| alias.name.as_str()))
             {
                 let collision = seen.iter().find(|(seen, _, cfg)| {
                     let same = if ignore_case {
@@ -4467,14 +4499,20 @@ mod tests {
         let ve = value_enum(
             r#"
             enum Provider {
-                #[value(name = "1password", alias = "op")]
+                /// Password manager.
+                #[value(name = "1password", alias = "op", visible_alias = "one", hide)]
                 OnePassword,
             }
         "#,
         )
         .expect("clap value metadata should remain usable");
         assert_eq!(ve.variants[0].name, "1password");
-        assert_eq!(ve.variants[0].aliases, ["op"]);
+        assert_eq!(ve.variants[0].help.as_deref(), Some("Password manager."));
+        assert!(ve.variants[0].hide);
+        assert_eq!(ve.variants[0].aliases[0].name, "op");
+        assert!(ve.variants[0].aliases[0].hide);
+        assert_eq!(ve.variants[0].aliases[1].name, "one");
+        assert!(!ve.variants[0].aliases[1].hide);
     }
 
     #[test]

--- a/docs/cli/reference/commands.json
+++ b/docs/cli/reference/commands.json
@@ -1162,7 +1162,15 @@
               "double_dash": "Optional",
               "hide": false,
               "choices": {
-                "choices": ["text", "json"]
+                "choices": ["text", "json"],
+                "details": [
+                  {
+                    "value": "text"
+                  },
+                  {
+                    "value": "json"
+                  }
+                ]
               }
             },
             "default": ["text"]

--- a/docs/rust/clap-compatibility.md
+++ b/docs/rust/clap-compatibility.md
@@ -22,16 +22,16 @@ not only from generated KDL, when a row says **usage only**.
 
 ## Types and declarations
 
-| clap                                             | usage       | clap → spec    | Notes                                                                                                                                                 |
-| ------------------------------------------------ | ----------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Parser`                                         | Supported   | Supported      | `#[derive(usage::Cli)]`                                                                                                                               |
-| `Args`                                           | Supported   | Supported      | `#[derive(usage::Args)]`, including `flatten`                                                                                                         |
-| `Subcommand`                                     | Supported   | Supported      | Nested and boxed variants are supported.                                                                                                              |
-| `ValueEnum`                                      | Partial     | Partial        | Names, aliases, cfg-gated variants, and case-insensitive matching work; per-value help and hidden values are not yet carried by Rust static metadata. |
-| `#[arg(skip)]`                                   | Supported   | Not applicable | `#[usage(skip)]`; skipped fields do not belong in a spec.                                                                                             |
-| arbitrary `Command` / `Arg` builder code         | Non-goal    | Partial        | `usage-lib` is the dynamic spec interpreter; usage derive does not reproduce clap's builder API.                                                      |
-| `ArgMatches`, `FromArgMatches`, `CommandFactory` | Non-goal    | Not applicable | Typed structs are built directly from static tables.                                                                                                  |
-| `update_from` / `try_update_from`                | Unsupported | Not applicable | A parse currently constructs a new value.                                                                                                             |
+| clap                                             | usage       | clap → spec    | Notes                                                                                                                                               |
+| ------------------------------------------------ | ----------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Parser`                                         | Supported   | Supported      | `#[derive(usage::Cli)]`                                                                                                                             |
+| `Args`                                           | Supported   | Supported      | `#[derive(usage::Args)]`, including `flatten`                                                                                                       |
+| `Subcommand`                                     | Supported   | Supported      | Nested and boxed variants are supported.                                                                                                            |
+| `ValueEnum`                                      | Supported   | Supported      | Names, per-value help, hidden values, visible and hidden aliases, cfg-gated variants, and case-insensitive matching are carried in static metadata. |
+| `#[arg(skip)]`                                   | Supported   | Not applicable | `#[usage(skip)]`; skipped fields do not belong in a spec.                                                                                           |
+| arbitrary `Command` / `Arg` builder code         | Non-goal    | Partial        | `usage-lib` is the dynamic spec interpreter; usage derive does not reproduce clap's builder API.                                                    |
+| `ArgMatches`, `FromArgMatches`, `CommandFactory` | Non-goal    | Not applicable | Typed structs are built directly from static tables.                                                                                                |
+| `update_from` / `try_update_from`                | Unsupported | Not applicable | A parse currently constructs a new value.                                                                                                           |
 
 ## Arguments and values
 

--- a/docs/rust/subcommands.md
+++ b/docs/rust/subcommands.md
@@ -152,9 +152,12 @@ For a flag or arg whose values are a fixed set of words, derive `ValueEnum` inst
 ```rust
 #[derive(usage::ValueEnum)]
 enum Shell {
+    /// Bourne Again shell
+    #[value(visible_alias = "b")]
     Bash,
+    #[value(alias = "shell-z", hide = true)]
     Zsh,
-    #[usage(name = "pwsh")]
+    #[value(name = "pwsh", help = "PowerShell")]
     PowerShell,
 }
 
@@ -166,9 +169,14 @@ struct Completion {
 }
 ```
 
-Variant names kebab-case into the accepted words. The derive also implements `FromStr`, whose
-error lists the valid words. One limitation: a single variant cannot be `cfg`-ed out (the word
-list is a `const`) — put the `cfg` on the whole enum.
+Variant names kebab-case into the accepted words. A doc comment supplies per-value help;
+`help` overrides it, `hide` keeps a value accepted without advertising it, `alias` adds a
+hidden spelling, and `visible_alias` advertises the alternate spelling. Plural alias attributes
+accept lists. `#[usage(ignore_case)]` applies to the whole enum, and `cfg`-gated variants remain
+gated in every generated metadata table.
+
+The type still implements its own `FromStr`: `ValueEnum` owns the portable CLI metadata and
+does not replace domain parsing.
 
 ## Mounts and restart tokens
 

--- a/lib/src/spec/choices.rs
+++ b/lib/src/spec/choices.rs
@@ -200,13 +200,14 @@ impl SpecChoices {
     }
 
     pub(crate) fn values_with_env(&self, env: Option<&HashMap<String, String>>) -> Vec<String> {
-        let mut values = self.visible_declared();
+        let values = self.visible_declared();
 
         #[cfg(not(feature = "unstable_choices_env"))]
         let _ = env;
 
         #[cfg(feature = "unstable_choices_env")]
-        {
+        let values = {
+            let mut values = values;
             if let Some(env_key) = self.env() {
                 let env_value = if let Some(env_map) = env {
                     env_map.get(env_key).cloned()
@@ -226,7 +227,8 @@ impl SpecChoices {
                     }
                 }
             }
-        }
+            values
+        };
 
         values
     }

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -475,7 +475,13 @@ fn emitted_specs_preserve_value_enum_aliases_and_case_policy() {
     assert!(kdl.contains("alias \"z-shell\" hide=#true"), "{kdl}");
     assert!(kdl.contains("alias \"zsh-shell\" hide=#true"), "{kdl}");
     assert!(kdl.contains("alias \"bourne-again\" hide=#true"), "{kdl}");
+    #[cfg(not(windows))]
     assert_eq!(<Shell as usage::spec::ValueEnum>::CHOICES, &["bash", "b"]);
+    #[cfg(windows)]
+    assert_eq!(
+        <Shell as usage::spec::ValueEnum>::CHOICES,
+        &["bash", "b", "power-shell"]
+    );
     #[cfg(not(windows))]
     assert!(!kdl.contains("power-shell"), "{kdl}");
 }

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -59,9 +59,17 @@ struct InlineEx {
 #[derive(ValueEnum)]
 #[usage(ignore_case)]
 enum Shell {
-    #[value(aliases(["bourne-again", "bash-shell"]))]
+    #[value(
+        aliases(["bourne-again", "bash-shell"]),
+        visible_alias = "b",
+        help = "Bourne Again shell"
+    )]
     Bash,
-    #[value(aliases = ["shell-z", "z-shell", "zsh-shell"])]
+    /// Z shell.
+    #[value(
+        aliases = ["shell-z", "z-shell", "zsh-shell"],
+        hide = true
+    )]
     Zsh,
     #[cfg(windows)]
     PowerShell,
@@ -453,10 +461,21 @@ fn emitted_specs_preserve_value_enum_aliases_and_case_policy() {
 
     let kdl = ChoiceEx::to_kdl();
     assert!(kdl.contains("choices ignore_case=#true"), "{kdl}");
+    assert!(
+        kdl.contains("choice \"bash\" help=\"Bourne Again shell\""),
+        "{kdl}"
+    );
+    assert!(kdl.contains("alias \"b\"\n"), "{kdl}");
+    assert!(!kdl.contains("alias \"b\" hide=#true"), "{kdl}");
+    assert!(
+        kdl.contains("choice \"zsh\" help=\"Z shell.\" hide=#true"),
+        "{kdl}"
+    );
     assert!(kdl.contains("alias \"shell-z\" hide=#true"), "{kdl}");
     assert!(kdl.contains("alias \"z-shell\" hide=#true"), "{kdl}");
     assert!(kdl.contains("alias \"zsh-shell\" hide=#true"), "{kdl}");
     assert!(kdl.contains("alias \"bourne-again\" hide=#true"), "{kdl}");
+    assert_eq!(<Shell as usage::spec::ValueEnum>::CHOICES, &["bash", "b"]);
     #[cfg(not(windows))]
     assert!(!kdl.contains("power-shell"), "{kdl}");
 }


### PR DESCRIPTION
Completes the Rust side of the `PossibleValue` compatibility model.

- carry per-value help, hidden canonical values, and visible/hidden aliases in static metadata
- keep hidden values parseable while filtering help and completion candidates
- attach value descriptions to runtime completion candidates
- emit rich choices losslessly to KDL, including mixed shorthand/detail sets
- update the compatibility matrix, Rust guide, and PLAN

Validation:
- `cargo test -p usage-argv -p usage-derive -p usage-rs --all-features`
- `cargo test -p usage-conformance --all-features`
- `cargo clippy --all --all-features --all-targets -- -D warnings`

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes derive codegen, spec emission, and completion behavior for enumerated values; broad surface area but no auth or data-path risk, with tests covering emission and completion.
> 
> **Overview**
> Finishes the Rust side of the **PossibleValue** model: per-value help, hidden canonical values, and visible vs hidden aliases now live in static metadata and round-trip through KDL.
> 
> **`ValueEnum`** gains `DETAILS` (and related tables): doc comments or `help`, `hide`, `alias` vs `visible_alias`, with `CHOICES` limited to advertised words while hidden spellings stay parseable via `ACCEPTED_CHOICES`. The derive maps clap-style `#[value(...)]` attributes into that model.
> 
> **Cold metadata** adds `ChoiceMeta` / `ChoiceAliasMeta` and `choice_details` on flag and arg meta; conformance and derive codegen wire spec choice details into those tables. **KDL emission** writes structured `choices { choice ... }` blocks (help, hide, nested aliases) instead of flat lists when detail is present.
> 
> **Completions** attach per-choice descriptions from `choice_details`, and positions that only have hidden accepted values are treated as choice positions (no erroneous file completion).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36b1e060039ba6476ec57e00f57f26d1704aa73a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->