### PR TITLE
feat(derive): accept clap field spellings

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -639,6 +639,13 @@ feature list is not an exhaustive audit.
       advertised; usage spells those `alias_hidden` and `alias`. The fnox rewrite
       initially made `completion`'s hidden aliases and `exec run` visible because
       a mechanical rename erased that distinction.
+      `Cli` and named `Args` fields now accept `#[arg(...)]` directly, `id` maps
+      losslessly to the usage field identity, `visible_alias` / `visible_aliases`
+      become advertised long forms, and the default `rename_all = "kebab-case"`
+      can remain on the command. Hidden `alias` / `aliases`, non-default casing,
+      `num_args`, and `value_parser` now produce targeted migration diagnostics
+      instead of a generic unknown-option error. Hidden flag alias representation
+      remains before this item can close.
 - [x] **Command-with-arguments completion hints.** `ExecutablePath`,
       `CommandName`, `CommandString`, and `CommandWithArguments` lower to
       shell-native completion types. A forwarded argv vector offers commands for

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -212,6 +212,10 @@
 //!
 //! [Settings]: #settings-and-the-flags-that-set-them
 //!
+//! Named fields accept both `#[usage(...)]` and clap-compatible `#[arg(...)]`.
+//! Lossless clap spellings such as `id` and visible aliases may therefore stay in
+//! place while a CLI changes derives.
+//!
 //! | option | meaning |
 //! | --- | --- |
 //! | `long`, `long = "x"` | a long form, defaulting to the field name |
@@ -234,6 +238,8 @@
 //! | `value_enum` | the words come from the field's type, which derives [`ValueEnum`] |
 //! | `value_hint = usage::ValueHint::FilePath` | ask the shell for paths, executables, or forwarded command argv |
 //! | `arg` | force a field to be positional |
+//! | `id = "name"` | clap-compatible spelling for the field identity / positional name |
+//! | `visible_alias = "other"` | clap-compatible advertised long alias; the plural array spelling also works |
 //! | `overrides = "--other"` | a flag this one displaces, the last given winning |
 //! | `conflicts = "--other"` | an argument this one cannot be given with |
 //! | `requires = "--other"` | a flag that must also be given when this one is |
@@ -330,7 +336,7 @@ mod crate_name;
 mod model;
 
 /// Compile a struct into a parser and a spec. See the [crate docs](crate).
