### PR TITLE
docs: publish versioned clap compatibility matrix

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -573,7 +573,7 @@ their parser, whether every behavior they rely on survives. clap's derive forwar
 arbitrary `Command`, `Arg` and `PossibleValue` builder methods, so a hand-selected
 feature list is not an exhaustive audit.
 
-- [ ] **A versioned clap compatibility matrix.** Inventory clap's public derive
+- [x] **A versioned clap compatibility matrix.** Inventory clap's public derive
       attributes and relevant builder methods, pinned to the clap release audited.
       Give every row a result for `usage-derive`, `usage-argv`, the KDL spec and
       usage-lib, help/completions, and the `clap_usage` bridge. Each cell must say

--- a/docs/rust/clap-compatibility.md
+++ b/docs/rust/clap-compatibility.md
@@ -1,103 +1,128 @@
 # clap compatibility
 
-This matrix describes compatibility with `clap` 4.6.6 and `clap_derive` 4.6.4, the
-versions audited in this workspace. It distinguishes what a CLI can declare directly with
-`usage` from what [`clap_usage`](/spec/integrations/clap) can recover from an existing
-`clap::Command`.
+This is the audited compatibility matrix for `clap` 4.6.6 and `clap_derive` 4.6.4,
+the versions in this workspace's lockfile. The audit covers clap's public derive
+attributes and the corresponding `Command`, `Arg`, `ArgGroup`, and `PossibleValue`
+builder settings that affect parsing or generated output. Builder operations for
+constructing and mutating a command graph are listed separately as architectural
+non-goals.
 
-The bridge is not a lossless migration verifier. clap exposes some settings only through
-setters, so `clap_usage` cannot detect that they were present. Migrate from the Rust declaration,
-not only from generated KDL, when a row says **usage only**.
+Updating either clap package requires updating the versions above and auditing this
+matrix in the same pull request.
 
-## Status
+The columns distinguish every layer a migration crosses:
 
-| Status          | Meaning                                                                                    |
-| --------------- | ------------------------------------------------------------------------------------------ |
-| **Supported**   | The derive, compiled parser, spec, and reference parser carry the behavior.                |
-| **Usage only**  | A usage declaration carries it, but clap exposes no getter or the bridge loses part of it. |
-| **Partial**     | The common form works; the note names the unsupported part.                                |
-| **Different**   | usage intentionally has different parsing behavior.                                        |
-| **Unsupported** | No equivalent is available yet.                                                            |
-| **Non-goal**    | The API shape is outside the static-parser architecture.                                   |
+- **derive** — `usage-rs` / `usage-derive` can declare it and has typed coverage.
+- **argv** — the compiled `usage-argv` parser enforces it.
+- **KDL** — the portable spec can represent and round-trip it.
+- **lib** — `usage-lib` enforces it when interpreting KDL.
+- **output** — help, diagnostics, docs, or completions preserve the relevant behavior.
+- **bridge** — `clap_usage` can recover it from a `clap::Command`.
+
+| Mark           | Meaning                                                                                                |
+| -------------- | ------------------------------------------------------------------------------------------------------ |
+| **yes**        | Supported and covered at this layer.                                                                   |
+| **usage-only** | Direct usage declarations work, but clap exposes no getter or the bridge cannot preserve the behavior. |
+| **lossy**      | Some common forms work; the note names what is lost.                                                   |
+| **different**  | Intentionally differs from clap.                                                                       |
+| **no**         | Unsupported.                                                                                           |
+| **n/a**        | The behavior does not belong at this layer.                                                            |
+| **non-goal**   | Deliberately outside the static typed-parser API.                                                      |
+
+The bridge is not a lossless migration verifier. clap exposes some settings only
+through setters, so a generated spec cannot report that it lost them. Migrate from
+the Rust declaration, not only from generated KDL, wherever the bridge column says
+**usage-only** or **lossy**.
 
 ## Types and declarations
 
