### PR TITLE
refactor(deps)!: stop shipping features and crates nobody uses

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,16 @@ jobs:
         run: |
           rustup target add x86_64-pc-windows-msvc
           cargo check -p usage-argv --all-features --target x86_64-pc-windows-msvc
+      # Everything else in this pipeline builds with `--all-features`, and resolver-v2 unification
+      # means a workspace build turns a feature on for every member as soon as one member wants it.
+      # So the shapes an adopter actually gets — usage-lib without `docs`, usage-rs without its
+      # defaults — are compiled nowhere else, and rotted unnoticed until they were measured.
+      - name: check the trimmed feature shapes still compile
+        run: |
+          cargo clippy -p usage-lib --no-default-features -- -D warnings
+          cargo clippy -p usage-rs --no-default-features -- -D warnings
+          cargo clippy -p usage-config-build -- -D warnings
+          cargo clippy -p usage-config --no-default-features -- -D warnings
       - run: mise r render
       # Same reasoning as `render`: the shadow is checked in, so a change to the derive's
       # vocabulary that would alter it has to be committed rather than discovered later.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -97,7 +97,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -165,7 +165,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -291,23 +291,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "cfg_aliases"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
-
-[[package]]
-name = "chacha20"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,7 +301,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -422,7 +405,7 @@ checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -430,15 +413,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "criterion"
@@ -637,18 +611,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
-name = "duct"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e66e9c0c03d094e1a0ba1be130b849034aa80c3a2ab8ee94316bc809f3fa684"
-dependencies = [
- "libc",
- "os_pipe",
- "shared_child",
- "shared_thread",
-]
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -713,7 +675,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -762,16 +724,6 @@ name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
-
-[[package]]
-name = "filetime"
-version = "0.2.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
-dependencies = [
- "cfg-if",
- "libc",
-]
 
 [[package]]
 name = "find-msvc-tools"
@@ -925,11 +877,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -974,18 +923,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "homedir"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68df315d2857b2d8d2898be54a85e1d001bbbe0dbb5f8ef847b48dd3a23c4527"
-dependencies = [
- "cfg-if",
- "nix",
- "widestring",
- "windows",
-]
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,7 +934,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -1109,7 +1046,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1247,18 +1184,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags 2.13.1",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
 name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1314,16 +1239,6 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
-name = "os_pipe"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "owo-colors"
@@ -1530,7 +1445,7 @@ dependencies = [
  "bit-vec",
  "bitflags 2.13.1",
  "num-traits",
- "rand 0.9.5",
+ "rand",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -1573,18 +1488,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
-dependencies = [
- "chacha20",
- "getrandom 0.4.3",
- "rand_core 0.10.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -1594,7 +1498,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
+ "rand_core",
 ]
 
 [[package]]
@@ -1607,18 +1511,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_core"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.9.5",
+ "rand_core",
 ]
 
 [[package]]
