### PR TITLE
feat(complete): add shell quoting filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2426,6 +2426,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "shell-words",
  "tera",
  "thiserror",
  "tokio",

--- a/PLAN.md
+++ b/PLAN.md
@@ -1191,7 +1191,7 @@ repeated here.
       `sh -c` string, with no shell-quoting filter". A quoting filter — or a
       structured argv channel — is owed before dynamic completers are a
       recommendation rather than a hazard. The completion renderer now provides a
-      `shell_quote` filter backed by `shell_words::quote`, rejects non-string inputs,
+      `shell_quote` and `shell_join` filters backed by `shell_words`, reject invalid inputs,
       and documents that interpolation remains raw unless the author opts into the
       filter. `run=` remains a shell program rather than being narrowed to an argv
       vector, preserving pipelines and the modern shell-out completion use case.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1184,13 +1184,17 @@ relationship families, remaining command parsing policy, fixed arity, the full
 `ValueHint` vocabulary) are not
 repeated here.
 
-- [ ] **The completer channel is unescaped Tera into `sh -c`.** aube's
+- [x] **The completer channel is unescaped Tera into `sh -c`.** aube's
       `completion.usage.kdl` documents the quote-escaping gymnastics, and its
       `extra.usage.kdl` records a `-C` non-forwarding limitation outright:
       "usage's only channel for the typed words is tera interpolation into a
       `sh -c` string, with no shell-quoting filter". A quoting filter — or a
       structured argv channel — is owed before dynamic completers are a
-      recommendation rather than a hazard.
+      recommendation rather than a hazard. The completion renderer now provides a
+      `shell_quote` filter backed by `shell_words::quote`, rejects non-string inputs,
+      and documents that interpolation remains raw unless the author opts into the
+      filter. `run=` remains a shell program rather than being narrowed to an argv
+      vector, preserving pipelines and the modern shell-out completion use case.
 - [ ] **A multicall CLI cannot describe its applets.** aube's 80 lines of spec
       surgery for `aubr`/`aubx` is the requirement written as a workaround: a
       spec (or the derive) should declare a sub-view — name, bin, a subset of

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -1572,7 +1572,7 @@ fn write_completers(
             out,
             " run={}",
             quoted(&format!(
-                "{bin} __complete_word__ --candidates {name} --line '{{{{ words | join(sep=\" \") | replace(from=\"'\", to=\"'\\\"'\\\"'\") }}}}'"
+                "{bin} __complete_word__ --candidates {name} --line={{{{ words | shell_join | shell_quote }}}}"
             ))
         )?;
         // No `descriptions=#true`: that tells the reference to read a description after an
