### PR TITLE
feat(parse): support arg required else help

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -489,15 +489,15 @@ Groups are the opposite case: `Command::get_groups`, `ArgGroup::get_args` and
       allocation-free `parse_from` primitive always has that contract, while
       clap-shaped `try_parse_from` includes argv0 by default and honors
       `#[command(no_binary_name)]` by routing directly to the primitive.
-- [ ] **Command parsing policy** — `arg_required_else_help`,
+- [x] **`arg_required_else_help`.** The derive, portable spec, usage-lib,
+      clap bridge, and generated Go front door show short help when the selected
+      command receives no argv tokens. This deliberately reads argv rather than
+      bound values: an environment variable or default may fill a field, but an
+      empty command line still means help.
+- [ ] **Remaining command parsing policy** —
       `args_conflicts_with_subcommands`, `subcommand_negates_reqs`,
-      `subcommand_precedence_over_arg`, `allow_missing_positional`,
-      and `args_override_self`. One design decision is made ahead of the
-      implementation: `arg_required_else_help` reads argv, not bound values.
-      clap counts an environment-supplied value as present (clap#3572), so a
-      user with a configured environment never sees the help — with MISE_*
-      set, that is most mise users. An empty command line means help,
-      whatever the environment holds.
+      `subcommand_precedence_over_arg`, `allow_missing_positional`, and
+      `args_override_self`.
 
 **Help output**
 
@@ -1143,8 +1143,8 @@ in all of them.
 The fleet's workarounds also route around usage, not only clap. These are the
 items the survey adds; the ones already tracked as unchecked boxes under **What
 clap can say that we cannot** (positionals in relationships, the complete
-relationship families, command parsing policy including
-`arg_required_else_help`, fixed arity, the full `ValueHint` vocabulary) are not
+relationship families, remaining command parsing policy, fixed arity, the full
+`ValueHint` vocabulary) are not
 repeated here.
 
 - [ ] **The completer channel is unescaped Tera into `sh -c`.** aube's

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -183,6 +183,12 @@ pub struct Command<'a> {
     /// unmatched word is taken, remaining tokens — including `--help` — are not parsed
     /// as this command's flags.
     pub external_subcommand: bool,
+    /// Show this command's help when no argv token follows its name.
+    ///
+    /// This is clap's `arg_required_else_help`. It deliberately observes argv rather than
+    /// bound values: an environment variable or default may fill a field, but neither means
+    /// the user supplied an argument to this invocation.
+    pub arg_required_else_help: bool,
     /// Accept an unambiguous prefix of a subcommand name or alias.
     /// Inherited by nested commands.
     pub infer_subcommands: bool,
@@ -230,6 +236,7 @@ impl Command<'_> {
         subcommands: &[],
         default_subcommand: ::core::option::Option::None,
         external_subcommand: false,
+        arg_required_else_help: false,
         infer_subcommands: false,
         infer_long_args: false,
         unknown_flags: ::core::option::Option::None,

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -1180,7 +1180,8 @@ impl<'t: 'v, 'a, 'v> Parser<'t, 'a, 'v> {
         self.help_span
     }
 
-    /// Where the command in scope began: the index in `argv` just after its name.
+    /// Where the command in scope began: the index in `argv` just after its name, or at the
+    /// unmatched word routed into a default subcommand.
     ///
     /// `argv[command_start()..]` is what that command was given, which is what a completion
     /// callback needs to be handed its own command's half-parsed struct rather than the root's.
@@ -1575,6 +1576,11 @@ impl<'t: 'v, 'a, 'v> Parser<'t, 'a, 'v> {
                     self.default_taken = true;
                     self.descend(default)?;
                     self.pos -= 1;
+                    // Unlike an explicitly named command, the default command receives the
+                    // word that caused descent. Keep its argv boundary at that word so
+                    // command-level policies and completion callbacks see the same input the
+                    // command parser is about to re-read.
+                    self.cmd_start = self.pos;
                     return Ok(Event::Command(default));
                 }
             }
@@ -2469,6 +2475,21 @@ mod tests {
                     value: b"build"
                 }
             ]
+        );
+    }
+
+    #[test]
+    fn a_default_subcommand_starts_at_the_word_it_receives() {
+        let a = argv(["build"]);
+        let mut parser = Parser::new(&DEFAULTING, &a);
+        assert_eq!(parser.next_event(), Some(Ok(Event::Command(&RUN))));
+        assert_eq!(parser.command_start(), 0);
+        assert_eq!(
+            parser.next_event(),
+            Some(Ok(Event::Arg {
+                arg: &RUN_TASK,
+                value: b"build"
+            }))
         );
     }
 

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -1082,6 +1082,9 @@ impl Spec<'_> {
         if self.root.cmd.external_subcommand {
             writeln!(out, "external_subcommand #true")?;
         }
+        if self.root.cmd.arg_required_else_help {
+            writeln!(out, "arg_required_else_help #true")?;
+        }
         if self.root.cmd.infer_subcommands {
             writeln!(out, "infer_subcommands #true")?;
         }
