### PR TITLE
feat(spec): add deprecated config environment aliases

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1588,14 +1588,16 @@ Where they differ is instructive, because it is mostly _drift_:
       spec's `config { prop ... }` block so settings documentation flows through
       the same pipeline as command documentation. Same canonicality rule as the
       parser: code authors, the spec defines.
-- [~] **A prop vocabulary that is the union of the four registries** — `type`
-  (bool, int, string, path, duration, list, map, plus a Rust-type escape
-  hatch), `default`, `env` and `deprecated_env`, `docs`, `deprecated` with
-  warn/remove versions, `enum`, `optional`, `aliases`, `merge`
-  (`replace`/`union` — hk needs union for its list settings), `scope`
-  (mise strips `global_only` settings out of project files, which is a
-  security property, not a preference), and per-source bindings in hk's
-  `sources.{cli,env,git,...}` shape.
+- [x] **A prop vocabulary that is the union of the four registries** — `type`
+      (bool, int, string, path, duration, list, map, plus a Rust-type escape
+      hatch), `default`, `env` and `deprecated_env`, `docs`, `deprecated` with
+      warn/remove versions, `enum`, `optional`, `aliases`, `merge`
+      (`replace`/`union` — hk needs union for its list settings), `scope`
+      (mise strips `global_only` settings out of project files, which is a
+      security property, not a preference), and per-source bindings in hk's
+      `sources.{cli,env,git,...}` shape. Current environment names are ordered;
+      `deprecated_env` names are consulted afterwards, warn when used, and remain
+      visible to generated registries and documentation.
 - [x] **Named, ordered, pluggable layers.** The order is CLI flags, then
       environment, then env-files, then the project file (found upward, with
       `.local` variants outranking their base), then user-global, then system, then

--- a/config-build/src/emit.rs
+++ b/config-build/src/emit.rs
@@ -132,6 +132,14 @@ fn prop_meta(key: &str, prop: &SpecConfigProp, problems: &mut Vec<String>) -> St
         let list: Vec<String> = envs.iter().map(|env| rust_str(env)).collect();
         let _ = writeln!(fields, "        envs: &[{}],", list.join(", "));
     }
