### PR TITLE
feat(config): a read that keeps every setting that reads

### DIFF
--- a/config/src/read.rs
+++ b/config/src/read.rs
@@ -110,6 +110,8 @@ impl std::error::Error for ReadErrors {}
 pub struct Fold<'a> {
     resolved: &'a Resolved,
     errors: Vec<ReadError>,
+    /// Whether a value that will not read falls back to the setting's declared default.
+    lossy: bool,
 }
 
 impl Resolved {
@@ -118,6 +120,26 @@ impl Resolved {
         Fold {
             resolved: self,
             errors: Vec::new(),
+            lossy: false,
+        }
+    }
+
+    /// Start reading, keeping every setting that does read.
+    ///
+    /// A strict fold reports and yields nothing, so one bad value costs the caller the whole
+    /// resolution — and a CLI whose only remaining move is `Settings::default()` has thrown away
+    /// the environment and every file over a single field. That is not a policy a library gets to
+    /// choose: erroring, warning and carrying on, or ignoring it outright are all reasonable, and
+    /// which one is right depends on the CLI. So this hands back both halves and lets it decide.
+    ///
+    /// A setting that will not read falls back to its declared default, which is the value the
+    /// CLI would have had if the offending layer had said nothing. The error is still recorded —
+    /// the fallback is not a repair, and a caller that wants to treat it as fatal still can.
+    pub fn fold_lossy(&self) -> Fold<'_> {
+        Fold {
+            resolved: self,
+            errors: Vec::new(),
+            lossy: true,
         }
     }
 
@@ -150,7 +172,7 @@ impl Fold<'_> {
                     origin: self.resolved.origin(id).cloned(),
                     kind: ReadErrorKind::Type(err),
                 });
-                None
+                self.fallback(id)
             }
         }
     }
@@ -167,9 +189,25 @@ impl Fold<'_> {
                 origin: None,
                 kind: ReadErrorKind::Missing,
             });
+            // No fallback, in a lossy fold either: the merge seeds every declared default into
+            // the values, so nothing at all here *means* nothing was declared. A setting with no
+            // value and no default is a hole in the spec, and inventing one would hide it.
             return None;
         }
         self.optional(id)
+    }
+
+    /// The declared default, for a value that would not read — in a lossy fold only.
+    ///
+    /// Nothing here re-validates: the default is a `Const` the spec declared, so if it does not
+    /// read as the field's type either, the declaration and the field disagree and there is
+    /// nothing to fall back *to*. The error is already recorded; the field goes without.
+    fn fallback<T: FromValue>(&self, id: PropId) -> Option<T> {
+        if !self.lossy {
+            return None;
+        }
+        let default = self.resolved.registry().get(id).default?;
+        T::from_value(&default.to_value()).ok()
     }
 
     /// What has gone wrong so far, for a caller that wants to add to the list.
@@ -184,6 +222,14 @@ impl Fold<'_> {
         } else {
             Err(ReadErrors(self.errors))
         }
+    }
+
+    /// Everything that went wrong, whether or not anything did.
+    ///
+    /// What a lossy fold ends with: [`Fold::finish`] answers "did this work", and the answer
+    /// there is always "not entirely" or the caller would not be folding lossily.
+    pub fn into_errors(self) -> ReadErrors {
+        ReadErrors(self.errors)
     }
 }
 
@@ -665,5 +711,63 @@ mod tests {
             err.to_string(),
             "jobs expected a boolean but has `12` (set by MYCLI_JOBS)"
         );
