### PR TITLE
feat(docs): group subcommands under help headings

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1306,10 +1306,11 @@ above are where it lands.
 
 **Worth building, demand attached:**
 
-- [ ] **Subcommand help headings** (clap#1553, 38 votes) — `help_heading`
+- [x] **Subcommand help headings** (clap#1553, 38 votes) — `help_heading`
       landed for flags and arguments; this is the same property on `cmd` nodes,
       so a 210-command CLI can group its help into sections. mise is the
-      obvious first user. clap#4589 asks for prose under a heading — Deno wants
+      obvious first user. It is now portable through KDL, the typed derive,
+      usage-lib and generated Go help. clap#4589 asks for prose under a heading — Deno wants
       per-section doc links — which is the same node with one more field.
 - [ ] **Deprecation and stability metadata on flags and commands** (clap#3321) —
       `deprecated`, with warn/remove versions, already exists in the

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -122,6 +122,13 @@ fn help_structure(
                 .unwrap_or("Commands")
                 .to_string(),
         );
+        headings.extend(
+            meta.subcommands
+                .iter()
+                .filter(|sub| !sub.hide)
+                .filter_map(|sub| sub.help_heading)
+                .map(str::to_string),
+        );
     }
 
     let (own, inherited) = own_and_global(chain);
@@ -813,9 +820,6 @@ fn commands_section(out: &mut String, path: &[&str], meta: &CommandMeta<'_>) {
     if visible.is_empty() {
         return;
     }
-    let heading = meta.subcommand_help_heading.unwrap_or("Commands");
-    let _ = writeln!(out, "\n{heading}:");
-
     // Sorted by the rendered usage rather than by name, as usage-lib sorts them — for a
     // command with no flags or arguments the two agree, and where they differ this is the
     // order a reader sees in the reference.
@@ -834,42 +838,59 @@ fn commands_section(out: &mut String, path: &[&str], meta: &CommandMeta<'_>) {
             .then_with(|| a.0.cmp(&b.0))
     });
 
-    for (usage, sub) in &lines {
-        let _ = write!(out, "  {usage}");
-        // Visible aliases only: a hidden alias works and is not advertised, which is the
-        // whole of the distinction.
-        let visible_aliases: Vec<&str> = sub
-            .cmd
-            .aliases
-            .iter()
-            .copied()
-            .filter(|a| !sub.hidden_aliases.contains(a))
-            .collect();
-        if !visible_aliases.is_empty() {
-            let _ = write!(out, " [aliases: {}]", visible_aliases.join(", "));
+    let default_title = meta.subcommand_help_heading.unwrap_or("Commands");
+    let mut headings = vec![None];
+    for (_, sub) in &lines {
+        let heading = command_help_section(sub, default_title);
+        if !headings.contains(&heading) {
+            headings.push(heading);
         }
-        if let Some(about) = sub.about {
-            if meta.next_line_help {
-                out.push('\n');
-                write_indented(out, about.trim_end(), 4);
-                continue;
-            }
-            // The row writes its own newline below. Trim trailing whitespace in both
-            // layouts, as usage-lib does before choosing a layout.
-            let _ = write!(out, "  {}", about.trim_end());
-        }
-        out.push('\n');
     }
-    if meta.next_line_help {
-        let _ = writeln!(
-            out,
-            "  help\n    Print this message or the help of the given subcommand(s)"
-        );
-    } else {
-        let _ = writeln!(
-            out,
-            "  help  Print this message or the help of the given subcommand(s)"
-        );
+    for heading in headings {
+        let title = heading.unwrap_or(default_title);
+        let _ = writeln!(out, "\n{title}:");
+        for (usage, sub) in lines
+            .iter()
+            .filter(|(_, sub)| command_help_section(sub, default_title) == heading)
+        {
+            let _ = write!(out, "  {usage}");
+            // Visible aliases only: a hidden alias works and is not advertised, which is the
+            // whole of the distinction.
+            let visible_aliases: Vec<&str> = sub
+                .cmd
+                .aliases
+                .iter()
+                .copied()
+                .filter(|a| !sub.hidden_aliases.contains(a))
+                .collect();
+            if !visible_aliases.is_empty() {
+                let _ = write!(out, " [aliases: {}]", visible_aliases.join(", "));
+            }
+            if let Some(about) = sub.about {
+                if meta.next_line_help {
+                    out.push('\n');
+                    write_indented(out, about.trim_end(), 4);
+                    continue;
+                }
+                // The row writes its own newline below. Trim trailing whitespace in both
+                // layouts, as usage-lib does before choosing a layout.
+                let _ = write!(out, "  {}", about.trim_end());
+            }
+            out.push('\n');
+        }
+        if heading.is_none() {
+            if meta.next_line_help {
+                let _ = writeln!(
+                    out,
+                    "  help\n    Print this message or the help of the given subcommand(s)"
+                );
+            } else {
+                let _ = writeln!(
+                    out,
+                    "  help  Print this message or the help of the given subcommand(s)"
+                );
+            }
+        }
     }
 }
 
@@ -1023,6 +1044,10 @@ fn order_commands(items: &mut Vec<&&CommandMeta<'_>>) {
             .cmp(&b.display_order.unwrap_or(999))
             .then_with(|| a.cmd.name.cmp(b.cmd.name))
     });
+}
+
+fn command_help_section<'a>(sub: &'a CommandMeta<'a>, default_title: &str) -> Option<&'a str> {
+    sub.help_heading.filter(|heading| *heading != default_title)
 }
 
 /// The bracketed notes after an entry's help: choices, environment, default.
@@ -1478,9 +1503,6 @@ fn long_commands_section(out: &mut String, path: &[&str], meta: &CommandMeta<'_>
     if visible.is_empty() {
         return;
     }
-    let heading = meta.subcommand_help_heading.unwrap_or("Commands");
-    let _ = writeln!(out, "\n{heading}:");
-
     let mut lines: Vec<(String, &&CommandMeta<'_>)> = visible
         .iter()
         .map(|sub| {
@@ -1496,34 +1518,51 @@ fn long_commands_section(out: &mut String, path: &[&str], meta: &CommandMeta<'_>
             .then_with(|| a.0.cmp(&b.0))
     });
 
-    for (usage, sub) in &lines {
-        let _ = write!(out, "  {usage}");
-        let visible_aliases: Vec<&str> = sub
-            .cmd
-            .aliases
-            .iter()
-            .copied()
-            .filter(|a| !sub.hidden_aliases.contains(a))
-            .collect();
-        if !visible_aliases.is_empty() {
-            let _ = write!(out, " [aliases: {}]", visible_aliases.join(", "));
+    let default_title = meta.subcommand_help_heading.unwrap_or("Commands");
+    let mut headings = vec![None];
+    for (_, sub) in &lines {
+        let heading = command_help_section(sub, default_title);
+        if !headings.contains(&heading) {
+            headings.push(heading);
         }
-        out.push('\n');
-        if let Some(about) = sub.long_about.or(sub.about) {
-            // Trailing whitespace trimmed: the blank line after each entry is written below, and
-            // a description that happens to end in a newline — which clap's `long_about` often
-            // does, reaching the spec verbatim — added a second one and left a stray blank in
-            // the middle of the list.
-            write_indented(out, about.trim_end(), 4);
-        }
-        // A blank line between entries, which the wider layout can afford and which keeps a
-        // multi-line description from running into the next command's name.
-        out.push('\n');
     }
-    let _ = writeln!(
-        out,
-        "  help\n    Print this message or the help of the given subcommand(s)"
-    );
+    for heading in headings {
+        let title = heading.unwrap_or(default_title);
+        let _ = writeln!(out, "\n{title}:");
+        for (usage, sub) in lines
+            .iter()
+            .filter(|(_, sub)| command_help_section(sub, default_title) == heading)
+        {
+            let _ = write!(out, "  {usage}");
+            let visible_aliases: Vec<&str> = sub
+                .cmd
+                .aliases
+                .iter()
+                .copied()
+                .filter(|a| !sub.hidden_aliases.contains(a))
+                .collect();
+            if !visible_aliases.is_empty() {
+                let _ = write!(out, " [aliases: {}]", visible_aliases.join(", "));
+            }
+            out.push('\n');
+            if let Some(about) = sub.long_about.or(sub.about) {
+                // Trailing whitespace trimmed: the blank line after each entry is written below, and
+                // a description that happens to end in a newline — which clap's `long_about` often
+                // does, reaching the spec verbatim — added a second one and left a stray blank in
+                // the middle of the list.
+                write_indented(out, about.trim_end(), 4);
+            }
+            // A blank line between entries, which the wider layout can afford and which keeps a
+            // multi-line description from running into the next command's name.
+            out.push('\n');
+        }
+        if heading.is_none() {
+            let _ = writeln!(
+                out,
+                "  help\n    Print this message or the help of the given subcommand(s)"
+            );
+        }
+    }
 }
 
 fn flat_commands_long(out: &mut String, path: &[&str], meta: &CommandMeta<'_>, width: usize) {

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -711,6 +711,8 @@ pub struct CommandMeta<'a> {
     pub hidden_aliases: &'a [&'a str],
     /// Whether the command is hidden from help and completions.
     pub hide: bool,
+    /// Help section this command appears under in its parent's command list.
+    pub help_heading: Option<&'a str>,
     /// Explicit placement within the parent's command section.
     pub display_order: Option<usize>,
     /// What running this does to the world, for a caller deciding whether to
@@ -780,6 +782,7 @@ impl CommandMeta<'_> {
         long_about: None,
         hidden_aliases: &[],
         hide: false,
+        help_heading: None,
         display_order: None,
         effect: None,
         mount: None,
@@ -1462,6 +1465,9 @@ fn write_command<'a>(
     }
     if meta.hide {
         out.push_str(" hide=#true");
+    }
+    if let Some(heading) = meta.help_heading {
+        write!(out, " help_heading={}", quoted(heading))?;
     }
     let effect = overlays
         .iter()

--- a/conformance/src/tables.rs
+++ b/conformance/src/tables.rs
@@ -144,6 +144,7 @@ pub fn build(
         ),
         hide: cmd.hide,
         display_order: cmd.display_order,
+        help_heading: opt(&cmd.help_heading),
         effect: cmd.effect.map(effect),
         // A command carries at most one mount in the tables; a spec may list several, and the
         // first is the one the tables can hold.

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -4197,6 +4197,7 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
             // A hidden command still answers to its name; it is simply not offered. Declared on
             // the variant, which is where the command itself is declared.
             let hide = v.hide;
+            let help_heading = option_str(v.help_heading.as_deref());
             let display_order = option_usize(v.display_order);
             quote! {
                 const #hidden_groups: &[&[&str]] = &[
@@ -4215,6 +4216,7 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
                         after_help: #after_help,
                         after_long_help: #after_long_help,
                         hide: #hide,
+                        help_heading: #help_heading,
                         display_order: #display_order,
                         hidden_aliases: &#hidden_name,
                         ..*<#ty as usage_argv::spec::CommandArgs>::META

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -313,7 +313,9 @@
 //! list. They may be written on the `Args` struct that owns the command or on its
 //! `Subcommands` variant; when both say some, the lists are joined. The parser matches both;
 //! the difference is only whether help and completions mention them.
-//! `display_order = n` on the variant controls where the command is presented in help.
+//! `help_heading = "Maintenance"` on a variant groups that command under a named section
+//! in its parent's help. `display_order = n` controls where it is presented within the
+//! section.
 //!
 //! # Settings and the flags that set them
 //!

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -3859,6 +3859,8 @@ fn unit_struct_ident(enum_ident: &syn::Ident, variant: &syn::Ident) -> syn::Iden
 /// One variant: a command name and the struct holding its flags and arguments.
 pub struct Variant {
     pub ident: syn::Ident,
+    /// Help section this command appears under in its parent's command list.
+    pub help_heading: Option<String>,
     /// Explicit placement within the parent's command section.
     pub display_order: Option<usize>,
     /// Whether the command is kept out of help and completions.
@@ -4028,6 +4030,7 @@ impl Variant {
         let mut hidden_aliases: Vec<String> = Vec::new();
         let mut effect = None;
         let mut hide = false;
+        let mut help_heading = None;
         let mut display_order = None;
         let mut external = false;
         let mut help_attr: Option<proc_macro2::TokenStream> = None;
@@ -4046,6 +4049,7 @@ impl Variant {
                     "alias" => aliases.extend(selectors(&meta)?),
                     "alias_hidden" => hidden_aliases.extend(selectors(&meta)?),
                     "hide" => hide = flag_value(&meta)?,
+                    "help_heading" => help_heading = Some(string_value(&meta)?),
                     "display_order" => display_order = Some(int_value(&meta)?),
                     "external_subcommand" => external = flag_value(&meta)?,
                     "effect" => {
@@ -4069,7 +4073,7 @@ impl Variant {
                             path,
                             format!(
                                 "unknown option `{other}` on a variant; a subcommand \
-                                 variant takes `name`, `alias`, `alias_hidden`, `display_order`, \
+                                 variant takes `name`, `alias`, `alias_hidden`, `help_heading`, `display_order`, \
                                  `external_subcommand`, `help`, `long_help`, `before_help`, \
                                  `before_long_help`, `after_help`, `after_long_help`, and `verbatim_doc_comment` here, \
                                  and its description comes from the doc comment"
@@ -4117,6 +4121,13 @@ impl Variant {
                     &variant.ident,
                     "`external_subcommand` is a catch-all rather than a command help lists, \
                      so there is nothing for `hide` to keep out of help",
+                ));
+            }
+            if help_heading.is_some() {
+                return Err(syn::Error::new_spanned(
+                    &variant.ident,
+                    "`external_subcommand` is a catch-all rather than a command help lists, \
+                     so it cannot belong to a `help_heading`",
                 ));
             }
             if help.is_some()
@@ -4167,6 +4178,7 @@ impl Variant {
             return Ok(Variant {
                 ident: variant.ident.clone(),
                 hide: false,
+                help_heading: None,
                 name,
                 effect: None,
                 display_order: None,
@@ -4231,6 +4243,7 @@ impl Variant {
 
         Ok(Variant {
             ident: variant.ident.clone(),
+            help_heading,
             display_order,
             hide,
             name,
@@ -5375,6 +5388,27 @@ mod tests {
         "#,
         );
         assert!(err.contains("hide"), "{err}");
+
+        let err = enum_rejection(
+            r#"
+            enum Commands {
+                #[usage(help_heading = "Other", external_subcommand)]
+                External(Vec<String>),
+            }
+        "#,
+        );
+        assert!(err.contains("help_heading"), "{err}");
+
+        let subs = subcommands(
+            r#"
+            enum Commands {
+                #[command(help_heading = "Other")]
+                Install,
+            }
+        "#,
+        )
+        .expect("regular subcommands should retain help_heading");
+        assert_eq!(subs.variants[0].help_heading.as_deref(), Some("Other"));
 
         let err = enum_rejection(
             r#"

--- a/docs/rust/clap-compatibility.md
+++ b/docs/rust/clap-compatibility.md
@@ -107,10 +107,10 @@ the Rust declaration, not only from generated KDL, wherever the bridge column sa
 | clap surface                                       | derive | argv | KDL | lib | output | bridge  | Notes                                                                                          |
 | -------------------------------------------------- | ------ | ---- | --- | --- | ------ | ------- | ---------------------------------------------------------------------------------------------- |
 | short/long help and doc comments                   | yes    | yes  | yes | yes | yes    | yes     | First paragraph is short help; the full block is long help.                                    |
-| `help_heading`                                     | yes    | n/a  | yes | yes | yes    | yes     | Flags and arguments are grouped and retain declaration order.                                  |
+| `help_heading` on flags and arguments              | yes    | n/a  | yes | yes | yes    | yes     | Flags and arguments are grouped and retain declaration order.                                  |
 | whole-entry `hide`                                 | yes    | yes  | yes | yes | yes    | yes     | Hidden commands, flags, arguments, and values still parse.                                     |
 | granular hide settings                             | yes    | yes  | yes | yes | yes    | yes     | Default, environment, possible-value, short-help, and long-help visibility is independent.     |
-| `subcommand_help_heading`, `subcommand_value_name` | yes    | yes  | yes | yes | yes    | yes     | Customize the subcommand section label and the synopsis placeholder.                           |
+| `subcommand_help_heading`, `subcommand_value_name` | yes    | yes  | yes | yes | yes    | yes     | Customize the single heading for all child commands and the synopsis placeholder.              |
 | `verbatim_doc_comment`                             | yes    | n/a  | yes | yes | yes    | n/a     | Commands, fields, and variants preserve line breaks and indentation when requested.            |
 | `rename_all`, `rename_all_env`                     | yes    | n/a  | yes | yes | yes    | n/a     | Full clap casing vocabulary; bare `env` uses the environment casing policy.                    |
 | `next_line_help`                                   | yes    | yes  | yes | yes | yes    | yes     | Put command, argument, and flag descriptions below their usage instead of beside it.           |
@@ -128,9 +128,10 @@ the Rust declaration, not only from generated KDL, wherever the bridge column sa
 ## Usage extensions
 
 These are not clap compatibility gaps. usage additionally supports `mount`,
-`restart_token`, `default_subcommand`, command and flag `effect`, Nushell completions,
-and a language-neutral conformance corpus. clap cannot express those properties, so
-a clap-generated spec cannot carry them without an overlay.
+`restart_token`, `default_subcommand`, command and flag `effect`, per-subcommand
+`help_heading` groups, Nushell completions, and a language-neutral conformance corpus.
+clap's `subcommand_help_heading` sets one heading for all child commands; it cannot
+express separate groups, so a clap-generated spec cannot carry them without an overlay.
 
 This matrix is the compatibility baseline, not a promise to reproduce clap's dynamic
 builder and `ArgMatches` architecture. Setter-only clap state remains explicitly

--- a/docs/rust/help.md
+++ b/docs/rust/help.md
@@ -56,7 +56,7 @@ convenience entry point for CLIs that want immediate print-and-exit behavior.
 - `usage = "…"` on the root replaces the generated synopsis line(s) verbatim.
 - `before_help`, `after_help`, `before_long_help`, `after_long_help` add text around the page —
   `after_long_help` is the conventional home for an Examples section.
-- `help_heading` on a field groups it under a heading.
+- `help_heading` on a field or subcommand variant groups it under a heading.
 - `display_order = n` on a field or subcommand controls its position within a help section
   without changing positional parsing order.
 - `next_line_help` on a command puts every argument, flag, and subcommand description beneath

--- a/docs/spec/reference/cmd.md
+++ b/docs/spec/reference/cmd.md
@@ -13,6 +13,7 @@ cmd "config" subcommand_help_heading="Actions" subcommand_value_name="ACTION"
 cmd "config" next_line_help=#true // put descriptions below each entry
 cmd "config" flatten_help=#true // expand visible subcommands into this page
 cmd "config" display_order=10 // present before commands with a greater order
+cmd "config" help_heading="Configuration" // group under this heading in its parent's help
 
 // these are shown under -h
 cmd "config" before_help="shown before the command"

--- a/go/argv/page.go
+++ b/go/argv/page.go
@@ -1,6 +1,7 @@
 package argv
 
 import (
+	"slices"
 	"sort"
 	"strings"
 	"unicode"
@@ -257,8 +258,6 @@ func commandsSection(out *strings.Builder, path []string, cmd *Command, help Hel
 		}
 		nextLineHelp = h.NextLineHelp
 	}
-	out.WriteString("\n" + heading + ":\n")
-
 	sort.SliceStable(lines, func(i, j int) bool {
 		left, right := helpOrder(help, lines[i].sub.Key, 999), helpOrder(help, lines[j].sub.Key, 999)
 		if left != right {
@@ -267,31 +266,55 @@ func commandsSection(out *strings.Builder, path []string, cmd *Command, help Hel
 		return lines[i].usage < lines[j].usage
 	})
 
+	headings := []string{""}
 	for _, l := range lines {
-		out.WriteString("  " + l.usage)
-		if h := help.Lookup(l.sub.Key); h != nil {
-			// Visible aliases only: a hidden alias works and is not advertised,
-			// which is the whole of the distinction.
-			if len(h.VisibleAliases) > 0 {
-				out.WriteString(" [aliases: " + strings.Join(h.VisibleAliases, ", ") + "]")
+		if h := headingOf(help, l.sub.Key); h == heading {
+			continue
+		} else if h != "" && !slices.Contains(headings, h) {
+			headings = append(headings, h)
+		}
+	}
+	for _, section := range headings {
+		title := section
+		if title == "" {
+			title = heading
+		}
+		out.WriteString("\n" + title + ":\n")
+		for _, l := range lines {
+			itemSection := headingOf(help, l.sub.Key)
+			if itemSection == heading {
+				itemSection = ""
 			}
-			if h.Short != "" {
-				if nextLineHelp {
-					out.WriteString("\n")
-					writeIndented(out, trimEnd(h.Short), 4)
-					continue
+			if itemSection != section {
+				continue
+			}
+			out.WriteString("  " + l.usage)
+			if h := help.Lookup(l.sub.Key); h != nil {
+				// Visible aliases only: a hidden alias works and is not advertised,
+				// which is the whole of the distinction.
+				if len(h.VisibleAliases) > 0 {
+					out.WriteString(" [aliases: " + strings.Join(h.VisibleAliases, ", ") + "]")
 				}
-				// The row owns its terminating newline. Trim the description in both
-				// layouts, as usage-lib does before selecting a layout.
-				out.WriteString("  " + trimEnd(h.Short))
+				if h.Short != "" {
+					if nextLineHelp {
+						out.WriteString("\n")
+						writeIndented(out, trimEnd(h.Short), 4)
+						continue
+					}
+					// The row owns its terminating newline. Trim the description in both
+					// layouts, as usage-lib does before selecting a layout.
+					out.WriteString("  " + trimEnd(h.Short))
+				}
+			}
+			out.WriteString("\n")
+		}
+		if section == "" {
+			if nextLineHelp {
+				out.WriteString("  help\n    Print this message or the help of the given subcommand(s)\n")
+			} else {
+				out.WriteString("  help  Print this message or the help of the given subcommand(s)\n")
 			}
 		}
-		out.WriteString("\n")
-	}
-	if nextLineHelp {
-		out.WriteString("  help\n    Print this message or the help of the given subcommand(s)\n")
-	} else {
-		out.WriteString("  help  Print this message or the help of the given subcommand(s)\n")
 	}
 }
 

--- a/go/argv/page_long.go
+++ b/go/argv/page_long.go
@@ -1,6 +1,7 @@
 package argv
 
 import (
+	"slices"
 	"sort"
 	"strings"
 )
@@ -181,7 +182,6 @@ func longCommandsSection(out *strings.Builder, path []string, cmd *Command, help
 	if h := help.Lookup(cmd.Key); h != nil && h.SubcommandHelpHeading != "" {
 		heading = h.SubcommandHelpHeading
 	}
-	out.WriteString("\n" + heading + ":\n")
 	sort.SliceStable(lines, func(i, j int) bool {
 		left, right := helpOrder(help, lines[i].sub.Key, 999), helpOrder(help, lines[j].sub.Key, 999)
 		if left != right {
@@ -190,26 +190,50 @@ func longCommandsSection(out *strings.Builder, path []string, cmd *Command, help
 		return lines[i].usage < lines[j].usage
 	})
 
+	headings := []string{""}
 	for _, l := range lines {
-		out.WriteString("  " + l.usage)
-		h := help.Lookup(l.sub.Key)
-		if h != nil && len(h.VisibleAliases) > 0 {
-			out.WriteString(" [aliases: " + strings.Join(h.VisibleAliases, ", ") + "]")
+		if h := headingOf(help, l.sub.Key); h == heading {
+			continue
+		} else if h != "" && !slices.Contains(headings, h) {
+			headings = append(headings, h)
 		}
-		out.WriteString("\n")
-		if h != nil {
-			// Trailing whitespace trimmed: the blank line after each entry is
-			// written below, and a description that happens to end in a newline
-			// added a second one — a stray blank in the middle of the list.
-			if about := trimEnd(firstOf(h.Long, h.Short)); about != "" {
-				writeIndented(out, about, 4)
-			}
-		}
-		// A blank line between entries, which the wider layout can afford and
-		// which keeps a multi-line description from running into the next name.
-		out.WriteString("\n")
 	}
-	out.WriteString("  help\n    Print this message or the help of the given subcommand(s)\n")
+	for _, section := range headings {
+		title := section
+		if title == "" {
+			title = heading
+		}
+		out.WriteString("\n" + title + ":\n")
+		for _, l := range lines {
+			itemSection := headingOf(help, l.sub.Key)
+			if itemSection == heading {
+				itemSection = ""
+			}
+			if itemSection != section {
+				continue
+			}
+			out.WriteString("  " + l.usage)
+			h := help.Lookup(l.sub.Key)
+			if h != nil && len(h.VisibleAliases) > 0 {
+				out.WriteString(" [aliases: " + strings.Join(h.VisibleAliases, ", ") + "]")
+			}
+			out.WriteString("\n")
+			if h != nil {
+				// Trailing whitespace trimmed: the blank line after each entry is
+				// written below, and a description that happens to end in a newline
+				// added a second one — a stray blank in the middle of the list.
+				if about := trimEnd(firstOf(h.Long, h.Short)); about != "" {
+					writeIndented(out, about, 4)
+				}
+			}
+			// A blank line between entries, which the wider layout can afford and
+			// which keeps a multi-line description from running into the next name.
+			out.WriteString("\n")
+		}
+		if section == "" {
+			out.WriteString("  help\n    Print this message or the help of the given subcommand(s)\n")
+		}
+	}
 }
 
 func flatCommandsLong(out *strings.Builder, path []string, cmd *Command, help HelpTable, nextLine bool) {

--- a/go/argv/page_test.go
+++ b/go/argv/page_test.go
@@ -139,6 +139,38 @@ func TestSubcommandPresentation(t *testing.T) {
 	}
 }
 
+func TestSubcommandHelpHeadings(t *testing.T) {
+	run := &Command{Name: "run", Key: 2}
+	clean := &Command{Name: "clean", Key: 3}
+	status := &Command{Name: "status", Key: 4}
+	root := &Command{Name: "ex", Key: 1, Subcommands: []*Command{run, clean, status}}
+	help := HelpTable{
+		{Key: 1},
+		{Key: 2, Short: "run it", Heading: "Core commands"},
+		{Key: 3, Short: "remove old state", Heading: "Maintenance"},
+		{Key: 4, Short: "show status", Heading: "Commands"},
+	}
+	for _, page := range []string{
+		ShortHelp(HelpSpec{Bin: "ex"}, []string{"ex"}, []*Command{root}, help),
+		LongHelp(HelpSpec{Bin: "ex"}, []string{"ex"}, []*Command{root}, help),
+	} {
+		commands := strings.Index(page, "\nCommands:\n")
+		core := strings.Index(page, "\nCore commands:\n")
+		maintenance := strings.Index(page, "\nMaintenance:\n")
+		if commands < 0 || core < commands || maintenance < commands {
+			t.Fatalf("command headings are missing or out of order:\n%s", page)
+		}
+		if strings.Count(page, "\nCommands:\n") != 1 {
+			t.Fatalf("default-equivalent heading was duplicated:\n%s", page)
+		}
+		defaultEnd := min(core, maintenance)
+		if !strings.Contains(page[commands:defaultEnd], "status") || !strings.Contains(page[commands:defaultEnd], "help") ||
+			!strings.Contains(page[core:], "run") || !strings.Contains(page[maintenance:], "clean") {
+			t.Fatalf("commands are in the wrong sections:\n%s", page)
+		}
+	}
+}
+
 func TestExplicitDisplayOrder(t *testing.T) {
 	second := &Flag{Key: 2, Name: "second", Longs: []string{"second"}}
 	first := &Flag{Key: 3, Name: "first", Longs: []string{"first"}}

--- a/go/internal/spec/spec.go
+++ b/go/internal/spec/spec.go
@@ -87,6 +87,7 @@ type Cmd struct {
 	Hide                        bool        `json:"hide"`
 	Help                        string      `json:"help"`
 	HelpLong                    string      `json:"help_long"`
+	HelpHeading                 string      `json:"help_heading"`
 	DisplayOrder                *uint32     `json:"display_order"`
 	Usage                       string      `json:"usage"`
 	BeforeHelp                  string      `json:"before_help"`
@@ -643,8 +644,9 @@ func (b *builder) command(c *Cmd, inherited argv.UnknownFlags) *argv.Command {
 		examples = append(examples, argv.Example{Header: e.Header, Code: e.Code, Help: e.Help})
 	}
 	commandHelp := argv.Help{
-		Hide:  c.Hide,
-		Short: first(c.Help, c.HelpLong),
+		Hide:    c.Hide,
+		Heading: c.HelpHeading,
+		Short:   first(c.Help, c.HelpLong),
 		// No fallback to the short text, because the emitter does not write one for
 		// a command: the page renderer falls back for itself, so carrying the same
 		// string twice would only put it in the table twice. What matters is that

--- a/go/internal/spec/spec_test.go
+++ b/go/internal/spec/spec_test.go
@@ -571,6 +571,21 @@ func TestCommandDisplayOrderSurvivesLoweredJSON(t *testing.T) {
 	}
 }
 
+func TestCommandHelpHeadingSurvivesLoweredJSON(t *testing.T) {
+	var s Spec
+	const lowered = `{"name":"ex","bin":"ex","cmd":{"name":"ex","subcommands":{
+		"run":{"name":"run","help_heading":"Core commands"}}}}`
+	if err := json.Unmarshal([]byte(lowered), &s); err != nil {
+		t.Fatalf("lowered spec should decode: %v", err)
+	}
+
+	root, _, help := s.BuildAll()
+	meta := help.Lookup(root.Subcommands[0].Key)
+	if meta == nil || meta.Heading != "Core commands" {
+		t.Fatalf("command help heading was lost: %#v", meta)
+	}
+}
+
 // Decoding into a spec that already holds one replaces its commands.
 //
 // A decoder does not get to assume a fresh value: appending to the receiver would

--- a/lib/src/docs/cli/mod.rs
+++ b/lib/src/docs/cli/mod.rs
@@ -983,6 +983,33 @@ cmd "alpha" help="Unordered"
     }
 
     #[test]
+    fn test_render_help_groups_subcommands_by_heading() {
+        let spec = crate::spec! { r#"
+bin "testcli"
+cmd "run" help="Run it" help_heading="Core commands"
+cmd "clean" help="Remove old state" help_heading="Maintenance"
+cmd "status" help="Show status" help_heading="Commands"
+        "# }
+        .unwrap();
+
+        for page in [
+            render_help(&spec, &spec.cmd, false),
+            render_help(&spec, &spec.cmd, true),
+        ] {
+            let commands = page.find("\nCommands:\n").expect("default command section");
+            assert_eq!(page.matches("\nCommands:\n").count(), 1, "{page}");
+            let core = page.find("\nCore commands:\n").expect("core section");
+            let maintenance = page.find("\nMaintenance:\n").expect("maintenance section");
+            assert!(commands < core && commands < maintenance, "{page}");
+            let default_end = core.min(maintenance);
+            assert!(page[commands..default_end].contains("status"), "{page}");
+            assert!(page[commands..default_end].contains("help"), "{page}");
+            assert!(page[core..].contains("run"), "{page}");
+            assert!(page[maintenance..].contains("clean"), "{page}");
+        }
+    }
+
+    #[test]
     fn test_render_help_with_next_line_layout() {
         let spec = crate::spec! { r#"
 bin "testcli"

--- a/lib/src/docs/cli/templates/spec_template_long.tera
+++ b/lib/src/docs/cli/templates/spec_template_long.tera
@@ -32,9 +32,10 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
 {%- endif %}
 
 {%- if cmd.subcommands and not cmd.flatten_help %}
+{%- for group in cmd.subcommand_groups %}
 
-{{ cmd.subcommand_help_heading | default(value="Commands") }}:
-{%- for cmd in cmd.help_subcommands %}
+{{ group.heading | default(value=cmd.subcommand_help_heading | default(value="Commands")) }}:
+{%- for cmd in group.items %}
   {{ cmd.usage | trim }}
 {%- if cmd.deprecated %} [deprecated: {{ cmd.deprecated }}]{%- endif %}
 {%- if cmd.aliases %} [aliases: {{ cmd.aliases | join(sep=", ") }}]{% endif %}
@@ -43,8 +44,11 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
     {{ help | indent(width=4) }}
 {%- endif %}
 {% endfor %}
+{%- if not group.heading %}
   help
     Print this message or the help of the given subcommand(s)
+{%- endif %}
+{%- endfor %}
 {%- endif %}
 
 {%- for group in cmd.arg_groups %}

--- a/lib/src/docs/cli/templates/spec_template_short.tera
+++ b/lib/src/docs/cli/templates/spec_template_short.tera
@@ -24,18 +24,22 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
 {%- endif %}
 
 {%- if cmd.subcommands and not cmd.flatten_help %}
-
-{{ cmd.subcommand_help_heading | default(value="Commands") }}:
 {%- set next_line_help = cmd.next_line_help %}
-{%- for cmd in cmd.help_subcommands %}
+{%- for group in cmd.subcommand_groups %}
+
+{{ group.heading | default(value=cmd.subcommand_help_heading | default(value="Commands")) }}:
+{%- for cmd in group.items %}
   {{ cmd.usage | trim }}
 {%- if cmd.deprecated %} [deprecated: {{ cmd.deprecated }}]{%- endif %}
 {%- if cmd.aliases %} [aliases: {{ cmd.aliases | join(sep=", ") }}]{% endif %}
 {%- if cmd.help %}{% if next_line_help %}
     {{ cmd.help | indent(width=4) }}{% else %}  {{ cmd.help }}{% endif %}{%- endif %}
 {%- endfor %}
+{%- if not group.heading %}
 {% if next_line_help %}  help
     Print this message or the help of the given subcommand(s){% else %}  help  Print this message or the help of the given subcommand(s){% endif %}
+{%- endif %}
+{%- endfor %}
 {%- endif %}
 
 {%- for group in cmd.arg_groups %}

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -37,6 +37,8 @@ pub struct SpecCommand {
     pub subcommands: IndexMap<String, SpecCommand>,
     /// Immediate children in help presentation order, without duplicating their trees.
     pub help_subcommands: Vec<HelpCommand>,
+    /// Visible subcommand summaries partitioned by their own `help_heading`.
+    pub subcommand_groups: Vec<Group<HelpCommand>>,
     pub args: Vec<SpecArg>,
     pub flags: Vec<SpecFlag>,
     /// `flags`, partitioned by `help_heading`. Same flags, same order.
@@ -47,6 +49,7 @@ pub struct SpecCommand {
     pub deprecated: Option<String>,
     pub effect: Option<SpecCommandEffect>,
     pub hide: bool,
+    pub help_heading: Option<String>,
     pub display_order: Option<usize>,
     pub subcommand_required: bool,
     pub subcommand_help_heading: Option<String>,
@@ -87,6 +90,7 @@ pub struct HelpCommand {
     pub aliases: Vec<String>,
     pub help: Option<String>,
     pub help_long: Option<String>,
+    pub help_heading: Option<String>,
 }
 
 impl From<&SpecCommand> for HelpCommand {
@@ -97,6 +101,7 @@ impl From<&SpecCommand> for HelpCommand {
             aliases: cmd.aliases.clone(),
             help: cmd.help.clone(),
             help_long: cmd.help_long.clone(),
+            help_heading: cmd.help_heading.clone(),
         }
     }
 }
@@ -542,6 +547,7 @@ impl From<&crate::SpecCommand> for SpecCommand {
             deprecated,
             effect,
             hide,
+            help_heading,
             display_order,
             subcommand_required,
             subcommand_help_heading,
@@ -604,13 +610,37 @@ impl From<&crate::SpecCommand> for SpecCommand {
         let help_subcommands: Vec<HelpCommand> = help_order
             .iter()
             .map(|(_, _, key)| {
-                HelpCommand::from(
+                let mut command = HelpCommand::from(
                     rendered_subcommands
                         .get(*key)
                         .expect("rendered subcommand retains its key"),
-                )
+                );
+                command.help_heading = command
+                    .help_heading
+                    .as_ref()
+                    .filter(|heading| {
+                        heading.as_str() != subcommand_help_heading.as_deref().unwrap_or("Commands")
+                    })
+                    .cloned();
+                command
             })
             .collect();
+        let mut subcommand_groups =
+            group_by_heading(&help_subcommands, |command| command.help_heading.as_deref());
+        subcommand_groups.sort_by_key(|group| group.heading.is_some());
+        if !help_subcommands.is_empty()
+            && subcommand_groups
+                .first()
+                .is_none_or(|group| group.heading.is_some())
+        {
+            subcommand_groups.insert(
+                0,
+                Group {
+                    heading: None,
+                    items: Vec::new(),
+                },
+            );
+        }
         let mut flattened_subcommands = Vec::new();
         if *flatten_help {
             for (_, _, key) in help_order {
@@ -632,6 +662,7 @@ impl From<&crate::SpecCommand> for SpecCommand {
             usage: usage.clone(),
             subcommands: rendered_subcommands,
             help_subcommands,
+            subcommand_groups,
             flag_groups: group_by_heading(&flags, |f| f.help_heading.as_deref()),
             arg_groups: group_by_heading(&args, |a| a.help_heading.as_deref()),
             args,
@@ -639,6 +670,7 @@ impl From<&crate::SpecCommand> for SpecCommand {
             deprecated: deprecated.clone(),
             effect: *effect,
             hide: *hide,
+            help_heading: help_heading.clone(),
             display_order: *display_order,
             subcommand_required: *subcommand_required,
             subcommand_help_heading: subcommand_help_heading.clone(),

--- a/lib/src/go/mod.rs
+++ b/lib/src/go/mod.rs
@@ -996,6 +996,9 @@ fn command_help(e: &Emitted) -> String {
     if e.cmd.hide {
         fields.push("Hide: true".to_string());
     }
+    if let Some(heading) = &e.cmd.help_heading {
+        fields.push(format!("Heading: {}", go_string(heading)));
+    }
     if let Some(order) = e.cmd.display_order {
         fields.push(format!("DisplayOrder: {order}"));
         fields.push("DisplayOrderSet: true".to_string());

--- a/lib/src/spec/cmd.rs
+++ b/lib/src/spec/cmd.rs
@@ -72,6 +72,9 @@ pub struct SpecCommand {
     pub unknown_flags: Option<UnknownFlags>,
     /// Whether to hide this command from help output
     pub hide: bool,
+    /// Help section this command appears under in its parent's command list.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub help_heading: Option<String>,
     /// Explicit placement within its parent's command section.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub display_order: Option<usize>,
@@ -208,6 +211,7 @@ impl Default for SpecCommand {
             effect: None,
             unknown_flags: None,
             hide: false,
+            help_heading: None,
             display_order: None,
             mounted: false,
             flags_from_mount: false,
@@ -352,6 +356,7 @@ impl SpecCommand {
                 }
                 "allow_missing_positional" => cmd.allow_missing_positional = v.ensure_bool()?,
                 "hide" => cmd.hide = v.ensure_bool()?,
+                "help_heading" => cmd.help_heading = Some(v.ensure_string()?),
                 "display_order" => cmd.display_order = Some(v.ensure_usize()?),
                 "unknown_flags" => {
                     let raw = v.ensure_string()?;
@@ -472,6 +477,9 @@ impl SpecCommand {
                 }
                 "subcommand_required" => {
                     cmd.subcommand_required = child.ensure_arg_len(1..=1)?.arg(0)?.ensure_bool()?
+                }
+                "help_heading" => {
+                    cmd.help_heading = Some(child.ensure_arg_len(1..=1)?.arg(0)?.ensure_string()?)
                 }
                 "subcommand_help_heading" => {
                     cmd.subcommand_help_heading =
@@ -643,6 +651,7 @@ impl SpecCommand {
             hidden_aliases,
             examples,
             hide,
+            help_heading,
             display_order,
             subcommand_required,
             subcommand_help_heading,
@@ -730,6 +739,9 @@ impl SpecCommand {
             self.examples = examples;
         }
         self.hide = hide;
+        if help_heading.is_some() {
+            self.help_heading = help_heading;
+        }
         if display_order.is_some() {
             self.display_order = display_order;
         }
@@ -857,6 +869,7 @@ impl From<&SpecCommand> for KdlNode {
         let SpecCommand {
             name,
             hide,
+            help_heading,
             display_order,
             subcommand_required,
             subcommand_help_heading,
@@ -906,6 +919,10 @@ impl From<&SpecCommand> for KdlNode {
         node.entries_mut().push(name.clone().into());
         if *hide {
             node.entries_mut().push(KdlEntry::new_prop("hide", true));
+        }
+        if let Some(heading) = help_heading {
+            node.entries_mut()
+                .push(KdlEntry::new_prop("help_heading", heading.clone()));
         }
         if let Some(order) = display_order {
             node.entries_mut()

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -223,6 +223,28 @@ enum OrderedCommand {
     First,
 }
 
+#[derive(Cli)]
+#[command(bin = "grouped")]
+#[allow(dead_code)]
+struct GroupedHelp {
+    #[command(subcommand)]
+    command: Option<GroupedCommand>,
+}
+
+#[derive(Subcommands)]
+#[allow(dead_code)]
+enum GroupedCommand {
+    /// Run the application.
+    #[command(help_heading = "Core commands")]
+    Run,
+    /// Remove old state.
+    #[command(help_heading = "Maintenance")]
+    Clean,
+    /// Show the current status.
+    #[command(help_heading = "Commands")]
+    Status,
+}
+
 #[derive(Subcommands, serde::Deserialize)]
 enum InlineCommand {
     /// Run a named benchmark.
@@ -1293,6 +1315,52 @@ fn explicit_display_order_reaches_help_and_the_portable_spec() {
     assert_eq!(portable.cmd.flags[1].display_order, Some(10));
     assert_eq!(portable.cmd.subcommands[0].display_order, Some(20));
     assert_eq!(portable.cmd.subcommands[1].display_order, Some(10));
+}
+
+#[test]
+fn subcommand_help_headings_reach_help_and_the_portable_spec() {
+    let spec = GroupedHelp::spec();
+    for page in [
+        usage::argv::help::short_help(spec, &["grouped"], &[spec.root]),
+        usage::argv::help::long_help(spec, &["grouped"], &[spec.root]),
+    ] {
+        let commands = page.find("\nCommands:\n").expect("default command section");
+        assert_eq!(page.matches("\nCommands:\n").count(), 1, "{page}");
+        let core = page.find("\nCore commands:\n").expect("core section");
+        let maintenance = page.find("\nMaintenance:\n").expect("maintenance section");
+        assert!(commands < core && commands < maintenance, "{page}");
+        let default_end = core.min(maintenance);
+        assert!(page[commands..default_end].contains("status"), "{page}");
+        assert!(page[commands..default_end].contains("help"), "{page}");
+        let core_end = page[core + 1..]
+            .find("\n\n")
+            .map_or(page.len(), |offset| core + 1 + offset);
+        assert!(page[core..core_end].contains("run"), "{page}");
+        let maintenance_end = page[maintenance + 1..]
+            .find("\n\n")
+            .map_or(page.len(), |offset| maintenance + 1 + offset);
+        assert!(
+            page[maintenance..maintenance_end].contains("clean"),
+            "{page}"
+        );
+    }
+
+    let kdl = GroupedHelp::to_kdl();
+    assert!(kdl.contains("help_heading=\"Core commands\""), "{kdl}");
+    assert!(kdl.contains("help_heading=Maintenance"), "{kdl}");
+    let portable: usage_parser::Spec = kdl.parse().unwrap();
+    assert_eq!(
+        portable.cmd.subcommands[0].help_heading.as_deref(),
+        Some("Core commands")
+    );
+    assert_eq!(
+        portable.cmd.subcommands[1].help_heading.as_deref(),
+        Some("Maintenance")
+    );
+    assert_eq!(
+        portable.cmd.subcommands[2].help_heading.as_deref(),
+        Some("Commands")
+    );
 }
 
 #[test]


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the help-page contract across KDL, derive, usage-lib, usage-argv, and generated Go, which is user-facing and held to byte-for-byte parity. Parsing and binding are untouched.
> 
> **Overview**
> Subcommands can now declare `help_heading` the same way flags and arguments already do, so a large CLI can split its command list into named sections.
> 
> The property is first-class on `cmd` in KDL, the typed derive (`#[command(help_heading = "…")]` on a variant), static metadata, usage-lib, and generated Go help. Short and long help group visible children by heading; a heading that matches the parent’s `subcommand_help_heading` (or `"Commands"`) stays in the default section so it is not duplicated. The built-in `help` entry stays in that default section.
> 
> Headings that match the default are treated as unheaded. `external_subcommand` catch-alls cannot take a heading. Docs and the clap matrix now distinguish clap’s single `subcommand_help_heading` from this per-child grouping, which clap cannot express without an overlay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2697926eeefe37bf5a35bee635a31021d02de33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added custom help headings for subcommands.
  * Grouped subcommands under their configured headings in short and long help output.
  * Preserved headings across generated specifications and supported output formats.
  * Kept default commands and built-in help entries in the standard commands section.

* **Documentation**
  * Updated help customization guidance, compatibility details, and examples for subcommand headings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->