### PR TITLE
feat(spec): add executable views

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1244,7 +1244,7 @@ repeated here.
       and documents that interpolation remains raw unless the author opts into the
       filter. `run=` remains a shell program rather than being narrowed to an argv
       vector, preserving pipelines and the modern shell-out completion use case.
-- [ ] **A multicall CLI cannot describe its applets.** aube's 80 lines of spec
+- [x] **A multicall CLI cannot describe its applets.** aube's 80 lines of spec
       surgery for `aubr`/`aubx` is the requirement written as a workaround: a
       spec (or the derive) should declare a sub-view — name, bin, a subset of
       commands, the global flags — without the host mutating a generated spec
@@ -1254,7 +1254,10 @@ repeated here.
       carrying name, bin, the command subset, and which globals carry over,
       that help, completions and docs all read, with the derive lowering an
       attribute into it. Not a derive-only emission, and not a blessed
-      transform API: the spec defines.
+      transform API: the spec defines. Root `view` nodes now promote a command
+      path, rename its executable surface, and carry all or selected globals.
+      Derives emit them, argv0 dispatch and built-in completions project through
+      them, and the documentation generators materialize the same portable view.
 - [x] **Post-parse hooks stay application-owned.** `parse_from` and
       `parse_from_argv` return `Error::Help` and `Error::Version` instead of
       exiting, so aube can run its notifier or customize version output before

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -79,8 +79,45 @@ pub struct Position<'t> {
 /// out here", which is exactly the position being asked about. The walk stops at the first one
 /// and reports the state it reached, rather than discarding it the way a real parse must.
 pub fn walk<'t>(root: &'t Command<'t>, words: &[String]) -> Position<'t> {
+    walk_inner(root, words, None)
+}
+
+/// Walk a command line through an executable view's selected globals.
+pub fn walk_view<'t>(
+    root: &'t Command<'t>,
+    words: &[String],
+    view: &'t crate::spec::ViewMeta<'t>,
+) -> Position<'t> {
+    // Route through the promoted command without changing the line custom completers see.
+    // Position offsets are translated back afterwards so `CompleteCtx` slices the user's
+    // words, not this internal projection.
+    let mut projected = words.to_vec();
+    let route: Vec<String> = view
+        .root
+        .split_ascii_whitespace()
+        .map(str::to_string)
+        .collect();
+    let count = route.len();
+    projected.splice(0..0, route);
+    let mut position = walk_inner(root, &projected, Some(view));
+    let original_index = |index: usize| index.saturating_sub(count);
+    position.command_start = original_index(position.command_start);
+    for (_, start) in &mut position.path {
+        *start = original_index(*start);
+    }
+    position
+}
+
+fn walk_inner<'t>(
+    root: &'t Command<'t>,
+    words: &[String],
+    view: Option<&'t crate::spec::ViewMeta<'t>>,
+) -> Position<'t> {
     let argv: Vec<&std::ffi::OsStr> = words.iter().map(std::ffi::OsStr::new).collect();
     let mut parser = Parser::for_completion(root, &argv);
+    if let Some(view) = view {
+        parser = parser.with_view(view);
+    }
     let mut awaiting_value = None;
     let mut last_arg = None;
     let mut last_arg_values = 0u32;
@@ -160,6 +197,28 @@ pub fn for_name<'a>(
     name: &str,
     ctx: &CompleteCtx<'_>,
 ) -> Option<Vec<Candidate<'static>>> {
+    let reached = walk(spec.root.cmd, ctx.command_words_start());
+    for_name_at(spec, name, ctx, &reached, None)
+}
+
+/// Answer for a named completer through an executable view.
+pub fn for_name_view<'a>(
+    spec: &'a Spec<'a>,
+    name: &str,
+    ctx: &CompleteCtx<'_>,
+    view: &'a crate::spec::ViewMeta<'a>,
+) -> Option<Vec<Candidate<'static>>> {
+    let reached = walk_view(spec.root.cmd, ctx.command_words_start(), view);
+    for_name_at(spec, name, ctx, &reached, Some(view))
+}
+
+fn for_name_at<'a>(
+    spec: &'a Spec<'a>,
+    name: &str,
+    ctx: &CompleteCtx<'_>,
+    reached: &Position<'a>,
+    view: Option<&'a crate::spec::ViewMeta<'a>>,
+) -> Option<Vec<Candidate<'static>>> {
     fn on(meta: &CommandMeta<'_>, name: &str) -> Option<Completer> {
         for arg in meta.args {
             if arg.arg.name.eq_ignore_ascii_case(name) {
@@ -220,17 +279,34 @@ pub fn for_name<'a>(
     //
     // Tree order last, and only as a fallback: two sibling commands may take a `tool` and mean
     // different things by it, and the one the line reached is the one being asked about.
-    let reached = walk(spec.root.cmd, ctx.command_words_start());
-    let reached_meta =
-        crate::help::find(spec, reached.cmd).and_then(|(_, chain)| chain.last().copied());
-    let owner = if on(spec.root, name).is_some() {
-        spec.root
-    } else if let Some(meta) = reached_meta.filter(|meta| on(meta, name).is_some()) {
-        meta
+    let chain = metadata_chain_on_route(spec, reached).unwrap_or_default();
+    // Cursor identity is stronger than name-keyed declaration order. In particular, an
+    // executable view may promote a field whose completion name is also used by an omitted
+    // host field. Only the promoted field's parser identity can match here.
+    let at_cursor = chain
+        .iter()
+        .rev()
+        .find_map(|meta| at_cursor(meta, name, reached));
+
+    let fallback = if let Some(view) = view {
+        let depth = view.root.split_ascii_whitespace().count();
+        chain.get(depth).copied().and_then(|promoted| {
+            let (flags, groups) = crate::help::view_root_fields(spec, promoted, view);
+            let projected = CommandMeta {
+                flags: &flags,
+                groups: &groups,
+                ..*promoted
+            };
+            on(&projected, name)
+                .or_else(|| chain.last().copied().and_then(|meta| on(meta, name)))
+                .or_else(|| find(promoted, name).and_then(|meta| on(meta, name)))
+        })
     } else {
-        find(spec.root, name)?
+        on(spec.root, name)
+            .or_else(|| chain.last().copied().and_then(|meta| on(meta, name)))
+            .or_else(|| find(spec.root, name).and_then(|meta| on(meta, name)))
     };
-    let completer = at_cursor(owner, name, &reached).or_else(|| on(owner, name))?;
+    let completer = at_cursor.or(fallback)?;
     let mut found = completer(ctx);
     found.retain(|c| c.value.starts_with(ctx.prefix));
     Some(found)
@@ -706,10 +782,30 @@ fn declared_files_at_cursor(
 /// Hidden things are never offered, in any branch. What is *not* here yet: the file fallback
 /// for a word nothing is known about, and the `run=` completions a spec can declare.
 pub fn complete<'a>(spec: &'a Spec<'a>, split: &Split) -> Completions<'a> {
-    let position = walk(spec.root.cmd, split.argv());
+    complete_inner(spec, split, None)
+}
+
+/// Complete through an executable view, omitting root globals it does not carry.
+pub fn complete_view<'a>(
+    spec: &'a Spec<'a>,
+    split: &Split,
+    view: &'a crate::spec::ViewMeta<'a>,
+) -> Completions<'a> {
+    complete_inner(spec, split, Some(view))
+}
+
+fn complete_inner<'a>(
+    spec: &'a Spec<'a>,
+    split: &Split,
+    view: Option<&'a crate::spec::ViewMeta<'a>>,
+) -> Completions<'a> {
+    let position = match view {
+        Some(view) => walk_view(spec.root.cmd, split.argv(), view),
+        None => walk(spec.root.cmd, split.argv()),
+    };
     let meta = metadata_chain_on_route(spec, &position).and_then(|chain| chain.last().copied());
     let token = split.prefix.as_str();
-    let candidates = candidates(spec, split);
+    let candidates = candidates_inner(spec, split, view);
 
     // Which argument the cursor is at — the same question `candidates` answers, asked once so
     // that the two halves cannot disagree. Past a restart token it is the command's *first*
@@ -1050,7 +1146,18 @@ fn metadata_chain_on_route<'a>(
 
 /// Just the candidates this CLI knows about, without the question of paths.
 pub fn candidates<'a>(spec: &'a Spec<'a>, split: &Split) -> Vec<Candidate<'a>> {
-    let position = walk(spec.root.cmd, split.argv());
+    candidates_inner(spec, split, None)
+}
+
+fn candidates_inner<'a>(
+    spec: &'a Spec<'a>,
+    split: &Split,
+    view: Option<&'a crate::spec::ViewMeta<'a>>,
+) -> Vec<Candidate<'a>> {
+    let position = match view {
+        Some(view) => walk_view(spec.root.cmd, split.argv(), view),
+        None => walk(spec.root.cmd, split.argv()),
+    };
     let meta = metadata_chain_on_route(spec, &position).and_then(|chain| chain.last().copied());
     let token = split.prefix.as_str();
 
@@ -2113,6 +2220,43 @@ mod tests {
             "tool",
             runtime_tools,
         )];