-| clap                                             | usage       | clap → spec    | Notes                                                                                                                                               |
-| ------------------------------------------------ | ----------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Parser`                                         | Supported   | Supported      | `#[derive(usage::Cli)]`                                                                                                                             |
-| `Args`                                           | Supported   | Supported      | `#[derive(usage::Args)]`, including `flatten`                                                                                                       |
-| `Subcommand`                                     | Supported   | Supported      | Nested and boxed variants are supported.                                                                                                            |
-| `ValueEnum`                                      | Supported   | Supported      | Names, per-value help, hidden values, visible and hidden aliases, cfg-gated variants, and case-insensitive matching are carried in static metadata. |
-| `#[arg(skip)]`                                   | Supported   | Not applicable | `#[usage(skip)]`; skipped fields do not belong in a spec.                                                                                           |
-| arbitrary `Command` / `Arg` builder code         | Non-goal    | Partial        | `usage-lib` is the dynamic spec interpreter; usage derive does not reproduce clap's builder API.                                                    |
-| `ArgMatches`, `FromArgMatches`, `CommandFactory` | Non-goal    | Not applicable | Typed structs are built directly from static tables.                                                                                                |
-| `update_from` / `try_update_from`                | Unsupported | Not applicable | A parse currently constructs a new value.                                                                                                           |
+| clap surface                                     | derive   | argv     | KDL | lib | output | bridge | Notes                                                                                              |
+| ------------------------------------------------ | -------- | -------- | --- | --- | ------ | ------ | -------------------------------------------------------------------------------------------------- |
+| `Parser` / `Command` metadata                    | yes      | yes      | yes | yes | yes    | yes    | `#[derive(usage::Cli)]`; name, bin, about, long about, before/after help, and version are carried. |
+| `Args`                                           | yes      | yes      | yes | yes | yes    | yes    | Dedicated, unit, reused, nested, and flattened Args types are covered.                             |
+| `Subcommand`                                     | yes      | yes      | yes | yes | yes    | yes    | Bare, tuple, inline-struct, nested, boxed, aliases, and hidden aliases are covered.                |
+| `ValueEnum` / `PossibleValue`                    | yes      | yes      | yes | yes | yes    | yes    | Names, help, hide, visible/hidden aliases, cfg, and case-insensitive matching are preserved.       |
+| `flatten`                                        | yes      | yes      | yes | yes | lossy  | yes    | Parsing is composed; flattened `next_help_heading` topology is not preserved.                      |
+| `skip`                                           | yes      | yes      | n/a | n/a | n/a    | n/a    | `#[usage(skip)]` fills the field from `Default` and emits no argument.                             |
+| `from_global`                                    | no       | no       | no  | no  | no     | no     | A global flag is parsed on its declaring root type; copying it into another field is unsupported.  |
+| arbitrary `Command` / `Arg` builder code         | non-goal | non-goal | n/a | yes | yes    | lossy  | `usage-lib` is the dynamic API; the typed derive does not reproduce clap's builder API.            |
+| `ArgMatches`, `FromArgMatches`, `CommandFactory` | non-goal | non-goal | n/a | n/a | n/a    | n/a    | Typed structs and borrowed static metadata replace these APIs.                                     |
+| `update_from` / `try_update_from`                | no       | no       | n/a | n/a | n/a    | n/a    | Parsing currently constructs a new value.                                                          |
 
 ## Arguments and values
 
