### PR TITLE
feat(cli): check that examples still parse, and let the derive declare them

### DIFF
--- a/cli/src/cli/lint.rs
+++ b/cli/src/cli/lint.rs
@@ -1,6 +1,9 @@
 use std::cmp::Ordering;
+use std::collections::HashMap;
 use std::path::PathBuf;
-use usage::{Spec, SpecArg, SpecCommand, SpecFlag};
+use usage::error::UsageErr;
+use usage::spec::cmd::SpecExample;
+use usage::{Parser, Spec, SpecArg, SpecCommand, SpecFlag, SpecFlagAction};
 
 use crate::cli::generate::parse_file_or_stdin;
 
@@ -246,8 +249,19 @@ pub fn lint_spec(spec: &Spec, opts: LintOptions) -> Vec<LintIssue> {
         }
     }
 
+    // Examples declared at the top level belong to the root command; the KDL parser
+    // keeps them in a separate field, so `lint_command` never sees them.
+    lint_examples(spec, &spec.examples, &spec.cmd.name, &mut issues);
+
     // Lint the root command
-    lint_command(&spec.cmd, &[], spec.about.is_some(), opts, &mut issues);
+    lint_command(
+        spec,
+        &spec.cmd,
+        &[],
+        spec.about.is_some(),
+        opts,
+        &mut issues,
+    );
 
     issues
 }
@@ -263,6 +277,7 @@ fn program_basename(program: &str) -> &str {
 }
 
 fn lint_command(
+    spec: &Spec,
     cmd: &SpecCommand,
     path: &[&str],
     has_root_about: bool,
@@ -419,6 +434,8 @@ fn lint_command(
         }
     }
 
+    lint_examples(spec, &cmd.examples, &cmd_path, issues);
+
     if opts.sorted {
         lint_sorted(cmd, &cmd_path, issues);
     }
@@ -430,7 +447,7 @@ fn lint_command(
         .chain(std::iter::once(cmd.name.as_str()))
         .collect();
     for subcmd in cmd.subcommands.values() {
-        lint_command(subcmd, &new_path, false, opts, issues);
+        lint_command(spec, subcmd, &new_path, false, opts, issues);
     }
 }
 
@@ -613,9 +630,421 @@ fn lint_arg(arg: &SpecArg, cmd_path: &str, issues: &mut Vec<LintIssue>) {
     }
 }
 
