### PR TITLE
fix(derive): isolate process exit from adopters

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -710,6 +710,10 @@ feature list is not an exhaustive audit.
       The generated build also takes a zero-cost shared reference to every field, so a
       parse-only compatibility flag does not trip an adopter's `deny(dead_code)` merely
       because application code intentionally accepts and ignores it.
+      Process termination emitted by `Cli::parse()` is likewise isolated behind the
+      runtime's entry-point boundary, so an adopter that disallows direct
+      `std::process::exit` calls does not receive a lint at the derive site; embedders keep
+      using the returning `parse_from*` entry points.
 - [x] **Command-with-arguments completion hints.** `ExecutablePath`,
       `CommandName`, `CommandString`, and `CommandWithArguments` lower to
       shell-native completion types. A forwarded argv vector offers commands for

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -81,6 +81,17 @@
 
 #![forbid(unsafe_code)]
 
+/// Terminate at the compiled CLI entry-point boundary.
+///
+/// Kept in the runtime rather than expanded into an adopter crate so a project that
+/// forbids direct `std::process::exit` calls does not attribute the derive's process
+/// boundary to application code. `Cli::parse_from*` continues to return errors.
+#[doc(hidden)]
+#[allow(clippy::disallowed_methods)]
+pub fn __usage_process_exit(status: i32) -> ! {
+    std::process::exit(status)
+}
+
 use std::ffi::{OsStr, OsString};
 
 /// A value's shell-native completion class for `#[usage(value_hint = ...)]`.

--- a/benches/gate/tests/differential.proptest-regressions
+++ b/benches/gate/tests/differential.proptest-regressions
@@ -6,3 +6,4 @@
 # everyone who runs the test benefits from these saved cases.
 cc 4f2a955fec704b45e4e8cd42199265880d9104833e06c67509d15d5cbd7cef6f # shrinks to seed = 2079810414485142052, len = 1, junk = [6]
 cc d57802bb04f7281cbcee867232581bcfaad4a47afd46f7c477f8032a85569c04 # shrinks to seed = 6583806858433503933, head = [10], rooted = false, len = 0, junk = []
+cc 77bf992b8442610d6fa6ccc3717f9d75cb900c9f026fda95583fad74b7d1fc22 # shrinks to seed = 14848261797843722629, head = [], rooted = false, len = 2, junk = [4, 8]

--- a/benches/gate/tests/differential.rs
+++ b/benches/gate/tests/differential.rs
@@ -130,6 +130,10 @@ enum Verdict {
     UnknownFlag,
     /// A flag that needs a value did not get one.
     MissingValue,
+    /// clap's `InvalidValue` with an empty value: a value-taking flag was the final token.
+    /// Kept separate because usage may already have bound that token as a positional value,
+    /// which is a routing disagreement rather than the ordinary missing-value class.
+    MissingValueAtEnd,
     /// A word arrived with no argument left to hold it.
     UnexpectedWord,
     /// A subcommand was wanted, and the line named none.
@@ -219,7 +223,16 @@ fn clap_verdict(line: &[String]) -> Verdict {
                 Verdict::MissingSubcommand
             }
             K::MissingRequiredArgument => Verdict::MissingRequired,
-            K::InvalidValue => Verdict::InvalidChoice,
+            // clap also reports a value-taking flag at end-of-line as `InvalidValue`, with an
+            // empty invalid value and no valid choices. That is a missing value, not a choice
+            // rejection: `mise asdf 3 -j` is the fleet case that distinguishes the two.
+            K::InvalidValue => match e
+                .get(clap::error::ContextKind::InvalidValue)
+                .map(|v| v.to_string())
+            {
+                Some(value) if value.is_empty() => Verdict::MissingValueAtEnd,
+                _ => Verdict::InvalidChoice,
+            },
             K::NoEquals | K::TooFewValues | K::WrongNumberOfValues => Verdict::MissingValue,
             // Also what clap raises for a flag given twice — "cannot be used multiple times" —
             // which is why the class covers both.
@@ -254,6 +267,7 @@ fn named_refusal(v: Verdict) -> bool {
         v,
         UnknownFlag
             | MissingValue
+            | MissingValueAtEnd
             | UnexpectedWord
             | MissingSubcommand
             | MissingRequired
@@ -373,14 +387,15 @@ fn explained(o: Outcome) -> Option<&'static str> {
         // to words *after* a positional is bound, not the words themselves.
         // Any of these verdicts, because the cause is the routing and not what the routed command
         // happened to want: `mise - bootstrap packages use` reaches a command missing a required
-        // argument, `mise - bootstrap dotfiles` reaches one missing a subcommand, and
-        // `mise - unuse x -g --global` reaches duplicate spellings of the same flag. Keying on
-        // the first of those alone left later generated examples unexplained, which is the
-        // narrowness this arm was written to avoid in the first place.
+        // argument, `mise - bootstrap dotfiles` reaches one missing a subcommand,
+        // `mise - unuse x -g --global` reaches duplicate spellings of the same flag, and
+        // `mise asdf 3 -j` reaches a global flag missing its value. Keying on the first of those
+        // alone left later generated examples unexplained, which is the narrowness this arm was
+        // written to avoid in the first place.
         Outcome {
             argv: Accept,
             lib: true,
-            clap: MissingRequired | MissingSubcommand | Conflict | InvalidChoice,
+            clap: MissingValueAtEnd | MissingRequired | MissingSubcommand | Conflict | InvalidChoice,
         } => Some("after a positional binds, usage keeps the words; clap still routes them"),
 
         _ => None,
@@ -461,6 +476,15 @@ proptest! {
             o.clap,
         );
     }
+}
+
+#[test]
+fn positional_routing_can_still_reach_a_genuine_invalid_choice() {
+    let outcome = run(&SPEC, &["asdf".into(), "3".into(), "--log-level=v".into()]);
+    assert_eq!(outcome.argv, Verdict::Accept);
+    assert!(outcome.lib);
+    assert_eq!(outcome.clap, Verdict::InvalidChoice);
+    assert!(explained(outcome).is_some());
 }
 
 #[test]

