### PR TITLE
test(clap): explain the conflict clap does not check across a boundary

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1380,7 +1380,11 @@ share of clap's top-voted open requests is usage's existing feature set:
   (clap#5840) comes with it, which clap_complete lacks.
 - Automatic negation flags (clap#815, 66) — `negate`.
 - Argument validation on globals (clap#1546, 48) — globals go through the same
-  post-binding checks as everything else.
+  post-binding checks as everything else. The differential gate now pins the
+  difference on mise's own spec: `--profile` declares `conflicts=--env`, and clap
+  enforces it only while both spellings land on the same command, so
+  `mise --env config set --profile=v` is accepted there and refused by both usage
+  parsers.
 - Partial parsing that captures unknown args instead of erroring (clap#1404) —
   the spec's lax `unknown_flags` mode, which mise task parsing runs on.
 - Command chaining (clap#2222, 29) — `restart_token`.

--- a/benches/gate/tests/differential.proptest-regressions
+++ b/benches/gate/tests/differential.proptest-regressions
@@ -8,3 +8,4 @@ cc 4f2a955fec704b45e4e8cd42199265880d9104833e06c67509d15d5cbd7cef6f # shrinks to
 cc d57802bb04f7281cbcee867232581bcfaad4a47afd46f7c477f8032a85569c04 # shrinks to seed = 6583806858433503933, head = [10], rooted = false, len = 0, junk = []
 cc 77bf992b8442610d6fa6ccc3717f9d75cb900c9f026fda95583fad74b7d1fc22 # shrinks to seed = 14848261797843722629, head = [], rooted = false, len = 2, junk = [4, 8]
 cc c478cc8d4703f5fdc81e93ee812d0e1b5d762d83cc32fc4cd64e3b4332f97423 # shrinks to seed = 9708144620049405411, head = [4], rooted = true, len = 1, junk = [2]
+cc 217131e5595842837651fa88a8b7cc033f998c184d1458015ed66821c2549e36 # shrinks to seed = 15889629386202493572, head = [6], rooted = false, len = 1, junk = [9]

--- a/benches/gate/tests/differential.rs
+++ b/benches/gate/tests/differential.rs
@@ -347,6 +347,30 @@ fn explained(o: Outcome) -> Option<&'static str> {
             clap: Accept,
         } => Some("the word needs the mount usage-argv does not run, which clap's shadow lacks"),
 
+        // A declared `conflicts` between two globals, given on *different* commands:
+        // `mise --env config set --profile=v`. Both usage parsers refuse it; clap accepts.
+        //
+        // Not a dropped declaration — the shadow's `--profile` carries `conflicts: ["env"]`, and
+        // clap enforces it perfectly well when both flags land on the same command, whether that
+        // is the root or `config set`. What it does not do is check a pair a *global* spread
+        // across a boundary, which is clap#1546 and one of the requests `PLAN.md` records usage as
+        // already answering: globals go through the same post-binding checks as everything else.
+        //
+        // So this is the one arm here where the disagreement is a difference an adopter feels
+        // going the *strict* way — a line clap accepted stops being accepted. Recorded rather
+        // than softened, because the spec says the two flags conflict, and a check that holds
+        // only while both spellings happen to land on the same command is not a check.
+        //
+        // Keyed on usage-argv's reason: `Verdict::Conflict` covers a declared conflict and a
+        // repeat both, and this fixture has no strict command in it — mise's spec never says
+        // `args_override_self=false` — so a repeat cannot reach this arm. If one ever does, it
+        // arrives as a permissive default turning strict, which is worth failing over.
+        Outcome {
+            argv: Conflict,
+            lib: false,
+            clap: Accept,
+        } => Some("clap does not check a conflict between globals given on different commands"),
+
         // And one that is usage-argv's alone: a bare `-`. usage-lib and clap both bind it to the
         // root's `[TASK]`; usage-argv lets it *select* the default subcommand, descends into
         // `run`, and finds no positional there — so it too refuses with a word it cannot place.
@@ -584,6 +608,47 @@ fn a_global_repeat_is_permissive_unless_the_command_opts_into_strictness() {
         assert_eq!(o.argv, Verdict::Accept, "{words:?} {o:?}");
         assert!(o.lib, "{words:?} {o:?}");
         assert_eq!(o.clap, Verdict::Conflict, "{words:?} {o:?}");
+    }
+}
+
+#[test]
+fn a_conflict_between_globals_is_checked_wherever_the_two_flags_land() {
+    // Found by the generator, as `mise --env config set --profile=v`. mise declares
+    // `-P --profile` as `global` and `conflicts=--env`, so the pair is illegal — and where the
+    // two spellings sit on the line has nothing to do with it.
+    let spec = spec();
+    let go = |words: &[&str]| {
+        run(
+            &spec,
+            &words.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+        )
+    };
+
+    // Both on one command: all three refuse, which is what says the declaration survived into
+    // every fixture and that clap is not simply missing it.
+    for words in [
+        &["--env", "x", "--profile=v"][..],
+        &["--profile=v", "--env", "x"][..],
+        &["config", "set", "--env", "x", "--profile=v"][..],
+    ] {
+        let o = go(words);
+        assert_eq!(o.argv, Verdict::Conflict, "{words:?} {o:?}");
+        assert!(!o.lib, "{words:?} {o:?}");
+        assert_eq!(o.clap, Verdict::Conflict, "{words:?} {o:?}");
+    }
+
+    // One on the root and one on the subcommand: the same illegal pair, and clap stops checking.
+    // Both usage parsers refuse for the declared reason at any distance.
+    for words in [
+        &["--env", "config", "set", "--profile=v"][..],
+        &["--env", "x", "config", "ls", "--profile=v"][..],
+        &["--profile=v", "config", "ls", "--env=x"][..],
+    ] {
+        let o = go(words);
+        assert_eq!(o.argv, Verdict::Conflict, "{words:?} {o:?}");
+        assert!(!o.lib, "{words:?} {o:?}");
+        assert_eq!(o.clap, Verdict::Accept, "{words:?} {o:?}");
+        assert!(explained(o).is_some(), "{words:?} {o:?}");
     }
 }
 


### PR DESCRIPTION
`benches/gate/tests/differential.rs::no_unexplained_disagreement` fails on `main` whenever a seed happens to reach `mise --env config set --profile=v`:

```
unexplained disagreement on `mise --env config set --profile=v`:
  usage-argv Conflict
  usage-lib  refuse
  clap       Accept
```

It is a proptest over random command lines, so it is not tied to any PR — it surfaced during an unrelated rebase and reproduces on `main` with the seed pinned. No arm in `explained` named the shape, so the gate correctly reported a finding.

## The finding is real, and usage is the one that is right

mise declares its old `--profile` spelling as a global that conflicts with `--env`:

```kdl
flag "-E --env"     help="…" var=#true global=#true
flag "-P --profile" help="…" var=#true hide=#true global=#true conflicts=--env
```

So the pair is illegal, and where the two spellings sit on the line has nothing to do with it. Verified by asking all three parsers about four lines rather than reasoning about it:

| line | usage-argv | usage-lib | clap |
| --- | --- | --- | --- |
| `--env x --profile=v` | `ConflictingFlags` | conflicts with `--env` | `ArgumentConflict` |
| `--profile=v --env x` | `ConflictingFlags` | conflicts with `--env` | `ArgumentConflict` |
| `config set --env x --profile=v` | `ConflictingFlags` | conflicts with `--env` | `ArgumentConflict` |
| `--env config set --profile=v` | `ConflictingFlags` | conflicts with `--env` | **accepts** |

Two things that rules out. It is **not a dropped declaration** — the shadow's `--profile` really does carry `conflicts: ["env"]` and `is_global_set() == true`, and clap enforces it perfectly well whenever both flags land on the same command, root or subcommand alike. And it is **not a usage bug** — both usage parsers give the declared reason at any distance.

What clap does not do is check a pair of *globals* spread across a command boundary. That is [clap#1546](https://github.com/clap-rs/clap/issues/1546) (48 votes), which `PLAN.md` already records usage as answering: globals go through the same post-binding checks as everything else. This PR turns that claim into something the gate pins on mise's own spec.

## What lands

- **A new `explained` arm** for `argv: Conflict, lib: false, clap: Accept`, carrying the reasoning above. This is the one arm in the file where the difference cuts the **strict** way — a line clap accepted stops being accepted — so it is recorded rather than softened: the spec says the two flags conflict, and a check that holds only while both spellings happen to land on the same command is not a check.
- **`a_conflict_between_globals_is_checked_wherever_the_two_flags_land`**, pinning both halves deterministically, so the class keeps its evidence instead of depending on a seed — the same shape as the `a_global_repeat_is_permissive_unless_the_command_opts_into_strictness` test beside it. The same-level rows are what stop the arm from silently absorbing a genuinely dropped `conflicts` later.
- **The seed** that found it, added to `differential.proptest-regressions`, per that file's own contract that a finding does not evaporate with the seed.
- **One clause in `PLAN.md`** beside the clap#1546 line, naming the concrete line, since the gate now demonstrates what that entry asserts.

## On the arm's breadth

Keyed on usage-argv's *reason*, which is the convention the file argues for at length. `Verdict::Conflict` merges a declared conflict and a repeat, because clap does not distinguish them — but this fixture has no strict command in it: mise's spec never says `args_override_self=false`, so a repeat cannot reach this arm at all. If one ever does, it arrives as usage's permissive default having turned strict, which is worth failing over rather than waving through. That reasoning is in the comment, not just here.

## Verification

- `cargo test -p gate --all-features --test differential` — 11 passed, including the pinned seed replaying green.
- `PROPTEST_CASES=20000` sweep of `no_unexplained_disagreement` — passes in 146s, turning up no other unexplained cause, which is the check the file's own note asks for.
- `mise run ci` — clean.

No parser, spec, or fixture behaviour changes; this is the gate learning to name a difference it found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_This PR description was generated by Claude Code._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and documentation only: it classifies an existing parser difference and pins a seed, with no change to parse, spec, or fixtures.
> 
> **Overview**
> Teaches the mise differential gate to name a real three-way disagreement: both usage parsers refuse a declared global conflict wherever the flags land, while clap accepts the pair when they sit on different commands (`mise --env config set --profile=v`).
> 
> Adds an `explained` arm for `argv: Conflict, lib: false, clap: Accept`, a deterministic test covering same-command vs cross-boundary cases, the discovering proptest seed, and a `PLAN.md` note tying clap#1546 to that line. No parser or spec behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5472ec70e103370be771747c236020e9d0acc490. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->