@@ -1747,7 +1645,7 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2014,23 +1912,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shared_child"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7"
-dependencies = [
- "libc",
- "sigchld",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "shared_thread"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52b86057fcb5423f5018e331ac04623e32d6b5ce85e33300f92c79a1973928b0"
-
-[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2041,37 +1922,6 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
-
-[[package]]
-name = "sigchld"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1"
-dependencies = [
- "libc",
- "os_pipe",
- "signal-hook",
-]
-
-[[package]]
-name = "signal-hook"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
-dependencies = [
- "errno 0.3.14",
- "libc",
-]
 
 [[package]]
 name = "similar"
@@ -2171,7 +2021,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2190,7 +2040,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2457,7 +2307,6 @@ dependencies = [
  "tokio",
  "usage-lib",
  "usage-rs",
- "xx",
 ]
 
 [[package]]
@@ -2530,7 +2379,6 @@ dependencies = [
  "thiserror",
  "usage-validation",
  "versions",
- "xx",
 ]
 
 [[package]]
@@ -2662,12 +2510,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "widestring"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2689,7 +2531,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2699,41 +2541,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.61.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-dependencies = [
- "windows-collections",
- "windows-core 0.61.2",
- "windows-future",
- "windows-link 0.1.3",
- "windows-numerics",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core 0.61.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
-]
-
-[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2741,20 +2548,9 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
- "windows-threading",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -2781,34 +2577,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
-]
 
 [[package]]
 name = "windows-result"
@@ -2816,16 +2587,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -2834,16 +2596,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -2852,82 +2605,8 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link 0.2.1",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -2957,24 +2636,6 @@ dependencies = [
  "serde",
  "serde_json",
  "usage-lib",
-]
-
-[[package]]
-name = "xx"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8aff208388ac09afbb2bd20c3db8f7d253c9fbed7076e3618d598bb3deef2c5"
-dependencies = [
- "duct",
- "filetime",
- "getrandom 0.4.3",
- "homedir",
- "log",
- "miette",
- "rand 0.10.2",
- "regex",
- "strsim",
- "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,13 @@ usage-cli = { path = "./cli" }
 usage-argv = { path = "./argv", version = "5.1.0" }
 usage-config = { path = "./config", version = "5.1.0" }
 usage-derive = { path = "./derive", version = "5.1.0" }
-usage-lib = { path = "./lib", version = "5.1.0", features = ["clap", "validation"] }
+# No features, and defaults off. A feature named here is inherited by every member that writes
+# `workspace = true` and inlines into their published manifests — so `clap` and `validation`
+# reached `usage-config-build`, which runs in an adopter's build script and uses neither. Defaults
+# are off rather than absent because cargo *ignores* a member's `default-features = false` unless
+# the workspace declaration sets it too, and warns that it may become a hard error. Members name
+# what they need, `docs` included.
+usage-lib = { path = "./lib", version = "5.1.0", default-features = false }
 usage-rs = { path = "./usage-rs", version = "5.1.0" }
 usage-validation = { path = "./validation", version = "5.1.0" }
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -47,8 +47,10 @@ tokio = { version = "1", features = ["rt", "macros", "io-std"] }
 # the parser it ships. Facade defaults already include diagnostics (and therefore
 # `spec`) for `--usage-spec` and clap-shaped parse errors.
 usage-rs = { workspace = true }
-usage-lib = { workspace = true, features = ["clap", "docs", "unstable_choices_env"] }
-xx = "2"
+# `validation` rather than `clap`: the CLI has no clap dependency to convert *from*, and it
+# parses arbitrary specs — without `validation`, a spec carrying `validate=` gets an error
+# saying the feature is off, and `usage lint` stops rejecting malformed expressions.
+usage-lib = { workspace = true, features = ["docs", "unstable_choices_env", "validation"] }
 
 [target.'cfg(unix)'.dependencies]
 exec = "0.3"

--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -6,9 +6,9 @@ use std::sync::Arc;
 
 use itertools::Itertools;
 use miette::IntoDiagnostic;
+use regex::Regex;
 use std::sync::LazyLock;
 use usage_rs::Args;
-use xx::regex;
 
 use usage::parse::{ParseOutput, ParseValue};
 use usage::sh::sh;
@@ -646,7 +646,9 @@ impl CompleteWord {
             trace!("run: {run}");
             let stdout = sh(&run)?;
             // trace!("stdout: {stdout}");
-            let re = regex!(r"[^\\]:");
+            static DESCRIPTION_SEPARATOR: LazyLock<Regex> =
+                LazyLock::new(|| Regex::new(r"[^\\]:").unwrap());
+            let re = &*DESCRIPTION_SEPARATOR;
             return Ok((
                 stdout
                     .lines()

--- a/cli/src/cli/generate/markdown.rs
+++ b/cli/src/cli/generate/markdown.rs
@@ -67,7 +67,7 @@ impl Markdown {
         // `-` meaning stdout cannot turn up here.
         let write = |path: &PathBuf, md: &str| -> miette::Result<()> {
             eprintln!("writing to {}", path.display());
-            xx::file::write(path, render(md))?;
+            super::write_file(path, render(md))?;
             Ok(())
         };
         let spec = select_view(parse_file_or_stdin(&self.file)?, self.view.as_deref())?;

--- a/cli/src/cli/generate/mod.rs
+++ b/cli/src/cli/generate/mod.rs
@@ -95,11 +95,24 @@ pub fn write_or_stdout(out_file: Option<&Path>, contents: &str) -> Result<(), Us
     match out_file {
         Some(path) if path.as_os_str() != "-" => {
             eprintln!("writing to {}", path.display());
-            xx::file::write(path, contents)?;
+            write_file(path, contents)?;
         }
         _ => write_stdout(contents)?,
     }
     Ok(())
+}
+
+/// Write a generated file, creating the directories leading to it.
+///
+/// Every caller's path is a join onto an `--out-dir` the user named, so the parents are
+/// created rather than demanded. The path travels with the error: "No such file or
+/// directory" alone does not say which one.
+pub fn write_file(path: &Path, contents: impl AsRef<[u8]>) -> Result<(), UsageErr> {
+    if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+        std::fs::create_dir_all(parent)
+            .map_err(|err| UsageErr::FileError(err, parent.to_path_buf()))?;
+    }
+    std::fs::write(path, contents).map_err(|err| UsageErr::FileError(err, path.to_path_buf()))
 }
 
 /// Write a generated document to stdout, reporting a failed write rather than panicking.

--- a/cli/src/cli/generate/sdk.rs
+++ b/cli/src/cli/generate/sdk.rs
@@ -62,7 +62,7 @@ impl Sdk {
         for file in &output.files {
             let path = self.output.join(&file.path);
             eprintln!("writing to {}", path.display());
-            xx::file::write(&path, &file.content)?;
+            super::write_file(&path, &file.content)?;
         }
 
         Ok(())

--- a/cli/src/cli/lint.rs
+++ b/cli/src/cli/lint.rs
@@ -968,6 +968,29 @@ fn is_this_program(spec: &Spec, word: &str) -> bool {
 mod tests {
     use super::*;
 
+    /// The CLI reads specs written by other people, so a `validate=` expression that does not
+    /// compile has to be refused when the spec is read rather than when a value reaches it.
+    ///
+    /// Here rather than in usage-lib because what it pins is this crate's manifest: usage-lib
+    /// only performs the check under its `validation` feature, and `usage lint` silently loses
+    /// the rule if `cli/Cargo.toml` stops asking for it.
+    #[test]
+    fn a_malformed_validate_expression_is_refused_when_a_spec_is_read() {
+        let err = r#"
+name "demo"
+bin "demo"
+arg "<port>" validate="int(value) >"
+"#
+        .parse::<Spec>()
+        .expect_err("a validate= expression that does not compile should be refused");
+        // The reason is the label, not the `Display` — which is the generic "Invalid usage
+        // config" for every parse error.
+        let UsageErr::InvalidInput(reason, ..) = &err else {
+            panic!("expected a parse error naming the expression, got {err:?}");
+        };
+        assert!(reason.contains("invalid validation expression"), "{reason}");
+    }
+
     fn example_issues(spec: &str) -> Vec<LintIssue> {
         let spec: Spec = spec.parse().unwrap();
         lint_spec(&spec, LintOptions::default())

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate log;
 extern crate miette;
-extern crate xx;
 
 use miette::Result;
 

--- a/config-build/Cargo.toml
+++ b/config-build/Cargo.toml
@@ -13,6 +13,8 @@ license = { workspace = true }
 # Runs in a build script, so its dependencies cost an adopter's *build* and never ship: the KDL
 # parser lives here and `usage-config` carries none of it.
 [dependencies]
+# No features: all this needs is `Spec::parse_file` and the `config` sub-model. `docs` would add
+# tera and roff to every adopter's build script to render markdown nobody asked for.
 usage-lib = { workspace = true }
 # For the *rules*, not for the generated code: a default has to be held to the same choices, and read
 # by the same coercion, that the runtime will apply — and a second implementation of those rules here

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -20,7 +20,9 @@ serde_json = "1"
 usage-argv = { workspace = true, features = ["spec", "complete", "diagnostics"] }
 usage-config = { workspace = true }
 usage-cli = { workspace = true }
-usage-lib = { workspace = true }
+# Both named explicitly: the corpus carries `validate=` vectors, checked against usage-lib's
+# reference parser, and the suites compare rendered help against `usage::docs`.
+usage-lib = { workspace = true, features = ["docs", "validation"] }
 
 [dev-dependencies]
 clap = { version = "4", features = ["derive", "env"] }

--- a/docs/spec/resolution.md
+++ b/docs/spec/resolution.md
@@ -194,4 +194,6 @@ no spec parser, so a CLI ships a resolver rather than a KDL reader.
 [`usage-config-build`](https://github.com/jdx/usage/tree/main/config-build) reads the
 spec at build time and emits the registry as consts, along with the typed `Settings`
 struct a CLI reads — so a setting that is declared is a setting that resolves, with
-no second declaration to keep in step.
+no second declaration to keep in step. It takes nothing from `usage-lib` beyond the
+spec parser: the build script that reads your settings does not compile a markdown
+renderer, an expression evaluator, or a second argument parser to do it.

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -37,7 +37,10 @@ strum = { version = "0.28", features = ["derive"] }
 tera = { version = "2", optional = true }
 thiserror = "2"
 versions = "7"
-xx = "2"
+# No `xx`: three helpers (a lazy-regex macro, `file::read_to_string`, `check_status`) were
+# worth 21 crates in every dependent's tree — duct, homedir, nix, rand and their libc
+# subtrees — including `usage-config-build`, which runs in an adopter's build script.
+# `LazyLock` and `std::fs` cover all three, so nothing here needs a process library.
 usage-validation = { workspace = true, optional = true }
 
 [features]

--- a/lib/src/docs/markdown/renderer.rs
+++ b/lib/src/docs/markdown/renderer.rs
@@ -2,6 +2,13 @@ use crate::docs::markdown::tera::TERA;
 use crate::docs::models::Spec;
 use crate::error::UsageErr;
 use itertools::Itertools;
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// An ANSI escape sequence: what `color_print::cstr!` leaves in help text.
+static SGR: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\x1b\[[0-?]*[ -/]*[@-~]").unwrap());
+/// A backtick span, or a bare `<` outside one.
+static CODE_SPAN_OR_LT: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(`[^`]*`)|(<)").unwrap());
 
 fn escape_md(value: &str, html_encode: bool) -> String {
     let mut in_fenced_code_block = false;
@@ -9,7 +16,7 @@ fn escape_md(value: &str, html_encode: bool) -> String {
     // their examples with `color_print::cstr!`, which embeds SGR sequences even when color is
     // disabled at runtime. Terminal styling has no meaning in generated Markdown, and leaving
     // it here publishes literal escape bytes in docs and downstream static sites.
-    let value = xx::regex!(r"\x1b\[[0-?]*[ -/]*[@-~]").replace_all(value, "");
+    let value = SGR.replace_all(value, "");
 
     value
         .lines()
@@ -38,7 +45,7 @@ fn escape_md(value: &str, html_encode: bool) -> String {
                 return line.to_string();
             }
             // replace '<' with '&lt;' but not inside code blocks
-            xx::regex!(r"(`[^`]*`)|(<)")
+            CODE_SPAN_OR_LT
                 .replace_all(line, |caps: &regex::Captures| {
                     if caps.get(1).is_some() {
                         caps.get(1).unwrap().as_str().to_string()

--- a/lib/src/docs/markdown/tera.rs
+++ b/lib/src/docs/markdown/tera.rs
@@ -1,7 +1,13 @@
 use itertools::Itertools;
+use regex::Regex;
 use std::sync::LazyLock;
 use tera::Tera;
-use xx::regex;
+
+/// The `blob/<ref>/` part of a GitHub or GitLab source URL, which
+/// `source_code_link` rewrites per command.
+static BLOB_PATH: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"https://(github.com/[^/]+/[^/]+|gitlab.com/[^/]+/[^/]+/-)/blob/[^/]+/").unwrap()
+});
 
 pub(crate) static TERA: LazyLock<Tera> = LazyLock::new(|| {
     let mut tera = Tera::default();
@@ -110,7 +116,6 @@ pub(crate) static TERA: LazyLock<Tera> = LazyLock::new(|| {
             Ok(value.clone())
         },
     );
-    let path_re = regex!(r"https://(github.com/[^/]+/[^/]+|gitlab.com/[^/]+/[^/]+/-)/blob/[^/]+/");
     tera.register_function(
         "source_code_link",
         move |args: tera::Kwargs, _: &tera::State| -> tera::TeraResult<String> {
@@ -134,8 +139,8 @@ pub(crate) static TERA: LazyLock<Tera> = LazyLock::new(|| {
                 let href = TERA
                     .clone()
                     .render_str(source_code_link_template, &ctx, false)?;
-                let friendly = path_re.replace_all(&href, "").to_string();
-                let link = if path_re.is_match(&href) {
+                let friendly = BLOB_PATH.replace_all(&href, "").to_string();
+                let link = if BLOB_PATH.is_match(&href) {
                     format!("[`{friendly}`]({href})")
                 } else {
                     format!("[{friendly}]({href})")

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -82,9 +82,19 @@ pub enum UsageErr {
     #[diagnostic(transparent)]
     KdlError(#[from] kdl::KdlError),
 
-    #[error(transparent)]
-    #[diagnostic(transparent)]
-    XXError(#[from] xx::error::XXError),
+    /// A file the spec model was asked to read could not be read.
+    ///
+    /// Carries the path as well as the io error: "No such file or directory" on its own
+    /// names nothing, and this is reported for spec files given on a command line.
+    #[error("{0}\nFile: {1}")]
+    #[diagnostic(code(usage::file))]
+    FileError(std::io::Error, std::path::PathBuf),
+
+    /// A `run=` script could not be run, exited non-zero, or produced output usage
+    /// could not read. The message names the shell and the script.
+    #[error("{0}")]
+    #[diagnostic(code(usage::shell))]
+    ShellError(String),
 
     #[error("Variadic argument <{name}> requires at least {min} value(s), got {got}")]
     VarArgTooFew {

--- a/lib/src/sh.rs
+++ b/lib/src/sh.rs
@@ -1,12 +1,10 @@
 //! Running the shell scripts a spec embeds in `run=`.
 
 use std::io;
-use std::process::Command;
+use std::process::{Command, ExitStatus};
 use std::string::FromUtf8Error;
-use xx::process::check_status;
-use xx::XXError;
 
-use crate::error::Result;
+use crate::error::{Result, UsageErr};
 
 /// The interpreter a `run=` script is handed to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -95,19 +93,37 @@ pub fn sh(script: &str) -> Result<String> {
         match fallback_for(kind, err.kind()) {
             Some(next) => kind = next,
             None if err.kind() == io::ErrorKind::NotFound && cfg!(windows) => {
-                return Err(XXError::Error(no_shell_message(script)).into());
+                return Err(UsageErr::ShellError(no_shell_message(script)));
             }
             None => {
-                return Err(XXError::ProcessError(err, format!("{shell} {flag} {script}")).into());
+                return Err(UsageErr::ShellError(format!(
+                    "{err}\n{shell} {flag} {script}"
+                )));
             }
         }
     };
 
     let (shell, flag) = shell_argv(kind);
-    check_status(output.status)
-        .map_err(|err| XXError::ProcessError(err, format!("{shell} {flag} {script}")))?;
+    if let Some(failure) = status_failure(output.status) {
+        return Err(UsageErr::ShellError(format!(
+            "{failure}\n{shell} {flag} {script}"
+        )));
+    }
     String::from_utf8(output.stdout)
-        .map_err(|err| XXError::Error(non_utf8_message(shell, flag, script, &err)).into())
+        .map_err(|err| UsageErr::ShellError(non_utf8_message(shell, flag, script, &err)))
+}
+
+/// How a non-successful exit reads, or `None` when the script succeeded.
+///
+/// A signal has no code, so it gets its own wording rather than a missing number.
+fn status_failure(status: ExitStatus) -> Option<String> {
+    if status.success() {
+        return None;
+    }
+    Some(match status.code() {
+        Some(code) => format!("exited with code {code}"),
+        None => "terminated by signal".to_string(),
+    })
 }
 
 fn run(shell: &str, flag: &str, script: &str) -> io::Result<std::process::Output> {

--- a/lib/src/spec/choices.rs
+++ b/lib/src/spec/choices.rs
@@ -282,6 +282,9 @@ impl SpecChoices {
         values
     }
 
+    /// The choices as a help page lists them: visible values only, and no details.
+    // Only `docs` renders help, and without it this is dead code that `-D warnings` fails on.
+    #[cfg(feature = "docs")]
     pub(crate) fn for_help(&self) -> Self {
         let mut choices = self.clone();
         choices.choices = self.visible_declared();
@@ -381,6 +384,7 @@ arg "<color>" {
             spec.cmd.args[0].choices.as_ref().unwrap().details
         );
         assert!(choices.ignore_case);
+        #[cfg(feature = "docs")]
         assert_eq!(choices.for_help().choices, vec!["always", "yes"]);
     }
 

--- a/lib/src/spec/cmd.rs
+++ b/lib/src/spec/cmd.rs
@@ -611,6 +611,9 @@ impl SpecCommand {
         self.usage_with_subcommands(true)
     }
 
+    // `docs` only, like `SpecChoices::for_help`: the usage line without the subcommand
+    // placeholder is a help-page shape, and nothing else asks for it.
+    #[cfg(feature = "docs")]
     pub(crate) fn usage_without_subcommands(&self) -> String {
         self.usage_with_subcommands(false)
     }

--- a/lib/src/spec/mod.rs
+++ b/lib/src/spec/mod.rs
@@ -18,13 +18,14 @@ pub mod view;
 use indexmap::IndexMap;
 use kdl::{KdlDocument, KdlEntry, KdlNode};
 use log::{info, warn};
+use regex::Regex;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use std::iter::once;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use xx::file;
+use std::sync::LazyLock;
 
 use crate::error::UsageErr;
 use crate::spec::cmd::{SpecCommand, SpecExample};
@@ -196,7 +197,7 @@ impl Spec {
     /// If `bin` is not specified in the spec, it defaults to the filename.
     #[must_use = "parsing result should be used"]
     pub fn parse_script(file: &Path) -> Result<Spec, UsageErr> {
-        let mut spec = Self::parse_script_with_path(&file::read_to_string(file)?, file)?;
+        let mut spec = Self::parse_script_with_path(&read_to_string(file)?, file)?;
         if spec.bin.is_empty() {
             spec.bin = file
                 .file_name()
@@ -749,32 +750,46 @@ fn check_usage_version(version: &str) {
     }
 }
 
+/// Read a file, keeping its path in the error.
+///
+/// `std::fs::read_to_string` reports "No such file or directory" and nothing about which
+/// file, and these paths come from a command line.
+fn read_to_string(file: &Path) -> Result<String, UsageErr> {
+    std::fs::read_to_string(file).map_err(|err| UsageErr::FileError(err, file.to_path_buf()))
+}
+
+/// A comment line that opens or continues an embedded spec: `#USAGE`, `//USAGE`, `::USAGE`,
+/// or their `[USAGE]` spellings.
+static USAGE_COMMENT: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(?:#|//|::)(?:USAGE| ?\[USAGE\])(.*)$").unwrap());
+/// The same, without capturing the rest of the line: used only to answer whether a script
+/// carries an embedded spec at all.
+static HAS_USAGE_COMMENT: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(?:#|//|::)(?:USAGE| ?\[USAGE\])").unwrap());
+/// A comment line with nothing on it, which continues a spec rather than ending it.
+static BLANK_COMMENT: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^(?:#|//|::)\s*$").unwrap());
+
 fn split_script(file: &Path) -> Result<String, UsageErr> {
-    let full = file::read_to_string(file)?;
+    let full = read_to_string(file)?;
     // If file has a shebang and USAGE comments, extract the spec from comments
-    if full.starts_with("#!") {
-        let usage_regex = xx::regex!(r"^(?:#|//|::)(?:USAGE| ?\[USAGE\])");
-        if full.lines().any(|l| usage_regex.is_match(l)) {
-            return Ok(extract_usage_from_comments(&full));
-        }
+    if full.starts_with("#!") && full.lines().any(|l| HAS_USAGE_COMMENT.is_match(l)) {
+        return Ok(extract_usage_from_comments(&full));
     }
     // Otherwise treat the whole file as a KDL spec (e.g., .usage.kdl files)
     Ok(full)
 }
 
 fn extract_usage_from_comments(full: &str) -> String {
-    let usage_regex = xx::regex!(r"^(?:#|//|::)(?:USAGE| ?\[USAGE\])(.*)$");
-    let blank_comment_regex = xx::regex!(r"^(?:#|//|::)\s*$");
     let mut usage = vec![];
     let mut found = false;
     for line in full.lines() {
-        if let Some(captures) = usage_regex.captures(line) {
+        if let Some(captures) = USAGE_COMMENT.captures(line) {
             found = true;
             let content = captures.get(1).map_or("", |m| m.as_str());
             usage.push(content.trim());
         } else if found {
             // Allow blank comment lines to continue parsing
-            if blank_comment_regex.is_match(line) {
+            if BLANK_COMMENT.is_match(line) {
                 continue;
             }
             // if there is a non-blank non-USAGE line, stop reading


### PR DESCRIPTION
Three unrelated dependency leaks, all measured with `cargo tree -e normal`.

## The workspace feature leak

`Cargo.toml` declared the shared `usage-lib` dependency as `features = ["clap", "validation"]`. A feature named in a workspace dependency is inherited by every member that writes `workspace = true`, and inlines into that member's published manifest — so both reached `usage-config-build`, which runs in an **adopter's build script** and uses neither. It was compiling clap and a full expression evaluator to read a `config` block.

Defaults are now off at the workspace level as well, because cargo *ignores* a member's `default-features = false` unless the workspace declaration sets it too (and warns that this may become a hard error). That is why `docs` — tera and roff — was reaching config-build too.

Each member now names what it needs:

| Crate | Before | After |
| --- | --- | --- |
| `clap_usage` | `["clap"]` | unchanged — the only real consumer of that feature |
| `usage-cli` | `["clap", "docs", "unstable_choices_env"]` | `["docs", "unstable_choices_env", "validation"]` |
| `usage-conformance` | inherited | `["docs", "validation"]` |
| `usage-config-build` | inherited | nothing |

The `clap` on `usage-cli` was dead — the CLI has no clap dependency to convert *from*. The `validation` is not: the CLI parses specs written by other people, and without it a `validate=` expression that does not compile is accepted when the spec is read, and `usage lint` silently loses the rule. There was no test for that; there is now.

## `xx` in `usage-lib`

Three helpers were in use — a lazy-regex macro, `file::read_to_string`, and `check_status` — for 21 crates in every dependent's tree: duct, homedir, nix, rand, filetime and their libc and windows subtrees. `LazyLock` and `std::fs` cover all three, and the regexes read better hoisted to named statics than inlined in a macro. The CLI's four remaining uses (`file::write` ×3, the regex macro) go the same way rather than keep the dependency alive.

## Result

|  | Before | After |
| --- | ---: | ---: |
| `usage-config-build` (build-dep) | 85 | **34** |
| `usage-lib` | 57 | **35** |
| `usage-cli` | 140 | **121** |
| `Cargo.lock` packages | — | **-36** |

config-build was measured from a scratch crate outside this workspace, where feature unification cannot flatter the number.

## Breaking

`UsageErr::XXError` is replaced by `UsageErr::FileError` and `UsageErr::ShellError`. The enum is `#[non_exhaustive]`, so a caller matching on it already needs a `_` arm — but one naming that variant does not compile. Marked `!`; release-plz decides the version.

## Coverage this needed

Nothing in CI compiled any of these shapes: every job passes `--all-features`, and resolver-v2 unification turns a feature on for the whole workspace as soon as one member wants it. So the trimmed shapes were unverifiable locally and only visible to adopters. `.github/workflows/test.yml` now clippies `usage-lib --no-default-features`, `usage-rs --no-default-features`, `usage-config`, and `usage-config-build`. That immediately found two `docs`-only methods in usage-lib that were dead code without the feature; they are gated now.

`mise run ci` is green, and `mise r render` produces no diff.

_This PR was generated by Claude Code._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public error-enum change and workspace feature defaults that alter what adopters compile. Not auth/data-path critical, but published crates and build-script graphs are affected.
> 
> **Overview**
> Stops workspace feature inheritance from pulling `clap`, `validation`, and default `docs` into every `usage-lib` consumer — especially `usage-config-build`, which runs in adopter build scripts. Workspace `usage-lib` now has **defaults off**; members name only what they need (`clap_usage` keeps `clap`; CLI and conformance take `docs` + `validation`).
> 
> Removes the `xx` crate from `usage-lib` and the CLI (regex/`fs`/`process` helpers inlined). **`UsageErr::XXError` is replaced** by `FileError` and `ShellError` (`#[non_exhaustive]`, but a match on `XXError` no longer compiles). Help-only APIs are gated on `docs`. CI clippy-checks the trimmed feature shapes so they cannot rot under `--all-features` unification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ec56077a0fcdcda6a26033687e0bcc7ef21e462. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error messages for file operations, shell execution, invalid input, and unsuccessful commands.
  - Malformed validation expressions are now rejected with clearer diagnostics.
  - Generated files are written reliably, including when parent directories are missing.
  - Markdown escaping and source-link handling remain consistent.

- **Documentation**
  - Clarified build-time documentation and specification-resolution behavior.

- **Chores**
  - Streamlined dependency and feature configuration without changing end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->