### PR TITLE
fix(complete): resolve config keys through aliases and renames

### DIFF
--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -563,7 +563,7 @@ impl CompleteWord {
             // offered another key's values for a line whose own key is a typo, where an unknown
             // key on its own correctly offers nothing.
             .next_back()
-            .and_then(|word| cx.spec.config.props.get(word))
+            .and_then(|word| resolve_config_key(&cx.spec.config, word))
     }
 
     /// The reserved `type=` of the completer for an argument, if it has one.
@@ -923,6 +923,46 @@ fn one_line(text: Option<&str>) -> String {
         .unwrap_or_default()
         .trim()
         .to_string()
+}
+
+/// The setting a key on the command line names, following the names it is also known by.
+///
+/// A plain lookup was not enough, because the key a user types is not always the key a spec
+/// declares. `alias` names are accepted by the config layer without so much as a warning
+/// (`Registry::deprecation` resolves them the same way), so a config file in the wild carries
+/// them and a user reading that file types them — and completion answering an accepted key
+/// with the contents of the working directory is worse than answering nothing.
+///
+/// `renamed_to` is followed for the same reason and one more: the old name is by definition
+/// the one people still have written down, and the values it takes are whatever its
+/// replacement takes. The chain is walked rather than the one hop taken, since a setting
+/// renamed twice is still reachable from the oldest name.
+///
+/// Bounded by the number of props, so a registry whose renames form a cycle stops instead of
+/// following them forever — the same guard, and the same reasoning, as `Registry::deprecation`
+/// in `usage-config`: that is an authoring mistake, and a completion that hangs reports it
+/// worse than one that goes quiet.
+fn resolve_config_key<'a>(
+    config: &'a usage::spec::config::SpecConfig,
+    key: &str,
+) -> Option<&'a SpecConfigProp> {
+    let (_, mut prop) = config
+        .props
+        .iter()
+        .find(|(name, prop)| name.as_str() == key || prop.aliases.iter().any(|a| a == key))?;
+    for _ in 0..config.props.len() {
+        let Some(target) = &prop.renamed_to else {
+            return Some(prop);
+        };
+        // A rename pointing at nothing is as far as the chain goes. The old declaration is
+        // still a real setting with its own type and choices, so it answers for itself rather
+        // than the key being treated as unknown.
+        let Some(next) = config.props.get(target) else {
+            return Some(prop);
+        };
+        prop = next;
+    }
+    Some(prop)
 }
 
 /// Whether this type accepts values no list could enumerate.

--- a/cli/tests/complete_word.rs
+++ b/cli/tests/complete_word.rs
@@ -783,13 +783,15 @@ fn complete_word_config_keys_come_from_the_spec() {
     // No subprocess and no `run=`: the `config` block already says what the keys are, which
     // is the whole point of declaring them there.
     assert_cmd("config.usage.kdl", &["config", "get", ""]).stdout(
-        "bool_or_path\tEither a switch or somewhere to put it\n\
+        "ancient_log_level\tdeprecated — How much to say\n\
+         bool_or_path\tEither a switch or somewhere to put it\n\
          cache_dir\tWhere to keep the cache\n\
          color\tColorize output\n\
          either\tA union with bool second\n\
          jobs\tNumber of parallel jobs\n\
          log_level\tHow much to say\n\
          old_jobs\tdeprecated — How many jobs\n\
+         old_log_level\tdeprecated — How much to say\n\
          python.compile\tCompile python from source\n\
          task.output\tHow to print task output\n",
     );
@@ -904,6 +906,53 @@ fn complete_word_the_key_is_the_argument_the_spec_says_holds_one() {
     )
     .stdout(contains("every decision"))
     .stdout(contains("false").not());
+}
+
+#[test]
+fn complete_word_config_values_follow_the_names_a_setting_answers_to() {
+    // The key a user types is not always the key the spec declares. An `alias` is accepted by
+    // the config layer without so much as a warning, so it reaches completion the same way any
+    // other key does — and answering it with the working directory, as this did, tells the user
+    // an accepted setting is not one.
+    assert_cmd("config.usage.kdl", &["config", "set", "loglevel", ""]).stdout(
+        "error\tonly failures\n\
+         warn\tfailures and warnings\n\
+         info\tthe usual\n\
+         debug\tevery decision\n",
+    );
+    // A prefix still filters, and still does not reach for files.
+    assert_cmd("config.usage.kdl", &["config", "set", "loglevel", "d"])
+        .stdout("debug\tevery decision\n");
+    // `renamed_to` is followed for the same reason, and the old name is by definition the one
+    // people still have written down. One hop, and two: a setting renamed twice is reachable
+    // from the oldest name it ever had.
+    assert_cmd("config.usage.kdl", &["config", "set", "old_log_level", ""])
+        .stdout(contains("debug\tevery decision"));
+    assert_cmd(
+        "config.usage.kdl",
+        &["config", "set", "ancient_log_level", ""],
+    )
+    .stdout(contains("debug\tevery decision"));
+    // The keys offered stay canonical: an alias is a spelling of a setting already in the
+    // list, and a second row for it would be a second setting as far as the menu shows.
+    assert_cmd("config.usage.kdl", &["config", "get", "loglev"]).stdout("");
+}
+
+#[test]
+fn complete_word_a_rename_that_leads_nowhere_still_answers() {
+    // A cycle is walked at most as far as there are settings, so this returns rather than
+    // following the rename forever. The test is that it terminates at all; both ends of the
+    // cycle are boolean so that giving up early could not pass by accident.
+    assert_cmd(
+        "config-rename-edges.usage.kdl",
+        &["config", "set", "cycle_a", ""],
+    );
+    // A rename pointing at nothing leaves a setting that is still real, with its own type.
+    assert_cmd(
+        "config-rename-edges.usage.kdl",
+        &["config", "set", "dangling", ""],
+    )
+    .stdout("false\ntrue\n");
 }
 
 #[test]

