### PR TITLE
fix(derive): preserve set-false actions

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -547,7 +547,12 @@ Groups are the opposite case: `Command::get_groups`, `ArgGroup::get_args` and
 - [x] **`flatten_help`.** Visible subcommands can be expanded into their parent's
       usage synopsis and help sections across typed Rust, KDL, the clap bridge,
       and Rust and generated Go help.
-- [ ] **`help_template`.**
+- [ ] **`help_template`.** **Design input needed:** define the stable template
+      context. A root-level Tera template can apply to the whole command tree,
+      but interpreted Rust, compiled Rust, and generated Go need to expose the
+      same named sections and values. Shipping only a `{{ help }}` wrapper would
+      technically accept a template without supporting clap's main use case of
+      rearranging help sections.
 - [x] **`subcommand_help_heading` / `subcommand_value_name`.** Custom subcommand
       section labels and synopsis placeholders survive KDL, typed Rust, generated
       Go, and the clap bridge and are rendered by both help implementations.
@@ -839,8 +844,9 @@ feature list is not an exhaustive audit.
   compares `require_equals`, defaults, delimiters, negative and hyphenated values,
   value enums, scalar overrides, fixed arity, globals through subcommands, required
   flags, conflicts/requires, required exclusive groups, optional values with equals,
-  external subcommands, `arg_required_else_help`, and subcommand requirement/conflict
-  policies. It
+  external subcommands, `arg_required_else_help`, subcommand requirement/conflict
+  policies, conditional defaults, value terminators, skipped optional positionals,
+  count/set-false actions, and subcommand and value-enum completion candidates. It
   records typed values, error classifications, exit status and stream, relevant help,
   and version output; the remaining matrix rows and completion candidates still need
   equivalent minimal pairs. One minimal CLI per matrix row,
@@ -1605,7 +1611,12 @@ Where they differ is instructive, because it is mostly _drift_:
       survive the portable spec. The markdown renderer and generated runtime registry
       consume the block; no fleet CLI emits one yet, which is the adoption half below.
 - [ ] **A registry JSON schema**, so the declaration format validates itself the
-      way hk's does.
+      way hk's does. **Design input needed:** 6.x no longer has a separate TOML
+      registry declaration to validate: the usage KDL spec is the declaration,
+      its parser validates that block, and `usage generate json-schema` describes
+      the _user config file_. Decide whether this means a machine schema for KDL,
+      retaining a supported TOML authoring format, or deleting this now-obsolete
+      requirement.
 
 ### Open questions
 

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -1231,12 +1231,16 @@ pub(crate) fn flag_spelling(meta: &FlagMeta<'_>) -> String {
                 .find(|short| !meta.hidden_shorts.contains(short))
                 .map(|short| format!("-{}", *short as char))
         })
+        .or_else(|| meta.flag.negate.map(|negate| format!("--{negate}")))
         .unwrap_or_else(|| meta.flag.name.to_string())
 }
 
 fn display_usage_masked(meta: &FlagMeta<'_>, show: &Shown) -> String {
     let usage = flag_usage_masked(meta, show);
     match meta.flag.negate.filter(|_| show.negate) {
+        Some(negate) if show.long.is_none() && show.short.is_none() => {
+            format!("{usage} --{negate}")
+        }
         Some(negate) => format!("{usage} / --{negate}"),
         None => usage,
     }
@@ -2660,8 +2664,9 @@ fn recursive_help<'a>(
 #[cfg(test)]
 mod style_tests {
     use super::{
-        commands_section, flag_notes, flag_usage, flat_commands_short, inline_environment_notes,
-        long_help, render_view_at_styled, styled_flag_usage, styled_help, Style,
+        commands_section, display_usage_masked, flag_notes, flag_usage, flat_commands_short,
+        inline_environment_notes, long_help, render_view_at_styled, styled_flag_usage, styled_help,
+        Shown, Style,
     };
     use crate::spec::{CommandMeta, FlagMeta, Spec, ViewMeta};
     use crate::{ArgAction, Command, Flag};
@@ -2682,6 +2687,28 @@ mod style_tests {
         };
 
         assert_eq!(flag_usage(&meta), "--color[=WHEN]");
+    }
+
+    #[test]
+    fn a_negation_left_after_positive_spellings_are_masked_keeps_its_flag_name() {
+        let flag = Flag {
+            name: "color",
+            shorts: b"c",
+            longs: &["color"],
+            negate: Some("no-color"),
+            ..Flag::BOOL
+        };
+        let meta = FlagMeta {
+            flag: &flag,
+            ..FlagMeta::EMPTY
+        };
+        let shown = Shown {
+            long: None,
+            short: None,
+            negate: true,
+        };
+
+        assert_eq!(display_usage_masked(&meta, &shown), "color: --no-color");
     }
 
     #[test]

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -2527,6 +2527,10 @@ fn flag_forms(meta: &FlagMeta<'_>) -> String {
         forms.push_str("--");
         forms.push_str(long);
     }
+    if forms.is_empty() {
+        forms.push_str(flag.name);
+        forms.push(':');
+    }
     forms
 }
 

