### PR TITLE
feat(spec)!: lower the derive's flatten into a flagset

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -321,10 +321,21 @@ tasks --usage"`, so task names are meant to come from running that. usage-argv d
       different arguments would mean two different things. Sets travel through `include`, and
       each file resolves its own `use` nodes — a file cannot use a set declared only by a file
       that includes _it_, which would make a spec's meaning depend on who read it.
-      What this does **not** do yet is give the derive's `flatten` a lossless lowering: it still
-      emits the expanded copy, so the flags mise's spec repeats stay repeated in the generated
-      file. Emitting one flagset per flattened struct is the follow-up, and it is what would
-      turn this from an authoring convenience into a smaller generated spec.
+      The derive lowers `flatten` into it rather than emitting the expanded copy: one flagset
+      per flattened struct, named after it, and a `use` on every command that flattens it. A
+      struct that flattens another becomes a set that uses a set. One set per struct rather
+      than only for the ones with several users — a threshold would make how one command is
+      written depend on what another does, so adding a `flatten` elsewhere would restructure a
+      command nobody touched. Two flattened structs whose names end in the same word get no set:
+      one name cannot stand for both, so both are written inline, which is what every flatten
+      did before. usage-cli's own checked-in spec is the first case of it, and its generated
+      markdown, JSON and manpage are byte-identical across the change — the reference parser
+      resolves the set while it reads the file, so what a command accepts never moved.
+      Still owed: a way to name a set other than after the Rust type, which is what a collision
+      needs to be fixable rather than merely safe. And usage-cli declares
+      `min_usage_version "4.0"` while now emitting a node no 4.0 can read — the floor moves to
+      whatever release carries this, which is release-plz's to stamp rather than a number to
+      guess here.
 
 ### Then: what a CLI framework has to have
 

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -851,6 +851,13 @@ pub struct CommandMeta<'a> {
     /// Cold like everything else here: a group is checked once the last token has been
     /// read, by code the derive generates, and a successful parse never reads this.
     pub groups: &'a [GroupMeta<'a>],
+    /// Which runs of [`Self::flags`] came from a flattened `Args` type.
+    ///
+    /// Only [`Spec::to_kdl`] reads this, and only to write a `flagset` once instead of the
+    /// same flags under every command that flattens the struct. It changes nothing about
+    /// parsing: the flags are in `flags` either way, which is why this is a description of
+    /// where they came from rather than a table anything binds against.
+    pub flatten_groups: &'a [FlattenGroup<'a>],
 }
 
 impl CommandMeta<'_> {
@@ -886,7 +893,27 @@ impl CommandMeta<'_> {
         flags: &[],
         args: &[],
         subcommands: &[],
+        flatten_groups: &[],
     };
+}
+
+/// A run of one command's flags that arrived from a flattened `Args` type.
+///
+/// `#[usage(flatten)]` splices a struct's declarations into the command that holds it, so a
+/// set of flags shared by thirty commands is thirty identical copies in the emitted spec.
+/// This records the seam the expansion leaves behind, so [`Spec::to_kdl`] can write the set
+/// once as a `flagset` and a `use` in each command that has it.
+#[derive(Debug, Clone, Copy)]
+pub struct FlattenGroup<'a> {
+    /// The name the emitted `flagset` is given: the flattened type's, in kebab-case.
+    pub name: &'a str,
+    /// Where this group's flags begin in the flattening command's flag list.
+    pub start: usize,
+    /// The flattened type's own metadata.
+    ///
+    /// The flagset's body comes from here rather than from the parent's slice, so a struct
+    /// that flattens another can be written as a set that `use`s a set.
+    pub meta: &'a CommandMeta<'a>,
 }
 
 /// What a flag knows about itself beyond how it parses.
@@ -1454,18 +1481,173 @@ impl Spec<'_> {
         for example in self.root.examples {
             write_example(out, example, 0)?;
         }
+        // Before the flags, since that is where the first `use` of one appears. Which sets
+        // there are is a property of the whole tree, so it is settled before anything is
+        // written rather than discovered command by command.
+        let w = Writing {
+            bin: self.bin.unwrap_or(self.name),
+            overlays,
+            sets: Flagsets::collect(self.root),
+        };
+        for entry in w.sets.written() {
+            writeln!(out, "flagset {} {{", quoted(entry.name))?;
+            write_flag_layout(out, entry.meta, 1, &w.sets)?;
+            out.push_str("}\n");
+        }
         // Nothing above the root, so what it does not state is the default.
         let mut path = Vec::new();
-        write_body(
-            out,
-            self.root,
-            0,
-            UnknownFlags::Value,
-            self.bin.unwrap_or(self.name),
-            overlays,
-            &mut path,
-        )
+        write_body(out, self.root, 0, UnknownFlags::Value, &w, &mut path)
     }
