### PR TITLE
feat(parse): warn at runtime when a deprecated declaration is used

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1398,6 +1398,18 @@ above are where it lands.
 - [x] **Deprecation and stability metadata on flags and commands** (clap#3321) —
       `deprecated`, with warn/remove versions, is portable through KDL, typed
       Rust, generated Go, help, docs and completions from one declaration.
+      **And a parse now says so**, which is the half that actually moves anybody
+      off an old spelling: a deprecated flag that was given, a deprecated command
+      that was selected, and a value that arrived through a `deprecated_env`
+      alias each come back as a structured warning from usage-argv and usage-lib
+      alike — reported rather than printed, per the rule config resolution
+      already follows, with `parse()` rendering them to stderr because it is the
+      entry point that is the process. `deprecated_warn_at` gates it: the
+      comparison rule for versions is written down in `docs/spec/argv.md` and a
+      conformance test holds both implementations to it. Generated Go and corpus
+      vectors are the follow-up; a positional still cannot be deprecated at all,
+      since the spec has `deprecated` on a flag and a command and not on an
+      `arg`.
 - [x] **Ordered environment fallbacks and deprecated aliases** — explicit
       full-name deprecated env aliases (clap#5447) stay greppable, while
       clap#5925's fallback across several env names preserves declaration

--- a/argv/src/diagnostic.rs
+++ b/argv/src/diagnostic.rs
@@ -74,6 +74,11 @@ impl Style {
         self.wrap("1m\u{1b}[31", text)
     }
 
+    /// `warning:` — something that worked, and should not have been asked for.
+    fn warning(self, text: &str) -> String {
+        self.wrap("1m\u{1b}[33", text)
+    }
+
     /// What the user typed that did not work.
     fn invalid(self, text: &str) -> String {
         self.wrap("33", text)
@@ -434,6 +439,41 @@ pub fn render(
     style: Style,
 ) -> String {
     render_inner(spec, argv, error, style, None)
+}
+
+/// Render the deprecations a command line used, the way a user should read them.
+///
+/// One line each, in the order they were collected, with the same colour vocabulary as a failure:
+/// what the user typed in yellow, what to use instead in green. The wording itself comes from
+/// [`crate::warn`], so the plain and coloured halves cannot drift apart.
+pub fn render_warnings(warnings: &[crate::warn::Warning<'_>], style: Style) -> String {
+    let mut out = String::new();
+    for warning in warnings {
+        out.push_str(&style.warning("warning:"));
+        out.push(' ');
+        out.push_str(&style.invalid(&crate::warn::subject(warning)));
+        out.push_str(" is deprecated");
+        if let Some(at) = warning.remove_at {
+            out.push_str(", removed at ");
+            out.push_str(&style.literal(at));
+        }
+        // A replacement is something to type, so it is coloured like anything else that would
+        // have worked; an author's own message is prose, and colouring a sentence green would
+        // claim more about it than is known.
+        match crate::warn::tail(warning) {
+            Some(crate::warn::Tail::Message(message)) => {
+                out.push_str(": ");
+                out.push_str(message);
+            }
+            Some(crate::warn::Tail::Replacement(replacement)) => {
+                out.push_str(": use ");
+                out.push_str(&style.valid(replacement));
+            }
+            None => {}
+        }
+        out.push('\n');
+    }
+    out
 }
 
 /// Render a parse failure through a spec-declared executable view.

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -164,6 +164,8 @@ macro_rules! __usage_needs_complete_feature {
 pub mod help;
 #[cfg(feature = "spec")]
 pub mod spec;
+#[cfg(feature = "spec")]
+pub mod warn;
 
 /// How deep a command tree this parser will descend.
 ///
@@ -1012,6 +1014,24 @@ pub fn render_failure_view(
 ) -> String {
     let _ = (spec, argv, view);
     ::std::format!("error: {error:?}\n")
+}
+
+/// What a caller should print for the deprecations a command line used.
+///
+/// The same arrangement as [`render_failure`], and for the same reason: whether the coloured
+/// rendering is available is a feature of *this* crate in the adopter's dependency graph, so the
+/// `#[cfg]` lives beside the thing it gates rather than in generated code.
+///
+/// Warnings are not failures. A caller prints these to stderr and carries on.
+#[cfg(feature = "diagnostics")]
+pub fn render_warnings(warnings: &[warn::Warning<'_>]) -> String {
+    diagnostic::render_warnings(warnings, diagnostic::Style::auto())
+}
+
+/// The same wording without the renderer that colours it. See the other half.
+#[cfg(all(feature = "spec", not(feature = "diagnostics")))]
+pub fn render_warnings(warnings: &[warn::Warning<'_>]) -> String {
+    warn::render_warnings(warnings)
 }
 
 /// Whether a flag is one of the two the parser supplies rather than the CLI declaring it.

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -2850,6 +2850,25 @@ pub trait CommandArgs: Sized {
         None
     }
 
+    /// The deprecated declarations this command line actually used.
+    ///
+    /// Read from the partial rather than from the built struct, because a struct cannot answer
+    /// what the parse saw: a `bool` field is `false` whether the flag was absent or negated. Asked
+    /// after the environment has been applied, since a value that arrived through a variable used
+    /// the deprecated declaration just as much as a typed word did — while a declared default is
+    /// nothing anybody asked for, and does not warn.
+    ///
+    /// The milestone gate is deliberately not applied here. A nested command's tables say nothing
+    /// about the root's version, and a CLI with a computed `runtime_version` only settles it at
+    /// run time, so [`crate::warn::retain_reached`] is applied once by the entry point that knows
+    /// it.
+    ///
+    /// Empty by default, like the rest of the composition points, so a hand-written implementation
+    /// with nothing to report is not forced to say so.
+    fn deprecations(partial: &Self::Partial, out: &mut Vec<crate::warn::Warning<'static>>) {
+        let _ = (partial, out);
+    }
+
     /// Find an argument by any selector it accepts.
     ///
     /// Parents use this to enforce a relationship declared beside a flattened
@@ -3169,6 +3188,20 @@ pub trait Subcommands: Sized {
     fn exclusive_given(partial: &Self::Partial, selected: Option<usize>) -> Option<&'static str> {
         let _ = (partial, selected);
         None
+    }
+
+    /// The deprecated declarations the selected command used, and the command itself if its own
+    /// declaration is deprecated.
+    ///
+    /// Every deprecated command on the selected path reports, not only the last one: a deprecated
+    /// group whose child is fine was still the way in. See [`CommandArgs::deprecations`] for when
+    /// this is asked and why the milestone gate is not applied here.
+    fn deprecations(
+        partial: &Self::Partial,
+        selected: Option<usize>,
+        out: &mut Vec<crate::warn::Warning<'static>>,
+    ) {
+        let _ = (partial, selected, out);
     }
 
     /// Fill fields in the selected command from their declared environment variables.

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -2869,6 +2869,22 @@ pub trait CommandArgs: Sized {
         let _ = (partial, out);
     }
 
+    /// Report deprecations while traversing the injected parents of a view.
+    ///
+    /// `remaining_descendants` is non-zero only for commands that are routing to the promoted
+    /// command rather than contributing their own surface, exactly as
+    /// [`CommandArgs::check_for_view_path`] means it. Those commands are structural under the
+    /// view — the program's own identity — so nothing about them is reported.
+    fn deprecations_for_view_path(
+        partial: &Self::Partial,
+        remaining_descendants: usize,
+        out: &mut Vec<crate::warn::Warning<'static>>,
+    ) {
+        if remaining_descendants == 0 {
+            Self::deprecations(partial, out);
+        }
+    }
+
     /// Find an argument by any selector it accepts.
     ///
     /// Parents use this to enforce a relationship declared beside a flattened
@@ -3202,6 +3218,26 @@ pub trait Subcommands: Sized {
         out: &mut Vec<crate::warn::Warning<'static>>,
     ) {
         let _ = (partial, selected, out);
+    }
+
+    /// Report the selected command's deprecations, traversing a view's injected parents.
+    ///
+    /// Under an executable view the words the view injected are the program's own identity —
+    /// `aubr` *is* `aube run` — so neither the promoted command nor anything routing to it is
+    /// reported, for the same reason the root never is. Whatever the user selected below it is.
+    ///
+    /// The default treats the promoted command as an ordinary selection, which is the most a
+    /// hand-written implementation can do without knowing its own variants; a derived one knows
+    /// which commands the view injected and leaves them out.
+    fn deprecations_for_view_path(
+        partial: &Self::Partial,
+        selected: Option<usize>,
+        remaining_commands: usize,
+        out: &mut Vec<crate::warn::Warning<'static>>,
+    ) {
+        if remaining_commands <= 1 {
+            Self::deprecations(partial, selected, out);
+        }
     }
 
     /// Fill fields in the selected command from their declared environment variables.

--- a/argv/src/warn.rs
+++ b/argv/src/warn.rs
@@ -1,0 +1,337 @@
+//! What a parse has to say about declarations that still work but should not be used.
+//!
+//! A `deprecated` flag, command, or environment alias reaches help and completion descriptions
+//! already. This is the other half: telling the person who just used one, which is the only thing
+//! that actually moves anybody off an old spelling.
+//!
+//! Nothing here prints. A library that writes to stderr cannot be used by anything with an
+//! opinion about output, and mise queues its deprecations until its logging is up — the same rule
+//! [`usage_config`](https://docs.rs/usage-config) resolution follows. `parse()`, which *is* the
+//! process, renders them; every other entry point hands them back.
+//!
+//! Every field borrows the static metadata tables, so a warning allocates nothing. The `Vec` a
+//! caller passes in only allocates if something was actually deprecated, and an entry point that
+//! was not asked for warnings never collects any.
+
+use core::cmp::Ordering;
+
+/// One thing a command line used that its own spec says not to use any more.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Warning<'t> {
+    /// What sort of declaration it was, for a caller that treats them differently.
+    pub kind: WarningKind,
+    /// What the user typed or set: `--old-flag`, `old-cmd`, `OLD_ENV`.
+    pub name: &'t str,
+    /// The author's reason, when the declaration carries one.
+    pub message: Option<&'t str>,
+    /// The release warnings start at. A warning that is here has already passed it.
+    pub warn_at: Option<&'t str>,
+    /// The release the declaration goes away in, when the author has named one.
+    pub remove_at: Option<&'t str>,
+    /// What to use instead, when the declaration implies one — the current variable, for a
+    /// deprecated environment alias.
+    pub replacement: Option<&'t str>,
+}
+
+/// The kinds of deprecation a parse can run into.
+///
+/// The message is for a person and its wording is nobody's contract; this is what a *program* can
+/// act on. A CLI that queues its warnings wants to sort them; a `--strict` mode wants to refuse
+/// one kind and not another; a conformance vector wants to pin what happened without pinning how
+/// it was worded.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum WarningKind {
+    /// A flag whose declaration says not to use it any more.
+    DeprecatedFlag,
+    /// A command whose declaration says not to use it any more. Every deprecated command on the
+    /// selected path reports, not only the last one.
+    DeprecatedCommand,
+    /// A value that arrived through a `deprecated_env` alias rather than a current name.
+    DeprecatedEnv,
+    /// Something a CLI's own layer says, which this crate has no name for.
+    #[default]
+    Other,
+}
+
+impl<'t> Warning<'t> {
+    /// A deprecated flag that was given.
+    pub const fn flag(
+        name: &'t str,
+        message: Option<&'t str>,
+        warn_at: Option<&'t str>,
+        remove_at: Option<&'t str>,
+    ) -> Self {
+        Self {
+            kind: WarningKind::DeprecatedFlag,
+            name,
+            message,
+            warn_at,
+            remove_at,
+            replacement: None,
+        }
+    }
+
+    /// A deprecated command that was selected.
+    pub const fn command(
+        name: &'t str,
+        message: Option<&'t str>,
+        warn_at: Option<&'t str>,
+        remove_at: Option<&'t str>,
+    ) -> Self {
+        Self {
+            kind: WarningKind::DeprecatedCommand,
+            name,
+            message,
+            warn_at,
+            remove_at,
+            replacement: None,
+        }
+    }
+
+    /// A value read from a deprecated environment alias, and the current name for it.
+    ///
+    /// An alias carries no milestones of its own: the declaration that named it is what says it
+    /// is deprecated, so this always warns.
+    pub const fn env(name: &'t str, replacement: Option<&'t str>) -> Self {
+        Self {
+            kind: WarningKind::DeprecatedEnv,
+            name,
+            message: None,
+            warn_at: None,
+            remove_at: None,
+            replacement,
+        }
+    }
+}
+
+/// Whether a CLI at `current` has reached the release a deprecation starts warning at.
+///
+/// The gate exists because `deprecated_warn_at` is how an author says *not yet*: a declaration
+/// deprecated in next year's release should not be shouting about it in this one.
+///
+/// Every uncertain case warns. A missing milestone means it is deprecated now; a version this
+/// cannot read is a spec or build problem, and answering it with silence would hide a deprecation
+/// nobody then hears about. Noise is recoverable, silence is not.
+pub fn version_reaches(current: Option<&str>, warn_at: Option<&str>) -> bool {
+    let Some(warn_at) = warn_at else {
+        return true;
+    };
+    let Some(current) = current else {
+        return true;
+    };
+    match compare(current, warn_at) {
+        Some(Ordering::Less) => false,
+        Some(_) => true,
+        None => true,
+    }
+}
+
+/// Order two versions, or `None` if either is not a version this can read.
+///
+/// Dotted integers, compared left to right, with a missing segment reading as zero so `2026.12`
+/// and `2026.12.0` are one release. A `-suffix` sorts before the same numbers without one, which
+/// is semver's rule and the one a `-rc` needs; build metadata after `+` is ignored, also semver's
+/// rule. Two pre-releases on the same numbers compare as text, which is coarser than semver's
+/// per-identifier rule and enough for a gate: the answer only has to be stable.
+///
+/// This is deliberately the same rule usage-lib implements separately. Neither crate can depend on
+/// the other — this one has no dependencies at all — so the rule is written down at
+/// <https://usage.jdx.dev/spec/argv> and a parity test holds the two to it.
+pub fn compare(a: &str, b: &str) -> Option<Ordering> {
+    let (a_core, a_pre) = split(a);
+    let (b_core, b_pre) = split(b);
+    let mut a_segments = a_core.split('.');
+    let mut b_segments = b_core.split('.');
+    loop {
+        let (a_next, b_next) = (a_segments.next(), b_segments.next());
+        if a_next.is_none() && b_next.is_none() {
+            break;
+        }
+        match segment(a_next)?.cmp(&segment(b_next)?) {
+            Ordering::Equal => continue,
+            ordering => return Some(ordering),
+        }
+    }
+    Some(match (a_pre, b_pre) {
+        (None, None) => Ordering::Equal,
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (Some(a), Some(b)) => a.cmp(b),
+    })
+}
+
+/// The numeric core of a version, and its pre-release suffix if it has one.
+fn split(version: &str) -> (&str, Option<&str>) {
+    let version = version.split('+').next().unwrap_or(version);
+    match version.split_once('-') {
+        Some((core, pre)) => (core, Some(pre)),
+        None => (version, None),
+    }
+}
+
+/// One dotted segment as a number. Absent is zero; anything not a number is unreadable.
+fn segment(segment: Option<&str>) -> Option<u64> {
+    match segment {
+        None => Some(0),
+        Some(text) => text.parse().ok(),
+    }
+}
+
+/// Drop the warnings a CLI at `version` has not reached yet.
+///
+/// Applied once, by the entry point that knows the CLI's version — which the command whose
+/// metadata carries the milestone does not: a nested command's tables say nothing about the root's
+/// version, and a CLI with a computed `runtime_version` only settles it at run time.
+pub fn retain_reached(warnings: &mut Vec<Warning<'_>>, version: Option<&str>) {
+    warnings.retain(|warning| version_reaches(version, warning.warn_at));
+}
+
+/// What a caller should print for one warning, without the renderer that colours it.
+///
+/// See [`crate::render_warnings`] for the entry point generated code reaches for; this is the
+/// wording both halves share.
+pub fn render_warning(warning: &Warning<'_>) -> String {
+    let mut out = String::new();
+    out.push_str("warning: ");
+    out.push_str(&subject(warning));
+    out.push_str(" is deprecated");
+    if let Some(at) = warning.remove_at {
+        out.push_str(", removed at ");
+        out.push_str(at);
+    }
+    match tail(warning) {
+        Some(Tail::Message(message)) => {
+            out.push_str(": ");
+            out.push_str(message);
+        }
+        Some(Tail::Replacement(replacement)) => {
+            out.push_str(": use ");
+            out.push_str(replacement);
+        }
+        None => {}
+    }
+    out.push('\n');
+    out
+}
+
+/// Every warning, in the order they were collected.
+pub fn render_warnings(warnings: &[Warning<'_>]) -> String {
+    warnings.iter().map(render_warning).collect()
+}
+
+/// What the warning is about, named the way the user named it.
+pub(crate) fn subject(warning: &Warning<'_>) -> String {
+    match warning.kind {
+        WarningKind::DeprecatedCommand => format!("the {} command", warning.name),
+        _ => warning.name.to_string(),
+    }
+}
+
+/// What to do about a deprecation: the author's own words, or the name that replaced this one.
+///
+/// Which of the two a warning has is decided here and nowhere else, so the plain renderer and the
+/// coloured one can differ in how they show it without differing in what they show.
+pub(crate) enum Tail<'t> {
+    /// The author's message, which is prose.
+    Message(&'t str),
+    /// A name to type instead.
+    Replacement(&'t str),
+}
+
+pub(crate) fn tail<'t>(warning: &Warning<'t>) -> Option<Tail<'t>> {
+    match (warning.message, warning.replacement) {
+        (Some(message), _) => Some(Tail::Message(message)),
+        (None, Some(replacement)) => Some(Tail::Replacement(replacement)),
+        (None, None) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_missing_milestone_warns_now() {
+        assert!(version_reaches(Some("1.0.0"), None));
+        assert!(version_reaches(None, None));
+    }
+
+    #[test]
+    fn a_version_the_cli_has_not_reached_stays_quiet() {
+        assert!(!version_reaches(Some("1.0.0"), Some("2.0.0")));
+        assert!(!version_reaches(Some("2026.11.0"), Some("2026.12.0")));
+        assert!(!version_reaches(Some("1.9.9"), Some("1.10.0")));
+    }
+
+    #[test]
+    fn the_release_itself_warns() {
+        assert!(version_reaches(Some("2.0.0"), Some("2.0.0")));
+        assert!(version_reaches(Some("2.0.1"), Some("2.0.0")));
+        assert!(version_reaches(Some("2026.12.0"), Some("2026.11.0")));
+    }
+
+    #[test]
+    fn a_missing_segment_is_zero() {
+        assert_eq!(compare("2026.12", "2026.12.0"), Some(Ordering::Equal));
+        assert_eq!(compare("1", "1.0.0"), Some(Ordering::Equal));
+        assert_eq!(compare("1.0.1", "1"), Some(Ordering::Greater));
+    }
+
+    #[test]
+    fn a_pre_release_comes_before_the_release() {
+        assert_eq!(compare("1.0.0-rc.1", "1.0.0"), Some(Ordering::Less));
+        assert!(!version_reaches(Some("2.0.0-rc.1"), Some("2.0.0")));
+        assert!(version_reaches(Some("2.0.0"), Some("2.0.0-rc.1")));
+        assert_eq!(compare("1.0.0-rc.1", "1.0.0-rc.2"), Some(Ordering::Less));
+    }
+
+    #[test]
+    fn build_metadata_is_ignored() {
+        assert_eq!(compare("1.0.0+abc", "1.0.0+def"), Some(Ordering::Equal));
+        assert!(version_reaches(Some("2.0.0+build.7"), Some("2.0.0")));
+    }
+
+    #[test]
+    fn a_version_that_cannot_be_read_warns_rather_than_hides() {
+        assert_eq!(compare("nightly", "2.0.0"), None);
+        assert_eq!(compare("", "2.0.0"), None);
+        assert!(version_reaches(Some("nightly"), Some("2.0.0")));
+        assert!(version_reaches(Some(""), Some("2.0.0")));
+        assert!(version_reaches(Some("1.0.0"), Some("whenever")));
+    }
+
+    #[test]
+    fn a_warning_says_what_to_do_about_it() {
+        assert_eq!(
+            render_warning(&Warning::flag("--old", Some("use --new"), None, None)),
+            "warning: --old is deprecated: use --new\n",
+        );
+        assert_eq!(
+            render_warning(&Warning::flag("--old", None, None, Some("2.0.0"))),
+            "warning: --old is deprecated, removed at 2.0.0\n",
+        );
+        assert_eq!(
+            render_warning(&Warning::command("old", None, None, None)),
+            "warning: the old command is deprecated\n",
+        );
+        assert_eq!(
+            render_warning(&Warning::env("OLD_TOKEN", Some("APP_TOKEN"))),
+            "warning: OLD_TOKEN is deprecated: use APP_TOKEN\n",
+        );
+    }
+
+    #[test]
+    fn retaining_drops_only_what_has_not_arrived() {
+        let mut warnings = vec![
+            Warning::flag("--soon", None, Some("9.0.0"), None),
+            Warning::flag("--now", None, Some("1.0.0"), None),
+            Warning::env("OLD_TOKEN", None),
+        ];
+        retain_reached(&mut warnings, Some("1.2.3"));
+        assert_eq!(
+            warnings.iter().map(|w| w.name).collect::<Vec<_>>(),
+            ["--now", "OLD_TOKEN"],
+        );
+    }
+}

--- a/conformance/tests/deprecation.rs
+++ b/conformance/tests/deprecation.rs
@@ -16,7 +16,12 @@ use usage_derive::{Args, Cli, Subcommands};
 
 /// The same CLI the spec below describes.
 #[derive(Cli)]
-#[usage(bin = "ex", version = "2.0.0")]
+#[usage(
+    bin = "ex",
+    version = "2.0.0",
+    view("ex-compile", root = "compile"),
+    view("ex-inner", root = "compile inner")
+)]
 struct Ex {
     /// Where to write the result
     #[usage(long, deprecated = "use --out", deprecated_remove_at = "3.0.0")]
@@ -54,6 +59,22 @@ enum ExCommand {
 struct ExCompile {
     #[usage(long, deprecated = "no longer read")]
     incremental: bool,
+    #[usage(subcommand)]
+    command: Option<ExCompileCommand>,
+}
+
+#[derive(Subcommands)]
+#[allow(dead_code)]
+enum ExCompileCommand {
+    /// Deprecated, and promoted by a view two words deep
+    #[usage(deprecated = "use build")]
+    Inner(ExInner),
+}
+
+#[derive(Args)]
+struct ExInner {
+    #[usage(long, deprecated = "no longer read")]
+    fast: bool,
 }
 
 #[derive(Args)]
@@ -75,10 +96,15 @@ flag "--token <token>" env="EX_DEP_TOKEN" deprecated="use --out" {
 flag "--mode <mode>" default="quiet" deprecated="use --out"
 cmd "compile" deprecated="use build" {
     flag "--incremental" deprecated="no longer read"
+    cmd "inner" deprecated="use build" {
+        flag "--fast" deprecated="no longer read"
+    }
 }
 cmd "build" {
     flag "--release"
 }
+view "ex-compile" root="compile"
+view "ex-inner" root="compile inner"
 "#;
 
 /// What the compiled parser reports, as kinds and names.
@@ -196,6 +222,76 @@ fn what_a_command_line_used_is_reported_by_both_implementations() {
     assert_eq!(
         usage_argv::warn::render_warnings(&warnings),
         "warning: --output is deprecated, removed at 3.0.0: use --out\n",
+    );
+
+    // Invoked through an executable view, the promoted command is not a selection anybody made
+    // — `ex-compile` *is* `ex compile` — so it is not reported, while a deprecated flag the user
+    // typed on it still is. Both implementations agree, from opposite directions: the compiled
+    // parser injects the view's words into argv and skips them, and the reference implementation
+    // parses a spec whose root already *is* the promoted command.
+    let mut warnings = Vec::new();
+    let argv = [OsStr::new("ex-compile"), OsStr::new("--incremental")];
+    Ex::parse_from_argv_with_warnings(&argv, &mut warnings).expect("the view should dispatch");
+    assert_eq!(
+        warnings
+            .iter()
+            .map(|w| (w.kind, w.name))
+            .collect::<Vec<_>>(),
+        [(WarningKind::DeprecatedFlag, "--incremental")],
+        "{warnings:?}",
+    );
+
+    let promoted = spec
+        .for_view("ex-compile")
+        .expect("the view should materialize");
+    let out = usage::parse(
+        &promoted,
+        &["ex-compile".to_string(), "--incremental".to_string()],
+    )
+    .expect("the view should parse");
+    assert_eq!(out.warnings.len(), 1, "{:?}", out.warnings);
+    assert_eq!(out.warnings[0].kind, LibWarningKind::DeprecatedFlag);
+    assert_eq!(out.warnings[0].name, "--incremental");
+
+    // A view two commands deep: neither the command it routes through nor the promoted one is
+    // reported, which is the branch that decrements rather than the one that stops.
+    let mut warnings = Vec::new();
+    let argv = [OsStr::new("ex-inner"), OsStr::new("--fast")];
+    Ex::parse_from_argv_with_warnings(&argv, &mut warnings).expect("the view should dispatch");
+    assert_eq!(
+        warnings
+            .iter()
+            .map(|w| (w.kind, w.name))
+            .collect::<Vec<_>>(),
+        [(WarningKind::DeprecatedFlag, "--fast")],
+        "{warnings:?}",
+    );
+
+    let promoted = spec
+        .for_view("ex-inner")
+        .expect("the nested view should materialize");
+    let out = usage::parse(&promoted, &["ex-inner".to_string(), "--fast".to_string()])
+        .expect("the view should parse");
+    assert_eq!(out.warnings.len(), 1, "{:?}", out.warnings);
+    assert_eq!(out.warnings[0].name, "--fast");
+
+    // Reached as ordinary subcommands, the same commands *are* selections, and say so.
+    both_report(
+        &["compile", "inner", "--fast"],
+        &[
+            (WarningKind::DeprecatedCommand, "compile"),
+            (WarningKind::DeprecatedCommand, "inner"),
+            (WarningKind::DeprecatedFlag, "--fast"),
+        ],
+    );
+
+    // Reached as an ordinary subcommand, the same command *is* a selection, and says so.
+    both_report(
+        &["compile", "--incremental"],
+        &[
+            (WarningKind::DeprecatedCommand, "compile"),
+            (WarningKind::DeprecatedFlag, "--incremental"),
+        ],
     );
 
     // A value that arrived through a deprecated alias, with the name to use instead. Last,

--- a/conformance/tests/deprecation.rs
+++ b/conformance/tests/deprecation.rs
@@ -1,0 +1,232 @@
+//! What a parse says about the deprecated declarations it used, in both implementations.
+//!
+//! The compiled parser reads static tables and the reference implementation interprets a spec, so
+//! nothing makes them agree except a test that asks them the same question. The rule they are both
+//! held to is on <https://usage.jdx.dev/spec/argv>.
+//!
+//! Its own test binary, for the reason `post_binding_env.rs` gives: one case sets an environment
+//! variable, and a variable is process-wide.
+
+use std::ffi::OsStr;
+
+use usage::warn::WarningKind as LibWarningKind;
+use usage::Spec;
+use usage_argv::warn::WarningKind;
+use usage_derive::{Args, Cli, Subcommands};
+
+/// The same CLI the spec below describes.
+#[derive(Cli)]
+#[usage(bin = "ex", version = "2.0.0")]
+struct Ex {
+    /// Where to write the result
+    #[usage(long, deprecated = "use --out", deprecated_remove_at = "3.0.0")]
+    output: Option<String>,
+    #[usage(long)]
+    out: Option<String>,
+    /// Deprecated in a release this CLI has not reached
+    #[usage(long, deprecated = "use --out", deprecated_warn_at = "9.0.0")]
+    outfile: Option<String>,
+    #[usage(
+        long,
+        env = "EX_DEP_TOKEN",
+        deprecated_env = "EX_DEP_OLD_TOKEN",
+        deprecated = "use --out"
+    )]
+    token: Option<String>,
+    /// A default fills this in, which is nobody's request
+    #[usage(long, default = "quiet", deprecated = "use --out")]
+    mode: Option<String>,
+    #[usage(subcommand)]
+    command: Option<ExCommand>,
+}
+
+#[derive(Subcommands)]
+// The variants exist to be selected, not read: what this file checks is what a selection
+// reports.
+#[allow(dead_code)]
+enum ExCommand {
+    #[usage(deprecated = "use build")]
+    Compile(ExCompile),
+    Build(ExBuild),
+}
+
+#[derive(Args)]
+struct ExCompile {
+    #[usage(long, deprecated = "no longer read")]
+    incremental: bool,
+}
+
+#[derive(Args)]
+struct ExBuild {
+    #[usage(long)]
+    release: bool,
+}
+
+const SPEC: &str = r#"
+name "ex"
+bin "ex"
+version "2.0.0"
+flag "--output <output>" help="Where to write the result" deprecated="use --out" deprecated_remove_at="3.0.0"
+flag "--out <out>"
+flag "--outfile <outfile>" deprecated="use --out" deprecated_warn_at="9.0.0"
+flag "--token <token>" env="EX_DEP_TOKEN" deprecated="use --out" {
+    deprecated_env "EX_DEP_OLD_TOKEN"
+}
+flag "--mode <mode>" default="quiet" deprecated="use --out"
+cmd "compile" deprecated="use build" {
+    flag "--incremental" deprecated="no longer read"
+}
+cmd "build" {
+    flag "--release"
+}
+"#;
+
+/// What the compiled parser reports, as kinds and names.
+fn compiled(words: &[&str]) -> Vec<(WarningKind, String)> {
+    let argv: Vec<&OsStr> = words.iter().map(OsStr::new).collect();
+    let mut warnings = Vec::new();
+    Ex::parse_from_with_warnings(&argv, &mut warnings).expect("a valid command line");
+    warnings
+        .iter()
+        .map(|warning| (warning.kind, warning.name.to_string()))
+        .collect()
+}
+
+/// What the reference implementation reports, in the same shape.
+fn interpreted(words: &[&str]) -> Vec<(LibWarningKind, String)> {
+    let spec: Spec = SPEC.parse().expect("the spec should parse");
+    let mut input = vec!["ex".to_string()];
+    input.extend(words.iter().map(|word| word.to_string()));
+    let out = usage::parse(&spec, &input).expect("a valid command line");
+    out.warnings
+        .iter()
+        .map(|warning| (warning.kind, warning.name.clone()))
+        .collect()
+}
+
+/// The two vocabularies are separate types on purpose — one borrows static tables, the other owns
+/// its strings — so agreement is checked by name.
+fn same_kind(compiled: WarningKind, interpreted: LibWarningKind) -> bool {
+    matches!(
+        (compiled, interpreted),
+        (WarningKind::DeprecatedFlag, LibWarningKind::DeprecatedFlag)
+            | (
+                WarningKind::DeprecatedCommand,
+                LibWarningKind::DeprecatedCommand
+            )
+            | (WarningKind::DeprecatedEnv, LibWarningKind::DeprecatedEnv)
+            | (WarningKind::Other, LibWarningKind::Other)
+    )
+}
+
+/// Both implementations report the same warnings for the same command line.
+///
+/// Compared in order, which is stricter than the grammar promises — it specifies the set and
+/// leaves the arrangement to the implementation. Every case here is one the two happen to agree
+/// on, and holding them to it catches a change in either; a case where they diverge in order
+/// would be compared as a set instead, not treated as a failure.
+#[track_caller]
+fn both_report(words: &[&str], expected: &[(WarningKind, &str)]) {
+    let compiled = compiled(words);
+    let interpreted = interpreted(words);
+    let expected: Vec<(WarningKind, String)> = expected
+        .iter()
+        .map(|(kind, name)| (*kind, (*name).to_string()))
+        .collect();
+    assert_eq!(compiled, expected, "compiled parser, for {words:?}");
+    assert_eq!(
+        interpreted.len(),
+        expected.len(),
+        "reference implementation, for {words:?}: {interpreted:?}"
+    );
+    for (found, want) in interpreted.iter().zip(&expected) {
+        assert!(
+            same_kind(want.0, found.0) && found.1 == want.1,
+            "reference implementation, for {words:?}: {found:?} is not {want:?}"
+        );
+    }
+}
+
+#[test]
+fn what_a_command_line_used_is_reported_by_both_implementations() {
+    // One test, in one process. A variable is process-wide, so the alias case below would race
+    // every other case in this binary that parses a CLI reading `EX_DEP_TOKEN` — which is all of
+    // them. `post_binding_env.rs` has the same shape for the same reason.
+
+    // A deprecated flag that was typed.
+    both_report(
+        &["--output", "a.txt"],
+        &[(WarningKind::DeprecatedFlag, "--output")],
+    );
+
+    // Its replacement says nothing.
+    both_report(&["--out", "a.txt"], &[]);
+
+    // `--mode` is deprecated and has a default, so a bare command line fills it without anybody
+    // having asked for it. A default is not a use.
+    both_report(&[], &[]);
+
+    // A milestone this CLI's version has not reached is an author saying *not yet*.
+    both_report(&["--outfile", "a.txt"], &[]);
+
+    // A deprecated command reports itself, and then whatever of its own was used.
+    both_report(
+        &["compile", "--incremental"],
+        &[
+            (WarningKind::DeprecatedCommand, "compile"),
+            (WarningKind::DeprecatedFlag, "--incremental"),
+        ],
+    );
+    both_report(&["build", "--release"], &[]);
+
+    // And both word it the same way.
+    let mut warnings = Vec::new();
+    let argv = [OsStr::new("--output"), OsStr::new("a.txt")];
+    Ex::parse_from_with_warnings(&argv, &mut warnings).expect("a valid command line");
+    let spec: Spec = SPEC.parse().expect("the spec should parse");
+    let out = usage::parse(
+        &spec,
+        &["ex".to_string(), "--output".into(), "a.txt".into()],
+    )
+    .expect("a valid command line");
+    assert_eq!(
+        usage_argv::warn::render_warnings(&warnings),
+        usage::warn::render(&out.warnings),
+    );
+    assert_eq!(
+        usage_argv::warn::render_warnings(&warnings),
+        "warning: --output is deprecated, removed at 3.0.0: use --out\n",
+    );
+
+    // A value that arrived through a deprecated alias, with the name to use instead. Last,
+    // because it is the case that has to touch the environment.
+    unsafe { std::env::set_var("EX_DEP_OLD_TOKEN", "secret") };
+
+    // `--token` is deprecated *and* reached through a deprecated alias, so both are reported —
+    // the flag first, then the variable, on both sides.
+    let mut warnings = Vec::new();
+    let empty: Vec<&OsStr> = Vec::new();
+    let ex = Ex::parse_from_with_warnings(&empty, &mut warnings).expect("the alias still supplies");
+    assert_eq!(ex.token.as_deref(), Some("secret"));
+    assert_eq!(warnings.len(), 2, "{warnings:?}");
+    assert_eq!(warnings[0].kind, WarningKind::DeprecatedFlag);
+    assert_eq!(warnings[0].name, "--token");
+    assert_eq!(warnings[1].kind, WarningKind::DeprecatedEnv);
+    assert_eq!(warnings[1].name, "EX_DEP_OLD_TOKEN");
+    assert_eq!(warnings[1].replacement, Some("EX_DEP_TOKEN"));
+
+    let out = usage::parse(&spec, &["ex".to_string()]).expect("the alias still supplies");
+    assert_eq!(out.warnings.len(), 2, "{:?}", out.warnings);
+    assert_eq!(out.warnings[0].kind, LibWarningKind::DeprecatedFlag);
+    assert_eq!(out.warnings[0].name, "--token");
+    assert_eq!(out.warnings[1].kind, LibWarningKind::DeprecatedEnv);
+    assert_eq!(out.warnings[1].name, "EX_DEP_OLD_TOKEN");
+    assert_eq!(out.warnings[1].replacement.as_deref(), Some("EX_DEP_TOKEN"));
+
+    // A current name is not a deprecated one — but supplying a deprecated flag through it is
+    // still using the flag, so that much is still reported.
+    unsafe { std::env::remove_var("EX_DEP_OLD_TOKEN") };
+    unsafe { std::env::set_var("EX_DEP_TOKEN", "secret") };
+    both_report(&[], &[(WarningKind::DeprecatedFlag, "--token")]);
+    unsafe { std::env::remove_var("EX_DEP_TOKEN") };
+}

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -252,6 +252,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
         .unwrap_or_default();
     let partial = partial_struct(cli);
     let argument_lookup = argument_lookup_functions(cli);
+    let deprecations = deprecations_fn(cli);
     let defaults = partial_defaults(cli);
     // A root resolves settings when it binds one itself, or when it says so — which is how a CLI
     // whose bound flags all live in a flattened group asks for the entry points, since it cannot
@@ -611,6 +612,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
             #partial
             #apply
             #argument_lookup
+            #deprecations
 
             /// Everything decided after the last token.
             ///
@@ -821,11 +823,67 @@ pub fn emit(cli: &Cli) -> TokenStream {
                 pub fn parse_from<'v>(
                     argv: &[&'v ::std::ffi::OsStr],
                 ) -> ::std::result::Result<Self, usage_argv::Error<'static, 'v>> {
+                    Self::__usage_parse_from(argv, ::std::option::Option::None)
+                }
+
+                /// Parse a command line, and collect what it used that is deprecated.
+                ///
+                /// Reported rather than printed: a library cannot decide where this program's
+                /// output goes, and a CLI that queues its diagnostics until its logging is up
+                /// needs them as values rather than as lines on stderr. [`Self::parse`], which
+                /// *is* the process, renders them itself.
+                ///
+                /// A warning whose `deprecated_warn_at` this CLI's version has not reached is
+                /// not collected — that is what declaring one means.
+                pub fn parse_from_with_warnings<'v>(
+                    argv: &[&'v ::std::ffi::OsStr],
+                    warnings: &mut ::std::vec::Vec<usage_argv::warn::Warning<'static>>,
+                ) -> ::std::result::Result<Self, usage_argv::Error<'static, 'v>> {
+                    Self::__usage_parse_from(argv, ::std::option::Option::Some(warnings))
+                }
+
+                /// The two above. Collecting is `Option` rather than always-on so a caller that
+                /// did not ask for warnings does not walk the tree looking for them.
+                #[doc(hidden)]
+                fn __usage_parse_from<'v>(
+                    argv: &[&'v ::std::ffi::OsStr],
+                    __usage_warnings: ::std::option::Option<
+                        &mut ::std::vec::Vec<usage_argv::warn::Warning<'static>>,
+                    >,
+                ) -> ::std::result::Result<Self, usage_argv::Error<'static, 'v>> {
                     // The partial is built here and filled through `&mut`, rather than
                     // returned up the chain: see `read_argv_into`.
                     #defaults
                     read_into(Self::command(), argv, &mut partial)?;
+                    if let ::std::option::Option::Some(__usage_out) = __usage_warnings {
+                        Self::__usage_deprecations(&partial, __usage_out);
+                    }
                     ::std::result::Result::Ok(#built)
+                }
+
+                /// Everything this invocation used that its declaration says not to use, gated by
+                /// the version the CLI is actually running as.
+                ///
+                /// The gate lives here rather than where the metadata is read because this is the
+                /// only place that knows the answer: a nested command's tables say nothing about
+                /// the root's version, and a computed `runtime_version` settles only at run time.
+                #[doc(hidden)]
+                fn __usage_deprecations(
+                    partial: &Partial,
+                    out: &mut ::std::vec::Vec<usage_argv::warn::Warning<'static>>,
+                ) {
+                    let mut __usage_found = ::std::vec::Vec::new();
+                    deprecations(partial, &mut __usage_found);
+                    // An empty `Vec` has not allocated, and a CLI with nothing deprecated never
+                    // reaches the version comparison at all.
+                    if !__usage_found.is_empty() {
+                        #effective_spec
+                        usage_argv::warn::retain_reached(
+                            &mut __usage_found,
+                            __usage_spec.version,
+                        );
+                        out.append(&mut __usage_found);
+                    }
                 }
 
                 /// Parse a full argv, including the program name.
@@ -837,10 +895,28 @@ pub fn emit(cli: &Cli) -> TokenStream {
                 pub fn parse_from_argv<'v>(
                     argv: &[&'v ::std::ffi::OsStr],
                 ) -> ::std::result::Result<Self, usage_argv::Error<'static, 'v>> {
+                    Self::__usage_parse_from_argv(argv, ::std::option::Option::None)
+                }
+
+                /// [`Self::parse_from_argv`], collecting the deprecations it used.
+                pub fn parse_from_argv_with_warnings<'v>(
+                    argv: &[&'v ::std::ffi::OsStr],
+                    warnings: &mut ::std::vec::Vec<usage_argv::warn::Warning<'static>>,
+                ) -> ::std::result::Result<Self, usage_argv::Error<'static, 'v>> {
+                    Self::__usage_parse_from_argv(argv, ::std::option::Option::Some(warnings))
+                }
+
+                #[doc(hidden)]
+                fn __usage_parse_from_argv<'v>(
+                    argv: &[&'v ::std::ffi::OsStr],
+                    __usage_warnings: ::std::option::Option<
+                        &mut ::std::vec::Vec<usage_argv::warn::Warning<'static>>,
+                    >,
+                ) -> ::std::result::Result<Self, usage_argv::Error<'static, 'v>> {
                     let ::std::option::Option::Some((__usage_argv0, __usage_words)) =
                         argv.split_first()
                     else {
-                        return Self::parse_from(&[]);
+                        return Self::__usage_parse_from(&[], __usage_warnings);
                     };
                     if let ::std::option::Option::Some(__usage_view) =
                         usage_argv::spec::view_for_program(&SPEC, __usage_argv0)
@@ -866,6 +942,9 @@ pub fn emit(cli: &Cli) -> TokenStream {
                             &mut partial,
                             ::std::option::Option::Some(__usage_view),
                         )?;
+                        if let ::std::option::Option::Some(__usage_out) = __usage_warnings {
+                            Self::__usage_deprecations(&partial, __usage_out);
+                        }
                         return ::std::result::Result::Ok(#built_for_view);
                     }
                     if SPEC.multicall {
@@ -878,10 +957,13 @@ pub fn emit(cli: &Cli) -> TokenStream {
                                 ::std::vec::Vec::with_capacity(argv.len());
                             __usage_rewritten.push(::std::ffi::OsStr::new(__usage_word));
                             __usage_rewritten.extend_from_slice(__usage_words);
-                            return Self::parse_from(&__usage_rewritten);
+                            return Self::__usage_parse_from(
+                                &__usage_rewritten,
+                                __usage_warnings,
+                            );
                         }
                     }
-                    Self::parse_from(__usage_words)
+                    Self::__usage_parse_from(__usage_words, __usage_warnings)
                 }
 
                 /// Parse using clap's `try_parse_from` argv contract.
@@ -891,10 +973,28 @@ pub fn emit(cli: &Cli) -> TokenStream {
                 pub fn try_parse_from<'v>(
                     argv: &[&'v ::std::ffi::OsStr],
                 ) -> ::std::result::Result<Self, usage_argv::Error<'static, 'v>> {
+                    Self::__usage_try_parse_from(argv, ::std::option::Option::None)
+                }
+
+                /// [`Self::try_parse_from`], collecting the deprecations it used.
+                pub fn try_parse_from_with_warnings<'v>(
+                    argv: &[&'v ::std::ffi::OsStr],
+                    warnings: &mut ::std::vec::Vec<usage_argv::warn::Warning<'static>>,
+                ) -> ::std::result::Result<Self, usage_argv::Error<'static, 'v>> {
+                    Self::__usage_try_parse_from(argv, ::std::option::Option::Some(warnings))
+                }
+
+                #[doc(hidden)]
+                fn __usage_try_parse_from<'v>(
+                    argv: &[&'v ::std::ffi::OsStr],
+                    __usage_warnings: ::std::option::Option<
+                        &mut ::std::vec::Vec<usage_argv::warn::Warning<'static>>,
+                    >,
+                ) -> ::std::result::Result<Self, usage_argv::Error<'static, 'v>> {
                     if #no_binary_name {
-                        Self::parse_from(argv)
+                        Self::__usage_parse_from(argv, __usage_warnings)
                     } else {
-                        Self::parse_from_argv(argv)
+                        Self::__usage_parse_from_argv(argv, __usage_warnings)
                     }
                 }
 
@@ -969,8 +1069,24 @@ pub fn emit(cli: &Cli) -> TokenStream {
                     // request — so it answers a failure the way a command-line program does:
                     // the message on stderr, and a non-zero status. `parse_from` hands the error
                     // back instead, for a library embedding this that wants to decide.
-                    match Self::parse_from_argv(&__usage_all_refs) {
-                        ::std::result::Result::Ok(parsed) => parsed,
+                    // Collected here rather than printed where they are found: `parse` is the
+                    // entry point that *is* the process, so it is the one that may write to
+                    // stderr. A failure prints nothing about deprecations — the error is what
+                    // the user needs, and what they typed did not run.
+                    let mut __usage_warnings = ::std::vec::Vec::new();
+                    match Self::__usage_parse_from_argv(
+                        &__usage_all_refs,
+                        ::std::option::Option::Some(&mut __usage_warnings),
+                    ) {
+                        ::std::result::Result::Ok(parsed) => {
+                            if !__usage_warnings.is_empty() {
+                                ::std::eprint!(
+                                    "{}",
+                                    usage_argv::render_warnings(&__usage_warnings),
+                                );
+                            }
+                            parsed
+                        }
                         // Not failures: someone asked a question, and the answer goes to stdout.
                         ::std::result::Result::Err(usage_argv::Error::Version { long }) => {
                             #runtime_program_for_version
@@ -2428,6 +2544,25 @@ fn tracks_invalid_choice(field: &Field) -> bool {
     (!field.choices.is_empty() || field.value_enum) && !field.allow_unknown_choices
 }
 
+/// Whether this field's partial has to remember which variable filled it.
+///
+/// Only a field with a deprecated alias: for every other field the answer could not be
+/// interesting, since every name it accepts is a current one.
+fn tracks_deprecated_env(field: &Field) -> bool {
+    !field.deprecated_env.is_empty()
+}
+
+fn deprecated_env_ident(field: &Field) -> proc_macro2::Ident {
+    format_ident!("__deprecated_env_{}", field.ident)
+}
+
+/// Whether using this field at all is something to warn about.
+fn tracks_deprecated(field: &Field) -> bool {
+    field.deprecated.is_some()
+        || field.deprecated_warn_at.is_some()
+        || field.deprecated_remove_at.is_some()
+}
+
 fn accepted_choices(field: &Field) -> TokenStream {
     match (field.value_enum, field.value_ty.as_ref()) {
         (true, Some(ty)) => quote!(<#ty as usage_argv::spec::ValueEnum>::ACCEPTED_CHOICES),
@@ -3275,7 +3410,16 @@ fn partial_struct(cli: &Cli) -> TokenStream {
             let invalid = format_ident!("__invalid_choice_{}", ident);
             quote!(pub #invalid: bool,)
         });
-        Some(quote!(pub #ident: #ty, pub #given: bool, #overridden #duplicated #here #negated #mirrored #invalid_choice))
+        // Which variable filled this field, when the one that won was a deprecated alias.
+        // Recorded by the fallback loop rather than worked out again afterwards: the precedence
+        // among a field's variables is decided in exactly one place, and a second reading of it
+        // would be free to disagree. Only for fields that declare an alias, so nothing else
+        // carries a word no code reads.
+        let deprecated_env = tracks_deprecated_env(f).then(|| {
+            let recorded = deprecated_env_ident(f);
+            quote!(pub #recorded: ::std::option::Option<&'static str>,)
+        });
+        Some(quote!(pub #ident: #ty, pub #given: bool, #overridden #duplicated #here #negated #mirrored #invalid_choice #deprecated_env))
     });
 
     // No derived `Default`: `start` is what produces a fresh partial, because a
@@ -3616,6 +3760,10 @@ fn partial_defaults(cli: &Cli) -> TokenStream {
             let invalid = format_ident!("__invalid_choice_{}", ident);
             quote!(#invalid: false,)
         });
+        let deprecated_env = tracks_deprecated_env(f).then(|| {
+            let recorded = deprecated_env_ident(f);
+            quote!(#recorded: ::std::option::Option::None,)
+        });
         Some(quote! {
             #ident: ::std::default::Default::default(),
             #given: false,
@@ -3625,6 +3773,7 @@ fn partial_defaults(cli: &Cli) -> TokenStream {
             #negated
             #mirrored
             #invalid_choice
+            #deprecated_env
         })
     });
     // Only the fields that declare one: `Partial`'s own initializer has already put
@@ -4590,6 +4739,7 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
     let deprecated_remove_at = option_str(cli.deprecated_remove_at.as_deref());
     let partial = partial_struct(cli);
     let argument_lookup = argument_lookup_functions(cli);
+    let deprecations = deprecations_fn(cli);
     let defaults = partial_defaults(cli);
     let apply = apply_fn(cli);
     let post = post_binding(cli);
@@ -4806,6 +4956,7 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
             #partial
             #apply
             #argument_lookup
+            #deprecations
 
             pub fn start() -> Partial {
                 #defaults
@@ -4875,6 +5026,13 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
                     event: &usage_argv::Event<'_, '_, '_>,
                 ) -> bool {
                     apply_mirrored_global(partial, event)
+                }
+
+                fn deprecations(
+                    partial: &Self::Partial,
+                    out: &mut ::std::vec::Vec<usage_argv::warn::Warning<'static>>,
+                ) {
+                    deprecations(partial, out)
                 }
 
                 fn check<'t, 'v>(
@@ -5445,6 +5603,40 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
             }
         }
     });
+    // Read from the variant's own metadata rather than from the attributes it was written with:
+    // a variant that says nothing inherits its struct's declaration, and `META_i` is where that
+    // fallback has already been resolved. Help reads the same fields, so the two cannot disagree
+    // about whether a command is deprecated.
+    let deprecations = subs.variants.iter().enumerate().map(|(i, v)| {
+        let variant = format_ident!("V{i}");
+        if v.external {
+            // An unmatched word is not a declared command, so there is nothing to deprecate.
+            quote! {
+                ::std::option::Option::Some(#i) => {}
+            }
+        } else {
+            let ty = &v.ty;
+            let meta = format_ident!("META_{i}");
+            quote! {
+                ::std::option::Option::Some(#i) => {
+                    if #meta.deprecated.is_some()
+                        || #meta.deprecated_warn_at.is_some()
+                        || #meta.deprecated_remove_at.is_some()
+                    {
+                        out.push(usage_argv::warn::Warning::command(
+                            #meta.cmd.name,
+                            #meta.deprecated,
+                            #meta.deprecated_warn_at,
+                            #meta.deprecated_remove_at,
+                        ));
+                    }
+                    if let Partial::#variant(__usage_p) = partial {
+                        <#ty as usage_argv::spec::CommandArgs>::deprecations(__usage_p, out);
+                    }
+                }
+            }
+        }
+    });
     let apply_envs = subs.variants.iter().enumerate().map(|(i, v)| {
         let variant = format_ident!("V{i}");
         if v.external {
@@ -5738,6 +5930,18 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
                     match selected {
                         #(#exclusive_givens)*
                         _ => ::std::option::Option::None,
+                    }
+                }
+
+                fn deprecations(
+                    partial: &Self::Partial,
+                    selected: ::std::option::Option<usize>,
+                    out: &mut ::std::vec::Vec<usage_argv::warn::Warning<'static>>,
+                ) {
+                    match selected {
+                        #(#deprecations)*
+                        // No subcommand was reached, so none of them was used.
+                        _ => {}
                     }
                 }
 
@@ -6126,14 +6330,45 @@ fn env_fallbacks(cli: &Cli, filter_view: bool) -> TokenStream {
         } else {
             quote!()
         };
+        // A deprecated alias is remembered where it won, rather than worked out again later:
+        // the order these names are tried in is the whole rule, and asking a second time
+        // whether an alias "would have" won is a copy of that rule free to disagree with it.
+        // `vars` puts the aliases last, so the winner is deprecated exactly when its index
+        // reaches the tail.
+        let record_deprecated = tracks_deprecated_env(f).then(|| {
+            let recorded = deprecated_env_ident(f);
+            let first_deprecated = vars.len() - f.deprecated_env.len();
+            // A field whose only names are deprecated needs no comparison, and emitting
+            // `>= 0` would be a lint in the adopter's crate rather than here.
+            if first_deprecated == 0 {
+                quote!(partial.#recorded = ::std::option::Option::Some(__usage_env);)
+            } else {
+                quote! {
+                    if __usage_index >= #first_deprecated {
+                        partial.#recorded = ::std::option::Option::Some(__usage_env);
+                    }
+                }
+            }
+        });
+        let names = if record_deprecated.is_some() {
+            quote!([#(#vars),*].into_iter().enumerate())
+        } else {
+            quote!([#(#vars),*])
+        };
+        let bind = if record_deprecated.is_some() {
+            quote!((__usage_index, __usage_env))
+        } else {
+            quote!(__usage_env)
+        };
         Some(quote! {
             if #active !partial.#given #standing {
-                for __usage_env in [#(#vars),*] {
+                for #bind in #names {
                     if let ::std::result::Result::Ok(value) = ::std::env::var(__usage_env) {
                         let mut continue_unset = false;
                         #assign
                         if !continue_unset {
                             partial.#given = true;
+                            #record_deprecated
                             break;
                         }
                     }
@@ -6194,6 +6429,107 @@ fn env_fallbacks(cli: &Cli, filter_view: bool) -> TokenStream {
         #(#own)*
         #(#flattened)*
         #selected
+    }
+}
+
+/// Everything the invocation used that its own declaration says not to use any more.
+///
+/// Read from the filled partial, so this runs after `check`: the environment has had its turn by
+/// then, and a value that arrived through a variable used the deprecated declaration just as much
+/// as a typed word did. A declared default does not — it fills a field without marking it given,
+/// which is exactly the distinction this needs and the one that already exists.
+///
+/// Nothing here consults `deprecated_warn_at`. A nested command's tables say nothing about the
+/// root's version, so the gate is applied once by the entry point that knows it.
+fn deprecations_fn(cli: &Cli) -> TokenStream {
+    let own = cli.fields.iter().filter_map(|f| {
+        // Flags only, because the spec has `deprecated` on a flag and on a command and not on a
+        // positional: warning about one would be a behaviour the emitted KDL cannot express.
+        let Kind::Flag { longs, shorts, .. } = &f.kind else {
+            return None;
+        };
+        if !tracks_deprecated(f) {
+            return None;
+        }
+        let given = format_ident!("__given_{}", f.ident);
+        // Named the way the user names it. `Field::name` is the spec's name for the flag, which
+        // has no dashes, and a warning that said `old-flag is deprecated` would be about a word
+        // nobody typed.
+        let spelling = match (longs.first(), shorts.first()) {
+            (Some(long), _) => format!("--{long}"),
+            (None, Some(short)) => format!("-{short}"),
+            (None, None) => f.name.clone(),
+        };
+        let message = option_str(f.deprecated.as_deref());
+        let warn_at = option_str(f.deprecated_warn_at.as_deref());
+        let remove_at = option_str(f.deprecated_remove_at.as_deref());
+        Some(quote! {
+            if partial.#given {
+                out.push(usage_argv::warn::Warning::flag(
+                    #spelling,
+                    #message,
+                    #warn_at,
+                    #remove_at,
+                ));
+            }
+        })
+    });
+    let aliases = cli.fields.iter().filter_map(|f| {
+        if !tracks_deprecated_env(f) {
+            return None;
+        }
+        let recorded = deprecated_env_ident(f);
+        // What to use instead: the name this field reads first. A field whose only variable is
+        // the deprecated one has nothing to suggest, and says only that it is deprecated.
+        let replacement = option_str(
+            f.env
+                .as_deref()
+                .or_else(|| f.env_fallback.first().map(String::as_str)),
+        );
+        Some(quote! {
+            if let ::std::option::Option::Some(__usage_env) = partial.#recorded {
+                out.push(usage_argv::warn::Warning::env(__usage_env, #replacement));
+            }
+        })
+    });
+    let flattened = cli.fields.iter().filter_map(|f| {
+        let Kind::Flatten { ty } = &f.kind else {
+            return None;
+        };
+        let ident = &f.ident;
+        Some(quote! {
+            <#ty as usage_argv::spec::CommandArgs>::deprecations(&partial.#ident, out);
+        })
+    });
+    let selected = cli.fields.iter().find_map(|f| {
+        let Kind::Subcommand { ty, .. } = &f.kind else {
+            return None;
+        };
+        Some(quote! {
+            <#ty as usage_argv::spec::Subcommands>::deprecations(
+                &partial.__usage_sub,
+                partial.__usage_selected,
+                out,
+            );
+        })
+    });
+    quote! {
+        /// What this command line used that the spec says not to use any more.
+        ///
+        /// Collected rather than printed, and only when an entry point was asked for it: a
+        /// `parse_from` that takes no sink never walks this at all.
+        pub fn deprecations(
+            partial: &Partial,
+            out: &mut ::std::vec::Vec<usage_argv::warn::Warning<'static>>,
+        ) {
+            // Read unconditionally, so a command with nothing deprecated does not leave its
+            // parameters unused in the adopter's crate, where nobody can silence it.
+            let _ = (&partial, &mut *out);
+            #(#own)*
+            #(#aliases)*
+            #(#flattened)*
+            #selected
+        }
     }
 }
 

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -4819,6 +4819,28 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
                     }
                 }
 
+                fn deprecations_for_view_path(
+                    partial: &Self::Partial,
+                    remaining_descendants: usize,
+                    out: &mut ::std::vec::Vec<usage_argv::warn::Warning<'static>>,
+                ) {
+                    if remaining_descendants == 0 {
+                        <Self as usage_argv::spec::CommandArgs>::deprecations(partial, out);
+                    } else if let ::std::option::Option::Some(__usage_at) =
+                        partial.__usage_selected
+                    {
+                        // Structural under this view, like `check_for_view_path`: an injected
+                        // parent's own declarations are not the promoted executable's surface,
+                        // so nothing about them is reported.
+                        <#ty as usage_argv::spec::Subcommands>::deprecations_for_view_path(
+                            &partial.__usage_sub,
+                            ::std::option::Option::Some(__usage_at),
+                            remaining_descendants,
+                            out,
+                        );
+                    }
+                }
+
                 fn check_for_view_path<'t, 'v>(
                     partial: &mut Self::Partial,
                     remaining_descendants: usize,
@@ -5637,6 +5659,34 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
             }
         }
     });
+    let view_deprecations = subs.variants.iter().enumerate().map(|(i, v)| {
+        let variant = format_ident!("V{i}");
+        if v.external {
+            quote! {
+                ::std::option::Option::Some(#i) => {}
+            }
+        } else {
+            let ty = &v.ty;
+            quote! {
+                ::std::option::Option::Some(#i) => {
+                    if let Partial::#variant(__usage_p) = partial {
+                        if remaining_commands <= 1 {
+                            // The promoted command itself is not reported — under this view it
+                            // is the program — but its own flags were still typed by somebody,
+                            // and so was anything selected below it.
+                            <#ty as usage_argv::spec::CommandArgs>::deprecations(__usage_p, out);
+                        } else {
+                            <#ty as usage_argv::spec::CommandArgs>::deprecations_for_view_path(
+                                __usage_p,
+                                remaining_commands - 1,
+                                out,
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    });
     let apply_envs = subs.variants.iter().enumerate().map(|(i, v)| {
         let variant = format_ident!("V{i}");
         if v.external {
@@ -5941,6 +5991,18 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
                     match selected {
                         #(#deprecations)*
                         // No subcommand was reached, so none of them was used.
+                        _ => {}
+                    }
+                }
+
+                fn deprecations_for_view_path(
+                    partial: &Self::Partial,
+                    selected: ::std::option::Option<usize>,
+                    remaining_commands: usize,
+                    out: &mut ::std::vec::Vec<usage_argv::warn::Warning<'static>>,
+                ) {
+                    match selected {
+                        #(#view_deprecations)*
                         _ => {}
                     }
                 }
@@ -6506,11 +6568,30 @@ fn deprecations_fn(cli: &Cli) -> TokenStream {
             return None;
         };
         Some(quote! {
-            <#ty as usage_argv::spec::Subcommands>::deprecations(
-                &partial.__usage_sub,
-                partial.__usage_selected,
-                out,
-            );
+            if let ::std::option::Option::Some(__usage_at) = partial.__usage_selected {
+                // `check_with_view` recorded the view on the partial, so this reads the same
+                // answer the rest of the post-binding work did.
+                match partial.__usage_view {
+                    // Under an executable view the words the view injected are not a selection
+                    // the user made — they are what the program is — so they are not reported,
+                    // for the same reason the root never is.
+                    ::std::option::Option::Some(__usage_view) => {
+                        <#ty as usage_argv::spec::Subcommands>::deprecations_for_view_path(
+                            &partial.__usage_sub,
+                            ::std::option::Option::Some(__usage_at),
+                            __usage_view.root.split_ascii_whitespace().count(),
+                            out,
+                        );
+                    }
+                    ::std::option::Option::None => {
+                        <#ty as usage_argv::spec::Subcommands>::deprecations(
+                            &partial.__usage_sub,
+                            ::std::option::Option::Some(__usage_at),
+                            out,
+                        );
+                    }
+                }
+            }
         })
     });
     quote! {

--- a/docs/rust/args-and-flags.md
+++ b/docs/rust/args-and-flags.md
@@ -71,7 +71,10 @@ jobs: Option<u32>,
 | `global`                                                | Usable on any subcommand below this one                                                 |
 | `env = "X"`                                             | Read the value from `X` when argv does not supply it                                    |
 | `env_fallback("A", "B")`                                | Try additional environment variables in declaration order                               |
-| `deprecated_env("OLD_X")`                               | Try deprecated aliases last and label them in generated help/docs                       |
+| `deprecated_env("OLD_X")`                               | Try deprecated aliases last, and report the one that supplied a value                   |
+| `deprecated = "…"`                                      | Still works, should not be used; reported when given                                    |
+| `deprecated_warn_at = "…"`                              | Withhold that warning until this build's version reaches the release                    |
+| `deprecated_remove_at = "…"`                            | The release it goes away in, which the warning mentions                                 |
 | `var` / `variadic`                                      | Repeatable / greedy multi-value (see above)                                             |
 | `var_min = n` / `var_max = n`                           | Bounds on how many values a `Vec` may hold                                              |
 | `num_args = n` / `num_args = a..=b`                     | clap-compatible spelling for exact or ranged `Vec` cardinality                          |

--- a/docs/rust/help.md
+++ b/docs/rust/help.md
@@ -51,6 +51,32 @@ arm and before command dispatch. There is no hidden callback lifecycle: the
 embedding application owns the order explicitly, and `parse()` remains the
 convenience entry point for CLIs that want immediate print-and-exit behavior.
 
+### Deprecation warnings
+
+A `deprecated` flag or command, or a value that arrived through a `deprecated_env` alias, is
+something a parse has to say — and saying it is not the parser's decision to make about your
+program's output. So the warnings come back as values:
+
+```rust
+let mut warnings = Vec::new();
+let cli = Cli::parse_from_with_warnings(&argv, &mut warnings)?;
+for warning in &warnings {
+    // your logger, once it is up
+    log::warn!("{}", usage::warn::render_warning(warning));
+}
+```
+
+`parse_from_argv_with_warnings` and `try_parse_from_with_warnings` are the same thing beside
+their own entry points. `parse()` — the one that already exits for `--help` — renders them to
+stderr itself and carries on. The entry points without a sink collect nothing at all, so a
+caller that does not want warnings pays for none of it.
+
+Each `usage::warn::Warning` carries a `kind`, the `name` as the user spelled it, the author's
+`message`, and the release milestones. A warning whose `deprecated_warn_at` this build's
+`version` has not reached is not collected: declaring one is how an author says _not yet_. The
+full rule, including what a default does not count as, is in
+[the grammar](/spec/argv#warnings).
+
 ### Customizing the page
 
 - `usage = "…"` on the root replaces the generated synopsis line(s) verbatim.

--- a/docs/spec/argv.md
+++ b/docs/spec/argv.md
@@ -365,6 +365,63 @@ None of this changes which token binds where. It only fills what the command lin
 left empty, which is why it is described last: an implementation can do all of it
 after the single pass is over.
 
+## Warnings
+
+A declaration may still work and still be something a CLI wants to stop people using.
+`deprecated` on a flag or a command says so, and `deprecated_env` says it about one of
+the variables a value may arrive through. Help and completions describe those already;
+this is what a parse says to the person who just used one.
+
+A parse **reports rather than prints**. A parser that wrote to stderr could not be used
+by anything with an opinion about output, and mise queues its deprecations until its
+logging is up — the same rule [configuration resolution](/spec/resolution#warnings)
+follows. What prints is the CLI's own process entry point, not the parse.
+
+Each warning has a **kind**, because the wording is for a person and the kind is what a
+program acts on:
+
+| kind                 | what happened                                                  |
+| -------------------- | -------------------------------------------------------------- |
+| `deprecated-flag`    | a flag whose declaration says not to use it any more was given |
+| `deprecated-command` | a selected command's declaration says not to use it any more   |
+| `deprecated-env`     | a value arrived through a `deprecated_env` alias               |
+
+What a parse reports is a _set_, not a sequence. Every deprecation a command line used
+is reported once, and the arrangement is a quality-of-implementation matter: two
+implementations agree on which warnings there are without having to agree on the order
+they come out in. A caller that cares about arrangement sorts by `kind`.
+
+Three rules decide whether there is anything to say.
+
+**The command line and the environment count; a default does not.** A flag supplied by a
+variable used the deprecated declaration as much as a typed word did, and both are things
+the user arranged. A declared default is nobody's request, so a deprecated flag with a
+default does not warn on a command line that never mentioned it.
+
+**Every deprecated command on the selected path reports**, not only the last one: a
+deprecated group whose child is fine was still the way in. The root is not one of them —
+it is the program that is running, not something the command line selected.
+
+**`deprecated_warn_at` is an author saying _not yet_.** A warning is withheld until the
+CLI's own `version` reaches that release. `deprecated_remove_at` never withholds anything
+and is never an error: removing a declaration is the author's job, not the parser's, and
+until then the milestone is something the message mentions.
+
+Versions compare as dotted integers, left to right:
+
+| case                                  | result                                               |
+| ------------------------------------- | ---------------------------------------------------- |
+| no `deprecated_warn_at`               | warn — it is deprecated now                          |
+| the CLI declares no `version`         | warn                                                 |
+| either version is not readable as one | warn                                                 |
+| unequal segment counts                | missing segments are `0`, so `2026.12` = `2026.12.0` |
+| a `-suffix`                           | sorts before the same numbers without one            |
+| a `+suffix`                           | ignored                                              |
+
+Semver and calver both work under that rule. Every uncertain case warns on purpose: noise
+is recoverable and silence is not, so a version string an implementation cannot read
+produces a warning rather than hiding one.
+
 ## Errors
 
 The grammar distinguishes these classes of failure. Wording is not specified —

--- a/docs/spec/argv.md
+++ b/docs/spec/argv.md
@@ -400,7 +400,11 @@ default does not warn on a command line that never mentioned it.
 
 **Every deprecated command on the selected path reports**, not only the last one: a
 deprecated group whose child is fine was still the way in. The root is not one of them —
-it is the program that is running, not something the command line selected.
+it is the program that is running, not something the command line selected. Neither is a
+command a [`view`](/rust/subcommands#executable-views) promoted, nor any command the view routes through:
+under `aubr` those words _are_ the program's identity, so an implementation that reaches
+them by rewriting `argv` reports no more than one that reads a spec whose root is already
+the promoted command.
 
 **`deprecated_warn_at` is an author saying _not yet_.** A warning is withheld until the
 CLI's own `version` reaches that release. `deprecated_remove_at` never withholds anything

--- a/docs/spec/reference/cmd.md
+++ b/docs/spec/reference/cmd.md
@@ -47,6 +47,21 @@ cmd "list" {
 }
 ```
 
+## Deprecating a command
+
+`deprecated="use build"` on a `cmd` says the command still works and should not be used
+any more, with `deprecated_warn_at` and `deprecated_remove_at` naming releases as they do
+on a [flag](/spec/reference/flag#deprecated).
+
+```kdl
+cmd "compile" deprecated="use build" deprecated_remove_at="3.0.0" {
+    flag "--incremental"
+}
+```
+
+Selecting it is what reports it, and every deprecated command on the path reports rather
+than only the last one. See [Warnings](/spec/argv#warnings).
+
 ## Mounting dynamic commands
 
 A usage spec can define a command to run which emits extra usage spec which will be merged into the

--- a/docs/spec/reference/flag.md
+++ b/docs/spec/reference/flag.md
@@ -115,6 +115,26 @@ flag "--file <file>" {
 }
 ```
 
+## `deprecated`
+
+`deprecated="use --out"` says a flag still works and should not be used any more. It shows
+in help and in completion descriptions, and a parse reports it when the flag is actually
+given — see [Warnings](/spec/argv#warnings) for what counts as a use and what a CLI does
+with the report.
+
+`deprecated_warn_at` and `deprecated_remove_at` name releases. The first withholds the
+warning until the CLI's own `version` reaches it, which is how a deprecation is declared
+before it starts nagging; the second is only ever mentioned in the message.
+
+```kdl
+flag "--output <output>" deprecated="use --out" deprecated_remove_at="3.0.0"
+flag "--legacy" deprecated="use --modern" deprecated_warn_at="2027.1.0"
+```
+
+A `deprecated_env` alias is the same idea for one of the names a value may arrive through:
+the value is still read, and the variable that supplied it is reported along with the
+current name to use instead.
+
 ## `conflicts` and `overrides`
 
 Both describe a pair of flags that should not be in effect at once, and they differ in

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -15,6 +15,7 @@ pub use crate::spec::mount::SpecMount;
 pub use crate::spec::unknown_flags::UnknownFlags;
 pub use crate::spec::view::SpecView;
 pub use crate::spec::Spec;
+pub use crate::warn::{Warning, WarningKind};
 
 #[macro_use]
 #[allow(unused_assignments)] // Fields in struct variants are read by derive macros
@@ -34,3 +35,4 @@ pub mod sh;
 pub(crate) mod string;
 #[cfg(test)]
 mod test;
+pub mod warn;

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -13,6 +13,7 @@ use crate::docs;
 use crate::error::UsageErr;
 use crate::spec::arg::SpecDoubleDashChoices;
 use crate::spec::unknown_flags::UnknownFlags;
+use crate::warn::Warning;
 use crate::{Spec, SpecArg, SpecChoices, SpecCommand, SpecFlag};
 
 /// Merge a subcommand's flags into the currently available flags when descending
@@ -280,6 +281,10 @@ pub struct ParseOutput {
     pub available_flags: BTreeMap<String, Arc<SpecFlag>>,
     pub flag_awaiting_value: Vec<Arc<SpecFlag>>,
     pub errors: Vec<UsageErr>,
+    /// Deprecated declarations this command line used, for the caller to render when its
+    /// logging is up. Empty from [`parse_partial`]: a half-typed line being completed has
+    /// not used anything yet.
+    pub warnings: Vec<Warning>,
     /// The positional argument the next word would have filled, i.e. where the parser's
     /// cursor stopped. `None` once every argument is satisfied.
     ///
@@ -337,6 +342,99 @@ pub enum ParseValue {
     String(String),
     MultiBool(Vec<bool>),
     MultiString(Vec<String>),
+}
+
+/// The deprecated declarations argv itself named: the commands it descended through, and the
+/// flags it bound.
+///
+/// Called before the environment and defaults have filled anything, because afterwards nothing
+/// distinguishes a flag the user typed from one a variable supplied — and the two are reported
+/// differently, at the point where each is applied.
+///
+/// The root is skipped. A `deprecated` root would otherwise warn on every invocation of the CLI,
+/// including `--help`, and the compiled parser reports selected commands rather than the one the
+/// process already is.
+fn collect_deprecations(out: &mut ParseOutput) {
+    for cmd in out.cmds.iter().skip(1) {
+        if cmd.deprecated.is_none()
+            && cmd.deprecated_warn_at.is_none()
+            && cmd.deprecated_remove_at.is_none()
+        {
+            continue;
+        }
+        out.warnings.push(Warning::command(
+            cmd.name.clone(),
+            cmd.deprecated.clone(),
+            cmd.deprecated_warn_at.clone(),
+            cmd.deprecated_remove_at.clone(),
+        ));
+    }
+    for flag in out.flags.keys() {
+        if let Some(warning) = flag_deprecation(flag) {
+            out.warnings.push(warning);
+        }
+    }
+}
+
+/// A warning for a flag that was used, if its declaration is deprecated at all.
+fn flag_deprecation(flag: &SpecFlag) -> Option<Warning> {
+    if flag.deprecated.is_none()
+        && flag.deprecated_warn_at.is_none()
+        && flag.deprecated_remove_at.is_none()
+    {
+        return None;
+    }
+    Some(Warning::flag(
+        flag_spelling(flag),
+        flag.deprecated.clone(),
+        flag.deprecated_warn_at.clone(),
+        flag.deprecated_remove_at.clone(),
+    ))
+}
+
+/// A flag named the way the user names it. The spec's name for it has no dashes, and a warning
+/// about `old-flag` would be about a word nobody typed.
+fn flag_spelling(flag: &SpecFlag) -> String {
+    flag.long
+        .first()
+        .map(|long| format!("--{long}"))
+        .or_else(|| flag.short.first().map(|short| format!("-{short}")))
+        .unwrap_or_else(|| flag.name.clone())
+}
+
+/// The name this flag reads first, which is what to use instead of a deprecated alias.
+fn flag_current_env(flag: &SpecFlag) -> Option<String> {
+    flag.env
+        .clone()
+        .or_else(|| flag.env_fallback.first().cloned())
+}
+
+fn flag_env_is_deprecated(flag: &SpecFlag, name: &str) -> bool {
+    flag.deprecated_env.iter().any(|declared| declared == name)
+}
+
+/// The same two questions for a positional, which has aliases but no `deprecated` of its own.
+fn arg_current_env(arg: &SpecArg) -> Option<String> {
+    arg.env
+        .clone()
+        .or_else(|| arg.env_fallback.first().cloned())
+}
+
+fn arg_env_is_deprecated(arg: &SpecArg, name: &str) -> bool {
+    arg.deprecated_env.iter().any(|declared| declared == name)
+}
+
+/// The first of `names` that is set, and which one it was.
+///
+/// `env_names()` yields the current name, then the declared fallbacks, then the deprecated
+/// aliases, so the winner's identity is what says whether a value arrived through an alias.
+/// Deciding that a second time, from the outside, would be a copy of this precedence rule free to
+/// disagree with it.
+fn first_set_env<'a>(
+    mut names: impl Iterator<Item = &'a str>,
+    get_env: &impl Fn(&str) -> Option<String>,
+) -> Option<(&'a str, String)> {
+    names.find_map(|name| get_env(name).map(|value| (name, value)))
 }
 
 /// Builder for parsing command-line arguments with custom options.
@@ -436,6 +534,11 @@ impl<'a> Parser<'a> {
             .into());
         }
 
+        // Before the environment and defaults have their turn, because both mark a field as
+        // filled and only argv can be reported as something the user typed. Env is reported
+        // where it is applied, below; a default is nobody's request and reports nothing.
+        collect_deprecations(&mut out);
+
         let get_env = |key: &str| -> Option<String> {
             if let Some(env_map) = custom_env {
                 env_map.get(key).cloned()
@@ -452,7 +555,11 @@ impl<'a> Parser<'a> {
             if out.args.contains_key(arg) {
                 continue;
             }
-            if let Some(env_value) = arg.env_names().find_map(&get_env) {
+            if let Some((env_name, env_value)) = first_set_env(arg.env_names(), &get_env) {
+                if arg_env_is_deprecated(arg, env_name) {
+                    out.warnings
+                        .push(Warning::env(env_name, arg_current_env(arg)));
+                }
                 let values = split_fallback_values(std::slice::from_ref(&env_value), arg.delimiter);
                 validate_choice_values(
                     ChoiceTarget::arg(arg),
@@ -508,7 +615,17 @@ impl<'a> Parser<'a> {
             if out.flags.contains_key(flag) || overridden_flags.contains(&flag.name) {
                 continue;
             }
-            if let Some(env_value) = flag.env_names().find_map(&get_env) {
+            if let Some((env_name, env_value)) = first_set_env(flag.env_names(), &get_env) {
+                // The flag's own deprecation before the alias's, which is the order the
+                // compiled parser reports them in: it walks a command's flags and then its
+                // aliases. Using a deprecated flag through a variable is still using it.
+                if let Some(warning) = flag_deprecation(flag) {
+                    out.warnings.push(warning);
+                }
+                if flag_env_is_deprecated(flag, env_name) {
+                    out.warnings
+                        .push(Warning::env(env_name, flag_current_env(flag)));
+                }
                 if let Some(arg) = flag.arg.as_ref() {
                     let values =
                         split_fallback_values(std::slice::from_ref(&env_value), arg.delimiter);
@@ -609,6 +726,9 @@ impl<'a> Parser<'a> {
         if !out.errors.is_empty() {
             bail!("{}", out.errors.iter().map(|e| e.to_string()).join("\n"));
         }
+        // Applied once, here, because this is where the CLI's own version is known: a
+        // `deprecated_warn_at` the spec has not reached yet is an author saying *not yet*.
+        crate::warn::retain_reached(&mut out.warnings, self.spec.version.as_deref());
         Ok(out)
     }
 }
@@ -707,6 +827,7 @@ fn parse_partial_with_env(
         available_flags: gather_flags(&spec.cmd),
         flag_awaiting_value: vec![],
         errors: vec![],
+        warnings: vec![],
         next_arg: None,
         double_dash_seen: false,
         external: None,
@@ -7268,6 +7389,83 @@ cmd "run" {
         let parsed =
             parse_with_env(&spec, &["test"], &[("DEPRECATED_NAME", "deprecated")]).unwrap();
         assert_eq!(first_string_value(&parsed), "deprecated");
+    }
+
+    #[test]
+    fn a_value_from_a_deprecated_alias_says_which_name_to_use() {
+        let spec = spec_with_flag(
+            SpecFlag::builder()
+                .long("name")
+                .env("NAME")
+                .deprecated_env("DEPRECATED_NAME")
+                .arg(SpecArg::builder().name("name").build())
+                .build(),
+        );
+
+        // The current name is not a deprecated one, and says nothing.
+        let parsed = parse_with_env(&spec, &["test"], &[("NAME", "canonical")]).unwrap();
+        assert!(parsed.warnings.is_empty(), "{:?}", parsed.warnings);
+
+        let parsed =
+            parse_with_env(&spec, &["test"], &[("DEPRECATED_NAME", "deprecated")]).unwrap();
+        assert_eq!(parsed.warnings.len(), 1, "{:?}", parsed.warnings);
+        assert_eq!(
+            parsed.warnings[0].kind,
+            crate::warn::WarningKind::DeprecatedEnv
+        );
+        assert_eq!(parsed.warnings[0].name, "DEPRECATED_NAME");
+        assert_eq!(parsed.warnings[0].replacement.as_deref(), Some("NAME"));
+        // Reported, not printed, and the value still arrives.
+        assert_eq!(first_string_value(&parsed), "deprecated");
+    }
+
+    #[test]
+    fn a_deprecated_flag_reports_only_when_it_was_used() {
+        let spec = spec_with_flag(
+            SpecFlag::builder()
+                .long("output")
+                .deprecated("use --out")
+                .deprecated_remove_at("3.0.0")
+                .arg(SpecArg::builder().name("output").build())
+                .build(),
+        );
+
+        let parsed = parse_with_env(&spec, &["test"], &[]).unwrap();
+        assert!(parsed.warnings.is_empty(), "{:?}", parsed.warnings);
+
+        let parsed = parse_with_env(&spec, &["test", "--output", "a.txt"], &[]).unwrap();
+        assert_eq!(parsed.warnings.len(), 1, "{:?}", parsed.warnings);
+        assert_eq!(
+            parsed.warnings[0].kind,
+            crate::warn::WarningKind::DeprecatedFlag
+        );
+        // Named the way it was typed, dashes and all.
+        assert_eq!(parsed.warnings[0].name, "--output");
+        assert_eq!(parsed.warnings[0].remove_at.as_deref(), Some("3.0.0"));
+        assert_eq!(
+            parsed.warnings[0].render(),
+            "warning: --output is deprecated, removed at 3.0.0: use --out\n",
+        );
+    }
+
+    #[test]
+    fn a_milestone_the_spec_has_not_reached_stays_quiet() {
+        let flag = SpecFlag::builder()
+            .long("output")
+            .deprecated("use --out")
+            .deprecated_warn_at("9.0.0")
+            .arg(SpecArg::builder().name("output").build())
+            .build();
+        let mut spec = spec_with_flag(flag);
+        spec.version = Some("2.0.0".to_string());
+
+        let parsed = parse_with_env(&spec, &["test", "--output", "a.txt"], &[]).unwrap();
+        assert!(parsed.warnings.is_empty(), "{:?}", parsed.warnings);
+
+        // And once the CLI is the release that was named, it speaks up.
+        spec.version = Some("9.0.0".to_string());
+        let parsed = parse_with_env(&spec, &["test", "--output", "a.txt"], &[]).unwrap();
+        assert_eq!(parsed.warnings.len(), 1, "{:?}", parsed.warnings);
     }
 
     #[test]

--- a/lib/src/warn.rs
+++ b/lib/src/warn.rs
@@ -1,0 +1,217 @@
+//! What a parse has to say about declarations that still work but should not be used.
+//!
+//! The reference implementation's half of what `usage-argv` reports from its static tables. Both
+//! answer the same question — which deprecated declarations did this command line use — and the
+//! rule they answer it by is written down at <https://usage.jdx.dev/spec/argv>, not in either
+//! crate. Neither can depend on the other: usage-argv has no dependencies at all, on purpose.
+//!
+//! Nothing here prints. A resolution reports, as configuration resolution does, so a CLI that
+//! queues its deprecations until its logging is up can have them as values.
+
+use std::cmp::Ordering;
+
+/// One thing a command line used that its own spec says not to use any more.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Warning {
+    /// What sort of declaration it was, for a caller that treats them differently.
+    pub kind: WarningKind,
+    /// What the user typed or set: `--old-flag`, `old-cmd`, `OLD_ENV`.
+    pub name: String,
+    /// The author's reason, when the declaration carries one.
+    pub message: Option<String>,
+    /// The release warnings start at. A warning that is here has already passed it.
+    pub warn_at: Option<String>,
+    /// The release the declaration goes away in, when the author has named one.
+    pub remove_at: Option<String>,
+    /// What to use instead, when the declaration implies one.
+    pub replacement: Option<String>,
+}
+
+/// The kinds of deprecation a parse can run into.
+///
+/// The wording of a message is nobody's contract; this is what a program can act on.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum WarningKind {
+    /// A flag whose declaration says not to use it any more.
+    DeprecatedFlag,
+    /// A command whose declaration says not to use it any more.
+    DeprecatedCommand,
+    /// A value that arrived through a `deprecated_env` alias rather than a current name.
+    DeprecatedEnv,
+    /// Something a CLI's own layer says, which this crate has no name for.
+    #[default]
+    Other,
+}
+
+impl Warning {
+    /// A deprecated flag that was given, named as the user names it.
+    pub fn flag(
+        name: impl Into<String>,
+        message: Option<String>,
+        warn_at: Option<String>,
+        remove_at: Option<String>,
+    ) -> Self {
+        Self {
+            kind: WarningKind::DeprecatedFlag,
+            name: name.into(),
+            message,
+            warn_at,
+            remove_at,
+            replacement: None,
+        }
+    }
+
+    /// A deprecated command that was selected.
+    pub fn command(
+        name: impl Into<String>,
+        message: Option<String>,
+        warn_at: Option<String>,
+        remove_at: Option<String>,
+    ) -> Self {
+        Self {
+            kind: WarningKind::DeprecatedCommand,
+            name: name.into(),
+            message,
+            warn_at,
+            remove_at,
+            replacement: None,
+        }
+    }
+
+    /// A value read from a deprecated environment alias, and the current name for it.
+    pub fn env(name: impl Into<String>, replacement: Option<String>) -> Self {
+        Self {
+            kind: WarningKind::DeprecatedEnv,
+            name: name.into(),
+            message: None,
+            warn_at: None,
+            remove_at: None,
+            replacement,
+        }
+    }
+
+    /// What a caller should print for this warning.
+    pub fn render(&self) -> String {
+        let subject = match self.kind {
+            WarningKind::DeprecatedCommand => format!("the {} command", self.name),
+            _ => self.name.clone(),
+        };
+        let mut out = format!("warning: {subject} is deprecated");
+        if let Some(at) = &self.remove_at {
+            out.push_str(&format!(", removed at {at}"));
+        }
+        match (&self.message, &self.replacement) {
+            (Some(message), _) => out.push_str(&format!(": {message}")),
+            (None, Some(replacement)) => out.push_str(&format!(": use {replacement}")),
+            (None, None) => {}
+        }
+        out.push('\n');
+        out
+    }
+}
+
+/// Whether a CLI at `current` has reached the release a deprecation starts warning at.
+///
+/// `deprecated_warn_at` is how an author says *not yet*. Every uncertain case warns: a missing
+/// milestone means deprecated now, and a version this cannot read is a spec or build problem that
+/// should be noisy rather than silent.
+pub fn version_reaches(current: Option<&str>, warn_at: Option<&str>) -> bool {
+    let (Some(warn_at), Some(current)) = (warn_at, current) else {
+        return true;
+    };
+    !matches!(compare(current, warn_at), Some(Ordering::Less))
+}
+
+/// Order two versions, or `None` if either is not a version this can read.
+///
+/// Dotted integers compared left to right, a missing segment reading as zero, a `-suffix` sorting
+/// before the same numbers without one, and `+build` ignored. The same rule `usage_argv::warn`
+/// implements, held to it by a parity test.
+pub fn compare(a: &str, b: &str) -> Option<Ordering> {
+    let (a_core, a_pre) = split(a);
+    let (b_core, b_pre) = split(b);
+    let mut a_segments = a_core.split('.');
+    let mut b_segments = b_core.split('.');
+    loop {
+        let (a_next, b_next) = (a_segments.next(), b_segments.next());
+        if a_next.is_none() && b_next.is_none() {
+            break;
+        }
+        match segment(a_next)?.cmp(&segment(b_next)?) {
+            Ordering::Equal => continue,
+            ordering => return Some(ordering),
+        }
+    }
+    Some(match (a_pre, b_pre) {
+        (None, None) => Ordering::Equal,
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (Some(a), Some(b)) => a.cmp(b),
+    })
+}
+
+fn split(version: &str) -> (&str, Option<&str>) {
+    let version = version.split('+').next().unwrap_or(version);
+    match version.split_once('-') {
+        Some((core, pre)) => (core, Some(pre)),
+        None => (version, None),
+    }
+}
+
+fn segment(segment: Option<&str>) -> Option<u64> {
+    match segment {
+        None => Some(0),
+        Some(text) => text.parse().ok(),
+    }
+}
+
+/// Drop the warnings a CLI at `version` has not reached yet.
+pub fn retain_reached(warnings: &mut Vec<Warning>, version: Option<&str>) {
+    warnings.retain(|warning| version_reaches(version, warning.warn_at.as_deref()));
+}
+
+/// Everything, one line each, in the order they were collected.
+pub fn render(warnings: &[Warning]) -> String {
+    warnings.iter().map(Warning::render).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_gate_matches_the_rule() {
+        assert!(version_reaches(Some("1.0.0"), None));
+        assert!(version_reaches(None, Some("2.0.0")));
+        assert!(!version_reaches(Some("1.0.0"), Some("2.0.0")));
+        assert!(version_reaches(Some("2.0.0"), Some("2.0.0")));
+        assert!(!version_reaches(Some("2.0.0-rc.1"), Some("2.0.0")));
+        assert!(version_reaches(Some("nightly"), Some("2.0.0")));
+        assert_eq!(compare("2026.12", "2026.12.0"), Some(Ordering::Equal));
+        assert_eq!(compare("1.0.0+abc", "1.0.0+def"), Some(Ordering::Equal));
+        assert_eq!(compare("nightly", "1.0.0"), None);
+    }
+
+    #[test]
+    fn a_warning_says_what_to_do_about_it() {
+        assert_eq!(
+            Warning::flag(
+                "--old",
+                Some("use --new".into()),
+                None,
+                Some("2.0.0".into())
+            )
+            .render(),
+            "warning: --old is deprecated, removed at 2.0.0: use --new\n",
+        );
+        assert_eq!(
+            Warning::command("old", None, None, None).render(),
+            "warning: the old command is deprecated\n",
+        );
+        assert_eq!(
+            Warning::env("OLD_TOKEN", Some("APP_TOKEN".into())).render(),
+            "warning: OLD_TOKEN is deprecated: use APP_TOKEN\n",
+        );
+    }
+}

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -2449,3 +2449,139 @@ fn runtime_program_identity_is_separate_from_the_portable_spec() {
     assert!(script.contains("runtime-ex"), "{script}");
     assert!(!script.contains("'portable-ex'"), "{script}");
 }
+
+/// A CLI whose declarations have all four shapes of deprecation on them.
+///
+/// Version `2.0.0`, so the milestones below are on both sides of where this CLI actually is.
+#[derive(Cli)]
+#[usage(bin = "deprecated-ex", version = "2.0.0")]
+struct DeprecatedEx {
+    /// Where to write the result
+    #[usage(long, deprecated = "use --out", deprecated_remove_at = "3.0.0")]
+    output: Option<String>,
+    #[usage(long)]
+    out: Option<String>,
+    /// Deprecated in a release this CLI has not reached
+    #[usage(long, deprecated = "use --out", deprecated_warn_at = "9.0.0")]
+    outfile: Option<String>,
+    /// A milestone that has passed, with no message beside it
+    #[usage(long, deprecated_warn_at = "1.0.0")]
+    legacy: bool,
+    // Declared here so the alias is part of the shape these cases parse, but exercised in
+    // `usage-conformance`'s `deprecation.rs` rather than here: a variable is process-wide, and
+    // setting one in this binary would race every other case in it that parses this CLI.
+    #[usage(
+        long,
+        env = "DEPRECATED_EX_TOKEN",
+        deprecated_env = "DEPRECATED_EX_OLD_TOKEN"
+    )]
+    token: Option<String>,
+    #[usage(long, default = "quiet")]
+    mode: Option<String>,
+    #[usage(subcommand)]
+    command: Option<DeprecatedExCommand>,
+}
+
+#[derive(Subcommands)]
+// Selected, not read: what these cases check is what a selection reports.
+#[allow(dead_code)]
+enum DeprecatedExCommand {
+    #[usage(deprecated = "use build")]
+    Compile(DeprecatedExCompile),
+    Build(DeprecatedExBuild),
+}
+
+#[derive(Args)]
+struct DeprecatedExCompile {
+    #[usage(long, deprecated = "no longer read")]
+    incremental: bool,
+}
+
+#[derive(Args)]
+struct DeprecatedExBuild {
+    #[usage(long)]
+    release: bool,
+}
+
+/// The kinds and names of what a command line reported, in order.
+fn deprecations_of(words: &[&str]) -> Vec<(usage::warn::WarningKind, String)> {
+    let owned: Vec<&OsStr> = words.iter().map(OsStr::new).collect();
+    let mut warnings = Vec::new();
+    DeprecatedEx::parse_from_with_warnings(&owned, &mut warnings).expect("a valid command line");
+    warnings
+        .iter()
+        .map(|warning| (warning.kind, warning.name.to_string()))
+        .collect()
+}
+
+#[test]
+fn a_deprecated_flag_that_was_typed_is_reported() {
+    assert_eq!(
+        deprecations_of(&["--output", "a.txt"]),
+        [(usage::warn::WarningKind::DeprecatedFlag, "--output".into())],
+    );
+}
+
+#[test]
+fn a_flag_nobody_typed_reports_nothing() {
+    assert!(deprecations_of(&["--out", "a.txt"]).is_empty());
+    // A default fills the field without anybody having asked for it, so it is not a use.
+    assert!(deprecations_of(&[]).is_empty());
+}
+
+#[test]
+fn a_milestone_the_cli_has_not_reached_stays_quiet() {
+    assert!(deprecations_of(&["--outfile", "a.txt"]).is_empty());
+    assert_eq!(
+        deprecations_of(&["--legacy"]),
+        [(usage::warn::WarningKind::DeprecatedFlag, "--legacy".into())],
+    );
+}
+
+#[test]
+fn a_deprecated_command_reports_itself_and_its_own_flags() {
+    assert_eq!(
+        deprecations_of(&["compile", "--incremental"]),
+        [
+            (
+                usage::warn::WarningKind::DeprecatedCommand,
+                "compile".into()
+            ),
+            (
+                usage::warn::WarningKind::DeprecatedFlag,
+                "--incremental".into()
+            ),
+        ],
+    );
+    assert!(deprecations_of(&["build", "--release"]).is_empty());
+}
+
+#[test]
+fn the_entry_points_that_were_not_asked_still_parse() {
+    let words = [OsStr::new("--output"), OsStr::new("a.txt")];
+    assert!(DeprecatedEx::parse_from(&words).is_ok());
+    let with_argv0 = [
+        OsStr::new("deprecated-ex"),
+        OsStr::new("--output"),
+        OsStr::new("a.txt"),
+    ];
+    assert!(DeprecatedEx::try_parse_from(&with_argv0).is_ok());
+    let mut warnings = Vec::new();
+    DeprecatedEx::try_parse_from_with_warnings(&with_argv0, &mut warnings)
+        .expect("a valid command line");
+    assert_eq!(warnings.len(), 1, "{warnings:?}");
+}
+
+#[test]
+fn what_a_user_reads_says_what_to_do_about_it() {
+    let mut warnings = Vec::new();
+    DeprecatedEx::parse_from_with_warnings(
+        &[OsStr::new("--output"), OsStr::new("a.txt")],
+        &mut warnings,
+    )
+    .expect("a valid command line");
+    assert_eq!(
+        usage::warn::render_warnings(&warnings),
+        "warning: --output is deprecated, removed at 3.0.0: use --out\n",
+    );
+}


### PR DESCRIPTION
## What this closes

`deprecated`, `deprecated_warn_at`, `deprecated_remove_at` and `deprecated_env` reached help ([argv/src/help.rs](../blob/main/argv/src/help.rs)) and completion descriptions — and nothing else. There was no `warn` anywhere in either parse path, so a user who typed a deprecated flag, selected a deprecated command, or set a deprecated env alias was told nothing. The metadata half had shipped; the half that actually moves people off an old spelling had not. `docs/spec/reference/config.md` even promised `deprecated_env` was "read last, with a warning".

## Shape

**Reported, not printed.** The rule [configuration resolution](https://usage.jdx.dev/spec/resolution#warnings) already follows: a parser that wrote to stderr could not be used by anything with an opinion about output, and mise queues its deprecations until its logging is up. `parse()` — the entry point that *is* the process — renders them to stderr and carries on; everything else hands them back.

```rust
let mut warnings = Vec::new();
let cli = Cli::parse_from_with_warnings(&argv, &mut warnings)?;
```

`parse_from_argv_with_warnings` and `try_parse_from_with_warnings` sit beside their own entry points. The three existing entry points keep their signatures and collect nothing, so a caller who did not ask pays nothing. The trait seams (`CommandArgs::deprecations`, `Subcommands::deprecations`) are defaulted, so hand-written implementations keep compiling.

**Three triggers:** a deprecated flag that was given, each deprecated command on the selected path, and a value that arrived through a `deprecated_env` alias — reported with the current name to use instead.

**The command line and the environment count; a default does not.** A variable supplying a deprecated flag used the declaration as much as a typed word did, and both are things the user arranged. A default fills a field without marking it given, which is exactly the distinction needed and one that already existed.

**`deprecated_warn_at` gates it**, because declaring one is how an author says *not yet*. That needed the project's first version comparison — dotted integers, missing segments as zero, `-rc` before the release, `+build` ignored — so the rule is written down in [`docs/spec/argv.md`](../blob/main/docs/spec/argv.md#warnings) rather than in either crate: `usage-argv` can take no dependency and `usage-lib` cannot depend on it. Every uncertain case warns, including a version neither can read: noise is recoverable and silence is not.

## Both implementations, held to each other

`usage-argv`/`usage-derive` and `usage-lib` land together, and `conformance/tests/deprecation.rs` asks both the same questions about the same CLI — including a flag that is both deprecated and reached through a deprecated alias. A deprecated alias is recorded **where it wins**, inside the one loop that decides precedence, rather than re-derived afterwards; a second reading of that rule would be free to disagree with it.

The grammar specifies the *set* of warnings, not their order, and says so.

## Cost

Nothing on the hot path. Deprecation lives in the cold metadata tables, so the module is `spec`-gated; a `Warning` borrows every field from static data and allocates nothing; the `Vec` only allocates if something was actually deprecated. The gate's allocation and instruction tests are unchanged.

## Worth a reviewer's attention

- **`ParseOutput` gains a public `warnings` field.** It is only ever constructed inside `usage-lib` ([one site](../blob/main/lib/src/parse.rs)), but a struct literal elsewhere would notice. Not marked `!` — release-plz's call.
- **The root command never warns about itself.** It is the program that is running, not something the command line selected.
- **`deprecated_remove_at` never withholds and is never an error.** Removing a declaration is the author's job.

## Follow-ups, deliberately not here

- Generated Go parsers and corpus vectors — the agreement mechanism for a third implementation.
- `deprecated` on a positional: args carry `deprecated_env` but no `deprecated` message field in either the spec model or `ArgMeta`, so warning about one would be behaviour the emitted KDL cannot express.
- `usage-config` props carry `deprecated_warn_at` and ignore it too; now that the version rule is written down, config can adopt it.

## Verification

`cargo test --all --all-features`, `cargo clippy --all --all-features --all-targets -- -D warnings`, `cargo fmt --all --check`, `prettier -c .`, `mise run test:go`, and `mise run render` (no artifact drift) all pass. The facade and parity tests were run repeatedly to check for the env-var flake that env-touching tests invite — env cases live in their own test binary, consolidated into one test, for the reason `post_binding_env.rs` documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a public `warnings` field on `ParseOutput` and new parse entry points, so embedders and struct-literal callers can notice. Behavior is additive and opt-in except for `parse()` printing to stderr.
> 
> **Overview**
> Parses now **report** when a command line used a `deprecated` flag or command, or a value that arrived through a `deprecated_env` alias. Help already described those; this is the half that tells the person who just used one.
> 
> Warnings are values, not stderr from the library. `parse_from_with_warnings` (and the argv / try_parse counterparts) collect them; existing entry points stay silent. `parse()` prints them and continues. `ParseOutput` gains a public `warnings` field.
> 
> A default does not count as a use. Every deprecated command on the selected path reports except the root and commands an executable view injected. `deprecated_warn_at` gates by CLI version (dotted integers, missing segments as 0, `-rc` before release); unreadable versions warn rather than hide. usage-argv and usage-lib implement the same rule independently, with a conformance test holding them together.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e74d57a836b11a147618836665bccb7f7e4e47f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->