### PR TITLE
fix(derive): propagate redeclared global values

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -514,6 +514,10 @@ Groups are the opposite case: `Command::get_groups`, `ArgGroup::get_args` and
       errors. KDL, usage-lib, the typed derive/static metadata, generated Go, and the
       clap bridge carry the policy. Repeatable, variadic, and count flags retain their
       collecting behavior.
+- [x] **Redeclared global values.** When a subcommand redeclares an inherited global
+      spelling, the nearer declaration parses the token and the value is propagated
+      into the ancestor's typed field too, matching clap. Attached values are covered
+      because mise normalizes its short option forms before parsing.
 - [x] **Optional flag values.** `Option<Option<T>>` distinguishes an absent flag,
       a bare flag, and an explicit value. The derive infers zero-or-one value arity,
       usage-argv binds all three states, and emitted KDL/help use an optional

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -314,6 +314,30 @@ pub fn multicall_applet<'a>(argv0: &'a str, name: &str, bin: Option<&str>) -> Op
     Some(base)
 }
 
+/// Resolved identity of a derive-generated binding type.
+#[derive(Clone, Copy)]
+pub struct BindingType(pub fn() -> &'static str);
+
+impl BindingType {
+    pub fn name(self) -> &'static str {
+        (self.0)()
+    }
+}
+
+impl ::core::fmt::Debug for BindingType {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        f.debug_tuple("BindingType").field(&self.name()).finish()
+    }
+}
+
+impl PartialEq for BindingType {
+    fn eq(&self, other: &Self) -> bool {
+        self.name() == other.name()
+    }
+}
+
+impl Eq for BindingType {}
+
 /// A flag, addressed by any of its long or short forms.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Flag<'a> {
@@ -321,6 +345,16 @@ pub struct Flag<'a> {
     /// generated code knows which field to assign without any string comparison.
     /// See [`Command::key`] on why it is this wide.
     pub key: u64,
+    /// Compatibility key for mirroring a redeclared child global into an ancestor field.
+    ///
+    /// Zero means no typed binding contract is declared. Derive-generated tables hash the
+    /// binding shape and portable metadata so only equivalent bindings receive the same event.
+    pub binding_key: u64,
+    /// Resolved Rust value type for a derive-generated binding.
+    ///
+    /// This is separate from [`Self::binding_key`] because token spellings are not type
+    /// identities: an imported alias and a fully qualified path can name the same type.
+    pub binding_type: Option<BindingType>,
     /// Unused by binding, kept so a table entry can carry its own name for
     /// diagnostics.
     pub name: &'a str,
@@ -413,6 +447,8 @@ impl Flag<'_> {
     /// A value-less flag, for use with struct update syntax.
     pub const BOOL: Flag<'static> = Flag {
         key: 0,
