### PR TITLE
refactor(deps): drop heck from usage-derive

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -139,3 +139,50 @@ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 ```
+
+## heck
+
+`derive/src/case.rs` reproduces the word-boundary rules and case conversions of
+[heck](https://github.com/withoutboats/heck). No heck source is vendored, but the
+algorithm is followed closely enough to warrant attribution: usage's `rename_all`
+vocabulary is a clone of `clap_derive`'s, `clap_derive` uses heck, and a declaration
+ported from clap has to produce the same names — so the reimplementation exists to keep
+heck out of every adopter's compile, not to behave differently. `derive/src/case.rs`
+tests itself against heck directly, and `usage-lib` still depends on heck as a normal
+dependency.
+
+heck is distributed under the terms of either the MIT license or the Apache License,
+Version 2.0, at the user's option. Usage takes it under the MIT option, reproduced
+verbatim below from heck's `LICENSE-MIT` (heck 0.5.0, the version in this workspace's
+lockfile):
+
+```
+Copyright (c) 2015 The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+```
+
+The Apache-2.0 option is available upstream at
+<https://github.com/withoutboats/heck/blob/master/LICENSE-APACHE>.

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -18,7 +18,9 @@ shared-version = true
 release = true
 
 [dependencies]
-heck = "0.5"
+# No `heck`: one function's worth of use (`CasingStyle::apply`), and the only crate an adopter
+# compiled here that is not `proc-macro2` / `quote` / `syn`. Its word boundaries are reproduced
+# in `case.rs` — exactly, because `rename_all` is a clone of clap's and clap's uses heck.
 proc-macro2 = "1"
 quote = "1"
 # syn 2 rather than 3, which is already in the tree via clap_derive: nothing here
@@ -36,3 +38,11 @@ syn = { version = "3", features = ["full"] }
 #
 # The crate-level example is therefore `ignore`d here and compiled for real in
 # conformance/tests/derive.rs, which is where the derive is tested anyway.
+
+[dev-dependencies]
+# heck, for tests only: `case::tests` asserts the vendored conversion equals heck's for every
+# string up to four chars over an alphabet that reaches every state of the segmenter, which is
+# the whole reason to trust it. Unlike usage-argv above, this is no publish cycle — heck is
+# third-party and versioned on its own clock — and a dev-dependency is not in an adopter's
+# graph at all: `cargo tree -p usage-rs --edges normal` is the proof.
+heck = "0.5"

--- a/derive/src/case.rs
+++ b/derive/src/case.rs
@@ -1,0 +1,268 @@
+//! Case conversion for `rename_all`, in the shapes clap's derive produces.
+//!
+//! Replaces `heck`, so the only third-party crates an adopter compiles for the derive are
+//! `proc-macro2`, `quote` and `syn` — the ones a proc macro cannot do without. Same reasoning
+//! as `crate_name.rs`, which replaced `proc-macro-crate`.
+//!
+//! usage's `rename_all` vocabulary is a clone of `clap_derive`'s, and `clap_derive` uses heck.
+//! So this reproduces heck 0.5's word boundaries rather than something merely reasonable: a
+//! declaration ported from clap has to yield the same flag names, or the port silently changes
+//! a CLI's interface. `tests::matches_heck_for_every_short_string` checks that against heck
+//! itself rather than against what anyone here believes heck does.
+//!
+//! This is *not* the default naming policy. With no `rename_all`, names come from
+//! `model::to_kebab`, which breaks before every uppercase char: `HTTPServer` is
+//! `h-t-t-p-server` there and `http-server` here. Both spellings are pinned by
+//! `model::tests::a_value_enum_accepts_clap_container_casing`. Do not unify them.
+
+/// The words in `s`, as heck segments them.
+///
+/// Boundaries fall between non-alphanumeric runs, after a lowercase char followed by an
+/// uppercase one, and before the last uppercase of a run that is followed by a lowercase one —
+/// so `XMLHttpRequest` is `XML|Http|Request`. Digits are alphanumeric but neither upper nor
+/// lower, so they belong to the word on their left and leave the case state alone: `Foo2Bar` is
+/// `Foo2|Bar`, `Foo2bar` is one word.
+///
+/// heck streams words into a `Formatter` and writes a separator before each one after the
+/// first. Collecting them is the same output, not an approximation: heck never emits an empty
+/// word, so there is no case where "join with the separator" and "write a separator first"
+/// disagree.
+fn words(s: &str) -> Vec<&str> {
+    /// The case of the last cased char seen since the current word began.
+    #[derive(PartialEq, Eq, Clone, Copy)]
+    enum Mode {
+        Boundary,
+        Lowercase,
+        Uppercase,
+    }
+
+    let mut words = Vec::new();
+    for chunk in s.split(|c: char| !c.is_alphanumeric()) {
+        let mut chars = chunk.char_indices().peekable();
+        let mut init = 0;
+        let mut mode = Mode::Boundary;
+
+        while let Some((i, c)) = chars.next() {
+            let Some(&(next_i, next)) = chars.peek() else {
+                // The last char of the chunk closes whatever word is open.
+                words.push(&chunk[init..]);
+                break;
+            };
+            // What the mode becomes if `c` does not end a word. A caseless char — a digit —
+            // inherits it, which is what keeps `HTTP2Server` splitting as `HTTP2|Server`.
+            let next_mode = if c.is_lowercase() {
+                Mode::Lowercase
+            } else if c.is_uppercase() {
+                Mode::Uppercase
+            } else {
+                mode
+            };
+
+            if next_mode == Mode::Lowercase && next.is_uppercase() {
+                // lower then upper: the boundary is after `c`.
+                words.push(&chunk[init..next_i]);
+                init = next_i;
+                mode = Mode::Boundary;
+            } else if mode == Mode::Uppercase && c.is_uppercase() && next.is_lowercase() {
+                // The tail of an uppercase run, followed by lowercase: `c` starts the next
+                // word, so the boundary is before it.
+                words.push(&chunk[init..i]);
+                init = i;
+                mode = Mode::Boundary;
+            } else {
+                mode = next_mode;
+            }
+        }
+    }
+    words
+}
+
+/// Lowercase `word`, with heck's Greek final-sigma rule.
+///
+/// A word-final `Σ` lowercases to `ς` rather than `σ`. Kept because it is heck's, and a
+/// divergence here would be one nobody could explain later — heck pins it in its own tests.
+fn lower(word: &str) -> String {
+    let mut out = String::with_capacity(word.len());
+    let mut chars = word.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == 'Σ' && chars.peek().is_none() {
+            out.push('ς');
+        } else {
+            out.extend(c.to_lowercase());
+        }
+    }
+    out
+}
+
+fn upper(word: &str) -> String {
+    word.chars().flat_map(char::to_uppercase).collect()
+}
+
+/// Uppercase the first char of `word` and lowercase the rest.
+fn capitalize(word: &str) -> String {
+    let mut chars = word.char_indices();
+    let Some((_, first)) = chars.next() else {
+        return String::new();
+    };
+    let mut out: String = first.to_uppercase().collect();
+    if let Some((i, _)) = chars.next() {
+        out.push_str(&lower(&word[i..]));
+    }
+    out
+}
+
+fn join(s: &str, separator: &str, word: impl Fn(&str) -> String) -> String {
+    words(s)
+        .into_iter()
+        .map(word)
+        .collect::<Vec<_>>()
+        .join(separator)
+}
+
+pub(crate) fn to_kebab_case(s: &str) -> String {
+    join(s, "-", lower)
+}
+
+pub(crate) fn to_snake_case(s: &str) -> String {
+    join(s, "_", lower)
+}
+
+pub(crate) fn to_shouty_snake_case(s: &str) -> String {
+    join(s, "_", upper)
+}
+
+pub(crate) fn to_upper_camel_case(s: &str) -> String {
+    join(s, "", capitalize)
+}
+
+pub(crate) fn to_lower_camel_case(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for (i, word) in words(s).into_iter().enumerate() {
+        if i == 0 {
+            out.push_str(&lower(word));
+        } else {
+            out.push_str(&capitalize(word));
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use heck::{
+        ToKebabCase, ToLowerCamelCase, ToShoutySnakeCase, ToSnakeCase, ToUpperCamelCase as _,
+    };
+
+    /// Every conversion of one input, so a mismatch names the input once rather than five times.
+    fn ours(s: &str) -> [String; 5] {
+        [
+            super::to_kebab_case(s),
+            super::to_snake_case(s),
+            super::to_shouty_snake_case(s),
+            super::to_lower_camel_case(s),
+            super::to_upper_camel_case(s),
+        ]
+    }
+
+    fn hecks(s: &str) -> [String; 5] {
+        [
+            s.to_kebab_case(),
+            s.to_snake_case(),
+            s.to_shouty_snake_case(),
+            s.to_lower_camel_case(),
+            s.to_upper_camel_case(),
+        ]
+    }
+
+    /// Exhaustive over the state machine rather than sampled.
+    ///
+    /// The segmenter's whole window is `(mode, char, next char)`, so every string up to length
+    /// four over an alphabet that reaches each transition — a lowercase, two uppercase (for a
+    /// run), a digit, two kinds of separator, and a char whose lowercasing is special — covers
+    /// it completely. ~4700 inputs, and it runs in milliseconds.
+    #[test]
+    fn matches_heck_for_every_short_string() {
+        const ALPHABET: [char; 8] = ['a', 'B', 'c', 'D', '0', '_', '-', 'Σ'];
+        let mut inputs = vec![String::new()];
+        let mut frontier = vec![String::new()];
+        for _ in 0..4 {
+            let mut next = Vec::with_capacity(frontier.len() * ALPHABET.len());
+            for base in &frontier {
+                for c in ALPHABET {
+                    let mut candidate = base.clone();
+                    candidate.push(c);
+                    next.push(candidate);
+                }
+            }
+            inputs.extend(next.iter().cloned());
+            frontier = next;
+        }
+        for input in &inputs {
+            assert_eq!(ours(input), hecks(input), "input {input:?}");
+        }
+    }
+
+    /// The readable half of the pair: the names a declaration actually carries.
+    #[test]
+    fn matches_heck_for_realistic_names() {
+        for input in [
+            "",
+            "a",
+            "A",
+            "T",
+            "api_token",
+            "type",
+            "HTTPServer",
+            "XMLHttpRequest",
+            "OnePassword",
+            "ApiServer",
+            "onePassword",
+            "ONE_PASSWORD",
+            "IPv6Addr",
+            "OAuth2Token",
+            "PDFReader",
+            "AWSConfigFile",
+            "Utf8Path",
+            "HTTP2Server",
+            "Foo2Bar",
+            "Foo2bar",
+            "S3Bucket",
+            "v2",
+            "x509",
+            "_leading",
+            "trailing_",
+            "__double__",
+            "a__b",
+            // `rename_all_env` re-cases a name that has already been renamed, so these are
+            // inputs the derive really produces.
+            "already-kebab",
+            "API_SERVER",
+            // And `id = "…"` / `name = "…"` are arbitrary strings, not identifiers.
+            "service credential",
+            "foo.bar",
+            "Ünïcode",
+            "XΣXΣ",
+            "straße",
+        ] {
+            assert_eq!(ours(input), hecks(input), "input {input:?}");
+        }
+    }
+
+    /// heck's own documented vectors, so a heck bump that changes what it means fails here
+    /// rather than quietly making this module the odd one out.
+    #[test]
+    fn matches_hecks_own_vectors() {
+        for input in [
+            "CamelCase",
+            "This is Human case.",
+            "MixedUP CamelCase, with some Spaces",
+            "mixed_up snake_case with some _spaces",
+            "this-contains_ ALLKinds OfWord_Boundaries",
+            "XΣXΣ baﬄe",
+            "XMLHttpRequest",
+            "ファイルを読み込み",
+        ] {
+            assert_eq!(ours(input), hecks(input), "input {input:?}");
+        }
+    }
+}

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -366,6 +366,7 @@
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};
 
+mod case;
 mod codegen;
 mod crate_name;
 mod model;

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -4,7 +4,7 @@
 //! [`crate::codegen`], which keeps the error messages — the part an author
 //! actually interacts with — in one place.
 
-use heck::{ToKebabCase, ToLowerCamelCase, ToShoutySnakeCase, ToSnakeCase, ToUpperCamelCase};
+use crate::case;
 use proc_macro2::Span;
 use syn::ext::IdentExt as _;
 use syn::parse::Parser as _;
@@ -4441,6 +4441,12 @@ fn shout(form: &str) -> String {
     form.to_uppercase().replace('-', "_")
 }
 
+/// The default naming policy: dashes for underscores, and a dash before every uppercase char.
+///
+/// Deliberately not `case::to_kebab_case`, which follows heck and folds acronyms —
+/// `HTTPServer` is `h-t-t-p-server` here and `http-server` there. Both are pinned by
+/// `tests::a_value_enum_accepts_clap_container_casing`; `rename_all` is the way to ask for
+/// the other one.
 pub(crate) fn to_kebab(s: &str) -> String {
     let mut out = String::with_capacity(s.len() + 4);
     for (i, ch) in s.chars().enumerate() {
@@ -4987,13 +4993,13 @@ impl CasingStyle {
 
     fn apply(self, name: &str) -> String {
         match self {
-            Self::Camel => name.to_lower_camel_case(),
-            Self::Kebab => name.to_kebab_case(),
-            Self::Pascal => name.to_upper_camel_case(),
-            Self::ScreamingSnake => name.to_shouty_snake_case(),
-            Self::Snake => name.to_snake_case(),
-            Self::Lower => name.to_snake_case().replace('_', ""),
-            Self::Upper => name.to_shouty_snake_case().replace('_', ""),
+            Self::Camel => case::to_lower_camel_case(name),
+            Self::Kebab => case::to_kebab_case(name),
+            Self::Pascal => case::to_upper_camel_case(name),
+            Self::ScreamingSnake => case::to_shouty_snake_case(name),
+            Self::Snake => case::to_snake_case(name),
+            Self::Lower => case::to_snake_case(name).replace('_', ""),
+            Self::Upper => case::to_shouty_snake_case(name).replace('_', ""),
             Self::Verbatim => name.to_string(),
         }
     }

--- a/usage-rs/tests/fixtures/runtime-identity/Cargo.lock
+++ b/usage-rs/tests/fixtures/runtime-identity/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,7 +45,6 @@ version = "5.1.0"
 name = "usage-derive"
 version = "5.1.0"
 dependencies = [
- "heck",
  "proc-macro2",
  "quote",
  "syn",


### PR DESCRIPTION
`heck` was the only crate an adopter compiled for the derive that a proc macro can do without:

```
before: heck  proc-macro2  quote  syn  unicode-ident
after:        proc-macro2  quote  syn  unicode-ident
```

Its entire use here was one function, `CasingStyle::apply`. Same move as [`derive/src/crate_name.rs`](https://github.com/jdx/usage/blob/main/derive/src/crate_name.rs), which replaced `proc-macro-crate` to keep `toml_edit` out of adopters' compiles.

## Why it has to be heck's algorithm and not a reasonable one

`rename_all` is a deliberate clone of `clap_derive`'s vocabulary, and `clap_derive` uses heck. A declaration ported from clap has to yield the same flag names, or the port silently changes a CLI's interface. So `case.rs` reproduces heck 0.5:

- the acronym rule — `XMLHttpRequest` segments as `XML|Http|Request`
- digits belong to the word on their left and don't reset the case state — `Foo2Bar` is `Foo2|Bar`, `Foo2bar` is one word, `HTTP2Server` is `HTTP2|Server`
- Unicode case mapping, not `to_ascii_*`. Three of the four call sites see Rust identifiers, but `rename_all_env` re-cases an already-resolved name that may have come from an arbitrary `id = "…"` string — `"service credential"`, `"foo.bar"`
- heck's Greek final-sigma rule, kept because it is heck's and a divergence would be unexplainable later

## The claim is checked, not asserted

`heck = "0.5"` stays as a **dev**-dependency and `case::tests` compares the two implementations:

- `matches_heck_for_every_short_string` — every string up to four chars over `['a','B','c','D','0','_','-','Σ']`, an alphabet that reaches every state of the segmenter. ~4700 inputs, milliseconds.
- `matches_heck_for_realistic_names` — the readable half: `HTTPServer`, `IPv6Addr`, `OAuth2Token`, `AWSConfigFile`, `S3Bucket`, `_leading`, `trailing_`, `__double__`, `already-kebab`, `API_SERVER`, `service credential`, `foo.bar`, `Ünïcode`, `straße`
- `matches_hecks_own_vectors` — heck's documented cases, so a heck bump that changes semantics fails loudly

A dev-dependency is not in an adopter's graph (`cargo tree -p usage-rs --edges normal`), and unlike the `usage-argv` note in that manifest it is no publish cycle: heck is third-party and versioned on its own clock. `cargo package -p usage-derive` is clean.

## What deliberately did not change

`model::to_kebab` — the default policy when no `rename_all` is given — is untouched and stays different on purpose: `HTTPServer` is `h-t-t-p-server` there and `http-server` here. `a_value_enum_accepts_clap_container_casing` pins both spellings; a comment on each now points at the other so nobody unifies them.

`usage-lib` keeps its own `heck` dependency — 46 call sites across `complete/`, `as_env`, the SDK and Go generators, coupled to ~73 insta snapshots. It costs adopters nothing, since heck only reached them through the derive.

`NOTICE.md` gains a `## heck` section: no heck source is vendored, but "closely modeled on" is the threshold that file sets, and a function-for-function reimplementation clears it.

`mise run ci` is green.

_This PR was generated by Claude Code._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and naming-helper swap with tests pinning heck 0.5 behavior; default kebab policy is unchanged. No auth, data, or runtime parser changes.
> 
> **Overview**
> Drops `heck` from `usage-derive`'s normal dependencies so adopters only compile `proc-macro2`, `quote`, and `syn` for the proc macro.
> 
> `CasingStyle::apply` now uses a local heck-compatible segmenter in `derive/src/case.rs` (acronyms, digits, Unicode, final sigma). Default `model::to_kebab` is unchanged and still splits every uppercase char. heck stays as a **dev**-dependency so tests can assert parity, including an exhaustive short-string check. `NOTICE.md` attributes the algorithm.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f54ddf357f8b80d3e6457538b119042f9b297bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->