### PR TITLE
ci: measure the mbx build cache against this workspace

### DIFF
--- a/.github/workflows/mbx-dogfood.yml
+++ b/.github/workflows/mbx-dogfood.yml
@@ -1,0 +1,136 @@
+name: mbx-dogfood
+
+# Measures jdx/mr-boxington's build cache against this workspace, which is a
+# real 26-member graph rather than a fixture.
+#
+# Deliberately additive and self-contained: it shares no cache, no key and no
+# job with `test`, so nothing here can slow or break the real pipeline, and
+# deleting this one file stops it entirely. It is an experiment on someone
+# else's build, and it should stay that cheap to abandon.
+
+on:
+  push:
+    branches: [main]
+  # So a change to this file is exercised by the PR that makes it.
+  pull_request:
+    paths: [".github/workflows/mbx-dogfood.yml"]
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: mbx-dogfood-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Pinned: an unannounced mbx release changing its hit rate would land here as
+  # a step change indistinguishable from something this repository did.
+  MBX_VERSION: v0.1.0
+  MBX_REMOTE_URL: https://cache.mise.jdx.dev
+  MBX_REMOTE_NAMESPACE: jdx/usage
+  MBX_REMOTE_OIDC_AUDIENCE: https://cache.mise.jdx.dev
+  CARGO_TERM_COLOR: always
+
+jobs:
+  dogfood:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      # Exchanged for a short-lived cache-server credential. mbx only publishes
+      # from a protected-branch push, so pull requests read the remote and never
+      # write to it — a fork cannot poison this cache.
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+
+      # No Swatinem/rust-cache, on purpose. It restores the whole target
+      # directory, so cargo would recompile nothing and mbx would have nothing
+      # to do: the run would look fast and measure zero. Absence here is the
+      # experiment, not an oversight.
+
+      - name: Install mbx
+        run: |
+          set -euo pipefail
+          base="https://github.com/jdx/mr-boxington/releases/download/$MBX_VERSION"
+          curl -fsSL --retry 3 -o mbx.tar.gz "$base/mbx-x86_64-unknown-linux-musl.tar.gz"
+          curl -fsSL --retry 3 -o SHA256SUMS "$base/SHA256SUMS"
+          sha256sum --ignore-missing --check SHA256SUMS
+          tar -xzf mbx.tar.gz
+          sudo install -m 0755 mbx /usr/local/bin/mbx
+          rm -f mbx mbx.tar.gz SHA256SUMS
+          mbx --version
+
+      # `--no-run` compiles every crate and every test binary without running
+      # them, which is the whole dependency graph and none of the shell,
+      # submodule and fixture setup the real suite needs. This job measures
+      # compilation, so it should fail only when compilation fails.
+      - name: Cold build
+        env:
+          MBX_STATS_REPORT: ${{ runner.temp }}/cold.json
+        run: |
+          start=$SECONDS
+          mbx build test --all --all-features --no-run
+          echo "COLD_SECONDS=$((SECONDS - start))" >> "$GITHUB_ENV"
+
+      # The deletion is the assertion, not cleanup. A second build that kept
+      # its target directory would be measuring cargo's freshness checks
+      # instead of the cache.
+      - name: Discard the target directory
+        run: rm -rf target
+
+      - name: Warm build
+        env:
+          MBX_STATS_REPORT: ${{ runner.temp }}/warm.json
+        run: |
+          start=$SECONDS
+          mbx build test --all --all-features --no-run
+          echo "WARM_SECONDS=$((SECONDS - start))" >> "$GITHUB_ENV"
+
+      - name: Summarize
+        if: always()
+        run: |
+          set -euo pipefail
+          row() {
+            local label="$1" file="$2" seconds="${3:-}"
+            [ -f "$file" ] || return 0
+            jq -r --arg label "$label" --arg seconds "$seconds" '
+              "| \($label) | \($seconds)s | \(.lookups) | \(.hits) | \(.misses) | " +
+              "\(if .lookups > 0 then (100 * .hits / .lookups | floor | tostring) + "%" else "n/a" end) | " +
+              "\((.bypasses | add) // 0) | \(.downloaded_bytes) | \(.uploaded_bytes) |"
+            ' "$file"
+          }
+          {
+            echo "### mbx $MBX_VERSION on this workspace"
+            echo
+            echo "| build | wall | lookups | hits | misses | hit rate | bypassed | down | up |"
+            echo "| --- | --- | --- | --- | --- | --- | --- | --- | --- |"
+            row cold "${RUNNER_TEMP}/cold.json" "${COLD_SECONDS:-?}"
+            row warm "${RUNNER_TEMP}/warm.json" "${WARM_SECONDS:-?}"
+            echo
+            if [ -f "${RUNNER_TEMP}/warm.json" ]; then
+              echo "Bypasses by reason, warm build:"
+              echo '```'
+              jq -r '.bypasses | to_entries[] | "\(.value)\t\(.key)"' "${RUNNER_TEMP}/warm.json"
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Without this the job goes green whether or not the cache did anything,
+      # which is the one outcome worth being told about. The warm build restores
+      # from the local store this job just populated, so this holds even on a
+      # pull request that is forbidden from writing to the remote.
+      - name: Assert the warm build restored something
+        run: |
+          set -euo pipefail
+          hits=$(jq -r '.hits' "${RUNNER_TEMP}/warm.json")
+          echo "warm build restored $hits actions"
+          if [ "$hits" -le 0 ]; then
+            echo "::error::the warm build restored nothing; the cache did not work"
+            exit 1
+          fi

--- a/.github/workflows/mbx-dogfood.yml
+++ b/.github/workflows/mbx-dogfood.yml
@@ -58,12 +58,16 @@ jobs:
         run: |
           set -euo pipefail
           base="https://github.com/jdx/mr-boxington/releases/download/$MBX_VERSION"
-          curl -fsSL --retry 3 -o mbx.tar.gz "$base/mbx-x86_64-unknown-linux-musl.tar.gz"
+          # Keep the published name: SHA256SUMS lists assets by it, and
+          # `--ignore-missing` silently skips entries whose file is absent, so
+          # downloading to any other name verifies nothing at all.
+          archive="mbx-x86_64-unknown-linux-musl.tar.gz"
+          curl -fsSL --retry 3 -o "$archive" "$base/$archive"
           curl -fsSL --retry 3 -o SHA256SUMS "$base/SHA256SUMS"
           sha256sum --ignore-missing --check SHA256SUMS
-          tar -xzf mbx.tar.gz
+          tar -xzf "$archive"
           sudo install -m 0755 mbx /usr/local/bin/mbx
-          rm -f mbx mbx.tar.gz SHA256SUMS
+          rm -f mbx "$archive" SHA256SUMS
           mbx --version
 
       # `--no-run` compiles every crate and every test binary without running


### PR DESCRIPTION
[mbx](https://github.com/jdx/mr-boxington) is an experimental cargo build cache: it caches individual rustc actions in a content-addressed store, deduplicates them across checkouts, and can restore them from a remote. It has been measured on fixtures and on mise. This workspace is a better test — 26 members of real dependency graph that CI compiles dozens of times a day — and mbx has never run against anything it did not ship with.

This adds one workflow. It shares no cache, no key and no job with `test`, so it cannot slow or break the real pipeline, and deleting the file stops it. An experiment on someone else's build should stay that cheap to abandon.

## What it measures

A cold build, then `rm -rf target`, then a warm one — both `cargo test --all --all-features --no-run` under an mbx session. It writes a step summary with wall time, lookups, hits, misses, hit rate, bypass count and bytes moved for each, plus the warm build's bypasses broken down by reason. That last one matters as much as the hit rate: a build can hit every action it looks up and still spend most of its time on work that never entered the cache.

## Three choices worth arguing with

- **No `Swatinem/rust-cache`, deliberately.** It restores the whole target directory, so cargo would recompile nothing and mbx would measure zero. Its absence here is the experiment, not an oversight — which is why it is commented in the file, where the next person will otherwise "fix" it.
- **`test --no-run`** compiles every crate and every test binary without the shells, submodules and fixtures the real suite needs. This job should fail when compilation fails and not otherwise.
- **The target directory is deleted between the two builds.** That deletion is the assertion. A second build that kept it would be measuring cargo's freshness checks, not the cache.

The job fails if the warm build restores nothing — a green run that silently cached nothing is the one outcome worth being told about. That holds on a pull request too, where mbx forbids remote writes: the warm build restores from the local store the cold build just filled.

## What this does not need from you

The remote is `cache.mise.jdx.dev` under a `jdx/usage` namespace, via OIDC. If that namespace has no grant on the server yet, remote failures are warnings rather than errors in mbx, so the job degrades to the local store and still reports — it just will not show cross-run reuse until the grant exists. Nothing here needs a secret: `id-token: write` is the whole authentication story, and pull requests are read-only by mbx's own policy, so a fork cannot poison the cache.

mbx is pinned to `v0.1.0` and its download is checksum-verified. Pinned because an unannounced mbx release changing its hit rate would land in this repo as a step change indistinguishable from something this repo did.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New CI job with `id-token: write` and a checksum-pinned third-party binary talking to an external cache; isolated from the main test pipeline but still extra compile time on main.
> 
> **Overview**
> Adds a self-contained `mbx-dogfood` workflow that measures [mr-boxington](https://github.com/jdx/mr-boxington) against this 26-crate workspace, without sharing caches or jobs with `test`.
> 
> On `main` (and PRs that only touch this file) it installs pinned `mbx` v0.1.0, runs `mbx build test --all --all-features --no-run` twice with `target` deleted in between, writes hit/miss/bypass stats to the step summary, and fails if the warm build restores nothing. Remote cache uses OIDC to `cache.mise.jdx.dev`; PRs are read-only so forks cannot poison it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0e2318202d67b07761a6832ec3da873c22fcb68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->