--- a/benches/gate/tests/differential.rs
+++ b/benches/gate/tests/differential.rs
@@ -496,6 +496,22 @@ fn clap_shadow_keeps_flag_requirements_from_the_shared_spec() {
 }
 
 #[test]
+fn an_override_does_not_erase_an_invalid_choice() {
+    let outcome = run(
+        &SPEC,
+        &[
+            "tool-alias".into(),
+            "set".into(),
+            "--log-level=v".into(),
+            "--index".into(),
+        ],
+    );
+    assert_eq!(outcome.argv, Verdict::InvalidChoice);
+    assert!(!outcome.lib);
+    assert_eq!(outcome.clap, Verdict::InvalidChoice);
+}
+
+#[test]
 fn a_bare_word_diverges_because_of_the_mount_not_the_parser() {
     // The first reading of this was "usage-argv refuses a lone `-` that clap accepts", filed as
     // a parser bug. It is not: `mise build` behaves identically, and the trace shows why —

--- a/conformance/tests/clap_micro.rs
+++ b/conformance/tests/clap_micro.rs
@@ -261,6 +261,28 @@ mod value_enum {
         assert_eq!(clap.kind(), clap::error::ErrorKind::InvalidValue);
         assert!(matches!(usage, Error::InvalidChoice { .. }));
     }
+
+    #[test]
+    fn declared_words_offer_the_same_completion_candidates() {
+        let clap: std::collections::BTreeSet<_> = ClapCli::command()
+            .get_arguments()
+            .find(|arg| arg.get_id() == "mode")
+            .expect("mode")
+            .get_possible_values()
+            .into_iter()
+            .filter(|value| !value.is_hide_set())
+            .map(|value| value.get_name().to_string())
+            .collect();
+        let line = "micro --mode ";
+        let split =
+            usage_argv::complete::split(line, line.len(), usage_argv::complete::Shell::Bash);
+        let usage: std::collections::BTreeSet<_> =
+            usage_argv::complete::candidates(UsageCli::spec(), &split)
+                .into_iter()
+                .map(|candidate| candidate.value)
+                .collect();
+        assert_eq!(usage, clap);
+    }
 }
 
 mod args_override_self {
@@ -271,6 +293,8 @@ mod args_override_self {
     struct ClapCli {
         #[arg(long)]
         value: String,
+        #[arg(long, value_parser = ["good", "better"])]
+        mode: Option<String>,
     }
 
     #[derive(Debug, Cli)]
@@ -278,6 +302,8 @@ mod args_override_self {
     struct UsageCli {
         #[usage(long)]
         value: String,
+        #[usage(long, choices("good", "better"))]
+        mode: Option<String>,
     }
 
     #[test]
@@ -291,6 +317,17 @@ mod args_override_self {
         ])
         .unwrap();
         assert_eq!(usage.value, clap.value);
+    }
+
+    #[test]
+    fn the_last_scalar_choice_controls_validation() {
+        let argv = ["--value", "kept", "--mode", "bad", "--mode", "good"];
+        let usage = UsageCli::parse_from(&argv.map(OsStr::new)).unwrap();
+        assert_eq!(usage.mode.as_deref(), Some("good"));
+
+        let argv = ["--value", "kept", "--mode", "good", "--mode", "bad"];
+        let usage = UsageCli::parse_from(&argv.map(OsStr::new)).unwrap_err();
+        assert!(matches!(usage, Error::InvalidChoice { .. }));
     }
 }
 
@@ -404,6 +441,24 @@ mod global_subcommand {
         let (ClapCommand::Run { task: clap_task }, UsageCommand::Run { task: usage_task }) =
             (clap.command, usage.command);
         assert_eq!(usage_task, clap_task);
+    }
+
+    #[test]
+    fn the_root_offers_the_same_subcommand_candidates() {
+        let clap: std::collections::BTreeSet<_> = ClapCli::command()
+            .get_subcommands()
+            .filter(|command| command.get_name() != "help" && !command.is_hide_set())
+            .map(|command| command.get_name().to_string())
+            .collect();
+        let line = "micro ";
+        let split =
+            usage_argv::complete::split(line, line.len(), usage_argv::complete::Shell::Bash);
+        let usage: std::collections::BTreeSet<_> =
+            usage_argv::complete::candidates(UsageCli::spec(), &split)
+                .into_iter()
+                .map(|candidate| candidate.value)
+                .collect();
+        assert_eq!(usage, clap);
     }
 }
 