-#[proc_macro_derive(Cli, attributes(usage, command))]
+#[proc_macro_derive(Cli, attributes(usage, command, arg))]
 pub fn derive_cli(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let parsed = model::Cli::from_input(&input)
@@ -349,7 +355,7 @@ pub fn derive_cli(input: TokenStream) -> TokenStream {
 /// tables and metadata as [`Cli`], minus the program-level parts a subcommand does
 /// not have — a name, a version, an entry point — plus the trait a parent uses to
 /// route events into it.
-#[proc_macro_derive(Args, attributes(usage, command))]
+#[proc_macro_derive(Args, attributes(usage, command, arg))]
 pub fn derive_args(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     // `restart_token` and `mount` are per-command and belong here; `default_subcommand` is

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -660,7 +660,7 @@ impl Cli {
                     "group" => cli.groups.push(group_decl(&meta)?),
                     "rename_all" => {
                         let case = string_value(&meta)?;
-                        if !matches!(case.as_str(), "kebab-case" | "kebab") {
+                        if !matches!(CasingStyle::parse(&meta)?, CasingStyle::Kebab) {
                             return Err(syn::Error::new_spanned(
                                 &meta,
                                 format!(
@@ -4036,6 +4036,22 @@ mod tests {
             panic!("long should make this a flag");
         };
         assert_eq!(longs, &["output", "out", "dest"]);
+    }
+
+    #[test]
+    fn clap_kebab_casing_aliases_are_no_ops() {
+        for case in ["kebab", "kebab-case", "kebab_case", "KebabCase"] {
+            cli(&format!(
+                r#"
+                    #[command(rename_all = "{case}")]
+                    struct Ex {{
+                        #[arg(long)]
+                        output_path: Option<String>,
+                    }}
+                "#
+            ))
+            .unwrap_or_else(|err| panic!("{case} should mean kebab case: {err}"));
+        }
     }
 
     #[test]

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -658,6 +658,27 @@ impl Cli {
                     "restart_token" => cli.restart_token = Some(string_value(&meta)?),
                     "mount" => cli.mount = Some(string_value(&meta)?),
                     "group" => cli.groups.push(group_decl(&meta)?),
+                    "rename_all" => {
+                        let case = string_value(&meta)?;
+                        if !matches!(case.as_str(), "kebab-case" | "kebab") {
+                            return Err(syn::Error::new_spanned(
+                                &meta,
+                                format!(
+                                    "usage currently derives kebab-case names; clap's \
+                                     `rename_all = \"{case}\"` needs explicit `name`/`long` \
+                                     declarations for that casing"
+                                ),
+                            ));
+                        }
+                    }
+                    "rename_all_env" => {
+                        return Err(syn::Error::new_spanned(
+                            &meta,
+                            "usage does not infer environment variable names; replace \
+                             clap's `rename_all_env` with explicit `env = \"NAME\"` on \
+                             each field that reads one",
+                        ));
+                    }
                     other => {
                         return Err(syn::Error::new_spanned(
                             path,
@@ -1614,6 +1635,12 @@ impl Field {
                         name = strip_dashes(&string_value(&meta)?);
                         name_given = true;
                     }
+                    // clap calls the parser identity `id`; usage's field name is the
+                    // same stable identity and also supplies the positional placeholder.
+                    "id" => {
+                        name = strip_dashes(&string_value(&meta)?);
+                        name_given = true;
+                    }
                     // Bare `long` takes the field name; `long = "x"` overrides it.
                     // A bare `long` is counted and resolved after the loop, so it
                     // picks up a `name` written later. Explicit ones are stored
@@ -1624,6 +1651,22 @@ impl Field {
                         Meta::Path(_) => bare_longs += 1,
                         _ => longs.push(strip_dashes(&string_value(&meta)?)),
                     },
+                    // clap distinguishes advertised and hidden aliases. Visible aliases
+                    // are losslessly additional long forms in usage.
+                    "visible_alias" | "visible_aliases" => {
+                        longs.extend(
+                            selectors(&meta)?
+                                .into_iter()
+                                .map(|name| strip_dashes(&name)),
+                        );
+                    }
+                    "alias" | "aliases" => {
+                        return Err(syn::Error::new_spanned(
+                            &meta,
+                            "clap's `alias` is hidden from help, while an additional usage \
+                             `long` is visible; hidden flag aliases are not representable yet",
+                        ));
+                    }
                     // Resolved after the loop, for the same reason a bare `long` is:
                     // `short` written before `name = "…"` would otherwise take the
                     // field's first letter rather than the renamed one's.
@@ -1742,6 +1785,22 @@ impl Field {
                     "help_heading" => help_heading = Some(string_value(&meta)?),
                     "effect" => effect = Some(effect_value(&meta)?),
                     "value_name" => value_name = Some(string_value(&meta)?),
+                    "num_args" => {
+                        return Err(syn::Error::new_spanned(
+                            &meta,
+                            "clap's `num_args` maps to the Rust field shape plus \
+                             `var_min`/`var_max`; use `Option<T>`, `Vec<T>`, and those \
+                             bounds to declare the same arity",
+                        ));
+                    }
+                    "value_parser" => {
+                        return Err(syn::Error::new_spanned(
+                            &meta,
+                            "clap's `value_parser` is Rust-only metadata; usage converts \
+                             through the field type's `FromStr`, with `value_enum`, \
+                             `choices`, or portable `validate` for additional constraints",
+                        ));
+                    }
                     // Help text a doc comment cannot carry. A comment's first paragraph is
                     // read the way Rust reads one — line breaks inside it are spaces — so
                     // help whose breaks are meant literally has to be given directly.
@@ -1772,7 +1831,7 @@ impl Field {
                         return Err(syn::Error::new_spanned(
                             path,
                             format!(
-                                "unknown option `{other}`; a field takes `name`, `long`, \
+                                "unknown option `{other}`; a field takes `name`, `id`, `long`, \
                                  `short`, `negate`, `global`, `var`, `variadic`, \
                                  `count`, `hide`, `arg`, `env`, `default`, `default_value_t`, `choices`, `validate`, \
                                  `validate_error`, \
@@ -1783,7 +1842,8 @@ impl Field {
                                  `required_if`, \
                                  `required_unless`, `help_heading`, `value_name`, \
                                  `verbatim_doc_comment`, \
-                                 `required`, `double_dash`, and `skip`"
+                                 `visible_alias`, `visible_aliases`, `required`, \
+                                 `double_dash`, and `skip`"
                             ),
                         ));
                     }
@@ -2641,12 +2701,13 @@ pub fn type_name(ty: &Type) -> String {
     }
 }
 
-/// The native `#[usage(...)]` or clap-compatible `#[command(...)]`
-/// attributes on a command struct.
+/// Native `#[usage(...)]` plus clap-compatible `#[command(...)]` and
+/// `#[arg(...)]` attributes. The latter appears on fields (and inline variants),
+/// while the iterator is shared by all three model readers.
 fn attrs(attrs: &[Attribute]) -> impl Iterator<Item = &Attribute> {
-    attrs
-        .iter()
-        .filter(|a| a.path().is_ident("usage") || a.path().is_ident("command"))
+    attrs.iter().filter(|a| {
+        a.path().is_ident("usage") || a.path().is_ident("command") || a.path().is_ident("arg")
+    })
 }
 
 /// Value metadata accepts clap's `#[value(...)]` spelling so an enum can keep its
@@ -3884,7 +3945,7 @@ impl ValueEnum {
 
 #[cfg(test)]
 mod tests {
-    use super::{Cli, Subcommands, ValueEnum};
+    use super::{Cli, Kind, Subcommands, ValueEnum};
 
     fn cli(body: &str) -> syn::Result<Cli> {
         Cli::from_input(&syn::parse_str::<syn::DeriveInput>(body).expect("valid Rust"))
@@ -3954,6 +4015,58 @@ mod tests {
         // Not a name: `-fx` is two flags bundled, and a bare word is not a selector.
         assert_eq!(named("-fx"), None);
         assert_eq!(named("force"), None);
+    }
+
+    #[test]
+    fn clap_id_and_visible_alias_spellings_are_lossless() {
+        let cli = cli(r#"
+            #[command(rename_all = "kebab-case")]
+            struct Ex {
+                #[arg(id = "output", long, visible_aliases = ["out", "dest"])]
+                path: Option<String>,
+            }
+        "#)
+        .expect("lossless clap spellings should compile");
+
+        let field = &cli.fields[0];
+        assert_eq!(field.name, "output");
+        let Kind::Flag { longs, .. } = &field.kind else {
+            panic!("long should make this a flag");
+        };
+        assert_eq!(longs, &["output", "out", "dest"]);
+    }
+
+    #[test]
+    fn lossy_clap_field_spellings_get_migration_diagnostics() {
+        let hidden = rejection(
+            r#"
+            struct Ex {
+                #[arg(long, alias = "quietly")]
+                output: Option<String>,
+            }
+        "#,
+        );
+        assert!(hidden.contains("hidden flag aliases"), "{hidden}");
+
+        let arity = rejection(
+            r#"
+            struct Ex {
+                #[arg(long, num_args = 2)]
+                pair: Vec<String>,
+            }
+        "#,
+        );
+        assert!(arity.contains("var_min"), "{arity}");
+
+        let parser = rejection(
+            r#"
+            struct Ex {
+                #[arg(long, value_parser = clap::value_parser!(u16))]
+                port: u16,
+            }
+        "#,
+        );
+        assert!(parser.contains("FromStr"), "{parser}");
     }
 
     #[test]

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -1580,6 +1580,7 @@ impl Field {
         let mut name = to_kebab(&ident.to_string());
         let mut name_given = false;
         let mut longs: Vec<String> = Vec::new();
+        let mut visible_long_aliases: Vec<String> = Vec::new();
         let mut bare_longs = 0usize;
         let mut shorts: Vec<char> = Vec::new();
         let mut bare_shorts = 0usize;
@@ -1654,7 +1655,7 @@ impl Field {
                     // clap distinguishes advertised and hidden aliases. Visible aliases
                     // are losslessly additional long forms in usage.
                     "visible_alias" | "visible_aliases" => {
-                        longs.extend(
+                        visible_long_aliases.extend(
                             selectors(&meta)?
                                 .into_iter()
                                 .map(|name| strip_dashes(&name)),
@@ -1860,6 +1861,7 @@ impl Field {
         for _ in 0..bare_longs {
             longs.insert(0, name.clone());
         }
+        longs.extend(visible_long_aliases);
         for _ in 0..bare_shorts {
             let first = name.chars().next().ok_or_else(|| {
                 syn::Error::new(span, "`short` needs a name to take its first letter from")
@@ -4034,6 +4036,24 @@ mod tests {
             panic!("long should make this a flag");
         };
         assert_eq!(longs, &["output", "out", "dest"]);
+    }
+
+    #[test]
+    fn explicit_long_stays_canonical_after_a_visible_alias() {
+        let cli = cli(r#"
+            struct Ex {
+                #[arg(visible_alias = "out", long = "result")]
+                path: Option<String>,
+            }
+        "#)
+        .expect("attribute order must not change the canonical spelling");
+
+        let field = &cli.fields[0];
+        assert_eq!(field.name, "result");
+        let Kind::Flag { longs, .. } = &field.kind else {
+            panic!("long should make this a flag");
+        };
+        assert_eq!(longs, &["result", "out"]);
     }
 
     #[test]

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -68,6 +68,13 @@ struct PositionalRelations {
     stdin: bool,
 }
 
+#[derive(Cli)]
+#[command(bin = "clap-spellings", rename_all = "kebab-case")]
+struct ClapSpellings {
+    #[arg(id = "output", long, visible_aliases = ["out", "dest"])]
+    path: Option<String>,
+}
+
 #[derive(ValueEnum)]
 #[usage(ignore_case)]
 enum Shell {
@@ -535,6 +542,18 @@ fn positional_relationships_parse_and_emit_losslessly() {
         kdl.contains("group \"input\" \"--from-file\" \"VALUE\""),
         "{kdl}"
     );
+}
+
+#[test]
+fn clap_field_ids_and_visible_aliases_need_no_rewrite() {
+    for spelling in ["--output", "--out", "--dest"] {
+        let parsed = ClapSpellings::parse_from(&[OsStr::new(spelling), OsStr::new("file")])
+            .expect("every visible alias should parse");
+        assert_eq!(parsed.path.as_deref(), Some("file"));
+    }
+
+    let kdl = ClapSpellings::to_kdl();
+    assert!(kdl.contains("--output --out --dest"), "{kdl}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- accept `#[arg(...)]` on `Cli` and named `Args` fields
- map clap-compatible `id`, `visible_alias`, and `visible_aliases` metadata losslessly
- accept default kebab-case rename policies and diagnose unsupported clap controls
- document the supported spellings and remaining compatibility gaps

## Validation

- `cargo test --all --all-features`
- `cargo clippy --all --all-features -- -D warnings`

_This PR was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are compile-time derive parsing and diagnostics only; runtime argv behavior is unchanged except where new spellings correctly emit extra long forms in generated tables.
> 
> **Overview**
> **Clap-shaped field attributes during migration.** `Cli` and `Args` now register `arg` on the derive and treat `#[arg(...)]` like `#[usage(...)]` on named fields, so migrations can keep clap annotations on the struct.
> 
> **Lossless mappings:** `id` sets the same field identity as `name`; `visible_alias` / `visible_aliases` add advertised long forms (merged into the flag’s long list). `#[command(rename_all = "kebab-case")]` (and common kebab spellings) is accepted as a no-op when it matches usage’s default casing.
> 
> **Explicit migration errors** replace generic “unknown option” for clap-only concepts: hidden `alias` / `aliases`, non-kebab `rename_all`, `rename_all_env`, `num_args`, and `value_parser` each get a short message pointing at the usage equivalent or limitation (hidden flag aliases still unsupported).
> 
> Docs (`derive` crate docs, `PLAN.md`) and tests (model unit tests plus `ClapSpellings` facade parse/KDL) cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 896f94bcb6c524b4b5faaebb4c54f93d0e6f09be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->