-| clap                                      | usage       | clap → spec    | Notes                                                                                                                                             |
-| ----------------------------------------- | ----------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| long and short flags                      | Supported   | Partial        | Multiple visible and hidden aliases are supported directly; clap spelling and alias visibility are not all bridge-lossless.                       |
-| positional arguments                      | Supported   | Supported      | Required, optional, and variadic positionals are supported.                                                                                       |
-| `Option<T>`, `Vec<T>`, `Option<Vec<T>>`   | Supported   | Not applicable | Values use `FromStr`; Unix `PathBuf` and `OsString` also accept non-UTF-8 bytes.                                                                  |
-| `ArgAction::SetTrue`, `SetFalse`, `Count` | Supported   | Supported      | `SetFalse` is `#[usage(negate)]`.                                                                                                                 |
-| `default_value`                           | Supported   | Supported      | Defaults are applied after argv and environment values.                                                                                           |
-| `default_missing_value`                   | Usage only  | Unsupported    | `#[usage(default_missing = "…")]`; clap has no getter.                                                                                            |
-| `default_value_if(s)`                     | Usage only  | Unsupported    | `#[usage(default_if(...))]`; clap has no getter.                                                                                                  |
-| `env`                                     | Supported   | Partial        | Environment fallback works, but the current bridge can lose the binding.                                                                          |
-| `value_delimiter`                         | Supported   | Supported      | ASCII delimiters round-trip.                                                                                                                      |
-| `num_args`                                | Partial     | Partial        | `var_min` / `var_max` cover ranges; fixed arity, distinct value names, and bridge preservation remain incomplete.                                 |
-| `allow_hyphen_values`                     | Supported   | Supported      | Available on value-taking flags; trailing positionals use `double_dash = "automatic"`.                                                            |
-| `allow_negative_numbers`                  | Unsupported | Unsupported    | `allow_hyphen_values` is broader, not equivalent.                                                                                                 |
-| `require_equals`                          | Supported   | Supported      | Detached values are refused.                                                                                                                      |
-| `value_terminator`                        | Unsupported | Unsupported    | No spec spelling yet.                                                                                                                             |
-| `dont_delimit_trailing_values`            | Unsupported | Unsupported    | No spec spelling yet.                                                                                                                             |
-| possible-values parser                    | Supported   | Supported      | Use `ValueEnum` or `choices`.                                                                                                                     |
-| arbitrary `value_parser` / numeric ranges | Usage only  | Unsupported    | `FromStr` validates conversion; portable `validate` expressions cover declarative rules, but Rust callbacks cannot enter a language-neutral spec. |
-| `ValueHint`                               | Partial     | Partial        | Path, executable, command, command-string, and forwarded command-with-arguments hints work; identity/network hints remain unsupported.            |
+| clap surface                                               | derive     | argv  | KDL   | lib   | output | bridge     | Notes                                                                                                                             |
+| ---------------------------------------------------------- | ---------- | ----- | ----- | ----- | ------ | ---------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `long`, `short`, visible aliases                           | yes        | yes   | yes   | yes   | yes    | lossy      | usage accepts multiple forms; clap-compatible alias spellings and all visibility distinctions are not yet lossless.               |
+| hidden flag `alias` / `aliases`                            | no         | no    | no    | no    | no     | lossy      | Hidden command and value aliases are supported, but flags currently have no alias-visibility model.                               |
+| explicit `id`                                              | no         | no    | no    | no    | no     | lossy      | Relationships currently use flag spellings, not stable clap IDs.                                                                  |
+| positional arguments                                       | yes        | yes   | yes   | yes   | yes    | yes        | Required, optional, and variadic positionals are supported.                                                                       |
+| `Option<T>`, `Vec<T>`, `Option<Vec<T>>`                    | yes        | yes   | yes   | yes   | yes    | n/a        | Values use `FromStr`; Unix `PathBuf` and `OsString` preserve non-UTF-8 bytes.                                                     |
+| `ArgAction::Set`, `SetTrue`, `SetFalse`, `Append`, `Count` | yes        | yes   | yes   | yes   | yes    | lossy      | Common typed shapes are covered; arbitrary action/type combinations are not.                                                      |
+| `default_value`                                            | yes        | yes   | yes   | yes   | yes    | yes        | Defaults apply after argv and environment values and clear token-required metadata.                                               |
+| `default_missing_value`                                    | yes        | yes   | yes   | yes   | yes    | usage-only | `#[usage(default_missing = "…")]`; clap has no getter.                                                                            |
+| `default_value_if(s)`                                      | yes        | yes   | yes   | yes   | yes    | usage-only | Presence and equality predicates are portable; clap has no getter.                                                                |
+| `env`                                                      | yes        | yes   | yes   | yes   | yes    | lossy      | Environment fallback works; the current bridge can lose the binding.                                                              |
+| `value_delimiter`                                          | yes        | yes   | yes   | yes   | yes    | yes        | ASCII delimiters round-trip and are applied before arity checks.                                                                  |
+| `num_args` ranges                                          | yes        | yes   | yes   | yes   | yes    | lossy      | `var_min` / `var_max` cover accumulated ranges; optional and repeatable per-occurrence ranges can be bridge-lossy.                |
+| fixed `num_args` with distinct `value_names`               | lossy      | lossy | lossy | lossy | lossy  | lossy      | Bounds work; one collection display name is repeated instead of preserving `<START> <END>`.                                       |
+| `allow_hyphen_values`                                      | yes        | yes   | yes   | yes   | yes    | yes        | Supported on value-taking flags; forwarded positionals use `double_dash = "automatic"`.                                           |
+| `allow_negative_numbers`                                   | no         | no    | no    | no    | no     | no         | The narrower numeric-only policy is not yet represented.                                                                          |
+| `require_equals`                                           | yes        | yes   | yes   | yes   | yes    | yes        | Detached values are refused.                                                                                                      |
+| `value_terminator`                                         | no         | no    | no    | no    | no     | no         | No portable spelling yet.                                                                                                         |
+| `trailing_var_arg` / `last`                                | yes        | yes   | yes   | yes   | yes    | lossy      | `double_dash` carries automatic/required/optional; clap shadow generation still drops automatic mode.                             |
+| `dont_delimit_trailing_values`                             | no         | no    | no    | no    | no     | no         | No portable spelling yet.                                                                                                         |
+| possible-values parser                                     | yes        | yes   | yes   | yes   | yes    | yes        | Use `ValueEnum` or `choices`.                                                                                                     |
+| arbitrary `value_parser` callbacks                         | usage-only | yes   | lossy | yes   | yes    | no         | `FromStr` handles typed conversion and portable `validate` expressions handle declarative rules; Rust callbacks cannot enter KDL. |
+| `ValueHint::{FilePath,DirPath}`                            | yes        | yes   | yes   | yes   | yes    | lossy      | Shell-native path completion is supported directly; `clap_usage` does not yet lower hints into completion nodes.                  |
+| executable and command value hints                         | yes        | yes   | yes   | yes   | yes    | lossy      | Direct usage declarations work; the clap bridge currently reports and drops these hints.                                          |
+| identity and network `ValueHint`s                          | no         | no    | no    | no    | no     | lossy      | Username, hostname, URL, email, and related hints are not yet represented.                                                        |
 
 ## Relationships and command routing
 