@@ -1327,6 +1330,9 @@ fn write_command<'a>(
     }
     if meta.cmd.external_subcommand {
         out.push_str(" external_subcommand=#true");
+    }
+    if meta.cmd.arg_required_else_help {
+        out.push_str(" arg_required_else_help=#true");
     }
     if meta.cmd.infer_subcommands {
         out.push_str(" infer_subcommands=#true");

--- a/clap_usage/src/report.rs
+++ b/clap_usage/src/report.rs
@@ -16,7 +16,6 @@ pub enum FidelityFeature {
     DistinctValueNames,
     GranularHide,
     DontDelimitTrailingValues,
-    ArgRequiredElseHelp,
     AllowMissingPositional,
     ArgsConflictWithSubcommands,
     ArgsOverrideSelf,
@@ -91,11 +90,6 @@ fn visit(cmd: &Command, ancestors: &[String], losses: &mut BTreeSet<FidelityLoss
         cmd.is_dont_delimit_trailing_values_set(),
         FidelityFeature::DontDelimitTrailingValues,
         "dont_delimit_trailing_values",
-    );
-    command_loss(
-        cmd.is_arg_required_else_help_set(),
-        FidelityFeature::ArgRequiredElseHelp,
-        "arg_required_else_help",
     );
     command_loss(
         cmd.is_allow_missing_positional_set(),

--- a/clap_usage/tests/fidelity_report.rs
+++ b/clap_usage/tests/fidelity_report.rs
@@ -24,10 +24,10 @@ fn reports_detectable_losses_with_locations() {
         .arg(Arg::new("target"))
         .group(ArgGroup::new("input").args(["config", "target"]));
 
-    let (_spec, report) = spec_with_report(&mut command, "ex");
+    let (spec, report) = spec_with_report(&mut command, "ex");
+    assert!(spec.cmd.arg_required_else_help);
     let features: Vec<_> = report.losses().iter().map(|loss| loss.feature).collect();
     for expected in [
-        FidelityFeature::ArgRequiredElseHelp,
         FidelityFeature::Environment,
         FidelityFeature::ValueHint,
         FidelityFeature::ValueTerminator,

--- a/conformance/src/tables.rs
+++ b/conformance/src/tables.rs
@@ -109,6 +109,7 @@ pub fn build(
         version: false,
         unknown_flags,
         external_subcommand: cmd.external_subcommand,
+        arg_required_else_help: cmd.arg_required_else_help,
         infer_subcommands: cmd.infer_subcommands,
         infer_long_args: cmd.infer_long_args,
         key: 0,

--- a/conformance/tests/arg_required_else_help.rs
+++ b/conformance/tests/arg_required_else_help.rs
@@ -33,6 +33,24 @@ struct Run {
     all: bool,
 }
 
+#[derive(Cli)]
+#[command(bin = "ex", default_subcommand = "run")]
+struct DefaultPolicy {
+    #[command(subcommand)]
+    command: Option<DefaultCommands>,
+}
+
+#[derive(Subcommands)]
+enum DefaultCommands {
+    Run(DefaultRun),
+}
+
+#[derive(Args)]
+#[command(arg_required_else_help)]
+struct DefaultRun {
+    task: String,
+}
+
 #[test]
 fn a_bare_root_asks_for_short_help_even_when_a_default_fills_a_field() {
     let Err(Error::Help { cmd, long }) = RootPolicy::parse_from(&[]) else {
@@ -56,6 +74,15 @@ fn a_nested_command_counts_only_tokens_after_its_own_name() {
     let parsed = NestedPolicy::parse_from(&argv(["run", "--all"])).expect("run has an argument");
     let Commands::Run(run) = parsed.command;
     assert!(run.all);
+}
+
+#[test]
+fn a_default_command_counts_the_unmatched_word_routed_into_it() {
+    let parsed = DefaultPolicy::parse_from(&argv(["build"])).expect("run received argv");
+    let Some(DefaultCommands::Run(run)) = parsed.command else {
+        panic!("the default command should be selected");
+    };
+    assert_eq!(run.task, "build");
 }
 
 #[test]

--- a/conformance/tests/arg_required_else_help.rs
+++ b/conformance/tests/arg_required_else_help.rs
@@ -1,0 +1,71 @@
+use std::ffi::OsStr;
+
+use usage_argv::Error;
+use usage_derive::{Args, Cli, Subcommands};
+
+fn argv<const N: usize>(tokens: [&str; N]) -> [&OsStr; N] {
+    tokens.map(OsStr::new)
+}
+
+#[derive(Cli)]
+#[command(bin = "ex", arg_required_else_help)]
+struct RootPolicy {
+    #[arg(long, default = "defaulted")]
+    value: String,
+}
+
+#[derive(Cli)]
+#[command(bin = "ex")]
+struct NestedPolicy {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommands)]
+enum Commands {
+    Run(Run),
+}
+
+#[derive(Args)]
+#[command(arg_required_else_help)]
+struct Run {
+    #[arg(long)]
+    all: bool,
+}
+
+#[test]
+fn a_bare_root_asks_for_short_help_even_when_a_default_fills_a_field() {
+    let Err(Error::Help { cmd, long }) = RootPolicy::parse_from(&[]) else {
+        panic!("a bare invocation should ask for help");
+    };
+    assert_eq!(cmd.name, "ex");
+    assert!(!long);
+
+    let parsed = RootPolicy::parse_from(&argv(["--value", "given"])).expect("argv was supplied");
+    assert_eq!(parsed.value, "given");
+}
+
+#[test]
+fn a_nested_command_counts_only_tokens_after_its_own_name() {
+    let Err(Error::Help { cmd, long }) = NestedPolicy::parse_from(&argv(["run"])) else {
+        panic!("the command name selects run but is not one of run's arguments");
+    };
+    assert_eq!(cmd.name, "run");
+    assert!(!long);
+
+    let parsed = NestedPolicy::parse_from(&argv(["run", "--all"])).expect("run has an argument");
+    let Commands::Run(run) = parsed.command;
+    assert!(run.all);
+}
+
+#[test]
+fn the_policy_is_emitted_in_the_portable_spec() {
+    let root = RootPolicy::to_kdl();
+    assert!(root.contains("arg_required_else_help #true"), "{root}");
+
+    let nested = NestedPolicy::to_kdl();
+    assert!(
+        nested.contains("cmd \"run\" arg_required_else_help=#true"),
+        "{nested}"
+    );
+}

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -140,6 +140,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
     let default_subcommand = option_str(cli.default_subcommand.as_deref());
     let multicall = cli.multicall;
     let no_binary_name = cli.no_binary_name;
+    let arg_required_else_help = cli.arg_required_else_help;
     let usage = option_str(cli.usage.as_deref());
     let restart_token = option_str(cli.restart_token.as_deref());
     let mount = option_str(cli.mount.as_deref());
@@ -422,6 +423,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
                 unknown_flags: #unknown_flags,
                 infer_subcommands: #infer_subcommands,
                 infer_long_args: #infer_long_args,
+                arg_required_else_help: #arg_required_else_help,
                 name: #name,
                 key: #root_key,
                 flags: #flag_table_ref,
@@ -558,6 +560,15 @@ pub fn emit(cli: &Cli) -> TokenStream {
                     // else into its subcommands, which is why a nested command needs
                     // nothing extra here.
                     apply(partial, &__usage_event);
+                }
+
+                if __usage_parser.command().arg_required_else_help
+                    && __usage_parser.command_start() == argv.len()
+                {
+                    return ::std::result::Result::Err(usage_argv::Error::Help {
+                        cmd: __usage_parser.command(),
+                        long: false,
+                    });
                 }
 
                 ::std::result::Result::Ok(())
@@ -3305,6 +3316,7 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
     let unknown_flags = unknown_flags_tokens(cli);
     let infer_subcommands = cli.infer_subcommands;
     let infer_long_args = cli.infer_long_args;
+    let arg_required_else_help = cli.arg_required_else_help;
     let before_help = option_expr(cli.before_help.as_ref());
     let before_long_help = option_expr(cli.before_long_help.as_ref());
     let after_help = option_expr(cli.after_help.as_ref());
@@ -3416,6 +3428,7 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
                 unknown_flags: #unknown_flags,
                 infer_subcommands: #infer_subcommands,
                 infer_long_args: #infer_long_args,
+                arg_required_else_help: #arg_required_else_help,
                 flags: #flag_table_ref,
                 args: #arg_table_ref,
                 #sub_commands

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -202,6 +202,7 @@
 //! On the struct itself: `bin`, `version`, `about`, `long_about`, `before_help`, `after_help`,
 //! `verbatim_doc_comment` — preserve doc-comment line breaks and whitespace —
 //! `default_subcommand`, `multicall` — argv[0]'s basename selects a subcommand —
+//! `arg_required_else_help` — a selected command with no argv of its own shows short help —
 //! `infer_subcommands`, `infer_long_args` — accept unambiguous prefixes and inherit that
 //! policy through nested commands —
 //! `min_usage_version` — the oldest `usage` that can read the emitted

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -106,6 +106,8 @@ pub struct Cli {
     pub multicall: bool,
     /// Whether clap-shaped `try_parse_from` input omits argv0.
     pub no_binary_name: bool,
+    /// Show help when no argv token follows this command's name.
+    pub arg_required_else_help: bool,
     /// Declared descriptions, for the case a doc comment cannot express: a long form that does
     /// not contain the short one.
     pub about_attr: Option<proc_macro2::TokenStream>,
@@ -525,6 +527,7 @@ impl Cli {
             default_subcommand: None,
             multicall: false,
             no_binary_name: false,
+            arg_required_else_help: false,
             about_attr: None,
             long_about_attr: None,
             before_help: None,
@@ -662,6 +665,7 @@ impl Cli {
                     }
                     "multicall" => cli.multicall = flag_value(&meta)?,
                     "no_binary_name" => cli.no_binary_name = flag_value(&meta)?,
+                    "arg_required_else_help" => cli.arg_required_else_help = flag_value(&meta)?,
                     "infer_subcommands" => cli.infer_subcommands = flag_value(&meta)?,
                     "infer_long_args" => cli.infer_long_args = flag_value(&meta)?,
                     "restart_token" => cli.restart_token = Some(string_value(&meta)?),
@@ -694,7 +698,7 @@ impl Cli {
                             format!(
                                 "unknown option `{other}` on a struct; usage::Cli takes \
                                  `name`, `name_spec`, `bin`, `bin_spec`, `version`, `version_spec`, `usage`, `verbatim_doc_comment`, `unknown_flags`, \
-                                 `default_subcommand`, `multicall`, `no_binary_name`, `infer_subcommands`, \
+                                 `default_subcommand`, `multicall`, `no_binary_name`, `arg_required_else_help`, `infer_subcommands`, \
                                  `infer_long_args`, `next_help_heading`, `restart_token`, `mount` and \
                                  `group` here, and the description comes from the doc \
                                  comment"

--- a/docs/rust/clap-compatibility.md
+++ b/docs/rust/clap-compatibility.md
@@ -95,7 +95,7 @@ the Rust declaration, not only from generated KDL, wherever the bridge column sa
 | `multicall`                                          | yes       | yes       | yes       | yes       | yes    | yes        | Process-level entry points route using the executable basename.                                            |
 | `no_binary_name`                                     | yes       | yes       | n/a       | yes       | n/a    | yes        | `parse_from` is words-only; full-argv helpers honor the command policy.                                    |
 | `infer_subcommands`, `infer_long_args`               | yes       | yes       | yes       | yes       | yes    | usage-only | Unambiguous names and aliases are inherited; clap exposes no public getter.                                |
-| `arg_required_else_help`                             | no        | no        | no        | no        | no     | no         | The planned usage behavior tests argv presence rather than environment-bound values.                       |
+| `arg_required_else_help`                             | yes       | yes       | yes       | yes       | yes    | yes        | Bare selected commands request short help; defaults and environment values do not count as argv.           |
 | remaining subcommand/argument policies               | no        | no        | no        | no        | no     | no         | `args_conflicts_with_subcommands`, precedence, missing positionals, and self-override are not represented. |
 | unknown flags                                        | different | different | different | different | yes    | different  | usage is permissive by default; `unknown_flags = "error"` opts into strict parsing.                        |
 

--- a/docs/rust/migrating-from-clap.md
+++ b/docs/rust/migrating-from-clap.md
@@ -70,6 +70,9 @@ Clap's global prefix settings migrate as
 clap exposes setters but not getters for these settings, a `clap::Command` bridge cannot infer
 that declaration for you.
 
+`#[command(arg_required_else_help)]` migrates in place. usage checks whether the selected
+command received an argv token; environment and default fallbacks do not count.
+
 ## Fields
 
 Common mappings retain their meaning:

--- a/docs/rust/subcommands.md
+++ b/docs/rust/subcommands.md
@@ -51,7 +51,7 @@ struct Install {
   `#[usage(subcommand)]` field, up to a maximum depth of 16.
 
 Variant attributes: `name`, `alias`, `alias_hidden`, `hide`, `effect`, `help`, `long_help`,
-`verbatim_doc_comment`, `external_subcommand`. Aliases declared on the variant and on the `Args`
+`verbatim_doc_comment`, `external_subcommand`, `arg_required_else_help`. Aliases declared on the variant and on the `Args`
 struct are joined.
 
 Two variants wrapping the _same_ struct is a compile error — each command needs its own

--- a/docs/spec/reference/cmd.md
+++ b/docs/spec/reference/cmd.md
@@ -156,6 +156,19 @@ as this command's flags.
 
 See [the argv grammar](../argv.md#external-subcommands).
 
+### Require an argument or show help
+
+`arg_required_else_help` makes a bare invocation request the command's short help:
+
+```kdl
+arg_required_else_help #true             // for the whole CLI
+cmd "run" arg_required_else_help=#true // or one command
+```
+
+The policy observes argv belonging to the selected command. A global flag before a
+subcommand does not count as that subcommand's argument, and values supplied later by an
+environment variable or default do not suppress help.
+
 ### Inferred prefixes
 
 A command can accept an unambiguous prefix of a subcommand name or alias, a long

--- a/go/argv/argv.go
+++ b/go/argv/argv.go
@@ -68,6 +68,8 @@ type Command struct {
 	// DefaultSubcommand still catches first. Once the unmatched word is taken,
 	// remaining tokens — including --help — are not parsed as this command's flags.
 	ExternalSubcommand bool
+	// ArgRequiredElseHelp shows this command's help when no argv token follows its name.
+	ArgRequiredElseHelp bool
 	// InferSubcommands accepts unambiguous prefixes of names and aliases.
 	InferSubcommands bool
 	// InferLongArgs accepts unambiguous prefixes of long flag names and aliases.

--- a/go/argv/parser.go
+++ b/go/argv/parser.go
@@ -162,7 +162,8 @@ func (p *Parser) FlagsStopped() bool { return p.flagsStopped }
 func (p *Parser) SubcommandsPossible() bool { return !p.argFilled && !p.flagsStopped }
 
 // CommandStart is where the command in scope began: the index in argv just after
-// its name. argv[CommandStart():] is what that command was given.
+// its name, or at the unmatched word routed into a default subcommand.
+// argv[CommandStart():] is what that command was given.
 func (p *Parser) CommandStart() int { return p.cmdStart }
 
 // Collecting reports a variadic flag that is still claiming words, if there is
@@ -509,6 +510,9 @@ func (p *Parser) word(token string) bool {
 				return false
 			}
 			p.pos--
+			// A default command receives the word that caused descent. Keep its argv
+			// boundary at that word so policies and completion callbacks see it.
+			p.cmdStart = p.pos
 			return p.emit(Event{Kind: KindCommand, Command: d})
 		}
 

--- a/go/argv/parser_test.go
+++ b/go/argv/parser_test.go
@@ -398,6 +398,14 @@ func TestExternalSubcommand(t *testing.T) {
 	if got := collect(both, "build"); got != "cmd:run arg:task=build" {
 		t.Errorf("default outranks: got %s", got)
 	}
+
+	p := New(both, []string{"build"})
+	if !p.Next() || p.Event().Kind != KindCommand {
+		t.Fatalf("default descent: event=%+v err=%v", p.Event(), p.Err())
+	}
+	if got := p.CommandStart(); got != 0 {
+		t.Errorf("default command starts at received word: got %d, want 0", got)
+	}
 }
 
 func TestInferredPrefixes(t *testing.T) {

--- a/go/internal/shadow/mise/tables.go
+++ b/go/internal/shadow/mise/tables.go
@@ -10477,6 +10477,9 @@ func Parse(args []string) (*Cli, error) {
 	if err := p.Err(); err != nil {
 		return nil, err
 	}
+	if p.Command().ArgRequiredElseHelp && p.CommandStart() == len(args) {
+		return nil, &argv.Error{Code: argv.CodeHelp, Cmd: p.Command()}
+	}
 
 	// Only the commands the words actually selected are judged: a required
 	// flag on a command nobody ran is not missing.

--- a/go/internal/spec/spec.go
+++ b/go/internal/spec/spec.go
@@ -81,25 +81,26 @@ type Completer struct {
 
 // Cmd is one command in the lowered spec.
 type Cmd struct {
-	Name               string      `json:"name"`
-	Hide               bool        `json:"hide"`
-	Help               string      `json:"help"`
-	HelpLong           string      `json:"help_long"`
-	Usage              string      `json:"usage"`
-	BeforeHelp         string      `json:"before_help"`
-	AfterHelp          string      `json:"after_help"`
-	BeforeHelpLong     string      `json:"before_help_long"`
-	AfterHelpLong      string      `json:"after_help_long"`
-	Examples           []Example   `json:"examples"`
-	Aliases            []string    `json:"aliases"`
-	HiddenAliases      []string    `json:"hidden_aliases"`
-	Subcommands        Subcommands `json:"subcommands"`
-	Args               []Arg       `json:"args"`
-	Flags              []Flag      `json:"flags"`
-	UnknownFlags       *string     `json:"unknown_flags"`
-	ExternalSubcommand bool        `json:"external_subcommand"`
-	InferSubcommands   bool        `json:"infer_subcommands"`
-	InferLongArgs      bool        `json:"infer_long_args"`
+	Name                string      `json:"name"`
+	Hide                bool        `json:"hide"`
+	Help                string      `json:"help"`
+	HelpLong            string      `json:"help_long"`
+	Usage               string      `json:"usage"`
+	BeforeHelp          string      `json:"before_help"`
+	AfterHelp           string      `json:"after_help"`
+	BeforeHelpLong      string      `json:"before_help_long"`
+	AfterHelpLong       string      `json:"after_help_long"`
+	Examples            []Example   `json:"examples"`
+	Aliases             []string    `json:"aliases"`
+	HiddenAliases       []string    `json:"hidden_aliases"`
+	Subcommands         Subcommands `json:"subcommands"`
+	Args                []Arg       `json:"args"`
+	Flags               []Flag      `json:"flags"`
+	UnknownFlags        *string     `json:"unknown_flags"`
+	ExternalSubcommand  bool        `json:"external_subcommand"`
+	ArgRequiredElseHelp bool        `json:"arg_required_else_help"`
+	InferSubcommands    bool        `json:"infer_subcommands"`
+	InferLongArgs       bool        `json:"infer_long_args"`
 }
 
 // Subcommands is a command's children, in the order the spec declared them.
@@ -582,12 +583,13 @@ func (b *builder) command(c *Cmd, inherited argv.UnknownFlags, inferSubcommands,
 	}
 
 	out := &argv.Command{
-		Name:               c.Name,
-		UnknownFlags:       unknown,
-		ExternalSubcommand: c.ExternalSubcommand,
-		InferSubcommands:   inferSubcommands || c.InferSubcommands,
-		InferLongArgs:      inferLongArgs || c.InferLongArgs,
-		Key:                b.next(),
+		Name:                c.Name,
+		UnknownFlags:        unknown,
+		ExternalSubcommand:  c.ExternalSubcommand,
+		ArgRequiredElseHelp: c.ArgRequiredElseHelp,
+		InferSubcommands:    inferSubcommands || c.InferSubcommands,
+		InferLongArgs:       inferLongArgs || c.InferLongArgs,
+		Key:                 b.next(),
 	}
 	examples := make([]argv.Example, 0, len(c.Examples))
 	for _, e := range c.Examples {

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -482,6 +482,7 @@ impl From<&crate::SpecCommand> for SpecCommand {
             // How a command line is read, which no rendered page shows.
             unknown_flags: _,
             external_subcommand: _,
+            arg_required_else_help: _,
             // Rendered above, or deliberately absent from the docs model.
             args: _,
             flags: _,

--- a/lib/src/go/mod.rs
+++ b/lib/src/go/mod.rs
@@ -374,6 +374,9 @@ impl<'a> Emitter<'a> {
             if e.cmd.external_subcommand {
                 lines.push(Line::Field("ExternalSubcommand".into(), "true".into()));
             }
+            if e.cmd.arg_required_else_help {
+                lines.push(Line::Field("ArgRequiredElseHelp".into(), "true".into()));
+            }
             if effective_command_setting(commands, i, |cmd| cmd.infer_subcommands) {
                 lines.push(Line::Field("InferSubcommands".into(), "true".into()));
             }
@@ -1759,6 +1762,25 @@ cmd "exec" external_subcommand=#true
             !block("cmdInstall").contains("ExternalSubcommand"),
             "a command that does not declare it should not carry it:\n{}",
             block("cmdInstall")
+        );
+    }
+
+    #[test]
+    fn arg_required_else_help_reaches_the_table_and_typed_front_door() {
+        let out = go(r#"
+name "ex"
+bin "ex"
+cmd "run" arg_required_else_help=#true {
+    flag "--all"
+}
+"#);
+        assert!(
+            out.contains("ArgRequiredElseHelp: true"),
+            "the command table should carry the policy:\n{out}"
+        );
+        assert!(
+            out.contains("p.Command().ArgRequiredElseHelp && p.CommandStart() == len(args)"),
+            "the typed parser should enforce it before fallbacks:\n{out}"
         );
     }
 

--- a/lib/src/go/snapshots/usage__go__tests__a_default_subcommand_points_into_the_tree.snap
+++ b/lib/src/go/snapshots/usage__go__tests__a_default_subcommand_points_into_the_tree.snap
@@ -140,6 +140,9 @@ func Parse(args []string) (*Cli, error) {
 	if err := p.Err(); err != nil {
 		return nil, err
 	}
+	if p.Command().ArgRequiredElseHelp && p.CommandStart() == len(args) {
+		return nil, &argv.Error{Code: argv.CodeHelp, Cmd: p.Command()}
+	}
 
 	// Only the commands the words actually selected are judged: a required
 	// flag on a command nobody ran is not missing.

--- a/lib/src/go/snapshots/usage__go__tests__a_whole_cli.snap
+++ b/lib/src/go/snapshots/usage__go__tests__a_whole_cli.snap
@@ -239,6 +239,9 @@ func Parse(args []string) (*Cli, error) {
 	if err := p.Err(); err != nil {
 		return nil, err
 	}
+	if p.Command().ArgRequiredElseHelp && p.CommandStart() == len(args) {
+		return nil, &argv.Error{Code: argv.CodeHelp, Cmd: p.Command()}
+	}
 
 	// Only the commands the words actually selected are judged: a required
 	// flag on a command nobody ran is not missing.

--- a/lib/src/go/snapshots/usage__go__tests__colliding_names_get_distinct_identifiers.snap
+++ b/lib/src/go/snapshots/usage__go__tests__colliding_names_get_distinct_identifiers.snap
@@ -176,6 +176,9 @@ func Parse(args []string) (*Cli, error) {
 	if err := p.Err(); err != nil {
 		return nil, err
 	}
+	if p.Command().ArgRequiredElseHelp && p.CommandStart() == len(args) {
+		return nil, &argv.Error{Code: argv.CodeHelp, Cmd: p.Command()}
+	}
 
 	// Only the commands the words actually selected are judged: a required
 	// flag on a command nobody ran is not missing.

--- a/lib/src/go/snapshots/usage__go__tests__unknown_flags_are_inherited_and_overridable.snap
+++ b/lib/src/go/snapshots/usage__go__tests__unknown_flags_are_inherited_and_overridable.snap
@@ -180,6 +180,9 @@ func Parse(args []string) (*Cli, error) {
 	if err := p.Err(); err != nil {
 		return nil, err
 	}
+	if p.Command().ArgRequiredElseHelp && p.CommandStart() == len(args) {
+		return nil, &argv.Error{Code: argv.CodeHelp, Cmd: p.Command()}
+	}
 
 	// Only the commands the words actually selected are judged: a required
 	// flag on a command nobody ran is not missing.

--- a/lib/src/go/structs.rs
+++ b/lib/src/go/structs.rs
@@ -231,6 +231,8 @@ fn parse_fn(out: &mut String, commands: &[Emitted], assigned: &Fields) {
         out,
         "\t\t\t}}\n\t\t}}\n\t}}\n\
          \tif err := p.Err(); err != nil {{\n\t\treturn nil, err\n\t}}\n\
+         \tif p.Command().ArgRequiredElseHelp && p.CommandStart() == len(args) {{\n\
+         \t\treturn nil, &argv.Error{{Code: argv.CodeHelp, Cmd: p.Command()}}\n\t}}\n\
          \n\t// Only the commands the words actually selected are judged: a required\n\
          \t// flag on a command nobody ran is not missing.\n\
          \tvar scope []uint64\n\

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -768,6 +768,10 @@ fn parse_partial_with_env(
             }
         }
     }
+    // The policy observes the selected command's own argv, not values eventually filled from
+    // env/default. Start at the root, then reset on every explicit descent. A default
+    // subcommand receives the unmatched word that selected it, so it is necessarily non-bare.
+    let mut command_has_argv = !input.is_empty();
 
     let mut out = ParseOutput {
         cmd: spec.cmd.clone(),
@@ -896,6 +900,7 @@ fn parse_partial_with_env(
             );
             // Remove subcommand from input
             input.remove(idx);
+            command_has_argv = idx < input.len();
             out.cmds.push(subcommand.clone());
             out.cmd = subcommand.clone();
             // A descent already ran the new command's mounts, above.
@@ -987,6 +992,7 @@ fn parse_partial_with_env(
                         );
                         out.cmds.push(subcommand.clone());
                         out.cmd = subcommand.clone();
+                        command_has_argv = true;
                         prefix_flags.clear();
                         // This descent ran the new command's mounts, so lazy
                         // discovery must not run them a second time.
@@ -1573,6 +1579,10 @@ fn parse_partial_with_env(
                 && !overridden_flags.contains(&flag.name)
                 && (flag_was_parsed(flag) || flag_has_env(flag, custom_env))
         });
+
+    if out.cmd.arg_required_else_help && !command_has_argv {
+        out.errors.push(render_help_err(spec, &out.cmd, false));
+    }
 
     // A command that says it needs a subcommand, given none. Checked on `out.cmd` and nowhere
     // else, because `out.cmd` *is* the command the words reached: had a subcommand been taken,
@@ -6655,6 +6665,31 @@ cmd "open" {
         // this is the half that keeps the check from being "any command with children".
         parse(&spec, &words(&["ex", "open"])).unwrap();
         parse(&spec, &words(&["ex", "open", "sub"])).unwrap();
+    }
+
+    #[test]
+    fn arg_required_else_help_observes_the_selected_commands_argv() {
+        let spec: Spec = r#"
+name "ex"
+bin "ex"
+flag "--verbose" global=#true
+cmd "run" arg_required_else_help=#true {
+    flag "--all"
+}
+"#
+        .parse()
+        .unwrap();
+        let words = |items: &[&str]| items.iter().map(|s| (*s).to_string()).collect::<Vec<_>>();
+
+        let err = parse(&spec, &words(&["ex", "run"])).unwrap_err();
+        assert!(err.to_string().contains("Usage: ex run"), "{err}");
+
+        // A global before the command belongs to the ancestor. It selected `run`, but did not
+        // give `run` an argument of its own.
+        let err = parse(&spec, &words(&["ex", "--verbose", "run"])).unwrap_err();
+        assert!(err.to_string().contains("Usage: ex run"), "{err}");
+
+        parse(&spec, &words(&["ex", "run", "--all"])).expect("run received an argv token");
     }
 
     #[test]

--- a/lib/src/spec/cmd.rs
+++ b/lib/src/spec/cmd.rs
@@ -102,6 +102,9 @@ pub struct SpecCommand {
     /// as this command's flags.
     #[serde(skip_serializing_if = "is_false")]
     pub external_subcommand: bool,
+    /// Whether a bare invocation of this command shows its help.
+    #[serde(skip_serializing_if = "is_false")]
+    pub arg_required_else_help: bool,
     /// Accept unambiguous prefixes of subcommand names and aliases, inherited by children.
     #[serde(skip_serializing_if = "is_false")]
     pub infer_subcommands: bool,
@@ -177,6 +180,7 @@ impl Default for SpecCommand {
             flags_from_mount: false,
             subcommand_required: false,
             external_subcommand: false,
+            arg_required_else_help: false,
             infer_subcommands: false,
             infer_long_args: false,
             restart_token: None,
@@ -285,6 +289,7 @@ impl SpecCommand {
                 "after_help_md" => cmd.after_help_md = Some(v.ensure_string()?),
                 "subcommand_required" => cmd.subcommand_required = v.ensure_bool()?,
                 "external_subcommand" => cmd.external_subcommand = v.ensure_bool()?,
+                "arg_required_else_help" => cmd.arg_required_else_help = v.ensure_bool()?,
                 "infer_subcommands" => cmd.infer_subcommands = v.ensure_bool()?,
                 "infer_long_args" => cmd.infer_long_args = v.ensure_bool()?,
                 "hide" => cmd.hide = v.ensure_bool()?,
@@ -411,6 +416,10 @@ impl SpecCommand {
                 "external_subcommand" => {
                     cmd.external_subcommand = child.ensure_arg_len(1..=1)?.arg(0)?.ensure_bool()?
                 }
+                "arg_required_else_help" => {
+                    cmd.arg_required_else_help =
+                        child.ensure_arg_len(1..=1)?.arg(0)?.ensure_bool()?
+                }
                 "infer_subcommands" => {
                     cmd.infer_subcommands = child.ensure_arg_len(1..=1)?.arg(0)?.ensure_bool()?
                 }
@@ -527,6 +536,7 @@ impl SpecCommand {
             hide,
             subcommand_required,
             external_subcommand,
+            arg_required_else_help,
             infer_subcommands,
             infer_long_args,
             restart_token,
@@ -602,6 +612,7 @@ impl SpecCommand {
         self.hide = hide;
         self.subcommand_required = subcommand_required;
         self.external_subcommand = external_subcommand;
+        self.arg_required_else_help = arg_required_else_help;
         self.infer_subcommands |= infer_subcommands;
         self.infer_long_args |= infer_long_args;
         if effect.is_some() {
@@ -737,6 +748,7 @@ impl From<&SpecCommand> for KdlNode {
             hide,
             subcommand_required,
             external_subcommand,
+            arg_required_else_help,
             infer_subcommands,
             infer_long_args,
             restart_token,
@@ -780,6 +792,10 @@ impl From<&SpecCommand> for KdlNode {
         if *external_subcommand {
             node.entries_mut()
                 .push(KdlEntry::new_prop("external_subcommand", true));
+        }
+        if *arg_required_else_help {
+            node.entries_mut()
+                .push(KdlEntry::new_prop("arg_required_else_help", true));
         }
         if *infer_subcommands {
             node.entries_mut()
@@ -1032,6 +1048,7 @@ impl From<&clap::Command> for SpecCommand {
             spec.groups.push(spec_group);
         }
         spec.subcommand_required = cmd.is_subcommand_required_set();
+        spec.arg_required_else_help = cmd.is_arg_required_else_help_set();
         for subcmd in cmd.get_subcommands() {
             let mut scmd: SpecCommand = subcmd.into();
             scmd.name = subcmd.get_name().to_string();

--- a/lib/src/spec/mod.rs
+++ b/lib/src/spec/mod.rs
@@ -298,6 +298,9 @@ impl Spec {
                 "external_subcommand" => {
                     schema.cmd.external_subcommand = node.arg(0)?.ensure_bool()?;
                 }
+                "arg_required_else_help" => {
+                    schema.cmd.arg_required_else_help = node.arg(0)?.ensure_bool()?;
+                }
                 "infer_subcommands" => {
                     schema.cmd.infer_subcommands = node.arg(0)?.ensure_bool()?;
                 }
@@ -579,6 +582,11 @@ impl Display for Spec {
         }
         if self.cmd.external_subcommand {
             let mut node = KdlNode::new("external_subcommand");
+            node.push(KdlEntry::new(true));
+            nodes.push(node);
+        }
+        if self.cmd.arg_required_else_help {
+            let mut node = KdlNode::new("arg_required_else_help");
             node.push(KdlEntry::new(true));
             nodes.push(node);
         }


### PR DESCRIPTION
Implements clap-compatible `arg_required_else_help` across the Rust derive, portable KDL, usage-lib, clap bridge, and generated Go parser.

The policy intentionally observes argv belonging to the selected command; defaults and environment fallbacks do not suppress help.

Validation:
- `cargo test --all --all-features`
- `cargo clippy --all --all-features --all-targets -- -D warnings`
- `(cd go && go test ./...)`

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI parsing and help behavior on an opt-in flag across Rust, Go, and spec consumers; mistakes in `command_start` or argv scoping could show help when parsing should succeed or vice versa, though coverage targets those paths.
> 
> **Overview**
> Adds **clap-compatible `arg_required_else_help`**: when a command is selected but has no argv tokens of its own, parsers return **short help** instead of succeeding on defaults or environment.
> 
> The flag is wired through **`usage_argv::Command`**, KDL/spec models, **`#[command(arg_required_else_help)]` / `#[usage(...)]`**, usage-lib parsing, generated Go tables, and the clap bridge (`is_arg_required_else_help_set`). Docs and the compatibility matrix mark the feature as supported; **`clap_usage` no longer reports it as a fidelity loss**.
> 
> **Semantics are argv-only** — a default or `env` may fill a field, but an empty command line still triggers help. Nested commands only count tokens after their name; globals on an ancestor do not satisfy a child’s policy.
> 
> **Default subcommands:** `command_start` now begins at the **unmatched word** routed into the default command (Rust and Go), so completion and this policy see the same input the default command re-reads.
> 
> Conformance and integration tests cover root/nested/default-subcommand cases and spec emission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b2d0907f97cf609770de6aae11a7ef8abc92960. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->