### PR TITLE
feat(config): support optional props and aliases

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1582,13 +1582,11 @@ Where they differ is instructive, because it is mostly _drift_:
 - [x] **Provenance through one merge path**, so `<bin> config explain` comes free
       everywhere instead of needing a parallel implementation. `config/src/explain.rs`
       — `explain`, `warnings`, `list`.
-- [~] **Extend `SpecConfigProp` first.** Mostly done, and the list of what was
-  missing has shrunk to two: `deprecated`, `merge`, `scope`, the per-source
-  `bindings`, and `choices` (the `enum` case) all exist now, alongside
-  `default`, `data_type`, `value_type`, `env`/`envs`, `cli`, and the help
-  fields. **`optional` and `aliases` are still absent.** The markdown renderer
-  reads the block, so it is no longer true that nothing consumes it — but no
-  _CLI_ emits one yet, which is the adoption half below.
+- [x] **Extend `SpecConfigProp` first.** `deprecated`, `merge`, `scope`, the
+      per-source `bindings`, `choices`, `default`, rich types, environment and CLI
+      bindings, help fields, explicit `optional`, and warning-free key `aliases` all
+      survive the portable spec. The markdown renderer and generated runtime registry
+      consume the block; no fleet CLI emits one yet, which is the adoption half below.
 - [ ] **A registry JSON schema**, so the declaration format validates itself the
       way hk's does.
 

--- a/config-build/src/emit.rs
+++ b/config-build/src/emit.rs
@@ -19,6 +19,7 @@ pub(crate) fn registry(config: &SpecConfig, name: &str) -> Result<String, Vec<St
     let props: Vec<(&String, &SpecConfigProp)> = config.props.iter().collect();
 
     check_keys(&props, &mut problems);
+    check_aliases(&props, &mut problems);
     check_renames(&props, &mut problems);
     let idents = identifiers(&props, &mut problems);
 
@@ -156,6 +157,13 @@ fn prop_meta(key: &str, prop: &SpecConfigProp, problems: &mut Vec<String>) -> St
     }
     if let Some(to) = prop.renamed_to.as_deref() {
         let _ = writeln!(fields, "        renamed_to: Some({}),", rust_str(to));
+    }
+    if !prop.aliases.is_empty() {
+        let aliases: Vec<String> = prop.aliases.iter().map(|alias| rust_str(alias)).collect();
+        let _ = writeln!(fields, "        aliases: &[{}],", aliases.join(", "));
+    }
+    if let Some(optional) = prop.optional {
+        let _ = writeln!(fields, "        optional: Some({optional}),");
     }
     if let Some(help) = prop.help.as_deref() {
         let _ = writeln!(fields, "        help: Some({}),", rust_str(help));
@@ -553,6 +561,27 @@ fn check_keys(props: &[(&String, &SpecConfigProp)], problems: &mut Vec<String>) 
                 "`{key}` has a part with no name in it: every piece of a dotted key needs an \
                  ASCII letter or digit"
             ));
+        }
+    }
+}
+
+/// Refuse aliases whose owner is ambiguous.
+fn check_aliases(props: &[(&String, &SpecConfigProp)], problems: &mut Vec<String>) {
+    let mut owners: BTreeMap<&str, &str> = props
+        .iter()
+        .map(|(key, _)| (key.as_str(), key.as_str()))
+        .collect();
+    for (key, prop) in props {
+        for alias in &prop.aliases {
+            if alias.is_empty() {
+                problems.push(format!("`{key}` has an empty alias"));
+                continue;
+            }
+            if let Some(owner) = owners.insert(alias, key) {
+                problems.push(format!(
+                    "`{alias}` names both `{owner}` and `{key}`; every setting key and alias must be unique"
+                ));
+            }
         }
     }
 }

