### PR TITLE
test(derive): cover verbatim doc compatibility

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -510,8 +510,11 @@ Groups are the opposite case: `Command::get_groups`, `ArgGroup::get_args` and
       whole-entry `hide` and nothing finer.
 - [ ] **`help_template`, `next_line_help`, `flatten_help`,
       `subcommand_help_heading`, `subcommand_value_name`.**
-- [ ] **`verbatim_doc_comment`, `rename_all`, `rename_all_env`** — casing is kebab
-      via `to_kebab`, with no opt-out.
+- [x] **`verbatim_doc_comment`.** Commands, fields, and subcommand variants can
+      preserve doc-comment line breaks and indentation instead of flowing the
+      first paragraph. The derive uses the same normalization path for all three.
+- [ ] **`rename_all`, `rename_all_env`.** Casing is kebab via `to_kebab`, with no
+      opt-out beyond explicit names on each declaration.
 - [ ] **Built-in action and flag control** — custom `ArgAction::Help`,
       `HelpShort`, `HelpLong` and `Version`, plus `disable_help_flag`,
       `disable_help_subcommand` and `disable_version_flag`. A clap

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -5731,6 +5731,25 @@ mod tests {
     }
 
     #[test]
+    fn verbatim_doc_comments_preserve_paragraph_shape() {
+        let cli = cli(r#"
+            #[command(verbatim_doc_comment)]
+            /// First line.
+            /// Second line.
+            ///
+            ///     indented example
+            struct Ex {}
+        "#)
+        .unwrap();
+
+        assert_eq!(cli.about.as_deref(), Some("First line.\nSecond line."));
+        assert_eq!(
+            cli.long_about.as_deref(),
+            Some("First line.\nSecond line.\n\n    indented example")
+        );
+    }
+
+    #[test]
     fn required_unless_needs_somewhere_to_put_absent() {
         // A bare `String` is always filled, so the exception could never take effect:
         // the shape says mandatory and the attribute says conditional.

--- a/docs/rust/clap-compatibility.md
+++ b/docs/rust/clap-compatibility.md
@@ -107,7 +107,7 @@ the Rust declaration, not only from generated KDL, wherever the bridge column sa
 | `help_heading`                                    | yes    | n/a  | yes | yes | yes    | yes    | Flags and arguments are grouped and retain declaration order.                                |
 | whole-entry `hide`                                | yes    | yes  | yes | yes | yes    | yes    | Hidden commands, flags, arguments, and values still parse.                                   |
 | granular hide settings                            | no     | n/a  | no  | no  | no     | lossy  | Defaults, env values, and possible values cannot be hidden independently.                    |
-| `verbatim_doc_comment`                            | no     | n/a  | no  | no  | no     | n/a    | Doc comments are normalized.                                                                 |
+| `verbatim_doc_comment`                            | yes    | n/a  | yes | yes | yes    | n/a    | Commands, fields, and variants preserve line breaks and indentation when requested.          |
 | `rename_all`, `rename_all_env`                    | no     | n/a  | no  | no  | no     | n/a    | Names default to kebab-case; explicit names remain available.                                |
 | `help_template`, `next_line_help`, `flatten_help` | no     | n/a  | no  | no  | no     | no     | No equivalent yet.                                                                           |
 | `term_width`, `max_term_width`                    | no     | n/a  | no  | no  | no     | no     | Help wraps using `COLUMNS`.                                                                  |


### PR DESCRIPTION
## Summary

- add a regression test for clap-compatible `verbatim_doc_comment` paragraph and indentation preservation
- mark the already-supported capability accurately in the compatibility matrix and PLAN
- keep `rename_all` and `rename_all_env` tracked separately as open casing work

## Validation

- `cargo test -p usage-derive verbatim_doc_comments_preserve_paragraph_shape`
- `cargo clippy -p usage-derive --all-features --all-targets -- -D warnings`
- `prettier -c PLAN.md docs/rust/clap-compatibility.md`

_This PR was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and documentation only; no runtime or parsing behavior changes.
> 
> **Overview**
> Documents **`verbatim_doc_comment`** as supported (commands, fields, subcommand variants) and splits **`rename_all` / `rename_all_env`** out as still-open casing work in **PLAN.md**.
> 
> Adds **`verbatim_doc_comments_preserve_paragraph_shape`** in `derive/src/model.rs` to lock in clap-style preservation of doc-comment line breaks and indentation for short vs long help.
> 
> Updates **`docs/rust/clap-compatibility.md`** so the matrix row moves from unsupported to supported across derive, KDL, lib, and output paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ecd1722aa9fc0526954a5d6500ff09c396af41e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->