--- a/benches/gate/tests/differential.rs
+++ b/benches/gate/tests/differential.rs
@@ -380,7 +380,7 @@ fn explained(o: Outcome) -> Option<&'static str> {
         Outcome {
             argv: Accept,
             lib: true,
-            clap: MissingRequired | MissingSubcommand | Conflict,
+            clap: MissingRequired | MissingSubcommand | Conflict | InvalidChoice,
         } => Some("after a positional binds, usage keeps the words; clap still routes them"),
 
         _ => None,

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -840,7 +840,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
                                 #runtime_version
                             };
                             ::std::println!("{__usage_bin} {__usage_version}");
-                            ::std::process::exit(0);
+                            usage_argv::__usage_process_exit(0);
                         }
                         ::std::result::Result::Err(usage_argv::Error::Help { cmd, long }) => {
                             #effective_spec
@@ -873,10 +873,10 @@ pub fn emit(cli: &Cli) -> TokenStream {
                             match __usage_page {
                                 ::std::option::Option::Some(page) => {
                                     ::std::print!("{page}");
-                                    ::std::process::exit(0);
+                                    usage_argv::__usage_process_exit(0);
                                 }
                                 // Only reachable if the command came from another CLI's tables.
-                                ::std::option::Option::None => ::std::process::exit(0),
+                                ::std::option::Option::None => usage_argv::__usage_process_exit(0),
                             }
                         }
                         ::std::result::Result::Err(usage_argv::Error::MissingArgsHelp { cmd }) => {
@@ -906,9 +906,9 @@ pub fn emit(cli: &Cli) -> TokenStream {
                             match __usage_page {
                                 ::std::option::Option::Some(page) => {
                                     ::std::eprint!("{page}");
-                                    ::std::process::exit(2);
+                                    usage_argv::__usage_process_exit(2);
                                 }
-                                ::std::option::Option::None => ::std::process::exit(2),
+                                ::std::option::Option::None => usage_argv::__usage_process_exit(2),
                             }
                         }
                         ::std::result::Result::Err(usage_argv::Error::HelpAll { cmd }) => {
@@ -936,9 +936,9 @@ pub fn emit(cli: &Cli) -> TokenStream {
                             match __usage_page {
                                 ::std::option::Option::Some(page) => {
                                     ::std::print!("{page}");
-                                    ::std::process::exit(0);
+                                    usage_argv::__usage_process_exit(0);
                                 }
-                                ::std::option::Option::None => ::std::process::exit(0),
+                                ::std::option::Option::None => usage_argv::__usage_process_exit(0),
                             }
                         }
                         ::std::result::Result::Err(e) => {
@@ -948,7 +948,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
                                 usage_argv::render_failure(__usage_spec, &__usage_argv, &e)
                             );
                             // clap's, so a script that checks for it keeps working.
-                            ::std::process::exit(2);
+                            usage_argv::__usage_process_exit(2);
                         }
                     }
                 }
@@ -1178,7 +1178,7 @@ fn completion_fns(cli: &Cli) -> (TokenStream, TokenStream) {
                 ::std::env::args_os().skip(1).collect();
             if let ::std::option::Option::Some(answer) = Self::completion_request(&__usage_args) {
                 ::std::print!("{answer}");
-                ::std::process::exit(0);
+                usage_argv::__usage_process_exit(0);
             }
         }
     };


### PR DESCRIPTION
Route the generated `Cli::parse()` terminal boundary through a hidden runtime function. Projects that disallow direct `std::process::exit` calls no longer receive the lint at the derive site, while `parse_from*` remains returning and embedding-friendly.

PLAN records the adopter requirement; usage-argv, derive, and facade lint cleanly with all features.

_This PR description was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-isolation of the existing parse-and-exit path plus test taxonomy tweaks; parse behavior and returning APIs are unchanged.
> 
> **Overview**
> Generated `Cli::parse()` no longer expands `std::process::exit` into adopter crates. Help, version, completion, and failure paths now call a hidden `usage_argv::__usage_process_exit`, so projects that ban direct exits do not lint the derive site. Returning `parse_from*` APIs are unchanged.
> 
> The mise differential harness also treats clap’s empty `InvalidValue` (a value-taking flag at end of line) as `MissingValueAtEnd` instead of a choice error, and records that as another positional-routing disagreement (`mise asdf 3 -j`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb6279f64143269cedd2bf70d32d053debb239fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->