### PR TITLE
feat(complete): support full value hint vocabulary

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -558,10 +558,13 @@ Groups are the opposite case: `Command::get_groups`, `ArgGroup::get_args` and
       `HelpShort`, `HelpLong` and `Version`, plus `disable_help_flag`,
       `disable_help_subcommand` and `disable_version_flag`. A clap
       CLI can move or remove these entry points; usage currently supplies its own.
-- [ ] **Ordering and remaining metadata** — explicit `display_order`, the full
-      `ValueHint` vocabulary, `long_version`, and custom help/version
-      text. Declaration order and path hints cover the common cases, not the
-      complete clap surface.
+- [x] **The full `ValueHint` vocabulary.** Typed declarations and the clap bridge
+      lower every stable clap hint into portable completion types. Username and
+      hostname hints use system candidates where the usage CLI owns completion;
+      open-ended identity/network values suppress the incorrect path fallback.
+- [ ] **Ordering and remaining metadata** — explicit `display_order`,
+      `long_version`, and custom help/version text. Declaration order covers the
+      common case, not the complete clap surface.
 
 **API surface**
 

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -675,18 +675,23 @@ fn declared_files_at_cursor(
     } else {
         (None, None)
     };
-    complete_type
-        .and_then(|type_| {
-            declared_files(
-                type_,
-                if after_restart {
-                    0
-                } else {
-                    position.next_arg_values
-                },
-            )
-        })
-        .or_else(|| name.and_then(files_for))
+    match complete_type {
+        Some(type_) => declared_files(
+            type_,
+            if after_restart {
+                0
+            } else {
+                position.next_arg_values
+            },
+        )
+        .or_else(|| {
+            type_
+                .eq_ignore_ascii_case("unknown")
+                .then(|| name.and_then(files_for))
+                .flatten()
+        }),
+        None => name.and_then(files_for),
+    }
 }
 
 /// What could be typed at the cursor, given a spec and a split line.
@@ -740,18 +745,23 @@ pub fn complete<'a>(spec: &'a Spec<'a>, split: &Split) -> Completions<'a> {
     } else {
         (None, false, None)
     };
-    let asked_for = complete_type
-        .and_then(|type_| {
-            declared_files(
-                type_,
-                if after_restart {
-                    0
-                } else {
-                    position.next_arg_values
-                },
-            )
-        })
-        .or_else(|| named.and_then(files_for));
+    let asked_for = match complete_type {
+        Some(type_) => declared_files(
+            type_,
+            if after_restart {
+                0
+            } else {
+                position.next_arg_values
+            },
+        )
+        .or_else(|| {
+            type_
+                .eq_ignore_ascii_case("unknown")
+                .then(|| named.and_then(files_for))
+                .flatten()
+        }),
+        None => named.and_then(files_for),
+    };
 
     // An argument that requires a separator is not fillable yet, so nothing else belongs here —
     // not even a path, which the parser would reject exactly as it rejects a value.