+
+    #[test]
+    fn a_failed_view_name_fallback_keeps_the_cursor_selected_completer() {
+        static DEEP_VIEW: crate::spec::ViewMeta = crate::spec::ViewMeta {
+            id: "installer",
+            name: "installer",
+            bin: "installer",
+            // Deliberately deeper than the metadata route below. A stale named-completion
+            // request may have enough cursor identity to answer even when its view path cannot
+            // be recovered, and the weaker name fallback must not erase that answer.
+            root: "install nested",
+            all_globals: false,
+            globals: &[],
+        };
+        let split = at_end("mise install r");
+        let position = walk(SPEC.root.cmd, split.argv());
+        let words = split.argv();
+        let command_path: Vec<(&Command<'_>, &[String])> = position
+            .path
+            .iter()
+            .map(|(cmd, start)| (*cmd, words.get(*start..).unwrap_or(&[])))
+            .collect();
+        let ctx = CompleteCtx {
+            words: &split.words,
+            cword: split.cword,
+            prefix: &split.prefix,
+            command_words: command_words(&split, &position),
+            command_path: &command_path,
+        };
+
+        let found = for_name_at(&SPEC, "tool", &ctx, &position, Some(&DEEP_VIEW))
+            .expect("the cursor-selected completer should survive fallback failure");
+        assert!(
+            found.iter().any(|candidate| candidate.value == "ruby"),
+            "{found:?}"
+        );
+    }
 
     #[test]
     fn async_overlays_run_only_for_the_field_and_projection_at_the_cursor() {

--- a/argv/src/diagnostic.rs
+++ b/argv/src/diagnostic.rs
@@ -23,7 +23,7 @@
 
 use core::fmt::Write as _;
 
-use crate::spec::{CommandMeta, Spec};
+use crate::spec::{CommandMeta, FlagMeta, Spec, ViewMeta};
 use crate::{Command, Error};
 
 /// Whether to colour, and what with.
@@ -334,8 +334,12 @@ fn value_bound_to(
     argv: &[&std::ffi::OsStr],
     name: &str,
     refused: &[&str],
+    view: Option<&ViewMeta<'_>>,
 ) -> Option<String> {
     let mut parser = crate::Parser::new(root, argv);
+    if let Some(view) = view {
+        parser = parser.with_view(view);
+    }
     let mut last = None;
     while let Some(event) = parser.next_event() {
         let value = match event {
@@ -373,9 +377,16 @@ fn value_bound_to(
 /// how `ex beta shared --betaglobl` came back describing `ex alpha shared`, suggesting alpha's
 /// globals and not beta's. The route is the only thing that tells the two apart, so the route is
 /// what gets carried.
-fn path_taken<'t>(root: &'t Command<'t>, argv: &[&std::ffi::OsStr]) -> Vec<&'t Command<'t>> {
+fn path_taken<'t>(
+    root: &'t Command<'t>,
+    argv: &[&std::ffi::OsStr],
+    view: Option<&'t ViewMeta<'t>>,
+) -> Vec<&'t Command<'t>> {
     let mut path = vec![root];
     let mut parser = crate::Parser::new(root, argv);
+    if let Some(view) = view {
+        parser = parser.with_view(view);
+    }
     while let Some(event) = parser.next_event() {
         match event {
             Ok(crate::Event::Command(cmd)) => path.push(cmd),
@@ -422,9 +433,77 @@ pub fn render(
     error: &Error<'_, '_>,
     style: Style,
 ) -> String {
-    let taken = path_taken(spec.root.cmd, argv);
+    render_inner(spec, argv, error, style, None)
+}
+
+/// Render a parse failure through a spec-declared executable view.
+pub fn render_view<'a>(
+    spec: &'a Spec<'a>,
+    argv: &[&std::ffi::OsStr],
+    error: &Error<'_, '_>,
+    style: Style,
+    view: &'a ViewMeta<'a>,
+) -> String {
+    let words = argv.get(1..).unwrap_or_default();
+    let mut rewritten =
+        Vec::with_capacity(words.len() + view.root.split_ascii_whitespace().count());
+    rewritten.extend(view.root.split_ascii_whitespace().map(std::ffi::OsStr::new));
+    rewritten.extend_from_slice(words);
+    render_inner(spec, &rewritten, error, style, Some(view))
+}
+
+fn render_inner<'a>(
+    spec: &'a Spec<'a>,
+    argv: &[&std::ffi::OsStr],
+    error: &Error<'_, '_>,
+    style: Style,
+    view: Option<&'a ViewMeta<'a>>,
+) -> String {
+    let canonical_spec = spec;
+    let taken = path_taken(spec.root.cmd, argv, view);
     let cmd = *taken.last().expect("the root is always on the path");
-    let resolved = resolve(spec, &taken);
+    let mut resolved = resolve(spec, &taken);
+    let mut projected_spec = None;
+    let mut projected_flags: Vec<FlagMeta<'_>> = Vec::new();
+    let mut projected_groups = Vec::new();
+    let projection = view.and_then(|view| {
+        let depth = view.root.split_ascii_whitespace().count();
+        resolved
+            .as_ref()
+            .and_then(|(_, chain)| chain.get(depth).copied())
+            .map(|promoted| (view, depth, promoted))
+    });
+    if let Some((_, _, promoted)) = projection {
+        let (flags, groups) =
+            crate::help::view_root_fields(spec, promoted, view.expect("a projection has a view"));
+        projected_flags = flags;
+        projected_groups = groups;
+    }
+    let projected_root = projection.map(|(_, _, promoted)| CommandMeta {
+        flags: &projected_flags,
+        groups: &projected_groups,
+        ..*promoted
+    });
+    if let (Some((view, depth, promoted)), Some(root), Some((names, chain))) =
+        (projection, projected_root.as_ref(), resolved.as_mut())
+    {
+        chain[0] = root;
+        chain.drain(1..=depth.min(chain.len().saturating_sub(1)));
+        names.drain(1..=depth.min(names.len().saturating_sub(1)));
+        names[0] = view.bin;
+        projected_spec = Some(Spec {
+            name: view.name,
+            bin: Some(view.bin),
+            about: promoted.about,
+            long_about: promoted.long_about,
+            usage: None,
+            default_subcommand: None,
+            multicall: false,
+            root,
+            ..*spec
+        });
+    }
+    let spec = projected_spec.as_ref().unwrap_or(spec);
     let chain: &[&CommandMeta<'_>] = resolved.as_ref().map(|(_, c)| &c[..]).unwrap_or(&[]);
     let here = chain.last().copied();
     let path = resolved
@@ -435,6 +514,7 @@ pub fn render(
         (Some((names, _)), Some(meta)) => crate::help::usage_line(names, meta),
         _ => path.clone(),
     };
+    let presented_route: Vec<&Command<'_>> = chain.iter().map(|meta| meta.cmd).collect();
 
     let mut out = String::new();
     let mut with_usage = false;
@@ -561,7 +641,11 @@ pub fn render(
             } else {
                 crate::help::Style::PLAIN
             };
-            if let Some(help) = crate::help::render_at_styled(spec, &taken, false, help_style) {
+            // `spec`, `chain`, and this route have already been projected above. Feeding the
+            // canonical host route through the view renderer a second time makes it look for
+            // host-only ancestors under the promoted root and loses the useful full help page.
+            let help = crate::help::render_at_styled(spec, &presented_route, false, help_style);
+            if let Some(help) = help {
                 return help;
             }
             with_usage = true;
@@ -607,13 +691,14 @@ pub fn render(
         }
         Error::InvalidChoice { name, choices } => {
             let shown_name = shown(here, name);
-            match value_bound_to(spec.root.cmd, argv, name, choices) {
+            let typed = value_bound_to(canonical_spec.root.cmd, argv, name, choices, view);
+            match typed.as_deref() {
                 Some(value) => {
                     let _ = writeln!(
                         out,
                         "{} invalid value '{}' for '{}'",
                         style.error("error:"),
-                        style.invalid(&value),
+                        style.invalid(value),
                         style.literal(&shown_name)
                     );
                 }
@@ -630,7 +715,7 @@ pub fn render(
             }
             let listed: Vec<String> = choices.iter().map(|c| style.valid(c)).collect();
             let _ = writeln!(out, "  [possible values: {}]", listed.join(", "));
-            if let Some(typed) = value_bound_to(spec.root.cmd, argv, name, choices) {
+            if let Some(typed) = typed {
                 out.push_str(&tip(
                     style,
                     "value",
@@ -950,6 +1035,66 @@ mod tests {
     }
 
     #[test]
+    fn a_view_missing_subcommand_prints_the_promoted_choices() {
+        static CHILD: Command = Command {
+            name: "child",
+            ..Command::EMPTY
+        };
+        static RUN: Command = Command {
+            name: "run",
+            subcommands: &[&CHILD],
+            ..Command::EMPTY
+        };
+        static HOST: Command = Command {
+            name: "host",
+            subcommands: &[&RUN],
+            ..Command::EMPTY
+        };
+        static CHILD_META: CommandMeta = CommandMeta {
+            cmd: &CHILD,
+            about: Some("Do the child thing"),
+            ..CommandMeta::EMPTY
+        };
+        static RUN_META: CommandMeta = CommandMeta {
+            cmd: &RUN,
+            subcommands: &[&CHILD_META],
+            ..CommandMeta::EMPTY
+        };
+        static HOST_META: CommandMeta = CommandMeta {
+            cmd: &HOST,
+            subcommands: &[&RUN_META],
+            ..CommandMeta::EMPTY
+        };
+        static VIEW: ViewMeta = ViewMeta {
+            id: "runner",
+            name: "runner",
+            bin: "runner",
+            root: "run",
+            all_globals: false,
+            globals: &[],
+        };
+        static VIEW_SPEC: Spec = Spec {
+            name: "host",
+            bin: Some("host"),
+            root: &HOST_META,
+            views: &[VIEW],
+            ..Spec::EMPTY
+        };
+
+        let message = render_view(
+            &VIEW_SPEC,
+            &[std::ffi::OsStr::new("runner")],
+            &Error::MissingSubcommand,
+            Style::PLAIN,
+            &VIEW,
+        );
+        assert!(message.contains("Usage: runner"), "{message}");
+        assert!(message.contains("Commands:"), "{message}");
+        assert!(message.contains("child"), "{message}");
+        assert!(!message.contains("requires a subcommand"), "{message}");
+    }
+
+    #[test]
     fn a_missing_value_names_what_it_wanted() {
         // No usage block: the shape of the command line was right, one value was missing — which
         // is the distinction clap draws too.
@@ -1109,6 +1254,41 @@ mod tests {
         assert!(
             message.starts_with("error: invalid value 'fsh' for '[SHELLS]…'"),
             "named a value that was fine: {message}"
+        );
+    }
+
+    #[test]
+    fn a_view_recovers_the_choice_value_from_the_canonical_parse() {
+        static VIEW: ViewMeta = ViewMeta {
+            id: "runner",
+            name: "runner",
+            bin: "runner",
+            root: "use",
+            all_globals: false,
+            globals: &[],
+        };
+        static VIEW_SPEC: Spec = Spec {
+            views: &[VIEW],
+            ..SPEC
+        };
+        let argv = [std::ffi::OsStr::new("runner"), std::ffi::OsStr::new("nod")];
+        let message = render_view(
+            &VIEW_SPEC,
+            &argv,
+            &Error::InvalidChoice {
+                name: "TOOL",
+                choices: &["node", "python"],
+            },
+            Style::PLAIN,
+            &VIEW,
+        );
+        assert!(
+            message.contains("invalid value 'nod' for '<TOOL>'"),
+            "{message}"
+        );
+        assert!(
+            message.contains("tip: a similar value exists: 'node'"),
+            "{message}"
         );
     }
 

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -19,7 +19,7 @@
 
 use core::fmt::Write as _;
 
-use crate::spec::{ArgMeta, CommandMeta, Example, FlagMeta, Spec};
+use crate::spec::{ArgMeta, CommandMeta, Example, FlagMeta, Spec, ViewMeta};
 use crate::Command;
 use crate::DoubleDash;
 
@@ -120,6 +120,7 @@ fn help_structure(
     path: &[&str],
     chain: &[&CommandMeta<'_>],
     long: bool,
+    inherit_version_actions: bool,
 ) -> (Vec<String>, Vec<String>, Vec<String>) {
     let meta = *chain.last().expect("a page is always about some command");
     let mut headings = Vec::new();
@@ -143,7 +144,7 @@ fn help_structure(
         );
     }
 
-    let (own, inherited) = own_and_global(chain);
+    let (own, inherited) = own_and_global(chain, inherit_version_actions);
     let visible_arg = |arg: &&ArgMeta<'_>| {
         !arg.hide
             && if long {
@@ -665,8 +666,17 @@ fn exact_arity(min: Option<usize>, max: Option<usize>) -> Option<usize> {
 ///
 /// `path` is the command as invoked, as for [`usage_line`].
 pub fn short_help(spec: &Spec<'_>, path: &[&str], chain: &[&CommandMeta<'_>]) -> String {
+    short_help_with(spec, path, chain, false)
+}
+
+fn short_help_with(
+    spec: &Spec<'_>,
+    path: &[&str],
+    chain: &[&CommandMeta<'_>],
+    inherit_version_actions: bool,
+) -> String {
     let meta = *chain.last().expect("a page is always about some command");
-    let (own, inherited) = own_and_global(chain);
+    let (own, inherited) = own_and_global(chain, inherit_version_actions);
     let own: Vec<_> = own
         .into_iter()
         .filter(|flag| !flag.hide_short_help)
@@ -1341,8 +1351,17 @@ fn terminal_width(meta: &CommandMeta<'_>) -> usize {
 /// under the usage rather than beside it, because there is no column that keeps a line the
 /// author already broke readable.
 pub fn long_help(spec: &Spec<'_>, path: &[&str], chain: &[&CommandMeta<'_>]) -> String {
+    long_help_with(spec, path, chain, false)
+}
+
+fn long_help_with(
+    spec: &Spec<'_>,
+    path: &[&str],
+    chain: &[&CommandMeta<'_>],
+    inherit_version_actions: bool,
+) -> String {
     let meta = *chain.last().expect("a page is always about some command");
-    let (own, inherited) = own_and_global(chain);
+    let (own, inherited) = own_and_global(chain, inherit_version_actions);
     let own: Vec<_> = own
         .into_iter()
         .filter(|flag| !flag.hide_long_help)
@@ -2086,6 +2105,7 @@ fn supplied_entries(cmd: &Command<'_>, taken: &[String]) -> Vec<&'static FlagMet
 /// and cannot discover, which is the worst way for help to be wrong.
 fn own_and_global<'a>(
     chain: &[&'a CommandMeta<'a>],
+    inherit_version_actions: bool,
 ) -> (Vec<&'a FlagMeta<'a>>, Vec<(&'a FlagMeta<'a>, String)>) {
     let Some((here, ancestors)) = chain.split_last() else {
         return (Vec::new(), Vec::new());
@@ -2124,12 +2144,9 @@ fn own_and_global<'a>(
     let every_form: Vec<String> = here
         .flags
         .iter()
-        .chain(
-            ancestors
-                .iter()
-                .flat_map(|m| m.flags.iter())
-                .filter(|f| f.flag.global),
-        )
+        .chain(ancestors.iter().flat_map(|m| m.flags.iter()).filter(|f| {
+            f.flag.global || (inherit_version_actions && crate::is_version_flag(f.flag))
+        }))
         .flat_map(forms)
         .collect();
 
@@ -2137,7 +2154,9 @@ fn own_and_global<'a>(
     let mut taken_negations: Vec<String> = here.flags.iter().filter_map(negation).collect();
     let mut keep: Vec<(*const FlagMeta<'_>, Shown<'_>)> = Vec::new();
     for meta in ancestors.iter().rev() {
-        for f in meta.flags.iter().filter(|f| f.flag.global) {
+        for f in meta.flags.iter().filter(|f| {
+            f.flag.global || (inherit_version_actions && crate::is_version_flag(f.flag))
+        }) {
             let show = Shown::surviving(f, &taken, &taken_negations, &every_form);
             // Reserved whether or not it is shown: a hidden one still binds, and so does one
             // whose every spelling something nearer already took.
@@ -2187,6 +2206,21 @@ fn own_and_global<'a>(
         .cloned()
         .chain(taken_negations.iter().cloned())
         .collect();
+    if inherit_version_actions {
+        if let Some(root) = ancestors.first() {
+            inherited.extend(
+                supplied_entries(root.cmd, &claimed)
+                    .into_iter()
+                    .filter(|flag| {
+                        matches!(
+                            flag.flag.key,
+                            crate::VERSION_LONG_KEY | crate::VERSION_SHORT_KEY
+                        )
+                    })
+                    .map(|flag| (flag, column_usage(flag))),
+            );
+        }
+    }
     own.extend(supplied_entries(here.cmd, &claimed));
     (own, inherited)
 }
@@ -2216,7 +2250,7 @@ pub fn render_styled(
     } else {
         short_help(spec, &path, &chain)
     };
-    let (headings, flag_usages, synopsis) = help_structure(spec, &path, &chain, long);
+    let (headings, flag_usages, synopsis) = help_structure(spec, &path, &chain, long, false);
     Some(styled_help(
         &page,
         style,
@@ -2234,7 +2268,7 @@ pub fn render_all(spec: &Spec<'_>, cmd: &Command<'_>) -> Option<String> {
 /// Recursive long help with an explicit colour policy.
 pub fn render_all_styled(spec: &Spec<'_>, cmd: &Command<'_>, style: Style) -> Option<String> {
     let (path, chain) = find(spec, cmd)?;
-    Some(recursive_help(spec, path, chain, style))
+    Some(recursive_help(spec, path, chain, style, false))
 }
 
 /// The route the words took to a command, for rendering its page unambiguously.
@@ -2294,6 +2328,25 @@ pub fn route_to<'t>(
     core::ptr::eq(*route.last()?, cmd).then_some(route)
 }
 
+/// Recover a command route from the full argv of a declared executable view.
+///
+/// `argv` includes the view executable as argv0. The promoted root is inserted internally,
+/// matching the derive-generated `parse_from_argv` without requiring callers to reconstruct its
+/// private rewrite.
+pub fn route_to_view<'t>(
+    root: &'t Command<'t>,
+    argv: &[&std::ffi::OsStr],
+    cmd: &Command<'_>,
+    view: &ViewMeta<'_>,
+) -> Option<Vec<&'t Command<'t>>> {
+    let words = argv.get(1..).unwrap_or_default();
+    let mut rewritten =
+        Vec::with_capacity(words.len() + view.root.split_ascii_whitespace().count());
+    rewritten.extend(view.root.split_ascii_whitespace().map(std::ffi::OsStr::new));
+    rewritten.extend_from_slice(words);
+    route_to(root, &rewritten, cmd)
+}
+
 /// The same page, for a command reached by a known route.
 ///
 /// [`render`] has only a `&Command` to go on and finds it by address. That is enough until one
@@ -2346,7 +2399,70 @@ pub fn render_at_styled(
     } else {
         short_help(spec, &path, &chain)
     };
-    let (headings, flag_usages, synopsis) = help_structure(spec, &path, &chain, long);
+    let (headings, flag_usages, synopsis) = help_structure(spec, &path, &chain, long, false);
+    Some(styled_help(
+        &page,
+        style,
+        &headings,
+        &flag_usages,
+        &synopsis,
+    ))
+}
+
+/// Render help through a spec-declared executable view.
+///
+/// The parser still walks the canonical static tables. This changes only the cold presentation:
+/// the promoted command becomes the displayed root and only the root globals declared by the
+/// view remain inherited.
+pub fn render_view_at_styled(
+    spec: &Spec<'_>,
+    route: &[&Command<'_>],
+    view: &ViewMeta<'_>,
+    long: bool,
+    style: Style,
+) -> Option<String> {
+    let (canonical_path, canonical_chain) = route_context(spec, route)?;
+    let depth = view.root.split_ascii_whitespace().count();
+    let promoted = *canonical_chain.get(depth)?;
+
+    let (root_flags, root_groups) = view_root_fields(spec, promoted, view);
+    let root_command = Command {
+        // Version actions belong to the executable, not to the promoted command. The parser
+        // retains that host policy before projection, so help must synthesize the same flag.
+        version: spec.root.cmd.version,
+        disable_version_flag: spec.root.cmd.disable_version_flag,
+        ..*promoted.cmd
+    };
+    let root = CommandMeta {
+        cmd: &root_command,
+        flags: &root_flags,
+        groups: &root_groups,
+        ..*promoted
+    };
+    let mut chain = Vec::with_capacity(canonical_chain.len());
+    chain.push(&root);
+    chain.extend_from_slice(canonical_chain.get(depth + 1..).unwrap_or_default());
+
+    let mut path = Vec::with_capacity(canonical_path.len().saturating_sub(depth));
+    path.push(view.bin);
+    path.extend_from_slice(canonical_path.get(depth + 1..).unwrap_or_default());
+    let viewed = Spec {
+        name: view.name,
+        bin: Some(view.bin),
+        about: promoted.about,
+        long_about: promoted.long_about,
+        usage: None,
+        default_subcommand: None,
+        multicall: false,
+        root: &root,
+        ..*spec
+    };
+    let page = if long {
+        long_help_with(&viewed, &path, &chain, true)
+    } else {
+        short_help_with(&viewed, &path, &chain, true)
+    };
+    let (headings, flag_usages, synopsis) = help_structure(&viewed, &path, &chain, long, true);
     Some(styled_help(
         &page,
         style,
@@ -2368,7 +2484,122 @@ pub fn render_all_at_styled(
     style: Style,
 ) -> Option<String> {
     let (path, chain) = route_context(spec, route)?;
-    Some(recursive_help(spec, path, chain, style))
+    Some(recursive_help(spec, path, chain, style, false))
+}
+
+/// Recursive long help through a spec-declared executable view.
+pub fn render_all_view_at_styled(
+    spec: &Spec<'_>,
+    route: &[&Command<'_>],
+    view: &ViewMeta<'_>,
+    style: Style,
+) -> Option<String> {
+    let (canonical_path, canonical_chain) = route_context(spec, route)?;
+    let depth = view.root.split_ascii_whitespace().count();
+    let promoted = *canonical_chain.get(depth)?;
+    let (root_flags, root_groups) = view_root_fields(spec, promoted, view);
+    let root_command = Command {
+        version: spec.root.cmd.version,
+        disable_version_flag: spec.root.cmd.disable_version_flag,
+        ..*promoted.cmd
+    };
+    let root = CommandMeta {
+        cmd: &root_command,
+        flags: &root_flags,
+        groups: &root_groups,
+        ..*promoted
+    };
+    let mut chain = Vec::with_capacity(canonical_chain.len().saturating_sub(depth));
+    chain.push(&root);
+    chain.extend_from_slice(canonical_chain.get(depth + 1..).unwrap_or_default());
+    let mut path = Vec::with_capacity(canonical_path.len().saturating_sub(depth));
+    path.push(view.bin);
+    path.extend_from_slice(canonical_path.get(depth + 1..).unwrap_or_default());
+    let viewed = Spec {
+        name: view.name,
+        bin: Some(view.bin),
+        about: promoted.about,
+        long_about: promoted.long_about,
+        usage: None,
+        default_subcommand: None,
+        multicall: false,
+        root: &root,
+        ..*spec
+    };
+    Some(recursive_help(&viewed, path, chain, style, true))
+}
+
+pub(crate) fn view_root_flags<'a>(
+    spec: &'a Spec<'a>,
+    promoted: &CommandMeta<'a>,
+    view: &ViewMeta<'a>,
+) -> Vec<FlagMeta<'a>> {
+    let selected = |flag: &&FlagMeta<'a>| {
+        let carried = crate::is_version_flag(flag.flag)
+            || (flag.flag.global
+                && (view.all_globals
+                    || view.globals.iter().any(|selector| {
+                        selector
+                            .strip_prefix("--")
+                            .is_some_and(|long| flag.flag.longs.contains(&long))
+                            || selector
+                                .strip_prefix('-')
+                                .filter(|short| short.len() == 1)
+                                .and_then(|short| short.as_bytes().first().copied())
+                                .is_some_and(|short| flag.flag.shorts.contains(&short))
+                    })));
+        carried
+            && !promoted
+                .flags
+                .iter()
+                .any(|local| crate::spec::flag_forms_overlap(flag.flag, local.flag))
+    };
+    let mut flags: Vec<FlagMeta<'a>> = spec.root.flags.iter().filter(selected).copied().collect();
+    flags.extend_from_slice(promoted.flags);
+    flags
+}
+
+pub(crate) fn view_root_fields<'a>(
+    spec: &'a Spec<'a>,
+    promoted: &CommandMeta<'a>,
+    view: &ViewMeta<'a>,
+) -> (Vec<FlagMeta<'a>>, Vec<crate::spec::GroupMeta<'a>>) {
+    let mut flags = view_root_flags(spec, promoted, view);
+    let carried = flags.len().saturating_sub(promoted.flags.len());
+    let matches = |flag: &FlagMeta<'_>, selector: &str| {
+        selector
+            .strip_prefix("--")
+            .is_some_and(|long| flag.flag.longs.contains(&long))
+            || selector
+                .strip_prefix('-')
+                .filter(|short| short.len() == 1)
+                .and_then(|short| short.as_bytes().first().copied())
+                .is_some_and(|short| flag.flag.shorts.contains(&short))
+    };
+    let mut groups = Vec::new();
+    for group in spec.root.groups {
+        let members: Vec<usize> = group
+            .members
+            .iter()
+            .filter_map(|selector| {
+                flags[..carried]
+                    .iter()
+                    .position(|flag| matches(flag, selector))
+            })
+            .collect();
+        match members.as_slice() {
+            [only] if group.required => flags[*only].required = true,
+            [_, _, ..] => {
+                // Help and diagnostics only need the relationship and its requiredness; the
+                // parser continues to enforce the canonical group. Retaining the original
+                // selector slice avoids allocating self-referential metadata on this cold path.
+                groups.push(*group);
+            }
+            _ => {}
+        }
+    }
+    groups.extend_from_slice(promoted.groups);
+    (flags, groups)
 }
 
 fn recursive_help<'a>(
@@ -2376,6 +2607,7 @@ fn recursive_help<'a>(
     path: Vec<&'a str>,
     chain: Vec<&'a CommandMeta<'a>>,
     style: Style,
+    inherit_version_actions: bool,
 ) -> String {
     fn append<'a>(
         out: &mut String,
@@ -2383,12 +2615,14 @@ fn recursive_help<'a>(
         path: &mut Vec<&'a str>,
         chain: &mut Vec<&'a CommandMeta<'a>>,
         style: Style,
+        inherit_version_actions: bool,
     ) {
         if !out.is_empty() {
             out.push('\n');
         }
-        let page = long_help(spec, path, chain);
-        let (headings, flag_usages, synopsis) = help_structure(spec, path, chain, true);
+        let page = long_help_with(spec, path, chain, inherit_version_actions);
+        let (headings, flag_usages, synopsis) =
+            help_structure(spec, path, chain, true, inherit_version_actions);
         out.push_str(&styled_help(
             &page,
             style,
@@ -2403,7 +2637,7 @@ fn recursive_help<'a>(
         for child in children {
             path.push(child.cmd.name);
             chain.push(child);
-            append(out, spec, path, chain, style);
+            append(out, spec, path, chain, style, inherit_version_actions);
             chain.pop();
             path.pop();
         }
@@ -2412,7 +2646,14 @@ fn recursive_help<'a>(
     let mut out = String::new();
     let mut path = path;
     let mut chain = chain;
-    append(&mut out, spec, &mut path, &mut chain, style);
+    append(
+        &mut out,
+        spec,
+        &mut path,
+        &mut chain,
+        style,
+        inherit_version_actions,
+    );
     out
 }
 
@@ -2420,10 +2661,10 @@ fn recursive_help<'a>(
 mod style_tests {
     use super::{
         commands_section, flag_notes, flag_usage, flat_commands_short, inline_environment_notes,
-        long_help, styled_flag_usage, styled_help, Style,
+        long_help, render_view_at_styled, styled_flag_usage, styled_help, Style,
     };
-    use crate::spec::{CommandMeta, FlagMeta, Spec};
-    use crate::{Command, Flag};
+    use crate::spec::{CommandMeta, FlagMeta, Spec, ViewMeta};
+    use crate::{ArgAction, Command, Flag};
 
     #[test]
     fn optional_equals_values_put_the_equals_inside_the_brackets() {
@@ -2604,6 +2845,78 @@ mod style_tests {
             page.contains("More help.\n\n\nAuthor: Example Author\n"),
             "{page}"
         );
+    }
+
+    #[test]
+    fn view_help_keeps_declared_and_synthesized_host_version_actions() {
+        let build_info = Flag {
+            name: "build-info",
+            longs: &["build-info"],
+            action: ArgAction::Version,
+            ..Flag::BOOL
+        };
+        let nested_command = Command {
+            name: "status",
+            ..Command::EMPTY
+        };
+        let child_command = Command {
+            name: "serve",
+            subcommands: &[&nested_command],
+            ..Command::EMPTY
+        };
+        let root_command = Command {
+            name: "host",
+            flags: &[&build_info],
+            subcommands: &[&child_command],
+            version: true,
+            ..Command::EMPTY
+        };
+        let build_info_meta = FlagMeta {
+            flag: &build_info,
+            help: Some("Print build information"),
+            ..FlagMeta::EMPTY
+        };
+        let nested_meta = CommandMeta {
+            cmd: &nested_command,
+            ..CommandMeta::EMPTY
+        };
+        let child_meta = CommandMeta {
+            cmd: &child_command,
+            subcommands: &[&nested_meta],
+            ..CommandMeta::EMPTY
+        };
+        let root_meta = CommandMeta {
+            cmd: &root_command,
+            flags: &[build_info_meta],
+            subcommands: &[&child_meta],
+            ..CommandMeta::EMPTY
+        };
+        let spec = Spec {
+            name: "host",
+            bin: Some("host"),
+            root: &root_meta,
+            ..Spec::EMPTY
+        };
+        let view = ViewMeta {
+            id: "server",
+            name: "server",
+            bin: "server",
+            root: "serve",
+            all_globals: false,
+            globals: &[],
+        };
+
+        let page = render_view_at_styled(
+            &spec,
+            &[&root_command, &child_command, &nested_command],
+            &view,
+            false,
+            Style::PLAIN,
+        )
+        .expect("view route");
+
+        assert!(page.contains("--build-info"), "{page}");
+        assert!(page.contains("-V, --version"), "{page}");
     }
 
     #[test]

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -979,6 +979,19 @@ pub fn render_failure(spec: &spec::Spec<'_>, argv: &[&OsStr], error: &Error<'_, 
     diagnostic::render(spec, argv, error, diagnostic::Style::auto())
 }
 
+/// Render a failure through a spec-declared executable view.
+///
+/// `argv` is the original full argv, including the view executable as argv0.
+#[cfg(feature = "diagnostics")]
+pub fn render_failure_view<'a>(
+    spec: &'a spec::Spec<'a>,
+    argv: &[&OsStr],
+    error: &Error<'_, '_>,
+    view: &'a spec::ViewMeta<'a>,
+) -> String {
+    diagnostic::render_view(spec, argv, error, diagnostic::Style::auto(), view)
+}
+
 /// What a caller should print for a parse failure, without the renderer that makes it readable.
 ///
 /// See the other half. A caller that wants the clap-shaped message turns on `diagnostics`;
@@ -986,6 +999,18 @@ pub fn render_failure(spec: &spec::Spec<'_>, argv: &[&OsStr], error: &Error<'_, 
 #[cfg(all(feature = "spec", not(feature = "diagnostics")))]
 pub fn render_failure(spec: &spec::Spec<'_>, argv: &[&OsStr], error: &Error<'_, '_>) -> String {
     let _ = (spec, argv);
+    ::std::format!("error: {error:?}\n")
+}
+
+/// Render a failure through a declared view without the optional diagnostics renderer.
+#[cfg(all(feature = "spec", not(feature = "diagnostics")))]
+pub fn render_failure_view(
+    spec: &spec::Spec<'_>,
+    argv: &[&OsStr],
+    error: &Error<'_, '_>,
+    view: &spec::ViewMeta<'_>,
+) -> String {
+    let _ = (spec, argv, view);
     ::std::format!("error: {error:?}\n")
 }
 
@@ -1000,6 +1025,38 @@ pub fn is_help_flag(flag: &Flag<'_>) -> bool {
 /// Whether a flag is one of the two the parser supplies for `--version`.
 pub fn is_version_flag(flag: &Flag<'_>) -> bool {
     flag.action == ArgAction::Version
+}
+
+/// Whether one exact root argument selects a declared or synthesized version action.
+///
+/// Declared flags are checked first because they shadow the built-in `--version` and `-V`
+/// spellings. Executable views use this before projection so custom version spellings keep
+/// reporting the package that owns the view.
+pub fn is_version_arg(cmd: &Command<'_>, word: &OsStr) -> bool {
+    let token = word.as_encoded_bytes();
+    if let Some(long) = token.strip_prefix(b"--") {
+        if let Some(flag) = cmd.flags.iter().find(|flag| {
+            flag.longs
+                .iter()
+                .any(|spelling| spelling.as_bytes() == long)
+        }) {
+            return is_version_flag(flag);
+        }
+        if cmd.flags.iter().any(|flag| {
+            flag.negate
+                .is_some_and(|spelling| spelling.as_bytes() == long)
+        }) {
+            return false;
+        }
+        return long == b"version" && cmd.version && !cmd.disable_version_flag;
+    }
+    if let [b'-', short] = token {
+        if let Some(flag) = cmd.flags.iter().find(|flag| flag.shorts.contains(short)) {
+            return is_version_flag(flag);
+        }
+        return *short == b'V' && cmd.version && !cmd.disable_version_flag;
+    }
+    false
 }
 
 /// Resolve a subcommand by name or alias, at compile time.
@@ -1163,6 +1220,12 @@ pub struct Parser<'t, 'a, 'v> {
     pos: usize,
     /// The command currently in scope.
     cmd: &'t Command<'t>,
+    /// The canonical root, used to hide root globals omitted by an executable view.
+    #[cfg(feature = "spec")]
+    root: &'t Command<'t>,
+    /// The executable projection being parsed, if argv0 selected one.
+    #[cfg(feature = "spec")]
+    view: Option<&'t spec::ViewMeta<'t>>,
     /// What an unrecognized flag-like token means in the command currently in scope.
     ///
     /// Carried rather than looked up, because it is inherited: a command that states
@@ -1255,6 +1318,10 @@ impl<'t: 'v, 'a, 'v> Parser<'t, 'a, 'v> {
             argv,
             pos: 0,
             cmd: root,
+            #[cfg(feature = "spec")]
+            root,
+            #[cfg(feature = "spec")]
+            view: None,
             unknown_flags: match root.unknown_flags {
                 ::core::option::Option::Some(mode) => mode,
                 // Nothing above the root to inherit from, so the default stands.
@@ -1280,6 +1347,13 @@ impl<'t: 'v, 'a, 'v> Parser<'t, 'a, 'v> {
             action_errors,
             help_span: (0, 0),
         }
+    }
+
+    /// Restrict inherited root globals to those carried by an executable view.
+    #[cfg(feature = "spec")]
+    pub fn with_view(mut self, view: &'t spec::ViewMeta<'t>) -> Self {
+        self.view = Some(view);
+        self
     }
 
     /// The command in scope: the root, or the deepest subcommand selected so far.
@@ -1589,7 +1663,8 @@ impl<'t: 'v, 'a, 'v> Parser<'t, 'a, 'v> {
 
         // Where the CLI declared a version, `--version` answers with it — asked after the
         // command's own flags, so a CLI declaring its own keeps it.
-        if name == b"version" && self.cmd.version && !self.cmd.disable_version_flag {
+        let version_command = self.version_command();
+        if name == b"version" && version_command.version && !version_command.disable_version_flag {
             return Ok(Event::Flag {
                 flag: &VERSION_LONG,
                 value: None,
@@ -1980,19 +2055,74 @@ impl<'t: 'v, 'a, 'v> Parser<'t, 'a, 'v> {
         }
     }
 
+    #[cfg(feature = "spec")]
+    fn view_allows_own_flag(&self, flag: &Flag<'_>) -> bool {
+        match self.view {
+            None => true,
+            // The promoted command keeps its own surface. While the injected path is
+            // still at the host root, however, only explicitly carried globals belong
+            // to the view; root-local flags are not part of the projected executable.
+            Some(view) => {
+                !core::ptr::eq(self.cmd, self.root) || is_version_flag(flag) || view.carries(flag)
+            }
+        }
+    }
+
+    #[cfg(not(feature = "spec"))]
+    fn view_allows_own_flag(&self, _flag: &Flag<'_>) -> bool {
+        true
+    }
+
+    #[cfg(feature = "spec")]
+    fn view_allows_inherited_flag(&self, flag: &Flag<'_>) -> bool {
+        match self.view {
+            None => true,
+            // A portable view carries selected host globals, not globals declared
+            // by intermediate commands on a multi-segment promoted path.
+            Some(view) => {
+                self.root
+                    .flags
+                    .iter()
+                    .any(|root| core::ptr::eq(*root, flag))
+                    && (is_version_flag(flag) || view.carries(flag))
+            }
+        }
+    }
+
+    #[cfg(not(feature = "spec"))]
+    fn view_allows_inherited_flag(&self, _flag: &Flag<'_>) -> bool {
+        true
+    }
+
+    #[cfg(feature = "spec")]
+    fn inherited_flag_is_in_scope(&self, flag: &Flag<'_>) -> bool {
+        flag.global || (self.view.is_some() && is_version_flag(flag))
+    }
+
+    #[cfg(not(feature = "spec"))]
+    fn inherited_flag_is_in_scope(&self, flag: &Flag<'_>) -> bool {
+        flag.global
+    }
+
     /// Flags in scope: this command's own, then any ancestor's globals.
     ///
     /// Own flags come first so that a subcommand redeclaring an inherited name
     /// shadows it, which is what mise relies on when it redeclares root globals
     /// on `run` with different shorts.
     fn in_scope(&self) -> impl Iterator<Item = &'t Flag<'t>> + '_ {
-        let own = self.cmd.flags.iter().copied();
+        let own = self
+            .cmd
+            .flags
+            .iter()
+            .copied()
+            .filter(|flag| self.view_allows_own_flag(flag));
         let inherited = self.ancestors[..self.depth]
             .iter()
             .rev()
             .filter_map(|c| *c)
             .flat_map(|c| c.flags.iter().copied())
-            .filter(|f| f.global);
+            .filter(|flag| self.inherited_flag_is_in_scope(flag))
+            .filter(|flag| self.view_allows_inherited_flag(flag));
         own.chain(inherited)
     }
 
@@ -2013,11 +2143,28 @@ impl<'t: 'v, 'a, 'v> Parser<'t, 'a, 'v> {
             // declared a `-h` of its own.
             .or(if byte == b'h' && !self.cmd.disable_help_flag {
                 Some(&HELP_SHORT)
-            } else if byte == b'V' && self.cmd.version && !self.cmd.disable_version_flag {
+            } else if byte == b'V'
+                && self.version_command().version
+                && !self.version_command().disable_version_flag
+            {
                 Some(&VERSION_SHORT)
             } else {
                 None
             })
+    }
+
+    #[cfg(feature = "spec")]
+    fn version_command(&self) -> &'t Command<'t> {
+        if self.view.is_some() {
+            self.root
+        } else {
+            self.cmd
+        }
+    }
+
+    #[cfg(not(feature = "spec"))]
+    fn version_command(&self) -> &'t Command<'t> {
+        self.cmd
     }
 
     fn find_subcommand(&self, name: &[u8]) -> Option<&'t Command<'t>> {

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -26,6 +26,16 @@ use core::fmt::Write as _;
 use crate::UnknownFlags;
 use crate::{Arg, Command, DoubleDash, Flag};
 
+/// Whether two declarations answer to at least one of the same flag spellings.
+pub(crate) fn flag_forms_overlap(a: &Flag<'_>, b: &Flag<'_>) -> bool {
+    a.longs.iter().any(|name| b.longs.contains(name))
+        || a.shorts.iter().any(|name| b.shorts.contains(name))
+        || a.negate.is_some_and(|name| {
+            b.longs.contains(&name) || b.negate.is_some_and(|other| other == name)
+        })
+        || b.negate.is_some_and(|name| a.longs.contains(&name))
+}
+
 /// The first key that appears twice anywhere in a command tree, if any.
 ///
 /// Keys are what a parse dispatches on, and a derive assigns them without being able
@@ -311,6 +321,8 @@ pub struct Spec<'a> {
     /// `.exe` are stripped. The parser itself does not see argv[0]; [`crate::multicall_applet`]
     /// is what a process entry applies before calling it.
     pub multicall: bool,
+    /// Spec-declared executable views promoted from commands below the root.
+    pub views: &'a [ViewMeta<'a>],
     /// The root command, and the home of everything a spec declares at its top level.
     ///
     /// A KDL spec has one place for surrounding text and examples — the top level — and the
@@ -319,6 +331,57 @@ pub struct Spec<'a> {
     /// fields on the spec: two homes for one declaration is two answers to one question, and
     /// `to_kdl` and the renderer picked differently.
     pub root: &'a CommandMeta<'a>,
+}
+
+/// A named executable surface emitted into the portable spec.
+#[derive(Debug, Clone, Copy)]
+pub struct ViewMeta<'a> {
+    pub id: &'a str,
+    pub name: &'a str,
+    pub bin: &'a str,
+    pub root: &'a str,
+    pub all_globals: bool,
+    pub globals: &'a [&'a str],
+}
+
+impl ViewMeta<'_> {
+    /// Whether this view carries a root-global flag into its executable surface.
+    pub fn carries(self, flag: &crate::Flag<'_>) -> bool {
+        flag.global
+            && (self.all_globals
+                || self.globals.iter().any(|selector| {
+                    selector
+                        .strip_prefix("--")
+                        .is_some_and(|long| flag.longs.contains(&long))
+                        || selector
+                            .strip_prefix('-')
+                            .filter(|short| short.len() == 1)
+                            .and_then(|short| short.as_bytes().first().copied())
+                            .is_some_and(|short| flag.shorts.contains(&short))
+                }))
+    }
+}
+
+/// The declared executable view selected by argv0, if any.
+///
+/// Matching uses the same path and `.exe` normalization as multicall applets. Both `bin` and
+/// the stable view identifier are accepted so changing the display name cannot break dispatch.
+pub fn view_for_program<'a>(
+    spec: &'a Spec<'a>,
+    argv0: &std::ffi::OsStr,
+) -> Option<&'a ViewMeta<'a>> {
+    let basename = crate::multicall_basename(argv0.to_str()?);
+    if basename == crate::multicall_basename(spec.name)
+        || spec
+            .bin
+            .is_some_and(|bin| basename == crate::multicall_basename(bin))
+    {
+        return None;
+    }
+    spec.views.iter().find(|view| {
+        basename == crate::multicall_basename(view.bin)
+            || basename == crate::multicall_basename(view.id)
+    })
 }
 
 /// A command selected for a cold-path metadata override.
@@ -499,6 +562,7 @@ impl<'a> SpecView<'a> {
             usage: self.base.usage,
             default_subcommand: self.base.default_subcommand,
             multicall: self.base.multicall,
+            views: self.base.views,
             root: self.base.root,
         }
     }
@@ -528,6 +592,7 @@ impl Spec<'_> {
         usage: None,
         default_subcommand: None,
         multicall: false,
+        views: &[],
         root: &CommandMeta::EMPTY,
     };
 
@@ -1249,6 +1314,28 @@ impl Spec<'_> {
         }
         if self.multicall {
             writeln!(out, "multicall #true")?;
+        }
+        for view in self.views {
+            write!(out, "view {}", quoted(view.id))?;
+            if view.name != view.id {
+                write!(out, " name={}", quoted(view.name))?;
+            }
+            if view.bin != view.name {
+                write!(out, " bin={}", quoted(view.bin))?;
+            }
+            write!(out, " root={}", quoted(view.root))?;
+            if view.all_globals {
+                out.push_str(" globals=#true");
+            }
+            if view.globals.is_empty() {
+                out.push('\n');
+            } else {
+                out.push_str(" {\n  global");
+                for selector in view.globals {
+                    write!(out, " {}", quoted(selector))?;
+                }
+                out.push_str("\n}\n");
+            }
         }
         if self.root.cmd.external_subcommand {
             writeln!(out, "external_subcommand #true")?;
@@ -2797,6 +2884,18 @@ pub trait CommandArgs: Sized {
         let _ = partial;
     }
 
+    /// Fill defaults for fields visible through an executable view.
+    ///
+    /// Derived implementations filter flattened root arguments to selected globals. The
+    /// default preserves hand-written implementations and ordinary parsing behavior.
+    fn apply_defaults_for_view(
+        partial: &mut Self::Partial,
+        view: Option<&'static ViewMeta<'static>>,
+    ) {
+        let _ = view;
+        Self::apply_defaults(partial);
+    }
+
     /// Fill fields in this command from their declared environment variables.
     ///
     /// A parent calls this before relationships that cross a flattened `CommandArgs`
@@ -2804,6 +2903,23 @@ pub trait CommandArgs: Sized {
     /// checks. Empty by default for hand-written implementations.
     fn apply_env(partial: &mut Self::Partial) {
         let _ = partial;
+    }
+
+    /// Fill environment fallbacks for fields visible through an executable view.
+    fn apply_env_for_view(partial: &mut Self::Partial, view: Option<&'static ViewMeta<'static>>) {
+        let _ = view;
+        Self::apply_env(partial);
+    }
+
+    /// Fill environment fallbacks while traversing the injected parents of a view.
+    ///
+    /// `remaining_descendants` is non-zero only for commands that are routing to the
+    /// promoted command rather than contributing their own surface. Derived commands
+    /// recurse through their selected subcommand without applying their own fallbacks.
+    fn apply_env_for_view_path(partial: &mut Self::Partial, remaining_descendants: usize) {
+        if remaining_descendants == 0 {
+            Self::apply_env(partial);
+        }
     }
 
     /// Everything this command decides after the last token: required-ness,
@@ -2832,11 +2948,73 @@ pub trait CommandArgs: Sized {
         Self::check(partial)
     }
 
+    /// Run checks under a parent command's repeat policy and executable projection.
+    fn check_with_args_override_self_for_view<'t, 'v>(
+        partial: &mut Self::Partial,
+        args_override_self: bool,
+        view: Option<&'static ViewMeta<'static>>,
+    ) -> Result<(), crate::Error<'t, 'v>> {
+        let _ = view;
+        Self::check_with_args_override_self(partial, args_override_self)
+    }
+
+    /// Check a command while traversing the injected parents of a view.
+    ///
+    /// An injected parent is structural: its own defaults and validation do not belong
+    /// to the promoted executable. Derived commands recurse until the promoted command,
+    /// which is then checked normally.
+    fn check_for_view_path<'t, 'v>(
+        partial: &mut Self::Partial,
+        remaining_descendants: usize,
+    ) -> Result<(), crate::Error<'t, 'v>> {
+        if remaining_descendants == 0 {
+            Self::check(partial)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Mark this command's own fields as outside an injected executable-view path.
+    ///
+    /// Derived implementations propagate the marker through flattened argument groups so
+    /// building the enclosing Rust value uses typed defaults instead of parsing empty argv.
+    fn omit_own_for_view(partial: &mut Self::Partial) {
+        let _ = partial;
+    }
+
     /// Build the struct from what was collected.
     ///
     /// Fallible because a command can require a subcommand of its own, and "none was
     /// given" is only knowable here — at the point where the value has to exist.
     fn build<'t, 'v>(partial: Self::Partial) -> Result<Self, crate::Error<'t, 'v>>;
+}
+
+/// Supplies a typed placeholder for fields outside an executable view.
+///
+/// Kept generic so deriving an ordinary command never imposes `Default` on its
+/// values. The process-level view entry point selects [`DefaultViewOmitter`], and
+/// only a CLI that actually declares a view therefore needs omitted field types
+/// to implement `Default`.
+pub trait Omitted<T> {
+    fn omitted() -> T;
+}
+
+/// The omission policy used by generated executable-view entry points.
+pub struct DefaultViewOmitter;
+
+impl<T: Default> Omitted<T> for DefaultViewOmitter {
+    fn omitted() -> T {
+        T::default()
+    }
+}
+
+/// View-aware construction for a derived command or flattened argument group.
+///
+/// `O` is deliberately a type parameter on the trait: generated implementations
+/// can state their field requirements without evaluating them for CLIs that never
+/// build an executable projection.
+pub trait ViewCommandArgs<O>: CommandArgs {
+    fn build_for_view<'t, 'v>(partial: Self::Partial) -> Result<Self, crate::Error<'t, 'v>>;
 }
 
 /// How many flags on `command` accept `selector`.
@@ -2997,6 +3175,17 @@ pub trait Subcommands: Sized {
         let _ = (partial, selected);
     }
 
+    /// Fill environment fallbacks on the promoted command, traversing injected parents.
+    fn apply_env_for_view_path(
+        partial: &mut Self::Partial,
+        selected: Option<usize>,
+        remaining_commands: usize,
+    ) {
+        if remaining_commands <= 1 {
+            Self::apply_env(partial, selected);
+        }
+    }
+
     /// Check the selected command's requirements, and nothing else's.
     ///
     /// A flag that `install` requires says nothing about an invocation that ran
@@ -3012,6 +3201,19 @@ pub trait Subcommands: Sized {
         selected: usize,
     ) -> Result<(), crate::Error<'t, 'v>>;
 
+    /// Check the promoted command, traversing injected parents without validating them.
+    fn check_for_view_path<'t, 'v>(
+        partial: &mut Self::Partial,
+        selected: usize,
+        remaining_commands: usize,
+    ) -> Result<(), crate::Error<'t, 'v>> {
+        if remaining_commands <= 1 {
+            Self::check(partial, selected)
+        } else {
+            Ok(())
+        }
+    }
+
     /// Build the variant at `selected`, a variant index.
     ///
     /// The same index [`apply`] and [`check`] take — mapped through [`VARIANT_OF`]
@@ -3022,6 +3224,14 @@ pub trait Subcommands: Sized {
     /// `None` when no variant was selected, which a caller reads as "no subcommand
     /// was given". An `Err` comes from building the variant that *was* selected.
     fn select<'t, 'v>(
+        partial: Self::Partial,
+        selected: usize,
+    ) -> Result<Option<Self>, crate::Error<'t, 'v>>;
+}
+
+/// View-aware construction for a derived subcommand enum.
+pub trait ViewSubcommands<O>: Subcommands {
+    fn select_for_view<'t, 'v>(
         partial: Self::Partial,
         selected: usize,
     ) -> Result<Option<Self>, crate::Error<'t, 'v>>;
@@ -3453,6 +3663,36 @@ mod tests {
         assert!(runtime.contains("name runtime"), "{runtime}");
         assert!(runtime.contains("cmd list effect=write"), "{runtime}");
         assert!(runtime.contains("cmd rm effect=destructive"), "{runtime}");
+    }
+
+    #[test]
+    fn an_invalid_view_cannot_capture_the_host_program() {
+        static ROOT: Command = Command {
+            name: "host",
+            ..Command::EMPTY
+        };
+        static ROOT_META: CommandMeta = CommandMeta {
+            cmd: &ROOT,
+            ..CommandMeta::EMPTY
+        };
+        static VIEW: ViewMeta = ViewMeta {
+            id: "host",
+            name: "host view",
+            bin: "host.exe",
+            root: "run",
+            all_globals: false,
+            globals: &[],
+        };
+        static SPEC: Spec = Spec {
+            name: "host",
+            bin: Some("/usr/bin/host"),
+            views: &[VIEW],
+            root: &ROOT_META,
+            ..Spec::EMPTY
+        };
+
+        assert!(view_for_program(&SPEC, std::ffi::OsStr::new("host")).is_none());
+        assert!(view_for_program(&SPEC, std::ffi::OsStr::new("/tmp/host.exe")).is_none());
     }
 
     #[test]

--- a/cli/assets/fig.ts
+++ b/cli/assets/fig.ts
@@ -406,6 +406,14 @@ const completionSpec: Fig.Spec = {
                 name: "spec",
               },
             },
+            {
+              name: "--view",
+              description: "Render one spec-declared executable view",
+              isRepeatable: false,
+              args: {
+                name: "view",
+              },
+            },
           ],
         },
         {
@@ -473,6 +481,14 @@ const completionSpec: Fig.Spec = {
               },
             },
             {
+              name: "--view",
+              description: "Render one spec-declared executable view",
+              isRepeatable: false,
+              args: {
+                name: "view",
+              },
+            },
+            {
               name: ["-o", "--out-file"],
               description: 'Output file path, or "-" for stdout (default)',
               isRepeatable: false,
@@ -503,6 +519,14 @@ const completionSpec: Fig.Spec = {
               args: {
                 name: "file",
                 template: "filepaths",
+              },
+            },
+            {
+              name: "--view",
+              description: "Render one spec-declared executable view",
+              isRepeatable: false,
+              args: {
+                name: "view",
               },
             },
             {

--- a/cli/assets/usage.1
+++ b/cli/assets/usage.1
@@ -325,6 +325,9 @@ A usage spec taken in as a file, use "\-" to read from stdin
 .TP
 \fB\-\-spec\fR \fI<SPEC>\fR
 raw string spec input
+.TP
+\fB\-\-view\fR \fI<VIEW>\fR
+Render one spec\-declared executable view
 .SH "USAGE GENERATE JSON-SCHEMA"
 Generate a JSON Schema for a CLI's config file from its usage spec
 .PP
@@ -358,6 +361,9 @@ Generate a manpage from a usage spec
 \fB\-f, \-\-file\fR \fI<FILE>\fR
 A usage spec taken in as a file, use "\-" to read from stdin
 .TP
+\fB\-\-view\fR \fI<VIEW>\fR
+Render one spec\-declared executable view
+.TP
 \fB\-o, \-\-out\-file\fR \fI<OUT_FILE>\fR
 Output file path, or "\-" for stdout (default)
 .TP
@@ -382,6 +388,9 @@ Generate markdown documentation from usage specs
 .TP
 \fB\-f, \-\-file\fR \fI<FILE>\fR
 A usage spec taken in as a file, use "\-" to read from stdin
+.TP
+\fB\-\-view\fR \fI<VIEW>\fR
+Render one spec\-declared executable view
 .TP
 \fB\-m, \-\-multi\fR
 Render each subcommand as a separate markdown file

--- a/cli/src/cli/generate/json.rs
+++ b/cli/src/cli/generate/json.rs
@@ -14,11 +14,18 @@ pub struct Json {
     /// raw string spec input
     #[usage(long, required_unless = "--file", overrides = "--file")]
     spec: Option<String>,
+
+    /// Render one spec-declared executable view
+    #[usage(long)]
+    view: Option<String>,
 }
 
 impl Json {
     pub fn run(&self) -> Result<()> {
-        let spec = generate::file_or_spec(&self.file, &self.spec)?;
+        let spec = generate::select_view(
+            generate::file_or_spec(&self.file, &self.spec)?,
+            self.view.as_deref(),
+        )?;
         let json = serde_json::to_string_pretty(&spec).into_diagnostic()?;
         println!("{json}");
         Ok(())

--- a/cli/src/cli/generate/manpage.rs
+++ b/cli/src/cli/generate/manpage.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use super::{parse_file_or_stdin, write_or_stdout};
+use super::{parse_file_or_stdin, select_view, write_or_stdout};
 use usage::docs::manpage::ManpageRenderer;
 use usage_rs::Args;
 
@@ -11,6 +11,10 @@ pub struct Manpage {
     /// A usage spec taken in as a file, use "-" to read from stdin
     #[usage(short, long)]
     file: PathBuf,
+
+    /// Render one spec-declared executable view
+    #[usage(long)]
+    view: Option<String>,
 
     /// Output file path, or "-" for stdout (default)
     #[usage(
@@ -34,7 +38,7 @@ pub struct Manpage {
 
 impl Manpage {
     pub fn run(&self) -> miette::Result<()> {
-        let spec = parse_file_or_stdin(&self.file)?;
+        let spec = select_view(parse_file_or_stdin(&self.file)?, self.view.as_deref())?;
         let renderer = ManpageRenderer::new(spec).with_section(self.section);
         let manpage = renderer.render()?;
 

--- a/cli/src/cli/generate/markdown.rs
+++ b/cli/src/cli/generate/markdown.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use super::{parse_file_or_stdin, write_or_stdout};
+use super::{parse_file_or_stdin, select_view, write_or_stdout};
 use usage::docs::markdown::MarkdownRenderer;
 use usage_rs::Args;
 
@@ -11,6 +11,10 @@ pub struct Markdown {
     /// A usage spec taken in as a file, use "-" to read from stdin
     #[usage(short, long)]
     file: PathBuf,
+
+    /// Render one spec-declared executable view
+    #[usage(long)]
+    view: Option<String>,
     // /// Pass a usage spec in an argument instead of a file
     // #[usage(short, long, required_unless = "--file", overrides = "--file")]
     // spec: Option<String>,
@@ -66,7 +70,7 @@ impl Markdown {
             xx::file::write(path, render(md))?;
             Ok(())
         };
-        let spec = parse_file_or_stdin(&self.file)?;
+        let spec = select_view(parse_file_or_stdin(&self.file)?, self.view.as_deref())?;
         let mut ctx = MarkdownRenderer::new(spec.clone())
             .with_html_encode(self.html_encode)
             .with_replace_pre_with_code_fences(self.replace_pre_with_code_fences);

--- a/cli/src/cli/generate/mod.rs
+++ b/cli/src/cli/generate/mod.rs
@@ -76,6 +76,14 @@ pub fn parse_file_or_stdin(file: &Path) -> Result<Spec, UsageErr> {
     }
 }
 
+/// Select a spec-declared executable view for a generator, when requested.
+pub fn select_view(spec: Spec, view: Option<&str>) -> Result<Spec, UsageErr> {
+    match view {
+        Some(view) => spec.for_view(view),
+        None => Ok(spec),
+    }
+}
+
 /// The mirror of [`parse_file_or_stdin`]: `-` means stdout, and so does no path at all.
 ///
 /// Both spellings are collapsed here so a caller never has to ask which of the two it is

--- a/cli/src/cli/lint.rs
+++ b/cli/src/cli/lint.rs
@@ -196,10 +196,70 @@ pub fn lint_spec(spec: &Spec, opts: LintOptions) -> Vec<LintIssue> {
         });
     }
 
+    for (position, (id, view)) in spec.views.iter().enumerate() {
+        if let Err(error) = spec.for_view(id) {
+            issues.push(LintIssue {
+                severity: Severity::Error,
+                code: "invalid-view".to_string(),
+                message: error.to_string(),
+                location: Some(format!("view {id}")),
+            });
+        }
+        let host_name = program_basename(&spec.name);
+        let host_bin = program_basename(&spec.bin);
+        if [id.as_str(), view.bin.as_str()].iter().any(|selector| {
+            let selector = program_basename(selector);
+            selector == host_name || (!host_bin.is_empty() && selector == host_bin)
+        }) {
+            issues.push(LintIssue {
+                severity: Severity::Error,
+                code: "view-host-collision".to_string(),
+                message: format!(
+                    "view `{id}` uses the host command's name or bin as an executable selector"
+                ),
+                location: Some(format!("view {id}")),
+            });
+        }
+        if let Some((other, declared)) =
+            spec.views.iter().take(position).find(|(other, declared)| {
+                [other.as_str(), declared.bin.as_str()].iter().any(|prior| {
+                    [id.as_str(), view.bin.as_str()]
+                        .iter()
+                        .any(|current| program_basename(prior) == program_basename(current))
+                })
+            })
+        {
+            let duplicate_bin = program_basename(&declared.bin) == program_basename(&view.bin);
+            issues.push(LintIssue {
+                severity: Severity::Error,
+                code: if duplicate_bin {
+                    "duplicate-view-bin"
+                } else {
+                    "ambiguous-view-program"
+                }
+                .to_string(),
+                message: format!(
+                    "views `{other}` and `{id}` collide after executable basename normalization in the identifier and executable namespaces"
+                ),
+                location: Some(format!("view {id}")),
+            });
+        }
+    }
+
     // Lint the root command
     lint_command(&spec.cmd, &[], spec.about.is_some(), opts, &mut issues);
 
     issues
+}
+
+fn program_basename(program: &str) -> &str {
+    let basename = program.rsplit(['/', '\\']).next().unwrap_or(program);
+    match basename.get(basename.len().saturating_sub(4)..) {
+        Some(extension) if extension.eq_ignore_ascii_case(".exe") => {
+            &basename[..basename.len() - 4]
+        }
+        _ => basename,
+    }
 }
 
 fn lint_command(
@@ -767,6 +827,82 @@ external_subcommand #true
 
         let issues = lint_spec(&spec, LintOptions::default());
         assert!(issues.iter().any(|i| i.code == "multicall-no-subcommands"));
+    }
+
+    #[test]
+    fn test_lint_invalid_executable_view() {
+        let spec: Spec = r#"
+bin "ex"
+flag "--local"
+view "runner" root="missing"
+view "bad-global" root="run" { global "--local" }
+cmd "run"
+        "#
+        .parse()
+        .unwrap();
+
+        let invalid: Vec<_> = lint_spec(&spec, LintOptions::default())
+            .into_iter()
+            .filter(|issue| issue.code == "invalid-view")
+            .collect();
+        assert_eq!(invalid.len(), 2);
+        assert!(invalid.iter().any(|issue| issue
+            .location
+            .as_deref()
+            .is_some_and(|location| location == "view runner")));
+        assert!(invalid.iter().any(|issue| issue
+            .location
+            .as_deref()
+            .is_some_and(|location| location == "view bad-global")));
+    }
+
+    #[test]
+    fn test_lint_ambiguous_executable_view_dispatch() {
+        let spec: Spec = r#"
+bin "ex"
+view "runner" bin="run-bin" root="run"
+view "other" bin="runner" root="other"
+cmd "run"
+cmd "other"
+        "#
+        .parse()
+        .unwrap();
+
+        let issues = lint_spec(&spec, LintOptions::default());
+        assert!(issues
+            .iter()
+            .any(|issue| issue.code == "ambiguous-view-program"));
+
+        let spec: Spec = r#"
+bin "ex"
+view "one" bin="runner" root="run"
+view "two" bin="/tmp/runner.EXE" root="other"
+cmd "run"
+cmd "other"
+        "#
+        .parse()
+        .unwrap();
+        let issues = lint_spec(&spec, LintOptions::default());
+        assert!(issues
+            .iter()
+            .any(|issue| issue.code == "duplicate-view-bin"));
+    }
+
+    #[test]
+    fn test_lint_executable_view_cannot_capture_host() {
+        let spec: Spec = r#"
+name "ex"
+bin "/usr/bin/ex.exe"
+view "ex" root="run"
+cmd "run"
+        "#
+        .parse()
+        .unwrap();
+
+        let issues = lint_spec(&spec, LintOptions::default());
+        assert!(issues
+            .iter()
+            .any(|issue| issue.code == "view-host-collision"));
     }
 
     #[test]

--- a/cli/usage.usage.kdl
+++ b/cli/usage.usage.kdl
@@ -132,6 +132,9 @@ cmd generate help="Generate completions, documentation, and other artifacts from
         flag --spec help="raw string spec input" overrides=--file required_unless=--file {
             arg <SPEC>
         }
+        flag --view help="Render one spec-declared executable view" {
+            arg <VIEW>
+        }
     }
     cmd json-schema help="Generate a JSON Schema for a CLI's config file from its usage spec" effect=read {
         flag "-f --file" help="A usage spec taken in as a file, use \"-\" to read from stdin" {
@@ -156,6 +159,9 @@ cmd generate help="Generate completions, documentation, and other artifacts from
         flag "-f --file" help="A usage spec taken in as a file, use \"-\" to read from stdin" required=#true {
             arg <FILE>
         }
+        flag --view help="Render one spec-declared executable view" {
+            arg <VIEW>
+        }
         flag "-o --out-file" help="Output file path, or \"-\" for stdout (default)" effect=write {
             arg <OUT_FILE>
         }
@@ -169,6 +175,9 @@ cmd generate help="Generate completions, documentation, and other artifacts from
         alias md
         flag "-f --file" help="A usage spec taken in as a file, use \"-\" to read from stdin" required=#true {
             arg <FILE>
+        }
+        flag --view help="Render one spec-declared executable view" {
+            arg <VIEW>
         }
         flag "-m --multi" help="Render each subcommand as a separate markdown file" conflicts=--out-file
         flag --html-encode help="Escape HTML in markdown"

--- a/conformance/src/tables.rs
+++ b/conformance/src/tables.rs
@@ -239,6 +239,7 @@ pub fn build_spec(spec: &Spec) -> &'static usage_argv::spec::Spec<'static> {
         long_about: opt(&spec.about_long),
         default_subcommand: opt(&spec.default_subcommand),
         multicall: spec.multicall,
+        views: &[],
         // An exact synopsis the spec declares, which replaces the generated line on the root's
         // page. usage-lib's manpage renderer honours it and its help renderer does not, so a
         // spec that declares one is a case the two disagree about; `render/03-sections.json`

--- a/conformance/tests/program_identity.rs
+++ b/conformance/tests/program_identity.rs
@@ -47,6 +47,26 @@ enum BusyCommand {
     Run,
 }
 
+#[derive(Cli)]
+#[usage(
+    bin = "view-host",
+    version = "9.9",
+    view("runner", root = "run", globals)
+)]
+struct ViewHost {
+    #[usage(long, global)]
+    verbose: bool,
+    #[arg(long = "build-info", action = clap::ArgAction::Version)]
+    build_info: bool,
+    #[usage(subcommand)]
+    command: Option<ViewCommand>,
+}
+
+#[derive(Subcommands)]
+enum ViewCommand {
+    Run,
+}
+
 #[test]
 fn a_program_is_called_what_its_binary_is_called() {
     // The name defaults to the struct's, and a struct is usually called `Cli`. So `bin` alone
@@ -90,6 +110,31 @@ fn a_bare_version_is_the_packages_own() {
 fn a_written_version_is_taken_as_written() {
     let spec: LibSpec = Renamed::to_kdl().parse().expect("valid spec");
     assert_eq!(spec.version.as_deref(), Some("9.9"));
+}
+
+#[test]
+fn a_view_keeps_a_custom_host_version_action() {
+    use std::ffi::OsStr;
+
+    let argv = [
+        OsStr::new("runner"),
+        OsStr::new("--verbose"),
+        OsStr::new("--build-info"),
+    ];
+    assert!(matches!(
+        ViewHost::parse_from_argv(&argv),
+        Err(usage_argv::Error::Version { .. })
+    ));
+
+    let argv = [
+        OsStr::new("runner"),
+        OsStr::new("--verbose"),
+        OsStr::new("--version"),
+    ];
+    assert!(matches!(
+        ViewHost::parse_from_argv(&argv),
+        Err(usage_argv::Error::Version { .. })
+    ));
 }
 
 #[test]

--- a/conformance/tests/spec_roundtrip.rs
+++ b/conformance/tests/spec_roundtrip.rs
@@ -332,6 +332,7 @@ static SPEC: Spec = Spec {
     usage: Some("Usage: ex <COMMAND>\n       ex --version \"quoted\""),
     default_subcommand: Some("run"),
     multicall: false,
+    views: &[],
     root: &ROOT_META,
 };
 
@@ -773,6 +774,7 @@ fn a_declared_completer_becomes_a_run_the_reference_can_read() {
         usage: None,
         default_subcommand: None,
         multicall: false,
+        views: &[],
         root: &META,
     };
 
@@ -910,6 +912,7 @@ fn two_commands_can_mean_different_things_by_one_name() {
         usage: None,
         default_subcommand: None,
         multicall: false,
+        views: &[],
         root: &ROOT_META_TWO,
     };
 
@@ -929,10 +932,9 @@ fn two_commands_can_mean_different_things_by_one_name() {
         );
     }
 
-    // A root that declares the same name wins over both, which is the order the reference
-    // resolves in — `spec.complete` before `cmd.complete` — and the root's completers are what a
-    // spec writes at the top level. Recorded here rather than assumed, because it is the one
-    // place this order is visible.
+    // A root may also declare the same name. Cursor identity still wins over that name-based
+    // fallback: otherwise a promoted view or an ordinary child argument could silently run the
+    // root completer merely because both fields use a conventional name such as `tool`.
     static ROOT_TOOL: Arg = Arg {
         key: 93,
         name: "TOOL",
@@ -968,6 +970,7 @@ fn two_commands_can_mean_different_things_by_one_name() {
         usage: None,
         default_subcommand: None,
         multicall: false,
+        views: &[],
         root: &ROOT_META_THREE,
     };
     let words = ["ex".to_string(), "use".to_string(), String::new()];
@@ -981,8 +984,8 @@ fn two_commands_can_mean_different_things_by_one_name() {
     let found = usage_argv::complete::for_name(&SPEC_THREE, "tool", &ctx).expect("a completer");
     assert_eq!(
         found.iter().map(|c| c.value.as_str()).collect::<Vec<_>>(),
-        ["root"],
-        "the root's wins, as it does in the reference"
+        ["installed"],
+        "the argument under the cursor wins before the root name fallback"
     );
 
     // And the binary answers about the command the line reached, not the first one in the tree.

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -18,7 +18,7 @@ use quote::{format_ident, quote};
 use crate::crate_name::{crate_name, FoundCrate};
 use crate::model::{
     rendered_path, to_kebab, Cli, ConditionalDefault, DoubleDash, Field, Kind, Shape, Subcommands,
-    ValueEnum,
+    ValueEnum, ViewDecl,
 };
 
 /// Construct the user's command type after its generated partial has been checked.
@@ -246,7 +246,10 @@ pub fn emit(cli: &Cli) -> TokenStream {
         .unwrap_or_default();
     let sub_metas = parts.as_ref().map(|p| p.metas.clone()).unwrap_or_default();
     let sub_build = parts.as_ref().map(|p| p.build.clone()).unwrap_or_default();
-
+    let sub_default_view_build = parts
+        .as_ref()
+        .map(|p| p.default_view_build.clone())
+        .unwrap_or_default();
     let partial = partial_struct(cli);
     let argument_lookup = argument_lookup_functions(cli);
     let defaults = partial_defaults(cli);
@@ -286,7 +289,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
             .fields
             .iter()
             .filter(|f| !matches!(f.kind, Kind::Subcommand { .. }))
-            .map(field_final)
+            .map(|field| field_final(field, None))
             .collect();
         let built = built_value(cli, &sub_build, &field_finals);
         quote! {
@@ -327,11 +330,59 @@ pub fn emit(cli: &Cli) -> TokenStream {
         .fields
         .iter()
         .filter(|f| !matches!(f.kind, Kind::Subcommand { .. }))
-        .map(field_final)
+        .map(|field| field_final(field, None))
         .collect();
     let built = built_value(cli, &sub_build, &field_finals);
+    let built_for_view = if cli.views.is_empty() {
+        built.clone()
+    } else {
+        let default_view_omitter = quote!(usage_argv::spec::DefaultViewOmitter);
+        let view_field_finals: Vec<_> = cli
+            .fields
+            .iter()
+            .filter(|f| !matches!(f.kind, Kind::Subcommand { .. }))
+            .map(|field| field_final(field, Some(&default_view_omitter)))
+            .collect();
+        // A one-command view promotes the selected child directly. None of that child's
+        // fields are omitted, so constructing it through the view-aware trait would impose
+        // `Default` on every value type in every sibling command for no semantic reason.
+        // Deeper views still need view-aware construction for the injected intermediate
+        // commands whose own fields are absent from argv.
+        let view_sub_build = if cli
+            .views
+            .iter()
+            .all(|view| view.root.split_ascii_whitespace().count() == 1)
+        {
+            &sub_build
+        } else {
+            &sub_default_view_build
+        };
+        built_value(cli, view_sub_build, &view_field_finals)
+    };
 
     let min_usage_version = option_str(cli.min_usage_version.as_deref());
+    let views: Vec<_> = cli
+        .views
+        .iter()
+        .map(|view| {
+            let id = &view.id;
+            let name = &view.name;
+            let bin = &view.bin;
+            let root = &view.root;
+            let all_globals = view.all_globals;
+            let globals = &view.globals;
+            quote! {
+                usage_argv::spec::ViewMeta {
+                    id: #id,
+                    name: #name,
+                    bin: #bin,
+                    root: #root,
+                    all_globals: #all_globals,
+                    globals: &[#(#globals),*],
+                }
+            }
+        })
+        .collect();
     let has_version = cli.version.is_some() || cli.long_version.is_some();
     let runtime_version = cli
         .runtime_version
@@ -566,9 +617,13 @@ pub fn emit(cli: &Cli) -> TokenStream {
             /// In the module rather than beside the parse, so every reference it makes
             /// to the user's own types sits at one consistent scope — the root and a
             /// nested command generate the same code here.
-            pub fn check<'t, 'v>(
+            fn check_with_view<'t, 'v>(
                 partial: &mut Partial,
+                __usage_view: ::std::option::Option<
+                    &'static usage_argv::spec::ViewMeta<'static>,
+                >,
             ) -> ::std::result::Result<(), usage_argv::Error<'t, 'v>> {
+                partial.__usage_view = __usage_view;
                 // Read unconditionally: a command that declares nothing to check would
                 // otherwise leave the parameter unused in the user's crate, where
                 // nobody can silence it.
@@ -576,6 +631,12 @@ pub fn emit(cli: &Cli) -> TokenStream {
                 let args_override_self = #args_override_self;
                 #post
                 ::std::result::Result::Ok(())
+            }
+
+            pub fn check<'t, 'v>(
+                partial: &mut Partial,
+            ) -> ::std::result::Result<(), usage_argv::Error<'t, 'v>> {
+                check_with_view(partial, ::std::option::Option::None)
             }
 
             /// Every token read, and nothing else decided.
@@ -609,7 +670,19 @@ pub fn emit(cli: &Cli) -> TokenStream {
                 argv: &[&'v ::std::ffi::OsStr],
                 partial: &mut Partial,
             ) -> ::std::result::Result<(), usage_argv::Error<'static, 'v>> {
+                read_argv_into_view(command, argv, partial, ::std::option::Option::None)
+            }
+
+            pub fn read_argv_into_view<'v>(
+                command: &'static usage_argv::Command<'static>,
+                argv: &[&'v ::std::ffi::OsStr],
+                partial: &mut Partial,
+                view: ::std::option::Option<&'static usage_argv::spec::ViewMeta<'static>>,
+            ) -> ::std::result::Result<(), usage_argv::Error<'static, 'v>> {
                 let mut __usage_parser = usage_argv::Parser::new(command, argv);
+                if let ::std::option::Option::Some(view) = view {
+                    __usage_parser = __usage_parser.with_view(view);
+                }
                 while let ::std::option::Option::Some(__usage_event) =
                     __usage_parser.next_event()
                 {
@@ -707,6 +780,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
                 usage: #usage,
                 default_subcommand: #default_subcommand,
                 multicall: #multicall,
+                views: &[#(#views),*],
                 root: &ROOT_META,
             };
 
@@ -768,6 +842,32 @@ pub fn emit(cli: &Cli) -> TokenStream {
                     else {
                         return Self::parse_from(&[]);
                     };
+                    if let ::std::option::Option::Some(__usage_view) =
+                        usage_argv::spec::view_for_program(&SPEC, __usage_argv0)
+                    {
+                        let mut __usage_rewritten = ::std::vec::Vec::with_capacity(
+                            __usage_words.len()
+                                + __usage_view.root.split_ascii_whitespace().count(),
+                        );
+                        __usage_rewritten.extend(
+                            __usage_view.root
+                                .split_ascii_whitespace()
+                                .map(::std::ffi::OsStr::new),
+                        );
+                        __usage_rewritten.extend_from_slice(__usage_words);
+                        #defaults
+                        read_argv_into_view(
+                            Self::command(),
+                            &__usage_rewritten,
+                            &mut partial,
+                            ::std::option::Option::Some(__usage_view),
+                        )?;
+                        check_with_view(
+                            &mut partial,
+                            ::std::option::Option::Some(__usage_view),
+                        )?;
+                        return ::std::result::Result::Ok(#built_for_view);
+                    }
                     if SPEC.multicall {
                         if let ::std::option::Option::Some(__usage_word) =
                             __usage_argv0.to_str().and_then(|s| {
@@ -803,37 +903,80 @@ pub fn emit(cli: &Cli) -> TokenStream {
 
                 pub fn parse() -> Self {
                     #completion_intercept
-                    let __usage_raw: ::std::vec::Vec<::std::ffi::OsString> = if SPEC.multicall {
-                        let mut __usage_all: ::std::vec::Vec<::std::ffi::OsString> =
-                            ::std::env::args_os().collect();
-                        if !__usage_all.is_empty() {
-                            let __usage_argv0 = __usage_all.remove(0);
-                            if let ::std::option::Option::Some(__usage_word) =
-                                __usage_argv0.to_str().and_then(|s| {
-                                    usage_argv::multicall_applet(s, SPEC.name, SPEC.bin)
-                                })
+                    let __usage_all: ::std::vec::Vec<::std::ffi::OsString> =
+                        ::std::env::args_os().collect();
+                    let __usage_all_refs: ::std::vec::Vec<&::std::ffi::OsStr> =
+                        __usage_all.iter().map(|a| a.as_os_str()).collect();
+                    let __usage_raw: ::std::vec::Vec<::std::ffi::OsString> =
+                        if let ::std::option::Option::Some((__usage_argv0, __usage_words)) =
+                            __usage_all_refs.split_first()
+                        {
+                            if let ::std::option::Option::Some(__usage_view) =
+                                usage_argv::spec::view_for_program(&SPEC, __usage_argv0)
                             {
-                                __usage_all.insert(
-                                    0,
-                                    ::std::ffi::OsString::from(__usage_word),
-                                );
+                                if __usage_words.first().is_some_and(|word| {
+                                    usage_argv::is_version_arg(SPEC.root.cmd, word)
+                                })
+                                {
+                                    __usage_words
+                                        .iter()
+                                        .map(|word| (*word).to_os_string())
+                                        .collect()
+                                } else {
+                                    __usage_view
+                                        .root
+                                        .split_ascii_whitespace()
+                                        .map(::std::ffi::OsString::from)
+                                        .chain(
+                                            __usage_words
+                                                .iter()
+                                                .map(|word| (*word).to_os_string()),
+                                        )
+                                        .collect()
+                                }
+                            } else if SPEC.multicall {
+                                let mut __usage_words: ::std::vec::Vec<::std::ffi::OsString> =
+                                    __usage_words
+                                        .iter()
+                                        .map(|word| (*word).to_os_string())
+                                        .collect();
+                                if let ::std::option::Option::Some(__usage_word) =
+                                    __usage_argv0.to_str().and_then(|s| {
+                                        usage_argv::multicall_applet(s, SPEC.name, SPEC.bin)
+                                    })
+                                {
+                                    __usage_words.insert(
+                                        0,
+                                        ::std::ffi::OsString::from(__usage_word),
+                                    );
+                                }
+                                __usage_words
+                            } else {
+                                __usage_words
+                                    .iter()
+                                    .map(|word| (*word).to_os_string())
+                                    .collect()
                             }
-                        }
-                        __usage_all
-                    } else {
-                        ::std::env::args_os().skip(1).collect()
-                    };
+                        } else {
+                            ::std::vec::Vec::new()
+                        };
                     let __usage_argv: ::std::vec::Vec<&::std::ffi::OsStr> =
                         __usage_raw.iter().map(|a| a.as_os_str()).collect();
+                    let __usage_selected_view = __usage_all
+                        .first()
+                        .and_then(|argv0| usage_argv::spec::view_for_program(&SPEC, argv0));
                     // This is the entry point that *is* the process — it already exits for a help
                     // request — so it answers a failure the way a command-line program does:
                     // the message on stderr, and a non-zero status. `parse_from` hands the error
                     // back instead, for a library embedding this that wants to decide.
-                    match Self::parse_from(&__usage_argv) {
+                    match Self::parse_from_argv(&__usage_all_refs) {
                         ::std::result::Result::Ok(parsed) => parsed,
                         // Not failures: someone asked a question, and the answer goes to stdout.
                         ::std::result::Result::Err(usage_argv::Error::Version { long }) => {
                             #runtime_program_for_version
+                            let __usage_bin = __usage_selected_view
+                                .map(|view| view.bin)
+                                .unwrap_or(__usage_bin);
                             let __usage_version = if long {
                                 #output_long_version
                             } else {
@@ -848,18 +991,36 @@ pub fn emit(cli: &Cli) -> TokenStream {
                             // `Subcommands` type mounted under two parents is one address, and a
                             // page found by searching for it carries the first mount's path and
                             // globals. Falls back where the route cannot be rebuilt.
-                            let __usage_page = match usage_argv::help::route_to(
-                                Self::command(),
-                                &__usage_argv,
-                                cmd,
-                            ) {
+                            let __usage_route = match __usage_selected_view {
+                                ::std::option::Option::Some(view) =>
+                                    usage_argv::help::route_to_view(
+                                        Self::command(), &__usage_all_refs, cmd, view,
+                                    ),
+                                ::std::option::Option::None => usage_argv::help::route_to(
+                                    Self::command(), &__usage_argv, cmd,
+                                ),
+                            };
+                            let __usage_page = match __usage_route {
                                 ::std::option::Option::Some(route) => {
-                                    usage_argv::help::render_at_styled(
-                                        __usage_spec,
-                                        &route,
-                                        long,
-                                        usage_argv::help::Style::auto(),
-                                    )
+                                    match __usage_selected_view {
+                                        ::std::option::Option::Some(view) => {
+                                            usage_argv::help::render_view_at_styled(
+                                                __usage_spec,
+                                                &route,
+                                                view,
+                                                long,
+                                                usage_argv::help::Style::auto(),
+                                            )
+                                        }
+                                        ::std::option::Option::None => {
+                                            usage_argv::help::render_at_styled(
+                                                __usage_spec,
+                                                &route,
+                                                long,
+                                                usage_argv::help::Style::auto(),
+                                            )
+                                        }
+                                    }
                                 }
                                 ::std::option::Option::None => {
                                     usage_argv::help::render_styled(
@@ -881,18 +1042,36 @@ pub fn emit(cli: &Cli) -> TokenStream {
                         }
                         ::std::result::Result::Err(usage_argv::Error::MissingArgsHelp { cmd }) => {
                             #effective_spec
-                            let __usage_page = match usage_argv::help::route_to(
-                                Self::command(),
-                                &__usage_argv,
-                                cmd,
-                            ) {
+                            let __usage_route = match __usage_selected_view {
+                                ::std::option::Option::Some(view) =>
+                                    usage_argv::help::route_to_view(
+                                        Self::command(), &__usage_all_refs, cmd, view,
+                                    ),
+                                ::std::option::Option::None => usage_argv::help::route_to(
+                                    Self::command(), &__usage_argv, cmd,
+                                ),
+                            };
+                            let __usage_page = match __usage_route {
                                 ::std::option::Option::Some(route) => {
-                                    usage_argv::help::render_at_styled(
-                                        __usage_spec,
-                                        &route,
-                                        false,
-                                        usage_argv::help::Style::auto_stderr(),
-                                    )
+                                    match __usage_selected_view {
+                                        ::std::option::Option::Some(view) => {
+                                            usage_argv::help::render_view_at_styled(
+                                                __usage_spec,
+                                                &route,
+                                                view,
+                                                false,
+                                                usage_argv::help::Style::auto_stderr(),
+                                            )
+                                        }
+                                        ::std::option::Option::None => {
+                                            usage_argv::help::render_at_styled(
+                                                __usage_spec,
+                                                &route,
+                                                false,
+                                                usage_argv::help::Style::auto_stderr(),
+                                            )
+                                        }
+                                    }
                                 }
                                 ::std::option::Option::None => {
                                     usage_argv::help::render_styled(
@@ -913,17 +1092,34 @@ pub fn emit(cli: &Cli) -> TokenStream {
                         }
                         ::std::result::Result::Err(usage_argv::Error::HelpAll { cmd }) => {
                             #effective_spec
-                            let __usage_page = match usage_argv::help::route_to(
-                                Self::command(),
-                                &__usage_argv,
-                                cmd,
-                            ) {
+                            let __usage_route = match __usage_selected_view {
+                                ::std::option::Option::Some(view) =>
+                                    usage_argv::help::route_to_view(
+                                        Self::command(), &__usage_all_refs, cmd, view,
+                                    ),
+                                ::std::option::Option::None => usage_argv::help::route_to(
+                                    Self::command(), &__usage_argv, cmd,
+                                ),
+                            };
+                            let __usage_page = match __usage_route {
                                 ::std::option::Option::Some(route) => {
-                                    usage_argv::help::render_all_at_styled(
-                                        __usage_spec,
-                                        &route,
-                                        usage_argv::help::Style::auto(),
-                                    )
+                                    match __usage_selected_view {
+                                        ::std::option::Option::Some(view) => {
+                                            usage_argv::help::render_all_view_at_styled(
+                                                __usage_spec,
+                                                &route,
+                                                view,
+                                                usage_argv::help::Style::auto(),
+                                            )
+                                        }
+                                        ::std::option::Option::None => {
+                                            usage_argv::help::render_all_at_styled(
+                                                __usage_spec,
+                                                &route,
+                                                usage_argv::help::Style::auto(),
+                                            )
+                                        }
+                                    }
                                 }
                                 ::std::option::Option::None => {
                                     usage_argv::help::render_all_styled(
@@ -943,9 +1139,26 @@ pub fn emit(cli: &Cli) -> TokenStream {
                         }
                         ::std::result::Result::Err(e) => {
                             #effective_spec
+                            let __usage_failure = match __usage_selected_view {
+                                ::std::option::Option::Some(view) => {
+                                    usage_argv::render_failure_view(
+                                        __usage_spec,
+                                        &__usage_all_refs,
+                                        &e,
+                                        view,
+                                    )
+                                }
+                                ::std::option::Option::None => {
+                                    usage_argv::render_failure(
+                                        __usage_spec,
+                                        &__usage_argv,
+                                        &e,
+                                    )
+                                }
+                            };
                             ::std::eprint!(
                                 "{}",
-                                usage_argv::render_failure(__usage_spec, &__usage_argv, &e)
+                                __usage_failure
                             );
                             // clap's, so a script that checks for it keeps working.
                             usage_argv::__usage_process_exit(2);
@@ -1071,6 +1284,18 @@ fn completion_fns(cli: &Cli) -> (TokenStream, TokenStream) {
             usage_argv::script::script(&__usage_program, shell)
         }
 
+        /// A declared executable view's completion script.
+        pub fn completion_script_for(
+            view: &str,
+            shell: usage_argv::complete::Shell,
+        ) -> ::std::option::Option<::std::string::String> {
+            Self::spec()
+                .views
+                .iter()
+                .find(|declared| declared.id == view)
+                .map(|declared| usage_argv::script::script(declared.bin, shell))
+        }
+
         /// The word a shell is completing, answered from this CLI's own tables.
         ///
         /// `None` when argv is an ordinary invocation. The request is recognized before the
@@ -1130,13 +1355,27 @@ fn completion_fns(cli: &Cli) -> (TokenStream, TokenStream) {
             // No cursor means the end of the line, which is where a shell puts it when it has
             // no way to say — nushell, whose completer only ever sees the words.
             let cursor = cursor.unwrap_or(line.len());
-            let split = usage_argv::complete::split(&line, cursor, shell);
+            let mut split = usage_argv::complete::split(&line, cursor, shell);
+            let __usage_selected_view = split.words.first().and_then(|__usage_program| {
+                usage_argv::spec::view_for_program(
+                    Self::spec(),
+                    ::std::ffi::OsStr::new(__usage_program),
+                )
+            });
             if let ::std::option::Option::Some(name) = candidates_for {
                 // Walked here as well, because a `--candidates` request names a completer and
                 // says nothing about where the cursor is — and the completer still wants the
                 // words its own command was given.
-                let position =
-                    usage_argv::complete::walk(Self::spec().root.cmd, split.argv());
+                let position = match __usage_selected_view {
+                    ::std::option::Option::Some(view) =>
+                        usage_argv::complete::walk_view(
+                            Self::spec().root.cmd,
+                            split.argv(),
+                            view,
+                        ),
+                    ::std::option::Option::None =>
+                        usage_argv::complete::walk(Self::spec().root.cmd, split.argv()),
+                };
                 let __usage_words = split.argv();
                 let __usage_path: ::std::vec::Vec<(
                     &usage_argv::Command<'_>,
@@ -1158,15 +1397,26 @@ fn completion_fns(cli: &Cli) -> (TokenStream, TokenStream) {
                 // Nothing of that name is an empty answer rather than an error: a spec written
                 // against a newer version of this CLI is a stale script, and a stale script
                 // should complete nothing rather than print a message into the user's prompt.
-                let found =
-                    usage_argv::complete::for_name(Self::spec(), &name, &ctx).unwrap_or_default();
+                let found = match __usage_selected_view {
+                    ::std::option::Option::Some(view) =>
+                        usage_argv::complete::for_name_view(Self::spec(), &name, &ctx, view)
+                            .unwrap_or_default(),
+                    ::std::option::Option::None =>
+                        usage_argv::complete::for_name(Self::spec(), &name, &ctx)
+                            .unwrap_or_default(),
+                };
                 let answer = usage_argv::complete::Completions {
                     candidates: found,
                     files: ::std::option::Option::None,
                 };
                 return ::std::option::Option::Some(usage_argv::complete::render(&answer, shell));
             }
-            let answer = usage_argv::complete::complete(Self::spec(), &split);
+            let answer = match __usage_selected_view {
+                ::std::option::Option::Some(view) =>
+                    usage_argv::complete::complete_view(Self::spec(), &split, view),
+                ::std::option::Option::None =>
+                    usage_argv::complete::complete(Self::spec(), &split),
+            };
             ::std::option::Option::Some(usage_argv::complete::render(&answer, shell))
         }
     };
@@ -2236,6 +2486,71 @@ fn semantic_given(field: &Field) -> TokenStream {
     quote!(partial.#given)
 }
 
+fn view_policy_given(field: &Field) -> TokenStream {
+    let given = policy_given(field);
+    let active = view_field_active(field);
+    quote!((#active) && (#given))
+}
+
+/// Whether a root field belongs to the executable surface currently being parsed.
+///
+/// A view promotes a subcommand and carries only the root globals it names. The selected
+/// subcommand is checked through its own generated module, where `__usage_view` is `None`;
+/// this predicate therefore filters only policy declared on the omitted root surface.
+fn view_field_active(field: &Field) -> TokenStream {
+    let Kind::Flag {
+        longs,
+        hidden_longs,
+        shorts,
+        global: true,
+        ..
+    } = &field.kind
+    else {
+        return quote!(__usage_view.is_none());
+    };
+    let long_selectors = longs
+        .iter()
+        .chain(hidden_longs)
+        .map(|long| format!("--{long}"));
+    let short_selectors = shorts.iter().map(|short| format!("-{short}"));
+    let selectors: Vec<String> = long_selectors.chain(short_selectors).collect();
+    quote! {
+        match __usage_view {
+            ::std::option::Option::None => true,
+            ::std::option::Option::Some(__usage_view) => {
+                __usage_view.all_globals
+                    || __usage_view.globals.iter().any(|__usage_selector| {
+                        matches!(*__usage_selector, #(#selectors)|*)
+                    })
+            }
+        }
+    }
+}
+
+/// Whether a root field is carried into one declared executable view.
+///
+/// This is the compile-time counterpart of [`view_field_active`]. It is used when an error
+/// needs a static slice containing only the group members that the selected view accepts.
+fn field_active_in_view(field: &Field, view: &ViewDecl) -> bool {
+    let Kind::Flag {
+        longs,
+        hidden_longs,
+        shorts,
+        global: true,
+        ..
+    } = &field.kind
+    else {
+        return false;
+    };
+    view.all_globals
+        || longs
+            .iter()
+            .chain(hidden_longs)
+            .map(|long| format!("--{long}"))
+            .chain(shorts.iter().map(|short| format!("-{short}")))
+            .any(|selector| view.globals.contains(&selector))
+}
+
 /// Whether a repeat of this flag is only a duplicate *within one command*.
 ///
 /// A `global` flag is in scope for every descendant, and clap lets it be given again on a
@@ -2846,6 +3161,10 @@ fn partial_struct(cli: &Cli) -> TokenStream {
     // its own starting values.
     quote! {
         pub struct Partial {
+            pub __usage_view: ::std::option::Option<
+                &'static usage_argv::spec::ViewMeta<'static>,
+            >,
+            pub __usage_omit_own: bool,
             #(#fields)*
             #sub
         }
@@ -3186,6 +3505,8 @@ fn partial_defaults(cli: &Cli) -> TokenStream {
     // that `#sub_starts` builds rather than a value.
     quote! {
         let mut partial = Partial {
+            __usage_view: ::std::option::Option::None,
+            __usage_omit_own: false,
             #(#plain)*
             #sub_starts
         };
@@ -3198,7 +3519,7 @@ fn partial_defaults(cli: &Cli) -> TokenStream {
 /// means. This is where meaning arrives: a `String` field takes the text as it is, and
 /// anything else is built with `FromStr` — which is what lets a field be a `PathBuf`, a
 /// number, or a type of the adopter's own.
-fn field_final(field: &Field) -> TokenStream {
+fn field_final(field: &Field, omitter: Option<&TokenStream>) -> TokenStream {
     let ident = &field.ident;
     let given = format_ident!("__given_{}", ident);
     let name = &field.name;
@@ -3209,14 +3530,37 @@ fn field_final(field: &Field) -> TokenStream {
     if let Kind::Flatten { ty } = &field.kind {
         // Built by its own derive, which is also what makes a nested flatten work: this is
         // the same call at every level.
-        //
-        return quote! {
-            #ident: <#ty as usage_argv::spec::CommandArgs>::build(partial.#ident)?
+        return match omitter {
+            Some(omitter) => quote! {
+                #ident: <#ty as usage_argv::spec::ViewCommandArgs<#omitter>>::build_for_view(
+                    partial.#ident,
+                )?
+            },
+            None => quote! {
+                #ident: <#ty as usage_argv::spec::CommandArgs>::build(partial.#ident)?
+            },
         };
     }
+    let active = view_field_active(field);
+    let ty = &field.ty;
+    let finished = |value: TokenStream| {
+        let Some(omitter) = omitter else {
+            return quote!(#ident: #value);
+        };
+        quote! {
+            #ident: {
+                let __usage_view = partial.__usage_view;
+                if partial.__usage_omit_own || !(#active) {
+                    <#omitter as usage_argv::spec::Omitted<#ty>>::omitted()
+                } else {
+                    #value
+                }
+            }
+        }
+    };
     let Some(ty) = field.value_ty.as_ref() else {
         // A switch or a count: nothing was parsed from a word.
-        return quote!(#ident: partial.#ident);
+        return finished(quote!(partial.#ident));
     };
 
     // Every type converts, `String` included: the partial holds the bytes that were typed,
@@ -3285,18 +3629,18 @@ fn field_final(field: &Field) -> TokenStream {
         return match field.shape {
             // Unreachable: a switch and a count have no `value_ty`, so the early return
             // above already handled them.
-            Shape::Bool | Shape::Count => quote!(#ident: partial.#ident),
+            Shape::Bool | Shape::Count => finished(quote!(partial.#ident)),
             Shape::Required => {
                 let value = converted(quote!(partial.#ident));
-                quote!(#ident: #value)
+                finished(value)
             }
             // A `match` rather than `.map`, and a loop rather than `.collect`, for the same
             // reason the text path below uses them: the conversion can fail, and a `return`
             // inside a closure would leave the error in the closure's own return type.
             Shape::Optional if field.optional_value_type => {
                 let value = converted(quote!(__usage_value));
-                quote! {
-                    #ident: match partial.#ident {
+                finished(quote! {
+                    match partial.#ident {
                         ::std::option::Option::Some(__usage_value) => {
                             ::std::option::Option::Some(::std::option::Option::Some(#value))
                         }
@@ -3305,18 +3649,18 @@ fn field_final(field: &Field) -> TokenStream {
                         }
                         ::std::option::Option::None => ::std::option::Option::None,
                     }
-                }
+                })
             }
             Shape::Optional => {
                 let value = converted(quote!(__usage_value));
-                quote! {
-                    #ident: match partial.#ident {
+                finished(quote! {
+                    match partial.#ident {
                         ::std::option::Option::Some(__usage_value) => {
                             ::std::option::Option::Some(#value)
                         }
                         ::std::option::Option::None => ::std::option::Option::None,
                     }
-                }
+                })
             }
             Shape::Many => {
                 let value = converted(quote!(__usage_value));
@@ -3334,15 +3678,15 @@ fn field_final(field: &Field) -> TokenStream {
                     // Same as below: whether anything arrived is what tells "never given"
                     // from "given nothing", which the `Vec` itself cannot. A `default_if`
                     // that fired has already pushed, so a non-empty vec is a value too.
-                    quote! {
-                        #ident: if partial.#given || #defaulted || !partial.#ident.is_empty() {
+                    finished(quote! {
+                        if partial.#given || #defaulted || !partial.#ident.is_empty() {
                             ::std::option::Option::Some(#collected)
                         } else {
                             ::std::option::Option::None
                         }
-                    }
+                    })
                 } else {
-                    quote!(#ident: #collected)
+                    finished(collected)
                 }
             }
         };
@@ -3412,15 +3756,15 @@ fn field_final(field: &Field) -> TokenStream {
     };
 
     match field.shape {
-        Shape::Bool | Shape::Count => quote!(#ident: partial.#ident),
+        Shape::Bool | Shape::Count => finished(quote!(partial.#ident)),
         Shape::Required => {
             let one = converted(quote!(partial.#ident));
-            quote!(#ident: #one)
+            finished(one)
         }
         Shape::Optional if field.optional_value_type => {
             let one = converted(quote!(__usage_value));
-            quote! {
-                #ident: match partial.#ident {
+            finished(quote! {
+                match partial.#ident {
                     ::std::option::Option::Some(__usage_value) => {
                         ::std::option::Option::Some(::std::option::Option::Some(#one))
                     }
@@ -3429,18 +3773,18 @@ fn field_final(field: &Field) -> TokenStream {
                     }
                     ::std::option::Option::None => ::std::option::Option::None,
                 }
-            }
+            })
         }
         Shape::Optional => {
             let one = converted(quote!(__usage_value));
-            quote! {
-                #ident: match partial.#ident {
+            finished(quote! {
+                match partial.#ident {
                     ::std::option::Option::Some(__usage_value) => {
                         ::std::option::Option::Some(#one)
                     }
                     ::std::option::Option::None => ::std::option::Option::None,
                 }
-            }
+            })
         }
         Shape::Many => {
             let one = converted(quote!(__usage_value));
@@ -3468,15 +3812,15 @@ fn field_final(field: &Field) -> TokenStream {
                 let defaulted = !field.default.is_empty();
                 // `Option<Vec<T>>` distinguishes "never given" from "given nothing", which
                 // no `Vec` can — so the answer comes from whether anything arrived.
-                quote! {
-                    #ident: if partial.#given || #defaulted || !partial.#ident.is_empty() {
+                finished(quote! {
+                    if partial.#given || #defaulted || !partial.#ident.is_empty() {
                         ::std::option::Option::Some(#collected)
                     } else {
                         ::std::option::Option::None
                     }
-                }
+                })
             } else {
-                quote!(#ident: #collected)
+                finished(collected)
             }
         }
     }
@@ -3799,6 +4143,10 @@ struct SubcommandParts {
     check: TokenStream,
     /// Building the field.
     build: TokenStream,
+    /// Building the field while an executable view omits injected parents.
+    view_build: TokenStream,
+    /// The process entry point's concrete view build.
+    default_view_build: TokenStream,
 }
 
 fn subcommand_parts(cli: &Cli) -> Option<SubcommandParts> {
@@ -3814,29 +4162,43 @@ fn subcommand_parts(cli: &Cli) -> Option<SubcommandParts> {
         quote!(ROOT)
     };
 
-    let selected = quote! {
-        match partial.__usage_selected {
-            ::std::option::Option::Some(__usage_at) => {
+    let selected = |omitter: Option<TokenStream>| {
+        let select = match omitter {
+            Some(omitter) => quote! {
+                <#ty as usage_argv::spec::ViewSubcommands<#omitter>>::select_for_view(
+                    partial.__usage_sub,
+                    __usage_at,
+                )?
+            },
+            None => quote! {
                 <#ty as usage_argv::spec::Subcommands>::select(
                     partial.__usage_sub,
                     __usage_at,
                 )?
+            },
+        };
+        quote! {
+            match partial.__usage_selected {
+                ::std::option::Option::Some(__usage_at) => #select,
+                ::std::option::Option::None => ::std::option::Option::None,
             }
-            ::std::option::Option::None => ::std::option::Option::None,
         }
     };
-    let build = if optional {
-        quote!(#ident: #selected,)
-    } else {
-        quote! {
-            #ident: match #selected {
-                ::std::option::Option::Some(__usage_cmd) => __usage_cmd,
-                ::std::option::Option::None => {
-                    return ::std::result::Result::Err(
-                        usage_argv::Error::MissingSubcommand,
-                    );
-                }
-            },
+    let build = |omitter: Option<TokenStream>| {
+        let selected = selected(omitter);
+        if optional {
+            quote!(#ident: #selected,)
+        } else {
+            quote! {
+                #ident: match #selected {
+                    ::std::option::Option::Some(__usage_cmd) => __usage_cmd,
+                    ::std::option::Option::None => {
+                        return ::std::result::Result::Err(
+                            usage_argv::Error::MissingSubcommand,
+                        );
+                    }
+                },
+            }
         }
     };
 
@@ -3954,13 +4316,26 @@ fn subcommand_parts(cli: &Cli) -> Option<SubcommandParts> {
         },
         check: quote! {
             if let ::std::option::Option::Some(__usage_at) = partial.__usage_selected {
-                <#ty as usage_argv::spec::Subcommands>::check(
-                    &mut partial.__usage_sub,
-                    __usage_at,
-                )?;
+                match __usage_view {
+                    ::std::option::Option::Some(__usage_view) => {
+                        <#ty as usage_argv::spec::Subcommands>::check_for_view_path(
+                            &mut partial.__usage_sub,
+                            __usage_at,
+                            __usage_view.root.split_ascii_whitespace().count(),
+                        )?;
+                    }
+                    ::std::option::Option::None => {
+                        <#ty as usage_argv::spec::Subcommands>::check(
+                            &mut partial.__usage_sub,
+                            __usage_at,
+                        )?;
+                    }
+                }
             }
         },
-        build,
+        build: build(None),
+        view_build: build(Some(quote!(__UsageOmitter))),
+        default_view_build: build(Some(quote!(usage_argv::spec::DefaultViewOmitter))),
     })
 }
 
@@ -3976,8 +4351,8 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
         .any(|field| field.validate.is_some())
         .then(|| quote!(use #validation as usage_validation;));
     let presence = presence_methods(cli);
-    let apply_defaults = declared_defaults(cli);
-    let apply_env = env_fallbacks(cli);
+    let apply_defaults = declared_defaults(cli, true);
+    let apply_env = env_fallbacks(cli, true);
     // A group carries settings the same way a root does, minus the layer: `SettingGiven` is
     // usage-argv's own vocabulary, so a flattened group can hand its parent what it was given
     // without either of them naming the config crate. Emitted whenever it has anything to say —
@@ -4102,6 +4477,10 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
         .unwrap_or_default();
     let sub_metas = parts.as_ref().map(|p| p.metas.clone()).unwrap_or_default();
     let sub_build = parts.as_ref().map(|p| p.build.clone()).unwrap_or_default();
+    let sub_view_build = parts
+        .as_ref()
+        .map(|p| p.view_build.clone())
+        .unwrap_or_default();
     // The same conversion the root gets. Two emitters producing one `build` is what let
     // this diverge: a typed field on a subcommand compiled here and not there, which is
     // every command mise has.
@@ -4109,9 +4488,97 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
         .fields
         .iter()
         .filter(|f| !matches!(f.kind, Kind::Subcommand { .. }))
-        .map(field_final)
+        .map(|field| field_final(field, None))
         .collect();
     let built = built_value(cli, &sub_build, &field_finals);
+    let view_omitter = quote!(__UsageOmitter);
+    let view_field_finals: Vec<_> = cli
+        .fields
+        .iter()
+        .filter(|f| !matches!(f.kind, Kind::Subcommand { .. }))
+        .map(|field| field_final(field, Some(&view_omitter)))
+        .collect();
+    let built_for_view = built_value(cli, &sub_view_build, &view_field_finals);
+    let view_bounds: Vec<_> = cli
+        .fields
+        .iter()
+        .map(|field| match &field.kind {
+            Kind::Flatten { ty } => {
+                quote!(#ty: usage_argv::spec::ViewCommandArgs<__UsageOmitter>)
+            }
+            Kind::Subcommand { ty, .. } => {
+                quote!(#ty: usage_argv::spec::ViewSubcommands<__UsageOmitter>)
+            }
+            _ => {
+                let ty = &field.ty;
+                quote!(__UsageOmitter: usage_argv::spec::Omitted<#ty>)
+            }
+        })
+        .collect();
+    let view_where = (!view_bounds.is_empty()).then(|| quote!(where #(#view_bounds,)*));
+
+    let view_path_methods = cli
+        .fields
+        .iter()
+        .find_map(|field| {
+            let Kind::Subcommand { ty, .. } = &field.kind else {
+                return None;
+            };
+            Some(quote! {
+                fn apply_env_for_view_path(
+                    partial: &mut Self::Partial,
+                    remaining_descendants: usize,
+                ) {
+                    if remaining_descendants == 0 {
+                        <Self as usage_argv::spec::CommandArgs>::apply_env(partial);
+                    } else if let ::std::option::Option::Some(__usage_at) =
+                        partial.__usage_selected
+                    {
+                        <#ty as usage_argv::spec::Subcommands>::apply_env_for_view_path(
+                            &mut partial.__usage_sub,
+                            ::std::option::Option::Some(__usage_at),
+                            remaining_descendants,
+                        );
+                    }
+                }
+
+                fn check_for_view_path<'t, 'v>(
+                    partial: &mut Self::Partial,
+                    remaining_descendants: usize,
+                ) -> ::std::result::Result<(), usage_argv::Error<'t, 'v>> {
+                    if remaining_descendants == 0 {
+                        <Self as usage_argv::spec::CommandArgs>::check(partial)
+                    } else if let ::std::option::Option::Some(__usage_at) =
+                        partial.__usage_selected
+                    {
+                        <Self as usage_argv::spec::CommandArgs>::omit_own_for_view(partial);
+                        <#ty as usage_argv::spec::Subcommands>::check_for_view_path(
+                            &mut partial.__usage_sub,
+                            __usage_at,
+                            remaining_descendants,
+                        )
+                    } else {
+                        ::std::result::Result::Ok(())
+                    }
+                }
+            })
+        })
+        .unwrap_or_default();
+    let omit_flattened = cli.fields.iter().filter_map(|field| {
+        let Kind::Flatten { ty } = &field.kind else {
+            return None;
+        };
+        let ident = &field.ident;
+        Some(quote! {
+            <#ty as usage_argv::spec::CommandArgs>::omit_own_for_view(&mut partial.#ident);
+        })
+    });
+    let omit_own = quote! {
+        fn omit_own_for_view(partial: &mut Self::Partial) {
+            partial.__usage_omit_own = true;
+            #(#omit_flattened)*
+        }
+    };
 
     // The root cannot carry one — the spec writer asserts it — so this is the non-root
     // path's alone, which is also the only path a command's own declaration reaches.
@@ -4223,16 +4690,31 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
             /// Separate from `build` because only the *selected* command's
             /// requirements apply: a flag that `install` requires says nothing about
             /// an invocation that ran `run`.
-            pub fn check_with_args_override_self<'t, 'v>(
+            fn check_with_args_override_self_for_view<'t, 'v>(
                 partial: &mut Partial,
                 args_override_self: bool,
+                __usage_view: ::std::option::Option<
+                    &'static usage_argv::spec::ViewMeta<'static>,
+                >,
             ) -> ::std::result::Result<(), usage_argv::Error<'t, 'v>> {
+                partial.__usage_view = __usage_view;
                 // Read unconditionally: a command that declares nothing to check would
                 // otherwise leave the parameter unused in the user's crate, where
                 // nobody can silence it.
                 let _ = &partial;
                 #post
                 ::std::result::Result::Ok(())
+            }
+
+            pub fn check_with_args_override_self<'t, 'v>(
+                partial: &mut Partial,
+                args_override_self: bool,
+            ) -> ::std::result::Result<(), usage_argv::Error<'t, 'v>> {
+                check_with_args_override_self_for_view(
+                    partial,
+                    args_override_self,
+                    ::std::option::Option::None,
+                )
             }
 
             pub fn check<'t, 'v>(
@@ -4281,15 +4763,52 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
                     check_with_args_override_self(partial, args_override_self)
                 }
 
+                fn check_with_args_override_self_for_view<'t, 'v>(
+                    partial: &mut Self::Partial,
+                    args_override_self: bool,
+                    view: ::std::option::Option<
+                        &'static usage_argv::spec::ViewMeta<'static>,
+                    >,
+                ) -> ::std::result::Result<(), usage_argv::Error<'t, 'v>> {
+                    check_with_args_override_self_for_view(partial, args_override_self, view)
+                }
+
                 #presence
 
                 fn apply_defaults(partial: &mut Self::Partial) {
+                    let __usage_view: ::std::option::Option<
+                        &'static usage_argv::spec::ViewMeta<'static>,
+                    > = ::std::option::Option::None;
+                    #apply_defaults
+                }
+
+                fn apply_defaults_for_view(
+                    partial: &mut Self::Partial,
+                    __usage_view: ::std::option::Option<
+                        &'static usage_argv::spec::ViewMeta<'static>,
+                    >,
+                ) {
                     #apply_defaults
                 }
 
                 fn apply_env(partial: &mut Self::Partial) {
+                    let __usage_view: ::std::option::Option<
+                        &'static usage_argv::spec::ViewMeta<'static>,
+                    > = ::std::option::Option::None;
                     #apply_env
                 }
+
+                fn apply_env_for_view(
+                    partial: &mut Self::Partial,
+                    __usage_view: ::std::option::Option<
+                        &'static usage_argv::spec::ViewMeta<'static>,
+                    >,
+                ) {
+                    #apply_env
+                }
+
+                #view_path_methods
+                #omit_own
 
                 #settings_impl
 
@@ -4297,6 +4816,17 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
                     partial: Self::Partial,
                 ) -> ::std::result::Result<Self, usage_argv::Error<'t, 'v>> {
                     ::std::result::Result::Ok(#built)
+                }
+            }
+
+            impl<__UsageOmitter> usage_argv::spec::ViewCommandArgs<__UsageOmitter>
+                for #ident
+                #view_where
+            {
+                fn build_for_view<'t, 'v>(
+                    partial: Self::Partial,
+                ) -> ::std::result::Result<Self, usage_argv::Error<'t, 'v>> {
+                    ::std::result::Result::Ok(#built_for_view)
                 }
             }
         };
@@ -4698,6 +5228,29 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
             }
         }
     });
+    let view_checks = subs.variants.iter().enumerate().map(|(i, v)| {
+        let variant = format_ident!("V{i}");
+        if v.external {
+            quote! { #i => ::std::result::Result::Ok(()), }
+        } else {
+            let ty = &v.ty;
+            quote! {
+                #i => match partial {
+                    Partial::#variant(__usage_p) => {
+                        if remaining_commands <= 1 {
+                            <#ty as usage_argv::spec::CommandArgs>::check(__usage_p)
+                        } else {
+                            <#ty as usage_argv::spec::CommandArgs>::check_for_view_path(
+                                __usage_p,
+                                remaining_commands - 1,
+                            )
+                        }
+                    }
+                    _ => ::std::result::Result::Ok(()),
+                },
+            }
+        }
+    });
     // Every variant's bindings, because a table says what the CLI *can* do and is compared
     // against a spec that documents all of them — but only the selected variant's values, since
     // those are about one invocation. A command nobody ran did not give anything.
@@ -4782,133 +5335,177 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
             }
         }
     });
-    let selects = subs.variants.iter().enumerate().map(|(i, v)| {
-        let held = format_ident!("V{i}");
-        let variant = &v.ident;
+    let view_apply_envs = subs.variants.iter().enumerate().map(|(i, v)| {
+        let variant = format_ident!("V{i}");
         if v.external {
-            let name = &v.name;
-            let collected = if v.external_os {
-                quote! {{
-                    let mut __usage_values = ::std::vec::Vec::with_capacity(__usage_p.len());
-                    for __usage_item in __usage_p {
-                        match usage_argv::os_string_from_bytes(__usage_item) {
-                            ::std::result::Result::Ok(__usage_os) => {
-                                __usage_values.push(__usage_os)
-                            }
-                            ::std::result::Result::Err(__usage_bytes) => {
-                                return ::std::result::Result::Err(
-                                    usage_argv::Error::InvalidValue(::std::boxed::Box::new(
-                                        usage_argv::InvalidValue {
-                                            name: #name,
-                                            value: ::std::string::String::from_utf8_lossy(
-                                                &__usage_bytes,
-                                            )
-                                            .into_owned(),
-                                            reason: ::std::string::ToString::to_string(
-                                                &"this platform cannot hold these bytes",
-                                            ),
-                                        },
-                                    )),
-                                );
-                            }
-                        }
-                    }
-                    __usage_values
-                }}
-            } else {
-                quote! {{
-                    let mut __usage_values = ::std::vec::Vec::with_capacity(__usage_p.len());
-                    for __usage_item in __usage_p {
-                        match ::std::string::String::from_utf8(__usage_item) {
-                            ::std::result::Result::Ok(__usage_text) => {
-                                __usage_values.push(__usage_text)
-                            }
-                            ::std::result::Result::Err(__usage_bad) => {
-                                return ::std::result::Result::Err(
-                                    usage_argv::Error::InvalidValue(::std::boxed::Box::new(
-                                        usage_argv::InvalidValue {
-                                            name: #name,
-                                            value: ::std::string::String::from_utf8_lossy(
-                                                __usage_bad.as_bytes(),
-                                            )
-                                            .into_owned(),
-                                            reason: ::std::string::ToString::to_string(
-                                                &__usage_bad.utf8_error(),
-                                            ),
-                                        },
-                                    )),
-                                );
-                            }
-                        }
-                    }
-                    __usage_values
-                }}
-            };
-            let made = quote!(#ident::#variant(#collected));
-            quote! {
-                #i => match partial {
-                    Partial::#held(__usage_p) => {
-                        ::std::result::Result::Ok(::std::option::Option::Some(#made))
-                    }
-                    _ => ::std::result::Result::Ok(::std::option::Option::None),
-                },
-            }
+            quote! { ::std::option::Option::Some(#i) => {} }
         } else {
             let ty = &v.ty;
-            // The one place the box matters: everything else — tables, partial, `build` —
-            // speaks to the struct itself.
-            let built = quote!(<#ty as usage_argv::spec::CommandArgs>::build(__usage_p)?);
-            let built = if v.boxed {
-                quote!(::std::boxed::Box::new(#built))
-            } else {
-                built
-            };
-            // A bare variant has nowhere to put what was built, and nothing was declared to go in
-            // it — but the build still runs, because that is where the command's own checks live.
-            let made = if v.unit {
-                quote! {{
-                    let _ = #built;
-                    #ident::#variant
-                }}
-            } else if let Some(fields) = &v.inline_fields {
-                let assignments = fields.iter().map(|field| {
-                    let name = field
-                        .ident
-                        .as_ref()
-                        .expect("named variant fields have names");
-                    let cfg_attrs = field
-                        .attrs
-                        .iter()
-                        .filter(|attr| meta_controls_field_presence(&attr.meta));
-                    quote! {
-                        #(#cfg_attrs)*
-                        #name: __usage_built.#name
-                    }
-                });
-                quote! {{
-                    let __usage_built = #built;
-                    // An empty named variant, or one whose fields were all removed by cfg,
-                    // still has to run `build` for the command's checks. Mark the result used
-                    // without changing the field moves below.
-                    let _ = &__usage_built;
-                    #ident::#variant {
-                        #(#assignments),*
-                    }
-                }}
-            } else {
-                quote!(#ident::#variant(#built))
-            };
             quote! {
-                #i => match partial {
-                    Partial::#held(__usage_p) => {
-                        ::std::result::Result::Ok(::std::option::Option::Some(#made))
+                ::std::option::Option::Some(#i) => {
+                    if let Partial::#variant(__usage_p) = partial {
+                        if remaining_commands <= 1 {
+                            <#ty as usage_argv::spec::CommandArgs>::apply_env(__usage_p);
+                        } else {
+                            <#ty as usage_argv::spec::CommandArgs>::apply_env_for_view_path(
+                                __usage_p,
+                                remaining_commands - 1,
+                            );
+                        }
                     }
-                    // Selected but unfilled cannot happen — see `Subcommands::begin`.
-                    _ => ::std::result::Result::Ok(::std::option::Option::None),
-                },
+                }
             }
         }
     });
+    let select_arms = |for_view: bool| {
+        subs.variants.iter().enumerate().map(move |(i, v)| {
+            let held = format_ident!("V{i}");
+            let variant = &v.ident;
+            if v.external {
+                let name = &v.name;
+                let collected = if v.external_os {
+                    quote! {{
+                        let mut __usage_values = ::std::vec::Vec::with_capacity(__usage_p.len());
+                        for __usage_item in __usage_p {
+                            match usage_argv::os_string_from_bytes(__usage_item) {
+                                ::std::result::Result::Ok(__usage_os) => {
+                                    __usage_values.push(__usage_os)
+                                }
+                                ::std::result::Result::Err(__usage_bytes) => {
+                                    return ::std::result::Result::Err(
+                                        usage_argv::Error::InvalidValue(::std::boxed::Box::new(
+                                            usage_argv::InvalidValue {
+                                                name: #name,
+                                                value: ::std::string::String::from_utf8_lossy(
+                                                    &__usage_bytes,
+                                                )
+                                                .into_owned(),
+                                                reason: ::std::string::ToString::to_string(
+                                                    &"this platform cannot hold these bytes",
+                                                ),
+                                            },
+                                        )),
+                                    );
+                                }
+                            }
+                        }
+                        __usage_values
+                    }}
+                } else {
+                    quote! {{
+                        let mut __usage_values = ::std::vec::Vec::with_capacity(__usage_p.len());
+                        for __usage_item in __usage_p {
+                            match ::std::string::String::from_utf8(__usage_item) {
+                                ::std::result::Result::Ok(__usage_text) => {
+                                    __usage_values.push(__usage_text)
+                                }
+                                ::std::result::Result::Err(__usage_bad) => {
+                                    return ::std::result::Result::Err(
+                                        usage_argv::Error::InvalidValue(::std::boxed::Box::new(
+                                            usage_argv::InvalidValue {
+                                                name: #name,
+                                                value: ::std::string::String::from_utf8_lossy(
+                                                    __usage_bad.as_bytes(),
+                                                )
+                                                .into_owned(),
+                                                reason: ::std::string::ToString::to_string(
+                                                    &__usage_bad.utf8_error(),
+                                                ),
+                                            },
+                                        )),
+                                    );
+                                }
+                            }
+                        }
+                        __usage_values
+                    }}
+                };
+                let made = quote!(#ident::#variant(#collected));
+                quote! {
+                    #i => match partial {
+                        Partial::#held(__usage_p) => {
+                            ::std::result::Result::Ok(::std::option::Option::Some(#made))
+                        }
+                        _ => ::std::result::Result::Ok(::std::option::Option::None),
+                    },
+                }
+            } else {
+                let ty = &v.ty;
+                // The one place the box matters: everything else — tables, partial, `build` —
+                // speaks to the struct itself.
+                let built = if for_view {
+                    quote!(
+                        <#ty as usage_argv::spec::ViewCommandArgs<__UsageOmitter>>::build_for_view(
+                            __usage_p,
+                        )?
+                    )
+                } else {
+                    quote!(<#ty as usage_argv::spec::CommandArgs>::build(__usage_p)?)
+                };
+                let built = if v.boxed {
+                    quote!(::std::boxed::Box::new(#built))
+                } else {
+                    built
+                };
+                // A bare variant has nowhere to put what was built, and nothing was declared to go in
+                // it — but the build still runs, because that is where the command's own checks live.
+                let made = if v.unit {
+                    quote! {{
+                        let _ = #built;
+                        #ident::#variant
+                    }}
+                } else if let Some(fields) = &v.inline_fields {
+                    let assignments = fields.iter().map(|field| {
+                        let name = field
+                            .ident
+                            .as_ref()
+                            .expect("named variant fields have names");
+                        let cfg_attrs = field
+                            .attrs
+                            .iter()
+                            .filter(|attr| meta_controls_field_presence(&attr.meta));
+                        quote! {
+                            #(#cfg_attrs)*
+                            #name: __usage_built.#name
+                        }
+                    });
+                    quote! {{
+                        let __usage_built = #built;
+                        // An empty named variant, or one whose fields were all removed by cfg,
+                        // still has to run `build` for the command's checks. Mark the result used
+                        // without changing the field moves below.
+                        let _ = &__usage_built;
+                        #ident::#variant {
+                            #(#assignments),*
+                        }
+                    }}
+                } else {
+                    quote!(#ident::#variant(#built))
+                };
+                quote! {
+                    #i => match partial {
+                        Partial::#held(__usage_p) => {
+                            ::std::result::Result::Ok(::std::option::Option::Some(#made))
+                        }
+                        // Selected but unfilled cannot happen — see `Subcommands::begin`.
+                        _ => ::std::result::Result::Ok(::std::option::Option::None),
+                    },
+                }
+            }
+        })
+    };
+    let selects = select_arms(false);
+    let view_selects = select_arms(true);
+    let view_bounds: Vec<_> = subs
+        .variants
+        .iter()
+        .filter(|v| !v.external)
+        .map(|v| {
+            let ty = &v.ty;
+            quote!(#ty: usage_argv::spec::ViewCommandArgs<__UsageOmitter>)
+        })
+        .collect();
+    let view_where = (!view_bounds.is_empty()).then(|| quote!(where #(#view_bounds,)*));
 
     quote! {
         // Beside the enum rather than inside the generated module: the variants name these
@@ -5027,6 +5624,17 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
                     }
                 }
 
+                fn apply_env_for_view_path(
+                    partial: &mut Self::Partial,
+                    selected: ::std::option::Option<usize>,
+                    remaining_commands: usize,
+                ) {
+                    match selected {
+                        #(#view_apply_envs)*
+                        _ => {}
+                    }
+                }
+
                 fn check<'t, 'v>(
                     partial: &mut Self::Partial,
                     selected: usize,
@@ -5035,6 +5643,17 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
                         #(#checks)*
                         // A position that is not one of these cannot be produced: it comes
                         // from finding a table's own address in COMMANDS.
+                        _ => ::std::result::Result::Ok(()),
+                    }
+                }
+
+                fn check_for_view_path<'t, 'v>(
+                    partial: &mut Self::Partial,
+                    selected: usize,
+                    remaining_commands: usize,
+                ) -> ::std::result::Result<(), usage_argv::Error<'t, 'v>> {
+                    match selected {
+                        #(#view_checks)*
                         _ => ::std::result::Result::Ok(()),
                     }
                 }
@@ -5048,6 +5667,24 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
                 > {
                     match selected {
                         #(#selects)*
+                        _ => ::std::result::Result::Ok(::std::option::Option::None),
+                    }
+                }
+            }
+
+            impl<__UsageOmitter> usage_argv::spec::ViewSubcommands<__UsageOmitter>
+                for #ident
+                #view_where
+            {
+                fn select_for_view<'t, 'v>(
+                    partial: Self::Partial,
+                    selected: usize,
+                ) -> ::std::result::Result<
+                    ::std::option::Option<Self>,
+                    usage_argv::Error<'t, 'v>,
+                > {
+                    match selected {
+                        #(#view_selects)*
                         _ => ::std::result::Result::Ok(::std::option::Option::None),
                     }
                 }
@@ -5227,7 +5864,7 @@ fn group_meta_table(cli: &Cli) -> (TokenStream, TokenStream) {
 /// Separate from the rest of `check` because exclusivity suppresses requiredness, not values a
 /// CLI promised to provide by default. A parent can therefore prepare an opaque flattened partial
 /// without also asking it to report a missing sibling.
-fn declared_defaults(cli: &Cli) -> TokenStream {
+fn declared_defaults(cli: &Cli, filter_view: bool) -> TokenStream {
     let own = cli.fields.iter().filter_map(|f| {
         if matches!(f.kind, Kind::Subcommand { .. } | Kind::Skip) {
             return None;
@@ -5256,8 +5893,14 @@ fn declared_defaults(cli: &Cli) -> TokenStream {
                 #assign
             }));
         }
+        let active = if filter_view {
+            let active = view_field_active(f);
+            quote!((#active) &&)
+        } else {
+            quote!()
+        };
         Some(quote! {
-            if !partial.#given #standing {
+            if #active !partial.#given #standing {
                 let mut __usage_filled = false;
                 #(#fills)*
             }
@@ -5268,8 +5911,17 @@ fn declared_defaults(cli: &Cli) -> TokenStream {
             return None;
         };
         let ident = &f.ident;
-        Some(quote! {
-            <#ty as usage_argv::spec::CommandArgs>::apply_defaults(&mut partial.#ident);
+        Some(if filter_view {
+            quote! {
+                <#ty as usage_argv::spec::CommandArgs>::apply_defaults_for_view(
+                    &mut partial.#ident,
+                    __usage_view,
+                );
+            }
+        } else {
+            quote! {
+                <#ty as usage_argv::spec::CommandArgs>::apply_defaults(&mut partial.#ident);
+            }
         })
     });
     quote! {
@@ -5282,7 +5934,7 @@ fn declared_defaults(cli: &Cli) -> TokenStream {
 ///
 /// Kept separate from the rest of post-binding validation because a parent must apply these
 /// before it can enforce a relationship whose other side lives across a flatten boundary.
-fn env_fallbacks(cli: &Cli) -> TokenStream {
+fn env_fallbacks(cli: &Cli, filter_view: bool) -> TokenStream {
     let own = cli.fields.iter().filter_map(|f| {
         let ident = &f.ident;
         let given = format_ident!("__given_{}", ident);
@@ -5341,8 +5993,14 @@ fn env_fallbacks(cli: &Cli) -> TokenStream {
         // A flag that lost an override is not merely unset: filling it from the
         // environment would undo the last-one-wins the command line asked for.
         let standing = displaced_guard(cli, f);
+        let active = if filter_view {
+            let active = view_field_active(f);
+            quote!((#active) &&)
+        } else {
+            quote!()
+        };
         Some(quote! {
-            if !partial.#given #standing {
+            if #active !partial.#given #standing {
                 for __usage_env in [#(#vars),*] {
                     if let ::std::result::Result::Ok(value) = ::std::env::var(__usage_env) {
                         let mut continue_unset = false;
@@ -5361,19 +6019,48 @@ fn env_fallbacks(cli: &Cli) -> TokenStream {
             return None;
         };
         let ident = &f.ident;
-        Some(quote! {
-            <#ty as usage_argv::spec::CommandArgs>::apply_env(&mut partial.#ident);
+        Some(if filter_view {
+            quote! {
+                <#ty as usage_argv::spec::CommandArgs>::apply_env_for_view(
+                    &mut partial.#ident,
+                    __usage_view,
+                );
+            }
+        } else {
+            quote! {
+                <#ty as usage_argv::spec::CommandArgs>::apply_env(&mut partial.#ident);
+            }
         })
     });
     let selected = cli.fields.iter().find_map(|f| {
         let Kind::Subcommand { ty, .. } = &f.kind else {
             return None;
         };
-        Some(quote! {
-            <#ty as usage_argv::spec::Subcommands>::apply_env(
-                &mut partial.__usage_sub,
-                partial.__usage_selected,
-            );
+        Some(if filter_view {
+            quote! {
+                match __usage_view {
+                    ::std::option::Option::Some(__usage_view) => {
+                        <#ty as usage_argv::spec::Subcommands>::apply_env_for_view_path(
+                            &mut partial.__usage_sub,
+                            partial.__usage_selected,
+                            __usage_view.root.split_ascii_whitespace().count(),
+                        );
+                    }
+                    ::std::option::Option::None => {
+                        <#ty as usage_argv::spec::Subcommands>::apply_env(
+                            &mut partial.__usage_sub,
+                            partial.__usage_selected,
+                        );
+                    }
+                }
+            }
+        } else {
+            quote! {
+                <#ty as usage_argv::spec::Subcommands>::apply_env(
+                    &mut partial.__usage_sub,
+                    partial.__usage_selected,
+                );
+            }
         })
     });
     quote! {
@@ -5390,6 +6077,10 @@ fn env_fallbacks(cli: &Cli) -> TokenStream {
 /// come last, because they judge a value however it arrived, including one that came
 /// from the environment or a default.
 fn post_binding(cli: &Cli) -> TokenStream {
+    // Shadow the general presence helper in this generator only. A projected executable
+    // validates carried root globals; policy on every other root field belongs to the
+    // surface the view omitted. Selected commands run their own checker with no view.
+    let policy_given = view_policy_given;
     let sub_check = subcommand_parts(cli).map(|p| p.check).unwrap_or_default();
     let subcommand_satisfies_requirements = if cli.subcommand_negates_reqs
         && cli
@@ -5453,9 +6144,10 @@ fn post_binding(cli: &Cli) -> TokenStream {
                 || <#ty as usage_argv::spec::CommandArgs>::exclusive_given(&partial.#ident)
                     .is_some()
             {
-                <#ty as usage_argv::spec::CommandArgs>::check_with_args_override_self(
+                <#ty as usage_argv::spec::CommandArgs>::check_with_args_override_self_for_view(
                     &mut partial.#ident,
                     args_override_self,
+                    __usage_view,
                 )?;
             }
         })
@@ -5481,9 +6173,9 @@ fn post_binding(cli: &Cli) -> TokenStream {
     // which is the CLI's size leaking into the invocation. `check` runs for the selected
     // command only. The helper also prepares flattened defaults before an exclusive flag can
     // suppress those groups' requiredness checks.
-    let declared_defaults = declared_defaults(cli);
+    let declared_defaults = declared_defaults(cli, true);
 
-    let env_fallbacks = env_fallbacks(cli);
+    let env_fallbacks = env_fallbacks(cli, true);
 
     let required_checks = cli.fields.iter().filter_map(|f| {
         // A `String` has nowhere to put "absent", so the type is the declaration; a collection
@@ -5501,12 +6193,13 @@ fn post_binding(cli: &Cli) -> TokenStream {
             return None;
         }
         let given = format_ident!("__given_{}", f.ident);
+        let active = view_field_active(f);
         let name = &f.name;
         // Same reason as the environment: a displaced flag was answered by the one that
         // displaced it, so it is not missing.
         let standing = displaced_guard(cli, f);
         Some(quote! {
-            if !partial.#given #standing {
+            if #active && !partial.#given #standing {
                 return ::std::result::Result::Err(
                     usage_argv::Error::MissingRequired { name: #name },
                 );
@@ -5547,9 +6240,11 @@ fn post_binding(cli: &Cli) -> TokenStream {
             // Rejected in the model: there is no value to check.
             Shape::Bool | Shape::Count => return None,
         };
+        let active = view_field_active(f);
         Some(quote! {
-            for value in #values {
-                // Compared as text, since a choice is a word.
+            if #active {
+                for value in #values {
+                    // Compared as text, since a choice is a word.
                 //
                 // Bytes that are not UTF-8 are passed over rather than reported here. They
                 // are not any of the choices, but saying so would answer the wrong question:
@@ -5557,17 +6252,18 @@ fn post_binding(cli: &Cli) -> TokenStream {
                 // alone, it reaches `build`, which reports the UTF-8 failure with the value
                 // in it. Comparing the empty string instead — which is what `unwrap_or_default`
                 // did — made every such value collide with the choices check first.
-                let ::std::result::Result::Ok(__usage_text) = ::std::str::from_utf8(value)
-                else {
-                    continue;
-                };
-                if !usage_argv::spec::choice_matches(#accepted_choices, __usage_text, #ignore_case) {
-                    return ::std::result::Result::Err(
-                        usage_argv::Error::InvalidChoice {
-                            name: #name,
-                            choices: #choices,
-                        },
-                    );
+                    let ::std::result::Result::Ok(__usage_text) = ::std::str::from_utf8(value)
+                    else {
+                        continue;
+                    };
+                    if !usage_argv::spec::choice_matches(#accepted_choices, __usage_text, #ignore_case) {
+                        return ::std::result::Result::Err(
+                            usage_argv::Error::InvalidChoice {
+                                name: #name,
+                                choices: #choices,
+                            },
+                        );
+                    }
                 }
             }
         })
@@ -5587,30 +6283,33 @@ fn post_binding(cli: &Cli) -> TokenStream {
             Shape::Many => quote!(partial.#ident.iter()),
             Shape::Bool | Shape::Count => return None,
         };
+        let active = view_field_active(f);
         Some(quote! {
-            for value in #values {
-                let ::std::result::Result::Ok(__usage_text) = ::std::str::from_utf8(value)
-                else {
+            if #active {
+                for value in #values {
+                    let ::std::result::Result::Ok(__usage_text) = ::std::str::from_utf8(value)
+                    else {
                     // The field conversion reports non-UTF-8 with the original bytes. An expr
                     // variable is text, so claiming the validation failed would hide that more
                     // precise error.
-                    continue;
-                };
-                let __usage_reason = match usage_validation::validate(#expression, __usage_text) {
-                    ::std::result::Result::Ok(true) => continue,
-                    ::std::result::Result::Ok(false) => #message.to_string(),
-                    ::std::result::Result::Err(error) =>
-                        ::std::format!("validation expression failed: {error}"),
-                };
-                return ::std::result::Result::Err(
-                    usage_argv::Error::InvalidValue(::std::boxed::Box::new(
-                        usage_argv::InvalidValue {
-                            name: #name,
-                            value: __usage_text.to_string(),
-                            reason: __usage_reason,
-                        },
-                    )),
-                );
+                        continue;
+                    };
+                    let __usage_reason = match usage_validation::validate(#expression, __usage_text) {
+                        ::std::result::Result::Ok(true) => continue,
+                        ::std::result::Result::Ok(false) => #message.to_string(),
+                        ::std::result::Result::Err(error) =>
+                            ::std::format!("validation expression failed: {error}"),
+                    };
+                    return ::std::result::Result::Err(
+                        usage_argv::Error::InvalidValue(::std::boxed::Box::new(
+                            usage_argv::InvalidValue {
+                                name: #name,
+                                value: __usage_text.to_string(),
+                                reason: __usage_reason,
+                            },
+                        )),
+                    );
+                }
             }
         })
     });
@@ -5662,12 +6361,13 @@ fn post_binding(cli: &Cli) -> TokenStream {
             None => quote!(),
         };
         let given = format_ident!("__given_{}", ident);
+        let active = view_field_active(f);
         Some(quote! {
             // Only when the field was used. A bound says "if you give values, give
             // this many" — reading an unused optional flag as a violation would make
             // `var_min` a second way to spell required-ness, and there would then be
             // no way to say "at least two, if you use it at all".
-            if partial.#given {
+            if #active && partial.#given {
                 let got = partial.#ident.len();
                 #min
                 #max
@@ -6023,9 +6723,6 @@ fn post_binding(cli: &Cli) -> TokenStream {
                 .filter_map(|selector| cli.field_for_selector(selector))
                 .collect();
             let given: Vec<TokenStream> = fields.iter().map(|f| policy_given(f)).collect();
-            // A member with a default always has a value, so the group can never be
-            // unsatisfied. Decided here rather than at run time, as `requires` is.
-            let always_filled = fields.iter().any(|f| !f.default.is_empty());
             let exclusivity = (!multiple).then(|| {
                 // Reported as the first two that were given, which is the pair the user has
                 // to choose between. `ConflictingFlags` rather than a group-shaped error:
@@ -6054,14 +6751,49 @@ fn post_binding(cli: &Cli) -> TokenStream {
                 });
                 quote!(#(#pairs)*)
             });
-            let requiredness = (required && !always_filled).then(|| {
+            let requiredness = required.then(|| {
                 let selectors = &members;
+                let active: Vec<TokenStream> =
+                    fields.iter().map(|f| view_field_active(f)).collect();
+                let view_members = cli.views.iter().map(|view| {
+                    let id = &view.id;
+                    let carried: Vec<&String> = fields
+                        .iter()
+                        .zip(&members)
+                        .filter_map(|(field, selector)| {
+                            field_active_in_view(field, view).then_some(selector)
+                        })
+                        .collect();
+                    quote!(#id => &[#(#carried),*])
+                });
+                let filled: Vec<TokenStream> = fields
+                    .iter()
+                    .zip(&given)
+                    .zip(&active)
+                    .map(|((field, given), active)| {
+                        if field.default.is_empty() {
+                            quote!((#active) && (#given))
+                        } else {
+                            quote!(#active)
+                        }
+                    })
+                    .collect();
                 quote! {
-                    if !(#(#given)||*) {
+                    if (#(#active)||*) && !(#(#filled)||*) {
+                        let __usage_group_members: &'static [&'static str] =
+                            match __usage_view {
+                                ::std::option::Option::None => &[#(#selectors),*],
+                                ::std::option::Option::Some(__usage_group_view) => {
+                                    match __usage_group_view.id {
+                                        #(#view_members,)*
+                                        _ => &[#(#selectors),*],
+                                    }
+                                }
+                            };
                         return ::std::result::Result::Err(
                             usage_argv::Error::MissingGroup {
                                 group: #name,
-                                members: &[#(#selectors),*],
+                                members: __usage_group_members,
                             },
                         );
                     }
@@ -6099,6 +6831,7 @@ fn post_binding(cli: &Cli) -> TokenStream {
             return None;
         }
         let given = format_ident!("__given_{}", f.ident);
+        let active = view_field_active(f);
         let name = &f.name;
         let selector_given = |selector: &String| {
             Some(match cli.field_for_selector(selector) {
@@ -6190,7 +6923,7 @@ fn post_binding(cli: &Cli) -> TokenStream {
                 }
             });
         Some(quote! {
-            if !partial.#given {
+            if #active && !partial.#given {
                 #required_if
                 #required_if_eq
                 #required_if_eq_all

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -167,6 +167,8 @@ pub struct Cli {
     /// properties live here, because a group that says nothing but "these three are
     /// exclusive" should not need declaring twice.
     pub groups: Vec<GroupDecl>,
+    /// Spec-declared executable views promoted from subcommands.
+    pub views: Vec<ViewDecl>,
     pub fields: Vec<Field>,
 }
 
@@ -183,6 +185,15 @@ pub struct GroupDecl {
     /// than replacing `Field::group`, because clap lets one field belong to both
     /// its Args group and an explicitly named group.
     pub members: Vec<String>,
+}
+
+pub struct ViewDecl {
+    pub id: String,
+    pub name: String,
+    pub bin: String,
+    pub root: String,
+    pub all_globals: bool,
+    pub globals: Vec<String>,
 }
 
 /// One field, resolved to the thing it declares.
@@ -689,6 +700,7 @@ impl Cli {
             restart_token: None,
             mount: None,
             groups: Vec::new(),
+            views: Vec::new(),
             fields: Vec::new(),
         };
 
@@ -904,6 +916,33 @@ impl Cli {
                     "restart_token" => cli.restart_token = Some(string_value(&meta)?),
                     "mount" => cli.mount = Some(string_value(&meta)?),
                     "group" => cli.groups.push(group_decl(&meta)?),
+                    "view" => {
+                        let view = view_decl(&meta)?;
+                        if cli.views.iter().any(|declared| declared.id == view.id) {
+                            return Err(syn::Error::new_spanned(
+                                &meta,
+                                format!("a view named `{}` is already declared", view.id),
+                            ));
+                        }
+                        if let Some(declared) = cli.views.iter().find(|declared| {
+                            [declared.id.as_str(), declared.bin.as_str()]
+                                .iter()
+                                .any(|prior| {
+                                    [view.id.as_str(), view.bin.as_str()].iter().any(|current| {
+                                        program_basename(prior) == program_basename(current)
+                                    })
+                                })
+                        }) {
+                            return Err(syn::Error::new_spanned(
+                                &meta,
+                                format!(
+                                    "view `{}` and view `{}` collide after executable basename normalization in the identifier and executable namespaces",
+                                    declared.id, view.id,
+                                ),
+                            ));
+                        }
+                        cli.views.push(view);
+                    }
                     "rename_all" => cli.rename_all = Some(CasingStyle::parse(&meta)?),
                     "rename_all_env" => cli.rename_all_env = CasingStyle::parse(&meta)?,
                     other => {
@@ -915,7 +954,7 @@ impl Cli {
                                  `default_subcommand`, `multicall`, `no_binary_name`, `arg_required_else_help`, `disable_help_flag`, `disable_help_subcommand`, `disable_version_flag`, `dont_delimit_trailing_values`, `args_override_self`, `subcommand_negates_reqs`, `args_conflicts_with_subcommands`, `subcommand_precedence_over_arg`, `allow_missing_positional`, \
                                  `next_help_heading`, `subcommand_help_heading`, `next_line_help`, `flatten_help`, `term_width`, `max_term_width`, \
                                  `subcommand_value_name`, `restart_token`, `mount` and \
-                                 `group` here, and the description comes from the doc \
+                                 `group` and `view` here, and the description comes from the doc \
                                  comment"
                             ),
                         ));
@@ -1007,6 +1046,25 @@ impl Cli {
                 cli.name = bin.clone();
             }
             cli.runtime_name = cli.runtime_bin.clone();
+        }
+        for view in &cli.views {
+            let host_name = program_basename(&cli.name);
+            let host_bin = cli.bin.as_deref().map(program_basename);
+            if [view.id.as_str(), view.bin.as_str()]
+                .iter()
+                .any(|selector| {
+                    let selector = program_basename(selector);
+                    selector == host_name || host_bin.is_some_and(|bin| selector == bin)
+                })
+            {
+                return Err(syn::Error::new_spanned(
+                    &input.ident,
+                    format!(
+                        "view `{}` uses the host command's name or bin as an executable selector",
+                        view.id
+                    ),
+                ));
+            }
         }
         cli.check()?;
         Ok(cli)
@@ -1120,6 +1178,12 @@ impl Cli {
                     ident,
                     "`no_binary_name` belongs on the root, where `#[derive(Cli)]` is: it \
                      selects the input contract of the whole CLI's clap-shaped parser",
+                ));
+            }
+            if !self.views.is_empty() {
+                return Err(self.misplaced(
+                    ident,
+                    "`view(...)` belongs on the root, where `#[derive(Cli)]` is: executable views project commands from the whole emitted spec, and nested `Args` do not emit a spec",
                 ));
             }
             return Ok(());
@@ -3643,6 +3707,80 @@ fn group_decl(meta: &Meta) -> syn::Result<GroupDecl> {
     Ok(decl)
 }
 
+fn program_basename(program: &str) -> &str {
+    let basename = program.rsplit(['/', '\\']).next().unwrap_or(program);
+    match basename.get(basename.len().saturating_sub(4)..) {
+        Some(extension) if extension.eq_ignore_ascii_case(".exe") => {
+            &basename[..basename.len() - 4]
+        }
+        _ => basename,
+    }
+}
+
+/// `view("aubr", root = "run", globals)` promotes `run` to the executable surface
+/// named `aubr`. `global = "--flag"` may be repeated instead of carrying all globals.
+fn view_decl(meta: &Meta) -> syn::Result<ViewDecl> {
+    let Meta::List(list) = meta else {
+        return Err(syn::Error::new_spanned(
+            meta,
+            "a view is declared as `view(\"aubr\", root = \"run\", globals)`",
+        ));
+    };
+    list.parse_args_with(|input: syn::parse::ParseStream| {
+        let id: syn::LitStr = input.parse()?;
+        let mut view = ViewDecl {
+            id: id.value(),
+            name: id.value(),
+            bin: id.value(),
+            root: String::new(),
+            all_globals: false,
+            globals: Vec::new(),
+        };
+        while !input.is_empty() {
+            input.parse::<syn::Token![,]>()?;
+            if input.is_empty() {
+                break;
+            }
+            let property: syn::Ident = input.parse()?;
+            let property_name = property.to_string();
+            if property_name == "globals" && !input.peek(syn::Token![=]) {
+                view.all_globals = true;
+                continue;
+            }
+            input.parse::<syn::Token![=]>()?;
+            let value: syn::LitStr = input.parse()?;
+            match property_name.as_str() {
+                "name" => view.name = value.value(),
+                "bin" => view.bin = value.value(),
+                "root" => view.root = value.value(),
+                "global" => view.globals.push(value.value()),
+                other => {
+                    return Err(syn::Error::new_spanned(
+                        property,
+                        format!(
+                            "unknown view property `{other}`; a view takes `name`, `bin`, \
+                             `root`, bare `globals`, and repeated `global = \"--flag\"`"
+                        ),
+                    ));
+                }
+            }
+        }
+        if view.id.is_empty() || view.name.is_empty() || view.bin.is_empty() {
+            return Err(syn::Error::new_spanned(
+                id,
+                "a view's identifier, name, and bin cannot be empty",
+            ));
+        }
+        if view.root.trim().is_empty() {
+            return Err(syn::Error::new_spanned(
+                meta,
+                "a view needs `root = \"command path\"`",
+            ));
+        }
+        Ok(view)
+    })
+}
+
 fn clap_group_default(attr: &Attribute, ident: &syn::Ident) -> GroupDecl {
     GroupDecl {
         name: ident.unraw().to_string(),
@@ -5383,6 +5521,76 @@ mod tests {
                 double_dash: DoubleDash::Required
             }
         ));
+    }
+
+    #[test]
+    fn executable_views_are_declared_on_the_root() {
+        let parsed = cli(r#"
+            #[usage(
+                view("aubr", root = "run", globals),
+                view("aubx", name = "Aube Execute", root = "dlx", global = "--quiet")
+            )]
+            struct Ex {}
+        "#)
+        .unwrap();
+
+        assert_eq!(parsed.views.len(), 2);
+        assert_eq!(parsed.views[0].id, "aubr");
+        assert_eq!(parsed.views[0].root, "run");
+        assert!(parsed.views[0].all_globals);
+        assert_eq!(parsed.views[1].name, "Aube Execute");
+        assert_eq!(parsed.views[1].globals, ["--quiet"]);
+    }
+
+    #[test]
+    fn executable_views_are_rejected_on_nested_args() {
+        let err = position_error(
+            r#"
+            #[usage(view("runner", root = "run"))]
+            struct Nested {}
+            "#,
+            false,
+        );
+        assert!(err.contains("`view(...)` belongs on the root"), "{err}");
+    }
+
+    #[test]
+    fn executable_view_identifiers_and_bins_share_one_dispatch_namespace() {
+        let err = rejection(
+            r#"
+            #[usage(
+                view("runner", bin = "run-bin", root = "run"),
+                view("other", bin = "runner", root = "other")
+            )]
+            struct Ex {}
+        "#,
+        );
+        assert!(
+            err.contains("identifier and executable namespaces"),
+            "{err}"
+        );
+
+        let err = rejection(
+            r#"
+            #[usage(
+                view("first", bin = "runner", root = "run"),
+                view("second", bin = "/tmp/runner.exe", root = "other")
+            )]
+            struct Ex {}
+        "#,
+        );
+        assert!(err.contains("basename normalization"), "{err}");
+    }
+
+    #[test]
+    fn executable_views_cannot_capture_the_host_program() {
+        for declaration in [
+            r#"#[usage(name = "host", view("host", root = "run"))]"#,
+            r#"#[usage(bin = "host", view("view", bin = "/tmp/host.exe", root = "run"))]"#,
+        ] {
+            let err = rejection(&format!("{declaration} struct Host {{}}"));
+            assert!(err.contains("host command's name or bin"), "{err}");
+        }
     }
 
     #[test]

--- a/docs/cli/reference/commands.json
+++ b/docs/cli/reference/commands.json
@@ -644,7 +644,7 @@
           },
           "json": {
             "full_cmd": ["generate", "json"],
-            "usage": "generate json [-f --file <FILE>] [--spec <SPEC>]",
+            "usage": "generate json [FLAGS]",
             "subcommands": {},
             "args": [],
             "flags": [
@@ -683,6 +683,23 @@
                   "hide": false
                 },
                 "overrides": ["--file"]
+              },
+              {
+                "name": "view",
+                "usage": "--view <VIEW>",
+                "help": "Render one spec-declared executable view",
+                "help_first_line": "Render one spec-declared executable view",
+                "short": [],
+                "long": ["view"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "VIEW",
+                  "usage": "<VIEW>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false
+                }
               }
             ],
             "mounts": [],
@@ -833,6 +850,23 @@
                 }
               },
               {
+                "name": "view",
+                "usage": "--view <VIEW>",
+                "help": "Render one spec-declared executable view",
+                "help_first_line": "Render one spec-declared executable view",
+                "short": [],
+                "long": ["view"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "VIEW",
+                  "usage": "<VIEW>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false
+                }
+              },
+              {
                 "name": "out-file",
                 "usage": "-o --out-file <OUT_FILE>",
                 "help": "Output file path, or \"-\" for stdout (default)",
@@ -906,6 +940,23 @@
                 "arg": {
                   "name": "FILE",
                   "usage": "<FILE>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false
+                }
+              },
+              {
+                "name": "view",
+                "usage": "--view <VIEW>",
+                "help": "Render one spec-declared executable view",
+                "help_first_line": "Render one spec-declared executable view",
+                "short": [],
+                "long": ["view"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "VIEW",
+                  "usage": "<VIEW>",
                   "required": true,
                   "double_dash": "Optional",
                   "hide": false

--- a/docs/cli/reference/generate.md
+++ b/docs/cli/reference/generate.md
@@ -15,7 +15,7 @@ Generate completions, documentation, and other artifacts from usage specs
 - [`usage generate completion-init [--usage-bin <USAGE_BIN>] <SHELL>`](/cli/reference/generate/completion-init.md)
 - [`usage generate fig [FLAGS]`](/cli/reference/generate/fig.md)
 - [`usage generate go [FLAGS]`](/cli/reference/generate/go.md)
-- [`usage generate json [-f --file <FILE>] [--spec <SPEC>]`](/cli/reference/generate/json.md)
+- [`usage generate json [FLAGS]`](/cli/reference/generate/json.md)
 - [`usage generate json-schema [FLAGS]`](/cli/reference/generate/json-schema.md)
 - [`usage generate manpage <FLAGS>`](/cli/reference/generate/manpage.md)
 - [`usage generate markdown <FLAGS>`](/cli/reference/generate/markdown.md)

--- a/docs/cli/reference/generate/json.md
+++ b/docs/cli/reference/generate/json.md
@@ -2,7 +2,7 @@
 
 # `usage generate json`
 
-- **Usage**: `usage generate json [-f --file <FILE>] [--spec <SPEC>]`
+- **Usage**: `usage generate json [FLAGS]`
 - **Effect**: read-only
 - **Source code**: [`cli/src/cli/generate/json.rs`](https://github.com/jdx/usage/blob/main/cli/src/cli/generate/json.rs)
 
@@ -17,3 +17,7 @@ A usage spec taken in as a file, use "-" to read from stdin
 ### `--spec <SPEC>`
 
 raw string spec input
+
+### `--view <VIEW>`
+
+Render one spec-declared executable view

--- a/docs/cli/reference/generate/manpage.md
+++ b/docs/cli/reference/generate/manpage.md
@@ -15,6 +15,10 @@ Generate a manpage from a usage spec
 
 A usage spec taken in as a file, use "-" to read from stdin
 
+### `--view <VIEW>`
+
+Render one spec-declared executable view
+
 ### `-o --out-file <OUT_FILE>`
 
 **Effect**: modifies state

--- a/docs/cli/reference/generate/markdown.md
+++ b/docs/cli/reference/generate/markdown.md
@@ -15,6 +15,10 @@ Generate markdown documentation from usage specs
 
 A usage spec taken in as a file, use "-" to read from stdin
 
+### `--view <VIEW>`
+
+Render one spec-declared executable view
+
 ### `-m --multi`
 
 Render each subcommand as a separate markdown file

--- a/docs/cli/reference/index.md
+++ b/docs/cli/reference/index.md
@@ -31,7 +31,7 @@ Outputs a `usage.kdl` spec for this CLI itself
 - [`usage generate completion-init [--usage-bin <USAGE_BIN>] <SHELL>`](/cli/reference/generate/completion-init.md)
 - [`usage generate fig [FLAGS]`](/cli/reference/generate/fig.md)
 - [`usage generate go [FLAGS]`](/cli/reference/generate/go.md)
-- [`usage generate json [-f --file <FILE>] [--spec <SPEC>]`](/cli/reference/generate/json.md)
+- [`usage generate json [FLAGS]`](/cli/reference/generate/json.md)
 - [`usage generate json-schema [FLAGS]`](/cli/reference/generate/json-schema.md)
 - [`usage generate manpage <FLAGS>`](/cli/reference/generate/manpage.md)
 - [`usage generate markdown <FLAGS>`](/cli/reference/generate/markdown.md)

--- a/docs/rust/args-and-flags.md
+++ b/docs/rust/args-and-flags.md
@@ -245,6 +245,7 @@ On the root `#[derive(Cli)]` struct:
 | `unknown_flags = "value"\|"error"`  | Treat unknown flags as values instead of errors                |
 | `default_subcommand = "run"`        | Command to assume when argv names none                         |
 | `multicall`                         | Treat argv[0]'s basename as a subcommand (busybox-style)       |
+| `view("bin", root = "command")`     | Promote a command as another executable surface                |
 | `completion`                        | Generate completion support ([Completions](/rust/completions)) |
 | `settings`                          | Generate config-settings bindings                              |
 | `min_usage_version = "…"`           | Declare the minimum usage version the spec needs               |

--- a/docs/rust/subcommands.md
+++ b/docs/rust/subcommands.md
@@ -86,6 +86,28 @@ struct Busybox {
 A symlink `ls -> busybox` runs the `ls` variant. `busybox ls` still does too: the
 dispatcher name is skipped. Path components and a trailing `.exe` are stripped.
 
+## Executable views
+
+Use a view when an installed executable should expose one command as its root rather than merely
+selecting a multicall subcommand:
+
+```rust
+#[derive(Cli)]
+#[usage(
+    bin = "aube",
+    completion,
+    view("aubr", root = "run", globals),
+    view("aubx", root = "dlx", global = "--config")
+)]
+struct Aube { /* … */ }
+```
+
+`parse()` and `parse_from_argv()` select the view from argv0 and route directly to its command.
+`to_kdl()` emits portable `view` nodes. With completion support enabled,
+`completion_script_for("aubr", shell)` emits the script registered for that executable, and its
+requests are completed from the promoted command. `global = "--flag"` may be repeated; bare
+`globals` carries every root global.
+
 ## External subcommands
 
 clap's `#[command(external_subcommand)]` is a catch-all variant that holds the unmatched

--- a/docs/spec/reference/index.md
+++ b/docs/spec/reference/index.md
@@ -50,6 +50,30 @@ cmd "cat"
 clap exposes this as `Command::multicall` / `#[command(multicall = true)]`, and
 the bridge reads `is_multicall_set`.
 
+## Executable views
+
+A `view` promotes a command path into a separately named executable surface. It is useful when
+one binary is installed under several names but an applet is more than multicall dispatch: its
+help, docs, and completions should begin at that command and may carry root globals.
+
+```kdl
+name "Aube"
+bin "aube"
+flag "-v --verbose" global=#true
+flag "--config <FILE>" global=#true
+view "aubr" root="run" globals=#true
+view "aubx" name="Aube Execute" root="dlx" {
+  global "--config"
+}
+cmd "run"
+cmd "dlx"
+```
+
+The first string is the stable view identifier and defaults both `name` and `bin`. `root` is a
+space-separated command path. `globals=#true` carries every root global; `global` children carry
+only the named root globals. Generators accept a view explicitly (`usage g markdown --view aubr`)
+or, for completions, select it when the requested binary matches the view's `bin`.
+
 ## Repository
 
 The URL of the CLI's source repository:

--- a/lib/src/complete/mod.rs
+++ b/lib/src/complete/mod.rs
@@ -41,6 +41,28 @@ pub struct CompleteOptions {
 /// - `zsh` - Zsh completion using `compdef`
 /// - `powershell` - PowerShell completion using `Register-ArgumentCompleter`
 pub fn complete(options: &CompleteOptions) -> Result<String, UsageErr> {
+    let viewed;
+    let effective;
+    let options = if let Some((spec, view)) = options
+        .spec
+        .as_ref()
+        .and_then(|spec| spec.view_for_program(&options.bin).map(|view| (spec, view)))
+    {
+        viewed = spec.for_view(view)?;
+        effective = CompleteOptions {
+            usage_bin: options.usage_bin.clone(),
+            shell: options.shell.clone(),
+            bin: options.bin.clone(),
+            cache_key: options.cache_key.clone(),
+            spec: Some(viewed),
+            usage_cmd: options.usage_cmd.clone(),
+            include_bash_completion_lib: options.include_bash_completion_lib,
+            source_file: options.source_file.clone(),
+        };
+        &effective
+    } else {
+        options
+    };
     match options.shell.as_str() {
         "bash" => Ok(bash::complete_bash(options)),
         "fish" => Ok(fish::complete_fish(options)),

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -117,6 +117,9 @@ pub enum UsageErr {
     #[error("Invalid file path: {0}")]
     InvalidPath(String),
 
+    #[error("Invalid spec view: {0}")]
+    InvalidView(String),
+
     #[error("Invalid value for {name}: {value}: {reason}")]
     InvalidValue {
         name: String,

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -13,6 +13,7 @@ pub use crate::spec::flag::{SpecDefaultIf, SpecFlag, SpecFlagAction, SpecRequire
 pub use crate::spec::group::SpecGroup;
 pub use crate::spec::mount::SpecMount;
 pub use crate::spec::unknown_flags::UnknownFlags;
+pub use crate::spec::view::SpecView;
 pub use crate::spec::Spec;
 
 #[macro_use]

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -680,6 +680,10 @@ fn parse_partial_with_env(
     mount_outputs: Option<&HashMap<String, String>>,
     mount_timing: MountTiming,
 ) -> Result<(ParseOutput, HashSet<String>), miette::Error> {
+    if let Some(view) = input.first().and_then(|argv0| spec.view_for_program(argv0)) {
+        let viewed = spec.for_view(view)?;
+        return parse_partial_with_env(&viewed, input, custom_env, mount_outputs, mount_timing);
+    }
     trace!("parse_partial: {input:?}");
     let mut input = input.iter().cloned().collect::<VecDeque<_>>();
     let argv0 = input.pop_front();
@@ -3293,6 +3297,51 @@ mod tests {
             return value;
         }
         panic!("expected first parsed value to be ParseValue::String");
+    }
+
+    #[test]
+    fn custom_environment_parser_dispatches_executable_views() {
+        let spec: Spec = r#"
+bin "ex"
+view "runner" root="run"
+cmd "run" {
+    flag "--token <token>" env="TOKEN"
+}
+        "#
+        .parse()
+        .unwrap();
+        let parsed = Parser::new(&spec)
+            .with_env([("TOKEN".to_string(), "secret".to_string())].into())
+            .parse(&input(&["runner"]))
+            .unwrap();
+
+        assert_eq!(parsed.cmd.name, "runner");
+        assert!(parsed.flags.iter().any(|(flag, value)| flag.name == "token"
+            && matches!(value, ParseValue::String(value) if value == "secret")));
+    }
+
+    #[test]
+    fn an_executable_view_keeps_the_hosts_version_action() {
+        let spec: Spec = r#"
+bin "ex"
+version "1.2.3"
+flag "-V --version" action="version"
+flag "--verbose" global=#true
+view "runner" root="run" globals=#true
+cmd "run"
+        "#
+        .parse()
+        .unwrap();
+
+        let error = Parser::new(&spec)
+            .parse(&input(&["runner", "--version"]))
+            .expect_err("the host version action should answer before view projection");
+        assert_eq!(error.to_string(), "1.2.3");
+
+        let error = Parser::new(&spec)
+            .parse(&input(&["runner", "--verbose", "--version"]))
+            .expect_err("the host version action should remain after a carried global");
+        assert_eq!(error.to_string(), "1.2.3");
     }
 
     fn flag_string_value<'a>(parsed: &'a ParseOutput, name: &str) -> &'a str {

--- a/lib/src/spec/mod.rs
+++ b/lib/src/spec/mod.rs
@@ -13,6 +13,7 @@ pub mod group;
 pub mod helpers;
 pub mod mount;
 pub mod unknown_flags;
+pub mod view;
 
 use indexmap::IndexMap;
 use kdl::{KdlDocument, KdlEntry, KdlNode};
@@ -31,6 +32,7 @@ use crate::spec::config::SpecConfig;
 use crate::spec::context::ParsingContext;
 use crate::spec::helpers::{string_entry, NodeHelper};
 use crate::{SpecArg, SpecComplete, SpecFlag};
+use view::SpecView;
 
 #[derive(Debug, Default, Clone, Serialize)]
 #[non_exhaustive]
@@ -45,6 +47,9 @@ pub struct Spec {
     pub long_version: Option<String>,
     pub usage: String,
     pub complete: IndexMap<String, SpecComplete>,
+    /// Named executable surfaces promoted from commands in this canonical spec.
+    #[serde(skip_serializing_if = "IndexMap::is_empty")]
+    pub views: IndexMap<String, SpecView>,
     /// Every file this spec was read from: its own path, then each `include`, recursively.
     ///
     /// What a build script has to watch. A generator that watches only the file it was pointed at
@@ -235,7 +240,175 @@ impl Spec {
             && self.cmd.is_empty()
             && self.config.is_empty()
             && self.complete.is_empty()
+            && self.views.is_empty()
             && self.examples.is_empty()
+    }
+
+    /// Materialize one declared executable view.
+    ///
+    /// This is a cold-path operation for documentation and completion generation. The canonical
+    /// spec remains unchanged; the returned spec promotes the view's command to the root and
+    /// carries only the root globals the view declares.
+    pub fn for_view(&self, id: &str) -> Result<Spec, UsageErr> {
+        let view = self
+            .views
+            .get(id)
+            .ok_or_else(|| UsageErr::InvalidView(format!("spec declares no view named `{id}`")))?;
+        let mut command = &self.cmd;
+        for segment in view.root.split_whitespace() {
+            command = command.subcommands.get(segment).ok_or_else(|| {
+                UsageErr::InvalidView(format!(
+                    "view `{id}` promotes `{}`, but `{segment}` is not a command on that path",
+                    view.root
+                ))
+            })?;
+        }
+        let mut promoted = command.clone();
+        let matches_selector = |flag: &SpecFlag, selector: &str| {
+            selector
+                .strip_prefix("--")
+                .is_some_and(|name| flag.long.iter().any(|long| long == name))
+                || selector
+                    .strip_prefix('-')
+                    .filter(|short| short.len() == 1)
+                    .and_then(|short| short.chars().next())
+                    .is_some_and(|short| flag.short.contains(&short))
+        };
+        let carries = |flag: &SpecFlag| {
+            if !flag.global {
+                return false;
+            }
+            view.all_globals
+                || view
+                    .globals
+                    .iter()
+                    .any(|selector| matches_selector(flag, selector))
+        };
+        for selector in &view.globals {
+            if !self
+                .cmd
+                .flags
+                .iter()
+                .any(|flag| flag.global && matches_selector(flag, selector))
+            {
+                return Err(UsageErr::InvalidView(format!(
+                    "view `{id}` carries `{selector}`, but it is not a root global flag"
+                )));
+            }
+        }
+        let globals: Vec<SpecFlag> = self
+            .cmd
+            .flags
+            .iter()
+            // A view is another executable surface of this package. Keep the host's
+            // version actions in addition to the globals explicitly carried by the view.
+            .filter(|flag| carries(flag) || flag.action == crate::SpecFlagAction::Version)
+            .cloned()
+            .collect();
+        // A promoted command may redeclare a global spelling. The nearer declaration owns it,
+        // matching ordinary parsing, so do not create a duplicate root flag.
+        let mut globals: Vec<SpecFlag> = globals
+            .into_iter()
+            .filter(|global| {
+                !promoted
+                    .flags
+                    .iter()
+                    .any(|local| spec_flag_forms_overlap(global, local))
+            })
+            .collect();
+        // Root completers belong to the host's fields, not to every executable view. Carry the
+        // ones for selected globals, then let the promoted command's own completers win on a
+        // shared name. A promoted command is the new root, so its command-scoped entries become
+        // the materialized spec's root entries rather than remaining in both places.
+        let mut complete = IndexMap::new();
+        for flag in &globals {
+            if let Some(arg) = &flag.arg {
+                let name = arg.name.to_lowercase();
+                if let Some(completer) = self.complete.get(&name) {
+                    complete.insert(name, completer.clone());
+                }
+            }
+        }
+        complete.extend(std::mem::take(&mut promoted.complete));
+        // Root groups are relationships between the root fields, so project them along with
+        // the carried globals. A group reduced to one required member is ordinary requiredness;
+        // keeping it as a one-member group would emit KDL the spec reader deliberately refuses.
+        let mut carried_groups = Vec::new();
+        for group in &self.cmd.groups {
+            let members: Vec<String> = group
+                .members
+                .iter()
+                .filter(|selector| {
+                    globals
+                        .iter()
+                        .any(|flag| flag_matches_selector(flag, selector))
+                })
+                .cloned()
+                .collect();
+            match members.as_slice() {
+                [only] if group.required => {
+                    if let Some(flag) = globals
+                        .iter_mut()
+                        .find(|flag| flag_matches_selector(flag, only))
+                    {
+                        flag.required = true;
+                    }
+                }
+                [_, _, ..] => {
+                    let mut projected = group.clone();
+                    projected.members = members;
+                    carried_groups.push(projected);
+                }
+                _ => {}
+            }
+        }
+        promoted.flags.splice(0..0, globals);
+        promoted.groups.splice(0..0, carried_groups);
+        promoted.name.clone_from(&view.bin);
+        promoted.full_cmd.clear();
+        promoted.aliases.clear();
+        promoted.hidden_aliases.clear();
+        // A view is another executable surface of the host package. Keep the host policy that
+        // governs its synthesized version entry along with the host version strings retained on
+        // `spec`; otherwise materializing a promoted command silently re-enables `--version`.
+        promoted.disable_version_flag = self.cmd.disable_version_flag;
+        set_subcommand_ancestors(&mut promoted, &[]);
+        promoted.usage = promoted.usage();
+
+        let mut spec = self.clone();
+        spec.name.clone_from(&view.name);
+        spec.bin.clone_from(&view.bin);
+        spec.about = promoted.help.clone();
+        spec.about_long = promoted.help_long.clone();
+        spec.about_md = promoted.help_md.clone();
+        spec.before_help = promoted.before_help.clone();
+        spec.before_help_long = promoted.before_help_long.clone();
+        spec.after_help = promoted.after_help.clone();
+        spec.after_help_long = promoted.after_help_long.clone();
+        spec.examples.clone_from(&promoted.examples);
+        spec.usage = promoted.usage.clone();
+        spec.complete = complete;
+        spec.cmd = promoted;
+        spec.default_subcommand = None;
+        spec.multicall = false;
+        spec.multicall_set = false;
+        spec.views.clear();
+        Ok(spec)
+    }
+
+    /// The stable identifier of the executable view selected by a program name.
+    pub fn view_for_program(&self, program: &str) -> Option<&str> {
+        let basename = crate::parse::multicall_basename(program);
+        if basename == crate::parse::multicall_basename(&self.name)
+            || (!self.bin.is_empty() && basename == crate::parse::multicall_basename(&self.bin))
+        {
+            return None;
+        }
+        self.views.values().find_map(|view| {
+            (basename == crate::parse::multicall_basename(&view.bin)
+                || basename == crate::parse::multicall_basename(&view.id))
+            .then_some(view.id.as_str())
+        })
     }
 
     pub(crate) fn parse(ctx: &ParsingContext, input: &str) -> Result<Spec, UsageErr> {
@@ -311,6 +484,16 @@ impl Spec {
                 "complete" => {
                     let complete = SpecComplete::parse(ctx, &node)?;
                     schema.complete.insert(complete.name.clone(), complete);
+                }
+                "view" => {
+                    let view = SpecView::parse(ctx, &node)?;
+                    if schema.views.insert(view.id.clone(), view).is_some() {
+                        bail_parse!(
+                            ctx,
+                            node.span(),
+                            "a view identifier may be declared only once"
+                        );
+                    }
                 }
                 "disable_help" => schema.disable_help = Some(node.arg(0)?.ensure_bool()?),
                 "min_usage_version" => {
@@ -498,6 +681,7 @@ impl Spec {
         }
         merge_opt!(unknown_flags);
         merge_extend!(complete);
+        merge_extend!(views);
         merge_extend!(examples);
         // An included spec brings the files *it* read, which is how a nested include is watched.
         merge_extend!(sources);
@@ -507,6 +691,48 @@ impl Spec {
         }
         self.cmd.merge(other.cmd);
     }
+}
+
+fn spec_flag_forms_overlap(a: &SpecFlag, b: &SpecFlag) -> bool {
+    fn long_forms(flag: &SpecFlag) -> impl Iterator<Item = &str> {
+        flag.long
+            .iter()
+            .chain(&flag.hidden_aliases)
+            .map(String::as_str)
+            .chain(
+                flag.negate
+                    .as_deref()
+                    .map(|name| name.strip_prefix("--").unwrap_or(name)),
+            )
+    }
+    fn short_forms(flag: &SpecFlag) -> impl Iterator<Item = &char> {
+        flag.short.iter().chain(&flag.hidden_short_aliases)
+    }
+
+    long_forms(a).any(|name| long_forms(b).any(|other| other == name))
+        || short_forms(a).any(|name| short_forms(b).any(|other| other == name))
+}
+
+fn flag_matches_selector(flag: &SpecFlag, selector: &str) -> bool {
+    selector.strip_prefix("--").is_some_and(|name| {
+        flag.long
+            .iter()
+            .chain(&flag.hidden_aliases)
+            .any(|long| long == name)
+            || flag
+                .negate
+                .as_deref()
+                .is_some_and(|negate| negate.strip_prefix("--").unwrap_or(negate) == name)
+    }) || selector
+        .strip_prefix('-')
+        .filter(|short| short.len() == 1)
+        .and_then(|short| short.chars().next())
+        .is_some_and(|short| {
+            flag.short
+                .iter()
+                .chain(&flag.hidden_short_aliases)
+                .any(|candidate| *candidate == short)
+        })
 }
 
 fn check_usage_version(version: &str) {
@@ -810,6 +1036,13 @@ impl Display for Spec {
         for complete in self.cmd.complete.values() {
             nodes.push(complete.into());
         }
+        for view in self.views.values() {
+            let rendered: KdlDocument = view
+                .to_string()
+                .parse()
+                .expect("a view always renders valid KDL");
+            nodes.extend(rendered.nodes().iter().cloned());
+        }
         for cmd in self.cmd.subcommands.values() {
             nodes.push(cmd.into())
         }
@@ -1039,6 +1272,190 @@ cmd "cat"
         );
         let again: Spec = emitted.parse().unwrap();
         assert!(again.multicall);
+    }
+
+    #[test]
+    fn a_declared_view_promotes_a_command_and_selected_globals() {
+        let spec: Spec = r#"
+name "aube"
+bin "aube"
+about_md "Host **markdown**"
+before_help "host before"
+before_long_help "host long before"
+after_help "host after"
+after_long_help "host long after"
+example "aube host" header="host example"
+flag "-v --verbose" global=#true
+flag "--config <FILE>" global=#true
+view "aubr" root="run" {
+  global "--verbose"
+}
+cmd "run" help="Run a package script" {
+  before_help "run before"
+  before_long_help "run long before"
+  after_help "run after"
+  after_long_help "run long after"
+  example "aubr task" header="run example"
+  flag "--if-present"
+  arg "[SCRIPT]"
+  cmd "nested"
+}
+"#
+        .parse()
+        .unwrap();
+
+        let rendered = spec.to_string();
+        assert!(rendered.contains("view aubr root=run"), "{rendered}");
+        let reparsed: Spec = rendered.parse().unwrap();
+        let applet = reparsed.for_view("aubr").unwrap();
+        assert_eq!(applet.name, "aubr");
+        assert_eq!(applet.bin, "aubr");
+        assert_eq!(applet.about.as_deref(), Some("Run a package script"));
+        assert_eq!(applet.about_md, None);
+        assert_eq!(applet.before_help.as_deref(), Some("run before"));
+        assert_eq!(applet.before_help_long.as_deref(), Some("run long before"));
+        assert_eq!(applet.after_help.as_deref(), Some("run after"));
+        assert_eq!(applet.after_help_long.as_deref(), Some("run long after"));
+        assert_eq!(applet.examples.len(), 1);
+        assert_eq!(applet.examples[0].header.as_deref(), Some("run example"));
+        assert!(applet.cmd.flags.iter().any(|flag| flag.name == "verbose"));
+        assert!(applet
+            .cmd
+            .flags
+            .iter()
+            .any(|flag| flag.name == "if-present"));
+        assert!(!applet.cmd.flags.iter().any(|flag| flag.name == "config"));
+        assert!(applet.cmd.subcommands.contains_key("nested"));
+        assert!(applet.views.is_empty());
+        assert!(applet.to_string().contains("bin aubr"));
+    }
+
+    #[test]
+    fn a_view_preserves_the_host_version_entry_policy() {
+        let spec: Spec = r#"
+bin "host"
+version "1.2.3"
+disable_version_flag #true
+view "runner" root=run
+cmd "run"
+"#
+        .parse()
+        .unwrap();
+
+        let view = spec.for_view("runner").unwrap();
+        assert!(view.cmd.disable_version_flag);
+        let emitted = view.to_string();
+        assert!(emitted.contains("disable_version_flag #true"), "{emitted}");
+        let reparsed: Spec = emitted.parse().unwrap();
+        assert!(reparsed.cmd.disable_version_flag);
+    }
+
+    #[test]
+    fn a_promoted_flag_shadows_every_carried_global_spelling() {
+        let spec: Spec = r#"
+bin "host"
+flag "--color" global=#true negate="--no-color"
+view "runner" root=run {
+  global "--color"
+}
+cmd "run" {
+  flag "--no-color"
+}
+"#
+        .parse()
+        .unwrap();
+
+        let view = spec.for_view("runner").unwrap();
+        assert_eq!(view.cmd.flags.len(), 1);
+        assert_eq!(view.cmd.flags[0].long, ["no-color"]);
+    }
+
+    #[test]
+    fn a_view_keeps_only_its_own_and_carried_global_completers() {
+        let spec: Spec = r#"
+bin "host"
+flag "--host <HOST>" global=#true
+flag "--carried <CARRIED>" global=#true
+complete "host" run="host candidates"
+complete "carried" run="carried candidates"
+view "runner" root=run {
+  global "--carried"
+}
+cmd "run" {
+  arg "<HOST>"
+  complete "host" run="view candidates"
+}
+"#
+        .parse()
+        .unwrap();
+
+        let view = spec.for_view("runner").unwrap();
+        assert_eq!(
+            view.complete.get("host").unwrap().run.as_deref(),
+            Some("view candidates")
+        );
+        assert_eq!(
+            view.complete.get("carried").unwrap().run.as_deref(),
+            Some("carried candidates")
+        );
+        assert!(view.cmd.complete.is_empty());
+        assert_eq!(view.complete.len(), 2);
+        assert_eq!(view.to_string().matches("complete ").count(), 2);
+    }
+
+    #[test]
+    fn a_view_projects_groups_of_carried_globals() {
+        let spec: Spec = r#"
+bin "host"
+flag "--json" global=#true
+flag "--yaml" global=#true
+flag "--toml" global=#true
+group "format" "--json" "--yaml" "--toml" required=#true
+view "all" root=run globals=#true
+view "json" root=run {
+  global "--json"
+}
+cmd "run"
+"#
+        .parse()
+        .unwrap();
+
+        let all = spec.for_view("all").unwrap();
+        assert_eq!(all.cmd.groups.len(), 1);
+        assert_eq!(all.cmd.groups[0].members, ["--json", "--yaml", "--toml"]);
+        assert!(all.to_string().parse::<Spec>().is_ok());
+
+        let json = spec.for_view("json").unwrap();
+        assert!(json.cmd.groups.is_empty());
+        assert!(
+            json.cmd
+                .flags
+                .iter()
+                .find(|flag| flag.name == "json")
+                .unwrap()
+                .required
+        );
+        assert!(json.to_string().parse::<Spec>().is_ok());
+    }
+
+    #[test]
+    fn a_view_refuses_unknown_commands_and_non_global_carryovers() {
+        let missing: Spec = "bin \"ex\"\nview \"x\" root=missing\n".parse().unwrap();
+        assert!(missing
+            .for_view("x")
+            .unwrap_err()
+            .to_string()
+            .contains("missing"));
+
+        let local: Spec =
+            "bin \"ex\"\nflag \"--local\"\nview \"x\" root=go { global \"--local\" }\ncmd go\n"
+                .parse()
+                .unwrap();
+        assert!(local
+            .for_view("x")
+            .unwrap_err()
+            .to_string()
+            .contains("not a root global"));
     }
 
     #[test]

--- a/lib/src/spec/view.rs
+++ b/lib/src/spec/view.rs
@@ -1,0 +1,106 @@
+use std::fmt::{Display, Formatter};
+
+use kdl::{KdlEntry, KdlNode};
+use serde::Serialize;
+
+use crate::error::Result;
+use crate::spec::context::ParsingContext;
+use crate::spec::helpers::{string_entry, NodeHelper};
+
+/// A named executable surface derived from one command in the canonical spec.
+///
+/// Multicall binaries use this to describe an applet without copying or mutating the
+/// generated command tree. `root` is a space-separated command path. Root global flags may be
+/// carried wholesale with `globals=#true`, or selected explicitly with `global` children.
+#[derive(Debug, Default, Clone, Serialize)]
+#[non_exhaustive]
+pub struct SpecView {
+    /// Stable identifier used to select the view.
+    pub id: String,
+    /// Program name shown in prose. Defaults to [`Self::id`].
+    pub name: String,
+    /// Executable name used in usage lines. Defaults to [`Self::name`].
+    pub bin: String,
+    /// Command path promoted to the view's root.
+    pub root: String,
+    /// Carry every root global into the promoted command.
+    pub all_globals: bool,
+    /// Root-global selectors to carry when [`Self::all_globals`] is false.
+    pub globals: Vec<String>,
+}
+
+impl SpecView {
+    pub(crate) fn parse(ctx: &ParsingContext, node: &NodeHelper<'_>) -> Result<Self> {
+        let id = node.arg(0)?.ensure_string()?;
+        let mut view = Self {
+            name: id.clone(),
+            bin: id.clone(),
+            id,
+            ..Self::default()
+        };
+        for (key, value) in node.props() {
+            match key {
+                "name" => view.name = value.ensure_string()?,
+                "bin" => view.bin = value.ensure_string()?,
+                "root" => view.root = value.ensure_string()?,
+                "globals" => view.all_globals = value.ensure_bool()?,
+                key => bail_parse!(ctx, value.entry.span(), "unsupported view key {key}"),
+            }
+        }
+        for child in node.children() {
+            match child.name() {
+                "global" => {
+                    for selector in child.args() {
+                        view.globals.push(selector.ensure_string()?);
+                    }
+                }
+                key => bail_parse!(
+                    ctx,
+                    child.node.name().span(),
+                    "unsupported view value {key}"
+                ),
+            }
+        }
+        if view.id.is_empty() {
+            bail_parse!(ctx, node.span(), "a view needs a non-empty identifier");
+        }
+        if view.name.is_empty() || view.bin.is_empty() {
+            bail_parse!(ctx, node.span(), "a view's name and bin cannot be empty");
+        }
+        if view.root.trim().is_empty() {
+            bail_parse!(
+                ctx,
+                node.span(),
+                "a view needs the command path it promotes in `root`"
+            );
+        }
+        Ok(view)
+    }
+}
+
+impl Display for SpecView {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut node = KdlNode::new("view");
+        node.push(string_entry(None, &self.id));
+        if self.name != self.id {
+            node.push(string_entry(Some("name"), &self.name));
+        }
+        if self.bin != self.name {
+            node.push(string_entry(Some("bin"), &self.bin));
+        }
+        node.push(string_entry(Some("root"), &self.root));
+        if self.all_globals {
+            node.push(KdlEntry::new_prop("globals", true));
+        }
+        if !self.globals.is_empty() {
+            let mut children = kdl::KdlDocument::new();
+            let mut global = KdlNode::new("global");
+            for selector in &self.globals {
+                global.push(string_entry(None, selector));
+            }
+            children.nodes_mut().push(global);
+            node.set_children(children);
+        }
+        write!(f, "{node}")
+    }
+}

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -16,6 +16,483 @@ struct Ex {
     command: Command,
 }
 
+#[derive(Cli)]
+#[usage(
+    bin = "view-host",
+    version = "1.2.3",
+    before_help = "HOST-ONLY SURROUNDING HELP",
+    unknown_flags = "error",
+    view(
+        "view-run",
+        root = "run",
+        global = "--verbose",
+        global = "--flat-required",
+        global = "--flat-default",
+        global = "--help-all"
+    )
+)]
+#[cfg_attr(feature = "completions", usage(completion))]
+struct ViewHost {
+    #[arg(long, global)]
+    root_token: String,
+    #[arg(long, global, required = true)]
+    verbose: bool,
+    #[arg(long, global)]
+    color: bool,
+    #[arg(long = "help-all", global, action = usage::ArgAction::HelpAll)]
+    help_all: bool,
+    #[command(flatten)]
+    view_globals: ViewGlobals,
+    #[arg(long)]
+    root_number: u32,
+    #[command(subcommand)]
+    command: ViewCommand,
+}
+
+#[derive(Args)]
+struct ViewGlobals {
+    #[arg(long, global, required = true)]
+    flat_required: bool,
+    #[arg(long, global, default_value = "carried")]
+    flat_default: String,
+    #[arg(long, global)]
+    flat_hidden: String,
+}
+
+#[derive(Subcommands)]
+enum ViewCommand {
+    /// Run one task.
+    Run {
+        #[arg(short = 'v', long)]
+        verbose: bool,
+        #[arg(long)]
+        dry_run: bool,
+        task: String,
+    },
+}
+
+#[test]
+fn executable_views_emit_and_dispatch_from_argv0() {
+    let kdl = ViewHost::to_kdl();
+    assert!(kdl.contains("view view-run root=run"), "{kdl}");
+    let portable: usage_parser::Spec = kdl.parse().expect("usage-lib should read the view");
+    let view = portable
+        .for_view("view-run")
+        .expect("the declared command should materialize");
+    assert_eq!(view.bin, "view-run");
+    assert_eq!(view.cmd.name, "view-run");
+    assert!(view.cmd.flags.iter().any(|flag| flag.name == "verbose"));
+
+    let parsed = ViewHost::parse_from_argv(&[
+        OsStr::new("/usr/local/bin/view-run"),
+        OsStr::new("--verbose"),
+        OsStr::new("--flat-required"),
+        OsStr::new("--dry-run"),
+        OsStr::new("build"),
+    ])
+    .expect("argv0 should promote the declared command");
+    assert_eq!(parsed.root_token, "");
+    assert!(parsed.verbose);
+    assert!(parsed.view_globals.flat_required);
+    assert_eq!(parsed.view_globals.flat_default, "carried");
+    assert_eq!(parsed.view_globals.flat_hidden, "");
+    assert_eq!(parsed.root_number, 0);
+    assert!(!parsed.color);
+    let ViewCommand::Run {
+        verbose,
+        dry_run,
+        task,
+    } = parsed.command;
+    assert!(verbose);
+    assert!(dry_run);
+    assert_eq!(task, "build");
+
+    assert!(matches!(
+        ViewHost::parse_from_argv(&[
+            OsStr::new("view-run"),
+            OsStr::new("--flat-required"),
+            OsStr::new("build")
+        ]),
+        Err(usage::Error::MissingRequired { name: "verbose" })
+    ));
+
+    assert!(matches!(
+        ViewHost::parse_from_argv(&[
+            OsStr::new("view-run"),
+            OsStr::new("--verbose"),
+            OsStr::new("build")
+        ]),
+        Err(usage::Error::MissingRequired {
+            name: "flat-required"
+        })
+    ));
+
+    let root_error = match ViewHost::parse_from(&[
+        OsStr::new("--flat-required"),
+        OsStr::new("run"),
+        OsStr::new("build"),
+    ]) {
+        Err(error) => error,
+        Ok(_) => panic!("the host root should enforce its required fields"),
+    };
+    assert!(
+        matches!(
+            root_error,
+            usage::Error::MissingRequired {
+                name: "flat-hidden"
+            }
+        ),
+        "{root_error:?}"
+    );
+
+    let help_argv = [OsStr::new("view-run"), OsStr::new("--help")];
+    let (cmd, long) =
+        match ViewHost::parse_from_argv(&[OsStr::new("view-run"), OsStr::new("--help")]) {
+            Err(usage::Error::Help { cmd, long }) => (cmd, long),
+            _ => panic!("the view should return the promoted command's help request"),
+        };
+    let route = usage::help::route_to_view(
+        ViewHost::command(),
+        &help_argv,
+        cmd,
+        &ViewHost::spec().views[0],
+    )
+    .expect("the injected route should be recoverable");
+    let page = usage::help::render_view_at_styled(
+        ViewHost::spec(),
+        &route,
+        &ViewHost::spec().views[0],
+        long,
+        usage::help::Style::PLAIN,
+    )
+    .expect("the view should have a help page");
+    assert!(page.contains("Usage: view-run"), "{page}");
+    assert!(!page.contains("view-host run"), "{page}");
+    assert!(page.contains("--verbose"), "{page}");
+    assert_eq!(page.matches("--verbose").count(), 1, "{page}");
+    assert!(!page.contains("--color"), "{page}");
+    assert!(!page.contains("HOST-ONLY SURROUNDING HELP"), "{page}");
+
+    assert!(matches!(
+        ViewHost::parse_from_argv(&[
+            OsStr::new("view-run"),
+            OsStr::new("--color"),
+            OsStr::new("build")
+        ]),
+        Err(usage::Error::UnknownFlag { .. })
+    ));
+
+    let bad_argv = [OsStr::new("view-run"), OsStr::new("--dry-ru")];
+    let error = match ViewHost::parse_from_argv(&[OsStr::new("view-run"), OsStr::new("--dry-ru")]) {
+        Err(error) => error,
+        Ok(_) => panic!("strict parsing should reject the misspelled view flag"),
+    };
+    let diagnostic = usage::render_failure_view(
+        ViewHost::spec(),
+        &bad_argv,
+        &error,
+        &ViewHost::spec().views[0],
+    );
+    assert!(diagnostic.contains("Usage: view-run"), "{diagnostic}");
+    assert!(!diagnostic.contains("view-host run"), "{diagnostic}");
+    assert!(diagnostic.contains("--dry-run"), "{diagnostic}");
+
+    let omitted_argv = [OsStr::new("view-run"), OsStr::new("--root-token")];
+    let omitted_error = match ViewHost::parse_from_argv(&omitted_argv) {
+        Err(error) => error,
+        Ok(_) => panic!("an omitted host global must remain outside the view"),
+    };
+    let omitted_diagnostic = usage::render_failure_view(
+        ViewHost::spec(),
+        &omitted_argv,
+        &omitted_error,
+        &ViewHost::spec().views[0],
+    );
+    assert_eq!(
+        omitted_diagnostic.matches("--root-token").count(),
+        1,
+        "an omitted host flag must not be suggested by view diagnostics: {omitted_diagnostic}"
+    );
+    assert!(
+        omitted_diagnostic.contains("Usage: view-run"),
+        "{omitted_diagnostic}"
+    );
+
+    let help_all_argv = [OsStr::new("view-run"), OsStr::new("--help-all")];
+    let help_all_cmd = match ViewHost::parse_from_argv(&help_all_argv) {
+        Err(usage::Error::HelpAll { cmd }) => cmd,
+        _ => panic!("the view should return recursive help"),
+    };
+    let route = usage::help::route_to_view(
+        ViewHost::command(),
+        &help_all_argv,
+        help_all_cmd,
+        &ViewHost::spec().views[0],
+    )
+    .expect("the view help-all route should be recoverable");
+    let all = usage::help::render_all_view_at_styled(
+        ViewHost::spec(),
+        &route,
+        &ViewHost::spec().views[0],
+        usage::help::Style::PLAIN,
+    )
+    .expect("the view should have recursive help");
+    assert!(all.contains("Usage: view-run"), "{all}");
+    assert!(!all.contains("view-host run"), "{all}");
+    assert!(!all.contains("HOST-ONLY SURROUNDING HELP"), "{all}");
+
+    assert!(matches!(
+        ViewHost::parse_from_argv(&[OsStr::new("view-run"), OsStr::new("--version")]),
+        Err(usage::Error::Version { long: true })
+    ));
+}
+
+#[cfg(feature = "completions")]
+#[test]
+fn executable_views_generate_scripts_for_their_binary() {
+    let script = ViewHost::completion_script_for("view-run", usage::complete::Shell::Bash)
+        .expect("the view is declared");
+    assert!(script.contains("view-run"), "{script}");
+
+    let answer = ViewHost::completion_request(&[
+        "__complete_word__".into(),
+        "--shell".into(),
+        "bash".into(),
+        "--line".into(),
+        "view-run --".into(),
+    ])
+    .expect("the hidden completion request should be recognized");
+    assert!(answer.contains("--dry-run"), "{answer}");
+    assert!(answer.contains("--verbose"), "{answer}");
+    assert!(answer.contains("--flat-required"), "{answer}");
+    assert!(!answer.contains("--color"), "{answer}");
+}
+
+#[derive(Cli)]
+#[usage(
+    bin = "nested-view-host",
+    unknown_flags = "error",
+    completion,
+    view("nested-run", root = "admin run")
+)]
+struct NestedViewHost {
+    #[command(flatten)]
+    host: NestedViewHostArgs,
+    #[command(subcommand)]
+    command: NestedViewTop,
+}
+
+#[derive(Args)]
+struct NestedViewHostArgs {
+    #[arg(long, complete = host_probe_words)]
+    probe: Option<String>,
+}
+
+#[cfg(feature = "completions")]
+fn host_probe_words(
+    _partial: &<NestedViewHostArgs as usage_argv::spec::CommandArgs>::Partial,
+    _ctx: &usage::complete::CompleteCtx<'_>,
+) -> Vec<usage::complete::Candidate<'static>> {
+    vec![usage::complete::Candidate::new("host-probe")]
+}
+
+#[derive(Subcommands)]
+enum NestedViewTop {
+    Admin(NestedViewAdmin),
+}
+
+#[derive(Args)]
+struct NestedViewAdmin {
+    #[arg(long, global)]
+    intermediate: bool,
+    #[arg(long)]
+    intermediate_required: String,
+    #[arg(long)]
+    intermediate_number: u32,
+    #[arg(long, default_value = "parent-default")]
+    intermediate_default: Option<String>,
+    #[arg(long, env = "PATH")]
+    intermediate_env: Option<String>,
+    #[command(subcommand)]
+    command: NestedViewAdminCommand,
+}
+
+#[derive(Subcommands)]
+enum NestedViewAdminCommand {
+    Run(NestedViewRun),
+}
+
+#[derive(Args)]
+struct NestedViewRun {
+    #[arg(long)]
+    leaf: bool,
+    #[arg(long, complete = nested_view_words)]
+    probe: Option<String>,
+}
+
+#[cfg(feature = "completions")]
+fn nested_view_words(
+    _partial: &<NestedViewRun as usage_argv::spec::CommandArgs>::Partial,
+    ctx: &usage::complete::CompleteCtx<'_>,
+) -> Vec<usage::complete::Candidate<'static>> {
+    vec![usage::complete::Candidate::new(format!(
+        "{}@{}",
+        ctx.words.join("|"),
+        ctx.cword
+    ))]
+}
+
+#[test]
+fn nested_views_drop_intermediate_command_globals() {
+    let parsed = NestedViewHost::parse_from_argv(&[OsStr::new("nested-run"), OsStr::new("--leaf")])
+        .expect("the promoted leaf command should parse");
+    let NestedViewTop::Admin(admin) = parsed.command;
+    assert!(!admin.intermediate);
+    assert_eq!(admin.intermediate_required, "");
+    assert_eq!(admin.intermediate_number, 0);
+    assert_eq!(admin.intermediate_default, None);
+    assert_eq!(admin.intermediate_env, None);
+    let NestedViewAdminCommand::Run(run) = admin.command;
+    assert!(run.leaf);
+    assert_eq!(run.probe, None);
+
+    assert!(matches!(
+        NestedViewHost::parse_from_argv(&[OsStr::new("nested-run"), OsStr::new("--intermediate")]),
+        Err(usage::Error::UnknownFlag { .. })
+    ));
+
+    let portable: usage_parser::Spec = NestedViewHost::to_kdl().parse().unwrap();
+    let view = portable.for_view("nested-run").unwrap();
+    assert!(!view
+        .cmd
+        .flags
+        .iter()
+        .any(|flag| flag.name == "intermediate"));
+}
+
+#[cfg(feature = "completions")]
+#[test]
+fn view_completers_receive_the_users_original_line() {
+    let answer = NestedViewHost::completion_request(&[
+        "__complete_word__".into(),
+        "--shell".into(),
+        "bash".into(),
+        "--line".into(),
+        "nested-run --probe ".into(),
+        "--candidates".into(),
+        "probe".into(),
+    ])
+    .expect("the hidden completion request should be recognized");
+    assert_eq!(answer, "nested-run|--probe|@2\n");
+}
+
+#[derive(Cli)]
+#[allow(clippy::duplicated_attributes)]
+#[usage(
+    bin = "view-group-host",
+    unknown_flags = "error",
+    group("mode", required),
+    view("view-group-run", root = "run", global = "--left", global = "--right"),
+    view("view-group-left", root = "run", global = "--left")
+)]
+struct ViewGroupHost {
+    #[arg(long, global, group = "mode")]
+    left: bool,
+    #[arg(long, global, group = "mode")]
+    right: bool,
+    #[command(subcommand)]
+    command: ViewGroupCommand,
+}
+
+#[derive(Subcommands)]
+enum ViewGroupCommand {
+    Run,
+}
+
+struct ViewLeafValue(String);
+
+impl std::str::FromStr for ViewLeafValue {
+    type Err = std::convert::Infallible;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(Self(value.to_owned()))
+    }
+}
+
+#[derive(Args)]
+struct ViewLeafArgs {
+    #[usage(long)]
+    value: ViewLeafValue,
+}
+
+#[derive(Subcommands)]
+#[allow(dead_code)]
+enum ViewLeafCommand {
+    Run(ViewLeafArgs),
+    Other {
+        #[usage(long)]
+        value: ViewLeafValue,
+    },
+}
+
+#[derive(Cli)]
+#[usage(bin = "view-leaf-host", view("view-leaf", root = "run"))]
+struct ViewLeafHost {
+    #[usage(subcommand)]
+    command: ViewLeafCommand,
+}
+
+#[test]
+fn a_direct_view_does_not_require_leaf_or_sibling_values_to_default() {
+    let parsed = ViewLeafHost::parse_from_argv(&[
+        OsStr::new("view-leaf"),
+        OsStr::new("--value"),
+        OsStr::new("kept"),
+    ])
+    .expect("the promoted leaf parses its own required value");
+    let ViewLeafCommand::Run(args) = parsed.command else {
+        panic!("the view should select run")
+    };
+    assert_eq!(args.value.0, "kept");
+}
+
+#[test]
+fn executable_views_enforce_required_groups_of_carried_globals() {
+    assert!(matches!(
+        ViewGroupHost::parse_from_argv(&[OsStr::new("view-group-run")]),
+        Err(usage::Error::MissingGroup {
+            group: "mode",
+            members: &["--left", "--right"],
+        })
+    ));
+    assert!(matches!(
+        ViewGroupHost::parse_from_argv(&[OsStr::new("view-group-left")]),
+        Err(usage::Error::MissingGroup {
+            group: "mode",
+            members: &["--left"],
+        })
+    ));
+
+    let parsed =
+        ViewGroupHost::parse_from_argv(&[OsStr::new("view-group-run"), OsStr::new("--left")])
+            .expect("a carried member should satisfy its required group");
+    assert!(parsed.left);
+    assert!(!parsed.right);
+
+    let spec = ViewGroupHost::spec();
+    let route = [spec.root.cmd, spec.root.subcommands[0].cmd];
+    let page = usage::help::render_view_at_styled(
+        spec,
+        &route,
+        &spec.views[1],
+        false,
+        usage::help::Style::PLAIN,
+    )
+    .expect("the singleton projection should render");
+    assert!(page.contains("<--left>"), "{page}");
+    assert!(!page.contains("--right"), "{page}");
+}
+
 #[derive(Subcommands)]
 enum Command {
     Show(Show),
@@ -788,6 +1265,35 @@ enum UnitArgsCommand {
 struct UnitArgsCli {
     #[usage(subcommand)]
     command: UnitArgsCommand,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct NonDefaultValue(String);
+
+impl std::str::FromStr for NonDefaultValue {
+    type Err = std::convert::Infallible;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(Self(value.to_owned()))
+    }
+}
+
+#[derive(Args)]
+struct NonDefaultArgs {
+    #[usage(long)]
+    value: NonDefaultValue,
+}
+
+#[derive(Subcommands)]
+enum NonDefaultCommand {
+    Run(NonDefaultArgs),
+}
+
+#[derive(Cli)]
+#[usage(bin = "non-default")]
+struct NonDefaultCli {
+    #[usage(subcommand)]
+    command: NonDefaultCommand,
 }
 
 #[derive(Cli)]
@@ -1846,6 +2352,15 @@ fn typed_flatten_help_reaches_help_and_the_portable_spec() {
     assert!(kdl.contains("flatten_help #true"), "{kdl}");
     let portable: usage_parser::Spec = kdl.parse().unwrap();
     assert!(portable.cmd.flatten_help);
+}
+
+#[test]
+fn args_without_views_do_not_require_value_defaults() {
+    let parsed =
+        NonDefaultCli::parse_from(&[OsStr::new("run"), OsStr::new("--value"), OsStr::new("kept")])
+            .unwrap();
+    let NonDefaultCommand::Run(args) = parsed.command;
+    assert_eq!(args.value, NonDefaultValue("kept".to_owned()));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add portable root `view` nodes that promote a command path under another executable identity
- carry all or selected root globals into help, diagnostics, docs, parsing, and completions
- lower `#[usage(view(...))]` through the usage-rs facade and dispatch typed CLIs from argv0
- replace the aube-style hand-mutated multicall spec workaround with a supported dialect feature
- mark the executable-view fleet gap complete in PLAN.md

## Validation

- `cargo test -p usage-rs --all-features executable_views`
- `cargo test -p usage-cli test_lint_invalid_executable_view`
- `cargo clippy --workspace --all-features --exclude gate -- -D warnings`
- full `mise run ci` is being re-run on the rebased stack tip

_This PR description was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches parser flag scoping, typed derive construction, completions, and diagnostics for a new dispatch path. Behavior is gated on declared views, but regressions would change CLI identity, globals, and completion answers.
> 
> **Overview**
> Adds portable root **`view` nodes** so a CLI can expose a nested command as its own executable (name, bin, command path, all or selected root globals) instead of hand-mutating a generated spec.
> 
> `#[usage(view(...))]` lowers into the spec. argv0 dispatch, `Parser::with_view`, help, diagnostics, completions, and doc generators (`--view` on json/manpage/markdown) all project through that surface. Injected parents skip their own defaults/validation; omitted host fields use typed placeholders. Version actions stay on the host executable.
> 
> Lint rejects invalid roots, host-name collisions, and ambiguous view bins. Completer lookup now prefers the field at the cursor over a same-named root completer so a promoted view cannot pick the host’s `tool` (etc.) by accident.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5157869c46ad06f47249378a081131258713bcf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->