-| clap                                                      | usage       | clap → spec | Notes                                                                                                    |
-| --------------------------------------------------------- | ----------- | ----------- | -------------------------------------------------------------------------------------------------------- |
-| `required`, `conflicts_with`, `overrides_with`            | Supported   | Supported   | Environment values participate in post-binding checks.                                                   |
-| `requires`                                                | Usage only  | Unsupported | clap exposes setters but no getter.                                                                      |
-| `requires_if(s)`                                          | Usage only  | Unsupported | Presence and value-conditional forms are supported in usage.                                             |
-| `required_if_eq`, `required_unless_present`               | Partial     | Partial     | Common single-selector forms work; the complete all/any families do not.                                 |
-| `ArgGroup`, required groups, `exclusive`                  | Supported   | Supported   | Positional group members are not represented yet.                                                        |
-| positional conflicts and relationships                    | Unsupported | Unsupported | Spec selectors currently name flags.                                                                     |
-| global flags                                              | Supported   | Supported   | A global may occur once per selected command scope.                                                      |
-| `allow_external_subcommands`                              | Supported   | Supported   | Use an `#[usage(external_subcommand)]` catch-all variant.                                                |
-| `multicall`                                               | Supported   | Supported   | `parse()` routes on the executable basename.                                                             |
-| `no_binary_name`                                          | Supported   | Supported   | `parse_from` is words-only; `try_parse_from` and `parse_from_argv` honor the clap-shaped command policy. |
-| `infer_subcommands`, `infer_long_args`                    | Supported   | Unsupported | Unambiguous prefixes and aliases are inherited; clap exposes no public getter for the bridge.            |
-| `arg_required_else_help` and subcommand/argument policies | Unsupported | Unsupported | No command-policy vocabulary yet.                                                                        |
-| unknown flags                                             | Different   | Different   | Parsing is permissive by default. Opt into clap-like rejection with `#[usage(unknown_flags = "error")]`. |
+| clap surface                                         | derive    | argv      | KDL       | lib       | output | bridge     | Notes                                                                                                      |
+| ---------------------------------------------------- | --------- | --------- | --------- | --------- | ------ | ---------- | ---------------------------------------------------------------------------------------------------------- |
+| flag `required`, `conflicts_with`, `overrides_with`  | yes       | yes       | yes       | yes       | yes    | yes        | Environment values participate in post-binding checks.                                                     |
+| `requires`                                           | yes       | yes       | yes       | yes       | yes    | usage-only | clap exposes setters but no getter.                                                                        |
+| `requires_if(s)`                                     | yes       | yes       | yes       | yes       | yes    | usage-only | Presence and value-conditional forms are supported.                                                        |
+| `required_if_eq`, `required_unless_present` families | lossy     | lossy     | lossy     | lossy     | lossy  | lossy      | Common single-selector forms work; all/any families remain incomplete.                                     |
+| `ArgGroup`, required groups, `exclusive`             | yes       | yes       | yes       | yes       | yes    | lossy      | Flag members work; positional members are not represented.                                                 |
+| positional conflicts and relationships               | no        | no        | no        | no        | no     | no         | Selectors currently name flags only.                                                                       |
+| relationships through `flatten`                      | lossy     | lossy     | yes       | yes       | yes    | lossy      | A declaring type cannot yet validate a selector supplied by a flattened sibling.                           |
+| global flags                                         | yes       | yes       | yes       | yes       | yes    | yes        | Exact lookup and inferred prefixes preserve child shadowing.                                               |
+| `allow_external_subcommands`                         | yes       | yes       | yes       | yes       | yes    | yes        | Use an `#[usage(external_subcommand)]` catch-all variant.                                                  |
+| `multicall`                                          | yes       | yes       | yes       | yes       | yes    | yes        | Process-level entry points route using the executable basename.                                            |
+| `no_binary_name`                                     | yes       | yes       | n/a       | yes       | n/a    | yes        | `parse_from` is words-only; full-argv helpers honor the command policy.                                    |
+| `infer_subcommands`, `infer_long_args`               | yes       | yes       | yes       | yes       | yes    | usage-only | Unambiguous names and aliases are inherited; clap exposes no public getter.                                |
+| `arg_required_else_help`                             | no        | no        | no        | no        | no     | no         | The planned usage behavior tests argv presence rather than environment-bound values.                       |
+| remaining subcommand/argument policies               | no        | no        | no        | no        | no     | no         | `args_conflicts_with_subcommands`, precedence, missing positionals, and self-override are not represented. |
+| unknown flags                                        | different | different | different | different | yes    | different  | usage is permissive by default; `unknown_flags = "error"` opts into strict parsing.                        |
 
 ## Help, version, and generated artifacts
 
