### PR TITLE
fix(derive): keep parsed fields live for lints

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -707,6 +707,9 @@ feature list is not an exhaustive audit.
       arity with distinct `value_names`); optional-value shapes that need
       per-occurrence presence semantics and arbitrary `value_parser` callbacks
       produce targeted migration diagnostics instead of a generic unknown-option error.
+      The generated build also takes a zero-cost shared reference to every field, so a
+      parse-only compatibility flag does not trip an adopter's `deny(dead_code)` merely
+      because application code intentionally accepts and ignores it.
 - [x] **Command-with-arguments completion hints.** `ExecutablePath`,
       `CommandName`, `CommandString`, and `CommandWithArguments` lower to
       shell-native completion types. A forwarded argv vector offers commands for

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -31,10 +31,19 @@ fn built_value(cli: &Cli, sub_build: &TokenStream, fields: &[TokenStream]) -> To
         debug_assert!(cli.fields.is_empty());
         quote!(Self)
     } else {
+        let field_reads = cli.fields.iter().map(|field| &field.ident);
         quote! {
-            Self {
-                #sub_build
-                #(#fields),*
+            {
+                let __usage_built = Self {
+                    #sub_build
+                    #(#fields),*
+                };
+                // A parsed compatibility flag may intentionally be accepted and ignored.
+                // Reading every field here keeps `#[deny(dead_code)]` from blaming the
+                // adopter for a field the derive itself owns. These shared references
+                // generate no runtime work after optimization.
+                #(let _ = &__usage_built.#field_reads;)*
+                __usage_built
             }
         }
     }

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -481,6 +481,15 @@ struct ClapSpellings {
     path: Option<String>,
 }
 
+#[deny(dead_code)]
+#[derive(Cli)]
+#[command(bin = "parse-only-field")]
+struct ParseOnlyField {
+    /// Accepted for compatibility even though the application intentionally ignores it.
+    #[arg(long)]
+    compatibility: bool,
+}
+
 #[derive(Cli)]
 #[command(bin = "clap-override-id")]
 struct ClapOverrideId {
@@ -1119,6 +1128,12 @@ fn clap_field_ids_and_aliases_need_no_rewrite() {
         kdl.contains("alias --quietly --silent-output hide=#true"),
         "{kdl}"
     );
+}
+
+#[test]
+fn parse_only_fields_do_not_trigger_dead_code() {
+    ParseOnlyField::parse_from(&[OsStr::new("--compatibility")])
+        .expect("the compatibility flag should still parse");
 }
 
 #[test]


### PR DESCRIPTION
Generated command construction now takes a shared reference to every parsed field. This preserves intentional parse-only compatibility flags under `deny(dead_code)` without adding optimized runtime work.

A facade regression compiles an ignored flag under `#[deny(dead_code)]`, and PLAN records the adopter requirement.

_This PR description was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small derive codegen tweak plus a regression test; no change to parse semantics or security-sensitive paths.
> 
> **Overview**
> Generated command construction now takes a shared reference to every parsed field so intentional parse-only compatibility flags no longer trip `deny(dead_code)`.
> 
> The extra reads are expected to optimize away. A facade regression compiles an ignored flag under `#[deny(dead_code)]`, and PLAN records the adopter requirement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04240b04eb13b030ff942c8faec20aa718d2a421. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->