### PR TITLE
test(docs): preserve fleet footer spacing

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -985,7 +985,7 @@ generated from clap via `clap_usage`. Anything clap does not expose, or that an
 older clap_usage dropped, is invisible to the gate. Trying the CLIs means
 looking at the clap surface, not only at the spec.
 
-- [ ] **Refresh the fleet fixtures against this crate's `clap_usage`.** The
+- [x] **Refresh the fleet fixtures against this crate's `clap_usage`.** The
       copies in `benches/fleet/` and `benches/mise.usage.kdl` are snapshots.
       Live `mise usage` (2026.8.8) and `aube usage` (1.20.0) still emit no
       `delimiter=` and no `allow_hyphen_values`, because they were built against
@@ -1000,8 +1000,11 @@ looking at the clap surface, not only at the spec.
       The six completed typed adopters now supply current `usage-rs` fixtures and
       regenerated shadows for hk, fnox, pitchfork, aube, tak, and communique. Their
       delimiter, optional-value, relationship, and command-policy metadata is therefore
-      visible to the gate. mise remains on its clap-era fixture until its router port can
-      emit the replacement metadata.
+      visible to the gate. mise now supplies its typed `usage-rs` metadata from
+      jdx/mise#12221; the refreshed fixture and every generated shadow are checked in.
+      That refresh exposed shadow-generator gaps for required switches and command
+      groups, which are fixed with the fixture rather than
+      being mistaken for adopter losses.
 - [x] **Docs and manpages on a fleet spec.** communique's checked-in spec and
       the KDL its shadow emits render the same markdown (index and every
       command) and the same manpage. usage-cli's own
@@ -1082,11 +1085,11 @@ a prerequisite for trying a CLI.
       The gaps found are recorded in the general launch gate above; closing the
       merge-blocking rows is required before publishing 6.x and converting these
       experiments into release-dependency PRs.
-- [ ] **mise** — the largest and least forgiving adopter. Likely a router first, then
-      commands lowered a few at a time, with mise's e2e argv corpus replayed against both
-      parsers. Adoption is measured by what it lets mise delete, listed below.
-      Do not start this until the clap-only rows in **Trying the fleet** that
-      mise actually uses are either implemented or accepted as lost.
+- [x] **mise** — jdx/mise#12221 replaces the main command tree and optional vfox CLI
+      with `usage-rs`, removes the direct clap dependencies, emits the canonical spec
+      from the same typed metadata, and uses first-party help and completions. Its CLI
+      test corpus exposed count actions, one-member implicit groups, and redeclared
+      global propagation gaps; those fixes live in their owning usage stack PRs.
 - [x] **pitchfork** — jdx/Pitchfork#754 removes clap, parses its typed command tree
       with `usage-rs`, uses the built-in completion protocol, and passes its Rust and
       bats suites against the stacked usage revision. Its refreshed spec is part of the

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -1525,13 +1525,25 @@ pub fn long_help(spec: &Spec<'_>, path: &[&str], chain: &[&CommandMeta<'_>]) -> 
 
     // mise puts an Examples section here on 115 commands, which is why a page without it is
     // missing the part a reader came for.
-    if let Some(after) = meta
+    let after = meta
         .after_long_help
         .or(meta.after_help)
         .or(spec.root.after_long_help)
-        .or(spec.root.after_help)
-    {
+        .or(spec.root.after_help);
+    if let Some(after) = after {
         let _ = writeln!(out, "\n{after}");
+    }
+    if spec.author.is_some() || spec.license.is_some() {
+        // The reference template starts the footer in a new paragraph without trimming the
+        // configured trailing help. A newline deliberately present in `after_help` therefore
+        // remains an additional blank line before package metadata.
+        out.push('\n');
+        if let Some(author) = spec.author {
+            let _ = writeln!(out, "Author: {author}");
+        }
+        if let Some(license) = spec.license {
+            let _ = writeln!(out, "License: {license}");
+        }
     }
 
     let trimmed = out.trim();
@@ -2408,9 +2420,9 @@ fn recursive_help<'a>(
 mod style_tests {
     use super::{
         commands_section, flag_notes, flag_usage, flat_commands_short, inline_environment_notes,
-        styled_flag_usage, styled_help, Style,
+        long_help, styled_flag_usage, styled_help, Style,
     };
-    use crate::spec::{CommandMeta, FlagMeta};
+    use crate::spec::{CommandMeta, FlagMeta, Spec};
     use crate::{Command, Flag};
 
     #[test]
@@ -2566,6 +2578,32 @@ mod style_tests {
 
         assert!(page.contains("  run  run it\n  help"));
         assert!(!page.contains("  run  run it\n\n  help"));
+    }
+
+    #[test]
+    fn long_help_preserves_configured_spacing_before_package_metadata() {
+        let command = Command {
+            name: "ex",
+            ..Command::EMPTY
+        };
+        let root = CommandMeta {
+            cmd: &command,
+            after_help: Some("More help.\n"),
+            ..CommandMeta::EMPTY
+        };
+        let spec = Spec {
+            name: "ex",
+            author: Some("Example Author"),
+            root: &root,
+            ..Spec::EMPTY
+        };
+
+        let page = long_help(&spec, &["ex"], &[&root]);
+
+        assert!(
+            page.contains("More help.\n\n\nAuthor: Example Author\n"),
+            "{page}"
+        );
     }
 
     #[test]

--- a/benches/gate/tests/differential.proptest-regressions
+++ b/benches/gate/tests/differential.proptest-regressions
@@ -7,3 +7,4 @@
 cc 4f2a955fec704b45e4e8cd42199265880d9104833e06c67509d15d5cbd7cef6f # shrinks to seed = 2079810414485142052, len = 1, junk = [6]
 cc d57802bb04f7281cbcee867232581bcfaad4a47afd46f7c477f8032a85569c04 # shrinks to seed = 6583806858433503933, head = [10], rooted = false, len = 0, junk = []
 cc 77bf992b8442610d6fa6ccc3717f9d75cb900c9f026fda95583fad74b7d1fc22 # shrinks to seed = 14848261797843722629, head = [], rooted = false, len = 2, junk = [4, 8]
+cc c478cc8d4703f5fdc81e93ee812d0e1b5d762d83cc32fc4cd64e3b4332f97423 # shrinks to seed = 9708144620049405411, head = [4], rooted = true, len = 1, junk = [2]

--- a/benches/gate/tests/differential.rs
+++ b/benches/gate/tests/differential.rs
@@ -488,6 +488,14 @@ fn positional_routing_can_still_reach_a_genuine_invalid_choice() {
 }
 
 #[test]
+fn clap_shadow_keeps_flag_requirements_from_the_shared_spec() {
+    let outcome = run(&SPEC, &["set".into(), "--stdin".into()]);
+    assert_eq!(outcome.argv, Verdict::MissingRequired);
+    assert!(!outcome.lib);
+    assert_eq!(outcome.clap, Verdict::MissingRequired);
+}
+
+#[test]
 fn a_bare_word_diverges_because_of_the_mount_not_the_parser() {
     // The first reading of this was "usage-argv refuses a lone `-` that clap accepts", filed as
     // a parser bug. It is not: `mise build` behaves identically, and the trace shows why —
@@ -496,8 +504,9 @@ fn a_bare_word_diverges_because_of_the_mount_not_the_parser() {
     // Pinned so the explanation stays attached to the evidence. If usage-argv ever accepts
     // these, it is because the mount got resolved, and this test should say so instead.
     let spec = spec();
-    // `x` is accepted by all three because `x` really is a command — mise's alias for `exec`.
-    // That is what separates this from the `-` case: every word naming *nothing* fails here.
+    // `x` really is a command — mise's alias for `exec` — but that command requires either its
+    // trailing command positional or `--command`. Both typed fixtures carry that positional
+    // relationship.
     for word in ["build", "foo", "node@20"] {
         let o = run(&spec, &[word.to_string()]);
         // The *reason* matters as much as the refusal: what the missing mount costs is a
@@ -520,8 +529,8 @@ fn a_bare_word_diverges_because_of_the_mount_not_the_parser() {
     let o = run(&spec, &["x".to_string()]);
     assert_eq!(
         o.accepted(),
-        (true, true, true),
-        "`x` names a command, so nothing diverges"
+        (false, false, false),
+        "`x` reaches exec, whose positional relationship every typed fixture carries"
     );
 }
 

--- a/benches/gate/tests/parse.rs
+++ b/benches/gate/tests/parse.rs
@@ -26,9 +26,9 @@ fn a_tool_is_installed_globally() {
 
 #[test]
 fn a_task_runs_with_arguments_after_a_separator() {
-    // The shape that made the derive's validation wrong: `[ARGS]…` before the `--` and
-    // `[-- ARGS_LAST]…` after it. `tasks run` is where mise's spec declares it; the
-    // top-level `run` carries no positionals of its own — see the note in the PR.
+    // `TASK` now declares `double_dash=automatic`: once the task name binds, every later token
+    // is task argv. That includes flag-looking words and a literal `--`; none return to mise's
+    // own flags or reach the older `ARGS_LAST` compatibility field.
     let a = argv([
         "tasks",
         "run",
@@ -45,12 +45,12 @@ fn a_task_runs_with_arguments_after_a_separator() {
     let Some(TasksCommands::Run(run)) = tasks.command else {
         panic!("expected `tasks run`")
     };
-    // The words, not just that a command was selected: a regression that merged the two
-    // sides of the `--` or dropped either would otherwise leave this green.
+    // The words, not just that a command was selected: dropping a flag-looking word or the
+    // separator itself would otherwise leave this green.
     assert_eq!(run.task.as_deref(), Some("build"));
-    assert_eq!(run.args, ["extra"]);
-    assert_eq!(run.args_last, ["--verbose"]);
-    assert!(run.dry_run);
+    assert_eq!(run.args, ["extra", "--dry-run", "--", "--verbose"]);
+    assert!(run.args_last.is_empty());
+    assert!(!run.dry_run);
 }
 
 #[test]

--- a/benches/go/cobra/main.go
+++ b/benches/go/cobra/main.go
@@ -28,7 +28,7 @@ func build() *cobra.Command {
 	root.PersistentFlags().StringArrayP("env", "E", nil, "Set the environment for loading `mise.<ENV>.toml`")
 	root.Flags().BoolP("force", "f", false, "Force the operation")
 	_ = root.Flags().MarkHidden("force")
-	root.PersistentFlags().StringP("jobs", "j", "", "How many jobs to run in parallel [default: 8]")
+	root.PersistentFlags().StringP("jobs", "j", "", "How many jobs to run in parallel; values below 1 are treated as 1 [default: 8]")
 	root.Flags().BoolP("dry-run", "n", false, "Dry run, don't actually do anything")
 	_ = root.Flags().MarkHidden("dry-run")
 	root.PersistentFlags().StringArrayP("profile", "P", nil, "Set the profile (environment)")
@@ -154,7 +154,7 @@ func build() *cobra.Command {
 	cmd27.Flags().StringP("source", "s", "", "Source path to use if the target is not yet managed")
 	cmd27.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt when adding an unmanaged target")
 	cmd24.AddCommand(cmd27)
-	cmd28 := &cobra.Command{Use: "status", Short: "Show the status of dotfiles from `[dotfiles]`", Aliases: []string{"ls"}, Run: func(*cobra.Command, []string) {}}
+	cmd28 := &cobra.Command{Use: "status", Short: "Show the status of dotfiles from `[dotfiles]`", Run: func(*cobra.Command, []string) {}}
 	cmd28.Flags().BoolP("json", "J", false, "Output in JSON format")
 	cmd28.Flags().Bool("missing", false, "Exit with code 1 if any configured dotfiles are not in their desired\nstate (missing, source missing, differs)")
 	cmd24.AddCommand(cmd28)
@@ -272,13 +272,13 @@ func build() *cobra.Command {
 	cmd61 := &cobra.Command{Use: "import", Short: "Import installed system packages into `[bootstrap.packages]`", Long: "Import installed system packages into `[bootstrap.packages]`\n\nCurrently supports Homebrew formulae only. By default, imports linked\nformulae whose active keg receipt says they were installed on request.\nPass `--all` to import every linked formula, including dependencies.", Run: func(*cobra.Command, []string) {}}
 	cmd61.Flags().StringP("env", "e", "", "Write to the config file for this environment (mise.<ENV>.toml)")
 	cmd61.Flags().BoolP("global", "g", false, "Write to the global config (~/.config/mise/config.toml)")
-	cmd61.Flags().StringP("manager", "m", "brew", "Only import packages for this manager. Currently only `brew` is supported")
+	cmd61.Flags().StringP("manager", "m", "brew", "Only import packages for this manager. Currently only `brew` is supported.")
 	cmd61.Flags().Bool("all", false, "Import every linked formula, including dependencies")
 	cmd61.Flags().BoolP("dry-run", "n", false, "Print the config change without writing config")
 	cmd61.Flags().StringP("path", "p", "", "Write to this config file or directory")
 	cmd56.AddCommand(cmd61)
-	cmd62 := &cobra.Command{Use: "prune", Short: "Prune installed system packages no longer declared in `[bootstrap.packages]`", Long: "Prune installed system packages no longer declared in `[bootstrap.packages]`\n\nCurrently supports Homebrew formulae only. Pruning removes linked formulae\nthat are not needed by the current config or by trusted, loadable tracked\nconfigs.", Run: func(*cobra.Command, []string) {}}
-	cmd62.Flags().StringP("manager", "m", "brew", "Only prune packages for this manager. Currently only `brew` is supported")
+	cmd62 := &cobra.Command{Use: "prune", Short: "Prune installed system packages no longer declared in `[bootstrap.packages]`", Long: "Prune installed system packages no longer declared in `[bootstrap.packages]`\n\nSupports Homebrew formulae and conservatively removable, mise-owned casks.\nPruning keeps packages needed by the current config or by trusted, loadable\ntracked configs.", Run: func(*cobra.Command, []string) {}}
+	cmd62.Flags().StringP("manager", "m", "brew", "Only prune packages for this manager")
 	cmd62.Flags().BoolP("dry-run", "n", false, "Print what would be removed without deleting anything")
 	cmd62.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt")
 	cmd56.AddCommand(cmd62)
@@ -286,7 +286,7 @@ func build() *cobra.Command {
 	cmd63.Flags().BoolP("json", "J", false, "Output in JSON format")
 	cmd63.Flags().Bool("missing", false, "Exit with code 1 if any configured packages are not in their desired state")
 	cmd56.AddCommand(cmd63)
-	cmd64 := &cobra.Command{Use: "upgrade", Short: "Upgrade installed bootstrap packages from `[bootstrap.packages]`", Long: "Upgrade installed bootstrap packages from `[bootstrap.packages]`\n\nRefreshes package manager metadata and upgrades the configured packages\nthat are already installed: apk/apt/dnf/pacman upgrade to the newest available\nversion (apk, apt, and dnf honor a version pinned in config), brew pours the\nformula's current bottle and replaces the old keg, brew-cask installs\nthe current cask artifact, flatpak updates applications and runtimes, and mas upgrades App Store apps. Packages that\nare not installed yet are skipped — use `mise bootstrap packages apply`\nfor those.\n\nPackages can also be given explicitly in `manager:package` form.", Aliases: []string{"up"}, Run: func(*cobra.Command, []string) {}}
+	cmd64 := &cobra.Command{Use: "upgrade", Short: "Upgrade installed bootstrap packages from `[bootstrap.packages]`", Long: "Upgrade installed bootstrap packages from `[bootstrap.packages]`\n\nRefreshes package manager metadata and upgrades the configured packages\nthat are already installed: apk/apt/dnf/pacman upgrade to the newest available\nversion (apk, apt, and dnf honor a version pinned in config), brew pours the\nformula's current bottle and replaces the old keg, brew-cask installs\nthe current cask artifact, flatpak and flatpak-user update applications and runtimes, and mas upgrades App Store apps. Packages that\nare not installed yet are skipped — use `mise bootstrap packages apply`\nfor those.\n\nPackages can also be given explicitly in `manager:package` form.", Aliases: []string{"up"}, Run: func(*cobra.Command, []string) {}}
 	cmd64.Flags().StringP("manager", "m", "", "Only upgrade packages for this built-in or plugin manager")
 	cmd64.Flags().BoolP("dry-run", "n", false, "Print the commands that would run without running them")
 	cmd64.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt")
@@ -316,6 +316,8 @@ func build() *cobra.Command {
 	cmd70.Flags().Bool("all", false, "Select every configured inventory host")
 	cmd70.Flags().String("bootstrap-command", "", "Explicit remote shell command that installs mise and places it on PATH")
 	cmd70.Flags().String("connect-timeout", "10", "SSH connection timeout in seconds")
+	cmd70.Flags().StringArray("copy-link", nil, "Dereference one source-relative symbolic link; repeat for multiple links")
+	cmd70.Flags().Bool("copy-links", false, "Dereference every symbolic link in the source archive")
 	cmd70.Flags().StringArray("exclude", nil, "Additional archive pattern to exclude; repeat for multiple patterns")
 	cmd70.Flags().Bool("fail-fast", false, "Stop after the first failed target")
 	cmd70.Flags().Bool("force-dotfiles", false, "Allow remote dotfile conflicts to be replaced")
@@ -327,6 +329,7 @@ func build() *cobra.Command {
 	cmd70.Flags().StringArray("only", nil, "Run only one or more remote bootstrap parts")
 	cmd70.Flags().String("port", "", "SSH port override")
 	cmd70.Flags().Bool("prompt-secrets", false, "Prompt securely for missing secret inputs on the remote host")
+	cmd70.Flags().StringArray("remote-env", nil, "Config environments to load on the remote host; repeat or delimit with commas (for example, ci,dotfiles)")
 	cmd70.Flags().String("remote-mise", "", "Existing mise executable name or path; relative paths use the staged project")
 	cmd70.Flags().StringArray("skip", nil, "Skip one or more remote bootstrap parts")
 	cmd70.Flags().String("source", "", "Local directory archived and sent to each target")
@@ -499,7 +502,7 @@ func build() *cobra.Command {
 	root.AddCommand(cmd113)
 	cmd114 := &cobra.Command{Use: "exec", Short: "Execute a command with tool(s) set", Long: "Execute a command with tool(s) set\n\nuse this to avoid modifying the shell session or running ad-hoc commands with mise tools set.\n\nTools will be loaded from mise.toml, though they can be overridden with <RUNTIME> args\nNote that only the plugin specified will be overridden, so if a `mise.toml` file\nincludes \"node 20\" but you run `mise exec python@3.11`; it will still load node@20.\n\nThe \"--\" separates runtimes from the commands to pass along to the subprocess.", Aliases: []string{"x"}, Run: func(*cobra.Command, []string) {}}
 	cmd114.Flags().StringP("command", "c", "", "Command string to execute")
-	cmd114.Flags().StringP("jobs", "j", "", "Number of jobs to run in parallel\n[default: 4]")
+	cmd114.Flags().StringP("jobs", "j", "", "Number of jobs to run in parallel\nValues below 1 are treated as 1\n[default: 4]")
 	cmd114.Flags().StringArray("allow-env", nil, "Allow specific env var through (implies --deny-env for everything else)\nSupports wildcards, e.g. --allow-env='MYAPP_*'")
 	cmd114.Flags().StringArray("allow-net", nil, "Allow network to specific host (implies --deny-net for everything else)\nmacOS only in v1; on Linux falls back to allowing all network")
 	cmd114.Flags().StringArray("allow-read", nil, "Allow reads from specific path (implies --deny-read for everything else)")
@@ -524,6 +527,7 @@ func build() *cobra.Command {
 	cmd117.Flags().StringP("version", "V", "", "Specify mise version to fetch")
 	cmd117.Flags().StringP("write", "w", "", "instead of outputting the script to stdout, write to a file and make it executable")
 	cmd117.Flags().String("localized-dir", ".mise", "Directory to put localized data into")
+	cmd117.Flags().Bool("windows", false, "Also write a Windows launcher, `<WRITE>.cmd`")
 	cmd116.AddCommand(cmd117)
 	cmd118 := &cobra.Command{Use: "config", Short: "Generate a mise.toml file", Run: func(*cobra.Command, []string) {}}
 	cmd118.Flags().BoolP("global", "g", false, "Generate the global config file (~/.config/mise/config.toml)")
@@ -554,7 +558,7 @@ func build() *cobra.Command {
 	cmd122.Flags().StringP("root", "r", "", "root directory to search for tasks")
 	cmd122.Flags().StringP("style", "s", "simple", "")
 	cmd116.AddCommand(cmd122)
-	cmd123 := &cobra.Command{Use: "task-stubs", Short: "Generates shims to run mise tasks", Long: "Generates shims to run mise tasks\n\nBy default, this will build shims like ./bin/<task>. These can be paired with `mise generate bootstrap`\nso contributors to a project can execute mise tasks without installing mise into their system.", Run: func(*cobra.Command, []string) {}}
+	cmd123 := &cobra.Command{Use: "task-stubs", Short: "Generates shims to run mise tasks", Long: "Generates shims to run mise tasks\n\nBy default, this will build shims like ./bin/<task>. These can be paired with `mise generate bootstrap`\nso contributors to a project can execute mise tasks without installing mise into their system.\nWhen a parent and nested task both exist, the parent stub is written to `<parent>/_default`.", Run: func(*cobra.Command, []string) {}}
 	cmd123.Flags().StringP("dir", "d", "bin", "Directory to create task stubs inside of")
 	cmd123.Flags().StringP("mise-bin", "m", "mise", "Path to a mise bin to use when running the task stub.")
 	cmd116.AddCommand(cmd123)
@@ -562,6 +566,7 @@ func build() *cobra.Command {
 	cmd124.Flags().StringP("bin", "b", "", "Binary path within the extracted archive")
 	cmd124.Flags().Bool("bootstrap", false, "Wrap stub in a bootstrap script that installs mise if not already present")
 	cmd124.Flags().String("bootstrap-version", "", "Specify mise version for the bootstrap script")
+	cmd124.Flags().String("checksum-algorithm", "blake3", "Checksum algorithm to use when downloading artifacts")
 	cmd124.Flags().Bool("fetch", false, "Fetch checksums and sizes for an existing tool stub file")
 	cmd124.Flags().String("http", "http", "HTTP backend type to use")
 	cmd124.Flags().Bool("lock", false, "Resolve and embed lockfile data (exact version + platform URLs/checksums) into an existing stub file for reproducible installs without runtime API calls")
@@ -608,11 +613,12 @@ func build() *cobra.Command {
 	cmd131.Flags().StringP("tool-versions", "t", "", "Path to a .tool-versions file to import tools from")
 	root.AddCommand(cmd131)
 	cmd132 := &cobra.Command{Use: "install", Short: "Install a tool version", Long: "Install a tool version\n\nInstalls a tool version to `~/.local/share/mise/installs/<TOOL>/<VERSION>`\nInstalling alone will not activate the tools so they won't be in PATH.\nTo install and/or activate in one command, use `mise use` which will create a `mise.toml` file\nin the current directory to activate this tool when inside the directory.\nAlternatively, run `mise exec <TOOL>@<VERSION> -- <COMMAND>` to execute a tool without creating config files.\n\nTools will be installed in parallel. To disable, set `--jobs=1` or `MISE_JOBS=1`", Aliases: []string{"i"}, Run: func(*cobra.Command, []string) {}}
-	cmd132.Flags().BoolP("force", "f", false, "Force reinstall even if already installed")
-	cmd132.Flags().StringP("jobs", "j", "", "Number of jobs to run in parallel\n[default: 4]")
+	cmd132.Flags().BoolP("force", "f", false, "Force reinstall even if already installed\nWith no tools specified, reinstall all configured tools")
+	cmd132.Flags().StringP("jobs", "j", "", "Number of jobs to run in parallel\nValues below 1 are treated as 1\n[default: 4]")
 	cmd132.Flags().BoolP("dry-run", "n", false, "Show what would be installed without actually installing")
 	cmd132.Flags().CountP("verbose", "v", "Show installation output")
 	cmd132.Flags().Bool("dry-run-code", false, "Like --dry-run but exits with code 1 if there are tools to install")
+	cmd132.Flags().Bool("include-task-tools", false, "Also install tools required by tasks in the current scope")
 	cmd132.Flags().String("minimum-release-age", "", "Only install versions released before this date or older than this duration")
 	cmd132.Flags().Bool("monorepo", false, "Install tools from every [monorepo].config_roots config root")
 	cmd132.Flags().Bool("raw", false, "Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1")
@@ -635,9 +641,9 @@ func build() *cobra.Command {
 	cmd136.Flags().Bool("pin", false, "Save exact version to `.tool-versions`\ne.g.: `mise local --pin node@20` will save `node 20.0.0` to .tool-versions")
 	cmd136.Flags().StringArray("remove", nil, "Remove the tool(s) from .tool-versions")
 	root.AddCommand(cmd136)
-	cmd137 := &cobra.Command{Use: "lock", Short: "Update lockfile checksums and URLs for all specified platforms", Long: "Update lockfile checksums and URLs for all specified platforms\n\nUpdates checksums and download URLs for all platforms already specified in the lockfile.\nIf no lockfile exists, shows what would be created based on the current configuration.\nThis allows you to refresh lockfile data for platforms other than the one you're currently on.\nOperates on the lockfile in the current config root. Use TOOL arguments to target specific tools.", Run: func(*cobra.Command, []string) {}}
+	cmd137 := &cobra.Command{Use: "lock", Short: "Update lockfile checksums and URLs for all specified platforms", Long: "Update lockfile checksums and URLs for all specified platforms\n\nUpdates checksums and download URLs for all platforms already specified in the lockfile.\nIf no lockfile exists, shows what would be created based on the current configuration,\nincluding tools declared by tasks.\nThis allows you to refresh lockfile data for platforms other than the one you're currently on.\nOperates on the lockfile in the current config root. Use TOOL arguments to target specific tools.", Run: func(*cobra.Command, []string) {}}
 	cmd137.Flags().BoolP("global", "g", false, "Target only global config lockfiles (~/.config/mise/mise.lock and system config)\nBy default, only the active project config root is locked")
-	cmd137.Flags().StringP("jobs", "j", "", "Number of jobs to run in parallel")
+	cmd137.Flags().StringP("jobs", "j", "", "Number of jobs to run in parallel\nValues below 1 are treated as 1")
 	cmd137.Flags().BoolP("dry-run", "n", false, "Show what would be updated without making changes")
 	cmd137.Flags().StringArrayP("platform", "p", nil, "Comma-separated list of platforms to target\ne.g.: linux-x64,macos-arm64,windows-x64\nIf not specified, all platforms already in lockfile will be updated")
 	cmd137.Flags().Bool("bump", false, "Re-resolve fuzzy version selectors against the latest available versions")
@@ -712,8 +718,8 @@ func build() *cobra.Command {
 	cmd141.AddCommand(cmd144)
 	root.AddCommand(cmd141)
 	cmd145 := &cobra.Command{Use: "outdated", Short: "Shows outdated tool versions", Long: "Shows outdated tool versions\n\nSee `mise upgrade` to upgrade these versions.", Run: func(*cobra.Command, []string) {}}
+	cmd145.Flags().BoolP("bump", "b", false, "Compares against the latest versions available, not what matches the current config")
 	cmd145.Flags().BoolP("json", "J", false, "Output in JSON format")
-	cmd145.Flags().BoolP("bump", "l", false, "Compares against the latest versions available, not what matches the current config")
 	cmd145.Flags().Bool("inactive", false, "Show outdated tools including installed-but-inactive tools not present in the current config")
 	cmd145.Flags().Bool("local", false, "Only show outdated tools defined in local config files")
 	cmd145.Flags().Bool("monorepo", false, "Placeholder for future monorepo outdated checks; `mise outdated --monorepo` is not implemented yet.")
@@ -734,7 +740,7 @@ func build() *cobra.Command {
 	cmd148 := &cobra.Command{Use: "install", Short: "Install a plugin", Long: "Install a plugin\n\nnote that mise can automatically install plugins when you install a tool\ne.g.: `mise install cmake@3.30` will autoinstall the cmake plugin\n\nThis behavior can be modified in ~/.config/mise/config.toml", Aliases: []string{"i", "a", "add"}, Run: func(*cobra.Command, []string) {}}
 	cmd148.Flags().BoolP("all", "a", false, "Install all missing plugins\nThis will only install plugins that have matching shorthands.\ni.e.: they don't need the full git repo url")
 	cmd148.Flags().BoolP("force", "f", false, "Reinstall even if plugin exists")
-	cmd148.Flags().StringP("jobs", "j", "", "Number of jobs to run in parallel")
+	cmd148.Flags().StringP("jobs", "j", "", "Number of jobs to run in parallel\nValues below 1 are treated as 1")
 	cmd148.Flags().CountP("verbose", "v", "Show installation output")
 	cmd147.AddCommand(cmd148)
 	cmd149 := &cobra.Command{Use: "link", Short: "Symlinks a plugin into mise", Long: "Symlinks a plugin into mise\n\nThis is used for developing a plugin.", Aliases: []string{"ln"}, Run: func(*cobra.Command, []string) {}}
@@ -761,7 +767,7 @@ func build() *cobra.Command {
 	cmd152.Flags().BoolP("purge", "p", false, "Also remove the plugin's installs, downloads, and cache")
 	cmd147.AddCommand(cmd152)
 	cmd153 := &cobra.Command{Use: "update", Short: "Updates a plugin to the latest version", Long: "Updates a plugin to the latest version\n\nnote: this updates the plugin itself, not the runtime versions", Aliases: []string{"up", "upgrade"}, Run: func(*cobra.Command, []string) {}}
-	cmd153.Flags().StringP("jobs", "j", "", "Number of jobs to run in parallel\nDefault: 4")
+	cmd153.Flags().StringP("jobs", "j", "", "Number of jobs to run in parallel\nValues below 1 are treated as 1\nDefault: 4")
 	cmd147.AddCommand(cmd153)
 	root.AddCommand(cmd147)
 	cmd154 := &cobra.Command{Use: "deps", Short: "[experimental] Manage project dependencies", Long: "[experimental] Manage project dependencies\n\nRuns all applicable dependency install steps for the current project.\nThis checks if dependency lockfiles are newer than installed outputs\n(e.g., package-lock.json vs node_modules/) and runs install commands\nif needed.\n\nProviders with `auto = true` are automatically invoked before `mise x` and `mise run`\nunless skipped with the --no-deps flag.", Aliases: []string{"dep", "prepare"}, Run: func(*cobra.Command, []string) {}}
@@ -800,7 +806,7 @@ func build() *cobra.Command {
 	_ = cmd159.Flags().MarkHidden("complete")
 	cmd159.Flags().Bool("hide-aliased", false, "Hide aliased tools")
 	cmd159.Flags().BoolP("json", "J", false, "Output in JSON format")
-	cmd159.Flags().Bool("security", false, "Include security features for each tool's backends in JSON output")
+	cmd159.Flags().Bool("security", false, "Include security features for each tool's backends in JSON output.")
 	root.AddCommand(cmd159)
 	cmd160 := &cobra.Command{Use: "render-help", Short: "internal command to generate markdown from help", Hidden: true, Run: func(*cobra.Command, []string) {}}
 	root.AddCommand(cmd160)
@@ -813,10 +819,11 @@ func build() *cobra.Command {
 	cmd162.Flags().Bool("affected-explain", false, "Explain why projects and tasks were selected by --affected")
 	cmd162.Flags().String("affected-head", "", "Git head revision for --affected\nDefaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD")
 	cmd162.Flags().Bool("affected-json", false, "Output affected projects and tasks as JSON without running tasks")
+	cmd162.Flags().Bool("all", false, "Open the interactive selector with all tasks from the entire monorepo")
 	cmd162.Flags().BoolP("continue-on-error", "c", false, "Continue running tasks even if one fails")
 	cmd162.Flags().StringP("cd", "C", "", "Change to this directory before executing the command")
 	cmd162.Flags().BoolP("force", "f", false, "Force the tasks to run even if outputs are up to date")
-	cmd162.Flags().StringP("jobs", "j", "", "Number of tasks to run in parallel\n[default: 4]\nConfigure with `jobs` config or `MISE_JOBS` env var")
+	cmd162.Flags().StringP("jobs", "j", "", "Number of tasks to run in parallel\nValues below 1 are treated as 1\n[default: 4]\nConfigure with `jobs` config or `MISE_JOBS` env var")
 	cmd162.Flags().BoolP("dry-run", "n", false, "Don't actually run the task(s), just print them in order of execution")
 	cmd162.Flags().StringP("output", "o", "", "Change how tasks information is output when running tasks")
 	cmd162.Flags().BoolP("quiet", "q", false, "Don't show extra output")
@@ -873,7 +880,7 @@ func build() *cobra.Command {
 	_ = cmd165.Flags().MarkHidden("remove")
 	cmd165.Flags().Bool("stdin", false, "Read the value from stdin (for multiline input)")
 	root.AddCommand(cmd165)
-	cmd166 := &cobra.Command{Use: "settings", Short: "Manage settings", Long: "Show current settings\n\nThis is the contents of ~/.config/mise/config.toml\n\nNote that aliases are also stored in this file\nbut managed separately with `mise tool-alias`", Run: func(*cobra.Command, []string) {}}
+	cmd166 := &cobra.Command{Use: "settings", Short: "Manage settings", Run: func(*cobra.Command, []string) {}}
 	cmd166.Flags().BoolP("all", "a", false, "List all settings")
 	cmd166.Flags().BoolP("json", "J", false, "Output in JSON format")
 	cmd166.PersistentFlags().BoolP("local", "l", false, "Use the local config file instead of the global one")
@@ -904,7 +911,7 @@ func build() *cobra.Command {
 	cmd166.AddCommand(cmd171)
 	root.AddCommand(cmd166)
 	cmd172 := &cobra.Command{Use: "shell", Short: "Sets a tool version for the current session.", Long: "Sets a tool version for the current session.\n\nOnly works in a session where mise is already activated.\n\nThis works by setting environment variables for the current shell session\nsuch as `MISE_NODE_VERSION=20` which is \"eval\"ed as a shell function created by `mise activate`.", Aliases: []string{"sh"}, Run: func(*cobra.Command, []string) {}}
-	cmd172.Flags().StringP("jobs", "j", "", "Number of jobs to run in parallel\n[default: 4]")
+	cmd172.Flags().StringP("jobs", "j", "", "Number of jobs to run in parallel\nValues below 1 are treated as 1\n[default: 4]")
 	cmd172.Flags().BoolP("unset", "u", false, "Removes a previously set version")
 	cmd172.Flags().Bool("raw", false, "Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1")
 	root.AddCommand(cmd172)
@@ -923,12 +930,12 @@ func build() *cobra.Command {
 	cmd178 := &cobra.Command{Use: "sponsors", Short: "Show the companies sponsoring mise and the jdx.dev open source tools", Run: func(*cobra.Command, []string) {}}
 	root.AddCommand(cmd178)
 	cmd179 := &cobra.Command{Use: "sync", Short: "Synchronize tools from other version managers with mise", Run: func(*cobra.Command, []string) {}}
-	cmd180 := &cobra.Command{Use: "node", Short: "Symlinks all tool versions from an external tool into mise", Long: "Symlinks all tool versions from an external tool into mise\n\nFor example, use this to import all Homebrew node installs into mise\n\nThis won't overwrite any existing installs but will overwrite any existing symlinks", Run: func(*cobra.Command, []string) {}}
+	cmd180 := &cobra.Command{Use: "node", Short: "Symlinks all tool versions from an external tool into mise", Long: "Symlinks all tool versions from an external tool into mise\n\nFor example, use this to import all Homebrew node installs into mise\n\nThis won't overwrite managed installs, runtime aliases, or links from other providers.", Run: func(*cobra.Command, []string) {}}
 	cmd180.Flags().Bool("brew", false, "Get tool versions from Homebrew")
 	cmd180.Flags().Bool("nodenv", false, "Get tool versions from nodenv")
 	cmd180.Flags().Bool("nvm", false, "Get tool versions from nvm")
 	cmd179.AddCommand(cmd180)
-	cmd181 := &cobra.Command{Use: "python", Short: "Symlinks all tool versions from an external tool into mise", Long: "Symlinks all tool versions from an external tool into mise\n\nFor example, use this to import all pyenv installs into mise\n\nThis won't overwrite any existing installs but will overwrite any existing symlinks", Run: func(*cobra.Command, []string) {}}
+	cmd181 := &cobra.Command{Use: "python", Short: "Symlinks all tool versions from an external tool into mise", Long: "Symlinks all tool versions from an external tool into mise\n\nFor example, use this to import all pyenv installs into mise\n\nThis won't overwrite managed installs, runtime aliases, or links from other providers.", Run: func(*cobra.Command, []string) {}}
 	cmd181.Flags().Bool("pyenv", false, "Get tool versions from pyenv")
 	cmd181.Flags().Bool("uv", false, "Sync tool versions with uv (2-way sync)")
 	cmd179.AddCommand(cmd181)
@@ -1006,10 +1013,11 @@ func build() *cobra.Command {
 	cmd190.Flags().Bool("affected-explain", false, "Explain why projects and tasks were selected by --affected")
 	cmd190.Flags().String("affected-head", "", "Git head revision for --affected\nDefaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD")
 	cmd190.Flags().Bool("affected-json", false, "Output affected projects and tasks as JSON without running tasks")
+	cmd190.Flags().Bool("all", false, "Open the interactive selector with all tasks from the entire monorepo")
 	cmd190.Flags().BoolP("continue-on-error", "c", false, "Continue running tasks even if one fails")
 	cmd190.Flags().StringP("cd", "C", "", "Change to this directory before executing the command")
 	cmd190.Flags().BoolP("force", "f", false, "Force the tasks to run even if outputs are up to date")
-	cmd190.Flags().StringP("jobs", "j", "", "Number of tasks to run in parallel\n[default: 4]\nConfigure with `jobs` config or `MISE_JOBS` env var")
+	cmd190.Flags().StringP("jobs", "j", "", "Number of tasks to run in parallel\nValues below 1 are treated as 1\n[default: 4]\nConfigure with `jobs` config or `MISE_JOBS` env var")
 	cmd190.Flags().BoolP("dry-run", "n", false, "Don't actually run the task(s), just print them in order of execution")
 	cmd190.Flags().StringP("output", "o", "", "Change how tasks information is output when running tasks")
 	cmd190.Flags().BoolP("quiet", "q", false, "Don't show extra output")
@@ -1047,22 +1055,22 @@ func build() *cobra.Command {
 	root.AddCommand(cmd183)
 	cmd192 := &cobra.Command{Use: "test-tool", Short: "Test a tool installs and executes", Run: func(*cobra.Command, []string) {}}
 	cmd192.Flags().BoolP("all", "a", false, "Test every tool specified in registry/")
-	cmd192.Flags().StringP("jobs", "j", "", "Number of tool tests to run in parallel\n[default: 4]")
+	cmd192.Flags().StringP("jobs", "j", "", "Number of tool tests to run in parallel\nValues below 1 are treated as 1\n[default: 4]")
 	cmd192.Flags().Bool("all-config", false, "Test all tools specified in config files")
 	cmd192.Flags().Bool("include-non-defined", false, "Also test tools not defined in registry/, guessing how to test it")
 	cmd192.Flags().Bool("raw", false, "Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1")
 	root.AddCommand(cmd192)
 	cmd193 := &cobra.Command{Use: "token", Short: "Display git provider tokens mise will use", Run: func(*cobra.Command, []string) {}}
-	cmd194 := &cobra.Command{Use: "forgejo", Short: "Forgejo token", Run: func(*cobra.Command, []string) {}}
+	cmd194 := &cobra.Command{Use: "forgejo", Short: "Forgejo token", Long: "Display the Forgejo token mise will use for a given host\n\nShows which token source mise would use, useful for debugging\nauthentication issues. The token is masked by default.", Run: func(*cobra.Command, []string) {}}
 	cmd194.Flags().Bool("unmask", false, "Show the full unmasked token")
 	cmd193.AddCommand(cmd194)
-	cmd195 := &cobra.Command{Use: "github", Short: "GitHub token", Run: func(*cobra.Command, []string) {}}
+	cmd195 := &cobra.Command{Use: "github", Short: "GitHub token", Long: "Display the GitHub token mise will use for a given host\n\nShows which token source mise would use, useful for debugging\nauthentication issues. The token is masked by default.", Run: func(*cobra.Command, []string) {}}
 	cmd195.Flags().Bool("oauth", false, "Resolve only via the native GitHub OAuth source (cache, refresh, or device-code flow), bypassing other token sources")
 	cmd195.Flags().Bool("raw", false, "Print only the token value")
 	cmd195.Flags().Bool("refresh", false, "Mint a fresh OAuth token even if the cached one has not expired, via the refresh-token grant or a new device-code flow. Use after changing the GitHub App's installations or permissions: cached tokens keep their original access until they expire")
 	cmd195.Flags().Bool("unmask", false, "Show the full unmasked token")
 	cmd193.AddCommand(cmd195)
-	cmd196 := &cobra.Command{Use: "gitlab", Short: "GitLab token", Run: func(*cobra.Command, []string) {}}
+	cmd196 := &cobra.Command{Use: "gitlab", Short: "GitLab token", Long: "Display the GitLab token mise will use for a given host\n\nShows which token source mise would use, useful for debugging\nauthentication issues. The token is masked by default.", Run: func(*cobra.Command, []string) {}}
 	cmd196.Flags().Bool("unmask", false, "Show the full unmasked token")
 	cmd193.AddCommand(cmd196)
 	root.AddCommand(cmd193)
@@ -1076,13 +1084,13 @@ func build() *cobra.Command {
 	cmd197.Flags().Bool("requested", false, "Only show requested versions")
 	cmd197.Flags().Bool("tool-options", false, "Only show tool options")
 	root.AddCommand(cmd197)
-	cmd198 := &cobra.Command{Use: "tool-stub", Short: "Execute a tool stub", Long: "Execute a tool stub\n\nTool stubs are executable files containing TOML configuration that specify which tool to run and how to run it. They provide a convenient way to create portable, self-contained executables that automatically manage tool installation and execution.\n\nA tool stub consists of: - A shebang line: #!/usr/bin/env -S mise tool-stub - TOML configuration specifying the tool, version, and options - Optional comments describing the tool's purpose\n\nExample stub file: #!/usr/bin/env -S mise tool-stub # Node.js v20 development environment\n\ntool = \"node\" version = \"20.0.0\" bin = \"node\"\n\nThe stub will automatically install the specified tool version if missing and execute it with any arguments passed to the stub.\n\nFor more information, see: https://mise.jdx.dev/dev-tools/tool-stubs.html", Run: func(*cobra.Command, []string) {}}
+	cmd198 := &cobra.Command{Use: "tool-stub", Short: "Execute a tool stub", Long: "Execute a tool stub\n\nTool stubs are executable files containing TOML configuration that specify\nwhich tool to run and how to run it. They provide a convenient way to create\nportable, self-contained executables that automatically manage tool installation\nand execution.\n\nA tool stub consists of:\n- A shebang line: #!/usr/bin/env -S mise tool-stub\n- TOML configuration specifying the tool, version, and options\n- Optional comments describing the tool's purpose\n\nExample stub file:\n  #!/usr/bin/env -S mise tool-stub\n  # Node.js v20 development environment\n\n  tool = \"node\"\n  version = \"20.0.0\"\n  bin = \"node\"\n\nThe stub will automatically install the specified tool version if missing\nand execute it with any arguments passed to the stub.\n\nFor more information, see: https://mise.jdx.dev/dev-tools/tool-stubs.html", Run: func(*cobra.Command, []string) {}}
 	root.AddCommand(cmd198)
-	cmd199 := &cobra.Command{Use: "trust", Short: "Marks a config file as trusted", Long: "Marks a config file as trusted\n\nThis means mise is allowed to parse the file when it needs to read config\nthat may execute code or affect the environment. mise checks trust before\nparsing `mise.toml`. Without trust, mise may prompt, skip the config in some\ndiscovery paths, fail with an untrusted-config error when it cannot prompt,\nor assume trust in detected CI unless paranoid mode is enabled.\n\nSafe config files do not require trust: files that only contain\n`min_version`, `[tools]` entries with plain version strings (or arrays\nof them), and `[tasks]` (no templates and no tool options) are loaded\nwithout prompting, since nothing in them executes code at load time —\ntools install and tasks run only on explicit commands like `mise install`\nor `mise run`.\n\nTrust is shared across git worktrees: a config file inside a linked\nworktree is trusted when the equivalent path in the repository's main\ncheckout has been trusted. Paranoid mode disables this sharing since\nworktrees can check out branches with different config contents.", Run: func(*cobra.Command, []string) {}}
+	cmd199 := &cobra.Command{Use: "trust", Short: "Marks a config file as trusted", Long: "Marks a config file as trusted\n\nThis means mise is allowed to parse the file when it needs to read config\nthat may execute code or affect the environment. Without trust, mise may\nprompt, skip the config in some discovery paths, or fail with an\nuntrusted-config error when it cannot prompt.\n\nIn normal mode, commands that execute project-defined behavior (`mise run`,\nnaked task invocations such as `mise <TASK>`, `mise install`, `mise exec`,\nand `mise watch`) automatically trust their active config. Paranoid mode\nrequires explicit, content-bound trust for every non-global config.\n\nIn normal mode, safe config files do not require trust: files that only contain\n`min_version`, `[tools]` entries with plain version strings (or arrays of\nthem), and `[tasks]` without templates or tool options.\n\nTrust is shared across git worktrees: a config file inside a linked\nworktree is trusted when the equivalent path in the repository's main\ncheckout has been trusted. Paranoid mode disables this sharing since\nworktrees can check out branches with different config contents.", Run: func(*cobra.Command, []string) {}}
 	cmd199.Flags().BoolP("all", "a", false, "Trust all config files in the current directory, its parents, and its subdirectories")
 	cmd199.Flags().Bool("ignore", false, "Do not trust this config and ignore it in the future")
 	cmd199.Flags().Bool("show", false, "Show the trusted status of config files from the current directory and its parents.\nDoes not trust or untrust any files.")
-	cmd199.Flags().Bool("untrust", false, "No longer trust this config, will prompt in the future")
+	cmd199.Flags().Bool("untrust", false, "Remove explicit trust for this config")
 	root.AddCommand(cmd199)
 	cmd200 := &cobra.Command{Use: "uninstall", Short: "Removes installed tool versions", Long: "Removes installed tool versions\n\nThis only removes the installed version, it does not modify mise.toml.", Run: func(*cobra.Command, []string) {}}
 	cmd200.Flags().BoolP("all", "a", false, "Delete all installed versions")
@@ -1093,7 +1101,7 @@ func build() *cobra.Command {
 	cmd201.Flags().StringP("file", "f", "", "Specify a file to use instead of `mise.toml`")
 	cmd201.Flags().BoolP("global", "g", false, "Use the global config file")
 	root.AddCommand(cmd201)
-	cmd202 := &cobra.Command{Use: "untrust", Short: "No longer trust a config, will prompt in the future", Run: func(*cobra.Command, []string) {}}
+	cmd202 := &cobra.Command{Use: "untrust", Short: "Remove explicit trust for a config", Run: func(*cobra.Command, []string) {}}
 	root.AddCommand(cmd202)
 	cmd203 := &cobra.Command{Use: "unuse", Short: "Removes installed tool versions from mise.toml", Long: "Removes installed tool versions from mise.toml\n\nBy default, this will use the `mise.toml` file that has the tool defined.\nIf multiple config files exist (e.g., both `mise.toml` and `mise.local.toml`),\nthe lowest precedence file (`mise.toml`) will be used.\nSee https://mise.jdx.dev/configuration.html#target-file-for-write-operations\n\nIn the following order:\n  - If `--global` is set, it will use the global config file.\n  - If `--path` is set, it will use the config file at the given path.\n  - If `--env` is set, it will use `mise.<env>.toml`.\n  - If [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) is set, it will use that instead.\n  - If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will the first from that list.\n  - Otherwise just \"mise.toml\" or global config if cwd is home directory.\n\nUse [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.\n\nWill also prune the installed version if no other configurations are using it.", Aliases: []string{"rm", "remove"}, Run: func(*cobra.Command, []string) {}}
 	cmd203.Flags().StringP("env", "e", "", "Create/modify an environment-specific config file like .mise.<env>.toml")
@@ -1102,9 +1110,9 @@ func build() *cobra.Command {
 	cmd203.Flags().Bool("no-prune", false, "Do not also prune the installed version")
 	root.AddCommand(cmd203)
 	cmd204 := &cobra.Command{Use: "upgrade", Short: "Upgrades outdated tools", Long: "Upgrades outdated tools\n\nBy default, this keeps the range specified in mise.toml. So if you have node@20 set, it will\nupgrade to the latest 20.x.x version available. See the `--bump` flag to use the latest version\nand bump the version in mise.toml.\n\nThis will update mise.lock if it is enabled, see https://mise.jdx.dev/configuration/settings.html#lockfile", Aliases: []string{"up"}, Run: func(*cobra.Command, []string) {}}
+	cmd204.Flags().BoolP("bump", "b", false, "Upgrades to the latest version available, bumping the version in mise.toml")
 	cmd204.Flags().BoolP("interactive", "i", false, "Display multiselect menu to choose which tools to upgrade")
-	cmd204.Flags().StringP("jobs", "j", "", "Number of jobs to run in parallel\n[default: 4]")
-	cmd204.Flags().BoolP("bump", "l", false, "Upgrades to the latest version available, bumping the version in mise.toml")
+	cmd204.Flags().StringP("jobs", "j", "", "Number of jobs to run in parallel\nValues below 1 are treated as 1\n[default: 4]")
 	cmd204.Flags().BoolP("dry-run", "n", false, "Just print what would be done, don't actually do it")
 	cmd204.Flags().StringArrayP("exclude", "x", nil, "Tool(s) to exclude from upgrading\ne.g.: go python")
 	cmd204.Flags().Bool("dry-run-code", false, "Like --dry-run but exits with code 1 if there are outdated tools")
@@ -1113,6 +1121,7 @@ func build() *cobra.Command {
 	cmd204.Flags().String("minimum-release-age", "", "Only upgrade to versions released before this date or older than this duration")
 	cmd204.Flags().Bool("monorepo", false, "Placeholder for future monorepo upgrades; `mise upgrade --monorepo` is not implemented yet.")
 	cmd204.Flags().Bool("no-prune", false, "Do not uninstall the versions that were upgraded away from")
+	cmd204.Flags().Bool("prune", false, "Uninstall the versions that were upgraded away from")
 	cmd204.Flags().Bool("raw", false, "Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1")
 	root.AddCommand(cmd204)
 	cmd205 := &cobra.Command{Use: "usage", Short: "Generate a usage CLI spec", Long: "Generate a usage CLI spec\n\nSee https://usage.jdx.dev for more information on this specification.", Hidden: true, Run: func(*cobra.Command, []string) {}}
@@ -1121,13 +1130,13 @@ func build() *cobra.Command {
 	cmd206.Flags().StringP("env", "e", "", "Create/modify an environment-specific config file like .mise.<env>.toml")
 	cmd206.Flags().BoolP("force", "f", false, "Force reinstall even if already installed")
 	cmd206.Flags().BoolP("global", "g", false, "Use the global config file (`~/.config/mise/config.toml`) instead of the local one")
-	cmd206.Flags().StringP("jobs", "j", "", "Number of jobs to run in parallel\n[default: 4]")
+	cmd206.Flags().StringP("jobs", "j", "", "Number of jobs to run in parallel\nValues below 1 are treated as 1\n[default: 4]")
 	cmd206.Flags().BoolP("dry-run", "n", false, "Perform a dry run, showing what would be installed and modified without making changes")
 	cmd206.Flags().StringP("path", "p", "", "Specify a path to a config file or directory")
 	cmd206.Flags().Bool("dry-run-code", false, "Like --dry-run but exits with code 1 if there are changes to make")
 	cmd206.Flags().Bool("fuzzy", false, "Save fuzzy version to config file")
 	cmd206.Flags().String("minimum-release-age", "", "Only install versions released before this date or older than this duration")
-	cmd206.Flags().Bool("pin", false, "Save exact version to config file\ne.g.: `mise use --pin node@20` will save 20.0.0 as the version\nSet `MISE_PIN=1` to make this the default behavior")
+	cmd206.Flags().Bool("pin", false, "Save the resolved concrete version to the config file")
 	cmd206.Flags().Bool("raw", false, "Connect backend install command stdin/stdout/stderr directly to the terminal Implies `--jobs=1`")
 	cmd206.Flags().StringArray("remove", nil, "Remove the tool(s) from config file")
 	root.AddCommand(cmd206)
@@ -1163,7 +1172,7 @@ func build() *cobra.Command {
 	cmd208.Flags().String("poll", "", "Poll for filesystem changes")
 	cmd208.Flags().String("shell", "", "Use a different shell")
 	cmd208.Flags().String("emit-events-to", "none", "Configure event emission")
-	cmd208.Flags().Bool("only-emit-events", false, "Only emit events to stdout, run no commands")
+	cmd208.Flags().Bool("only-emit-events", false, "Only emit events to stdout, run no commands.")
 	cmd208.Flags().StringArrayP("env", "E", nil, "Add env vars to the command")
 	cmd208.Flags().String("wrap-process", "", "Configure how the process is wrapped")
 	cmd208.Flags().BoolP("notify", "N", false, "Alert when commands start and end")
@@ -1176,7 +1185,7 @@ func build() *cobra.Command {
 	cmd208.Flags().StringArrayP("exts", "e", nil, "Filename extensions to filter to")
 	cmd208.Flags().StringArrayP("filter", "f", nil, "Filename patterns to filter to")
 	cmd208.Flags().StringArray("filter-file", nil, "Files to load filters from")
-	cmd208.Flags().StringArrayP("filter-prog", "J", nil, "[experimental] Filter programs")
+	cmd208.Flags().StringArrayP("filter-prog", "J", nil, "[experimental] Filter programs.")
 	cmd208.Flags().StringArrayP("ignore", "i", nil, "Filename patterns to filter out")
 	cmd208.Flags().StringArray("ignore-file", nil, "Files to load ignores from")
 	cmd208.Flags().StringArray("fs-events", nil, "Filesystem events to filter to")

--- a/benches/mise.usage.kdl
+++ b/benches/mise.usage.kdl
@@ -1,10 +1,12 @@
 min_usage_version "4.0"
 name mise
 bin mise
+author "Jeff Dickey <@jdx>"
 about "Dev tools, env vars, and tasks in one CLI"
 long_about "mise prepares your development environment before each command runs. https://github.com/jdx/mise"
+after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise install node@20.0.0\u{1b}[22m       Install a specific node version\n    $ \u{1b}[1mmise install node@20\u{1b}[22m           Install a version matching a prefix\n    $ \u{1b}[1mmise install node\u{1b}[22m              Install the node version defined in config\n    $ \u{1b}[1mmise install\u{1b}[22m                   Install all plugins/tools defined in config\n\n    $ \u{1b}[1mmise install cargo:ripgrep\u{1b}[22m     Install something via cargo\n    $ \u{1b}[1mmise install npm:prettier\u{1b}[22m      Install something via npm\n\n    $ \u{1b}[1mmise use node@20\u{1b}[22m               Use node-20.x in current project\n    $ \u{1b}[1mmise use -g node@20\u{1b}[22m            Use node-20.x as default\n    $ \u{1b}[1mmise use node@latest\u{1b}[22m           Use latest node in current directory\n\n    $ \u{1b}[1mmise up --interactive\u{1b}[22m          Show a menu to upgrade tools\n\n    $ \u{1b}[1mmise x -- npm install\u{1b}[22m          `npm install` w/ config loaded into PATH\n    $ \u{1b}[1mmise x node@20 -- node app.js\u{1b}[22m  `node app.js` w/ config + node-20.x on PATH\n\n    $ \u{1b}[1mmise set NODE_ENV=production\u{1b}[22m   Set NODE_ENV=production in config\n\n    $ \u{1b}[1mmise run build\u{1b}[22m                 Run `build` tasks\n    $ \u{1b}[1mmise watch build\u{1b}[22m               Run `build` tasks repeatedly when files change\n\n    $ \u{1b}[1mmise settings\u{1b}[22m                  Show settings in use\n    $ \u{1b}[1mmise settings color=0\u{1b}[22m          Disable color by modifying global config file\n"
 default_subcommand run
-usage "Usage: mise [OPTIONS] [TASK] [COMMAND]"
+arg_required_else_help #true
 flag "-c --continue-on-error" help="Continue running tasks even if one fails" hide=#true
 flag "-C --cd" help="Change directory before running command" global=#true {
     arg <DIR>
@@ -13,27 +15,44 @@ flag "-E --env" help="Set the environment for loading `mise.<ENV>.toml`" var=#tr
     arg <ENV>
 }
 flag "-f --force" help="Force the operation" hide=#true
-flag "-j --jobs" help="How many jobs to run in parallel [default: 8]" global=#true {
+flag "-j --jobs" help="How many jobs to run in parallel; values below 1 are treated as 1 [default: 8]" global=#true env=MISE_JOBS {
     arg <JOBS>
 }
 flag "-n --dry-run" help="Dry run, don't actually do anything" hide=#true
-flag "-P --profile" help="Set the profile (environment)" var=#true hide=#true global=#true {
+flag "-P --profile" help="Set the profile (environment)" var=#true hide=#true global=#true conflicts=--env {
     arg <PROFILE>
 }
-flag "-q --quiet" help="Suppress non-error messages" global=#true
+flag "-q --quiet" help="Suppress non-error messages" global=#true {
+    overrides "--silent" "--trace" "--verbose" "--debug" "--log-level"
+}
 flag "-s --shell" hide=#true {
     arg <SHELL>
 }
-flag "-t --tool" help="Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10" var=#true hide=#true {
+flag "-t --tool" help="Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10" var=#true hide=#true env=MISE_QUIET {
+    long_help #"""
+Tool(s) to run in addition to what is in mise.toml files
+e.g.: node@20 python@3.10
+"""#
     arg <TOOL@VERSION>
 }
-flag "-v --verbose" help="Show extra output (use -vv for even more)" var=#true global=#true count=#true
+flag "-v --verbose" help="Show extra output (use -vv for even more)" var=#true global=#true count=#true {
+    overrides "--quiet" "--silent" "--trace" "--debug"
+}
 flag "-V --version" hide=#true
 flag "-y --yes" help="Answer yes to all confirmation prompts" global=#true
-flag --debug help="Sets log level to debug" hide=#true global=#true
+flag --debug help="Sets log level to debug" hide=#true global=#true {
+    overrides "--quiet" "--trace" "--verbose" "--silent" "--log-level"
+}
 flag --log-level hide=#true global=#true {
+    overrides "--quiet" "--trace" "--verbose" "--silent" "--debug"
     arg <LEVEL> {
-        choices trace debug info warning error
+        choices {
+            choice trace
+            choice debug
+            choice info
+            choice warning
+            choice error
+        }
     }
 }
 flag --no-config help="Do not load any config files" {
@@ -58,6 +77,7 @@ Can also use `MISE_NO_HOOKS=1`
 """#
 }
 flag --no-timings help="Hides elapsed time after each task completes" hide=#true {
+    alias "--no-timing" hide=#true
     long_help #"""
 Hides elapsed time after each task completes
 
@@ -77,22 +97,28 @@ This prevents API calls to GitHub, aqua registry, etc.
 Can also be enabled via MISE_LOCKED=1 or settings.locked=true
 """#
 }
-flag --silent help="Suppress all task output and mise non-error messages" global=#true
+flag --silent help="Suppress all task output and mise non-error messages" global=#true {
+    overrides "--quiet" "--trace" "--verbose" "--debug" "--log-level"
+}
 flag --timings help="Shows elapsed time after each task completes" hide=#true {
+    alias "--timing" hide=#true
     long_help #"""
 Shows elapsed time after each task completes
 
 Default to always show with `MISE_TASK_TIMINGS=1`
 """#
 }
-flag --trace help="Sets log level to trace" hide=#true global=#true
+flag --trace help="Sets log level to trace" hide=#true global=#true {
+    overrides "--quiet" "--silent" "--verbose" "--debug" "--log-level"
+}
 arg "[TASK]" help="Task to run" help_long=#"""
 Task to run.
 
 Shorthand for `mise tasks run <TASK>`.
-"""# required=#false
+"""# required=#false double_dash=automatic
 arg "[TASK_ARGS]…" help="Task arguments" required=#false var=#true hide=#true
 arg "[-- TASK_ARGS_LAST]…" required=#false var=#true hide=#true
+complete dir type=dir
 cmd activate help="Initializes mise in the current shell session" effect=read {
     long_help #"""
 Initializes mise in the current shell session
@@ -112,16 +138,7 @@ specify the full path like this:
 
 Customize status output with `status` settings.
 """#
-    after_long_help #"""
-Examples:
-
-    $ eval "$(mise activate bash)"
-    $ eval "$(mise activate zsh)"
-    $ mise activate fish | source
-    $ execx($(mise activate xonsh))
-    $ (&mise activate pwsh) | Out-String | Invoke-Expression
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1meval \"$(mise activate bash)\"\u{1b}[22m\n    $ \u{1b}[1meval \"$(mise activate zsh)\"\u{1b}[22m\n    $ \u{1b}[1mmise activate fish | source\u{1b}[22m\n    $ \u{1b}[1mexecx($(mise activate xonsh))\u{1b}[22m\n    $ \u{1b}[1m(&mise activate pwsh) | Out-String | Invoke-Expression\u{1b}[22m\n"
     flag "-q --quiet" help="Suppress non-error messages"
     flag "-s --shell" help="Shell type to generate the script for" hide=#true {
         arg <SHELL> {
@@ -132,7 +149,10 @@ Examples:
         long_help #"""
 Do not automatically call hook-env
 
-This can be helpful for debugging mise. If you run `eval "$(mise activate --no-hook-env)"`, then you can call `mise hook-env` manually which will output the env vars to stdout without actually modifying the environment. That way you can do things like `mise hook-env --trace` to get more information or just see the values that hook-env is outputting.
+This can be helpful for debugging mise. If you run `eval "$(mise activate --no-hook-env)"`, then
+you can call `mise hook-env` manually which will output the env vars to stdout without actually
+modifying the environment. That way you can do things like `mise hook-env --trace` to get more
+information or just see the values that hook-env is outputting.
 """#
     }
     flag --shims help=#"""
@@ -157,6 +177,7 @@ See https://mise.jdx.dev/dev-tools/shims.html#shims-vs-path for more information
 cmd tool-alias help="Manage tool version aliases." effect=read {
     alias alias aliases hide=#true
     flag "-p --tool" help="Filter aliases by tool" {
+        alias "--plugin" hide=#true
         arg <TOOL>
     }
     flag --no-header help="Don't show table header"
@@ -166,13 +187,7 @@ Show an alias for a tool
 
 This is the contents of a tool_alias.<TOOL> entry in ~/.config/mise/config.toml
 """#
-        after_long_help #"""
-Examples:
-
-    $ mise tool-alias get node lts-hydrogen
-    20.0.0
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise tool-alias get node lts-hydrogen\u{1b}[22m\n    20.0.0\n"
         arg <TOOL> help="The tool to show the alias for"
         arg <ALIAS> help="The alias to show"
     }
@@ -192,13 +207,7 @@ For user config, aliases are defined like the following in `~/.config/mise/confi
     [tool_alias.node.versions]
     lts = "22.0.0"
 """#
-        after_long_help #"""
-Examples:
-
-    $ mise tool-alias ls
-    node  lts-jod      22
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise tool-alias ls\u{1b}[22m\n    node  lts-jod      22\n"
         flag --no-header help="Don't show table header"
         arg "[TOOL]" help="Show aliases for <TOOL>" required=#false
     }
@@ -209,13 +218,7 @@ Add/update an alias for a tool/backend
 
 This modifies the contents of ~/.config/mise/config.toml
 """#
-        after_long_help #"""
-Examples:
-
-    $ mise tool-alias set maven asdf:mise-plugins/mise-maven
-    $ mise tool-alias set node lts-jod 22.0.0
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise tool-alias set maven asdf:mise-plugins/mise-maven\u{1b}[22m\n    $ \u{1b}[1mmise tool-alias set node lts-jod 22.0.0\u{1b}[22m\n"
         arg <TOOL> help="The tool/backend to set the alias for"
         arg <ALIAS> help="The alias to set"
         arg "[VALUE]" help="The value to set the alias to" required=#false
@@ -227,53 +230,27 @@ Clears an alias for a tool/backend
 
 This modifies the contents of ~/.config/mise/config.toml
 """#
-        after_long_help #"""
-Examples:
-
-    $ mise tool-alias unset maven
-    $ mise tool-alias unset node lts-jod
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise tool-alias unset maven\u{1b}[22m\n    $ \u{1b}[1mmise tool-alias unset node lts-jod\u{1b}[22m\n"
         arg <TOOL> help="The tool/backend to remove the alias from"
         arg "[ALIAS]" help="The alias to remove" required=#false
     }
 }
 cmd asdf hide=#true help="[internal] simulates asdf for plugins that call \"asdf\" internally" {
     arg "[ARGS]…" help="all arguments" required=#false double_dash=automatic var=#true
+    complete args type=command_args
 }
 cmd backends help="Manage backends" effect=read {
     alias b backend backend-list hide=#true
-    after_long_help #"""
-Deprecation:
-
-The `mise b` alias is deprecated and will be removed in mise 2027.4.0.
-Use `mise backends` instead.
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mDeprecation:\u{1b}[22m\u{1b}[24m\n\nThe `mise b` alias is deprecated and will be removed in mise 2027.4.0.\nUse `mise backends` instead.\n"
     cmd ls help="List built-in backends" effect=read {
         alias list
-        after_long_help #"""
-Examples:
-
-    $ mise backends ls
-    aqua
-    asdf
-    cargo
-    core
-    dotnet
-    gem
-    go
-    npm
-    pipx
-    spm
-    ubi
-    vfox
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise backends ls\u{1b}[22m\n    aqua\n    asdf\n    cargo\n    core\n    dotnet\n    gem\n    go\n    npm\n    pipx\n    spm\n    ubi\n    vfox\n"
     }
 }
 cmd bin-paths help="List all the active runtime bin paths" effect=read {
-    flag --bin-names help="Output executable names instead of bin directories"
+    flag --bin-names help="Output executable names instead of bin directories" {
+        default_if "--json" "true"
+    }
     flag "-J --json" help="Output executable entries in JSON format (implies --bin-names)"
     arg "[TOOL@VERSION]…" help=#"""
 Tool(s) to look up
@@ -281,7 +258,7 @@ e.g.: ruby@3
 """# required=#false var=#true
 }
 cmd bootstrap help="Set up a machine for the current config in one command" effect=destructive {
-    alias bs
+    alias bs hide=#true
     long_help #"""
 Set up a machine for the current config in one command
 
@@ -333,36 +310,45 @@ Use `--skip <part>` to skip named parts, or `--only <part>` to run just
 named parts. Both flags can be repeated or comma-separated, but they
 cannot be used together.
 """#
-    after_long_help #"""
-Examples:
-
-    $ mise bootstrap                    # packages + repos + dotfiles + tools + bootstrap task
-    $ mise bootstrap --force-dotfiles   # replace conflicting dotfile targets
-    $ mise bootstrap --skip tools,task  # skip tool installation and the bootstrap task
-    $ mise bootstrap --only tools       # run just tool installation
-    $ mise bootstrap status --missing
-    $ mise bootstrap packages apply --yes
-    $ mise bootstrap repos status
-    $ mise bootstrap repos apply --dry-run
-    $ mise bootstrap dotfiles status
-    $ mise bootstrap mise-shell-activate apply --dry-run
-    $ mise bootstrap macos defaults status
-    $ mise bootstrap macos launchd-agents apply --dry-run
-    $ mise bootstrap linux systemd-units apply --dry-run
-    $ mise bootstrap user apply --dry-run
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap\u{1b}[22m                    # packages + repos + dotfiles + tools + bootstrap task\n    $ \u{1b}[1mmise bootstrap --force-dotfiles\u{1b}[22m   # replace conflicting dotfile targets\n    $ \u{1b}[1mmise bootstrap --skip tools,task\u{1b}[22m  # skip tool installation and the bootstrap task\n    $ \u{1b}[1mmise bootstrap --only tools\u{1b}[22m       # run just tool installation\n    $ \u{1b}[1mmise bootstrap status --missing\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages apply --yes\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap repos status\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap repos apply --dry-run\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles status\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap mise-shell-activate apply --dry-run\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap macos defaults status\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap macos launchd-agents apply --dry-run\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap linux systemd-units apply --dry-run\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap user apply --dry-run\u{1b}[22m\n"
     flag "-n --dry-run" help="Print what would happen without installing anything"
     flag "-y --yes" help="Skip confirmation prompts"
     flag --force-dotfiles help="Overwrite existing files that conflict with whole-file dotfile entries"
-    flag --only help="Run only one or more bootstrap parts" var=#true {
+    flag --only help="Run only one or more bootstrap parts" var=#true conflicts=--skip {
         long_help #"""
 Run only one or more bootstrap parts
 
-Can be passed multiple times or as a comma-separated list. Cannot be used with `--skip`.
+Can be passed multiple times or as a comma-separated list.
+Cannot be used with `--skip`.
 """#
-        arg <ONLY> {
-            choices plugins packages accounts files services firewall compose repos dotfiles mise-shell-activate shell macos-defaults defaults macos-launchd-agents launchd linux-systemd-units systemd user tools task final-hook
+        arg <ONLY> delimiter=, {
+            choices {
+                choice plugins
+                choice packages
+                choice accounts
+                choice files
+                choice services
+                choice firewall
+                choice compose
+                choice repos
+                choice dotfiles
+                choice mise-shell-activate {
+                    alias shell hide=#true
+                }
+                choice macos-defaults {
+                    alias defaults hide=#true
+                }
+                choice macos-launchd-agents {
+                    alias launchd hide=#true
+                }
+                choice linux-systemd-units {
+                    alias systemd hide=#true
+                }
+                choice user
+                choice tools
+                choice task
+                choice final-hook
+            }
         }
     }
     flag --prompt-secrets help="Prompt securely for missing bootstrap secret inputs"
@@ -372,8 +358,34 @@ Skip one or more bootstrap parts
 
 Can be passed multiple times or as a comma-separated list.
 """#
-        arg <SKIP> {
-            choices plugins packages accounts files services firewall compose repos dotfiles mise-shell-activate shell macos-defaults defaults macos-launchd-agents launchd linux-systemd-units systemd user tools task final-hook
+        arg <SKIP> delimiter=, {
+            choices {
+                choice plugins
+                choice packages
+                choice accounts
+                choice files
+                choice services
+                choice firewall
+                choice compose
+                choice repos
+                choice dotfiles
+                choice mise-shell-activate {
+                    alias shell hide=#true
+                }
+                choice macos-defaults {
+                    alias defaults hide=#true
+                }
+                choice macos-launchd-agents {
+                    alias launchd hide=#true
+                }
+                choice linux-systemd-units {
+                    alias systemd hide=#true
+                }
+                choice user
+                choice tools
+                choice task
+                choice final-hook
+            }
         }
     }
     flag --update help="Refresh package manager metadata and update configured repos"
@@ -412,23 +424,21 @@ If the target is already managed, this updates its source from the live
 target. Otherwise it creates a `[dotfiles]` entry and seeds the source
 under `dotfiles.root` unless `--source` is provided.
 """#
-            after_long_help #"""
-Examples:
-
-    $ mise bootstrap dotfiles add ~/.zshrc
-    $ mise bootstrap dotfiles add --mode copy ~/.config/starship.toml
-    $ mise bootstrap dotfiles add --source dotfiles/gitconfig ~/.gitconfig
-
-"""#
+            after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap dotfiles add ~/.zshrc\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles add --mode copy ~/.config/starship.toml\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles add --source dotfiles/gitconfig ~/.gitconfig\u{1b}[22m\n"
             flag "-f --force" help="Overwrite existing sources without prompting"
-            flag "-g --global" help="Write to the global config"
-            flag "-l --local" help="Write to the local config instead of the global config"
+            flag "-g --global" help="Write to the global config" {
+                conflicts "--local" "--path"
+            }
+            flag "-l --local" help="Write to the local config instead of the global config" {
+                conflicts "--global" "--path"
+            }
             flag "-m --mode" help="Dotfile mode to write" {
                 arg <MODE>
             }
             flag "-n --dry-run" help="Print the config/source updates without writing anything"
             flag --no-apply help="Add the entry without applying it"
-            flag "-p --path --file" help="Write to this config file or directory" {
+            flag "-p --path" help="Write to this config file or directory" {
+                conflicts "--global" "--local"
                 arg <PATH>
             }
             flag "-s --source" help="Source path to use for a single target" {
@@ -446,27 +456,14 @@ desired state. Whole-file entries may symlink, copy, or render templates.
 Edit entries manage a marker-delimited block or a single line in a file
 mise doesn't otherwise own.
 """#
-            after_long_help #"""
-Examples:
-
-    $ mise bootstrap dotfiles apply
-    $ mise bootstrap dotfiles apply --dry-run
-    $ mise bootstrap dotfiles apply --force --yes
-
-"""#
+            after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap dotfiles apply\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles apply --dry-run\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles apply --force --yes\u{1b}[22m\n"
             flag "-f --force" help="Overwrite existing files that conflict with whole-file dotfile entries"
             flag "-n --dry-run" help="Print the actions that would run without writing anything"
             flag "-y --yes" help="Skip the confirmation prompt"
             arg "[TARGET]…" help="Only apply these targets" required=#false var=#true
         }
         cmd edit help="Edit a managed dotfile source" effect=write {
-            after_long_help #"""
-Examples:
-
-    $ mise bootstrap dotfiles edit ~/.zshrc
-    $ mise bootstrap dotfiles edit --apply ~/.config/starship.toml
-
-"""#
+            after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap dotfiles edit ~/.zshrc\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles edit --apply ~/.config/starship.toml\u{1b}[22m\n"
             flag --apply help="Apply this target after the editor exits"
             flag "-m --mode" help="Dotfile mode to use if the target is not yet managed" {
                 arg <MODE>
@@ -478,16 +475,7 @@ Examples:
             arg <TARGET> help="Target to edit"
         }
         cmd status help="Show the status of dotfiles from `[dotfiles]`" effect=read {
-            alias ls
-            after_long_help #"""
-Examples:
-
-    $ mise bootstrap dotfiles status
-    $ mise bootstrap dotfiles status ~/.zshrc
-    $ mise bootstrap dotfiles status --json
-    $ mise bootstrap dotfiles status --missing # exit 1 if anything is out of sync
-
-"""#
+            after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap dotfiles status\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles status ~/.zshrc\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles status --json\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles status --missing\u{1b}[22m # exit 1 if anything is out of sync\n"
             flag "-J --json" help="Output in JSON format"
             flag --missing help=#"""
 Exit with code 1 if any configured dotfiles are not in their desired
@@ -503,15 +491,7 @@ Removes configured whole-file entries and edits while preserving files
 mise cannot identify as managed. Modified copies, templates, and plain-line
 edits require `--force`.
 """#
-            after_long_help #"""
-Examples:
-
-    $ mise bootstrap dotfiles unapply
-    $ mise bootstrap dotfiles unapply ~/.zshrc
-    $ mise bootstrap dotfiles unapply --dry-run
-    $ mise bootstrap dotfiles unapply --force --yes
-
-"""#
+            after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap dotfiles unapply\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles unapply ~/.zshrc\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles unapply --dry-run\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles unapply --force --yes\u{1b}[22m\n"
             flag "-f --force" help="Remove modified or otherwise ambiguous managed files and lines"
             flag "-n --dry-run" help="Print the actions that would run without writing anything"
             flag "-y --yes" help="Skip the confirmation prompt"
@@ -623,22 +603,17 @@ Packages can also be given explicitly in `manager:package` form (e.g.
 the config. Explicit packages and `--manager` scope the run to packages
 only. `install` is accepted as an alias for this command.
 """#
-            after_long_help #"""
-Examples:
-
-    $ mise bootstrap packages apply
-    $ mise bootstrap packages apply apk:zlib-dev apt:curl brew:jq brew-cask:firefox flatpak:org.mozilla.firefox mas:497799835
-    $ mise bootstrap packages apply --dry-run
-    $ mise bootstrap packages apply --manager apt --yes
-
-"""#
+            after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap packages apply\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages apply apk:zlib-dev apt:curl brew:jq brew-cask:firefox flatpak:org.mozilla.firefox flatpak-user:org.gnome.Builder mas:497799835\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages apply --dry-run\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages apply --manager apt --yes\u{1b}[22m\n"
             flag "-m --manager" help="Only install packages for this built-in or plugin manager" {
                 arg <MANAGER>
             }
             flag "-n --dry-run" help="Print the commands that would run without running them"
             flag "-y --yes" help="Skip the confirmation prompt"
             flag --update help="Refresh package manager metadata first (apk: `--update-cache`, apt: `apt-get update`)"
-            arg "[PACKAGE]…" help="Packages in `manager:package` form; defaults to everything configured in [bootstrap.packages]" required=#false var=#true
+            arg "[PACKAGE]…" help="Packages in `manager:package` form; defaults to everything configured in [bootstrap.packages]" help_long=#"""
+Packages in `manager:package` form; defaults to everything configured
+in [bootstrap.packages]
+"""# required=#false var=#true
         }
         cmd brew subcommand_required=#true help="Manage Homebrew taps used by bootstrap packages" effect=read {
             long_help #"""
@@ -648,32 +623,22 @@ These commands edit `[bootstrap.brew.taps]` so tapped formulae and casks
 can be fetched directly by mise without a Homebrew installation.
 """#
             cmd tap help="Add a Homebrew tap URL to [bootstrap.brew.taps]" effect=write {
-                after_long_help #"""
-Examples:
-
-    $ mise bootstrap packages brew tap railwaycat/emacsmacport
-    $ mise bootstrap packages brew tap acme/tools https://github.com/acme/homebrew-tools.git
-
-"""#
+                after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap packages brew tap railwaycat/emacsmacport\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages brew tap acme/tools https://github.com/acme/homebrew-tools.git\u{1b}[22m\n"
                 flag "-l --local" help="Write to the local config instead of the global config"
                 flag "-n --dry-run" help="Print the config change without writing it"
-                flag "-p --path --file" help="Write to this config file or directory" {
+                flag "-p --path --file" help="Write to this config file or directory" conflicts=--local {
                     arg <PATH>
                 }
                 arg <TAP> help="Tap name, e.g. `owner/repo`"
                 arg "[URL]" help="GitHub URL for the tap. Defaults to https://github.com/<owner>/homebrew-<repo>.git" required=#false
+                complete url type=url
             }
             cmd untap help="Remove Homebrew tap URLs from [bootstrap.brew.taps]" effect=write {
                 alias remove rm
-                after_long_help #"""
-Examples:
-
-    $ mise bootstrap packages brew untap railwaycat/emacsmacport
-
-"""#
+                after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap packages brew untap railwaycat/emacsmacport\u{1b}[22m\n"
                 flag "-l --local" help="Write to the local config instead of the global config"
                 flag "-n --dry-run" help="Print the config change without writing it"
-                flag "-p --path --file" help="Write to this config file or directory" {
+                flag "-p --path --file" help="Write to this config file or directory" conflicts=--local {
                     arg <PATH>
                 }
                 arg <TAPS>… help="Tap name(s), e.g. `owner/repo`" var=#true
@@ -687,27 +652,22 @@ Currently supports Homebrew formulae only. By default, imports linked
 formulae whose active keg receipt says they were installed on request.
 Pass `--all` to import every linked formula, including dependencies.
 """#
-            after_long_help #"""
-Examples:
-
-    $ mise bootstrap packages import --manager brew
-    $ mise bootstrap packages import --manager brew --all
-    $ mise bootstrap packages import --manager brew --global
-    $ mise bootstrap packages import --manager brew --dry-run
-
-"""#
+            after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap packages import --manager brew\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages import --manager brew --all\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages import --manager brew --global\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages import --manager brew --dry-run\u{1b}[22m\n"
             flag "-e --env" help="Write to the config file for this environment (mise.<ENV>.toml)" {
+                conflicts "--global" "--path"
                 arg <ENV>
             }
-            flag "-g --global" help="Write to the global config (~/.config/mise/config.toml)"
-            flag "-m --manager" help="Only import packages for this manager. Currently only `brew` is supported" default=brew {
+            flag "-g --global" help="Write to the global config (~/.config/mise/config.toml)" {
+                conflicts "--env" "--path"
+            }
+            flag "-m --manager" help="Only import packages for this manager. Currently only `brew` is supported." default=brew {
                 arg <MANAGER> {
                     choices brew
                 }
             }
             flag --all help="Import every linked formula, including dependencies"
             flag "-n --dry-run" help="Print the config change without writing config"
-            flag "-p --path --file" help="Write to this config file or directory" {
+            flag "-p --path --file" help="Write to this config file or directory" conflicts=--global {
                 arg <PATH>
             }
         }
@@ -715,21 +675,14 @@ Examples:
             long_help #"""
 Prune installed system packages no longer declared in `[bootstrap.packages]`
 
-Currently supports Homebrew formulae only. Pruning removes linked formulae
-that are not needed by the current config or by trusted, loadable tracked
-configs.
+Supports Homebrew formulae and conservatively removable, mise-owned casks.
+Pruning keeps packages needed by the current config or by trusted, loadable
+tracked configs.
 """#
-            after_long_help #"""
-Examples:
-
-    $ mise bootstrap packages prune --manager brew
-    $ mise bootstrap packages prune --manager brew --dry-run
-    $ mise bootstrap packages prune --manager brew --yes
-
-"""#
-            flag "-m --manager" help="Only prune packages for this manager. Currently only `brew` is supported" default=brew {
+            after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap packages prune --manager brew\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages prune --manager brew --dry-run\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages prune --manager brew --yes\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages prune --manager brew-cask --dry-run\u{1b}[22m\n"
+            flag "-m --manager" help="Only prune packages for this manager" default=brew {
                 arg <MANAGER> {
-                    choices brew
+                    choices brew brew-cask
                 }
             }
             flag "-n --dry-run" help="Print what would be removed without deleting anything"
@@ -737,14 +690,7 @@ Examples:
         }
         cmd status help="Show the status of system packages from `[bootstrap.packages]`" effect=read {
             alias ls
-            after_long_help #"""
-Examples:
-
-    $ mise bootstrap packages status
-    $ mise bootstrap packages status --json
-    $ mise bootstrap packages status --missing # exit 1 if anything is out of sync
-
-"""#
+            after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap packages status\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages status --json\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages status --missing\u{1b}[22m # exit 1 if anything is out of sync\n"
             flag "-J --json" help="Output in JSON format"
             flag --missing help="Exit with code 1 if any configured packages are not in their desired state"
         }
@@ -757,29 +703,22 @@ Refreshes package manager metadata and upgrades the configured packages
 that are already installed: apk/apt/dnf/pacman upgrade to the newest available
 version (apk, apt, and dnf honor a version pinned in config), brew pours the
 formula's current bottle and replaces the old keg, brew-cask installs
-the current cask artifact, flatpak updates applications and runtimes, and mas upgrades App Store apps. Packages that
+the current cask artifact, flatpak and flatpak-user update applications and runtimes, and mas upgrades App Store apps. Packages that
 are not installed yet are skipped — use `mise bootstrap packages apply`
 for those.
 
 Packages can also be given explicitly in `manager:package` form.
 """#
-            after_long_help #"""
-Examples:
-
-    $ mise bootstrap packages upgrade
-    $ mise bootstrap packages upgrade brew:postgresql@17
-    $ mise bootstrap packages upgrade --manager brew-cask
-    $ mise bootstrap packages upgrade --manager mas
-    $ mise bootstrap packages upgrade --manager apt --yes
-    $ mise bootstrap packages upgrade --dry-run
-
-"""#
+            after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap packages upgrade\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages upgrade brew:postgresql@17\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages upgrade --manager brew-cask\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages upgrade --manager mas\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages upgrade --manager apt --yes\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages upgrade --dry-run\u{1b}[22m\n"
             flag "-m --manager" help="Only upgrade packages for this built-in or plugin manager" {
                 arg <MANAGER>
             }
             flag "-n --dry-run" help="Print the commands that would run without running them"
             flag "-y --yes" help="Skip the confirmation prompt"
-            arg "[PACKAGE]…" help="Packages in `manager:package` form; defaults to everything configured in [bootstrap.packages]" required=#false var=#true
+            arg "[PACKAGE]…" help="Packages in `manager:package` form; defaults to everything configured in [bootstrap.packages]" help_long=#"""
+Packages in `manager:package` form; defaults to everything configured
+in [bootstrap.packages]
+"""# required=#false var=#true
         }
         cmd use help="Add bootstrap packages to [bootstrap.packages] and install them" effect=write {
             alias u
@@ -796,20 +735,19 @@ version through their names instead (for example `brew:postgresql@17`,
 `brew-cask:temurin@17`), where `@` is part of the Homebrew name rather than
 a mise version selector. mas uses numeric ADAM IDs and does not support pins.
 """#
-            after_long_help #"""
-Examples:
-
-    $ mise bootstrap packages use apk:zlib-dev apt:curl brew:jq brew-cask:firefox flatpak:org.mozilla.firefox mas:497799835
-    $ mise bootstrap packages use -g brew:postgresql@17
-    $ mise bootstrap packages use apt:curl@8.5.0-2
-
-"""#
+            after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap packages use apk:zlib-dev apt:curl brew:jq brew-cask:firefox flatpak:org.mozilla.firefox flatpak-user:org.gnome.Builder mas:497799835\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages use -g brew:postgresql@17\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages use apt:curl@8.5.0-2\u{1b}[22m\n"
             flag "-e --env" help="Write to the config file for this environment (mise.<ENV>.toml)" {
+                conflicts "--global" "--path"
                 arg <ENV>
             }
-            flag "-g --global" help="Write to the global config (~/.config/mise/config.toml) instead of the local one"
+            flag "-g --global" help="Write to the global config (~/.config/mise/config.toml) instead of the local one" {
+                long_help #"""
+Write to the global config (~/.config/mise/config.toml) instead of the
+local one
+"""#
+            }
             flag "-n --dry-run" help="Print the commands that would run without writing config or installing"
-            flag "-p --path --file" help="Write to this config file or directory" {
+            flag "-p --path --file" help="Write to this config file or directory" conflicts=--global {
                 arg <PATH>
             }
             flag "-y --yes" help="Skip the confirmation prompt"
@@ -832,11 +770,16 @@ Examples:
     cmd remote help="Bootstrap one or more machines over OpenSSH" effect=destructive {
         flag --all help="Select every configured inventory host"
         flag --bootstrap-command help="Explicit remote shell command that installs mise and places it on PATH" {
+            conflicts "--mise-bin" "--remote-mise"
             arg <COMMAND>
         }
         flag --connect-timeout help="SSH connection timeout in seconds" default="10" {
             arg <CONNECT_TIMEOUT>
         }
+        flag --copy-link help="Dereference one source-relative symbolic link; repeat for multiple links" var=#true {
+            arg <PATH>
+        }
+        flag --copy-links help="Dereference every symbolic link in the source archive"
         flag --exclude help="Additional archive pattern to exclude; repeat for multiple patterns" var=#true {
             arg <PATTERN>
         }
@@ -851,23 +794,80 @@ Examples:
         flag "-n --dry-run" help="Print the remote bootstrap changes without applying them"
         flag --keep-staging help="Keep the remote staging directory for debugging"
         flag --mise-bin help="Local mise binary to upload (escape hatch for custom architectures)" {
+            conflicts "--remote-mise" "--bootstrap-command"
             arg <MISE_BIN>
         }
-        flag --only help="Run only one or more remote bootstrap parts" var=#true {
-            arg <ONLY> {
-                choices plugins packages accounts files services firewall compose repos dotfiles mise-shell-activate shell macos-defaults defaults macos-launchd-agents launchd linux-systemd-units systemd user tools task final-hook
+        flag --only help="Run only one or more remote bootstrap parts" var=#true conflicts=--skip {
+            arg <ONLY> delimiter=, {
+                choices {
+                    choice plugins
+                    choice packages
+                    choice accounts
+                    choice files
+                    choice services
+                    choice firewall
+                    choice compose
+                    choice repos
+                    choice dotfiles
+                    choice mise-shell-activate {
+                        alias shell hide=#true
+                    }
+                    choice macos-defaults {
+                        alias defaults hide=#true
+                    }
+                    choice macos-launchd-agents {
+                        alias launchd hide=#true
+                    }
+                    choice linux-systemd-units {
+                        alias systemd hide=#true
+                    }
+                    choice user
+                    choice tools
+                    choice task
+                    choice final-hook
+                }
             }
         }
         flag --port help="SSH port override" {
             arg <PORT>
         }
         flag --prompt-secrets help="Prompt securely for missing secret inputs on the remote host"
+        flag --remote-env help="Config environments to load on the remote host; repeat or delimit with commas (for example, ci,dotfiles)" var=#true {
+            arg <ENV> delimiter=,
+        }
         flag --remote-mise help="Existing mise executable name or path; relative paths use the staged project" {
+            conflicts "--mise-bin" "--bootstrap-command"
             arg <COMMAND>
         }
         flag --skip help="Skip one or more remote bootstrap parts" var=#true {
-            arg <SKIP> {
-                choices plugins packages accounts files services firewall compose repos dotfiles mise-shell-activate shell macos-defaults defaults macos-launchd-agents launchd linux-systemd-units systemd user tools task final-hook
+            arg <SKIP> delimiter=, {
+                choices {
+                    choice plugins
+                    choice packages
+                    choice accounts
+                    choice files
+                    choice services
+                    choice firewall
+                    choice compose
+                    choice repos
+                    choice dotfiles
+                    choice mise-shell-activate {
+                        alias shell hide=#true
+                    }
+                    choice macos-defaults {
+                        alias defaults hide=#true
+                    }
+                    choice macos-launchd-agents {
+                        alias launchd hide=#true
+                    }
+                    choice linux-systemd-units {
+                        alias systemd hide=#true
+                    }
+                    choice user
+                    choice tools
+                    choice task
+                    choice final-hook
+                }
             }
         }
         flag --source help="Local directory archived and sent to each target" {
@@ -882,6 +882,10 @@ Examples:
         flag --update help="Refresh package manager metadata and update configured repos remotely"
         flag "-y --yes" help="Skip remote confirmation prompts"
         arg "[TARGET]…" help="Inventory host names from `[bootstrap.remote.hosts]`" required=#false var=#true
+        complete path type=path
+        complete identity_file type=path
+        complete mise_bin type=path
+        complete source type=dir
     }
     cmd repos subcommand_required=#true help="Manage git repo checkouts from `[bootstrap.repos]`" effect=read {
         cmd apply effect=write {
@@ -958,9 +962,13 @@ Run `mise cache` with no args to view the current cache directory.
         alias clean hide=#true
         flag --outdate help="Mark all cache files as old" hide=#true
         flag --task help="Clear output cache entries for a task name or pattern" {
+            conflicts TOOL "--outdate"
             arg <TASK>
         }
-        arg "[TOOL]…" help="Tool(s) to clear cache for e.g.: node, python" required=#false var=#true
+        arg "[TOOL]…" help="Tool(s) to clear cache for e.g.: node, python" help_long=#"""
+Tool(s) to clear cache for
+e.g.: node, python
+"""# required=#false var=#true
     }
     cmd path help="Show the cache directory path" effect=read {
         alias dir
@@ -975,7 +983,10 @@ Change this with the MISE_CACHE_PRUNE_AGE environment variable.
 """#
         flag "-v --verbose" help="Show pruned files" var=#true count=#true
         flag --dry-run help="Just show what would be pruned"
-        arg "[TOOL]…" help="Tool(s) to prune cache for e.g.: node, python" required=#false var=#true
+        arg "[TOOL]…" help="Tool(s) to prune cache for e.g.: node, python" help_long=#"""
+Tool(s) to prune cache for
+e.g.: node, python
+"""# required=#false var=#true
     }
     cmd task help="Inspect output cache entries for a task" effect=read {
         flag "-J --json" help="Output in JSON format"
@@ -984,19 +995,9 @@ Change this with the MISE_CACHE_PRUNE_AGE environment variable.
 }
 cmd completion help="Generate shell completions" effect=read {
     alias complete completions hide=#true
-    after_long_help #"""
-Examples:
-
-    $ mise completion bash --include-bash-completion-lib > ~/.local/share/bash-completion/completions/mise
-    $ mise completion zsh  > /usr/local/share/zsh/site-functions/_mise
-    $ mise completion fish > ~/.config/fish/completions/mise.fish
-    $ mise completion powershell >> $PROFILE
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise completion bash --include-bash-completion-lib > ~/.local/share/bash-completion/completions/mise\u{1b}[22m\n    $ \u{1b}[1mmise completion zsh  > /usr/local/share/zsh/site-functions/_mise\u{1b}[22m\n    $ \u{1b}[1mmise completion fish > ~/.config/fish/completions/mise.fish\u{1b}[22m\n    $ \u{1b}[1mmise completion powershell >> $PROFILE\u{1b}[22m\n"
     flag "-s --shell" help="Shell type to generate completions for" hide=#true {
-        arg <SHELL_TYPE> {
-            choices bash fish powershell zsh
-        }
+        arg <SHELL>
     }
     flag --include-bash-completion-lib help="Include the bash completion library in the bash completion script" {
         long_help #"""
@@ -1020,33 +1021,18 @@ This requires the `usage` CLI to be installed.
 https://usage.jdx.dev
 """#
     }
-    arg "[SHELL]" help="Shell type to generate completions for" required=#false {
-        choices bash fish powershell zsh
-    }
+    arg "[SHELL]" help="Shell type to generate completions for" required=#false required_unless=--shell
 }
 cmd config help="Manage config files" effect=read {
     alias cfg
     alias toml hide=#true
-    after_long_help #"""
-Examples:
-
-    $ mise config ls
-    Path                        Tools
-    ~/.config/mise/config.toml  pitchfork
-    ~/src/mise/mise.toml        actionlint, bun, cargo-binstall, cargo:cargo-insta
-
-"""#
     flag "-J --json" help="Output in JSON format"
-    flag --no-header help="Do not print table header"
+    flag --no-header help="Do not print table header" {
+        alias "--no-headers" hide=#true
+    }
     flag --tracked-configs help="List all tracked config files"
     cmd get help="Display the value of a setting in a mise.toml file" effect=read {
-        after_long_help #"""
-Examples:
-
-    $ mise toml get tools.python
-    3.12
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise toml get tools.python\u{1b}[22m\n    3.12\n"
         flag "-f --file --path" help="The path to the mise.toml file to read" {
             long_help #"""
 The path to the mise.toml file to read
@@ -1058,35 +1044,19 @@ If not provided, the nearest mise.toml file will be used
             arg <FILE>
         }
         arg "[KEY]" help="The path of the config to display" required=#false
+        complete file type=path
     }
     cmd ls help="List config files currently in use" effect=read {
         alias list
-        after_long_help #"""
-Examples:
-
-    $ mise config ls
-    Path                        Tools
-    ~/.config/mise/config.toml  pitchfork
-    ~/src/mise/mise.toml        actionlint, bun, cargo-binstall, cargo:cargo-insta
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise config ls\u{1b}[22m\n    Path                        Tools\n    ~/.config/mise/config.toml  pitchfork\n    ~/src/mise/mise.toml        actionlint, bun, cargo-binstall, cargo:cargo-insta\n"
         flag "-J --json" help="Output in JSON format"
-        flag --no-header help="Do not print table header"
+        flag --no-header help="Do not print table header" {
+            alias "--no-headers" hide=#true
+        }
         flag --tracked-configs help="List all tracked config files"
     }
     cmd set help="Set the value of a setting in a mise.toml file" effect=write {
-        after_long_help #"""
-Examples:
-
-    $ mise config set tools.python 3.12
-    $ mise config set settings.always_keep_download true
-    $ mise config set env.TEST_ENV_VAR ABC
-    $ mise config set settings.disable_tools node,rust
-
-    # Type for `settings` is inferred
-    $ mise config set settings.jobs 4
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise config set tools.python 3.12\u{1b}[22m\n    $ \u{1b}[1mmise config set settings.always_keep_download true\u{1b}[22m\n    $ \u{1b}[1mmise config set env.TEST_ENV_VAR ABC\u{1b}[22m\n    $ \u{1b}[1mmise config set settings.disable_tools node,rust\u{1b}[22m\n\n    # Type for `settings` is inferred\n    $ \u{1b}[1mmise config set settings.jobs 4\u{1b}[22m\n"
         flag "-f --file --path" help="The path to the mise.toml file to edit" {
             long_help #"""
 The path to the mise.toml file to edit
@@ -1099,11 +1069,20 @@ If not provided, the nearest mise.toml file will be used
         }
         flag "-t --type" default=infer {
             arg <TYPE> {
-                choices infer string integer float bool list set
+                choices {
+                    choice infer
+                    choice string
+                    choice integer
+                    choice float
+                    choice bool
+                    choice list
+                    choice set
+                }
             }
         }
         arg <KEY> help="The path of the config to display"
         arg "[VALUE]" help="The value to set the key to (optional if provided as KEY=VALUE)" required=#false
+        complete file type=path
     }
 }
 cmd current hide=#true help="Shows current active and installed runtime versions" effect=read {
@@ -1113,25 +1092,11 @@ Shows current active and installed runtime versions
 This is similar to `mise ls --current`, but this only shows the runtime
 and/or version. It's designed to fit into scripts more easily.
 """#
-    after_long_help #"""
-Examples:
-
-    # outputs `.tool-versions` compatible format
-    $ mise current
-    python 3.11.0 3.10.0
-    shfmt 3.6.0
-    shellcheck 0.9.0
-    node 20.0.0
-
-    $ mise current node
-    20.0.0
-
-    # can output multiple versions
-    $ mise current python
-    3.11.0 3.10.0
-
-"""#
-    arg "[PLUGIN]" help="Plugin to show versions of e.g.: ruby, node, cargo:eza, npm:prettier, etc" required=#false
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # outputs `.tool-versions` compatible format\n    $ \u{1b}[1mmise current\u{1b}[22m\n    python 3.11.0 3.10.0\n    shfmt 3.6.0\n    shellcheck 0.9.0\n    node 20.0.0\n\n    $ \u{1b}[1mmise current node\u{1b}[22m\n    20.0.0\n\n    # can output multiple versions\n    $ \u{1b}[1mmise current python\u{1b}[22m\n    3.11.0 3.10.0\n"
+    arg "[PLUGIN]" help="Plugin to show versions of e.g.: ruby, node, cargo:eza, npm:prettier, etc." help_long=#"""
+Plugin to show versions of
+e.g.: ruby, node, cargo:eza, npm:prettier, etc.
+"""# required=#false
 }
 cmd deactivate help="Disable mise for current shell session" effect=read {
     long_help #"""
@@ -1139,12 +1104,7 @@ Disable mise for current shell session
 
 This can be used to temporarily disable mise in a shell session.
 """#
-    after_long_help #"""
-Examples:
-
-    $ mise deactivate
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise deactivate\u{1b}[22m\n"
 }
 cmd direnv hide=#true help="Output direnv function to use mise inside direnv" effect=read {
     long_help #"""
@@ -1166,14 +1126,7 @@ Because this generates the idiomatic files based on currently installed plugins,
 you should run this command after installing new plugins. Otherwise
 direnv may not know to update environment variables when idiomatic file versions change.
 """#
-        after_long_help #"""
-Examples:
-
-    $ mise direnv activate > ~/.config/direnv/lib/use_mise.sh
-    $ echo 'use mise' > .envrc
-    $ direnv allow
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise direnv activate > ~/.config/direnv/lib/use_mise.sh\u{1b}[22m\n    $ \u{1b}[1mecho 'use mise' > .envrc\u{1b}[22m\n    $ \u{1b}[1mdirenv allow\u{1b}[22m\n"
     }
     cmd envrc hide=#true help=#"""
 [internal] This is an internal command that writes an envrc file
@@ -1198,23 +1151,21 @@ If the target is already managed, this updates its source from the live
 target. Otherwise it creates a `[dotfiles]` entry and seeds the source
 under `dotfiles.root` unless `--source` is provided.
 """#
-        after_long_help #"""
-Examples:
-
-    $ mise bootstrap dotfiles add ~/.zshrc
-    $ mise bootstrap dotfiles add --mode copy ~/.config/starship.toml
-    $ mise bootstrap dotfiles add --source dotfiles/gitconfig ~/.gitconfig
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap dotfiles add ~/.zshrc\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles add --mode copy ~/.config/starship.toml\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles add --source dotfiles/gitconfig ~/.gitconfig\u{1b}[22m\n"
         flag "-f --force" help="Overwrite existing sources without prompting"
-        flag "-g --global" help="Write to the global config"
-        flag "-l --local" help="Write to the local config instead of the global config"
+        flag "-g --global" help="Write to the global config" {
+            conflicts "--local" "--path"
+        }
+        flag "-l --local" help="Write to the local config instead of the global config" {
+            conflicts "--global" "--path"
+        }
         flag "-m --mode" help="Dotfile mode to write" {
             arg <MODE>
         }
         flag "-n --dry-run" help="Print the config/source updates without writing anything"
         flag --no-apply help="Add the entry without applying it"
-        flag "-p --path --file" help="Write to this config file or directory" {
+        flag "-p --path" help="Write to this config file or directory" {
+            conflicts "--global" "--local"
             arg <PATH>
         }
         flag "-s --source" help="Source path to use for a single target" {
@@ -1232,27 +1183,14 @@ desired state. Whole-file entries may symlink, copy, or render templates.
 Edit entries manage a marker-delimited block or a single line in a file
 mise doesn't otherwise own.
 """#
-        after_long_help #"""
-Examples:
-
-    $ mise bootstrap dotfiles apply
-    $ mise bootstrap dotfiles apply --dry-run
-    $ mise bootstrap dotfiles apply --force --yes
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap dotfiles apply\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles apply --dry-run\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles apply --force --yes\u{1b}[22m\n"
         flag "-f --force" help="Overwrite existing files that conflict with whole-file dotfile entries"
         flag "-n --dry-run" help="Print the actions that would run without writing anything"
         flag "-y --yes" help="Skip the confirmation prompt"
         arg "[TARGET]…" help="Only apply these targets" required=#false var=#true
     }
     cmd edit hide=#true help="Edit a managed dotfile source" effect=write {
-        after_long_help #"""
-Examples:
-
-    $ mise bootstrap dotfiles edit ~/.zshrc
-    $ mise bootstrap dotfiles edit --apply ~/.config/starship.toml
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap dotfiles edit ~/.zshrc\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles edit --apply ~/.config/starship.toml\u{1b}[22m\n"
         flag --apply help="Apply this target after the editor exits"
         flag "-m --mode" help="Dotfile mode to use if the target is not yet managed" {
             arg <MODE>
@@ -1265,15 +1203,7 @@ Examples:
     }
     cmd status hide=#true help="Show the status of dotfiles from `[dotfiles]`" effect=read {
         alias ls
-        after_long_help #"""
-Examples:
-
-    $ mise bootstrap dotfiles status
-    $ mise bootstrap dotfiles status ~/.zshrc
-    $ mise bootstrap dotfiles status --json
-    $ mise bootstrap dotfiles status --missing # exit 1 if anything is out of sync
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap dotfiles status\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles status ~/.zshrc\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles status --json\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles status --missing\u{1b}[22m # exit 1 if anything is out of sync\n"
         flag "-J --json" help="Output in JSON format"
         flag --missing help=#"""
 Exit with code 1 if any configured dotfiles are not in their desired
@@ -1289,15 +1219,7 @@ Removes configured whole-file entries and edits while preserving files
 mise cannot identify as managed. Modified copies, templates, and plain-line
 edits require `--force`.
 """#
-        after_long_help #"""
-Examples:
-
-    $ mise bootstrap dotfiles unapply
-    $ mise bootstrap dotfiles unapply ~/.zshrc
-    $ mise bootstrap dotfiles unapply --dry-run
-    $ mise bootstrap dotfiles unapply --force --yes
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap dotfiles unapply\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles unapply ~/.zshrc\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles unapply --dry-run\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles unapply --force --yes\u{1b}[22m\n"
         flag "-f --force" help="Remove modified or otherwise ambiguous managed files and lines"
         flag "-n --dry-run" help="Print the actions that would run without writing anything"
         flag "-y --yes" help="Skip the confirmation prompt"
@@ -1306,26 +1228,11 @@ Examples:
 }
 cmd doctor help="Check mise installation for possible problems" effect=read {
     alias dr
-    after_long_help #"""
-Examples:
-
-    $ mise doctor
-    [WARN] plugin node is not installed
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise doctor\u{1b}[22m\n    [WARN] plugin node is not installed\n"
     flag "-J --json"
     cmd path help="Print the current PATH entries mise is providing" effect=read {
         alias paths hide=#true
-        after_long_help #"""
-Examples:
-
-    Get the current PATH entries mise is providing
-    $ mise doctor path
-    /home/user/.local/share/mise/installs/node/24.0.0/bin
-    /home/user/.local/share/mise/installs/rust/1.90.0/bin
-    /home/user/.local/share/mise/installs/python/3.10.0/bin
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    Get the current PATH entries mise is providing\n    $ mise doctor path\n    /home/user/.local/share/mise/installs/node/24.0.0/bin\n    /home/user/.local/share/mise/installs/rust/1.90.0/bin\n    /home/user/.local/share/mise/installs/python/3.10.0/bin\n"
         flag "-f --full" help="Print all entries including those not provided by mise"
     }
 }
@@ -1337,20 +1244,7 @@ This is an alternative to `mise activate` that allows you to explicitly start a 
 It will have the tools and environment variables in the configs loaded.
 Note that changing directories will not update the mise environment.
 """#
-    after_long_help #"""
-Examples:
-
-    $ mise en .
-    $ node -v
-    v20.0.0
-
-    Skip loading bashrc:
-    $ mise en -s "bash --norc"
-
-    Skip loading zshrc:
-    $ mise en -s "zsh -f"
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise en .\u{1b}[22m\n    $ \u{1b}[1mnode -v\u{1b}[22m\n    v20.0.0\n\n    Skip loading bashrc:\n    $ \u{1b}[1mmise en -s \"bash --norc\"\u{1b}[22m\n\n    Skip loading zshrc:\n    $ \u{1b}[1mmise en -s \"zsh -f\"\u{1b}[22m\n"
     flag "-s --shell" help="Shell to start" {
         long_help #"""
 Shell to start
@@ -1360,6 +1254,7 @@ Defaults to $SHELL
         arg <SHELL>
     }
     arg "[DIR]" help="Directory to start the shell in" required=#false default=.
+    complete dir type=dir
 }
 cmd env help="Exports env vars to activate mise a single time" effect=read {
     alias e
@@ -1369,23 +1264,13 @@ Exports env vars to activate mise a single time
 Use this if you don't want to permanently install mise. It's not necessary to
 use this if you have `mise activate` in your shell rc file.
 """#
-    after_long_help #"""
-Examples:
-
-    $ eval "$(mise env -s bash)"
-    $ eval "$(mise env -s zsh)"
-    $ mise env -s fish | source
-    $ execx($(mise env -s xonsh))
-
-"""#
-    flag "-D --dotenv" help="Output in dotenv format"
-    flag "-J --json" help="Output in JSON format"
-    flag "-s --shell" help="Shell type to generate environment variables for" {
-        arg <SHELL> {
-            choices bash elvish fish nu xonsh zsh pwsh
-        }
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1meval \"$(mise env -s bash)\"\u{1b}[22m\n    $ \u{1b}[1meval \"$(mise env -s zsh)\"\u{1b}[22m\n    $ \u{1b}[1mmise env -s fish | source\u{1b}[22m\n    $ \u{1b}[1mexecx($(mise env -s xonsh))\u{1b}[22m\n"
+    flag "-D --dotenv" help="Output in dotenv format" overrides=--shell
+    flag "-J --json" help="Output in JSON format" overrides=--shell
+    flag "-s --shell" help="Shell type to generate environment variables for" overrides=--json {
+        arg <SHELL>
     }
-    flag --json-extended help="Output in JSON format with additional information (source, tool)"
+    flag --json-extended help="Output in JSON format with additional information (source, tool)" overrides=--shell
     flag --redacted help="Only show redacted environment variables"
     flag --values help="Only show values of environment variables"
     arg "[TOOL@VERSION]…" help="Tool(s) to use" required=#false var=#true
@@ -1403,26 +1288,15 @@ includes "node 20" but you run `mise exec python@3.11`; it will still load node@
 
 The "--" separates runtimes from the commands to pass along to the subprocess.
 """#
-    after_long_help #"""
-Examples:
-
-    $ mise exec node@20 -- node ./app.js  # launch app.js using node-20.x
-    $ mise x node@20 -- node ./app.js     # shorter alias
-
-    # Specify command as a string:
-    $ mise exec node@20 python@3.11 --command "node -v && python -V"
-
-    # Run a command in a different directory:
-    $ mise x -C /path/to/project node@20 -- node ./app.js
-
-"""#
-    flag "-c --command" help="Command string to execute" {
-        arg <C>
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise exec node@20 -- node ./app.js\u{1b}[22m  # launch app.js using node-20.x\n    $ \u{1b}[1mmise x node@20 -- node ./app.js\u{1b}[22m     # shorter alias\n\n    # Specify command as a string:\n    $ \u{1b}[1mmise exec node@20 python@3.11 --command \"node -v && python -V\"\u{1b}[22m\n\n    # Run a command in a different directory:\n    $ \u{1b}[1mmise x -C /path/to/project node@20 -- node ./app.js\u{1b}[22m\n"
+    flag "-c --command" help="Command string to execute" conflicts=COMMAND {
+        arg <COMMAND>
     }
     flag "-j --jobs" help=#"""
 Number of jobs to run in parallel
+Values below 1 are treated as 1
 [default: 4]
-"""# {
+"""# env=MISE_JOBS {
         arg <JOBS>
     }
     flag --allow-env help=#"""
@@ -1450,9 +1324,18 @@ macOS only in v1; on Linux falls back to allowing all network
     flag --deny-write help="Block all filesystem writes"
     flag --fresh-env help="Bypass the environment cache and recompute the environment"
     flag --no-deps help="Skip automatic dependency preparation"
-    flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1"
-    arg "[TOOL@VERSION]…" help="Tool(s) to start e.g.: node@20 python@3.10" required=#false var=#true
-    arg "[-- COMMAND]…" help="Command string to execute (same as --command)" required=#false var=#true
+    flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1" overrides=--jobs {
+        long_help #"""
+Connect backend install command stdin/stdout/stderr directly to the terminal
+Implies --jobs=1
+"""#
+    }
+    arg "[TOOL@VERSION]…" help="Tool(s) to start e.g.: node@20 python@3.10" help_long=#"""
+Tool(s) to start
+e.g.: node@20 python@3.10
+"""# required=#false var=#true
+    arg "[-- COMMAND]…" help="Command string to execute (same as --command)" required=#false var=#true conflicts=--command required_unless=--command
+    complete command type=command
 }
 cmd fmt help="Formats mise.toml" effect=write {
     long_help #"""
@@ -1460,15 +1343,15 @@ Formats mise.toml
 
 Sorts keys and cleans up whitespace in mise.toml
 """#
-    after_long_help #"""
-Examples:
-
-    $ mise fmt
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise fmt\u{1b}[22m\n"
     flag "-a --all" help="Format all files from the current directory"
     flag "-c --check" help="Check if the configs are formatted, no formatting is done"
-    flag "-s --stdin" help="Read config from stdin and write its formatted version into stdout"
+    flag "-s --stdin" help="Read config from stdin and write its formatted version into stdout" {
+        long_help #"""
+Read config from stdin and write its formatted version into
+stdout
+"""#
+    }
 }
 cmd generate subcommand_required=#true help="Generate files for various tools/services" effect=read {
     alias gen
@@ -1479,14 +1362,7 @@ Generate a script to download+execute mise
 
 This is designed to be used in a project where contributors may not have mise installed.
 """#
-        after_long_help #"""
-Examples:
-
-    $ mise generate bootstrap >./bin/mise
-    $ chmod +x ./bin/mise
-    $ ./bin/mise install – automatically downloads mise to .mise if not already installed
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise generate bootstrap --write ./bin/mise\u{1b}[22m\n    $ \u{1b}[1m./bin/mise install\u{1b}[22m                                    \u{1b}[2m# downloads mise to .mise if not already installed\u{1b}[22m\n\n    \u{1b}[2m# add a launcher for contributors who clone the project on Windows\u{1b}[22m\n    $ \u{1b}[1mmise generate bootstrap --write ./bin/mise --windows\u{1b}[22m  \u{1b}[2m# also writes bin/mise.cmd\u{1b}[22m\n    $ \u{1b}[1m.\\bin\\mise.cmd install\u{1b}[22m\n"
         flag "-l --localize" help="Sandboxes mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a `.mise` directory in the project" {
             long_help #"""
 Sandboxes mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a `.mise` directory in the project
@@ -1497,38 +1373,39 @@ This is necessary if users may use a different version of mise outside the proje
         flag "-V --version" help="Specify mise version to fetch" {
             arg <VERSION>
         }
-        flag "-w --write" help="instead of outputting the script to stdout, write to a file and make it executable" {
-            arg <WRITE>
+        flag "-w --write" help="instead of outputting the script to stdout, write to a file and make it executable" value_optional=#true default_missing="./bin/mise" {
+            arg "[WRITE]" required=#false var_min=0 var_max=1
         }
         flag --localized-dir help="Directory to put localized data into" default=.mise {
             arg <LOCALIZED_DIR>
         }
+        flag --windows help="Also write a Windows launcher, `<WRITE>.cmd`" requires=--write {
+            long_help #"""
+Also write a Windows launcher, `<WRITE>.cmd`
+
+Windows cannot execute the `#!/usr/bin/env bash` script, so a contributor who clones the
+project on Windows has nothing to run without this.
+
+Generated on every host, not only on Windows: the file is committed, and whoever runs it
+on Windows is not the person who generated it. Requires `--write`, since stdout cannot
+carry two files.
+"""#
+        }
+        complete localized_dir type=dir
     }
     cmd config help="Generate a mise.toml file" effect=write {
-        after_long_help #"""
-Examples:
-
-    $ mise generate config             # generate mise.toml interactively
-    $ mise generate config .mise.toml  # generate a specific file
-    $ mise generate config -g          # generate the global config file
-    $ mise generate config -y          # skip interactive editor
-    $ mise generate config -n          # preview without writing
-
-"""#
-        flag "-g --global" help="Generate the global config file (~/.config/mise/config.toml)"
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise generate config\u{1b}[22m             \u{1b}[2m# generate mise.toml interactively\u{1b}[22m\n    $ \u{1b}[1mmise generate config .mise.toml\u{1b}[22m  \u{1b}[2m# generate a specific file\u{1b}[22m\n    $ \u{1b}[1mmise generate config -g\u{1b}[22m          \u{1b}[2m# generate the global config file\u{1b}[22m\n    $ \u{1b}[1mmise generate config -y\u{1b}[22m          \u{1b}[2m# skip interactive editor\u{1b}[22m\n    $ \u{1b}[1mmise generate config -n\u{1b}[22m          \u{1b}[2m# preview without writing\u{1b}[22m\n"
+        flag "-g --global" help="Generate the global config file (~/.config/mise/config.toml)" conflicts=PATH
         flag "-n --dry-run" help="Show what would be generated without writing to file"
         flag "-t --tool-versions" help="Path to a .tool-versions file to import tools from" {
             arg <TOOL_VERSIONS>
         }
         arg "[PATH]" help="Path to the config file to create" required=#false
+        complete path type=path
+        complete tool_versions type=path
     }
     cmd devcontainer help="Generate a devcontainer to execute mise" effect=write {
-        after_long_help #"""
-Examples:
-
-    $ mise generate devcontainer
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise generate devcontainer\u{1b}[22m\n"
         flag "-i --image" help="The image to use for the devcontainer" {
             arg <IMAGE>
         }
@@ -1550,13 +1427,7 @@ Staged files are passed to the task as `STAGED`.
 
 For more advanced pre-commit functionality, see mise's sister project: https://hk.jdx.dev/
 """#
-        after_long_help #"""
-Examples:
-
-    $ mise generate git-pre-commit --write --task=pre-commit
-    $ git commit -m "feat: add new feature" # runs `mise run pre-commit`
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise generate git-pre-commit --write --task=pre-commit\u{1b}[22m\n    $ \u{1b}[1mgit commit -m \"feat: add new feature\"\u{1b}[22m \u{1b}[2m# runs `mise run pre-commit`\u{1b}[22m\n\n    \u{1b}[2m# config lives in a subdirectory, so the hook has to change into it first\u{1b}[22m\n    $ \u{1b}[1mmise generate git-pre-commit --write -- -C subdir\u{1b}[22m\n"
         flag "-t --task" help="The task to run when the pre-commit hook is triggered" default=pre-commit {
             arg <TASK>
         }
@@ -1564,6 +1435,13 @@ Examples:
         flag --hook help="Which hook to generate (saves to .git/hooks/$hook)" default=pre-commit {
             arg <HOOK>
         }
+        arg "[-- MISE_ARG]…" help="mise flags to embed in the generated hook, given after `--`" help_long=#"""
+mise flags to embed in the generated hook, given after `--`
+
+These are inserted between `mise` and `run`, so the hook carries the same context you
+would pass on the command line. Useful when the config is not at the repository root,
+since git runs hooks from the top level: `-- -C subdir` makes the hook find it.
+"""# required=#false var=#true
     }
     cmd github-action help="Generate a GitHub Action workflow file" effect=write {
         long_help #"""
@@ -1572,14 +1450,7 @@ Generate a GitHub Action workflow file
 This command generates a GitHub Action workflow file that runs a mise task like `mise run ci`
 when you push changes to your repository.
 """#
-        after_long_help #"""
-Examples:
-
-    $ mise generate github-action --write --task=ci
-    $ git commit -m "feat: add new feature"
-    $ git push # runs `mise run ci` on GitHub
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise generate github-action --write --task=ci\u{1b}[22m\n    $ \u{1b}[1mgit commit -m \"feat: add new feature\"\u{1b}[22m\n    $ \u{1b}[1mgit push\u{1b}[22m \u{1b}[2m# runs `mise run ci` on GitHub\u{1b}[22m\n"
         flag "-t --task" help="The task to run when the workflow is triggered" default=ci {
             arg <TASK>
         }
@@ -1589,12 +1460,7 @@ Examples:
         }
     }
     cmd task-docs help="Generate documentation for tasks in a project" effect=write {
-        after_long_help #"""
-Examples:
-
-    $ mise generate task-docs
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise generate task-docs\u{1b}[22m\n"
         flag "-i --inject" help="inserts the documentation into an existing file" {
             long_help #"""
 inserts the documentation into an existing file
@@ -1615,9 +1481,13 @@ The file must already contain both comments; mise errors instead of modifying th
         }
         flag "-s --style" default=simple {
             arg <STYLE> {
-                choices simple detailed
+                choices {
+                    choice simple
+                    choice detailed
+                }
             }
         }
+        complete root type=dir
     }
     cmd task-stubs help="Generates shims to run mise tasks" effect=write {
         long_help #"""
@@ -1625,16 +1495,9 @@ Generates shims to run mise tasks
 
 By default, this will build shims like ./bin/<task>. These can be paired with `mise generate bootstrap`
 so contributors to a project can execute mise tasks without installing mise into their system.
+When a parent and nested task both exist, the parent stub is written to `<parent>/_default`.
 """#
-        after_long_help #"""
-Examples:
-
-    $ mise tasks add test -- echo 'running tests'
-    $ mise generate task-stubs
-    $ ./bin/test
-    running tests
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise tasks add test -- echo 'running tests'\u{1b}[22m\n    $ \u{1b}[1mmise generate task-stubs\u{1b}[22m\n    $ \u{1b}[1m./bin/test\u{1b}[22m\n    running tests\n"
         flag "-d --dir" help="Directory to create task stubs inside of" default=bin {
             arg <DIR>
         }
@@ -1646,6 +1509,7 @@ Use `--mise-bin=./bin/mise` to use a mise bin generated from `mise generate boot
 """#
             arg <MISE_BIN>
         }
+        complete dir type=dir
     }
     cmd tool-stub help="Generate a tool stub for HTTP-based tools" effect=write {
         long_help #"""
@@ -1659,57 +1523,7 @@ When generating stubs with platform-specific URLs, the command will append new
 platforms to existing stub files rather than overwriting them. This allows you
 to incrementally build cross-platform tool stubs.
 """#
-        after_long_help #"""
-Examples:
-
-    Generate a tool stub for a single URL:
-    $ mise generate tool-stub ./bin/gh --url "https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_linux_amd64.tar.gz"
-
-    Generate a tool stub with platform-specific URLs:
-    $ mise generate tool-stub ./bin/rg \
-        --platform-url linux-x64:https://github.com/BurntSushi/ripgrep/releases/download/14.0.3/ripgrep-14.0.3-x86_64-unknown-linux-musl.tar.gz \
-        --platform-url darwin-arm64:https://github.com/BurntSushi/ripgrep/releases/download/14.0.3/ripgrep-14.0.3-aarch64-apple-darwin.tar.gz
-
-    Append additional platforms to an existing stub:
-    $ mise generate tool-stub ./bin/rg \
-        --platform-url linux-x64:https://example.com/rg-linux.tar.gz
-    $ mise generate tool-stub ./bin/rg \
-        --platform-url darwin-arm64:https://example.com/rg-darwin.tar.gz
-    # The stub now contains both platforms
-
-    Use auto-detection for platform from URL:
-    $ mise generate tool-stub ./bin/node \
-        --platform-url https://nodejs.org/dist/v22.17.1/node-v22.17.1-darwin-arm64.tar.gz
-    # Platform 'macos-arm64' will be auto-detected from the URL
-
-    Generate with platform-specific binary paths:
-    $ mise generate tool-stub ./bin/tool \
-        --platform-url linux-x64:https://example.com/tool-linux.tar.gz \
-        --platform-url windows-x64:https://example.com/tool-windows.zip \
-        --platform-bin windows-x64:tool.exe
-
-    Generate without downloading (faster):
-    $ mise generate tool-stub ./bin/tool --url "https://example.com/tool.tar.gz" --skip-download
-
-    Fetch checksums for an existing stub:
-    $ mise generate tool-stub ./bin/jq --fetch
-    # This will read the existing stub and download files to fill in any missing checksums/sizes
-
-    Generate a bootstrap stub that installs mise if needed:
-    $ mise generate tool-stub ./bin/tool --url "https://example.com/tool.tar.gz" --bootstrap
-    # The stub will check for mise and install it automatically before running the tool
-
-    Generate a bootstrap stub with a pinned mise version:
-    $ mise generate tool-stub ./bin/tool --url "https://example.com/tool.tar.gz" --bootstrap --bootstrap-version 2025.1.0
-
-    Lock an existing tool stub with pinned version and platform URLs/checksums:
-    $ mise generate tool-stub ./bin/node --lock
-
-    Bump the version in a locked stub:
-    $ mise generate tool-stub ./bin/node --lock --version 22
-    # Resolves the latest node 22.x, pins it, and updates platform URLs/checksums
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    Generate a tool stub for a single URL:\n    $ \u{1b}[1mmise generate tool-stub ./bin/gh --url \"https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_linux_amd64.tar.gz\"\u{1b}[22m\n\n    Generate a tool stub with platform-specific URLs:\n    $ \u{1b}[1mmise generate tool-stub ./bin/rg \\\n        --platform-url linux-x64:https://github.com/BurntSushi/ripgrep/releases/download/14.0.3/ripgrep-14.0.3-x86_64-unknown-linux-musl.tar.gz \\\n        --platform-url darwin-arm64:https://github.com/BurntSushi/ripgrep/releases/download/14.0.3/ripgrep-14.0.3-aarch64-apple-darwin.tar.gz\u{1b}[22m\n\n    Append additional platforms to an existing stub:\n    $ \u{1b}[1mmise generate tool-stub ./bin/rg \\\n        --platform-url linux-x64:https://example.com/rg-linux.tar.gz\u{1b}[22m\n    $ \u{1b}[1mmise generate tool-stub ./bin/rg \\\n        --platform-url darwin-arm64:https://example.com/rg-darwin.tar.gz\u{1b}[22m\n    # The stub now contains both platforms\n\n    Use auto-detection for platform from URL:\n    $ \u{1b}[1mmise generate tool-stub ./bin/node \\\n        --platform-url https://nodejs.org/dist/v22.17.1/node-v22.17.1-darwin-arm64.tar.gz\u{1b}[22m\n    # Platform 'macos-arm64' will be auto-detected from the URL\n\n    Generate with platform-specific binary paths:\n    $ \u{1b}[1mmise generate tool-stub ./bin/tool \\\n        --platform-url linux-x64:https://example.com/tool-linux.tar.gz \\\n        --platform-url windows-x64:https://example.com/tool-windows.zip \\\n        --platform-bin windows-x64:tool.exe\u{1b}[22m\n\n    Generate without downloading (faster):\n    $ \u{1b}[1mmise generate tool-stub ./bin/tool --url \"https://example.com/tool.tar.gz\" --skip-download\u{1b}[22m\n\n    Fetch checksums for an existing stub:\n    $ \u{1b}[1mmise generate tool-stub ./bin/jq --fetch\u{1b}[22m\n    # This will read the existing stub and download files to fill in any missing checksums/sizes\n\n    Generate a bootstrap stub that installs mise if needed:\n    $ \u{1b}[1mmise generate tool-stub ./bin/tool --url \"https://example.com/tool.tar.gz\" --bootstrap\u{1b}[22m\n    # The stub will check for mise and install it automatically before running the tool\n\n    Generate a bootstrap stub with a pinned mise version:\n    $ \u{1b}[1mmise generate tool-stub ./bin/tool --url \"https://example.com/tool.tar.gz\" --bootstrap --bootstrap-version 2025.1.0\u{1b}[22m\n\n    Lock an existing tool stub with pinned version and platform URLs/checksums:\n    $ \u{1b}[1mmise generate tool-stub ./bin/node --lock\u{1b}[22m\n\n    Bump the version in a locked stub:\n    $ \u{1b}[1mmise generate tool-stub ./bin/node --lock --version 22\u{1b}[22m\n    # Resolves the latest node 22.x, pins it, and updates platform URLs/checksums\n"
         flag "-b --bin" help="Binary path within the extracted archive" {
             long_help #"""
 Binary path within the extracted archive
@@ -1728,7 +1542,7 @@ When enabled, generates a bash script that:
 3. Executes the tool stub using mise
 """#
         }
-        flag --bootstrap-version help="Specify mise version for the bootstrap script" {
+        flag --bootstrap-version help="Specify mise version for the bootstrap script" requires=--bootstrap {
             long_help #"""
 Specify mise version for the bootstrap script
 
@@ -1737,17 +1551,41 @@ Use this to pin to a specific version (e.g., "2025.1.0").
 """#
             arg <BOOTSTRAP_VERSION>
         }
+        flag --checksum-algorithm help="Checksum algorithm to use when downloading artifacts" default=blake3 {
+            long_help #"""
+Checksum algorithm to use when downloading artifacts
+
+Accepts `blake3` or `sha256` and defaults to `blake3`.
+Cannot be used with `--lock` or `--skip-download` because those modes do not
+calculate checksums.
+"""#
+            conflicts "--lock" "--skip-download"
+            arg <CHECKSUM_ALGORITHM> {
+                choices {
+                    choice blake3
+                    choice sha256
+                }
+            }
+        }
         flag --fetch help="Fetch checksums and sizes for an existing tool stub file" {
             long_help #"""
 Fetch checksums and sizes for an existing tool stub file
 
-This reads an existing stub file and fills in any missing checksum/size fields by downloading the files. URLs must already be present in the stub.
+This reads an existing stub file and fills in any missing checksum/size fields
+by downloading the files. URLs must already be present in the stub.
 """#
+            conflicts "--url" "--platform-url" "--version" "--bin" "--platform-bin" "--skip-download" "--lock"
         }
         flag --http help="HTTP backend type to use" default=http {
             arg <HTTP>
         }
-        flag --lock help="Resolve and embed lockfile data (exact version + platform URLs/checksums) into an existing stub file for reproducible installs without runtime API calls"
+        flag --lock help="Resolve and embed lockfile data (exact version + platform URLs/checksums) into an existing stub file for reproducible installs without runtime API calls" {
+            long_help #"""
+Resolve and embed lockfile data (exact version + platform URLs/checksums)
+into an existing stub file for reproducible installs without runtime API calls
+"""#
+            conflicts "--url" "--platform-url" "--bin" "--platform-bin" "--fetch" "--skip-download"
+        }
         flag --platform-bin help="Platform-specific binary paths in the format platform:path" var=#true {
             long_help #"""
 Platform-specific binary paths in the format platform:path
@@ -1760,11 +1598,15 @@ Examples: --platform-bin windows-x64:tool.exe --platform-bin linux-x64:bin/tool
             long_help #"""
 Platform-specific URLs in the format platform:url or just url (auto-detect platform)
 
-When the output file already exists, new platforms will be appended to the existing platforms table. Existing platform URLs will be updated if specified again.
+When the output file already exists, new platforms will be appended to the existing
+platforms table. Existing platform URLs will be updated if specified again.
 
-If only a URL is provided (without platform:), the platform will be automatically detected from the URL filename.
+If only a URL is provided (without platform:), the platform will be automatically
+detected from the URL filename.
 
-Examples: --platform-url linux-x64:https://... --platform-url https://nodejs.org/dist/v22.17.1/node-v22.17.1-darwin-arm64.tar.gz
+Examples:
+--platform-url linux-x64:https://...
+--platform-url https://nodejs.org/dist/v22.17.1/node-v22.17.1-darwin-arm64.tar.gz
 """#
             arg <PLATFORM_URL>
         }
@@ -1781,6 +1623,7 @@ Example: https://github.com/owner/repo/releases/download/v2.0.0/tool-linux-x64.t
             arg <VERSION>
         }
         arg <OUTPUT> help="Output file path for the tool stub"
+        complete output type=path
     }
 }
 cmd github hide=#true subcommand_required=#true help="GitHub related commands" effect=read {
@@ -1791,22 +1634,15 @@ Display the GitHub token mise will use for a given host
 Shows which token source mise would use, useful for debugging
 authentication issues. The token is masked by default.
 """#
-        after_long_help #"""
-Examples:
-
-    $ mise github token
-    github.com: ghp_…xxxx (source: GITHUB_TOKEN)
-
-    $ mise github token --unmask
-    github.com: ghp_xxxxxxxxxxxx (source: GITHUB_TOKEN)
-
-    $ mise github token github.mycompany.com
-    github.mycompany.com: (none)
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise github token\u{1b}[22m\n    github.com: ghp_…xxxx (source: GITHUB_TOKEN)\n\n    $ \u{1b}[1mmise github token --unmask\u{1b}[22m\n    github.com: ghp_xxxxxxxxxxxx (source: GITHUB_TOKEN)\n\n    $ \u{1b}[1mmise github token github.mycompany.com\u{1b}[22m\n    github.mycompany.com: (none)\n"
         flag --oauth help="Force native GitHub OAuth device flow instead of normal token resolution"
         flag --raw help="Print only the token value"
-        flag --refresh help="Mint a fresh OAuth token even if the cached one has not expired, via the refresh-token grant or a new device-code flow"
+        flag --refresh help="Mint a fresh OAuth token even if the cached one has not expired, via the refresh-token grant or a new device-code flow" requires=--oauth {
+            long_help #"""
+Mint a fresh OAuth token even if the cached one has not
+expired, via the refresh-token grant or a new device-code flow
+"""#
+        }
         flag --unmask help="Show the full unmasked token"
         arg "[HOST]" help="GitHub hostname" required=#false default=github.com
     }
@@ -1824,32 +1660,19 @@ Use MISE_ASDF_COMPAT=1 to default the global config to ~/.tool-versions
 
 Use `mise local` to set a tool version locally in the current directory.
 """#
-    after_long_help #"""
-Examples:
-    # set the current version of node to 20.x
-    # will use a fuzzy version (e.g.: 20) in .tool-versions file
-    $ mise global --fuzzy node@20
-
-    # set the current version of node to 20.x
-    # will use a precise version (e.g.: 20.0.0) in .tool-versions file
-    $ mise global --pin node@20
-
-    # show the current version of node in ~/.tool-versions
-    $ mise global node
-    20.0.0
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n    # set the current version of node to 20.x\n    # will use a fuzzy version (e.g.: 20) in .tool-versions file\n    $ \u{1b}[1mmise global --fuzzy node@20\u{1b}[22m\n\n    # set the current version of node to 20.x\n    # will use a precise version (e.g.: 20.0.0) in .tool-versions file\n    $ \u{1b}[1mmise global --pin node@20\u{1b}[22m\n\n    # show the current version of node in ~/.tool-versions\n    $ \u{1b}[1mmise global node\u{1b}[22m\n    20.0.0\n"
     flag --fuzzy help=#"""
 Save fuzzy version to `~/.tool-versions`
 e.g.: `mise global --fuzzy node@20` will save `node 20` to ~/.tool-versions
 this is the default behavior unless MISE_ASDF_COMPAT=1
-"""#
+"""# overrides=--pin
     flag --path help="Get the path of the global config file"
     flag --pin help=#"""
 Save exact version to `~/.tool-versions`
 e.g.: `mise global --pin node@20` will save `node 20.0.0` to ~/.tool-versions
-"""#
+"""# overrides=--fuzzy
     flag --remove help="Remove the tool(s) from ~/.tool-versions" var=#true {
+        alias "--rm" "--unset" hide=#true
         arg <TOOL>
     }
     arg "[TOOL@VERSION]…" help=#"""
@@ -1863,22 +1686,21 @@ cmd hook-env hide=#true help="[internal] called by activate hook to update env v
     flag "-f --force" help="Skip early exit check"
     flag "-q --quiet" help="Hide warnings such as when a tool is not installed"
     flag "-s --shell" help="Shell type to generate script for" {
-        arg <SHELL> {
-            choices bash elvish fish nu xonsh zsh pwsh
-        }
+        arg <SHELL>
     }
     flag --reason help="Reason for calling hook-env (e.g., \"precmd\", \"chpwd\")" hide=#true {
         arg <REASON> {
-            choices precmd chpwd
+            choices {
+                choice precmd
+                choice chpwd
+            }
         }
     }
     flag --status help="Show \"mise: <TOOL>@<VERSION>\" message when changing directories" hide=#true
 }
 cmd hook-not-found hide=#true help="[internal] called by shell when a command is not found" effect=write {
     flag "-s --shell" help="Shell type to generate script for" {
-        arg <SHELL> {
-            choices bash elvish fish nu xonsh zsh pwsh
-        }
+        arg <SHELL>
     }
     arg <BIN> help="Attempted bin to run"
 }
@@ -1892,22 +1714,15 @@ Skips config directory by default.
     flag --config help="Also remove config directory"
 }
 cmd edit help="Edit mise.toml interactively" effect=write {
-    after_long_help #"""
-Examples:
-
-    $ mise edit             # edit mise.toml interactively
-    $ mise edit .mise.toml  # edit a specific file
-    $ mise edit -g          # edit the global config file
-    $ mise edit -y          # skip interactive editor
-    $ mise edit -n          # preview without writing
-
-"""#
-    flag "-g --global" help="Edit the global config file (~/.config/mise/config.toml)"
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise edit\u{1b}[22m             \u{1b}[2m# edit mise.toml interactively\u{1b}[22m\n    $ \u{1b}[1mmise edit .mise.toml\u{1b}[22m  \u{1b}[2m# edit a specific file\u{1b}[22m\n    $ \u{1b}[1mmise edit -g\u{1b}[22m          \u{1b}[2m# edit the global config file\u{1b}[22m\n    $ \u{1b}[1mmise edit -y\u{1b}[22m          \u{1b}[2m# skip interactive editor\u{1b}[22m\n    $ \u{1b}[1mmise edit -n\u{1b}[22m          \u{1b}[2m# preview without writing\u{1b}[22m\n"
+    flag "-g --global" help="Edit the global config file (~/.config/mise/config.toml)" conflicts=PATH
     flag "-n --dry-run" help="Show what would be generated without writing to file"
     flag "-t --tool-versions" help="Path to a .tool-versions file to import tools from" {
         arg <TOOL_VERSIONS>
     }
     arg "[PATH]" help="Path to the config file to create" required=#false
+    complete path type=path
+    complete tool_versions type=path
 }
 cmd install help="Install a tool version" effect=write {
     alias i
@@ -1922,20 +1737,16 @@ Alternatively, run `mise exec <TOOL>@<VERSION> -- <COMMAND>` to execute a tool w
 
 Tools will be installed in parallel. To disable, set `--jobs=1` or `MISE_JOBS=1`
 """#
-    after_long_help #"""
-Examples:
-
-    $ mise install node@20.0.0  # install specific node version
-    $ mise install node@20      # install fuzzy node version
-    $ mise install node         # install version specified in mise.toml
-    $ mise install              # installs everything specified in mise.toml
-
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise install node@20.0.0\u{1b}[22m  # install specific node version\n    $ \u{1b}[1mmise install node@20\u{1b}[22m      # install fuzzy node version\n    $ \u{1b}[1mmise install node\u{1b}[22m         # install version specified in mise.toml\n    $ \u{1b}[1mmise install\u{1b}[22m              # installs everything specified in mise.toml\n    $ \u{1b}[1mmise install --include-task-tools\u{1b}[22m # also install tools required by tasks\n"
+    flag "-f --force" help=#"""
+Force reinstall even if already installed
+With no tools specified, reinstall all configured tools
 """#
-    flag "-f --force" help="Force reinstall even if already installed"
     flag "-j --jobs" help=#"""
 Number of jobs to run in parallel
+Values below 1 are treated as 1
 [default: 4]
-"""# {
+"""# env=MISE_JOBS {
         arg <JOBS>
     }
     flag "-n --dry-run" help="Show what would be installed without actually installing"
@@ -1953,7 +1764,16 @@ Like --dry-run but exits with code 1 if there are tools to install
 This is useful for scripts to check if tools need to be installed.
 """#
     }
+    flag --include-task-tools help="Also install tools required by tasks in the current scope" {
+        long_help #"""
+Also install tools required by tasks in the current scope
+
+This prepares task tools without running task commands or dependencies.
+Combine with --monorepo to include tasks from every configured root.
+"""#
+    }
     flag --minimum-release-age help="Only install versions released before this date or older than this duration" {
+        alias "--before" hide=#true
         long_help #"""
 Only install versions released before this date or older than this duration
 
@@ -1961,7 +1781,7 @@ Supports absolute dates like "2024-06-01" and relative durations like "90d" or "
 """#
         arg <MINIMUM_RELEASE_AGE>
     }
-    flag --monorepo help="Install tools from every [monorepo].config_roots config root" {
+    flag --monorepo help="Install tools from every [monorepo].config_roots config root" env=MISE_MONOREPO {
         long_help #"""
 Install tools from every [monorepo].config_roots config root
 
@@ -1969,8 +1789,13 @@ Uses the active MISE_ENV and requires monorepo_root = true plus explicit
 [monorepo].config_roots in the monorepo root config.
 """#
     }
-    flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1"
-    flag --shared help="Install tool(s) to a shared directory" {
+    flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1" overrides=--jobs {
+        long_help #"""
+Connect backend install command stdin/stdout/stderr directly to the terminal
+Implies --jobs=1
+"""#
+    }
+    flag --shared help="Install tool(s) to a shared directory" conflicts=--system {
         long_help #"""
 Install tool(s) to a shared directory
 
@@ -1979,7 +1804,7 @@ May require elevated permissions depending on the path.
 """#
         arg <SHARED>
     }
-    flag --system help="Install tool(s) to the system-wide shared directory" {
+    flag --system help="Install tool(s) to the system-wide shared directory" conflicts=--shared {
         long_help #"""
 Install tool(s) to the system-wide shared directory
 
@@ -1987,7 +1812,11 @@ Installs to /usr/local/share/mise/installs (or MISE_SYSTEM_DATA_DIR/installs).
 May require elevated permissions (e.g. sudo).
 """#
     }
-    arg "[TOOL@VERSION]…" help="Tool(s) to install e.g.: node@20" required=#false var=#true
+    arg "[TOOL@VERSION]…" help="Tool(s) to install e.g.: node@20" help_long=#"""
+Tool(s) to install
+e.g.: node@20
+"""# required=#false var=#true
+    complete shared type=dir
 }
 cmd install-into help="Install a tool version to a specific path" effect=write {
     long_help #"""
@@ -1995,16 +1824,13 @@ Install a tool version to a specific path
 
 Used for building a tool to a directory for use outside of mise
 """#
-    after_long_help #"""
-Examples:
-
-    # install node@20.0.0 into ./mynode
-    $ mise install-into node@20.0.0 ./mynode && ./mynode/bin/node -v
-    20.0.0
-
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # install node@20.0.0 into ./mynode\n    $ \u{1b}[1mmise install-into node@20.0.0 ./mynode && ./mynode/bin/node -v\u{1b}[22m\n    20.0.0\n"
+    arg <TOOL@VERSION> help="Tool to install e.g.: node@20" help_long=#"""
+Tool to install
+e.g.: node@20
 """#
-    arg <TOOL@VERSION> help="Tool to install e.g.: node@20"
     arg <PATH> help="Path to install the tool into"
+    complete path type=dir
 }
 cmd latest help="Gets the latest available version for a plugin" effect=read {
     long_help #"""
@@ -2012,20 +1838,10 @@ Gets the latest available version for a plugin
 
 Supports prefixes such as `node@20` to get the latest version of node 20.
 """#
-    after_long_help #"""
-Examples:
-
-    $ mise latest node@20  # get the latest version of node 20
-    20.0.0
-
-    $ mise latest node     # get the latest stable version of node
-    20.0.0
-
-    $ mise latest node --minimum-release-age 2024-01-01  # latest stable node released before 2024-01-01
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise latest node@20\u{1b}[22m  # get the latest version of node 20\n    20.0.0\n\n    $ \u{1b}[1mmise latest node\u{1b}[22m     # get the latest stable version of node\n    20.0.0\n\n    $ \u{1b}[1mmise latest node --minimum-release-age 2024-01-01\u{1b}[22m  # latest stable node released before 2024-01-01\n"
     flag "-i --installed" help="Show latest installed instead of available version"
-    flag --minimum-release-age help="Only consider versions released before this date or older than this duration" {
+    flag --minimum-release-age help="Only consider versions released before this date or older than this duration" conflicts=--installed {
+        alias "--before" hide=#true
         long_help #"""
 Only consider versions released before this date or older than this duration
 
@@ -2035,7 +1851,11 @@ Overrides per-tool `minimum_release_age` options and the global `minimum_release
         arg <MINIMUM_RELEASE_AGE>
     }
     arg <TOOL@VERSION> help="Tool to get the latest version of"
-    arg "[ASDF_VERSION]" help="The version prefix to use when querying the latest version same as the first argument after the \"@\" used for asdf compatibility" required=#false hide=#true
+    arg "[ASDF_VERSION]" help="The version prefix to use when querying the latest version same as the first argument after the \"@\" used for asdf compatibility" help_long=#"""
+The version prefix to use when querying the latest version
+same as the first argument after the "@"
+used for asdf compatibility
+"""# required=#false hide=#true
 }
 cmd link help="Symlinks a tool version into mise" effect=write {
     alias ln
@@ -2044,25 +1864,14 @@ Symlinks a tool version into mise
 
 Use this for adding installs either custom compiled outside mise or built with a different tool.
 """#
-    after_long_help #"""
-Examples:
-
-    # build node-20.0.0 with node-build and link it into mise
-    $ node-build 20.0.0 ~/.nodes/20.0.0
-    $ mise link node@20.0.0 ~/.nodes/20.0.0
-
-    # have mise use the node version provided by Homebrew
-    $ brew install node
-    $ mise link node@brew $(brew --prefix node)
-    $ mise use node@brew
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # build node-20.0.0 with node-build and link it into mise\n    $ \u{1b}[1mnode-build 20.0.0 ~/.nodes/20.0.0\u{1b}[22m\n    $ \u{1b}[1mmise link node@20.0.0 ~/.nodes/20.0.0\u{1b}[22m\n\n    # have mise use the node version provided by Homebrew\n    $ \u{1b}[1mbrew install node\u{1b}[22m\n    $ \u{1b}[1mmise link node@brew $(brew --prefix node)\u{1b}[22m\n    $ \u{1b}[1mmise use node@brew\u{1b}[22m\n"
     flag "-f --force" help="Overwrite an existing tool version if it exists"
     arg <TOOL@VERSION> help="Tool name and version to create a symlink for"
     arg <PATH> help=#"""
 The local path to the tool version
 e.g.: ~/.nvm/versions/node/v20.0.0
 """#
+    complete path type=dir
 }
 cmd local hide=#true help="Sets/gets tool version in local .tool-versions or mise.toml" effect=write {
     alias l hide=#true
@@ -2074,38 +1883,25 @@ Use `mise global` to set a tool version globally
 This uses `.tool-version` by default unless there is a `mise.toml` file or if `MISE_USE_TOML`
 is set. A future v2 release of mise will default to using `mise.toml`.
 """#
-    after_long_help #"""
-Examples:
-    # set the current version of node to 20.x for the current directory
-    # will use a precise version (e.g.: 20.0.0) in .tool-versions file
-    $ mise local node@20
-
-    # set node to 20.x for the current project (recurses up to find .tool-versions)
-    $ mise local -p node@20
-
-    # set the current version of node to 20.x for the current directory
-    # will use a fuzzy version (e.g.: 20) in .tool-versions file
-    $ mise local --fuzzy node@20
-
-    # removes node from .tool-versions
-    $ mise local --remove=node
-
-    # show the current version of node in .tool-versions
-    $ mise local node
-    20.0.0
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n    # set the current version of node to 20.x for the current directory\n    # will use a precise version (e.g.: 20.0.0) in .tool-versions file\n    $ \u{1b}[1mmise local node@20\u{1b}[22m\n\n    # set node to 20.x for the current project (recurses up to find .tool-versions)\n    $ \u{1b}[1mmise local -p node@20\u{1b}[22m\n\n    # set the current version of node to 20.x for the current directory\n    # will use a fuzzy version (e.g.: 20) in .tool-versions file\n    $ \u{1b}[1mmise local --fuzzy node@20\u{1b}[22m\n\n    # removes node from .tool-versions\n    $ \u{1b}[1mmise local --remove=node\u{1b}[22m\n\n    # show the current version of node in .tool-versions\n    $ \u{1b}[1mmise local node\u{1b}[22m\n    20.0.0\n"
     flag "-p --parent" help=#"""
 Recurse up to find a .tool-versions file rather than using the current directory only
 by default this command will only set the tool in the current directory ("$PWD/.tool-versions")
 """#
-    flag --fuzzy help="Save fuzzy version to `.tool-versions` e.g.: `mise local --fuzzy node@20` will save `node 20` to .tool-versions This is the default behavior unless MISE_ASDF_COMPAT=1"
+    flag --fuzzy help="Save fuzzy version to `.tool-versions` e.g.: `mise local --fuzzy node@20` will save `node 20` to .tool-versions This is the default behavior unless MISE_ASDF_COMPAT=1" overrides=--pin {
+        long_help #"""
+Save fuzzy version to `.tool-versions`
+e.g.: `mise local --fuzzy node@20` will save `node 20` to .tool-versions
+This is the default behavior unless MISE_ASDF_COMPAT=1
+"""#
+    }
     flag --path help="Get the path of the config file"
     flag --pin help=#"""
 Save exact version to `.tool-versions`
 e.g.: `mise local --pin node@20` will save `node 20.0.0` to .tool-versions
-"""#
+"""# overrides=--fuzzy
     flag --remove help="Remove the tool(s) from .tool-versions" var=#true {
+        alias "--rm" "--unset" hide=#true
         arg <TOOL>
     }
     arg "[TOOL@VERSION]…" help=#"""
@@ -2120,29 +1916,20 @@ cmd lock help="Update lockfile checksums and URLs for all specified platforms" e
 Update lockfile checksums and URLs for all specified platforms
 
 Updates checksums and download URLs for all platforms already specified in the lockfile.
-If no lockfile exists, shows what would be created based on the current configuration.
+If no lockfile exists, shows what would be created based on the current configuration,
+including tools declared by tasks.
 This allows you to refresh lockfile data for platforms other than the one you're currently on.
 Operates on the lockfile in the current config root. Use TOOL arguments to target specific tools.
 """#
-    after_long_help #"""
-Examples:
-
-    $ mise lock                       # update lockfile for all common platforms
-    $ mise lock node python           # update only node and python
-    $ mise lock --platform linux-x64  # update only linux-x64 platform
-    $ mise lock --dry-run             # show what would be updated
-    $ mise lock --bump                # re-resolve selectors like "latest" or "20" to the latest matching versions
-    $ mise lock --bump --dry-run --json   # list available updates as JSON without writing
-    $ mise lock --minimum-release-age 2024-01-01   # lock latest/fuzzy versions released before 2024-01-01
-    $ mise lock --local               # update mise.local.lock for local configs
-    $ mise lock --global              # update only global config lockfiles
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise lock\u{1b}[22m                       # update lockfile for all common platforms\n    $ \u{1b}[1mmise lock node python\u{1b}[22m           # update only node and python\n    $ \u{1b}[1mmise lock --platform linux-x64\u{1b}[22m  # update only linux-x64 platform\n    $ \u{1b}[1mmise lock --dry-run\u{1b}[22m             # show what would be updated\n    $ \u{1b}[1mmise lock --bump\u{1b}[22m                # re-resolve selectors like \"latest\" or \"20\" to the latest matching versions\n    $ \u{1b}[1mmise lock --bump --dry-run --json\u{1b}[22m   # list available updates as JSON without writing\n    $ \u{1b}[1mmise lock --minimum-release-age 2024-01-01\u{1b}[22m   # lock latest/fuzzy versions released before 2024-01-01\n    $ \u{1b}[1mmise lock --local\u{1b}[22m               # update mise.local.lock for local configs\n    $ \u{1b}[1mmise lock --global\u{1b}[22m              # update only global config lockfiles\n"
     flag "-g --global" help=#"""
 Target only global config lockfiles (~/.config/mise/mise.lock and system config)
 By default, only the active project config root is locked
 """#
-    flag "-j --jobs" help="Number of jobs to run in parallel" {
+    flag "-j --jobs" help=#"""
+Number of jobs to run in parallel
+Values below 1 are treated as 1
+"""# env=MISE_JOBS {
         arg <JOBS>
     }
     flag "-n --dry-run" help="Show what would be updated without making changes"
@@ -2151,7 +1938,7 @@ Comma-separated list of platforms to target
 e.g.: linux-x64,macos-arm64,windows-x64
 If not specified, all platforms already in lockfile will be updated
 """# var=#true {
-        arg <PLATFORM>
+        arg <PLATFORM> delimiter=,
     }
     flag --bump help="Re-resolve fuzzy version selectors against the latest available versions" {
         long_help #"""
@@ -2184,6 +1971,7 @@ Update mise.local.lock instead of mise.lock
 Use for tools defined in .local.toml configs
 """#
     flag --minimum-release-age help="Only lock versions released before this age or date" {
+        alias "--before" hide=#true
         long_help #"""
 Only lock versions released before this age or date
 
@@ -2197,7 +1985,7 @@ Existing matching lockfile entries are preserved and are not downgraded solely b
     arg "[TOOL]…" help=#"""
 Tool(s) to update in lockfile
 e.g.: node python
-If not specified, all tools in lockfile will be updated
+If not specified, all configured and task-specific tools will be updated
 """# required=#false var=#true
 }
 cmd ls help="List installed and active tool versions" effect=read {
@@ -2211,64 +1999,43 @@ that are in a config file (active) but may or may not be installed.
 
 It's a useful command to get the current state of your tools.
 """#
-    after_long_help #"""
-Examples:
-
-    $ mise ls
-    node    20.0.0 ~/src/myapp/.tool-versions latest
-    python  3.11.0 ~/.tool-versions           3.10
-    python  3.10.0
-
-    $ mise ls --current
-    node    20.0.0 ~/src/myapp/.tool-versions 20
-    python  3.11.0 ~/.tool-versions           3.11.0
-
-    $ mise ls --json
-    {
-      "node": [
-        {
-          "version": "20.0.0",
-          "install_path": "/Users/jdx/.mise/installs/node/20.0.0",
-          "source": {
-            "type": "mise.toml",
-            "path": "/Users/jdx/mise.toml"
-          }
-        }
-      ],
-      "python": [...]
-    }
-
-    $ mise ls --all-sources
-    node    20.0.0  ~/src/myapp/mise.toml  20
-                    ~/.config/mise/config.toml  latest
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise ls\u{1b}[22m\n    node    20.0.0 ~/src/myapp/.tool-versions latest\n    python  3.11.0 ~/.tool-versions           3.10\n    python  3.10.0\n\n    $ \u{1b}[1mmise ls --current\u{1b}[22m\n    node    20.0.0 ~/src/myapp/.tool-versions 20\n    python  3.11.0 ~/.tool-versions           3.11.0\n\n    $ \u{1b}[1mmise ls --json\u{1b}[22m\n    {\n      \"node\": [\n        {\n          \"version\": \"20.0.0\",\n          \"install_path\": \"/Users/jdx/.mise/installs/node/20.0.0\",\n          \"source\": {\n            \"type\": \"mise.toml\",\n            \"path\": \"/Users/jdx/mise.toml\"\n          }\n        }\n      ],\n      \"python\": [...]\n    }\n\n    $ \u{1b}[1mmise ls --all-sources\u{1b}[22m\n    node    20.0.0  ~/src/myapp/mise.toml  20\n                    ~/.config/mise/config.toml  latest\n"
     flag "-c --current" help="Only show tool versions currently specified in a mise.toml"
-    flag "-g --global" help="Only show tool versions currently specified in the global mise.toml"
-    flag "-i --installed" help="Only show tool versions that are installed (Hides tools defined in mise.toml but not installed)"
+    flag "-g --global" help="Only show tool versions currently specified in the global mise.toml" conflicts=--local
+    flag "-i --installed" help="Only show tool versions that are installed (Hides tools defined in mise.toml but not installed)" {
+        long_help #"""
+Only show tool versions that are installed
+(Hides tools defined in mise.toml but not installed)
+"""#
+    }
     flag "-J --json" help="Output in JSON format"
-    flag "-l --local" help="Only show tool versions currently specified in the local mise.toml"
-    flag "-m --missing" help="Display missing tool versions"
+    flag "-l --local" help="Only show tool versions currently specified in the local mise.toml" conflicts=--global
+    flag "-m --missing" help="Display missing tool versions" conflicts=--installed
     flag "-o --offline" help="Don't fetch information such as outdated versions" hide=#true
     flag "-p --plugin" hide=#true {
-        arg <TOOL_FLAG>
+        arg <PLUGIN>
     }
-    flag --all-sources help="Display all tracked config sources for tools"
-    flag --monorepo help="List tools from every [monorepo].config_roots config root" {
+    flag --all-sources help="Display all tracked config sources for tools" {
+        conflicts "--current" "--global" "--local" "--prunable"
+    }
+    flag --monorepo help="List tools from every [monorepo].config_roots config root" env=MISE_MONOREPO {
         long_help #"""
 List tools from every [monorepo].config_roots config root
 
 Uses the active MISE_ENV and requires monorepo_root = true plus explicit
 [monorepo].config_roots in the monorepo root config.
 """#
+        conflicts "--all-sources" "--prunable"
     }
-    flag --no-header help="Don't display headers"
+    flag --no-header help="Don't display headers" conflicts=--json {
+        alias "--no-headers" hide=#true
+    }
     flag --outdated help="Display whether a version is outdated"
-    flag --prefix help="Display versions matching this prefix" {
+    flag --prefix help="Display versions matching this prefix" requires=INSTALLED_TOOL {
         arg <PREFIX>
     }
     flag --prunable help="List only tools that can be pruned with `mise prune`"
-    arg "[INSTALLED_TOOL]…" help="Only show tool versions from [TOOL]" required=#false var=#true
+    arg "[INSTALLED_TOOL]…" help="Only show tool versions from [TOOL]" required=#false var=#true conflicts=--plugin
 }
 cmd ls-remote help="List runtime versions available for install." effect=read {
     alias list-all list-remote hide=#true
@@ -2277,30 +2044,12 @@ List runtime versions available for install.
 
 Note that the results may be cached, run `mise cache clean` to clear the cache and get fresh results.
 """#
-    after_long_help #"""
-Examples:
-
-    $ mise ls-remote node
-    18.0.0
-    20.0.0
-
-    $ mise ls-remote node@20
-    20.0.0
-    20.1.0
-
-    $ mise ls-remote node 20
-    20.0.0
-    20.1.0
-
-    $ mise ls-remote node --minimum-release-age 2024-01-01
-    20.0.0
-
-    $ mise ls-remote github:cli/cli --json
-    [{"version":"2.62.0","created_at":"2024-11-14T15:40:35Z","prerelease":false},{"version":"2.61.0","created_at":"2024-10-23T19:22:15Z","prerelease":false}]
-
-"""#
-    flag --all help="Show all installed plugins and versions"
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise ls-remote node\u{1b}[22m\n    18.0.0\n    20.0.0\n\n    $ \u{1b}[1mmise ls-remote node@20\u{1b}[22m\n    20.0.0\n    20.1.0\n\n    $ \u{1b}[1mmise ls-remote node 20\u{1b}[22m\n    20.0.0\n    20.1.0\n\n    $ \u{1b}[1mmise ls-remote node --minimum-release-age 2024-01-01\u{1b}[22m\n    20.0.0\n\n    $ \u{1b}[1mmise ls-remote github:cli/cli --json\u{1b}[22m\n    [{\"version\":\"2.62.0\",\"created_at\":\"2024-11-14T15:40:35Z\",\"prerelease\":false},{\"version\":\"2.61.0\",\"created_at\":\"2024-10-23T19:22:15Z\",\"prerelease\":false}]\n"
+    flag --all help="Show all installed plugins and versions" {
+        conflicts TOOL@VERSION PREFIX
+    }
     flag --minimum-release-age help="Only show versions released before this age or date" {
+        alias "--before" hide=#true
         long_help #"""
 Only show versions released before this age or date
 
@@ -2325,8 +2074,9 @@ Requires --json and --no-versions-host.
 This prevents metadata consumers from accepting empty fallback results
 when a backend's metadata-producing upstream request fails.
 """#
+        requires "--json" "--no-versions-host"
     }
-    arg "[TOOL@VERSION]" help="Tool to get versions for" required=#false
+    arg "[TOOL@VERSION]" help="Tool to get versions for" required=#false required_unless=--all
     arg "[PREFIX]" help=#"""
 The version prefix to use when querying the latest version
 same as the first argument after the "@"
@@ -2360,41 +2110,7 @@ Tools available:
 Note: This is primarily intended for integration with AI assistants like Claude,
 Cursor, or other tools that support the Model Context Protocol.
 """#
-    after_long_help #"""
-Examples:
-
-    # Start the MCP server (typically used by AI assistant tools)
-    $ mise mcp
-
-    # Example integration with Claude Desktop (add to claude_desktop_config.json):
-    {
-      "mcpServers": {
-        "mise": {
-          "command": "mise",
-          "args": ["mcp"],
-          "env": {}
-        }
-      }
-    }
-
-    # Interactive testing with JSON-RPC commands:
-    $ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' | mise mcp
-
-    # Resources you can query:
-    - mise://tools - List active tools
-    - mise://tools?include_inactive=true - List all installed tools
-    - mise://tasks - List all tasks
-    - mise://env - List environment variables
-    - mise://config - Show configuration info
-
-    # Tools available:
-    - list_commands - Every mise command and what running it does
-      Example: {"include_hidden": false}
-    - install_tool - Install a tool (not yet implemented)
-    - run_task - Execute a mise task with optional arguments
-      Example: {"task": "build", "args": ["--verbose"]}
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Start the MCP server (typically used by AI assistant tools)\n    $ \u{1b}[1mmise mcp\u{1b}[22m\n\n    # Example integration with Claude Desktop (add to claude_desktop_config.json):\n    {\n      \"mcpServers\": {\n        \"mise\": {\n          \"command\": \"mise\",\n          \"args\": [\"mcp\"],\n          \"env\": {}\n        }\n      }\n    }\n\n    # Interactive testing with JSON-RPC commands:\n    $ \u{1b}[1mecho '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{},\"clientInfo\":{\"name\":\"test\",\"version\":\"1.0\"}}}' | mise mcp\u{1b}[22m\n\n    # Resources you can query:\n    - \u{1b}[1mmise://tools\u{1b}[22m - List active tools\n    - \u{1b}[1mmise://tools?include_inactive=true\u{1b}[22m - List all installed tools\n    - \u{1b}[1mmise://tasks\u{1b}[22m - List all tasks\n    - \u{1b}[1mmise://env\u{1b}[22m - List environment variables\n    - \u{1b}[1mmise://config\u{1b}[22m - Show configuration info\n\n    # Tools available:\n    - \u{1b}[1mlist_commands\u{1b}[22m - Every mise command and what running it does\n      Example: {\"include_hidden\": false}\n    - \u{1b}[1minstall_tool\u{1b}[22m - Install a tool (not yet implemented)\n    - \u{1b}[1mrun_task\u{1b}[22m - Execute a mise task with optional arguments\n      Example: {\"task\": \"build\", \"args\": [\"--verbose\"]}\n"
 }
 cmd oci subcommand_required=#true help="[experimental] Build OCI container images from a mise.toml" effect=read {
     long_help #"""
@@ -2420,33 +2136,7 @@ the OCI image-layout spec and can be consumed by `skopeo`, `crane`, or
 
 Requires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`).
 """#
-        after_long_help #"""
-Examples:
-
-    Build with defaults (debian:bookworm-slim base):
-    $ mise oci build
-
-    Build with a specific base image and tag:
-    $ mise oci build --from ubuntu:24.04 --tag myorg/dev:latest -o ./img
-
-    Inspect the result with skopeo:
-    $ skopeo inspect oci:./mise-oci
-
-    Push to a registry:
-    $ mise oci push --image-dir ./mise-oci ghcr.io/me/dev:latest
-
-Notes:
-
-    - The image only contains tools from the project's mise config (and
-      any configs at-or-below the project root). Tools from
-      `~/.config/mise/config.toml` are not included; pass --include-global
-      to package them too.
-    - asdf and vfox plugins are not supported in v1; use a different backend
-      (core, aqua, ubi, github, cargo, npm, go, pipx, spm, http) for each tool.
-    - The host mise binary is embedded at /usr/local/bin/mise by default;
-      build on the same OS/arch as your target image (or pass --no-mise).
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    Build with defaults (debian:bookworm-slim base):\n    $ \u{1b}[1mmise oci build\u{1b}[22m\n\n    Build with a specific base image and tag:\n    $ \u{1b}[1mmise oci build --from ubuntu:24.04 --tag myorg/dev:latest -o ./img\u{1b}[22m\n\n    Inspect the result with skopeo:\n    $ \u{1b}[1mskopeo inspect oci:./mise-oci\u{1b}[22m\n\n    Push to a registry:\n    $ \u{1b}[1mmise oci push --image-dir ./mise-oci ghcr.io/me/dev:latest\u{1b}[22m\n\n\u{1b}[1m\u{1b}[4mNotes:\u{1b}[22m\u{1b}[24m\n\n    - The image only contains tools from the project's mise config (and\n      any configs at-or-below the project root). Tools from\n      `~/.config/mise/config.toml` are not included; pass --include-global\n      to package them too.\n    - asdf and vfox plugins are not supported in v1; use a different backend\n      (core, aqua, ubi, github, cargo, npm, go, pipx, spm, http) for each tool.\n    - The host mise binary is embedded at /usr/local/bin/mise by default;\n      build on the same OS/arch as your target image (or pass --no-mise).\n"
         flag --copy help="Copy a host file, directory, or symlink into the image (repeatable, HOST:IMAGE)" var=#true {
             arg <HOST_PATH:IMAGE_PATH>
         }
@@ -2460,7 +2150,12 @@ Notes:
             long_help #"""
 Also include tools from the global / system config (default: project-only)
 
-By default `mise oci build` only packages tools declared in the project's mise config (and any parent configs at-or-below the project root, e.g. a monorepo root config). Personal dev tools in `~/.config/mise/config.toml` are excluded so they don't bake into a project image. Pass `--include-global` to revert to the old "merge all loaded configs" behavior.
+By default `mise oci build` only packages tools declared in the
+project's mise config (and any parent configs at-or-below the
+project root, e.g. a monorepo root config). Personal dev tools in
+`~/.config/mise/config.toml` are excluded so they don't bake into a
+project image. Pass `--include-global` to revert to the old
+"merge all loaded configs" behavior.
 """#
         }
         flag "-t --tag" help="Tag to record in the image index (the org.opencontainers.image.ref.name annotation)" {
@@ -2474,10 +2169,13 @@ By default `mise oci build` only packages tools declared in the project's mise c
             long_help #"""
 UID[:GID] to assign to every tar entry in generated layers
 
-Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive.
+Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is
+omitted, it defaults to UID. This affects file ownership only; [oci].user
+controls the image USER directive.
 """#
             arg "<UID[:GID]>"
         }
+        complete output type=dir
     }
     cmd push help="[experimental] Build an OCI image and push it to a registry" effect=write {
         long_help #"""
@@ -2501,38 +2199,23 @@ is all the setup needed.
 
 Requires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`).
 """#
-        after_long_help #"""
-Examples:
-
-    Build and push to GHCR:
-    $ mise oci push ghcr.io/me/devenv:latest
-
-    Push an image built earlier:
-    $ mise oci build -o ./img
-    $ mise oci push --image-dir ./img ghcr.io/me/devenv:v1
-
-Auth:
-
-    Credentials are resolved the same way docker/podman resolve them:
-    $REGISTRY_AUTH_FILE, $XDG_RUNTIME_DIR/containers/auth.json,
-    ~/.config/containers/auth.json, then ~/.docker/config.json
-    (inline auths and credential helpers). Log in with either:
-    $ docker login ghcr.io
-    $ podman login ghcr.io
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    Build and push to GHCR:\n    $ \u{1b}[1mmise oci push ghcr.io/me/devenv:latest\u{1b}[22m\n\n    Push an image built earlier:\n    $ \u{1b}[1mmise oci build -o ./img\u{1b}[22m\n    $ \u{1b}[1mmise oci push --image-dir ./img ghcr.io/me/devenv:v1\u{1b}[22m\n\n\u{1b}[1m\u{1b}[4mAuth:\u{1b}[22m\u{1b}[24m\n\n    Credentials are resolved the same way docker/podman resolve them:\n    \u{1b}[1m$REGISTRY_AUTH_FILE\u{1b}[22m, \u{1b}[1m$XDG_RUNTIME_DIR/containers/auth.json\u{1b}[22m,\n    \u{1b}[1m~/.config/containers/auth.json\u{1b}[22m, then \u{1b}[1m~/.docker/config.json\u{1b}[22m\n    (inline auths and credential helpers). Log in with either:\n    $ \u{1b}[1mdocker login ghcr.io\u{1b}[22m\n    $ \u{1b}[1mpodman login ghcr.io\u{1b}[22m\n"
         flag --cache-from help="Reuse unchanged tool layers from this image instead of the destination ref" {
             long_help #"""
 Reuse unchanged tool layers from this image instead of the destination ref
 
-Must live in the same repository as the destination. Useful when each push gets a unique tag (e.g. per-commit tags in CI): `--cache-from ghcr.io/me/dev:latest ghcr.io/me/dev:$SHA`.
+Must live in the same repository as the destination. Useful when each
+push gets a unique tag (e.g. per-commit tags in CI):
+`--cache-from ghcr.io/me/dev:latest ghcr.io/me/dev:$SHA`.
 """#
+            conflicts "--no-cache" "--image-dir"
             arg <REF>
         }
         flag --from help="Base image for the build (ignored with --image-dir)" {
             arg <FROM>
         }
         flag --image-dir help="Push an already-built OCI image layout (skip the build step)" {
+            conflicts "--from" "--mount-point" "--no-mise" "--owner" "--include-global"
             arg <IMAGE_DIR>
         }
         flag --include-global help="Also include tools from the global / system config (default: project-only)" {
@@ -2551,7 +2234,9 @@ See `mise oci build --help` for details.
             long_help #"""
 UID[:GID] to assign to every tar entry when building (conflicts with --image-dir)
 
-Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive.
+Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is
+omitted, it defaults to UID. This affects file ownership only; [oci].user
+controls the image USER directive.
 """#
             arg "<UID[:GID]>"
         }
@@ -2559,10 +2244,14 @@ Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it
             long_help #"""
 Maintain the tag as a multi-arch image index
 
-Pushes this build's manifest by digest and points the tag at an OCI image index containing one entry per platform, preserving entries other architectures pushed. Run `mise oci push --update-index` from one runner per platform to assemble a multi-arch tag.
+Pushes this build's manifest by digest and points the tag at an OCI
+image index containing one entry per platform, preserving entries
+other architectures pushed. Run `mise oci push --update-index` from
+one runner per platform to assemble a multi-arch tag.
 """#
         }
         arg <REF> help="Destination registry reference (e.g. `ghcr.io/me/devenv:latest`)"
+        complete image_dir type=dir
     }
     cmd run help="[experimental] Build an OCI image from the current mise.toml and run a command in it" {
         long_help #"""
@@ -2576,34 +2265,21 @@ given command is executed inside it with stdin/stdout/stderr inherited.
 Requires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`) and
 one of: `podman`, `docker`.
 """#
-        after_long_help #"""
-Examples:
-
-    Build the current mise.toml and drop into bash:
-    $ mise oci run -it -- bash
-
-    Run a one-shot command with env + volume (note: `-v` is reserved
-    for --verbose, so use `--volume`):
-    $ mise oci run -e DEBUG=1 --volume $PWD:/work -w /work -- npm test
-
-    Re-use a previously built layout (skip the build step):
-    $ mise oci build -o ./img && mise oci run --image-dir ./img -- node -e 'console.log(process.version)'
-
-Engines:
-
-    Prefers podman (loads OCI layouts natively). Falls back to docker
-    (loaded via docker load). Pass --engine podman or --engine docker to override.
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    Build the current mise.toml and drop into bash:\n    $ \u{1b}[1mmise oci run -it -- bash\u{1b}[22m\n\n    Run a one-shot command with env + volume (note: `-v` is reserved\n    for --verbose, so use `--volume`):\n    $ \u{1b}[1mmise oci run -e DEBUG=1 --volume $PWD:/work -w /work -- npm test\u{1b}[22m\n\n    Re-use a previously built layout (skip the build step):\n    $ \u{1b}[1mmise oci build -o ./img && mise oci run --image-dir ./img -- node -e 'console.log(process.version)'\u{1b}[22m\n\n\u{1b}[1m\u{1b}[4mEngines:\u{1b}[22m\u{1b}[24m\n\n    Prefers \u{1b}[1mpodman\u{1b}[22m (loads OCI layouts natively). Falls back to \u{1b}[1mdocker\u{1b}[22m\n    (loaded via \u{1b}[1mdocker load\u{1b}[22m). Pass \u{1b}[1m--engine podman\u{1b}[22m or \u{1b}[1m--engine docker\u{1b}[22m to override.\n"
         flag --engine help="Container engine to use (`auto`, `podman`, or `docker`)" default=auto {
             arg <ENGINE> {
-                choices auto podman docker
+                choices {
+                    choice auto
+                    choice podman
+                    choice docker
+                }
             }
         }
         flag --from help="Base image reference for the build (ignored with --image-dir)" {
             arg <FROM>
         }
         flag --image-dir help="Use an already-built OCI image layout instead of building fresh" {
+            conflicts "--from" "--mount-point" "--no-mise" "--owner" "--include-global"
             arg <IMAGE_DIR>
         }
         flag --include-global help="Also include tools from the global / system config (default: project-only)" {
@@ -2617,7 +2293,11 @@ See `mise oci build --help` for details.
             long_help #"""
 Keep the loaded image in the engine's storage after the run
 
-By default, both the container (`--rm`) and the loaded image are removed when the command exits, so repeated `mise oci run` calls don't accumulate images in podman / docker storage. Pass `--keep` to retain the image under the tag mise used (`mise-oci:run-*` for docker; the pulled image ID for podman).
+By default, both the container (`--rm`) and the loaded image are
+removed when the command exits, so repeated `mise oci run` calls
+don't accumulate images in podman / docker storage. Pass `--keep`
+to retain the image under the tag mise used (`mise-oci:run-*` for
+docker; the pulled image ID for podman).
 """#
         }
         flag --mount-point help="Override in-image mount point (ignored with --image-dir)" {
@@ -2628,15 +2308,19 @@ By default, both the container (`--rm`) and the loaded image are removed when th
             long_help #"""
 UID[:GID] to assign to every tar entry when building (conflicts with --image-dir)
 
-Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive.
+Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is
+omitted, it defaults to UID. This affects file ownership only; [oci].user
+controls the image USER directive.
 """#
             arg "<UID[:GID]>"
         }
         flag --volume help="Bind-mount a host path (repeatable, `HOST:CONTAINER[:MODE]`)" var=#true {
+            alias "--mount" hide=#true
             long_help #"""
 Bind-mount a host path (repeatable, `HOST:CONTAINER[:MODE]`)
 
-Note: unlike `docker run -v`, there's no `-v` short flag here because mise reserves `-v` for --verbose. Use `--volume` or `--mount`.
+Note: unlike `docker run -v`, there's no `-v` short flag here because
+mise reserves `-v` for --verbose. Use `--volume` or `--mount`.
 """#
             arg <HOST:CONTAINER>
         }
@@ -2649,6 +2333,7 @@ Note: unlike `docker run -v`, there's no `-v` short flag here because mise reser
             arg <WORKDIR>
         }
         arg "[-- CMD]…" help="Command and arguments to run inside the container (after `--`)" required=#false var=#true
+        complete image_dir type=dir
     }
 }
 cmd outdated help="Shows outdated tool versions" effect=read {
@@ -2657,28 +2342,8 @@ Shows outdated tool versions
 
 See `mise upgrade` to upgrade these versions.
 """#
-    after_long_help #"""
-Examples:
-
-    $ mise outdated
-    Plugin  Requested  Current  Latest
-    python  3.11       3.11.0   3.11.1
-    node    20         20.0.0   20.1.0
-
-    $ mise outdated node
-    Plugin  Requested  Current  Latest
-    node    20         20.0.0   20.1.0
-
-    $ mise outdated --json
-    {"python": {"requested": "3.11", "current": "3.11.0", "latest": "3.11.1"}, ...}
-
-    $ mise outdated --local
-    Plugin  Requested  Current  Latest
-    node    20         20.0.0   20.1.0
-
-"""#
-    flag "-J --json" help="Output in JSON format"
-    flag "-l --bump" help="Compares against the latest versions available, not what matches the current config" {
+    after_long_help "\u{1b}[1m\u{1b}[4mDeprecation:\u{1b}[22m\u{1b}[24m\n\nThe `-l` shorthand for `--bump` is deprecated and will be removed in mise 2027.8.5.\nAfter removal, `-l` will become shorthand for `--local`. Use `-b` or `--bump` instead.\n\n\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise outdated\u{1b}[22m\n    Plugin  Requested  Current  Latest\n    python  3.11       3.11.0   3.11.1\n    node    20         20.0.0   20.1.0\n\n    $ \u{1b}[1mmise outdated node\u{1b}[22m\n    Plugin  Requested  Current  Latest\n    node    20         20.0.0   20.1.0\n\n    $ \u{1b}[1mmise outdated --json\u{1b}[22m\n    {\"python\": {\"requested\": \"3.11\", \"current\": \"3.11.0\", \"latest\": \"3.11.1\"}, ...}\n\n    $ \u{1b}[1mmise outdated --local\u{1b}[22m\n    Plugin  Requested  Current  Latest\n    node    20         20.0.0   20.1.0\n"
+    flag "-b --bump" help="Compares against the latest versions available, not what matches the current config" {
         long_help #"""
 Compares against the latest versions available, not what matches the current config
 
@@ -2688,7 +2353,9 @@ show other 20.x versions, not 21.x or 22.x versions.
 Using this flag, if there are 21.x or newer versions it will display those instead of 20.x.
 """#
     }
-    flag --inactive help="Show outdated tools including installed-but-inactive tools not present in the current config" {
+    flag "-J --json" help="Output in JSON format"
+    flag -l help="Deprecated shorthand for --bump" hide=#true
+    flag --inactive help="Show outdated tools including installed-but-inactive tools not present in the current config" conflicts=--local {
         long_help #"""
 Show outdated tools including installed-but-inactive tools not present in the current config
 
@@ -2721,13 +2388,7 @@ name as a clickable link via OSC 8 hyperlinks.
 
 To appear here, become a patron at <https://jdx.dev/sponsors.html>.
 """#
-    after_long_help #"""
-Examples:
-
-    $ mise patrons
-    $ mise patrons -J
-    $ mise patrons --refresh
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise patrons\u{1b}[22m\n    $ \u{1b}[1mmise patrons -J\u{1b}[22m\n    $ \u{1b}[1mmise patrons --refresh\u{1b}[22m"
     flag "-J --json" help="Output in JSON format"
     flag --refresh help="Bypass the local cache and re-fetch"
 }
@@ -2744,16 +2405,18 @@ same as `mise plugins ls-remote`
     flag "-c --core" help=#"""
 The built-in plugins only
 Normally these are not shown
-"""#
+"""# conflicts=--all
     flag "-u --urls" help=#"""
 Show the git url for each plugin
 e.g.: https://github.com/mise-plugins/vfox-cmake.git
-"""#
+"""# {
+        alias "--url" hide=#true
+    }
     flag --refs help=#"""
 Show the git refs for each plugin
 e.g.: main 1234abc
 """# hide=#true
-    flag --user help="List installed plugins" {
+    flag --user help="List installed plugins" conflicts=--all {
         long_help #"""
 List installed plugins
 
@@ -2771,30 +2434,19 @@ e.g.: `mise install cmake@3.30` will autoinstall the cmake plugin
 
 This behavior can be modified in ~/.config/mise/config.toml
 """#
-        after_long_help #"""
-Examples:
-
-    # install the poetry via shorthand
-    $ mise plugins install poetry
-
-    # install the poetry plugin using a specific git url
-    $ mise plugins install poetry https://github.com/mise-plugins/mise-poetry.git
-
-    # install the poetry plugin using the git url only
-    # (poetry is inferred from the url)
-    $ mise plugins install https://github.com/mise-plugins/mise-poetry.git
-
-    # install the poetry plugin using a specific ref
-    $ mise plugins install poetry https://github.com/mise-plugins/mise-poetry.git#11d0c1e
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # install the poetry via shorthand\n    $ \u{1b}[1mmise plugins install poetry\u{1b}[22m\n\n    # install the poetry plugin using a specific git url\n    $ \u{1b}[1mmise plugins install poetry https://github.com/mise-plugins/mise-poetry.git\u{1b}[22m\n\n    # install the poetry plugin using the git url only\n    # (poetry is inferred from the url)\n    $ \u{1b}[1mmise plugins install https://github.com/mise-plugins/mise-poetry.git\u{1b}[22m\n\n    # install the poetry plugin using a specific ref\n    $ \u{1b}[1mmise plugins install poetry https://github.com/mise-plugins/mise-poetry.git#11d0c1e\u{1b}[22m\n"
         flag "-a --all" help=#"""
 Install all missing plugins
 This will only install plugins that have matching shorthands.
 i.e.: they don't need the full git repo url
-"""#
+"""# {
+            conflicts NEW_PLUGIN "--force"
+        }
         flag "-f --force" help="Reinstall even if plugin exists"
-        flag "-j --jobs" help="Number of jobs to run in parallel" {
+        flag "-j --jobs" help=#"""
+Number of jobs to run in parallel
+Values below 1 are treated as 1
+"""# {
             arg <JOBS>
         }
         flag "-v --verbose" help="Show installation output" var=#true count=#true
@@ -2802,9 +2454,10 @@ i.e.: they don't need the full git repo url
 The name of the plugin to install
 e.g.: cmake, poetry
 Can specify multiple plugins: `mise plugins install cmake poetry`
-"""# required=#false
+"""# required=#false required_unless=--all
         arg "[GIT_URL]" help="The git url of the plugin" required=#false
         arg "[REST]…" required=#false var=#true hide=#true
+        complete git_url type=url
     }
     cmd link help="Symlinks a plugin into mise" effect=write {
         alias ln
@@ -2813,16 +2466,7 @@ Symlinks a plugin into mise
 
 This is used for developing a plugin.
 """#
-        after_long_help #"""
-Examples:
-
-    # essentially just `ln -s ./vfox-cmake ~/.local/share/mise/plugins/cmake`
-    $ mise plugins link cmake ./vfox-cmake
-
-    # infer plugin name as "cmake"
-    $ mise plugins link ./vfox-cmake
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # essentially just `ln -s ./vfox-cmake ~/.local/share/mise/plugins/cmake`\n    $ \u{1b}[1mmise plugins link cmake ./vfox-cmake\u{1b}[22m\n\n    # infer plugin name as \"cmake\"\n    $ \u{1b}[1mmise plugins link ./vfox-cmake\u{1b}[22m\n"
         flag "-f --force" help="Overwrite existing plugin"
         arg <NAME> help=#"""
 The name of the plugin
@@ -2832,6 +2476,7 @@ e.g.: cmake, poetry
 The local path to the plugin
 e.g.: ./vfox-cmake
 """# required=#false
+        complete dir type=dir
     }
     cmd ls help="List installed plugins" effect=read {
         alias list
@@ -2840,18 +2485,7 @@ List installed plugins
 
 Can also show remotely available plugins to install.
 """#
-        after_long_help #"""
-Examples:
-
-    $ mise plugins ls
-    cmake
-    poetry
-
-    $ mise plugins ls --urls
-    cmake     https://github.com/mise-plugins/vfox-cmake.git
-    poetry    https://github.com/mise-plugins/vfox-poetry.git
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise plugins ls\u{1b}[22m\n    cmake\n    poetry\n\n    $ \u{1b}[1mmise plugins ls --urls\u{1b}[22m\n    cmake     https://github.com/mise-plugins/vfox-cmake.git\n    poetry    https://github.com/mise-plugins/vfox-poetry.git\n"
         flag "-a --all" help=#"""
 List all available remote plugins
 Same as `mise plugins ls-remote`
@@ -2859,7 +2493,7 @@ Same as `mise plugins ls-remote`
         flag "-c --core" help=#"""
 The built-in plugins only
 Normally these are not shown
-"""# hide=#true
+"""# hide=#true conflicts=--all
         flag "-o --outdated" help=#"""
 Show plugins with available updates
 Checks the remote for newer versions and only displays plugins that are outdated
@@ -2867,12 +2501,14 @@ Checks the remote for newer versions and only displays plugins that are outdated
         flag "-u --urls" help=#"""
 Show the git url for each plugin
 e.g.: https://github.com/mise-plugins/vfox-cmake.git
-"""#
+"""# {
+            alias "--url" hide=#true
+        }
         flag --refs help=#"""
 Show the git refs for each plugin
 e.g.: main 1234abc
 """# hide=#true
-        flag --user help="List installed plugins" hide=#true
+        flag --user help="List installed plugins" hide=#true conflicts=--all
     }
     cmd ls-remote help="List all available remote plugins" effect=read {
         alias list-remote list-all
@@ -2887,18 +2523,23 @@ Examples:
     $ mise plugins ls-remote
 
 """#
-        flag "-u --urls" help="Show the git url for each plugin e.g.: https://github.com/mise-plugins/mise-poetry.git"
-        flag --only-names help="Only show the name of each plugin by default it will show a \"*\" next to installed plugins"
+        flag "-u --urls" help="Show the git url for each plugin e.g.: https://github.com/mise-plugins/mise-poetry.git" {
+            long_help #"""
+Show the git url for each plugin
+e.g.: https://github.com/mise-plugins/mise-poetry.git
+"""#
+        }
+        flag --only-names help="Only show the name of each plugin by default it will show a \"*\" next to installed plugins" {
+            long_help #"""
+Only show the name of each plugin
+by default it will show a "*" next to installed plugins
+"""#
+        }
     }
     cmd uninstall help="Removes a plugin" effect=destructive {
         alias remove rm
-        after_long_help #"""
-Examples:
-
-    $ mise plugins uninstall cmake
-
-"""#
-        flag "-a --all" help="Remove all plugins"
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise plugins uninstall cmake\u{1b}[22m\n"
+        flag "-a --all" help="Remove all plugins" conflicts=PLUGIN
         flag "-p --purge" help="Also remove the plugin's installs, downloads, and cache"
         arg "[PLUGIN]…" help="Plugin(s) to remove" required=#false var=#true
     }
@@ -2909,16 +2550,10 @@ Updates a plugin to the latest version
 
 note: this updates the plugin itself, not the runtime versions
 """#
-        after_long_help #"""
-Examples:
-
-    $ mise plugins update              # update all plugins
-    $ mise plugins update cmake       # update only cmake
-    $ mise plugins update cmake#beta  # specify a ref
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise plugins update\u{1b}[22m              # update all plugins\n    $ \u{1b}[1mmise plugins update cmake\u{1b}[22m       # update only cmake\n    $ \u{1b}[1mmise plugins update cmake#beta\u{1b}[22m  # specify a ref\n"
         flag "-j --jobs" help=#"""
 Number of jobs to run in parallel
+Values below 1 are treated as 1
 Default: 4
 """# {
             arg <JOBS>
@@ -2940,42 +2575,12 @@ if needed.
 Providers with `auto = true` are automatically invoked before `mise x` and `mise run`
 unless skipped with the --no-deps flag.
 """#
-    after_long_help #"""
-Examples:
-
-    $ mise deps                    # Install all project dependencies
-    $ mise deps install            # Same as bare `mise deps`
-    $ mise deps install --force    # Force reinstall even if fresh
-    $ mise deps install --dry-run  # Show what would run
-    $ mise deps --monorepo         # Install deps from explicit monorepo config roots
-    $ mise deps add npm:react      # Add a dependency
-    $ mise deps add -D npm:vitest  # Add a dev dependency
-    $ mise deps remove npm:lodash  # Remove a dependency
-
-Configuration:
-
-```toml
-# Built-in npm provider (auto-detects lockfile)
-[deps.npm]
-auto = true              # Auto-run before mise x/run
-
-# Custom provider
-[deps.codegen]
-auto = true
-sources = ["schema/*.graphql"]
-outputs = ["src/generated/"]
-run = "npm run codegen"
-
-[deps]
-disable = ["npm"]        # Disable specific providers at runtime
-```
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise deps\u{1b}[22m                    # Install all project dependencies\n    $ \u{1b}[1mmise deps install\u{1b}[22m            # Same as bare `mise deps`\n    $ \u{1b}[1mmise deps install --force\u{1b}[22m    # Force reinstall even if fresh\n    $ \u{1b}[1mmise deps install --dry-run\u{1b}[22m  # Show what would run\n    $ \u{1b}[1mmise deps --monorepo\u{1b}[22m         # Install deps from explicit monorepo config roots\n    $ \u{1b}[1mmise deps add npm:react\u{1b}[22m      # Add a dependency\n    $ \u{1b}[1mmise deps add -D npm:vitest\u{1b}[22m  # Add a dev dependency\n    $ \u{1b}[1mmise deps remove npm:lodash\u{1b}[22m  # Remove a dependency\n\n\u{1b}[1m\u{1b}[4mConfiguration:\u{1b}[22m\u{1b}[24m\n\n```toml\n# Built-in npm provider (auto-detects lockfile)\n[deps.npm]\nauto = true              # Auto-run before mise x/run\n\n# Custom provider\n[deps.codegen]\nauto = true\nsources = [\"schema/*.graphql\"]\noutputs = [\"src/generated/\"]\nrun = \"npm run codegen\"\n\n[deps]\ndisable = [\"npm\"]        # Disable specific providers at runtime\n```\n"
     flag --explain help="Show why a provider is fresh or stale (requires a provider argument)"
     flag "-f --force" help="Force run all deps steps even if outputs are fresh"
     flag "-n --dry-run" help="Only check if deps install is needed, don't run commands"
     flag --list help="Show what deps providers are available"
-    flag --monorepo help="Install dependencies from every [monorepo].config_roots config root" {
+    flag --monorepo help="Install dependencies from every [monorepo].config_roots config root" env=MISE_MONOREPO {
         long_help #"""
 Install dependencies from every [monorepo].config_roots config root
 
@@ -3011,7 +2616,7 @@ and runs install commands if needed.
         flag "-f --force" help="Force run all deps steps even if outputs are fresh"
         flag "-n --dry-run" help="Only check if deps install is needed, don't run commands"
         flag --list help="Show what deps providers are available"
-        flag --monorepo help="Install dependencies from every [monorepo].config_roots config root" {
+        flag --monorepo help="Install dependencies from every [monorepo].config_roots config root" env=MISE_MONOREPO {
             long_help #"""
 Install dependencies from every [monorepo].config_roots config root
 
@@ -3051,14 +2656,7 @@ Versions still referenced by a tracked stub are not deleted.
 
 You can list prunable tools with `mise ls --prunable`
 """#
-    after_long_help #"""
-Examples:
-
-    $ mise prune --dry-run
-    rm -rf ~/.local/share/mise/versions/node/20.0.0
-    rm -rf ~/.local/share/mise/versions/node/20.0.1
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise prune --dry-run\u{1b}[22m\n    rm -rf ~/.local/share/mise/versions/node/20.0.0\n    rm -rf ~/.local/share/mise/versions/node/20.0.1\n"
     flag "-n --dry-run" help="Do not actually delete anything"
     flag --configs help="Prune only tracked and trusted configuration links that point to nonexistent configurations"
     flag --dry-run-code help="Like --dry-run but exits with code 1 if there are tools to prune" {
@@ -3080,29 +2678,20 @@ This command lists the tools available in the registry as shorthand names.
 
 For example, `poetry` is shorthand for `asdf:mise-plugins/mise-poetry`.
 """#
-    after_long_help #"""
-Examples:
-
-    $ mise registry
-    node    core:node
-    poetry  asdf:mise-plugins/mise-poetry
-    ubi     cargo:ubi-cli
-
-    $ mise registry poetry
-    asdf:mise-plugins/mise-poetry
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise registry\u{1b}[22m\n    node    core:node\n    poetry  asdf:mise-plugins/mise-poetry\n    ubi     cargo:ubi-cli\n\n    $ \u{1b}[1mmise registry poetry\u{1b}[22m\n    asdf:mise-plugins/mise-poetry\n"
     flag "-b --backend" help="Show only tools for this backend" {
         arg <BACKEND>
     }
     flag --complete help="Print all tools with descriptions for shell completions" hide=#true
     flag --hide-aliased help="Hide aliased tools"
     flag "-J --json" help="Output in JSON format"
-    flag --security help="Include security features for each tool's backends in JSON output" {
+    flag --security help="Include security features for each tool's backends in JSON output." requires=--json {
         long_help #"""
 Include security features for each tool's backends in JSON output.
 
-Requires --json. Security info is de-duplicated across all of a tool's backends. This can add noticeable time for large listings since each backend's security info is resolved individually.
+Requires --json. Security info is de-duplicated across
+all of a tool's backends. This can add noticeable time for large
+listings since each backend's security info is resolved individually.
 """#
     }
     arg "[NAME]" help="Show only the specified tool's full name" required=#false
@@ -3129,19 +2718,12 @@ automatically (it's really fast so you don't need to worry about overhead):
 Note that this creates shims for _all_ installed tools, not just the ones that are
 currently active in mise.toml.
 """#
-    after_long_help #"""
-Examples:
-
-    $ mise reshim
-    $ ~/.local/share/mise/shims/node -v
-    v20.0.0
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise reshim\u{1b}[22m\n    $ \u{1b}[1m~/.local/share/mise/shims/node -v\u{1b}[22m\n    v20.0.0\n"
     flag "-f --force" help="Removes all shims before reshimming"
     arg "[TOOL]" required=#false hide=#true
     arg "[VERSION]" required=#false hide=#true
 }
-cmd run restart_token=::: help="Run task(s)" {
+cmd run disable_help_flag=#true restart_token=::: help="Run task(s)" {
     alias r
     long_help #"""
 Run task(s)
@@ -3170,42 +2752,23 @@ The name of the script will be the name of the tasks.
     EOF
     $ mise run build
 """#
-    after_long_help #"""
-Examples:
-
-    # Runs the "lint" tasks. This needs to either be defined in mise.toml
-    # or as a standalone script. See the project README for more information.
-    $ mise run lint
-
-    # Forces the "build" tasks to run even if its sources are up-to-date.
-    $ mise run --force build
-
-    # Run "test" with stdin/stdout/stderr all connected to the current terminal.
-    # This forces `--jobs=1` to prevent interleaving of output.
-    $ mise run --raw test
-
-    # Runs the "lint", "test", and "check" tasks in parallel.
-    $ mise run lint ::: test ::: check
-
-    # Execute multiple tasks each with their own arguments.
-    $ mise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Runs the \"lint\" tasks. This needs to either be defined in mise.toml\n    # or as a standalone script. See the project README for more information.\n    $ \u{1b}[1mmise run lint\u{1b}[22m\n\n    # Forces the \"build\" tasks to run even if its sources are up-to-date.\n    $ \u{1b}[1mmise run --force build\u{1b}[22m\n\n    # Run \"test\" with stdin/stdout/stderr all connected to the current terminal.\n    # This forces `--jobs=1` to prevent interleaving of output.\n    $ \u{1b}[1mmise run --raw test\u{1b}[22m\n\n    # Runs the \"lint\", \"test\", and \"check\" tasks in parallel.\n    $ \u{1b}[1mmise run lint ::: test ::: check\u{1b}[22m\n\n    # Execute multiple tasks each with their own arguments.\n    $ \u{1b}[1mmise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2\u{1b}[22m\n"
     flag --affected help="Run matching tasks only for projects affected by Git changes"
     flag --affected-base help=#"""
 Git base revision for --affected
 Defaults to MISE_AFFECTED_BASE, CI metadata, or HEAD~1
-"""# {
+"""# requires=--affected {
         arg <REV>
     }
-    flag --affected-explain help="Explain why projects and tasks were selected by --affected"
+    flag --affected-explain help="Explain why projects and tasks were selected by --affected" conflicts=--affected-json requires=--affected
     flag --affected-head help=#"""
 Git head revision for --affected
 Defaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD
-"""# {
+"""# requires=--affected {
         arg <REV>
     }
-    flag --affected-json help="Output affected projects and tasks as JSON without running tasks"
+    flag --affected-json help="Output affected projects and tasks as JSON without running tasks" conflicts=--affected-explain requires=--affected
+    flag --all help="Open the interactive selector with all tasks from the entire monorepo" conflicts=--affected
     flag "-c --continue-on-error" help="Continue running tasks even if one fails"
     flag "-C --cd" help="Change to this directory before executing the command" {
         arg <CD>
@@ -3213,13 +2776,14 @@ Defaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD
     flag "-f --force" help="Force the tasks to run even if outputs are up to date"
     flag "-j --jobs" help=#"""
 Number of tasks to run in parallel
+Values below 1 are treated as 1
 [default: 4]
 Configure with `jobs` config or `MISE_JOBS` env var
-"""# {
+"""# env=MISE_JOBS {
         arg <JOBS>
     }
     flag "-n --dry-run" help="Don't actually run the task(s), just print them in order of execution"
-    flag "-o --output" help="Change how tasks information is output when running tasks" {
+    flag "-o --output" help="Change how tasks information is output when running tasks" env=MISE_TASK_OUTPUT {
         long_help #"""
 Change how tasks information is output when running tasks
 
@@ -3233,7 +2797,7 @@ Change how tasks information is output when running tasks
 """#
         arg <OUTPUT>
     }
-    flag "-q --quiet" help="Don't show extra output"
+    flag "-q --quiet" help="Don't show extra output" env=MISE_QUIET
     flag "-r --raw" help=#"""
 Read/write directly to stdin/stdout/stderr instead of by line
 Redactions are not applied with this option
@@ -3249,8 +2813,12 @@ Or it can be overridden with the `shell` property on a task.
 """#
         arg <SHELL>
     }
-    flag "-S --silent" help="Don't show any output except for errors"
+    flag "-S --silent" help="Don't show any output except for errors" env=MISE_SILENT
     flag "-t --tool" help="Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10" var=#true {
+        long_help #"""
+Tool(s) to run in addition to what is in mise.toml files
+e.g.: node@20 python@3.10
+"""#
         arg <TOOL@VERSION>
     }
     flag --allow-env help=#"""
@@ -3274,16 +2842,17 @@ Supports wildcards, e.g. --allow-env='MYAPP_*'
     flag --deny-read help="Block filesystem reads (system libs and tool dirs still accessible)"
     flag --deny-write help="Block all filesystem writes"
     flag --fresh-env help="Bypass the environment cache and recompute the environment"
-    flag --no-cache help="Do not use cache on remote tasks"
+    flag --no-cache help="Do not use cache on remote tasks" env=MISE_TASK_REMOTE_NO_CACHE
     flag --no-deps help="Skip automatic dependency preparation"
     flag --no-timings help="Hides elapsed time after each task completes" {
+        alias "--no-timing" hide=#true
         long_help #"""
 Hides elapsed time after each task completes
 
 Default to always hide with `MISE_TASK_TIMINGS=0`
 """#
     }
-    flag --skip-deps help="Run only the specified tasks skipping all dependencies"
+    flag --skip-deps help="Run only the specified tasks skipping all dependencies" env=MISE_TASK_SKIP_DEPENDS
     flag --skip-tools help="Skip installing tools before running tasks" {
         long_help #"""
 Skip installing tools before running tasks
@@ -3292,7 +2861,7 @@ Can also be set persistently with the `task.run_auto_install` setting
 or `MISE_TASK_RUN_AUTO_INSTALL=false` env var
 """#
     }
-    flag --task-cache help="Set task output cache access for this run" default=read-write {
+    flag --task-cache help="Set task output cache access for this run" env=MISE_TASK_CACHE default=read-write {
         long_help #"""
 Set task output cache access for this run
 
@@ -3303,12 +2872,18 @@ Set task output cache access for this run
 - `local-only` - Read and write only the local cache; currently equivalent to `read-write`
 """#
         arg <TASK_CACHE> {
-            choices read-write read-only write-only off local-only
+            choices {
+                choice read-write help="Read cached results and write new results."
+                choice read-only help="Read cached results without writing new results."
+                choice write-only help="Write new results without reading cached results."
+                choice off help="Disable task output caching for this run."
+                choice local-only help="Read and write only the local cache."
+            }
         }
     }
     flag --task-cache-explain help="Explain the inputs that produced each task's output cache key"
-    flag --task-cache-explain-json help="Output cache-key input details as JSON Lines without running tasks"
-    flag --task-cache-stats help="Report task output cache hits, restored bytes, and time saved"
+    flag --task-cache-explain-json help="Output cache-key input details as JSON Lines without running tasks" conflicts=--task-cache-explain requires=--dry-run
+    flag --task-cache-stats help="Report task output cache hits, restored bytes, and time saved" conflicts=--dry-run
     flag --timeout help=#"""
 Timeout for the task to complete
 e.g.: 30s, 5m
@@ -3316,6 +2891,7 @@ e.g.: 30s, 5m
         arg <TIMEOUT>
     }
     flag --timings help="Shows elapsed time after each task completes" hide=#true {
+        alias "--timing" hide=#true
         long_help #"""
 Shows elapsed time after each task completes
 
@@ -3323,6 +2899,7 @@ Default to always show with `MISE_TASK_TIMINGS=1`
 """#
     }
     mount run="mise tasks --usage"
+    complete cd type=dir
 }
 cmd search help="Search for tools in the registry" effect=read {
     long_help #"""
@@ -3333,34 +2910,22 @@ This command searches a tool in the registry.
 By default, it will show all tools that fuzzy match the search term. For
 non-fuzzy matches, use the `--match-type` flag.
 """#
-    after_long_help #"""
-Examples:
-
-    $ mise search jq
-    Tool  Description
-    jq    Command-line JSON processor. https://github.com/jqlang/jq
-    jqp   A TUI playground to experiment with jq. https://github.com/noahgorstein/jqp
-    jiq   jid on jq - interactive JSON query tool using jq expressions. https://github.com/fiatjaf/jiq
-    gojq  Pure Go implementation of jq. https://github.com/itchyny/gojq
-
-    $ mise search --interactive
-    Tool
-    Search a tool
-    ❯ jq    Command-line JSON processor. https://github.com/jqlang/jq
-      jqp   A TUI playground to experiment with jq. https://github.com/noahgorstein/jqp
-      jiq   jid on jq - interactive JSON query tool using jq expressions. https://github.com/fiatjaf/jiq
-      gojq  Pure Go implementation of jq. https://github.com/itchyny/gojq
-    /jq 
-    esc clear filter • enter confirm
-
-"""#
-    flag "-i --interactive" help="Show interactive search"
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise search jq\u{1b}[22m\n    Tool  Description\n    jq    Command-line JSON processor. https://github.com/jqlang/jq\n    jqp   A TUI playground to experiment with jq. https://github.com/noahgorstein/jqp\n    jiq   jid on jq - interactive JSON query tool using jq expressions. https://github.com/fiatjaf/jiq\n    gojq  Pure Go implementation of jq. https://github.com/itchyny/gojq\n\n    $ \u{1b}[1mmise search --interactive\u{1b}[22m\n    Tool\n    Search a tool\n    ❯ jq    Command-line JSON processor. https://github.com/jqlang/jq\n      jqp   A TUI playground to experiment with jq. https://github.com/noahgorstein/jqp\n      jiq   jid on jq - interactive JSON query tool using jq expressions. https://github.com/fiatjaf/jiq\n      gojq  Pure Go implementation of jq. https://github.com/itchyny/gojq\n    /jq \n    esc clear filter • enter confirm\n"
+    flag "-i --interactive" help="Show interactive search" {
+        conflicts "--match-type" "--no-header"
+    }
     flag "-m --match-type" help="Match type: equal, contains, or fuzzy" default=fuzzy {
         arg <MATCH_TYPE> {
-            choices equal contains fuzzy
+            choices {
+                choice equal
+                choice contains
+                choice fuzzy
+            }
         }
     }
-    flag --no-header help="Don't display headers"
+    flag --no-header help="Don't display headers" {
+        alias "--no-headers" hide=#true
+    }
     arg "[NAME]" help="The tool to search for" required=#false
 }
 cmd self-update help="Updates mise itself." effect=write {
@@ -3392,44 +2957,16 @@ See https://mise.jdx.dev/configuration.html#target-file-for-write-operations
 
 Use `-E <env>` to create/modify environment-specific config files like `mise.<env>.toml`.
 """#
-    after_long_help #"""
-Examples:
-
-    $ mise set NODE_ENV=production
-
-    $ mise set NODE_ENV
-    production
-
-    $ mise set -E staging NODE_ENV=staging
-    # creates or modifies mise.staging.toml
-
-    $ mise set
-    key       value       source
-    NODE_ENV  production  ~/.config/mise/config.toml
-
-    $ mise set --prompt PASSWORD
-    Enter value for PASSWORD: [hidden input]
-
-    Multiline Values (--stdin):
-
-    $ cat private.key | mise set --stdin MY_KEY
-
-    $ printf "line1\nline2" | mise set --stdin MY_KEY
-
-    [experimental] Age Encryption:
-
-    $ mise set --age-encrypt API_KEY=secret
-
-    $ mise set --age-encrypt --prompt API_KEY
-    Enter value for API_KEY: [hidden input]
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise set NODE_ENV=production\u{1b}[22m\n\n    $ \u{1b}[1mmise set NODE_ENV\u{1b}[22m\n    production\n\n    $ \u{1b}[1mmise set -E staging NODE_ENV=staging\u{1b}[22m\n    # creates or modifies mise.staging.toml\n\n    $ \u{1b}[1mmise set\u{1b}[22m\n    key       value       source\n    NODE_ENV  production  ~/.config/mise/config.toml\n\n    $ \u{1b}[1mmise set --prompt PASSWORD\u{1b}[22m\n    Enter value for PASSWORD: [hidden input]\n\n    \u{1b}[1m\u{1b}[4mMultiline Values (--stdin):\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mcat private.key | mise set --stdin MY_KEY\u{1b}[22m\n\n    $ \u{1b}[1mprintf \"line1\\nline2\" | mise set --stdin MY_KEY\u{1b}[22m\n\n    \u{1b}[1m\u{1b}[4m[experimental] Age Encryption:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise set --age-encrypt API_KEY=secret\u{1b}[22m\n\n    $ \u{1b}[1mmise set --age-encrypt --prompt API_KEY\u{1b}[22m\n    Enter value for API_KEY: [hidden input]\n"
     flag "-E --env" help="Create/modify an environment-specific config file like .mise.<env>.toml" {
+        overrides "--global" "--file"
         arg <ENV>
     }
-    flag "-g --global" help="Set the environment variable in the global config file"
-    flag --age-encrypt help="[experimental] Encrypt the value with age before storing"
-    flag --age-key-file help="[experimental] Age identity file for encryption" {
+    flag "-g --global" help="Set the environment variable in the global config file" {
+        overrides "--file" "--env"
+    }
+    flag --age-encrypt help="[experimental] Encrypt the value with age before storing" requires=ENV_VAR
+    flag --age-key-file help="[experimental] Age identity file for encryption" requires=--age-encrypt {
         long_help #"""
 [experimental] Age identity file for encryption
 
@@ -3437,7 +2974,7 @@ Defaults to ~/.config/mise/age.txt if it exists
 """#
         arg <PATH>
     }
-    flag --age-recipient help="[experimental] Age recipient (x25519 public key) for encryption" var=#true {
+    flag --age-recipient help="[experimental] Age recipient (x25519 public key) for encryption" var=#true requires=--age-encrypt {
         long_help #"""
 [experimental] Age recipient (x25519 public key) for encryption
 
@@ -3445,7 +2982,7 @@ Can be used multiple times. Requires --age-encrypt.
 """#
         arg <RECIPIENT>
     }
-    flag --age-ssh-recipient help="[experimental] SSH recipient (public key or path) for age encryption" var=#true {
+    flag --age-ssh-recipient help="[experimental] SSH recipient (public key or path) for age encryption" var=#true requires=--age-encrypt {
         long_help #"""
 [experimental] SSH recipient (public key or path) for age encryption
 
@@ -3474,42 +3011,23 @@ Can be used multiple times.
 """#
         arg <ENV_KEY>
     }
-    flag --stdin help="Read the value from stdin (for multiline input)" {
+    flag --stdin help="Read the value from stdin (for multiline input)" conflicts=--prompt requires=ENV_VAR {
         long_help #"""
 Read the value from stdin (for multiline input)
 
-When using --stdin, provide a single key without a value. The value will be read from stdin until EOF.
+When using --stdin, provide a single key without a value.
+The value will be read from stdin until EOF.
 """#
     }
     arg "[ENV_VAR]…" help=#"""
 Environment variable(s) to set
 e.g.: NODE_ENV=production
 """# required=#false var=#true
+    complete path type=path
+    complete file type=path
 }
 cmd settings help="Manage settings" effect=write {
-    long_help #"""
-Show current settings
-
-This is the contents of ~/.config/mise/config.toml
-
-Note that aliases are also stored in this file
-but managed separately with `mise tool-alias`
-"""#
-    after_long_help #"""
-Examples:
-    # list all settings
-    $ mise settings
-
-    # get the value of the setting "always_keep_download"
-    $ mise settings always_keep_download
-
-    # set the value of the setting "always_keep_download" to "true"
-    $ mise settings always_keep_download=true
-
-    # set the value of the setting "node.mirror_url" to "https://npmmirror.com/mirrors/node/"
-    $ mise settings node.mirror_url https://npmmirror.com/mirrors/node/
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n    # list all settings\n    $ \u{1b}[1mmise settings\u{1b}[22m\n\n    # get the value of the setting \"always_keep_download\"\n    $ \u{1b}[1mmise settings always_keep_download\u{1b}[22m\n\n    # set the value of the setting \"always_keep_download\" to \"true\"\n    $ \u{1b}[1mmise settings always_keep_download=true\u{1b}[22m\n\n    # set the value of the setting \"node.mirror_url\" to \"https://npmmirror.com/mirrors/node/\"\n    $ \u{1b}[1mmise settings node.mirror_url https://npmmirror.com/mirrors/node/\u{1b}[22m\n"
     flag "-a --all" help="List all settings"
     flag "-J --json" help="Output in JSON format"
     flag "-l --local" help="Use the local config file instead of the global one" global=#true
@@ -3517,7 +3035,8 @@ Examples:
     flag --complete help="Print all settings with descriptions for shell completions" hide=#true
     flag --json-extended help="Output in JSON format with sources"
     arg "[SETTING]" help="Name of setting" required=#false
-    arg "[VALUE]" help="Setting value to set" required=#false
+    arg "[VALUE]" help="Setting value to set" required=#false conflicts=all
+    group output "--json" "--toml" "--json-extended"
     cmd add help="Adds a setting to the configuration file" effect=write {
         long_help #"""
 Adds a setting to the configuration file
@@ -3525,12 +3044,7 @@ Adds a setting to the configuration file
 Used with an array setting, this will append the value to the array.
 This modifies the contents of ~/.config/mise/config.toml
 """#
-        after_long_help #"""
-Examples:
-
-    $ mise settings add disable_hints python_multi
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise settings add disable_hints python_multi\u{1b}[22m\n"
         flag "-l --local" help="Use the local config file instead of the global one"
         arg <SETTING> help="The setting to set"
         arg "[VALUE]" help="The value to set (optional if provided as KEY=VALUE)" required=#false
@@ -3544,13 +3058,7 @@ This is the contents of a single entry in ~/.config/mise/config.toml
 Note that aliases are also stored in this file
 but managed separately with `mise tool-alias get`
 """#
-        after_long_help #"""
-Examples:
-
-    $ mise settings get idiomatic_version_file
-    true
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise settings get idiomatic_version_file\u{1b}[22m\n    true\n"
         flag "-l --local" help="Use the local config file instead of the global one"
         arg <SETTING> help="The setting to show"
     }
@@ -3564,18 +3072,7 @@ This is the contents of ~/.config/mise/config.toml
 Note that aliases are also stored in this file
 but managed separately with `mise tool-alias`
 """#
-        after_long_help #"""
-Examples:
-
-    $ mise settings ls
-    idiomatic_version_file = false
-    ...
-
-    $ mise settings ls python
-    default_packages_file = "~/.default-python-packages"
-    ...
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise settings ls\u{1b}[22m\n    idiomatic_version_file = false\n    ...\n\n    $ \u{1b}[1mmise settings ls python\u{1b}[22m\n    default_packages_file = \"~/.default-python-packages\"\n    ...\n"
         flag "-a --all" help="List all settings"
         flag "-J --json" help="Output in JSON format"
         flag "-l --local" help="Use the local config file instead of the global one" global=#true
@@ -3583,6 +3080,7 @@ Examples:
         flag --complete help="Print all settings with descriptions for shell completions" hide=#true
         flag --json-extended help="Output in JSON format with sources"
         arg "[SETTING]" help="Name of setting" required=#false
+        group output "--json" "--toml" "--json-extended"
     }
     cmd set help="Add/update a setting" effect=write {
         alias create
@@ -3593,12 +3091,7 @@ This modifies the contents of ~/.config/mise/config.toml by default.
 With `--local`, modifies the local config file instead.
 See https://mise.jdx.dev/configuration.html#target-file-for-write-operations
 """#
-        after_long_help #"""
-Examples:
-
-    $ mise settings idiomatic_version_file=true
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise settings idiomatic_version_file=true\u{1b}[22m\n"
         flag "-l --local" help="Use the local config file instead of the global one"
         arg <SETTING> help="The setting to set"
         arg "[VALUE]" help="The value to set (optional if provided as KEY=VALUE)" required=#false
@@ -3610,12 +3103,7 @@ Clears a setting
 
 This modifies the contents of ~/.config/mise/config.toml
 """#
-        after_long_help #"""
-Examples:
-
-    $ mise settings unset idiomatic_version_file
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise settings unset idiomatic_version_file\u{1b}[22m\n"
         flag "-l --local" help="Use the local config file instead of the global one"
         arg <KEY> help="The setting to remove"
     }
@@ -3630,34 +3118,27 @@ Only works in a session where mise is already activated.
 This works by setting environment variables for the current shell session
 such as `MISE_NODE_VERSION=20` which is "eval"ed as a shell function created by `mise activate`.
 """#
-    after_long_help #"""
-Examples:
-
-    $ mise shell node@20
-    $ node -v
-    v20.0.0
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise shell node@20\u{1b}[22m\n    $ \u{1b}[1mnode -v\u{1b}[22m\n    v20.0.0\n"
     flag "-j --jobs" help=#"""
 Number of jobs to run in parallel
+Values below 1 are treated as 1
 [default: 4]
-"""# {
+"""# env=MISE_JOBS {
         arg <JOBS>
     }
     flag "-u --unset" help="Removes a previously set version"
-    flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1"
+    flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1" overrides=--jobs {
+        long_help #"""
+Connect backend install command stdin/stdout/stderr directly to the terminal
+Implies --jobs=1
+"""#
+    }
     arg <TOOL@VERSION>… help="Tool(s) to use" var=#true
 }
 cmd shell-alias help="Manage shell aliases." effect=read {
     flag --no-header help="Don't show table header"
     cmd get help="Show the command for a shell alias" effect=read {
-        after_long_help #"""
-Examples:
-
-    $ mise shell-alias get ll
-    ls -la
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise shell-alias get ll\u{1b}[22m\n    ls -la\n"
         arg <shell_alias> help="The alias to show"
     }
     cmd ls help="List shell aliases" effect=read {
@@ -3668,15 +3149,7 @@ List shell aliases
 Shows the shell aliases that are set in the current directory.
 These are defined in `mise.toml` under the `[shell_alias]` section.
 """#
-        after_long_help #"""
-Examples:
-
-    $ mise shell-alias ls
-    alias    command
-    ll       ls -la
-    gs       git status
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise shell-alias ls\u{1b}[22m\n    alias    command\n    ll       ls -la\n    gs       git status\n"
         flag --no-header help="Don't show table header"
     }
     cmd set help="Add/update a shell alias" effect=write {
@@ -3686,13 +3159,7 @@ Add/update a shell alias
 
 This modifies the contents of ~/.config/mise/config.toml
 """#
-        after_long_help #"""
-Examples:
-
-    $ mise shell-alias set ll "ls -la"
-    $ mise shell-alias set gs "git status"
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise shell-alias set ll \"ls -la\"\u{1b}[22m\n    $ \u{1b}[1mmise shell-alias set gs \"git status\"\u{1b}[22m\n"
         arg <shell_alias> help="The alias name"
         arg "[COMMAND]" help="The command to run (optional if provided as ALIAS=COMMAND)" required=#false
     }
@@ -3703,12 +3170,7 @@ Removes a shell alias
 
 This modifies the contents of ~/.config/mise/config.toml
 """#
-        after_long_help #"""
-Examples:
-
-    $ mise shell-alias unset ll
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise shell-alias unset ll\u{1b}[22m\n"
         arg <shell_alias> help="The alias to remove"
     }
 }
@@ -3720,19 +3182,13 @@ Symlinks all tool versions from an external tool into mise
 
 For example, use this to import all Homebrew node installs into mise
 
-This won't overwrite any existing installs but will overwrite any existing symlinks
+This won't overwrite managed installs, runtime aliases, or links from other providers.
 """#
-        after_long_help #"""
-Examples:
-
-    $ brew install node@18 node@20
-    $ mise sync node --brew
-    $ mise use -g node@18 - uses Homebrew-provided node
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mbrew install node@18 node@20\u{1b}[22m\n    $ \u{1b}[1mmise sync node --brew\u{1b}[22m\n    $ \u{1b}[1mmise use -g node@18\u{1b}[22m - uses Homebrew-provided node\n"
         flag --brew help="Get tool versions from Homebrew"
         flag --nodenv help="Get tool versions from nodenv"
         flag --nvm help="Get tool versions from nvm"
+        group SyncNodeType "--brew" "--nodenv" "--nvm" required=#true multiple=#true
     }
     cmd python help="Symlinks all tool versions from an external tool into mise" effect=write {
         long_help #"""
@@ -3740,49 +3196,23 @@ Symlinks all tool versions from an external tool into mise
 
 For example, use this to import all pyenv installs into mise
 
-This won't overwrite any existing installs but will overwrite any existing symlinks
+This won't overwrite managed installs, runtime aliases, or links from other providers.
 """#
-        after_long_help #"""
-Examples:
-
-    $ pyenv install 3.11.0
-    $ mise sync python --pyenv
-    $ mise use -g python@3.11.0 - uses pyenv-provided python
-    
-    $ uv python install 3.11.0
-    $ mise install python@3.10.0
-    $ mise sync python --uv
-    $ mise x python@3.11.0 -- python -V - uses uv-provided python
-    $ uv run -p 3.10.0 -- python -V - uses mise-provided python
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mpyenv install 3.11.0\u{1b}[22m\n    $ \u{1b}[1mmise sync python --pyenv\u{1b}[22m\n    $ \u{1b}[1mmise use -g python@3.11.0\u{1b}[22m - uses pyenv-provided python\n    \n    $ \u{1b}[1muv python install 3.11.0\u{1b}[22m\n    $ \u{1b}[1mmise install python@3.10.0\u{1b}[22m\n    $ \u{1b}[1mmise sync python --uv\u{1b}[22m\n    $ \u{1b}[1mmise x python@3.11.0 -- python -V\u{1b}[22m - uses uv-provided python\n    $ \u{1b}[1muv run -p 3.10.0 -- python -V\u{1b}[22m - uses mise-provided python\n"
         flag --pyenv help="Get tool versions from pyenv"
         flag --uv help="Sync tool versions with uv (2-way sync)"
     }
     cmd ruby help="Symlinks all ruby tool versions from an external tool into mise" effect=write {
-        after_long_help #"""
-Examples:
-
-    $ brew install ruby
-    $ mise sync ruby --brew
-    $ mise use -g ruby - Use the latest version of Ruby installed by Homebrew
-
-"""#
-        flag --brew help="Get tool versions from Homebrew"
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mbrew install ruby\u{1b}[22m\n    $ \u{1b}[1mmise sync ruby --brew\u{1b}[22m\n    $ \u{1b}[1mmise use -g ruby\u{1b}[22m - Use the latest version of Ruby installed by Homebrew\n"
+        flag --brew help="Get tool versions from Homebrew" required=#true
     }
 }
 cmd tasks help="Manage tasks" effect=read {
     alias t
     alias task hide=#true
-    after_long_help #"""
-Examples:
-
-    $ mise tasks ls
-
-"""#
-    flag "-g --global" help="Only show global tasks"
+    flag "-g --global" help="Only show global tasks" overrides=--local
     flag "-J --json" help="Output in JSON format"
-    flag "-l --local" help="Only show non-global tasks"
+    flag "-l --local" help="Only show non-global tasks" overrides=--global
     flag "-x --extended" help="Show all columns"
     flag --all help=#"""
 Load all tasks from the entire monorepo, including sibling directories.
@@ -3790,16 +3220,28 @@ By default, only tasks from the current directory hierarchy are loaded.
 """#
     flag --complete help="Display tasks for usage completion" hide=#true
     flag --hidden help="Show hidden tasks"
-    flag --name-only help="Only show task names, one per line. Useful for piping to fzf and similar tools."
-    flag --no-header help="Do not print table header"
+    flag --name-only help="Only show task names, one per line. Useful for piping to fzf and similar tools." {
+        conflicts "--json" "--extended" "--usage"
+    }
+    flag --no-header help="Do not print table header" {
+        alias "--no-headers" hide=#true
+    }
     flag --sort help="Sort by column. Default is name." {
         arg <COLUMN> {
-            choices name alias description source
+            choices {
+                choice name
+                choice alias
+                choice description
+                choice source
+            }
         }
     }
     flag --sort-order help="Sort order. Default is asc." {
         arg <SORT_ORDER> {
-            choices asc desc
+            choices {
+                choice asc
+                choice desc
+            }
         }
     }
     flag --usage hide=#true
@@ -3811,12 +3253,7 @@ Create a new task
 Adds a task to the local mise.toml file.
 See https://mise.jdx.dev/configuration.html#target-file-for-write-operations
 """#
-        after_long_help #"""
-Examples:
-
-    $ mise tasks add pre-commit --depends "test" --depends "render" -- echo pre-commit
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise tasks add pre-commit --depends \"test\" --depends \"render\" -- echo pre-commit\u{1b}[22m\n"
         flag "-a --alias" help="Other names for the task" var=#true {
             arg <ALIAS>
         }
@@ -3856,23 +3293,8 @@ Examples:
         arg "[-- RUN]…" required=#false var=#true
     }
     cmd deps help="Display a tree visualization of a dependency graph" effect=read {
-        after_long_help #"""
-Examples:
-
-    # Show dependencies for all tasks
-    $ mise tasks deps
-
-    # Show dependencies for the "lint", "test" and "check" tasks
-    $ mise tasks deps lint test check
-
-    # Show dependencies in DOT format
-    $ mise tasks deps --dot
-
-    # Collapse repeated dependencies
-    $ mise tasks deps --compact
-
-"""#
-        flag --compact help="Collapse repeated dependencies after their first occurrence"
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Show dependencies for all tasks\n    $ \u{1b}[1mmise tasks deps\u{1b}[22m\n\n    # Show dependencies for the \"lint\", \"test\" and \"check\" tasks\n    $ \u{1b}[1mmise tasks deps lint test check\u{1b}[22m\n\n    # Show dependencies in DOT format\n    $ \u{1b}[1mmise tasks deps --dot\u{1b}[22m\n\n    # Collapse repeated dependencies\n    $ \u{1b}[1mmise tasks deps --compact\u{1b}[22m\n"
+        flag --compact help="Collapse repeated dependencies after their first occurrence" conflicts=--dot
         flag --dot help="Display dependencies in DOT format"
         flag --hidden help="Show hidden tasks"
         arg "[TASKS]…" help=#"""
@@ -3887,66 +3309,20 @@ Edit a task with $EDITOR
 
 The task will be created as a standalone script if it does not already exist.
 """#
-        after_long_help #"""
-Examples:
-
-    $ mise tasks edit build
-    $ mise tasks edit test
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise tasks edit build\u{1b}[22m\n    $ \u{1b}[1mmise tasks edit test\u{1b}[22m\n"
         flag "-p --path" help="Display the path to the task instead of editing it"
         arg <TASK> help="Task to edit"
     }
     cmd graph help="[experimental] Inspect the workspace project graph" effect=read {
-        after_long_help #"""
-Examples:
-
-    # Inspect projects and their dependency edges
-    $ mise tasks graph
-
-    # Emit the project graph as JSON
-    $ mise tasks graph --json
-
-    # Explain where inferred projects and task fields came from
-    $ mise tasks graph --explain
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Inspect projects and their dependency edges\n    $ \u{1b}[1mmise tasks graph\u{1b}[22m\n\n    # Emit the project graph as JSON\n    $ \u{1b}[1mmise tasks graph --json\u{1b}[22m\n\n    # Explain where inferred projects and task fields came from\n    $ \u{1b}[1mmise tasks graph --explain\u{1b}[22m\n"
         flag "-J --json" help="Output the project graph as JSON"
-        flag --explain help="Explain provider attribution for inferred projects and tasks"
-        flag --no-header help="Do not print table headers"
+        flag --explain help="Explain provider attribution for inferred projects and tasks" conflicts=--json
+        flag --no-header help="Do not print table headers" {
+            alias "--no-headers" hide=#true
+        }
     }
     cmd info help="Get information about a task" effect=read {
-        after_long_help #"""
-Examples:
-
-    $ mise tasks info
-    Name: test
-    Aliases: t
-    Description: Test the application
-    Source: ~/src/myproj/mise.toml
-
-    $ mise tasks info test --json
-    {
-      "name": "test",
-      "aliases": "t",
-      "description": "Test the application",
-      "source": "~/src/myproj/mise.toml",
-      "config_sources": ["~/src/myproj/mise.toml"],
-      "depends": [],
-      "env": {},
-      "dir": null,
-      "hide": false,
-      "raw": false,
-      "sources": [],
-      "outputs": [],
-      "run": [
-        "echo \"testing!\""
-      ],
-      "file": null,
-      "usage_spec": {}
-    }
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise tasks info\u{1b}[22m\n    Name: test\n    Aliases: t\n    Description: Test the application\n    Source: ~/src/myproj/mise.toml\n\n    $ \u{1b}[1mmise tasks info test --json\u{1b}[22m\n    {\n      \"name\": \"test\",\n      \"aliases\": \"t\",\n      \"description\": \"Test the application\",\n      \"source\": \"~/src/myproj/mise.toml\",\n      \"config_sources\": [\"~/src/myproj/mise.toml\"],\n      \"depends\": [],\n      \"env\": {},\n      \"dir\": null,\n      \"hide\": false,\n      \"raw\": false,\n      \"sources\": [],\n      \"outputs\": [],\n      \"run\": [\n        \"echo \\\"testing!\\\"\"\n      ],\n      \"file\": null,\n      \"usage_spec\": {}\n    }\n"
         flag "-J --json" help="Output in JSON format"
         arg <TASK> help="Name of the task to get information about"
     }
@@ -3964,15 +3340,10 @@ So if you have global tasks in `~/.config/mise/tasks/*` and project-specific tas
 ~/myproject/.mise/tasks/*, then they'll both be available but the project-specific
 tasks will override the global ones if they have the same name.
 """#
-        after_long_help #"""
-Examples:
-
-    $ mise tasks ls
-
-"""#
-        flag "-g --global" help="Only show global tasks"
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise tasks ls\u{1b}[22m\n"
+        flag "-g --global" help="Only show global tasks" overrides=--local
         flag "-J --json" help="Output in JSON format"
-        flag "-l --local" help="Only show non-global tasks"
+        flag "-l --local" help="Only show non-global tasks" overrides=--global
         flag "-x --extended" help="Show all columns"
         flag --all help=#"""
 Load all tasks from the entire monorepo, including sibling directories.
@@ -3980,21 +3351,33 @@ By default, only tasks from the current directory hierarchy are loaded.
 """#
         flag --complete help="Display tasks for usage completion" hide=#true
         flag --hidden help="Show hidden tasks"
-        flag --name-only help="Only show task names, one per line. Useful for piping to fzf and similar tools."
-        flag --no-header help="Do not print table header"
+        flag --name-only help="Only show task names, one per line. Useful for piping to fzf and similar tools." {
+            conflicts "--json" "--extended" "--usage"
+        }
+        flag --no-header help="Do not print table header" {
+            alias "--no-headers" hide=#true
+        }
         flag --sort help="Sort by column. Default is name." {
             arg <COLUMN> {
-                choices name alias description source
+                choices {
+                    choice name
+                    choice alias
+                    choice description
+                    choice source
+                }
             }
         }
         flag --sort-order help="Sort order. Default is asc." {
             arg <SORT_ORDER> {
-                choices asc desc
+                choices {
+                    choice asc
+                    choice desc
+                }
             }
         }
         flag --usage hide=#true
     }
-    cmd run restart_token=::: help="Run task(s)" {
+    cmd run disable_help_flag=#true restart_token=::: help="Run task(s)" {
         alias r
         long_help #"""
 Run task(s)
@@ -4023,42 +3406,25 @@ The name of the script will be the name of the tasks.
     EOF
     $ mise run build
 """#
-        after_long_help #"""
-Examples:
-
-    # Runs the "lint" tasks. This needs to either be defined in mise.toml
-    # or as a standalone script. See the project README for more information.
-    $ mise run lint
-
-    # Forces the "build" tasks to run even if its sources are up-to-date.
-    $ mise run --force build
-
-    # Run "test" with stdin/stdout/stderr all connected to the current terminal.
-    # This forces `--jobs=1` to prevent interleaving of output.
-    $ mise run --raw test
-
-    # Runs the "lint", "test", and "check" tasks in parallel.
-    $ mise run lint ::: test ::: check
-
-    # Execute multiple tasks each with their own arguments.
-    $ mise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Runs the \"lint\" tasks. This needs to either be defined in mise.toml\n    # or as a standalone script. See the project README for more information.\n    $ \u{1b}[1mmise run lint\u{1b}[22m\n\n    # Forces the \"build\" tasks to run even if its sources are up-to-date.\n    $ \u{1b}[1mmise run --force build\u{1b}[22m\n\n    # Run \"test\" with stdin/stdout/stderr all connected to the current terminal.\n    # This forces `--jobs=1` to prevent interleaving of output.\n    $ \u{1b}[1mmise run --raw test\u{1b}[22m\n\n    # Runs the \"lint\", \"test\", and \"check\" tasks in parallel.\n    $ \u{1b}[1mmise run lint ::: test ::: check\u{1b}[22m\n\n    # Execute multiple tasks each with their own arguments.\n    $ \u{1b}[1mmise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2\u{1b}[22m\n"
         flag --affected help="Run matching tasks only for projects affected by Git changes"
         flag --affected-base help=#"""
 Git base revision for --affected
 Defaults to MISE_AFFECTED_BASE, CI metadata, or HEAD~1
-"""# {
+"""# requires=--affected {
             arg <REV>
         }
-        flag --affected-explain help="Explain why projects and tasks were selected by --affected"
+        flag --affected-explain help="Explain why projects and tasks were selected by --affected" conflicts=--affected-json requires=--affected
         flag --affected-head help=#"""
 Git head revision for --affected
 Defaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD
-"""# {
+"""# requires=--affected {
             arg <REV>
         }
-        flag --affected-json help="Output affected projects and tasks as JSON without running tasks"
+        flag --affected-json help="Output affected projects and tasks as JSON without running tasks" conflicts=--affected-explain requires=--affected
+        flag --all help="Open the interactive selector with all tasks from the entire monorepo" {
+            conflicts TASK "--affected"
+        }
         flag "-c --continue-on-error" help="Continue running tasks even if one fails"
         flag "-C --cd" help="Change to this directory before executing the command" {
             arg <CD>
@@ -4066,13 +3432,14 @@ Defaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD
         flag "-f --force" help="Force the tasks to run even if outputs are up to date"
         flag "-j --jobs" help=#"""
 Number of tasks to run in parallel
+Values below 1 are treated as 1
 [default: 4]
 Configure with `jobs` config or `MISE_JOBS` env var
-"""# {
+"""# env=MISE_JOBS {
             arg <JOBS>
         }
         flag "-n --dry-run" help="Don't actually run the task(s), just print them in order of execution"
-        flag "-o --output" help="Change how tasks information is output when running tasks" {
+        flag "-o --output" help="Change how tasks information is output when running tasks" env=MISE_TASK_OUTPUT {
             long_help #"""
 Change how tasks information is output when running tasks
 
@@ -4086,7 +3453,7 @@ Change how tasks information is output when running tasks
 """#
             arg <OUTPUT>
         }
-        flag "-q --quiet" help="Don't show extra output"
+        flag "-q --quiet" help="Don't show extra output" env=MISE_QUIET
         flag "-r --raw" help=#"""
 Read/write directly to stdin/stdout/stderr instead of by line
 Redactions are not applied with this option
@@ -4102,8 +3469,12 @@ Or it can be overridden with the `shell` property on a task.
 """#
             arg <SHELL>
         }
-        flag "-S --silent" help="Don't show any output except for errors"
+        flag "-S --silent" help="Don't show any output except for errors" env=MISE_SILENT
         flag "-t --tool" help="Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10" var=#true {
+            long_help #"""
+Tool(s) to run in addition to what is in mise.toml files
+e.g.: node@20 python@3.10
+"""#
             arg <TOOL@VERSION>
         }
         flag --allow-env help=#"""
@@ -4127,16 +3498,17 @@ Supports wildcards, e.g. --allow-env='MYAPP_*'
         flag --deny-read help="Block filesystem reads (system libs and tool dirs still accessible)"
         flag --deny-write help="Block all filesystem writes"
         flag --fresh-env help="Bypass the environment cache and recompute the environment"
-        flag --no-cache help="Do not use cache on remote tasks"
+        flag --no-cache help="Do not use cache on remote tasks" env=MISE_TASK_REMOTE_NO_CACHE
         flag --no-deps help="Skip automatic dependency preparation"
         flag --no-timings help="Hides elapsed time after each task completes" {
+            alias "--no-timing" hide=#true
             long_help #"""
 Hides elapsed time after each task completes
 
 Default to always hide with `MISE_TASK_TIMINGS=0`
 """#
         }
-        flag --skip-deps help="Run only the specified tasks skipping all dependencies"
+        flag --skip-deps help="Run only the specified tasks skipping all dependencies" env=MISE_TASK_SKIP_DEPENDS
         flag --skip-tools help="Skip installing tools before running tasks" {
             long_help #"""
 Skip installing tools before running tasks
@@ -4145,7 +3517,7 @@ Can also be set persistently with the `task.run_auto_install` setting
 or `MISE_TASK_RUN_AUTO_INSTALL=false` env var
 """#
         }
-        flag --task-cache help="Set task output cache access for this run" default=read-write {
+        flag --task-cache help="Set task output cache access for this run" env=MISE_TASK_CACHE default=read-write {
             long_help #"""
 Set task output cache access for this run
 
@@ -4156,12 +3528,18 @@ Set task output cache access for this run
 - `local-only` - Read and write only the local cache; currently equivalent to `read-write`
 """#
             arg <TASK_CACHE> {
-                choices read-write read-only write-only off local-only
+                choices {
+                    choice read-write help="Read cached results and write new results."
+                    choice read-only help="Read cached results without writing new results."
+                    choice write-only help="Write new results without reading cached results."
+                    choice off help="Disable task output caching for this run."
+                    choice local-only help="Read and write only the local cache."
+                }
             }
         }
         flag --task-cache-explain help="Explain the inputs that produced each task's output cache key"
-        flag --task-cache-explain-json help="Output cache-key input details as JSON Lines without running tasks"
-        flag --task-cache-stats help="Report task output cache hits, restored bytes, and time saved"
+        flag --task-cache-explain-json help="Output cache-key input details as JSON Lines without running tasks" conflicts=--task-cache-explain requires=--dry-run
+        flag --task-cache-stats help="Report task output cache hits, restored bytes, and time saved" conflicts=--dry-run
         flag --timeout help=#"""
 Timeout for the task to complete
 e.g.: 30s, 5m
@@ -4169,6 +3547,7 @@ e.g.: 30s, 5m
             arg <TIMEOUT>
         }
         flag --timings help="Shows elapsed time after each task completes" hide=#true {
+            alias "--timing" hide=#true
             long_help #"""
 Shows elapsed time after each task completes
 
@@ -4179,43 +3558,15 @@ Default to always show with `MISE_TASK_TIMINGS=1`
 Tasks to run
 Can specify multiple tasks by separating with `:::`
 e.g.: mise run task1 arg1 arg2 ::: task2 arg1 arg2
-"""# required=#false default=default
-        arg "[ARGS]…" help="Arguments to pass to the tasks. Use \":::\" to separate tasks" required=#false var=#true
-        arg "[-- ARGS_LAST]…" help="Arguments to pass to the tasks. Use \":::\" to separate tasks" required=#false var=#true hide=#true
+Defaults to `default` when omitted
+"""# required=#false double_dash=automatic
+        arg "[ARGS]…" help="Arguments to pass to the tasks. Use \":::\" to separate tasks." required=#false var=#true
+        arg "[-- ARGS_LAST]…" help="Arguments to pass to the tasks. Use \":::\" to separate tasks." required=#false var=#true hide=#true
         mount run="mise tasks --usage"
+        complete cd type=dir
     }
     cmd validate help="Validate tasks for common errors and issues" effect=read {
-        after_long_help #"""
-Examples:
-
-    # Validate all tasks
-    $ mise tasks validate
-
-    # Validate specific tasks
-    $ mise tasks validate build test
-
-    # Output results as JSON
-    $ mise tasks validate --json
-
-    # Only show errors (skip warnings)
-    $ mise tasks validate --errors-only
-
-Validation Checks:
-
-The validate command performs the following checks:
-
-  • Circular Dependencies: Detects dependency cycles
-  • Missing References: Finds references to nonexistent tasks
-  • Usage Spec Parsing: Validates #USAGE directives and specs
-  • Timeout Format: Checks timeout values are valid durations
-  • Alias Conflicts: Detects duplicate aliases across tasks
-  • File Existence: Verifies file-based tasks exist
-  • Directory Templates: Validates directory paths and templates
-  • Shell Commands: Checks shell executables exist
-  • Glob Patterns: Validates source and output patterns
-  • Run Entries: Ensures tasks reference valid dependencies
-
-"""#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Validate all tasks\n    $ \u{1b}[1mmise tasks validate\u{1b}[22m\n\n    # Validate specific tasks\n    $ \u{1b}[1mmise tasks validate build test\u{1b}[22m\n\n    # Output results as JSON\n    $ \u{1b}[1mmise tasks validate --json\u{1b}[22m\n\n    # Only show errors (skip warnings)\n    $ \u{1b}[1mmise tasks validate --errors-only\u{1b}[22m\n\n\u{1b}[1m\u{1b}[4mValidation Checks:\u{1b}[22m\u{1b}[24m\n\nThe validate command performs the following checks:\n\n  • \u{1b}[1mCircular Dependencies\u{1b}[22m: Detects dependency cycles\n  • \u{1b}[1mMissing References\u{1b}[22m: Finds references to nonexistent tasks\n  • \u{1b}[1mUsage Spec Parsing\u{1b}[22m: Validates #USAGE directives and specs\n  • \u{1b}[1mTimeout Format\u{1b}[22m: Checks timeout values are valid durations\n  • \u{1b}[1mAlias Conflicts\u{1b}[22m: Detects duplicate aliases across tasks\n  • \u{1b}[1mFile Existence\u{1b}[22m: Verifies file-based tasks exist\n  • \u{1b}[1mDirectory Templates\u{1b}[22m: Validates directory paths and templates\n  • \u{1b}[1mShell Commands\u{1b}[22m: Checks shell executables exist\n  • \u{1b}[1mGlob Patterns\u{1b}[22m: Validates source and output patterns\n  • \u{1b}[1mRun Entries\u{1b}[22m: Ensures tasks reference valid dependencies\n"
         flag --errors-only help="Only show errors (skip warnings)"
         flag --json help="Output validation results in JSON format"
         arg "[TASKS]…" help=#"""
@@ -4225,96 +3576,83 @@ If not specified, validates all tasks
     }
 }
 cmd test-tool help="Test a tool installs and executes" {
-    after_long_help #"""
-Examples:
-
-    $ mise test-tool ripgrep
-
-"""#
-    flag "-a --all" help="Test every tool specified in registry/"
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise test-tool ripgrep\u{1b}[22m\n"
+    flag "-a --all" help="Test every tool specified in registry/" {
+        conflicts TOOLS "--all-config"
+    }
     flag "-j --jobs" help=#"""
 Number of tool tests to run in parallel
+Values below 1 are treated as 1
 [default: 4]
-"""# {
+"""# env=MISE_TEST_TOOL_JOBS {
         arg <JOBS>
     }
-    flag --all-config help="Test all tools specified in config files"
+    flag --all-config help="Test all tools specified in config files" {
+        conflicts TOOLS "--all"
+    }
     flag --include-non-defined help="Also test tools not defined in registry/, guessing how to test it"
-    flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1"
-    arg "[TOOLS]…" help="Tool(s) to test" required=#false var=#true
+    flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1" overrides=--jobs {
+        long_help #"""
+Connect backend install command stdin/stdout/stderr directly to the terminal
+Implies --jobs=1
+"""#
+    }
+    arg "[TOOLS]…" help="Tool(s) to test" required=#false var=#true {
+        required_unless "--all" "--all-config"
+    }
 }
 cmd token subcommand_required=#true help="Display git provider tokens mise will use" effect=read {
     cmd forgejo help="Forgejo token" effect=read {
-        after_long_help #"""
-Examples:
+        long_help #"""
+Display the Forgejo token mise will use for a given host
 
-    $ mise token forgejo
-    codeberg.org: a180…61f6 (source: FORGEJO_TOKEN)
-
-    $ mise token forgejo --unmask
-    codeberg.org: a18099ca69064be387fbe37b8ad1d333758361f6 (source: FORGEJO_TOKEN)
-
-    $ mise token forgejo forgejo.mycompany.com
-    forgejo.mycompany.com: (none)
-
+Shows which token source mise would use, useful for debugging
+authentication issues. The token is masked by default.
 """#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise token forgejo\u{1b}[22m\n    codeberg.org: a180…61f6 (source: FORGEJO_TOKEN)\n\n    $ \u{1b}[1mmise token forgejo --unmask\u{1b}[22m\n    codeberg.org: a18099ca69064be387fbe37b8ad1d333758361f6 (source: FORGEJO_TOKEN)\n\n    $ \u{1b}[1mmise token forgejo forgejo.mycompany.com\u{1b}[22m\n    forgejo.mycompany.com: (none)\n"
         flag --unmask help="Show the full unmasked token"
         arg "[HOST]" help="Forgejo hostname" required=#false default=codeberg.org
     }
     cmd github help="GitHub token" effect=read {
-        after_long_help #"""
-Examples:
+        long_help #"""
+Display the GitHub token mise will use for a given host
 
-    $ mise token github
-    github.com: ghp_…xxxx (source: GITHUB_TOKEN)
-
-    $ mise token github --unmask
-    github.com: ghp_xxxxxxxxxxxx (source: GITHUB_TOKEN)
-
-    $ mise token github github.mycompany.com
-    github.mycompany.com: (none)
-
-    $ mise token github --oauth --refresh
-    github.com: gho_…xxxx (source: GitHub OAuth)
-
+Shows which token source mise would use, useful for debugging
+authentication issues. The token is masked by default.
 """#
-        flag --oauth help="Resolve only via the native GitHub OAuth source (cache, refresh, or device-code flow), bypassing other token sources"
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise token github\u{1b}[22m\n    github.com: ghp_…xxxx (source: GITHUB_TOKEN)\n\n    $ \u{1b}[1mmise token github --unmask\u{1b}[22m\n    github.com: ghp_xxxxxxxxxxxx (source: GITHUB_TOKEN)\n\n    $ \u{1b}[1mmise token github github.mycompany.com\u{1b}[22m\n    github.mycompany.com: (none)\n\n    $ \u{1b}[1mmise token github --oauth --refresh\u{1b}[22m\n    github.com: gho_…xxxx (source: GitHub OAuth)\n"
+        flag --oauth help="Resolve only via the native GitHub OAuth source (cache, refresh, or device-code flow), bypassing other token sources" {
+            long_help #"""
+Resolve only via the native GitHub OAuth source (cache,
+refresh, or device-code flow), bypassing other token sources
+"""#
+        }
         flag --raw help="Print only the token value"
-        flag --refresh help="Mint a fresh OAuth token even if the cached one has not expired, via the refresh-token grant or a new device-code flow. Use after changing the GitHub App's installations or permissions: cached tokens keep their original access until they expire"
+        flag --refresh help="Mint a fresh OAuth token even if the cached one has not expired, via the refresh-token grant or a new device-code flow. Use after changing the GitHub App's installations or permissions: cached tokens keep their original access until they expire" requires=--oauth {
+            long_help #"""
+Mint a fresh OAuth token even if the cached one has not
+expired, via the refresh-token grant or a new device-code flow.
+Use after changing the GitHub App's installations or permissions:
+cached tokens keep their original access until they expire
+"""#
+        }
         flag --unmask help="Show the full unmasked token"
         arg "[HOST]" help="GitHub hostname" required=#false default=github.com
     }
     cmd gitlab help="GitLab token" effect=read {
-        after_long_help #"""
-Examples:
+        long_help #"""
+Display the GitLab token mise will use for a given host
 
-    $ mise token gitlab
-    gitlab.com: glpa…xxxx (source: GITLAB_TOKEN)
-
-    $ mise token gitlab --unmask
-    gitlab.com: glpat-xxxxxxxxxxxx (source: GITLAB_TOKEN)
-
-    $ mise token gitlab gitlab.mycompany.com
-    gitlab.mycompany.com: (none)
-
+Shows which token source mise would use, useful for debugging
+authentication issues. The token is masked by default.
 """#
+        after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise token gitlab\u{1b}[22m\n    gitlab.com: glpa…xxxx (source: GITLAB_TOKEN)\n\n    $ \u{1b}[1mmise token gitlab --unmask\u{1b}[22m\n    gitlab.com: glpat-xxxxxxxxxxxx (source: GITLAB_TOKEN)\n\n    $ \u{1b}[1mmise token gitlab gitlab.mycompany.com\u{1b}[22m\n    gitlab.mycompany.com: (none)\n"
         flag --unmask help="Show the full unmasked token"
         arg "[HOST]" help="GitLab hostname" required=#false default=gitlab.com
     }
 }
 cmd tool help="Gets information about a tool" effect=read {
-    after_long_help #"""
-Examples:
-
-    $ mise tool node
-    Backend:            core
-    Installed Versions: 20.0.0 22.0.0
-    Active Version:     20.0.0
-    Requested Version:  20
-    Config Source:      ~/.config/mise/mise.toml
-    Tool Options:       [none]
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise tool node\u{1b}[22m\n    Backend:            core\n    Installed Versions: 20.0.0 22.0.0\n    Active Version:     20.0.0\n    Requested Version:  20\n    Config Source:      ~/.config/mise/mise.toml\n    Tool Options:       [none]\n"
     flag "-J --json" help="Output in JSON format"
     flag --active help="Only show active versions"
     flag --backend help="Only show backend field"
@@ -4324,32 +3662,48 @@ Examples:
     flag --requested help="Only show requested versions"
     flag --tool-options help="Only show tool options"
     arg <TOOL> help="Tool name to get information about"
+    group ToolInfoFilter "--active" "--backend" "--config-source" "--description" "--installed" "--requested" "--tool-options"
 }
-cmd tool-stub help="Execute a tool stub" {
+cmd tool-stub disable_help_flag=#true disable_version_flag=#true help="Execute a tool stub" {
     long_help #"""
 Execute a tool stub
 
-Tool stubs are executable files containing TOML configuration that specify which tool to run and how to run it. They provide a convenient way to create portable, self-contained executables that automatically manage tool installation and execution.
+Tool stubs are executable files containing TOML configuration that specify
+which tool to run and how to run it. They provide a convenient way to create
+portable, self-contained executables that automatically manage tool installation
+and execution.
 
-A tool stub consists of: - A shebang line: #!/usr/bin/env -S mise tool-stub - TOML configuration specifying the tool, version, and options - Optional comments describing the tool's purpose
+A tool stub consists of:
+- A shebang line: #!/usr/bin/env -S mise tool-stub
+- TOML configuration specifying the tool, version, and options
+- Optional comments describing the tool's purpose
 
-Example stub file: #!/usr/bin/env -S mise tool-stub # Node.js v20 development environment
+Example stub file:
+  #!/usr/bin/env -S mise tool-stub
+  # Node.js v20 development environment
 
-tool = "node" version = "20.0.0" bin = "node"
+  tool = "node"
+  version = "20.0.0"
+  bin = "node"
 
-The stub will automatically install the specified tool version if missing and execute it with any arguments passed to the stub.
+The stub will automatically install the specified tool version if missing
+and execute it with any arguments passed to the stub.
 
 For more information, see: https://mise.jdx.dev/dev-tools/tool-stubs.html
 """#
     arg <FILE> help="Path to the TOML tool stub file to execute" help_long=#"""
 Path to the TOML tool stub file to execute
 
-The stub file must contain TOML configuration specifying the tool and version to run. At minimum, it should specify a 'version' field. Other common fields include 'tool', 'bin', and backend-specific options.
+The stub file must contain TOML configuration specifying the tool
+and version to run. At minimum, it should specify a 'version' field.
+Other common fields include 'tool', 'bin', and backend-specific options.
 """#
     arg "[ARGS]…" help="Arguments to pass to the tool" help_long=#"""
 Arguments to pass to the tool
 
-All arguments after the stub file path will be forwarded to the underlying tool. Use '--' to separate mise arguments from tool arguments if needed.
+All arguments after the stub file path will be forwarded to the
+underlying tool. Use '--' to separate mise arguments from tool arguments
+if needed.
 """# required=#false double_dash=automatic var=#true
 }
 cmd trust help="Marks a config file as trusted" effect=write {
@@ -4357,33 +3711,25 @@ cmd trust help="Marks a config file as trusted" effect=write {
 Marks a config file as trusted
 
 This means mise is allowed to parse the file when it needs to read config
-that may execute code or affect the environment. mise checks trust before
-parsing `mise.toml`. Without trust, mise may prompt, skip the config in some
-discovery paths, fail with an untrusted-config error when it cannot prompt,
-or assume trust in detected CI unless paranoid mode is enabled.
+that may execute code or affect the environment. Without trust, mise may
+prompt, skip the config in some discovery paths, or fail with an
+untrusted-config error when it cannot prompt.
 
-Safe config files do not require trust: files that only contain
-`min_version`, `[tools]` entries with plain version strings (or arrays
-of them), and `[tasks]` (no templates and no tool options) are loaded
-without prompting, since nothing in them executes code at load time —
-tools install and tasks run only on explicit commands like `mise install`
-or `mise run`.
+In normal mode, commands that execute project-defined behavior (`mise run`,
+naked task invocations such as `mise <TASK>`, `mise install`, `mise exec`,
+and `mise watch`) automatically trust their active config. Paranoid mode
+requires explicit, content-bound trust for every non-global config.
+
+In normal mode, safe config files do not require trust: files that only contain
+`min_version`, `[tools]` entries with plain version strings (or arrays of
+them), and `[tasks]` without templates or tool options.
 
 Trust is shared across git worktrees: a config file inside a linked
 worktree is trusted when the equivalent path in the repository's main
 checkout has been trusted. Paranoid mode disables this sharing since
 worktrees can check out branches with different config contents.
 """#
-    after_long_help #"""
-Examples:
-
-    # trusts ~/some_dir/mise.toml
-    $ mise trust ~/some_dir/mise.toml
-
-    # trusts mise.toml in the current or parent directory
-    $ mise trust
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # trusts ~/some_dir/mise.toml\n    $ \u{1b}[1mmise trust ~/some_dir/mise.toml\u{1b}[22m\n\n    # trusts mise.toml in the current or parent directory\n    $ \u{1b}[1mmise trust\u{1b}[22m\n"
     flag "-a --all" help="Trust all config files in the current directory, its parents, and its subdirectories" {
         long_help #"""
 Trust all config files in the current directory, its parents, and its subdirectories
@@ -4391,14 +3737,16 @@ Trust all config files in the current directory, its parents, and its subdirecto
 Subdirectories are walked respecting .gitignore, skipping hidden directories
 and common build/dependency directories (node_modules, vendor, target, dist, build).
 """#
+        conflicts "--ignore" "--untrust"
     }
-    flag --ignore help="Do not trust this config and ignore it in the future"
+    flag --ignore help="Do not trust this config and ignore it in the future" conflicts=--untrust
     flag --show help=#"""
 Show the trusted status of config files from the current directory and its parents.
 Does not trust or untrust any files.
 """#
-    flag --untrust help="No longer trust this config, will prompt in the future"
-    arg "[CONFIG_FILE]" help="The config file to trust" required=#false
+    flag --untrust help="Remove explicit trust for this config"
+    arg "[CONFIG_FILE]" help="The config file whose trust status to change" required=#false
+    complete config_file type=path
 }
 cmd uninstall help="Removes installed tool versions" effect=destructive {
     long_help #"""
@@ -4406,19 +3754,7 @@ Removes installed tool versions
 
 This only removes the installed version, it does not modify mise.toml.
 """#
-    after_long_help #"""
-Examples:
-
-    # will uninstall specific version
-    $ mise uninstall node@18.0.0
-
-    # will uninstall the current node version (if only one version is installed)
-    $ mise uninstall node
-
-    # will uninstall all installed versions of node
-    $ mise uninstall --all node@18.0.0 # will uninstall all node versions
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # will uninstall specific version\n    $ \u{1b}[1mmise uninstall node@18.0.0\u{1b}[22m\n\n    # will uninstall the current node version (if only one version is installed)\n    $ \u{1b}[1mmise uninstall node\u{1b}[22m\n\n    # will uninstall all installed versions of node\n    $ \u{1b}[1mmise uninstall --all node@18.0.0\u{1b}[22m # will uninstall all node versions\n"
     flag "-a --all" help="Delete all installed versions"
     flag "-n --dry-run" help="Do not actually delete anything"
     flag --dry-run-code help="Like --dry-run but exits with code 1 if there are tools to uninstall" {
@@ -4428,7 +3764,7 @@ Like --dry-run but exits with code 1 if there are tools to uninstall
 This is useful for scripts to check if tools need to be uninstalled.
 """#
     }
-    arg "[INSTALLED_TOOL@VERSION]…" help="Tool(s) to remove" required=#false var=#true
+    arg "[INSTALLED_TOOL@VERSION]…" help="Tool(s) to remove" required=#false var=#true required_unless=--all
 }
 cmd unset help="Remove environment variable(s) from the config file." effect=write {
     long_help #"""
@@ -4436,34 +3772,28 @@ Remove environment variable(s) from the config file.
 
 By default, this command modifies `mise.toml` in the current directory.
 """#
-    after_long_help #"""
-Examples:
-
-    # Remove NODE_ENV from the current directory's config
-    $ mise unset NODE_ENV
-
-    # Remove NODE_ENV from the global config
-    $ mise unset NODE_ENV -g
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Remove NODE_ENV from the current directory's config\n    $ \u{1b}[1mmise unset NODE_ENV\u{1b}[22m\n\n    # Remove NODE_ENV from the global config\n    $ \u{1b}[1mmise unset NODE_ENV -g\u{1b}[22m\n"
     flag "-f --file --path" help="Specify a file to use instead of `mise.toml`" {
         long_help #"""
 Specify a file to use instead of `mise.toml`
 
 Can be a file path or directory. If a directory is provided, will create/use mise.toml in that directory.
 
-Defaults to [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) environment variable, or `mise.toml`. Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
+Defaults to [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) environment variable, or `mise.toml`.
+Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
 """#
         arg <FILE>
     }
-    flag "-g --global" help="Use the global config file"
+    flag "-g --global" help="Use the global config file" overrides=--file
     arg "[ENV_KEY]…" help=#"""
 Environment variable(s) to remove
 e.g.: NODE_ENV
 """# required=#false var=#true
+    complete file type=path
 }
-cmd untrust help="No longer trust a config, will prompt in the future" effect=write {
+cmd untrust help="Remove explicit trust for a config" effect=write {
     arg "[CONFIG_FILE]" help="The config file to untrust" required=#false
+    complete config_file type=path
 }
 cmd unuse help="Removes installed tool versions from mise.toml" effect=destructive {
     alias rm remove
@@ -4487,36 +3817,27 @@ Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_glo
 
 Will also prune the installed version if no other configurations are using it.
 """#
-    after_long_help #"""
-Examples:
-
-    # will uninstall specific version
-    $ mise unuse node@18.0.0
-
-    # will uninstall specific version from global config
-    $ mise unuse -g node@18.0.0
-
-    # will uninstall specific version from .mise.local.toml
-    $ mise unuse --env local node@20
-
-    # will uninstall specific version from .mise.staging.toml
-    $ mise unuse --env staging node@20
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # will uninstall specific version\n    $ \u{1b}[1mmise unuse node@18.0.0\u{1b}[22m\n\n    # will uninstall specific version from global config\n    $ \u{1b}[1mmise unuse -g node@18.0.0\u{1b}[22m\n\n    # will uninstall specific version from .mise.local.toml\n    $ \u{1b}[1mmise unuse --env local node@20\u{1b}[22m\n\n    # will uninstall specific version from .mise.staging.toml\n    $ \u{1b}[1mmise unuse --env staging node@20\u{1b}[22m\n"
     flag "-e --env" help="Create/modify an environment-specific config file like .mise.<env>.toml" {
+        overrides "--global" "--path"
         arg <ENV>
     }
-    flag "-g --global" help="Use the global config file (`~/.config/mise/config.toml`) instead of the local one"
+    flag "-g --global" help="Use the global config file (`~/.config/mise/config.toml`) instead of the local one" {
+        overrides "--path" "--env"
+    }
     flag "-p --path --file" help="Specify a path to a config file or directory" {
         long_help #"""
 Specify a path to a config file or directory
 
-If a directory is specified, it will look for a config file in that directory following the rules above.
+If a directory is specified, it will look for a config file in that directory following
+the rules above.
 """#
+        overrides "--global" "--env"
         arg <PATH>
     }
     flag --no-prune help="Do not also prune the installed version"
     arg <INSTALLED_TOOL@VERSION>… help="Tool(s) to remove" var=#true
+    complete path type=path
 }
 cmd upgrade help="Upgrades outdated tools" effect=write {
     alias up
@@ -4529,45 +3850,8 @@ and bump the version in mise.toml.
 
 This will update mise.lock if it is enabled, see https://mise.jdx.dev/configuration/settings.html#lockfile
 """#
-    after_long_help #"""
-Examples:
-
-    # Upgrades node to the latest version matching the range in mise.toml
-    $ mise upgrade node
-
-    # Upgrades node to the latest version and bumps the version in mise.toml
-    $ mise upgrade node --bump
-
-    # Upgrades all tools to the latest versions
-    $ mise upgrade
-
-    # Upgrades all tools to the latest versions and bumps the version in mise.toml
-    $ mise upgrade --bump
-
-    # Just print what would be done, don't actually do it
-    $ mise upgrade --dry-run
-
-    # Upgrades node and python to the latest versions
-    $ mise upgrade node python
-
-    # Upgrade all tools except go
-    $ mise upgrade --exclude go
-
-    # Show a multiselect menu to choose which tools to upgrade
-    $ mise upgrade --interactive
-
-    # Only upgrade tools defined in local mise.toml, not global ones
-    $ mise upgrade --local
-
-"""#
-    flag "-i --interactive" help="Display multiselect menu to choose which tools to upgrade"
-    flag "-j --jobs" help=#"""
-Number of jobs to run in parallel
-[default: 4]
-"""# {
-        arg <JOBS>
-    }
-    flag "-l --bump" help="Upgrades to the latest version available, bumping the version in mise.toml" {
+    after_long_help "\u{1b}[1m\u{1b}[4mDeprecation:\u{1b}[22m\u{1b}[24m\n\nThe `-l` shorthand for `--bump` is deprecated and will be removed in mise 2027.8.5.\nAfter removal, `-l` will become shorthand for `--local`. Use `-b` or `--bump` instead.\n\n\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Upgrades node to the latest version matching the range in mise.toml\n    $ \u{1b}[1mmise upgrade node\u{1b}[22m\n\n    # Upgrades node to the latest version and bumps the version in mise.toml\n    $ \u{1b}[1mmise upgrade node --bump\u{1b}[22m\n\n    # Upgrades all tools to the latest versions\n    $ \u{1b}[1mmise upgrade\u{1b}[22m\n\n    # Upgrades all tools to the latest versions and bumps the version in mise.toml\n    $ \u{1b}[1mmise upgrade --bump\u{1b}[22m\n\n    # Just print what would be done, don't actually do it\n    $ \u{1b}[1mmise upgrade --dry-run\u{1b}[22m\n\n    # Upgrades node and python to the latest versions\n    $ \u{1b}[1mmise upgrade node python\u{1b}[22m\n\n    # Upgrade all tools except go\n    $ \u{1b}[1mmise upgrade --exclude go\u{1b}[22m\n\n    # Show a multiselect menu to choose which tools to upgrade\n    $ \u{1b}[1mmise upgrade --interactive\u{1b}[22m\n\n    # Only upgrade tools defined in local mise.toml, not global ones\n    $ \u{1b}[1mmise upgrade --local\u{1b}[22m\n"
+    flag "-b --bump" help="Upgrades to the latest version available, bumping the version in mise.toml" {
         long_help #"""
 Upgrades to the latest version available, bumping the version in mise.toml
 
@@ -4578,6 +3862,15 @@ It keeps the same precision as what was there before, so if you instead had `nod
 would change your config to `node = "22"`.
 """#
     }
+    flag "-i --interactive" help="Display multiselect menu to choose which tools to upgrade" conflicts=INSTALLED_TOOL@VERSION
+    flag "-j --jobs" help=#"""
+Number of jobs to run in parallel
+Values below 1 are treated as 1
+[default: 4]
+"""# env=MISE_JOBS {
+        arg <JOBS>
+    }
+    flag -l help="Deprecated shorthand for --bump" hide=#true
     flag "-n --dry-run" help="Just print what would be done, don't actually do it"
     flag "-x --exclude" help=#"""
 Tool(s) to exclude from upgrading
@@ -4592,7 +3885,7 @@ Like --dry-run but exits with code 1 if there are outdated tools
 This is useful for scripts to check if tools need to be upgraded.
 """#
     }
-    flag --inactive help="Upgrade all tools, including installed-but-inactive tools not present in the current config"
+    flag --inactive help="Upgrade all tools, including installed-but-inactive tools not present in the current config" conflicts=--local
     flag --local help="Only upgrade tools defined in local config files" {
         long_help #"""
 Only upgrade tools defined in local config files
@@ -4602,6 +3895,7 @@ will skip tools defined in the global config (~/.config/mise/config.toml).
 """#
     }
     flag --minimum-release-age help="Only upgrade to versions released before this date or older than this duration" {
+        alias "--before" hide=#true
         long_help #"""
 Only upgrade to versions released before this date or older than this duration
 
@@ -4614,16 +3908,31 @@ Explicitly pinned versions like "22.5.0" are not filtered.
         arg <MINIMUM_RELEASE_AGE>
     }
     flag --monorepo help="Placeholder for future monorepo upgrades; `mise upgrade --monorepo` is not implemented yet."
-    flag --no-prune help="Do not uninstall the versions that were upgraded away from" {
+    flag --no-prune help="Do not uninstall the versions that were upgraded away from" overrides=--prune {
         long_help #"""
 Do not uninstall the versions that were upgraded away from
 
 By default the old version is removed once the new one installs, unless another
 tracked config or tool stub still needs it. Use this to keep it anyway, e.g. when
 something outside of mise points at the old install directory.
+
+Set `upgrade.auto_prune = false` to make this the default.
 """#
     }
-    flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1"
+    flag --prune help="Uninstall the versions that were upgraded away from" overrides=--no-prune {
+        long_help #"""
+Uninstall the versions that were upgraded away from
+
+This is already the default. Use it to override `upgrade.auto_prune = false`
+for a single run.
+"""#
+    }
+    flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1" overrides=--jobs {
+        long_help #"""
+Connect backend install command stdin/stdout/stderr directly to the terminal
+Implies --jobs=1
+"""#
+    }
     arg "[INSTALLED_TOOL@VERSION]…" help=#"""
 Tool(s) to upgrade
 e.g.: node@20 python@3.10
@@ -4660,45 +3969,31 @@ Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_glo
 
 Use the `--global` flag to use the global config file instead.
 """#
-    after_long_help #"""
-Examples:
-
-    # run with no arguments to use the interactive selector
-    $ mise use
-
-    # set the current version of node to 20.x in mise.toml of current directory
-    # will write the fuzzy version (e.g.: 20)
-    $ mise use node@20
-
-    # set the current version of node to 20.x in ~/.config/mise/config.toml
-    # will write the precise version (e.g.: 20.0.0)
-    $ mise use -g --pin node@20
-
-    # sets .mise.local.toml (which is intended not to be committed to a project)
-    $ mise use --env local node@20
-
-    # sets .mise.staging.toml (which is used if MISE_ENV=staging)
-    $ mise use --env staging node@20
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # run with no arguments to use the interactive selector\n    $ \u{1b}[1mmise use\u{1b}[22m\n\n    # set the current version of node to 20.x in mise.toml of current directory\n    # will write the fuzzy version (e.g.: 20)\n    $ \u{1b}[1mmise use node@20\u{1b}[22m\n\n    # set the current version of node to 20.x in ~/.config/mise/config.toml\n    # will write the precise version (e.g.: 20.0.0)\n    $ \u{1b}[1mmise use -g --pin node@20\u{1b}[22m\n\n    # sets .mise.local.toml (which is intended not to be committed to a project)\n    $ \u{1b}[1mmise use --env local node@20\u{1b}[22m\n\n    # sets .mise.staging.toml (which is used if MISE_ENV=staging)\n    $ \u{1b}[1mmise use --env staging node@20\u{1b}[22m\n"
     flag "-e --env" help="Create/modify an environment-specific config file like .mise.<env>.toml" {
+        overrides "--global" "--path"
         arg <ENV>
     }
-    flag "-f --force" help="Force reinstall even if already installed"
-    flag "-g --global" help="Use the global config file (`~/.config/mise/config.toml`) instead of the local one"
+    flag "-f --force" help="Force reinstall even if already installed" requires=TOOL@VERSION
+    flag "-g --global" help="Use the global config file (`~/.config/mise/config.toml`) instead of the local one" {
+        overrides "--path" "--env"
+    }
     flag "-j --jobs" help=#"""
 Number of jobs to run in parallel
+Values below 1 are treated as 1
 [default: 4]
-"""# {
+"""# env=MISE_JOBS {
         arg <JOBS>
     }
     flag "-n --dry-run" help="Perform a dry run, showing what would be installed and modified without making changes"
-    flag "-p --path --file" help="Specify a path to a config file or directory" {
+    flag "-p --path" help="Specify a path to a config file or directory" {
         long_help #"""
 Specify a path to a config file or directory
 
-If a directory is specified, it will look for a config file in that directory following the rules above.
+If a directory is specified, it will look for a config file in that directory following
+the rules above.
 """#
+        overrides "--global" "--env"
         arg <PATH>
     }
     flag --dry-run-code help="Like --dry-run but exits with code 1 if there are changes to make" {
@@ -4708,7 +4003,7 @@ Like --dry-run but exits with code 1 if there are changes to make
 This is useful for scripts to check if tools need to be added or removed.
 """#
     }
-    flag --fuzzy help="Save fuzzy version to config file" {
+    flag --fuzzy help="Save fuzzy version to config file" overrides=--pin {
         long_help #"""
 Save fuzzy version to config file
 
@@ -4717,6 +4012,7 @@ this is the default behavior unless `MISE_PIN=1`
 """#
     }
     flag --minimum-release-age help="Only install versions released before this date or older than this duration" {
+        alias "--before" hide=#true
         long_help #"""
 Only install versions released before this date or older than this duration
 
@@ -4724,22 +4020,27 @@ Supports absolute dates like "2024-06-01" and relative durations like "90d" or "
 """#
         arg <MINIMUM_RELEASE_AGE>
     }
-    flag --pin help=#"""
-Save exact version to config file
-e.g.: `mise use --pin node@20` will save 20.0.0 as the version
-Set `MISE_PIN=1` to make this the default behavior
-"""# {
+    flag --pin help="Save the resolved concrete version to the config file" overrides=--fuzzy {
         long_help #"""
-Save exact version to config file
-e.g.: `mise use --pin node@20` will save 20.0.0 as the version
+Save the resolved concrete version to the config file
+
+If the request exactly matches an available release, that release is preferred over
+installed fuzzy matches. Use `prefix:` to explicitly request recursive prefix matching.
+e.g.: `mise use --pin node@20` will save the resolved `20.x.y` version
 Set `MISE_PIN=1` to make this the default behavior
 
 Consider using mise.lock as a better alternative to pinning in mise.toml:
 https://mise.jdx.dev/configuration/settings.html#lockfile
 """#
     }
-    flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal Implies `--jobs=1`"
+    flag --raw help="Connect backend install command stdin/stdout/stderr directly to the terminal Implies `--jobs=1`" overrides=--jobs {
+        long_help #"""
+Connect backend install command stdin/stdout/stderr directly to the terminal
+Implies `--jobs=1`
+"""#
+    }
     flag --remove help="Remove the tool(s) from config file" var=#true {
+        alias "--rm" "--unset" hide=#true
         arg <TOOL>
     }
     arg "[TOOL@VERSION]…" help="Tool(s) to add to config file" help_long=#"""
@@ -4752,6 +4053,7 @@ Tool options can be set with this syntax:
 
     mise use ubi:BurntSushi/ripgrep[exe=rg]
 """# required=#false var=#true
+    complete path type=path
 }
 cmd version help="Display the version of mise" effect=read {
     alias v
@@ -4762,15 +4064,7 @@ Displays the version, os, architecture, and the date of the build.
 
 If the version is out of date, it will display a warning.
 """#
-    after_long_help #"""
-Examples:
-
-    $ mise version
-    $ mise --version
-    $ mise -v
-    $ mise -V
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise version\u{1b}[22m\n    $ \u{1b}[1mmise --version\u{1b}[22m\n    $ \u{1b}[1mmise -v\u{1b}[22m\n    $ \u{1b}[1mmise -V\u{1b}[22m\n"
     flag "-J --json" help="Print the version information in JSON format"
 }
 cmd watch help="Run task(s) and watch for changes to rerun it" {
@@ -4784,24 +4078,7 @@ It must be installed for this command to work, but you can install it with `mise
 For more advanced process management (daemon management, auto-restart, readiness checks,
 cron scheduling), see mise's sister project: https://pitchfork.jdx.dev
 """#
-    after_long_help #"""
-Examples:
-
-    $ mise watch build
-    Runs the "build" tasks. Will re-run the tasks when any of its sources change.
-    Uses "sources" from the tasks definition to determine which files to watch.
-
-    $ mise watch build --glob src/**/*.rs
-    Runs the "build" tasks but specify the files to watch with a glob pattern.
-    This overrides the "sources" from the tasks definition.
-
-    $ mise watch build --clear
-    Extra arguments are passed to watchexec. See `watchexec --help` for details.
-
-    $ mise watch serve --watch src --exts rs --restart
-    Starts an api server, watching for changes to "*.rs" files in "./src" and kills/restarts the server when they change.
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise watch build\u{1b}[22m\n    Runs the \"build\" tasks. Will re-run the tasks when any of its sources change.\n    Uses \"sources\" from the tasks definition to determine which files to watch.\n\n    $ \u{1b}[1mmise watch build --glob src/**/*.rs\u{1b}[22m\n    Runs the \"build\" tasks but specify the files to watch with a glob pattern.\n    This overrides the \"sources\" from the tasks definition.\n\n    $ \u{1b}[1mmise watch build --clear\u{1b}[22m\n    Extra arguments are passed to watchexec. See `watchexec --help` for details.\n\n    $ \u{1b}[1mmise watch serve --watch src --exts rs --restart\u{1b}[22m\n    Starts an api server, watching for changes to \"*.rs\" files in \"./src\" and kills/restarts the server when they change.\n"
     flag "-t --task-flag" help="Tasks to run" var=#true hide=#true {
         arg <TASK_FLAG>
     }
@@ -4812,23 +4089,27 @@ Defaults to sources from the task(s)
         arg <GLOB>
     }
     flag --skip-deps help="Run only the specified tasks skipping all dependencies"
-    flag "-w --watch" help="Watch a specific file or directory" var=#true {
+    flag "-w --watch" help="Watch a specific file or directory" var=#true help_heading=Filtering {
         long_help #"""
 Watch a specific file or directory
 
 By default, Watchexec watches the current directory.
 
-When watching a single file, it's often better to watch the containing directory instead, and filter on the filename. Some editors may replace the file with a new one when saving, and some platforms may not detect that or further changes.
+When watching a single file, it's often better to watch the containing directory instead,
+and filter on the filename. Some editors may replace the file with a new one when saving,
+and some platforms may not detect that or further changes.
 
-Upon starting, Watchexec resolves a "project origin" from the watched paths. See the help for '--project-origin' for more information.
+Upon starting, Watchexec resolves a "project origin" from the watched paths. See the help
+for '--project-origin' for more information.
 
 This option can be specified multiple times to watch multiple files or directories.
 
-The special value '/dev/null', provided as the only path watched, will cause Watchexec to not watch any paths. Other event sources (like signals or key events) may still be used.
+The special value '/dev/null', provided as the only path watched, will cause Watchexec to
+not watch any paths. Other event sources (like signals or key events) may still be used.
 """#
         arg <PATH>
     }
-    flag "-W --watch-non-recursive" help="Watch a specific directory, non-recursively" var=#true {
+    flag "-W --watch-non-recursive" help="Watch a specific directory, non-recursively" var=#true help_heading=Filtering {
         long_help #"""
 Watch a specific directory, non-recursively
 
@@ -4838,56 +4119,73 @@ This option can be specified multiple times to watch multiple directories non-re
 """#
         arg <PATH>
     }
-    flag "-F --watch-file" help="Watch files and directories from a file" {
+    flag "-F --watch-file" help="Watch files and directories from a file" help_heading=Filtering {
         long_help #"""
 Watch files and directories from a file
 
 Each line in the file will be interpreted as if given to '-w'.
 
-For more complex uses (like watching non-recursively), use the argfile capability: build a file containing command-line options and pass it to watchexec with `@path/to/argfile`.
+For more complex uses (like watching non-recursively), use the argfile capability: build a
+file containing command-line options and pass it to watchexec with `@path/to/argfile`.
 
 The special value '-' will read from STDIN; this in incompatible with '--stdin-quit'.
 """#
         arg <PATH>
     }
-    flag "-c --clear" help="Clear screen before running command" {
+    flag "-c --clear" help="Clear screen before running command" value_optional=#true default_missing=clear help_heading=Output {
         long_help #"""
 Clear screen before running command
 
 If this doesn't completely clear the screen, try '--clear=reset'.
 """#
-        arg <MODE> {
-            choices clear reset
+        arg "[MODE]" required=#false var_min=0 var_max=1 {
+            choices {
+                choice clear
+                choice reset
+            }
         }
     }
-    flag "-o --on-busy-update" help="What to do when receiving events while the command is running" default=do-nothing {
+    flag "-o --on-busy-update" help="What to do when receiving events while the command is running" hide_default_value=#true default=do-nothing {
         long_help #"""
 What to do when receiving events while the command is running
 
-Default is to 'do-nothing', which ignores events while the command is running, so that changes that occur due to the command are ignored, like compilation outputs. You can also use 'queue' which will run the command once again when the current run has finished if any events occur while it's running, or 'restart', which terminates the running command and starts a new one. Finally, there's 'signal', which only sends a signal; this can be useful with programs that can reload their configuration without a full restart.
+Default is to 'do-nothing', which ignores events while the command is running, so that
+changes that occur due to the command are ignored, like compilation outputs. You can also
+use 'queue' which will run the command once again when the current run has finished if any
+events occur while it's running, or 'restart', which terminates the running command and starts
+a new one. Finally, there's 'signal', which only sends a signal; this can be useful with
+programs that can reload their configuration without a full restart.
 
 The signal can be specified with the '--signal' option.
 """#
         arg <MODE> {
-            choices queue do-nothing restart signal
+            choices {
+                choice queue
+                choice do-nothing
+                choice restart
+                choice signal
+            }
         }
     }
-    flag "-r --restart" help="Restart the process if it's still running" {
+    flag "-r --restart" help="Restart the process if it's still running" conflicts=--on-busy-update {
         long_help #"""
 Restart the process if it's still running
 
 This is a shorthand for '--on-busy-update=restart'.
 """#
     }
-    flag "-s --signal" help="Send a signal to the process when it's still running" {
+    flag "-s --signal" help="Send a signal to the process when it's still running" conflicts=--restart {
         long_help #"""
 Send a signal to the process when it's still running
 
-Specify a signal to send to the process when it's still running. This implies '--on-busy-update=signal'; otherwise the signal used when that mode is 'restart' is controlled by '--stop-signal'.
+Specify a signal to send to the process when it's still running. This implies
+'--on-busy-update=signal'; otherwise the signal used when that mode is 'restart' is
+controlled by '--stop-signal'.
 
 See the long documentation for '--stop-signal' for syntax.
 
-Signals are not supported on Windows at the moment, and will always be overridden to 'kill'. See '--stop-signal' for more on Windows "signals".
+Signals are not supported on Windows at the moment, and will always be overridden to 'kill'.
+See '--stop-signal' for more on Windows "signals".
 """#
         arg <SIGNAL>
     }
@@ -4895,27 +4193,38 @@ Signals are not supported on Windows at the moment, and will always be overridde
         long_help #"""
 Signal to send to stop the command
 
-This is used by 'restart' and 'signal' modes of '--on-busy-update' (unless '--signal' is provided). The restart behaviour is to send the signal, wait for the command to exit, and if it hasn't exited after some time (see '--timeout-stop'), forcefully terminate it.
+This is used by 'restart' and 'signal' modes of '--on-busy-update' (unless '--signal' is
+provided). The restart behaviour is to send the signal, wait for the command to exit, and if
+it hasn't exited after some time (see '--timeout-stop'), forcefully terminate it.
 
 The default on unix is "SIGTERM".
 
-Input is parsed as a full signal name (like "SIGTERM"), a short signal name (like "TERM"), or a signal number (like "15"). All input is case-insensitive.
+Input is parsed as a full signal name (like "SIGTERM"), a short signal name (like "TERM"),
+or a signal number (like "15"). All input is case-insensitive.
 
-On Windows this option is technically supported but only supports the "KILL" event, as Watchexec cannot yet deliver other events. Windows doesn't have signals as such; instead it has termination (here called "KILL" or "STOP") and "CTRL+C", "CTRL+BREAK", and "CTRL+CLOSE" events. For portability the unix signals "SIGKILL", "SIGINT", "SIGTERM", and "SIGHUP" are respectively mapped to these.
+On Windows this option is technically supported but only supports the "KILL" event, as
+Watchexec cannot yet deliver other events. Windows doesn't have signals as such; instead it
+has termination (here called "KILL" or "STOP") and "CTRL+C", "CTRL+BREAK", and "CTRL+CLOSE"
+events. For portability the unix signals "SIGKILL", "SIGINT", "SIGTERM", and "SIGHUP" are
+respectively mapped to these.
 """#
         arg <SIGNAL>
     }
-    flag --stop-timeout help="Time to wait for the command to exit gracefully" default="10s" {
+    flag --stop-timeout help="Time to wait for the command to exit gracefully" hide_default_value=#true default="10s" {
         long_help #"""
 Time to wait for the command to exit gracefully
 
-This is used by the 'restart' mode of '--on-busy-update'. After the graceful stop signal is sent, Watchexec will wait for the command to exit. If it hasn't exited after this time, it is forcefully terminated.
+This is used by the 'restart' mode of '--on-busy-update'. After the graceful stop signal
+is sent, Watchexec will wait for the command to exit. If it hasn't exited after this time,
+it is forcefully terminated.
 
-Takes a unit-less value in seconds, or a time span value such as "5min 20s". Providing a unit-less value is deprecated and will warn; it will be an error in the future.
+Takes a unit-less value in seconds, or a time span value such as "5min 20s".
+Providing a unit-less value is deprecated and will warn; it will be an error in the future.
 
 The default is 10 seconds. Set to 0 to immediately force-kill the command.
 
-This has no practical effect on Windows as the command is always forcefully terminated; see '--stop-signal' for why.
+This has no practical effect on Windows as the command is always forcefully terminated; see
+'--stop-signal' for why.
 """#
         arg <TIMEOUT>
     }
@@ -4923,25 +4232,41 @@ This has no practical effect on Windows as the command is always forcefully term
         long_help #"""
 Translate signals from the OS to signals to send to the command
 
-Takes a pair of signal names, separated by a colon, such as "TERM:INT" to map SIGTERM to SIGINT. The first signal is the one received by watchexec, and the second is the one sent to the command. The second can be omitted to discard the first signal, such as "TERM:" to not do anything on SIGTERM.
+Takes a pair of signal names, separated by a colon, such as "TERM:INT" to map SIGTERM to
+SIGINT. The first signal is the one received by watchexec, and the second is the one sent to
+the command. The second can be omitted to discard the first signal, such as "TERM:" to
+not do anything on SIGTERM.
 
-If SIGINT or SIGTERM are mapped, then they no longer quit Watchexec. Besides making it hard to quit Watchexec itself, this is useful to send pass a Ctrl-C to the command without also terminating Watchexec and the underlying program with it, e.g. with "INT:INT".
+If SIGINT or SIGTERM are mapped, then they no longer quit Watchexec. Besides making it hard
+to quit Watchexec itself, this is useful to send pass a Ctrl-C to the command without also
+terminating Watchexec and the underlying program with it, e.g. with "INT:INT".
 
 This option can be specified multiple times to map multiple signals.
 
-Signal syntax is case-insensitive for short names (like "TERM", "USR2") and long names (like "SIGKILL", "SIGHUP"). Signal numbers are also supported (like "15", "31"). On Windows, the forms "STOP", "CTRL+C", and "CTRL+BREAK" are also supported to receive, but Watchexec cannot yet deliver other "signals" than a STOP.
+Signal syntax is case-insensitive for short names (like "TERM", "USR2") and long names (like
+"SIGKILL", "SIGHUP"). Signal numbers are also supported (like "15", "31"). On Windows, the
+forms "STOP", "CTRL+C", and "CTRL+BREAK" are also supported to receive, but Watchexec cannot
+yet deliver other "signals" than a STOP.
 """#
         arg <SIGNAL:SIGNAL>
     }
-    flag "-d --debounce" help="Time to wait for new events before taking action" default="50ms" {
+    flag "-d --debounce" help="Time to wait for new events before taking action" hide_default_value=#true default="50ms" {
         long_help #"""
 Time to wait for new events before taking action
 
-When an event is received, Watchexec will wait for up to this amount of time before handling it (such as running the command). This is essential as what you might perceive as a single change may actually emit many events, and without this behaviour, Watchexec would run much too often. Additionally, it's not infrequent that file writes are not atomic, and each write may emit an event, so this is a good way to avoid running a command while a file is partially written.
+When an event is received, Watchexec will wait for up to this amount of time before handling
+it (such as running the command). This is essential as what you might perceive as a single
+change may actually emit many events, and without this behaviour, Watchexec would run much
+too often. Additionally, it's not infrequent that file writes are not atomic, and each write
+may emit an event, so this is a good way to avoid running a command while a file is
+partially written.
 
-An alternative use is to set a high value (like "30min" or longer), to save power or bandwidth on intensive tasks, like an ad-hoc backup script. In those use cases, note that every accumulated event will build up in memory.
+An alternative use is to set a high value (like "30min" or longer), to save power or
+bandwidth on intensive tasks, like an ad-hoc backup script. In those use cases, note that
+every accumulated event will build up in memory.
 
-Takes a unit-less value in milliseconds, or a time span value such as "5sec 20ms". Providing a unit-less value is deprecated and will warn; it will be an error in the future.
+Takes a unit-less value in milliseconds, or a time span value such as "5sec 20ms".
+Providing a unit-less value is deprecated and will warn; it will be an error in the future.
 
 The default is 50 milliseconds. Setting to 0 is highly discouraged.
 """#
@@ -4951,19 +4276,22 @@ The default is 50 milliseconds. Setting to 0 is highly discouraged.
         long_help #"""
 Exit when stdin closes
 
-This watches the stdin file descriptor for EOF, and exits Watchexec gracefully when it is closed. This is used by some process managers to avoid leaving zombie processes around.
+This watches the stdin file descriptor for EOF, and exits Watchexec gracefully when it is
+closed. This is used by some process managers to avoid leaving zombie processes around.
 """#
     }
-    flag --no-vcs-ignore help="Don't load gitignores" {
+    flag --no-vcs-ignore help="Don't load gitignores" help_heading=Filtering {
         long_help #"""
 Don't load gitignores
 
-Among other VCS exclude files, like for Mercurial, Subversion, Bazaar, DARCS, Fossil. Note that Watchexec will detect which of these is in use, if any, and only load the relevant files. Both global (like '~/.gitignore') and local (like '.gitignore') files are considered.
+Among other VCS exclude files, like for Mercurial, Subversion, Bazaar, DARCS, Fossil. Note
+that Watchexec will detect which of these is in use, if any, and only load the relevant
+files. Both global (like '~/.gitignore') and local (like '.gitignore') files are considered.
 
 This option is useful if you want to watch files that are ignored by Git.
 """#
     }
-    flag --no-project-ignore help="Don't load project-local ignores" {
+    flag --no-project-ignore help="Don't load project-local ignores" help_heading=Filtering {
         long_help #"""
 Don't load project-local ignores
 
@@ -4986,7 +4314,7 @@ VCS is discovered to be in use for the project/origin. For example, a .bzrignore
 repository will be discarded.
 """#
     }
-    flag --no-global-ignore help="Don't load global ignores" {
+    flag --no-global-ignore help="Don't load global ignores" help_heading=Filtering {
         long_help #"""
 Don't load global ignores
 
@@ -5005,102 +4333,125 @@ Like for project files, Git and Bazaar global files will only be used for the co
 VCS as used in the project.
 """#
     }
-    flag --no-default-ignore help="Don't use internal default ignores" {
+    flag --no-default-ignore help="Don't use internal default ignores" help_heading=Filtering {
         long_help #"""
 Don't use internal default ignores
 
-Watchexec has a set of default ignore patterns, such as editor swap files, `*.pyc`, `*.pyo`, `.DS_Store`, `.bzr`, `_darcs`, `.fossil-settings`, `.git`, `.hg`, `.pijul`, `.svn`, and Watchexec log files.
+Watchexec has a set of default ignore patterns, such as editor swap files, `*.pyc`, `*.pyo`,
+`.DS_Store`, `.bzr`, `_darcs`, `.fossil-settings`, `.git`, `.hg`, `.pijul`, `.svn`, and
+Watchexec log files.
 """#
     }
-    flag --no-discover-ignore help="Don't discover ignore files at all" {
+    flag --no-discover-ignore help="Don't discover ignore files at all" help_heading=Filtering {
         long_help #"""
 Don't discover ignore files at all
 
-This is a shorthand for '--no-global-ignore', '--no-vcs-ignore', '--no-project-ignore', but even more efficient as it will skip all the ignore discovery mechanisms from the get go.
+This is a shorthand for '--no-global-ignore', '--no-vcs-ignore', '--no-project-ignore', but
+even more efficient as it will skip all the ignore discovery mechanisms from the get go.
 
 Note that default ignores are still loaded, see '--no-default-ignore'.
 """#
     }
-    flag --ignore-nothing help="Don't ignore anything at all" {
+    flag --ignore-nothing help="Don't ignore anything at all" help_heading=Filtering {
         long_help #"""
 Don't ignore anything at all
 
 This is a shorthand for '--no-discover-ignore', '--no-default-ignore'.
 
-Note that ignores explicitly loaded via other command line options, such as '--ignore' or '--ignore-file', will still be used.
+Note that ignores explicitly loaded via other command line options, such as '--ignore' or
+'--ignore-file', will still be used.
 """#
     }
     flag "-p --postpone" help="Wait until first change before running command" {
         long_help #"""
 Wait until first change before running command
 
-By default, Watchexec will run the command once immediately. With this option, it will instead wait until an event is detected before running the command as normal.
+By default, Watchexec will run the command once immediately. With this option, it will
+instead wait until an event is detected before running the command as normal.
 """#
     }
     flag --delay-run help="Sleep before running the command" {
         long_help #"""
 Sleep before running the command
 
-This option will cause Watchexec to sleep for the specified amount of time before running the command, after an event is detected. This is like using "sleep 5 && command" in a shell, but portable and slightly more efficient.
+This option will cause Watchexec to sleep for the specified amount of time before running
+the command, after an event is detected. This is like using "sleep 5 && command" in a shell,
+but portable and slightly more efficient.
 
-Takes a unit-less value in seconds, or a time span value such as "2min 5s". Providing a unit-less value is deprecated and will warn; it will be an error in the future.
+Takes a unit-less value in seconds, or a time span value such as "2min 5s".
+Providing a unit-less value is deprecated and will warn; it will be an error in the future.
 """#
         arg <DURATION>
     }
-    flag --poll help="Poll for filesystem changes" {
+    flag --poll help="Poll for filesystem changes" value_optional=#true default_missing="30s" {
+        alias "--force-poll" hide=#true
         long_help #"""
 Poll for filesystem changes
 
-By default, and where available, Watchexec uses the operating system's native file system watching capabilities. This option disables that and instead uses a polling mechanism, which is less efficient but can work around issues with some file systems (like network shares) or edge cases.
+By default, and where available, Watchexec uses the operating system's native file system
+watching capabilities. This option disables that and instead uses a polling mechanism, which
+is less efficient but can work around issues with some file systems (like network shares) or
+edge cases.
 
-Optionally takes a unit-less value in milliseconds, or a time span value such as "2s 500ms", to use as the polling interval. If not specified, the default is 30 seconds. Providing a unit-less value is deprecated and will warn; it will be an error in the future.
+Optionally takes a unit-less value in milliseconds, or a time span value such as "2s 500ms",
+to use as the polling interval. If not specified, the default is 30 seconds.
+Providing a unit-less value is deprecated and will warn; it will be an error in the future.
 
 Aliased as '--force-poll'.
 """#
-        arg <INTERVAL>
+        arg "[INTERVAL]" required=#false var_min=0 var_max=1
     }
-    flag --shell help="Use a different shell" {
+    flag --shell help="Use a different shell" help_heading=Command {
         long_help #"""
 Use a different shell
 
-By default, Watchexec will use '$SHELL' if it's defined or a default of 'sh' on Unix-likes, and either 'pwsh', 'powershell', or 'cmd' (CMD.EXE) on Windows, depending on what Watchexec detects is the running shell.
+By default, Watchexec will use '$SHELL' if it's defined or a default of 'sh' on Unix-likes,
+and either 'pwsh', 'powershell', or 'cmd' (CMD.EXE) on Windows, depending on what Watchexec
+detects is the running shell.
 
-With this option, you can override that and use a different shell, for example one with more features or one which has your custom aliases and functions.
+With this option, you can override that and use a different shell, for example one with more
+features or one which has your custom aliases and functions.
 
-If the value has spaces, it is parsed as a command line, and the first word used as the shell program, with the rest as arguments to the shell.
+If the value has spaces, it is parsed as a command line, and the first word used as the
+shell program, with the rest as arguments to the shell.
 
 The command is run with the '-c' flag (except for 'cmd' on Windows, where it's '/C').
 
-The special value 'none' can be used to disable shell use entirely. In that case, the command provided to Watchexec will be parsed, with the first word being the executable and the rest being the arguments, and executed directly. Note that this parsing is rudimentary, and may not work as expected in all cases.
+The special value 'none' can be used to disable shell use entirely. In that case, the
+command provided to Watchexec will be parsed, with the first word being the executable and
+the rest being the arguments, and executed directly. Note that this parsing is rudimentary,
+and may not work as expected in all cases.
 
-Using 'none' is a little more efficient and can enable a stricter interpretation of the input, but it also means that you can't use shell features like globbing, redirection, control flow, logic, or pipes.
+Using 'none' is a little more efficient and can enable a stricter interpretation of the
+input, but it also means that you can't use shell features like globbing, redirection,
+control flow, logic, or pipes.
 
 Examples:
 
 Use without shell:
 
-$ watchexec -n -- zsh -x -o shwordsplit scr
+  $ watchexec -n -- zsh -x -o shwordsplit scr
 
 Use with powershell core:
 
-$ watchexec --shell=pwsh -- Test-Connection localhost
+  $ watchexec --shell=pwsh -- Test-Connection localhost
 
 Use with CMD.exe:
 
-$ watchexec --shell=cmd -- dir
+  $ watchexec --shell=cmd -- dir
 
 Use with a different unix shell:
 
-$ watchexec --shell=bash -- 'echo $BASH_VERSION'
+  $ watchexec --shell=bash -- 'echo $BASH_VERSION'
 
 Use with a unix shell and options:
 
-$ watchexec --shell='zsh -x -o shwordsplit' -- scr
+  $ watchexec --shell='zsh -x -o shwordsplit' -- scr
 """#
         arg <SHELL>
     }
-    flag -n help="Shorthand for '--shell=none'"
-    flag --emit-events-to help="Configure event emission" default=none {
+    flag -n help="Shorthand for '--shell=none'" help_heading=Command
+    flag --emit-events-to help="Configure event emission" hide_default_value=#true help_heading=Command default=none {
         long_help #"""
 Configure event emission
 
@@ -5203,82 +4554,112 @@ numbers of files will either cause the environment to be truncated, or may error
 the process entirely. The $WATCHEXEC_COMMON_PATH is also unintuitive, as demonstrated by the
 multiple confused queries that have landed in my inbox over the years.
 """#
+        required_if_eq "--only-emit-events" "true"
         arg <MODE> {
-            choices environment stdio file json-stdio json-file none
+            choices {
+                choice environment
+                choice stdio
+                choice file
+                choice json-stdio
+                choice json-file
+                choice none
+            }
         }
     }
-    flag --only-emit-events help="Only emit events to stdout, run no commands" {
+    flag --only-emit-events help="Only emit events to stdout, run no commands." conflicts=--manual help_heading=Output {
         long_help #"""
 Only emit events to stdout, run no commands.
 
-This is a convenience option for using Watchexec as a file watcher, without running any commands. It is almost equivalent to using `cat` as the command, except that it will not spawn a new process for each event.
+This is a convenience option for using Watchexec as a file watcher, without running any
+commands. It is almost equivalent to using `cat` as the command, except that it will not
+spawn a new process for each event.
 
-This option requires `--emit-events-to` to be set, and restricts the available modes to `stdio` and `json-stdio`, modifying their behaviour to write to stdout instead of the stdin of the command.
+This option requires `--emit-events-to` to be set, and restricts the available modes to
+`stdio` and `json-stdio`, modifying their behaviour to write to stdout instead of the stdin
+of the command.
 """#
     }
-    flag "-E --env" help="Add env vars to the command" var=#true {
+    flag "-E --env" help="Add env vars to the command" var=#true help_heading=Command {
         long_help #"""
 Add env vars to the command
 
-This is a convenience option for setting environment variables for the command, without setting them for the Watchexec process itself.
+This is a convenience option for setting environment variables for the command, without
+setting them for the Watchexec process itself.
 
 Use key=value syntax. Multiple variables can be set by repeating the option.
 """#
         arg "<KEY=VALUE>"
     }
-    flag --wrap-process help="Configure how the process is wrapped" {
+    flag --wrap-process help="Configure how the process is wrapped" help_heading=Command {
         long_help #"""
 Configure how the process is wrapped
 
-By default, Watchexec will run the command in a session on macOS, in a process group on other Unix platforms, and in a Job Object in Windows.
+By default, Watchexec will run the command in a session on macOS, in a process group on
+other Unix platforms, and in a Job Object in Windows.
 
 Some Unix programs prefer running in a session, while others do not work in a process group.
 
-Use 'group' to use a process group, 'session' to use a process session, and 'none' to run the command directly. On Windows, either of 'group' or 'session' will use a Job Object.
+Use 'group' to use a process group, 'session' to use a process session, and 'none' to run
+the command directly. On Windows, either of 'group' or 'session' will use a Job Object.
 """#
         arg <MODE> {
-            choices group session none
+            choices {
+                choice group
+                choice session
+                choice none
+            }
         }
     }
-    flag "-N --notify" help="Alert when commands start and end" {
+    flag "-N --notify" help="Alert when commands start and end" help_heading=Output {
         long_help #"""
 Alert when commands start and end
 
-With this, Watchexec will emit a desktop notification when a command starts and ends, on supported platforms. On unsupported platforms, it may silently do nothing, or log a warning.
+With this, Watchexec will emit a desktop notification when a command starts and ends, on
+supported platforms. On unsupported platforms, it may silently do nothing, or log a warning.
 """#
     }
-    flag --color help="When to use terminal colours" default=auto {
+    flag --color help="When to use terminal colours" help_heading=Output default=auto {
+        alias "--colour" hide=#true
         long_help #"""
 When to use terminal colours
 
 Setting the environment variable `NO_COLOR` to any value is equivalent to `--color=never`.
 """#
         arg <MODE> {
-            choices auto always never
+            choices {
+                choice auto
+                choice always
+                choice never
+            }
         }
     }
-    flag --timings help="Print how long the command took to run" {
+    flag --timings help="Print how long the command took to run" help_heading=Output {
         long_help #"""
 Print how long the command took to run
 
-This may not be exactly accurate, as it includes some overhead from Watchexec itself. Use the `time` utility, high-precision timers, or benchmarking tools for more accurate results.
+This may not be exactly accurate, as it includes some overhead from Watchexec itself. Use
+the `time` utility, high-precision timers, or benchmarking tools for more accurate results.
 """#
     }
-    flag "-q --quiet" help="Don't print starting and stopping messages" {
+    flag "-q --quiet" help="Don't print starting and stopping messages" help_heading=Output {
         long_help #"""
 Don't print starting and stopping messages
 
-By default Watchexec will print a message when the command starts and stops. This option disables this behaviour, so only the command's output, warnings, and errors will be printed.
+By default Watchexec will print a message when the command starts and stops. This option
+disables this behaviour, so only the command's output, warnings, and errors will be printed.
 """#
     }
-    flag --bell help="Ring the terminal bell on command completion"
+    flag --bell help="Ring the terminal bell on command completion" help_heading=Output
     flag --project-origin help="Set the project origin" {
         long_help #"""
 Set the project origin
 
-Watchexec will attempt to discover the project's "origin" (or "root") by searching for a variety of markers, like files or directory patterns. It does its best but sometimes gets it it wrong, and you can override that with this option.
+Watchexec will attempt to discover the project's "origin" (or "root") by searching for a
+variety of markers, like files or directory patterns. It does its best but sometimes gets it
+it wrong, and you can override that with this option.
 
-The project origin is used to determine the path of certain ignore files, which VCS is being used, the meaning of a leading '/' in filtering patterns, and maybe more in the future.
+The project origin is used to determine the path of certain ignore files, which VCS is being
+used, the meaning of a leading '/' in filtering patterns, and maybe more in the future.
 
 When set, Watchexec will also not bother searching, which can be significantly faster.
 """#
@@ -5288,152 +4669,187 @@ When set, Watchexec will also not bother searching, which can be significantly f
         long_help #"""
 Set the working directory
 
-By default, the working directory of the command is the working directory of Watchexec. You can change that with this option. Note that paths may be less intuitive to use with this.
+By default, the working directory of the command is the working directory of Watchexec. You
+can change that with this option. Note that paths may be less intuitive to use with this.
 """#
         arg <DIRECTORY>
     }
-    flag "-e --exts" help="Filename extensions to filter to" var=#true {
+    flag "-e --exts" help="Filename extensions to filter to" var=#true help_heading=Filtering {
         long_help #"""
 Filename extensions to filter to
 
-This is a quick filter to only emit events for files with the given extensions. Extensions can be given with or without the leading dot (e.g. 'js' or '.js'). Multiple extensions can be given by repeating the option or by separating them with commas.
+This is a quick filter to only emit events for files with the given extensions. Extensions
+can be given with or without the leading dot (e.g. 'js' or '.js'). Multiple extensions can
+be given by repeating the option or by separating them with commas.
 """#
-        arg <EXTENSIONS>
+        arg <EXTENSIONS> delimiter=,
     }
-    flag "-f --filter" help="Filename patterns to filter to" var=#true {
+    flag "-f --filter" help="Filename patterns to filter to" var=#true help_heading=Filtering {
         long_help #"""
 Filename patterns to filter to
 
-Provide a glob-like filter pattern, and only events for files matching the pattern will be emitted. Multiple patterns can be given by repeating the option. Events that are not from files (e.g. signals, keyboard events) will pass through untouched.
+Provide a glob-like filter pattern, and only events for files matching the pattern will be
+emitted. Multiple patterns can be given by repeating the option. Events that are not from
+files (e.g. signals, keyboard events) will pass through untouched.
 """#
         arg <PATTERN>
     }
-    flag --filter-file help="Files to load filters from" var=#true {
+    flag --filter-file help="Files to load filters from" var=#true hide_env=#true env=WATCHEXEC_FILTER_FILES help_heading=Filtering {
         long_help #"""
 Files to load filters from
 
-Provide a path to a file containing filters, one per line. Empty lines and lines starting with '#' are ignored. Uses the same pattern format as the '--filter' option.
+Provide a path to a file containing filters, one per line. Empty lines and lines starting
+with '#' are ignored. Uses the same pattern format as the '--filter' option.
 
 This can also be used via the $WATCHEXEC_FILTER_FILES environment variable.
 """#
-        arg <PATH>
+        arg <PATH> delimiter=:
     }
-    flag "-J --filter-prog" help="[experimental] Filter programs" var=#true {
+    flag "-J --filter-prog" help="[experimental] Filter programs." var=#true help_heading=Filtering {
         long_help #"""
 [experimental] Filter programs.
 
 /!\ This option is EXPERIMENTAL and may change and/or vanish without notice.
 
-Provide your own custom filter programs in jaq (similar to jq) syntax. Programs are given an event in the same format as described in '--emit-events-to' and must return a boolean. Invalid programs will make watchexec fail to start; use '-v' to see program runtime errors.
+Provide your own custom filter programs in jaq (similar to jq) syntax. Programs are given
+an event in the same format as described in '--emit-events-to' and must return a boolean.
+Invalid programs will make watchexec fail to start; use '-v' to see program runtime errors.
 
 In addition to the jaq stdlib, watchexec adds some custom filter definitions:
 
-- 'path | file_meta' returns file metadata or null if the file does not exist.
+  - 'path | file_meta' returns file metadata or null if the file does not exist.
 
-- 'path | file_size' returns the size of the file at path, or null if it does not exist.
+  - 'path | file_size' returns the size of the file at path, or null if it does not exist.
 
-- 'path | file_read(bytes)' returns a string with the first n bytes of the file at path. If the file is smaller than n bytes, the whole file is returned. There is no filter to read the whole file at once to encourage limiting the amount of data read and processed.
+  - 'path | file_read(bytes)' returns a string with the first n bytes of the file at path.
+    If the file is smaller than n bytes, the whole file is returned. There is no filter to
+    read the whole file at once to encourage limiting the amount of data read and processed.
 
-- 'string | hash', and 'path | file_hash' return the hash of the string or file at path. No guarantee is made about the algorithm used: treat it as an opaque value.
+  - 'string | hash', and 'path | file_hash' return the hash of the string or file at path.
+    No guarantee is made about the algorithm used: treat it as an opaque value.
 
-- 'any | kv_store(key)', 'kv_fetch(key)', and 'kv_clear' provide a simple key-value store. Data is kept in memory only, there is no persistence. Consistency is not guaranteed.
+  - 'any | kv_store(key)', 'kv_fetch(key)', and 'kv_clear' provide a simple key-value store.
+    Data is kept in memory only, there is no persistence. Consistency is not guaranteed.
 
-- 'any | printout', 'any | printerr', and 'any | log(level)' will print or log any given value to stdout, stderr, or the log (levels = error, warn, info, debug, trace), and pass the value through (so '[1] | log("debug") | .[]' will produce a '1' and log '[1]').
+  - 'any | printout', 'any | printerr', and 'any | log(level)' will print or log any given
+    value to stdout, stderr, or the log (levels = error, warn, info, debug, trace), and
+    pass the value through (so '[1] | log("debug") | .[]' will produce a '1' and log '[1]').
 
-All filtering done with such programs, and especially those using kv or filesystem access, is much slower than the other filtering methods. If filtering is too slow, events will back up and stall watchexec. Take care when designing your filters.
+All filtering done with such programs, and especially those using kv or filesystem access,
+is much slower than the other filtering methods. If filtering is too slow, events will back
+up and stall watchexec. Take care when designing your filters.
 
-If the argument to this option starts with an '@', the rest of the argument is taken to be the path to a file containing a jaq program.
+If the argument to this option starts with an '@', the rest of the argument is taken to be
+the path to a file containing a jaq program.
 
-Jaq programs are run in order, after all other filters, and short-circuit: if a filter (jaq or not) rejects an event, execution stops there, and no other filters are run. Additionally, they stop after outputting the first value, so you'll want to use 'any' or 'all' when iterating, otherwise only the first item will be processed, which can be quite confusing!
+Jaq programs are run in order, after all other filters, and short-circuit: if a filter (jaq
+or not) rejects an event, execution stops there, and no other filters are run. Additionally,
+they stop after outputting the first value, so you'll want to use 'any' or 'all' when
+iterating, otherwise only the first item will be processed, which can be quite confusing!
 
-Find user-contributed programs or submit your own useful ones at <https://github.com/watchexec/watchexec/discussions/592>.
+Find user-contributed programs or submit your own useful ones at
+<https://github.com/watchexec/watchexec/discussions/592>.
 
 ## Examples:
 
 Regexp ignore filter on paths:
 
-'all(.tags[] | select(.kind == "path"); .absolute | test("[.]test[.]js$")) | not'
+  'all(.tags[] | select(.kind == "path"); .absolute | test("[.]test[.]js$")) | not'
 
 Pass any event that creates a file:
 
-'any(.tags[] | select(.kind == "fs"); .simple == "create")'
+  'any(.tags[] | select(.kind == "fs"); .simple == "create")'
 
 Pass events that touch executable files:
 
-'any(.tags[] | select(.kind == "path" && .filetype == "file"); .absolute | metadata | .executable)'
+  'any(.tags[] | select(.kind == "path" && .filetype == "file"); .absolute | metadata | .executable)'
 
 Ignore files that start with shebangs:
 
-'any(.tags[] | select(.kind == "path" && .filetype == "file"); .absolute | read(2) == "#!") | not'
+  'any(.tags[] | select(.kind == "path" && .filetype == "file"); .absolute | read(2) == "#!") | not'
 """#
         arg <EXPRESSION>
     }
-    flag "-i --ignore" help="Filename patterns to filter out" var=#true {
+    flag "-i --ignore" help="Filename patterns to filter out" var=#true help_heading=Filtering {
         long_help #"""
 Filename patterns to filter out
 
-Provide a glob-like filter pattern, and events for files matching the pattern will be excluded. Multiple patterns can be given by repeating the option. Events that are not from files (e.g. signals, keyboard events) will pass through untouched.
+Provide a glob-like filter pattern, and events for files matching the pattern will be
+excluded. Multiple patterns can be given by repeating the option. Events that are not from
+files (e.g. signals, keyboard events) will pass through untouched.
 """#
         arg <PATTERN>
     }
-    flag --ignore-file help="Files to load ignores from" var=#true {
+    flag --ignore-file help="Files to load ignores from" var=#true hide_env=#true env=WATCHEXEC_IGNORE_FILES help_heading=Filtering {
         long_help #"""
 Files to load ignores from
 
-Provide a path to a file containing ignores, one per line. Empty lines and lines starting with '#' are ignored. Uses the same pattern format as the '--ignore' option.
+Provide a path to a file containing ignores, one per line. Empty lines and lines starting
+with '#' are ignored. Uses the same pattern format as the '--ignore' option.
 
 This can also be used via the $WATCHEXEC_IGNORE_FILES environment variable.
 """#
-        arg <PATH>
+        arg <PATH> delimiter=:
     }
-    flag --fs-events help="Filesystem events to filter to" var=#true {
+    flag --fs-events help="Filesystem events to filter to" var=#true hide_default_value=#true help_heading=Filtering default=create,remove,rename,modify,metadata {
         long_help #"""
 Filesystem events to filter to
 
-This is a quick filter to only emit events for the given types of filesystem changes. Choose from 'access', 'create', 'remove', 'rename', 'modify', 'metadata'. Multiple types can be given by repeating the option or by separating them with commas. By default, this is all types except for 'access'.
+This is a quick filter to only emit events for the given types of filesystem changes. Choose
+from 'access', 'create', 'remove', 'rename', 'modify', 'metadata'. Multiple types can be
+given by repeating the option or by separating them with commas. By default, this is all
+types except for 'access'.
 
-This may apply filtering at the kernel level when possible, which can be more efficient, but may be more confusing when reading the logs.
+This may apply filtering at the kernel level when possible, which can be more efficient, but
+may be more confusing when reading the logs.
 """#
-        default {
-            create
-            remove
-            rename
-            modify
-            metadata
-        }
-        arg <EVENTS> {
-            choices access create remove rename modify metadata
+        arg <EVENTS> delimiter=, {
+            choices {
+                choice access
+                choice create
+                choice remove
+                choice rename
+                choice modify
+                choice metadata
+            }
         }
     }
-    flag --no-meta help="Don't emit fs events for metadata changes" {
+    flag --no-meta help="Don't emit fs events for metadata changes" conflicts=--fs-events help_heading=Filtering {
         long_help #"""
 Don't emit fs events for metadata changes
 
-This is a shorthand for '--fs-events create,remove,rename,modify'. Using it alongside the '--fs-events' option is non-sensical and not allowed.
+This is a shorthand for '--fs-events create,remove,rename,modify'. Using it alongside the
+'--fs-events' option is non-sensical and not allowed.
 """#
     }
-    flag --print-events help="Print events that trigger actions" {
+    flag --print-events help="Print events that trigger actions" help_heading=Debugging {
         long_help #"""
 Print events that trigger actions
 
-This prints the events that triggered the action when handling it (after debouncing), in a human readable form. This is useful for debugging filters.
+This prints the events that triggered the action when handling it (after debouncing), in a
+human readable form. This is useful for debugging filters.
 
 Use '-vvv' instead when you need more diagnostic information.
 """#
     }
-    flag --manual help="Show the manual page" {
+    flag --manual help="Show the manual page" help_heading=Debugging {
         long_help #"""
 Show the manual page
 
-This shows the manual page for Watchexec, if the output is a terminal and the 'man' program is available. If not, the manual page is printed to stdout in ROFF format (suitable for writing to a watchexec.1 file).
+This shows the manual page for Watchexec, if the output is a terminal and the 'man' program
+is available. If not, the manual page is printed to stdout in ROFF format (suitable for
+writing to a watchexec.1 file).
 """#
     }
     arg "[TASK]" help=#"""
 Tasks to run
 Can specify multiple tasks by separating with `:::`
 e.g.: `mise run task1 arg1 arg2 ::: task2 arg1 arg2`
-"""# required=#false
+Defaults to `default`
+"""# required=#false double_dash=automatic
     arg "[ARGS]…" help="Task and arguments to run" required=#false double_dash=automatic var=#true
+    complete path type=path
+    complete directory type=dir
 }
 cmd where help="Display the installation path for a tool" effect=read {
     long_help #"""
@@ -5441,20 +4857,7 @@ Display the installation path for a tool
 
 The tool must be installed for this to work.
 """#
-    after_long_help #"""
-Examples:
-
-    # Show the latest installed version of node
-    # If it is is not installed, errors
-    $ mise where node@20
-    /home/jdx/.local/share/mise/installs/node/20.0.0
-
-    # Show the current, active install directory of node
-    # Errors if node is not referenced in any .tool-version file
-    $ mise where node
-    /home/jdx/.local/share/mise/installs/node/20.0.0
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Show the latest installed version of node\n    # If it is is not installed, errors\n    $ \u{1b}[1mmise where node@20\u{1b}[22m\n    /home/jdx/.local/share/mise/installs/node/20.0.0\n\n    # Show the current, active install directory of node\n    # Errors if node is not referenced in any .tool-version file\n    $ \u{1b}[1mmise where node\u{1b}[22m\n    /home/jdx/.local/share/mise/installs/node/20.0.0\n"
     arg <TOOL@VERSION> help=#"""
 Tool(s) to look up
 e.g.: ruby@3
@@ -5474,19 +4877,7 @@ Shows the path that a tool's bin points to.
 
 Use this to figure out what version of a tool is currently active.
 """#
-    after_long_help #"""
-Examples:
-
-    $ mise which node
-    /home/username/.local/share/mise/installs/node/20.0.0/bin/node
-
-    $ mise which node --plugin
-    node
-
-    $ mise which node --version
-    20.0.0
-
-"""#
+    after_long_help "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise which node\u{1b}[22m\n    /home/username/.local/share/mise/installs/node/20.0.0/bin/node\n\n    $ \u{1b}[1mmise which node --plugin\u{1b}[22m\n    node\n\n    $ \u{1b}[1mmise which node --version\u{1b}[22m\n    20.0.0\n"
     flag "-t --tool" help=#"""
 Use a specific tool@version
 e.g.: `mise which npm --tool=node@20`
@@ -5494,9 +4885,9 @@ e.g.: `mise which npm --tool=node@20`
         arg <TOOL@VERSION>
     }
     flag --complete hide=#true
-    flag --plugin help="Show the plugin name instead of the path"
-    flag --version help="Show the version instead of the path"
-    arg "[BIN_NAME]" help="The bin to look up" required=#false
+    flag --plugin help="Show the plugin name instead of the path" conflicts=--version
+    flag --version help="Show the version instead of the path" conflicts=--plugin
+    arg "[BIN_NAME]" help="The bin to look up" required=#false required_unless=--complete
 }
 source_code_link_template #"""
 {%- set path = path | replace(from='-', to='_') -%}

--- a/benches/shadows/aube/src/lib.rs
+++ b/benches/shadows/aube/src/lib.rs
@@ -648,7 +648,7 @@ pub struct BinArgs {
 /// Open package bug tracker URLs
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n  $ aube bugs\n\n  $ aube bugs react\n\n  $ aube issues react react-dom",
+    after_long_help = "Examples:\n\n  $ aube bugs\n\n  $ aube bugs react\n\n  $ aube issues react react-dom\n",
     effect = "read"
 )]
 pub struct BugsArgs {
@@ -2992,7 +2992,7 @@ pub struct LinkArgs {
 /// Print the resolved dependency tree
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n  $ aube list\n  my-app@1.0.0 /home/user/project\n\n  dependencies:\n  ├── express 4.19.2\n  ├── lodash 4.17.21\n  └── zod 3.23.8\n\n  devDependencies:\n  ├── typescript 5.4.5\n  └── vitest 1.6.0\n\n  # Show the full transitive tree\n  $ aube list --depth Infinity\n  my-app@1.0.0 /home/user/project\n\n  dependencies:\n  ├─┬ express 4.19.2\n  │ ├── accepts 1.3.8\n  │ ├── body-parser 1.20.2\n  │ └── ...\n\n  # Only direct production deps\n  $ aube list --prod\n\n  # Machine-readable: one path per line (real store locations)\n  $ aube list --parseable\n  /home/user/project\n  /home/user/project/node_modules/.aube/express@4.19.2/node_modules/express\n  /home/user/project/node_modules/.aube/lodash@4.17.21/node_modules/lodash\n\n  # Filter to a single package\n  $ aube list express",
+    after_long_help = "Examples:\n\n  $ aube list\n  my-app@1.0.0 /home/user/project\n\n  dependencies:\n  ├── express 4.19.2\n  ├── lodash 4.17.21\n  └── zod 3.23.8\n\n  devDependencies:\n  ├── typescript 5.4.5\n  └── vitest 1.6.0\n\n  # Show the full transitive tree\n  $ aube list --depth Infinity\n  my-app@1.0.0 /home/user/project\n\n  dependencies:\n  ├─┬ express 4.19.2\n  │ ├── accepts 1.3.8\n  │ ├── body-parser 1.20.2\n  │ └── ...\n\n  # Only direct production deps\n  $ aube list --prod\n\n  # Machine-readable: one path per line (real store locations)\n  $ aube list --parseable\n  /home/user/project\n  /home/user/project/node_modules/.aube/express@4.19.2/node_modules/express\n  /home/user/project/node_modules/.aube/lodash@4.17.21/node_modules/lodash\n\n  # Filter to a single package\n  $ aube list express\n",
     effect = "read"
 )]
 pub struct ListArgs {
@@ -3523,7 +3523,7 @@ pub struct PatchRemoveArgs {
 
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n  $ aube peers check\n  All peer dependencies are satisfied.\n\n  # With issues\n  $ aube peers check\n  1 unmet, 1 missing peer dependencies:\n\n  ├─┬ @emotion/react@11.11.4\n  │ └── ✕ unmet peer react@>=16.8: found 17.0.2\n  └─┬ react-dom@18.2.0\n    └── ✕ missing peer react@^18.0.0\n\n  # Machine-readable\n  $ aube peers check --json",
+    after_long_help = "Examples:\n\n  $ aube peers check\n  All peer dependencies are satisfied.\n\n  # With issues\n  $ aube peers check\n  1 unmet, 1 missing peer dependencies:\n\n  ├─┬ @emotion/react@11.11.4\n  │ └── ✕ unmet peer react@>=16.8: found 17.0.2\n  └─┬ react-dom@18.2.0\n    └── ✕ missing peer react@^18.0.0\n\n  # Machine-readable\n  $ aube peers check --json\n",
     effect = "read"
 )]
 pub struct PeersCheckArgs {
@@ -5053,7 +5053,7 @@ pub struct TokenArgs {
 /// Check one package version for a publishing-trust downgrade
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n  $ aube trust check @hono/node-server@1.19.17\n  @hono/node-server@1.19.17: pass\n  published: 2026-07-27T03:07:48.993Z\n  current evidence: trusted publisher\n  strongest earlier evidence: trusted publisher (2.0.10)\n\n  # Evaluate the underlying policy even when aube has a built-in exception\n  $ aube trust check @hono/node-server@1.19.15 --ignore-default-excludes\n\n  # Machine-readable report\n  $ aube trust check @hono/node-server@1.19.17 --json",
+    after_long_help = "Examples:\n\n  $ aube trust check @hono/node-server@1.19.17\n  @hono/node-server@1.19.17: pass\n  published: 2026-07-27T03:07:48.993Z\n  current evidence: trusted publisher\n  strongest earlier evidence: trusted publisher (2.0.10)\n\n  # Evaluate the underlying policy even when aube has a built-in exception\n  $ aube trust check @hono/node-server@1.19.15 --ignore-default-excludes\n\n  # Machine-readable report\n  $ aube trust check @hono/node-server@1.19.17 --json\n",
     effect = "read"
 )]
 pub struct TrustCheckArgs {
@@ -5546,7 +5546,7 @@ pub struct VersionArgs {
 /// Print package metadata from the registry
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n  $ aube view\n  my-package@1.0.0 | MIT | deps: 0 | versions: 1\n\n  $ aube view react\n  react@18.3.1 | MIT | deps: 1 | versions: 2037\n  React is a JavaScript library for building user interfaces.\n  https://react.dev/\n\n  keywords: react\n\n  dist\n  .tarball: https://registry.npmjs.org/react/-/react-18.3.1.tgz\n  .shasum:  a0b2eb79...\n  .integrity: sha512-...\n\n  # A specific version\n  $ aube view react@17.0.2\n\n  # A single field\n  $ aube view react version\n  18.3.1\n\n  $ aube view react dist.tarball\n  https://registry.npmjs.org/react/-/react-18.3.1.tgz\n\n  # All versions ever published\n  $ aube view react versions --json\n\n  # Raw JSON for the resolved version\n  $ aube view react@next --json",
+    after_long_help = "Examples:\n\n  $ aube view\n  my-package@1.0.0 | MIT | deps: 0 | versions: 1\n\n  $ aube view react\n  react@18.3.1 | MIT | deps: 1 | versions: 2037\n  React is a JavaScript library for building user interfaces.\n  https://react.dev/\n\n  keywords: react\n\n  dist\n  .tarball: https://registry.npmjs.org/react/-/react-18.3.1.tgz\n  .shasum:  a0b2eb79...\n  .integrity: sha512-...\n\n  # A specific version\n  $ aube view react@17.0.2\n\n  # A single field\n  $ aube view react version\n  18.3.1\n\n  $ aube view react dist.tarball\n  https://registry.npmjs.org/react/-/react-18.3.1.tgz\n\n  # All versions ever published\n  $ aube view react versions --json\n\n  # Raw JSON for the resolved version\n  $ aube view react@next --json\n",
     effect = "read"
 )]
 pub struct ViewArgs {
@@ -5690,7 +5690,7 @@ pub struct WhoamiArgs {
 /// Print reverse dependency chains explaining why a package is installed
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n  $ aube why debug\n  my-app@1.0.0 /home/user/project\n\n  dependencies:\n  express 4.19.2\n  └── debug 2.6.9\n  body-parser 1.20.2\n  └── debug 2.6.9\n\n  # Only follow chains starting at a devDependency\n  $ aube why --dev typescript\n\n  # Include each node's store path\n  $ aube why --long debug\n\n  # Tab-separated, one chain per line (pipe-friendly)\n  $ aube why --parseable debug\n\n  # JSON: an array of chain objects\n  $ aube why --json debug",
+    after_long_help = "Examples:\n\n  $ aube why debug\n  my-app@1.0.0 /home/user/project\n\n  dependencies:\n  express 4.19.2\n  └── debug 2.6.9\n  body-parser 1.20.2\n  └── debug 2.6.9\n\n  # Only follow chains starting at a devDependency\n  $ aube why --dev typescript\n\n  # Include each node's store path\n  $ aube why --long debug\n\n  # Tab-separated, one chain per line (pipe-friendly)\n  $ aube why --parseable debug\n\n  # JSON: an array of chain objects\n  $ aube why --json debug\n",
     effect = "read"
 )]
 pub struct WhyArgs {

--- a/benches/shadows/mise-argh/src/lib.rs
+++ b/benches/shadows/mise-argh/src/lib.rs
@@ -865,7 +865,7 @@ pub struct BootstrapPackagesImportArgs {
     /// write to the global config (~/.config/mise/config.toml)
     #[argh(switch, long = "global", short = 'g')]
     pub global: bool,
-    /// only import packages for this manager. Currently only `brew` is supported
+    /// only import packages for this manager. Currently only `brew` is supported.
     #[argh(option, long = "manager", short = 'm')]
     pub manager: Option<String>,
     /// import every linked formula, including dependencies
@@ -883,7 +883,7 @@ pub struct BootstrapPackagesImportArgs {
 #[derive(FromArgs)]
 #[argh(subcommand, name = "prune")]
 pub struct BootstrapPackagesPruneArgs {
-    /// only prune packages for this manager. Currently only `brew` is supported
+    /// only prune packages for this manager
     #[argh(option, long = "manager", short = 'm')]
     pub manager: Option<String>,
     /// print what would be removed without deleting anything
@@ -1040,6 +1040,12 @@ pub struct BootstrapRemoteArgs {
     /// sSH connection timeout in seconds
     #[argh(option, long = "connect-timeout")]
     pub connect_timeout: Option<String>,
+    /// dereference one source-relative symbolic link; repeat for multiple links
+    #[argh(option, long = "copy-link")]
+    pub copy_link: Vec<String>,
+    /// dereference every symbolic link in the source archive
+    #[argh(switch, long = "copy-links")]
+    pub copy_links: bool,
     /// additional archive pattern to exclude; repeat for multiple patterns
     #[argh(option, long = "exclude")]
     pub exclude: Vec<String>,
@@ -1073,6 +1079,9 @@ pub struct BootstrapRemoteArgs {
     /// prompt securely for missing secret inputs on the remote host
     #[argh(switch, long = "prompt-secrets")]
     pub prompt_secrets: bool,
+    /// config environments to load on the remote host; repeat or delimit with commas (for example, ci,dotfiles)
+    #[argh(option, long = "remote-env")]
+    pub remote_env: Vec<String>,
     /// existing mise executable name or path; relative paths use the staged project
     #[argh(option, long = "remote-mise")]
     pub remote_mise: Option<String>,
@@ -1599,7 +1608,7 @@ pub enum ConfigCommands {
 #[derive(FromArgs)]
 #[argh(subcommand, name = "current")]
 pub struct CurrentArgs {
-    /// plugin to show versions of e.g.: ruby, node, cargo:eza, npm:prettier, etc
+    /// plugin to show versions of e.g.: ruby, node, cargo:eza, npm:prettier, etc.
     #[argh(positional)]
     pub plugin: Option<String>,
 }
@@ -1928,6 +1937,9 @@ pub struct GenerateBootstrapArgs {
     /// directory to put localized data into
     #[argh(option, long = "localized-dir")]
     pub localized_dir: Option<String>,
+    /// also write a Windows launcher, `<WRITE>.cmd`
+    #[argh(switch, long = "windows")]
+    pub windows: bool,
 }
 
 /// generate a mise.toml file
@@ -1979,6 +1991,9 @@ pub struct GenerateGitPreCommitArgs {
     /// which hook to generate (saves to .git/hooks/$hook)
     #[argh(option, long = "hook")]
     pub hook: Option<String>,
+    /// mise flags to embed in the generated hook, given after `--`
+    #[argh(positional)]
+    pub mise_arg: Vec<String>,
 }
 
 /// generate a GitHub Action workflow file
@@ -2045,6 +2060,9 @@ pub struct GenerateToolStubArgs {
     /// specify mise version for the bootstrap script
     #[argh(option, long = "bootstrap-version")]
     pub bootstrap_version: Option<String>,
+    /// checksum algorithm to use when downloading artifacts
+    #[argh(option, long = "checksum-algorithm")]
+    pub checksum_algorithm: Option<String>,
     /// fetch checksums and sizes for an existing tool stub file
     #[argh(switch, long = "fetch")]
     pub fetch: bool,
@@ -2244,6 +2262,9 @@ pub struct InstallArgs {
     /// like --dry-run but exits with code 1 if there are tools to install
     #[argh(switch, long = "dry-run-code")]
     pub dry_run_code: bool,
+    /// also install tools required by tasks in the current scope
+    #[argh(switch, long = "include-task-tools")]
+    pub include_task_tools: bool,
     /// only install versions released before this date or older than this duration
     #[argh(option, long = "minimum-release-age")]
     pub minimum_release_age: Option<String>,
@@ -2590,12 +2611,15 @@ pub enum OciCommands {
 #[derive(FromArgs)]
 #[argh(subcommand, name = "outdated")]
 pub struct OutdatedArgs {
+    /// compares against the latest versions available, not what matches the current config
+    #[argh(switch, long = "bump", short = 'b')]
+    pub bump: bool,
     /// output in JSON format
     #[argh(switch, long = "json", short = 'J')]
     pub json: bool,
-    /// compares against the latest versions available, not what matches the current config
-    #[argh(switch, long = "bump", short = 'l')]
-    pub bump: bool,
+    /// deprecated shorthand for --bump
+    #[argh(switch, short = 'l')]
+    pub l: bool,
     /// show outdated tools including installed-but-inactive tools not present in the current config
     #[argh(switch, long = "inactive")]
     pub inactive: bool,
@@ -2903,7 +2927,7 @@ pub struct RegistryArgs {
     /// output in JSON format
     #[argh(switch, long = "json", short = 'J')]
     pub json: bool,
-    /// include security features for each tool's backends in JSON output
+    /// include security features for each tool's backends in JSON output.
     #[argh(switch, long = "security")]
     pub security: bool,
     /// show only the specified tool's full name
@@ -2950,6 +2974,9 @@ pub struct RunArgs {
     /// output affected projects and tasks as JSON without running tasks
     #[argh(switch, long = "affected-json")]
     pub affected_json: bool,
+    /// open the interactive selector with all tasks from the entire monorepo
+    #[argh(switch, long = "all")]
+    pub all: bool,
     /// continue running tasks even if one fails
     #[argh(switch, long = "continue-on-error", short = 'c')]
     pub continue_on_error: bool,
@@ -3570,6 +3597,9 @@ pub struct TasksRunArgs {
     /// output affected projects and tasks as JSON without running tasks
     #[argh(switch, long = "affected-json")]
     pub affected_json: bool,
+    /// open the interactive selector with all tasks from the entire monorepo
+    #[argh(switch, long = "all")]
+    pub all: bool,
     /// continue running tasks even if one fails
     #[argh(switch, long = "continue-on-error", short = 'c')]
     pub continue_on_error: bool,
@@ -3669,10 +3699,10 @@ pub struct TasksRunArgs {
     /// tasks to run
     #[argh(positional)]
     pub task: String,
-    /// arguments to pass to the tasks. Use ":::" to separate tasks
+    /// arguments to pass to the tasks. Use ":::" to separate tasks.
     #[argh(positional)]
     pub args: String,
-    /// arguments to pass to the tasks. Use ":::" to separate tasks
+    /// arguments to pass to the tasks. Use ":::" to separate tasks.
     #[argh(positional)]
     pub args_last: Vec<String>,
 }
@@ -3905,10 +3935,10 @@ pub struct TrustArgs {
     /// show the trusted status of config files from the current directory and its parents.
     #[argh(switch, long = "show")]
     pub show: bool,
-    /// no longer trust this config, will prompt in the future
+    /// remove explicit trust for this config
     #[argh(switch, long = "untrust")]
     pub untrust: bool,
-    /// the config file to trust
+    /// the config file whose trust status to change
     #[argh(positional)]
     pub config_file: Option<String>,
 }
@@ -3946,7 +3976,7 @@ pub struct UnsetArgs {
     pub env_key: Vec<String>,
 }
 
-/// no longer trust a config, will prompt in the future
+/// remove explicit trust for a config
 #[derive(FromArgs)]
 #[argh(subcommand, name = "untrust")]
 pub struct UntrustArgs {
@@ -3980,15 +4010,18 @@ pub struct UnuseArgs {
 #[derive(FromArgs)]
 #[argh(subcommand, name = "upgrade")]
 pub struct UpgradeArgs {
+    /// upgrades to the latest version available, bumping the version in mise.toml
+    #[argh(switch, long = "bump", short = 'b')]
+    pub bump: bool,
     /// display multiselect menu to choose which tools to upgrade
     #[argh(switch, long = "interactive", short = 'i')]
     pub interactive: bool,
     /// number of jobs to run in parallel
     #[argh(option, long = "jobs", short = 'j')]
     pub jobs: Option<String>,
-    /// upgrades to the latest version available, bumping the version in mise.toml
-    #[argh(switch, long = "bump", short = 'l')]
-    pub bump: bool,
+    /// deprecated shorthand for --bump
+    #[argh(switch, short = 'l')]
+    pub l: bool,
     /// just print what would be done, don't actually do it
     #[argh(switch, long = "dry-run", short = 'n')]
     pub dry_run: bool,
@@ -4013,6 +4046,9 @@ pub struct UpgradeArgs {
     /// do not uninstall the versions that were upgraded away from
     #[argh(switch, long = "no-prune")]
     pub no_prune: bool,
+    /// uninstall the versions that were upgraded away from
+    #[argh(switch, long = "prune")]
+    pub prune: bool,
     /// connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1
     #[argh(switch, long = "raw")]
     pub raw: bool,
@@ -4057,7 +4093,7 @@ pub struct UseArgs {
     /// only install versions released before this date or older than this duration
     #[argh(option, long = "minimum-release-age")]
     pub minimum_release_age: Option<String>,
-    /// save exact version to config file
+    /// save the resolved concrete version to the config file
     #[argh(switch, long = "pin")]
     pub pin: bool,
     /// connect backend install command stdin/stdout/stderr directly to the terminal Implies `--jobs=1`
@@ -4165,7 +4201,7 @@ pub struct WatchArgs {
     /// configure event emission
     #[argh(option, long = "emit-events-to")]
     pub emit_events_to: Option<String>,
-    /// only emit events to stdout, run no commands
+    /// only emit events to stdout, run no commands.
     #[argh(switch, long = "only-emit-events")]
     pub only_emit_events: bool,
     /// add env vars to the command
@@ -4204,7 +4240,7 @@ pub struct WatchArgs {
     /// files to load filters from
     #[argh(option, long = "filter-file")]
     pub filter_file: Vec<String>,
-    /// experimental] Filter programs
+    /// experimental] Filter programs.
     #[argh(option, long = "filter-prog", short = 'J')]
     pub filter_prog: Vec<String>,
     /// filename patterns to filter out
@@ -4281,7 +4317,7 @@ pub struct Cli {
     /// force the operation
     #[argh(switch, long = "force", short = 'f')]
     pub force: bool,
-    /// how many jobs to run in parallel [default: 8]
+    /// how many jobs to run in parallel; values below 1 are treated as 1 [default: 8]
     #[argh(option, long = "jobs", short = 'j')]
     pub jobs: Option<String>,
     /// dry run, don't actually do anything
@@ -4472,7 +4508,7 @@ pub enum Commands {
     Uninstall(UninstallArgs),
     /// remove environment variable(s) from the config file.
     Unset(UnsetArgs),
-    /// no longer trust a config, will prompt in the future
+    /// remove explicit trust for a config
     Untrust(UntrustArgs),
     /// removes installed tool versions from mise.toml
     Unuse(UnuseArgs),

--- a/benches/shadows/mise-bpaf/src/lib.rs
+++ b/benches/shadows/mise-bpaf/src/lib.rs
@@ -34,7 +34,10 @@ pub struct ActivateArgs {
     pub shell: Option<String>,
     /// Do not automatically call hook-env
     ///
-    /// This can be helpful for debugging mise. If you run `eval "$(mise activate --no-hook-env)"`, then you can call `mise hook-env` manually which will output the env vars to stdout without actually modifying the environment. That way you can do things like `mise hook-env --trace` to get more information or just see the values that hook-env is outputting.
+    /// This can be helpful for debugging mise. If you run `eval "$(mise activate --no-hook-env)"`, then
+    /// you can call `mise hook-env` manually which will output the env vars to stdout without actually
+    /// modifying the environment. That way you can do things like `mise hook-env --trace` to get more
+    /// information or just see the values that hook-env is outputting.
     #[bpaf(long("no-hook-env"), switch)]
     pub no_hook_env: bool,
     #[bpaf(long("shims"), switch)]
@@ -845,7 +848,6 @@ pub struct BootstrapPackagesApplyArgs {
     /// Refresh package manager metadata first (apk: `--update-cache`, apt: `apt-get update`)
     #[bpaf(long("update"), switch)]
     pub update: bool,
-    /// Packages in `manager:package` form; defaults to everything configured in [bootstrap.packages]
     #[bpaf(positional("PACKAGE"))]
     pub package: Vec<String>,
 }
@@ -925,7 +927,7 @@ pub struct BootstrapPackagesImportArgs {
     /// Write to the global config (~/.config/mise/config.toml)
     #[bpaf(long("global"), short('g'), switch)]
     pub global: bool,
-    /// Only import packages for this manager. Currently only `brew` is supported
+    /// Only import packages for this manager. Currently only `brew` is supported.
     #[bpaf(long("manager"), short('m'), argument("MANAGER"))]
     pub manager: Option<String>,
     /// Import every linked formula, including dependencies
@@ -941,13 +943,13 @@ pub struct BootstrapPackagesImportArgs {
 
 /// Prune installed system packages no longer declared in `[bootstrap.packages]`
 ///
-/// Currently supports Homebrew formulae only. Pruning removes linked formulae
-/// that are not needed by the current config or by trusted, loadable tracked
-/// configs.
+/// Supports Homebrew formulae and conservatively removable, mise-owned casks.
+/// Pruning keeps packages needed by the current config or by trusted, loadable
+/// tracked configs.
 #[derive(Debug, Clone, Bpaf)]
 #[bpaf(generate(bootstrappackagespruneargs_p))]
 pub struct BootstrapPackagesPruneArgs {
-    /// Only prune packages for this manager. Currently only `brew` is supported
+    /// Only prune packages for this manager
     #[bpaf(long("manager"), short('m'), argument("MANAGER"))]
     pub manager: Option<String>,
     /// Print what would be removed without deleting anything
@@ -976,7 +978,7 @@ pub struct BootstrapPackagesStatusArgs {
 /// that are already installed: apk/apt/dnf/pacman upgrade to the newest available
 /// version (apk, apt, and dnf honor a version pinned in config), brew pours the
 /// formula's current bottle and replaces the old keg, brew-cask installs
-/// the current cask artifact, flatpak updates applications and runtimes, and mas upgrades App Store apps. Packages that
+/// the current cask artifact, flatpak and flatpak-user update applications and runtimes, and mas upgrades App Store apps. Packages that
 /// are not installed yet are skipped — use `mise bootstrap packages apply`
 /// for those.
 ///
@@ -993,7 +995,6 @@ pub struct BootstrapPackagesUpgradeArgs {
     /// Skip the confirmation prompt
     #[bpaf(long("yes"), short('y'), switch)]
     pub yes: bool,
-    /// Packages in `manager:package` form; defaults to everything configured in [bootstrap.packages]
     #[bpaf(positional("PACKAGE"))]
     pub package: Vec<String>,
 }
@@ -1015,7 +1016,6 @@ pub struct BootstrapPackagesUseArgs {
     /// Write to the config file for this environment (mise.<ENV>.toml)
     #[bpaf(long("env"), short('e'), argument("ENV"))]
     pub env: Option<String>,
-    /// Write to the global config (~/.config/mise/config.toml) instead of the local one
     #[bpaf(long("global"), short('g'), switch)]
     pub global: bool,
     /// Print the commands that would run without writing config or installing
@@ -1127,6 +1127,12 @@ pub struct BootstrapRemoteArgs {
     /// SSH connection timeout in seconds
     #[bpaf(long("connect-timeout"), argument("CONNECT_TIMEOUT"))]
     pub connect_timeout: Option<String>,
+    /// Dereference one source-relative symbolic link; repeat for multiple links
+    #[bpaf(long("copy-link"), argument("PATH"))]
+    pub copy_link: Vec<String>,
+    /// Dereference every symbolic link in the source archive
+    #[bpaf(long("copy-links"), switch)]
+    pub copy_links: bool,
     /// Additional archive pattern to exclude; repeat for multiple patterns
     #[bpaf(long("exclude"), argument("PATTERN"))]
     pub exclude: Vec<String>,
@@ -1160,6 +1166,9 @@ pub struct BootstrapRemoteArgs {
     /// Prompt securely for missing secret inputs on the remote host
     #[bpaf(long("prompt-secrets"), switch)]
     pub prompt_secrets: bool,
+    /// Config environments to load on the remote host; repeat or delimit with commas (for example, ci,dotfiles)
+    #[bpaf(long("remote-env"), argument("ENV"))]
+    pub remote_env: Vec<String>,
     /// Existing mise executable name or path; relative paths use the staged project
     #[bpaf(long("remote-mise"), argument("COMMAND"))]
     pub remote_mise: Option<String>,
@@ -1487,7 +1496,8 @@ pub struct BootstrapArgs {
     pub force_dotfiles: bool,
     /// Run only one or more bootstrap parts
     ///
-    /// Can be passed multiple times or as a comma-separated list. Cannot be used with `--skip`.
+    /// Can be passed multiple times or as a comma-separated list.
+    /// Cannot be used with `--skip`.
     #[bpaf(long("only"), argument("ONLY"))]
     pub only: Vec<String>,
     /// Prompt securely for missing bootstrap secret inputs
@@ -1604,7 +1614,6 @@ pub struct CacheClearArgs {
     /// Clear output cache entries for a task name or pattern
     #[bpaf(long("task"), argument("TASK"))]
     pub task: Option<String>,
-    /// Tool(s) to clear cache for e.g.: node, python
     #[bpaf(positional("TOOL"))]
     pub tool: Vec<String>,
 }
@@ -1627,7 +1636,6 @@ pub struct CachePruneArgs {
     /// Just show what would be pruned
     #[bpaf(long("dry-run"), switch)]
     pub dry_run: bool,
-    /// Tool(s) to prune cache for e.g.: node, python
     #[bpaf(positional("TOOL"))]
     pub tool: Vec<String>,
 }
@@ -1676,7 +1684,7 @@ pub enum CacheCommands {
 #[bpaf(generate(completionargs_p))]
 pub struct CompletionArgs {
     /// Shell type to generate completions for
-    #[bpaf(long("shell"), short('s'), argument("SHELL_TYPE"))]
+    #[bpaf(long("shell"), short('s'), argument("SHELL"))]
     pub shell: Option<String>,
     /// Include the bash completion library in the bash completion script
     ///
@@ -1781,7 +1789,6 @@ pub enum ConfigCommands {
 #[derive(Debug, Clone, Bpaf)]
 #[bpaf(generate(currentargs_p))]
 pub struct CurrentArgs {
-    /// Plugin to show versions of e.g.: ruby, node, cargo:eza, npm:prettier, etc
     #[bpaf(positional("PLUGIN"))]
     pub plugin: Option<String>,
 }
@@ -2076,7 +2083,7 @@ pub struct EnvArgs {
 #[bpaf(generate(execargs_p))]
 pub struct ExecArgs {
     /// Command string to execute
-    #[bpaf(long("command"), short('c'), argument("C"))]
+    #[bpaf(long("command"), short('c'), argument("COMMAND"))]
     pub command: Option<String>,
     #[bpaf(long("jobs"), short('j'), argument("JOBS"))]
     pub jobs: Option<String>,
@@ -2111,10 +2118,8 @@ pub struct ExecArgs {
     /// Skip automatic dependency preparation
     #[bpaf(long("no-deps"), switch)]
     pub no_deps: bool,
-    /// Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1
     #[bpaf(long("raw"), switch)]
     pub raw: bool,
-    /// Tool(s) to start e.g.: node@20 python@3.10
     #[bpaf(positional("TOOL@VERSION"))]
     pub tool_version: Vec<String>,
     /// Command string to execute (same as --command)
@@ -2134,7 +2139,6 @@ pub struct FmtArgs {
     /// Check if the configs are formatted, no formatting is done
     #[bpaf(long("check"), short('c'), switch)]
     pub check: bool,
-    /// Read config from stdin and write its formatted version into stdout
     #[bpaf(long("stdin"), short('s'), switch)]
     pub stdin: bool,
 }
@@ -2159,6 +2163,16 @@ pub struct GenerateBootstrapArgs {
     /// Directory to put localized data into
     #[bpaf(long("localized-dir"), argument("LOCALIZED_DIR"))]
     pub localized_dir: Option<String>,
+    /// Also write a Windows launcher, `<WRITE>.cmd`
+    ///
+    /// Windows cannot execute the `#!/usr/bin/env bash` script, so a contributor who clones the
+    /// project on Windows has nothing to run without this.
+    ///
+    /// Generated on every host, not only on Windows: the file is committed, and whoever runs it
+    /// on Windows is not the person who generated it. Requires `--write`, since stdout cannot
+    /// carry two files.
+    #[bpaf(long("windows"), switch)]
+    pub windows: bool,
 }
 
 /// Generate a mise.toml file
@@ -2217,6 +2231,13 @@ pub struct GenerateGitPreCommitArgs {
     /// Which hook to generate (saves to .git/hooks/$hook)
     #[bpaf(long("hook"), argument("HOOK"))]
     pub hook: Option<String>,
+    /// mise flags to embed in the generated hook, given after `--`
+    ///
+    /// These are inserted between `mise` and `run`, so the hook carries the same context you
+    /// would pass on the command line. Useful when the config is not at the repository root,
+    /// since git runs hooks from the top level: `-- -C subdir` makes the hook find it.
+    #[bpaf(positional("MISE_ARG"), strict, many)]
+    pub mise_arg: Vec<String>,
 }
 
 /// Generate a GitHub Action workflow file
@@ -2269,6 +2290,7 @@ pub struct GenerateTaskDocsArgs {
 ///
 /// By default, this will build shims like ./bin/<task>. These can be paired with `mise generate bootstrap`
 /// so contributors to a project can execute mise tasks without installing mise into their system.
+/// When a parent and nested task both exist, the parent stub is written to `<parent>/_default`.
 #[derive(Debug, Clone, Bpaf)]
 #[bpaf(generate(generatetaskstubsargs_p))]
 pub struct GenerateTaskStubsArgs {
@@ -2313,15 +2335,22 @@ pub struct GenerateToolStubArgs {
     /// Use this to pin to a specific version (e.g., "2025.1.0").
     #[bpaf(long("bootstrap-version"), argument("BOOTSTRAP_VERSION"))]
     pub bootstrap_version: Option<String>,
+    /// Checksum algorithm to use when downloading artifacts
+    ///
+    /// Accepts `blake3` or `sha256` and defaults to `blake3`.
+    /// Cannot be used with `--lock` or `--skip-download` because those modes do not
+    /// calculate checksums.
+    #[bpaf(long("checksum-algorithm"), argument("CHECKSUM_ALGORITHM"))]
+    pub checksum_algorithm: Option<String>,
     /// Fetch checksums and sizes for an existing tool stub file
     ///
-    /// This reads an existing stub file and fills in any missing checksum/size fields by downloading the files. URLs must already be present in the stub.
+    /// This reads an existing stub file and fills in any missing checksum/size fields
+    /// by downloading the files. URLs must already be present in the stub.
     #[bpaf(long("fetch"), switch)]
     pub fetch: bool,
     /// HTTP backend type to use
     #[bpaf(long("http"), argument("HTTP"))]
     pub http: Option<String>,
-    /// Resolve and embed lockfile data (exact version + platform URLs/checksums) into an existing stub file for reproducible installs without runtime API calls
     #[bpaf(long("lock"), switch)]
     pub lock: bool,
     /// Platform-specific binary paths in the format platform:path
@@ -2331,11 +2360,15 @@ pub struct GenerateToolStubArgs {
     pub platform_bin: Vec<String>,
     /// Platform-specific URLs in the format platform:url or just url (auto-detect platform)
     ///
-    /// When the output file already exists, new platforms will be appended to the existing platforms table. Existing platform URLs will be updated if specified again.
+    /// When the output file already exists, new platforms will be appended to the existing
+    /// platforms table. Existing platform URLs will be updated if specified again.
     ///
-    /// If only a URL is provided (without platform:), the platform will be automatically detected from the URL filename.
+    /// If only a URL is provided (without platform:), the platform will be automatically
+    /// detected from the URL filename.
     ///
-    /// Examples: --platform-url linux-x64:https://... --platform-url https://nodejs.org/dist/v22.17.1/node-v22.17.1-darwin-arm64.tar.gz
+    /// Examples:
+    /// --platform-url linux-x64:https://...
+    /// --platform-url https://nodejs.org/dist/v22.17.1/node-v22.17.1-darwin-arm64.tar.gz
     #[bpaf(long("platform-url"), argument("PLATFORM_URL"))]
     pub platform_url: Vec<String>,
     /// Skip downloading for checksum and binary path detection (faster but less informative)
@@ -2404,7 +2437,6 @@ pub struct GithubTokenArgs {
     /// Print only the token value
     #[bpaf(long("raw"), switch)]
     pub raw: bool,
-    /// Mint a fresh OAuth token even if the cached one has not expired, via the refresh-token grant or a new device-code flow
     #[bpaf(long("refresh"), switch)]
     pub refresh: bool,
     /// Show the full unmasked token
@@ -2535,7 +2567,6 @@ pub struct EditArgs {
 #[derive(Debug, Clone, Bpaf)]
 #[bpaf(generate(installargs_p))]
 pub struct InstallArgs {
-    /// Force reinstall even if already installed
     #[bpaf(long("force"), short('f'), switch)]
     pub force: bool,
     #[bpaf(long("jobs"), short('j'), argument("JOBS"))]
@@ -2553,6 +2584,12 @@ pub struct InstallArgs {
     /// This is useful for scripts to check if tools need to be installed.
     #[bpaf(long("dry-run-code"), switch)]
     pub dry_run_code: bool,
+    /// Also install tools required by tasks in the current scope
+    ///
+    /// This prepares task tools without running task commands or dependencies.
+    /// Combine with --monorepo to include tasks from every configured root.
+    #[bpaf(long("include-task-tools"), switch)]
+    pub include_task_tools: bool,
     /// Only install versions released before this date or older than this duration
     ///
     /// Supports absolute dates like "2024-06-01" and relative durations like "90d" or "1y".
@@ -2564,7 +2601,6 @@ pub struct InstallArgs {
     /// [monorepo].config_roots in the monorepo root config.
     #[bpaf(long("monorepo"), switch)]
     pub monorepo: bool,
-    /// Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1
     #[bpaf(long("raw"), switch)]
     pub raw: bool,
     /// Install tool(s) to a shared directory
@@ -2579,7 +2615,6 @@ pub struct InstallArgs {
     /// May require elevated permissions (e.g. sudo).
     #[bpaf(long("system"), switch)]
     pub system: bool,
-    /// Tool(s) to install e.g.: node@20
     #[bpaf(positional("TOOL@VERSION"))]
     pub tool_version: Vec<String>,
 }
@@ -2590,7 +2625,6 @@ pub struct InstallArgs {
 #[derive(Debug, Clone, Bpaf)]
 #[bpaf(generate(installintoargs_p))]
 pub struct InstallIntoArgs {
-    /// Tool to install e.g.: node@20
     #[bpaf(positional("TOOL@VERSION"))]
     pub tool_version: String,
     /// Path to install the tool into
@@ -2616,7 +2650,6 @@ pub struct LatestArgs {
     /// Tool to get the latest version of
     #[bpaf(positional("TOOL@VERSION"))]
     pub tool_version: String,
-    /// The version prefix to use when querying the latest version same as the first argument after the "@" used for asdf compatibility
     #[bpaf(positional("ASDF_VERSION"))]
     pub asdf_version: Option<String>,
 }
@@ -2648,7 +2681,6 @@ pub struct LinkArgs {
 pub struct LocalArgs {
     #[bpaf(long("parent"), short('p'), switch)]
     pub parent: bool,
-    /// Save fuzzy version to `.tool-versions` e.g.: `mise local --fuzzy node@20` will save `node 20` to .tool-versions This is the default behavior unless MISE_ASDF_COMPAT=1
     #[bpaf(long("fuzzy"), switch)]
     pub fuzzy: bool,
     /// Get the path of the config file
@@ -2666,7 +2698,8 @@ pub struct LocalArgs {
 /// Update lockfile checksums and URLs for all specified platforms
 ///
 /// Updates checksums and download URLs for all platforms already specified in the lockfile.
-/// If no lockfile exists, shows what would be created based on the current configuration.
+/// If no lockfile exists, shows what would be created based on the current configuration,
+/// including tools declared by tasks.
 /// This allows you to refresh lockfile data for platforms other than the one you're currently on.
 /// Operates on the lockfile in the current config root. Use TOOL arguments to target specific tools.
 #[derive(Debug, Clone, Bpaf)]
@@ -2674,7 +2707,6 @@ pub struct LocalArgs {
 pub struct LockArgs {
     #[bpaf(long("global"), short('g'), switch)]
     pub global: bool,
-    /// Number of jobs to run in parallel
     #[bpaf(long("jobs"), short('j'), argument("JOBS"))]
     pub jobs: Option<String>,
     /// Show what would be updated without making changes
@@ -2734,7 +2766,6 @@ pub struct LsArgs {
     /// Only show tool versions currently specified in the global mise.toml
     #[bpaf(long("global"), short('g'), switch)]
     pub global: bool,
-    /// Only show tool versions that are installed (Hides tools defined in mise.toml but not installed)
     #[bpaf(long("installed"), short('i'), switch)]
     pub installed: bool,
     /// Output in JSON format
@@ -2749,7 +2780,7 @@ pub struct LsArgs {
     /// Don't fetch information such as outdated versions
     #[bpaf(long("offline"), short('o'), switch)]
     pub offline: bool,
-    #[bpaf(long("plugin"), short('p'), argument("TOOL_FLAG"))]
+    #[bpaf(long("plugin"), short('p'), argument("PLUGIN"))]
     pub plugin: Option<String>,
     /// Display all tracked config sources for tools
     #[bpaf(long("all-sources"), switch)]
@@ -2866,7 +2897,12 @@ pub struct OciBuildArgs {
     pub from: Option<String>,
     /// Also include tools from the global / system config (default: project-only)
     ///
-    /// By default `mise oci build` only packages tools declared in the project's mise config (and any parent configs at-or-below the project root, e.g. a monorepo root config). Personal dev tools in `~/.config/mise/config.toml` are excluded so they don't bake into a project image. Pass `--include-global` to revert to the old "merge all loaded configs" behavior.
+    /// By default `mise oci build` only packages tools declared in the
+    /// project's mise config (and any parent configs at-or-below the
+    /// project root, e.g. a monorepo root config). Personal dev tools in
+    /// `~/.config/mise/config.toml` are excluded so they don't bake into a
+    /// project image. Pass `--include-global` to revert to the old
+    /// "merge all loaded configs" behavior.
     #[bpaf(long("include-global"), switch)]
     pub include_global: bool,
     /// Tag to record in the image index (the org.opencontainers.image.ref.name annotation)
@@ -2880,7 +2916,9 @@ pub struct OciBuildArgs {
     pub no_mise: bool,
     /// UID[:GID] to assign to every tar entry in generated layers
     ///
-    /// Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive.
+    /// Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is
+    /// omitted, it defaults to UID. This affects file ownership only; [oci].user
+    /// controls the image USER directive.
     #[bpaf(long("owner"), argument("UID[:GID]"))]
     pub owner: Option<String>,
 }
@@ -2909,7 +2947,9 @@ pub struct OciBuildArgs {
 pub struct OciPushArgs {
     /// Reuse unchanged tool layers from this image instead of the destination ref
     ///
-    /// Must live in the same repository as the destination. Useful when each push gets a unique tag (e.g. per-commit tags in CI): `--cache-from ghcr.io/me/dev:latest ghcr.io/me/dev:$SHA`.
+    /// Must live in the same repository as the destination. Useful when each
+    /// push gets a unique tag (e.g. per-commit tags in CI):
+    /// `--cache-from ghcr.io/me/dev:latest ghcr.io/me/dev:$SHA`.
     #[bpaf(long("cache-from"), argument("REF"))]
     pub cache_from: Option<String>,
     /// Base image for the build (ignored with --image-dir)
@@ -2934,12 +2974,17 @@ pub struct OciPushArgs {
     pub no_mise: bool,
     /// UID[:GID] to assign to every tar entry when building (conflicts with --image-dir)
     ///
-    /// Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive.
+    /// Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is
+    /// omitted, it defaults to UID. This affects file ownership only; [oci].user
+    /// controls the image USER directive.
     #[bpaf(long("owner"), argument("UID[:GID]"))]
     pub owner: Option<String>,
     /// Maintain the tag as a multi-arch image index
     ///
-    /// Pushes this build's manifest by digest and points the tag at an OCI image index containing one entry per platform, preserving entries other architectures pushed. Run `mise oci push --update-index` from one runner per platform to assemble a multi-arch tag.
+    /// Pushes this build's manifest by digest and points the tag at an OCI
+    /// image index containing one entry per platform, preserving entries
+    /// other architectures pushed. Run `mise oci push --update-index` from
+    /// one runner per platform to assemble a multi-arch tag.
     #[bpaf(long("update-index"), switch)]
     pub update_index: bool,
     /// Destination registry reference (e.g. `ghcr.io/me/devenv:latest`)
@@ -2975,7 +3020,11 @@ pub struct OciRunArgs {
     pub include_global: bool,
     /// Keep the loaded image in the engine's storage after the run
     ///
-    /// By default, both the container (`--rm`) and the loaded image are removed when the command exits, so repeated `mise oci run` calls don't accumulate images in podman / docker storage. Pass `--keep` to retain the image under the tag mise used (`mise-oci:run-*` for docker; the pulled image ID for podman).
+    /// By default, both the container (`--rm`) and the loaded image are
+    /// removed when the command exits, so repeated `mise oci run` calls
+    /// don't accumulate images in podman / docker storage. Pass `--keep`
+    /// to retain the image under the tag mise used (`mise-oci:run-*` for
+    /// docker; the pulled image ID for podman).
     #[bpaf(long("keep"), switch)]
     pub keep: bool,
     /// Override in-image mount point (ignored with --image-dir)
@@ -2986,12 +3035,15 @@ pub struct OciRunArgs {
     pub no_mise: bool,
     /// UID[:GID] to assign to every tar entry when building (conflicts with --image-dir)
     ///
-    /// Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive.
+    /// Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is
+    /// omitted, it defaults to UID. This affects file ownership only; [oci].user
+    /// controls the image USER directive.
     #[bpaf(long("owner"), argument("UID[:GID]"))]
     pub owner: Option<String>,
     /// Bind-mount a host path (repeatable, `HOST:CONTAINER[:MODE]`)
     ///
-    /// Note: unlike `docker run -v`, there's no `-v` short flag here because mise reserves `-v` for --verbose. Use `--volume` or `--mount`.
+    /// Note: unlike `docker run -v`, there's no `-v` short flag here because
+    /// mise reserves `-v` for --verbose. Use `--volume` or `--mount`.
     #[bpaf(long("volume"), argument("HOST:CONTAINER"))]
     pub volume: Vec<String>,
     /// Set environment variable in the container (repeatable, `KEY=VAL`)
@@ -3047,17 +3099,20 @@ pub enum OciCommands {
 #[derive(Debug, Clone, Bpaf)]
 #[bpaf(generate(outdatedargs_p))]
 pub struct OutdatedArgs {
-    /// Output in JSON format
-    #[bpaf(long("json"), short('J'), switch)]
-    pub json: bool,
     /// Compares against the latest versions available, not what matches the current config
     ///
     /// For example, if you have `node = "20"` in your config by default `mise outdated` will only
     /// show other 20.x versions, not 21.x or 22.x versions.
     ///
     /// Using this flag, if there are 21.x or newer versions it will display those instead of 20.x.
-    #[bpaf(long("bump"), short('l'), switch)]
+    #[bpaf(long("bump"), short('b'), switch)]
     pub bump: bool,
+    /// Output in JSON format
+    #[bpaf(long("json"), short('J'), switch)]
+    pub json: bool,
+    /// Deprecated shorthand for --bump
+    #[bpaf(short('l'), switch)]
+    pub l: bool,
     /// Show outdated tools including installed-but-inactive tools not present in the current config
     ///
     /// By default, `mise outdated` only shows tools that come from the current config.
@@ -3111,7 +3166,6 @@ pub struct PluginsInstallArgs {
     /// Reinstall even if plugin exists
     #[bpaf(long("force"), short('f'), switch)]
     pub force: bool,
-    /// Number of jobs to run in parallel
     #[bpaf(long("jobs"), short('j'), argument("JOBS"))]
     pub jobs: Option<String>,
     /// Show installation output
@@ -3165,10 +3219,8 @@ pub struct PluginsLsArgs {
 #[derive(Debug, Clone, Bpaf)]
 #[bpaf(generate(pluginslsremoteargs_p))]
 pub struct PluginsLsRemoteArgs {
-    /// Show the git url for each plugin e.g.: https://github.com/mise-plugins/mise-poetry.git
     #[bpaf(long("urls"), short('u'), switch)]
     pub urls: bool,
-    /// Only show the name of each plugin by default it will show a "*" next to installed plugins
     #[bpaf(long("only-names"), switch)]
     pub only_names: bool,
 }
@@ -3422,6 +3474,11 @@ pub struct RegistryArgs {
     /// Output in JSON format
     #[bpaf(long("json"), short('J'), switch)]
     pub json: bool,
+    /// Include security features for each tool's backends in JSON output.
+    ///
+    /// Requires --json. Security info is de-duplicated across
+    /// all of a tool's backends. This can add noticeable time for large
+    /// listings since each backend's security info is resolved individually.
     #[bpaf(long("security"), switch)]
     pub security: bool,
     /// Show only the specified tool's full name
@@ -3505,6 +3562,9 @@ pub struct RunArgs {
     /// Output affected projects and tasks as JSON without running tasks
     #[bpaf(long("affected-json"), switch)]
     pub affected_json: bool,
+    /// Open the interactive selector with all tasks from the entire monorepo
+    #[bpaf(long("all"), switch)]
+    pub all: bool,
     /// Continue running tasks even if one fails
     #[bpaf(long("continue-on-error"), short('c'), switch)]
     pub continue_on_error: bool,
@@ -3545,7 +3605,6 @@ pub struct RunArgs {
     /// Don't show any output except for errors
     #[bpaf(long("silent"), short('S'), switch)]
     pub silent: bool,
-    /// Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10
     #[bpaf(long("tool"), short('t'), argument("TOOL@VERSION"))]
     pub tool: Vec<String>,
     #[bpaf(long("allow-env"), argument("VAR"))]
@@ -3731,7 +3790,8 @@ pub struct SetArgs {
     pub remove: Vec<String>,
     /// Read the value from stdin (for multiline input)
     ///
-    /// When using --stdin, provide a single key without a value. The value will be read from stdin until EOF.
+    /// When using --stdin, provide a single key without a value.
+    /// The value will be read from stdin until EOF.
     #[bpaf(long("stdin"), switch)]
     pub stdin: bool,
     #[bpaf(positional("ENV_VAR"))]
@@ -3838,6 +3898,7 @@ pub struct SettingsUnsetArgs {
     pub key: String,
 }
 
+/// Manage settings
 #[derive(Debug, Clone, Bpaf)]
 #[bpaf(generate(settingsargs_p))]
 pub struct SettingsArgs {
@@ -3897,7 +3958,6 @@ pub struct ShellArgs {
     /// Removes a previously set version
     #[bpaf(long("unset"), short('u'), switch)]
     pub unset: bool,
-    /// Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1
     #[bpaf(long("raw"), switch)]
     pub raw: bool,
     /// Tool(s) to use
@@ -3988,7 +4048,7 @@ pub struct SponsorsArgs {}
 ///
 /// For example, use this to import all Homebrew node installs into mise
 ///
-/// This won't overwrite any existing installs but will overwrite any existing symlinks
+/// This won't overwrite managed installs, runtime aliases, or links from other providers.
 #[derive(Debug, Clone, Bpaf)]
 #[bpaf(generate(syncnodeargs_p))]
 pub struct SyncNodeArgs {
@@ -4007,7 +4067,7 @@ pub struct SyncNodeArgs {
 ///
 /// For example, use this to import all pyenv installs into mise
 ///
-/// This won't overwrite any existing installs but will overwrite any existing symlinks
+/// This won't overwrite managed installs, runtime aliases, or links from other providers.
 #[derive(Debug, Clone, Bpaf)]
 #[bpaf(generate(syncpythonargs_p))]
 pub struct SyncPythonArgs {
@@ -4247,6 +4307,9 @@ pub struct TasksRunArgs {
     /// Output affected projects and tasks as JSON without running tasks
     #[bpaf(long("affected-json"), switch)]
     pub affected_json: bool,
+    /// Open the interactive selector with all tasks from the entire monorepo
+    #[bpaf(long("all"), switch)]
+    pub all: bool,
     /// Continue running tasks even if one fails
     #[bpaf(long("continue-on-error"), short('c'), switch)]
     pub continue_on_error: bool,
@@ -4287,7 +4350,6 @@ pub struct TasksRunArgs {
     /// Don't show any output except for errors
     #[bpaf(long("silent"), short('S'), switch)]
     pub silent: bool,
-    /// Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10
     #[bpaf(long("tool"), short('t'), argument("TOOL@VERSION"))]
     pub tool: Vec<String>,
     #[bpaf(long("allow-env"), argument("VAR"))]
@@ -4366,10 +4428,10 @@ pub struct TasksRunArgs {
     pub timings: bool,
     #[bpaf(positional("TASK"))]
     pub task: Option<String>,
-    /// Arguments to pass to the tasks. Use ":::" to separate tasks
+    /// Arguments to pass to the tasks. Use ":::" to separate tasks.
     #[bpaf(positional("ARGS"))]
     pub args: Vec<String>,
-    /// Arguments to pass to the tasks. Use ":::" to separate tasks
+    /// Arguments to pass to the tasks. Use ":::" to separate tasks.
     #[bpaf(positional("ARGS_LAST"), strict, many)]
     pub args_last: Vec<String>,
 }
@@ -4473,7 +4535,6 @@ pub struct TestToolArgs {
     /// Also test tools not defined in registry/, guessing how to test it
     #[bpaf(long("include-non-defined"), switch)]
     pub include_non_defined: bool,
-    /// Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1
     #[bpaf(long("raw"), switch)]
     pub raw: bool,
     /// Tool(s) to test
@@ -4481,7 +4542,6 @@ pub struct TestToolArgs {
     pub tools: Vec<String>,
 }
 
-/// Forgejo token
 #[derive(Debug, Clone, Bpaf)]
 #[bpaf(generate(tokenforgejoargs_p))]
 pub struct TokenForgejoArgs {
@@ -4493,17 +4553,14 @@ pub struct TokenForgejoArgs {
     pub host: Option<String>,
 }
 
-/// GitHub token
 #[derive(Debug, Clone, Bpaf)]
 #[bpaf(generate(tokengithubargs_p))]
 pub struct TokenGithubArgs {
-    /// Resolve only via the native GitHub OAuth source (cache, refresh, or device-code flow), bypassing other token sources
     #[bpaf(long("oauth"), switch)]
     pub oauth: bool,
     /// Print only the token value
     #[bpaf(long("raw"), switch)]
     pub raw: bool,
-    /// Mint a fresh OAuth token even if the cached one has not expired, via the refresh-token grant or a new device-code flow. Use after changing the GitHub App's installations or permissions: cached tokens keep their original access until they expire
     #[bpaf(long("refresh"), switch)]
     pub refresh: bool,
     /// Show the full unmasked token
@@ -4514,7 +4571,6 @@ pub struct TokenGithubArgs {
     pub host: Option<String>,
 }
 
-/// GitLab token
 #[derive(Debug, Clone, Bpaf)]
 #[bpaf(generate(tokengitlabargs_p))]
 pub struct TokenGitlabArgs {
@@ -4583,15 +4639,26 @@ pub struct ToolArgs {
 
 /// Execute a tool stub
 ///
-/// Tool stubs are executable files containing TOML configuration that specify which tool to run and how to run it. They provide a convenient way to create portable, self-contained executables that automatically manage tool installation and execution.
+/// Tool stubs are executable files containing TOML configuration that specify
+/// which tool to run and how to run it. They provide a convenient way to create
+/// portable, self-contained executables that automatically manage tool installation
+/// and execution.
 ///
-/// A tool stub consists of: - A shebang line: #!/usr/bin/env -S mise tool-stub - TOML configuration specifying the tool, version, and options - Optional comments describing the tool's purpose
+/// A tool stub consists of:
+/// - A shebang line: #!/usr/bin/env -S mise tool-stub
+/// - TOML configuration specifying the tool, version, and options
+/// - Optional comments describing the tool's purpose
 ///
-/// Example stub file: #!/usr/bin/env -S mise tool-stub # Node.js v20 development environment
+/// Example stub file:
+///   #!/usr/bin/env -S mise tool-stub
+///   # Node.js v20 development environment
 ///
-/// tool = "node" version = "20.0.0" bin = "node"
+///   tool = "node"
+///   version = "20.0.0"
+///   bin = "node"
 ///
-/// The stub will automatically install the specified tool version if missing and execute it with any arguments passed to the stub.
+/// The stub will automatically install the specified tool version if missing
+/// and execute it with any arguments passed to the stub.
 ///
 /// For more information, see: https://mise.jdx.dev/dev-tools/tool-stubs.html
 #[derive(Debug, Clone, Bpaf)]
@@ -4599,12 +4666,16 @@ pub struct ToolArgs {
 pub struct ToolStubArgs {
     /// Path to the TOML tool stub file to execute
     ///
-    /// The stub file must contain TOML configuration specifying the tool and version to run. At minimum, it should specify a 'version' field. Other common fields include 'tool', 'bin', and backend-specific options.
+    /// The stub file must contain TOML configuration specifying the tool
+    /// and version to run. At minimum, it should specify a 'version' field.
+    /// Other common fields include 'tool', 'bin', and backend-specific options.
     #[bpaf(positional("FILE"))]
     pub file: String,
     /// Arguments to pass to the tool
     ///
-    /// All arguments after the stub file path will be forwarded to the underlying tool. Use '--' to separate mise arguments from tool arguments if needed.
+    /// All arguments after the stub file path will be forwarded to the
+    /// underlying tool. Use '--' to separate mise arguments from tool arguments
+    /// if needed.
     #[bpaf(positional("ARGS"))]
     pub args: Vec<String>,
 }
@@ -4612,17 +4683,18 @@ pub struct ToolStubArgs {
 /// Marks a config file as trusted
 ///
 /// This means mise is allowed to parse the file when it needs to read config
-/// that may execute code or affect the environment. mise checks trust before
-/// parsing `mise.toml`. Without trust, mise may prompt, skip the config in some
-/// discovery paths, fail with an untrusted-config error when it cannot prompt,
-/// or assume trust in detected CI unless paranoid mode is enabled.
+/// that may execute code or affect the environment. Without trust, mise may
+/// prompt, skip the config in some discovery paths, or fail with an
+/// untrusted-config error when it cannot prompt.
 ///
-/// Safe config files do not require trust: files that only contain
-/// `min_version`, `[tools]` entries with plain version strings (or arrays
-/// of them), and `[tasks]` (no templates and no tool options) are loaded
-/// without prompting, since nothing in them executes code at load time —
-/// tools install and tasks run only on explicit commands like `mise install`
-/// or `mise run`.
+/// In normal mode, commands that execute project-defined behavior (`mise run`,
+/// naked task invocations such as `mise <TASK>`, `mise install`, `mise exec`,
+/// and `mise watch`) automatically trust their active config. Paranoid mode
+/// requires explicit, content-bound trust for every non-global config.
+///
+/// In normal mode, safe config files do not require trust: files that only contain
+/// `min_version`, `[tools]` entries with plain version strings (or arrays of
+/// them), and `[tasks]` without templates or tool options.
 ///
 /// Trust is shared across git worktrees: a config file inside a linked
 /// worktree is trusted when the equivalent path in the repository's main
@@ -4642,10 +4714,10 @@ pub struct TrustArgs {
     pub ignore: bool,
     #[bpaf(long("show"), switch)]
     pub show: bool,
-    /// No longer trust this config, will prompt in the future
+    /// Remove explicit trust for this config
     #[bpaf(long("untrust"), switch)]
     pub untrust: bool,
-    /// The config file to trust
+    /// The config file whose trust status to change
     #[bpaf(positional("CONFIG_FILE"))]
     pub config_file: Option<String>,
 }
@@ -4682,7 +4754,8 @@ pub struct UnsetArgs {
     ///
     /// Can be a file path or directory. If a directory is provided, will create/use mise.toml in that directory.
     ///
-    /// Defaults to [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) environment variable, or `mise.toml`. Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
+    /// Defaults to [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) environment variable, or `mise.toml`.
+    /// Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
     #[bpaf(long("file"), short('f'), argument("FILE"))]
     pub file: Option<String>,
     /// Use the global config file
@@ -4692,7 +4765,7 @@ pub struct UnsetArgs {
     pub env_key: Vec<String>,
 }
 
-/// No longer trust a config, will prompt in the future
+/// Remove explicit trust for a config
 #[derive(Debug, Clone, Bpaf)]
 #[bpaf(generate(untrustargs_p))]
 pub struct UntrustArgs {
@@ -4730,7 +4803,8 @@ pub struct UnuseArgs {
     pub global: bool,
     /// Specify a path to a config file or directory
     ///
-    /// If a directory is specified, it will look for a config file in that directory following the rules above.
+    /// If a directory is specified, it will look for a config file in that directory following
+    /// the rules above.
     #[bpaf(long("path"), short('p'), argument("PATH"))]
     pub path: Option<String>,
     /// Do not also prune the installed version
@@ -4751,11 +4825,6 @@ pub struct UnuseArgs {
 #[derive(Debug, Clone, Bpaf)]
 #[bpaf(generate(upgradeargs_p))]
 pub struct UpgradeArgs {
-    /// Display multiselect menu to choose which tools to upgrade
-    #[bpaf(long("interactive"), short('i'), switch)]
-    pub interactive: bool,
-    #[bpaf(long("jobs"), short('j'), argument("JOBS"))]
-    pub jobs: Option<String>,
     /// Upgrades to the latest version available, bumping the version in mise.toml
     ///
     /// For example, if you have `node = "20.0.0"` in your mise.toml but 22.1.0 is the latest available,
@@ -4763,8 +4832,16 @@ pub struct UpgradeArgs {
     ///
     /// It keeps the same precision as what was there before, so if you instead had `node = "20"`, it
     /// would change your config to `node = "22"`.
-    #[bpaf(long("bump"), short('l'), switch)]
+    #[bpaf(long("bump"), short('b'), switch)]
     pub bump: bool,
+    /// Display multiselect menu to choose which tools to upgrade
+    #[bpaf(long("interactive"), short('i'), switch)]
+    pub interactive: bool,
+    #[bpaf(long("jobs"), short('j'), argument("JOBS"))]
+    pub jobs: Option<String>,
+    /// Deprecated shorthand for --bump
+    #[bpaf(short('l'), switch)]
+    pub l: bool,
     /// Just print what would be done, don't actually do it
     #[bpaf(long("dry-run"), short('n'), switch)]
     pub dry_run: bool,
@@ -4801,9 +4878,16 @@ pub struct UpgradeArgs {
     /// By default the old version is removed once the new one installs, unless another
     /// tracked config or tool stub still needs it. Use this to keep it anyway, e.g. when
     /// something outside of mise points at the old install directory.
+    ///
+    /// Set `upgrade.auto_prune = false` to make this the default.
     #[bpaf(long("no-prune"), switch)]
     pub no_prune: bool,
-    /// Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1
+    /// Uninstall the versions that were upgraded away from
+    ///
+    /// This is already the default. Use it to override `upgrade.auto_prune = false`
+    /// for a single run.
+    #[bpaf(long("prune"), switch)]
+    pub prune: bool,
     #[bpaf(long("raw"), switch)]
     pub raw: bool,
     #[bpaf(positional("INSTALLED_TOOL@VERSION"))]
@@ -4855,7 +4939,8 @@ pub struct UseArgs {
     pub dry_run: bool,
     /// Specify a path to a config file or directory
     ///
-    /// If a directory is specified, it will look for a config file in that directory following the rules above.
+    /// If a directory is specified, it will look for a config file in that directory following
+    /// the rules above.
     #[bpaf(long("path"), short('p'), argument("PATH"))]
     pub path: Option<String>,
     /// Like --dry-run but exits with code 1 if there are changes to make
@@ -4874,9 +4959,17 @@ pub struct UseArgs {
     /// Supports absolute dates like "2024-06-01" and relative durations like "90d" or "1y".
     #[bpaf(long("minimum-release-age"), argument("MINIMUM_RELEASE_AGE"))]
     pub minimum_release_age: Option<String>,
+    /// Save the resolved concrete version to the config file
+    ///
+    /// If the request exactly matches an available release, that release is preferred over
+    /// installed fuzzy matches. Use `prefix:` to explicitly request recursive prefix matching.
+    /// e.g.: `mise use --pin node@20` will save the resolved `20.x.y` version
+    /// Set `MISE_PIN=1` to make this the default behavior
+    ///
+    /// Consider using mise.lock as a better alternative to pinning in mise.toml:
+    /// https://mise.jdx.dev/configuration/settings.html#lockfile
     #[bpaf(long("pin"), switch)]
     pub pin: bool,
-    /// Connect backend install command stdin/stdout/stderr directly to the terminal Implies `--jobs=1`
     #[bpaf(long("raw"), switch)]
     pub raw: bool,
     /// Remove the tool(s) from config file
@@ -4929,13 +5022,17 @@ pub struct WatchArgs {
     ///
     /// By default, Watchexec watches the current directory.
     ///
-    /// When watching a single file, it's often better to watch the containing directory instead, and filter on the filename. Some editors may replace the file with a new one when saving, and some platforms may not detect that or further changes.
+    /// When watching a single file, it's often better to watch the containing directory instead,
+    /// and filter on the filename. Some editors may replace the file with a new one when saving,
+    /// and some platforms may not detect that or further changes.
     ///
-    /// Upon starting, Watchexec resolves a "project origin" from the watched paths. See the help for '--project-origin' for more information.
+    /// Upon starting, Watchexec resolves a "project origin" from the watched paths. See the help
+    /// for '--project-origin' for more information.
     ///
     /// This option can be specified multiple times to watch multiple files or directories.
     ///
-    /// The special value '/dev/null', provided as the only path watched, will cause Watchexec to not watch any paths. Other event sources (like signals or key events) may still be used.
+    /// The special value '/dev/null', provided as the only path watched, will cause Watchexec to
+    /// not watch any paths. Other event sources (like signals or key events) may still be used.
     #[bpaf(long("watch"), short('w'), argument("PATH"))]
     pub watch: Vec<String>,
     /// Watch a specific directory, non-recursively
@@ -4949,7 +5046,8 @@ pub struct WatchArgs {
     ///
     /// Each line in the file will be interpreted as if given to '-w'.
     ///
-    /// For more complex uses (like watching non-recursively), use the argfile capability: build a file containing command-line options and pass it to watchexec with `@path/to/argfile`.
+    /// For more complex uses (like watching non-recursively), use the argfile capability: build a
+    /// file containing command-line options and pass it to watchexec with `@path/to/argfile`.
     ///
     /// The special value '-' will read from STDIN; this in incompatible with '--stdin-quit'.
     #[bpaf(long("watch-file"), short('F'), argument("PATH"))]
@@ -4961,7 +5059,12 @@ pub struct WatchArgs {
     pub clear: Option<String>,
     /// What to do when receiving events while the command is running
     ///
-    /// Default is to 'do-nothing', which ignores events while the command is running, so that changes that occur due to the command are ignored, like compilation outputs. You can also use 'queue' which will run the command once again when the current run has finished if any events occur while it's running, or 'restart', which terminates the running command and starts a new one. Finally, there's 'signal', which only sends a signal; this can be useful with programs that can reload their configuration without a full restart.
+    /// Default is to 'do-nothing', which ignores events while the command is running, so that
+    /// changes that occur due to the command are ignored, like compilation outputs. You can also
+    /// use 'queue' which will run the command once again when the current run has finished if any
+    /// events occur while it's running, or 'restart', which terminates the running command and starts
+    /// a new one. Finally, there's 'signal', which only sends a signal; this can be useful with
+    /// programs that can reload their configuration without a full restart.
     ///
     /// The signal can be specified with the '--signal' option.
     #[bpaf(long("on-busy-update"), short('o'), argument("MODE"))]
@@ -4973,65 +5076,98 @@ pub struct WatchArgs {
     pub restart: bool,
     /// Send a signal to the process when it's still running
     ///
-    /// Specify a signal to send to the process when it's still running. This implies '--on-busy-update=signal'; otherwise the signal used when that mode is 'restart' is controlled by '--stop-signal'.
+    /// Specify a signal to send to the process when it's still running. This implies
+    /// '--on-busy-update=signal'; otherwise the signal used when that mode is 'restart' is
+    /// controlled by '--stop-signal'.
     ///
     /// See the long documentation for '--stop-signal' for syntax.
     ///
-    /// Signals are not supported on Windows at the moment, and will always be overridden to 'kill'. See '--stop-signal' for more on Windows "signals".
+    /// Signals are not supported on Windows at the moment, and will always be overridden to 'kill'.
+    /// See '--stop-signal' for more on Windows "signals".
     #[bpaf(long("signal"), short('s'), argument("SIGNAL"))]
     pub signal: Option<String>,
     /// Signal to send to stop the command
     ///
-    /// This is used by 'restart' and 'signal' modes of '--on-busy-update' (unless '--signal' is provided). The restart behaviour is to send the signal, wait for the command to exit, and if it hasn't exited after some time (see '--timeout-stop'), forcefully terminate it.
+    /// This is used by 'restart' and 'signal' modes of '--on-busy-update' (unless '--signal' is
+    /// provided). The restart behaviour is to send the signal, wait for the command to exit, and if
+    /// it hasn't exited after some time (see '--timeout-stop'), forcefully terminate it.
     ///
     /// The default on unix is "SIGTERM".
     ///
-    /// Input is parsed as a full signal name (like "SIGTERM"), a short signal name (like "TERM"), or a signal number (like "15"). All input is case-insensitive.
+    /// Input is parsed as a full signal name (like "SIGTERM"), a short signal name (like "TERM"),
+    /// or a signal number (like "15"). All input is case-insensitive.
     ///
-    /// On Windows this option is technically supported but only supports the "KILL" event, as Watchexec cannot yet deliver other events. Windows doesn't have signals as such; instead it has termination (here called "KILL" or "STOP") and "CTRL+C", "CTRL+BREAK", and "CTRL+CLOSE" events. For portability the unix signals "SIGKILL", "SIGINT", "SIGTERM", and "SIGHUP" are respectively mapped to these.
+    /// On Windows this option is technically supported but only supports the "KILL" event, as
+    /// Watchexec cannot yet deliver other events. Windows doesn't have signals as such; instead it
+    /// has termination (here called "KILL" or "STOP") and "CTRL+C", "CTRL+BREAK", and "CTRL+CLOSE"
+    /// events. For portability the unix signals "SIGKILL", "SIGINT", "SIGTERM", and "SIGHUP" are
+    /// respectively mapped to these.
     #[bpaf(long("stop-signal"), argument("SIGNAL"))]
     pub stop_signal: Option<String>,
     /// Time to wait for the command to exit gracefully
     ///
-    /// This is used by the 'restart' mode of '--on-busy-update'. After the graceful stop signal is sent, Watchexec will wait for the command to exit. If it hasn't exited after this time, it is forcefully terminated.
+    /// This is used by the 'restart' mode of '--on-busy-update'. After the graceful stop signal
+    /// is sent, Watchexec will wait for the command to exit. If it hasn't exited after this time,
+    /// it is forcefully terminated.
     ///
-    /// Takes a unit-less value in seconds, or a time span value such as "5min 20s". Providing a unit-less value is deprecated and will warn; it will be an error in the future.
+    /// Takes a unit-less value in seconds, or a time span value such as "5min 20s".
+    /// Providing a unit-less value is deprecated and will warn; it will be an error in the future.
     ///
     /// The default is 10 seconds. Set to 0 to immediately force-kill the command.
     ///
-    /// This has no practical effect on Windows as the command is always forcefully terminated; see '--stop-signal' for why.
+    /// This has no practical effect on Windows as the command is always forcefully terminated; see
+    /// '--stop-signal' for why.
     #[bpaf(long("stop-timeout"), argument("TIMEOUT"))]
     pub stop_timeout: Option<String>,
     /// Translate signals from the OS to signals to send to the command
     ///
-    /// Takes a pair of signal names, separated by a colon, such as "TERM:INT" to map SIGTERM to SIGINT. The first signal is the one received by watchexec, and the second is the one sent to the command. The second can be omitted to discard the first signal, such as "TERM:" to not do anything on SIGTERM.
+    /// Takes a pair of signal names, separated by a colon, such as "TERM:INT" to map SIGTERM to
+    /// SIGINT. The first signal is the one received by watchexec, and the second is the one sent to
+    /// the command. The second can be omitted to discard the first signal, such as "TERM:" to
+    /// not do anything on SIGTERM.
     ///
-    /// If SIGINT or SIGTERM are mapped, then they no longer quit Watchexec. Besides making it hard to quit Watchexec itself, this is useful to send pass a Ctrl-C to the command without also terminating Watchexec and the underlying program with it, e.g. with "INT:INT".
+    /// If SIGINT or SIGTERM are mapped, then they no longer quit Watchexec. Besides making it hard
+    /// to quit Watchexec itself, this is useful to send pass a Ctrl-C to the command without also
+    /// terminating Watchexec and the underlying program with it, e.g. with "INT:INT".
     ///
     /// This option can be specified multiple times to map multiple signals.
     ///
-    /// Signal syntax is case-insensitive for short names (like "TERM", "USR2") and long names (like "SIGKILL", "SIGHUP"). Signal numbers are also supported (like "15", "31"). On Windows, the forms "STOP", "CTRL+C", and "CTRL+BREAK" are also supported to receive, but Watchexec cannot yet deliver other "signals" than a STOP.
+    /// Signal syntax is case-insensitive for short names (like "TERM", "USR2") and long names (like
+    /// "SIGKILL", "SIGHUP"). Signal numbers are also supported (like "15", "31"). On Windows, the
+    /// forms "STOP", "CTRL+C", and "CTRL+BREAK" are also supported to receive, but Watchexec cannot
+    /// yet deliver other "signals" than a STOP.
     #[bpaf(long("map-signal"), argument("SIGNAL:SIGNAL"))]
     pub map_signal: Vec<String>,
     /// Time to wait for new events before taking action
     ///
-    /// When an event is received, Watchexec will wait for up to this amount of time before handling it (such as running the command). This is essential as what you might perceive as a single change may actually emit many events, and without this behaviour, Watchexec would run much too often. Additionally, it's not infrequent that file writes are not atomic, and each write may emit an event, so this is a good way to avoid running a command while a file is partially written.
+    /// When an event is received, Watchexec will wait for up to this amount of time before handling
+    /// it (such as running the command). This is essential as what you might perceive as a single
+    /// change may actually emit many events, and without this behaviour, Watchexec would run much
+    /// too often. Additionally, it's not infrequent that file writes are not atomic, and each write
+    /// may emit an event, so this is a good way to avoid running a command while a file is
+    /// partially written.
     ///
-    /// An alternative use is to set a high value (like "30min" or longer), to save power or bandwidth on intensive tasks, like an ad-hoc backup script. In those use cases, note that every accumulated event will build up in memory.
+    /// An alternative use is to set a high value (like "30min" or longer), to save power or
+    /// bandwidth on intensive tasks, like an ad-hoc backup script. In those use cases, note that
+    /// every accumulated event will build up in memory.
     ///
-    /// Takes a unit-less value in milliseconds, or a time span value such as "5sec 20ms". Providing a unit-less value is deprecated and will warn; it will be an error in the future.
+    /// Takes a unit-less value in milliseconds, or a time span value such as "5sec 20ms".
+    /// Providing a unit-less value is deprecated and will warn; it will be an error in the future.
     ///
     /// The default is 50 milliseconds. Setting to 0 is highly discouraged.
     #[bpaf(long("debounce"), short('d'), argument("TIMEOUT"))]
     pub debounce: Option<String>,
     /// Exit when stdin closes
     ///
-    /// This watches the stdin file descriptor for EOF, and exits Watchexec gracefully when it is closed. This is used by some process managers to avoid leaving zombie processes around.
+    /// This watches the stdin file descriptor for EOF, and exits Watchexec gracefully when it is
+    /// closed. This is used by some process managers to avoid leaving zombie processes around.
     #[bpaf(long("stdin-quit"), switch)]
     pub stdin_quit: bool,
     /// Don't load gitignores
     ///
-    /// Among other VCS exclude files, like for Mercurial, Subversion, Bazaar, DARCS, Fossil. Note that Watchexec will detect which of these is in use, if any, and only load the relevant files. Both global (like '~/.gitignore') and local (like '.gitignore') files are considered.
+    /// Among other VCS exclude files, like for Mercurial, Subversion, Bazaar, DARCS, Fossil. Note
+    /// that Watchexec will detect which of these is in use, if any, and only load the relevant
+    /// files. Both global (like '~/.gitignore') and local (like '.gitignore') files are considered.
     ///
     /// This option is useful if you want to watch files that are ignored by Git.
     #[bpaf(long("no-vcs-ignore"), switch)]
@@ -5076,12 +5212,15 @@ pub struct WatchArgs {
     pub no_global_ignore: bool,
     /// Don't use internal default ignores
     ///
-    /// Watchexec has a set of default ignore patterns, such as editor swap files, `*.pyc`, `*.pyo`, `.DS_Store`, `.bzr`, `_darcs`, `.fossil-settings`, `.git`, `.hg`, `.pijul`, `.svn`, and Watchexec log files.
+    /// Watchexec has a set of default ignore patterns, such as editor swap files, `*.pyc`, `*.pyo`,
+    /// `.DS_Store`, `.bzr`, `_darcs`, `.fossil-settings`, `.git`, `.hg`, `.pijul`, `.svn`, and
+    /// Watchexec log files.
     #[bpaf(long("no-default-ignore"), switch)]
     pub no_default_ignore: bool,
     /// Don't discover ignore files at all
     ///
-    /// This is a shorthand for '--no-global-ignore', '--no-vcs-ignore', '--no-project-ignore', but even more efficient as it will skip all the ignore discovery mechanisms from the get go.
+    /// This is a shorthand for '--no-global-ignore', '--no-vcs-ignore', '--no-project-ignore', but
+    /// even more efficient as it will skip all the ignore discovery mechanisms from the get go.
     ///
     /// Note that default ignores are still loaded, see '--no-default-ignore'.
     #[bpaf(long("no-discover-ignore"), switch)]
@@ -5090,65 +5229,84 @@ pub struct WatchArgs {
     ///
     /// This is a shorthand for '--no-discover-ignore', '--no-default-ignore'.
     ///
-    /// Note that ignores explicitly loaded via other command line options, such as '--ignore' or '--ignore-file', will still be used.
+    /// Note that ignores explicitly loaded via other command line options, such as '--ignore' or
+    /// '--ignore-file', will still be used.
     #[bpaf(long("ignore-nothing"), switch)]
     pub ignore_nothing: bool,
     /// Wait until first change before running command
     ///
-    /// By default, Watchexec will run the command once immediately. With this option, it will instead wait until an event is detected before running the command as normal.
+    /// By default, Watchexec will run the command once immediately. With this option, it will
+    /// instead wait until an event is detected before running the command as normal.
     #[bpaf(long("postpone"), short('p'), switch)]
     pub postpone: bool,
     /// Sleep before running the command
     ///
-    /// This option will cause Watchexec to sleep for the specified amount of time before running the command, after an event is detected. This is like using "sleep 5 && command" in a shell, but portable and slightly more efficient.
+    /// This option will cause Watchexec to sleep for the specified amount of time before running
+    /// the command, after an event is detected. This is like using "sleep 5 && command" in a shell,
+    /// but portable and slightly more efficient.
     ///
-    /// Takes a unit-less value in seconds, or a time span value such as "2min 5s". Providing a unit-less value is deprecated and will warn; it will be an error in the future.
+    /// Takes a unit-less value in seconds, or a time span value such as "2min 5s".
+    /// Providing a unit-less value is deprecated and will warn; it will be an error in the future.
     #[bpaf(long("delay-run"), argument("DURATION"))]
     pub delay_run: Option<String>,
     /// Poll for filesystem changes
     ///
-    /// By default, and where available, Watchexec uses the operating system's native file system watching capabilities. This option disables that and instead uses a polling mechanism, which is less efficient but can work around issues with some file systems (like network shares) or edge cases.
+    /// By default, and where available, Watchexec uses the operating system's native file system
+    /// watching capabilities. This option disables that and instead uses a polling mechanism, which
+    /// is less efficient but can work around issues with some file systems (like network shares) or
+    /// edge cases.
     ///
-    /// Optionally takes a unit-less value in milliseconds, or a time span value such as "2s 500ms", to use as the polling interval. If not specified, the default is 30 seconds. Providing a unit-less value is deprecated and will warn; it will be an error in the future.
+    /// Optionally takes a unit-less value in milliseconds, or a time span value such as "2s 500ms",
+    /// to use as the polling interval. If not specified, the default is 30 seconds.
+    /// Providing a unit-less value is deprecated and will warn; it will be an error in the future.
     ///
     /// Aliased as '--force-poll'.
     #[bpaf(long("poll"), argument("INTERVAL"))]
     pub poll: Option<String>,
     /// Use a different shell
     ///
-    /// By default, Watchexec will use '$SHELL' if it's defined or a default of 'sh' on Unix-likes, and either 'pwsh', 'powershell', or 'cmd' (CMD.EXE) on Windows, depending on what Watchexec detects is the running shell.
+    /// By default, Watchexec will use '$SHELL' if it's defined or a default of 'sh' on Unix-likes,
+    /// and either 'pwsh', 'powershell', or 'cmd' (CMD.EXE) on Windows, depending on what Watchexec
+    /// detects is the running shell.
     ///
-    /// With this option, you can override that and use a different shell, for example one with more features or one which has your custom aliases and functions.
+    /// With this option, you can override that and use a different shell, for example one with more
+    /// features or one which has your custom aliases and functions.
     ///
-    /// If the value has spaces, it is parsed as a command line, and the first word used as the shell program, with the rest as arguments to the shell.
+    /// If the value has spaces, it is parsed as a command line, and the first word used as the
+    /// shell program, with the rest as arguments to the shell.
     ///
     /// The command is run with the '-c' flag (except for 'cmd' on Windows, where it's '/C').
     ///
-    /// The special value 'none' can be used to disable shell use entirely. In that case, the command provided to Watchexec will be parsed, with the first word being the executable and the rest being the arguments, and executed directly. Note that this parsing is rudimentary, and may not work as expected in all cases.
+    /// The special value 'none' can be used to disable shell use entirely. In that case, the
+    /// command provided to Watchexec will be parsed, with the first word being the executable and
+    /// the rest being the arguments, and executed directly. Note that this parsing is rudimentary,
+    /// and may not work as expected in all cases.
     ///
-    /// Using 'none' is a little more efficient and can enable a stricter interpretation of the input, but it also means that you can't use shell features like globbing, redirection, control flow, logic, or pipes.
+    /// Using 'none' is a little more efficient and can enable a stricter interpretation of the
+    /// input, but it also means that you can't use shell features like globbing, redirection,
+    /// control flow, logic, or pipes.
     ///
     /// Examples:
     ///
     /// Use without shell:
     ///
-    /// $ watchexec -n -- zsh -x -o shwordsplit scr
+    ///   $ watchexec -n -- zsh -x -o shwordsplit scr
     ///
     /// Use with powershell core:
     ///
-    /// $ watchexec --shell=pwsh -- Test-Connection localhost
+    ///   $ watchexec --shell=pwsh -- Test-Connection localhost
     ///
     /// Use with CMD.exe:
     ///
-    /// $ watchexec --shell=cmd -- dir
+    ///   $ watchexec --shell=cmd -- dir
     ///
     /// Use with a different unix shell:
     ///
-    /// $ watchexec --shell=bash -- 'echo $BASH_VERSION'
+    ///   $ watchexec --shell=bash -- 'echo $BASH_VERSION'
     ///
     /// Use with a unix shell and options:
     ///
-    /// $ watchexec --shell='zsh -x -o shwordsplit' -- scr
+    ///   $ watchexec --shell='zsh -x -o shwordsplit' -- scr
     #[bpaf(long("shell"), argument("SHELL"))]
     pub shell: Option<String>,
     /// Shorthand for '--shell=none'
@@ -5256,27 +5414,40 @@ pub struct WatchArgs {
     /// multiple confused queries that have landed in my inbox over the years.
     #[bpaf(long("emit-events-to"), argument("MODE"))]
     pub emit_events_to: Option<String>,
+    /// Only emit events to stdout, run no commands.
+    ///
+    /// This is a convenience option for using Watchexec as a file watcher, without running any
+    /// commands. It is almost equivalent to using `cat` as the command, except that it will not
+    /// spawn a new process for each event.
+    ///
+    /// This option requires `--emit-events-to` to be set, and restricts the available modes to
+    /// `stdio` and `json-stdio`, modifying their behaviour to write to stdout instead of the stdin
+    /// of the command.
     #[bpaf(long("only-emit-events"), switch)]
     pub only_emit_events: bool,
     /// Add env vars to the command
     ///
-    /// This is a convenience option for setting environment variables for the command, without setting them for the Watchexec process itself.
+    /// This is a convenience option for setting environment variables for the command, without
+    /// setting them for the Watchexec process itself.
     ///
     /// Use key=value syntax. Multiple variables can be set by repeating the option.
     #[bpaf(long("env"), short('E'), argument("KEY=VALUE"))]
     pub env: Vec<String>,
     /// Configure how the process is wrapped
     ///
-    /// By default, Watchexec will run the command in a session on macOS, in a process group on other Unix platforms, and in a Job Object in Windows.
+    /// By default, Watchexec will run the command in a session on macOS, in a process group on
+    /// other Unix platforms, and in a Job Object in Windows.
     ///
     /// Some Unix programs prefer running in a session, while others do not work in a process group.
     ///
-    /// Use 'group' to use a process group, 'session' to use a process session, and 'none' to run the command directly. On Windows, either of 'group' or 'session' will use a Job Object.
+    /// Use 'group' to use a process group, 'session' to use a process session, and 'none' to run
+    /// the command directly. On Windows, either of 'group' or 'session' will use a Job Object.
     #[bpaf(long("wrap-process"), argument("MODE"))]
     pub wrap_process: Option<String>,
     /// Alert when commands start and end
     ///
-    /// With this, Watchexec will emit a desktop notification when a command starts and ends, on supported platforms. On unsupported platforms, it may silently do nothing, or log a warning.
+    /// With this, Watchexec will emit a desktop notification when a command starts and ends, on
+    /// supported platforms. On unsupported platforms, it may silently do nothing, or log a warning.
     #[bpaf(long("notify"), short('N'), switch)]
     pub notify: bool,
     /// When to use terminal colours
@@ -5286,12 +5457,14 @@ pub struct WatchArgs {
     pub color: Option<String>,
     /// Print how long the command took to run
     ///
-    /// This may not be exactly accurate, as it includes some overhead from Watchexec itself. Use the `time` utility, high-precision timers, or benchmarking tools for more accurate results.
+    /// This may not be exactly accurate, as it includes some overhead from Watchexec itself. Use
+    /// the `time` utility, high-precision timers, or benchmarking tools for more accurate results.
     #[bpaf(long("timings"), switch)]
     pub timings: bool,
     /// Don't print starting and stopping messages
     ///
-    /// By default Watchexec will print a message when the command starts and stops. This option disables this behaviour, so only the command's output, warnings, and errors will be printed.
+    /// By default Watchexec will print a message when the command starts and stops. This option
+    /// disables this behaviour, so only the command's output, warnings, and errors will be printed.
     #[bpaf(long("quiet"), short('q'), switch)]
     pub quiet: bool,
     /// Ring the terminal bell on command completion
@@ -5299,71 +5472,151 @@ pub struct WatchArgs {
     pub bell: bool,
     /// Set the project origin
     ///
-    /// Watchexec will attempt to discover the project's "origin" (or "root") by searching for a variety of markers, like files or directory patterns. It does its best but sometimes gets it it wrong, and you can override that with this option.
+    /// Watchexec will attempt to discover the project's "origin" (or "root") by searching for a
+    /// variety of markers, like files or directory patterns. It does its best but sometimes gets it
+    /// it wrong, and you can override that with this option.
     ///
-    /// The project origin is used to determine the path of certain ignore files, which VCS is being used, the meaning of a leading '/' in filtering patterns, and maybe more in the future.
+    /// The project origin is used to determine the path of certain ignore files, which VCS is being
+    /// used, the meaning of a leading '/' in filtering patterns, and maybe more in the future.
     ///
     /// When set, Watchexec will also not bother searching, which can be significantly faster.
     #[bpaf(long("project-origin"), argument("DIRECTORY"))]
     pub project_origin: Option<String>,
     /// Set the working directory
     ///
-    /// By default, the working directory of the command is the working directory of Watchexec. You can change that with this option. Note that paths may be less intuitive to use with this.
+    /// By default, the working directory of the command is the working directory of Watchexec. You
+    /// can change that with this option. Note that paths may be less intuitive to use with this.
     #[bpaf(long("workdir"), argument("DIRECTORY"))]
     pub workdir: Option<String>,
     /// Filename extensions to filter to
     ///
-    /// This is a quick filter to only emit events for files with the given extensions. Extensions can be given with or without the leading dot (e.g. 'js' or '.js'). Multiple extensions can be given by repeating the option or by separating them with commas.
+    /// This is a quick filter to only emit events for files with the given extensions. Extensions
+    /// can be given with or without the leading dot (e.g. 'js' or '.js'). Multiple extensions can
+    /// be given by repeating the option or by separating them with commas.
     #[bpaf(long("exts"), short('e'), argument("EXTENSIONS"))]
     pub exts: Vec<String>,
     /// Filename patterns to filter to
     ///
-    /// Provide a glob-like filter pattern, and only events for files matching the pattern will be emitted. Multiple patterns can be given by repeating the option. Events that are not from files (e.g. signals, keyboard events) will pass through untouched.
+    /// Provide a glob-like filter pattern, and only events for files matching the pattern will be
+    /// emitted. Multiple patterns can be given by repeating the option. Events that are not from
+    /// files (e.g. signals, keyboard events) will pass through untouched.
     #[bpaf(long("filter"), short('f'), argument("PATTERN"))]
     pub filter: Vec<String>,
     /// Files to load filters from
     ///
-    /// Provide a path to a file containing filters, one per line. Empty lines and lines starting with '#' are ignored. Uses the same pattern format as the '--filter' option.
+    /// Provide a path to a file containing filters, one per line. Empty lines and lines starting
+    /// with '#' are ignored. Uses the same pattern format as the '--filter' option.
     ///
     /// This can also be used via the $WATCHEXEC_FILTER_FILES environment variable.
     #[bpaf(long("filter-file"), argument("PATH"))]
     pub filter_file: Vec<String>,
+    /// [experimental] Filter programs.
+    ///
+    /// /!\ This option is EXPERIMENTAL and may change and/or vanish without notice.
+    ///
+    /// Provide your own custom filter programs in jaq (similar to jq) syntax. Programs are given
+    /// an event in the same format as described in '--emit-events-to' and must return a boolean.
+    /// Invalid programs will make watchexec fail to start; use '-v' to see program runtime errors.
+    ///
+    /// In addition to the jaq stdlib, watchexec adds some custom filter definitions:
+    ///
+    ///   - 'path | file_meta' returns file metadata or null if the file does not exist.
+    ///
+    ///   - 'path | file_size' returns the size of the file at path, or null if it does not exist.
+    ///
+    ///   - 'path | file_read(bytes)' returns a string with the first n bytes of the file at path.
+    ///     If the file is smaller than n bytes, the whole file is returned. There is no filter to
+    ///     read the whole file at once to encourage limiting the amount of data read and processed.
+    ///
+    ///   - 'string | hash', and 'path | file_hash' return the hash of the string or file at path.
+    ///     No guarantee is made about the algorithm used: treat it as an opaque value.
+    ///
+    ///   - 'any | kv_store(key)', 'kv_fetch(key)', and 'kv_clear' provide a simple key-value store.
+    ///     Data is kept in memory only, there is no persistence. Consistency is not guaranteed.
+    ///
+    ///   - 'any | printout', 'any | printerr', and 'any | log(level)' will print or log any given
+    ///     value to stdout, stderr, or the log (levels = error, warn, info, debug, trace), and
+    ///     pass the value through (so '[1] | log("debug") | .[]' will produce a '1' and log '[1]').
+    ///
+    /// All filtering done with such programs, and especially those using kv or filesystem access,
+    /// is much slower than the other filtering methods. If filtering is too slow, events will back
+    /// up and stall watchexec. Take care when designing your filters.
+    ///
+    /// If the argument to this option starts with an '@', the rest of the argument is taken to be
+    /// the path to a file containing a jaq program.
+    ///
+    /// Jaq programs are run in order, after all other filters, and short-circuit: if a filter (jaq
+    /// or not) rejects an event, execution stops there, and no other filters are run. Additionally,
+    /// they stop after outputting the first value, so you'll want to use 'any' or 'all' when
+    /// iterating, otherwise only the first item will be processed, which can be quite confusing!
+    ///
+    /// Find user-contributed programs or submit your own useful ones at
+    /// <https://github.com/watchexec/watchexec/discussions/592>.
+    ///
+    /// ## Examples:
+    ///
+    /// Regexp ignore filter on paths:
+    ///
+    ///   'all(.tags[] | select(.kind == "path"); .absolute | test("[.]test[.]js$")) | not'
+    ///
+    /// Pass any event that creates a file:
+    ///
+    ///   'any(.tags[] | select(.kind == "fs"); .simple == "create")'
+    ///
+    /// Pass events that touch executable files:
+    ///
+    ///   'any(.tags[] | select(.kind == "path" && .filetype == "file"); .absolute | metadata | .executable)'
+    ///
+    /// Ignore files that start with shebangs:
+    ///
+    ///   'any(.tags[] | select(.kind == "path" && .filetype == "file"); .absolute | read(2) == "#!") | not'
     #[bpaf(long("filter-prog"), short('J'), argument("EXPRESSION"))]
     pub filter_prog: Vec<String>,
     /// Filename patterns to filter out
     ///
-    /// Provide a glob-like filter pattern, and events for files matching the pattern will be excluded. Multiple patterns can be given by repeating the option. Events that are not from files (e.g. signals, keyboard events) will pass through untouched.
+    /// Provide a glob-like filter pattern, and events for files matching the pattern will be
+    /// excluded. Multiple patterns can be given by repeating the option. Events that are not from
+    /// files (e.g. signals, keyboard events) will pass through untouched.
     #[bpaf(long("ignore"), short('i'), argument("PATTERN"))]
     pub ignore: Vec<String>,
     /// Files to load ignores from
     ///
-    /// Provide a path to a file containing ignores, one per line. Empty lines and lines starting with '#' are ignored. Uses the same pattern format as the '--ignore' option.
+    /// Provide a path to a file containing ignores, one per line. Empty lines and lines starting
+    /// with '#' are ignored. Uses the same pattern format as the '--ignore' option.
     ///
     /// This can also be used via the $WATCHEXEC_IGNORE_FILES environment variable.
     #[bpaf(long("ignore-file"), argument("PATH"))]
     pub ignore_file: Vec<String>,
     /// Filesystem events to filter to
     ///
-    /// This is a quick filter to only emit events for the given types of filesystem changes. Choose from 'access', 'create', 'remove', 'rename', 'modify', 'metadata'. Multiple types can be given by repeating the option or by separating them with commas. By default, this is all types except for 'access'.
+    /// This is a quick filter to only emit events for the given types of filesystem changes. Choose
+    /// from 'access', 'create', 'remove', 'rename', 'modify', 'metadata'. Multiple types can be
+    /// given by repeating the option or by separating them with commas. By default, this is all
+    /// types except for 'access'.
     ///
-    /// This may apply filtering at the kernel level when possible, which can be more efficient, but may be more confusing when reading the logs.
+    /// This may apply filtering at the kernel level when possible, which can be more efficient, but
+    /// may be more confusing when reading the logs.
     #[bpaf(long("fs-events"), argument("EVENTS"))]
     pub fs_events: Vec<String>,
     /// Don't emit fs events for metadata changes
     ///
-    /// This is a shorthand for '--fs-events create,remove,rename,modify'. Using it alongside the '--fs-events' option is non-sensical and not allowed.
+    /// This is a shorthand for '--fs-events create,remove,rename,modify'. Using it alongside the
+    /// '--fs-events' option is non-sensical and not allowed.
     #[bpaf(long("no-meta"), switch)]
     pub no_meta: bool,
     /// Print events that trigger actions
     ///
-    /// This prints the events that triggered the action when handling it (after debouncing), in a human readable form. This is useful for debugging filters.
+    /// This prints the events that triggered the action when handling it (after debouncing), in a
+    /// human readable form. This is useful for debugging filters.
     ///
     /// Use '-vvv' instead when you need more diagnostic information.
     #[bpaf(long("print-events"), switch)]
     pub print_events: bool,
     /// Show the manual page
     ///
-    /// This shows the manual page for Watchexec, if the output is a terminal and the 'man' program is available. If not, the manual page is printed to stdout in ROFF format (suitable for writing to a watchexec.1 file).
+    /// This shows the manual page for Watchexec, if the output is a terminal and the 'man' program
+    /// is available. If not, the manual page is printed to stdout in ROFF format (suitable for
+    /// writing to a watchexec.1 file).
     #[bpaf(long("manual"), switch)]
     pub manual: bool,
     #[bpaf(positional("TASK"))]
@@ -5421,7 +5674,7 @@ pub struct Cli {
     /// Force the operation
     #[bpaf(long("force"), short('f'), switch)]
     pub force: bool,
-    /// How many jobs to run in parallel [default: 8]
+    /// How many jobs to run in parallel; values below 1 are treated as 1 [default: 8]
     #[bpaf(long("jobs"), short('j'), argument("JOBS"))]
     pub jobs: Option<String>,
     /// Dry run, don't actually do anything
@@ -5435,7 +5688,6 @@ pub struct Cli {
     pub quiet: bool,
     #[bpaf(long("shell"), short('s'), argument("SHELL"))]
     pub shell: Option<String>,
-    /// Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10
     #[bpaf(long("tool"), short('t'), argument("TOOL@VERSION"))]
     pub tool: Vec<String>,
     /// Show extra output (use -vv for even more)
@@ -5681,7 +5933,7 @@ pub enum Commands {
     /// Remove environment variable(s) from the config file.
     #[bpaf(command("unset"))]
     Unset(#[bpaf(external(unsetargs_p))] UnsetArgs),
-    /// No longer trust a config, will prompt in the future
+    /// Remove explicit trust for a config
     #[bpaf(command("untrust"))]
     Untrust(#[bpaf(external(untrustargs_p))] UntrustArgs),
     /// Removes installed tool versions from mise.toml

--- a/benches/shadows/mise-clap/src/lib.rs
+++ b/benches/shadows/mise-clap/src/lib.rs
@@ -33,7 +33,10 @@ pub struct ActivateArgs {
     pub shell: Option<String>,
     /// Do not automatically call hook-env
     ///
-    /// This can be helpful for debugging mise. If you run `eval "$(mise activate --no-hook-env)"`, then you can call `mise hook-env` manually which will output the env vars to stdout without actually modifying the environment. That way you can do things like `mise hook-env --trace` to get more information or just see the values that hook-env is outputting.
+    /// This can be helpful for debugging mise. If you run `eval "$(mise activate --no-hook-env)"`, then
+    /// you can call `mise hook-env` manually which will output the env vars to stdout without actually
+    /// modifying the environment. That way you can do things like `mise hook-env --trace` to get more
+    /// information or just see the values that hook-env is outputting.
     #[arg(long = "no-hook-env")]
     pub no_hook_env: bool,
     #[arg(
@@ -106,7 +109,7 @@ pub struct ToolAliasUnsetArgs {
 #[derive(Args)]
 pub struct ToolAliasArgs {
     /// Filter aliases by tool
-    #[arg(long = "tool", short = 'p', value_name = "TOOL")]
+    #[arg(long = "tool", short = 'p', alias = "plugin", value_name = "TOOL")]
     pub tool: Option<String>,
     /// Don't show table header
     #[arg(long = "no-header")]
@@ -281,10 +284,20 @@ pub struct BootstrapDotfilesAddArgs {
     #[arg(long = "force", short = 'f')]
     pub force: bool,
     /// Write to the global config
-    #[arg(long = "global", short = 'g')]
+    #[arg(
+        long = "global",
+        short = 'g',
+        conflicts_with = "local",
+        conflicts_with = "path"
+    )]
     pub global: bool,
     /// Write to the local config instead of the global config
-    #[arg(long = "local", short = 'l')]
+    #[arg(
+        long = "local",
+        short = 'l',
+        conflicts_with = "global",
+        conflicts_with = "path"
+    )]
     pub local: bool,
     /// Dotfile mode to write
     #[arg(long = "mode", short = 'm', value_name = "MODE")]
@@ -296,7 +309,13 @@ pub struct BootstrapDotfilesAddArgs {
     #[arg(long = "no-apply")]
     pub no_apply: bool,
     /// Write to this config file or directory
-    #[arg(long = "path", short = 'p', alias = "file", value_name = "PATH")]
+    #[arg(
+        long = "path",
+        short = 'p',
+        conflicts_with = "global",
+        conflicts_with = "local",
+        value_name = "PATH"
+    )]
     pub path: Option<String>,
     /// Source path to use for a single target
     #[arg(long = "source", short = 's', value_name = "PATH")]
@@ -407,7 +426,7 @@ pub enum BootstrapDotfilesCommands {
     #[command(name = "edit")]
     Edit(Box<BootstrapDotfilesEditArgs>),
     /// Show the status of dotfiles from `[dotfiles]`
-    #[command(name = "status", visible_alias = "ls")]
+    #[command(name = "status")]
     Status(Box<BootstrapDotfilesStatusArgs>),
     /// Remove dotfiles applied from `[dotfiles]`
     #[command(name = "unapply")]
@@ -763,8 +782,7 @@ pub struct BootstrapPackagesApplyArgs {
     /// Refresh package manager metadata first (apk: `--update-cache`, apt: `apt-get update`)
     #[arg(long = "update")]
     pub update: bool,
-    /// Packages in `manager:package` form; defaults to everything configured in [bootstrap.packages]
-    #[arg(value_name = "PACKAGE", num_args = 0..)]
+    #[arg(value_name = "PACKAGE", help = "Packages in `manager:package` form; defaults to everything configured in [bootstrap.packages]", long_help = "Packages in `manager:package` form; defaults to everything configured\nin [bootstrap.packages]", num_args = 0..)]
     pub package: Vec<String>,
 }
 
@@ -778,7 +796,13 @@ pub struct BootstrapPackagesBrewTapArgs {
     #[arg(long = "dry-run", short = 'n')]
     pub dry_run: bool,
     /// Write to this config file or directory
-    #[arg(long = "path", short = 'p', alias = "file", value_name = "PATH")]
+    #[arg(
+        long = "path",
+        short = 'p',
+        alias = "file",
+        conflicts_with = "local",
+        value_name = "PATH"
+    )]
     pub path: Option<String>,
     /// Tap name, e.g. `owner/repo`
     #[arg(value_name = "TAP")]
@@ -798,7 +822,13 @@ pub struct BootstrapPackagesBrewUntapArgs {
     #[arg(long = "dry-run", short = 'n')]
     pub dry_run: bool,
     /// Write to this config file or directory
-    #[arg(long = "path", short = 'p', alias = "file", value_name = "PATH")]
+    #[arg(
+        long = "path",
+        short = 'p',
+        alias = "file",
+        conflicts_with = "local",
+        value_name = "PATH"
+    )]
     pub path: Option<String>,
     /// Tap name(s), e.g. `owner/repo`
     #[arg(value_name = "TAPS", required = true, num_args = 0..)]
@@ -833,12 +863,23 @@ pub enum BootstrapPackagesBrewCommands {
 #[derive(Args)]
 pub struct BootstrapPackagesImportArgs {
     /// Write to the config file for this environment (mise.<ENV>.toml)
-    #[arg(long = "env", short = 'e', value_name = "ENV")]
+    #[arg(
+        long = "env",
+        short = 'e',
+        conflicts_with = "global",
+        conflicts_with = "path",
+        value_name = "ENV"
+    )]
     pub env: Option<String>,
     /// Write to the global config (~/.config/mise/config.toml)
-    #[arg(long = "global", short = 'g')]
+    #[arg(
+        long = "global",
+        short = 'g',
+        conflicts_with = "env",
+        conflicts_with = "path"
+    )]
     pub global: bool,
-    /// Only import packages for this manager. Currently only `brew` is supported
+    /// Only import packages for this manager. Currently only `brew` is supported.
     #[arg(long = "manager", short = 'm', value_name = "MANAGER", value_parser = ::clap::builder::PossibleValuesParser::new(["brew"]), default_value = "brew")]
     pub manager: Option<String>,
     /// Import every linked formula, including dependencies
@@ -848,19 +889,25 @@ pub struct BootstrapPackagesImportArgs {
     #[arg(long = "dry-run", short = 'n')]
     pub dry_run: bool,
     /// Write to this config file or directory
-    #[arg(long = "path", short = 'p', alias = "file", value_name = "PATH")]
+    #[arg(
+        long = "path",
+        short = 'p',
+        alias = "file",
+        conflicts_with = "global",
+        value_name = "PATH"
+    )]
     pub path: Option<String>,
 }
 
 /// Prune installed system packages no longer declared in `[bootstrap.packages]`
 ///
-/// Currently supports Homebrew formulae only. Pruning removes linked formulae
-/// that are not needed by the current config or by trusted, loadable tracked
-/// configs.
+/// Supports Homebrew formulae and conservatively removable, mise-owned casks.
+/// Pruning keeps packages needed by the current config or by trusted, loadable
+/// tracked configs.
 #[derive(Args)]
 pub struct BootstrapPackagesPruneArgs {
-    /// Only prune packages for this manager. Currently only `brew` is supported
-    #[arg(long = "manager", short = 'm', value_name = "MANAGER", value_parser = ::clap::builder::PossibleValuesParser::new(["brew"]), default_value = "brew")]
+    /// Only prune packages for this manager
+    #[arg(long = "manager", short = 'm', value_name = "MANAGER", value_parser = ::clap::builder::PossibleValuesParser::new(["brew", "brew-cask"]), default_value = "brew")]
     pub manager: Option<String>,
     /// Print what would be removed without deleting anything
     #[arg(long = "dry-run", short = 'n')]
@@ -887,7 +934,7 @@ pub struct BootstrapPackagesStatusArgs {
 /// that are already installed: apk/apt/dnf/pacman upgrade to the newest available
 /// version (apk, apt, and dnf honor a version pinned in config), brew pours the
 /// formula's current bottle and replaces the old keg, brew-cask installs
-/// the current cask artifact, flatpak updates applications and runtimes, and mas upgrades App Store apps. Packages that
+/// the current cask artifact, flatpak and flatpak-user update applications and runtimes, and mas upgrades App Store apps. Packages that
 /// are not installed yet are skipped — use `mise bootstrap packages apply`
 /// for those.
 ///
@@ -903,8 +950,7 @@ pub struct BootstrapPackagesUpgradeArgs {
     /// Skip the confirmation prompt
     #[arg(long = "yes", short = 'y')]
     pub yes: bool,
-    /// Packages in `manager:package` form; defaults to everything configured in [bootstrap.packages]
-    #[arg(value_name = "PACKAGE", num_args = 0..)]
+    #[arg(value_name = "PACKAGE", help = "Packages in `manager:package` form; defaults to everything configured in [bootstrap.packages]", long_help = "Packages in `manager:package` form; defaults to everything configured\nin [bootstrap.packages]", num_args = 0..)]
     pub package: Vec<String>,
 }
 
@@ -922,16 +968,32 @@ pub struct BootstrapPackagesUpgradeArgs {
 #[derive(Args)]
 pub struct BootstrapPackagesUseArgs {
     /// Write to the config file for this environment (mise.<ENV>.toml)
-    #[arg(long = "env", short = 'e', value_name = "ENV")]
+    #[arg(
+        long = "env",
+        short = 'e',
+        conflicts_with = "global",
+        conflicts_with = "path",
+        value_name = "ENV"
+    )]
     pub env: Option<String>,
-    /// Write to the global config (~/.config/mise/config.toml) instead of the local one
-    #[arg(long = "global", short = 'g')]
+    #[arg(
+        help = "Write to the global config (~/.config/mise/config.toml) instead of the local one",
+        long_help = "Write to the global config (~/.config/mise/config.toml) instead of the\nlocal one",
+        long = "global",
+        short = 'g'
+    )]
     pub global: bool,
     /// Print the commands that would run without writing config or installing
     #[arg(long = "dry-run", short = 'n')]
     pub dry_run: bool,
     /// Write to this config file or directory
-    #[arg(long = "path", short = 'p', alias = "file", value_name = "PATH")]
+    #[arg(
+        long = "path",
+        short = 'p',
+        alias = "file",
+        conflicts_with = "global",
+        value_name = "PATH"
+    )]
     pub path: Option<String>,
     /// Skip the confirmation prompt
     #[arg(long = "yes", short = 'y')]
@@ -1023,7 +1085,12 @@ pub struct BootstrapRemoteArgs {
     #[arg(long = "all")]
     pub all: bool,
     /// Explicit remote shell command that installs mise and places it on PATH
-    #[arg(long = "bootstrap-command", value_name = "COMMAND")]
+    #[arg(
+        long = "bootstrap-command",
+        conflicts_with = "mise_bin",
+        conflicts_with = "remote_mise",
+        value_name = "COMMAND"
+    )]
     pub bootstrap_command: Option<String>,
     /// SSH connection timeout in seconds
     #[arg(
@@ -1032,6 +1099,12 @@ pub struct BootstrapRemoteArgs {
         default_value = "10"
     )]
     pub connect_timeout: Option<String>,
+    /// Dereference one source-relative symbolic link; repeat for multiple links
+    #[arg(long = "copy-link", value_name = "PATH")]
+    pub copy_link: Vec<String>,
+    /// Dereference every symbolic link in the source archive
+    #[arg(long = "copy-links")]
+    pub copy_links: bool,
     /// Additional archive pattern to exclude; repeat for multiple patterns
     #[arg(long = "exclude", value_name = "PATTERN")]
     pub exclude: Vec<String>,
@@ -1054,10 +1127,15 @@ pub struct BootstrapRemoteArgs {
     #[arg(long = "keep-staging")]
     pub keep_staging: bool,
     /// Local mise binary to upload (escape hatch for custom architectures)
-    #[arg(long = "mise-bin", value_name = "MISE_BIN")]
+    #[arg(
+        long = "mise-bin",
+        conflicts_with = "remote_mise",
+        conflicts_with = "bootstrap_command",
+        value_name = "MISE_BIN"
+    )]
     pub mise_bin: Option<String>,
     /// Run only one or more remote bootstrap parts
-    #[arg(long = "only", value_name = "ONLY", value_parser = ::clap::builder::PossibleValuesParser::new(["plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "shell", "macos-defaults", "defaults", "macos-launchd-agents", "launchd", "linux-systemd-units", "systemd", "user", "tools", "task", "final-hook"]))]
+    #[arg(long = "only", value_delimiter = ',', conflicts_with = "skip", value_name = "ONLY", value_parser = ::clap::builder::PossibleValuesParser::new(["plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "macos-defaults", "macos-launchd-agents", "linux-systemd-units", "user", "tools", "task", "final-hook"]))]
     pub only: Vec<String>,
     /// SSH port override
     #[arg(long = "port", value_name = "PORT")]
@@ -1065,11 +1143,19 @@ pub struct BootstrapRemoteArgs {
     /// Prompt securely for missing secret inputs on the remote host
     #[arg(long = "prompt-secrets")]
     pub prompt_secrets: bool,
+    /// Config environments to load on the remote host; repeat or delimit with commas (for example, ci,dotfiles)
+    #[arg(long = "remote-env", value_delimiter = ',', value_name = "ENV")]
+    pub remote_env: Vec<String>,
     /// Existing mise executable name or path; relative paths use the staged project
-    #[arg(long = "remote-mise", value_name = "COMMAND")]
+    #[arg(
+        long = "remote-mise",
+        conflicts_with = "mise_bin",
+        conflicts_with = "bootstrap_command",
+        value_name = "COMMAND"
+    )]
     pub remote_mise: Option<String>,
     /// Skip one or more remote bootstrap parts
-    #[arg(long = "skip", value_name = "SKIP", value_parser = ::clap::builder::PossibleValuesParser::new(["plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "shell", "macos-defaults", "defaults", "macos-launchd-agents", "launchd", "linux-systemd-units", "systemd", "user", "tools", "task", "final-hook"]))]
+    #[arg(long = "skip", value_delimiter = ',', value_name = "SKIP", value_parser = ::clap::builder::PossibleValuesParser::new(["plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "macos-defaults", "macos-launchd-agents", "linux-systemd-units", "user", "tools", "task", "final-hook"]))]
     pub skip: Vec<String>,
     /// Local directory archived and sent to each target
     #[arg(long = "source", value_name = "SOURCE")]
@@ -1369,8 +1455,9 @@ pub struct BootstrapArgs {
     pub force_dotfiles: bool,
     /// Run only one or more bootstrap parts
     ///
-    /// Can be passed multiple times or as a comma-separated list. Cannot be used with `--skip`.
-    #[arg(long = "only", value_name = "ONLY", value_parser = ::clap::builder::PossibleValuesParser::new(["plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "shell", "macos-defaults", "defaults", "macos-launchd-agents", "launchd", "linux-systemd-units", "systemd", "user", "tools", "task", "final-hook"]))]
+    /// Can be passed multiple times or as a comma-separated list.
+    /// Cannot be used with `--skip`.
+    #[arg(long = "only", value_delimiter = ',', conflicts_with = "skip", value_name = "ONLY", value_parser = ::clap::builder::PossibleValuesParser::new(["plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "macos-defaults", "macos-launchd-agents", "linux-systemd-units", "user", "tools", "task", "final-hook"]))]
     pub only: Vec<String>,
     /// Prompt securely for missing bootstrap secret inputs
     #[arg(long = "prompt-secrets")]
@@ -1378,7 +1465,7 @@ pub struct BootstrapArgs {
     /// Skip one or more bootstrap parts
     ///
     /// Can be passed multiple times or as a comma-separated list.
-    #[arg(long = "skip", value_name = "SKIP", value_parser = ::clap::builder::PossibleValuesParser::new(["plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "shell", "macos-defaults", "defaults", "macos-launchd-agents", "launchd", "linux-systemd-units", "systemd", "user", "tools", "task", "final-hook"]))]
+    #[arg(long = "skip", value_delimiter = ',', value_name = "SKIP", value_parser = ::clap::builder::PossibleValuesParser::new(["plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "macos-defaults", "macos-launchd-agents", "linux-systemd-units", "user", "tools", "task", "final-hook"]))]
     pub skip: Vec<String>,
     /// Refresh package manager metadata and update configured repos
     #[arg(long = "update")]
@@ -1389,17 +1476,17 @@ pub struct BootstrapArgs {
 
 #[derive(Subcommand)]
 pub enum BootstrapCommands {
-    #[command(name = "__apply-account-plan")]
+    #[command(name = "__apply-account-plan", hide = true)]
     ApplyAccountPlan(Box<BootstrapApplyAccountPlanArgs>),
-    #[command(name = "__apply-service-plan")]
+    #[command(name = "__apply-service-plan", hide = true)]
     ApplyServicePlan(Box<BootstrapApplyServicePlanArgs>),
-    #[command(name = "__apply-firewall-plan")]
+    #[command(name = "__apply-firewall-plan", hide = true)]
     ApplyFirewallPlan(Box<BootstrapApplyFirewallPlanArgs>),
-    #[command(name = "__apply-system-plan")]
+    #[command(name = "__apply-system-plan", hide = true)]
     ApplySystemPlan(Box<BootstrapApplySystemPlanArgs>),
-    #[command(name = "__inspect-system-files")]
+    #[command(name = "__inspect-system-files", hide = true)]
     InspectSystemFiles(Box<BootstrapInspectSystemFilesArgs>),
-    #[command(name = "__inspect-firewall-plan")]
+    #[command(name = "__inspect-firewall-plan", hide = true)]
     InspectFirewallPlan(Box<BootstrapInspectFirewallPlanArgs>),
     /// Manage Linux users and groups from `[bootstrap.users]` and `[bootstrap.groups]`
     #[command(name = "accounts")]
@@ -1417,7 +1504,7 @@ pub enum BootstrapCommands {
     #[command(name = "firewall")]
     Firewall(Box<BootstrapFirewallArgs>),
     /// Manage macOS LaunchAgents from `[bootstrap.macos.launchd.agents]`
-    #[command(name = "launchd")]
+    #[command(name = "launchd", hide = true)]
     Launchd(Box<BootstrapLaunchdArgs>),
     /// Manage Linux bootstrap config from `[bootstrap.linux]`
     #[command(name = "linux")]
@@ -1426,7 +1513,7 @@ pub enum BootstrapCommands {
     #[command(name = "macos")]
     Macos(Box<BootstrapMacosArgs>),
     /// Manage macOS defaults from `[bootstrap.macos.defaults]`
-    #[command(name = "macos-defaults")]
+    #[command(name = "macos-defaults", hide = true)]
     MacosDefaults(Box<BootstrapMacosDefaultsArgs>),
     /// Manage mise shell activation from `[bootstrap.mise_shell_activate]`
     #[command(name = "mise-shell-activate", alias = "shell")]
@@ -1456,7 +1543,7 @@ pub enum BootstrapCommands {
     #[command(name = "status", visible_alias = "ls")]
     Status(Box<BootstrapStatusArgs>),
     /// Manage systemd user services from `[bootstrap.linux.systemd.units]`
-    #[command(name = "systemd")]
+    #[command(name = "systemd", hide = true)]
     Systemd(Box<BootstrapSystemdArgs>),
     /// Manage current-user bootstrap settings from `[bootstrap.user]`
     #[command(name = "user")]
@@ -1470,10 +1557,14 @@ pub struct CacheClearArgs {
     #[arg(long = "outdate", hide = true)]
     pub outdate: bool,
     /// Clear output cache entries for a task name or pattern
-    #[arg(long = "task", value_name = "TASK")]
+    #[arg(
+        long = "task",
+        conflicts_with = "tool",
+        conflicts_with = "outdate",
+        value_name = "TASK"
+    )]
     pub task: Option<String>,
-    /// Tool(s) to clear cache for e.g.: node, python
-    #[arg(value_name = "TOOL", num_args = 0..)]
+    #[arg(value_name = "TOOL", help = "Tool(s) to clear cache for e.g.: node, python", long_help = "Tool(s) to clear cache for\ne.g.: node, python", num_args = 0..)]
     pub tool: Vec<String>,
 }
 
@@ -1493,8 +1584,7 @@ pub struct CachePruneArgs {
     /// Just show what would be pruned
     #[arg(long = "dry-run")]
     pub dry_run: bool,
-    /// Tool(s) to prune cache for e.g.: node, python
-    #[arg(value_name = "TOOL", num_args = 0..)]
+    #[arg(value_name = "TOOL", help = "Tool(s) to prune cache for e.g.: node, python", long_help = "Tool(s) to prune cache for\ne.g.: node, python", num_args = 0..)]
     pub tool: Vec<String>,
 }
 
@@ -1538,7 +1628,7 @@ pub enum CacheCommands {
 #[derive(Args)]
 pub struct CompletionArgs {
     /// Shell type to generate completions for
-    #[arg(long = "shell", short = 's', hide = true, value_name = "SHELL_TYPE", value_parser = ::clap::builder::PossibleValuesParser::new(["bash", "fish", "powershell", "zsh"]))]
+    #[arg(long = "shell", short = 's', hide = true, value_name = "SHELL")]
     pub shell: Option<String>,
     /// Include the bash completion library in the bash completion script
     ///
@@ -1554,7 +1644,7 @@ pub struct CompletionArgs {
     )]
     pub usage: bool,
     /// Shell type to generate completions for
-    #[arg(value_name = "SHELL", value_parser = ::clap::builder::PossibleValuesParser::new(["bash", "fish", "powershell", "zsh"]))]
+    #[arg(value_name = "SHELL", required_unless_present = "shell")]
     pub shell_2: Option<String>,
 }
 
@@ -1580,7 +1670,7 @@ pub struct ConfigLsArgs {
     #[arg(long = "json", short = 'J')]
     pub json: bool,
     /// Do not print table header
-    #[arg(long = "no-header")]
+    #[arg(long = "no-header", alias = "no-headers")]
     pub no_header: bool,
     /// List all tracked config files
     #[arg(long = "tracked-configs")]
@@ -1614,7 +1704,7 @@ pub struct ConfigArgs {
     #[arg(long = "json", short = 'J')]
     pub json: bool,
     /// Do not print table header
-    #[arg(long = "no-header")]
+    #[arg(long = "no-header", alias = "no-headers")]
     pub no_header: bool,
     /// List all tracked config files
     #[arg(long = "tracked-configs")]
@@ -1642,8 +1732,11 @@ pub enum ConfigCommands {
 /// and/or version. It's designed to fit into scripts more easily.
 #[derive(Args)]
 pub struct CurrentArgs {
-    /// Plugin to show versions of e.g.: ruby, node, cargo:eza, npm:prettier, etc
-    #[arg(value_name = "PLUGIN")]
+    #[arg(
+        value_name = "PLUGIN",
+        help = "Plugin to show versions of e.g.: ruby, node, cargo:eza, npm:prettier, etc.",
+        long_help = "Plugin to show versions of\ne.g.: ruby, node, cargo:eza, npm:prettier, etc."
+    )]
     pub plugin: Option<String>,
 }
 
@@ -1685,16 +1778,18 @@ pub struct DirenvArgs {
 #[derive(Subcommand)]
 pub enum DirenvCommands {
     /// Output direnv function to use mise inside direnv
-    #[command(name = "activate")]
+    #[command(name = "activate", hide = true)]
     Activate(Box<DirenvActivateArgs>),
     #[command(
         name = "envrc",
-        about = "[internal] This is an internal command that writes an envrc file\nfor direnv to consume."
+        about = "[internal] This is an internal command that writes an envrc file\nfor direnv to consume.",
+        hide = true
     )]
     Envrc(Box<DirenvEnvrcArgs>),
     #[command(
         name = "exec",
-        about = "[internal] This is an internal command that writes an envrc file\nfor direnv to consume."
+        about = "[internal] This is an internal command that writes an envrc file\nfor direnv to consume.",
+        hide = true
     )]
     Exec(Box<DirenvExecArgs>),
 }
@@ -1710,10 +1805,20 @@ pub struct DotfilesAddArgs {
     #[arg(long = "force", short = 'f')]
     pub force: bool,
     /// Write to the global config
-    #[arg(long = "global", short = 'g')]
+    #[arg(
+        long = "global",
+        short = 'g',
+        conflicts_with = "local",
+        conflicts_with = "path"
+    )]
     pub global: bool,
     /// Write to the local config instead of the global config
-    #[arg(long = "local", short = 'l')]
+    #[arg(
+        long = "local",
+        short = 'l',
+        conflicts_with = "global",
+        conflicts_with = "path"
+    )]
     pub local: bool,
     /// Dotfile mode to write
     #[arg(long = "mode", short = 'm', value_name = "MODE")]
@@ -1725,7 +1830,13 @@ pub struct DotfilesAddArgs {
     #[arg(long = "no-apply")]
     pub no_apply: bool,
     /// Write to this config file or directory
-    #[arg(long = "path", short = 'p', alias = "file", value_name = "PATH")]
+    #[arg(
+        long = "path",
+        short = 'p',
+        conflicts_with = "global",
+        conflicts_with = "local",
+        value_name = "PATH"
+    )]
     pub path: Option<String>,
     /// Source path to use for a single target
     #[arg(long = "source", short = 's', value_name = "PATH")]
@@ -1829,19 +1940,19 @@ pub struct DotfilesArgs {
 #[derive(Subcommand)]
 pub enum DotfilesCommands {
     /// Add or update dotfiles in `[dotfiles]`
-    #[command(name = "add")]
+    #[command(name = "add", hide = true)]
     Add(Box<DotfilesAddArgs>),
     /// Apply dotfiles from `[dotfiles]`
-    #[command(name = "apply")]
+    #[command(name = "apply", hide = true)]
     Apply(Box<DotfilesApplyArgs>),
     /// Edit a managed dotfile source
-    #[command(name = "edit")]
+    #[command(name = "edit", hide = true)]
     Edit(Box<DotfilesEditArgs>),
     /// Show the status of dotfiles from `[dotfiles]`
-    #[command(name = "status", visible_alias = "ls")]
+    #[command(name = "status", hide = true, visible_alias = "ls")]
     Status(Box<DotfilesStatusArgs>),
     /// Remove dotfiles applied from `[dotfiles]`
-    #[command(name = "unapply")]
+    #[command(name = "unapply", hide = true)]
     Unapply(Box<DotfilesUnapplyArgs>),
 }
 
@@ -1893,16 +2004,21 @@ pub struct EnArgs {
 #[derive(Args)]
 pub struct EnvArgs {
     /// Output in dotenv format
-    #[arg(long = "dotenv", short = 'D')]
+    #[arg(long = "dotenv", short = 'D', overrides_with = "shell")]
     pub dotenv: bool,
     /// Output in JSON format
-    #[arg(long = "json", short = 'J')]
+    #[arg(long = "json", short = 'J', overrides_with = "shell")]
     pub json: bool,
     /// Shell type to generate environment variables for
-    #[arg(long = "shell", short = 's', value_name = "SHELL", value_parser = ::clap::builder::PossibleValuesParser::new(["bash", "elvish", "fish", "nu", "xonsh", "zsh", "pwsh"]))]
+    #[arg(
+        long = "shell",
+        short = 's',
+        overrides_with = "json",
+        value_name = "SHELL"
+    )]
     pub shell: Option<String>,
     /// Output in JSON format with additional information (source, tool)
-    #[arg(long = "json-extended")]
+    #[arg(long = "json-extended", overrides_with = "shell")]
     pub json_extended: bool,
     /// Only show redacted environment variables
     #[arg(long = "redacted")]
@@ -1927,12 +2043,18 @@ pub struct EnvArgs {
 #[derive(Args)]
 pub struct ExecArgs {
     /// Command string to execute
-    #[arg(long = "command", short = 'c', value_name = "C")]
+    #[arg(
+        long = "command",
+        short = 'c',
+        conflicts_with = "command_2",
+        value_name = "COMMAND"
+    )]
     pub command: Option<String>,
     #[arg(
-        help = "Number of jobs to run in parallel\n[default: 4]",
+        help = "Number of jobs to run in parallel\nValues below 1 are treated as 1\n[default: 4]",
         long = "jobs",
         short = 'j',
+        env = "MISE_JOBS",
         value_name = "JOBS"
     )]
     pub jobs: Option<String>,
@@ -1975,14 +2097,17 @@ pub struct ExecArgs {
     /// Skip automatic dependency preparation
     #[arg(long = "no-deps")]
     pub no_deps: bool,
-    /// Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1
-    #[arg(long = "raw")]
+    #[arg(
+        help = "Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1",
+        long_help = "Connect backend install command stdin/stdout/stderr directly to the terminal\nImplies --jobs=1",
+        long = "raw",
+        overrides_with = "jobs"
+    )]
     pub raw: bool,
-    /// Tool(s) to start e.g.: node@20 python@3.10
-    #[arg(value_name = "TOOL@VERSION", num_args = 0..)]
+    #[arg(value_name = "TOOL@VERSION", help = "Tool(s) to start e.g.: node@20 python@3.10", long_help = "Tool(s) to start\ne.g.: node@20 python@3.10", num_args = 0..)]
     pub tool_version: Vec<String>,
     /// Command string to execute (same as --command)
-    #[arg(value_name = "COMMAND", num_args = 0.., last = true)]
+    #[arg(value_name = "COMMAND", conflicts_with = "command", required_unless_present = "command", num_args = 0.., last = true)]
     pub command_2: Vec<String>,
 }
 
@@ -1997,8 +2122,12 @@ pub struct FmtArgs {
     /// Check if the configs are formatted, no formatting is done
     #[arg(long = "check", short = 'c')]
     pub check: bool,
-    /// Read config from stdin and write its formatted version into stdout
-    #[arg(long = "stdin", short = 's')]
+    #[arg(
+        help = "Read config from stdin and write its formatted version into stdout",
+        long_help = "Read config from stdin and write its formatted version into\nstdout",
+        long = "stdin",
+        short = 's'
+    )]
     pub stdin: bool,
 }
 
@@ -2016,7 +2145,7 @@ pub struct GenerateBootstrapArgs {
     #[arg(long = "version", short = 'V', value_name = "VERSION")]
     pub version: Option<String>,
     /// instead of outputting the script to stdout, write to a file and make it executable
-    #[arg(long = "write", short = 'w', value_name = "WRITE")]
+    #[arg(long = "write", short = 'w', num_args = 0..=1, default_missing_value = "./bin/mise", value_name = "WRITE")]
     pub write: Option<String>,
     /// Directory to put localized data into
     #[arg(
@@ -2025,13 +2154,23 @@ pub struct GenerateBootstrapArgs {
         default_value = ".mise"
     )]
     pub localized_dir: Option<String>,
+    /// Also write a Windows launcher, `<WRITE>.cmd`
+    ///
+    /// Windows cannot execute the `#!/usr/bin/env bash` script, so a contributor who clones the
+    /// project on Windows has nothing to run without this.
+    ///
+    /// Generated on every host, not only on Windows: the file is committed, and whoever runs it
+    /// on Windows is not the person who generated it. Requires `--write`, since stdout cannot
+    /// carry two files.
+    #[arg(long = "windows", requires = "write")]
+    pub windows: bool,
 }
 
 /// Generate a mise.toml file
 #[derive(Args)]
 pub struct GenerateConfigArgs {
     /// Generate the global config file (~/.config/mise/config.toml)
-    #[arg(long = "global", short = 'g')]
+    #[arg(long = "global", short = 'g', conflicts_with = "path")]
     pub global: bool,
     /// Show what would be generated without writing to file
     #[arg(long = "dry-run", short = 'n')]
@@ -2085,6 +2224,13 @@ pub struct GenerateGitPreCommitArgs {
     /// Which hook to generate (saves to .git/hooks/$hook)
     #[arg(long = "hook", value_name = "HOOK", default_value = "pre-commit")]
     pub hook: Option<String>,
+    /// mise flags to embed in the generated hook, given after `--`
+    ///
+    /// These are inserted between `mise` and `run`, so the hook carries the same context you
+    /// would pass on the command line. Useful when the config is not at the repository root,
+    /// since git runs hooks from the top level: `-- -C subdir` makes the hook find it.
+    #[arg(value_name = "MISE_ARG", num_args = 0.., last = true)]
+    pub mise_arg: Vec<String>,
 }
 
 /// Generate a GitHub Action workflow file
@@ -2135,6 +2281,7 @@ pub struct GenerateTaskDocsArgs {
 ///
 /// By default, this will build shims like ./bin/<task>. These can be paired with `mise generate bootstrap`
 /// so contributors to a project can execute mise tasks without installing mise into their system.
+/// When a parent and nested task both exist, the parent stub is written to `<parent>/_default`.
 #[derive(Args)]
 pub struct GenerateTaskStubsArgs {
     /// Directory to create task stubs inside of
@@ -2180,18 +2327,48 @@ pub struct GenerateToolStubArgs {
     ///
     /// By default, uses the latest version from the install script.
     /// Use this to pin to a specific version (e.g., "2025.1.0").
-    #[arg(long = "bootstrap-version", value_name = "BOOTSTRAP_VERSION")]
+    #[arg(
+        long = "bootstrap-version",
+        requires = "bootstrap",
+        value_name = "BOOTSTRAP_VERSION"
+    )]
     pub bootstrap_version: Option<String>,
+    /// Checksum algorithm to use when downloading artifacts
+    ///
+    /// Accepts `blake3` or `sha256` and defaults to `blake3`.
+    /// Cannot be used with `--lock` or `--skip-download` because those modes do not
+    /// calculate checksums.
+    #[arg(long = "checksum-algorithm", conflicts_with = "lock", conflicts_with = "skip_download", value_name = "CHECKSUM_ALGORITHM", value_parser = ::clap::builder::PossibleValuesParser::new(["blake3", "sha256"]), default_value = "blake3")]
+    pub checksum_algorithm: Option<String>,
     /// Fetch checksums and sizes for an existing tool stub file
     ///
-    /// This reads an existing stub file and fills in any missing checksum/size fields by downloading the files. URLs must already be present in the stub.
-    #[arg(long = "fetch")]
+    /// This reads an existing stub file and fills in any missing checksum/size fields
+    /// by downloading the files. URLs must already be present in the stub.
+    #[arg(
+        long = "fetch",
+        conflicts_with = "url",
+        conflicts_with = "platform_url",
+        conflicts_with = "version",
+        conflicts_with = "bin",
+        conflicts_with = "platform_bin",
+        conflicts_with = "skip_download",
+        conflicts_with = "lock"
+    )]
     pub fetch: bool,
     /// HTTP backend type to use
     #[arg(long = "http", value_name = "HTTP", default_value = "http")]
     pub http: Option<String>,
-    /// Resolve and embed lockfile data (exact version + platform URLs/checksums) into an existing stub file for reproducible installs without runtime API calls
-    #[arg(long = "lock")]
+    #[arg(
+        help = "Resolve and embed lockfile data (exact version + platform URLs/checksums) into an existing stub file for reproducible installs without runtime API calls",
+        long_help = "Resolve and embed lockfile data (exact version + platform URLs/checksums)\ninto an existing stub file for reproducible installs without runtime API calls",
+        long = "lock",
+        conflicts_with = "url",
+        conflicts_with = "platform_url",
+        conflicts_with = "bin",
+        conflicts_with = "platform_bin",
+        conflicts_with = "fetch",
+        conflicts_with = "skip_download"
+    )]
     pub lock: bool,
     /// Platform-specific binary paths in the format platform:path
     ///
@@ -2200,11 +2377,15 @@ pub struct GenerateToolStubArgs {
     pub platform_bin: Vec<String>,
     /// Platform-specific URLs in the format platform:url or just url (auto-detect platform)
     ///
-    /// When the output file already exists, new platforms will be appended to the existing platforms table. Existing platform URLs will be updated if specified again.
+    /// When the output file already exists, new platforms will be appended to the existing
+    /// platforms table. Existing platform URLs will be updated if specified again.
     ///
-    /// If only a URL is provided (without platform:), the platform will be automatically detected from the URL filename.
+    /// If only a URL is provided (without platform:), the platform will be automatically
+    /// detected from the URL filename.
     ///
-    /// Examples: --platform-url linux-x64:https://... --platform-url https://nodejs.org/dist/v22.17.1/node-v22.17.1-darwin-arm64.tar.gz
+    /// Examples:
+    /// --platform-url linux-x64:https://...
+    /// --platform-url https://nodejs.org/dist/v22.17.1/node-v22.17.1-darwin-arm64.tar.gz
     #[arg(long = "platform-url", value_name = "PLATFORM_URL")]
     pub platform_url: Vec<String>,
     /// Skip downloading for checksum and binary path detection (faster but less informative)
@@ -2270,8 +2451,12 @@ pub struct GithubTokenArgs {
     /// Print only the token value
     #[arg(long = "raw")]
     pub raw: bool,
-    /// Mint a fresh OAuth token even if the cached one has not expired, via the refresh-token grant or a new device-code flow
-    #[arg(long = "refresh")]
+    #[arg(
+        help = "Mint a fresh OAuth token even if the cached one has not expired, via the refresh-token grant or a new device-code flow",
+        long_help = "Mint a fresh OAuth token even if the cached one has not\nexpired, via the refresh-token grant or a new device-code flow",
+        long = "refresh",
+        requires = "oauth"
+    )]
     pub refresh: bool,
     /// Show the full unmasked token
     #[arg(long = "unmask")]
@@ -2291,7 +2476,7 @@ pub struct GithubArgs {
 #[derive(Subcommand)]
 pub enum GithubCommands {
     /// Display the GitHub token mise will use for a given host
-    #[command(name = "token")]
+    #[command(name = "token", hide = true)]
     Token(Box<GithubTokenArgs>),
 }
 
@@ -2309,7 +2494,8 @@ pub enum GithubCommands {
 pub struct GlobalArgs {
     #[arg(
         help = "Save fuzzy version to `~/.tool-versions`\ne.g.: `mise global --fuzzy node@20` will save `node 20` to ~/.tool-versions\nthis is the default behavior unless MISE_ASDF_COMPAT=1",
-        long = "fuzzy"
+        long = "fuzzy",
+        overrides_with = "pin"
     )]
     pub fuzzy: bool,
     /// Get the path of the global config file
@@ -2317,11 +2503,12 @@ pub struct GlobalArgs {
     pub path: bool,
     #[arg(
         help = "Save exact version to `~/.tool-versions`\ne.g.: `mise global --pin node@20` will save `node 20.0.0` to ~/.tool-versions",
-        long = "pin"
+        long = "pin",
+        overrides_with = "fuzzy"
     )]
     pub pin: bool,
     /// Remove the tool(s) from ~/.tool-versions
-    #[arg(long = "remove", value_name = "TOOL")]
+    #[arg(long = "remove", alias = "rm", alias = "unset", value_name = "TOOL")]
     pub remove: Vec<String>,
     #[arg(value_name = "TOOL@VERSION", help = "Tool(s) to add to .tool-versions\ne.g.: node@20\nIf this is a single tool with no version, the current value of the global\n.tool-versions will be displayed", num_args = 0..)]
     pub tool_version: Vec<String>,
@@ -2337,7 +2524,7 @@ pub struct HookEnvArgs {
     #[arg(long = "quiet", short = 'q')]
     pub quiet: bool,
     /// Shell type to generate script for
-    #[arg(long = "shell", short = 's', value_name = "SHELL", value_parser = ::clap::builder::PossibleValuesParser::new(["bash", "elvish", "fish", "nu", "xonsh", "zsh", "pwsh"]))]
+    #[arg(long = "shell", short = 's', value_name = "SHELL")]
     pub shell: Option<String>,
     /// Reason for calling hook-env (e.g., "precmd", "chpwd")
     #[arg(long = "reason", hide = true, value_name = "REASON", value_parser = ::clap::builder::PossibleValuesParser::new(["precmd", "chpwd"]))]
@@ -2351,7 +2538,7 @@ pub struct HookEnvArgs {
 #[derive(Args)]
 pub struct HookNotFoundArgs {
     /// Shell type to generate script for
-    #[arg(long = "shell", short = 's', value_name = "SHELL", value_parser = ::clap::builder::PossibleValuesParser::new(["bash", "elvish", "fish", "nu", "xonsh", "zsh", "pwsh"]))]
+    #[arg(long = "shell", short = 's', value_name = "SHELL")]
     pub shell: Option<String>,
     /// Attempted bin to run
     #[arg(value_name = "BIN")]
@@ -2375,7 +2562,7 @@ pub struct ImplodeArgs {
 #[derive(Args)]
 pub struct EditArgs {
     /// Edit the global config file (~/.config/mise/config.toml)
-    #[arg(long = "global", short = 'g')]
+    #[arg(long = "global", short = 'g', conflicts_with = "path")]
     pub global: bool,
     /// Show what would be generated without writing to file
     #[arg(long = "dry-run", short = 'n')]
@@ -2399,13 +2586,17 @@ pub struct EditArgs {
 /// Tools will be installed in parallel. To disable, set `--jobs=1` or `MISE_JOBS=1`
 #[derive(Args)]
 pub struct InstallArgs {
-    /// Force reinstall even if already installed
-    #[arg(long = "force", short = 'f')]
+    #[arg(
+        help = "Force reinstall even if already installed\nWith no tools specified, reinstall all configured tools",
+        long = "force",
+        short = 'f'
+    )]
     pub force: bool,
     #[arg(
-        help = "Number of jobs to run in parallel\n[default: 4]",
+        help = "Number of jobs to run in parallel\nValues below 1 are treated as 1\n[default: 4]",
         long = "jobs",
         short = 'j',
+        env = "MISE_JOBS",
         value_name = "JOBS"
     )]
     pub jobs: Option<String>,
@@ -2422,34 +2613,47 @@ pub struct InstallArgs {
     /// This is useful for scripts to check if tools need to be installed.
     #[arg(long = "dry-run-code")]
     pub dry_run_code: bool,
+    /// Also install tools required by tasks in the current scope
+    ///
+    /// This prepares task tools without running task commands or dependencies.
+    /// Combine with --monorepo to include tasks from every configured root.
+    #[arg(long = "include-task-tools")]
+    pub include_task_tools: bool,
     /// Only install versions released before this date or older than this duration
     ///
     /// Supports absolute dates like "2024-06-01" and relative durations like "90d" or "1y".
-    #[arg(long = "minimum-release-age", value_name = "MINIMUM_RELEASE_AGE")]
+    #[arg(
+        long = "minimum-release-age",
+        alias = "before",
+        value_name = "MINIMUM_RELEASE_AGE"
+    )]
     pub minimum_release_age: Option<String>,
     /// Install tools from every [monorepo].config_roots config root
     ///
     /// Uses the active MISE_ENV and requires monorepo_root = true plus explicit
     /// [monorepo].config_roots in the monorepo root config.
-    #[arg(long = "monorepo")]
+    #[arg(long = "monorepo", env = "MISE_MONOREPO")]
     pub monorepo: bool,
-    /// Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1
-    #[arg(long = "raw")]
+    #[arg(
+        help = "Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1",
+        long_help = "Connect backend install command stdin/stdout/stderr directly to the terminal\nImplies --jobs=1",
+        long = "raw",
+        overrides_with = "jobs"
+    )]
     pub raw: bool,
     /// Install tool(s) to a shared directory
     ///
     /// Installs to the specified directory instead of the default install location.
     /// May require elevated permissions depending on the path.
-    #[arg(long = "shared", value_name = "SHARED")]
+    #[arg(long = "shared", conflicts_with = "system", value_name = "SHARED")]
     pub shared: Option<String>,
     /// Install tool(s) to the system-wide shared directory
     ///
     /// Installs to /usr/local/share/mise/installs (or MISE_SYSTEM_DATA_DIR/installs).
     /// May require elevated permissions (e.g. sudo).
-    #[arg(long = "system")]
+    #[arg(long = "system", conflicts_with = "shared")]
     pub system: bool,
-    /// Tool(s) to install e.g.: node@20
-    #[arg(value_name = "TOOL@VERSION", num_args = 0..)]
+    #[arg(value_name = "TOOL@VERSION", help = "Tool(s) to install e.g.: node@20", long_help = "Tool(s) to install\ne.g.: node@20", num_args = 0..)]
     pub tool_version: Vec<String>,
 }
 
@@ -2458,8 +2662,11 @@ pub struct InstallArgs {
 /// Used for building a tool to a directory for use outside of mise
 #[derive(Args)]
 pub struct InstallIntoArgs {
-    /// Tool to install e.g.: node@20
-    #[arg(value_name = "TOOL@VERSION")]
+    #[arg(
+        value_name = "TOOL@VERSION",
+        help = "Tool to install e.g.: node@20",
+        long_help = "Tool to install\ne.g.: node@20"
+    )]
     pub tool_version: String,
     /// Path to install the tool into
     #[arg(value_name = "PATH")]
@@ -2478,13 +2685,22 @@ pub struct LatestArgs {
     ///
     /// Supports absolute dates like "2024-06-01" and relative durations like "90d" or "1y".
     /// Overrides per-tool `minimum_release_age` options and the global `minimum_release_age` setting.
-    #[arg(long = "minimum-release-age", value_name = "MINIMUM_RELEASE_AGE")]
+    #[arg(
+        long = "minimum-release-age",
+        alias = "before",
+        conflicts_with = "installed",
+        value_name = "MINIMUM_RELEASE_AGE"
+    )]
     pub minimum_release_age: Option<String>,
     /// Tool to get the latest version of
     #[arg(value_name = "TOOL@VERSION")]
     pub tool_version: String,
-    /// The version prefix to use when querying the latest version same as the first argument after the "@" used for asdf compatibility
-    #[arg(value_name = "ASDF_VERSION", hide = true)]
+    #[arg(
+        value_name = "ASDF_VERSION",
+        help = "The version prefix to use when querying the latest version same as the first argument after the \"@\" used for asdf compatibility",
+        long_help = "The version prefix to use when querying the latest version\nsame as the first argument after the \"@\"\nused for asdf compatibility",
+        hide = true
+    )]
     pub asdf_version: Option<String>,
 }
 
@@ -2520,19 +2736,24 @@ pub struct LocalArgs {
         short = 'p'
     )]
     pub parent: bool,
-    /// Save fuzzy version to `.tool-versions` e.g.: `mise local --fuzzy node@20` will save `node 20` to .tool-versions This is the default behavior unless MISE_ASDF_COMPAT=1
-    #[arg(long = "fuzzy")]
+    #[arg(
+        help = "Save fuzzy version to `.tool-versions` e.g.: `mise local --fuzzy node@20` will save `node 20` to .tool-versions This is the default behavior unless MISE_ASDF_COMPAT=1",
+        long_help = "Save fuzzy version to `.tool-versions`\ne.g.: `mise local --fuzzy node@20` will save `node 20` to .tool-versions\nThis is the default behavior unless MISE_ASDF_COMPAT=1",
+        long = "fuzzy",
+        overrides_with = "pin"
+    )]
     pub fuzzy: bool,
     /// Get the path of the config file
     #[arg(long = "path")]
     pub path: bool,
     #[arg(
         help = "Save exact version to `.tool-versions`\ne.g.: `mise local --pin node@20` will save `node 20.0.0` to .tool-versions",
-        long = "pin"
+        long = "pin",
+        overrides_with = "fuzzy"
     )]
     pub pin: bool,
     /// Remove the tool(s) from .tool-versions
-    #[arg(long = "remove", value_name = "TOOL")]
+    #[arg(long = "remove", alias = "rm", alias = "unset", value_name = "TOOL")]
     pub remove: Vec<String>,
     #[arg(value_name = "TOOL@VERSION", help = "Tool(s) to add to .tool-versions/mise.toml\ne.g.: node@20\nif this is a single tool with no version,\nthe current value of .tool-versions/mise.toml will be displayed", num_args = 0..)]
     pub tool_version: Vec<String>,
@@ -2541,7 +2762,8 @@ pub struct LocalArgs {
 /// Update lockfile checksums and URLs for all specified platforms
 ///
 /// Updates checksums and download URLs for all platforms already specified in the lockfile.
-/// If no lockfile exists, shows what would be created based on the current configuration.
+/// If no lockfile exists, shows what would be created based on the current configuration,
+/// including tools declared by tasks.
 /// This allows you to refresh lockfile data for platforms other than the one you're currently on.
 /// Operates on the lockfile in the current config root. Use TOOL arguments to target specific tools.
 #[derive(Args)]
@@ -2552,8 +2774,13 @@ pub struct LockArgs {
         short = 'g'
     )]
     pub global: bool,
-    /// Number of jobs to run in parallel
-    #[arg(long = "jobs", short = 'j', value_name = "JOBS")]
+    #[arg(
+        help = "Number of jobs to run in parallel\nValues below 1 are treated as 1",
+        long = "jobs",
+        short = 'j',
+        env = "MISE_JOBS",
+        value_name = "JOBS"
+    )]
     pub jobs: Option<String>,
     /// Show what would be updated without making changes
     #[arg(long = "dry-run", short = 'n')]
@@ -2562,6 +2789,7 @@ pub struct LockArgs {
         help = "Comma-separated list of platforms to target\ne.g.: linux-x64,macos-arm64,windows-x64\nIf not specified, all platforms already in lockfile will be updated",
         long = "platform",
         short = 'p',
+        value_delimiter = ',',
         value_name = "PLATFORM"
     )]
     pub platform: Vec<String>,
@@ -2598,9 +2826,13 @@ pub struct LockArgs {
     /// This only affects fuzzy version matches like "20" or "latest".
     /// Explicitly pinned versions like "22.5.0" are not filtered.
     /// Existing matching lockfile entries are preserved and are not downgraded solely by this flag.
-    #[arg(long = "minimum-release-age", value_name = "MINIMUM_RELEASE_AGE")]
+    #[arg(
+        long = "minimum-release-age",
+        alias = "before",
+        value_name = "MINIMUM_RELEASE_AGE"
+    )]
     pub minimum_release_age: Option<String>,
-    #[arg(value_name = "TOOL", help = "Tool(s) to update in lockfile\ne.g.: node python\nIf not specified, all tools in lockfile will be updated", num_args = 0..)]
+    #[arg(value_name = "TOOL", help = "Tool(s) to update in lockfile\ne.g.: node python\nIf not specified, all configured and task-specific tools will be updated", num_args = 0..)]
     pub tool: Vec<String>,
 }
 
@@ -2617,48 +2849,63 @@ pub struct LsArgs {
     #[arg(long = "current", short = 'c')]
     pub current: bool,
     /// Only show tool versions currently specified in the global mise.toml
-    #[arg(long = "global", short = 'g')]
+    #[arg(long = "global", short = 'g', conflicts_with = "local")]
     pub global: bool,
-    /// Only show tool versions that are installed (Hides tools defined in mise.toml but not installed)
-    #[arg(long = "installed", short = 'i')]
+    #[arg(
+        help = "Only show tool versions that are installed (Hides tools defined in mise.toml but not installed)",
+        long_help = "Only show tool versions that are installed\n(Hides tools defined in mise.toml but not installed)",
+        long = "installed",
+        short = 'i'
+    )]
     pub installed: bool,
     /// Output in JSON format
     #[arg(long = "json", short = 'J')]
     pub json: bool,
     /// Only show tool versions currently specified in the local mise.toml
-    #[arg(long = "local", short = 'l')]
+    #[arg(long = "local", short = 'l', conflicts_with = "global")]
     pub local: bool,
     /// Display missing tool versions
-    #[arg(long = "missing", short = 'm')]
+    #[arg(long = "missing", short = 'm', conflicts_with = "installed")]
     pub missing: bool,
     /// Don't fetch information such as outdated versions
     #[arg(long = "offline", short = 'o', hide = true)]
     pub offline: bool,
-    #[arg(long = "plugin", short = 'p', hide = true, value_name = "TOOL_FLAG")]
+    #[arg(long = "plugin", short = 'p', hide = true, value_name = "PLUGIN")]
     pub plugin: Option<String>,
     /// Display all tracked config sources for tools
-    #[arg(long = "all-sources")]
+    #[arg(
+        long = "all-sources",
+        conflicts_with = "current",
+        conflicts_with = "global",
+        conflicts_with = "local",
+        conflicts_with = "prunable"
+    )]
     pub all_sources: bool,
     /// List tools from every [monorepo].config_roots config root
     ///
     /// Uses the active MISE_ENV and requires monorepo_root = true plus explicit
     /// [monorepo].config_roots in the monorepo root config.
-    #[arg(long = "monorepo")]
+    #[arg(
+        long = "monorepo",
+        env = "MISE_MONOREPO",
+        conflicts_with = "all_sources",
+        conflicts_with = "prunable"
+    )]
     pub monorepo: bool,
     /// Don't display headers
-    #[arg(long = "no-header")]
+    #[arg(long = "no-header", alias = "no-headers", conflicts_with = "json")]
     pub no_header: bool,
     /// Display whether a version is outdated
     #[arg(long = "outdated")]
     pub outdated: bool,
     /// Display versions matching this prefix
-    #[arg(long = "prefix", value_name = "PREFIX")]
+    #[arg(long = "prefix", requires = "installed_tool", value_name = "PREFIX")]
     pub prefix: Option<String>,
     /// List only tools that can be pruned with `mise prune`
     #[arg(long = "prunable")]
     pub prunable: bool,
     /// Only show tool versions from [TOOL]
-    #[arg(value_name = "INSTALLED_TOOL", num_args = 0..)]
+    #[arg(value_name = "INSTALLED_TOOL", conflicts_with = "plugin", num_args = 0..)]
     pub installed_tool: Vec<String>,
 }
 
@@ -2668,12 +2915,20 @@ pub struct LsArgs {
 #[derive(Args)]
 pub struct LsRemoteArgs {
     /// Show all installed plugins and versions
-    #[arg(long = "all")]
+    #[arg(
+        long = "all",
+        conflicts_with = "tool_version",
+        conflicts_with = "prefix"
+    )]
     pub all: bool,
     /// Only show versions released before this age or date
     ///
     /// Supports absolute dates like "2024-06-01" and relative durations like "90d" or "1y".
-    #[arg(long = "minimum-release-age", value_name = "MINIMUM_RELEASE_AGE")]
+    #[arg(
+        long = "minimum-release-age",
+        alias = "before",
+        value_name = "MINIMUM_RELEASE_AGE"
+    )]
     pub minimum_release_age: Option<String>,
     /// Output in JSON format (includes version metadata like created_at timestamps when available)
     #[arg(long = "json", short = 'J')]
@@ -2692,10 +2947,14 @@ pub struct LsRemoteArgs {
     ///
     /// This prevents metadata consumers from accepting empty fallback results
     /// when a backend's metadata-producing upstream request fails.
-    #[arg(long = "strict-metadata")]
+    #[arg(
+        long = "strict-metadata",
+        requires = "json",
+        requires = "no_versions_host"
+    )]
     pub strict_metadata: bool,
     /// Tool to get versions for
-    #[arg(value_name = "TOOL@VERSION")]
+    #[arg(value_name = "TOOL@VERSION", required_unless_present = "all")]
     pub tool_version: Option<String>,
     #[arg(
         value_name = "PREFIX",
@@ -2759,7 +3018,12 @@ pub struct OciBuildArgs {
     pub from: Option<String>,
     /// Also include tools from the global / system config (default: project-only)
     ///
-    /// By default `mise oci build` only packages tools declared in the project's mise config (and any parent configs at-or-below the project root, e.g. a monorepo root config). Personal dev tools in `~/.config/mise/config.toml` are excluded so they don't bake into a project image. Pass `--include-global` to revert to the old "merge all loaded configs" behavior.
+    /// By default `mise oci build` only packages tools declared in the
+    /// project's mise config (and any parent configs at-or-below the
+    /// project root, e.g. a monorepo root config). Personal dev tools in
+    /// `~/.config/mise/config.toml` are excluded so they don't bake into a
+    /// project image. Pass `--include-global` to revert to the old
+    /// "merge all loaded configs" behavior.
     #[arg(long = "include-global")]
     pub include_global: bool,
     /// Tag to record in the image index (the org.opencontainers.image.ref.name annotation)
@@ -2773,7 +3037,9 @@ pub struct OciBuildArgs {
     pub no_mise: bool,
     /// UID[:GID] to assign to every tar entry in generated layers
     ///
-    /// Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive.
+    /// Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is
+    /// omitted, it defaults to UID. This affects file ownership only; [oci].user
+    /// controls the image USER directive.
     #[arg(long = "owner", value_name = "UID[:GID]")]
     pub owner: Option<String>,
 }
@@ -2801,14 +3067,29 @@ pub struct OciBuildArgs {
 pub struct OciPushArgs {
     /// Reuse unchanged tool layers from this image instead of the destination ref
     ///
-    /// Must live in the same repository as the destination. Useful when each push gets a unique tag (e.g. per-commit tags in CI): `--cache-from ghcr.io/me/dev:latest ghcr.io/me/dev:$SHA`.
-    #[arg(long = "cache-from", value_name = "REF")]
+    /// Must live in the same repository as the destination. Useful when each
+    /// push gets a unique tag (e.g. per-commit tags in CI):
+    /// `--cache-from ghcr.io/me/dev:latest ghcr.io/me/dev:$SHA`.
+    #[arg(
+        long = "cache-from",
+        conflicts_with = "no_cache",
+        conflicts_with = "image_dir",
+        value_name = "REF"
+    )]
     pub cache_from: Option<String>,
     /// Base image for the build (ignored with --image-dir)
     #[arg(long = "from", value_name = "FROM")]
     pub from: Option<String>,
     /// Push an already-built OCI image layout (skip the build step)
-    #[arg(long = "image-dir", value_name = "IMAGE_DIR")]
+    #[arg(
+        long = "image-dir",
+        conflicts_with = "from",
+        conflicts_with = "mount_point",
+        conflicts_with = "no_mise",
+        conflicts_with = "owner",
+        conflicts_with = "include_global",
+        value_name = "IMAGE_DIR"
+    )]
     pub image_dir: Option<String>,
     /// Also include tools from the global / system config (default: project-only)
     ///
@@ -2826,12 +3107,17 @@ pub struct OciPushArgs {
     pub no_mise: bool,
     /// UID[:GID] to assign to every tar entry when building (conflicts with --image-dir)
     ///
-    /// Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive.
+    /// Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is
+    /// omitted, it defaults to UID. This affects file ownership only; [oci].user
+    /// controls the image USER directive.
     #[arg(long = "owner", value_name = "UID[:GID]")]
     pub owner: Option<String>,
     /// Maintain the tag as a multi-arch image index
     ///
-    /// Pushes this build's manifest by digest and points the tag at an OCI image index containing one entry per platform, preserving entries other architectures pushed. Run `mise oci push --update-index` from one runner per platform to assemble a multi-arch tag.
+    /// Pushes this build's manifest by digest and points the tag at an OCI
+    /// image index containing one entry per platform, preserving entries
+    /// other architectures pushed. Run `mise oci push --update-index` from
+    /// one runner per platform to assemble a multi-arch tag.
     #[arg(long = "update-index")]
     pub update_index: bool,
     /// Destination registry reference (e.g. `ghcr.io/me/devenv:latest`)
@@ -2857,7 +3143,15 @@ pub struct OciRunArgs {
     #[arg(long = "from", value_name = "FROM")]
     pub from: Option<String>,
     /// Use an already-built OCI image layout instead of building fresh
-    #[arg(long = "image-dir", value_name = "IMAGE_DIR")]
+    #[arg(
+        long = "image-dir",
+        conflicts_with = "from",
+        conflicts_with = "mount_point",
+        conflicts_with = "no_mise",
+        conflicts_with = "owner",
+        conflicts_with = "include_global",
+        value_name = "IMAGE_DIR"
+    )]
     pub image_dir: Option<String>,
     /// Also include tools from the global / system config (default: project-only)
     ///
@@ -2866,7 +3160,11 @@ pub struct OciRunArgs {
     pub include_global: bool,
     /// Keep the loaded image in the engine's storage after the run
     ///
-    /// By default, both the container (`--rm`) and the loaded image are removed when the command exits, so repeated `mise oci run` calls don't accumulate images in podman / docker storage. Pass `--keep` to retain the image under the tag mise used (`mise-oci:run-*` for docker; the pulled image ID for podman).
+    /// By default, both the container (`--rm`) and the loaded image are
+    /// removed when the command exits, so repeated `mise oci run` calls
+    /// don't accumulate images in podman / docker storage. Pass `--keep`
+    /// to retain the image under the tag mise used (`mise-oci:run-*` for
+    /// docker; the pulled image ID for podman).
     #[arg(long = "keep")]
     pub keep: bool,
     /// Override in-image mount point (ignored with --image-dir)
@@ -2877,13 +3175,16 @@ pub struct OciRunArgs {
     pub no_mise: bool,
     /// UID[:GID] to assign to every tar entry when building (conflicts with --image-dir)
     ///
-    /// Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive.
+    /// Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is
+    /// omitted, it defaults to UID. This affects file ownership only; [oci].user
+    /// controls the image USER directive.
     #[arg(long = "owner", value_name = "UID[:GID]")]
     pub owner: Option<String>,
     /// Bind-mount a host path (repeatable, `HOST:CONTAINER[:MODE]`)
     ///
-    /// Note: unlike `docker run -v`, there's no `-v` short flag here because mise reserves `-v` for --verbose. Use `--volume` or `--mount`.
-    #[arg(long = "volume", value_name = "HOST:CONTAINER")]
+    /// Note: unlike `docker run -v`, there's no `-v` short flag here because
+    /// mise reserves `-v` for --verbose. Use `--volume` or `--mount`.
+    #[arg(long = "volume", alias = "mount", value_name = "HOST:CONTAINER")]
     pub volume: Vec<String>,
     /// Set environment variable in the container (repeatable, `KEY=VAL`)
     #[arg(long = "env", short = 'e', value_name = "KEY=VAL")]
@@ -2935,21 +3236,24 @@ pub enum OciCommands {
 /// See `mise upgrade` to upgrade these versions.
 #[derive(Args)]
 pub struct OutdatedArgs {
-    /// Output in JSON format
-    #[arg(long = "json", short = 'J')]
-    pub json: bool,
     /// Compares against the latest versions available, not what matches the current config
     ///
     /// For example, if you have `node = "20"` in your config by default `mise outdated` will only
     /// show other 20.x versions, not 21.x or 22.x versions.
     ///
     /// Using this flag, if there are 21.x or newer versions it will display those instead of 20.x.
-    #[arg(long = "bump", short = 'l')]
+    #[arg(long = "bump", short = 'b')]
     pub bump: bool,
+    /// Output in JSON format
+    #[arg(long = "json", short = 'J')]
+    pub json: bool,
+    /// Deprecated shorthand for --bump
+    #[arg(short = 'l', hide = true)]
+    pub l: bool,
     /// Show outdated tools including installed-but-inactive tools not present in the current config
     ///
     /// By default, `mise outdated` only shows tools that come from the current config.
-    #[arg(long = "inactive")]
+    #[arg(long = "inactive", conflicts_with = "local")]
     pub inactive: bool,
     /// Only show outdated tools defined in local config files
     ///
@@ -2995,21 +3299,28 @@ pub struct PluginsInstallArgs {
     #[arg(
         help = "Install all missing plugins\nThis will only install plugins that have matching shorthands.\ni.e.: they don't need the full git repo url",
         long = "all",
-        short = 'a'
+        short = 'a',
+        conflicts_with = "new_plugin",
+        conflicts_with = "force"
     )]
     pub all: bool,
     /// Reinstall even if plugin exists
     #[arg(long = "force", short = 'f')]
     pub force: bool,
-    /// Number of jobs to run in parallel
-    #[arg(long = "jobs", short = 'j', value_name = "JOBS")]
+    #[arg(
+        help = "Number of jobs to run in parallel\nValues below 1 are treated as 1",
+        long = "jobs",
+        short = 'j',
+        value_name = "JOBS"
+    )]
     pub jobs: Option<String>,
     /// Show installation output
     #[arg(long = "verbose", short = 'v', action = ::clap::ArgAction::Count)]
     pub verbose: u8,
     #[arg(
         value_name = "NEW_PLUGIN",
-        help = "The name of the plugin to install\ne.g.: cmake, poetry\nCan specify multiple plugins: `mise plugins install cmake poetry`"
+        help = "The name of the plugin to install\ne.g.: cmake, poetry\nCan specify multiple plugins: `mise plugins install cmake poetry`",
+        required_unless_present = "all"
     )]
     pub new_plugin: Option<String>,
     /// The git url of the plugin
@@ -3055,7 +3366,8 @@ pub struct PluginsLsArgs {
         help = "The built-in plugins only\nNormally these are not shown",
         long = "core",
         short = 'c',
-        hide = true
+        hide = true,
+        conflicts_with = "all"
     )]
     pub core: bool,
     #[arg(
@@ -3067,7 +3379,8 @@ pub struct PluginsLsArgs {
     #[arg(
         help = "Show the git url for each plugin\ne.g.: https://github.com/mise-plugins/vfox-cmake.git",
         long = "urls",
-        short = 'u'
+        short = 'u',
+        alias = "url"
     )]
     pub urls: bool,
     #[arg(
@@ -3077,17 +3390,24 @@ pub struct PluginsLsArgs {
     )]
     pub refs: bool,
     /// List installed plugins
-    #[arg(long = "user", hide = true)]
+    #[arg(long = "user", hide = true, conflicts_with = "all")]
     pub user: bool,
 }
 
 #[derive(Args)]
 pub struct PluginsLsRemoteArgs {
-    /// Show the git url for each plugin e.g.: https://github.com/mise-plugins/mise-poetry.git
-    #[arg(long = "urls", short = 'u')]
+    #[arg(
+        help = "Show the git url for each plugin e.g.: https://github.com/mise-plugins/mise-poetry.git",
+        long_help = "Show the git url for each plugin\ne.g.: https://github.com/mise-plugins/mise-poetry.git",
+        long = "urls",
+        short = 'u'
+    )]
     pub urls: bool,
-    /// Only show the name of each plugin by default it will show a "*" next to installed plugins
-    #[arg(long = "only-names")]
+    #[arg(
+        help = "Only show the name of each plugin by default it will show a \"*\" next to installed plugins",
+        long_help = "Only show the name of each plugin\nby default it will show a \"*\" next to installed plugins",
+        long = "only-names"
+    )]
     pub only_names: bool,
 }
 
@@ -3095,7 +3415,7 @@ pub struct PluginsLsRemoteArgs {
 #[derive(Args)]
 pub struct PluginsUninstallArgs {
     /// Remove all plugins
-    #[arg(long = "all", short = 'a')]
+    #[arg(long = "all", short = 'a', conflicts_with = "plugin")]
     pub all: bool,
     /// Also remove the plugin's installs, downloads, and cache
     #[arg(long = "purge", short = 'p')]
@@ -3111,7 +3431,7 @@ pub struct PluginsUninstallArgs {
 #[derive(Args)]
 pub struct PluginsUpdateArgs {
     #[arg(
-        help = "Number of jobs to run in parallel\nDefault: 4",
+        help = "Number of jobs to run in parallel\nValues below 1 are treated as 1\nDefault: 4",
         long = "jobs",
         short = 'j',
         value_name = "JOBS"
@@ -3133,13 +3453,15 @@ pub struct PluginsArgs {
     #[arg(
         help = "The built-in plugins only\nNormally these are not shown",
         long = "core",
-        short = 'c'
+        short = 'c',
+        conflicts_with = "all"
     )]
     pub core: bool,
     #[arg(
         help = "Show the git url for each plugin\ne.g.: https://github.com/mise-plugins/vfox-cmake.git",
         long = "urls",
-        short = 'u'
+        short = 'u',
+        alias = "url"
     )]
     pub urls: bool,
     #[arg(
@@ -3152,7 +3474,7 @@ pub struct PluginsArgs {
     ///
     /// This is the default behavior but can be used with --core
     /// to show core and user plugins
-    #[arg(long = "user")]
+    #[arg(long = "user", conflicts_with = "all")]
     pub user: bool,
     #[command(subcommand)]
     pub command: Option<PluginsCommands>,
@@ -3216,7 +3538,7 @@ pub struct DepsInstallArgs {
     ///
     /// Requires monorepo_root = true plus explicit [monorepo].config_roots in
     /// the monorepo root config. Providers are named like //apps/api:uv.
-    #[arg(long = "monorepo")]
+    #[arg(long = "monorepo", env = "MISE_MONOREPO")]
     pub monorepo: bool,
     /// Run specific deps rule(s) only
     #[arg(long = "only", value_name = "ONLY")]
@@ -3267,7 +3589,7 @@ pub struct DepsArgs {
     ///
     /// Requires monorepo_root = true plus explicit [monorepo].config_roots in
     /// the monorepo root config. Providers are named like //apps/api:uv.
-    #[arg(long = "monorepo")]
+    #[arg(long = "monorepo", env = "MISE_MONOREPO")]
     pub monorepo: bool,
     /// Run specific deps rule(s) only
     #[arg(long = "only", value_name = "ONLY")]
@@ -3349,11 +3671,12 @@ pub struct RegistryArgs {
     /// Output in JSON format
     #[arg(long = "json", short = 'J')]
     pub json: bool,
-    #[arg(
-        help = "Include security features for each tool's backends in JSON output",
-        long_help = "Include security features for each tool's backends in JSON output.\n\nRequires --json. Security info is de-duplicated across all of a tool's backends. This can add noticeable time for large listings since each backend's security info is resolved individually.",
-        long = "security"
-    )]
+    /// Include security features for each tool's backends in JSON output.
+    ///
+    /// Requires --json. Security info is de-duplicated across
+    /// all of a tool's backends. This can add noticeable time for large
+    /// listings since each backend's security info is resolved individually.
+    #[arg(long = "security", requires = "json")]
     pub security: bool,
     /// Show only the specified tool's full name
     #[arg(value_name = "NAME")]
@@ -3426,21 +3749,34 @@ pub struct RunArgs {
     #[arg(
         help = "Git base revision for --affected\nDefaults to MISE_AFFECTED_BASE, CI metadata, or HEAD~1",
         long = "affected-base",
+        requires = "affected",
         value_name = "REV"
     )]
     pub affected_base: Option<String>,
     /// Explain why projects and tasks were selected by --affected
-    #[arg(long = "affected-explain")]
+    #[arg(
+        long = "affected-explain",
+        requires = "affected",
+        conflicts_with = "affected_json"
+    )]
     pub affected_explain: bool,
     #[arg(
         help = "Git head revision for --affected\nDefaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD",
         long = "affected-head",
+        requires = "affected",
         value_name = "REV"
     )]
     pub affected_head: Option<String>,
     /// Output affected projects and tasks as JSON without running tasks
-    #[arg(long = "affected-json")]
+    #[arg(
+        long = "affected-json",
+        requires = "affected",
+        conflicts_with = "affected_explain"
+    )]
     pub affected_json: bool,
+    /// Open the interactive selector with all tasks from the entire monorepo
+    #[arg(long = "all", conflicts_with = "affected")]
+    pub all: bool,
     /// Continue running tasks even if one fails
     #[arg(long = "continue-on-error", short = 'c')]
     pub continue_on_error: bool,
@@ -3451,9 +3787,10 @@ pub struct RunArgs {
     #[arg(long = "force", short = 'f')]
     pub force: bool,
     #[arg(
-        help = "Number of tasks to run in parallel\n[default: 4]\nConfigure with `jobs` config or `MISE_JOBS` env var",
+        help = "Number of tasks to run in parallel\nValues below 1 are treated as 1\n[default: 4]\nConfigure with `jobs` config or `MISE_JOBS` env var",
         long = "jobs",
         short = 'j',
+        env = "MISE_JOBS",
         value_name = "JOBS"
     )]
     pub jobs: Option<String>,
@@ -3469,10 +3806,15 @@ pub struct RunArgs {
     /// - `keep-order` - Print stdout/stderr by line, prefixed with the task's label, but keep the order of the output
     /// - `quiet` - Don't show extra output
     /// - `silent` - Don't show any output including stdout and stderr from the task except for errors
-    #[arg(long = "output", short = 'o', value_name = "OUTPUT")]
+    #[arg(
+        long = "output",
+        short = 'o',
+        env = "MISE_TASK_OUTPUT",
+        value_name = "OUTPUT"
+    )]
     pub output: Option<String>,
     /// Don't show extra output
-    #[arg(long = "quiet", short = 'q')]
+    #[arg(long = "quiet", short = 'q', env = "MISE_QUIET")]
     pub quiet: bool,
     #[arg(
         help = "Read/write directly to stdin/stdout/stderr instead of by line\nRedactions are not applied with this option\nConfigure with `raw` config or `MISE_RAW` env var",
@@ -3488,10 +3830,15 @@ pub struct RunArgs {
     #[arg(long = "shell", short = 's', value_name = "SHELL")]
     pub shell: Option<String>,
     /// Don't show any output except for errors
-    #[arg(long = "silent", short = 'S')]
+    #[arg(long = "silent", short = 'S', env = "MISE_SILENT")]
     pub silent: bool,
-    /// Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10
-    #[arg(long = "tool", short = 't', value_name = "TOOL@VERSION")]
+    #[arg(
+        help = "Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10",
+        long_help = "Tool(s) to run in addition to what is in mise.toml files\ne.g.: node@20 python@3.10",
+        long = "tool",
+        short = 't',
+        value_name = "TOOL@VERSION"
+    )]
     pub tool: Vec<String>,
     #[arg(
         help = "Allow specific env var through (implies --deny-env for everything else)\nSupports wildcards, e.g. --allow-env='MYAPP_*'",
@@ -3527,7 +3874,7 @@ pub struct RunArgs {
     #[arg(long = "fresh-env")]
     pub fresh_env: bool,
     /// Do not use cache on remote tasks
-    #[arg(long = "no-cache")]
+    #[arg(long = "no-cache", env = "MISE_TASK_REMOTE_NO_CACHE")]
     pub no_cache: bool,
     /// Skip automatic dependency preparation
     #[arg(long = "no-deps")]
@@ -3535,10 +3882,10 @@ pub struct RunArgs {
     /// Hides elapsed time after each task completes
     ///
     /// Default to always hide with `MISE_TASK_TIMINGS=0`
-    #[arg(long = "no-timings")]
+    #[arg(long = "no-timings", alias = "no-timing")]
     pub no_timings: bool,
     /// Run only the specified tasks skipping all dependencies
-    #[arg(long = "skip-deps")]
+    #[arg(long = "skip-deps", env = "MISE_TASK_SKIP_DEPENDS")]
     pub skip_deps: bool,
     /// Skip installing tools before running tasks
     ///
@@ -3553,16 +3900,20 @@ pub struct RunArgs {
     /// - `write-only` - Write new results without reading cached results
     /// - `off` - Disable task output caching
     /// - `local-only` - Read and write only the local cache; currently equivalent to `read-write`
-    #[arg(long = "task-cache", value_name = "TASK_CACHE", value_parser = ::clap::builder::PossibleValuesParser::new(["read-write", "read-only", "write-only", "off", "local-only"]), default_value = "read-write")]
+    #[arg(long = "task-cache", env = "MISE_TASK_CACHE", value_name = "TASK_CACHE", value_parser = ::clap::builder::PossibleValuesParser::new(["read-write", "read-only", "write-only", "off", "local-only"]), default_value = "read-write")]
     pub task_cache: Option<String>,
     /// Explain the inputs that produced each task's output cache key
     #[arg(long = "task-cache-explain")]
     pub task_cache_explain: bool,
     /// Output cache-key input details as JSON Lines without running tasks
-    #[arg(long = "task-cache-explain-json")]
+    #[arg(
+        long = "task-cache-explain-json",
+        requires = "dry_run",
+        conflicts_with = "task_cache_explain"
+    )]
     pub task_cache_explain_json: bool,
     /// Report task output cache hits, restored bytes, and time saved
-    #[arg(long = "task-cache-stats")]
+    #[arg(long = "task-cache-stats", conflicts_with = "dry_run")]
     pub task_cache_stats: bool,
     #[arg(
         help = "Timeout for the task to complete\ne.g.: 30s, 5m",
@@ -3573,7 +3924,7 @@ pub struct RunArgs {
     /// Shows elapsed time after each task completes
     ///
     /// Default to always show with `MISE_TASK_TIMINGS=1`
-    #[arg(long = "timings", hide = true)]
+    #[arg(long = "timings", alias = "timing", hide = true)]
     pub timings: bool,
 }
 
@@ -3586,13 +3937,18 @@ pub struct RunArgs {
 #[derive(Args)]
 pub struct SearchArgs {
     /// Show interactive search
-    #[arg(long = "interactive", short = 'i')]
+    #[arg(
+        long = "interactive",
+        short = 'i',
+        conflicts_with = "match_type",
+        conflicts_with = "no_header"
+    )]
     pub interactive: bool,
     /// Match type: equal, contains, or fuzzy
     #[arg(long = "match-type", short = 'm', value_name = "MATCH_TYPE", value_parser = ::clap::builder::PossibleValuesParser::new(["equal", "contains", "fuzzy"]), default_value = "fuzzy")]
     pub match_type: Option<String>,
     /// Don't display headers
-    #[arg(long = "no-header")]
+    #[arg(long = "no-header", alias = "no-headers")]
     pub no_header: bool,
     /// The tool to search for
     #[arg(value_name = "NAME")]
@@ -3635,28 +3991,47 @@ pub struct SelfUpdateArgs {
 #[derive(Args)]
 pub struct SetArgs {
     /// Create/modify an environment-specific config file like .mise.<env>.toml
-    #[arg(long = "env", short = 'E', value_name = "ENV")]
+    #[arg(
+        long = "env",
+        short = 'E',
+        overrides_with = "global",
+        overrides_with = "file",
+        value_name = "ENV"
+    )]
     pub env: Option<String>,
     /// Set the environment variable in the global config file
-    #[arg(long = "global", short = 'g')]
+    #[arg(
+        long = "global",
+        short = 'g',
+        overrides_with = "file",
+        overrides_with = "env"
+    )]
     pub global: bool,
     /// [experimental] Encrypt the value with age before storing
-    #[arg(long = "age-encrypt")]
+    #[arg(long = "age-encrypt", requires = "env_var")]
     pub age_encrypt: bool,
     /// [experimental] Age identity file for encryption
     ///
     /// Defaults to ~/.config/mise/age.txt if it exists
-    #[arg(long = "age-key-file", value_name = "PATH")]
+    #[arg(long = "age-key-file", requires = "age_encrypt", value_name = "PATH")]
     pub age_key_file: Option<String>,
     /// [experimental] Age recipient (x25519 public key) for encryption
     ///
     /// Can be used multiple times. Requires --age-encrypt.
-    #[arg(long = "age-recipient", value_name = "RECIPIENT")]
+    #[arg(
+        long = "age-recipient",
+        requires = "age_encrypt",
+        value_name = "RECIPIENT"
+    )]
     pub age_recipient: Vec<String>,
     /// [experimental] SSH recipient (public key or path) for age encryption
     ///
     /// Can be used multiple times. Requires --age-encrypt.
-    #[arg(long = "age-ssh-recipient", value_name = "PATH_OR_PUBKEY")]
+    #[arg(
+        long = "age-ssh-recipient",
+        requires = "age_encrypt",
+        value_name = "PATH_OR_PUBKEY"
+    )]
     pub age_ssh_recipient: Vec<String>,
     /// Render completions
     #[arg(long = "complete", hide = true)]
@@ -3687,8 +4062,9 @@ pub struct SetArgs {
     pub remove: Vec<String>,
     /// Read the value from stdin (for multiline input)
     ///
-    /// When using --stdin, provide a single key without a value. The value will be read from stdin until EOF.
-    #[arg(long = "stdin")]
+    /// When using --stdin, provide a single key without a value.
+    /// The value will be read from stdin until EOF.
+    #[arg(long = "stdin", requires = "env_var", conflicts_with = "prompt")]
     pub stdin: bool,
     #[arg(value_name = "ENV_VAR", help = "Environment variable(s) to set\ne.g.: NODE_ENV=production", num_args = 0..)]
     pub env_var: Vec<String>,
@@ -3734,24 +4110,26 @@ pub struct SettingsGetArgs {
 /// Note that aliases are also stored in this file
 /// but managed separately with `mise tool-alias`
 #[derive(Args)]
+#[group(skip)]
+#[command(group = ::clap::ArgGroup::new("output").required(false).multiple(false))]
 pub struct SettingsLsArgs {
     /// List all settings
     #[arg(long = "all", short = 'a')]
     pub all: bool,
     /// Output in JSON format
-    #[arg(long = "json", short = 'J')]
+    #[arg(long = "json", short = 'J', group = "output")]
     pub json: bool,
     /// Use the local config file instead of the global one
     #[arg(long = "local", short = 'l', global = true)]
     pub local: bool,
     /// Output in TOML format
-    #[arg(long = "toml", short = 'T')]
+    #[arg(long = "toml", short = 'T', group = "output")]
     pub toml: bool,
     /// Print all settings with descriptions for shell completions
     #[arg(long = "complete", hide = true)]
     pub complete: bool,
     /// Output in JSON format with sources
-    #[arg(long = "json-extended")]
+    #[arg(long = "json-extended", group = "output")]
     pub json_extended: bool,
     /// Name of setting
     #[arg(value_name = "SETTING")]
@@ -3789,25 +4167,28 @@ pub struct SettingsUnsetArgs {
     pub key: String,
 }
 
+/// Manage settings
 #[derive(Args)]
+#[group(skip)]
+#[command(group = ::clap::ArgGroup::new("output").required(false).multiple(false))]
 pub struct SettingsArgs {
     /// List all settings
     #[arg(long = "all", short = 'a')]
     pub all: bool,
     /// Output in JSON format
-    #[arg(long = "json", short = 'J')]
+    #[arg(long = "json", short = 'J', group = "output")]
     pub json: bool,
     /// Use the local config file instead of the global one
     #[arg(long = "local", short = 'l', global = true)]
     pub local: bool,
     /// Output in TOML format
-    #[arg(long = "toml", short = 'T')]
+    #[arg(long = "toml", short = 'T', group = "output")]
     pub toml: bool,
     /// Print all settings with descriptions for shell completions
     #[arg(long = "complete", hide = true)]
     pub complete: bool,
     /// Output in JSON format with sources
-    #[arg(long = "json-extended")]
+    #[arg(long = "json-extended", group = "output")]
     pub json_extended: bool,
     /// Name of setting
     #[arg(value_name = "SETTING")]
@@ -3847,17 +4228,22 @@ pub enum SettingsCommands {
 #[derive(Args)]
 pub struct ShellArgs {
     #[arg(
-        help = "Number of jobs to run in parallel\n[default: 4]",
+        help = "Number of jobs to run in parallel\nValues below 1 are treated as 1\n[default: 4]",
         long = "jobs",
         short = 'j',
+        env = "MISE_JOBS",
         value_name = "JOBS"
     )]
     pub jobs: Option<String>,
     /// Removes a previously set version
     #[arg(long = "unset", short = 'u')]
     pub unset: bool,
-    /// Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1
-    #[arg(long = "raw")]
+    #[arg(
+        help = "Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1",
+        long_help = "Connect backend install command stdin/stdout/stderr directly to the terminal\nImplies --jobs=1",
+        long = "raw",
+        overrides_with = "jobs"
+    )]
     pub raw: bool,
     /// Tool(s) to use
     #[arg(value_name = "TOOL@VERSION", required = true, num_args = 0..)]
@@ -3940,17 +4326,19 @@ pub struct SponsorsArgs {}
 ///
 /// For example, use this to import all Homebrew node installs into mise
 ///
-/// This won't overwrite any existing installs but will overwrite any existing symlinks
+/// This won't overwrite managed installs, runtime aliases, or links from other providers.
 #[derive(Args)]
+#[group(skip)]
+#[command(group = ::clap::ArgGroup::new("SyncNodeType").required(true).multiple(true))]
 pub struct SyncNodeArgs {
     /// Get tool versions from Homebrew
-    #[arg(long = "brew")]
+    #[arg(long = "brew", group = "SyncNodeType")]
     pub brew: bool,
     /// Get tool versions from nodenv
-    #[arg(long = "nodenv")]
+    #[arg(long = "nodenv", group = "SyncNodeType")]
     pub nodenv: bool,
     /// Get tool versions from nvm
-    #[arg(long = "nvm")]
+    #[arg(long = "nvm", group = "SyncNodeType")]
     pub nvm: bool,
 }
 
@@ -3958,7 +4346,7 @@ pub struct SyncNodeArgs {
 ///
 /// For example, use this to import all pyenv installs into mise
 ///
-/// This won't overwrite any existing installs but will overwrite any existing symlinks
+/// This won't overwrite managed installs, runtime aliases, or links from other providers.
 #[derive(Args)]
 pub struct SyncPythonArgs {
     /// Get tool versions from pyenv
@@ -3973,7 +4361,7 @@ pub struct SyncPythonArgs {
 #[derive(Args)]
 pub struct SyncRubyArgs {
     /// Get tool versions from Homebrew
-    #[arg(long = "brew")]
+    #[arg(long = "brew", required = true)]
     pub brew: bool,
 }
 
@@ -4059,7 +4447,7 @@ pub struct TasksAddArgs {
 #[derive(Args)]
 pub struct TasksDepsArgs {
     /// Collapse repeated dependencies after their first occurrence
-    #[arg(long = "compact")]
+    #[arg(long = "compact", conflicts_with = "dot")]
     pub compact: bool,
     /// Display dependencies in DOT format
     #[arg(long = "dot")]
@@ -4091,10 +4479,10 @@ pub struct TasksGraphArgs {
     #[arg(long = "json", short = 'J')]
     pub json: bool,
     /// Explain provider attribution for inferred projects and tasks
-    #[arg(long = "explain")]
+    #[arg(long = "explain", conflicts_with = "json")]
     pub explain: bool,
     /// Do not print table headers
-    #[arg(long = "no-header")]
+    #[arg(long = "no-header", alias = "no-headers")]
     pub no_header: bool,
 }
 
@@ -4112,13 +4500,13 @@ pub struct TasksInfoArgs {
 #[derive(Args)]
 pub struct TasksLsArgs {
     /// Only show global tasks
-    #[arg(long = "global", short = 'g')]
+    #[arg(long = "global", short = 'g', overrides_with = "local")]
     pub global: bool,
     /// Output in JSON format
     #[arg(long = "json", short = 'J')]
     pub json: bool,
     /// Only show non-global tasks
-    #[arg(long = "local", short = 'l')]
+    #[arg(long = "local", short = 'l', overrides_with = "global")]
     pub local: bool,
     /// Show all columns
     #[arg(long = "extended", short = 'x')]
@@ -4135,10 +4523,15 @@ pub struct TasksLsArgs {
     #[arg(long = "hidden")]
     pub hidden: bool,
     /// Only show task names, one per line. Useful for piping to fzf and similar tools.
-    #[arg(long = "name-only")]
+    #[arg(
+        long = "name-only",
+        conflicts_with = "json",
+        conflicts_with = "extended",
+        conflicts_with = "usage"
+    )]
     pub name_only: bool,
     /// Do not print table header
-    #[arg(long = "no-header")]
+    #[arg(long = "no-header", alias = "no-headers")]
     pub no_header: bool,
     /// Sort by column. Default is name.
     #[arg(long = "sort", value_name = "COLUMN", value_parser = ::clap::builder::PossibleValuesParser::new(["name", "alias", "description", "source"]))]
@@ -4183,21 +4576,34 @@ pub struct TasksRunArgs {
     #[arg(
         help = "Git base revision for --affected\nDefaults to MISE_AFFECTED_BASE, CI metadata, or HEAD~1",
         long = "affected-base",
+        requires = "affected",
         value_name = "REV"
     )]
     pub affected_base: Option<String>,
     /// Explain why projects and tasks were selected by --affected
-    #[arg(long = "affected-explain")]
+    #[arg(
+        long = "affected-explain",
+        requires = "affected",
+        conflicts_with = "affected_json"
+    )]
     pub affected_explain: bool,
     #[arg(
         help = "Git head revision for --affected\nDefaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD",
         long = "affected-head",
+        requires = "affected",
         value_name = "REV"
     )]
     pub affected_head: Option<String>,
     /// Output affected projects and tasks as JSON without running tasks
-    #[arg(long = "affected-json")]
+    #[arg(
+        long = "affected-json",
+        requires = "affected",
+        conflicts_with = "affected_explain"
+    )]
     pub affected_json: bool,
+    /// Open the interactive selector with all tasks from the entire monorepo
+    #[arg(long = "all", conflicts_with = "task", conflicts_with = "affected")]
+    pub all: bool,
     /// Continue running tasks even if one fails
     #[arg(long = "continue-on-error", short = 'c')]
     pub continue_on_error: bool,
@@ -4208,9 +4614,10 @@ pub struct TasksRunArgs {
     #[arg(long = "force", short = 'f')]
     pub force: bool,
     #[arg(
-        help = "Number of tasks to run in parallel\n[default: 4]\nConfigure with `jobs` config or `MISE_JOBS` env var",
+        help = "Number of tasks to run in parallel\nValues below 1 are treated as 1\n[default: 4]\nConfigure with `jobs` config or `MISE_JOBS` env var",
         long = "jobs",
         short = 'j',
+        env = "MISE_JOBS",
         value_name = "JOBS"
     )]
     pub jobs: Option<String>,
@@ -4226,10 +4633,15 @@ pub struct TasksRunArgs {
     /// - `keep-order` - Print stdout/stderr by line, prefixed with the task's label, but keep the order of the output
     /// - `quiet` - Don't show extra output
     /// - `silent` - Don't show any output including stdout and stderr from the task except for errors
-    #[arg(long = "output", short = 'o', value_name = "OUTPUT")]
+    #[arg(
+        long = "output",
+        short = 'o',
+        env = "MISE_TASK_OUTPUT",
+        value_name = "OUTPUT"
+    )]
     pub output: Option<String>,
     /// Don't show extra output
-    #[arg(long = "quiet", short = 'q')]
+    #[arg(long = "quiet", short = 'q', env = "MISE_QUIET")]
     pub quiet: bool,
     #[arg(
         help = "Read/write directly to stdin/stdout/stderr instead of by line\nRedactions are not applied with this option\nConfigure with `raw` config or `MISE_RAW` env var",
@@ -4245,10 +4657,15 @@ pub struct TasksRunArgs {
     #[arg(long = "shell", short = 's', value_name = "SHELL")]
     pub shell: Option<String>,
     /// Don't show any output except for errors
-    #[arg(long = "silent", short = 'S')]
+    #[arg(long = "silent", short = 'S', env = "MISE_SILENT")]
     pub silent: bool,
-    /// Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10
-    #[arg(long = "tool", short = 't', value_name = "TOOL@VERSION")]
+    #[arg(
+        help = "Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10",
+        long_help = "Tool(s) to run in addition to what is in mise.toml files\ne.g.: node@20 python@3.10",
+        long = "tool",
+        short = 't',
+        value_name = "TOOL@VERSION"
+    )]
     pub tool: Vec<String>,
     #[arg(
         help = "Allow specific env var through (implies --deny-env for everything else)\nSupports wildcards, e.g. --allow-env='MYAPP_*'",
@@ -4284,7 +4701,7 @@ pub struct TasksRunArgs {
     #[arg(long = "fresh-env")]
     pub fresh_env: bool,
     /// Do not use cache on remote tasks
-    #[arg(long = "no-cache")]
+    #[arg(long = "no-cache", env = "MISE_TASK_REMOTE_NO_CACHE")]
     pub no_cache: bool,
     /// Skip automatic dependency preparation
     #[arg(long = "no-deps")]
@@ -4292,10 +4709,10 @@ pub struct TasksRunArgs {
     /// Hides elapsed time after each task completes
     ///
     /// Default to always hide with `MISE_TASK_TIMINGS=0`
-    #[arg(long = "no-timings")]
+    #[arg(long = "no-timings", alias = "no-timing")]
     pub no_timings: bool,
     /// Run only the specified tasks skipping all dependencies
-    #[arg(long = "skip-deps")]
+    #[arg(long = "skip-deps", env = "MISE_TASK_SKIP_DEPENDS")]
     pub skip_deps: bool,
     /// Skip installing tools before running tasks
     ///
@@ -4310,16 +4727,20 @@ pub struct TasksRunArgs {
     /// - `write-only` - Write new results without reading cached results
     /// - `off` - Disable task output caching
     /// - `local-only` - Read and write only the local cache; currently equivalent to `read-write`
-    #[arg(long = "task-cache", value_name = "TASK_CACHE", value_parser = ::clap::builder::PossibleValuesParser::new(["read-write", "read-only", "write-only", "off", "local-only"]), default_value = "read-write")]
+    #[arg(long = "task-cache", env = "MISE_TASK_CACHE", value_name = "TASK_CACHE", value_parser = ::clap::builder::PossibleValuesParser::new(["read-write", "read-only", "write-only", "off", "local-only"]), default_value = "read-write")]
     pub task_cache: Option<String>,
     /// Explain the inputs that produced each task's output cache key
     #[arg(long = "task-cache-explain")]
     pub task_cache_explain: bool,
     /// Output cache-key input details as JSON Lines without running tasks
-    #[arg(long = "task-cache-explain-json")]
+    #[arg(
+        long = "task-cache-explain-json",
+        requires = "dry_run",
+        conflicts_with = "task_cache_explain"
+    )]
     pub task_cache_explain_json: bool,
     /// Report task output cache hits, restored bytes, and time saved
-    #[arg(long = "task-cache-stats")]
+    #[arg(long = "task-cache-stats", conflicts_with = "dry_run")]
     pub task_cache_stats: bool,
     #[arg(
         help = "Timeout for the task to complete\ne.g.: 30s, 5m",
@@ -4330,18 +4751,17 @@ pub struct TasksRunArgs {
     /// Shows elapsed time after each task completes
     ///
     /// Default to always show with `MISE_TASK_TIMINGS=1`
-    #[arg(long = "timings", hide = true)]
+    #[arg(long = "timings", alias = "timing", hide = true)]
     pub timings: bool,
     #[arg(
         value_name = "TASK",
-        help = "Tasks to run\nCan specify multiple tasks by separating with `:::`\ne.g.: mise run task1 arg1 arg2 ::: task2 arg1 arg2",
-        default_value = "default"
+        help = "Tasks to run\nCan specify multiple tasks by separating with `:::`\ne.g.: mise run task1 arg1 arg2 ::: task2 arg1 arg2\nDefaults to `default` when omitted"
     )]
     pub task: Option<String>,
-    /// Arguments to pass to the tasks. Use ":::" to separate tasks
+    /// Arguments to pass to the tasks. Use ":::" to separate tasks.
     #[arg(value_name = "ARGS", num_args = 0..)]
     pub args: Vec<String>,
-    /// Arguments to pass to the tasks. Use ":::" to separate tasks
+    /// Arguments to pass to the tasks. Use ":::" to separate tasks.
     #[arg(value_name = "ARGS_LAST", hide = true, num_args = 0.., last = true)]
     pub args_last: Vec<String>,
 }
@@ -4363,13 +4783,13 @@ pub struct TasksValidateArgs {
 #[derive(Args)]
 pub struct TasksArgs {
     /// Only show global tasks
-    #[arg(long = "global", short = 'g')]
+    #[arg(long = "global", short = 'g', overrides_with = "local")]
     pub global: bool,
     /// Output in JSON format
     #[arg(long = "json", short = 'J')]
     pub json: bool,
     /// Only show non-global tasks
-    #[arg(long = "local", short = 'l')]
+    #[arg(long = "local", short = 'l', overrides_with = "global")]
     pub local: bool,
     /// Show all columns
     #[arg(long = "extended", short = 'x')]
@@ -4386,10 +4806,15 @@ pub struct TasksArgs {
     #[arg(long = "hidden")]
     pub hidden: bool,
     /// Only show task names, one per line. Useful for piping to fzf and similar tools.
-    #[arg(long = "name-only")]
+    #[arg(
+        long = "name-only",
+        conflicts_with = "json",
+        conflicts_with = "extended",
+        conflicts_with = "usage"
+    )]
     pub name_only: bool,
     /// Do not print table header
-    #[arg(long = "no-header")]
+    #[arg(long = "no-header", alias = "no-headers")]
     pub no_header: bool,
     /// Sort by column. Default is name.
     #[arg(long = "sort", value_name = "COLUMN", value_parser = ::clap::builder::PossibleValuesParser::new(["name", "alias", "description", "source"]))]
@@ -4441,30 +4866,39 @@ pub enum TasksCommands {
 #[derive(Args)]
 pub struct TestToolArgs {
     /// Test every tool specified in registry/
-    #[arg(long = "all", short = 'a')]
+    #[arg(
+        long = "all",
+        short = 'a',
+        conflicts_with = "tools",
+        conflicts_with = "all_config"
+    )]
     pub all: bool,
     #[arg(
-        help = "Number of tool tests to run in parallel\n[default: 4]",
+        help = "Number of tool tests to run in parallel\nValues below 1 are treated as 1\n[default: 4]",
         long = "jobs",
         short = 'j',
+        env = "MISE_TEST_TOOL_JOBS",
         value_name = "JOBS"
     )]
     pub jobs: Option<String>,
     /// Test all tools specified in config files
-    #[arg(long = "all-config")]
+    #[arg(long = "all-config", conflicts_with = "tools", conflicts_with = "all")]
     pub all_config: bool,
     /// Also test tools not defined in registry/, guessing how to test it
     #[arg(long = "include-non-defined")]
     pub include_non_defined: bool,
-    /// Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1
-    #[arg(long = "raw")]
+    #[arg(
+        help = "Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1",
+        long_help = "Connect backend install command stdin/stdout/stderr directly to the terminal\nImplies --jobs=1",
+        long = "raw",
+        overrides_with = "jobs"
+    )]
     pub raw: bool,
     /// Tool(s) to test
-    #[arg(value_name = "TOOLS", num_args = 0..)]
+    #[arg(value_name = "TOOLS", required_unless_present = "all", required_unless_present = "all_config", num_args = 0..)]
     pub tools: Vec<String>,
 }
 
-/// Forgejo token
 #[derive(Args)]
 pub struct TokenForgejoArgs {
     /// Show the full unmasked token
@@ -4475,17 +4909,23 @@ pub struct TokenForgejoArgs {
     pub host: Option<String>,
 }
 
-/// GitHub token
 #[derive(Args)]
 pub struct TokenGithubArgs {
-    /// Resolve only via the native GitHub OAuth source (cache, refresh, or device-code flow), bypassing other token sources
-    #[arg(long = "oauth")]
+    #[arg(
+        help = "Resolve only via the native GitHub OAuth source (cache, refresh, or device-code flow), bypassing other token sources",
+        long_help = "Resolve only via the native GitHub OAuth source (cache,\nrefresh, or device-code flow), bypassing other token sources",
+        long = "oauth"
+    )]
     pub oauth: bool,
     /// Print only the token value
     #[arg(long = "raw")]
     pub raw: bool,
-    /// Mint a fresh OAuth token even if the cached one has not expired, via the refresh-token grant or a new device-code flow. Use after changing the GitHub App's installations or permissions: cached tokens keep their original access until they expire
-    #[arg(long = "refresh")]
+    #[arg(
+        help = "Mint a fresh OAuth token even if the cached one has not expired, via the refresh-token grant or a new device-code flow. Use after changing the GitHub App's installations or permissions: cached tokens keep their original access until they expire",
+        long_help = "Mint a fresh OAuth token even if the cached one has not\nexpired, via the refresh-token grant or a new device-code flow.\nUse after changing the GitHub App's installations or permissions:\ncached tokens keep their original access until they expire",
+        long = "refresh",
+        requires = "oauth"
+    )]
     pub refresh: bool,
     /// Show the full unmasked token
     #[arg(long = "unmask")]
@@ -4495,7 +4935,6 @@ pub struct TokenGithubArgs {
     pub host: Option<String>,
 }
 
-/// GitLab token
 #[derive(Args)]
 pub struct TokenGitlabArgs {
     /// Show the full unmasked token
@@ -4516,42 +4955,56 @@ pub struct TokenArgs {
 #[derive(Subcommand)]
 pub enum TokenCommands {
     /// Forgejo token
-    #[command(name = "forgejo")]
+    #[command(
+        name = "forgejo",
+        about = "Forgejo token",
+        long_about = "Display the Forgejo token mise will use for a given host\n\nShows which token source mise would use, useful for debugging\nauthentication issues. The token is masked by default."
+    )]
     Forgejo(Box<TokenForgejoArgs>),
     /// GitHub token
-    #[command(name = "github")]
+    #[command(
+        name = "github",
+        about = "GitHub token",
+        long_about = "Display the GitHub token mise will use for a given host\n\nShows which token source mise would use, useful for debugging\nauthentication issues. The token is masked by default."
+    )]
     Github(Box<TokenGithubArgs>),
     /// GitLab token
-    #[command(name = "gitlab")]
+    #[command(
+        name = "gitlab",
+        about = "GitLab token",
+        long_about = "Display the GitLab token mise will use for a given host\n\nShows which token source mise would use, useful for debugging\nauthentication issues. The token is masked by default."
+    )]
     Gitlab(Box<TokenGitlabArgs>),
 }
 
 /// Gets information about a tool
 #[derive(Args)]
+#[group(skip)]
+#[command(group = ::clap::ArgGroup::new("ToolInfoFilter").required(false).multiple(false))]
 pub struct ToolArgs {
     /// Output in JSON format
     #[arg(long = "json", short = 'J')]
     pub json: bool,
     /// Only show active versions
-    #[arg(long = "active")]
+    #[arg(long = "active", group = "ToolInfoFilter")]
     pub active: bool,
     /// Only show backend field
-    #[arg(long = "backend")]
+    #[arg(long = "backend", group = "ToolInfoFilter")]
     pub backend: bool,
     /// Only show config source
-    #[arg(long = "config-source")]
+    #[arg(long = "config-source", group = "ToolInfoFilter")]
     pub config_source: bool,
     /// Only show description field
-    #[arg(long = "description")]
+    #[arg(long = "description", group = "ToolInfoFilter")]
     pub description: bool,
     /// Only show installed versions
-    #[arg(long = "installed")]
+    #[arg(long = "installed", group = "ToolInfoFilter")]
     pub installed: bool,
     /// Only show requested versions
-    #[arg(long = "requested")]
+    #[arg(long = "requested", group = "ToolInfoFilter")]
     pub requested: bool,
     /// Only show tool options
-    #[arg(long = "tool-options")]
+    #[arg(long = "tool-options", group = "ToolInfoFilter")]
     pub tool_options: bool,
     /// Tool name to get information about
     #[arg(value_name = "TOOL")]
@@ -4560,27 +5013,42 @@ pub struct ToolArgs {
 
 /// Execute a tool stub
 ///
-/// Tool stubs are executable files containing TOML configuration that specify which tool to run and how to run it. They provide a convenient way to create portable, self-contained executables that automatically manage tool installation and execution.
+/// Tool stubs are executable files containing TOML configuration that specify
+/// which tool to run and how to run it. They provide a convenient way to create
+/// portable, self-contained executables that automatically manage tool installation
+/// and execution.
 ///
-/// A tool stub consists of: - A shebang line: #!/usr/bin/env -S mise tool-stub - TOML configuration specifying the tool, version, and options - Optional comments describing the tool's purpose
+/// A tool stub consists of:
+/// - A shebang line: #!/usr/bin/env -S mise tool-stub
+/// - TOML configuration specifying the tool, version, and options
+/// - Optional comments describing the tool's purpose
 ///
-/// Example stub file: #!/usr/bin/env -S mise tool-stub # Node.js v20 development environment
+/// Example stub file:
+///   #!/usr/bin/env -S mise tool-stub
+///   # Node.js v20 development environment
 ///
-/// tool = "node" version = "20.0.0" bin = "node"
+///   tool = "node"
+///   version = "20.0.0"
+///   bin = "node"
 ///
-/// The stub will automatically install the specified tool version if missing and execute it with any arguments passed to the stub.
+/// The stub will automatically install the specified tool version if missing
+/// and execute it with any arguments passed to the stub.
 ///
 /// For more information, see: https://mise.jdx.dev/dev-tools/tool-stubs.html
 #[derive(Args)]
 pub struct ToolStubArgs {
     /// Path to the TOML tool stub file to execute
     ///
-    /// The stub file must contain TOML configuration specifying the tool and version to run. At minimum, it should specify a 'version' field. Other common fields include 'tool', 'bin', and backend-specific options.
+    /// The stub file must contain TOML configuration specifying the tool
+    /// and version to run. At minimum, it should specify a 'version' field.
+    /// Other common fields include 'tool', 'bin', and backend-specific options.
     #[arg(value_name = "FILE")]
     pub file: String,
     /// Arguments to pass to the tool
     ///
-    /// All arguments after the stub file path will be forwarded to the underlying tool. Use '--' to separate mise arguments from tool arguments if needed.
+    /// All arguments after the stub file path will be forwarded to the
+    /// underlying tool. Use '--' to separate mise arguments from tool arguments
+    /// if needed.
     #[arg(value_name = "ARGS", num_args = 0..)]
     pub args: Vec<String>,
 }
@@ -4588,17 +5056,18 @@ pub struct ToolStubArgs {
 /// Marks a config file as trusted
 ///
 /// This means mise is allowed to parse the file when it needs to read config
-/// that may execute code or affect the environment. mise checks trust before
-/// parsing `mise.toml`. Without trust, mise may prompt, skip the config in some
-/// discovery paths, fail with an untrusted-config error when it cannot prompt,
-/// or assume trust in detected CI unless paranoid mode is enabled.
+/// that may execute code or affect the environment. Without trust, mise may
+/// prompt, skip the config in some discovery paths, or fail with an
+/// untrusted-config error when it cannot prompt.
 ///
-/// Safe config files do not require trust: files that only contain
-/// `min_version`, `[tools]` entries with plain version strings (or arrays
-/// of them), and `[tasks]` (no templates and no tool options) are loaded
-/// without prompting, since nothing in them executes code at load time —
-/// tools install and tasks run only on explicit commands like `mise install`
-/// or `mise run`.
+/// In normal mode, commands that execute project-defined behavior (`mise run`,
+/// naked task invocations such as `mise <TASK>`, `mise install`, `mise exec`,
+/// and `mise watch`) automatically trust their active config. Paranoid mode
+/// requires explicit, content-bound trust for every non-global config.
+///
+/// In normal mode, safe config files do not require trust: files that only contain
+/// `min_version`, `[tools]` entries with plain version strings (or arrays of
+/// them), and `[tasks]` without templates or tool options.
 ///
 /// Trust is shared across git worktrees: a config file inside a linked
 /// worktree is trusted when the equivalent path in the repository's main
@@ -4610,20 +5079,25 @@ pub struct TrustArgs {
     ///
     /// Subdirectories are walked respecting .gitignore, skipping hidden directories
     /// and common build/dependency directories (node_modules, vendor, target, dist, build).
-    #[arg(long = "all", short = 'a')]
+    #[arg(
+        long = "all",
+        short = 'a',
+        conflicts_with = "ignore",
+        conflicts_with = "untrust"
+    )]
     pub all: bool,
     /// Do not trust this config and ignore it in the future
-    #[arg(long = "ignore")]
+    #[arg(long = "ignore", conflicts_with = "untrust")]
     pub ignore: bool,
     #[arg(
         help = "Show the trusted status of config files from the current directory and its parents.\nDoes not trust or untrust any files.",
         long = "show"
     )]
     pub show: bool,
-    /// No longer trust this config, will prompt in the future
+    /// Remove explicit trust for this config
     #[arg(long = "untrust")]
     pub untrust: bool,
-    /// The config file to trust
+    /// The config file whose trust status to change
     #[arg(value_name = "CONFIG_FILE")]
     pub config_file: Option<String>,
 }
@@ -4645,7 +5119,7 @@ pub struct UninstallArgs {
     #[arg(long = "dry-run-code")]
     pub dry_run_code: bool,
     /// Tool(s) to remove
-    #[arg(value_name = "INSTALLED_TOOL@VERSION", num_args = 0..)]
+    #[arg(value_name = "INSTALLED_TOOL@VERSION", required_unless_present = "all", num_args = 0..)]
     pub installed_tool_version: Vec<String>,
 }
 
@@ -4658,17 +5132,18 @@ pub struct UnsetArgs {
     ///
     /// Can be a file path or directory. If a directory is provided, will create/use mise.toml in that directory.
     ///
-    /// Defaults to [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) environment variable, or `mise.toml`. Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
+    /// Defaults to [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) environment variable, or `mise.toml`.
+    /// Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
     #[arg(long = "file", short = 'f', alias = "path", value_name = "FILE")]
     pub file: Option<String>,
     /// Use the global config file
-    #[arg(long = "global", short = 'g')]
+    #[arg(long = "global", short = 'g', overrides_with = "file")]
     pub global: bool,
     #[arg(value_name = "ENV_KEY", help = "Environment variable(s) to remove\ne.g.: NODE_ENV", num_args = 0..)]
     pub env_key: Vec<String>,
 }
 
-/// No longer trust a config, will prompt in the future
+/// Remove explicit trust for a config
 #[derive(Args)]
 pub struct UntrustArgs {
     /// The config file to untrust
@@ -4697,15 +5172,34 @@ pub struct UntrustArgs {
 #[derive(Args)]
 pub struct UnuseArgs {
     /// Create/modify an environment-specific config file like .mise.<env>.toml
-    #[arg(long = "env", short = 'e', value_name = "ENV")]
+    #[arg(
+        long = "env",
+        short = 'e',
+        overrides_with = "global",
+        overrides_with = "path",
+        value_name = "ENV"
+    )]
     pub env: Option<String>,
     /// Use the global config file (`~/.config/mise/config.toml`) instead of the local one
-    #[arg(long = "global", short = 'g')]
+    #[arg(
+        long = "global",
+        short = 'g',
+        overrides_with = "path",
+        overrides_with = "env"
+    )]
     pub global: bool,
     /// Specify a path to a config file or directory
     ///
-    /// If a directory is specified, it will look for a config file in that directory following the rules above.
-    #[arg(long = "path", short = 'p', alias = "file", value_name = "PATH")]
+    /// If a directory is specified, it will look for a config file in that directory following
+    /// the rules above.
+    #[arg(
+        long = "path",
+        short = 'p',
+        alias = "file",
+        overrides_with = "global",
+        overrides_with = "env",
+        value_name = "PATH"
+    )]
     pub path: Option<String>,
     /// Do not also prune the installed version
     #[arg(long = "no-prune")]
@@ -4724,16 +5218,6 @@ pub struct UnuseArgs {
 /// This will update mise.lock if it is enabled, see https://mise.jdx.dev/configuration/settings.html#lockfile
 #[derive(Args)]
 pub struct UpgradeArgs {
-    /// Display multiselect menu to choose which tools to upgrade
-    #[arg(long = "interactive", short = 'i')]
-    pub interactive: bool,
-    #[arg(
-        help = "Number of jobs to run in parallel\n[default: 4]",
-        long = "jobs",
-        short = 'j',
-        value_name = "JOBS"
-    )]
-    pub jobs: Option<String>,
     /// Upgrades to the latest version available, bumping the version in mise.toml
     ///
     /// For example, if you have `node = "20.0.0"` in your mise.toml but 22.1.0 is the latest available,
@@ -4741,8 +5225,26 @@ pub struct UpgradeArgs {
     ///
     /// It keeps the same precision as what was there before, so if you instead had `node = "20"`, it
     /// would change your config to `node = "22"`.
-    #[arg(long = "bump", short = 'l')]
+    #[arg(long = "bump", short = 'b')]
     pub bump: bool,
+    /// Display multiselect menu to choose which tools to upgrade
+    #[arg(
+        long = "interactive",
+        short = 'i',
+        conflicts_with = "installed_tool_version"
+    )]
+    pub interactive: bool,
+    #[arg(
+        help = "Number of jobs to run in parallel\nValues below 1 are treated as 1\n[default: 4]",
+        long = "jobs",
+        short = 'j',
+        env = "MISE_JOBS",
+        value_name = "JOBS"
+    )]
+    pub jobs: Option<String>,
+    /// Deprecated shorthand for --bump
+    #[arg(short = 'l', hide = true)]
+    pub l: bool,
     /// Just print what would be done, don't actually do it
     #[arg(long = "dry-run", short = 'n')]
     pub dry_run: bool,
@@ -4759,7 +5261,7 @@ pub struct UpgradeArgs {
     #[arg(long = "dry-run-code")]
     pub dry_run_code: bool,
     /// Upgrade all tools, including installed-but-inactive tools not present in the current config
-    #[arg(long = "inactive")]
+    #[arg(long = "inactive", conflicts_with = "local")]
     pub inactive: bool,
     /// Only upgrade tools defined in local config files
     ///
@@ -4774,7 +5276,11 @@ pub struct UpgradeArgs {
     ///
     /// This only affects fuzzy version matches like "20" or "latest".
     /// Explicitly pinned versions like "22.5.0" are not filtered.
-    #[arg(long = "minimum-release-age", value_name = "MINIMUM_RELEASE_AGE")]
+    #[arg(
+        long = "minimum-release-age",
+        alias = "before",
+        value_name = "MINIMUM_RELEASE_AGE"
+    )]
     pub minimum_release_age: Option<String>,
     /// Placeholder for future monorepo upgrades; `mise upgrade --monorepo` is not implemented yet.
     #[arg(long = "monorepo")]
@@ -4784,10 +5290,22 @@ pub struct UpgradeArgs {
     /// By default the old version is removed once the new one installs, unless another
     /// tracked config or tool stub still needs it. Use this to keep it anyway, e.g. when
     /// something outside of mise points at the old install directory.
-    #[arg(long = "no-prune")]
+    ///
+    /// Set `upgrade.auto_prune = false` to make this the default.
+    #[arg(long = "no-prune", overrides_with = "prune")]
     pub no_prune: bool,
-    /// Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1
-    #[arg(long = "raw")]
+    /// Uninstall the versions that were upgraded away from
+    ///
+    /// This is already the default. Use it to override `upgrade.auto_prune = false`
+    /// for a single run.
+    #[arg(long = "prune", overrides_with = "no_prune")]
+    pub prune: bool,
+    #[arg(
+        help = "Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1",
+        long_help = "Connect backend install command stdin/stdout/stderr directly to the terminal\nImplies --jobs=1",
+        long = "raw",
+        overrides_with = "jobs"
+    )]
     pub raw: bool,
     #[arg(value_name = "INSTALLED_TOOL@VERSION", help = "Tool(s) to upgrade\ne.g.: node@20 python@3.10\nIf not specified, all current tools will be upgraded", num_args = 0..)]
     pub installed_tool_version: Vec<String>,
@@ -4821,18 +5339,30 @@ pub struct UsageArgs {}
 #[derive(Args)]
 pub struct UseArgs {
     /// Create/modify an environment-specific config file like .mise.<env>.toml
-    #[arg(long = "env", short = 'e', value_name = "ENV")]
+    #[arg(
+        long = "env",
+        short = 'e',
+        overrides_with = "global",
+        overrides_with = "path",
+        value_name = "ENV"
+    )]
     pub env: Option<String>,
     /// Force reinstall even if already installed
-    #[arg(long = "force", short = 'f')]
+    #[arg(long = "force", short = 'f', requires = "tool_version")]
     pub force: bool,
     /// Use the global config file (`~/.config/mise/config.toml`) instead of the local one
-    #[arg(long = "global", short = 'g')]
+    #[arg(
+        long = "global",
+        short = 'g',
+        overrides_with = "path",
+        overrides_with = "env"
+    )]
     pub global: bool,
     #[arg(
-        help = "Number of jobs to run in parallel\n[default: 4]",
+        help = "Number of jobs to run in parallel\nValues below 1 are treated as 1\n[default: 4]",
         long = "jobs",
         short = 'j',
+        env = "MISE_JOBS",
         value_name = "JOBS"
     )]
     pub jobs: Option<String>,
@@ -4841,8 +5371,15 @@ pub struct UseArgs {
     pub dry_run: bool,
     /// Specify a path to a config file or directory
     ///
-    /// If a directory is specified, it will look for a config file in that directory following the rules above.
-    #[arg(long = "path", short = 'p', alias = "file", value_name = "PATH")]
+    /// If a directory is specified, it will look for a config file in that directory following
+    /// the rules above.
+    #[arg(
+        long = "path",
+        short = 'p',
+        overrides_with = "global",
+        overrides_with = "env",
+        value_name = "PATH"
+    )]
     pub path: Option<String>,
     /// Like --dry-run but exits with code 1 if there are changes to make
     ///
@@ -4853,24 +5390,37 @@ pub struct UseArgs {
     ///
     /// e.g.: `mise use --fuzzy node@20` will save 20 as the version
     /// this is the default behavior unless `MISE_PIN=1`
-    #[arg(long = "fuzzy")]
+    #[arg(long = "fuzzy", overrides_with = "pin")]
     pub fuzzy: bool,
     /// Only install versions released before this date or older than this duration
     ///
     /// Supports absolute dates like "2024-06-01" and relative durations like "90d" or "1y".
-    #[arg(long = "minimum-release-age", value_name = "MINIMUM_RELEASE_AGE")]
-    pub minimum_release_age: Option<String>,
     #[arg(
-        help = "Save exact version to config file\ne.g.: `mise use --pin node@20` will save 20.0.0 as the version\nSet `MISE_PIN=1` to make this the default behavior",
-        long_help = "Save exact version to config file\ne.g.: `mise use --pin node@20` will save 20.0.0 as the version\nSet `MISE_PIN=1` to make this the default behavior\n\nConsider using mise.lock as a better alternative to pinning in mise.toml:\nhttps://mise.jdx.dev/configuration/settings.html#lockfile",
-        long = "pin"
+        long = "minimum-release-age",
+        alias = "before",
+        value_name = "MINIMUM_RELEASE_AGE"
     )]
+    pub minimum_release_age: Option<String>,
+    /// Save the resolved concrete version to the config file
+    ///
+    /// If the request exactly matches an available release, that release is preferred over
+    /// installed fuzzy matches. Use `prefix:` to explicitly request recursive prefix matching.
+    /// e.g.: `mise use --pin node@20` will save the resolved `20.x.y` version
+    /// Set `MISE_PIN=1` to make this the default behavior
+    ///
+    /// Consider using mise.lock as a better alternative to pinning in mise.toml:
+    /// https://mise.jdx.dev/configuration/settings.html#lockfile
+    #[arg(long = "pin", overrides_with = "fuzzy")]
     pub pin: bool,
-    /// Connect backend install command stdin/stdout/stderr directly to the terminal Implies `--jobs=1`
-    #[arg(long = "raw")]
+    #[arg(
+        help = "Connect backend install command stdin/stdout/stderr directly to the terminal Implies `--jobs=1`",
+        long_help = "Connect backend install command stdin/stdout/stderr directly to the terminal\nImplies `--jobs=1`",
+        long = "raw",
+        overrides_with = "jobs"
+    )]
     pub raw: bool,
     /// Remove the tool(s) from config file
-    #[arg(long = "remove", value_name = "TOOL")]
+    #[arg(long = "remove", alias = "rm", alias = "unset", value_name = "TOOL")]
     pub remove: Vec<String>,
     /// Tool(s) to add to config file
     ///
@@ -4923,39 +5473,64 @@ pub struct WatchArgs {
     ///
     /// By default, Watchexec watches the current directory.
     ///
-    /// When watching a single file, it's often better to watch the containing directory instead, and filter on the filename. Some editors may replace the file with a new one when saving, and some platforms may not detect that or further changes.
+    /// When watching a single file, it's often better to watch the containing directory instead,
+    /// and filter on the filename. Some editors may replace the file with a new one when saving,
+    /// and some platforms may not detect that or further changes.
     ///
-    /// Upon starting, Watchexec resolves a "project origin" from the watched paths. See the help for '--project-origin' for more information.
+    /// Upon starting, Watchexec resolves a "project origin" from the watched paths. See the help
+    /// for '--project-origin' for more information.
     ///
     /// This option can be specified multiple times to watch multiple files or directories.
     ///
-    /// The special value '/dev/null', provided as the only path watched, will cause Watchexec to not watch any paths. Other event sources (like signals or key events) may still be used.
-    #[arg(long = "watch", short = 'w', value_name = "PATH")]
+    /// The special value '/dev/null', provided as the only path watched, will cause Watchexec to
+    /// not watch any paths. Other event sources (like signals or key events) may still be used.
+    #[arg(
+        long = "watch",
+        short = 'w',
+        help_heading = "Filtering",
+        value_name = "PATH"
+    )]
     pub watch: Vec<String>,
     /// Watch a specific directory, non-recursively
     ///
     /// Unlike '-w', folders watched with this option are not recursed into.
     ///
     /// This option can be specified multiple times to watch multiple directories non-recursively.
-    #[arg(long = "watch-non-recursive", short = 'W', value_name = "PATH")]
+    #[arg(
+        long = "watch-non-recursive",
+        short = 'W',
+        help_heading = "Filtering",
+        value_name = "PATH"
+    )]
     pub watch_non_recursive: Vec<String>,
     /// Watch files and directories from a file
     ///
     /// Each line in the file will be interpreted as if given to '-w'.
     ///
-    /// For more complex uses (like watching non-recursively), use the argfile capability: build a file containing command-line options and pass it to watchexec with `@path/to/argfile`.
+    /// For more complex uses (like watching non-recursively), use the argfile capability: build a
+    /// file containing command-line options and pass it to watchexec with `@path/to/argfile`.
     ///
     /// The special value '-' will read from STDIN; this in incompatible with '--stdin-quit'.
-    #[arg(long = "watch-file", short = 'F', value_name = "PATH")]
+    #[arg(
+        long = "watch-file",
+        short = 'F',
+        help_heading = "Filtering",
+        value_name = "PATH"
+    )]
     pub watch_file: Option<String>,
     /// Clear screen before running command
     ///
     /// If this doesn't completely clear the screen, try '--clear=reset'.
-    #[arg(long = "clear", short = 'c', value_name = "MODE", value_parser = ::clap::builder::PossibleValuesParser::new(["clear", "reset"]))]
+    #[arg(long = "clear", short = 'c', num_args = 0..=1, default_missing_value = "clear", help_heading = "Output", value_name = "MODE", value_parser = ::clap::builder::PossibleValuesParser::new(["clear", "reset"]))]
     pub clear: Option<String>,
     /// What to do when receiving events while the command is running
     ///
-    /// Default is to 'do-nothing', which ignores events while the command is running, so that changes that occur due to the command are ignored, like compilation outputs. You can also use 'queue' which will run the command once again when the current run has finished if any events occur while it's running, or 'restart', which terminates the running command and starts a new one. Finally, there's 'signal', which only sends a signal; this can be useful with programs that can reload their configuration without a full restart.
+    /// Default is to 'do-nothing', which ignores events while the command is running, so that
+    /// changes that occur due to the command are ignored, like compilation outputs. You can also
+    /// use 'queue' which will run the command once again when the current run has finished if any
+    /// events occur while it's running, or 'restart', which terminates the running command and starts
+    /// a new one. Finally, there's 'signal', which only sends a signal; this can be useful with
+    /// programs that can reload their configuration without a full restart.
     ///
     /// The signal can be specified with the '--signal' option.
     #[arg(long = "on-busy-update", short = 'o', value_name = "MODE", value_parser = ::clap::builder::PossibleValuesParser::new(["queue", "do-nothing", "restart", "signal"]), default_value = "do-nothing")]
@@ -4963,57 +5538,92 @@ pub struct WatchArgs {
     /// Restart the process if it's still running
     ///
     /// This is a shorthand for '--on-busy-update=restart'.
-    #[arg(long = "restart", short = 'r')]
+    #[arg(long = "restart", short = 'r', conflicts_with = "on_busy_update")]
     pub restart: bool,
     /// Send a signal to the process when it's still running
     ///
-    /// Specify a signal to send to the process when it's still running. This implies '--on-busy-update=signal'; otherwise the signal used when that mode is 'restart' is controlled by '--stop-signal'.
+    /// Specify a signal to send to the process when it's still running. This implies
+    /// '--on-busy-update=signal'; otherwise the signal used when that mode is 'restart' is
+    /// controlled by '--stop-signal'.
     ///
     /// See the long documentation for '--stop-signal' for syntax.
     ///
-    /// Signals are not supported on Windows at the moment, and will always be overridden to 'kill'. See '--stop-signal' for more on Windows "signals".
-    #[arg(long = "signal", short = 's', value_name = "SIGNAL")]
+    /// Signals are not supported on Windows at the moment, and will always be overridden to 'kill'.
+    /// See '--stop-signal' for more on Windows "signals".
+    #[arg(
+        long = "signal",
+        short = 's',
+        conflicts_with = "restart",
+        value_name = "SIGNAL"
+    )]
     pub signal: Option<String>,
     /// Signal to send to stop the command
     ///
-    /// This is used by 'restart' and 'signal' modes of '--on-busy-update' (unless '--signal' is provided). The restart behaviour is to send the signal, wait for the command to exit, and if it hasn't exited after some time (see '--timeout-stop'), forcefully terminate it.
+    /// This is used by 'restart' and 'signal' modes of '--on-busy-update' (unless '--signal' is
+    /// provided). The restart behaviour is to send the signal, wait for the command to exit, and if
+    /// it hasn't exited after some time (see '--timeout-stop'), forcefully terminate it.
     ///
     /// The default on unix is "SIGTERM".
     ///
-    /// Input is parsed as a full signal name (like "SIGTERM"), a short signal name (like "TERM"), or a signal number (like "15"). All input is case-insensitive.
+    /// Input is parsed as a full signal name (like "SIGTERM"), a short signal name (like "TERM"),
+    /// or a signal number (like "15"). All input is case-insensitive.
     ///
-    /// On Windows this option is technically supported but only supports the "KILL" event, as Watchexec cannot yet deliver other events. Windows doesn't have signals as such; instead it has termination (here called "KILL" or "STOP") and "CTRL+C", "CTRL+BREAK", and "CTRL+CLOSE" events. For portability the unix signals "SIGKILL", "SIGINT", "SIGTERM", and "SIGHUP" are respectively mapped to these.
+    /// On Windows this option is technically supported but only supports the "KILL" event, as
+    /// Watchexec cannot yet deliver other events. Windows doesn't have signals as such; instead it
+    /// has termination (here called "KILL" or "STOP") and "CTRL+C", "CTRL+BREAK", and "CTRL+CLOSE"
+    /// events. For portability the unix signals "SIGKILL", "SIGINT", "SIGTERM", and "SIGHUP" are
+    /// respectively mapped to these.
     #[arg(long = "stop-signal", value_name = "SIGNAL")]
     pub stop_signal: Option<String>,
     /// Time to wait for the command to exit gracefully
     ///
-    /// This is used by the 'restart' mode of '--on-busy-update'. After the graceful stop signal is sent, Watchexec will wait for the command to exit. If it hasn't exited after this time, it is forcefully terminated.
+    /// This is used by the 'restart' mode of '--on-busy-update'. After the graceful stop signal
+    /// is sent, Watchexec will wait for the command to exit. If it hasn't exited after this time,
+    /// it is forcefully terminated.
     ///
-    /// Takes a unit-less value in seconds, or a time span value such as "5min 20s". Providing a unit-less value is deprecated and will warn; it will be an error in the future.
+    /// Takes a unit-less value in seconds, or a time span value such as "5min 20s".
+    /// Providing a unit-less value is deprecated and will warn; it will be an error in the future.
     ///
     /// The default is 10 seconds. Set to 0 to immediately force-kill the command.
     ///
-    /// This has no practical effect on Windows as the command is always forcefully terminated; see '--stop-signal' for why.
+    /// This has no practical effect on Windows as the command is always forcefully terminated; see
+    /// '--stop-signal' for why.
     #[arg(long = "stop-timeout", value_name = "TIMEOUT", default_value = "10s")]
     pub stop_timeout: Option<String>,
     /// Translate signals from the OS to signals to send to the command
     ///
-    /// Takes a pair of signal names, separated by a colon, such as "TERM:INT" to map SIGTERM to SIGINT. The first signal is the one received by watchexec, and the second is the one sent to the command. The second can be omitted to discard the first signal, such as "TERM:" to not do anything on SIGTERM.
+    /// Takes a pair of signal names, separated by a colon, such as "TERM:INT" to map SIGTERM to
+    /// SIGINT. The first signal is the one received by watchexec, and the second is the one sent to
+    /// the command. The second can be omitted to discard the first signal, such as "TERM:" to
+    /// not do anything on SIGTERM.
     ///
-    /// If SIGINT or SIGTERM are mapped, then they no longer quit Watchexec. Besides making it hard to quit Watchexec itself, this is useful to send pass a Ctrl-C to the command without also terminating Watchexec and the underlying program with it, e.g. with "INT:INT".
+    /// If SIGINT or SIGTERM are mapped, then they no longer quit Watchexec. Besides making it hard
+    /// to quit Watchexec itself, this is useful to send pass a Ctrl-C to the command without also
+    /// terminating Watchexec and the underlying program with it, e.g. with "INT:INT".
     ///
     /// This option can be specified multiple times to map multiple signals.
     ///
-    /// Signal syntax is case-insensitive for short names (like "TERM", "USR2") and long names (like "SIGKILL", "SIGHUP"). Signal numbers are also supported (like "15", "31"). On Windows, the forms "STOP", "CTRL+C", and "CTRL+BREAK" are also supported to receive, but Watchexec cannot yet deliver other "signals" than a STOP.
+    /// Signal syntax is case-insensitive for short names (like "TERM", "USR2") and long names (like
+    /// "SIGKILL", "SIGHUP"). Signal numbers are also supported (like "15", "31"). On Windows, the
+    /// forms "STOP", "CTRL+C", and "CTRL+BREAK" are also supported to receive, but Watchexec cannot
+    /// yet deliver other "signals" than a STOP.
     #[arg(long = "map-signal", value_name = "SIGNAL:SIGNAL")]
     pub map_signal: Vec<String>,
     /// Time to wait for new events before taking action
     ///
-    /// When an event is received, Watchexec will wait for up to this amount of time before handling it (such as running the command). This is essential as what you might perceive as a single change may actually emit many events, and without this behaviour, Watchexec would run much too often. Additionally, it's not infrequent that file writes are not atomic, and each write may emit an event, so this is a good way to avoid running a command while a file is partially written.
+    /// When an event is received, Watchexec will wait for up to this amount of time before handling
+    /// it (such as running the command). This is essential as what you might perceive as a single
+    /// change may actually emit many events, and without this behaviour, Watchexec would run much
+    /// too often. Additionally, it's not infrequent that file writes are not atomic, and each write
+    /// may emit an event, so this is a good way to avoid running a command while a file is
+    /// partially written.
     ///
-    /// An alternative use is to set a high value (like "30min" or longer), to save power or bandwidth on intensive tasks, like an ad-hoc backup script. In those use cases, note that every accumulated event will build up in memory.
+    /// An alternative use is to set a high value (like "30min" or longer), to save power or
+    /// bandwidth on intensive tasks, like an ad-hoc backup script. In those use cases, note that
+    /// every accumulated event will build up in memory.
     ///
-    /// Takes a unit-less value in milliseconds, or a time span value such as "5sec 20ms". Providing a unit-less value is deprecated and will warn; it will be an error in the future.
+    /// Takes a unit-less value in milliseconds, or a time span value such as "5sec 20ms".
+    /// Providing a unit-less value is deprecated and will warn; it will be an error in the future.
     ///
     /// The default is 50 milliseconds. Setting to 0 is highly discouraged.
     #[arg(
@@ -5025,15 +5635,18 @@ pub struct WatchArgs {
     pub debounce: Option<String>,
     /// Exit when stdin closes
     ///
-    /// This watches the stdin file descriptor for EOF, and exits Watchexec gracefully when it is closed. This is used by some process managers to avoid leaving zombie processes around.
+    /// This watches the stdin file descriptor for EOF, and exits Watchexec gracefully when it is
+    /// closed. This is used by some process managers to avoid leaving zombie processes around.
     #[arg(long = "stdin-quit")]
     pub stdin_quit: bool,
     /// Don't load gitignores
     ///
-    /// Among other VCS exclude files, like for Mercurial, Subversion, Bazaar, DARCS, Fossil. Note that Watchexec will detect which of these is in use, if any, and only load the relevant files. Both global (like '~/.gitignore') and local (like '.gitignore') files are considered.
+    /// Among other VCS exclude files, like for Mercurial, Subversion, Bazaar, DARCS, Fossil. Note
+    /// that Watchexec will detect which of these is in use, if any, and only load the relevant
+    /// files. Both global (like '~/.gitignore') and local (like '.gitignore') files are considered.
     ///
     /// This option is useful if you want to watch files that are ignored by Git.
-    #[arg(long = "no-vcs-ignore")]
+    #[arg(long = "no-vcs-ignore", help_heading = "Filtering")]
     pub no_vcs_ignore: bool,
     /// Don't load project-local ignores
     ///
@@ -5054,7 +5667,7 @@ pub struct WatchArgs {
     /// VCS ignore files (Git, Mercurial, Bazaar, Darcs, Fossil) are only used if the corresponding
     /// VCS is discovered to be in use for the project/origin. For example, a .bzrignore in a Git
     /// repository will be discarded.
-    #[arg(long = "no-project-ignore")]
+    #[arg(long = "no-project-ignore", help_heading = "Filtering")]
     pub no_project_ignore: bool,
     /// Don't load global ignores
     ///
@@ -5071,87 +5684,109 @@ pub struct WatchArgs {
     ///
     /// Like for project files, Git and Bazaar global files will only be used for the corresponding
     /// VCS as used in the project.
-    #[arg(long = "no-global-ignore")]
+    #[arg(long = "no-global-ignore", help_heading = "Filtering")]
     pub no_global_ignore: bool,
     /// Don't use internal default ignores
     ///
-    /// Watchexec has a set of default ignore patterns, such as editor swap files, `*.pyc`, `*.pyo`, `.DS_Store`, `.bzr`, `_darcs`, `.fossil-settings`, `.git`, `.hg`, `.pijul`, `.svn`, and Watchexec log files.
-    #[arg(long = "no-default-ignore")]
+    /// Watchexec has a set of default ignore patterns, such as editor swap files, `*.pyc`, `*.pyo`,
+    /// `.DS_Store`, `.bzr`, `_darcs`, `.fossil-settings`, `.git`, `.hg`, `.pijul`, `.svn`, and
+    /// Watchexec log files.
+    #[arg(long = "no-default-ignore", help_heading = "Filtering")]
     pub no_default_ignore: bool,
     /// Don't discover ignore files at all
     ///
-    /// This is a shorthand for '--no-global-ignore', '--no-vcs-ignore', '--no-project-ignore', but even more efficient as it will skip all the ignore discovery mechanisms from the get go.
+    /// This is a shorthand for '--no-global-ignore', '--no-vcs-ignore', '--no-project-ignore', but
+    /// even more efficient as it will skip all the ignore discovery mechanisms from the get go.
     ///
     /// Note that default ignores are still loaded, see '--no-default-ignore'.
-    #[arg(long = "no-discover-ignore")]
+    #[arg(long = "no-discover-ignore", help_heading = "Filtering")]
     pub no_discover_ignore: bool,
     /// Don't ignore anything at all
     ///
     /// This is a shorthand for '--no-discover-ignore', '--no-default-ignore'.
     ///
-    /// Note that ignores explicitly loaded via other command line options, such as '--ignore' or '--ignore-file', will still be used.
-    #[arg(long = "ignore-nothing")]
+    /// Note that ignores explicitly loaded via other command line options, such as '--ignore' or
+    /// '--ignore-file', will still be used.
+    #[arg(long = "ignore-nothing", help_heading = "Filtering")]
     pub ignore_nothing: bool,
     /// Wait until first change before running command
     ///
-    /// By default, Watchexec will run the command once immediately. With this option, it will instead wait until an event is detected before running the command as normal.
+    /// By default, Watchexec will run the command once immediately. With this option, it will
+    /// instead wait until an event is detected before running the command as normal.
     #[arg(long = "postpone", short = 'p')]
     pub postpone: bool,
     /// Sleep before running the command
     ///
-    /// This option will cause Watchexec to sleep for the specified amount of time before running the command, after an event is detected. This is like using "sleep 5 && command" in a shell, but portable and slightly more efficient.
+    /// This option will cause Watchexec to sleep for the specified amount of time before running
+    /// the command, after an event is detected. This is like using "sleep 5 && command" in a shell,
+    /// but portable and slightly more efficient.
     ///
-    /// Takes a unit-less value in seconds, or a time span value such as "2min 5s". Providing a unit-less value is deprecated and will warn; it will be an error in the future.
+    /// Takes a unit-less value in seconds, or a time span value such as "2min 5s".
+    /// Providing a unit-less value is deprecated and will warn; it will be an error in the future.
     #[arg(long = "delay-run", value_name = "DURATION")]
     pub delay_run: Option<String>,
     /// Poll for filesystem changes
     ///
-    /// By default, and where available, Watchexec uses the operating system's native file system watching capabilities. This option disables that and instead uses a polling mechanism, which is less efficient but can work around issues with some file systems (like network shares) or edge cases.
+    /// By default, and where available, Watchexec uses the operating system's native file system
+    /// watching capabilities. This option disables that and instead uses a polling mechanism, which
+    /// is less efficient but can work around issues with some file systems (like network shares) or
+    /// edge cases.
     ///
-    /// Optionally takes a unit-less value in milliseconds, or a time span value such as "2s 500ms", to use as the polling interval. If not specified, the default is 30 seconds. Providing a unit-less value is deprecated and will warn; it will be an error in the future.
+    /// Optionally takes a unit-less value in milliseconds, or a time span value such as "2s 500ms",
+    /// to use as the polling interval. If not specified, the default is 30 seconds.
+    /// Providing a unit-less value is deprecated and will warn; it will be an error in the future.
     ///
     /// Aliased as '--force-poll'.
-    #[arg(long = "poll", value_name = "INTERVAL")]
+    #[arg(long = "poll", alias = "force-poll", num_args = 0..=1, default_missing_value = "30s", value_name = "INTERVAL")]
     pub poll: Option<String>,
     /// Use a different shell
     ///
-    /// By default, Watchexec will use '$SHELL' if it's defined or a default of 'sh' on Unix-likes, and either 'pwsh', 'powershell', or 'cmd' (CMD.EXE) on Windows, depending on what Watchexec detects is the running shell.
+    /// By default, Watchexec will use '$SHELL' if it's defined or a default of 'sh' on Unix-likes,
+    /// and either 'pwsh', 'powershell', or 'cmd' (CMD.EXE) on Windows, depending on what Watchexec
+    /// detects is the running shell.
     ///
-    /// With this option, you can override that and use a different shell, for example one with more features or one which has your custom aliases and functions.
+    /// With this option, you can override that and use a different shell, for example one with more
+    /// features or one which has your custom aliases and functions.
     ///
-    /// If the value has spaces, it is parsed as a command line, and the first word used as the shell program, with the rest as arguments to the shell.
+    /// If the value has spaces, it is parsed as a command line, and the first word used as the
+    /// shell program, with the rest as arguments to the shell.
     ///
     /// The command is run with the '-c' flag (except for 'cmd' on Windows, where it's '/C').
     ///
-    /// The special value 'none' can be used to disable shell use entirely. In that case, the command provided to Watchexec will be parsed, with the first word being the executable and the rest being the arguments, and executed directly. Note that this parsing is rudimentary, and may not work as expected in all cases.
+    /// The special value 'none' can be used to disable shell use entirely. In that case, the
+    /// command provided to Watchexec will be parsed, with the first word being the executable and
+    /// the rest being the arguments, and executed directly. Note that this parsing is rudimentary,
+    /// and may not work as expected in all cases.
     ///
-    /// Using 'none' is a little more efficient and can enable a stricter interpretation of the input, but it also means that you can't use shell features like globbing, redirection, control flow, logic, or pipes.
+    /// Using 'none' is a little more efficient and can enable a stricter interpretation of the
+    /// input, but it also means that you can't use shell features like globbing, redirection,
+    /// control flow, logic, or pipes.
     ///
     /// Examples:
     ///
     /// Use without shell:
     ///
-    /// $ watchexec -n -- zsh -x -o shwordsplit scr
+    ///   $ watchexec -n -- zsh -x -o shwordsplit scr
     ///
     /// Use with powershell core:
     ///
-    /// $ watchexec --shell=pwsh -- Test-Connection localhost
+    ///   $ watchexec --shell=pwsh -- Test-Connection localhost
     ///
     /// Use with CMD.exe:
     ///
-    /// $ watchexec --shell=cmd -- dir
+    ///   $ watchexec --shell=cmd -- dir
     ///
     /// Use with a different unix shell:
     ///
-    /// $ watchexec --shell=bash -- 'echo $BASH_VERSION'
+    ///   $ watchexec --shell=bash -- 'echo $BASH_VERSION'
     ///
     /// Use with a unix shell and options:
     ///
-    /// $ watchexec --shell='zsh -x -o shwordsplit' -- scr
-    #[arg(long = "shell", value_name = "SHELL")]
+    ///   $ watchexec --shell='zsh -x -o shwordsplit' -- scr
+    #[arg(long = "shell", help_heading = "Command", value_name = "SHELL")]
     pub shell: Option<String>,
     /// Shorthand for '--shell=none'
-    #[arg(short = 'n')]
+    #[arg(short = 'n', help_heading = "Command")]
     pub n: bool,
     /// Configure event emission
     ///
@@ -5253,131 +5888,262 @@ pub struct WatchArgs {
     /// numbers of files will either cause the environment to be truncated, or may error or crash
     /// the process entirely. The $WATCHEXEC_COMMON_PATH is also unintuitive, as demonstrated by the
     /// multiple confused queries that have landed in my inbox over the years.
-    #[arg(long = "emit-events-to", value_name = "MODE", value_parser = ::clap::builder::PossibleValuesParser::new(["environment", "stdio", "file", "json-stdio", "json-file", "none"]), default_value = "none")]
+    #[arg(long = "emit-events-to", help_heading = "Command", value_name = "MODE", value_parser = ::clap::builder::PossibleValuesParser::new(["environment", "stdio", "file", "json-stdio", "json-file", "none"]), default_value = "none")]
     pub emit_events_to: Option<String>,
+    /// Only emit events to stdout, run no commands.
+    ///
+    /// This is a convenience option for using Watchexec as a file watcher, without running any
+    /// commands. It is almost equivalent to using `cat` as the command, except that it will not
+    /// spawn a new process for each event.
+    ///
+    /// This option requires `--emit-events-to` to be set, and restricts the available modes to
+    /// `stdio` and `json-stdio`, modifying their behaviour to write to stdout instead of the stdin
+    /// of the command.
     #[arg(
-        help = "Only emit events to stdout, run no commands",
-        long_help = "Only emit events to stdout, run no commands.\n\nThis is a convenience option for using Watchexec as a file watcher, without running any commands. It is almost equivalent to using `cat` as the command, except that it will not spawn a new process for each event.\n\nThis option requires `--emit-events-to` to be set, and restricts the available modes to `stdio` and `json-stdio`, modifying their behaviour to write to stdout instead of the stdin of the command.",
-        long = "only-emit-events"
+        long = "only-emit-events",
+        help_heading = "Output",
+        conflicts_with = "manual"
     )]
     pub only_emit_events: bool,
     /// Add env vars to the command
     ///
-    /// This is a convenience option for setting environment variables for the command, without setting them for the Watchexec process itself.
+    /// This is a convenience option for setting environment variables for the command, without
+    /// setting them for the Watchexec process itself.
     ///
     /// Use key=value syntax. Multiple variables can be set by repeating the option.
-    #[arg(long = "env", short = 'E', value_name = "KEY=VALUE")]
+    #[arg(
+        long = "env",
+        short = 'E',
+        help_heading = "Command",
+        value_name = "KEY=VALUE"
+    )]
     pub env: Vec<String>,
     /// Configure how the process is wrapped
     ///
-    /// By default, Watchexec will run the command in a session on macOS, in a process group on other Unix platforms, and in a Job Object in Windows.
+    /// By default, Watchexec will run the command in a session on macOS, in a process group on
+    /// other Unix platforms, and in a Job Object in Windows.
     ///
     /// Some Unix programs prefer running in a session, while others do not work in a process group.
     ///
-    /// Use 'group' to use a process group, 'session' to use a process session, and 'none' to run the command directly. On Windows, either of 'group' or 'session' will use a Job Object.
-    #[arg(long = "wrap-process", value_name = "MODE", value_parser = ::clap::builder::PossibleValuesParser::new(["group", "session", "none"]))]
+    /// Use 'group' to use a process group, 'session' to use a process session, and 'none' to run
+    /// the command directly. On Windows, either of 'group' or 'session' will use a Job Object.
+    #[arg(long = "wrap-process", help_heading = "Command", value_name = "MODE", value_parser = ::clap::builder::PossibleValuesParser::new(["group", "session", "none"]))]
     pub wrap_process: Option<String>,
     /// Alert when commands start and end
     ///
-    /// With this, Watchexec will emit a desktop notification when a command starts and ends, on supported platforms. On unsupported platforms, it may silently do nothing, or log a warning.
-    #[arg(long = "notify", short = 'N')]
+    /// With this, Watchexec will emit a desktop notification when a command starts and ends, on
+    /// supported platforms. On unsupported platforms, it may silently do nothing, or log a warning.
+    #[arg(long = "notify", short = 'N', help_heading = "Output")]
     pub notify: bool,
     /// When to use terminal colours
     ///
     /// Setting the environment variable `NO_COLOR` to any value is equivalent to `--color=never`.
-    #[arg(long = "color", value_name = "MODE", value_parser = ::clap::builder::PossibleValuesParser::new(["auto", "always", "never"]), default_value = "auto")]
+    #[arg(long = "color", alias = "colour", help_heading = "Output", value_name = "MODE", value_parser = ::clap::builder::PossibleValuesParser::new(["auto", "always", "never"]), default_value = "auto")]
     pub color: Option<String>,
     /// Print how long the command took to run
     ///
-    /// This may not be exactly accurate, as it includes some overhead from Watchexec itself. Use the `time` utility, high-precision timers, or benchmarking tools for more accurate results.
-    #[arg(long = "timings")]
+    /// This may not be exactly accurate, as it includes some overhead from Watchexec itself. Use
+    /// the `time` utility, high-precision timers, or benchmarking tools for more accurate results.
+    #[arg(long = "timings", help_heading = "Output")]
     pub timings: bool,
     /// Don't print starting and stopping messages
     ///
-    /// By default Watchexec will print a message when the command starts and stops. This option disables this behaviour, so only the command's output, warnings, and errors will be printed.
-    #[arg(long = "quiet", short = 'q')]
+    /// By default Watchexec will print a message when the command starts and stops. This option
+    /// disables this behaviour, so only the command's output, warnings, and errors will be printed.
+    #[arg(long = "quiet", short = 'q', help_heading = "Output")]
     pub quiet: bool,
     /// Ring the terminal bell on command completion
-    #[arg(long = "bell")]
+    #[arg(long = "bell", help_heading = "Output")]
     pub bell: bool,
     /// Set the project origin
     ///
-    /// Watchexec will attempt to discover the project's "origin" (or "root") by searching for a variety of markers, like files or directory patterns. It does its best but sometimes gets it it wrong, and you can override that with this option.
+    /// Watchexec will attempt to discover the project's "origin" (or "root") by searching for a
+    /// variety of markers, like files or directory patterns. It does its best but sometimes gets it
+    /// it wrong, and you can override that with this option.
     ///
-    /// The project origin is used to determine the path of certain ignore files, which VCS is being used, the meaning of a leading '/' in filtering patterns, and maybe more in the future.
+    /// The project origin is used to determine the path of certain ignore files, which VCS is being
+    /// used, the meaning of a leading '/' in filtering patterns, and maybe more in the future.
     ///
     /// When set, Watchexec will also not bother searching, which can be significantly faster.
     #[arg(long = "project-origin", value_name = "DIRECTORY")]
     pub project_origin: Option<String>,
     /// Set the working directory
     ///
-    /// By default, the working directory of the command is the working directory of Watchexec. You can change that with this option. Note that paths may be less intuitive to use with this.
+    /// By default, the working directory of the command is the working directory of Watchexec. You
+    /// can change that with this option. Note that paths may be less intuitive to use with this.
     #[arg(long = "workdir", value_name = "DIRECTORY")]
     pub workdir: Option<String>,
     /// Filename extensions to filter to
     ///
-    /// This is a quick filter to only emit events for files with the given extensions. Extensions can be given with or without the leading dot (e.g. 'js' or '.js'). Multiple extensions can be given by repeating the option or by separating them with commas.
-    #[arg(long = "exts", short = 'e', value_name = "EXTENSIONS")]
+    /// This is a quick filter to only emit events for files with the given extensions. Extensions
+    /// can be given with or without the leading dot (e.g. 'js' or '.js'). Multiple extensions can
+    /// be given by repeating the option or by separating them with commas.
+    #[arg(
+        long = "exts",
+        short = 'e',
+        value_delimiter = ',',
+        help_heading = "Filtering",
+        value_name = "EXTENSIONS"
+    )]
     pub exts: Vec<String>,
     /// Filename patterns to filter to
     ///
-    /// Provide a glob-like filter pattern, and only events for files matching the pattern will be emitted. Multiple patterns can be given by repeating the option. Events that are not from files (e.g. signals, keyboard events) will pass through untouched.
-    #[arg(long = "filter", short = 'f', value_name = "PATTERN")]
+    /// Provide a glob-like filter pattern, and only events for files matching the pattern will be
+    /// emitted. Multiple patterns can be given by repeating the option. Events that are not from
+    /// files (e.g. signals, keyboard events) will pass through untouched.
+    #[arg(
+        long = "filter",
+        short = 'f',
+        help_heading = "Filtering",
+        value_name = "PATTERN"
+    )]
     pub filter: Vec<String>,
     /// Files to load filters from
     ///
-    /// Provide a path to a file containing filters, one per line. Empty lines and lines starting with '#' are ignored. Uses the same pattern format as the '--filter' option.
+    /// Provide a path to a file containing filters, one per line. Empty lines and lines starting
+    /// with '#' are ignored. Uses the same pattern format as the '--filter' option.
     ///
     /// This can also be used via the $WATCHEXEC_FILTER_FILES environment variable.
-    #[arg(long = "filter-file", value_name = "PATH")]
-    pub filter_file: Vec<String>,
     #[arg(
-        help = "[experimental] Filter programs",
-        long_help = "[experimental] Filter programs.\n\n/!\\ This option is EXPERIMENTAL and may change and/or vanish without notice.\n\nProvide your own custom filter programs in jaq (similar to jq) syntax. Programs are given an event in the same format as described in '--emit-events-to' and must return a boolean. Invalid programs will make watchexec fail to start; use '-v' to see program runtime errors.\n\nIn addition to the jaq stdlib, watchexec adds some custom filter definitions:\n\n- 'path | file_meta' returns file metadata or null if the file does not exist.\n\n- 'path | file_size' returns the size of the file at path, or null if it does not exist.\n\n- 'path | file_read(bytes)' returns a string with the first n bytes of the file at path. If the file is smaller than n bytes, the whole file is returned. There is no filter to read the whole file at once to encourage limiting the amount of data read and processed.\n\n- 'string | hash', and 'path | file_hash' return the hash of the string or file at path. No guarantee is made about the algorithm used: treat it as an opaque value.\n\n- 'any | kv_store(key)', 'kv_fetch(key)', and 'kv_clear' provide a simple key-value store. Data is kept in memory only, there is no persistence. Consistency is not guaranteed.\n\n- 'any | printout', 'any | printerr', and 'any | log(level)' will print or log any given value to stdout, stderr, or the log (levels = error, warn, info, debug, trace), and pass the value through (so '[1] | log(\"debug\") | .[]' will produce a '1' and log '[1]').\n\nAll filtering done with such programs, and especially those using kv or filesystem access, is much slower than the other filtering methods. If filtering is too slow, events will back up and stall watchexec. Take care when designing your filters.\n\nIf the argument to this option starts with an '@', the rest of the argument is taken to be the path to a file containing a jaq program.\n\nJaq programs are run in order, after all other filters, and short-circuit: if a filter (jaq or not) rejects an event, execution stops there, and no other filters are run. Additionally, they stop after outputting the first value, so you'll want to use 'any' or 'all' when iterating, otherwise only the first item will be processed, which can be quite confusing!\n\nFind user-contributed programs or submit your own useful ones at <https://github.com/watchexec/watchexec/discussions/592>.\n\n## Examples:\n\nRegexp ignore filter on paths:\n\n'all(.tags[] | select(.kind == \"path\"); .absolute | test(\"[.]test[.]js$\")) | not'\n\nPass any event that creates a file:\n\n'any(.tags[] | select(.kind == \"fs\"); .simple == \"create\")'\n\nPass events that touch executable files:\n\n'any(.tags[] | select(.kind == \"path\" && .filetype == \"file\"); .absolute | metadata | .executable)'\n\nIgnore files that start with shebangs:\n\n'any(.tags[] | select(.kind == \"path\" && .filetype == \"file\"); .absolute | read(2) == \"#!\") | not'",
+        long = "filter-file",
+        value_delimiter = ':',
+        env = "WATCHEXEC_FILTER_FILES",
+        help_heading = "Filtering",
+        value_name = "PATH"
+    )]
+    pub filter_file: Vec<String>,
+    /// [experimental] Filter programs.
+    ///
+    /// /!\ This option is EXPERIMENTAL and may change and/or vanish without notice.
+    ///
+    /// Provide your own custom filter programs in jaq (similar to jq) syntax. Programs are given
+    /// an event in the same format as described in '--emit-events-to' and must return a boolean.
+    /// Invalid programs will make watchexec fail to start; use '-v' to see program runtime errors.
+    ///
+    /// In addition to the jaq stdlib, watchexec adds some custom filter definitions:
+    ///
+    ///   - 'path | file_meta' returns file metadata or null if the file does not exist.
+    ///
+    ///   - 'path | file_size' returns the size of the file at path, or null if it does not exist.
+    ///
+    ///   - 'path | file_read(bytes)' returns a string with the first n bytes of the file at path.
+    ///     If the file is smaller than n bytes, the whole file is returned. There is no filter to
+    ///     read the whole file at once to encourage limiting the amount of data read and processed.
+    ///
+    ///   - 'string | hash', and 'path | file_hash' return the hash of the string or file at path.
+    ///     No guarantee is made about the algorithm used: treat it as an opaque value.
+    ///
+    ///   - 'any | kv_store(key)', 'kv_fetch(key)', and 'kv_clear' provide a simple key-value store.
+    ///     Data is kept in memory only, there is no persistence. Consistency is not guaranteed.
+    ///
+    ///   - 'any | printout', 'any | printerr', and 'any | log(level)' will print or log any given
+    ///     value to stdout, stderr, or the log (levels = error, warn, info, debug, trace), and
+    ///     pass the value through (so '[1] | log("debug") | .[]' will produce a '1' and log '[1]').
+    ///
+    /// All filtering done with such programs, and especially those using kv or filesystem access,
+    /// is much slower than the other filtering methods. If filtering is too slow, events will back
+    /// up and stall watchexec. Take care when designing your filters.
+    ///
+    /// If the argument to this option starts with an '@', the rest of the argument is taken to be
+    /// the path to a file containing a jaq program.
+    ///
+    /// Jaq programs are run in order, after all other filters, and short-circuit: if a filter (jaq
+    /// or not) rejects an event, execution stops there, and no other filters are run. Additionally,
+    /// they stop after outputting the first value, so you'll want to use 'any' or 'all' when
+    /// iterating, otherwise only the first item will be processed, which can be quite confusing!
+    ///
+    /// Find user-contributed programs or submit your own useful ones at
+    /// <https://github.com/watchexec/watchexec/discussions/592>.
+    ///
+    /// ## Examples:
+    ///
+    /// Regexp ignore filter on paths:
+    ///
+    ///   'all(.tags[] | select(.kind == "path"); .absolute | test("[.]test[.]js$")) | not'
+    ///
+    /// Pass any event that creates a file:
+    ///
+    ///   'any(.tags[] | select(.kind == "fs"); .simple == "create")'
+    ///
+    /// Pass events that touch executable files:
+    ///
+    ///   'any(.tags[] | select(.kind == "path" && .filetype == "file"); .absolute | metadata | .executable)'
+    ///
+    /// Ignore files that start with shebangs:
+    ///
+    ///   'any(.tags[] | select(.kind == "path" && .filetype == "file"); .absolute | read(2) == "#!") | not'
+    #[arg(
         long = "filter-prog",
         short = 'J',
+        help_heading = "Filtering",
         value_name = "EXPRESSION"
     )]
     pub filter_prog: Vec<String>,
     /// Filename patterns to filter out
     ///
-    /// Provide a glob-like filter pattern, and events for files matching the pattern will be excluded. Multiple patterns can be given by repeating the option. Events that are not from files (e.g. signals, keyboard events) will pass through untouched.
-    #[arg(long = "ignore", short = 'i', value_name = "PATTERN")]
+    /// Provide a glob-like filter pattern, and events for files matching the pattern will be
+    /// excluded. Multiple patterns can be given by repeating the option. Events that are not from
+    /// files (e.g. signals, keyboard events) will pass through untouched.
+    #[arg(
+        long = "ignore",
+        short = 'i',
+        help_heading = "Filtering",
+        value_name = "PATTERN"
+    )]
     pub ignore: Vec<String>,
     /// Files to load ignores from
     ///
-    /// Provide a path to a file containing ignores, one per line. Empty lines and lines starting with '#' are ignored. Uses the same pattern format as the '--ignore' option.
+    /// Provide a path to a file containing ignores, one per line. Empty lines and lines starting
+    /// with '#' are ignored. Uses the same pattern format as the '--ignore' option.
     ///
     /// This can also be used via the $WATCHEXEC_IGNORE_FILES environment variable.
-    #[arg(long = "ignore-file", value_name = "PATH")]
+    #[arg(
+        long = "ignore-file",
+        value_delimiter = ':',
+        env = "WATCHEXEC_IGNORE_FILES",
+        help_heading = "Filtering",
+        value_name = "PATH"
+    )]
     pub ignore_file: Vec<String>,
     /// Filesystem events to filter to
     ///
-    /// This is a quick filter to only emit events for the given types of filesystem changes. Choose from 'access', 'create', 'remove', 'rename', 'modify', 'metadata'. Multiple types can be given by repeating the option or by separating them with commas. By default, this is all types except for 'access'.
+    /// This is a quick filter to only emit events for the given types of filesystem changes. Choose
+    /// from 'access', 'create', 'remove', 'rename', 'modify', 'metadata'. Multiple types can be
+    /// given by repeating the option or by separating them with commas. By default, this is all
+    /// types except for 'access'.
     ///
-    /// This may apply filtering at the kernel level when possible, which can be more efficient, but may be more confusing when reading the logs.
-    #[arg(long = "fs-events", value_name = "EVENTS", value_parser = ::clap::builder::PossibleValuesParser::new(["access", "create", "remove", "rename", "modify", "metadata"]), default_value = "create")]
+    /// This may apply filtering at the kernel level when possible, which can be more efficient, but
+    /// may be more confusing when reading the logs.
+    #[arg(long = "fs-events", value_delimiter = ',', help_heading = "Filtering", value_name = "EVENTS", value_parser = ::clap::builder::PossibleValuesParser::new(["access", "create", "remove", "rename", "modify", "metadata"]), default_value = "create,remove,rename,modify,metadata")]
     pub fs_events: Vec<String>,
     /// Don't emit fs events for metadata changes
     ///
-    /// This is a shorthand for '--fs-events create,remove,rename,modify'. Using it alongside the '--fs-events' option is non-sensical and not allowed.
-    #[arg(long = "no-meta")]
+    /// This is a shorthand for '--fs-events create,remove,rename,modify'. Using it alongside the
+    /// '--fs-events' option is non-sensical and not allowed.
+    #[arg(
+        long = "no-meta",
+        help_heading = "Filtering",
+        conflicts_with = "fs_events"
+    )]
     pub no_meta: bool,
     /// Print events that trigger actions
     ///
-    /// This prints the events that triggered the action when handling it (after debouncing), in a human readable form. This is useful for debugging filters.
+    /// This prints the events that triggered the action when handling it (after debouncing), in a
+    /// human readable form. This is useful for debugging filters.
     ///
     /// Use '-vvv' instead when you need more diagnostic information.
-    #[arg(long = "print-events")]
+    #[arg(long = "print-events", help_heading = "Debugging")]
     pub print_events: bool,
     /// Show the manual page
     ///
-    /// This shows the manual page for Watchexec, if the output is a terminal and the 'man' program is available. If not, the manual page is printed to stdout in ROFF format (suitable for writing to a watchexec.1 file).
-    #[arg(long = "manual")]
+    /// This shows the manual page for Watchexec, if the output is a terminal and the 'man' program
+    /// is available. If not, the manual page is printed to stdout in ROFF format (suitable for
+    /// writing to a watchexec.1 file).
+    #[arg(long = "manual", help_heading = "Debugging")]
     pub manual: bool,
     #[arg(
         value_name = "TASK",
-        help = "Tasks to run\nCan specify multiple tasks by separating with `:::`\ne.g.: `mise run task1 arg1 arg2 ::: task2 arg1 arg2`"
+        help = "Tasks to run\nCan specify multiple tasks by separating with `:::`\ne.g.: `mise run task1 arg1 arg2 ::: task2 arg1 arg2`\nDefaults to `default`"
     )]
     pub task: Option<String>,
     /// Task and arguments to run
@@ -5418,13 +6184,13 @@ pub struct WhichArgs {
     #[arg(long = "complete", hide = true)]
     pub complete: bool,
     /// Show the plugin name instead of the path
-    #[arg(long = "plugin")]
+    #[arg(long = "plugin", conflicts_with = "version")]
     pub plugin: bool,
     /// Show the version instead of the path
-    #[arg(long = "version")]
+    #[arg(long = "version", conflicts_with = "plugin")]
     pub version: bool,
     /// The bin to look up
-    #[arg(value_name = "BIN_NAME")]
+    #[arg(value_name = "BIN_NAME", required_unless_present = "complete")]
     pub bin_name: Option<String>,
 }
 
@@ -5447,8 +6213,14 @@ pub struct Cli {
     /// Force the operation
     #[arg(long = "force", short = 'f', hide = true)]
     pub force: bool,
-    /// How many jobs to run in parallel [default: 8]
-    #[arg(long = "jobs", short = 'j', global = true, value_name = "JOBS")]
+    /// How many jobs to run in parallel; values below 1 are treated as 1 [default: 8]
+    #[arg(
+        long = "jobs",
+        short = 'j',
+        global = true,
+        env = "MISE_JOBS",
+        value_name = "JOBS"
+    )]
     pub jobs: Option<String>,
     /// Dry run, don't actually do anything
     #[arg(long = "dry-run", short = 'n', hide = true)]
@@ -5459,19 +6231,36 @@ pub struct Cli {
         short = 'P',
         global = true,
         hide = true,
+        conflicts_with = "env",
         value_name = "PROFILE"
     )]
     pub profile: Vec<String>,
     /// Suppress non-error messages
-    #[arg(long = "quiet", short = 'q', global = true)]
+    #[arg(
+        long = "quiet",
+        short = 'q',
+        global = true,
+        overrides_with = "silent",
+        overrides_with = "trace",
+        overrides_with = "verbose",
+        overrides_with = "debug",
+        overrides_with = "log_level"
+    )]
     pub quiet: bool,
     #[arg(long = "shell", short = 's', hide = true, value_name = "SHELL")]
     pub shell: Option<String>,
-    /// Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10
-    #[arg(long = "tool", short = 't', hide = true, value_name = "TOOL@VERSION")]
+    #[arg(
+        help = "Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10",
+        long_help = "Tool(s) to run in addition to what is in mise.toml files\ne.g.: node@20 python@3.10",
+        long = "tool",
+        short = 't',
+        hide = true,
+        env = "MISE_QUIET",
+        value_name = "TOOL@VERSION"
+    )]
     pub tool: Vec<String>,
     /// Show extra output (use -vv for even more)
-    #[arg(long = "verbose", short = 'v', global = true, action = ::clap::ArgAction::Count)]
+    #[arg(long = "verbose", short = 'v', global = true, action = ::clap::ArgAction::Count, overrides_with = "quiet", overrides_with = "silent", overrides_with = "trace", overrides_with = "debug")]
     pub verbose: u8,
     #[arg(long = "version", short = 'V', hide = true)]
     pub version: bool,
@@ -5479,9 +6268,18 @@ pub struct Cli {
     #[arg(long = "yes", short = 'y', global = true)]
     pub yes: bool,
     /// Sets log level to debug
-    #[arg(long = "debug", global = true, hide = true)]
+    #[arg(
+        long = "debug",
+        global = true,
+        hide = true,
+        overrides_with = "quiet",
+        overrides_with = "trace",
+        overrides_with = "verbose",
+        overrides_with = "silent",
+        overrides_with = "log_level"
+    )]
     pub debug: bool,
-    #[arg(long = "log-level", global = true, hide = true, value_name = "LEVEL", value_parser = ::clap::builder::PossibleValuesParser::new(["trace", "debug", "info", "warning", "error"]))]
+    #[arg(long = "log-level", global = true, hide = true, overrides_with = "quiet", overrides_with = "trace", overrides_with = "verbose", overrides_with = "silent", overrides_with = "debug", value_name = "LEVEL", value_parser = ::clap::builder::PossibleValuesParser::new(["trace", "debug", "info", "warning", "error"]))]
     pub log_level: Option<String>,
     /// Do not load any config files
     ///
@@ -5501,7 +6299,7 @@ pub struct Cli {
     /// Hides elapsed time after each task completes
     ///
     /// Default to always hide with `MISE_TASK_TIMINGS=0`
-    #[arg(long = "no-timings", hide = true)]
+    #[arg(long = "no-timings", alias = "no-timing", hide = true)]
     pub no_timings: bool,
     #[arg(long = "output", value_name = "OUTPUT")]
     pub output: Option<String>,
@@ -5516,15 +6314,32 @@ pub struct Cli {
     #[arg(long = "locked", global = true)]
     pub locked: bool,
     /// Suppress all task output and mise non-error messages
-    #[arg(long = "silent", global = true)]
+    #[arg(
+        long = "silent",
+        global = true,
+        overrides_with = "quiet",
+        overrides_with = "trace",
+        overrides_with = "verbose",
+        overrides_with = "debug",
+        overrides_with = "log_level"
+    )]
     pub silent: bool,
     /// Shows elapsed time after each task completes
     ///
     /// Default to always show with `MISE_TASK_TIMINGS=1`
-    #[arg(long = "timings", hide = true)]
+    #[arg(long = "timings", alias = "timing", hide = true)]
     pub timings: bool,
     /// Sets log level to trace
-    #[arg(long = "trace", global = true, hide = true)]
+    #[arg(
+        long = "trace",
+        global = true,
+        hide = true,
+        overrides_with = "quiet",
+        overrides_with = "silent",
+        overrides_with = "verbose",
+        overrides_with = "debug",
+        overrides_with = "log_level"
+    )]
     pub trace: bool,
     #[arg(
         value_name = "TASK",
@@ -5550,7 +6365,7 @@ pub enum Commands {
     #[command(name = "tool-alias", aliases = ["alias", "aliases"])]
     ToolAlias(Box<ToolAliasArgs>),
     /// [internal] simulates asdf for plugins that call "asdf" internally
-    #[command(name = "asdf")]
+    #[command(name = "asdf", hide = true)]
     Asdf(Box<AsdfArgs>),
     /// Manage backends
     #[command(name = "backends", aliases = ["b", "backend", "backend-list"])]
@@ -5559,7 +6374,7 @@ pub enum Commands {
     #[command(name = "bin-paths")]
     BinPaths(Box<BinPathsArgs>),
     /// Set up a machine for the current config in one command
-    #[command(name = "bootstrap", visible_alias = "bs")]
+    #[command(name = "bootstrap", alias = "bs")]
     Bootstrap(Box<BootstrapArgs>),
     /// Manage the mise cache
     #[command(name = "cache")]
@@ -5571,16 +6386,16 @@ pub enum Commands {
     #[command(name = "config", visible_alias = "cfg", alias = "toml")]
     Config(Box<ConfigArgs>),
     /// Shows current active and installed runtime versions
-    #[command(name = "current")]
+    #[command(name = "current", hide = true)]
     Current(Box<CurrentArgs>),
     /// Disable mise for current shell session
     #[command(name = "deactivate")]
     Deactivate(Box<DeactivateArgs>),
     /// Output direnv function to use mise inside direnv
-    #[command(name = "direnv")]
+    #[command(name = "direnv", hide = true)]
     Direnv(Box<DirenvArgs>),
     /// Manage dotfiles from `[dotfiles]` (deprecated)
-    #[command(name = "dotfiles")]
+    #[command(name = "dotfiles", hide = true)]
     Dotfiles(Box<DotfilesArgs>),
     /// Check mise installation for possible problems
     #[command(name = "doctor", visible_alias = "dr")]
@@ -5601,16 +6416,16 @@ pub enum Commands {
     #[command(name = "generate", visible_alias = "gen", alias = "g")]
     Generate(Box<GenerateArgs>),
     /// GitHub related commands
-    #[command(name = "github")]
+    #[command(name = "github", hide = true)]
     Github(Box<GithubArgs>),
     /// Sets/gets the global tool version(s)
-    #[command(name = "global")]
+    #[command(name = "global", hide = true)]
     Global(Box<GlobalArgs>),
     /// [internal] called by activate hook to update env vars directory change
-    #[command(name = "hook-env")]
+    #[command(name = "hook-env", hide = true)]
     HookEnv(Box<HookEnvArgs>),
     /// [internal] called by shell when a command is not found
-    #[command(name = "hook-not-found")]
+    #[command(name = "hook-not-found", hide = true)]
     HookNotFound(Box<HookNotFoundArgs>),
     /// Removes mise CLI and all related data
     #[command(name = "implode")]
@@ -5631,7 +6446,7 @@ pub enum Commands {
     #[command(name = "link", visible_alias = "ln")]
     Link(Box<LinkArgs>),
     /// Sets/gets tool version in local .tool-versions or mise.toml
-    #[command(name = "local", alias = "l")]
+    #[command(name = "local", hide = true, alias = "l")]
     Local(Box<LocalArgs>),
     /// Update lockfile checksums and URLs for all specified platforms
     #[command(name = "lock")]
@@ -5667,7 +6482,7 @@ pub enum Commands {
     #[command(name = "registry")]
     Registry(Box<RegistryArgs>),
     /// internal command to generate markdown from help
-    #[command(name = "render-help")]
+    #[command(name = "render-help", hide = true)]
     RenderHelp(Box<RenderHelpArgs>),
     /// Creates new shims based on bin paths from currently installed tools.
     #[command(name = "reshim")]
@@ -5685,11 +6500,7 @@ pub enum Commands {
     #[command(name = "set", aliases = ["ev", "env-vars"])]
     Set(Box<SetArgs>),
     /// Manage settings
-    #[command(
-        name = "settings",
-        about = "Manage settings",
-        long_about = "Show current settings\n\nThis is the contents of ~/.config/mise/config.toml\n\nNote that aliases are also stored in this file\nbut managed separately with `mise tool-alias`"
-    )]
+    #[command(name = "settings")]
     Settings(Box<SettingsArgs>),
     /// Sets a tool version for the current session.
     #[command(name = "shell", visible_alias = "sh")]
@@ -5727,7 +6538,7 @@ pub enum Commands {
     /// Remove environment variable(s) from the config file.
     #[command(name = "unset")]
     Unset(Box<UnsetArgs>),
-    /// No longer trust a config, will prompt in the future
+    /// Remove explicit trust for a config
     #[command(name = "untrust")]
     Untrust(Box<UntrustArgs>),
     /// Removes installed tool versions from mise.toml
@@ -5737,7 +6548,7 @@ pub enum Commands {
     #[command(name = "upgrade", visible_alias = "up")]
     Upgrade(Box<UpgradeArgs>),
     /// Generate a usage CLI spec
-    #[command(name = "usage")]
+    #[command(name = "usage", hide = true)]
     Usage(Box<UsageArgs>),
     /// Installs a tool and adds the version to mise.toml.
     #[command(name = "use", visible_alias = "u")]

--- a/benches/shadows/mise/src/lib.rs
+++ b/benches/shadows/mise/src/lib.rs
@@ -25,7 +25,7 @@ use usage_derive::{Args, Cli, Subcommands};
 /// Customize status output with `status` settings.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ eval \"$(mise activate bash)\"\n    $ eval \"$(mise activate zsh)\"\n    $ mise activate fish | source\n    $ execx($(mise activate xonsh))\n    $ (&mise activate pwsh) | Out-String | Invoke-Expression",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1meval \"$(mise activate bash)\"\u{1b}[22m\n    $ \u{1b}[1meval \"$(mise activate zsh)\"\u{1b}[22m\n    $ \u{1b}[1mmise activate fish | source\u{1b}[22m\n    $ \u{1b}[1mexecx($(mise activate xonsh))\u{1b}[22m\n    $ \u{1b}[1m(&mise activate pwsh) | Out-String | Invoke-Expression\u{1b}[22m\n",
     effect = "read"
 )]
 pub struct ActivateArgs {
@@ -43,7 +43,10 @@ pub struct ActivateArgs {
     pub shell: ::std::option::Option<::std::string::String>,
     /// Do not automatically call hook-env
     ///
-    /// This can be helpful for debugging mise. If you run `eval "$(mise activate --no-hook-env)"`, then you can call `mise hook-env` manually which will output the env vars to stdout without actually modifying the environment. That way you can do things like `mise hook-env --trace` to get more information or just see the values that hook-env is outputting.
+    /// This can be helpful for debugging mise. If you run `eval "$(mise activate --no-hook-env)"`, then
+    /// you can call `mise hook-env` manually which will output the env vars to stdout without actually
+    /// modifying the environment. That way you can do things like `mise hook-env --trace` to get more
+    /// information or just see the values that hook-env is outputting.
     #[usage(long = "no-hook-env")]
     pub no_hook_env: bool,
     #[usage(
@@ -69,7 +72,7 @@ pub struct ActivateArgs {
 /// This is the contents of a tool_alias.<TOOL> entry in ~/.config/mise/config.toml
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise tool-alias get node lts-hydrogen\n    20.0.0",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise tool-alias get node lts-hydrogen\u{1b}[22m\n    20.0.0\n",
     effect = "read"
 )]
 pub struct ToolAliasGetArgs {
@@ -83,7 +86,7 @@ pub struct ToolAliasGetArgs {
 
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise tool-alias ls\n    node  lts-jod      22",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise tool-alias ls\u{1b}[22m\n    node  lts-jod      22\n",
     effect = "read"
 )]
 pub struct ToolAliasLsArgs {
@@ -100,7 +103,7 @@ pub struct ToolAliasLsArgs {
 /// This modifies the contents of ~/.config/mise/config.toml
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise tool-alias set maven asdf:mise-plugins/mise-maven\n    $ mise tool-alias set node lts-jod 22.0.0",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise tool-alias set maven asdf:mise-plugins/mise-maven\u{1b}[22m\n    $ \u{1b}[1mmise tool-alias set node lts-jod 22.0.0\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct ToolAliasSetArgs {
@@ -120,7 +123,7 @@ pub struct ToolAliasSetArgs {
 /// This modifies the contents of ~/.config/mise/config.toml
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise tool-alias unset maven\n    $ mise tool-alias unset node lts-jod",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise tool-alias unset maven\u{1b}[22m\n    $ \u{1b}[1mmise tool-alias unset node lts-jod\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct ToolAliasUnsetArgs {
@@ -137,7 +140,7 @@ pub struct ToolAliasUnsetArgs {
 #[usage(effect = "read")]
 pub struct ToolAliasArgs {
     /// Filter aliases by tool
-    #[usage(long = "tool", short = 'p', value_name = "TOOL")]
+    #[usage(long = "tool", alias = "plugin", short = 'p', value_name = "TOOL")]
     pub tool: ::std::option::Option<::std::string::String>,
     /// Don't show table header
     #[usage(long = "no-header")]
@@ -177,7 +180,7 @@ pub struct AsdfArgs {
 /// List built-in backends
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise backends ls\n    aqua\n    asdf\n    cargo\n    core\n    dotnet\n    gem\n    go\n    npm\n    pipx\n    spm\n    ubi\n    vfox",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise backends ls\u{1b}[22m\n    aqua\n    asdf\n    cargo\n    core\n    dotnet\n    gem\n    go\n    npm\n    pipx\n    spm\n    ubi\n    vfox\n",
     effect = "read"
 )]
 pub struct BackendsLsArgs {}
@@ -185,7 +188,7 @@ pub struct BackendsLsArgs {}
 /// Manage backends
 #[derive(Args)]
 #[usage(
-    after_long_help = "Deprecation:\n\nThe `mise b` alias is deprecated and will be removed in mise 2027.4.0.\nUse `mise backends` instead.",
+    after_long_help = "\u{1b}[1m\u{1b}[4mDeprecation:\u{1b}[22m\u{1b}[24m\n\nThe `mise b` alias is deprecated and will be removed in mise 2027.4.0.\nUse `mise backends` instead.\n",
     effect = "read"
 )]
 pub struct BackendsArgs {
@@ -329,7 +332,7 @@ pub enum BootstrapComposeCommands {
 /// under `dotfiles.root` unless `--source` is provided.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise bootstrap dotfiles add ~/.zshrc\n    $ mise bootstrap dotfiles add --mode copy ~/.config/starship.toml\n    $ mise bootstrap dotfiles add --source dotfiles/gitconfig ~/.gitconfig",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap dotfiles add ~/.zshrc\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles add --mode copy ~/.config/starship.toml\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles add --source dotfiles/gitconfig ~/.gitconfig\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct BootstrapDotfilesAddArgs {
@@ -337,10 +340,10 @@ pub struct BootstrapDotfilesAddArgs {
     #[usage(long = "force", short = 'f')]
     pub force: bool,
     /// Write to the global config
-    #[usage(long = "global", short = 'g')]
+    #[usage(long = "global", short = 'g', conflicts("--local", "--path"))]
     pub global: bool,
     /// Write to the local config instead of the global config
-    #[usage(long = "local", short = 'l')]
+    #[usage(long = "local", short = 'l', conflicts("--global", "--path"))]
     pub local: bool,
     /// Dotfile mode to write
     #[usage(long = "mode", short = 'm', value_name = "MODE")]
@@ -352,7 +355,12 @@ pub struct BootstrapDotfilesAddArgs {
     #[usage(long = "no-apply")]
     pub no_apply: bool,
     /// Write to this config file or directory
-    #[usage(long = "path", long = "file", short = 'p', value_name = "PATH")]
+    #[usage(
+        long = "path",
+        short = 'p',
+        conflicts("--global", "--local"),
+        value_name = "PATH"
+    )]
     pub path: ::std::option::Option<::std::string::String>,
     /// Source path to use for a single target
     #[usage(long = "source", short = 's', value_name = "PATH")]
@@ -373,7 +381,7 @@ pub struct BootstrapDotfilesAddArgs {
 /// mise doesn't otherwise own.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise bootstrap dotfiles apply\n    $ mise bootstrap dotfiles apply --dry-run\n    $ mise bootstrap dotfiles apply --force --yes",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap dotfiles apply\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles apply --dry-run\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles apply --force --yes\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct BootstrapDotfilesApplyArgs {
@@ -394,7 +402,7 @@ pub struct BootstrapDotfilesApplyArgs {
 /// Edit a managed dotfile source
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise bootstrap dotfiles edit ~/.zshrc\n    $ mise bootstrap dotfiles edit --apply ~/.config/starship.toml",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap dotfiles edit ~/.zshrc\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles edit --apply ~/.config/starship.toml\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct BootstrapDotfilesEditArgs {
@@ -418,7 +426,7 @@ pub struct BootstrapDotfilesEditArgs {
 /// Show the status of dotfiles from `[dotfiles]`
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise bootstrap dotfiles status\n    $ mise bootstrap dotfiles status ~/.zshrc\n    $ mise bootstrap dotfiles status --json\n    $ mise bootstrap dotfiles status --missing # exit 1 if anything is out of sync",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap dotfiles status\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles status ~/.zshrc\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles status --json\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles status --missing\u{1b}[22m # exit 1 if anything is out of sync\n",
     effect = "read"
 )]
 pub struct BootstrapDotfilesStatusArgs {
@@ -442,7 +450,7 @@ pub struct BootstrapDotfilesStatusArgs {
 /// edits require `--force`.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise bootstrap dotfiles unapply\n    $ mise bootstrap dotfiles unapply ~/.zshrc\n    $ mise bootstrap dotfiles unapply --dry-run\n    $ mise bootstrap dotfiles unapply --force --yes",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap dotfiles unapply\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles unapply ~/.zshrc\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles unapply --dry-run\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles unapply --force --yes\u{1b}[22m\n",
     effect = "destructive"
 )]
 pub struct BootstrapDotfilesUnapplyArgs {
@@ -480,7 +488,7 @@ pub enum BootstrapDotfilesCommands {
     #[usage(name = "edit")]
     Edit(Box<BootstrapDotfilesEditArgs>),
     /// Show the status of dotfiles from `[dotfiles]`
-    #[usage(name = "status", alias = "ls")]
+    #[usage(name = "status")]
     Status(Box<BootstrapDotfilesStatusArgs>),
     /// Remove dotfiles applied from `[dotfiles]`
     #[usage(name = "unapply")]
@@ -850,7 +858,7 @@ pub enum BootstrapMiseShellActivateCommands {
 /// only. `install` is accepted as an alias for this command.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise bootstrap packages apply\n    $ mise bootstrap packages apply apk:zlib-dev apt:curl brew:jq brew-cask:firefox flatpak:org.mozilla.firefox mas:497799835\n    $ mise bootstrap packages apply --dry-run\n    $ mise bootstrap packages apply --manager apt --yes",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap packages apply\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages apply apk:zlib-dev apt:curl brew:jq brew-cask:firefox flatpak:org.mozilla.firefox flatpak-user:org.gnome.Builder mas:497799835\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages apply --dry-run\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages apply --manager apt --yes\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct BootstrapPackagesApplyArgs {
@@ -866,15 +874,19 @@ pub struct BootstrapPackagesApplyArgs {
     /// Refresh package manager metadata first (apk: `--update-cache`, apt: `apt-get update`)
     #[usage(long = "update")]
     pub update: bool,
-    /// Packages in `manager:package` form; defaults to everything configured in [bootstrap.packages]
-    #[usage(arg, name = "PACKAGE")]
+    #[usage(
+        arg,
+        name = "PACKAGE",
+        help = "Packages in `manager:package` form; defaults to everything configured in [bootstrap.packages]",
+        long_help = "Packages in `manager:package` form; defaults to everything configured\nin [bootstrap.packages]"
+    )]
     pub package: ::std::vec::Vec<::std::string::String>,
 }
 
 /// Add a Homebrew tap URL to [bootstrap.brew.taps]
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise bootstrap packages brew tap railwaycat/emacsmacport\n    $ mise bootstrap packages brew tap acme/tools https://github.com/acme/homebrew-tools.git",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap packages brew tap railwaycat/emacsmacport\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages brew tap acme/tools https://github.com/acme/homebrew-tools.git\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct BootstrapPackagesBrewTapArgs {
@@ -885,7 +897,13 @@ pub struct BootstrapPackagesBrewTapArgs {
     #[usage(long = "dry-run", short = 'n')]
     pub dry_run: bool,
     /// Write to this config file or directory
-    #[usage(long = "path", long = "file", short = 'p', value_name = "PATH")]
+    #[usage(
+        long = "path",
+        long = "file",
+        short = 'p',
+        conflicts = "--local",
+        value_name = "PATH"
+    )]
     pub path: ::std::option::Option<::std::string::String>,
     /// Tap name, e.g. `owner/repo`
     #[usage(arg, name = "TAP")]
@@ -898,7 +916,7 @@ pub struct BootstrapPackagesBrewTapArgs {
 /// Remove Homebrew tap URLs from [bootstrap.brew.taps]
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise bootstrap packages brew untap railwaycat/emacsmacport",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap packages brew untap railwaycat/emacsmacport\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct BootstrapPackagesBrewUntapArgs {
@@ -909,7 +927,13 @@ pub struct BootstrapPackagesBrewUntapArgs {
     #[usage(long = "dry-run", short = 'n')]
     pub dry_run: bool,
     /// Write to this config file or directory
-    #[usage(long = "path", long = "file", short = 'p', value_name = "PATH")]
+    #[usage(
+        long = "path",
+        long = "file",
+        short = 'p',
+        conflicts = "--local",
+        value_name = "PATH"
+    )]
     pub path: ::std::option::Option<::std::string::String>,
     /// Tap name(s), e.g. `owner/repo`
     #[usage(arg, name = "TAPS", required)]
@@ -944,17 +968,22 @@ pub enum BootstrapPackagesBrewCommands {
 /// Pass `--all` to import every linked formula, including dependencies.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise bootstrap packages import --manager brew\n    $ mise bootstrap packages import --manager brew --all\n    $ mise bootstrap packages import --manager brew --global\n    $ mise bootstrap packages import --manager brew --dry-run",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap packages import --manager brew\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages import --manager brew --all\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages import --manager brew --global\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages import --manager brew --dry-run\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct BootstrapPackagesImportArgs {
     /// Write to the config file for this environment (mise.<ENV>.toml)
-    #[usage(long = "env", short = 'e', value_name = "ENV")]
+    #[usage(
+        long = "env",
+        short = 'e',
+        conflicts("--global", "--path"),
+        value_name = "ENV"
+    )]
     pub env: ::std::option::Option<::std::string::String>,
     /// Write to the global config (~/.config/mise/config.toml)
-    #[usage(long = "global", short = 'g')]
+    #[usage(long = "global", short = 'g', conflicts("--env", "--path"))]
     pub global: bool,
-    /// Only import packages for this manager. Currently only `brew` is supported
+    /// Only import packages for this manager. Currently only `brew` is supported.
     #[usage(
         long = "manager",
         short = 'm',
@@ -970,27 +999,33 @@ pub struct BootstrapPackagesImportArgs {
     #[usage(long = "dry-run", short = 'n')]
     pub dry_run: bool,
     /// Write to this config file or directory
-    #[usage(long = "path", long = "file", short = 'p', value_name = "PATH")]
+    #[usage(
+        long = "path",
+        long = "file",
+        short = 'p',
+        conflicts = "--global",
+        value_name = "PATH"
+    )]
     pub path: ::std::option::Option<::std::string::String>,
 }
 
 /// Prune installed system packages no longer declared in `[bootstrap.packages]`
 ///
-/// Currently supports Homebrew formulae only. Pruning removes linked formulae
-/// that are not needed by the current config or by trusted, loadable tracked
-/// configs.
+/// Supports Homebrew formulae and conservatively removable, mise-owned casks.
+/// Pruning keeps packages needed by the current config or by trusted, loadable
+/// tracked configs.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise bootstrap packages prune --manager brew\n    $ mise bootstrap packages prune --manager brew --dry-run\n    $ mise bootstrap packages prune --manager brew --yes",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap packages prune --manager brew\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages prune --manager brew --dry-run\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages prune --manager brew --yes\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages prune --manager brew-cask --dry-run\u{1b}[22m\n",
     effect = "destructive"
 )]
 pub struct BootstrapPackagesPruneArgs {
-    /// Only prune packages for this manager. Currently only `brew` is supported
+    /// Only prune packages for this manager
     #[usage(
         long = "manager",
         short = 'm',
         value_name = "MANAGER",
-        choices("brew"),
+        choices("brew", "brew-cask"),
         default = "brew"
     )]
     pub manager: ::std::option::Option<::std::string::String>,
@@ -1005,7 +1040,7 @@ pub struct BootstrapPackagesPruneArgs {
 /// Show the status of system packages from `[bootstrap.packages]`
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise bootstrap packages status\n    $ mise bootstrap packages status --json\n    $ mise bootstrap packages status --missing # exit 1 if anything is out of sync",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap packages status\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages status --json\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages status --missing\u{1b}[22m # exit 1 if anything is out of sync\n",
     effect = "read"
 )]
 pub struct BootstrapPackagesStatusArgs {
@@ -1023,14 +1058,14 @@ pub struct BootstrapPackagesStatusArgs {
 /// that are already installed: apk/apt/dnf/pacman upgrade to the newest available
 /// version (apk, apt, and dnf honor a version pinned in config), brew pours the
 /// formula's current bottle and replaces the old keg, brew-cask installs
-/// the current cask artifact, flatpak updates applications and runtimes, and mas upgrades App Store apps. Packages that
+/// the current cask artifact, flatpak and flatpak-user update applications and runtimes, and mas upgrades App Store apps. Packages that
 /// are not installed yet are skipped — use `mise bootstrap packages apply`
 /// for those.
 ///
 /// Packages can also be given explicitly in `manager:package` form.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise bootstrap packages upgrade\n    $ mise bootstrap packages upgrade brew:postgresql@17\n    $ mise bootstrap packages upgrade --manager brew-cask\n    $ mise bootstrap packages upgrade --manager mas\n    $ mise bootstrap packages upgrade --manager apt --yes\n    $ mise bootstrap packages upgrade --dry-run",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap packages upgrade\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages upgrade brew:postgresql@17\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages upgrade --manager brew-cask\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages upgrade --manager mas\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages upgrade --manager apt --yes\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages upgrade --dry-run\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct BootstrapPackagesUpgradeArgs {
@@ -1043,8 +1078,12 @@ pub struct BootstrapPackagesUpgradeArgs {
     /// Skip the confirmation prompt
     #[usage(long = "yes", short = 'y')]
     pub yes: bool,
-    /// Packages in `manager:package` form; defaults to everything configured in [bootstrap.packages]
-    #[usage(arg, name = "PACKAGE")]
+    #[usage(
+        arg,
+        name = "PACKAGE",
+        help = "Packages in `manager:package` form; defaults to everything configured in [bootstrap.packages]",
+        long_help = "Packages in `manager:package` form; defaults to everything configured\nin [bootstrap.packages]"
+    )]
     pub package: ::std::vec::Vec<::std::string::String>,
 }
 
@@ -1061,21 +1100,36 @@ pub struct BootstrapPackagesUpgradeArgs {
 /// a mise version selector. mas uses numeric ADAM IDs and does not support pins.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise bootstrap packages use apk:zlib-dev apt:curl brew:jq brew-cask:firefox flatpak:org.mozilla.firefox mas:497799835\n    $ mise bootstrap packages use -g brew:postgresql@17\n    $ mise bootstrap packages use apt:curl@8.5.0-2",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap packages use apk:zlib-dev apt:curl brew:jq brew-cask:firefox flatpak:org.mozilla.firefox flatpak-user:org.gnome.Builder mas:497799835\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages use -g brew:postgresql@17\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages use apt:curl@8.5.0-2\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct BootstrapPackagesUseArgs {
     /// Write to the config file for this environment (mise.<ENV>.toml)
-    #[usage(long = "env", short = 'e', value_name = "ENV")]
+    #[usage(
+        long = "env",
+        short = 'e',
+        conflicts("--global", "--path"),
+        value_name = "ENV"
+    )]
     pub env: ::std::option::Option<::std::string::String>,
-    /// Write to the global config (~/.config/mise/config.toml) instead of the local one
-    #[usage(long = "global", short = 'g')]
+    #[usage(
+        help = "Write to the global config (~/.config/mise/config.toml) instead of the local one",
+        long_help = "Write to the global config (~/.config/mise/config.toml) instead of the\nlocal one",
+        long = "global",
+        short = 'g'
+    )]
     pub global: bool,
     /// Print the commands that would run without writing config or installing
     #[usage(long = "dry-run", short = 'n')]
     pub dry_run: bool,
     /// Write to this config file or directory
-    #[usage(long = "path", long = "file", short = 'p', value_name = "PATH")]
+    #[usage(
+        long = "path",
+        long = "file",
+        short = 'p',
+        conflicts = "--global",
+        value_name = "PATH"
+    )]
     pub path: ::std::option::Option<::std::string::String>,
     /// Skip the confirmation prompt
     #[usage(long = "yes", short = 'y')]
@@ -1173,7 +1227,11 @@ pub struct BootstrapRemoteArgs {
     #[usage(long = "all")]
     pub all: bool,
     /// Explicit remote shell command that installs mise and places it on PATH
-    #[usage(long = "bootstrap-command", value_name = "COMMAND")]
+    #[usage(
+        long = "bootstrap-command",
+        conflicts("--mise-bin", "--remote-mise"),
+        value_name = "COMMAND"
+    )]
     pub bootstrap_command: ::std::option::Option<::std::string::String>,
     /// SSH connection timeout in seconds
     #[usage(
@@ -1182,6 +1240,12 @@ pub struct BootstrapRemoteArgs {
         default = "10"
     )]
     pub connect_timeout: ::std::option::Option<::std::string::String>,
+    /// Dereference one source-relative symbolic link; repeat for multiple links
+    #[usage(long = "copy-link", value_name = "PATH", var)]
+    pub copy_link: ::std::vec::Vec<::std::string::String>,
+    /// Dereference every symbolic link in the source archive
+    #[usage(long = "copy-links")]
+    pub copy_links: bool,
     /// Additional archive pattern to exclude; repeat for multiple patterns
     #[usage(long = "exclude", value_name = "PATTERN", var)]
     pub exclude: ::std::vec::Vec<::std::string::String>,
@@ -1204,11 +1268,17 @@ pub struct BootstrapRemoteArgs {
     #[usage(long = "keep-staging")]
     pub keep_staging: bool,
     /// Local mise binary to upload (escape hatch for custom architectures)
-    #[usage(long = "mise-bin", value_name = "MISE_BIN")]
+    #[usage(
+        long = "mise-bin",
+        conflicts("--remote-mise", "--bootstrap-command"),
+        value_name = "MISE_BIN"
+    )]
     pub mise_bin: ::std::option::Option<::std::string::String>,
     /// Run only one or more remote bootstrap parts
     #[usage(
         long = "only",
+        conflicts = "--skip",
+        delimiter = ',',
         value_name = "ONLY",
         choices(
             "plugins",
@@ -1221,13 +1291,9 @@ pub struct BootstrapRemoteArgs {
             "repos",
             "dotfiles",
             "mise-shell-activate",
-            "shell",
             "macos-defaults",
-            "defaults",
             "macos-launchd-agents",
-            "launchd",
             "linux-systemd-units",
-            "systemd",
             "user",
             "tools",
             "task",
@@ -1242,12 +1308,20 @@ pub struct BootstrapRemoteArgs {
     /// Prompt securely for missing secret inputs on the remote host
     #[usage(long = "prompt-secrets")]
     pub prompt_secrets: bool,
+    /// Config environments to load on the remote host; repeat or delimit with commas (for example, ci,dotfiles)
+    #[usage(long = "remote-env", delimiter = ',', value_name = "ENV", var)]
+    pub remote_env: ::std::vec::Vec<::std::string::String>,
     /// Existing mise executable name or path; relative paths use the staged project
-    #[usage(long = "remote-mise", value_name = "COMMAND")]
+    #[usage(
+        long = "remote-mise",
+        conflicts("--mise-bin", "--bootstrap-command"),
+        value_name = "COMMAND"
+    )]
     pub remote_mise: ::std::option::Option<::std::string::String>,
     /// Skip one or more remote bootstrap parts
     #[usage(
         long = "skip",
+        delimiter = ',',
         value_name = "SKIP",
         choices(
             "plugins",
@@ -1260,13 +1334,9 @@ pub struct BootstrapRemoteArgs {
             "repos",
             "dotfiles",
             "mise-shell-activate",
-            "shell",
             "macos-defaults",
-            "defaults",
             "macos-launchd-agents",
-            "launchd",
             "linux-systemd-units",
-            "systemd",
             "user",
             "tools",
             "task",
@@ -1578,7 +1648,7 @@ pub enum BootstrapUserCommands {
 /// cannot be used together.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise bootstrap                    # packages + repos + dotfiles + tools + bootstrap task\n    $ mise bootstrap --force-dotfiles   # replace conflicting dotfile targets\n    $ mise bootstrap --skip tools,task  # skip tool installation and the bootstrap task\n    $ mise bootstrap --only tools       # run just tool installation\n    $ mise bootstrap status --missing\n    $ mise bootstrap packages apply --yes\n    $ mise bootstrap repos status\n    $ mise bootstrap repos apply --dry-run\n    $ mise bootstrap dotfiles status\n    $ mise bootstrap mise-shell-activate apply --dry-run\n    $ mise bootstrap macos defaults status\n    $ mise bootstrap macos launchd-agents apply --dry-run\n    $ mise bootstrap linux systemd-units apply --dry-run\n    $ mise bootstrap user apply --dry-run",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap\u{1b}[22m                    # packages + repos + dotfiles + tools + bootstrap task\n    $ \u{1b}[1mmise bootstrap --force-dotfiles\u{1b}[22m   # replace conflicting dotfile targets\n    $ \u{1b}[1mmise bootstrap --skip tools,task\u{1b}[22m  # skip tool installation and the bootstrap task\n    $ \u{1b}[1mmise bootstrap --only tools\u{1b}[22m       # run just tool installation\n    $ \u{1b}[1mmise bootstrap status --missing\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap packages apply --yes\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap repos status\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap repos apply --dry-run\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles status\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap mise-shell-activate apply --dry-run\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap macos defaults status\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap macos launchd-agents apply --dry-run\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap linux systemd-units apply --dry-run\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap user apply --dry-run\u{1b}[22m\n",
     effect = "destructive"
 )]
 pub struct BootstrapArgs {
@@ -1593,9 +1663,12 @@ pub struct BootstrapArgs {
     pub force_dotfiles: bool,
     /// Run only one or more bootstrap parts
     ///
-    /// Can be passed multiple times or as a comma-separated list. Cannot be used with `--skip`.
+    /// Can be passed multiple times or as a comma-separated list.
+    /// Cannot be used with `--skip`.
     #[usage(
         long = "only",
+        conflicts = "--skip",
+        delimiter = ',',
         value_name = "ONLY",
         choices(
             "plugins",
@@ -1608,13 +1681,9 @@ pub struct BootstrapArgs {
             "repos",
             "dotfiles",
             "mise-shell-activate",
-            "shell",
             "macos-defaults",
-            "defaults",
             "macos-launchd-agents",
-            "launchd",
             "linux-systemd-units",
-            "systemd",
             "user",
             "tools",
             "task",
@@ -1631,6 +1700,7 @@ pub struct BootstrapArgs {
     /// Can be passed multiple times or as a comma-separated list.
     #[usage(
         long = "skip",
+        delimiter = ',',
         value_name = "SKIP",
         choices(
             "plugins",
@@ -1643,13 +1713,9 @@ pub struct BootstrapArgs {
             "repos",
             "dotfiles",
             "mise-shell-activate",
-            "shell",
             "macos-defaults",
-            "defaults",
             "macos-launchd-agents",
-            "launchd",
             "linux-systemd-units",
-            "systemd",
             "user",
             "tools",
             "task",
@@ -1749,10 +1815,14 @@ pub struct CacheClearArgs {
     #[usage(long = "outdate", hide)]
     pub outdate: bool,
     /// Clear output cache entries for a task name or pattern
-    #[usage(long = "task", value_name = "TASK")]
+    #[usage(long = "task", conflicts("TOOL", "--outdate"), value_name = "TASK")]
     pub task: ::std::option::Option<::std::string::String>,
-    /// Tool(s) to clear cache for e.g.: node, python
-    #[usage(arg, name = "TOOL")]
+    #[usage(
+        arg,
+        name = "TOOL",
+        help = "Tool(s) to clear cache for e.g.: node, python",
+        long_help = "Tool(s) to clear cache for\ne.g.: node, python"
+    )]
     pub tool: ::std::vec::Vec<::std::string::String>,
 }
 
@@ -1774,8 +1844,12 @@ pub struct CachePruneArgs {
     /// Just show what would be pruned
     #[usage(long = "dry-run")]
     pub dry_run: bool,
-    /// Tool(s) to prune cache for e.g.: node, python
-    #[usage(arg, name = "TOOL")]
+    #[usage(
+        arg,
+        name = "TOOL",
+        help = "Tool(s) to prune cache for e.g.: node, python",
+        long_help = "Tool(s) to prune cache for\ne.g.: node, python"
+    )]
     pub tool: ::std::vec::Vec<::std::string::String>,
 }
 
@@ -1820,18 +1894,12 @@ pub enum CacheCommands {
 /// Generate shell completions
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise completion bash --include-bash-completion-lib > ~/.local/share/bash-completion/completions/mise\n    $ mise completion zsh  > /usr/local/share/zsh/site-functions/_mise\n    $ mise completion fish > ~/.config/fish/completions/mise.fish\n    $ mise completion powershell >> $PROFILE",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise completion bash --include-bash-completion-lib > ~/.local/share/bash-completion/completions/mise\u{1b}[22m\n    $ \u{1b}[1mmise completion zsh  > /usr/local/share/zsh/site-functions/_mise\u{1b}[22m\n    $ \u{1b}[1mmise completion fish > ~/.config/fish/completions/mise.fish\u{1b}[22m\n    $ \u{1b}[1mmise completion powershell >> $PROFILE\u{1b}[22m\n",
     effect = "read"
 )]
 pub struct CompletionArgs {
     /// Shell type to generate completions for
-    #[usage(
-        long = "shell",
-        short = 's',
-        hide,
-        value_name = "SHELL_TYPE",
-        choices("bash", "fish", "powershell", "zsh")
-    )]
+    #[usage(long = "shell", short = 's', hide, value_name = "SHELL")]
     pub shell: ::std::option::Option<::std::string::String>,
     /// Include the bash completion library in the bash completion script
     ///
@@ -1847,14 +1915,14 @@ pub struct CompletionArgs {
     )]
     pub usage: bool,
     /// Shell type to generate completions for
-    #[usage(arg, name = "SHELL", choices("bash", "fish", "powershell", "zsh"))]
+    #[usage(arg, name = "SHELL", required_unless = "--shell")]
     pub shell_2: ::std::option::Option<::std::string::String>,
 }
 
 /// Display the value of a setting in a mise.toml file
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise toml get tools.python\n    3.12",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise toml get tools.python\u{1b}[22m\n    3.12\n",
     effect = "read"
 )]
 pub struct ConfigGetArgs {
@@ -1873,7 +1941,7 @@ pub struct ConfigGetArgs {
 /// List config files currently in use
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise config ls\n    Path                        Tools\n    ~/.config/mise/config.toml  pitchfork\n    ~/src/mise/mise.toml        actionlint, bun, cargo-binstall, cargo:cargo-insta",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise config ls\u{1b}[22m\n    Path                        Tools\n    ~/.config/mise/config.toml  pitchfork\n    ~/src/mise/mise.toml        actionlint, bun, cargo-binstall, cargo:cargo-insta\n",
     effect = "read"
 )]
 pub struct ConfigLsArgs {
@@ -1881,7 +1949,7 @@ pub struct ConfigLsArgs {
     #[usage(long = "json", short = 'J')]
     pub json: bool,
     /// Do not print table header
-    #[usage(long = "no-header")]
+    #[usage(long = "no-header", alias = "no-headers")]
     pub no_header: bool,
     /// List all tracked config files
     #[usage(long = "tracked-configs")]
@@ -1891,7 +1959,7 @@ pub struct ConfigLsArgs {
 /// Set the value of a setting in a mise.toml file
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise config set tools.python 3.12\n    $ mise config set settings.always_keep_download true\n    $ mise config set env.TEST_ENV_VAR ABC\n    $ mise config set settings.disable_tools node,rust\n\n    # Type for `settings` is inferred\n    $ mise config set settings.jobs 4",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise config set tools.python 3.12\u{1b}[22m\n    $ \u{1b}[1mmise config set settings.always_keep_download true\u{1b}[22m\n    $ \u{1b}[1mmise config set env.TEST_ENV_VAR ABC\u{1b}[22m\n    $ \u{1b}[1mmise config set settings.disable_tools node,rust\u{1b}[22m\n\n    # Type for `settings` is inferred\n    $ \u{1b}[1mmise config set settings.jobs 4\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct ConfigSetArgs {
@@ -1920,16 +1988,13 @@ pub struct ConfigSetArgs {
 
 /// Manage config files
 #[derive(Args)]
-#[usage(
-    after_long_help = "Examples:\n\n    $ mise config ls\n    Path                        Tools\n    ~/.config/mise/config.toml  pitchfork\n    ~/src/mise/mise.toml        actionlint, bun, cargo-binstall, cargo:cargo-insta",
-    effect = "read"
-)]
+#[usage(effect = "read")]
 pub struct ConfigArgs {
     /// Output in JSON format
     #[usage(long = "json", short = 'J')]
     pub json: bool,
     /// Do not print table header
-    #[usage(long = "no-header")]
+    #[usage(long = "no-header", alias = "no-headers")]
     pub no_header: bool,
     /// List all tracked config files
     #[usage(long = "tracked-configs")]
@@ -1957,12 +2022,16 @@ pub enum ConfigCommands {
 /// and/or version. It's designed to fit into scripts more easily.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    # outputs `.tool-versions` compatible format\n    $ mise current\n    python 3.11.0 3.10.0\n    shfmt 3.6.0\n    shellcheck 0.9.0\n    node 20.0.0\n\n    $ mise current node\n    20.0.0\n\n    # can output multiple versions\n    $ mise current python\n    3.11.0 3.10.0",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # outputs `.tool-versions` compatible format\n    $ \u{1b}[1mmise current\u{1b}[22m\n    python 3.11.0 3.10.0\n    shfmt 3.6.0\n    shellcheck 0.9.0\n    node 20.0.0\n\n    $ \u{1b}[1mmise current node\u{1b}[22m\n    20.0.0\n\n    # can output multiple versions\n    $ \u{1b}[1mmise current python\u{1b}[22m\n    3.11.0 3.10.0\n",
     effect = "read"
 )]
 pub struct CurrentArgs {
-    /// Plugin to show versions of e.g.: ruby, node, cargo:eza, npm:prettier, etc
-    #[usage(arg, name = "PLUGIN")]
+    #[usage(
+        arg,
+        name = "PLUGIN",
+        help = "Plugin to show versions of e.g.: ruby, node, cargo:eza, npm:prettier, etc.",
+        long_help = "Plugin to show versions of\ne.g.: ruby, node, cargo:eza, npm:prettier, etc."
+    )]
     pub plugin: ::std::option::Option<::std::string::String>,
 }
 
@@ -1971,7 +2040,7 @@ pub struct CurrentArgs {
 /// This can be used to temporarily disable mise in a shell session.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise deactivate",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise deactivate\u{1b}[22m\n",
     effect = "read"
 )]
 pub struct DeactivateArgs {}
@@ -1985,7 +2054,7 @@ pub struct DeactivateArgs {}
 /// direnv may not know to update environment variables when idiomatic file versions change.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise direnv activate > ~/.config/direnv/lib/use_mise.sh\n    $ echo 'use mise' > .envrc\n    $ direnv allow",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise direnv activate > ~/.config/direnv/lib/use_mise.sh\u{1b}[22m\n    $ \u{1b}[1mecho 'use mise' > .envrc\u{1b}[22m\n    $ \u{1b}[1mdirenv allow\u{1b}[22m\n",
     effect = "read"
 )]
 pub struct DirenvActivateArgs {}
@@ -2037,7 +2106,7 @@ pub enum DirenvCommands {
 /// under `dotfiles.root` unless `--source` is provided.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise bootstrap dotfiles add ~/.zshrc\n    $ mise bootstrap dotfiles add --mode copy ~/.config/starship.toml\n    $ mise bootstrap dotfiles add --source dotfiles/gitconfig ~/.gitconfig",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap dotfiles add ~/.zshrc\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles add --mode copy ~/.config/starship.toml\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles add --source dotfiles/gitconfig ~/.gitconfig\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct DotfilesAddArgs {
@@ -2045,10 +2114,10 @@ pub struct DotfilesAddArgs {
     #[usage(long = "force", short = 'f')]
     pub force: bool,
     /// Write to the global config
-    #[usage(long = "global", short = 'g')]
+    #[usage(long = "global", short = 'g', conflicts("--local", "--path"))]
     pub global: bool,
     /// Write to the local config instead of the global config
-    #[usage(long = "local", short = 'l')]
+    #[usage(long = "local", short = 'l', conflicts("--global", "--path"))]
     pub local: bool,
     /// Dotfile mode to write
     #[usage(long = "mode", short = 'm', value_name = "MODE")]
@@ -2060,7 +2129,12 @@ pub struct DotfilesAddArgs {
     #[usage(long = "no-apply")]
     pub no_apply: bool,
     /// Write to this config file or directory
-    #[usage(long = "path", long = "file", short = 'p', value_name = "PATH")]
+    #[usage(
+        long = "path",
+        short = 'p',
+        conflicts("--global", "--local"),
+        value_name = "PATH"
+    )]
     pub path: ::std::option::Option<::std::string::String>,
     /// Source path to use for a single target
     #[usage(long = "source", short = 's', value_name = "PATH")]
@@ -2081,7 +2155,7 @@ pub struct DotfilesAddArgs {
 /// mise doesn't otherwise own.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise bootstrap dotfiles apply\n    $ mise bootstrap dotfiles apply --dry-run\n    $ mise bootstrap dotfiles apply --force --yes",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap dotfiles apply\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles apply --dry-run\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles apply --force --yes\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct DotfilesApplyArgs {
@@ -2102,7 +2176,7 @@ pub struct DotfilesApplyArgs {
 /// Edit a managed dotfile source
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise bootstrap dotfiles edit ~/.zshrc\n    $ mise bootstrap dotfiles edit --apply ~/.config/starship.toml",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap dotfiles edit ~/.zshrc\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles edit --apply ~/.config/starship.toml\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct DotfilesEditArgs {
@@ -2126,7 +2200,7 @@ pub struct DotfilesEditArgs {
 /// Show the status of dotfiles from `[dotfiles]`
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise bootstrap dotfiles status\n    $ mise bootstrap dotfiles status ~/.zshrc\n    $ mise bootstrap dotfiles status --json\n    $ mise bootstrap dotfiles status --missing # exit 1 if anything is out of sync",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap dotfiles status\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles status ~/.zshrc\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles status --json\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles status --missing\u{1b}[22m # exit 1 if anything is out of sync\n",
     effect = "read"
 )]
 pub struct DotfilesStatusArgs {
@@ -2150,7 +2224,7 @@ pub struct DotfilesStatusArgs {
 /// edits require `--force`.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise bootstrap dotfiles unapply\n    $ mise bootstrap dotfiles unapply ~/.zshrc\n    $ mise bootstrap dotfiles unapply --dry-run\n    $ mise bootstrap dotfiles unapply --force --yes",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise bootstrap dotfiles unapply\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles unapply ~/.zshrc\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles unapply --dry-run\u{1b}[22m\n    $ \u{1b}[1mmise bootstrap dotfiles unapply --force --yes\u{1b}[22m\n",
     effect = "destructive"
 )]
 pub struct DotfilesUnapplyArgs {
@@ -2200,7 +2274,7 @@ pub enum DotfilesCommands {
 /// Print the current PATH entries mise is providing
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    Get the current PATH entries mise is providing\n    $ mise doctor path\n    /home/user/.local/share/mise/installs/node/24.0.0/bin\n    /home/user/.local/share/mise/installs/rust/1.90.0/bin\n    /home/user/.local/share/mise/installs/python/3.10.0/bin",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    Get the current PATH entries mise is providing\n    $ mise doctor path\n    /home/user/.local/share/mise/installs/node/24.0.0/bin\n    /home/user/.local/share/mise/installs/rust/1.90.0/bin\n    /home/user/.local/share/mise/installs/python/3.10.0/bin\n",
     effect = "read"
 )]
 pub struct DoctorPathArgs {
@@ -2212,7 +2286,7 @@ pub struct DoctorPathArgs {
 /// Check mise installation for possible problems
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise doctor\n    [WARN] plugin node is not installed",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise doctor\u{1b}[22m\n    [WARN] plugin node is not installed\n",
     effect = "read"
 )]
 pub struct DoctorArgs {
@@ -2236,7 +2310,7 @@ pub enum DoctorCommands {
 /// Note that changing directories will not update the mise environment.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise en .\n    $ node -v\n    v20.0.0\n\n    Skip loading bashrc:\n    $ mise en -s \"bash --norc\"\n\n    Skip loading zshrc:\n    $ mise en -s \"zsh -f\""
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise en .\u{1b}[22m\n    $ \u{1b}[1mnode -v\u{1b}[22m\n    v20.0.0\n\n    Skip loading bashrc:\n    $ \u{1b}[1mmise en -s \"bash --norc\"\u{1b}[22m\n\n    Skip loading zshrc:\n    $ \u{1b}[1mmise en -s \"zsh -f\"\u{1b}[22m\n"
 )]
 pub struct EnArgs {
     /// Shell to start
@@ -2255,26 +2329,26 @@ pub struct EnArgs {
 /// use this if you have `mise activate` in your shell rc file.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ eval \"$(mise env -s bash)\"\n    $ eval \"$(mise env -s zsh)\"\n    $ mise env -s fish | source\n    $ execx($(mise env -s xonsh))",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1meval \"$(mise env -s bash)\"\u{1b}[22m\n    $ \u{1b}[1meval \"$(mise env -s zsh)\"\u{1b}[22m\n    $ \u{1b}[1mmise env -s fish | source\u{1b}[22m\n    $ \u{1b}[1mexecx($(mise env -s xonsh))\u{1b}[22m\n",
     effect = "read"
 )]
 pub struct EnvArgs {
     /// Output in dotenv format
-    #[usage(long = "dotenv", short = 'D')]
+    #[usage(long = "dotenv", short = 'D', overrides = "--shell")]
     pub dotenv: bool,
     /// Output in JSON format
-    #[usage(long = "json", short = 'J')]
+    #[usage(long = "json", short = 'J', overrides = "--shell")]
     pub json: bool,
     /// Shell type to generate environment variables for
     #[usage(
         long = "shell",
         short = 's',
-        value_name = "SHELL",
-        choices("bash", "elvish", "fish", "nu", "xonsh", "zsh", "pwsh")
+        overrides = "--json",
+        value_name = "SHELL"
     )]
     pub shell: ::std::option::Option<::std::string::String>,
     /// Output in JSON format with additional information (source, tool)
-    #[usage(long = "json-extended")]
+    #[usage(long = "json-extended", overrides = "--shell")]
     pub json_extended: bool,
     /// Only show redacted environment variables
     #[usage(long = "redacted")]
@@ -2298,16 +2372,22 @@ pub struct EnvArgs {
 /// The "--" separates runtimes from the commands to pass along to the subprocess.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise exec node@20 -- node ./app.js  # launch app.js using node-20.x\n    $ mise x node@20 -- node ./app.js     # shorter alias\n\n    # Specify command as a string:\n    $ mise exec node@20 python@3.11 --command \"node -v && python -V\"\n\n    # Run a command in a different directory:\n    $ mise x -C /path/to/project node@20 -- node ./app.js"
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise exec node@20 -- node ./app.js\u{1b}[22m  # launch app.js using node-20.x\n    $ \u{1b}[1mmise x node@20 -- node ./app.js\u{1b}[22m     # shorter alias\n\n    # Specify command as a string:\n    $ \u{1b}[1mmise exec node@20 python@3.11 --command \"node -v && python -V\"\u{1b}[22m\n\n    # Run a command in a different directory:\n    $ \u{1b}[1mmise x -C /path/to/project node@20 -- node ./app.js\u{1b}[22m\n"
 )]
 pub struct ExecArgs {
     /// Command string to execute
-    #[usage(long = "command", short = 'c', value_name = "C")]
+    #[usage(
+        long = "command",
+        short = 'c',
+        conflicts = "COMMAND",
+        value_name = "COMMAND"
+    )]
     pub command: ::std::option::Option<::std::string::String>,
     #[usage(
-        help = "Number of jobs to run in parallel\n[default: 4]",
+        help = "Number of jobs to run in parallel\nValues below 1 are treated as 1\n[default: 4]",
         long = "jobs",
         short = 'j',
+        env = "MISE_JOBS",
         value_name = "JOBS"
     )]
     pub jobs: ::std::option::Option<::std::string::String>,
@@ -2352,14 +2432,28 @@ pub struct ExecArgs {
     /// Skip automatic dependency preparation
     #[usage(long = "no-deps")]
     pub no_deps: bool,
-    /// Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1
-    #[usage(long = "raw")]
+    #[usage(
+        help = "Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1",
+        long_help = "Connect backend install command stdin/stdout/stderr directly to the terminal\nImplies --jobs=1",
+        long = "raw",
+        overrides = "--jobs"
+    )]
     pub raw: bool,
-    /// Tool(s) to start e.g.: node@20 python@3.10
-    #[usage(arg, name = "TOOL@VERSION")]
+    #[usage(
+        arg,
+        name = "TOOL@VERSION",
+        help = "Tool(s) to start e.g.: node@20 python@3.10",
+        long_help = "Tool(s) to start\ne.g.: node@20 python@3.10"
+    )]
     pub tool_version: ::std::vec::Vec<::std::string::String>,
     /// Command string to execute (same as --command)
-    #[usage(arg, name = "COMMAND", double_dash = "required")]
+    #[usage(
+        arg,
+        name = "COMMAND",
+        conflicts = "--command",
+        required_unless = "--command",
+        double_dash = "required"
+    )]
     pub command_2: ::std::vec::Vec<::std::string::String>,
 }
 
@@ -2367,7 +2461,10 @@ pub struct ExecArgs {
 ///
 /// Sorts keys and cleans up whitespace in mise.toml
 #[derive(Args)]
-#[usage(after_long_help = "Examples:\n\n    $ mise fmt", effect = "write")]
+#[usage(
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise fmt\u{1b}[22m\n",
+    effect = "write"
+)]
 pub struct FmtArgs {
     /// Format all files from the current directory
     #[usage(long = "all", short = 'a')]
@@ -2375,8 +2472,12 @@ pub struct FmtArgs {
     /// Check if the configs are formatted, no formatting is done
     #[usage(long = "check", short = 'c')]
     pub check: bool,
-    /// Read config from stdin and write its formatted version into stdout
-    #[usage(long = "stdin", short = 's')]
+    #[usage(
+        help = "Read config from stdin and write its formatted version into stdout",
+        long_help = "Read config from stdin and write its formatted version into\nstdout",
+        long = "stdin",
+        short = 's'
+    )]
     pub stdin: bool,
 }
 
@@ -2385,7 +2486,7 @@ pub struct FmtArgs {
 /// This is designed to be used in a project where contributors may not have mise installed.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise generate bootstrap >./bin/mise\n    $ chmod +x ./bin/mise\n    $ ./bin/mise install – automatically downloads mise to .mise if not already installed",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise generate bootstrap --write ./bin/mise\u{1b}[22m\n    $ \u{1b}[1m./bin/mise install\u{1b}[22m                                    \u{1b}[2m# downloads mise to .mise if not already installed\u{1b}[22m\n\n    \u{1b}[2m# add a launcher for contributors who clone the project on Windows\u{1b}[22m\n    $ \u{1b}[1mmise generate bootstrap --write ./bin/mise --windows\u{1b}[22m  \u{1b}[2m# also writes bin/mise.cmd\u{1b}[22m\n    $ \u{1b}[1m.\\bin\\mise.cmd install\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct GenerateBootstrapArgs {
@@ -2398,7 +2499,13 @@ pub struct GenerateBootstrapArgs {
     #[usage(long = "version", short = 'V', value_name = "VERSION")]
     pub version: ::std::option::Option<::std::string::String>,
     /// instead of outputting the script to stdout, write to a file and make it executable
-    #[usage(long = "write", short = 'w', value_name = "WRITE")]
+    #[usage(
+        long = "write",
+        short = 'w',
+        default_missing = "./bin/mise",
+        value_name = "WRITE",
+        value_optional
+    )]
     pub write: ::std::option::Option<::std::string::String>,
     /// Directory to put localized data into
     #[usage(
@@ -2407,17 +2514,27 @@ pub struct GenerateBootstrapArgs {
         default = ".mise"
     )]
     pub localized_dir: ::std::option::Option<::std::string::String>,
+    /// Also write a Windows launcher, `<WRITE>.cmd`
+    ///
+    /// Windows cannot execute the `#!/usr/bin/env bash` script, so a contributor who clones the
+    /// project on Windows has nothing to run without this.
+    ///
+    /// Generated on every host, not only on Windows: the file is committed, and whoever runs it
+    /// on Windows is not the person who generated it. Requires `--write`, since stdout cannot
+    /// carry two files.
+    #[usage(long = "windows", requires = "--write")]
+    pub windows: bool,
 }
 
 /// Generate a mise.toml file
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise generate config             # generate mise.toml interactively\n    $ mise generate config .mise.toml  # generate a specific file\n    $ mise generate config -g          # generate the global config file\n    $ mise generate config -y          # skip interactive editor\n    $ mise generate config -n          # preview without writing",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise generate config\u{1b}[22m             \u{1b}[2m# generate mise.toml interactively\u{1b}[22m\n    $ \u{1b}[1mmise generate config .mise.toml\u{1b}[22m  \u{1b}[2m# generate a specific file\u{1b}[22m\n    $ \u{1b}[1mmise generate config -g\u{1b}[22m          \u{1b}[2m# generate the global config file\u{1b}[22m\n    $ \u{1b}[1mmise generate config -y\u{1b}[22m          \u{1b}[2m# skip interactive editor\u{1b}[22m\n    $ \u{1b}[1mmise generate config -n\u{1b}[22m          \u{1b}[2m# preview without writing\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct GenerateConfigArgs {
     /// Generate the global config file (~/.config/mise/config.toml)
-    #[usage(long = "global", short = 'g')]
+    #[usage(long = "global", short = 'g', conflicts = "PATH")]
     pub global: bool,
     /// Show what would be generated without writing to file
     #[usage(long = "dry-run", short = 'n')]
@@ -2433,7 +2550,7 @@ pub struct GenerateConfigArgs {
 /// Generate a devcontainer to execute mise
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise generate devcontainer",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise generate devcontainer\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct GenerateDevcontainerArgs {
@@ -2461,7 +2578,7 @@ pub struct GenerateDevcontainerArgs {
 /// For more advanced pre-commit functionality, see mise's sister project: https://hk.jdx.dev/
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise generate git-pre-commit --write --task=pre-commit\n    $ git commit -m \"feat: add new feature\" # runs `mise run pre-commit`",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise generate git-pre-commit --write --task=pre-commit\u{1b}[22m\n    $ \u{1b}[1mgit commit -m \"feat: add new feature\"\u{1b}[22m \u{1b}[2m# runs `mise run pre-commit`\u{1b}[22m\n\n    \u{1b}[2m# config lives in a subdirectory, so the hook has to change into it first\u{1b}[22m\n    $ \u{1b}[1mmise generate git-pre-commit --write -- -C subdir\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct GenerateGitPreCommitArgs {
@@ -2479,6 +2596,13 @@ pub struct GenerateGitPreCommitArgs {
     /// Which hook to generate (saves to .git/hooks/$hook)
     #[usage(long = "hook", value_name = "HOOK", default = "pre-commit")]
     pub hook: ::std::option::Option<::std::string::String>,
+    /// mise flags to embed in the generated hook, given after `--`
+    ///
+    /// These are inserted between `mise` and `run`, so the hook carries the same context you
+    /// would pass on the command line. Useful when the config is not at the repository root,
+    /// since git runs hooks from the top level: `-- -C subdir` makes the hook find it.
+    #[usage(arg, name = "MISE_ARG", double_dash = "required")]
+    pub mise_arg: ::std::vec::Vec<::std::string::String>,
 }
 
 /// Generate a GitHub Action workflow file
@@ -2487,7 +2611,7 @@ pub struct GenerateGitPreCommitArgs {
 /// when you push changes to your repository.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise generate github-action --write --task=ci\n    $ git commit -m \"feat: add new feature\"\n    $ git push # runs `mise run ci` on GitHub",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise generate github-action --write --task=ci\u{1b}[22m\n    $ \u{1b}[1mgit commit -m \"feat: add new feature\"\u{1b}[22m\n    $ \u{1b}[1mgit push\u{1b}[22m \u{1b}[2m# runs `mise run ci` on GitHub\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct GenerateGithubActionArgs {
@@ -2505,7 +2629,7 @@ pub struct GenerateGithubActionArgs {
 /// Generate documentation for tasks in a project
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise generate task-docs",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise generate task-docs\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct GenerateTaskDocsArgs {
@@ -2543,9 +2667,10 @@ pub struct GenerateTaskDocsArgs {
 ///
 /// By default, this will build shims like ./bin/<task>. These can be paired with `mise generate bootstrap`
 /// so contributors to a project can execute mise tasks without installing mise into their system.
+/// When a parent and nested task both exist, the parent stub is written to `<parent>/_default`.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise tasks add test -- echo 'running tests'\n    $ mise generate task-stubs\n    $ ./bin/test\n    running tests",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise tasks add test -- echo 'running tests'\u{1b}[22m\n    $ \u{1b}[1mmise generate task-stubs\u{1b}[22m\n    $ \u{1b}[1m./bin/test\u{1b}[22m\n    running tests\n",
     effect = "write"
 )]
 pub struct GenerateTaskStubsArgs {
@@ -2575,7 +2700,7 @@ pub struct GenerateTaskStubsArgs {
 /// to incrementally build cross-platform tool stubs.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    Generate a tool stub for a single URL:\n    $ mise generate tool-stub ./bin/gh --url \"https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_linux_amd64.tar.gz\"\n\n    Generate a tool stub with platform-specific URLs:\n    $ mise generate tool-stub ./bin/rg \\\n        --platform-url linux-x64:https://github.com/BurntSushi/ripgrep/releases/download/14.0.3/ripgrep-14.0.3-x86_64-unknown-linux-musl.tar.gz \\\n        --platform-url darwin-arm64:https://github.com/BurntSushi/ripgrep/releases/download/14.0.3/ripgrep-14.0.3-aarch64-apple-darwin.tar.gz\n\n    Append additional platforms to an existing stub:\n    $ mise generate tool-stub ./bin/rg \\\n        --platform-url linux-x64:https://example.com/rg-linux.tar.gz\n    $ mise generate tool-stub ./bin/rg \\\n        --platform-url darwin-arm64:https://example.com/rg-darwin.tar.gz\n    # The stub now contains both platforms\n\n    Use auto-detection for platform from URL:\n    $ mise generate tool-stub ./bin/node \\\n        --platform-url https://nodejs.org/dist/v22.17.1/node-v22.17.1-darwin-arm64.tar.gz\n    # Platform 'macos-arm64' will be auto-detected from the URL\n\n    Generate with platform-specific binary paths:\n    $ mise generate tool-stub ./bin/tool \\\n        --platform-url linux-x64:https://example.com/tool-linux.tar.gz \\\n        --platform-url windows-x64:https://example.com/tool-windows.zip \\\n        --platform-bin windows-x64:tool.exe\n\n    Generate without downloading (faster):\n    $ mise generate tool-stub ./bin/tool --url \"https://example.com/tool.tar.gz\" --skip-download\n\n    Fetch checksums for an existing stub:\n    $ mise generate tool-stub ./bin/jq --fetch\n    # This will read the existing stub and download files to fill in any missing checksums/sizes\n\n    Generate a bootstrap stub that installs mise if needed:\n    $ mise generate tool-stub ./bin/tool --url \"https://example.com/tool.tar.gz\" --bootstrap\n    # The stub will check for mise and install it automatically before running the tool\n\n    Generate a bootstrap stub with a pinned mise version:\n    $ mise generate tool-stub ./bin/tool --url \"https://example.com/tool.tar.gz\" --bootstrap --bootstrap-version 2025.1.0\n\n    Lock an existing tool stub with pinned version and platform URLs/checksums:\n    $ mise generate tool-stub ./bin/node --lock\n\n    Bump the version in a locked stub:\n    $ mise generate tool-stub ./bin/node --lock --version 22\n    # Resolves the latest node 22.x, pins it, and updates platform URLs/checksums",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    Generate a tool stub for a single URL:\n    $ \u{1b}[1mmise generate tool-stub ./bin/gh --url \"https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_linux_amd64.tar.gz\"\u{1b}[22m\n\n    Generate a tool stub with platform-specific URLs:\n    $ \u{1b}[1mmise generate tool-stub ./bin/rg \\\n        --platform-url linux-x64:https://github.com/BurntSushi/ripgrep/releases/download/14.0.3/ripgrep-14.0.3-x86_64-unknown-linux-musl.tar.gz \\\n        --platform-url darwin-arm64:https://github.com/BurntSushi/ripgrep/releases/download/14.0.3/ripgrep-14.0.3-aarch64-apple-darwin.tar.gz\u{1b}[22m\n\n    Append additional platforms to an existing stub:\n    $ \u{1b}[1mmise generate tool-stub ./bin/rg \\\n        --platform-url linux-x64:https://example.com/rg-linux.tar.gz\u{1b}[22m\n    $ \u{1b}[1mmise generate tool-stub ./bin/rg \\\n        --platform-url darwin-arm64:https://example.com/rg-darwin.tar.gz\u{1b}[22m\n    # The stub now contains both platforms\n\n    Use auto-detection for platform from URL:\n    $ \u{1b}[1mmise generate tool-stub ./bin/node \\\n        --platform-url https://nodejs.org/dist/v22.17.1/node-v22.17.1-darwin-arm64.tar.gz\u{1b}[22m\n    # Platform 'macos-arm64' will be auto-detected from the URL\n\n    Generate with platform-specific binary paths:\n    $ \u{1b}[1mmise generate tool-stub ./bin/tool \\\n        --platform-url linux-x64:https://example.com/tool-linux.tar.gz \\\n        --platform-url windows-x64:https://example.com/tool-windows.zip \\\n        --platform-bin windows-x64:tool.exe\u{1b}[22m\n\n    Generate without downloading (faster):\n    $ \u{1b}[1mmise generate tool-stub ./bin/tool --url \"https://example.com/tool.tar.gz\" --skip-download\u{1b}[22m\n\n    Fetch checksums for an existing stub:\n    $ \u{1b}[1mmise generate tool-stub ./bin/jq --fetch\u{1b}[22m\n    # This will read the existing stub and download files to fill in any missing checksums/sizes\n\n    Generate a bootstrap stub that installs mise if needed:\n    $ \u{1b}[1mmise generate tool-stub ./bin/tool --url \"https://example.com/tool.tar.gz\" --bootstrap\u{1b}[22m\n    # The stub will check for mise and install it automatically before running the tool\n\n    Generate a bootstrap stub with a pinned mise version:\n    $ \u{1b}[1mmise generate tool-stub ./bin/tool --url \"https://example.com/tool.tar.gz\" --bootstrap --bootstrap-version 2025.1.0\u{1b}[22m\n\n    Lock an existing tool stub with pinned version and platform URLs/checksums:\n    $ \u{1b}[1mmise generate tool-stub ./bin/node --lock\u{1b}[22m\n\n    Bump the version in a locked stub:\n    $ \u{1b}[1mmise generate tool-stub ./bin/node --lock --version 22\u{1b}[22m\n    # Resolves the latest node 22.x, pins it, and updates platform URLs/checksums\n",
     effect = "write"
 )]
 pub struct GenerateToolStubArgs {
@@ -2596,18 +2721,58 @@ pub struct GenerateToolStubArgs {
     ///
     /// By default, uses the latest version from the install script.
     /// Use this to pin to a specific version (e.g., "2025.1.0").
-    #[usage(long = "bootstrap-version", value_name = "BOOTSTRAP_VERSION")]
+    #[usage(
+        long = "bootstrap-version",
+        requires = "--bootstrap",
+        value_name = "BOOTSTRAP_VERSION"
+    )]
     pub bootstrap_version: ::std::option::Option<::std::string::String>,
+    /// Checksum algorithm to use when downloading artifacts
+    ///
+    /// Accepts `blake3` or `sha256` and defaults to `blake3`.
+    /// Cannot be used with `--lock` or `--skip-download` because those modes do not
+    /// calculate checksums.
+    #[usage(
+        long = "checksum-algorithm",
+        conflicts("--lock", "--skip-download"),
+        value_name = "CHECKSUM_ALGORITHM",
+        choices("blake3", "sha256"),
+        default = "blake3"
+    )]
+    pub checksum_algorithm: ::std::option::Option<::std::string::String>,
     /// Fetch checksums and sizes for an existing tool stub file
     ///
-    /// This reads an existing stub file and fills in any missing checksum/size fields by downloading the files. URLs must already be present in the stub.
-    #[usage(long = "fetch")]
+    /// This reads an existing stub file and fills in any missing checksum/size fields
+    /// by downloading the files. URLs must already be present in the stub.
+    #[usage(
+        long = "fetch",
+        conflicts(
+            "--url",
+            "--platform-url",
+            "--version",
+            "--bin",
+            "--platform-bin",
+            "--skip-download",
+            "--lock"
+        )
+    )]
     pub fetch: bool,
     /// HTTP backend type to use
     #[usage(long = "http", value_name = "HTTP", default = "http")]
     pub http: ::std::option::Option<::std::string::String>,
-    /// Resolve and embed lockfile data (exact version + platform URLs/checksums) into an existing stub file for reproducible installs without runtime API calls
-    #[usage(long = "lock")]
+    #[usage(
+        help = "Resolve and embed lockfile data (exact version + platform URLs/checksums) into an existing stub file for reproducible installs without runtime API calls",
+        long_help = "Resolve and embed lockfile data (exact version + platform URLs/checksums)\ninto an existing stub file for reproducible installs without runtime API calls",
+        long = "lock",
+        conflicts(
+            "--url",
+            "--platform-url",
+            "--bin",
+            "--platform-bin",
+            "--fetch",
+            "--skip-download"
+        )
+    )]
     pub lock: bool,
     /// Platform-specific binary paths in the format platform:path
     ///
@@ -2616,11 +2781,15 @@ pub struct GenerateToolStubArgs {
     pub platform_bin: ::std::vec::Vec<::std::string::String>,
     /// Platform-specific URLs in the format platform:url or just url (auto-detect platform)
     ///
-    /// When the output file already exists, new platforms will be appended to the existing platforms table. Existing platform URLs will be updated if specified again.
+    /// When the output file already exists, new platforms will be appended to the existing
+    /// platforms table. Existing platform URLs will be updated if specified again.
     ///
-    /// If only a URL is provided (without platform:), the platform will be automatically detected from the URL filename.
+    /// If only a URL is provided (without platform:), the platform will be automatically
+    /// detected from the URL filename.
     ///
-    /// Examples: --platform-url linux-x64:https://... --platform-url https://nodejs.org/dist/v22.17.1/node-v22.17.1-darwin-arm64.tar.gz
+    /// Examples:
+    /// --platform-url linux-x64:https://...
+    /// --platform-url https://nodejs.org/dist/v22.17.1/node-v22.17.1-darwin-arm64.tar.gz
     #[usage(long = "platform-url", value_name = "PLATFORM_URL", var)]
     pub platform_url: ::std::vec::Vec<::std::string::String>,
     /// Skip downloading for checksum and binary path detection (faster but less informative)
@@ -2681,7 +2850,7 @@ pub enum GenerateCommands {
 /// authentication issues. The token is masked by default.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise github token\n    github.com: ghp_…xxxx (source: GITHUB_TOKEN)\n\n    $ mise github token --unmask\n    github.com: ghp_xxxxxxxxxxxx (source: GITHUB_TOKEN)\n\n    $ mise github token github.mycompany.com\n    github.mycompany.com: (none)",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise github token\u{1b}[22m\n    github.com: ghp_…xxxx (source: GITHUB_TOKEN)\n\n    $ \u{1b}[1mmise github token --unmask\u{1b}[22m\n    github.com: ghp_xxxxxxxxxxxx (source: GITHUB_TOKEN)\n\n    $ \u{1b}[1mmise github token github.mycompany.com\u{1b}[22m\n    github.mycompany.com: (none)\n",
     effect = "read"
 )]
 pub struct GithubTokenArgs {
@@ -2691,8 +2860,12 @@ pub struct GithubTokenArgs {
     /// Print only the token value
     #[usage(long = "raw")]
     pub raw: bool,
-    /// Mint a fresh OAuth token even if the cached one has not expired, via the refresh-token grant or a new device-code flow
-    #[usage(long = "refresh")]
+    #[usage(
+        help = "Mint a fresh OAuth token even if the cached one has not expired, via the refresh-token grant or a new device-code flow",
+        long_help = "Mint a fresh OAuth token even if the cached one has not\nexpired, via the refresh-token grant or a new device-code flow",
+        long = "refresh",
+        requires = "--oauth"
+    )]
     pub refresh: bool,
     /// Show the full unmasked token
     #[usage(long = "unmask")]
@@ -2729,13 +2902,14 @@ pub enum GithubCommands {
 /// Use `mise local` to set a tool version locally in the current directory.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n    # set the current version of node to 20.x\n    # will use a fuzzy version (e.g.: 20) in .tool-versions file\n    $ mise global --fuzzy node@20\n\n    # set the current version of node to 20.x\n    # will use a precise version (e.g.: 20.0.0) in .tool-versions file\n    $ mise global --pin node@20\n\n    # show the current version of node in ~/.tool-versions\n    $ mise global node\n    20.0.0",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n    # set the current version of node to 20.x\n    # will use a fuzzy version (e.g.: 20) in .tool-versions file\n    $ \u{1b}[1mmise global --fuzzy node@20\u{1b}[22m\n\n    # set the current version of node to 20.x\n    # will use a precise version (e.g.: 20.0.0) in .tool-versions file\n    $ \u{1b}[1mmise global --pin node@20\u{1b}[22m\n\n    # show the current version of node in ~/.tool-versions\n    $ \u{1b}[1mmise global node\u{1b}[22m\n    20.0.0\n",
     effect = "write"
 )]
 pub struct GlobalArgs {
     #[usage(
         help = "Save fuzzy version to `~/.tool-versions`\ne.g.: `mise global --fuzzy node@20` will save `node 20` to ~/.tool-versions\nthis is the default behavior unless MISE_ASDF_COMPAT=1",
-        long = "fuzzy"
+        long = "fuzzy",
+        overrides = "--pin"
     )]
     pub fuzzy: bool,
     /// Get the path of the global config file
@@ -2743,11 +2917,12 @@ pub struct GlobalArgs {
     pub path: bool,
     #[usage(
         help = "Save exact version to `~/.tool-versions`\ne.g.: `mise global --pin node@20` will save `node 20.0.0` to ~/.tool-versions",
-        long = "pin"
+        long = "pin",
+        overrides = "--fuzzy"
     )]
     pub pin: bool,
     /// Remove the tool(s) from ~/.tool-versions
-    #[usage(long = "remove", value_name = "TOOL", var)]
+    #[usage(long = "remove", alias("rm", "unset"), value_name = "TOOL", var)]
     pub remove: ::std::vec::Vec<::std::string::String>,
     #[usage(
         arg,
@@ -2768,12 +2943,7 @@ pub struct HookEnvArgs {
     #[usage(long = "quiet", short = 'q')]
     pub quiet: bool,
     /// Shell type to generate script for
-    #[usage(
-        long = "shell",
-        short = 's',
-        value_name = "SHELL",
-        choices("bash", "elvish", "fish", "nu", "xonsh", "zsh", "pwsh")
-    )]
+    #[usage(long = "shell", short = 's', value_name = "SHELL")]
     pub shell: ::std::option::Option<::std::string::String>,
     /// Reason for calling hook-env (e.g., "precmd", "chpwd")
     #[usage(
@@ -2793,12 +2963,7 @@ pub struct HookEnvArgs {
 #[usage(effect = "write")]
 pub struct HookNotFoundArgs {
     /// Shell type to generate script for
-    #[usage(
-        long = "shell",
-        short = 's',
-        value_name = "SHELL",
-        choices("bash", "elvish", "fish", "nu", "xonsh", "zsh", "pwsh")
-    )]
+    #[usage(long = "shell", short = 's', value_name = "SHELL")]
     pub shell: ::std::option::Option<::std::string::String>,
     /// Attempted bin to run
     #[usage(arg, name = "BIN")]
@@ -2822,12 +2987,12 @@ pub struct ImplodeArgs {
 /// Edit mise.toml interactively
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise edit             # edit mise.toml interactively\n    $ mise edit .mise.toml  # edit a specific file\n    $ mise edit -g          # edit the global config file\n    $ mise edit -y          # skip interactive editor\n    $ mise edit -n          # preview without writing",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise edit\u{1b}[22m             \u{1b}[2m# edit mise.toml interactively\u{1b}[22m\n    $ \u{1b}[1mmise edit .mise.toml\u{1b}[22m  \u{1b}[2m# edit a specific file\u{1b}[22m\n    $ \u{1b}[1mmise edit -g\u{1b}[22m          \u{1b}[2m# edit the global config file\u{1b}[22m\n    $ \u{1b}[1mmise edit -y\u{1b}[22m          \u{1b}[2m# skip interactive editor\u{1b}[22m\n    $ \u{1b}[1mmise edit -n\u{1b}[22m          \u{1b}[2m# preview without writing\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct EditArgs {
     /// Edit the global config file (~/.config/mise/config.toml)
-    #[usage(long = "global", short = 'g')]
+    #[usage(long = "global", short = 'g', conflicts = "PATH")]
     pub global: bool,
     /// Show what would be generated without writing to file
     #[usage(long = "dry-run", short = 'n')]
@@ -2851,17 +3016,21 @@ pub struct EditArgs {
 /// Tools will be installed in parallel. To disable, set `--jobs=1` or `MISE_JOBS=1`
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise install node@20.0.0  # install specific node version\n    $ mise install node@20      # install fuzzy node version\n    $ mise install node         # install version specified in mise.toml\n    $ mise install              # installs everything specified in mise.toml",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise install node@20.0.0\u{1b}[22m  # install specific node version\n    $ \u{1b}[1mmise install node@20\u{1b}[22m      # install fuzzy node version\n    $ \u{1b}[1mmise install node\u{1b}[22m         # install version specified in mise.toml\n    $ \u{1b}[1mmise install\u{1b}[22m              # installs everything specified in mise.toml\n    $ \u{1b}[1mmise install --include-task-tools\u{1b}[22m # also install tools required by tasks\n",
     effect = "write"
 )]
 pub struct InstallArgs {
-    /// Force reinstall even if already installed
-    #[usage(long = "force", short = 'f')]
+    #[usage(
+        help = "Force reinstall even if already installed\nWith no tools specified, reinstall all configured tools",
+        long = "force",
+        short = 'f'
+    )]
     pub force: bool,
     #[usage(
-        help = "Number of jobs to run in parallel\n[default: 4]",
+        help = "Number of jobs to run in parallel\nValues below 1 are treated as 1\n[default: 4]",
         long = "jobs",
         short = 'j',
+        env = "MISE_JOBS",
         value_name = "JOBS"
     )]
     pub jobs: ::std::option::Option<::std::string::String>,
@@ -2878,34 +3047,52 @@ pub struct InstallArgs {
     /// This is useful for scripts to check if tools need to be installed.
     #[usage(long = "dry-run-code")]
     pub dry_run_code: bool,
+    /// Also install tools required by tasks in the current scope
+    ///
+    /// This prepares task tools without running task commands or dependencies.
+    /// Combine with --monorepo to include tasks from every configured root.
+    #[usage(long = "include-task-tools")]
+    pub include_task_tools: bool,
     /// Only install versions released before this date or older than this duration
     ///
     /// Supports absolute dates like "2024-06-01" and relative durations like "90d" or "1y".
-    #[usage(long = "minimum-release-age", value_name = "MINIMUM_RELEASE_AGE")]
+    #[usage(
+        long = "minimum-release-age",
+        alias = "before",
+        value_name = "MINIMUM_RELEASE_AGE"
+    )]
     pub minimum_release_age: ::std::option::Option<::std::string::String>,
     /// Install tools from every [monorepo].config_roots config root
     ///
     /// Uses the active MISE_ENV and requires monorepo_root = true plus explicit
     /// [monorepo].config_roots in the monorepo root config.
-    #[usage(long = "monorepo")]
+    #[usage(long = "monorepo", env = "MISE_MONOREPO")]
     pub monorepo: bool,
-    /// Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1
-    #[usage(long = "raw")]
+    #[usage(
+        help = "Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1",
+        long_help = "Connect backend install command stdin/stdout/stderr directly to the terminal\nImplies --jobs=1",
+        long = "raw",
+        overrides = "--jobs"
+    )]
     pub raw: bool,
     /// Install tool(s) to a shared directory
     ///
     /// Installs to the specified directory instead of the default install location.
     /// May require elevated permissions depending on the path.
-    #[usage(long = "shared", value_name = "SHARED")]
+    #[usage(long = "shared", conflicts = "--system", value_name = "SHARED")]
     pub shared: ::std::option::Option<::std::string::String>,
     /// Install tool(s) to the system-wide shared directory
     ///
     /// Installs to /usr/local/share/mise/installs (or MISE_SYSTEM_DATA_DIR/installs).
     /// May require elevated permissions (e.g. sudo).
-    #[usage(long = "system")]
+    #[usage(long = "system", conflicts = "--shared")]
     pub system: bool,
-    /// Tool(s) to install e.g.: node@20
-    #[usage(arg, name = "TOOL@VERSION")]
+    #[usage(
+        arg,
+        name = "TOOL@VERSION",
+        help = "Tool(s) to install e.g.: node@20",
+        long_help = "Tool(s) to install\ne.g.: node@20"
+    )]
     pub tool_version: ::std::vec::Vec<::std::string::String>,
 }
 
@@ -2914,12 +3101,16 @@ pub struct InstallArgs {
 /// Used for building a tool to a directory for use outside of mise
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    # install node@20.0.0 into ./mynode\n    $ mise install-into node@20.0.0 ./mynode && ./mynode/bin/node -v\n    20.0.0",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # install node@20.0.0 into ./mynode\n    $ \u{1b}[1mmise install-into node@20.0.0 ./mynode && ./mynode/bin/node -v\u{1b}[22m\n    20.0.0\n",
     effect = "write"
 )]
 pub struct InstallIntoArgs {
-    /// Tool to install e.g.: node@20
-    #[usage(arg, name = "TOOL@VERSION")]
+    #[usage(
+        arg,
+        name = "TOOL@VERSION",
+        help = "Tool to install e.g.: node@20",
+        long_help = "Tool to install\ne.g.: node@20"
+    )]
     pub tool_version: ::std::string::String,
     /// Path to install the tool into
     #[usage(arg, name = "PATH")]
@@ -2931,7 +3122,7 @@ pub struct InstallIntoArgs {
 /// Supports prefixes such as `node@20` to get the latest version of node 20.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise latest node@20  # get the latest version of node 20\n    20.0.0\n\n    $ mise latest node     # get the latest stable version of node\n    20.0.0\n\n    $ mise latest node --minimum-release-age 2024-01-01  # latest stable node released before 2024-01-01",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise latest node@20\u{1b}[22m  # get the latest version of node 20\n    20.0.0\n\n    $ \u{1b}[1mmise latest node\u{1b}[22m     # get the latest stable version of node\n    20.0.0\n\n    $ \u{1b}[1mmise latest node --minimum-release-age 2024-01-01\u{1b}[22m  # latest stable node released before 2024-01-01\n",
     effect = "read"
 )]
 pub struct LatestArgs {
@@ -2942,13 +3133,23 @@ pub struct LatestArgs {
     ///
     /// Supports absolute dates like "2024-06-01" and relative durations like "90d" or "1y".
     /// Overrides per-tool `minimum_release_age` options and the global `minimum_release_age` setting.
-    #[usage(long = "minimum-release-age", value_name = "MINIMUM_RELEASE_AGE")]
+    #[usage(
+        long = "minimum-release-age",
+        alias = "before",
+        conflicts = "--installed",
+        value_name = "MINIMUM_RELEASE_AGE"
+    )]
     pub minimum_release_age: ::std::option::Option<::std::string::String>,
     /// Tool to get the latest version of
     #[usage(arg, name = "TOOL@VERSION")]
     pub tool_version: ::std::string::String,
-    /// The version prefix to use when querying the latest version same as the first argument after the "@" used for asdf compatibility
-    #[usage(arg, name = "ASDF_VERSION", hide)]
+    #[usage(
+        arg,
+        name = "ASDF_VERSION",
+        help = "The version prefix to use when querying the latest version same as the first argument after the \"@\" used for asdf compatibility",
+        long_help = "The version prefix to use when querying the latest version\nsame as the first argument after the \"@\"\nused for asdf compatibility",
+        hide
+    )]
     pub asdf_version: ::std::option::Option<::std::string::String>,
 }
 
@@ -2957,7 +3158,7 @@ pub struct LatestArgs {
 /// Use this for adding installs either custom compiled outside mise or built with a different tool.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    # build node-20.0.0 with node-build and link it into mise\n    $ node-build 20.0.0 ~/.nodes/20.0.0\n    $ mise link node@20.0.0 ~/.nodes/20.0.0\n\n    # have mise use the node version provided by Homebrew\n    $ brew install node\n    $ mise link node@brew $(brew --prefix node)\n    $ mise use node@brew",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # build node-20.0.0 with node-build and link it into mise\n    $ \u{1b}[1mnode-build 20.0.0 ~/.nodes/20.0.0\u{1b}[22m\n    $ \u{1b}[1mmise link node@20.0.0 ~/.nodes/20.0.0\u{1b}[22m\n\n    # have mise use the node version provided by Homebrew\n    $ \u{1b}[1mbrew install node\u{1b}[22m\n    $ \u{1b}[1mmise link node@brew $(brew --prefix node)\u{1b}[22m\n    $ \u{1b}[1mmise use node@brew\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct LinkArgs {
@@ -2983,7 +3184,7 @@ pub struct LinkArgs {
 /// is set. A future v2 release of mise will default to using `mise.toml`.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n    # set the current version of node to 20.x for the current directory\n    # will use a precise version (e.g.: 20.0.0) in .tool-versions file\n    $ mise local node@20\n\n    # set node to 20.x for the current project (recurses up to find .tool-versions)\n    $ mise local -p node@20\n\n    # set the current version of node to 20.x for the current directory\n    # will use a fuzzy version (e.g.: 20) in .tool-versions file\n    $ mise local --fuzzy node@20\n\n    # removes node from .tool-versions\n    $ mise local --remove=node\n\n    # show the current version of node in .tool-versions\n    $ mise local node\n    20.0.0",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n    # set the current version of node to 20.x for the current directory\n    # will use a precise version (e.g.: 20.0.0) in .tool-versions file\n    $ \u{1b}[1mmise local node@20\u{1b}[22m\n\n    # set node to 20.x for the current project (recurses up to find .tool-versions)\n    $ \u{1b}[1mmise local -p node@20\u{1b}[22m\n\n    # set the current version of node to 20.x for the current directory\n    # will use a fuzzy version (e.g.: 20) in .tool-versions file\n    $ \u{1b}[1mmise local --fuzzy node@20\u{1b}[22m\n\n    # removes node from .tool-versions\n    $ \u{1b}[1mmise local --remove=node\u{1b}[22m\n\n    # show the current version of node in .tool-versions\n    $ \u{1b}[1mmise local node\u{1b}[22m\n    20.0.0\n",
     effect = "write"
 )]
 pub struct LocalArgs {
@@ -2993,19 +3194,24 @@ pub struct LocalArgs {
         short = 'p'
     )]
     pub parent: bool,
-    /// Save fuzzy version to `.tool-versions` e.g.: `mise local --fuzzy node@20` will save `node 20` to .tool-versions This is the default behavior unless MISE_ASDF_COMPAT=1
-    #[usage(long = "fuzzy")]
+    #[usage(
+        help = "Save fuzzy version to `.tool-versions` e.g.: `mise local --fuzzy node@20` will save `node 20` to .tool-versions This is the default behavior unless MISE_ASDF_COMPAT=1",
+        long_help = "Save fuzzy version to `.tool-versions`\ne.g.: `mise local --fuzzy node@20` will save `node 20` to .tool-versions\nThis is the default behavior unless MISE_ASDF_COMPAT=1",
+        long = "fuzzy",
+        overrides = "--pin"
+    )]
     pub fuzzy: bool,
     /// Get the path of the config file
     #[usage(long = "path")]
     pub path: bool,
     #[usage(
         help = "Save exact version to `.tool-versions`\ne.g.: `mise local --pin node@20` will save `node 20.0.0` to .tool-versions",
-        long = "pin"
+        long = "pin",
+        overrides = "--fuzzy"
     )]
     pub pin: bool,
     /// Remove the tool(s) from .tool-versions
-    #[usage(long = "remove", value_name = "TOOL", var)]
+    #[usage(long = "remove", alias("rm", "unset"), value_name = "TOOL", var)]
     pub remove: ::std::vec::Vec<::std::string::String>,
     #[usage(
         arg,
@@ -3018,12 +3224,13 @@ pub struct LocalArgs {
 /// Update lockfile checksums and URLs for all specified platforms
 ///
 /// Updates checksums and download URLs for all platforms already specified in the lockfile.
-/// If no lockfile exists, shows what would be created based on the current configuration.
+/// If no lockfile exists, shows what would be created based on the current configuration,
+/// including tools declared by tasks.
 /// This allows you to refresh lockfile data for platforms other than the one you're currently on.
 /// Operates on the lockfile in the current config root. Use TOOL arguments to target specific tools.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise lock                       # update lockfile for all common platforms\n    $ mise lock node python           # update only node and python\n    $ mise lock --platform linux-x64  # update only linux-x64 platform\n    $ mise lock --dry-run             # show what would be updated\n    $ mise lock --bump                # re-resolve selectors like \"latest\" or \"20\" to the latest matching versions\n    $ mise lock --bump --dry-run --json   # list available updates as JSON without writing\n    $ mise lock --minimum-release-age 2024-01-01   # lock latest/fuzzy versions released before 2024-01-01\n    $ mise lock --local               # update mise.local.lock for local configs\n    $ mise lock --global              # update only global config lockfiles",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise lock\u{1b}[22m                       # update lockfile for all common platforms\n    $ \u{1b}[1mmise lock node python\u{1b}[22m           # update only node and python\n    $ \u{1b}[1mmise lock --platform linux-x64\u{1b}[22m  # update only linux-x64 platform\n    $ \u{1b}[1mmise lock --dry-run\u{1b}[22m             # show what would be updated\n    $ \u{1b}[1mmise lock --bump\u{1b}[22m                # re-resolve selectors like \"latest\" or \"20\" to the latest matching versions\n    $ \u{1b}[1mmise lock --bump --dry-run --json\u{1b}[22m   # list available updates as JSON without writing\n    $ \u{1b}[1mmise lock --minimum-release-age 2024-01-01\u{1b}[22m   # lock latest/fuzzy versions released before 2024-01-01\n    $ \u{1b}[1mmise lock --local\u{1b}[22m               # update mise.local.lock for local configs\n    $ \u{1b}[1mmise lock --global\u{1b}[22m              # update only global config lockfiles\n",
     effect = "write"
 )]
 pub struct LockArgs {
@@ -3033,8 +3240,13 @@ pub struct LockArgs {
         short = 'g'
     )]
     pub global: bool,
-    /// Number of jobs to run in parallel
-    #[usage(long = "jobs", short = 'j', value_name = "JOBS")]
+    #[usage(
+        help = "Number of jobs to run in parallel\nValues below 1 are treated as 1",
+        long = "jobs",
+        short = 'j',
+        env = "MISE_JOBS",
+        value_name = "JOBS"
+    )]
     pub jobs: ::std::option::Option<::std::string::String>,
     /// Show what would be updated without making changes
     #[usage(long = "dry-run", short = 'n')]
@@ -3043,6 +3255,7 @@ pub struct LockArgs {
         help = "Comma-separated list of platforms to target\ne.g.: linux-x64,macos-arm64,windows-x64\nIf not specified, all platforms already in lockfile will be updated",
         long = "platform",
         short = 'p',
+        delimiter = ',',
         value_name = "PLATFORM",
         var
     )]
@@ -3080,12 +3293,16 @@ pub struct LockArgs {
     /// This only affects fuzzy version matches like "20" or "latest".
     /// Explicitly pinned versions like "22.5.0" are not filtered.
     /// Existing matching lockfile entries are preserved and are not downgraded solely by this flag.
-    #[usage(long = "minimum-release-age", value_name = "MINIMUM_RELEASE_AGE")]
+    #[usage(
+        long = "minimum-release-age",
+        alias = "before",
+        value_name = "MINIMUM_RELEASE_AGE"
+    )]
     pub minimum_release_age: ::std::option::Option<::std::string::String>,
     #[usage(
         arg,
         name = "TOOL",
-        help = "Tool(s) to update in lockfile\ne.g.: node python\nIf not specified, all tools in lockfile will be updated"
+        help = "Tool(s) to update in lockfile\ne.g.: node python\nIf not specified, all configured and task-specific tools will be updated"
     )]
     pub tool: ::std::vec::Vec<::std::string::String>,
 }
@@ -3099,7 +3316,7 @@ pub struct LockArgs {
 /// It's a useful command to get the current state of your tools.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise ls\n    node    20.0.0 ~/src/myapp/.tool-versions latest\n    python  3.11.0 ~/.tool-versions           3.10\n    python  3.10.0\n\n    $ mise ls --current\n    node    20.0.0 ~/src/myapp/.tool-versions 20\n    python  3.11.0 ~/.tool-versions           3.11.0\n\n    $ mise ls --json\n    {\n      \"node\": [\n        {\n          \"version\": \"20.0.0\",\n          \"install_path\": \"/Users/jdx/.mise/installs/node/20.0.0\",\n          \"source\": {\n            \"type\": \"mise.toml\",\n            \"path\": \"/Users/jdx/mise.toml\"\n          }\n        }\n      ],\n      \"python\": [...]\n    }\n\n    $ mise ls --all-sources\n    node    20.0.0  ~/src/myapp/mise.toml  20\n                    ~/.config/mise/config.toml  latest",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise ls\u{1b}[22m\n    node    20.0.0 ~/src/myapp/.tool-versions latest\n    python  3.11.0 ~/.tool-versions           3.10\n    python  3.10.0\n\n    $ \u{1b}[1mmise ls --current\u{1b}[22m\n    node    20.0.0 ~/src/myapp/.tool-versions 20\n    python  3.11.0 ~/.tool-versions           3.11.0\n\n    $ \u{1b}[1mmise ls --json\u{1b}[22m\n    {\n      \"node\": [\n        {\n          \"version\": \"20.0.0\",\n          \"install_path\": \"/Users/jdx/.mise/installs/node/20.0.0\",\n          \"source\": {\n            \"type\": \"mise.toml\",\n            \"path\": \"/Users/jdx/mise.toml\"\n          }\n        }\n      ],\n      \"python\": [...]\n    }\n\n    $ \u{1b}[1mmise ls --all-sources\u{1b}[22m\n    node    20.0.0  ~/src/myapp/mise.toml  20\n                    ~/.config/mise/config.toml  latest\n",
     effect = "read"
 )]
 pub struct LsArgs {
@@ -3107,48 +3324,59 @@ pub struct LsArgs {
     #[usage(long = "current", short = 'c')]
     pub current: bool,
     /// Only show tool versions currently specified in the global mise.toml
-    #[usage(long = "global", short = 'g')]
+    #[usage(long = "global", short = 'g', conflicts = "--local")]
     pub global: bool,
-    /// Only show tool versions that are installed (Hides tools defined in mise.toml but not installed)
-    #[usage(long = "installed", short = 'i')]
+    #[usage(
+        help = "Only show tool versions that are installed (Hides tools defined in mise.toml but not installed)",
+        long_help = "Only show tool versions that are installed\n(Hides tools defined in mise.toml but not installed)",
+        long = "installed",
+        short = 'i'
+    )]
     pub installed: bool,
     /// Output in JSON format
     #[usage(long = "json", short = 'J')]
     pub json: bool,
     /// Only show tool versions currently specified in the local mise.toml
-    #[usage(long = "local", short = 'l')]
+    #[usage(long = "local", short = 'l', conflicts = "--global")]
     pub local: bool,
     /// Display missing tool versions
-    #[usage(long = "missing", short = 'm')]
+    #[usage(long = "missing", short = 'm', conflicts = "--installed")]
     pub missing: bool,
     /// Don't fetch information such as outdated versions
     #[usage(long = "offline", short = 'o', hide)]
     pub offline: bool,
-    #[usage(long = "plugin", short = 'p', hide, value_name = "TOOL_FLAG")]
+    #[usage(long = "plugin", short = 'p', hide, value_name = "PLUGIN")]
     pub plugin: ::std::option::Option<::std::string::String>,
     /// Display all tracked config sources for tools
-    #[usage(long = "all-sources")]
+    #[usage(
+        long = "all-sources",
+        conflicts("--current", "--global", "--local", "--prunable")
+    )]
     pub all_sources: bool,
     /// List tools from every [monorepo].config_roots config root
     ///
     /// Uses the active MISE_ENV and requires monorepo_root = true plus explicit
     /// [monorepo].config_roots in the monorepo root config.
-    #[usage(long = "monorepo")]
+    #[usage(
+        long = "monorepo",
+        env = "MISE_MONOREPO",
+        conflicts("--all-sources", "--prunable")
+    )]
     pub monorepo: bool,
     /// Don't display headers
-    #[usage(long = "no-header")]
+    #[usage(long = "no-header", alias = "no-headers", conflicts = "--json")]
     pub no_header: bool,
     /// Display whether a version is outdated
     #[usage(long = "outdated")]
     pub outdated: bool,
     /// Display versions matching this prefix
-    #[usage(long = "prefix", value_name = "PREFIX")]
+    #[usage(long = "prefix", requires = "INSTALLED_TOOL", value_name = "PREFIX")]
     pub prefix: ::std::option::Option<::std::string::String>,
     /// List only tools that can be pruned with `mise prune`
     #[usage(long = "prunable")]
     pub prunable: bool,
     /// Only show tool versions from [TOOL]
-    #[usage(arg, name = "INSTALLED_TOOL")]
+    #[usage(arg, name = "INSTALLED_TOOL", conflicts = "--plugin")]
     pub installed_tool: ::std::vec::Vec<::std::string::String>,
 }
 
@@ -3157,17 +3385,21 @@ pub struct LsArgs {
 /// Note that the results may be cached, run `mise cache clean` to clear the cache and get fresh results.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise ls-remote node\n    18.0.0\n    20.0.0\n\n    $ mise ls-remote node@20\n    20.0.0\n    20.1.0\n\n    $ mise ls-remote node 20\n    20.0.0\n    20.1.0\n\n    $ mise ls-remote node --minimum-release-age 2024-01-01\n    20.0.0\n\n    $ mise ls-remote github:cli/cli --json\n    [{\"version\":\"2.62.0\",\"created_at\":\"2024-11-14T15:40:35Z\",\"prerelease\":false},{\"version\":\"2.61.0\",\"created_at\":\"2024-10-23T19:22:15Z\",\"prerelease\":false}]",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise ls-remote node\u{1b}[22m\n    18.0.0\n    20.0.0\n\n    $ \u{1b}[1mmise ls-remote node@20\u{1b}[22m\n    20.0.0\n    20.1.0\n\n    $ \u{1b}[1mmise ls-remote node 20\u{1b}[22m\n    20.0.0\n    20.1.0\n\n    $ \u{1b}[1mmise ls-remote node --minimum-release-age 2024-01-01\u{1b}[22m\n    20.0.0\n\n    $ \u{1b}[1mmise ls-remote github:cli/cli --json\u{1b}[22m\n    [{\"version\":\"2.62.0\",\"created_at\":\"2024-11-14T15:40:35Z\",\"prerelease\":false},{\"version\":\"2.61.0\",\"created_at\":\"2024-10-23T19:22:15Z\",\"prerelease\":false}]\n",
     effect = "read"
 )]
 pub struct LsRemoteArgs {
     /// Show all installed plugins and versions
-    #[usage(long = "all")]
+    #[usage(long = "all", conflicts("TOOL@VERSION", "PREFIX"))]
     pub all: bool,
     /// Only show versions released before this age or date
     ///
     /// Supports absolute dates like "2024-06-01" and relative durations like "90d" or "1y".
-    #[usage(long = "minimum-release-age", value_name = "MINIMUM_RELEASE_AGE")]
+    #[usage(
+        long = "minimum-release-age",
+        alias = "before",
+        value_name = "MINIMUM_RELEASE_AGE"
+    )]
     pub minimum_release_age: ::std::option::Option<::std::string::String>,
     /// Output in JSON format (includes version metadata like created_at timestamps when available)
     #[usage(long = "json", short = 'J')]
@@ -3186,10 +3418,10 @@ pub struct LsRemoteArgs {
     ///
     /// This prevents metadata consumers from accepting empty fallback results
     /// when a backend's metadata-producing upstream request fails.
-    #[usage(long = "strict-metadata")]
+    #[usage(long = "strict-metadata", requires("--json", "--no-versions-host"))]
     pub strict_metadata: bool,
     /// Tool to get versions for
-    #[usage(arg, name = "TOOL@VERSION")]
+    #[usage(arg, name = "TOOL@VERSION", required_unless = "--all")]
     pub tool_version: ::std::option::Option<::std::string::String>,
     #[usage(
         arg,
@@ -3226,7 +3458,7 @@ pub struct LsRemoteArgs {
 /// Cursor, or other tools that support the Model Context Protocol.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    # Start the MCP server (typically used by AI assistant tools)\n    $ mise mcp\n\n    # Example integration with Claude Desktop (add to claude_desktop_config.json):\n    {\n      \"mcpServers\": {\n        \"mise\": {\n          \"command\": \"mise\",\n          \"args\": [\"mcp\"],\n          \"env\": {}\n        }\n      }\n    }\n\n    # Interactive testing with JSON-RPC commands:\n    $ echo '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{},\"clientInfo\":{\"name\":\"test\",\"version\":\"1.0\"}}}' | mise mcp\n\n    # Resources you can query:\n    - mise://tools - List active tools\n    - mise://tools?include_inactive=true - List all installed tools\n    - mise://tasks - List all tasks\n    - mise://env - List environment variables\n    - mise://config - Show configuration info\n\n    # Tools available:\n    - list_commands - Every mise command and what running it does\n      Example: {\"include_hidden\": false}\n    - install_tool - Install a tool (not yet implemented)\n    - run_task - Execute a mise task with optional arguments\n      Example: {\"task\": \"build\", \"args\": [\"--verbose\"]}"
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Start the MCP server (typically used by AI assistant tools)\n    $ \u{1b}[1mmise mcp\u{1b}[22m\n\n    # Example integration with Claude Desktop (add to claude_desktop_config.json):\n    {\n      \"mcpServers\": {\n        \"mise\": {\n          \"command\": \"mise\",\n          \"args\": [\"mcp\"],\n          \"env\": {}\n        }\n      }\n    }\n\n    # Interactive testing with JSON-RPC commands:\n    $ \u{1b}[1mecho '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{},\"clientInfo\":{\"name\":\"test\",\"version\":\"1.0\"}}}' | mise mcp\u{1b}[22m\n\n    # Resources you can query:\n    - \u{1b}[1mmise://tools\u{1b}[22m - List active tools\n    - \u{1b}[1mmise://tools?include_inactive=true\u{1b}[22m - List all installed tools\n    - \u{1b}[1mmise://tasks\u{1b}[22m - List all tasks\n    - \u{1b}[1mmise://env\u{1b}[22m - List environment variables\n    - \u{1b}[1mmise://config\u{1b}[22m - Show configuration info\n\n    # Tools available:\n    - \u{1b}[1mlist_commands\u{1b}[22m - Every mise command and what running it does\n      Example: {\"include_hidden\": false}\n    - \u{1b}[1minstall_tool\u{1b}[22m - Install a tool (not yet implemented)\n    - \u{1b}[1mrun_task\u{1b}[22m - Execute a mise task with optional arguments\n      Example: {\"task\": \"build\", \"args\": [\"--verbose\"]}\n"
 )]
 pub struct McpArgs {}
 
@@ -3241,7 +3473,7 @@ pub struct McpArgs {}
 /// Requires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`).
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    Build with defaults (debian:bookworm-slim base):\n    $ mise oci build\n\n    Build with a specific base image and tag:\n    $ mise oci build --from ubuntu:24.04 --tag myorg/dev:latest -o ./img\n\n    Inspect the result with skopeo:\n    $ skopeo inspect oci:./mise-oci\n\n    Push to a registry:\n    $ mise oci push --image-dir ./mise-oci ghcr.io/me/dev:latest\n\nNotes:\n\n    - The image only contains tools from the project's mise config (and\n      any configs at-or-below the project root). Tools from\n      `~/.config/mise/config.toml` are not included; pass --include-global\n      to package them too.\n    - asdf and vfox plugins are not supported in v1; use a different backend\n      (core, aqua, ubi, github, cargo, npm, go, pipx, spm, http) for each tool.\n    - The host mise binary is embedded at /usr/local/bin/mise by default;\n      build on the same OS/arch as your target image (or pass --no-mise).",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    Build with defaults (debian:bookworm-slim base):\n    $ \u{1b}[1mmise oci build\u{1b}[22m\n\n    Build with a specific base image and tag:\n    $ \u{1b}[1mmise oci build --from ubuntu:24.04 --tag myorg/dev:latest -o ./img\u{1b}[22m\n\n    Inspect the result with skopeo:\n    $ \u{1b}[1mskopeo inspect oci:./mise-oci\u{1b}[22m\n\n    Push to a registry:\n    $ \u{1b}[1mmise oci push --image-dir ./mise-oci ghcr.io/me/dev:latest\u{1b}[22m\n\n\u{1b}[1m\u{1b}[4mNotes:\u{1b}[22m\u{1b}[24m\n\n    - The image only contains tools from the project's mise config (and\n      any configs at-or-below the project root). Tools from\n      `~/.config/mise/config.toml` are not included; pass --include-global\n      to package them too.\n    - asdf and vfox plugins are not supported in v1; use a different backend\n      (core, aqua, ubi, github, cargo, npm, go, pipx, spm, http) for each tool.\n    - The host mise binary is embedded at /usr/local/bin/mise by default;\n      build on the same OS/arch as your target image (or pass --no-mise).\n",
     effect = "write"
 )]
 pub struct OciBuildArgs {
@@ -3261,7 +3493,12 @@ pub struct OciBuildArgs {
     pub from: ::std::option::Option<::std::string::String>,
     /// Also include tools from the global / system config (default: project-only)
     ///
-    /// By default `mise oci build` only packages tools declared in the project's mise config (and any parent configs at-or-below the project root, e.g. a monorepo root config). Personal dev tools in `~/.config/mise/config.toml` are excluded so they don't bake into a project image. Pass `--include-global` to revert to the old "merge all loaded configs" behavior.
+    /// By default `mise oci build` only packages tools declared in the
+    /// project's mise config (and any parent configs at-or-below the
+    /// project root, e.g. a monorepo root config). Personal dev tools in
+    /// `~/.config/mise/config.toml` are excluded so they don't bake into a
+    /// project image. Pass `--include-global` to revert to the old
+    /// "merge all loaded configs" behavior.
     #[usage(long = "include-global")]
     pub include_global: bool,
     /// Tag to record in the image index (the org.opencontainers.image.ref.name annotation)
@@ -3275,7 +3512,9 @@ pub struct OciBuildArgs {
     pub no_mise: bool,
     /// UID[:GID] to assign to every tar entry in generated layers
     ///
-    /// Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive.
+    /// Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is
+    /// omitted, it defaults to UID. This affects file ownership only; [oci].user
+    /// controls the image USER directive.
     #[usage(long = "owner", value_name = "UID[:GID]")]
     pub owner: ::std::option::Option<::std::string::String>,
 }
@@ -3301,20 +3540,30 @@ pub struct OciBuildArgs {
 /// Requires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`).
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    Build and push to GHCR:\n    $ mise oci push ghcr.io/me/devenv:latest\n\n    Push an image built earlier:\n    $ mise oci build -o ./img\n    $ mise oci push --image-dir ./img ghcr.io/me/devenv:v1\n\nAuth:\n\n    Credentials are resolved the same way docker/podman resolve them:\n    $REGISTRY_AUTH_FILE, $XDG_RUNTIME_DIR/containers/auth.json,\n    ~/.config/containers/auth.json, then ~/.docker/config.json\n    (inline auths and credential helpers). Log in with either:\n    $ docker login ghcr.io\n    $ podman login ghcr.io",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    Build and push to GHCR:\n    $ \u{1b}[1mmise oci push ghcr.io/me/devenv:latest\u{1b}[22m\n\n    Push an image built earlier:\n    $ \u{1b}[1mmise oci build -o ./img\u{1b}[22m\n    $ \u{1b}[1mmise oci push --image-dir ./img ghcr.io/me/devenv:v1\u{1b}[22m\n\n\u{1b}[1m\u{1b}[4mAuth:\u{1b}[22m\u{1b}[24m\n\n    Credentials are resolved the same way docker/podman resolve them:\n    \u{1b}[1m$REGISTRY_AUTH_FILE\u{1b}[22m, \u{1b}[1m$XDG_RUNTIME_DIR/containers/auth.json\u{1b}[22m,\n    \u{1b}[1m~/.config/containers/auth.json\u{1b}[22m, then \u{1b}[1m~/.docker/config.json\u{1b}[22m\n    (inline auths and credential helpers). Log in with either:\n    $ \u{1b}[1mdocker login ghcr.io\u{1b}[22m\n    $ \u{1b}[1mpodman login ghcr.io\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct OciPushArgs {
     /// Reuse unchanged tool layers from this image instead of the destination ref
     ///
-    /// Must live in the same repository as the destination. Useful when each push gets a unique tag (e.g. per-commit tags in CI): `--cache-from ghcr.io/me/dev:latest ghcr.io/me/dev:$SHA`.
-    #[usage(long = "cache-from", value_name = "REF")]
+    /// Must live in the same repository as the destination. Useful when each
+    /// push gets a unique tag (e.g. per-commit tags in CI):
+    /// `--cache-from ghcr.io/me/dev:latest ghcr.io/me/dev:$SHA`.
+    #[usage(
+        long = "cache-from",
+        conflicts("--no-cache", "--image-dir"),
+        value_name = "REF"
+    )]
     pub cache_from: ::std::option::Option<::std::string::String>,
     /// Base image for the build (ignored with --image-dir)
     #[usage(long = "from", value_name = "FROM")]
     pub from: ::std::option::Option<::std::string::String>,
     /// Push an already-built OCI image layout (skip the build step)
-    #[usage(long = "image-dir", value_name = "IMAGE_DIR")]
+    #[usage(
+        long = "image-dir",
+        conflicts("--from", "--mount-point", "--no-mise", "--owner", "--include-global"),
+        value_name = "IMAGE_DIR"
+    )]
     pub image_dir: ::std::option::Option<::std::string::String>,
     /// Also include tools from the global / system config (default: project-only)
     ///
@@ -3332,12 +3581,17 @@ pub struct OciPushArgs {
     pub no_mise: bool,
     /// UID[:GID] to assign to every tar entry when building (conflicts with --image-dir)
     ///
-    /// Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive.
+    /// Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is
+    /// omitted, it defaults to UID. This affects file ownership only; [oci].user
+    /// controls the image USER directive.
     #[usage(long = "owner", value_name = "UID[:GID]")]
     pub owner: ::std::option::Option<::std::string::String>,
     /// Maintain the tag as a multi-arch image index
     ///
-    /// Pushes this build's manifest by digest and points the tag at an OCI image index containing one entry per platform, preserving entries other architectures pushed. Run `mise oci push --update-index` from one runner per platform to assemble a multi-arch tag.
+    /// Pushes this build's manifest by digest and points the tag at an OCI
+    /// image index containing one entry per platform, preserving entries
+    /// other architectures pushed. Run `mise oci push --update-index` from
+    /// one runner per platform to assemble a multi-arch tag.
     #[usage(long = "update-index")]
     pub update_index: bool,
     /// Destination registry reference (e.g. `ghcr.io/me/devenv:latest`)
@@ -3356,7 +3610,7 @@ pub struct OciPushArgs {
 /// one of: `podman`, `docker`.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    Build the current mise.toml and drop into bash:\n    $ mise oci run -it -- bash\n\n    Run a one-shot command with env + volume (note: `-v` is reserved\n    for --verbose, so use `--volume`):\n    $ mise oci run -e DEBUG=1 --volume $PWD:/work -w /work -- npm test\n\n    Re-use a previously built layout (skip the build step):\n    $ mise oci build -o ./img && mise oci run --image-dir ./img -- node -e 'console.log(process.version)'\n\nEngines:\n\n    Prefers podman (loads OCI layouts natively). Falls back to docker\n    (loaded via docker load). Pass --engine podman or --engine docker to override."
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    Build the current mise.toml and drop into bash:\n    $ \u{1b}[1mmise oci run -it -- bash\u{1b}[22m\n\n    Run a one-shot command with env + volume (note: `-v` is reserved\n    for --verbose, so use `--volume`):\n    $ \u{1b}[1mmise oci run -e DEBUG=1 --volume $PWD:/work -w /work -- npm test\u{1b}[22m\n\n    Re-use a previously built layout (skip the build step):\n    $ \u{1b}[1mmise oci build -o ./img && mise oci run --image-dir ./img -- node -e 'console.log(process.version)'\u{1b}[22m\n\n\u{1b}[1m\u{1b}[4mEngines:\u{1b}[22m\u{1b}[24m\n\n    Prefers \u{1b}[1mpodman\u{1b}[22m (loads OCI layouts natively). Falls back to \u{1b}[1mdocker\u{1b}[22m\n    (loaded via \u{1b}[1mdocker load\u{1b}[22m). Pass \u{1b}[1m--engine podman\u{1b}[22m or \u{1b}[1m--engine docker\u{1b}[22m to override.\n"
 )]
 pub struct OciRunArgs {
     /// Container engine to use (`auto`, `podman`, or `docker`)
@@ -3371,7 +3625,11 @@ pub struct OciRunArgs {
     #[usage(long = "from", value_name = "FROM")]
     pub from: ::std::option::Option<::std::string::String>,
     /// Use an already-built OCI image layout instead of building fresh
-    #[usage(long = "image-dir", value_name = "IMAGE_DIR")]
+    #[usage(
+        long = "image-dir",
+        conflicts("--from", "--mount-point", "--no-mise", "--owner", "--include-global"),
+        value_name = "IMAGE_DIR"
+    )]
     pub image_dir: ::std::option::Option<::std::string::String>,
     /// Also include tools from the global / system config (default: project-only)
     ///
@@ -3380,7 +3638,11 @@ pub struct OciRunArgs {
     pub include_global: bool,
     /// Keep the loaded image in the engine's storage after the run
     ///
-    /// By default, both the container (`--rm`) and the loaded image are removed when the command exits, so repeated `mise oci run` calls don't accumulate images in podman / docker storage. Pass `--keep` to retain the image under the tag mise used (`mise-oci:run-*` for docker; the pulled image ID for podman).
+    /// By default, both the container (`--rm`) and the loaded image are
+    /// removed when the command exits, so repeated `mise oci run` calls
+    /// don't accumulate images in podman / docker storage. Pass `--keep`
+    /// to retain the image under the tag mise used (`mise-oci:run-*` for
+    /// docker; the pulled image ID for podman).
     #[usage(long = "keep")]
     pub keep: bool,
     /// Override in-image mount point (ignored with --image-dir)
@@ -3391,13 +3653,16 @@ pub struct OciRunArgs {
     pub no_mise: bool,
     /// UID[:GID] to assign to every tar entry when building (conflicts with --image-dir)
     ///
-    /// Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive.
+    /// Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is
+    /// omitted, it defaults to UID. This affects file ownership only; [oci].user
+    /// controls the image USER directive.
     #[usage(long = "owner", value_name = "UID[:GID]")]
     pub owner: ::std::option::Option<::std::string::String>,
     /// Bind-mount a host path (repeatable, `HOST:CONTAINER[:MODE]`)
     ///
-    /// Note: unlike `docker run -v`, there's no `-v` short flag here because mise reserves `-v` for --verbose. Use `--volume` or `--mount`.
-    #[usage(long = "volume", value_name = "HOST:CONTAINER", var)]
+    /// Note: unlike `docker run -v`, there's no `-v` short flag here because
+    /// mise reserves `-v` for --verbose. Use `--volume` or `--mount`.
+    #[usage(long = "volume", alias = "mount", value_name = "HOST:CONTAINER", var)]
     pub volume: ::std::vec::Vec<::std::string::String>,
     /// Set environment variable in the container (repeatable, `KEY=VAL`)
     #[usage(long = "env", short = 'e', value_name = "KEY=VAL", var)]
@@ -3450,25 +3715,28 @@ pub enum OciCommands {
 /// See `mise upgrade` to upgrade these versions.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise outdated\n    Plugin  Requested  Current  Latest\n    python  3.11       3.11.0   3.11.1\n    node    20         20.0.0   20.1.0\n\n    $ mise outdated node\n    Plugin  Requested  Current  Latest\n    node    20         20.0.0   20.1.0\n\n    $ mise outdated --json\n    {\"python\": {\"requested\": \"3.11\", \"current\": \"3.11.0\", \"latest\": \"3.11.1\"}, ...}\n\n    $ mise outdated --local\n    Plugin  Requested  Current  Latest\n    node    20         20.0.0   20.1.0",
+    after_long_help = "\u{1b}[1m\u{1b}[4mDeprecation:\u{1b}[22m\u{1b}[24m\n\nThe `-l` shorthand for `--bump` is deprecated and will be removed in mise 2027.8.5.\nAfter removal, `-l` will become shorthand for `--local`. Use `-b` or `--bump` instead.\n\n\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise outdated\u{1b}[22m\n    Plugin  Requested  Current  Latest\n    python  3.11       3.11.0   3.11.1\n    node    20         20.0.0   20.1.0\n\n    $ \u{1b}[1mmise outdated node\u{1b}[22m\n    Plugin  Requested  Current  Latest\n    node    20         20.0.0   20.1.0\n\n    $ \u{1b}[1mmise outdated --json\u{1b}[22m\n    {\"python\": {\"requested\": \"3.11\", \"current\": \"3.11.0\", \"latest\": \"3.11.1\"}, ...}\n\n    $ \u{1b}[1mmise outdated --local\u{1b}[22m\n    Plugin  Requested  Current  Latest\n    node    20         20.0.0   20.1.0\n",
     effect = "read"
 )]
 pub struct OutdatedArgs {
-    /// Output in JSON format
-    #[usage(long = "json", short = 'J')]
-    pub json: bool,
     /// Compares against the latest versions available, not what matches the current config
     ///
     /// For example, if you have `node = "20"` in your config by default `mise outdated` will only
     /// show other 20.x versions, not 21.x or 22.x versions.
     ///
     /// Using this flag, if there are 21.x or newer versions it will display those instead of 20.x.
-    #[usage(long = "bump", short = 'l')]
+    #[usage(long = "bump", short = 'b')]
     pub bump: bool,
+    /// Output in JSON format
+    #[usage(long = "json", short = 'J')]
+    pub json: bool,
+    /// Deprecated shorthand for --bump
+    #[usage(short = 'l', hide)]
+    pub l: bool,
     /// Show outdated tools including installed-but-inactive tools not present in the current config
     ///
     /// By default, `mise outdated` only shows tools that come from the current config.
-    #[usage(long = "inactive")]
+    #[usage(long = "inactive", conflicts = "--local")]
     pub inactive: bool,
     /// Only show outdated tools defined in local config files
     ///
@@ -3499,7 +3767,7 @@ pub struct OutdatedArgs {
 /// To appear here, become a patron at <https://jdx.dev/sponsors.html>.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise patrons\n    $ mise patrons -J\n    $ mise patrons --refresh",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise patrons\u{1b}[22m\n    $ \u{1b}[1mmise patrons -J\u{1b}[22m\n    $ \u{1b}[1mmise patrons --refresh\u{1b}[22m",
     effect = "read"
 )]
 pub struct PatronsArgs {
@@ -3519,21 +3787,26 @@ pub struct PatronsArgs {
 /// This behavior can be modified in ~/.config/mise/config.toml
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    # install the poetry via shorthand\n    $ mise plugins install poetry\n\n    # install the poetry plugin using a specific git url\n    $ mise plugins install poetry https://github.com/mise-plugins/mise-poetry.git\n\n    # install the poetry plugin using the git url only\n    # (poetry is inferred from the url)\n    $ mise plugins install https://github.com/mise-plugins/mise-poetry.git\n\n    # install the poetry plugin using a specific ref\n    $ mise plugins install poetry https://github.com/mise-plugins/mise-poetry.git#11d0c1e",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # install the poetry via shorthand\n    $ \u{1b}[1mmise plugins install poetry\u{1b}[22m\n\n    # install the poetry plugin using a specific git url\n    $ \u{1b}[1mmise plugins install poetry https://github.com/mise-plugins/mise-poetry.git\u{1b}[22m\n\n    # install the poetry plugin using the git url only\n    # (poetry is inferred from the url)\n    $ \u{1b}[1mmise plugins install https://github.com/mise-plugins/mise-poetry.git\u{1b}[22m\n\n    # install the poetry plugin using a specific ref\n    $ \u{1b}[1mmise plugins install poetry https://github.com/mise-plugins/mise-poetry.git#11d0c1e\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct PluginsInstallArgs {
     #[usage(
         help = "Install all missing plugins\nThis will only install plugins that have matching shorthands.\ni.e.: they don't need the full git repo url",
         long = "all",
-        short = 'a'
+        short = 'a',
+        conflicts("NEW_PLUGIN", "--force")
     )]
     pub all: bool,
     /// Reinstall even if plugin exists
     #[usage(long = "force", short = 'f')]
     pub force: bool,
-    /// Number of jobs to run in parallel
-    #[usage(long = "jobs", short = 'j', value_name = "JOBS")]
+    #[usage(
+        help = "Number of jobs to run in parallel\nValues below 1 are treated as 1",
+        long = "jobs",
+        short = 'j',
+        value_name = "JOBS"
+    )]
     pub jobs: ::std::option::Option<::std::string::String>,
     /// Show installation output
     #[usage(long = "verbose", short = 'v', count)]
@@ -3541,7 +3814,8 @@ pub struct PluginsInstallArgs {
     #[usage(
         arg,
         name = "NEW_PLUGIN",
-        help = "The name of the plugin to install\ne.g.: cmake, poetry\nCan specify multiple plugins: `mise plugins install cmake poetry`"
+        help = "The name of the plugin to install\ne.g.: cmake, poetry\nCan specify multiple plugins: `mise plugins install cmake poetry`",
+        required_unless = "--all"
     )]
     pub new_plugin: ::std::option::Option<::std::string::String>,
     /// The git url of the plugin
@@ -3556,7 +3830,7 @@ pub struct PluginsInstallArgs {
 /// This is used for developing a plugin.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    # essentially just `ln -s ./vfox-cmake ~/.local/share/mise/plugins/cmake`\n    $ mise plugins link cmake ./vfox-cmake\n\n    # infer plugin name as \"cmake\"\n    $ mise plugins link ./vfox-cmake",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # essentially just `ln -s ./vfox-cmake ~/.local/share/mise/plugins/cmake`\n    $ \u{1b}[1mmise plugins link cmake ./vfox-cmake\u{1b}[22m\n\n    # infer plugin name as \"cmake\"\n    $ \u{1b}[1mmise plugins link ./vfox-cmake\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct PluginsLinkArgs {
@@ -3582,7 +3856,7 @@ pub struct PluginsLinkArgs {
 /// Can also show remotely available plugins to install.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise plugins ls\n    cmake\n    poetry\n\n    $ mise plugins ls --urls\n    cmake     https://github.com/mise-plugins/vfox-cmake.git\n    poetry    https://github.com/mise-plugins/vfox-poetry.git",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise plugins ls\u{1b}[22m\n    cmake\n    poetry\n\n    $ \u{1b}[1mmise plugins ls --urls\u{1b}[22m\n    cmake     https://github.com/mise-plugins/vfox-cmake.git\n    poetry    https://github.com/mise-plugins/vfox-poetry.git\n",
     effect = "read"
 )]
 pub struct PluginsLsArgs {
@@ -3597,7 +3871,8 @@ pub struct PluginsLsArgs {
         help = "The built-in plugins only\nNormally these are not shown",
         long = "core",
         short = 'c',
-        hide
+        hide,
+        conflicts = "--all"
     )]
     pub core: bool,
     #[usage(
@@ -3609,6 +3884,7 @@ pub struct PluginsLsArgs {
     #[usage(
         help = "Show the git url for each plugin\ne.g.: https://github.com/mise-plugins/vfox-cmake.git",
         long = "urls",
+        alias = "url",
         short = 'u'
     )]
     pub urls: bool,
@@ -3619,30 +3895,37 @@ pub struct PluginsLsArgs {
     )]
     pub refs: bool,
     /// List installed plugins
-    #[usage(long = "user", hide)]
+    #[usage(long = "user", hide, conflicts = "--all")]
     pub user: bool,
 }
 
 #[derive(Args)]
 #[usage(effect = "read")]
 pub struct PluginsLsRemoteArgs {
-    /// Show the git url for each plugin e.g.: https://github.com/mise-plugins/mise-poetry.git
-    #[usage(long = "urls", short = 'u')]
+    #[usage(
+        help = "Show the git url for each plugin e.g.: https://github.com/mise-plugins/mise-poetry.git",
+        long_help = "Show the git url for each plugin\ne.g.: https://github.com/mise-plugins/mise-poetry.git",
+        long = "urls",
+        short = 'u'
+    )]
     pub urls: bool,
-    /// Only show the name of each plugin by default it will show a "*" next to installed plugins
-    #[usage(long = "only-names")]
+    #[usage(
+        help = "Only show the name of each plugin by default it will show a \"*\" next to installed plugins",
+        long_help = "Only show the name of each plugin\nby default it will show a \"*\" next to installed plugins",
+        long = "only-names"
+    )]
     pub only_names: bool,
 }
 
 /// Removes a plugin
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise plugins uninstall cmake",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise plugins uninstall cmake\u{1b}[22m\n",
     effect = "destructive"
 )]
 pub struct PluginsUninstallArgs {
     /// Remove all plugins
-    #[usage(long = "all", short = 'a')]
+    #[usage(long = "all", short = 'a', conflicts = "PLUGIN")]
     pub all: bool,
     /// Also remove the plugin's installs, downloads, and cache
     #[usage(long = "purge", short = 'p')]
@@ -3657,12 +3940,12 @@ pub struct PluginsUninstallArgs {
 /// note: this updates the plugin itself, not the runtime versions
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise plugins update              # update all plugins\n    $ mise plugins update cmake       # update only cmake\n    $ mise plugins update cmake#beta  # specify a ref",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise plugins update\u{1b}[22m              # update all plugins\n    $ \u{1b}[1mmise plugins update cmake\u{1b}[22m       # update only cmake\n    $ \u{1b}[1mmise plugins update cmake#beta\u{1b}[22m  # specify a ref\n",
     effect = "write"
 )]
 pub struct PluginsUpdateArgs {
     #[usage(
-        help = "Number of jobs to run in parallel\nDefault: 4",
+        help = "Number of jobs to run in parallel\nValues below 1 are treated as 1\nDefault: 4",
         long = "jobs",
         short = 'j',
         value_name = "JOBS"
@@ -3685,12 +3968,14 @@ pub struct PluginsArgs {
     #[usage(
         help = "The built-in plugins only\nNormally these are not shown",
         long = "core",
-        short = 'c'
+        short = 'c',
+        conflicts = "--all"
     )]
     pub core: bool,
     #[usage(
         help = "Show the git url for each plugin\ne.g.: https://github.com/mise-plugins/vfox-cmake.git",
         long = "urls",
+        alias = "url",
         short = 'u'
     )]
     pub urls: bool,
@@ -3704,7 +3989,7 @@ pub struct PluginsArgs {
     ///
     /// This is the default behavior but can be used with --core
     /// to show core and user plugins
-    #[usage(long = "user")]
+    #[usage(long = "user", conflicts = "--all")]
     pub user: bool,
     #[usage(subcommand)]
     pub command: ::std::option::Option<PluginsCommands>,
@@ -3775,7 +4060,7 @@ pub struct DepsInstallArgs {
     ///
     /// Requires monorepo_root = true plus explicit [monorepo].config_roots in
     /// the monorepo root config. Providers are named like //apps/api:uv.
-    #[usage(long = "monorepo")]
+    #[usage(long = "monorepo", env = "MISE_MONOREPO")]
     pub monorepo: bool,
     /// Run specific deps rule(s) only
     #[usage(long = "only", value_name = "ONLY", var)]
@@ -3811,7 +4096,7 @@ pub struct DepsRemoveArgs {
 /// unless skipped with the --no-deps flag.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise deps                    # Install all project dependencies\n    $ mise deps install            # Same as bare `mise deps`\n    $ mise deps install --force    # Force reinstall even if fresh\n    $ mise deps install --dry-run  # Show what would run\n    $ mise deps --monorepo         # Install deps from explicit monorepo config roots\n    $ mise deps add npm:react      # Add a dependency\n    $ mise deps add -D npm:vitest  # Add a dev dependency\n    $ mise deps remove npm:lodash  # Remove a dependency\n\nConfiguration:\n\n```toml\n# Built-in npm provider (auto-detects lockfile)\n[deps.npm]\nauto = true              # Auto-run before mise x/run\n\n# Custom provider\n[deps.codegen]\nauto = true\nsources = [\"schema/*.graphql\"]\noutputs = [\"src/generated/\"]\nrun = \"npm run codegen\"\n\n[deps]\ndisable = [\"npm\"]        # Disable specific providers at runtime\n```",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise deps\u{1b}[22m                    # Install all project dependencies\n    $ \u{1b}[1mmise deps install\u{1b}[22m            # Same as bare `mise deps`\n    $ \u{1b}[1mmise deps install --force\u{1b}[22m    # Force reinstall even if fresh\n    $ \u{1b}[1mmise deps install --dry-run\u{1b}[22m  # Show what would run\n    $ \u{1b}[1mmise deps --monorepo\u{1b}[22m         # Install deps from explicit monorepo config roots\n    $ \u{1b}[1mmise deps add npm:react\u{1b}[22m      # Add a dependency\n    $ \u{1b}[1mmise deps add -D npm:vitest\u{1b}[22m  # Add a dev dependency\n    $ \u{1b}[1mmise deps remove npm:lodash\u{1b}[22m  # Remove a dependency\n\n\u{1b}[1m\u{1b}[4mConfiguration:\u{1b}[22m\u{1b}[24m\n\n```toml\n# Built-in npm provider (auto-detects lockfile)\n[deps.npm]\nauto = true              # Auto-run before mise x/run\n\n# Custom provider\n[deps.codegen]\nauto = true\nsources = [\"schema/*.graphql\"]\noutputs = [\"src/generated/\"]\nrun = \"npm run codegen\"\n\n[deps]\ndisable = [\"npm\"]        # Disable specific providers at runtime\n```\n",
     effect = "write"
 )]
 pub struct DepsArgs {
@@ -3831,7 +4116,7 @@ pub struct DepsArgs {
     ///
     /// Requires monorepo_root = true plus explicit [monorepo].config_roots in
     /// the monorepo root config. Providers are named like //apps/api:uv.
-    #[usage(long = "monorepo")]
+    #[usage(long = "monorepo", env = "MISE_MONOREPO")]
     pub monorepo: bool,
     /// Run specific deps rule(s) only
     #[usage(long = "only", value_name = "ONLY", var)]
@@ -3872,7 +4157,7 @@ pub enum DepsCommands {
 /// You can list prunable tools with `mise ls --prunable`
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise prune --dry-run\n    rm -rf ~/.local/share/mise/versions/node/20.0.0\n    rm -rf ~/.local/share/mise/versions/node/20.0.1",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise prune --dry-run\u{1b}[22m\n    rm -rf ~/.local/share/mise/versions/node/20.0.0\n    rm -rf ~/.local/share/mise/versions/node/20.0.1\n",
     effect = "destructive"
 )]
 pub struct PruneArgs {
@@ -3905,7 +4190,7 @@ pub struct PruneArgs {
 /// For example, `poetry` is shorthand for `asdf:mise-plugins/mise-poetry`.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise registry\n    node    core:node\n    poetry  asdf:mise-plugins/mise-poetry\n    ubi     cargo:ubi-cli\n\n    $ mise registry poetry\n    asdf:mise-plugins/mise-poetry",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise registry\u{1b}[22m\n    node    core:node\n    poetry  asdf:mise-plugins/mise-poetry\n    ubi     cargo:ubi-cli\n\n    $ \u{1b}[1mmise registry poetry\u{1b}[22m\n    asdf:mise-plugins/mise-poetry\n",
     effect = "read"
 )]
 pub struct RegistryArgs {
@@ -3921,11 +4206,12 @@ pub struct RegistryArgs {
     /// Output in JSON format
     #[usage(long = "json", short = 'J')]
     pub json: bool,
-    #[usage(
-        help = "Include security features for each tool's backends in JSON output",
-        long_help = "Include security features for each tool's backends in JSON output.\n\nRequires --json. Security info is de-duplicated across all of a tool's backends. This can add noticeable time for large listings since each backend's security info is resolved individually.",
-        long = "security"
-    )]
+    /// Include security features for each tool's backends in JSON output.
+    ///
+    /// Requires --json. Security info is de-duplicated across
+    /// all of a tool's backends. This can add noticeable time for large
+    /// listings since each backend's security info is resolved individually.
+    #[usage(long = "security", requires = "--json")]
     pub security: bool,
     /// Show only the specified tool's full name
     #[usage(arg, name = "NAME")]
@@ -3957,7 +4243,7 @@ pub struct RenderHelpArgs {}
 /// currently active in mise.toml.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise reshim\n    $ ~/.local/share/mise/shims/node -v\n    v20.0.0",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise reshim\u{1b}[22m\n    $ \u{1b}[1m~/.local/share/mise/shims/node -v\u{1b}[22m\n    v20.0.0\n",
     effect = "write"
 )]
 pub struct ReshimArgs {
@@ -3997,9 +4283,10 @@ pub struct ReshimArgs {
 ///     $ mise run build
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    # Runs the \"lint\" tasks. This needs to either be defined in mise.toml\n    # or as a standalone script. See the project README for more information.\n    $ mise run lint\n\n    # Forces the \"build\" tasks to run even if its sources are up-to-date.\n    $ mise run --force build\n\n    # Run \"test\" with stdin/stdout/stderr all connected to the current terminal.\n    # This forces `--jobs=1` to prevent interleaving of output.\n    $ mise run --raw test\n\n    # Runs the \"lint\", \"test\", and \"check\" tasks in parallel.\n    $ mise run lint ::: test ::: check\n\n    # Execute multiple tasks each with their own arguments.\n    $ mise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Runs the \"lint\" tasks. This needs to either be defined in mise.toml\n    # or as a standalone script. See the project README for more information.\n    $ \u{1b}[1mmise run lint\u{1b}[22m\n\n    # Forces the \"build\" tasks to run even if its sources are up-to-date.\n    $ \u{1b}[1mmise run --force build\u{1b}[22m\n\n    # Run \"test\" with stdin/stdout/stderr all connected to the current terminal.\n    # This forces `--jobs=1` to prevent interleaving of output.\n    $ \u{1b}[1mmise run --raw test\u{1b}[22m\n\n    # Runs the \"lint\", \"test\", and \"check\" tasks in parallel.\n    $ \u{1b}[1mmise run lint ::: test ::: check\u{1b}[22m\n\n    # Execute multiple tasks each with their own arguments.\n    $ \u{1b}[1mmise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2\u{1b}[22m\n",
     restart_token = ":::",
-    mount = "mise tasks --usage"
+    mount = "mise tasks --usage",
+    disable_help_flag
 )]
 pub struct RunArgs {
     /// Run matching tasks only for projects affected by Git changes
@@ -4008,21 +4295,34 @@ pub struct RunArgs {
     #[usage(
         help = "Git base revision for --affected\nDefaults to MISE_AFFECTED_BASE, CI metadata, or HEAD~1",
         long = "affected-base",
+        requires = "--affected",
         value_name = "REV"
     )]
     pub affected_base: ::std::option::Option<::std::string::String>,
     /// Explain why projects and tasks were selected by --affected
-    #[usage(long = "affected-explain")]
+    #[usage(
+        long = "affected-explain",
+        conflicts = "--affected-json",
+        requires = "--affected"
+    )]
     pub affected_explain: bool,
     #[usage(
         help = "Git head revision for --affected\nDefaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD",
         long = "affected-head",
+        requires = "--affected",
         value_name = "REV"
     )]
     pub affected_head: ::std::option::Option<::std::string::String>,
     /// Output affected projects and tasks as JSON without running tasks
-    #[usage(long = "affected-json")]
+    #[usage(
+        long = "affected-json",
+        conflicts = "--affected-explain",
+        requires = "--affected"
+    )]
     pub affected_json: bool,
+    /// Open the interactive selector with all tasks from the entire monorepo
+    #[usage(long = "all", conflicts = "--affected")]
+    pub all: bool,
     /// Continue running tasks even if one fails
     #[usage(long = "continue-on-error", short = 'c')]
     pub continue_on_error: bool,
@@ -4033,9 +4333,10 @@ pub struct RunArgs {
     #[usage(long = "force", short = 'f')]
     pub force: bool,
     #[usage(
-        help = "Number of tasks to run in parallel\n[default: 4]\nConfigure with `jobs` config or `MISE_JOBS` env var",
+        help = "Number of tasks to run in parallel\nValues below 1 are treated as 1\n[default: 4]\nConfigure with `jobs` config or `MISE_JOBS` env var",
         long = "jobs",
         short = 'j',
+        env = "MISE_JOBS",
         value_name = "JOBS"
     )]
     pub jobs: ::std::option::Option<::std::string::String>,
@@ -4051,10 +4352,15 @@ pub struct RunArgs {
     /// - `keep-order` - Print stdout/stderr by line, prefixed with the task's label, but keep the order of the output
     /// - `quiet` - Don't show extra output
     /// - `silent` - Don't show any output including stdout and stderr from the task except for errors
-    #[usage(long = "output", short = 'o', value_name = "OUTPUT")]
+    #[usage(
+        long = "output",
+        short = 'o',
+        env = "MISE_TASK_OUTPUT",
+        value_name = "OUTPUT"
+    )]
     pub output: ::std::option::Option<::std::string::String>,
     /// Don't show extra output
-    #[usage(long = "quiet", short = 'q')]
+    #[usage(long = "quiet", short = 'q', env = "MISE_QUIET")]
     pub quiet: bool,
     #[usage(
         help = "Read/write directly to stdin/stdout/stderr instead of by line\nRedactions are not applied with this option\nConfigure with `raw` config or `MISE_RAW` env var",
@@ -4070,10 +4376,16 @@ pub struct RunArgs {
     #[usage(long = "shell", short = 's', value_name = "SHELL")]
     pub shell: ::std::option::Option<::std::string::String>,
     /// Don't show any output except for errors
-    #[usage(long = "silent", short = 'S')]
+    #[usage(long = "silent", short = 'S', env = "MISE_SILENT")]
     pub silent: bool,
-    /// Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10
-    #[usage(long = "tool", short = 't', value_name = "TOOL@VERSION", var)]
+    #[usage(
+        help = "Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10",
+        long_help = "Tool(s) to run in addition to what is in mise.toml files\ne.g.: node@20 python@3.10",
+        long = "tool",
+        short = 't',
+        value_name = "TOOL@VERSION",
+        var
+    )]
     pub tool: ::std::vec::Vec<::std::string::String>,
     #[usage(
         help = "Allow specific env var through (implies --deny-env for everything else)\nSupports wildcards, e.g. --allow-env='MYAPP_*'",
@@ -4110,7 +4422,7 @@ pub struct RunArgs {
     #[usage(long = "fresh-env")]
     pub fresh_env: bool,
     /// Do not use cache on remote tasks
-    #[usage(long = "no-cache")]
+    #[usage(long = "no-cache", env = "MISE_TASK_REMOTE_NO_CACHE")]
     pub no_cache: bool,
     /// Skip automatic dependency preparation
     #[usage(long = "no-deps")]
@@ -4118,10 +4430,10 @@ pub struct RunArgs {
     /// Hides elapsed time after each task completes
     ///
     /// Default to always hide with `MISE_TASK_TIMINGS=0`
-    #[usage(long = "no-timings")]
+    #[usage(long = "no-timings", alias = "no-timing")]
     pub no_timings: bool,
     /// Run only the specified tasks skipping all dependencies
-    #[usage(long = "skip-deps")]
+    #[usage(long = "skip-deps", env = "MISE_TASK_SKIP_DEPENDS")]
     pub skip_deps: bool,
     /// Skip installing tools before running tasks
     ///
@@ -4138,6 +4450,7 @@ pub struct RunArgs {
     /// - `local-only` - Read and write only the local cache; currently equivalent to `read-write`
     #[usage(
         long = "task-cache",
+        env = "MISE_TASK_CACHE",
         value_name = "TASK_CACHE",
         choices("read-write", "read-only", "write-only", "off", "local-only"),
         default = "read-write"
@@ -4147,10 +4460,14 @@ pub struct RunArgs {
     #[usage(long = "task-cache-explain")]
     pub task_cache_explain: bool,
     /// Output cache-key input details as JSON Lines without running tasks
-    #[usage(long = "task-cache-explain-json")]
+    #[usage(
+        long = "task-cache-explain-json",
+        conflicts = "--task-cache-explain",
+        requires = "--dry-run"
+    )]
     pub task_cache_explain_json: bool,
     /// Report task output cache hits, restored bytes, and time saved
-    #[usage(long = "task-cache-stats")]
+    #[usage(long = "task-cache-stats", conflicts = "--dry-run")]
     pub task_cache_stats: bool,
     #[usage(
         help = "Timeout for the task to complete\ne.g.: 30s, 5m",
@@ -4161,7 +4478,7 @@ pub struct RunArgs {
     /// Shows elapsed time after each task completes
     ///
     /// Default to always show with `MISE_TASK_TIMINGS=1`
-    #[usage(long = "timings", hide)]
+    #[usage(long = "timings", alias = "timing", hide)]
     pub timings: bool,
 }
 
@@ -4173,12 +4490,16 @@ pub struct RunArgs {
 /// non-fuzzy matches, use the `--match-type` flag.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise search jq\n    Tool  Description\n    jq    Command-line JSON processor. https://github.com/jqlang/jq\n    jqp   A TUI playground to experiment with jq. https://github.com/noahgorstein/jqp\n    jiq   jid on jq - interactive JSON query tool using jq expressions. https://github.com/fiatjaf/jiq\n    gojq  Pure Go implementation of jq. https://github.com/itchyny/gojq\n\n    $ mise search --interactive\n    Tool\n    Search a tool\n    ❯ jq    Command-line JSON processor. https://github.com/jqlang/jq\n      jqp   A TUI playground to experiment with jq. https://github.com/noahgorstein/jqp\n      jiq   jid on jq - interactive JSON query tool using jq expressions. https://github.com/fiatjaf/jiq\n      gojq  Pure Go implementation of jq. https://github.com/itchyny/gojq\n    /jq \n    esc clear filter • enter confirm",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise search jq\u{1b}[22m\n    Tool  Description\n    jq    Command-line JSON processor. https://github.com/jqlang/jq\n    jqp   A TUI playground to experiment with jq. https://github.com/noahgorstein/jqp\n    jiq   jid on jq - interactive JSON query tool using jq expressions. https://github.com/fiatjaf/jiq\n    gojq  Pure Go implementation of jq. https://github.com/itchyny/gojq\n\n    $ \u{1b}[1mmise search --interactive\u{1b}[22m\n    Tool\n    Search a tool\n    ❯ jq    Command-line JSON processor. https://github.com/jqlang/jq\n      jqp   A TUI playground to experiment with jq. https://github.com/noahgorstein/jqp\n      jiq   jid on jq - interactive JSON query tool using jq expressions. https://github.com/fiatjaf/jiq\n      gojq  Pure Go implementation of jq. https://github.com/itchyny/gojq\n    /jq \n    esc clear filter • enter confirm\n",
     effect = "read"
 )]
 pub struct SearchArgs {
     /// Show interactive search
-    #[usage(long = "interactive", short = 'i')]
+    #[usage(
+        long = "interactive",
+        short = 'i',
+        conflicts("--match-type", "--no-header")
+    )]
     pub interactive: bool,
     /// Match type: equal, contains, or fuzzy
     #[usage(
@@ -4190,7 +4511,7 @@ pub struct SearchArgs {
     )]
     pub match_type: ::std::option::Option<::std::string::String>,
     /// Don't display headers
-    #[usage(long = "no-header")]
+    #[usage(long = "no-header", alias = "no-headers")]
     pub no_header: bool,
     /// The tool to search for
     #[usage(arg, name = "NAME")]
@@ -4233,33 +4554,48 @@ pub struct SelfUpdateArgs {
 /// Use `-E <env>` to create/modify environment-specific config files like `mise.<env>.toml`.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise set NODE_ENV=production\n\n    $ mise set NODE_ENV\n    production\n\n    $ mise set -E staging NODE_ENV=staging\n    # creates or modifies mise.staging.toml\n\n    $ mise set\n    key       value       source\n    NODE_ENV  production  ~/.config/mise/config.toml\n\n    $ mise set --prompt PASSWORD\n    Enter value for PASSWORD: [hidden input]\n\n    Multiline Values (--stdin):\n\n    $ cat private.key | mise set --stdin MY_KEY\n\n    $ printf \"line1\\nline2\" | mise set --stdin MY_KEY\n\n    [experimental] Age Encryption:\n\n    $ mise set --age-encrypt API_KEY=secret\n\n    $ mise set --age-encrypt --prompt API_KEY\n    Enter value for API_KEY: [hidden input]",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise set NODE_ENV=production\u{1b}[22m\n\n    $ \u{1b}[1mmise set NODE_ENV\u{1b}[22m\n    production\n\n    $ \u{1b}[1mmise set -E staging NODE_ENV=staging\u{1b}[22m\n    # creates or modifies mise.staging.toml\n\n    $ \u{1b}[1mmise set\u{1b}[22m\n    key       value       source\n    NODE_ENV  production  ~/.config/mise/config.toml\n\n    $ \u{1b}[1mmise set --prompt PASSWORD\u{1b}[22m\n    Enter value for PASSWORD: [hidden input]\n\n    \u{1b}[1m\u{1b}[4mMultiline Values (--stdin):\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mcat private.key | mise set --stdin MY_KEY\u{1b}[22m\n\n    $ \u{1b}[1mprintf \"line1\\nline2\" | mise set --stdin MY_KEY\u{1b}[22m\n\n    \u{1b}[1m\u{1b}[4m[experimental] Age Encryption:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise set --age-encrypt API_KEY=secret\u{1b}[22m\n\n    $ \u{1b}[1mmise set --age-encrypt --prompt API_KEY\u{1b}[22m\n    Enter value for API_KEY: [hidden input]\n",
     effect = "write"
 )]
 pub struct SetArgs {
     /// Create/modify an environment-specific config file like .mise.<env>.toml
-    #[usage(long = "env", short = 'E', value_name = "ENV")]
+    #[usage(
+        long = "env",
+        short = 'E',
+        overrides("--global", "--file"),
+        value_name = "ENV"
+    )]
     pub env: ::std::option::Option<::std::string::String>,
     /// Set the environment variable in the global config file
-    #[usage(long = "global", short = 'g')]
+    #[usage(long = "global", short = 'g', overrides("--file", "--env"))]
     pub global: bool,
     /// [experimental] Encrypt the value with age before storing
-    #[usage(long = "age-encrypt")]
+    #[usage(long = "age-encrypt", requires = "ENV_VAR")]
     pub age_encrypt: bool,
     /// [experimental] Age identity file for encryption
     ///
     /// Defaults to ~/.config/mise/age.txt if it exists
-    #[usage(long = "age-key-file", value_name = "PATH")]
+    #[usage(long = "age-key-file", requires = "--age-encrypt", value_name = "PATH")]
     pub age_key_file: ::std::option::Option<::std::string::String>,
     /// [experimental] Age recipient (x25519 public key) for encryption
     ///
     /// Can be used multiple times. Requires --age-encrypt.
-    #[usage(long = "age-recipient", value_name = "RECIPIENT", var)]
+    #[usage(
+        long = "age-recipient",
+        requires = "--age-encrypt",
+        value_name = "RECIPIENT",
+        var
+    )]
     pub age_recipient: ::std::vec::Vec<::std::string::String>,
     /// [experimental] SSH recipient (public key or path) for age encryption
     ///
     /// Can be used multiple times. Requires --age-encrypt.
-    #[usage(long = "age-ssh-recipient", value_name = "PATH_OR_PUBKEY", var)]
+    #[usage(
+        long = "age-ssh-recipient",
+        requires = "--age-encrypt",
+        value_name = "PATH_OR_PUBKEY",
+        var
+    )]
     pub age_ssh_recipient: ::std::vec::Vec<::std::string::String>,
     /// Render completions
     #[usage(long = "complete", hide)]
@@ -4291,8 +4627,9 @@ pub struct SetArgs {
     pub remove: ::std::vec::Vec<::std::string::String>,
     /// Read the value from stdin (for multiline input)
     ///
-    /// When using --stdin, provide a single key without a value. The value will be read from stdin until EOF.
-    #[usage(long = "stdin")]
+    /// When using --stdin, provide a single key without a value.
+    /// The value will be read from stdin until EOF.
+    #[usage(long = "stdin", conflicts = "--prompt", requires = "ENV_VAR")]
     pub stdin: bool,
     #[usage(
         arg,
@@ -4308,7 +4645,7 @@ pub struct SetArgs {
 /// This modifies the contents of ~/.config/mise/config.toml
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise settings add disable_hints python_multi",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise settings add disable_hints python_multi\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct SettingsAddArgs {
@@ -4331,7 +4668,7 @@ pub struct SettingsAddArgs {
 /// but managed separately with `mise tool-alias get`
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise settings get idiomatic_version_file\n    true",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise settings get idiomatic_version_file\u{1b}[22m\n    true\n",
     effect = "read"
 )]
 pub struct SettingsGetArgs {
@@ -4351,27 +4688,28 @@ pub struct SettingsGetArgs {
 /// but managed separately with `mise tool-alias`
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise settings ls\n    idiomatic_version_file = false\n    ...\n\n    $ mise settings ls python\n    default_packages_file = \"~/.default-python-packages\"\n    ...",
-    effect = "read"
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise settings ls\u{1b}[22m\n    idiomatic_version_file = false\n    ...\n\n    $ \u{1b}[1mmise settings ls python\u{1b}[22m\n    default_packages_file = \"~/.default-python-packages\"\n    ...\n",
+    effect = "read",
+    group("output")
 )]
 pub struct SettingsLsArgs {
     /// List all settings
     #[usage(long = "all", short = 'a')]
     pub all: bool,
     /// Output in JSON format
-    #[usage(long = "json", short = 'J')]
+    #[usage(long = "json", short = 'J', group = "output")]
     pub json: bool,
     /// Use the local config file instead of the global one
     #[usage(long = "local", short = 'l', global)]
     pub local: bool,
     /// Output in TOML format
-    #[usage(long = "toml", short = 'T')]
+    #[usage(long = "toml", short = 'T', group = "output")]
     pub toml: bool,
     /// Print all settings with descriptions for shell completions
     #[usage(long = "complete", hide)]
     pub complete: bool,
     /// Output in JSON format with sources
-    #[usage(long = "json-extended")]
+    #[usage(long = "json-extended", group = "output")]
     pub json_extended: bool,
     /// Name of setting
     #[usage(arg, name = "SETTING")]
@@ -4385,7 +4723,7 @@ pub struct SettingsLsArgs {
 /// See https://mise.jdx.dev/configuration.html#target-file-for-write-operations
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise settings idiomatic_version_file=true",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise settings idiomatic_version_file=true\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct SettingsSetArgs {
@@ -4405,7 +4743,7 @@ pub struct SettingsSetArgs {
 /// This modifies the contents of ~/.config/mise/config.toml
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise settings unset idiomatic_version_file",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise settings unset idiomatic_version_file\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct SettingsUnsetArgs {
@@ -4417,35 +4755,37 @@ pub struct SettingsUnsetArgs {
     pub key: ::std::string::String,
 }
 
+/// Manage settings
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n    # list all settings\n    $ mise settings\n\n    # get the value of the setting \"always_keep_download\"\n    $ mise settings always_keep_download\n\n    # set the value of the setting \"always_keep_download\" to \"true\"\n    $ mise settings always_keep_download=true\n\n    # set the value of the setting \"node.mirror_url\" to \"https://npmmirror.com/mirrors/node/\"\n    $ mise settings node.mirror_url https://npmmirror.com/mirrors/node/",
-    effect = "write"
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n    # list all settings\n    $ \u{1b}[1mmise settings\u{1b}[22m\n\n    # get the value of the setting \"always_keep_download\"\n    $ \u{1b}[1mmise settings always_keep_download\u{1b}[22m\n\n    # set the value of the setting \"always_keep_download\" to \"true\"\n    $ \u{1b}[1mmise settings always_keep_download=true\u{1b}[22m\n\n    # set the value of the setting \"node.mirror_url\" to \"https://npmmirror.com/mirrors/node/\"\n    $ \u{1b}[1mmise settings node.mirror_url https://npmmirror.com/mirrors/node/\u{1b}[22m\n",
+    effect = "write",
+    group("output")
 )]
 pub struct SettingsArgs {
     /// List all settings
     #[usage(long = "all", short = 'a')]
     pub all: bool,
     /// Output in JSON format
-    #[usage(long = "json", short = 'J')]
+    #[usage(long = "json", short = 'J', group = "output")]
     pub json: bool,
     /// Use the local config file instead of the global one
     #[usage(long = "local", short = 'l', global)]
     pub local: bool,
     /// Output in TOML format
-    #[usage(long = "toml", short = 'T')]
+    #[usage(long = "toml", short = 'T', group = "output")]
     pub toml: bool,
     /// Print all settings with descriptions for shell completions
     #[usage(long = "complete", hide)]
     pub complete: bool,
     /// Output in JSON format with sources
-    #[usage(long = "json-extended")]
+    #[usage(long = "json-extended", group = "output")]
     pub json_extended: bool,
     /// Name of setting
     #[usage(arg, name = "SETTING")]
     pub setting: ::std::option::Option<::std::string::String>,
     /// Setting value to set
-    #[usage(arg, name = "VALUE")]
+    #[usage(arg, name = "VALUE", conflicts = "all")]
     pub value: ::std::option::Option<::std::string::String>,
     #[usage(subcommand)]
     pub command: ::std::option::Option<SettingsCommands>,
@@ -4478,22 +4818,27 @@ pub enum SettingsCommands {
 /// such as `MISE_NODE_VERSION=20` which is "eval"ed as a shell function created by `mise activate`.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise shell node@20\n    $ node -v\n    v20.0.0",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise shell node@20\u{1b}[22m\n    $ \u{1b}[1mnode -v\u{1b}[22m\n    v20.0.0\n",
     effect = "read"
 )]
 pub struct ShellArgs {
     #[usage(
-        help = "Number of jobs to run in parallel\n[default: 4]",
+        help = "Number of jobs to run in parallel\nValues below 1 are treated as 1\n[default: 4]",
         long = "jobs",
         short = 'j',
+        env = "MISE_JOBS",
         value_name = "JOBS"
     )]
     pub jobs: ::std::option::Option<::std::string::String>,
     /// Removes a previously set version
     #[usage(long = "unset", short = 'u')]
     pub unset: bool,
-    /// Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1
-    #[usage(long = "raw")]
+    #[usage(
+        help = "Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1",
+        long_help = "Connect backend install command stdin/stdout/stderr directly to the terminal\nImplies --jobs=1",
+        long = "raw",
+        overrides = "--jobs"
+    )]
     pub raw: bool,
     /// Tool(s) to use
     #[usage(arg, name = "TOOL@VERSION", required)]
@@ -4503,7 +4848,7 @@ pub struct ShellArgs {
 /// Show the command for a shell alias
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise shell-alias get ll\n    ls -la",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise shell-alias get ll\u{1b}[22m\n    ls -la\n",
     effect = "read"
 )]
 pub struct ShellAliasGetArgs {
@@ -4518,7 +4863,7 @@ pub struct ShellAliasGetArgs {
 /// These are defined in `mise.toml` under the `[shell_alias]` section.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise shell-alias ls\n    alias    command\n    ll       ls -la\n    gs       git status",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise shell-alias ls\u{1b}[22m\n    alias    command\n    ll       ls -la\n    gs       git status\n",
     effect = "read"
 )]
 pub struct ShellAliasLsArgs {
@@ -4532,7 +4877,7 @@ pub struct ShellAliasLsArgs {
 /// This modifies the contents of ~/.config/mise/config.toml
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise shell-alias set ll \"ls -la\"\n    $ mise shell-alias set gs \"git status\"",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise shell-alias set ll \"ls -la\"\u{1b}[22m\n    $ \u{1b}[1mmise shell-alias set gs \"git status\"\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct ShellAliasSetArgs {
@@ -4549,7 +4894,7 @@ pub struct ShellAliasSetArgs {
 /// This modifies the contents of ~/.config/mise/config.toml
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise shell-alias unset ll",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise shell-alias unset ll\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct ShellAliasUnsetArgs {
@@ -4594,21 +4939,22 @@ pub struct SponsorsArgs {}
 ///
 /// For example, use this to import all Homebrew node installs into mise
 ///
-/// This won't overwrite any existing installs but will overwrite any existing symlinks
+/// This won't overwrite managed installs, runtime aliases, or links from other providers.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ brew install node@18 node@20\n    $ mise sync node --brew\n    $ mise use -g node@18 - uses Homebrew-provided node",
-    effect = "write"
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mbrew install node@18 node@20\u{1b}[22m\n    $ \u{1b}[1mmise sync node --brew\u{1b}[22m\n    $ \u{1b}[1mmise use -g node@18\u{1b}[22m - uses Homebrew-provided node\n",
+    effect = "write",
+    group("SyncNodeType", required, multiple)
 )]
 pub struct SyncNodeArgs {
     /// Get tool versions from Homebrew
-    #[usage(long = "brew")]
+    #[usage(long = "brew", group = "SyncNodeType")]
     pub brew: bool,
     /// Get tool versions from nodenv
-    #[usage(long = "nodenv")]
+    #[usage(long = "nodenv", group = "SyncNodeType")]
     pub nodenv: bool,
     /// Get tool versions from nvm
-    #[usage(long = "nvm")]
+    #[usage(long = "nvm", group = "SyncNodeType")]
     pub nvm: bool,
 }
 
@@ -4616,10 +4962,10 @@ pub struct SyncNodeArgs {
 ///
 /// For example, use this to import all pyenv installs into mise
 ///
-/// This won't overwrite any existing installs but will overwrite any existing symlinks
+/// This won't overwrite managed installs, runtime aliases, or links from other providers.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ pyenv install 3.11.0\n    $ mise sync python --pyenv\n    $ mise use -g python@3.11.0 - uses pyenv-provided python\n\n    $ uv python install 3.11.0\n    $ mise install python@3.10.0\n    $ mise sync python --uv\n    $ mise x python@3.11.0 -- python -V - uses uv-provided python\n    $ uv run -p 3.10.0 -- python -V - uses mise-provided python",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mpyenv install 3.11.0\u{1b}[22m\n    $ \u{1b}[1mmise sync python --pyenv\u{1b}[22m\n    $ \u{1b}[1mmise use -g python@3.11.0\u{1b}[22m - uses pyenv-provided python\n    \n    $ \u{1b}[1muv python install 3.11.0\u{1b}[22m\n    $ \u{1b}[1mmise install python@3.10.0\u{1b}[22m\n    $ \u{1b}[1mmise sync python --uv\u{1b}[22m\n    $ \u{1b}[1mmise x python@3.11.0 -- python -V\u{1b}[22m - uses uv-provided python\n    $ \u{1b}[1muv run -p 3.10.0 -- python -V\u{1b}[22m - uses mise-provided python\n",
     effect = "write"
 )]
 pub struct SyncPythonArgs {
@@ -4634,12 +4980,12 @@ pub struct SyncPythonArgs {
 /// Symlinks all ruby tool versions from an external tool into mise
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ brew install ruby\n    $ mise sync ruby --brew\n    $ mise use -g ruby - Use the latest version of Ruby installed by Homebrew",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mbrew install ruby\u{1b}[22m\n    $ \u{1b}[1mmise sync ruby --brew\u{1b}[22m\n    $ \u{1b}[1mmise use -g ruby\u{1b}[22m - Use the latest version of Ruby installed by Homebrew\n",
     effect = "write"
 )]
 pub struct SyncRubyArgs {
     /// Get tool versions from Homebrew
-    #[usage(long = "brew")]
+    #[usage(long = "brew", required)]
     pub brew: bool,
 }
 
@@ -4670,7 +5016,7 @@ pub enum SyncCommands {
 /// See https://mise.jdx.dev/configuration.html#target-file-for-write-operations
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise tasks add pre-commit --depends \"test\" --depends \"render\" -- echo pre-commit",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise tasks add pre-commit --depends \"test\" --depends \"render\" -- echo pre-commit\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct TasksAddArgs {
@@ -4729,12 +5075,12 @@ pub struct TasksAddArgs {
 /// Display a tree visualization of a dependency graph
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    # Show dependencies for all tasks\n    $ mise tasks deps\n\n    # Show dependencies for the \"lint\", \"test\" and \"check\" tasks\n    $ mise tasks deps lint test check\n\n    # Show dependencies in DOT format\n    $ mise tasks deps --dot\n\n    # Collapse repeated dependencies\n    $ mise tasks deps --compact",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Show dependencies for all tasks\n    $ \u{1b}[1mmise tasks deps\u{1b}[22m\n\n    # Show dependencies for the \"lint\", \"test\" and \"check\" tasks\n    $ \u{1b}[1mmise tasks deps lint test check\u{1b}[22m\n\n    # Show dependencies in DOT format\n    $ \u{1b}[1mmise tasks deps --dot\u{1b}[22m\n\n    # Collapse repeated dependencies\n    $ \u{1b}[1mmise tasks deps --compact\u{1b}[22m\n",
     effect = "read"
 )]
 pub struct TasksDepsArgs {
     /// Collapse repeated dependencies after their first occurrence
-    #[usage(long = "compact")]
+    #[usage(long = "compact", conflicts = "--dot")]
     pub compact: bool,
     /// Display dependencies in DOT format
     #[usage(long = "dot")]
@@ -4755,7 +5101,7 @@ pub struct TasksDepsArgs {
 /// The task will be created as a standalone script if it does not already exist.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise tasks edit build\n    $ mise tasks edit test",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise tasks edit build\u{1b}[22m\n    $ \u{1b}[1mmise tasks edit test\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct TasksEditArgs {
@@ -4770,7 +5116,7 @@ pub struct TasksEditArgs {
 /// [experimental] Inspect the workspace project graph
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    # Inspect projects and their dependency edges\n    $ mise tasks graph\n\n    # Emit the project graph as JSON\n    $ mise tasks graph --json\n\n    # Explain where inferred projects and task fields came from\n    $ mise tasks graph --explain",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Inspect projects and their dependency edges\n    $ \u{1b}[1mmise tasks graph\u{1b}[22m\n\n    # Emit the project graph as JSON\n    $ \u{1b}[1mmise tasks graph --json\u{1b}[22m\n\n    # Explain where inferred projects and task fields came from\n    $ \u{1b}[1mmise tasks graph --explain\u{1b}[22m\n",
     effect = "read"
 )]
 pub struct TasksGraphArgs {
@@ -4778,17 +5124,17 @@ pub struct TasksGraphArgs {
     #[usage(long = "json", short = 'J')]
     pub json: bool,
     /// Explain provider attribution for inferred projects and tasks
-    #[usage(long = "explain")]
+    #[usage(long = "explain", conflicts = "--json")]
     pub explain: bool,
     /// Do not print table headers
-    #[usage(long = "no-header")]
+    #[usage(long = "no-header", alias = "no-headers")]
     pub no_header: bool,
 }
 
 /// Get information about a task
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise tasks info\n    Name: test\n    Aliases: t\n    Description: Test the application\n    Source: ~/src/myproj/mise.toml\n\n    $ mise tasks info test --json\n    {\n      \"name\": \"test\",\n      \"aliases\": \"t\",\n      \"description\": \"Test the application\",\n      \"source\": \"~/src/myproj/mise.toml\",\n      \"config_sources\": [\"~/src/myproj/mise.toml\"],\n      \"depends\": [],\n      \"env\": {},\n      \"dir\": null,\n      \"hide\": false,\n      \"raw\": false,\n      \"sources\": [],\n      \"outputs\": [],\n      \"run\": [\n        \"echo \\\"testing!\\\"\"\n      ],\n      \"file\": null,\n      \"usage_spec\": {}\n    }",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise tasks info\u{1b}[22m\n    Name: test\n    Aliases: t\n    Description: Test the application\n    Source: ~/src/myproj/mise.toml\n\n    $ \u{1b}[1mmise tasks info test --json\u{1b}[22m\n    {\n      \"name\": \"test\",\n      \"aliases\": \"t\",\n      \"description\": \"Test the application\",\n      \"source\": \"~/src/myproj/mise.toml\",\n      \"config_sources\": [\"~/src/myproj/mise.toml\"],\n      \"depends\": [],\n      \"env\": {},\n      \"dir\": null,\n      \"hide\": false,\n      \"raw\": false,\n      \"sources\": [],\n      \"outputs\": [],\n      \"run\": [\n        \"echo \\\"testing!\\\"\"\n      ],\n      \"file\": null,\n      \"usage_spec\": {}\n    }\n",
     effect = "read"
 )]
 pub struct TasksInfoArgs {
@@ -4801,16 +5147,19 @@ pub struct TasksInfoArgs {
 }
 
 #[derive(Args)]
-#[usage(after_long_help = "Examples:\n\n    $ mise tasks ls", effect = "read")]
+#[usage(
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise tasks ls\u{1b}[22m\n",
+    effect = "read"
+)]
 pub struct TasksLsArgs {
     /// Only show global tasks
-    #[usage(long = "global", short = 'g')]
+    #[usage(long = "global", short = 'g', overrides = "--local")]
     pub global: bool,
     /// Output in JSON format
     #[usage(long = "json", short = 'J')]
     pub json: bool,
     /// Only show non-global tasks
-    #[usage(long = "local", short = 'l')]
+    #[usage(long = "local", short = 'l', overrides = "--global")]
     pub local: bool,
     /// Show all columns
     #[usage(long = "extended", short = 'x')]
@@ -4827,10 +5176,10 @@ pub struct TasksLsArgs {
     #[usage(long = "hidden")]
     pub hidden: bool,
     /// Only show task names, one per line. Useful for piping to fzf and similar tools.
-    #[usage(long = "name-only")]
+    #[usage(long = "name-only", conflicts("--json", "--extended", "--usage"))]
     pub name_only: bool,
     /// Do not print table header
-    #[usage(long = "no-header")]
+    #[usage(long = "no-header", alias = "no-headers")]
     pub no_header: bool,
     /// Sort by column. Default is name.
     #[usage(
@@ -4873,9 +5222,10 @@ pub struct TasksLsArgs {
 ///     $ mise run build
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    # Runs the \"lint\" tasks. This needs to either be defined in mise.toml\n    # or as a standalone script. See the project README for more information.\n    $ mise run lint\n\n    # Forces the \"build\" tasks to run even if its sources are up-to-date.\n    $ mise run --force build\n\n    # Run \"test\" with stdin/stdout/stderr all connected to the current terminal.\n    # This forces `--jobs=1` to prevent interleaving of output.\n    $ mise run --raw test\n\n    # Runs the \"lint\", \"test\", and \"check\" tasks in parallel.\n    $ mise run lint ::: test ::: check\n\n    # Execute multiple tasks each with their own arguments.\n    $ mise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Runs the \"lint\" tasks. This needs to either be defined in mise.toml\n    # or as a standalone script. See the project README for more information.\n    $ \u{1b}[1mmise run lint\u{1b}[22m\n\n    # Forces the \"build\" tasks to run even if its sources are up-to-date.\n    $ \u{1b}[1mmise run --force build\u{1b}[22m\n\n    # Run \"test\" with stdin/stdout/stderr all connected to the current terminal.\n    # This forces `--jobs=1` to prevent interleaving of output.\n    $ \u{1b}[1mmise run --raw test\u{1b}[22m\n\n    # Runs the \"lint\", \"test\", and \"check\" tasks in parallel.\n    $ \u{1b}[1mmise run lint ::: test ::: check\u{1b}[22m\n\n    # Execute multiple tasks each with their own arguments.\n    $ \u{1b}[1mmise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2\u{1b}[22m\n",
     restart_token = ":::",
-    mount = "mise tasks --usage"
+    mount = "mise tasks --usage",
+    disable_help_flag
 )]
 pub struct TasksRunArgs {
     /// Run matching tasks only for projects affected by Git changes
@@ -4884,21 +5234,34 @@ pub struct TasksRunArgs {
     #[usage(
         help = "Git base revision for --affected\nDefaults to MISE_AFFECTED_BASE, CI metadata, or HEAD~1",
         long = "affected-base",
+        requires = "--affected",
         value_name = "REV"
     )]
     pub affected_base: ::std::option::Option<::std::string::String>,
     /// Explain why projects and tasks were selected by --affected
-    #[usage(long = "affected-explain")]
+    #[usage(
+        long = "affected-explain",
+        conflicts = "--affected-json",
+        requires = "--affected"
+    )]
     pub affected_explain: bool,
     #[usage(
         help = "Git head revision for --affected\nDefaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD",
         long = "affected-head",
+        requires = "--affected",
         value_name = "REV"
     )]
     pub affected_head: ::std::option::Option<::std::string::String>,
     /// Output affected projects and tasks as JSON without running tasks
-    #[usage(long = "affected-json")]
+    #[usage(
+        long = "affected-json",
+        conflicts = "--affected-explain",
+        requires = "--affected"
+    )]
     pub affected_json: bool,
+    /// Open the interactive selector with all tasks from the entire monorepo
+    #[usage(long = "all", conflicts("TASK", "--affected"))]
+    pub all: bool,
     /// Continue running tasks even if one fails
     #[usage(long = "continue-on-error", short = 'c')]
     pub continue_on_error: bool,
@@ -4909,9 +5272,10 @@ pub struct TasksRunArgs {
     #[usage(long = "force", short = 'f')]
     pub force: bool,
     #[usage(
-        help = "Number of tasks to run in parallel\n[default: 4]\nConfigure with `jobs` config or `MISE_JOBS` env var",
+        help = "Number of tasks to run in parallel\nValues below 1 are treated as 1\n[default: 4]\nConfigure with `jobs` config or `MISE_JOBS` env var",
         long = "jobs",
         short = 'j',
+        env = "MISE_JOBS",
         value_name = "JOBS"
     )]
     pub jobs: ::std::option::Option<::std::string::String>,
@@ -4927,10 +5291,15 @@ pub struct TasksRunArgs {
     /// - `keep-order` - Print stdout/stderr by line, prefixed with the task's label, but keep the order of the output
     /// - `quiet` - Don't show extra output
     /// - `silent` - Don't show any output including stdout and stderr from the task except for errors
-    #[usage(long = "output", short = 'o', value_name = "OUTPUT")]
+    #[usage(
+        long = "output",
+        short = 'o',
+        env = "MISE_TASK_OUTPUT",
+        value_name = "OUTPUT"
+    )]
     pub output: ::std::option::Option<::std::string::String>,
     /// Don't show extra output
-    #[usage(long = "quiet", short = 'q')]
+    #[usage(long = "quiet", short = 'q', env = "MISE_QUIET")]
     pub quiet: bool,
     #[usage(
         help = "Read/write directly to stdin/stdout/stderr instead of by line\nRedactions are not applied with this option\nConfigure with `raw` config or `MISE_RAW` env var",
@@ -4946,10 +5315,16 @@ pub struct TasksRunArgs {
     #[usage(long = "shell", short = 's', value_name = "SHELL")]
     pub shell: ::std::option::Option<::std::string::String>,
     /// Don't show any output except for errors
-    #[usage(long = "silent", short = 'S')]
+    #[usage(long = "silent", short = 'S', env = "MISE_SILENT")]
     pub silent: bool,
-    /// Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10
-    #[usage(long = "tool", short = 't', value_name = "TOOL@VERSION", var)]
+    #[usage(
+        help = "Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10",
+        long_help = "Tool(s) to run in addition to what is in mise.toml files\ne.g.: node@20 python@3.10",
+        long = "tool",
+        short = 't',
+        value_name = "TOOL@VERSION",
+        var
+    )]
     pub tool: ::std::vec::Vec<::std::string::String>,
     #[usage(
         help = "Allow specific env var through (implies --deny-env for everything else)\nSupports wildcards, e.g. --allow-env='MYAPP_*'",
@@ -4986,7 +5361,7 @@ pub struct TasksRunArgs {
     #[usage(long = "fresh-env")]
     pub fresh_env: bool,
     /// Do not use cache on remote tasks
-    #[usage(long = "no-cache")]
+    #[usage(long = "no-cache", env = "MISE_TASK_REMOTE_NO_CACHE")]
     pub no_cache: bool,
     /// Skip automatic dependency preparation
     #[usage(long = "no-deps")]
@@ -4994,10 +5369,10 @@ pub struct TasksRunArgs {
     /// Hides elapsed time after each task completes
     ///
     /// Default to always hide with `MISE_TASK_TIMINGS=0`
-    #[usage(long = "no-timings")]
+    #[usage(long = "no-timings", alias = "no-timing")]
     pub no_timings: bool,
     /// Run only the specified tasks skipping all dependencies
-    #[usage(long = "skip-deps")]
+    #[usage(long = "skip-deps", env = "MISE_TASK_SKIP_DEPENDS")]
     pub skip_deps: bool,
     /// Skip installing tools before running tasks
     ///
@@ -5014,6 +5389,7 @@ pub struct TasksRunArgs {
     /// - `local-only` - Read and write only the local cache; currently equivalent to `read-write`
     #[usage(
         long = "task-cache",
+        env = "MISE_TASK_CACHE",
         value_name = "TASK_CACHE",
         choices("read-write", "read-only", "write-only", "off", "local-only"),
         default = "read-write"
@@ -5023,10 +5399,14 @@ pub struct TasksRunArgs {
     #[usage(long = "task-cache-explain")]
     pub task_cache_explain: bool,
     /// Output cache-key input details as JSON Lines without running tasks
-    #[usage(long = "task-cache-explain-json")]
+    #[usage(
+        long = "task-cache-explain-json",
+        conflicts = "--task-cache-explain",
+        requires = "--dry-run"
+    )]
     pub task_cache_explain_json: bool,
     /// Report task output cache hits, restored bytes, and time saved
-    #[usage(long = "task-cache-stats")]
+    #[usage(long = "task-cache-stats", conflicts = "--dry-run")]
     pub task_cache_stats: bool,
     #[usage(
         help = "Timeout for the task to complete\ne.g.: 30s, 5m",
@@ -5037,19 +5417,19 @@ pub struct TasksRunArgs {
     /// Shows elapsed time after each task completes
     ///
     /// Default to always show with `MISE_TASK_TIMINGS=1`
-    #[usage(long = "timings", hide)]
+    #[usage(long = "timings", alias = "timing", hide)]
     pub timings: bool,
     #[usage(
         arg,
         name = "TASK",
-        help = "Tasks to run\nCan specify multiple tasks by separating with `:::`\ne.g.: mise run task1 arg1 arg2 ::: task2 arg1 arg2",
-        default = "default"
+        help = "Tasks to run\nCan specify multiple tasks by separating with `:::`\ne.g.: mise run task1 arg1 arg2 ::: task2 arg1 arg2\nDefaults to `default` when omitted",
+        double_dash = "automatic"
     )]
     pub task: ::std::option::Option<::std::string::String>,
-    /// Arguments to pass to the tasks. Use ":::" to separate tasks
+    /// Arguments to pass to the tasks. Use ":::" to separate tasks.
     #[usage(arg, name = "ARGS")]
     pub args: ::std::vec::Vec<::std::string::String>,
-    /// Arguments to pass to the tasks. Use ":::" to separate tasks
+    /// Arguments to pass to the tasks. Use ":::" to separate tasks.
     #[usage(arg, name = "ARGS_LAST", hide, double_dash = "required")]
     pub args_last: ::std::vec::Vec<::std::string::String>,
 }
@@ -5057,7 +5437,7 @@ pub struct TasksRunArgs {
 /// Validate tasks for common errors and issues
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    # Validate all tasks\n    $ mise tasks validate\n\n    # Validate specific tasks\n    $ mise tasks validate build test\n\n    # Output results as JSON\n    $ mise tasks validate --json\n\n    # Only show errors (skip warnings)\n    $ mise tasks validate --errors-only\n\nValidation Checks:\n\nThe validate command performs the following checks:\n\n  • Circular Dependencies: Detects dependency cycles\n  • Missing References: Finds references to nonexistent tasks\n  • Usage Spec Parsing: Validates #USAGE directives and specs\n  • Timeout Format: Checks timeout values are valid durations\n  • Alias Conflicts: Detects duplicate aliases across tasks\n  • File Existence: Verifies file-based tasks exist\n  • Directory Templates: Validates directory paths and templates\n  • Shell Commands: Checks shell executables exist\n  • Glob Patterns: Validates source and output patterns\n  • Run Entries: Ensures tasks reference valid dependencies",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Validate all tasks\n    $ \u{1b}[1mmise tasks validate\u{1b}[22m\n\n    # Validate specific tasks\n    $ \u{1b}[1mmise tasks validate build test\u{1b}[22m\n\n    # Output results as JSON\n    $ \u{1b}[1mmise tasks validate --json\u{1b}[22m\n\n    # Only show errors (skip warnings)\n    $ \u{1b}[1mmise tasks validate --errors-only\u{1b}[22m\n\n\u{1b}[1m\u{1b}[4mValidation Checks:\u{1b}[22m\u{1b}[24m\n\nThe validate command performs the following checks:\n\n  • \u{1b}[1mCircular Dependencies\u{1b}[22m: Detects dependency cycles\n  • \u{1b}[1mMissing References\u{1b}[22m: Finds references to nonexistent tasks\n  • \u{1b}[1mUsage Spec Parsing\u{1b}[22m: Validates #USAGE directives and specs\n  • \u{1b}[1mTimeout Format\u{1b}[22m: Checks timeout values are valid durations\n  • \u{1b}[1mAlias Conflicts\u{1b}[22m: Detects duplicate aliases across tasks\n  • \u{1b}[1mFile Existence\u{1b}[22m: Verifies file-based tasks exist\n  • \u{1b}[1mDirectory Templates\u{1b}[22m: Validates directory paths and templates\n  • \u{1b}[1mShell Commands\u{1b}[22m: Checks shell executables exist\n  • \u{1b}[1mGlob Patterns\u{1b}[22m: Validates source and output patterns\n  • \u{1b}[1mRun Entries\u{1b}[22m: Ensures tasks reference valid dependencies\n",
     effect = "read"
 )]
 pub struct TasksValidateArgs {
@@ -5077,16 +5457,16 @@ pub struct TasksValidateArgs {
 
 /// Manage tasks
 #[derive(Args)]
-#[usage(after_long_help = "Examples:\n\n    $ mise tasks ls", effect = "read")]
+#[usage(effect = "read")]
 pub struct TasksArgs {
     /// Only show global tasks
-    #[usage(long = "global", short = 'g')]
+    #[usage(long = "global", short = 'g', overrides = "--local")]
     pub global: bool,
     /// Output in JSON format
     #[usage(long = "json", short = 'J')]
     pub json: bool,
     /// Only show non-global tasks
-    #[usage(long = "local", short = 'l')]
+    #[usage(long = "local", short = 'l', overrides = "--global")]
     pub local: bool,
     /// Show all columns
     #[usage(long = "extended", short = 'x')]
@@ -5103,10 +5483,10 @@ pub struct TasksArgs {
     #[usage(long = "hidden")]
     pub hidden: bool,
     /// Only show task names, one per line. Useful for piping to fzf and similar tools.
-    #[usage(long = "name-only")]
+    #[usage(long = "name-only", conflicts("--json", "--extended", "--usage"))]
     pub name_only: bool,
     /// Do not print table header
-    #[usage(long = "no-header")]
+    #[usage(long = "no-header", alias = "no-headers")]
     pub no_header: bool,
     /// Sort by column. Default is name.
     #[usage(
@@ -5160,36 +5540,42 @@ pub enum TasksCommands {
 
 /// Test a tool installs and executes
 #[derive(Args)]
-#[usage(after_long_help = "Examples:\n\n    $ mise test-tool ripgrep")]
+#[usage(
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise test-tool ripgrep\u{1b}[22m\n"
+)]
 pub struct TestToolArgs {
     /// Test every tool specified in registry/
-    #[usage(long = "all", short = 'a')]
+    #[usage(long = "all", short = 'a', conflicts("TOOLS", "--all-config"))]
     pub all: bool,
     #[usage(
-        help = "Number of tool tests to run in parallel\n[default: 4]",
+        help = "Number of tool tests to run in parallel\nValues below 1 are treated as 1\n[default: 4]",
         long = "jobs",
         short = 'j',
+        env = "MISE_TEST_TOOL_JOBS",
         value_name = "JOBS"
     )]
     pub jobs: ::std::option::Option<::std::string::String>,
     /// Test all tools specified in config files
-    #[usage(long = "all-config")]
+    #[usage(long = "all-config", conflicts("TOOLS", "--all"))]
     pub all_config: bool,
     /// Also test tools not defined in registry/, guessing how to test it
     #[usage(long = "include-non-defined")]
     pub include_non_defined: bool,
-    /// Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1
-    #[usage(long = "raw")]
+    #[usage(
+        help = "Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1",
+        long_help = "Connect backend install command stdin/stdout/stderr directly to the terminal\nImplies --jobs=1",
+        long = "raw",
+        overrides = "--jobs"
+    )]
     pub raw: bool,
     /// Tool(s) to test
-    #[usage(arg, name = "TOOLS")]
+    #[usage(arg, name = "TOOLS", required_unless("--all", "--all-config"))]
     pub tools: ::std::vec::Vec<::std::string::String>,
 }
 
-/// Forgejo token
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise token forgejo\n    codeberg.org: a180…61f6 (source: FORGEJO_TOKEN)\n\n    $ mise token forgejo --unmask\n    codeberg.org: a18099ca69064be387fbe37b8ad1d333758361f6 (source: FORGEJO_TOKEN)\n\n    $ mise token forgejo forgejo.mycompany.com\n    forgejo.mycompany.com: (none)",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise token forgejo\u{1b}[22m\n    codeberg.org: a180…61f6 (source: FORGEJO_TOKEN)\n\n    $ \u{1b}[1mmise token forgejo --unmask\u{1b}[22m\n    codeberg.org: a18099ca69064be387fbe37b8ad1d333758361f6 (source: FORGEJO_TOKEN)\n\n    $ \u{1b}[1mmise token forgejo forgejo.mycompany.com\u{1b}[22m\n    forgejo.mycompany.com: (none)\n",
     effect = "read"
 )]
 pub struct TokenForgejoArgs {
@@ -5201,21 +5587,27 @@ pub struct TokenForgejoArgs {
     pub host: ::std::option::Option<::std::string::String>,
 }
 
-/// GitHub token
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise token github\n    github.com: ghp_…xxxx (source: GITHUB_TOKEN)\n\n    $ mise token github --unmask\n    github.com: ghp_xxxxxxxxxxxx (source: GITHUB_TOKEN)\n\n    $ mise token github github.mycompany.com\n    github.mycompany.com: (none)\n\n    $ mise token github --oauth --refresh\n    github.com: gho_…xxxx (source: GitHub OAuth)",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise token github\u{1b}[22m\n    github.com: ghp_…xxxx (source: GITHUB_TOKEN)\n\n    $ \u{1b}[1mmise token github --unmask\u{1b}[22m\n    github.com: ghp_xxxxxxxxxxxx (source: GITHUB_TOKEN)\n\n    $ \u{1b}[1mmise token github github.mycompany.com\u{1b}[22m\n    github.mycompany.com: (none)\n\n    $ \u{1b}[1mmise token github --oauth --refresh\u{1b}[22m\n    github.com: gho_…xxxx (source: GitHub OAuth)\n",
     effect = "read"
 )]
 pub struct TokenGithubArgs {
-    /// Resolve only via the native GitHub OAuth source (cache, refresh, or device-code flow), bypassing other token sources
-    #[usage(long = "oauth")]
+    #[usage(
+        help = "Resolve only via the native GitHub OAuth source (cache, refresh, or device-code flow), bypassing other token sources",
+        long_help = "Resolve only via the native GitHub OAuth source (cache,\nrefresh, or device-code flow), bypassing other token sources",
+        long = "oauth"
+    )]
     pub oauth: bool,
     /// Print only the token value
     #[usage(long = "raw")]
     pub raw: bool,
-    /// Mint a fresh OAuth token even if the cached one has not expired, via the refresh-token grant or a new device-code flow. Use after changing the GitHub App's installations or permissions: cached tokens keep their original access until they expire
-    #[usage(long = "refresh")]
+    #[usage(
+        help = "Mint a fresh OAuth token even if the cached one has not expired, via the refresh-token grant or a new device-code flow. Use after changing the GitHub App's installations or permissions: cached tokens keep their original access until they expire",
+        long_help = "Mint a fresh OAuth token even if the cached one has not\nexpired, via the refresh-token grant or a new device-code flow.\nUse after changing the GitHub App's installations or permissions:\ncached tokens keep their original access until they expire",
+        long = "refresh",
+        requires = "--oauth"
+    )]
     pub refresh: bool,
     /// Show the full unmasked token
     #[usage(long = "unmask")]
@@ -5225,10 +5617,9 @@ pub struct TokenGithubArgs {
     pub host: ::std::option::Option<::std::string::String>,
 }
 
-/// GitLab token
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise token gitlab\n    gitlab.com: glpa…xxxx (source: GITLAB_TOKEN)\n\n    $ mise token gitlab --unmask\n    gitlab.com: glpat-xxxxxxxxxxxx (source: GITLAB_TOKEN)\n\n    $ mise token gitlab gitlab.mycompany.com\n    gitlab.mycompany.com: (none)",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise token gitlab\u{1b}[22m\n    gitlab.com: glpa…xxxx (source: GITLAB_TOKEN)\n\n    $ \u{1b}[1mmise token gitlab --unmask\u{1b}[22m\n    gitlab.com: glpat-xxxxxxxxxxxx (source: GITLAB_TOKEN)\n\n    $ \u{1b}[1mmise token gitlab gitlab.mycompany.com\u{1b}[22m\n    gitlab.mycompany.com: (none)\n",
     effect = "read"
 )]
 pub struct TokenGitlabArgs {
@@ -5251,46 +5642,59 @@ pub struct TokenArgs {
 #[derive(Subcommands)]
 pub enum TokenCommands {
     /// Forgejo token
-    #[usage(name = "forgejo")]
+    #[usage(
+        name = "forgejo",
+        help = "Forgejo token",
+        long_help = "Display the Forgejo token mise will use for a given host\n\nShows which token source mise would use, useful for debugging\nauthentication issues. The token is masked by default."
+    )]
     Forgejo(Box<TokenForgejoArgs>),
     /// GitHub token
-    #[usage(name = "github")]
+    #[usage(
+        name = "github",
+        help = "GitHub token",
+        long_help = "Display the GitHub token mise will use for a given host\n\nShows which token source mise would use, useful for debugging\nauthentication issues. The token is masked by default."
+    )]
     Github(Box<TokenGithubArgs>),
     /// GitLab token
-    #[usage(name = "gitlab")]
+    #[usage(
+        name = "gitlab",
+        help = "GitLab token",
+        long_help = "Display the GitLab token mise will use for a given host\n\nShows which token source mise would use, useful for debugging\nauthentication issues. The token is masked by default."
+    )]
     Gitlab(Box<TokenGitlabArgs>),
 }
 
 /// Gets information about a tool
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise tool node\n    Backend:            core\n    Installed Versions: 20.0.0 22.0.0\n    Active Version:     20.0.0\n    Requested Version:  20\n    Config Source:      ~/.config/mise/mise.toml\n    Tool Options:       [none]",
-    effect = "read"
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise tool node\u{1b}[22m\n    Backend:            core\n    Installed Versions: 20.0.0 22.0.0\n    Active Version:     20.0.0\n    Requested Version:  20\n    Config Source:      ~/.config/mise/mise.toml\n    Tool Options:       [none]\n",
+    effect = "read",
+    group("ToolInfoFilter")
 )]
 pub struct ToolArgs {
     /// Output in JSON format
     #[usage(long = "json", short = 'J')]
     pub json: bool,
     /// Only show active versions
-    #[usage(long = "active")]
+    #[usage(long = "active", group = "ToolInfoFilter")]
     pub active: bool,
     /// Only show backend field
-    #[usage(long = "backend")]
+    #[usage(long = "backend", group = "ToolInfoFilter")]
     pub backend: bool,
     /// Only show config source
-    #[usage(long = "config-source")]
+    #[usage(long = "config-source", group = "ToolInfoFilter")]
     pub config_source: bool,
     /// Only show description field
-    #[usage(long = "description")]
+    #[usage(long = "description", group = "ToolInfoFilter")]
     pub description: bool,
     /// Only show installed versions
-    #[usage(long = "installed")]
+    #[usage(long = "installed", group = "ToolInfoFilter")]
     pub installed: bool,
     /// Only show requested versions
-    #[usage(long = "requested")]
+    #[usage(long = "requested", group = "ToolInfoFilter")]
     pub requested: bool,
     /// Only show tool options
-    #[usage(long = "tool-options")]
+    #[usage(long = "tool-options", group = "ToolInfoFilter")]
     pub tool_options: bool,
     /// Tool name to get information about
     #[usage(arg, name = "TOOL")]
@@ -5299,27 +5703,43 @@ pub struct ToolArgs {
 
 /// Execute a tool stub
 ///
-/// Tool stubs are executable files containing TOML configuration that specify which tool to run and how to run it. They provide a convenient way to create portable, self-contained executables that automatically manage tool installation and execution.
+/// Tool stubs are executable files containing TOML configuration that specify
+/// which tool to run and how to run it. They provide a convenient way to create
+/// portable, self-contained executables that automatically manage tool installation
+/// and execution.
 ///
-/// A tool stub consists of: - A shebang line: #!/usr/bin/env -S mise tool-stub - TOML configuration specifying the tool, version, and options - Optional comments describing the tool's purpose
+/// A tool stub consists of:
+/// - A shebang line: #!/usr/bin/env -S mise tool-stub
+/// - TOML configuration specifying the tool, version, and options
+/// - Optional comments describing the tool's purpose
 ///
-/// Example stub file: #!/usr/bin/env -S mise tool-stub # Node.js v20 development environment
+/// Example stub file:
+///   #!/usr/bin/env -S mise tool-stub
+///   # Node.js v20 development environment
 ///
-/// tool = "node" version = "20.0.0" bin = "node"
+///   tool = "node"
+///   version = "20.0.0"
+///   bin = "node"
 ///
-/// The stub will automatically install the specified tool version if missing and execute it with any arguments passed to the stub.
+/// The stub will automatically install the specified tool version if missing
+/// and execute it with any arguments passed to the stub.
 ///
 /// For more information, see: https://mise.jdx.dev/dev-tools/tool-stubs.html
 #[derive(Args)]
+#[usage(disable_help_flag, disable_version_flag)]
 pub struct ToolStubArgs {
     /// Path to the TOML tool stub file to execute
     ///
-    /// The stub file must contain TOML configuration specifying the tool and version to run. At minimum, it should specify a 'version' field. Other common fields include 'tool', 'bin', and backend-specific options.
+    /// The stub file must contain TOML configuration specifying the tool
+    /// and version to run. At minimum, it should specify a 'version' field.
+    /// Other common fields include 'tool', 'bin', and backend-specific options.
     #[usage(arg, name = "FILE")]
     pub file: ::std::string::String,
     /// Arguments to pass to the tool
     ///
-    /// All arguments after the stub file path will be forwarded to the underlying tool. Use '--' to separate mise arguments from tool arguments if needed.
+    /// All arguments after the stub file path will be forwarded to the
+    /// underlying tool. Use '--' to separate mise arguments from tool arguments
+    /// if needed.
     #[usage(arg, name = "ARGS", double_dash = "automatic")]
     pub args: ::std::vec::Vec<::std::string::String>,
 }
@@ -5327,17 +5747,18 @@ pub struct ToolStubArgs {
 /// Marks a config file as trusted
 ///
 /// This means mise is allowed to parse the file when it needs to read config
-/// that may execute code or affect the environment. mise checks trust before
-/// parsing `mise.toml`. Without trust, mise may prompt, skip the config in some
-/// discovery paths, fail with an untrusted-config error when it cannot prompt,
-/// or assume trust in detected CI unless paranoid mode is enabled.
+/// that may execute code or affect the environment. Without trust, mise may
+/// prompt, skip the config in some discovery paths, or fail with an
+/// untrusted-config error when it cannot prompt.
 ///
-/// Safe config files do not require trust: files that only contain
-/// `min_version`, `[tools]` entries with plain version strings (or arrays
-/// of them), and `[tasks]` (no templates and no tool options) are loaded
-/// without prompting, since nothing in them executes code at load time —
-/// tools install and tasks run only on explicit commands like `mise install`
-/// or `mise run`.
+/// In normal mode, commands that execute project-defined behavior (`mise run`,
+/// naked task invocations such as `mise <TASK>`, `mise install`, `mise exec`,
+/// and `mise watch`) automatically trust their active config. Paranoid mode
+/// requires explicit, content-bound trust for every non-global config.
+///
+/// In normal mode, safe config files do not require trust: files that only contain
+/// `min_version`, `[tools]` entries with plain version strings (or arrays of
+/// them), and `[tasks]` without templates or tool options.
 ///
 /// Trust is shared across git worktrees: a config file inside a linked
 /// worktree is trusted when the equivalent path in the repository's main
@@ -5345,7 +5766,7 @@ pub struct ToolStubArgs {
 /// worktrees can check out branches with different config contents.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    # trusts ~/some_dir/mise.toml\n    $ mise trust ~/some_dir/mise.toml\n\n    # trusts mise.toml in the current or parent directory\n    $ mise trust",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # trusts ~/some_dir/mise.toml\n    $ \u{1b}[1mmise trust ~/some_dir/mise.toml\u{1b}[22m\n\n    # trusts mise.toml in the current or parent directory\n    $ \u{1b}[1mmise trust\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct TrustArgs {
@@ -5353,20 +5774,20 @@ pub struct TrustArgs {
     ///
     /// Subdirectories are walked respecting .gitignore, skipping hidden directories
     /// and common build/dependency directories (node_modules, vendor, target, dist, build).
-    #[usage(long = "all", short = 'a')]
+    #[usage(long = "all", short = 'a', conflicts("--ignore", "--untrust"))]
     pub all: bool,
     /// Do not trust this config and ignore it in the future
-    #[usage(long = "ignore")]
+    #[usage(long = "ignore", conflicts = "--untrust")]
     pub ignore: bool,
     #[usage(
         help = "Show the trusted status of config files from the current directory and its parents.\nDoes not trust or untrust any files.",
         long = "show"
     )]
     pub show: bool,
-    /// No longer trust this config, will prompt in the future
+    /// Remove explicit trust for this config
     #[usage(long = "untrust")]
     pub untrust: bool,
-    /// The config file to trust
+    /// The config file whose trust status to change
     #[usage(arg, name = "CONFIG_FILE")]
     pub config_file: ::std::option::Option<::std::string::String>,
 }
@@ -5376,7 +5797,7 @@ pub struct TrustArgs {
 /// This only removes the installed version, it does not modify mise.toml.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    # will uninstall specific version\n    $ mise uninstall node@18.0.0\n\n    # will uninstall the current node version (if only one version is installed)\n    $ mise uninstall node\n\n    # will uninstall all installed versions of node\n    $ mise uninstall --all node@18.0.0 # will uninstall all node versions",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # will uninstall specific version\n    $ \u{1b}[1mmise uninstall node@18.0.0\u{1b}[22m\n\n    # will uninstall the current node version (if only one version is installed)\n    $ \u{1b}[1mmise uninstall node\u{1b}[22m\n\n    # will uninstall all installed versions of node\n    $ \u{1b}[1mmise uninstall --all node@18.0.0\u{1b}[22m # will uninstall all node versions\n",
     effect = "destructive"
 )]
 pub struct UninstallArgs {
@@ -5392,7 +5813,7 @@ pub struct UninstallArgs {
     #[usage(long = "dry-run-code")]
     pub dry_run_code: bool,
     /// Tool(s) to remove
-    #[usage(arg, name = "INSTALLED_TOOL@VERSION")]
+    #[usage(arg, name = "INSTALLED_TOOL@VERSION", required_unless = "--all")]
     pub installed_tool_version: ::std::vec::Vec<::std::string::String>,
 }
 
@@ -5401,7 +5822,7 @@ pub struct UninstallArgs {
 /// By default, this command modifies `mise.toml` in the current directory.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    # Remove NODE_ENV from the current directory's config\n    $ mise unset NODE_ENV\n\n    # Remove NODE_ENV from the global config\n    $ mise unset NODE_ENV -g",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Remove NODE_ENV from the current directory's config\n    $ \u{1b}[1mmise unset NODE_ENV\u{1b}[22m\n\n    # Remove NODE_ENV from the global config\n    $ \u{1b}[1mmise unset NODE_ENV -g\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct UnsetArgs {
@@ -5409,11 +5830,12 @@ pub struct UnsetArgs {
     ///
     /// Can be a file path or directory. If a directory is provided, will create/use mise.toml in that directory.
     ///
-    /// Defaults to [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) environment variable, or `mise.toml`. Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
+    /// Defaults to [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) environment variable, or `mise.toml`.
+    /// Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.
     #[usage(long = "file", long = "path", short = 'f', value_name = "FILE")]
     pub file: ::std::option::Option<::std::string::String>,
     /// Use the global config file
-    #[usage(long = "global", short = 'g')]
+    #[usage(long = "global", short = 'g', overrides = "--file")]
     pub global: bool,
     #[usage(
         arg,
@@ -5423,7 +5845,7 @@ pub struct UnsetArgs {
     pub env_key: ::std::vec::Vec<::std::string::String>,
 }
 
-/// No longer trust a config, will prompt in the future
+/// Remove explicit trust for a config
 #[derive(Args)]
 #[usage(effect = "write")]
 pub struct UntrustArgs {
@@ -5452,20 +5874,32 @@ pub struct UntrustArgs {
 /// Will also prune the installed version if no other configurations are using it.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    # will uninstall specific version\n    $ mise unuse node@18.0.0\n\n    # will uninstall specific version from global config\n    $ mise unuse -g node@18.0.0\n\n    # will uninstall specific version from .mise.local.toml\n    $ mise unuse --env local node@20\n\n    # will uninstall specific version from .mise.staging.toml\n    $ mise unuse --env staging node@20",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # will uninstall specific version\n    $ \u{1b}[1mmise unuse node@18.0.0\u{1b}[22m\n\n    # will uninstall specific version from global config\n    $ \u{1b}[1mmise unuse -g node@18.0.0\u{1b}[22m\n\n    # will uninstall specific version from .mise.local.toml\n    $ \u{1b}[1mmise unuse --env local node@20\u{1b}[22m\n\n    # will uninstall specific version from .mise.staging.toml\n    $ \u{1b}[1mmise unuse --env staging node@20\u{1b}[22m\n",
     effect = "destructive"
 )]
 pub struct UnuseArgs {
     /// Create/modify an environment-specific config file like .mise.<env>.toml
-    #[usage(long = "env", short = 'e', value_name = "ENV")]
+    #[usage(
+        long = "env",
+        short = 'e',
+        overrides("--global", "--path"),
+        value_name = "ENV"
+    )]
     pub env: ::std::option::Option<::std::string::String>,
     /// Use the global config file (`~/.config/mise/config.toml`) instead of the local one
-    #[usage(long = "global", short = 'g')]
+    #[usage(long = "global", short = 'g', overrides("--path", "--env"))]
     pub global: bool,
     /// Specify a path to a config file or directory
     ///
-    /// If a directory is specified, it will look for a config file in that directory following the rules above.
-    #[usage(long = "path", long = "file", short = 'p', value_name = "PATH")]
+    /// If a directory is specified, it will look for a config file in that directory following
+    /// the rules above.
+    #[usage(
+        long = "path",
+        long = "file",
+        short = 'p',
+        overrides("--global", "--env"),
+        value_name = "PATH"
+    )]
     pub path: ::std::option::Option<::std::string::String>,
     /// Do not also prune the installed version
     #[usage(long = "no-prune")]
@@ -5484,20 +5918,10 @@ pub struct UnuseArgs {
 /// This will update mise.lock if it is enabled, see https://mise.jdx.dev/configuration/settings.html#lockfile
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    # Upgrades node to the latest version matching the range in mise.toml\n    $ mise upgrade node\n\n    # Upgrades node to the latest version and bumps the version in mise.toml\n    $ mise upgrade node --bump\n\n    # Upgrades all tools to the latest versions\n    $ mise upgrade\n\n    # Upgrades all tools to the latest versions and bumps the version in mise.toml\n    $ mise upgrade --bump\n\n    # Just print what would be done, don't actually do it\n    $ mise upgrade --dry-run\n\n    # Upgrades node and python to the latest versions\n    $ mise upgrade node python\n\n    # Upgrade all tools except go\n    $ mise upgrade --exclude go\n\n    # Show a multiselect menu to choose which tools to upgrade\n    $ mise upgrade --interactive\n\n    # Only upgrade tools defined in local mise.toml, not global ones\n    $ mise upgrade --local",
+    after_long_help = "\u{1b}[1m\u{1b}[4mDeprecation:\u{1b}[22m\u{1b}[24m\n\nThe `-l` shorthand for `--bump` is deprecated and will be removed in mise 2027.8.5.\nAfter removal, `-l` will become shorthand for `--local`. Use `-b` or `--bump` instead.\n\n\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Upgrades node to the latest version matching the range in mise.toml\n    $ \u{1b}[1mmise upgrade node\u{1b}[22m\n\n    # Upgrades node to the latest version and bumps the version in mise.toml\n    $ \u{1b}[1mmise upgrade node --bump\u{1b}[22m\n\n    # Upgrades all tools to the latest versions\n    $ \u{1b}[1mmise upgrade\u{1b}[22m\n\n    # Upgrades all tools to the latest versions and bumps the version in mise.toml\n    $ \u{1b}[1mmise upgrade --bump\u{1b}[22m\n\n    # Just print what would be done, don't actually do it\n    $ \u{1b}[1mmise upgrade --dry-run\u{1b}[22m\n\n    # Upgrades node and python to the latest versions\n    $ \u{1b}[1mmise upgrade node python\u{1b}[22m\n\n    # Upgrade all tools except go\n    $ \u{1b}[1mmise upgrade --exclude go\u{1b}[22m\n\n    # Show a multiselect menu to choose which tools to upgrade\n    $ \u{1b}[1mmise upgrade --interactive\u{1b}[22m\n\n    # Only upgrade tools defined in local mise.toml, not global ones\n    $ \u{1b}[1mmise upgrade --local\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct UpgradeArgs {
-    /// Display multiselect menu to choose which tools to upgrade
-    #[usage(long = "interactive", short = 'i')]
-    pub interactive: bool,
-    #[usage(
-        help = "Number of jobs to run in parallel\n[default: 4]",
-        long = "jobs",
-        short = 'j',
-        value_name = "JOBS"
-    )]
-    pub jobs: ::std::option::Option<::std::string::String>,
     /// Upgrades to the latest version available, bumping the version in mise.toml
     ///
     /// For example, if you have `node = "20.0.0"` in your mise.toml but 22.1.0 is the latest available,
@@ -5505,8 +5929,26 @@ pub struct UpgradeArgs {
     ///
     /// It keeps the same precision as what was there before, so if you instead had `node = "20"`, it
     /// would change your config to `node = "22"`.
-    #[usage(long = "bump", short = 'l')]
+    #[usage(long = "bump", short = 'b')]
     pub bump: bool,
+    /// Display multiselect menu to choose which tools to upgrade
+    #[usage(
+        long = "interactive",
+        short = 'i',
+        conflicts = "INSTALLED_TOOL@VERSION"
+    )]
+    pub interactive: bool,
+    #[usage(
+        help = "Number of jobs to run in parallel\nValues below 1 are treated as 1\n[default: 4]",
+        long = "jobs",
+        short = 'j',
+        env = "MISE_JOBS",
+        value_name = "JOBS"
+    )]
+    pub jobs: ::std::option::Option<::std::string::String>,
+    /// Deprecated shorthand for --bump
+    #[usage(short = 'l', hide)]
+    pub l: bool,
     /// Just print what would be done, don't actually do it
     #[usage(long = "dry-run", short = 'n')]
     pub dry_run: bool,
@@ -5524,7 +5966,7 @@ pub struct UpgradeArgs {
     #[usage(long = "dry-run-code")]
     pub dry_run_code: bool,
     /// Upgrade all tools, including installed-but-inactive tools not present in the current config
-    #[usage(long = "inactive")]
+    #[usage(long = "inactive", conflicts = "--local")]
     pub inactive: bool,
     /// Only upgrade tools defined in local config files
     ///
@@ -5539,7 +5981,11 @@ pub struct UpgradeArgs {
     ///
     /// This only affects fuzzy version matches like "20" or "latest".
     /// Explicitly pinned versions like "22.5.0" are not filtered.
-    #[usage(long = "minimum-release-age", value_name = "MINIMUM_RELEASE_AGE")]
+    #[usage(
+        long = "minimum-release-age",
+        alias = "before",
+        value_name = "MINIMUM_RELEASE_AGE"
+    )]
     pub minimum_release_age: ::std::option::Option<::std::string::String>,
     /// Placeholder for future monorepo upgrades; `mise upgrade --monorepo` is not implemented yet.
     #[usage(long = "monorepo")]
@@ -5549,10 +5995,22 @@ pub struct UpgradeArgs {
     /// By default the old version is removed once the new one installs, unless another
     /// tracked config or tool stub still needs it. Use this to keep it anyway, e.g. when
     /// something outside of mise points at the old install directory.
-    #[usage(long = "no-prune")]
+    ///
+    /// Set `upgrade.auto_prune = false` to make this the default.
+    #[usage(long = "no-prune", overrides = "--prune")]
     pub no_prune: bool,
-    /// Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1
-    #[usage(long = "raw")]
+    /// Uninstall the versions that were upgraded away from
+    ///
+    /// This is already the default. Use it to override `upgrade.auto_prune = false`
+    /// for a single run.
+    #[usage(long = "prune", overrides = "--no-prune")]
+    pub prune: bool,
+    #[usage(
+        help = "Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1",
+        long_help = "Connect backend install command stdin/stdout/stderr directly to the terminal\nImplies --jobs=1",
+        long = "raw",
+        overrides = "--jobs"
+    )]
     pub raw: bool,
     #[usage(
         arg,
@@ -5590,23 +6048,29 @@ pub struct UsageArgs {}
 /// Use the `--global` flag to use the global config file instead.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    # run with no arguments to use the interactive selector\n    $ mise use\n\n    # set the current version of node to 20.x in mise.toml of current directory\n    # will write the fuzzy version (e.g.: 20)\n    $ mise use node@20\n\n    # set the current version of node to 20.x in ~/.config/mise/config.toml\n    # will write the precise version (e.g.: 20.0.0)\n    $ mise use -g --pin node@20\n\n    # sets .mise.local.toml (which is intended not to be committed to a project)\n    $ mise use --env local node@20\n\n    # sets .mise.staging.toml (which is used if MISE_ENV=staging)\n    $ mise use --env staging node@20",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # run with no arguments to use the interactive selector\n    $ \u{1b}[1mmise use\u{1b}[22m\n\n    # set the current version of node to 20.x in mise.toml of current directory\n    # will write the fuzzy version (e.g.: 20)\n    $ \u{1b}[1mmise use node@20\u{1b}[22m\n\n    # set the current version of node to 20.x in ~/.config/mise/config.toml\n    # will write the precise version (e.g.: 20.0.0)\n    $ \u{1b}[1mmise use -g --pin node@20\u{1b}[22m\n\n    # sets .mise.local.toml (which is intended not to be committed to a project)\n    $ \u{1b}[1mmise use --env local node@20\u{1b}[22m\n\n    # sets .mise.staging.toml (which is used if MISE_ENV=staging)\n    $ \u{1b}[1mmise use --env staging node@20\u{1b}[22m\n",
     effect = "write"
 )]
 pub struct UseArgs {
     /// Create/modify an environment-specific config file like .mise.<env>.toml
-    #[usage(long = "env", short = 'e', value_name = "ENV")]
+    #[usage(
+        long = "env",
+        short = 'e',
+        overrides("--global", "--path"),
+        value_name = "ENV"
+    )]
     pub env: ::std::option::Option<::std::string::String>,
     /// Force reinstall even if already installed
-    #[usage(long = "force", short = 'f')]
+    #[usage(long = "force", short = 'f', requires = "TOOL@VERSION")]
     pub force: bool,
     /// Use the global config file (`~/.config/mise/config.toml`) instead of the local one
-    #[usage(long = "global", short = 'g')]
+    #[usage(long = "global", short = 'g', overrides("--path", "--env"))]
     pub global: bool,
     #[usage(
-        help = "Number of jobs to run in parallel\n[default: 4]",
+        help = "Number of jobs to run in parallel\nValues below 1 are treated as 1\n[default: 4]",
         long = "jobs",
         short = 'j',
+        env = "MISE_JOBS",
         value_name = "JOBS"
     )]
     pub jobs: ::std::option::Option<::std::string::String>,
@@ -5615,8 +6079,14 @@ pub struct UseArgs {
     pub dry_run: bool,
     /// Specify a path to a config file or directory
     ///
-    /// If a directory is specified, it will look for a config file in that directory following the rules above.
-    #[usage(long = "path", long = "file", short = 'p', value_name = "PATH")]
+    /// If a directory is specified, it will look for a config file in that directory following
+    /// the rules above.
+    #[usage(
+        long = "path",
+        short = 'p',
+        overrides("--global", "--env"),
+        value_name = "PATH"
+    )]
     pub path: ::std::option::Option<::std::string::String>,
     /// Like --dry-run but exits with code 1 if there are changes to make
     ///
@@ -5627,24 +6097,37 @@ pub struct UseArgs {
     ///
     /// e.g.: `mise use --fuzzy node@20` will save 20 as the version
     /// this is the default behavior unless `MISE_PIN=1`
-    #[usage(long = "fuzzy")]
+    #[usage(long = "fuzzy", overrides = "--pin")]
     pub fuzzy: bool,
     /// Only install versions released before this date or older than this duration
     ///
     /// Supports absolute dates like "2024-06-01" and relative durations like "90d" or "1y".
-    #[usage(long = "minimum-release-age", value_name = "MINIMUM_RELEASE_AGE")]
-    pub minimum_release_age: ::std::option::Option<::std::string::String>,
     #[usage(
-        help = "Save exact version to config file\ne.g.: `mise use --pin node@20` will save 20.0.0 as the version\nSet `MISE_PIN=1` to make this the default behavior",
-        long_help = "Save exact version to config file\ne.g.: `mise use --pin node@20` will save 20.0.0 as the version\nSet `MISE_PIN=1` to make this the default behavior\n\nConsider using mise.lock as a better alternative to pinning in mise.toml:\nhttps://mise.jdx.dev/configuration/settings.html#lockfile",
-        long = "pin"
+        long = "minimum-release-age",
+        alias = "before",
+        value_name = "MINIMUM_RELEASE_AGE"
     )]
+    pub minimum_release_age: ::std::option::Option<::std::string::String>,
+    /// Save the resolved concrete version to the config file
+    ///
+    /// If the request exactly matches an available release, that release is preferred over
+    /// installed fuzzy matches. Use `prefix:` to explicitly request recursive prefix matching.
+    /// e.g.: `mise use --pin node@20` will save the resolved `20.x.y` version
+    /// Set `MISE_PIN=1` to make this the default behavior
+    ///
+    /// Consider using mise.lock as a better alternative to pinning in mise.toml:
+    /// https://mise.jdx.dev/configuration/settings.html#lockfile
+    #[usage(long = "pin", overrides = "--fuzzy")]
     pub pin: bool,
-    /// Connect backend install command stdin/stdout/stderr directly to the terminal Implies `--jobs=1`
-    #[usage(long = "raw")]
+    #[usage(
+        help = "Connect backend install command stdin/stdout/stderr directly to the terminal Implies `--jobs=1`",
+        long_help = "Connect backend install command stdin/stdout/stderr directly to the terminal\nImplies `--jobs=1`",
+        long = "raw",
+        overrides = "--jobs"
+    )]
     pub raw: bool,
     /// Remove the tool(s) from config file
-    #[usage(long = "remove", value_name = "TOOL", var)]
+    #[usage(long = "remove", alias("rm", "unset"), value_name = "TOOL", var)]
     pub remove: ::std::vec::Vec<::std::string::String>,
     /// Tool(s) to add to config file
     ///
@@ -5665,7 +6148,7 @@ pub struct UseArgs {
 /// If the version is out of date, it will display a warning.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise version\n    $ mise --version\n    $ mise -v\n    $ mise -V",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise version\u{1b}[22m\n    $ \u{1b}[1mmise --version\u{1b}[22m\n    $ \u{1b}[1mmise -v\u{1b}[22m\n    $ \u{1b}[1mmise -V\u{1b}[22m\n",
     effect = "read"
 )]
 pub struct VersionArgs {
@@ -5683,7 +6166,7 @@ pub struct VersionArgs {
 /// cron scheduling), see mise's sister project: https://pitchfork.jdx.dev
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise watch build\n    Runs the \"build\" tasks. Will re-run the tasks when any of its sources change.\n    Uses \"sources\" from the tasks definition to determine which files to watch.\n\n    $ mise watch build --glob src/**/*.rs\n    Runs the \"build\" tasks but specify the files to watch with a glob pattern.\n    This overrides the \"sources\" from the tasks definition.\n\n    $ mise watch build --clear\n    Extra arguments are passed to watchexec. See `watchexec --help` for details.\n\n    $ mise watch serve --watch src --exts rs --restart\n    Starts an api server, watching for changes to \"*.rs\" files in \"./src\" and kills/restarts the server when they change."
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise watch build\u{1b}[22m\n    Runs the \"build\" tasks. Will re-run the tasks when any of its sources change.\n    Uses \"sources\" from the tasks definition to determine which files to watch.\n\n    $ \u{1b}[1mmise watch build --glob src/**/*.rs\u{1b}[22m\n    Runs the \"build\" tasks but specify the files to watch with a glob pattern.\n    This overrides the \"sources\" from the tasks definition.\n\n    $ \u{1b}[1mmise watch build --clear\u{1b}[22m\n    Extra arguments are passed to watchexec. See `watchexec --help` for details.\n\n    $ \u{1b}[1mmise watch serve --watch src --exts rs --restart\u{1b}[22m\n    Starts an api server, watching for changes to \"*.rs\" files in \"./src\" and kills/restarts the server when they change.\n"
 )]
 pub struct WatchArgs {
     /// Tasks to run
@@ -5705,30 +6188,52 @@ pub struct WatchArgs {
     ///
     /// By default, Watchexec watches the current directory.
     ///
-    /// When watching a single file, it's often better to watch the containing directory instead, and filter on the filename. Some editors may replace the file with a new one when saving, and some platforms may not detect that or further changes.
+    /// When watching a single file, it's often better to watch the containing directory instead,
+    /// and filter on the filename. Some editors may replace the file with a new one when saving,
+    /// and some platforms may not detect that or further changes.
     ///
-    /// Upon starting, Watchexec resolves a "project origin" from the watched paths. See the help for '--project-origin' for more information.
+    /// Upon starting, Watchexec resolves a "project origin" from the watched paths. See the help
+    /// for '--project-origin' for more information.
     ///
     /// This option can be specified multiple times to watch multiple files or directories.
     ///
-    /// The special value '/dev/null', provided as the only path watched, will cause Watchexec to not watch any paths. Other event sources (like signals or key events) may still be used.
-    #[usage(long = "watch", short = 'w', value_name = "PATH", var)]
+    /// The special value '/dev/null', provided as the only path watched, will cause Watchexec to
+    /// not watch any paths. Other event sources (like signals or key events) may still be used.
+    #[usage(
+        long = "watch",
+        short = 'w',
+        help_heading = "Filtering",
+        value_name = "PATH",
+        var
+    )]
     pub watch: ::std::vec::Vec<::std::string::String>,
     /// Watch a specific directory, non-recursively
     ///
     /// Unlike '-w', folders watched with this option are not recursed into.
     ///
     /// This option can be specified multiple times to watch multiple directories non-recursively.
-    #[usage(long = "watch-non-recursive", short = 'W', value_name = "PATH", var)]
+    #[usage(
+        long = "watch-non-recursive",
+        short = 'W',
+        help_heading = "Filtering",
+        value_name = "PATH",
+        var
+    )]
     pub watch_non_recursive: ::std::vec::Vec<::std::string::String>,
     /// Watch files and directories from a file
     ///
     /// Each line in the file will be interpreted as if given to '-w'.
     ///
-    /// For more complex uses (like watching non-recursively), use the argfile capability: build a file containing command-line options and pass it to watchexec with `@path/to/argfile`.
+    /// For more complex uses (like watching non-recursively), use the argfile capability: build a
+    /// file containing command-line options and pass it to watchexec with `@path/to/argfile`.
     ///
     /// The special value '-' will read from STDIN; this in incompatible with '--stdin-quit'.
-    #[usage(long = "watch-file", short = 'F', value_name = "PATH")]
+    #[usage(
+        long = "watch-file",
+        short = 'F',
+        help_heading = "Filtering",
+        value_name = "PATH"
+    )]
     pub watch_file: ::std::option::Option<::std::string::String>,
     /// Clear screen before running command
     ///
@@ -5736,18 +6241,27 @@ pub struct WatchArgs {
     #[usage(
         long = "clear",
         short = 'c',
+        help_heading = "Output",
+        default_missing = "clear",
         value_name = "MODE",
+        value_optional,
         choices("clear", "reset")
     )]
     pub clear: ::std::option::Option<::std::string::String>,
     /// What to do when receiving events while the command is running
     ///
-    /// Default is to 'do-nothing', which ignores events while the command is running, so that changes that occur due to the command are ignored, like compilation outputs. You can also use 'queue' which will run the command once again when the current run has finished if any events occur while it's running, or 'restart', which terminates the running command and starts a new one. Finally, there's 'signal', which only sends a signal; this can be useful with programs that can reload their configuration without a full restart.
+    /// Default is to 'do-nothing', which ignores events while the command is running, so that
+    /// changes that occur due to the command are ignored, like compilation outputs. You can also
+    /// use 'queue' which will run the command once again when the current run has finished if any
+    /// events occur while it's running, or 'restart', which terminates the running command and starts
+    /// a new one. Finally, there's 'signal', which only sends a signal; this can be useful with
+    /// programs that can reload their configuration without a full restart.
     ///
     /// The signal can be specified with the '--signal' option.
     #[usage(
         long = "on-busy-update",
         short = 'o',
+        hide_default_value,
         value_name = "MODE",
         choices("queue", "do-nothing", "restart", "signal"),
         default = "do-nothing"
@@ -5756,77 +6270,121 @@ pub struct WatchArgs {
     /// Restart the process if it's still running
     ///
     /// This is a shorthand for '--on-busy-update=restart'.
-    #[usage(long = "restart", short = 'r')]
+    #[usage(long = "restart", short = 'r', conflicts = "--on-busy-update")]
     pub restart: bool,
     /// Send a signal to the process when it's still running
     ///
-    /// Specify a signal to send to the process when it's still running. This implies '--on-busy-update=signal'; otherwise the signal used when that mode is 'restart' is controlled by '--stop-signal'.
+    /// Specify a signal to send to the process when it's still running. This implies
+    /// '--on-busy-update=signal'; otherwise the signal used when that mode is 'restart' is
+    /// controlled by '--stop-signal'.
     ///
     /// See the long documentation for '--stop-signal' for syntax.
     ///
-    /// Signals are not supported on Windows at the moment, and will always be overridden to 'kill'. See '--stop-signal' for more on Windows "signals".
-    #[usage(long = "signal", short = 's', value_name = "SIGNAL")]
+    /// Signals are not supported on Windows at the moment, and will always be overridden to 'kill'.
+    /// See '--stop-signal' for more on Windows "signals".
+    #[usage(
+        long = "signal",
+        short = 's',
+        conflicts = "--restart",
+        value_name = "SIGNAL"
+    )]
     pub signal: ::std::option::Option<::std::string::String>,
     /// Signal to send to stop the command
     ///
-    /// This is used by 'restart' and 'signal' modes of '--on-busy-update' (unless '--signal' is provided). The restart behaviour is to send the signal, wait for the command to exit, and if it hasn't exited after some time (see '--timeout-stop'), forcefully terminate it.
+    /// This is used by 'restart' and 'signal' modes of '--on-busy-update' (unless '--signal' is
+    /// provided). The restart behaviour is to send the signal, wait for the command to exit, and if
+    /// it hasn't exited after some time (see '--timeout-stop'), forcefully terminate it.
     ///
     /// The default on unix is "SIGTERM".
     ///
-    /// Input is parsed as a full signal name (like "SIGTERM"), a short signal name (like "TERM"), or a signal number (like "15"). All input is case-insensitive.
+    /// Input is parsed as a full signal name (like "SIGTERM"), a short signal name (like "TERM"),
+    /// or a signal number (like "15"). All input is case-insensitive.
     ///
-    /// On Windows this option is technically supported but only supports the "KILL" event, as Watchexec cannot yet deliver other events. Windows doesn't have signals as such; instead it has termination (here called "KILL" or "STOP") and "CTRL+C", "CTRL+BREAK", and "CTRL+CLOSE" events. For portability the unix signals "SIGKILL", "SIGINT", "SIGTERM", and "SIGHUP" are respectively mapped to these.
+    /// On Windows this option is technically supported but only supports the "KILL" event, as
+    /// Watchexec cannot yet deliver other events. Windows doesn't have signals as such; instead it
+    /// has termination (here called "KILL" or "STOP") and "CTRL+C", "CTRL+BREAK", and "CTRL+CLOSE"
+    /// events. For portability the unix signals "SIGKILL", "SIGINT", "SIGTERM", and "SIGHUP" are
+    /// respectively mapped to these.
     #[usage(long = "stop-signal", value_name = "SIGNAL")]
     pub stop_signal: ::std::option::Option<::std::string::String>,
     /// Time to wait for the command to exit gracefully
     ///
-    /// This is used by the 'restart' mode of '--on-busy-update'. After the graceful stop signal is sent, Watchexec will wait for the command to exit. If it hasn't exited after this time, it is forcefully terminated.
+    /// This is used by the 'restart' mode of '--on-busy-update'. After the graceful stop signal
+    /// is sent, Watchexec will wait for the command to exit. If it hasn't exited after this time,
+    /// it is forcefully terminated.
     ///
-    /// Takes a unit-less value in seconds, or a time span value such as "5min 20s". Providing a unit-less value is deprecated and will warn; it will be an error in the future.
+    /// Takes a unit-less value in seconds, or a time span value such as "5min 20s".
+    /// Providing a unit-less value is deprecated and will warn; it will be an error in the future.
     ///
     /// The default is 10 seconds. Set to 0 to immediately force-kill the command.
     ///
-    /// This has no practical effect on Windows as the command is always forcefully terminated; see '--stop-signal' for why.
-    #[usage(long = "stop-timeout", value_name = "TIMEOUT", default = "10s")]
+    /// This has no practical effect on Windows as the command is always forcefully terminated; see
+    /// '--stop-signal' for why.
+    #[usage(
+        long = "stop-timeout",
+        hide_default_value,
+        value_name = "TIMEOUT",
+        default = "10s"
+    )]
     pub stop_timeout: ::std::option::Option<::std::string::String>,
     /// Translate signals from the OS to signals to send to the command
     ///
-    /// Takes a pair of signal names, separated by a colon, such as "TERM:INT" to map SIGTERM to SIGINT. The first signal is the one received by watchexec, and the second is the one sent to the command. The second can be omitted to discard the first signal, such as "TERM:" to not do anything on SIGTERM.
+    /// Takes a pair of signal names, separated by a colon, such as "TERM:INT" to map SIGTERM to
+    /// SIGINT. The first signal is the one received by watchexec, and the second is the one sent to
+    /// the command. The second can be omitted to discard the first signal, such as "TERM:" to
+    /// not do anything on SIGTERM.
     ///
-    /// If SIGINT or SIGTERM are mapped, then they no longer quit Watchexec. Besides making it hard to quit Watchexec itself, this is useful to send pass a Ctrl-C to the command without also terminating Watchexec and the underlying program with it, e.g. with "INT:INT".
+    /// If SIGINT or SIGTERM are mapped, then they no longer quit Watchexec. Besides making it hard
+    /// to quit Watchexec itself, this is useful to send pass a Ctrl-C to the command without also
+    /// terminating Watchexec and the underlying program with it, e.g. with "INT:INT".
     ///
     /// This option can be specified multiple times to map multiple signals.
     ///
-    /// Signal syntax is case-insensitive for short names (like "TERM", "USR2") and long names (like "SIGKILL", "SIGHUP"). Signal numbers are also supported (like "15", "31"). On Windows, the forms "STOP", "CTRL+C", and "CTRL+BREAK" are also supported to receive, but Watchexec cannot yet deliver other "signals" than a STOP.
+    /// Signal syntax is case-insensitive for short names (like "TERM", "USR2") and long names (like
+    /// "SIGKILL", "SIGHUP"). Signal numbers are also supported (like "15", "31"). On Windows, the
+    /// forms "STOP", "CTRL+C", and "CTRL+BREAK" are also supported to receive, but Watchexec cannot
+    /// yet deliver other "signals" than a STOP.
     #[usage(long = "map-signal", value_name = "SIGNAL:SIGNAL", var)]
     pub map_signal: ::std::vec::Vec<::std::string::String>,
     /// Time to wait for new events before taking action
     ///
-    /// When an event is received, Watchexec will wait for up to this amount of time before handling it (such as running the command). This is essential as what you might perceive as a single change may actually emit many events, and without this behaviour, Watchexec would run much too often. Additionally, it's not infrequent that file writes are not atomic, and each write may emit an event, so this is a good way to avoid running a command while a file is partially written.
+    /// When an event is received, Watchexec will wait for up to this amount of time before handling
+    /// it (such as running the command). This is essential as what you might perceive as a single
+    /// change may actually emit many events, and without this behaviour, Watchexec would run much
+    /// too often. Additionally, it's not infrequent that file writes are not atomic, and each write
+    /// may emit an event, so this is a good way to avoid running a command while a file is
+    /// partially written.
     ///
-    /// An alternative use is to set a high value (like "30min" or longer), to save power or bandwidth on intensive tasks, like an ad-hoc backup script. In those use cases, note that every accumulated event will build up in memory.
+    /// An alternative use is to set a high value (like "30min" or longer), to save power or
+    /// bandwidth on intensive tasks, like an ad-hoc backup script. In those use cases, note that
+    /// every accumulated event will build up in memory.
     ///
-    /// Takes a unit-less value in milliseconds, or a time span value such as "5sec 20ms". Providing a unit-less value is deprecated and will warn; it will be an error in the future.
+    /// Takes a unit-less value in milliseconds, or a time span value such as "5sec 20ms".
+    /// Providing a unit-less value is deprecated and will warn; it will be an error in the future.
     ///
     /// The default is 50 milliseconds. Setting to 0 is highly discouraged.
     #[usage(
         long = "debounce",
         short = 'd',
+        hide_default_value,
         value_name = "TIMEOUT",
         default = "50ms"
     )]
     pub debounce: ::std::option::Option<::std::string::String>,
     /// Exit when stdin closes
     ///
-    /// This watches the stdin file descriptor for EOF, and exits Watchexec gracefully when it is closed. This is used by some process managers to avoid leaving zombie processes around.
+    /// This watches the stdin file descriptor for EOF, and exits Watchexec gracefully when it is
+    /// closed. This is used by some process managers to avoid leaving zombie processes around.
     #[usage(long = "stdin-quit")]
     pub stdin_quit: bool,
     /// Don't load gitignores
     ///
-    /// Among other VCS exclude files, like for Mercurial, Subversion, Bazaar, DARCS, Fossil. Note that Watchexec will detect which of these is in use, if any, and only load the relevant files. Both global (like '~/.gitignore') and local (like '.gitignore') files are considered.
+    /// Among other VCS exclude files, like for Mercurial, Subversion, Bazaar, DARCS, Fossil. Note
+    /// that Watchexec will detect which of these is in use, if any, and only load the relevant
+    /// files. Both global (like '~/.gitignore') and local (like '.gitignore') files are considered.
     ///
     /// This option is useful if you want to watch files that are ignored by Git.
-    #[usage(long = "no-vcs-ignore")]
+    #[usage(long = "no-vcs-ignore", help_heading = "Filtering")]
     pub no_vcs_ignore: bool,
     /// Don't load project-local ignores
     ///
@@ -5847,7 +6405,7 @@ pub struct WatchArgs {
     /// VCS ignore files (Git, Mercurial, Bazaar, Darcs, Fossil) are only used if the corresponding
     /// VCS is discovered to be in use for the project/origin. For example, a .bzrignore in a Git
     /// repository will be discarded.
-    #[usage(long = "no-project-ignore")]
+    #[usage(long = "no-project-ignore", help_heading = "Filtering")]
     pub no_project_ignore: bool,
     /// Don't load global ignores
     ///
@@ -5864,87 +6422,115 @@ pub struct WatchArgs {
     ///
     /// Like for project files, Git and Bazaar global files will only be used for the corresponding
     /// VCS as used in the project.
-    #[usage(long = "no-global-ignore")]
+    #[usage(long = "no-global-ignore", help_heading = "Filtering")]
     pub no_global_ignore: bool,
     /// Don't use internal default ignores
     ///
-    /// Watchexec has a set of default ignore patterns, such as editor swap files, `*.pyc`, `*.pyo`, `.DS_Store`, `.bzr`, `_darcs`, `.fossil-settings`, `.git`, `.hg`, `.pijul`, `.svn`, and Watchexec log files.
-    #[usage(long = "no-default-ignore")]
+    /// Watchexec has a set of default ignore patterns, such as editor swap files, `*.pyc`, `*.pyo`,
+    /// `.DS_Store`, `.bzr`, `_darcs`, `.fossil-settings`, `.git`, `.hg`, `.pijul`, `.svn`, and
+    /// Watchexec log files.
+    #[usage(long = "no-default-ignore", help_heading = "Filtering")]
     pub no_default_ignore: bool,
     /// Don't discover ignore files at all
     ///
-    /// This is a shorthand for '--no-global-ignore', '--no-vcs-ignore', '--no-project-ignore', but even more efficient as it will skip all the ignore discovery mechanisms from the get go.
+    /// This is a shorthand for '--no-global-ignore', '--no-vcs-ignore', '--no-project-ignore', but
+    /// even more efficient as it will skip all the ignore discovery mechanisms from the get go.
     ///
     /// Note that default ignores are still loaded, see '--no-default-ignore'.
-    #[usage(long = "no-discover-ignore")]
+    #[usage(long = "no-discover-ignore", help_heading = "Filtering")]
     pub no_discover_ignore: bool,
     /// Don't ignore anything at all
     ///
     /// This is a shorthand for '--no-discover-ignore', '--no-default-ignore'.
     ///
-    /// Note that ignores explicitly loaded via other command line options, such as '--ignore' or '--ignore-file', will still be used.
-    #[usage(long = "ignore-nothing")]
+    /// Note that ignores explicitly loaded via other command line options, such as '--ignore' or
+    /// '--ignore-file', will still be used.
+    #[usage(long = "ignore-nothing", help_heading = "Filtering")]
     pub ignore_nothing: bool,
     /// Wait until first change before running command
     ///
-    /// By default, Watchexec will run the command once immediately. With this option, it will instead wait until an event is detected before running the command as normal.
+    /// By default, Watchexec will run the command once immediately. With this option, it will
+    /// instead wait until an event is detected before running the command as normal.
     #[usage(long = "postpone", short = 'p')]
     pub postpone: bool,
     /// Sleep before running the command
     ///
-    /// This option will cause Watchexec to sleep for the specified amount of time before running the command, after an event is detected. This is like using "sleep 5 && command" in a shell, but portable and slightly more efficient.
+    /// This option will cause Watchexec to sleep for the specified amount of time before running
+    /// the command, after an event is detected. This is like using "sleep 5 && command" in a shell,
+    /// but portable and slightly more efficient.
     ///
-    /// Takes a unit-less value in seconds, or a time span value such as "2min 5s". Providing a unit-less value is deprecated and will warn; it will be an error in the future.
+    /// Takes a unit-less value in seconds, or a time span value such as "2min 5s".
+    /// Providing a unit-less value is deprecated and will warn; it will be an error in the future.
     #[usage(long = "delay-run", value_name = "DURATION")]
     pub delay_run: ::std::option::Option<::std::string::String>,
     /// Poll for filesystem changes
     ///
-    /// By default, and where available, Watchexec uses the operating system's native file system watching capabilities. This option disables that and instead uses a polling mechanism, which is less efficient but can work around issues with some file systems (like network shares) or edge cases.
+    /// By default, and where available, Watchexec uses the operating system's native file system
+    /// watching capabilities. This option disables that and instead uses a polling mechanism, which
+    /// is less efficient but can work around issues with some file systems (like network shares) or
+    /// edge cases.
     ///
-    /// Optionally takes a unit-less value in milliseconds, or a time span value such as "2s 500ms", to use as the polling interval. If not specified, the default is 30 seconds. Providing a unit-less value is deprecated and will warn; it will be an error in the future.
+    /// Optionally takes a unit-less value in milliseconds, or a time span value such as "2s 500ms",
+    /// to use as the polling interval. If not specified, the default is 30 seconds.
+    /// Providing a unit-less value is deprecated and will warn; it will be an error in the future.
     ///
     /// Aliased as '--force-poll'.
-    #[usage(long = "poll", value_name = "INTERVAL")]
+    #[usage(
+        long = "poll",
+        alias = "force-poll",
+        default_missing = "30s",
+        value_name = "INTERVAL",
+        value_optional
+    )]
     pub poll: ::std::option::Option<::std::string::String>,
     /// Use a different shell
     ///
-    /// By default, Watchexec will use '$SHELL' if it's defined or a default of 'sh' on Unix-likes, and either 'pwsh', 'powershell', or 'cmd' (CMD.EXE) on Windows, depending on what Watchexec detects is the running shell.
+    /// By default, Watchexec will use '$SHELL' if it's defined or a default of 'sh' on Unix-likes,
+    /// and either 'pwsh', 'powershell', or 'cmd' (CMD.EXE) on Windows, depending on what Watchexec
+    /// detects is the running shell.
     ///
-    /// With this option, you can override that and use a different shell, for example one with more features or one which has your custom aliases and functions.
+    /// With this option, you can override that and use a different shell, for example one with more
+    /// features or one which has your custom aliases and functions.
     ///
-    /// If the value has spaces, it is parsed as a command line, and the first word used as the shell program, with the rest as arguments to the shell.
+    /// If the value has spaces, it is parsed as a command line, and the first word used as the
+    /// shell program, with the rest as arguments to the shell.
     ///
     /// The command is run with the '-c' flag (except for 'cmd' on Windows, where it's '/C').
     ///
-    /// The special value 'none' can be used to disable shell use entirely. In that case, the command provided to Watchexec will be parsed, with the first word being the executable and the rest being the arguments, and executed directly. Note that this parsing is rudimentary, and may not work as expected in all cases.
+    /// The special value 'none' can be used to disable shell use entirely. In that case, the
+    /// command provided to Watchexec will be parsed, with the first word being the executable and
+    /// the rest being the arguments, and executed directly. Note that this parsing is rudimentary,
+    /// and may not work as expected in all cases.
     ///
-    /// Using 'none' is a little more efficient and can enable a stricter interpretation of the input, but it also means that you can't use shell features like globbing, redirection, control flow, logic, or pipes.
+    /// Using 'none' is a little more efficient and can enable a stricter interpretation of the
+    /// input, but it also means that you can't use shell features like globbing, redirection,
+    /// control flow, logic, or pipes.
     ///
     /// Examples:
     ///
     /// Use without shell:
     ///
-    /// $ watchexec -n -- zsh -x -o shwordsplit scr
+    ///   $ watchexec -n -- zsh -x -o shwordsplit scr
     ///
     /// Use with powershell core:
     ///
-    /// $ watchexec --shell=pwsh -- Test-Connection localhost
+    ///   $ watchexec --shell=pwsh -- Test-Connection localhost
     ///
     /// Use with CMD.exe:
     ///
-    /// $ watchexec --shell=cmd -- dir
+    ///   $ watchexec --shell=cmd -- dir
     ///
     /// Use with a different unix shell:
     ///
-    /// $ watchexec --shell=bash -- 'echo $BASH_VERSION'
+    ///   $ watchexec --shell=bash -- 'echo $BASH_VERSION'
     ///
     /// Use with a unix shell and options:
     ///
-    /// $ watchexec --shell='zsh -x -o shwordsplit' -- scr
-    #[usage(long = "shell", value_name = "SHELL")]
+    ///   $ watchexec --shell='zsh -x -o shwordsplit' -- scr
+    #[usage(long = "shell", help_heading = "Command", value_name = "SHELL")]
     pub shell: ::std::option::Option<::std::string::String>,
     /// Shorthand for '--shell=none'
-    #[usage(short = 'n')]
+    #[usage(short = 'n', help_heading = "Command")]
     pub n: bool,
     /// Configure event emission
     ///
@@ -6048,47 +6634,71 @@ pub struct WatchArgs {
     /// multiple confused queries that have landed in my inbox over the years.
     #[usage(
         long = "emit-events-to",
+        hide_default_value,
+        help_heading = "Command",
         value_name = "MODE",
         choices("environment", "stdio", "file", "json-stdio", "json-file", "none"),
         default = "none"
     )]
     pub emit_events_to: ::std::option::Option<::std::string::String>,
+    /// Only emit events to stdout, run no commands.
+    ///
+    /// This is a convenience option for using Watchexec as a file watcher, without running any
+    /// commands. It is almost equivalent to using `cat` as the command, except that it will not
+    /// spawn a new process for each event.
+    ///
+    /// This option requires `--emit-events-to` to be set, and restricts the available modes to
+    /// `stdio` and `json-stdio`, modifying their behaviour to write to stdout instead of the stdin
+    /// of the command.
     #[usage(
-        help = "Only emit events to stdout, run no commands",
-        long_help = "Only emit events to stdout, run no commands.\n\nThis is a convenience option for using Watchexec as a file watcher, without running any commands. It is almost equivalent to using `cat` as the command, except that it will not spawn a new process for each event.\n\nThis option requires `--emit-events-to` to be set, and restricts the available modes to `stdio` and `json-stdio`, modifying their behaviour to write to stdout instead of the stdin of the command.",
-        long = "only-emit-events"
+        long = "only-emit-events",
+        help_heading = "Output",
+        conflicts = "--manual"
     )]
     pub only_emit_events: bool,
     /// Add env vars to the command
     ///
-    /// This is a convenience option for setting environment variables for the command, without setting them for the Watchexec process itself.
+    /// This is a convenience option for setting environment variables for the command, without
+    /// setting them for the Watchexec process itself.
     ///
     /// Use key=value syntax. Multiple variables can be set by repeating the option.
-    #[usage(long = "env", short = 'E', value_name = "KEY=VALUE", var)]
+    #[usage(
+        long = "env",
+        short = 'E',
+        help_heading = "Command",
+        value_name = "KEY=VALUE",
+        var
+    )]
     pub env: ::std::vec::Vec<::std::string::String>,
     /// Configure how the process is wrapped
     ///
-    /// By default, Watchexec will run the command in a session on macOS, in a process group on other Unix platforms, and in a Job Object in Windows.
+    /// By default, Watchexec will run the command in a session on macOS, in a process group on
+    /// other Unix platforms, and in a Job Object in Windows.
     ///
     /// Some Unix programs prefer running in a session, while others do not work in a process group.
     ///
-    /// Use 'group' to use a process group, 'session' to use a process session, and 'none' to run the command directly. On Windows, either of 'group' or 'session' will use a Job Object.
+    /// Use 'group' to use a process group, 'session' to use a process session, and 'none' to run
+    /// the command directly. On Windows, either of 'group' or 'session' will use a Job Object.
     #[usage(
         long = "wrap-process",
+        help_heading = "Command",
         value_name = "MODE",
         choices("group", "session", "none")
     )]
     pub wrap_process: ::std::option::Option<::std::string::String>,
     /// Alert when commands start and end
     ///
-    /// With this, Watchexec will emit a desktop notification when a command starts and ends, on supported platforms. On unsupported platforms, it may silently do nothing, or log a warning.
-    #[usage(long = "notify", short = 'N')]
+    /// With this, Watchexec will emit a desktop notification when a command starts and ends, on
+    /// supported platforms. On unsupported platforms, it may silently do nothing, or log a warning.
+    #[usage(long = "notify", short = 'N', help_heading = "Output")]
     pub notify: bool,
     /// When to use terminal colours
     ///
     /// Setting the environment variable `NO_COLOR` to any value is equivalent to `--color=never`.
     #[usage(
         long = "color",
+        alias = "colour",
+        help_heading = "Output",
         value_name = "MODE",
         choices("auto", "always", "never"),
         default = "auto"
@@ -6096,107 +6706,227 @@ pub struct WatchArgs {
     pub color: ::std::option::Option<::std::string::String>,
     /// Print how long the command took to run
     ///
-    /// This may not be exactly accurate, as it includes some overhead from Watchexec itself. Use the `time` utility, high-precision timers, or benchmarking tools for more accurate results.
-    #[usage(long = "timings")]
+    /// This may not be exactly accurate, as it includes some overhead from Watchexec itself. Use
+    /// the `time` utility, high-precision timers, or benchmarking tools for more accurate results.
+    #[usage(long = "timings", help_heading = "Output")]
     pub timings: bool,
     /// Don't print starting and stopping messages
     ///
-    /// By default Watchexec will print a message when the command starts and stops. This option disables this behaviour, so only the command's output, warnings, and errors will be printed.
-    #[usage(long = "quiet", short = 'q')]
+    /// By default Watchexec will print a message when the command starts and stops. This option
+    /// disables this behaviour, so only the command's output, warnings, and errors will be printed.
+    #[usage(long = "quiet", short = 'q', help_heading = "Output")]
     pub quiet: bool,
     /// Ring the terminal bell on command completion
-    #[usage(long = "bell")]
+    #[usage(long = "bell", help_heading = "Output")]
     pub bell: bool,
     /// Set the project origin
     ///
-    /// Watchexec will attempt to discover the project's "origin" (or "root") by searching for a variety of markers, like files or directory patterns. It does its best but sometimes gets it it wrong, and you can override that with this option.
+    /// Watchexec will attempt to discover the project's "origin" (or "root") by searching for a
+    /// variety of markers, like files or directory patterns. It does its best but sometimes gets it
+    /// it wrong, and you can override that with this option.
     ///
-    /// The project origin is used to determine the path of certain ignore files, which VCS is being used, the meaning of a leading '/' in filtering patterns, and maybe more in the future.
+    /// The project origin is used to determine the path of certain ignore files, which VCS is being
+    /// used, the meaning of a leading '/' in filtering patterns, and maybe more in the future.
     ///
     /// When set, Watchexec will also not bother searching, which can be significantly faster.
     #[usage(long = "project-origin", value_name = "DIRECTORY")]
     pub project_origin: ::std::option::Option<::std::string::String>,
     /// Set the working directory
     ///
-    /// By default, the working directory of the command is the working directory of Watchexec. You can change that with this option. Note that paths may be less intuitive to use with this.
+    /// By default, the working directory of the command is the working directory of Watchexec. You
+    /// can change that with this option. Note that paths may be less intuitive to use with this.
     #[usage(long = "workdir", value_name = "DIRECTORY")]
     pub workdir: ::std::option::Option<::std::string::String>,
     /// Filename extensions to filter to
     ///
-    /// This is a quick filter to only emit events for files with the given extensions. Extensions can be given with or without the leading dot (e.g. 'js' or '.js'). Multiple extensions can be given by repeating the option or by separating them with commas.
-    #[usage(long = "exts", short = 'e', value_name = "EXTENSIONS", var)]
+    /// This is a quick filter to only emit events for files with the given extensions. Extensions
+    /// can be given with or without the leading dot (e.g. 'js' or '.js'). Multiple extensions can
+    /// be given by repeating the option or by separating them with commas.
+    #[usage(
+        long = "exts",
+        short = 'e',
+        help_heading = "Filtering",
+        delimiter = ',',
+        value_name = "EXTENSIONS",
+        var
+    )]
     pub exts: ::std::vec::Vec<::std::string::String>,
     /// Filename patterns to filter to
     ///
-    /// Provide a glob-like filter pattern, and only events for files matching the pattern will be emitted. Multiple patterns can be given by repeating the option. Events that are not from files (e.g. signals, keyboard events) will pass through untouched.
-    #[usage(long = "filter", short = 'f', value_name = "PATTERN", var)]
+    /// Provide a glob-like filter pattern, and only events for files matching the pattern will be
+    /// emitted. Multiple patterns can be given by repeating the option. Events that are not from
+    /// files (e.g. signals, keyboard events) will pass through untouched.
+    #[usage(
+        long = "filter",
+        short = 'f',
+        help_heading = "Filtering",
+        value_name = "PATTERN",
+        var
+    )]
     pub filter: ::std::vec::Vec<::std::string::String>,
     /// Files to load filters from
     ///
-    /// Provide a path to a file containing filters, one per line. Empty lines and lines starting with '#' are ignored. Uses the same pattern format as the '--filter' option.
+    /// Provide a path to a file containing filters, one per line. Empty lines and lines starting
+    /// with '#' are ignored. Uses the same pattern format as the '--filter' option.
     ///
     /// This can also be used via the $WATCHEXEC_FILTER_FILES environment variable.
-    #[usage(long = "filter-file", value_name = "PATH", var)]
-    pub filter_file: ::std::vec::Vec<::std::string::String>,
     #[usage(
-        help = "[experimental] Filter programs",
-        long_help = "[experimental] Filter programs.\n\n/!\\ This option is EXPERIMENTAL and may change and/or vanish without notice.\n\nProvide your own custom filter programs in jaq (similar to jq) syntax. Programs are given an event in the same format as described in '--emit-events-to' and must return a boolean. Invalid programs will make watchexec fail to start; use '-v' to see program runtime errors.\n\nIn addition to the jaq stdlib, watchexec adds some custom filter definitions:\n\n- 'path | file_meta' returns file metadata or null if the file does not exist.\n\n- 'path | file_size' returns the size of the file at path, or null if it does not exist.\n\n- 'path | file_read(bytes)' returns a string with the first n bytes of the file at path. If the file is smaller than n bytes, the whole file is returned. There is no filter to read the whole file at once to encourage limiting the amount of data read and processed.\n\n- 'string | hash', and 'path | file_hash' return the hash of the string or file at path. No guarantee is made about the algorithm used: treat it as an opaque value.\n\n- 'any | kv_store(key)', 'kv_fetch(key)', and 'kv_clear' provide a simple key-value store. Data is kept in memory only, there is no persistence. Consistency is not guaranteed.\n\n- 'any | printout', 'any | printerr', and 'any | log(level)' will print or log any given value to stdout, stderr, or the log (levels = error, warn, info, debug, trace), and pass the value through (so '[1] | log(\"debug\") | .[]' will produce a '1' and log '[1]').\n\nAll filtering done with such programs, and especially those using kv or filesystem access, is much slower than the other filtering methods. If filtering is too slow, events will back up and stall watchexec. Take care when designing your filters.\n\nIf the argument to this option starts with an '@', the rest of the argument is taken to be the path to a file containing a jaq program.\n\nJaq programs are run in order, after all other filters, and short-circuit: if a filter (jaq or not) rejects an event, execution stops there, and no other filters are run. Additionally, they stop after outputting the first value, so you'll want to use 'any' or 'all' when iterating, otherwise only the first item will be processed, which can be quite confusing!\n\nFind user-contributed programs or submit your own useful ones at <https://github.com/watchexec/watchexec/discussions/592>.\n\n## Examples:\n\nRegexp ignore filter on paths:\n\n'all(.tags[] | select(.kind == \"path\"); .absolute | test(\"[.]test[.]js$\")) | not'\n\nPass any event that creates a file:\n\n'any(.tags[] | select(.kind == \"fs\"); .simple == \"create\")'\n\nPass events that touch executable files:\n\n'any(.tags[] | select(.kind == \"path\" && .filetype == \"file\"); .absolute | metadata | .executable)'\n\nIgnore files that start with shebangs:\n\n'any(.tags[] | select(.kind == \"path\" && .filetype == \"file\"); .absolute | read(2) == \"#!\") | not'",
+        long = "filter-file",
+        hide_env,
+        env = "WATCHEXEC_FILTER_FILES",
+        help_heading = "Filtering",
+        delimiter = ':',
+        value_name = "PATH",
+        var
+    )]
+    pub filter_file: ::std::vec::Vec<::std::string::String>,
+    /// [experimental] Filter programs.
+    ///
+    /// /!\ This option is EXPERIMENTAL and may change and/or vanish without notice.
+    ///
+    /// Provide your own custom filter programs in jaq (similar to jq) syntax. Programs are given
+    /// an event in the same format as described in '--emit-events-to' and must return a boolean.
+    /// Invalid programs will make watchexec fail to start; use '-v' to see program runtime errors.
+    ///
+    /// In addition to the jaq stdlib, watchexec adds some custom filter definitions:
+    ///
+    ///   - 'path | file_meta' returns file metadata or null if the file does not exist.
+    ///
+    ///   - 'path | file_size' returns the size of the file at path, or null if it does not exist.
+    ///
+    ///   - 'path | file_read(bytes)' returns a string with the first n bytes of the file at path.
+    ///     If the file is smaller than n bytes, the whole file is returned. There is no filter to
+    ///     read the whole file at once to encourage limiting the amount of data read and processed.
+    ///
+    ///   - 'string | hash', and 'path | file_hash' return the hash of the string or file at path.
+    ///     No guarantee is made about the algorithm used: treat it as an opaque value.
+    ///
+    ///   - 'any | kv_store(key)', 'kv_fetch(key)', and 'kv_clear' provide a simple key-value store.
+    ///     Data is kept in memory only, there is no persistence. Consistency is not guaranteed.
+    ///
+    ///   - 'any | printout', 'any | printerr', and 'any | log(level)' will print or log any given
+    ///     value to stdout, stderr, or the log (levels = error, warn, info, debug, trace), and
+    ///     pass the value through (so '[1] | log("debug") | .[]' will produce a '1' and log '[1]').
+    ///
+    /// All filtering done with such programs, and especially those using kv or filesystem access,
+    /// is much slower than the other filtering methods. If filtering is too slow, events will back
+    /// up and stall watchexec. Take care when designing your filters.
+    ///
+    /// If the argument to this option starts with an '@', the rest of the argument is taken to be
+    /// the path to a file containing a jaq program.
+    ///
+    /// Jaq programs are run in order, after all other filters, and short-circuit: if a filter (jaq
+    /// or not) rejects an event, execution stops there, and no other filters are run. Additionally,
+    /// they stop after outputting the first value, so you'll want to use 'any' or 'all' when
+    /// iterating, otherwise only the first item will be processed, which can be quite confusing!
+    ///
+    /// Find user-contributed programs or submit your own useful ones at
+    /// <https://github.com/watchexec/watchexec/discussions/592>.
+    ///
+    /// ## Examples:
+    ///
+    /// Regexp ignore filter on paths:
+    ///
+    ///   'all(.tags[] | select(.kind == "path"); .absolute | test("[.]test[.]js$")) | not'
+    ///
+    /// Pass any event that creates a file:
+    ///
+    ///   'any(.tags[] | select(.kind == "fs"); .simple == "create")'
+    ///
+    /// Pass events that touch executable files:
+    ///
+    ///   'any(.tags[] | select(.kind == "path" && .filetype == "file"); .absolute | metadata | .executable)'
+    ///
+    /// Ignore files that start with shebangs:
+    ///
+    ///   'any(.tags[] | select(.kind == "path" && .filetype == "file"); .absolute | read(2) == "#!") | not'
+    #[usage(
         long = "filter-prog",
         short = 'J',
+        help_heading = "Filtering",
         value_name = "EXPRESSION",
         var
     )]
     pub filter_prog: ::std::vec::Vec<::std::string::String>,
     /// Filename patterns to filter out
     ///
-    /// Provide a glob-like filter pattern, and events for files matching the pattern will be excluded. Multiple patterns can be given by repeating the option. Events that are not from files (e.g. signals, keyboard events) will pass through untouched.
-    #[usage(long = "ignore", short = 'i', value_name = "PATTERN", var)]
+    /// Provide a glob-like filter pattern, and events for files matching the pattern will be
+    /// excluded. Multiple patterns can be given by repeating the option. Events that are not from
+    /// files (e.g. signals, keyboard events) will pass through untouched.
+    #[usage(
+        long = "ignore",
+        short = 'i',
+        help_heading = "Filtering",
+        value_name = "PATTERN",
+        var
+    )]
     pub ignore: ::std::vec::Vec<::std::string::String>,
     /// Files to load ignores from
     ///
-    /// Provide a path to a file containing ignores, one per line. Empty lines and lines starting with '#' are ignored. Uses the same pattern format as the '--ignore' option.
+    /// Provide a path to a file containing ignores, one per line. Empty lines and lines starting
+    /// with '#' are ignored. Uses the same pattern format as the '--ignore' option.
     ///
     /// This can also be used via the $WATCHEXEC_IGNORE_FILES environment variable.
-    #[usage(long = "ignore-file", value_name = "PATH", var)]
+    #[usage(
+        long = "ignore-file",
+        hide_env,
+        env = "WATCHEXEC_IGNORE_FILES",
+        help_heading = "Filtering",
+        delimiter = ':',
+        value_name = "PATH",
+        var
+    )]
     pub ignore_file: ::std::vec::Vec<::std::string::String>,
     /// Filesystem events to filter to
     ///
-    /// This is a quick filter to only emit events for the given types of filesystem changes. Choose from 'access', 'create', 'remove', 'rename', 'modify', 'metadata'. Multiple types can be given by repeating the option or by separating them with commas. By default, this is all types except for 'access'.
+    /// This is a quick filter to only emit events for the given types of filesystem changes. Choose
+    /// from 'access', 'create', 'remove', 'rename', 'modify', 'metadata'. Multiple types can be
+    /// given by repeating the option or by separating them with commas. By default, this is all
+    /// types except for 'access'.
     ///
-    /// This may apply filtering at the kernel level when possible, which can be more efficient, but may be more confusing when reading the logs.
+    /// This may apply filtering at the kernel level when possible, which can be more efficient, but
+    /// may be more confusing when reading the logs.
     #[usage(
         long = "fs-events",
+        hide_default_value,
+        help_heading = "Filtering",
+        delimiter = ',',
         value_name = "EVENTS",
         choices("access", "create", "remove", "rename", "modify", "metadata"),
-        default = "create",
-        default = "remove",
-        default = "rename",
-        default = "modify",
-        default = "metadata",
+        default = "create,remove,rename,modify,metadata",
         var
     )]
     pub fs_events: ::std::vec::Vec<::std::string::String>,
     /// Don't emit fs events for metadata changes
     ///
-    /// This is a shorthand for '--fs-events create,remove,rename,modify'. Using it alongside the '--fs-events' option is non-sensical and not allowed.
-    #[usage(long = "no-meta")]
+    /// This is a shorthand for '--fs-events create,remove,rename,modify'. Using it alongside the
+    /// '--fs-events' option is non-sensical and not allowed.
+    #[usage(
+        long = "no-meta",
+        help_heading = "Filtering",
+        conflicts = "--fs-events"
+    )]
     pub no_meta: bool,
     /// Print events that trigger actions
     ///
-    /// This prints the events that triggered the action when handling it (after debouncing), in a human readable form. This is useful for debugging filters.
+    /// This prints the events that triggered the action when handling it (after debouncing), in a
+    /// human readable form. This is useful for debugging filters.
     ///
     /// Use '-vvv' instead when you need more diagnostic information.
-    #[usage(long = "print-events")]
+    #[usage(long = "print-events", help_heading = "Debugging")]
     pub print_events: bool,
     /// Show the manual page
     ///
-    /// This shows the manual page for Watchexec, if the output is a terminal and the 'man' program is available. If not, the manual page is printed to stdout in ROFF format (suitable for writing to a watchexec.1 file).
-    #[usage(long = "manual")]
+    /// This shows the manual page for Watchexec, if the output is a terminal and the 'man' program
+    /// is available. If not, the manual page is printed to stdout in ROFF format (suitable for
+    /// writing to a watchexec.1 file).
+    #[usage(long = "manual", help_heading = "Debugging")]
     pub manual: bool,
     #[usage(
         arg,
         name = "TASK",
-        help = "Tasks to run\nCan specify multiple tasks by separating with `:::`\ne.g.: `mise run task1 arg1 arg2 ::: task2 arg1 arg2`"
+        help = "Tasks to run\nCan specify multiple tasks by separating with `:::`\ne.g.: `mise run task1 arg1 arg2 ::: task2 arg1 arg2`\nDefaults to `default`",
+        double_dash = "automatic"
     )]
     pub task: ::std::option::Option<::std::string::String>,
     /// Task and arguments to run
@@ -6209,7 +6939,7 @@ pub struct WatchArgs {
 /// The tool must be installed for this to work.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    # Show the latest installed version of node\n    # If it is is not installed, errors\n    $ mise where node@20\n    /home/jdx/.local/share/mise/installs/node/20.0.0\n\n    # Show the current, active install directory of node\n    # Errors if node is not referenced in any .tool-version file\n    $ mise where node\n    /home/jdx/.local/share/mise/installs/node/20.0.0",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    # Show the latest installed version of node\n    # If it is is not installed, errors\n    $ \u{1b}[1mmise where node@20\u{1b}[22m\n    /home/jdx/.local/share/mise/installs/node/20.0.0\n\n    # Show the current, active install directory of node\n    # Errors if node is not referenced in any .tool-version file\n    $ \u{1b}[1mmise where node\u{1b}[22m\n    /home/jdx/.local/share/mise/installs/node/20.0.0\n",
     effect = "read"
 )]
 pub struct WhereArgs {
@@ -6233,7 +6963,7 @@ pub struct WhereArgs {
 /// Use this to figure out what version of a tool is currently active.
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    $ mise which node\n    /home/username/.local/share/mise/installs/node/20.0.0/bin/node\n\n    $ mise which node --plugin\n    node\n\n    $ mise which node --version\n    20.0.0",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise which node\u{1b}[22m\n    /home/username/.local/share/mise/installs/node/20.0.0/bin/node\n\n    $ \u{1b}[1mmise which node --plugin\u{1b}[22m\n    node\n\n    $ \u{1b}[1mmise which node --version\u{1b}[22m\n    20.0.0\n",
     effect = "read"
 )]
 pub struct WhichArgs {
@@ -6247,13 +6977,13 @@ pub struct WhichArgs {
     #[usage(long = "complete", hide)]
     pub complete: bool,
     /// Show the plugin name instead of the path
-    #[usage(long = "plugin")]
+    #[usage(long = "plugin", conflicts = "--version")]
     pub plugin: bool,
     /// Show the version instead of the path
-    #[usage(long = "version")]
+    #[usage(long = "version", conflicts = "--plugin")]
     pub version: bool,
     /// The bin to look up
-    #[usage(arg, name = "BIN_NAME")]
+    #[usage(arg, name = "BIN_NAME", required_unless = "--complete")]
     pub bin_name: ::std::option::Option<::std::string::String>,
 }
 
@@ -6261,8 +6991,10 @@ pub struct WhichArgs {
 #[usage(
     bin = "mise",
     name = "mise",
+    author = "Jeff Dickey <@jdx>",
     about = "Dev tools, env vars, and tasks in one CLI",
     long_about = "mise prepares your development environment before each command runs. https://github.com/jdx/mise",
+    after_long_help = "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    $ \u{1b}[1mmise install node@20.0.0\u{1b}[22m       Install a specific node version\n    $ \u{1b}[1mmise install node@20\u{1b}[22m           Install a version matching a prefix\n    $ \u{1b}[1mmise install node\u{1b}[22m              Install the node version defined in config\n    $ \u{1b}[1mmise install\u{1b}[22m                   Install all plugins/tools defined in config\n\n    $ \u{1b}[1mmise install cargo:ripgrep\u{1b}[22m     Install something via cargo\n    $ \u{1b}[1mmise install npm:prettier\u{1b}[22m      Install something via npm\n\n    $ \u{1b}[1mmise use node@20\u{1b}[22m               Use node-20.x in current project\n    $ \u{1b}[1mmise use -g node@20\u{1b}[22m            Use node-20.x as default\n    $ \u{1b}[1mmise use node@latest\u{1b}[22m           Use latest node in current directory\n\n    $ \u{1b}[1mmise up --interactive\u{1b}[22m          Show a menu to upgrade tools\n\n    $ \u{1b}[1mmise x -- npm install\u{1b}[22m          `npm install` w/ config loaded into PATH\n    $ \u{1b}[1mmise x node@20 -- node app.js\u{1b}[22m  `node app.js` w/ config + node-20.x on PATH\n\n    $ \u{1b}[1mmise set NODE_ENV=production\u{1b}[22m   Set NODE_ENV=production in config\n\n    $ \u{1b}[1mmise run build\u{1b}[22m                 Run `build` tasks\n    $ \u{1b}[1mmise watch build\u{1b}[22m               Run `build` tasks repeatedly when files change\n\n    $ \u{1b}[1mmise settings\u{1b}[22m                  Show settings in use\n    $ \u{1b}[1mmise settings color=0\u{1b}[22m          Disable color by modifying global config file\n",
     default_subcommand = "run"
 )]
 pub struct Cli {
@@ -6278,8 +7010,14 @@ pub struct Cli {
     /// Force the operation
     #[usage(long = "force", short = 'f', hide)]
     pub force: bool,
-    /// How many jobs to run in parallel [default: 8]
-    #[usage(long = "jobs", short = 'j', global, value_name = "JOBS")]
+    /// How many jobs to run in parallel; values below 1 are treated as 1 [default: 8]
+    #[usage(
+        long = "jobs",
+        short = 'j',
+        global,
+        env = "MISE_JOBS",
+        value_name = "JOBS"
+    )]
     pub jobs: ::std::option::Option<::std::string::String>,
     /// Dry run, don't actually do anything
     #[usage(long = "dry-run", short = 'n', hide)]
@@ -6290,20 +7028,40 @@ pub struct Cli {
         short = 'P',
         global,
         hide,
+        conflicts = "--env",
         value_name = "PROFILE",
         var
     )]
     pub profile: ::std::vec::Vec<::std::string::String>,
     /// Suppress non-error messages
-    #[usage(long = "quiet", short = 'q', global)]
+    #[usage(
+        long = "quiet",
+        short = 'q',
+        global,
+        overrides("--silent", "--trace", "--verbose", "--debug", "--log-level")
+    )]
     pub quiet: bool,
     #[usage(long = "shell", short = 's', hide, value_name = "SHELL")]
     pub shell: ::std::option::Option<::std::string::String>,
-    /// Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10
-    #[usage(long = "tool", short = 't', hide, value_name = "TOOL@VERSION", var)]
+    #[usage(
+        help = "Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10",
+        long_help = "Tool(s) to run in addition to what is in mise.toml files\ne.g.: node@20 python@3.10",
+        long = "tool",
+        short = 't',
+        hide,
+        env = "MISE_QUIET",
+        value_name = "TOOL@VERSION",
+        var
+    )]
     pub tool: ::std::vec::Vec<::std::string::String>,
     /// Show extra output (use -vv for even more)
-    #[usage(long = "verbose", short = 'v', global, count)]
+    #[usage(
+        long = "verbose",
+        short = 'v',
+        global,
+        count,
+        overrides("--quiet", "--silent", "--trace", "--debug")
+    )]
     pub verbose: u8,
     #[usage(long = "version", short = 'V', hide)]
     pub version: bool,
@@ -6311,12 +7069,18 @@ pub struct Cli {
     #[usage(long = "yes", short = 'y', global)]
     pub yes: bool,
     /// Sets log level to debug
-    #[usage(long = "debug", global, hide)]
+    #[usage(
+        long = "debug",
+        global,
+        hide,
+        overrides("--quiet", "--trace", "--verbose", "--silent", "--log-level")
+    )]
     pub debug: bool,
     #[usage(
         long = "log-level",
         global,
         hide,
+        overrides("--quiet", "--trace", "--verbose", "--silent", "--debug"),
         value_name = "LEVEL",
         choices("trace", "debug", "info", "warning", "error")
     )]
@@ -6339,7 +7103,7 @@ pub struct Cli {
     /// Hides elapsed time after each task completes
     ///
     /// Default to always hide with `MISE_TASK_TIMINGS=0`
-    #[usage(long = "no-timings", hide)]
+    #[usage(long = "no-timings", alias = "no-timing", hide)]
     pub no_timings: bool,
     #[usage(long = "output", value_name = "OUTPUT")]
     pub output: ::std::option::Option<::std::string::String>,
@@ -6354,21 +7118,31 @@ pub struct Cli {
     #[usage(long = "locked", global)]
     pub locked: bool,
     /// Suppress all task output and mise non-error messages
-    #[usage(long = "silent", global)]
+    #[usage(
+        long = "silent",
+        global,
+        overrides("--quiet", "--trace", "--verbose", "--debug", "--log-level")
+    )]
     pub silent: bool,
     /// Shows elapsed time after each task completes
     ///
     /// Default to always show with `MISE_TASK_TIMINGS=1`
-    #[usage(long = "timings", hide)]
+    #[usage(long = "timings", alias = "timing", hide)]
     pub timings: bool,
     /// Sets log level to trace
-    #[usage(long = "trace", global, hide)]
+    #[usage(
+        long = "trace",
+        global,
+        hide,
+        overrides("--quiet", "--silent", "--verbose", "--debug", "--log-level")
+    )]
     pub trace: bool,
     #[usage(
         arg,
         name = "TASK",
         help = "Task to run",
-        long_help = "Task to run.\n\nShorthand for `mise tasks run <TASK>`."
+        long_help = "Task to run.\n\nShorthand for `mise tasks run <TASK>`.",
+        double_dash = "automatic"
     )]
     pub task: ::std::option::Option<::std::string::String>,
     /// Task arguments
@@ -6398,7 +7172,7 @@ pub enum Commands {
     #[usage(name = "bin-paths")]
     BinPaths(Box<BinPathsArgs>),
     /// Set up a machine for the current config in one command
-    #[usage(name = "bootstrap", alias = "bs")]
+    #[usage(name = "bootstrap", alias_hidden = "bs")]
     Bootstrap(Box<BootstrapArgs>),
     /// Manage the mise cache
     #[usage(name = "cache")]
@@ -6524,11 +7298,7 @@ pub enum Commands {
     #[usage(name = "set", alias_hidden("ev", "env-vars"))]
     Set(Box<SetArgs>),
     /// Manage settings
-    #[usage(
-        name = "settings",
-        help = "Manage settings",
-        long_help = "Show current settings\n\nThis is the contents of ~/.config/mise/config.toml\n\nNote that aliases are also stored in this file\nbut managed separately with `mise tool-alias`"
-    )]
+    #[usage(name = "settings")]
     Settings(Box<SettingsArgs>),
     /// Sets a tool version for the current session.
     #[usage(name = "shell", alias = "sh")]
@@ -6566,7 +7336,7 @@ pub enum Commands {
     /// Remove environment variable(s) from the config file.
     #[usage(name = "unset")]
     Unset(Box<UnsetArgs>),
-    /// No longer trust a config, will prompt in the future
+    /// Remove explicit trust for a config
     #[usage(name = "untrust")]
     Untrust(Box<UntrustArgs>),
     /// Removes installed tool versions from mise.toml

--- a/benches/shadows/pitchfork/src/lib.rs
+++ b/benches/shadows/pitchfork/src/lib.rs
@@ -635,7 +635,7 @@ pub struct LogsArgs {
 ///     pitchfork_logs      Return recent log output for a daemon
 #[derive(Args)]
 #[usage(
-    after_long_help = "Examples:\n\n    # Start the MCP server (used by AI assistant tools)\n    $ pitchfork mcp\n\n    # Claude Desktop configuration (claude_desktop_config.json):\n    {\n      \"mcpServers\": {\n        \"pitchfork\": {\n          \"command\": \"pitchfork\",\n          \"args\": [\"mcp\"]\n        }\n      }\n    }\n\n    # Interactive testing with JSON-RPC:\n    $ echo '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-03-26\",\"capabilities\":{},\"clientInfo\":{\"name\":\"test\",\"version\":\"1.0\"}}}' | pitchfork mcp\n\n# Available tools:\n- pitchfork_status  - List all daemons and their state\n- pitchfork_start   - Start daemon(s) by name\n- pitchfork_stop    - Stop daemon(s) by name\n- pitchfork_restart - Restart daemon(s) by name\n- pitchfork_logs    - Return recent log output for daemon(s)"
+    after_long_help = "Examples:\n\n    # Start the MCP server (used by AI assistant tools)\n    $ pitchfork mcp\n\n    # Claude Desktop configuration (claude_desktop_config.json):\n    {\n      \"mcpServers\": {\n        \"pitchfork\": {\n          \"command\": \"pitchfork\",\n          \"args\": [\"mcp\"]\n        }\n      }\n    }\n\n    # Interactive testing with JSON-RPC:\n    $ echo '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-03-26\",\"capabilities\":{},\"clientInfo\":{\"name\":\"test\",\"version\":\"1.0\"}}}' | pitchfork mcp\n\n# Available tools:\n- pitchfork_status  - List all daemons and their state\n- pitchfork_start   - Start daemon(s) by name\n- pitchfork_stop    - Stop daemon(s) by name\n- pitchfork_restart - Restart daemon(s) by name\n- pitchfork_logs    - Return recent log output for daemon(s)\n"
 )]
 pub struct McpArgs {}
 
@@ -934,7 +934,7 @@ pub struct RestartArgs {
     #[usage(long = "quiet", short = 'q')]
     pub quiet: bool,
     /// ID of the daemon(s) to restart
-    #[usage(arg, name = "ID")]
+    #[usage(arg, name = "ID", conflicts("--local", "--global", "--all"))]
     pub id: ::std::vec::Vec<::std::string::String>,
 }
 
@@ -1190,7 +1190,7 @@ pub struct StartArgs {
     #[usage(long = "quiet", short = 'q')]
     pub quiet: bool,
     /// ID of the daemon(s) in pitchfork.toml to start
-    #[usage(arg, name = "ID")]
+    #[usage(arg, name = "ID", conflicts("--local", "--global", "--all"))]
     pub id: ::std::vec::Vec<::std::string::String>,
 }
 
@@ -1271,7 +1271,7 @@ pub struct StopArgs {
     )]
     pub global: bool,
     /// The name of the daemon(s) to stop
-    #[usage(arg, name = "ID")]
+    #[usage(arg, name = "ID", conflicts("--local", "--global", "--all"))]
     pub id: ::std::vec::Vec<::std::string::String>,
 }
 

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -2004,9 +2004,12 @@ impl Field {
         }
 
         let rust_name = ident.unraw().to_string();
+        // clap treats the conventional suffix used to escape Rust keywords as a Rust-only
+        // detail: `type_` is exposed as `--type` / `TYPE`, not `--type-` / `TYPE_`.
+        let inferred_name = rust_name.strip_suffix('_').unwrap_or(&rust_name);
         let mut name = rename_all
-            .map(|style| style.apply(&rust_name))
-            .unwrap_or_else(|| to_kebab(&rust_name));
+            .map(|style| style.apply(inferred_name))
+            .unwrap_or_else(|| to_kebab(inferred_name));
         let mut name_given = false;
         let mut longs: Vec<String> = Vec::new();
         let mut visible_long_aliases: Vec<String> = Vec::new();
@@ -2708,7 +2711,17 @@ impl Field {
         if !choices.is_empty() && !allow_unknown_choices {
             // Each of them, not the first: a collection's second default is as unusable as its
             // first if the choices do not allow it.
-            if let Some(default) = default.iter().find(|d| !choices.contains(d)) {
+            let invalid_default = default.iter().find_map(|declared| {
+                if shape == Shape::Many {
+                    if let Some(delimiter) = delimiter {
+                        return declared
+                            .split(delimiter)
+                            .find(|part| !choices.iter().any(|choice| choice == part));
+                    }
+                }
+                (!choices.contains(declared)).then_some(declared.as_str())
+            });
+            if let Some(default) = invalid_default {
                 return Err(syn::Error::new(
                     span,
                     format!(
@@ -2893,11 +2906,11 @@ impl Field {
             ));
         }
 
-        // `required` is for the one case the type cannot express. Anywhere else it either
-        // repeats what the type says or contradicts it, and both are worth refusing: a
-        // declaration that changes nothing is a declaration someone will trust.
+        // Collections and switches cannot express occurrence requiredness in their Rust
+        // type. clap permits `required` on both, and generated clap-compatible definitions
+        // use it for commands whose only valid spelling includes a switch.
         if required_collection
-            && shape != Shape::Many
+            && !matches!(shape, Shape::Many | Shape::Bool | Shape::Count)
             && !(subcommand_negates_reqs && shape == Shape::Optional)
         {
             return Err(syn::Error::new(
@@ -2913,8 +2926,8 @@ impl Field {
                                         for a collecting field, where the type cannot say it"
                     }
                     _ => {
-                        "`required` is only for a collecting field, which is the one shape \
-                          whose type cannot say whether a value is needed"
+                        "`required` is only for a collecting field or switch, whose type \
+                          cannot say whether an occurrence is needed"
                     }
                 },
             ));
@@ -3010,12 +3023,10 @@ impl Field {
         // And an `Option<Vec<_>>` is shaped like any other collection, so `required` was
         // accepted there too — after which the field can never be `None` and the `Option` means
         // nothing at all.
-        // `required` is for the one shape whose type cannot say it. Anywhere else it repeats
-        // what the type says or contradicts it, and a declaration that changes nothing is one
-        // someone will eventually trust. (This guard was lost while two fixes for the same
-        // review finding met in the middle; the test for it is what noticed.)
+        // Collections and switches cannot express occurrence requiredness in their Rust type.
+        // Anywhere else this repeats or contradicts the type.
         if required_collection
-            && shape != Shape::Many
+            && !matches!(shape, Shape::Many | Shape::Bool | Shape::Count)
             && !(subcommand_negates_reqs && shape == Shape::Optional)
         {
             return Err(syn::Error::new(
@@ -3030,8 +3041,8 @@ impl Field {
                                         a collecting field, where the type cannot say it"
                     }
                     _ => {
-                        "`required` is only for a collecting field, which is the one shape \
-                          whose type cannot say whether a value is needed"
+                        "`required` is only for a collecting field or switch, whose type \
+                          cannot say whether an occurrence is needed"
                     }
                 },
             ));
@@ -5183,6 +5194,20 @@ mod tests {
 
     #[test]
     fn clap_field_spellings_preserve_supported_metadata() {
+        let keyword = cli(r#"
+            struct Ex {
+                #[arg(long)]
+                type_: Option<String>,
+            }
+        "#)
+        .expect("a Rust keyword escape is not part of clap's public name");
+        assert_eq!(keyword.fields[0].name, "type");
+        assert_eq!(keyword.fields[0].value_name.as_deref(), Some("TYPE"));
+        let Kind::Flag { longs, .. } = &keyword.fields[0].kind else {
+            panic!("long should make this a flag");
+        };
+        assert_eq!(longs, &["type"]);
+
         let parsed = cli(r#"
             struct Ex {
                 #[arg(long, num_args = 2, value_names = ["START", "END"])]
@@ -5744,6 +5769,14 @@ mod tests {
         "#,
         );
         assert!(err.contains("the default `z`"), "unhelpful message: {err}");
+
+        cli(r#"
+            struct Ex {
+                #[usage(long, var, delimiter = ',', choices("a", "b"), default = "a,b")]
+                out: Vec<String>,
+            }
+        "#)
+        .expect("a delimited collection default is validated value by value");
     }
 
     #[test]
@@ -7236,6 +7269,19 @@ mod tests {
                 "{condition} produced an unhelpful message: {err}"
             );
         }
+    }
+
+    #[test]
+    fn required_switch_is_clap_compatible() {
+        let cli = cli(r#"
+            struct Ex {
+                #[arg(long, required = true)]
+                brew: bool,
+            }
+        "#)
+        .unwrap();
+
+        assert!(cli.fields[0].required_collection);
     }
 
     #[test]

--- a/go/argv/page.go
+++ b/go/argv/page.go
@@ -32,6 +32,9 @@ type HelpSpec struct {
 	About string
 	// LongAbout is what `--help` prefers over About.
 	LongAbout string
+	// Author and License are printed at the end of every long page.
+	Author  string
+	License string
 	// BeforeHelp and AfterHelp bracket every page that does not override them,
 	// and the long variants are what `--help` prefers.
 	BeforeHelp     string

--- a/go/argv/page_long.go
+++ b/go/argv/page_long.go
@@ -159,6 +159,15 @@ func LongHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) st
 	if after != "" {
 		out.WriteString("\n" + after + "\n")
 	}
+	if spec.Author != "" || spec.License != "" {
+		out.WriteByte('\n')
+		if spec.Author != "" {
+			out.WriteString("Author: " + spec.Author + "\n")
+		}
+		if spec.License != "" {
+			out.WriteString("License: " + spec.License + "\n")
+		}
+	}
 
 	return strings.TrimSpace(out.String()) + "\n"
 }

--- a/go/argv/page_test.go
+++ b/go/argv/page_test.go
@@ -36,6 +36,18 @@ func TestExamplesFallBackToTheRoot(t *testing.T) {
 	}
 }
 
+func TestLongHelpEndsWithAuthorshipAndLicense(t *testing.T) {
+	root := &Command{Name: "ex", Key: 1}
+	spec := HelpSpec{Bin: "ex", Author: "A. Person", License: "MIT"}
+	page := LongHelp(spec, []string{"ex"}, []*Command{root}, HelpTable{{Key: 1}})
+	if !strings.HasSuffix(page, "Author: A. Person\nLicense: MIT\n") {
+		t.Fatalf("missing long-page footer:\n%s", page)
+	}
+	if strings.Contains(ShortHelp(spec, []string{"ex"}, []*Command{root}, HelpTable{{Key: 1}}), "Author:") {
+		t.Fatal("short help should not print the long-page footer")
+	}
+}
+
 func TestHiddenFlagAliasesStayOutOfHelp(t *testing.T) {
 	flag := &Flag{
 		Key: 2, Name: "output",

--- a/go/conformance/page_test.go
+++ b/go/conformance/page_test.go
@@ -120,8 +120,11 @@ func firstDiff(ours, theirs string) string {
 		}
 		return strings.TrimRight(out.String(), "\n")
 	}
-	return "  same for " + itoa(min(len(mine), len(ref))) + " lines, then ours has " +
-		itoa(len(mine)) + " and the reference " + itoa(len(ref))
+	shared := min(len(mine), len(ref))
+	return "  same for " + itoa(shared) + " lines, then ours has " +
+		itoa(len(mine)) + " and the reference " + itoa(len(ref)) +
+		"\n  ours continues: " + quote(strings.Join(mine[shared:], "\\n")) +
+		"\n   lib continues: " + quote(strings.Join(ref[shared:], "\\n"))
 }
 
 // at is a line of a page, or a marker where the page has ended — so a window

--- a/go/internal/shadow/mise/meta_test.go
+++ b/go/internal/shadow/mise/meta_test.go
@@ -304,8 +304,8 @@ func TestGeneratedParseFillsTheStructs(t *testing.T) {
 	}
 }
 
-// The shape that made the Rust derive's validation wrong, through the front door.
-func TestGeneratedParseSplitsArgsAcrossASeparator(t *testing.T) {
+// An automatic trailing argument forwards even a literal separator, matching the typed fixture.
+func TestGeneratedParseKeepsAutomaticTrailingArgsTogether(t *testing.T) {
 	cli, err := Parse([]string{"tasks", "run", "build", "extra", "--", "--verbose"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -317,11 +317,11 @@ func TestGeneratedParseSplitsArgsAcrossASeparator(t *testing.T) {
 	if run.Task != "build" {
 		t.Errorf("want build, got %q", run.Task)
 	}
-	if len(run.Args) != 1 || run.Args[0] != "extra" {
-		t.Errorf("want [extra] before the separator, got %q", run.Args)
+	if len(run.Args) != 3 || run.Args[0] != "extra" || run.Args[1] != "--" || run.Args[2] != "--verbose" {
+		t.Errorf("want [extra -- --verbose], got %q", run.Args)
 	}
-	if len(run.ArgsLast) != 1 || run.ArgsLast[0] != "--verbose" {
-		t.Errorf("want [--verbose] after it, got %q", run.ArgsLast)
+	if len(run.ArgsLast) != 0 {
+		t.Errorf("the compatibility field should stay empty, got %q", run.ArgsLast)
 	}
 }
 

--- a/go/internal/shadow/mise/parse_test.go
+++ b/go/internal/shadow/mise/parse_test.go
@@ -61,11 +61,10 @@ func TestRealCommandLines(t *testing.T) {
 			"cmd:use flag:global arg:TOOL@VERSION=node@20",
 		},
 		{
-			// The shape that made the Rust derive's validation wrong: `[ARGS]…`
-			// before the separator and `[-- ARGS_LAST]…` after it.
-			"a task runs with arguments after a separator",
+			// Once TASK binds, every later token is forwarded through automatic ARGS.
+			"an automatic task argument forwards every trailing token",
 			[]string{"tasks", "run", "build", "extra", "--dry-run", "--", "--verbose"},
-			"cmd:tasks cmd:run arg:TASK=build arg:ARGS=extra flag:dry-run arg:ARGS_LAST=--verbose",
+			"cmd:tasks cmd:run arg:TASK=build arg:ARGS=extra arg:ARGS=--dry-run arg:ARGS=-- arg:ARGS=--verbose",
 		},
 		{
 			// `x` is a hidden alias in the spec, and hiding is a help-output concern:

--- a/go/internal/shadow/mise/tables.go
+++ b/go/internal/shadow/mise/tables.go
@@ -252,818 +252,830 @@ const (
 	FlagBootstrapRemoteAll                       uint64 = 236
 	FlagBootstrapRemoteBootstrapCommand          uint64 = 237
 	FlagBootstrapRemoteConnectTimeout            uint64 = 238
-	FlagBootstrapRemoteExclude                   uint64 = 239
-	FlagBootstrapRemoteFailFast                  uint64 = 240
-	FlagBootstrapRemoteForceDotfiles             uint64 = 241
-	FlagBootstrapRemoteHost                      uint64 = 242
-	FlagBootstrapRemoteIdentityFile              uint64 = 243
-	FlagBootstrapRemoteDryRun                    uint64 = 244
-	FlagBootstrapRemoteKeepStaging               uint64 = 245
-	FlagBootstrapRemoteMiseBin                   uint64 = 246
-	FlagBootstrapRemoteOnly                      uint64 = 247
-	FlagBootstrapRemotePort                      uint64 = 248
-	FlagBootstrapRemotePromptSecrets             uint64 = 249
-	FlagBootstrapRemoteRemoteMise                uint64 = 250
-	FlagBootstrapRemoteSkip                      uint64 = 251
-	FlagBootstrapRemoteSource                    uint64 = 252
-	FlagBootstrapRemoteSshOption                 uint64 = 253
-	FlagBootstrapRemoteTag                       uint64 = 254
-	FlagBootstrapRemoteUpdate                    uint64 = 255
-	FlagBootstrapRemoteYes                       uint64 = 256
-	ArgBootstrapRemoteTarget                     uint64 = 257
-	CmdBootstrapRepos                            uint64 = 258
-	CmdBootstrapReposApply                       uint64 = 259
-	FlagBootstrapReposApplyDryRun                uint64 = 260
-	FlagBootstrapReposApplyYes                   uint64 = 261
-	CmdBootstrapReposExec                        uint64 = 262
-	FlagBootstrapReposExecContinueOnError        uint64 = 263
-	FlagBootstrapReposExecDryRun                 uint64 = 264
-	ArgBootstrapReposExecPath                    uint64 = 265
-	ArgBootstrapReposExecCommand                 uint64 = 266
-	CmdBootstrapReposStatus                      uint64 = 267
-	FlagBootstrapReposStatusJson                 uint64 = 268
-	FlagBootstrapReposStatusMissing              uint64 = 269
-	CmdBootstrapReposUpdate                      uint64 = 270
-	FlagBootstrapReposUpdateDryRun               uint64 = 271
-	FlagBootstrapReposUpdateYes                  uint64 = 272
-	ArgBootstrapReposUpdatePath                  uint64 = 273
-	CmdBootstrapSecrets                          uint64 = 274
-	CmdBootstrapSecretsStatus                    uint64 = 275
-	FlagBootstrapSecretsStatusJson               uint64 = 276
-	FlagBootstrapSecretsStatusMissing            uint64 = 277
-	CmdBootstrapServices                         uint64 = 278
-	CmdBootstrapServicesApply                    uint64 = 279
-	FlagBootstrapServicesApplyDryRun             uint64 = 280
-	FlagBootstrapServicesApplyYes                uint64 = 281
-	CmdBootstrapServicesStatus                   uint64 = 282
-	FlagBootstrapServicesStatusJson              uint64 = 283
-	FlagBootstrapServicesStatusMissing           uint64 = 284
-	CmdBootstrapStatus                           uint64 = 285
-	FlagBootstrapStatusJson                      uint64 = 286
-	FlagBootstrapStatusMissing                   uint64 = 287
-	FlagBootstrapStatusPromptSecrets             uint64 = 288
-	CmdBootstrapSystemd                          uint64 = 289
-	CmdBootstrapSystemdApply                     uint64 = 290
-	FlagBootstrapSystemdApplyDryRun              uint64 = 291
-	FlagBootstrapSystemdApplyYes                 uint64 = 292
-	CmdBootstrapSystemdStatus                    uint64 = 293
-	FlagBootstrapSystemdStatusJson               uint64 = 294
-	FlagBootstrapSystemdStatusMissing            uint64 = 295
-	CmdBootstrapUser                             uint64 = 296
-	CmdBootstrapUserApply                        uint64 = 297
-	FlagBootstrapUserApplyDryRun                 uint64 = 298
-	FlagBootstrapUserApplyYes                    uint64 = 299
-	CmdBootstrapUserStatus                       uint64 = 300
-	FlagBootstrapUserStatusJson                  uint64 = 301
-	FlagBootstrapUserStatusMissing               uint64 = 302
-	CmdCache                                     uint64 = 303
-	CmdCacheClear                                uint64 = 304
-	FlagCacheClearOutdate                        uint64 = 305
-	FlagCacheClearTask                           uint64 = 306
-	ArgCacheClearTool                            uint64 = 307
-	CmdCachePath                                 uint64 = 308
-	CmdCachePrune                                uint64 = 309
-	FlagCachePruneVerbose                        uint64 = 310
-	FlagCachePruneDryRun                         uint64 = 311
-	ArgCachePruneTool                            uint64 = 312
-	CmdCacheTask                                 uint64 = 313
-	FlagCacheTaskJson                            uint64 = 314
-	ArgCacheTaskTask                             uint64 = 315
-	CmdCompletion                                uint64 = 316
-	FlagCompletionShell                          uint64 = 317
-	FlagCompletionIncludeBashCompletionLib       uint64 = 318
-	FlagCompletionUsage                          uint64 = 319
-	ArgCompletionShell                           uint64 = 320
-	CmdConfig                                    uint64 = 321
-	FlagConfigJson                               uint64 = 322
-	FlagConfigNoHeader                           uint64 = 323
-	FlagConfigTrackedConfigs                     uint64 = 324
-	CmdConfigGet                                 uint64 = 325
-	FlagConfigGetFile                            uint64 = 326
-	ArgConfigGetKey                              uint64 = 327
-	CmdConfigLs                                  uint64 = 328
-	FlagConfigLsJson                             uint64 = 329
-	FlagConfigLsNoHeader                         uint64 = 330
-	FlagConfigLsTrackedConfigs                   uint64 = 331
-	CmdConfigSet                                 uint64 = 332
-	FlagConfigSetFile                            uint64 = 333
-	FlagConfigSetType                            uint64 = 334
-	ArgConfigSetKey                              uint64 = 335
-	ArgConfigSetValue                            uint64 = 336
-	CmdCurrent                                   uint64 = 337
-	ArgCurrentPlugin                             uint64 = 338
-	CmdDeactivate                                uint64 = 339
-	CmdDirenv                                    uint64 = 340
-	CmdDirenvActivate                            uint64 = 341
-	CmdDirenvEnvrc                               uint64 = 342
-	CmdDirenvExec                                uint64 = 343
-	CmdDotfiles                                  uint64 = 344
-	CmdDotfilesAdd                               uint64 = 345
-	FlagDotfilesAddForce                         uint64 = 346
-	FlagDotfilesAddGlobal                        uint64 = 347
-	FlagDotfilesAddLocal                         uint64 = 348
-	FlagDotfilesAddMode                          uint64 = 349
-	FlagDotfilesAddDryRun                        uint64 = 350
-	FlagDotfilesAddNoApply                       uint64 = 351
-	FlagDotfilesAddPath                          uint64 = 352
-	FlagDotfilesAddSource                        uint64 = 353
-	FlagDotfilesAddYes                           uint64 = 354
-	ArgDotfilesAddTarget                         uint64 = 355
-	CmdDotfilesApply                             uint64 = 356
-	FlagDotfilesApplyForce                       uint64 = 357
-	FlagDotfilesApplyDryRun                      uint64 = 358
-	FlagDotfilesApplyYes                         uint64 = 359
-	ArgDotfilesApplyTarget                       uint64 = 360
-	CmdDotfilesEdit                              uint64 = 361
-	FlagDotfilesEditApply                        uint64 = 362
-	FlagDotfilesEditMode                         uint64 = 363
-	FlagDotfilesEditSource                       uint64 = 364
-	FlagDotfilesEditYes                          uint64 = 365
-	ArgDotfilesEditTarget                        uint64 = 366
-	CmdDotfilesStatus                            uint64 = 367
-	FlagDotfilesStatusJson                       uint64 = 368
-	FlagDotfilesStatusMissing                    uint64 = 369
-	ArgDotfilesStatusTarget                      uint64 = 370
-	CmdDotfilesUnapply                           uint64 = 371
-	FlagDotfilesUnapplyForce                     uint64 = 372
-	FlagDotfilesUnapplyDryRun                    uint64 = 373
-	FlagDotfilesUnapplyYes                       uint64 = 374
-	ArgDotfilesUnapplyTarget                     uint64 = 375
-	CmdDoctor                                    uint64 = 376
-	FlagDoctorJson                               uint64 = 377
-	CmdDoctorPath                                uint64 = 378
-	FlagDoctorPathFull                           uint64 = 379
-	CmdEn                                        uint64 = 380
-	FlagEnShell                                  uint64 = 381
-	ArgEnDir                                     uint64 = 382
-	CmdEnv                                       uint64 = 383
-	FlagEnvDotenv                                uint64 = 384
-	FlagEnvJson                                  uint64 = 385
-	FlagEnvShell                                 uint64 = 386
-	FlagEnvJsonExtended                          uint64 = 387
-	FlagEnvRedacted                              uint64 = 388
-	FlagEnvValues                                uint64 = 389
-	ArgEnvToolVersion                            uint64 = 390
-	CmdExec                                      uint64 = 391
-	FlagExecCommand                              uint64 = 392
-	FlagExecJobs                                 uint64 = 393
-	FlagExecAllowEnv                             uint64 = 394
-	FlagExecAllowNet                             uint64 = 395
-	FlagExecAllowRead                            uint64 = 396
-	FlagExecAllowWrite                           uint64 = 397
-	FlagExecDenyAll                              uint64 = 398
-	FlagExecDenyEnv                              uint64 = 399
-	FlagExecDenyNet                              uint64 = 400
-	FlagExecDenyRead                             uint64 = 401
-	FlagExecDenyWrite                            uint64 = 402
-	FlagExecFreshEnv                             uint64 = 403
-	FlagExecNoDeps                               uint64 = 404
-	FlagExecRaw                                  uint64 = 405
-	ArgExecToolVersion                           uint64 = 406
-	ArgExecCommand                               uint64 = 407
-	CmdFmt                                       uint64 = 408
-	FlagFmtAll                                   uint64 = 409
-	FlagFmtCheck                                 uint64 = 410
-	FlagFmtStdin                                 uint64 = 411
-	CmdGenerate                                  uint64 = 412
-	CmdGenerateBootstrap                         uint64 = 413
-	FlagGenerateBootstrapLocalize                uint64 = 414
-	FlagGenerateBootstrapVersion                 uint64 = 415
-	FlagGenerateBootstrapWrite                   uint64 = 416
-	FlagGenerateBootstrapLocalizedDir            uint64 = 417
-	CmdGenerateConfig                            uint64 = 418
-	FlagGenerateConfigGlobal                     uint64 = 419
-	FlagGenerateConfigDryRun                     uint64 = 420
-	FlagGenerateConfigToolVersions               uint64 = 421
-	ArgGenerateConfigPath                        uint64 = 422
-	CmdGenerateDevcontainer                      uint64 = 423
-	FlagGenerateDevcontainerImage                uint64 = 424
-	FlagGenerateDevcontainerMountMiseData        uint64 = 425
-	FlagGenerateDevcontainerName                 uint64 = 426
-	FlagGenerateDevcontainerWrite                uint64 = 427
-	CmdGenerateGitPreCommit                      uint64 = 428
-	FlagGenerateGitPreCommitTask                 uint64 = 429
-	FlagGenerateGitPreCommitWrite                uint64 = 430
-	FlagGenerateGitPreCommitHook                 uint64 = 431
-	CmdGenerateGithubAction                      uint64 = 432
-	FlagGenerateGithubActionTask                 uint64 = 433
-	FlagGenerateGithubActionWrite                uint64 = 434
-	FlagGenerateGithubActionName                 uint64 = 435
-	CmdGenerateTaskDocs                          uint64 = 436
-	FlagGenerateTaskDocsInject                   uint64 = 437
-	FlagGenerateTaskDocsIndex                    uint64 = 438
-	FlagGenerateTaskDocsMulti                    uint64 = 439
-	FlagGenerateTaskDocsOutput                   uint64 = 440
-	FlagGenerateTaskDocsRoot                     uint64 = 441
-	FlagGenerateTaskDocsStyle                    uint64 = 442
-	CmdGenerateTaskStubs                         uint64 = 443
-	FlagGenerateTaskStubsDir                     uint64 = 444
-	FlagGenerateTaskStubsMiseBin                 uint64 = 445
-	CmdGenerateToolStub                          uint64 = 446
-	FlagGenerateToolStubBin                      uint64 = 447
-	FlagGenerateToolStubBootstrap                uint64 = 448
-	FlagGenerateToolStubBootstrapVersion         uint64 = 449
-	FlagGenerateToolStubFetch                    uint64 = 450
-	FlagGenerateToolStubHttp                     uint64 = 451
-	FlagGenerateToolStubLock                     uint64 = 452
-	FlagGenerateToolStubPlatformBin              uint64 = 453
-	FlagGenerateToolStubPlatformUrl              uint64 = 454
-	FlagGenerateToolStubSkipDownload             uint64 = 455
-	FlagGenerateToolStubUrl                      uint64 = 456
-	FlagGenerateToolStubVersion                  uint64 = 457
-	ArgGenerateToolStubOutput                    uint64 = 458
-	CmdGithub                                    uint64 = 459
-	CmdGithubToken                               uint64 = 460
-	FlagGithubTokenOauth                         uint64 = 461
-	FlagGithubTokenRaw                           uint64 = 462
-	FlagGithubTokenRefresh                       uint64 = 463
-	FlagGithubTokenUnmask                        uint64 = 464
-	ArgGithubTokenHost                           uint64 = 465
-	CmdGlobal                                    uint64 = 466
-	FlagGlobalFuzzy                              uint64 = 467
-	FlagGlobalPath                               uint64 = 468
-	FlagGlobalPin                                uint64 = 469
-	FlagGlobalRemove                             uint64 = 470
-	ArgGlobalToolVersion                         uint64 = 471
-	CmdHookEnv                                   uint64 = 472
-	FlagHookEnvForce                             uint64 = 473
-	FlagHookEnvQuiet                             uint64 = 474
-	FlagHookEnvShell                             uint64 = 475
-	FlagHookEnvReason                            uint64 = 476
-	FlagHookEnvStatus                            uint64 = 477
-	CmdHookNotFound                              uint64 = 478
-	FlagHookNotFoundShell                        uint64 = 479
-	ArgHookNotFoundBin                           uint64 = 480
-	CmdImplode                                   uint64 = 481
-	FlagImplodeDryRun                            uint64 = 482
-	FlagImplodeConfig                            uint64 = 483
-	CmdEdit                                      uint64 = 484
-	FlagEditGlobal                               uint64 = 485
-	FlagEditDryRun                               uint64 = 486
-	FlagEditToolVersions                         uint64 = 487
-	ArgEditPath                                  uint64 = 488
-	CmdInstall                                   uint64 = 489
-	FlagInstallForce                             uint64 = 490
-	FlagInstallJobs                              uint64 = 491
-	FlagInstallDryRun                            uint64 = 492
-	FlagInstallVerbose                           uint64 = 493
-	FlagInstallDryRunCode                        uint64 = 494
-	FlagInstallMinimumReleaseAge                 uint64 = 495
-	FlagInstallMonorepo                          uint64 = 496
-	FlagInstallRaw                               uint64 = 497
-	FlagInstallShared                            uint64 = 498
-	FlagInstallSystem                            uint64 = 499
-	ArgInstallToolVersion                        uint64 = 500
-	CmdInstallInto                               uint64 = 501
-	ArgInstallIntoToolVersion                    uint64 = 502
-	ArgInstallIntoPath                           uint64 = 503
-	CmdLatest                                    uint64 = 504
-	FlagLatestInstalled                          uint64 = 505
-	FlagLatestMinimumReleaseAge                  uint64 = 506
-	ArgLatestToolVersion                         uint64 = 507
-	ArgLatestAsdfVersion                         uint64 = 508
-	CmdLink                                      uint64 = 509
-	FlagLinkForce                                uint64 = 510
-	ArgLinkToolVersion                           uint64 = 511
-	ArgLinkPath                                  uint64 = 512
-	CmdLocal                                     uint64 = 513
-	FlagLocalParent                              uint64 = 514
-	FlagLocalFuzzy                               uint64 = 515
-	FlagLocalPath                                uint64 = 516
-	FlagLocalPin                                 uint64 = 517
-	FlagLocalRemove                              uint64 = 518
-	ArgLocalToolVersion                          uint64 = 519
-	CmdLock                                      uint64 = 520
-	FlagLockGlobal                               uint64 = 521
-	FlagLockJobs                                 uint64 = 522
-	FlagLockDryRun                               uint64 = 523
-	FlagLockPlatform                             uint64 = 524
-	FlagLockBump                                 uint64 = 525
-	FlagLockJson                                 uint64 = 526
-	FlagLockLocal                                uint64 = 527
-	FlagLockMinimumReleaseAge                    uint64 = 528
-	ArgLockTool                                  uint64 = 529
-	CmdLs                                        uint64 = 530
-	FlagLsCurrent                                uint64 = 531
-	FlagLsGlobal                                 uint64 = 532
-	FlagLsInstalled                              uint64 = 533
-	FlagLsJson                                   uint64 = 534
-	FlagLsLocal                                  uint64 = 535
-	FlagLsMissing                                uint64 = 536
-	FlagLsOffline                                uint64 = 537
-	FlagLsPlugin                                 uint64 = 538
-	FlagLsAllSources                             uint64 = 539
-	FlagLsMonorepo                               uint64 = 540
-	FlagLsNoHeader                               uint64 = 541
-	FlagLsOutdated                               uint64 = 542
-	FlagLsPrefix                                 uint64 = 543
-	FlagLsPrunable                               uint64 = 544
-	ArgLsInstalledTool                           uint64 = 545
-	CmdLsRemote                                  uint64 = 546
-	FlagLsRemoteAll                              uint64 = 547
-	FlagLsRemoteMinimumReleaseAge                uint64 = 548
-	FlagLsRemoteJson                             uint64 = 549
-	FlagLsRemoteNoVersionsHost                   uint64 = 550
-	FlagLsRemotePrerelease                       uint64 = 551
-	FlagLsRemoteStrictMetadata                   uint64 = 552
-	ArgLsRemoteToolVersion                       uint64 = 553
-	ArgLsRemotePrefix                            uint64 = 554
-	CmdMcp                                       uint64 = 555
-	CmdOci                                       uint64 = 556
-	CmdOciBuild                                  uint64 = 557
-	FlagOciBuildCopy                             uint64 = 558
-	FlagOciBuildOutput                           uint64 = 559
-	FlagOciBuildFrom                             uint64 = 560
-	FlagOciBuildIncludeGlobal                    uint64 = 561
-	FlagOciBuildTag                              uint64 = 562
-	FlagOciBuildMountPoint                       uint64 = 563
-	FlagOciBuildNoMise                           uint64 = 564
-	FlagOciBuildOwner                            uint64 = 565
-	CmdOciPush                                   uint64 = 566
-	FlagOciPushCacheFrom                         uint64 = 567
-	FlagOciPushFrom                              uint64 = 568
-	FlagOciPushImageDir                          uint64 = 569
-	FlagOciPushIncludeGlobal                     uint64 = 570
-	FlagOciPushMountPoint                        uint64 = 571
-	FlagOciPushNoCache                           uint64 = 572
-	FlagOciPushNoMise                            uint64 = 573
-	FlagOciPushOwner                             uint64 = 574
-	FlagOciPushUpdateIndex                       uint64 = 575
-	ArgOciPushRef                                uint64 = 576
-	CmdOciRun                                    uint64 = 577
-	FlagOciRunEngine                             uint64 = 578
-	FlagOciRunFrom                               uint64 = 579
-	FlagOciRunImageDir                           uint64 = 580
-	FlagOciRunIncludeGlobal                      uint64 = 581
-	FlagOciRunKeep                               uint64 = 582
-	FlagOciRunMountPoint                         uint64 = 583
-	FlagOciRunNoMise                             uint64 = 584
-	FlagOciRunOwner                              uint64 = 585
-	FlagOciRunVolume                             uint64 = 586
-	FlagOciRunEnv                                uint64 = 587
-	FlagOciRunInteractive                        uint64 = 588
-	FlagOciRunTty                                uint64 = 589
-	FlagOciRunWorkdir                            uint64 = 590
-	ArgOciRunCmd                                 uint64 = 591
-	CmdOutdated                                  uint64 = 592
-	FlagOutdatedJson                             uint64 = 593
-	FlagOutdatedBump                             uint64 = 594
-	FlagOutdatedInactive                         uint64 = 595
-	FlagOutdatedLocal                            uint64 = 596
-	FlagOutdatedMonorepo                         uint64 = 597
-	FlagOutdatedNoHeader                         uint64 = 598
-	ArgOutdatedToolVersion                       uint64 = 599
-	CmdPatrons                                   uint64 = 600
-	FlagPatronsJson                              uint64 = 601
-	FlagPatronsRefresh                           uint64 = 602
-	CmdPlugins                                   uint64 = 603
-	FlagPluginsAll                               uint64 = 604
-	FlagPluginsCore                              uint64 = 605
-	FlagPluginsUrls                              uint64 = 606
-	FlagPluginsRefs                              uint64 = 607
-	FlagPluginsUser                              uint64 = 608
-	CmdPluginsInstall                            uint64 = 609
-	FlagPluginsInstallAll                        uint64 = 610
-	FlagPluginsInstallForce                      uint64 = 611
-	FlagPluginsInstallJobs                       uint64 = 612
-	FlagPluginsInstallVerbose                    uint64 = 613
-	ArgPluginsInstallNewPlugin                   uint64 = 614
-	ArgPluginsInstallGitUrl                      uint64 = 615
-	ArgPluginsInstallRest                        uint64 = 616
-	CmdPluginsLink                               uint64 = 617
-	FlagPluginsLinkForce                         uint64 = 618
-	ArgPluginsLinkName                           uint64 = 619
-	ArgPluginsLinkDir                            uint64 = 620
-	CmdPluginsLs                                 uint64 = 621
-	FlagPluginsLsAll                             uint64 = 622
-	FlagPluginsLsCore                            uint64 = 623
-	FlagPluginsLsOutdated                        uint64 = 624
-	FlagPluginsLsUrls                            uint64 = 625
-	FlagPluginsLsRefs                            uint64 = 626
-	FlagPluginsLsUser                            uint64 = 627
-	CmdPluginsLsRemote                           uint64 = 628
-	FlagPluginsLsRemoteUrls                      uint64 = 629
-	FlagPluginsLsRemoteOnlyNames                 uint64 = 630
-	CmdPluginsUninstall                          uint64 = 631
-	FlagPluginsUninstallAll                      uint64 = 632
-	FlagPluginsUninstallPurge                    uint64 = 633
-	ArgPluginsUninstallPlugin                    uint64 = 634
-	CmdPluginsUpdate                             uint64 = 635
-	FlagPluginsUpdateJobs                        uint64 = 636
-	ArgPluginsUpdatePlugin                       uint64 = 637
-	CmdDeps                                      uint64 = 638
-	FlagDepsExplain                              uint64 = 639
-	FlagDepsForce                                uint64 = 640
-	FlagDepsDryRun                               uint64 = 641
-	FlagDepsList                                 uint64 = 642
-	FlagDepsMonorepo                             uint64 = 643
-	FlagDepsOnly                                 uint64 = 644
-	FlagDepsSkip                                 uint64 = 645
-	ArgDepsProvider                              uint64 = 646
-	CmdDepsAdd                                   uint64 = 647
-	FlagDepsAddDev                               uint64 = 648
-	ArgDepsAddPackages                           uint64 = 649
-	CmdDepsInstall                               uint64 = 650
-	FlagDepsInstallExplain                       uint64 = 651
-	FlagDepsInstallForce                         uint64 = 652
-	FlagDepsInstallDryRun                        uint64 = 653
-	FlagDepsInstallList                          uint64 = 654
-	FlagDepsInstallMonorepo                      uint64 = 655
-	FlagDepsInstallOnly                          uint64 = 656
-	FlagDepsInstallSkip                          uint64 = 657
-	ArgDepsInstallProvider                       uint64 = 658
-	CmdDepsRemove                                uint64 = 659
-	ArgDepsRemovePackages                        uint64 = 660
-	CmdPrune                                     uint64 = 661
-	FlagPruneDryRun                              uint64 = 662
-	FlagPruneConfigs                             uint64 = 663
-	FlagPruneDryRunCode                          uint64 = 664
-	FlagPruneMonorepo                            uint64 = 665
-	FlagPruneTools                               uint64 = 666
-	ArgPruneInstalledTool                        uint64 = 667
-	CmdRegistry                                  uint64 = 668
-	FlagRegistryBackend                          uint64 = 669
-	FlagRegistryComplete                         uint64 = 670
-	FlagRegistryHideAliased                      uint64 = 671
-	FlagRegistryJson                             uint64 = 672
-	FlagRegistrySecurity                         uint64 = 673
-	ArgRegistryName                              uint64 = 674
-	CmdRenderHelp                                uint64 = 675
-	CmdReshim                                    uint64 = 676
-	FlagReshimForce                              uint64 = 677
-	ArgReshimTool                                uint64 = 678
-	ArgReshimVersion                             uint64 = 679
-	CmdRun                                       uint64 = 680
-	FlagRunAffected                              uint64 = 681
-	FlagRunAffectedBase                          uint64 = 682
-	FlagRunAffectedExplain                       uint64 = 683
-	FlagRunAffectedHead                          uint64 = 684
-	FlagRunAffectedJson                          uint64 = 685
-	FlagRunContinueOnError                       uint64 = 686
-	FlagRunCd                                    uint64 = 687
-	FlagRunForce                                 uint64 = 688
-	FlagRunJobs                                  uint64 = 689
-	FlagRunDryRun                                uint64 = 690
-	FlagRunOutput                                uint64 = 691
-	FlagRunQuiet                                 uint64 = 692
-	FlagRunRaw                                   uint64 = 693
-	FlagRunShell                                 uint64 = 694
-	FlagRunSilent                                uint64 = 695
-	FlagRunTool                                  uint64 = 696
-	FlagRunAllowEnv                              uint64 = 697
-	FlagRunAllowNet                              uint64 = 698
-	FlagRunAllowRead                             uint64 = 699
-	FlagRunAllowWrite                            uint64 = 700
-	FlagRunDenyAll                               uint64 = 701
-	FlagRunDenyEnv                               uint64 = 702
-	FlagRunDenyNet                               uint64 = 703
-	FlagRunDenyRead                              uint64 = 704
-	FlagRunDenyWrite                             uint64 = 705
-	FlagRunFreshEnv                              uint64 = 706
-	FlagRunNoCache                               uint64 = 707
-	FlagRunNoDeps                                uint64 = 708
-	FlagRunNoTimings                             uint64 = 709
-	FlagRunSkipDeps                              uint64 = 710
-	FlagRunSkipTools                             uint64 = 711
-	FlagRunTaskCache                             uint64 = 712
-	FlagRunTaskCacheExplain                      uint64 = 713
-	FlagRunTaskCacheExplainJson                  uint64 = 714
-	FlagRunTaskCacheStats                        uint64 = 715
-	FlagRunTimeout                               uint64 = 716
-	FlagRunTimings                               uint64 = 717
-	CmdSearch                                    uint64 = 718
-	FlagSearchInteractive                        uint64 = 719
-	FlagSearchMatchType                          uint64 = 720
-	FlagSearchNoHeader                           uint64 = 721
-	ArgSearchName                                uint64 = 722
-	CmdSelfUpdate                                uint64 = 723
-	FlagSelfUpdateForce                          uint64 = 724
-	FlagSelfUpdateYes                            uint64 = 725
-	FlagSelfUpdateNoPlugins                      uint64 = 726
-	ArgSelfUpdateVersion                         uint64 = 727
-	CmdSet                                       uint64 = 728
-	FlagSetEnv                                   uint64 = 729
-	FlagSetGlobal                                uint64 = 730
-	FlagSetAgeEncrypt                            uint64 = 731
-	FlagSetAgeKeyFile                            uint64 = 732
-	FlagSetAgeRecipient                          uint64 = 733
-	FlagSetAgeSshRecipient                       uint64 = 734
-	FlagSetComplete                              uint64 = 735
-	FlagSetFile                                  uint64 = 736
-	FlagSetNoRedact                              uint64 = 737
-	FlagSetPrompt                                uint64 = 738
-	FlagSetRemove                                uint64 = 739
-	FlagSetStdin                                 uint64 = 740
-	ArgSetEnvVar                                 uint64 = 741
-	CmdSettings                                  uint64 = 742
-	FlagSettingsAll                              uint64 = 743
-	FlagSettingsJson                             uint64 = 744
-	FlagSettingsLocal                            uint64 = 745
-	FlagSettingsToml                             uint64 = 746
-	FlagSettingsComplete                         uint64 = 747
-	FlagSettingsJsonExtended                     uint64 = 748
-	ArgSettingsSetting                           uint64 = 749
-	ArgSettingsValue                             uint64 = 750
-	CmdSettingsAdd                               uint64 = 751
-	FlagSettingsAddLocal                         uint64 = 752
-	ArgSettingsAddSetting                        uint64 = 753
-	ArgSettingsAddValue                          uint64 = 754
-	CmdSettingsGet                               uint64 = 755
-	FlagSettingsGetLocal                         uint64 = 756
-	ArgSettingsGetSetting                        uint64 = 757
-	CmdSettingsLs                                uint64 = 758
-	FlagSettingsLsAll                            uint64 = 759
-	FlagSettingsLsJson                           uint64 = 760
-	FlagSettingsLsLocal                          uint64 = 761
-	FlagSettingsLsToml                           uint64 = 762
-	FlagSettingsLsComplete                       uint64 = 763
-	FlagSettingsLsJsonExtended                   uint64 = 764
-	ArgSettingsLsSetting                         uint64 = 765
-	CmdSettingsSet                               uint64 = 766
-	FlagSettingsSetLocal                         uint64 = 767
-	ArgSettingsSetSetting                        uint64 = 768
-	ArgSettingsSetValue                          uint64 = 769
-	CmdSettingsUnset                             uint64 = 770
-	FlagSettingsUnsetLocal                       uint64 = 771
-	ArgSettingsUnsetKey                          uint64 = 772
-	CmdShell                                     uint64 = 773
-	FlagShellJobs                                uint64 = 774
-	FlagShellUnset                               uint64 = 775
-	FlagShellRaw                                 uint64 = 776
-	ArgShellToolVersion                          uint64 = 777
-	CmdShellAlias                                uint64 = 778
-	FlagShellAliasNoHeader                       uint64 = 779
-	CmdShellAliasGet                             uint64 = 780
-	ArgShellAliasGetShellAlias                   uint64 = 781
-	CmdShellAliasLs                              uint64 = 782
-	FlagShellAliasLsNoHeader                     uint64 = 783
-	CmdShellAliasSet                             uint64 = 784
-	ArgShellAliasSetShellAlias                   uint64 = 785
-	ArgShellAliasSetCommand                      uint64 = 786
-	CmdShellAliasUnset                           uint64 = 787
-	ArgShellAliasUnsetShellAlias                 uint64 = 788
-	CmdSponsors                                  uint64 = 789
-	CmdSync                                      uint64 = 790
-	CmdSyncNode                                  uint64 = 791
-	FlagSyncNodeBrew                             uint64 = 792
-	FlagSyncNodeNodenv                           uint64 = 793
-	FlagSyncNodeNvm                              uint64 = 794
-	CmdSyncPython                                uint64 = 795
-	FlagSyncPythonPyenv                          uint64 = 796
-	FlagSyncPythonUv                             uint64 = 797
-	CmdSyncRuby                                  uint64 = 798
-	FlagSyncRubyBrew                             uint64 = 799
-	CmdTasks                                     uint64 = 800
-	FlagTasksGlobal                              uint64 = 801
-	FlagTasksJson                                uint64 = 802
-	FlagTasksLocal                               uint64 = 803
-	FlagTasksExtended                            uint64 = 804
-	FlagTasksAll                                 uint64 = 805
-	FlagTasksComplete                            uint64 = 806
-	FlagTasksHidden                              uint64 = 807
-	FlagTasksNameOnly                            uint64 = 808
-	FlagTasksNoHeader                            uint64 = 809
-	FlagTasksSort                                uint64 = 810
-	FlagTasksSortOrder                           uint64 = 811
-	FlagTasksUsage                               uint64 = 812
-	ArgTasksTask                                 uint64 = 813
-	CmdTasksAdd                                  uint64 = 814
-	FlagTasksAddAlias                            uint64 = 815
-	FlagTasksAddDepends                          uint64 = 816
-	FlagTasksAddDir                              uint64 = 817
-	FlagTasksAddFile                             uint64 = 818
-	FlagTasksAddHide                             uint64 = 819
-	FlagTasksAddQuiet                            uint64 = 820
-	FlagTasksAddRaw                              uint64 = 821
-	FlagTasksAddSources                          uint64 = 822
-	FlagTasksAddWaitFor                          uint64 = 823
-	FlagTasksAddDependsPost                      uint64 = 824
-	FlagTasksAddDescription                      uint64 = 825
-	FlagTasksAddOutputs                          uint64 = 826
-	FlagTasksAddRunWindows                       uint64 = 827
-	FlagTasksAddShell                            uint64 = 828
-	FlagTasksAddSilent                           uint64 = 829
-	ArgTasksAddTask                              uint64 = 830
-	ArgTasksAddRun                               uint64 = 831
-	CmdTasksDeps                                 uint64 = 832
-	FlagTasksDepsCompact                         uint64 = 833
-	FlagTasksDepsDot                             uint64 = 834
-	FlagTasksDepsHidden                          uint64 = 835
-	ArgTasksDepsTasks                            uint64 = 836
-	CmdTasksEdit                                 uint64 = 837
-	FlagTasksEditPath                            uint64 = 838
-	ArgTasksEditTask                             uint64 = 839
-	CmdTasksGraph                                uint64 = 840
-	FlagTasksGraphJson                           uint64 = 841
-	FlagTasksGraphExplain                        uint64 = 842
-	FlagTasksGraphNoHeader                       uint64 = 843
-	CmdTasksInfo                                 uint64 = 844
-	FlagTasksInfoJson                            uint64 = 845
-	ArgTasksInfoTask                             uint64 = 846
-	CmdTasksLs                                   uint64 = 847
-	FlagTasksLsGlobal                            uint64 = 848
-	FlagTasksLsJson                              uint64 = 849
-	FlagTasksLsLocal                             uint64 = 850
-	FlagTasksLsExtended                          uint64 = 851
-	FlagTasksLsAll                               uint64 = 852
-	FlagTasksLsComplete                          uint64 = 853
-	FlagTasksLsHidden                            uint64 = 854
-	FlagTasksLsNameOnly                          uint64 = 855
-	FlagTasksLsNoHeader                          uint64 = 856
-	FlagTasksLsSort                              uint64 = 857
-	FlagTasksLsSortOrder                         uint64 = 858
-	FlagTasksLsUsage                             uint64 = 859
-	CmdTasksRun                                  uint64 = 860
-	FlagTasksRunAffected                         uint64 = 861
-	FlagTasksRunAffectedBase                     uint64 = 862
-	FlagTasksRunAffectedExplain                  uint64 = 863
-	FlagTasksRunAffectedHead                     uint64 = 864
-	FlagTasksRunAffectedJson                     uint64 = 865
-	FlagTasksRunContinueOnError                  uint64 = 866
-	FlagTasksRunCd                               uint64 = 867
-	FlagTasksRunForce                            uint64 = 868
-	FlagTasksRunJobs                             uint64 = 869
-	FlagTasksRunDryRun                           uint64 = 870
-	FlagTasksRunOutput                           uint64 = 871
-	FlagTasksRunQuiet                            uint64 = 872
-	FlagTasksRunRaw                              uint64 = 873
-	FlagTasksRunShell                            uint64 = 874
-	FlagTasksRunSilent                           uint64 = 875
-	FlagTasksRunTool                             uint64 = 876
-	FlagTasksRunAllowEnv                         uint64 = 877
-	FlagTasksRunAllowNet                         uint64 = 878
-	FlagTasksRunAllowRead                        uint64 = 879
-	FlagTasksRunAllowWrite                       uint64 = 880
-	FlagTasksRunDenyAll                          uint64 = 881
-	FlagTasksRunDenyEnv                          uint64 = 882
-	FlagTasksRunDenyNet                          uint64 = 883
-	FlagTasksRunDenyRead                         uint64 = 884
-	FlagTasksRunDenyWrite                        uint64 = 885
-	FlagTasksRunFreshEnv                         uint64 = 886
-	FlagTasksRunNoCache                          uint64 = 887
-	FlagTasksRunNoDeps                           uint64 = 888
-	FlagTasksRunNoTimings                        uint64 = 889
-	FlagTasksRunSkipDeps                         uint64 = 890
-	FlagTasksRunSkipTools                        uint64 = 891
-	FlagTasksRunTaskCache                        uint64 = 892
-	FlagTasksRunTaskCacheExplain                 uint64 = 893
-	FlagTasksRunTaskCacheExplainJson             uint64 = 894
-	FlagTasksRunTaskCacheStats                   uint64 = 895
-	FlagTasksRunTimeout                          uint64 = 896
-	FlagTasksRunTimings                          uint64 = 897
-	ArgTasksRunTask                              uint64 = 898
-	ArgTasksRunArgs                              uint64 = 899
-	ArgTasksRunArgsLast                          uint64 = 900
-	CmdTasksValidate                             uint64 = 901
-	FlagTasksValidateErrorsOnly                  uint64 = 902
-	FlagTasksValidateJson                        uint64 = 903
-	ArgTasksValidateTasks                        uint64 = 904
-	CmdTestTool                                  uint64 = 905
-	FlagTestToolAll                              uint64 = 906
-	FlagTestToolJobs                             uint64 = 907
-	FlagTestToolAllConfig                        uint64 = 908
-	FlagTestToolIncludeNonDefined                uint64 = 909
-	FlagTestToolRaw                              uint64 = 910
-	ArgTestToolTools                             uint64 = 911
-	CmdToken                                     uint64 = 912
-	CmdTokenForgejo                              uint64 = 913
-	FlagTokenForgejoUnmask                       uint64 = 914
-	ArgTokenForgejoHost                          uint64 = 915
-	CmdTokenGithub                               uint64 = 916
-	FlagTokenGithubOauth                         uint64 = 917
-	FlagTokenGithubRaw                           uint64 = 918
-	FlagTokenGithubRefresh                       uint64 = 919
-	FlagTokenGithubUnmask                        uint64 = 920
-	ArgTokenGithubHost                           uint64 = 921
-	CmdTokenGitlab                               uint64 = 922
-	FlagTokenGitlabUnmask                        uint64 = 923
-	ArgTokenGitlabHost                           uint64 = 924
-	CmdTool                                      uint64 = 925
-	FlagToolJson                                 uint64 = 926
-	FlagToolActive                               uint64 = 927
-	FlagToolBackend                              uint64 = 928
-	FlagToolConfigSource                         uint64 = 929
-	FlagToolDescription                          uint64 = 930
-	FlagToolInstalled                            uint64 = 931
-	FlagToolRequested                            uint64 = 932
-	FlagToolToolOptions                          uint64 = 933
-	ArgToolTool                                  uint64 = 934
-	CmdToolStub                                  uint64 = 935
-	ArgToolStubFile                              uint64 = 936
-	ArgToolStubArgs                              uint64 = 937
-	CmdTrust                                     uint64 = 938
-	FlagTrustAll                                 uint64 = 939
-	FlagTrustIgnore                              uint64 = 940
-	FlagTrustShow                                uint64 = 941
-	FlagTrustUntrust                             uint64 = 942
-	ArgTrustConfigFile                           uint64 = 943
-	CmdUninstall                                 uint64 = 944
-	FlagUninstallAll                             uint64 = 945
-	FlagUninstallDryRun                          uint64 = 946
-	FlagUninstallDryRunCode                      uint64 = 947
-	ArgUninstallInstalledToolVersion             uint64 = 948
-	CmdUnset                                     uint64 = 949
-	FlagUnsetFile                                uint64 = 950
-	FlagUnsetGlobal                              uint64 = 951
-	ArgUnsetEnvKey                               uint64 = 952
-	CmdUntrust                                   uint64 = 953
-	ArgUntrustConfigFile                         uint64 = 954
-	CmdUnuse                                     uint64 = 955
-	FlagUnuseEnv                                 uint64 = 956
-	FlagUnuseGlobal                              uint64 = 957
-	FlagUnusePath                                uint64 = 958
-	FlagUnuseNoPrune                             uint64 = 959
-	ArgUnuseInstalledToolVersion                 uint64 = 960
-	CmdUpgrade                                   uint64 = 961
-	FlagUpgradeInteractive                       uint64 = 962
-	FlagUpgradeJobs                              uint64 = 963
-	FlagUpgradeBump                              uint64 = 964
-	FlagUpgradeDryRun                            uint64 = 965
-	FlagUpgradeExclude                           uint64 = 966
-	FlagUpgradeDryRunCode                        uint64 = 967
-	FlagUpgradeInactive                          uint64 = 968
-	FlagUpgradeLocal                             uint64 = 969
-	FlagUpgradeMinimumReleaseAge                 uint64 = 970
-	FlagUpgradeMonorepo                          uint64 = 971
-	FlagUpgradeNoPrune                           uint64 = 972
-	FlagUpgradeRaw                               uint64 = 973
-	ArgUpgradeInstalledToolVersion               uint64 = 974
-	CmdUsage                                     uint64 = 975
-	CmdUse                                       uint64 = 976
-	FlagUseEnv                                   uint64 = 977
-	FlagUseForce                                 uint64 = 978
-	FlagUseGlobal                                uint64 = 979
-	FlagUseJobs                                  uint64 = 980
-	FlagUseDryRun                                uint64 = 981
-	FlagUsePath                                  uint64 = 982
-	FlagUseDryRunCode                            uint64 = 983
-	FlagUseFuzzy                                 uint64 = 984
-	FlagUseMinimumReleaseAge                     uint64 = 985
-	FlagUsePin                                   uint64 = 986
-	FlagUseRaw                                   uint64 = 987
-	FlagUseRemove                                uint64 = 988
-	ArgUseToolVersion                            uint64 = 989
-	CmdVersion                                   uint64 = 990
-	FlagVersionJson                              uint64 = 991
-	CmdWatch                                     uint64 = 992
-	FlagWatchTaskFlag                            uint64 = 993
-	FlagWatchGlob                                uint64 = 994
-	FlagWatchSkipDeps                            uint64 = 995
-	FlagWatchWatch                               uint64 = 996
-	FlagWatchWatchNonRecursive                   uint64 = 997
-	FlagWatchWatchFile                           uint64 = 998
-	FlagWatchClear                               uint64 = 999
-	FlagWatchOnBusyUpdate                        uint64 = 1000
-	FlagWatchRestart                             uint64 = 1001
-	FlagWatchSignal                              uint64 = 1002
-	FlagWatchStopSignal                          uint64 = 1003
-	FlagWatchStopTimeout                         uint64 = 1004
-	FlagWatchMapSignal                           uint64 = 1005
-	FlagWatchDebounce                            uint64 = 1006
-	FlagWatchStdinQuit                           uint64 = 1007
-	FlagWatchNoVcsIgnore                         uint64 = 1008
-	FlagWatchNoProjectIgnore                     uint64 = 1009
-	FlagWatchNoGlobalIgnore                      uint64 = 1010
-	FlagWatchNoDefaultIgnore                     uint64 = 1011
-	FlagWatchNoDiscoverIgnore                    uint64 = 1012
-	FlagWatchIgnoreNothing                       uint64 = 1013
-	FlagWatchPostpone                            uint64 = 1014
-	FlagWatchDelayRun                            uint64 = 1015
-	FlagWatchPoll                                uint64 = 1016
-	FlagWatchShell                               uint64 = 1017
-	FlagWatchN                                   uint64 = 1018
-	FlagWatchEmitEventsTo                        uint64 = 1019
-	FlagWatchOnlyEmitEvents                      uint64 = 1020
-	FlagWatchEnv                                 uint64 = 1021
-	FlagWatchWrapProcess                         uint64 = 1022
-	FlagWatchNotify                              uint64 = 1023
-	FlagWatchColor                               uint64 = 1024
-	FlagWatchTimings                             uint64 = 1025
-	FlagWatchQuiet                               uint64 = 1026
-	FlagWatchBell                                uint64 = 1027
-	FlagWatchProjectOrigin                       uint64 = 1028
-	FlagWatchWorkdir                             uint64 = 1029
-	FlagWatchExts                                uint64 = 1030
-	FlagWatchFilter                              uint64 = 1031
-	FlagWatchFilterFile                          uint64 = 1032
-	FlagWatchFilterProg                          uint64 = 1033
-	FlagWatchIgnore                              uint64 = 1034
-	FlagWatchIgnoreFile                          uint64 = 1035
-	FlagWatchFsEvents                            uint64 = 1036
-	FlagWatchNoMeta                              uint64 = 1037
-	FlagWatchPrintEvents                         uint64 = 1038
-	FlagWatchManual                              uint64 = 1039
-	ArgWatchTask                                 uint64 = 1040
-	ArgWatchArgs                                 uint64 = 1041
-	CmdWhere                                     uint64 = 1042
-	ArgWhereToolVersion                          uint64 = 1043
-	ArgWhereAsdfVersion                          uint64 = 1044
-	CmdWhich                                     uint64 = 1045
-	FlagWhichTool                                uint64 = 1046
-	FlagWhichComplete                            uint64 = 1047
-	FlagWhichPlugin                              uint64 = 1048
-	FlagWhichVersion                             uint64 = 1049
-	ArgWhichBinName                              uint64 = 1050
+	FlagBootstrapRemoteCopyLink                  uint64 = 239
+	FlagBootstrapRemoteCopyLinks                 uint64 = 240
+	FlagBootstrapRemoteExclude                   uint64 = 241
+	FlagBootstrapRemoteFailFast                  uint64 = 242
+	FlagBootstrapRemoteForceDotfiles             uint64 = 243
+	FlagBootstrapRemoteHost                      uint64 = 244
+	FlagBootstrapRemoteIdentityFile              uint64 = 245
+	FlagBootstrapRemoteDryRun                    uint64 = 246
+	FlagBootstrapRemoteKeepStaging               uint64 = 247
+	FlagBootstrapRemoteMiseBin                   uint64 = 248
+	FlagBootstrapRemoteOnly                      uint64 = 249
+	FlagBootstrapRemotePort                      uint64 = 250
+	FlagBootstrapRemotePromptSecrets             uint64 = 251
+	FlagBootstrapRemoteRemoteEnv                 uint64 = 252
+	FlagBootstrapRemoteRemoteMise                uint64 = 253
+	FlagBootstrapRemoteSkip                      uint64 = 254
+	FlagBootstrapRemoteSource                    uint64 = 255
+	FlagBootstrapRemoteSshOption                 uint64 = 256
+	FlagBootstrapRemoteTag                       uint64 = 257
+	FlagBootstrapRemoteUpdate                    uint64 = 258
+	FlagBootstrapRemoteYes                       uint64 = 259
+	ArgBootstrapRemoteTarget                     uint64 = 260
+	CmdBootstrapRepos                            uint64 = 261
+	CmdBootstrapReposApply                       uint64 = 262
+	FlagBootstrapReposApplyDryRun                uint64 = 263
+	FlagBootstrapReposApplyYes                   uint64 = 264
+	CmdBootstrapReposExec                        uint64 = 265
+	FlagBootstrapReposExecContinueOnError        uint64 = 266
+	FlagBootstrapReposExecDryRun                 uint64 = 267
+	ArgBootstrapReposExecPath                    uint64 = 268
+	ArgBootstrapReposExecCommand                 uint64 = 269
+	CmdBootstrapReposStatus                      uint64 = 270
+	FlagBootstrapReposStatusJson                 uint64 = 271
+	FlagBootstrapReposStatusMissing              uint64 = 272
+	CmdBootstrapReposUpdate                      uint64 = 273
+	FlagBootstrapReposUpdateDryRun               uint64 = 274
+	FlagBootstrapReposUpdateYes                  uint64 = 275
+	ArgBootstrapReposUpdatePath                  uint64 = 276
+	CmdBootstrapSecrets                          uint64 = 277
+	CmdBootstrapSecretsStatus                    uint64 = 278
+	FlagBootstrapSecretsStatusJson               uint64 = 279
+	FlagBootstrapSecretsStatusMissing            uint64 = 280
+	CmdBootstrapServices                         uint64 = 281
+	CmdBootstrapServicesApply                    uint64 = 282
+	FlagBootstrapServicesApplyDryRun             uint64 = 283
+	FlagBootstrapServicesApplyYes                uint64 = 284
+	CmdBootstrapServicesStatus                   uint64 = 285
+	FlagBootstrapServicesStatusJson              uint64 = 286
+	FlagBootstrapServicesStatusMissing           uint64 = 287
+	CmdBootstrapStatus                           uint64 = 288
+	FlagBootstrapStatusJson                      uint64 = 289
+	FlagBootstrapStatusMissing                   uint64 = 290
+	FlagBootstrapStatusPromptSecrets             uint64 = 291
+	CmdBootstrapSystemd                          uint64 = 292
+	CmdBootstrapSystemdApply                     uint64 = 293
+	FlagBootstrapSystemdApplyDryRun              uint64 = 294
+	FlagBootstrapSystemdApplyYes                 uint64 = 295
+	CmdBootstrapSystemdStatus                    uint64 = 296
+	FlagBootstrapSystemdStatusJson               uint64 = 297
+	FlagBootstrapSystemdStatusMissing            uint64 = 298
+	CmdBootstrapUser                             uint64 = 299
+	CmdBootstrapUserApply                        uint64 = 300
+	FlagBootstrapUserApplyDryRun                 uint64 = 301
+	FlagBootstrapUserApplyYes                    uint64 = 302
+	CmdBootstrapUserStatus                       uint64 = 303
+	FlagBootstrapUserStatusJson                  uint64 = 304
+	FlagBootstrapUserStatusMissing               uint64 = 305
+	CmdCache                                     uint64 = 306
+	CmdCacheClear                                uint64 = 307
+	FlagCacheClearOutdate                        uint64 = 308
+	FlagCacheClearTask                           uint64 = 309
+	ArgCacheClearTool                            uint64 = 310
+	CmdCachePath                                 uint64 = 311
+	CmdCachePrune                                uint64 = 312
+	FlagCachePruneVerbose                        uint64 = 313
+	FlagCachePruneDryRun                         uint64 = 314
+	ArgCachePruneTool                            uint64 = 315
+	CmdCacheTask                                 uint64 = 316
+	FlagCacheTaskJson                            uint64 = 317
+	ArgCacheTaskTask                             uint64 = 318
+	CmdCompletion                                uint64 = 319
+	FlagCompletionShell                          uint64 = 320
+	FlagCompletionIncludeBashCompletionLib       uint64 = 321
+	FlagCompletionUsage                          uint64 = 322
+	ArgCompletionShell                           uint64 = 323
+	CmdConfig                                    uint64 = 324
+	FlagConfigJson                               uint64 = 325
+	FlagConfigNoHeader                           uint64 = 326
+	FlagConfigTrackedConfigs                     uint64 = 327
+	CmdConfigGet                                 uint64 = 328
+	FlagConfigGetFile                            uint64 = 329
+	ArgConfigGetKey                              uint64 = 330
+	CmdConfigLs                                  uint64 = 331
+	FlagConfigLsJson                             uint64 = 332
+	FlagConfigLsNoHeader                         uint64 = 333
+	FlagConfigLsTrackedConfigs                   uint64 = 334
+	CmdConfigSet                                 uint64 = 335
+	FlagConfigSetFile                            uint64 = 336
+	FlagConfigSetType                            uint64 = 337
+	ArgConfigSetKey                              uint64 = 338
+	ArgConfigSetValue                            uint64 = 339
+	CmdCurrent                                   uint64 = 340
+	ArgCurrentPlugin                             uint64 = 341
+	CmdDeactivate                                uint64 = 342
+	CmdDirenv                                    uint64 = 343
+	CmdDirenvActivate                            uint64 = 344
+	CmdDirenvEnvrc                               uint64 = 345
+	CmdDirenvExec                                uint64 = 346
+	CmdDotfiles                                  uint64 = 347
+	CmdDotfilesAdd                               uint64 = 348
+	FlagDotfilesAddForce                         uint64 = 349
+	FlagDotfilesAddGlobal                        uint64 = 350
+	FlagDotfilesAddLocal                         uint64 = 351
+	FlagDotfilesAddMode                          uint64 = 352
+	FlagDotfilesAddDryRun                        uint64 = 353
+	FlagDotfilesAddNoApply                       uint64 = 354
+	FlagDotfilesAddPath                          uint64 = 355
+	FlagDotfilesAddSource                        uint64 = 356
+	FlagDotfilesAddYes                           uint64 = 357
+	ArgDotfilesAddTarget                         uint64 = 358
+	CmdDotfilesApply                             uint64 = 359
+	FlagDotfilesApplyForce                       uint64 = 360
+	FlagDotfilesApplyDryRun                      uint64 = 361
+	FlagDotfilesApplyYes                         uint64 = 362
+	ArgDotfilesApplyTarget                       uint64 = 363
+	CmdDotfilesEdit                              uint64 = 364
+	FlagDotfilesEditApply                        uint64 = 365
+	FlagDotfilesEditMode                         uint64 = 366
+	FlagDotfilesEditSource                       uint64 = 367
+	FlagDotfilesEditYes                          uint64 = 368
+	ArgDotfilesEditTarget                        uint64 = 369
+	CmdDotfilesStatus                            uint64 = 370
+	FlagDotfilesStatusJson                       uint64 = 371
+	FlagDotfilesStatusMissing                    uint64 = 372
+	ArgDotfilesStatusTarget                      uint64 = 373
+	CmdDotfilesUnapply                           uint64 = 374
+	FlagDotfilesUnapplyForce                     uint64 = 375
+	FlagDotfilesUnapplyDryRun                    uint64 = 376
+	FlagDotfilesUnapplyYes                       uint64 = 377
+	ArgDotfilesUnapplyTarget                     uint64 = 378
+	CmdDoctor                                    uint64 = 379
+	FlagDoctorJson                               uint64 = 380
+	CmdDoctorPath                                uint64 = 381
+	FlagDoctorPathFull                           uint64 = 382
+	CmdEn                                        uint64 = 383
+	FlagEnShell                                  uint64 = 384
+	ArgEnDir                                     uint64 = 385
+	CmdEnv                                       uint64 = 386
+	FlagEnvDotenv                                uint64 = 387
+	FlagEnvJson                                  uint64 = 388
+	FlagEnvShell                                 uint64 = 389
+	FlagEnvJsonExtended                          uint64 = 390
+	FlagEnvRedacted                              uint64 = 391
+	FlagEnvValues                                uint64 = 392
+	ArgEnvToolVersion                            uint64 = 393
+	CmdExec                                      uint64 = 394
+	FlagExecCommand                              uint64 = 395
+	FlagExecJobs                                 uint64 = 396
+	FlagExecAllowEnv                             uint64 = 397
+	FlagExecAllowNet                             uint64 = 398
+	FlagExecAllowRead                            uint64 = 399
+	FlagExecAllowWrite                           uint64 = 400
+	FlagExecDenyAll                              uint64 = 401
+	FlagExecDenyEnv                              uint64 = 402
+	FlagExecDenyNet                              uint64 = 403
+	FlagExecDenyRead                             uint64 = 404
+	FlagExecDenyWrite                            uint64 = 405
+	FlagExecFreshEnv                             uint64 = 406
+	FlagExecNoDeps                               uint64 = 407
+	FlagExecRaw                                  uint64 = 408
+	ArgExecToolVersion                           uint64 = 409
+	ArgExecCommand                               uint64 = 410
+	CmdFmt                                       uint64 = 411
+	FlagFmtAll                                   uint64 = 412
+	FlagFmtCheck                                 uint64 = 413
+	FlagFmtStdin                                 uint64 = 414
+	CmdGenerate                                  uint64 = 415
+	CmdGenerateBootstrap                         uint64 = 416
+	FlagGenerateBootstrapLocalize                uint64 = 417
+	FlagGenerateBootstrapVersion                 uint64 = 418
+	FlagGenerateBootstrapWrite                   uint64 = 419
+	FlagGenerateBootstrapLocalizedDir            uint64 = 420
+	FlagGenerateBootstrapWindows                 uint64 = 421
+	CmdGenerateConfig                            uint64 = 422
+	FlagGenerateConfigGlobal                     uint64 = 423
+	FlagGenerateConfigDryRun                     uint64 = 424
+	FlagGenerateConfigToolVersions               uint64 = 425
+	ArgGenerateConfigPath                        uint64 = 426
+	CmdGenerateDevcontainer                      uint64 = 427
+	FlagGenerateDevcontainerImage                uint64 = 428
+	FlagGenerateDevcontainerMountMiseData        uint64 = 429
+	FlagGenerateDevcontainerName                 uint64 = 430
+	FlagGenerateDevcontainerWrite                uint64 = 431
+	CmdGenerateGitPreCommit                      uint64 = 432
+	FlagGenerateGitPreCommitTask                 uint64 = 433
+	FlagGenerateGitPreCommitWrite                uint64 = 434
+	FlagGenerateGitPreCommitHook                 uint64 = 435
+	ArgGenerateGitPreCommitMiseArg               uint64 = 436
+	CmdGenerateGithubAction                      uint64 = 437
+	FlagGenerateGithubActionTask                 uint64 = 438
+	FlagGenerateGithubActionWrite                uint64 = 439
+	FlagGenerateGithubActionName                 uint64 = 440
+	CmdGenerateTaskDocs                          uint64 = 441
+	FlagGenerateTaskDocsInject                   uint64 = 442
+	FlagGenerateTaskDocsIndex                    uint64 = 443
+	FlagGenerateTaskDocsMulti                    uint64 = 444
+	FlagGenerateTaskDocsOutput                   uint64 = 445
+	FlagGenerateTaskDocsRoot                     uint64 = 446
+	FlagGenerateTaskDocsStyle                    uint64 = 447
+	CmdGenerateTaskStubs                         uint64 = 448
+	FlagGenerateTaskStubsDir                     uint64 = 449
+	FlagGenerateTaskStubsMiseBin                 uint64 = 450
+	CmdGenerateToolStub                          uint64 = 451
+	FlagGenerateToolStubBin                      uint64 = 452
+	FlagGenerateToolStubBootstrap                uint64 = 453
+	FlagGenerateToolStubBootstrapVersion         uint64 = 454
+	FlagGenerateToolStubChecksumAlgorithm        uint64 = 455
+	FlagGenerateToolStubFetch                    uint64 = 456
+	FlagGenerateToolStubHttp                     uint64 = 457
+	FlagGenerateToolStubLock                     uint64 = 458
+	FlagGenerateToolStubPlatformBin              uint64 = 459
+	FlagGenerateToolStubPlatformUrl              uint64 = 460
+	FlagGenerateToolStubSkipDownload             uint64 = 461
+	FlagGenerateToolStubUrl                      uint64 = 462
+	FlagGenerateToolStubVersion                  uint64 = 463
+	ArgGenerateToolStubOutput                    uint64 = 464
+	CmdGithub                                    uint64 = 465
+	CmdGithubToken                               uint64 = 466
+	FlagGithubTokenOauth                         uint64 = 467
+	FlagGithubTokenRaw                           uint64 = 468
+	FlagGithubTokenRefresh                       uint64 = 469
+	FlagGithubTokenUnmask                        uint64 = 470
+	ArgGithubTokenHost                           uint64 = 471
+	CmdGlobal                                    uint64 = 472
+	FlagGlobalFuzzy                              uint64 = 473
+	FlagGlobalPath                               uint64 = 474
+	FlagGlobalPin                                uint64 = 475
+	FlagGlobalRemove                             uint64 = 476
+	ArgGlobalToolVersion                         uint64 = 477
+	CmdHookEnv                                   uint64 = 478
+	FlagHookEnvForce                             uint64 = 479
+	FlagHookEnvQuiet                             uint64 = 480
+	FlagHookEnvShell                             uint64 = 481
+	FlagHookEnvReason                            uint64 = 482
+	FlagHookEnvStatus                            uint64 = 483
+	CmdHookNotFound                              uint64 = 484
+	FlagHookNotFoundShell                        uint64 = 485
+	ArgHookNotFoundBin                           uint64 = 486
+	CmdImplode                                   uint64 = 487
+	FlagImplodeDryRun                            uint64 = 488
+	FlagImplodeConfig                            uint64 = 489
+	CmdEdit                                      uint64 = 490
+	FlagEditGlobal                               uint64 = 491
+	FlagEditDryRun                               uint64 = 492
+	FlagEditToolVersions                         uint64 = 493
+	ArgEditPath                                  uint64 = 494
+	CmdInstall                                   uint64 = 495
+	FlagInstallForce                             uint64 = 496
+	FlagInstallJobs                              uint64 = 497
+	FlagInstallDryRun                            uint64 = 498
+	FlagInstallVerbose                           uint64 = 499
+	FlagInstallDryRunCode                        uint64 = 500
+	FlagInstallIncludeTaskTools                  uint64 = 501
+	FlagInstallMinimumReleaseAge                 uint64 = 502
+	FlagInstallMonorepo                          uint64 = 503
+	FlagInstallRaw                               uint64 = 504
+	FlagInstallShared                            uint64 = 505
+	FlagInstallSystem                            uint64 = 506
+	ArgInstallToolVersion                        uint64 = 507
+	CmdInstallInto                               uint64 = 508
+	ArgInstallIntoToolVersion                    uint64 = 509
+	ArgInstallIntoPath                           uint64 = 510
+	CmdLatest                                    uint64 = 511
+	FlagLatestInstalled                          uint64 = 512
+	FlagLatestMinimumReleaseAge                  uint64 = 513
+	ArgLatestToolVersion                         uint64 = 514
+	ArgLatestAsdfVersion                         uint64 = 515
+	CmdLink                                      uint64 = 516
+	FlagLinkForce                                uint64 = 517
+	ArgLinkToolVersion                           uint64 = 518
+	ArgLinkPath                                  uint64 = 519
+	CmdLocal                                     uint64 = 520
+	FlagLocalParent                              uint64 = 521
+	FlagLocalFuzzy                               uint64 = 522
+	FlagLocalPath                                uint64 = 523
+	FlagLocalPin                                 uint64 = 524
+	FlagLocalRemove                              uint64 = 525
+	ArgLocalToolVersion                          uint64 = 526
+	CmdLock                                      uint64 = 527
+	FlagLockGlobal                               uint64 = 528
+	FlagLockJobs                                 uint64 = 529
+	FlagLockDryRun                               uint64 = 530
+	FlagLockPlatform                             uint64 = 531
+	FlagLockBump                                 uint64 = 532
+	FlagLockJson                                 uint64 = 533
+	FlagLockLocal                                uint64 = 534
+	FlagLockMinimumReleaseAge                    uint64 = 535
+	ArgLockTool                                  uint64 = 536
+	CmdLs                                        uint64 = 537
+	FlagLsCurrent                                uint64 = 538
+	FlagLsGlobal                                 uint64 = 539
+	FlagLsInstalled                              uint64 = 540
+	FlagLsJson                                   uint64 = 541
+	FlagLsLocal                                  uint64 = 542
+	FlagLsMissing                                uint64 = 543
+	FlagLsOffline                                uint64 = 544
+	FlagLsPlugin                                 uint64 = 545
+	FlagLsAllSources                             uint64 = 546
+	FlagLsMonorepo                               uint64 = 547
+	FlagLsNoHeader                               uint64 = 548
+	FlagLsOutdated                               uint64 = 549
+	FlagLsPrefix                                 uint64 = 550
+	FlagLsPrunable                               uint64 = 551
+	ArgLsInstalledTool                           uint64 = 552
+	CmdLsRemote                                  uint64 = 553
+	FlagLsRemoteAll                              uint64 = 554
+	FlagLsRemoteMinimumReleaseAge                uint64 = 555
+	FlagLsRemoteJson                             uint64 = 556
+	FlagLsRemoteNoVersionsHost                   uint64 = 557
+	FlagLsRemotePrerelease                       uint64 = 558
+	FlagLsRemoteStrictMetadata                   uint64 = 559
+	ArgLsRemoteToolVersion                       uint64 = 560
+	ArgLsRemotePrefix                            uint64 = 561
+	CmdMcp                                       uint64 = 562
+	CmdOci                                       uint64 = 563
+	CmdOciBuild                                  uint64 = 564
+	FlagOciBuildCopy                             uint64 = 565
+	FlagOciBuildOutput                           uint64 = 566
+	FlagOciBuildFrom                             uint64 = 567
+	FlagOciBuildIncludeGlobal                    uint64 = 568
+	FlagOciBuildTag                              uint64 = 569
+	FlagOciBuildMountPoint                       uint64 = 570
+	FlagOciBuildNoMise                           uint64 = 571
+	FlagOciBuildOwner                            uint64 = 572
+	CmdOciPush                                   uint64 = 573
+	FlagOciPushCacheFrom                         uint64 = 574
+	FlagOciPushFrom                              uint64 = 575
+	FlagOciPushImageDir                          uint64 = 576
+	FlagOciPushIncludeGlobal                     uint64 = 577
+	FlagOciPushMountPoint                        uint64 = 578
+	FlagOciPushNoCache                           uint64 = 579
+	FlagOciPushNoMise                            uint64 = 580
+	FlagOciPushOwner                             uint64 = 581
+	FlagOciPushUpdateIndex                       uint64 = 582
+	ArgOciPushRef                                uint64 = 583
+	CmdOciRun                                    uint64 = 584
+	FlagOciRunEngine                             uint64 = 585
+	FlagOciRunFrom                               uint64 = 586
+	FlagOciRunImageDir                           uint64 = 587
+	FlagOciRunIncludeGlobal                      uint64 = 588
+	FlagOciRunKeep                               uint64 = 589
+	FlagOciRunMountPoint                         uint64 = 590
+	FlagOciRunNoMise                             uint64 = 591
+	FlagOciRunOwner                              uint64 = 592
+	FlagOciRunVolume                             uint64 = 593
+	FlagOciRunEnv                                uint64 = 594
+	FlagOciRunInteractive                        uint64 = 595
+	FlagOciRunTty                                uint64 = 596
+	FlagOciRunWorkdir                            uint64 = 597
+	ArgOciRunCmd                                 uint64 = 598
+	CmdOutdated                                  uint64 = 599
+	FlagOutdatedBump                             uint64 = 600
+	FlagOutdatedJson                             uint64 = 601
+	FlagOutdatedL                                uint64 = 602
+	FlagOutdatedInactive                         uint64 = 603
+	FlagOutdatedLocal                            uint64 = 604
+	FlagOutdatedMonorepo                         uint64 = 605
+	FlagOutdatedNoHeader                         uint64 = 606
+	ArgOutdatedToolVersion                       uint64 = 607
+	CmdPatrons                                   uint64 = 608
+	FlagPatronsJson                              uint64 = 609
+	FlagPatronsRefresh                           uint64 = 610
+	CmdPlugins                                   uint64 = 611
+	FlagPluginsAll                               uint64 = 612
+	FlagPluginsCore                              uint64 = 613
+	FlagPluginsUrls                              uint64 = 614
+	FlagPluginsRefs                              uint64 = 615
+	FlagPluginsUser                              uint64 = 616
+	CmdPluginsInstall                            uint64 = 617
+	FlagPluginsInstallAll                        uint64 = 618
+	FlagPluginsInstallForce                      uint64 = 619
+	FlagPluginsInstallJobs                       uint64 = 620
+	FlagPluginsInstallVerbose                    uint64 = 621
+	ArgPluginsInstallNewPlugin                   uint64 = 622
+	ArgPluginsInstallGitUrl                      uint64 = 623
+	ArgPluginsInstallRest                        uint64 = 624
+	CmdPluginsLink                               uint64 = 625
+	FlagPluginsLinkForce                         uint64 = 626
+	ArgPluginsLinkName                           uint64 = 627
+	ArgPluginsLinkDir                            uint64 = 628
+	CmdPluginsLs                                 uint64 = 629
+	FlagPluginsLsAll                             uint64 = 630
+	FlagPluginsLsCore                            uint64 = 631
+	FlagPluginsLsOutdated                        uint64 = 632
+	FlagPluginsLsUrls                            uint64 = 633
+	FlagPluginsLsRefs                            uint64 = 634
+	FlagPluginsLsUser                            uint64 = 635
+	CmdPluginsLsRemote                           uint64 = 636
+	FlagPluginsLsRemoteUrls                      uint64 = 637
+	FlagPluginsLsRemoteOnlyNames                 uint64 = 638
+	CmdPluginsUninstall                          uint64 = 639
+	FlagPluginsUninstallAll                      uint64 = 640
+	FlagPluginsUninstallPurge                    uint64 = 641
+	ArgPluginsUninstallPlugin                    uint64 = 642
+	CmdPluginsUpdate                             uint64 = 643
+	FlagPluginsUpdateJobs                        uint64 = 644
+	ArgPluginsUpdatePlugin                       uint64 = 645
+	CmdDeps                                      uint64 = 646
+	FlagDepsExplain                              uint64 = 647
+	FlagDepsForce                                uint64 = 648
+	FlagDepsDryRun                               uint64 = 649
+	FlagDepsList                                 uint64 = 650
+	FlagDepsMonorepo                             uint64 = 651
+	FlagDepsOnly                                 uint64 = 652
+	FlagDepsSkip                                 uint64 = 653
+	ArgDepsProvider                              uint64 = 654
+	CmdDepsAdd                                   uint64 = 655
+	FlagDepsAddDev                               uint64 = 656
+	ArgDepsAddPackages                           uint64 = 657
+	CmdDepsInstall                               uint64 = 658
+	FlagDepsInstallExplain                       uint64 = 659
+	FlagDepsInstallForce                         uint64 = 660
+	FlagDepsInstallDryRun                        uint64 = 661
+	FlagDepsInstallList                          uint64 = 662
+	FlagDepsInstallMonorepo                      uint64 = 663
+	FlagDepsInstallOnly                          uint64 = 664
+	FlagDepsInstallSkip                          uint64 = 665
+	ArgDepsInstallProvider                       uint64 = 666
+	CmdDepsRemove                                uint64 = 667
+	ArgDepsRemovePackages                        uint64 = 668
+	CmdPrune                                     uint64 = 669
+	FlagPruneDryRun                              uint64 = 670
+	FlagPruneConfigs                             uint64 = 671
+	FlagPruneDryRunCode                          uint64 = 672
+	FlagPruneMonorepo                            uint64 = 673
+	FlagPruneTools                               uint64 = 674
+	ArgPruneInstalledTool                        uint64 = 675
+	CmdRegistry                                  uint64 = 676
+	FlagRegistryBackend                          uint64 = 677
+	FlagRegistryComplete                         uint64 = 678
+	FlagRegistryHideAliased                      uint64 = 679
+	FlagRegistryJson                             uint64 = 680
+	FlagRegistrySecurity                         uint64 = 681
+	ArgRegistryName                              uint64 = 682
+	CmdRenderHelp                                uint64 = 683
+	CmdReshim                                    uint64 = 684
+	FlagReshimForce                              uint64 = 685
+	ArgReshimTool                                uint64 = 686
+	ArgReshimVersion                             uint64 = 687
+	CmdRun                                       uint64 = 688
+	FlagRunAffected                              uint64 = 689
+	FlagRunAffectedBase                          uint64 = 690
+	FlagRunAffectedExplain                       uint64 = 691
+	FlagRunAffectedHead                          uint64 = 692
+	FlagRunAffectedJson                          uint64 = 693
+	FlagRunAll                                   uint64 = 694
+	FlagRunContinueOnError                       uint64 = 695
+	FlagRunCd                                    uint64 = 696
+	FlagRunForce                                 uint64 = 697
+	FlagRunJobs                                  uint64 = 698
+	FlagRunDryRun                                uint64 = 699
+	FlagRunOutput                                uint64 = 700
+	FlagRunQuiet                                 uint64 = 701
+	FlagRunRaw                                   uint64 = 702
+	FlagRunShell                                 uint64 = 703
+	FlagRunSilent                                uint64 = 704
+	FlagRunTool                                  uint64 = 705
+	FlagRunAllowEnv                              uint64 = 706
+	FlagRunAllowNet                              uint64 = 707
+	FlagRunAllowRead                             uint64 = 708
+	FlagRunAllowWrite                            uint64 = 709
+	FlagRunDenyAll                               uint64 = 710
+	FlagRunDenyEnv                               uint64 = 711
+	FlagRunDenyNet                               uint64 = 712
+	FlagRunDenyRead                              uint64 = 713
+	FlagRunDenyWrite                             uint64 = 714
+	FlagRunFreshEnv                              uint64 = 715
+	FlagRunNoCache                               uint64 = 716
+	FlagRunNoDeps                                uint64 = 717
+	FlagRunNoTimings                             uint64 = 718
+	FlagRunSkipDeps                              uint64 = 719
+	FlagRunSkipTools                             uint64 = 720
+	FlagRunTaskCache                             uint64 = 721
+	FlagRunTaskCacheExplain                      uint64 = 722
+	FlagRunTaskCacheExplainJson                  uint64 = 723
+	FlagRunTaskCacheStats                        uint64 = 724
+	FlagRunTimeout                               uint64 = 725
+	FlagRunTimings                               uint64 = 726
+	CmdSearch                                    uint64 = 727
+	FlagSearchInteractive                        uint64 = 728
+	FlagSearchMatchType                          uint64 = 729
+	FlagSearchNoHeader                           uint64 = 730
+	ArgSearchName                                uint64 = 731
+	CmdSelfUpdate                                uint64 = 732
+	FlagSelfUpdateForce                          uint64 = 733
+	FlagSelfUpdateYes                            uint64 = 734
+	FlagSelfUpdateNoPlugins                      uint64 = 735
+	ArgSelfUpdateVersion                         uint64 = 736
+	CmdSet                                       uint64 = 737
+	FlagSetEnv                                   uint64 = 738
+	FlagSetGlobal                                uint64 = 739
+	FlagSetAgeEncrypt                            uint64 = 740
+	FlagSetAgeKeyFile                            uint64 = 741
+	FlagSetAgeRecipient                          uint64 = 742
+	FlagSetAgeSshRecipient                       uint64 = 743
+	FlagSetComplete                              uint64 = 744
+	FlagSetFile                                  uint64 = 745
+	FlagSetNoRedact                              uint64 = 746
+	FlagSetPrompt                                uint64 = 747
+	FlagSetRemove                                uint64 = 748
+	FlagSetStdin                                 uint64 = 749
+	ArgSetEnvVar                                 uint64 = 750
+	CmdSettings                                  uint64 = 751
+	FlagSettingsAll                              uint64 = 752
+	FlagSettingsJson                             uint64 = 753
+	FlagSettingsLocal                            uint64 = 754
+	FlagSettingsToml                             uint64 = 755
+	FlagSettingsComplete                         uint64 = 756
+	FlagSettingsJsonExtended                     uint64 = 757
+	ArgSettingsSetting                           uint64 = 758
+	ArgSettingsValue                             uint64 = 759
+	CmdSettingsAdd                               uint64 = 760
+	FlagSettingsAddLocal                         uint64 = 761
+	ArgSettingsAddSetting                        uint64 = 762
+	ArgSettingsAddValue                          uint64 = 763
+	CmdSettingsGet                               uint64 = 764
+	FlagSettingsGetLocal                         uint64 = 765
+	ArgSettingsGetSetting                        uint64 = 766
+	CmdSettingsLs                                uint64 = 767
+	FlagSettingsLsAll                            uint64 = 768
+	FlagSettingsLsJson                           uint64 = 769
+	FlagSettingsLsLocal                          uint64 = 770
+	FlagSettingsLsToml                           uint64 = 771
+	FlagSettingsLsComplete                       uint64 = 772
+	FlagSettingsLsJsonExtended                   uint64 = 773
+	ArgSettingsLsSetting                         uint64 = 774
+	CmdSettingsSet                               uint64 = 775
+	FlagSettingsSetLocal                         uint64 = 776
+	ArgSettingsSetSetting                        uint64 = 777
+	ArgSettingsSetValue                          uint64 = 778
+	CmdSettingsUnset                             uint64 = 779
+	FlagSettingsUnsetLocal                       uint64 = 780
+	ArgSettingsUnsetKey                          uint64 = 781
+	CmdShell                                     uint64 = 782
+	FlagShellJobs                                uint64 = 783
+	FlagShellUnset                               uint64 = 784
+	FlagShellRaw                                 uint64 = 785
+	ArgShellToolVersion                          uint64 = 786
+	CmdShellAlias                                uint64 = 787
+	FlagShellAliasNoHeader                       uint64 = 788
+	CmdShellAliasGet                             uint64 = 789
+	ArgShellAliasGetShellAlias                   uint64 = 790
+	CmdShellAliasLs                              uint64 = 791
+	FlagShellAliasLsNoHeader                     uint64 = 792
+	CmdShellAliasSet                             uint64 = 793
+	ArgShellAliasSetShellAlias                   uint64 = 794
+	ArgShellAliasSetCommand                      uint64 = 795
+	CmdShellAliasUnset                           uint64 = 796
+	ArgShellAliasUnsetShellAlias                 uint64 = 797
+	CmdSponsors                                  uint64 = 798
+	CmdSync                                      uint64 = 799
+	CmdSyncNode                                  uint64 = 800
+	FlagSyncNodeBrew                             uint64 = 801
+	FlagSyncNodeNodenv                           uint64 = 802
+	FlagSyncNodeNvm                              uint64 = 803
+	CmdSyncPython                                uint64 = 804
+	FlagSyncPythonPyenv                          uint64 = 805
+	FlagSyncPythonUv                             uint64 = 806
+	CmdSyncRuby                                  uint64 = 807
+	FlagSyncRubyBrew                             uint64 = 808
+	CmdTasks                                     uint64 = 809
+	FlagTasksGlobal                              uint64 = 810
+	FlagTasksJson                                uint64 = 811
+	FlagTasksLocal                               uint64 = 812
+	FlagTasksExtended                            uint64 = 813
+	FlagTasksAll                                 uint64 = 814
+	FlagTasksComplete                            uint64 = 815
+	FlagTasksHidden                              uint64 = 816
+	FlagTasksNameOnly                            uint64 = 817
+	FlagTasksNoHeader                            uint64 = 818
+	FlagTasksSort                                uint64 = 819
+	FlagTasksSortOrder                           uint64 = 820
+	FlagTasksUsage                               uint64 = 821
+	ArgTasksTask                                 uint64 = 822
+	CmdTasksAdd                                  uint64 = 823
+	FlagTasksAddAlias                            uint64 = 824
+	FlagTasksAddDepends                          uint64 = 825
+	FlagTasksAddDir                              uint64 = 826
+	FlagTasksAddFile                             uint64 = 827
+	FlagTasksAddHide                             uint64 = 828
+	FlagTasksAddQuiet                            uint64 = 829
+	FlagTasksAddRaw                              uint64 = 830
+	FlagTasksAddSources                          uint64 = 831
+	FlagTasksAddWaitFor                          uint64 = 832
+	FlagTasksAddDependsPost                      uint64 = 833
+	FlagTasksAddDescription                      uint64 = 834
+	FlagTasksAddOutputs                          uint64 = 835
+	FlagTasksAddRunWindows                       uint64 = 836
+	FlagTasksAddShell                            uint64 = 837
+	FlagTasksAddSilent                           uint64 = 838
+	ArgTasksAddTask                              uint64 = 839
+	ArgTasksAddRun                               uint64 = 840
+	CmdTasksDeps                                 uint64 = 841
+	FlagTasksDepsCompact                         uint64 = 842
+	FlagTasksDepsDot                             uint64 = 843
+	FlagTasksDepsHidden                          uint64 = 844
+	ArgTasksDepsTasks                            uint64 = 845
+	CmdTasksEdit                                 uint64 = 846
+	FlagTasksEditPath                            uint64 = 847
+	ArgTasksEditTask                             uint64 = 848
+	CmdTasksGraph                                uint64 = 849
+	FlagTasksGraphJson                           uint64 = 850
+	FlagTasksGraphExplain                        uint64 = 851
+	FlagTasksGraphNoHeader                       uint64 = 852
+	CmdTasksInfo                                 uint64 = 853
+	FlagTasksInfoJson                            uint64 = 854
+	ArgTasksInfoTask                             uint64 = 855
+	CmdTasksLs                                   uint64 = 856
+	FlagTasksLsGlobal                            uint64 = 857
+	FlagTasksLsJson                              uint64 = 858
+	FlagTasksLsLocal                             uint64 = 859
+	FlagTasksLsExtended                          uint64 = 860
+	FlagTasksLsAll                               uint64 = 861
+	FlagTasksLsComplete                          uint64 = 862
+	FlagTasksLsHidden                            uint64 = 863
+	FlagTasksLsNameOnly                          uint64 = 864
+	FlagTasksLsNoHeader                          uint64 = 865
+	FlagTasksLsSort                              uint64 = 866
+	FlagTasksLsSortOrder                         uint64 = 867
+	FlagTasksLsUsage                             uint64 = 868
+	CmdTasksRun                                  uint64 = 869
+	FlagTasksRunAffected                         uint64 = 870
+	FlagTasksRunAffectedBase                     uint64 = 871
+	FlagTasksRunAffectedExplain                  uint64 = 872
+	FlagTasksRunAffectedHead                     uint64 = 873
+	FlagTasksRunAffectedJson                     uint64 = 874
+	FlagTasksRunAll                              uint64 = 875
+	FlagTasksRunContinueOnError                  uint64 = 876
+	FlagTasksRunCd                               uint64 = 877
+	FlagTasksRunForce                            uint64 = 878
+	FlagTasksRunJobs                             uint64 = 879
+	FlagTasksRunDryRun                           uint64 = 880
+	FlagTasksRunOutput                           uint64 = 881
+	FlagTasksRunQuiet                            uint64 = 882
+	FlagTasksRunRaw                              uint64 = 883
+	FlagTasksRunShell                            uint64 = 884
+	FlagTasksRunSilent                           uint64 = 885
+	FlagTasksRunTool                             uint64 = 886
+	FlagTasksRunAllowEnv                         uint64 = 887
+	FlagTasksRunAllowNet                         uint64 = 888
+	FlagTasksRunAllowRead                        uint64 = 889
+	FlagTasksRunAllowWrite                       uint64 = 890
+	FlagTasksRunDenyAll                          uint64 = 891
+	FlagTasksRunDenyEnv                          uint64 = 892
+	FlagTasksRunDenyNet                          uint64 = 893
+	FlagTasksRunDenyRead                         uint64 = 894
+	FlagTasksRunDenyWrite                        uint64 = 895
+	FlagTasksRunFreshEnv                         uint64 = 896
+	FlagTasksRunNoCache                          uint64 = 897
+	FlagTasksRunNoDeps                           uint64 = 898
+	FlagTasksRunNoTimings                        uint64 = 899
+	FlagTasksRunSkipDeps                         uint64 = 900
+	FlagTasksRunSkipTools                        uint64 = 901
+	FlagTasksRunTaskCache                        uint64 = 902
+	FlagTasksRunTaskCacheExplain                 uint64 = 903
+	FlagTasksRunTaskCacheExplainJson             uint64 = 904
+	FlagTasksRunTaskCacheStats                   uint64 = 905
+	FlagTasksRunTimeout                          uint64 = 906
+	FlagTasksRunTimings                          uint64 = 907
+	ArgTasksRunTask                              uint64 = 908
+	ArgTasksRunArgs                              uint64 = 909
+	ArgTasksRunArgsLast                          uint64 = 910
+	CmdTasksValidate                             uint64 = 911
+	FlagTasksValidateErrorsOnly                  uint64 = 912
+	FlagTasksValidateJson                        uint64 = 913
+	ArgTasksValidateTasks                        uint64 = 914
+	CmdTestTool                                  uint64 = 915
+	FlagTestToolAll                              uint64 = 916
+	FlagTestToolJobs                             uint64 = 917
+	FlagTestToolAllConfig                        uint64 = 918
+	FlagTestToolIncludeNonDefined                uint64 = 919
+	FlagTestToolRaw                              uint64 = 920
+	ArgTestToolTools                             uint64 = 921
+	CmdToken                                     uint64 = 922
+	CmdTokenForgejo                              uint64 = 923
+	FlagTokenForgejoUnmask                       uint64 = 924
+	ArgTokenForgejoHost                          uint64 = 925
+	CmdTokenGithub                               uint64 = 926
+	FlagTokenGithubOauth                         uint64 = 927
+	FlagTokenGithubRaw                           uint64 = 928
+	FlagTokenGithubRefresh                       uint64 = 929
+	FlagTokenGithubUnmask                        uint64 = 930
+	ArgTokenGithubHost                           uint64 = 931
+	CmdTokenGitlab                               uint64 = 932
+	FlagTokenGitlabUnmask                        uint64 = 933
+	ArgTokenGitlabHost                           uint64 = 934
+	CmdTool                                      uint64 = 935
+	FlagToolJson                                 uint64 = 936
+	FlagToolActive                               uint64 = 937
+	FlagToolBackend                              uint64 = 938
+	FlagToolConfigSource                         uint64 = 939
+	FlagToolDescription                          uint64 = 940
+	FlagToolInstalled                            uint64 = 941
+	FlagToolRequested                            uint64 = 942
+	FlagToolToolOptions                          uint64 = 943
+	ArgToolTool                                  uint64 = 944
+	CmdToolStub                                  uint64 = 945
+	ArgToolStubFile                              uint64 = 946
+	ArgToolStubArgs                              uint64 = 947
+	CmdTrust                                     uint64 = 948
+	FlagTrustAll                                 uint64 = 949
+	FlagTrustIgnore                              uint64 = 950
+	FlagTrustShow                                uint64 = 951
+	FlagTrustUntrust                             uint64 = 952
+	ArgTrustConfigFile                           uint64 = 953
+	CmdUninstall                                 uint64 = 954
+	FlagUninstallAll                             uint64 = 955
+	FlagUninstallDryRun                          uint64 = 956
+	FlagUninstallDryRunCode                      uint64 = 957
+	ArgUninstallInstalledToolVersion             uint64 = 958
+	CmdUnset                                     uint64 = 959
+	FlagUnsetFile                                uint64 = 960
+	FlagUnsetGlobal                              uint64 = 961
+	ArgUnsetEnvKey                               uint64 = 962
+	CmdUntrust                                   uint64 = 963
+	ArgUntrustConfigFile                         uint64 = 964
+	CmdUnuse                                     uint64 = 965
+	FlagUnuseEnv                                 uint64 = 966
+	FlagUnuseGlobal                              uint64 = 967
+	FlagUnusePath                                uint64 = 968
+	FlagUnuseNoPrune                             uint64 = 969
+	ArgUnuseInstalledToolVersion                 uint64 = 970
+	CmdUpgrade                                   uint64 = 971
+	FlagUpgradeBump                              uint64 = 972
+	FlagUpgradeInteractive                       uint64 = 973
+	FlagUpgradeJobs                              uint64 = 974
+	FlagUpgradeL                                 uint64 = 975
+	FlagUpgradeDryRun                            uint64 = 976
+	FlagUpgradeExclude                           uint64 = 977
+	FlagUpgradeDryRunCode                        uint64 = 978
+	FlagUpgradeInactive                          uint64 = 979
+	FlagUpgradeLocal                             uint64 = 980
+	FlagUpgradeMinimumReleaseAge                 uint64 = 981
+	FlagUpgradeMonorepo                          uint64 = 982
+	FlagUpgradeNoPrune                           uint64 = 983
+	FlagUpgradePrune                             uint64 = 984
+	FlagUpgradeRaw                               uint64 = 985
+	ArgUpgradeInstalledToolVersion               uint64 = 986
+	CmdUsage                                     uint64 = 987
+	CmdUse                                       uint64 = 988
+	FlagUseEnv                                   uint64 = 989
+	FlagUseForce                                 uint64 = 990
+	FlagUseGlobal                                uint64 = 991
+	FlagUseJobs                                  uint64 = 992
+	FlagUseDryRun                                uint64 = 993
+	FlagUsePath                                  uint64 = 994
+	FlagUseDryRunCode                            uint64 = 995
+	FlagUseFuzzy                                 uint64 = 996
+	FlagUseMinimumReleaseAge                     uint64 = 997
+	FlagUsePin                                   uint64 = 998
+	FlagUseRaw                                   uint64 = 999
+	FlagUseRemove                                uint64 = 1000
+	ArgUseToolVersion                            uint64 = 1001
+	CmdVersion                                   uint64 = 1002
+	FlagVersionJson                              uint64 = 1003
+	CmdWatch                                     uint64 = 1004
+	FlagWatchTaskFlag                            uint64 = 1005
+	FlagWatchGlob                                uint64 = 1006
+	FlagWatchSkipDeps                            uint64 = 1007
+	FlagWatchWatch                               uint64 = 1008
+	FlagWatchWatchNonRecursive                   uint64 = 1009
+	FlagWatchWatchFile                           uint64 = 1010
+	FlagWatchClear                               uint64 = 1011
+	FlagWatchOnBusyUpdate                        uint64 = 1012
+	FlagWatchRestart                             uint64 = 1013
+	FlagWatchSignal                              uint64 = 1014
+	FlagWatchStopSignal                          uint64 = 1015
+	FlagWatchStopTimeout                         uint64 = 1016
+	FlagWatchMapSignal                           uint64 = 1017
+	FlagWatchDebounce                            uint64 = 1018
+	FlagWatchStdinQuit                           uint64 = 1019
+	FlagWatchNoVcsIgnore                         uint64 = 1020
+	FlagWatchNoProjectIgnore                     uint64 = 1021
+	FlagWatchNoGlobalIgnore                      uint64 = 1022
+	FlagWatchNoDefaultIgnore                     uint64 = 1023
+	FlagWatchNoDiscoverIgnore                    uint64 = 1024
+	FlagWatchIgnoreNothing                       uint64 = 1025
+	FlagWatchPostpone                            uint64 = 1026
+	FlagWatchDelayRun                            uint64 = 1027
+	FlagWatchPoll                                uint64 = 1028
+	FlagWatchShell                               uint64 = 1029
+	FlagWatchN                                   uint64 = 1030
+	FlagWatchEmitEventsTo                        uint64 = 1031
+	FlagWatchOnlyEmitEvents                      uint64 = 1032
+	FlagWatchEnv                                 uint64 = 1033
+	FlagWatchWrapProcess                         uint64 = 1034
+	FlagWatchNotify                              uint64 = 1035
+	FlagWatchColor                               uint64 = 1036
+	FlagWatchTimings                             uint64 = 1037
+	FlagWatchQuiet                               uint64 = 1038
+	FlagWatchBell                                uint64 = 1039
+	FlagWatchProjectOrigin                       uint64 = 1040
+	FlagWatchWorkdir                             uint64 = 1041
+	FlagWatchExts                                uint64 = 1042
+	FlagWatchFilter                              uint64 = 1043
+	FlagWatchFilterFile                          uint64 = 1044
+	FlagWatchFilterProg                          uint64 = 1045
+	FlagWatchIgnore                              uint64 = 1046
+	FlagWatchIgnoreFile                          uint64 = 1047
+	FlagWatchFsEvents                            uint64 = 1048
+	FlagWatchNoMeta                              uint64 = 1049
+	FlagWatchPrintEvents                         uint64 = 1050
+	FlagWatchManual                              uint64 = 1051
+	ArgWatchTask                                 uint64 = 1052
+	ArgWatchArgs                                 uint64 = 1053
+	CmdWhere                                     uint64 = 1054
+	ArgWhereToolVersion                          uint64 = 1055
+	ArgWhereAsdfVersion                          uint64 = 1056
+	CmdWhich                                     uint64 = 1057
+	FlagWhichTool                                uint64 = 1058
+	FlagWhichComplete                            uint64 = 1059
+	FlagWhichPlugin                              uint64 = 1060
+	FlagWhichVersion                             uint64 = 1061
+	ArgWhichBinName                              uint64 = 1062
 )
 
 // Root is the command tree for `mise`. Pass it to argv.New.
@@ -1089,21 +1101,22 @@ var Root = &argv.Command{
 		{Key: FlagNoConfig, Name: "no-config", Longs: []string{"no-config"}},
 		{Key: FlagNoEnv, Name: "no-env", Longs: []string{"no-env"}},
 		{Key: FlagNoHooks, Name: "no-hooks", Longs: []string{"no-hooks"}},
-		{Key: FlagNoTimings, Name: "no-timings", Longs: []string{"no-timings"}},
+		{Key: FlagNoTimings, Name: "no-timings", Longs: []string{"no-timings", "no-timing"}, HiddenLongs: []string{"no-timing"}},
 		{Key: FlagOutput, Name: "output", Longs: []string{"output"}, TakesValue: true},
 		{Key: FlagRaw, Name: "raw", Longs: []string{"raw"}, Global: true},
 		{Key: FlagLocked, Name: "locked", Longs: []string{"locked"}, Global: true},
 		{Key: FlagSilent, Name: "silent", Longs: []string{"silent"}, Global: true},
-		{Key: FlagTimings, Name: "timings", Longs: []string{"timings"}},
+		{Key: FlagTimings, Name: "timings", Longs: []string{"timings", "timing"}, HiddenLongs: []string{"timing"}},
 		{Key: FlagTrace, Name: "trace", Longs: []string{"trace"}, Global: true},
 	},
 	Args: []*argv.Arg{
-		{Key: ArgTask, Name: "TASK"},
+		{Key: ArgTask, Name: "TASK", DoubleDash: argv.DoubleDashAutomatic},
 		{Key: ArgTaskArgs, Name: "TASK_ARGS", Var: true},
 		{Key: ArgTaskArgsLast, Name: "TASK_ARGS_LAST", Var: true, DoubleDash: argv.DoubleDashRequired},
 	},
-	Subcommands:       []*argv.Command{cmdActivate, cmdToolAlias, cmdAsdf, cmdBackends, cmdBinPaths, cmdBootstrap, cmdCache, cmdCompletion, cmdConfig, cmdCurrent, cmdDeactivate, cmdDirenv, cmdDotfiles, cmdDoctor, cmdEn, cmdEnv, cmdExec, cmdFmt, cmdGenerate, cmdGithub, cmdGlobal, cmdHookEnv, cmdHookNotFound, cmdImplode, cmdEdit, cmdInstall, cmdInstallInto, cmdLatest, cmdLink, cmdLocal, cmdLock, cmdLs, cmdLsRemote, cmdMcp, cmdOci, cmdOutdated, cmdPatrons, cmdPlugins, cmdDeps, cmdPrune, cmdRegistry, cmdRenderHelp, cmdReshim, cmdRun, cmdSearch, cmdSelfUpdate, cmdSet, cmdSettings, cmdShell, cmdShellAlias, cmdSponsors, cmdSync, cmdTasks, cmdTestTool, cmdToken, cmdTool, cmdToolStub, cmdTrust, cmdUninstall, cmdUnset, cmdUntrust, cmdUnuse, cmdUpgrade, cmdUsage, cmdUse, cmdVersion, cmdWatch, cmdWhere, cmdWhich},
-	DefaultSubcommand: cmdRun,
+	Subcommands:         []*argv.Command{cmdActivate, cmdToolAlias, cmdAsdf, cmdBackends, cmdBinPaths, cmdBootstrap, cmdCache, cmdCompletion, cmdConfig, cmdCurrent, cmdDeactivate, cmdDirenv, cmdDotfiles, cmdDoctor, cmdEn, cmdEnv, cmdExec, cmdFmt, cmdGenerate, cmdGithub, cmdGlobal, cmdHookEnv, cmdHookNotFound, cmdImplode, cmdEdit, cmdInstall, cmdInstallInto, cmdLatest, cmdLink, cmdLocal, cmdLock, cmdLs, cmdLsRemote, cmdMcp, cmdOci, cmdOutdated, cmdPatrons, cmdPlugins, cmdDeps, cmdPrune, cmdRegistry, cmdRenderHelp, cmdReshim, cmdRun, cmdSearch, cmdSelfUpdate, cmdSet, cmdSettings, cmdShell, cmdShellAlias, cmdSponsors, cmdSync, cmdTasks, cmdTestTool, cmdToken, cmdTool, cmdToolStub, cmdTrust, cmdUninstall, cmdUnset, cmdUntrust, cmdUnuse, cmdUpgrade, cmdUsage, cmdUse, cmdVersion, cmdWatch, cmdWhere, cmdWhich},
+	ArgRequiredElseHelp: true,
+	DefaultSubcommand:   cmdRun,
 }
 
 // activate
@@ -1128,7 +1141,7 @@ var cmdToolAlias = &argv.Command{
 	Key:     CmdToolAlias,
 	Aliases: []string{"alias", "aliases"},
 	Flags: []*argv.Flag{
-		{Key: FlagToolAliasTool, Name: "tool", Longs: []string{"tool"}, Shorts: []byte{'p'}, TakesValue: true},
+		{Key: FlagToolAliasTool, Name: "tool", Longs: []string{"tool", "plugin"}, HiddenLongs: []string{"plugin"}, Shorts: []byte{'p'}, TakesValue: true},
 		{Key: FlagToolAliasNoHeader, Name: "no-header", Longs: []string{"no-header"}},
 	},
 	Subcommands: []*argv.Command{cmdToolAliasGet, cmdToolAliasLs, cmdToolAliasSet, cmdToolAliasUnset},
@@ -1226,9 +1239,9 @@ var cmdBootstrap = &argv.Command{
 		{Key: FlagBootstrapDryRun, Name: "dry-run", Longs: []string{"dry-run"}, Shorts: []byte{'n'}},
 		{Key: FlagBootstrapYes, Name: "yes", Longs: []string{"yes"}, Shorts: []byte{'y'}},
 		{Key: FlagBootstrapForceDotfiles, Name: "force-dotfiles", Longs: []string{"force-dotfiles"}},
-		{Key: FlagBootstrapOnly, Name: "only", Longs: []string{"only"}, TakesValue: true},
+		{Key: FlagBootstrapOnly, Name: "only", Longs: []string{"only"}, TakesValue: true, Delimiter: ','},
 		{Key: FlagBootstrapPromptSecrets, Name: "prompt-secrets", Longs: []string{"prompt-secrets"}},
-		{Key: FlagBootstrapSkip, Name: "skip", Longs: []string{"skip"}, TakesValue: true},
+		{Key: FlagBootstrapSkip, Name: "skip", Longs: []string{"skip"}, TakesValue: true, Delimiter: ','},
 		{Key: FlagBootstrapUpdate, Name: "update", Longs: []string{"update"}},
 	},
 	Subcommands: []*argv.Command{cmdBootstrapApplyAccountPlan, cmdBootstrapApplyServicePlan, cmdBootstrapApplyFirewallPlan, cmdBootstrapApplySystemPlan, cmdBootstrapInspectSystemFiles, cmdBootstrapInspectFirewallPlan, cmdBootstrapAccounts, cmdBootstrapCompose, cmdBootstrapDotfiles, cmdBootstrapFiles, cmdBootstrapFirewall, cmdBootstrapLaunchd, cmdBootstrapLinux, cmdBootstrapMacos, cmdBootstrapMacosDefaults2, cmdBootstrapMiseShellActivate, cmdBootstrapPackages, cmdBootstrapPlan, cmdBootstrapPlugins, cmdBootstrapRemote, cmdBootstrapRepos, cmdBootstrapSecrets, cmdBootstrapServices, cmdBootstrapStatus, cmdBootstrapSystemd, cmdBootstrapUser},
@@ -1342,7 +1355,7 @@ var cmdBootstrapDotfilesAdd = &argv.Command{
 		{Key: FlagBootstrapDotfilesAddMode, Name: "mode", Longs: []string{"mode"}, Shorts: []byte{'m'}, TakesValue: true},
 		{Key: FlagBootstrapDotfilesAddDryRun, Name: "dry-run", Longs: []string{"dry-run"}, Shorts: []byte{'n'}},
 		{Key: FlagBootstrapDotfilesAddNoApply, Name: "no-apply", Longs: []string{"no-apply"}},
-		{Key: FlagBootstrapDotfilesAddPath, Name: "path", Longs: []string{"path", "file"}, Shorts: []byte{'p'}, TakesValue: true},
+		{Key: FlagBootstrapDotfilesAddPath, Name: "path", Longs: []string{"path"}, Shorts: []byte{'p'}, TakesValue: true},
 		{Key: FlagBootstrapDotfilesAddSource, Name: "source", Longs: []string{"source"}, Shorts: []byte{'s'}, TakesValue: true},
 		{Key: FlagBootstrapDotfilesAddYes, Name: "yes", Longs: []string{"yes"}, Shorts: []byte{'y'}},
 	},
@@ -1382,9 +1395,8 @@ var cmdBootstrapDotfilesEdit = &argv.Command{
 
 // bootstrap dotfiles status
 var cmdBootstrapDotfilesStatus = &argv.Command{
-	Name:    "status",
-	Key:     CmdBootstrapDotfilesStatus,
-	Aliases: []string{"ls"},
+	Name: "status",
+	Key:  CmdBootstrapDotfilesStatus,
 	Flags: []*argv.Flag{
 		{Key: FlagBootstrapDotfilesStatusJson, Name: "json", Longs: []string{"json"}, Shorts: []byte{'J'}},
 		{Key: FlagBootstrapDotfilesStatusMissing, Name: "missing", Longs: []string{"missing"}},
@@ -1815,6 +1827,8 @@ var cmdBootstrapRemote = &argv.Command{
 		{Key: FlagBootstrapRemoteAll, Name: "all", Longs: []string{"all"}},
 		{Key: FlagBootstrapRemoteBootstrapCommand, Name: "bootstrap-command", Longs: []string{"bootstrap-command"}, TakesValue: true},
 		{Key: FlagBootstrapRemoteConnectTimeout, Name: "connect-timeout", Longs: []string{"connect-timeout"}, TakesValue: true},
+		{Key: FlagBootstrapRemoteCopyLink, Name: "copy-link", Longs: []string{"copy-link"}, TakesValue: true},
+		{Key: FlagBootstrapRemoteCopyLinks, Name: "copy-links", Longs: []string{"copy-links"}},
 		{Key: FlagBootstrapRemoteExclude, Name: "exclude", Longs: []string{"exclude"}, TakesValue: true},
 		{Key: FlagBootstrapRemoteFailFast, Name: "fail-fast", Longs: []string{"fail-fast"}},
 		{Key: FlagBootstrapRemoteForceDotfiles, Name: "force-dotfiles", Longs: []string{"force-dotfiles"}},
@@ -1823,11 +1837,12 @@ var cmdBootstrapRemote = &argv.Command{
 		{Key: FlagBootstrapRemoteDryRun, Name: "dry-run", Longs: []string{"dry-run"}, Shorts: []byte{'n'}},
 		{Key: FlagBootstrapRemoteKeepStaging, Name: "keep-staging", Longs: []string{"keep-staging"}},
 		{Key: FlagBootstrapRemoteMiseBin, Name: "mise-bin", Longs: []string{"mise-bin"}, TakesValue: true},
-		{Key: FlagBootstrapRemoteOnly, Name: "only", Longs: []string{"only"}, TakesValue: true},
+		{Key: FlagBootstrapRemoteOnly, Name: "only", Longs: []string{"only"}, TakesValue: true, Delimiter: ','},
 		{Key: FlagBootstrapRemotePort, Name: "port", Longs: []string{"port"}, TakesValue: true},
 		{Key: FlagBootstrapRemotePromptSecrets, Name: "prompt-secrets", Longs: []string{"prompt-secrets"}},
+		{Key: FlagBootstrapRemoteRemoteEnv, Name: "remote-env", Longs: []string{"remote-env"}, TakesValue: true, Delimiter: ','},
 		{Key: FlagBootstrapRemoteRemoteMise, Name: "remote-mise", Longs: []string{"remote-mise"}, TakesValue: true},
-		{Key: FlagBootstrapRemoteSkip, Name: "skip", Longs: []string{"skip"}, TakesValue: true},
+		{Key: FlagBootstrapRemoteSkip, Name: "skip", Longs: []string{"skip"}, TakesValue: true, Delimiter: ','},
 		{Key: FlagBootstrapRemoteSource, Name: "source", Longs: []string{"source"}, TakesValue: true},
 		{Key: FlagBootstrapRemoteSshOption, Name: "ssh-option", Longs: []string{"ssh-option"}, TakesValue: true},
 		{Key: FlagBootstrapRemoteTag, Name: "tag", Longs: []string{"tag"}, TakesValue: true},
@@ -2079,7 +2094,7 @@ var cmdConfig = &argv.Command{
 	Aliases: []string{"cfg", "toml"},
 	Flags: []*argv.Flag{
 		{Key: FlagConfigJson, Name: "json", Longs: []string{"json"}, Shorts: []byte{'J'}},
-		{Key: FlagConfigNoHeader, Name: "no-header", Longs: []string{"no-header"}},
+		{Key: FlagConfigNoHeader, Name: "no-header", Longs: []string{"no-header", "no-headers"}, HiddenLongs: []string{"no-headers"}},
 		{Key: FlagConfigTrackedConfigs, Name: "tracked-configs", Longs: []string{"tracked-configs"}},
 	},
 	Subcommands: []*argv.Command{cmdConfigGet, cmdConfigLs, cmdConfigSet},
@@ -2104,7 +2119,7 @@ var cmdConfigLs = &argv.Command{
 	Aliases: []string{"list"},
 	Flags: []*argv.Flag{
 		{Key: FlagConfigLsJson, Name: "json", Longs: []string{"json"}, Shorts: []byte{'J'}},
-		{Key: FlagConfigLsNoHeader, Name: "no-header", Longs: []string{"no-header"}},
+		{Key: FlagConfigLsNoHeader, Name: "no-header", Longs: []string{"no-header", "no-headers"}, HiddenLongs: []string{"no-headers"}},
 		{Key: FlagConfigLsTrackedConfigs, Name: "tracked-configs", Longs: []string{"tracked-configs"}},
 	},
 }
@@ -2181,7 +2196,7 @@ var cmdDotfilesAdd = &argv.Command{
 		{Key: FlagDotfilesAddMode, Name: "mode", Longs: []string{"mode"}, Shorts: []byte{'m'}, TakesValue: true},
 		{Key: FlagDotfilesAddDryRun, Name: "dry-run", Longs: []string{"dry-run"}, Shorts: []byte{'n'}},
 		{Key: FlagDotfilesAddNoApply, Name: "no-apply", Longs: []string{"no-apply"}},
-		{Key: FlagDotfilesAddPath, Name: "path", Longs: []string{"path", "file"}, Shorts: []byte{'p'}, TakesValue: true},
+		{Key: FlagDotfilesAddPath, Name: "path", Longs: []string{"path"}, Shorts: []byte{'p'}, TakesValue: true},
 		{Key: FlagDotfilesAddSource, Name: "source", Longs: []string{"source"}, Shorts: []byte{'s'}, TakesValue: true},
 		{Key: FlagDotfilesAddYes, Name: "yes", Longs: []string{"yes"}, Shorts: []byte{'y'}},
 	},
@@ -2351,8 +2366,9 @@ var cmdGenerateBootstrap = &argv.Command{
 	Flags: []*argv.Flag{
 		{Key: FlagGenerateBootstrapLocalize, Name: "localize", Longs: []string{"localize"}, Shorts: []byte{'l'}},
 		{Key: FlagGenerateBootstrapVersion, Name: "version", Longs: []string{"version"}, Shorts: []byte{'V'}, TakesValue: true},
-		{Key: FlagGenerateBootstrapWrite, Name: "write", Longs: []string{"write"}, Shorts: []byte{'w'}, TakesValue: true},
+		{Key: FlagGenerateBootstrapWrite, Name: "write", Longs: []string{"write"}, Shorts: []byte{'w'}, TakesValue: true, ValueOptional: true, DefaultMissing: "./bin/mise"},
 		{Key: FlagGenerateBootstrapLocalizedDir, Name: "localized-dir", Longs: []string{"localized-dir"}, TakesValue: true},
+		{Key: FlagGenerateBootstrapWindows, Name: "windows", Longs: []string{"windows"}},
 	},
 }
 
@@ -2391,6 +2407,9 @@ var cmdGenerateGitPreCommit = &argv.Command{
 		{Key: FlagGenerateGitPreCommitTask, Name: "task", Longs: []string{"task"}, Shorts: []byte{'t'}, TakesValue: true},
 		{Key: FlagGenerateGitPreCommitWrite, Name: "write", Longs: []string{"write"}, Shorts: []byte{'w'}},
 		{Key: FlagGenerateGitPreCommitHook, Name: "hook", Longs: []string{"hook"}, TakesValue: true},
+	},
+	Args: []*argv.Arg{
+		{Key: ArgGenerateGitPreCommitMiseArg, Name: "MISE_ARG", Var: true, DoubleDash: argv.DoubleDashRequired},
 	},
 }
 
@@ -2437,6 +2456,7 @@ var cmdGenerateToolStub = &argv.Command{
 		{Key: FlagGenerateToolStubBin, Name: "bin", Longs: []string{"bin"}, Shorts: []byte{'b'}, TakesValue: true},
 		{Key: FlagGenerateToolStubBootstrap, Name: "bootstrap", Longs: []string{"bootstrap"}},
 		{Key: FlagGenerateToolStubBootstrapVersion, Name: "bootstrap-version", Longs: []string{"bootstrap-version"}, TakesValue: true},
+		{Key: FlagGenerateToolStubChecksumAlgorithm, Name: "checksum-algorithm", Longs: []string{"checksum-algorithm"}, TakesValue: true},
 		{Key: FlagGenerateToolStubFetch, Name: "fetch", Longs: []string{"fetch"}},
 		{Key: FlagGenerateToolStubHttp, Name: "http", Longs: []string{"http"}, TakesValue: true},
 		{Key: FlagGenerateToolStubLock, Name: "lock", Longs: []string{"lock"}},
@@ -2481,7 +2501,7 @@ var cmdGlobal = &argv.Command{
 		{Key: FlagGlobalFuzzy, Name: "fuzzy", Longs: []string{"fuzzy"}},
 		{Key: FlagGlobalPath, Name: "path", Longs: []string{"path"}},
 		{Key: FlagGlobalPin, Name: "pin", Longs: []string{"pin"}},
-		{Key: FlagGlobalRemove, Name: "remove", Longs: []string{"remove"}, TakesValue: true},
+		{Key: FlagGlobalRemove, Name: "remove", Longs: []string{"remove", "rm", "unset"}, HiddenLongs: []string{"rm", "unset"}, TakesValue: true},
 	},
 	Args: []*argv.Arg{
 		{Key: ArgGlobalToolVersion, Name: "TOOL@VERSION", Var: true},
@@ -2548,7 +2568,8 @@ var cmdInstall = &argv.Command{
 		{Key: FlagInstallDryRun, Name: "dry-run", Longs: []string{"dry-run"}, Shorts: []byte{'n'}},
 		{Key: FlagInstallVerbose, Name: "verbose", Longs: []string{"verbose"}, Shorts: []byte{'v'}},
 		{Key: FlagInstallDryRunCode, Name: "dry-run-code", Longs: []string{"dry-run-code"}},
-		{Key: FlagInstallMinimumReleaseAge, Name: "minimum-release-age", Longs: []string{"minimum-release-age"}, TakesValue: true},
+		{Key: FlagInstallIncludeTaskTools, Name: "include-task-tools", Longs: []string{"include-task-tools"}},
+		{Key: FlagInstallMinimumReleaseAge, Name: "minimum-release-age", Longs: []string{"minimum-release-age", "before"}, HiddenLongs: []string{"before"}, TakesValue: true},
 		{Key: FlagInstallMonorepo, Name: "monorepo", Longs: []string{"monorepo"}},
 		{Key: FlagInstallRaw, Name: "raw", Longs: []string{"raw"}},
 		{Key: FlagInstallShared, Name: "shared", Longs: []string{"shared"}, TakesValue: true},
@@ -2575,7 +2596,7 @@ var cmdLatest = &argv.Command{
 	Key:  CmdLatest,
 	Flags: []*argv.Flag{
 		{Key: FlagLatestInstalled, Name: "installed", Longs: []string{"installed"}, Shorts: []byte{'i'}},
-		{Key: FlagLatestMinimumReleaseAge, Name: "minimum-release-age", Longs: []string{"minimum-release-age"}, TakesValue: true},
+		{Key: FlagLatestMinimumReleaseAge, Name: "minimum-release-age", Longs: []string{"minimum-release-age", "before"}, HiddenLongs: []string{"before"}, TakesValue: true},
 	},
 	Args: []*argv.Arg{
 		{Key: ArgLatestToolVersion, Name: "TOOL@VERSION", Required: true},
@@ -2607,7 +2628,7 @@ var cmdLocal = &argv.Command{
 		{Key: FlagLocalFuzzy, Name: "fuzzy", Longs: []string{"fuzzy"}},
 		{Key: FlagLocalPath, Name: "path", Longs: []string{"path"}},
 		{Key: FlagLocalPin, Name: "pin", Longs: []string{"pin"}},
-		{Key: FlagLocalRemove, Name: "remove", Longs: []string{"remove"}, TakesValue: true},
+		{Key: FlagLocalRemove, Name: "remove", Longs: []string{"remove", "rm", "unset"}, HiddenLongs: []string{"rm", "unset"}, TakesValue: true},
 	},
 	Args: []*argv.Arg{
 		{Key: ArgLocalToolVersion, Name: "TOOL@VERSION", Var: true},
@@ -2622,11 +2643,11 @@ var cmdLock = &argv.Command{
 		{Key: FlagLockGlobal, Name: "global", Longs: []string{"global"}, Shorts: []byte{'g'}},
 		{Key: FlagLockJobs, Name: "jobs", Longs: []string{"jobs"}, Shorts: []byte{'j'}, TakesValue: true},
 		{Key: FlagLockDryRun, Name: "dry-run", Longs: []string{"dry-run"}, Shorts: []byte{'n'}},
-		{Key: FlagLockPlatform, Name: "platform", Longs: []string{"platform"}, Shorts: []byte{'p'}, TakesValue: true},
+		{Key: FlagLockPlatform, Name: "platform", Longs: []string{"platform"}, Shorts: []byte{'p'}, TakesValue: true, Delimiter: ','},
 		{Key: FlagLockBump, Name: "bump", Longs: []string{"bump"}},
 		{Key: FlagLockJson, Name: "json", Longs: []string{"json"}},
 		{Key: FlagLockLocal, Name: "local", Longs: []string{"local"}},
-		{Key: FlagLockMinimumReleaseAge, Name: "minimum-release-age", Longs: []string{"minimum-release-age"}, TakesValue: true},
+		{Key: FlagLockMinimumReleaseAge, Name: "minimum-release-age", Longs: []string{"minimum-release-age", "before"}, HiddenLongs: []string{"before"}, TakesValue: true},
 	},
 	Args: []*argv.Arg{
 		{Key: ArgLockTool, Name: "TOOL", Var: true},
@@ -2649,7 +2670,7 @@ var cmdLs = &argv.Command{
 		{Key: FlagLsPlugin, Name: "plugin", Longs: []string{"plugin"}, Shorts: []byte{'p'}, TakesValue: true},
 		{Key: FlagLsAllSources, Name: "all-sources", Longs: []string{"all-sources"}},
 		{Key: FlagLsMonorepo, Name: "monorepo", Longs: []string{"monorepo"}},
-		{Key: FlagLsNoHeader, Name: "no-header", Longs: []string{"no-header"}},
+		{Key: FlagLsNoHeader, Name: "no-header", Longs: []string{"no-header", "no-headers"}, HiddenLongs: []string{"no-headers"}},
 		{Key: FlagLsOutdated, Name: "outdated", Longs: []string{"outdated"}},
 		{Key: FlagLsPrefix, Name: "prefix", Longs: []string{"prefix"}, TakesValue: true},
 		{Key: FlagLsPrunable, Name: "prunable", Longs: []string{"prunable"}},
@@ -2666,7 +2687,7 @@ var cmdLsRemote = &argv.Command{
 	Aliases: []string{"list-all", "list-remote"},
 	Flags: []*argv.Flag{
 		{Key: FlagLsRemoteAll, Name: "all", Longs: []string{"all"}},
-		{Key: FlagLsRemoteMinimumReleaseAge, Name: "minimum-release-age", Longs: []string{"minimum-release-age"}, TakesValue: true},
+		{Key: FlagLsRemoteMinimumReleaseAge, Name: "minimum-release-age", Longs: []string{"minimum-release-age", "before"}, HiddenLongs: []string{"before"}, TakesValue: true},
 		{Key: FlagLsRemoteJson, Name: "json", Longs: []string{"json"}, Shorts: []byte{'J'}},
 		{Key: FlagLsRemoteNoVersionsHost, Name: "no-versions-host", Longs: []string{"no-versions-host"}},
 		{Key: FlagLsRemotePrerelease, Name: "prerelease", Longs: []string{"prerelease"}},
@@ -2740,7 +2761,7 @@ var cmdOciRun = &argv.Command{
 		{Key: FlagOciRunMountPoint, Name: "mount-point", Longs: []string{"mount-point"}, TakesValue: true},
 		{Key: FlagOciRunNoMise, Name: "no-mise", Longs: []string{"no-mise"}},
 		{Key: FlagOciRunOwner, Name: "owner", Longs: []string{"owner"}, TakesValue: true},
-		{Key: FlagOciRunVolume, Name: "volume", Longs: []string{"volume"}, TakesValue: true},
+		{Key: FlagOciRunVolume, Name: "volume", Longs: []string{"volume", "mount"}, HiddenLongs: []string{"mount"}, TakesValue: true},
 		{Key: FlagOciRunEnv, Name: "env", Longs: []string{"env"}, Shorts: []byte{'e'}, TakesValue: true},
 		{Key: FlagOciRunInteractive, Name: "interactive", Longs: []string{"interactive"}, Shorts: []byte{'i'}},
 		{Key: FlagOciRunTty, Name: "tty", Longs: []string{"tty"}, Shorts: []byte{'t'}},
@@ -2756,8 +2777,9 @@ var cmdOutdated = &argv.Command{
 	Name: "outdated",
 	Key:  CmdOutdated,
 	Flags: []*argv.Flag{
+		{Key: FlagOutdatedBump, Name: "bump", Longs: []string{"bump"}, Shorts: []byte{'b'}},
 		{Key: FlagOutdatedJson, Name: "json", Longs: []string{"json"}, Shorts: []byte{'J'}},
-		{Key: FlagOutdatedBump, Name: "bump", Longs: []string{"bump"}, Shorts: []byte{'l'}},
+		{Key: FlagOutdatedL, Name: "l", Shorts: []byte{'l'}},
 		{Key: FlagOutdatedInactive, Name: "inactive", Longs: []string{"inactive"}},
 		{Key: FlagOutdatedLocal, Name: "local", Longs: []string{"local"}},
 		{Key: FlagOutdatedMonorepo, Name: "monorepo", Longs: []string{"monorepo"}},
@@ -2786,7 +2808,7 @@ var cmdPlugins = &argv.Command{
 	Flags: []*argv.Flag{
 		{Key: FlagPluginsAll, Name: "all", Longs: []string{"all"}, Shorts: []byte{'a'}},
 		{Key: FlagPluginsCore, Name: "core", Longs: []string{"core"}, Shorts: []byte{'c'}},
-		{Key: FlagPluginsUrls, Name: "urls", Longs: []string{"urls"}, Shorts: []byte{'u'}},
+		{Key: FlagPluginsUrls, Name: "urls", Longs: []string{"urls", "url"}, HiddenLongs: []string{"url"}, Shorts: []byte{'u'}},
 		{Key: FlagPluginsRefs, Name: "refs", Longs: []string{"refs"}},
 		{Key: FlagPluginsUser, Name: "user", Longs: []string{"user"}},
 	},
@@ -2834,7 +2856,7 @@ var cmdPluginsLs = &argv.Command{
 		{Key: FlagPluginsLsAll, Name: "all", Longs: []string{"all"}, Shorts: []byte{'a'}},
 		{Key: FlagPluginsLsCore, Name: "core", Longs: []string{"core"}, Shorts: []byte{'c'}},
 		{Key: FlagPluginsLsOutdated, Name: "outdated", Longs: []string{"outdated"}, Shorts: []byte{'o'}},
-		{Key: FlagPluginsLsUrls, Name: "urls", Longs: []string{"urls"}, Shorts: []byte{'u'}},
+		{Key: FlagPluginsLsUrls, Name: "urls", Longs: []string{"urls", "url"}, HiddenLongs: []string{"url"}, Shorts: []byte{'u'}},
 		{Key: FlagPluginsLsRefs, Name: "refs", Longs: []string{"refs"}},
 		{Key: FlagPluginsLsUser, Name: "user", Longs: []string{"user"}},
 	},
@@ -2999,6 +3021,7 @@ var cmdRun = &argv.Command{
 		{Key: FlagRunAffectedExplain, Name: "affected-explain", Longs: []string{"affected-explain"}},
 		{Key: FlagRunAffectedHead, Name: "affected-head", Longs: []string{"affected-head"}, TakesValue: true},
 		{Key: FlagRunAffectedJson, Name: "affected-json", Longs: []string{"affected-json"}},
+		{Key: FlagRunAll, Name: "all", Longs: []string{"all"}},
 		{Key: FlagRunContinueOnError, Name: "continue-on-error", Longs: []string{"continue-on-error"}, Shorts: []byte{'c'}},
 		{Key: FlagRunCd, Name: "cd", Longs: []string{"cd"}, Shorts: []byte{'C'}, TakesValue: true},
 		{Key: FlagRunForce, Name: "force", Longs: []string{"force"}, Shorts: []byte{'f'}},
@@ -3022,7 +3045,7 @@ var cmdRun = &argv.Command{
 		{Key: FlagRunFreshEnv, Name: "fresh-env", Longs: []string{"fresh-env"}},
 		{Key: FlagRunNoCache, Name: "no-cache", Longs: []string{"no-cache"}},
 		{Key: FlagRunNoDeps, Name: "no-deps", Longs: []string{"no-deps"}},
-		{Key: FlagRunNoTimings, Name: "no-timings", Longs: []string{"no-timings"}},
+		{Key: FlagRunNoTimings, Name: "no-timings", Longs: []string{"no-timings", "no-timing"}, HiddenLongs: []string{"no-timing"}},
 		{Key: FlagRunSkipDeps, Name: "skip-deps", Longs: []string{"skip-deps"}},
 		{Key: FlagRunSkipTools, Name: "skip-tools", Longs: []string{"skip-tools"}},
 		{Key: FlagRunTaskCache, Name: "task-cache", Longs: []string{"task-cache"}, TakesValue: true},
@@ -3030,8 +3053,9 @@ var cmdRun = &argv.Command{
 		{Key: FlagRunTaskCacheExplainJson, Name: "task-cache-explain-json", Longs: []string{"task-cache-explain-json"}},
 		{Key: FlagRunTaskCacheStats, Name: "task-cache-stats", Longs: []string{"task-cache-stats"}},
 		{Key: FlagRunTimeout, Name: "timeout", Longs: []string{"timeout"}, TakesValue: true},
-		{Key: FlagRunTimings, Name: "timings", Longs: []string{"timings"}},
+		{Key: FlagRunTimings, Name: "timings", Longs: []string{"timings", "timing"}, HiddenLongs: []string{"timing"}},
 	},
+	DisableHelpFlag: true,
 }
 
 // search
@@ -3041,7 +3065,7 @@ var cmdSearch = &argv.Command{
 	Flags: []*argv.Flag{
 		{Key: FlagSearchInteractive, Name: "interactive", Longs: []string{"interactive"}, Shorts: []byte{'i'}},
 		{Key: FlagSearchMatchType, Name: "match-type", Longs: []string{"match-type"}, Shorts: []byte{'m'}, TakesValue: true},
-		{Key: FlagSearchNoHeader, Name: "no-header", Longs: []string{"no-header"}},
+		{Key: FlagSearchNoHeader, Name: "no-header", Longs: []string{"no-header", "no-headers"}, HiddenLongs: []string{"no-headers"}},
 	},
 	Args: []*argv.Arg{
 		{Key: ArgSearchName, Name: "NAME"},
@@ -3297,7 +3321,7 @@ var cmdTasks = &argv.Command{
 		{Key: FlagTasksComplete, Name: "complete", Longs: []string{"complete"}},
 		{Key: FlagTasksHidden, Name: "hidden", Longs: []string{"hidden"}},
 		{Key: FlagTasksNameOnly, Name: "name-only", Longs: []string{"name-only"}},
-		{Key: FlagTasksNoHeader, Name: "no-header", Longs: []string{"no-header"}},
+		{Key: FlagTasksNoHeader, Name: "no-header", Longs: []string{"no-header", "no-headers"}, HiddenLongs: []string{"no-headers"}},
 		{Key: FlagTasksSort, Name: "sort", Longs: []string{"sort"}, TakesValue: true},
 		{Key: FlagTasksSortOrder, Name: "sort-order", Longs: []string{"sort-order"}, TakesValue: true},
 		{Key: FlagTasksUsage, Name: "usage", Longs: []string{"usage"}},
@@ -3368,7 +3392,7 @@ var cmdTasksGraph = &argv.Command{
 	Flags: []*argv.Flag{
 		{Key: FlagTasksGraphJson, Name: "json", Longs: []string{"json"}, Shorts: []byte{'J'}},
 		{Key: FlagTasksGraphExplain, Name: "explain", Longs: []string{"explain"}},
-		{Key: FlagTasksGraphNoHeader, Name: "no-header", Longs: []string{"no-header"}},
+		{Key: FlagTasksGraphNoHeader, Name: "no-header", Longs: []string{"no-header", "no-headers"}, HiddenLongs: []string{"no-headers"}},
 	},
 }
 
@@ -3397,7 +3421,7 @@ var cmdTasksLs = &argv.Command{
 		{Key: FlagTasksLsComplete, Name: "complete", Longs: []string{"complete"}},
 		{Key: FlagTasksLsHidden, Name: "hidden", Longs: []string{"hidden"}},
 		{Key: FlagTasksLsNameOnly, Name: "name-only", Longs: []string{"name-only"}},
-		{Key: FlagTasksLsNoHeader, Name: "no-header", Longs: []string{"no-header"}},
+		{Key: FlagTasksLsNoHeader, Name: "no-header", Longs: []string{"no-header", "no-headers"}, HiddenLongs: []string{"no-headers"}},
 		{Key: FlagTasksLsSort, Name: "sort", Longs: []string{"sort"}, TakesValue: true},
 		{Key: FlagTasksLsSortOrder, Name: "sort-order", Longs: []string{"sort-order"}, TakesValue: true},
 		{Key: FlagTasksLsUsage, Name: "usage", Longs: []string{"usage"}},
@@ -3415,6 +3439,7 @@ var cmdTasksRun = &argv.Command{
 		{Key: FlagTasksRunAffectedExplain, Name: "affected-explain", Longs: []string{"affected-explain"}},
 		{Key: FlagTasksRunAffectedHead, Name: "affected-head", Longs: []string{"affected-head"}, TakesValue: true},
 		{Key: FlagTasksRunAffectedJson, Name: "affected-json", Longs: []string{"affected-json"}},
+		{Key: FlagTasksRunAll, Name: "all", Longs: []string{"all"}},
 		{Key: FlagTasksRunContinueOnError, Name: "continue-on-error", Longs: []string{"continue-on-error"}, Shorts: []byte{'c'}},
 		{Key: FlagTasksRunCd, Name: "cd", Longs: []string{"cd"}, Shorts: []byte{'C'}, TakesValue: true},
 		{Key: FlagTasksRunForce, Name: "force", Longs: []string{"force"}, Shorts: []byte{'f'}},
@@ -3438,7 +3463,7 @@ var cmdTasksRun = &argv.Command{
 		{Key: FlagTasksRunFreshEnv, Name: "fresh-env", Longs: []string{"fresh-env"}},
 		{Key: FlagTasksRunNoCache, Name: "no-cache", Longs: []string{"no-cache"}},
 		{Key: FlagTasksRunNoDeps, Name: "no-deps", Longs: []string{"no-deps"}},
-		{Key: FlagTasksRunNoTimings, Name: "no-timings", Longs: []string{"no-timings"}},
+		{Key: FlagTasksRunNoTimings, Name: "no-timings", Longs: []string{"no-timings", "no-timing"}, HiddenLongs: []string{"no-timing"}},
 		{Key: FlagTasksRunSkipDeps, Name: "skip-deps", Longs: []string{"skip-deps"}},
 		{Key: FlagTasksRunSkipTools, Name: "skip-tools", Longs: []string{"skip-tools"}},
 		{Key: FlagTasksRunTaskCache, Name: "task-cache", Longs: []string{"task-cache"}, TakesValue: true},
@@ -3446,13 +3471,14 @@ var cmdTasksRun = &argv.Command{
 		{Key: FlagTasksRunTaskCacheExplainJson, Name: "task-cache-explain-json", Longs: []string{"task-cache-explain-json"}},
 		{Key: FlagTasksRunTaskCacheStats, Name: "task-cache-stats", Longs: []string{"task-cache-stats"}},
 		{Key: FlagTasksRunTimeout, Name: "timeout", Longs: []string{"timeout"}, TakesValue: true},
-		{Key: FlagTasksRunTimings, Name: "timings", Longs: []string{"timings"}},
+		{Key: FlagTasksRunTimings, Name: "timings", Longs: []string{"timings", "timing"}, HiddenLongs: []string{"timing"}},
 	},
 	Args: []*argv.Arg{
-		{Key: ArgTasksRunTask, Name: "TASK"},
+		{Key: ArgTasksRunTask, Name: "TASK", DoubleDash: argv.DoubleDashAutomatic},
 		{Key: ArgTasksRunArgs, Name: "ARGS", Var: true},
 		{Key: ArgTasksRunArgsLast, Name: "ARGS_LAST", Var: true, DoubleDash: argv.DoubleDashRequired},
 	},
+	DisableHelpFlag: true,
 }
 
 // tasks validate
@@ -3557,6 +3583,8 @@ var cmdToolStub = &argv.Command{
 		{Key: ArgToolStubFile, Name: "FILE", Required: true},
 		{Key: ArgToolStubArgs, Name: "ARGS", Var: true, DoubleDash: argv.DoubleDashAutomatic},
 	},
+	DisableHelpFlag:    true,
+	DisableVersionFlag: true,
 }
 
 // trust
@@ -3632,17 +3660,19 @@ var cmdUpgrade = &argv.Command{
 	Key:     CmdUpgrade,
 	Aliases: []string{"up"},
 	Flags: []*argv.Flag{
+		{Key: FlagUpgradeBump, Name: "bump", Longs: []string{"bump"}, Shorts: []byte{'b'}},
 		{Key: FlagUpgradeInteractive, Name: "interactive", Longs: []string{"interactive"}, Shorts: []byte{'i'}},
 		{Key: FlagUpgradeJobs, Name: "jobs", Longs: []string{"jobs"}, Shorts: []byte{'j'}, TakesValue: true},
-		{Key: FlagUpgradeBump, Name: "bump", Longs: []string{"bump"}, Shorts: []byte{'l'}},
+		{Key: FlagUpgradeL, Name: "l", Shorts: []byte{'l'}},
 		{Key: FlagUpgradeDryRun, Name: "dry-run", Longs: []string{"dry-run"}, Shorts: []byte{'n'}},
 		{Key: FlagUpgradeExclude, Name: "exclude", Longs: []string{"exclude"}, Shorts: []byte{'x'}, TakesValue: true},
 		{Key: FlagUpgradeDryRunCode, Name: "dry-run-code", Longs: []string{"dry-run-code"}},
 		{Key: FlagUpgradeInactive, Name: "inactive", Longs: []string{"inactive"}},
 		{Key: FlagUpgradeLocal, Name: "local", Longs: []string{"local"}},
-		{Key: FlagUpgradeMinimumReleaseAge, Name: "minimum-release-age", Longs: []string{"minimum-release-age"}, TakesValue: true},
+		{Key: FlagUpgradeMinimumReleaseAge, Name: "minimum-release-age", Longs: []string{"minimum-release-age", "before"}, HiddenLongs: []string{"before"}, TakesValue: true},
 		{Key: FlagUpgradeMonorepo, Name: "monorepo", Longs: []string{"monorepo"}},
 		{Key: FlagUpgradeNoPrune, Name: "no-prune", Longs: []string{"no-prune"}},
+		{Key: FlagUpgradePrune, Name: "prune", Longs: []string{"prune"}},
 		{Key: FlagUpgradeRaw, Name: "raw", Longs: []string{"raw"}},
 	},
 	Args: []*argv.Arg{
@@ -3667,13 +3697,13 @@ var cmdUse = &argv.Command{
 		{Key: FlagUseGlobal, Name: "global", Longs: []string{"global"}, Shorts: []byte{'g'}},
 		{Key: FlagUseJobs, Name: "jobs", Longs: []string{"jobs"}, Shorts: []byte{'j'}, TakesValue: true},
 		{Key: FlagUseDryRun, Name: "dry-run", Longs: []string{"dry-run"}, Shorts: []byte{'n'}},
-		{Key: FlagUsePath, Name: "path", Longs: []string{"path", "file"}, Shorts: []byte{'p'}, TakesValue: true},
+		{Key: FlagUsePath, Name: "path", Longs: []string{"path"}, Shorts: []byte{'p'}, TakesValue: true},
 		{Key: FlagUseDryRunCode, Name: "dry-run-code", Longs: []string{"dry-run-code"}},
 		{Key: FlagUseFuzzy, Name: "fuzzy", Longs: []string{"fuzzy"}},
-		{Key: FlagUseMinimumReleaseAge, Name: "minimum-release-age", Longs: []string{"minimum-release-age"}, TakesValue: true},
+		{Key: FlagUseMinimumReleaseAge, Name: "minimum-release-age", Longs: []string{"minimum-release-age", "before"}, HiddenLongs: []string{"before"}, TakesValue: true},
 		{Key: FlagUsePin, Name: "pin", Longs: []string{"pin"}},
 		{Key: FlagUseRaw, Name: "raw", Longs: []string{"raw"}},
-		{Key: FlagUseRemove, Name: "remove", Longs: []string{"remove"}, TakesValue: true},
+		{Key: FlagUseRemove, Name: "remove", Longs: []string{"remove", "rm", "unset"}, HiddenLongs: []string{"rm", "unset"}, TakesValue: true},
 	},
 	Args: []*argv.Arg{
 		{Key: ArgUseToolVersion, Name: "TOOL@VERSION", Var: true},
@@ -3702,7 +3732,7 @@ var cmdWatch = &argv.Command{
 		{Key: FlagWatchWatch, Name: "watch", Longs: []string{"watch"}, Shorts: []byte{'w'}, TakesValue: true},
 		{Key: FlagWatchWatchNonRecursive, Name: "watch-non-recursive", Longs: []string{"watch-non-recursive"}, Shorts: []byte{'W'}, TakesValue: true},
 		{Key: FlagWatchWatchFile, Name: "watch-file", Longs: []string{"watch-file"}, Shorts: []byte{'F'}, TakesValue: true},
-		{Key: FlagWatchClear, Name: "clear", Longs: []string{"clear"}, Shorts: []byte{'c'}, TakesValue: true},
+		{Key: FlagWatchClear, Name: "clear", Longs: []string{"clear"}, Shorts: []byte{'c'}, TakesValue: true, ValueOptional: true, DefaultMissing: "clear"},
 		{Key: FlagWatchOnBusyUpdate, Name: "on-busy-update", Longs: []string{"on-busy-update"}, Shorts: []byte{'o'}, TakesValue: true},
 		{Key: FlagWatchRestart, Name: "restart", Longs: []string{"restart"}, Shorts: []byte{'r'}},
 		{Key: FlagWatchSignal, Name: "signal", Longs: []string{"signal"}, Shorts: []byte{'s'}, TakesValue: true},
@@ -3719,7 +3749,7 @@ var cmdWatch = &argv.Command{
 		{Key: FlagWatchIgnoreNothing, Name: "ignore-nothing", Longs: []string{"ignore-nothing"}},
 		{Key: FlagWatchPostpone, Name: "postpone", Longs: []string{"postpone"}, Shorts: []byte{'p'}},
 		{Key: FlagWatchDelayRun, Name: "delay-run", Longs: []string{"delay-run"}, TakesValue: true},
-		{Key: FlagWatchPoll, Name: "poll", Longs: []string{"poll"}, TakesValue: true},
+		{Key: FlagWatchPoll, Name: "poll", Longs: []string{"poll", "force-poll"}, HiddenLongs: []string{"force-poll"}, TakesValue: true, ValueOptional: true, DefaultMissing: "30s"},
 		{Key: FlagWatchShell, Name: "shell", Longs: []string{"shell"}, TakesValue: true},
 		{Key: FlagWatchN, Name: "n", Shorts: []byte{'n'}},
 		{Key: FlagWatchEmitEventsTo, Name: "emit-events-to", Longs: []string{"emit-events-to"}, TakesValue: true},
@@ -3727,25 +3757,25 @@ var cmdWatch = &argv.Command{
 		{Key: FlagWatchEnv, Name: "env", Longs: []string{"env"}, Shorts: []byte{'E'}, TakesValue: true},
 		{Key: FlagWatchWrapProcess, Name: "wrap-process", Longs: []string{"wrap-process"}, TakesValue: true},
 		{Key: FlagWatchNotify, Name: "notify", Longs: []string{"notify"}, Shorts: []byte{'N'}},
-		{Key: FlagWatchColor, Name: "color", Longs: []string{"color"}, TakesValue: true},
+		{Key: FlagWatchColor, Name: "color", Longs: []string{"color", "colour"}, HiddenLongs: []string{"colour"}, TakesValue: true},
 		{Key: FlagWatchTimings, Name: "timings", Longs: []string{"timings"}},
 		{Key: FlagWatchQuiet, Name: "quiet", Longs: []string{"quiet"}, Shorts: []byte{'q'}},
 		{Key: FlagWatchBell, Name: "bell", Longs: []string{"bell"}},
 		{Key: FlagWatchProjectOrigin, Name: "project-origin", Longs: []string{"project-origin"}, TakesValue: true},
 		{Key: FlagWatchWorkdir, Name: "workdir", Longs: []string{"workdir"}, TakesValue: true},
-		{Key: FlagWatchExts, Name: "exts", Longs: []string{"exts"}, Shorts: []byte{'e'}, TakesValue: true},
+		{Key: FlagWatchExts, Name: "exts", Longs: []string{"exts"}, Shorts: []byte{'e'}, TakesValue: true, Delimiter: ','},
 		{Key: FlagWatchFilter, Name: "filter", Longs: []string{"filter"}, Shorts: []byte{'f'}, TakesValue: true},
-		{Key: FlagWatchFilterFile, Name: "filter-file", Longs: []string{"filter-file"}, TakesValue: true},
+		{Key: FlagWatchFilterFile, Name: "filter-file", Longs: []string{"filter-file"}, TakesValue: true, Delimiter: ':'},
 		{Key: FlagWatchFilterProg, Name: "filter-prog", Longs: []string{"filter-prog"}, Shorts: []byte{'J'}, TakesValue: true},
 		{Key: FlagWatchIgnore, Name: "ignore", Longs: []string{"ignore"}, Shorts: []byte{'i'}, TakesValue: true},
-		{Key: FlagWatchIgnoreFile, Name: "ignore-file", Longs: []string{"ignore-file"}, TakesValue: true},
-		{Key: FlagWatchFsEvents, Name: "fs-events", Longs: []string{"fs-events"}, TakesValue: true},
+		{Key: FlagWatchIgnoreFile, Name: "ignore-file", Longs: []string{"ignore-file"}, TakesValue: true, Delimiter: ':'},
+		{Key: FlagWatchFsEvents, Name: "fs-events", Longs: []string{"fs-events"}, TakesValue: true, Delimiter: ','},
 		{Key: FlagWatchNoMeta, Name: "no-meta", Longs: []string{"no-meta"}},
 		{Key: FlagWatchPrintEvents, Name: "print-events", Longs: []string{"print-events"}},
 		{Key: FlagWatchManual, Name: "manual", Longs: []string{"manual"}},
 	},
 	Args: []*argv.Arg{
-		{Key: ArgWatchTask, Name: "TASK"},
+		{Key: ArgWatchTask, Name: "TASK", DoubleDash: argv.DoubleDashAutomatic},
 		{Key: ArgWatchArgs, Name: "ARGS", Var: true, DoubleDash: argv.DoubleDashAutomatic},
 	},
 }
@@ -3785,20 +3815,20 @@ var cmdWhich = &argv.Command{
 var Meta = argv.Metadata{
 	{},
 	{Key: FlagContinueOnError, Name: "continue-on-error", Flag: true, RequiresIfBoolean: true, Spelling: "--continue-on-error"},
-	{Key: FlagCd, Name: "cd", Flag: true, Spelling: "--cd", ValueName: "DIR"},
+	{Key: FlagCd, Name: "cd", Flag: true, Spelling: "--cd", ValueName: "DIR", CompleteType: "dir"},
 	{Key: FlagEnv, Name: "env", Flag: true, Spelling: "--env", ValueName: "ENV"},
 	{Key: FlagForce, Name: "force", Flag: true, RequiresIfBoolean: true, Spelling: "--force"},
-	{Key: FlagJobs, Name: "jobs", Flag: true, Spelling: "--jobs", ValueName: "JOBS"},
+	{Key: FlagJobs, Name: "jobs", Flag: true, Spelling: "--jobs", ValueName: "JOBS", Env: "MISE_JOBS"},
 	{Key: FlagDryRun, Name: "dry-run", Flag: true, RequiresIfBoolean: true, Spelling: "--dry-run"},
-	{Key: FlagProfile, Name: "profile", Flag: true, Spelling: "--profile", ValueName: "PROFILE"},
-	{Key: FlagQuiet, Name: "quiet", Flag: true, RequiresIfBoolean: true, Spelling: "--quiet"},
+	{Key: FlagProfile, Name: "profile", Flag: true, Spelling: "--profile", ValueName: "PROFILE", Conflicts: []uint64{FlagEnv}},
+	{Key: FlagQuiet, Name: "quiet", Flag: true, RequiresIfBoolean: true, Spelling: "--quiet", Overrides: []uint64{FlagSilent, FlagTrace, FlagVerbose, FlagDebug, FlagLogLevel}},
 	{Key: FlagShell, Name: "shell", Flag: true, Spelling: "--shell", ValueName: "SHELL"},
-	{Key: FlagTool, Name: "tool", Flag: true, Spelling: "--tool", ValueName: "TOOL@VERSION"},
-	{Key: FlagVerbose, Name: "verbose", Flag: true, RequiresIfBoolean: true, Spelling: "--verbose"},
+	{Key: FlagTool, Name: "tool", Flag: true, Spelling: "--tool", ValueName: "TOOL@VERSION", Env: "MISE_QUIET"},
+	{Key: FlagVerbose, Name: "verbose", Flag: true, RequiresIfBoolean: true, Spelling: "--verbose", Overrides: []uint64{FlagQuiet, FlagSilent, FlagTrace, FlagDebug}},
 	{Key: FlagVersion, Name: "version", Flag: true, RequiresIfBoolean: true, Spelling: "--version"},
 	{Key: FlagYes, Name: "yes", Flag: true, RequiresIfBoolean: true, Spelling: "--yes"},
-	{Key: FlagDebug, Name: "debug", Flag: true, RequiresIfBoolean: true, Spelling: "--debug"},
-	{Key: FlagLogLevel, Name: "log-level", Flag: true, Spelling: "--log-level", ValueName: "LEVEL", Choices: []string{"trace", "debug", "info", "warning", "error"}, AcceptedChoices: []string{"trace", "debug", "info", "warning", "error"}},
+	{Key: FlagDebug, Name: "debug", Flag: true, RequiresIfBoolean: true, Spelling: "--debug", Overrides: []uint64{FlagQuiet, FlagTrace, FlagVerbose, FlagSilent, FlagLogLevel}},
+	{Key: FlagLogLevel, Name: "log-level", Flag: true, Spelling: "--log-level", ValueName: "LEVEL", Choices: []string{"trace", "debug", "info", "warning", "error"}, AcceptedChoices: []string{"trace", "debug", "info", "warning", "error"}, Overrides: []uint64{FlagQuiet, FlagTrace, FlagVerbose, FlagSilent, FlagDebug}},
 	{Key: FlagNoConfig, Name: "no-config", Flag: true, RequiresIfBoolean: true, Spelling: "--no-config"},
 	{Key: FlagNoEnv, Name: "no-env", Flag: true, RequiresIfBoolean: true, Spelling: "--no-env"},
 	{Key: FlagNoHooks, Name: "no-hooks", Flag: true, RequiresIfBoolean: true, Spelling: "--no-hooks"},
@@ -3806,9 +3836,9 @@ var Meta = argv.Metadata{
 	{Key: FlagOutput, Name: "output", Flag: true, Spelling: "--output", ValueName: "OUTPUT"},
 	{Key: FlagRaw, Name: "raw", Flag: true, RequiresIfBoolean: true, Spelling: "--raw"},
 	{Key: FlagLocked, Name: "locked", Flag: true, RequiresIfBoolean: true, Spelling: "--locked"},
-	{Key: FlagSilent, Name: "silent", Flag: true, RequiresIfBoolean: true, Spelling: "--silent"},
+	{Key: FlagSilent, Name: "silent", Flag: true, RequiresIfBoolean: true, Spelling: "--silent", Overrides: []uint64{FlagQuiet, FlagTrace, FlagVerbose, FlagDebug, FlagLogLevel}},
 	{Key: FlagTimings, Name: "timings", Flag: true, RequiresIfBoolean: true, Spelling: "--timings"},
-	{Key: FlagTrace, Name: "trace", Flag: true, RequiresIfBoolean: true, Spelling: "--trace"},
+	{Key: FlagTrace, Name: "trace", Flag: true, RequiresIfBoolean: true, Spelling: "--trace", Overrides: []uint64{FlagQuiet, FlagSilent, FlagVerbose, FlagDebug, FlagLogLevel}},
 	{Key: ArgTask, Name: "TASK"},
 	{Key: ArgTaskArgs, Name: "TASK_ARGS"},
 	{Key: ArgTaskArgsLast, Name: "TASK_ARGS_LAST"},
@@ -3840,16 +3870,16 @@ var Meta = argv.Metadata{
 	{},
 	{},
 	{},
-	{Key: FlagBinPathsBinNames, Name: "bin-names", Flag: true, RequiresIfBoolean: true, Spelling: "--bin-names"},
+	{Key: FlagBinPathsBinNames, Name: "bin-names", Flag: true, RequiresIfBoolean: true, Spelling: "--bin-names", DefaultIf: []argv.DefaultIf{{Key: FlagBinPathsJson, Value: "true"}}},
 	{Key: FlagBinPathsJson, Name: "json", Flag: true, RequiresIfBoolean: true, Spelling: "--json"},
 	{Key: ArgBinPathsToolVersion, Name: "TOOL@VERSION"},
 	{},
 	{Key: FlagBootstrapDryRun, Name: "dry-run", Flag: true, RequiresIfBoolean: true, Spelling: "--dry-run"},
 	{Key: FlagBootstrapYes, Name: "yes", Flag: true, RequiresIfBoolean: true, Spelling: "--yes"},
 	{Key: FlagBootstrapForceDotfiles, Name: "force-dotfiles", Flag: true, RequiresIfBoolean: true, Spelling: "--force-dotfiles"},
-	{Key: FlagBootstrapOnly, Name: "only", Flag: true, Spelling: "--only", ValueName: "ONLY", Choices: []string{"plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "shell", "macos-defaults", "defaults", "macos-launchd-agents", "launchd", "linux-systemd-units", "systemd", "user", "tools", "task", "final-hook"}, AcceptedChoices: []string{"plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "shell", "macos-defaults", "defaults", "macos-launchd-agents", "launchd", "linux-systemd-units", "systemd", "user", "tools", "task", "final-hook"}},
+	{Key: FlagBootstrapOnly, Name: "only", Flag: true, Spelling: "--only", ValueName: "ONLY", Choices: []string{"plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "macos-defaults", "macos-launchd-agents", "linux-systemd-units", "user", "tools", "task", "final-hook"}, AcceptedChoices: []string{"plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "macos-defaults", "macos-launchd-agents", "linux-systemd-units", "user", "tools", "task", "final-hook", "shell", "defaults", "launchd", "systemd"}, Conflicts: []uint64{FlagBootstrapSkip}},
 	{Key: FlagBootstrapPromptSecrets, Name: "prompt-secrets", Flag: true, RequiresIfBoolean: true, Spelling: "--prompt-secrets"},
-	{Key: FlagBootstrapSkip, Name: "skip", Flag: true, Spelling: "--skip", ValueName: "SKIP", Choices: []string{"plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "shell", "macos-defaults", "defaults", "macos-launchd-agents", "launchd", "linux-systemd-units", "systemd", "user", "tools", "task", "final-hook"}, AcceptedChoices: []string{"plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "shell", "macos-defaults", "defaults", "macos-launchd-agents", "launchd", "linux-systemd-units", "systemd", "user", "tools", "task", "final-hook"}},
+	{Key: FlagBootstrapSkip, Name: "skip", Flag: true, Spelling: "--skip", ValueName: "SKIP", Choices: []string{"plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "macos-defaults", "macos-launchd-agents", "linux-systemd-units", "user", "tools", "task", "final-hook"}, AcceptedChoices: []string{"plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "macos-defaults", "macos-launchd-agents", "linux-systemd-units", "user", "tools", "task", "final-hook", "shell", "defaults", "launchd", "systemd"}},
 	{Key: FlagBootstrapUpdate, Name: "update", Flag: true, RequiresIfBoolean: true, Spelling: "--update"},
 	{},
 	{},
@@ -3874,12 +3904,12 @@ var Meta = argv.Metadata{
 	{},
 	{},
 	{Key: FlagBootstrapDotfilesAddForce, Name: "force", Flag: true, RequiresIfBoolean: true, Spelling: "--force"},
-	{Key: FlagBootstrapDotfilesAddGlobal, Name: "global", Flag: true, RequiresIfBoolean: true, Spelling: "--global"},
-	{Key: FlagBootstrapDotfilesAddLocal, Name: "local", Flag: true, RequiresIfBoolean: true, Spelling: "--local"},
+	{Key: FlagBootstrapDotfilesAddGlobal, Name: "global", Flag: true, RequiresIfBoolean: true, Spelling: "--global", Conflicts: []uint64{FlagBootstrapDotfilesAddLocal, FlagBootstrapDotfilesAddPath}},
+	{Key: FlagBootstrapDotfilesAddLocal, Name: "local", Flag: true, RequiresIfBoolean: true, Spelling: "--local", Conflicts: []uint64{FlagBootstrapDotfilesAddGlobal, FlagBootstrapDotfilesAddPath}},
 	{Key: FlagBootstrapDotfilesAddMode, Name: "mode", Flag: true, Spelling: "--mode", ValueName: "MODE"},
 	{Key: FlagBootstrapDotfilesAddDryRun, Name: "dry-run", Flag: true, RequiresIfBoolean: true, Spelling: "--dry-run"},
 	{Key: FlagBootstrapDotfilesAddNoApply, Name: "no-apply", Flag: true, RequiresIfBoolean: true, Spelling: "--no-apply"},
-	{Key: FlagBootstrapDotfilesAddPath, Name: "path", Flag: true, Spelling: "--path", ValueName: "PATH"},
+	{Key: FlagBootstrapDotfilesAddPath, Name: "path", Flag: true, Spelling: "--path", ValueName: "PATH", Conflicts: []uint64{FlagBootstrapDotfilesAddGlobal, FlagBootstrapDotfilesAddLocal}},
 	{Key: FlagBootstrapDotfilesAddSource, Name: "source", Flag: true, Spelling: "--source", ValueName: "PATH"},
 	{Key: FlagBootstrapDotfilesAddYes, Name: "yes", Flag: true, RequiresIfBoolean: true, Spelling: "--yes"},
 	{Key: ArgBootstrapDotfilesAddTarget, Name: "TARGET", Required: true},
@@ -3974,23 +4004,23 @@ var Meta = argv.Metadata{
 	{},
 	{Key: FlagBootstrapPackagesBrewTapLocal, Name: "local", Flag: true, RequiresIfBoolean: true, Spelling: "--local"},
 	{Key: FlagBootstrapPackagesBrewTapDryRun, Name: "dry-run", Flag: true, RequiresIfBoolean: true, Spelling: "--dry-run"},
-	{Key: FlagBootstrapPackagesBrewTapPath, Name: "path", Flag: true, Spelling: "--path", ValueName: "PATH"},
+	{Key: FlagBootstrapPackagesBrewTapPath, Name: "path", Flag: true, Spelling: "--path", ValueName: "PATH", Conflicts: []uint64{FlagBootstrapPackagesBrewTapLocal}},
 	{Key: ArgBootstrapPackagesBrewTapTap, Name: "TAP", Required: true},
 	{Key: ArgBootstrapPackagesBrewTapUrl, Name: "URL"},
 	{},
 	{Key: FlagBootstrapPackagesBrewUntapLocal, Name: "local", Flag: true, RequiresIfBoolean: true, Spelling: "--local"},
 	{Key: FlagBootstrapPackagesBrewUntapDryRun, Name: "dry-run", Flag: true, RequiresIfBoolean: true, Spelling: "--dry-run"},
-	{Key: FlagBootstrapPackagesBrewUntapPath, Name: "path", Flag: true, Spelling: "--path", ValueName: "PATH"},
+	{Key: FlagBootstrapPackagesBrewUntapPath, Name: "path", Flag: true, Spelling: "--path", ValueName: "PATH", Conflicts: []uint64{FlagBootstrapPackagesBrewUntapLocal}},
 	{Key: ArgBootstrapPackagesBrewUntapTaps, Name: "TAPS", Required: true},
 	{},
-	{Key: FlagBootstrapPackagesImportEnv, Name: "env", Flag: true, Spelling: "--env", ValueName: "ENV"},
-	{Key: FlagBootstrapPackagesImportGlobal, Name: "global", Flag: true, RequiresIfBoolean: true, Spelling: "--global"},
+	{Key: FlagBootstrapPackagesImportEnv, Name: "env", Flag: true, Spelling: "--env", ValueName: "ENV", Conflicts: []uint64{FlagBootstrapPackagesImportGlobal, FlagBootstrapPackagesImportPath}},
+	{Key: FlagBootstrapPackagesImportGlobal, Name: "global", Flag: true, RequiresIfBoolean: true, Spelling: "--global", Conflicts: []uint64{FlagBootstrapPackagesImportEnv, FlagBootstrapPackagesImportPath}},
 	{Key: FlagBootstrapPackagesImportManager, Name: "manager", Flag: true, Spelling: "--manager", ValueName: "MANAGER", Choices: []string{"brew"}, AcceptedChoices: []string{"brew"}, Default: []string{"brew"}},
 	{Key: FlagBootstrapPackagesImportAll, Name: "all", Flag: true, RequiresIfBoolean: true, Spelling: "--all"},
 	{Key: FlagBootstrapPackagesImportDryRun, Name: "dry-run", Flag: true, RequiresIfBoolean: true, Spelling: "--dry-run"},
-	{Key: FlagBootstrapPackagesImportPath, Name: "path", Flag: true, Spelling: "--path", ValueName: "PATH"},
+	{Key: FlagBootstrapPackagesImportPath, Name: "path", Flag: true, Spelling: "--path", ValueName: "PATH", Conflicts: []uint64{FlagBootstrapPackagesImportGlobal}},
 	{},
-	{Key: FlagBootstrapPackagesPruneManager, Name: "manager", Flag: true, Spelling: "--manager", ValueName: "MANAGER", Choices: []string{"brew"}, AcceptedChoices: []string{"brew"}, Default: []string{"brew"}},
+	{Key: FlagBootstrapPackagesPruneManager, Name: "manager", Flag: true, Spelling: "--manager", ValueName: "MANAGER", Choices: []string{"brew", "brew-cask"}, AcceptedChoices: []string{"brew", "brew-cask"}, Default: []string{"brew"}},
 	{Key: FlagBootstrapPackagesPruneDryRun, Name: "dry-run", Flag: true, RequiresIfBoolean: true, Spelling: "--dry-run"},
 	{Key: FlagBootstrapPackagesPruneYes, Name: "yes", Flag: true, RequiresIfBoolean: true, Spelling: "--yes"},
 	{},
@@ -4002,10 +4032,10 @@ var Meta = argv.Metadata{
 	{Key: FlagBootstrapPackagesUpgradeYes, Name: "yes", Flag: true, RequiresIfBoolean: true, Spelling: "--yes"},
 	{Key: ArgBootstrapPackagesUpgradePackage, Name: "PACKAGE"},
 	{},
-	{Key: FlagBootstrapPackagesUseEnv, Name: "env", Flag: true, Spelling: "--env", ValueName: "ENV"},
+	{Key: FlagBootstrapPackagesUseEnv, Name: "env", Flag: true, Spelling: "--env", ValueName: "ENV", Conflicts: []uint64{FlagBootstrapPackagesUseGlobal, FlagBootstrapPackagesUsePath}},
 	{Key: FlagBootstrapPackagesUseGlobal, Name: "global", Flag: true, RequiresIfBoolean: true, Spelling: "--global"},
 	{Key: FlagBootstrapPackagesUseDryRun, Name: "dry-run", Flag: true, RequiresIfBoolean: true, Spelling: "--dry-run"},
-	{Key: FlagBootstrapPackagesUsePath, Name: "path", Flag: true, Spelling: "--path", ValueName: "PATH"},
+	{Key: FlagBootstrapPackagesUsePath, Name: "path", Flag: true, Spelling: "--path", ValueName: "PATH", Conflicts: []uint64{FlagBootstrapPackagesUseGlobal}},
 	{Key: FlagBootstrapPackagesUseYes, Name: "yes", Flag: true, RequiresIfBoolean: true, Spelling: "--yes"},
 	{Key: ArgBootstrapPackagesUsePackage, Name: "PACKAGE", Required: true},
 	{},
@@ -4019,8 +4049,10 @@ var Meta = argv.Metadata{
 	{Key: FlagBootstrapPluginsStatusMissing, Name: "missing", Flag: true, RequiresIfBoolean: true, Spelling: "--missing"},
 	{},
 	{Key: FlagBootstrapRemoteAll, Name: "all", Flag: true, RequiresIfBoolean: true, Spelling: "--all"},
-	{Key: FlagBootstrapRemoteBootstrapCommand, Name: "bootstrap-command", Flag: true, Spelling: "--bootstrap-command", ValueName: "COMMAND"},
+	{Key: FlagBootstrapRemoteBootstrapCommand, Name: "bootstrap-command", Flag: true, Spelling: "--bootstrap-command", ValueName: "COMMAND", Conflicts: []uint64{FlagBootstrapRemoteMiseBin, FlagBootstrapRemoteRemoteMise}},
 	{Key: FlagBootstrapRemoteConnectTimeout, Name: "connect-timeout", Flag: true, Spelling: "--connect-timeout", ValueName: "CONNECT_TIMEOUT", Default: []string{"10"}},
+	{Key: FlagBootstrapRemoteCopyLink, Name: "copy-link", Flag: true, Spelling: "--copy-link", ValueName: "PATH"},
+	{Key: FlagBootstrapRemoteCopyLinks, Name: "copy-links", Flag: true, RequiresIfBoolean: true, Spelling: "--copy-links"},
 	{Key: FlagBootstrapRemoteExclude, Name: "exclude", Flag: true, Spelling: "--exclude", ValueName: "PATTERN"},
 	{Key: FlagBootstrapRemoteFailFast, Name: "fail-fast", Flag: true, RequiresIfBoolean: true, Spelling: "--fail-fast"},
 	{Key: FlagBootstrapRemoteForceDotfiles, Name: "force-dotfiles", Flag: true, RequiresIfBoolean: true, Spelling: "--force-dotfiles"},
@@ -4028,12 +4060,13 @@ var Meta = argv.Metadata{
 	{Key: FlagBootstrapRemoteIdentityFile, Name: "identity-file", Flag: true, Spelling: "--identity-file", ValueName: "IDENTITY_FILE"},
 	{Key: FlagBootstrapRemoteDryRun, Name: "dry-run", Flag: true, RequiresIfBoolean: true, Spelling: "--dry-run"},
 	{Key: FlagBootstrapRemoteKeepStaging, Name: "keep-staging", Flag: true, RequiresIfBoolean: true, Spelling: "--keep-staging"},
-	{Key: FlagBootstrapRemoteMiseBin, Name: "mise-bin", Flag: true, Spelling: "--mise-bin", ValueName: "MISE_BIN"},
-	{Key: FlagBootstrapRemoteOnly, Name: "only", Flag: true, Spelling: "--only", ValueName: "ONLY", Choices: []string{"plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "shell", "macos-defaults", "defaults", "macos-launchd-agents", "launchd", "linux-systemd-units", "systemd", "user", "tools", "task", "final-hook"}, AcceptedChoices: []string{"plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "shell", "macos-defaults", "defaults", "macos-launchd-agents", "launchd", "linux-systemd-units", "systemd", "user", "tools", "task", "final-hook"}},
+	{Key: FlagBootstrapRemoteMiseBin, Name: "mise-bin", Flag: true, Spelling: "--mise-bin", ValueName: "MISE_BIN", Conflicts: []uint64{FlagBootstrapRemoteRemoteMise, FlagBootstrapRemoteBootstrapCommand}},
+	{Key: FlagBootstrapRemoteOnly, Name: "only", Flag: true, Spelling: "--only", ValueName: "ONLY", Choices: []string{"plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "macos-defaults", "macos-launchd-agents", "linux-systemd-units", "user", "tools", "task", "final-hook"}, AcceptedChoices: []string{"plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "macos-defaults", "macos-launchd-agents", "linux-systemd-units", "user", "tools", "task", "final-hook", "shell", "defaults", "launchd", "systemd"}, Conflicts: []uint64{FlagBootstrapRemoteSkip}},
 	{Key: FlagBootstrapRemotePort, Name: "port", Flag: true, Spelling: "--port", ValueName: "PORT"},
 	{Key: FlagBootstrapRemotePromptSecrets, Name: "prompt-secrets", Flag: true, RequiresIfBoolean: true, Spelling: "--prompt-secrets"},
-	{Key: FlagBootstrapRemoteRemoteMise, Name: "remote-mise", Flag: true, Spelling: "--remote-mise", ValueName: "COMMAND"},
-	{Key: FlagBootstrapRemoteSkip, Name: "skip", Flag: true, Spelling: "--skip", ValueName: "SKIP", Choices: []string{"plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "shell", "macos-defaults", "defaults", "macos-launchd-agents", "launchd", "linux-systemd-units", "systemd", "user", "tools", "task", "final-hook"}, AcceptedChoices: []string{"plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "shell", "macos-defaults", "defaults", "macos-launchd-agents", "launchd", "linux-systemd-units", "systemd", "user", "tools", "task", "final-hook"}},
+	{Key: FlagBootstrapRemoteRemoteEnv, Name: "remote-env", Flag: true, Spelling: "--remote-env", ValueName: "ENV"},
+	{Key: FlagBootstrapRemoteRemoteMise, Name: "remote-mise", Flag: true, Spelling: "--remote-mise", ValueName: "COMMAND", Conflicts: []uint64{FlagBootstrapRemoteMiseBin, FlagBootstrapRemoteBootstrapCommand}},
+	{Key: FlagBootstrapRemoteSkip, Name: "skip", Flag: true, Spelling: "--skip", ValueName: "SKIP", Choices: []string{"plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "macos-defaults", "macos-launchd-agents", "linux-systemd-units", "user", "tools", "task", "final-hook"}, AcceptedChoices: []string{"plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "macos-defaults", "macos-launchd-agents", "linux-systemd-units", "user", "tools", "task", "final-hook", "shell", "defaults", "launchd", "systemd"}},
 	{Key: FlagBootstrapRemoteSource, Name: "source", Flag: true, Spelling: "--source", ValueName: "SOURCE"},
 	{Key: FlagBootstrapRemoteSshOption, Name: "ssh-option", Flag: true, Spelling: "--ssh-option", ValueName: "OPTION"},
 	{Key: FlagBootstrapRemoteTag, Name: "tag", Flag: true, Spelling: "--tag", ValueName: "TAG"},
@@ -4088,7 +4121,7 @@ var Meta = argv.Metadata{
 	{},
 	{},
 	{Key: FlagCacheClearOutdate, Name: "outdate", Flag: true, RequiresIfBoolean: true, Spelling: "--outdate"},
-	{Key: FlagCacheClearTask, Name: "task", Flag: true, Spelling: "--task", ValueName: "TASK"},
+	{Key: FlagCacheClearTask, Name: "task", Flag: true, Spelling: "--task", ValueName: "TASK", Conflicts: []uint64{ArgCacheClearTool, FlagCacheClearOutdate}},
 	{Key: ArgCacheClearTool, Name: "TOOL"},
 	{},
 	{},
@@ -4099,10 +4132,10 @@ var Meta = argv.Metadata{
 	{Key: FlagCacheTaskJson, Name: "json", Flag: true, RequiresIfBoolean: true, Spelling: "--json"},
 	{Key: ArgCacheTaskTask, Name: "TASK", Required: true},
 	{},
-	{Key: FlagCompletionShell, Name: "shell", Flag: true, Spelling: "--shell", ValueName: "SHELL_TYPE", Choices: []string{"bash", "fish", "powershell", "zsh"}, AcceptedChoices: []string{"bash", "fish", "powershell", "zsh"}},
+	{Key: FlagCompletionShell, Name: "shell", Flag: true, Spelling: "--shell", ValueName: "SHELL"},
 	{Key: FlagCompletionIncludeBashCompletionLib, Name: "include-bash-completion-lib", Flag: true, RequiresIfBoolean: true, Spelling: "--include-bash-completion-lib"},
 	{Key: FlagCompletionUsage, Name: "usage", Flag: true, RequiresIfBoolean: true, Spelling: "--usage"},
-	{Key: ArgCompletionShell, Name: "SHELL", Choices: []string{"bash", "fish", "powershell", "zsh"}, AcceptedChoices: []string{"bash", "fish", "powershell", "zsh"}},
+	{Key: ArgCompletionShell, Name: "SHELL", RequiredUnless: []uint64{FlagCompletionShell}},
 	{},
 	{Key: FlagConfigJson, Name: "json", Flag: true, RequiresIfBoolean: true, Spelling: "--json"},
 	{Key: FlagConfigNoHeader, Name: "no-header", Flag: true, RequiresIfBoolean: true, Spelling: "--no-header"},
@@ -4129,12 +4162,12 @@ var Meta = argv.Metadata{
 	{},
 	{},
 	{Key: FlagDotfilesAddForce, Name: "force", Flag: true, RequiresIfBoolean: true, Spelling: "--force"},
-	{Key: FlagDotfilesAddGlobal, Name: "global", Flag: true, RequiresIfBoolean: true, Spelling: "--global"},
-	{Key: FlagDotfilesAddLocal, Name: "local", Flag: true, RequiresIfBoolean: true, Spelling: "--local"},
+	{Key: FlagDotfilesAddGlobal, Name: "global", Flag: true, RequiresIfBoolean: true, Spelling: "--global", Conflicts: []uint64{FlagDotfilesAddLocal, FlagDotfilesAddPath}},
+	{Key: FlagDotfilesAddLocal, Name: "local", Flag: true, RequiresIfBoolean: true, Spelling: "--local", Conflicts: []uint64{FlagDotfilesAddGlobal, FlagDotfilesAddPath}},
 	{Key: FlagDotfilesAddMode, Name: "mode", Flag: true, Spelling: "--mode", ValueName: "MODE"},
 	{Key: FlagDotfilesAddDryRun, Name: "dry-run", Flag: true, RequiresIfBoolean: true, Spelling: "--dry-run"},
 	{Key: FlagDotfilesAddNoApply, Name: "no-apply", Flag: true, RequiresIfBoolean: true, Spelling: "--no-apply"},
-	{Key: FlagDotfilesAddPath, Name: "path", Flag: true, Spelling: "--path", ValueName: "PATH"},
+	{Key: FlagDotfilesAddPath, Name: "path", Flag: true, Spelling: "--path", ValueName: "PATH", Conflicts: []uint64{FlagDotfilesAddGlobal, FlagDotfilesAddLocal}},
 	{Key: FlagDotfilesAddSource, Name: "source", Flag: true, Spelling: "--source", ValueName: "PATH"},
 	{Key: FlagDotfilesAddYes, Name: "yes", Flag: true, RequiresIfBoolean: true, Spelling: "--yes"},
 	{Key: ArgDotfilesAddTarget, Name: "TARGET", Required: true},
@@ -4164,18 +4197,18 @@ var Meta = argv.Metadata{
 	{Key: FlagDoctorPathFull, Name: "full", Flag: true, RequiresIfBoolean: true, Spelling: "--full"},
 	{},
 	{Key: FlagEnShell, Name: "shell", Flag: true, Spelling: "--shell", ValueName: "SHELL"},
-	{Key: ArgEnDir, Name: "DIR", Default: []string{"."}},
+	{Key: ArgEnDir, Name: "DIR", CompleteType: "dir", Default: []string{"."}},
 	{},
-	{Key: FlagEnvDotenv, Name: "dotenv", Flag: true, RequiresIfBoolean: true, Spelling: "--dotenv"},
-	{Key: FlagEnvJson, Name: "json", Flag: true, RequiresIfBoolean: true, Spelling: "--json"},
-	{Key: FlagEnvShell, Name: "shell", Flag: true, Spelling: "--shell", ValueName: "SHELL", Choices: []string{"bash", "elvish", "fish", "nu", "xonsh", "zsh", "pwsh"}, AcceptedChoices: []string{"bash", "elvish", "fish", "nu", "xonsh", "zsh", "pwsh"}},
-	{Key: FlagEnvJsonExtended, Name: "json-extended", Flag: true, RequiresIfBoolean: true, Spelling: "--json-extended"},
+	{Key: FlagEnvDotenv, Name: "dotenv", Flag: true, RequiresIfBoolean: true, Spelling: "--dotenv", Overrides: []uint64{FlagEnvShell}},
+	{Key: FlagEnvJson, Name: "json", Flag: true, RequiresIfBoolean: true, Spelling: "--json", Overrides: []uint64{FlagEnvShell}},
+	{Key: FlagEnvShell, Name: "shell", Flag: true, Spelling: "--shell", ValueName: "SHELL", Overrides: []uint64{FlagEnvJson}},
+	{Key: FlagEnvJsonExtended, Name: "json-extended", Flag: true, RequiresIfBoolean: true, Spelling: "--json-extended", Overrides: []uint64{FlagEnvShell}},
 	{Key: FlagEnvRedacted, Name: "redacted", Flag: true, RequiresIfBoolean: true, Spelling: "--redacted"},
 	{Key: FlagEnvValues, Name: "values", Flag: true, RequiresIfBoolean: true, Spelling: "--values"},
 	{Key: ArgEnvToolVersion, Name: "TOOL@VERSION"},
 	{},
-	{Key: FlagExecCommand, Name: "command", Flag: true, Spelling: "--command", ValueName: "C"},
-	{Key: FlagExecJobs, Name: "jobs", Flag: true, Spelling: "--jobs", ValueName: "JOBS"},
+	{Key: FlagExecCommand, Name: "command", Flag: true, Spelling: "--command", ValueName: "COMMAND", Conflicts: []uint64{ArgExecCommand}},
+	{Key: FlagExecJobs, Name: "jobs", Flag: true, Spelling: "--jobs", ValueName: "JOBS", Env: "MISE_JOBS"},
 	{Key: FlagExecAllowEnv, Name: "allow-env", Flag: true, Spelling: "--allow-env", ValueName: "VAR"},
 	{Key: FlagExecAllowNet, Name: "allow-net", Flag: true, Spelling: "--allow-net", ValueName: "HOST"},
 	{Key: FlagExecAllowRead, Name: "allow-read", Flag: true, Spelling: "--allow-read", ValueName: "PATH"},
@@ -4187,9 +4220,9 @@ var Meta = argv.Metadata{
 	{Key: FlagExecDenyWrite, Name: "deny-write", Flag: true, RequiresIfBoolean: true, Spelling: "--deny-write"},
 	{Key: FlagExecFreshEnv, Name: "fresh-env", Flag: true, RequiresIfBoolean: true, Spelling: "--fresh-env"},
 	{Key: FlagExecNoDeps, Name: "no-deps", Flag: true, RequiresIfBoolean: true, Spelling: "--no-deps"},
-	{Key: FlagExecRaw, Name: "raw", Flag: true, RequiresIfBoolean: true, Spelling: "--raw"},
+	{Key: FlagExecRaw, Name: "raw", Flag: true, RequiresIfBoolean: true, Spelling: "--raw", Overrides: []uint64{FlagExecJobs}},
 	{Key: ArgExecToolVersion, Name: "TOOL@VERSION"},
-	{Key: ArgExecCommand, Name: "COMMAND"},
+	{Key: ArgExecCommand, Name: "COMMAND", Conflicts: []uint64{FlagExecCommand}, RequiredUnless: []uint64{FlagExecCommand}},
 	{},
 	{Key: FlagFmtAll, Name: "all", Flag: true, RequiresIfBoolean: true, Spelling: "--all"},
 	{Key: FlagFmtCheck, Name: "check", Flag: true, RequiresIfBoolean: true, Spelling: "--check"},
@@ -4200,8 +4233,9 @@ var Meta = argv.Metadata{
 	{Key: FlagGenerateBootstrapVersion, Name: "version", Flag: true, Spelling: "--version", ValueName: "VERSION"},
 	{Key: FlagGenerateBootstrapWrite, Name: "write", Flag: true, Spelling: "--write", ValueName: "WRITE"},
 	{Key: FlagGenerateBootstrapLocalizedDir, Name: "localized-dir", Flag: true, Spelling: "--localized-dir", ValueName: "LOCALIZED_DIR", Default: []string{".mise"}},
+	{Key: FlagGenerateBootstrapWindows, Name: "windows", Flag: true, RequiresIfBoolean: true, Spelling: "--windows", Requires: []uint64{FlagGenerateBootstrapWrite}},
 	{},
-	{Key: FlagGenerateConfigGlobal, Name: "global", Flag: true, RequiresIfBoolean: true, Spelling: "--global"},
+	{Key: FlagGenerateConfigGlobal, Name: "global", Flag: true, RequiresIfBoolean: true, Spelling: "--global", Conflicts: []uint64{ArgGenerateConfigPath}},
 	{Key: FlagGenerateConfigDryRun, Name: "dry-run", Flag: true, RequiresIfBoolean: true, Spelling: "--dry-run"},
 	{Key: FlagGenerateConfigToolVersions, Name: "tool-versions", Flag: true, Spelling: "--tool-versions", ValueName: "TOOL_VERSIONS"},
 	{Key: ArgGenerateConfigPath, Name: "PATH"},
@@ -4214,6 +4248,7 @@ var Meta = argv.Metadata{
 	{Key: FlagGenerateGitPreCommitTask, Name: "task", Flag: true, Spelling: "--task", ValueName: "TASK", Default: []string{"pre-commit"}},
 	{Key: FlagGenerateGitPreCommitWrite, Name: "write", Flag: true, RequiresIfBoolean: true, Spelling: "--write"},
 	{Key: FlagGenerateGitPreCommitHook, Name: "hook", Flag: true, Spelling: "--hook", ValueName: "HOOK", Default: []string{"pre-commit"}},
+	{Key: ArgGenerateGitPreCommitMiseArg, Name: "MISE_ARG"},
 	{},
 	{Key: FlagGenerateGithubActionTask, Name: "task", Flag: true, Spelling: "--task", ValueName: "TASK", Default: []string{"ci"}},
 	{Key: FlagGenerateGithubActionWrite, Name: "write", Flag: true, RequiresIfBoolean: true, Spelling: "--write"},
@@ -4226,15 +4261,16 @@ var Meta = argv.Metadata{
 	{Key: FlagGenerateTaskDocsRoot, Name: "root", Flag: true, Spelling: "--root", ValueName: "ROOT"},
 	{Key: FlagGenerateTaskDocsStyle, Name: "style", Flag: true, Spelling: "--style", ValueName: "STYLE", Choices: []string{"simple", "detailed"}, AcceptedChoices: []string{"simple", "detailed"}, Default: []string{"simple"}},
 	{},
-	{Key: FlagGenerateTaskStubsDir, Name: "dir", Flag: true, Spelling: "--dir", ValueName: "DIR", Default: []string{"bin"}},
+	{Key: FlagGenerateTaskStubsDir, Name: "dir", Flag: true, Spelling: "--dir", ValueName: "DIR", CompleteType: "dir", Default: []string{"bin"}},
 	{Key: FlagGenerateTaskStubsMiseBin, Name: "mise-bin", Flag: true, Spelling: "--mise-bin", ValueName: "MISE_BIN", Default: []string{"mise"}},
 	{},
 	{Key: FlagGenerateToolStubBin, Name: "bin", Flag: true, Spelling: "--bin", ValueName: "BIN"},
 	{Key: FlagGenerateToolStubBootstrap, Name: "bootstrap", Flag: true, RequiresIfBoolean: true, Spelling: "--bootstrap"},
-	{Key: FlagGenerateToolStubBootstrapVersion, Name: "bootstrap-version", Flag: true, Spelling: "--bootstrap-version", ValueName: "BOOTSTRAP_VERSION"},
-	{Key: FlagGenerateToolStubFetch, Name: "fetch", Flag: true, RequiresIfBoolean: true, Spelling: "--fetch"},
+	{Key: FlagGenerateToolStubBootstrapVersion, Name: "bootstrap-version", Flag: true, Spelling: "--bootstrap-version", ValueName: "BOOTSTRAP_VERSION", Requires: []uint64{FlagGenerateToolStubBootstrap}},
+	{Key: FlagGenerateToolStubChecksumAlgorithm, Name: "checksum-algorithm", Flag: true, Spelling: "--checksum-algorithm", ValueName: "CHECKSUM_ALGORITHM", Choices: []string{"blake3", "sha256"}, AcceptedChoices: []string{"blake3", "sha256"}, Default: []string{"blake3"}, Conflicts: []uint64{FlagGenerateToolStubLock, FlagGenerateToolStubSkipDownload}},
+	{Key: FlagGenerateToolStubFetch, Name: "fetch", Flag: true, RequiresIfBoolean: true, Spelling: "--fetch", Conflicts: []uint64{FlagGenerateToolStubUrl, FlagGenerateToolStubPlatformUrl, FlagGenerateToolStubVersion, FlagGenerateToolStubBin, FlagGenerateToolStubPlatformBin, FlagGenerateToolStubSkipDownload, FlagGenerateToolStubLock}},
 	{Key: FlagGenerateToolStubHttp, Name: "http", Flag: true, Spelling: "--http", ValueName: "HTTP", Default: []string{"http"}},
-	{Key: FlagGenerateToolStubLock, Name: "lock", Flag: true, RequiresIfBoolean: true, Spelling: "--lock"},
+	{Key: FlagGenerateToolStubLock, Name: "lock", Flag: true, RequiresIfBoolean: true, Spelling: "--lock", Conflicts: []uint64{FlagGenerateToolStubUrl, FlagGenerateToolStubPlatformUrl, FlagGenerateToolStubBin, FlagGenerateToolStubPlatformBin, FlagGenerateToolStubFetch, FlagGenerateToolStubSkipDownload}},
 	{Key: FlagGenerateToolStubPlatformBin, Name: "platform-bin", Flag: true, Spelling: "--platform-bin", ValueName: "PLATFORM_BIN"},
 	{Key: FlagGenerateToolStubPlatformUrl, Name: "platform-url", Flag: true, Spelling: "--platform-url", ValueName: "PLATFORM_URL"},
 	{Key: FlagGenerateToolStubSkipDownload, Name: "skip-download", Flag: true, RequiresIfBoolean: true, Spelling: "--skip-download"},
@@ -4245,50 +4281,51 @@ var Meta = argv.Metadata{
 	{},
 	{Key: FlagGithubTokenOauth, Name: "oauth", Flag: true, RequiresIfBoolean: true, Spelling: "--oauth"},
 	{Key: FlagGithubTokenRaw, Name: "raw", Flag: true, RequiresIfBoolean: true, Spelling: "--raw"},
-	{Key: FlagGithubTokenRefresh, Name: "refresh", Flag: true, RequiresIfBoolean: true, Spelling: "--refresh"},
+	{Key: FlagGithubTokenRefresh, Name: "refresh", Flag: true, RequiresIfBoolean: true, Spelling: "--refresh", Requires: []uint64{FlagGithubTokenOauth}},
 	{Key: FlagGithubTokenUnmask, Name: "unmask", Flag: true, RequiresIfBoolean: true, Spelling: "--unmask"},
 	{Key: ArgGithubTokenHost, Name: "HOST", Default: []string{"github.com"}},
 	{},
-	{Key: FlagGlobalFuzzy, Name: "fuzzy", Flag: true, RequiresIfBoolean: true, Spelling: "--fuzzy"},
+	{Key: FlagGlobalFuzzy, Name: "fuzzy", Flag: true, RequiresIfBoolean: true, Spelling: "--fuzzy", Overrides: []uint64{FlagGlobalPin}},
 	{Key: FlagGlobalPath, Name: "path", Flag: true, RequiresIfBoolean: true, Spelling: "--path"},
-	{Key: FlagGlobalPin, Name: "pin", Flag: true, RequiresIfBoolean: true, Spelling: "--pin"},
+	{Key: FlagGlobalPin, Name: "pin", Flag: true, RequiresIfBoolean: true, Spelling: "--pin", Overrides: []uint64{FlagGlobalFuzzy}},
 	{Key: FlagGlobalRemove, Name: "remove", Flag: true, Spelling: "--remove", ValueName: "TOOL"},
 	{Key: ArgGlobalToolVersion, Name: "TOOL@VERSION"},
 	{},
 	{Key: FlagHookEnvForce, Name: "force", Flag: true, RequiresIfBoolean: true, Spelling: "--force"},
 	{Key: FlagHookEnvQuiet, Name: "quiet", Flag: true, RequiresIfBoolean: true, Spelling: "--quiet"},
-	{Key: FlagHookEnvShell, Name: "shell", Flag: true, Spelling: "--shell", ValueName: "SHELL", Choices: []string{"bash", "elvish", "fish", "nu", "xonsh", "zsh", "pwsh"}, AcceptedChoices: []string{"bash", "elvish", "fish", "nu", "xonsh", "zsh", "pwsh"}},
+	{Key: FlagHookEnvShell, Name: "shell", Flag: true, Spelling: "--shell", ValueName: "SHELL"},
 	{Key: FlagHookEnvReason, Name: "reason", Flag: true, Spelling: "--reason", ValueName: "REASON", Choices: []string{"precmd", "chpwd"}, AcceptedChoices: []string{"precmd", "chpwd"}},
 	{Key: FlagHookEnvStatus, Name: "status", Flag: true, RequiresIfBoolean: true, Spelling: "--status"},
 	{},
-	{Key: FlagHookNotFoundShell, Name: "shell", Flag: true, Spelling: "--shell", ValueName: "SHELL", Choices: []string{"bash", "elvish", "fish", "nu", "xonsh", "zsh", "pwsh"}, AcceptedChoices: []string{"bash", "elvish", "fish", "nu", "xonsh", "zsh", "pwsh"}},
+	{Key: FlagHookNotFoundShell, Name: "shell", Flag: true, Spelling: "--shell", ValueName: "SHELL"},
 	{Key: ArgHookNotFoundBin, Name: "BIN", Required: true},
 	{},
 	{Key: FlagImplodeDryRun, Name: "dry-run", Flag: true, RequiresIfBoolean: true, Spelling: "--dry-run"},
 	{Key: FlagImplodeConfig, Name: "config", Flag: true, RequiresIfBoolean: true, Spelling: "--config"},
 	{},
-	{Key: FlagEditGlobal, Name: "global", Flag: true, RequiresIfBoolean: true, Spelling: "--global"},
+	{Key: FlagEditGlobal, Name: "global", Flag: true, RequiresIfBoolean: true, Spelling: "--global", Conflicts: []uint64{ArgEditPath}},
 	{Key: FlagEditDryRun, Name: "dry-run", Flag: true, RequiresIfBoolean: true, Spelling: "--dry-run"},
 	{Key: FlagEditToolVersions, Name: "tool-versions", Flag: true, Spelling: "--tool-versions", ValueName: "TOOL_VERSIONS"},
 	{Key: ArgEditPath, Name: "PATH"},
 	{},
 	{Key: FlagInstallForce, Name: "force", Flag: true, RequiresIfBoolean: true, Spelling: "--force"},
-	{Key: FlagInstallJobs, Name: "jobs", Flag: true, Spelling: "--jobs", ValueName: "JOBS"},
+	{Key: FlagInstallJobs, Name: "jobs", Flag: true, Spelling: "--jobs", ValueName: "JOBS", Env: "MISE_JOBS"},
 	{Key: FlagInstallDryRun, Name: "dry-run", Flag: true, RequiresIfBoolean: true, Spelling: "--dry-run"},
 	{Key: FlagInstallVerbose, Name: "verbose", Flag: true, RequiresIfBoolean: true, Spelling: "--verbose"},
 	{Key: FlagInstallDryRunCode, Name: "dry-run-code", Flag: true, RequiresIfBoolean: true, Spelling: "--dry-run-code"},
+	{Key: FlagInstallIncludeTaskTools, Name: "include-task-tools", Flag: true, RequiresIfBoolean: true, Spelling: "--include-task-tools"},
 	{Key: FlagInstallMinimumReleaseAge, Name: "minimum-release-age", Flag: true, Spelling: "--minimum-release-age", ValueName: "MINIMUM_RELEASE_AGE"},
-	{Key: FlagInstallMonorepo, Name: "monorepo", Flag: true, RequiresIfBoolean: true, Spelling: "--monorepo"},
-	{Key: FlagInstallRaw, Name: "raw", Flag: true, RequiresIfBoolean: true, Spelling: "--raw"},
-	{Key: FlagInstallShared, Name: "shared", Flag: true, Spelling: "--shared", ValueName: "SHARED"},
-	{Key: FlagInstallSystem, Name: "system", Flag: true, RequiresIfBoolean: true, Spelling: "--system"},
+	{Key: FlagInstallMonorepo, Name: "monorepo", Flag: true, RequiresIfBoolean: true, Spelling: "--monorepo", Env: "MISE_MONOREPO"},
+	{Key: FlagInstallRaw, Name: "raw", Flag: true, RequiresIfBoolean: true, Spelling: "--raw", Overrides: []uint64{FlagInstallJobs}},
+	{Key: FlagInstallShared, Name: "shared", Flag: true, Spelling: "--shared", ValueName: "SHARED", Conflicts: []uint64{FlagInstallSystem}},
+	{Key: FlagInstallSystem, Name: "system", Flag: true, RequiresIfBoolean: true, Spelling: "--system", Conflicts: []uint64{FlagInstallShared}},
 	{Key: ArgInstallToolVersion, Name: "TOOL@VERSION"},
 	{},
 	{Key: ArgInstallIntoToolVersion, Name: "TOOL@VERSION", Required: true},
 	{Key: ArgInstallIntoPath, Name: "PATH", Required: true},
 	{},
 	{Key: FlagLatestInstalled, Name: "installed", Flag: true, RequiresIfBoolean: true, Spelling: "--installed"},
-	{Key: FlagLatestMinimumReleaseAge, Name: "minimum-release-age", Flag: true, Spelling: "--minimum-release-age", ValueName: "MINIMUM_RELEASE_AGE"},
+	{Key: FlagLatestMinimumReleaseAge, Name: "minimum-release-age", Flag: true, Spelling: "--minimum-release-age", ValueName: "MINIMUM_RELEASE_AGE", Conflicts: []uint64{FlagLatestInstalled}},
 	{Key: ArgLatestToolVersion, Name: "TOOL@VERSION", Required: true},
 	{Key: ArgLatestAsdfVersion, Name: "ASDF_VERSION"},
 	{},
@@ -4297,14 +4334,14 @@ var Meta = argv.Metadata{
 	{Key: ArgLinkPath, Name: "PATH", Required: true},
 	{},
 	{Key: FlagLocalParent, Name: "parent", Flag: true, RequiresIfBoolean: true, Spelling: "--parent"},
-	{Key: FlagLocalFuzzy, Name: "fuzzy", Flag: true, RequiresIfBoolean: true, Spelling: "--fuzzy"},
+	{Key: FlagLocalFuzzy, Name: "fuzzy", Flag: true, RequiresIfBoolean: true, Spelling: "--fuzzy", Overrides: []uint64{FlagLocalPin}},
 	{Key: FlagLocalPath, Name: "path", Flag: true, RequiresIfBoolean: true, Spelling: "--path"},
-	{Key: FlagLocalPin, Name: "pin", Flag: true, RequiresIfBoolean: true, Spelling: "--pin"},
+	{Key: FlagLocalPin, Name: "pin", Flag: true, RequiresIfBoolean: true, Spelling: "--pin", Overrides: []uint64{FlagLocalFuzzy}},
 	{Key: FlagLocalRemove, Name: "remove", Flag: true, Spelling: "--remove", ValueName: "TOOL"},
 	{Key: ArgLocalToolVersion, Name: "TOOL@VERSION"},
 	{},
 	{Key: FlagLockGlobal, Name: "global", Flag: true, RequiresIfBoolean: true, Spelling: "--global"},
-	{Key: FlagLockJobs, Name: "jobs", Flag: true, Spelling: "--jobs", ValueName: "JOBS"},
+	{Key: FlagLockJobs, Name: "jobs", Flag: true, Spelling: "--jobs", ValueName: "JOBS", Env: "MISE_JOBS"},
 	{Key: FlagLockDryRun, Name: "dry-run", Flag: true, RequiresIfBoolean: true, Spelling: "--dry-run"},
 	{Key: FlagLockPlatform, Name: "platform", Flag: true, Spelling: "--platform", ValueName: "PLATFORM"},
 	{Key: FlagLockBump, Name: "bump", Flag: true, RequiresIfBoolean: true, Spelling: "--bump"},
@@ -4314,28 +4351,28 @@ var Meta = argv.Metadata{
 	{Key: ArgLockTool, Name: "TOOL"},
 	{},
 	{Key: FlagLsCurrent, Name: "current", Flag: true, RequiresIfBoolean: true, Spelling: "--current"},
-	{Key: FlagLsGlobal, Name: "global", Flag: true, RequiresIfBoolean: true, Spelling: "--global"},
+	{Key: FlagLsGlobal, Name: "global", Flag: true, RequiresIfBoolean: true, Spelling: "--global", Conflicts: []uint64{FlagLsLocal}},
 	{Key: FlagLsInstalled, Name: "installed", Flag: true, RequiresIfBoolean: true, Spelling: "--installed"},
 	{Key: FlagLsJson, Name: "json", Flag: true, RequiresIfBoolean: true, Spelling: "--json"},
-	{Key: FlagLsLocal, Name: "local", Flag: true, RequiresIfBoolean: true, Spelling: "--local"},
-	{Key: FlagLsMissing, Name: "missing", Flag: true, RequiresIfBoolean: true, Spelling: "--missing"},
+	{Key: FlagLsLocal, Name: "local", Flag: true, RequiresIfBoolean: true, Spelling: "--local", Conflicts: []uint64{FlagLsGlobal}},
+	{Key: FlagLsMissing, Name: "missing", Flag: true, RequiresIfBoolean: true, Spelling: "--missing", Conflicts: []uint64{FlagLsInstalled}},
 	{Key: FlagLsOffline, Name: "offline", Flag: true, RequiresIfBoolean: true, Spelling: "--offline"},
-	{Key: FlagLsPlugin, Name: "plugin", Flag: true, Spelling: "--plugin", ValueName: "TOOL_FLAG"},
-	{Key: FlagLsAllSources, Name: "all-sources", Flag: true, RequiresIfBoolean: true, Spelling: "--all-sources"},
-	{Key: FlagLsMonorepo, Name: "monorepo", Flag: true, RequiresIfBoolean: true, Spelling: "--monorepo"},
-	{Key: FlagLsNoHeader, Name: "no-header", Flag: true, RequiresIfBoolean: true, Spelling: "--no-header"},
+	{Key: FlagLsPlugin, Name: "plugin", Flag: true, Spelling: "--plugin", ValueName: "PLUGIN"},
+	{Key: FlagLsAllSources, Name: "all-sources", Flag: true, RequiresIfBoolean: true, Spelling: "--all-sources", Conflicts: []uint64{FlagLsCurrent, FlagLsGlobal, FlagLsLocal, FlagLsPrunable}},
+	{Key: FlagLsMonorepo, Name: "monorepo", Flag: true, RequiresIfBoolean: true, Spelling: "--monorepo", Env: "MISE_MONOREPO", Conflicts: []uint64{FlagLsAllSources, FlagLsPrunable}},
+	{Key: FlagLsNoHeader, Name: "no-header", Flag: true, RequiresIfBoolean: true, Spelling: "--no-header", Conflicts: []uint64{FlagLsJson}},
 	{Key: FlagLsOutdated, Name: "outdated", Flag: true, RequiresIfBoolean: true, Spelling: "--outdated"},
-	{Key: FlagLsPrefix, Name: "prefix", Flag: true, Spelling: "--prefix", ValueName: "PREFIX"},
+	{Key: FlagLsPrefix, Name: "prefix", Flag: true, Spelling: "--prefix", ValueName: "PREFIX", Requires: []uint64{ArgLsInstalledTool}},
 	{Key: FlagLsPrunable, Name: "prunable", Flag: true, RequiresIfBoolean: true, Spelling: "--prunable"},
-	{Key: ArgLsInstalledTool, Name: "INSTALLED_TOOL"},
+	{Key: ArgLsInstalledTool, Name: "INSTALLED_TOOL", Conflicts: []uint64{FlagLsPlugin}},
 	{},
-	{Key: FlagLsRemoteAll, Name: "all", Flag: true, RequiresIfBoolean: true, Spelling: "--all"},
+	{Key: FlagLsRemoteAll, Name: "all", Flag: true, RequiresIfBoolean: true, Spelling: "--all", Conflicts: []uint64{ArgLsRemoteToolVersion, ArgLsRemotePrefix}},
 	{Key: FlagLsRemoteMinimumReleaseAge, Name: "minimum-release-age", Flag: true, Spelling: "--minimum-release-age", ValueName: "MINIMUM_RELEASE_AGE"},
 	{Key: FlagLsRemoteJson, Name: "json", Flag: true, RequiresIfBoolean: true, Spelling: "--json"},
 	{Key: FlagLsRemoteNoVersionsHost, Name: "no-versions-host", Flag: true, RequiresIfBoolean: true, Spelling: "--no-versions-host"},
 	{Key: FlagLsRemotePrerelease, Name: "prerelease", Flag: true, RequiresIfBoolean: true, Spelling: "--prerelease"},
-	{Key: FlagLsRemoteStrictMetadata, Name: "strict-metadata", Flag: true, RequiresIfBoolean: true, Spelling: "--strict-metadata"},
-	{Key: ArgLsRemoteToolVersion, Name: "TOOL@VERSION"},
+	{Key: FlagLsRemoteStrictMetadata, Name: "strict-metadata", Flag: true, RequiresIfBoolean: true, Spelling: "--strict-metadata", Requires: []uint64{FlagLsRemoteJson, FlagLsRemoteNoVersionsHost}},
+	{Key: ArgLsRemoteToolVersion, Name: "TOOL@VERSION", RequiredUnless: []uint64{FlagLsRemoteAll}},
 	{Key: ArgLsRemotePrefix, Name: "PREFIX"},
 	{},
 	{},
@@ -4349,9 +4386,9 @@ var Meta = argv.Metadata{
 	{Key: FlagOciBuildNoMise, Name: "no-mise", Flag: true, RequiresIfBoolean: true, Spelling: "--no-mise"},
 	{Key: FlagOciBuildOwner, Name: "owner", Flag: true, Spelling: "--owner", ValueName: "UID[:GID]"},
 	{},
-	{Key: FlagOciPushCacheFrom, Name: "cache-from", Flag: true, Spelling: "--cache-from", ValueName: "REF"},
+	{Key: FlagOciPushCacheFrom, Name: "cache-from", Flag: true, Spelling: "--cache-from", ValueName: "REF", Conflicts: []uint64{FlagOciPushNoCache, FlagOciPushImageDir}},
 	{Key: FlagOciPushFrom, Name: "from", Flag: true, Spelling: "--from", ValueName: "FROM"},
-	{Key: FlagOciPushImageDir, Name: "image-dir", Flag: true, Spelling: "--image-dir", ValueName: "IMAGE_DIR"},
+	{Key: FlagOciPushImageDir, Name: "image-dir", Flag: true, Spelling: "--image-dir", ValueName: "IMAGE_DIR", Conflicts: []uint64{FlagOciPushFrom, FlagOciPushMountPoint, FlagOciPushNoMise, FlagOciPushOwner, FlagOciPushIncludeGlobal}},
 	{Key: FlagOciPushIncludeGlobal, Name: "include-global", Flag: true, RequiresIfBoolean: true, Spelling: "--include-global"},
 	{Key: FlagOciPushMountPoint, Name: "mount-point", Flag: true, Spelling: "--mount-point", ValueName: "MOUNT_POINT"},
 	{Key: FlagOciPushNoCache, Name: "no-cache", Flag: true, RequiresIfBoolean: true, Spelling: "--no-cache"},
@@ -4362,7 +4399,7 @@ var Meta = argv.Metadata{
 	{},
 	{Key: FlagOciRunEngine, Name: "engine", Flag: true, Spelling: "--engine", ValueName: "ENGINE", Choices: []string{"auto", "podman", "docker"}, AcceptedChoices: []string{"auto", "podman", "docker"}, Default: []string{"auto"}},
 	{Key: FlagOciRunFrom, Name: "from", Flag: true, Spelling: "--from", ValueName: "FROM"},
-	{Key: FlagOciRunImageDir, Name: "image-dir", Flag: true, Spelling: "--image-dir", ValueName: "IMAGE_DIR"},
+	{Key: FlagOciRunImageDir, Name: "image-dir", Flag: true, Spelling: "--image-dir", ValueName: "IMAGE_DIR", Conflicts: []uint64{FlagOciRunFrom, FlagOciRunMountPoint, FlagOciRunNoMise, FlagOciRunOwner, FlagOciRunIncludeGlobal}},
 	{Key: FlagOciRunIncludeGlobal, Name: "include-global", Flag: true, RequiresIfBoolean: true, Spelling: "--include-global"},
 	{Key: FlagOciRunKeep, Name: "keep", Flag: true, RequiresIfBoolean: true, Spelling: "--keep"},
 	{Key: FlagOciRunMountPoint, Name: "mount-point", Flag: true, Spelling: "--mount-point", ValueName: "MOUNT_POINT"},
@@ -4375,9 +4412,10 @@ var Meta = argv.Metadata{
 	{Key: FlagOciRunWorkdir, Name: "workdir", Flag: true, Spelling: "--workdir", ValueName: "WORKDIR"},
 	{Key: ArgOciRunCmd, Name: "CMD"},
 	{},
-	{Key: FlagOutdatedJson, Name: "json", Flag: true, RequiresIfBoolean: true, Spelling: "--json"},
 	{Key: FlagOutdatedBump, Name: "bump", Flag: true, RequiresIfBoolean: true, Spelling: "--bump"},
-	{Key: FlagOutdatedInactive, Name: "inactive", Flag: true, RequiresIfBoolean: true, Spelling: "--inactive"},
+	{Key: FlagOutdatedJson, Name: "json", Flag: true, RequiresIfBoolean: true, Spelling: "--json"},
+	{Key: FlagOutdatedL, Name: "l", Flag: true, RequiresIfBoolean: true, Spelling: "-l"},
+	{Key: FlagOutdatedInactive, Name: "inactive", Flag: true, RequiresIfBoolean: true, Spelling: "--inactive", Conflicts: []uint64{FlagOutdatedLocal}},
 	{Key: FlagOutdatedLocal, Name: "local", Flag: true, RequiresIfBoolean: true, Spelling: "--local"},
 	{Key: FlagOutdatedMonorepo, Name: "monorepo", Flag: true, RequiresIfBoolean: true, Spelling: "--monorepo"},
 	{Key: FlagOutdatedNoHeader, Name: "no-header", Flag: true, RequiresIfBoolean: true, Spelling: "--no-header"},
@@ -4387,34 +4425,34 @@ var Meta = argv.Metadata{
 	{Key: FlagPatronsRefresh, Name: "refresh", Flag: true, RequiresIfBoolean: true, Spelling: "--refresh"},
 	{},
 	{Key: FlagPluginsAll, Name: "all", Flag: true, RequiresIfBoolean: true, Spelling: "--all"},
-	{Key: FlagPluginsCore, Name: "core", Flag: true, RequiresIfBoolean: true, Spelling: "--core"},
+	{Key: FlagPluginsCore, Name: "core", Flag: true, RequiresIfBoolean: true, Spelling: "--core", Conflicts: []uint64{FlagPluginsAll}},
 	{Key: FlagPluginsUrls, Name: "urls", Flag: true, RequiresIfBoolean: true, Spelling: "--urls"},
 	{Key: FlagPluginsRefs, Name: "refs", Flag: true, RequiresIfBoolean: true, Spelling: "--refs"},
-	{Key: FlagPluginsUser, Name: "user", Flag: true, RequiresIfBoolean: true, Spelling: "--user"},
+	{Key: FlagPluginsUser, Name: "user", Flag: true, RequiresIfBoolean: true, Spelling: "--user", Conflicts: []uint64{FlagPluginsAll}},
 	{},
-	{Key: FlagPluginsInstallAll, Name: "all", Flag: true, RequiresIfBoolean: true, Spelling: "--all"},
+	{Key: FlagPluginsInstallAll, Name: "all", Flag: true, RequiresIfBoolean: true, Spelling: "--all", Conflicts: []uint64{ArgPluginsInstallNewPlugin, FlagPluginsInstallForce}},
 	{Key: FlagPluginsInstallForce, Name: "force", Flag: true, RequiresIfBoolean: true, Spelling: "--force"},
 	{Key: FlagPluginsInstallJobs, Name: "jobs", Flag: true, Spelling: "--jobs", ValueName: "JOBS"},
 	{Key: FlagPluginsInstallVerbose, Name: "verbose", Flag: true, RequiresIfBoolean: true, Spelling: "--verbose"},
-	{Key: ArgPluginsInstallNewPlugin, Name: "NEW_PLUGIN"},
+	{Key: ArgPluginsInstallNewPlugin, Name: "NEW_PLUGIN", RequiredUnless: []uint64{FlagPluginsInstallAll}},
 	{Key: ArgPluginsInstallGitUrl, Name: "GIT_URL"},
 	{Key: ArgPluginsInstallRest, Name: "REST"},
 	{},
 	{Key: FlagPluginsLinkForce, Name: "force", Flag: true, RequiresIfBoolean: true, Spelling: "--force"},
 	{Key: ArgPluginsLinkName, Name: "NAME", Required: true},
-	{Key: ArgPluginsLinkDir, Name: "DIR"},
+	{Key: ArgPluginsLinkDir, Name: "DIR", CompleteType: "dir"},
 	{},
 	{Key: FlagPluginsLsAll, Name: "all", Flag: true, RequiresIfBoolean: true, Spelling: "--all"},
-	{Key: FlagPluginsLsCore, Name: "core", Flag: true, RequiresIfBoolean: true, Spelling: "--core"},
+	{Key: FlagPluginsLsCore, Name: "core", Flag: true, RequiresIfBoolean: true, Spelling: "--core", Conflicts: []uint64{FlagPluginsLsAll}},
 	{Key: FlagPluginsLsOutdated, Name: "outdated", Flag: true, RequiresIfBoolean: true, Spelling: "--outdated"},
 	{Key: FlagPluginsLsUrls, Name: "urls", Flag: true, RequiresIfBoolean: true, Spelling: "--urls"},
 	{Key: FlagPluginsLsRefs, Name: "refs", Flag: true, RequiresIfBoolean: true, Spelling: "--refs"},
-	{Key: FlagPluginsLsUser, Name: "user", Flag: true, RequiresIfBoolean: true, Spelling: "--user"},
+	{Key: FlagPluginsLsUser, Name: "user", Flag: true, RequiresIfBoolean: true, Spelling: "--user", Conflicts: []uint64{FlagPluginsLsAll}},
 	{},
 	{Key: FlagPluginsLsRemoteUrls, Name: "urls", Flag: true, RequiresIfBoolean: true, Spelling: "--urls"},
 	{Key: FlagPluginsLsRemoteOnlyNames, Name: "only-names", Flag: true, RequiresIfBoolean: true, Spelling: "--only-names"},
 	{},
-	{Key: FlagPluginsUninstallAll, Name: "all", Flag: true, RequiresIfBoolean: true, Spelling: "--all"},
+	{Key: FlagPluginsUninstallAll, Name: "all", Flag: true, RequiresIfBoolean: true, Spelling: "--all", Conflicts: []uint64{ArgPluginsUninstallPlugin}},
 	{Key: FlagPluginsUninstallPurge, Name: "purge", Flag: true, RequiresIfBoolean: true, Spelling: "--purge"},
 	{Key: ArgPluginsUninstallPlugin, Name: "PLUGIN"},
 	{},
@@ -4425,7 +4463,7 @@ var Meta = argv.Metadata{
 	{Key: FlagDepsForce, Name: "force", Flag: true, RequiresIfBoolean: true, Spelling: "--force"},
 	{Key: FlagDepsDryRun, Name: "dry-run", Flag: true, RequiresIfBoolean: true, Spelling: "--dry-run"},
 	{Key: FlagDepsList, Name: "list", Flag: true, RequiresIfBoolean: true, Spelling: "--list"},
-	{Key: FlagDepsMonorepo, Name: "monorepo", Flag: true, RequiresIfBoolean: true, Spelling: "--monorepo"},
+	{Key: FlagDepsMonorepo, Name: "monorepo", Flag: true, RequiresIfBoolean: true, Spelling: "--monorepo", Env: "MISE_MONOREPO"},
 	{Key: FlagDepsOnly, Name: "only", Flag: true, Spelling: "--only", ValueName: "ONLY"},
 	{Key: FlagDepsSkip, Name: "skip", Flag: true, Spelling: "--skip", ValueName: "SKIP"},
 	{Key: ArgDepsProvider, Name: "PROVIDER"},
@@ -4437,7 +4475,7 @@ var Meta = argv.Metadata{
 	{Key: FlagDepsInstallForce, Name: "force", Flag: true, RequiresIfBoolean: true, Spelling: "--force"},
 	{Key: FlagDepsInstallDryRun, Name: "dry-run", Flag: true, RequiresIfBoolean: true, Spelling: "--dry-run"},
 	{Key: FlagDepsInstallList, Name: "list", Flag: true, RequiresIfBoolean: true, Spelling: "--list"},
-	{Key: FlagDepsInstallMonorepo, Name: "monorepo", Flag: true, RequiresIfBoolean: true, Spelling: "--monorepo"},
+	{Key: FlagDepsInstallMonorepo, Name: "monorepo", Flag: true, RequiresIfBoolean: true, Spelling: "--monorepo", Env: "MISE_MONOREPO"},
 	{Key: FlagDepsInstallOnly, Name: "only", Flag: true, Spelling: "--only", ValueName: "ONLY"},
 	{Key: FlagDepsInstallSkip, Name: "skip", Flag: true, Spelling: "--skip", ValueName: "SKIP"},
 	{Key: ArgDepsInstallProvider, Name: "PROVIDER"},
@@ -4455,7 +4493,7 @@ var Meta = argv.Metadata{
 	{Key: FlagRegistryComplete, Name: "complete", Flag: true, RequiresIfBoolean: true, Spelling: "--complete"},
 	{Key: FlagRegistryHideAliased, Name: "hide-aliased", Flag: true, RequiresIfBoolean: true, Spelling: "--hide-aliased"},
 	{Key: FlagRegistryJson, Name: "json", Flag: true, RequiresIfBoolean: true, Spelling: "--json"},
-	{Key: FlagRegistrySecurity, Name: "security", Flag: true, RequiresIfBoolean: true, Spelling: "--security"},
+	{Key: FlagRegistrySecurity, Name: "security", Flag: true, RequiresIfBoolean: true, Spelling: "--security", Requires: []uint64{FlagRegistryJson}},
 	{Key: ArgRegistryName, Name: "NAME"},
 	{},
 	{},
@@ -4464,20 +4502,21 @@ var Meta = argv.Metadata{
 	{Key: ArgReshimVersion, Name: "VERSION"},
 	{},
 	{Key: FlagRunAffected, Name: "affected", Flag: true, RequiresIfBoolean: true, Spelling: "--affected"},
-	{Key: FlagRunAffectedBase, Name: "affected-base", Flag: true, Spelling: "--affected-base", ValueName: "REV"},
-	{Key: FlagRunAffectedExplain, Name: "affected-explain", Flag: true, RequiresIfBoolean: true, Spelling: "--affected-explain"},
-	{Key: FlagRunAffectedHead, Name: "affected-head", Flag: true, Spelling: "--affected-head", ValueName: "REV"},
-	{Key: FlagRunAffectedJson, Name: "affected-json", Flag: true, RequiresIfBoolean: true, Spelling: "--affected-json"},
+	{Key: FlagRunAffectedBase, Name: "affected-base", Flag: true, Spelling: "--affected-base", ValueName: "REV", Requires: []uint64{FlagRunAffected}},
+	{Key: FlagRunAffectedExplain, Name: "affected-explain", Flag: true, RequiresIfBoolean: true, Spelling: "--affected-explain", Conflicts: []uint64{FlagRunAffectedJson}, Requires: []uint64{FlagRunAffected}},
+	{Key: FlagRunAffectedHead, Name: "affected-head", Flag: true, Spelling: "--affected-head", ValueName: "REV", Requires: []uint64{FlagRunAffected}},
+	{Key: FlagRunAffectedJson, Name: "affected-json", Flag: true, RequiresIfBoolean: true, Spelling: "--affected-json", Conflicts: []uint64{FlagRunAffectedExplain}, Requires: []uint64{FlagRunAffected}},
+	{Key: FlagRunAll, Name: "all", Flag: true, RequiresIfBoolean: true, Spelling: "--all", Conflicts: []uint64{FlagRunAffected}},
 	{Key: FlagRunContinueOnError, Name: "continue-on-error", Flag: true, RequiresIfBoolean: true, Spelling: "--continue-on-error"},
 	{Key: FlagRunCd, Name: "cd", Flag: true, Spelling: "--cd", ValueName: "CD"},
 	{Key: FlagRunForce, Name: "force", Flag: true, RequiresIfBoolean: true, Spelling: "--force"},
-	{Key: FlagRunJobs, Name: "jobs", Flag: true, Spelling: "--jobs", ValueName: "JOBS"},
+	{Key: FlagRunJobs, Name: "jobs", Flag: true, Spelling: "--jobs", ValueName: "JOBS", Env: "MISE_JOBS"},
 	{Key: FlagRunDryRun, Name: "dry-run", Flag: true, RequiresIfBoolean: true, Spelling: "--dry-run"},
-	{Key: FlagRunOutput, Name: "output", Flag: true, Spelling: "--output", ValueName: "OUTPUT"},
-	{Key: FlagRunQuiet, Name: "quiet", Flag: true, RequiresIfBoolean: true, Spelling: "--quiet"},
+	{Key: FlagRunOutput, Name: "output", Flag: true, Spelling: "--output", ValueName: "OUTPUT", Env: "MISE_TASK_OUTPUT"},
+	{Key: FlagRunQuiet, Name: "quiet", Flag: true, RequiresIfBoolean: true, Spelling: "--quiet", Env: "MISE_QUIET"},
 	{Key: FlagRunRaw, Name: "raw", Flag: true, RequiresIfBoolean: true, Spelling: "--raw"},
 	{Key: FlagRunShell, Name: "shell", Flag: true, Spelling: "--shell", ValueName: "SHELL"},
-	{Key: FlagRunSilent, Name: "silent", Flag: true, RequiresIfBoolean: true, Spelling: "--silent"},
+	{Key: FlagRunSilent, Name: "silent", Flag: true, RequiresIfBoolean: true, Spelling: "--silent", Env: "MISE_SILENT"},
 	{Key: FlagRunTool, Name: "tool", Flag: true, Spelling: "--tool", ValueName: "TOOL@VERSION"},
 	{Key: FlagRunAllowEnv, Name: "allow-env", Flag: true, Spelling: "--allow-env", ValueName: "VAR"},
 	{Key: FlagRunAllowNet, Name: "allow-net", Flag: true, Spelling: "--allow-net", ValueName: "HOST"},
@@ -4489,19 +4528,19 @@ var Meta = argv.Metadata{
 	{Key: FlagRunDenyRead, Name: "deny-read", Flag: true, RequiresIfBoolean: true, Spelling: "--deny-read"},
 	{Key: FlagRunDenyWrite, Name: "deny-write", Flag: true, RequiresIfBoolean: true, Spelling: "--deny-write"},
 	{Key: FlagRunFreshEnv, Name: "fresh-env", Flag: true, RequiresIfBoolean: true, Spelling: "--fresh-env"},
-	{Key: FlagRunNoCache, Name: "no-cache", Flag: true, RequiresIfBoolean: true, Spelling: "--no-cache"},
+	{Key: FlagRunNoCache, Name: "no-cache", Flag: true, RequiresIfBoolean: true, Spelling: "--no-cache", Env: "MISE_TASK_REMOTE_NO_CACHE"},
 	{Key: FlagRunNoDeps, Name: "no-deps", Flag: true, RequiresIfBoolean: true, Spelling: "--no-deps"},
 	{Key: FlagRunNoTimings, Name: "no-timings", Flag: true, RequiresIfBoolean: true, Spelling: "--no-timings"},
-	{Key: FlagRunSkipDeps, Name: "skip-deps", Flag: true, RequiresIfBoolean: true, Spelling: "--skip-deps"},
+	{Key: FlagRunSkipDeps, Name: "skip-deps", Flag: true, RequiresIfBoolean: true, Spelling: "--skip-deps", Env: "MISE_TASK_SKIP_DEPENDS"},
 	{Key: FlagRunSkipTools, Name: "skip-tools", Flag: true, RequiresIfBoolean: true, Spelling: "--skip-tools"},
-	{Key: FlagRunTaskCache, Name: "task-cache", Flag: true, Spelling: "--task-cache", ValueName: "TASK_CACHE", Choices: []string{"read-write", "read-only", "write-only", "off", "local-only"}, AcceptedChoices: []string{"read-write", "read-only", "write-only", "off", "local-only"}, Default: []string{"read-write"}},
+	{Key: FlagRunTaskCache, Name: "task-cache", Flag: true, Spelling: "--task-cache", ValueName: "TASK_CACHE", Choices: []string{"read-write", "read-only", "write-only", "off", "local-only"}, AcceptedChoices: []string{"read-write", "read-only", "write-only", "off", "local-only"}, Default: []string{"read-write"}, Env: "MISE_TASK_CACHE"},
 	{Key: FlagRunTaskCacheExplain, Name: "task-cache-explain", Flag: true, RequiresIfBoolean: true, Spelling: "--task-cache-explain"},
-	{Key: FlagRunTaskCacheExplainJson, Name: "task-cache-explain-json", Flag: true, RequiresIfBoolean: true, Spelling: "--task-cache-explain-json"},
-	{Key: FlagRunTaskCacheStats, Name: "task-cache-stats", Flag: true, RequiresIfBoolean: true, Spelling: "--task-cache-stats"},
+	{Key: FlagRunTaskCacheExplainJson, Name: "task-cache-explain-json", Flag: true, RequiresIfBoolean: true, Spelling: "--task-cache-explain-json", Conflicts: []uint64{FlagRunTaskCacheExplain}, Requires: []uint64{FlagRunDryRun}},
+	{Key: FlagRunTaskCacheStats, Name: "task-cache-stats", Flag: true, RequiresIfBoolean: true, Spelling: "--task-cache-stats", Conflicts: []uint64{FlagRunDryRun}},
 	{Key: FlagRunTimeout, Name: "timeout", Flag: true, Spelling: "--timeout", ValueName: "TIMEOUT"},
 	{Key: FlagRunTimings, Name: "timings", Flag: true, RequiresIfBoolean: true, Spelling: "--timings"},
 	{},
-	{Key: FlagSearchInteractive, Name: "interactive", Flag: true, RequiresIfBoolean: true, Spelling: "--interactive"},
+	{Key: FlagSearchInteractive, Name: "interactive", Flag: true, RequiresIfBoolean: true, Spelling: "--interactive", Conflicts: []uint64{FlagSearchMatchType, FlagSearchNoHeader}},
 	{Key: FlagSearchMatchType, Name: "match-type", Flag: true, Spelling: "--match-type", ValueName: "MATCH_TYPE", Choices: []string{"equal", "contains", "fuzzy"}, AcceptedChoices: []string{"equal", "contains", "fuzzy"}, Default: []string{"fuzzy"}},
 	{Key: FlagSearchNoHeader, Name: "no-header", Flag: true, RequiresIfBoolean: true, Spelling: "--no-header"},
 	{Key: ArgSearchName, Name: "NAME"},
@@ -4511,18 +4550,18 @@ var Meta = argv.Metadata{
 	{Key: FlagSelfUpdateNoPlugins, Name: "no-plugins", Flag: true, RequiresIfBoolean: true, Spelling: "--no-plugins"},
 	{Key: ArgSelfUpdateVersion, Name: "VERSION"},
 	{},
-	{Key: FlagSetEnv, Name: "env", Flag: true, Spelling: "--env", ValueName: "ENV"},
-	{Key: FlagSetGlobal, Name: "global", Flag: true, RequiresIfBoolean: true, Spelling: "--global"},
-	{Key: FlagSetAgeEncrypt, Name: "age-encrypt", Flag: true, RequiresIfBoolean: true, Spelling: "--age-encrypt"},
-	{Key: FlagSetAgeKeyFile, Name: "age-key-file", Flag: true, Spelling: "--age-key-file", ValueName: "PATH"},
-	{Key: FlagSetAgeRecipient, Name: "age-recipient", Flag: true, Spelling: "--age-recipient", ValueName: "RECIPIENT"},
-	{Key: FlagSetAgeSshRecipient, Name: "age-ssh-recipient", Flag: true, Spelling: "--age-ssh-recipient", ValueName: "PATH_OR_PUBKEY"},
+	{Key: FlagSetEnv, Name: "env", Flag: true, Spelling: "--env", ValueName: "ENV", Overrides: []uint64{FlagSetGlobal, FlagSetFile}},
+	{Key: FlagSetGlobal, Name: "global", Flag: true, RequiresIfBoolean: true, Spelling: "--global", Overrides: []uint64{FlagSetFile, FlagSetEnv}},
+	{Key: FlagSetAgeEncrypt, Name: "age-encrypt", Flag: true, RequiresIfBoolean: true, Spelling: "--age-encrypt", Requires: []uint64{ArgSetEnvVar}},
+	{Key: FlagSetAgeKeyFile, Name: "age-key-file", Flag: true, Spelling: "--age-key-file", ValueName: "PATH", Requires: []uint64{FlagSetAgeEncrypt}},
+	{Key: FlagSetAgeRecipient, Name: "age-recipient", Flag: true, Spelling: "--age-recipient", ValueName: "RECIPIENT", Requires: []uint64{FlagSetAgeEncrypt}},
+	{Key: FlagSetAgeSshRecipient, Name: "age-ssh-recipient", Flag: true, Spelling: "--age-ssh-recipient", ValueName: "PATH_OR_PUBKEY", Requires: []uint64{FlagSetAgeEncrypt}},
 	{Key: FlagSetComplete, Name: "complete", Flag: true, RequiresIfBoolean: true, Spelling: "--complete"},
 	{Key: FlagSetFile, Name: "file", Flag: true, Spelling: "--file", ValueName: "FILE"},
 	{Key: FlagSetNoRedact, Name: "no-redact", Flag: true, RequiresIfBoolean: true, Spelling: "--no-redact"},
 	{Key: FlagSetPrompt, Name: "prompt", Flag: true, RequiresIfBoolean: true, Spelling: "--prompt"},
 	{Key: FlagSetRemove, Name: "remove", Flag: true, Spelling: "--remove", ValueName: "ENV_KEY"},
-	{Key: FlagSetStdin, Name: "stdin", Flag: true, RequiresIfBoolean: true, Spelling: "--stdin"},
+	{Key: FlagSetStdin, Name: "stdin", Flag: true, RequiresIfBoolean: true, Spelling: "--stdin", Conflicts: []uint64{FlagSetPrompt}, Requires: []uint64{ArgSetEnvVar}},
 	{Key: ArgSetEnvVar, Name: "ENV_VAR"},
 	{},
 	{Key: FlagSettingsAll, Name: "all", Flag: true, RequiresIfBoolean: true, Spelling: "--all"},
@@ -4532,7 +4571,7 @@ var Meta = argv.Metadata{
 	{Key: FlagSettingsComplete, Name: "complete", Flag: true, RequiresIfBoolean: true, Spelling: "--complete"},
 	{Key: FlagSettingsJsonExtended, Name: "json-extended", Flag: true, RequiresIfBoolean: true, Spelling: "--json-extended"},
 	{Key: ArgSettingsSetting, Name: "SETTING"},
-	{Key: ArgSettingsValue, Name: "VALUE"},
+	{Key: ArgSettingsValue, Name: "VALUE", Conflicts: []uint64{FlagSettingsAll}},
 	{},
 	{Key: FlagSettingsAddLocal, Name: "local", Flag: true, RequiresIfBoolean: true, Spelling: "--local"},
 	{Key: ArgSettingsAddSetting, Name: "SETTING", Required: true},
@@ -4556,9 +4595,9 @@ var Meta = argv.Metadata{
 	{Key: FlagSettingsUnsetLocal, Name: "local", Flag: true, RequiresIfBoolean: true, Spelling: "--local"},
 	{Key: ArgSettingsUnsetKey, Name: "KEY", Required: true},
 	{},
-	{Key: FlagShellJobs, Name: "jobs", Flag: true, Spelling: "--jobs", ValueName: "JOBS"},
+	{Key: FlagShellJobs, Name: "jobs", Flag: true, Spelling: "--jobs", ValueName: "JOBS", Env: "MISE_JOBS"},
 	{Key: FlagShellUnset, Name: "unset", Flag: true, RequiresIfBoolean: true, Spelling: "--unset"},
-	{Key: FlagShellRaw, Name: "raw", Flag: true, RequiresIfBoolean: true, Spelling: "--raw"},
+	{Key: FlagShellRaw, Name: "raw", Flag: true, RequiresIfBoolean: true, Spelling: "--raw", Overrides: []uint64{FlagShellJobs}},
 	{Key: ArgShellToolVersion, Name: "TOOL@VERSION", Required: true},
 	{},
 	{Key: FlagShellAliasNoHeader, Name: "no-header", Flag: true, RequiresIfBoolean: true, Spelling: "--no-header"},
@@ -4581,16 +4620,16 @@ var Meta = argv.Metadata{
 	{Key: FlagSyncPythonPyenv, Name: "pyenv", Flag: true, RequiresIfBoolean: true, Spelling: "--pyenv"},
 	{Key: FlagSyncPythonUv, Name: "uv", Flag: true, RequiresIfBoolean: true, Spelling: "--uv"},
 	{},
-	{Key: FlagSyncRubyBrew, Name: "brew", Flag: true, RequiresIfBoolean: true, Spelling: "--brew"},
+	{Key: FlagSyncRubyBrew, Name: "brew", Flag: true, Required: true, RequiresIfBoolean: true, Spelling: "--brew"},
 	{},
-	{Key: FlagTasksGlobal, Name: "global", Flag: true, RequiresIfBoolean: true, Spelling: "--global"},
+	{Key: FlagTasksGlobal, Name: "global", Flag: true, RequiresIfBoolean: true, Spelling: "--global", Overrides: []uint64{FlagTasksLocal}},
 	{Key: FlagTasksJson, Name: "json", Flag: true, RequiresIfBoolean: true, Spelling: "--json"},
-	{Key: FlagTasksLocal, Name: "local", Flag: true, RequiresIfBoolean: true, Spelling: "--local"},
+	{Key: FlagTasksLocal, Name: "local", Flag: true, RequiresIfBoolean: true, Spelling: "--local", Overrides: []uint64{FlagTasksGlobal}},
 	{Key: FlagTasksExtended, Name: "extended", Flag: true, RequiresIfBoolean: true, Spelling: "--extended"},
 	{Key: FlagTasksAll, Name: "all", Flag: true, RequiresIfBoolean: true, Spelling: "--all"},
 	{Key: FlagTasksComplete, Name: "complete", Flag: true, RequiresIfBoolean: true, Spelling: "--complete"},
 	{Key: FlagTasksHidden, Name: "hidden", Flag: true, RequiresIfBoolean: true, Spelling: "--hidden"},
-	{Key: FlagTasksNameOnly, Name: "name-only", Flag: true, RequiresIfBoolean: true, Spelling: "--name-only"},
+	{Key: FlagTasksNameOnly, Name: "name-only", Flag: true, RequiresIfBoolean: true, Spelling: "--name-only", Conflicts: []uint64{FlagTasksJson, FlagTasksExtended, FlagTasksUsage}},
 	{Key: FlagTasksNoHeader, Name: "no-header", Flag: true, RequiresIfBoolean: true, Spelling: "--no-header"},
 	{Key: FlagTasksSort, Name: "sort", Flag: true, Spelling: "--sort", ValueName: "COLUMN", Choices: []string{"name", "alias", "description", "source"}, AcceptedChoices: []string{"name", "alias", "description", "source"}},
 	{Key: FlagTasksSortOrder, Name: "sort-order", Flag: true, Spelling: "--sort-order", ValueName: "SORT_ORDER", Choices: []string{"asc", "desc"}, AcceptedChoices: []string{"asc", "desc"}},
@@ -4599,7 +4638,7 @@ var Meta = argv.Metadata{
 	{},
 	{Key: FlagTasksAddAlias, Name: "alias", Flag: true, Spelling: "--alias", ValueName: "ALIAS"},
 	{Key: FlagTasksAddDepends, Name: "depends", Flag: true, Spelling: "--depends", ValueName: "DEPENDS"},
-	{Key: FlagTasksAddDir, Name: "dir", Flag: true, Spelling: "--dir", ValueName: "DIR"},
+	{Key: FlagTasksAddDir, Name: "dir", Flag: true, Spelling: "--dir", ValueName: "DIR", CompleteType: "dir"},
 	{Key: FlagTasksAddFile, Name: "file", Flag: true, RequiresIfBoolean: true, Spelling: "--file"},
 	{Key: FlagTasksAddHide, Name: "hide", Flag: true, RequiresIfBoolean: true, Spelling: "--hide"},
 	{Key: FlagTasksAddQuiet, Name: "quiet", Flag: true, RequiresIfBoolean: true, Spelling: "--quiet"},
@@ -4615,7 +4654,7 @@ var Meta = argv.Metadata{
 	{Key: ArgTasksAddTask, Name: "TASK", Required: true},
 	{Key: ArgTasksAddRun, Name: "RUN"},
 	{},
-	{Key: FlagTasksDepsCompact, Name: "compact", Flag: true, RequiresIfBoolean: true, Spelling: "--compact"},
+	{Key: FlagTasksDepsCompact, Name: "compact", Flag: true, RequiresIfBoolean: true, Spelling: "--compact", Conflicts: []uint64{FlagTasksDepsDot}},
 	{Key: FlagTasksDepsDot, Name: "dot", Flag: true, RequiresIfBoolean: true, Spelling: "--dot"},
 	{Key: FlagTasksDepsHidden, Name: "hidden", Flag: true, RequiresIfBoolean: true, Spelling: "--hidden"},
 	{Key: ArgTasksDepsTasks, Name: "TASKS"},
@@ -4624,40 +4663,41 @@ var Meta = argv.Metadata{
 	{Key: ArgTasksEditTask, Name: "TASK", Required: true},
 	{},
 	{Key: FlagTasksGraphJson, Name: "json", Flag: true, RequiresIfBoolean: true, Spelling: "--json"},
-	{Key: FlagTasksGraphExplain, Name: "explain", Flag: true, RequiresIfBoolean: true, Spelling: "--explain"},
+	{Key: FlagTasksGraphExplain, Name: "explain", Flag: true, RequiresIfBoolean: true, Spelling: "--explain", Conflicts: []uint64{FlagTasksGraphJson}},
 	{Key: FlagTasksGraphNoHeader, Name: "no-header", Flag: true, RequiresIfBoolean: true, Spelling: "--no-header"},
 	{},
 	{Key: FlagTasksInfoJson, Name: "json", Flag: true, RequiresIfBoolean: true, Spelling: "--json"},
 	{Key: ArgTasksInfoTask, Name: "TASK", Required: true},
 	{},
-	{Key: FlagTasksLsGlobal, Name: "global", Flag: true, RequiresIfBoolean: true, Spelling: "--global"},
+	{Key: FlagTasksLsGlobal, Name: "global", Flag: true, RequiresIfBoolean: true, Spelling: "--global", Overrides: []uint64{FlagTasksLsLocal}},
 	{Key: FlagTasksLsJson, Name: "json", Flag: true, RequiresIfBoolean: true, Spelling: "--json"},
-	{Key: FlagTasksLsLocal, Name: "local", Flag: true, RequiresIfBoolean: true, Spelling: "--local"},
+	{Key: FlagTasksLsLocal, Name: "local", Flag: true, RequiresIfBoolean: true, Spelling: "--local", Overrides: []uint64{FlagTasksLsGlobal}},
 	{Key: FlagTasksLsExtended, Name: "extended", Flag: true, RequiresIfBoolean: true, Spelling: "--extended"},
 	{Key: FlagTasksLsAll, Name: "all", Flag: true, RequiresIfBoolean: true, Spelling: "--all"},
 	{Key: FlagTasksLsComplete, Name: "complete", Flag: true, RequiresIfBoolean: true, Spelling: "--complete"},
 	{Key: FlagTasksLsHidden, Name: "hidden", Flag: true, RequiresIfBoolean: true, Spelling: "--hidden"},
-	{Key: FlagTasksLsNameOnly, Name: "name-only", Flag: true, RequiresIfBoolean: true, Spelling: "--name-only"},
+	{Key: FlagTasksLsNameOnly, Name: "name-only", Flag: true, RequiresIfBoolean: true, Spelling: "--name-only", Conflicts: []uint64{FlagTasksLsJson, FlagTasksLsExtended, FlagTasksLsUsage}},
 	{Key: FlagTasksLsNoHeader, Name: "no-header", Flag: true, RequiresIfBoolean: true, Spelling: "--no-header"},
 	{Key: FlagTasksLsSort, Name: "sort", Flag: true, Spelling: "--sort", ValueName: "COLUMN", Choices: []string{"name", "alias", "description", "source"}, AcceptedChoices: []string{"name", "alias", "description", "source"}},
 	{Key: FlagTasksLsSortOrder, Name: "sort-order", Flag: true, Spelling: "--sort-order", ValueName: "SORT_ORDER", Choices: []string{"asc", "desc"}, AcceptedChoices: []string{"asc", "desc"}},
 	{Key: FlagTasksLsUsage, Name: "usage", Flag: true, RequiresIfBoolean: true, Spelling: "--usage"},
 	{},
 	{Key: FlagTasksRunAffected, Name: "affected", Flag: true, RequiresIfBoolean: true, Spelling: "--affected"},
-	{Key: FlagTasksRunAffectedBase, Name: "affected-base", Flag: true, Spelling: "--affected-base", ValueName: "REV"},
-	{Key: FlagTasksRunAffectedExplain, Name: "affected-explain", Flag: true, RequiresIfBoolean: true, Spelling: "--affected-explain"},
-	{Key: FlagTasksRunAffectedHead, Name: "affected-head", Flag: true, Spelling: "--affected-head", ValueName: "REV"},
-	{Key: FlagTasksRunAffectedJson, Name: "affected-json", Flag: true, RequiresIfBoolean: true, Spelling: "--affected-json"},
+	{Key: FlagTasksRunAffectedBase, Name: "affected-base", Flag: true, Spelling: "--affected-base", ValueName: "REV", Requires: []uint64{FlagTasksRunAffected}},
+	{Key: FlagTasksRunAffectedExplain, Name: "affected-explain", Flag: true, RequiresIfBoolean: true, Spelling: "--affected-explain", Conflicts: []uint64{FlagTasksRunAffectedJson}, Requires: []uint64{FlagTasksRunAffected}},
+	{Key: FlagTasksRunAffectedHead, Name: "affected-head", Flag: true, Spelling: "--affected-head", ValueName: "REV", Requires: []uint64{FlagTasksRunAffected}},
+	{Key: FlagTasksRunAffectedJson, Name: "affected-json", Flag: true, RequiresIfBoolean: true, Spelling: "--affected-json", Conflicts: []uint64{FlagTasksRunAffectedExplain}, Requires: []uint64{FlagTasksRunAffected}},
+	{Key: FlagTasksRunAll, Name: "all", Flag: true, RequiresIfBoolean: true, Spelling: "--all", Conflicts: []uint64{ArgTasksRunTask, FlagTasksRunAffected}},
 	{Key: FlagTasksRunContinueOnError, Name: "continue-on-error", Flag: true, RequiresIfBoolean: true, Spelling: "--continue-on-error"},
 	{Key: FlagTasksRunCd, Name: "cd", Flag: true, Spelling: "--cd", ValueName: "CD"},
 	{Key: FlagTasksRunForce, Name: "force", Flag: true, RequiresIfBoolean: true, Spelling: "--force"},
-	{Key: FlagTasksRunJobs, Name: "jobs", Flag: true, Spelling: "--jobs", ValueName: "JOBS"},
+	{Key: FlagTasksRunJobs, Name: "jobs", Flag: true, Spelling: "--jobs", ValueName: "JOBS", Env: "MISE_JOBS"},
 	{Key: FlagTasksRunDryRun, Name: "dry-run", Flag: true, RequiresIfBoolean: true, Spelling: "--dry-run"},
-	{Key: FlagTasksRunOutput, Name: "output", Flag: true, Spelling: "--output", ValueName: "OUTPUT"},
-	{Key: FlagTasksRunQuiet, Name: "quiet", Flag: true, RequiresIfBoolean: true, Spelling: "--quiet"},
+	{Key: FlagTasksRunOutput, Name: "output", Flag: true, Spelling: "--output", ValueName: "OUTPUT", Env: "MISE_TASK_OUTPUT"},
+	{Key: FlagTasksRunQuiet, Name: "quiet", Flag: true, RequiresIfBoolean: true, Spelling: "--quiet", Env: "MISE_QUIET"},
 	{Key: FlagTasksRunRaw, Name: "raw", Flag: true, RequiresIfBoolean: true, Spelling: "--raw"},
 	{Key: FlagTasksRunShell, Name: "shell", Flag: true, Spelling: "--shell", ValueName: "SHELL"},
-	{Key: FlagTasksRunSilent, Name: "silent", Flag: true, RequiresIfBoolean: true, Spelling: "--silent"},
+	{Key: FlagTasksRunSilent, Name: "silent", Flag: true, RequiresIfBoolean: true, Spelling: "--silent", Env: "MISE_SILENT"},
 	{Key: FlagTasksRunTool, Name: "tool", Flag: true, Spelling: "--tool", ValueName: "TOOL@VERSION"},
 	{Key: FlagTasksRunAllowEnv, Name: "allow-env", Flag: true, Spelling: "--allow-env", ValueName: "VAR"},
 	{Key: FlagTasksRunAllowNet, Name: "allow-net", Flag: true, Spelling: "--allow-net", ValueName: "HOST"},
@@ -4669,18 +4709,18 @@ var Meta = argv.Metadata{
 	{Key: FlagTasksRunDenyRead, Name: "deny-read", Flag: true, RequiresIfBoolean: true, Spelling: "--deny-read"},
 	{Key: FlagTasksRunDenyWrite, Name: "deny-write", Flag: true, RequiresIfBoolean: true, Spelling: "--deny-write"},
 	{Key: FlagTasksRunFreshEnv, Name: "fresh-env", Flag: true, RequiresIfBoolean: true, Spelling: "--fresh-env"},
-	{Key: FlagTasksRunNoCache, Name: "no-cache", Flag: true, RequiresIfBoolean: true, Spelling: "--no-cache"},
+	{Key: FlagTasksRunNoCache, Name: "no-cache", Flag: true, RequiresIfBoolean: true, Spelling: "--no-cache", Env: "MISE_TASK_REMOTE_NO_CACHE"},
 	{Key: FlagTasksRunNoDeps, Name: "no-deps", Flag: true, RequiresIfBoolean: true, Spelling: "--no-deps"},
 	{Key: FlagTasksRunNoTimings, Name: "no-timings", Flag: true, RequiresIfBoolean: true, Spelling: "--no-timings"},
-	{Key: FlagTasksRunSkipDeps, Name: "skip-deps", Flag: true, RequiresIfBoolean: true, Spelling: "--skip-deps"},
+	{Key: FlagTasksRunSkipDeps, Name: "skip-deps", Flag: true, RequiresIfBoolean: true, Spelling: "--skip-deps", Env: "MISE_TASK_SKIP_DEPENDS"},
 	{Key: FlagTasksRunSkipTools, Name: "skip-tools", Flag: true, RequiresIfBoolean: true, Spelling: "--skip-tools"},
-	{Key: FlagTasksRunTaskCache, Name: "task-cache", Flag: true, Spelling: "--task-cache", ValueName: "TASK_CACHE", Choices: []string{"read-write", "read-only", "write-only", "off", "local-only"}, AcceptedChoices: []string{"read-write", "read-only", "write-only", "off", "local-only"}, Default: []string{"read-write"}},
+	{Key: FlagTasksRunTaskCache, Name: "task-cache", Flag: true, Spelling: "--task-cache", ValueName: "TASK_CACHE", Choices: []string{"read-write", "read-only", "write-only", "off", "local-only"}, AcceptedChoices: []string{"read-write", "read-only", "write-only", "off", "local-only"}, Default: []string{"read-write"}, Env: "MISE_TASK_CACHE"},
 	{Key: FlagTasksRunTaskCacheExplain, Name: "task-cache-explain", Flag: true, RequiresIfBoolean: true, Spelling: "--task-cache-explain"},
-	{Key: FlagTasksRunTaskCacheExplainJson, Name: "task-cache-explain-json", Flag: true, RequiresIfBoolean: true, Spelling: "--task-cache-explain-json"},
-	{Key: FlagTasksRunTaskCacheStats, Name: "task-cache-stats", Flag: true, RequiresIfBoolean: true, Spelling: "--task-cache-stats"},
+	{Key: FlagTasksRunTaskCacheExplainJson, Name: "task-cache-explain-json", Flag: true, RequiresIfBoolean: true, Spelling: "--task-cache-explain-json", Conflicts: []uint64{FlagTasksRunTaskCacheExplain}, Requires: []uint64{FlagTasksRunDryRun}},
+	{Key: FlagTasksRunTaskCacheStats, Name: "task-cache-stats", Flag: true, RequiresIfBoolean: true, Spelling: "--task-cache-stats", Conflicts: []uint64{FlagTasksRunDryRun}},
 	{Key: FlagTasksRunTimeout, Name: "timeout", Flag: true, Spelling: "--timeout", ValueName: "TIMEOUT"},
 	{Key: FlagTasksRunTimings, Name: "timings", Flag: true, RequiresIfBoolean: true, Spelling: "--timings"},
-	{Key: ArgTasksRunTask, Name: "TASK", Default: []string{"default"}},
+	{Key: ArgTasksRunTask, Name: "TASK"},
 	{Key: ArgTasksRunArgs, Name: "ARGS"},
 	{Key: ArgTasksRunArgsLast, Name: "ARGS_LAST"},
 	{},
@@ -4688,12 +4728,12 @@ var Meta = argv.Metadata{
 	{Key: FlagTasksValidateJson, Name: "json", Flag: true, RequiresIfBoolean: true, Spelling: "--json"},
 	{Key: ArgTasksValidateTasks, Name: "TASKS"},
 	{},
-	{Key: FlagTestToolAll, Name: "all", Flag: true, RequiresIfBoolean: true, Spelling: "--all"},
-	{Key: FlagTestToolJobs, Name: "jobs", Flag: true, Spelling: "--jobs", ValueName: "JOBS"},
-	{Key: FlagTestToolAllConfig, Name: "all-config", Flag: true, RequiresIfBoolean: true, Spelling: "--all-config"},
+	{Key: FlagTestToolAll, Name: "all", Flag: true, RequiresIfBoolean: true, Spelling: "--all", Conflicts: []uint64{ArgTestToolTools, FlagTestToolAllConfig}},
+	{Key: FlagTestToolJobs, Name: "jobs", Flag: true, Spelling: "--jobs", ValueName: "JOBS", Env: "MISE_TEST_TOOL_JOBS"},
+	{Key: FlagTestToolAllConfig, Name: "all-config", Flag: true, RequiresIfBoolean: true, Spelling: "--all-config", Conflicts: []uint64{ArgTestToolTools, FlagTestToolAll}},
 	{Key: FlagTestToolIncludeNonDefined, Name: "include-non-defined", Flag: true, RequiresIfBoolean: true, Spelling: "--include-non-defined"},
-	{Key: FlagTestToolRaw, Name: "raw", Flag: true, RequiresIfBoolean: true, Spelling: "--raw"},
-	{Key: ArgTestToolTools, Name: "TOOLS"},
+	{Key: FlagTestToolRaw, Name: "raw", Flag: true, RequiresIfBoolean: true, Spelling: "--raw", Overrides: []uint64{FlagTestToolJobs}},
+	{Key: ArgTestToolTools, Name: "TOOLS", RequiredUnless: []uint64{FlagTestToolAll, FlagTestToolAllConfig}},
 	{},
 	{},
 	{Key: FlagTokenForgejoUnmask, Name: "unmask", Flag: true, RequiresIfBoolean: true, Spelling: "--unmask"},
@@ -4701,7 +4741,7 @@ var Meta = argv.Metadata{
 	{},
 	{Key: FlagTokenGithubOauth, Name: "oauth", Flag: true, RequiresIfBoolean: true, Spelling: "--oauth"},
 	{Key: FlagTokenGithubRaw, Name: "raw", Flag: true, RequiresIfBoolean: true, Spelling: "--raw"},
-	{Key: FlagTokenGithubRefresh, Name: "refresh", Flag: true, RequiresIfBoolean: true, Spelling: "--refresh"},
+	{Key: FlagTokenGithubRefresh, Name: "refresh", Flag: true, RequiresIfBoolean: true, Spelling: "--refresh", Requires: []uint64{FlagTokenGithubOauth}},
 	{Key: FlagTokenGithubUnmask, Name: "unmask", Flag: true, RequiresIfBoolean: true, Spelling: "--unmask"},
 	{Key: ArgTokenGithubHost, Name: "HOST", Default: []string{"github.com"}},
 	{},
@@ -4721,8 +4761,8 @@ var Meta = argv.Metadata{
 	{Key: ArgToolStubFile, Name: "FILE", Required: true},
 	{Key: ArgToolStubArgs, Name: "ARGS"},
 	{},
-	{Key: FlagTrustAll, Name: "all", Flag: true, RequiresIfBoolean: true, Spelling: "--all"},
-	{Key: FlagTrustIgnore, Name: "ignore", Flag: true, RequiresIfBoolean: true, Spelling: "--ignore"},
+	{Key: FlagTrustAll, Name: "all", Flag: true, RequiresIfBoolean: true, Spelling: "--all", Conflicts: []uint64{FlagTrustIgnore, FlagTrustUntrust}},
+	{Key: FlagTrustIgnore, Name: "ignore", Flag: true, RequiresIfBoolean: true, Spelling: "--ignore", Conflicts: []uint64{FlagTrustUntrust}},
 	{Key: FlagTrustShow, Name: "show", Flag: true, RequiresIfBoolean: true, Spelling: "--show"},
 	{Key: FlagTrustUntrust, Name: "untrust", Flag: true, RequiresIfBoolean: true, Spelling: "--untrust"},
 	{Key: ArgTrustConfigFile, Name: "CONFIG_FILE", CompleteType: "file"},
@@ -4730,46 +4770,48 @@ var Meta = argv.Metadata{
 	{Key: FlagUninstallAll, Name: "all", Flag: true, RequiresIfBoolean: true, Spelling: "--all"},
 	{Key: FlagUninstallDryRun, Name: "dry-run", Flag: true, RequiresIfBoolean: true, Spelling: "--dry-run"},
 	{Key: FlagUninstallDryRunCode, Name: "dry-run-code", Flag: true, RequiresIfBoolean: true, Spelling: "--dry-run-code"},
-	{Key: ArgUninstallInstalledToolVersion, Name: "INSTALLED_TOOL@VERSION"},
+	{Key: ArgUninstallInstalledToolVersion, Name: "INSTALLED_TOOL@VERSION", RequiredUnless: []uint64{FlagUninstallAll}},
 	{},
 	{Key: FlagUnsetFile, Name: "file", Flag: true, Spelling: "--file", ValueName: "FILE"},
-	{Key: FlagUnsetGlobal, Name: "global", Flag: true, RequiresIfBoolean: true, Spelling: "--global"},
+	{Key: FlagUnsetGlobal, Name: "global", Flag: true, RequiresIfBoolean: true, Spelling: "--global", Overrides: []uint64{FlagUnsetFile}},
 	{Key: ArgUnsetEnvKey, Name: "ENV_KEY"},
 	{},
 	{Key: ArgUntrustConfigFile, Name: "CONFIG_FILE", CompleteType: "file"},
 	{},
-	{Key: FlagUnuseEnv, Name: "env", Flag: true, Spelling: "--env", ValueName: "ENV"},
-	{Key: FlagUnuseGlobal, Name: "global", Flag: true, RequiresIfBoolean: true, Spelling: "--global"},
-	{Key: FlagUnusePath, Name: "path", Flag: true, Spelling: "--path", ValueName: "PATH"},
+	{Key: FlagUnuseEnv, Name: "env", Flag: true, Spelling: "--env", ValueName: "ENV", Overrides: []uint64{FlagUnuseGlobal, FlagUnusePath}},
+	{Key: FlagUnuseGlobal, Name: "global", Flag: true, RequiresIfBoolean: true, Spelling: "--global", Overrides: []uint64{FlagUnusePath, FlagUnuseEnv}},
+	{Key: FlagUnusePath, Name: "path", Flag: true, Spelling: "--path", ValueName: "PATH", Overrides: []uint64{FlagUnuseGlobal, FlagUnuseEnv}},
 	{Key: FlagUnuseNoPrune, Name: "no-prune", Flag: true, RequiresIfBoolean: true, Spelling: "--no-prune"},
 	{Key: ArgUnuseInstalledToolVersion, Name: "INSTALLED_TOOL@VERSION", Required: true},
 	{},
-	{Key: FlagUpgradeInteractive, Name: "interactive", Flag: true, RequiresIfBoolean: true, Spelling: "--interactive"},
-	{Key: FlagUpgradeJobs, Name: "jobs", Flag: true, Spelling: "--jobs", ValueName: "JOBS"},
 	{Key: FlagUpgradeBump, Name: "bump", Flag: true, RequiresIfBoolean: true, Spelling: "--bump"},
+	{Key: FlagUpgradeInteractive, Name: "interactive", Flag: true, RequiresIfBoolean: true, Spelling: "--interactive", Conflicts: []uint64{ArgUpgradeInstalledToolVersion}},
+	{Key: FlagUpgradeJobs, Name: "jobs", Flag: true, Spelling: "--jobs", ValueName: "JOBS", Env: "MISE_JOBS"},
+	{Key: FlagUpgradeL, Name: "l", Flag: true, RequiresIfBoolean: true, Spelling: "-l"},
 	{Key: FlagUpgradeDryRun, Name: "dry-run", Flag: true, RequiresIfBoolean: true, Spelling: "--dry-run"},
 	{Key: FlagUpgradeExclude, Name: "exclude", Flag: true, Spelling: "--exclude", ValueName: "INSTALLED_TOOL"},
 	{Key: FlagUpgradeDryRunCode, Name: "dry-run-code", Flag: true, RequiresIfBoolean: true, Spelling: "--dry-run-code"},
-	{Key: FlagUpgradeInactive, Name: "inactive", Flag: true, RequiresIfBoolean: true, Spelling: "--inactive"},
+	{Key: FlagUpgradeInactive, Name: "inactive", Flag: true, RequiresIfBoolean: true, Spelling: "--inactive", Conflicts: []uint64{FlagUpgradeLocal}},
 	{Key: FlagUpgradeLocal, Name: "local", Flag: true, RequiresIfBoolean: true, Spelling: "--local"},
 	{Key: FlagUpgradeMinimumReleaseAge, Name: "minimum-release-age", Flag: true, Spelling: "--minimum-release-age", ValueName: "MINIMUM_RELEASE_AGE"},
 	{Key: FlagUpgradeMonorepo, Name: "monorepo", Flag: true, RequiresIfBoolean: true, Spelling: "--monorepo"},
-	{Key: FlagUpgradeNoPrune, Name: "no-prune", Flag: true, RequiresIfBoolean: true, Spelling: "--no-prune"},
-	{Key: FlagUpgradeRaw, Name: "raw", Flag: true, RequiresIfBoolean: true, Spelling: "--raw"},
+	{Key: FlagUpgradeNoPrune, Name: "no-prune", Flag: true, RequiresIfBoolean: true, Spelling: "--no-prune", Overrides: []uint64{FlagUpgradePrune}},
+	{Key: FlagUpgradePrune, Name: "prune", Flag: true, RequiresIfBoolean: true, Spelling: "--prune", Overrides: []uint64{FlagUpgradeNoPrune}},
+	{Key: FlagUpgradeRaw, Name: "raw", Flag: true, RequiresIfBoolean: true, Spelling: "--raw", Overrides: []uint64{FlagUpgradeJobs}},
 	{Key: ArgUpgradeInstalledToolVersion, Name: "INSTALLED_TOOL@VERSION"},
 	{},
 	{},
-	{Key: FlagUseEnv, Name: "env", Flag: true, Spelling: "--env", ValueName: "ENV"},
-	{Key: FlagUseForce, Name: "force", Flag: true, RequiresIfBoolean: true, Spelling: "--force"},
-	{Key: FlagUseGlobal, Name: "global", Flag: true, RequiresIfBoolean: true, Spelling: "--global"},
-	{Key: FlagUseJobs, Name: "jobs", Flag: true, Spelling: "--jobs", ValueName: "JOBS"},
+	{Key: FlagUseEnv, Name: "env", Flag: true, Spelling: "--env", ValueName: "ENV", Overrides: []uint64{FlagUseGlobal, FlagUsePath}},
+	{Key: FlagUseForce, Name: "force", Flag: true, RequiresIfBoolean: true, Spelling: "--force", Requires: []uint64{ArgUseToolVersion}},
+	{Key: FlagUseGlobal, Name: "global", Flag: true, RequiresIfBoolean: true, Spelling: "--global", Overrides: []uint64{FlagUsePath, FlagUseEnv}},
+	{Key: FlagUseJobs, Name: "jobs", Flag: true, Spelling: "--jobs", ValueName: "JOBS", Env: "MISE_JOBS"},
 	{Key: FlagUseDryRun, Name: "dry-run", Flag: true, RequiresIfBoolean: true, Spelling: "--dry-run"},
-	{Key: FlagUsePath, Name: "path", Flag: true, Spelling: "--path", ValueName: "PATH"},
+	{Key: FlagUsePath, Name: "path", Flag: true, Spelling: "--path", ValueName: "PATH", Overrides: []uint64{FlagUseGlobal, FlagUseEnv}},
 	{Key: FlagUseDryRunCode, Name: "dry-run-code", Flag: true, RequiresIfBoolean: true, Spelling: "--dry-run-code"},
-	{Key: FlagUseFuzzy, Name: "fuzzy", Flag: true, RequiresIfBoolean: true, Spelling: "--fuzzy"},
+	{Key: FlagUseFuzzy, Name: "fuzzy", Flag: true, RequiresIfBoolean: true, Spelling: "--fuzzy", Overrides: []uint64{FlagUsePin}},
 	{Key: FlagUseMinimumReleaseAge, Name: "minimum-release-age", Flag: true, Spelling: "--minimum-release-age", ValueName: "MINIMUM_RELEASE_AGE"},
-	{Key: FlagUsePin, Name: "pin", Flag: true, RequiresIfBoolean: true, Spelling: "--pin"},
-	{Key: FlagUseRaw, Name: "raw", Flag: true, RequiresIfBoolean: true, Spelling: "--raw"},
+	{Key: FlagUsePin, Name: "pin", Flag: true, RequiresIfBoolean: true, Spelling: "--pin", Overrides: []uint64{FlagUseFuzzy}},
+	{Key: FlagUseRaw, Name: "raw", Flag: true, RequiresIfBoolean: true, Spelling: "--raw", Overrides: []uint64{FlagUseJobs}},
 	{Key: FlagUseRemove, Name: "remove", Flag: true, Spelling: "--remove", ValueName: "TOOL"},
 	{Key: ArgUseToolVersion, Name: "TOOL@VERSION"},
 	{},
@@ -4783,8 +4825,8 @@ var Meta = argv.Metadata{
 	{Key: FlagWatchWatchFile, Name: "watch-file", Flag: true, Spelling: "--watch-file", ValueName: "PATH"},
 	{Key: FlagWatchClear, Name: "clear", Flag: true, Spelling: "--clear", ValueName: "MODE", Choices: []string{"clear", "reset"}, AcceptedChoices: []string{"clear", "reset"}},
 	{Key: FlagWatchOnBusyUpdate, Name: "on-busy-update", Flag: true, Spelling: "--on-busy-update", ValueName: "MODE", Choices: []string{"queue", "do-nothing", "restart", "signal"}, AcceptedChoices: []string{"queue", "do-nothing", "restart", "signal"}, Default: []string{"do-nothing"}},
-	{Key: FlagWatchRestart, Name: "restart", Flag: true, RequiresIfBoolean: true, Spelling: "--restart"},
-	{Key: FlagWatchSignal, Name: "signal", Flag: true, Spelling: "--signal", ValueName: "SIGNAL"},
+	{Key: FlagWatchRestart, Name: "restart", Flag: true, RequiresIfBoolean: true, Spelling: "--restart", Conflicts: []uint64{FlagWatchOnBusyUpdate}},
+	{Key: FlagWatchSignal, Name: "signal", Flag: true, Spelling: "--signal", ValueName: "SIGNAL", Conflicts: []uint64{FlagWatchRestart}},
 	{Key: FlagWatchStopSignal, Name: "stop-signal", Flag: true, Spelling: "--stop-signal", ValueName: "SIGNAL"},
 	{Key: FlagWatchStopTimeout, Name: "stop-timeout", Flag: true, Spelling: "--stop-timeout", ValueName: "TIMEOUT", Default: []string{"10s"}},
 	{Key: FlagWatchMapSignal, Name: "map-signal", Flag: true, Spelling: "--map-signal", ValueName: "SIGNAL:SIGNAL"},
@@ -4801,8 +4843,8 @@ var Meta = argv.Metadata{
 	{Key: FlagWatchPoll, Name: "poll", Flag: true, Spelling: "--poll", ValueName: "INTERVAL"},
 	{Key: FlagWatchShell, Name: "shell", Flag: true, Spelling: "--shell", ValueName: "SHELL"},
 	{Key: FlagWatchN, Name: "n", Flag: true, RequiresIfBoolean: true, Spelling: "-n"},
-	{Key: FlagWatchEmitEventsTo, Name: "emit-events-to", Flag: true, Spelling: "--emit-events-to", ValueName: "MODE", Choices: []string{"environment", "stdio", "file", "json-stdio", "json-file", "none"}, AcceptedChoices: []string{"environment", "stdio", "file", "json-stdio", "json-file", "none"}, Default: []string{"none"}},
-	{Key: FlagWatchOnlyEmitEvents, Name: "only-emit-events", Flag: true, RequiresIfBoolean: true, Spelling: "--only-emit-events"},
+	{Key: FlagWatchEmitEventsTo, Name: "emit-events-to", Flag: true, Spelling: "--emit-events-to", ValueName: "MODE", Choices: []string{"environment", "stdio", "file", "json-stdio", "json-file", "none"}, AcceptedChoices: []string{"environment", "stdio", "file", "json-stdio", "json-file", "none"}, Default: []string{"none"}, RequiredIfEq: []argv.ValueCondition{{Key: FlagWatchOnlyEmitEvents, Value: "true"}}},
+	{Key: FlagWatchOnlyEmitEvents, Name: "only-emit-events", Flag: true, RequiresIfBoolean: true, Spelling: "--only-emit-events", Conflicts: []uint64{FlagWatchManual}},
 	{Key: FlagWatchEnv, Name: "env", Flag: true, Spelling: "--env", ValueName: "KEY=VALUE"},
 	{Key: FlagWatchWrapProcess, Name: "wrap-process", Flag: true, Spelling: "--wrap-process", ValueName: "MODE", Choices: []string{"group", "session", "none"}, AcceptedChoices: []string{"group", "session", "none"}},
 	{Key: FlagWatchNotify, Name: "notify", Flag: true, RequiresIfBoolean: true, Spelling: "--notify"},
@@ -4814,12 +4856,12 @@ var Meta = argv.Metadata{
 	{Key: FlagWatchWorkdir, Name: "workdir", Flag: true, Spelling: "--workdir", ValueName: "DIRECTORY"},
 	{Key: FlagWatchExts, Name: "exts", Flag: true, Spelling: "--exts", ValueName: "EXTENSIONS"},
 	{Key: FlagWatchFilter, Name: "filter", Flag: true, Spelling: "--filter", ValueName: "PATTERN"},
-	{Key: FlagWatchFilterFile, Name: "filter-file", Flag: true, Spelling: "--filter-file", ValueName: "PATH"},
+	{Key: FlagWatchFilterFile, Name: "filter-file", Flag: true, Spelling: "--filter-file", ValueName: "PATH", Env: "WATCHEXEC_FILTER_FILES"},
 	{Key: FlagWatchFilterProg, Name: "filter-prog", Flag: true, Spelling: "--filter-prog", ValueName: "EXPRESSION"},
 	{Key: FlagWatchIgnore, Name: "ignore", Flag: true, Spelling: "--ignore", ValueName: "PATTERN"},
-	{Key: FlagWatchIgnoreFile, Name: "ignore-file", Flag: true, Spelling: "--ignore-file", ValueName: "PATH"},
-	{Key: FlagWatchFsEvents, Name: "fs-events", Flag: true, Spelling: "--fs-events", ValueName: "EVENTS", Choices: []string{"access", "create", "remove", "rename", "modify", "metadata"}, AcceptedChoices: []string{"access", "create", "remove", "rename", "modify", "metadata"}, Default: []string{"create", "remove", "rename", "modify", "metadata"}},
-	{Key: FlagWatchNoMeta, Name: "no-meta", Flag: true, RequiresIfBoolean: true, Spelling: "--no-meta"},
+	{Key: FlagWatchIgnoreFile, Name: "ignore-file", Flag: true, Spelling: "--ignore-file", ValueName: "PATH", Env: "WATCHEXEC_IGNORE_FILES"},
+	{Key: FlagWatchFsEvents, Name: "fs-events", Flag: true, Spelling: "--fs-events", ValueName: "EVENTS", Choices: []string{"access", "create", "remove", "rename", "modify", "metadata"}, AcceptedChoices: []string{"access", "create", "remove", "rename", "modify", "metadata"}, Default: []string{"create,remove,rename,modify,metadata"}},
+	{Key: FlagWatchNoMeta, Name: "no-meta", Flag: true, RequiresIfBoolean: true, Spelling: "--no-meta", Conflicts: []uint64{FlagWatchFsEvents}},
 	{Key: FlagWatchPrintEvents, Name: "print-events", Flag: true, RequiresIfBoolean: true, Spelling: "--print-events"},
 	{Key: FlagWatchManual, Name: "manual", Flag: true, RequiresIfBoolean: true, Spelling: "--manual"},
 	{Key: ArgWatchTask, Name: "TASK"},
@@ -4830,9 +4872,9 @@ var Meta = argv.Metadata{
 	{},
 	{Key: FlagWhichTool, Name: "tool", Flag: true, Spelling: "--tool", ValueName: "TOOL@VERSION"},
 	{Key: FlagWhichComplete, Name: "complete", Flag: true, RequiresIfBoolean: true, Spelling: "--complete"},
-	{Key: FlagWhichPlugin, Name: "plugin", Flag: true, RequiresIfBoolean: true, Spelling: "--plugin"},
-	{Key: FlagWhichVersion, Name: "version", Flag: true, RequiresIfBoolean: true, Spelling: "--version"},
-	{Key: ArgWhichBinName, Name: "BIN_NAME"},
+	{Key: FlagWhichPlugin, Name: "plugin", Flag: true, RequiresIfBoolean: true, Spelling: "--plugin", Conflicts: []uint64{FlagWhichVersion}},
+	{Key: FlagWhichVersion, Name: "version", Flag: true, RequiresIfBoolean: true, Spelling: "--version", Conflicts: []uint64{FlagWhichPlugin}},
+	{Key: ArgWhichBinName, Name: "BIN_NAME", RequiredUnless: []uint64{FlagWhichComplete}},
 }
 
 // HelpText is the third table, read only when a page is rendered. Neither the
@@ -4846,12 +4888,12 @@ var HelpText = argv.HelpTable{
 	{Key: FlagCd, ValueName: "DIR", ValueDemanded: true, Short: "Change directory before running command", Long: "Change directory before running command"},
 	{Key: FlagEnv, Repeatable: true, ValueName: "ENV", ValueDemanded: true, Short: "Set the environment for loading `mise.<ENV>.toml`", Long: "Set the environment for loading `mise.<ENV>.toml`"},
 	{Key: FlagForce, Hide: true, Short: "Force the operation", Long: "Force the operation"},
-	{Key: FlagJobs, ValueName: "JOBS", ValueDemanded: true, Short: "How many jobs to run in parallel [default: 8]", Long: "How many jobs to run in parallel [default: 8]"},
+	{Key: FlagJobs, ValueName: "JOBS", ValueDemanded: true, Short: "How many jobs to run in parallel; values below 1 are treated as 1 [default: 8]", Long: "How many jobs to run in parallel; values below 1 are treated as 1 [default: 8]", Env: "MISE_JOBS"},
 	{Key: FlagDryRun, Hide: true, Short: "Dry run, don't actually do anything", Long: "Dry run, don't actually do anything"},
 	{Key: FlagProfile, Hide: true, Repeatable: true, ValueName: "PROFILE", ValueDemanded: true, Short: "Set the profile (environment)", Long: "Set the profile (environment)"},
 	{Key: FlagQuiet, Short: "Suppress non-error messages", Long: "Suppress non-error messages"},
 	{Key: FlagShell, Hide: true, ValueName: "SHELL", ValueDemanded: true},
-	{Key: FlagTool, Hide: true, Repeatable: true, ValueName: "TOOL@VERSION", ValueDemanded: true, Short: "Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10", Long: "Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10"},
+	{Key: FlagTool, Hide: true, Repeatable: true, ValueName: "TOOL@VERSION", ValueDemanded: true, Short: "Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10", Long: "Tool(s) to run in addition to what is in mise.toml files\ne.g.: node@20 python@3.10", Env: "MISE_QUIET"},
 	{Key: FlagVerbose, Repeatable: true, Short: "Show extra output (use -vv for even more)", Long: "Show extra output (use -vv for even more)"},
 	{Key: FlagVersion, Hide: true},
 	{Key: FlagYes, Short: "Answer yes to all confirmation prompts", Long: "Answer yes to all confirmation prompts"},
@@ -4870,44 +4912,44 @@ var HelpText = argv.HelpTable{
 	{Key: ArgTask, Short: "Task to run", Long: "Task to run.\n\nShorthand for `mise tasks run <TASK>`."},
 	{Key: ArgTaskArgs, Hide: true, Short: "Task arguments", Long: "Task arguments"},
 	{Key: ArgTaskArgsLast, Hide: true},
-	{Key: CmdActivate, Short: "Initializes mise in the current shell session", Long: "Initializes mise in the current shell session\n\nThis should go into your shell's rc file or login shell.\nOtherwise, it will only take effect in the current session.\n(e.g. ~/.zshrc, ~/.zprofile, ~/.zshenv, ~/.bashrc, ~/.bash_profile, ~/.profile, ~/.config/fish/config.fish, or $PROFILE for powershell)\n\nTypically, this can be added with something like the following:\n\n    echo 'eval \"$(mise activate zsh)\"' >> ~/.zshrc\n\nHowever, this requires that \"mise\" is in your PATH. If it is not, you need to\nspecify the full path like this:\n\n    echo 'eval \"$(/path/to/mise activate zsh)\"' >> ~/.zshrc\n\nCustomize status output with `status` settings.", AfterLongHelp: "Examples:\n\n    $ eval \"$(mise activate bash)\"\n    $ eval \"$(mise activate zsh)\"\n    $ mise activate fish | source\n    $ execx($(mise activate xonsh))\n    $ (&mise activate pwsh) | Out-String | Invoke-Expression\n"},
+	{Key: CmdActivate, Short: "Initializes mise in the current shell session", Long: "Initializes mise in the current shell session\n\nThis should go into your shell's rc file or login shell.\nOtherwise, it will only take effect in the current session.\n(e.g. ~/.zshrc, ~/.zprofile, ~/.zshenv, ~/.bashrc, ~/.bash_profile, ~/.profile, ~/.config/fish/config.fish, or $PROFILE for powershell)\n\nTypically, this can be added with something like the following:\n\n    echo 'eval \"$(mise activate zsh)\"' >> ~/.zshrc\n\nHowever, this requires that \"mise\" is in your PATH. If it is not, you need to\nspecify the full path like this:\n\n    echo 'eval \"$(/path/to/mise activate zsh)\"' >> ~/.zshrc\n\nCustomize status output with `status` settings.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1meval \"$(mise activate bash)\"\x1b[22m\n    $ \x1b[1meval \"$(mise activate zsh)\"\x1b[22m\n    $ \x1b[1mmise activate fish | source\x1b[22m\n    $ \x1b[1mexecx($(mise activate xonsh))\x1b[22m\n    $ \x1b[1m(&mise activate pwsh) | Out-String | Invoke-Expression\x1b[22m\n"},
 	{Key: FlagActivateQuiet, Short: "Suppress non-error messages", Long: "Suppress non-error messages"},
 	{Key: FlagActivateShell, Hide: true, ValueName: "SHELL", ValueDemanded: true, Short: "Shell type to generate the script for", Long: "Shell type to generate the script for", Choices: []string{"bash", "elvish", "fish", "nu", "xonsh", "zsh", "pwsh"}},
-	{Key: FlagActivateNoHookEnv, Short: "Do not automatically call hook-env", Long: "Do not automatically call hook-env\n\nThis can be helpful for debugging mise. If you run `eval \"$(mise activate --no-hook-env)\"`, then you can call `mise hook-env` manually which will output the env vars to stdout without actually modifying the environment. That way you can do things like `mise hook-env --trace` to get more information or just see the values that hook-env is outputting."},
+	{Key: FlagActivateNoHookEnv, Short: "Do not automatically call hook-env", Long: "Do not automatically call hook-env\n\nThis can be helpful for debugging mise. If you run `eval \"$(mise activate --no-hook-env)\"`, then\nyou can call `mise hook-env` manually which will output the env vars to stdout without actually\nmodifying the environment. That way you can do things like `mise hook-env --trace` to get more\ninformation or just see the values that hook-env is outputting."},
 	{Key: FlagActivateShims, Short: "Use shims instead of modifying PATH\nEffectively the same as:", Long: "Use shims instead of modifying PATH\nEffectively the same as:\n\n    PATH=\"$HOME/.local/share/mise/shims:$PATH\"\n\n`mise activate --shims` does not support all the features of `mise activate`.\nSee https://mise.jdx.dev/dev-tools/shims.html#shims-vs-path for more information"},
 	{Key: FlagActivateStatus, Hide: true, Short: "Show \"mise: <TOOL>@<VERSION>\" message when changing directories", Long: "Show \"mise: <TOOL>@<VERSION>\" message when changing directories"},
 	{Key: ArgActivateShellType, Short: "Shell type to generate the script for", Long: "Shell type to generate the script for", Choices: []string{"bash", "elvish", "fish", "nu", "xonsh", "zsh", "pwsh"}},
 	{Key: CmdToolAlias, Short: "Manage tool version aliases."},
 	{Key: FlagToolAliasTool, ValueName: "TOOL", ValueDemanded: true, Short: "Filter aliases by tool", Long: "Filter aliases by tool"},
 	{Key: FlagToolAliasNoHeader, Short: "Don't show table header", Long: "Don't show table header"},
-	{Key: CmdToolAliasGet, Short: "Show an alias for a tool", Long: "Show an alias for a tool\n\nThis is the contents of a tool_alias.<TOOL> entry in ~/.config/mise/config.toml", AfterLongHelp: "Examples:\n\n    $ mise tool-alias get node lts-hydrogen\n    20.0.0\n"},
+	{Key: CmdToolAliasGet, Short: "Show an alias for a tool", Long: "Show an alias for a tool\n\nThis is the contents of a tool_alias.<TOOL> entry in ~/.config/mise/config.toml", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise tool-alias get node lts-hydrogen\x1b[22m\n    20.0.0\n"},
 	{Key: ArgToolAliasGetTool, Demanded: true, Short: "The tool to show the alias for", Long: "The tool to show the alias for"},
 	{Key: ArgToolAliasGetAlias, Demanded: true, Short: "The alias to show", Long: "The alias to show"},
-	{Key: CmdToolAliasLs, Short: "List tool version aliases\nShows the aliases that can be specified.\nThese can come from user config or from plugins in `bin/list-aliases`.", Long: "List tool version aliases\nShows the aliases that can be specified.\nThese can come from user config or from plugins in `bin/list-aliases`.\n\nFor user config, aliases are defined like the following in `~/.config/mise/config.toml`:\n\n    [tool_alias.node.versions]\n    lts = \"22.0.0\"", VisibleAliases: []string{"list"}, AfterLongHelp: "Examples:\n\n    $ mise tool-alias ls\n    node  lts-jod      22\n"},
+	{Key: CmdToolAliasLs, Short: "List tool version aliases\nShows the aliases that can be specified.\nThese can come from user config or from plugins in `bin/list-aliases`.", Long: "List tool version aliases\nShows the aliases that can be specified.\nThese can come from user config or from plugins in `bin/list-aliases`.\n\nFor user config, aliases are defined like the following in `~/.config/mise/config.toml`:\n\n    [tool_alias.node.versions]\n    lts = \"22.0.0\"", VisibleAliases: []string{"list"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise tool-alias ls\x1b[22m\n    node  lts-jod      22\n"},
 	{Key: FlagToolAliasLsNoHeader, Short: "Don't show table header", Long: "Don't show table header"},
 	{Key: ArgToolAliasLsTool, Short: "Show aliases for <TOOL>", Long: "Show aliases for <TOOL>"},
-	{Key: CmdToolAliasSet, Short: "Add/update an alias for a tool/backend", Long: "Add/update an alias for a tool/backend\n\nThis modifies the contents of ~/.config/mise/config.toml", VisibleAliases: []string{"add", "create"}, AfterLongHelp: "Examples:\n\n    $ mise tool-alias set maven asdf:mise-plugins/mise-maven\n    $ mise tool-alias set node lts-jod 22.0.0\n"},
+	{Key: CmdToolAliasSet, Short: "Add/update an alias for a tool/backend", Long: "Add/update an alias for a tool/backend\n\nThis modifies the contents of ~/.config/mise/config.toml", VisibleAliases: []string{"add", "create"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise tool-alias set maven asdf:mise-plugins/mise-maven\x1b[22m\n    $ \x1b[1mmise tool-alias set node lts-jod 22.0.0\x1b[22m\n"},
 	{Key: ArgToolAliasSetTool, Demanded: true, Short: "The tool/backend to set the alias for", Long: "The tool/backend to set the alias for"},
 	{Key: ArgToolAliasSetAlias, Demanded: true, Short: "The alias to set", Long: "The alias to set"},
 	{Key: ArgToolAliasSetValue, Short: "The value to set the alias to", Long: "The value to set the alias to"},
-	{Key: CmdToolAliasUnset, Short: "Clears an alias for a tool/backend", Long: "Clears an alias for a tool/backend\n\nThis modifies the contents of ~/.config/mise/config.toml", VisibleAliases: []string{"rm", "remove", "delete", "del"}, AfterLongHelp: "Examples:\n\n    $ mise tool-alias unset maven\n    $ mise tool-alias unset node lts-jod\n"},
+	{Key: CmdToolAliasUnset, Short: "Clears an alias for a tool/backend", Long: "Clears an alias for a tool/backend\n\nThis modifies the contents of ~/.config/mise/config.toml", VisibleAliases: []string{"rm", "remove", "delete", "del"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise tool-alias unset maven\x1b[22m\n    $ \x1b[1mmise tool-alias unset node lts-jod\x1b[22m\n"},
 	{Key: ArgToolAliasUnsetTool, Demanded: true, Short: "The tool/backend to remove the alias from", Long: "The tool/backend to remove the alias from"},
 	{Key: ArgToolAliasUnsetAlias, Short: "The alias to remove", Long: "The alias to remove"},
 	{Key: CmdAsdf, Hide: true, Short: "[internal] simulates asdf for plugins that call \"asdf\" internally"},
 	{Key: ArgAsdfArgs, Short: "all arguments", Long: "all arguments"},
-	{Key: CmdBackends, Short: "Manage backends", AfterLongHelp: "Deprecation:\n\nThe `mise b` alias is deprecated and will be removed in mise 2027.4.0.\nUse `mise backends` instead.\n"},
-	{Key: CmdBackendsLs, Short: "List built-in backends", VisibleAliases: []string{"list"}, AfterLongHelp: "Examples:\n\n    $ mise backends ls\n    aqua\n    asdf\n    cargo\n    core\n    dotnet\n    gem\n    go\n    npm\n    pipx\n    spm\n    ubi\n    vfox\n"},
+	{Key: CmdBackends, Short: "Manage backends", AfterLongHelp: "\x1b[1m\x1b[4mDeprecation:\x1b[22m\x1b[24m\n\nThe `mise b` alias is deprecated and will be removed in mise 2027.4.0.\nUse `mise backends` instead.\n"},
+	{Key: CmdBackendsLs, Short: "List built-in backends", VisibleAliases: []string{"list"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise backends ls\x1b[22m\n    aqua\n    asdf\n    cargo\n    core\n    dotnet\n    gem\n    go\n    npm\n    pipx\n    spm\n    ubi\n    vfox\n"},
 	{Key: CmdBinPaths, Short: "List all the active runtime bin paths"},
 	{Key: FlagBinPathsBinNames, Short: "Output executable names instead of bin directories", Long: "Output executable names instead of bin directories"},
 	{Key: FlagBinPathsJson, Short: "Output executable entries in JSON format (implies --bin-names)", Long: "Output executable entries in JSON format (implies --bin-names)"},
 	{Key: ArgBinPathsToolVersion, Short: "Tool(s) to look up\ne.g.: ruby@3", Long: "Tool(s) to look up\ne.g.: ruby@3"},
-	{Key: CmdBootstrap, Short: "Set up a machine for the current config in one command", Long: "Set up a machine for the current config in one command\n\nRuns the bootstrap steps for the current config in order:\n\n0. `mise bootstrap accounts apply` — converge `[bootstrap.users]` and\n   `[bootstrap.groups]` (Linux)\n1. `mise bootstrap plugins apply` — install `[bootstrap.plugins]`\n   1.7. `[bootstrap.hooks.pre-packages]` — optional setup hook\n2. Install built-in-manager entries from `[bootstrap.packages]`\n3. `mise bootstrap files apply` — converge `[bootstrap.files]` and\n   `[bootstrap.directories]`\n4. `mise bootstrap services apply` — converge `[bootstrap.services]`\n   systemd system services (Linux)\n5. `mise bootstrap firewall apply` — converge `[bootstrap.linux.firewall]`\n   host firewall policy and rules (Linux)\n6. `mise bootstrap compose apply` — converge `[bootstrap.compose]`\n   Docker Compose projects\n7. `mise bootstrap repos apply` — clone/converge `[bootstrap.repos]`\n   surrounded by `pre-repos`/`post-repos` hooks\n8. `mise bootstrap dotfiles apply` — apply dotfiles from `[dotfiles]`\n   surrounded by `pre-dotfiles`/`post-dotfiles` hooks\n9. `mise bootstrap mise-shell-activate apply` — configure shell activation\n   from `[bootstrap.mise_shell_activate]`\n10. `mise bootstrap macos defaults apply` — write\n    `[bootstrap.macos.defaults]` entries (macOS)\n    surrounded by `pre-defaults`/`post-defaults` hooks\n11. `mise bootstrap macos launchd-agents apply` — install/load\n    `[bootstrap.macos.launchd.agents]`\n12. `mise bootstrap linux systemd-units apply` — install/start\n    `[bootstrap.linux.systemd.units]`\n13. `mise bootstrap user apply` — set `[bootstrap.user].login_shell`\n    (Unix)\n    surrounded by `pre-user`/`post-user` hooks\n14. `mise install` — install missing tools from `[tools]`\n    surrounded by `pre-tools`/`post-tools` hooks; package-plugin entries\n    from `[bootstrap.packages]` install afterward, followed by\n    `[bootstrap.hooks.post-packages]`\n15. `mise run bootstrap` — if a task named `bootstrap` is defined\n16. `[bootstrap.hooks.final]` — optional final hook\n\nThe declarative steps converge — anything already in its desired state\nis skipped, so re-running is safe. The `bootstrap` task runs on every\ninvocation; keep it idempotent. Use it for any project-specific setup\nthat doesn't fit the declarative sections (seeding databases, auth flows,\netc.) — it runs with the installed tools on PATH.\n\nUse `--skip <part>` to skip named parts, or `--only <part>` to run just\nnamed parts. Both flags can be repeated or comma-separated, but they\ncannot be used together.", VisibleAliases: []string{"bs"}, AfterLongHelp: "Examples:\n\n    $ mise bootstrap                    # packages + repos + dotfiles + tools + bootstrap task\n    $ mise bootstrap --force-dotfiles   # replace conflicting dotfile targets\n    $ mise bootstrap --skip tools,task  # skip tool installation and the bootstrap task\n    $ mise bootstrap --only tools       # run just tool installation\n    $ mise bootstrap status --missing\n    $ mise bootstrap packages apply --yes\n    $ mise bootstrap repos status\n    $ mise bootstrap repos apply --dry-run\n    $ mise bootstrap dotfiles status\n    $ mise bootstrap mise-shell-activate apply --dry-run\n    $ mise bootstrap macos defaults status\n    $ mise bootstrap macos launchd-agents apply --dry-run\n    $ mise bootstrap linux systemd-units apply --dry-run\n    $ mise bootstrap user apply --dry-run\n"},
+	{Key: CmdBootstrap, Short: "Set up a machine for the current config in one command", Long: "Set up a machine for the current config in one command\n\nRuns the bootstrap steps for the current config in order:\n\n0. `mise bootstrap accounts apply` — converge `[bootstrap.users]` and\n   `[bootstrap.groups]` (Linux)\n1. `mise bootstrap plugins apply` — install `[bootstrap.plugins]`\n   1.7. `[bootstrap.hooks.pre-packages]` — optional setup hook\n2. Install built-in-manager entries from `[bootstrap.packages]`\n3. `mise bootstrap files apply` — converge `[bootstrap.files]` and\n   `[bootstrap.directories]`\n4. `mise bootstrap services apply` — converge `[bootstrap.services]`\n   systemd system services (Linux)\n5. `mise bootstrap firewall apply` — converge `[bootstrap.linux.firewall]`\n   host firewall policy and rules (Linux)\n6. `mise bootstrap compose apply` — converge `[bootstrap.compose]`\n   Docker Compose projects\n7. `mise bootstrap repos apply` — clone/converge `[bootstrap.repos]`\n   surrounded by `pre-repos`/`post-repos` hooks\n8. `mise bootstrap dotfiles apply` — apply dotfiles from `[dotfiles]`\n   surrounded by `pre-dotfiles`/`post-dotfiles` hooks\n9. `mise bootstrap mise-shell-activate apply` — configure shell activation\n   from `[bootstrap.mise_shell_activate]`\n10. `mise bootstrap macos defaults apply` — write\n    `[bootstrap.macos.defaults]` entries (macOS)\n    surrounded by `pre-defaults`/`post-defaults` hooks\n11. `mise bootstrap macos launchd-agents apply` — install/load\n    `[bootstrap.macos.launchd.agents]`\n12. `mise bootstrap linux systemd-units apply` — install/start\n    `[bootstrap.linux.systemd.units]`\n13. `mise bootstrap user apply` — set `[bootstrap.user].login_shell`\n    (Unix)\n    surrounded by `pre-user`/`post-user` hooks\n14. `mise install` — install missing tools from `[tools]`\n    surrounded by `pre-tools`/`post-tools` hooks; package-plugin entries\n    from `[bootstrap.packages]` install afterward, followed by\n    `[bootstrap.hooks.post-packages]`\n15. `mise run bootstrap` — if a task named `bootstrap` is defined\n16. `[bootstrap.hooks.final]` — optional final hook\n\nThe declarative steps converge — anything already in its desired state\nis skipped, so re-running is safe. The `bootstrap` task runs on every\ninvocation; keep it idempotent. Use it for any project-specific setup\nthat doesn't fit the declarative sections (seeding databases, auth flows,\netc.) — it runs with the installed tools on PATH.\n\nUse `--skip <part>` to skip named parts, or `--only <part>` to run just\nnamed parts. Both flags can be repeated or comma-separated, but they\ncannot be used together.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise bootstrap\x1b[22m                    # packages + repos + dotfiles + tools + bootstrap task\n    $ \x1b[1mmise bootstrap --force-dotfiles\x1b[22m   # replace conflicting dotfile targets\n    $ \x1b[1mmise bootstrap --skip tools,task\x1b[22m  # skip tool installation and the bootstrap task\n    $ \x1b[1mmise bootstrap --only tools\x1b[22m       # run just tool installation\n    $ \x1b[1mmise bootstrap status --missing\x1b[22m\n    $ \x1b[1mmise bootstrap packages apply --yes\x1b[22m\n    $ \x1b[1mmise bootstrap repos status\x1b[22m\n    $ \x1b[1mmise bootstrap repos apply --dry-run\x1b[22m\n    $ \x1b[1mmise bootstrap dotfiles status\x1b[22m\n    $ \x1b[1mmise bootstrap mise-shell-activate apply --dry-run\x1b[22m\n    $ \x1b[1mmise bootstrap macos defaults status\x1b[22m\n    $ \x1b[1mmise bootstrap macos launchd-agents apply --dry-run\x1b[22m\n    $ \x1b[1mmise bootstrap linux systemd-units apply --dry-run\x1b[22m\n    $ \x1b[1mmise bootstrap user apply --dry-run\x1b[22m\n"},
 	{Key: FlagBootstrapDryRun, Short: "Print what would happen without installing anything", Long: "Print what would happen without installing anything"},
 	{Key: FlagBootstrapYes, Short: "Skip confirmation prompts", Long: "Skip confirmation prompts"},
 	{Key: FlagBootstrapForceDotfiles, Short: "Overwrite existing files that conflict with whole-file dotfile entries", Long: "Overwrite existing files that conflict with whole-file dotfile entries"},
-	{Key: FlagBootstrapOnly, Repeatable: true, ValueName: "ONLY", ValueDemanded: true, Short: "Run only one or more bootstrap parts", Long: "Run only one or more bootstrap parts\n\nCan be passed multiple times or as a comma-separated list. Cannot be used with `--skip`.", Choices: []string{"plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "shell", "macos-defaults", "defaults", "macos-launchd-agents", "launchd", "linux-systemd-units", "systemd", "user", "tools", "task", "final-hook"}},
+	{Key: FlagBootstrapOnly, Repeatable: true, ValueName: "ONLY", ValueDemanded: true, Short: "Run only one or more bootstrap parts", Long: "Run only one or more bootstrap parts\n\nCan be passed multiple times or as a comma-separated list.\nCannot be used with `--skip`.", Choices: []string{"plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "macos-defaults", "macos-launchd-agents", "linux-systemd-units", "user", "tools", "task", "final-hook"}},
 	{Key: FlagBootstrapPromptSecrets, Short: "Prompt securely for missing bootstrap secret inputs", Long: "Prompt securely for missing bootstrap secret inputs"},
-	{Key: FlagBootstrapSkip, Repeatable: true, ValueName: "SKIP", ValueDemanded: true, Short: "Skip one or more bootstrap parts", Long: "Skip one or more bootstrap parts\n\nCan be passed multiple times or as a comma-separated list.", Choices: []string{"plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "shell", "macos-defaults", "defaults", "macos-launchd-agents", "launchd", "linux-systemd-units", "systemd", "user", "tools", "task", "final-hook"}},
+	{Key: FlagBootstrapSkip, Repeatable: true, ValueName: "SKIP", ValueDemanded: true, Short: "Skip one or more bootstrap parts", Long: "Skip one or more bootstrap parts\n\nCan be passed multiple times or as a comma-separated list.", Choices: []string{"plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "macos-defaults", "macos-launchd-agents", "linux-systemd-units", "user", "tools", "task", "final-hook"}},
 	{Key: FlagBootstrapUpdate, Short: "Refresh package manager metadata and update configured repos", Long: "Refresh package manager metadata and update configured repos"},
 	{Key: CmdBootstrapApplyAccountPlan, Hide: true},
 	{Key: CmdBootstrapApplyServicePlan, Hide: true},
@@ -4930,7 +4972,7 @@ var HelpText = argv.HelpTable{
 	{Key: FlagBootstrapComposeStatusJson, Short: "Output in JSON format", Long: "Output in JSON format"},
 	{Key: FlagBootstrapComposeStatusMissing, Short: "Exit with code 1 when any Compose project is not converged", Long: "Exit with code 1 when any Compose project is not converged"},
 	{Key: CmdBootstrapDotfiles, Short: "Manage dotfiles from `[dotfiles]`", SubcommandRequired: true},
-	{Key: CmdBootstrapDotfilesAdd, Short: "Add or update dotfiles in `[dotfiles]`", Long: "Add or update dotfiles in `[dotfiles]`\n\nIf the target is already managed, this updates its source from the live\ntarget. Otherwise it creates a `[dotfiles]` entry and seeds the source\nunder `dotfiles.root` unless `--source` is provided.", AfterLongHelp: "Examples:\n\n    $ mise bootstrap dotfiles add ~/.zshrc\n    $ mise bootstrap dotfiles add --mode copy ~/.config/starship.toml\n    $ mise bootstrap dotfiles add --source dotfiles/gitconfig ~/.gitconfig\n"},
+	{Key: CmdBootstrapDotfilesAdd, Short: "Add or update dotfiles in `[dotfiles]`", Long: "Add or update dotfiles in `[dotfiles]`\n\nIf the target is already managed, this updates its source from the live\ntarget. Otherwise it creates a `[dotfiles]` entry and seeds the source\nunder `dotfiles.root` unless `--source` is provided.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise bootstrap dotfiles add ~/.zshrc\x1b[22m\n    $ \x1b[1mmise bootstrap dotfiles add --mode copy ~/.config/starship.toml\x1b[22m\n    $ \x1b[1mmise bootstrap dotfiles add --source dotfiles/gitconfig ~/.gitconfig\x1b[22m\n"},
 	{Key: FlagBootstrapDotfilesAddForce, Short: "Overwrite existing sources without prompting", Long: "Overwrite existing sources without prompting"},
 	{Key: FlagBootstrapDotfilesAddGlobal, Short: "Write to the global config", Long: "Write to the global config"},
 	{Key: FlagBootstrapDotfilesAddLocal, Short: "Write to the local config instead of the global config", Long: "Write to the local config instead of the global config"},
@@ -4941,22 +4983,22 @@ var HelpText = argv.HelpTable{
 	{Key: FlagBootstrapDotfilesAddSource, ValueName: "PATH", ValueDemanded: true, Short: "Source path to use for a single target", Long: "Source path to use for a single target"},
 	{Key: FlagBootstrapDotfilesAddYes, Short: "Skip the confirmation prompt", Long: "Skip the confirmation prompt"},
 	{Key: ArgBootstrapDotfilesAddTarget, Demanded: true, Short: "Targets to add or update", Long: "Targets to add or update"},
-	{Key: CmdBootstrapDotfilesApply, Short: "Apply dotfiles from `[dotfiles]`", Long: "Apply dotfiles from `[dotfiles]`\n\nApplies configured whole-file entries and edits that aren't in their\ndesired state. Whole-file entries may symlink, copy, or render templates.\nEdit entries manage a marker-delimited block or a single line in a file\nmise doesn't otherwise own.", AfterLongHelp: "Examples:\n\n    $ mise bootstrap dotfiles apply\n    $ mise bootstrap dotfiles apply --dry-run\n    $ mise bootstrap dotfiles apply --force --yes\n"},
+	{Key: CmdBootstrapDotfilesApply, Short: "Apply dotfiles from `[dotfiles]`", Long: "Apply dotfiles from `[dotfiles]`\n\nApplies configured whole-file entries and edits that aren't in their\ndesired state. Whole-file entries may symlink, copy, or render templates.\nEdit entries manage a marker-delimited block or a single line in a file\nmise doesn't otherwise own.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise bootstrap dotfiles apply\x1b[22m\n    $ \x1b[1mmise bootstrap dotfiles apply --dry-run\x1b[22m\n    $ \x1b[1mmise bootstrap dotfiles apply --force --yes\x1b[22m\n"},
 	{Key: FlagBootstrapDotfilesApplyForce, Short: "Overwrite existing files that conflict with whole-file dotfile entries", Long: "Overwrite existing files that conflict with whole-file dotfile entries"},
 	{Key: FlagBootstrapDotfilesApplyDryRun, Short: "Print the actions that would run without writing anything", Long: "Print the actions that would run without writing anything"},
 	{Key: FlagBootstrapDotfilesApplyYes, Short: "Skip the confirmation prompt", Long: "Skip the confirmation prompt"},
 	{Key: ArgBootstrapDotfilesApplyTarget, Short: "Only apply these targets", Long: "Only apply these targets"},
-	{Key: CmdBootstrapDotfilesEdit, Short: "Edit a managed dotfile source", AfterLongHelp: "Examples:\n\n    $ mise bootstrap dotfiles edit ~/.zshrc\n    $ mise bootstrap dotfiles edit --apply ~/.config/starship.toml\n"},
+	{Key: CmdBootstrapDotfilesEdit, Short: "Edit a managed dotfile source", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise bootstrap dotfiles edit ~/.zshrc\x1b[22m\n    $ \x1b[1mmise bootstrap dotfiles edit --apply ~/.config/starship.toml\x1b[22m\n"},
 	{Key: FlagBootstrapDotfilesEditApply, Short: "Apply this target after the editor exits", Long: "Apply this target after the editor exits"},
 	{Key: FlagBootstrapDotfilesEditMode, ValueName: "MODE", ValueDemanded: true, Short: "Dotfile mode to use if the target is not yet managed", Long: "Dotfile mode to use if the target is not yet managed"},
 	{Key: FlagBootstrapDotfilesEditSource, ValueName: "PATH", ValueDemanded: true, Short: "Source path to use if the target is not yet managed", Long: "Source path to use if the target is not yet managed"},
 	{Key: FlagBootstrapDotfilesEditYes, Short: "Skip the confirmation prompt when adding an unmanaged target", Long: "Skip the confirmation prompt when adding an unmanaged target"},
 	{Key: ArgBootstrapDotfilesEditTarget, Demanded: true, Short: "Target to edit", Long: "Target to edit"},
-	{Key: CmdBootstrapDotfilesStatus, Short: "Show the status of dotfiles from `[dotfiles]`", VisibleAliases: []string{"ls"}, AfterLongHelp: "Examples:\n\n    $ mise bootstrap dotfiles status\n    $ mise bootstrap dotfiles status ~/.zshrc\n    $ mise bootstrap dotfiles status --json\n    $ mise bootstrap dotfiles status --missing # exit 1 if anything is out of sync\n"},
+	{Key: CmdBootstrapDotfilesStatus, Short: "Show the status of dotfiles from `[dotfiles]`", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise bootstrap dotfiles status\x1b[22m\n    $ \x1b[1mmise bootstrap dotfiles status ~/.zshrc\x1b[22m\n    $ \x1b[1mmise bootstrap dotfiles status --json\x1b[22m\n    $ \x1b[1mmise bootstrap dotfiles status --missing\x1b[22m # exit 1 if anything is out of sync\n"},
 	{Key: FlagBootstrapDotfilesStatusJson, Short: "Output in JSON format", Long: "Output in JSON format"},
 	{Key: FlagBootstrapDotfilesStatusMissing, Short: "Exit with code 1 if any configured dotfiles are not in their desired\nstate (missing, source missing, differs)", Long: "Exit with code 1 if any configured dotfiles are not in their desired\nstate (missing, source missing, differs)"},
 	{Key: ArgBootstrapDotfilesStatusTarget, Short: "Only show these targets", Long: "Only show these targets"},
-	{Key: CmdBootstrapDotfilesUnapply, Short: "Remove dotfiles applied from `[dotfiles]`", Long: "Remove dotfiles applied from `[dotfiles]`\n\nRemoves configured whole-file entries and edits while preserving files\nmise cannot identify as managed. Modified copies, templates, and plain-line\nedits require `--force`.", AfterLongHelp: "Examples:\n\n    $ mise bootstrap dotfiles unapply\n    $ mise bootstrap dotfiles unapply ~/.zshrc\n    $ mise bootstrap dotfiles unapply --dry-run\n    $ mise bootstrap dotfiles unapply --force --yes\n"},
+	{Key: CmdBootstrapDotfilesUnapply, Short: "Remove dotfiles applied from `[dotfiles]`", Long: "Remove dotfiles applied from `[dotfiles]`\n\nRemoves configured whole-file entries and edits while preserving files\nmise cannot identify as managed. Modified copies, templates, and plain-line\nedits require `--force`.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise bootstrap dotfiles unapply\x1b[22m\n    $ \x1b[1mmise bootstrap dotfiles unapply ~/.zshrc\x1b[22m\n    $ \x1b[1mmise bootstrap dotfiles unapply --dry-run\x1b[22m\n    $ \x1b[1mmise bootstrap dotfiles unapply --force --yes\x1b[22m\n"},
 	{Key: FlagBootstrapDotfilesUnapplyForce, Short: "Remove modified or otherwise ambiguous managed files and lines", Long: "Remove modified or otherwise ambiguous managed files and lines"},
 	{Key: FlagBootstrapDotfilesUnapplyDryRun, Short: "Print the actions that would run without writing anything", Long: "Print the actions that would run without writing anything"},
 	{Key: FlagBootstrapDotfilesUnapplyYes, Short: "Skip the confirmation prompt", Long: "Skip the confirmation prompt"},
@@ -5022,46 +5064,46 @@ var HelpText = argv.HelpTable{
 	{Key: FlagBootstrapMiseShellActivateStatusJson, Short: "Output in JSON format", Long: "Output in JSON format"},
 	{Key: FlagBootstrapMiseShellActivateStatusMissing, Short: "Exit with code 1 if any configured shell activation is not in its desired state", Long: "Exit with code 1 if any configured shell activation is not in its desired state"},
 	{Key: CmdBootstrapPackages, Short: "Manage bootstrap system packages from `[bootstrap.packages]`", SubcommandRequired: true},
-	{Key: CmdBootstrapPackagesApply, Short: "Apply system packages from `[bootstrap.packages]`", Long: "Apply system packages from `[bootstrap.packages]`\n\nChecks which configured packages are missing and installs them with the\nsystem package manager. Built-in system managers may elevate with sudo when\nnot running as root (see `system_packages.sudo`); package plugins never do.\n\nPackages can also be given explicitly in `manager:package` form (e.g.\n`apk:zlib-dev`, `apt:curl`, `brew:jq`); they are installed whether or not they appear in\nthe config. Explicit packages and `--manager` scope the run to packages\nonly. `install` is accepted as an alias for this command.", VisibleAliases: []string{"i"}, AfterLongHelp: "Examples:\n\n    $ mise bootstrap packages apply\n    $ mise bootstrap packages apply apk:zlib-dev apt:curl brew:jq brew-cask:firefox flatpak:org.mozilla.firefox mas:497799835\n    $ mise bootstrap packages apply --dry-run\n    $ mise bootstrap packages apply --manager apt --yes\n"},
+	{Key: CmdBootstrapPackagesApply, Short: "Apply system packages from `[bootstrap.packages]`", Long: "Apply system packages from `[bootstrap.packages]`\n\nChecks which configured packages are missing and installs them with the\nsystem package manager. Built-in system managers may elevate with sudo when\nnot running as root (see `system_packages.sudo`); package plugins never do.\n\nPackages can also be given explicitly in `manager:package` form (e.g.\n`apk:zlib-dev`, `apt:curl`, `brew:jq`); they are installed whether or not they appear in\nthe config. Explicit packages and `--manager` scope the run to packages\nonly. `install` is accepted as an alias for this command.", VisibleAliases: []string{"i"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise bootstrap packages apply\x1b[22m\n    $ \x1b[1mmise bootstrap packages apply apk:zlib-dev apt:curl brew:jq brew-cask:firefox flatpak:org.mozilla.firefox flatpak-user:org.gnome.Builder mas:497799835\x1b[22m\n    $ \x1b[1mmise bootstrap packages apply --dry-run\x1b[22m\n    $ \x1b[1mmise bootstrap packages apply --manager apt --yes\x1b[22m\n"},
 	{Key: FlagBootstrapPackagesApplyManager, ValueName: "MANAGER", ValueDemanded: true, Short: "Only install packages for this built-in or plugin manager", Long: "Only install packages for this built-in or plugin manager"},
 	{Key: FlagBootstrapPackagesApplyDryRun, Short: "Print the commands that would run without running them", Long: "Print the commands that would run without running them"},
 	{Key: FlagBootstrapPackagesApplyYes, Short: "Skip the confirmation prompt", Long: "Skip the confirmation prompt"},
 	{Key: FlagBootstrapPackagesApplyUpdate, Short: "Refresh package manager metadata first (apk: `--update-cache`, apt: `apt-get update`)", Long: "Refresh package manager metadata first (apk: `--update-cache`, apt: `apt-get update`)"},
-	{Key: ArgBootstrapPackagesApplyPackage, Short: "Packages in `manager:package` form; defaults to everything configured in [bootstrap.packages]", Long: "Packages in `manager:package` form; defaults to everything configured in [bootstrap.packages]"},
+	{Key: ArgBootstrapPackagesApplyPackage, Short: "Packages in `manager:package` form; defaults to everything configured in [bootstrap.packages]", Long: "Packages in `manager:package` form; defaults to everything configured\nin [bootstrap.packages]"},
 	{Key: CmdBootstrapPackagesBrew, Short: "Manage Homebrew taps used by bootstrap packages", Long: "Manage Homebrew taps used by bootstrap packages\n\nThese commands edit `[bootstrap.brew.taps]` so tapped formulae and casks\ncan be fetched directly by mise without a Homebrew installation.", SubcommandRequired: true},
-	{Key: CmdBootstrapPackagesBrewTap, Short: "Add a Homebrew tap URL to [bootstrap.brew.taps]", AfterLongHelp: "Examples:\n\n    $ mise bootstrap packages brew tap railwaycat/emacsmacport\n    $ mise bootstrap packages brew tap acme/tools https://github.com/acme/homebrew-tools.git\n"},
+	{Key: CmdBootstrapPackagesBrewTap, Short: "Add a Homebrew tap URL to [bootstrap.brew.taps]", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise bootstrap packages brew tap railwaycat/emacsmacport\x1b[22m\n    $ \x1b[1mmise bootstrap packages brew tap acme/tools https://github.com/acme/homebrew-tools.git\x1b[22m\n"},
 	{Key: FlagBootstrapPackagesBrewTapLocal, Short: "Write to the local config instead of the global config", Long: "Write to the local config instead of the global config"},
 	{Key: FlagBootstrapPackagesBrewTapDryRun, Short: "Print the config change without writing it", Long: "Print the config change without writing it"},
 	{Key: FlagBootstrapPackagesBrewTapPath, ValueName: "PATH", ValueDemanded: true, Short: "Write to this config file or directory", Long: "Write to this config file or directory"},
 	{Key: ArgBootstrapPackagesBrewTapTap, Demanded: true, Short: "Tap name, e.g. `owner/repo`", Long: "Tap name, e.g. `owner/repo`"},
 	{Key: ArgBootstrapPackagesBrewTapUrl, Short: "GitHub URL for the tap. Defaults to https://github.com/<owner>/homebrew-<repo>.git", Long: "GitHub URL for the tap. Defaults to https://github.com/<owner>/homebrew-<repo>.git"},
-	{Key: CmdBootstrapPackagesBrewUntap, Short: "Remove Homebrew tap URLs from [bootstrap.brew.taps]", VisibleAliases: []string{"remove", "rm"}, AfterLongHelp: "Examples:\n\n    $ mise bootstrap packages brew untap railwaycat/emacsmacport\n"},
+	{Key: CmdBootstrapPackagesBrewUntap, Short: "Remove Homebrew tap URLs from [bootstrap.brew.taps]", VisibleAliases: []string{"remove", "rm"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise bootstrap packages brew untap railwaycat/emacsmacport\x1b[22m\n"},
 	{Key: FlagBootstrapPackagesBrewUntapLocal, Short: "Write to the local config instead of the global config", Long: "Write to the local config instead of the global config"},
 	{Key: FlagBootstrapPackagesBrewUntapDryRun, Short: "Print the config change without writing it", Long: "Print the config change without writing it"},
 	{Key: FlagBootstrapPackagesBrewUntapPath, ValueName: "PATH", ValueDemanded: true, Short: "Write to this config file or directory", Long: "Write to this config file or directory"},
 	{Key: ArgBootstrapPackagesBrewUntapTaps, Demanded: true, Short: "Tap name(s), e.g. `owner/repo`", Long: "Tap name(s), e.g. `owner/repo`"},
-	{Key: CmdBootstrapPackagesImport, Short: "Import installed system packages into `[bootstrap.packages]`", Long: "Import installed system packages into `[bootstrap.packages]`\n\nCurrently supports Homebrew formulae only. By default, imports linked\nformulae whose active keg receipt says they were installed on request.\nPass `--all` to import every linked formula, including dependencies.", AfterLongHelp: "Examples:\n\n    $ mise bootstrap packages import --manager brew\n    $ mise bootstrap packages import --manager brew --all\n    $ mise bootstrap packages import --manager brew --global\n    $ mise bootstrap packages import --manager brew --dry-run\n"},
+	{Key: CmdBootstrapPackagesImport, Short: "Import installed system packages into `[bootstrap.packages]`", Long: "Import installed system packages into `[bootstrap.packages]`\n\nCurrently supports Homebrew formulae only. By default, imports linked\nformulae whose active keg receipt says they were installed on request.\nPass `--all` to import every linked formula, including dependencies.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise bootstrap packages import --manager brew\x1b[22m\n    $ \x1b[1mmise bootstrap packages import --manager brew --all\x1b[22m\n    $ \x1b[1mmise bootstrap packages import --manager brew --global\x1b[22m\n    $ \x1b[1mmise bootstrap packages import --manager brew --dry-run\x1b[22m\n"},
 	{Key: FlagBootstrapPackagesImportEnv, ValueName: "ENV", ValueDemanded: true, Short: "Write to the config file for this environment (mise.<ENV>.toml)", Long: "Write to the config file for this environment (mise.<ENV>.toml)"},
 	{Key: FlagBootstrapPackagesImportGlobal, Short: "Write to the global config (~/.config/mise/config.toml)", Long: "Write to the global config (~/.config/mise/config.toml)"},
-	{Key: FlagBootstrapPackagesImportManager, ValueName: "MANAGER", ValueDemanded: true, Short: "Only import packages for this manager. Currently only `brew` is supported", Long: "Only import packages for this manager. Currently only `brew` is supported", Choices: []string{"brew"}, Default: []string{"brew"}},
+	{Key: FlagBootstrapPackagesImportManager, ValueName: "MANAGER", ValueDemanded: true, Short: "Only import packages for this manager. Currently only `brew` is supported.", Long: "Only import packages for this manager. Currently only `brew` is supported.", Choices: []string{"brew"}, Default: []string{"brew"}},
 	{Key: FlagBootstrapPackagesImportAll, Short: "Import every linked formula, including dependencies", Long: "Import every linked formula, including dependencies"},
 	{Key: FlagBootstrapPackagesImportDryRun, Short: "Print the config change without writing config", Long: "Print the config change without writing config"},
 	{Key: FlagBootstrapPackagesImportPath, ValueName: "PATH", ValueDemanded: true, Short: "Write to this config file or directory", Long: "Write to this config file or directory"},
-	{Key: CmdBootstrapPackagesPrune, Short: "Prune installed system packages no longer declared in `[bootstrap.packages]`", Long: "Prune installed system packages no longer declared in `[bootstrap.packages]`\n\nCurrently supports Homebrew formulae only. Pruning removes linked formulae\nthat are not needed by the current config or by trusted, loadable tracked\nconfigs.", AfterLongHelp: "Examples:\n\n    $ mise bootstrap packages prune --manager brew\n    $ mise bootstrap packages prune --manager brew --dry-run\n    $ mise bootstrap packages prune --manager brew --yes\n"},
-	{Key: FlagBootstrapPackagesPruneManager, ValueName: "MANAGER", ValueDemanded: true, Short: "Only prune packages for this manager. Currently only `brew` is supported", Long: "Only prune packages for this manager. Currently only `brew` is supported", Choices: []string{"brew"}, Default: []string{"brew"}},
+	{Key: CmdBootstrapPackagesPrune, Short: "Prune installed system packages no longer declared in `[bootstrap.packages]`", Long: "Prune installed system packages no longer declared in `[bootstrap.packages]`\n\nSupports Homebrew formulae and conservatively removable, mise-owned casks.\nPruning keeps packages needed by the current config or by trusted, loadable\ntracked configs.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise bootstrap packages prune --manager brew\x1b[22m\n    $ \x1b[1mmise bootstrap packages prune --manager brew --dry-run\x1b[22m\n    $ \x1b[1mmise bootstrap packages prune --manager brew --yes\x1b[22m\n    $ \x1b[1mmise bootstrap packages prune --manager brew-cask --dry-run\x1b[22m\n"},
+	{Key: FlagBootstrapPackagesPruneManager, ValueName: "MANAGER", ValueDemanded: true, Short: "Only prune packages for this manager", Long: "Only prune packages for this manager", Choices: []string{"brew", "brew-cask"}, Default: []string{"brew"}},
 	{Key: FlagBootstrapPackagesPruneDryRun, Short: "Print what would be removed without deleting anything", Long: "Print what would be removed without deleting anything"},
 	{Key: FlagBootstrapPackagesPruneYes, Short: "Skip the confirmation prompt", Long: "Skip the confirmation prompt"},
-	{Key: CmdBootstrapPackagesStatus, Short: "Show the status of system packages from `[bootstrap.packages]`", VisibleAliases: []string{"ls"}, AfterLongHelp: "Examples:\n\n    $ mise bootstrap packages status\n    $ mise bootstrap packages status --json\n    $ mise bootstrap packages status --missing # exit 1 if anything is out of sync\n"},
+	{Key: CmdBootstrapPackagesStatus, Short: "Show the status of system packages from `[bootstrap.packages]`", VisibleAliases: []string{"ls"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise bootstrap packages status\x1b[22m\n    $ \x1b[1mmise bootstrap packages status --json\x1b[22m\n    $ \x1b[1mmise bootstrap packages status --missing\x1b[22m # exit 1 if anything is out of sync\n"},
 	{Key: FlagBootstrapPackagesStatusJson, Short: "Output in JSON format", Long: "Output in JSON format"},
 	{Key: FlagBootstrapPackagesStatusMissing, Short: "Exit with code 1 if any configured packages are not in their desired state", Long: "Exit with code 1 if any configured packages are not in their desired state"},
-	{Key: CmdBootstrapPackagesUpgrade, Short: "Upgrade installed bootstrap packages from `[bootstrap.packages]`", Long: "Upgrade installed bootstrap packages from `[bootstrap.packages]`\n\nRefreshes package manager metadata and upgrades the configured packages\nthat are already installed: apk/apt/dnf/pacman upgrade to the newest available\nversion (apk, apt, and dnf honor a version pinned in config), brew pours the\nformula's current bottle and replaces the old keg, brew-cask installs\nthe current cask artifact, flatpak updates applications and runtimes, and mas upgrades App Store apps. Packages that\nare not installed yet are skipped — use `mise bootstrap packages apply`\nfor those.\n\nPackages can also be given explicitly in `manager:package` form.", VisibleAliases: []string{"up"}, AfterLongHelp: "Examples:\n\n    $ mise bootstrap packages upgrade\n    $ mise bootstrap packages upgrade brew:postgresql@17\n    $ mise bootstrap packages upgrade --manager brew-cask\n    $ mise bootstrap packages upgrade --manager mas\n    $ mise bootstrap packages upgrade --manager apt --yes\n    $ mise bootstrap packages upgrade --dry-run\n"},
+	{Key: CmdBootstrapPackagesUpgrade, Short: "Upgrade installed bootstrap packages from `[bootstrap.packages]`", Long: "Upgrade installed bootstrap packages from `[bootstrap.packages]`\n\nRefreshes package manager metadata and upgrades the configured packages\nthat are already installed: apk/apt/dnf/pacman upgrade to the newest available\nversion (apk, apt, and dnf honor a version pinned in config), brew pours the\nformula's current bottle and replaces the old keg, brew-cask installs\nthe current cask artifact, flatpak and flatpak-user update applications and runtimes, and mas upgrades App Store apps. Packages that\nare not installed yet are skipped — use `mise bootstrap packages apply`\nfor those.\n\nPackages can also be given explicitly in `manager:package` form.", VisibleAliases: []string{"up"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise bootstrap packages upgrade\x1b[22m\n    $ \x1b[1mmise bootstrap packages upgrade brew:postgresql@17\x1b[22m\n    $ \x1b[1mmise bootstrap packages upgrade --manager brew-cask\x1b[22m\n    $ \x1b[1mmise bootstrap packages upgrade --manager mas\x1b[22m\n    $ \x1b[1mmise bootstrap packages upgrade --manager apt --yes\x1b[22m\n    $ \x1b[1mmise bootstrap packages upgrade --dry-run\x1b[22m\n"},
 	{Key: FlagBootstrapPackagesUpgradeManager, ValueName: "MANAGER", ValueDemanded: true, Short: "Only upgrade packages for this built-in or plugin manager", Long: "Only upgrade packages for this built-in or plugin manager"},
 	{Key: FlagBootstrapPackagesUpgradeDryRun, Short: "Print the commands that would run without running them", Long: "Print the commands that would run without running them"},
 	{Key: FlagBootstrapPackagesUpgradeYes, Short: "Skip the confirmation prompt", Long: "Skip the confirmation prompt"},
-	{Key: ArgBootstrapPackagesUpgradePackage, Short: "Packages in `manager:package` form; defaults to everything configured in [bootstrap.packages]", Long: "Packages in `manager:package` form; defaults to everything configured in [bootstrap.packages]"},
-	{Key: CmdBootstrapPackagesUse, Short: "Add bootstrap packages to [bootstrap.packages] and install them", Long: "Add bootstrap packages to [bootstrap.packages] and install them\n\nLike `mise use` for tools: writes `\"manager:package\" = \"version\"` entries\nto mise.toml (the local config by default, the global one with `-g`) and\nthen installs whatever is missing.\n\nVersions are pinned with `@`: `mise bootstrap packages use apt:curl@8.5.0-2`. Without\n`@` (or with `@latest`) no pin is written. brew formulae and casks\nversion through their names instead (for example `brew:postgresql@17`,\n`brew-cask:temurin@17`), where `@` is part of the Homebrew name rather than\na mise version selector. mas uses numeric ADAM IDs and does not support pins.", VisibleAliases: []string{"u"}, AfterLongHelp: "Examples:\n\n    $ mise bootstrap packages use apk:zlib-dev apt:curl brew:jq brew-cask:firefox flatpak:org.mozilla.firefox mas:497799835\n    $ mise bootstrap packages use -g brew:postgresql@17\n    $ mise bootstrap packages use apt:curl@8.5.0-2\n"},
+	{Key: ArgBootstrapPackagesUpgradePackage, Short: "Packages in `manager:package` form; defaults to everything configured in [bootstrap.packages]", Long: "Packages in `manager:package` form; defaults to everything configured\nin [bootstrap.packages]"},
+	{Key: CmdBootstrapPackagesUse, Short: "Add bootstrap packages to [bootstrap.packages] and install them", Long: "Add bootstrap packages to [bootstrap.packages] and install them\n\nLike `mise use` for tools: writes `\"manager:package\" = \"version\"` entries\nto mise.toml (the local config by default, the global one with `-g`) and\nthen installs whatever is missing.\n\nVersions are pinned with `@`: `mise bootstrap packages use apt:curl@8.5.0-2`. Without\n`@` (or with `@latest`) no pin is written. brew formulae and casks\nversion through their names instead (for example `brew:postgresql@17`,\n`brew-cask:temurin@17`), where `@` is part of the Homebrew name rather than\na mise version selector. mas uses numeric ADAM IDs and does not support pins.", VisibleAliases: []string{"u"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise bootstrap packages use apk:zlib-dev apt:curl brew:jq brew-cask:firefox flatpak:org.mozilla.firefox flatpak-user:org.gnome.Builder mas:497799835\x1b[22m\n    $ \x1b[1mmise bootstrap packages use -g brew:postgresql@17\x1b[22m\n    $ \x1b[1mmise bootstrap packages use apt:curl@8.5.0-2\x1b[22m\n"},
 	{Key: FlagBootstrapPackagesUseEnv, ValueName: "ENV", ValueDemanded: true, Short: "Write to the config file for this environment (mise.<ENV>.toml)", Long: "Write to the config file for this environment (mise.<ENV>.toml)"},
-	{Key: FlagBootstrapPackagesUseGlobal, Short: "Write to the global config (~/.config/mise/config.toml) instead of the local one", Long: "Write to the global config (~/.config/mise/config.toml) instead of the local one"},
+	{Key: FlagBootstrapPackagesUseGlobal, Short: "Write to the global config (~/.config/mise/config.toml) instead of the local one", Long: "Write to the global config (~/.config/mise/config.toml) instead of the\nlocal one"},
 	{Key: FlagBootstrapPackagesUseDryRun, Short: "Print the commands that would run without writing config or installing", Long: "Print the commands that would run without writing config or installing"},
 	{Key: FlagBootstrapPackagesUsePath, ValueName: "PATH", ValueDemanded: true, Short: "Write to this config file or directory", Long: "Write to this config file or directory"},
 	{Key: FlagBootstrapPackagesUseYes, Short: "Skip the confirmation prompt", Long: "Skip the confirmation prompt"},
@@ -5079,6 +5121,8 @@ var HelpText = argv.HelpTable{
 	{Key: FlagBootstrapRemoteAll, Short: "Select every configured inventory host", Long: "Select every configured inventory host"},
 	{Key: FlagBootstrapRemoteBootstrapCommand, ValueName: "COMMAND", ValueDemanded: true, Short: "Explicit remote shell command that installs mise and places it on PATH", Long: "Explicit remote shell command that installs mise and places it on PATH"},
 	{Key: FlagBootstrapRemoteConnectTimeout, ValueName: "CONNECT_TIMEOUT", ValueDemanded: true, Short: "SSH connection timeout in seconds", Long: "SSH connection timeout in seconds", Default: []string{"10"}},
+	{Key: FlagBootstrapRemoteCopyLink, Repeatable: true, ValueName: "PATH", ValueDemanded: true, Short: "Dereference one source-relative symbolic link; repeat for multiple links", Long: "Dereference one source-relative symbolic link; repeat for multiple links"},
+	{Key: FlagBootstrapRemoteCopyLinks, Short: "Dereference every symbolic link in the source archive", Long: "Dereference every symbolic link in the source archive"},
 	{Key: FlagBootstrapRemoteExclude, Repeatable: true, ValueName: "PATTERN", ValueDemanded: true, Short: "Additional archive pattern to exclude; repeat for multiple patterns", Long: "Additional archive pattern to exclude; repeat for multiple patterns"},
 	{Key: FlagBootstrapRemoteFailFast, Short: "Stop after the first failed target", Long: "Stop after the first failed target"},
 	{Key: FlagBootstrapRemoteForceDotfiles, Short: "Allow remote dotfile conflicts to be replaced", Long: "Allow remote dotfile conflicts to be replaced"},
@@ -5087,11 +5131,12 @@ var HelpText = argv.HelpTable{
 	{Key: FlagBootstrapRemoteDryRun, Short: "Print the remote bootstrap changes without applying them", Long: "Print the remote bootstrap changes without applying them"},
 	{Key: FlagBootstrapRemoteKeepStaging, Short: "Keep the remote staging directory for debugging", Long: "Keep the remote staging directory for debugging"},
 	{Key: FlagBootstrapRemoteMiseBin, ValueName: "MISE_BIN", ValueDemanded: true, Short: "Local mise binary to upload (escape hatch for custom architectures)", Long: "Local mise binary to upload (escape hatch for custom architectures)"},
-	{Key: FlagBootstrapRemoteOnly, Repeatable: true, ValueName: "ONLY", ValueDemanded: true, Short: "Run only one or more remote bootstrap parts", Long: "Run only one or more remote bootstrap parts", Choices: []string{"plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "shell", "macos-defaults", "defaults", "macos-launchd-agents", "launchd", "linux-systemd-units", "systemd", "user", "tools", "task", "final-hook"}},
+	{Key: FlagBootstrapRemoteOnly, Repeatable: true, ValueName: "ONLY", ValueDemanded: true, Short: "Run only one or more remote bootstrap parts", Long: "Run only one or more remote bootstrap parts", Choices: []string{"plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "macos-defaults", "macos-launchd-agents", "linux-systemd-units", "user", "tools", "task", "final-hook"}},
 	{Key: FlagBootstrapRemotePort, ValueName: "PORT", ValueDemanded: true, Short: "SSH port override", Long: "SSH port override"},
 	{Key: FlagBootstrapRemotePromptSecrets, Short: "Prompt securely for missing secret inputs on the remote host", Long: "Prompt securely for missing secret inputs on the remote host"},
+	{Key: FlagBootstrapRemoteRemoteEnv, Repeatable: true, ValueName: "ENV", ValueDemanded: true, Short: "Config environments to load on the remote host; repeat or delimit with commas (for example, ci,dotfiles)", Long: "Config environments to load on the remote host; repeat or delimit with commas (for example, ci,dotfiles)"},
 	{Key: FlagBootstrapRemoteRemoteMise, ValueName: "COMMAND", ValueDemanded: true, Short: "Existing mise executable name or path; relative paths use the staged project", Long: "Existing mise executable name or path; relative paths use the staged project"},
-	{Key: FlagBootstrapRemoteSkip, Repeatable: true, ValueName: "SKIP", ValueDemanded: true, Short: "Skip one or more remote bootstrap parts", Long: "Skip one or more remote bootstrap parts", Choices: []string{"plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "shell", "macos-defaults", "defaults", "macos-launchd-agents", "launchd", "linux-systemd-units", "systemd", "user", "tools", "task", "final-hook"}},
+	{Key: FlagBootstrapRemoteSkip, Repeatable: true, ValueName: "SKIP", ValueDemanded: true, Short: "Skip one or more remote bootstrap parts", Long: "Skip one or more remote bootstrap parts", Choices: []string{"plugins", "packages", "accounts", "files", "services", "firewall", "compose", "repos", "dotfiles", "mise-shell-activate", "macos-defaults", "macos-launchd-agents", "linux-systemd-units", "user", "tools", "task", "final-hook"}},
 	{Key: FlagBootstrapRemoteSource, ValueName: "SOURCE", ValueDemanded: true, Short: "Local directory archived and sent to each target", Long: "Local directory archived and sent to each target"},
 	{Key: FlagBootstrapRemoteSshOption, Repeatable: true, ValueName: "OPTION", ValueDemanded: true, Short: "OpenSSH `-o` option; repeat for multiple options", Long: "OpenSSH `-o` option; repeat for multiple options"},
 	{Key: FlagBootstrapRemoteTag, Repeatable: true, ValueName: "TAG", ValueDemanded: true, Short: "Select configured hosts with this tag; repeat to match any tag", Long: "Select configured hosts with this tag; repeat to match any tag"},
@@ -5147,45 +5192,45 @@ var HelpText = argv.HelpTable{
 	{Key: CmdCacheClear, Short: "Deletes all cache files in mise", VisibleAliases: []string{"c"}},
 	{Key: FlagCacheClearOutdate, Hide: true, Short: "Mark all cache files as old", Long: "Mark all cache files as old"},
 	{Key: FlagCacheClearTask, ValueName: "TASK", ValueDemanded: true, Short: "Clear output cache entries for a task name or pattern", Long: "Clear output cache entries for a task name or pattern"},
-	{Key: ArgCacheClearTool, Short: "Tool(s) to clear cache for e.g.: node, python", Long: "Tool(s) to clear cache for e.g.: node, python"},
+	{Key: ArgCacheClearTool, Short: "Tool(s) to clear cache for e.g.: node, python", Long: "Tool(s) to clear cache for\ne.g.: node, python"},
 	{Key: CmdCachePath, Short: "Show the cache directory path", VisibleAliases: []string{"dir"}},
 	{Key: CmdCachePrune, Short: "Removes stale mise cache files", Long: "Removes stale mise cache files\n\nBy default, this command will remove files that have not been accessed in 30 days.\nChange this with the MISE_CACHE_PRUNE_AGE environment variable.", VisibleAliases: []string{"p"}},
 	{Key: FlagCachePruneVerbose, Repeatable: true, Short: "Show pruned files", Long: "Show pruned files"},
 	{Key: FlagCachePruneDryRun, Short: "Just show what would be pruned", Long: "Just show what would be pruned"},
-	{Key: ArgCachePruneTool, Short: "Tool(s) to prune cache for e.g.: node, python", Long: "Tool(s) to prune cache for e.g.: node, python"},
+	{Key: ArgCachePruneTool, Short: "Tool(s) to prune cache for e.g.: node, python", Long: "Tool(s) to prune cache for\ne.g.: node, python"},
 	{Key: CmdCacheTask, Short: "Inspect output cache entries for a task"},
 	{Key: FlagCacheTaskJson, Short: "Output in JSON format", Long: "Output in JSON format"},
 	{Key: ArgCacheTaskTask, Demanded: true, Short: "Task name or pattern to inspect", Long: "Task name or pattern to inspect"},
-	{Key: CmdCompletion, Short: "Generate shell completions", AfterLongHelp: "Examples:\n\n    $ mise completion bash --include-bash-completion-lib > ~/.local/share/bash-completion/completions/mise\n    $ mise completion zsh  > /usr/local/share/zsh/site-functions/_mise\n    $ mise completion fish > ~/.config/fish/completions/mise.fish\n    $ mise completion powershell >> $PROFILE\n"},
-	{Key: FlagCompletionShell, Hide: true, ValueName: "SHELL_TYPE", ValueDemanded: true, Short: "Shell type to generate completions for", Long: "Shell type to generate completions for", Choices: []string{"bash", "fish", "powershell", "zsh"}},
+	{Key: CmdCompletion, Short: "Generate shell completions", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise completion bash --include-bash-completion-lib > ~/.local/share/bash-completion/completions/mise\x1b[22m\n    $ \x1b[1mmise completion zsh  > /usr/local/share/zsh/site-functions/_mise\x1b[22m\n    $ \x1b[1mmise completion fish > ~/.config/fish/completions/mise.fish\x1b[22m\n    $ \x1b[1mmise completion powershell >> $PROFILE\x1b[22m\n"},
+	{Key: FlagCompletionShell, Hide: true, ValueName: "SHELL", ValueDemanded: true, Short: "Shell type to generate completions for", Long: "Shell type to generate completions for"},
 	{Key: FlagCompletionIncludeBashCompletionLib, Short: "Include the bash completion library in the bash completion script", Long: "Include the bash completion library in the bash completion script\n\nThis is required for completions to work in bash, but it is not included by default\nyou may source it separately or enable this flag to enable it in the script."},
 	{Key: FlagCompletionUsage, Hide: true, Short: "Always use usage for completions.\nCurrently, usage is the default for fish and bash but not zsh since it has a few quirks\nto work out first.", Long: "Always use usage for completions.\nCurrently, usage is the default for fish and bash but not zsh since it has a few quirks\nto work out first.\n\nThis requires the `usage` CLI to be installed.\nhttps://usage.jdx.dev"},
-	{Key: ArgCompletionShell, Short: "Shell type to generate completions for", Long: "Shell type to generate completions for", Choices: []string{"bash", "fish", "powershell", "zsh"}},
-	{Key: CmdConfig, Short: "Manage config files", VisibleAliases: []string{"cfg"}, AfterLongHelp: "Examples:\n\n    $ mise config ls\n    Path                        Tools\n    ~/.config/mise/config.toml  pitchfork\n    ~/src/mise/mise.toml        actionlint, bun, cargo-binstall, cargo:cargo-insta\n"},
+	{Key: ArgCompletionShell, Short: "Shell type to generate completions for", Long: "Shell type to generate completions for"},
+	{Key: CmdConfig, Short: "Manage config files", VisibleAliases: []string{"cfg"}},
 	{Key: FlagConfigJson, Short: "Output in JSON format", Long: "Output in JSON format"},
 	{Key: FlagConfigNoHeader, Short: "Do not print table header", Long: "Do not print table header"},
 	{Key: FlagConfigTrackedConfigs, Short: "List all tracked config files", Long: "List all tracked config files"},
-	{Key: CmdConfigGet, Short: "Display the value of a setting in a mise.toml file", AfterLongHelp: "Examples:\n\n    $ mise toml get tools.python\n    3.12\n"},
+	{Key: CmdConfigGet, Short: "Display the value of a setting in a mise.toml file", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise toml get tools.python\x1b[22m\n    3.12\n"},
 	{Key: FlagConfigGetFile, ValueName: "FILE", ValueDemanded: true, Short: "The path to the mise.toml file to read", Long: "The path to the mise.toml file to read\n\nCan be a file path or directory. If a directory is provided, the config file in that directory is used.\n\nIf not provided, the nearest mise.toml file will be used"},
 	{Key: ArgConfigGetKey, Short: "The path of the config to display", Long: "The path of the config to display"},
-	{Key: CmdConfigLs, Short: "List config files currently in use", VisibleAliases: []string{"list"}, AfterLongHelp: "Examples:\n\n    $ mise config ls\n    Path                        Tools\n    ~/.config/mise/config.toml  pitchfork\n    ~/src/mise/mise.toml        actionlint, bun, cargo-binstall, cargo:cargo-insta\n"},
+	{Key: CmdConfigLs, Short: "List config files currently in use", VisibleAliases: []string{"list"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise config ls\x1b[22m\n    Path                        Tools\n    ~/.config/mise/config.toml  pitchfork\n    ~/src/mise/mise.toml        actionlint, bun, cargo-binstall, cargo:cargo-insta\n"},
 	{Key: FlagConfigLsJson, Short: "Output in JSON format", Long: "Output in JSON format"},
 	{Key: FlagConfigLsNoHeader, Short: "Do not print table header", Long: "Do not print table header"},
 	{Key: FlagConfigLsTrackedConfigs, Short: "List all tracked config files", Long: "List all tracked config files"},
-	{Key: CmdConfigSet, Short: "Set the value of a setting in a mise.toml file", AfterLongHelp: "Examples:\n\n    $ mise config set tools.python 3.12\n    $ mise config set settings.always_keep_download true\n    $ mise config set env.TEST_ENV_VAR ABC\n    $ mise config set settings.disable_tools node,rust\n\n    # Type for `settings` is inferred\n    $ mise config set settings.jobs 4\n"},
+	{Key: CmdConfigSet, Short: "Set the value of a setting in a mise.toml file", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise config set tools.python 3.12\x1b[22m\n    $ \x1b[1mmise config set settings.always_keep_download true\x1b[22m\n    $ \x1b[1mmise config set env.TEST_ENV_VAR ABC\x1b[22m\n    $ \x1b[1mmise config set settings.disable_tools node,rust\x1b[22m\n\n    # Type for `settings` is inferred\n    $ \x1b[1mmise config set settings.jobs 4\x1b[22m\n"},
 	{Key: FlagConfigSetFile, ValueName: "FILE", ValueDemanded: true, Short: "The path to the mise.toml file to edit", Long: "The path to the mise.toml file to edit\n\nCan be a file path or directory. If a directory is provided, the config file in that directory is used.\n\nIf not provided, the nearest mise.toml file will be used"},
 	{Key: FlagConfigSetType, ValueName: "TYPE", ValueDemanded: true, Choices: []string{"infer", "string", "integer", "float", "bool", "list", "set"}, Default: []string{"infer"}},
 	{Key: ArgConfigSetKey, Demanded: true, Short: "The path of the config to display", Long: "The path of the config to display"},
 	{Key: ArgConfigSetValue, Short: "The value to set the key to (optional if provided as KEY=VALUE)", Long: "The value to set the key to (optional if provided as KEY=VALUE)"},
-	{Key: CmdCurrent, Hide: true, Short: "Shows current active and installed runtime versions", Long: "Shows current active and installed runtime versions\n\nThis is similar to `mise ls --current`, but this only shows the runtime\nand/or version. It's designed to fit into scripts more easily.", AfterLongHelp: "Examples:\n\n    # outputs `.tool-versions` compatible format\n    $ mise current\n    python 3.11.0 3.10.0\n    shfmt 3.6.0\n    shellcheck 0.9.0\n    node 20.0.0\n\n    $ mise current node\n    20.0.0\n\n    # can output multiple versions\n    $ mise current python\n    3.11.0 3.10.0\n"},
-	{Key: ArgCurrentPlugin, Short: "Plugin to show versions of e.g.: ruby, node, cargo:eza, npm:prettier, etc", Long: "Plugin to show versions of e.g.: ruby, node, cargo:eza, npm:prettier, etc"},
-	{Key: CmdDeactivate, Short: "Disable mise for current shell session", Long: "Disable mise for current shell session\n\nThis can be used to temporarily disable mise in a shell session.", AfterLongHelp: "Examples:\n\n    $ mise deactivate\n"},
+	{Key: CmdCurrent, Hide: true, Short: "Shows current active and installed runtime versions", Long: "Shows current active and installed runtime versions\n\nThis is similar to `mise ls --current`, but this only shows the runtime\nand/or version. It's designed to fit into scripts more easily.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    # outputs `.tool-versions` compatible format\n    $ \x1b[1mmise current\x1b[22m\n    python 3.11.0 3.10.0\n    shfmt 3.6.0\n    shellcheck 0.9.0\n    node 20.0.0\n\n    $ \x1b[1mmise current node\x1b[22m\n    20.0.0\n\n    # can output multiple versions\n    $ \x1b[1mmise current python\x1b[22m\n    3.11.0 3.10.0\n"},
+	{Key: ArgCurrentPlugin, Short: "Plugin to show versions of e.g.: ruby, node, cargo:eza, npm:prettier, etc.", Long: "Plugin to show versions of\ne.g.: ruby, node, cargo:eza, npm:prettier, etc."},
+	{Key: CmdDeactivate, Short: "Disable mise for current shell session", Long: "Disable mise for current shell session\n\nThis can be used to temporarily disable mise in a shell session.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise deactivate\x1b[22m\n"},
 	{Key: CmdDirenv, Hide: true, Short: "Output direnv function to use mise inside direnv", Long: "Output direnv function to use mise inside direnv\n\nSee https://mise.jdx.dev/direnv.html for more information\n\nBecause this generates the idiomatic files based on currently installed plugins,\nyou should run this command after installing new plugins. Otherwise\ndirenv may not know to update environment variables when idiomatic file versions change."},
-	{Key: CmdDirenvActivate, Hide: true, Short: "Output direnv function to use mise inside direnv", Long: "Output direnv function to use mise inside direnv\n\nSee https://mise.jdx.dev/direnv.html for more information\n\nBecause this generates the idiomatic files based on currently installed plugins,\nyou should run this command after installing new plugins. Otherwise\ndirenv may not know to update environment variables when idiomatic file versions change.", AfterLongHelp: "Examples:\n\n    $ mise direnv activate > ~/.config/direnv/lib/use_mise.sh\n    $ echo 'use mise' > .envrc\n    $ direnv allow\n"},
+	{Key: CmdDirenvActivate, Hide: true, Short: "Output direnv function to use mise inside direnv", Long: "Output direnv function to use mise inside direnv\n\nSee https://mise.jdx.dev/direnv.html for more information\n\nBecause this generates the idiomatic files based on currently installed plugins,\nyou should run this command after installing new plugins. Otherwise\ndirenv may not know to update environment variables when idiomatic file versions change.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise direnv activate > ~/.config/direnv/lib/use_mise.sh\x1b[22m\n    $ \x1b[1mecho 'use mise' > .envrc\x1b[22m\n    $ \x1b[1mdirenv allow\x1b[22m\n"},
 	{Key: CmdDirenvEnvrc, Hide: true, Short: "[internal] This is an internal command that writes an envrc file\nfor direnv to consume."},
 	{Key: CmdDirenvExec, Hide: true, Short: "[internal] This is an internal command that writes an envrc file\nfor direnv to consume."},
 	{Key: CmdDotfiles, Hide: true, Short: "Manage dotfiles from `[dotfiles]` (deprecated)", Long: "Manage dotfiles from `[dotfiles]` (deprecated)\n\nUse `mise bootstrap dotfiles` instead.", SubcommandRequired: true},
-	{Key: CmdDotfilesAdd, Hide: true, Short: "Add or update dotfiles in `[dotfiles]`", Long: "Add or update dotfiles in `[dotfiles]`\n\nIf the target is already managed, this updates its source from the live\ntarget. Otherwise it creates a `[dotfiles]` entry and seeds the source\nunder `dotfiles.root` unless `--source` is provided.", AfterLongHelp: "Examples:\n\n    $ mise bootstrap dotfiles add ~/.zshrc\n    $ mise bootstrap dotfiles add --mode copy ~/.config/starship.toml\n    $ mise bootstrap dotfiles add --source dotfiles/gitconfig ~/.gitconfig\n"},
+	{Key: CmdDotfilesAdd, Hide: true, Short: "Add or update dotfiles in `[dotfiles]`", Long: "Add or update dotfiles in `[dotfiles]`\n\nIf the target is already managed, this updates its source from the live\ntarget. Otherwise it creates a `[dotfiles]` entry and seeds the source\nunder `dotfiles.root` unless `--source` is provided.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise bootstrap dotfiles add ~/.zshrc\x1b[22m\n    $ \x1b[1mmise bootstrap dotfiles add --mode copy ~/.config/starship.toml\x1b[22m\n    $ \x1b[1mmise bootstrap dotfiles add --source dotfiles/gitconfig ~/.gitconfig\x1b[22m\n"},
 	{Key: FlagDotfilesAddForce, Short: "Overwrite existing sources without prompting", Long: "Overwrite existing sources without prompting"},
 	{Key: FlagDotfilesAddGlobal, Short: "Write to the global config", Long: "Write to the global config"},
 	{Key: FlagDotfilesAddLocal, Short: "Write to the local config instead of the global config", Long: "Write to the local config instead of the global config"},
@@ -5196,44 +5241,44 @@ var HelpText = argv.HelpTable{
 	{Key: FlagDotfilesAddSource, ValueName: "PATH", ValueDemanded: true, Short: "Source path to use for a single target", Long: "Source path to use for a single target"},
 	{Key: FlagDotfilesAddYes, Short: "Skip the confirmation prompt", Long: "Skip the confirmation prompt"},
 	{Key: ArgDotfilesAddTarget, Demanded: true, Short: "Targets to add or update", Long: "Targets to add or update"},
-	{Key: CmdDotfilesApply, Hide: true, Short: "Apply dotfiles from `[dotfiles]`", Long: "Apply dotfiles from `[dotfiles]`\n\nApplies configured whole-file entries and edits that aren't in their\ndesired state. Whole-file entries may symlink, copy, or render templates.\nEdit entries manage a marker-delimited block or a single line in a file\nmise doesn't otherwise own.", AfterLongHelp: "Examples:\n\n    $ mise bootstrap dotfiles apply\n    $ mise bootstrap dotfiles apply --dry-run\n    $ mise bootstrap dotfiles apply --force --yes\n"},
+	{Key: CmdDotfilesApply, Hide: true, Short: "Apply dotfiles from `[dotfiles]`", Long: "Apply dotfiles from `[dotfiles]`\n\nApplies configured whole-file entries and edits that aren't in their\ndesired state. Whole-file entries may symlink, copy, or render templates.\nEdit entries manage a marker-delimited block or a single line in a file\nmise doesn't otherwise own.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise bootstrap dotfiles apply\x1b[22m\n    $ \x1b[1mmise bootstrap dotfiles apply --dry-run\x1b[22m\n    $ \x1b[1mmise bootstrap dotfiles apply --force --yes\x1b[22m\n"},
 	{Key: FlagDotfilesApplyForce, Short: "Overwrite existing files that conflict with whole-file dotfile entries", Long: "Overwrite existing files that conflict with whole-file dotfile entries"},
 	{Key: FlagDotfilesApplyDryRun, Short: "Print the actions that would run without writing anything", Long: "Print the actions that would run without writing anything"},
 	{Key: FlagDotfilesApplyYes, Short: "Skip the confirmation prompt", Long: "Skip the confirmation prompt"},
 	{Key: ArgDotfilesApplyTarget, Short: "Only apply these targets", Long: "Only apply these targets"},
-	{Key: CmdDotfilesEdit, Hide: true, Short: "Edit a managed dotfile source", AfterLongHelp: "Examples:\n\n    $ mise bootstrap dotfiles edit ~/.zshrc\n    $ mise bootstrap dotfiles edit --apply ~/.config/starship.toml\n"},
+	{Key: CmdDotfilesEdit, Hide: true, Short: "Edit a managed dotfile source", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise bootstrap dotfiles edit ~/.zshrc\x1b[22m\n    $ \x1b[1mmise bootstrap dotfiles edit --apply ~/.config/starship.toml\x1b[22m\n"},
 	{Key: FlagDotfilesEditApply, Short: "Apply this target after the editor exits", Long: "Apply this target after the editor exits"},
 	{Key: FlagDotfilesEditMode, ValueName: "MODE", ValueDemanded: true, Short: "Dotfile mode to use if the target is not yet managed", Long: "Dotfile mode to use if the target is not yet managed"},
 	{Key: FlagDotfilesEditSource, ValueName: "PATH", ValueDemanded: true, Short: "Source path to use if the target is not yet managed", Long: "Source path to use if the target is not yet managed"},
 	{Key: FlagDotfilesEditYes, Short: "Skip the confirmation prompt when adding an unmanaged target", Long: "Skip the confirmation prompt when adding an unmanaged target"},
 	{Key: ArgDotfilesEditTarget, Demanded: true, Short: "Target to edit", Long: "Target to edit"},
-	{Key: CmdDotfilesStatus, Hide: true, Short: "Show the status of dotfiles from `[dotfiles]`", VisibleAliases: []string{"ls"}, AfterLongHelp: "Examples:\n\n    $ mise bootstrap dotfiles status\n    $ mise bootstrap dotfiles status ~/.zshrc\n    $ mise bootstrap dotfiles status --json\n    $ mise bootstrap dotfiles status --missing # exit 1 if anything is out of sync\n"},
+	{Key: CmdDotfilesStatus, Hide: true, Short: "Show the status of dotfiles from `[dotfiles]`", VisibleAliases: []string{"ls"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise bootstrap dotfiles status\x1b[22m\n    $ \x1b[1mmise bootstrap dotfiles status ~/.zshrc\x1b[22m\n    $ \x1b[1mmise bootstrap dotfiles status --json\x1b[22m\n    $ \x1b[1mmise bootstrap dotfiles status --missing\x1b[22m # exit 1 if anything is out of sync\n"},
 	{Key: FlagDotfilesStatusJson, Short: "Output in JSON format", Long: "Output in JSON format"},
 	{Key: FlagDotfilesStatusMissing, Short: "Exit with code 1 if any configured dotfiles are not in their desired\nstate (missing, source missing, differs)", Long: "Exit with code 1 if any configured dotfiles are not in their desired\nstate (missing, source missing, differs)"},
 	{Key: ArgDotfilesStatusTarget, Short: "Only show these targets", Long: "Only show these targets"},
-	{Key: CmdDotfilesUnapply, Hide: true, Short: "Remove dotfiles applied from `[dotfiles]`", Long: "Remove dotfiles applied from `[dotfiles]`\n\nRemoves configured whole-file entries and edits while preserving files\nmise cannot identify as managed. Modified copies, templates, and plain-line\nedits require `--force`.", AfterLongHelp: "Examples:\n\n    $ mise bootstrap dotfiles unapply\n    $ mise bootstrap dotfiles unapply ~/.zshrc\n    $ mise bootstrap dotfiles unapply --dry-run\n    $ mise bootstrap dotfiles unapply --force --yes\n"},
+	{Key: CmdDotfilesUnapply, Hide: true, Short: "Remove dotfiles applied from `[dotfiles]`", Long: "Remove dotfiles applied from `[dotfiles]`\n\nRemoves configured whole-file entries and edits while preserving files\nmise cannot identify as managed. Modified copies, templates, and plain-line\nedits require `--force`.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise bootstrap dotfiles unapply\x1b[22m\n    $ \x1b[1mmise bootstrap dotfiles unapply ~/.zshrc\x1b[22m\n    $ \x1b[1mmise bootstrap dotfiles unapply --dry-run\x1b[22m\n    $ \x1b[1mmise bootstrap dotfiles unapply --force --yes\x1b[22m\n"},
 	{Key: FlagDotfilesUnapplyForce, Short: "Remove modified or otherwise ambiguous managed files and lines", Long: "Remove modified or otherwise ambiguous managed files and lines"},
 	{Key: FlagDotfilesUnapplyDryRun, Short: "Print the actions that would run without writing anything", Long: "Print the actions that would run without writing anything"},
 	{Key: FlagDotfilesUnapplyYes, Short: "Skip the confirmation prompt", Long: "Skip the confirmation prompt"},
 	{Key: ArgDotfilesUnapplyTarget, Short: "Only unapply these targets", Long: "Only unapply these targets"},
-	{Key: CmdDoctor, Short: "Check mise installation for possible problems", VisibleAliases: []string{"dr"}, AfterLongHelp: "Examples:\n\n    $ mise doctor\n    [WARN] plugin node is not installed\n"},
+	{Key: CmdDoctor, Short: "Check mise installation for possible problems", VisibleAliases: []string{"dr"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise doctor\x1b[22m\n    [WARN] plugin node is not installed\n"},
 	{Key: FlagDoctorJson},
-	{Key: CmdDoctorPath, Short: "Print the current PATH entries mise is providing", AfterLongHelp: "Examples:\n\n    Get the current PATH entries mise is providing\n    $ mise doctor path\n    /home/user/.local/share/mise/installs/node/24.0.0/bin\n    /home/user/.local/share/mise/installs/rust/1.90.0/bin\n    /home/user/.local/share/mise/installs/python/3.10.0/bin\n"},
+	{Key: CmdDoctorPath, Short: "Print the current PATH entries mise is providing", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    Get the current PATH entries mise is providing\n    $ mise doctor path\n    /home/user/.local/share/mise/installs/node/24.0.0/bin\n    /home/user/.local/share/mise/installs/rust/1.90.0/bin\n    /home/user/.local/share/mise/installs/python/3.10.0/bin\n"},
 	{Key: FlagDoctorPathFull, Short: "Print all entries including those not provided by mise", Long: "Print all entries including those not provided by mise"},
-	{Key: CmdEn, Short: "Starts a new shell with the mise environment built from the current configuration", Long: "Starts a new shell with the mise environment built from the current configuration\n\nThis is an alternative to `mise activate` that allows you to explicitly start a mise session.\nIt will have the tools and environment variables in the configs loaded.\nNote that changing directories will not update the mise environment.", AfterLongHelp: "Examples:\n\n    $ mise en .\n    $ node -v\n    v20.0.0\n\n    Skip loading bashrc:\n    $ mise en -s \"bash --norc\"\n\n    Skip loading zshrc:\n    $ mise en -s \"zsh -f\"\n"},
+	{Key: CmdEn, Short: "Starts a new shell with the mise environment built from the current configuration", Long: "Starts a new shell with the mise environment built from the current configuration\n\nThis is an alternative to `mise activate` that allows you to explicitly start a mise session.\nIt will have the tools and environment variables in the configs loaded.\nNote that changing directories will not update the mise environment.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise en .\x1b[22m\n    $ \x1b[1mnode -v\x1b[22m\n    v20.0.0\n\n    Skip loading bashrc:\n    $ \x1b[1mmise en -s \"bash --norc\"\x1b[22m\n\n    Skip loading zshrc:\n    $ \x1b[1mmise en -s \"zsh -f\"\x1b[22m\n"},
 	{Key: FlagEnShell, ValueName: "SHELL", ValueDemanded: true, Short: "Shell to start", Long: "Shell to start\n\nDefaults to $SHELL"},
 	{Key: ArgEnDir, Short: "Directory to start the shell in", Long: "Directory to start the shell in", Default: []string{"."}},
-	{Key: CmdEnv, Short: "Exports env vars to activate mise a single time", Long: "Exports env vars to activate mise a single time\n\nUse this if you don't want to permanently install mise. It's not necessary to\nuse this if you have `mise activate` in your shell rc file.", VisibleAliases: []string{"e"}, AfterLongHelp: "Examples:\n\n    $ eval \"$(mise env -s bash)\"\n    $ eval \"$(mise env -s zsh)\"\n    $ mise env -s fish | source\n    $ execx($(mise env -s xonsh))\n"},
+	{Key: CmdEnv, Short: "Exports env vars to activate mise a single time", Long: "Exports env vars to activate mise a single time\n\nUse this if you don't want to permanently install mise. It's not necessary to\nuse this if you have `mise activate` in your shell rc file.", VisibleAliases: []string{"e"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1meval \"$(mise env -s bash)\"\x1b[22m\n    $ \x1b[1meval \"$(mise env -s zsh)\"\x1b[22m\n    $ \x1b[1mmise env -s fish | source\x1b[22m\n    $ \x1b[1mexecx($(mise env -s xonsh))\x1b[22m\n"},
 	{Key: FlagEnvDotenv, Short: "Output in dotenv format", Long: "Output in dotenv format"},
 	{Key: FlagEnvJson, Short: "Output in JSON format", Long: "Output in JSON format"},
-	{Key: FlagEnvShell, ValueName: "SHELL", ValueDemanded: true, Short: "Shell type to generate environment variables for", Long: "Shell type to generate environment variables for", Choices: []string{"bash", "elvish", "fish", "nu", "xonsh", "zsh", "pwsh"}},
+	{Key: FlagEnvShell, ValueName: "SHELL", ValueDemanded: true, Short: "Shell type to generate environment variables for", Long: "Shell type to generate environment variables for"},
 	{Key: FlagEnvJsonExtended, Short: "Output in JSON format with additional information (source, tool)", Long: "Output in JSON format with additional information (source, tool)"},
 	{Key: FlagEnvRedacted, Short: "Only show redacted environment variables", Long: "Only show redacted environment variables"},
 	{Key: FlagEnvValues, Short: "Only show values of environment variables", Long: "Only show values of environment variables"},
 	{Key: ArgEnvToolVersion, Short: "Tool(s) to use", Long: "Tool(s) to use"},
-	{Key: CmdExec, Short: "Execute a command with tool(s) set", Long: "Execute a command with tool(s) set\n\nuse this to avoid modifying the shell session or running ad-hoc commands with mise tools set.\n\nTools will be loaded from mise.toml, though they can be overridden with <RUNTIME> args\nNote that only the plugin specified will be overridden, so if a `mise.toml` file\nincludes \"node 20\" but you run `mise exec python@3.11`; it will still load node@20.\n\nThe \"--\" separates runtimes from the commands to pass along to the subprocess.", VisibleAliases: []string{"x"}, AfterLongHelp: "Examples:\n\n    $ mise exec node@20 -- node ./app.js  # launch app.js using node-20.x\n    $ mise x node@20 -- node ./app.js     # shorter alias\n\n    # Specify command as a string:\n    $ mise exec node@20 python@3.11 --command \"node -v && python -V\"\n\n    # Run a command in a different directory:\n    $ mise x -C /path/to/project node@20 -- node ./app.js\n"},
-	{Key: FlagExecCommand, ValueName: "C", ValueDemanded: true, Short: "Command string to execute", Long: "Command string to execute"},
-	{Key: FlagExecJobs, ValueName: "JOBS", ValueDemanded: true, Short: "Number of jobs to run in parallel\n[default: 4]", Long: "Number of jobs to run in parallel\n[default: 4]"},
+	{Key: CmdExec, Short: "Execute a command with tool(s) set", Long: "Execute a command with tool(s) set\n\nuse this to avoid modifying the shell session or running ad-hoc commands with mise tools set.\n\nTools will be loaded from mise.toml, though they can be overridden with <RUNTIME> args\nNote that only the plugin specified will be overridden, so if a `mise.toml` file\nincludes \"node 20\" but you run `mise exec python@3.11`; it will still load node@20.\n\nThe \"--\" separates runtimes from the commands to pass along to the subprocess.", VisibleAliases: []string{"x"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise exec node@20 -- node ./app.js\x1b[22m  # launch app.js using node-20.x\n    $ \x1b[1mmise x node@20 -- node ./app.js\x1b[22m     # shorter alias\n\n    # Specify command as a string:\n    $ \x1b[1mmise exec node@20 python@3.11 --command \"node -v && python -V\"\x1b[22m\n\n    # Run a command in a different directory:\n    $ \x1b[1mmise x -C /path/to/project node@20 -- node ./app.js\x1b[22m\n"},
+	{Key: FlagExecCommand, ValueName: "COMMAND", ValueDemanded: true, Short: "Command string to execute", Long: "Command string to execute"},
+	{Key: FlagExecJobs, ValueName: "JOBS", ValueDemanded: true, Short: "Number of jobs to run in parallel\nValues below 1 are treated as 1\n[default: 4]", Long: "Number of jobs to run in parallel\nValues below 1 are treated as 1\n[default: 4]", Env: "MISE_JOBS"},
 	{Key: FlagExecAllowEnv, Repeatable: true, ValueName: "VAR", ValueDemanded: true, Short: "Allow specific env var through (implies --deny-env for everything else)\nSupports wildcards, e.g. --allow-env='MYAPP_*'", Long: "Allow specific env var through (implies --deny-env for everything else)\nSupports wildcards, e.g. --allow-env='MYAPP_*'"},
 	{Key: FlagExecAllowNet, Repeatable: true, ValueName: "HOST", ValueDemanded: true, Short: "Allow network to specific host (implies --deny-net for everything else)\nmacOS only in v1; on Linux falls back to allowing all network", Long: "Allow network to specific host (implies --deny-net for everything else)\nmacOS only in v1; on Linux falls back to allowing all network"},
 	{Key: FlagExecAllowRead, Repeatable: true, ValueName: "PATH", ValueDemanded: true, Short: "Allow reads from specific path (implies --deny-read for everything else)", Long: "Allow reads from specific path (implies --deny-read for everything else)"},
@@ -5245,68 +5290,71 @@ var HelpText = argv.HelpTable{
 	{Key: FlagExecDenyWrite, Short: "Block all filesystem writes", Long: "Block all filesystem writes"},
 	{Key: FlagExecFreshEnv, Short: "Bypass the environment cache and recompute the environment", Long: "Bypass the environment cache and recompute the environment"},
 	{Key: FlagExecNoDeps, Short: "Skip automatic dependency preparation", Long: "Skip automatic dependency preparation"},
-	{Key: FlagExecRaw, Short: "Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1", Long: "Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1"},
-	{Key: ArgExecToolVersion, Short: "Tool(s) to start e.g.: node@20 python@3.10", Long: "Tool(s) to start e.g.: node@20 python@3.10"},
+	{Key: FlagExecRaw, Short: "Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1", Long: "Connect backend install command stdin/stdout/stderr directly to the terminal\nImplies --jobs=1"},
+	{Key: ArgExecToolVersion, Short: "Tool(s) to start e.g.: node@20 python@3.10", Long: "Tool(s) to start\ne.g.: node@20 python@3.10"},
 	{Key: ArgExecCommand, Short: "Command string to execute (same as --command)", Long: "Command string to execute (same as --command)"},
-	{Key: CmdFmt, Short: "Formats mise.toml", Long: "Formats mise.toml\n\nSorts keys and cleans up whitespace in mise.toml", AfterLongHelp: "Examples:\n\n    $ mise fmt\n"},
+	{Key: CmdFmt, Short: "Formats mise.toml", Long: "Formats mise.toml\n\nSorts keys and cleans up whitespace in mise.toml", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise fmt\x1b[22m\n"},
 	{Key: FlagFmtAll, Short: "Format all files from the current directory", Long: "Format all files from the current directory"},
 	{Key: FlagFmtCheck, Short: "Check if the configs are formatted, no formatting is done", Long: "Check if the configs are formatted, no formatting is done"},
-	{Key: FlagFmtStdin, Short: "Read config from stdin and write its formatted version into stdout", Long: "Read config from stdin and write its formatted version into stdout"},
+	{Key: FlagFmtStdin, Short: "Read config from stdin and write its formatted version into stdout", Long: "Read config from stdin and write its formatted version into\nstdout"},
 	{Key: CmdGenerate, Short: "Generate files for various tools/services", SubcommandRequired: true, VisibleAliases: []string{"gen"}},
-	{Key: CmdGenerateBootstrap, Short: "Generate a script to download+execute mise", Long: "Generate a script to download+execute mise\n\nThis is designed to be used in a project where contributors may not have mise installed.", AfterLongHelp: "Examples:\n\n    $ mise generate bootstrap >./bin/mise\n    $ chmod +x ./bin/mise\n    $ ./bin/mise install – automatically downloads mise to .mise if not already installed\n"},
+	{Key: CmdGenerateBootstrap, Short: "Generate a script to download+execute mise", Long: "Generate a script to download+execute mise\n\nThis is designed to be used in a project where contributors may not have mise installed.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise generate bootstrap --write ./bin/mise\x1b[22m\n    $ \x1b[1m./bin/mise install\x1b[22m                                    \x1b[2m# downloads mise to .mise if not already installed\x1b[22m\n\n    \x1b[2m# add a launcher for contributors who clone the project on Windows\x1b[22m\n    $ \x1b[1mmise generate bootstrap --write ./bin/mise --windows\x1b[22m  \x1b[2m# also writes bin/mise.cmd\x1b[22m\n    $ \x1b[1m.\\bin\\mise.cmd install\x1b[22m\n"},
 	{Key: FlagGenerateBootstrapLocalize, Short: "Sandboxes mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a `.mise` directory in the project", Long: "Sandboxes mise internal directories like MISE_DATA_DIR and MISE_CACHE_DIR into a `.mise` directory in the project\n\nThis is necessary if users may use a different version of mise outside the project."},
 	{Key: FlagGenerateBootstrapVersion, ValueName: "VERSION", ValueDemanded: true, Short: "Specify mise version to fetch", Long: "Specify mise version to fetch"},
-	{Key: FlagGenerateBootstrapWrite, ValueName: "WRITE", ValueDemanded: true, Short: "instead of outputting the script to stdout, write to a file and make it executable", Long: "instead of outputting the script to stdout, write to a file and make it executable"},
+	{Key: FlagGenerateBootstrapWrite, ValueName: "WRITE", Short: "instead of outputting the script to stdout, write to a file and make it executable", Long: "instead of outputting the script to stdout, write to a file and make it executable"},
 	{Key: FlagGenerateBootstrapLocalizedDir, ValueName: "LOCALIZED_DIR", ValueDemanded: true, Short: "Directory to put localized data into", Long: "Directory to put localized data into", Default: []string{".mise"}},
-	{Key: CmdGenerateConfig, Short: "Generate a mise.toml file", AfterLongHelp: "Examples:\n\n    $ mise generate config             # generate mise.toml interactively\n    $ mise generate config .mise.toml  # generate a specific file\n    $ mise generate config -g          # generate the global config file\n    $ mise generate config -y          # skip interactive editor\n    $ mise generate config -n          # preview without writing\n"},
+	{Key: FlagGenerateBootstrapWindows, Short: "Also write a Windows launcher, `<WRITE>.cmd`", Long: "Also write a Windows launcher, `<WRITE>.cmd`\n\nWindows cannot execute the `#!/usr/bin/env bash` script, so a contributor who clones the\nproject on Windows has nothing to run without this.\n\nGenerated on every host, not only on Windows: the file is committed, and whoever runs it\non Windows is not the person who generated it. Requires `--write`, since stdout cannot\ncarry two files."},
+	{Key: CmdGenerateConfig, Short: "Generate a mise.toml file", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise generate config\x1b[22m             \x1b[2m# generate mise.toml interactively\x1b[22m\n    $ \x1b[1mmise generate config .mise.toml\x1b[22m  \x1b[2m# generate a specific file\x1b[22m\n    $ \x1b[1mmise generate config -g\x1b[22m          \x1b[2m# generate the global config file\x1b[22m\n    $ \x1b[1mmise generate config -y\x1b[22m          \x1b[2m# skip interactive editor\x1b[22m\n    $ \x1b[1mmise generate config -n\x1b[22m          \x1b[2m# preview without writing\x1b[22m\n"},
 	{Key: FlagGenerateConfigGlobal, Short: "Generate the global config file (~/.config/mise/config.toml)", Long: "Generate the global config file (~/.config/mise/config.toml)"},
 	{Key: FlagGenerateConfigDryRun, Short: "Show what would be generated without writing to file", Long: "Show what would be generated without writing to file"},
 	{Key: FlagGenerateConfigToolVersions, ValueName: "TOOL_VERSIONS", ValueDemanded: true, Short: "Path to a .tool-versions file to import tools from", Long: "Path to a .tool-versions file to import tools from"},
 	{Key: ArgGenerateConfigPath, Short: "Path to the config file to create", Long: "Path to the config file to create"},
-	{Key: CmdGenerateDevcontainer, Short: "Generate a devcontainer to execute mise", AfterLongHelp: "Examples:\n\n    $ mise generate devcontainer\n"},
+	{Key: CmdGenerateDevcontainer, Short: "Generate a devcontainer to execute mise", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise generate devcontainer\x1b[22m\n"},
 	{Key: FlagGenerateDevcontainerImage, ValueName: "IMAGE", ValueDemanded: true, Short: "The image to use for the devcontainer", Long: "The image to use for the devcontainer"},
 	{Key: FlagGenerateDevcontainerMountMiseData, Short: "Bind the mise-data-volume to the devcontainer", Long: "Bind the mise-data-volume to the devcontainer"},
 	{Key: FlagGenerateDevcontainerName, ValueName: "NAME", ValueDemanded: true, Short: "The name of the devcontainer", Long: "The name of the devcontainer"},
 	{Key: FlagGenerateDevcontainerWrite, Short: "write to .devcontainer/devcontainer.json", Long: "write to .devcontainer/devcontainer.json"},
-	{Key: CmdGenerateGitPreCommit, Short: "Generate a git pre-commit hook", Long: "Generate a git pre-commit hook\n\nThis command generates a git pre-commit hook that runs a mise task like `mise run pre-commit`\nwhen you commit changes to your repository.\n\nStaged files are passed to the task as `STAGED`.\n\nFor more advanced pre-commit functionality, see mise's sister project: https://hk.jdx.dev/", VisibleAliases: []string{"pre-commit"}, AfterLongHelp: "Examples:\n\n    $ mise generate git-pre-commit --write --task=pre-commit\n    $ git commit -m \"feat: add new feature\" # runs `mise run pre-commit`\n"},
+	{Key: CmdGenerateGitPreCommit, Short: "Generate a git pre-commit hook", Long: "Generate a git pre-commit hook\n\nThis command generates a git pre-commit hook that runs a mise task like `mise run pre-commit`\nwhen you commit changes to your repository.\n\nStaged files are passed to the task as `STAGED`.\n\nFor more advanced pre-commit functionality, see mise's sister project: https://hk.jdx.dev/", VisibleAliases: []string{"pre-commit"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise generate git-pre-commit --write --task=pre-commit\x1b[22m\n    $ \x1b[1mgit commit -m \"feat: add new feature\"\x1b[22m \x1b[2m# runs `mise run pre-commit`\x1b[22m\n\n    \x1b[2m# config lives in a subdirectory, so the hook has to change into it first\x1b[22m\n    $ \x1b[1mmise generate git-pre-commit --write -- -C subdir\x1b[22m\n"},
 	{Key: FlagGenerateGitPreCommitTask, ValueName: "TASK", ValueDemanded: true, Short: "The task to run when the pre-commit hook is triggered", Long: "The task to run when the pre-commit hook is triggered", Default: []string{"pre-commit"}},
 	{Key: FlagGenerateGitPreCommitWrite, Short: "write to .git/hooks/pre-commit and make it executable", Long: "write to .git/hooks/pre-commit and make it executable"},
 	{Key: FlagGenerateGitPreCommitHook, ValueName: "HOOK", ValueDemanded: true, Short: "Which hook to generate (saves to .git/hooks/$hook)", Long: "Which hook to generate (saves to .git/hooks/$hook)", Default: []string{"pre-commit"}},
-	{Key: CmdGenerateGithubAction, Short: "Generate a GitHub Action workflow file", Long: "Generate a GitHub Action workflow file\n\nThis command generates a GitHub Action workflow file that runs a mise task like `mise run ci`\nwhen you push changes to your repository.", AfterLongHelp: "Examples:\n\n    $ mise generate github-action --write --task=ci\n    $ git commit -m \"feat: add new feature\"\n    $ git push # runs `mise run ci` on GitHub\n"},
+	{Key: ArgGenerateGitPreCommitMiseArg, Short: "mise flags to embed in the generated hook, given after `--`", Long: "mise flags to embed in the generated hook, given after `--`\n\nThese are inserted between `mise` and `run`, so the hook carries the same context you\nwould pass on the command line. Useful when the config is not at the repository root,\nsince git runs hooks from the top level: `-- -C subdir` makes the hook find it."},
+	{Key: CmdGenerateGithubAction, Short: "Generate a GitHub Action workflow file", Long: "Generate a GitHub Action workflow file\n\nThis command generates a GitHub Action workflow file that runs a mise task like `mise run ci`\nwhen you push changes to your repository.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise generate github-action --write --task=ci\x1b[22m\n    $ \x1b[1mgit commit -m \"feat: add new feature\"\x1b[22m\n    $ \x1b[1mgit push\x1b[22m \x1b[2m# runs `mise run ci` on GitHub\x1b[22m\n"},
 	{Key: FlagGenerateGithubActionTask, ValueName: "TASK", ValueDemanded: true, Short: "The task to run when the workflow is triggered", Long: "The task to run when the workflow is triggered", Default: []string{"ci"}},
 	{Key: FlagGenerateGithubActionWrite, Short: "write to .github/workflows/$name.yml", Long: "write to .github/workflows/$name.yml"},
 	{Key: FlagGenerateGithubActionName, ValueName: "NAME", ValueDemanded: true, Short: "the name of the workflow to generate", Long: "the name of the workflow to generate", Default: []string{"ci"}},
-	{Key: CmdGenerateTaskDocs, Short: "Generate documentation for tasks in a project", AfterLongHelp: "Examples:\n\n    $ mise generate task-docs\n"},
+	{Key: CmdGenerateTaskDocs, Short: "Generate documentation for tasks in a project", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise generate task-docs\x1b[22m\n"},
 	{Key: FlagGenerateTaskDocsInject, Short: "inserts the documentation into an existing file", Long: "inserts the documentation into an existing file\n\nThis will look for a special comment, `<!-- mise-tasks -->`, and replace it with the generated documentation.\nIt will replace everything between the comment and the next comment, `<!-- /mise-tasks -->` so it can be\nrun multiple times on the same file to update the documentation.\nThe file must already contain both comments; mise errors instead of modifying the file if they are missing."},
 	{Key: FlagGenerateTaskDocsIndex, Short: "write only an index of tasks, intended for use with `--multi`", Long: "write only an index of tasks, intended for use with `--multi`"},
 	{Key: FlagGenerateTaskDocsMulti, Short: "render each task as a separate document, requires `--output` to be a directory", Long: "render each task as a separate document, requires `--output` to be a directory"},
 	{Key: FlagGenerateTaskDocsOutput, ValueName: "OUTPUT", ValueDemanded: true, Short: "writes the generated docs to a file/directory", Long: "writes the generated docs to a file/directory"},
 	{Key: FlagGenerateTaskDocsRoot, ValueName: "ROOT", ValueDemanded: true, Short: "root directory to search for tasks", Long: "root directory to search for tasks"},
 	{Key: FlagGenerateTaskDocsStyle, ValueName: "STYLE", ValueDemanded: true, Choices: []string{"simple", "detailed"}, Default: []string{"simple"}},
-	{Key: CmdGenerateTaskStubs, Short: "Generates shims to run mise tasks", Long: "Generates shims to run mise tasks\n\nBy default, this will build shims like ./bin/<task>. These can be paired with `mise generate bootstrap`\nso contributors to a project can execute mise tasks without installing mise into their system.", AfterLongHelp: "Examples:\n\n    $ mise tasks add test -- echo 'running tests'\n    $ mise generate task-stubs\n    $ ./bin/test\n    running tests\n"},
+	{Key: CmdGenerateTaskStubs, Short: "Generates shims to run mise tasks", Long: "Generates shims to run mise tasks\n\nBy default, this will build shims like ./bin/<task>. These can be paired with `mise generate bootstrap`\nso contributors to a project can execute mise tasks without installing mise into their system.\nWhen a parent and nested task both exist, the parent stub is written to `<parent>/_default`.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise tasks add test -- echo 'running tests'\x1b[22m\n    $ \x1b[1mmise generate task-stubs\x1b[22m\n    $ \x1b[1m./bin/test\x1b[22m\n    running tests\n"},
 	{Key: FlagGenerateTaskStubsDir, ValueName: "DIR", ValueDemanded: true, Short: "Directory to create task stubs inside of", Long: "Directory to create task stubs inside of", Default: []string{"bin"}},
 	{Key: FlagGenerateTaskStubsMiseBin, ValueName: "MISE_BIN", ValueDemanded: true, Short: "Path to a mise bin to use when running the task stub.", Long: "Path to a mise bin to use when running the task stub.\n\nUse `--mise-bin=./bin/mise` to use a mise bin generated from `mise generate bootstrap`", Default: []string{"mise"}},
-	{Key: CmdGenerateToolStub, Short: "Generate a tool stub for HTTP-based tools", Long: "Generate a tool stub for HTTP-based tools\n\nThis command generates tool stubs that can automatically download and execute\ntools from HTTP URLs. It can detect checksums, file sizes, and binary paths\nautomatically by downloading and analyzing the tool.\n\nWhen generating stubs with platform-specific URLs, the command will append new\nplatforms to existing stub files rather than overwriting them. This allows you\nto incrementally build cross-platform tool stubs.", AfterLongHelp: "Examples:\n\n    Generate a tool stub for a single URL:\n    $ mise generate tool-stub ./bin/gh --url \"https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_linux_amd64.tar.gz\"\n\n    Generate a tool stub with platform-specific URLs:\n    $ mise generate tool-stub ./bin/rg \\\n        --platform-url linux-x64:https://github.com/BurntSushi/ripgrep/releases/download/14.0.3/ripgrep-14.0.3-x86_64-unknown-linux-musl.tar.gz \\\n        --platform-url darwin-arm64:https://github.com/BurntSushi/ripgrep/releases/download/14.0.3/ripgrep-14.0.3-aarch64-apple-darwin.tar.gz\n\n    Append additional platforms to an existing stub:\n    $ mise generate tool-stub ./bin/rg \\\n        --platform-url linux-x64:https://example.com/rg-linux.tar.gz\n    $ mise generate tool-stub ./bin/rg \\\n        --platform-url darwin-arm64:https://example.com/rg-darwin.tar.gz\n    # The stub now contains both platforms\n\n    Use auto-detection for platform from URL:\n    $ mise generate tool-stub ./bin/node \\\n        --platform-url https://nodejs.org/dist/v22.17.1/node-v22.17.1-darwin-arm64.tar.gz\n    # Platform 'macos-arm64' will be auto-detected from the URL\n\n    Generate with platform-specific binary paths:\n    $ mise generate tool-stub ./bin/tool \\\n        --platform-url linux-x64:https://example.com/tool-linux.tar.gz \\\n        --platform-url windows-x64:https://example.com/tool-windows.zip \\\n        --platform-bin windows-x64:tool.exe\n\n    Generate without downloading (faster):\n    $ mise generate tool-stub ./bin/tool --url \"https://example.com/tool.tar.gz\" --skip-download\n\n    Fetch checksums for an existing stub:\n    $ mise generate tool-stub ./bin/jq --fetch\n    # This will read the existing stub and download files to fill in any missing checksums/sizes\n\n    Generate a bootstrap stub that installs mise if needed:\n    $ mise generate tool-stub ./bin/tool --url \"https://example.com/tool.tar.gz\" --bootstrap\n    # The stub will check for mise and install it automatically before running the tool\n\n    Generate a bootstrap stub with a pinned mise version:\n    $ mise generate tool-stub ./bin/tool --url \"https://example.com/tool.tar.gz\" --bootstrap --bootstrap-version 2025.1.0\n\n    Lock an existing tool stub with pinned version and platform URLs/checksums:\n    $ mise generate tool-stub ./bin/node --lock\n\n    Bump the version in a locked stub:\n    $ mise generate tool-stub ./bin/node --lock --version 22\n    # Resolves the latest node 22.x, pins it, and updates platform URLs/checksums\n"},
+	{Key: CmdGenerateToolStub, Short: "Generate a tool stub for HTTP-based tools", Long: "Generate a tool stub for HTTP-based tools\n\nThis command generates tool stubs that can automatically download and execute\ntools from HTTP URLs. It can detect checksums, file sizes, and binary paths\nautomatically by downloading and analyzing the tool.\n\nWhen generating stubs with platform-specific URLs, the command will append new\nplatforms to existing stub files rather than overwriting them. This allows you\nto incrementally build cross-platform tool stubs.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    Generate a tool stub for a single URL:\n    $ \x1b[1mmise generate tool-stub ./bin/gh --url \"https://github.com/cli/cli/releases/download/v2.96.0/gh_2.96.0_linux_amd64.tar.gz\"\x1b[22m\n\n    Generate a tool stub with platform-specific URLs:\n    $ \x1b[1mmise generate tool-stub ./bin/rg \\\n        --platform-url linux-x64:https://github.com/BurntSushi/ripgrep/releases/download/14.0.3/ripgrep-14.0.3-x86_64-unknown-linux-musl.tar.gz \\\n        --platform-url darwin-arm64:https://github.com/BurntSushi/ripgrep/releases/download/14.0.3/ripgrep-14.0.3-aarch64-apple-darwin.tar.gz\x1b[22m\n\n    Append additional platforms to an existing stub:\n    $ \x1b[1mmise generate tool-stub ./bin/rg \\\n        --platform-url linux-x64:https://example.com/rg-linux.tar.gz\x1b[22m\n    $ \x1b[1mmise generate tool-stub ./bin/rg \\\n        --platform-url darwin-arm64:https://example.com/rg-darwin.tar.gz\x1b[22m\n    # The stub now contains both platforms\n\n    Use auto-detection for platform from URL:\n    $ \x1b[1mmise generate tool-stub ./bin/node \\\n        --platform-url https://nodejs.org/dist/v22.17.1/node-v22.17.1-darwin-arm64.tar.gz\x1b[22m\n    # Platform 'macos-arm64' will be auto-detected from the URL\n\n    Generate with platform-specific binary paths:\n    $ \x1b[1mmise generate tool-stub ./bin/tool \\\n        --platform-url linux-x64:https://example.com/tool-linux.tar.gz \\\n        --platform-url windows-x64:https://example.com/tool-windows.zip \\\n        --platform-bin windows-x64:tool.exe\x1b[22m\n\n    Generate without downloading (faster):\n    $ \x1b[1mmise generate tool-stub ./bin/tool --url \"https://example.com/tool.tar.gz\" --skip-download\x1b[22m\n\n    Fetch checksums for an existing stub:\n    $ \x1b[1mmise generate tool-stub ./bin/jq --fetch\x1b[22m\n    # This will read the existing stub and download files to fill in any missing checksums/sizes\n\n    Generate a bootstrap stub that installs mise if needed:\n    $ \x1b[1mmise generate tool-stub ./bin/tool --url \"https://example.com/tool.tar.gz\" --bootstrap\x1b[22m\n    # The stub will check for mise and install it automatically before running the tool\n\n    Generate a bootstrap stub with a pinned mise version:\n    $ \x1b[1mmise generate tool-stub ./bin/tool --url \"https://example.com/tool.tar.gz\" --bootstrap --bootstrap-version 2025.1.0\x1b[22m\n\n    Lock an existing tool stub with pinned version and platform URLs/checksums:\n    $ \x1b[1mmise generate tool-stub ./bin/node --lock\x1b[22m\n\n    Bump the version in a locked stub:\n    $ \x1b[1mmise generate tool-stub ./bin/node --lock --version 22\x1b[22m\n    # Resolves the latest node 22.x, pins it, and updates platform URLs/checksums\n"},
 	{Key: FlagGenerateToolStubBin, ValueName: "BIN", ValueDemanded: true, Short: "Binary path within the extracted archive", Long: "Binary path within the extracted archive\n\nIf not specified and the archive is downloaded, will auto-detect the most likely binary"},
 	{Key: FlagGenerateToolStubBootstrap, Short: "Wrap stub in a bootstrap script that installs mise if not already present", Long: "Wrap stub in a bootstrap script that installs mise if not already present\n\nWhen enabled, generates a bash script that:\n1. Checks if mise is installed at the expected path\n2. If not, downloads and installs mise using the embedded installer\n3. Executes the tool stub using mise"},
 	{Key: FlagGenerateToolStubBootstrapVersion, ValueName: "BOOTSTRAP_VERSION", ValueDemanded: true, Short: "Specify mise version for the bootstrap script", Long: "Specify mise version for the bootstrap script\n\nBy default, uses the latest version from the install script.\nUse this to pin to a specific version (e.g., \"2025.1.0\")."},
-	{Key: FlagGenerateToolStubFetch, Short: "Fetch checksums and sizes for an existing tool stub file", Long: "Fetch checksums and sizes for an existing tool stub file\n\nThis reads an existing stub file and fills in any missing checksum/size fields by downloading the files. URLs must already be present in the stub."},
+	{Key: FlagGenerateToolStubChecksumAlgorithm, ValueName: "CHECKSUM_ALGORITHM", ValueDemanded: true, Short: "Checksum algorithm to use when downloading artifacts", Long: "Checksum algorithm to use when downloading artifacts\n\nAccepts `blake3` or `sha256` and defaults to `blake3`.\nCannot be used with `--lock` or `--skip-download` because those modes do not\ncalculate checksums.", Choices: []string{"blake3", "sha256"}, Default: []string{"blake3"}},
+	{Key: FlagGenerateToolStubFetch, Short: "Fetch checksums and sizes for an existing tool stub file", Long: "Fetch checksums and sizes for an existing tool stub file\n\nThis reads an existing stub file and fills in any missing checksum/size fields\nby downloading the files. URLs must already be present in the stub."},
 	{Key: FlagGenerateToolStubHttp, ValueName: "HTTP", ValueDemanded: true, Short: "HTTP backend type to use", Long: "HTTP backend type to use", Default: []string{"http"}},
-	{Key: FlagGenerateToolStubLock, Short: "Resolve and embed lockfile data (exact version + platform URLs/checksums) into an existing stub file for reproducible installs without runtime API calls", Long: "Resolve and embed lockfile data (exact version + platform URLs/checksums) into an existing stub file for reproducible installs without runtime API calls"},
+	{Key: FlagGenerateToolStubLock, Short: "Resolve and embed lockfile data (exact version + platform URLs/checksums) into an existing stub file for reproducible installs without runtime API calls", Long: "Resolve and embed lockfile data (exact version + platform URLs/checksums)\ninto an existing stub file for reproducible installs without runtime API calls"},
 	{Key: FlagGenerateToolStubPlatformBin, Repeatable: true, ValueName: "PLATFORM_BIN", ValueDemanded: true, Short: "Platform-specific binary paths in the format platform:path", Long: "Platform-specific binary paths in the format platform:path\n\nExamples: --platform-bin windows-x64:tool.exe --platform-bin linux-x64:bin/tool"},
-	{Key: FlagGenerateToolStubPlatformUrl, Repeatable: true, ValueName: "PLATFORM_URL", ValueDemanded: true, Short: "Platform-specific URLs in the format platform:url or just url (auto-detect platform)", Long: "Platform-specific URLs in the format platform:url or just url (auto-detect platform)\n\nWhen the output file already exists, new platforms will be appended to the existing platforms table. Existing platform URLs will be updated if specified again.\n\nIf only a URL is provided (without platform:), the platform will be automatically detected from the URL filename.\n\nExamples: --platform-url linux-x64:https://... --platform-url https://nodejs.org/dist/v22.17.1/node-v22.17.1-darwin-arm64.tar.gz"},
+	{Key: FlagGenerateToolStubPlatformUrl, Repeatable: true, ValueName: "PLATFORM_URL", ValueDemanded: true, Short: "Platform-specific URLs in the format platform:url or just url (auto-detect platform)", Long: "Platform-specific URLs in the format platform:url or just url (auto-detect platform)\n\nWhen the output file already exists, new platforms will be appended to the existing\nplatforms table. Existing platform URLs will be updated if specified again.\n\nIf only a URL is provided (without platform:), the platform will be automatically\ndetected from the URL filename.\n\nExamples:\n--platform-url linux-x64:https://...\n--platform-url https://nodejs.org/dist/v22.17.1/node-v22.17.1-darwin-arm64.tar.gz"},
 	{Key: FlagGenerateToolStubSkipDownload, Short: "Skip downloading for checksum and binary path detection (faster but less informative)", Long: "Skip downloading for checksum and binary path detection (faster but less informative)"},
 	{Key: FlagGenerateToolStubUrl, ValueName: "URL", ValueDemanded: true, Short: "URL for downloading the tool", Long: "URL for downloading the tool\n\nExample: https://github.com/owner/repo/releases/download/v2.0.0/tool-linux-x64.tar.gz"},
 	{Key: FlagGenerateToolStubVersion, ValueName: "VERSION", ValueDemanded: true, Short: "Version of the tool", Long: "Version of the tool", Default: []string{"latest"}},
 	{Key: ArgGenerateToolStubOutput, Demanded: true, Short: "Output file path for the tool stub", Long: "Output file path for the tool stub"},
 	{Key: CmdGithub, Hide: true, Short: "GitHub related commands", SubcommandRequired: true},
-	{Key: CmdGithubToken, Hide: true, Short: "Display the GitHub token mise will use for a given host", Long: "Display the GitHub token mise will use for a given host\n\nShows which token source mise would use, useful for debugging\nauthentication issues. The token is masked by default.", AfterLongHelp: "Examples:\n\n    $ mise github token\n    github.com: ghp_…xxxx (source: GITHUB_TOKEN)\n\n    $ mise github token --unmask\n    github.com: ghp_xxxxxxxxxxxx (source: GITHUB_TOKEN)\n\n    $ mise github token github.mycompany.com\n    github.mycompany.com: (none)\n"},
+	{Key: CmdGithubToken, Hide: true, Short: "Display the GitHub token mise will use for a given host", Long: "Display the GitHub token mise will use for a given host\n\nShows which token source mise would use, useful for debugging\nauthentication issues. The token is masked by default.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise github token\x1b[22m\n    github.com: ghp_…xxxx (source: GITHUB_TOKEN)\n\n    $ \x1b[1mmise github token --unmask\x1b[22m\n    github.com: ghp_xxxxxxxxxxxx (source: GITHUB_TOKEN)\n\n    $ \x1b[1mmise github token github.mycompany.com\x1b[22m\n    github.mycompany.com: (none)\n"},
 	{Key: FlagGithubTokenOauth, Short: "Force native GitHub OAuth device flow instead of normal token resolution", Long: "Force native GitHub OAuth device flow instead of normal token resolution"},
 	{Key: FlagGithubTokenRaw, Short: "Print only the token value", Long: "Print only the token value"},
-	{Key: FlagGithubTokenRefresh, Short: "Mint a fresh OAuth token even if the cached one has not expired, via the refresh-token grant or a new device-code flow", Long: "Mint a fresh OAuth token even if the cached one has not expired, via the refresh-token grant or a new device-code flow"},
+	{Key: FlagGithubTokenRefresh, Short: "Mint a fresh OAuth token even if the cached one has not expired, via the refresh-token grant or a new device-code flow", Long: "Mint a fresh OAuth token even if the cached one has not\nexpired, via the refresh-token grant or a new device-code flow"},
 	{Key: FlagGithubTokenUnmask, Short: "Show the full unmasked token", Long: "Show the full unmasked token"},
 	{Key: ArgGithubTokenHost, Short: "GitHub hostname", Long: "GitHub hostname", Default: []string{"github.com"}},
-	{Key: CmdGlobal, Hide: true, Short: "Sets/gets the global tool version(s)", Long: "Sets/gets the global tool version(s)\n\nDisplays the contents of global config after writing.\nThe file is `$HOME/.config/mise/config.toml` by default. It can be changed with `$MISE_GLOBAL_CONFIG_FILE`.\nIf `$MISE_GLOBAL_CONFIG_FILE` is set to anything that ends in `.toml`, it will be parsed as `mise.toml`.\nOtherwise, it will be parsed as a `.tool-versions` file.\n\nUse MISE_ASDF_COMPAT=1 to default the global config to ~/.tool-versions\n\nUse `mise local` to set a tool version locally in the current directory.", AfterLongHelp: "Examples:\n    # set the current version of node to 20.x\n    # will use a fuzzy version (e.g.: 20) in .tool-versions file\n    $ mise global --fuzzy node@20\n\n    # set the current version of node to 20.x\n    # will use a precise version (e.g.: 20.0.0) in .tool-versions file\n    $ mise global --pin node@20\n\n    # show the current version of node in ~/.tool-versions\n    $ mise global node\n    20.0.0\n"},
+	{Key: CmdGlobal, Hide: true, Short: "Sets/gets the global tool version(s)", Long: "Sets/gets the global tool version(s)\n\nDisplays the contents of global config after writing.\nThe file is `$HOME/.config/mise/config.toml` by default. It can be changed with `$MISE_GLOBAL_CONFIG_FILE`.\nIf `$MISE_GLOBAL_CONFIG_FILE` is set to anything that ends in `.toml`, it will be parsed as `mise.toml`.\nOtherwise, it will be parsed as a `.tool-versions` file.\n\nUse MISE_ASDF_COMPAT=1 to default the global config to ~/.tool-versions\n\nUse `mise local` to set a tool version locally in the current directory.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n    # set the current version of node to 20.x\n    # will use a fuzzy version (e.g.: 20) in .tool-versions file\n    $ \x1b[1mmise global --fuzzy node@20\x1b[22m\n\n    # set the current version of node to 20.x\n    # will use a precise version (e.g.: 20.0.0) in .tool-versions file\n    $ \x1b[1mmise global --pin node@20\x1b[22m\n\n    # show the current version of node in ~/.tool-versions\n    $ \x1b[1mmise global node\x1b[22m\n    20.0.0\n"},
 	{Key: FlagGlobalFuzzy, Short: "Save fuzzy version to `~/.tool-versions`\ne.g.: `mise global --fuzzy node@20` will save `node 20` to ~/.tool-versions\nthis is the default behavior unless MISE_ASDF_COMPAT=1", Long: "Save fuzzy version to `~/.tool-versions`\ne.g.: `mise global --fuzzy node@20` will save `node 20` to ~/.tool-versions\nthis is the default behavior unless MISE_ASDF_COMPAT=1"},
 	{Key: FlagGlobalPath, Short: "Get the path of the global config file", Long: "Get the path of the global config file"},
 	{Key: FlagGlobalPin, Short: "Save exact version to `~/.tool-versions`\ne.g.: `mise global --pin node@20` will save `node 20.0.0` to ~/.tool-versions", Long: "Save exact version to `~/.tool-versions`\ne.g.: `mise global --pin node@20` will save `node 20.0.0` to ~/.tool-versions"},
@@ -5315,78 +5363,79 @@ var HelpText = argv.HelpTable{
 	{Key: CmdHookEnv, Hide: true, Short: "[internal] called by activate hook to update env vars directory change"},
 	{Key: FlagHookEnvForce, Short: "Skip early exit check", Long: "Skip early exit check"},
 	{Key: FlagHookEnvQuiet, Short: "Hide warnings such as when a tool is not installed", Long: "Hide warnings such as when a tool is not installed"},
-	{Key: FlagHookEnvShell, ValueName: "SHELL", ValueDemanded: true, Short: "Shell type to generate script for", Long: "Shell type to generate script for", Choices: []string{"bash", "elvish", "fish", "nu", "xonsh", "zsh", "pwsh"}},
+	{Key: FlagHookEnvShell, ValueName: "SHELL", ValueDemanded: true, Short: "Shell type to generate script for", Long: "Shell type to generate script for"},
 	{Key: FlagHookEnvReason, Hide: true, ValueName: "REASON", ValueDemanded: true, Short: "Reason for calling hook-env (e.g., \"precmd\", \"chpwd\")", Long: "Reason for calling hook-env (e.g., \"precmd\", \"chpwd\")", Choices: []string{"precmd", "chpwd"}},
 	{Key: FlagHookEnvStatus, Hide: true, Short: "Show \"mise: <TOOL>@<VERSION>\" message when changing directories", Long: "Show \"mise: <TOOL>@<VERSION>\" message when changing directories"},
 	{Key: CmdHookNotFound, Hide: true, Short: "[internal] called by shell when a command is not found"},
-	{Key: FlagHookNotFoundShell, ValueName: "SHELL", ValueDemanded: true, Short: "Shell type to generate script for", Long: "Shell type to generate script for", Choices: []string{"bash", "elvish", "fish", "nu", "xonsh", "zsh", "pwsh"}},
+	{Key: FlagHookNotFoundShell, ValueName: "SHELL", ValueDemanded: true, Short: "Shell type to generate script for", Long: "Shell type to generate script for"},
 	{Key: ArgHookNotFoundBin, Demanded: true, Short: "Attempted bin to run", Long: "Attempted bin to run"},
 	{Key: CmdImplode, Short: "Removes mise CLI and all related data", Long: "Removes mise CLI and all related data\n\nSkips config directory by default."},
 	{Key: FlagImplodeDryRun, Short: "List directories that would be removed without actually removing them", Long: "List directories that would be removed without actually removing them"},
 	{Key: FlagImplodeConfig, Short: "Also remove config directory", Long: "Also remove config directory"},
-	{Key: CmdEdit, Short: "Edit mise.toml interactively", AfterLongHelp: "Examples:\n\n    $ mise edit             # edit mise.toml interactively\n    $ mise edit .mise.toml  # edit a specific file\n    $ mise edit -g          # edit the global config file\n    $ mise edit -y          # skip interactive editor\n    $ mise edit -n          # preview without writing\n"},
+	{Key: CmdEdit, Short: "Edit mise.toml interactively", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise edit\x1b[22m             \x1b[2m# edit mise.toml interactively\x1b[22m\n    $ \x1b[1mmise edit .mise.toml\x1b[22m  \x1b[2m# edit a specific file\x1b[22m\n    $ \x1b[1mmise edit -g\x1b[22m          \x1b[2m# edit the global config file\x1b[22m\n    $ \x1b[1mmise edit -y\x1b[22m          \x1b[2m# skip interactive editor\x1b[22m\n    $ \x1b[1mmise edit -n\x1b[22m          \x1b[2m# preview without writing\x1b[22m\n"},
 	{Key: FlagEditGlobal, Short: "Edit the global config file (~/.config/mise/config.toml)", Long: "Edit the global config file (~/.config/mise/config.toml)"},
 	{Key: FlagEditDryRun, Short: "Show what would be generated without writing to file", Long: "Show what would be generated without writing to file"},
 	{Key: FlagEditToolVersions, ValueName: "TOOL_VERSIONS", ValueDemanded: true, Short: "Path to a .tool-versions file to import tools from", Long: "Path to a .tool-versions file to import tools from"},
 	{Key: ArgEditPath, Short: "Path to the config file to create", Long: "Path to the config file to create"},
-	{Key: CmdInstall, Short: "Install a tool version", Long: "Install a tool version\n\nInstalls a tool version to `~/.local/share/mise/installs/<TOOL>/<VERSION>`\nInstalling alone will not activate the tools so they won't be in PATH.\nTo install and/or activate in one command, use `mise use` which will create a `mise.toml` file\nin the current directory to activate this tool when inside the directory.\nAlternatively, run `mise exec <TOOL>@<VERSION> -- <COMMAND>` to execute a tool without creating config files.\n\nTools will be installed in parallel. To disable, set `--jobs=1` or `MISE_JOBS=1`", VisibleAliases: []string{"i"}, AfterLongHelp: "Examples:\n\n    $ mise install node@20.0.0  # install specific node version\n    $ mise install node@20      # install fuzzy node version\n    $ mise install node         # install version specified in mise.toml\n    $ mise install              # installs everything specified in mise.toml\n"},
-	{Key: FlagInstallForce, Short: "Force reinstall even if already installed", Long: "Force reinstall even if already installed"},
-	{Key: FlagInstallJobs, ValueName: "JOBS", ValueDemanded: true, Short: "Number of jobs to run in parallel\n[default: 4]", Long: "Number of jobs to run in parallel\n[default: 4]"},
+	{Key: CmdInstall, Short: "Install a tool version", Long: "Install a tool version\n\nInstalls a tool version to `~/.local/share/mise/installs/<TOOL>/<VERSION>`\nInstalling alone will not activate the tools so they won't be in PATH.\nTo install and/or activate in one command, use `mise use` which will create a `mise.toml` file\nin the current directory to activate this tool when inside the directory.\nAlternatively, run `mise exec <TOOL>@<VERSION> -- <COMMAND>` to execute a tool without creating config files.\n\nTools will be installed in parallel. To disable, set `--jobs=1` or `MISE_JOBS=1`", VisibleAliases: []string{"i"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise install node@20.0.0\x1b[22m  # install specific node version\n    $ \x1b[1mmise install node@20\x1b[22m      # install fuzzy node version\n    $ \x1b[1mmise install node\x1b[22m         # install version specified in mise.toml\n    $ \x1b[1mmise install\x1b[22m              # installs everything specified in mise.toml\n    $ \x1b[1mmise install --include-task-tools\x1b[22m # also install tools required by tasks\n"},
+	{Key: FlagInstallForce, Short: "Force reinstall even if already installed\nWith no tools specified, reinstall all configured tools", Long: "Force reinstall even if already installed\nWith no tools specified, reinstall all configured tools"},
+	{Key: FlagInstallJobs, ValueName: "JOBS", ValueDemanded: true, Short: "Number of jobs to run in parallel\nValues below 1 are treated as 1\n[default: 4]", Long: "Number of jobs to run in parallel\nValues below 1 are treated as 1\n[default: 4]", Env: "MISE_JOBS"},
 	{Key: FlagInstallDryRun, Short: "Show what would be installed without actually installing", Long: "Show what would be installed without actually installing"},
 	{Key: FlagInstallVerbose, Repeatable: true, Short: "Show installation output", Long: "Show installation output\n\nThis argument will print backend output such as download, configuration, and compilation output."},
 	{Key: FlagInstallDryRunCode, Short: "Like --dry-run but exits with code 1 if there are tools to install", Long: "Like --dry-run but exits with code 1 if there are tools to install\n\nThis is useful for scripts to check if tools need to be installed."},
+	{Key: FlagInstallIncludeTaskTools, Short: "Also install tools required by tasks in the current scope", Long: "Also install tools required by tasks in the current scope\n\nThis prepares task tools without running task commands or dependencies.\nCombine with --monorepo to include tasks from every configured root."},
 	{Key: FlagInstallMinimumReleaseAge, ValueName: "MINIMUM_RELEASE_AGE", ValueDemanded: true, Short: "Only install versions released before this date or older than this duration", Long: "Only install versions released before this date or older than this duration\n\nSupports absolute dates like \"2024-06-01\" and relative durations like \"90d\" or \"1y\"."},
-	{Key: FlagInstallMonorepo, Short: "Install tools from every [monorepo].config_roots config root", Long: "Install tools from every [monorepo].config_roots config root\n\nUses the active MISE_ENV and requires monorepo_root = true plus explicit\n[monorepo].config_roots in the monorepo root config."},
-	{Key: FlagInstallRaw, Short: "Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1", Long: "Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1"},
+	{Key: FlagInstallMonorepo, Short: "Install tools from every [monorepo].config_roots config root", Long: "Install tools from every [monorepo].config_roots config root\n\nUses the active MISE_ENV and requires monorepo_root = true plus explicit\n[monorepo].config_roots in the monorepo root config.", Env: "MISE_MONOREPO"},
+	{Key: FlagInstallRaw, Short: "Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1", Long: "Connect backend install command stdin/stdout/stderr directly to the terminal\nImplies --jobs=1"},
 	{Key: FlagInstallShared, ValueName: "SHARED", ValueDemanded: true, Short: "Install tool(s) to a shared directory", Long: "Install tool(s) to a shared directory\n\nInstalls to the specified directory instead of the default install location.\nMay require elevated permissions depending on the path."},
 	{Key: FlagInstallSystem, Short: "Install tool(s) to the system-wide shared directory", Long: "Install tool(s) to the system-wide shared directory\n\nInstalls to /usr/local/share/mise/installs (or MISE_SYSTEM_DATA_DIR/installs).\nMay require elevated permissions (e.g. sudo)."},
-	{Key: ArgInstallToolVersion, Short: "Tool(s) to install e.g.: node@20", Long: "Tool(s) to install e.g.: node@20"},
-	{Key: CmdInstallInto, Short: "Install a tool version to a specific path", Long: "Install a tool version to a specific path\n\nUsed for building a tool to a directory for use outside of mise", AfterLongHelp: "Examples:\n\n    # install node@20.0.0 into ./mynode\n    $ mise install-into node@20.0.0 ./mynode && ./mynode/bin/node -v\n    20.0.0\n"},
-	{Key: ArgInstallIntoToolVersion, Demanded: true, Short: "Tool to install e.g.: node@20", Long: "Tool to install e.g.: node@20"},
+	{Key: ArgInstallToolVersion, Short: "Tool(s) to install e.g.: node@20", Long: "Tool(s) to install\ne.g.: node@20"},
+	{Key: CmdInstallInto, Short: "Install a tool version to a specific path", Long: "Install a tool version to a specific path\n\nUsed for building a tool to a directory for use outside of mise", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    # install node@20.0.0 into ./mynode\n    $ \x1b[1mmise install-into node@20.0.0 ./mynode && ./mynode/bin/node -v\x1b[22m\n    20.0.0\n"},
+	{Key: ArgInstallIntoToolVersion, Demanded: true, Short: "Tool to install e.g.: node@20", Long: "Tool to install\ne.g.: node@20"},
 	{Key: ArgInstallIntoPath, Demanded: true, Short: "Path to install the tool into", Long: "Path to install the tool into"},
-	{Key: CmdLatest, Short: "Gets the latest available version for a plugin", Long: "Gets the latest available version for a plugin\n\nSupports prefixes such as `node@20` to get the latest version of node 20.", AfterLongHelp: "Examples:\n\n    $ mise latest node@20  # get the latest version of node 20\n    20.0.0\n\n    $ mise latest node     # get the latest stable version of node\n    20.0.0\n\n    $ mise latest node --minimum-release-age 2024-01-01  # latest stable node released before 2024-01-01\n"},
+	{Key: CmdLatest, Short: "Gets the latest available version for a plugin", Long: "Gets the latest available version for a plugin\n\nSupports prefixes such as `node@20` to get the latest version of node 20.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise latest node@20\x1b[22m  # get the latest version of node 20\n    20.0.0\n\n    $ \x1b[1mmise latest node\x1b[22m     # get the latest stable version of node\n    20.0.0\n\n    $ \x1b[1mmise latest node --minimum-release-age 2024-01-01\x1b[22m  # latest stable node released before 2024-01-01\n"},
 	{Key: FlagLatestInstalled, Short: "Show latest installed instead of available version", Long: "Show latest installed instead of available version"},
 	{Key: FlagLatestMinimumReleaseAge, ValueName: "MINIMUM_RELEASE_AGE", ValueDemanded: true, Short: "Only consider versions released before this date or older than this duration", Long: "Only consider versions released before this date or older than this duration\n\nSupports absolute dates like \"2024-06-01\" and relative durations like \"90d\" or \"1y\".\nOverrides per-tool `minimum_release_age` options and the global `minimum_release_age` setting."},
 	{Key: ArgLatestToolVersion, Demanded: true, Short: "Tool to get the latest version of", Long: "Tool to get the latest version of"},
-	{Key: ArgLatestAsdfVersion, Hide: true, Short: "The version prefix to use when querying the latest version same as the first argument after the \"@\" used for asdf compatibility", Long: "The version prefix to use when querying the latest version same as the first argument after the \"@\" used for asdf compatibility"},
-	{Key: CmdLink, Short: "Symlinks a tool version into mise", Long: "Symlinks a tool version into mise\n\nUse this for adding installs either custom compiled outside mise or built with a different tool.", VisibleAliases: []string{"ln"}, AfterLongHelp: "Examples:\n\n    # build node-20.0.0 with node-build and link it into mise\n    $ node-build 20.0.0 ~/.nodes/20.0.0\n    $ mise link node@20.0.0 ~/.nodes/20.0.0\n\n    # have mise use the node version provided by Homebrew\n    $ brew install node\n    $ mise link node@brew $(brew --prefix node)\n    $ mise use node@brew\n"},
+	{Key: ArgLatestAsdfVersion, Hide: true, Short: "The version prefix to use when querying the latest version same as the first argument after the \"@\" used for asdf compatibility", Long: "The version prefix to use when querying the latest version\nsame as the first argument after the \"@\"\nused for asdf compatibility"},
+	{Key: CmdLink, Short: "Symlinks a tool version into mise", Long: "Symlinks a tool version into mise\n\nUse this for adding installs either custom compiled outside mise or built with a different tool.", VisibleAliases: []string{"ln"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    # build node-20.0.0 with node-build and link it into mise\n    $ \x1b[1mnode-build 20.0.0 ~/.nodes/20.0.0\x1b[22m\n    $ \x1b[1mmise link node@20.0.0 ~/.nodes/20.0.0\x1b[22m\n\n    # have mise use the node version provided by Homebrew\n    $ \x1b[1mbrew install node\x1b[22m\n    $ \x1b[1mmise link node@brew $(brew --prefix node)\x1b[22m\n    $ \x1b[1mmise use node@brew\x1b[22m\n"},
 	{Key: FlagLinkForce, Short: "Overwrite an existing tool version if it exists", Long: "Overwrite an existing tool version if it exists"},
 	{Key: ArgLinkToolVersion, Demanded: true, Short: "Tool name and version to create a symlink for", Long: "Tool name and version to create a symlink for"},
 	{Key: ArgLinkPath, Demanded: true, Short: "The local path to the tool version\ne.g.: ~/.nvm/versions/node/v20.0.0", Long: "The local path to the tool version\ne.g.: ~/.nvm/versions/node/v20.0.0"},
-	{Key: CmdLocal, Hide: true, Short: "Sets/gets tool version in local .tool-versions or mise.toml", Long: "Sets/gets tool version in local .tool-versions or mise.toml\n\nUse this to set a tool's version when within a directory\nUse `mise global` to set a tool version globally\nThis uses `.tool-version` by default unless there is a `mise.toml` file or if `MISE_USE_TOML`\nis set. A future v2 release of mise will default to using `mise.toml`.", AfterLongHelp: "Examples:\n    # set the current version of node to 20.x for the current directory\n    # will use a precise version (e.g.: 20.0.0) in .tool-versions file\n    $ mise local node@20\n\n    # set node to 20.x for the current project (recurses up to find .tool-versions)\n    $ mise local -p node@20\n\n    # set the current version of node to 20.x for the current directory\n    # will use a fuzzy version (e.g.: 20) in .tool-versions file\n    $ mise local --fuzzy node@20\n\n    # removes node from .tool-versions\n    $ mise local --remove=node\n\n    # show the current version of node in .tool-versions\n    $ mise local node\n    20.0.0\n"},
+	{Key: CmdLocal, Hide: true, Short: "Sets/gets tool version in local .tool-versions or mise.toml", Long: "Sets/gets tool version in local .tool-versions or mise.toml\n\nUse this to set a tool's version when within a directory\nUse `mise global` to set a tool version globally\nThis uses `.tool-version` by default unless there is a `mise.toml` file or if `MISE_USE_TOML`\nis set. A future v2 release of mise will default to using `mise.toml`.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n    # set the current version of node to 20.x for the current directory\n    # will use a precise version (e.g.: 20.0.0) in .tool-versions file\n    $ \x1b[1mmise local node@20\x1b[22m\n\n    # set node to 20.x for the current project (recurses up to find .tool-versions)\n    $ \x1b[1mmise local -p node@20\x1b[22m\n\n    # set the current version of node to 20.x for the current directory\n    # will use a fuzzy version (e.g.: 20) in .tool-versions file\n    $ \x1b[1mmise local --fuzzy node@20\x1b[22m\n\n    # removes node from .tool-versions\n    $ \x1b[1mmise local --remove=node\x1b[22m\n\n    # show the current version of node in .tool-versions\n    $ \x1b[1mmise local node\x1b[22m\n    20.0.0\n"},
 	{Key: FlagLocalParent, Short: "Recurse up to find a .tool-versions file rather than using the current directory only\nby default this command will only set the tool in the current directory (\"$PWD/.tool-versions\")", Long: "Recurse up to find a .tool-versions file rather than using the current directory only\nby default this command will only set the tool in the current directory (\"$PWD/.tool-versions\")"},
-	{Key: FlagLocalFuzzy, Short: "Save fuzzy version to `.tool-versions` e.g.: `mise local --fuzzy node@20` will save `node 20` to .tool-versions This is the default behavior unless MISE_ASDF_COMPAT=1", Long: "Save fuzzy version to `.tool-versions` e.g.: `mise local --fuzzy node@20` will save `node 20` to .tool-versions This is the default behavior unless MISE_ASDF_COMPAT=1"},
+	{Key: FlagLocalFuzzy, Short: "Save fuzzy version to `.tool-versions` e.g.: `mise local --fuzzy node@20` will save `node 20` to .tool-versions This is the default behavior unless MISE_ASDF_COMPAT=1", Long: "Save fuzzy version to `.tool-versions`\ne.g.: `mise local --fuzzy node@20` will save `node 20` to .tool-versions\nThis is the default behavior unless MISE_ASDF_COMPAT=1"},
 	{Key: FlagLocalPath, Short: "Get the path of the config file", Long: "Get the path of the config file"},
 	{Key: FlagLocalPin, Short: "Save exact version to `.tool-versions`\ne.g.: `mise local --pin node@20` will save `node 20.0.0` to .tool-versions", Long: "Save exact version to `.tool-versions`\ne.g.: `mise local --pin node@20` will save `node 20.0.0` to .tool-versions"},
 	{Key: FlagLocalRemove, Repeatable: true, ValueName: "TOOL", ValueDemanded: true, Short: "Remove the tool(s) from .tool-versions", Long: "Remove the tool(s) from .tool-versions"},
 	{Key: ArgLocalToolVersion, Short: "Tool(s) to add to .tool-versions/mise.toml\ne.g.: node@20\nif this is a single tool with no version,\nthe current value of .tool-versions/mise.toml will be displayed", Long: "Tool(s) to add to .tool-versions/mise.toml\ne.g.: node@20\nif this is a single tool with no version,\nthe current value of .tool-versions/mise.toml will be displayed"},
-	{Key: CmdLock, Short: "Update lockfile checksums and URLs for all specified platforms", Long: "Update lockfile checksums and URLs for all specified platforms\n\nUpdates checksums and download URLs for all platforms already specified in the lockfile.\nIf no lockfile exists, shows what would be created based on the current configuration.\nThis allows you to refresh lockfile data for platforms other than the one you're currently on.\nOperates on the lockfile in the current config root. Use TOOL arguments to target specific tools.", AfterLongHelp: "Examples:\n\n    $ mise lock                       # update lockfile for all common platforms\n    $ mise lock node python           # update only node and python\n    $ mise lock --platform linux-x64  # update only linux-x64 platform\n    $ mise lock --dry-run             # show what would be updated\n    $ mise lock --bump                # re-resolve selectors like \"latest\" or \"20\" to the latest matching versions\n    $ mise lock --bump --dry-run --json   # list available updates as JSON without writing\n    $ mise lock --minimum-release-age 2024-01-01   # lock latest/fuzzy versions released before 2024-01-01\n    $ mise lock --local               # update mise.local.lock for local configs\n    $ mise lock --global              # update only global config lockfiles\n"},
+	{Key: CmdLock, Short: "Update lockfile checksums and URLs for all specified platforms", Long: "Update lockfile checksums and URLs for all specified platforms\n\nUpdates checksums and download URLs for all platforms already specified in the lockfile.\nIf no lockfile exists, shows what would be created based on the current configuration,\nincluding tools declared by tasks.\nThis allows you to refresh lockfile data for platforms other than the one you're currently on.\nOperates on the lockfile in the current config root. Use TOOL arguments to target specific tools.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise lock\x1b[22m                       # update lockfile for all common platforms\n    $ \x1b[1mmise lock node python\x1b[22m           # update only node and python\n    $ \x1b[1mmise lock --platform linux-x64\x1b[22m  # update only linux-x64 platform\n    $ \x1b[1mmise lock --dry-run\x1b[22m             # show what would be updated\n    $ \x1b[1mmise lock --bump\x1b[22m                # re-resolve selectors like \"latest\" or \"20\" to the latest matching versions\n    $ \x1b[1mmise lock --bump --dry-run --json\x1b[22m   # list available updates as JSON without writing\n    $ \x1b[1mmise lock --minimum-release-age 2024-01-01\x1b[22m   # lock latest/fuzzy versions released before 2024-01-01\n    $ \x1b[1mmise lock --local\x1b[22m               # update mise.local.lock for local configs\n    $ \x1b[1mmise lock --global\x1b[22m              # update only global config lockfiles\n"},
 	{Key: FlagLockGlobal, Short: "Target only global config lockfiles (~/.config/mise/mise.lock and system config)\nBy default, only the active project config root is locked", Long: "Target only global config lockfiles (~/.config/mise/mise.lock and system config)\nBy default, only the active project config root is locked"},
-	{Key: FlagLockJobs, ValueName: "JOBS", ValueDemanded: true, Short: "Number of jobs to run in parallel", Long: "Number of jobs to run in parallel"},
+	{Key: FlagLockJobs, ValueName: "JOBS", ValueDemanded: true, Short: "Number of jobs to run in parallel\nValues below 1 are treated as 1", Long: "Number of jobs to run in parallel\nValues below 1 are treated as 1", Env: "MISE_JOBS"},
 	{Key: FlagLockDryRun, Short: "Show what would be updated without making changes", Long: "Show what would be updated without making changes"},
 	{Key: FlagLockPlatform, Repeatable: true, ValueName: "PLATFORM", ValueDemanded: true, Short: "Comma-separated list of platforms to target\ne.g.: linux-x64,macos-arm64,windows-x64\nIf not specified, all platforms already in lockfile will be updated", Long: "Comma-separated list of platforms to target\ne.g.: linux-x64,macos-arm64,windows-x64\nIf not specified, all platforms already in lockfile will be updated"},
 	{Key: FlagLockBump, Short: "Re-resolve fuzzy version selectors against the latest available versions", Long: "Re-resolve fuzzy version selectors against the latest available versions\n\nBy default, `mise lock` refreshes metadata for the currently locked versions.\nWith this flag, selectors like \"latest\", \"lts\", or prefixes like \"20\" are\nre-resolved against the latest matching remote versions, so the lockfile\nadvances without installing anything. Config files are never modified:\nexactly pinned versions resolve to themselves and stay unchanged\n(use `mise upgrade --bump` to rewrite pins in mise.toml)."},
 	{Key: FlagLockJson, Short: "Output version changes as JSON", Long: "Output version changes as JSON\n\nPrints an array of objects describing lockfile version changes:\nname, backend, lockfile, old_versions, new_versions.\nVersion lists keep config/lockfile order; they are not sorted.\nOnly version-level changes are reported: checksum/URL refreshes for\nunchanged versions produce no entries, so plain `mise lock --json`\ntypically prints `[]` while still updating the lockfile.\nSuppresses the human-readable output. Combine with `--dry-run` to\ndetect available updates without writing the lockfile."},
 	{Key: FlagLockLocal, Short: "Update mise.local.lock instead of mise.lock\nUse for tools defined in .local.toml configs", Long: "Update mise.local.lock instead of mise.lock\nUse for tools defined in .local.toml configs"},
 	{Key: FlagLockMinimumReleaseAge, ValueName: "MINIMUM_RELEASE_AGE", ValueDemanded: true, Short: "Only lock versions released before this age or date", Long: "Only lock versions released before this age or date\n\nSupports absolute dates like \"2024-06-01\" and relative durations like \"90d\" or \"1y\".\nThis only affects fuzzy version matches like \"20\" or \"latest\".\nExplicitly pinned versions like \"22.5.0\" are not filtered.\nExisting matching lockfile entries are preserved and are not downgraded solely by this flag."},
-	{Key: ArgLockTool, Short: "Tool(s) to update in lockfile\ne.g.: node python\nIf not specified, all tools in lockfile will be updated", Long: "Tool(s) to update in lockfile\ne.g.: node python\nIf not specified, all tools in lockfile will be updated"},
-	{Key: CmdLs, Short: "List installed and active tool versions", Long: "List installed and active tool versions\n\nThis command lists tools that mise \"knows about\".\nThese may be tools that are currently installed, or those\nthat are in a config file (active) but may or may not be installed.\n\nIt's a useful command to get the current state of your tools.", VisibleAliases: []string{"list"}, AfterLongHelp: "Examples:\n\n    $ mise ls\n    node    20.0.0 ~/src/myapp/.tool-versions latest\n    python  3.11.0 ~/.tool-versions           3.10\n    python  3.10.0\n\n    $ mise ls --current\n    node    20.0.0 ~/src/myapp/.tool-versions 20\n    python  3.11.0 ~/.tool-versions           3.11.0\n\n    $ mise ls --json\n    {\n      \"node\": [\n        {\n          \"version\": \"20.0.0\",\n          \"install_path\": \"/Users/jdx/.mise/installs/node/20.0.0\",\n          \"source\": {\n            \"type\": \"mise.toml\",\n            \"path\": \"/Users/jdx/mise.toml\"\n          }\n        }\n      ],\n      \"python\": [...]\n    }\n\n    $ mise ls --all-sources\n    node    20.0.0  ~/src/myapp/mise.toml  20\n                    ~/.config/mise/config.toml  latest\n"},
+	{Key: ArgLockTool, Short: "Tool(s) to update in lockfile\ne.g.: node python\nIf not specified, all configured and task-specific tools will be updated", Long: "Tool(s) to update in lockfile\ne.g.: node python\nIf not specified, all configured and task-specific tools will be updated"},
+	{Key: CmdLs, Short: "List installed and active tool versions", Long: "List installed and active tool versions\n\nThis command lists tools that mise \"knows about\".\nThese may be tools that are currently installed, or those\nthat are in a config file (active) but may or may not be installed.\n\nIt's a useful command to get the current state of your tools.", VisibleAliases: []string{"list"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise ls\x1b[22m\n    node    20.0.0 ~/src/myapp/.tool-versions latest\n    python  3.11.0 ~/.tool-versions           3.10\n    python  3.10.0\n\n    $ \x1b[1mmise ls --current\x1b[22m\n    node    20.0.0 ~/src/myapp/.tool-versions 20\n    python  3.11.0 ~/.tool-versions           3.11.0\n\n    $ \x1b[1mmise ls --json\x1b[22m\n    {\n      \"node\": [\n        {\n          \"version\": \"20.0.0\",\n          \"install_path\": \"/Users/jdx/.mise/installs/node/20.0.0\",\n          \"source\": {\n            \"type\": \"mise.toml\",\n            \"path\": \"/Users/jdx/mise.toml\"\n          }\n        }\n      ],\n      \"python\": [...]\n    }\n\n    $ \x1b[1mmise ls --all-sources\x1b[22m\n    node    20.0.0  ~/src/myapp/mise.toml  20\n                    ~/.config/mise/config.toml  latest\n"},
 	{Key: FlagLsCurrent, Short: "Only show tool versions currently specified in a mise.toml", Long: "Only show tool versions currently specified in a mise.toml"},
 	{Key: FlagLsGlobal, Short: "Only show tool versions currently specified in the global mise.toml", Long: "Only show tool versions currently specified in the global mise.toml"},
-	{Key: FlagLsInstalled, Short: "Only show tool versions that are installed (Hides tools defined in mise.toml but not installed)", Long: "Only show tool versions that are installed (Hides tools defined in mise.toml but not installed)"},
+	{Key: FlagLsInstalled, Short: "Only show tool versions that are installed (Hides tools defined in mise.toml but not installed)", Long: "Only show tool versions that are installed\n(Hides tools defined in mise.toml but not installed)"},
 	{Key: FlagLsJson, Short: "Output in JSON format", Long: "Output in JSON format"},
 	{Key: FlagLsLocal, Short: "Only show tool versions currently specified in the local mise.toml", Long: "Only show tool versions currently specified in the local mise.toml"},
 	{Key: FlagLsMissing, Short: "Display missing tool versions", Long: "Display missing tool versions"},
 	{Key: FlagLsOffline, Hide: true, Short: "Don't fetch information such as outdated versions", Long: "Don't fetch information such as outdated versions"},
-	{Key: FlagLsPlugin, Hide: true, ValueName: "TOOL_FLAG", ValueDemanded: true},
+	{Key: FlagLsPlugin, Hide: true, ValueName: "PLUGIN", ValueDemanded: true},
 	{Key: FlagLsAllSources, Short: "Display all tracked config sources for tools", Long: "Display all tracked config sources for tools"},
-	{Key: FlagLsMonorepo, Short: "List tools from every [monorepo].config_roots config root", Long: "List tools from every [monorepo].config_roots config root\n\nUses the active MISE_ENV and requires monorepo_root = true plus explicit\n[monorepo].config_roots in the monorepo root config."},
+	{Key: FlagLsMonorepo, Short: "List tools from every [monorepo].config_roots config root", Long: "List tools from every [monorepo].config_roots config root\n\nUses the active MISE_ENV and requires monorepo_root = true plus explicit\n[monorepo].config_roots in the monorepo root config.", Env: "MISE_MONOREPO"},
 	{Key: FlagLsNoHeader, Short: "Don't display headers", Long: "Don't display headers"},
 	{Key: FlagLsOutdated, Short: "Display whether a version is outdated", Long: "Display whether a version is outdated"},
 	{Key: FlagLsPrefix, ValueName: "PREFIX", ValueDemanded: true, Short: "Display versions matching this prefix", Long: "Display versions matching this prefix"},
 	{Key: FlagLsPrunable, Short: "List only tools that can be pruned with `mise prune`", Long: "List only tools that can be pruned with `mise prune`"},
 	{Key: ArgLsInstalledTool, Short: "Only show tool versions from [TOOL]", Long: "Only show tool versions from [TOOL]"},
-	{Key: CmdLsRemote, Short: "List runtime versions available for install.", Long: "List runtime versions available for install.\n\nNote that the results may be cached, run `mise cache clean` to clear the cache and get fresh results.", AfterLongHelp: "Examples:\n\n    $ mise ls-remote node\n    18.0.0\n    20.0.0\n\n    $ mise ls-remote node@20\n    20.0.0\n    20.1.0\n\n    $ mise ls-remote node 20\n    20.0.0\n    20.1.0\n\n    $ mise ls-remote node --minimum-release-age 2024-01-01\n    20.0.0\n\n    $ mise ls-remote github:cli/cli --json\n    [{\"version\":\"2.62.0\",\"created_at\":\"2024-11-14T15:40:35Z\",\"prerelease\":false},{\"version\":\"2.61.0\",\"created_at\":\"2024-10-23T19:22:15Z\",\"prerelease\":false}]\n"},
+	{Key: CmdLsRemote, Short: "List runtime versions available for install.", Long: "List runtime versions available for install.\n\nNote that the results may be cached, run `mise cache clean` to clear the cache and get fresh results.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise ls-remote node\x1b[22m\n    18.0.0\n    20.0.0\n\n    $ \x1b[1mmise ls-remote node@20\x1b[22m\n    20.0.0\n    20.1.0\n\n    $ \x1b[1mmise ls-remote node 20\x1b[22m\n    20.0.0\n    20.1.0\n\n    $ \x1b[1mmise ls-remote node --minimum-release-age 2024-01-01\x1b[22m\n    20.0.0\n\n    $ \x1b[1mmise ls-remote github:cli/cli --json\x1b[22m\n    [{\"version\":\"2.62.0\",\"created_at\":\"2024-11-14T15:40:35Z\",\"prerelease\":false},{\"version\":\"2.61.0\",\"created_at\":\"2024-10-23T19:22:15Z\",\"prerelease\":false}]\n"},
 	{Key: FlagLsRemoteAll, Short: "Show all installed plugins and versions", Long: "Show all installed plugins and versions"},
 	{Key: FlagLsRemoteMinimumReleaseAge, ValueName: "MINIMUM_RELEASE_AGE", ValueDemanded: true, Short: "Only show versions released before this age or date", Long: "Only show versions released before this age or date\n\nSupports absolute dates like \"2024-06-01\" and relative durations like \"90d\" or \"1y\"."},
 	{Key: FlagLsRemoteJson, Short: "Output in JSON format (includes version metadata like created_at timestamps when available)", Long: "Output in JSON format (includes version metadata like created_at timestamps when available)"},
@@ -5395,52 +5444,53 @@ var HelpText = argv.HelpTable{
 	{Key: FlagLsRemoteStrictMetadata, Short: "Fail if release metadata fetches fail", Long: "Fail if release metadata fetches fail\n\nRequires --json and --no-versions-host.\n\nThis prevents metadata consumers from accepting empty fallback results\nwhen a backend's metadata-producing upstream request fails."},
 	{Key: ArgLsRemoteToolVersion, Short: "Tool to get versions for", Long: "Tool to get versions for"},
 	{Key: ArgLsRemotePrefix, Short: "The version prefix to use when querying the latest version\nsame as the first argument after the \"@\"", Long: "The version prefix to use when querying the latest version\nsame as the first argument after the \"@\""},
-	{Key: CmdMcp, Short: "Run Model Context Protocol (MCP) server", Long: "Run Model Context Protocol (MCP) server\n\nThis command starts an MCP server that exposes mise functionality\nto AI assistants over stdin/stdout using JSON-RPC protocol.\n\nThe MCP server provides access to:\n- Installed and available tools\n- Task definitions and execution\n- Environment variables\n- Configuration information\n- Task execution via the run_task tool\n\nResources available:\n- mise://tools - List all tools (use ?include_inactive=true to include inactive tools)\n- mise://tasks - List all tasks with their configurations\n- mise://env - List all environment variables\n- mise://config - Show configuration files and project root\n\nTools available:\n- list_commands - Every mise command, with its declared effect on the world\n- install_tool - Install a tool with an optional version (not yet implemented)\n- run_task - Execute a mise task with optional arguments\n\nNote: This is primarily intended for integration with AI assistants like Claude,\nCursor, or other tools that support the Model Context Protocol.", AfterLongHelp: "Examples:\n\n    # Start the MCP server (typically used by AI assistant tools)\n    $ mise mcp\n\n    # Example integration with Claude Desktop (add to claude_desktop_config.json):\n    {\n      \"mcpServers\": {\n        \"mise\": {\n          \"command\": \"mise\",\n          \"args\": [\"mcp\"],\n          \"env\": {}\n        }\n      }\n    }\n\n    # Interactive testing with JSON-RPC commands:\n    $ echo '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{},\"clientInfo\":{\"name\":\"test\",\"version\":\"1.0\"}}}' | mise mcp\n\n    # Resources you can query:\n    - mise://tools - List active tools\n    - mise://tools?include_inactive=true - List all installed tools\n    - mise://tasks - List all tasks\n    - mise://env - List environment variables\n    - mise://config - Show configuration info\n\n    # Tools available:\n    - list_commands - Every mise command and what running it does\n      Example: {\"include_hidden\": false}\n    - install_tool - Install a tool (not yet implemented)\n    - run_task - Execute a mise task with optional arguments\n      Example: {\"task\": \"build\", \"args\": [\"--verbose\"]}\n"},
+	{Key: CmdMcp, Short: "Run Model Context Protocol (MCP) server", Long: "Run Model Context Protocol (MCP) server\n\nThis command starts an MCP server that exposes mise functionality\nto AI assistants over stdin/stdout using JSON-RPC protocol.\n\nThe MCP server provides access to:\n- Installed and available tools\n- Task definitions and execution\n- Environment variables\n- Configuration information\n- Task execution via the run_task tool\n\nResources available:\n- mise://tools - List all tools (use ?include_inactive=true to include inactive tools)\n- mise://tasks - List all tasks with their configurations\n- mise://env - List all environment variables\n- mise://config - Show configuration files and project root\n\nTools available:\n- list_commands - Every mise command, with its declared effect on the world\n- install_tool - Install a tool with an optional version (not yet implemented)\n- run_task - Execute a mise task with optional arguments\n\nNote: This is primarily intended for integration with AI assistants like Claude,\nCursor, or other tools that support the Model Context Protocol.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    # Start the MCP server (typically used by AI assistant tools)\n    $ \x1b[1mmise mcp\x1b[22m\n\n    # Example integration with Claude Desktop (add to claude_desktop_config.json):\n    {\n      \"mcpServers\": {\n        \"mise\": {\n          \"command\": \"mise\",\n          \"args\": [\"mcp\"],\n          \"env\": {}\n        }\n      }\n    }\n\n    # Interactive testing with JSON-RPC commands:\n    $ \x1b[1mecho '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{},\"clientInfo\":{\"name\":\"test\",\"version\":\"1.0\"}}}' | mise mcp\x1b[22m\n\n    # Resources you can query:\n    - \x1b[1mmise://tools\x1b[22m - List active tools\n    - \x1b[1mmise://tools?include_inactive=true\x1b[22m - List all installed tools\n    - \x1b[1mmise://tasks\x1b[22m - List all tasks\n    - \x1b[1mmise://env\x1b[22m - List environment variables\n    - \x1b[1mmise://config\x1b[22m - Show configuration info\n\n    # Tools available:\n    - \x1b[1mlist_commands\x1b[22m - Every mise command and what running it does\n      Example: {\"include_hidden\": false}\n    - \x1b[1minstall_tool\x1b[22m - Install a tool (not yet implemented)\n    - \x1b[1mrun_task\x1b[22m - Execute a mise task with optional arguments\n      Example: {\"task\": \"build\", \"args\": [\"--verbose\"]}\n"},
 	{Key: CmdOci, Short: "[experimental] Build OCI container images from a mise.toml", Long: "[experimental] Build OCI container images from a mise.toml\n\nEach tool becomes its own OCI layer, so bumping any single tool version\nonly invalidates one content-addressable blob — unlike a Dockerfile where\nchanging an early `RUN` invalidates every layer above it.\n\nThis command is experimental and requires `mise settings experimental=true`\n(or `MISE_EXPERIMENTAL=1`). Behavior, flags, and output layout may change\nin future releases.", SubcommandRequired: true},
-	{Key: CmdOciBuild, Short: "[experimental] Build an OCI image from the current mise.toml", Long: "[experimental] Build an OCI image from the current mise.toml\n\nEach tool version becomes its own content-addressable OCI layer. Bumping a\ntool version only invalidates that tool's layer — other tools, the base\nimage, and config are reused unchanged. The output directory conforms to\nthe OCI image-layout spec and can be consumed by `skopeo`, `crane`, or\n`podman load`.\n\nRequires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`).", AfterLongHelp: "Examples:\n\n    Build with defaults (debian:bookworm-slim base):\n    $ mise oci build\n\n    Build with a specific base image and tag:\n    $ mise oci build --from ubuntu:24.04 --tag myorg/dev:latest -o ./img\n\n    Inspect the result with skopeo:\n    $ skopeo inspect oci:./mise-oci\n\n    Push to a registry:\n    $ mise oci push --image-dir ./mise-oci ghcr.io/me/dev:latest\n\nNotes:\n\n    - The image only contains tools from the project's mise config (and\n      any configs at-or-below the project root). Tools from\n      `~/.config/mise/config.toml` are not included; pass --include-global\n      to package them too.\n    - asdf and vfox plugins are not supported in v1; use a different backend\n      (core, aqua, ubi, github, cargo, npm, go, pipx, spm, http) for each tool.\n    - The host mise binary is embedded at /usr/local/bin/mise by default;\n      build on the same OS/arch as your target image (or pass --no-mise).\n"},
+	{Key: CmdOciBuild, Short: "[experimental] Build an OCI image from the current mise.toml", Long: "[experimental] Build an OCI image from the current mise.toml\n\nEach tool version becomes its own content-addressable OCI layer. Bumping a\ntool version only invalidates that tool's layer — other tools, the base\nimage, and config are reused unchanged. The output directory conforms to\nthe OCI image-layout spec and can be consumed by `skopeo`, `crane`, or\n`podman load`.\n\nRequires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`).", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    Build with defaults (debian:bookworm-slim base):\n    $ \x1b[1mmise oci build\x1b[22m\n\n    Build with a specific base image and tag:\n    $ \x1b[1mmise oci build --from ubuntu:24.04 --tag myorg/dev:latest -o ./img\x1b[22m\n\n    Inspect the result with skopeo:\n    $ \x1b[1mskopeo inspect oci:./mise-oci\x1b[22m\n\n    Push to a registry:\n    $ \x1b[1mmise oci push --image-dir ./mise-oci ghcr.io/me/dev:latest\x1b[22m\n\n\x1b[1m\x1b[4mNotes:\x1b[22m\x1b[24m\n\n    - The image only contains tools from the project's mise config (and\n      any configs at-or-below the project root). Tools from\n      `~/.config/mise/config.toml` are not included; pass --include-global\n      to package them too.\n    - asdf and vfox plugins are not supported in v1; use a different backend\n      (core, aqua, ubi, github, cargo, npm, go, pipx, spm, http) for each tool.\n    - The host mise binary is embedded at /usr/local/bin/mise by default;\n      build on the same OS/arch as your target image (or pass --no-mise).\n"},
 	{Key: FlagOciBuildCopy, Repeatable: true, ValueName: "HOST_PATH:IMAGE_PATH", ValueDemanded: true, Short: "Copy a host file, directory, or symlink into the image (repeatable, HOST:IMAGE)", Long: "Copy a host file, directory, or symlink into the image (repeatable, HOST:IMAGE)"},
 	{Key: FlagOciBuildOutput, ValueName: "OUTPUT", ValueDemanded: true, Short: "Output directory for the OCI image layout", Long: "Output directory for the OCI image layout", Default: []string{"./mise-oci"}},
 	{Key: FlagOciBuildFrom, ValueName: "FROM", ValueDemanded: true, Short: "Base image reference (overrides [oci].from and the oci.default_from setting)", Long: "Base image reference (overrides [oci].from and the oci.default_from setting)"},
-	{Key: FlagOciBuildIncludeGlobal, Short: "Also include tools from the global / system config (default: project-only)", Long: "Also include tools from the global / system config (default: project-only)\n\nBy default `mise oci build` only packages tools declared in the project's mise config (and any parent configs at-or-below the project root, e.g. a monorepo root config). Personal dev tools in `~/.config/mise/config.toml` are excluded so they don't bake into a project image. Pass `--include-global` to revert to the old \"merge all loaded configs\" behavior."},
+	{Key: FlagOciBuildIncludeGlobal, Short: "Also include tools from the global / system config (default: project-only)", Long: "Also include tools from the global / system config (default: project-only)\n\nBy default `mise oci build` only packages tools declared in the\nproject's mise config (and any parent configs at-or-below the\nproject root, e.g. a monorepo root config). Personal dev tools in\n`~/.config/mise/config.toml` are excluded so they don't bake into a\nproject image. Pass `--include-global` to revert to the old\n\"merge all loaded configs\" behavior."},
 	{Key: FlagOciBuildTag, ValueName: "TAG", ValueDemanded: true, Short: "Tag to record in the image index (the org.opencontainers.image.ref.name annotation)", Long: "Tag to record in the image index (the org.opencontainers.image.ref.name annotation)"},
 	{Key: FlagOciBuildMountPoint, ValueName: "MOUNT_POINT", ValueDemanded: true, Short: "Where to place tool installs inside the image (default: /mise)", Long: "Where to place tool installs inside the image (default: /mise)"},
 	{Key: FlagOciBuildNoMise, Short: "Do not embed the currently-running mise binary at /usr/local/bin/mise", Long: "Do not embed the currently-running mise binary at /usr/local/bin/mise"},
-	{Key: FlagOciBuildOwner, ValueName: "UID[:GID]", ValueDemanded: true, Short: "UID[:GID] to assign to every tar entry in generated layers", Long: "UID[:GID] to assign to every tar entry in generated layers\n\nOverrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive."},
-	{Key: CmdOciPush, Short: "[experimental] Build an OCI image and push it to a registry", Long: "[experimental] Build an OCI image and push it to a registry\n\nPushes with mise's built-in registry client — no skopeo/crane/docker\nrequired. If `--image-dir` is not passed, builds fresh from the current\nmise.toml first. Only blobs the registry doesn't already have are\nuploaded, so repeat pushes of mostly-unchanged toolsets are cheap.\n\nTool layers whose tool, version, mount point, and file owner match the\npreviously pushed image (or `--cache-from`) are reused without being\nrebuilt — those tools don't even need to be installed locally. Pass\n`--no-cache` to force a full local rebuild.\n\nCredentials are read from the same places docker and podman use:\n`$REGISTRY_AUTH_FILE`, `$XDG_RUNTIME_DIR/containers/auth.json`,\n`~/.config/containers/auth.json`, and `~/.docker/config.json`\n(including credential helpers) — so `docker login` / `podman login`\nis all the setup needed.\n\nRequires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`).", AfterLongHelp: "Examples:\n\n    Build and push to GHCR:\n    $ mise oci push ghcr.io/me/devenv:latest\n\n    Push an image built earlier:\n    $ mise oci build -o ./img\n    $ mise oci push --image-dir ./img ghcr.io/me/devenv:v1\n\nAuth:\n\n    Credentials are resolved the same way docker/podman resolve them:\n    $REGISTRY_AUTH_FILE, $XDG_RUNTIME_DIR/containers/auth.json,\n    ~/.config/containers/auth.json, then ~/.docker/config.json\n    (inline auths and credential helpers). Log in with either:\n    $ docker login ghcr.io\n    $ podman login ghcr.io\n"},
-	{Key: FlagOciPushCacheFrom, ValueName: "REF", ValueDemanded: true, Short: "Reuse unchanged tool layers from this image instead of the destination ref", Long: "Reuse unchanged tool layers from this image instead of the destination ref\n\nMust live in the same repository as the destination. Useful when each push gets a unique tag (e.g. per-commit tags in CI): `--cache-from ghcr.io/me/dev:latest ghcr.io/me/dev:$SHA`."},
+	{Key: FlagOciBuildOwner, ValueName: "UID[:GID]", ValueDemanded: true, Short: "UID[:GID] to assign to every tar entry in generated layers", Long: "UID[:GID] to assign to every tar entry in generated layers\n\nOverrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is\nomitted, it defaults to UID. This affects file ownership only; [oci].user\ncontrols the image USER directive."},
+	{Key: CmdOciPush, Short: "[experimental] Build an OCI image and push it to a registry", Long: "[experimental] Build an OCI image and push it to a registry\n\nPushes with mise's built-in registry client — no skopeo/crane/docker\nrequired. If `--image-dir` is not passed, builds fresh from the current\nmise.toml first. Only blobs the registry doesn't already have are\nuploaded, so repeat pushes of mostly-unchanged toolsets are cheap.\n\nTool layers whose tool, version, mount point, and file owner match the\npreviously pushed image (or `--cache-from`) are reused without being\nrebuilt — those tools don't even need to be installed locally. Pass\n`--no-cache` to force a full local rebuild.\n\nCredentials are read from the same places docker and podman use:\n`$REGISTRY_AUTH_FILE`, `$XDG_RUNTIME_DIR/containers/auth.json`,\n`~/.config/containers/auth.json`, and `~/.docker/config.json`\n(including credential helpers) — so `docker login` / `podman login`\nis all the setup needed.\n\nRequires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`).", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    Build and push to GHCR:\n    $ \x1b[1mmise oci push ghcr.io/me/devenv:latest\x1b[22m\n\n    Push an image built earlier:\n    $ \x1b[1mmise oci build -o ./img\x1b[22m\n    $ \x1b[1mmise oci push --image-dir ./img ghcr.io/me/devenv:v1\x1b[22m\n\n\x1b[1m\x1b[4mAuth:\x1b[22m\x1b[24m\n\n    Credentials are resolved the same way docker/podman resolve them:\n    \x1b[1m$REGISTRY_AUTH_FILE\x1b[22m, \x1b[1m$XDG_RUNTIME_DIR/containers/auth.json\x1b[22m,\n    \x1b[1m~/.config/containers/auth.json\x1b[22m, then \x1b[1m~/.docker/config.json\x1b[22m\n    (inline auths and credential helpers). Log in with either:\n    $ \x1b[1mdocker login ghcr.io\x1b[22m\n    $ \x1b[1mpodman login ghcr.io\x1b[22m\n"},
+	{Key: FlagOciPushCacheFrom, ValueName: "REF", ValueDemanded: true, Short: "Reuse unchanged tool layers from this image instead of the destination ref", Long: "Reuse unchanged tool layers from this image instead of the destination ref\n\nMust live in the same repository as the destination. Useful when each\npush gets a unique tag (e.g. per-commit tags in CI):\n`--cache-from ghcr.io/me/dev:latest ghcr.io/me/dev:$SHA`."},
 	{Key: FlagOciPushFrom, ValueName: "FROM", ValueDemanded: true, Short: "Base image for the build (ignored with --image-dir)", Long: "Base image for the build (ignored with --image-dir)"},
 	{Key: FlagOciPushImageDir, ValueName: "IMAGE_DIR", ValueDemanded: true, Short: "Push an already-built OCI image layout (skip the build step)", Long: "Push an already-built OCI image layout (skip the build step)"},
 	{Key: FlagOciPushIncludeGlobal, Short: "Also include tools from the global / system config (default: project-only)", Long: "Also include tools from the global / system config (default: project-only)\n\nSee `mise oci build --help` for details."},
 	{Key: FlagOciPushMountPoint, ValueName: "MOUNT_POINT", ValueDemanded: true, Short: "Override in-image mount point (ignored with --image-dir)", Long: "Override in-image mount point (ignored with --image-dir)"},
 	{Key: FlagOciPushNoCache, Short: "Don't reuse tool layers from the previously pushed image", Long: "Don't reuse tool layers from the previously pushed image"},
 	{Key: FlagOciPushNoMise, Short: "Don't embed the mise binary (ignored with --image-dir)", Long: "Don't embed the mise binary (ignored with --image-dir)"},
-	{Key: FlagOciPushOwner, ValueName: "UID[:GID]", ValueDemanded: true, Short: "UID[:GID] to assign to every tar entry when building (conflicts with --image-dir)", Long: "UID[:GID] to assign to every tar entry when building (conflicts with --image-dir)\n\nOverrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive."},
-	{Key: FlagOciPushUpdateIndex, Short: "Maintain the tag as a multi-arch image index", Long: "Maintain the tag as a multi-arch image index\n\nPushes this build's manifest by digest and points the tag at an OCI image index containing one entry per platform, preserving entries other architectures pushed. Run `mise oci push --update-index` from one runner per platform to assemble a multi-arch tag."},
+	{Key: FlagOciPushOwner, ValueName: "UID[:GID]", ValueDemanded: true, Short: "UID[:GID] to assign to every tar entry when building (conflicts with --image-dir)", Long: "UID[:GID] to assign to every tar entry when building (conflicts with --image-dir)\n\nOverrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is\nomitted, it defaults to UID. This affects file ownership only; [oci].user\ncontrols the image USER directive."},
+	{Key: FlagOciPushUpdateIndex, Short: "Maintain the tag as a multi-arch image index", Long: "Maintain the tag as a multi-arch image index\n\nPushes this build's manifest by digest and points the tag at an OCI\nimage index containing one entry per platform, preserving entries\nother architectures pushed. Run `mise oci push --update-index` from\none runner per platform to assemble a multi-arch tag."},
 	{Key: ArgOciPushRef, Demanded: true, Short: "Destination registry reference (e.g. `ghcr.io/me/devenv:latest`)", Long: "Destination registry reference (e.g. `ghcr.io/me/devenv:latest`)"},
-	{Key: CmdOciRun, Short: "[experimental] Build an OCI image from the current mise.toml and run a command in it", Long: "[experimental] Build an OCI image from the current mise.toml and run a command in it\n\nEquivalent to `mise oci build` followed by `docker run` / `podman run`.\nThe built image is loaded into the local container engine (podman pulls\nthe OCI layout natively; docker receives it via `docker load`) and the\ngiven command is executed inside it with stdin/stdout/stderr inherited.\n\nRequires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`) and\none of: `podman`, `docker`.", AfterLongHelp: "Examples:\n\n    Build the current mise.toml and drop into bash:\n    $ mise oci run -it -- bash\n\n    Run a one-shot command with env + volume (note: `-v` is reserved\n    for --verbose, so use `--volume`):\n    $ mise oci run -e DEBUG=1 --volume $PWD:/work -w /work -- npm test\n\n    Re-use a previously built layout (skip the build step):\n    $ mise oci build -o ./img && mise oci run --image-dir ./img -- node -e 'console.log(process.version)'\n\nEngines:\n\n    Prefers podman (loads OCI layouts natively). Falls back to docker\n    (loaded via docker load). Pass --engine podman or --engine docker to override.\n"},
+	{Key: CmdOciRun, Short: "[experimental] Build an OCI image from the current mise.toml and run a command in it", Long: "[experimental] Build an OCI image from the current mise.toml and run a command in it\n\nEquivalent to `mise oci build` followed by `docker run` / `podman run`.\nThe built image is loaded into the local container engine (podman pulls\nthe OCI layout natively; docker receives it via `docker load`) and the\ngiven command is executed inside it with stdin/stdout/stderr inherited.\n\nRequires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`) and\none of: `podman`, `docker`.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    Build the current mise.toml and drop into bash:\n    $ \x1b[1mmise oci run -it -- bash\x1b[22m\n\n    Run a one-shot command with env + volume (note: `-v` is reserved\n    for --verbose, so use `--volume`):\n    $ \x1b[1mmise oci run -e DEBUG=1 --volume $PWD:/work -w /work -- npm test\x1b[22m\n\n    Re-use a previously built layout (skip the build step):\n    $ \x1b[1mmise oci build -o ./img && mise oci run --image-dir ./img -- node -e 'console.log(process.version)'\x1b[22m\n\n\x1b[1m\x1b[4mEngines:\x1b[22m\x1b[24m\n\n    Prefers \x1b[1mpodman\x1b[22m (loads OCI layouts natively). Falls back to \x1b[1mdocker\x1b[22m\n    (loaded via \x1b[1mdocker load\x1b[22m). Pass \x1b[1m--engine podman\x1b[22m or \x1b[1m--engine docker\x1b[22m to override.\n"},
 	{Key: FlagOciRunEngine, ValueName: "ENGINE", ValueDemanded: true, Short: "Container engine to use (`auto`, `podman`, or `docker`)", Long: "Container engine to use (`auto`, `podman`, or `docker`)", Choices: []string{"auto", "podman", "docker"}, Default: []string{"auto"}},
 	{Key: FlagOciRunFrom, ValueName: "FROM", ValueDemanded: true, Short: "Base image reference for the build (ignored with --image-dir)", Long: "Base image reference for the build (ignored with --image-dir)"},
 	{Key: FlagOciRunImageDir, ValueName: "IMAGE_DIR", ValueDemanded: true, Short: "Use an already-built OCI image layout instead of building fresh", Long: "Use an already-built OCI image layout instead of building fresh"},
 	{Key: FlagOciRunIncludeGlobal, Short: "Also include tools from the global / system config (default: project-only)", Long: "Also include tools from the global / system config (default: project-only)\n\nSee `mise oci build --help` for details."},
-	{Key: FlagOciRunKeep, Short: "Keep the loaded image in the engine's storage after the run", Long: "Keep the loaded image in the engine's storage after the run\n\nBy default, both the container (`--rm`) and the loaded image are removed when the command exits, so repeated `mise oci run` calls don't accumulate images in podman / docker storage. Pass `--keep` to retain the image under the tag mise used (`mise-oci:run-*` for docker; the pulled image ID for podman)."},
+	{Key: FlagOciRunKeep, Short: "Keep the loaded image in the engine's storage after the run", Long: "Keep the loaded image in the engine's storage after the run\n\nBy default, both the container (`--rm`) and the loaded image are\nremoved when the command exits, so repeated `mise oci run` calls\ndon't accumulate images in podman / docker storage. Pass `--keep`\nto retain the image under the tag mise used (`mise-oci:run-*` for\ndocker; the pulled image ID for podman)."},
 	{Key: FlagOciRunMountPoint, ValueName: "MOUNT_POINT", ValueDemanded: true, Short: "Override in-image mount point (ignored with --image-dir)", Long: "Override in-image mount point (ignored with --image-dir)"},
 	{Key: FlagOciRunNoMise, Short: "Don't embed the mise binary (ignored with --image-dir)", Long: "Don't embed the mise binary (ignored with --image-dir)"},
-	{Key: FlagOciRunOwner, ValueName: "UID[:GID]", ValueDemanded: true, Short: "UID[:GID] to assign to every tar entry when building (conflicts with --image-dir)", Long: "UID[:GID] to assign to every tar entry when building (conflicts with --image-dir)\n\nOverrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive."},
-	{Key: FlagOciRunVolume, Repeatable: true, ValueName: "HOST:CONTAINER", ValueDemanded: true, Short: "Bind-mount a host path (repeatable, `HOST:CONTAINER[:MODE]`)", Long: "Bind-mount a host path (repeatable, `HOST:CONTAINER[:MODE]`)\n\nNote: unlike `docker run -v`, there's no `-v` short flag here because mise reserves `-v` for --verbose. Use `--volume` or `--mount`."},
+	{Key: FlagOciRunOwner, ValueName: "UID[:GID]", ValueDemanded: true, Short: "UID[:GID] to assign to every tar entry when building (conflicts with --image-dir)", Long: "UID[:GID] to assign to every tar entry when building (conflicts with --image-dir)\n\nOverrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is\nomitted, it defaults to UID. This affects file ownership only; [oci].user\ncontrols the image USER directive."},
+	{Key: FlagOciRunVolume, Repeatable: true, ValueName: "HOST:CONTAINER", ValueDemanded: true, Short: "Bind-mount a host path (repeatable, `HOST:CONTAINER[:MODE]`)", Long: "Bind-mount a host path (repeatable, `HOST:CONTAINER[:MODE]`)\n\nNote: unlike `docker run -v`, there's no `-v` short flag here because\nmise reserves `-v` for --verbose. Use `--volume` or `--mount`."},
 	{Key: FlagOciRunEnv, Repeatable: true, ValueName: "KEY=VAL", ValueDemanded: true, Short: "Set environment variable in the container (repeatable, `KEY=VAL`)", Long: "Set environment variable in the container (repeatable, `KEY=VAL`)"},
 	{Key: FlagOciRunInteractive, Short: "Run interactively (pass `-i` to the engine)", Long: "Run interactively (pass `-i` to the engine)"},
 	{Key: FlagOciRunTty, Short: "Allocate a TTY (pass `-t` to the engine)", Long: "Allocate a TTY (pass `-t` to the engine)"},
 	{Key: FlagOciRunWorkdir, ValueName: "WORKDIR", ValueDemanded: true, Short: "Working directory inside the container", Long: "Working directory inside the container"},
 	{Key: ArgOciRunCmd, Short: "Command and arguments to run inside the container (after `--`)", Long: "Command and arguments to run inside the container (after `--`)"},
-	{Key: CmdOutdated, Short: "Shows outdated tool versions", Long: "Shows outdated tool versions\n\nSee `mise upgrade` to upgrade these versions.", AfterLongHelp: "Examples:\n\n    $ mise outdated\n    Plugin  Requested  Current  Latest\n    python  3.11       3.11.0   3.11.1\n    node    20         20.0.0   20.1.0\n\n    $ mise outdated node\n    Plugin  Requested  Current  Latest\n    node    20         20.0.0   20.1.0\n\n    $ mise outdated --json\n    {\"python\": {\"requested\": \"3.11\", \"current\": \"3.11.0\", \"latest\": \"3.11.1\"}, ...}\n\n    $ mise outdated --local\n    Plugin  Requested  Current  Latest\n    node    20         20.0.0   20.1.0\n"},
-	{Key: FlagOutdatedJson, Short: "Output in JSON format", Long: "Output in JSON format"},
+	{Key: CmdOutdated, Short: "Shows outdated tool versions", Long: "Shows outdated tool versions\n\nSee `mise upgrade` to upgrade these versions.", AfterLongHelp: "\x1b[1m\x1b[4mDeprecation:\x1b[22m\x1b[24m\n\nThe `-l` shorthand for `--bump` is deprecated and will be removed in mise 2027.8.5.\nAfter removal, `-l` will become shorthand for `--local`. Use `-b` or `--bump` instead.\n\n\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise outdated\x1b[22m\n    Plugin  Requested  Current  Latest\n    python  3.11       3.11.0   3.11.1\n    node    20         20.0.0   20.1.0\n\n    $ \x1b[1mmise outdated node\x1b[22m\n    Plugin  Requested  Current  Latest\n    node    20         20.0.0   20.1.0\n\n    $ \x1b[1mmise outdated --json\x1b[22m\n    {\"python\": {\"requested\": \"3.11\", \"current\": \"3.11.0\", \"latest\": \"3.11.1\"}, ...}\n\n    $ \x1b[1mmise outdated --local\x1b[22m\n    Plugin  Requested  Current  Latest\n    node    20         20.0.0   20.1.0\n"},
 	{Key: FlagOutdatedBump, Short: "Compares against the latest versions available, not what matches the current config", Long: "Compares against the latest versions available, not what matches the current config\n\nFor example, if you have `node = \"20\"` in your config by default `mise outdated` will only\nshow other 20.x versions, not 21.x or 22.x versions.\n\nUsing this flag, if there are 21.x or newer versions it will display those instead of 20.x."},
+	{Key: FlagOutdatedJson, Short: "Output in JSON format", Long: "Output in JSON format"},
+	{Key: FlagOutdatedL, Hide: true, Short: "Deprecated shorthand for --bump", Long: "Deprecated shorthand for --bump"},
 	{Key: FlagOutdatedInactive, Short: "Show outdated tools including installed-but-inactive tools not present in the current config", Long: "Show outdated tools including installed-but-inactive tools not present in the current config\n\nBy default, `mise outdated` only shows tools that come from the current config."},
 	{Key: FlagOutdatedLocal, Short: "Only show outdated tools defined in local config files", Long: "Only show outdated tools defined in local config files\n\nThis will only show tools that are defined in project-local mise.toml and\nwill skip tools defined in the global config (~/.config/mise/config.toml)."},
 	{Key: FlagOutdatedMonorepo, Short: "Placeholder for future monorepo outdated checks; `mise outdated --monorepo` is not implemented yet.", Long: "Placeholder for future monorepo outdated checks; `mise outdated --monorepo` is not implemented yet."},
 	{Key: FlagOutdatedNoHeader, Short: "Don't show table header", Long: "Don't show table header"},
 	{Key: ArgOutdatedToolVersion, Short: "Tool(s) to show outdated versions for\ne.g.: node@20 python@3.10\nIf not specified, all tools in global and local configs will be shown", Long: "Tool(s) to show outdated versions for\ne.g.: node@20 python@3.10\nIf not specified, all tools in global and local configs will be shown"},
-	{Key: CmdPatrons, Short: "Show the individuals supporting mise as Patron-tier members", Long: "Show the individuals supporting mise as Patron-tier members\n\nLists the individuals on the Patron tier from <https://jdx.dev/patrons.json>.\nThe list refreshes daily; supporting terminals will render each patron's\nname as a clickable link via OSC 8 hyperlinks.\n\nTo appear here, become a patron at <https://jdx.dev/sponsors.html>.", AfterLongHelp: "Examples:\n\n    $ mise patrons\n    $ mise patrons -J\n    $ mise patrons --refresh"},
+	{Key: CmdPatrons, Short: "Show the individuals supporting mise as Patron-tier members", Long: "Show the individuals supporting mise as Patron-tier members\n\nLists the individuals on the Patron tier from <https://jdx.dev/patrons.json>.\nThe list refreshes daily; supporting terminals will render each patron's\nname as a clickable link via OSC 8 hyperlinks.\n\nTo appear here, become a patron at <https://jdx.dev/sponsors.html>.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise patrons\x1b[22m\n    $ \x1b[1mmise patrons -J\x1b[22m\n    $ \x1b[1mmise patrons --refresh\x1b[22m"},
 	{Key: FlagPatronsJson, Short: "Output in JSON format", Long: "Output in JSON format"},
 	{Key: FlagPatronsRefresh, Short: "Bypass the local cache and re-fetch", Long: "Bypass the local cache and re-fetch"},
 	{Key: CmdPlugins, Short: "Manage plugins", VisibleAliases: []string{"p"}},
@@ -5449,19 +5499,19 @@ var HelpText = argv.HelpTable{
 	{Key: FlagPluginsUrls, Short: "Show the git url for each plugin\ne.g.: https://github.com/mise-plugins/vfox-cmake.git", Long: "Show the git url for each plugin\ne.g.: https://github.com/mise-plugins/vfox-cmake.git"},
 	{Key: FlagPluginsRefs, Hide: true, Short: "Show the git refs for each plugin\ne.g.: main 1234abc", Long: "Show the git refs for each plugin\ne.g.: main 1234abc"},
 	{Key: FlagPluginsUser, Short: "List installed plugins", Long: "List installed plugins\n\nThis is the default behavior but can be used with --core\nto show core and user plugins"},
-	{Key: CmdPluginsInstall, Short: "Install a plugin", Long: "Install a plugin\n\nnote that mise can automatically install plugins when you install a tool\ne.g.: `mise install cmake@3.30` will autoinstall the cmake plugin\n\nThis behavior can be modified in ~/.config/mise/config.toml", VisibleAliases: []string{"i", "a", "add"}, AfterLongHelp: "Examples:\n\n    # install the poetry via shorthand\n    $ mise plugins install poetry\n\n    # install the poetry plugin using a specific git url\n    $ mise plugins install poetry https://github.com/mise-plugins/mise-poetry.git\n\n    # install the poetry plugin using the git url only\n    # (poetry is inferred from the url)\n    $ mise plugins install https://github.com/mise-plugins/mise-poetry.git\n\n    # install the poetry plugin using a specific ref\n    $ mise plugins install poetry https://github.com/mise-plugins/mise-poetry.git#11d0c1e\n"},
+	{Key: CmdPluginsInstall, Short: "Install a plugin", Long: "Install a plugin\n\nnote that mise can automatically install plugins when you install a tool\ne.g.: `mise install cmake@3.30` will autoinstall the cmake plugin\n\nThis behavior can be modified in ~/.config/mise/config.toml", VisibleAliases: []string{"i", "a", "add"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    # install the poetry via shorthand\n    $ \x1b[1mmise plugins install poetry\x1b[22m\n\n    # install the poetry plugin using a specific git url\n    $ \x1b[1mmise plugins install poetry https://github.com/mise-plugins/mise-poetry.git\x1b[22m\n\n    # install the poetry plugin using the git url only\n    # (poetry is inferred from the url)\n    $ \x1b[1mmise plugins install https://github.com/mise-plugins/mise-poetry.git\x1b[22m\n\n    # install the poetry plugin using a specific ref\n    $ \x1b[1mmise plugins install poetry https://github.com/mise-plugins/mise-poetry.git#11d0c1e\x1b[22m\n"},
 	{Key: FlagPluginsInstallAll, Short: "Install all missing plugins\nThis will only install plugins that have matching shorthands.\ni.e.: they don't need the full git repo url", Long: "Install all missing plugins\nThis will only install plugins that have matching shorthands.\ni.e.: they don't need the full git repo url"},
 	{Key: FlagPluginsInstallForce, Short: "Reinstall even if plugin exists", Long: "Reinstall even if plugin exists"},
-	{Key: FlagPluginsInstallJobs, ValueName: "JOBS", ValueDemanded: true, Short: "Number of jobs to run in parallel", Long: "Number of jobs to run in parallel"},
+	{Key: FlagPluginsInstallJobs, ValueName: "JOBS", ValueDemanded: true, Short: "Number of jobs to run in parallel\nValues below 1 are treated as 1", Long: "Number of jobs to run in parallel\nValues below 1 are treated as 1"},
 	{Key: FlagPluginsInstallVerbose, Repeatable: true, Short: "Show installation output", Long: "Show installation output"},
 	{Key: ArgPluginsInstallNewPlugin, Short: "The name of the plugin to install\ne.g.: cmake, poetry\nCan specify multiple plugins: `mise plugins install cmake poetry`", Long: "The name of the plugin to install\ne.g.: cmake, poetry\nCan specify multiple plugins: `mise plugins install cmake poetry`"},
 	{Key: ArgPluginsInstallGitUrl, Short: "The git url of the plugin", Long: "The git url of the plugin"},
 	{Key: ArgPluginsInstallRest, Hide: true},
-	{Key: CmdPluginsLink, Short: "Symlinks a plugin into mise", Long: "Symlinks a plugin into mise\n\nThis is used for developing a plugin.", VisibleAliases: []string{"ln"}, AfterLongHelp: "Examples:\n\n    # essentially just `ln -s ./vfox-cmake ~/.local/share/mise/plugins/cmake`\n    $ mise plugins link cmake ./vfox-cmake\n\n    # infer plugin name as \"cmake\"\n    $ mise plugins link ./vfox-cmake\n"},
+	{Key: CmdPluginsLink, Short: "Symlinks a plugin into mise", Long: "Symlinks a plugin into mise\n\nThis is used for developing a plugin.", VisibleAliases: []string{"ln"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    # essentially just `ln -s ./vfox-cmake ~/.local/share/mise/plugins/cmake`\n    $ \x1b[1mmise plugins link cmake ./vfox-cmake\x1b[22m\n\n    # infer plugin name as \"cmake\"\n    $ \x1b[1mmise plugins link ./vfox-cmake\x1b[22m\n"},
 	{Key: FlagPluginsLinkForce, Short: "Overwrite existing plugin", Long: "Overwrite existing plugin"},
 	{Key: ArgPluginsLinkName, Demanded: true, Short: "The name of the plugin\ne.g.: cmake, poetry", Long: "The name of the plugin\ne.g.: cmake, poetry"},
 	{Key: ArgPluginsLinkDir, Short: "The local path to the plugin\ne.g.: ./vfox-cmake", Long: "The local path to the plugin\ne.g.: ./vfox-cmake"},
-	{Key: CmdPluginsLs, Short: "List installed plugins", Long: "List installed plugins\n\nCan also show remotely available plugins to install.", VisibleAliases: []string{"list"}, AfterLongHelp: "Examples:\n\n    $ mise plugins ls\n    cmake\n    poetry\n\n    $ mise plugins ls --urls\n    cmake     https://github.com/mise-plugins/vfox-cmake.git\n    poetry    https://github.com/mise-plugins/vfox-poetry.git\n"},
+	{Key: CmdPluginsLs, Short: "List installed plugins", Long: "List installed plugins\n\nCan also show remotely available plugins to install.", VisibleAliases: []string{"list"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise plugins ls\x1b[22m\n    cmake\n    poetry\n\n    $ \x1b[1mmise plugins ls --urls\x1b[22m\n    cmake     https://github.com/mise-plugins/vfox-cmake.git\n    poetry    https://github.com/mise-plugins/vfox-poetry.git\n"},
 	{Key: FlagPluginsLsAll, Hide: true, Short: "List all available remote plugins\nSame as `mise plugins ls-remote`", Long: "List all available remote plugins\nSame as `mise plugins ls-remote`"},
 	{Key: FlagPluginsLsCore, Hide: true, Short: "The built-in plugins only\nNormally these are not shown", Long: "The built-in plugins only\nNormally these are not shown"},
 	{Key: FlagPluginsLsOutdated, Short: "Show plugins with available updates\nChecks the remote for newer versions and only displays plugins that are outdated", Long: "Show plugins with available updates\nChecks the remote for newer versions and only displays plugins that are outdated"},
@@ -5469,21 +5519,21 @@ var HelpText = argv.HelpTable{
 	{Key: FlagPluginsLsRefs, Hide: true, Short: "Show the git refs for each plugin\ne.g.: main 1234abc", Long: "Show the git refs for each plugin\ne.g.: main 1234abc"},
 	{Key: FlagPluginsLsUser, Hide: true, Short: "List installed plugins", Long: "List installed plugins"},
 	{Key: CmdPluginsLsRemote, Short: "List all available remote plugins", Long: "\nList all available remote plugins\n\nThe full list is here: https://github.com/jdx/mise/blob/main/registry/\n\nExamples:\n\n    $ mise plugins ls-remote\n", VisibleAliases: []string{"list-remote", "list-all"}},
-	{Key: FlagPluginsLsRemoteUrls, Short: "Show the git url for each plugin e.g.: https://github.com/mise-plugins/mise-poetry.git", Long: "Show the git url for each plugin e.g.: https://github.com/mise-plugins/mise-poetry.git"},
-	{Key: FlagPluginsLsRemoteOnlyNames, Short: "Only show the name of each plugin by default it will show a \"*\" next to installed plugins", Long: "Only show the name of each plugin by default it will show a \"*\" next to installed plugins"},
-	{Key: CmdPluginsUninstall, Short: "Removes a plugin", VisibleAliases: []string{"remove", "rm"}, AfterLongHelp: "Examples:\n\n    $ mise plugins uninstall cmake\n"},
+	{Key: FlagPluginsLsRemoteUrls, Short: "Show the git url for each plugin e.g.: https://github.com/mise-plugins/mise-poetry.git", Long: "Show the git url for each plugin\ne.g.: https://github.com/mise-plugins/mise-poetry.git"},
+	{Key: FlagPluginsLsRemoteOnlyNames, Short: "Only show the name of each plugin by default it will show a \"*\" next to installed plugins", Long: "Only show the name of each plugin\nby default it will show a \"*\" next to installed plugins"},
+	{Key: CmdPluginsUninstall, Short: "Removes a plugin", VisibleAliases: []string{"remove", "rm"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise plugins uninstall cmake\x1b[22m\n"},
 	{Key: FlagPluginsUninstallAll, Short: "Remove all plugins", Long: "Remove all plugins"},
 	{Key: FlagPluginsUninstallPurge, Short: "Also remove the plugin's installs, downloads, and cache", Long: "Also remove the plugin's installs, downloads, and cache"},
 	{Key: ArgPluginsUninstallPlugin, Short: "Plugin(s) to remove", Long: "Plugin(s) to remove"},
-	{Key: CmdPluginsUpdate, Short: "Updates a plugin to the latest version", Long: "Updates a plugin to the latest version\n\nnote: this updates the plugin itself, not the runtime versions", VisibleAliases: []string{"up", "upgrade"}, AfterLongHelp: "Examples:\n\n    $ mise plugins update              # update all plugins\n    $ mise plugins update cmake       # update only cmake\n    $ mise plugins update cmake#beta  # specify a ref\n"},
-	{Key: FlagPluginsUpdateJobs, ValueName: "JOBS", ValueDemanded: true, Short: "Number of jobs to run in parallel\nDefault: 4", Long: "Number of jobs to run in parallel\nDefault: 4"},
+	{Key: CmdPluginsUpdate, Short: "Updates a plugin to the latest version", Long: "Updates a plugin to the latest version\n\nnote: this updates the plugin itself, not the runtime versions", VisibleAliases: []string{"up", "upgrade"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise plugins update\x1b[22m              # update all plugins\n    $ \x1b[1mmise plugins update cmake\x1b[22m       # update only cmake\n    $ \x1b[1mmise plugins update cmake#beta\x1b[22m  # specify a ref\n"},
+	{Key: FlagPluginsUpdateJobs, ValueName: "JOBS", ValueDemanded: true, Short: "Number of jobs to run in parallel\nValues below 1 are treated as 1\nDefault: 4", Long: "Number of jobs to run in parallel\nValues below 1 are treated as 1\nDefault: 4"},
 	{Key: ArgPluginsUpdatePlugin, Short: "Plugin(s) to update", Long: "Plugin(s) to update"},
-	{Key: CmdDeps, Short: "[experimental] Manage project dependencies", Long: "[experimental] Manage project dependencies\n\nRuns all applicable dependency install steps for the current project.\nThis checks if dependency lockfiles are newer than installed outputs\n(e.g., package-lock.json vs node_modules/) and runs install commands\nif needed.\n\nProviders with `auto = true` are automatically invoked before `mise x` and `mise run`\nunless skipped with the --no-deps flag.", VisibleAliases: []string{"dep"}, AfterLongHelp: "Examples:\n\n    $ mise deps                    # Install all project dependencies\n    $ mise deps install            # Same as bare `mise deps`\n    $ mise deps install --force    # Force reinstall even if fresh\n    $ mise deps install --dry-run  # Show what would run\n    $ mise deps --monorepo         # Install deps from explicit monorepo config roots\n    $ mise deps add npm:react      # Add a dependency\n    $ mise deps add -D npm:vitest  # Add a dev dependency\n    $ mise deps remove npm:lodash  # Remove a dependency\n\nConfiguration:\n\n```toml\n# Built-in npm provider (auto-detects lockfile)\n[deps.npm]\nauto = true              # Auto-run before mise x/run\n\n# Custom provider\n[deps.codegen]\nauto = true\nsources = [\"schema/*.graphql\"]\noutputs = [\"src/generated/\"]\nrun = \"npm run codegen\"\n\n[deps]\ndisable = [\"npm\"]        # Disable specific providers at runtime\n```\n"},
+	{Key: CmdDeps, Short: "[experimental] Manage project dependencies", Long: "[experimental] Manage project dependencies\n\nRuns all applicable dependency install steps for the current project.\nThis checks if dependency lockfiles are newer than installed outputs\n(e.g., package-lock.json vs node_modules/) and runs install commands\nif needed.\n\nProviders with `auto = true` are automatically invoked before `mise x` and `mise run`\nunless skipped with the --no-deps flag.", VisibleAliases: []string{"dep"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise deps\x1b[22m                    # Install all project dependencies\n    $ \x1b[1mmise deps install\x1b[22m            # Same as bare `mise deps`\n    $ \x1b[1mmise deps install --force\x1b[22m    # Force reinstall even if fresh\n    $ \x1b[1mmise deps install --dry-run\x1b[22m  # Show what would run\n    $ \x1b[1mmise deps --monorepo\x1b[22m         # Install deps from explicit monorepo config roots\n    $ \x1b[1mmise deps add npm:react\x1b[22m      # Add a dependency\n    $ \x1b[1mmise deps add -D npm:vitest\x1b[22m  # Add a dev dependency\n    $ \x1b[1mmise deps remove npm:lodash\x1b[22m  # Remove a dependency\n\n\x1b[1m\x1b[4mConfiguration:\x1b[22m\x1b[24m\n\n```toml\n# Built-in npm provider (auto-detects lockfile)\n[deps.npm]\nauto = true              # Auto-run before mise x/run\n\n# Custom provider\n[deps.codegen]\nauto = true\nsources = [\"schema/*.graphql\"]\noutputs = [\"src/generated/\"]\nrun = \"npm run codegen\"\n\n[deps]\ndisable = [\"npm\"]        # Disable specific providers at runtime\n```\n"},
 	{Key: FlagDepsExplain, Short: "Show why a provider is fresh or stale (requires a provider argument)", Long: "Show why a provider is fresh or stale (requires a provider argument)"},
 	{Key: FlagDepsForce, Short: "Force run all deps steps even if outputs are fresh", Long: "Force run all deps steps even if outputs are fresh"},
 	{Key: FlagDepsDryRun, Short: "Only check if deps install is needed, don't run commands", Long: "Only check if deps install is needed, don't run commands"},
 	{Key: FlagDepsList, Short: "Show what deps providers are available", Long: "Show what deps providers are available"},
-	{Key: FlagDepsMonorepo, Short: "Install dependencies from every [monorepo].config_roots config root", Long: "Install dependencies from every [monorepo].config_roots config root\n\nRequires monorepo_root = true plus explicit [monorepo].config_roots in\nthe monorepo root config. Providers are named like //apps/api:uv."},
+	{Key: FlagDepsMonorepo, Short: "Install dependencies from every [monorepo].config_roots config root", Long: "Install dependencies from every [monorepo].config_roots config root\n\nRequires monorepo_root = true plus explicit [monorepo].config_roots in\nthe monorepo root config. Providers are named like //apps/api:uv.", Env: "MISE_MONOREPO"},
 	{Key: FlagDepsOnly, Repeatable: true, ValueName: "ONLY", ValueDemanded: true, Short: "Run specific deps rule(s) only", Long: "Run specific deps rule(s) only"},
 	{Key: FlagDepsSkip, Repeatable: true, ValueName: "SKIP", ValueDemanded: true, Short: "Skip specific deps rule(s)", Long: "Skip specific deps rule(s)"},
 	{Key: ArgDepsProvider, Short: "Provider to operate on (runs only this provider, or use with --explain)", Long: "Provider to operate on (runs only this provider, or use with --explain)"},
@@ -5495,48 +5545,49 @@ var HelpText = argv.HelpTable{
 	{Key: FlagDepsInstallForce, Short: "Force run all deps steps even if outputs are fresh", Long: "Force run all deps steps even if outputs are fresh"},
 	{Key: FlagDepsInstallDryRun, Short: "Only check if deps install is needed, don't run commands", Long: "Only check if deps install is needed, don't run commands"},
 	{Key: FlagDepsInstallList, Short: "Show what deps providers are available", Long: "Show what deps providers are available"},
-	{Key: FlagDepsInstallMonorepo, Short: "Install dependencies from every [monorepo].config_roots config root", Long: "Install dependencies from every [monorepo].config_roots config root\n\nRequires monorepo_root = true plus explicit [monorepo].config_roots in\nthe monorepo root config. Providers are named like //apps/api:uv."},
+	{Key: FlagDepsInstallMonorepo, Short: "Install dependencies from every [monorepo].config_roots config root", Long: "Install dependencies from every [monorepo].config_roots config root\n\nRequires monorepo_root = true plus explicit [monorepo].config_roots in\nthe monorepo root config. Providers are named like //apps/api:uv.", Env: "MISE_MONOREPO"},
 	{Key: FlagDepsInstallOnly, Repeatable: true, ValueName: "ONLY", ValueDemanded: true, Short: "Run specific deps rule(s) only", Long: "Run specific deps rule(s) only"},
 	{Key: FlagDepsInstallSkip, Repeatable: true, ValueName: "SKIP", ValueDemanded: true, Short: "Skip specific deps rule(s)", Long: "Skip specific deps rule(s)"},
 	{Key: ArgDepsInstallProvider, Short: "Provider to operate on (runs only this provider, or use with --explain)", Long: "Provider to operate on (runs only this provider, or use with --explain)"},
 	{Key: CmdDepsRemove, Short: "Remove a dependency", Long: "Remove a dependency\n\nRemoves one or more packages from the project using the appropriate package manager.\nPackage specs use the format `ecosystem:package`, e.g., `npm:lodash`."},
 	{Key: ArgDepsRemovePackages, Demanded: true, Short: "Package(s) to remove (e.g., npm:lodash)", Long: "Package(s) to remove (e.g., npm:lodash)"},
-	{Key: CmdPrune, Short: "Delete unused versions of tools", Long: "Delete unused versions of tools\n\nmise tracks which config files have been used in ~/.local/state/mise/tracked-configs\nVersions which are no longer the latest specified in any of those configs are deleted.\nVersions installed only with environment variables `MISE_<TOOL>_VERSION` will be deleted,\nas will versions only referenced on the command line `mise exec <TOOL>@<VERSION>`.\n\nTool stubs that have been executed are tracked in ~/.local/state/mise/tracked-stubs.\nVersions still referenced by a tracked stub are not deleted.\n\nYou can list prunable tools with `mise ls --prunable`", AfterLongHelp: "Examples:\n\n    $ mise prune --dry-run\n    rm -rf ~/.local/share/mise/versions/node/20.0.0\n    rm -rf ~/.local/share/mise/versions/node/20.0.1\n"},
+	{Key: CmdPrune, Short: "Delete unused versions of tools", Long: "Delete unused versions of tools\n\nmise tracks which config files have been used in ~/.local/state/mise/tracked-configs\nVersions which are no longer the latest specified in any of those configs are deleted.\nVersions installed only with environment variables `MISE_<TOOL>_VERSION` will be deleted,\nas will versions only referenced on the command line `mise exec <TOOL>@<VERSION>`.\n\nTool stubs that have been executed are tracked in ~/.local/state/mise/tracked-stubs.\nVersions still referenced by a tracked stub are not deleted.\n\nYou can list prunable tools with `mise ls --prunable`", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise prune --dry-run\x1b[22m\n    rm -rf ~/.local/share/mise/versions/node/20.0.0\n    rm -rf ~/.local/share/mise/versions/node/20.0.1\n"},
 	{Key: FlagPruneDryRun, Short: "Do not actually delete anything", Long: "Do not actually delete anything"},
 	{Key: FlagPruneConfigs, Short: "Prune only tracked and trusted configuration links that point to nonexistent configurations", Long: "Prune only tracked and trusted configuration links that point to nonexistent configurations"},
 	{Key: FlagPruneDryRunCode, Short: "Like --dry-run but exits with code 1 if there are tools to prune", Long: "Like --dry-run but exits with code 1 if there are tools to prune\n\nThis is useful for scripts to check if tools need to be pruned."},
 	{Key: FlagPruneMonorepo, Short: "Placeholder for future monorepo pruning; `mise prune --monorepo` is not implemented yet.", Long: "Placeholder for future monorepo pruning; `mise prune --monorepo` is not implemented yet."},
 	{Key: FlagPruneTools, Short: "Prune only unused versions of tools", Long: "Prune only unused versions of tools"},
 	{Key: ArgPruneInstalledTool, Short: "Prune only these tools", Long: "Prune only these tools"},
-	{Key: CmdRegistry, Short: "List available tools to install", Long: "List available tools to install\n\nThis command lists the tools available in the registry as shorthand names.\n\nFor example, `poetry` is shorthand for `asdf:mise-plugins/mise-poetry`.", AfterLongHelp: "Examples:\n\n    $ mise registry\n    node    core:node\n    poetry  asdf:mise-plugins/mise-poetry\n    ubi     cargo:ubi-cli\n\n    $ mise registry poetry\n    asdf:mise-plugins/mise-poetry\n"},
+	{Key: CmdRegistry, Short: "List available tools to install", Long: "List available tools to install\n\nThis command lists the tools available in the registry as shorthand names.\n\nFor example, `poetry` is shorthand for `asdf:mise-plugins/mise-poetry`.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise registry\x1b[22m\n    node    core:node\n    poetry  asdf:mise-plugins/mise-poetry\n    ubi     cargo:ubi-cli\n\n    $ \x1b[1mmise registry poetry\x1b[22m\n    asdf:mise-plugins/mise-poetry\n"},
 	{Key: FlagRegistryBackend, ValueName: "BACKEND", ValueDemanded: true, Short: "Show only tools for this backend", Long: "Show only tools for this backend"},
 	{Key: FlagRegistryComplete, Hide: true, Short: "Print all tools with descriptions for shell completions", Long: "Print all tools with descriptions for shell completions"},
 	{Key: FlagRegistryHideAliased, Short: "Hide aliased tools", Long: "Hide aliased tools"},
 	{Key: FlagRegistryJson, Short: "Output in JSON format", Long: "Output in JSON format"},
-	{Key: FlagRegistrySecurity, Short: "Include security features for each tool's backends in JSON output", Long: "Include security features for each tool's backends in JSON output.\n\nRequires --json. Security info is de-duplicated across all of a tool's backends. This can add noticeable time for large listings since each backend's security info is resolved individually."},
+	{Key: FlagRegistrySecurity, Short: "Include security features for each tool's backends in JSON output.", Long: "Include security features for each tool's backends in JSON output.\n\nRequires --json. Security info is de-duplicated across\nall of a tool's backends. This can add noticeable time for large\nlistings since each backend's security info is resolved individually."},
 	{Key: ArgRegistryName, Short: "Show only the specified tool's full name", Long: "Show only the specified tool's full name"},
 	{Key: CmdRenderHelp, Hide: true, Short: "internal command to generate markdown from help"},
-	{Key: CmdReshim, Short: "Creates new shims based on bin paths from currently installed tools.", Long: "Creates new shims based on bin paths from currently installed tools.\n\nThis creates new shims in ~/.local/share/mise/shims for CLIs that have been added.\nmise will try to do this automatically for commands like `npm i -g` but there are\nother ways to install things (like using yarn or pnpm for node) that mise does\nnot know about and so it will be necessary to call this explicitly.\n\nIf you think mise should automatically call this for a particular command, please\nopen an issue on the mise repo. You can also set up a shell function to reshim\nautomatically (it's really fast so you don't need to worry about overhead):\n\n    npm() {\n      command npm \"$@\"\n      mise reshim\n    }\n\nNote that this creates shims for _all_ installed tools, not just the ones that are\ncurrently active in mise.toml.", AfterLongHelp: "Examples:\n\n    $ mise reshim\n    $ ~/.local/share/mise/shims/node -v\n    v20.0.0\n"},
+	{Key: CmdReshim, Short: "Creates new shims based on bin paths from currently installed tools.", Long: "Creates new shims based on bin paths from currently installed tools.\n\nThis creates new shims in ~/.local/share/mise/shims for CLIs that have been added.\nmise will try to do this automatically for commands like `npm i -g` but there are\nother ways to install things (like using yarn or pnpm for node) that mise does\nnot know about and so it will be necessary to call this explicitly.\n\nIf you think mise should automatically call this for a particular command, please\nopen an issue on the mise repo. You can also set up a shell function to reshim\nautomatically (it's really fast so you don't need to worry about overhead):\n\n    npm() {\n      command npm \"$@\"\n      mise reshim\n    }\n\nNote that this creates shims for _all_ installed tools, not just the ones that are\ncurrently active in mise.toml.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise reshim\x1b[22m\n    $ \x1b[1m~/.local/share/mise/shims/node -v\x1b[22m\n    v20.0.0\n"},
 	{Key: FlagReshimForce, Short: "Removes all shims before reshimming", Long: "Removes all shims before reshimming"},
 	{Key: ArgReshimTool, Hide: true},
 	{Key: ArgReshimVersion, Hide: true},
-	{Key: CmdRun, Short: "Run task(s)", Long: "Run task(s)\n\nThis command will run a task, or multiple tasks in parallel.\nTasks may have dependencies on other tasks or on source files.\nIf source is configured on a task, it will only run if the source\nfiles have changed.\n\nTasks can be defined in mise.toml or as standalone scripts.\nIn mise.toml, tasks take this form:\n\n    [tasks.build]\n    run = \"npm run build\"\n    sources = [\"src/**/*.ts\"]\n    outputs = [\"dist/**/*.js\"]\n\nAlternatively, tasks can be defined as standalone scripts.\nThese must be located in `mise-tasks`, `.mise-tasks`, `.mise/tasks`, `mise/tasks` or\n`.config/mise/tasks`.\nThe name of the script will be the name of the tasks.\n\n    $ cat .mise/tasks/build<<EOF\n    #!/usr/bin/env bash\n    npm run build\n    EOF\n    $ mise run build", VisibleAliases: []string{"r"}, AfterLongHelp: "Examples:\n\n    # Runs the \"lint\" tasks. This needs to either be defined in mise.toml\n    # or as a standalone script. See the project README for more information.\n    $ mise run lint\n\n    # Forces the \"build\" tasks to run even if its sources are up-to-date.\n    $ mise run --force build\n\n    # Run \"test\" with stdin/stdout/stderr all connected to the current terminal.\n    # This forces `--jobs=1` to prevent interleaving of output.\n    $ mise run --raw test\n\n    # Runs the \"lint\", \"test\", and \"check\" tasks in parallel.\n    $ mise run lint ::: test ::: check\n\n    # Execute multiple tasks each with their own arguments.\n    $ mise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2\n"},
+	{Key: CmdRun, Short: "Run task(s)", Long: "Run task(s)\n\nThis command will run a task, or multiple tasks in parallel.\nTasks may have dependencies on other tasks or on source files.\nIf source is configured on a task, it will only run if the source\nfiles have changed.\n\nTasks can be defined in mise.toml or as standalone scripts.\nIn mise.toml, tasks take this form:\n\n    [tasks.build]\n    run = \"npm run build\"\n    sources = [\"src/**/*.ts\"]\n    outputs = [\"dist/**/*.js\"]\n\nAlternatively, tasks can be defined as standalone scripts.\nThese must be located in `mise-tasks`, `.mise-tasks`, `.mise/tasks`, `mise/tasks` or\n`.config/mise/tasks`.\nThe name of the script will be the name of the tasks.\n\n    $ cat .mise/tasks/build<<EOF\n    #!/usr/bin/env bash\n    npm run build\n    EOF\n    $ mise run build", VisibleAliases: []string{"r"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    # Runs the \"lint\" tasks. This needs to either be defined in mise.toml\n    # or as a standalone script. See the project README for more information.\n    $ \x1b[1mmise run lint\x1b[22m\n\n    # Forces the \"build\" tasks to run even if its sources are up-to-date.\n    $ \x1b[1mmise run --force build\x1b[22m\n\n    # Run \"test\" with stdin/stdout/stderr all connected to the current terminal.\n    # This forces `--jobs=1` to prevent interleaving of output.\n    $ \x1b[1mmise run --raw test\x1b[22m\n\n    # Runs the \"lint\", \"test\", and \"check\" tasks in parallel.\n    $ \x1b[1mmise run lint ::: test ::: check\x1b[22m\n\n    # Execute multiple tasks each with their own arguments.\n    $ \x1b[1mmise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2\x1b[22m\n"},
 	{Key: FlagRunAffected, Short: "Run matching tasks only for projects affected by Git changes", Long: "Run matching tasks only for projects affected by Git changes"},
 	{Key: FlagRunAffectedBase, ValueName: "REV", ValueDemanded: true, Short: "Git base revision for --affected\nDefaults to MISE_AFFECTED_BASE, CI metadata, or HEAD~1", Long: "Git base revision for --affected\nDefaults to MISE_AFFECTED_BASE, CI metadata, or HEAD~1"},
 	{Key: FlagRunAffectedExplain, Short: "Explain why projects and tasks were selected by --affected", Long: "Explain why projects and tasks were selected by --affected"},
 	{Key: FlagRunAffectedHead, ValueName: "REV", ValueDemanded: true, Short: "Git head revision for --affected\nDefaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD", Long: "Git head revision for --affected\nDefaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD"},
 	{Key: FlagRunAffectedJson, Short: "Output affected projects and tasks as JSON without running tasks", Long: "Output affected projects and tasks as JSON without running tasks"},
+	{Key: FlagRunAll, Short: "Open the interactive selector with all tasks from the entire monorepo", Long: "Open the interactive selector with all tasks from the entire monorepo"},
 	{Key: FlagRunContinueOnError, Short: "Continue running tasks even if one fails", Long: "Continue running tasks even if one fails"},
 	{Key: FlagRunCd, ValueName: "CD", ValueDemanded: true, Short: "Change to this directory before executing the command", Long: "Change to this directory before executing the command"},
 	{Key: FlagRunForce, Short: "Force the tasks to run even if outputs are up to date", Long: "Force the tasks to run even if outputs are up to date"},
-	{Key: FlagRunJobs, ValueName: "JOBS", ValueDemanded: true, Short: "Number of tasks to run in parallel\n[default: 4]\nConfigure with `jobs` config or `MISE_JOBS` env var", Long: "Number of tasks to run in parallel\n[default: 4]\nConfigure with `jobs` config or `MISE_JOBS` env var"},
+	{Key: FlagRunJobs, ValueName: "JOBS", ValueDemanded: true, Short: "Number of tasks to run in parallel\nValues below 1 are treated as 1\n[default: 4]\nConfigure with `jobs` config or `MISE_JOBS` env var", Long: "Number of tasks to run in parallel\nValues below 1 are treated as 1\n[default: 4]\nConfigure with `jobs` config or `MISE_JOBS` env var", Env: "MISE_JOBS"},
 	{Key: FlagRunDryRun, Short: "Don't actually run the task(s), just print them in order of execution", Long: "Don't actually run the task(s), just print them in order of execution"},
-	{Key: FlagRunOutput, ValueName: "OUTPUT", ValueDemanded: true, Short: "Change how tasks information is output when running tasks", Long: "Change how tasks information is output when running tasks\n\n- `prefix` - Print stdout/stderr by line, prefixed with the task's label\n- `interleave` - Print directly to stdout/stderr instead of by line\n- `replacing` - Stdout is replaced each time, stderr is printed as is\n- `timed` - Only show stdout lines if they are displayed for more than 1 second\n- `keep-order` - Print stdout/stderr by line, prefixed with the task's label, but keep the order of the output\n- `quiet` - Don't show extra output\n- `silent` - Don't show any output including stdout and stderr from the task except for errors"},
-	{Key: FlagRunQuiet, Short: "Don't show extra output", Long: "Don't show extra output"},
+	{Key: FlagRunOutput, ValueName: "OUTPUT", ValueDemanded: true, Short: "Change how tasks information is output when running tasks", Long: "Change how tasks information is output when running tasks\n\n- `prefix` - Print stdout/stderr by line, prefixed with the task's label\n- `interleave` - Print directly to stdout/stderr instead of by line\n- `replacing` - Stdout is replaced each time, stderr is printed as is\n- `timed` - Only show stdout lines if they are displayed for more than 1 second\n- `keep-order` - Print stdout/stderr by line, prefixed with the task's label, but keep the order of the output\n- `quiet` - Don't show extra output\n- `silent` - Don't show any output including stdout and stderr from the task except for errors", Env: "MISE_TASK_OUTPUT"},
+	{Key: FlagRunQuiet, Short: "Don't show extra output", Long: "Don't show extra output", Env: "MISE_QUIET"},
 	{Key: FlagRunRaw, Short: "Read/write directly to stdin/stdout/stderr instead of by line\nRedactions are not applied with this option\nConfigure with `raw` config or `MISE_RAW` env var", Long: "Read/write directly to stdin/stdout/stderr instead of by line\nRedactions are not applied with this option\nConfigure with `raw` config or `MISE_RAW` env var"},
 	{Key: FlagRunShell, ValueName: "SHELL", ValueDemanded: true, Short: "Shell to use to run toml tasks", Long: "Shell to use to run toml tasks\n\nDefaults to `sh -c -o errexit -o pipefail` on unix, and `cmd /c` on Windows\nCan also be set with the setting `MISE_UNIX_DEFAULT_INLINE_SHELL_ARGS` or `MISE_WINDOWS_DEFAULT_INLINE_SHELL_ARGS`\nOr it can be overridden with the `shell` property on a task."},
-	{Key: FlagRunSilent, Short: "Don't show any output except for errors", Long: "Don't show any output except for errors"},
-	{Key: FlagRunTool, Repeatable: true, ValueName: "TOOL@VERSION", ValueDemanded: true, Short: "Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10", Long: "Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10"},
+	{Key: FlagRunSilent, Short: "Don't show any output except for errors", Long: "Don't show any output except for errors", Env: "MISE_SILENT"},
+	{Key: FlagRunTool, Repeatable: true, ValueName: "TOOL@VERSION", ValueDemanded: true, Short: "Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10", Long: "Tool(s) to run in addition to what is in mise.toml files\ne.g.: node@20 python@3.10"},
 	{Key: FlagRunAllowEnv, Repeatable: true, ValueName: "VAR", ValueDemanded: true, Short: "Allow specific env var through (implies --deny-env for everything else)\nSupports wildcards, e.g. --allow-env='MYAPP_*'", Long: "Allow specific env var through (implies --deny-env for everything else)\nSupports wildcards, e.g. --allow-env='MYAPP_*'"},
 	{Key: FlagRunAllowNet, Repeatable: true, ValueName: "HOST", ValueDemanded: true, Short: "Allow network to specific host (implies --deny-net for everything else)", Long: "Allow network to specific host (implies --deny-net for everything else)"},
 	{Key: FlagRunAllowRead, Repeatable: true, ValueName: "PATH", ValueDemanded: true, Short: "Allow reads from specific path (implies --deny-read for everything else)", Long: "Allow reads from specific path (implies --deny-read for everything else)"},
@@ -5547,18 +5598,18 @@ var HelpText = argv.HelpTable{
 	{Key: FlagRunDenyRead, Short: "Block filesystem reads (system libs and tool dirs still accessible)", Long: "Block filesystem reads (system libs and tool dirs still accessible)"},
 	{Key: FlagRunDenyWrite, Short: "Block all filesystem writes", Long: "Block all filesystem writes"},
 	{Key: FlagRunFreshEnv, Short: "Bypass the environment cache and recompute the environment", Long: "Bypass the environment cache and recompute the environment"},
-	{Key: FlagRunNoCache, Short: "Do not use cache on remote tasks", Long: "Do not use cache on remote tasks"},
+	{Key: FlagRunNoCache, Short: "Do not use cache on remote tasks", Long: "Do not use cache on remote tasks", Env: "MISE_TASK_REMOTE_NO_CACHE"},
 	{Key: FlagRunNoDeps, Short: "Skip automatic dependency preparation", Long: "Skip automatic dependency preparation"},
 	{Key: FlagRunNoTimings, Short: "Hides elapsed time after each task completes", Long: "Hides elapsed time after each task completes\n\nDefault to always hide with `MISE_TASK_TIMINGS=0`"},
-	{Key: FlagRunSkipDeps, Short: "Run only the specified tasks skipping all dependencies", Long: "Run only the specified tasks skipping all dependencies"},
+	{Key: FlagRunSkipDeps, Short: "Run only the specified tasks skipping all dependencies", Long: "Run only the specified tasks skipping all dependencies", Env: "MISE_TASK_SKIP_DEPENDS"},
 	{Key: FlagRunSkipTools, Short: "Skip installing tools before running tasks", Long: "Skip installing tools before running tasks\n\nCan also be set persistently with the `task.run_auto_install` setting\nor `MISE_TASK_RUN_AUTO_INSTALL=false` env var"},
-	{Key: FlagRunTaskCache, ValueName: "TASK_CACHE", ValueDemanded: true, Short: "Set task output cache access for this run", Long: "Set task output cache access for this run\n\n- `read-write` - Read cached results and write new results\n- `read-only` - Read cached results without writing new results\n- `write-only` - Write new results without reading cached results\n- `off` - Disable task output caching\n- `local-only` - Read and write only the local cache; currently equivalent to `read-write`", Choices: []string{"read-write", "read-only", "write-only", "off", "local-only"}, Default: []string{"read-write"}},
+	{Key: FlagRunTaskCache, ValueName: "TASK_CACHE", ValueDemanded: true, Short: "Set task output cache access for this run", Long: "Set task output cache access for this run\n\n- `read-write` - Read cached results and write new results\n- `read-only` - Read cached results without writing new results\n- `write-only` - Write new results without reading cached results\n- `off` - Disable task output caching\n- `local-only` - Read and write only the local cache; currently equivalent to `read-write`", Choices: []string{"read-write", "read-only", "write-only", "off", "local-only"}, Env: "MISE_TASK_CACHE", Default: []string{"read-write"}},
 	{Key: FlagRunTaskCacheExplain, Short: "Explain the inputs that produced each task's output cache key", Long: "Explain the inputs that produced each task's output cache key"},
 	{Key: FlagRunTaskCacheExplainJson, Short: "Output cache-key input details as JSON Lines without running tasks", Long: "Output cache-key input details as JSON Lines without running tasks"},
 	{Key: FlagRunTaskCacheStats, Short: "Report task output cache hits, restored bytes, and time saved", Long: "Report task output cache hits, restored bytes, and time saved"},
 	{Key: FlagRunTimeout, ValueName: "TIMEOUT", ValueDemanded: true, Short: "Timeout for the task to complete\ne.g.: 30s, 5m", Long: "Timeout for the task to complete\ne.g.: 30s, 5m"},
 	{Key: FlagRunTimings, Hide: true, Short: "Shows elapsed time after each task completes", Long: "Shows elapsed time after each task completes\n\nDefault to always show with `MISE_TASK_TIMINGS=1`"},
-	{Key: CmdSearch, Short: "Search for tools in the registry", Long: "Search for tools in the registry\n\nThis command searches a tool in the registry.\n\nBy default, it will show all tools that fuzzy match the search term. For\nnon-fuzzy matches, use the `--match-type` flag.", AfterLongHelp: "Examples:\n\n    $ mise search jq\n    Tool  Description\n    jq    Command-line JSON processor. https://github.com/jqlang/jq\n    jqp   A TUI playground to experiment with jq. https://github.com/noahgorstein/jqp\n    jiq   jid on jq - interactive JSON query tool using jq expressions. https://github.com/fiatjaf/jiq\n    gojq  Pure Go implementation of jq. https://github.com/itchyny/gojq\n\n    $ mise search --interactive\n    Tool\n    Search a tool\n    ❯ jq    Command-line JSON processor. https://github.com/jqlang/jq\n      jqp   A TUI playground to experiment with jq. https://github.com/noahgorstein/jqp\n      jiq   jid on jq - interactive JSON query tool using jq expressions. https://github.com/fiatjaf/jiq\n      gojq  Pure Go implementation of jq. https://github.com/itchyny/gojq\n    /jq \n    esc clear filter • enter confirm\n"},
+	{Key: CmdSearch, Short: "Search for tools in the registry", Long: "Search for tools in the registry\n\nThis command searches a tool in the registry.\n\nBy default, it will show all tools that fuzzy match the search term. For\nnon-fuzzy matches, use the `--match-type` flag.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise search jq\x1b[22m\n    Tool  Description\n    jq    Command-line JSON processor. https://github.com/jqlang/jq\n    jqp   A TUI playground to experiment with jq. https://github.com/noahgorstein/jqp\n    jiq   jid on jq - interactive JSON query tool using jq expressions. https://github.com/fiatjaf/jiq\n    gojq  Pure Go implementation of jq. https://github.com/itchyny/gojq\n\n    $ \x1b[1mmise search --interactive\x1b[22m\n    Tool\n    Search a tool\n    ❯ jq    Command-line JSON processor. https://github.com/jqlang/jq\n      jqp   A TUI playground to experiment with jq. https://github.com/noahgorstein/jqp\n      jiq   jid on jq - interactive JSON query tool using jq expressions. https://github.com/fiatjaf/jiq\n      gojq  Pure Go implementation of jq. https://github.com/itchyny/gojq\n    /jq \n    esc clear filter • enter confirm\n"},
 	{Key: FlagSearchInteractive, Short: "Show interactive search", Long: "Show interactive search"},
 	{Key: FlagSearchMatchType, ValueName: "MATCH_TYPE", ValueDemanded: true, Short: "Match type: equal, contains, or fuzzy", Long: "Match type: equal, contains, or fuzzy", Choices: []string{"equal", "contains", "fuzzy"}, Default: []string{"fuzzy"}},
 	{Key: FlagSearchNoHeader, Short: "Don't display headers", Long: "Don't display headers"},
@@ -5568,7 +5619,7 @@ var HelpText = argv.HelpTable{
 	{Key: FlagSelfUpdateYes, Short: "Skip confirmation prompt", Long: "Skip confirmation prompt"},
 	{Key: FlagSelfUpdateNoPlugins, Short: "Disable auto-updating plugins", Long: "Disable auto-updating plugins"},
 	{Key: ArgSelfUpdateVersion, Short: "Update to a specific version", Long: "Update to a specific version"},
-	{Key: CmdSet, Short: "Set environment variables in mise.toml", Long: "Set environment variables in mise.toml\n\nBy default, this command modifies `mise.toml` in the current directory.\nIf multiple config files exist (e.g., both `mise.toml` and `mise.local.toml`),\nthe lowest precedence file (`mise.toml`) will be used.\nSee https://mise.jdx.dev/configuration.html#target-file-for-write-operations\n\nUse `-E <env>` to create/modify environment-specific config files like `mise.<env>.toml`.", AfterLongHelp: "Examples:\n\n    $ mise set NODE_ENV=production\n\n    $ mise set NODE_ENV\n    production\n\n    $ mise set -E staging NODE_ENV=staging\n    # creates or modifies mise.staging.toml\n\n    $ mise set\n    key       value       source\n    NODE_ENV  production  ~/.config/mise/config.toml\n\n    $ mise set --prompt PASSWORD\n    Enter value for PASSWORD: [hidden input]\n\n    Multiline Values (--stdin):\n\n    $ cat private.key | mise set --stdin MY_KEY\n\n    $ printf \"line1\\nline2\" | mise set --stdin MY_KEY\n\n    [experimental] Age Encryption:\n\n    $ mise set --age-encrypt API_KEY=secret\n\n    $ mise set --age-encrypt --prompt API_KEY\n    Enter value for API_KEY: [hidden input]\n"},
+	{Key: CmdSet, Short: "Set environment variables in mise.toml", Long: "Set environment variables in mise.toml\n\nBy default, this command modifies `mise.toml` in the current directory.\nIf multiple config files exist (e.g., both `mise.toml` and `mise.local.toml`),\nthe lowest precedence file (`mise.toml`) will be used.\nSee https://mise.jdx.dev/configuration.html#target-file-for-write-operations\n\nUse `-E <env>` to create/modify environment-specific config files like `mise.<env>.toml`.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise set NODE_ENV=production\x1b[22m\n\n    $ \x1b[1mmise set NODE_ENV\x1b[22m\n    production\n\n    $ \x1b[1mmise set -E staging NODE_ENV=staging\x1b[22m\n    # creates or modifies mise.staging.toml\n\n    $ \x1b[1mmise set\x1b[22m\n    key       value       source\n    NODE_ENV  production  ~/.config/mise/config.toml\n\n    $ \x1b[1mmise set --prompt PASSWORD\x1b[22m\n    Enter value for PASSWORD: [hidden input]\n\n    \x1b[1m\x1b[4mMultiline Values (--stdin):\x1b[22m\x1b[24m\n\n    $ \x1b[1mcat private.key | mise set --stdin MY_KEY\x1b[22m\n\n    $ \x1b[1mprintf \"line1\\nline2\" | mise set --stdin MY_KEY\x1b[22m\n\n    \x1b[1m\x1b[4m[experimental] Age Encryption:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise set --age-encrypt API_KEY=secret\x1b[22m\n\n    $ \x1b[1mmise set --age-encrypt --prompt API_KEY\x1b[22m\n    Enter value for API_KEY: [hidden input]\n"},
 	{Key: FlagSetEnv, ValueName: "ENV", ValueDemanded: true, Short: "Create/modify an environment-specific config file like .mise.<env>.toml", Long: "Create/modify an environment-specific config file like .mise.<env>.toml"},
 	{Key: FlagSetGlobal, Short: "Set the environment variable in the global config file", Long: "Set the environment variable in the global config file"},
 	{Key: FlagSetAgeEncrypt, Short: "[experimental] Encrypt the value with age before storing", Long: "[experimental] Encrypt the value with age before storing"},
@@ -5580,9 +5631,9 @@ var HelpText = argv.HelpTable{
 	{Key: FlagSetNoRedact, Short: "Show raw values instead of redacting secrets", Long: "Show raw values instead of redacting secrets"},
 	{Key: FlagSetPrompt, Short: "Prompt for environment variable values", Long: "Prompt for environment variable values"},
 	{Key: FlagSetRemove, Hide: true, Repeatable: true, ValueName: "ENV_KEY", ValueDemanded: true, Short: "Remove the environment variable from config file", Long: "Remove the environment variable from config file\n\nCan be used multiple times."},
-	{Key: FlagSetStdin, Short: "Read the value from stdin (for multiline input)", Long: "Read the value from stdin (for multiline input)\n\nWhen using --stdin, provide a single key without a value. The value will be read from stdin until EOF."},
+	{Key: FlagSetStdin, Short: "Read the value from stdin (for multiline input)", Long: "Read the value from stdin (for multiline input)\n\nWhen using --stdin, provide a single key without a value.\nThe value will be read from stdin until EOF."},
 	{Key: ArgSetEnvVar, Short: "Environment variable(s) to set\ne.g.: NODE_ENV=production", Long: "Environment variable(s) to set\ne.g.: NODE_ENV=production"},
-	{Key: CmdSettings, Short: "Manage settings", Long: "Show current settings\n\nThis is the contents of ~/.config/mise/config.toml\n\nNote that aliases are also stored in this file\nbut managed separately with `mise tool-alias`", AfterLongHelp: "Examples:\n    # list all settings\n    $ mise settings\n\n    # get the value of the setting \"always_keep_download\"\n    $ mise settings always_keep_download\n\n    # set the value of the setting \"always_keep_download\" to \"true\"\n    $ mise settings always_keep_download=true\n\n    # set the value of the setting \"node.mirror_url\" to \"https://npmmirror.com/mirrors/node/\"\n    $ mise settings node.mirror_url https://npmmirror.com/mirrors/node/\n"},
+	{Key: CmdSettings, Short: "Manage settings", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n    # list all settings\n    $ \x1b[1mmise settings\x1b[22m\n\n    # get the value of the setting \"always_keep_download\"\n    $ \x1b[1mmise settings always_keep_download\x1b[22m\n\n    # set the value of the setting \"always_keep_download\" to \"true\"\n    $ \x1b[1mmise settings always_keep_download=true\x1b[22m\n\n    # set the value of the setting \"node.mirror_url\" to \"https://npmmirror.com/mirrors/node/\"\n    $ \x1b[1mmise settings node.mirror_url https://npmmirror.com/mirrors/node/\x1b[22m\n"},
 	{Key: FlagSettingsAll, Short: "List all settings", Long: "List all settings"},
 	{Key: FlagSettingsJson, Short: "Output in JSON format", Long: "Output in JSON format"},
 	{Key: FlagSettingsLocal, Short: "Use the local config file instead of the global one", Long: "Use the local config file instead of the global one"},
@@ -5591,14 +5642,14 @@ var HelpText = argv.HelpTable{
 	{Key: FlagSettingsJsonExtended, Short: "Output in JSON format with sources", Long: "Output in JSON format with sources"},
 	{Key: ArgSettingsSetting, Short: "Name of setting", Long: "Name of setting"},
 	{Key: ArgSettingsValue, Short: "Setting value to set", Long: "Setting value to set"},
-	{Key: CmdSettingsAdd, Short: "Adds a setting to the configuration file", Long: "Adds a setting to the configuration file\n\nUsed with an array setting, this will append the value to the array.\nThis modifies the contents of ~/.config/mise/config.toml", AfterLongHelp: "Examples:\n\n    $ mise settings add disable_hints python_multi\n"},
+	{Key: CmdSettingsAdd, Short: "Adds a setting to the configuration file", Long: "Adds a setting to the configuration file\n\nUsed with an array setting, this will append the value to the array.\nThis modifies the contents of ~/.config/mise/config.toml", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise settings add disable_hints python_multi\x1b[22m\n"},
 	{Key: FlagSettingsAddLocal, Short: "Use the local config file instead of the global one", Long: "Use the local config file instead of the global one"},
 	{Key: ArgSettingsAddSetting, Demanded: true, Short: "The setting to set", Long: "The setting to set"},
 	{Key: ArgSettingsAddValue, Short: "The value to set (optional if provided as KEY=VALUE)", Long: "The value to set (optional if provided as KEY=VALUE)"},
-	{Key: CmdSettingsGet, Short: "Show a current setting", Long: "Show a current setting\n\nThis is the contents of a single entry in ~/.config/mise/config.toml\n\nNote that aliases are also stored in this file\nbut managed separately with `mise tool-alias get`", AfterLongHelp: "Examples:\n\n    $ mise settings get idiomatic_version_file\n    true\n"},
+	{Key: CmdSettingsGet, Short: "Show a current setting", Long: "Show a current setting\n\nThis is the contents of a single entry in ~/.config/mise/config.toml\n\nNote that aliases are also stored in this file\nbut managed separately with `mise tool-alias get`", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise settings get idiomatic_version_file\x1b[22m\n    true\n"},
 	{Key: FlagSettingsGetLocal, Short: "Use the local config file instead of the global one", Long: "Use the local config file instead of the global one"},
 	{Key: ArgSettingsGetSetting, Demanded: true, Short: "The setting to show", Long: "The setting to show"},
-	{Key: CmdSettingsLs, Short: "Show current settings", Long: "Show current settings\n\nThis is the contents of ~/.config/mise/config.toml\n\nNote that aliases are also stored in this file\nbut managed separately with `mise tool-alias`", VisibleAliases: []string{"list"}, AfterLongHelp: "Examples:\n\n    $ mise settings ls\n    idiomatic_version_file = false\n    ...\n\n    $ mise settings ls python\n    default_packages_file = \"~/.default-python-packages\"\n    ...\n"},
+	{Key: CmdSettingsLs, Short: "Show current settings", Long: "Show current settings\n\nThis is the contents of ~/.config/mise/config.toml\n\nNote that aliases are also stored in this file\nbut managed separately with `mise tool-alias`", VisibleAliases: []string{"list"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise settings ls\x1b[22m\n    idiomatic_version_file = false\n    ...\n\n    $ \x1b[1mmise settings ls python\x1b[22m\n    default_packages_file = \"~/.default-python-packages\"\n    ...\n"},
 	{Key: FlagSettingsLsAll, Short: "List all settings", Long: "List all settings"},
 	{Key: FlagSettingsLsJson, Short: "Output in JSON format", Long: "Output in JSON format"},
 	{Key: FlagSettingsLsLocal, Short: "Use the local config file instead of the global one", Long: "Use the local config file instead of the global one"},
@@ -5606,41 +5657,41 @@ var HelpText = argv.HelpTable{
 	{Key: FlagSettingsLsComplete, Hide: true, Short: "Print all settings with descriptions for shell completions", Long: "Print all settings with descriptions for shell completions"},
 	{Key: FlagSettingsLsJsonExtended, Short: "Output in JSON format with sources", Long: "Output in JSON format with sources"},
 	{Key: ArgSettingsLsSetting, Short: "Name of setting", Long: "Name of setting"},
-	{Key: CmdSettingsSet, Short: "Add/update a setting", Long: "Add/update a setting\n\nThis modifies the contents of ~/.config/mise/config.toml by default.\nWith `--local`, modifies the local config file instead.\nSee https://mise.jdx.dev/configuration.html#target-file-for-write-operations", VisibleAliases: []string{"create"}, AfterLongHelp: "Examples:\n\n    $ mise settings idiomatic_version_file=true\n"},
+	{Key: CmdSettingsSet, Short: "Add/update a setting", Long: "Add/update a setting\n\nThis modifies the contents of ~/.config/mise/config.toml by default.\nWith `--local`, modifies the local config file instead.\nSee https://mise.jdx.dev/configuration.html#target-file-for-write-operations", VisibleAliases: []string{"create"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise settings idiomatic_version_file=true\x1b[22m\n"},
 	{Key: FlagSettingsSetLocal, Short: "Use the local config file instead of the global one", Long: "Use the local config file instead of the global one"},
 	{Key: ArgSettingsSetSetting, Demanded: true, Short: "The setting to set", Long: "The setting to set"},
 	{Key: ArgSettingsSetValue, Short: "The value to set (optional if provided as KEY=VALUE)", Long: "The value to set (optional if provided as KEY=VALUE)"},
-	{Key: CmdSettingsUnset, Short: "Clears a setting", Long: "Clears a setting\n\nThis modifies the contents of ~/.config/mise/config.toml", VisibleAliases: []string{"rm", "remove", "delete", "del"}, AfterLongHelp: "Examples:\n\n    $ mise settings unset idiomatic_version_file\n"},
+	{Key: CmdSettingsUnset, Short: "Clears a setting", Long: "Clears a setting\n\nThis modifies the contents of ~/.config/mise/config.toml", VisibleAliases: []string{"rm", "remove", "delete", "del"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise settings unset idiomatic_version_file\x1b[22m\n"},
 	{Key: FlagSettingsUnsetLocal, Short: "Use the local config file instead of the global one", Long: "Use the local config file instead of the global one"},
 	{Key: ArgSettingsUnsetKey, Demanded: true, Short: "The setting to remove", Long: "The setting to remove"},
-	{Key: CmdShell, Short: "Sets a tool version for the current session.", Long: "Sets a tool version for the current session.\n\nOnly works in a session where mise is already activated.\n\nThis works by setting environment variables for the current shell session\nsuch as `MISE_NODE_VERSION=20` which is \"eval\"ed as a shell function created by `mise activate`.", VisibleAliases: []string{"sh"}, AfterLongHelp: "Examples:\n\n    $ mise shell node@20\n    $ node -v\n    v20.0.0\n"},
-	{Key: FlagShellJobs, ValueName: "JOBS", ValueDemanded: true, Short: "Number of jobs to run in parallel\n[default: 4]", Long: "Number of jobs to run in parallel\n[default: 4]"},
+	{Key: CmdShell, Short: "Sets a tool version for the current session.", Long: "Sets a tool version for the current session.\n\nOnly works in a session where mise is already activated.\n\nThis works by setting environment variables for the current shell session\nsuch as `MISE_NODE_VERSION=20` which is \"eval\"ed as a shell function created by `mise activate`.", VisibleAliases: []string{"sh"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise shell node@20\x1b[22m\n    $ \x1b[1mnode -v\x1b[22m\n    v20.0.0\n"},
+	{Key: FlagShellJobs, ValueName: "JOBS", ValueDemanded: true, Short: "Number of jobs to run in parallel\nValues below 1 are treated as 1\n[default: 4]", Long: "Number of jobs to run in parallel\nValues below 1 are treated as 1\n[default: 4]", Env: "MISE_JOBS"},
 	{Key: FlagShellUnset, Short: "Removes a previously set version", Long: "Removes a previously set version"},
-	{Key: FlagShellRaw, Short: "Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1", Long: "Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1"},
+	{Key: FlagShellRaw, Short: "Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1", Long: "Connect backend install command stdin/stdout/stderr directly to the terminal\nImplies --jobs=1"},
 	{Key: ArgShellToolVersion, Demanded: true, Short: "Tool(s) to use", Long: "Tool(s) to use"},
 	{Key: CmdShellAlias, Short: "Manage shell aliases."},
 	{Key: FlagShellAliasNoHeader, Short: "Don't show table header", Long: "Don't show table header"},
-	{Key: CmdShellAliasGet, Short: "Show the command for a shell alias", AfterLongHelp: "Examples:\n\n    $ mise shell-alias get ll\n    ls -la\n"},
+	{Key: CmdShellAliasGet, Short: "Show the command for a shell alias", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise shell-alias get ll\x1b[22m\n    ls -la\n"},
 	{Key: ArgShellAliasGetShellAlias, Demanded: true, Short: "The alias to show", Long: "The alias to show"},
-	{Key: CmdShellAliasLs, Short: "List shell aliases", Long: "List shell aliases\n\nShows the shell aliases that are set in the current directory.\nThese are defined in `mise.toml` under the `[shell_alias]` section.", VisibleAliases: []string{"list"}, AfterLongHelp: "Examples:\n\n    $ mise shell-alias ls\n    alias    command\n    ll       ls -la\n    gs       git status\n"},
+	{Key: CmdShellAliasLs, Short: "List shell aliases", Long: "List shell aliases\n\nShows the shell aliases that are set in the current directory.\nThese are defined in `mise.toml` under the `[shell_alias]` section.", VisibleAliases: []string{"list"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise shell-alias ls\x1b[22m\n    alias    command\n    ll       ls -la\n    gs       git status\n"},
 	{Key: FlagShellAliasLsNoHeader, Short: "Don't show table header", Long: "Don't show table header"},
-	{Key: CmdShellAliasSet, Short: "Add/update a shell alias", Long: "Add/update a shell alias\n\nThis modifies the contents of ~/.config/mise/config.toml", VisibleAliases: []string{"add", "create"}, AfterLongHelp: "Examples:\n\n    $ mise shell-alias set ll \"ls -la\"\n    $ mise shell-alias set gs \"git status\"\n"},
+	{Key: CmdShellAliasSet, Short: "Add/update a shell alias", Long: "Add/update a shell alias\n\nThis modifies the contents of ~/.config/mise/config.toml", VisibleAliases: []string{"add", "create"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise shell-alias set ll \"ls -la\"\x1b[22m\n    $ \x1b[1mmise shell-alias set gs \"git status\"\x1b[22m\n"},
 	{Key: ArgShellAliasSetShellAlias, Demanded: true, Short: "The alias name", Long: "The alias name"},
 	{Key: ArgShellAliasSetCommand, Short: "The command to run (optional if provided as ALIAS=COMMAND)", Long: "The command to run (optional if provided as ALIAS=COMMAND)"},
-	{Key: CmdShellAliasUnset, Short: "Removes a shell alias", Long: "Removes a shell alias\n\nThis modifies the contents of ~/.config/mise/config.toml", VisibleAliases: []string{"rm", "remove", "delete", "del"}, AfterLongHelp: "Examples:\n\n    $ mise shell-alias unset ll\n"},
+	{Key: CmdShellAliasUnset, Short: "Removes a shell alias", Long: "Removes a shell alias\n\nThis modifies the contents of ~/.config/mise/config.toml", VisibleAliases: []string{"rm", "remove", "delete", "del"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise shell-alias unset ll\x1b[22m\n"},
 	{Key: ArgShellAliasUnsetShellAlias, Demanded: true, Short: "The alias to remove", Long: "The alias to remove"},
 	{Key: CmdSponsors, Short: "Show the companies sponsoring mise and the jdx.dev open source tools"},
 	{Key: CmdSync, Short: "Synchronize tools from other version managers with mise", SubcommandRequired: true},
-	{Key: CmdSyncNode, Short: "Symlinks all tool versions from an external tool into mise", Long: "Symlinks all tool versions from an external tool into mise\n\nFor example, use this to import all Homebrew node installs into mise\n\nThis won't overwrite any existing installs but will overwrite any existing symlinks", AfterLongHelp: "Examples:\n\n    $ brew install node@18 node@20\n    $ mise sync node --brew\n    $ mise use -g node@18 - uses Homebrew-provided node\n"},
+	{Key: CmdSyncNode, Short: "Symlinks all tool versions from an external tool into mise", Long: "Symlinks all tool versions from an external tool into mise\n\nFor example, use this to import all Homebrew node installs into mise\n\nThis won't overwrite managed installs, runtime aliases, or links from other providers.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mbrew install node@18 node@20\x1b[22m\n    $ \x1b[1mmise sync node --brew\x1b[22m\n    $ \x1b[1mmise use -g node@18\x1b[22m - uses Homebrew-provided node\n"},
 	{Key: FlagSyncNodeBrew, Short: "Get tool versions from Homebrew", Long: "Get tool versions from Homebrew"},
 	{Key: FlagSyncNodeNodenv, Short: "Get tool versions from nodenv", Long: "Get tool versions from nodenv"},
 	{Key: FlagSyncNodeNvm, Short: "Get tool versions from nvm", Long: "Get tool versions from nvm"},
-	{Key: CmdSyncPython, Short: "Symlinks all tool versions from an external tool into mise", Long: "Symlinks all tool versions from an external tool into mise\n\nFor example, use this to import all pyenv installs into mise\n\nThis won't overwrite any existing installs but will overwrite any existing symlinks", AfterLongHelp: "Examples:\n\n    $ pyenv install 3.11.0\n    $ mise sync python --pyenv\n    $ mise use -g python@3.11.0 - uses pyenv-provided python\n\n    $ uv python install 3.11.0\n    $ mise install python@3.10.0\n    $ mise sync python --uv\n    $ mise x python@3.11.0 -- python -V - uses uv-provided python\n    $ uv run -p 3.10.0 -- python -V - uses mise-provided python\n"},
+	{Key: CmdSyncPython, Short: "Symlinks all tool versions from an external tool into mise", Long: "Symlinks all tool versions from an external tool into mise\n\nFor example, use this to import all pyenv installs into mise\n\nThis won't overwrite managed installs, runtime aliases, or links from other providers.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mpyenv install 3.11.0\x1b[22m\n    $ \x1b[1mmise sync python --pyenv\x1b[22m\n    $ \x1b[1mmise use -g python@3.11.0\x1b[22m - uses pyenv-provided python\n    \n    $ \x1b[1muv python install 3.11.0\x1b[22m\n    $ \x1b[1mmise install python@3.10.0\x1b[22m\n    $ \x1b[1mmise sync python --uv\x1b[22m\n    $ \x1b[1mmise x python@3.11.0 -- python -V\x1b[22m - uses uv-provided python\n    $ \x1b[1muv run -p 3.10.0 -- python -V\x1b[22m - uses mise-provided python\n"},
 	{Key: FlagSyncPythonPyenv, Short: "Get tool versions from pyenv", Long: "Get tool versions from pyenv"},
 	{Key: FlagSyncPythonUv, Short: "Sync tool versions with uv (2-way sync)", Long: "Sync tool versions with uv (2-way sync)"},
-	{Key: CmdSyncRuby, Short: "Symlinks all ruby tool versions from an external tool into mise", AfterLongHelp: "Examples:\n\n    $ brew install ruby\n    $ mise sync ruby --brew\n    $ mise use -g ruby - Use the latest version of Ruby installed by Homebrew\n"},
-	{Key: FlagSyncRubyBrew, Short: "Get tool versions from Homebrew", Long: "Get tool versions from Homebrew"},
-	{Key: CmdTasks, Short: "Manage tasks", VisibleAliases: []string{"t"}, AfterLongHelp: "Examples:\n\n    $ mise tasks ls\n"},
+	{Key: CmdSyncRuby, Short: "Symlinks all ruby tool versions from an external tool into mise", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mbrew install ruby\x1b[22m\n    $ \x1b[1mmise sync ruby --brew\x1b[22m\n    $ \x1b[1mmise use -g ruby\x1b[22m - Use the latest version of Ruby installed by Homebrew\n"},
+	{Key: FlagSyncRubyBrew, Demanded: true, Short: "Get tool versions from Homebrew", Long: "Get tool versions from Homebrew"},
+	{Key: CmdTasks, Short: "Manage tasks", VisibleAliases: []string{"t"}},
 	{Key: FlagTasksGlobal, Short: "Only show global tasks", Long: "Only show global tasks"},
 	{Key: FlagTasksJson, Short: "Output in JSON format", Long: "Output in JSON format"},
 	{Key: FlagTasksLocal, Short: "Only show non-global tasks", Long: "Only show non-global tasks"},
@@ -5654,7 +5705,7 @@ var HelpText = argv.HelpTable{
 	{Key: FlagTasksSortOrder, ValueName: "SORT_ORDER", ValueDemanded: true, Short: "Sort order. Default is asc.", Long: "Sort order. Default is asc.", Choices: []string{"asc", "desc"}},
 	{Key: FlagTasksUsage, Hide: true},
 	{Key: ArgTasksTask, Short: "Task name to get info of", Long: "Task name to get info of"},
-	{Key: CmdTasksAdd, Short: "Create a new task", Long: "Create a new task\n\nAdds a task to the local mise.toml file.\nSee https://mise.jdx.dev/configuration.html#target-file-for-write-operations", AfterLongHelp: "Examples:\n\n    $ mise tasks add pre-commit --depends \"test\" --depends \"render\" -- echo pre-commit\n"},
+	{Key: CmdTasksAdd, Short: "Create a new task", Long: "Create a new task\n\nAdds a task to the local mise.toml file.\nSee https://mise.jdx.dev/configuration.html#target-file-for-write-operations", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise tasks add pre-commit --depends \"test\" --depends \"render\" -- echo pre-commit\x1b[22m\n"},
 	{Key: FlagTasksAddAlias, Repeatable: true, ValueName: "ALIAS", ValueDemanded: true, Short: "Other names for the task", Long: "Other names for the task"},
 	{Key: FlagTasksAddDepends, Repeatable: true, ValueName: "DEPENDS", ValueDemanded: true, Short: "Add dependencies to the task", Long: "Add dependencies to the task"},
 	{Key: FlagTasksAddDir, ValueName: "DIR", ValueDemanded: true, Short: "Run the task in a specific directory", Long: "Run the task in a specific directory"},
@@ -5672,22 +5723,22 @@ var HelpText = argv.HelpTable{
 	{Key: FlagTasksAddSilent, Short: "Do not print the command or its output", Long: "Do not print the command or its output"},
 	{Key: ArgTasksAddTask, Demanded: true, Short: "Tasks name to add", Long: "Tasks name to add"},
 	{Key: ArgTasksAddRun},
-	{Key: CmdTasksDeps, Short: "Display a tree visualization of a dependency graph", AfterLongHelp: "Examples:\n\n    # Show dependencies for all tasks\n    $ mise tasks deps\n\n    # Show dependencies for the \"lint\", \"test\" and \"check\" tasks\n    $ mise tasks deps lint test check\n\n    # Show dependencies in DOT format\n    $ mise tasks deps --dot\n\n    # Collapse repeated dependencies\n    $ mise tasks deps --compact\n"},
+	{Key: CmdTasksDeps, Short: "Display a tree visualization of a dependency graph", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    # Show dependencies for all tasks\n    $ \x1b[1mmise tasks deps\x1b[22m\n\n    # Show dependencies for the \"lint\", \"test\" and \"check\" tasks\n    $ \x1b[1mmise tasks deps lint test check\x1b[22m\n\n    # Show dependencies in DOT format\n    $ \x1b[1mmise tasks deps --dot\x1b[22m\n\n    # Collapse repeated dependencies\n    $ \x1b[1mmise tasks deps --compact\x1b[22m\n"},
 	{Key: FlagTasksDepsCompact, Short: "Collapse repeated dependencies after their first occurrence", Long: "Collapse repeated dependencies after their first occurrence"},
 	{Key: FlagTasksDepsDot, Short: "Display dependencies in DOT format", Long: "Display dependencies in DOT format"},
 	{Key: FlagTasksDepsHidden, Short: "Show hidden tasks", Long: "Show hidden tasks"},
 	{Key: ArgTasksDepsTasks, Short: "Tasks to show dependencies for\nCan specify multiple tasks by separating with spaces\ne.g.: mise tasks deps lint test check", Long: "Tasks to show dependencies for\nCan specify multiple tasks by separating with spaces\ne.g.: mise tasks deps lint test check"},
-	{Key: CmdTasksEdit, Short: "Edit a task with $EDITOR", Long: "Edit a task with $EDITOR\n\nThe task will be created as a standalone script if it does not already exist.", AfterLongHelp: "Examples:\n\n    $ mise tasks edit build\n    $ mise tasks edit test\n"},
+	{Key: CmdTasksEdit, Short: "Edit a task with $EDITOR", Long: "Edit a task with $EDITOR\n\nThe task will be created as a standalone script if it does not already exist.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise tasks edit build\x1b[22m\n    $ \x1b[1mmise tasks edit test\x1b[22m\n"},
 	{Key: FlagTasksEditPath, Short: "Display the path to the task instead of editing it", Long: "Display the path to the task instead of editing it"},
 	{Key: ArgTasksEditTask, Demanded: true, Short: "Task to edit", Long: "Task to edit"},
-	{Key: CmdTasksGraph, Short: "[experimental] Inspect the workspace project graph", AfterLongHelp: "Examples:\n\n    # Inspect projects and their dependency edges\n    $ mise tasks graph\n\n    # Emit the project graph as JSON\n    $ mise tasks graph --json\n\n    # Explain where inferred projects and task fields came from\n    $ mise tasks graph --explain\n"},
+	{Key: CmdTasksGraph, Short: "[experimental] Inspect the workspace project graph", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    # Inspect projects and their dependency edges\n    $ \x1b[1mmise tasks graph\x1b[22m\n\n    # Emit the project graph as JSON\n    $ \x1b[1mmise tasks graph --json\x1b[22m\n\n    # Explain where inferred projects and task fields came from\n    $ \x1b[1mmise tasks graph --explain\x1b[22m\n"},
 	{Key: FlagTasksGraphJson, Short: "Output the project graph as JSON", Long: "Output the project graph as JSON"},
 	{Key: FlagTasksGraphExplain, Short: "Explain provider attribution for inferred projects and tasks", Long: "Explain provider attribution for inferred projects and tasks"},
 	{Key: FlagTasksGraphNoHeader, Short: "Do not print table headers", Long: "Do not print table headers"},
-	{Key: CmdTasksInfo, Short: "Get information about a task", AfterLongHelp: "Examples:\n\n    $ mise tasks info\n    Name: test\n    Aliases: t\n    Description: Test the application\n    Source: ~/src/myproj/mise.toml\n\n    $ mise tasks info test --json\n    {\n      \"name\": \"test\",\n      \"aliases\": \"t\",\n      \"description\": \"Test the application\",\n      \"source\": \"~/src/myproj/mise.toml\",\n      \"config_sources\": [\"~/src/myproj/mise.toml\"],\n      \"depends\": [],\n      \"env\": {},\n      \"dir\": null,\n      \"hide\": false,\n      \"raw\": false,\n      \"sources\": [],\n      \"outputs\": [],\n      \"run\": [\n        \"echo \\\"testing!\\\"\"\n      ],\n      \"file\": null,\n      \"usage_spec\": {}\n    }\n"},
+	{Key: CmdTasksInfo, Short: "Get information about a task", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise tasks info\x1b[22m\n    Name: test\n    Aliases: t\n    Description: Test the application\n    Source: ~/src/myproj/mise.toml\n\n    $ \x1b[1mmise tasks info test --json\x1b[22m\n    {\n      \"name\": \"test\",\n      \"aliases\": \"t\",\n      \"description\": \"Test the application\",\n      \"source\": \"~/src/myproj/mise.toml\",\n      \"config_sources\": [\"~/src/myproj/mise.toml\"],\n      \"depends\": [],\n      \"env\": {},\n      \"dir\": null,\n      \"hide\": false,\n      \"raw\": false,\n      \"sources\": [],\n      \"outputs\": [],\n      \"run\": [\n        \"echo \\\"testing!\\\"\"\n      ],\n      \"file\": null,\n      \"usage_spec\": {}\n    }\n"},
 	{Key: FlagTasksInfoJson, Short: "Output in JSON format", Long: "Output in JSON format"},
 	{Key: ArgTasksInfoTask, Demanded: true, Short: "Name of the task to get information about", Long: "Name of the task to get information about"},
-	{Key: CmdTasksLs, Short: "List available tasks to execute\nThese may be included from the config file or from the project's .mise/tasks directory\nmise will merge all tasks from all parent directories into this list.", Long: "List available tasks to execute\nThese may be included from the config file or from the project's .mise/tasks directory\nmise will merge all tasks from all parent directories into this list.\n\nSo if you have global tasks in `~/.config/mise/tasks/*` and project-specific tasks in\n~/myproject/.mise/tasks/*, then they'll both be available but the project-specific\ntasks will override the global ones if they have the same name.", AfterLongHelp: "Examples:\n\n    $ mise tasks ls\n"},
+	{Key: CmdTasksLs, Short: "List available tasks to execute\nThese may be included from the config file or from the project's .mise/tasks directory\nmise will merge all tasks from all parent directories into this list.", Long: "List available tasks to execute\nThese may be included from the config file or from the project's .mise/tasks directory\nmise will merge all tasks from all parent directories into this list.\n\nSo if you have global tasks in `~/.config/mise/tasks/*` and project-specific tasks in\n~/myproject/.mise/tasks/*, then they'll both be available but the project-specific\ntasks will override the global ones if they have the same name.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise tasks ls\x1b[22m\n"},
 	{Key: FlagTasksLsGlobal, Short: "Only show global tasks", Long: "Only show global tasks"},
 	{Key: FlagTasksLsJson, Short: "Output in JSON format", Long: "Output in JSON format"},
 	{Key: FlagTasksLsLocal, Short: "Only show non-global tasks", Long: "Only show non-global tasks"},
@@ -5700,23 +5751,24 @@ var HelpText = argv.HelpTable{
 	{Key: FlagTasksLsSort, ValueName: "COLUMN", ValueDemanded: true, Short: "Sort by column. Default is name.", Long: "Sort by column. Default is name.", Choices: []string{"name", "alias", "description", "source"}},
 	{Key: FlagTasksLsSortOrder, ValueName: "SORT_ORDER", ValueDemanded: true, Short: "Sort order. Default is asc.", Long: "Sort order. Default is asc.", Choices: []string{"asc", "desc"}},
 	{Key: FlagTasksLsUsage, Hide: true},
-	{Key: CmdTasksRun, Short: "Run task(s)", Long: "Run task(s)\n\nThis command will run a task, or multiple tasks in parallel.\nTasks may have dependencies on other tasks or on source files.\nIf source is configured on a task, it will only run if the source\nfiles have changed.\n\nTasks can be defined in mise.toml or as standalone scripts.\nIn mise.toml, tasks take this form:\n\n    [tasks.build]\n    run = \"npm run build\"\n    sources = [\"src/**/*.ts\"]\n    outputs = [\"dist/**/*.js\"]\n\nAlternatively, tasks can be defined as standalone scripts.\nThese must be located in `mise-tasks`, `.mise-tasks`, `.mise/tasks`, `mise/tasks` or\n`.config/mise/tasks`.\nThe name of the script will be the name of the tasks.\n\n    $ cat .mise/tasks/build<<EOF\n    #!/usr/bin/env bash\n    npm run build\n    EOF\n    $ mise run build", VisibleAliases: []string{"r"}, AfterLongHelp: "Examples:\n\n    # Runs the \"lint\" tasks. This needs to either be defined in mise.toml\n    # or as a standalone script. See the project README for more information.\n    $ mise run lint\n\n    # Forces the \"build\" tasks to run even if its sources are up-to-date.\n    $ mise run --force build\n\n    # Run \"test\" with stdin/stdout/stderr all connected to the current terminal.\n    # This forces `--jobs=1` to prevent interleaving of output.\n    $ mise run --raw test\n\n    # Runs the \"lint\", \"test\", and \"check\" tasks in parallel.\n    $ mise run lint ::: test ::: check\n\n    # Execute multiple tasks each with their own arguments.\n    $ mise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2\n"},
+	{Key: CmdTasksRun, Short: "Run task(s)", Long: "Run task(s)\n\nThis command will run a task, or multiple tasks in parallel.\nTasks may have dependencies on other tasks or on source files.\nIf source is configured on a task, it will only run if the source\nfiles have changed.\n\nTasks can be defined in mise.toml or as standalone scripts.\nIn mise.toml, tasks take this form:\n\n    [tasks.build]\n    run = \"npm run build\"\n    sources = [\"src/**/*.ts\"]\n    outputs = [\"dist/**/*.js\"]\n\nAlternatively, tasks can be defined as standalone scripts.\nThese must be located in `mise-tasks`, `.mise-tasks`, `.mise/tasks`, `mise/tasks` or\n`.config/mise/tasks`.\nThe name of the script will be the name of the tasks.\n\n    $ cat .mise/tasks/build<<EOF\n    #!/usr/bin/env bash\n    npm run build\n    EOF\n    $ mise run build", VisibleAliases: []string{"r"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    # Runs the \"lint\" tasks. This needs to either be defined in mise.toml\n    # or as a standalone script. See the project README for more information.\n    $ \x1b[1mmise run lint\x1b[22m\n\n    # Forces the \"build\" tasks to run even if its sources are up-to-date.\n    $ \x1b[1mmise run --force build\x1b[22m\n\n    # Run \"test\" with stdin/stdout/stderr all connected to the current terminal.\n    # This forces `--jobs=1` to prevent interleaving of output.\n    $ \x1b[1mmise run --raw test\x1b[22m\n\n    # Runs the \"lint\", \"test\", and \"check\" tasks in parallel.\n    $ \x1b[1mmise run lint ::: test ::: check\x1b[22m\n\n    # Execute multiple tasks each with their own arguments.\n    $ \x1b[1mmise run cmd1 arg1 arg2 ::: cmd2 arg1 arg2\x1b[22m\n"},
 	{Key: FlagTasksRunAffected, Short: "Run matching tasks only for projects affected by Git changes", Long: "Run matching tasks only for projects affected by Git changes"},
 	{Key: FlagTasksRunAffectedBase, ValueName: "REV", ValueDemanded: true, Short: "Git base revision for --affected\nDefaults to MISE_AFFECTED_BASE, CI metadata, or HEAD~1", Long: "Git base revision for --affected\nDefaults to MISE_AFFECTED_BASE, CI metadata, or HEAD~1"},
 	{Key: FlagTasksRunAffectedExplain, Short: "Explain why projects and tasks were selected by --affected", Long: "Explain why projects and tasks were selected by --affected"},
 	{Key: FlagTasksRunAffectedHead, ValueName: "REV", ValueDemanded: true, Short: "Git head revision for --affected\nDefaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD", Long: "Git head revision for --affected\nDefaults to MISE_AFFECTED_HEAD, CI metadata, or HEAD"},
 	{Key: FlagTasksRunAffectedJson, Short: "Output affected projects and tasks as JSON without running tasks", Long: "Output affected projects and tasks as JSON without running tasks"},
+	{Key: FlagTasksRunAll, Short: "Open the interactive selector with all tasks from the entire monorepo", Long: "Open the interactive selector with all tasks from the entire monorepo"},
 	{Key: FlagTasksRunContinueOnError, Short: "Continue running tasks even if one fails", Long: "Continue running tasks even if one fails"},
 	{Key: FlagTasksRunCd, ValueName: "CD", ValueDemanded: true, Short: "Change to this directory before executing the command", Long: "Change to this directory before executing the command"},
 	{Key: FlagTasksRunForce, Short: "Force the tasks to run even if outputs are up to date", Long: "Force the tasks to run even if outputs are up to date"},
-	{Key: FlagTasksRunJobs, ValueName: "JOBS", ValueDemanded: true, Short: "Number of tasks to run in parallel\n[default: 4]\nConfigure with `jobs` config or `MISE_JOBS` env var", Long: "Number of tasks to run in parallel\n[default: 4]\nConfigure with `jobs` config or `MISE_JOBS` env var"},
+	{Key: FlagTasksRunJobs, ValueName: "JOBS", ValueDemanded: true, Short: "Number of tasks to run in parallel\nValues below 1 are treated as 1\n[default: 4]\nConfigure with `jobs` config or `MISE_JOBS` env var", Long: "Number of tasks to run in parallel\nValues below 1 are treated as 1\n[default: 4]\nConfigure with `jobs` config or `MISE_JOBS` env var", Env: "MISE_JOBS"},
 	{Key: FlagTasksRunDryRun, Short: "Don't actually run the task(s), just print them in order of execution", Long: "Don't actually run the task(s), just print them in order of execution"},
-	{Key: FlagTasksRunOutput, ValueName: "OUTPUT", ValueDemanded: true, Short: "Change how tasks information is output when running tasks", Long: "Change how tasks information is output when running tasks\n\n- `prefix` - Print stdout/stderr by line, prefixed with the task's label\n- `interleave` - Print directly to stdout/stderr instead of by line\n- `replacing` - Stdout is replaced each time, stderr is printed as is\n- `timed` - Only show stdout lines if they are displayed for more than 1 second\n- `keep-order` - Print stdout/stderr by line, prefixed with the task's label, but keep the order of the output\n- `quiet` - Don't show extra output\n- `silent` - Don't show any output including stdout and stderr from the task except for errors"},
-	{Key: FlagTasksRunQuiet, Short: "Don't show extra output", Long: "Don't show extra output"},
+	{Key: FlagTasksRunOutput, ValueName: "OUTPUT", ValueDemanded: true, Short: "Change how tasks information is output when running tasks", Long: "Change how tasks information is output when running tasks\n\n- `prefix` - Print stdout/stderr by line, prefixed with the task's label\n- `interleave` - Print directly to stdout/stderr instead of by line\n- `replacing` - Stdout is replaced each time, stderr is printed as is\n- `timed` - Only show stdout lines if they are displayed for more than 1 second\n- `keep-order` - Print stdout/stderr by line, prefixed with the task's label, but keep the order of the output\n- `quiet` - Don't show extra output\n- `silent` - Don't show any output including stdout and stderr from the task except for errors", Env: "MISE_TASK_OUTPUT"},
+	{Key: FlagTasksRunQuiet, Short: "Don't show extra output", Long: "Don't show extra output", Env: "MISE_QUIET"},
 	{Key: FlagTasksRunRaw, Short: "Read/write directly to stdin/stdout/stderr instead of by line\nRedactions are not applied with this option\nConfigure with `raw` config or `MISE_RAW` env var", Long: "Read/write directly to stdin/stdout/stderr instead of by line\nRedactions are not applied with this option\nConfigure with `raw` config or `MISE_RAW` env var"},
 	{Key: FlagTasksRunShell, ValueName: "SHELL", ValueDemanded: true, Short: "Shell to use to run toml tasks", Long: "Shell to use to run toml tasks\n\nDefaults to `sh -c -o errexit -o pipefail` on unix, and `cmd /c` on Windows\nCan also be set with the setting `MISE_UNIX_DEFAULT_INLINE_SHELL_ARGS` or `MISE_WINDOWS_DEFAULT_INLINE_SHELL_ARGS`\nOr it can be overridden with the `shell` property on a task."},
-	{Key: FlagTasksRunSilent, Short: "Don't show any output except for errors", Long: "Don't show any output except for errors"},
-	{Key: FlagTasksRunTool, Repeatable: true, ValueName: "TOOL@VERSION", ValueDemanded: true, Short: "Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10", Long: "Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10"},
+	{Key: FlagTasksRunSilent, Short: "Don't show any output except for errors", Long: "Don't show any output except for errors", Env: "MISE_SILENT"},
+	{Key: FlagTasksRunTool, Repeatable: true, ValueName: "TOOL@VERSION", ValueDemanded: true, Short: "Tool(s) to run in addition to what is in mise.toml files e.g.: node@20 python@3.10", Long: "Tool(s) to run in addition to what is in mise.toml files\ne.g.: node@20 python@3.10"},
 	{Key: FlagTasksRunAllowEnv, Repeatable: true, ValueName: "VAR", ValueDemanded: true, Short: "Allow specific env var through (implies --deny-env for everything else)\nSupports wildcards, e.g. --allow-env='MYAPP_*'", Long: "Allow specific env var through (implies --deny-env for everything else)\nSupports wildcards, e.g. --allow-env='MYAPP_*'"},
 	{Key: FlagTasksRunAllowNet, Repeatable: true, ValueName: "HOST", ValueDemanded: true, Short: "Allow network to specific host (implies --deny-net for everything else)", Long: "Allow network to specific host (implies --deny-net for everything else)"},
 	{Key: FlagTasksRunAllowRead, Repeatable: true, ValueName: "PATH", ValueDemanded: true, Short: "Allow reads from specific path (implies --deny-read for everything else)", Long: "Allow reads from specific path (implies --deny-read for everything else)"},
@@ -5727,45 +5779,45 @@ var HelpText = argv.HelpTable{
 	{Key: FlagTasksRunDenyRead, Short: "Block filesystem reads (system libs and tool dirs still accessible)", Long: "Block filesystem reads (system libs and tool dirs still accessible)"},
 	{Key: FlagTasksRunDenyWrite, Short: "Block all filesystem writes", Long: "Block all filesystem writes"},
 	{Key: FlagTasksRunFreshEnv, Short: "Bypass the environment cache and recompute the environment", Long: "Bypass the environment cache and recompute the environment"},
-	{Key: FlagTasksRunNoCache, Short: "Do not use cache on remote tasks", Long: "Do not use cache on remote tasks"},
+	{Key: FlagTasksRunNoCache, Short: "Do not use cache on remote tasks", Long: "Do not use cache on remote tasks", Env: "MISE_TASK_REMOTE_NO_CACHE"},
 	{Key: FlagTasksRunNoDeps, Short: "Skip automatic dependency preparation", Long: "Skip automatic dependency preparation"},
 	{Key: FlagTasksRunNoTimings, Short: "Hides elapsed time after each task completes", Long: "Hides elapsed time after each task completes\n\nDefault to always hide with `MISE_TASK_TIMINGS=0`"},
-	{Key: FlagTasksRunSkipDeps, Short: "Run only the specified tasks skipping all dependencies", Long: "Run only the specified tasks skipping all dependencies"},
+	{Key: FlagTasksRunSkipDeps, Short: "Run only the specified tasks skipping all dependencies", Long: "Run only the specified tasks skipping all dependencies", Env: "MISE_TASK_SKIP_DEPENDS"},
 	{Key: FlagTasksRunSkipTools, Short: "Skip installing tools before running tasks", Long: "Skip installing tools before running tasks\n\nCan also be set persistently with the `task.run_auto_install` setting\nor `MISE_TASK_RUN_AUTO_INSTALL=false` env var"},
-	{Key: FlagTasksRunTaskCache, ValueName: "TASK_CACHE", ValueDemanded: true, Short: "Set task output cache access for this run", Long: "Set task output cache access for this run\n\n- `read-write` - Read cached results and write new results\n- `read-only` - Read cached results without writing new results\n- `write-only` - Write new results without reading cached results\n- `off` - Disable task output caching\n- `local-only` - Read and write only the local cache; currently equivalent to `read-write`", Choices: []string{"read-write", "read-only", "write-only", "off", "local-only"}, Default: []string{"read-write"}},
+	{Key: FlagTasksRunTaskCache, ValueName: "TASK_CACHE", ValueDemanded: true, Short: "Set task output cache access for this run", Long: "Set task output cache access for this run\n\n- `read-write` - Read cached results and write new results\n- `read-only` - Read cached results without writing new results\n- `write-only` - Write new results without reading cached results\n- `off` - Disable task output caching\n- `local-only` - Read and write only the local cache; currently equivalent to `read-write`", Choices: []string{"read-write", "read-only", "write-only", "off", "local-only"}, Env: "MISE_TASK_CACHE", Default: []string{"read-write"}},
 	{Key: FlagTasksRunTaskCacheExplain, Short: "Explain the inputs that produced each task's output cache key", Long: "Explain the inputs that produced each task's output cache key"},
 	{Key: FlagTasksRunTaskCacheExplainJson, Short: "Output cache-key input details as JSON Lines without running tasks", Long: "Output cache-key input details as JSON Lines without running tasks"},
 	{Key: FlagTasksRunTaskCacheStats, Short: "Report task output cache hits, restored bytes, and time saved", Long: "Report task output cache hits, restored bytes, and time saved"},
 	{Key: FlagTasksRunTimeout, ValueName: "TIMEOUT", ValueDemanded: true, Short: "Timeout for the task to complete\ne.g.: 30s, 5m", Long: "Timeout for the task to complete\ne.g.: 30s, 5m"},
 	{Key: FlagTasksRunTimings, Hide: true, Short: "Shows elapsed time after each task completes", Long: "Shows elapsed time after each task completes\n\nDefault to always show with `MISE_TASK_TIMINGS=1`"},
-	{Key: ArgTasksRunTask, Short: "Tasks to run\nCan specify multiple tasks by separating with `:::`\ne.g.: mise run task1 arg1 arg2 ::: task2 arg1 arg2", Long: "Tasks to run\nCan specify multiple tasks by separating with `:::`\ne.g.: mise run task1 arg1 arg2 ::: task2 arg1 arg2", Default: []string{"default"}},
-	{Key: ArgTasksRunArgs, Short: "Arguments to pass to the tasks. Use \":::\" to separate tasks", Long: "Arguments to pass to the tasks. Use \":::\" to separate tasks"},
-	{Key: ArgTasksRunArgsLast, Hide: true, Short: "Arguments to pass to the tasks. Use \":::\" to separate tasks", Long: "Arguments to pass to the tasks. Use \":::\" to separate tasks"},
-	{Key: CmdTasksValidate, Short: "Validate tasks for common errors and issues", AfterLongHelp: "Examples:\n\n    # Validate all tasks\n    $ mise tasks validate\n\n    # Validate specific tasks\n    $ mise tasks validate build test\n\n    # Output results as JSON\n    $ mise tasks validate --json\n\n    # Only show errors (skip warnings)\n    $ mise tasks validate --errors-only\n\nValidation Checks:\n\nThe validate command performs the following checks:\n\n  • Circular Dependencies: Detects dependency cycles\n  • Missing References: Finds references to nonexistent tasks\n  • Usage Spec Parsing: Validates #USAGE directives and specs\n  • Timeout Format: Checks timeout values are valid durations\n  • Alias Conflicts: Detects duplicate aliases across tasks\n  • File Existence: Verifies file-based tasks exist\n  • Directory Templates: Validates directory paths and templates\n  • Shell Commands: Checks shell executables exist\n  • Glob Patterns: Validates source and output patterns\n  • Run Entries: Ensures tasks reference valid dependencies\n"},
+	{Key: ArgTasksRunTask, Short: "Tasks to run\nCan specify multiple tasks by separating with `:::`\ne.g.: mise run task1 arg1 arg2 ::: task2 arg1 arg2\nDefaults to `default` when omitted", Long: "Tasks to run\nCan specify multiple tasks by separating with `:::`\ne.g.: mise run task1 arg1 arg2 ::: task2 arg1 arg2\nDefaults to `default` when omitted"},
+	{Key: ArgTasksRunArgs, Short: "Arguments to pass to the tasks. Use \":::\" to separate tasks.", Long: "Arguments to pass to the tasks. Use \":::\" to separate tasks."},
+	{Key: ArgTasksRunArgsLast, Hide: true, Short: "Arguments to pass to the tasks. Use \":::\" to separate tasks.", Long: "Arguments to pass to the tasks. Use \":::\" to separate tasks."},
+	{Key: CmdTasksValidate, Short: "Validate tasks for common errors and issues", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    # Validate all tasks\n    $ \x1b[1mmise tasks validate\x1b[22m\n\n    # Validate specific tasks\n    $ \x1b[1mmise tasks validate build test\x1b[22m\n\n    # Output results as JSON\n    $ \x1b[1mmise tasks validate --json\x1b[22m\n\n    # Only show errors (skip warnings)\n    $ \x1b[1mmise tasks validate --errors-only\x1b[22m\n\n\x1b[1m\x1b[4mValidation Checks:\x1b[22m\x1b[24m\n\nThe validate command performs the following checks:\n\n  • \x1b[1mCircular Dependencies\x1b[22m: Detects dependency cycles\n  • \x1b[1mMissing References\x1b[22m: Finds references to nonexistent tasks\n  • \x1b[1mUsage Spec Parsing\x1b[22m: Validates #USAGE directives and specs\n  • \x1b[1mTimeout Format\x1b[22m: Checks timeout values are valid durations\n  • \x1b[1mAlias Conflicts\x1b[22m: Detects duplicate aliases across tasks\n  • \x1b[1mFile Existence\x1b[22m: Verifies file-based tasks exist\n  • \x1b[1mDirectory Templates\x1b[22m: Validates directory paths and templates\n  • \x1b[1mShell Commands\x1b[22m: Checks shell executables exist\n  • \x1b[1mGlob Patterns\x1b[22m: Validates source and output patterns\n  • \x1b[1mRun Entries\x1b[22m: Ensures tasks reference valid dependencies\n"},
 	{Key: FlagTasksValidateErrorsOnly, Short: "Only show errors (skip warnings)", Long: "Only show errors (skip warnings)"},
 	{Key: FlagTasksValidateJson, Short: "Output validation results in JSON format", Long: "Output validation results in JSON format"},
 	{Key: ArgTasksValidateTasks, Short: "Tasks to validate\nIf not specified, validates all tasks", Long: "Tasks to validate\nIf not specified, validates all tasks"},
-	{Key: CmdTestTool, Short: "Test a tool installs and executes", AfterLongHelp: "Examples:\n\n    $ mise test-tool ripgrep\n"},
+	{Key: CmdTestTool, Short: "Test a tool installs and executes", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise test-tool ripgrep\x1b[22m\n"},
 	{Key: FlagTestToolAll, Short: "Test every tool specified in registry/", Long: "Test every tool specified in registry/"},
-	{Key: FlagTestToolJobs, ValueName: "JOBS", ValueDemanded: true, Short: "Number of tool tests to run in parallel\n[default: 4]", Long: "Number of tool tests to run in parallel\n[default: 4]"},
+	{Key: FlagTestToolJobs, ValueName: "JOBS", ValueDemanded: true, Short: "Number of tool tests to run in parallel\nValues below 1 are treated as 1\n[default: 4]", Long: "Number of tool tests to run in parallel\nValues below 1 are treated as 1\n[default: 4]", Env: "MISE_TEST_TOOL_JOBS"},
 	{Key: FlagTestToolAllConfig, Short: "Test all tools specified in config files", Long: "Test all tools specified in config files"},
 	{Key: FlagTestToolIncludeNonDefined, Short: "Also test tools not defined in registry/, guessing how to test it", Long: "Also test tools not defined in registry/, guessing how to test it"},
-	{Key: FlagTestToolRaw, Short: "Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1", Long: "Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1"},
+	{Key: FlagTestToolRaw, Short: "Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1", Long: "Connect backend install command stdin/stdout/stderr directly to the terminal\nImplies --jobs=1"},
 	{Key: ArgTestToolTools, Short: "Tool(s) to test", Long: "Tool(s) to test"},
 	{Key: CmdToken, Short: "Display git provider tokens mise will use", SubcommandRequired: true},
-	{Key: CmdTokenForgejo, Short: "Forgejo token", AfterLongHelp: "Examples:\n\n    $ mise token forgejo\n    codeberg.org: a180…61f6 (source: FORGEJO_TOKEN)\n\n    $ mise token forgejo --unmask\n    codeberg.org: a18099ca69064be387fbe37b8ad1d333758361f6 (source: FORGEJO_TOKEN)\n\n    $ mise token forgejo forgejo.mycompany.com\n    forgejo.mycompany.com: (none)\n"},
+	{Key: CmdTokenForgejo, Short: "Forgejo token", Long: "Display the Forgejo token mise will use for a given host\n\nShows which token source mise would use, useful for debugging\nauthentication issues. The token is masked by default.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise token forgejo\x1b[22m\n    codeberg.org: a180…61f6 (source: FORGEJO_TOKEN)\n\n    $ \x1b[1mmise token forgejo --unmask\x1b[22m\n    codeberg.org: a18099ca69064be387fbe37b8ad1d333758361f6 (source: FORGEJO_TOKEN)\n\n    $ \x1b[1mmise token forgejo forgejo.mycompany.com\x1b[22m\n    forgejo.mycompany.com: (none)\n"},
 	{Key: FlagTokenForgejoUnmask, Short: "Show the full unmasked token", Long: "Show the full unmasked token"},
 	{Key: ArgTokenForgejoHost, Short: "Forgejo hostname", Long: "Forgejo hostname", Default: []string{"codeberg.org"}},
-	{Key: CmdTokenGithub, Short: "GitHub token", AfterLongHelp: "Examples:\n\n    $ mise token github\n    github.com: ghp_…xxxx (source: GITHUB_TOKEN)\n\n    $ mise token github --unmask\n    github.com: ghp_xxxxxxxxxxxx (source: GITHUB_TOKEN)\n\n    $ mise token github github.mycompany.com\n    github.mycompany.com: (none)\n\n    $ mise token github --oauth --refresh\n    github.com: gho_…xxxx (source: GitHub OAuth)\n"},
-	{Key: FlagTokenGithubOauth, Short: "Resolve only via the native GitHub OAuth source (cache, refresh, or device-code flow), bypassing other token sources", Long: "Resolve only via the native GitHub OAuth source (cache, refresh, or device-code flow), bypassing other token sources"},
+	{Key: CmdTokenGithub, Short: "GitHub token", Long: "Display the GitHub token mise will use for a given host\n\nShows which token source mise would use, useful for debugging\nauthentication issues. The token is masked by default.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise token github\x1b[22m\n    github.com: ghp_…xxxx (source: GITHUB_TOKEN)\n\n    $ \x1b[1mmise token github --unmask\x1b[22m\n    github.com: ghp_xxxxxxxxxxxx (source: GITHUB_TOKEN)\n\n    $ \x1b[1mmise token github github.mycompany.com\x1b[22m\n    github.mycompany.com: (none)\n\n    $ \x1b[1mmise token github --oauth --refresh\x1b[22m\n    github.com: gho_…xxxx (source: GitHub OAuth)\n"},
+	{Key: FlagTokenGithubOauth, Short: "Resolve only via the native GitHub OAuth source (cache, refresh, or device-code flow), bypassing other token sources", Long: "Resolve only via the native GitHub OAuth source (cache,\nrefresh, or device-code flow), bypassing other token sources"},
 	{Key: FlagTokenGithubRaw, Short: "Print only the token value", Long: "Print only the token value"},
-	{Key: FlagTokenGithubRefresh, Short: "Mint a fresh OAuth token even if the cached one has not expired, via the refresh-token grant or a new device-code flow. Use after changing the GitHub App's installations or permissions: cached tokens keep their original access until they expire", Long: "Mint a fresh OAuth token even if the cached one has not expired, via the refresh-token grant or a new device-code flow. Use after changing the GitHub App's installations or permissions: cached tokens keep their original access until they expire"},
+	{Key: FlagTokenGithubRefresh, Short: "Mint a fresh OAuth token even if the cached one has not expired, via the refresh-token grant or a new device-code flow. Use after changing the GitHub App's installations or permissions: cached tokens keep their original access until they expire", Long: "Mint a fresh OAuth token even if the cached one has not\nexpired, via the refresh-token grant or a new device-code flow.\nUse after changing the GitHub App's installations or permissions:\ncached tokens keep their original access until they expire"},
 	{Key: FlagTokenGithubUnmask, Short: "Show the full unmasked token", Long: "Show the full unmasked token"},
 	{Key: ArgTokenGithubHost, Short: "GitHub hostname", Long: "GitHub hostname", Default: []string{"github.com"}},
-	{Key: CmdTokenGitlab, Short: "GitLab token", AfterLongHelp: "Examples:\n\n    $ mise token gitlab\n    gitlab.com: glpa…xxxx (source: GITLAB_TOKEN)\n\n    $ mise token gitlab --unmask\n    gitlab.com: glpat-xxxxxxxxxxxx (source: GITLAB_TOKEN)\n\n    $ mise token gitlab gitlab.mycompany.com\n    gitlab.mycompany.com: (none)\n"},
+	{Key: CmdTokenGitlab, Short: "GitLab token", Long: "Display the GitLab token mise will use for a given host\n\nShows which token source mise would use, useful for debugging\nauthentication issues. The token is masked by default.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise token gitlab\x1b[22m\n    gitlab.com: glpa…xxxx (source: GITLAB_TOKEN)\n\n    $ \x1b[1mmise token gitlab --unmask\x1b[22m\n    gitlab.com: glpat-xxxxxxxxxxxx (source: GITLAB_TOKEN)\n\n    $ \x1b[1mmise token gitlab gitlab.mycompany.com\x1b[22m\n    gitlab.mycompany.com: (none)\n"},
 	{Key: FlagTokenGitlabUnmask, Short: "Show the full unmasked token", Long: "Show the full unmasked token"},
 	{Key: ArgTokenGitlabHost, Short: "GitLab hostname", Long: "GitLab hostname", Default: []string{"gitlab.com"}},
-	{Key: CmdTool, Short: "Gets information about a tool", AfterLongHelp: "Examples:\n\n    $ mise tool node\n    Backend:            core\n    Installed Versions: 20.0.0 22.0.0\n    Active Version:     20.0.0\n    Requested Version:  20\n    Config Source:      ~/.config/mise/mise.toml\n    Tool Options:       [none]\n"},
+	{Key: CmdTool, Short: "Gets information about a tool", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise tool node\x1b[22m\n    Backend:            core\n    Installed Versions: 20.0.0 22.0.0\n    Active Version:     20.0.0\n    Requested Version:  20\n    Config Source:      ~/.config/mise/mise.toml\n    Tool Options:       [none]\n"},
 	{Key: FlagToolJson, Short: "Output in JSON format", Long: "Output in JSON format"},
 	{Key: FlagToolActive, Short: "Only show active versions", Long: "Only show active versions"},
 	{Key: FlagToolBackend, Short: "Only show backend field", Long: "Only show backend field"},
@@ -5775,36 +5827,37 @@ var HelpText = argv.HelpTable{
 	{Key: FlagToolRequested, Short: "Only show requested versions", Long: "Only show requested versions"},
 	{Key: FlagToolToolOptions, Short: "Only show tool options", Long: "Only show tool options"},
 	{Key: ArgToolTool, Demanded: true, Short: "Tool name to get information about", Long: "Tool name to get information about"},
-	{Key: CmdToolStub, Short: "Execute a tool stub", Long: "Execute a tool stub\n\nTool stubs are executable files containing TOML configuration that specify which tool to run and how to run it. They provide a convenient way to create portable, self-contained executables that automatically manage tool installation and execution.\n\nA tool stub consists of: - A shebang line: #!/usr/bin/env -S mise tool-stub - TOML configuration specifying the tool, version, and options - Optional comments describing the tool's purpose\n\nExample stub file: #!/usr/bin/env -S mise tool-stub # Node.js v20 development environment\n\ntool = \"node\" version = \"20.0.0\" bin = \"node\"\n\nThe stub will automatically install the specified tool version if missing and execute it with any arguments passed to the stub.\n\nFor more information, see: https://mise.jdx.dev/dev-tools/tool-stubs.html"},
-	{Key: ArgToolStubFile, Demanded: true, Short: "Path to the TOML tool stub file to execute", Long: "Path to the TOML tool stub file to execute\n\nThe stub file must contain TOML configuration specifying the tool and version to run. At minimum, it should specify a 'version' field. Other common fields include 'tool', 'bin', and backend-specific options."},
-	{Key: ArgToolStubArgs, Short: "Arguments to pass to the tool", Long: "Arguments to pass to the tool\n\nAll arguments after the stub file path will be forwarded to the underlying tool. Use '--' to separate mise arguments from tool arguments if needed."},
-	{Key: CmdTrust, Short: "Marks a config file as trusted", Long: "Marks a config file as trusted\n\nThis means mise is allowed to parse the file when it needs to read config\nthat may execute code or affect the environment. mise checks trust before\nparsing `mise.toml`. Without trust, mise may prompt, skip the config in some\ndiscovery paths, fail with an untrusted-config error when it cannot prompt,\nor assume trust in detected CI unless paranoid mode is enabled.\n\nSafe config files do not require trust: files that only contain\n`min_version`, `[tools]` entries with plain version strings (or arrays\nof them), and `[tasks]` (no templates and no tool options) are loaded\nwithout prompting, since nothing in them executes code at load time —\ntools install and tasks run only on explicit commands like `mise install`\nor `mise run`.\n\nTrust is shared across git worktrees: a config file inside a linked\nworktree is trusted when the equivalent path in the repository's main\ncheckout has been trusted. Paranoid mode disables this sharing since\nworktrees can check out branches with different config contents.", AfterLongHelp: "Examples:\n\n    # trusts ~/some_dir/mise.toml\n    $ mise trust ~/some_dir/mise.toml\n\n    # trusts mise.toml in the current or parent directory\n    $ mise trust\n"},
+	{Key: CmdToolStub, Short: "Execute a tool stub", Long: "Execute a tool stub\n\nTool stubs are executable files containing TOML configuration that specify\nwhich tool to run and how to run it. They provide a convenient way to create\nportable, self-contained executables that automatically manage tool installation\nand execution.\n\nA tool stub consists of:\n- A shebang line: #!/usr/bin/env -S mise tool-stub\n- TOML configuration specifying the tool, version, and options\n- Optional comments describing the tool's purpose\n\nExample stub file:\n  #!/usr/bin/env -S mise tool-stub\n  # Node.js v20 development environment\n\n  tool = \"node\"\n  version = \"20.0.0\"\n  bin = \"node\"\n\nThe stub will automatically install the specified tool version if missing\nand execute it with any arguments passed to the stub.\n\nFor more information, see: https://mise.jdx.dev/dev-tools/tool-stubs.html"},
+	{Key: ArgToolStubFile, Demanded: true, Short: "Path to the TOML tool stub file to execute", Long: "Path to the TOML tool stub file to execute\n\nThe stub file must contain TOML configuration specifying the tool\nand version to run. At minimum, it should specify a 'version' field.\nOther common fields include 'tool', 'bin', and backend-specific options."},
+	{Key: ArgToolStubArgs, Short: "Arguments to pass to the tool", Long: "Arguments to pass to the tool\n\nAll arguments after the stub file path will be forwarded to the\nunderlying tool. Use '--' to separate mise arguments from tool arguments\nif needed."},
+	{Key: CmdTrust, Short: "Marks a config file as trusted", Long: "Marks a config file as trusted\n\nThis means mise is allowed to parse the file when it needs to read config\nthat may execute code or affect the environment. Without trust, mise may\nprompt, skip the config in some discovery paths, or fail with an\nuntrusted-config error when it cannot prompt.\n\nIn normal mode, commands that execute project-defined behavior (`mise run`,\nnaked task invocations such as `mise <TASK>`, `mise install`, `mise exec`,\nand `mise watch`) automatically trust their active config. Paranoid mode\nrequires explicit, content-bound trust for every non-global config.\n\nIn normal mode, safe config files do not require trust: files that only contain\n`min_version`, `[tools]` entries with plain version strings (or arrays of\nthem), and `[tasks]` without templates or tool options.\n\nTrust is shared across git worktrees: a config file inside a linked\nworktree is trusted when the equivalent path in the repository's main\ncheckout has been trusted. Paranoid mode disables this sharing since\nworktrees can check out branches with different config contents.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    # trusts ~/some_dir/mise.toml\n    $ \x1b[1mmise trust ~/some_dir/mise.toml\x1b[22m\n\n    # trusts mise.toml in the current or parent directory\n    $ \x1b[1mmise trust\x1b[22m\n"},
 	{Key: FlagTrustAll, Short: "Trust all config files in the current directory, its parents, and its subdirectories", Long: "Trust all config files in the current directory, its parents, and its subdirectories\n\nSubdirectories are walked respecting .gitignore, skipping hidden directories\nand common build/dependency directories (node_modules, vendor, target, dist, build)."},
 	{Key: FlagTrustIgnore, Short: "Do not trust this config and ignore it in the future", Long: "Do not trust this config and ignore it in the future"},
 	{Key: FlagTrustShow, Short: "Show the trusted status of config files from the current directory and its parents.\nDoes not trust or untrust any files.", Long: "Show the trusted status of config files from the current directory and its parents.\nDoes not trust or untrust any files."},
-	{Key: FlagTrustUntrust, Short: "No longer trust this config, will prompt in the future", Long: "No longer trust this config, will prompt in the future"},
-	{Key: ArgTrustConfigFile, Short: "The config file to trust", Long: "The config file to trust"},
-	{Key: CmdUninstall, Short: "Removes installed tool versions", Long: "Removes installed tool versions\n\nThis only removes the installed version, it does not modify mise.toml.", AfterLongHelp: "Examples:\n\n    # will uninstall specific version\n    $ mise uninstall node@18.0.0\n\n    # will uninstall the current node version (if only one version is installed)\n    $ mise uninstall node\n\n    # will uninstall all installed versions of node\n    $ mise uninstall --all node@18.0.0 # will uninstall all node versions\n"},
+	{Key: FlagTrustUntrust, Short: "Remove explicit trust for this config", Long: "Remove explicit trust for this config"},
+	{Key: ArgTrustConfigFile, Short: "The config file whose trust status to change", Long: "The config file whose trust status to change"},
+	{Key: CmdUninstall, Short: "Removes installed tool versions", Long: "Removes installed tool versions\n\nThis only removes the installed version, it does not modify mise.toml.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    # will uninstall specific version\n    $ \x1b[1mmise uninstall node@18.0.0\x1b[22m\n\n    # will uninstall the current node version (if only one version is installed)\n    $ \x1b[1mmise uninstall node\x1b[22m\n\n    # will uninstall all installed versions of node\n    $ \x1b[1mmise uninstall --all node@18.0.0\x1b[22m # will uninstall all node versions\n"},
 	{Key: FlagUninstallAll, Short: "Delete all installed versions", Long: "Delete all installed versions"},
 	{Key: FlagUninstallDryRun, Short: "Do not actually delete anything", Long: "Do not actually delete anything"},
 	{Key: FlagUninstallDryRunCode, Short: "Like --dry-run but exits with code 1 if there are tools to uninstall", Long: "Like --dry-run but exits with code 1 if there are tools to uninstall\n\nThis is useful for scripts to check if tools need to be uninstalled."},
 	{Key: ArgUninstallInstalledToolVersion, Short: "Tool(s) to remove", Long: "Tool(s) to remove"},
-	{Key: CmdUnset, Short: "Remove environment variable(s) from the config file.", Long: "Remove environment variable(s) from the config file.\n\nBy default, this command modifies `mise.toml` in the current directory.", AfterLongHelp: "Examples:\n\n    # Remove NODE_ENV from the current directory's config\n    $ mise unset NODE_ENV\n\n    # Remove NODE_ENV from the global config\n    $ mise unset NODE_ENV -g\n"},
-	{Key: FlagUnsetFile, ValueName: "FILE", ValueDemanded: true, Short: "Specify a file to use instead of `mise.toml`", Long: "Specify a file to use instead of `mise.toml`\n\nCan be a file path or directory. If a directory is provided, will create/use mise.toml in that directory.\n\nDefaults to [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) environment variable, or `mise.toml`. Use [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path."},
+	{Key: CmdUnset, Short: "Remove environment variable(s) from the config file.", Long: "Remove environment variable(s) from the config file.\n\nBy default, this command modifies `mise.toml` in the current directory.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    # Remove NODE_ENV from the current directory's config\n    $ \x1b[1mmise unset NODE_ENV\x1b[22m\n\n    # Remove NODE_ENV from the global config\n    $ \x1b[1mmise unset NODE_ENV -g\x1b[22m\n"},
+	{Key: FlagUnsetFile, ValueName: "FILE", ValueDemanded: true, Short: "Specify a file to use instead of `mise.toml`", Long: "Specify a file to use instead of `mise.toml`\n\nCan be a file path or directory. If a directory is provided, will create/use mise.toml in that directory.\n\nDefaults to [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) environment variable, or `mise.toml`.\nUse [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path."},
 	{Key: FlagUnsetGlobal, Short: "Use the global config file", Long: "Use the global config file"},
 	{Key: ArgUnsetEnvKey, Short: "Environment variable(s) to remove\ne.g.: NODE_ENV", Long: "Environment variable(s) to remove\ne.g.: NODE_ENV"},
-	{Key: CmdUntrust, Short: "No longer trust a config, will prompt in the future"},
+	{Key: CmdUntrust, Short: "Remove explicit trust for a config"},
 	{Key: ArgUntrustConfigFile, Short: "The config file to untrust", Long: "The config file to untrust"},
-	{Key: CmdUnuse, Short: "Removes installed tool versions from mise.toml", Long: "Removes installed tool versions from mise.toml\n\nBy default, this will use the `mise.toml` file that has the tool defined.\nIf multiple config files exist (e.g., both `mise.toml` and `mise.local.toml`),\nthe lowest precedence file (`mise.toml`) will be used.\nSee https://mise.jdx.dev/configuration.html#target-file-for-write-operations\n\nIn the following order:\n  - If `--global` is set, it will use the global config file.\n  - If `--path` is set, it will use the config file at the given path.\n  - If `--env` is set, it will use `mise.<env>.toml`.\n  - If [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) is set, it will use that instead.\n  - If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will the first from that list.\n  - Otherwise just \"mise.toml\" or global config if cwd is home directory.\n\nUse [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.\n\nWill also prune the installed version if no other configurations are using it.", VisibleAliases: []string{"rm", "remove"}, AfterLongHelp: "Examples:\n\n    # will uninstall specific version\n    $ mise unuse node@18.0.0\n\n    # will uninstall specific version from global config\n    $ mise unuse -g node@18.0.0\n\n    # will uninstall specific version from .mise.local.toml\n    $ mise unuse --env local node@20\n\n    # will uninstall specific version from .mise.staging.toml\n    $ mise unuse --env staging node@20\n"},
+	{Key: CmdUnuse, Short: "Removes installed tool versions from mise.toml", Long: "Removes installed tool versions from mise.toml\n\nBy default, this will use the `mise.toml` file that has the tool defined.\nIf multiple config files exist (e.g., both `mise.toml` and `mise.local.toml`),\nthe lowest precedence file (`mise.toml`) will be used.\nSee https://mise.jdx.dev/configuration.html#target-file-for-write-operations\n\nIn the following order:\n  - If `--global` is set, it will use the global config file.\n  - If `--path` is set, it will use the config file at the given path.\n  - If `--env` is set, it will use `mise.<env>.toml`.\n  - If [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) is set, it will use that instead.\n  - If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will the first from that list.\n  - Otherwise just \"mise.toml\" or global config if cwd is home directory.\n\nUse [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.\n\nWill also prune the installed version if no other configurations are using it.", VisibleAliases: []string{"rm", "remove"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    # will uninstall specific version\n    $ \x1b[1mmise unuse node@18.0.0\x1b[22m\n\n    # will uninstall specific version from global config\n    $ \x1b[1mmise unuse -g node@18.0.0\x1b[22m\n\n    # will uninstall specific version from .mise.local.toml\n    $ \x1b[1mmise unuse --env local node@20\x1b[22m\n\n    # will uninstall specific version from .mise.staging.toml\n    $ \x1b[1mmise unuse --env staging node@20\x1b[22m\n"},
 	{Key: FlagUnuseEnv, ValueName: "ENV", ValueDemanded: true, Short: "Create/modify an environment-specific config file like .mise.<env>.toml", Long: "Create/modify an environment-specific config file like .mise.<env>.toml"},
 	{Key: FlagUnuseGlobal, Short: "Use the global config file (`~/.config/mise/config.toml`) instead of the local one", Long: "Use the global config file (`~/.config/mise/config.toml`) instead of the local one"},
-	{Key: FlagUnusePath, ValueName: "PATH", ValueDemanded: true, Short: "Specify a path to a config file or directory", Long: "Specify a path to a config file or directory\n\nIf a directory is specified, it will look for a config file in that directory following the rules above."},
+	{Key: FlagUnusePath, ValueName: "PATH", ValueDemanded: true, Short: "Specify a path to a config file or directory", Long: "Specify a path to a config file or directory\n\nIf a directory is specified, it will look for a config file in that directory following\nthe rules above."},
 	{Key: FlagUnuseNoPrune, Short: "Do not also prune the installed version", Long: "Do not also prune the installed version"},
 	{Key: ArgUnuseInstalledToolVersion, Demanded: true, Short: "Tool(s) to remove", Long: "Tool(s) to remove"},
-	{Key: CmdUpgrade, Short: "Upgrades outdated tools", Long: "Upgrades outdated tools\n\nBy default, this keeps the range specified in mise.toml. So if you have node@20 set, it will\nupgrade to the latest 20.x.x version available. See the `--bump` flag to use the latest version\nand bump the version in mise.toml.\n\nThis will update mise.lock if it is enabled, see https://mise.jdx.dev/configuration/settings.html#lockfile", VisibleAliases: []string{"up"}, AfterLongHelp: "Examples:\n\n    # Upgrades node to the latest version matching the range in mise.toml\n    $ mise upgrade node\n\n    # Upgrades node to the latest version and bumps the version in mise.toml\n    $ mise upgrade node --bump\n\n    # Upgrades all tools to the latest versions\n    $ mise upgrade\n\n    # Upgrades all tools to the latest versions and bumps the version in mise.toml\n    $ mise upgrade --bump\n\n    # Just print what would be done, don't actually do it\n    $ mise upgrade --dry-run\n\n    # Upgrades node and python to the latest versions\n    $ mise upgrade node python\n\n    # Upgrade all tools except go\n    $ mise upgrade --exclude go\n\n    # Show a multiselect menu to choose which tools to upgrade\n    $ mise upgrade --interactive\n\n    # Only upgrade tools defined in local mise.toml, not global ones\n    $ mise upgrade --local\n"},
-	{Key: FlagUpgradeInteractive, Short: "Display multiselect menu to choose which tools to upgrade", Long: "Display multiselect menu to choose which tools to upgrade"},
-	{Key: FlagUpgradeJobs, ValueName: "JOBS", ValueDemanded: true, Short: "Number of jobs to run in parallel\n[default: 4]", Long: "Number of jobs to run in parallel\n[default: 4]"},
+	{Key: CmdUpgrade, Short: "Upgrades outdated tools", Long: "Upgrades outdated tools\n\nBy default, this keeps the range specified in mise.toml. So if you have node@20 set, it will\nupgrade to the latest 20.x.x version available. See the `--bump` flag to use the latest version\nand bump the version in mise.toml.\n\nThis will update mise.lock if it is enabled, see https://mise.jdx.dev/configuration/settings.html#lockfile", VisibleAliases: []string{"up"}, AfterLongHelp: "\x1b[1m\x1b[4mDeprecation:\x1b[22m\x1b[24m\n\nThe `-l` shorthand for `--bump` is deprecated and will be removed in mise 2027.8.5.\nAfter removal, `-l` will become shorthand for `--local`. Use `-b` or `--bump` instead.\n\n\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    # Upgrades node to the latest version matching the range in mise.toml\n    $ \x1b[1mmise upgrade node\x1b[22m\n\n    # Upgrades node to the latest version and bumps the version in mise.toml\n    $ \x1b[1mmise upgrade node --bump\x1b[22m\n\n    # Upgrades all tools to the latest versions\n    $ \x1b[1mmise upgrade\x1b[22m\n\n    # Upgrades all tools to the latest versions and bumps the version in mise.toml\n    $ \x1b[1mmise upgrade --bump\x1b[22m\n\n    # Just print what would be done, don't actually do it\n    $ \x1b[1mmise upgrade --dry-run\x1b[22m\n\n    # Upgrades node and python to the latest versions\n    $ \x1b[1mmise upgrade node python\x1b[22m\n\n    # Upgrade all tools except go\n    $ \x1b[1mmise upgrade --exclude go\x1b[22m\n\n    # Show a multiselect menu to choose which tools to upgrade\n    $ \x1b[1mmise upgrade --interactive\x1b[22m\n\n    # Only upgrade tools defined in local mise.toml, not global ones\n    $ \x1b[1mmise upgrade --local\x1b[22m\n"},
 	{Key: FlagUpgradeBump, Short: "Upgrades to the latest version available, bumping the version in mise.toml", Long: "Upgrades to the latest version available, bumping the version in mise.toml\n\nFor example, if you have `node = \"20.0.0\"` in your mise.toml but 22.1.0 is the latest available,\nthis will install 22.1.0 and set `node = \"22.1.0\"` in your config.\n\nIt keeps the same precision as what was there before, so if you instead had `node = \"20\"`, it\nwould change your config to `node = \"22\"`."},
+	{Key: FlagUpgradeInteractive, Short: "Display multiselect menu to choose which tools to upgrade", Long: "Display multiselect menu to choose which tools to upgrade"},
+	{Key: FlagUpgradeJobs, ValueName: "JOBS", ValueDemanded: true, Short: "Number of jobs to run in parallel\nValues below 1 are treated as 1\n[default: 4]", Long: "Number of jobs to run in parallel\nValues below 1 are treated as 1\n[default: 4]", Env: "MISE_JOBS"},
+	{Key: FlagUpgradeL, Hide: true, Short: "Deprecated shorthand for --bump", Long: "Deprecated shorthand for --bump"},
 	{Key: FlagUpgradeDryRun, Short: "Just print what would be done, don't actually do it", Long: "Just print what would be done, don't actually do it"},
 	{Key: FlagUpgradeExclude, Repeatable: true, ValueName: "INSTALLED_TOOL", ValueDemanded: true, Short: "Tool(s) to exclude from upgrading\ne.g.: go python", Long: "Tool(s) to exclude from upgrading\ne.g.: go python"},
 	{Key: FlagUpgradeDryRunCode, Short: "Like --dry-run but exits with code 1 if there are outdated tools", Long: "Like --dry-run but exits with code 1 if there are outdated tools\n\nThis is useful for scripts to check if tools need to be upgraded."},
@@ -5812,80 +5865,81 @@ var HelpText = argv.HelpTable{
 	{Key: FlagUpgradeLocal, Short: "Only upgrade tools defined in local config files", Long: "Only upgrade tools defined in local config files\n\nThis will only upgrade tools that are defined in project-local mise.toml and\nwill skip tools defined in the global config (~/.config/mise/config.toml)."},
 	{Key: FlagUpgradeMinimumReleaseAge, ValueName: "MINIMUM_RELEASE_AGE", ValueDemanded: true, Short: "Only upgrade to versions released before this date or older than this duration", Long: "Only upgrade to versions released before this date or older than this duration\n\nSupports absolute dates like \"2024-06-01\" and relative durations like \"90d\" or \"1y\".\nThis can be useful for reproducibility or security purposes.\n\nThis only affects fuzzy version matches like \"20\" or \"latest\".\nExplicitly pinned versions like \"22.5.0\" are not filtered."},
 	{Key: FlagUpgradeMonorepo, Short: "Placeholder for future monorepo upgrades; `mise upgrade --monorepo` is not implemented yet.", Long: "Placeholder for future monorepo upgrades; `mise upgrade --monorepo` is not implemented yet."},
-	{Key: FlagUpgradeNoPrune, Short: "Do not uninstall the versions that were upgraded away from", Long: "Do not uninstall the versions that were upgraded away from\n\nBy default the old version is removed once the new one installs, unless another\ntracked config or tool stub still needs it. Use this to keep it anyway, e.g. when\nsomething outside of mise points at the old install directory."},
-	{Key: FlagUpgradeRaw, Short: "Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1", Long: "Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1"},
+	{Key: FlagUpgradeNoPrune, Short: "Do not uninstall the versions that were upgraded away from", Long: "Do not uninstall the versions that were upgraded away from\n\nBy default the old version is removed once the new one installs, unless another\ntracked config or tool stub still needs it. Use this to keep it anyway, e.g. when\nsomething outside of mise points at the old install directory.\n\nSet `upgrade.auto_prune = false` to make this the default."},
+	{Key: FlagUpgradePrune, Short: "Uninstall the versions that were upgraded away from", Long: "Uninstall the versions that were upgraded away from\n\nThis is already the default. Use it to override `upgrade.auto_prune = false`\nfor a single run."},
+	{Key: FlagUpgradeRaw, Short: "Connect backend install command stdin/stdout/stderr directly to the terminal Implies --jobs=1", Long: "Connect backend install command stdin/stdout/stderr directly to the terminal\nImplies --jobs=1"},
 	{Key: ArgUpgradeInstalledToolVersion, Short: "Tool(s) to upgrade\ne.g.: node@20 python@3.10\nIf not specified, all current tools will be upgraded", Long: "Tool(s) to upgrade\ne.g.: node@20 python@3.10\nIf not specified, all current tools will be upgraded"},
 	{Key: CmdUsage, Hide: true, Short: "Generate a usage CLI spec", Long: "Generate a usage CLI spec\n\nSee https://usage.jdx.dev for more information on this specification."},
-	{Key: CmdUse, Short: "Installs a tool and adds the version to mise.toml.", Long: "Installs a tool and adds the version to mise.toml.\n\nThis will install the tool version if it is not already installed.\nBy default, this will use a `mise.toml` file in the current directory.\nIf multiple config files exist (e.g., both `mise.toml` and `mise.local.toml`),\nthe lowest precedence file (`mise.toml`) will be used.\nSee https://mise.jdx.dev/configuration.html#target-file-for-write-operations\n\nIn the following order:\n  - If `--global` is set, it will use the global config file.\n  - If `--path` is set, it will use the config file at the given path.\n  - If `--env` is set, it will use `mise.<env>.toml`.\n  - If [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) is set, it will use that instead.\n  - If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will the first from that list.\n  - Otherwise just \"mise.toml\" or global config if cwd is home directory.\n\nUse [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.\n\nUse the `--global` flag to use the global config file instead.", VisibleAliases: []string{"u"}, AfterLongHelp: "Examples:\n\n    # run with no arguments to use the interactive selector\n    $ mise use\n\n    # set the current version of node to 20.x in mise.toml of current directory\n    # will write the fuzzy version (e.g.: 20)\n    $ mise use node@20\n\n    # set the current version of node to 20.x in ~/.config/mise/config.toml\n    # will write the precise version (e.g.: 20.0.0)\n    $ mise use -g --pin node@20\n\n    # sets .mise.local.toml (which is intended not to be committed to a project)\n    $ mise use --env local node@20\n\n    # sets .mise.staging.toml (which is used if MISE_ENV=staging)\n    $ mise use --env staging node@20\n"},
+	{Key: CmdUse, Short: "Installs a tool and adds the version to mise.toml.", Long: "Installs a tool and adds the version to mise.toml.\n\nThis will install the tool version if it is not already installed.\nBy default, this will use a `mise.toml` file in the current directory.\nIf multiple config files exist (e.g., both `mise.toml` and `mise.local.toml`),\nthe lowest precedence file (`mise.toml`) will be used.\nSee https://mise.jdx.dev/configuration.html#target-file-for-write-operations\n\nIn the following order:\n  - If `--global` is set, it will use the global config file.\n  - If `--path` is set, it will use the config file at the given path.\n  - If `--env` is set, it will use `mise.<env>.toml`.\n  - If [`MISE_DEFAULT_CONFIG_FILENAME`](https://mise.jdx.dev/configuration.html#mise_default_config_filename) is set, it will use that instead.\n  - If `MISE_OVERRIDE_CONFIG_FILENAMES` is set, it will the first from that list.\n  - Otherwise just \"mise.toml\" or global config if cwd is home directory.\n\nUse [`MISE_GLOBAL_CONFIG_FILE`](https://mise.jdx.dev/configuration.html#mise_global_config_file) to choose a different global config path.\n\nUse the `--global` flag to use the global config file instead.", VisibleAliases: []string{"u"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    # run with no arguments to use the interactive selector\n    $ \x1b[1mmise use\x1b[22m\n\n    # set the current version of node to 20.x in mise.toml of current directory\n    # will write the fuzzy version (e.g.: 20)\n    $ \x1b[1mmise use node@20\x1b[22m\n\n    # set the current version of node to 20.x in ~/.config/mise/config.toml\n    # will write the precise version (e.g.: 20.0.0)\n    $ \x1b[1mmise use -g --pin node@20\x1b[22m\n\n    # sets .mise.local.toml (which is intended not to be committed to a project)\n    $ \x1b[1mmise use --env local node@20\x1b[22m\n\n    # sets .mise.staging.toml (which is used if MISE_ENV=staging)\n    $ \x1b[1mmise use --env staging node@20\x1b[22m\n"},
 	{Key: FlagUseEnv, ValueName: "ENV", ValueDemanded: true, Short: "Create/modify an environment-specific config file like .mise.<env>.toml", Long: "Create/modify an environment-specific config file like .mise.<env>.toml"},
 	{Key: FlagUseForce, Short: "Force reinstall even if already installed", Long: "Force reinstall even if already installed"},
 	{Key: FlagUseGlobal, Short: "Use the global config file (`~/.config/mise/config.toml`) instead of the local one", Long: "Use the global config file (`~/.config/mise/config.toml`) instead of the local one"},
-	{Key: FlagUseJobs, ValueName: "JOBS", ValueDemanded: true, Short: "Number of jobs to run in parallel\n[default: 4]", Long: "Number of jobs to run in parallel\n[default: 4]"},
+	{Key: FlagUseJobs, ValueName: "JOBS", ValueDemanded: true, Short: "Number of jobs to run in parallel\nValues below 1 are treated as 1\n[default: 4]", Long: "Number of jobs to run in parallel\nValues below 1 are treated as 1\n[default: 4]", Env: "MISE_JOBS"},
 	{Key: FlagUseDryRun, Short: "Perform a dry run, showing what would be installed and modified without making changes", Long: "Perform a dry run, showing what would be installed and modified without making changes"},
-	{Key: FlagUsePath, ValueName: "PATH", ValueDemanded: true, Short: "Specify a path to a config file or directory", Long: "Specify a path to a config file or directory\n\nIf a directory is specified, it will look for a config file in that directory following the rules above."},
+	{Key: FlagUsePath, ValueName: "PATH", ValueDemanded: true, Short: "Specify a path to a config file or directory", Long: "Specify a path to a config file or directory\n\nIf a directory is specified, it will look for a config file in that directory following\nthe rules above."},
 	{Key: FlagUseDryRunCode, Short: "Like --dry-run but exits with code 1 if there are changes to make", Long: "Like --dry-run but exits with code 1 if there are changes to make\n\nThis is useful for scripts to check if tools need to be added or removed."},
 	{Key: FlagUseFuzzy, Short: "Save fuzzy version to config file", Long: "Save fuzzy version to config file\n\ne.g.: `mise use --fuzzy node@20` will save 20 as the version\nthis is the default behavior unless `MISE_PIN=1`"},
 	{Key: FlagUseMinimumReleaseAge, ValueName: "MINIMUM_RELEASE_AGE", ValueDemanded: true, Short: "Only install versions released before this date or older than this duration", Long: "Only install versions released before this date or older than this duration\n\nSupports absolute dates like \"2024-06-01\" and relative durations like \"90d\" or \"1y\"."},
-	{Key: FlagUsePin, Short: "Save exact version to config file\ne.g.: `mise use --pin node@20` will save 20.0.0 as the version\nSet `MISE_PIN=1` to make this the default behavior", Long: "Save exact version to config file\ne.g.: `mise use --pin node@20` will save 20.0.0 as the version\nSet `MISE_PIN=1` to make this the default behavior\n\nConsider using mise.lock as a better alternative to pinning in mise.toml:\nhttps://mise.jdx.dev/configuration/settings.html#lockfile"},
-	{Key: FlagUseRaw, Short: "Connect backend install command stdin/stdout/stderr directly to the terminal Implies `--jobs=1`", Long: "Connect backend install command stdin/stdout/stderr directly to the terminal Implies `--jobs=1`"},
+	{Key: FlagUsePin, Short: "Save the resolved concrete version to the config file", Long: "Save the resolved concrete version to the config file\n\nIf the request exactly matches an available release, that release is preferred over\ninstalled fuzzy matches. Use `prefix:` to explicitly request recursive prefix matching.\ne.g.: `mise use --pin node@20` will save the resolved `20.x.y` version\nSet `MISE_PIN=1` to make this the default behavior\n\nConsider using mise.lock as a better alternative to pinning in mise.toml:\nhttps://mise.jdx.dev/configuration/settings.html#lockfile"},
+	{Key: FlagUseRaw, Short: "Connect backend install command stdin/stdout/stderr directly to the terminal Implies `--jobs=1`", Long: "Connect backend install command stdin/stdout/stderr directly to the terminal\nImplies `--jobs=1`"},
 	{Key: FlagUseRemove, Repeatable: true, ValueName: "TOOL", ValueDemanded: true, Short: "Remove the tool(s) from config file", Long: "Remove the tool(s) from config file"},
 	{Key: ArgUseToolVersion, Short: "Tool(s) to add to config file", Long: "Tool(s) to add to config file\n\ne.g.: node@20, cargo:ripgrep@latest npm:prettier@3\nIf no version is specified, it will default to @latest\n\nTool options can be set with this syntax:\n\n    mise use ubi:BurntSushi/ripgrep[exe=rg]"},
-	{Key: CmdVersion, Short: "Display the version of mise", Long: "Display the version of mise\n\nDisplays the version, os, architecture, and the date of the build.\n\nIf the version is out of date, it will display a warning.", VisibleAliases: []string{"v"}, AfterLongHelp: "Examples:\n\n    $ mise version\n    $ mise --version\n    $ mise -v\n    $ mise -V\n"},
+	{Key: CmdVersion, Short: "Display the version of mise", Long: "Display the version of mise\n\nDisplays the version, os, architecture, and the date of the build.\n\nIf the version is out of date, it will display a warning.", VisibleAliases: []string{"v"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise version\x1b[22m\n    $ \x1b[1mmise --version\x1b[22m\n    $ \x1b[1mmise -v\x1b[22m\n    $ \x1b[1mmise -V\x1b[22m\n"},
 	{Key: FlagVersionJson, Short: "Print the version information in JSON format", Long: "Print the version information in JSON format"},
-	{Key: CmdWatch, Short: "Run task(s) and watch for changes to rerun it", Long: "Run task(s) and watch for changes to rerun it\n\nThis command uses the `watchexec` tool to watch for changes to files and rerun the specified task(s).\nIt must be installed for this command to work, but you can install it with `mise use -g watchexec@latest`.\n\nFor more advanced process management (daemon management, auto-restart, readiness checks,\ncron scheduling), see mise's sister project: https://pitchfork.jdx.dev", VisibleAliases: []string{"w"}, AfterLongHelp: "Examples:\n\n    $ mise watch build\n    Runs the \"build\" tasks. Will re-run the tasks when any of its sources change.\n    Uses \"sources\" from the tasks definition to determine which files to watch.\n\n    $ mise watch build --glob src/**/*.rs\n    Runs the \"build\" tasks but specify the files to watch with a glob pattern.\n    This overrides the \"sources\" from the tasks definition.\n\n    $ mise watch build --clear\n    Extra arguments are passed to watchexec. See `watchexec --help` for details.\n\n    $ mise watch serve --watch src --exts rs --restart\n    Starts an api server, watching for changes to \"*.rs\" files in \"./src\" and kills/restarts the server when they change.\n"},
+	{Key: CmdWatch, Short: "Run task(s) and watch for changes to rerun it", Long: "Run task(s) and watch for changes to rerun it\n\nThis command uses the `watchexec` tool to watch for changes to files and rerun the specified task(s).\nIt must be installed for this command to work, but you can install it with `mise use -g watchexec@latest`.\n\nFor more advanced process management (daemon management, auto-restart, readiness checks,\ncron scheduling), see mise's sister project: https://pitchfork.jdx.dev", VisibleAliases: []string{"w"}, AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise watch build\x1b[22m\n    Runs the \"build\" tasks. Will re-run the tasks when any of its sources change.\n    Uses \"sources\" from the tasks definition to determine which files to watch.\n\n    $ \x1b[1mmise watch build --glob src/**/*.rs\x1b[22m\n    Runs the \"build\" tasks but specify the files to watch with a glob pattern.\n    This overrides the \"sources\" from the tasks definition.\n\n    $ \x1b[1mmise watch build --clear\x1b[22m\n    Extra arguments are passed to watchexec. See `watchexec --help` for details.\n\n    $ \x1b[1mmise watch serve --watch src --exts rs --restart\x1b[22m\n    Starts an api server, watching for changes to \"*.rs\" files in \"./src\" and kills/restarts the server when they change.\n"},
 	{Key: FlagWatchTaskFlag, Hide: true, Repeatable: true, ValueName: "TASK_FLAG", ValueDemanded: true, Short: "Tasks to run", Long: "Tasks to run"},
 	{Key: FlagWatchGlob, Hide: true, Repeatable: true, ValueName: "GLOB", ValueDemanded: true, Short: "Files to watch\nDefaults to sources from the task(s)", Long: "Files to watch\nDefaults to sources from the task(s)"},
 	{Key: FlagWatchSkipDeps, Short: "Run only the specified tasks skipping all dependencies", Long: "Run only the specified tasks skipping all dependencies"},
-	{Key: FlagWatchWatch, Repeatable: true, ValueName: "PATH", ValueDemanded: true, Short: "Watch a specific file or directory", Long: "Watch a specific file or directory\n\nBy default, Watchexec watches the current directory.\n\nWhen watching a single file, it's often better to watch the containing directory instead, and filter on the filename. Some editors may replace the file with a new one when saving, and some platforms may not detect that or further changes.\n\nUpon starting, Watchexec resolves a \"project origin\" from the watched paths. See the help for '--project-origin' for more information.\n\nThis option can be specified multiple times to watch multiple files or directories.\n\nThe special value '/dev/null', provided as the only path watched, will cause Watchexec to not watch any paths. Other event sources (like signals or key events) may still be used."},
-	{Key: FlagWatchWatchNonRecursive, Repeatable: true, ValueName: "PATH", ValueDemanded: true, Short: "Watch a specific directory, non-recursively", Long: "Watch a specific directory, non-recursively\n\nUnlike '-w', folders watched with this option are not recursed into.\n\nThis option can be specified multiple times to watch multiple directories non-recursively."},
-	{Key: FlagWatchWatchFile, ValueName: "PATH", ValueDemanded: true, Short: "Watch files and directories from a file", Long: "Watch files and directories from a file\n\nEach line in the file will be interpreted as if given to '-w'.\n\nFor more complex uses (like watching non-recursively), use the argfile capability: build a file containing command-line options and pass it to watchexec with `@path/to/argfile`.\n\nThe special value '-' will read from STDIN; this in incompatible with '--stdin-quit'."},
-	{Key: FlagWatchClear, ValueName: "MODE", ValueDemanded: true, Short: "Clear screen before running command", Long: "Clear screen before running command\n\nIf this doesn't completely clear the screen, try '--clear=reset'.", Choices: []string{"clear", "reset"}},
-	{Key: FlagWatchOnBusyUpdate, ValueName: "MODE", ValueDemanded: true, Short: "What to do when receiving events while the command is running", Long: "What to do when receiving events while the command is running\n\nDefault is to 'do-nothing', which ignores events while the command is running, so that changes that occur due to the command are ignored, like compilation outputs. You can also use 'queue' which will run the command once again when the current run has finished if any events occur while it's running, or 'restart', which terminates the running command and starts a new one. Finally, there's 'signal', which only sends a signal; this can be useful with programs that can reload their configuration without a full restart.\n\nThe signal can be specified with the '--signal' option.", Choices: []string{"queue", "do-nothing", "restart", "signal"}, Default: []string{"do-nothing"}},
+	{Key: FlagWatchWatch, Repeatable: true, ValueName: "PATH", ValueDemanded: true, Short: "Watch a specific file or directory", Long: "Watch a specific file or directory\n\nBy default, Watchexec watches the current directory.\n\nWhen watching a single file, it's often better to watch the containing directory instead,\nand filter on the filename. Some editors may replace the file with a new one when saving,\nand some platforms may not detect that or further changes.\n\nUpon starting, Watchexec resolves a \"project origin\" from the watched paths. See the help\nfor '--project-origin' for more information.\n\nThis option can be specified multiple times to watch multiple files or directories.\n\nThe special value '/dev/null', provided as the only path watched, will cause Watchexec to\nnot watch any paths. Other event sources (like signals or key events) may still be used.", Heading: "Filtering"},
+	{Key: FlagWatchWatchNonRecursive, Repeatable: true, ValueName: "PATH", ValueDemanded: true, Short: "Watch a specific directory, non-recursively", Long: "Watch a specific directory, non-recursively\n\nUnlike '-w', folders watched with this option are not recursed into.\n\nThis option can be specified multiple times to watch multiple directories non-recursively.", Heading: "Filtering"},
+	{Key: FlagWatchWatchFile, ValueName: "PATH", ValueDemanded: true, Short: "Watch files and directories from a file", Long: "Watch files and directories from a file\n\nEach line in the file will be interpreted as if given to '-w'.\n\nFor more complex uses (like watching non-recursively), use the argfile capability: build a\nfile containing command-line options and pass it to watchexec with `@path/to/argfile`.\n\nThe special value '-' will read from STDIN; this in incompatible with '--stdin-quit'.", Heading: "Filtering"},
+	{Key: FlagWatchClear, ValueName: "MODE", Short: "Clear screen before running command", Long: "Clear screen before running command\n\nIf this doesn't completely clear the screen, try '--clear=reset'.", Heading: "Output", Choices: []string{"clear", "reset"}},
+	{Key: FlagWatchOnBusyUpdate, HideDefaultValue: true, ValueName: "MODE", ValueDemanded: true, Short: "What to do when receiving events while the command is running", Long: "What to do when receiving events while the command is running\n\nDefault is to 'do-nothing', which ignores events while the command is running, so that\nchanges that occur due to the command are ignored, like compilation outputs. You can also\nuse 'queue' which will run the command once again when the current run has finished if any\nevents occur while it's running, or 'restart', which terminates the running command and starts\na new one. Finally, there's 'signal', which only sends a signal; this can be useful with\nprograms that can reload their configuration without a full restart.\n\nThe signal can be specified with the '--signal' option.", Choices: []string{"queue", "do-nothing", "restart", "signal"}, Default: []string{"do-nothing"}},
 	{Key: FlagWatchRestart, Short: "Restart the process if it's still running", Long: "Restart the process if it's still running\n\nThis is a shorthand for '--on-busy-update=restart'."},
-	{Key: FlagWatchSignal, ValueName: "SIGNAL", ValueDemanded: true, Short: "Send a signal to the process when it's still running", Long: "Send a signal to the process when it's still running\n\nSpecify a signal to send to the process when it's still running. This implies '--on-busy-update=signal'; otherwise the signal used when that mode is 'restart' is controlled by '--stop-signal'.\n\nSee the long documentation for '--stop-signal' for syntax.\n\nSignals are not supported on Windows at the moment, and will always be overridden to 'kill'. See '--stop-signal' for more on Windows \"signals\"."},
-	{Key: FlagWatchStopSignal, ValueName: "SIGNAL", ValueDemanded: true, Short: "Signal to send to stop the command", Long: "Signal to send to stop the command\n\nThis is used by 'restart' and 'signal' modes of '--on-busy-update' (unless '--signal' is provided). The restart behaviour is to send the signal, wait for the command to exit, and if it hasn't exited after some time (see '--timeout-stop'), forcefully terminate it.\n\nThe default on unix is \"SIGTERM\".\n\nInput is parsed as a full signal name (like \"SIGTERM\"), a short signal name (like \"TERM\"), or a signal number (like \"15\"). All input is case-insensitive.\n\nOn Windows this option is technically supported but only supports the \"KILL\" event, as Watchexec cannot yet deliver other events. Windows doesn't have signals as such; instead it has termination (here called \"KILL\" or \"STOP\") and \"CTRL+C\", \"CTRL+BREAK\", and \"CTRL+CLOSE\" events. For portability the unix signals \"SIGKILL\", \"SIGINT\", \"SIGTERM\", and \"SIGHUP\" are respectively mapped to these."},
-	{Key: FlagWatchStopTimeout, ValueName: "TIMEOUT", ValueDemanded: true, Short: "Time to wait for the command to exit gracefully", Long: "Time to wait for the command to exit gracefully\n\nThis is used by the 'restart' mode of '--on-busy-update'. After the graceful stop signal is sent, Watchexec will wait for the command to exit. If it hasn't exited after this time, it is forcefully terminated.\n\nTakes a unit-less value in seconds, or a time span value such as \"5min 20s\". Providing a unit-less value is deprecated and will warn; it will be an error in the future.\n\nThe default is 10 seconds. Set to 0 to immediately force-kill the command.\n\nThis has no practical effect on Windows as the command is always forcefully terminated; see '--stop-signal' for why.", Default: []string{"10s"}},
-	{Key: FlagWatchMapSignal, Repeatable: true, ValueName: "SIGNAL:SIGNAL", ValueDemanded: true, Short: "Translate signals from the OS to signals to send to the command", Long: "Translate signals from the OS to signals to send to the command\n\nTakes a pair of signal names, separated by a colon, such as \"TERM:INT\" to map SIGTERM to SIGINT. The first signal is the one received by watchexec, and the second is the one sent to the command. The second can be omitted to discard the first signal, such as \"TERM:\" to not do anything on SIGTERM.\n\nIf SIGINT or SIGTERM are mapped, then they no longer quit Watchexec. Besides making it hard to quit Watchexec itself, this is useful to send pass a Ctrl-C to the command without also terminating Watchexec and the underlying program with it, e.g. with \"INT:INT\".\n\nThis option can be specified multiple times to map multiple signals.\n\nSignal syntax is case-insensitive for short names (like \"TERM\", \"USR2\") and long names (like \"SIGKILL\", \"SIGHUP\"). Signal numbers are also supported (like \"15\", \"31\"). On Windows, the forms \"STOP\", \"CTRL+C\", and \"CTRL+BREAK\" are also supported to receive, but Watchexec cannot yet deliver other \"signals\" than a STOP."},
-	{Key: FlagWatchDebounce, ValueName: "TIMEOUT", ValueDemanded: true, Short: "Time to wait for new events before taking action", Long: "Time to wait for new events before taking action\n\nWhen an event is received, Watchexec will wait for up to this amount of time before handling it (such as running the command). This is essential as what you might perceive as a single change may actually emit many events, and without this behaviour, Watchexec would run much too often. Additionally, it's not infrequent that file writes are not atomic, and each write may emit an event, so this is a good way to avoid running a command while a file is partially written.\n\nAn alternative use is to set a high value (like \"30min\" or longer), to save power or bandwidth on intensive tasks, like an ad-hoc backup script. In those use cases, note that every accumulated event will build up in memory.\n\nTakes a unit-less value in milliseconds, or a time span value such as \"5sec 20ms\". Providing a unit-less value is deprecated and will warn; it will be an error in the future.\n\nThe default is 50 milliseconds. Setting to 0 is highly discouraged.", Default: []string{"50ms"}},
-	{Key: FlagWatchStdinQuit, Short: "Exit when stdin closes", Long: "Exit when stdin closes\n\nThis watches the stdin file descriptor for EOF, and exits Watchexec gracefully when it is closed. This is used by some process managers to avoid leaving zombie processes around."},
-	{Key: FlagWatchNoVcsIgnore, Short: "Don't load gitignores", Long: "Don't load gitignores\n\nAmong other VCS exclude files, like for Mercurial, Subversion, Bazaar, DARCS, Fossil. Note that Watchexec will detect which of these is in use, if any, and only load the relevant files. Both global (like '~/.gitignore') and local (like '.gitignore') files are considered.\n\nThis option is useful if you want to watch files that are ignored by Git."},
-	{Key: FlagWatchNoProjectIgnore, Short: "Don't load project-local ignores", Long: "Don't load project-local ignores\n\nThis disables loading of project-local ignore files, like '.gitignore' or '.ignore' in the\nwatched project. This is contrasted with '--no-vcs-ignore', which disables loading of Git\nand other VCS ignore files, and with '--no-global-ignore', which disables loading of global\nor user ignore files, like '~/.gitignore' or '~/.config/watchexec/ignore'.\n\nSupported project ignore files:\n\n  - Git: .gitignore at project root and child directories, .git/info/exclude, and the file pointed to by `core.excludesFile` in .git/config.\n  - Mercurial: .hgignore at project root and child directories.\n  - Bazaar: .bzrignore at project root.\n  - Darcs: _darcs/prefs/boring\n  - Fossil: .fossil-settings/ignore-glob\n  - Ripgrep/Watchexec/generic: .ignore at project root and child directories.\n\nVCS ignore files (Git, Mercurial, Bazaar, Darcs, Fossil) are only used if the corresponding\nVCS is discovered to be in use for the project/origin. For example, a .bzrignore in a Git\nrepository will be discarded."},
-	{Key: FlagWatchNoGlobalIgnore, Short: "Don't load global ignores", Long: "Don't load global ignores\n\nThis disables loading of global or user ignore files, like '~/.gitignore',\n'~/.config/watchexec/ignore', or '%APPDATA%\\Bazaar\\2.0\\ignore'. Contrast with\n'--no-vcs-ignore' and '--no-project-ignore'.\n\nSupported global ignore files\n\n  - Git (if core.excludesFile is set): the file at that path\n  - Git (otherwise): the first found of $XDG_CONFIG_HOME/git/ignore, %APPDATA%/.gitignore, %USERPROFILE%/.gitignore, $HOME/.config/git/ignore, $HOME/.gitignore.\n  - Bazaar: the first found of %APPDATA%/Bazaar/2.0/ignore, $HOME/.bazaar/ignore.\n  - Watchexec: the first found of $XDG_CONFIG_HOME/watchexec/ignore, %APPDATA%/watchexec/ignore, %USERPROFILE%/.watchexec/ignore, $HOME/.watchexec/ignore.\n\nLike for project files, Git and Bazaar global files will only be used for the corresponding\nVCS as used in the project."},
-	{Key: FlagWatchNoDefaultIgnore, Short: "Don't use internal default ignores", Long: "Don't use internal default ignores\n\nWatchexec has a set of default ignore patterns, such as editor swap files, `*.pyc`, `*.pyo`, `.DS_Store`, `.bzr`, `_darcs`, `.fossil-settings`, `.git`, `.hg`, `.pijul`, `.svn`, and Watchexec log files."},
-	{Key: FlagWatchNoDiscoverIgnore, Short: "Don't discover ignore files at all", Long: "Don't discover ignore files at all\n\nThis is a shorthand for '--no-global-ignore', '--no-vcs-ignore', '--no-project-ignore', but even more efficient as it will skip all the ignore discovery mechanisms from the get go.\n\nNote that default ignores are still loaded, see '--no-default-ignore'."},
-	{Key: FlagWatchIgnoreNothing, Short: "Don't ignore anything at all", Long: "Don't ignore anything at all\n\nThis is a shorthand for '--no-discover-ignore', '--no-default-ignore'.\n\nNote that ignores explicitly loaded via other command line options, such as '--ignore' or '--ignore-file', will still be used."},
-	{Key: FlagWatchPostpone, Short: "Wait until first change before running command", Long: "Wait until first change before running command\n\nBy default, Watchexec will run the command once immediately. With this option, it will instead wait until an event is detected before running the command as normal."},
-	{Key: FlagWatchDelayRun, ValueName: "DURATION", ValueDemanded: true, Short: "Sleep before running the command", Long: "Sleep before running the command\n\nThis option will cause Watchexec to sleep for the specified amount of time before running the command, after an event is detected. This is like using \"sleep 5 && command\" in a shell, but portable and slightly more efficient.\n\nTakes a unit-less value in seconds, or a time span value such as \"2min 5s\". Providing a unit-less value is deprecated and will warn; it will be an error in the future."},
-	{Key: FlagWatchPoll, ValueName: "INTERVAL", ValueDemanded: true, Short: "Poll for filesystem changes", Long: "Poll for filesystem changes\n\nBy default, and where available, Watchexec uses the operating system's native file system watching capabilities. This option disables that and instead uses a polling mechanism, which is less efficient but can work around issues with some file systems (like network shares) or edge cases.\n\nOptionally takes a unit-less value in milliseconds, or a time span value such as \"2s 500ms\", to use as the polling interval. If not specified, the default is 30 seconds. Providing a unit-less value is deprecated and will warn; it will be an error in the future.\n\nAliased as '--force-poll'."},
-	{Key: FlagWatchShell, ValueName: "SHELL", ValueDemanded: true, Short: "Use a different shell", Long: "Use a different shell\n\nBy default, Watchexec will use '$SHELL' if it's defined or a default of 'sh' on Unix-likes, and either 'pwsh', 'powershell', or 'cmd' (CMD.EXE) on Windows, depending on what Watchexec detects is the running shell.\n\nWith this option, you can override that and use a different shell, for example one with more features or one which has your custom aliases and functions.\n\nIf the value has spaces, it is parsed as a command line, and the first word used as the shell program, with the rest as arguments to the shell.\n\nThe command is run with the '-c' flag (except for 'cmd' on Windows, where it's '/C').\n\nThe special value 'none' can be used to disable shell use entirely. In that case, the command provided to Watchexec will be parsed, with the first word being the executable and the rest being the arguments, and executed directly. Note that this parsing is rudimentary, and may not work as expected in all cases.\n\nUsing 'none' is a little more efficient and can enable a stricter interpretation of the input, but it also means that you can't use shell features like globbing, redirection, control flow, logic, or pipes.\n\nExamples:\n\nUse without shell:\n\n$ watchexec -n -- zsh -x -o shwordsplit scr\n\nUse with powershell core:\n\n$ watchexec --shell=pwsh -- Test-Connection localhost\n\nUse with CMD.exe:\n\n$ watchexec --shell=cmd -- dir\n\nUse with a different unix shell:\n\n$ watchexec --shell=bash -- 'echo $BASH_VERSION'\n\nUse with a unix shell and options:\n\n$ watchexec --shell='zsh -x -o shwordsplit' -- scr"},
-	{Key: FlagWatchN, Short: "Shorthand for '--shell=none'", Long: "Shorthand for '--shell=none'"},
-	{Key: FlagWatchEmitEventsTo, ValueName: "MODE", ValueDemanded: true, Short: "Configure event emission", Long: "Configure event emission\n\nWatchexec can emit event information when running a command, which can be used by the child\nprocess to target specific changed files.\n\nOne thing to take care with is assuming inherent behaviour where there is only chance.\nNotably, it could appear as if the `RENAMED` variable contains both the original and the new\npath being renamed. In previous versions, it would even appear on some platforms as if the\noriginal always came before the new. However, none of this was true. It's impossible to\nreliably and portably know which changed path is the old or new, \"half\" renames may appear\n(only the original, only the new), \"unknown\" renames may appear (change was a rename, but\nwhether it was the old or new isn't known), rename events might split across two debouncing\nboundaries, and so on.\n\nThis option controls where that information is emitted. It defaults to 'none', which doesn't\nemit event information at all. The other options are 'environment' (deprecated), 'stdio',\n'file', 'json-stdio', and 'json-file'.\n\nThe 'stdio' and 'file' modes are text-based: 'stdio' writes absolute paths to the stdin of\nthe command, one per line, each prefixed with `create:`, `remove:`, `rename:`, `modify:`,\nor `other:`, then closes the handle; 'file' writes the same thing to a temporary file, and\nits path is given with the $WATCHEXEC_EVENTS_FILE environment variable.\n\nThere are also two JSON modes, which are based on JSON objects and can represent the full\nset of events Watchexec handles. Here's an example of a folder being created on Linux:\n\n```json\n  {\n    \"tags\": [\n      {\n        \"kind\": \"path\",\n        \"absolute\": \"/home/user/your/new-folder\",\n        \"filetype\": \"dir\"\n      },\n      {\n        \"kind\": \"fs\",\n        \"simple\": \"create\",\n        \"full\": \"Create(Folder)\"\n      },\n      {\n        \"kind\": \"source\",\n        \"source\": \"filesystem\",\n      }\n    ],\n    \"metadata\": {\n      \"notify-backend\": \"inotify\"\n    }\n  }\n```\n\nThe fields are as follows:\n\n  - `tags`, structured event data.\n  - `tags[].kind`, which can be:\n    * 'path', along with:\n      + `absolute`, an absolute path.\n      + `filetype`, a file type if known ('dir', 'file', 'symlink', 'other').\n    * 'fs':\n      + `simple`, the \"simple\" event type ('access', 'create', 'modify', 'remove', or 'other').\n      + `full`, the \"full\" event type, which is too complex to fully describe here, but looks like 'General(Precise(Specific))'.\n    * 'source', along with:\n      + `source`, the source of the event ('filesystem', 'keyboard', 'mouse', 'os', 'time', 'internal').\n    * 'keyboard', along with:\n      + `keycode`. Currently only the value 'eof' is supported.\n    * 'process', for events caused by processes:\n      + `pid`, the process ID.\n    * 'signal', for signals sent to Watchexec:\n      + `signal`, the normalised signal name ('hangup', 'interrupt', 'quit', 'terminate', 'user1', 'user2').\n    * 'completion', for when a command ends:\n      + `disposition`, the exit disposition ('success', 'error', 'signal', 'stop', 'exception', 'continued').\n      + `code`, the exit, signal, stop, or exception code.\n  - `metadata`, additional information about the event.\n\nThe 'json-stdio' mode will emit JSON events to the standard input of the command, one per\nline, then close stdin. The 'json-file' mode will create a temporary file, write the\nevents to it, and provide the path to the file with the $WATCHEXEC_EVENTS_FILE\nenvironment variable.\n\nFinally, the 'environment' mode was the default until 2.0. It sets environment variables\nwith the paths of the affected files, for filesystem events:\n\n$WATCHEXEC_COMMON_PATH is set to the longest common path of all of the below variables,\nand so should be prepended to each path to obtain the full/real path. Then:\n\n  - $WATCHEXEC_CREATED_PATH is set when files/folders were created\n  - $WATCHEXEC_REMOVED_PATH is set when files/folders were removed\n  - $WATCHEXEC_RENAMED_PATH is set when files/folders were renamed\n  - $WATCHEXEC_WRITTEN_PATH is set when files/folders were modified\n  - $WATCHEXEC_META_CHANGED_PATH is set when files/folders' metadata were modified\n  - $WATCHEXEC_OTHERWISE_CHANGED_PATH is set for every other kind of pathed event\n\nMultiple paths are separated by the system path separator, ';' on Windows and ':' on unix.\nWithin each variable, paths are deduplicated and sorted in binary order (i.e. neither\nUnicode nor locale aware).\n\nThis is the legacy mode, is deprecated, and will be removed in the future. The environment\nis a very restricted space, while also limited in what it can usefully represent. Large\nnumbers of files will either cause the environment to be truncated, or may error or crash\nthe process entirely. The $WATCHEXEC_COMMON_PATH is also unintuitive, as demonstrated by the\nmultiple confused queries that have landed in my inbox over the years.", Choices: []string{"environment", "stdio", "file", "json-stdio", "json-file", "none"}, Default: []string{"none"}},
-	{Key: FlagWatchOnlyEmitEvents, Short: "Only emit events to stdout, run no commands", Long: "Only emit events to stdout, run no commands.\n\nThis is a convenience option for using Watchexec as a file watcher, without running any commands. It is almost equivalent to using `cat` as the command, except that it will not spawn a new process for each event.\n\nThis option requires `--emit-events-to` to be set, and restricts the available modes to `stdio` and `json-stdio`, modifying their behaviour to write to stdout instead of the stdin of the command."},
-	{Key: FlagWatchEnv, Repeatable: true, ValueName: "KEY=VALUE", ValueDemanded: true, Short: "Add env vars to the command", Long: "Add env vars to the command\n\nThis is a convenience option for setting environment variables for the command, without setting them for the Watchexec process itself.\n\nUse key=value syntax. Multiple variables can be set by repeating the option."},
-	{Key: FlagWatchWrapProcess, ValueName: "MODE", ValueDemanded: true, Short: "Configure how the process is wrapped", Long: "Configure how the process is wrapped\n\nBy default, Watchexec will run the command in a session on macOS, in a process group on other Unix platforms, and in a Job Object in Windows.\n\nSome Unix programs prefer running in a session, while others do not work in a process group.\n\nUse 'group' to use a process group, 'session' to use a process session, and 'none' to run the command directly. On Windows, either of 'group' or 'session' will use a Job Object.", Choices: []string{"group", "session", "none"}},
-	{Key: FlagWatchNotify, Short: "Alert when commands start and end", Long: "Alert when commands start and end\n\nWith this, Watchexec will emit a desktop notification when a command starts and ends, on supported platforms. On unsupported platforms, it may silently do nothing, or log a warning."},
-	{Key: FlagWatchColor, ValueName: "MODE", ValueDemanded: true, Short: "When to use terminal colours", Long: "When to use terminal colours\n\nSetting the environment variable `NO_COLOR` to any value is equivalent to `--color=never`.", Choices: []string{"auto", "always", "never"}, Default: []string{"auto"}},
-	{Key: FlagWatchTimings, Short: "Print how long the command took to run", Long: "Print how long the command took to run\n\nThis may not be exactly accurate, as it includes some overhead from Watchexec itself. Use the `time` utility, high-precision timers, or benchmarking tools for more accurate results."},
-	{Key: FlagWatchQuiet, Short: "Don't print starting and stopping messages", Long: "Don't print starting and stopping messages\n\nBy default Watchexec will print a message when the command starts and stops. This option disables this behaviour, so only the command's output, warnings, and errors will be printed."},
-	{Key: FlagWatchBell, Short: "Ring the terminal bell on command completion", Long: "Ring the terminal bell on command completion"},
-	{Key: FlagWatchProjectOrigin, ValueName: "DIRECTORY", ValueDemanded: true, Short: "Set the project origin", Long: "Set the project origin\n\nWatchexec will attempt to discover the project's \"origin\" (or \"root\") by searching for a variety of markers, like files or directory patterns. It does its best but sometimes gets it it wrong, and you can override that with this option.\n\nThe project origin is used to determine the path of certain ignore files, which VCS is being used, the meaning of a leading '/' in filtering patterns, and maybe more in the future.\n\nWhen set, Watchexec will also not bother searching, which can be significantly faster."},
-	{Key: FlagWatchWorkdir, ValueName: "DIRECTORY", ValueDemanded: true, Short: "Set the working directory", Long: "Set the working directory\n\nBy default, the working directory of the command is the working directory of Watchexec. You can change that with this option. Note that paths may be less intuitive to use with this."},
-	{Key: FlagWatchExts, Repeatable: true, ValueName: "EXTENSIONS", ValueDemanded: true, Short: "Filename extensions to filter to", Long: "Filename extensions to filter to\n\nThis is a quick filter to only emit events for files with the given extensions. Extensions can be given with or without the leading dot (e.g. 'js' or '.js'). Multiple extensions can be given by repeating the option or by separating them with commas."},
-	{Key: FlagWatchFilter, Repeatable: true, ValueName: "PATTERN", ValueDemanded: true, Short: "Filename patterns to filter to", Long: "Filename patterns to filter to\n\nProvide a glob-like filter pattern, and only events for files matching the pattern will be emitted. Multiple patterns can be given by repeating the option. Events that are not from files (e.g. signals, keyboard events) will pass through untouched."},
-	{Key: FlagWatchFilterFile, Repeatable: true, ValueName: "PATH", ValueDemanded: true, Short: "Files to load filters from", Long: "Files to load filters from\n\nProvide a path to a file containing filters, one per line. Empty lines and lines starting with '#' are ignored. Uses the same pattern format as the '--filter' option.\n\nThis can also be used via the $WATCHEXEC_FILTER_FILES environment variable."},
-	{Key: FlagWatchFilterProg, Repeatable: true, ValueName: "EXPRESSION", ValueDemanded: true, Short: "[experimental] Filter programs", Long: "[experimental] Filter programs.\n\n/!\\ This option is EXPERIMENTAL and may change and/or vanish without notice.\n\nProvide your own custom filter programs in jaq (similar to jq) syntax. Programs are given an event in the same format as described in '--emit-events-to' and must return a boolean. Invalid programs will make watchexec fail to start; use '-v' to see program runtime errors.\n\nIn addition to the jaq stdlib, watchexec adds some custom filter definitions:\n\n- 'path | file_meta' returns file metadata or null if the file does not exist.\n\n- 'path | file_size' returns the size of the file at path, or null if it does not exist.\n\n- 'path | file_read(bytes)' returns a string with the first n bytes of the file at path. If the file is smaller than n bytes, the whole file is returned. There is no filter to read the whole file at once to encourage limiting the amount of data read and processed.\n\n- 'string | hash', and 'path | file_hash' return the hash of the string or file at path. No guarantee is made about the algorithm used: treat it as an opaque value.\n\n- 'any | kv_store(key)', 'kv_fetch(key)', and 'kv_clear' provide a simple key-value store. Data is kept in memory only, there is no persistence. Consistency is not guaranteed.\n\n- 'any | printout', 'any | printerr', and 'any | log(level)' will print or log any given value to stdout, stderr, or the log (levels = error, warn, info, debug, trace), and pass the value through (so '[1] | log(\"debug\") | .[]' will produce a '1' and log '[1]').\n\nAll filtering done with such programs, and especially those using kv or filesystem access, is much slower than the other filtering methods. If filtering is too slow, events will back up and stall watchexec. Take care when designing your filters.\n\nIf the argument to this option starts with an '@', the rest of the argument is taken to be the path to a file containing a jaq program.\n\nJaq programs are run in order, after all other filters, and short-circuit: if a filter (jaq or not) rejects an event, execution stops there, and no other filters are run. Additionally, they stop after outputting the first value, so you'll want to use 'any' or 'all' when iterating, otherwise only the first item will be processed, which can be quite confusing!\n\nFind user-contributed programs or submit your own useful ones at <https://github.com/watchexec/watchexec/discussions/592>.\n\n## Examples:\n\nRegexp ignore filter on paths:\n\n'all(.tags[] | select(.kind == \"path\"); .absolute | test(\"[.]test[.]js$\")) | not'\n\nPass any event that creates a file:\n\n'any(.tags[] | select(.kind == \"fs\"); .simple == \"create\")'\n\nPass events that touch executable files:\n\n'any(.tags[] | select(.kind == \"path\" && .filetype == \"file\"); .absolute | metadata | .executable)'\n\nIgnore files that start with shebangs:\n\n'any(.tags[] | select(.kind == \"path\" && .filetype == \"file\"); .absolute | read(2) == \"#!\") | not'"},
-	{Key: FlagWatchIgnore, Repeatable: true, ValueName: "PATTERN", ValueDemanded: true, Short: "Filename patterns to filter out", Long: "Filename patterns to filter out\n\nProvide a glob-like filter pattern, and events for files matching the pattern will be excluded. Multiple patterns can be given by repeating the option. Events that are not from files (e.g. signals, keyboard events) will pass through untouched."},
-	{Key: FlagWatchIgnoreFile, Repeatable: true, ValueName: "PATH", ValueDemanded: true, Short: "Files to load ignores from", Long: "Files to load ignores from\n\nProvide a path to a file containing ignores, one per line. Empty lines and lines starting with '#' are ignored. Uses the same pattern format as the '--ignore' option.\n\nThis can also be used via the $WATCHEXEC_IGNORE_FILES environment variable."},
-	{Key: FlagWatchFsEvents, Repeatable: true, ValueName: "EVENTS", ValueDemanded: true, Short: "Filesystem events to filter to", Long: "Filesystem events to filter to\n\nThis is a quick filter to only emit events for the given types of filesystem changes. Choose from 'access', 'create', 'remove', 'rename', 'modify', 'metadata'. Multiple types can be given by repeating the option or by separating them with commas. By default, this is all types except for 'access'.\n\nThis may apply filtering at the kernel level when possible, which can be more efficient, but may be more confusing when reading the logs.", Choices: []string{"access", "create", "remove", "rename", "modify", "metadata"}, Default: []string{"create", "remove", "rename", "modify", "metadata"}},
-	{Key: FlagWatchNoMeta, Short: "Don't emit fs events for metadata changes", Long: "Don't emit fs events for metadata changes\n\nThis is a shorthand for '--fs-events create,remove,rename,modify'. Using it alongside the '--fs-events' option is non-sensical and not allowed."},
-	{Key: FlagWatchPrintEvents, Short: "Print events that trigger actions", Long: "Print events that trigger actions\n\nThis prints the events that triggered the action when handling it (after debouncing), in a human readable form. This is useful for debugging filters.\n\nUse '-vvv' instead when you need more diagnostic information."},
-	{Key: FlagWatchManual, Short: "Show the manual page", Long: "Show the manual page\n\nThis shows the manual page for Watchexec, if the output is a terminal and the 'man' program is available. If not, the manual page is printed to stdout in ROFF format (suitable for writing to a watchexec.1 file)."},
-	{Key: ArgWatchTask, Short: "Tasks to run\nCan specify multiple tasks by separating with `:::`\ne.g.: `mise run task1 arg1 arg2 ::: task2 arg1 arg2`", Long: "Tasks to run\nCan specify multiple tasks by separating with `:::`\ne.g.: `mise run task1 arg1 arg2 ::: task2 arg1 arg2`"},
+	{Key: FlagWatchSignal, ValueName: "SIGNAL", ValueDemanded: true, Short: "Send a signal to the process when it's still running", Long: "Send a signal to the process when it's still running\n\nSpecify a signal to send to the process when it's still running. This implies\n'--on-busy-update=signal'; otherwise the signal used when that mode is 'restart' is\ncontrolled by '--stop-signal'.\n\nSee the long documentation for '--stop-signal' for syntax.\n\nSignals are not supported on Windows at the moment, and will always be overridden to 'kill'.\nSee '--stop-signal' for more on Windows \"signals\"."},
+	{Key: FlagWatchStopSignal, ValueName: "SIGNAL", ValueDemanded: true, Short: "Signal to send to stop the command", Long: "Signal to send to stop the command\n\nThis is used by 'restart' and 'signal' modes of '--on-busy-update' (unless '--signal' is\nprovided). The restart behaviour is to send the signal, wait for the command to exit, and if\nit hasn't exited after some time (see '--timeout-stop'), forcefully terminate it.\n\nThe default on unix is \"SIGTERM\".\n\nInput is parsed as a full signal name (like \"SIGTERM\"), a short signal name (like \"TERM\"),\nor a signal number (like \"15\"). All input is case-insensitive.\n\nOn Windows this option is technically supported but only supports the \"KILL\" event, as\nWatchexec cannot yet deliver other events. Windows doesn't have signals as such; instead it\nhas termination (here called \"KILL\" or \"STOP\") and \"CTRL+C\", \"CTRL+BREAK\", and \"CTRL+CLOSE\"\nevents. For portability the unix signals \"SIGKILL\", \"SIGINT\", \"SIGTERM\", and \"SIGHUP\" are\nrespectively mapped to these."},
+	{Key: FlagWatchStopTimeout, HideDefaultValue: true, ValueName: "TIMEOUT", ValueDemanded: true, Short: "Time to wait for the command to exit gracefully", Long: "Time to wait for the command to exit gracefully\n\nThis is used by the 'restart' mode of '--on-busy-update'. After the graceful stop signal\nis sent, Watchexec will wait for the command to exit. If it hasn't exited after this time,\nit is forcefully terminated.\n\nTakes a unit-less value in seconds, or a time span value such as \"5min 20s\".\nProviding a unit-less value is deprecated and will warn; it will be an error in the future.\n\nThe default is 10 seconds. Set to 0 to immediately force-kill the command.\n\nThis has no practical effect on Windows as the command is always forcefully terminated; see\n'--stop-signal' for why.", Default: []string{"10s"}},
+	{Key: FlagWatchMapSignal, Repeatable: true, ValueName: "SIGNAL:SIGNAL", ValueDemanded: true, Short: "Translate signals from the OS to signals to send to the command", Long: "Translate signals from the OS to signals to send to the command\n\nTakes a pair of signal names, separated by a colon, such as \"TERM:INT\" to map SIGTERM to\nSIGINT. The first signal is the one received by watchexec, and the second is the one sent to\nthe command. The second can be omitted to discard the first signal, such as \"TERM:\" to\nnot do anything on SIGTERM.\n\nIf SIGINT or SIGTERM are mapped, then they no longer quit Watchexec. Besides making it hard\nto quit Watchexec itself, this is useful to send pass a Ctrl-C to the command without also\nterminating Watchexec and the underlying program with it, e.g. with \"INT:INT\".\n\nThis option can be specified multiple times to map multiple signals.\n\nSignal syntax is case-insensitive for short names (like \"TERM\", \"USR2\") and long names (like\n\"SIGKILL\", \"SIGHUP\"). Signal numbers are also supported (like \"15\", \"31\"). On Windows, the\nforms \"STOP\", \"CTRL+C\", and \"CTRL+BREAK\" are also supported to receive, but Watchexec cannot\nyet deliver other \"signals\" than a STOP."},
+	{Key: FlagWatchDebounce, HideDefaultValue: true, ValueName: "TIMEOUT", ValueDemanded: true, Short: "Time to wait for new events before taking action", Long: "Time to wait for new events before taking action\n\nWhen an event is received, Watchexec will wait for up to this amount of time before handling\nit (such as running the command). This is essential as what you might perceive as a single\nchange may actually emit many events, and without this behaviour, Watchexec would run much\ntoo often. Additionally, it's not infrequent that file writes are not atomic, and each write\nmay emit an event, so this is a good way to avoid running a command while a file is\npartially written.\n\nAn alternative use is to set a high value (like \"30min\" or longer), to save power or\nbandwidth on intensive tasks, like an ad-hoc backup script. In those use cases, note that\nevery accumulated event will build up in memory.\n\nTakes a unit-less value in milliseconds, or a time span value such as \"5sec 20ms\".\nProviding a unit-less value is deprecated and will warn; it will be an error in the future.\n\nThe default is 50 milliseconds. Setting to 0 is highly discouraged.", Default: []string{"50ms"}},
+	{Key: FlagWatchStdinQuit, Short: "Exit when stdin closes", Long: "Exit when stdin closes\n\nThis watches the stdin file descriptor for EOF, and exits Watchexec gracefully when it is\nclosed. This is used by some process managers to avoid leaving zombie processes around."},
+	{Key: FlagWatchNoVcsIgnore, Short: "Don't load gitignores", Long: "Don't load gitignores\n\nAmong other VCS exclude files, like for Mercurial, Subversion, Bazaar, DARCS, Fossil. Note\nthat Watchexec will detect which of these is in use, if any, and only load the relevant\nfiles. Both global (like '~/.gitignore') and local (like '.gitignore') files are considered.\n\nThis option is useful if you want to watch files that are ignored by Git.", Heading: "Filtering"},
+	{Key: FlagWatchNoProjectIgnore, Short: "Don't load project-local ignores", Long: "Don't load project-local ignores\n\nThis disables loading of project-local ignore files, like '.gitignore' or '.ignore' in the\nwatched project. This is contrasted with '--no-vcs-ignore', which disables loading of Git\nand other VCS ignore files, and with '--no-global-ignore', which disables loading of global\nor user ignore files, like '~/.gitignore' or '~/.config/watchexec/ignore'.\n\nSupported project ignore files:\n\n  - Git: .gitignore at project root and child directories, .git/info/exclude, and the file pointed to by `core.excludesFile` in .git/config.\n  - Mercurial: .hgignore at project root and child directories.\n  - Bazaar: .bzrignore at project root.\n  - Darcs: _darcs/prefs/boring\n  - Fossil: .fossil-settings/ignore-glob\n  - Ripgrep/Watchexec/generic: .ignore at project root and child directories.\n\nVCS ignore files (Git, Mercurial, Bazaar, Darcs, Fossil) are only used if the corresponding\nVCS is discovered to be in use for the project/origin. For example, a .bzrignore in a Git\nrepository will be discarded.", Heading: "Filtering"},
+	{Key: FlagWatchNoGlobalIgnore, Short: "Don't load global ignores", Long: "Don't load global ignores\n\nThis disables loading of global or user ignore files, like '~/.gitignore',\n'~/.config/watchexec/ignore', or '%APPDATA%\\Bazaar\\2.0\\ignore'. Contrast with\n'--no-vcs-ignore' and '--no-project-ignore'.\n\nSupported global ignore files\n\n  - Git (if core.excludesFile is set): the file at that path\n  - Git (otherwise): the first found of $XDG_CONFIG_HOME/git/ignore, %APPDATA%/.gitignore, %USERPROFILE%/.gitignore, $HOME/.config/git/ignore, $HOME/.gitignore.\n  - Bazaar: the first found of %APPDATA%/Bazaar/2.0/ignore, $HOME/.bazaar/ignore.\n  - Watchexec: the first found of $XDG_CONFIG_HOME/watchexec/ignore, %APPDATA%/watchexec/ignore, %USERPROFILE%/.watchexec/ignore, $HOME/.watchexec/ignore.\n\nLike for project files, Git and Bazaar global files will only be used for the corresponding\nVCS as used in the project.", Heading: "Filtering"},
+	{Key: FlagWatchNoDefaultIgnore, Short: "Don't use internal default ignores", Long: "Don't use internal default ignores\n\nWatchexec has a set of default ignore patterns, such as editor swap files, `*.pyc`, `*.pyo`,\n`.DS_Store`, `.bzr`, `_darcs`, `.fossil-settings`, `.git`, `.hg`, `.pijul`, `.svn`, and\nWatchexec log files.", Heading: "Filtering"},
+	{Key: FlagWatchNoDiscoverIgnore, Short: "Don't discover ignore files at all", Long: "Don't discover ignore files at all\n\nThis is a shorthand for '--no-global-ignore', '--no-vcs-ignore', '--no-project-ignore', but\neven more efficient as it will skip all the ignore discovery mechanisms from the get go.\n\nNote that default ignores are still loaded, see '--no-default-ignore'.", Heading: "Filtering"},
+	{Key: FlagWatchIgnoreNothing, Short: "Don't ignore anything at all", Long: "Don't ignore anything at all\n\nThis is a shorthand for '--no-discover-ignore', '--no-default-ignore'.\n\nNote that ignores explicitly loaded via other command line options, such as '--ignore' or\n'--ignore-file', will still be used.", Heading: "Filtering"},
+	{Key: FlagWatchPostpone, Short: "Wait until first change before running command", Long: "Wait until first change before running command\n\nBy default, Watchexec will run the command once immediately. With this option, it will\ninstead wait until an event is detected before running the command as normal."},
+	{Key: FlagWatchDelayRun, ValueName: "DURATION", ValueDemanded: true, Short: "Sleep before running the command", Long: "Sleep before running the command\n\nThis option will cause Watchexec to sleep for the specified amount of time before running\nthe command, after an event is detected. This is like using \"sleep 5 && command\" in a shell,\nbut portable and slightly more efficient.\n\nTakes a unit-less value in seconds, or a time span value such as \"2min 5s\".\nProviding a unit-less value is deprecated and will warn; it will be an error in the future."},
+	{Key: FlagWatchPoll, ValueName: "INTERVAL", Short: "Poll for filesystem changes", Long: "Poll for filesystem changes\n\nBy default, and where available, Watchexec uses the operating system's native file system\nwatching capabilities. This option disables that and instead uses a polling mechanism, which\nis less efficient but can work around issues with some file systems (like network shares) or\nedge cases.\n\nOptionally takes a unit-less value in milliseconds, or a time span value such as \"2s 500ms\",\nto use as the polling interval. If not specified, the default is 30 seconds.\nProviding a unit-less value is deprecated and will warn; it will be an error in the future.\n\nAliased as '--force-poll'."},
+	{Key: FlagWatchShell, ValueName: "SHELL", ValueDemanded: true, Short: "Use a different shell", Long: "Use a different shell\n\nBy default, Watchexec will use '$SHELL' if it's defined or a default of 'sh' on Unix-likes,\nand either 'pwsh', 'powershell', or 'cmd' (CMD.EXE) on Windows, depending on what Watchexec\ndetects is the running shell.\n\nWith this option, you can override that and use a different shell, for example one with more\nfeatures or one which has your custom aliases and functions.\n\nIf the value has spaces, it is parsed as a command line, and the first word used as the\nshell program, with the rest as arguments to the shell.\n\nThe command is run with the '-c' flag (except for 'cmd' on Windows, where it's '/C').\n\nThe special value 'none' can be used to disable shell use entirely. In that case, the\ncommand provided to Watchexec will be parsed, with the first word being the executable and\nthe rest being the arguments, and executed directly. Note that this parsing is rudimentary,\nand may not work as expected in all cases.\n\nUsing 'none' is a little more efficient and can enable a stricter interpretation of the\ninput, but it also means that you can't use shell features like globbing, redirection,\ncontrol flow, logic, or pipes.\n\nExamples:\n\nUse without shell:\n\n  $ watchexec -n -- zsh -x -o shwordsplit scr\n\nUse with powershell core:\n\n  $ watchexec --shell=pwsh -- Test-Connection localhost\n\nUse with CMD.exe:\n\n  $ watchexec --shell=cmd -- dir\n\nUse with a different unix shell:\n\n  $ watchexec --shell=bash -- 'echo $BASH_VERSION'\n\nUse with a unix shell and options:\n\n  $ watchexec --shell='zsh -x -o shwordsplit' -- scr", Heading: "Command"},
+	{Key: FlagWatchN, Short: "Shorthand for '--shell=none'", Long: "Shorthand for '--shell=none'", Heading: "Command"},
+	{Key: FlagWatchEmitEventsTo, HideDefaultValue: true, ValueName: "MODE", ValueDemanded: true, Short: "Configure event emission", Long: "Configure event emission\n\nWatchexec can emit event information when running a command, which can be used by the child\nprocess to target specific changed files.\n\nOne thing to take care with is assuming inherent behaviour where there is only chance.\nNotably, it could appear as if the `RENAMED` variable contains both the original and the new\npath being renamed. In previous versions, it would even appear on some platforms as if the\noriginal always came before the new. However, none of this was true. It's impossible to\nreliably and portably know which changed path is the old or new, \"half\" renames may appear\n(only the original, only the new), \"unknown\" renames may appear (change was a rename, but\nwhether it was the old or new isn't known), rename events might split across two debouncing\nboundaries, and so on.\n\nThis option controls where that information is emitted. It defaults to 'none', which doesn't\nemit event information at all. The other options are 'environment' (deprecated), 'stdio',\n'file', 'json-stdio', and 'json-file'.\n\nThe 'stdio' and 'file' modes are text-based: 'stdio' writes absolute paths to the stdin of\nthe command, one per line, each prefixed with `create:`, `remove:`, `rename:`, `modify:`,\nor `other:`, then closes the handle; 'file' writes the same thing to a temporary file, and\nits path is given with the $WATCHEXEC_EVENTS_FILE environment variable.\n\nThere are also two JSON modes, which are based on JSON objects and can represent the full\nset of events Watchexec handles. Here's an example of a folder being created on Linux:\n\n```json\n  {\n    \"tags\": [\n      {\n        \"kind\": \"path\",\n        \"absolute\": \"/home/user/your/new-folder\",\n        \"filetype\": \"dir\"\n      },\n      {\n        \"kind\": \"fs\",\n        \"simple\": \"create\",\n        \"full\": \"Create(Folder)\"\n      },\n      {\n        \"kind\": \"source\",\n        \"source\": \"filesystem\",\n      }\n    ],\n    \"metadata\": {\n      \"notify-backend\": \"inotify\"\n    }\n  }\n```\n\nThe fields are as follows:\n\n  - `tags`, structured event data.\n  - `tags[].kind`, which can be:\n    * 'path', along with:\n      + `absolute`, an absolute path.\n      + `filetype`, a file type if known ('dir', 'file', 'symlink', 'other').\n    * 'fs':\n      + `simple`, the \"simple\" event type ('access', 'create', 'modify', 'remove', or 'other').\n      + `full`, the \"full\" event type, which is too complex to fully describe here, but looks like 'General(Precise(Specific))'.\n    * 'source', along with:\n      + `source`, the source of the event ('filesystem', 'keyboard', 'mouse', 'os', 'time', 'internal').\n    * 'keyboard', along with:\n      + `keycode`. Currently only the value 'eof' is supported.\n    * 'process', for events caused by processes:\n      + `pid`, the process ID.\n    * 'signal', for signals sent to Watchexec:\n      + `signal`, the normalised signal name ('hangup', 'interrupt', 'quit', 'terminate', 'user1', 'user2').\n    * 'completion', for when a command ends:\n      + `disposition`, the exit disposition ('success', 'error', 'signal', 'stop', 'exception', 'continued').\n      + `code`, the exit, signal, stop, or exception code.\n  - `metadata`, additional information about the event.\n\nThe 'json-stdio' mode will emit JSON events to the standard input of the command, one per\nline, then close stdin. The 'json-file' mode will create a temporary file, write the\nevents to it, and provide the path to the file with the $WATCHEXEC_EVENTS_FILE\nenvironment variable.\n\nFinally, the 'environment' mode was the default until 2.0. It sets environment variables\nwith the paths of the affected files, for filesystem events:\n\n$WATCHEXEC_COMMON_PATH is set to the longest common path of all of the below variables,\nand so should be prepended to each path to obtain the full/real path. Then:\n\n  - $WATCHEXEC_CREATED_PATH is set when files/folders were created\n  - $WATCHEXEC_REMOVED_PATH is set when files/folders were removed\n  - $WATCHEXEC_RENAMED_PATH is set when files/folders were renamed\n  - $WATCHEXEC_WRITTEN_PATH is set when files/folders were modified\n  - $WATCHEXEC_META_CHANGED_PATH is set when files/folders' metadata were modified\n  - $WATCHEXEC_OTHERWISE_CHANGED_PATH is set for every other kind of pathed event\n\nMultiple paths are separated by the system path separator, ';' on Windows and ':' on unix.\nWithin each variable, paths are deduplicated and sorted in binary order (i.e. neither\nUnicode nor locale aware).\n\nThis is the legacy mode, is deprecated, and will be removed in the future. The environment\nis a very restricted space, while also limited in what it can usefully represent. Large\nnumbers of files will either cause the environment to be truncated, or may error or crash\nthe process entirely. The $WATCHEXEC_COMMON_PATH is also unintuitive, as demonstrated by the\nmultiple confused queries that have landed in my inbox over the years.", Heading: "Command", Choices: []string{"environment", "stdio", "file", "json-stdio", "json-file", "none"}, Default: []string{"none"}},
+	{Key: FlagWatchOnlyEmitEvents, Short: "Only emit events to stdout, run no commands.", Long: "Only emit events to stdout, run no commands.\n\nThis is a convenience option for using Watchexec as a file watcher, without running any\ncommands. It is almost equivalent to using `cat` as the command, except that it will not\nspawn a new process for each event.\n\nThis option requires `--emit-events-to` to be set, and restricts the available modes to\n`stdio` and `json-stdio`, modifying their behaviour to write to stdout instead of the stdin\nof the command.", Heading: "Output"},
+	{Key: FlagWatchEnv, Repeatable: true, ValueName: "KEY=VALUE", ValueDemanded: true, Short: "Add env vars to the command", Long: "Add env vars to the command\n\nThis is a convenience option for setting environment variables for the command, without\nsetting them for the Watchexec process itself.\n\nUse key=value syntax. Multiple variables can be set by repeating the option.", Heading: "Command"},
+	{Key: FlagWatchWrapProcess, ValueName: "MODE", ValueDemanded: true, Short: "Configure how the process is wrapped", Long: "Configure how the process is wrapped\n\nBy default, Watchexec will run the command in a session on macOS, in a process group on\nother Unix platforms, and in a Job Object in Windows.\n\nSome Unix programs prefer running in a session, while others do not work in a process group.\n\nUse 'group' to use a process group, 'session' to use a process session, and 'none' to run\nthe command directly. On Windows, either of 'group' or 'session' will use a Job Object.", Heading: "Command", Choices: []string{"group", "session", "none"}},
+	{Key: FlagWatchNotify, Short: "Alert when commands start and end", Long: "Alert when commands start and end\n\nWith this, Watchexec will emit a desktop notification when a command starts and ends, on\nsupported platforms. On unsupported platforms, it may silently do nothing, or log a warning.", Heading: "Output"},
+	{Key: FlagWatchColor, ValueName: "MODE", ValueDemanded: true, Short: "When to use terminal colours", Long: "When to use terminal colours\n\nSetting the environment variable `NO_COLOR` to any value is equivalent to `--color=never`.", Heading: "Output", Choices: []string{"auto", "always", "never"}, Default: []string{"auto"}},
+	{Key: FlagWatchTimings, Short: "Print how long the command took to run", Long: "Print how long the command took to run\n\nThis may not be exactly accurate, as it includes some overhead from Watchexec itself. Use\nthe `time` utility, high-precision timers, or benchmarking tools for more accurate results.", Heading: "Output"},
+	{Key: FlagWatchQuiet, Short: "Don't print starting and stopping messages", Long: "Don't print starting and stopping messages\n\nBy default Watchexec will print a message when the command starts and stops. This option\ndisables this behaviour, so only the command's output, warnings, and errors will be printed.", Heading: "Output"},
+	{Key: FlagWatchBell, Short: "Ring the terminal bell on command completion", Long: "Ring the terminal bell on command completion", Heading: "Output"},
+	{Key: FlagWatchProjectOrigin, ValueName: "DIRECTORY", ValueDemanded: true, Short: "Set the project origin", Long: "Set the project origin\n\nWatchexec will attempt to discover the project's \"origin\" (or \"root\") by searching for a\nvariety of markers, like files or directory patterns. It does its best but sometimes gets it\nit wrong, and you can override that with this option.\n\nThe project origin is used to determine the path of certain ignore files, which VCS is being\nused, the meaning of a leading '/' in filtering patterns, and maybe more in the future.\n\nWhen set, Watchexec will also not bother searching, which can be significantly faster."},
+	{Key: FlagWatchWorkdir, ValueName: "DIRECTORY", ValueDemanded: true, Short: "Set the working directory", Long: "Set the working directory\n\nBy default, the working directory of the command is the working directory of Watchexec. You\ncan change that with this option. Note that paths may be less intuitive to use with this."},
+	{Key: FlagWatchExts, Repeatable: true, ValueName: "EXTENSIONS", ValueDemanded: true, Short: "Filename extensions to filter to", Long: "Filename extensions to filter to\n\nThis is a quick filter to only emit events for files with the given extensions. Extensions\ncan be given with or without the leading dot (e.g. 'js' or '.js'). Multiple extensions can\nbe given by repeating the option or by separating them with commas.", Heading: "Filtering"},
+	{Key: FlagWatchFilter, Repeatable: true, ValueName: "PATTERN", ValueDemanded: true, Short: "Filename patterns to filter to", Long: "Filename patterns to filter to\n\nProvide a glob-like filter pattern, and only events for files matching the pattern will be\nemitted. Multiple patterns can be given by repeating the option. Events that are not from\nfiles (e.g. signals, keyboard events) will pass through untouched.", Heading: "Filtering"},
+	{Key: FlagWatchFilterFile, HideEnv: true, Repeatable: true, ValueName: "PATH", ValueDemanded: true, Short: "Files to load filters from", Long: "Files to load filters from\n\nProvide a path to a file containing filters, one per line. Empty lines and lines starting\nwith '#' are ignored. Uses the same pattern format as the '--filter' option.\n\nThis can also be used via the $WATCHEXEC_FILTER_FILES environment variable.", Heading: "Filtering", Env: "WATCHEXEC_FILTER_FILES"},
+	{Key: FlagWatchFilterProg, Repeatable: true, ValueName: "EXPRESSION", ValueDemanded: true, Short: "[experimental] Filter programs.", Long: "[experimental] Filter programs.\n\n/!\\ This option is EXPERIMENTAL and may change and/or vanish without notice.\n\nProvide your own custom filter programs in jaq (similar to jq) syntax. Programs are given\nan event in the same format as described in '--emit-events-to' and must return a boolean.\nInvalid programs will make watchexec fail to start; use '-v' to see program runtime errors.\n\nIn addition to the jaq stdlib, watchexec adds some custom filter definitions:\n\n  - 'path | file_meta' returns file metadata or null if the file does not exist.\n\n  - 'path | file_size' returns the size of the file at path, or null if it does not exist.\n\n  - 'path | file_read(bytes)' returns a string with the first n bytes of the file at path.\n    If the file is smaller than n bytes, the whole file is returned. There is no filter to\n    read the whole file at once to encourage limiting the amount of data read and processed.\n\n  - 'string | hash', and 'path | file_hash' return the hash of the string or file at path.\n    No guarantee is made about the algorithm used: treat it as an opaque value.\n\n  - 'any | kv_store(key)', 'kv_fetch(key)', and 'kv_clear' provide a simple key-value store.\n    Data is kept in memory only, there is no persistence. Consistency is not guaranteed.\n\n  - 'any | printout', 'any | printerr', and 'any | log(level)' will print or log any given\n    value to stdout, stderr, or the log (levels = error, warn, info, debug, trace), and\n    pass the value through (so '[1] | log(\"debug\") | .[]' will produce a '1' and log '[1]').\n\nAll filtering done with such programs, and especially those using kv or filesystem access,\nis much slower than the other filtering methods. If filtering is too slow, events will back\nup and stall watchexec. Take care when designing your filters.\n\nIf the argument to this option starts with an '@', the rest of the argument is taken to be\nthe path to a file containing a jaq program.\n\nJaq programs are run in order, after all other filters, and short-circuit: if a filter (jaq\nor not) rejects an event, execution stops there, and no other filters are run. Additionally,\nthey stop after outputting the first value, so you'll want to use 'any' or 'all' when\niterating, otherwise only the first item will be processed, which can be quite confusing!\n\nFind user-contributed programs or submit your own useful ones at\n<https://github.com/watchexec/watchexec/discussions/592>.\n\n## Examples:\n\nRegexp ignore filter on paths:\n\n  'all(.tags[] | select(.kind == \"path\"); .absolute | test(\"[.]test[.]js$\")) | not'\n\nPass any event that creates a file:\n\n  'any(.tags[] | select(.kind == \"fs\"); .simple == \"create\")'\n\nPass events that touch executable files:\n\n  'any(.tags[] | select(.kind == \"path\" && .filetype == \"file\"); .absolute | metadata | .executable)'\n\nIgnore files that start with shebangs:\n\n  'any(.tags[] | select(.kind == \"path\" && .filetype == \"file\"); .absolute | read(2) == \"#!\") | not'", Heading: "Filtering"},
+	{Key: FlagWatchIgnore, Repeatable: true, ValueName: "PATTERN", ValueDemanded: true, Short: "Filename patterns to filter out", Long: "Filename patterns to filter out\n\nProvide a glob-like filter pattern, and events for files matching the pattern will be\nexcluded. Multiple patterns can be given by repeating the option. Events that are not from\nfiles (e.g. signals, keyboard events) will pass through untouched.", Heading: "Filtering"},
+	{Key: FlagWatchIgnoreFile, HideEnv: true, Repeatable: true, ValueName: "PATH", ValueDemanded: true, Short: "Files to load ignores from", Long: "Files to load ignores from\n\nProvide a path to a file containing ignores, one per line. Empty lines and lines starting\nwith '#' are ignored. Uses the same pattern format as the '--ignore' option.\n\nThis can also be used via the $WATCHEXEC_IGNORE_FILES environment variable.", Heading: "Filtering", Env: "WATCHEXEC_IGNORE_FILES"},
+	{Key: FlagWatchFsEvents, HideDefaultValue: true, Repeatable: true, ValueName: "EVENTS", ValueDemanded: true, Short: "Filesystem events to filter to", Long: "Filesystem events to filter to\n\nThis is a quick filter to only emit events for the given types of filesystem changes. Choose\nfrom 'access', 'create', 'remove', 'rename', 'modify', 'metadata'. Multiple types can be\ngiven by repeating the option or by separating them with commas. By default, this is all\ntypes except for 'access'.\n\nThis may apply filtering at the kernel level when possible, which can be more efficient, but\nmay be more confusing when reading the logs.", Heading: "Filtering", Choices: []string{"access", "create", "remove", "rename", "modify", "metadata"}, Default: []string{"create,remove,rename,modify,metadata"}},
+	{Key: FlagWatchNoMeta, Short: "Don't emit fs events for metadata changes", Long: "Don't emit fs events for metadata changes\n\nThis is a shorthand for '--fs-events create,remove,rename,modify'. Using it alongside the\n'--fs-events' option is non-sensical and not allowed.", Heading: "Filtering"},
+	{Key: FlagWatchPrintEvents, Short: "Print events that trigger actions", Long: "Print events that trigger actions\n\nThis prints the events that triggered the action when handling it (after debouncing), in a\nhuman readable form. This is useful for debugging filters.\n\nUse '-vvv' instead when you need more diagnostic information.", Heading: "Debugging"},
+	{Key: FlagWatchManual, Short: "Show the manual page", Long: "Show the manual page\n\nThis shows the manual page for Watchexec, if the output is a terminal and the 'man' program\nis available. If not, the manual page is printed to stdout in ROFF format (suitable for\nwriting to a watchexec.1 file).", Heading: "Debugging"},
+	{Key: ArgWatchTask, Short: "Tasks to run\nCan specify multiple tasks by separating with `:::`\ne.g.: `mise run task1 arg1 arg2 ::: task2 arg1 arg2`\nDefaults to `default`", Long: "Tasks to run\nCan specify multiple tasks by separating with `:::`\ne.g.: `mise run task1 arg1 arg2 ::: task2 arg1 arg2`\nDefaults to `default`"},
 	{Key: ArgWatchArgs, Short: "Task and arguments to run", Long: "Task and arguments to run"},
-	{Key: CmdWhere, Short: "Display the installation path for a tool", Long: "Display the installation path for a tool\n\nThe tool must be installed for this to work.", AfterLongHelp: "Examples:\n\n    # Show the latest installed version of node\n    # If it is is not installed, errors\n    $ mise where node@20\n    /home/jdx/.local/share/mise/installs/node/20.0.0\n\n    # Show the current, active install directory of node\n    # Errors if node is not referenced in any .tool-version file\n    $ mise where node\n    /home/jdx/.local/share/mise/installs/node/20.0.0\n"},
+	{Key: CmdWhere, Short: "Display the installation path for a tool", Long: "Display the installation path for a tool\n\nThe tool must be installed for this to work.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    # Show the latest installed version of node\n    # If it is is not installed, errors\n    $ \x1b[1mmise where node@20\x1b[22m\n    /home/jdx/.local/share/mise/installs/node/20.0.0\n\n    # Show the current, active install directory of node\n    # Errors if node is not referenced in any .tool-version file\n    $ \x1b[1mmise where node\x1b[22m\n    /home/jdx/.local/share/mise/installs/node/20.0.0\n"},
 	{Key: ArgWhereToolVersion, Demanded: true, Short: "Tool(s) to look up\ne.g.: ruby@3\nif \"@<PREFIX>\" is specified, it will show the latest installed version\nthat matches the prefix\notherwise, it will show the current, active installed version", Long: "Tool(s) to look up\ne.g.: ruby@3\nif \"@<PREFIX>\" is specified, it will show the latest installed version\nthat matches the prefix\notherwise, it will show the current, active installed version"},
 	{Key: ArgWhereAsdfVersion, Hide: true, Short: "the version prefix to use when querying the latest version\nsame as the first argument after the \"@\"\nused for asdf compatibility", Long: "the version prefix to use when querying the latest version\nsame as the first argument after the \"@\"\nused for asdf compatibility"},
-	{Key: CmdWhich, Short: "Shows the path that a tool's bin points to.", Long: "Shows the path that a tool's bin points to.\n\nUse this to figure out what version of a tool is currently active.", AfterLongHelp: "Examples:\n\n    $ mise which node\n    /home/username/.local/share/mise/installs/node/20.0.0/bin/node\n\n    $ mise which node --plugin\n    node\n\n    $ mise which node --version\n    20.0.0\n"},
+	{Key: CmdWhich, Short: "Shows the path that a tool's bin points to.", Long: "Shows the path that a tool's bin points to.\n\nUse this to figure out what version of a tool is currently active.", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise which node\x1b[22m\n    /home/username/.local/share/mise/installs/node/20.0.0/bin/node\n\n    $ \x1b[1mmise which node --plugin\x1b[22m\n    node\n\n    $ \x1b[1mmise which node --version\x1b[22m\n    20.0.0\n"},
 	{Key: FlagWhichTool, ValueName: "TOOL@VERSION", ValueDemanded: true, Short: "Use a specific tool@version\ne.g.: `mise which npm --tool=node@20`", Long: "Use a specific tool@version\ne.g.: `mise which npm --tool=node@20`"},
 	{Key: FlagWhichComplete, Hide: true},
 	{Key: FlagWhichPlugin, Short: "Show the plugin name instead of the path", Long: "Show the plugin name instead of the path"},
@@ -5895,7 +5949,7 @@ var HelpText = argv.HelpTable{
 
 // HelpMeta is what a page needs from the spec's root rather than from any one
 // command: the header, and the text that brackets every page.
-var HelpMeta = argv.HelpSpec{Name: "mise", Bin: "mise", About: "Dev tools, env vars, and tasks in one CLI", LongAbout: "mise prepares your development environment before each command runs. https://github.com/jdx/mise"}
+var HelpMeta = argv.HelpSpec{Name: "mise", Bin: "mise", About: "Dev tools, env vars, and tasks in one CLI", LongAbout: "mise prepares your development environment before each command runs. https://github.com/jdx/mise", Author: "Jeff Dickey <@jdx>", AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    $ \x1b[1mmise install node@20.0.0\x1b[22m       Install a specific node version\n    $ \x1b[1mmise install node@20\x1b[22m           Install a version matching a prefix\n    $ \x1b[1mmise install node\x1b[22m              Install the node version defined in config\n    $ \x1b[1mmise install\x1b[22m                   Install all plugins/tools defined in config\n\n    $ \x1b[1mmise install cargo:ripgrep\x1b[22m     Install something via cargo\n    $ \x1b[1mmise install npm:prettier\x1b[22m      Install something via npm\n\n    $ \x1b[1mmise use node@20\x1b[22m               Use node-20.x in current project\n    $ \x1b[1mmise use -g node@20\x1b[22m            Use node-20.x as default\n    $ \x1b[1mmise use node@latest\x1b[22m           Use latest node in current directory\n\n    $ \x1b[1mmise up --interactive\x1b[22m          Show a menu to upgrade tools\n\n    $ \x1b[1mmise x -- npm install\x1b[22m          `npm install` w/ config loaded into PATH\n    $ \x1b[1mmise x node@20 -- node app.js\x1b[22m  `node app.js` w/ config + node-20.x on PATH\n\n    $ \x1b[1mmise set NODE_ENV=production\x1b[22m   Set NODE_ENV=production in config\n\n    $ \x1b[1mmise run build\x1b[22m                 Run `build` tasks\n    $ \x1b[1mmise watch build\x1b[22m               Run `build` tasks repeatedly when files change\n\n    $ \x1b[1mmise settings\x1b[22m                  Show settings in use\n    $ \x1b[1mmise settings color=0\x1b[22m          Disable color by modifying global config file\n"}
 
 // Cli is the whole command line.
 type Cli struct {
@@ -6485,6 +6539,8 @@ type BootstrapRemoteCmd struct {
 	All              bool     // FlagBootstrapRemoteAll
 	BootstrapCommand string   // FlagBootstrapRemoteBootstrapCommand
 	ConnectTimeout   string   // FlagBootstrapRemoteConnectTimeout
+	CopyLink         []string // FlagBootstrapRemoteCopyLink
+	CopyLinks        bool     // FlagBootstrapRemoteCopyLinks
 	Exclude          []string // FlagBootstrapRemoteExclude
 	FailFast         bool     // FlagBootstrapRemoteFailFast
 	ForceDotfiles    bool     // FlagBootstrapRemoteForceDotfiles
@@ -6496,6 +6552,7 @@ type BootstrapRemoteCmd struct {
 	Only             []string // FlagBootstrapRemoteOnly
 	Port             string   // FlagBootstrapRemotePort
 	PromptSecrets    bool     // FlagBootstrapRemotePromptSecrets
+	RemoteEnv        []string // FlagBootstrapRemoteRemoteEnv
 	RemoteMise       string   // FlagBootstrapRemoteRemoteMise
 	Skip             []string // FlagBootstrapRemoteSkip
 	Source           string   // FlagBootstrapRemoteSource
@@ -6840,6 +6897,7 @@ type GenerateBootstrapCmd struct {
 	Version      string // FlagGenerateBootstrapVersion
 	Write        string // FlagGenerateBootstrapWrite
 	LocalizedDir string // FlagGenerateBootstrapLocalizedDir
+	Windows      bool   // FlagGenerateBootstrapWindows
 }
 
 // GenerateConfigCmd is `generate config`.
@@ -6860,9 +6918,10 @@ type GenerateDevcontainerCmd struct {
 
 // GenerateGitPreCommitCmd is `generate git-pre-commit`.
 type GenerateGitPreCommitCmd struct {
-	Task  string // FlagGenerateGitPreCommitTask
-	Write bool   // FlagGenerateGitPreCommitWrite
-	Hook  string // FlagGenerateGitPreCommitHook
+	Task    string   // FlagGenerateGitPreCommitTask
+	Write   bool     // FlagGenerateGitPreCommitWrite
+	Hook    string   // FlagGenerateGitPreCommitHook
+	MiseArg []string // ArgGenerateGitPreCommitMiseArg
 }
 
 // GenerateGithubActionCmd is `generate github-action`.
@@ -6890,18 +6949,19 @@ type GenerateTaskStubsCmd struct {
 
 // GenerateToolStubCmd is `generate tool-stub`.
 type GenerateToolStubCmd struct {
-	Bin              string   // FlagGenerateToolStubBin
-	Bootstrap        bool     // FlagGenerateToolStubBootstrap
-	BootstrapVersion string   // FlagGenerateToolStubBootstrapVersion
-	Fetch            bool     // FlagGenerateToolStubFetch
-	Http             string   // FlagGenerateToolStubHttp
-	Lock             bool     // FlagGenerateToolStubLock
-	PlatformBin      []string // FlagGenerateToolStubPlatformBin
-	PlatformUrl      []string // FlagGenerateToolStubPlatformUrl
-	SkipDownload     bool     // FlagGenerateToolStubSkipDownload
-	Url              string   // FlagGenerateToolStubUrl
-	Version          string   // FlagGenerateToolStubVersion
-	Output           string   // ArgGenerateToolStubOutput
+	Bin               string   // FlagGenerateToolStubBin
+	Bootstrap         bool     // FlagGenerateToolStubBootstrap
+	BootstrapVersion  string   // FlagGenerateToolStubBootstrapVersion
+	ChecksumAlgorithm string   // FlagGenerateToolStubChecksumAlgorithm
+	Fetch             bool     // FlagGenerateToolStubFetch
+	Http              string   // FlagGenerateToolStubHttp
+	Lock              bool     // FlagGenerateToolStubLock
+	PlatformBin       []string // FlagGenerateToolStubPlatformBin
+	PlatformUrl       []string // FlagGenerateToolStubPlatformUrl
+	SkipDownload      bool     // FlagGenerateToolStubSkipDownload
+	Url               string   // FlagGenerateToolStubUrl
+	Version           string   // FlagGenerateToolStubVersion
+	Output            string   // ArgGenerateToolStubOutput
 }
 
 // GithubCmd is `github`.
@@ -6963,6 +7023,7 @@ type InstallCmd struct {
 	DryRun            bool     // FlagInstallDryRun
 	Verbose           int      // FlagInstallVerbose
 	DryRunCode        bool     // FlagInstallDryRunCode
+	IncludeTaskTools  bool     // FlagInstallIncludeTaskTools
 	MinimumReleaseAge string   // FlagInstallMinimumReleaseAge
 	Monorepo          bool     // FlagInstallMonorepo
 	Raw               bool     // FlagInstallRaw
@@ -7103,8 +7164,9 @@ type OciRunCmd struct {
 
 // OutdatedCmd is `outdated`.
 type OutdatedCmd struct {
-	Json        bool     // FlagOutdatedJson
 	Bump        bool     // FlagOutdatedBump
+	Json        bool     // FlagOutdatedJson
+	L           bool     // FlagOutdatedL
 	Inactive    bool     // FlagOutdatedInactive
 	Local       bool     // FlagOutdatedLocal
 	Monorepo    bool     // FlagOutdatedMonorepo
@@ -7256,6 +7318,7 @@ type RunCmd struct {
 	AffectedExplain      bool     // FlagRunAffectedExplain
 	AffectedHead         string   // FlagRunAffectedHead
 	AffectedJson         bool     // FlagRunAffectedJson
+	All                  bool     // FlagRunAll
 	ContinueOnError      bool     // FlagRunContinueOnError
 	Cd                   string   // FlagRunCd
 	Force                bool     // FlagRunForce
@@ -7540,6 +7603,7 @@ type TasksRunCmd struct {
 	AffectedExplain      bool     // FlagTasksRunAffectedExplain
 	AffectedHead         string   // FlagTasksRunAffectedHead
 	AffectedJson         bool     // FlagTasksRunAffectedJson
+	All                  bool     // FlagTasksRunAll
 	ContinueOnError      bool     // FlagTasksRunContinueOnError
 	Cd                   string   // FlagTasksRunCd
 	Force                bool     // FlagTasksRunForce
@@ -7681,9 +7745,10 @@ type UnuseCmd struct {
 
 // UpgradeCmd is `upgrade`.
 type UpgradeCmd struct {
+	Bump                 bool     // FlagUpgradeBump
 	Interactive          bool     // FlagUpgradeInteractive
 	Jobs                 string   // FlagUpgradeJobs
-	Bump                 bool     // FlagUpgradeBump
+	L                    bool     // FlagUpgradeL
 	DryRun               bool     // FlagUpgradeDryRun
 	Exclude              []string // FlagUpgradeExclude
 	DryRunCode           bool     // FlagUpgradeDryRunCode
@@ -7692,6 +7757,7 @@ type UpgradeCmd struct {
 	MinimumReleaseAge    string   // FlagUpgradeMinimumReleaseAge
 	Monorepo             bool     // FlagUpgradeMonorepo
 	NoPrune              bool     // FlagUpgradeNoPrune
+	Prune                bool     // FlagUpgradePrune
 	Raw                  bool     // FlagUpgradeRaw
 	InstalledToolVersion []string // ArgUpgradeInstalledToolVersion
 }
@@ -8016,6 +8082,7 @@ func Parse(args []string) (*Cli, error) {
 	// before any of it is handed back.
 	given := map[uint64][]string{}
 	seen := map[uint64]int{}
+	negated := map[uint64]bool{}
 	chain := []*argv.Command{Root}
 
 	p := argv.New(Root, args)
@@ -8658,6 +8725,7 @@ func Parse(args []string) (*Cli, error) {
 			}
 		case argv.KindFlag:
 			seen[ev.Flag.Key]++
+			negated[ev.Flag.Key] = ev.Negated
 			if ev.Flag.BoolValue {
 				// Boolean binding is last-one-wins. Replace an earlier attached value even
 				// when the last occurrence is bare, so relationship polarity follows the field.
@@ -8968,6 +9036,12 @@ func Parse(args []string) (*Cli, error) {
 				cmdBootstrapRemoteV.BootstrapCommand = ev.Value
 			case FlagBootstrapRemoteConnectTimeout:
 				cmdBootstrapRemoteV.ConnectTimeout = ev.Value
+			case FlagBootstrapRemoteCopyLink:
+				if ev.HasValue {
+					cmdBootstrapRemoteV.CopyLink = append(cmdBootstrapRemoteV.CopyLink, argv.SplitValue(ev.Value, ev.Flag.Delimiter, true)...)
+				}
+			case FlagBootstrapRemoteCopyLinks:
+				cmdBootstrapRemoteV.CopyLinks = !ev.Negated
 			case FlagBootstrapRemoteExclude:
 				if ev.HasValue {
 					cmdBootstrapRemoteV.Exclude = append(cmdBootstrapRemoteV.Exclude, argv.SplitValue(ev.Value, ev.Flag.Delimiter, true)...)
@@ -8996,6 +9070,10 @@ func Parse(args []string) (*Cli, error) {
 				cmdBootstrapRemoteV.Port = ev.Value
 			case FlagBootstrapRemotePromptSecrets:
 				cmdBootstrapRemoteV.PromptSecrets = !ev.Negated
+			case FlagBootstrapRemoteRemoteEnv:
+				if ev.HasValue {
+					cmdBootstrapRemoteV.RemoteEnv = append(cmdBootstrapRemoteV.RemoteEnv, argv.SplitValue(ev.Value, ev.Flag.Delimiter, true)...)
+				}
 			case FlagBootstrapRemoteRemoteMise:
 				cmdBootstrapRemoteV.RemoteMise = ev.Value
 			case FlagBootstrapRemoteSkip:
@@ -9210,6 +9288,8 @@ func Parse(args []string) (*Cli, error) {
 				cmdGenerateBootstrapV.Write = ev.Value
 			case FlagGenerateBootstrapLocalizedDir:
 				cmdGenerateBootstrapV.LocalizedDir = ev.Value
+			case FlagGenerateBootstrapWindows:
+				cmdGenerateBootstrapV.Windows = !ev.Negated
 			case FlagGenerateConfigGlobal:
 				cmdGenerateConfigV.Global = !ev.Negated
 			case FlagGenerateConfigDryRun:
@@ -9258,6 +9338,8 @@ func Parse(args []string) (*Cli, error) {
 				cmdGenerateToolStubV.Bootstrap = !ev.Negated
 			case FlagGenerateToolStubBootstrapVersion:
 				cmdGenerateToolStubV.BootstrapVersion = ev.Value
+			case FlagGenerateToolStubChecksumAlgorithm:
+				cmdGenerateToolStubV.ChecksumAlgorithm = ev.Value
 			case FlagGenerateToolStubFetch:
 				cmdGenerateToolStubV.Fetch = !ev.Negated
 			case FlagGenerateToolStubHttp:
@@ -9328,6 +9410,8 @@ func Parse(args []string) (*Cli, error) {
 				cmdInstallV.Verbose++
 			case FlagInstallDryRunCode:
 				cmdInstallV.DryRunCode = !ev.Negated
+			case FlagInstallIncludeTaskTools:
+				cmdInstallV.IncludeTaskTools = !ev.Negated
 			case FlagInstallMinimumReleaseAge:
 				cmdInstallV.MinimumReleaseAge = ev.Value
 			case FlagInstallMonorepo:
@@ -9480,10 +9564,12 @@ func Parse(args []string) (*Cli, error) {
 				cmdOciRunV.Tty = !ev.Negated
 			case FlagOciRunWorkdir:
 				cmdOciRunV.Workdir = ev.Value
-			case FlagOutdatedJson:
-				cmdOutdatedV.Json = !ev.Negated
 			case FlagOutdatedBump:
 				cmdOutdatedV.Bump = !ev.Negated
+			case FlagOutdatedJson:
+				cmdOutdatedV.Json = !ev.Negated
+			case FlagOutdatedL:
+				cmdOutdatedV.L = !ev.Negated
 			case FlagOutdatedInactive:
 				cmdOutdatedV.Inactive = !ev.Negated
 			case FlagOutdatedLocal:
@@ -9608,6 +9694,8 @@ func Parse(args []string) (*Cli, error) {
 				cmdRunV.AffectedHead = ev.Value
 			case FlagRunAffectedJson:
 				cmdRunV.AffectedJson = !ev.Negated
+			case FlagRunAll:
+				cmdRunV.All = !ev.Negated
 			case FlagRunContinueOnError:
 				cmdRunV.ContinueOnError = !ev.Negated
 			case FlagRunCd:
@@ -9894,6 +9982,8 @@ func Parse(args []string) (*Cli, error) {
 				cmdTasksRunV.AffectedHead = ev.Value
 			case FlagTasksRunAffectedJson:
 				cmdTasksRunV.AffectedJson = !ev.Negated
+			case FlagTasksRunAll:
+				cmdTasksRunV.All = !ev.Negated
 			case FlagTasksRunContinueOnError:
 				cmdTasksRunV.ContinueOnError = !ev.Negated
 			case FlagTasksRunCd:
@@ -10036,12 +10126,14 @@ func Parse(args []string) (*Cli, error) {
 				cmdUnuseV.Path = ev.Value
 			case FlagUnuseNoPrune:
 				cmdUnuseV.NoPrune = !ev.Negated
+			case FlagUpgradeBump:
+				cmdUpgradeV.Bump = !ev.Negated
 			case FlagUpgradeInteractive:
 				cmdUpgradeV.Interactive = !ev.Negated
 			case FlagUpgradeJobs:
 				cmdUpgradeV.Jobs = ev.Value
-			case FlagUpgradeBump:
-				cmdUpgradeV.Bump = !ev.Negated
+			case FlagUpgradeL:
+				cmdUpgradeV.L = !ev.Negated
 			case FlagUpgradeDryRun:
 				cmdUpgradeV.DryRun = !ev.Negated
 			case FlagUpgradeExclude:
@@ -10060,6 +10152,8 @@ func Parse(args []string) (*Cli, error) {
 				cmdUpgradeV.Monorepo = !ev.Negated
 			case FlagUpgradeNoPrune:
 				cmdUpgradeV.NoPrune = !ev.Negated
+			case FlagUpgradePrune:
+				cmdUpgradeV.Prune = !ev.Negated
 			case FlagUpgradeRaw:
 				cmdUpgradeV.Raw = !ev.Negated
 			case FlagUseEnv:
@@ -10318,6 +10412,8 @@ func Parse(args []string) (*Cli, error) {
 				cmdExecV.CommandArg = append(cmdExecV.CommandArg, values...)
 			case ArgGenerateConfigPath:
 				cmdGenerateConfigV.Path = ev.Value
+			case ArgGenerateGitPreCommitMiseArg:
+				cmdGenerateGitPreCommitV.MiseArg = append(cmdGenerateGitPreCommitV.MiseArg, values...)
 			case ArgGenerateToolStubOutput:
 				cmdGenerateToolStubV.Output = ev.Value
 			case ArgGithubTokenHost:
@@ -10507,14 +10603,16 @@ func Parse(args []string) (*Cli, error) {
 	}
 	sources := map[uint64]argv.Source{}
 	filled := map[uint64][]string{}
+	resolved := map[uint64][]string{}
 	for _, key := range scope {
 		values, source := argv.Fill(Meta.Lookup(key), given[key], argv.LookupEnv)
 		filled[key] = values
 		sources[key] = source
 	}
-	argv.ApplyDefaultIf(Meta, scope, filled, sources, nil)
+	argv.ApplyDefaultIf(Meta, scope, filled, sources, negated)
 	for _, key := range scope {
 		values, source := filled[key], sources[key]
+		resolved[key] = values
 		entryMeta := Meta.Lookup(key)
 		if entryMeta != nil && !requirements[key] {
 			copy := *entryMeta
@@ -11314,6 +11412,14 @@ func Parse(args []string) (*Cli, error) {
 				cmdBootstrapRemoteV.BootstrapCommand = values[len(values)-1]
 			case FlagBootstrapRemoteConnectTimeout:
 				cmdBootstrapRemoteV.ConnectTimeout = values[len(values)-1]
+			case FlagBootstrapRemoteCopyLink:
+				cmdBootstrapRemoteV.CopyLink = append(cmdBootstrapRemoteV.CopyLink, values...)
+			case FlagBootstrapRemoteCopyLinks:
+				if source == argv.FromEnv {
+					cmdBootstrapRemoteV.CopyLinks = argv.EnvTruth(values[0])
+				} else {
+					cmdBootstrapRemoteV.CopyLinks = values[0] == "true"
+				}
 			case FlagBootstrapRemoteExclude:
 				cmdBootstrapRemoteV.Exclude = append(cmdBootstrapRemoteV.Exclude, values...)
 			case FlagBootstrapRemoteFailFast:
@@ -11356,6 +11462,8 @@ func Parse(args []string) (*Cli, error) {
 				} else {
 					cmdBootstrapRemoteV.PromptSecrets = values[0] == "true"
 				}
+			case FlagBootstrapRemoteRemoteEnv:
+				cmdBootstrapRemoteV.RemoteEnv = append(cmdBootstrapRemoteV.RemoteEnv, values...)
 			case FlagBootstrapRemoteRemoteMise:
 				cmdBootstrapRemoteV.RemoteMise = values[len(values)-1]
 			case FlagBootstrapRemoteSkip:
@@ -11888,6 +11996,12 @@ func Parse(args []string) (*Cli, error) {
 				cmdGenerateBootstrapV.Write = values[len(values)-1]
 			case FlagGenerateBootstrapLocalizedDir:
 				cmdGenerateBootstrapV.LocalizedDir = values[len(values)-1]
+			case FlagGenerateBootstrapWindows:
+				if source == argv.FromEnv {
+					cmdGenerateBootstrapV.Windows = argv.EnvTruth(values[0])
+				} else {
+					cmdGenerateBootstrapV.Windows = values[0] == "true"
+				}
 			case FlagGenerateConfigGlobal:
 				if source == argv.FromEnv {
 					cmdGenerateConfigV.Global = argv.EnvTruth(values[0])
@@ -11930,6 +12044,8 @@ func Parse(args []string) (*Cli, error) {
 				}
 			case FlagGenerateGitPreCommitHook:
 				cmdGenerateGitPreCommitV.Hook = values[len(values)-1]
+			case ArgGenerateGitPreCommitMiseArg:
+				cmdGenerateGitPreCommitV.MiseArg = append(cmdGenerateGitPreCommitV.MiseArg, values...)
 			case FlagGenerateGithubActionTask:
 				cmdGenerateGithubActionV.Task = values[len(values)-1]
 			case FlagGenerateGithubActionWrite:
@@ -11978,6 +12094,8 @@ func Parse(args []string) (*Cli, error) {
 				}
 			case FlagGenerateToolStubBootstrapVersion:
 				cmdGenerateToolStubV.BootstrapVersion = values[len(values)-1]
+			case FlagGenerateToolStubChecksumAlgorithm:
+				cmdGenerateToolStubV.ChecksumAlgorithm = values[len(values)-1]
 			case FlagGenerateToolStubFetch:
 				if source == argv.FromEnv {
 					cmdGenerateToolStubV.Fetch = argv.EnvTruth(values[0])
@@ -12129,6 +12247,12 @@ func Parse(args []string) (*Cli, error) {
 					cmdInstallV.DryRunCode = argv.EnvTruth(values[0])
 				} else {
 					cmdInstallV.DryRunCode = values[0] == "true"
+				}
+			case FlagInstallIncludeTaskTools:
+				if source == argv.FromEnv {
+					cmdInstallV.IncludeTaskTools = argv.EnvTruth(values[0])
+				} else {
+					cmdInstallV.IncludeTaskTools = values[0] == "true"
 				}
 			case FlagInstallMinimumReleaseAge:
 				cmdInstallV.MinimumReleaseAge = values[len(values)-1]
@@ -12468,17 +12592,23 @@ func Parse(args []string) (*Cli, error) {
 				cmdOciRunV.Workdir = values[len(values)-1]
 			case ArgOciRunCmd:
 				cmdOciRunV.Cmd = append(cmdOciRunV.Cmd, values...)
+			case FlagOutdatedBump:
+				if source == argv.FromEnv {
+					cmdOutdatedV.Bump = argv.EnvTruth(values[0])
+				} else {
+					cmdOutdatedV.Bump = values[0] == "true"
+				}
 			case FlagOutdatedJson:
 				if source == argv.FromEnv {
 					cmdOutdatedV.Json = argv.EnvTruth(values[0])
 				} else {
 					cmdOutdatedV.Json = values[0] == "true"
 				}
-			case FlagOutdatedBump:
+			case FlagOutdatedL:
 				if source == argv.FromEnv {
-					cmdOutdatedV.Bump = argv.EnvTruth(values[0])
+					cmdOutdatedV.L = argv.EnvTruth(values[0])
 				} else {
-					cmdOutdatedV.Bump = values[0] == "true"
+					cmdOutdatedV.L = values[0] == "true"
 				}
 			case FlagOutdatedInactive:
 				if source == argv.FromEnv {
@@ -12817,6 +12947,12 @@ func Parse(args []string) (*Cli, error) {
 					cmdRunV.AffectedJson = argv.EnvTruth(values[0])
 				} else {
 					cmdRunV.AffectedJson = values[0] == "true"
+				}
+			case FlagRunAll:
+				if source == argv.FromEnv {
+					cmdRunV.All = argv.EnvTruth(values[0])
+				} else {
+					cmdRunV.All = values[0] == "true"
 				}
 			case FlagRunContinueOnError:
 				if source == argv.FromEnv {
@@ -13498,6 +13634,12 @@ func Parse(args []string) (*Cli, error) {
 				} else {
 					cmdTasksRunV.AffectedJson = values[0] == "true"
 				}
+			case FlagTasksRunAll:
+				if source == argv.FromEnv {
+					cmdTasksRunV.All = argv.EnvTruth(values[0])
+				} else {
+					cmdTasksRunV.All = values[0] == "true"
+				}
 			case FlagTasksRunContinueOnError:
 				if source == argv.FromEnv {
 					cmdTasksRunV.ContinueOnError = argv.EnvTruth(values[0])
@@ -13866,6 +14008,12 @@ func Parse(args []string) (*Cli, error) {
 				}
 			case ArgUnuseInstalledToolVersion:
 				cmdUnuseV.InstalledToolVersion = append(cmdUnuseV.InstalledToolVersion, values...)
+			case FlagUpgradeBump:
+				if source == argv.FromEnv {
+					cmdUpgradeV.Bump = argv.EnvTruth(values[0])
+				} else {
+					cmdUpgradeV.Bump = values[0] == "true"
+				}
 			case FlagUpgradeInteractive:
 				if source == argv.FromEnv {
 					cmdUpgradeV.Interactive = argv.EnvTruth(values[0])
@@ -13874,11 +14022,11 @@ func Parse(args []string) (*Cli, error) {
 				}
 			case FlagUpgradeJobs:
 				cmdUpgradeV.Jobs = values[len(values)-1]
-			case FlagUpgradeBump:
+			case FlagUpgradeL:
 				if source == argv.FromEnv {
-					cmdUpgradeV.Bump = argv.EnvTruth(values[0])
+					cmdUpgradeV.L = argv.EnvTruth(values[0])
 				} else {
-					cmdUpgradeV.Bump = values[0] == "true"
+					cmdUpgradeV.L = values[0] == "true"
 				}
 			case FlagUpgradeDryRun:
 				if source == argv.FromEnv {
@@ -13919,6 +14067,12 @@ func Parse(args []string) (*Cli, error) {
 					cmdUpgradeV.NoPrune = argv.EnvTruth(values[0])
 				} else {
 					cmdUpgradeV.NoPrune = values[0] == "true"
+				}
+			case FlagUpgradePrune:
+				if source == argv.FromEnv {
+					cmdUpgradeV.Prune = argv.EnvTruth(values[0])
+				} else {
+					cmdUpgradeV.Prune = values[0] == "true"
 				}
 			case FlagUpgradeRaw:
 				if source == argv.FromEnv {
@@ -14193,7 +14347,9 @@ func Parse(args []string) (*Cli, error) {
 	}
 	if err := argv.CheckRelationshipsWithValuesAndRequirements(Meta, scope, func(k uint64) argv.Source {
 		return sources[k]
-	}, nil, func(k uint64) bool { return requirements[k] }); err != nil {
+	}, func(k uint64) []string {
+		return argv.RelationshipValues(Meta.Lookup(k), resolved[k], sources[k], negated[k])
+	}, func(k uint64) bool { return requirements[k] }); err != nil {
 		return nil, err
 	}
 	return out, nil

--- a/go/internal/spec/spec.go
+++ b/go/internal/spec/spec.go
@@ -46,6 +46,8 @@ type Spec struct {
 	LongVersion string `json:"long_version"`
 	About       string `json:"about"`
 	AboutLong   string `json:"about_long"`
+	Author      string `json:"author"`
+	License     string `json:"license"`
 	// Complete is the completers a spec declares, keyed by the lowercased name of
 	// the argument or flag value they belong to — which is how usage-lib keys
 	// them, and how a lookup has to be spelled.
@@ -66,6 +68,8 @@ func (s *Spec) HelpSpec() argv.HelpSpec {
 		LongVersion:    s.LongVersion,
 		About:          s.About,
 		LongAbout:      s.AboutLong,
+		Author:         s.Author,
+		License:        s.License,
 		BeforeHelp:     s.BeforeHelp,
 		AfterHelp:      s.AfterHelp,
 		BeforeLongHelp: s.BeforeHelpLong,

--- a/lib/src/go/mod.rs
+++ b/lib/src/go/mod.rs
@@ -392,6 +392,15 @@ impl<'a> Emitter<'a> {
             if e.cmd.arg_required_else_help {
                 lines.push(Line::Field("ArgRequiredElseHelp".into(), "true".into()));
             }
+            if e.cmd.disable_help_flag {
+                lines.push(Line::Field("DisableHelpFlag".into(), "true".into()));
+            }
+            if e.cmd.disable_help_subcommand {
+                lines.push(Line::Field("DisableHelpSubcommand".into(), "true".into()));
+            }
+            if e.cmd.disable_version_flag {
+                lines.push(Line::Field("DisableVersionFlag".into(), "true".into()));
+            }
             if e.cmd.subcommand_negates_reqs {
                 lines.push(Line::Field("SubcommandNegatesReqs".into(), "true".into()));
             }
@@ -993,6 +1002,12 @@ impl Emitter<'_> {
         }
         if let Some(long) = &self.spec.about_long {
             fields.push(format!("LongAbout: {}", go_string(long)));
+        }
+        if let Some(author) = &self.spec.author {
+            fields.push(format!("Author: {}", go_string(author)));
+        }
+        if let Some(license) = &self.spec.license {
+            fields.push(format!("License: {}", go_string(license)));
         }
         if let Some(before) = &self.spec.before_help {
             fields.push(format!("BeforeHelp: {}", go_string(before)));
@@ -1964,6 +1979,27 @@ cmd "run" {
             out.contains("DefaultSubcommand: cmdRun,"),
             "should point at the root's own `run`, got:\n{out}"
         );
+    }
+
+    #[test]
+    fn command_builtin_controls_reach_generated_go_tables() {
+        let out = go(r#"
+name "ex"
+bin "ex"
+disable_help_flag #true
+disable_help_subcommand #true
+disable_version_flag #true
+"#);
+        let root = out
+            .split("var Root = &argv.Command{")
+            .nth(1)
+            .expect("the root command should be emitted")
+            .split("}\n")
+            .next()
+            .unwrap();
+        assert!(root.contains("DisableHelpFlag:"), "{root}");
+        assert!(root.contains("DisableHelpSubcommand:"), "{root}");
+        assert!(root.contains("DisableVersionFlag:"), "{root}");
     }
 
     /// A command's own name outranks another command's alias, so which command the

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -13,7 +13,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::fmt::Write as _;
 use std::path::Path;
 
-use usage::{Spec, SpecArg, SpecCommand, SpecFlag};
+use usage::{Spec, SpecArg, SpecCommand, SpecFlag, SpecGroup};
 
 mod cobra;
 mod help_pages;

--- a/xtask/src/shadow.rs
+++ b/xtask/src/shadow.rs
@@ -169,6 +169,13 @@ fn render(spec: &Spec, spec_path: &Path, dialect: Dialect) -> (String, Skipped) 
             multicall: spec.multicall,
             about: spec.about.as_deref(),
             about_long: spec.about_long.as_deref(),
+            author: spec.author.as_deref(),
+            license: spec.license.as_deref(),
+            repository: spec.repository.as_deref(),
+            before_help: spec.before_help.as_deref(),
+            before_help_long: spec.before_help_long.as_deref(),
+            after_help: spec.after_help.as_deref(),
+            after_help_long: spec.after_help_long.as_deref(),
             dialect,
             skipped: &mut skipped,
             names: &mut names,
@@ -293,9 +300,51 @@ struct Run<'a> {
     /// The spec's own description, which belongs to the root.
     about: Option<&'a str>,
     about_long: Option<&'a str>,
+    author: Option<&'a str>,
+    license: Option<&'a str>,
+    repository: Option<&'a str>,
+    before_help: Option<&'a str>,
+    before_help_long: Option<&'a str>,
+    after_help: Option<&'a str>,
+    after_help_long: Option<&'a str>,
     dialect: Dialect,
     skipped: &'a mut Skipped,
     names: &'a mut Names,
+}
+
+fn emit_clap_groups(out: &mut String, groups: &[SpecGroup]) {
+    if !groups.is_empty() {
+        // Disable clap's implicit Args group, which otherwise includes every field in the
+        // struct. The portable groups below name only their declared members through each
+        // field's `group = ...` attribute.
+        out.push_str("#[group(skip)]\n");
+    }
+    for group in groups {
+        writeln!(
+            out,
+            "#[command(group = ::clap::ArgGroup::new({:?}).required({}).multiple({}))]",
+            group.name, group.required, group.multiple
+        )
+        .expect("writing to a String");
+    }
+}
+
+fn group_for_selectors<'a>(
+    groups: &'a [SpecGroup],
+    selectors: &[String],
+    skipped: &mut Skipped,
+) -> Option<&'a str> {
+    let mut matches = groups.iter().filter(|group| {
+        group
+            .members
+            .iter()
+            .any(|member| selectors.contains(member))
+    });
+    let first = matches.next();
+    if matches.next().is_some() {
+        skipped.note("an argument in more than one group");
+    }
+    first.map(|group| group.name.as_str())
 }
 
 fn emit_command(out: &mut String, cmd: &SpecCommand, ty: &Type, is_root: bool, run: &mut Run) {
@@ -317,12 +366,7 @@ fn emit_command(out: &mut String, cmd: &SpecCommand, ty: &Type, is_root: bool, r
             run.skipped.note("a command's second and later mounts");
         }
     }
-    // Counted rather than emitted, in *both* dialects. Both can express a group — the
-    // derive with `group(…)` and clap with `ArgGroup` — so this is a gap in the shadow
-    // generator rather than in either target, and no spec in the fleet declares one yet
-    // for it to matter to. It is counted so the report cannot claim the shadow expressed
-    // a whole spec that it did not.
-    if !cmd.groups.is_empty() {
+    if !cmd.groups.is_empty() && matches!(run.dialect, Dialect::Argh | Dialect::Bpaf) {
         run.skipped.note("a `group` on a command");
     }
     for (_, sub, sub_ty) in &children {
@@ -381,18 +425,57 @@ fn emit_command(out: &mut String, cmd: &SpecCommand, ty: &Type, is_root: bool, r
         if let Some(version) = run.version {
             usage_opts.push(format!("version = {version:?}"));
         }
+        if let Some(author) = run.author {
+            usage_opts.push(format!("author = {author:?}"));
+        }
+        if let Some(license) = run.license {
+            usage_opts.push(format!("license = {license:?}"));
+        }
+        if let Some(repository) = run.repository {
+            usage_opts.push(format!("repository = {repository:?}"));
+        }
         usage_opts.extend(declared_about.iter().cloned());
     }
     // Text around the rest of the page. clap spells the long forms the same way, so both
     // dialects can carry them.
     for (node, text) in [
-        ("before_help", cmd.before_help.as_deref()),
-        ("before_long_help", cmd.before_help_long.as_deref()),
-        ("after_help", cmd.after_help.as_deref()),
-        ("after_long_help", cmd.after_help_long.as_deref()),
+        (
+            "before_help",
+            if is_root {
+                run.before_help
+            } else {
+                cmd.before_help.as_deref()
+            },
+        ),
+        (
+            "before_long_help",
+            if is_root {
+                run.before_help_long
+            } else {
+                cmd.before_help_long.as_deref()
+            },
+        ),
+        (
+            "after_help",
+            if is_root {
+                run.after_help
+            } else {
+                cmd.after_help.as_deref()
+            },
+        ),
+        (
+            "after_long_help",
+            if is_root {
+                run.after_help_long
+            } else {
+                cmd.after_help_long.as_deref()
+            },
+        ),
     ] {
         if let Some(text) = text.filter(|t| !t.trim().is_empty()) {
-            usage_opts.push(format!("{node} = {:?}", text.trim_end()));
+            // Trailing newlines are page layout, not incidental source whitespace: the
+            // reference renderer preserves them before author/license footers.
+            usage_opts.push(format!("{node} = {text:?}"));
         }
     }
 
@@ -437,6 +520,33 @@ fn emit_command(out: &mut String, cmd: &SpecCommand, ty: &Type, is_root: bool, r
     if is_root && run.multicall {
         usage_opts.push("multicall".into());
     }
+    if dialect == Dialect::Usage {
+        for (enabled, attr) in [
+            (cmd.disable_help_flag, "disable_help_flag"),
+            (cmd.disable_help_subcommand, "disable_help_subcommand"),
+            (cmd.disable_version_flag, "disable_version_flag"),
+        ] {
+            if enabled {
+                usage_opts.push(attr.into());
+            }
+        }
+    }
+    if dialect == Dialect::Usage {
+        for group in &cmd.groups {
+            let mut properties = Vec::new();
+            if group.required {
+                properties.push("required");
+            }
+            if group.multiple {
+                properties.push("multiple");
+            }
+            let suffix = properties
+                .iter()
+                .map(|property| format!(", {property}"))
+                .collect::<String>();
+            usage_opts.push(format!("group({:?}{suffix})", group.name));
+        }
+    }
     match (is_root, dialect) {
         (true, Dialect::Usage) => {
             out.push_str("#[derive(Cli)]\n");
@@ -444,6 +554,7 @@ fn emit_command(out: &mut String, cmd: &SpecCommand, ty: &Type, is_root: bool, r
         }
         (true, Dialect::Clap) => {
             out.push_str("#[derive(Parser)]\n");
+            emit_clap_groups(out, &cmd.groups);
             // The descriptions go here too when a comment cannot carry them. clap takes an
             // independent `about` and `long_about`, and skipping the comment without writing
             // them left the clap shadow not describing the program at all — a fixture for
@@ -469,7 +580,10 @@ fn emit_command(out: &mut String, cmd: &SpecCommand, ty: &Type, is_root: bool, r
                 out.push_str(&format!("#[usage({})]\n", usage_opts.join(", ")));
             }
         }
-        (false, Dialect::Clap) => out.push_str("#[derive(Args)]\n"),
+        (false, Dialect::Clap) => {
+            out.push_str("#[derive(Args)]\n");
+            emit_clap_groups(out, &cmd.groups);
+        }
         // argh declares the command's *name* on the struct rather than on the variant that
         // holds it, so this is where a subcommand says what it answers to.
         (true, Dialect::Argh) => out.push_str("#[derive(FromArgs)]\n"),
@@ -506,7 +620,11 @@ fn emit_command(out: &mut String, cmd: &SpecCommand, ty: &Type, is_root: bool, r
         .flags
         .iter()
         .filter_map(|flag| {
-            let long = flag.long.first().cloned();
+            let long = flag
+                .long
+                .iter()
+                .find(|long| !flag.hidden_aliases.contains(*long))
+                .cloned();
             if long.is_none() && flag.short.is_empty() {
                 run.skipped.note("a flag with no long or short form");
                 return None;
@@ -514,6 +632,11 @@ fn emit_command(out: &mut String, cmd: &SpecCommand, ty: &Type, is_root: bool, r
             let field = fields.claim(long.as_deref().unwrap_or(&flag.name));
             Some((flag, long, field))
         })
+        .collect();
+    let args: Vec<(&SpecArg, String)> = cmd
+        .args
+        .iter()
+        .map(|arg| (arg, fields.claim(&arg.name)))
         .collect();
     let ids: BTreeMap<String, String> = flags
         .iter()
@@ -524,9 +647,31 @@ fn emit_command(out: &mut String, cmd: &SpecCommand, ty: &Type, is_root: bool, r
                 .chain(flag.short.iter().map(|s| format!("-{s}")))
                 .map(move |selector| (selector, field.clone()))
         })
+        .chain(
+            args.iter()
+                .map(|(arg, field)| (arg.name.clone(), field.clone())),
+        )
         .collect();
     for (flag, long, field) in &flags {
-        emit_flag(out, flag, long.clone(), field, dialect, &ids, run.skipped);
+        let selectors = flag
+            .long
+            .iter()
+            .map(|name| format!("--{name}"))
+            .chain(flag.short.iter().map(|name| format!("-{name}")))
+            .collect::<Vec<_>>();
+        let group = group_for_selectors(&cmd.groups, &selectors, run.skipped);
+        emit_flag(
+            out,
+            flag,
+            FlagField {
+                long: long.as_deref(),
+                rust: field,
+                group,
+            },
+            dialect,
+            &ids,
+            run.skipped,
+        );
     }
     // A positional beside a subcommand is a grammar neither argh nor bpaf can express: the
     // positional wins, so the command word lands in it and the subcommand is never reached.
@@ -538,15 +683,24 @@ fn emit_command(out: &mut String, cmd: &SpecCommand, ty: &Type, is_root: bool, r
         && !cmd.args.is_empty()
         && matches!(dialect, Dialect::Argh | Dialect::Bpaf);
     if drop_positionals {
-        for _ in &cmd.args {
+        for _ in &args {
             run.skipped
                 .note("a positional on a command that also has subcommands");
         }
     } else {
-        let last_arg = cmd.args.len().saturating_sub(1);
-        for (at, arg) in cmd.args.iter().enumerate() {
-            let field = fields.claim(&arg.name);
-            emit_arg(out, arg, &field, dialect, at == last_arg, run.skipped);
+        let last_arg = args.len().saturating_sub(1);
+        for (at, (arg, field)) in args.iter().enumerate() {
+            let group =
+                group_for_selectors(&cmd.groups, ::std::slice::from_ref(&arg.name), run.skipped);
+            emit_arg(
+                out,
+                arg,
+                ArgField { rust: field, group },
+                dialect,
+                &ids,
+                at == last_arg,
+                run.skipped,
+            );
         }
     }
     if !ty.subcommands.is_empty() {
@@ -647,6 +801,9 @@ fn emit_command(out: &mut String, cmd: &SpecCommand, ty: &Type, is_root: bool, r
                         sub.help_long.as_deref(),
                         true,
                     ));
+                    if sub.hide {
+                        opts.push("hide = true".into());
+                    }
                     match sub.aliases.as_slice() {
                         [] => {}
                         [one] => opts.push(format!("visible_alias = {one:?}")),
@@ -780,11 +937,16 @@ fn flag_defaults(flag: &SpecFlag) -> &[String] {
     }
 }
 
+struct FlagField<'a> {
+    long: Option<&'a str>,
+    rust: &'a str,
+    group: Option<&'a str>,
+}
+
 fn emit_flag(
     out: &mut String,
     flag: &SpecFlag,
-    long: Option<String>,
-    field: &str,
+    field: FlagField<'_>,
     dialect: Dialect,
     ids: &BTreeMap<String, String>,
     skipped: &mut Skipped,
@@ -798,23 +960,24 @@ fn emit_flag(
         flag.help_long.as_deref(),
         1,
         dialect,
-        field,
+        field.rust,
     );
     let ty = flag_type(flag, dialect);
     let opts = match dialect {
-        Dialect::Usage => usage_flag_opts(flag, long.as_deref(), ty, skipped),
-        Dialect::Clap => clap_flag_opts(flag, long.as_deref(), ids, skipped),
-        Dialect::Argh => argh_flag_opts(flag, long.as_deref(), skipped),
-        Dialect::Bpaf => bpaf_flag_opts(flag, long.as_deref(), skipped),
+        Dialect::Usage => usage_flag_opts(flag, field.long, ty, field.group, skipped),
+        Dialect::Clap => clap_flag_opts(flag, field.long, ids, field.group, skipped),
+        Dialect::Argh => argh_flag_opts(flag, field.long, skipped),
+        Dialect::Bpaf => bpaf_flag_opts(flag, field.long, skipped),
     };
     writeln!(out, "    #[{}({})]", dialect.attr(), opts.join(", ")).expect("writing to a String");
-    writeln!(out, "    pub {field}: {ty},").expect("writing to a String");
+    writeln!(out, "    pub {}: {ty},", field.rust).expect("writing to a String");
 }
 
 fn usage_flag_opts(
     flag: &SpecFlag,
     long: Option<&str>,
     ty: &str,
+    group: Option<&str>,
     skipped: &mut Skipped,
 ) -> Vec<String> {
     // `flag.help_long`, not `long` — that is the flag's long *name*, which every other caller of
@@ -830,12 +993,17 @@ fn usage_flag_opts(
     if let Some(long) = long {
         opts.push(format!("long = {long:?}"));
     }
-    // Every *other* long, in the order the spec gives them. The derive takes `long` more than
+    // Every *other visible* long, in the order the spec gives them. The derive takes `long` more than
     // once and the parse table holds a list, so a flag written `-p --path --file` is expressible
     // exactly — it was being dropped here, and the drop was invisible in the help comparison
     // (which renders one long form per flag) until a completion offered every name.
-    for extra in flag.long.iter().skip(1) {
+    for extra in flag.long.iter().filter(|candidate| {
+        Some(candidate.as_str()) != long && !flag.hidden_aliases.contains(*candidate)
+    }) {
         opts.push(format!("long = {extra:?}"));
+    }
+    if !flag.hidden_aliases.is_empty() {
+        opts.push(selector_list("alias", &flag.hidden_aliases));
     }
     for short in &flag.short {
         opts.push(format!("short = {short:?}"));
@@ -846,8 +1014,23 @@ fn usage_flag_opts(
     if flag.global {
         opts.push("global".into());
     }
+    if let Some(group) = group {
+        opts.push(format!("group = {group:?}"));
+    }
     if flag.hide {
         opts.push("hide".into());
+    }
+    if flag.hide_default_value {
+        opts.push("hide_default_value".into());
+    }
+    if flag.hide_env {
+        opts.push("hide_env".into());
+    }
+    if flag.hide_env_values {
+        opts.push("hide_env_values".into());
+    }
+    if flag.hide_possible_values {
+        opts.push("hide_possible_values".into());
     }
     if flag.count {
         opts.push("count".into());
@@ -970,7 +1153,7 @@ fn usage_flag_opts(
         }
     }
     if flag.required && flag.arg.is_none() {
-        skipped.note("`required` on a flag that takes no value");
+        opts.push("required".into());
     }
 
     opts
@@ -980,6 +1163,7 @@ fn clap_flag_opts(
     flag: &SpecFlag,
     long: Option<&str>,
     ids: &BTreeMap<String, String>,
+    group: Option<&str>,
     skipped: &mut Skipped,
 ) -> Vec<String> {
     let mut opts: Vec<String> =
@@ -1032,6 +1216,9 @@ fn clap_flag_opts(
     if flag.global {
         opts.push("global = true".into());
     }
+    if let Some(group) = group {
+        opts.push(format!("group = {group:?}"));
+    }
     if flag.hide {
         opts.push("hide = true".into());
     }
@@ -1045,16 +1232,11 @@ fn clap_flag_opts(
         opts.push(format!("help_heading = {heading:?}"));
     }
     // A relationship names the field it points at, so a selector the struct does not
-    // declare is dropped rather than guessed at.
-    // `requires` is the one asymmetric entry: clap has the setter, so the shadow can write
-    // it, and clap exposes no getter, so a spec regenerated from that command comes back
-    // without it. Counted rather than emitted, because the shadow's job is to say what the
-    // clap dialect can carry *round trip* — writing it and silently losing it on the way
-    // back would make the clap side look more faithful than it is.
-    if !flag.requires.is_empty() {
-        skipped.note("`requires` on a flag");
-    }
+    // declare is dropped rather than guessed at. clap cannot expose `requires` again through
+    // Command introspection, but its derive can enforce the declaration. This shadow measures
+    // parser behavior, so keeping the setter is more faithful than dropping the policy.
     for (option, selectors) in [
+        ("requires", &flag.requires),
         ("overrides_with", &flag.overrides),
         ("conflicts_with", &flag.conflicts),
         ("required_unless_present", &flag.required_unless),
@@ -1113,7 +1295,7 @@ fn clap_flag_opts(
             opts.push("required = true".into());
         }
     } else if flag.required {
-        skipped.note("`required` on a flag that takes no value");
+        opts.push("required = true".into());
     }
     opts
 }
@@ -1321,11 +1503,17 @@ fn bpaf_flag_opts(flag: &SpecFlag, long: Option<&str>, skipped: &mut Skipped) ->
     opts
 }
 
+struct ArgField<'a> {
+    rust: &'a str,
+    group: Option<&'a str>,
+}
+
 fn emit_arg(
     out: &mut String,
     arg: &SpecArg,
-    field: &str,
+    field: ArgField<'_>,
     dialect: Dialect,
+    ids: &BTreeMap<String, String>,
     last: bool,
     skipped: &mut Skipped,
 ) {
@@ -1335,7 +1523,7 @@ fn emit_arg(
         arg.help_long.as_deref(),
         1,
         dialect,
-        field,
+        field.rust,
     );
     // argh allows `Option` or `Vec` in the last position only, so an optional or variadic
     // positional with another behind it has to be declared required. mise has nine, and the
@@ -1350,20 +1538,56 @@ fn emit_arg(
         arg_type(arg, dialect)
     };
     let opts = match dialect {
-        Dialect::Usage => usage_arg_opts(arg, skipped),
-        Dialect::Clap => clap_arg_opts(arg, skipped),
+        Dialect::Usage => usage_arg_opts(arg, field.group, skipped),
+        Dialect::Clap => clap_arg_opts(arg, field.group, ids, skipped),
         Dialect::Argh => argh_arg_opts(arg, skipped),
         Dialect::Bpaf => bpaf_arg_opts(arg, skipped),
     };
     writeln!(out, "    #[{}({})]", dialect.attr(), opts.join(", ")).expect("writing to a String");
-    writeln!(out, "    pub {field}: {ty},").expect("writing to a String");
+    writeln!(out, "    pub {}: {ty},", field.rust).expect("writing to a String");
 }
 
-fn usage_arg_opts(arg: &SpecArg, skipped: &mut Skipped) -> Vec<String> {
+fn usage_arg_opts(arg: &SpecArg, group: Option<&str>, skipped: &mut Skipped) -> Vec<String> {
     let mut opts: Vec<String> = vec!["arg".into(), format!("name = {:?}", arg.name)];
     opts.extend(declared_help(arg.help.as_deref(), arg.help_long.as_deref()));
     if arg.hide {
         opts.push("hide".into());
+    }
+    if let Some(group) = group {
+        opts.push(format!("group = {group:?}"));
+    }
+    if !arg.conflicts.is_empty() {
+        opts.push(selector_list("conflicts", &arg.conflicts));
+    }
+    if !arg.requires.is_empty() {
+        opts.push(selector_list("requires", &arg.requires));
+    }
+    if !arg.required_if.is_empty() {
+        opts.push(selector_list("required_if", &arg.required_if));
+    }
+    for condition in &arg.required_if_eq {
+        opts.push(format!(
+            "required_if_eq({:?}, {:?})",
+            condition.selector, condition.value
+        ));
+    }
+    if !arg.required_if_eq_all.is_empty() {
+        let conditions = arg
+            .required_if_eq_all
+            .iter()
+            .map(|condition| format!("({:?}, {:?})", condition.selector, condition.value))
+            .collect::<Vec<_>>()
+            .join(", ");
+        opts.push(format!("required_if_eq_all = [{conditions}]"));
+    }
+    if !arg.required_unless.is_empty() {
+        opts.push(selector_list("required_unless", &arg.required_unless));
+    }
+    if !arg.required_unless_all.is_empty() {
+        opts.push(selector_list(
+            "required_unless_all",
+            &arg.required_unless_all,
+        ));
     }
     // The derive refuses `effect` on a positional: supplying a flag changes what
     // happens; a positional is the thing being acted on. Counted rather than
@@ -1415,7 +1639,12 @@ fn usage_arg_opts(arg: &SpecArg, skipped: &mut Skipped) -> Vec<String> {
     opts
 }
 
-fn clap_arg_opts(arg: &SpecArg, skipped: &mut Skipped) -> Vec<String> {
+fn clap_arg_opts(
+    arg: &SpecArg,
+    group: Option<&str>,
+    ids: &BTreeMap<String, String>,
+    skipped: &mut Skipped,
+) -> Vec<String> {
     let mut opts: Vec<String> = vec![format!("value_name = {:?}", arg.name)];
     // clap reads a `Vec` as optional whatever the spec says, so a required variadic has to say
     // so — the same declaration the usage dialect needed, for the same reason.
@@ -1429,6 +1658,21 @@ fn clap_arg_opts(arg: &SpecArg, skipped: &mut Skipped) -> Vec<String> {
     ));
     if arg.hide {
         opts.push("hide = true".into());
+    }
+    if let Some(group) = group {
+        opts.push(format!("group = {group:?}"));
+    }
+    for (option, selectors) in [
+        ("requires", &arg.requires),
+        ("conflicts_with", &arg.conflicts),
+        ("required_unless_present", &arg.required_unless),
+    ] {
+        for selector in selectors {
+            match ids.get(selector) {
+                Some(id) => opts.push(format!("{option} = {id:?}")),
+                None => skipped.note("a positional relationship naming another command"),
+            }
+        }
     }
     if arg.effect.is_some() {
         skipped.note("`effect` on an argument");
@@ -2085,6 +2329,95 @@ mod tests {
         );
         assert!(out.contains("var_min = 1"), "{out}");
         assert!(out.contains("var_max = 5"), "{out}");
+    }
+
+    #[test]
+    fn the_usage_shadow_keeps_required_switches_and_groups() {
+        let spec = "name \"ex\"\nbin \"ex\"\n\
+            group \"source\" \"--brew\" \"--uv\" required=#true multiple=#true\n\
+            flag \"--brew\" required=#true\nflag \"--uv\"\n";
+        let (out, skipped) = rendered_as(spec, Dialect::Usage);
+
+        assert!(
+            out.contains(r#"group("source", required, multiple)"#),
+            "{out}"
+        );
+        assert!(
+            out.contains(r#"long = "brew", group = "source", required"#),
+            "{out}"
+        );
+        assert!(out.contains(r#"long = "uv", group = "source""#), "{out}");
+        assert!(skipped.counts.is_empty(), "{:?}", skipped.counts);
+    }
+
+    #[test]
+    fn a_clap_group_skips_fields_that_are_not_members() {
+        let spec = "name \"ex\"\nbin \"ex\"\n\
+            group \"source\" \"--brew\" \"--uv\"\n\
+            flag \"--brew\"\nflag \"--uv\"\nflag \"--verbose\"\narg \"[task]\"\n";
+        let (out, skipped) = rendered_as(spec, Dialect::Clap);
+
+        assert!(out.contains("#[group(skip)]"), "{out}");
+        assert!(
+            out.contains(
+                r#"#[command(group = ::clap::ArgGroup::new("source").required(false).multiple(false))]"#
+            ) && out.contains(r#"#[arg(long = "brew", group = "source")]"#)
+                && out.contains(r#"#[arg(long = "uv", group = "source")]"#)
+                && out.contains(r#"#[arg(long = "verbose")]"#)
+                && out.contains(r#"#[arg(value_name = "task")]"#),
+            "{out}"
+        );
+        assert!(skipped.counts.is_empty(), "{:?}", skipped.counts);
+    }
+
+    #[test]
+    fn the_usage_shadow_keeps_help_visibility_metadata() {
+        let spec = "name \"ex\"\nbin \"ex\"\ndisable_help_flag #true\n\
+            flag \"--mode <MODE>\" default=fast env=EX_MODE \
+            hide_default_value=#true hide_env=#true hide_env_values=#true \
+            hide_possible_values=#true\n";
+        let (out, _) = rendered_as(spec, Dialect::Usage);
+
+        for declaration in [
+            "disable_help_flag",
+            "hide_default_value",
+            "hide_env",
+            "hide_env_values",
+            "hide_possible_values",
+        ] {
+            assert!(out.contains(declaration), "missing {declaration}: {out}");
+        }
+    }
+
+    #[test]
+    fn the_usage_shadow_keeps_hidden_long_aliases_hidden() {
+        let spec = "name \"ex\"\nbin \"ex\"\nflag \"--remove\" {\n  alias \"--rm\" \"--unset\" hide=#true\n}\n";
+        let (out, skipped) = rendered_as(spec, Dialect::Usage);
+
+        assert!(out.contains(r#"long = "remove""#), "{out}");
+        assert!(out.contains(r#"alias("rm", "unset")"#), "{out}");
+        assert!(!out.contains(r#"long = "rm""#), "{out}");
+        assert!(!out.contains(r#"long = "unset""#), "{out}");
+        assert!(skipped.counts.is_empty(), "{:?}", skipped.counts);
+    }
+
+    #[test]
+    fn both_typed_shadows_keep_positional_relationships() {
+        let spec = "name \"ex\"\nbin \"ex\"\nflag \"--all\" requires=ITEM\narg \"[ITEM]\" conflicts=--all required_unless=--all requires=--all\n";
+        let (out, skipped) = rendered_as(spec, Dialect::Usage);
+
+        assert!(out.contains(r#"requires = "ITEM""#), "{out}");
+        assert!(out.contains(r#"requires = "--all""#), "{out}");
+        assert!(out.contains(r#"conflicts = "--all""#), "{out}");
+        assert!(out.contains(r#"required_unless = "--all""#), "{out}");
+        assert!(skipped.counts.is_empty(), "{:?}", skipped.counts);
+
+        let (out, skipped) = rendered_as(spec, Dialect::Clap);
+        assert!(out.contains(r#"requires = "item""#), "{out}");
+        assert!(out.contains(r#"requires = "all""#), "{out}");
+        assert!(out.contains(r#"conflicts_with = "all""#), "{out}");
+        assert!(out.contains(r#"required_unless_present = "all""#), "{out}");
+        assert!(skipped.counts.is_empty(), "{:?}", skipped.counts);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- refresh the mise fleet fixture from jdx/mise#12221’s typed `usage-rs` command tree
- teach shadow generation to preserve groups, required switches, help visibility, package metadata, and trailing help layout
- accept delimiter-packed collection defaults and render long-help author/license footers like usage-lib
- mark the typed mise adoption and fixture gate complete in PLAN.md

## Validation
- `cargo test -p usage-derive -p usage-argv -p xtask`
- `cargo clippy -p xtask -p usage-derive -p usage-argv --all-features -- -D warnings`
- `cargo test -p gate --test fleet`

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the largest fleet fixture, clap/Go shadows, and differential parse expectations, so a generator or help-layout mistake can look like adopter regressions. Help footer spacing is presentation-only.
> 
> **Overview**
> Completes the mise fleet gate: the checked-in spec and shadows now come from jdx/mise#12221’s typed `usage-rs` tree, and `PLAN.md` marks both the fixture refresh and the mise adoption item done.
> 
> Long help now renders `Author`/`License` after trailing help and keeps a configured trailing newline as an extra blank line before that footer. Shadow generation and gate tests follow the new metadata: required switches and groups are preserved, `tasks run` treats later tokens as task argv under `double_dash=automatic`, and `mise x` is expected to fail the exec positional relationship rather than accept as a bare alias.
> 
> The Go cobra fixture and differential corpus are updated to the same CLI surface (jobs help, new flags, short-option remaps) so those changes are treated as fixture truth, not parser losses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 599738a3ae40c3854df7b7c41d7ad36f7f087cc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Long-form help can now display author and license information.
  * Command-line specifications better preserve aliases, argument groups, relationships, visibility, and help text across generated interfaces.
  * Added support for updated task, bootstrap, upgrade, trust, remote environment, Windows, and tool-management options.
  * Generated Go commands now honor controls for help and version flags.

* **Bug Fixes**
  * Improved handling of required switches, keyword-based option names, collection defaults, and trailing task arguments.
  * Added clearer command validation and regression coverage for parsing and help output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->