### PR TITLE
feat(spec): answer __usage_spec__ from a binary's own tables

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1450,7 +1450,9 @@ share of clap's top-voted open requests is usage's existing feature set:
   discussion clap#6491 asking for schemas AI agents can read) — the spec _is_
   the export, `effect` is the safety vocabulary an agent wants, and usage-cli
   renders JSON already. clap#6026 was closed with advice to "implement your
-  own argument parser" — which is this project.
+  own argument parser" — which is this project. **And the binary now hands it
+  over itself** — see the endpoint item below, which is what makes this an
+  answer for a tool in front of somebody else's CLI rather than for its author.
 
 When the migration guide is written, a "top clap feature requests that just
 work here" section is cheap and persuasive; the launch-gate documentation items
@@ -1458,6 +1460,36 @@ above are where it lands.
 
 **Worth building, demand attached:**
 
+- [x] **A binary that describes itself** (clap#918, clap#6491) — `__usage_spec__`,
+      answered from the same static tables the parser reads, in every binary that
+      does not opt out. The gap was never `to_kdl`: it was that getting a spec
+      _out_ of a CLI was a convention each adopter reimplemented, which the docs
+      taught as `#[usage(long, hide)] usage_spec: bool` — so no tool in front of
+      somebody else's CLI could rely on it, which is the only position that
+      matters for `usage g …`, `usage lint`, `usage mcp` and an agent reading
+      `effect`. Four decisions, settled 2026-08-21. **A hidden word, not a
+      flag**, for the reason `__complete_word__` is one: a request is not
+      something the CLI _does_, so it is answered before the parse, stays out of
+      the tables, cannot collide with an adopter's flags, and does not perturb
+      the document it prints. **On by default**, which is the whole point — an
+      opt-in nobody remembers to write is an endpoint nothing can rely on — with
+      a declaration of that spelling winning (checked against the tables, since a
+      `Cli` derive cannot see a separate `Subcommands` enum's variants) and
+      `spec_endpoint = false` for a binary counting bytes, worth 65KB on a small
+      CLI. **KDL only**, since `usage g json -f -` converts and a hand-rolled
+      serializer in a dependency-free crate would be a second emitter to keep in
+      step with the serde-derived shape.
+      **`spec_extra`** appends a file's KDL to `to_kdl()` for a node no attribute
+      carries. It was built for usage-cli's `repository` and
+      `source_code_link_template`, and #1184 gave both of those real attributes
+      while this was in review — which is the canonicality rule working as
+      intended, and leaves the hook with no in-tree user. Kept as the escape
+      hatch rather than removed, and documented as one; reconsider if nothing
+      needs it. usage-cli answers both spellings, reaching the endpoint through
+      `is_spec_request` because it renders its own output rather
+      than calling `parse()`. Not projected through a `view`: the document already
+      declares every view, so projecting would hand a tool a lossier spec
+      depending on which name launched the process.
 - [x] **Subcommand help headings** (clap#1553, 38 votes) — `help_heading`
       landed for flags and arguments; this is the same property on `cmd` nodes,
       so a 210-command CLI can group its help into sections. mise is the

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -1064,6 +1064,29 @@ pub fn render_warnings(warnings: &[warn::Warning<'_>]) -> String {
     warn::render_warnings(warnings)
 }
 
+/// The word a tool sends to ask a binary for its own spec.
+///
+/// Not a flag and not a command: a spec request is not something this CLI *does*, so it is
+/// answered before the parse and stays out of the tables — the same reason
+/// `__complete_word__` is a word rather than a subcommand. It also keeps the endpoint from
+/// perturbing the document it prints, which a declared flag would not.
+pub const SPEC_REQUEST: &str = "__usage_spec__";
+
+/// Whether this argv asks for the spec rather than for the CLI to run.
+///
+/// Only the first word counts: `mycli build __usage_spec__` passes the word through as an
+/// ordinary value, because a request is the whole invocation or it is nothing.
+///
+/// A root that declares a command of that name keeps it, which is the precedence the `help`
+/// subcommand already has. The check is here rather than in the derive because a `Cli` derive
+/// expands one struct and cannot see the variant names of a separate `Subcommands` enum — the
+/// static tables can.
+pub fn is_spec_request(root: &Command<'_>, argv: &[&OsStr]) -> bool {
+    let [first, ..] = argv else { return false };
+    first.as_encoded_bytes() == SPEC_REQUEST.as_bytes()
+        && find_named(root, SPEC_REQUEST.as_bytes()).is_none()
+}
+
 /// Whether a flag is one of the two the parser supplies rather than the CLI declaring it.
 pub fn is_help_flag(flag: &Flag<'_>) -> bool {
     matches!(
@@ -4105,5 +4128,48 @@ mod tests {
             multicall_applet("busybox.exe", "BusyBox", Some("busybox.exe")),
             None
         );
+    }
+
+    #[test]
+    fn a_spec_request_is_the_first_word_and_nothing_else() {
+        let request = [OsStr::new(SPEC_REQUEST)];
+        assert!(is_spec_request(&ROOT, &request));
+
+        // Anywhere but the front it is an ordinary value, which is what makes the endpoint
+        // safe for a CLI whose arguments are arbitrary text.
+        let later = ["install", SPEC_REQUEST].map(OsStr::new);
+        assert!(!is_spec_request(&ROOT, &later));
+        assert!(!is_spec_request(&ROOT, &[]));
+        assert!(!is_spec_request(&ROOT, &[OsStr::new("--help")]));
+    }
+
+    #[test]
+    fn a_declared_command_of_that_name_keeps_it() {
+        static DECLARED: Command = Command {
+            name: SPEC_REQUEST,
+            key: 200,
+            ..Command::EMPTY
+        };
+        static ALIASED: Command = Command {
+            name: "describe",
+            aliases: &[SPEC_REQUEST],
+            key: 201,
+            ..Command::EMPTY
+        };
+        static DECLARES_IT: Command = Command {
+            name: "ex",
+            subcommands: &[&DECLARED],
+            ..Command::EMPTY
+        };
+        static ALIASES_IT: Command = Command {
+            name: "ex",
+            subcommands: &[&ALIASED],
+            ..Command::EMPTY
+        };
+
+        let request = [OsStr::new(SPEC_REQUEST)];
+        assert!(!is_spec_request(&DECLARES_IT, &request));
+        // An alias selects a command just as its name does, so it wins here too.
+        assert!(!is_spec_request(&ALIASES_IT, &request));
     }
 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -39,7 +39,14 @@ pub fn run(args: &[String]) -> Result<()> {
             // copies of the crate name, which is not what this binary is called.
             println!("{}", cli::version());
             return Ok(());
-        } else if script == "--usage-spec" {
+        } else if script == "--usage-spec"
+            // The built-in endpoint, answered here rather than by the generated `parse()`:
+            // this CLI hands its command line to `parse_from` and renders its own output, so
+            // nothing generated is ever in a position to intercept. Asked of the runtime so
+            // the spelling and the declaration-wins rule have one definition, and answered
+            // through `generate` so both spellings print the same document.
+            || usage_rs::is_spec_request(Cli::command(), &[std::ffi::OsStr::new(script)])
+        {
             return usage_spec::generate();
         } else if script == "--completions" && args.len() > 2 {
             return usage_spec::complete(args.get(2).unwrap());

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -325,6 +325,8 @@ pub fn emit(cli: &Cli) -> TokenStream {
     let apply = apply_fn(cli);
     let post = post_binding(cli);
     let (completion, completion_intercept) = completion_fns(cli);
+    let spec_extra = spec_extra_append(cli);
+    let (spec_endpoint, spec_endpoint_intercept) = spec_endpoint_fns(cli);
     // `field: local` rather than the shorthand, because the locals are prefixed:
     // a field called `text` or `parser` would otherwise collide with something the
     // generated code needs.
@@ -848,8 +850,13 @@ pub fn emit(cli: &Cli) -> TokenStream {
                 /// This CLI's spec as KDL, which is what `usage g markdown|manpage`
                 /// and the completion generators read.
                 pub fn to_kdl() -> ::std::string::String {
-                    SPEC.to_kdl()
+                    #[allow(unused_mut)]
+                    let mut __usage_kdl = SPEC.to_kdl();
+                    #spec_extra
+                    __usage_kdl
                 }
+
+                #spec_endpoint
 
                 #settings_binding_forward
                 #settings_parse
@@ -1042,6 +1049,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
                         ::std::env::args_os().collect();
                     let __usage_all_refs: ::std::vec::Vec<&::std::ffi::OsStr> =
                         __usage_all.iter().map(|a| a.as_os_str()).collect();
+                    #spec_endpoint_intercept
                     let __usage_raw: ::std::vec::Vec<::std::ffi::OsString> =
                         if let ::std::option::Option::Some((__usage_argv0, __usage_words)) =
                             __usage_all_refs.split_first()
@@ -1282,6 +1290,81 @@ fn unknown_flags_tokens(cli: &Cli) -> TokenStream {
         )),
         None => quote!(::core::option::Option::None),
     }
+}
+
+/// The `spec_extra` tail, appended to the emitted document.
+///
+/// Appended rather than merged: this crate does not parse KDL, so extra nodes join the document
+/// and not the model. Both `to_kdl` and the endpoint read the same function, so a checked-in
+/// artifact and what the binary hands a tool cannot differ.
+fn spec_extra_append(cli: &Cli) -> TokenStream {
+    let Some(path) = cli.spec_extra.as_deref() else {
+        return TokenStream::new();
+    };
+    quote! {
+        {
+            // Resolved in the declaring crate, which is where the path was written.
+            const __USAGE_SPEC_EXTRA: &str = ::core::include_str!(::core::concat!(
+                ::core::env!("CARGO_MANIFEST_DIR"),
+                "/",
+                #path,
+            ));
+            let __usage_extra = __USAGE_SPEC_EXTRA.trim();
+            if !__usage_extra.is_empty() {
+                __usage_kdl = ::std::format!(
+                    "{}\n{}\n",
+                    __usage_kdl.trim_end(),
+                    __usage_extra,
+                );
+            }
+        }
+    }
+}
+
+/// The spec endpoint, which every CLI has unless it says otherwise.
+///
+/// Two pieces, the same shape as the completion pair below: a function that answers, and the line
+/// in `parse` that notices. On by default because the point of it is that a tool can ask *any*
+/// usage binary for its spec — an endpoint each adopter has to remember to enable is one no
+/// external tool can rely on. `spec_endpoint = false` is the way out for a binary that does not
+/// want to carry the KDL writer.
+fn spec_endpoint_fns(cli: &Cli) -> (TokenStream, TokenStream) {
+    if !cli.spec_endpoint {
+        return (TokenStream::new(), TokenStream::new());
+    }
+    let functions = quote! {
+        /// This CLI's own spec, when argv asks for it.
+        ///
+        /// `Some` for a command line whose first word is `usage_argv::SPEC_REQUEST`, and `None`
+        /// for an ordinary invocation — including one that names a command of that spelling,
+        /// which keeps a declaration ahead of the built-in. Takes the command line *without*
+        /// the program name, like [`Self::parse_from`].
+        ///
+        /// [`Self::parse`] answers it and exits. An embedder that renders its own output, or
+        /// wants to refuse the request, calls this instead.
+        pub fn spec_request(
+            argv: &[&::std::ffi::OsStr],
+        ) -> ::std::option::Option<::std::string::String> {
+            if usage_argv::is_spec_request(Self::command(), argv) {
+                ::std::option::Option::Some(Self::to_kdl())
+            } else {
+                ::std::option::Option::None
+            }
+        }
+    };
+    let intercept = quote! {
+        // Before the view and multicall rewrites below, for the reason a completion request is
+        // answered before the parse: asking what this CLI *is* is not one of the things it does,
+        // so its grammar has no say. Reads the argv already collected, so the endpoint costs one
+        // comparison and no allocation.
+        if let ::std::option::Option::Some(__usage_answer) =
+            Self::spec_request(__usage_all_refs.get(1..).unwrap_or(&[]))
+        {
+            ::std::print!("{__usage_answer}");
+            usage_argv::__usage_process_exit(0);
+        }
+    };
+    (functions, intercept)
 }
 
 /// The completion entry points, for a CLI that asked for them.

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -55,6 +55,24 @@ pub struct Cli {
     /// generator is emitted under the same flag, which makes a script that calls a command the
     /// binary lacks a compile error rather than a puzzle at the prompt.
     pub completion: bool,
+    /// Whether this CLI answers `__usage_spec__` with its own spec.
+    ///
+    /// On unless a CLI says otherwise, which is the opposite of `completion` and deliberate: the
+    /// point of the endpoint is that a tool can ask *any* usage binary, and an opt-in nobody
+    /// remembers to write is an endpoint nothing can rely on. `spec_endpoint = false` is for a
+    /// binary that does not want to carry the KDL writer at all.
+    pub spec_endpoint: bool,
+    /// A file whose KDL is appended to the emitted spec.
+    ///
+    /// The escape hatch for a node no attribute carries, so a CLI that needs one keeps a single
+    /// spec rather than a generated one plus a hand-edited copy. It has no in-tree user: this was
+    /// written for usage-cli's `source_code_link_template`, and that gained a real attribute
+    /// (#1184) while this was in review — the canonicality rule preferring vocabulary over a
+    /// hatch, which is the right outcome even though it leaves this unused.
+    ///
+    /// Read at compile time relative to the declaring crate; its content is never parsed here, so
+    /// the round-trip test on the emitted document is what catches a bad file.
+    pub spec_extra: Option<String>,
     /// Whether this CLI resolves settings, when nothing on the root itself says so.
     ///
     /// Only needed when every bound flag lives in a flattened group: the root cannot see another
@@ -664,6 +682,8 @@ impl Cli {
             runtime_name: None,
             runtime_bin: None,
             completion: false,
+            spec_endpoint: true,
+            spec_extra: None,
             settings: false,
             dispatch: Dispatch::default(),
             min_usage_version: None,
@@ -790,6 +810,8 @@ impl Cli {
                     // means false rather than being read as the bare word with something
                     // decorative after it.
                     "completion" => cli.completion = flag_value(&meta)?,
+                    "spec_endpoint" => cli.spec_endpoint = flag_value(&meta)?,
+                    "spec_extra" => cli.spec_extra = Some(string_value(&meta)?),
                     "settings" => cli.settings = flag_value(&meta)?,
                     "run" => cli.dispatch.run = flag_value(&meta)?,
                     "run_with" => cli.dispatch.run_with = flag_value(&meta)?,

--- a/docs/rust/index.md
+++ b/docs/rust/index.md
@@ -142,30 +142,20 @@ are the async pair. See [Dispatch](/rust/dispatch).
 ## One declaration, every artifact
 
 Because the derive also emits a usage spec, everything on this site that consumes a spec works
-with your CLI. The pattern `usage-cli` itself ships is a hidden flag that prints the spec:
-
-```rust
-#[usage(long, hide)]
-usage_spec: bool,
-```
-
-```rust
-if cli.usage_spec {
-    println!("{}", Cli::to_kdl().trim());
-    return;
-}
-```
-
-Then generate everything else from it:
+with your CLI — and you do not have to wire anything up for it. Every binary answers
+`__usage_spec__` with its own spec:
 
 ```bash
-mycli --usage-spec > mycli.usage.kdl
+mycli __usage_spec__ > mycli.usage.kdl
 usage g markdown -f mycli.usage.kdl --out-dir docs
 usage g manpage -f mycli.usage.kdl > mycli.1
 usage g completion bash mycli --file mycli.usage.kdl
 ```
 
-See [Spec output](/rust/spec) for the round-trip guarantees and what the emitted KDL looks like.
+`Cli::to_kdl()` is the same document in-process, for a build script or a checked-in artifact.
+
+See [Spec output](/rust/spec) for the round-trip guarantees, what the emitted KDL looks like, and
+how to opt out of the endpoint.
 
 ## Where to go next
 

--- a/docs/rust/spec.md
+++ b/docs/rust/spec.md
@@ -56,25 +56,66 @@ Beyond parsing, `to_kdl` asserts (in debug builds) that the tree is coherent: no
 no duplicate flag spellings across a `flatten` boundary, no duplicate group names, no unfillable
 argument after an unbounded variadic. Those fire in your test, not on users.
 
-## Feeding usage-cli
+## The endpoint
 
-The pattern usage-cli itself ships is a hidden flag that prints the spec, so the binary is the
-source of truth:
-
-```rust
-#[usage(long, hide)]
-usage_spec: bool,
-```
+Every binary answers `__usage_spec__` with its own spec. You do not declare it, and there is
+nothing to wire up:
 
 ```bash
-mycli --usage-spec > mycli.usage.kdl
+mycli __usage_spec__ > mycli.usage.kdl
 
 usage g markdown -f mycli.usage.kdl --out-dir docs   # markdown docs
 usage g manpage  -f mycli.usage.kdl > mycli.1        # man page
 usage g completion bash mycli --file mycli.usage.kdl # completion script
 usage g json     -f mycli.usage.kdl                  # JSON form
-usage lint       -f mycli.usage.kdl                  # lint the spec
+usage lint          mycli.usage.kdl                  # lint the spec
+usage mcp        -f mycli.usage.kdl                  # serve it to an agent
 ```
+
+It is a word rather than a flag, and it is answered before the parse — so it is not in your
+tables, cannot collide with a flag of yours, and does not appear in the document it prints. A
+command line whose first word is `__usage_spec__` is the request; anywhere else the word is an
+ordinary value. If your CLI declares a command of that spelling, yours wins.
+
+KDL is the only format the binary emits. Pipe it through `usage g json -f -` for JSON: a second
+serializer in every adopter's binary is a cost the conversion does not need.
+
+A CLI in another language has no derive to generate this, so the convention there stays a flag
+its author intercepts — `--usage-spec`, as in the [cobra guide](/spec/integrations/cobra).
+usage-cli answers both, being both a Rust CLI and the tool that documented the flag first.
+
+Three ways in, for the three shapes a program takes:
+
+| you write                  | you get                                                               |
+| -------------------------- | --------------------------------------------------------------------- |
+| `Cli::parse()`             | the endpoint, answered and exited, before anything else               |
+| `Cli::spec_request(&argv)` | `Some(kdl)` for a request, so an embedder renders it itself           |
+| `Cli::to_kdl()`            | the document, in-process, for a build script or a checked-in artifact |
+
+`#[usage(spec_endpoint = false)]` removes it, for a CLI counting bytes. What it costs is the KDL
+writer and the cold metadata being reachable from `main`, which is **65 KB** on a small CLI
+(773,424 against 708,768 bytes, stripped release, four flags and two subcommands). A CLI that
+calls `to_kdl()` for a checked-in artifact links the same code and pays nothing extra for the
+endpoint. `to_kdl()` itself stays either way — opting out removes the entry point, not the ability
+to emit a spec.
+
+### Appending raw KDL
+
+Every node the derive can say, it says — see [what can't be
+expressed](#what-can-t-be-expressed-from-the-derive), which is nearly nothing. `spec_extra` is
+there for when that is not enough, and appends a file's KDL to the emitted document:
+
+```rust
+#[derive(usage::Cli)]
+#[usage(bin = "mycli", spec_extra = "assets/mycli-extra.usage.kdl")]
+struct Cli { /* … */ }
+```
+
+The path is relative to the crate that declares it, and the file is read at compile time. It joins
+`to_kdl()` itself, so the endpoint, a checked-in artifact and your docs build all see one
+document. Nothing parses the appended text while compiling — the [round-trip
+test](#round-trip-guarantee) above is what catches a file with a mistake in it, so write that test
+if you use this.
 
 `min_usage_version = "…"` on the root is written first in the document, as the CLI's claim about
 which usage consumers can read it.
@@ -135,9 +176,12 @@ help pages through both.
 
 ## What can't be expressed from the derive
 
-Nothing, as of `example`: every node the spec format defines now has a derive attribute. That is
+Nearly nothing, as of `example`: every node a command declares now has a derive attribute. That is
 the rule this project holds itself to — a typed declaration must lower into the spec losslessly,
 and where it cannot, the derive gains the vocabulary rather than the spec losing it.
 
-The one property that does not carry over is an example's `lang`, which picks syntax
-highlighting for a KDL-authored example and has nothing to choose between in Rust.
+The one property that does not carry over is an example's `lang`, which picks syntax highlighting
+for a KDL-authored example and has nothing to choose between in Rust.
+
+[`spec_extra`](#appending-raw-kdl) is the escape hatch if that ever stops being true for something
+you need. Nothing in this repository uses it.

--- a/usage-rs/tests/external.rs
+++ b/usage-rs/tests/external.rs
@@ -76,3 +76,31 @@ fn direct_dependencies_win_in_a_mixed_configuration() {
 fn workspace_inherited_facade_is_resolved() {
     run_fixture("workspace-inheritance");
 }
+
+/// The endpoint at process level, which is the half `spec_request` unit tests cannot reach.
+///
+/// This fixture is the right one to ask: it declares `unknown_flags = "error"` and takes no
+/// arguments at all, so any ordinary word is a failure — which is how the control below shows
+/// that the request is answered *before* the grammar sees it rather than by passing through it.
+#[test]
+fn a_spec_request_is_answered_before_the_parse() {
+    let control = fixture_output("runtime-identity", &["ordinary-word"]);
+    assert_eq!(
+        control.status.code(),
+        Some(2),
+        "a word this CLI does not accept must fail, or the assertion below proves nothing"
+    );
+
+    let spec = fixture_output("runtime-identity", &["__usage_spec__"]);
+    assert!(
+        spec.status.success(),
+        "{}",
+        String::from_utf8_lossy(&spec.stderr)
+    );
+    let out = String::from_utf8_lossy(&spec.stdout);
+    // The portable identity, not the runtime one: a tool asking a binary for its spec wants
+    // the deterministic document, not what this process happens to be called.
+    assert!(out.contains("name portable-ex"), "{out}");
+    assert!(out.contains("version \"6.0.0\""), "{out}");
+    assert!(!out.contains("runtime-ex"), "{out}");
+}

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -2650,3 +2650,164 @@ fn the_facade_exposes_the_dispatch_traits() {
     assert!(!ex.command.run_with(&mut calls));
     assert_eq!(calls, 1);
 }
+
+/// A CLI declaring nothing about the endpoint, which is how most of them will look.
+#[derive(Cli)]
+#[usage(bin = "endpoint-ex", version = "1.0.0")]
+struct EndpointEx {
+    #[usage(long)]
+    force: bool,
+    #[usage(subcommand)]
+    command: EndpointCommand,
+}
+
+#[derive(Subcommands)]
+enum EndpointCommand {
+    /// Build the thing.
+    Build {
+        #[usage(long)]
+        release: bool,
+    },
+}
+
+#[test]
+fn a_spec_request_is_answered_from_the_binary_s_own_tables() {
+    let answer = EndpointEx::spec_request(&[OsStr::new(usage::SPEC_REQUEST)])
+        .expect("the endpoint is on unless a CLI says otherwise");
+    assert_eq!(answer, EndpointEx::to_kdl());
+
+    // What a tool receives has to be a spec, not merely a string: this is the whole contract
+    // of the endpoint, so it is checked through usage-lib rather than by grepping.
+    let spec: usage_parser::Spec = answer.parse().expect("the endpoint should emit a spec");
+    assert_eq!(spec.bin, "endpoint-ex");
+    assert!(spec.cmd.subcommands.contains_key("build"), "{spec:?}");
+}
+
+#[test]
+fn an_ordinary_command_line_is_not_a_spec_request() {
+    assert!(EndpointEx::spec_request(&[]).is_none());
+    assert!(EndpointEx::spec_request(&[OsStr::new("--force")]).is_none());
+
+    // And what is not a request still parses as it always did, which is the half worth
+    // checking on a CLI that gained an entry point it never declared.
+    let argv = ["--force", "build", "--release"].map(OsStr::new);
+    let cli = EndpointEx::parse_from(&argv).expect("valid command line");
+    assert!(cli.force);
+    let EndpointCommand::Build { release } = cli.command;
+    assert!(release);
+
+    // Not the first word, so it is an ordinary value — which is what keeps the endpoint from
+    // eating an argument of a CLI whose arguments are arbitrary text.
+    let later = ["build", usage::SPEC_REQUEST].map(OsStr::new);
+    assert!(EndpointEx::spec_request(&later).is_none());
+}
+
+/// A CLI that declares the spelling itself. Contrived, and the point: a declaration wins.
+#[derive(Cli)]
+#[usage(bin = "declares-ex")]
+struct DeclaresEndpointEx {
+    #[usage(subcommand)]
+    command: DeclaresEndpointCommand,
+}
+
+#[derive(Subcommands)]
+enum DeclaresEndpointCommand {
+    /// Whatever this CLI meant by it.
+    #[usage(name = "__usage_spec__")]
+    UsageSpec {
+        #[usage(long)]
+        mine: bool,
+    },
+}
+
+#[test]
+fn a_declared_command_of_that_name_outranks_the_endpoint() {
+    assert!(DeclaresEndpointEx::spec_request(&[OsStr::new(usage::SPEC_REQUEST)]).is_none());
+    // And it still parses as the command it declared, which is the behavior being protected.
+    let cli =
+        DeclaresEndpointEx::parse_from(&[OsStr::new(usage::SPEC_REQUEST), OsStr::new("--mine")])
+            .expect("the declared command should still parse");
+    let DeclaresEndpointCommand::UsageSpec { mine } = cli.command;
+    assert!(mine);
+}
+
+/// A CLI that does not want to carry the KDL writer at all.
+#[derive(Cli)]
+#[usage(bin = "opted-out-ex", spec_endpoint = false)]
+struct OptedOutEx {
+    #[usage(long)]
+    force: bool,
+}
+
+#[test]
+fn opting_out_leaves_the_spec_itself_alone() {
+    // No `spec_request` is generated — absence is a compile-time property, so what is checked
+    // here is that opting out costs nothing else: the spec and the parse are unchanged.
+    let kdl = OptedOutEx::to_kdl();
+    assert!(kdl.contains("name opted-out-ex"), "{kdl}");
+    let _: usage_parser::Spec = kdl.parse().expect("opting out should not change the spec");
+    let cli = OptedOutEx::parse_from(&[OsStr::new("--force")]).expect("valid command line");
+    assert!(cli.force);
+}
+
+/// The nodes no attribute carries yet, appended from a file beside this test.
+#[derive(Cli)]
+#[usage(bin = "extra-ex", spec_extra = "tests/spec-extra.usage.kdl")]
+struct SpecExtraEx {
+    #[usage(long)]
+    force: bool,
+}
+
+#[test]
+fn spec_extra_joins_the_document_the_endpoint_hands_over() {
+    let kdl = SpecExtraEx::to_kdl();
+    assert!(kdl.contains("name extra-ex"), "{kdl}");
+    assert!(kdl.contains("example \"extra --help\""), "{kdl}");
+
+    // One document, so a tool asking the binary sees the appended nodes too — that is the
+    // reason the hook is on `to_kdl` rather than on the endpoint alone.
+    let answer = SpecExtraEx::spec_request(&[OsStr::new(usage::SPEC_REQUEST)])
+        .expect("the endpoint should answer");
+    assert_eq!(answer, kdl);
+
+    // And the join has to leave something usage-lib can still read, since nothing validated
+    // the appended text at compile time.
+    let spec: usage_parser::Spec = answer.parse().expect("the joined document should parse");
+    assert_eq!(spec.examples.len(), 1);
+    assert_eq!(spec.examples[0].code, "extra --help");
+
+    // Appending nodes to the document changes nothing about the declaration that produced it.
+    let cli = SpecExtraEx::parse_from(&[OsStr::new("--force")]).expect("valid command line");
+    assert!(cli.force);
+}
+
+/// mise's root shape: an unmatched word is a task name rather than a mistake.
+///
+/// This is the one CLI shape where the endpoint changes what a command line means, so the
+/// boundary is pinned rather than argued about. `__complete_word__` already shadows the same
+/// task-name space in the same CLI, which is the precedent the spelling was chosen against.
+#[derive(Cli)]
+#[usage(bin = "task-ex", default_subcommand = "run")]
+struct DefaultSubcommandEx {
+    #[usage(subcommand)]
+    command: DefaultSubcommandCommand,
+}
+
+#[derive(Subcommands)]
+enum DefaultSubcommandCommand {
+    /// Run a task by name.
+    Run { task: String },
+}
+
+#[test]
+fn the_endpoint_wins_over_default_subcommand_routing() {
+    // Any other word still routes to `run`, which is what makes the next assertion a statement
+    // about the endpoint rather than about a CLI that routes nothing.
+    let cli = DefaultSubcommandEx::parse_from(&[OsStr::new("build")]).expect("valid command line");
+    let DefaultSubcommandCommand::Run { task } = cli.command;
+    assert_eq!(task, "build");
+
+    // The request is answered instead of being routed to `run` as a task of that name. A CLI
+    // that wants the word back declares it, or sets `spec_endpoint = false`.
+    assert!(DefaultSubcommandEx::spec_request(&[OsStr::new(usage::SPEC_REQUEST)]).is_some());
+}

--- a/usage-rs/tests/spec-extra.usage.kdl
+++ b/usage-rs/tests/spec-extra.usage.kdl
@@ -1,0 +1,3 @@
+// Appended to the derived spec by `#[usage(spec_extra = ...)]`. These are the nodes no
+// attribute carries yet, which is the whole reason the hook exists.
+example "extra --help" header="Getting help" help="What a spec_extra node looks like"


### PR DESCRIPTION
## The gap

`Cli::to_kdl()` has always emitted a complete spec. What was missing is that nothing *served* it: getting a spec out of a usage-built CLI was a convention each adopter reimplemented. The docs taught it as a hand-rolled flag (`docs/rust/spec.md`, `docs/rust/index.md`, and the [cobra guide](docs/spec/integrations/cobra.md) for Go), and usage-cli hand-rolled exactly that — a raw argv check in `cli/src/lib.rs` plus a declared `usage_spec: bool` field.

A convention each adopter writes is one an external tool cannot rely on, and the consumers here are not the adopter: `usage g markdown|manpage|json|completion`, `usage lint`, `usage mcp`, and an agent that wants `effect` before it runs something. clap#918 (open since 2017) and clap#6491 are people asking clap for this. usage's answer is that the spec *is* the export — which only holds if every binary hands it over without its author writing code.

## What this does

Every binary answers `__usage_spec__` with its own spec, from the same static tables the parser reads.

```bash
mycli __usage_spec__ | usage g markdown -f - --out-dir docs
```

Four decisions behind it:

- **A hidden word, not a flag**, for the reason `__complete_word__` is one: a request is not something the CLI *does*, so it is answered before the parse, stays out of the tables, cannot collide with an adopter's flags, and does not perturb the document it prints. Only the first word counts; anywhere else it is an ordinary value.
- **On by default** — an opt-in nobody remembers to write is an endpoint nothing can rely on. A declared command of that spelling wins, checked against the tables rather than in the derive, because a `Cli` derive expands one struct and cannot see a separate `Subcommands` enum's variants. `#[usage(spec_endpoint = false)]` opts out.
- **KDL only.** `usage g json -f -` converts. A hand-rolled serializer in a dependency-free crate would be a second emitter to keep in step with the serde-derived shape.
- **`spec_extra`** appends a file's KDL to `to_kdl()` for a node no attribute carries — a deliberate escape hatch, and see the note below on why it currently has no in-tree user.

Three entry points, for the three shapes a program takes: `parse()` answers and exits; `spec_request(&argv)` hands the document back to an embedder that renders its own output; `to_kdl()` is the same document in-process.

## usage-cli, and what happened to `spec_extra`

This was written with usage-cli adopting `spec_extra` for its own `repository` and `source_code_link_template` nodes, which it had been stitching onto the spec after the fact. While the PR was in review, **#1184 landed `source_code_link_template` as a real derive attribute** and deleted that fragment — so usage-cli no longer needs the hook, and `spec_extra` ships with no in-tree user beyond its own test.

That is the canonicality rule working exactly as written: where a declaration cannot lower into the spec, the derive gains the vocabulary rather than the spec losing it. An escape hatch was the weaker answer and the stronger one arrived first. Kept anyway, as a deliberate hatch, and the docs say plainly that nothing here uses it — happy to drop it instead if you would rather not carry an unused attribute.

usage-cli's spec is byte-identical either way, and `mise run render` leaves every generated artifact unchanged.

It reaches the endpoint through `is_spec_request` in `crate::run` rather than through the generated intercept — it hands its command line to `parse_from` and renders its own output, so nothing generated is ever in a position to intercept. That is the embedder path the docs now describe, exercised by the flagship adopter.

## Not in scope, deliberately

- **JSON from the binary** — `usage g json -f -` already converts.
- **View projection.** A view-invoked binary emits the base document, which already declares every `view`; projecting would hand tooling a *lossier* spec depending on which name launched the process.
- **`--usage-spec` as a built-in spelling** — adopter-owned. A CLI in another language has no derive to generate an endpoint, so the flag remains the convention there, and usage-cli answers both.

## Cost

Measured, stripped release, on a four-flag two-subcommand CLI: **773,424 bytes with the endpoint against 708,768 without** — 65KB, which is the KDL writer and cold metadata being reachable from `main`. A CLI that already calls `to_kdl()` for a checked-in artifact links the same code and pays nothing extra. Nothing lands on the parse path: the intercept reads the argv `parse()` had already collected, so it is one comparison and no allocation.

## Verification

- `cargo test --all --all-features` — clean, no failures.
- `cargo fmt --all --check`, `cargo clippy --all --all-features -- -D warnings` — clean.
- `mise run render` then `git diff` — no artifact moved.
- `diff <(usage __usage_spec__) <(usage --usage-spec)` — identical, and both match the checked-in `cli/usage.usage.kdl`.
- `usage __usage_spec__ | usage lint -` — clean (the five pre-existing `info` lines only).
- New tests: `is_spec_request` unit tests in usage-argv (first-word-only, declaration and alias precedence); five facade tests (answer parses as a spec, ordinary argv is not a request, a declared command outranks the endpoint, opting out changes nothing else, `spec_extra` joins the document the endpoint hands over); and a process-level test in `usage-rs/tests/external.rs` that runs the real intercept — with a control asserting the same fixture rejects an ordinary word, so it proves the request is answered *before* the grammar rather than by passing through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default-on intercept of the first argv word changes meaning for CLIs with default-subcommand routing (the word is no longer a task name) and slightly grows binaries that did not already link `to_kdl()`. Opt-out and declaration-wins rules are explicit and tested.
> 
> **Overview**
> Every derived CLI now answers `__usage_spec__` with its own KDL spec from the same static tables the parser uses, so tools no longer depend on each adopter wiring a hidden `--usage-spec` flag.
> 
> The request is a **hidden first word**, not a flag: it is handled before parse (same shape as `__complete_word__`), stays out of the tables, and cannot collide with adopter flags. A declared command or alias of that spelling wins. `#[usage(spec_endpoint = false)]` opts out (~65KB of KDL writer on a small CLI). `parse()` prints and exits; embedders use `spec_request`; `to_kdl()` is the same document in-process.
> 
> `spec_extra` appends a compile-time KDL file onto `to_kdl()` as an escape hatch. usage-cli answers both `__usage_spec__` and `--usage-spec` via `is_spec_request` because it renders its own output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c29dea1a84582878483aaf5b094234088d232ffc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