--- a/config-build/src/settings.rs
+++ b/config-build/src/settings.rs
@@ -184,6 +184,9 @@ fn construct(group: &Group<'_>, name: &str, depth: usize) -> String {
 /// nothing declared a default, in which case the resolution can perfectly well come back with no
 /// value. Writing the field as `T` would mean a failure at run time for a shape the spec allows.
 fn optional(leaf: &Leaf<'_>) -> bool {
+    if let Some(optional) = leaf.prop.optional {
+        return optional;
+    }
     leaf.prop.default.is_none() && leaf.prop.default_list.is_empty()
         || leaf
             .prop

--- a/config-build/tests/optional_aliases.rs
+++ b/config-build/tests/optional_aliases.rs
@@ -1,0 +1,70 @@
+use usage_config_build::source_of_spec;
+
+fn generated(settings: &str) -> String {
+    source_of_spec(
+        &format!("name \"ex\"\nbin \"ex\"\nconfig {{\n{settings}\n}}\n"),
+        "ex.usage.kdl",
+    )
+    .expect("registry")
+}
+
+#[test]
+fn aliases_reach_the_runtime_registry() {
+    let source = generated(
+        r#"prop "jobs" type="uint" {
+    alias "parallelism" "threads"
+}"#,
+    );
+    assert!(
+        source.contains(r#"aliases: &["parallelism", "threads"]"#),
+        "{source}"
+    );
+}
+
+#[test]
+fn explicit_optionality_overrides_default_inference() {
+    let source = generated(
+        r#"prop "required_without_default" type="string" optional=#false
+prop "optional_with_default" type="string" default="value" optional=#true"#,
+    );
+    assert!(
+        source.contains("pub required_without_default: String"),
+        "{source}"
+    );
+    assert!(
+        source.contains("fold.required(prop::REQUIRED_WITHOUT_DEFAULT)"),
+        "{source}"
+    );
+    assert!(
+        source.contains("pub optional_with_default: Option<String>"),
+        "{source}"
+    );
+    assert!(
+        source.contains("fold.optional(prop::OPTIONAL_WITH_DEFAULT)"),
+        "{source}"
+    );
+}
+
+#[test]
+fn ambiguous_aliases_are_refused_together() {
+    let error = source_of_spec(
+        r#"name "ex"
+bin "ex"
+config {
+    prop "jobs" { alias "shared" }
+    prop "threads" { alias "shared" "jobs" }
+}
+"#,
+        "ex.usage.kdl",
+    )
+    .expect_err("ambiguous names");
+    let text = error.to_string();
+    assert!(
+        text.contains("`shared` names both `jobs` and `threads`"),
+        "{text}"
+    );
+    assert!(
+        text.contains("`jobs` names both `jobs` and `threads`"),
+        "{text}"
+    );
+}

--- a/config/src/explain.rs
+++ b/config/src/explain.rs
@@ -121,7 +121,7 @@ pub fn explain(resolved: &Resolved, key: &str) -> Option<String> {
     // reading it off the setting that replaced it printed nothing at all for the one case where it
     // matters — and following the renames from there, because a notice can sit anywhere along a
     // chain: `a` renamed to `b`, and `b` the one carrying the notice that says to use `c`.
-    let deprecated = registry.deprecation(found.renamed_from.unwrap_or(meta.key));
+    let deprecated = registry.deprecation(found.written);
     if let Some(why) = deprecated {
         let _ = writeln!(out, "\n  deprecated: {}", one_line(why));
     }
@@ -345,6 +345,29 @@ mod tests {
         let resolved = resolve(CHAINED, Layers::new()).expect("should resolve");
         let text = explain(&resolved, "threads").expect("declared");
         assert!(text.starts_with("threads is now jobs\n"), "{text}");
+        assert!(text.contains("deprecated: Use jobs instead."), "{text}");
+    }
+
+    #[test]
+    fn an_alias_on_a_renamed_setting_keeps_its_deprecation_notice() {
+        static ALIASED: &[PropMeta] = &[
+            PropMeta {
+                default: Some(Const::Int(4)),
+                ..PropMeta::new("jobs", Ty::Uint)
+            },
+            PropMeta {
+                aliases: &["parallelism"],
+                deprecated: Some("Use jobs instead."),
+                renamed_to: Some("jobs"),
+                ..PropMeta::new("concurrency", Ty::Uint)
+            },
+        ];
+        const REGISTRY: Registry = Registry::new(ALIASED);
+
+        let resolved = resolve(REGISTRY, Layers::new()).expect("should resolve");
+        let text = explain(&resolved, "parallelism").expect("declared alias");
+        assert!(text.starts_with("jobs = 4\n"), "{text}");
+        assert!(!text.contains("is now"), "an alias is not a rename: {text}");
         assert!(text.contains("deprecated: Use jobs instead."), "{text}");
     }
 

--- a/config/src/files.rs
+++ b/config/src/files.rs
@@ -216,7 +216,7 @@ impl FileLayer {
         // and an *empty* table under a scalar key produced no keys at all, so nothing was set
         // and nothing was said. Handing the table over lets the declared type answer: a `map`
         // takes it, a union takes it, a `uint` refuses it and that refusal is the warning.
-        let names_a_setting = |key: &str| ctx.prop(key).is_some();
+        let names_a_setting = |key: &str| ctx.registry().names_file_value(key);
         let flat =
             parse(format, &text, self.prefix.as_deref(), &names_a_setting).map_err(|why| {
                 LayerError::Unreadable {

--- a/config/src/layer.rs
+++ b/config/src/layer.rs
@@ -24,6 +24,8 @@ pub struct Entry {
     /// this the resolver cannot tell that anybody used the old name — and the warning that a
     /// deprecated key is in somebody's config file never fires.
     pub renamed_from: Option<&'static str>,
+    /// The exact canonical key or supported alias a keyed layer matched.
+    pub written_key: Option<&'static str>,
 }
 
 impl Entry {
@@ -33,6 +35,7 @@ impl Entry {
             value,
             origin,
             renamed_from: None,
+            written_key: None,
         }
     }
 }
@@ -278,11 +281,26 @@ impl LayerCtx {
             return Err(Warning::at(format!("unknown setting `{key}`"), origin)
                 .of(WarningKind::UnknownSetting));
         };
-        let mut entry = self.entry(found.id, raw, origin)?;
-        // `lookup` already folded, so `entry` had nothing left to fold and nothing to report;
-        // the name the *user* wrote is the one to keep.
-        entry.renamed_from = found.renamed_from.or(entry.renamed_from);
-        Ok(entry)
+        match self.parse(found.id, raw) {
+            Ok(value) => {
+                if let Some(refused) = self.refused(found.id, &value, found.written, &origin) {
+                    return Err(refused);
+                }
+                Ok(Entry {
+                    renamed_from: found.renamed_from,
+                    written_key: Some(found.written),
+                    ..Entry::new(found.id, value, origin)
+                })
+            }
+            Err(err) => Err(Warning::at(
+                format!(
+                    "{} expected {} but has `{}`",
+                    found.written, err.expected, err.found
+                ),
+                origin,
+            )
+            .of(WarningKind::WrongType)),
+        }
     }
 
     /// An entry for a dotted key whose value already has a shape.
@@ -305,21 +323,19 @@ impl LayerCtx {
         let meta = self.registry.get(found.id);
         match meta.ty.coerce(value) {
             Ok(value) => {
-                let key = found.renamed_from.unwrap_or(meta.key);
-                if let Some(refused) = self.refused(found.id, &value, key, &origin) {
+                if let Some(refused) = self.refused(found.id, &value, found.written, &origin) {
                     return Err(refused);
                 }
                 Ok(Entry {
                     renamed_from: found.renamed_from,
+                    written_key: Some(found.written),
                     ..Entry::new(found.id, value, origin)
                 })
             }
             Err(err) => Err(Warning::at(
                 format!(
                     "{} expected {} but has `{}`",
-                    found.renamed_from.unwrap_or(meta.key),
-                    err.expected,
-                    err.found
+                    found.written, err.expected, err.found
                 ),
                 origin,
             )
@@ -346,7 +362,10 @@ mod tests {
     use crate::value::Const;
 
     static PROPS: &[PropMeta] = &[
-        PropMeta::new("jobs", Ty::Uint),
+        PropMeta {
+            aliases: &["parallelism"],
+            ..PropMeta::new("jobs", Ty::Uint)
+        },
         PropMeta {
             parse: Some(Parser::ListByComma),
             ..PropMeta::new("exclude", Ty::List(&Ty::String))
@@ -367,6 +386,7 @@ mod tests {
         // A setting the spec limits to three values, which is hk's `stash` and mise's nine
         // enum-valued settings.
         PropMeta {
+            aliases: &["storage"],
             choices: &[
                 Const::Str("git"),
                 Const::Str("patch-file"),
@@ -409,6 +429,13 @@ mod tests {
         // Which is a different sort of thing from a value of the wrong *type*, and a caller that
         // treats them differently needs to be able to tell.
         assert_eq!(warning.kind, WarningKind::NotAllowed);
+        let alias_warning = ctx
+            .entry_for_key("storage", "svn", origin.clone())
+            .expect_err("alias should use the same choices");
+        assert_eq!(
+            alias_warning.message,
+            "storage expected one of git, patch-file, none but has `svn`"
+        );
         assert_eq!(
             ctx.entry_for_key("jobs", "lots", origin.clone())
                 .expect_err("not a number")
@@ -421,6 +448,9 @@ mod tests {
                 .map(|entry| entry.value),
             Ok(Value::from("git"))
         );
+        let alias = ctx.entry_for_key("storage", "git", origin.clone()).unwrap();
+        assert_eq!(alias.written_key, Some("storage"));
+        assert_eq!(alias.renamed_from, None);
 
         // A list is checked item by item, and the *item* is what the message quotes — naming the
         // whole list would leave the user to work out which of five items was the problem.
@@ -654,6 +684,27 @@ mod tests {
             "jobs expected a non-negative integer but has `lots`"
         );
         assert_eq!(warning.origin, Some(origin));
+
+        let alias_warning = ctx
+            .entry_for_key(
+                "parallelism",
+                "lots",
+                Origin::new(SourceKind::FILE, "config.toml"),
+            )
+            .expect_err("alias value should still be checked");
+        assert_eq!(
+            alias_warning.message,
+            "parallelism expected a non-negative integer but has `lots`"
+        );
+
+        let structured_alias_warning = ctx
+            .entry_from_value(
+                "parallelism",
+                Value::from("lots"),
+                Origin::new(SourceKind::FILE, "config.toml"),
+            )
+            .expect_err("structured alias value should still be checked");
+        assert_eq!(structured_alias_warning.message, alias_warning.message);
 
         // And under an old name, the message says the name that was written — a complaint about
         // a key the user cannot find in their own file is no help at all.

--- a/config/src/registry.rs
+++ b/config/src/registry.rs
@@ -96,6 +96,10 @@ pub struct PropMeta {
     /// The setting that replaces this one. A value found under the old key is folded into the
     /// new one at the same precedence, with a warning.
     pub renamed_to: Option<&'static str>,
+    /// Equivalent keys accepted without a rename warning.
+    pub aliases: &'static [&'static str],
+    /// An explicit optionality contract, when the declaration does not use inference.
+    pub optional: Option<bool>,
     pub help: Option<&'static str>,
 }
 
@@ -116,6 +120,8 @@ impl PropMeta {
             hide: false,
             deprecated: None,
             renamed_to: None,
+            aliases: &[],
+            optional: None,
             help: None,
         }
     }
@@ -131,6 +137,9 @@ pub struct Registry {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Lookup {
     pub id: PropId,
+    /// The canonical key or alias that matched the lookup, so diagnostics can repeat the key the
+    /// user actually wrote without treating a supported alias as a deprecated rename.
+    pub written: &'static str,
     /// The key that was asked for, when it is not the key that was found — an old name still
     /// in somebody's config file. Carried so a warning can name it.
     pub renamed_from: Option<&'static str>,
@@ -218,13 +227,19 @@ impl Registry {
     /// supplies — not once per key that exists. A binary search over a sorted table would be
     /// a fine optimization and is not yet worth the invariant it demands of the generator.
     pub fn lookup(&self, key: &str) -> Option<Lookup> {
-        let (index, meta) = self
-            .props
-            .iter()
-            .enumerate()
-            .find(|(_, meta)| meta.key == key)?;
+        let (index, written, matched_alias) =
+            self.props.iter().enumerate().find_map(|(index, meta)| {
+                if meta.key == key {
+                    Some((index, meta.key, false))
+                } else {
+                    meta.aliases
+                        .iter()
+                        .copied()
+                        .find(|alias| *alias == key)
+                        .map(|alias| (index, alias, true))
+                }
+            })?;
         let mut id = PropId(index as u16);
-        let written = meta.key;
         // A chain of renames resolves to its end, so two releases of renaming do not leave the
         // second one unreachable — walked rather than recursed, and bounded by the number of
         // settings there are. A cycle, which is one mistyped field away in a registry somebody
@@ -234,7 +249,8 @@ impl Registry {
             let Some(new_key) = self.props[id.index()].renamed_to else {
                 return Some(Lookup {
                     id,
-                    renamed_from: (id.index() != index).then_some(written),
+                    written,
+                    renamed_from: (id.index() != index && !matched_alias).then_some(written),
                 });
             };
             id = self.lookup_exact(new_key)?;
@@ -254,6 +270,30 @@ impl Registry {
             .map(|index| PropId(index as u16))
     }
 
+    /// Whether a table at `key` is itself a setting value rather than a path to
+    /// more-specific settings.
+    ///
+    /// Aliases participate in file lookup, but an alias that is also the prefix
+    /// of a declared dotted key must not swallow that nested value. A leaf alias
+    /// for a map or object still names the whole table.
+    pub fn names_file_value(&self, key: &str) -> bool {
+        let Some(found) = self.lookup(key) else {
+            return false;
+        };
+        let meta = self.get(found.id);
+        // A canonical table setting owns its value. Another declaration's alias below
+        // that key cannot turn the canonical map into a namespace and make the whole
+        // value disappear during flattening.
+        if meta.key == key && matches!(meta.ty.inner(), Ty::Map(_) | Ty::Object | Ty::Any) {
+            return true;
+        }
+        let prefix = format!("{key}.");
+        !self.props.iter().any(|meta| {
+            meta.key.starts_with(&prefix)
+                || meta.aliases.iter().any(|alias| alias.starts_with(&prefix))
+        })
+    }
+
     /// The first deprecation notice along the rename chain that starts at `key`.
     ///
     /// The chain, not the declaration named: `a` renamed to `b`, and `b` the one carrying the notice
@@ -265,7 +305,11 @@ impl Registry {
     /// same reason: this is an authoring mistake, and hanging is a worse way to report one than
     /// nothing at all. `usage-config-build` refuses such a registry outright.
     pub fn deprecation(&self, key: &str) -> Option<&'static str> {
-        let mut current = self.lookup_exact(key)?;
+        let mut current = self
+            .props
+            .iter()
+            .position(|meta| meta.key == key || meta.aliases.contains(&key))
+            .map(|index| PropId(index as u16))?;
         for _ in 0..self.props.len() {
             let meta = self.get(current);
             if let Some(why) = meta.deprecated {
@@ -393,6 +437,7 @@ mod tests {
     static PROPS: &[PropMeta] = &[
         PropMeta {
             key: "jobs",
+            aliases: &["parallelism"],
             envs: &["HK_JOBS", "HK_JOB"],
             cli: &["--jobs", "-j"],
             bindings: &[("git", "hk.jobs"), ("pkl", "jobs")],
@@ -416,6 +461,80 @@ mod tests {
         },
     ];
     const REGISTRY: Registry = Registry::new(PROPS);
+
+    #[test]
+    fn aliases_resolve_without_becoming_renames() {
+        let found = REGISTRY.lookup("parallelism").expect("alias");
+        assert_eq!(found.id, REGISTRY.lookup("jobs").unwrap().id);
+        assert_eq!(found.written, "parallelism");
+        assert_eq!(found.renamed_from, None);
+        assert_eq!(REGISTRY.deprecation("parallelism"), None);
+    }
+
+    #[test]
+    fn an_alias_on_a_renamed_prop_stays_warning_free_but_keeps_deprecation() {
+        static RENAMED: &[PropMeta] = &[
+            PropMeta::new("jobs", Ty::Uint),
+            PropMeta {
+                aliases: &["parallelism"],
+                renamed_to: Some("jobs"),
+                deprecated: Some("Use jobs instead."),
+                ..PropMeta::new("concurrency", Ty::Uint)
+            },
+        ];
+        let registry = Registry::new(RENAMED);
+        let found = registry.lookup("parallelism").unwrap();
+        assert_eq!(found.id, PropId(0));
+        assert_eq!(found.renamed_from, None);
+        assert_eq!(
+            registry.deprecation("parallelism"),
+            Some("Use jobs instead.")
+        );
+    }
+
+    #[test]
+    fn an_alias_prefix_does_not_swallow_a_nested_file_key() {
+        const PREFIXED: &[PropMeta] = &[
+            PropMeta {
+                aliases: &["old.key"],
+                ..PropMeta::new("replacement", Ty::Map(&Ty::String))
+            },
+            PropMeta::new("old.key.extra", Ty::String),
+            PropMeta {
+                aliases: &["whole.table"],
+                ..PropMeta::new("map", Ty::Map(&Ty::String))
+            },
+        ];
+        let registry = Registry::new(PREFIXED);
+        assert!(!registry.names_file_value("old.key"));
+        assert!(registry.names_file_value("old.key.extra"));
+        assert!(registry.names_file_value("whole.table"));
+    }
+
+    #[test]
+    fn a_canonical_table_value_is_not_turned_into_a_namespace_by_an_alias() {
+        const PROPS: &[PropMeta] = &[
+            PropMeta::new("providers", Ty::Map(&Ty::String)),
+            PropMeta::new("optional", Ty::Option(&Ty::Map(&Ty::String))),
+            PropMeta::new("union", Ty::Any),
+            PropMeta {
+                aliases: &["providers.legacy"],
+                ..PropMeta::new("legacy_provider", Ty::String)
+            },
+            PropMeta {
+                aliases: &["optional.legacy"],
+                ..PropMeta::new("optional_legacy", Ty::String)
+            },
+            PropMeta {
+                aliases: &["union.legacy"],
+                ..PropMeta::new("union_legacy", Ty::String)
+            },
+        ];
+        let registry = Registry::new(PROPS);
+        assert!(registry.names_file_value("providers"));
+        assert!(registry.names_file_value("optional"));
+        assert!(registry.names_file_value("union"));
+    }
 
     #[test]
     fn a_cli_that_binds_what_the_spec_declares_has_no_drift() {

--- a/config/src/resolve.rs
+++ b/config/src/resolve.rs
@@ -179,7 +179,10 @@ pub fn resolve(registry: Registry, layers: Layers<'_>) -> Result<Resolved, Layer
             // Whichever way the old name arrived: on the entry, because the layer looked the
             // key up and `LayerCtx` folded it, or as a raw id this loop folded just now.
             // Keyed on the fold alone, a file layer's deprecated key was folded in silence.
-            let written_key = entry.renamed_from.unwrap_or(written.key);
+            let written_key = entry
+                .written_key
+                .or(entry.renamed_from)
+                .unwrap_or(written.key);
             if let Some(refusal) = refuse(meta.scope, &entry.origin) {
                 // `written_key`, like the two warnings below it: after `LayerCtx` folds a
                 // rename, `written.key` is the *replacement's* name, so a refused value was
@@ -204,7 +207,7 @@ pub fn resolve(registry: Registry, layers: Layers<'_>) -> Result<Resolved, Layer
                     .of(WarningKind::Deprecated),
                 );
             }
-            if written_key != meta.key {
+            if entry.renamed_from.is_some() || prop != entry.prop {
                 // Both names: the key the user wrote, and the one it was read as.
                 resolved.warnings.push(
                     Warning::at(

--- a/conformance/src/config.rs
+++ b/conformance/src/config.rs
@@ -700,6 +700,8 @@ fn registry_of(settings: &[Setting]) -> Result<Registry, String> {
             hide: false,
             deprecated: setting.deprecated.as_deref().map(leak),
             renamed_to: setting.renamed_to.as_deref().map(leak),
+            aliases: &[],
+            optional: None,
             help: None,
         });
     }

--- a/docs/spec/reference/config.md
+++ b/docs/spec/reference/config.md
@@ -88,6 +88,7 @@ files, so a setting a repository must not be able to change can say so.
 | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | `type`                                       | the type, see [below](#types). Defaults to `string`                                                          |
 | `default`                                    | the value when nothing supplies one — a typed KDL value: `4`, `#true`, `"x"`                                 |
+| `optional`                                   | explicitly permit or require absence; otherwise inferred from the type and default                           |
 | `default_note`                               | what to print instead of the default, when the real one needs explaining                                     |
 | `help`, `long_help`                          | one line, and the whole markdown story                                                                       |
 | `help_heading`                               | the section to list it under in generated docs                                                               |
@@ -103,16 +104,17 @@ files, so a setting a repository must not be able to change can say so.
 
 And as child nodes, for anything multi-valued or long:
 
-| node                              | meaning                                                       |
-| --------------------------------- | ------------------------------------------------------------- |
-| `cli "--jobs" "-j"`               | flags that set it                                             |
-| `env "A" "B"`                     | environment variables, highest precedence first               |
-| `source "git" "a.b"`              | its keys in a declared source kind                            |
-| `default "a" "b"`                 | a list default, values typed as written (`default 80 443`)    |
-| `long_help "…"`                   | the long form, when a raw string reads better than a property |
-| `example "…"`                     | one invocation worth showing                                  |
-| `choices { choice "a" help="…" }` | the values it accepts, each with its own help                 |
-| `x "ns.key" value`                | see [extensions](#extensions)                                 |
+| node                              | meaning                                                        |
+| --------------------------------- | -------------------------------------------------------------- |
+| `cli "--jobs" "-j"`               | flags that set it                                              |
+| `env "A" "B"`                     | environment variables, highest precedence first                |
+| `alias "old.key"`                 | equivalent config keys, accepted without a deprecation warning |
+| `source "git" "a.b"`              | its keys in a declared source kind                             |
+| `default "a" "b"`                 | a list default, values typed as written (`default 80 443`)     |
+| `long_help "…"`                   | the long form, when a raw string reads better than a property  |
+| `example "…"`                     | one invocation worth showing                                   |
+| `choices { choice "a" help="…" }` | the values it accepts, each with its own help                  |
+| `x "ns.key" value`                | see [extensions](#extensions)                                  |
 
 ## Types
 

--- a/lib/src/docs/manpage/renderer.rs
+++ b/lib/src/docs/manpage/renderer.rs
@@ -154,6 +154,12 @@ impl ManpageRenderer {
             if let Some(ty) = &prop.type_ {
                 facts.push(format!("type: {ty}"));
             }
+            if !prop.aliases.is_empty() {
+                facts.push(format!("aliases: {}", prop.aliases.join(", ")));
+            }
+            if let Some(optional) = prop.optional {
+                facts.push(format!("optional: {optional}"));
+            }
             if let Some(default) = &prop.default {
                 facts.push(format!("default: {default}"));
             }

--- a/lib/src/docs/markdown/config.rs
+++ b/lib/src/docs/markdown/config.rs
@@ -42,6 +42,26 @@ mod tests {
     }
 
     #[test]
+    fn explicit_optionality_and_aliases_are_documented() {
+        let page = rendered(
+            r#"
+name "ex"
+bin "ex"
+config {
+    prop "jobs" type="uint" optional=#false {
+        alias "parallelism" "threads"
+    }
+}
+"#,
+        );
+        assert!(
+            page.contains("**aliases**: `parallelism`, `threads`"),
+            "{page}"
+        );
+        assert!(page.contains("**optional**: false"), "{page}");
+    }
+
+    #[test]
     fn the_facts_list_starts_on_its_own_line_whatever_its_first_item_is() {
         // The blank line that opens the list was emitted inside the `type_` branch, so a prop
         // with a default and no declared type put its first list item straight against the

--- a/lib/src/docs/markdown/templates/config_template.md.tera
+++ b/lib/src/docs/markdown/templates/config_template.md.tera
@@ -28,10 +28,16 @@ Read from, in ascending precedence — the last one that names a setting wins:
     branch — a prop with a default but no declared type used to put its first list item
     directly against the heading above (or against a deprecation admonition's closing `:::`),
     which some markdown renderers read as part of that block rather than as a list. #}
-{%- if prop.type_ or prop.default or prop.merge or prop.scope == "global" or prop.scope == "env" or prop.since or prop.sources %}
+{%- if prop.type_ or prop.default or prop.aliases or prop.optional is not none or prop.merge or prop.scope == "global" or prop.scope == "env" or prop.since or prop.sources %}
 {% endif %}
 {%- if prop.type_ %}
 - **type**: `{{ prop.type_ }}`
+{%- endif %}
+{%- if prop.aliases %}
+- **aliases**: {% for alias in prop.aliases %}`{{ alias }}`{% if not loop.last %}, {% endif %}{% endfor %}
+{%- endif %}
+{%- if prop.optional is not none %}
+- **optional**: {{ prop.optional }}
 {%- endif %}
 {%- if prop.default %}
 - **default**: {% if prop.default_note %}{{ prop.default_note }}{% else %}`{{ prop.default }}`{% endif %}

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -192,6 +192,8 @@ pub struct SpecConfigFile {
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct SpecConfigProp {
     pub key: String,
+    pub aliases: Vec<String>,
+    pub optional: Option<bool>,
     /// The type as written, or nothing when the spec did not say.
     pub type_: Option<String>,
     pub default: Option<String>,
@@ -291,6 +293,8 @@ impl SpecConfigProp {
     ) -> Self {
         Self {
             key: key.to_string(),
+            aliases: prop.aliases.clone(),
+            optional: prop.optional,
             type_: prop.value_type.as_ref().map(|t| t.to_string()),
             default: prop
                 .default_note

--- a/lib/src/spec/config.rs
+++ b/lib/src/spec/config.rs
@@ -423,6 +423,16 @@ impl SpecConfig {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[non_exhaustive]
 pub struct SpecConfigProp {
+    /// Whether absence is a legitimate resolved value.
+    ///
+    /// `None` keeps the inferred rule: an `option<T>` or a property without a default is
+    /// optional. An explicit value lets a registry state the contract instead of relying on
+    /// that inference.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub optional: Option<bool>,
+    /// Equivalent config keys accepted without a deprecation warning.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub aliases: Vec<String>,
     pub default: Option<SpecConfigValue>,
     pub default_note: Option<String>,
     /// The old five-value type, kept so a spec written against it still means what it said.
@@ -519,6 +529,9 @@ impl SpecConfigProp {
         if let Some(default) = &self.default {
             node.push(default.to_kdl_entry("default"));
         }
+        if let Some(optional) = self.optional {
+            node.push(KdlEntry::new_prop("optional", optional));
+        }
         // The grammar spelling when there is one, the old five-value name otherwise: a
         // spec that said `data_type` keeps saying it, and one that says `type` keeps the
         // richer type it declared. Either way it is written, unlike before — a type parsed
@@ -583,6 +596,11 @@ impl SpecConfigProp {
         let mut children = KdlDocument::new();
         if self.envs.len() > 1 {
             children.nodes_mut().push(string_list("env", &self.envs));
+        }
+        if !self.aliases.is_empty() {
+            children
+                .nodes_mut()
+                .push(string_list("alias", &self.aliases));
         }
         if !self.cli.is_empty() {
             children.nodes_mut().push(string_list("cli", &self.cli));
@@ -700,6 +718,7 @@ impl SpecConfigProp {
                     }
                 }
                 "default_note" => prop.default_note = Some(v.ensure_string()?),
+                "optional" => prop.optional = Some(v.ensure_bool()?),
                 // `data_type` was the old spelling and stays readable; `type` is the
                 // grammar, and setting either fills the other in where they overlap.
                 "data_type" | "type" => {
@@ -741,6 +760,7 @@ impl SpecConfigProp {
                 // second `env` line is the natural parallel — assigning silently dropped the
                 // aliases on the first one.
                 "env" => prop.envs.extend(string_args(&child)?),
+                "alias" => prop.aliases.extend(string_args(&child)?),
                 "cli" => prop.cli.extend(string_args(&child)?),
                 "example" => prop.examples.extend(string_args(&child)?),
                 "long_help" => {
@@ -896,6 +916,8 @@ where
 impl Default for SpecConfigProp {
     fn default() -> Self {
         Self {
+            optional: None,
+            aliases: Vec::new(),
             default: None,
             default_note: None,
             data_type: SpecDataTypes::Null,
@@ -985,6 +1007,28 @@ mod tests {
     use super::{SpecConfigMerge, SpecConfigScope, SpecConfigValue};
     use crate::Spec;
     use insta::assert_snapshot;
+
+    #[test]
+    fn optionality_and_key_aliases_round_trip() {
+        let spec: Spec = r#"
+name "ex"
+bin "ex"
+config {
+    prop "jobs" type="uint" optional=#false {
+        alias "parallelism" "threads"
+    }
+}
+"#
+        .parse()
+        .unwrap();
+        let jobs = &spec.config.props["jobs"];
+        assert_eq!(jobs.optional, Some(false));
+        assert_eq!(jobs.aliases, ["parallelism", "threads"]);
+
+        let written = spec.to_string();
+        let reparsed: Spec = written.parse().unwrap();
+        assert_eq!(reparsed.config.props["jobs"], *jobs, "{written}");
+    }
 
     #[test]
     fn test_config_defaults() {


### PR DESCRIPTION
Adds the two remaining portable config-property vocabulary items from PLAN.md.

- carries explicit tri-state optionality through KDL, docs, generated registries, and generated Settings fields
- accepts warning-free equivalent config-key aliases, distinct from deprecated `renamed_to` keys
- rejects aliases that collide with canonical keys or other aliases
- marks the SpecConfigProp vocabulary item complete in PLAN.md

Validation: focused usage-lib, usage-config, and usage-config-build suites; workspace all-target/all-feature clippy.

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches config key resolution, file flattening, diagnostics, and generated Settings types. Wrong alias/optional handling could mis-merge files or silently change required vs optional fields.
> 
> **Overview**
> Completes the remaining `SpecConfigProp` vocabulary: explicit **optionality** and warning-free **key aliases**, distinct from deprecated `renamed_to`.
> 
> `optional` is a tri-state on the spec (`None` still infers from type/default). Codegen honors an explicit value when emitting `Settings` fields (`T` vs `Option<T>`) and fold required/optional. `alias` children round-trip in KDL, docs, manpages, and generated `PropMeta`.
> 
> Runtime lookup treats aliases as the same setting without a rename warning, while still repeating the written key in type/choice errors and keeping deprecation notices. File flattening uses `names_file_value` so an alias prefix cannot swallow nested keys, and a canonical map/object is not turned into a namespace by a nested alias. Build-time `check_aliases` refuses empty or colliding aliases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 047b107141cc94d98b95289585205ea16b53373a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->