### PR TITLE
feat(docs): support help width controls

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -531,8 +531,10 @@ Groups are the opposite case: `Command::get_groups`, `ArgGroup::get_args` and
 - [x] **Visible aliases in generated references.** Markdown and JSON reference
       models list every visible short and long spelling while interactive help
       retains its compact aligned first-pair layout; hidden aliases stay hidden.
-- [ ] **`term_width` / `max_term_width`** — we wrap to `COLUMNS` and take no
-      instruction about it.
+- [x] **`term_width` / `max_term_width`.** Typed and KDL commands can fix help at
+      a width or cap the detected `COLUMNS` width; zero disables wrapping or the
+      cap, and a fixed width takes precedence. clap does not expose getters for
+      these builder settings, so the clap-to-spec bridge cannot recover them.
 - [x] **The granular hides** — `hide_default_value`, `hide_env`, `hide_env_values`,
       `hide_possible_values`, `hide_short_help`, and `hide_long_help` round-trip
       through KDL and the clap bridge and are honored by Rust and Go help output.

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -918,15 +918,23 @@ fn page_examples<'a>(spec: &Spec<'a>, meta: &CommandMeta<'a>) -> &'a [Example<'a
     }
 }
 
-/// The width help is wrapped to, from `COLUMNS`.
+/// The width help is wrapped to.
 ///
-/// usage-lib reads the same variable and falls back to the same 80, so the two agree about
-/// where a line ends whatever the terminal says.
-fn terminal_width() -> usize {
-    std::env::var("COLUMNS")
+/// A fixed width wins over terminal detection and the maximum, as in clap. Zero means
+/// unbounded for either setting. Without a declaration both implementations read `COLUMNS`
+/// and fall back to 80.
+fn terminal_width(meta: &CommandMeta<'_>) -> usize {
+    if let Some(width) = meta.term_width {
+        return if width == 0 { usize::MAX } else { width };
+    }
+    let detected = std::env::var("COLUMNS")
         .ok()
         .and_then(|s| s.parse().ok())
-        .unwrap_or(80)
+        .unwrap_or(80);
+    match meta.max_term_width {
+        Some(0) | None => detected,
+        Some(max) => detected.min(max),
+    }
 }
 
 /// Everything `--help` prints.
@@ -949,7 +957,7 @@ pub fn long_help(spec: &Spec<'_>, path: &[&str], chain: &[&CommandMeta<'_>]) -> 
         .into_iter()
         .filter(|(flag, _)| !flag.hide_long_help)
         .collect();
-    let width = terminal_width();
+    let width = terminal_width(meta);
     let mut out = String::new();
 
     if let Some(before) = meta

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -712,6 +712,10 @@ pub struct CommandMeta<'a> {
     pub subcommand_help_heading: Option<&'a str>,
     /// Placeholder used for a subcommand in the usage synopsis.
     pub subcommand_value_name: Option<&'a str>,
+    /// Fixed help width. Zero disables wrapping.
+    pub term_width: Option<usize>,
+    /// Maximum detected terminal width when `term_width` is unset. Zero disables the cap.
+    pub max_term_width: Option<usize>,
     /// Whether later single-valued occurrences replace earlier ones.
     pub args_override_self: bool,
     /// Text printed above the usage line, and below everything else.
@@ -751,6 +755,8 @@ impl CommandMeta<'_> {
         subcommand_required: false,
         subcommand_help_heading: None,
         subcommand_value_name: None,
+        term_width: None,
+        max_term_width: None,
         args_override_self: true,
         before_help: None,
         before_long_help: None,
@@ -1182,6 +1188,12 @@ impl Spec<'_> {
         if let Some(name) = self.root.subcommand_value_name {
             prop(out, "subcommand_value_name", name)?;
         }
+        if let Some(width) = self.root.term_width {
+            writeln!(out, "term_width {width}")?;
+        }
+        if let Some(width) = self.root.max_term_width {
+            writeln!(out, "max_term_width {width}")?;
+        }
         // A `complete` block for every completer this CLI declares, naming the command that
         // asks the binary itself. Written rather than declared, so there is one place a
         // completer is said to exist: the Rust function. Everything that reads a spec — the