+    }
+
+    #[test]
+    fn a_lossy_fold_falls_back_to_the_declared_default_and_still_reports() {
+        let resolved = resolve(REGISTRY, Layers::new().then(&Text(&[]))).expect("resolves");
+        let mut resolved = resolved;
+        // The unchecked door into a resolution, and the reason these errors exist at all.
+        resolved.coerced(id("jobs"), Value::Int(-1), "a hook that got it wrong");
+
+        // Strict: nothing comes back, so a caller folding a whole struct loses every other
+        // setting it just resolved.
+        let mut strict = resolved.fold();
+        assert_eq!(strict.required::<u64>(id("jobs")), None);
+        assert_eq!(strict.required::<bool>(id("raw")), Some(false));
+        strict.finish().expect_err("one field did not read");
+
+        // Lossy: the field that failed takes what it declared, and the failure is still on the
+        // list for the CLI to raise, log, or ignore.
+        let mut lossy = resolved.fold_lossy();
+        assert_eq!(
+            lossy.required::<u64>(id("jobs")),
+            Some(4),
+            "the declared default, not the hook's -1"
+        );
+        assert_eq!(lossy.required::<bool>(id("raw")), Some(false));
+        let errors = lossy.into_errors();
+        assert_eq!(errors.0.len(), 1, "{errors}");
+        assert_eq!(errors.0[0].key, "jobs");
+    }
+
+    #[test]
+    fn a_lossy_fold_does_not_invent_a_default_that_was_never_declared() {
+        // The merge seeds every declared default into the values, so nothing at all here means
+        // nothing was declared — a hole in the spec rather than a bad value, and filling it
+        // would hide the one thing the caller needs told.
+        let resolved = resolve(REGISTRY, Layers::new().then(&Text(&[]))).expect("resolves");
+        let mut lossy = resolved.fold_lossy();
+        assert_eq!(lossy.required::<String>(id("profile")), None);
+        let errors = lossy.into_errors();
+        assert_eq!(errors.0.len(), 1, "{errors}");
+        assert!(matches!(errors.0[0].kind, ReadErrorKind::Missing));
+    }
+
+    #[test]
+    fn a_lossy_fold_leaves_an_optional_field_empty_when_its_value_is_bad() {
+        // `Option<T>` already has somewhere to put "no usable value", and the setting declares
+        // no default to reach for. The error is what carries the news.
+        let resolved = resolve(
+            REGISTRY,
+            Layers::new().then(&Text(&[("MYCLI_RATIO", "0.5")])),
+        )
+        .expect("resolves");
+        let mut resolved = resolved;
+        resolved.coerced(id("ratio"), Value::from("not a number"), "a hook, again");
+
+        let mut lossy = resolved.fold_lossy();
+        assert_eq!(lossy.optional::<f64>(id("ratio")), None);
+        assert_eq!(lossy.into_errors().0.len(), 1);
     }
 }

--- a/conformance/tests/derive_config.rs
+++ b/conformance/tests/derive_config.rs
@@ -543,3 +543,67 @@ fn a_negate_only_flag_is_not_named_twice_in_help() {
     assert!(page.contains("--no-credit"), "{page}");
     assert!(!page.contains("no-credit: --no-credit"), "{page}");
 }
