### PR TITLE
test(parse): add clap micro-conformance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2455,6 +2455,7 @@ dependencies = [
 name = "usage-conformance"
 version = "0.0.0"
 dependencies = [
+ "clap",
  "insta",
  "kdl",
  "serde",

--- a/PLAN.md
+++ b/PLAN.md
@@ -824,16 +824,24 @@ feature list is not an exhaustive audit.
       `parse_from_argv` is the explicit full-argv helper: it strips the binary
       for ordinary CLIs and applies the same basename-selected applet rewrite as
       `parse()` for multicall CLIs, while returning errors for tests and embedders.
-- [ ] **Generated micro-conformance against clap.** One minimal CLI per matrix row,
-      compared on accepted and rejected argv, typed values, error kind and exit
-      status, stdout versus stderr, short and long help, usage/version output, and
-      completion candidates. Include setting-specific diagnostics: for example,
-      clap explains that `--flag=value` is required when `require_equals` rejects
-      a detached or missing value, while usage currently reports only a generic
-      missing value and forced Aube to adapt that error locally. Run the portable
-      cases on Unix and Windows and the byte-value cases on Unix. The mise fuzzer
-      remains the scale test; this is the configuration-space test it cannot be.
-- [ ] **Combination and stateful tests.** Pairwise-cover settings that interact:
+- [~] **Generated micro-conformance against clap.** A paired typed-CLI harness now
+  compares `require_equals`, defaults, delimiters, negative and hyphenated values,
+  value enums, scalar overrides, fixed arity, globals through subcommands, required
+  flags, conflicts/requires, required exclusive groups, optional values with equals,
+  external subcommands, `arg_required_else_help`, and subcommand requirement/conflict
+  policies. It
+  records typed values, error classifications, exit status and stream, relevant help,
+  and version output; the remaining matrix rows and completion candidates still need
+  equivalent minimal pairs. One minimal CLI per matrix row,
+  compared on accepted and rejected argv, typed values, error kind and exit
+  status, stdout versus stderr, short and long help, usage/version output, and
+  completion candidates. Include setting-specific diagnostics: for example,
+  clap explains that `--flag=value` is required when `require_equals` rejects
+  a detached or missing value, while usage currently reports only a generic
+  missing value and forced Aube to adapt that error locally. Run the portable
+  cases on Unix and Windows and the byte-value cases on Unix. The mise fuzzer
+  remains the scale test; this is the configuration-space test it cannot be.
+- [x] **Combination and stateful tests.** Focused typed conformance cases pair
       defaults with env and delimiters, optional values with `require_equals`,
       globals with overrides, subcommands with required positionals, groups with
       defaults, and help/version collisions. Add `update_from` cases if that API is

--- a/argv/src/diagnostic.rs
+++ b/argv/src/diagnostic.rs
@@ -588,14 +588,22 @@ pub fn render(
                         .find(|m| core::ptr::eq(m.flag, *flag))
                         .and_then(|m| m.value_name)
                 })
-                .map(|v| format!(" <{v}>"))
-                .unwrap_or_default();
-            let _ = writeln!(
-                out,
-                "{} a value is required for '{}' but none was supplied",
-                style.error("error:"),
-                style.invalid(&format!("{name}{value}"))
-            );
+                .unwrap_or(flag.name);
+            if flag.require_equals {
+                let _ = writeln!(
+                    out,
+                    "{} equal sign is needed when assigning values to '{}'",
+                    style.error("error:"),
+                    style.invalid(&format!("{name}=<{value}>"))
+                );
+            } else {
+                let _ = writeln!(
+                    out,
+                    "{} a value is required for '{}' but none was supplied",
+                    style.error("error:"),
+                    style.invalid(&format!("{name} <{value}>"))
+                );
+            }
         }
         Error::InvalidChoice { name, choices } => {
             let shown_name = shown(here, name);
@@ -703,7 +711,10 @@ pub fn render(
         // message would hide that rather than help.
         // Neither is a failure, and a caller that has not handled them before reaching here
         // has a bug this cannot paper over.
-        Error::Help { .. } | Error::HelpAll { .. } | Error::Version { .. } => {
+        Error::Help { .. }
+        | Error::MissingArgsHelp { .. }
+        | Error::HelpAll { .. }
+        | Error::Version { .. } => {
             return String::new();
         }
     }

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -47,11 +47,21 @@ impl Style {
     /// Colour when stdout is a terminal and the environment permits it.
     pub fn auto() -> Style {
         use std::io::IsTerminal as _;
+        Self::auto_for(std::io::stdout().is_terminal())
+    }
+
+    /// Colour when stderr is a terminal and the environment permits it.
+    pub fn auto_stderr() -> Style {
+        use std::io::IsTerminal as _;
+        Self::auto_for(std::io::stderr().is_terminal())
+    }
+
+    fn auto_for(is_terminal: bool) -> Style {
         let forced = std::env::var_os("CLICOLOR_FORCE").is_some_and(|v| v != "0");
         let refused = std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty());
         if refused {
             Style::PLAIN
-        } else if forced || std::io::stdout().is_terminal() {
+        } else if forced || is_terminal {
             Style::COLOURED
         } else {
             Style::PLAIN
@@ -92,7 +102,9 @@ fn styled_flag_usage(usage: &str, style: Style) -> String {
         let end = rest[start..]
             .char_indices()
             .skip(1)
-            .find_map(|(i, c)| (c.is_whitespace() || matches!(c, ',' | ']' | '>')).then_some(i))
+            .find_map(|(i, c)| {
+                (c.is_whitespace() || matches!(c, ',' | '=' | '[' | ']' | '>')).then_some(i)
+            })
             .unwrap_or(rest.len() - start)
             + start;
         out.push_str(&rest[..start]);
@@ -503,11 +515,6 @@ fn flag_usage_masked(meta: &FlagMeta<'_>, show: &Shown) -> String {
     if flag.takes_value {
         // Angled where the value must be given, squared where it need not — the same brackets
         // an argument uses, and for the same reason. pitchfork's `--bump` is the fleet's case.
-        let (open, close) = if meta.value_optional {
-            ('[', ']')
-        } else {
-            ('<', '>')
-        };
         let exact = exact_arity(meta.value_var_min, meta.value_var_max);
         if meta.value_names.len() <= 1 && exact.is_some_and(|n| n > 1) {
             let name = meta
@@ -516,8 +523,14 @@ fn flag_usage_masked(meta: &FlagMeta<'_>, show: &Shown) -> String {
                 .copied()
                 .or(meta.value_name)
                 .unwrap_or(flag.name);
-            for _ in 0..exact.unwrap() {
-                let _ = write!(out, " {open}{name}{close}");
+            for index in 0..exact.unwrap() {
+                append_flag_value(
+                    &mut out,
+                    name,
+                    meta.value_optional,
+                    flag.require_equals,
+                    index == 0,
+                );
             }
         } else if meta.value_names.len() <= 1 {
             let name = meta
@@ -526,10 +539,22 @@ fn flag_usage_masked(meta: &FlagMeta<'_>, show: &Shown) -> String {
                 .copied()
                 .or(meta.value_name)
                 .unwrap_or(flag.name);
-            let _ = write!(out, " {open}{name}{close}");
+            append_flag_value(
+                &mut out,
+                name,
+                meta.value_optional,
+                flag.require_equals,
+                true,
+            );
         } else {
-            for name in meta.value_names {
-                let _ = write!(out, " {open}{name}{close}");
+            for (index, name) in meta.value_names.iter().enumerate() {
+                append_flag_value(
+                    &mut out,
+                    name,
+                    meta.value_optional,
+                    flag.require_equals,
+                    index == 0,
+                );
             }
         }
         if flag.variadic && meta.value_names.len() <= 1 && exact.is_none() {
@@ -537,6 +562,22 @@ fn flag_usage_masked(meta: &FlagMeta<'_>, show: &Shown) -> String {
         }
     }
     out
+}
+
+fn append_flag_value(
+    out: &mut String,
+    name: &str,
+    optional: bool,
+    require_equals: bool,
+    first: bool,
+) {
+    if first && optional && require_equals {
+        let _ = write!(out, "[={name}]");
+    } else {
+        let separator = if first && require_equals { "=" } else { " " };
+        let (open, close) = if optional { ('[', ']') } else { ('<', '>') };
+        let _ = write!(out, "{separator}{open}{name}{close}");
+    }
 }
 
 /// How one positional argument appears: `<TOOL>`, `[FILES]…`, `-- <ARGS>`.
@@ -2366,11 +2407,29 @@ fn recursive_help<'a>(
 #[cfg(test)]
 mod style_tests {
     use super::{
-        commands_section, flag_notes, flat_commands_short, inline_environment_notes, styled_help,
-        Style,
+        commands_section, flag_notes, flag_usage, flat_commands_short, inline_environment_notes,
+        styled_flag_usage, styled_help, Style,
     };
     use crate::spec::{CommandMeta, FlagMeta};
     use crate::{Command, Flag};
+
+    #[test]
+    fn optional_equals_values_put_the_equals_inside_the_brackets() {
+        let flag = Flag {
+            name: "color",
+            longs: &["color"],
+            require_equals: true,
+            ..Flag::VALUE
+        };
+        let meta = FlagMeta {
+            flag: &flag,
+            value_name: Some("WHEN"),
+            value_optional: true,
+            ..FlagMeta::EMPTY
+        };
+
+        assert_eq!(flag_usage(&meta), "--color[=WHEN]");
+    }
 
     #[test]
     fn flattened_next_line_deprecation_follows_help_without_a_blank_row() {
@@ -2534,6 +2593,18 @@ mod style_tests {
         assert!(coloured.contains("[possible values: --auto]"));
         assert!(coloured.contains("(default: -1)"));
         assert_eq!(strip_ansi(&coloured), page);
+    }
+
+    #[test]
+    fn equals_separates_a_coloured_flag_from_its_value() {
+        assert_eq!(
+            styled_flag_usage("--output=<FILE>", Style::COLOURED),
+            "\u{1b}[36m--output\u{1b}[0m=<FILE>"
+        );
+        assert_eq!(
+            styled_flag_usage("--color[=WHEN]", Style::COLOURED),
+            "\u{1b}[36m--color\u{1b}[0m[=WHEN]"
+        );
     }
 
     fn strip_ansi(text: &str) -> String {

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -670,6 +670,12 @@ pub enum Error<'t, 'v> {
     /// clap has them. The caller renders — this crate does not print, because a library that
     /// writes to stdout on its own is one an adopter cannot embed.
     Help { cmd: &'t Command<'t>, long: bool },
+    /// `arg_required_else_help` found no command-line arguments for `cmd`.
+    ///
+    /// Unlike an explicit help request, this is a usage failure: clap prints the short help to
+    /// stderr and exits with status 2. Keeping the shape separate lets embedders preserve that
+    /// terminal contract without guessing why [`Error::Help`] was returned.
+    MissingArgsHelp { cmd: &'t Command<'t> },
     /// Recursive long help was requested for `cmd` and every visible descendant.
     HelpAll { cmd: &'t Command<'t> },
     /// `--version` or `-V` was asked for. Not a failure either — the caller prints and leaves.

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -23,6 +23,7 @@ usage-cli = { workspace = true }
 usage-lib = { workspace = true }
 
 [dev-dependencies]
+clap = { version = "4", features = ["derive", "env"] }
 insta = "1"
 usage-derive = { workspace = true }
 usage-validation = { workspace = true }

--- a/conformance/tests/arg_required_else_help.rs
+++ b/conformance/tests/arg_required_else_help.rs
@@ -53,11 +53,10 @@ struct DefaultRun {
 
 #[test]
 fn a_bare_root_asks_for_short_help_even_when_a_default_fills_a_field() {
-    let Err(Error::Help { cmd, long }) = RootPolicy::parse_from(&[]) else {
+    let Err(Error::MissingArgsHelp { cmd }) = RootPolicy::parse_from(&[]) else {
         panic!("a bare invocation should ask for help");
     };
     assert_eq!(cmd.name, "ex");
-    assert!(!long);
 
     let parsed = RootPolicy::parse_from(&argv(["--value", "given"])).expect("argv was supplied");
     assert_eq!(parsed.value, "given");
@@ -65,11 +64,10 @@ fn a_bare_root_asks_for_short_help_even_when_a_default_fills_a_field() {
 
 #[test]
 fn a_nested_command_counts_only_tokens_after_its_own_name() {
-    let Err(Error::Help { cmd, long }) = NestedPolicy::parse_from(&argv(["run"])) else {
+    let Err(Error::MissingArgsHelp { cmd }) = NestedPolicy::parse_from(&argv(["run"])) else {
         panic!("the command name selects run but is not one of run's arguments");
     };
     assert_eq!(cmd.name, "run");
-    assert!(!long);
 
     let parsed = NestedPolicy::parse_from(&argv(["run", "--all"])).expect("run has an argument");
     let Commands::Run(run) = parsed.command;

--- a/conformance/tests/clap_micro.rs
+++ b/conformance/tests/clap_micro.rs
@@ -1,0 +1,754 @@
+//! Minimal paired CLIs that turn the clap compatibility matrix into executable claims.
+
+use std::ffi::OsStr;
+
+use clap::{CommandFactory, Parser as _};
+use usage_argv::Error;
+use usage_derive::Cli;
+
+#[derive(Debug, PartialEq, Eq)]
+enum Stream {
+    Stdout,
+    Stderr,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct Exit {
+    status: i32,
+    stream: Stream,
+    text: String,
+}
+
+fn clap_exit<T>(argv: &[&str]) -> Exit
+where
+    T: clap::Parser + CommandFactory + std::fmt::Debug,
+{
+    let result = T::try_parse_from(std::iter::once("micro").chain(argv.iter().copied()));
+    let error = result.expect_err("the vector requests terminal output");
+    Exit {
+        status: error.exit_code(),
+        stream: if error.use_stderr() {
+            Stream::Stderr
+        } else {
+            Stream::Stdout
+        },
+        text: error.to_string(),
+    }
+}
+
+fn usage_error(spec: &usage_argv::spec::Spec<'_>, words: &[&OsStr], error: Error<'_, '_>) -> Exit {
+    match error {
+        Error::Help { cmd, long } => Exit {
+            status: 0,
+            stream: Stream::Stdout,
+            text: usage_argv::help::render(spec, cmd, long).expect("this CLI's command"),
+        },
+        Error::MissingArgsHelp { cmd } => Exit {
+            status: 2,
+            stream: Stream::Stderr,
+            text: usage_argv::help::render(spec, cmd, false).expect("this CLI's command"),
+        },
+        Error::Version { long } => {
+            let version = if long {
+                spec.long_version.or(spec.version)
+            } else {
+                spec.version
+            }
+            .unwrap_or_default();
+            Exit {
+                status: 0,
+                stream: Stream::Stdout,
+                text: format!("{} {version}\n", spec.bin.unwrap_or(spec.name)),
+            }
+        }
+        error => Exit {
+            status: 2,
+            stream: Stream::Stderr,
+            text: usage_argv::diagnostic::render(
+                spec,
+                words,
+                &error,
+                usage_argv::diagnostic::Style::PLAIN,
+            ),
+        },
+    }
+}
+
+mod require_equals {
+    use super::*;
+
+    #[derive(Debug, clap::Parser)]
+    #[command(name = "micro", version = "1.2.3")]
+    struct ClapCli {
+        /// Value to record
+        #[arg(long, require_equals = true)]
+        value: String,
+    }
+
+    #[derive(Debug, Cli)]
+    #[usage(bin = "micro", version = "1.2.3", unknown_flags = "error")]
+    struct UsageCli {
+        /// Value to record
+        #[usage(long, require_equals)]
+        value: String,
+    }
+
+    fn usage_exit(argv: &[&str]) -> Exit {
+        let words: Vec<&OsStr> = argv.iter().map(OsStr::new).collect();
+        let error = UsageCli::parse_from(&words).expect_err("the vector requests terminal output");
+        usage_error(UsageCli::spec(), &words, error)
+    }
+
+    #[test]
+    fn accepted_argv_binds_the_same_typed_value() {
+        let clap = ClapCli::try_parse_from(["micro", "--value=kept"]).unwrap();
+        let usage = UsageCli::parse_from(&[OsStr::new("--value=kept")]).unwrap();
+        assert_eq!(usage.value, clap.value);
+    }
+
+    #[test]
+    fn detached_values_have_the_same_terminal_contract() {
+        let clap = clap_exit::<ClapCli>(&["--value", "kept"]);
+        let usage = usage_exit(&["--value", "kept"]);
+        assert_eq!(usage.status, clap.status);
+        assert_eq!(usage.stream, clap.stream);
+        let message = "equal sign is needed when assigning values to '--value=<VALUE>'";
+        assert!(clap.text.contains(message), "{}", clap.text);
+        assert!(usage.text.contains(message), "{}", usage.text);
+    }
+
+    #[test]
+    fn help_and_version_use_the_same_stream_and_status() {
+        for argv in [["-h"].as_slice(), ["--help"].as_slice()] {
+            let clap = clap_exit::<ClapCli>(argv);
+            let usage = usage_exit(argv);
+            assert_eq!(usage.status, clap.status, "{argv:?}");
+            assert_eq!(usage.stream, clap.stream, "{argv:?}");
+            for text in [&clap.text, &usage.text] {
+                assert!(text.contains("--value=<VALUE>"), "{argv:?}: {text}");
+                assert!(text.contains("Value to record"), "{argv:?}: {text}");
+            }
+        }
+
+        assert_eq!(
+            usage_exit(&["--version"]),
+            clap_exit::<ClapCli>(&["--version"])
+        );
+    }
+}
+
+mod default_value {
+    use super::*;
+
+    #[derive(Debug, clap::Parser)]
+    #[command(name = "micro")]
+    struct ClapCli {
+        #[arg(long, default_value_t = 4)]
+        jobs: u32,
+    }
+
+    #[derive(Debug, Cli)]
+    #[usage(bin = "micro", unknown_flags = "error")]
+    struct UsageCli {
+        #[usage(long, default = "4")]
+        jobs: u32,
+    }
+
+    #[test]
+    fn omitted_values_bind_the_same_default() {
+        assert_eq!(
+            UsageCli::parse_from(&[]).unwrap().jobs,
+            ClapCli::try_parse_from(["micro"]).unwrap().jobs
+        );
+        let clap_help = ClapCli::command().render_long_help().to_string();
+        let usage_help =
+            usage_argv::help::render(UsageCli::spec(), UsageCli::spec().root.cmd, true).unwrap();
+        for help in [clap_help, usage_help] {
+            assert!(help.contains("--jobs <JOBS>"), "{help}");
+            assert!(help.contains("default: 4"), "{help}");
+        }
+    }
+}
+
+mod value_delimiter {
+    use super::*;
+
+    #[derive(Debug, clap::Parser)]
+    #[command(name = "micro")]
+    struct ClapCli {
+        #[arg(long, value_delimiter = ',')]
+        values: Vec<String>,
+    }
+
+    #[derive(Debug, Cli)]
+    #[usage(bin = "micro", unknown_flags = "error")]
+    struct UsageCli {
+        #[usage(long, var, delimiter = ',')]
+        values: Vec<String>,
+    }
+
+    #[test]
+    fn one_token_binds_the_same_values() {
+        let clap = ClapCli::try_parse_from(["micro", "--values", "a,b"]).unwrap();
+        let usage = UsageCli::parse_from(&[OsStr::new("--values"), OsStr::new("a,b")]).unwrap();
+        assert_eq!(usage.values, clap.values);
+    }
+}
+
+mod allow_negative_numbers {
+    use super::*;
+
+    #[derive(Debug, clap::Parser)]
+    #[command(name = "micro")]
+    struct ClapCli {
+        #[arg(long, allow_negative_numbers = true)]
+        number: i32,
+    }
+
+    #[derive(Debug, Cli)]
+    #[usage(bin = "micro", unknown_flags = "error")]
+    struct UsageCli {
+        #[usage(long, allow_negative_numbers)]
+        number: i32,
+    }
+
+    #[test]
+    fn a_negative_token_binds_as_the_value() {
+        let clap = ClapCli::try_parse_from(["micro", "--number", "-7"]).unwrap();
+        let usage = UsageCli::parse_from(&[OsStr::new("--number"), OsStr::new("-7")]).unwrap();
+        assert_eq!(usage.number, clap.number);
+    }
+}
+
+mod value_enum {
+    use super::*;
+
+    #[derive(Clone, Debug, PartialEq, Eq, clap::ValueEnum)]
+    enum ClapMode {
+        Fast,
+        Slow,
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq, usage_derive::ValueEnum)]
+    enum UsageMode {
+        Fast,
+        Slow,
+    }
+
+    #[derive(Debug, clap::Parser)]
+    #[command(name = "micro")]
+    struct ClapCli {
+        #[arg(long, value_enum)]
+        mode: ClapMode,
+    }
+
+    #[derive(Debug, Cli)]
+    #[usage(bin = "micro", unknown_flags = "error")]
+    struct UsageCli {
+        #[usage(long, value_enum)]
+        mode: UsageMode,
+    }
+
+    #[test]
+    fn declared_words_bind_and_invalid_choices_fail() {
+        let clap = ClapCli::try_parse_from(["micro", "--mode", "slow"]).unwrap();
+        let usage = UsageCli::parse_from(&[OsStr::new("--mode"), OsStr::new("slow")]).unwrap();
+        assert_eq!(format!("{:?}", usage.mode), format!("{:?}", clap.mode));
+
+        let clap = ClapCli::try_parse_from(["micro", "--mode", "medium"]).unwrap_err();
+        let usage =
+            UsageCli::parse_from(&[OsStr::new("--mode"), OsStr::new("medium")]).unwrap_err();
+        assert_eq!(clap.kind(), clap::error::ErrorKind::InvalidValue);
+        assert!(matches!(usage, Error::InvalidChoice { .. }));
+    }
+}
+
+mod args_override_self {
+    use super::*;
+
+    #[derive(Debug, clap::Parser)]
+    #[command(name = "micro", args_override_self = true)]
+    struct ClapCli {
+        #[arg(long)]
+        value: String,
+    }
+
+    #[derive(Debug, Cli)]
+    #[usage(bin = "micro", unknown_flags = "error")]
+    struct UsageCli {
+        #[usage(long)]
+        value: String,
+    }
+
+    #[test]
+    fn the_last_scalar_value_wins() {
+        let clap = ClapCli::try_parse_from(["micro", "--value", "old", "--value", "new"]).unwrap();
+        let usage = UsageCli::parse_from(&[
+            OsStr::new("--value"),
+            OsStr::new("old"),
+            OsStr::new("--value"),
+            OsStr::new("new"),
+        ])
+        .unwrap();
+        assert_eq!(usage.value, clap.value);
+    }
+}
+
+mod allow_hyphen_values {
+    use super::*;
+
+    #[derive(Debug, clap::Parser)]
+    #[command(name = "micro")]
+    struct ClapCli {
+        #[arg(long, allow_hyphen_values = true)]
+        value: String,
+    }
+
+    #[derive(Debug, Cli)]
+    #[usage(bin = "micro", unknown_flags = "error")]
+    struct UsageCli {
+        #[usage(long, allow_hyphen_values)]
+        value: String,
+    }
+
+    #[test]
+    fn a_flaglike_token_binds_as_the_value() {
+        let clap = ClapCli::try_parse_from(["micro", "--value", "--literal"]).unwrap();
+        let usage =
+            UsageCli::parse_from(&[OsStr::new("--value"), OsStr::new("--literal")]).unwrap();
+        assert_eq!(usage.value, clap.value);
+    }
+}
+
+mod fixed_arity {
+    use super::*;
+
+    #[derive(Debug, clap::Parser)]
+    #[command(name = "micro")]
+    struct ClapCli {
+        #[arg(long, num_args = 2, value_names = ["START", "END"])]
+        range: Vec<String>,
+    }
+
+    #[derive(Debug, Cli)]
+    #[usage(bin = "micro", unknown_flags = "error")]
+    struct UsageCli {
+        #[arg(long, num_args = 2, value_names = ["START", "END"])]
+        range: Vec<String>,
+    }
+
+    #[test]
+    fn one_occurrence_consumes_the_same_number_of_values() {
+        let clap = ClapCli::try_parse_from(["micro", "--range", "1", "9"]).unwrap();
+        let usage =
+            UsageCli::parse_from(&[OsStr::new("--range"), OsStr::new("1"), OsStr::new("9")])
+                .unwrap();
+        assert_eq!(usage.range, clap.range);
+
+        let clap = ClapCli::try_parse_from(["micro", "--range", "1"]).unwrap_err();
+        let usage = UsageCli::parse_from(&[OsStr::new("--range"), OsStr::new("1")]).unwrap_err();
+        assert_eq!(clap.kind(), clap::error::ErrorKind::WrongNumberOfValues);
+        assert!(matches!(usage, Error::VarTooFew { .. }));
+    }
+}
+
+mod global_subcommand {
+    use super::*;
+
+    #[derive(Debug, clap::Subcommand)]
+    enum ClapCommand {
+        Run {
+            #[arg(long)]
+            task: String,
+        },
+    }
+
+    #[derive(Debug, clap::Parser)]
+    #[command(name = "micro")]
+    struct ClapCli {
+        #[arg(long, global = true)]
+        verbose: bool,
+        #[command(subcommand)]
+        command: ClapCommand,
+    }
+
+    #[derive(Debug, usage_derive::Subcommands)]
+    enum UsageCommand {
+        Run {
+            #[usage(long)]
+            task: String,
+        },
+    }
+
+    #[derive(Debug, Cli)]
+    #[usage(bin = "micro", unknown_flags = "error")]
+    struct UsageCli {
+        #[usage(long, global)]
+        verbose: bool,
+        #[usage(subcommand)]
+        command: UsageCommand,
+    }
+
+    #[test]
+    fn a_root_global_binds_after_the_selected_child() {
+        let clap =
+            ClapCli::try_parse_from(["micro", "run", "--task", "build", "--verbose"]).unwrap();
+        let usage = UsageCli::parse_from(&[
+            OsStr::new("run"),
+            OsStr::new("--task"),
+            OsStr::new("build"),
+            OsStr::new("--verbose"),
+        ])
+        .unwrap();
+        assert_eq!(usage.verbose, clap.verbose);
+        let (ClapCommand::Run { task: clap_task }, UsageCommand::Run { task: usage_task }) =
+            (clap.command, usage.command);
+        assert_eq!(usage_task, clap_task);
+    }
+}
+
+mod required_flag {
+    use super::*;
+
+    #[derive(Debug, clap::Parser)]
+    #[command(name = "micro")]
+    struct ClapCli {
+        #[arg(long)]
+        config: String,
+    }
+
+    #[derive(Debug, Cli)]
+    #[usage(bin = "micro", unknown_flags = "error")]
+    struct UsageCli {
+        #[usage(long)]
+        config: String,
+    }
+
+    #[test]
+    fn required_values_accept_and_reject_the_same_shapes() {
+        let clap = ClapCli::try_parse_from(["micro", "--config", "config.toml"]).unwrap();
+        let usage =
+            UsageCli::parse_from(&[OsStr::new("--config"), OsStr::new("config.toml")]).unwrap();
+        assert_eq!(usage.config, clap.config);
+
+        let clap = ClapCli::try_parse_from(["micro"]).unwrap_err();
+        let usage = UsageCli::parse_from(&[]).unwrap_err();
+        assert_eq!(clap.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+        assert!(matches!(usage, Error::MissingRequired { .. }));
+    }
+}
+
+mod conflicts_and_requires {
+    use super::*;
+
+    #[derive(Debug, clap::Parser)]
+    #[command(name = "micro")]
+    struct ClapCli {
+        #[arg(long, conflicts_with = "quiet")]
+        verbose: bool,
+        #[arg(long)]
+        quiet: bool,
+        #[arg(long, requires = "key")]
+        sign: bool,
+        #[arg(long)]
+        key: Option<String>,
+    }
+
+    #[derive(Debug, Cli)]
+    #[usage(bin = "micro", unknown_flags = "error")]
+    struct UsageCli {
+        #[usage(long, conflicts = "--quiet")]
+        verbose: bool,
+        #[usage(long)]
+        quiet: bool,
+        #[usage(long, requires = "--key")]
+        sign: bool,
+        #[usage(long)]
+        key: Option<String>,
+    }
+
+    #[test]
+    fn relationships_accept_and_reject_the_same_shapes() {
+        let clap = ClapCli::try_parse_from(["micro", "--verbose"]).unwrap();
+        let usage = UsageCli::parse_from(&[OsStr::new("--verbose")]).unwrap();
+        assert_eq!((usage.verbose, usage.quiet), (clap.verbose, clap.quiet));
+
+        let clap = ClapCli::try_parse_from(["micro", "--sign", "--key", "secret"]).unwrap();
+        let usage = UsageCli::parse_from(&[
+            OsStr::new("--sign"),
+            OsStr::new("--key"),
+            OsStr::new("secret"),
+        ])
+        .unwrap();
+        assert_eq!(usage.sign, clap.sign);
+        assert_eq!(usage.key, clap.key);
+
+        let clap = ClapCli::try_parse_from(["micro", "--verbose", "--quiet"]).unwrap_err();
+        let usage =
+            UsageCli::parse_from(&[OsStr::new("--verbose"), OsStr::new("--quiet")]).unwrap_err();
+        assert_eq!(clap.kind(), clap::error::ErrorKind::ArgumentConflict);
+        assert!(matches!(usage, Error::ConflictingFlags { .. }));
+
+        let clap = ClapCli::try_parse_from(["micro", "--sign"]).unwrap_err();
+        let usage = UsageCli::parse_from(&[OsStr::new("--sign")]).unwrap_err();
+        assert_eq!(clap.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+        assert!(matches!(usage, Error::MissingRequired { .. }));
+    }
+}
+
+mod required_exclusive_group {
+    use super::*;
+    use clap::ArgGroup;
+
+    #[derive(Debug, clap::Parser)]
+    #[command(
+        name = "micro",
+        group(ArgGroup::new("input").required(true).multiple(false))
+    )]
+    struct ClapCli {
+        #[arg(long, group = "input")]
+        file: bool,
+        #[arg(long, group = "input")]
+        stdin: bool,
+    }
+
+    #[derive(Debug, Cli)]
+    #[usage(bin = "micro", unknown_flags = "error", group("input", required))]
+    struct UsageCli {
+        #[usage(long, group = "input")]
+        file: bool,
+        #[usage(long, group = "input")]
+        stdin: bool,
+    }
+
+    #[test]
+    fn exactly_one_member_is_required() {
+        let clap = ClapCli::try_parse_from(["micro", "--file"]).unwrap();
+        let usage = UsageCli::parse_from(&[OsStr::new("--file")]).unwrap();
+        assert_eq!((usage.file, usage.stdin), (clap.file, clap.stdin));
+
+        let clap = ClapCli::try_parse_from(["micro"]).unwrap_err();
+        let usage = UsageCli::parse_from(&[]).unwrap_err();
+        assert_eq!(clap.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+        assert!(matches!(usage, Error::MissingGroup { .. }));
+
+        let clap = ClapCli::try_parse_from(["micro", "--file", "--stdin"]).unwrap_err();
+        let usage =
+            UsageCli::parse_from(&[OsStr::new("--file"), OsStr::new("--stdin")]).unwrap_err();
+        assert_eq!(clap.kind(), clap::error::ErrorKind::ArgumentConflict);
+        assert!(matches!(usage, Error::ConflictingFlags { .. }));
+    }
+}
+
+mod optional_value_with_equals {
+    use super::*;
+
+    #[derive(Debug, clap::Parser)]
+    #[command(name = "micro")]
+    struct ClapCli {
+        #[arg(long, num_args = 0..=1, require_equals = true)]
+        color: Option<Option<String>>,
+        rest: Option<String>,
+    }
+
+    #[derive(Debug, Cli)]
+    #[usage(bin = "micro", unknown_flags = "error")]
+    struct UsageCli {
+        #[usage(long, require_equals)]
+        color: Option<Option<String>>,
+        #[usage(arg)]
+        rest: Option<String>,
+    }
+
+    #[test]
+    fn detached_words_remain_positional() {
+        let clap = ClapCli::try_parse_from(["micro", "--color", "input"]).unwrap();
+        let usage = UsageCli::parse_from(&[OsStr::new("--color"), OsStr::new("input")]).unwrap();
+        assert_eq!(usage.color, clap.color);
+        assert_eq!(usage.rest, clap.rest);
+
+        let clap = ClapCli::try_parse_from(["micro", "--color=always"]).unwrap();
+        let usage = UsageCli::parse_from(&[OsStr::new("--color=always")]).unwrap();
+        assert_eq!(usage.color, clap.color);
+    }
+}
+
+mod external_subcommand {
+    use super::*;
+    use usage_derive::Subcommands;
+
+    #[derive(Debug, clap::Subcommand)]
+    enum ClapCommand {
+        Run,
+        #[command(external_subcommand)]
+        External(Vec<String>),
+    }
+
+    #[derive(Debug, clap::Parser)]
+    #[command(name = "micro")]
+    struct ClapCli {
+        #[command(subcommand)]
+        command: ClapCommand,
+    }
+
+    #[derive(Debug, Subcommands)]
+    enum UsageCommand {
+        Run,
+        #[usage(external_subcommand)]
+        External(Vec<String>),
+    }
+
+    #[derive(Debug, Cli)]
+    #[usage(bin = "micro", unknown_flags = "error")]
+    struct UsageCli {
+        #[usage(subcommand)]
+        command: UsageCommand,
+    }
+
+    #[test]
+    fn unmatched_commands_forward_the_same_words() {
+        let clap = ClapCli::try_parse_from(["micro", "plugin", "--literal", "value"]).unwrap();
+        let usage = UsageCli::parse_from(&[
+            OsStr::new("plugin"),
+            OsStr::new("--literal"),
+            OsStr::new("value"),
+        ])
+        .unwrap();
+        let (ClapCommand::External(clap), UsageCommand::External(usage)) =
+            (clap.command, usage.command)
+        else {
+            panic!("the unknown command should select the external variant")
+        };
+        assert_eq!(usage, clap);
+    }
+}
+
+mod arg_required_else_help {
+    use super::*;
+
+    #[derive(Debug, clap::Parser)]
+    #[command(name = "micro", arg_required_else_help = true)]
+    struct ClapCli {
+        #[arg(long)]
+        all: bool,
+    }
+
+    #[derive(Debug, Cli)]
+    #[usage(bin = "micro", unknown_flags = "error", arg_required_else_help)]
+    struct UsageCli {
+        #[usage(long)]
+        all: bool,
+    }
+
+    fn usage_exit(argv: &[&str]) -> Exit {
+        let words: Vec<&OsStr> = argv.iter().map(OsStr::new).collect();
+        let error = UsageCli::parse_from(&words).expect_err("bare argv requests help");
+        usage_error(UsageCli::spec(), &words, error)
+    }
+
+    #[test]
+    fn bare_argv_has_the_same_terminal_contract() {
+        let clap = clap_exit::<ClapCli>(&[]);
+        let usage = usage_exit(&[]);
+        assert_eq!(usage.status, clap.status);
+        assert_eq!(usage.stream, clap.stream);
+        for help in [usage.text, clap.text] {
+            assert!(help.contains("--all"), "{help}");
+        }
+
+        assert_eq!(
+            UsageCli::parse_from(&[OsStr::new("--all")]).unwrap().all,
+            ClapCli::try_parse_from(["micro", "--all"]).unwrap().all
+        );
+    }
+}
+
+mod subcommand_policies {
+    use super::*;
+    use usage_derive::Subcommands;
+
+    #[derive(Debug, clap::Subcommand)]
+    enum ClapCommand {
+        Run,
+    }
+
+    #[derive(Debug, clap::Parser)]
+    #[command(
+        name = "micro",
+        subcommand_negates_reqs = true,
+        subcommand_precedence_over_arg = true
+    )]
+    struct ClapNegates {
+        #[command(subcommand)]
+        command: Option<ClapCommand>,
+        #[arg(long, required = true)]
+        profile: Option<String>,
+    }
+
+    #[derive(Debug, clap::Parser)]
+    #[command(name = "micro", args_conflicts_with_subcommands = true)]
+    struct ClapConflicts {
+        #[arg(long)]
+        verbose: bool,
+        #[command(subcommand)]
+        command: Option<ClapCommand>,
+    }
+
+    #[derive(Debug, Subcommands)]
+    enum UsageCommand {
+        Run,
+    }
+
+    #[derive(Debug, Cli)]
+    #[usage(
+        bin = "micro",
+        unknown_flags = "error",
+        subcommand_negates_reqs,
+        subcommand_precedence_over_arg
+    )]
+    struct UsageNegates {
+        #[usage(subcommand)]
+        command: Option<UsageCommand>,
+        #[usage(long, required)]
+        profile: Option<String>,
+    }
+
+    #[derive(Debug, Cli)]
+    #[usage(
+        bin = "micro",
+        unknown_flags = "error",
+        args_conflicts_with_subcommands
+    )]
+    struct UsageConflicts {
+        #[usage(long)]
+        verbose: bool,
+        #[usage(subcommand)]
+        command: Option<UsageCommand>,
+    }
+
+    #[test]
+    fn a_subcommand_can_suppress_parent_requirements() {
+        assert!(ClapNegates::command().is_subcommand_negates_reqs_set());
+        assert!(ClapNegates::command().is_subcommand_precedence_over_arg_set());
+        let clap = ClapNegates::try_parse_from(["micro", "run"]).unwrap();
+        let usage = UsageNegates::parse_from(&[OsStr::new("run")]).unwrap();
+        assert!(clap.profile.is_none());
+        assert!(usage.profile.is_none());
+        assert!(matches!(clap.command, Some(ClapCommand::Run)));
+        assert!(matches!(usage.command, Some(UsageCommand::Run)));
+    }
+
+    #[test]
+    fn parent_arguments_can_conflict_with_a_subcommand() {
+        let clap = ClapConflicts::try_parse_from(["micro", "--verbose"]).unwrap();
+        let usage = UsageConflicts::parse_from(&[OsStr::new("--verbose")]).unwrap();
+        assert_eq!(usage.verbose, clap.verbose);
+        assert!(usage.command.is_none());
+
+        let clap = ClapConflicts::try_parse_from(["micro", "--verbose", "run"]).unwrap_err();
+        let usage =
+            UsageConflicts::parse_from(&[OsStr::new("--verbose"), OsStr::new("run")]).unwrap_err();
+        assert_eq!(clap.kind(), clap::error::ErrorKind::ArgumentConflict);
+        assert!(matches!(usage, Error::SubcommandConflict { .. }));
+    }
+}

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -645,9 +645,8 @@ pub fn emit(cli: &Cli) -> TokenStream {
                 if __usage_parser.command().arg_required_else_help
                     && __usage_parser.command_start() == argv.len()
                 {
-                    return ::std::result::Result::Err(usage_argv::Error::Help {
+                    return ::std::result::Result::Err(usage_argv::Error::MissingArgsHelp {
                         cmd: __usage_parser.command(),
-                        long: false,
                     });
                 }
 
@@ -869,6 +868,38 @@ pub fn emit(cli: &Cli) -> TokenStream {
                                 }
                                 // Only reachable if the command came from another CLI's tables.
                                 ::std::option::Option::None => ::std::process::exit(0),
+                            }
+                        }
+                        ::std::result::Result::Err(usage_argv::Error::MissingArgsHelp { cmd }) => {
+                            #effective_spec
+                            let __usage_page = match usage_argv::help::route_to(
+                                Self::command(),
+                                &__usage_argv,
+                                cmd,
+                            ) {
+                                ::std::option::Option::Some(route) => {
+                                    usage_argv::help::render_at_styled(
+                                        __usage_spec,
+                                        &route,
+                                        false,
+                                        usage_argv::help::Style::auto_stderr(),
+                                    )
+                                }
+                                ::std::option::Option::None => {
+                                    usage_argv::help::render_styled(
+                                        __usage_spec,
+                                        cmd,
+                                        false,
+                                        usage_argv::help::Style::auto_stderr(),
+                                    )
+                                }
+                            };
+                            match __usage_page {
+                                ::std::option::Option::Some(page) => {
+                                    ::std::eprint!("{page}");
+                                    ::std::process::exit(2);
+                                }
+                                ::std::option::Option::None => ::std::process::exit(2),
                             }
                         }
                         ::std::result::Result::Err(usage_argv::Error::HelpAll { cmd }) => {

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -816,8 +816,13 @@ fn reference_usage(flag: &crate::SpecFlag) -> String {
         usage.push('…');
     }
     if let Some(arg) = &flag.arg {
-        usage.push(' ');
-        usage.push_str(&arg.usage());
+        let arg_usage = arg.usage();
+        if flag.require_equals && (flag.value_optional || !arg.required) {
+            usage.push_str(&crate::spec::flag::optional_equals_usage(&arg_usage));
+        } else {
+            usage.push(if flag.require_equals { '=' } else { ' ' });
+            usage.push_str(&arg_usage);
+        }
     }
     usage
 }

--- a/lib/src/spec/flag.rs
+++ b/lib/src/spec/flag.rs
@@ -853,10 +853,30 @@ impl SpecFlag {
             out = format!("{out}…");
         }
         if let Some(arg) = &self.arg {
-            out = format!("{} {}", out, arg.usage());
+            let usage = arg.usage();
+            if self.require_equals && (self.value_optional || !arg.required) {
+                out = format!("{out}{}", optional_equals_usage(&usage));
+            } else {
+                let separator = if self.require_equals { "=" } else { " " };
+                out = format!("{out}{separator}{usage}");
+            }
         }
         out
     }
+}
+
+pub(crate) fn optional_equals_usage(usage: &str) -> String {
+    let (value, closing) = if let Some(value) = usage.strip_prefix('[') {
+        (value, ']')
+    } else if let Some(value) = usage.strip_prefix('<') {
+        (value, '>')
+    } else {
+        return format!("={usage}");
+    };
+    let Some(end) = value.find(closing) else {
+        return format!("={usage}");
+    };
+    format!("[={}]{}", &value[..end], &value[end + 1..])
 }
 
 impl From<&SpecFlag> for KdlNode {
@@ -1114,8 +1134,103 @@ impl FromStr for SpecFlag {
     type Err = UsageErr;
     fn from_str(input: &str) -> Result<Self> {
         let mut flag = Self::default();
-        let input = input.replace("...", "…").replace("…", " … ");
+        // Keep a flag-level repetition marker attached when an equals value follows it.
+        // Every other ellipsis becomes its own token so its position still distinguishes
+        // a repeatable flag (`--flag… <ARG>`) from a variadic value (`--flag <ARG>…`).
+        let input = input
+            .replace("...", "…")
+            .replace("…[=", "\u{e000}[=")
+            .replace("…=", "\u{e000}=")
+            .replace("…", " … ")
+            .replace('\u{e000}', "…");
         for part in input.split_whitespace() {
+            if let Some((form, value)) = part
+                .strip_suffix(']')
+                .and_then(|part| part.split_once("[="))
+            {
+                let (form, repeatable) = form
+                    .strip_suffix('…')
+                    .map_or((form, false), |form| (form, true));
+                let recognized = if let Some(long) = form.strip_prefix("--") {
+                    if long.is_empty() {
+                        false
+                    } else {
+                        flag.long.push(long.to_string());
+                        true
+                    }
+                } else if let Some(short) = form.strip_prefix('-') {
+                    if short.chars().count() != 1 {
+                        return Err(InvalidFlag {
+                            token: form.to_string(),
+                            reason:
+                                "short flags must be a single character (use -- for long flags)"
+                                    .to_string(),
+                            span: (0, input.len()).into(),
+                            input: input.to_string(),
+                        });
+                    }
+                    flag.short.push(short.chars().next().unwrap());
+                    true
+                } else {
+                    false
+                };
+                if recognized && !value.is_empty() {
+                    flag.var |= repeatable;
+                    flag.require_equals = true;
+                    flag.arg = Some(match flag.arg.take() {
+                        Some(existing) => format!("{} [{value}]", existing.usage()).parse()?,
+                        None => format!("[{value}]").parse()?,
+                    });
+                    continue;
+                }
+            }
+            if let Some((form, value)) = part.split_once('=') {
+                let (form, repeatable) = form
+                    .strip_suffix('…')
+                    .map_or((form, false), |form| (form, true));
+                let recognized = if let Some(long) = form.strip_prefix("--") {
+                    if long.is_empty() {
+                        false
+                    } else {
+                        flag.long.push(long.to_string());
+                        true
+                    }
+                } else if let Some(short) = form.strip_prefix('-') {
+                    if short.chars().count() != 1 {
+                        return Err(InvalidFlag {
+                            token: form.to_string(),
+                            reason:
+                                "short flags must be a single character (use -- for long flags)"
+                                    .to_string(),
+                            span: (0, input.len()).into(),
+                            input: input.to_string(),
+                        });
+                    }
+                    flag.short.push(short.chars().next().unwrap());
+                    true
+                } else {
+                    false
+                };
+                if recognized {
+                    flag.var |= repeatable;
+                    if !(value.starts_with('<') && value.ends_with('>')
+                        || value.starts_with('[') && value.ends_with(']'))
+                    {
+                        return Err(InvalidFlag {
+                            token: part.to_string(),
+                            reason: "an equals sign must attach <arg> or [arg]".to_string(),
+                            span: (0, input.len()).into(),
+                            input: input.to_string(),
+                        });
+                    }
+                    flag.require_equals = true;
+                    flag.arg = Some(match flag.arg.take() {
+                        Some(existing) => format!("{} {value}", existing.usage()).parse()?,
+                        None => value.to_string().parse()?,
+                    });
+                    continue;
+                }
+            }
             if let Some(name) = part.strip_suffix(':') {
                 flag.name = name.to_string();
             } else if let Some(long) = part.strip_prefix("--") {
@@ -1654,6 +1769,105 @@ mod tests {
         let spec = Spec::from(&cmd);
         let inspect = spec.cmd.flags.iter().find(|f| f.name == "inspect").unwrap();
         assert!(inspect.require_equals);
+        assert_eq!(inspect.usage(), "--inspect=<inspect>");
+        let usage_reparsed: SpecFlag = inspect.usage().parse().unwrap();
+        assert!(usage_reparsed.require_equals);
+        assert_eq!(usage_reparsed.long, ["inspect"]);
+        assert_eq!(usage_reparsed.arg.unwrap().name, "inspect");
+        assert_eq!(
+            crate::docs::models::SpecFlag::from(inspect).usage,
+            "--inspect=<inspect>"
+        );
+
+        let cmd = clap::Command::new("ex").arg(
+            clap::Arg::new("color")
+                .long("color")
+                .action(clap::ArgAction::Set)
+                .num_args(0..=1)
+                .require_equals(true),
+        );
+        let spec = Spec::from(&cmd);
+        let color = spec.cmd.flags.iter().find(|f| f.name == "color").unwrap();
+        assert!(color.require_equals);
+        assert!(color.value_optional);
+        assert!(
+            color.arg.as_ref().unwrap().required,
+            "clap's optional arity is flag metadata, not positional presentation"
+        );
+        assert_eq!(color.usage(), "--color[=color]");
+        assert_eq!(
+            crate::docs::models::SpecFlag::from(color).usage,
+            "--color[=color]"
+        );
+
+        let optional: SpecFlag = "--color [WHEN]".parse().unwrap();
+        let optional = SpecFlag {
+            require_equals: true,
+            ..optional
+        };
+        assert_eq!(optional.usage(), "--color[=WHEN]");
+        let reparsed: SpecFlag = optional.usage().parse().unwrap();
+        assert!(reparsed.require_equals);
+        assert!(!reparsed.arg.as_ref().unwrap().required);
+        assert_eq!(reparsed.arg.as_ref().unwrap().name, "WHEN");
+        assert_eq!(
+            crate::docs::models::SpecFlag::from(&optional).usage,
+            "--color[=WHEN]"
+        );
+
+        let variadic: SpecFlag = "--color [WHEN]…".parse().unwrap();
+        let variadic = SpecFlag {
+            require_equals: true,
+            ..variadic
+        };
+        assert_eq!(variadic.usage(), "--color[=WHEN]…");
+        assert_eq!(
+            crate::docs::models::SpecFlag::from(&variadic).usage,
+            "--color[=WHEN]…"
+        );
+        assert_eq!(
+            variadic.usage().parse::<SpecFlag>().unwrap().usage(),
+            "--color[=WHEN]…"
+        );
+
+        let pair: SpecFlag = "--range [START] [END]".parse().unwrap();
+        let pair = SpecFlag {
+            require_equals: true,
+            ..pair
+        };
+        assert_eq!(pair.usage(), "--range[=START] [END]");
+        assert_eq!(
+            crate::docs::models::SpecFlag::from(&pair).usage,
+            "--range[=START] [END]"
+        );
+        assert_eq!(
+            pair.usage().parse::<SpecFlag>().unwrap().usage(),
+            "--range[=START] [END]"
+        );
+
+        let repeatable: SpecFlag = "--tag <TAG>".parse().unwrap();
+        let repeatable = SpecFlag {
+            var: true,
+            require_equals: true,
+            ..repeatable
+        };
+        assert_eq!(repeatable.usage(), "--tag…=<TAG>");
+        let reparsed: SpecFlag = repeatable.usage().parse().unwrap();
+        assert!(reparsed.var);
+        assert!(reparsed.require_equals);
+        assert!(!reparsed.arg.as_ref().unwrap().var);
+
+        let repeatable_optional: SpecFlag = "--color [WHEN]".parse().unwrap();
+        let repeatable_optional = SpecFlag {
+            var: true,
+            require_equals: true,
+            ..repeatable_optional
+        };
+        assert_eq!(repeatable_optional.usage(), "--color…[=WHEN]");
+        let reparsed: SpecFlag = repeatable_optional.usage().parse().unwrap();
+        assert!(reparsed.var);
+        assert!(reparsed.require_equals);
+        assert!(!reparsed.arg.as_ref().unwrap().var);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a paired clap/usage typed-CLI harness that compares accepted argv, terminal status/stream, diagnostics, help semantics, and version output
- add the first setting-specific row for `require_equals`
- match clap's equals-specific diagnostic and render `=` in typed help placeholders

This establishes the executable harness for the larger generated micro-conformance PLAN item; later stack PRs can add matrix rows without mixing harness design into every feature test.

## Validation

- `cargo test -p usage-conformance --test clap_micro --all-features`
- `cargo test -p usage-argv --all-features`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`

_This PR was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public parse-error enum and help/spec usage rendering, which can break embedders that treated empty-argv help as `Error::Help`. Behavior is test-covered but is a user-visible CLI contract change.
> 
> **Overview**
> Adds a paired clap/usage typed-CLI harness (`clap_micro`) that compares accepted argv, typed values, error kinds, exit status/stream, help, and version for the first matrix rows (`require_equals`, defaults, delimiters, hyphen/negative values, enums, arity, globals, groups, external subcommands, and command policies).
> 
> Splits `arg_required_else_help` into `Error::MissingArgsHelp` so generated `parse()` prints short help to **stderr** and exits **2**, matching clap, instead of treating it as an explicit help request.
> 
> Aligns `require_equals` presentation: missing-value diagnostics now say an equals is required, and help/spec usage render `--flag=<VAL>` / `--flag[=VAL]`, including round-trip parsing of those forms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 271fdb1f8f6cbb2812bf18c41ed1a85a1e4b33d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->