-| clap                                              | usage       | clap → spec    | Notes                                                                                                               |
-| ------------------------------------------------- | ----------- | -------------- | ------------------------------------------------------------------------------------------------------------------- |
-| short and long help                               | Supported   | Supported      | The compiled renderer is checked against usage-lib across the jdx CLI fleet.                                        |
-| help headings                                     | Supported   | Supported      | Flags and arguments are grouped by heading.                                                                         |
-| hidden commands, flags, and arguments             | Supported   | Supported      | Granular hides for defaults, env, and possible values are unsupported.                                              |
-| doc comments and long help                        | Supported   | Supported      | First paragraph is short help; the full block is long help.                                                         |
-| `verbatim_doc_comment`                            | Unsupported | Not applicable | Doc comments are normalized.                                                                                        |
-| `help_template`, `next_line_help`, `flatten_help` | Unsupported | Unsupported    | No equivalent yet.                                                                                                  |
-| `term_width`, `max_term_width`                    | Unsupported | Unsupported    | Help wraps using `COLUMNS`.                                                                                         |
-| help styles and color                             | Partial     | Unsupported    | Diagnostics are styled; help output is not.                                                                         |
-| built-in help/version flag control                | Unsupported | Unsupported    | Custom help/version actions and disabling built-ins are not represented.                                            |
-| `--version` / `-V`                                | Supported   | Supported      | Version propagation is supported.                                                                                   |
-| completions                                       | Partial     | Supported      | Self-contained bash, fish, Nushell, PowerShell, and zsh scripts plus runtime overlays are available; Elvish is not. |
-| KDL, markdown, and manpages                       | Supported   | Supported      | Emitted KDL feeds the existing generators without a runtime dependency.                                             |
+| clap surface                                      | derive | argv | KDL | lib | output | bridge | Notes                                                                                        |
+| ------------------------------------------------- | ------ | ---- | --- | --- | ------ | ------ | -------------------------------------------------------------------------------------------- |
+| short/long help and doc comments                  | yes    | yes  | yes | yes | yes    | yes    | First paragraph is short help; the full block is long help.                                  |
+| `help_heading`                                    | yes    | n/a  | yes | yes | yes    | yes    | Flags and arguments are grouped and retain declaration order.                                |
+| whole-entry `hide`                                | yes    | yes  | yes | yes | yes    | yes    | Hidden commands, flags, arguments, and values still parse.                                   |
+| granular hide settings                            | no     | n/a  | no  | no  | no     | lossy  | Defaults, env values, and possible values cannot be hidden independently.                    |
+| `verbatim_doc_comment`                            | no     | n/a  | no  | no  | no     | n/a    | Doc comments are normalized.                                                                 |
+| `rename_all`, `rename_all_env`                    | no     | n/a  | no  | no  | no     | n/a    | Names default to kebab-case; explicit names remain available.                                |
+| `help_template`, `next_line_help`, `flatten_help` | no     | n/a  | no  | no  | no     | no     | No equivalent yet.                                                                           |
+| `term_width`, `max_term_width`                    | no     | n/a  | no  | no  | no     | no     | Help wraps using `COLUMNS`.                                                                  |
+| help styles and color                             | n/a    | n/a  | n/a | n/a | lossy  | no     | Diagnostics are styled; help is not.                                                         |
+| built-in help/version action and flag control     | no     | no   | no  | no  | no     | no     | Custom actions and disabling or relocating built-ins are not represented.                    |
+| `--version` / `-V`, dynamic version               | yes    | yes  | yes | yes | yes    | yes    | Literal and runtime versions propagate through nested commands.                              |
+| completion generation                             | yes    | yes  | yes | yes | lossy  | yes    | Bash, fish, Nushell, PowerShell, and zsh plus runtime overlays are supported; Elvish is not. |
+| KDL, markdown, JSON, and manpages                 | yes    | n/a  | yes | yes | yes    | yes    | Direct derived KDL feeds the existing generators; broader canonicalization remains open.     |
 
 ## Usage extensions
 