--- a/docs/spec/reference/complete.md
+++ b/docs/spec/reference/complete.md
@@ -55,6 +55,11 @@ it does not matter where the key sits relative to the cursor. It offers that set
 `choices` with their own help, or `true` and `false` for a boolean. For anything else it stays
 quiet and the file fallback applies, which is what a path-valued setting wants anyway.
 
+A key is matched by every name the setting answers to, not only the one it is declared
+under: an `alias` resolves to the setting that declares it, and a `renamed_to` chain is
+followed to the setting that now holds the values. Those are the names a config file in the
+wild still carries, so they are the ones a user types.
+
 Both are _closed_: where the spec enumerates the candidates, a prefix matching none of them
 completes to nothing rather than falling back to filenames. A setting whose values the spec
 does not enumerate keeps the fallback — including a union like `bool|path`, where `true` and

--- a/examples/config-rename-edges.usage.kdl
+++ b/examples/config-rename-edges.usage.kdl
@@ -1,0 +1,29 @@
+// Renames that do not lead anywhere, kept out of `config.usage.kdl` so that file stays a
+// spec worth copying.
+//
+// Both are authoring mistakes rather than shapes to imitate, and the point of the fixture is
+// that a completion meets them without hanging and without claiming to know the answer.
+name "mycli"
+bin "mycli"
+
+complete "key" type="config_keys"
+complete "value" type="config_values"
+
+config {
+    // A cycle. Following it forever is the failure this guards against, so the values here
+    // are deliberately enumerable: a chain walker that terminated by giving up early would
+    // still answer `false`/`true` and look correct.
+    prop "cycle_a" type="bool" renamed_to="cycle_b" help="Renamed to cycle_b"
+    prop "cycle_b" type="bool" renamed_to="cycle_a" help="Renamed to cycle_a"
+
+    // A rename pointing at a setting that does not exist. The old declaration is still a
+    // real setting with its own type, so it answers for itself.
+    prop "dangling" type="bool" renamed_to="never_declared" help="Renamed to nothing"
+}
+
+cmd "config" help="Manage settings" {
+    cmd "set" help="Change one setting" {
+        arg "<key>" help="The setting to change"
+        arg "<value>" help="Its new value"
+    }
+}

