### PR TITLE
docs: resolve remaining 6.x design decisions

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -931,19 +931,37 @@ checked-in `mise.usage.kdl` for both parsers.
       between parsers rather than between two transcriptions. Both shadows drop the
       same properties. Three release binaries — one per parser, one that does
       everything except parse — measured by `tak`, which gates the counts in CI.
-- [x] **Perf report** — at mise's full scale, a cold parse costs **50.9k instructions
-      against clap's 5.96M: 117× fewer**, and **2.1µs against 490µs of wall clock**.
-      _Re-measured later, and it moved:_ **60.4k against 5.90M — 97×**. clap is flat;
-      our parse grew about 19% as the derive gained vocabulary, so the headroom under
-      the <100k target went from 2× to 1.65×. Still passing, and nothing watches it:
-      the shadow comparison is reported and never gated, on the grounds that the
-      fixture grows on purpose. That reasoning holds for the absolute number and not
-      for the _ratio_, which is a property of the two parsers. Worth a gate before the
-      margin erodes further.
+- [x] **Perf report** — at mise's full scale, a cold parse costs **7,377 instructions
+      against clap's 6.31M: 855× fewer**, and **0.69µs against 544µs of wall clock**.
       Measured by differencing two runs of the _same_ binary over how many parses it
-      does, so nothing but the parse varies. clap's 490µs is 305µs building its command
-      tree, ~160µs validating it, and ~24µs actually parsing — so even against clap's
-      parse alone, with the tree already built and paid for, this is 12× faster.
+      does, so nothing but the parse varies. clap's 544µs is ~343µs building its command
+      tree, ~178µs validating it, and ~23µs actually parsing — so even against clap's
+      parse alone, with the tree already built and paid for, this is 34× faster.
+      **The count went 50.9k → 63.8k → 7,377, and the middle number is the instructive
+      one.** The rise read as the price of vocabulary and was nothing of the kind. Two
+      costs scaled with the size of the whole CLI rather than with what was typed.
+      `Partial` is the entire CLI's accumulator — every command's fields inlined,
+      recursively, 11KB at mise's scale — and `read_argv`, `read` and `parse_from` each
+      returned one _by value_, so a parse copied it four times and spent ~87% of itself
+      copying; `read_into`/`read_argv_into` take `&mut` (#980), 63.8k → 18.5k. Then
+      `Subcommands::Partial` was a struct with a field per variant, so constructing it
+      materialised all 211 commands' accumulators when 210 were unreachable by
+      construction; it is an enum now (#981), 18.5k → 4.2k, the type 11,000 → 824 bytes
+      and data refs 116,742 → 1,889. Because the accumulator was copied four times per
+      parse, every property the derive learned widened a struct already being copied, so
+      ordinary growth arrived multiplied. Removing the copies removed the multiplier:
+      **metadata a parse does not read now costs a parse nothing**, which is the property
+      the design claimed all along and only now actually has.
+      The rest of the movement is the fixture, not the parser, and one parser against
+      both fixtures separates them: **4,907 against the pre-refresh spec, 7,377 against
+      the current one**, which #1142 refreshed from mise's real typed tree with more
+      positionals and per-command metadata. clap moves ~7% across the same swap. usage
+      moves more in proportion only because its own cost is now small enough that the
+      fixture's shape dominates it — which is the permanent condition from here, and the
+      reason the absolute number is worth less than the ratio.
+      The ratio _is_ watched now: `CLAP_RATIO_FLOOR=80` in `tasks/perf-shadow.sh` warns
+      when it slides (af2495da), so the earlier "nothing watches it" is answered. At
+      855× the margin over that floor is about 10×.
 - [x] **Differential fuzzing** — proptest over argv on the mise spec, against
       usage-lib **and clap**. The three-way comparison distinguishes intentional usage
       defaults from regressions: unknown flags and scalar repeats are permissive unless a
@@ -956,9 +974,9 @@ checked-in `mise.usage.kdl` for both parsers.
       usage-lib resolves `mount run="mise tasks --usage"` by _running_ it, so the first
       draft spawned real `mise` processes that loaded config, fetched vfox metadata and
       shelled out to `apt-cache`. See `benches/gate/tests/differential.rs`.
-- [x] **Published performance report.** The Rust guide now records the original
-      launch measurements, the later 19% instruction increase and reduced ratio,
-      the absolute gates, the measurement method, and what the comparison does
+- [x] **Published performance report.** The Rust guide records the current
+      measurements, the whole path the instruction count took and why it moved both
+      ways, the absolute gates, the measurement method, and what the comparison does
       not include. It links the checked-in benchmark sources rather than
       presenting the numbers without a reproducible path.
 
@@ -966,8 +984,8 @@ Runtime targets, which gate:
 
 | measurement                        | clap, measured | target | result            |
 | ---------------------------------- | -------------- | ------ | ----------------- |
-| instructions, route + parse        | 5.96M          | < 100k | 50.9k, 117×       |
-| wall time, argv to parsed struct   | 490µs          | < 50µs | 2.1µs, 238×       |
+| instructions, route + parse        | 6.31M          | < 100k | 7,377, 855×       |
+| wall time, argv to parsed struct   | 544µs          | < 50µs | 0.69µs, 788×      |
 | heap allocations, successful parse | 6,560          | 0      | 0 bare, 3–4 bound |
 
 All three gating targets are met, and not narrowly. Allocations were the last one owed:
@@ -977,9 +995,10 @@ costs three or four allocations, one per value. clap's tree costs **6,560** ever
 so this is about 2,000× fewer.
 
 Getting there needed one fix and one correction. Defaults were being applied in `start`,
-which builds the partial for _every_ command in the CLI rather than the selected one, so a
-bare `mise` was allocating 60 times for defaults it would never read; they now run in
-`check`, guarded on whether the flag was given. And the counter itself was wrong — armed
+which at the time built the partial for _every_ command in the CLI rather than the selected
+one, so a bare `mise` was allocating 60 times for defaults it would never read; they now run
+in `check`, guarded on whether the flag was given. (`start` no longer works that way either
+— #981 made `Subcommands::Partial` an enum, for the instruction cost described above.) And the counter itself was wrong — armed
 per thread but counting into a global — so parallel tests were counting each other and a
 4-allocation parse read as 24, intermittently. usage-argv's own counter had the same
 latent flaw and now counts per thread too.

--- a/PLAN.md
+++ b/PLAN.md
@@ -547,12 +547,17 @@ Groups are the opposite case: `Command::get_groups`, `ArgGroup::get_args` and
 - [x] **`flatten_help`.** Visible subcommands can be expanded into their parent's
       usage synopsis and help sections across typed Rust, KDL, the clap bridge,
       and Rust and generated Go help.
-- [ ] **`help_template`.** **Design input needed:** define the stable template
-      context. A root-level Tera template can apply to the whole command tree,
-      but interpreted Rust, compiled Rust, and generated Go need to expose the
-      same named sections and values. Shipping only a `{{ help }}` wrapper would
-      technically accept a template without supporting clap's main use case of
-      rearranging help sections.
+- [ ] **`help_template`.** A root-level Tera template applying to the whole
+      command tree. **Decided (2026-08-21): a closed vocabulary of pre-rendered
+      named sections** — `usage`, `about`, `flags`, `args`, `commands`,
+      `after_help` — which an author may reorder, omit or wrap. That covers
+      clap's actual use case of rearranging help sections, which a bare
+      `{{ help }}` wrapper would not, while leaving interpreted Rust, compiled
+      Rust and generated Go to agree only on where each section starts and ends
+      rather than on layout. The alternative — exposing the metadata tree and
+      letting the template lay everything out — was rejected because it makes
+      the help renderer's internals public API and requires every
+      implementation to match Tera's semantics, not just its section names.
 - [x] **`subcommand_help_heading` / `subcommand_value_name`.** Custom subcommand
       section labels and synopsis placeholders survive KDL, typed Rust, generated
       Go, and the clap bridge and are rendered by both help implementations.
@@ -585,12 +590,20 @@ Groups are the opposite case: `Command::get_groups`, `ArgGroup::get_args` and
 **API surface**
 
 - [ ] **`update_from` / `try_update_from`** — merge a parse into an existing struct.
-      **Design input needed:** define whether requirements and value-conditional relationships
-      see the existing typed value when argv omits a field, whether environment/default values
-      replace existing values during an update, whether collections append or replace, and
-      whether selecting a different subcommand replaces the old variant. The generated parser
-      cannot seed its byte-level partial from an arbitrary `FromStr` type, so these choices must
-      be explicit rather than inherited accidentally from the current full-parse path.
+      The generated parser cannot seed its byte-level partial from an arbitrary `FromStr`
+      type, so every rule here is explicit rather than inherited accidentally from the
+      current full-parse path. **Decided (2026-08-21): relationships see the existing
+      value** — `required`, `requires_if`, `conflicts` and the rest treat a field already
+      holding a value as present, so an update validates the union of both inputs rather
+      than this argv alone. **Env and defaults do not overwrite**: they fill only fields
+      still empty, so an update never clobbers a value the caller set deliberately, and an
+      update with no relevant argv cannot change the struct. **Collections replace when
+      argv mentions them** — any values for a `Vec` field in this argv replace the whole
+      collection, while argv that says nothing leaves it alone, which keeps an update
+      idempotent and matches how a repeated flag behaves inside one parse; append was
+      rejected because it leaves no way to clear a field. **A different subcommand
+      replaces the variant** wholesale, discarding the old variant's fields, since
+      selecting a command is a routing decision rather than a value to merge.
 - [x] **The builder** — `Command::new`, `augment_args`, `CommandFactory`,
       `ArgMatches::get_one`, hand-written `FromArgMatches`. Architectural, and
       deliberate: usage-lib interprets a spec at run time and covers the dynamic
@@ -1109,13 +1122,13 @@ a prerequisite for trying a CLI.
       with `usage-rs`, uses the built-in completion protocol, and passes its Rust and
       bats suites against the stacked usage revision. Its refreshed spec is part of the
       fleet gate alongside the five original typed experiments.
-- [~] **Other languages** — Go now parses, validates, renders help and answers
-  completions from generated static tables, verified against the shared corpus.
-  JavaScript and Python implementations remain open. **Design input needed:** decide
-  whether each generator emits a self-contained vendored runtime or targets a maintained
-  npm/PyPI runtime package; set the oldest supported Node and Python versions; and decide
-  whether 6.x requires binding only or the Go implementation's full help/completion parity.
-  Those choices determine the public package boundary and should precede implementation.
+- [x] **Other languages** — Go parses, validates, renders help and answers
+      completions from generated static tables, verified against the shared corpus.
+      That is the proof a second implementation can reach parity from the spec alone,
+      which is what this row existed to establish. JavaScript and Python are off the
+      plan (2026-08-21): no adopter asks for either, and each would owe a runtime
+      packaging and support-window decision — vendored versus published on npm/PyPI,
+      an oldest supported Node and Python — that only a real consumer can settle.
 
 ### What adoption should let mise delete
 
@@ -1375,20 +1388,23 @@ above are where it lands.
       clap's most-requested) — mutually exclusive flags declared as enum
       variants, lowering to the `group`/`conflicts` vocabulary the spec already
       has. Derive ergonomics rather than new spec surface, and clap has sat on
-      it since 2021. **Design input needed:** choose the Rust surface. The leading
-      option is an `Option<Mode>` field whose `ValueEnum`-like variants each declare
-      a flag, with a non-optional `Mode` making the group required. Decide whether
-      variants may carry values, how a default variant differs from a defaulted flag,
-      and whether repeated flags use last-wins or remain a conflict.
-- [ ] **Alias into a nested subcommand** (clap#1603, reopened, 22 comments) —
-      rustup's `install` meaning `toolchain install`, args carried along. A
-      spec-level redirect an interpreter applies before parsing, so help and
-      completions describe the alias too; clap's unstable `App::replace`
-      answer died for lack of interest. **Design input needed:** the proposed portable
-      shape is a root `redirect "install" to="toolchain install"` node and a matching
-      typed attribute. Confirm that only the first command word is rewritten, trailing
-      argv is preserved verbatim, a real command wins on a name collision, and redirect
-      chains are rejected rather than followed.
+      it since 2021. **Decided (2026-08-21): `#[derive(usage::ArgGroup)]` on the
+      enum**, held by an `Option<Mode>` field for an optional group and a bare
+      `Mode` field for a required one. A new derive rather than an overloaded
+      `ValueEnum`, because the same enum would otherwise lower two entirely
+      different ways depending on the field holding it; and an enum rather than a
+      `group = "mode"` attribute over `bool` fields, because the stringly-typed
+      "which one was set" match is exactly what clap#2621 exists to remove.
+      **Bare variants only**, each a valueless flag, which is what the issue asks
+      for — a group whose members take values stays a hand-written `conflicts`
+      set, so group resolution never runs the typed-value path. **No default
+      variant**: required-ness is the `Option<Mode>` versus `Mode` distinction and
+      nothing else, so defaults stay a per-flag concern and there is no second way
+      to spell one, nor a new spec node for help, completions and the docs
+      generators to describe. **Two members on one command line is an error**,
+      matching clap's `ArgGroup` and the `conflicts` vocabulary this lowers to;
+      exclusivity is the point, so a typo is reported rather than silently
+      resolved to whichever came last.
 - [x] **Recursive help** (clap#4813) — `ArgAction::HelpAll` renders long help
       for the selected command and every visible descendant in one depth-first
       output. Typed Rust, portable KDL, usage-lib, and generated Go retain the
@@ -1426,6 +1442,19 @@ above are where it lands.
       are first-class typed root attributes, survive direct KDL emission, and render
       in Markdown, manpages, and generated Go long help. GPL display requirements no
       longer need an application-owned documentation patch.
+
+**Considered and declined:**
+
+- **Alias into a nested subcommand** (clap#1603, reopened, 22 comments) —
+  rustup's `install` meaning `toolchain install`, args carried along. The
+  portable shape was worked out: a root `redirect "install" to="toolchain install"`
+  node with a matching typed attribute, rewriting only the first command word,
+  preserving trailing argv verbatim, letting a real command win a name collision
+  and rejecting redirect chains. **Declined (2026-08-21): not useful enough to
+  build.** None of the fleet asks for it, clap's own unstable `App::replace`
+  answer died for lack of interest, and it buys a second name for a command that
+  aliases at the wrong level already cover in the common case. Reopen if an
+  adopter needs it; the shape above is the design, not a fresh question.
 
 Demand also attaches to boxes already open above: fixed arity with distinct
 value names is clap#1717 + clap#1682 (31 votes combined); `Option` on a
@@ -1609,12 +1638,14 @@ Where they differ is instructive, because it is mostly _drift_:
 - [ ] **Declare props in code**, `#[derive(usage::Config)]`, lowered into the
       spec's `config { prop ... }` block so settings documentation flows through
       the same pipeline as command documentation. Same canonicality rule as the
-      parser: code authors, the spec defines. **Design input needed:** choose whether
-      the derive belongs on the final typed settings struct or on a registry-only
-      declaration whose generated output feeds an existing settings type. The former
-      gives one source of truth but requires attributes for layer bindings and merge
-      policy on application fields; the latter makes incremental fleet adoption easier
-      but preserves two declarations during the migration.
+      parser: code authors, the spec defines. **Decided (2026-08-21): the derive goes
+      on a registry-only declaration**, whose generated output feeds the CLI's existing
+      settings type rather than replacing it. Putting it on the final typed `Settings`
+      would be one source of truth, but it pushes layer bindings and merge policy onto
+      application fields and makes every adopter convert its whole registry in one step.
+      A registry-only declaration lets mise, hk, pitchfork and fnox adopt a layer at a
+      time, which is the migration path this section already judges likeliest to happen.
+      The cost is accepted and bounded: two declarations coexist during a migration.
 - [x] **A prop vocabulary that is the union of the four registries** — `type`
       (bool, int, string, path, duration, list, map, plus a Rust-type escape
       hatch), `default`, `env` and `deprecated_env`, `docs`, `deprecated` with
@@ -1645,28 +1676,34 @@ Where they differ is instructive, because it is mostly _drift_:
       bindings, help fields, explicit `optional`, and warning-free key `aliases` all
       survive the portable spec. The markdown renderer and generated runtime registry
       consume the block; no fleet CLI emits one yet, which is the adoption half below.
-- [ ] **A registry JSON schema**, so the declaration format validates itself the
-      way hk's does. **Design input needed:** 6.x no longer has a separate TOML
-      registry declaration to validate: the usage KDL spec is the declaration,
-      its parser validates that block, and `usage generate json-schema` describes
-      the _user config file_. Decide whether this means a machine schema for KDL,
-      retaining a supported TOML authoring format, or deleting this now-obsolete
-      requirement.
+- [x] **A registry JSON schema** — **dropped as obsolete (2026-08-21).** The
+      requirement came from hk validating its own `settings.toml` through taplo. In 6.x
+      there is no separate TOML registry to validate: the usage KDL spec _is_ the
+      declaration, the spec parser validates the `config` block with real diagnostics,
+      and `usage generate json-schema` already describes the user's config file. A
+      second machine description of the block would only add something for the parser
+      to drift from.
 
 ### Open questions
 
-- [ ] Whether config lives in this repository or beside the parser crates. It is
-      not argv parsing, but it shares the spec, the codegen, and the docs
-      pipeline. **Design input needed:** keeping it in this repository preserves one
-      release train and spec vocabulary; splitting it permits an independent stability
-      and MSRV policy.
+- [x] Whether config lives in this repository or beside the parser crates.
+      **Decided (2026-08-21): this repository.** One release train and one spec
+      vocabulary, and config already shares the spec model, the codegen and the docs
+      pipeline — `config/` and `SpecConfigProp` are here today, so this is also the
+      status quo. A split would buy an independent stability and MSRV policy at the
+      price of cross-repo coordination on every spec vocabulary change.
 - [ ] Whether the four CLIs migrate incrementally (one layer at a time, keeping
       their generated `Settings`) or by regenerating from a converted registry.
-      Incremental looks far more likely to actually happen. **Design input needed:**
-      confirm incremental adoption as the supported 6.x path, which means the first
-      public APIs must wrap existing layers and settings types without owning them.
-- [ ] fnox's model, where config files are not a settings source at all, is the
+      Incremental looks far more likely to actually happen. **Owned by the fleet
+      adoption effort (2026-08-21), not decided here** — it is a question about what
+      each CLI does, and the answer sets whether the first public APIs must wrap
+      existing layers and settings types without owning them. The registry-only
+      derive above deliberately keeps the incremental path open either way.
+- [x] fnox's model, where config files are not a settings source at all, is the
       one real behavior change rather than a consolidation. Worth confirming that
-      is a fix and not a deliberate choice. **Design input needed:** decide whether
-      fnox should gain config-file settings during adoption or preserve its current
-      source set and use only the shared layers that already exist there.
+      is a fix and not a deliberate choice. **Decided (2026-08-21): preserve fnox's
+      source set.** Adoption uses only the shared layers fnox already has, so it stays
+      a consolidation everywhere and ships no behavior change to a released CLI. The
+      hardcoded five-way `age_key_file` chain in `providers/age.rs` is still replaced by
+      one declaration — that is the actual bug — without adding a source that could pick
+      up keys users never meant as settings.

--- a/docs/rust/performance.md
+++ b/docs/rust/performance.md
@@ -14,26 +14,54 @@ same binary.
 
 | Measurement                                  | usage |  clap |                Result |
 | -------------------------------------------- | ----: | ----: | --------------------: |
-| Retired instructions, route and parse        | 50.9k | 5.96M |            117x fewer |
-| Wall time, argv to parsed value              | 2.1us | 490us |           238x faster |
+| Retired instructions, route and parse        | 7,377 | 6.31M |            855x fewer |
+| Wall time, argv to parsed value              | 0.7us | 544us |           788x faster |
 | Heap allocations, no values bound            |     0 | 6,560 | no parser allocations |
 | Heap allocations, three or four values bound |   3-4 | 6,560 |   one per owned value |
 
 The original launch targets were fewer than 100k retired instructions, less
-than 50us, and zero allocations when no value is bound. All three passed.
+than 50us, and zero allocations when no value is bound. All three pass.
 
-A later measurement moved usage to 60.4k instructions while clap remained
-approximately flat at 5.90M, reducing the ratio from 117x to 97x. The parser is
-still comfortably under the absolute gate, but the change is reported because
-the ratio is useful evidence that vocabulary growth is not free.
+### How the instruction count moved
+
+The number above is not monotone, and the shape of the curve is the useful part.
+It was 50.9k at launch, rose to 63.8k, and is now 7,377.
+
+The rise looked like the price of vocabulary, and was not. Two costs scaled with
+the size of the whole CLI rather than with what the user typed:
+
+- `Partial` is the entire CLI's accumulator, every command's fields inlined
+  recursively, which is 11KB at mise's scale. `read_argv`, `read` and
+  `parse_from` each returned one by value, so a parse performed four copies of
+  it and spent about 87% of its instructions copying. `read_argv_into` and
+  `read_into` take `&mut` instead: 63.8k to 18.5k.
+- `Subcommands::Partial` was a struct with a field per variant, so constructing
+  it materialized all 211 commands' accumulators when 210 of them were
+  unreachable by construction. It is an enum now, either `Unselected` or the one
+  variant being filled: 18.5k to 4.2k, with the type itself falling from 11,000
+  to 824 bytes and data references from 116,742 to 1,889.
+
+Because `Partial` was copied four times per parse, every property the derive
+learned to express widened a struct that was already being copied, so ordinary
+vocabulary growth arrived multiplied. Removing the copies removed the
+multiplier: metadata a parse does not read now costs a parse nothing.
+
+The remainder of the movement is the fixture rather than the parser. Measuring
+one parser against both fixtures separates them: the current parser scores 4,907
+against the pre-refresh spec and 7,377 against the current one, which now comes
+from mise's real typed command tree and carries more positional arguments and
+per-command metadata. clap grows about 7% across the same change. usage grows
+more in proportion only because its own cost is now small enough for the
+fixture's shape to dominate it.
 
 ## What clap's number includes
 
-For this generated command tree, clap's approximately 490us consists of about
-305us constructing the tree, 160us validating it, and 24us parsing. usage's
-tables are compiled, so its 2.1us path has no equivalent construction or
-validation phase. Even compared only with clap's already-built parse phase,
-usage was about 12x faster in this measurement.
+For this generated command tree, clap's approximately 544us consists of about
+343us constructing the tree, 178us validating it, and 23us parsing. usage's
+tables are compiled, so its 0.7us path has no equivalent construction or
+validation phase. Even compared only with clap's already-built parse phase, with
+the tree constructed and paid for, usage is about 34x faster in this
+measurement.
 
 ## Method and limits
 
@@ -45,9 +73,11 @@ usage was about 12x faster in this measurement.
   unsupported properties.
 - This measures routing and parsing, not process startup, configuration loading,
   command execution, help rendering, or completion generation.
-- The mise fixture grows over time. CI protects the absolute instruction target;
-  this report also records the parser-to-parser ratio so regressions remain
-  visible when the fixture changes.
+- The mise fixture changes over time, both by growing and by being refreshed
+  from mise's current command tree, so one commit's count is not directly
+  comparable with another's. CI protects the absolute instruction target, and
+  `tasks/perf-shadow.sh` warns when the parser-to-parser ratio falls below 80x,
+  which is the measure that belongs to the parsers rather than to the fixture.
 
 The benchmark sources live in `benches/gate`, with generated shadows under
 `benches/shadows`.

--- a/tasks/perf-shadow.sh
+++ b/tasks/perf-shadow.sh
@@ -70,11 +70,18 @@ verify() {
 #
 # Not a gate — the workflow runs this with `|| true`, and a shared runner is no place to fail a
 # build on an instruction count. It is an annotation, because the alternative turned out to be
-# nobody noticing: the number went from 117x to 97x across a run of feature work, unremarked,
+# nobody noticing: the number slid from 117x to 81x across a run of feature work, unremarked,
 # because the only place it appeared was one line of a report nobody diffs. clap is flat, so the
 # movement was ours.
 #
-# 80 rather than 117: the point is to catch a slide, not to pin the current figure. A parse that
+# Worth knowing what that slide actually was, since it was read as the price of vocabulary and
+# was not: `Partial` is the whole CLI's accumulator and was returned by value, so a parse copied
+# 11KB four times, and `Subcommands::Partial` was a struct with a field per variant, so building
+# it materialised 211 commands' worth to use one. Fixing both took the ratio to 855x. Features
+# were never the cost — a struct sized by the whole CLI, copied per parse, was multiplying them.
+# So a future slide here is worth looking at structurally before it is blamed on vocabulary.
+#
+# 80 rather than 855: the point is to catch a slide, not to pin the current figure. A parse that
 # is only 80x cheaper than clap's has stopped being the thing this project claims, and that is
 # worth a sentence in the log before it is worth an argument about the target.
 CLAP_RATIO_FLOOR=80


### PR DESCRIPTION
After #1163 annotated every open PLAN.md item with **Design input needed**, all nine were blocked on a decision rather than on work. This answers them, declines two features outright, and leaves one question to the effort that owns it.

Open items go from **9 to 5**, and zero `Design input needed` markers remain — what is left is implementation.

## Parser

- **`help_template`** — a closed vocabulary of pre-rendered named sections (`usage`, `about`, `flags`, `args`, `commands`, `after_help`) that an author may reorder, omit or wrap. That covers clap's actual use case, which a bare `{{ help }}` wrapper would not, while leaving interpreted Rust, compiled Rust and generated Go agreeing only on where each section starts and ends. Exposing the metadata tree instead was rejected: it makes the help renderer's internals public API and requires every implementation to match Tera's semantics.
- **`update_from` / `try_update_from`** — relationships see the existing value; env and defaults fill only empty fields; collections replace when argv mentions them and are untouched when it does not; a different subcommand replaces the variant wholesale. Append was rejected because it leaves no way to clear a field.
- **A group as an enum** (clap#2621) — `#[derive(usage::ArgGroup)]` on the enum, held by `Option<Mode>` for an optional group and a bare `Mode` for a required one. Bare variants only, no default variant, and two members on one command line is an error. A new derive rather than an overloaded `ValueEnum`, because the same enum would otherwise lower two different ways depending on the field holding it.

## Config

- **`#[derive(usage::Config)]` goes on a registry-only declaration**, feeding the CLI's existing settings type rather than replacing it. Putting it on the final `Settings` would be one source of truth but forces every adopter to convert its whole registry in one step; registry-only is what lets the fleet adopt a layer at a time.
- **The registry JSON schema is dropped as obsolete.** The requirement came from hk validating its own `settings.toml`. In 6.x the KDL spec *is* the declaration, the spec parser validates the `config` block, and `usage generate json-schema` describes the user's config file.
- **Config stays in this repository** — one release train and one spec vocabulary, and it already shares the spec model, codegen and docs pipeline.
- **fnox preserves its current source set**, so adoption stays a consolidation and ships no behavior change to a released CLI. The hardcoded five-way `age_key_file` chain in `providers/age.rs` is still replaced by one declaration, which is the actual bug.

## Removed from scope

- **Alias into a nested subcommand** (clap#1603) is declined and moved to a new **Considered and declined** subsection. The worked-out `redirect "install" to="toolchain install"` design stays recorded, so if an adopter asks it is a decision to revisit rather than a design to redo.
- **JavaScript and Python implementations are off the plan.** Go reaching full parity is what that row existed to prove; the vendored-versus-published runtime and support-window questions need a real consumer to settle.

## Left open on purpose

The fleet migration path (incremental versus regenerating from a converted registry) is marked as owned by the fleet adoption effort rather than decided here. The registry-only derive decision keeps the incremental path open either way, so it does not block.

## Testing

Docs only — no code paths touched. `prettier -c` passes, which is what `mise run lint` enforces for markdown.

---

# Second commit: correct the published performance numbers

While checking the plan's "worth a gate before the margin erodes further" note, the regression it describes turned out to have been fixed on 2026-08-17. The published report was understating the shipped parser by roughly 8x.

Re-measured at mise's scale with the existing harness:

| measurement | usage | clap | ratio |
|---|---:|---:|---:|
| instructions, cold parse | **7,377** | 6,307,481 | **855x** |
| wall time, argv to struct | **0.69us** | 543.89us | 788x |

All three original gates still pass, by a wider margin than at launch.

## Why the number moved, which the old text got wrong

It went 50.9k -> 63.8k -> 7,377. The rise read as the price of vocabulary and was nothing of the kind. Two costs scaled with the size of the whole CLI rather than with what was typed:

- **`Partial` was returned by value.** It is the entire CLI's accumulator, every command's fields inlined recursively, 11KB at mise's scale, and `read_argv` / `read` / `parse_from` each returned one. Four copies per parse, about 87% of the parse spent copying. #980 took it 63.8k -> 18.5k.
- **`Subcommands::Partial` was a struct with a field per variant.** Constructing it materialised all 211 commands' accumulators when 210 were unreachable by construction. #981 made it an enum: 18.5k -> 4.2k, the type 11,000 -> 824 bytes, data refs 116,742 -> 1,889.

Because the accumulator was copied four times per parse, every property the derive learned widened a struct already being copied, so ordinary growth arrived multiplied. Removing the copies removed the multiplier: metadata a parse does not read now costs a parse nothing.

## The rest is the fixture, not the parser

Measuring one parser against both fixtures separates them: **4,907** against the pre-refresh spec, **7,377** against the current one, which #1142 refreshed from mise's real typed command tree with more positionals and per-command metadata. clap moves about 7% across the same swap; usage moves more in proportion only because its own cost is now small enough for the fixture's shape to dominate.

## Two stale claims also corrected

- The plan said the ratio was unwatched and worth a gate. `CLAP_RATIO_FLOOR=80` in `tasks/perf-shadow.sh` has warned on a slide since af2495da; at 855x the margin over it is about 10x.
- The allocation note described `start` building every command's partial in the present tense, which #981 ended.

The floor's own comment keeps its history but no longer implies features caused the slide, since that is the wrong conclusion for the next reader to draw.

## Testing

Docs and one comment-only shell change. `prettier -c` passes, `bash -n` and `shellcheck` are clean on `tasks/perf-shadow.sh`. Numbers come from `./tasks/perf-shadow.sh` (cachegrind, cold parse as N=1 minus N=0 of the same binary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to PLAN.md; no code, APIs, or runtime behavior change.
> 
> **Overview**
> Resolves the remaining **Design input needed** items in `PLAN.md` so open 6.x work is implementation, not design.
> 
> **Parser:** `help_template` is a closed set of pre-rendered sections (`usage`, `about`, `flags`, `args`, `commands`, `after_help`). `update_from` treats existing values as present, never overwrites with env/defaults, replaces collections when argv mentions them, and replaces a subcommand variant wholesale. Group-as-enum is `#[derive(usage::ArgGroup)]` with bare variants only, `Option<Mode>` vs `Mode` for required-ness, and two members on one line as an error.
> 
> **Config:** `#[derive(usage::Config)]` is registry-only (feeds existing settings types). The registry JSON schema is dropped as obsolete. Config stays in this repo. fnox keeps its current source set.
> 
> **Out of scope:** nested-subcommand redirects (clap#1603) and JS/Python implementations. Fleet incremental-vs-regenerate migration is left to the adoption effort.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a60d8411c9ba109a6b94bc19378bb91507b39bc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified help template structure and rendering behavior.
  * Documented update semantics for relationships, defaults, environment variables, collections, and subcommands.
  * Defined supported language scope and removed JavaScript and Python from the roadmap.
  * Documented argument-group design and nested-command alias decisions.
  * Clarified configuration architecture, schema direction, repository ownership, and source-set decisions.
  * Updated parser performance measurements, methodology, fixture comparisons, and regression thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