@@ -750,5 +805,176 @@ mod subcommand_policies {
             UsageConflicts::parse_from(&[OsStr::new("--verbose"), OsStr::new("run")]).unwrap_err();
         assert_eq!(clap.kind(), clap::error::ErrorKind::ArgumentConflict);
         assert!(matches!(usage, Error::SubcommandConflict { .. }));
+    }
+}
+
+mod conditional_defaults {
+    use super::*;
+
+    #[derive(Debug, clap::Parser)]
+    #[command(name = "micro")]
+    struct ClapCli {
+        #[arg(long)]
+        json: bool,
+        #[arg(long, default_value_if("json", "true", "json"))]
+        format: Option<String>,
+    }
+
+    #[derive(Debug, Cli)]
+    #[usage(bin = "micro", unknown_flags = "error")]
+    struct UsageCli {
+        #[usage(long)]
+        json: bool,
+        #[usage(long, default_if("--json", "json"))]
+        format: Option<String>,
+    }
+
+    #[test]
+    fn a_present_flag_supplies_the_same_conditional_default() {
+        let clap = ClapCli::try_parse_from(["micro", "--json"]).unwrap();
+        let usage = UsageCli::parse_from(&[OsStr::new("--json")]).unwrap();
+        assert_eq!(usage.format, clap.format);
+
+        let clap = ClapCli::try_parse_from(["micro", "--json", "--format", "text"]).unwrap();
+        let usage = UsageCli::parse_from(&[
+            OsStr::new("--json"),
+            OsStr::new("--format"),
+            OsStr::new("text"),
+        ])
+        .unwrap();
+        assert_eq!(usage.format, clap.format);
+
+        assert_eq!(
+            UsageCli::parse_from(&[]).unwrap().format,
+            ClapCli::try_parse_from(["micro"]).unwrap().format
+        );
+    }
+}
+
+mod value_terminator {
+    use super::*;
+
+    #[derive(Debug, clap::Parser)]
+    #[command(name = "micro")]
+    struct ClapCli {
+        #[arg(long, num_args = 1.., value_terminator = ";")]
+        include: Vec<String>,
+        rest: Option<String>,
+    }
+
+    #[derive(Debug, Cli)]
+    #[usage(bin = "micro", unknown_flags = "error")]
+    struct UsageCli {
+        #[arg(long, num_args = 1.., value_terminator = ";")]
+        include: Vec<String>,
+        #[usage(arg)]
+        rest: Option<String>,
+    }
+
+    #[test]
+    fn the_terminator_ends_the_value_without_becoming_a_positional() {
+        assert!(UsageCli::spec().root.cmd.flags[0].variadic);
+        assert_eq!(
+            UsageCli::spec().root.cmd.flags[0].value_terminator,
+            Some(b";".as_slice())
+        );
+        let clap =
+            ClapCli::try_parse_from(["micro", "--include", "one", "two", ";", "tail"]).unwrap();
+        let usage = UsageCli::parse_from(&[
+            OsStr::new("--include"),
+            OsStr::new("one"),
+            OsStr::new("two"),
+            OsStr::new(";"),
+            OsStr::new("tail"),
+        ])
+        .unwrap();
+        assert_eq!(usage.include, clap.include);
+        assert_eq!(usage.rest, clap.rest);
+    }
+}
+
+mod missing_positionals {
+    use super::*;
+
+    #[derive(Debug, clap::Parser)]
+    #[command(name = "micro", allow_missing_positional = true)]
+    struct ClapCli {
+        optional: Option<String>,
+        required: String,
+    }
+
+    #[derive(Debug, Cli)]
+    #[usage(bin = "micro", unknown_flags = "error", allow_missing_positional)]
+    struct UsageCli {
+        #[usage(arg)]
+        optional: Option<String>,
+        #[usage(arg)]
+        required: String,
+    }
+
+    #[test]
+    fn the_last_word_can_skip_an_earlier_optional_position() {
+        let clap = ClapCli::try_parse_from(["micro", "required"]).unwrap();
+        let usage = UsageCli::parse_from(&[OsStr::new("required")]).unwrap();
+        assert_eq!(usage.optional, clap.optional);
+        assert_eq!(usage.required, clap.required);
+
+        let clap = ClapCli::try_parse_from(["micro", "optional", "required"]).unwrap();
+        let usage =
+            UsageCli::parse_from(&[OsStr::new("optional"), OsStr::new("required")]).unwrap();
+        assert_eq!(usage.optional, clap.optional);
+        assert_eq!(usage.required, clap.required);
+    }
+}
+
+mod actions {
+    use super::*;
+
+    #[derive(Debug, clap::Parser)]
+    #[command(name = "micro")]
+    struct ClapCli {
+        #[arg(short, long, action = clap::ArgAction::Count)]
+        verbose: u8,
+        #[arg(long, action = clap::ArgAction::SetFalse, default_value_t = true)]
+        color: bool,
+    }
+
+    #[derive(Debug, Cli)]
+    #[usage(bin = "micro", unknown_flags = "error")]
+    struct UsageCli {
+        #[usage(short, long, count)]
+        verbose: u8,
+        #[arg(long, action = clap::ArgAction::SetFalse, default_value = "true")]
+        color: bool,
+    }
+
+    #[test]
+    fn count_and_set_false_actions_build_the_same_values() {
+        let clap = ClapCli::try_parse_from(["micro", "-vvv", "--color"]).unwrap();
+        let usage = UsageCli::parse_from(&[OsStr::new("-vvv"), OsStr::new("--color")]).unwrap();
+        assert_eq!(usage.verbose, clap.verbose);
+        assert_eq!(usage.color, clap.color);
+
+        let clap = ClapCli::try_parse_from(["micro"]).unwrap();
+        let usage = UsageCli::parse_from(&[]).unwrap();
+        assert_eq!(usage.verbose, clap.verbose);
+        assert_eq!(usage.color, clap.color);
+
+        let kdl = UsageCli::to_kdl();
+        assert!(kdl.contains("flag color: negate=--color"), "{kdl}");
+        let spec: usage::Spec = kdl.parse().expect("the negative-only form round-trips");
+        let color = spec
+            .cmd
+            .flags
+            .iter()
+            .find(|flag| flag.name == "color")
+            .expect("color");
+        assert!(color.long.is_empty());
+        assert_eq!(color.negate.as_deref(), Some("--color"));
+
+        let help = usage_argv::help::render(UsageCli::spec(), UsageCli::command(), false)
+            .expect("root help");
+        assert!(help.contains("--color"), "{help}");
+        assert!(!help.contains("color: /"), "{help}");
     }
 }

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -2389,6 +2389,7 @@ fn flag_arm(cli: &Cli, i: usize, field: &Field) -> TokenStream {
         }
     });
     let body = flag_binding_body(field);
