### PR TITLE
fix(parse): let a bundle contain a supplied short

### DIFF
--- a/docs/spec/argv.md
+++ b/docs/spec/argv.md
@@ -176,6 +176,12 @@ letters are applied: `-az` does not set `-a` on the way to discovering that `z`
 names nothing. What happens to the token instead is described under
 [unrecognized flags](#unrecognized-flags).
 
+`-h` is recognized, and so is `-V` on the root of a CLI that declares a version.
+A parser supplies both rather than a spec declaring them, and they are letters
+like any other: `-vh` is a bundle, and it asks for help. A spec that declares the
+letter itself keeps it — `-h` is supplied only where nothing else claims it, so a
+CLI whose `-h` means `--host` reads `-vhlocal` as its own.
+
 `-` alone is not a flag. It is a value, conventionally meaning stdin.
 
 ## Unrecognized flags

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -854,8 +854,8 @@ fn parse_partial_with_env(
             // first read: a token containing an unrecognized letter is not a bundle,
             // and recording it as one is what let `-a` be applied from a token that
             // never named it.
-            let is_bundle =
-                word.starts_with("--") || short_bundle_is_known(&out.available_flags, &word);
+            let is_bundle = word.starts_with("--")
+                || short_bundle_is_known(spec, &out.cmds, &out.available_flags, &word);
             if let Some(f) = out
                 .available_flags
                 .get(flag_key)
@@ -1282,7 +1282,7 @@ fn parse_partial_with_env(
             && w.len() > 1
             && is_flag_like(&w)
             && !positional_negative_number
-            && !short_bundle_is_known(&out.available_flags, &w)
+            && !short_bundle_is_known(spec, &out.cmds, &out.available_flags, &w)
         {
             // Refused if this command asked for that; otherwise it carries on below
             // as one word, with none of its letters applied.
@@ -1356,6 +1356,14 @@ fn parse_partial_with_env(
                     out.flags.insert(Arc::clone(f), ParseValue::Bool(value));
                 }
                 continue;
+            }
+            // The letter nothing declared may still be one the parser supplies, and it may
+            // sit anywhere in the token: `-hv` asks for help as surely as `-vh` does, and
+            // neither reaches the whole-token spellings below.
+            if let Some(err) = supplied_short(spec, &out.cmds, short) {
+                out.errors.push(err);
+                record_cursor(&mut out, next_arg_idx, seen_double_dash);
+                return Ok((out, overridden_flags));
             }
             if is_help_arg(spec, &out.cmd, &w) {
                 out.errors
@@ -2640,15 +2648,43 @@ impl<'a> ChoiceTarget<'a> {
 ///
 /// Scanning stops at the first letter whose flag takes a value, because everything
 /// after it is that value rather than more letters.
-fn short_bundle_is_known(available: &BTreeMap<String, Arc<SpecFlag>>, token: &str) -> bool {
+fn short_bundle_is_known(
+    spec: &Spec,
+    cmds: &[SpecCommand],
+    available: &BTreeMap<String, Arc<SpecFlag>>,
+    token: &str,
+) -> bool {
     for c in token.chars().skip(1) {
         match available.get(&format!("-{c}")) {
+            // `-h` and `-V` are recognized letters even though no spec declares them, so a
+            // bundle containing one is a bundle. Without this `-vh` was not read as one at
+            // all and fell through to `unexpected word`, while usage-argv, usage-go and
+            // clap all answer it with help.
+            None if supplied_short(spec, cmds, c).is_some() => {}
             None => return false,
             Some(f) if f.arg.is_some() => return true,
             Some(_) => {}
         }
     }
     true
+}
+
+/// The response `-h` or `-V` produces where nothing declares that letter.
+///
+/// The letter form of the flags the parser supplies rather than a spec declaring them,
+/// under exactly the conditions [`is_help_arg`] and [`is_version_arg`] state — asked
+/// about here one letter at a time, because a bundle is read one letter at a time.
+///
+/// Always the short response: `-h` is short help however many letters share its token,
+/// and `-V` the concise version. The long forms belong to the long spellings. `-?` is not
+/// here — it is a whole-token spelling of `-h` rather than a letter anyone bundles.
+fn supplied_short(spec: &Spec, cmds: &[SpecCommand], letter: char) -> Option<UsageErr> {
+    let cmd = cmds.last()?;
+    match letter {
+        'h' if is_help_arg(spec, cmd, "-h") => Some(render_help_err(spec, cmd, false)),
+        'V' if is_version_arg(spec, cmds, "-V") => Some(render_version_err(spec, false)),
+        _ => None,
+    }
 }
 
 /// Refuse a flag-like token that named nothing, if this command asked for that.
@@ -3398,6 +3434,99 @@ mod tests {
             parse(&spec, &input(&["ex", "-V"])).unwrap_err().to_string(),
             "1.2.3"
         );
+    }
+
+    #[test]
+    fn a_supplied_short_is_a_letter_a_bundle_may_contain() {
+        // `-h` and `-V` are recognized letters that no spec declares, so a token holding
+        // one beside a declared letter is a bundle. usage-lib alone read `-vh` as a word
+        // naming nothing: usage-argv and usage-go both resolve the letter through the
+        // same lookup that finds a declared short, and clap prints help for it too.
+        let spec: Spec =
+            "name \"ex\"\nbin \"ex\"\nversion \"1.2.3\"\nflag \"-v --verbose\"\ncmd \"run\"\n"
+                .parse()
+                .unwrap();
+
+        for token in ["-vh", "-hv"] {
+            let err = parse(&spec, &input(&["ex", token])).expect_err("help ends the parse");
+            assert!(err.to_string().starts_with("ex 1.2.3"), "{token}: {err}");
+        }
+        for token in ["-vV", "-Vv"] {
+            let err = parse(&spec, &input(&["ex", token])).expect_err("a version ends it too");
+            assert_eq!(err.to_string(), "1.2.3", "{token}");
+        }
+    }
+
+    #[test]
+    fn a_bundled_help_letter_asks_for_the_short_page() {
+        // Whatever else shares the token: `-h` is the short spelling, and the letters
+        // beside it say nothing about which page was asked for.
+        let spec: Spec = "name \"ex\"\nbin \"ex\"\nflag \"-v --verbose\" help=\"Be loud\" {\n    long_help \"Be loud, and say so at length.\"\n}\n"
+            .parse()
+            .unwrap();
+
+        let short = parse(&spec, &input(&["ex", "-vh"]))
+            .unwrap_err()
+            .to_string();
+        let long = parse(&spec, &input(&["ex", "--help"]))
+            .unwrap_err()
+            .to_string();
+        assert!(short.contains("Be loud"), "{short}");
+        assert!(!short.contains("at length"), "{short}");
+        assert!(long.contains("at length"), "{long}");
+    }
+
+    #[test]
+    fn the_bundled_version_letter_is_the_roots_alone() {
+        // The same rule the whole-token spelling follows, asked one letter at a time.
+        let spec: Spec =
+            "name \"ex\"\nbin \"ex\"\nversion \"1.2.3\"\nflag \"-v --verbose\" global=#true\ncmd \"run\"\n"
+                .parse()
+                .unwrap();
+
+        let err = parse(&spec, &input(&["ex", "run", "-vV"])).unwrap_err();
+        assert_eq!(err.to_string(), "unexpected word: -vV");
+    }
+
+    #[test]
+    fn a_declared_letter_keeps_its_meaning_inside_a_bundle() {
+        // Nothing is supplied where the CLI spent the letter itself, so `-vh local` is
+        // this spec's own `-h`, taking its value from the rest of the token.
+        let spec: Spec =
+            "name \"ex\"\nbin \"ex\"\nversion \"1.2.3\"\nflag \"-v --verbose\"\nflag \"-h --host <host>\"\n"
+                .parse()
+                .unwrap();
+
+        let out = parse(&spec, &input(&["ex", "-vhlocal"])).expect("a bundle and its value");
+        assert_eq!(out.flags.len(), 2);
+        assert!(out
+            .flags
+            .iter()
+            .any(|(flag, value)| flag.name == "host" && value.to_string() == "local"));
+    }
+
+    #[test]
+    fn disabling_help_takes_the_letter_back_out_of_the_bundle() {
+        let spec: Spec =
+            "name \"ex\"\nbin \"ex\"\ndisable_help_flag #true\nflag \"-v --verbose\"\n"
+                .parse()
+                .unwrap();
+
+        let err = parse(&spec, &input(&["ex", "-vh"])).unwrap_err();
+        assert_eq!(err.to_string(), "unexpected word: -vh");
+    }
+
+    #[test]
+    fn a_letter_nothing_supplies_still_refuses_the_whole_bundle() {
+        // The rule this must not weaken: `-az` is not a bundle at all, so `-a` is not set
+        // on the way to discovering that `z` names nothing.
+        let spec: Spec = "name \"ex\"\nbin \"ex\"\nflag \"-a --all\"\narg \"[file]\"\n"
+            .parse()
+            .unwrap();
+
+        let out = parse(&spec, &input(&["ex", "-az"])).expect("it falls through to the argument");
+        assert!(out.flags.is_empty(), "{:?}", out.flags);
+        assert_eq!(out.args.len(), 1);
     }
 
     fn spec_with_arg(arg: SpecArg) -> Spec {


### PR DESCRIPTION
Follow-up to the `-vh` question raised in review on #1168. Stacked on that branch, because the `-V` half needs the supplied version flag that lands there; the diff here is one commit.

## The bug

`-vh` was refused as an unknown word wherever `-h` was not declared:

```
$ demo -vh
unexpected word: -vh
```

`short_bundle_is_known` asks whether every letter names a declared flag, on the grammar's rule that a token containing an unrecognized letter is not a bundle at all. But `-h` **is** recognized — the parser supplies it, as it supplies `-V` on a root that declares a version — so the token was a bundle and the check was reading it against the wrong set. The peeling machinery below it was always fine: `-v` applies and pushes `-h` back, which the whole-token spelling then answers. It simply never got there.

## Who else was already right

| | `-vh` |
| --- | --- |
| usage-argv | help |
| usage-go | help |
| clap | help |
| **usage-lib** | **`unexpected word: -vh`** |

Both other implementations resolve the letter through the same lookup that finds a declared short (`find_short` in `argv/src/lib.rs`, `findShort` in `go/argv/parser.go`, each falling back to a supplied `HELP_SHORT`/`VERSION_SHORT`). usage-lib is the implementation the corpus measures the others against, and it was the one that disagreed — the same shape as the `--version` divergence in the commit below it, and unseen for the same reason: the binding corpus has no vocabulary for an invocation that prints and exits, so nothing measures these at all.

## What changed

- `short_bundle_is_known` counts a supplied `-h` or `-V` as a recognized letter, under exactly the conditions `is_help_arg` and `is_version_arg` already state — asked one letter at a time, because a bundle is read one letter at a time.
- The letter is answered wherever it sits, so `-hv` asks for help as surely as `-vh` does. Neither reached the whole-token spellings that handled `-h` alone.
- Always the short response: `-h` is short help however many letters share its token, and `-V` the concise version. The long forms belong to the long spellings.
- `-?` stays a whole-token spelling rather than a letter anyone bundles, and `-V` keeps its root-only rule — `demo run -vV` is still refused.

Two rules deliberately unweakened, both tested:

- **A declared letter keeps its meaning.** Nothing is supplied where the CLI spent the letter, so a `-h` meaning `--host` still reads `-vhlocal` as a bundle and its value.
- **A letter nothing supplies still refuses the whole bundle.** `-az` sets nothing on the way to discovering that `z` names nothing, which is what the corpus pins in `short-bundle-unknown-letter-applies-nothing`.

`disable_help_flag` takes the letter back out, and that is tested too.

## The grammar

`docs/spec/argv.md` said nothing about supplied letters anywhere — which is what left three implementations agreeing by coincidence and one disagreeing without anything noticing. The section that states the bundle rule now states this one beside it.

## Observed, not fixed

While testing value-taking shorts: `-jh` on a spec declaring `-j <n>` errors with `Invalid flag --jobs: requires an argument` in usage-lib, while usage-argv binds `jobs = "h"` — which is what the grammar's own table says (`-j8` takes the rest of the token). Present on `main`, unchanged by this PR, and a different mechanism: the pushed-back remainder is refused as a pending value for looking flag-like. Worth its own change.

## Testing

Six cases in `lib/src/parse.rs` covering both letters, both orders, the short-page rule, the root-only rule for `-V`, a declared letter winning, `disable_help_flag`, and the unchanged `-az`. `cargo test --all --all-features` passes (1,990), clippy and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes argv binding for help/version shorts, which is user-facing CLI behavior, but the rules are narrow and covered by tests.
> 
> **Overview**
> Treats parser-supplied `-h` and `-V` as recognized short letters so tokens like `-vh` and `-hv` are real bundles that print help or version, matching usage-argv, usage-go, and clap.
> 
> `short_bundle_is_known` now counts those letters under the same conditions as `is_help_arg` / `is_version_arg`. The letter is answered wherever it sits, always as the short help page or concise version. A declared `-h` still wins (`-vhlocal` as `--host`), unknown letters still refuse the whole token (`-az`), and `disable_help_flag` / root-only `-V` stay as they were.
> 
> The argv grammar now states this beside the bundle rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13b278ab129e754ca9f5cec21c5be6fe29a7cdff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->