+
+#[test]
+fn a_lossy_read_keeps_every_setting_that_does_read() {
+    let env = EnvLayer::new([("EX_TASK_JOBS".to_string(), "2".to_string())]);
+    let mut resolved =
+        resolve(Settings::SETTINGS_REGISTRY, Layers::new().then(&env)).expect("resolves");
+
+    // The way a value gets past the merge holding something its field cannot take: a post-merge
+    // hook, unchecked by design because it is where a CLI's own rules live.
+    let jobs = Settings::SETTINGS_REGISTRY
+        .lookup("jobs")
+        .expect("declared")
+        .id;
+    resolved.coerced(jobs, Value::Int(-1), "a hook that got it wrong");
+
+    // Strict: one bad field costs the caller the whole resolution, and a CLI left holding
+    // `Settings::default()` has thrown away the environment over a value it never set.
+    Settings::read(&resolved).expect_err("-1 does not fit a u64");
+
+    // Lossy: the bad field falls back to what it declared, and nothing else is touched.
+    let (settings, errors) = Settings::read_lossy(&resolved);
+    let settings = settings.expect("every field had a value or a default");
+    assert_eq!(settings.jobs, 4, "the declared default, not the hook's -1");
+    assert_eq!(
+        settings.task.jobs,
+        Some(2),
+        "EX_TASK_JOBS is not collateral damage"
+    );
+    // A `default_fn` field has no `Const` to fall back to and does not need one: nothing was
+    // wrong with it, and the fold never reached for a fallback.
+    assert_eq!(settings.cache_dir, default_cache_dir());
+
+    // Reported, not repaired — a CLI that decides a bad value is fatal has lost nothing by
+    // asking lossily.
+    assert_eq!(errors.0.len(), 1, "{errors}");
+    assert_eq!(errors.0[0].key, "jobs");
+    assert!(
+        errors.0[0].origin.is_some(),
+        "the hook that wrote it is named: {errors}"
+    );
+}
+
+#[test]
+fn a_lossy_read_with_nothing_wrong_is_the_strict_one() {
+    let env = EnvLayer::new([("EX_JOBS".to_string(), "9".to_string())]);
+    let resolved =
+        resolve(Settings::SETTINGS_REGISTRY, Layers::new().then(&env)).expect("resolves");
+
+    let strict = Settings::read(&resolved).expect("reads");
+    let (lossy, errors) = Settings::read_lossy(&resolved);
+    assert_eq!(lossy.expect("reads"), strict);
+    assert!(errors.0.is_empty(), "{errors}");
+}
+
+#[test]
+fn a_lossy_read_does_not_invent_a_default_that_was_never_declared() {
+    // The merge seeds every declared default into the values, so a setting with no value at all
+    // is one with nothing to fall back to. Filling it anyway would hide a hole in the spec.
+    let resolved = resolve(Required::SETTINGS_REGISTRY, Layers::new()).expect("resolves");
+    let (settings, errors) = Required::read_lossy(&resolved);
+    assert!(settings.is_none(), "no value and no default");
+    assert_eq!(errors.0.len(), 1, "{errors}");
+    assert_eq!(errors.0[0].key, "token");
+}

--- a/derive/src/config.rs
+++ b/derive/src/config.rs
@@ -1238,6 +1238,29 @@ pub fn emit(config: &Config) -> TokenStream {
                     ))
                 }
 
+                /// This resolution's values, keeping every setting that reads.
+                ///
+                /// [`Self::read`] is all or nothing, which leaves a CLI two moves when one
+                /// field is bad: refuse to start, or fall back to a struct of declared
+                /// defaults and lose the environment and every config file along with the
+                /// offending value. Neither is a choice this crate should be making.
+                ///
+                /// So: a field that will not read falls back to its own declared default and
+                /// the rest keep what the merge gave them, with every failure returned
+                /// alongside for the CLI to raise, log, or ignore as it sees fit. The errors
+                /// are the same [`::usage_config::ReadError`]s [`Self::read`] returns, so a
+                /// caller that decides a bad value *is* fatal has lost nothing by asking.
+                ///
+                /// `None` only where a setting has no value and no declared default — a hole
+                /// in the declaration rather than a bad value, and nothing to fall back to.
+                pub fn read_lossy(
+                    __usage_resolved: &#cfg::Resolved,
+                ) -> (::std::option::Option<Self>, #cfg::ReadErrors) {
+                    let mut __usage_fold = __usage_resolved.fold_lossy();
+                    let __usage_read = <Self as #cfg::Props>::read_at(&mut __usage_fold, 0);
+                    (__usage_read, __usage_fold.into_errors())
+                }
+
                 /// The spec `config` block for these settings, as KDL.
                 ///
                 /// What documents, JSON schema and completions read. A CLI deriving

