### PR TITLE
feat(derive): support flattened overrides

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -675,15 +675,15 @@ feature list is not an exhaustive audit.
       parent conflicts, requirements, conditional requirements/defaults, and
       required-if/unless rules resolve against the composed command without a
       dynamic command graph or allocation. Flags use every accepted spelling and
-      positionals use their stable field identity. Binding-time `overrides` remains
-      a separate gap below and is rejected when it names a flattened field rather
-      than compiling into a no-op.
-- [ ] **Binding-time overrides across flatten boundaries.** `overrides` is
+      positionals use their stable field identity. Binding-time `overrides` uses
+      the separate composed hook below because it must act while tokens are bound.
+- [x] **Binding-time overrides across flatten boundaries.** `overrides` is
       last-token-wins and therefore cannot be implemented by the post-binding
       presence/value lookup used for conflicts and requirements. Add a composed
-      displacement hook that can reset an opaque flattened partial, preserve the
-      losing field's default/env suppression, and handle either token order before
-      allowing a parent selector to name a flattened target.
+      displacement hook that resets an opaque flattened partial, preserves the
+      losing field's default/env suppression, and handles either token order. A
+      matching event is identified by the flattened type's static tables, so nested
+      flattening composes without allocation or a runtime command graph.
 - [ ] **Flattened help topology.** clap's `next_help_heading` and flattened flag
       groups preserve meaningful sections in aube's long help. usage flattens the
       fields but discards that struct-level heading, so a migration can preserve

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -2456,7 +2456,7 @@ mod tests {
     fn composed_relationship_selectors_count_flag_spellings() {
         static FIRST: Flag = Flag {
             longs: &["first", "alias"],
-            shorts: &[b'f'],
+            shorts: b"f",
             negate: Some("no-first"),
             ..Flag::BOOL
         };

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -2210,6 +2210,18 @@ pub trait CommandArgs: Sized {
         None
     }
 
+    /// Reset the flag named by `selector` after an overriding token wins.
+    fn displace(partial: &mut Self::Partial, selector: &str) -> bool {
+        let _ = (partial, selector);
+        false
+    }
+
+    /// Whether this event binds the flag named by `selector`.
+    fn event_matches(event: &crate::Event<'_, '_, '_>, selector: &str) -> bool {
+        let _ = (event, selector);
+        false
+    }
+
     /// Fill fields in this command from their declared defaults.
     ///
     /// Kept separate from [`CommandArgs::check`] so a parent can preserve defaults in a
@@ -2246,6 +2258,61 @@ pub trait CommandArgs: Sized {
     /// Fallible because a command can require a subcommand of its own, and "none was
     /// given" is only knowable here — at the point where the value has to exist.
     fn build<'t, 'v>(partial: Self::Partial) -> Result<Self, crate::Error<'t, 'v>>;
+}
+
+/// How many flags on `command` accept `selector`.
+///
+/// Used by derives after flattened tables are composed, where neither expansion could validate
+/// a cross-boundary relationship on its own.
+pub const fn flag_selector_count(command: &Command<'_>, selector: &str) -> usize {
+    let selector = selector.as_bytes();
+    let mut count = 0;
+    let mut i = 0;
+    while i < command.flags.len() {
+        let flag = command.flags[i];
+        let mut matched = false;
+        if selector.len() == 2 && selector[0] == b'-' && selector[1] != b'-' {
+            let mut short = 0;
+            while short < flag.shorts.len() {
+                if flag.shorts[short] == selector[1] {
+                    matched = true;
+                }
+                short += 1;
+            }
+        } else if selector.len() > 2 && selector[0] == b'-' && selector[1] == b'-' {
+            let mut long = 0;
+            while long < flag.longs.len() {
+                if long_selector_equal(selector, flag.longs[long].as_bytes()) {
+                    matched = true;
+                }
+                long += 1;
+            }
+            if let Some(negate) = flag.negate {
+                if long_selector_equal(selector, negate.as_bytes()) {
+                    matched = true;
+                }
+            }
+        }
+        if matched {
+            count += 1;
+        }
+        i += 1;
+    }
+    count
+}
+
+const fn long_selector_equal(selector: &[u8], name: &[u8]) -> bool {
+    if selector.len() != name.len() + 2 {
+        return false;
+    }
+    let mut i = 0;
+    while i < name.len() {
+        if selector[i + 2] != name[i] {
+            return false;
+        }
+        i += 1;
+    }
+    true
 }
 
 /// An enum whose variants are a command's subcommands.
@@ -2384,6 +2451,30 @@ pub trait Subcommands: Sized {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn composed_relationship_selectors_count_flag_spellings() {
+        static FIRST: Flag = Flag {
+            longs: &["first", "alias"],
+            shorts: &[b'f'],
+            negate: Some("no-first"),
+            ..Flag::BOOL
+        };
+        static SECOND: Flag = Flag {
+            longs: &["second"],
+            ..Flag::BOOL
+        };
+        static COMMAND: Command = Command {
+            flags: &[&FIRST, &SECOND],
+            ..Command::EMPTY
+        };
+        assert_eq!(flag_selector_count(&COMMAND, "--first"), 1);
+        assert_eq!(flag_selector_count(&COMMAND, "--alias"), 1);
+        assert_eq!(flag_selector_count(&COMMAND, "--no-first"), 1);
+        assert_eq!(flag_selector_count(&COMMAND, "-f"), 1);
+        assert_eq!(flag_selector_count(&COMMAND, "first"), 0);
+        assert_eq!(flag_selector_count(&COMMAND, "--missing"), 0);
+    }
 
     #[test]
     fn quoting_escapes_what_would_break_a_document() {

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -793,7 +793,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
 /// flattened type here: the tables are emitted beside their struct now rather than in a module
 /// above it, so there is no path to rewrite.
 fn flatten_checks(cli: &Cli) -> TokenStream {
-    let checks = cli.fields.iter().filter_map(|f| {
+    let shape_checks = cli.fields.iter().filter_map(|f| {
         let Kind::Flatten { ty } = &f.kind else {
             return None;
         };
@@ -807,7 +807,30 @@ fn flatten_checks(cli: &Cli) -> TokenStream {
             );
         })
     });
-    quote!(#(#checks)*)
+    let command = if cli.composable {
+        quote!(COMMAND)
+    } else {
+        quote!(ROOT)
+    };
+    let relationship_checks = cli.fields.iter().flat_map(|field| {
+        field
+            .overrides
+            .iter()
+            .filter(|selector| cli.field_for_selector(selector).is_none())
+            .map(|selector| {
+                quote! {
+                    const _: () = ::core::assert!(
+                        usage_argv::spec::flag_selector_count(&#command, #selector) == 1,
+                        ::core::concat!(
+                            "`overrides = ",
+                            #selector,
+                            "` must name exactly one flag after flattened groups are composed",
+                        ),
+                    );
+                }
+            })
+    });
+    quote!(#(#shape_checks)* #(#relationship_checks)*)
 }
 
 /// A command's `unknown_flags`, as the table's `Option`.
@@ -1746,28 +1769,49 @@ fn has_negate(field: &Field) -> bool {
 /// clap resolves `--file a --stdin` and `--stdin --file a` the same way whichever side
 /// declared it, and so does usage-lib.
 fn displacements(cli: &Cli, field: &Field) -> Vec<TokenStream> {
-    displaced_by(cli, field)
+    let mut displacements: Vec<TokenStream> = displaced_by(cli, field)
         .into_iter()
-        .map(|other| {
-            let reset = reset_to_default(other);
-            let given = format_ident!("__given_{}", other.ident);
-            let overridden = format_ident!("__overridden_{}", other.ident);
-            let duplicated = rejects_duplicate(other).then(|| {
-                let duplicated = format_ident!("__duplicated_{}", other.ident);
-                quote!(partial.#duplicated = false;)
+        .map(displace_statement)
+        .collect();
+    for selector in field
+        .overrides
+        .iter()
+        .filter(|selector| cli.field_for_selector(selector).is_none())
+    {
+        for flattened in &cli.fields {
+            let Kind::Flatten { ty } = &flattened.kind else {
+                continue;
+            };
+            let ident = &flattened.ident;
+            displacements.push(quote! {
+                let _ = <#ty as usage_argv::spec::CommandArgs>::displace(
+                    &mut partial.#ident,
+                    #selector,
+                );
             });
-            quote! {
-                #reset
-                partial.#given = false;
-                #duplicated
-                // Remembered, not just cleared: without this the environment fallback
-                // would refill the flag that lost and mark it given again, and a
-                // displaced `String` would be reported missing. usage-lib keeps the
-                // same set for the same reason.
-                partial.#overridden = true;
-            }
-        })
-        .collect()
+        }
+    }
+    displacements
+}
+
+fn displace_statement(field: &Field) -> TokenStream {
+    let reset = reset_to_default(field);
+    let given = format_ident!("__given_{}", field.ident);
+    let overridden = format_ident!("__overridden_{}", field.ident);
+    let duplicated = rejects_duplicate(field).then(|| {
+        let duplicated = format_ident!("__duplicated_{}", field.ident);
+        quote!(partial.#duplicated = false;)
+    });
+    quote! {
+        #reset
+        partial.#given = false;
+        #duplicated
+        // Remembered, not just cleared: without this the environment fallback
+        // would refill the flag that lost and mark it given again, and a
+        // displaced `String` would be reported missing. usage-lib keeps the
+        // same set for the same reason.
+        partial.#overridden = true;
+    }
 }
 
 /// The fields a flag displaces, in both directions.
@@ -1790,7 +1834,9 @@ fn displaced_by<'a>(cli: &'a Cli, field: &Field) -> Vec<&'a Field> {
 /// Whether a field is on either side of an `overrides`, and so needs somewhere to
 /// record that it lost.
 fn is_displaceable(cli: &Cli, field: &Field) -> bool {
-    !displaced_by(cli, field).is_empty()
+    (cli.composable && matches!(field.kind, Kind::Flag { .. }))
+        || !field.overrides.is_empty()
+        || !displaced_by(cli, field).is_empty()
 }
 
 fn arg_arm(i: usize, field: &Field) -> TokenStream {
@@ -1940,6 +1986,17 @@ fn presence_methods(cli: &Cli) -> TokenStream {
         ) -> ::std::option::Option<bool> {
             argument_matches(partial, selector, value)
         }
+
+        fn displace(partial: &mut Self::Partial, selector: &str) -> bool {
+            displace(partial, selector)
+        }
+
+        fn event_matches(
+            event: &usage_argv::Event<'_, '_, '_>,
+            selector: &str,
+        ) -> bool {
+            event_matches(event, selector)
+        }
     }
 }
 
@@ -2059,6 +2116,58 @@ fn argument_lookup_functions(cli: &Cli) -> TokenStream {
             }
         })
     });
+    let displace_arms = cli.fields.iter().filter_map(|field| {
+        if !matches!(field.kind, Kind::Flag { .. }) || !is_displaceable(cli, field) {
+            return None;
+        }
+        let selectors = field_selectors(field);
+        let statement = displace_statement(field);
+        Some(quote! {
+            #(#selectors)|* => {
+                #statement
+                return true;
+            }
+        })
+    });
+    let displace_flattened = cli.fields.iter().filter_map(|field| {
+        let Kind::Flatten { ty } = &field.kind else {
+            return None;
+        };
+        let ident = &field.ident;
+        Some(quote! {
+            if <#ty as usage_argv::spec::CommandArgs>::displace(
+                &mut partial.#ident,
+                selector,
+            ) {
+                return true;
+            }
+        })
+    });
+    let flags: Vec<&Field> = cli
+        .fields
+        .iter()
+        .filter(|field| matches!(field.kind, Kind::Flag { .. }))
+        .collect();
+    let event_arms = flags.iter().enumerate().map(|(i, field)| {
+        let key = key_ident("FLAG", Some(i));
+        let table = format_ident!("FLAG_{i}");
+        let selectors = field_selectors(field);
+        quote! {
+            #key if ::core::ptr::eq(*flag, &#table) => {
+                matches!(selector, #(#selectors)|*)
+            }
+        }
+    });
+    let event_flattened = cli.fields.iter().filter_map(|field| {
+        let Kind::Flatten { ty } = &field.kind else {
+            return None;
+        };
+        Some(quote! {
+            if <#ty as usage_argv::spec::CommandArgs>::event_matches(event, selector) {
+                return true;
+            }
+        })
+    });
     quote! {
         #[allow(dead_code)]
         pub fn argument_state(
@@ -2085,6 +2194,32 @@ fn argument_lookup_functions(cli: &Cli) -> TokenStream {
             }
             #(#match_flattened)*
             ::std::option::Option::None
+        }
+
+        pub fn displace(partial: &mut Partial, selector: &str) -> bool {
+            match selector {
+                #(#displace_arms)*
+                _ => {}
+            }
+            #(#displace_flattened)*
+            false
+        }
+
+        pub fn event_matches(
+            event: &usage_argv::Event<'_, '_, '_>,
+            selector: &str,
+        ) -> bool {
+            if let usage_argv::Event::Flag { flag, .. } = event {
+                let matched = match flag.key {
+                    #(#event_arms)*
+                    _ => false,
+                };
+                if matched {
+                    return true;
+                }
+            }
+            #(#event_flattened)*
+            false
         }
     }
 }
@@ -2876,8 +3011,26 @@ fn apply_fn(cli: &Cli) -> TokenStream {
             return None;
         };
         let ident = &f.ident;
+        let reverse_displacements = cli.fields.iter().flat_map(|field| {
+            field
+                .overrides
+                .iter()
+                .filter(|selector| cli.field_for_selector(selector).is_none())
+                .map(move |selector| {
+                    let statement = displace_statement(field);
+                    quote! {
+                        if <#ty as usage_argv::spec::CommandArgs>::event_matches(
+                            event,
+                            #selector,
+                        ) {
+                            #statement
+                        }
+                    }
+                })
+        });
         Some(quote! {
             if <#ty as usage_argv::spec::CommandArgs>::apply(&mut partial.#ident, event) {
+                #(#reverse_displacements)*
                 return true;
             }
         })

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -2196,6 +2196,7 @@ fn argument_lookup_functions(cli: &Cli) -> TokenStream {
             ::std::option::Option::None
         }
 