+        binding_key: 0,
+        binding_type: None,
         name: "",
         longs: &[],
         shorts: &[],

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -2707,6 +2707,20 @@ pub trait CommandArgs: Sized {
     /// for whoever owns it rather than mistaken for a local field.
     fn apply(partial: &mut Self::Partial, event: &crate::Event<'_, '_, '_>) -> bool;
 
+    /// Mirror a redeclared child flag's value into this command's matching global field.
+    ///
+    /// This deliberately skips occurrence and relationship bookkeeping: the token was parsed
+    /// against the child's declaration, so policies such as `exclusive` and `overrides` belong
+    /// to that declaration even though clap-compatible typed access exposes the value at both
+    /// levels. The default keeps hand-written implementations source compatible.
+    fn apply_mirrored_global(
+        partial: &mut Self::Partial,
+        event: &crate::Event<'_, '_, '_>,
+    ) -> bool {
+        let _ = (partial, event);
+        false
+    }
+
     /// Every flag this command reads into a setting, and the setting it sets.
     ///
     /// Empty by default, so a command that binds nothing implements nothing and a parent can ask

--- a/conformance/src/tables.rs
+++ b/conformance/src/tables.rs
@@ -267,6 +267,10 @@ fn build_flag(f: &SpecFlag) -> &'static Flag<'static> {
         .collect();
     Box::leak(Box::new(Flag {
         key: 0,
+        // Dynamic portable specs have no Rust field type to identify. They never participate
+        // in derive's typed ancestor mirroring, so zero deliberately declares no contract.
+        binding_key: 0,
+        binding_type: None,
         name: leak(&f.name),
         longs: Box::leak(longs.into_boxed_slice()),
         shorts: Box::leak(shorts.into_boxed_slice()),

--- a/conformance/tests/global_flags.rs
+++ b/conformance/tests/global_flags.rs
@@ -229,7 +229,10 @@ fn the_fields_are_bound() {
     ]
     .map(OsStr::new);
     let ex = Ex::parse_from(&argv).expect("should parse");
-    assert!(ex.verbose && !ex.raw && !ex.root_only);
+    assert!(
+        ex.verbose && ex.raw && !ex.root_only,
+        "the child and root declarations of the same canonical global both bind"
+    );
     let Some(Command::Config(config)) = ex.command else {
         panic!("expected config")
     };

--- a/conformance/tests/post_binding.rs
+++ b/conformance/tests/post_binding.rs
@@ -7,6 +7,7 @@
 //! harness's spec-built tables.
 
 use std::ffi::OsStr;
+use std::path::PathBuf as ImportedPathBuf;
 
 use usage_argv::Error;
 use usage_derive::{Args, Cli, Subcommands};
@@ -1121,8 +1122,245 @@ fn an_orphan_ancestor_alias_keeps_its_exclusivity_past_a_child_redeclaration() {
     );
 
     let a = argv(["run", "--clean", "--verbose"]);
-    OrphanAliasExclusive::parse_from(&a)
+    let parsed = OrphanAliasExclusive::parse_from(&a)
         .expect("the child's spelling drops the exclusivity the child did not restate");
+    assert!(
+        parsed.clean,
+        "the mirrored ancestor value remains observable"
+    );
+    let Some(RedeclaredCleanCommands::Run(run)) = parsed.command else {
+        panic!("expected run");
+    };
+    assert!(run.clean && run.verbose);
+}
+
+#[allow(dead_code)]
+#[derive(Subcommands)]
+enum RedeclaredPolicyCommands {
+    Run(RedeclaredClean),
+}
+
+#[allow(dead_code)]
+#[derive(Cli)]
+#[usage(bin = "redeclared-conflict")]
+struct RedeclaredConflict {
+    #[usage(long, global, conflicts = "--parent-only")]
+    clean: bool,
+    #[usage(long)]
+    parent_only: bool,
+    #[usage(subcommand)]
+    command: Option<RedeclaredPolicyCommands>,
+}
+
+#[allow(dead_code)]
+#[derive(Cli)]
+#[usage(bin = "redeclared-requires")]
+struct RedeclaredRequires {
+    #[usage(long, global, requires = "--parent-only")]
+    clean: bool,
+    #[usage(long)]
+    parent_only: bool,
+    #[usage(subcommand)]
+    command: Option<RedeclaredPolicyCommands>,
+}
+
+#[allow(dead_code)]
+#[derive(Cli)]
+#[usage(bin = "redeclared-requirement-target")]
+struct RedeclaredRequirementTarget {
+    #[usage(long, global)]
+    clean: bool,
+    #[usage(long, requires = "--clean")]
+    sign: bool,
+    #[usage(long, requires_if("strict", "--clean"))]
+    mode: Option<String>,
+    #[usage(subcommand)]
+    command: Option<RedeclaredPolicyCommands>,
+}
+
+#[allow(dead_code)]
+#[derive(Cli)]
+#[usage(bin = "redeclared-group", group("source"))]
+struct RedeclaredGroup {
+    #[usage(long, global, group = "source")]
+    clean: bool,
+    #[usage(long, group = "source")]
+    parent_only: bool,
+    #[usage(subcommand)]
+    command: Option<RedeclaredPolicyCommands>,
+}
+
+#[test]
+fn a_child_redeclaration_does_not_invoke_ancestor_relationship_policy() {
+    let a = argv(["--parent-only", "run", "--clean"]);
+    RedeclaredConflict::parse_from(&a)
+        .expect("the child spelling does not invoke the ancestor conflict");
+
+    let a = argv(["run", "--clean"]);
+    RedeclaredRequires::parse_from(&a)
+        .expect("the child spelling does not invoke the ancestor requirement");
+
+    let a = argv(["--parent-only", "run", "--clean"]);
+    RedeclaredGroup::parse_from(&a)
+        .expect("the child spelling is not an occurrence in the ancestor group");
+}
+
+#[test]
+fn a_mirrored_global_can_satisfy_an_ancestor_requirement() {
+    let a = argv(["--sign", "run", "--clean"]);
+    let parsed = RedeclaredRequirementTarget::parse_from(&a)
+        .expect("the mirrored clean value satisfies sign's requirement");
+    assert!(parsed.clean && parsed.sign);
+
+    let a = argv(["--mode", "strict", "run", "--clean"]);
+    let parsed = RedeclaredRequirementTarget::parse_from(&a)
+        .expect("the mirrored clean value satisfies mode's conditional requirement");
+    assert!(parsed.clean);
+    assert_eq!(parsed.mode.as_deref(), Some("strict"));
+
+    let a = argv(["--sign", "run"]);
+    assert!(matches!(
+        RedeclaredRequirementTarget::parse_from(&a),
+        Err(Error::MissingRequired { name: "clean" })
+    ));
+}
+
+#[allow(dead_code)]
+#[derive(Args)]
+struct LooserRedeclaredValues {
+    #[usage(long = "item", variadic, var_min = 1, var_max = 3)]
+    item: Vec<String>,
+}
+
+#[allow(dead_code)]
+#[derive(Subcommands)]
+enum LooserRedeclaredValueCommands {
+    Run(LooserRedeclaredValues),
+}
+
+#[allow(dead_code)]
+#[derive(Cli)]
+#[usage(bin = "redeclared-cardinality")]
+struct RedeclaredCardinality {
+    #[usage(long, global, variadic, var_min = 2, var_max = 3)]
+    item: Vec<String>,
+    #[usage(subcommand)]
+    command: Option<LooserRedeclaredValueCommands>,
+}
+
+#[test]
+fn an_incompatible_child_cardinality_is_not_mirrored_into_the_ancestor() {
+    let a = argv(["run", "--item", "one"]);
+    let parsed = RedeclaredCardinality::parse_from(&a)
+        .expect("the child accepts one value without invoking the ancestor bound");
+    assert!(parsed.item.is_empty());
+    let Some(LooserRedeclaredValueCommands::Run(run)) = parsed.command else {
+        panic!("expected run");
+    };
+    assert_eq!(run.item, ["one"]);
+
+    let a = argv(["--item", "one"]);
+    assert!(matches!(
+        RedeclaredCardinality::parse_from(&a),
+        Err(Error::VarTooFew { name: "item", .. })
+    ));
+}
+
+#[allow(dead_code)]
+#[derive(Args)]
+struct RedeclaredBooleanValue {
+    #[usage(long = "mode")]
+    mode: String,
+}
+
+#[allow(dead_code)]
+#[derive(Subcommands)]
+enum RedeclaredBooleanValueCommands {
+    Run(RedeclaredBooleanValue),
+}
+
+#[allow(dead_code)]
+#[derive(Cli)]
+#[usage(bin = "redeclared-bool-value")]
+struct RedeclaredBooleanValueRoot {
+    #[usage(long, global, bool_value)]
+    mode: bool,
+    #[usage(subcommand)]
+    command: RedeclaredBooleanValueCommands,
+}
+
+#[test]
+fn an_incompatible_child_value_is_not_mirrored_into_a_boolean_global() {
+    let a = argv(["run", "--mode", "fast"]);
+    let parsed = RedeclaredBooleanValueRoot::parse_from(&a)
+        .expect("the child value should not panic while mirroring globals");
+    assert!(!parsed.mode);
+    let RedeclaredBooleanValueCommands::Run(run) = parsed.command;
+    assert_eq!(run.mode, "fast");
+}
+
+#[allow(dead_code)]
+#[derive(Args)]
+struct AliasedRedeclaredPath {
+    #[usage(long)]
+    output: Option<ImportedPathBuf>,
+}
+
+#[allow(dead_code)]
+#[derive(Subcommands)]
+enum AliasedRedeclaredPathCommands {
+    Run(AliasedRedeclaredPath),
+}
+
+#[allow(dead_code)]
+#[derive(Cli)]
+#[usage(bin = "redeclared-path")]
+struct AliasedRedeclaredPathRoot {
+    #[usage(long, global)]
+    output: Option<std::path::PathBuf>,
+    #[usage(subcommand)]
+    command: AliasedRedeclaredPathCommands,
+}
+
+#[test]
+fn equivalent_type_spellings_share_redeclared_global_values() {
+    let a = argv(["run", "--output", "artifact"]);
+    let parsed = AliasedRedeclaredPathRoot::parse_from(&a).unwrap();
+    assert_eq!(parsed.output, Some(std::path::PathBuf::from("artifact")));
+    let AliasedRedeclaredPathCommands::Run(run) = parsed.command;
+    assert_eq!(run.output, Some(ImportedPathBuf::from("artifact")));
+}
+
+#[allow(dead_code)]
+#[derive(Args)]
+struct DifferentlyValidatedMode {
+    #[usage(long, validate = "value == 'bad'")]
+    mode: Option<String>,
+}
+
+#[allow(dead_code)]
+#[derive(Subcommands)]
+enum DifferentlyValidatedModeCommands {
+    Run(DifferentlyValidatedMode),
+}
+
+#[allow(dead_code)]
+#[derive(Cli)]
+#[usage(bin = "validated-redeclaration")]
+struct DifferentlyValidatedModeRoot {
+    #[usage(long, global, default = "good", validate = "value != 'bad'")]
+    mode: Option<String>,
+    #[usage(subcommand)]
+    command: DifferentlyValidatedModeCommands,
+}
+
+#[test]
+fn differently_validated_redeclarations_do_not_overwrite_ancestor_fallbacks() {
+    let a = argv(["run", "--mode", "bad"]);
+    let parsed = DifferentlyValidatedModeRoot::parse_from(&a).unwrap();
+    assert_eq!(parsed.mode.as_deref(), Some("good"));
+    let DifferentlyValidatedModeCommands::Run(run) = parsed.command;
+    assert_eq!(run.mode.as_deref(), Some("bad"));
 }
 
 #[allow(dead_code)]

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -1187,8 +1187,21 @@ fn completion_fns(cli: &Cli) -> (TokenStream, TokenStream) {
 
 fn flag_table(i: usize, field: &Field) -> TokenStream {
     let name = format_ident!("FLAG_{i}");
+    let binding_type_name = format_ident!("FLAG_{i}_BINDING_TYPE");
     let key = key_ident("FLAG", Some(i));
     let field_name = &field.name;
+    let binding_key = binding_hash(field);
+    let (binding_type_fn, binding_type) = match field.value_ty.as_ref() {
+        Some(ty) => (
+            quote! {
+                fn #binding_type_name() -> &'static str {
+                    ::core::any::type_name::<#ty>()
+                }
+            },
+            quote!(::core::option::Option::Some(usage_argv::BindingType(#binding_type_name))),
+        ),
+        None => (quote!(), quote!(::core::option::Option::None)),
+    };
     let Kind::Flag {
         longs,
         hidden_longs: _,
@@ -1244,8 +1257,11 @@ fn flag_table(i: usize, field: &Field) -> TokenStream {
         crate::model::ArgAction::Version => quote!(usage_argv::ArgAction::Version),
     };
     quote! {
+        #binding_type_fn
         pub static #name: usage_argv::Flag = usage_argv::Flag {
             key: #key,
+            binding_key: #binding_key,
+            binding_type: #binding_type,
             name: #field_name,
             longs: &[#(#longs),*],
             shorts: &[#(#shorts),*],
@@ -1264,6 +1280,107 @@ fn flag_table(i: usize, field: &Field) -> TokenStream {
             global: #global,
             action: #action,
         };
+    }
+}
+
+/// Stable identity of the typed contract that receives a flag event.
+///
+/// A child redeclaration may share an argument name while changing its shape, Rust type,
+/// choices, or validator. Such an event belongs only to the child; mirroring it into the
+/// ancestor would either overwrite a valid fallback or fail while building the ancestor.
+fn binding_hash(field: &Field) -> u64 {
+    let shape = match field.shape {
+        Shape::Bool => "bool",
+        Shape::Count => "count",
+        Shape::Optional => "optional",
+        Shape::Required => "required",
+        Shape::Many => "many",
+    };
+    let mut hash = 0xcbf2_9ce4_8422_2325u64;
+    hash_binding_part(&mut hash, b"shape", Some(shape.as_bytes()));
+    hash_binding_part(
+        &mut hash,
+        b"bool-value",
+        Some(&[u8::from(field.bool_value)]),
+    );
+    hash_binding_part(
+        &mut hash,
+        b"optional-value",
+        Some(&[u8::from(field.optional_value_type)]),
+    );
+    let variadic = matches!(field.kind, Kind::Flag { variadic: true, .. });
+    hash_binding_part(&mut hash, b"variadic", Some(&[u8::from(variadic)]));
+    hash_binding_part(
+        &mut hash,
+        b"repeatable",
+        Some(&[u8::from(field.repeatable)]),
+    );
+    hash_binding_usize(&mut hash, b"var-min", field.var_min);
+    hash_binding_usize(&mut hash, b"var-max", field.var_max);
+    hash_binding_usize(&mut hash, b"value-var-min", field.value_var_min);
+    hash_binding_usize(&mut hash, b"value-var-max", field.value_var_max);
+    hash_binding_part(
+        &mut hash,
+        b"value-enum",
+        Some(&[u8::from(field.value_enum)]),
+    );
+    hash_binding_part(
+        &mut hash,
+        b"open-choices",
+        Some(&[u8::from(field.allow_unknown_choices)]),
+    );
+    for choice in &field.choices {
+        hash_binding_part(&mut hash, b"choice", Some(choice.as_bytes()));
+    }
+    hash_binding_part(&mut hash, b"choices-end", None);
+    hash_binding_part(
+        &mut hash,
+        b"validate",
+        field.validate.as_deref().map(str::as_bytes),
+    );
+    hash_binding_part(
+        &mut hash,
+        b"validate-error",
+        field.validate_error.as_deref().map(str::as_bytes),
+    );
+    let delimiter = field.delimiter.map(|value| value.to_string());
+    hash_binding_part(
+        &mut hash,
+        b"delimiter",
+        delimiter.as_deref().map(str::as_bytes),
+    );
+    hash
+}
+
+fn hash_binding_usize(hash: &mut u64, label: &[u8], value: Option<usize>) {
+    let value = value.map(|value| (value as u64).to_le_bytes());
+    hash_binding_part(hash, label, value.as_ref().map(|value| value.as_slice()));
+}
+
+/// Add one labelled, length-delimited part to a binding contract hash.
+///
+/// Labels keep adjacent properties distinct, while lengths keep values such as `("a", "bc")`
+/// from becoming indistinguishable from `("ab", "c")`.
+fn hash_binding_part(hash: &mut u64, label: &[u8], value: Option<&[u8]>) {
+    for byte in (label.len() as u64)
+        .to_le_bytes()
+        .into_iter()
+        .chain(label.iter().copied())
+    {
+        *hash ^= u64::from(byte);
+        *hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    let (present, value) = match value {
+        Some(value) => (1u8, value),
+        None => (0u8, &[][..]),
+    };
+    for byte in [present]
+        .into_iter()
+        .chain((value.len() as u64).to_le_bytes())
+        .chain(value.iter().copied())
+    {
+        *hash ^= u64::from(byte);
+        *hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
     }
 }
 
@@ -1976,6 +2093,7 @@ fn flag_arm(cli: &Cli, i: usize, field: &Field) -> TokenStream {
     let key = key_ident("FLAG", Some(i));
     let ident = &field.ident;
     let given = format_ident!("__given_{}", ident);
+    let direct = mirrored_global_ident(field).map(|mirrored| quote!(partial.#mirrored = false;));
     let displaced = displacements(cli, field);
     let undisplaced = is_displaceable(cli, field).then(|| {
         let overridden = format_ident!("__overridden_{}", ident);
@@ -2020,14 +2138,49 @@ fn flag_arm(cli: &Cli, i: usize, field: &Field) -> TokenStream {
             }
         }
     });
-    let body = match field.shape {
+    let body = flag_binding_body(field);
+    let table = format_ident!("FLAG_{i}");
+    quote! {
+        // The key gets us to the right arm in one jump; the identity check makes a
+        // collision harmless rather than wrong. Two identical declarations in
+        // different modules hash alike — a macro cannot see a module path — and
+        // without this, one command's flag would fill another's field. `static` items
+        // have distinct addresses, so this is exact.
+        #key if ::core::ptr::eq(*flag, &#table) => {
+            #duplicate
+            #body
+            partial.#given = true;
+            #direct
+            // Given again after having lost: it is standing once more, which matters
+            // when the flags alternate — `--include a --all --include b`.
+            #undisplaced
+            // Whatever this flag displaces, undone here rather than after the parse:
+            // `overrides` is about which of two flags came last, and the token that
+            // just arrived is the last one so far.
+            #(#displaced)*
+            true
+        }
+    }
+}
+
+/// Assign one flag's value without changing the ledgers used by validation.
+///
+/// Ordinary occurrences wrap this with given/duplicate/relationship bookkeeping. A child
+/// redeclaration mirrored into an ancestor needs only this part: clap exposes the value through
+/// both typed fields, but the spelling still belongs to the child's declaration and must not
+/// acquire the ancestor's `exclusive`, `overrides`, or duplicate policy.
+fn flag_binding_body(field: &Field) -> TokenStream {
+    let ident = &field.ident;
+    match field.shape {
         // `negated` is what distinguishes `--color` from `--no-color`.
         Shape::Bool if field.bool_value => quote! {
             partial.#ident = match value {
                 Some(b"true") => !negated,
                 Some(b"false") => negated,
-                // The binding parser validates explicit boolean values.
-                Some(_) => unreachable!("bool_value was validated while binding"),
+                // The binding parser validates explicit boolean values for this declaration.
+                // A child may redeclare the same global identity with a non-boolean value;
+                // mirroring that event must leave this incompatible ancestor alone.
+                Some(_) => return false,
                 None => !negated,
             };
         },
@@ -2055,28 +2208,32 @@ fn flag_arm(cli: &Cli, i: usize, field: &Field) -> TokenStream {
             }
             None => quote!(partial.#ident.push(__usage_value_text(value));),
         },
-    };
-    let table = format_ident!("FLAG_{i}");
-    quote! {
-        // The key gets us to the right arm in one jump; the identity check makes a
-        // collision harmless rather than wrong. Two identical declarations in
-        // different modules hash alike — a macro cannot see a module path — and
-        // without this, one command's flag would fill another's field. `static` items
-        // have distinct addresses, so this is exact.
-        #key if ::core::ptr::eq(*flag, &#table) => {
-            #duplicate
-            #body
-            partial.#given = true;
-            // Given again after having lost: it is standing once more, which matters
-            // when the flags alternate — `--include a --all --include b`.
-            #undisplaced
-            // Whatever this flag displaces, undone here rather than after the parse:
-            // `overrides` is about which of two flags came last, and the token that
-            // just arrived is the last one so far.
-            #(#displaced)*
-            true
-        }
     }
+}
+
+/// The marker needed when a global can receive a child's redeclared value.
+fn mirrored_global_ident(field: &Field) -> Option<proc_macro2::Ident> {
+    matches!(field.kind, Kind::Flag { global: true, .. })
+        .then(|| format_ident!("__mirrored_{}", field.ident))
+}
+
+/// Whether this field directly invoked policy declared on this command.
+fn policy_given(field: &Field) -> TokenStream {
+    let given = format_ident!("__given_{}", field.ident);
+    match mirrored_global_ident(field) {
+        Some(mirrored) => quote!(partial.#given && !partial.#mirrored),
+        None => quote!(partial.#given),
+    }
+}
+
+/// Whether this field has a value supplied by argv or an environment fallback.
+///
+/// Unlike [`policy_given`], this includes a child redeclaration mirrored into a global.
+/// Such a value does not invoke policy declared on the ancestor, but it can satisfy a
+/// requirement imposed by a different, directly given field.
+fn semantic_given(field: &Field) -> TokenStream {
+    let given = format_ident!("__given_{}", field.ident);
+    quote!(partial.#given)
 }
 
 /// Whether a repeat of this flag is only a duplicate *within one command*.
@@ -2166,9 +2323,11 @@ fn displace_statement(cli: &Cli, field: &Field) -> TokenStream {
         let duplicated = format_ident!("__duplicated_{}", field.ident);
         quote!(partial.#duplicated = false;)
     });
+    let mirrored = mirrored_global_ident(field).map(|mirrored| quote!(partial.#mirrored = false;));
     quote! {
         #reset
         partial.#given = false;
+        #mirrored
         #duplicated
         // Remembered, not just cleared: without this the environment fallback
         // would refill the flag that lost and mark it given again, and a
@@ -2270,10 +2429,10 @@ fn presence_methods(cli: &Cli) -> TokenStream {
         ) {
             return None;
         }
-        let given = format_ident!("__given_{}", field.ident);
+        let given = policy_given(field);
         let name = &field.name;
         Some(quote! {
-            if partial.#given {
+            if #given {
                 return ::std::option::Option::Some(#name);
             }
         })
@@ -2306,10 +2465,10 @@ fn presence_methods(cli: &Cli) -> TokenStream {
         if !field.exclusive {
             return None;
         }
-        let given = format_ident!("__given_{}", field.ident);
+        let given = policy_given(field);
         let name = &field.name;
         Some(quote! {
-            if partial.#given {
+            if #given {
                 return ::std::option::Option::Some(#name);
             }
         })
@@ -2425,8 +2584,8 @@ fn argument_lookup_functions(cli: &Cli) -> TokenStream {
             return None;
         }
         let selectors = field_selectors(field);
-        let ident = &field.ident;
-        let given = format_ident!("__given_{}", ident);
+        let given = policy_given(field);
+        let satisfied = semantic_given(field);
         let name = &field.name;
         // Look through conditional defaults as well as unconditional ones. This lookup
         // runs after `apply_defaults` during relationship validation, so a predicate
@@ -2439,8 +2598,8 @@ fn argument_lookup_functions(cli: &Cli) -> TokenStream {
             #(#selectors)|* => return ::std::option::Option::Some(
                 usage_argv::spec::ArgumentState {
                     name: #name,
-                    given: partial.#given,
-                    satisfied: partial.#given || #defaulted || (#conditionally_defaulted),
+                    given: #given,
+                    satisfied: #satisfied || #defaulted || (#conditionally_defaulted),
                 },
             ),
         })
@@ -2470,7 +2629,7 @@ fn argument_lookup_functions(cli: &Cli) -> TokenStream {
         }
         let selectors = field_selectors(field);
         let ident = &field.ident;
-        let given = format_ident!("__given_{}", ident);
+        let given = policy_given(field);
         let matches = match field.shape {
             Shape::Optional => quote!(partial.#ident.as_deref().is_some_and(|v| v == value)),
             Shape::Required => quote!(partial.#ident.as_slice() == value),
@@ -2483,7 +2642,7 @@ fn argument_lookup_functions(cli: &Cli) -> TokenStream {
                     || (value == b"false" && partial.#ident == 0)
             ),
         };
-        Some(quote!(#(#selectors)|* => return ::std::option::Option::Some(partial.#given && #matches),))
+        Some(quote!(#(#selectors)|* => return ::std::option::Option::Some(#given && #matches),))
     });
     let match_flattened = cli.fields.iter().filter_map(|field| {
         let Kind::Flatten { ty } = &field.kind else {
@@ -2676,7 +2835,10 @@ fn partial_struct(cli: &Cli) -> TokenStream {
             let negated = format_ident!("__negated_{}", ident);
             quote!(pub #negated: bool,)
         });
-        Some(quote!(pub #ident: #ty, pub #given: bool, #overridden #duplicated #here #negated))
+        let mirrored = mirrored_global_ident(f).map(|mirrored| {
+            quote!(pub #mirrored: bool,)
+        });
+        Some(quote!(pub #ident: #ty, pub #given: bool, #overridden #duplicated #here #negated #mirrored))
     });
 
     // No derived `Default`: `start` is what produces a fresh partial, because a
@@ -3008,6 +3170,7 @@ fn partial_defaults(cli: &Cli) -> TokenStream {
             let negated = format_ident!("__negated_{}", ident);
             quote!(#negated: false,)
         });
+        let mirrored = mirrored_global_ident(f).map(|mirrored| quote!(#mirrored: false,));
         Some(quote! {
             #ident: ::std::default::Default::default(),
             #given: false,
@@ -3015,6 +3178,7 @@ fn partial_defaults(cli: &Cli) -> TokenStream {
             #duplicated
             #here
             #negated
+            #mirrored
         })
     });
     // Only the fields that declare one: `Partial`'s own initializer has already put
@@ -3410,10 +3574,10 @@ fn default_if_predicate(cli: &Cli, condition: &ConditionalDefault) -> TokenStrea
             ),
         };
     };
-    let other_given = format_ident!("__given_{}", other.ident);
+    let other_given = policy_given(other);
     let ident = &other.ident;
     match &condition.when {
-        None => quote!(partial.#other_given),
+        None => quote!(#other_given),
         Some(when) => {
             let matches = match other.shape {
                 Shape::Optional => quote!(
@@ -3434,7 +3598,7 @@ fn default_if_predicate(cli: &Cli, condition: &ConditionalDefault) -> TokenStrea
                     _ => quote!(false),
                 },
             };
-            quote!(partial.#other_given && #matches)
+            quote!(#other_given && #matches)
         }
     }
 }
@@ -3458,31 +3622,49 @@ fn apply_fn(cli: &Cli) -> TokenStream {
     // A flattened struct's flags are in this command's table, but its *keys* were minted in
     // its own expansion — so they cannot be matched here. Its `apply` recognises them, and
     // says whether it took the event.
-    let flattened = cli.fields.iter().filter_map(|f| {
+    let flattened: Vec<TokenStream> = cli
+        .fields
+        .iter()
+        .filter_map(|f| {
+            let Kind::Flatten { ty } = &f.kind else {
+                return None;
+            };
+            let ident = &f.ident;
+            let reverse_displacements = cli.fields.iter().flat_map(|field| {
+                field
+                    .overrides
+                    .iter()
+                    .filter(|selector| cli.field_for_selector(selector).is_none())
+                    .map(move |selector| {
+                        let statement = displace_statement(cli, field);
+                        quote! {
+                            if <#ty as usage_argv::spec::CommandArgs>::event_matches(
+                                event,
+                                #selector,
+                            ) {
+                                #statement
+                            }
+                        }
+                    })
+            });
+            Some(quote! {
+                if <#ty as usage_argv::spec::CommandArgs>::apply(&mut partial.#ident, event) {
+                    #(#reverse_displacements)*
+                    return true;
+                }
+            })
+        })
+        .collect();
+    let mirrored_flattened = cli.fields.iter().filter_map(|f| {
         let Kind::Flatten { ty } = &f.kind else {
             return None;
         };
         let ident = &f.ident;
-        let reverse_displacements = cli.fields.iter().flat_map(|field| {
-            field
-                .overrides
-                .iter()
-                .filter(|selector| cli.field_for_selector(selector).is_none())
-                .map(move |selector| {
-                    let statement = displace_statement(cli, field);
-                    quote! {
-                        if <#ty as usage_argv::spec::CommandArgs>::event_matches(
-                            event,
-                            #selector,
-                        ) {
-                            #statement
-                        }
-                    }
-                })
-        });
         Some(quote! {
-            if <#ty as usage_argv::spec::CommandArgs>::apply(&mut partial.#ident, event) {
-                #(#reverse_displacements)*
+            if <#ty as usage_argv::spec::CommandArgs>::apply_mirrored_global(
+                &mut partial.#ident,
+                event,
+            ) {
                 return true;
             }
         })
@@ -3498,6 +3680,30 @@ fn apply_fn(cli: &Cli) -> TokenStream {
         .filter(|f| matches!(f.kind, Kind::Arg { .. }))
         .collect();
     let flag_arms = flags.iter().enumerate().map(|(i, f)| flag_arm(cli, i, f));
+    let mirrored_flag_arms = flags.iter().enumerate().filter_map(|(i, field)| {
+        if !matches!(field.kind, Kind::Flag { global: true, .. }) {
+            return None;
+        }
+        let key = key_ident("FLAG", Some(i));
+        let table = format_ident!("FLAG_{i}");
+        let body = flag_binding_body(field);
+        let given = format_ident!("__given_{}", field.ident);
+        let mirrored = mirrored_global_ident(field).map(|mirrored| {
+            quote! {
+                if !partial.#given {
+                    partial.#mirrored = true;
+                }
+            }
+        });
+        Some(quote! {
+            #key if ::core::ptr::eq(*flag, &#table) => {
+                #body
+                #mirrored
+                partial.#given = true;
+                true
+            }
+        })
+    });
     let arg_arms = args.iter().enumerate().map(|(i, f)| arg_arm(i, f));
 
     quote! {
@@ -3548,6 +3754,24 @@ fn apply_fn(cli: &Cli) -> TokenStream {
                 Event::External { .. } => false,
             }
         }
+
+        pub fn apply_mirrored_global(
+            partial: &mut Partial,
+            event: &usage_argv::Event<'_, '_, '_>,
+        ) -> bool {
+            #(#mirrored_flattened)*
+            match event {
+                usage_argv::Event::Flag { flag, value, negated } => {
+                    let (value, negated) = (*value, *negated);
+                    let _ = (value, negated);
+                    match flag.key {
+                        #(#mirrored_flag_arms)*
+                        _ => false,
+                    }
+                }
+                _ => false,
+            }
+        }
     }
 }
 
@@ -3584,6 +3808,11 @@ fn subcommand_parts(cli: &Cli) -> Option<SubcommandParts> {
     })?;
     let ident = &field.ident;
     let optional = matches!(&field.kind, Kind::Subcommand { optional: true, .. });
+    let command_table = if cli.composable {
+        quote!(COMMAND)
+    } else {
+        quote!(ROOT)
+    };
 
     let selected = quote! {
         match partial.__usage_selected {
@@ -3684,11 +3913,42 @@ fn subcommand_parts(cli: &Cli) -> Option<SubcommandParts> {
             // Only the selected one is asked — see `Subcommands::apply`. The selection is
             // set just above, so a command word reaches the command it named on the same
             // event that selected it.
-            if <#ty as usage_argv::spec::Subcommands>::apply(
+            let __usage_routed = <#ty as usage_argv::spec::Subcommands>::apply(
                 &mut partial.__usage_sub,
                 partial.__usage_selected,
                 event,
-            ) {
+            );
+            if __usage_routed {
+                // clap propagates a global value into the ancestor even when the
+                // selected subcommand redeclares the same spelling. The parser
+                // correctly chooses the nearer flag; mirror that event onto the
+                // ancestor's global table so both typed fields observe it.
+                if let usage_argv::Event::Flag { flag, value, negated } = event {
+                    if let ::std::option::Option::Some(__usage_global) = #command_table
+                        .flags
+                        .iter()
+                        .copied()
+                        .find(|candidate| {
+                            candidate.global
+                                && candidate.key != flag.key
+                                && candidate.binding_key != 0
+                                && candidate.binding_key == flag.binding_key
+                                && candidate.binding_type == flag.binding_type
+                                // A shared alias is not a redeclaration. clap mirrors a
+                                // global when the child declares the same argument identity;
+                                // `name` is the portable canonical identity while the table
+                                // key identifies the two Rust fields separately.
+                                && candidate.name == flag.name
+                        })
+                    {
+                        let __usage_global_event = usage_argv::Event::Flag {
+                            flag: __usage_global,
+                            value: *value,
+                            negated: *negated,
+                        };
+                        apply_mirrored_global(partial, &__usage_global_event);
+                    }
+                }
                 return true;
             }
         },
@@ -3999,6 +4259,13 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
                     event: &usage_argv::Event<'_, '_, '_>,
                 ) -> bool {
                     apply(partial, event)
+                }
+
+                fn apply_mirrored_global(
+                    partial: &mut Self::Partial,
+                    event: &usage_argv::Event<'_, '_, '_>,
+                ) -> bool {
+                    apply_mirrored_global(partial, event)
                 }
 
                 fn check<'t, 'v>(
@@ -5138,8 +5405,7 @@ fn post_binding(cli: &Cli) -> TokenStream {
         if !field.exclusive {
             return None;
         }
-        let given = format_ident!("__given_{}", field.ident);
-        Some(quote!(partial.#given))
+        Some(policy_given(field))
     });
     let flattened_exclusive_present = cli.fields.iter().filter_map(|field| {
         let Kind::Flatten { ty } = &field.kind else {
@@ -5430,14 +5696,14 @@ fn post_binding(cli: &Cli) -> TokenStream {
                 .filter(|field| !matches!(field.kind, Kind::Flag { .. })),
         );
     let conflict_checks = conflict_fields.flat_map(move |f| {
-        let given = format_ident!("__given_{}", f.ident);
+        let given = policy_given(f);
         let name = &f.name;
         f.conflicts.iter().map(move |selector| {
             if let Some(other) = cli.field_for_selector(selector) {
-                let other_given = format_ident!("__given_{}", other.ident);
+                let other_given = policy_given(other);
                 let other_name = &other.name;
                 quote! {
-                    if partial.#given && partial.#other_given {
+                    if #given && #other_given {
                         return ::std::result::Result::Err(
                             usage_argv::Error::ConflictingFlags {
                                 name: #name,
@@ -5448,7 +5714,7 @@ fn post_binding(cli: &Cli) -> TokenStream {
                 }
             } else {
                 quote! {
-                    if partial.#given {
+                    if #given {
                         if let ::std::option::Option::Some(other) = argument_state(partial, #selector) {
                             if other.given {
                                 return ::std::result::Result::Err(
@@ -5476,11 +5742,11 @@ fn post_binding(cli: &Cli) -> TokenStream {
     //
     // A target with a default is skipped outright, since it can never be missing.
     let requirement_checks = cli.fields.iter().flat_map(move |f| {
-        let given = format_ident!("__given_{}", f.ident);
+        let given = policy_given(f);
         f.requires.iter().map(move |selector| {
             let Some(other) = cli.field_for_selector(selector) else {
                 return quote! {
-                    if partial.#given {
+                    if #given {
                         match argument_state(partial, #selector) {
                             ::std::option::Option::Some(other) if other.satisfied => {}
                             ::std::option::Option::Some(other) => {
@@ -5500,7 +5766,7 @@ fn post_binding(cli: &Cli) -> TokenStream {
             if !other.default.is_empty() {
                 return quote!();
             }
-            let other_given = format_ident!("__given_{}", other.ident);
+            let other_given = semantic_given(other);
             let other_name = &other.name;
             let missing = quote! {
                 return ::std::result::Result::Err(
@@ -5509,12 +5775,12 @@ fn post_binding(cli: &Cli) -> TokenStream {
             };
             match default_if_would_apply(cli, other) {
                 Some(pred) => quote! {
-                    if partial.#given && !partial.#other_given && !(#pred) {
+                    if #given && !(#other_given) && !(#pred) {
                         #missing
                     }
                 },
                 None => quote! {
-                    if partial.#given && !partial.#other_given {
+                    if #given && !(#other_given) {
                         #missing
                     }
                 },
@@ -5526,7 +5792,7 @@ fn post_binding(cli: &Cli) -> TokenStream {
     // without setting `__given_*`; argv and environment fallback set it. The partial
     // still holds bytes, so matching does not parse or otherwise reinterpret a value.
     let conditional_requirement_checks = cli.fields.iter().flat_map(move |f| {
-        let given = format_ident!("__given_{}", f.ident);
+        let given = policy_given(f);
         let ident = &f.ident;
         f.requires_if.iter().map(move |condition| {
             let external = cli.field_for_selector(&condition.requires).is_none();
@@ -5554,7 +5820,7 @@ fn post_binding(cli: &Cli) -> TokenStream {
                     },
                 };
                 return quote! {
-                    if partial.#given && #matches {
+                    if #given && #matches {
                         match argument_state(partial, #selector) {
                             ::std::option::Option::Some(other) if other.satisfied => {}
                             ::std::option::Option::Some(other) => {
@@ -5571,7 +5837,7 @@ fn post_binding(cli: &Cli) -> TokenStream {
             if !other.default.is_empty() {
                 return quote!();
             }
-            let other_given = format_ident!("__given_{}", other.ident);
+            let other_given = semantic_given(other);
             let other_name = &other.name;
             let value = &condition.value;
             let matches = match f.shape {
@@ -5598,7 +5864,7 @@ fn post_binding(cli: &Cli) -> TokenStream {
                 None => quote!(),
             };
             quote! {
-                if partial.#given && #matches && !partial.#other_given #unless_default_if {
+                if #given && #matches && !(#other_given) #unless_default_if {
                     return ::std::result::Result::Err(
                         usage_argv::Error::MissingRequired { name: #other_name },
                     );
@@ -5619,7 +5885,7 @@ fn post_binding(cli: &Cli) -> TokenStream {
         .iter()
         .filter(|f| f.exclusive)
         .flat_map(move |f| {
-            let given = format_ident!("__given_{}", f.ident);
+            let given = policy_given(f);
             let name = &f.name;
             cli.fields
                 .iter()
@@ -5631,10 +5897,10 @@ fn post_binding(cli: &Cli) -> TokenStream {
                     )
                 })
                 .map(move |other| {
-                    let other_given = format_ident!("__given_{}", other.ident);
+                    let other_given = policy_given(other);
                     let other_name = &other.name;
                     quote! {
-                        if partial.#given && partial.#other_given {
+                        if #given && #other_given {
                             return ::std::result::Result::Err(
                                 usage_argv::Error::ConflictingFlags {
                                     name: #other_name,
@@ -5663,9 +5929,9 @@ fn post_binding(cli: &Cli) -> TokenStream {
         })
         .rev()
         .fold(quote!(::std::option::Option::None), |rest, field| {
-            let given = format_ident!("__given_{}", field.ident);
+            let given = policy_given(field);
             let name = &field.name;
-            quote!(if partial.#given { ::std::option::Option::Some(#name) } else { #rest })
+            quote!(if #given { ::std::option::Option::Some(#name) } else { #rest })
         });
     let direct_exclusive = cli
         .fields
@@ -5673,9 +5939,9 @@ fn post_binding(cli: &Cli) -> TokenStream {
         .filter(|field| field.exclusive)
         .rev()
         .fold(quote!(::std::option::Option::None), |rest, field| {
-            let given = format_ident!("__given_{}", field.ident);
+            let given = policy_given(field);
             let name = &field.name;
-            quote!(if partial.#given { ::std::option::Option::Some(#name) } else { #rest })
+            quote!(if #given { ::std::option::Option::Some(#name) } else { #rest })
         });
     let has_flatten = cli
         .fields
@@ -5756,13 +6022,7 @@ fn post_binding(cli: &Cli) -> TokenStream {
                 .iter()
                 .filter_map(|selector| cli.field_for_selector(selector))
                 .collect();
-            let given: Vec<TokenStream> = fields
-                .iter()
-                .map(|f| {
-                    let given = format_ident!("__given_{}", f.ident);
-                    quote!(partial.#given)
-                })
-                .collect();
+            let given: Vec<TokenStream> = fields.iter().map(|f| policy_given(f)).collect();
             // A member with a default always has a value, so the group can never be
             // unsatisfied. Decided here rather than at run time, as `requires` is.
             let always_filled = fields.iter().any(|f| !f.default.is_empty());
@@ -5842,10 +6102,7 @@ fn post_binding(cli: &Cli) -> TokenStream {
         let name = &f.name;
         let selector_given = |selector: &String| {
             Some(match cli.field_for_selector(selector) {
-                Some(other) => {
-                    let other_given = format_ident!("__given_{}", other.ident);
-                    quote!(partial.#other_given)
-                }
+                Some(other) => policy_given(other),
                 None => quote!(
                     argument_state(partial, #selector).is_some_and(|state| state.given)
                 ),
@@ -6060,5 +6317,26 @@ pub fn emit_value_enum(value_enum: &ValueEnum) -> TokenStream {
                 }
             }
         };
+    }
+}
+
+#[cfg(test)]
+mod binding_hash_tests {
+    use super::hash_binding_part;
+
+    fn contract(validate: &str, validate_error: &str) -> u64 {
+        let mut hash = 0xcbf2_9ce4_8422_2325u64;
+        hash_binding_part(&mut hash, b"validate", Some(validate.as_bytes()));
+        hash_binding_part(
+            &mut hash,
+            b"validate-error",
+            Some(validate_error.as_bytes()),
+        );
+        hash
+    }
+
+    #[test]
+    fn adjacent_binding_properties_cannot_alias_by_concatenation() {
+        assert_ne!(contract("a", "bc"), contract("ab", "c"));
     }
 }

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -23,6 +23,126 @@ enum Command {
     Version,
 }
 
+#[derive(Args)]
+struct RepeatedGlobalChild {
+    #[arg(long)]
+    cd: Option<String>,
+}
+
+#[derive(Subcommands)]
+enum RepeatedGlobalCommand {
+    Run(RepeatedGlobalChild),
+}
+
+#[derive(Cli)]
+#[usage(bin = "repeated-global")]
+struct RepeatedGlobal {
+    #[arg(long, global, default_value = "/default")]
+    cd: Option<String>,
+    #[command(subcommand)]
+    command: RepeatedGlobalCommand,
+}
+
+#[test]
+fn a_redeclared_global_value_reaches_the_ancestor_and_child() {
+    let parsed = RepeatedGlobal::parse_from(&[OsStr::new("run"), OsStr::new("--cd=/tmp")])
+        .expect("the child spelling should bind at both levels like clap");
+    assert_eq!(parsed.cd.as_deref(), Some("/tmp"));
+    let RepeatedGlobalCommand::Run(run) = parsed.command;
+    assert_eq!(run.cd.as_deref(), Some("/tmp"));
+}
+
+#[derive(Args)]
+struct FlattenedGlobal {
+    #[arg(long, global)]
+    cd: Option<String>,
+}
+
+#[derive(Cli)]
+#[usage(bin = "flattened-repeated-global")]
+struct FlattenedRepeatedGlobal {
+    #[command(flatten)]
+    global: FlattenedGlobal,
+    #[command(subcommand)]
+    command: RepeatedGlobalCommand,
+}
+
+#[test]
+fn a_redeclared_global_value_reaches_a_flattened_ancestor_field() {
+    let parsed =
+        FlattenedRepeatedGlobal::parse_from(&[OsStr::new("run"), OsStr::new("--cd=/flattened")])
+            .expect("the child spelling should mirror through a flattened global group");
+    assert_eq!(parsed.global.cd.as_deref(), Some("/flattened"));
+    let RepeatedGlobalCommand::Run(run) = parsed.command;
+    assert_eq!(run.cd.as_deref(), Some("/flattened"));
+}
+
+#[derive(Args)]
+struct GlobalAliasChild {
+    #[arg(long = "work-dir", alias = "dir")]
+    work_dir: Option<String>,
+}
+
+#[derive(Subcommands)]
+enum GlobalAliasCommand {
+    Run(GlobalAliasChild),
+}
+
+#[derive(Cli)]
+#[usage(bin = "global-alias")]
+struct GlobalAliasCli {
+    #[arg(long = "directory", alias = "dir", global)]
+    directory: Option<String>,
+    #[command(subcommand)]
+    command: GlobalAliasCommand,
+}
+
+#[test]
+fn a_shared_alias_does_not_fill_an_unrelated_global() {
+    let parsed = GlobalAliasCli::parse_from(&[OsStr::new("run"), OsStr::new("--dir=/tmp")])
+        .expect("the nearer child alias should parse");
+    assert_eq!(parsed.directory, None);
+    let GlobalAliasCommand::Run(run) = parsed.command;
+    assert_eq!(run.work_dir.as_deref(), Some("/tmp"));
+}
+
+#[derive(Subcommands)]
+enum IncompatibleGlobalCommand {
+    Run {
+        #[arg(long)]
+        mode: bool,
+        #[arg(long)]
+        jobs: String,
+    },
+}
+
+#[derive(Cli)]
+#[usage(bin = "incompatible-global")]
+struct IncompatibleGlobalCli {
+    #[arg(long, global, default_value = "fast", value_parser = ["fast", "slow"])]
+    mode: String,
+    #[arg(long, global, default_value = "1")]
+    jobs: u32,
+    #[command(subcommand)]
+    command: IncompatibleGlobalCommand,
+}
+
+#[test]
+fn incompatible_child_bindings_do_not_fill_ancestor_globals() {
+    let parsed = IncompatibleGlobalCli::parse_from(&[
+        OsStr::new("run"),
+        OsStr::new("--mode"),
+        OsStr::new("--jobs"),
+        OsStr::new("many"),
+    ])
+    .expect("the child declarations own their values");
+    assert_eq!(parsed.mode, "fast");
+    assert_eq!(parsed.jobs, 1);
+    let IncompatibleGlobalCommand::Run { mode, jobs } = parsed.command;
+    assert!(mode);
+    assert_eq!(jobs, "many");
+}
+
 #[derive(Cli)]
 #[usage(
     bin = "metadata",


### PR DESCRIPTION
## Summary
- propagate a subcommand redeclaration of a global flag into the ancestor typed field
- preserve the nearer subcommand binding while matching clap global propagation
- cover attached global option values exposed by the mise conversion
- record the closed compatibility gap in PLAN.md

## Verification
- `cargo clippy -p usage-derive -p usage-rs --all-features -- -D warnings`
- `cargo test -p usage-rs --test facade`

_This PR was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This changes how derived parsers bind global flags and how relationship checks treat those values. Incorrect matching could fill the wrong ancestor field or skip conflicts/requires.
> 
> **Overview**
> When a subcommand redeclares an inherited global spelling, the nearer declaration still parses the token, and the same value is now copied into the ancestor typed field (including flattened globals), matching clap.
> 
> Mirroring is gated on a hashed binding contract plus `type_name`, so incompatible child types, cardinality, choices, or validators do not overwrite ancestor defaults. The child occurrence does **not** run ancestor `conflicts` / `exclusive` / group / duplicate policy, but a mirrored value **can** satisfy an ancestor `requires` / `requires_if`. Shared aliases alone are not treated as a redeclaration.
> 
> `CommandArgs::apply_mirrored_global` is the new hook; hand-written impls keep the default no-op. Conformance and facade tests cover attached values, flatten, aliases, and incompatible child bindings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fee7e17423a776b808b1e8678b7489a014f5a66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->