### PR TITLE
feat(spec): reusable flag declarations with flagset and use

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -304,6 +304,27 @@ tasks --usage"`, so task names are meant to come from running that. usage-argv d
       mise's help from the shadow and diffing every line against usage-lib's — 23 of 211 differed,
       and every difference traced to one of these. They matter past help text, since the emitted
       spec is what docs, manpages, completions and the SDK generators read.
+- [x] **Reusable declarations inside a spec** — mise's checked-in spec is 5,592 lines for 711
+      flags, and most of that count is the same handful of declarations written again under the
+      next command. The derive has `flatten` for this and a hand-authored spec had nothing, so
+      `flagset "name" { flag … }` plus `use "name"` now says it once. Resolved while the file is
+      read, so nothing downstream — help, completions, docs, the generated parsers — learns a
+      concept: reuse disappears into what it stands for rather than becoming vocabulary every
+      consumer has to implement.
+      Decisions worth recording, since each had a defensible other answer. A `use` expands **in
+      place**, because help order is spec order and appending would reorder the command that
+      used it. A command's own declaration **wins** over one arriving from a set, per-form, which
+      is the rule a redeclared global already follows — so a diamond through composition also
+      contributes once. Sets may **compose**; a cycle is an error naming the path that closes it.
+      Sets hold **flags only**: a flag is identified by its spelling wherever it lands, while a
+      positional is identified by its position, so the same set spliced into two commands with
+      different arguments would mean two different things. Sets travel through `include`, and
+      each file resolves its own `use` nodes — a file cannot use a set declared only by a file
+      that includes _it_, which would make a spec's meaning depend on who read it.
+      What this does **not** do yet is give the derive's `flatten` a lossless lowering: it still
+      emits the expanded copy, so the flags mise's spec repeats stay repeated in the generated
+      file. Emitting one flagset per flattened struct is the follow-up, and it is what would
+      turn this from an authoring convenience into a smaller generated spec.
 
 ### Then: what a CLI framework has to have
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -117,6 +117,7 @@ export default defineConfig({
               { text: "cmd", link: "/spec/reference/cmd" },
               { text: "complete", link: "/spec/reference/complete" },
               { text: "flag", link: "/spec/reference/flag" },
+              { text: "flagset", link: "/spec/reference/flagset" },
               { text: "group", link: "/spec/reference/group" },
               // { text: 'env', link: '/spec/reference/env' },
               { text: "config", link: "/spec/reference/config" }

--- a/docs/spec/reference/flagset.md
+++ b/docs/spec/reference/flagset.md
@@ -165,6 +165,11 @@ the file that wrote it.
 Every set is resolved while its file is read, whether or not anything uses it, so a `use`
 naming a set that does not exist is reported even inside a set nothing has reached for yet.
 
+A `use` belongs to the flags it stands among, so an included file that declares flags of its
+own for the same command replaces the `use` along with them — the same rule
+[`group`](/spec/reference/group) follows, and for the same reason: whoever owns the flag list
+owns what is said about it.
+
 ## What a flagset is not
 
 **Not `global`.** A [global flag](/spec/reference/flag#global) is declared once and

--- a/docs/spec/reference/flagset.md
+++ b/docs/spec/reference/flagset.md
@@ -162,6 +162,9 @@ includes. A file cannot use a set declared only by a file that includes _it_ —
 make the meaning of a spec depend on who read it — so an unresolved name is an error in
 the file that wrote it.
 
+Every set is resolved while its file is read, whether or not anything uses it, so a `use`
+naming a set that does not exist is reported even inside a set nothing has reached for yet.
+
 ## What a flagset is not
 
 **Not `global`.** A [global flag](/spec/reference/flag#global) is declared once and

--- a/docs/spec/reference/flagset.md
+++ b/docs/spec/reference/flagset.md
@@ -165,6 +165,10 @@ the file that wrote it.
 Every set is resolved while its file is read, whether or not anything uses it, so a `use`
 naming a set that does not exist is reported even inside a set nothing has reached for yet.
 
+A name may still be declared only once, and an `include` does not make that a choice: two
+files declaring `common` is an error wherever the `include` stands, rather than one of them
+quietly taking the name from the other.
+
 A `use` belongs to the flags it stands among, so an included file that declares flags of its
 own for the same command replaces the `use` along with them — the same rule
 [`group`](/spec/reference/group) follows, and for the same reason: whoever owns the flag list

--- a/docs/spec/reference/flagset.md
+++ b/docs/spec/reference/flagset.md
@@ -167,7 +167,10 @@ naming a set that does not exist is reported even inside a set nothing has reach
 
 A name may still be declared only once, and an `include` does not make that a choice: two
 files declaring `common` is an error wherever the `include` stands, rather than one of them
-quietly taking the name from the other.
+quietly taking the name from the other. What is counted is declarations rather than
+arrivals, so the shared file above may be included by every file that uses its sets and by
+the spec that includes those — one declaration reaching a spec by several routes is what
+this feature is for.
 
 A `use` belongs to the flags it stands among, so an included file that declares flags of its
 own for the same command replaces the `use` along with them — the same rule

--- a/docs/spec/reference/flagset.md
+++ b/docs/spec/reference/flagset.md
@@ -1,0 +1,192 @@
+# `flagset`
+
+A named set of flag declarations that any command can pull in with `use`.
+
+```kdl
+name "demo"
+bin "demo"
+
+flagset "output" {
+  flag "-v --verbose" help="Print more"
+  flag "--json" help="Machine-readable output"
+}
+
+cmd "build" {
+  use "output"
+  flag "--release"
+}
+
+cmd "test" {
+  use "output"
+  flag "--filter <pattern>"
+}
+```
+
+`build` and `test` each end up with three ordinary flags. A `flagset` is resolved while
+the spec is read, so nothing downstream — help, completions, docs, manpages, the
+generated parsers — sees a new concept. It is the spec's answer to the same repetition
+[`flatten`](/rust/subcommands#sharing-declarations-with-flatten) removes on the typed side.
+
+## Where each node goes
+
+`flagset` is declared at the top level of a spec, never inside a command: a set one
+command can see and its sibling cannot is a scoping rule to explain for no benefit.
+
+`use` goes wherever the flags themselves would go — at the top level, inside any `cmd` at
+any depth, or inside another `flagset`. It takes one or more set names:
+
+```kdl
+name "demo"
+bin "demo"
+
+flagset "logging" {
+  flag "-v --verbose"
+}
+flagset "output" {
+  flag "--json"
+}
+
+// the root's own flags
+use "logging"
+
+cmd "build" {
+  use "logging" "output"
+}
+```
+
+Order does not matter: the whole file is read before any `use` is resolved, so a set may
+be declared below the command that uses it.
+
+## Expansion happens in place
+
+A `use` between two flags expands between them. Help order is spec order, so a set that
+always appended would reorder the command that used it:
+
+```kdl
+name "demo"
+bin "demo"
+
+flagset "output" {
+  flag "--json"
+}
+
+cmd "build" {
+  flag "--release"
+  use "output"
+  flag "--target <triple>"
+}
+```
+
+`build`'s flags are `--release`, `--json`, `--target`, in that order.
+
+## The nearer declaration wins
+
+A command that declares a flag the set also declares keeps its own, matching what happens
+when a subcommand [redeclares a global](/spec/reference/flag#global):
+
+```kdl
+name "demo"
+bin "demo"
+
+flagset "output" {
+  flag "--json" help="Machine-readable output"
+  flag "-q --quiet"
+}
+
+cmd "build" {
+  use "output"
+  flag "--json" help="JSON build report, with a schema"
+}
+```
+
+`build` gets its own `--json` and the set's `-q --quiet`. Overlap is measured per form,
+the way it is everywhere else in a spec: a command declaring `-j --job-count` takes the
+set's `-j --jobs` out of the expansion, because `-j` is already spoken for.
+
+## Sets compose
+
+A `flagset` may `use` another, so a large set can be assembled from small ones:
+
+```kdl
+name "demo"
+bin "demo"
+
+flagset "common" {
+  flag "-v --verbose"
+}
+flagset "output" {
+  use "common"
+  flag "--json"
+}
+flagset "input" {
+  use "common"
+  flag "--stdin"
+}
+
+cmd "run" {
+  use "output" "input"
+}
+```
+
+`run` gets `-v --verbose` once — a set reachable twice through composition contributes
+once, by the same per-form rule above. A cycle is an error, reported as the path that
+closes it (`flagset cycle: a -> b -> a`), and so is a `use` naming a set that does not
+exist.
+
+## Shared sets in their own file
+
+Sets travel through [`include`](/spec/reference/), which is how a CLI
+with several specs keeps its shared declarations in one place:
+
+```kdl
+// common.usage.kdl
+flagset "common" {
+  flag "-v --verbose"
+  flag "--config <FILE>"
+}
+```
+
+```kdl
+// demo.usage.kdl
+name "demo"
+bin "demo"
+include file="./common.usage.kdl"
+
+cmd "build" {
+  use "common"
+}
+```
+
+Each file resolves its own `use` nodes against the sets it declares and the ones it
+includes. A file cannot use a set declared only by a file that includes _it_ — that would
+make the meaning of a spec depend on who read it — so an unresolved name is an error in
+the file that wrote it.
+
+## What a flagset is not
+
+**Not `global`.** A [global flag](/spec/reference/flag#global) is declared once and
+inherited by every subcommand automatically. Reach for a flagset when inheritance is the
+wrong shape: a set that belongs to some commands and not others, or one whose flags should
+be answered by each command rather than by the root.
+
+**Not a [`group`](/spec/reference/group).** A group states a relationship between flags —
+at most one, exactly one — and is enforced when a command line is parsed. A flagset states
+nothing about the flags it holds; it is only a way to declare them once. A set's flags may
+of course be named by a group on the command that used them.
+
+**Not for arguments.** A flag is identified by its spelling wherever it lands, so the same
+declaration means the same thing under any command. A positional is identified by its
+position, so the same set spliced into two commands with different arguments would mean
+two different things. Declaring `arg` inside a `flagset` is an error rather than a guess.
+
+## One-way
+
+Expansion is part of reading the file. A spec that is parsed and re-emitted — by
+`usage g json`, by a generator, by anything that prints a spec back out — contains the
+flags, not the `flagset` and `use` nodes that produced them, the same way `include` does
+not survive a round trip. What a flagset saves is authoring and review, not bytes on the
+wire.
+
+Because `flagset` and `use` are spec nodes, a spec using them needs a `usage` new enough
+to know them. Say so with `min_usage_version` if your spec is read by tooling you do not
+control.

--- a/docs/spec/reference/index.md
+++ b/docs/spec/reference/index.md
@@ -30,6 +30,9 @@ example "mycli --version"
 source_code_link_template "https://github.com/me/myproj/blob/main/src/cli/{{path}}.rs"
 
 include file="./my_overrides.usage.kdl" // include another spec, will be merged and override existing values
+
+// a reusable set of flags, pulled into a command with `use` (see ./flagset.md)
+flagset "common" { flag "-v --verbose" }
 ```
 
 ## Multicall

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -613,6 +613,9 @@ impl From<&crate::SpecCommand> for SpecCommand {
             // Rendered above, or deliberately absent from the docs model.
             args: _,
             flags: _,
+            // Where a flag was declared is not something a rendered page shows: a `use` is
+            // resolved before docs are generated, and the flags it named are in `flags`.
+            uses: _,
             mounts: _,
             complete: _,
             mounted: _,

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -10,6 +10,7 @@ pub use crate::spec::cmd::SpecCommand;
 pub use crate::spec::complete::SpecComplete;
 pub use crate::spec::effect::SpecCommandEffect;
 pub use crate::spec::flag::{SpecDefaultIf, SpecFlag, SpecFlagAction, SpecRequiresIf};
+pub use crate::spec::flagset::{SpecFlagSet, SpecUse};
 pub use crate::spec::group::SpecGroup;
 pub use crate::spec::mount::SpecMount;
 pub use crate::spec::unknown_flags::UnknownFlags;

--- a/lib/src/spec/cmd.rs
+++ b/lib/src/spec/cmd.rs
@@ -777,10 +777,14 @@ impl SpecCommand {
             self.flags = flags;
         }
         // Unresolved `use` nodes travel with the flags they were written among, for the same
-        // reason groups do. In practice this is always empty: a spec resolves its own sets
-        // before it can be merged into another, so the only way to reach here with one is a
-        // command assembled by hand.
-        if !uses.is_empty() {
+        // reason groups do — including when that means going with none. A `use` is a
+        // declaration of flags, so whoever owns the flag list owns it: an included file that
+        // replaces this command's flags replaces what it says about them, and a `use` left
+        // behind would splice a set into the incoming list at a position from the old one.
+        //
+        // `other.uses` is normally empty either way: a spec resolves its own sets before it
+        // can be merged into another, and what arrives here has been through that already.
+        if flags_replaced || !uses.is_empty() {
             self.uses = uses;
         }
         if !mounts.is_empty() {

--- a/lib/src/spec/cmd.rs
+++ b/lib/src/spec/cmd.rs
@@ -6,6 +6,7 @@ use crate::sh::sh;
 use crate::spec::builder::SpecCommandBuilder;
 use crate::spec::context::ParsingContext;
 use crate::spec::effect::{SpecCommandEffect, EFFECT_VALUES};
+use crate::spec::flagset::SpecUse;
 use crate::spec::group::SpecGroup;
 use crate::spec::helpers::{string_entry, NodeHelper};
 use crate::spec::is_false;
@@ -47,6 +48,14 @@ pub struct SpecCommand {
     pub args: Vec<SpecArg>,
     /// Flags/options for this command
     pub flags: Vec<SpecFlag>,
+    /// Flagsets this command pulls in, and where in [`Self::flags`] they belong.
+    ///
+    /// `pub(crate)` because it is always empty by the time anyone else can see it: a `use` is
+    /// resolved while the spec is read, so a consumer holding a `SpecCommand` holds the flags
+    /// the sets named. Visible to the rest of the crate only so that other modules can
+    /// destructure `SpecCommand` exhaustively.
+    #[serde(skip)]
+    pub(crate) uses: Vec<SpecUse>,
     /// Mounted external specs
     pub mounts: Vec<SpecMount>,
     /// Sets of flags that relate to one another as a set.
@@ -217,6 +226,7 @@ impl Default for SpecCommand {
             subcommands: IndexMap::new(),
             args: vec![],
             flags: vec![],
+            uses: vec![],
             mounts: vec![],
             groups: vec![],
             deprecated: None,
@@ -417,6 +427,10 @@ impl SpecCommand {
         for child in node.children() {
             match child.name() {
                 "flag" => cmd.flags.push(SpecFlag::parse(ctx, &child)?),
+                "use" => {
+                    let at = cmd.flags.len();
+                    cmd.uses.push(SpecUse::parse(ctx, &child, at)?);
+                }
                 "arg" => {
                     let arg = SpecArg::parse(ctx, &child)?;
                     // As on a flag: splitting a word that has room for one value would
@@ -683,6 +697,7 @@ impl SpecCommand {
             after_help_md,
             args,
             flags,
+            uses,
             mounts,
             groups,
             aliases,
@@ -760,6 +775,13 @@ impl SpecCommand {
         let flags_replaced = !flags.is_empty();
         if flags_replaced {
             self.flags = flags;
+        }
+        // Unresolved `use` nodes travel with the flags they were written among, for the same
+        // reason groups do. In practice this is always empty: a spec resolves its own sets
+        // before it can be merged into another, so the only way to reach here with one is a
+        // command assembled by hand.
+        if !uses.is_empty() {
+            self.uses = uses;
         }
         if !mounts.is_empty() {
             self.mounts = mounts;
@@ -980,6 +1002,9 @@ impl From<&SpecCommand> for KdlNode {
             subcommands,
             complete,
             examples,
+            // Resolved while the spec was read: whatever a `use` named is among `flags`
+            // by now, so emitting the request too would declare those flags twice.
+            uses: _,
             // Derived from the spec rather than written by it.
             full_cmd: _,
             usage: _,

--- a/lib/src/spec/flagset.rs
+++ b/lib/src/spec/flagset.rs
@@ -544,6 +544,58 @@ cmd "remote" {
     }
 
     #[test]
+    fn a_use_goes_with_the_flags_an_include_replaced() {
+        // An included file that declares root flags owns the root's flags — that is what
+        // `include` has always meant, and why the merge drops groups with them. A `use` is a
+        // declaration of flags, so it goes the same way: keeping it would splice the set into
+        // the incoming list at a position from a list that is gone.
+        let dir = tempfile::tempdir().unwrap();
+        let included = dir.path().join("overrides.usage.kdl");
+        let root = dir.path().join("ex.usage.kdl");
+        std::fs::write(&included, "flag \"--from-include\"\n").unwrap();
+        std::fs::write(
+            &root,
+            "bin \"ex\"\nflagset \"common\" {\n    flag \"-v --verbose\"\n}\nflag \"--own\"\n             use \"common\"\ninclude file=\"./overrides.usage.kdl\"\n",
+        )
+        .unwrap();
+
+        let spec = Spec::parse_file(&root).unwrap();
+
+        assert_snapshot!(spec, @r#"
+        name ex
+        bin ex
+        flag --from-include
+        "#);
+    }
+
+    #[test]
+    fn a_use_survives_an_include_that_declares_no_flags() {
+        // The ordinary shape: a file of shared declarations, and a spec that uses them. The
+        // rule above must not reach this one.
+        let dir = tempfile::tempdir().unwrap();
+        let included = dir.path().join("common.usage.kdl");
+        let root = dir.path().join("ex.usage.kdl");
+        std::fs::write(
+            &included,
+            "flagset \"common\" {\n    flag \"-v --verbose\"\n}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            &root,
+            "bin \"ex\"\nuse \"common\"\ninclude file=\"./common.usage.kdl\"\n",
+        )
+        .unwrap();
+
+        let spec = Spec::parse_file(&root).unwrap();
+
+        assert_snapshot!(spec, @r#"
+        name ex
+        bin ex
+        flag "-v --verbose"
+        "#);
+    }
+
+    #[test]
     fn a_set_nothing_uses_is_still_resolved() {
         // Every set is flattened whether or not a command asks for one, so a mistake inside
         // an unused set is reported rather than waiting for the day something uses it.

--- a/lib/src/spec/flagset.rs
+++ b/lib/src/spec/flagset.rs
@@ -735,6 +735,68 @@ flagset "output" {
         assert!(msg.contains("a flagset may be declared only once"), "{msg}");
     }
 
+    /// The message from a spec read off disk, so an include can take part.
+    fn err_file(root: &std::path::Path) -> String {
+        match Spec::parse_file(root).unwrap_err() {
+            crate::error::UsageErr::InvalidInput(msg, _, _) => msg,
+            err => panic!("unexpected error: {err:?}"),
+        }
+    }
+
+    #[test]
+    fn a_name_an_include_also_declares_is_refused_whichever_side_wrote_it_first() {
+        // Declared twice is declared twice, and an `include` does not make it a choice.
+        // Extending the map would have let the incoming set take the name — but only when
+        // the `include` stood below the declaration, since a `flagset` written after an
+        // `include` already hit the once-only check. So which set answered a `use` came
+        // down to where in the file the `include` was written.
+        let dir = tempfile::tempdir().unwrap();
+        let common = dir.path().join("common.usage.kdl");
+        std::fs::write(&common, "flagset \"output\" {\n    flag \"--yaml\"\n}\n").unwrap();
+        let own = "flagset \"output\" {\n    flag \"--json\"\n}\n";
+        let include = "include file=\"./common.usage.kdl\"\n";
+
+        let after = dir.path().join("after.usage.kdl");
+        std::fs::write(&after, format!("bin \"ex\"\n{own}{include}")).unwrap();
+        let msg = err_file(&after);
+        assert!(
+            msg.contains("a flagset may be declared only once")
+                && msg.contains("common.usage.kdl")
+                && msg.contains("\"output\""),
+            "{msg}"
+        );
+
+        // The other order was already refused, and still says so.
+        let before = dir.path().join("before.usage.kdl");
+        std::fs::write(&before, format!("bin \"ex\"\n{include}{own}")).unwrap();
+        let msg = err_file(&before);
+        assert!(msg.contains("a flagset may be declared only once"), "{msg}");
+    }
+
+    #[test]
+    fn two_includes_may_not_declare_the_same_name() {
+        // Neither file is the nearer declaration, so there is nothing to prefer: a CLI
+        // whose shared files have grown a collision hears about it here rather than at
+        // whichever command happened to use the name.
+        let dir = tempfile::tempdir().unwrap();
+        for (file, flag) in [("a.usage.kdl", "--json"), ("b.usage.kdl", "--yaml")] {
+            let body = format!("flagset \"output\" {{\n    flag \"{flag}\"\n}}\n");
+            std::fs::write(dir.path().join(file), body).unwrap();
+        }
+        let root = dir.path().join("ex.usage.kdl");
+        std::fs::write(
+            &root,
+            "bin \"ex\"\ninclude file=\"./a.usage.kdl\"\ninclude file=\"./b.usage.kdl\"\n",
+        )
+        .unwrap();
+
+        let msg = err_file(&root);
+        assert!(
+            msg.contains("a flagset may be declared only once") && msg.contains("b.usage.kdl"),
+            "{msg}"
+        );
+    }
+
     #[test]
     fn a_set_holds_flags_and_says_so_about_arguments() {
         let msg = err("flagset \"output\" {\n    arg \"<file>\"\n}\n");

--- a/lib/src/spec/flagset.rs
+++ b/lib/src/spec/flagset.rs
@@ -45,15 +45,22 @@ use crate::{SpecCommand, SpecFlag};
 ///
 /// Declared at the root of a spec, never inside a command: a set that one command
 /// can see and its sibling cannot is a scoping rule to explain for no benefit.
-#[derive(Debug, Default, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 #[non_exhaustive]
 pub struct SpecFlagSet {
     pub name: String,
     /// Flags declared directly in the set.
     pub flags: Vec<SpecFlag>,
     /// Sets this one composes, so a big set can be assembled from small ones.
+    ///
+    /// Emptied while the file is read, like a command's: what it named becomes part of
+    /// [`Self::flags`], so a file that includes this one inherits a set with nothing left to
+    /// resolve.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub uses: Vec<SpecUse>,
+    /// The node, for an error raised while flattening the set rather than at one `use`.
+    #[serde(skip)]
+    pub(crate) span: SourceSpan,
 }
 
 /// One `use` node: the flagsets whose declarations belong where it stands.
@@ -73,6 +80,19 @@ pub struct SpecUse {
     pub(crate) span: SourceSpan,
 }
 
+impl Default for SpecFlagSet {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            flags: vec![],
+            uses: vec![],
+            // Nowhere to point: a set that was not read from a file has no node, and the
+            // errors this span serves can only come from one that was.
+            span: (0, 0).into(),
+        }
+    }
+}
+
 impl SpecFlagSet {
     pub(crate) fn parse(ctx: &ParsingContext, node: &NodeHelper) -> Result<Self, UsageErr> {
         node.ensure_arg_len(1..=1)?;
@@ -80,6 +100,7 @@ impl SpecFlagSet {
             name: node.arg(0)?.ensure_string()?,
             flags: vec![],
             uses: vec![],
+            span: node.span(),
         };
         if let Some((k, v)) = node.props().first() {
             bail_parse!(ctx, v.entry.span(), "unsupported flagset prop {k}");
@@ -136,22 +157,46 @@ impl SpecUse {
     }
 }
 
-/// Replace every `use` in the tree with the flags it names.
+/// Replace every `use` in the file with the flags it names.
 ///
-/// Runs once, after the whole file is read, so a `use` may name a set declared
-/// below it or brought in by an `include`. What it cannot see is a set declared
-/// in a file that includes *this* one: each file resolves its own `use` nodes,
-/// and an unresolved one is an error there rather than a value carried up to be
-/// resolved by whoever reads the file next.
+/// Runs once, after the whole file is read, so a `use` may name a set declared below it or
+/// brought in by an `include`. What it cannot see is a set declared in a file that includes
+/// *this* one: each file resolves its own `use` nodes, and an unresolved one is an error
+/// there rather than a value carried up to be resolved by whoever reads the file next.
+///
+/// Which is why the sets are flattened first, before any command is looked at, even though
+/// nothing may use them. Resolving a set only when a command asked for one left an included
+/// file's `use` to be answered by the file that included it — with the wrong flagsets in
+/// scope, and an error pointing into the wrong source.
 pub(crate) fn expand(
     ctx: &ParsingContext,
     cmd: &mut SpecCommand,
-    flagsets: &IndexMap<String, SpecFlagSet>,
+    flagsets: &mut IndexMap<String, SpecFlagSet>,
 ) -> Result<(), UsageErr> {
+    let mut cache = {
+        let mut resolver = Resolver {
+            ctx,
+            flagsets,
+            cache: HashMap::new(),
+            stack: vec![],
+        };
+        for (name, set) in resolver.flagsets {
+            resolver.resolve(name, set.span)?;
+        }
+        resolver.cache
+    };
+    // A set that used another is now the flags of both. Written back so that what travels
+    // through an `include` is a set and not a question.
+    for (name, set) in flagsets.iter_mut() {
+        if let Some(flags) = cache.get(name) {
+            set.flags = flags.clone();
+        }
+        set.uses.clear();
+    }
     let mut resolver = Resolver {
         ctx,
         flagsets,
-        cache: HashMap::new(),
+        cache: core::mem::take(&mut cache),
         stack: vec![],
     };
     expand_cmd(cmd, &mut resolver)
@@ -462,6 +507,74 @@ cmd "remote" {
         bin ex
         cmd build {
             flag "-v --verbose"
+        }
+        "#);
+    }
+
+    #[test]
+    fn a_set_is_resolved_by_the_file_that_wrote_it() {
+        // The composition an included file writes is answered by the included file. Letting
+        // the includer answer it would make what a file means depend on who read it, and
+        // would report the mistake against the wrong source.
+        let dir = tempfile::tempdir().unwrap();
+        let common = dir.path().join("common.usage.kdl");
+        let root = dir.path().join("ex.usage.kdl");
+        std::fs::write(&common, "flagset \"child\" {\n    use \"parent-only\"\n}\n").unwrap();
+        std::fs::write(
+            &root,
+            "bin \"ex\"\ninclude file=\"./common.usage.kdl\"\nflagset \"parent-only\" {\n                 flag \"--from-parent\"\n}\ncmd \"build\" {\n    use \"child\"\n}\n",
+        )
+        .unwrap();
+
+        let err = Spec::parse_file(&root).unwrap_err();
+        let crate::error::UsageErr::InvalidInput(msg, _, source) = err else {
+            panic!("unexpected error: {err:?}");
+        };
+        assert!(
+            msg.contains("unknown flagset \"parent-only\" (declared: child)"),
+            "{msg}"
+        );
+        // Named against the file that wrote the `use`, which is the half a lazy resolve got
+        // wrong even where it happened to refuse.
+        assert!(
+            source.name().ends_with("common.usage.kdl"),
+            "{:?}",
+            source.name()
+        );
+    }
+
+    #[test]
+    fn a_set_nothing_uses_is_still_resolved() {
+        // Every set is flattened whether or not a command asks for one, so a mistake inside
+        // an unused set is reported rather than waiting for the day something uses it.
+        let msg = err("flagset \"a\" {\n    use \"missing\"\n}\n");
+        assert!(msg.contains("unknown flagset \"missing\""), "{msg}");
+    }
+
+    #[test]
+    fn an_included_set_may_compose_one_from_its_own_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let common = dir.path().join("common.usage.kdl");
+        let root = dir.path().join("ex.usage.kdl");
+        std::fs::write(
+            &common,
+            "flagset \"logging\" {\n    flag \"-v --verbose\"\n}\nflagset \"common\" {\n                 use \"logging\"\n    flag \"--config\"\n}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            &root,
+            "bin \"ex\"\ninclude file=\"./common.usage.kdl\"\ncmd \"build\" {\n    use \"common\"\n}\n",
+        )
+        .unwrap();
+
+        let spec = Spec::parse_file(&root).unwrap();
+
+        assert_snapshot!(spec, @r#"
+        name ex
+        bin ex
+        cmd build {
+            flag "-v --verbose"
+            flag --config
         }
         "#);
     }

--- a/lib/src/spec/flagset.rs
+++ b/lib/src/spec/flagset.rs
@@ -30,6 +30,7 @@
 //! them, the same way `include` does not survive a round trip.
 
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 
 use indexmap::IndexMap;
 use miette::SourceSpan;
@@ -61,6 +62,13 @@ pub struct SpecFlagSet {
     /// The node, for an error raised while flattening the set rather than at one `use`.
     #[serde(skip)]
     pub(crate) span: SourceSpan,
+    /// The file this set was declared in, resolved so two routes to one file agree.
+    ///
+    /// A name may be declared once, and what makes that one rule rather than two is that a
+    /// *declaration* is what is counted: a shared file reaching a spec through two includes
+    /// is one declaration arriving twice, not two of them.
+    #[serde(skip)]
+    pub(crate) declared_in: PathBuf,
 }
 
 /// One `use` node: the flagsets whose declarations belong where it stands.
@@ -89,8 +97,20 @@ impl Default for SpecFlagSet {
             // Nowhere to point: a set that was not read from a file has no node, and the
             // errors this span serves can only come from one that was.
             span: (0, 0).into(),
+            declared_in: PathBuf::new(),
         }
     }
+}
+
+/// Where a file's declarations come from, as a name two routes to that file share.
+///
+/// A diamond of includes reaches one shared file as `a/../common.usage.kdl` from one side and
+/// `b/../common.usage.kdl` from the other. Those are the same declaration, and comparing the
+/// paths as written would call them two.
+pub(crate) fn declaring_file(file: &Path) -> PathBuf {
+    // A spec parsed from a string has no file, and canonicalizing nothing fails: the empty
+    // path is then the honest answer, and it cannot collide with a real one.
+    std::fs::canonicalize(file).unwrap_or_else(|_| file.to_path_buf())
 }
 
 impl SpecFlagSet {
@@ -101,6 +121,7 @@ impl SpecFlagSet {
             flags: vec![],
             uses: vec![],
             span: node.span(),
+            declared_in: declaring_file(&ctx.file),
         };
         if let Some((k, v)) = node.props().first() {
             bail_parse!(ctx, v.entry.span(), "unsupported flagset prop {k}");
@@ -771,6 +792,53 @@ flagset "output" {
         std::fs::write(&before, format!("bin \"ex\"\n{include}{own}")).unwrap();
         let msg = err_file(&before);
         assert!(msg.contains("a flagset may be declared only once"), "{msg}");
+    }
+
+    #[test]
+    fn a_shared_file_may_reach_a_spec_by_two_routes() {
+        // The shape the feature asks for. Each file resolves its own `use` nodes, so every
+        // file whose commands name the shared sets includes the file that declares them —
+        // and a spec that includes two such files sees the shared set arrive twice. That is
+        // one declaration by two routes, not two declarations, so the once-only rule has
+        // nothing to say about it.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("cmds")).unwrap();
+        std::fs::write(
+            dir.path().join("common.usage.kdl"),
+            "flagset \"common\" {\n    flag \"-v --verbose\"\n}\n",
+        )
+        .unwrap();
+        for cmd in ["build", "test"] {
+            // Reached as `cmds/../common.usage.kdl` from here and as `./common.usage.kdl`
+            // from the root: the same file, spelled two ways.
+            let body = format!(
+                "include file=\"../common.usage.kdl\"\ncmd \"{cmd}\" {{\n    use \"common\"\n}}\n"
+            );
+            std::fs::write(
+                dir.path().join("cmds").join(format!("{cmd}.usage.kdl")),
+                body,
+            )
+            .unwrap();
+        }
+        let root = dir.path().join("ex.usage.kdl");
+        std::fs::write(
+            &root,
+            "bin \"ex\"\ninclude file=\"./common.usage.kdl\"\ninclude file=\"./cmds/build.usage.kdl\"\ninclude file=\"./cmds/test.usage.kdl\"\n",
+        )
+        .unwrap();
+
+        let spec = Spec::parse_file(&root).unwrap();
+
+        assert_snapshot!(spec, @r#"
+        name ex
+        bin ex
+        cmd build {
+            flag "-v --verbose"
+        }
+        cmd test {
+            flag "-v --verbose"
+        }
+        "#);
     }
 
     #[test]

--- a/lib/src/spec/flagset.rs
+++ b/lib/src/spec/flagset.rs
@@ -1,0 +1,600 @@
+//! Named sets of flag declarations, and the `use` node that pulls one in.
+//!
+//! mise's checked-in spec is 5,592 lines for 711 flags, and most of that count is
+//! the same handful of declarations written again under the next command. The
+//! derive has an answer for this — `flatten` — and a hand-written spec had none.
+//!
+//! A flagset is authoring sugar, resolved while the file is read:
+//!
+//! ```kdl
+//! flagset "output" {
+//!     flag "-v --verbose" help="Print more"
+//!     flag "--json" help="JSON output"
+//! }
+//!
+//! cmd "build" {
+//!     use "output"
+//!     flag "--release"
+//! }
+//! ```
+//!
+//! By the time anything downstream sees the spec, `build` holds three ordinary
+//! flags in that order. Nothing else in the model, in help, in completions or in
+//! the generated parsers learns a new concept, which is the point: the same rule
+//! the derive follows, that a spec is the semantic model, means reuse has to
+//! disappear into what it stands for rather than becoming vocabulary every
+//! consumer must implement.
+//!
+//! The cost of that choice is that it is one-way. A spec parsed and re-emitted
+//! contains the expanded flags, not the `flagset` and `use` nodes that produced
+//! them, the same way `include` does not survive a round trip.
+
+use std::collections::HashMap;
+
+use indexmap::IndexMap;
+use miette::SourceSpan;
+use serde::Serialize;
+
+use crate::error::UsageErr;
+use crate::spec::context::ParsingContext;
+use crate::spec::helpers::NodeHelper;
+use crate::spec::spec_flag_forms_overlap;
+use crate::{SpecCommand, SpecFlag};
+
+/// A named, reusable set of flag declarations.
+///
+/// Declared at the root of a spec, never inside a command: a set that one command
+/// can see and its sibling cannot is a scoping rule to explain for no benefit.
+#[derive(Debug, Default, Clone, Serialize)]
+#[non_exhaustive]
+pub struct SpecFlagSet {
+    pub name: String,
+    /// Flags declared directly in the set.
+    pub flags: Vec<SpecFlag>,
+    /// Sets this one composes, so a big set can be assembled from small ones.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub uses: Vec<SpecUse>,
+}
+
+/// One `use` node: the flagsets whose declarations belong where it stands.
+#[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
+pub struct SpecUse {
+    /// The sets named, in the order they were written.
+    pub names: Vec<String>,
+    /// Where the expansion belongs in the owner's flag list.
+    ///
+    /// Help order is spec order, so a `use` between two flags has to expand
+    /// between them rather than at the end of the list.
+    pub at: usize,
+    /// Kept for the error a bad name produces, which is reported after the whole
+    /// file is read rather than at the node.
+    #[serde(skip)]
+    pub(crate) span: SourceSpan,
+}
+
+impl SpecFlagSet {
+    pub(crate) fn parse(ctx: &ParsingContext, node: &NodeHelper) -> Result<Self, UsageErr> {
+        node.ensure_arg_len(1..=1)?;
+        let mut set = Self {
+            name: node.arg(0)?.ensure_string()?,
+            flags: vec![],
+            uses: vec![],
+        };
+        if let Some((k, v)) = node.props().first() {
+            bail_parse!(ctx, v.entry.span(), "unsupported flagset prop {k}");
+        }
+        for child in node.children() {
+            match child.name() {
+                "flag" => set.flags.push(SpecFlag::parse(ctx, &child)?),
+                "use" => set.uses.push(SpecUse::parse(ctx, &child, set.flags.len())?),
+                // Positionals are deliberately not here. A set of flags is reusable
+                // because a flag is identified by its spelling wherever it lands; a
+                // positional is identified by its position, so the same set spliced
+                // into two commands with different arguments means two different
+                // things. `flatten` on the derive side has the field order of one
+                // struct to go by and this has nothing.
+                "arg" => bail_parse!(
+                    ctx,
+                    child.node.name().span(),
+                    "a flagset holds flags, not arguments: declare the argument on \
+                     each command that takes it"
+                ),
+                k => bail_parse!(ctx, child.node.name().span(), "unsupported flagset key {k}"),
+            }
+        }
+        Ok(set)
+    }
+}
+
+impl SpecUse {
+    pub(crate) fn parse(
+        ctx: &ParsingContext,
+        node: &NodeHelper,
+        at: usize,
+    ) -> Result<Self, UsageErr> {
+        node.ensure_arg_len(1..)?;
+        if let Some((k, v)) = node.props().first() {
+            bail_parse!(ctx, v.entry.span(), "unsupported use prop {k}");
+        }
+        if !node.children().is_empty() {
+            bail_parse!(
+                ctx,
+                node.span(),
+                "`use` names flagsets and holds nothing: declare the flags in the \
+                 flagset itself"
+            );
+        }
+        Ok(Self {
+            names: node
+                .args()
+                .map(|a| a.ensure_string())
+                .collect::<Result<Vec<_>, _>>()?,
+            at,
+            span: node.span(),
+        })
+    }
+}
+
+/// Replace every `use` in the tree with the flags it names.
+///
+/// Runs once, after the whole file is read, so a `use` may name a set declared
+/// below it or brought in by an `include`. What it cannot see is a set declared
+/// in a file that includes *this* one: each file resolves its own `use` nodes,
+/// and an unresolved one is an error there rather than a value carried up to be
+/// resolved by whoever reads the file next.
+pub(crate) fn expand(
+    ctx: &ParsingContext,
+    cmd: &mut SpecCommand,
+    flagsets: &IndexMap<String, SpecFlagSet>,
+) -> Result<(), UsageErr> {
+    let mut resolver = Resolver {
+        ctx,
+        flagsets,
+        cache: HashMap::new(),
+        stack: vec![],
+    };
+    expand_cmd(cmd, &mut resolver)
+}
+
+fn expand_cmd(cmd: &mut SpecCommand, resolver: &mut Resolver) -> Result<(), UsageErr> {
+    // Taken rather than read: the expansion _is_ the flags now, and leaving the
+    // request behind would let a second pass double it.
+    let uses = std::mem::take(&mut cmd.uses);
+    splice(&mut cmd.flags, &uses, resolver)?;
+    for sub in cmd.subcommands.values_mut() {
+        expand_cmd(sub, resolver)?;
+    }
+    Ok(())
+}
+
+/// Insert what each `use` names, at the position where it stood.
+fn splice(
+    flags: &mut Vec<SpecFlag>,
+    uses: &[SpecUse],
+    resolver: &mut Resolver,
+) -> Result<(), UsageErr> {
+    let mut inserted = 0;
+    for u in uses {
+        let mut at = (u.at + inserted).min(flags.len());
+        for name in &u.names {
+            for flag in resolver.resolve(name, u.span)? {
+                // The nearer declaration owns the spelling, as it does when a
+                // subcommand redeclares a global: a command that says `use "output"`
+                // and then declares its own `--json` gets its own, and a set
+                // reachable twice through composition contributes once.
+                if flags.iter().any(|f| spec_flag_forms_overlap(f, &flag)) {
+                    continue;
+                }
+                flags.insert(at, flag);
+                at += 1;
+                inserted += 1;
+            }
+        }
+    }
+    Ok(())
+}
+
+struct Resolver<'a> {
+    ctx: &'a ParsingContext,
+    flagsets: &'a IndexMap<String, SpecFlagSet>,
+    /// A set composed by several commands is resolved once.
+    cache: HashMap<String, Vec<SpecFlag>>,
+    /// The chain currently being resolved, so a cycle is reported as the path
+    /// that closes it rather than as a stack overflow.
+    stack: Vec<String>,
+}
+
+impl Resolver<'_> {
+    fn resolve(&mut self, name: &str, span: SourceSpan) -> Result<Vec<SpecFlag>, UsageErr> {
+        if let Some(flags) = self.cache.get(name) {
+            return Ok(flags.clone());
+        }
+        if self.stack.iter().any(|seen| seen == name) {
+            let ctx = self.ctx;
+            let path = self
+                .stack
+                .iter()
+                .map(String::as_str)
+                .chain([name])
+                .collect::<Vec<_>>()
+                .join(" -> ");
+            bail_parse!(ctx, span, "flagset cycle: {path}");
+        }
+        let flagsets = self.flagsets;
+        let Some(set) = flagsets.get(name) else {
+            let ctx = self.ctx;
+            let known = flagsets.keys().cloned().collect::<Vec<_>>().join(", ");
+            let hint = match known.is_empty() {
+                true => "no flagsets are declared".to_string(),
+                false => format!("declared: {known}"),
+            };
+            bail_parse!(ctx, span, "unknown flagset \"{name}\" ({hint})");
+        };
+        self.stack.push(name.to_string());
+        let mut flags = set.flags.clone();
+        let result = splice(&mut flags, &set.uses, self);
+        self.stack.pop();
+        result?;
+        self.cache.insert(name.to_string(), flags.clone());
+        Ok(flags)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Spec;
+    use insta::assert_snapshot;
+
+    fn parse(input: &str) -> Spec {
+        Spec::parse(&Default::default(), input).unwrap()
+    }
+
+    /// The message a bad spec produced. `UsageErr::InvalidInput` renders as a miette
+    /// diagnostic, so `to_string` is the headline rather than what went wrong.
+    fn err(input: &str) -> String {
+        match Spec::parse(&Default::default(), input).unwrap_err() {
+            crate::error::UsageErr::InvalidInput(msg, _, _) => msg,
+            err => panic!("unexpected error: {err:?}"),
+        }
+    }
+
+    #[test]
+    fn a_set_expands_where_the_use_stands() {
+        // The `use` is between two flags, so the set's flags land between them: help order
+        // is spec order, and a set that always appended would reorder the command.
+        let spec = parse(
+            r#"
+bin "ex"
+flagset "output" {
+    flag "-v --verbose" help="Print more"
+    flag "--json" help="JSON output"
+}
+cmd "build" {
+    flag "--release"
+    use "output"
+    flag "--target" {
+        arg "<triple>"
+    }
+}
+        "#,
+        );
+        assert_snapshot!(spec, @r#"
+        name ex
+        bin ex
+        cmd build {
+            flag --release
+            flag "-v --verbose" help="Print more"
+            flag --json help="JSON output"
+            flag --target {
+                arg <triple>
+            }
+        }
+        "#);
+    }
+
+    #[test]
+    fn one_use_names_several_sets_and_the_root_can_use_them_too() {
+        let spec = parse(
+            r#"
+bin "ex"
+use "logging" "output"
+flagset "logging" {
+    flag "-v --verbose" global=#true
+}
+flagset "output" {
+    flag "--json"
+}
+        "#,
+        );
+        // Declared below the `use` that names them: a spec is read whole before it is
+        // resolved, so declaration order is the author's business.
+        assert_snapshot!(spec, @r#"
+        name ex
+        bin ex
+        flag "-v --verbose" global=#true
+        flag --json
+        "#);
+    }
+
+    #[test]
+    fn a_set_composes_other_sets_and_a_diamond_contributes_once() {
+        let spec = parse(
+            r#"
+bin "ex"
+flagset "common" {
+    flag "-v --verbose"
+}
+flagset "output" {
+    use "common"
+    flag "--json"
+}
+flagset "input" {
+    use "common"
+    flag "--stdin"
+}
+cmd "run" {
+    use "output" "input"
+}
+        "#,
+        );
+        assert_snapshot!(spec, @r#"
+        name ex
+        bin ex
+        cmd run {
+            flag "-v --verbose"
+            flag --json
+            flag --stdin
+        }
+        "#);
+    }
+
+    #[test]
+    fn the_commands_own_declaration_wins() {
+        // The same rule a redeclared global follows: the nearer declaration owns the
+        // spelling. A command that wants one flag of a set said differently keeps the set.
+        let spec = parse(
+            r#"
+bin "ex"
+flagset "output" {
+    flag "--json" help="JSON output"
+    flag "-q --quiet"
+}
+cmd "build" {
+    use "output"
+    flag "--json" help="build's own JSON, with a schema"
+}
+        "#,
+        );
+        assert_snapshot!(spec, @r#"
+        name ex
+        bin ex
+        cmd build {
+            flag "-q --quiet"
+            flag --json help="build's own JSON, with a schema"
+        }
+        "#);
+    }
+
+    #[test]
+    fn a_short_form_collision_counts_as_the_same_flag() {
+        // Overlap is per-form, as it is everywhere else: `-j` is taken even though the
+        // long names differ.
+        let spec = parse(
+            r#"
+bin "ex"
+flagset "common" {
+    flag "-j --jobs" {
+        arg "<n>"
+    }
+}
+cmd "build" {
+    use "common"
+    flag "-j --job-count" {
+        arg "<n>"
+    }
+}
+        "#,
+        );
+        assert_snapshot!(spec, @r#"
+        name ex
+        bin ex
+        cmd build {
+            flag "-j --job-count" {
+                arg <n>
+            }
+        }
+        "#);
+    }
+
+    #[test]
+    fn a_set_reaches_every_depth_of_the_tree() {
+        let spec = parse(
+            r#"
+bin "ex"
+flagset "common" {
+    flag "-v --verbose"
+}
+cmd "remote" {
+    use "common"
+    cmd "add" {
+        use "common"
+        arg "<name>"
+    }
+}
+        "#,
+        );
+        assert_snapshot!(spec, @r#"
+        name ex
+        bin ex
+        cmd remote {
+            flag "-v --verbose"
+            cmd add {
+                flag "-v --verbose"
+                arg <name>
+            }
+        }
+        "#);
+    }
+
+    #[test]
+    fn an_included_file_can_hold_the_shared_sets() {
+        // The reason `include` exists is a file of declarations shared by a CLI's specs,
+        // and flagsets are exactly that kind of declaration.
+        let dir = tempfile::tempdir().unwrap();
+        let common = dir.path().join("common.usage.kdl");
+        let root = dir.path().join("ex.usage.kdl");
+        std::fs::write(
+            &common,
+            "flagset \"common\" {\n    flag \"-v --verbose\"\n}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            &root,
+            "bin \"ex\"\ninclude file=\"./common.usage.kdl\"\ncmd \"build\" {\n    use \"common\"\n}\n",
+        )
+        .unwrap();
+
+        let spec = Spec::parse_file(&root).unwrap();
+
+        assert_snapshot!(spec, @r#"
+        name ex
+        bin ex
+        cmd build {
+            flag "-v --verbose"
+        }
+        "#);
+    }
+
+    #[test]
+    fn the_flags_a_set_brought_parse_like_any_other() {
+        // The expansion is the whole feature: nothing downstream of the parse knows a
+        // flagset was involved.
+        let spec = parse(
+            r#"
+bin "ex"
+flagset "common" {
+    flag "-j --jobs" {
+        arg "<n>"
+    }
+}
+cmd "build" {
+    use "common"
+}
+        "#,
+        );
+        let words = ["ex", "build", "--jobs", "4"].map(String::from);
+        let parsed = crate::parse(&spec, &words).unwrap();
+        assert_eq!(parsed.as_env().get("usage_jobs").unwrap(), "4");
+    }
+
+    #[test]
+    fn a_global_from_a_set_is_inherited_like_any_other() {
+        // Expansion happens before anything reads the spec, so a set's flags take part in
+        // every rule an inline declaration would: `global` here, and equally `conflicts`,
+        // `group` membership, or a completer keyed on the flag's value name.
+        let spec = parse(
+            r#"
+bin "ex"
+flagset "logging" {
+    flag "-v --verbose" global=#true
+}
+use "logging"
+cmd "build"
+        "#,
+        );
+        let words = ["ex", "build", "--verbose"].map(String::from);
+        let parsed = crate::parse(&spec, &words).unwrap();
+        assert_eq!(parsed.as_env().get("usage_verbose").unwrap(), "true");
+    }
+
+    #[test]
+    fn an_unknown_set_says_what_is_declared() {
+        let msg = err(r#"
+bin "ex"
+flagset "output" {
+    flag "--json"
+}
+cmd "build" {
+    use "outupt"
+}
+        "#);
+        assert!(
+            msg.contains("unknown flagset \"outupt\" (declared: output)"),
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn a_use_with_no_sets_at_all_says_so() {
+        let msg = err("bin \"ex\"\ncmd \"build\" {\n    use \"output\"\n}\n");
+        assert!(
+            msg.contains("unknown flagset \"output\" (no flagsets are declared)"),
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn a_cycle_is_reported_as_the_path_that_closes_it() {
+        let msg = err(r#"
+bin "ex"
+flagset "a" {
+    use "b"
+}
+flagset "b" {
+    use "a"
+}
+cmd "build" {
+    use "a"
+}
+        "#);
+        assert!(msg.contains("flagset cycle: a -> b -> a"), "{msg}");
+    }
+
+    #[test]
+    fn a_set_that_uses_itself_is_the_same_error() {
+        let msg = err("bin \"ex\"\nflagset \"a\" {\n    use \"a\"\n}\nuse \"a\"\n");
+        assert!(msg.contains("flagset cycle: a -> a"), "{msg}");
+    }
+
+    #[test]
+    fn a_name_may_be_declared_once() {
+        let msg = err(r#"
+flagset "output" {
+    flag "--json"
+}
+flagset "output" {
+    flag "--yaml"
+}
+        "#);
+        assert!(msg.contains("a flagset may be declared only once"), "{msg}");
+    }
+
+    #[test]
+    fn a_set_holds_flags_and_says_so_about_arguments() {
+        let msg = err("flagset \"output\" {\n    arg \"<file>\"\n}\n");
+        assert!(
+            msg.contains("a flagset holds flags, not arguments"),
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn a_set_rejects_what_it_has_no_meaning_for() {
+        let msg = err("flagset \"output\" {\n    cmd \"nested\"\n}\n");
+        assert!(msg.contains("unsupported flagset key cmd"), "{msg}");
+        let msg = err("flagset \"output\" help=\"a set\" {\n    flag \"--json\"\n}\n");
+        assert!(msg.contains("unsupported flagset prop help"), "{msg}");
+    }
+
+    #[test]
+    fn a_use_names_sets_and_nothing_else() {
+        let msg = err("use \"output\" {\n    flag \"--json\"\n}\n");
+        assert!(
+            msg.contains("`use` names flagsets and holds nothing"),
+            "{msg}"
+        );
+        let msg = err("flagset \"o\" {\n    flag \"--json\"\n}\nuse from=\"o\"\n");
+        assert!(msg.contains("expected 1.. arguments, got 0"), "{msg}");
+    }
+}

--- a/lib/src/spec/mod.rs
+++ b/lib/src/spec/mod.rs
@@ -9,6 +9,7 @@ mod context;
 pub mod data_types;
 pub mod effect;
 pub mod flag;
+pub mod flagset;
 pub mod group;
 pub mod helpers;
 pub mod mount;
@@ -30,6 +31,7 @@ use crate::error::UsageErr;
 use crate::spec::cmd::{SpecCommand, SpecExample};
 use crate::spec::config::SpecConfig;
 use crate::spec::context::ParsingContext;
+use crate::spec::flagset::{SpecFlagSet, SpecUse};
 use crate::spec::helpers::{string_entry, NodeHelper};
 use crate::{SpecArg, SpecComplete, SpecFlag};
 use view::SpecView;
@@ -50,6 +52,13 @@ pub struct Spec {
     /// Named executable surfaces promoted from commands in this canonical spec.
     #[serde(skip_serializing_if = "IndexMap::is_empty")]
     pub views: IndexMap<String, SpecView>,
+    /// Reusable flag declarations, by name.
+    ///
+    /// Not serialized, and not re-emitted: a `use` is resolved while the file is read, so by
+    /// the time anything reads this spec the flags are on the commands that use them and these
+    /// entries only record where they came from.
+    #[serde(skip)]
+    pub flagsets: IndexMap<String, SpecFlagSet>,
     /// Every file this spec was read from: its own path, then each `include`, recursively.
     ///
     /// What a build script has to watch. A generator that watches only the file it was pointed at
@@ -480,6 +489,18 @@ impl Spec {
                     let node: SpecCommand = SpecCommand::parse(ctx, &node)?;
                     schema.cmd.subcommands.insert(node.name.to_string(), node);
                 }
+                "flagset" => {
+                    let set = SpecFlagSet::parse(ctx, &node)?;
+                    if schema.flagsets.insert(set.name.clone(), set).is_some() {
+                        bail_parse!(ctx, node.span(), "a flagset may be declared only once");
+                    }
+                }
+                // The root is a command like any other: if its own flags repeat a set, it
+                // says so the same way a subcommand does.
+                "use" => {
+                    let at = schema.cmd.flags.len();
+                    schema.cmd.uses.push(SpecUse::parse(ctx, &node, at)?);
+                }
                 "config" => schema.config = SpecConfig::parse(ctx, &node)?,
                 "complete" => {
                     let complete = SpecComplete::parse(ctx, &node)?;
@@ -629,6 +650,8 @@ impl Spec {
         } else {
             schema.bin.clone()
         };
+        // Before ancestors, because a command's usage string is built from its flags.
+        flagset::expand(ctx, &mut schema.cmd, &schema.flagsets)?;
         set_subcommand_ancestors(&mut schema.cmd, &[]);
         Ok(schema)
     }
@@ -682,6 +705,10 @@ impl Spec {
         merge_opt!(unknown_flags);
         merge_extend!(complete);
         merge_extend!(views);
+        // An included file's sets are visible to the file that includes it, which is how a
+        // spec keeps its shared declarations in a file of their own. Its own `use` nodes are
+        // already resolved by the time it gets here, so nothing is expanded twice.
+        merge_extend!(flagsets);
         merge_extend!(examples);
         // An included spec brings the files *it* read, which is how a nested include is watched.
         merge_extend!(sources);
@@ -693,7 +720,7 @@ impl Spec {
     }
 }
 
-fn spec_flag_forms_overlap(a: &SpecFlag, b: &SpecFlag) -> bool {
+pub(crate) fn spec_flag_forms_overlap(a: &SpecFlag, b: &SpecFlag) -> bool {
     fn long_forms(flag: &SpecFlag) -> impl Iterator<Item = &str> {
         flag.long
             .iter()

--- a/lib/src/spec/mod.rs
+++ b/lib/src/spec/mod.rs
@@ -640,6 +640,24 @@ impl Spec {
                     };
                     info!("include: {}", file.display());
                     let other = Self::parse_file_with_metadata_inference(&file, false)?;
+                    // A name declared on both sides of an `include` is refused, the same as
+                    // one declared twice in a single file. Letting the incoming set win
+                    // would make which declaration a `use` gets depend on whether the
+                    // `include` stands above or below it — and only in that direction, since
+                    // a `flagset` written after an `include` already fails here.
+                    if let Some(name) = other
+                        .flagsets
+                        .keys()
+                        .find(|name| schema.flagsets.contains_key(*name))
+                    {
+                        bail_parse!(
+                            ctx,
+                            node.span(),
+                            "a flagset may be declared only once: {} declares \"{name}\", \
+                             which this spec already has",
+                            file.display()
+                        );
+                    }
                     schema.merge(other);
                 }
                 k => bail_parse!(ctx, node.node.name().span(), "unsupported spec key {k}"),
@@ -707,7 +725,9 @@ impl Spec {
         merge_extend!(views);
         // An included file's sets are visible to the file that includes it, which is how a
         // spec keeps its shared declarations in a file of their own. Its own `use` nodes are
-        // already resolved by the time it gets here, so nothing is expanded twice.
+        // already resolved by the time it gets here, so nothing is expanded twice. A name
+        // both sides declare never reaches this extend: the `include` refuses it, rather
+        // than one silently taking the other's name.
         merge_extend!(flagsets);
         merge_extend!(examples);
         // An included spec brings the files *it* read, which is how a nested include is watched.

--- a/lib/src/spec/mod.rs
+++ b/lib/src/spec/mod.rs
@@ -651,7 +651,7 @@ impl Spec {
             schema.bin.clone()
         };
         // Before ancestors, because a command's usage string is built from its flags.
-        flagset::expand(ctx, &mut schema.cmd, &schema.flagsets)?;
+        flagset::expand(ctx, &mut schema.cmd, &mut schema.flagsets)?;
         set_subcommand_ancestors(&mut schema.cmd, &[]);
         Ok(schema)
     }

--- a/lib/src/spec/mod.rs
+++ b/lib/src/spec/mod.rs
@@ -640,22 +640,35 @@ impl Spec {
                     };
                     info!("include: {}", file.display());
                     let other = Self::parse_file_with_metadata_inference(&file, false)?;
-                    // A name declared on both sides of an `include` is refused, the same as
-                    // one declared twice in a single file. Letting the incoming set win
-                    // would make which declaration a `use` gets depend on whether the
-                    // `include` stands above or below it — and only in that direction, since
-                    // a `flagset` written after an `include` already fails here.
-                    if let Some(name) = other
-                        .flagsets
-                        .keys()
-                        .find(|name| schema.flagsets.contains_key(*name))
-                    {
+                    // Two *declarations* of one name are refused, the same as two in a single
+                    // file. Letting the incoming set win would make which declaration a
+                    // `use` gets depend on whether the `include` stands above or below it —
+                    // and only in that direction, since a `flagset` written after an
+                    // `include` already fails here.
+                    //
+                    // Which declaration, not which name: a file of shared sets is included
+                    // by every file whose `use` nodes name them, since each file resolves
+                    // its own. A spec that includes two of those files sees the shared set
+                    // arrive twice, and that is one declaration by two routes.
+                    let clash = other.flagsets.values().find(|incoming| {
+                        schema
+                            .flagsets
+                            .get(&incoming.name)
+                            .is_some_and(|own| own.declared_in != incoming.declared_in)
+                    });
+                    if let Some(incoming) = clash {
+                        let name = &incoming.name;
+                        let owner = schema.flagsets[name].declared_in.clone();
+                        let owner = match owner.as_os_str().is_empty() {
+                            true => "this spec".to_string(),
+                            false => owner.display().to_string(),
+                        };
                         bail_parse!(
                             ctx,
                             node.span(),
-                            "a flagset may be declared only once: {} declares \"{name}\", \
-                             which this spec already has",
-                            file.display()
+                            "a flagset may be declared only once: \"{name}\" is declared in \
+                             {} and in {owner}",
+                            incoming.declared_in.display()
                         );
                     }
                     schema.merge(other);
@@ -725,9 +738,10 @@ impl Spec {
         merge_extend!(views);
         // An included file's sets are visible to the file that includes it, which is how a
         // spec keeps its shared declarations in a file of their own. Its own `use` nodes are
-        // already resolved by the time it gets here, so nothing is expanded twice. A name
-        // both sides declare never reaches this extend: the `include` refuses it, rather
-        // than one silently taking the other's name.
+        // already resolved by the time it gets here, so nothing is expanded twice. Two files
+        // declaring one name never reach this extend: the `include` refuses them, rather
+        // than one silently taking the other's name. What does reach it is the same shared
+        // file arriving by two routes, which overwrites an entry with itself.
         merge_extend!(flagsets);
         merge_extend!(examples);
         // An included spec brings the files *it* read, which is how a nested include is watched.

--- a/lib/tests/docs_examples.rs
+++ b/lib/tests/docs_examples.rs
@@ -11,8 +11,12 @@
 //! doing and is not this change. Running this test against them today reports five
 //! failures, one of which — `flag "flag1"` in `cmd.md`, missing its dashes — is a real
 //! documentation bug of exactly the kind this test exists to catch.
+//!
+//! A block that reads another file is parsed from disk rather than skipped, because the
+//! `include` examples are the ones a reader is least able to check for themselves: the
+//! whole point of one is that the meaning is spread over two blocks.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// A fenced block, and what has to be true of it.
 enum Example {
@@ -22,19 +26,49 @@ enum Example {
     ConfigBody(String),
     /// Top-level nodes shown without the `name`/`bin` a real spec carries.
     Fragment(String),
-    /// Reads another file, so it cannot be parsed from a string. Named so the reason is
-    /// recorded rather than the block quietly skipped.
-    NeedsAFileOnDisk,
+    /// A spec that only means something as a file: it reads another one, or a block that
+    /// does names it. Written under `name` in a scratch directory and parsed from there,
+    /// so a relative `include` resolves the way the page says it does.
+    File { name: String, body: String },
 }
 
-fn classify(block: &str) -> Example {
+/// The file a `// name.usage.kdl` header claims, if the block opens with one.
+fn declared_name(block: &str) -> Option<String> {
+    let first = block.lines().map(str::trim).find(|l| !l.is_empty())?;
+    let name = first.strip_prefix("//")?.trim();
+    let is_file = name.ends_with(".kdl") && !name.contains(char::is_whitespace);
+    is_file.then(|| name.to_string())
+}
+
+/// Every file an `include` in this block reads, as written.
+fn included_files(block: &str) -> Vec<String> {
+    block
+        .lines()
+        .filter_map(|l| l.split_once("include file="))
+        .filter_map(|(_, rest)| rest.trim_start().strip_prefix('"'))
+        .filter_map(|rest| rest.split_once('"'))
+        .map(|(file, _)| file.to_string())
+        .collect()
+}
+
+fn classify(block: &str, index: usize) -> Example {
     let first = block
         .lines()
         .map(str::trim)
         .find(|l| !l.is_empty() && !l.starts_with("//"))
         .unwrap_or_default();
-    if block.contains("include file=") {
-        Example::NeedsAFileOnDisk
+    if let Some(name) = declared_name(block) {
+        Example::File {
+            name,
+            body: block.to_string(),
+        }
+    } else if !included_files(block).is_empty() {
+        // Nothing named it, so the name is ours to pick; it only has to be somewhere an
+        // `include` written relative to it can resolve.
+        Example::File {
+            name: format!("block-{index}.usage.kdl"),
+            body: block.to_string(),
+        }
     } else if first.starts_with("prop ")
         || first.starts_with("source ")
         || first.starts_with("file ")
@@ -70,12 +104,42 @@ fn kdl_blocks(markdown: &str) -> Vec<String> {
     blocks
 }
 
+/// Lay a page's file-shaped blocks out in `dir`, and return where each one landed.
+///
+/// Written before anything is parsed rather than as each block is reached: a page is free
+/// to show the including file first, and a test that depended on the order would be a
+/// documentation rule nobody agreed to.
+fn write_files(dir: &Path, blocks: &[String]) -> Vec<(usize, PathBuf)> {
+    let mut written = Vec::new();
+    for (i, block) in blocks.iter().enumerate() {
+        if let Example::File { name, body } = classify(block, i) {
+            let path = dir.join(&name);
+            std::fs::write(&path, &body).expect("writable");
+            written.push((i, path));
+        }
+    }
+    // A page may show the file that includes without showing what it includes — `config.md`
+    // points at a `settings.usage.kdl` whose contents are the rest of that page. An empty
+    // stand-in keeps the including block honestly parsed; what the target says is checked
+    // wherever the page shows it.
+    for block in blocks {
+        for file in included_files(block) {
+            let path = dir.join(&file);
+            if !path.exists() {
+                std::fs::write(&path, "").expect("writable");
+            }
+        }
+    }
+    written
+}
+
 #[test]
 fn every_kdl_example_on_the_checked_pages_parses() {
     let pages = [
         Path::new(env!("CARGO_MANIFEST_DIR")).join("../docs/spec/reference/config.md"),
-        // Every block on the flagset page is a whole spec or a top-level fragment, so the
-        // page can be held to parsing from the day it was written.
+        // Every block on the flagset page is a whole spec, a top-level fragment or a file
+        // another block reads, so the page can be held to parsing from the day it was
+        // written.
         Path::new(env!("CARGO_MANIFEST_DIR")).join("../docs/spec/reference/flagset.md"),
     ];
     let mut checked = 0;
@@ -87,19 +151,26 @@ fn every_kdl_example_on_the_checked_pages_parses() {
             .unwrap_or_default()
             .to_string_lossy()
             .to_string();
-        for (i, block) in kdl_blocks(&std::fs::read_to_string(&page).expect("readable"))
-            .iter()
-            .enumerate()
-        {
-            let source = match classify(block) {
-                Example::NeedsAFileOnDisk => continue,
+        let blocks = kdl_blocks(&std::fs::read_to_string(&page).expect("readable"));
+        let dir = tempfile::tempdir().expect("temp dir");
+        let files = write_files(dir.path(), &blocks);
+
+        for (i, block) in blocks.iter().enumerate() {
+            checked += 1;
+            if let Some((_, path)) = files.iter().find(|(at, _)| *at == i) {
+                if let Err(err) = usage::Spec::parse_file(path) {
+                    failures.push(format!("{name} block {i}: {err}\n{block}"));
+                }
+                continue;
+            }
+            let source = match classify(block, i) {
+                Example::File { .. } => unreachable!("written above"),
                 Example::Spec(spec) => spec,
                 Example::ConfigBody(body) => {
                     format!("name \"ex\"\nbin \"ex\"\nconfig {{\n{body}}}\n")
                 }
                 Example::Fragment(body) => format!("name \"ex\"\nbin \"ex\"\n{body}"),
             };
-            checked += 1;
             if let Err(err) = source.parse::<usage::Spec>() {
                 failures.push(format!("{name} block {i}: {err}\n{source}"));
             }

--- a/lib/tests/docs_examples.rs
+++ b/lib/tests/docs_examples.rs
@@ -1,4 +1,4 @@
-//! Every KDL example on the config reference page parses.
+//! Every KDL example on the config and flagset reference pages parses.
 //!
 //! That page used to document a vocabulary which had never existed — `file`, `findup`,
 //! `default "k" "v"`, `alias`, `config_file` — while the parser accepted only `prop`, which
@@ -71,8 +71,13 @@ fn kdl_blocks(markdown: &str) -> Vec<String> {
 }
 
 #[test]
-fn every_kdl_example_on_the_config_page_parses() {
-    let pages = [Path::new(env!("CARGO_MANIFEST_DIR")).join("../docs/spec/reference/config.md")];
+fn every_kdl_example_on_the_checked_pages_parses() {
+    let pages = [
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../docs/spec/reference/config.md"),
+        // Every block on the flagset page is a whole spec or a top-level fragment, so the
+        // page can be held to parsing from the day it was written.
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../docs/spec/reference/flagset.md"),
+    ];
     let mut checked = 0;
     let mut failures = Vec::new();
 


### PR DESCRIPTION
## What

A spec can declare a named set of flags once and pull it into any command:

```kdl
flagset "output" {
  flag "-v --verbose" help="Print more"
  flag "--json" help="Machine-readable output"
}

cmd "build" {
  use "output"
  flag "--release"
}

cmd "test" {
  use "output"
  flag "--filter <pattern>"
}
```

mise's checked-in spec is 5,592 lines for 711 flags, and most of that count is the same handful of declarations written again under the next command. The derive has `flatten` for exactly this; a hand-authored spec had nothing.

## How

`use` is resolved while the file is read. By the time anything downstream sees the spec — help, completions, docs, manpages, usage-argv, the Go runtime, the SDK generators — the commands hold ordinary flags, so nothing learns a new concept. That is the point: reuse disappears into what it stands for rather than becoming vocabulary every consumer has to implement.

## Decisions, each of which had a defensible other answer

- **Expansion is in place.** A `use` between two flags expands between them, because help order is spec order and appending would reorder the command that used it.
- **The command's own declaration wins**, measured per form — the rule a [redeclared global](https://github.com/jdx/usage/blob/main/lib/src/spec/mod.rs) already follows. A command that says `use "output"` and then declares its own `--json` gets its own; a command declaring `-j --job-count` takes the set's `-j --jobs` out of the expansion. The same rule makes a set reached twice through composition contribute once.
- **Sets compose.** A `flagset` may `use` another. A cycle is an error naming the path that closes it (`flagset cycle: a -> b -> a`), as is a `use` naming a set that does not exist — with the declared names listed.
- **Sets hold flags only.** A flag is identified by its spelling wherever it lands; a positional is identified by its position, so the same set spliced into two commands with different arguments would mean two different things. `arg` inside a `flagset` is an error rather than a guess.
- **Sets travel through `include`**, which is how a CLI keeps shared declarations in a file of their own. Each file resolves its own `use` nodes: a file cannot use a set declared only by a file that includes *it*, which would make a spec's meaning depend on who read it.
- **Declaration order does not matter** — the whole file is read before anything is resolved.
- **One-way.** A spec parsed and re-emitted holds the flags, not the nodes that produced them, the same way `include` does not survive a round trip. `SpecCommand::uses` is `pub(crate)` accordingly: it is empty by the time any consumer can see it, so exposing it would advertise a field that is always `[]`. `Spec::flagsets` is public and unserialized, as a record of what the file said.

## Not in this PR

The derive's `flatten` still emits the expanded copy, so the flags mise's spec repeats stay repeated in the *generated* file. Emitting one flagset per flattened struct is the follow-up, and it is what would turn this from an authoring convenience into a smaller generated spec. Recorded as such in `PLAN.md`.

## Tests

17 tests in `lib/src/spec/flagset.rs`: in-place order, several sets in one `use`, root `use`, forward references, composition and the diamond, own-declaration-wins on both long and short forms, depth, `include`, a global from a set inheriting normally, an argv parse against expanded flags, and each error — unknown name (with and without any sets declared), self-cycle, mutual cycle, duplicate name, `arg` in a set, unsupported keys and props, `use` with children, `use` with no names.

The new reference page joins `docs_examples.rs`, so every KDL block on it is parsed by the test suite.

`cargo test --all --all-features`, `go test ./...`, `cargo clippy --all --all-features --all-targets -- -D warnings`, `cargo fmt`, and `prettier -c .` are all green.

_This PR was created by Claude Code._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches spec parsing, include merge, and flag expansion—the path every consumer reads. Expansion is one-way and well-tested, but a bug here would change which flags a command actually has.
> 
> **Overview**
> Hand-authored specs can now declare a named `flagset` once and pull it into any command with `use`, the spec-side counterpart to derive `flatten`. Expansion happens while the file is read, so help, completions, docs, and generated parsers still see ordinary flags.
> 
> `use` expands **in place** (help order is spec order). A command’s own declaration **wins per form**, so overlap and diamond composition contribute once. Sets may compose; cycles and unknown names error. Sets hold **flags only**, travel through `include`, and each file resolves its own `use` nodes. Duplicate names are refused unless they are the same file arriving by two routes. Round-trip emit drops `flagset`/`use`, same as `include`.
> 
> Docs add a flagset reference page; `docs_examples.rs` now parses those KDL blocks (including `include` examples written to disk). The derive still emits expanded copies—emitting one flagset per flattened struct is follow-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3655bef87e39e7f14d7d06bea4d3b93b02368caa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reusable named flagsets that can be inserted into specifications with `use`.
  - Supports composing multiple flagsets, declaration-order independence, nested commands, includes, and local flag precedence.
  - Detects missing flagsets, duplicate declarations, and circular references with clear errors.
  - Expanded flags are available directly to downstream consumers and flattening workflows.

- **Documentation**
  - Added comprehensive flagset reference documentation and examples.
  - Added validation for flagset documentation examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->