### PR TITLE
docs(complete): define 6.x shell support

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -793,11 +793,11 @@ feature list is not an exhaustive audit.
       been removed; the clap integration now recommends the matching
       `clap_usage = "6"`. Concrete workspace and generated-artifact versions remain
       release-plz's responsibility.
-- [ ] **Completion ecosystem coverage.** Decide whether general clap parity includes
-      every shell in `clap_complete` and every `ValueHint`. At minimum, either add
-      Elvish beside bash, fish, PowerShell and zsh or document it as a launch non-goal;
-      keep Nushell as an explicit usage extension rather than accidentally counting
-      it as clap parity.
+- [x] **Completion ecosystem coverage.** The 6.0 clap-parity set is bash, fish,
+      PowerShell and zsh. Nushell remains an explicit usage extension and does not
+      substitute for a clap-supported shell in the compatibility count. Elvish is a
+      documented post-6.0 non-goal rather than a release gate; the compatibility
+      matrix continues to mark completion output lossy for a clap CLI that ships it.
 
 ### The gate
 

--- a/docs/cli/completions.md
+++ b/docs/cli/completions.md
@@ -83,6 +83,18 @@ source ~/.config/nushell/autoload/mycli.nu
 mycli --<TAB>
 ```
 
+PowerShell:
+
+```powershell
+usage g completion powershell mycli -f ./mycli.usage.kdl > ./mycli.ps1
+. ./mycli.ps1
+mycli --<TAB>
+```
+
+The supported 6.x targets are bash, zsh, fish, PowerShell, and Nushell. The
+first four are the clap-compatibility set; Nushell is a usage extension. Elvish
+is not a 6.0 target.
+
 ::: info
 Usage CLI is a runtime dependency for the generated completion scripts. Your users
 will need to have `usage` installed in order for the completion scripts to work.

--- a/docs/rust/completions.md
+++ b/docs/rust/completions.md
@@ -31,6 +31,11 @@ pub fn completion_request(argv: &[OsString]) -> Option<String>;
 
 `Shell` covers `Bash`, `Zsh`, `Fish`, `Nu`, and `PowerShell`.
 
+For the 6.x compatibility contract, bash, fish, PowerShell, and zsh are the
+clap-parity set. Nushell is an additional usage-native target. Elvish is not
+supported in 6.0, so a clap application that currently publishes an Elvish script
+must keep that generator or defer the migration of that artifact.
+
 ## How it works
 
 The installed script calls your binary back at completion time with a hidden


### PR DESCRIPTION
## Summary

- define bash, fish, PowerShell, and zsh as the 6.x clap-parity completion set
- keep Nushell explicitly classified as a usage extension
- document Elvish as a post-6.0 non-goal and close the corresponding PLAN decision

## Validation

- `prettier -c PLAN.md docs/rust/completions.md docs/cli/completions.md`

_This PR was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to PLAN and completion guides; no parser, completion, or API behavior changes.
> 
> **Overview**
> **Documents which shells count for usage 6.x completions** and closes the corresponding PLAN launch-gate item—no runtime or generator changes.
> 
> The **clap-parity set** is bash, fish, PowerShell, and zsh. **Nushell** stays a usage extension and does not fill in for a missing clap shell in compatibility counts. **Elvish** is a post-6.0 non-goal (not a release blocker); clap apps that ship Elvish scripts should keep that generator or defer migrating that artifact.
> 
> `docs/cli/completions.md` gains a **PowerShell** install example and a short note on the supported targets. `docs/rust/completions.md` states the same contract next to the `Shell` enum docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40c39750a898b0c5b434a3ddbc2b97eee5f30f8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->