-These are not clap compatibility gaps. usage additionally supports `mount`, `restart_token`,
-`default_subcommand`, command and flag `effect`, Nushell completions, and a language-neutral
-conformance corpus. clap cannot express those properties, so a clap-generated spec cannot carry
-them without an overlay.
+These are not clap compatibility gaps. usage additionally supports `mount`,
+`restart_token`, `default_subcommand`, command and flag `effect`, Nushell completions,
+and a language-neutral conformance corpus. clap cannot express those properties, so
+a clap-generated spec cannot carry them without an overlay.
 
-This page is the compatibility baseline, not a claim that every clap builder method is covered.
-When clap is updated, audit new public derive attributes and relevant `Command`, `Arg`, and
-`PossibleValue` methods here before treating the update as migration-neutral.
+This matrix is the compatibility baseline, not a promise to reproduce clap's dynamic
+builder and `ArgMatches` architecture. Setter-only clap state remains explicitly
+**usage-only** until clap exposes a getter or the bridge gains another reliable source.

--- a/docs/rust/index.md
+++ b/docs/rust/index.md
@@ -153,7 +153,8 @@ equivalent yet:
   binds; arbitrary zero-or-one value ranges from clap are not inferred.
 - Rust `value_parser` functions are not portable metadata. Values use `FromStr`; use
   `validate` for a portable expression rule and `validate_error` for its diagnostic.
-- Prefix matching (`infer_long_args`) is suggested in error messages but never accepted.
+- Prefix matching is exact by default. `#[usage(infer_long_args, infer_subcommands)]` opts into
+  unambiguous long-flag and subcommand prefixes, including aliases.
 - On Unix, `PathBuf` and `OsString` fields accept non-UTF-8 argv without changing a byte. String
   fields still report invalid UTF-8 precisely rather than replacing it; on Windows, values that
   cannot be converted safely are reported instead of using an unchecked reconstruction.


### PR DESCRIPTION
## Summary

- audit clap 4.6.6 and clap_derive 4.6.4 across derive, compiled argv, KDL, usage-lib, output, and bridge layers
- distinguish tested support, usage-only metadata, lossy bridge behavior, intentional differences, and unsupported surfaces
- remove the stale documentation claim that inferred prefixes are never accepted
- mark the versioned compatibility-matrix launch gate complete

## Validation

- `prettier --check docs/rust/clap-compatibility.md docs/rust/index.md PLAN.md`
- `git diff --check`

_This pull request was generated by an AI coding agent._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or parser behavior impact.
> 
> **Overview**
> Publishes the **versioned clap compatibility audit** for `clap` 4.6.6 / `clap_derive` 4.6.4 by replacing the old three-column summary with a **six-layer matrix** (`derive`, `argv`, `KDL`, `lib`, `output`, `bridge`) and a normalized legend (**yes**, **usage-only**, **lossy**, **different**, **no**, **n/a**, **non-goal**). Rows now spell out support, bridge gaps, and intentional differences across types, arguments, relationships, help/output, and usage-only extensions.
> 
> **`docs/rust/index.md`** drops the outdated claim that inferred prefixes are never accepted; it now documents opt-in `#[usage(infer_long_args, infer_subcommands)]`.
> 
> **`PLAN.md`** checks off the general clap launch gate item for maintaining this matrix when clap versions change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5a4a7540af2d63554b1391abe19214e77acc595. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->