### PR TITLE
docs(plan): record completion corpus coverage

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1414,13 +1414,15 @@ docs.
 
 ## Not covered by the corpus yet
 
-- [ ] **Restart tokens** — `restart_token` (mise's `:::`) makes one command line
-      describe several invocations. `expect` holds a single result, so this needs a
-      multi-invocation vector shape first.
+- [x] **Restart tokens** — the completion corpus covers returning to the first
+      argument, prefix filtering after the restart, and flags remaining available.
+      This is the observable contract restart tokens have while a line is partial;
+      successful binding remains one invocation at a time.
 - [ ] **Mounts** — `mount` resolves a sub-spec by running a command mid-parse,
       which makes a vector depend on an external process. Needs stubbing.
-- [ ] **Completion parsing** — `parse_partial` accepts deliberately incomplete
-      input. Different contract, different expectations, its own corpus.
+- [x] **Completion parsing** — `corpus/complete` is the separate partial-input
+      corpus, with line/cursor positions, candidates, path fallback, and explicit
+      reference-agreement labels. It runs against usage-argv and usage-cli.
 
 ## Known usage-lib divergences
 


### PR DESCRIPTION
## Summary

- mark restart-token completion coverage complete based on the existing shared corpus vectors
- mark partial completion parsing coverage complete based on `corpus/complete`
- replace the stale prerequisite text with the behavior and cross-implementation gate that exist today

## Verification

- `prettier -c PLAN.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only status update in PLAN.md; no code, parser, or corpus behavior changes.
> 
> **Overview**
> Updates `PLAN.md` so the corpus status matches what already exists: **restart tokens** and **completion parsing** are marked done.
> 
> The notes now describe the actual gate: partial-line restart-token behavior (return to the first argument, prefix filtering, flags still available) plus `corpus/complete` (cursor positions, candidates, path fallback, reference-agreement labels) running against usage-argv and usage-cli. Successful binding is still one invocation at a time. Mounts remain uncovered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit accff77d55d8bfafa76e03d47caf07a0865c29fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->