### PR TITLE
test(parse): cover mounted command discovery

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1429,8 +1429,9 @@ docs.
       argument, prefix filtering after the restart, and flags remaining available.
       This is the observable contract restart tokens have while a line is partial;
       successful binding remains one invocation at a time.
-- [ ] **Mounts** — `mount` resolves a sub-spec by running a command mid-parse,
-      which makes a vector depend on an external process. Needs stubbing.
+- [x] **Mounts** — corpus vectors inject deterministic stdout by exact `run`
+      declaration, so usage-lib exercises discovery without spawning a process
+      and static-table runners compose the same mounted sub-spec before binding.
 - [x] **Completion parsing** — `corpus/complete` is the separate partial-input
       corpus, with line/cursor positions, candidates, path fallback, and explicit
       reference-agreement labels. It runs against usage-argv and usage-cli.

--- a/conformance/src/argv.rs
+++ b/conformance/src/argv.rs
@@ -45,10 +45,16 @@ impl Outcome {
 
 /// Parse a vector with usage-argv.
 pub fn run(vector: &Vector) -> Outcome {
-    let spec: Spec = match vector.spec.parse() {
+    let mut spec: Spec = match vector.spec.parse() {
         Ok(spec) => spec,
         Err(e) => return Outcome::BadSpec(e.to_string()),
     };
+    if !vector.mounts.is_empty() {
+        let outputs = vector.mounts.clone().into_iter().collect();
+        if let Err(error) = spec.resolve_mount_outputs(&outputs) {
+            return Outcome::BadSpec(error.to_string());
+        }
+    }
 
     if let Some(reason) = out_of_scope(vector) {
         return Outcome::OutOfScope(reason);

--- a/conformance/src/lib.rs
+++ b/conformance/src/lib.rs
@@ -63,6 +63,10 @@ pub struct Vector {
     /// can depend on the machine running it.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub env: BTreeMap<String, String>,
+    /// Deterministic stdout for mount commands, keyed by the exact `run` string.
+    /// Absent means the spec declares no mounts.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub mounts: BTreeMap<String, String>,
     pub expect: Expect,
     /// Whether usage-lib, the reference implementation, agrees with `expect`.
     ///

--- a/conformance/src/reference.rs
+++ b/conformance/src/reference.rs
@@ -62,7 +62,11 @@ pub fn run(vector: &Vector) -> Observed {
     let mut input = vec![vector.argv0.clone().unwrap_or_else(|| spec.bin.clone())];
     input.extend(vector.argv.iter().cloned());
 
-    match Parser::new(&spec).with_env(env).parse(&input) {
+    match Parser::new(&spec)
+        .with_env(env)
+        .with_mount_outputs(vector.mounts.clone().into_iter().collect())
+        .parse(&input)
+    {
         Ok(out) => {
             let cmd = out
                 .cmds

--- a/corpus/13-mounts.json
+++ b/corpus/13-mounts.json
@@ -1,0 +1,95 @@
+{
+  "section": "mounts",
+  "about": "Mount commands discover specs at parse time. Their stdout is injected by exact run string so the grammar does not depend on a shell, executable, filesystem, or host platform.",
+  "vectors": [
+    {
+      "id": "root-mount-discovers-command",
+      "doc": "An unknown command name triggers the root mount and is re-examined against the commands it contributes.",
+      "spec": "name \"ex\"\nbin \"ex\"\nmount run=\"discover commands\"\n",
+      "argv": ["dynamic", "--force"],
+      "mounts": {
+        "discover commands": "name \"plugins\"\nbin \"plugins\"\ncmd \"dynamic\" {\n  flag \"--force\"\n}\n"
+      },
+      "expect": {
+        "ok": {
+          "cmd": ["dynamic"],
+          "flags": { "force": true }
+        }
+      }
+    },
+    {
+      "id": "nested-mount-discovers-command",
+      "doc": "A mount on a selected command contributes its children at that command rather than at the root.",
+      "spec": "name \"ex\"\nbin \"ex\"\ncmd \"plugin\" {\n  mount run=\"discover plugin commands\"\n}\n",
+      "argv": ["plugin", "run", "task"],
+      "mounts": {
+        "discover plugin commands": "name \"plugin\"\nbin \"plugin\"\ncmd \"run\" {\n  arg \"<task>\"\n}\n"
+      },
+      "expect": {
+        "ok": {
+          "cmd": ["plugin", "run"],
+          "args": { "task": "task" }
+        }
+      }
+    },
+    {
+      "id": "default-subcommand-outranks-root-mount",
+      "doc": "A root mount that does not opt into overriding the default cannot claim an unmatched word from that default.",
+      "spec": "name \"ex\"\nbin \"ex\"\ndefault_subcommand \"run\"\nmount run=\"discover commands\"\ncmd \"run\" {\n  arg \"<task>\"\n}\n",
+      "argv": ["dynamic"],
+      "mounts": {
+        "discover commands": "name \"plugins\"\nbin \"plugins\"\ncmd \"dynamic\"\n"
+      },
+      "expect": {
+        "ok": {
+          "cmd": ["run"],
+          "args": { "task": "dynamic" }
+        }
+      }
+    },
+    {
+      "id": "root-mount-can-override-default-subcommand",
+      "doc": "A root mount with overrides_default may discover a command before the default consumes its name.",
+      "spec": "name \"ex\"\nbin \"ex\"\ndefault_subcommand \"run\"\nmount run=\"discover commands\" overrides_default=#true\ncmd \"run\" {\n  arg \"<task>\"\n}\n",
+      "argv": ["dynamic"],
+      "mounts": {
+        "discover commands": "name \"plugins\"\nbin \"plugins\"\ncmd \"dynamic\"\n"
+      },
+      "expect": {
+        "ok": {
+          "cmd": ["dynamic"]
+        }
+      }
+    },
+    {
+      "id": "mounted-command-owns-colliding-flag",
+      "doc": "After crossing a mount boundary, the mounted command's local spelling owns a name that also belongs to the mounting CLI's global flag.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--env <root-env>\" global=#true\nmount run=\"discover task\"\n",
+      "argv": ["task", "--env", "task-env"],
+      "mounts": {
+        "discover task": "name \"tasks\"\nbin \"tasks\"\ncmd \"task\" {\n  flag \"--env <task-env>\"\n}\n"
+      },
+      "expect": {
+        "ok": {
+          "cmd": ["task"],
+          "flags": { "env": "task-env" }
+        }
+      }
+    },
+    {
+      "id": "mounted-root-flags-merge-at-mount-point",
+      "doc": "Flags on the mounted spec's root are accepted at the command holding the mount, alongside its discovered children.",
+      "spec": "name \"ex\"\nbin \"ex\"\ncmd \"plugin\" {\n  mount run=\"discover plugin root\"\n}\n",
+      "argv": ["plugin", "--verbose", "run"],
+      "mounts": {
+        "discover plugin root": "name \"plugin\"\nbin \"plugin\"\nflag \"--verbose\"\ncmd \"run\"\n"
+      },
+      "expect": {
+        "ok": {
+          "cmd": ["plugin", "run"],
+          "flags": { "verbose": true }
+        }
+      }
+    }
+  ]
+}

--- a/corpus/README.md
+++ b/corpus/README.md
@@ -40,6 +40,7 @@ the group establishes, and `vectors`:
 | `argv`      | the command line, excluding the program name                                                                                                                       |
 | `argv0`     | the process's argv[0], when that is the question; absent means the spec's `bin`. A `multicall` applet is selected by this basename rather than by a word in `argv` |
 | `env`       | the environment the parse sees; absent means empty                                                                                                                 |
+| `mounts`    | deterministic stdout for mount commands, keyed by the exact `run` string; harnesses inject these instead of spawning a process                                     |
 | `expect`    | `{"ok": {...}}` or `{"error": "code"}`                                                                                                                             |
 | `reference` | whether usage-lib agrees; see below                                                                                                                                |
 

--- a/docs/spec/argv.md
+++ b/docs/spec/argv.md
@@ -464,9 +464,6 @@ rather than discovered by whoever writes the next implementation.
   holds a single result. Supporting it needs a multi-invocation shape, and until
   then usage-lib's behavior — rewind, and let the last invocation's bindings
   stand — is untested here.
-- **Mounts.** `mount` resolves a sub-spec by running a command during the parse.
-  That makes a vector depend on an external process, so it needs a stubbing
-  mechanism first.
 - **Completion parsing.** `parse_partial` deliberately accepts incomplete input
   to drive completions. It is a different contract with different expectations,
   and deserves its own corpus.

--- a/docs/spec/reference/cmd.md
+++ b/docs/spec/reference/cmd.md
@@ -88,6 +88,11 @@ task commands as if they were statically defined in the usage spec.
 a shebang script therefore needs a POSIX shell to be available; one that invokes a program
 directly, like `mycli mount-usage-tasks` above, works either way.
 
+Tests and deterministic generators can opt out of process execution with
+`usage::parse::Parser::with_mount_outputs`. The supplied map is keyed by the exact
+`run` declaration and must contain every mount the parse reaches; a missing entry
+is an error rather than permission to fall back to the host shell.
+
 ### Mounting at the top level
 
 A `mount` also works as a top-level node, for a CLI whose _own_ commands are

--- a/go/conformance/conformance_test.go
+++ b/go/conformance/conformance_test.go
@@ -41,6 +41,7 @@ type Vector struct {
 	Argv   []string          `json:"argv"`
 	Argv0  *string           `json:"argv0"`
 	Env    map[string]string `json:"env"`
+	Mounts map[string]string `json:"mounts"`
 	Expect Expect            `json:"expect"`
 	// Layer says which layer of a parser the vector is a question for. Absent
 	// means binding, which is the default and most of them.
@@ -94,10 +95,16 @@ func TestCorpus(t *testing.T) {
 			}
 			ran++
 
-			s, ok := lowered[v.Spec]
+			mountKey, err := json.Marshal(v.Mounts)
+			if err != nil {
+				t.Fatalf("encoding mount outputs: %v", err)
+			}
+			key := v.Spec + "\x00" + string(mountKey)
+			s, ok := lowered[key]
 			if !ok {
 				s = lower(t, usageBin, v.Spec)
-				lowered[v.Spec] = s
+				resolveMounts(t, usageBin, &s.Cmd, v.Mounts, s.DefaultSubcommand != "")
+				lowered[key] = s
 			}
 
 			got, gotErr := run(s, v.Argv, v.Argv0, v.Env)
@@ -138,6 +145,83 @@ func TestCorpus(t *testing.T) {
 	if skipped != len(notYet) {
 		t.Errorf("skipped %d vectors but `notYet` lists %d; a listed id may have been "+
 			"renamed, which would silently stop excluding anything", skipped, len(notYet))
+	}
+}
+
+// resolveMounts composes injected mount stdout before building static tables.
+// usage-lib receives the same map at parse time; Go deliberately never starts
+// processes from its parser, so its corpus adapter performs the equivalent
+// deterministic lowering here.
+func resolveMounts(t *testing.T, usageBin string, cmd *spec.Cmd, outputs map[string]string, defaultAtRoot bool) {
+	t.Helper()
+	defaultOutranksMounts := defaultAtRoot
+	for _, mount := range cmd.Mounts {
+		defaultOutranksMounts = defaultOutranksMounts && !mount.OverridesDefault
+	}
+	if !defaultOutranksMounts {
+		for _, mount := range cmd.Mounts {
+			output, ok := outputs[mount.Run]
+			if !ok {
+				t.Fatalf("no injected output for mount command %q", mount.Run)
+			}
+			mounted := lower(t, usageBin, output)
+			resolveMounts(t, usageBin, &mounted.Cmd, outputs, false)
+			mergeMountedCommand(cmd, &mounted.Cmd)
+		}
+		cmd.Mounts = nil
+	}
+	for i := range cmd.Subcommands {
+		resolveMounts(t, usageBin, &cmd.Subcommands[i].Cmd, outputs, false)
+	}
+}
+
+func mergeMountedCommand(dst, mounted *spec.Cmd) {
+	if mounted.Name != "" {
+		dst.Name = mounted.Name
+	}
+	if len(mounted.Args) > 0 {
+		dst.Args = mounted.Args
+	}
+	if len(mounted.Flags) > 0 {
+		dst.Flags = mounted.Flags
+	}
+	if len(mounted.Aliases) > 0 {
+		dst.Aliases = mounted.Aliases
+	}
+	if len(mounted.HiddenAliases) > 0 {
+		dst.HiddenAliases = mounted.HiddenAliases
+	}
+	if mounted.UnknownFlags != nil {
+		dst.UnknownFlags = mounted.UnknownFlags
+	}
+	dst.ExternalSubcommand = mounted.ExternalSubcommand
+	dst.ArgRequiredElseHelp = mounted.ArgRequiredElseHelp
+	dst.DisableHelpFlag = mounted.DisableHelpFlag
+	dst.DisableHelpSubcommand = mounted.DisableHelpSubcommand
+	dst.DisableVersionFlag = mounted.DisableVersionFlag
+	dst.DontDelimitTrailingValues = mounted.DontDelimitTrailingValues
+	dst.ArgsOverrideSelf = mounted.ArgsOverrideSelf
+	dst.SubcommandNegatesReqs = mounted.SubcommandNegatesReqs
+	dst.ArgsConflictWithSubcommands = mounted.ArgsConflictWithSubcommands
+	dst.SubcommandPrecedenceOverArg = mounted.SubcommandPrecedenceOverArg
+	dst.AllowMissingPositional = mounted.AllowMissingPositional
+	dst.SubcommandRequired = mounted.SubcommandRequired
+	mergeSubcommands(&dst.Subcommands, mounted.Subcommands)
+}
+
+func mergeSubcommands(dst *spec.Subcommands, additions spec.Subcommands) {
+	for _, addition := range additions {
+		replaced := false
+		for i := range *dst {
+			if (*dst)[i].Name == addition.Name {
+				(*dst)[i] = addition
+				replaced = true
+				break
+			}
+		}
+		if !replaced {
+			*dst = append(*dst, addition)
+		}
 	}
 }
 

--- a/go/internal/spec/spec.go
+++ b/go/internal/spec/spec.go
@@ -103,6 +103,7 @@ type Cmd struct {
 	Subcommands                 Subcommands `json:"subcommands"`
 	Args                        []Arg       `json:"args"`
 	Flags                       []Flag      `json:"flags"`
+	Mounts                      []Mount     `json:"mounts"`
 	UnknownFlags                *string     `json:"unknown_flags"`
 	ExternalSubcommand          bool        `json:"external_subcommand"`
 	ArgRequiredElseHelp         bool        `json:"arg_required_else_help"`
@@ -120,6 +121,12 @@ type Cmd struct {
 	SubcommandRequired          bool        `json:"subcommand_required"`
 	NextLineHelp                bool        `json:"next_line_help"`
 	FlattenHelp                 bool        `json:"flatten_help"`
+}
+
+// Mount is a command whose stdout contributes another spec at this command.
+type Mount struct {
+	Run              string `json:"run"`
+	OverridesDefault bool   `json:"overrides_default"`
 }
 
 // Subcommands is a command's children, in the order the spec declared them.

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -126,6 +126,9 @@ pub enum UsageErr {
 
     #[error("Unsupported shell: {0}")]
     UnsupportedShell(String),
+
+    #[error("No injected output was provided for mount command: {0}")]
+    MissingMountOutput(String),
 }
 pub type Result<T> = std::result::Result<T, UsageErr>;
 

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -362,12 +362,17 @@ pub enum ParseValue {
 pub struct Parser<'a> {
     spec: &'a Spec,
     env: Option<HashMap<String, String>>,
+    mount_outputs: Option<HashMap<String, String>>,
 }
 
 impl<'a> Parser<'a> {
     /// Create a new parser for the given spec.
     pub fn new(spec: &'a Spec) -> Self {
-        Self { spec, env: None }
+        Self {
+            spec,
+            env: None,
+            mount_outputs: None,
+        }
     }
 
     /// Use a custom environment variable map instead of the process environment.
@@ -376,6 +381,17 @@ impl<'a> Parser<'a> {
     /// come from a child config file rather than the current process environment.
     pub fn with_env(mut self, env: HashMap<String, String>) -> Self {
         self.env = Some(env);
+        self
+    }
+
+    /// Inject deterministic outputs for mount commands instead of executing them.
+    ///
+    /// Keys are the exact `run` strings declared by mount nodes and values are the
+    /// usage specs those commands would print. When this is set, every encountered
+    /// mount must have an entry. Production parsing remains process-backed unless a
+    /// caller explicitly opts into injection.
+    pub fn with_mount_outputs(mut self, outputs: HashMap<String, String>) -> Self {
+        self.mount_outputs = Some(outputs);
         self
     }
 
@@ -388,6 +404,7 @@ impl<'a> Parser<'a> {
             self.spec,
             input,
             custom_env,
+            self.mount_outputs.as_ref(),
             MountTiming::WhenAWordIsUnknown,
         )?;
         trace!("{out:?}");
@@ -612,7 +629,7 @@ pub fn parse(spec: &Spec, input: &[String]) -> Result<ParseOutput, miette::Error
 /// Use this for help text generation or when you need the raw parsed values.
 #[must_use = "parsing result should be used"]
 pub fn parse_partial(spec: &Spec, input: &[String]) -> Result<ParseOutput, miette::Error> {
-    parse_partial_with_env(spec, input, None, MountTiming::Eager).map(|(out, _)| out)
+    parse_partial_with_env(spec, input, None, None, MountTiming::Eager).map(|(out, _)| out)
 }
 
 /// Basename of argv[0] for a multicall CLI: last path component, with a trailing
@@ -660,6 +677,7 @@ fn parse_partial_with_env(
     spec: &Spec,
     input: &[String],
     custom_env: Option<&HashMap<String, String>>,
+    mount_outputs: Option<&HashMap<String, String>>,
     mount_timing: MountTiming,
 ) -> Result<(ParseOutput, HashSet<String>), miette::Error> {
     trace!("parse_partial: {input:?}");
@@ -746,7 +764,7 @@ fn parse_partial_with_env(
     {
         mounts_resolved = true;
         let mut mounted = out.cmd.clone();
-        mounted.mount(&[])?;
+        mounted.mount(&[], mount_outputs)?;
         merge_subcommand_flags(&mut out.available_flags, gather_flags(&mounted), false);
         if let Some(last) = out.cmds.last_mut() {
             *last = mounted.clone();
@@ -777,7 +795,7 @@ fn parse_partial_with_env(
         {
             mounts_resolved = true;
             let mut mounted = out.cmd.clone();
-            mounted.mount(&mount_prefix_words(&prefix_flags))?;
+            mounted.mount(&mount_prefix_words(&prefix_flags), mount_outputs)?;
             merge_subcommand_flags(&mut out.available_flags, gather_flags(&mounted), false);
             if let Some(last) = out.cmds.last_mut() {
                 *last = mounted.clone();
@@ -799,7 +817,7 @@ fn parse_partial_with_env(
             }
             let mut subcommand = subcommand.clone();
             // Pass prefix words (global flags before this subcommand) to mount
-            subcommand.mount(&mount_prefix_words(&prefix_flags))?;
+            subcommand.mount(&mount_prefix_words(&prefix_flags), mount_outputs)?;
             // Only the *boundary* is a mount crossing: below it, the mounted program's own
             // commands are ordinary commands relative to each other.
             let crossing_mount = subcommand.mounted && !out.cmd.mounted;
@@ -904,7 +922,7 @@ fn parse_partial_with_env(
                         }
                         let mut subcommand = subcommand.clone();
                         // Pass prefix words (global flags before this) to mount
-                        subcommand.mount(&mount_prefix_words(&prefix_flags))?;
+                        subcommand.mount(&mount_prefix_words(&prefix_flags), mount_outputs)?;
                         let crossing_mount = subcommand.mounted && !out.cmd.mounted;
                         merge_subcommand_flags(
                             &mut out.available_flags,
@@ -3378,6 +3396,34 @@ mount run="echo 'cmd \"discovered\"'"
 
         let out = parse(&spec, &["ex".to_string(), "discovered".to_string()]).unwrap();
         assert_eq!(out.cmd.name, "discovered");
+    }
+
+    #[test]
+    fn injected_mount_outputs_are_complete_and_never_fall_back_to_processes() {
+        let spec: Spec = r#"
+name "ex"
+bin "ex"
+mount run="this command must never run"
+cmd "declared"
+"#
+        .parse()
+        .unwrap();
+
+        Parser::new(&spec)
+            .with_mount_outputs(HashMap::new())
+            .parse(&input(&["ex", "declared"]))
+            .expect("a declared command does not resolve the mount");
+
+        let error = Parser::new(&spec)
+            .with_mount_outputs(HashMap::new())
+            .parse(&input(&["ex", "discovered"]))
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("No injected output was provided for mount command"),
+            "{error}"
+        );
     }
 
     #[cfg(unix)]

--- a/lib/src/spec/cmd.rs
+++ b/lib/src/spec/cmd.rs
@@ -873,7 +873,11 @@ impl SpecCommand {
         self.subcommands.get(name)
     }
 
-    pub(crate) fn mount(&mut self, global_flag_args: &[String]) -> Result<(), UsageErr> {
+    pub(crate) fn mount(
+        &mut self,
+        global_flag_args: &[String],
+        injected: Option<&HashMap<String, String>>,
+    ) -> Result<(), UsageErr> {
         for mount in self.mounts.iter().cloned().collect_vec() {
             let cmd = if global_flag_args.is_empty() {
                 mount.run.clone()
@@ -890,8 +894,19 @@ impl SpecCommand {
                 // Join tokens back into a properly quoted command string
                 shell_words::join(tokens)
             };
-            let output = sh(&cmd)?;
+            let output = match injected {
+                Some(outputs) => outputs
+                    .get(&mount.run)
+                    .cloned()
+                    .ok_or_else(|| UsageErr::MissingMountOutput(mount.run.clone()))?,
+                None => sh(&cmd)?,
+            };
             let mut spec: Spec = output.parse()?;
+            if let Some(outputs) = injected {
+                // A mounted spec's root is merged into this command, so its root-only
+                // default-subcommand precedence does not apply while composing mounts.
+                spec.resolve_mount_outputs_at_root(outputs, false)?;
+            }
             // The subcommands emitted by a mount describe another program, so mark them (and
             // everything below them) as mounted. See `SpecCommand::mounted`.
             for cmd in spec.cmd.subcommands.values_mut() {

--- a/lib/src/spec/mod.rs
+++ b/lib/src/spec/mod.rs
@@ -18,6 +18,7 @@ use indexmap::IndexMap;
 use kdl::{KdlDocument, KdlEntry, KdlNode};
 use log::{info, warn};
 use serde::Serialize;
+use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use std::iter::once;
 use std::path::{Path, PathBuf};
@@ -114,6 +115,44 @@ pub struct Spec {
 }
 
 impl Spec {
+    /// Resolve every mount from supplied command outputs without spawning processes.
+    ///
+    /// This is intended for deterministic generators and conformance harnesses. The
+    /// map is keyed by each mount's exact `run` declaration. Missing entries are an
+    /// error, so injecting a partial view cannot silently execute the remainder.
+    pub fn resolve_mount_outputs(
+        &mut self,
+        outputs: &HashMap<String, String>,
+    ) -> Result<(), UsageErr> {
+        self.resolve_mount_outputs_at_root(outputs, true)
+    }
+
+    pub(crate) fn resolve_mount_outputs_at_root(
+        &mut self,
+        outputs: &HashMap<String, String>,
+        apply_default_subcommand: bool,
+    ) -> Result<(), UsageErr> {
+        fn resolve(
+            cmd: &mut SpecCommand,
+            outputs: &HashMap<String, String>,
+            skip_mounts: bool,
+        ) -> Result<(), UsageErr> {
+            if !skip_mounts && !cmd.mounts.is_empty() {
+                cmd.mount(&[], Some(outputs))?;
+                cmd.mounts.clear();
+            }
+            for subcommand in cmd.subcommands.values_mut() {
+                resolve(subcommand, outputs, false)?;
+            }
+            Ok(())
+        }
+
+        let default_outranks_root_mounts = apply_default_subcommand
+            && self.default_subcommand.is_some()
+            && !self.cmd.mounts.iter().any(|mount| mount.overrides_default);
+        resolve(&mut self.cmd, outputs, default_outranks_root_mounts)
+    }
+
     /// Parse a spec from a file.
     ///
     /// Automatically detects whether the file is:
@@ -1466,5 +1505,21 @@ echo "hello"
         assert_eq!(spec.name, "my-script.usage.kdl");
         assert_eq!(spec.bin, "my-script.usage.kdl");
         assert!(spec.cmd.name.is_empty());
+    }
+
+    #[test]
+    fn injected_nested_mounts_ignore_the_mounted_specs_root_default() {
+        let mut spec: Spec = "mount run=outer".parse().unwrap();
+        let outputs = HashMap::from([
+            (
+                "outer".to_string(),
+                "default_subcommand run\nmount run=nested\ncmd run".to_string(),
+            ),
+            ("nested".to_string(), "cmd leaf".to_string()),
+        ]);
+
+        spec.resolve_mount_outputs(&outputs).unwrap();
+
+        assert!(spec.cmd.subcommands.contains_key("leaf"));
     }
 }


### PR DESCRIPTION
## Summary

- add deterministic mount-output injection to usage-lib without changing production shell-backed mounts
- add shared corpus vectors for root/nested discovery, mounted flag precedence, and mounted-root flags
- teach the Rust static-table and Go corpus adapters to compose the same injected sub-specs
- close the mount coverage gap in PLAN

## Validation

- `cargo clippy --workspace --all-features -- -D warnings`
- `cargo test -p usage-conformance`
- `cargo test -p usage-lib --all-features`
- `(cd go && go test ./...)`

_This PR was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mount resolution in usage-lib and both corpus adapters, including default-subcommand vs discovery precedence. Production still shells out unless a caller opts into injection.
> 
> **Overview**
> Makes **mount discovery testable without spawning processes**. Callers can inject stdout keyed by the exact `run` string; a missing entry is an error rather than a silent fallback to the host shell.
> 
> Adds a mounts corpus covering root and nested discovery, default-subcommand precedence (including `overrides_default`), colliding flags after a mount boundary, and flags merged from a mounted spec’s root.
> 
> usage-lib’s parser and `Spec::resolve_mount_outputs` share that map. The usage-argv harness lowers mounts before building static tables; the Go runner composes the same injected sub-specs up front because its parser never starts processes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2b854b4971030277d72b3192daccfbd4eaa44bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->