### PR TITLE
feat(derive): preserve flattened help headings

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -684,11 +684,12 @@ feature list is not an exhaustive audit.
       losing field's default/env suppression, and handles either token order. A
       matching event is identified by the flattened type's static tables, so nested
       flattening composes without allocation or a runtime command graph.
-- [ ] **Flattened help topology.** clap's `next_help_heading` and flattened flag
-      groups preserve meaningful sections in aube's long help. usage flattens the
-      fields but discards that struct-level heading, so a migration can preserve
-      parsing while silently degrading help. Define heading inheritance for a
-      flattened Args type and cover short/long help ordering in conformance.
+- [x] **Flattened help topology.** clap's `next_help_heading` and flattened flag
+      groups preserve meaningful sections in aube's long help. An Args-level
+      heading now becomes the default for each direct flag or positional while an
+      explicit field heading wins. Because flattened metadata tables retain those
+      headings, both short and long help keep unheaded and named sections in their
+      declaration order.
 - [x] **Facade-owned derive validation.** `usage-rs` exposes portable expression
       validation through its `validation` feature and the derive resolves that
       facade path when an application does not depend on `usage-validation`

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -114,6 +114,8 @@ pub struct Cli {
     /// `after_long_help` on 115 commands, and a page without it is missing what a reader came
     /// for. Nothing derives these from the code, so they are declared.
     pub before_help: Option<proc_macro2::TokenStream>,
+    /// Default help section for fields declared by this argument struct.
+    pub next_help_heading: Option<String>,
     pub before_long_help: Option<proc_macro2::TokenStream>,
     pub after_help: Option<proc_macro2::TokenStream>,
     pub after_long_help: Option<proc_macro2::TokenStream>,
@@ -526,6 +528,7 @@ impl Cli {
             about_attr: None,
             long_about_attr: None,
             before_help: None,
+            next_help_heading: None,
             before_long_help: None,
             after_help: None,
             after_long_help: None,
@@ -633,6 +636,7 @@ impl Cli {
                     "about" => cli.about_attr = Some(metadata_expr(&meta)?),
                     "long_about" => cli.long_about_attr = Some(metadata_expr(&meta)?),
                     "before_help" => cli.before_help = Some(metadata_expr(&meta)?),
+                    "next_help_heading" => cli.next_help_heading = Some(string_value(&meta)?),
                     "before_long_help" => cli.before_long_help = Some(metadata_expr(&meta)?),
                     "after_help" => cli.after_help = Some(metadata_expr(&meta)?),
                     "after_long_help" => cli.after_long_help = Some(metadata_expr(&meta)?),
@@ -691,7 +695,7 @@ impl Cli {
                                 "unknown option `{other}` on a struct; usage::Cli takes \
                                  `name`, `name_spec`, `bin`, `bin_spec`, `version`, `version_spec`, `usage`, `verbatim_doc_comment`, `unknown_flags`, \
                                  `default_subcommand`, `multicall`, `no_binary_name`, `infer_subcommands`, \
-                                 `infer_long_args`, `restart_token`, `mount` and \
+                                 `infer_long_args`, `next_help_heading`, `restart_token`, `mount` and \
                                  `group` here, and the description comes from the doc \
                                  comment"
                             ),
@@ -743,6 +747,15 @@ impl Cli {
 
         for field in data.fields.iter() {
             cli.fields.push(Field::from_field(field)?);
+        }
+        if let Some(heading) = &cli.next_help_heading {
+            for field in &mut cli.fields {
+                if matches!(field.kind, Kind::Flag { .. } | Kind::Arg { .. })
+                    && field.help_heading.is_none()
+                {
+                    field.help_heading = Some(heading.clone());
+                }
+            }
         }
         // A program is called what its binary is called, unless it says otherwise. The name
         // defaults to the struct's, and a struct is usually called `Cli` — so `bin =
@@ -5696,6 +5709,25 @@ mod tests {
             }
         "#)
         .expect("the composed partial resolves the target while binding");
+    }
+
+    #[test]
+    fn next_help_heading_defaults_each_direct_field() {
+        let cli = cli(r#"
+            #[command(next_help_heading = "Network")]
+            struct Ex {
+                #[arg(long)]
+                registry: Option<String>,
+                #[arg(long, help_heading = "Authentication")]
+                token: Option<String>,
+            }
+        "#)
+        .unwrap();
+        assert_eq!(cli.fields[0].help_heading.as_deref(), Some("Network"));
+        assert_eq!(
+            cli.fields[1].help_heading.as_deref(),
+            Some("Authentication")
+        );
     }
 
     #[test]

--- a/docs/rust/clap-compatibility.md
+++ b/docs/rust/clap-compatibility.md
@@ -42,7 +42,7 @@ the Rust declaration, not only from generated KDL, wherever the bridge column sa
 | `Args`                                           | yes      | yes      | yes | yes | yes    | yes    | Dedicated, unit, reused, nested, and flattened Args types are covered.                             |
 | `Subcommand`                                     | yes      | yes      | yes | yes | yes    | yes    | Bare, tuple, inline-struct, nested, boxed, aliases, and hidden aliases are covered.                |
 | `ValueEnum` / `PossibleValue`                    | yes      | yes      | yes | yes | yes    | yes    | Names, help, hide, visible/hidden aliases, cfg, and case-insensitive matching are preserved.       |
-| `flatten`                                        | yes      | yes      | yes | yes | lossy  | yes    | Parsing is composed; flattened `next_help_heading` topology is not preserved.                      |
+| `flatten`                                        | yes      | yes      | yes | yes | yes    | yes    | Parsing and flattened `next_help_heading` topology are composed.                                   |
 | `skip`                                           | yes      | yes      | n/a | n/a | n/a    | n/a    | `#[usage(skip)]` fills the field from `Default` and emits no argument.                             |
 | `from_global`                                    | no       | no       | no  | no  | no     | no     | A global flag is parsed on its declaring root type; copying it into another field is unsupported.  |
 | arbitrary `Command` / `Arg` builder code         | non-goal | non-goal | n/a | yes | yes    | lossy  | `usage-lib` is the dynamic API; the typed derive does not reproduce clap's builder API.            |

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -113,6 +113,29 @@ struct FlattenedRelationships {
     shared: FlattenedRelationshipTargets,
 }
 
+#[derive(usage::Args)]
+#[command(next_help_heading = "Network")]
+#[allow(dead_code)]
+struct HeadedSharedArgs {
+    /// Registry URL.
+    #[arg(long)]
+    registry: Option<String>,
+    /// Authentication token.
+    #[arg(long, help_heading = "Authentication")]
+    token: Option<String>,
+}
+
+#[derive(Cli)]
+#[usage(bin = "headed-flatten")]
+#[allow(dead_code)]
+struct HeadedFlatten {
+    /// Ordinary root flag.
+    #[arg(long)]
+    verbose: bool,
+    #[usage(flatten)]
+    shared: HeadedSharedArgs,
+}
+
 #[derive(ValueEnum)]
 #[usage(ignore_case)]
 enum Shell {
@@ -663,6 +686,33 @@ fn relationships_resolve_targets_inside_flattened_args() {
     assert!(kdl.contains("overrides=\"--nested\""), "{kdl}");
     assert!(kdl.contains("requires=\"--key\""), "{kdl}");
     assert!(kdl.contains("required_if=\"--json\""), "{kdl}");
+}
+
+#[test]
+fn flattened_args_keep_their_help_heading_topology() {
+    let spec = HeadedFlatten::spec();
+    let registry = spec
+        .root
+        .flags
+        .iter()
+        .find(|field| field.flag.name == "registry")
+        .unwrap();
+    let token = spec
+        .root
+        .flags
+        .iter()
+        .find(|field| field.flag.name == "token")
+        .unwrap();
+    assert_eq!(registry.help_heading, Some("Network"));
+    assert_eq!(token.help_heading, Some("Authentication"));
+
+    for long in [false, true] {
+        let help = usage::help::render(spec, spec.root.cmd, long).unwrap();
+        let ordinary = help.find("Flags:").unwrap();
+        let network = help.find("Network:").unwrap();
+        let authentication = help.find("Authentication:").unwrap();
+        assert!(ordinary < network && network < authentication, "{help}");
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- accept clap-compatible `#[command(next_help_heading = "...")]` on derived Args structs
- apply that heading to direct fields while preserving explicit per-field overrides
- cover flattened short/long help section ordering and mark the PLAN gap complete

## Validation

- `cargo test --all --all-features`
- `cargo clippy --all --all-features -- -D warnings`

_This PR was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes derive-time metadata and help rendering only; parsing behavior is unchanged and new tests cover the flattened heading case.
> 
> **Overview**
> Adds clap-compatible **`#[command(next_help_heading = "...")]`** on derived **`Args`** structs. After fields are parsed, that string becomes the default **`help_heading`** for each direct flag or positional that does not already set one; per-field **`help_heading`** still wins.
> 
> Flattened groups keep headings in static metadata, so short and long help render unheaded and named sections in declaration order. The clap compatibility doc no longer marks flatten help topology as lossy, and the PLAN item is checked off. Coverage includes a derive unit test and a facade test that asserts spec metadata and help section ordering for a flattened **`HeadedSharedArgs`** shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9952670243f0e7e3d812eac10d49bece3e0255b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->