### PR TITLE
feat(complete): support command value hints

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -638,10 +638,13 @@ feature list is not an exhaustive audit.
       advertised; usage spells those `alias_hidden` and `alias`. The fnox rewrite
       initially made `completion`'s hidden aliases and `exec run` visible because
       a mechanical rename erased that distinction.
-- [ ] **Command-with-arguments completion hints.** fnox uses
-      `ValueHint::CommandWithArguments` for forwarded argv. usage accepts only
-      file, path and directory hints today. Add the command/argv cases or record
-      them as an explicit completion non-goal before claiming clap coverage.
+- [x] **Command-with-arguments completion hints.** `ExecutablePath`,
+      `CommandName`, `CommandString`, and `CommandWithArguments` lower to
+      shell-native completion types. A forwarded argv vector offers commands for
+      its first value and ordinary argument paths after it; the derive requires
+      the same positional `Vec` plus `double_dash = "automatic"` shape that makes
+      flag-looking child arguments parse as values. Rust and Go runtime completion,
+      generated shell scripts, KDL, and the reference CLI share the vocabulary.
 - [x] **Version omission and dynamic version policy.** A literal `version`
       remains compile-time metadata, while `version = expression` evaluates a
       computed runtime string for hk-style build information. Cold metadata

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -42,6 +42,11 @@ pub struct Position<'t> {
     pub awaiting_value: Option<&'t Flag<'t>>,
     /// The positional a word here would fill, if any are left.
     pub next_arg: Option<&'t Arg<'t>>,
+    /// Values already bound to [`next_arg`](Self::next_arg).
+    ///
+    /// Non-zero only for a variadic positional that is still collecting. Completion hints use
+    /// this to distinguish the command word from the arguments in a forwarded argv vector.
+    pub next_arg_values: u32,
     /// Whether a `--` has been typed.
     ///
     /// Narrower than `flags_possible`, which is also false past an `automatic` argument. An
