### PR TITLE
test(clap): cover stateful parser features

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -847,7 +847,8 @@ feature list is not an exhaustive audit.
   external subcommands, `arg_required_else_help`, subcommand requirement/conflict
   policies, conditional defaults, value terminators, skipped optional positionals,
   count/set-false actions, flag and subcommand aliases, case-insensitive value aliases,
-  help headings/placeholders/visibility, and subcommand and value-enum completion candidates. It
+  help headings/placeholders/visibility, default-missing values, flatten/skip, required trailing
+  separators, short/long version output, and subcommand and value-enum completion candidates. It
   records typed values, error classifications, exit status and stream, relevant help,
   and version output; the remaining matrix rows and completion candidates still need
   equivalent minimal pairs. One minimal CLI per matrix row,

--- a/conformance/tests/clap_micro.rs
+++ b/conformance/tests/clap_micro.rs
@@ -1178,3 +1178,155 @@ mod help_metadata {
         }
     }
 }
+
+mod default_missing_value {
+    use super::*;
+
+    #[derive(Debug, clap::Parser)]
+    #[command(name = "micro")]
+    struct ClapCli {
+        #[arg(
+            long,
+            num_args = 0..=1,
+            require_equals = true,
+            default_missing_value = "always"
+        )]
+        color: Option<String>,
+    }
+
+    #[derive(Debug, Cli)]
+    #[usage(bin = "micro", unknown_flags = "error")]
+    struct UsageCli {
+        #[usage(long, require_equals, default_missing = "always")]
+        color: Option<String>,
+    }
+
+    #[test]
+    fn absent_bare_and_explicit_values_have_the_same_states() {
+        for argv in [
+            [].as_slice(),
+            ["--color"].as_slice(),
+            ["--color=never"].as_slice(),
+        ] {
+            let clap =
+                ClapCli::try_parse_from(std::iter::once("micro").chain(argv.iter().copied()))
+                    .unwrap();
+            let words: Vec<&OsStr> = argv.iter().map(OsStr::new).collect();
+            let usage = UsageCli::parse_from(&words).unwrap();
+            assert_eq!(usage.color, clap.color, "{argv:?}");
+        }
+    }
+}
+
+mod flatten_and_skip {
+    use super::*;
+
+    #[derive(Debug, clap::Args)]
+    struct ClapShared {
+        #[arg(long)]
+        verbose: bool,
+        #[arg(skip)]
+        cache_generation: u32,
+    }
+
+    #[derive(Debug, usage_derive::Args)]
+    struct UsageShared {
+        #[usage(long)]
+        verbose: bool,
+        #[usage(skip)]
+        cache_generation: u32,
+    }
+
+    #[derive(Debug, clap::Parser)]
+    #[command(name = "micro")]
+    struct ClapCli {
+        #[command(flatten)]
+        shared: ClapShared,
+        input: Option<String>,
+    }
+
+    #[derive(Debug, Cli)]
+    #[usage(bin = "micro", unknown_flags = "error")]
+    struct UsageCli {
+        #[usage(flatten)]
+        shared: UsageShared,
+        #[usage(arg)]
+        input: Option<String>,
+    }
+
+    #[test]
+    fn flattened_values_bind_and_skipped_values_default() {
+        let clap = ClapCli::try_parse_from(["micro", "--verbose", "input"]).unwrap();
+        let usage = UsageCli::parse_from(&[OsStr::new("--verbose"), OsStr::new("input")]).unwrap();
+        assert_eq!(usage.shared.verbose, clap.shared.verbose);
+        assert_eq!(usage.shared.cache_generation, clap.shared.cache_generation);
+        assert_eq!(usage.input, clap.input);
+    }
+}
+
+mod trailing_values {
+    use super::*;
+
+    #[derive(Debug, clap::Parser)]
+    #[command(name = "micro")]
+    struct ClapCli {
+        #[arg(last = true)]
+        rest: Vec<String>,
+    }
+
+    #[derive(Debug, Cli)]
+    #[usage(bin = "micro", unknown_flags = "error")]
+    struct UsageCli {
+        #[usage(arg, double_dash = "required")]
+        rest: Vec<String>,
+    }
+
+    #[test]
+    fn a_separator_is_required_and_not_collected() {
+        let clap = ClapCli::try_parse_from(["micro", "--", "--literal", "tail"]).unwrap();
+        let usage = UsageCli::parse_from(&[
+            OsStr::new("--"),
+            OsStr::new("--literal"),
+            OsStr::new("tail"),
+        ])
+        .unwrap();
+        assert_eq!(usage.rest, clap.rest);
+
+        let clap = ClapCli::try_parse_from(["micro", "tail"]).unwrap_err();
+        let usage = UsageCli::parse_from(&[OsStr::new("tail")]).unwrap_err();
+        assert_eq!(clap.kind(), clap::error::ErrorKind::UnknownArgument);
+        assert!(matches!(usage, Error::ArgRequiresDoubleDash { .. }));
+    }
+}
+
+mod long_version {
+    use super::*;
+
+    #[derive(Debug, clap::Parser)]
+    #[command(name = "micro", version = "1.2.3", long_version = "1.2.3\ncommit abc")]
+    struct ClapCli {}
+
+    #[derive(Debug, Cli)]
+    #[usage(
+        bin = "micro",
+        version = "1.2.3",
+        long_version = "1.2.3\ncommit abc",
+        unknown_flags = "error"
+    )]
+    struct UsageCli {}
+
+    fn usage_exit(argv: &[&str]) -> Exit {
+        let words: Vec<&OsStr> = argv.iter().map(OsStr::new).collect();
+        let error = UsageCli::parse_from(&words).expect_err("version exits");
+        usage_error(UsageCli::spec(), &words, error)
+    }
+
+    #[test]
+    fn short_and_long_actions_emit_the_same_versions() {
+        assert_eq!(usage_exit(&["-V"]), clap_exit::<ClapCli>(&["-V"]));
+        assert_eq!(
+            usage_exit(&["--version"]),
+            clap_exit::<ClapCli>(&["--version"])
+        );
+    }
+}


### PR DESCRIPTION
Replaces #1149, which GitHub automatically marked merged when dependent branch refs temporarily matched during a restack. This is the same layer on the corrected stack.\n\n_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and plan-status updates; no parser or production behavior changes.
> 
> **Overview**
> Extends the clap micro-conformance harness with four more paired CLIs so usage and clap agree on **default-missing values**, **flatten + skip**, **required trailing `--`**, and **short vs long version** output.
> 
> `PLAN.md` now lists those rows as covered; remaining matrix rows are still open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8495044ce0618ed5b39712ccc291b0c46b51e98f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->