@@ -770,7 +780,10 @@ pub fn complete<'a>(spec: &'a Spec<'a>, split: &Split) -> Completions<'a> {
     // between "there is nothing else this can be" and "nothing matched what you typed".
     // Offering the working directory for a mistyped choice answers the second as though it were
     // the first.
-    let closed = !candidates.is_empty() || declares_choices || position.help_topic;
+    let declared_non_file_type = complete_type
+        .is_some_and(|type_| !type_.eq_ignore_ascii_case("unknown") && asked_for.is_none());
+    let closed =
+        !candidates.is_empty() || declares_choices || declared_non_file_type || position.help_topic;
 
     let files = if flag_like || needs_separator {
         None
@@ -2786,6 +2799,56 @@ mod tests {
     fn executable_paths_and_command_names_are_distinct_shell_requests() {
         assert_eq!(files_for("executable"), Some(Files::ExecutablePaths));
         assert_eq!(files_for("command"), Some(Files::Commands));
+    }
+
+    #[test]
+    fn open_ended_value_hints_suppress_path_fallback() {
+        static URL: Arg = Arg {
+            key: 80,
+            name: "URL",
+            ..Arg::REQUIRED
+        };
+        static ROOT: Command = Command {
+            name: "ex",
+            args: &[&URL],
+            ..Command::EMPTY
+        };
+        static URL_META: CommandMeta = CommandMeta {
+            cmd: &ROOT,
+            args: &[ArgMeta {
+                arg: &URL,
+                complete_type: Some("url"),
+                ..ArgMeta::EMPTY
+            }],
+            ..CommandMeta::EMPTY
+        };
+        static URL_SPEC: Spec = Spec {
+            name: "ex",
+            bin: Some("ex"),
+            root: &URL_META,
+            ..Spec::EMPTY
+        };
+        static UNKNOWN_META: CommandMeta = CommandMeta {
+            cmd: &ROOT,
+            args: &[ArgMeta {
+                arg: &URL,
+                complete_type: Some("unknown"),
+                ..ArgMeta::EMPTY
+            }],
+            ..CommandMeta::EMPTY
+        };
+        static UNKNOWN_SPEC: Spec = Spec {
+            name: "ex",
+            bin: Some("ex"),
+            root: &UNKNOWN_META,
+            ..Spec::EMPTY
+        };
+
+        assert_eq!(complete(&URL_SPEC, &at_end("ex ")).files, None);
+        assert_eq!(
+            complete(&UNKNOWN_SPEC, &at_end("ex ")).files,
+            Some(Files::Any)
+        );
     }
 
     #[test]

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -90,6 +90,10 @@ use std::ffi::{OsStr, OsString};
 /// parse.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ValueHint {
+    /// Let the shell use its normal fallback behavior.
+    Unknown,
+    /// No structured hint applies; suppress the shell's path fallback.
+    Other,
     /// A path to a file.
     FilePath,
     /// A path to either a file or a directory.
@@ -104,6 +108,14 @@ pub enum ValueHint {
     CommandString,
     /// A trailing argv vector: complete the first value as a command, then its arguments.
     CommandWithArguments,
+    /// A local operating-system user name.
+    Username,
+    /// A host name known to the shell or operating system.
+    Hostname,
+    /// A web address. This suppresses path fallback but offers no finite candidate set.
+    Url,
+    /// An email address. This suppresses path fallback but offers no finite candidate set.
+    EmailAddress,
 }
 
 #[cfg(feature = "complete")]

--- a/clap_usage/src/report.rs
+++ b/clap_usage/src/report.rs
@@ -1,4 +1,4 @@
-use clap::{Arg, ArgAction, ColorChoice, Command, ValueHint};
+use clap::{Arg, ArgAction, ColorChoice, Command};
 use std::collections::BTreeSet;
 
 /// A clap behavior that the generated usage spec cannot preserve.
@@ -7,7 +7,6 @@ use std::collections::BTreeSet;
 pub enum FidelityFeature {
     Environment,
     HiddenFlagAlias,
-    ValueHint,
     NonAsciiDelimiter,
     NonUtf8Default,
     ValueArity,
@@ -121,12 +120,6 @@ fn argument_losses(arg: &Arg, path: &[String], losses: &mut BTreeSet<FidelityLos
         add(
             FidelityFeature::Environment,
             format!("env={}", env.to_string_lossy()),
-        );
-    }
-    if arg.get_value_hint() != ValueHint::Unknown {
-        add(
-            FidelityFeature::ValueHint,
-            format!("value_hint={:?}", arg.get_value_hint()),
         );
     }
     if let Some(delimiter) = arg

--- a/clap_usage/tests/fidelity_report.rs
+++ b/clap_usage/tests/fidelity_report.rs
@@ -26,13 +26,13 @@ fn reports_detectable_losses_with_locations() {
 
     let (spec, report) = spec_with_report(&mut command, "ex");
     assert!(spec.cmd.arg_required_else_help);
+    assert_eq!(spec.cmd.complete["config"].type_.as_deref(), Some("path"));
     let features: Vec<_> = report.losses().iter().map(|loss| loss.feature).collect();
-    for expected in [FidelityFeature::Environment, FidelityFeature::ValueHint] {
-        assert!(
-            features.contains(&expected),
-            "missing {expected:?}: {report:#?}"
-        );
-    }
+    let expected = FidelityFeature::Environment;
+    assert!(
+        features.contains(&expected),
+        "missing {expected:?}: {report:#?}"
+    );
     let pair = spec
         .cmd
         .flags
@@ -58,6 +58,52 @@ fn reports_detectable_losses_with_locations() {
     assert!(!features.contains(&FidelityFeature::DistinctValueNames));
     assert!(report.losses().iter().all(|loss| loss.command == ["ex"]));
     assert!(!report.is_lossless());
+}
+
+#[test]
+fn every_clap_value_hint_is_portable() {
+    let cases = [
+        (ValueHint::Other, Some("none")),
+        (ValueHint::AnyPath, Some("path")),
+        (ValueHint::FilePath, Some("path")),
+        (ValueHint::DirPath, Some("dir")),
+        (ValueHint::ExecutablePath, Some("executable")),
+        (ValueHint::CommandName, Some("command")),
+        (ValueHint::CommandString, Some("command")),
+        (ValueHint::CommandWithArguments, Some("command_args")),
+        (ValueHint::Username, Some("username")),
+        (ValueHint::Hostname, Some("hostname")),
+        (ValueHint::Url, Some("url")),
+        (ValueHint::EmailAddress, Some("email")),
+        (ValueHint::Unknown, None),
+    ];
+    for (hint, expected) in cases {
+        let mut command = if hint == ValueHint::CommandWithArguments {
+            Command::new("ex").trailing_var_arg(true).arg(
+                Arg::new("value")
+                    .action(ArgAction::Append)
+                    .num_args(1..)
+                    .value_hint(hint),
+            )
+        } else {
+            Command::new("ex").arg(
+                Arg::new("value")
+                    .long("value")
+                    .action(ArgAction::Set)
+                    .value_hint(hint),
+            )
+        };
+        let (spec, report) = spec_with_report(&mut command, "ex");
+        assert!(report.is_lossless(), "{hint:?}: {report:#?}");
+        assert_eq!(
+            spec.cmd
+                .complete
+                .get("value")
+                .and_then(|complete| complete.type_.as_deref()),
+            expected,
+            "{hint:?}"
+        );
+    }
 }
 
 #[test]

--- a/clap_usage/tests/snapshots/simple__simple.snap
+++ b/clap_usage/tests/snapshots/simple__simple.snap
@@ -12,3 +12,4 @@ flag --file help="some input file" {
     arg <FILE>
 }
 flag --usage default="false"
+complete file type=path

--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -620,15 +620,14 @@ impl CompleteWord {
             .get(&name)
             .or(cmd.complete.get(&name))
             .unwrap_or(&EMPTY_COMPL);
-        let type_ = complete.type_.as_ref().unwrap_or(&name);
-
-        // A closed completer answers even when its answer is nothing: it knows the whole set
-        // of candidates, so an unmatched prefix means no matches rather than "ask somebody
-        // else". Returning empty-and-open here is what let a mistyped setting name complete
-        // to the contents of the working directory.
-        let (builtin, closed) = self.complete_builtin(cx, type_, ctoken);
-        if !builtin.is_empty() || closed {
-            return Ok((builtin, closed));
+        if let Some(type_) = complete.type_.as_deref() {
+            // An explicitly declared closed completer answers even when its answer is nothing:
+            // it knows the whole set of candidates, so an unmatched prefix means no matches
+            // rather than "ask somebody else".
+            let (builtin, closed) = self.complete_builtin(cx, type_, ctoken);
+            if !builtin.is_empty() || closed {
+                return Ok((builtin, closed));
+            }
         }
 
         if let Some(choices) = &arg.choices {
@@ -673,6 +672,18 @@ impl CompleteWord {
                 // had nothing to say about this prefix.
                 false,
             ));
+        }
+
+        // Argument-name inference is only a fallback. An existing spec may legitimately name
+        // an argument `url`, `email`, `username`, or another reserved word and attach `run=`;
+        // treating the inferred type as explicit would close the set before that command ran.
+        // The same is true in the other direction: an explicitly declared open type such as
+        // `command_args` must not fall through to a different builtin inferred from its name.
+        if complete.type_.is_none() {
+            let (builtin, closed) = self.complete_builtin(cx, &name, ctoken);
+            if !builtin.is_empty() || closed {
+                return Ok((builtin, closed));
+            }
         }
 
         Ok((vec![], false))

--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -412,6 +412,11 @@ impl CompleteWord {
                 );
             }
             "command" => return (self.complete_commands(ctoken), true),
+            "username" => return (complete_usernames(ctoken), true),
+            "hostname" => return (complete_hostnames(ctoken), true),
+            "none" | "url" | "email" => return (vec![], true),
+            // `Unknown` asks for the shell's normal fallback, so this stays open.
+            "unknown" => {}
             "command_args" => {
                 let command_was_bound = cx.parsed.next_arg.as_ref().is_some_and(|next| {
                     // `parse_partial` records the cursor with a fresh `Arc` around a
@@ -754,6 +759,57 @@ impl CompleteWord {
             .map(|value| (value, String::new()))
             .collect()
     }
+}
+
+fn complete_usernames(prefix: &str) -> Vec<(String, String)> {
+    let mut found = BTreeSet::new();
+    for key in ["USER", "USERNAME"] {
+        if let Ok(value) = env::var(key) {
+            if value.starts_with(prefix) {
+                found.insert(value);
+            }
+        }
+    }
+    if let Ok(passwd) = std::fs::read_to_string("/etc/passwd") {
+        for line in passwd.lines() {
+            if let Some(name) = line
+                .split(':')
+                .next()
+                .filter(|name| name.starts_with(prefix))
+            {
+                found.insert(name.to_string());
+            }
+        }
+    }
+    found
+        .into_iter()
+        .map(|value| (value, String::new()))
+        .collect()
+}
+
+fn complete_hostnames(prefix: &str) -> Vec<(String, String)> {
+    let mut found = BTreeSet::new();
+    for key in ["HOSTNAME", "COMPUTERNAME"] {
+        if let Ok(value) = env::var(key) {
+            if value.starts_with(prefix) {
+                found.insert(value);
+            }
+        }
+    }
+    if let Ok(hosts) = std::fs::read_to_string("/etc/hosts") {
+        for line in hosts.lines() {
+            let line = line.split('#').next().unwrap_or_default();
+            for name in line.split_whitespace().skip(1) {
+                if name.starts_with(prefix) {
+                    found.insert(name.to_string());
+                }
+            }
+        }
+    }
+    found
+        .into_iter()
+        .map(|value| (value, String::new()))
+        .collect()
 }
 
 fn command_name_starts_with(name: &str, prefix: &str, case_insensitive: bool) -> bool {

--- a/cli/tests/complete_word.rs
+++ b/cli/tests/complete_word.rs
@@ -72,6 +72,11 @@ fn complete_word_completer() {
 }
 
 #[test]
+fn complete_word_run_outranks_a_builtin_inferred_from_the_argument_name() {
+    assert_cmd("run-named-builtin.usage.kdl", &["ru"]).stdout("run-result\n");
+}
+
+#[test]
 fn complete_word_variadic_arg_reuses_completer() {
     assert_cmd("variadic-completion.usage.kdl", &["--", "variadic", ""]).stdout("foo\nbar\n");
     assert_cmd(

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -416,17 +416,24 @@ fn value_hint(meta: &Meta) -> syn::Result<String> {
         ));
     };
     match variant.ident.to_string().as_str() {
+        "Unknown" => Ok("unknown".to_string()),
+        "Other" => Ok("none".to_string()),
         "FilePath" | "AnyPath" => Ok("path".to_string()),
         "DirPath" => Ok("dir".to_string()),
         "ExecutablePath" => Ok("executable".to_string()),
         "CommandName" | "CommandString" => Ok("command".to_string()),
         "CommandWithArguments" => Ok("command_args".to_string()),
+        "Username" => Ok("username".to_string()),
+        "Hostname" => Ok("hostname".to_string()),
+        "Url" => Ok("url".to_string()),
+        "EmailAddress" => Ok("email".to_string()),
         other => Err(syn::Error::new_spanned(
             value,
             format!(
                 "`ValueHint::{other}` has no usage completion type yet; supported hints are \
-                 `FilePath`, `AnyPath`, `DirPath`, `ExecutablePath`, `CommandName`, \
-                 `CommandString`, and `CommandWithArguments`"
+                 `Unknown`, `Other`, `FilePath`, `AnyPath`, `DirPath`, `ExecutablePath`, \
+                 `CommandName`, `CommandString`, `CommandWithArguments`, `Username`, \
+                 `Hostname`, `Url`, and `EmailAddress`"
             ),
         )),
     }

--- a/docs/rust/args-and-flags.md
+++ b/docs/rust/args-and-flags.md
@@ -106,10 +106,12 @@ computed state beside parsed state, and nothing about it reaches the spec, the p
 help. Combining it with `long`, `arg`, or any other field option is a compile error. The type
 has to implement `Default`.
 
-`value_hint` accepts `FilePath`, `AnyPath`, `DirPath`, `ExecutablePath`, `CommandName`,
-`CommandString`, and `CommandWithArguments`. The last is for wrapper CLIs and must be a
-positional `Vec` with `double_dash = "automatic"`: its first value completes from the shell's
-commands, while later values fall back to ordinary argument paths.
+`value_hint` accepts clap's full stable vocabulary: `Unknown`, `Other`, `FilePath`, `AnyPath`,
+`DirPath`, `ExecutablePath`, `CommandName`, `CommandString`, `CommandWithArguments`,
+`Username`, `Hostname`, `Url`, and `EmailAddress`. `CommandWithArguments` is for wrapper CLIs
+and must be a positional `Vec` with `double_dash = "automatic"`: its first value completes
+from the shell's commands, while later values fall back to ordinary argument paths. `Other`,
+URL, and email values suppress filename fallback without pretending there is a finite list.
 
 `#[usage(allow_hyphen_values)]` is clap's attribute of the same name: `--args -destroy` binds
 `-destroy` instead of reading `-d` as a short. The flag has to take a value; a positional that

--- a/docs/rust/clap-compatibility.md
+++ b/docs/rust/clap-compatibility.md
@@ -75,9 +75,7 @@ the Rust declaration, not only from generated KDL, wherever the bridge column sa
 | `dont_delimit_trailing_values`                               | yes        | yes  | yes   | yes | yes    | yes        | Preserves delimiters after `--` and on automatic trailing positionals while ordinary values still split.                                                |
 | possible-values parser                                       | yes        | yes  | yes   | yes | yes    | yes        | Use `ValueEnum` or `choices`.                                                                                                                           |
 | arbitrary `value_parser` callbacks                           | usage-only | yes  | lossy | yes | yes    | no         | `FromStr` handles typed conversion and portable `validate` expressions handle declarative rules; Rust callbacks cannot enter KDL.                       |
-| `ValueHint::{FilePath,DirPath}`                              | yes        | yes  | yes   | yes | yes    | lossy      | Shell-native path completion is supported directly; `clap_usage` does not yet lower hints into completion nodes.                                        |
-| executable and command value hints                           | yes        | yes  | yes   | yes | yes    | lossy      | Direct usage declarations work; the clap bridge currently reports and drops these hints.                                                                |
-| identity and network `ValueHint`s                            | no         | no   | no    | no  | no     | lossy      | Username, hostname, URL, email, and related hints are not yet represented.                                                                              |
+| `ValueHint` completion vocabulary                            | yes        | yes  | yes   | yes | yes    | yes        | Every stable clap hint lowers to a portable completion type; open-ended URL/email hints suppress path fallback.                                         |
 
 ## Relationships and command routing
 

--- a/docs/rust/completions.md
+++ b/docs/rust/completions.md
@@ -79,9 +79,10 @@ file: Option<PathBuf>,
 task: Option<String>,
 ```
 
-`ValueHint` (`FilePath`, `DirPath`, `AnyPath`) answers with the shell's own file/directory
-completion and also emits `complete "file" type="path"` into the KDL, so external consumers of
-the spec give the same answer.
+`ValueHint` carries clap's full stable vocabulary. Path, executable, and command hints delegate
+to the shell; username and hostname hints use system candidates; `Other`, URL, and email values
+suppress the shell's misleading filename fallback. Every hint emits a portable `complete`
+type into KDL so external consumers preserve the same policy.
 
 A custom completer is a plain function, referenced by _path_ — a typo is a compile error, not a
 silent dead completer:

--- a/examples/run-named-builtin.usage.kdl
+++ b/examples/run-named-builtin.usage.kdl
@@ -1,0 +1,2 @@
+arg "<url>"
+complete "url" run="printf 'run-result\\n'"

--- a/go/argv/request.go
+++ b/go/argv/request.go
@@ -149,8 +149,13 @@ func filesAt(pos Position, split SplitLine, candidates []Candidate, meta Metadat
 		if m.ValueName != "" {
 			named = m.ValueName
 		}
-		if asked := declaredFiles(m.CompleteType, pos); asked != NoFiles {
-			return asked
+		if m.CompleteType != "" {
+			if asked := declaredFiles(m.CompleteType, pos); asked != NoFiles {
+				return asked
+			}
+			if !strings.EqualFold(m.CompleteType, "unknown") {
+				return NoFiles
+			}
 		}
 	}
 	if asked := filesFor(named); asked != NoFiles {

--- a/go/argv/request_test.go
+++ b/go/argv/request_test.go
@@ -179,6 +179,25 @@ func TestFlagsDoNotCloseThePositionToPaths(t *testing.T) {
 	}
 }
 
+func TestOpenEndedValueHintsSuppressPathFallback(t *testing.T) {
+	root := &Command{Key: 1, Name: "ex", Args: []*Arg{{Key: 2, Name: "URL"}}}
+	help := HelpTable{{Key: 1}, {Key: 2}}
+
+	for _, typeName := range []string{"none", "username", "hostname", "url", "email"} {
+		meta := Metadata{{Key: 1}, {Key: 2, Name: "URL", CompleteType: typeName}}
+		answer := Request{Shell: Bash, Line: "ex ", Cursor: 3}.Answer(root, help, meta)
+		if answer.Files != NoFiles {
+			t.Errorf("%s should suppress path fallback, got %v", typeName, answer.Files)
+		}
+	}
+
+	meta := Metadata{{Key: 1}, {Key: 2, Name: "URL", CompleteType: "unknown"}}
+	answer := Request{Shell: Bash, Line: "ex ", Cursor: 3}.Answer(root, help, meta)
+	if answer.Files != AnyFile {
+		t.Errorf("unknown should preserve normal fallback, got %v", answer.Files)
+	}
+}
+
 func TestHiddenChoicesCloseThePositionToPaths(t *testing.T) {
 	root := &Command{Key: 1, Name: "ex", Args: []*Arg{{Key: 2, Name: "MODE"}}}
 	help := HelpTable{{Key: 1}, {Key: 2}}

--- a/lib/src/spec/arg.rs
+++ b/lib/src/spec/arg.rs
@@ -841,6 +841,27 @@ pub(crate) fn value_names_from_clap(source: &clap::Arg) -> Vec<String> {
     }
 }
 
+/// The portable completion type corresponding to clap's complete `ValueHint` vocabulary.
+#[cfg(feature = "clap")]
+pub(crate) fn value_hint_type(hint: clap::ValueHint) -> Option<&'static str> {
+    use clap::ValueHint;
+
+    match hint {
+        ValueHint::Unknown => None,
+        ValueHint::Other => Some("none"),
+        ValueHint::AnyPath | ValueHint::FilePath => Some("path"),
+        ValueHint::DirPath => Some("dir"),
+        ValueHint::ExecutablePath => Some("executable"),
+        ValueHint::CommandName | ValueHint::CommandString => Some("command"),
+        ValueHint::CommandWithArguments => Some("command_args"),
+        ValueHint::Username => Some("username"),
+        ValueHint::Hostname => Some("hostname"),
+        ValueHint::Url => Some("url"),
+        ValueHint::EmailAddress => Some("email"),
+        _ => None,
+    }
+}
+
 #[cfg(feature = "clap")]
 pub(crate) fn choices_from_clap(arg: &clap::Arg) -> Option<SpecChoices> {
     let possible = arg.get_possible_values();

--- a/lib/src/spec/cmd.rs
+++ b/lib/src/spec/cmd.rs
@@ -1118,6 +1118,7 @@ impl From<&clap::Command> for SpecCommand {
             spec.hidden_aliases.push(alias.to_string());
         }
         for arg in cmd.get_arguments() {
+            let complete_type = crate::spec::arg::value_hint_type(arg.get_value_hint());
             let conflicts: Vec<String> = cmd
                 .get_arg_conflicts_with(arg)
                 .iter()
@@ -1132,6 +1133,17 @@ impl From<&clap::Command> for SpecCommand {
                 let mut positional: SpecArg = arg.into();
                 positional.allow_negative_numbers |= cmd.is_allow_negative_numbers_set();
                 positional.conflicts = conflicts;
+                if let Some(type_) = complete_type {
+                    let name = positional.name.to_lowercase();
+                    spec.complete.insert(
+                        name.clone(),
+                        SpecComplete {
+                            name,
+                            type_: Some(type_.to_string()),
+                            ..Default::default()
+                        },
+                    );
+                }
                 spec.args.push(positional)
             } else {
                 let mut flag: SpecFlag = arg.into();
@@ -1146,6 +1158,17 @@ impl From<&clap::Command> for SpecCommand {
                 // `--long`: taking only the long form would have dropped the conflict
                 // and let the spec accept a combination clap rejects.
                 flag.conflicts = conflicts;
+                if let (Some(type_), Some(value)) = (complete_type, flag.arg.as_ref()) {
+                    let name = value.name.to_lowercase();
+                    spec.complete.insert(
+                        name.clone(),
+                        SpecComplete {
+                            name,
+                            type_: Some(type_.to_string()),
+                            ..Default::default()
+                        },
+                    );
+                }
                 spec.flags.push(flag)
             }
         }

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -435,6 +435,24 @@ struct CompletionDedup {
     output: Option<PathBuf>,
 }
 
+#[derive(Cli)]
+#[usage(bin = "value-hints")]
+#[allow(dead_code)]
+struct ValueHints {
+    #[usage(long, value_hint = usage::ValueHint::Unknown)]
+    unknown: Option<String>,
+    #[usage(long, value_hint = usage::ValueHint::Other)]
+    other: Option<String>,
+    #[usage(long, value_hint = usage::ValueHint::Username)]
+    username: Option<String>,
+    #[usage(long, value_hint = usage::ValueHint::Hostname)]
+    hostname: Option<String>,
+    #[usage(long, value_hint = usage::ValueHint::Url)]
+    url: Option<String>,
+    #[usage(long, value_hint = usage::ValueHint::EmailAddress)]
+    email: Option<String>,
+}
+
 #[derive(Args)]
 struct SharedArgs {
     #[usage(long)]
@@ -589,6 +607,24 @@ fn identical_builtin_completers_are_emitted_once() {
 
     let kdl = CompletionDedup::to_kdl();
     assert_eq!(kdl.matches("complete path type=path").count(), 1, "{kdl}");
+}
+
+#[test]
+fn the_full_value_hint_vocabulary_reaches_portable_completion_types() {
+    let kdl = ValueHints::to_kdl();
+    for (name, type_) in [
+        ("unknown", "unknown"),
+        ("other", "none"),
+        ("username", "username"),
+        ("hostname", "hostname"),
+        ("url", "url"),
+        ("email", "email"),
+    ] {
+        assert!(
+            kdl.contains(&format!("complete {name} type={type_}")),
+            "{kdl}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- expose every stable clap `ValueHint` through typed usage declarations and the clap bridge
- provide username and hostname candidates while suppressing incorrect path fallback for open-ended hints
- keep `Unknown` open to normal shell fallback and retain shell-out `run` completers
- document the portable vocabulary and close the PLAN gap

## Test plan
- `cargo test --all --all-features`
- `cargo clippy --all --all-features -- -D warnings`
- `go test ./...` (from `go/`)
- `mise run render`
- `mise run gen-shadow`
- `mise run gen-go`

_This pull request was generated with Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to completion metadata and shell suggestions, with broad test coverage; no parsing or auth paths are touched.
> 
> **Overview**
> Adds the **full stable clap `ValueHint` set** to `usage::ValueHint`, the derive, KDL, and **`clap_usage`** (value hints are no longer fidelity losses). The clap bridge now emits `complete` nodes with portable `type=` strings for flags and positionals.
> 
> **Completion behavior** is aligned across **Rust (`argv` + usage-cli)**, **Go**, and tests: path-like hints still request files; **`username`** / **`hostname`** use system sources; **`none`**, **`url`**, and **`email`** close the position without offering paths; **`unknown`** alone keeps name-based path fallback. Explicit `complete.type` is honored before inferring builtins from argument names, so a `run=` completer can coexist with a reserved-looking name.
> 
> Docs and **PLAN.md** mark the ValueHint gap closed; compatibility matrix rows are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0ed699fec0ce78b41506fd25fb2cc237c8acaa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->