@@ -77,9 +82,19 @@ pub fn walk<'t>(root: &'t Command<'t>, words: &[String]) -> Position<'t> {
     let argv: Vec<&std::ffi::OsStr> = words.iter().map(std::ffi::OsStr::new).collect();
     let mut parser = Parser::new(root, &argv);
     let mut awaiting_value = None;
+    let mut last_arg = None;
+    let mut last_arg_values = 0u32;
 
     while let Some(event) = parser.next_event() {
         match event {
+            Ok(crate::Event::Arg { arg, .. }) => {
+                if last_arg.is_some_and(|prior| core::ptr::eq(prior, arg)) {
+                    last_arg_values = last_arg_values.saturating_add(1);
+                } else {
+                    last_arg = Some(arg);
+                    last_arg_values = 1;
+                }
+            }
             Ok(_) => {}
             // The one error that says something about the cursor rather than about the line:
             // the last word was a flag that takes a value, so the cursor is standing in it.
@@ -99,6 +114,7 @@ pub fn walk<'t>(root: &'t Command<'t>, words: &[String]) -> Position<'t> {
                     flags_possible: false,
                     awaiting_value: None,
                     next_arg: None,
+                    next_arg_values: 0,
                     path: Vec::new(),
                     separator_seen: false,
                     command_start: 0,
@@ -110,6 +126,7 @@ pub fn walk<'t>(root: &'t Command<'t>, words: &[String]) -> Position<'t> {
         }
     }
 
+    let next_arg = parser.pending_arg();
     Position {
         path: parser.command_path(),
         cmd: parser.command(),
@@ -117,7 +134,10 @@ pub fn walk<'t>(root: &'t Command<'t>, words: &[String]) -> Position<'t> {
         // A variadic flag still claiming words is standing in the same place a flag waiting
         // for its first value is: the next word belongs to it, not to the positional after it.
         awaiting_value: awaiting_value.or_else(|| parser.collecting()),
-        next_arg: parser.pending_arg(),
+        next_arg,
+        next_arg_values: next_arg
+            .filter(|arg| last_arg.is_some_and(|prior| core::ptr::eq(prior, *arg)))
+            .map_or(0, |_| last_arg_values),
         separator_seen: parser.double_dash_seen(),
         command_start: parser.command_start(),
         help_topic: false,
@@ -259,6 +279,8 @@ pub enum Files {
     Any,
     /// Directories only.
     Dirs,
+    /// Executable commands, including names found through the shell's command table.
+    Executables,
 }
 
 /// Everything a shell needs to answer one Tab.
@@ -466,6 +488,8 @@ impl Request {
 pub const FILES_MARKER: &str = "\u{1}files";
 /// See [`FILES_MARKER`]. Directories only.
 pub const DIRS_MARKER: &str = "\u{1}dirs";
+/// See [`FILES_MARKER`]. Commands and executable paths only.
+pub const EXECUTABLES_MARKER: &str = "\u{1}commands";
 
 /// Write an answer the way `shell` reads it.
 ///
@@ -515,6 +539,10 @@ pub fn render(answer: &Completions<'_>, shell: Shell) -> String {
         }
         Some(Files::Dirs) => {
             out.push_str(DIRS_MARKER);
+            out.push('\n');
+        }
+        Some(Files::Executables) => {
+            out.push_str(EXECUTABLES_MARKER);
             out.push('\n');
         }
         None => {}
@@ -580,9 +608,22 @@ fn files_for(name: &str) -> Option<Files> {
         Some(Files::Any)
     } else if matches("dir") || matches("directory") {
         Some(Files::Dirs)
+    } else if matches("executable") || matches("command") {
+        Some(Files::Executables)
     } else {
         None
     }
+}
+
+fn declared_files(type_: &str, position: &Position<'_>) -> Option<Files> {
+    if type_.eq_ignore_ascii_case("command_args") {
+        return Some(if position.next_arg_values == 0 {
+            Files::Executables
+        } else {
+            Files::Any
+        });
+    }
+    files_for(type_)
 }
 
 fn declared_files_at_cursor(
@@ -624,7 +665,7 @@ fn declared_files_at_cursor(
         (None, None)
     };
     complete_type
-        .and_then(files_for)
+        .and_then(|type_| declared_files(type_, position))
         .or_else(|| name.and_then(files_for))
 }
 
@@ -679,7 +720,7 @@ pub fn complete<'a>(spec: &'a Spec<'a>, split: &Split) -> Completions<'a> {
         (None, false, None)
     };
     let asked_for = complete_type
-        .and_then(files_for)
+        .and_then(|type_| declared_files(type_, &position))
         .or_else(|| named.and_then(files_for));
 
     // An argument that requires a separator is not fillable yet, so nothing else belongs here —

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -279,8 +279,10 @@ pub enum Files {
     Any,
     /// Directories only.
     Dirs,
-    /// Executable commands, including names found through the shell's command table.
-    Executables,
+    /// Executable files at a filesystem path.
+    ExecutablePaths,
+    /// Command names, including entries from the shell's command table and `PATH`.
+    Commands,
 }
 
 /// Everything a shell needs to answer one Tab.
@@ -488,8 +490,10 @@ impl Request {
 pub const FILES_MARKER: &str = "\u{1}files";
 /// See [`FILES_MARKER`]. Directories only.
 pub const DIRS_MARKER: &str = "\u{1}dirs";
-/// See [`FILES_MARKER`]. Commands and executable paths only.
-pub const EXECUTABLES_MARKER: &str = "\u{1}commands";
+/// See [`FILES_MARKER`]. Executable filesystem paths only.
+pub const EXECUTABLE_PATHS_MARKER: &str = "\u{1}executables";
+/// See [`FILES_MARKER`]. Command names from the shell and `PATH` only.
+pub const COMMANDS_MARKER: &str = "\u{1}commands";
 
 /// Write an answer the way `shell` reads it.
 ///
@@ -541,8 +545,12 @@ pub fn render(answer: &Completions<'_>, shell: Shell) -> String {
             out.push_str(DIRS_MARKER);
             out.push('\n');
         }
-        Some(Files::Executables) => {
-            out.push_str(EXECUTABLES_MARKER);
+        Some(Files::ExecutablePaths) => {
+            out.push_str(EXECUTABLE_PATHS_MARKER);
+            out.push('\n');
+        }
+        Some(Files::Commands) => {
+            out.push_str(COMMANDS_MARKER);
             out.push('\n');
         }
         None => {}
@@ -608,8 +616,10 @@ fn files_for(name: &str) -> Option<Files> {
         Some(Files::Any)
     } else if matches("dir") || matches("directory") {
         Some(Files::Dirs)
-    } else if matches("executable") || matches("command") {
-        Some(Files::Executables)
+    } else if matches("executable") {
+        Some(Files::ExecutablePaths)
+    } else if matches("command") {
+        Some(Files::Commands)
     } else {
         None
     }
@@ -618,7 +628,7 @@ fn files_for(name: &str) -> Option<Files> {
 fn declared_files(type_: &str, position: &Position<'_>) -> Option<Files> {
     if type_.eq_ignore_ascii_case("command_args") {
         return Some(if position.next_arg_values == 0 {
-            Files::Executables
+            Files::Commands
         } else {
             Files::Any
         });
@@ -2742,6 +2752,12 @@ mod tests {
         assert_eq!(offered("mise edit "), ["mise.local.toml", "mise.toml"]);
         // And a flag's value is named by its placeholder, not by the flag.
         assert_eq!(answer("mise edit --into ").files, Some(Files::Dirs));
+    }
+
+    #[test]
+    fn executable_paths_and_command_names_are_distinct_shell_requests() {
+        assert_eq!(files_for("executable"), Some(Files::ExecutablePaths));
+        assert_eq!(files_for("command"), Some(Files::Commands));
     }
 
     #[test]

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -83,7 +83,7 @@
 
 use std::ffi::{OsStr, OsString};
 
-/// A value's filesystem completion class for `#[usage(value_hint = ...)]`.
+/// A value's shell-native completion class for `#[usage(value_hint = ...)]`.
 ///
 /// This lives in the runtime crate so a declaration never needs clap merely to describe what
 /// kind of path a shell should offer. It is metadata only and adds no work to a successful
@@ -96,6 +96,14 @@ pub enum ValueHint {
     AnyPath,
     /// A path to a directory.
     DirPath,
+    /// A path to an executable file.
+    ExecutablePath,
+    /// A command name, resolved through the shell's command table and `PATH`.
+    CommandName,
+    /// One string containing a command and any arguments.
+    CommandString,
+    /// A trailing argv vector: complete the first value as a command, then its arguments.
+    CommandWithArguments,
 }
 
 #[cfg(feature = "complete")]

--- a/argv/src/script.rs
+++ b/argv/src/script.rs
@@ -277,8 +277,9 @@ def --env __usage_complete_{ident} [spans: list<string>] {{
     if $out.exit_code != 0 {{ return null }}
     let lines = ($out.stdout | lines | where {{|l| $l != "" }})
     let marker = "\u{{1}}"
-    let wants_files = ($lines | any {{|l| $l == $marker + "files" or $l == $marker + "dirs" or $l == $marker + "commands" }})
-    let candidates = (
+    let wants_files = ($lines | any {{|l| $l == $marker + "files" or $l == $marker + "dirs" }})
+    let wants_commands = ($lines | any {{|l| $l == $marker + "commands" }})
+    let declared = (
         $lines
         | where {{|l| not ($l | str starts-with $marker) }}
         | each {{|l|
@@ -289,6 +290,15 @@ def --env __usage_complete_{ident} [spans: list<string>] {{
             }}
         }}
     )
+    # Ask nushell for command names from the current word alone. Giving it the
+    # original line would complete this CLI's next argument and recurse through
+    # the external completer instead of completing a command to forward.
+    let commands = (if $wants_commands {{
+        ($spans | last) | commandline complete --detailed
+    }} else {{
+        []
+    }})
+    let candidates = ($declared | append $commands)
     # `null` is how a nushell completer says "you do this one", and what it does is complete
     # paths. So an answer that is only the marker returns null rather than nothing, which would
     # mean "there is nothing here".
@@ -492,6 +502,17 @@ mod tests {
         assert!(
             out.contains(r"command 'my-tool' __complete_word__"),
             "{out}"
+        );
+    }
+
+    #[test]
+    fn nu_asks_nushell_for_command_candidates() {
+        let out = script("ex", Shell::Nu);
+        assert!(out.contains("commandline complete --detailed"), "{out}");
+        assert!(out.contains("let wants_commands"), "{out}");
+        assert!(
+            !out.contains("or $l == $marker + \"commands\" }})\n    let declared"),
+            "a command marker must not trigger path fallback: {out}"
         );
     }
 }

--- a/argv/src/script.rs
+++ b/argv/src/script.rs
@@ -392,7 +392,7 @@ Register-ArgumentCompleter -Native -CommandName '{bin}' -ScriptBlock {{
                 )
             )
         }}
-    }} else if ($files) {{
+    }} elseif ($files) {{
         # PowerShell's own, so that `~`, drive-relative paths and provider paths behave as they
         # do everywhere else in the shell.
         foreach ($path in [System.Management.Automation.CompletionCompleters]::CompleteFilename($wordToComplete)) {{
@@ -491,6 +491,8 @@ mod tests {
             powershell.contains("-CommandType Application, ExternalScript"),
             "{powershell}"
         );
+        assert!(powershell.contains("} elseif ($files) {"), "{powershell}");
+        assert!(!powershell.contains("} else if ($files) {"), "{powershell}");
     }
 
     #[test]

--- a/argv/src/script.rs
+++ b/argv/src/script.rs
@@ -307,11 +307,14 @@ def --env __usage_complete_{ident} [spans: list<string>] {{
             }}
         }}
     )
-    # Ask nushell for command names from the current word alone. Giving it the
-    # original line would complete this CLI's next argument and recurse through
-    # the external completer instead of completing a command to forward.
+    # which with no names returns nushell's commands and the executables on PATH.
+    # Unlike commandline complete, it cannot reinterpret an exact command name as
+    # the start of that command's arguments or re-enter this external completer.
     let commands = (if $wants_commands {{
-        ($spans | last) | commandline complete --detailed
+        let prefix = ($spans | last)
+        which
+        | where {{|row| $row.command | str starts-with $prefix }}
+        | each {{|row| {{ value: $row.command, description: $row.path }} }}
     }} else {{
         []
     }})
@@ -555,7 +558,8 @@ mod tests {
     #[test]
     fn nu_asks_nushell_for_command_candidates() {
         let out = script("ex", Shell::Nu);
-        assert!(out.contains("commandline complete --detailed"), "{out}");
+        assert!(out.contains("which"), "{out}");
+        assert!(!out.contains("| commandline complete"), "{out}");
         assert!(out.contains("let wants_commands"), "{out}");
         assert!(
             !out.contains("or $l == $marker + \"commands\" }})\n    let declared"),

--- a/argv/src/script.rs
+++ b/argv/src/script.rs
@@ -101,6 +101,7 @@ _usage_complete_{bin}() {{
         case "$__usage_line" in
             $'\001files') __usage_files=any ;;
             $'\001dirs') __usage_files=dirs ;;
+            $'\001executables') __usage_files=executables ;;
             $'\001commands') __usage_files=commands ;;
             '') ;;
             *) COMPREPLY+=("$__usage_line") ;;
@@ -117,6 +118,10 @@ _usage_complete_{bin}() {{
         if [[ $__usage_files == commands ]]; then
             while IFS= read -r __usage_path; do __usage_paths+=("$__usage_path"); done \
                 < <(compgen -c -- "$__usage_cur")
+        elif [[ $__usage_files == executables ]]; then
+            while IFS= read -r __usage_path; do
+                [[ -d "$__usage_path" || -x "$__usage_path" ]] && __usage_paths+=("$__usage_path")
+            done < <(compgen -f -- "$__usage_cur")
         elif [[ $__usage_files == dirs ]]; then
             while IFS= read -r __usage_path; do __usage_paths+=("$__usage_path"); done \
                 < <(compgen -d -- "$__usage_cur")
@@ -160,6 +165,7 @@ _{bin}() {{
         case "$__usage_line" in
             $'\001files') __usage_files=any; continue ;;
             $'\001dirs') __usage_files=dirs; continue ;;
+            $'\001executables') __usage_files=executables; continue ;;
             $'\001commands') __usage_files=commands; continue ;;
             '') continue ;;
         esac
@@ -197,6 +203,7 @@ _{bin}() {{
     case "$__usage_files" in
         any) _files && __usage_ret=0 ;;
         dirs) _files -/ && __usage_ret=0 ;;
+        executables) _files -g '*(*)' && __usage_ret=0 ;;
         commands) _command_names && __usage_ret=0 ;;
     esac
     return $__usage_ret
@@ -228,6 +235,7 @@ function __usage_complete_{bin}
     # computed values, and a control byte is not something to spell twice.
     set -l marker_any (printf '\x01files')
     set -l marker_dirs (printf '\x01dirs')
+    set -l marker_executables (printf '\x01executables')
     set -l marker_commands (printf '\x01commands')
     set -l files ""
     for entry in $out
@@ -235,6 +243,8 @@ function __usage_complete_{bin}
             set files any
         else if test "$entry" = "$marker_dirs"
             set files dirs
+        else if test "$entry" = "$marker_executables"
+            set files executables
         else if test "$entry" = "$marker_commands"
             set files commands
         else if test -n "$entry"
@@ -250,6 +260,13 @@ function __usage_complete_{bin}
             __fish_complete_path (commandline -ct)
         case dirs
             __fish_complete_directories (commandline -ct)
+        case executables
+            for candidate in (__fish_complete_path (commandline -ct))
+                set -l value (string split -m 1 (printf '\t') -- $candidate)[1]
+                if test -d "$value"; or test -x "$value"
+                    printf '%s\n' $candidate
+                end
+            end
         case commands
             __fish_complete_command (commandline -ct)
     end
@@ -277,7 +294,7 @@ def --env __usage_complete_{ident} [spans: list<string>] {{
     if $out.exit_code != 0 {{ return null }}
     let lines = ($out.stdout | lines | where {{|l| $l != "" }})
     let marker = "\u{{1}}"
-    let wants_files = ($lines | any {{|l| $l == $marker + "files" or $l == $marker + "dirs" }})
+    let wants_files = ($lines | any {{|l| $l == $marker + "files" or $l == $marker + "dirs" or $l == $marker + "executables" }})
     let wants_commands = ($lines | any {{|l| $l == $marker + "commands" }})
     let declared = (
         $lines
@@ -355,6 +372,7 @@ Register-ArgumentCompleter -Native -CommandName '{bin}' -ScriptBlock {{
         if ([string]::IsNullOrEmpty($entry)) {{ continue }}
         if ($entry -eq ($marker + 'files')) {{ $files = 'any'; continue }}
         if ($entry -eq ($marker + 'dirs')) {{ $files = 'dirs'; continue }}
+        if ($entry -eq ($marker + 'executables')) {{ $files = 'executables'; continue }}
         if ($entry -eq ($marker + 'commands')) {{ $files = 'commands'; continue }}
         $parts = $entry -split "`t", 2
         $value = $parts[0]
@@ -378,11 +396,17 @@ Register-ArgumentCompleter -Native -CommandName '{bin}' -ScriptBlock {{
         # PowerShell's own, so that `~`, drive-relative paths and provider paths behave as they
         # do everywhere else in the shell.
         foreach ($path in [System.Management.Automation.CompletionCompleters]::CompleteFilename($wordToComplete)) {{
-            # By what PowerShell said it is, not by testing the path again: `CompletionText` is
-            # the text to *insert* and may already carry quoting, so a directory whose name needs
-            # quotes would fail a `Test-Path` and vanish from a dirs-only completion.
+            # Trust PowerShell's result type for directories because CompletionText may already
+            # carry quoting. Executable leaves are checked as commands after stripping only the
+            # outer quote characters PowerShell added.
             if ($files -eq 'dirs' -and $path.ResultType -ne 'ProviderContainer') {{
                 continue
+            }}
+            if ($files -eq 'executables' -and $path.ResultType -ne 'ProviderContainer') {{
+                $candidatePath = $path.CompletionText.Trim([char[]]@([char]39, [char]34))
+                if (-not (Get-Command -Name $candidatePath -CommandType Application, ExternalScript -ErrorAction SilentlyContinue)) {{
+                    continue
+                }}
             }}
             $results.Add($path)
         }}
@@ -446,6 +470,27 @@ mod tests {
             "fish's echo eats a leading -n: {out}"
         );
         assert!(out.contains(r"printf '%s\n' $entry"), "{out}");
+    }
+
+    #[test]
+    fn executable_path_markers_filter_non_executable_files() {
+        let bash = script("mise", Shell::Bash);
+        assert!(
+            bash.contains(r#"[[ -d "$__usage_path" || -x "$__usage_path" ]]"#),
+            "{bash}"
+        );
+
+        let fish = script("mise", Shell::Fish);
+        assert!(
+            fish.contains(r#"test -d "$value"; or test -x "$value""#),
+            "{fish}"
+        );
+
+        let powershell = script("mise", Shell::PowerShell);
+        assert!(
+            powershell.contains("-CommandType Application, ExternalScript"),
+            "{powershell}"
+        );
     }
 
     #[test]

--- a/argv/src/script.rs
+++ b/argv/src/script.rs
@@ -312,13 +312,20 @@ def --env __usage_complete_{ident} [spans: list<string>] {{
     # the start of that command's arguments or re-enter this external completer.
     let commands = (if $wants_commands {{
         let prefix = ($spans | last)
+        let insensitive = $nu.os-info.name == "windows"
+        let match_prefix = if $insensitive {{ $prefix | str downcase }} else {{ $prefix }}
         which
-        | where {{|row| $row.command | str starts-with $prefix }}
+        | where {{|row|
+            let candidate = if $insensitive {{ $row.command | str downcase }} else {{ $row.command }}
+            $candidate | str starts-with $match_prefix
+        }}
         | each {{|row| {{ value: $row.command, description: $row.path }} }}
     }} else {{
         []
     }})
     let candidates = ($declared | append $commands)
+    let command_is_path = (($spans | last) | str contains "/") or (($spans | last) | str contains "\\")
+    let wants_path_fallback = $wants_files or ($wants_commands and $command_is_path)
     # `null` is how a nushell completer says "you do this one", and what it does is complete
     # paths. So an answer that is only the marker returns null rather than nothing, which would
     # mean "there is nothing here".
@@ -328,7 +335,7 @@ def --env __usage_complete_{ident} [spans: list<string>] {{
     # "and files too". The candidates win, because they are what this CLI knows and a path is
     # something the user can finish typing. Every other shell here appends both; this is
     # nushell's completer interface rather than a decision of this design.
-    if ($candidates | is-empty) and $wants_files {{ null }} else {{ $candidates }}
+    if ($candidates | is-empty) and $wants_path_fallback {{ null }} else {{ $candidates }}
 }}
 
 # Slot this into the external completer nushell already has, if any, rather than replacing it:
@@ -561,6 +568,8 @@ mod tests {
         assert!(out.contains("which"), "{out}");
         assert!(!out.contains("| commandline complete"), "{out}");
         assert!(out.contains("let wants_commands"), "{out}");
+        assert!(out.contains("let wants_path_fallback"), "{out}");
+        assert!(out.contains("$nu.os-info.name == \"windows\""), "{out}");
         assert!(
             !out.contains("or $l == $marker + \"commands\" }})\n    let declared"),
             "a command marker must not trigger path fallback: {out}"

--- a/argv/src/script.rs
+++ b/argv/src/script.rs
@@ -101,6 +101,7 @@ _usage_complete_{bin}() {{
         case "$__usage_line" in
             $'\001files') __usage_files=any ;;
             $'\001dirs') __usage_files=dirs ;;
+            $'\001commands') __usage_files=commands ;;
             '') ;;
             *) COMPREPLY+=("$__usage_line") ;;
         esac
@@ -110,10 +111,13 @@ _usage_complete_{bin}() {{
         # Set here rather than on `complete`, because whether this position takes a path is not
         # known until the answer comes back. It is what makes bash append a `/` to a directory
         # and stop escaping what it should not.
-        compopt -o filenames 2>/dev/null
+        [[ $__usage_files == commands ]] || compopt -o filenames 2>/dev/null
         local __usage_cur="${{COMP_WORDS[COMP_CWORD]}}" __usage_path
         local -a __usage_paths=()
-        if [[ $__usage_files == dirs ]]; then
+        if [[ $__usage_files == commands ]]; then
+            while IFS= read -r __usage_path; do __usage_paths+=("$__usage_path"); done \
+                < <(compgen -c -- "$__usage_cur")
+        elif [[ $__usage_files == dirs ]]; then
             while IFS= read -r __usage_path; do __usage_paths+=("$__usage_path"); done \
                 < <(compgen -d -- "$__usage_cur")
         else
@@ -156,6 +160,7 @@ _{bin}() {{
         case "$__usage_line" in
             $'\001files') __usage_files=any; continue ;;
             $'\001dirs') __usage_files=dirs; continue ;;
+            $'\001commands') __usage_files=commands; continue ;;
             '') continue ;;
         esac
         local -a parts=("${{(@ps:\t:)__usage_line}}")
@@ -192,6 +197,7 @@ _{bin}() {{
     case "$__usage_files" in
         any) _files && __usage_ret=0 ;;
         dirs) _files -/ && __usage_ret=0 ;;
+        commands) _command_names && __usage_ret=0 ;;
     esac
     return $__usage_ret
 }}
@@ -222,12 +228,15 @@ function __usage_complete_{bin}
     # computed values, and a control byte is not something to spell twice.
     set -l marker_any (printf '\x01files')
     set -l marker_dirs (printf '\x01dirs')
+    set -l marker_commands (printf '\x01commands')
     set -l files ""
     for entry in $out
         if test "$entry" = "$marker_any"
             set files any
         else if test "$entry" = "$marker_dirs"
             set files dirs
+        else if test "$entry" = "$marker_commands"
+            set files commands
         else if test -n "$entry"
             # printf, not echo: fish's echo reads a leading -n, -e, -s or -E as its own option,
             # so a CLI with a `-n` would have that candidate swallowed on the way to the prompt.
@@ -241,6 +250,8 @@ function __usage_complete_{bin}
             __fish_complete_path (commandline -ct)
         case dirs
             __fish_complete_directories (commandline -ct)
+        case commands
+            __fish_complete_command (commandline -ct)
     end
 end
 
@@ -266,7 +277,7 @@ def --env __usage_complete_{ident} [spans: list<string>] {{
     if $out.exit_code != 0 {{ return null }}
     let lines = ($out.stdout | lines | where {{|l| $l != "" }})
     let marker = "\u{{1}}"
-    let wants_files = ($lines | any {{|l| $l == $marker + "files" or $l == $marker + "dirs" }})
+    let wants_files = ($lines | any {{|l| $l == $marker + "files" or $l == $marker + "dirs" or $l == $marker + "commands" }})
     let candidates = (
         $lines
         | where {{|l| not ($l | str starts-with $marker) }}
@@ -334,6 +345,7 @@ Register-ArgumentCompleter -Native -CommandName '{bin}' -ScriptBlock {{
         if ([string]::IsNullOrEmpty($entry)) {{ continue }}
         if ($entry -eq ($marker + 'files')) {{ $files = 'any'; continue }}
         if ($entry -eq ($marker + 'dirs')) {{ $files = 'dirs'; continue }}
+        if ($entry -eq ($marker + 'commands')) {{ $files = 'commands'; continue }}
         $parts = $entry -split "`t", 2
         $value = $parts[0]
         $description = if ($parts.Count -gt 1 -and $parts[1]) {{ $parts[1] }} else {{ $value }}
@@ -344,7 +356,15 @@ Register-ArgumentCompleter -Native -CommandName '{bin}' -ScriptBlock {{
         )
     }}
 
-    if ($files) {{
+    if ($files -eq 'commands') {{
+        foreach ($command in Get-Command -Name ($wordToComplete + '*') -CommandType Application, ExternalScript -ErrorAction SilentlyContinue) {{
+            $results.Add(
+                [System.Management.Automation.CompletionResult]::new(
+                    $command.Name, $command.Name, 'Command', $command.Source
+                )
+            )
+        }}
+    }} else if ($files) {{
         # PowerShell's own, so that `~`, drive-relative paths and provider paths behave as they
         # do everywhere else in the shell.
         foreach ($path in [System.Management.Automation.CompletionCompleters]::CompleteFilename($wordToComplete)) {{

--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -360,7 +360,17 @@ impl CompleteWord {
         match type_ {
             "config_keys" => return (self.complete_config_keys(cx.spec, ctoken), true),
             "config_values" => return self.complete_config_values(cx, ctoken),
-            "executable" | "command" => return (self.complete_commands(ctoken), true),
+            "executable" => {
+                let cwd = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+                return (
+                    self.complete_path(&cwd, ctoken, |path| path.is_dir() || is_executable(path))
+                        .into_iter()
+                        .map(|value| (value, String::new()))
+                        .collect(),
+                    true,
+                );
+            }
+            "command" => return (self.complete_commands(ctoken), true),
             "command_args" => {
                 let command_was_bound = cx.parsed.next_arg.as_ref().is_some_and(|next| {
                     // `parse_partial` records the cursor with a fresh `Arc` around a
@@ -690,7 +700,9 @@ impl CompleteWord {
                 for entry in std::fs::read_dir(dir).ok().into_iter().flatten().flatten() {
                     let path = entry.path();
                     let name = entry.file_name().to_string_lossy().into_owned();
-                    if name.starts_with(ctoken) && is_executable(&path) {
+                    if command_name_starts_with(&name, ctoken, cfg!(windows))
+                        && is_executable(&path)
+                    {
                         found.insert(name);
                     }
                 }
@@ -700,6 +712,15 @@ impl CompleteWord {
             .into_iter()
             .map(|value| (value, String::new()))
             .collect()
+    }
+}
+
+fn command_name_starts_with(name: &str, prefix: &str, case_insensitive: bool) -> bool {
+    if case_insensitive {
+        name.get(..prefix.len())
+            .is_some_and(|start| start.eq_ignore_ascii_case(prefix))
+    } else {
+        name.starts_with(prefix)
     }
 }
 
@@ -797,4 +818,15 @@ fn zsh_shell_quote(s: &str) -> String {
     // Wrap in single quotes; close-open dance escapes any internal apostrophes.
     let escaped = s.replace('\'', "'\\''");
     format!("'{escaped}'")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::command_name_starts_with;
+
+    #[test]
+    fn windows_command_prefixes_ignore_ascii_case() {
+        assert!(command_name_starts_with("Cargo.EXE", "car", true));
+        assert!(!command_name_starts_with("Cargo.EXE", "car", false));
+    }
 }

--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::env;
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
@@ -360,6 +360,15 @@ impl CompleteWord {
         match type_ {
             "config_keys" => return (self.complete_config_keys(cx.spec, ctoken), true),
             "config_values" => return self.complete_config_values(cx, ctoken),
+            "executable" | "command" => return (self.complete_commands(ctoken), true),
+            "command_args" => {
+                let command_was_bound = cx.parsed.next_arg.as_ref().is_some_and(|next| {
+                    cx.parsed.args.keys().any(|bound| Arc::ptr_eq(bound, next))
+                });
+                if !command_was_bound {
+                    return (self.complete_commands(ctoken), true);
+                }
+            }
             _ => {}
         }
         let names = match (type_, env::current_dir()) {
@@ -657,6 +666,54 @@ impl CompleteWord {
             .sorted()
             .collect()
     }
+
+    fn complete_commands(&self, ctoken: &str) -> Vec<(String, String)> {
+        if ctoken.contains(std::path::MAIN_SEPARATOR) || (cfg!(windows) && ctoken.contains('/')) {
+            let cwd = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+            return self
+                .complete_path(&cwd, ctoken, |path| path.is_dir() || is_executable(path))
+                .into_iter()
+                .map(|value| (value, String::new()))
+                .collect();
+        }
+
+        let mut found = BTreeSet::new();
+        if let Some(path) = env::var_os("PATH") {
+            for dir in env::split_paths(&path) {
+                for entry in std::fs::read_dir(dir).ok().into_iter().flatten().flatten() {
+                    let path = entry.path();
+                    let name = entry.file_name().to_string_lossy().into_owned();
+                    if name.starts_with(ctoken) && is_executable(&path) {
+                        found.insert(name);
+                    }
+                }
+            }
+        }
+        found
+            .into_iter()
+            .map(|value| (value, String::new()))
+            .collect()
+    }
+}
+
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    path.metadata()
+        .is_ok_and(|meta| meta.is_file() && meta.permissions().mode() & 0o111 != 0)
+}
+
+#[cfg(windows)]
+fn is_executable(path: &Path) -> bool {
+    let extensions = env::var_os("PATHEXT").unwrap_or_else(|| ".COM;.EXE;.BAT;.CMD".into());
+    path.is_file()
+        && path.extension().is_some_and(|extension| {
+            let extension = format!(".{}", extension.to_string_lossy());
+            extensions
+                .to_string_lossy()
+                .split(';')
+                .any(|candidate| candidate.eq_ignore_ascii_case(&extension))
+        })
 }
 
 /// Wrap a completion value in single quotes if any character would otherwise

--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -363,7 +363,14 @@ impl CompleteWord {
             "executable" | "command" => return (self.complete_commands(ctoken), true),
             "command_args" => {
                 let command_was_bound = cx.parsed.next_arg.as_ref().is_some_and(|next| {
-                    cx.parsed.args.keys().any(|bound| Arc::ptr_eq(bound, next))
+                    // `parse_partial` records the cursor with a fresh `Arc` around a
+                    // cloned argument, so pointer identity cannot connect it to the
+                    // separately cloned map key. Argument names are the stable identity
+                    // within a command (and the one `SpecArg` equality uses).
+                    cx.parsed
+                        .args
+                        .keys()
+                        .any(|bound| bound.as_ref() == next.as_ref())
                 });
                 if !command_was_bound {
                     return (self.complete_commands(ctoken), true);

--- a/cli/tests/complete_word.rs
+++ b/cli/tests/complete_word.rs
@@ -658,6 +658,24 @@ fn complete_word_fallback_to_files() {
 }
 
 #[test]
+fn complete_word_command_args_starts_with_executables() {
+    let usage = cargo::cargo_bin!("usage");
+    let executable = usage.file_name().unwrap().to_string_lossy().into_owned();
+    let spec = r#"
+name "mycli"
+bin "mycli"
+arg "<COMMAND>..." double_dash="automatic"
+complete "command" type="command_args"
+"#;
+    Command::new(usage)
+        .args(["cw", "--shell", "fish", "--spec", spec, "--", "mycli", ""])
+        .env("PATH", usage.parent().unwrap())
+        .assert()
+        .success()
+        .stdout(contains(executable));
+}
+
+#[test]
 fn complete_word_subcommands_without_shell() {
     let mut cmd = cmd("basic.usage.kdl", None);
     cmd.args(["plugins", "install"]);

--- a/cli/tests/complete_word.rs
+++ b/cli/tests/complete_word.rs
@@ -676,6 +676,25 @@ complete "command" type="command_args"
 }
 
 #[test]
+fn complete_word_command_args_uses_paths_after_the_command() {
+    let usage = cargo::cargo_bin!("usage");
+    let spec = r#"
+name "mycli"
+bin "mycli"
+arg "<COMMAND>..." double_dash="automatic"
+complete "command" type="command_args"
+"#;
+    Command::new(usage)
+        .args([
+            "cw", "--shell", "fish", "--spec", spec, "--", "mycli", "usage", "Cargo",
+        ])
+        .env("PATH", usage.parent().unwrap())
+        .assert()
+        .success()
+        .stdout(contains("Cargo.toml"));
+}
+
+#[test]
 fn complete_word_subcommands_without_shell() {
     let mut cmd = cmd("basic.usage.kdl", None);
     cmd.args(["plugins", "install"]);

--- a/conformance/tests/completion.rs
+++ b/conformance/tests/completion.rs
@@ -103,7 +103,7 @@ fn ask_forward(line: &str) -> String {
 fn command_with_arguments_changes_native_completion_after_the_command_word() {
     assert_eq!(
         ask_forward("forward "),
-        format!("{}\n", usage_argv::complete::EXECUTABLES_MARKER)
+        format!("{}\n", usage_argv::complete::COMMANDS_MARKER)
     );
     assert_eq!(
         ask_forward("forward git "),

--- a/conformance/tests/completion.rs
+++ b/conformance/tests/completion.rs
@@ -78,6 +78,48 @@ fn ask_hinted(line: &str) -> String {
     Hinted::completion_request(&argv).expect("this is a completion request")
 }
 
+#[derive(Cli)]
+#[usage(bin = "forward", completion)]
+struct Forward {
+    /// Command followed by its arguments
+    #[usage(
+        arg,
+        name = "COMMAND",
+        double_dash = "automatic",
+        value_hint = usage_argv::ValueHint::CommandWithArguments
+    )]
+    command: Vec<OsString>,
+}
+
+fn ask_forward(line: &str) -> String {
+    let argv: Vec<OsString> = ["__complete_word__", "--shell", "bash", "--line", line]
+        .iter()
+        .map(OsString::from)
+        .collect();
+    Forward::completion_request(&argv).expect("this is a completion request")
+}
+
+#[test]
+fn command_with_arguments_changes_native_completion_after_the_command_word() {
+    assert_eq!(
+        ask_forward("forward "),
+        format!("{}\n", usage_argv::complete::EXECUTABLES_MARKER)
+    );
+    assert_eq!(
+        ask_forward("forward git "),
+        format!("{}\n", usage_argv::complete::FILES_MARKER)
+    );
+
+    let kdl = Forward::to_kdl();
+    assert!(
+        kdl.contains("complete \"command\" type=\"command_args\""),
+        "{kdl}"
+    );
+    let argv = [OsStr::new("git"), OsStr::new("-C"), OsStr::new("repo")];
+    let parsed = Forward::parse_from(&argv).expect("forwarded flags are values");
+    assert_eq!(parsed.command, argv);
+}
+
 #[test]
 fn usage_path_value_hints_reach_native_and_emitted_completions() {
     assert_eq!(

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -232,7 +232,7 @@
 //! | `double_dash = "…"` | how a positional relates to `--`: `optional` (the default), `required` (fillable only after one), `preserve` (the `--` is a value), `automatic` (filling it ends flag parsing, so a wrapper forwards) |
 //! | `complete = my_fn` | a function that answers for this value when a shell asks |
 //! | `value_enum` | the words come from the field's type, which derives [`ValueEnum`] |
-//! | `value_hint = usage::ValueHint::FilePath` | ask the shell for paths; `AnyPath` and `DirPath` are also supported |
+//! | `value_hint = usage::ValueHint::FilePath` | ask the shell for paths, executables, or forwarded command argv |
 //! | `arg` | force a field to be positional |
 //! | `overrides = "--other"` | a flag this one displaces, the last given winning |
 //! | `conflicts = "--other"` | a flag this one cannot be given with |

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -345,7 +345,7 @@ fn effect_value(meta: &Meta) -> syn::Result<proc_macro2::TokenStream> {
     )))
 }
 
-/// usage's path-oriented `ValueHint`s lowered into the completion types the spec has.
+/// usage's shell-native `ValueHint`s lowered into the completion types the spec has.
 fn value_hint(meta: &Meta) -> syn::Result<String> {
     let value = &meta.require_name_value()?.value;
     let Expr::Path(path) = value else {
@@ -364,11 +364,15 @@ fn value_hint(meta: &Meta) -> syn::Result<String> {
     match variant.ident.to_string().as_str() {
         "FilePath" | "AnyPath" => Ok("path".to_string()),
         "DirPath" => Ok("dir".to_string()),
+        "ExecutablePath" => Ok("executable".to_string()),
+        "CommandName" | "CommandString" => Ok("command".to_string()),
+        "CommandWithArguments" => Ok("command_args".to_string()),
         other => Err(syn::Error::new_spanned(
             value,
             format!(
                 "`ValueHint::{other}` has no usage completion type yet; supported hints are \
-                 `FilePath`, `AnyPath`, and `DirPath`"
+                 `FilePath`, `AnyPath`, `DirPath`, `ExecutablePath`, `CommandName`, \
+                 `CommandString`, and `CommandWithArguments`"
             ),
         )),
     }
@@ -2249,6 +2253,18 @@ impl Field {
             }
             Kind::Arg { double_dash }
         };
+
+        if complete_type.as_deref() == Some("command_args")
+            && (!matches!(kind, Kind::Arg { .. })
+                || shape != Shape::Many
+                || double_dash != DoubleDash::Automatic)
+        {
+            return Err(syn::Error::new(
+                span,
+                "`ValueHint::CommandWithArguments` describes a forwarded argv vector; use \
+                 it on a positional `Vec` with `double_dash = \"automatic\"`",
+            ));
+        }
 
         // `required` on a collection is the only way a `Vec` can say it, and it means *always*.
         // Two declarations contradict that, and both compiled:

--- a/docs/rust/args-and-flags.md
+++ b/docs/rust/args-and-flags.md
@@ -84,7 +84,7 @@ jobs: Option<u32>,
 | `overrides(…)`                          | Later occurrence silently overrides the named flag                                      |
 | `required_if(…)` / `required_unless(…)` | Conditional required-ness                                                               |
 | `complete = my_fn`                      | Custom completion function ([Completions](/rust/completions))                           |
-| `value_hint = ValueHint::FilePath`      | Complete values as paths (`FilePath`, `DirPath`, `AnyPath`)                             |
+| `value_hint = ValueHint::FilePath`      | Ask the shell for paths or commands (see below)                                         |
 | `value_name = "…"`                      | The placeholder shown in help (`--file <PATH>`)                                         |
 | `help = "…"` / `long_help = "…"`        | Help text (doc comments are usually nicer)                                              |
 | `help_heading = "…"`                    | Group the entry under a heading in help output                                          |
@@ -101,6 +101,11 @@ jobs: Option<u32>,
 computed state beside parsed state, and nothing about it reaches the spec, the parse tables, or
 help. Combining it with `long`, `arg`, or any other field option is a compile error. The type
 has to implement `Default`.
+
+`value_hint` accepts `FilePath`, `AnyPath`, `DirPath`, `ExecutablePath`, `CommandName`,
+`CommandString`, and `CommandWithArguments`. The last is for wrapper CLIs and must be a
+positional `Vec` with `double_dash = "automatic"`: its first value completes from the shell's
+commands, while later values fall back to ordinary argument paths.
 
 `#[usage(allow_hyphen_values)]` is clap's attribute of the same name: `--args -destroy` binds
 `-destroy` instead of reading `-d` as a short. The flag has to take a value; a positional that

--- a/docs/rust/clap-compatibility.md
+++ b/docs/rust/clap-compatibility.md
@@ -54,7 +54,7 @@ not only from generated KDL, when a row says **usage only**.
 | `dont_delimit_trailing_values`            | Unsupported | Unsupported    | No spec spelling yet.                                                                                                                             |
 | possible-values parser                    | Supported   | Supported      | Use `ValueEnum` or `choices`.                                                                                                                     |
 | arbitrary `value_parser` / numeric ranges | Usage only  | Unsupported    | `FromStr` validates conversion; portable `validate` expressions cover declarative rules, but Rust callbacks cannot enter a language-neutral spec. |
-| `ValueHint`                               | Partial     | Partial        | Path hints used by completions work; the full clap vocabulary does not.                                                                           |
+| `ValueHint`                               | Partial     | Partial        | Path, executable, command, command-string, and forwarded command-with-arguments hints work; identity/network hints remain unsupported.            |
 
 ## Relationships and command routing
 

--- a/docs/spec/reference/complete.md
+++ b/docs/spec/reference/complete.md
@@ -20,6 +20,9 @@ complete "value" type="config_values"
 | --------------- | -------------------------------------------------------------------- |
 | `file`, `path`  | files and directories, relative to the working directory             |
 | `dir`           | directories only                                                     |
+| `executable`    | executable paths                                                     |
+| `command`       | commands known to the shell, including names found on `PATH`         |
+| `command_args`  | a command for the first value, then ordinary argument paths          |
 | `config_keys`   | the settings this spec's [`config`](./config.md) block declares      |
 | `config_values` | the values accepted by the setting named earlier on the command line |
 

--- a/go/argv/complete.go
+++ b/go/argv/complete.go
@@ -41,6 +41,9 @@ type Position struct {
 	Collecting *Flag
 	// NextArg is the positional a word here would fill, if any are left.
 	NextArg *Arg
+	// NextArgValues is how many values are already bound to NextArg. Non-zero only
+	// while a variadic positional is still collecting.
+	NextArgValues uint32
 	// SeparatorSeen is whether a `--` has been typed. Narrower than
 	// FlagsPossible, and what an argument requiring a separator is asking about.
 	SeparatorSeen bool
@@ -60,10 +63,19 @@ func Walk(root *Command, words []string) Position {
 	p := New(root, words)
 	chain := []*Command{root}
 	var awaiting *Flag
+	var lastArg *Arg
+	var lastArgValues uint32
 
 	for p.Next() {
-		if ev := p.Event(); ev.Kind == KindCommand {
+		ev := p.Event()
+		if ev.Kind == KindCommand {
 			chain = append(chain, ev.Command)
+		} else if ev.Kind == KindArg {
+			if ev.Arg == lastArg {
+				lastArgValues++
+			} else {
+				lastArg, lastArgValues = ev.Arg, 1
+			}
 		}
 	}
 	if err, ok := p.Err().(*Error); ok && err != nil {
@@ -85,6 +97,10 @@ func Walk(root *Command, words []string) Position {
 		}
 	}
 
+	nextArg := p.PendingArg()
+	if nextArg != lastArg {
+		lastArgValues = 0
+	}
 	return Position{
 		Cmd:   p.Command(),
 		Chain: chain,
@@ -95,7 +111,8 @@ func Walk(root *Command, words []string) Position {
 		Collecting:          p.Collecting(),
 		FlagsPossible:       !p.FlagsStopped(),
 		SubcommandsPossible: p.SubcommandsPossible(),
-		NextArg:             p.PendingArg(),
+		NextArg:             nextArg,
+		NextArgValues:       lastArgValues,
 		SeparatorSeen:       p.DoubleDashSeen(),
 	}
 }

--- a/go/argv/complete_shell.go
+++ b/go/argv/complete_shell.go
@@ -60,6 +60,8 @@ const (
 	AnyFile
 	// Dirs means directories only.
 	Dirs
+	// Executables means commands and executable paths.
+	Executables
 )
 
 // The line a shell reads to mean "paths belong here too".
@@ -70,8 +72,9 @@ const (
 // values are escaped before they are rendered anywhere — so it cannot be mistaken
 // for one.
 const (
-	FilesMarker = "\x01files"
-	DirsMarker  = "\x01dirs"
+	FilesMarker       = "\x01files"
+	DirsMarker        = "\x01dirs"
+	ExecutablesMarker = "\x01commands"
 )
 
 // Answer is everything a shell needs to resolve one Tab.
@@ -144,6 +147,8 @@ func RenderAnswer(a Answer, shell Shell) string {
 		out.WriteString(FilesMarker + "\n")
 	case Dirs:
 		out.WriteString(DirsMarker + "\n")
+	case Executables:
+		out.WriteString(ExecutablesMarker + "\n")
 	}
 	return out.String()
 }

--- a/go/argv/complete_shell.go
+++ b/go/argv/complete_shell.go
@@ -60,8 +60,10 @@ const (
 	AnyFile
 	// Dirs means directories only.
 	Dirs
-	// Executables means commands and executable paths.
-	Executables
+	// ExecutablePaths means executable files at a filesystem path.
+	ExecutablePaths
+	// Commands means command names from the shell and PATH.
+	Commands
 )
 
 // The line a shell reads to mean "paths belong here too".
@@ -72,9 +74,10 @@ const (
 // values are escaped before they are rendered anywhere — so it cannot be mistaken
 // for one.
 const (
-	FilesMarker       = "\x01files"
-	DirsMarker        = "\x01dirs"
-	ExecutablesMarker = "\x01commands"
+	FilesMarker           = "\x01files"
+	DirsMarker            = "\x01dirs"
+	ExecutablePathsMarker = "\x01executables"
+	CommandsMarker        = "\x01commands"
 )
 
 // Answer is everything a shell needs to resolve one Tab.
@@ -147,8 +150,10 @@ func RenderAnswer(a Answer, shell Shell) string {
 		out.WriteString(FilesMarker + "\n")
 	case Dirs:
 		out.WriteString(DirsMarker + "\n")
-	case Executables:
-		out.WriteString(ExecutablesMarker + "\n")
+	case ExecutablePaths:
+		out.WriteString(ExecutablePathsMarker + "\n")
+	case Commands:
+		out.WriteString(CommandsMarker + "\n")
 	}
 	return out.String()
 }

--- a/go/argv/request.go
+++ b/go/argv/request.go
@@ -177,8 +177,10 @@ func filesFor(name string) Files {
 		return AnyFile
 	case strings.EqualFold(name, "dir"), strings.EqualFold(name, "directory"):
 		return Dirs
-	case strings.EqualFold(name, "executable"), strings.EqualFold(name, "command"):
-		return Executables
+	case strings.EqualFold(name, "executable"):
+		return ExecutablePaths
+	case strings.EqualFold(name, "command"):
+		return Commands
 	}
 	return NoFiles
 }
@@ -186,7 +188,7 @@ func filesFor(name string) Files {
 func declaredFiles(name string, pos Position) Files {
 	if strings.EqualFold(name, "command_args") {
 		if pos.NextArgValues == 0 {
-			return Executables
+			return Commands
 		}
 		return AnyFile
 	}

--- a/go/argv/request.go
+++ b/go/argv/request.go
@@ -149,7 +149,7 @@ func filesAt(pos Position, split SplitLine, candidates []Candidate, meta Metadat
 		if m.ValueName != "" {
 			named = m.ValueName
 		}
-		if asked := filesFor(m.CompleteType); asked != NoFiles {
+		if asked := declaredFiles(m.CompleteType, pos); asked != NoFiles {
 			return asked
 		}
 	}
@@ -177,8 +177,20 @@ func filesFor(name string) Files {
 		return AnyFile
 	case strings.EqualFold(name, "dir"), strings.EqualFold(name, "directory"):
 		return Dirs
+	case strings.EqualFold(name, "executable"), strings.EqualFold(name, "command"):
+		return Executables
 	}
 	return NoFiles
+}
+
+func declaredFiles(name string, pos Position) Files {
+	if strings.EqualFold(name, "command_args") {
+		if pos.NextArgValues == 0 {
+			return Executables
+		}
+		return AnyFile
+	}
+	return filesFor(name)
 }
 
 // atoi is [strconv.Atoi] for a non-negative number, written out because this

--- a/go/argv/request_test.go
+++ b/go/argv/request_test.go
@@ -16,10 +16,13 @@ func requestFixture() (*Command, HelpTable, Metadata) {
 		Args: []*Arg{{Key: 7, Name: "TOOL"}}}
 	after := &Command{Key: 8, Name: "run",
 		Args: []*Arg{{Key: 9, Name: "TASK", DoubleDash: DoubleDashRequired}}}
-	root := &Command{Key: 1, Name: "ex", Subcommands: []*Command{edit, use, after}}
+	forward := &Command{Key: 10, Name: "forward",
+		Args: []*Arg{{Key: 11, Name: "COMMAND", Var: true, DoubleDash: DoubleDashAutomatic}}}
+	root := &Command{Key: 1, Name: "ex", Subcommands: []*Command{edit, use, after, forward}}
 
 	help := HelpTable{{Key: 1}, {Key: 2}, {Key: 3}, {Key: 4}, {Key: 5, Short: "Edit a file"},
-		{Key: 6, Short: "Use a tool"}, {Key: 7}, {Key: 8, Short: "Run a task"}, {Key: 9}}
+		{Key: 6, Short: "Use a tool"}, {Key: 7}, {Key: 8, Short: "Run a task"}, {Key: 9},
+		{Key: 10, Short: "Forward a command"}, {Key: 11}}
 	meta := Metadata{
 		{Key: 1},
 		{Key: 2, Name: "into", Flag: true, ValueName: "DIR"},
@@ -30,6 +33,8 @@ func requestFixture() (*Command, HelpTable, Metadata) {
 		{Key: 7, Name: "TOOL", Choices: []string{"node", "python"}},
 		{Key: 8},
 		{Key: 9, Name: "TASK"},
+		{Key: 10},
+		{Key: 11, Name: "COMMAND", CompleteType: "command_args"},
 	}
 	return root, help, meta
 }
@@ -135,6 +140,8 @@ func TestWhenPathsBelongAtTheCursor(t *testing.T) {
 		{"ex use --tool ⌶", NoFiles, "so does the value"},
 		{"ex run ⌶", NoFiles, "that argument is not readable until after a --"},
 		{"ex run -- ⌶", AnyFile, "and past the separator it is anything at all"},
+		{"ex forward ⌶", Executables, "the first forwarded word is a command"},
+		{"ex forward git ⌶", AnyFile, "later forwarded words are command arguments"},
 	} {
 		answer, _ := ask(t, Bash, c.line)
 		if answer.Files != c.want {

--- a/go/argv/request_test.go
+++ b/go/argv/request_test.go
@@ -140,7 +140,7 @@ func TestWhenPathsBelongAtTheCursor(t *testing.T) {
 		{"ex use --tool ⌶", NoFiles, "so does the value"},
 		{"ex run ⌶", NoFiles, "that argument is not readable until after a --"},
 		{"ex run -- ⌶", AnyFile, "and past the separator it is anything at all"},
-		{"ex forward ⌶", Executables, "the first forwarded word is a command"},
+		{"ex forward ⌶", Commands, "the first forwarded word is a command"},
 		{"ex forward git ⌶", AnyFile, "later forwarded words are command arguments"},
 	} {
 		answer, _ := ask(t, Bash, c.line)

--- a/go/argv/script.go
+++ b/go/argv/script.go
@@ -325,13 +325,20 @@ def --env __usage_complete_{ident} [spans: list<string>] {
     # the start of that command's arguments or re-enter this external completer.
     let commands = (if $wants_commands {
         let prefix = ($spans | last)
+        let insensitive = $nu.os-info.name == "windows"
+        let match_prefix = if $insensitive { $prefix | str downcase } else { $prefix }
         which
-        | where {|row| $row.command | str starts-with $prefix }
+        | where {|row|
+            let candidate = if $insensitive { $row.command | str downcase } else { $row.command }
+            $candidate | str starts-with $match_prefix
+        }
         | each {|row| { value: $row.command, description: $row.path } }
     } else {
         []
     })
     let candidates = ($declared | append $commands)
+    let command_is_path = (($spans | last) | str contains "/") or (($spans | last) | str contains "\\")
+    let wants_path_fallback = $wants_files or ($wants_commands and $command_is_path)
     # ` + "`" + `null` + "`" + ` is how a nushell completer says "you do this one", and what it does is complete
     # paths. So an answer that is only the marker returns null rather than nothing, which would
     # mean "there is nothing here".
@@ -341,7 +348,7 @@ def --env __usage_complete_{ident} [spans: list<string>] {
     # "and files too". The candidates win, because they are what this CLI knows and a path is
     # something the user can finish typing. Every other shell here appends both; this is
     # nushell's completer interface rather than a decision of this design.
-    if ($candidates | is-empty) and $wants_files { null } else { $candidates }
+    if ($candidates | is-empty) and $wants_path_fallback { null } else { $candidates }
 }
 
 # Slot this into the external completer nushell already has, if any, rather than replacing it:

--- a/go/argv/script.go
+++ b/go/argv/script.go
@@ -147,6 +147,7 @@ _usage_complete_{bin}() {
         case "$__usage_line" in
             $'\001files') __usage_files=any ;;
             $'\001dirs') __usage_files=dirs ;;
+            $'\001commands') __usage_files=commands ;;
             '') ;;
             *) COMPREPLY+=("$__usage_line") ;;
         esac
@@ -156,10 +157,13 @@ _usage_complete_{bin}() {
         # Set here rather than on ` + "`" + `complete` + "`" + `, because whether this position takes a path is not
         # known until the answer comes back. It is what makes bash append a ` + "`" + `/` + "`" + ` to a directory
         # and stop escaping what it should not.
-        compopt -o filenames 2>/dev/null
+        [[ $__usage_files == commands ]] || compopt -o filenames 2>/dev/null
         local __usage_cur="${COMP_WORDS[COMP_CWORD]}" __usage_path
         local -a __usage_paths=()
-        if [[ $__usage_files == dirs ]]; then
+        if [[ $__usage_files == commands ]]; then
+            while IFS= read -r __usage_path; do __usage_paths+=("$__usage_path"); done \
+                < <(compgen -c -- "$__usage_cur")
+        elif [[ $__usage_files == dirs ]]; then
             while IFS= read -r __usage_path; do __usage_paths+=("$__usage_path"); done \
                 < <(compgen -d -- "$__usage_cur")
         else
@@ -183,6 +187,7 @@ _{bin}() {
         case "$__usage_line" in
             $'\001files') __usage_files=any; continue ;;
             $'\001dirs') __usage_files=dirs; continue ;;
+            $'\001commands') __usage_files=commands; continue ;;
             '') continue ;;
         esac
         local -a parts=("${(@ps:\t:)__usage_line}")
@@ -219,6 +224,7 @@ _{bin}() {
     case "$__usage_files" in
         any) _files && __usage_ret=0 ;;
         dirs) _files -/ && __usage_ret=0 ;;
+        commands) _command_names && __usage_ret=0 ;;
     esac
     return $__usage_ret
 }
@@ -243,12 +249,15 @@ function __usage_complete_{bin}
     # computed values, and a control byte is not something to spell twice.
     set -l marker_any (printf '\x01files')
     set -l marker_dirs (printf '\x01dirs')
+    set -l marker_commands (printf '\x01commands')
     set -l files ""
     for entry in $out
         if test "$entry" = "$marker_any"
             set files any
         else if test "$entry" = "$marker_dirs"
             set files dirs
+        else if test "$entry" = "$marker_commands"
+            set files commands
         else if test -n "$entry"
             # printf, not echo: fish's echo reads a leading -n, -e, -s or -E as
             # its own option, so those flags would be swallowed or mangled rather
@@ -262,6 +271,8 @@ function __usage_complete_{bin}
             __fish_complete_path (commandline -ct)
         case dirs
             __fish_complete_directories (commandline -ct)
+        case commands
+            __fish_complete_command (commandline -ct)
     end
 end
 
@@ -280,7 +291,8 @@ def --env __usage_complete_{ident} [spans: list<string>] {
     let lines = ($out.stdout | lines | where {|l| $l != "" })
     let marker = "\u{1}"
     let wants_files = ($lines | any {|l| $l == $marker + "files" or $l == $marker + "dirs" })
-    let candidates = (
+    let wants_commands = ($lines | any {|l| $l == $marker + "commands" })
+    let declared = (
         $lines
         | where {|l| not ($l | str starts-with $marker) }
         | each {|l|
@@ -291,6 +303,15 @@ def --env __usage_complete_{ident} [spans: list<string>] {
             }
         }
     )
+    # Ask nushell for command names from the current word alone. Giving it the
+    # original line would complete this CLI's next argument and recurse through
+    # the external completer instead of completing a command to forward.
+    let commands = (if $wants_commands {
+        ($spans | last) | commandline complete --detailed
+    } else {
+        []
+    })
+    let candidates = ($declared | append $commands)
     # ` + "`" + `null` + "`" + ` is how a nushell completer says "you do this one", and what it does is complete
     # paths. So an answer that is only the marker returns null rather than nothing, which would
     # mean "there is nothing here".
@@ -339,6 +360,7 @@ Register-ArgumentCompleter -Native -CommandName '{bin}' -ScriptBlock {
         if ([string]::IsNullOrEmpty($entry)) { continue }
         if ($entry -eq ($marker + 'files')) { $files = 'any'; continue }
         if ($entry -eq ($marker + 'dirs')) { $files = 'dirs'; continue }
+        if ($entry -eq ($marker + 'commands')) { $files = 'commands'; continue }
         $parts = $entry -split "` + "`" + `t", 2
         $value = $parts[0]
         $description = if ($parts.Count -gt 1 -and $parts[1]) { $parts[1] } else { $value }
@@ -349,7 +371,15 @@ Register-ArgumentCompleter -Native -CommandName '{bin}' -ScriptBlock {
         )
     }
 
-    if ($files) {
+    if ($files -eq 'commands') {
+        foreach ($command in Get-Command -Name ($wordToComplete + '*') -CommandType Application, ExternalScript -ErrorAction SilentlyContinue) {
+            $results.Add(
+                [System.Management.Automation.CompletionResult]::new(
+                    $command.Name, $command.Name, 'Command', $command.Source
+                )
+            )
+        }
+    } else if ($files) {
         # PowerShell's own, so that ` + "`" + `~` + "`" + `, drive-relative paths and provider paths behave as they
         # do everywhere else in the shell.
         foreach ($path in [System.Management.Automation.CompletionCompleters]::CompleteFilename($wordToComplete)) {

--- a/go/argv/script.go
+++ b/go/argv/script.go
@@ -147,6 +147,7 @@ _usage_complete_{bin}() {
         case "$__usage_line" in
             $'\001files') __usage_files=any ;;
             $'\001dirs') __usage_files=dirs ;;
+            $'\001executables') __usage_files=executables ;;
             $'\001commands') __usage_files=commands ;;
             '') ;;
             *) COMPREPLY+=("$__usage_line") ;;
@@ -163,6 +164,10 @@ _usage_complete_{bin}() {
         if [[ $__usage_files == commands ]]; then
             while IFS= read -r __usage_path; do __usage_paths+=("$__usage_path"); done \
                 < <(compgen -c -- "$__usage_cur")
+        elif [[ $__usage_files == executables ]]; then
+            while IFS= read -r __usage_path; do
+                [[ -d "$__usage_path" || -x "$__usage_path" ]] && __usage_paths+=("$__usage_path")
+            done < <(compgen -f -- "$__usage_cur")
         elif [[ $__usage_files == dirs ]]; then
             while IFS= read -r __usage_path; do __usage_paths+=("$__usage_path"); done \
                 < <(compgen -d -- "$__usage_cur")
@@ -187,6 +192,7 @@ _{bin}() {
         case "$__usage_line" in
             $'\001files') __usage_files=any; continue ;;
             $'\001dirs') __usage_files=dirs; continue ;;
+            $'\001executables') __usage_files=executables; continue ;;
             $'\001commands') __usage_files=commands; continue ;;
             '') continue ;;
         esac
@@ -224,6 +230,7 @@ _{bin}() {
     case "$__usage_files" in
         any) _files && __usage_ret=0 ;;
         dirs) _files -/ && __usage_ret=0 ;;
+        executables) _files -g '*(*)' && __usage_ret=0 ;;
         commands) _command_names && __usage_ret=0 ;;
     esac
     return $__usage_ret
@@ -249,6 +256,7 @@ function __usage_complete_{bin}
     # computed values, and a control byte is not something to spell twice.
     set -l marker_any (printf '\x01files')
     set -l marker_dirs (printf '\x01dirs')
+    set -l marker_executables (printf '\x01executables')
     set -l marker_commands (printf '\x01commands')
     set -l files ""
     for entry in $out
@@ -256,6 +264,8 @@ function __usage_complete_{bin}
             set files any
         else if test "$entry" = "$marker_dirs"
             set files dirs
+        else if test "$entry" = "$marker_executables"
+            set files executables
         else if test "$entry" = "$marker_commands"
             set files commands
         else if test -n "$entry"
@@ -271,6 +281,13 @@ function __usage_complete_{bin}
             __fish_complete_path (commandline -ct)
         case dirs
             __fish_complete_directories (commandline -ct)
+        case executables
+            for candidate in (__fish_complete_path (commandline -ct))
+                set -l value (string split -m 1 (printf '\t') -- $candidate)[1]
+                if test -d "$value"; or test -x "$value"
+                    printf '%s\n' $candidate
+                end
+            end
         case commands
             __fish_complete_command (commandline -ct)
     end
@@ -290,7 +307,7 @@ def --env __usage_complete_{ident} [spans: list<string>] {
     if $out.exit_code != 0 { return null }
     let lines = ($out.stdout | lines | where {|l| $l != "" })
     let marker = "\u{1}"
-    let wants_files = ($lines | any {|l| $l == $marker + "files" or $l == $marker + "dirs" })
+    let wants_files = ($lines | any {|l| $l == $marker + "files" or $l == $marker + "dirs" or $l == $marker + "executables" })
     let wants_commands = ($lines | any {|l| $l == $marker + "commands" })
     let declared = (
         $lines
@@ -360,6 +377,7 @@ Register-ArgumentCompleter -Native -CommandName '{bin}' -ScriptBlock {
         if ([string]::IsNullOrEmpty($entry)) { continue }
         if ($entry -eq ($marker + 'files')) { $files = 'any'; continue }
         if ($entry -eq ($marker + 'dirs')) { $files = 'dirs'; continue }
+        if ($entry -eq ($marker + 'executables')) { $files = 'executables'; continue }
         if ($entry -eq ($marker + 'commands')) { $files = 'commands'; continue }
         $parts = $entry -split "` + "`" + `t", 2
         $value = $parts[0]
@@ -383,11 +401,17 @@ Register-ArgumentCompleter -Native -CommandName '{bin}' -ScriptBlock {
         # PowerShell's own, so that ` + "`" + `~` + "`" + `, drive-relative paths and provider paths behave as they
         # do everywhere else in the shell.
         foreach ($path in [System.Management.Automation.CompletionCompleters]::CompleteFilename($wordToComplete)) {
-            # By what PowerShell said it is, not by testing the path again: ` + "`" + `CompletionText` + "`" + ` is
-            # the text to *insert* and may already carry quoting, so a directory whose name needs
-            # quotes would fail a ` + "`" + `Test-Path` + "`" + ` and vanish from a dirs-only completion.
+            # Trust PowerShell's result type for directories because CompletionText may already
+            # carry quoting. Executable leaves are checked as commands after stripping only the
+            # outer quote characters PowerShell added.
             if ($files -eq 'dirs' -and $path.ResultType -ne 'ProviderContainer') {
                 continue
+            }
+            if ($files -eq 'executables' -and $path.ResultType -ne 'ProviderContainer') {
+                $candidatePath = $path.CompletionText.Trim([char[]]@([char]39, [char]34))
+                if (-not (Get-Command -Name $candidatePath -CommandType Application, ExternalScript -ErrorAction SilentlyContinue)) {
+                    continue
+                }
             }
             $results.Add($path)
         }

--- a/go/argv/script.go
+++ b/go/argv/script.go
@@ -397,7 +397,7 @@ Register-ArgumentCompleter -Native -CommandName '{bin}' -ScriptBlock {
                 )
             )
         }
-    } else if ($files) {
+    } elseif ($files) {
         # PowerShell's own, so that ` + "`" + `~` + "`" + `, drive-relative paths and provider paths behave as they
         # do everywhere else in the shell.
         foreach ($path in [System.Management.Automation.CompletionCompleters]::CompleteFilename($wordToComplete)) {

--- a/go/argv/script.go
+++ b/go/argv/script.go
@@ -320,11 +320,14 @@ def --env __usage_complete_{ident} [spans: list<string>] {
             }
         }
     )
-    # Ask nushell for command names from the current word alone. Giving it the
-    # original line would complete this CLI's next argument and recurse through
-    # the external completer instead of completing a command to forward.
+    # which with no names returns nushell's commands and the executables on PATH.
+    # Unlike commandline complete, it cannot reinterpret an exact command name as
+    # the start of that command's arguments or re-enter this external completer.
     let commands = (if $wants_commands {
-        ($spans | last) | commandline complete --detailed
+        let prefix = ($spans | last)
+        which
+        | where {|row| $row.command | str starts-with $prefix }
+        | each {|row| { value: $row.command, description: $row.path } }
     } else {
         []
     })

--- a/go/argv/script_test.go
+++ b/go/argv/script_test.go
@@ -56,12 +56,12 @@ func TestEveryScriptCallsTheBinaryAndRegistersIt(t *testing.T) {
 // PowerShell, `\u{1}` in nushell — so a change to the constant would leave five
 // scripts watching for something that never arrives.
 func TestTheScriptsWatchForTheMarkerTheRendererWrites(t *testing.T) {
-	if FilesMarker != "\x01files" || DirsMarker != "\x01dirs" || ExecutablesMarker != "\x01commands" {
-		t.Fatalf("the scripts are written for \\x01: %q %q %q", FilesMarker, DirsMarker, ExecutablesMarker)
+	if FilesMarker != "\x01files" || DirsMarker != "\x01dirs" || ExecutablePathsMarker != "\x01executables" || CommandsMarker != "\x01commands" {
+		t.Fatalf("the scripts are written for \\x01: %q %q %q %q", FilesMarker, DirsMarker, ExecutablePathsMarker, CommandsMarker)
 	}
 	for _, c := range []struct{ shell, spelling Shell }{{Bash, Bash}, {Zsh, Zsh}} {
 		out := Script("mise", c.shell)
-		for _, want := range []string{`$'\001files'`, `$'\001dirs'`, `$'\001commands'`} {
+		for _, want := range []string{`$'\001files'`, `$'\001dirs'`, `$'\001executables'`, `$'\001commands'`} {
 			if !strings.Contains(out, want) {
 				t.Errorf("%v should watch for %s:\n%s", c.shell, want, out)
 			}
@@ -69,6 +69,12 @@ func TestTheScriptsWatchForTheMarkerTheRendererWrites(t *testing.T) {
 	}
 	if !strings.Contains(Script("mise", Fish), `printf '\x01files'`) {
 		t.Error("fish builds the marker with printf")
+	}
+	if !strings.Contains(Script("mise", Fish), `test -d "$value"; or test -x "$value"`) {
+		t.Error("fish filters executable-path candidates")
+	}
+	if !strings.Contains(Script("mise", PowerShell), "-CommandType Application, ExternalScript") {
+		t.Error("powershell filters executable-path candidates")
 	}
 	if !strings.Contains(Script("mise", Nu), `"\u{1}"`) {
 		t.Error("nushell spells it as an escape")

--- a/go/argv/script_test.go
+++ b/go/argv/script_test.go
@@ -92,12 +92,15 @@ func TestTheScriptsWatchForTheMarkerTheRendererWrites(t *testing.T) {
 		{Bash, "compgen -c"},
 		{Zsh, "_command_names"},
 		{Fish, "__fish_complete_command"},
-		{Nu, "commandline complete --detailed"},
+		{Nu, "which"},
 		{PowerShell, "Get-Command"},
 	} {
 		if out := Script("mise", test.shell); !strings.Contains(out, test.want) {
 			t.Errorf("%v should ask the shell for commands with %q:\n%s", test.shell, test.want, out)
 		}
+	}
+	if out := Script("mise", Nu); strings.Contains(out, "| commandline complete") {
+		t.Errorf("nushell command completion must not recurse through the external completer:\n%s", out)
 	}
 }
 

--- a/go/argv/script_test.go
+++ b/go/argv/script_test.go
@@ -76,6 +76,9 @@ func TestTheScriptsWatchForTheMarkerTheRendererWrites(t *testing.T) {
 	if !strings.Contains(Script("mise", PowerShell), "-CommandType Application, ExternalScript") {
 		t.Error("powershell filters executable-path candidates")
 	}
+	if out := Script("mise", PowerShell); !strings.Contains(out, "} elseif ($files) {") || strings.Contains(out, "} else if ($files) {") {
+		t.Errorf("powershell uses its elseif keyword:\n%s", out)
+	}
 	if !strings.Contains(Script("mise", Nu), `"\u{1}"`) {
 		t.Error("nushell spells it as an escape")
 	}

--- a/go/argv/script_test.go
+++ b/go/argv/script_test.go
@@ -102,6 +102,9 @@ func TestTheScriptsWatchForTheMarkerTheRendererWrites(t *testing.T) {
 	if out := Script("mise", Nu); strings.Contains(out, "| commandline complete") {
 		t.Errorf("nushell command completion must not recurse through the external completer:\n%s", out)
 	}
+	if out := Script("mise", Nu); !strings.Contains(out, "let wants_path_fallback") || !strings.Contains(out, `$nu.os-info.name == "windows"`) {
+		t.Errorf("nushell command completion must preserve path and Windows lookup semantics:\n%s", out)
+	}
 }
 
 // A candidate that looks like an option to the shell's own printer is still

--- a/go/argv/script_test.go
+++ b/go/argv/script_test.go
@@ -56,12 +56,12 @@ func TestEveryScriptCallsTheBinaryAndRegistersIt(t *testing.T) {
 // PowerShell, `\u{1}` in nushell — so a change to the constant would leave five
 // scripts watching for something that never arrives.
 func TestTheScriptsWatchForTheMarkerTheRendererWrites(t *testing.T) {
-	if FilesMarker != "\x01files" || DirsMarker != "\x01dirs" {
-		t.Fatalf("the scripts are written for \\x01: %q %q", FilesMarker, DirsMarker)
+	if FilesMarker != "\x01files" || DirsMarker != "\x01dirs" || ExecutablesMarker != "\x01commands" {
+		t.Fatalf("the scripts are written for \\x01: %q %q %q", FilesMarker, DirsMarker, ExecutablesMarker)
 	}
 	for _, c := range []struct{ shell, spelling Shell }{{Bash, Bash}, {Zsh, Zsh}} {
 		out := Script("mise", c.shell)
-		for _, want := range []string{`$'\001files'`, `$'\001dirs'`} {
+		for _, want := range []string{`$'\001files'`, `$'\001dirs'`, `$'\001commands'`} {
 			if !strings.Contains(out, want) {
 				t.Errorf("%v should watch for %s:\n%s", c.shell, want, out)
 			}
@@ -75,6 +75,20 @@ func TestTheScriptsWatchForTheMarkerTheRendererWrites(t *testing.T) {
 	}
 	if !strings.Contains(Script("mise", PowerShell), "[char]1") {
 		t.Error("PowerShell builds it from the code point")
+	}
+	for _, test := range []struct {
+		shell Shell
+		want  string
+	}{
+		{Bash, "compgen -c"},
+		{Zsh, "_command_names"},
+		{Fish, "__fish_complete_command"},
+		{Nu, "commandline complete --detailed"},
+		{PowerShell, "Get-Command"},
+	} {
+		if out := Script("mise", test.shell); !strings.Contains(out, test.want) {
+			t.Errorf("%v should ask the shell for commands with %q:\n%s", test.shell, test.want, out)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- add executable, command, command-string, and command-with-arguments value hints
- delegate command names to native shell completion in all generated scripts
- complete the first forwarded argv value as a command and later values as argument paths
- keep Rust, Go, KDL, and the reference CLI on the same completion vocabulary
- close the fleet PLAN gap exposed by fnox

## Validation

- `cargo test -p usage-conformance --test completion --all-features`
- `cargo test -p usage-argv --all-features`
- `cargo test -p usage-cli --test complete_word`
- `go test ./argv ./internal/spec`
- `cargo clippy --all --all-features --all-targets -- -D warnings`

_This pull request was generated by an AI coding agent._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad touch across completion protocol, parser walk state, and five shell scripts; behavior is heavily tested but regressions in Tab completion or wrapper CLIs would be user-visible.
> 
> **Overview**
> **Extends completion beyond file/path hints** with `executable`, `command`, and `command_args` types, plus new `ValueHint` variants (`ExecutablePath`, `CommandName`, `CommandString`, `CommandWithArguments`) mapped in the derive and documented in the spec.
> 
> **Forwarded argv** uses `command_args`: completion walk tracks **`next_arg_values`** on variadic positionals so the **first** word gets command names and **later** words get ordinary paths. The derive enforces `CommandWithArguments` only on a positional `Vec` with `double_dash = "automatic"`.
> 
> **End-to-end parity**: Rust (`argv`), Go (`go/argv`), generated bash/zsh/fish/nu/PowerShell scripts, and the reference `complete_word` CLI all emit/consume new `\x01executables` / `\x01commands` markers and delegate to native shell completion (`compgen -c`, `_command_names`, `which`, `Get-Command`, etc.). **PLAN.md** marks the fnox-related command-with-arguments gap as done.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 611e1a5e511c27b7505a28cc7e38e08511ddc5fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->