+    if !prop.deprecated_envs.is_empty() {
+        let list: Vec<String> = prop
+            .deprecated_envs
+            .iter()
+            .map(|env| rust_str(env))
+            .collect();
+        let _ = writeln!(fields, "        deprecated_envs: &[{}],", list.join(", "));
+    }
     if !prop.cli.is_empty() {
         let flags: Vec<String> = prop.cli.iter().map(|flag| rust_str(flag)).collect();
         let _ = writeln!(fields, "        cli: &[{}],", flags.join(", "));

--- a/config-build/tests/fixtures/hk.usage.kdl
+++ b/config-build/tests/fixtures/hk.usage.kdl
@@ -14,6 +14,7 @@ config {
     prop "jobs" type="uint" default=4 default_note="0 = one per core" \
         help="How many jobs to run at once" {
         env "HK_JOBS" "HK_JOB"
+        deprecated_env "HK_JOBS_OLD"
         source "git" "hk.jobs"
         cli "--jobs" "-j"
     }

--- a/config-build/tests/generated.rs
+++ b/config-build/tests/generated.rs
@@ -113,6 +113,7 @@ fn what_the_spec_said_about_each_setting_is_what_the_registry_holds() {
     // generator used to read and drop — leaving the registry unable to say a setting is settable from
     // the command line at all.
     assert_eq!(meta(prop::JOBS).cli, &["--jobs", "-j"]);
+    assert_eq!(meta(prop::JOBS).deprecated_envs, &["HK_JOBS_OLD"]);
     assert!(
         meta(prop::EXCLUDE).cli.is_empty(),
         "most settings have no flag"

--- a/config-build/tests/golden/settings.rs
+++ b/config-build/tests/golden/settings.rs
@@ -30,6 +30,7 @@ pub static SETTINGS_PROPS: &[::usage_config::PropMeta] = &[
     ::usage_config::PropMeta {
         default: Some(::usage_config::Const::Int(4)),
         envs: &["HK_JOBS", "HK_JOB"],
+        deprecated_envs: &["HK_JOBS_OLD"],
         cli: &["--jobs", "-j"],
         bindings: &[("git", "hk.jobs")],
         help: Some("How many jobs to run at once"),

--- a/config/src/env.rs
+++ b/config/src/env.rs
@@ -96,13 +96,18 @@ impl Layer for EnvLayer {
 
         // Everything the environment has to say, gathered by the setting it will end up in — which
         // is what an old name shares with the name that replaced it.
-        let mut found: BTreeMap<PropId, Vec<(PropId, &str, &str)>> = BTreeMap::new();
+        let mut found: BTreeMap<PropId, Vec<(PropId, &str, &str, bool)>> = BTreeMap::new();
         for id in registry.ids() {
             let meta = registry.get(id);
             // The *declared* order, because a setting's variables are listed highest first: mise's
             // `MISE_JOBS` beside an older `MISE_JOB`. First one set wins and the rest are not looked
             // at, which is what makes an alias an alias rather than a second setting.
-            for name in meta.envs {
+            for (name, deprecated) in meta
+                .envs
+                .iter()
+                .map(|name| (*name, false))
+                .chain(meta.deprecated_envs.iter().map(|name| (*name, true)))
+            {
                 let Some(raw) = self.get(name) else {
                     continue;
                 };
@@ -114,7 +119,10 @@ impl Layer for EnvLayer {
                     .renamed_to
                     .and_then(|to| registry.lookup(to))
                     .map_or(id, |found| found.id);
-                found.entry(target).or_default().push((id, set_as, raw));
+                found
+                    .entry(target)
+                    .or_default()
+                    .push((id, set_as, raw, deprecated));
                 break;
             }
         }
@@ -125,12 +133,13 @@ impl Layer for EnvLayer {
             // items from a deprecated variable *as well*, and an emptied one cleared the default
             // before the current name was merged.
             //
-            // The setting's own name wins; among old names, the first the registry declares. Which
-            // old name should beat another is a question nothing declares an answer to, so the answer
-            // is stable and the layer says what it did.
-            candidates.sort_by_key(|(id, ..)| *id != target);
+            // Every current environment name wins over every deprecated alias, including across a
+            // renamed setting that folds into this target. Within the same class, the target's own
+            // name wins; among old setting names, registry order is stable and the layer reports
+            // what it did.
+            candidates.sort_by_key(|(id, _, _, deprecated_env)| (*deprecated_env, *id != target));
             let mut read_by: Option<&str> = None;
-            for (id, set_as, raw) in candidates {
+            for (id, set_as, raw, deprecated_env) in candidates {
                 let origin = Origin::new(SourceKind::ENV, set_as);
                 if let Some(first) = read_by {
                     out.warn(
@@ -151,6 +160,24 @@ impl Layer for EnvLayer {
                     Ok(entry) => {
                         out.push(entry);
                         read_by = Some(set_as);
+                        if deprecated_env {
+                            let target_meta = registry.get(target);
+                            out.warn(
+                                Warning::at(
+                                    format!(
+                                        "{set_as} is deprecated; use {} for {}",
+                                        target_meta
+                                            .envs
+                                            .first()
+                                            .copied()
+                                            .unwrap_or(target_meta.key),
+                                        target_meta.key
+                                    ),
+                                    Origin::new(SourceKind::ENV, set_as),
+                                )
+                                .of(WarningKind::Deprecated),
+                            );
+                        }
                     }
                     // And a value of the wrong type costs that variable and nothing else. Refusing to
                     // start because one variable in a shell profile is a typo would be worse than the
@@ -176,6 +203,7 @@ mod tests {
             default: Some(Const::Int(4)),
             // Highest first, which is what makes the second one an alias.
             envs: &["HK_JOBS", "HK_JOB"],
+            deprecated_envs: &["HK_JOBS_OLD"],
             ..PropMeta::new("jobs", Ty::Uint)
         },
         PropMeta {
@@ -192,6 +220,7 @@ mod tests {
         PropMeta::new("stash", Ty::String),
         PropMeta {
             envs: &["HK_CONCURRENCY"],
+            deprecated_envs: &["HK_CONCURRENCY_OLD"],
             deprecated: Some("Use jobs instead."),
             renamed_to: Some("jobs"),
             ..PropMeta::new("concurrency", Ty::Uint)
@@ -283,6 +312,79 @@ mod tests {
             resolved.origin(id).map(|o| o.describe()),
             Some("HK_JOB"),
             "named as the user set it"
+        );
+    }
+
+    #[test]
+    fn a_deprecated_environment_alias_is_read_last_and_warned_about() {
+        let id = REGISTRY.lookup("jobs").expect("declared").id;
+        let resolved =
+            resolve(REGISTRY, Layers::new().then(&env(&[("HK_JOBS_OLD", "3")]))).expect("resolves");
+        assert_eq!(resolved.get(id), Some(&Value::Int(3)));
+        let warnings = crate::explain::warnings(&resolved);
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
+        assert!(
+            warnings[0].contains("HK_JOBS_OLD is deprecated"),
+            "{warnings:?}"
+        );
+        assert!(warnings[0].contains("use HK_JOBS"), "{warnings:?}");
+
+        let resolved = resolve(
+            REGISTRY,
+            Layers::new().then(&env(&[("HK_JOBS", "8"), ("HK_JOBS_OLD", "3")])),
+        )
+        .expect("resolves");
+        assert_eq!(resolved.get(id), Some(&Value::Int(8)));
+        assert!(resolved.warnings.is_empty(), "{:?}", resolved.warnings);
+    }
+
+    #[test]
+    fn a_renamed_settings_deprecated_environment_alias_names_the_replacement() {
+        let resolved = resolve(
+            REGISTRY,
+            Layers::new().then(&env(&[("HK_CONCURRENCY_OLD", "6")])),
+        )
+        .expect("resolves");
+        assert_eq!(resolved.get_key("jobs"), Some(&Value::Int(6)));
+        let warnings = crate::explain::warnings(&resolved);
+        assert!(
+            warnings.iter().any(|warning| warning
+                .starts_with("HK_CONCURRENCY_OLD is deprecated; use HK_JOBS for jobs")),
+            "{warnings:?}"
+        );
+        assert!(
+            !warnings
+                .iter()
+                .any(|warning| warning.contains("use HK_CONCURRENCY for concurrency")),
+            "the deprecated alias should direct the user to the folded replacement: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn a_current_renamed_variable_beats_a_deprecated_target_alias() {
+        let id = REGISTRY.lookup("jobs").expect("declared").id;
+        let resolved = resolve(
+            REGISTRY,
+            Layers::new().then(&env(&[("HK_JOBS_OLD", "3"), ("HK_CONCURRENCY", "6")])),
+        )
+        .expect("resolves");
+        assert_eq!(resolved.get(id), Some(&Value::Int(6)));
+        assert_eq!(
+            resolved.origin(id).map(|origin| origin.describe()),
+            Some("HK_CONCURRENCY")
+        );
+        let warnings = crate::explain::warnings(&resolved);
+        assert!(
+            warnings
+                .iter()
+                .any(|warning| warning.starts_with("HK_JOBS_OLD was not read: HK_CONCURRENCY")),
+            "{warnings:?}"
+        );
+        assert!(
+            !warnings
+                .iter()
+                .any(|warning| warning.contains("HK_JOBS_OLD is deprecated")),
+            "an unused deprecated alias should not produce an actionable warning: {warnings:?}"
         );
     }
 

--- a/config/src/registry.rs
+++ b/config/src/registry.rs
@@ -72,6 +72,8 @@ pub struct PropMeta {
     pub parse: Option<Parser>,
     /// Environment variables that set it, highest precedence first.
     pub envs: &'static [&'static str],
+    /// Deprecated environment aliases, consulted after every current name.
+    pub deprecated_envs: &'static [&'static str],
     /// The flags that set it, as the spec's `cli` node declares them: `["--jobs", "-j"]`.
     ///
     /// Documentation for the most part — an explanation that lists the environment variables and not
@@ -114,6 +116,7 @@ impl PropMeta {
             scope: Scope::Any,
             parse: None,
             envs: &[],
+            deprecated_envs: &[],
             cli: &[],
             bindings: &[],
             choices: &[],

--- a/conformance/src/config.rs
+++ b/conformance/src/config.rs
@@ -684,6 +684,7 @@ fn registry_of(settings: &[Setting]) -> Result<Registry, String> {
                 None => None,
             },
             envs: &[],
+            deprecated_envs: &[],
             // No flags: a corpus vector describes what reaches a *resolution*, and which flag a
             // setting declares does not change one. It is documentation, and the drift test that
             // holds it against a CLI's own binding is that CLI's test rather than this corpus's.

--- a/docs/spec/reference/config.md
+++ b/docs/spec/reference/config.md
@@ -37,6 +37,7 @@ are consulted.
 prop "check" type="bool" {
     cli "--check"              // flags that set it, as declared elsewhere in this spec
     env "HK_CHECK" "HK_LINT"   // several: aliases, highest precedence first
+    deprecated_env "HK_VERIFY" // read last, with a warning
     source "git" "hk.check"    // a source kind declared below
 }
 ```
@@ -108,6 +109,7 @@ And as child nodes, for anything multi-valued or long:
 | --------------------------------- | -------------------------------------------------------------- |
 | `cli "--jobs" "-j"`               | flags that set it                                              |
 | `env "A" "B"`                     | environment variables, highest precedence first                |
+| `deprecated_env "OLD_A"`          | environment aliases read last and reported as deprecated       |
 | `alias "old.key"`                 | equivalent config keys, accepted without a deprecation warning |
 | `source "git" "a.b"`              | its keys in a declared source kind                             |
 | `default "a" "b"`                 | a list default, values typed as written (`default 80 443`)     |

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -359,6 +359,14 @@ fn describe_sources(
             described.push(format!("`{first}` (or {})", aliases.join(", ")));
         }
     }
+    if !prop.deprecated_envs.is_empty() {
+        let names: Vec<String> = prop
+            .deprecated_envs
+            .iter()
+            .map(|env| format!("`{env}`"))
+            .collect();
+        described.push(format!("{} (deprecated)", names.join(", ")));
+    }
     for (kind, keys) in &prop.bindings {
         let declared = config.sources.get(kind);
         let name = declared

--- a/lib/src/spec/config.rs
+++ b/lib/src/spec/config.rs
@@ -446,6 +446,9 @@ pub struct SpecConfigProp {
     pub env: Option<String>,
     /// Every environment variable that sets this, highest precedence first.
     pub envs: Vec<String>,
+    /// Environment aliases still read after current names, with a deprecation warning.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub deprecated_envs: Vec<String>,
     /// Flags that set this, as declared elsewhere in the spec.
     pub cli: Vec<String>,
     /// Keys this setting has in a custom source kind, by kind name.
@@ -504,6 +507,12 @@ impl SpecConfigProp {
             self.env = Some(env.clone());
         }
         self.envs.push(env);
+        self
+    }
+
+    /// A deprecated environment alias, read after every current name.
+    pub fn deprecated_env(mut self, env: impl Into<String>) -> Self {
+        self.deprecated_envs.push(env.into());
         self
     }
 
@@ -596,6 +605,11 @@ impl SpecConfigProp {
         let mut children = KdlDocument::new();
         if self.envs.len() > 1 {
             children.nodes_mut().push(string_list("env", &self.envs));
+        }
+        if !self.deprecated_envs.is_empty() {
+            children
+                .nodes_mut()
+                .push(string_list("deprecated_env", &self.deprecated_envs));
         }
         if !self.aliases.is_empty() {
             children
@@ -760,6 +774,7 @@ impl SpecConfigProp {
                 // second `env` line is the natural parallel — assigning silently dropped the
                 // aliases on the first one.
                 "env" => prop.envs.extend(string_args(&child)?),
+                "deprecated_env" => prop.deprecated_envs.extend(string_args(&child)?),
                 "alias" => prop.aliases.extend(string_args(&child)?),
                 "cli" => prop.cli.extend(string_args(&child)?),
                 "example" => prop.examples.extend(string_args(&child)?),
@@ -924,6 +939,7 @@ impl Default for SpecConfigProp {
             value_type: None,
             env: None,
             envs: Vec::new(),
+            deprecated_envs: Vec::new(),
             cli: Vec::new(),
             bindings: BTreeMap::new(),
             help: None,
@@ -1308,6 +1324,7 @@ config {
         help="Number of parallel jobs" since="1.0.0" help_heading="Performance" {
         cli "--jobs" "-j"
         env "HK_JOBS" "HK_JOB"
+        deprecated_env "HK_JOBS_OLD"
         source "git" "hk.jobs"
         source "pkl" "jobs" "defaults.jobs"
         example "hk check --jobs 4"
@@ -1357,6 +1374,7 @@ config {
         let jobs = &spec.config.props["jobs"];
         assert_eq!(jobs.cli, ["--jobs", "-j"]);
         assert_eq!(jobs.envs, ["HK_JOBS", "HK_JOB"]);
+        assert_eq!(jobs.deprecated_envs, ["HK_JOBS_OLD"]);
         assert_eq!(
             jobs.env.as_deref(),
             Some("HK_JOBS"),

--- a/lib/src/spec/snapshots/usage__spec__config__tests__the_whole_vocabulary_survives_a_round_trip.snap
+++ b/lib/src/spec/snapshots/usage__spec__config__tests__the_whole_vocabulary_survives_a_round_trip.snap
@@ -96,6 +96,9 @@ expression: "serde_json::to_string_pretty(&spec.config).unwrap()"
         "HK_JOBS",
         "HK_JOB"
       ],
+      "deprecated_envs": [
+        "HK_JOBS_OLD"
+      ],
       "cli": [
         "--jobs",
         "-j"


### PR DESCRIPTION
## Summary
- carry `deprecated_env` through config KDL, JSON, docs, and generated registries
- consult deprecated variables after current names and warn only when one supplies the value
- close the remaining config property-vocabulary PLAN gap

## Tests
- `cargo test -p usage-lib --all-features spec::config`
- `cargo test -p usage-config --all-features`
- `cargo test -p usage-config-build --all-features`
- `cargo clippy -p usage-lib -p usage-config -p usage-config-build --all-features -- -D warnings`

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes config environment resolution and warning behavior, including precedence across renamed settings, so a mistake could silently prefer the wrong variable.
> 
> **Overview**
> Adds a `deprecated_env` child on config props so old environment names stay greppable, round-trip through KDL/JSON/docs, and land in generated `PropMeta`.
> 
> The env layer now consults those names **after** every current `env` (including across a rename fold). A deprecated alias is used only when no current name supplies a value, and a deprecation warning is emitted only for the alias that actually won. Unused aliases get a not-read warning instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea87bfed6ba64f547631bc940eff854b3eef9545. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->