+}
+
+/// Whether two flattened groups are the same declarations.
+///
+/// Keys are hashed from the type a declaration came from, so a matching key sequence means
+/// a matching struct. Pointer equality is tried first because it is the usual case: the same
+/// associated const, reached from every command that flattens the type.
+fn same_group(a: &CommandMeta<'_>, b: &CommandMeta<'_>) -> bool {
+    core::ptr::eq(a, b)
+        || (a.flags.len() == b.flags.len()
+            && a.flags
+                .iter()
+                .zip(b.flags)
+                .all(|(x, y)| x.flag.key == y.flag.key))
+}
+
+/// The flagsets a spec is going to write, worked out before anything is written.
+///
+/// One per flattened struct, whether it is flattened once or thirty times. A threshold —
+/// only sets with several users, or only ones that save lines — would make how a command is
+/// written depend on what some other command does, so adding a second `#[usage(flatten)]`
+/// elsewhere would restructure a command nobody touched. A `flatten` is a shared declaration
+/// wherever it appears, and this writes it as one.
+struct Flagsets<'a> {
+    entries: Vec<FlagsetEntry<'a>>,
+}
+
+struct FlagsetEntry<'a> {
+    name: &'a str,
+    meta: &'a CommandMeta<'a>,
+    /// Another type claimed this name, so it cannot stand for either of them.
+    ambiguous: bool,
+}
+
+impl<'a> Flagsets<'a> {
+    fn collect(root: &'a CommandMeta<'a>) -> Self {
+        let mut sets = Self {
+            entries: Vec::new(),
+        };
+        sets.walk(root);
+        sets
+    }
+
+    fn walk(&mut self, meta: &'a CommandMeta<'a>) {
+        for group in meta.flatten_groups {
+            self.record(group);
+        }
+        for sub in meta.subcommands {
+            self.walk(sub);
+        }
+    }
+
+    fn record(&mut self, group: &'a FlattenGroup<'a>) {
+        if let Some(entry) = self.entries.iter_mut().find(|e| e.name == group.name) {
+            if !same_group(entry.meta, group.meta) {
+                // Two flattened types whose names end in the same word. Neither can have
+                // the name, because a `use` of it would put one struct's flags on the
+                // command that asked for the other's. Both are written inline instead, which
+                // is what every flatten did before sets existed.
+                entry.ambiguous = true;
+            }
+            return;
+        }
+        self.entries.push(FlagsetEntry {
+            name: group.name,
+            meta: group.meta,
+            ambiguous: false,
+        });
+        // The sets this one composes. Recorded once, when the set is first met, because
+        // they are written inside its body rather than by everything that uses it.
+        for nested in group.meta.flatten_groups {
+            self.record(nested);
+        }
+    }
+
+    /// The sets that get written, in the order they were met.
+    fn written(&self) -> impl Iterator<Item = &FlagsetEntry<'a>> {
+        self.entries.iter().filter(|e| Self::worth_writing(e))
+    }
+
+    /// Whether a `use` may stand for this group, or its flags have to be written out.
+    fn covers(&self, group: &FlattenGroup<'_>) -> bool {
+        self.entries.iter().any(|e| {
+            e.name == group.name && Self::worth_writing(e) && same_group(e.meta, group.meta)
+        })
+    }
+
+    /// A set with no flags in it has nothing to declare and nothing to stand for: a
+    /// flattened struct may hold only positionals, which stay where they are.
+    fn worth_writing(entry: &FlagsetEntry<'_>) -> bool {
+        !entry.ambiguous && !entry.meta.flags.is_empty()
+    }
+}
+
+/// What every command in one document is written against.
+///
+/// Bundled because it is the same for all of them: the binary a completer would name, the
+/// per-command overlays a view applies, and which flagsets exist. Passing them one by one had
+/// `write_command` and `write_body` at eight parameters each, most of them pass-through.
+struct Writing<'a, 'o> {
+    bin: &'a str,
+    overlays: &'o [CommandOverlay<'o>],
+    sets: Flagsets<'a>,
+}
+
+/// Write one command's flags, as `use` for every set that stands for a run of them.
+///
+/// Shared with the body of a `flagset`, which is the same question asked of a flattened
+/// struct's own metadata — so a struct that flattens another is written as a set that uses a
+/// set, and a group written inline still uses the sets it composes.
+fn write_flag_layout(
+    out: &mut String,
+    meta: &CommandMeta<'_>,
+    depth: usize,
+    sets: &Flagsets<'_>,
+) -> core::fmt::Result {
+    let mut i = 0;
+    while i < meta.flags.len() {
+        // A group that contributed no flags has no run to stand for, and matching it would
+        // advance nothing.
+        let group = meta
+            .flatten_groups
+            .iter()
+            .find(|g| g.start == i && !g.meta.flags.is_empty());
+        match group {
+            Some(group) if sets.covers(group) => {
+                indent(out, depth)?;
+                writeln!(out, "use {}", quoted(group.name))?;
+                i += group.meta.flags.len();
+            }
+            Some(group) => {
+                write_flag_layout(out, group.meta, depth, sets)?;
+                i += group.meta.flags.len();
+            }
+            None => {
+                // The two tables are written in the same order by construction, so a
+                // mismatch means a table was edited without its metadata.
+                debug_assert!(
+                    meta.cmd
+                        .flags
+                        .get(i)
+                        .is_some_and(|f| core::ptr::eq(*f, meta.flags[i].flag)),
+                    "flag metadata is out of step with the parse table"
+                );
+                write_flag(out, &meta.flags[i], depth)?;
+                i += 1;
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Write a command's contents: its flags, arguments, and subcommands.
@@ -1477,8 +1659,7 @@ fn write_body<'a>(
     meta: &CommandMeta<'a>,
     depth: usize,
     inherited_unknown_flags: UnknownFlags,
-    bin: &str,
-    overlays: &[CommandOverlay<'_>],
+    w: &Writing<'_, '_>,
     path: &mut Vec<&'a str>,
 ) -> core::fmt::Result {
     // The effective setting for everything inside, which is this command's if it stated one
@@ -1501,18 +1682,7 @@ fn write_body<'a>(
         meta.subcommands.len(),
         "every subcommand in the parse table needs metadata"
     );
-    for (i, flag) in meta.flags.iter().enumerate() {
-        // The two tables are written in the same order by construction, so a
-        // mismatch means a table was edited without its metadata.
-        debug_assert!(
-            meta.cmd
-                .flags
-                .get(i)
-                .is_some_and(|f| core::ptr::eq(*f, flag.flag)),
-            "flag metadata is out of step with the parse table"
-        );
-        write_flag(out, flag, depth)?;
-    }
+    write_flag_layout(out, meta, depth, &w.sets)?;
     for (i, arg) in meta.args.iter().enumerate() {
         debug_assert!(
             meta.cmd
@@ -1530,17 +1700,9 @@ fn write_body<'a>(
         write_group(out, group, depth)?;
     }
     #[cfg(feature = "complete")]
-    write_completers(out, meta, bin, depth)?;
+    write_completers(out, meta, w.bin, depth)?;
     for sub in meta.subcommands {
-        write_command(
-            out,
-            sub,
-            depth,
-            enclosing_unknown_flags,
-            bin,
-            overlays,
-            path,
-        )?;
+        write_command(out, sub, depth, enclosing_unknown_flags, w, path)?;
     }
     Ok(())
 }
@@ -1599,8 +1761,7 @@ fn write_command<'a>(
     meta: &CommandMeta<'a>,
     depth: usize,
     inherited_unknown_flags: UnknownFlags,
-    bin: &str,
-    overlays: &[CommandOverlay<'_>],
+    w: &Writing<'_, '_>,
     path: &mut Vec<&'a str>,
 ) -> core::fmt::Result {
     path.push(meta.cmd.name);
@@ -1624,7 +1785,8 @@ fn write_command<'a>(
     if let Some(heading) = meta.help_heading {
         write!(out, " help_heading={}", quoted(heading))?;
     }
-    let effect = overlays
+    let effect = w
+        .overlays
         .iter()
         .rev()
         .find(|overlay| overlay.command.matches(meta, path))
@@ -1745,15 +1907,7 @@ fn write_command<'a>(
     for example in meta.examples {
         write_example(out, example, inner)?;
     }
-    write_body(
-        out,
-        meta,
-        inner,
-        effective_unknown_flags,
-        bin,
-        overlays,
-        path,
-    )?;
+    write_body(out, meta, inner, effective_unknown_flags, w, path)?;
 
     indent(out, depth)?;
     out.push_str("}\n");
@@ -3603,13 +3757,17 @@ mod tests {
         };
 
         let mut out = String::new();
+        let w = Writing {
+            bin: "ex",
+            overlays: &[],
+            sets: Flagsets::collect(&ROOT_META),
+        };
         write_body(
             &mut out,
             &ROOT_META,
             0,
             UnknownFlags::Value,
-            "ex",
-            &[],
+            &w,
             &mut Vec::new(),
         )
         .unwrap();

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -1552,12 +1552,21 @@ impl<'a> Flagsets<'a> {
 
     fn record(&mut self, group: &'a FlattenGroup<'a>) {
         if let Some(entry) = self.entries.iter_mut().find(|e| e.name == group.name) {
-            if !same_group(entry.meta, group.meta) {
-                // Two flattened types whose names end in the same word. Neither can have
-                // the name, because a `use` of it would put one struct's flags on the
-                // command that asked for the other's. Both are written inline instead, which
-                // is what every flatten did before sets existed.
-                entry.ambiguous = true;
+            if same_group(entry.meta, group.meta) {
+                // The same struct again, whose own sets were recorded the first time.
+                return;
+            }
+            // Two flattened types whose names end in the same word. Neither can have the
+            // name, because a `use` of it would put one struct's flags on the command that
+            // asked for the other's. Both are written inline instead, which is what every
+            // flatten did before sets existed.
+            entry.ambiguous = true;
+            // Its nested sets are still sets, and still have to face the same-name rule:
+            // returning here left whatever this one composes uncompared, so which of two
+            // colliding nested structs got the name came down to which parent was walked
+            // first.
+            for nested in group.meta.flatten_groups {
+                self.record(nested);
             }
             return;
         }

--- a/cli/src/cli/mod.rs
+++ b/cli/src/cli/mod.rs
@@ -20,6 +20,11 @@ mod sponsors;
 // 3.6 added `effect=` and 4.0 added it on flags and args; older `usage` CLIs reject the spec
 // outright with "unsupported cmd prop effect", so this moves in lockstep with the fields the
 // spec actually carries.
+//
+// Owed a bump: the four shell commands flatten `Shell`, which now emits a `flagset`, and no
+// 4.0 can read that node. The floor is whichever release carries flagsets, so the number waits
+// for that release rather than being guessed at here — and this crate warning about its own
+// spec until then is worse than the stale claim.
 #[derive(DeriveCli)]
 #[usage(
     bin = "usage",

--- a/cli/usage.usage.kdl
+++ b/cli/usage.usage.kdl
@@ -9,14 +9,17 @@ about "CLI for working with usage-based CLIs"
 usage "Usage: usage <COMMAND>\n       usage --completions <COMPLETIONS>\n       usage --usage-spec"
 unknown_flags error
 subcommand_required #true
+flagset shell {
+    flag -h help="Show help"
+    flag --help help="Show help"
+}
 flag --completions help="Outputs completions for the specified shell for completing the `usage` CLI itself" {
     arg <COMPLETIONS>
 }
 flag --usage-spec help="Outputs a `usage.kdl` spec for this CLI itself"
 cmd bash help="Execute a shell script using bash" unknown_flags=value {
     long_help "Execute a shell script with the specified shell\n\nTypically, this will be called by a script's shebang.\n\nIf using `var=#true` on args/flags, they will be joined with spaces using `shell_words::join()`\nto properly escape and quote values with spaces in them."
-    flag -h help="Show help"
-    flag --help help="Show help"
+    use shell
     arg <SCRIPT>
     arg "[ARGS]..." help="Arguments to pass to script" {
         long_help "Arguments to pass to script\n\nAnything `usage` does not recognise is a value rather than a mistake, which is what\nlets a shebang script take flags of its own."
@@ -51,8 +54,7 @@ cmd exec help="Execute a script, parsing args and exposing them as environment v
 }
 cmd fish help="Execute a shell script using fish" unknown_flags=value {
     long_help "Execute a shell script with the specified shell\n\nTypically, this will be called by a script's shebang.\n\nIf using `var=#true` on args/flags, they will be joined with spaces using `shell_words::join()`\nto properly escape and quote values with spaces in them."
-    flag -h help="Show help"
-    flag --help help="Show help"
+    use shell
     arg <SCRIPT>
     arg "[ARGS]..." help="Arguments to pass to script" {
         long_help "Arguments to pass to script\n\nAnything `usage` does not recognise is a value rather than a mistake, which is what\nlets a shebang script take flags of its own."
@@ -244,8 +246,7 @@ cmd mcp help="Serve a usage spec over the Model Context Protocol" effect=read {
 }
 cmd powershell help="Execute a shell script using PowerShell" unknown_flags=value {
     long_help "Execute a shell script with the specified shell\n\nTypically, this will be called by a script's shebang.\n\nIf using `var=#true` on args/flags, they will be joined with spaces using `shell_words::join()`\nto properly escape and quote values with spaces in them."
-    flag -h help="Show help"
-    flag --help help="Show help"
+    use shell
     arg <SCRIPT>
     arg "[ARGS]..." help="Arguments to pass to script" {
         long_help "Arguments to pass to script\n\nAnything `usage` does not recognise is a value rather than a mistake, which is what\nlets a shebang script take flags of its own."
@@ -255,8 +256,7 @@ cmd sponsors help="Show the companies sponsoring usage and the jdx.dev open sour
 }
 cmd zsh help="Execute a shell script using zsh" unknown_flags=value {
     long_help "Execute a shell script with the specified shell\n\nTypically, this will be called by a script's shebang.\n\nIf using `var=#true` on args/flags, they will be joined with spaces using `shell_words::join()`\nto properly escape and quote values with spaces in them."
-    flag -h help="Show help"
-    flag --help help="Show help"
+    use shell
     arg <SCRIPT>
     arg "[ARGS]..." help="Arguments to pass to script" {
         long_help "Arguments to pass to script\n\nAnything `usage` does not recognise is a value rather than a mistake, which is what\nlets a shebang script take flags of its own."

--- a/conformance/src/tables.rs
+++ b/conformance/src/tables.rs
@@ -172,6 +172,9 @@ pub fn build(
         groups: groups(&cmd.groups),
         flags: Box::leak(flag_metas.into_boxed_slice()),
         args: Box::leak(arg_metas.into_boxed_slice()),
+        // A spec read from KDL has already had its `use` nodes resolved, so there is no seam
+        // left to record: these tables come from flags, not from the struct that declared them.
+        flatten_groups: &[],
         subcommands: Box::leak(
             subs.iter()
                 .map(|s| s.meta)

--- a/conformance/tests/flatten.rs
+++ b/conformance/tests/flatten.rs
@@ -2,9 +2,13 @@
 //!
 //! mise writes `ConfigLs` once and gives it to both `config` and `config ls`, so that
 //! `mise config --no-header` and `mise config ls --no-header` accept the same flags. Ten
-//! commands do this. It is a Rust-side device with no counterpart in the spec: the emitted
-//! KDL lists the flags inline, exactly as a hand-written command would, because a spec
-//! describes what a CLI accepts and not how the declarations were organised.
+//! commands do this. The spec has a counterpart for it — a `flagset`, and a `use` on each
+//! command that has the flags — so the emitted KDL says it once too, rather than repeating
+//! the declarations under every command.
+//!
+//! What a command *accepts* is the same either way, which is the property these tests hold:
+//! the reference parser resolves a `use` while it reads the file, so a spec with sets and
+//! the same spec written out flat describe one CLI.
 //!
 //! The tables are joined at compile time, so the parser walks one flat slice and flatten
 //! costs nothing at run time.
@@ -131,9 +135,9 @@ fn a_flattened_declaration_is_still_checked() {
 }
 
 #[test]
-fn the_spec_shows_the_flags_inline() {
-    // A spec has no idea of flattening, and does not need one: what reaches the KDL is the
-    // command with every flag it accepts, indistinguishable from one written out by hand.
+fn the_spec_says_the_flags_are_shared() {
+    // The shared declarations reach the KDL as a set the two commands use, and every flag
+    // is still on every command that accepts it once the reference parser has read it.
     let kdl = Ex::to_kdl();
     let spec: LibSpec = kdl.parse().expect("valid spec");
     let config = spec.cmd.subcommands.get("config").expect("config");
@@ -166,9 +170,13 @@ fn the_spec_shows_the_flags_inline() {
         Some("Do not print a header")
     );
 
-    // Nothing about the Rust-side arrangement leaks in.
+    // Said once, and used by both commands rather than copied into each.
+    assert!(kdl.contains("flagset listing {"), "{kdl}");
+    assert_eq!(kdl.matches("use listing").count(), 2, "{kdl}");
+    assert_eq!(kdl.matches("flag --no-header").count(), 1, "{kdl}");
+    // The set is a spec node. How the Rust side arranged it — the attribute, the field name
+    // holding the struct — still does not appear.
     assert!(!kdl.contains("flatten"), "{kdl}");
-    assert!(!kdl.contains("listing"), "{kdl}");
 }
 
 /// A parent with a required flag of its own, to pit against a flattened rule.

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -17,8 +17,8 @@ use quote::{format_ident, quote};
 
 use crate::crate_name::{crate_name, FoundCrate};
 use crate::model::{
-    rendered_path, to_kebab, type_name, Cli, ConditionalDefault, Dispatch, DoubleDash,
-    ExampleDecl, Field, Kind, Shape, Subcommands, ValueEnum, ViewDecl,
+    rendered_path, to_kebab, type_name, Cli, ConditionalDefault, Dispatch, DoubleDash, ExampleDecl,
+    Field, Kind, Shape, Subcommands, ValueEnum, ViewDecl,
 };
 
 /// Construct the user's command type after its generated partial has been checked.

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -17,8 +17,8 @@ use quote::{format_ident, quote};
 
 use crate::crate_name::{crate_name, FoundCrate};
 use crate::model::{
-    rendered_path, to_kebab, Cli, ConditionalDefault, Dispatch, DoubleDash, ExampleDecl, Field,
-    Kind, Shape, Subcommands, ValueEnum, ViewDecl,
+    rendered_path, to_kebab, type_name, Cli, ConditionalDefault, Dispatch, DoubleDash,
+    ExampleDecl, Field, Kind, Shape, Subcommands, ValueEnum, ViewDecl,
 };
 
 /// Construct the user's command type after its generated partial has been checked.
@@ -207,6 +207,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
     let arg_table_ref = &tables.args;
     let flag_meta_table_ref = &tables.flag_metas;
     let arg_meta_table_ref = &tables.arg_metas;
+    let flatten_group_table_ref = &tables.flatten_groups;
 
     let name = &cli.name;
     let bin = option_str(cli.bin.as_deref());
@@ -627,6 +628,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
                 flags: #flag_meta_table_ref,
                 args: #arg_meta_table_ref,
                 groups: #group_meta_table_ref,
+                flatten_groups: #flatten_group_table_ref,
                 #sub_metas
                 ..usage_argv::spec::CommandMeta::EMPTY
             };
@@ -2402,6 +2404,9 @@ struct Tables {
     args: TokenStream,
     flag_metas: TokenStream,
     arg_metas: TokenStream,
+    /// Where each flattened struct's flags landed, for the emitted spec to write one
+    /// `flagset` instead of the same flags under every command that flattens it.
+    flatten_groups: TokenStream,
 }
 
 /// Build the four expressions, splicing any flattened groups into place.
@@ -2420,6 +2425,13 @@ fn tables(cli: &Cli) -> Tables {
     let mut own_args: Vec<usize> = Vec::new();
     let (mut flag_at, mut arg_at) = (0usize, 0usize);
     let mut flattened = false;
+    // One entry per flattened field, naming the struct and where its flags begin. The
+    // offset is written as a sum rather than a number because the lengths that make it up
+    // belong to other structs' tables: `.len()` on a const slice is a const expression, so
+    // the arithmetic happens where the rest of the table does.
+    let mut flatten_groups: Vec<TokenStream> = Vec::new();
+    let mut flag_offset: Vec<TokenStream> = Vec::new();
+    let mut own_since_flatten = 0usize;
 
     // Flush the runs collected so far, so that what follows lands after them.
     fn flush_flags(
@@ -2462,6 +2474,7 @@ fn tables(cli: &Cli) -> Tables {
             Kind::Flag { .. } => {
                 own_flags.push(flag_at);
                 flag_at += 1;
+                own_since_flatten += 1;
             }
             Kind::Arg { .. } => {
                 own_args.push(arg_at);
@@ -2469,6 +2482,21 @@ fn tables(cli: &Cli) -> Tables {
             }
             Kind::Flatten { ty } => {
                 flattened = true;
+                if own_since_flatten > 0 {
+                    flag_offset.push(quote!(#own_since_flatten));
+                    own_since_flatten = 0;
+                }
+                let name = flagset_name(ty);
+                let terms = flag_offset.iter();
+                flatten_groups.push(quote! {
+                    usage_argv::spec::FlattenGroup {
+                        name: #name,
+                        start: 0 #(+ #terms)*,
+                        meta: <#ty as usage_argv::spec::CommandArgs>::META,
+                    }
+                });
+                flag_offset
+                    .push(quote!(<#ty as usage_argv::spec::CommandArgs>::COMMAND.flags.len()));
                 flush_flags(&mut own_flags, &mut flag_groups, &mut flag_meta_groups);
                 flush_args(&mut own_args, &mut arg_groups, &mut arg_meta_groups);
                 flag_groups.push(quote!(<#ty as usage_argv::spec::CommandArgs>::COMMAND.flags));
@@ -2501,6 +2529,7 @@ fn tables(cli: &Cli) -> Tables {
             args: quote!(&[#(#arg_refs),*]),
             flag_metas: quote!(&[#(#flag_meta_refs),*]),
             arg_metas: quote!(&[#(#arg_meta_refs),*]),
+            flatten_groups: quote!(&[]),
         };
     }
 
@@ -2525,12 +2554,32 @@ fn tables(cli: &Cli) -> Tables {
             static ARG_METAS: [usage_argv::spec::ArgMeta<'static>;
                 usage_argv::table_len(ARG_META_GROUPS)] =
                 usage_argv::spec::concat_arg_metas(ARG_META_GROUPS);
+            const FLATTEN_GROUPS: &[usage_argv::spec::FlattenGroup<'static>] =
+                &[#(#flatten_groups),*];
         },
         flags: quote!(&FLAGS),
         args: quote!(&ARGS),
         flag_metas: quote!(&FLAG_METAS),
         arg_metas: quote!(&ARG_METAS),
+        flatten_groups: quote!(FLATTEN_GROUPS),
     }
+}
+
+/// The name a flattened struct's flagset is given: its own, in kebab-case.
+///
+/// The last path segment only, so `cli::CommonArgs` and `super::CommonArgs` name the same
+/// set — which they must, since they are the same struct. Two different structs whose names
+/// end in the same word collide, and [`usage_argv::spec::Spec::to_kdl`] resolves that by
+/// writing neither as a set rather than by guessing which one meant it.
+fn flagset_name(ty: &syn::Type) -> String {
+    let rendered = type_name(ty);
+    let last = rendered
+        .rsplit("::")
+        .next()
+        .unwrap_or(&rendered)
+        .trim()
+        .to_string();
+    to_kebab(&last)
 }
 
 fn flag_arm(cli: &Cli, i: usize, field: &Field) -> TokenStream {
@@ -4811,6 +4860,7 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
     let arg_table_ref = &tables.args;
     let flag_meta_table_ref = &tables.flag_metas;
     let arg_meta_table_ref = &tables.arg_metas;
+    let flatten_group_table_ref = &tables.flatten_groups;
 
     let name = &cli.name;
     let aliases = cli.aliases.iter().chain(&cli.hidden_aliases);
@@ -5053,6 +5103,7 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
                 flags: #flag_meta_table_ref,
                 args: #arg_meta_table_ref,
                 groups: #group_meta_table_ref,
+                flatten_groups: #flatten_group_table_ref,
                 #sub_metas
                 ..usage_argv::spec::CommandMeta::EMPTY
             };

--- a/docs/rust/subcommands.md
+++ b/docs/rust/subcommands.md
@@ -163,9 +163,37 @@ struct Config {
 }
 ```
 
-The tables are joined at compile time and the emitted KDL lists the flags inline — a consumer of
-the spec can't tell a flattened flag from a declared one. Groups and `exclusive` flags declared
-on the flattened struct are enforced (and emitted) on the command that flattens them.
+The tables are joined at compile time, so the parser walks one flat slice and `flatten` costs
+nothing at run time. Groups and `exclusive` flags declared on the flattened struct are enforced
+(and emitted) on the command that flattens them.
+
+The emitted KDL says the declarations are shared, rather than repeating them under each command:
+the struct becomes a [`flagset`](/spec/reference/flagset) named after it, and every command that
+flattens it gets a `use`.
+
+```kdl
+flagset listing {
+    flag --no-header help="Do not print a header"
+    flag --format help="Output format" {
+        arg <FORMAT> {
+            choices json table
+        }
+    }
+}
+cmd config {
+    flag "-f --file" {
+        arg <FILE>
+    }
+    use listing
+}
+```
+
+A `use` is resolved while the spec is read, so what a command accepts is exactly what it was
+when the flags were written out: anything reading the spec — docs, manpages, completions, another
+implementation — sees `config` with all three flags. A struct that flattens another becomes a set
+that uses a set. Positionals stay on each command, since a set holds flags only, and two flattened
+structs whose names end in the same word get no set at all — one name cannot stand for both, so
+both are written inline.
 
 A flattened struct may not declare subcommands; that's a compile-time error with an explanation.
 

--- a/docs/spec/reference/flagset.md
+++ b/docs/spec/reference/flagset.md
@@ -194,6 +194,18 @@ declaration means the same thing under any command. A positional is identified b
 position, so the same set spliced into two commands with different arguments would mean
 two different things. Declaring `arg` inside a `flagset` is an error rather than a guess.
 
+## What the derive emits
+
+The typed Rust side has its own way to share declarations —
+[`#[usage(flatten)]`](/rust/subcommands#sharing-declarations-with-flatten) — and it lowers into
+this node: a flattened struct becomes one `flagset` named after it, and every command that
+flattens the struct gets a `use`. So a CLI written in Rust and a CLI written as a spec say the
+same thing the same way, which is the point of the node existing on both sides.
+
+Two flattened structs whose names end in the same word cannot both have the name, so neither gets
+it and both are written inline. That is never wrong, only longer — but it is worth knowing if a
+set you expected did not appear.
+
 ## One-way
 
 Expansion is part of reading the file. A spec that is parsed and re-emitted — by

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -2852,3 +2852,278 @@ fn the_endpoint_wins_over_default_subcommand_routing() {
     // that wants the word back declares it, or sets `spec_endpoint = false`.
     assert!(DefaultSubcommandEx::spec_request(&[OsStr::new(usage::SPEC_REQUEST)]).is_some());
 }
+
+// A struct flattened into more than one command: the shape mise has 200-odd times over, and
+// the reason the emitted spec used to repeat itself.
+#[derive(Args)]
+#[allow(dead_code)]
+struct SharedFlags {
+    /// Print more.
+    #[arg(long, short)]
+    verbose: bool,
+    /// How many at once.
+    #[arg(long)]
+    jobs: Option<usize>,
+}
+
+#[derive(Args)]
+#[allow(dead_code)]
+struct BuildCmd {
+    #[arg(long)]
+    release: bool,
+    #[usage(flatten)]
+    shared: SharedFlags,
+    #[arg(long)]
+    target: Option<String>,
+}
+
+#[derive(Args)]
+#[allow(dead_code)]
+struct TestCmd {
+    #[usage(flatten)]
+    shared: SharedFlags,
+}
+
+#[derive(Subcommands)]
+#[allow(dead_code)]
+enum FlagsetCommand {
+    Build(BuildCmd),
+    Test(TestCmd),
+}
+
+#[derive(Cli)]
+#[usage(bin = "flagset-ex")]
+#[allow(dead_code)]
+struct FlagsetEx {
+    #[usage(subcommand)]
+    command: FlagsetCommand,
+}
+
+#[test]
+fn a_struct_flattened_twice_is_written_once_as_a_flagset() {
+    let kdl = FlagsetEx::to_kdl();
+    assert!(kdl.contains("flagset shared-flags {"), "{kdl}");
+    // Two commands, one set, and the flags written once rather than under each.
+    assert_eq!(kdl.matches("use shared-flags").count(), 2, "{kdl}");
+    assert_eq!(kdl.matches("flag \"-v --verbose\"").count(), 1, "{kdl}");
+
+    // The set stands where the struct did, so help order is still declaration order.
+    let spec: usage_parser::Spec = kdl.parse().expect("the emitted set should parse back");
+    let build = spec.cmd.subcommands.get("build").expect("build");
+    let flags: Vec<&str> = build.flags.iter().map(|f| f.name.as_str()).collect();
+    assert_eq!(flags, ["release", "verbose", "jobs", "target"], "{kdl}");
+    let test = spec.cmd.subcommands.get("test").expect("test");
+    let flags: Vec<&str> = test.flags.iter().map(|f| f.name.as_str()).collect();
+    assert_eq!(flags, ["verbose", "jobs"], "{kdl}");
+
+    // Help text and values survive the trip, not just the names: a set that lost them
+    // would still pass the assertions above.
+    let verbose = build
+        .flags
+        .iter()
+        .find(|f| f.name == "verbose")
+        .expect("verbose");
+    assert_eq!(verbose.help.as_deref(), Some("Print more."));
+    assert_eq!(verbose.short, vec!['v']);
+    let jobs = build.flags.iter().find(|f| f.name == "jobs").expect("jobs");
+    assert!(jobs.arg.is_some(), "{kdl}");
+}
+
+#[test]
+fn what_the_flagset_expands_to_is_what_the_typed_parse_binds() {
+    // The emitted spec is what docs, completions and other implementations read, so the
+    // question is not only whether it parses but whether it means the same thing.
+    let spec: usage_parser::Spec = FlagsetEx::to_kdl().parse().expect("parses");
+    let words = ["flagset-ex", "build", "--verbose", "--jobs", "4"].map(String::from);
+    let parsed = usage_parser::parse(&spec, &words).expect("the reference parser binds it");
+    assert_eq!(
+        parsed.as_env().get("usage_jobs").map(String::as_str),
+        Some("4")
+    );
+
+    let typed = FlagsetEx::parse_from(&[
+        OsStr::new("build"),
+        OsStr::new("--verbose"),
+        OsStr::new("--jobs"),
+        OsStr::new("4"),
+    ])
+    .expect("the typed parse binds it too");
+    let FlagsetCommand::Build(build) = typed.command else {
+        panic!("build should have been selected");
+    };
+    assert!(build.shared.verbose);
+    assert_eq!(build.shared.jobs, Some(4));
+}
+
+// A set assembled from a smaller one, which is the composition the spec node allows.
+#[derive(Args)]
+#[allow(dead_code)]
+struct InnerFlags {
+    #[arg(long)]
+    inner: bool,
+}
+
+#[derive(Args)]
+#[allow(dead_code)]
+struct OuterFlags {
+    #[usage(flatten)]
+    inner: InnerFlags,
+    #[arg(long)]
+    outer: bool,
+}
+
+#[derive(Args)]
+#[allow(dead_code)]
+struct NestedOne {
+    #[usage(flatten)]
+    outer: OuterFlags,
+}
+
+#[derive(Args)]
+#[allow(dead_code)]
+struct NestedTwo {
+    #[usage(flatten)]
+    outer: OuterFlags,
+}
+
+#[derive(Subcommands)]
+#[allow(dead_code)]
+enum NestedFlagsetCommand {
+    One(NestedOne),
+    Two(NestedTwo),
+}
+
+#[derive(Cli)]
+#[usage(bin = "nested-flagset-ex")]
+#[allow(dead_code)]
+struct NestedFlagsetEx {
+    #[usage(subcommand)]
+    command: NestedFlagsetCommand,
+}
+
+#[test]
+fn a_struct_that_flattens_another_is_a_set_that_uses_a_set() {
+    let kdl = NestedFlagsetEx::to_kdl();
+    assert!(kdl.contains("flagset inner-flags {"), "{kdl}");
+    assert!(kdl.contains("flagset outer-flags {"), "{kdl}");
+    // `--inner` is declared once, inside its own set, and the outer set uses it rather
+    // than holding a copy.
+    assert_eq!(kdl.matches("flag --inner").count(), 1, "{kdl}");
+    assert_eq!(kdl.matches("use inner-flags").count(), 1, "{kdl}");
+    assert_eq!(kdl.matches("use outer-flags").count(), 2, "{kdl}");
+
+    let spec: usage_parser::Spec = kdl.parse().expect("composed sets should parse back");
+    for name in ["one", "two"] {
+        let cmd = spec.cmd.subcommands.get(name).expect(name);
+        let flags: Vec<&str> = cmd.flags.iter().map(|f| f.name.as_str()).collect();
+        assert_eq!(flags, ["inner", "outer"], "{name}: {kdl}");
+    }
+}
+
+// A flattened struct holding only positionals. There is no set of flags to name, and the
+// arguments stay on each command that flattens it.
+#[derive(Args)]
+#[allow(dead_code)]
+struct PositionalsOnly {
+    script: String,
+}
+
+#[derive(Args)]
+#[allow(dead_code)]
+struct RunsAScript {
+    #[usage(flatten)]
+    script: PositionalsOnly,
+}
+
+#[derive(Cli)]
+#[usage(bin = "args-only-ex")]
+#[allow(dead_code)]
+struct ArgsOnlyEx {
+    #[usage(flatten)]
+    script: PositionalsOnly,
+}
+
+#[test]
+fn a_flattened_struct_with_no_flags_declares_no_set() {
+    let kdl = ArgsOnlyEx::to_kdl();
+    assert!(!kdl.contains("flagset"), "{kdl}");
+    assert!(!kdl.contains("use "), "{kdl}");
+    assert!(kdl.contains("arg <SCRIPT>"), "{kdl}");
+}
+
+mod first {
+    #[derive(usage_rs::Args)]
+    #[allow(dead_code)]
+    pub struct Collides {
+        #[arg(long)]
+        pub left: bool,
+    }
+}
+
+mod second {
+    #[derive(usage_rs::Args)]
+    #[allow(dead_code)]
+    pub struct Collides {
+        #[arg(long)]
+        pub right: bool,
+    }
+}
+
+#[derive(Args)]
+#[allow(dead_code)]
+struct UsesFirst {
+    #[usage(flatten)]
+    inner: first::Collides,
+}
+
+#[derive(Args)]
+#[allow(dead_code)]
+struct UsesSecond {
+    #[usage(flatten)]
+    inner: second::Collides,
+}
+
+#[derive(Subcommands)]
+#[allow(dead_code)]
+enum CollidingCommand {
+    One(UsesFirst),
+    Two(UsesSecond),
+}
+
+#[derive(Cli)]
+#[usage(bin = "colliding-ex")]
+#[allow(dead_code)]
+struct CollidingEx {
+    #[usage(subcommand)]
+    command: CollidingCommand,
+}
+
+#[test]
+fn two_structs_whose_names_end_the_same_way_get_no_set_at_all() {
+    // A set named for one of them would put its flags on the command that asked for the
+    // other's, so neither gets the name and both are written inline — which is what every
+    // flatten did before sets existed, and is never wrong, only longer.
+    let kdl = CollidingEx::to_kdl();
+    assert!(!kdl.contains("flagset collides"), "{kdl}");
+    assert!(!kdl.contains("use collides"), "{kdl}");
+
+    let spec: usage_parser::Spec = kdl.parse().expect("parses");
+    let one = spec.cmd.subcommands.get("one").expect("one");
+    assert_eq!(
+        one.flags
+            .iter()
+            .map(|f| f.name.as_str())
+            .collect::<Vec<_>>(),
+        ["left"],
+        "{kdl}"
+    );
+    let two = spec.cmd.subcommands.get("two").expect("two");
+    assert_eq!(
+        two.flags
+            .iter()
+            .map(|f| f.name.as_str())
+            .collect::<Vec<_>>(),
+        ["right"],
+        "{kdl}"
+    );
+}

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -3058,6 +3058,16 @@ mod first {
         #[arg(long)]
         pub left: bool,
     }
+
+    /// Holds a colliding struct, and collides itself.
+    #[derive(usage_rs::Args)]
+    #[allow(dead_code)]
+    pub struct Nested {
+        #[usage(flatten)]
+        pub inner: Collides,
+        #[arg(long)]
+        pub one: bool,
+    }
 }
 
 mod second {
@@ -3066,6 +3076,15 @@ mod second {
     pub struct Collides {
         #[arg(long)]
         pub right: bool,
+    }
+
+    #[derive(usage_rs::Args)]
+    #[allow(dead_code)]
+    pub struct Nested {
+        #[usage(flatten)]
+        pub inner: Collides,
+        #[arg(long)]
+        pub two: bool,
     }
 }
 
@@ -3124,6 +3143,67 @@ fn two_structs_whose_names_end_the_same_way_get_no_set_at_all() {
             .map(|f| f.name.as_str())
             .collect::<Vec<_>>(),
         ["right"],
+        "{kdl}"
+    );
+}
+
+#[derive(Args)]
+#[allow(dead_code)]
+struct NestsFirst {
+    #[usage(flatten)]
+    nested: first::Nested,
+}
+
+#[derive(Args)]
+#[allow(dead_code)]
+struct NestsSecond {
+    #[usage(flatten)]
+    nested: second::Nested,
+}
+
+#[derive(Subcommands)]
+#[allow(dead_code)]
+enum NestedCollidingCommand {
+    One(NestsFirst),
+    Two(NestsSecond),
+}
+
+#[derive(Cli)]
+#[usage(bin = "nested-colliding-ex")]
+#[allow(dead_code)]
+struct NestedCollidingEx {
+    #[usage(subcommand)]
+    command: NestedCollidingCommand,
+}
+
+#[test]
+fn a_collision_does_not_hide_the_one_inside_it() {
+    // Both `Nested` types collide, and so do the `Collides` types they hold. Stopping at the
+    // outer collision left the inner pair uncompared, so whichever parent was walked first
+    // gave its `Collides` the name — and which command got a `use` came down to traversal
+    // order rather than to anything either command said.
+    let kdl = NestedCollidingEx::to_kdl();
+    assert!(!kdl.contains("flagset nested"), "{kdl}");
+    assert!(!kdl.contains("flagset collides"), "{kdl}");
+    assert!(!kdl.contains("use collides"), "{kdl}");
+
+    let spec: usage_parser::Spec = kdl.parse().expect("parses");
+    let one = spec.cmd.subcommands.get("one").expect("one");
+    assert_eq!(
+        one.flags
+            .iter()
+            .map(|f| f.name.as_str())
+            .collect::<Vec<_>>(),
+        ["left", "one"],
+        "{kdl}"
+    );
+    let two = spec.cmd.subcommands.get("two").expect("two");
+    assert_eq!(
+        two.flags
+            .iter()
+            .map(|f| f.name.as_str())
+            .collect::<Vec<_>>(),
+        ["right", "two"],
         "{kdl}"
     );
 }


### PR DESCRIPTION
Stacked on #1170, which adds the `flagset`/`use` nodes. This is the follow-up that PR named as still owed.

## What

`#[usage(flatten)]` splices a struct's declarations into the command that holds it, and the emitted spec repeated them under every command that flattened the struct. mise gives one `Args` type to ten commands; the spec said it ten times.

Now the struct becomes one `flagset`, named after it, and each command that flattens it gets a `use`:

```kdl
flagset listing {
    flag --no-header help="Do not print a header"
    flag --format help="Output format" {
        arg <FORMAT> {
            choices json table
        }
    }
}
cmd config {
    flag "-f --file" {
        arg <FILE>
    }
    use listing
}
```

A struct that flattens another becomes a set that uses a set. Positionals stay on each command, since a set holds flags only.

## How

`CommandMeta` gains `flatten_groups` — the seam the expansion leaves behind: which run of a command's flag list came from which struct, and that struct's own metadata, so a nested flatten can be written as composition. The derive emits it with const arithmetic (`.len()` on another struct's const table), so nothing is computed at run time. Parsing is untouched: the flags are in the flag table either way, and the hot path never reads metadata.

## Decisions

- **One set per flattened struct**, not only for the ones with several users or the ones that would save lines. A threshold would make how one command is written depend on what another command does — adding a `#[usage(flatten)]` somewhere else would restructure a command nobody touched. A `flatten` is a shared declaration wherever it appears, and this writes it as one.
- **Two structs whose names end in the same word get no set at all.** One name cannot stand for both, so both are written inline — which is what every flatten did before, never wrong and only longer. Detected by comparing flag keys, which the derive hashes from the declaring type, so it does not depend on pointer identity holding across crates.
- **`write_body`/`write_command` take a `Writing` context** rather than an eighth pass-through parameter. `bin`, the view overlays and the flagsets are the same for every command in a document.

## Verification

usage-cli is the first adopter: its four shell commands flatten `Shell`, and [cli/usage.usage.kdl](https://github.com/jdx/usage/blob/agent/derive-flatten-flagsets/cli/usage.usage.kdl) now says so. The rest of `mise run render` is byte-identical — the generated markdown, JSON reference, manpage and fig output do not move, because the reference parser resolves a `use` while it reads the file. That is the losslessness claim, checked on this repo's own artifacts rather than asserted.

Five new tests in `usage-rs/tests/facade.rs` cover: a struct flattened twice (one set, two uses, flags declared once, and the parsed-back spec's flag order, help text and values); the emitted spec parsing to what the typed parse binds; nested flatten as a set that uses a set; a flattened struct with only positionals declaring no set; and two same-named structs in different modules getting no set.

`conformance/tests/flatten.rs` asserted the old contract — "the emitted KDL lists the flags inline" — and now asserts the new one. Its checks that every flag still reaches every command that accepts it, with its help text, are unchanged and are what makes the new shape safe.

`cargo test --all --all-features`, `go test ./...`, `cargo clippy --all --all-features --all-targets -- -D warnings`, `cargo fmt`, `prettier -c .` and `mise run render` are all green.

## Breaking

Only in that `CommandMeta` grows a public field. It is constructed by generated code, which moves in lockstep with this crate, so an adopter recompiles rather than edits. It cannot be `#[non_exhaustive]` for the same reason — generated code in someone else's crate has to build one.

## Still owed

- **A way to name a set other than after the Rust type.** That is what makes a name collision fixable rather than merely safe, and it is also the answer for a struct whose Rust name is not what the spec should call it. Left out to keep this reviewable; the natural spelling is on the flattened struct rather than at each use.
- **`min_usage_version`.** usage-cli declares `"4.0"` and now emits a node no 4.0 can read. The floor is whichever release carries flagsets, so the number waits for that release rather than being guessed here — declaring `"6.0"` today would also make usage-lib warn about usage-cli's own spec on every render, since the crate is still 5.1.0. Recorded at the declaration site and in PLAN.md.

_This PR was created by Claude Code._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes public `CommandMeta` and the derived KDL shape (`flagset`/`use`), so older usage 4.0 readers cannot consume new specs. Parse tables and runtime binding are unchanged.
> 
> **Overview**
> `#[usage(flatten)]` no longer expands shared flags into every command in the emitted spec. Each flattened struct becomes one `flagset` named after the type, and every command that flattens it gets a `use`. Nested flatten is a set that uses a set. Positionals stay inline.
> 
> `CommandMeta` records `flatten_groups` (name, start index, nested meta) for `Spec::to_kdl` only. The derive fills that with const `.len()` arithmetic. Parsing is unchanged: flags remain in the flat table.
> 
> Name collisions (two types whose last path segment kebab-cases the same) write both groups inline. Empty-flag structs emit no set. usage-cli’s four shell commands now share `flagset shell`; generated markdown/JSON/manpage stay byte-identical because the reference parser expands `use` on read.
> 
> `min_usage_version` is still `"4.0"` even though 4.0 cannot read `flagset` — left for the release that ships this. Custom flagset names are still owed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 458aab5a2ba0978a753bd7bfab2b5cc5349c74e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->