--- a/examples/config.usage.kdl
+++ b/examples/config.usage.kdl
@@ -21,6 +21,9 @@ config {
     prop "color" type="bool" default=#true help="Colorize output"
     prop "jobs" type="uint" default=4 help="Number of parallel jobs"
     prop "log_level" type="string" default="info" help="How much to say" {
+        // An accepted spelling of the same setting, which the config layer reads without a
+        // warning — so a config file in the wild carries it and a user types it.
+        alias "loglevel"
         choices {
             choice "error" help="only failures"
             choice "warn" help="failures and warnings"
@@ -41,6 +44,12 @@ config {
     prop "internal_thing" type="bool" hide=#true help="Not for public use"
     prop "old_jobs" type="uint" deprecated="Use jobs instead." renamed_to="jobs" \
         help="How many jobs"
+    // Renamed once, and renamed twice: the values the old name takes are whatever its
+    // replacement takes, however many renames back the name a user has written down is.
+    prop "old_log_level" type="string" deprecated="Use log_level instead." \
+        renamed_to="log_level" help="How much to say"
+    prop "ancient_log_level" type="string" deprecated="Use log_level instead." \
+        renamed_to="old_log_level" help="How much to say"
 }
 
 cmd "config" help="Manage settings" {


### PR DESCRIPTION
## What this is

I set out to build "config-driven completion for settings" as a new feature and found it
already shipped in #840 — `type="config_keys"` and `type="config_values"` are implemented,
documented in `docs/spec/reference/complete.md`, and covered by tests. My earlier note
calling it a gap was wrong.

Verifying it turned up a real bug instead, which is what this PR fixes.

## The bug

`config_values` resolved the typed key with a plain `spec.config.props.get(word)`, so it
only recognised a setting under the name it is declared with. Given a spec whose
`log_level` declares `alias "loglevel"`:

```
$ mycli config set log_level ⌶     # error / warn / info / debug
$ mycli config set loglevel ⌶      # AGENTS.md  CHANGELOG.md  Cargo.toml  …
```

An `alias` is accepted by the config layer without so much as a warning, and `renamed_to`
names are by definition the ones people still have written down — both arrive at completion
the same way any other key does. Answering an accepted key with the contents of the working
directory tells the user a real setting is not one.

`usage-config` has resolved keys this way all along — `Registry::deprecation` matches on
`meta.key == key || meta.aliases.contains(&key)` and then follows `renamed_to`. Only the
completion path disagreed with the runtime.

## The fix

`resolve_config_key` matches the canonical name or any `alias`, then follows the
`renamed_to` chain to the setting that actually holds the values. Walked at most as far as
there are props, so a registry whose renames form a cycle stops instead of hanging — the
same bound and the same reasoning as `Registry::deprecation`. A rename pointing at nothing
leaves the old declaration answering for itself, since it is still a real setting with its
own type and choices.

## One deliberate non-change

The **keys offered stay canonical**. An alias is a spelling of a setting already in the
list, and a second row for it would read as a second setting — at mise's 273 settings that
roughly doubles the menu. There is an argument the other way, since `config_keys`
deliberately does offer `deprecated` settings on the grounds that "a config file in the wild
names it, so it must be completable", and an alias is exactly a name in the wild. Happy to
flip it if you prefer; the test pins the current choice either way.

## Tests

- `complete_word_config_values_follow_the_names_a_setting_answers_to` — alias, prefix
  filtering under an alias, one rename hop, two rename hops, and that keys stay canonical.
  Verified to fail without the fix.
- `complete_word_a_rename_that_leads_nowhere_still_answers` — cycle terminates, dangling
  rename answers for itself. Both ends of the cycle are boolean so that giving up early
  could not pass by accident.

Fixture changes: `alias "loglevel"` plus a two-hop rename chain in
`examples/config.usage.kdl`, and a new `examples/config-rename-edges.usage.kdl` for the
cycle and dangling cases — kept out of the main example so that file stays a spec worth
copying.

`cargo test -p usage-cli`, `-p usage-lib --all-features`, `clippy -D warnings`, `cargo fmt`
and `prettier` all pass, checked in a clean worktree at this commit.

_This PR description was generated by Claude Code._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Completion-only lookup change with cycle/dangling guards and tests; no runtime config or auth behavior is modified.
> 
> **Overview**
> **`config_values` now treats aliases and old names as the same setting.** Completing `config set loglevel` (or a `renamed_to` predecessor) used a plain `props.get`, so an accepted key fell through to filenames. Lookup now matches canonical name or `alias`, then walks `renamed_to` to the prop that holds choices/type.
> 
> The walk is bounded by the number of props (same cycle guard as `Registry::deprecation`). A dangling rename still completes from the old declaration. **Key menus stay canonical** — aliases are not extra rows.
> 
> Docs and fixtures cover alias, multi-hop rename, cycle, and dangling rename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7430320b5fb8af791ba382388baae1322d0d8ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Configuration value completion now recognizes aliases and legacy setting names.
  - Completion follows chains of renamed settings to provide values for the current configuration.
  - Canonical settings remain available, including cases with cyclic or incomplete rename mappings.

- **Documentation**
  - Updated completion reference documentation to explain alias and rename support.

- **Tests**
  - Added coverage for deprecated names, multi-step renames, cyclic mappings, and missing rename targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->