### PR TITLE
refactor(deps): take expr-lang without the builtins a spec cannot reach

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,22 +297,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
-]
-
-[[package]]
-name = "chrono-tz"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
-dependencies = [
- "chrono",
- "phf",
- "serde",
 ]
 
 [[package]]
@@ -700,23 +687,15 @@ dependencies = [
 
 [[package]]
 name = "expr-lang"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86283664be0dc99b1247e957cf8234bb0e98fe76096bd36767d8f87ac98f00b7"
+checksum = "0ccbe01093a53933ac2e794bf8de543359ba840520304a6b93b8d00d0b99ceaf"
 dependencies = [
- "base64 0.23.1",
- "chrono",
- "chrono-tz",
- "iana-time-zone",
  "indexmap 2.14.0",
  "log",
- "once_cell",
  "pest",
  "pest_derive",
  "regex",
- "serde_json",
- "strum",
- "thiserror",
 ]
 
 [[package]]
@@ -1305,24 +1284,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "phf"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
-dependencies = [
- "phf_shared",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1760,7 +1721,6 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
- "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -1928,12 +1888,6 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
-
-[[package]]
-name = "siphasher"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"

--- a/conformance/tests/validation.rs
+++ b/conformance/tests/validation.rs
@@ -22,3 +22,17 @@ fn rust_matches_the_portable_validation_vectors() {
         );
     }
 }
+
+/// `matches` is in the vectors above, so this only records the other half of the choice:
+/// which builtins the Rust runtime does *not* carry, and that it says so.
+///
+/// The failure is at evaluation, not at `check`, which has only ever parsed — `nosuchfn(value)`
+/// behaves identically and always has.
+#[test]
+fn a_builtin_this_build_leaves_out_names_the_feature_to_add() {
+    let expression = "date(value) > now()";
+    usage_validation::check(expression).expect("it parses; the language has these builtins");
+    let err = usage_validation::validate(expression, "2020-01-01")
+        .expect_err("this build does not carry them");
+    assert!(err.contains("`temporal` feature"), "{err}");
+}

--- a/conformance/validation.json
+++ b/conformance/validation.json
@@ -18,5 +18,15 @@
     "expression": "value startsWith 'release-'",
     "value": "nightly",
     "valid": false
+  },
+  {
+    "expression": "value matches '^v[0-9]+$'",
+    "value": "v51",
+    "valid": true
+  },
+  {
+    "expression": "value matches '^v[0-9]+$'",
+    "value": "51",
+    "valid": false
   }
 ]

--- a/docs/spec/reference/arg.md
+++ b/docs/spec/reference/arg.md
@@ -53,6 +53,16 @@ value after defaults and environment fallbacks are applied. The only variable is
 `validate_error`, or a generic validation error when it is omitted. Because the
 expression is stored in the spec, generated Rust and Go parsers enforce the same rule.
 
+The Rust runtime compiles the operators, the string, array and numeric builtins, and
+`matches`. The date, JSON and base64 builtins are left out — twelve crates for something a
+`validate=` rule rarely reaches, since the only variable is a string. An expression that
+uses one fails when a value reaches it, naming the feature to add; a CLI that wants them
+adds it to its own manifest:
+
+```toml
+expr-lang = { version = "2.1", features = ["temporal"] }
+```
+
 ## Using Variadic Args in Bash
 
 When using variadic arguments (`var=#true`), the values are passed as a shell-escaped

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -11,7 +11,12 @@ authors = { workspace = true }
 license = { workspace = true }
 
 [dependencies]
-expr-lang = "2.0.0"
+# Defaults off, `regex` back on. A spec's `validate=` sees one string and returns a boolean, so
+# the dates, the JSON codec and base64 that expr-lang ships by default are 12 crates a CLI
+# compiles to evaluate `int(value) > 0`. `matches` stays because dropping it would make the
+# same expression pass in Go and fail here, and the spec reference promises that generated
+# Rust and Go parsers enforce the same rule — `conformance/validation.json` has the vectors.
+expr-lang = { version = "2.1.0", default-features = false, features = ["regex"] }
 
 [package.metadata.release]
 shared-version = true

--- a/validation/src/lib.rs
+++ b/validation/src/lib.rs
@@ -3,6 +3,28 @@
 //! Expressions use the language implemented by both `jdx/expr.rs` and the original
 //! `expr-lang/expr` Go package. The spec supplies a raw CLI value as `value`, so explicit
 //! conversions such as `int(value)` have the same meaning in every runtime.
