### PR TITLE
fix(parse): honor separator after automatic args

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1553,6 +1553,11 @@ including telling you to delete the label afterwards.
       [the arg reference](https://usage.jdx.dev/spec/reference/arg) says outright. The
       arg's first value now stops flag interpretation, and that note is gone from the
       reference.
+- [x] An automatic argument made a later explicit `--` ordinary data before it could
+      unlock a `double_dash="required"` argument. This broke mise's nested task
+      passthrough shape (`mise run wrapper -- command ...`): the wrapper received `--`
+      as its executable. The first explicit separator now remains syntax after automatic
+      flag stopping; only separators after that first one are data.
 - [x] An attached value was read a second time as a token, so `--jobs=--force` bound
       `force` and left `jobs` unset. The `=` has already settled that the text is a
       value, so it binds where it is read instead of going back on the queue.

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -1539,7 +1539,10 @@ impl<'t: 'v, 'a, 'v> Parser<'t, 'a, 'v> {
         let token = bytes(self.argv.get(self.pos)?);
         self.pos += 1;
 
-        if self.flags_stopped {
+        // An automatic trailing argument stops flag interpretation without consuming an
+        // explicit separator. A later `--` must still unlock a required trailing argument
+        // (clap's `last`), while a separator already consumed makes every later `--` data.
+        if self.flags_stopped && (token != b"--" || self.separator_seen) {
             return Some(self.word(token));
         }
 

--- a/benches/gate/tests/parse.rs
+++ b/benches/gate/tests/parse.rs
@@ -26,9 +26,9 @@ fn a_tool_is_installed_globally() {
 
 #[test]
 fn a_task_runs_with_arguments_after_a_separator() {
-    // `TASK` now declares `double_dash=automatic`: once the task name binds, every later token
-    // is task argv. That includes flag-looking words and a literal `--`; none return to mise's
-    // own flags or reach the older `ARGS_LAST` compatibility field.
+    // `TASK` declares `double_dash=automatic`: once the task name binds, later flag-looking
+    // words are task argv. An explicit `--` still has its narrower clap-compatible meaning:
+    // it ends `ARGS` and unlocks the trailing `ARGS_LAST` field.
     let a = argv([
         "tasks",
         "run",
@@ -45,11 +45,11 @@ fn a_task_runs_with_arguments_after_a_separator() {
     let Some(TasksCommands::Run(run)) = tasks.command else {
         panic!("expected `tasks run`")
     };
-    // The words, not just that a command was selected: dropping a flag-looking word or the
-    // separator itself would otherwise leave this green.
+    // The words, not just that a command was selected: dropping a flag-looking word on either
+    // side of the separator would otherwise leave this green.
     assert_eq!(run.task.as_deref(), Some("build"));
-    assert_eq!(run.args, ["extra", "--dry-run", "--", "--verbose"]);
-    assert!(run.args_last.is_empty());
+    assert_eq!(run.args, ["extra", "--dry-run"]);
+    assert_eq!(run.args_last, ["--verbose"]);
     assert!(!run.dry_run);
 }
 

--- a/conformance/tests/double_dash.rs
+++ b/conformance/tests/double_dash.rs
@@ -12,6 +12,7 @@
 
 use std::ffi::OsStr;
 
+use usage::parse::ParseValue;
 use usage::Spec as LibSpec;
 use usage_derive::Cli;
 
@@ -47,6 +48,18 @@ struct Keeper {
     /// Everything, `--` included
     #[usage(arg, name = "REST", double_dash = "preserve")]
     rest: Vec<String>,
+}
+
+/// A task runner with ordinary task args before `--` and passthrough args after it.
+#[derive(Cli)]
+#[usage(bin = "split")]
+struct Split {
+    #[usage(arg, name = "TASK", double_dash = "automatic")]
+    task: String,
+    #[usage(arg, name = "ARGS")]
+    args: Vec<String>,
+    #[usage(arg, name = "TRAILING", double_dash = "required")]
+    trailing: Vec<String>,
 }
 
 #[test]
@@ -117,6 +130,47 @@ fn preserve_gives_the_separator_to_the_argument() {
     let parsed = Keeper::parse_from(&argv).expect("should parse");
     assert!(parsed.verbose);
     assert_eq!(parsed.rest, ["a", "--", "b"]);
+}
+
+#[test]
+fn an_explicit_separator_still_ends_an_automatic_argument() {
+    let argv = [
+        OsStr::new("task"),
+        OsStr::new("--"),
+        OsStr::new("mise"),
+        OsStr::new("x"),
+        OsStr::new("--"),
+        OsStr::new("command"),
+    ];
+    let parsed = Split::parse_from(&argv).expect("the separator unlocks the trailing argument");
+    assert_eq!(parsed.task, "task");
+    assert!(parsed.args.is_empty());
+    assert_eq!(parsed.trailing, ["mise", "x", "--", "command"]);
+
+    // The emitted spec is also consumed by usage-lib for completion and shell integrations.
+    // Keep its interpretation identical to the typed parser: the first explicit separator is
+    // syntax even though `automatic` has already stopped flags, while the second is data.
+    let spec: LibSpec = Split::to_kdl().parse().expect("valid spec");
+    let argv = ["split", "task", "--", "mise", "x", "--", "command"].map(str::to_string);
+    let interpreted = usage::Parser::new(&spec)
+        .parse(&argv)
+        .expect("the emitted spec accepts the same command line");
+    let args = interpreted
+        .args
+        .iter()
+        .find(|(arg, _)| arg.name == "ARGS")
+        .map(|(_, value)| value);
+    assert!(args
+        .is_none_or(|value| matches!(value, ParseValue::MultiString(values) if values.is_empty())));
+    let trailing = interpreted
+        .args
+        .iter()
+        .find(|(arg, _)| arg.name == "TRAILING")
+        .map(|(_, value)| value)
+        .expect("TRAILING is present");
+    assert!(
+        matches!(trailing, ParseValue::MultiString(values) if values == &["mise", "x", "--", "command"])
+    );
 }
 
 #[test]

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -1083,11 +1083,12 @@ fn parse_partial_with_env(
             try_bind_default_missing(&mut out.flags, &mut out.flag_awaiting_value, custom_env)?;
         }
 
-        // Only while flags are still being read. Once a `--` has done its job, a
-        // second one is an ordinary value: every parser worth comparing against
-        // keeps it (POSIX getopt, argparse, clap, commander, yargs), and jdx/usage#229
-        // was a user reporting the old behavior as the bug it is.
-        if w == "--" && enable_flags {
+        // The first explicit `--` is still a separator after an `automatic` argument has
+        // stopped flag parsing. Once an explicit separator has done its job, a second one is
+        // an ordinary value: every parser worth comparing against keeps it (POSIX getopt,
+        // argparse, clap, commander, yargs), and jdx/usage#229 was a user reporting the old
+        // behavior as the bug it is.
+        if w == "--" && !seen_double_dash {
             enable_flags = false;
 
             // Only preserve the double dash token if we're collecting values for a variadic arg


### PR DESCRIPTION
Fix the fleet-discovered parser gap where `double_dash="automatic"` stopped flag parsing so early that a later explicit `--` could not unlock a `double_dash="required"` trailing argument.

This restores mise's nested task passthrough shape, preserves later separators as data, adds conformance coverage, and records the closed gap in PLAN.md.

Tests:
- `cargo test -p usage-conformance an_explicit_separator_still_ends_an_automatic_argument`
- `cargo test -p usage-argv second_double_dash_is_a_value`
- targeted clippy with all features/targets

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes argv `--` semantics in both usage-argv and usage-lib, which can rebind nested passthrough command lines. Coverage is added, but this is core parser behavior.
> 
> **Overview**
> Fixes a parser gap where `double_dash="automatic"` stopped flag parsing so early that a later explicit `--` became data and could not unlock a `double_dash="required"` trailing argument.
> 
> The first explicit separator now stays syntax after automatic flag stopping; only later `--` tokens are values. That restores mise’s nested passthrough shape (`mise run wrapper -- command ...`) instead of handing `--` to the wrapper as the executable.
> 
> The same rule is applied in usage-argv and usage-lib. Tests now expect `tasks run` to split `ARGS` vs `ARGS_LAST` around `--`, and a new `Split` conformance case checks both the typed parser and the emitted spec. PLAN.md records the closed gap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2e9692178b1c9fc56fa69769eeecddd056aae7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->