### PR TITLE
fix(parse): keep optional validation lint-clean

### DIFF
--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -2089,10 +2089,8 @@ fn validate_expression(
         ParseValue::MultiString(values) => values,
         ParseValue::Bool(_) | ParseValue::MultiBool(_) => return,
     };
+    #[cfg(feature = "validation")]
     for value in values {
-        #[cfg(not(feature = "validation"))]
-        let _ = message;
-        #[cfg(feature = "validation")]
         let reason = match usage_validation::validate(expression, value) {
             Ok(true) => continue,
             Ok(false) => message
@@ -2100,14 +2098,21 @@ fn validate_expression(
                 .to_string(),
             Err(error) => format!("validation expression failed: {error}"),
         };
-        #[cfg(not(feature = "validation"))]
-        let reason = "expression validation requires the `validation` feature".to_string();
         errors.push(UsageErr::InvalidValue {
             name: name.to_string(),
             value: value.clone(),
             reason,
         });
         break;
+    }
+    #[cfg(not(feature = "validation"))]
+    if let Some(value) = values.first() {
+        let _ = message;
+        errors.push(UsageErr::InvalidValue {
+            name: name.to_string(),
+            value: value.clone(),
+            reason: "expression validation requires the `validation` feature".to_string(),
+        });
     }
 }
 


### PR DESCRIPTION
## Summary
- separate validation-enabled iteration from the feature-disabled diagnostic path
- avoid Rust 1.97’s `never_loop` lint without changing either runtime behavior

## Validation
- `cargo test -p usage-lib --all-features`
- `cargo clippy -p usage-lib --all-features --all-targets -- -D warnings`

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small cfg-only refactor of parse diagnostics; no change to validation logic when the feature is enabled.
> 
> **Overview**
> Splits `validate_expression` so the validation-enabled loop and the feature-disabled error path are separate `cfg` blocks.
> 
> This avoids Rust 1.97’s `never_loop` lint when `validation` is off, without changing runtime behavior: missing the feature still reports `InvalidValue` for the first string value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d69fe7b1f9b27d14e57c3b6ce51f89c2159b96e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->