+    let remember_invalid_choice = remember_invalid_flag_choice(field);
     let table = format_ident!("FLAG_{i}");
     quote! {
         // The key gets us to the right arm in one jump; the identity check makes a
@@ -2398,6 +2399,7 @@ fn flag_arm(cli: &Cli, i: usize, field: &Field) -> TokenStream {
         // have distinct addresses, so this is exact.
         #key if ::core::ptr::eq(*flag, &#table) => {
             #duplicate
+            #remember_invalid_choice
             #body
             partial.#given = true;
             #direct
@@ -2410,6 +2412,70 @@ fn flag_arm(cli: &Cli, i: usize, field: &Field) -> TokenStream {
             #(#displaced)*
             true
         }
+    }
+}
+
+fn tracks_invalid_choice(field: &Field) -> bool {
+    (!field.choices.is_empty() || field.value_enum) && !field.allow_unknown_choices
+}
+
+fn accepted_choices(field: &Field) -> TokenStream {
+    match (field.value_enum, field.value_ty.as_ref()) {
+        (true, Some(ty)) => quote!(<#ty as usage_argv::spec::ValueEnum>::ACCEPTED_CHOICES),
+        _ => {
+            let choices = &field.choices;
+            quote!(&[#(#choices),*])
+        }
+    }
+}
+
+fn choice_ignore_case(field: &Field) -> TokenStream {
+    match (field.value_enum, field.value_ty.as_ref()) {
+        (true, Some(ty)) => quote!(<#ty as usage_argv::spec::ValueEnum>::IGNORE_CASE),
+        _ => quote!(false),
+    }
+}
+
+fn remember_invalid_flag_choice(field: &Field) -> TokenStream {
+    if !tracks_invalid_choice(field) {
+        return TokenStream::new();
+    }
+    let invalid = format_ident!("__invalid_choice_{}", field.ident);
+    let accepted = accepted_choices(field);
+    let ignore_case = choice_ignore_case(field);
+    let reset = (!matches!(field.shape, Shape::Many)).then(|| quote!(partial.#invalid = false;));
+    let check = quote! {
+        if let ::std::result::Result::Ok(__usage_choice_text) =
+            ::std::str::from_utf8(__usage_choice_value)
+        {
+            partial.#invalid |= !usage_argv::spec::choice_matches(
+                #accepted,
+                __usage_choice_text,
+                #ignore_case,
+            );
+        }
+    };
+    match field.delimiter {
+        Some(delimiter) => {
+            let byte =
+                u8::try_from(u32::from(delimiter)).expect("the model rejects non-ASCII delimiters");
+            quote! {
+                #reset
+                if let ::std::option::Option::Some(__usage_choice_value) = value {
+                    for __usage_choice_value in
+                        __usage_choice_value.split(|byte| *byte == #byte)
+                    {
+                        #check
+                    }
+                }
+            }
+        }
+        None => quote! {
+            #reset
+            if let ::std::option::Option::Some(__usage_choice_value) = value {
+                #check
+            }
+        },
     }
 }
 
@@ -2703,9 +2769,52 @@ fn arg_arm(i: usize, field: &Field) -> TokenStream {
         },
         _ => quote!(partial.#ident = __usage_text(value);),
     };
+    let remember_invalid_choice = if tracks_invalid_choice(field) {
+        let invalid = format_ident!("__invalid_choice_{}", field.ident);
+        let accepted = accepted_choices(field);
+        let ignore_case = choice_ignore_case(field);
+        let reset =
+            (!matches!(field.shape, Shape::Many)).then(|| quote!(partial.#invalid = false;));
+        let check = quote! {
+            if let ::std::result::Result::Ok(__usage_choice_text) =
+                ::std::str::from_utf8(__usage_choice_value)
+            {
+                partial.#invalid |= !usage_argv::spec::choice_matches(
+                    #accepted,
+                    __usage_choice_text,
+                    #ignore_case,
+                );
+            }
+        };
+        match field.delimiter {
+            Some(delimiter) => {
+                let byte = u8::try_from(u32::from(delimiter))
+                    .expect("the model rejects non-ASCII delimiters");
+                quote! {
+                    #reset
+                    if delimit {
+                        for __usage_choice_value in value.split(|byte| *byte == #byte) {
+                            #check
+                        }
+                    } else {
+                        let __usage_choice_value = value;
+                        #check
+                    }
+                }
+            }
+            None => quote! {
+                #reset
+                let __usage_choice_value = value;
+                #check
+            },
+        }
+    } else {
+        TokenStream::new()
+    };
     let table = format_ident!("ARG_{i}");
     quote! {
         #key if ::core::ptr::eq(*arg, &#table) => {
+            #remember_invalid_choice
             #body
             partial.#given = true;
             true
@@ -3153,7 +3262,11 @@ fn partial_struct(cli: &Cli) -> TokenStream {
         let mirrored = mirrored_global_ident(f).map(|mirrored| {
             quote!(pub #mirrored: bool,)
         });
-        Some(quote!(pub #ident: #ty, pub #given: bool, #overridden #duplicated #here #negated #mirrored))
+        let invalid_choice = tracks_invalid_choice(f).then(|| {
+            let invalid = format_ident!("__invalid_choice_{}", ident);
+            quote!(pub #invalid: bool,)
+        });
+        Some(quote!(pub #ident: #ty, pub #given: bool, #overridden #duplicated #here #negated #mirrored #invalid_choice))
     });
 
     // No derived `Default`: `start` is what produces a fresh partial, because a
@@ -3490,6 +3603,10 @@ fn partial_defaults(cli: &Cli) -> TokenStream {
             quote!(#negated: false,)
         });
         let mirrored = mirrored_global_ident(f).map(|mirrored| quote!(#mirrored: false,));
+        let invalid_choice = tracks_invalid_choice(f).then(|| {
+            let invalid = format_ident!("__invalid_choice_{}", ident);
+            quote!(#invalid: false,)
+        });
         Some(quote! {
             #ident: ::std::default::Default::default(),
             #given: false,
@@ -3498,6 +3615,7 @@ fn partial_defaults(cli: &Cli) -> TokenStream {
             #here
             #negated
             #mirrored
+            #invalid_choice
         })
     });
     // Only the fields that declare one: `Partial`'s own initializer has already put
@@ -6225,14 +6343,9 @@ fn post_binding(cli: &Cli) -> TokenStream {
                 quote!(&[#(#list),*])
             }
         };
-        let accepted_choices: TokenStream = match (f.value_enum, f.value_ty.as_ref()) {
-            (true, Some(ty)) => quote!(<#ty as usage_argv::spec::ValueEnum>::ACCEPTED_CHOICES),
-            _ => quote!(#choices),
-        };
-        let ignore_case: TokenStream = match (f.value_enum, f.value_ty.as_ref()) {
-            (true, Some(ty)) => quote!(<#ty as usage_argv::spec::ValueEnum>::IGNORE_CASE),
-            _ => quote!(false),
-        };
+        let accepted_choices = accepted_choices(f);
+        let ignore_case = choice_ignore_case(f);
+        let invalid = format_ident!("__invalid_choice_{}", ident);
         let values = match f.shape {
             Shape::Optional => quote!(partial.#ident.iter()),
             Shape::Required => quote!(::std::iter::once(&partial.#ident)),
@@ -6243,6 +6356,14 @@ fn post_binding(cli: &Cli) -> TokenStream {
         let active = view_field_active(f);
         Some(quote! {
             if #active {
+                if partial.#invalid {
+                    return ::std::result::Result::Err(
+                        usage_argv::Error::InvalidChoice {
+                            name: #name,
+                            choices: #choices,
+                        },
+                    );
+                }
                 for value in #values {
                     // Compared as text, since a choice is a word.
                 //

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -382,7 +382,7 @@ pub enum ArgAction {
     Version,
 }
 
-fn arg_action(meta: &Meta) -> syn::Result<(ArgAction, bool, bool)> {
+fn arg_action(meta: &Meta) -> syn::Result<(ArgAction, bool, bool, bool)> {
     let value = &meta.require_name_value()?.value;
     let Expr::Path(path) = value else {
         return Err(syn::Error::new_spanned(
@@ -394,14 +394,15 @@ fn arg_action(meta: &Meta) -> syn::Result<(ArgAction, bool, bool)> {
         return Err(syn::Error::new_spanned(value, "`action` needs a variant"));
     };
     match variant.ident.to_string().as_str() {
-        "Set" | "SetTrue" | "SetFalse" => Ok((ArgAction::Set, false, false)),
-        "Append" => Ok((ArgAction::Set, false, true)),
-        "Count" => Ok((ArgAction::Set, true, false)),
-        "Help" => Ok((ArgAction::Help, false, false)),
-        "HelpShort" => Ok((ArgAction::HelpShort, false, false)),
-        "HelpLong" => Ok((ArgAction::HelpLong, false, false)),
-        "HelpAll" => Ok((ArgAction::HelpAll, false, false)),
-        "Version" => Ok((ArgAction::Version, false, false)),
+        "Set" | "SetTrue" => Ok((ArgAction::Set, false, false, false)),
+        "SetFalse" => Ok((ArgAction::Set, false, false, true)),
+        "Append" => Ok((ArgAction::Set, false, true, false)),
+        "Count" => Ok((ArgAction::Set, true, false, false)),
+        "Help" => Ok((ArgAction::Help, false, false, false)),
+        "HelpShort" => Ok((ArgAction::HelpShort, false, false, false)),
+        "HelpLong" => Ok((ArgAction::HelpLong, false, false, false)),
+        "HelpAll" => Ok((ArgAction::HelpAll, false, false, false)),
+        "Version" => Ok((ArgAction::Version, false, false, false)),
         other => Err(syn::Error::new_spanned(
             value,
             format!("`ArgAction::{other}` is not supported by usage"),
@@ -2146,6 +2147,7 @@ impl Field {
         let mut required_unless: Vec<String> = Vec::new();
         let mut required_unless_all: Vec<String> = Vec::new();
         let mut action = ArgAction::Set;
+        let mut set_false = false;
 
         for attr in attrs(&field.attrs) {
             for meta in nested(attr)? {
@@ -2205,10 +2207,11 @@ impl Field {
                     "variadic" => variadic = flag_value(&meta)?,
                     "count" => count = flag_value(&meta)?,
                     "action" => {
-                        let (parsed, is_count, is_append) = arg_action(&meta)?;
+                        let (parsed, is_count, is_append, is_set_false) = arg_action(&meta)?;
                         action = parsed;
                         count |= is_count;
                         repeatable |= is_append;
+                        set_false |= is_set_false;
                     }
                     // Help only: the parser refuses a bare `--bump` either way. What this
                     // changes is the brackets, which is the whole of what a spec's
@@ -2605,6 +2608,30 @@ impl Field {
                 span,
                 "help and version actions do not bind a value, so their field must be `bool`",
             ));
+        }
+        if set_false {
+            if shape != Shape::Bool {
+                return Err(syn::Error::new(
+                    span,
+                    "`ArgAction::SetFalse` can only bind a `bool` field",
+                ));
+            }
+            if negate.is_some() {
+                return Err(syn::Error::new(
+                    span,
+                    "`ArgAction::SetFalse` already makes the flag a negative spelling; remove `negate`",
+                ));
+            }
+            if longs.len() != 1 || !shorts.is_empty() || !hidden_longs.is_empty() {
+                return Err(syn::Error::new(
+                    span,
+                    "`ArgAction::SetFalse` currently needs exactly one long spelling and no aliases; the portable spec has one negative spelling",
+                ));
+            }
+            if !name_given {
+                name.clone_from(&longs[0]);
+            }
+            negate = longs.pop();
         }
         let (mut value_var_min, mut value_var_max) = (None, None);
         if let Some((min, max)) = num_args {
@@ -5483,6 +5510,46 @@ mod tests {
         .expect("clap value actions preserve their binding shape");
         assert!(actions.fields[0].shape == Shape::Count);
         assert!(actions.fields[1].repeatable);
+
+        let set_false = cli(r#"
+            struct Ex {
+                #[arg(long, action = clap::ArgAction::SetFalse)]
+                color: bool,
+            }
+        "#)
+        .expect("a single long SetFalse action lowers to a negative-only spelling");
+        let Kind::Flag { longs, negate, .. } = &set_false.fields[0].kind else {
+            panic!("SetFalse remains a flag")
+        };
+        assert!(longs.is_empty());
+        assert_eq!(negate.as_deref(), Some("color"));
+
+        let renamed_set_false = cli(r#"
+            struct Ex {
+                #[arg(long = "no-cache", action = clap::ArgAction::SetFalse)]
+                cache_enabled: bool,
+            }
+        "#)
+        .expect("SetFalse keeps an explicit long spelling as its portable identity");
+        assert_eq!(renamed_set_false.fields[0].name, "no-cache");
+        let Kind::Flag { longs, negate, .. } = &renamed_set_false.fields[0].kind else {
+            panic!("SetFalse remains a flag")
+        };
+        assert!(longs.is_empty());
+        assert_eq!(negate.as_deref(), Some("no-cache"));
+
+        let unsupported_set_false = rejection(
+            r#"
+                struct Ex {
+                    #[arg(short, long, action = clap::ArgAction::SetFalse)]
+                    color: bool,
+                }
+            "#,
+        );
+        assert!(
+            unsupported_set_false.contains("exactly one long spelling"),
+            "{unsupported_set_false}"
+        );
 
         let appended_values = cli(r#"
             struct Ex {

--- a/lib/src/spec/flag.rs
+++ b/lib/src/spec/flag.rs
@@ -882,20 +882,36 @@ pub(crate) fn optional_equals_usage(usage: &str) -> String {
 impl From<&SpecFlag> for KdlNode {
     fn from(flag: &SpecFlag) -> KdlNode {
         let mut node = KdlNode::new("flag");
-        let name = flag
+        let visible_shorts = flag
             .short
             .iter()
-            .filter(|short| !flag.hidden_short_aliases.contains(short))
+            .filter(|short| !flag.hidden_short_aliases.contains(short));
+        let visible_longs = flag
+            .long
+            .iter()
+            .filter(|long| !flag.hidden_aliases.contains(long));
+        let inferred_matches = visible_longs
+            .clone()
+            .next()
+            .is_some_and(|long| long == &flag.name)
+            || (visible_longs.clone().next().is_none()
+                && visible_shorts
+                    .clone()
+                    .next()
+                    .is_some_and(|short| short.to_string() == flag.name));
+        let forms = visible_shorts
             .map(|c| format!("-{c}"))
-            .chain(
-                flag.long
-                    .iter()
-                    .filter(|long| !flag.hidden_aliases.contains(long))
-                    .map(|s| format!("--{s}")),
-            )
+            .chain(visible_longs.map(|s| format!("--{s}")))
             .collect_vec()
             .join(" ");
-        node.push(KdlEntry::new(name));
+        let declaration = if inferred_matches {
+            forms
+        } else if forms.is_empty() {
+            format!("{}:", flag.name)
+        } else {
+            format!("{}: {forms}", flag.name)
+        };
+        node.push(KdlEntry::new(declaration));
         if let Some(desc) = &flag.help {
             node.push(string_entry(Some("help"), desc));
         }
@@ -1314,6 +1330,18 @@ impl From<&clap::Arg> for SpecFlag {
             .collect::<Vec<_>>();
         long.extend(hidden_aliases.iter().cloned());
         let name = get_name_from_short_and_long(&short, &long).unwrap_or_default();
+        // A false-setting switch is the negative spelling itself. The portable model keeps
+        // that as `negate`, and a name-only flag form (`color:`) preserves its identity without
+        // inventing a positive spelling that clap never accepted. One spelling is lossless;
+        // multiple aliases remain the bridge's documented action lossiness.
+        let negate = if matches!(c.get_action(), clap::ArgAction::SetFalse)
+            && short.is_empty()
+            && long.len() == 1
+        {
+            Some(format!("--{}", long.remove(0)))
+        } else {
+            None
+        };
         let arg = if let clap::ArgAction::Set | clap::ArgAction::Append = c.get_action() {
             let value_names = crate::spec::arg::value_names_from_clap(c);
             let mut arg = SpecArg::from(
@@ -1430,7 +1458,7 @@ impl From<&clap::Arg> for SpecFlag {
             },
             default,
             deprecated: None,
-            negate: None,
+            negate,
             overrides: vec![],
             // Filled by the command conversion: clap keeps conflicts on the
             // `Command`, not the `Arg`, so an `Arg` alone cannot see them.
@@ -1448,6 +1476,7 @@ impl From<&clap::Arg> for SpecFlag {
                 arg.double_dash = SpecDoubleDashChoices::Automatic;
             }
         }
+        flag.usage = flag.usage();
         flag
     }
 }
@@ -1748,6 +1777,30 @@ mod tests {
         assert!(dump.exclusive);
         let verbose = spec.cmd.flags.iter().find(|f| f.name == "verbose").unwrap();
         assert!(!verbose.exclusive);
+    }
+
+    #[test]
+    fn a_single_clap_set_false_spelling_becomes_a_negative_only_flag() {
+        let cmd = clap::Command::new("ex").arg(
+            clap::Arg::new("color")
+                .long("color")
+                .action(clap::ArgAction::SetFalse),
+        );
+        let spec = Spec::from(&cmd);
+        let color = spec.cmd.flags.iter().find(|f| f.name == "color").unwrap();
+        assert!(color.long.is_empty());
+        assert!(color.short.is_empty());
+        assert_eq!(color.negate.as_deref(), Some("--color"));
+        assert_eq!(color.usage(), "color:");
+        assert_eq!(color.usage, "color:");
+
+        let rendered = spec.to_string();
+        assert!(
+            rendered.contains("flag color: negate=--color"),
+            "{rendered}"
+        );
+        let reparsed: Spec = rendered.parse().expect("the bridge must emit readable KDL");
+        assert_eq!(reparsed.cmd.flags[0].negate.as_deref(), Some("--color"));
     }
 
     #[test]


### PR DESCRIPTION
Restores the set-false conformance layer after the original dependent PR was automatically marked merged while its branch temporarily matched its base during a restack. This branch contains the original reviewed commit on the corrected stack.\n\n_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how SetFalse flags are modeled and how invalid choices interact with scalar overrides, which can alter parse errors and help/KDL for those flags. Coverage is strong, but this is core derive/parser behavior.
> 
> **Overview**
> Lowers clap `ArgAction::SetFalse` to a portable **negate-only** flag instead of inventing a positive spelling. A single long form becomes `negate` (KDL like `flag color: negate=--color`); aliases/shorts are still rejected as lossy.
> 
> Help and KDL emission keep the identity when no visible short/long remains (`color: --no-color` rather than a blank or `/ --negate` form).
> 
> Scalar **choice validation now follows last-token-wins**: an invalid earlier value is forgotten when a later occurrence overrides it, so `--mode bad --mode good` succeeds and `--mode good --mode bad` still fails. Micro-conformance also covers conditional defaults, value terminators, skipped optional positionals, count/set-false, and completion candidates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a71d7c1fbbb3eeb804642a6be85f29b381247bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for negative boolean flags, including `--no-*` spellings.
  * Expanded command-line completion for subcommands and enumerated values.
  * Added conditional defaults, value terminators, counted flags, and skipped optional positional arguments.
* **Bug Fixes**
  * Improved help and usage rendering when positive flag spellings are hidden.
  * Improved invalid-choice detection for repeated, aliased, delimited, and case-insensitive values.
  * Preserved explicit flag names and aliases during configuration serialization.
* **Tests**
  * Added broad conformance and regression coverage for parsing, completion, help output, and configuration round trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->