+//!
+//! # What this build of the language carries
+//!
+//! A `validate=` expression reads one string and returns a boolean, so this depends on
+//! `expr-lang` with its default features off — the dates, JSON codec and base64 it ships by
+//! default are twelve crates a CLI would compile to evaluate `int(value) > 0`. The operators,
+//! the string and array builtins, the numeric conversions and `matches` are all here.
+//!
+//! `matches` is kept deliberately: the Go runtime has it, and a spec is supposed to mean the
+//! same thing in both.
+//!
+//! A spec that does want the rest — `date(value) > now()`, `fromJSON(value)` — gets it by
+//! naming the feature in the *application's* manifest, which cargo unifies with this crate's
+//! copy:
+//!
+//! ```toml
+//! expr-lang = { version = "2.1", features = ["temporal"] }
+//! ```
+//!
+//! Without that, such an expression fails the same way `nosuchfn(value)` always has: not at
+//! [`check`] time, which only parses, but when a value reaches it — with a message naming the
+//! feature to add.
 
 #![forbid(unsafe_code)]
 


### PR DESCRIPTION
Follows [jdx/expr.rs#110](https://github.com/jdx/expr.rs/pull/110), released as expr-lang 2.1.0. Its dependencies are optional now, so `validation` stops costing a timezone database.

```
usage-rs -F validation:   39 -> 19 crates
usage-rs (defaults):       4 crates, unchanged
```

A `validate=` expression reads one string and returns a boolean. The dates, JSON codec and base64 expr-lang ships by default were twelve crates compiled so a CLI could evaluate `int(value) > 0`.

## `regex` stays on, against the trimming

[docs/spec/reference/arg.md](https://github.com/jdx/usage/blob/main/docs/spec/reference/arg.md) says "generated Rust and Go parsers enforce the same rule", and the Go side runs the whole language (`expr-lang/expr` v1.17.8). Dropping `matches` would make one expression pass there and fail here — a divergence in exactly the thing that sentence promises. It costs 4 crates and I kept it.

Two vectors in `conformance/validation.json` hold that now. Both runtimes read that file, so they pass in Go and Rust today, and fail in Rust if anyone trims further. They were added and confirmed green *before* the bump, so they are a baseline rather than a new claim.

## The other half of the choice is recorded, not left to be discovered

`date(value) > now()` and `fromJSON(value)` are gone from this build. A test says so, the crate docs say so, and the spec reference says so — because the failure mode deserves to be a decision with a name rather than a surprise:

```
date() requires expr-lang's `temporal` feature
```

They fail the way `nosuchfn(value)` always has — at evaluation, not at `check`, which has only ever parsed function *syntax* and never resolved names. So this is not a new hole in `usage lint`; it adds names to a set that already behaved this way.

A CLI that does want them names the feature in its own manifest, which cargo unifies with this crate's copy:

```toml
expr-lang = { version = "2.1", features = ["temporal"] }
```

I verified that rather than assuming it: with that line in an application depending on `usage-validation`, `date(value) > now()` evaluates instead of erroring.

## Judgement call to overrule if you disagree

Keeping `matches` is the difference between 19 crates and 15. If you would rather have the 15 and let `matches` be a documented Rust-only gap, it is one line here plus deleting the two vectors — but it would be the first place a spec means different things in the two runtimes, which is why I did not.

`mise run ci` is green, `mise r render` produces no diff, and the Go conformance suite passes against the same vectors.

_This PR was generated by Claude Code._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which `validate=` builtins the Rust runtime actually evaluates. Specs that used date/JSON/base64 will now fail at value time unless the app opts those features back in.
> 
> **Overview**
> Cuts the `usage-validation` `expr-lang` graph by turning default features off and enabling only `regex`. Date, JSON, and base64 builtins no longer compile in unless a CLI re-enables them (e.g. `temporal`) in its own manifest.
> 
> `matches` stays so a spec still means the same thing in generated Rust and Go. Conformance vectors cover that operator; a new test documents that omitted builtins fail at evaluation (not `check`) and name the feature to add. Spec and crate docs record the split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 935a9f2fd1d98483b36d9cf509f8dad7c7528165. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->