+        #[allow(dead_code)]
         pub fn displace(partial: &mut Partial, selector: &str) -> bool {
             match selector {
                 #(#displace_arms)*
@@ -2205,6 +2206,7 @@ fn argument_lookup_functions(cli: &Cli) -> TokenStream {
             false
         }
 
+        #[allow(dead_code)]
         pub fn event_matches(
             event: &usage_argv::Event<'_, '_, '_>,
             selector: &str,

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -361,8 +361,10 @@ pub fn derive_args(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     // `restart_token` and `mount` are per-command and belong here; `default_subcommand` is
     // declared once for the whole spec and does not.
-    let parsed = model::Cli::from_input(&input)
-        .and_then(|cli| cli.check_position(&input.ident, false).map(|()| cli));
+    let parsed = model::Cli::from_input(&input).and_then(|mut cli| {
+        cli.composable = true;
+        cli.check_position(&input.ident, false).map(|()| cli)
+    });
     match parsed {
         Ok(cli) => codegen::emit_args(&cli).into(),
         Err(e) => e.to_compile_error().into(),

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -14,6 +14,8 @@ use syn::{Attribute, Data, DeriveInput, Expr, ExprLit, Fields, Lit, Meta, Type};
 /// A CLI, as declared by a struct.
 pub struct Cli {
     pub ident: syn::Ident,
+    /// Whether this argument struct may be flattened into another command.
+    pub composable: bool,
     /// Whether the declaration is a unit struct (`struct Command;`).
     ///
     /// Unit structs have the same empty command metadata as `{}` structs, but
@@ -492,6 +494,7 @@ impl Cli {
         let mut version_needs_spec = false;
         let mut cli = Cli {
             ident: input.ident.clone(),
+            composable: false,
             unit: matches!(&data.fields, Fields::Unit),
             fingerprint: quote::ToTokens::to_token_stream(input).to_string(),
             name: to_kebab(&input.ident.to_string()),
@@ -1189,24 +1192,11 @@ impl Cli {
             ] {
                 for selector in selectors {
                     let Some(target) = self.field_for_selector(selector) else {
-                        // Post-binding relationships can ask an opaque flattened partial
-                        // about presence and values. `overrides` is different: last-one-wins
-                        // has to displace a value while tokens are being bound, and the
-                        // parent cannot mutate an unknown field in another derive expansion.
-                        // Reject it explicitly instead of accepting a declaration that does
-                        // nothing at runtime.
-                        if has_flatten && option != "overrides" {
+                        // Relationship lookup composes through an opaque flattened partial.
+                        // Post-binding rules ask it about presence and values; binding-time
+                        // overrides ask it to displace the selected field as tokens arrive.
+                        if has_flatten {
                             continue;
-                        }
-                        if has_flatten && option == "overrides" {
-                            return Err(syn::Error::new(
-                                field.span,
-                                format!(
-                                    "`overrides = \"{selector}\"` cannot cross a flatten \
-                                     boundary; declare the override inside the flattened Args \
-                                     type"
-                                ),
-                            ));
                         }
                         return Err(syn::Error::new(
                             field.span,
@@ -5696,21 +5686,16 @@ mod tests {
     }
 
     #[test]
-    fn overrides_does_not_silently_cross_a_flatten_boundary() {
-        let err = rejection(
-            r#"
+    fn overrides_may_cross_a_flatten_boundary() {
+        cli(r#"
             struct Ex {
                 #[usage(long, overrides = "--nested")]
                 force: bool,
                 #[usage(flatten)]
                 shared: Shared,
             }
-        "#,
-        );
-        assert!(
-            err.contains("cannot cross a flatten boundary"),
-            "unhelpful message: {err}"
-        );
+        "#)
+        .expect("the composed partial resolves the target while binding");
     }
 
     #[test]

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -82,6 +82,8 @@ struct ClapSpellings {
 
 #[derive(usage::Args)]
 struct FlattenedRelationshipTargets {
+    #[usage(long, default = "nested-default")]
+    nested: Option<String>,
     #[usage(long)]
     frozen: bool,
     #[usage(long, default_if("--preset", "true"))]
@@ -95,6 +97,8 @@ struct FlattenedRelationshipTargets {
 #[derive(Cli)]
 #[usage(bin = "flattened-relationships")]
 struct FlattenedRelationships {
+    #[usage(long, overrides = "--nested")]
+    replace: bool,
     #[usage(long, conflicts = "--frozen")]
     fix: bool,
     #[usage(long, requires = "--key")]
@@ -603,6 +607,24 @@ fn clap_field_ids_and_aliases_need_no_rewrite() {
 
 #[test]
 fn relationships_resolve_targets_inside_flattened_args() {
+    let parent_wins = FlattenedRelationships::parse_from(&[
+        OsStr::new("--nested"),
+        OsStr::new("given"),
+        OsStr::new("--replace"),
+    ])
+    .expect("a parent flag should displace a flattened flag");
+    assert!(parent_wins.replace);
+    assert_eq!(parent_wins.shared.nested.as_deref(), Some("nested-default"));
+
+    let flattened_wins = FlattenedRelationships::parse_from(&[
+        OsStr::new("--replace"),
+        OsStr::new("--nested"),
+        OsStr::new("given"),
+    ])
+    .expect("a later flattened flag should displace its parent peer");
+    assert!(!flattened_wins.replace);
+    assert_eq!(flattened_wins.shared.nested.as_deref(), Some("given"));
+
     assert!(
         FlattenedRelationships::parse_from(&[OsStr::new("--fix"), OsStr::new("--frozen"),])
             .is_err()
@@ -625,17 +647,20 @@ fn relationships_resolve_targets_inside_flattened_args() {
     ])
     .expect("the flattened condition should satisfy the schema relationship");
     assert!(!parsed.fix);
+    assert!(!parsed.replace);
     assert!(!parsed.signed);
     assert!(parsed.mode.is_none());
     assert_eq!(parsed.schema.as_deref(), Some("schema.json"));
     assert_eq!(parsed.output.as_deref(), Some("auto"));
     assert!(parsed.shared.json);
     assert!(!parsed.shared.frozen);
+    assert_eq!(parsed.shared.nested.as_deref(), Some("nested-default"));
     assert!(!parsed.shared.key);
     assert!(!parsed.shared.preset);
 
     let kdl = FlattenedRelationships::to_kdl();
     assert!(kdl.contains("conflicts=\"--frozen\""), "{kdl}");
+    assert!(kdl.contains("overrides=\"--nested\""), "{kdl}");
     assert!(kdl.contains("requires=\"--key\""), "{kdl}");
     assert!(kdl.contains("required_if=\"--json\""), "{kdl}");
 }


### PR DESCRIPTION
## Summary
- compose last-token-wins displacement through flattened `CommandArgs` partials
- preserve defaults, environment suppression, duplicate state, and both token orders
- validate cross-flatten override selectors against the joined static flag table
- close the corresponding 6.x PLAN gap

## Validation
- `cargo test --all --all-features`
- `cargo clippy --all --all-features -- -D warnings`
- targeted facade tests for both token orders

_This PR was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes last-token-wins binding semantics for real override graphs that span flatten boundaries; risk is mitigated by targeted facade tests and const-time selector validation.
> 
> **Overview**
> **Binding-time `overrides` now work when the target flag lives in a flattened `Args` group**, instead of being rejected at derive time.
> 
> `CommandArgs` gains **`displace`** and **`event_matches`** so each expansion can reset a displaced flag and recognize which parse event bound a selector. The derive wires parent `overrides` into flattened partials on bind, and applies **reverse displacement** when a flattened flag wins so parent peers still lose correctly. **`flag_selector_count`** validates at compile time that a cross-flatten override selector names exactly one flag on the composed command table.
> 
> `Args` derives set **`composable`** so displacement metadata is emitted where flattening needs it. Facade tests cover **both token orders** (`--nested` then `--replace`, and the reverse).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d15eab9349fdfc8853872af77031e0cdda49fba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->