+/// Checks that every `example` still parses against the spec that declares it.
+///
+/// An example is a command line a reader is invited to type, and until now nothing
+/// checked that the spec it sits in still accepts it — so an example outlives the flag
+/// it demonstrates, and the docs, help output and manpages keep publishing it. Parsing
+/// each one makes `example` load-bearing rather than prose.
+///
+/// The check is deliberately conservative, because a linter that reports a working
+/// example as broken gets switched off. A line is examined only when it is
+/// unmistakably an invocation of *this* CLI; output lines, other programs, and shell
+/// constructs are left alone rather than guessed at. What that skips is listed on
+/// [`invocation_words`].
+///
+/// It also never runs another program. Examples are parsed with injected — and empty —
+/// mount outputs, so a spec whose commands are discovered by running something gets
+/// that example skipped rather than a `mise tasks --usage` spawned by a linter. The
+/// environment is empty for the same reason a linter should not read the machine it
+/// runs on: an example that only parses because of a variable the author happens to
+/// have exported is one the reader cannot type.
+fn lint_examples(
+    spec: &Spec,
+    examples: &[SpecExample],
+    cmd_path: &str,
+    issues: &mut Vec<LintIssue>,
+) {
+    for example in examples {
+        if !is_shell_example(&example.lang) {
+            continue;
+        }
+        for line in logical_lines(&example.code) {
+            let Some(words) = invocation_words(spec, &line) else {
+                continue;
+            };
+            match Parser::new(spec)
+                .with_env(HashMap::new())
+                .with_mount_outputs(HashMap::new())
+                .parse(&words)
+            {
+                Ok(_) => {}
+                // The example reaches a command this spec only knows by running
+                // something. Discovering it is the mounted program's answer to give,
+                // not a linter's to spawn.
+                Err(err)
+                    if matches!(
+                        err.downcast_ref::<UsageErr>(),
+                        Some(UsageErr::MissingMountOutput(_))
+                    ) => {}
+                // `--help` and `--version` end the parse by printing, which usage-lib
+                // reports as an error carrying the text — and reports in preference to
+                // any other error on the line. The invocation works; showing an author
+                // their own help output as a lint message would not.
+                Err(_) if prints_and_exits(spec, &words) => {}
+                Err(err) => issues.push(LintIssue {
+                    severity: Severity::Warning,
+                    code: "example-does-not-parse".to_string(),
+                    message: format!("Example `{}` does not parse: {}", line, one_line(&err)),
+                    location: Some(format!("cmd {} example", cmd_path)),
+                }),
+            }
+        }
+    }
+}
+
+/// Whether an invocation asks for help or a version rather than doing anything.
+///
+/// The spellings are the ones the parser answers to: those of any declared flag whose
+/// action prints instead of binding, plus the `--help`, `-h` and `-?` the parser
+/// supplies for every command and the `help` subcommand word, both subject to the
+/// spec's `disable_help`. Collected over the whole tree rather than the routed chain,
+/// because a line that asks for help is one whether or not the rest of it routes.
+fn prints_and_exits(spec: &Spec, words: &[String]) -> bool {
+    let mut spellings: Vec<String> = Vec::new();
+    if spec.disable_help != Some(true) {
+        spellings.extend(["--help".into(), "-h".into(), "-?".into(), "help".into()]);
+    }
+    collect_printing_flags(&spec.cmd, &mut spellings);
+
+    // Skipping argv[0]: a program named `help` is not a request for it.
+    words[1..].iter().any(|word| {
+        let word = word.split_once('=').map_or(word.as_str(), |(name, _)| name);
+        spellings.iter().any(|spelling| spelling == word)
+    })
+}
+
+fn collect_printing_flags(cmd: &SpecCommand, spellings: &mut Vec<String>) {
+    for flag in &cmd.flags {
+        if matches!(flag.action, SpecFlagAction::Set) {
+            continue;
+        }
+        spellings.extend(flag.long.iter().map(|long| format!("--{long}")));
+        spellings.extend(flag.short.iter().map(|short| format!("-{short}")));
+    }
+    for sub in cmd.subcommands.values() {
+        collect_printing_flags(sub, spellings);
+    }
+}
+
+/// The error as one line, since a lint issue is one line.
+fn one_line(err: &miette::Error) -> String {
+    err.to_string()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Whether an example's `lang` describes a shell session at all.
+///
+/// `lang` is there for syntax highlighting, so an example carrying `lang="toml"` is a
+/// config file being shown rather than a command line, and reading it as argv would be
+/// nonsense. An unset `lang` is the common case and means a shell.
+fn is_shell_example(lang: &str) -> bool {
+    matches!(
+        lang,
+        "" | "sh" | "bash" | "zsh" | "fish" | "shell" | "shell-session" | "console" | "terminal"
+    )
+}
+
+/// The example's lines, with backslash continuations folded into one.
+///
+/// A multi-line example is usually a session: some lines are commands and some are the
+/// output they printed. Each line is judged on its own, and [`invocation_words`] keeps
+/// only the ones that are invocations — but a command split across lines with a
+/// trailing `\` has to be rejoined first, or the check sees half a command line and
+/// reports the half.
+fn logical_lines(code: &str) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut pending = String::new();
+    for line in code.lines() {
+        let line = line.trim();
+        match line.strip_suffix('\\') {
+            Some(head) => {
+                pending.push_str(head.trim_end());
+                pending.push(' ');
+            }
+            None => {
+                pending.push_str(line);
+                lines.push(std::mem::take(&mut pending));
+            }
+        }
+    }
+    if !pending.is_empty() {
+        lines.push(pending);
+    }
+    lines
+}
+
+/// One line of an example as an argv, or `None` if it is not this CLI being invoked.
+///
+/// Skipped, in each case because the line is not something the spec can answer for:
+///
+/// - output lines, comments, and blank lines;
+/// - other programs, including the shell functions and `curl | sh` an install section
+///   shows;
+/// - anything whose quoting does not close, which is prose rather than a command line.
+///
+/// Kept, after being tidied down to the part this spec owns: a `$` or `%` prompt,
+/// leading `VAR=value` assignments, and everything from the first shell operator
+/// onwards — so `$ mycli ls --json | jq .` is checked as `mycli ls --json`. An operator
+/// only counts when it is a whole word, so a quoted `"a|b"` stays a value.
+fn invocation_words(spec: &Spec, line: &str) -> Option<Vec<String>> {
+    let line = line.trim();
+    let line = line
+        .strip_prefix("$ ")
+        .or_else(|| line.strip_prefix("% "))
+        .unwrap_or(line);
+    if line.is_empty() || line.starts_with('#') {
+        return None;
+    }
+
+    let mut words = shell_words::split(line).ok()?;
+    if let Some(end) = words.iter().position(|word| is_shell_operator(word)) {
+        words.truncate(end);
+    }
+    let assignments = words
+        .iter()
+        .position(|word| !is_env_assignment(word))
+        .unwrap_or(words.len());
+    words.drain(..assignments);
+
+    if !is_this_program(spec, words.first()?) {
+        return None;
+    }
+    Some(words)
+}
+
+fn is_shell_operator(word: &str) -> bool {
+    matches!(
+        word,
+        "|" | "||" | "&&" | "&" | ";" | "|&" | ">" | ">>" | "<" | "<<" | "2>" | "2>&1" | "#"
+    )
+}
+
+/// A leading `MISE_DEBUG=1`, which sets the environment rather than being part of argv.
+fn is_env_assignment(word: &str) -> bool {
+    let Some((name, _)) = word.split_once('=') else {
+        return false;
+    };
+    !name.is_empty()
+        && name.starts_with(|c: char| c.is_ascii_alphabetic() || c == '_')
+        && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Whether the first word of a line invokes the CLI this spec describes.
+///
+/// Compared by executable basename, so `./mycli` and `/usr/local/bin/mycli` are the
+/// same program as `mycli`. A view is matched by the program name it is selected with,
+/// and a multicall CLI additionally answers to each of its applets — both are ways for
+/// one spec to describe more than one command name, and an example is entitled to show
+/// any of them.
+fn is_this_program(spec: &Spec, word: &str) -> bool {
+    let base = program_basename(word);
+    [spec.name.as_str(), spec.bin.as_str()]
+        .iter()
+        .any(|declared| !declared.is_empty() && program_basename(declared) == base)
+        || spec.view_for_program(word).is_some()
+        || (spec.multicall && spec.cmd.find_subcommand(base).is_some())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn example_issues(spec: &str) -> Vec<LintIssue> {
+        let spec: Spec = spec.parse().unwrap();
+        lint_spec(&spec, LintOptions::default())
+            .into_iter()
+            .filter(|i| i.code == "example-does-not-parse")
+            .collect()
+    }
+
+    #[test]
+    fn test_lint_example_that_parses() {
+        let issues = example_issues(
+            r#"
+name "demo"
+bin "demo"
+cmd "deploy" help="deploy" {
+    flag "-e --environment <env>" help="env"
+    example "demo deploy -e prod"
+}
+"#,
+        );
+        assert!(issues.is_empty(), "{issues:?}");
+    }
+
+    #[test]
+    fn test_lint_example_naming_a_flag_the_spec_dropped() {
+        // The failure this rule exists for: the flag was renamed and the example that
+        // demonstrates it kept being published by help, docs and manpages.
+        let issues = example_issues(
+            r#"
+name "demo"
+bin "demo"
+cmd "deploy" help="deploy" {
+    flag "--env <env>" help="env"
+    example "demo deploy --environment prod"
+}
+"#,
+        );
+        assert_eq!(issues.len(), 1, "{issues:?}");
+        assert!(
+            issues[0].message.contains("--environment"),
+            "{}",
+            issues[0].message
+        );
+    }
+
+    #[test]
+    fn test_lint_example_declared_at_the_top_level() {
+        // Root examples live on the spec rather than on its command, so the walk over
+        // commands never sees them.
+        let issues = example_issues(
+            r#"
+name "demo"
+bin "demo"
+example "demo --nope"
+cmd "deploy" help="deploy"
+"#,
+        );
+        assert_eq!(issues.len(), 1, "{issues:?}");
+    }
+
+    #[test]
+    fn test_lint_example_asking_for_help_or_version() {
+        // Both end the parse by printing, which usage-lib reports as an error carrying
+        // the text. The invocation works.
+        let issues = example_issues(
+            r#"
+name "demo"
+bin "demo"
+version "1.0.0"
+flag "-V --version" action="version" help="version"
+example "demo --help"
+example "demo -h"
+example "demo --version"
+example "demo deploy --help"
+cmd "deploy" help="deploy"
+"#,
+        );
+        assert!(issues.is_empty(), "{issues:?}");
+    }
+
+    #[test]
+    fn test_lint_example_lines_that_are_not_this_program() {
+        // A session: a prompt, the output it printed, another program, and a comment.
+        // Only the first line is a question this spec can answer.
+        let issues = example_issues(
+            r#"
+name "demo"
+bin "demo"
+cmd "ls" help="ls" {
+    example "$ demo ls\nnode 20.0.0\n# then install it\ncurl -fsSL https://example.com | sh"
+}
+"#,
+        );
+        assert!(issues.is_empty(), "{issues:?}");
+
+        // The same session with one of its own commands broken, so the lines above are
+        // shown to be skipped rather than the whole example being.
+        let issues = example_issues(
+            r#"
+name "demo"
+bin "demo"
+cmd "ls" help="ls" {
+    example "$ demo ls\nnode 20.0.0\n$ demo ls --nope"
+}
+"#,
+        );
+        assert_eq!(issues.len(), 1, "{issues:?}");
+    }
+
+    #[test]
+    fn test_lint_example_checks_only_up_to_a_shell_operator() {
+        let issues = example_issues(
+            r#"
+name "demo"
+bin "demo"
+cmd "ls" help="ls" {
+    flag "--json" help="json"
+    example "demo ls --json | jq ."
+    example "demo ls --nope | jq ."
+}
+"#,
+        );
+        assert_eq!(issues.len(), 1, "{issues:?}");
+        assert!(
+            issues[0].message.contains("--nope"),
+            "{}",
+            issues[0].message
+        );
+    }
+
+    #[test]
+    fn test_lint_example_keeps_a_quoted_operator_as_a_value() {
+        let issues = example_issues(
+            r#"
+name "demo"
+bin "demo"
+cmd "run" help="run" {
+    arg "<task>" help="task"
+    example "demo run \"a|b\""
+}
+"#,
+        );
+        assert!(issues.is_empty(), "{issues:?}");
+    }
+
+    #[test]
+    fn test_lint_example_with_a_leading_assignment_and_a_continuation() {
+        let issues = example_issues(
+            r#"
+name "demo"
+bin "demo"
+cmd "deploy" help="deploy" {
+    flag "-e --environment <env>" help="env"
+    flag "-f --force" help="force"
+    example "DEMO_DEBUG=1 demo deploy \\\n    -e prod --force"
+}
+"#,
+        );
+        assert!(issues.is_empty(), "{issues:?}");
+    }
+
+    #[test]
+    fn test_lint_example_in_a_language_that_is_not_a_shell() {
+        let issues = example_issues(
+            r#"
+name "demo"
+bin "demo"
+cmd "config" help="config" {
+    example "demo = { environment = \"prod\" }" lang="toml"
+}
+"#,
+        );
+        assert!(issues.is_empty(), "{issues:?}");
+    }
+
+    #[test]
+    fn test_lint_example_reaching_a_mount_never_runs_it() {
+        // The mount's `run` is not a command: if the linter resolved mounts by running
+        // them, the shell would fail and the example would be reported. Skipping it is
+        // the point — a linter must not spawn the program it is linting.
+        let issues = example_issues(
+            r#"
+name "demo"
+bin "demo"
+mount run="this command must never run"
+cmd "ls" help="ls" {
+    example "demo ls"
+}
+example "demo discovered --whatever"
+"#,
+        );
+        assert!(issues.is_empty(), "{issues:?}");
+    }
 
     #[test]
     fn test_lint_missing_help() {

--- a/cli/src/cli/lint.rs
+++ b/cli/src/cli/lint.rs
@@ -783,30 +783,34 @@ fn collect_mount_answers(cmd: &SpecCommand, answers: &mut HashMap<String, String
 /// up to the first word that selects a subcommand. Help has no such limit — the parser
 /// supplies it on every command.
 fn prints_and_exits(spec: &Spec, words: &[String]) -> bool {
-    let mut spellings: Vec<String> = Vec::new();
-    if spec.disable_help != Some(true) {
-        spellings.extend(["--help".into(), "-h".into(), "-?".into(), "help".into()]);
-    }
-    collect_printing_flags(&spec.cmd, &mut spellings);
-
     // Skipping argv[0]: a program named `help` is not a request for it.
     let words = &words[1..];
-    fn named(word: &str) -> &str {
-        word.split_once('=').map_or(word, |(name, _)| name)
-    }
-    if words
-        .iter()
-        .any(|word| spellings.iter().any(|spelling| spelling == named(word)))
-    {
+
+    // A declared flag has its attached value split off before the parser looks the flag
+    // up, so `--info=anything` still performs the action `--info` names.
+    let mut declared: Vec<String> = Vec::new();
+    collect_printing_flags(&spec.cmd, &mut declared);
+    if words.iter().any(|word| {
+        let name = word.split_once('=').map_or(word.as_str(), |(name, _)| name);
+        declared.iter().any(|spelling| spelling == name)
+    }) {
         return true;
     }
 
-    (spec.version.is_some() || spec.long_version.is_some())
+    // The supplied spellings are compared whole, because that is how the parser compares
+    // them: nothing declares them, so nothing splits a value off first, and
+    // `--help=bad` is an unknown word rather than a request for help.
+    let asks_for_help = spec.disable_help != Some(true)
+        && words
+            .iter()
+            .any(|word| matches!(word.as_str(), "--help" | "-h" | "-?" | "help"));
+    let asks_for_a_version = (spec.version.is_some() || spec.long_version.is_some())
         && !spec.cmd.disable_version_flag
         && words
             .iter()
             .take_while(|word| spec.cmd.find_subcommand(word).is_none())
-            .any(|word| matches!(named(word), "--version" | "-V"))
+            .any(|word| matches!(word.as_str(), "--version" | "-V"));
+    asks_for_help || asks_for_a_version
 }
 
 fn collect_printing_flags(cmd: &SpecCommand, spellings: &mut Vec<String>) {
@@ -1236,6 +1240,36 @@ cmd "tasks" help="tasks" {
         );
         assert_eq!(issues.len(), 1, "{issues:?}");
         assert_eq!(issues[0].code, "example-not-checked");
+
+        // A value attached to a supplied spelling is not one of these. The parser
+        // compares the whole token, because nothing declares `--help` and so nothing
+        // splits a value off it first — `--help=bad` is an unknown word.
+        let issues = example_issues(
+            r#"
+name "demo"
+bin "demo"
+version "1.0.0"
+example "demo --help=bad"
+example "demo --version=bad"
+example "demo -V=bad"
+"#,
+        );
+        assert_eq!(issues.len(), 3, "{issues:?}");
+
+        // A declared flag is the other way round: its attached value is split off before
+        // the lookup, so the action still fires.
+        let issues = example_issues(
+            r#"
+name "demo"
+bin "demo"
+version "1.0.0"
+flag "--info" action="help" help="info"
+flag "--ver" action="version" help="ver"
+example "demo --info=bad"
+example "demo --ver=bad"
+"#,
+        );
+        assert!(issues.is_empty(), "{issues:?}");
 
         // Asking for help is answered by the command itself, so what the mount would
         // have added cannot change it. Reporting these as unchecked would put a notice

--- a/cli/src/cli/lint.rs
+++ b/cli/src/cli/lint.rs
@@ -768,26 +768,42 @@ fn collect_mount_answers(cmd: &SpecCommand, answers: &mut HashMap<String, String
 /// Whether an invocation asks for help or a version rather than doing anything.
 ///
 /// The spellings are the ones the parser answers to: those of any declared flag whose
-/// action prints instead of binding, plus the ones the parser supplies rather than a
-/// spec declaring them — `--help`, `-h`, `-?` and the `help` subcommand word under
+/// action prints instead of binding, plus the ones the parser supplies rather than a spec
+/// declaring them — `--help`, `-h`, `-?` and the `help` subcommand word under
 /// `disable_help`, and `--version` and `-V` where the spec declares a version. Collected
 /// over the whole tree rather than the routed chain, because a line that asks for help is
 /// one whether or not the rest of it routes.
+///
+/// The supplied version is the exception, because the parser supplies it to the root
+/// alone: `mycli run --version` is refused, so suppressing it here would hide a real
+/// finding behind a spelling that does not work where the example puts it. It counts only
+/// up to the first word that selects a subcommand. Help has no such limit — the parser
+/// supplies it on every command.
 fn prints_and_exits(spec: &Spec, words: &[String]) -> bool {
     let mut spellings: Vec<String> = Vec::new();
     if spec.disable_help != Some(true) {
         spellings.extend(["--help".into(), "-h".into(), "-?".into(), "help".into()]);
     }
-    if (spec.version.is_some() || spec.long_version.is_some()) && !spec.cmd.disable_version_flag {
-        spellings.extend(["--version".into(), "-V".into()]);
-    }
     collect_printing_flags(&spec.cmd, &mut spellings);
 
     // Skipping argv[0]: a program named `help` is not a request for it.
-    words[1..].iter().any(|word| {
-        let word = word.split_once('=').map_or(word.as_str(), |(name, _)| name);
-        spellings.iter().any(|spelling| spelling == word)
-    })
+    let words = &words[1..];
+    fn named(word: &str) -> &str {
+        word.split_once('=').map_or(word, |(name, _)| name)
+    }
+    if words
+        .iter()
+        .any(|word| spellings.iter().any(|spelling| spelling == named(word)))
+    {
+        return true;
+    }
+
+    (spec.version.is_some() || spec.long_version.is_some())
+        && !spec.cmd.disable_version_flag
+        && words
+            .iter()
+            .take_while(|word| spec.cmd.find_subcommand(word).is_none())
+            .any(|word| matches!(named(word), "--version" | "-V"))
 }
 
 fn collect_printing_flags(cmd: &SpecCommand, spellings: &mut Vec<String>) {
@@ -1045,6 +1061,25 @@ example "demo --version"
 "#,
         );
         assert_eq!(issues.len(), 1, "{issues:?}");
+
+        // The supplied version belongs to the root, so a subcommand carrying it is a
+        // real finding rather than a request to print — the parser refuses that line.
+        let issues = example_issues(
+            r#"
+name "demo"
+bin "demo"
+version "1.0.0"
+cmd "run" help="run"
+example "demo run --version"
+example "demo run --help"
+"#,
+        );
+        assert_eq!(issues.len(), 1, "{issues:?}");
+        assert!(
+            issues[0].message.contains("--version"),
+            "{}",
+            issues[0].message
+        );
     }
 
     #[test]

--- a/cli/src/cli/lint.rs
+++ b/cli/src/cli/lint.rs
@@ -696,14 +696,18 @@ fn lint_examples(
 /// Whether an invocation asks for help or a version rather than doing anything.
 ///
 /// The spellings are the ones the parser answers to: those of any declared flag whose
-/// action prints instead of binding, plus the `--help`, `-h` and `-?` the parser
-/// supplies for every command and the `help` subcommand word, both subject to the
-/// spec's `disable_help`. Collected over the whole tree rather than the routed chain,
-/// because a line that asks for help is one whether or not the rest of it routes.
+/// action prints instead of binding, plus the ones the parser supplies rather than a
+/// spec declaring them — `--help`, `-h`, `-?` and the `help` subcommand word under
+/// `disable_help`, and `--version` and `-V` where the spec declares a version. Collected
+/// over the whole tree rather than the routed chain, because a line that asks for help is
+/// one whether or not the rest of it routes.
 fn prints_and_exits(spec: &Spec, words: &[String]) -> bool {
     let mut spellings: Vec<String> = Vec::new();
     if spec.disable_help != Some(true) {
         spellings.extend(["--help".into(), "-h".into(), "-?".into(), "help".into()]);
+    }
+    if (spec.version.is_some() || spec.long_version.is_some()) && !spec.cmd.disable_version_flag {
+        spellings.extend(["--version".into(), "-V".into()]);
     }
     collect_printing_flags(&spec.cmd, &mut spellings);
 
@@ -930,6 +934,28 @@ cmd "deploy" help="deploy"
 "#,
         );
         assert!(issues.is_empty(), "{issues:?}");
+
+        // The same, with the version flag supplied by the parser rather than declared.
+        let issues = example_issues(
+            r#"
+name "demo"
+bin "demo"
+version "1.0.0"
+example "demo --version"
+example "demo -V"
+"#,
+        );
+        assert!(issues.is_empty(), "{issues:?}");
+
+        // And where nothing declares a version, nothing supplies one either.
+        let issues = example_issues(
+            r#"
+name "demo"
+bin "demo"
+example "demo --version"
+"#,
+        );
+        assert_eq!(issues.len(), 1, "{issues:?}");
     }
 
     #[test]

--- a/cli/src/cli/lint.rs
+++ b/cli/src/cli/lint.rs
@@ -663,26 +663,27 @@ fn lint_examples(
             let Some(words) = invocation_words(spec, &line) else {
                 continue;
             };
-            match Parser::new(spec)
-                .with_env(HashMap::new())
-                .with_mount_outputs(HashMap::new())
-                .parse(&words)
-            {
+            match parse_example(spec, &words) {
                 Ok(_) => {}
-                // The example reaches a command this spec only knows by running
-                // something. Discovering it is the mounted program's answer to give,
-                // not a linter's to spawn.
-                Err(err)
-                    if matches!(
-                        err.downcast_ref::<UsageErr>(),
-                        Some(UsageErr::MissingMountOutput(_))
-                    ) => {}
+                // Everything the mounted program would have contributed is missing, and
+                // this line needed some of it. Said out loud rather than skipped
+                // quietly: a lint that stays silent about the lines it could not read
+                // reports "checked and fine" over exactly the ones it never checked.
+                Err(Unparsed::NeedsAMount) => issues.push(LintIssue {
+                    severity: Severity::Info,
+                    code: "example-not-checked".to_string(),
+                    message: format!(
+                        "Example `{line}` was not checked: it reaches past a mount, \
+                         which names its commands only when run"
+                    ),
+                    location: Some(format!("cmd {} example", cmd_path)),
+                }),
                 // `--help` and `--version` end the parse by printing, which usage-lib
                 // reports as an error carrying the text — and reports in preference to
                 // any other error on the line. The invocation works; showing an author
                 // their own help output as a lint message would not.
-                Err(_) if prints_and_exits(spec, &words) => {}
-                Err(err) => issues.push(LintIssue {
+                Err(Unparsed::Refused(_)) if prints_and_exits(spec, &words) => {}
+                Err(Unparsed::Refused(err)) => issues.push(LintIssue {
                     severity: Severity::Warning,
                     code: "example-does-not-parse".to_string(),
                     message: format!("Example `{}` does not parse: {}", line, one_line(&err)),
@@ -690,6 +691,77 @@ fn lint_examples(
                 }),
             }
         }
+    }
+}
+
+/// Why an example did not parse, once a mount has been accounted for.
+enum Unparsed {
+    /// The spec refused the line, and can answer for it.
+    Refused(miette::Error),
+    /// The line needs something only the mounted program could have said.
+    NeedsAMount,
+}
+
+/// Parse one example, without running anything and without reading the environment.
+///
+/// Mounts are the whole difficulty. usage-lib resolves a command's mounts on the way
+/// *into* it, so a spec that mounts anything cannot be parsed at all without either
+/// spawning the mounted program or being handed its answer. Injecting an empty set of
+/// answers avoids the process but refuses every line under a mounting command, checked
+/// or not — which is most of an adopter's spec, since mise, aube and pitchfork all mount.
+///
+/// So the empty set is only the first attempt. When it comes back short, the mount is
+/// answered with a spec that declares nothing and the line is parsed again: a line using
+/// only the command's own declared vocabulary now parses on its own merits, and one that
+/// still fails is a line the mounted program might have accepted, which nothing here can
+/// know. That second group — and only that group — goes unchecked.
+fn parse_example(spec: &Spec, words: &[String]) -> Result<(), Unparsed> {
+    let parse = |mounts: HashMap<String, String>| {
+        Parser::new(spec)
+            .with_env(HashMap::new())
+            .with_mount_outputs(mounts)
+            .parse(words)
+    };
+    let needs_a_mount = |err: &miette::Error| {
+        matches!(
+            err.downcast_ref::<UsageErr>(),
+            Some(UsageErr::MissingMountOutput(_))
+        )
+    };
+
+    match parse(HashMap::new()) {
+        Ok(_) => Ok(()),
+        Err(err) if !needs_a_mount(&err) => Err(Unparsed::Refused(err)),
+        Err(_) => match parse(empty_mount_answers(&spec.cmd)) {
+            Ok(_) => Ok(()),
+            Err(err) if needs_a_mount(&err) => Err(Unparsed::NeedsAMount),
+            // The mounted program contributes commands and flags, so it can only ever
+            // make a line parse. One that fails against a mount contributing nothing may
+            // still have been fine against the real one.
+            Err(_) => Err(Unparsed::NeedsAMount),
+        },
+    }
+}
+
+/// A spec that declares nothing, as the answer to every mount in the tree.
+///
+/// Keyed by the exact `run` string, which is how injected answers are looked up. It is a
+/// whole spec rather than an empty string because that is what a mount's stdout is.
+fn empty_mount_answers(cmd: &SpecCommand) -> HashMap<String, String> {
+    let mut answers = HashMap::new();
+    collect_mount_answers(cmd, &mut answers);
+    answers
+}
+
+fn collect_mount_answers(cmd: &SpecCommand, answers: &mut HashMap<String, String>) {
+    for mount in &cmd.mounts {
+        answers.insert(
+            mount.run.clone(),
+            "name \"mounted\"\nbin \"mounted\"\n".to_string(),
+        );
+    }
+    for sub in cmd.subcommands.values() {
+        collect_mount_answers(sub, answers);
     }
 }
 
@@ -746,7 +818,7 @@ fn one_line(err: &miette::Error) -> String {
 /// nonsense. An unset `lang` is the common case and means a shell.
 fn is_shell_example(lang: &str) -> bool {
     matches!(
-        lang,
+        lang.to_ascii_lowercase().as_str(),
         "" | "sh" | "bash" | "zsh" | "fish" | "shell" | "shell-session" | "console" | "terminal"
     )
 }
@@ -804,7 +876,10 @@ fn invocation_words(spec: &Spec, line: &str) -> Option<Vec<String>> {
     }
 
     let mut words = shell_words::split(line).ok()?;
-    if let Some(end) = words.iter().position(|word| is_shell_operator(word)) {
+    if let Some(end) = words
+        .iter()
+        .position(|word| is_shell_operator(word) || starts_a_redirection(word))
+    {
         words.truncate(end);
     }
     let assignments = words
@@ -822,8 +897,22 @@ fn invocation_words(spec: &Spec, line: &str) -> Option<Vec<String>> {
 fn is_shell_operator(word: &str) -> bool {
     matches!(
         word,
-        "|" | "||" | "&&" | "&" | ";" | "|&" | ">" | ">>" | "<" | "<<" | "2>" | "2>&1" | "#"
+        "|" | "||" | "&&" | "&" | ";" | "|&" | ">" | ">>" | "<" | "<<" | "2>" | "2>&1"
     )
+}
+
+/// A redirection written without the space that would make it its own word, as in
+/// `>out.txt` or `2>/dev/null`, which `shell_words` hands back whole.
+///
+/// Only the output side. `<` is deliberately absent: `mycli deploy <env>` is how
+/// documentation writes a placeholder, and truncating there would report the argument
+/// the placeholder stands in for as missing. `#` is absent for the opposite reason —
+/// `shell_words` drops an unquoted comment itself, so a `#` that survives to be a word
+/// came out of quotes and is a value, as in `mycli issue view "#123"`.
+fn starts_a_redirection(word: &str) -> bool {
+    word.strip_prefix(|c: char| c.is_ascii_digit() || c == '&')
+        .unwrap_or(word)
+        .starts_with('>')
 }
 
 /// A leading `MISE_DEBUG=1`, which sets the environment rather than being part of argv.
@@ -860,7 +949,7 @@ mod tests {
         let spec: Spec = spec.parse().unwrap();
         lint_spec(&spec, LintOptions::default())
             .into_iter()
-            .filter(|i| i.code == "example-does-not-parse")
+            .filter(|i| i.code.starts_with("example-"))
             .collect()
     }
 
@@ -1056,8 +1145,9 @@ cmd "config" help="config" {
     #[test]
     fn test_lint_example_reaching_a_mount_never_runs_it() {
         // The mount's `run` is not a command: if the linter resolved mounts by running
-        // them, the shell would fail and the example would be reported. Skipping it is
-        // the point — a linter must not spawn the program it is linting.
+        // them, the shell would fail. It must not spawn the program it is linting, so a
+        // line that only the mounted program could explain goes unchecked — and says so,
+        // rather than passing quietly as though it had been read.
         let issues = example_issues(
             r#"
 name "demo"
@@ -1069,7 +1159,143 @@ cmd "ls" help="ls" {
 example "demo discovered --whatever"
 "#,
         );
+        assert_eq!(issues.len(), 1, "{issues:?}");
+        assert_eq!(issues[0].code, "example-not-checked");
+        assert_eq!(issues[0].severity, Severity::Info);
+    }
+
+    #[test]
+    fn test_lint_example_under_a_mount_is_still_checked_where_it_can_be() {
+        // A mounting command's own flags are declared, so a line using them is an
+        // ordinary question with an ordinary answer. Refusing to check anything below a
+        // mount would give up on most of an adopter's spec — mise, aube and pitchfork
+        // all mount.
+        let issues = example_issues(
+            r#"
+name "demo"
+bin "demo"
+cmd "tasks" help="tasks" {
+    mount run="this command must never run"
+    flag "--all" help="all"
+    example "demo tasks --all"
+}
+"#,
+        );
         assert!(issues.is_empty(), "{issues:?}");
+
+        // And the same command's unknown word is the undecidable case: the mounted
+        // program might have declared it.
+        let issues = example_issues(
+            r#"
+name "demo"
+bin "demo"
+cmd "tasks" help="tasks" {
+    mount run="this command must never run"
+    flag "--all" help="all"
+    example "demo tasks --nope"
+}
+"#,
+        );
+        assert_eq!(issues.len(), 1, "{issues:?}");
+        assert_eq!(issues[0].code, "example-not-checked");
+    }
+
+    #[test]
+    fn test_lint_example_with_an_attached_redirection() {
+        // `shell_words` hands back `>out.txt` and `2>/dev/null` whole, so the whole-word
+        // operator rule does not see them.
+        let issues = example_issues(
+            r#"
+name "demo"
+bin "demo"
+cmd "ls" help="ls" {
+    example "demo ls >out.txt"
+    example "demo ls 2>/dev/null"
+}
+"#,
+        );
+        assert!(issues.is_empty(), "{issues:?}");
+    }
+
+    #[test]
+    fn test_lint_example_keeps_a_placeholder_and_a_quoted_hash() {
+        // The two shapes an eager redirection rule would break. `<env>` is how
+        // documentation writes a placeholder, and a `#` that survives `shell_words` came
+        // out of quotes, so it is a value rather than a comment.
+        let issues = example_issues(
+            r##"
+name "demo"
+bin "demo"
+cmd "deploy" help="deploy" {
+    arg "<env>" help="env"
+    example "demo deploy <env>"
+}
+cmd "issue" help="issue" {
+    arg "<id>" help="id"
+    example "demo issue \"#123\""
+}
+"##,
+        );
+        assert!(issues.is_empty(), "{issues:?}");
+    }
+
+    #[test]
+    fn test_lint_example_lang_is_matched_without_case() {
+        let issues = example_issues(
+            r#"
+name "demo"
+bin "demo"
+cmd "ls" help="ls" {
+    example "demo ls --nope" lang="Bash"
+}
+"#,
+        );
+        assert_eq!(issues.len(), 1, "{issues:?}");
+    }
+
+    #[test]
+    fn test_lint_example_invoking_a_view_or_an_applet() {
+        // One spec, more than one command name. An example is entitled to show any of
+        // them, so neither shape may be mistaken for another program and skipped.
+        // Written so that recognition is what the assertion turns on: an unrecognized
+        // program is a skipped line, which is indistinguishable from a clean one.
+        let issues = example_issues(
+            r#"
+name "demo"
+bin "demo"
+view "runner" root="run" globals=#true
+cmd "run" help="run" {
+    flag "--all" help="all"
+}
+example "./runner --all"
+example "./runner --nope"
+"#,
+        );
+        assert_eq!(issues.len(), 1, "{issues:?}");
+        assert!(
+            issues[0].message.contains("--nope"),
+            "{}",
+            issues[0].message
+        );
+
+        let issues = example_issues(
+            r#"
+name "demo"
+bin "demo"
+multicall #true
+cmd "applet" help="applet" {
+    flag "--all" help="all"
+    example "applet --all"
+    example "applet --nope"
+}
+"#,
+        );
+        assert_eq!(issues.len(), 1, "{issues:?}");
+        assert!(
+            issues[0].message.contains("--nope"),
+            "{}",
+            issues[0].message
+        );
     }
 
     #[test]

--- a/cli/src/cli/lint.rs
+++ b/cli/src/cli/lint.rs
@@ -678,11 +678,6 @@ fn lint_examples(
                     ),
                     location: Some(format!("cmd {} example", cmd_path)),
                 }),
-                // `--help` and `--version` end the parse by printing, which usage-lib
-                // reports as an error carrying the text — and reports in preference to
-                // any other error on the line. The invocation works; showing an author
-                // their own help output as a lint message would not.
-                Err(Unparsed::Refused(_)) if prints_and_exits(spec, &words) => {}
                 Err(Unparsed::Refused(err)) => issues.push(LintIssue {
                     severity: Severity::Warning,
                     code: "example-does-not-parse".to_string(),
@@ -729,15 +724,23 @@ fn parse_example(spec: &Spec, words: &[String]) -> Result<(), Unparsed> {
         )
     };
 
+    // `--help` and `--version` end the parse by printing, which usage-lib reports as an
+    // error carrying the text — and reports in preference to any other error on the
+    // line. The invocation works; showing an author their own help output as a lint
+    // message would not. True of either parse: what a mount would have added cannot
+    // stop a line from asking for help.
+    let printed = |err: &miette::Error| !needs_a_mount(err) && prints_and_exits(spec, words);
+
     match parse(HashMap::new()) {
         Ok(_) => Ok(()),
+        Err(err) if printed(&err) => Ok(()),
         Err(err) if !needs_a_mount(&err) => Err(Unparsed::Refused(err)),
         Err(_) => match parse(empty_mount_answers(&spec.cmd)) {
             Ok(_) => Ok(()),
-            Err(err) if needs_a_mount(&err) => Err(Unparsed::NeedsAMount),
+            Err(err) if printed(&err) => Ok(()),
             // The mounted program contributes commands and flags, so it can only ever
             // make a line parse. One that fails against a mount contributing nothing may
-            // still have been fine against the real one.
+            // still have been fine against the real one, and nothing here can know which.
             Err(_) => Err(Unparsed::NeedsAMount),
         },
     }
@@ -1233,6 +1236,23 @@ cmd "tasks" help="tasks" {
         );
         assert_eq!(issues.len(), 1, "{issues:?}");
         assert_eq!(issues[0].code, "example-not-checked");
+
+        // Asking for help is answered by the command itself, so what the mount would
+        // have added cannot change it. Reporting these as unchecked would put a notice
+        // on every `--help` example a mounting CLI publishes.
+        let issues = example_issues(
+            r#"
+name "demo"
+bin "demo"
+version "1.0.0"
+cmd "tasks" help="tasks" {
+    mount run="this command must never run"
+    example "demo tasks --help"
+}
+example "demo --version"
+"#,
+        );
+        assert!(issues.is_empty(), "{issues:?}");
     }
 
     #[test]

--- a/conformance/tests/metadata.rs
+++ b/conformance/tests/metadata.rs
@@ -585,7 +585,6 @@ fn the_roots_surrounding_text_reaches_every_page() {
     header = "Basic deployment",
     help = "Deploy to production"
 ))]
-#[allow(dead_code)]
 struct Deploy {
     /// Where to deploy
     #[usage(short, long)]
@@ -666,4 +665,18 @@ fn examples_survive_the_round_trip_from_a_typed_declaration() {
     let page = usage_argv::help::render(spec, argv_deploy.cmd, true).unwrap();
     assert!(page.contains("  Basic deployment:"), "{page}");
     assert_eq!(page, usage::docs::cli::render_help(&portable, deploy, true));
+
+    // And the example is a command line this CLI accepts, which is the whole claim an
+    // example makes. `usage lint` asks the same question of a spec; here it is asked of
+    // the declaration the spec came from.
+    let argv = [
+        std::ffi::OsStr::new("deploy"),
+        std::ffi::OsStr::new("-e"),
+        std::ffi::OsStr::new("prod"),
+    ];
+    let parsed = Worked::parse_from(&argv).expect("the example it documents");
+    let Some(WorkedCommands::Deploy(deploy)) = parsed.command else {
+        panic!("expected deploy")
+    };
+    assert_eq!(deploy.environment.as_deref(), Some("prod"));
 }

--- a/conformance/tests/metadata.rs
+++ b/conformance/tests/metadata.rs
@@ -577,3 +577,93 @@ fn the_roots_surrounding_text_reaches_every_page() {
     let lib_go = lib.cmd.subcommands.get("go").expect("go");
     assert_eq!(page, usage::docs::cli::render_help(&lib, lib_go, false));
 }
+
+/// A command whose examples are declared on the type that holds them.
+#[derive(Args)]
+#[usage(example(
+    "worked deploy -e prod",
+    header = "Basic deployment",
+    help = "Deploy to production"
+))]
+#[allow(dead_code)]
+struct Deploy {
+    /// Where to deploy
+    #[usage(short, long)]
+    environment: Option<String>,
+}
+
+/// A command whose examples belong to the variant rather than to the type.
+#[derive(Args)]
+#[usage(example = "worked shared --from-the-type")]
+#[allow(dead_code)]
+struct Shared {}
+
+#[derive(Subcommands)]
+enum WorkedCommands {
+    /// Deploy the application
+    Deploy(Deploy),
+    /// Do the shared thing
+    #[usage(example = "worked shared --from-the-variant")]
+    Shared(Shared),
+}
+
+/// A tool with worked invocations
+#[derive(Cli)]
+#[usage(bin = "worked", example = "worked deploy -e prod")]
+#[allow(dead_code)]
+struct Worked {
+    #[usage(subcommand)]
+    command: Option<WorkedCommands>,
+}
+
+/// Examples were the last thing a KDL spec could say and a typed CLI could not.
+///
+/// The tables and both help renderers have carried `example` the whole time — only the
+/// derive had no vocabulary for one, so a typed CLI's worked invocations had to live as
+/// prose inside `after_long_help`, where docs, manpages and `usage lint` cannot read
+/// them.
+#[test]
+fn examples_survive_the_round_trip_from_a_typed_declaration() {
+    let spec = Worked::spec();
+    let portable: LibSpec = Worked::to_kdl().parse().expect("valid spec");
+
+    assert_eq!(portable.examples.len(), 1);
+    assert_eq!(portable.examples[0].code, "worked deploy -e prod");
+
+    let deploy = portable.cmd.subcommands.get("deploy").expect("deploy");
+    assert_eq!(deploy.examples.len(), 1);
+    assert_eq!(deploy.examples[0].code, "worked deploy -e prod");
+    assert_eq!(
+        deploy.examples[0].header.as_deref(),
+        Some("Basic deployment")
+    );
+    assert_eq!(
+        deploy.examples[0].help.as_deref(),
+        Some("Deploy to production")
+    );
+
+    // A variant that declares examples speaks for the command; the held type's stand
+    // only where it declares none, which is how `after_help` already behaves.
+    let shared = portable.cmd.subcommands.get("shared").expect("shared");
+    assert_eq!(shared.examples.len(), 1);
+    assert_eq!(shared.examples[0].code, "worked shared --from-the-variant");
+
+    // And both renderers show the same page, reading the same declaration.
+    let page = usage_argv::help::render(spec, spec.root.cmd, true).unwrap();
+    assert!(page.contains("Examples:"), "{page}");
+    assert!(page.contains("$ worked deploy -e prod"), "{page}");
+    assert_eq!(
+        page,
+        usage::docs::cli::render_help(&portable, &portable.cmd, true)
+    );
+
+    let argv_deploy = spec
+        .root
+        .subcommands
+        .iter()
+        .find(|meta| meta.cmd.name == "deploy")
+        .expect("deploy");
+    let page = usage_argv::help::render(spec, argv_deploy.cmd, true).unwrap();
+    assert!(page.contains("  Basic deployment:"), "{page}");
+    assert_eq!(page, usage::docs::cli::render_help(&portable, deploy, true));
+}

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -17,8 +17,8 @@ use quote::{format_ident, quote};
 
 use crate::crate_name::{crate_name, FoundCrate};
 use crate::model::{
-    rendered_path, to_kebab, Cli, ConditionalDefault, DoubleDash, Field, Kind, Shape, Subcommands,
-    ValueEnum, ViewDecl,
+    rendered_path, to_kebab, Cli, ConditionalDefault, DoubleDash, ExampleDecl, Field, Kind, Shape,
+    Subcommands, ValueEnum, ViewDecl,
 };
 
 /// Construct the user's command type after its generated partial has been checked.
@@ -183,6 +183,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
     let before_long_help = option_expr(cli.before_long_help.as_ref());
     let after_help = option_expr(cli.after_help.as_ref());
     let after_long_help = option_expr(cli.after_long_help.as_ref());
+    let examples = examples_table(&cli.examples);
     let root_key = key_ident("COMMAND", None);
     let keys = key_consts(&cli.fingerprint, flags.len(), args.len());
     let flag_tables = flags.iter().enumerate().map(|(i, f)| flag_table(i, f));
@@ -587,6 +588,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
                 before_long_help: #before_long_help,
                 after_help: #after_help,
                 after_long_help: #after_long_help,
+                examples: #examples,
                 flags: #flag_meta_table_ref,
                 args: #arg_meta_table_ref,
                 groups: #group_meta_table_ref,
@@ -2838,6 +2840,26 @@ fn option_str(value: Option<&str>) -> TokenStream {
     }
 }
 
+/// The `examples` slice for a command's metadata.
+///
+/// A constant expression, so it promotes into the `static CommandMeta` beside the rest
+/// of the cold tables; nothing here is reached by a parse that succeeds.
+fn examples_table(examples: &[ExampleDecl]) -> TokenStream {
+    let entries = examples.iter().map(|example| {
+        let code = &example.code;
+        let header = option_expr(example.header.as_ref());
+        let help = option_expr(example.help.as_ref());
+        quote! {
+            usage_argv::spec::Example {
+                code: #code,
+                header: #header,
+                help: #help,
+            }
+        }
+    });
+    quote!(&[#(#entries),*])
+}
+
 fn option_expr(value: Option<&TokenStream>) -> TokenStream {
     match value {
         Some(v) => quote!(::std::option::Option::Some(#v)),
@@ -4539,6 +4561,7 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
     let before_long_help = option_expr(cli.before_long_help.as_ref());
     let after_help = option_expr(cli.after_help.as_ref());
     let after_long_help = option_expr(cli.after_long_help.as_ref());
+    let examples = examples_table(&cli.examples);
 
     let flags: Vec<&Field> = cli
         .fields
@@ -4786,6 +4809,7 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
                 before_long_help: #before_long_help,
                 after_help: #after_help,
                 after_long_help: #after_long_help,
+                examples: #examples,
                 flags: #flag_meta_table_ref,
                 args: #arg_meta_table_ref,
                 groups: #group_meta_table_ref,
@@ -5290,6 +5314,13 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
                 .unwrap_or_else(
                     || quote!(<#ty as usage_argv::spec::CommandArgs>::META.after_long_help),
                 );
+            // A variant that declares examples speaks for the command; one that does not
+            // leaves the held type's own standing, as `after_help` does.
+            let examples = if v.examples.is_empty() {
+                quote!(<#ty as usage_argv::spec::CommandArgs>::META.examples)
+            } else {
+                examples_table(&v.examples)
+            };
             // Which of the table's aliases are hidden. The visible ones are not listed
             // anywhere: `cmd.aliases` minus these is what help and completions show.
             let hidden = &v.hidden_aliases;
@@ -5317,6 +5348,7 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
                         before_long_help: #before_long_help,
                         after_help: #after_help,
                         after_long_help: #after_long_help,
+                        examples: #examples,
                         hide: #hide || <#ty as usage_argv::spec::CommandArgs>::META.hide,
                         help_heading: #help_heading,
                         display_order: #display_order,

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -154,6 +154,13 @@ pub struct Cli {
     pub before_long_help: Option<proc_macro2::TokenStream>,
     pub after_help: Option<proc_macro2::TokenStream>,
     pub after_long_help: Option<proc_macro2::TokenStream>,
+    /// Worked invocations, shown on the help page and emitted into the spec.
+    ///
+    /// A KDL spec has said `example` since before this derive existed, and the metadata
+    /// tables and help renderer have carried them the whole time; a typed CLI simply had
+    /// no way to declare one, so every example in the fleet lives as prose inside
+    /// `after_long_help` where nothing can read it — or check it.
+    pub examples: Vec<ExampleDecl>,
     /// The word that starts another invocation of the same command: mise's `:::`.
     pub restart_token: Option<String>,
     /// A command to run for subcommands discovered at completion time.
@@ -698,6 +705,7 @@ impl Cli {
             before_long_help: None,
             after_help: None,
             after_long_help: None,
+            examples: Vec::new(),
             restart_token: None,
             mount: None,
             groups: Vec::new(),
@@ -917,6 +925,7 @@ impl Cli {
                     "restart_token" => cli.restart_token = Some(string_value(&meta)?),
                     "mount" => cli.mount = Some(string_value(&meta)?),
                     "group" => cli.groups.push(group_decl(&meta)?),
+                    "example" => cli.examples.push(example_decl(&meta)?),
                     "view" => {
                         let view = view_decl(&meta)?;
                         if cli.views.iter().any(|declared| declared.id == view.id) {
@@ -954,7 +963,7 @@ impl Cli {
                                  `name`, `name_spec`, `bin`, `bin_spec`, `version`, `version_spec`, `long_version`, `long_version_spec`, `author`, `license`, `repository`, `usage`, `alias`, `alias_hidden`, `visible_alias`, `hide`, `deprecated`, `deprecated_warn_at`, `deprecated_remove_at`, `verbatim_doc_comment`, `unknown_flags`, \
                                  `default_subcommand`, `multicall`, `no_binary_name`, `arg_required_else_help`, `disable_help_flag`, `disable_help_subcommand`, `disable_version_flag`, `dont_delimit_trailing_values`, `args_override_self`, `subcommand_negates_reqs`, `args_conflicts_with_subcommands`, `subcommand_precedence_over_arg`, `allow_missing_positional`, \
                                  `next_help_heading`, `subcommand_help_heading`, `next_line_help`, `flatten_help`, `term_width`, `max_term_width`, \
-                                 `subcommand_value_name`, `restart_token`, `mount` and \
+                                 `subcommand_value_name`, `restart_token`, `mount`, `example` and \
                                  `group` and `view` here, and the description comes from the doc \
                                  comment"
                             ),
@@ -3734,6 +3743,67 @@ fn program_basename(program: &str) -> &str {
 
 /// `view("aubr", root = "run", globals)` promotes `run` to the executable surface
 /// named `aubr`. `global = "--flag"` may be repeated instead of carrying all globals.
+/// One worked invocation, as `example = "mycli deploy -e prod"` or, when it needs more
+/// than the line itself, `example("mycli deploy -e prod", header = "Basic deployment",
+/// help = "Deploy to production")`.
+///
+/// The three fields are the spec's, minus `lang`: a typed declaration is Rust, so the
+/// example is a command line and there is nothing for a highlighting hint to choose
+/// between. Each part keeps its tokens rather than its text, so a constant or `concat!`
+/// can be the source of truth here as it already can for `after_help`.
+pub struct ExampleDecl {
+    pub code: proc_macro2::TokenStream,
+    pub header: Option<proc_macro2::TokenStream>,
+    pub help: Option<proc_macro2::TokenStream>,
+}
+
+fn example_decl(meta: &Meta) -> syn::Result<ExampleDecl> {
+    match meta {
+        Meta::NameValue(_) => Ok(ExampleDecl {
+            code: metadata_expr(meta)?,
+            header: None,
+            help: None,
+        }),
+        Meta::List(list) => list.parse_args_with(|input: syn::parse::ParseStream| {
+            let code: Expr = input.parse()?;
+            let mut example = ExampleDecl {
+                code: quote::ToTokens::to_token_stream(&code),
+                header: None,
+                help: None,
+            };
+            while !input.is_empty() {
+                input.parse::<syn::Token![,]>()?;
+                if input.is_empty() {
+                    break;
+                }
+                let property: syn::Ident = input.parse()?;
+                input.parse::<syn::Token![=]>()?;
+                let value: Expr = input.parse()?;
+                let value = quote::ToTokens::to_token_stream(&value);
+                match property.to_string().as_str() {
+                    "header" => example.header = Some(value),
+                    "help" => example.help = Some(value),
+                    other => {
+                        return Err(syn::Error::new_spanned(
+                            property,
+                            format!(
+                                "unknown example property `{other}`; an example takes \
+                                 `header` and `help` after the command line"
+                            ),
+                        ));
+                    }
+                }
+            }
+            Ok(example)
+        }),
+        Meta::Path(_) => Err(syn::Error::new_spanned(
+            meta,
+            "an example is declared as `example = \"mycli deploy\"`, with \
+             `example(\"mycli deploy\", header = \"…\", help = \"…\")` when it needs more",
+        )),
+    }
+}
+
 fn view_decl(meta: &Meta) -> syn::Result<ViewDecl> {
     let Meta::List(list) = meta else {
         return Err(syn::Error::new_spanned(
@@ -4485,6 +4555,9 @@ pub struct Variant {
     pub before_long_help: Option<proc_macro2::TokenStream>,
     pub after_help: Option<proc_macro2::TokenStream>,
     pub after_long_help: Option<proc_macro2::TokenStream>,
+    /// Declared on the variant, which is where the command is. Left empty, the held
+    /// `Args` type's own examples stand — the same inheritance `after_help` has.
+    pub examples: Vec<ExampleDecl>,
 }
 
 impl Subcommands {
@@ -4608,6 +4681,7 @@ impl Variant {
         let mut before_long_help = None;
         let mut after_help = None;
         let mut after_long_help = None;
+        let mut examples: Vec<ExampleDecl> = Vec::new();
 
         for attr in attrs(&variant.attrs) {
             let clap_attr = attr.path().is_ident("command");
@@ -4644,6 +4718,7 @@ impl Variant {
                     "before_long_help" => before_long_help = Some(metadata_expr(&meta)?),
                     "after_help" => after_help = Some(metadata_expr(&meta)?),
                     "after_long_help" => after_long_help = Some(metadata_expr(&meta)?),
+                    "example" => examples.push(example_decl(&meta)?),
                     "verbatim_doc_comment" => verbatim_doc_comment = flag_value(&meta)?,
                     other => {
                         return Err(syn::Error::new_spanned(
@@ -4652,7 +4727,7 @@ impl Variant {
                                 "unknown option `{other}` on a variant; a subcommand \
                                  variant takes `name`, `alias`, `alias_hidden`, `help_heading`, `display_order`, \
                                  `external_subcommand`, `help`, `long_help`, `deprecated`, `deprecated_warn_at`, `deprecated_remove_at`, `before_help`, \
-                                 `before_long_help`, `after_help`, `after_long_help`, and `verbatim_doc_comment` here, \
+                                 `before_long_help`, `after_help`, `after_long_help`, `example`, and `verbatim_doc_comment` here, \
                                  and its description comes from the doc comment"
                             ),
                         ));
@@ -4713,6 +4788,7 @@ impl Variant {
                 || before_long_help.is_some()
                 || after_help.is_some()
                 || after_long_help.is_some()
+                || !examples.is_empty()
             {
                 return Err(syn::Error::new_spanned(
                     &variant.ident,
@@ -4776,6 +4852,7 @@ impl Variant {
                 before_long_help: None,
                 after_help: None,
                 after_long_help: None,
+                examples: Vec::new(),
             });
         }
 
@@ -4845,6 +4922,7 @@ impl Variant {
             before_long_help,
             after_help,
             after_long_help,
+            examples,
         })
     }
 }

--- a/docs/rust/help.md
+++ b/docs/rust/help.md
@@ -54,8 +54,14 @@ convenience entry point for CLIs that want immediate print-and-exit behavior.
 ### Customizing the page
 
 - `usage = "…"` on the root replaces the generated synopsis line(s) verbatim.
-- `before_help`, `after_help`, `before_long_help`, `after_long_help` add text around the page —
-  `after_long_help` is the conventional home for an Examples section.
+- `before_help`, `after_help`, `before_long_help`, `after_long_help` add text around the page.
+- `example = "mycli deploy -e prod"` on a command declares a worked invocation, repeatable, and
+  rendered as an Examples section. It takes a header and prose where the line needs them:
+  `example("mycli deploy -e prod", header = "Basic deployment", help = "Deploy to production")`.
+  Declared on a subcommand variant, it speaks for that command; declared on the `Args` type, it
+  stands wherever the variant declares none. Unlike an Examples section written by hand into
+  `after_long_help`, a declared example reaches the emitted spec, so docs, manpages and
+  `usage lint` can all read it — the last of those checks that it still parses.
 - `help_heading` on a field or subcommand variant groups it under a heading.
 - `display_order = n` on a field or subcommand controls its position within a help section
   without changing positional parsing order.
@@ -71,9 +77,9 @@ held to identical output over mise's 211 command pages in CI.
 ## Version
 
 Declaring `version` (or bare `version`, which reads `CARGO_PKG_VERSION`) gives the root command
-`--version` and `-V`. Neither is listed in help. If your CLI declares its own `--version` or
-`-V`, your spelling wins and the other still answers — where clap panics at startup for the
-same collision.
+`--version` and `-V`, and lists them on its page. If your CLI declares its own `--version` or
+`-V`, your spelling wins, the other still answers, and the page shows whichever is left — where
+clap panics at startup for the same collision.
 
 `parse()` prints `{bin} {version}` and exits `0`.
 

--- a/docs/rust/index.md
+++ b/docs/rust/index.md
@@ -147,8 +147,6 @@ See [Spec output](/rust/spec) for the round-trip guarantees and what the emitted
 The framework intentionally targets standard GNU-style CLIs, and a few clap features have no
 equivalent yet:
 
-- `example` nodes exist in the spec format but cannot be declared from the derive — put an
-  Examples section in `after_long_help` instead (mise does this).
 - A declared `value_optional` needs either `default_missing` or an
   `Option<Option<T>>` field to define what a bare flag binds.
 - Rust `value_parser` functions are not portable metadata. Values use `FromStr`; use

--- a/docs/rust/spec.md
+++ b/docs/rust/spec.md
@@ -118,9 +118,9 @@ help pages through both.
 
 ## What can't be expressed from the derive
 
-A few spec nodes have no derive attribute yet:
+Nothing, as of `example`: every node the spec format defines now has a derive attribute. That is
+the rule this project holds itself to — a typed declaration must lower into the spec losslessly,
+and where it cannot, the derive gains the vocabulary rather than the spec losing it.
 
-- `example` nodes — declare examples in `after_long_help` instead
-
-If you need these today, maintain a KDL spec alongside the derive or generate docs from a
-post-processed spec.
+The one property that does not carry over is an example's `lang`, which picks syntax
+highlighting for a KDL-authored example and has nothing to choose between in Rust.

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -1251,6 +1251,11 @@ fn parse_partial_with_env(
                 record_cursor(&mut out, next_arg_idx, seen_double_dash);
                 return Ok((out, overridden_flags));
             }
+            if is_version_arg(spec, &out.cmds, &w) {
+                out.errors.push(render_version_err(spec, w.len() > 2));
+                record_cursor(&mut out, next_arg_idx, seen_double_dash);
+                return Ok((out, overridden_flags));
+            }
             reject_unknown_flag_if_asked(spec, &out.cmds, &w)?;
         }
 
@@ -1355,6 +1360,11 @@ fn parse_partial_with_env(
             if is_help_arg(spec, &out.cmd, &w) {
                 out.errors
                     .push(render_help_err(spec, &out.cmd, w.len() > 2));
+                record_cursor(&mut out, next_arg_idx, seen_double_dash);
+                return Ok((out, overridden_flags));
+            }
+            if is_version_arg(spec, &out.cmds, &w) {
+                out.errors.push(render_version_err(spec, w.len() > 2));
                 record_cursor(&mut out, next_arg_idx, seen_double_dash);
                 return Ok((out, overridden_flags));
             }
@@ -1534,6 +1544,11 @@ fn parse_partial_with_env(
         if is_help_arg(spec, &out.cmd, &w) {
             out.errors
                 .push(render_help_err(spec, &out.cmd, w.len() > 2));
+            record_cursor(&mut out, next_arg_idx, seen_double_dash);
+            return Ok((out, overridden_flags));
+        }
+        if is_version_arg(spec, &out.cmds, &w) {
+            out.errors.push(render_version_err(spec, w.len() > 2));
             record_cursor(&mut out, next_arg_idx, seen_double_dash);
             return Ok((out, overridden_flags));
         }
@@ -2576,6 +2591,17 @@ fn render_help_all_err(_spec: &Spec, _cmd: &SpecCommand) -> UsageErr {
     UsageErr::Help("help".to_string())
 }
 
+/// The version to answer with. `--version` prefers the long text and `-V` the concise
+/// one, each falling back to the other when only one is declared.
+fn render_version_err(spec: &Spec, long: bool) -> UsageErr {
+    let value = if long {
+        spec.long_version.as_ref().or(spec.version.as_ref())
+    } else {
+        spec.version.as_ref().or(spec.long_version.as_ref())
+    };
+    UsageErr::Version(value.cloned().unwrap_or_default())
+}
+
 fn render_action_err(spec: &Spec, cmd: &SpecCommand, flag: &SpecFlag, spelling: &str) -> UsageErr {
     use crate::SpecFlagAction;
     match flag.action {
@@ -2583,14 +2609,7 @@ fn render_action_err(spec: &Spec, cmd: &SpecCommand, flag: &SpecFlag, spelling: 
         SpecFlagAction::HelpShort => render_help_err(spec, cmd, false),
         SpecFlagAction::HelpLong => render_help_err(spec, cmd, true),
         SpecFlagAction::HelpAll => render_help_all_err(spec, cmd),
-        SpecFlagAction::Version => {
-            let value = if spelling.starts_with("--") {
-                spec.long_version.as_ref().or(spec.version.as_ref())
-            } else {
-                spec.version.as_ref().or(spec.long_version.as_ref())
-            };
-            UsageErr::Version(value.cloned().unwrap_or_default())
-        }
+        SpecFlagAction::Version => render_version_err(spec, spelling.starts_with("--")),
         SpecFlagAction::Set => unreachable!("binding actions are handled before this helper"),
     }
 }
@@ -3189,6 +3208,27 @@ fn report_double_dash_violation(
     }
 }
 
+/// `--version` and `-V`, which the parser supplies where the spec declares a version.
+///
+/// The twin of [`is_help_arg`], and of the `version` bit in usage-argv's and usage-go's
+/// command tables — both of which accepted these spellings while this parser called them
+/// unknown words. The help page has always listed `-V, --version` under the same
+/// condition, and said in as many words that it did so "only where a version is
+/// declared, which is where a parser accepts one", so a spec with a `version` rendered a
+/// page advertising a flag the parse refused.
+///
+/// The root only, because that is where the page lists it: `version` is a property of
+/// the program, and a subcommand answering with the program's version is a claim no spec
+/// made. A declared flag wins by arriving first — every scan consults this only after
+/// nothing declared matched — so a CLI that spends `-V` on something else keeps it, and
+/// keeps `--version` supplied beside it.
+fn is_version_arg(spec: &Spec, cmds: &[SpecCommand], w: &str) -> bool {
+    (spec.version.is_some() || spec.long_version.is_some())
+        && cmds.len() == 1
+        && !spec.cmd.disable_version_flag
+        && (w == "--version" || w == "-V")
+}
+
 fn is_help_arg(spec: &Spec, cmd: &SpecCommand, w: &str) -> bool {
     spec.disable_help != Some(true)
         && (((w == "--help" || w == "-h" || w == "-?") && !cmd.disable_help_flag)
@@ -3269,6 +3309,95 @@ mod tests {
 
     fn input(words: &[&str]) -> Vec<String> {
         words.iter().map(|word| (*word).to_string()).collect()
+    }
+
+    #[test]
+    fn a_declared_version_supplies_the_flag_the_help_page_lists() {
+        // The page has always listed `-V, --version` wherever a `version` is declared,
+        // and usage-argv and usage-go have always accepted both. This parser called them
+        // unknown words, so the one implementation the corpus measures the others against
+        // was the one that disagreed.
+        let spec: Spec = "name \"ex\"\nbin \"ex\"\nversion \"1.2.3\"\ncmd \"run\"\n"
+            .parse()
+            .unwrap();
+
+        for spelling in ["--version", "-V"] {
+            let err = parse(&spec, &input(&["ex", spelling]))
+                .expect_err("answering with a version ends the parse");
+            assert_eq!(err.to_string(), "1.2.3", "{spelling}");
+        }
+    }
+
+    #[test]
+    fn the_supplied_version_flag_is_the_roots_alone() {
+        // `version` describes the program, and the page lists the entry on the program's
+        // own page only. A subcommand answering with it would be a claim no spec made.
+        let spec: Spec = "name \"ex\"\nbin \"ex\"\nversion \"1.2.3\"\ncmd \"run\"\n"
+            .parse()
+            .unwrap();
+
+        let err = parse(&spec, &input(&["ex", "run", "--version"])).unwrap_err();
+        assert_eq!(err.to_string(), "unexpected word: --version");
+    }
+
+    #[test]
+    fn no_declared_version_supplies_nothing() {
+        // A `--version` answering with nothing is worse than one that is not there, which
+        // is why the entry is conditional on the page and the spelling on the parse.
+        let spec: Spec = "name \"ex\"\nbin \"ex\"\n".parse().unwrap();
+
+        for spelling in ["--version", "-V"] {
+            let err = parse(&spec, &input(&["ex", spelling])).unwrap_err();
+            assert_eq!(err.to_string(), format!("unexpected word: {spelling}"));
+        }
+    }
+
+    #[test]
+    fn disable_version_flag_removes_the_supplied_spellings() {
+        let spec: Spec = "name \"ex\"\nbin \"ex\"\nversion \"1.2.3\"\ndisable_version_flag #true\n"
+            .parse()
+            .unwrap();
+
+        for spelling in ["--version", "-V"] {
+            let err = parse(&spec, &input(&["ex", spelling])).unwrap_err();
+            assert_eq!(err.to_string(), format!("unexpected word: {spelling}"));
+        }
+    }
+
+    #[test]
+    fn a_spelling_the_spec_spends_elsewhere_keeps_its_meaning() {
+        // The page drops each supplied spelling the CLI claimed and keeps the other; the
+        // parse agrees without being told, because a declared flag is matched first.
+        let spec: Spec = "name \"ex\"\nbin \"ex\"\nversion \"1.2.3\"\nflag \"-V --verbose\"\n"
+            .parse()
+            .unwrap();
+
+        let out = parse(&spec, &input(&["ex", "-V"])).expect("-V is the CLI's own flag");
+        assert_eq!(out.flags.len(), 1);
+
+        let err = parse(&spec, &input(&["ex", "--version"])).unwrap_err();
+        assert_eq!(err.to_string(), "1.2.3");
+    }
+
+    #[test]
+    fn the_supplied_spellings_split_the_two_version_texts() {
+        // The same split `render_action_err` gives a declared version flag: the long
+        // spelling prefers `long_version`, the short prefers the concise one.
+        let spec: Spec =
+            "name \"ex\"\nbin \"ex\"\nversion \"1.2.3\"\nlong_version \"1.2.3 (abcdef)\"\n"
+                .parse()
+                .unwrap();
+
+        assert_eq!(
+            parse(&spec, &input(&["ex", "--version"]))
+                .unwrap_err()
+                .to_string(),
+            "1.2.3 (abcdef)"
+        );
+        assert_eq!(
+            parse(&spec, &input(&["ex", "-V"])).unwrap_err().to_string(),
+            "1.2.3"
+        );
     }
 
     fn spec_with_arg(arg: SpecArg) -> Spec {


### PR DESCRIPTION
Idea 3 from the feature list — examples are documentation that nothing has ever tested — plus the two findings that came out of building it.

## 1. `usage lint` parses every example

An `example` node is a command line a reader is invited to type. Nothing checked that the spec declaring it still accepts it, so a renamed flag leaves the example behind and help output, markdown and manpages keep publishing it. `usage lint` now parses each example against its own spec and reports `example-does-not-parse` (warning), which makes `example` load-bearing rather than prose.

The check is conservative on purpose — a linter that reports a working example as broken gets switched off. A line is examined only when it is unmistakably an invocation of *this* CLI:

- a `$` or `%` prompt and leading `VAR=value` assignments are stripped;
- everything from the first bare shell operator onward is dropped, so `mycli ls --json | jq .` is checked as `mycli ls --json` — an operator only counts as a whole word, so a quoted `"a|b"` stays a value;
- backslash continuations are folded, and each line of a session is judged on its own, so output lines, comments and other programs are skipped rather than guessed at;
- a non-shell `lang` (`lang="toml"`) is a file being shown, not argv;
- views and multicall applets count as this program, since both are ways for one spec to name more than one command.

Two outcomes are not failures. `--help` and `--version` end the parse by printing, which usage-lib reports as an error carrying the text — and reports in preference to any other error on the line. And a command reached through a mount is skipped: mount outputs are injected and empty, so a linter never spawns the program it is linting. The environment is empty for the same reason: an example that only parses because of a variable the author happens to have exported is one the reader cannot type.

## 2. `--version` now parses where the help page says it does

The lint's first run reported `demo --version` in `examples/spec-with-examples.usage.kdl`, and it was right to. usage-lib refused `--version` and `-V` unless a spec declared a flag with `action="version"`, while its own help renderer supplied a `-V, --version` entry for any root declaring a `version` — and `lib/src/docs/cli/mod.rs:93` said it did so "only where a version is declared, **which is where a parser accepts one**". So a spec with a version rendered a page advertising a flag the parse called an unknown word.

usage-argv and usage-go both accept the supplied spellings already, each carrying a `version` bit on the command table for exactly this. usage-lib is the implementation the corpus measures the others against, and it was the one that disagreed — so the fix is here.

Supplied on the root alone, because that is where the page lists it. `disable_version_flag` removes both spellings; a declared flag wins by arriving first, so a CLI spending `-V` on something else keeps it and keeps `--version` supplied beside it; `--version` prefers `long_version` and `-V` the concise text, the same split a declared version flag already had.

Worth noting for later: nothing in the binding corpus covers this, because `expect` has no vocabulary for an invocation that prints and exits. That is why the divergence went unseen, and it is a gap this PR does not close — extending the corpus format reaches the Go runner and the conformance harness, which is its own change.

## 3. The derive can declare examples

The second finding was that no fleet spec declares a single `example`: they are generated from clap, which has no vocabulary for one, and the derive had none either. The metadata tables have carried examples the whole time and both help renderers show them, so the gap was the derive alone.

```rust
#[usage(example = "mycli deploy -e prod")]
```

and, where the line needs more than itself:

```rust
#[usage(example(
    "mycli deploy -e prod",
    header = "Basic deployment",
    help = "Deploy to production",
))]
```

Repeatable, on a `Cli` root, on an `Args` command, and on a subcommand variant. Each part keeps its tokens rather than its text, so a constant or `concat!` can be the source of truth as it already can for `after_help`. A variant that declares examples speaks for its command; the held type's stand where the variant declares none — the inheritance `after_help` already has. An `external_subcommand` refuses them along with the rest of its page. The spec's `lang` has no derive spelling: it picks syntax highlighting for a KDL-authored example, and a typed declaration is Rust.

`docs/rust/spec.md` and `docs/rust/index.md` both listed this as the one spec node the derive could not express. That list is now empty.

## Testing

- Twelve lint cases in `cli/src/cli/lint.rs`, with negative controls: a session whose own second command is broken is reported while its output lines are not, and the mount case uses a `run` string that is not a command, so a linter resolving mounts by running them would fail it.
- Six parse cases in `lib/src/parse.rs` covering the supplied spellings, the root-only rule, `disable_version_flag`, a claimed `-V`, and the long/short version split.
- One conformance case in `conformance/tests/metadata.rs` — the file for "things a spec can say that the derive could not" — checking that examples reach the emitted KDL at both levels, that a variant overrides its type, and that usage-argv's page and usage-lib's are byte-identical.

`cargo test --all --all-features` passes (1,979 tests), `cargo clippy --all --all-features -- -D warnings` clean, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the usage-lib parser so `--version`/`-V` now succeed on the root, which can change CLI behavior for specs that only declared `version`. Lint and derive additions are additive and well-tested.
> 
> **Overview**
> Makes `example` load-bearing: `usage lint` now parses each shell example against its spec (`example-does-not-parse`), and the derive can declare examples so they reach help, KDL, docs, and that lint instead of living as prose in `after_long_help`.
> 
> The lint is conservative: it only checks lines that look like this CLI (prompts, env assignments, pipes, sessions, non-shell `lang` skipped). It never runs mounts; lines that need a mounted program get `example-not-checked`. `--help`/`--version` that print-and-exit are treated as valid.
> 
> usage-lib now accepts the supplied root `--version`/`-V` wherever help already listed them (matching argv/go). Declared flags still win; `disable_version_flag` still removes both.
> 
> `#[usage(example = "…")]` (optional `header`/`help`) works on `Cli`, `Args`, and subcommand variants, with the same variant-over-type inheritance as `after_help`. Every spec node now has a derive spelling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ed43ae86920f3021bb98d4bfca75fcffe316cd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for declaring command examples directly on CLI commands, subcommands, and variants, including optional headers and help text.
  - Examples are now included consistently in generated help and specification output.
  - Root commands recognize `--version` and `-V`, with appropriate short or long version text.

- **Bug Fixes**
  - Improved example linting for mounted commands, redirections, quoted values, placeholders, and case-insensitive shell languages.
  - Preserved explicitly declared flags when version options could conflict.

- **Documentation**
  - Updated guidance for command examples, help customization, version options, and specification generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->