@@ -1424,6 +1436,12 @@ fn write_command<'a>(
     }
     if let Some(name) = meta.subcommand_value_name {
         write!(out, " subcommand_value_name={}", quoted(name))?;
+    }
+    if let Some(width) = meta.term_width {
+        write!(out, " term_width={width}")?;
+    }
+    if let Some(width) = meta.max_term_width {
+        write!(out, " max_term_width={width}")?;
     }
     if meta.cmd.external_subcommand {
         out.push_str(" external_subcommand=#true");

--- a/conformance/src/tables.rs
+++ b/conformance/src/tables.rs
@@ -151,6 +151,8 @@ pub fn build(
         subcommand_required: cmd.subcommand_required,
         subcommand_help_heading: opt(&cmd.subcommand_help_heading),
         subcommand_value_name: opt(&cmd.subcommand_value_name),
+        term_width: cmd.term_width,
+        max_term_width: cmd.max_term_width,
         args_override_self: cmd.args_override_self,
         before_help: opt(&cmd.before_help),
         before_long_help: opt(&cmd.before_help_long),

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -147,6 +147,8 @@ pub fn emit(cli: &Cli) -> TokenStream {
     let allow_missing_positional = cli.allow_missing_positional;
     let subcommand_help_heading = option_str(cli.subcommand_help_heading.as_deref());
     let subcommand_value_name = option_str(cli.subcommand_value_name.as_deref());
+    let term_width = option_usize(cli.term_width);
+    let max_term_width = option_usize(cli.max_term_width);
     let usage = option_str(cli.usage.as_deref());
     let restart_token = option_str(cli.restart_token.as_deref());
     let mount = option_str(cli.mount.as_deref());
@@ -465,6 +467,8 @@ pub fn emit(cli: &Cli) -> TokenStream {
                 subcommand_required: #subcommand_required,
                 subcommand_help_heading: #subcommand_help_heading,
                 subcommand_value_name: #subcommand_value_name,
+                term_width: #term_width,
+                max_term_width: #max_term_width,
                 args_override_self: #args_override_self,
                 mount: #mount,
                 before_help: #before_help,
@@ -2053,6 +2057,13 @@ fn option_expr(value: Option<&TokenStream>) -> TokenStream {
     }
 }
 
+fn option_usize(value: Option<usize>) -> TokenStream {
+    match value {
+        Some(v) => quote!(::std::option::Option::Some(#v)),
+        None => quote!(::std::option::Option::None),
+    }
+}
+
 /// The presence summaries a parent needs to enforce exclusivity across a flattened
 /// `CommandArgs` boundary.
 fn presence_methods(cli: &Cli) -> TokenStream {
@@ -3551,6 +3562,8 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
     });
     let subcommand_help_heading = option_str(cli.subcommand_help_heading.as_deref());
     let subcommand_value_name = option_str(cli.subcommand_value_name.as_deref());
+    let term_width = option_usize(cli.term_width);
+    let max_term_width = option_usize(cli.max_term_width);
     let unknown_flags = unknown_flags_tokens(cli);
     let arg_required_else_help = cli.arg_required_else_help;
     let dont_delimit_trailing_values = cli.dont_delimit_trailing_values;
@@ -3697,6 +3710,8 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
                 subcommand_required: #subcommand_required,
                 subcommand_help_heading: #subcommand_help_heading,
                 subcommand_value_name: #subcommand_value_name,
+                term_width: #term_width,
+                max_term_width: #max_term_width,
                 args_override_self: #args_override_self,
                 mount: #mount,
                 before_help: #before_help,

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -117,6 +117,8 @@ pub struct Cli {
     pub allow_missing_positional: bool,
     pub subcommand_help_heading: Option<String>,
     pub subcommand_value_name: Option<String>,
+    pub term_width: Option<usize>,
+    pub max_term_width: Option<usize>,
     /// Declared descriptions, for the case a doc comment cannot express: a long form that does
     /// not contain the short one.
     pub about_attr: Option<proc_macro2::TokenStream>,
@@ -573,6 +575,8 @@ impl Cli {
             allow_missing_positional: false,
             subcommand_help_heading: None,
             subcommand_value_name: None,
+            term_width: None,
+            max_term_width: None,
             about_attr: None,
             long_about_attr: None,
             before_help: None,
@@ -729,6 +733,8 @@ impl Cli {
                     "subcommand_value_name" => {
                         cli.subcommand_value_name = Some(string_value(&meta)?)
                     }
+                    "term_width" => cli.term_width = Some(int_value(&meta)?),
+                    "max_term_width" => cli.max_term_width = Some(int_value(&meta)?),
                     "restart_token" => cli.restart_token = Some(string_value(&meta)?),
                     "mount" => cli.mount = Some(string_value(&meta)?),
                     "group" => cli.groups.push(group_decl(&meta)?),
@@ -741,7 +747,7 @@ impl Cli {
                                 "unknown option `{other}` on a struct; usage::Cli takes \
                                  `name`, `name_spec`, `bin`, `bin_spec`, `version`, `version_spec`, `usage`, `verbatim_doc_comment`, `unknown_flags`, \
                                  `default_subcommand`, `multicall`, `no_binary_name`, `arg_required_else_help`, `dont_delimit_trailing_values`, `args_override_self`, `subcommand_negates_reqs`, `args_conflicts_with_subcommands`, `subcommand_precedence_over_arg`, `allow_missing_positional`, \
-                                 `next_help_heading`, `subcommand_help_heading`, \
+                                 `next_help_heading`, `subcommand_help_heading`, `term_width`, `max_term_width`, \
                                  `subcommand_value_name`, `restart_token`, `mount` and \
                                  `group` here, and the description comes from the doc \
                                  comment"

--- a/docs/rust/clap-compatibility.md
+++ b/docs/rust/clap-compatibility.md
@@ -106,22 +106,22 @@ the Rust declaration, not only from generated KDL, wherever the bridge column sa
 
 ## Help, version, and generated artifacts
 
-| clap surface                                       | derive | argv | KDL | lib | output | bridge | Notes                                                                                        |
-| -------------------------------------------------- | ------ | ---- | --- | --- | ------ | ------ | -------------------------------------------------------------------------------------------- |
-| short/long help and doc comments                   | yes    | yes  | yes | yes | yes    | yes    | First paragraph is short help; the full block is long help.                                  |
-| `help_heading`                                     | yes    | n/a  | yes | yes | yes    | yes    | Flags and arguments are grouped and retain declaration order.                                |
-| whole-entry `hide`                                 | yes    | yes  | yes | yes | yes    | yes    | Hidden commands, flags, arguments, and values still parse.                                   |
-| granular hide settings                             | yes    | yes  | yes | yes | yes    | yes    | Default, environment, possible-value, short-help, and long-help visibility is independent.   |
-| `subcommand_help_heading`, `subcommand_value_name` | yes    | yes  | yes | yes | yes    | yes    | Customize the subcommand section label and the synopsis placeholder.                         |
-| `verbatim_doc_comment`                             | yes    | n/a  | yes | yes | yes    | n/a    | Commands, fields, and variants preserve line breaks and indentation when requested.          |
-| `rename_all`, `rename_all_env`                     | yes    | n/a  | yes | yes | yes    | n/a    | Full clap casing vocabulary; bare `env` uses the environment casing policy.                  |
-| `help_template`, `next_line_help`, `flatten_help`  | no     | n/a  | no  | no  | no     | no     | No equivalent yet.                                                                           |
+| clap surface                                       | derive | argv | KDL | lib | output | bridge | Notes                                                                                          |
+| -------------------------------------------------- | ------ | ---- | --- | --- | ------ | ------ | ---------------------------------------------------------------------------------------------- |
+| short/long help and doc comments                   | yes    | yes  | yes | yes | yes    | yes    | First paragraph is short help; the full block is long help.                                    |
+| `help_heading`                                     | yes    | n/a  | yes | yes | yes    | yes    | Flags and arguments are grouped and retain declaration order.                                  |
+| whole-entry `hide`                                 | yes    | yes  | yes | yes | yes    | yes    | Hidden commands, flags, arguments, and values still parse.                                     |
+| granular hide settings                             | yes    | yes  | yes | yes | yes    | yes    | Default, environment, possible-value, short-help, and long-help visibility is independent.     |
+| `subcommand_help_heading`, `subcommand_value_name` | yes    | yes  | yes | yes | yes    | yes    | Customize the subcommand section label and the synopsis placeholder.                           |
+| `verbatim_doc_comment`                             | yes    | n/a  | yes | yes | yes    | n/a    | Commands, fields, and variants preserve line breaks and indentation when requested.            |
+| `rename_all`, `rename_all_env`                     | yes    | n/a  | yes | yes | yes    | n/a    | Full clap casing vocabulary; bare `env` uses the environment casing policy.                    |
+| `help_template`, `next_line_help`, `flatten_help`  | no     | n/a  | no  | no  | no     | no     | No equivalent yet.                                                                             |
 | `term_width`, `max_term_width`                     | yes    | yes  | yes | yes | yes    | no     | Fixed width overrides a detected-width cap; clap exposes no bridge getters for these settings. |
-| help styles and color                              | n/a    | n/a  | n/a | yes | lossy  | no     | Help and diagnostics use automatic ANSI styles; clap's custom style palette is not portable. |
-| built-in help/version action and flag control      | no     | no   | no  | no  | no     | no     | Custom actions and disabling or relocating built-ins are not represented.                    |
-| `--version` / `-V`, dynamic version                | yes    | yes  | yes | yes | yes    | yes    | Literal and runtime versions propagate through nested commands.                              |
-| completion generation                              | yes    | yes  | yes | yes | lossy  | yes    | Bash, fish, Nushell, PowerShell, and zsh plus runtime overlays are supported; Elvish is not. |
-| KDL, markdown, JSON, and manpages                  | yes    | n/a  | yes | yes | yes    | yes    | Direct derived KDL feeds the existing generators; broader canonicalization remains open.     |
+| help styles and color                              | n/a    | n/a  | n/a | yes | lossy  | no     | Help and diagnostics use automatic ANSI styles; clap's custom style palette is not portable.   |
+| built-in help/version action and flag control      | no     | no   | no  | no  | no     | no     | Custom actions and disabling or relocating built-ins are not represented.                      |
+| `--version` / `-V`, dynamic version                | yes    | yes  | yes | yes | yes    | yes    | Literal and runtime versions propagate through nested commands.                                |
+| completion generation                              | yes    | yes  | yes | yes | lossy  | yes    | Bash, fish, Nushell, PowerShell, and zsh plus runtime overlays are supported; Elvish is not.   |
+| KDL, markdown, JSON, and manpages                  | yes    | n/a  | yes | yes | yes    | yes    | Direct derived KDL feeds the existing generators; broader canonicalization remains open.       |
 
 ## Usage extensions
 

--- a/docs/rust/clap-compatibility.md
+++ b/docs/rust/clap-compatibility.md
@@ -116,7 +116,7 @@ the Rust declaration, not only from generated KDL, wherever the bridge column sa
 | `verbatim_doc_comment`                             | yes    | n/a  | yes | yes | yes    | n/a    | Commands, fields, and variants preserve line breaks and indentation when requested.          |
 | `rename_all`, `rename_all_env`                     | yes    | n/a  | yes | yes | yes    | n/a    | Full clap casing vocabulary; bare `env` uses the environment casing policy.                  |
 | `help_template`, `next_line_help`, `flatten_help`  | no     | n/a  | no  | no  | no     | no     | No equivalent yet.                                                                           |
-| `term_width`, `max_term_width`                     | no     | n/a  | no  | no  | no     | no     | Help wraps using `COLUMNS`.                                                                  |
+| `term_width`, `max_term_width`                     | yes    | yes  | yes | yes | yes    | no     | Fixed width overrides a detected-width cap; clap exposes no bridge getters for these settings. |
 | help styles and color                              | n/a    | n/a  | n/a | yes | lossy  | no     | Help and diagnostics use automatic ANSI styles; clap's custom style palette is not portable. |
 | built-in help/version action and flag control      | no     | no   | no  | no  | no     | no     | Custom actions and disabling or relocating built-ins are not represented.                    |
 | `--version` / `-V`, dynamic version                | yes    | yes  | yes | yes | yes    | yes    | Literal and runtime versions propagate through nested commands.                              |

--- a/lib/src/docs/cli/mod.rs
+++ b/lib/src/docs/cli/mod.rs
@@ -53,7 +53,7 @@ pub fn render_help(spec: &Spec, cmd: &SpecCommand, long: bool) -> String {
         }
     }
 
-    let width = crate::docs::layout::get_terminal_width();
+    let width = crate::docs::layout::help_width(cmd.term_width, cmd.max_term_width);
     let col = crate::docs::layout::max_usage_width(
         docs_cmd
             .flag_groups

--- a/lib/src/docs/layout.rs
+++ b/lib/src/docs/layout.rs
@@ -6,6 +6,18 @@ pub fn get_terminal_width() -> usize {
         .unwrap_or(80)
 }
 
+/// Resolve a command's help width using clap-compatible precedence.
+pub fn help_width(term_width: Option<usize>, max_term_width: Option<usize>) -> usize {
+    if let Some(width) = term_width {
+        return if width == 0 { usize::MAX } else { width };
+    }
+    let detected = get_terminal_width();
+    match max_term_width {
+        Some(0) | None => detected,
+        Some(max) => detected.min(max),
+    }
+}
+
 /// Calculate maximum usage string width across items
 pub fn max_usage_width<'a>(items: impl Iterator<Item = &'a str>) -> usize {
     items.map(visible_width).max().unwrap_or(0)

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -414,9 +414,9 @@ impl From<crate::Spec> for Spec {
 
 impl From<&crate::SpecCommand> for SpecCommand {
     fn from(cmd: &crate::SpecCommand) -> Self {
-        use crate::docs::layout::{get_terminal_width, max_usage_width, render_help_text};
+        use crate::docs::layout::{help_width, max_usage_width, render_help_text};
 
-        let terminal_width = get_terminal_width();
+        let terminal_width = help_width(cmd.term_width, cmd.max_term_width);
 
         // Calculate layout for args
         let args_usage_col_width = max_usage_width(cmd.args.iter().map(|a| a.usage.as_str()));
@@ -480,6 +480,9 @@ impl From<&crate::SpecCommand> for SpecCommand {
             subcommand_required,
             subcommand_help_heading,
             subcommand_value_name: _,
+            // Consumed above while laying help out; templates need only the result.
+            term_width: _,
+            max_term_width: _,
             help,
             help_long,
             help_md,

--- a/lib/src/spec/builder.rs
+++ b/lib/src/spec/builder.rs
@@ -847,6 +847,18 @@ impl SpecCommandBuilder {
         self
     }
 
+    /// Set a fixed help width. Zero disables wrapping.
+    pub fn term_width(mut self, width: usize) -> Self {
+        self.inner.term_width = Some(width);
+        self
+    }
+
+    /// Cap detected terminal width when no fixed width is set. Zero disables the cap.
+    pub fn max_term_width(mut self, width: usize) -> Self {
+        self.inner.max_term_width = Some(width);
+        self
+    }
+
     /// Forward an unmatched word as an external command plus the rest of argv
     pub fn external_subcommand(mut self, enabled: bool) -> Self {
         self.inner.external_subcommand = enabled;

--- a/lib/src/spec/cmd.rs
+++ b/lib/src/spec/cmd.rs
@@ -100,6 +100,12 @@ pub struct SpecCommand {
     /// Placeholder used for subcommands in the synopsis.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subcommand_value_name: Option<String>,
+    /// Fixed help width. Zero disables wrapping.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub term_width: Option<usize>,
+    /// Maximum detected terminal width when `term_width` is unset. Zero disables the cap.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_term_width: Option<usize>,
     /// Whether an unmatched word is forwarded as an external command plus the rest of argv.
     ///
     /// clap's `allow_external_subcommands` / `#[command(external_subcommand)]`. Known
@@ -198,6 +204,8 @@ impl Default for SpecCommand {
             subcommand_required: false,
             subcommand_help_heading: None,
             subcommand_value_name: None,
+            term_width: None,
+            max_term_width: None,
             external_subcommand: false,
             arg_required_else_help: false,
             dont_delimit_trailing_values: false,
@@ -313,6 +321,8 @@ impl SpecCommand {
                 "subcommand_required" => cmd.subcommand_required = v.ensure_bool()?,
                 "subcommand_help_heading" => cmd.subcommand_help_heading = Some(v.ensure_string()?),
                 "subcommand_value_name" => cmd.subcommand_value_name = Some(v.ensure_string()?),
+                "term_width" => cmd.term_width = Some(v.ensure_usize()?),
+                "max_term_width" => cmd.max_term_width = Some(v.ensure_usize()?),
                 "external_subcommand" => cmd.external_subcommand = v.ensure_bool()?,
                 "arg_required_else_help" => cmd.arg_required_else_help = v.ensure_bool()?,
                 "dont_delimit_trailing_values" => {
@@ -455,6 +465,12 @@ impl SpecCommand {
                 "subcommand_value_name" => {
                     cmd.subcommand_value_name =
                         Some(child.ensure_arg_len(1..=1)?.arg(0)?.ensure_string()?)
+                }
+                "term_width" => {
+                    cmd.term_width = Some(child.ensure_arg_len(1..=1)?.arg(0)?.ensure_usize()?)
+                }
+                "max_term_width" => {
+                    cmd.max_term_width = Some(child.ensure_arg_len(1..=1)?.arg(0)?.ensure_usize()?)
                 }
                 "external_subcommand" => {
                     cmd.external_subcommand = child.ensure_arg_len(1..=1)?.arg(0)?.ensure_bool()?
@@ -601,6 +617,8 @@ impl SpecCommand {
             subcommand_required,
             subcommand_help_heading,
             subcommand_value_name,
+            term_width,
+            max_term_width,
             external_subcommand,
             arg_required_else_help,
             dont_delimit_trailing_values,
@@ -686,6 +704,12 @@ impl SpecCommand {
         }
         if subcommand_value_name.is_some() {
             self.subcommand_value_name = subcommand_value_name;
+        }
+        if term_width.is_some() {
+            self.term_width = term_width;
+        }
+        if max_term_width.is_some() {
+            self.max_term_width = max_term_width;
         }
         self.external_subcommand = external_subcommand;
         self.arg_required_else_help = arg_required_else_help;
@@ -799,6 +823,8 @@ impl From<&SpecCommand> for KdlNode {
             subcommand_required,
             subcommand_help_heading,
             subcommand_value_name,
+            term_width,
+            max_term_width,
             external_subcommand,
             arg_required_else_help,
             dont_delimit_trailing_values,
@@ -853,6 +879,12 @@ impl From<&SpecCommand> for KdlNode {
         }
         if let Some(name) = subcommand_value_name {
             node.push(KdlEntry::new_prop("subcommand_value_name", name.clone()));
+        }
+        if let Some(width) = term_width {
+            node.push(KdlEntry::new_prop("term_width", *width as i128));
+        }
+        if let Some(width) = max_term_width {
+            node.push(KdlEntry::new_prop("max_term_width", *width as i128));
         }
         if *external_subcommand {
             node.entries_mut()

--- a/lib/src/spec/mod.rs
+++ b/lib/src/spec/mod.rs
@@ -325,6 +325,12 @@ impl Spec {
                 "subcommand_value_name" => {
                     schema.cmd.subcommand_value_name = Some(node.arg(0)?.ensure_string()?);
                 }
+                "term_width" => {
+                    schema.cmd.term_width = Some(node.arg(0)?.ensure_usize()?);
+                }
+                "max_term_width" => {
+                    schema.cmd.max_term_width = Some(node.arg(0)?.ensure_usize()?);
+                }
                 "example" => {
                     let code = node.ensure_arg_len(1..=1)?.arg(0)?.ensure_string()?;
                     let mut example = SpecExample::new(code.trim().to_string());
@@ -646,6 +652,16 @@ impl Display for Spec {
         if let Some(name) = &self.cmd.subcommand_value_name {
             let mut node = KdlNode::new("subcommand_value_name");
             node.push(string_entry(None, name));
+            nodes.push(node);
+        }
+        if let Some(width) = self.cmd.term_width {
+            let mut node = KdlNode::new("term_width");
+            node.push(width as i128);
+            nodes.push(node);
+        }
+        if let Some(width) = self.cmd.max_term_width {
+            let mut node = KdlNode::new("max_term_width");
+            node.push(width as i128);
             nodes.push(node);
         }
         if !self.usage.is_empty() {

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -107,6 +107,15 @@ struct HelpOptionalValue {
     bump: Option<u32>,
 }
 
+#[derive(Debug, Cli)]
+#[usage(bin = "sized-help", term_width = 36, max_term_width = 20)]
+#[allow(dead_code)]
+struct SizedHelp {
+    /// A description long enough to wrap at the command's declared help width.
+    #[usage(long)]
+    output: Option<String>,
+}
+
 #[derive(Cli)]
 #[command(
     bin = "presented",
@@ -1115,6 +1124,25 @@ fn typed_subcommand_presentation_reaches_help_and_the_spec() {
     let page = usage::argv::help::short_help(spec, &["presented"], &[spec.root]);
     assert!(page.contains("<ACTION>"), "{page}");
     assert!(page.contains("Actions:"), "{page}");
+}
+
+#[test]
+fn typed_help_width_reaches_help_and_the_portable_spec() {
+    let spec = SizedHelp::spec();
+    assert_eq!(spec.root.term_width, Some(36));
+    assert_eq!(spec.root.max_term_width, Some(20));
+    let page = usage::argv::help::long_help(spec, &["sized-help"], &[spec.root]);
+    assert!(
+        page.contains("                         description\n"),
+        "fixed width should wrap and override the lower maximum: {page}"
+    );
+
+    let kdl = SizedHelp::to_kdl();
+    assert!(kdl.contains("term_width 36"), "{kdl}");
+    assert!(kdl.contains("max_term_width 20"), "{kdl}");
+    let portable: usage_parser::Spec = kdl.parse().unwrap();
+    assert_eq!(portable.cmd.term_width, Some(36));
+    assert_eq!(portable.cmd.max_term_width, Some(20));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- carry `term_width` and `max_term_width` through typed metadata and portable KDL
- apply clap-compatible precedence in usage-argv and usage-lib help rendering
- document the clap bridge getter limitation and close the PLAN gap

## Validation
- `cargo test -p usage-rs --all-features typed_help_width_reaches_help_and_the_portable_spec`
- `cargo test -p usage-lib --all-features`
- `cargo test -p usage-argv --all-features`
- `cargo clippy --all --all-features -- -D warnings`

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Help layout and metadata only; parsing behavior is unchanged. Risk is limited to help wrapping regressions if width precedence is wrong.
> 
> **Overview**
> Commands can now declare **`term_width`** and **`max_term_width`** so long help wraps like clap: a fixed width wins over terminal detection, **`max_term_width`** caps `COLUMNS` when no fixed width is set, and **zero** means unbounded wrapping or no cap. Without either field, behavior stays **`COLUMNS`** with an **80** fallback.
> 
> The settings are wired through **`#[usage(term_width = …, max_term_width = …)]`**, portable **`SpecCommand` / KDL**, derive static metadata, conformance tables, and **`usage-argv`** / **`usage-lib`** help layout (`help_width` / `terminal_width(meta)`). **PLAN.md** and **`docs/rust/clap-compatibility.md`** mark this clap surface as supported; the bridge still cannot recover these from clap builders (no getters). A facade test (`SizedHelp`) checks metadata, wrapped long help, and KDL round-trip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e4708999b669b8341317b86719e10a9a811741b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->