@@ -2863,6 +2863,47 @@ mod tests {
         assert_eq!(quoted(r#"say "hi""#), r#""say \"hi\"""#);
         assert_eq!(quoted("a\\b"), r#""a\\b""#);
         assert_eq!(quoted("one\ntwo"), r#""one\ntwo""#);
+    }
+
+    fn test_completer(_: &CompleteCtx<'_>) -> Vec<Candidate<'static>> {
+        Vec::new()
+    }
+
+    #[test]
+    fn generated_completer_bridges_preserve_the_argv_vector() {
+        static ARG: Arg = Arg {
+            name: "ARG",
+            ..Arg::REQUIRED
+        };
+        static ARG_META: ArgMeta = ArgMeta {
+            arg: &ARG,
+            complete: Some(test_completer),
+            ..ArgMeta::EMPTY
+        };
+        static COMMAND: Command = Command {
+            args: &[&ARG],
+            ..Command::EMPTY
+        };
+        static META: CommandMeta = CommandMeta {
+            cmd: &COMMAND,
+            args: &[ARG_META],
+            ..CommandMeta::EMPTY
+        };
+        static SPEC: Spec = Spec {
+            name: "ex",
+            bin: Some("ex"),
+            root: &META,
+            ..Spec::EMPTY
+        };
+
+        let kdl = SPEC.to_kdl();
+        assert!(
+            kdl.contains(
+                "__complete_word__ --candidates arg --line={{ words | shell_join | shell_quote }}"
+            ),
+            "{kdl}"
+        );
+        assert!(!kdl.contains("replace(from="), "{kdl}");
     }
 
     #[test]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -38,6 +38,7 @@ schemars = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 serde_with = "3"
+shell-words = "1"
 tera = "2"
 thiserror = "2"
 tokio = { version = "1", features = ["rt", "macros", "io-std"] }

--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -18,6 +18,24 @@ use usage::{Spec, SpecArg, SpecCommand, SpecComplete, SpecDoubleDashChoices, Spe
 
 use crate::cli::generate;
 
+static COMPLETER_TERA: LazyLock<tera::Tera> = LazyLock::new(|| {
+    let mut tera = tera::Tera::default();
+    tera.register_filter(
+        "shell_quote",
+        |value: &tera::Value, _: tera::Kwargs, _: &tera::State| -> tera::TeraResult<String> {
+            let value = value
+                .as_str()
+                .ok_or_else(|| tera::Error::message("shell_quote expects a string"))?;
+            Ok(shell_words::quote(value).into_owned())
+        },
+    );
+    tera
+});
+
+fn render_completer_run(run: &str, ctx: &tera::Context) -> tera::TeraResult<String> {
+    COMPLETER_TERA.render_str(run, ctx, false)
+}
+
 /// Generate shell completion candidates for a partial command line
 ///
 /// This is used internally by shell completion scripts to provide
@@ -603,7 +621,7 @@ impl CompleteWord {
             ));
         }
         if let Some(run) = &complete.run {
-            let run = tera::Tera::one_off(run, cx.tera, false).into_diagnostic()?;
+            let run = render_completer_run(run, cx.tera).into_diagnostic()?;
             trace!("run: {run}");
             let stdout = sh(&run)?;
             // trace!("stdout: {stdout}");
@@ -829,11 +847,42 @@ fn zsh_shell_quote(s: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::command_name_starts_with;
+    use super::{command_name_starts_with, render_completer_run};
 
     #[test]
     fn windows_command_prefixes_ignore_ascii_case() {
         assert!(command_name_starts_with("Cargo.EXE", "car", true));
         assert!(!command_name_starts_with("Cargo.EXE", "car", false));
+    }
+
+    #[test]
+    fn completer_templates_can_shell_quote_typed_words() {
+        let mut ctx = tera::Context::new();
+        ctx.insert("word", "a'b; echo injected");
+        let rendered = render_completer_run("printf '%s\\n' {{ word | shell_quote }}", &ctx)
+            .expect("the filter should render");
+        assert_eq!(rendered, "printf '%s\\n' 'a'\\''b; echo injected'");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shell_quoted_template_values_remain_one_literal_argument() {
+        let mut ctx = tera::Context::new();
+        ctx.insert("word", "$(printf injected); a'b");
+        let rendered = render_completer_run("printf '%s\\n' {{ word | shell_quote }}", &ctx)
+            .expect("the filter should render");
+        let stdout = usage::sh::sh(&rendered).expect("the rendered command should run");
+        assert_eq!(stdout, "$(printf injected); a'b\n");
+    }
+
+    #[test]
+    fn shell_quote_rejects_non_strings() {
+        let mut ctx = tera::Context::new();
+        ctx.insert("word", &42);
+        let err = render_completer_run("{{ word | shell_quote }}", &ctx).unwrap_err();
+        assert!(
+            err.to_string().contains("shell_quote expects a string"),
+            "{err}"
+        );
     }
 }

--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -29,6 +29,23 @@ static COMPLETER_TERA: LazyLock<tera::Tera> = LazyLock::new(|| {
             Ok(shell_words::quote(value).into_owned())
         },
     );
+    tera.register_filter(
+        "shell_join",
+        |value: &tera::Value, _: tera::Kwargs, _: &tera::State| -> tera::TeraResult<String> {
+            let values = value
+                .as_array()
+                .ok_or_else(|| tera::Error::message("shell_join expects a list of strings"))?;
+            let words = values
+                .iter()
+                .map(|value| {
+                    value
+                        .as_str()
+                        .ok_or_else(|| tera::Error::message("shell_join expects a list of strings"))
+                })
+                .collect::<tera::TeraResult<Vec<_>>>()?;
+            Ok(shell_words::join(words))
+        },
+    );
     tera
 });
 
@@ -884,5 +901,21 @@ mod tests {
             err.to_string().contains("shell_quote expects a string"),
             "{err}"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shell_join_preserves_the_argv_vector_when_forwarded_as_one_argument() {
+        let expected = ["ex", "two words", "a'b"];
+        let mut ctx = tera::Context::new();
+        ctx.insert("words", &expected);
+        let rendered = render_completer_run(
+            "printf '%s\\n' {{ words | shell_join | shell_quote }}",
+            &ctx,
+        )
+        .expect("the filters should render");
+        let stdout = usage::sh::sh(&rendered).expect("the rendered command should run");
+        let reparsed = shell_words::split(stdout.trim()).expect("the joined value should parse");
+        assert_eq!(reparsed, expected);
     }
 }

--- a/conformance/tests/spec_roundtrip.rs
+++ b/conformance/tests/spec_roundtrip.rs
@@ -786,14 +786,14 @@ fn a_declared_completer_becomes_a_run_the_reference_can_read() {
     // The line goes with the request, interpolated by whoever runs it — without it a completer
     // that reads an earlier flag answers against nothing, which is a wrong answer rather than a
     // missing one.
-    assert!(run.contains("--line '{{ words | join(sep=\" \")"), "{run}");
-    // The interpolated line is one single-quoted shell argument. An apostrophe in an earlier
-    // word has to close that quote, write a quoted apostrophe, and reopen it; otherwise the
-    // completion command is split (or executes the rest of the line as shell syntax).
+    // shell_join preserves the argv boundaries before shell_quote makes the reconstructed line
+    // one inert shell argument. The reference owns both filters, so generated producers do not
+    // duplicate an incomplete hand-written quote transform.
     assert!(
-        run.contains("replace(from=\"'\", to=\"'\\\"'\\\"'\") }}'"),
+        run.contains("--line={{ words | shell_join | shell_quote }}"),
         "{run}"
     );
+    assert!(!run.contains("replace(from="), "{run}");
     // And no `descriptions=#true`, which would tell the reference to read a description after an
     // unescaped colon: what this answers with is values, and mise's task names are full of colons.
     assert!(!complete.descriptions, "{run}");

--- a/docs/spec/reference/complete.md
+++ b/docs/spec/reference/complete.md
@@ -88,13 +88,25 @@ The run can be customized with [tera](https://keats.github.io/tera/) templates. 
 - `CURRENT`: The index of the word currently being typed, combine with `words` to get the current word e.g. `words[CURRENT]`.
 - `PREV`: The index of the previous word in the prompt (CURRENT-1), combine with `words` to get the previous word e.g. `words[PREV]`.
 
+Values interpolated into `run` are not escaped automatically. Pass every typed word that
+becomes one shell argument through `shell_quote`; the filter emits one POSIX-shell-safe word,
+including spaces, quotes, substitutions, and command separators as literal data:
+
+```kdl
+complete "package" run="mycli complete --query={{ words[CURRENT] | shell_quote }}"
+```
+
+Leaving off the filter is appropriate only when the interpolation is deliberately shell
+syntax. `shell_quote` accepts strings; quote list members individually rather than quoting a
+joined command line.
+
 Example of completing the second argument based on the first:
 
 ```kdl
 arg "<module>"
 arg "<controller>"
 complete "module" run="ls modules"
-complete "controller" run="ls modules/{{words[PREV]}}/controllers"
+complete "controller" run="ls modules/{{ words[PREV] | shell_quote }}/controllers"
 ```
 
 Example of using multiple words (one, two, three) for the completions of the forth argument:

--- a/docs/spec/reference/complete.md
+++ b/docs/spec/reference/complete.md
@@ -100,6 +100,13 @@ Leaving off the filter is appropriate only when the interpolation is deliberatel
 syntax. `shell_quote` accepts strings; quote list members individually rather than quoting a
 joined command line.
 
+When a child process needs the complete argv as one command-line string, `shell_join` preserves
+the original word boundaries before `shell_quote` makes that command line one inert argument:
+
+```kdl
+complete "arg" run="mycli __complete --line={{ words | shell_join | shell_quote }}"
+```
+
 Example of completing the second argument based on the first:
 
 ```kdl


### PR DESCRIPTION
## Summary

- register a `shell_quote` Tera filter for dynamic `run=` completers
- preserve `run=` as a shell program while making typed-word interpolation safe when opted in
- document the filter and close the corresponding PLAN gap

## Validation

- `cargo test -p usage-cli --all-features`
- `cargo clippy -p usage-cli --all-features -- -D warnings`

_This PR was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how user-typed words are embedded into shell completion commands; the new defaults improve safety for generated bridges, but custom `run=` templates remain dangerous if authors skip the filters.
> 
> **Overview**
> **Safer dynamic completers.** Completer `run=` strings are still rendered with Tera and executed via `sh -c`, but authors can now pass typed words through **`shell_quote`** and **`shell_join`** (backed by `shell-words`) instead of ad hoc `join`/`replace` escaping.
> 
> The CLI registers these filters on a shared completer Tera instance and routes `complete.run` rendering through it. **Generated KDL** for built-in completer bridges now emits `--line={{ words | shell_join | shell_quote }}` rather than the previous manual quote transform.
> 
> **Docs and tests** document that interpolation stays raw unless a filter is used, with examples for single words and full argv lines. Conformance and unit tests assert the new bridge shape and that quoted/joined values survive as one literal shell argument.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cddc2873adde499fc2889b4e767ad70880b65d45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->