### PR TITLE
docs: mark usage-go as not ready for testing

### DIFF
--- a/docs/go/binding.md
+++ b/docs/go/binding.md
@@ -1,8 +1,10 @@
 # Binding and Values
 
-::: warning Draft
-This page is a draft. Some of what it documents is still in open pull requests, and details may
-change before release.
+::: danger Not ready for testing
+The Go framework is far more experimental than the [Rust framework](/rust/) and is **not ready
+for any amount of testing yet** — do not build against it. Much of what this page documents only
+exists in open pull requests and may change before release. These docs are a draft published for
+review, not an invitation to try it.
 :::
 
 Generated `Parse` does everything on this page for you. It's documented separately because the

--- a/docs/go/completions.md
+++ b/docs/go/completions.md
@@ -1,8 +1,10 @@
 # Completions
 
-::: warning Draft
-This page is a draft. Some of what it documents is still in open pull requests, and details may
-change before release.
+::: danger Not ready for testing
+The Go framework is far more experimental than the [Rust framework](/rust/) and is **not ready
+for any amount of testing yet** — do not build against it. Much of what this page documents only
+exists in open pull requests and may change before release. These docs are a draft published for
+review, not an invitation to try it.
 :::
 
 The Go runtime answers the question every completion request boils down to — _what could go

--- a/docs/go/generated-code.md
+++ b/docs/go/generated-code.md
@@ -1,8 +1,10 @@
 # Generated Code
 
-::: warning Draft
-This page is a draft. Some of what it documents is still in open pull requests, and details may
-change before release.
+::: danger Not ready for testing
+The Go framework is far more experimental than the [Rust framework](/rust/) and is **not ready
+for any amount of testing yet** — do not build against it. Much of what this page documents only
+exists in open pull requests and may change before release. These docs are a draft published for
+review, not an invitation to try it.
 :::
 
 `usage generate go` lowers a KDL spec into one Go file. The output is `gofmt`-clean and carries

--- a/docs/go/help.md
+++ b/docs/go/help.md
@@ -1,8 +1,10 @@
 # Help and Errors
 
-::: warning Draft
-This page is a draft. Some of what it documents is still in open pull requests, and details may
-change before release.
+::: danger Not ready for testing
+The Go framework is far more experimental than the [Rust framework](/rust/) and is **not ready
+for any amount of testing yet** — do not build against it. Much of what this page documents only
+exists in open pull requests and may change before release. These docs are a draft published for
+review, not an invitation to try it.
 :::
 
 ## Help pages

--- a/docs/go/index.md
+++ b/docs/go/index.md
@@ -1,10 +1,11 @@
 # Go Framework
 
-::: warning Experimental — draft docs
-The Go framework is experimental. Its parsing behavior is verified against the same conformance
-corpus as the Rust implementation, but APIs may still change between releases. These docs are a
-draft: some of what they document is still in open pull requests, and details may change before
-release.
+::: danger Not ready for testing
+The Go framework is far more experimental than the [Rust framework](/rust/) and is **not ready
+for any amount of testing yet** — do not build against it. Unlike usage-rs, which is experimental
+but complete enough that `usage-cli` itself is built with it, usage-go's APIs, generated output,
+and behavior are all still in flux, and much of what these pages document only exists in open
+pull requests. These docs are a draft published for review, not an invitation to try it.
 :::
 
 The Go framework builds your CLI from a usage spec — but unlike most Go CLI libraries, your

--- a/docs/go/parser.md
+++ b/docs/go/parser.md
@@ -1,8 +1,10 @@
 # The Parser
 
-::: warning Draft
-This page is a draft. Some of what it documents is still in open pull requests, and details may
-change before release.
+::: danger Not ready for testing
+The Go framework is far more experimental than the [Rust framework](/rust/) and is **not ready
+for any amount of testing yet** — do not build against it. Much of what this page documents only
+exists in open pull requests and may change before release. These docs are a draft published for
+review, not an invitation to try it.
 :::
 
 Generated `Parse` is the front door, but the event-level API underneath is public and stable —

--- a/go/README.md
+++ b/go/README.md
@@ -1,5 +1,12 @@
 # usage-go
 
+> [!CAUTION]
+> **usage-go is not ready for any amount of testing.** It is far more experimental
+> than the Rust framework (`usage-rs`) — which is itself experimental, but complete
+> enough that `usage-cli` is built with it. usage-go's APIs, generated output, and
+> behavior are all still in flux, and parts of what is described below only exist in
+> open pull requests. Do not build against it yet.
+
 A CLI framework for Go, built the way [usage-argv](../argv) is built for Rust: the
 command line is bound against **static tables** instead of a command tree
 assembled at run time.


### PR DESCRIPTION
## What changed

- Replaced the mild `::: warning Experimental — draft docs` / `::: warning Draft` notes on all six Go docs pages (`docs/go/*.md`) with a loud `::: danger Not ready for testing` banner.
- Added a matching `[!CAUTION]` GitHub alert at the top of `go/README.md`, above the existing "Status: the binder" note.

## Why

The Go framework carried the same soft experimental warning as the Rust framework, but the two are not at the same maturity level: usage-rs is experimental yet complete enough that usage-cli itself is built with it, while usage-go's APIs, generated output, and behavior are still in flux, with parts of the documented surface only existing in open PRs. The new banners state explicitly that usage-go is not ready for any amount of testing and that the docs are a draft published for review, not an invitation to try it.

## Notes for reviewers

- The Rust docs keep their existing softer warning, so the two tiers now read distinctly.
- Prettier passes on all edited files; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only copy changes; no code, APIs, or runtime behavior are modified.
> 
> **Overview**
> Strengthens the Go framework warnings so they no longer look as mature as usage-rs.
> 
> Replaces the mild `::: warning Draft` / experimental banners on all six `docs/go` pages with a `::: danger Not ready for testing` callout: do not build against it, docs are for review only, and much of the surface still lives in open PRs. Adds a matching GitHub `[!CAUTION]` alert at the top of `go/README.md`. Rust docs keep the softer experimental warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db530177ef3f7901950a196bd9dc6eb6619e9381. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Strengthened warnings across the Go framework documentation and README.
  * Clearly states that the framework is experimental, not ready for testing or use, and subject to significant changes.
  * Clarifies that the documentation is a review draft and should not be treated as an invitation to build with the framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->