### PR TITLE
feat(complete): expand partial path segments

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -576,6 +576,12 @@ Groups are the opposite case: `Command::get_groups`, `ArgGroup::get_args` and
 **API surface**
 
 - [ ] **`update_from` / `try_update_from`** — merge a parse into an existing struct.
+      **Design input needed:** define whether requirements and value-conditional relationships
+      see the existing typed value when argv omits a field, whether environment/default values
+      replace existing values during an update, whether collections append or replace, and
+      whether selecting a different subcommand replaces the old variant. The generated parser
+      cannot seed its byte-level partial from an arbitrary `FromStr` type, so these choices must
+      be explicit rather than inherited accidentally from the current full-parse path.
 - [x] **The builder** — `Command::new`, `augment_args`, `CommandFactory`,
       `ArgMatches::get_one`, hand-written `FromArgMatches`. Architectural, and
       deliberate: usage-lib interprets a spec at run time and covers the dynamic
@@ -1339,12 +1345,14 @@ above are where it lands.
       accepting unknown values. Strict validation remains the default. mise's
       tool names are this exact shape: a registry to offer, arbitrary backends
       still legal.
-- [ ] **Completion runtime niceties** — completions that work when the binary
-      is invoked through a shell alias (clap#1764, stalled since 2020), and
-      multi-segment path completion, `tar/de/inc` completing to
-      `target/debug/incremental` (clap#5279). usage owns the registration
-      scripts and the `complete-word` runtime, so each is implementable once,
-      for every shell.
+- [ ] **Completion through shell aliases** (clap#1764, stalled since 2020).
+      The runtime already ignores argv0, but registration differs by shell; define whether usage
+      should discover aliases, install a default completion handler, or expose an explicit alias
+      registration API before changing every generated script.
+- [x] **Multi-segment path completion** (clap#5279). The shared runtime resolves the
+      typed parent path and preserves every segment in the candidate, so
+      `target/de/inc` completes to `target/debug/incremental/`; an end-to-end regression
+      exercises the same `complete-word` entry all generated shell scripts call.
 - [x] **`--flag=false` on booleans** (clap#5577; clap#1649 closed with 28
       reactions behind it) — **semantic decided (2026-08-19): opt-in per flag,
       and `=`-attached only.** `--flag=false` binds; `--flag false` never does,

--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -697,28 +697,37 @@ impl CompleteWord {
     ) -> Vec<String> {
         trace!("complete_path: {ctoken}");
         let path = PathBuf::from(ctoken);
-        let mut dir = path.parent().unwrap_or(&path).to_path_buf();
-        if dir.is_relative() {
-            dir = base.join(dir);
-        }
-        let mut prefix = path
-            .file_name()
-            .unwrap_or_default()
-            .to_string_lossy()
-            .to_string();
-        if path.is_dir() && ctoken.ends_with('/') {
-            dir = path.to_path_buf();
-            prefix = "".to_string();
+        let exact = if path.is_absolute() {
+            path.clone()
+        } else {
+            base.join(&path)
         };
-        std::fs::read_dir(dir)
-            .ok()
+        // A slash means "show this directory's children" only after the directory itself is
+        // exact. For an abbreviated segment (`tar/` or `target/de/`), Path still exposes the
+        // final non-empty component as `file_name`; keep completing that component first.
+        let trailing_separator = (ctoken.ends_with(std::path::MAIN_SEPARATOR)
+            || (cfg!(windows) && ctoken.ends_with('/')))
+            && exact.is_dir();
+        let (parent, prefix) = if trailing_separator {
+            (path.as_path(), "")
+        } else {
+            (
+                path.parent().unwrap_or_else(|| Path::new("")),
+                path.file_name()
+                    .unwrap_or_default()
+                    .to_str()
+                    .unwrap_or_default(),
+            )
+        };
+
+        resolve_path_dirs(base, parent)
             .into_iter()
-            .flatten()
+            .flat_map(|dir| std::fs::read_dir(dir).ok().into_iter().flatten())
             .filter_map(Result::ok)
             .filter(|de| {
                 let name = de.file_name();
                 let name = name.to_string_lossy();
-                !name.starts_with('.') && name.starts_with(&prefix)
+                !name.starts_with('.') && name.starts_with(prefix)
             })
             .filter(|de| filter(&de.path()))
             .map(|de| {
@@ -770,6 +779,40 @@ impl CompleteWord {
             .map(|value| (value, String::new()))
             .collect()
     }
+}
+
+/// Existing directories described by a possibly abbreviated path.
+///
+/// Exact parents keep the old single-directory fast path. When one does not exist, resolve its
+/// parent first and expand the final segment as a directory prefix; recursion is what lets every
+/// component be partial (`tar/de` -> `target/debug`) rather than only the component at the cursor.
+fn resolve_path_dirs(base: &Path, path: &Path) -> Vec<PathBuf> {
+    let exact = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        base.join(path)
+    };
+    if exact.is_dir() {
+        return vec![exact];
+    }
+
+    let Some(prefix) = path.file_name().and_then(|name| name.to_str()) else {
+        return Vec::new();
+    };
+    let parent = path.parent().unwrap_or_else(|| Path::new(""));
+    resolve_path_dirs(base, parent)
+        .into_iter()
+        .flat_map(|dir| std::fs::read_dir(dir).ok().into_iter().flatten())
+        .filter_map(Result::ok)
+        .filter(|entry| {
+            entry.file_type().is_ok_and(|kind| kind.is_dir())
+                && entry
+                    .file_name()
+                    .to_str()
+                    .is_some_and(|name| !name.starts_with('.') && name.starts_with(prefix))
+        })
+        .map(|entry| entry.path())
+        .collect()
 }
 
 fn complete_usernames(prefix: &str) -> Vec<(String, String)> {

--- a/cli/tests/shell_completions_integration.rs
+++ b/cli/tests/shell_completions_integration.rs
@@ -153,6 +153,16 @@ fn checked_in_completion(name: &str) -> PathBuf {
 
 /// Helper to run usage complete-word and return stdout
 fn run_complete_word(usage_bin: &Path, shell: &str, spec_file: &Path, words: &[&str]) -> String {
+    run_complete_word_in(usage_bin, shell, spec_file, words, None)
+}
+
+fn run_complete_word_in(
+    usage_bin: &Path,
+    shell: &str,
+    spec_file: &Path,
+    words: &[&str],
+    cwd: Option<&Path>,
+) -> String {
     let mut args = vec![
         "complete-word".to_string(),
         "--shell".to_string(),
@@ -163,10 +173,12 @@ fn run_complete_word(usage_bin: &Path, shell: &str, spec_file: &Path, words: &[&
     ];
     args.extend(words.iter().map(|w| w.to_string()));
 
-    let output = Command::new(usage_bin)
-        .args(&args)
-        .output()
-        .expect("Failed to run usage complete-word");
+    let mut command = Command::new(usage_bin);
+    command.args(&args);
+    if let Some(cwd) = cwd {
+        command.current_dir(cwd);
+    }
+    let output = command.output().expect("Failed to run usage complete-word");
 
     String::from_utf8_lossy(&output.stdout).to_string()
 }
@@ -1856,5 +1868,53 @@ complete path type="path"
     );
 
     // Cleanup
+    let _ = fs::remove_dir_all(&temp_dir);
+}
+
+#[test]
+fn test_complete_path_preserves_partially_typed_segments() {
+    static NEXT: AtomicUsize = AtomicUsize::new(0);
+    let usage_bin = build_usage_binary();
+    let temp_dir = env::temp_dir().join(format!(
+        "usage_segment_path_test_{}_{}",
+        std::process::id(),
+        NEXT.fetch_add(1, Ordering::Relaxed)
+    ));
+    fs::create_dir_all(temp_dir.join("target/debug/incremental")).unwrap();
+
+    let spec_file = temp_dir.join("test.spec");
+    fs::write(
+        &spec_file,
+        "name testcli\nbin testcli\narg <path>\ncomplete path type=\"path\"\n",
+    )
+    .unwrap();
+
+    let output = run_complete_word_in(
+        &usage_bin,
+        "bash",
+        &spec_file,
+        &["testcli", "target/de/inc"],
+        Some(&temp_dir),
+    );
+    assert_eq!(output, "target/debug/incremental/\n");
+
+    let output = run_complete_word_in(
+        &usage_bin,
+        "bash",
+        &spec_file,
+        &["testcli", "tar/"],
+        Some(&temp_dir),
+    );
+    assert_eq!(output, "target/\n");
+
+    let output = run_complete_word_in(
+        &usage_bin,
+        "bash",
+        &spec_file,
+        &["testcli", "target/de/"],
+        Some(&temp_dir),
+    );
+    assert_eq!(output, "target/debug/\n");
+
     let _ = fs::remove_dir_all(&temp_dir);
 }


### PR DESCRIPTION
## Summary

- expand every partially typed directory component during path completion
- preserve exact-parent behavior and directory suffixes
- add end-to-end coverage and record the remaining alias-registration design question

## Testing

- `cargo test -p usage-cli --test shell_completions_integration test_complete_path -- --nocapture`

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Completion-only filesystem matching; no parse, auth, or spec-model changes. Recursion is bounded to existing directory prefixes.
> 
> **Overview**
> Path completion now expands **every abbreviated directory component**, not just the last one. `target/de/inc` completes to `target/debug/incremental/`, and a trailing slash lists children only when that directory exists exactly (`tar/` still completes `target/`).
> 
> `complete_path` walks parents via new `resolve_path_dirs` instead of reading a single parent directory. An integration test covers the `complete-word` path all generated shells use.
> 
> `PLAN.md` marks clap#5279 done, splits alias-based completion (clap#1764) as an open design question, and notes the remaining `update_from` semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dc9ab46de5709dd1464e38f7ce8c8ef27522fb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->