--- a/docs/rust/settings.md
+++ b/docs/rust/settings.md
@@ -129,6 +129,34 @@ for warning in usage::config::explain::warnings(&resolved) {
 rather than the first thing found. Provenance is the merge's own output: `explain`, `list`,
 and per-setting `origin` come free, without a second merge to drift from the first.
 
+### When a value will not read
+
+`read` is all or nothing, which leaves a CLI two moves when one field is bad: refuse to start,
+or fall back to a struct of declared defaults and lose the environment and every config file
+along with the offending value. Neither is a choice a library should be making for you, so
+there is `read_lossy`:
+
+```rust
+let (settings, errors) = Settings::read_lossy(&resolved);
+for error in &errors.0 {
+    warn!("{error}");   // or bail, or ignore — the policy is yours
+}
+let settings = settings.expect("every setting declares a default");
+```
+
+A field that will not read falls back to its own declared default; every other field keeps what
+the merge gave it. The failures come back alongside as the same `ReadError`s `read` returns, so
+deciding a bad value is fatal after all costs nothing.
+
+The struct is `None` only where a setting has no value _and_ no declared default — a hole in the
+declaration rather than a bad value, and nothing to fall back to. A settings type where every
+field declares a default can `expect` it.
+
+Most of this cannot happen: the merge already coerces every value to the type its setting
+declares. What is left is a post-merge hook writing through
+`Resolved::coerced`, which is unchecked by design, a type only the tool understands, and a field
+that narrows further than the setting does — a `uint` setting held as a `u16` port.
+
 ## The spec carries the settings
 
 A root deriving [`Cli`](/rust/args-and-flags) names its settings type, and its emitted spec


### PR DESCRIPTION
`Settings::read` is all or nothing. One field the merge could not hand to its type loses the caller the whole resolution, which leaves a CLI two moves:

1. refuse to start, or
2. fall back to a struct of declared defaults — throwing away the environment and every config file along with the offending value.

pitchfork does the second ([jdx/pitchfork#756](https://github.com/jdx/pitchfork/pull/756)), so one bad field would quietly demote all 68 of its settings to built-in defaults.

Neither is a choice this crate should be making. Erroring, warning and carrying on, or ignoring it outright are all defensible, and which one is right is the CLI's business.

## What changes

`Resolved::fold_lossy` and a generated `read_lossy`:

```rust
let (settings, errors) = Settings::read_lossy(&resolved);
for error in &errors.0 {
    warn!("{error}");   // or bail, or ignore — the policy is yours
}
let settings = settings.expect("every setting declares a default");
```

- A field that will not read falls back to **its own declared default**; every other field keeps what the merge gave it.
- Failures come back alongside as the same `ReadError`s `read` returns, so deciding a bad value is fatal after all costs nothing. The fallback is not a repair.
- `None` only where a setting has no value **and** no declared default. The merge seeds every declared default into the values, so nothing there means nothing was declared — a hole in the spec rather than a bad value, and inventing one would hide the thing worth reporting.
- `Fold::into_errors` for the list whether or not it is empty, since `finish`'s question ("did this work") is one a lossy caller has already answered.

No existing API changes; `fold()` is unchanged and strict.

## Reachability

This is not hypothetical for long. The merge coerces every value to the type its setting declares, so what is left is a post-merge hook writing through `Resolved::coerced` (unchecked by design — it is where a CLI's own rules live), a type only the tool understands, and a field that narrows further than the setting does. The last one is a `uint` setting held as a `u16` port, which is a normal thing to write.

## Tests

Three in `config/src/read.rs` at the `Fold` level and three in `conformance/tests/derive_config.rs` at the derive level: the fallback happens and is still reported, an unrelated field is not collateral damage, a `default_fn` field is untouched, a clean lossy read equals the strict one, and a setting with no value and no default stays `None`.

Docs: a "When a value will not read" section in `docs/rust/settings.md`.

_This PR was generated by Claude Code._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Additive API with the strict `read` path unchanged, but it changes how typed settings are assembled when a field fails, so callers that treat a partial struct as fully valid could silently run on defaults.
> 
> **Overview**
> Lets a CLI keep every setting that still reads when one field cannot be typed, instead of all-or-nothing `Settings::read` (or throwing away env/files via `Settings::default()`).
> 
> `Resolved::fold_lossy` and generated `read_lossy` return the struct plus the same `ReadError`s as strict `read`. A bad field uses **its own declared default**; other fields keep the merge. Missing values with no default stay `None` (no invented default). `Fold::into_errors` always yields the list. Strict `fold()` is unchanged.
> 
> Documented under “When a value will not read”; tests cover fallback, no collateral damage, and holes in the spec.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3c5247f7b91c81f2807bd690dec3d7d5fb12fea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->