### PR TITLE
docs(rust): refresh experimental note and fix draft inaccuracies

### DIFF
--- a/docs/rust/args-and-flags.md
+++ b/docs/rust/args-and-flags.md
@@ -116,7 +116,7 @@ accepted — see [Migrating from clap](/rust/migrating-from-clap) and the
 
 | Attribute                                               | Effect                                                                                                         |
 | ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `conflicts(…)`, `requires(…)`, `overrides(…)`           | Relations to other args ([Validation](/rust/validation))                                                       |
+| `conflicts(…)`, `requires(…)`, `overrides(…)`           | Relations to other args; `overrides` is flag-only ([Validation](/rust/validation))                             |
 | `required_if(…)`, `required_if_eq…`, `required_unless…` | Conditional required-ness with single, any, and all forms                                                      |
 | `validate` / `validate_error`                           | Portable expression rule ([Validation](/rust/validation#portable-expressions)); needs the `validation` feature |
 | `group = "name"`                                        | Join a flag group ([Validation](/rust/validation#groups))                                                      |

--- a/docs/rust/args-and-flags.md
+++ b/docs/rust/args-and-flags.md
@@ -1,8 +1,7 @@
 # Args and Flags
 
 ::: warning Draft
-This page is a draft. Some of what it documents is still in open pull requests, and details may
-change before release.
+This page is a draft and has not yet been human reviewed. Details may change.
 :::
 
 A field on a `#[derive(Cli)]` or `#[derive(Args)]` struct becomes a flag when it carries `long`
@@ -58,6 +57,11 @@ required-ness is declared rather than inferred: `#[usage(arg, required)]`.
 jobs: Option<u32>,
 ```
 
+The tables below cover the attributes most CLIs need. Many clap-compatible spellings
+(`visible_alias`, `hide_*`, `last`, `trailing_var_arg`, `requires_if`, and others) are also
+accepted — see [Migrating from clap](/rust/migrating-from-clap) and the
+[compatibility matrix](/rust/clap-compatibility) for the audited surface.
+
 **Naming and shape** — what the field is called and what kind of argument it is:
 
 | Attribute                | Effect                                                          |
@@ -110,12 +114,13 @@ jobs: Option<u32>,
 
 **Relationships** — constraints between arguments, checked after parsing:
 
-| Attribute                                               | Effect                                                               |
-| ------------------------------------------------------- | -------------------------------------------------------------------- |
-| `conflicts(…)` / `requires(…)`                          | Relations to other flags ([Validation](/rust/validation))            |
-| `required_if(…)`, `required_if_eq…`, `required_unless…` | Conditional required-ness with single, any, and all forms            |
-| `group = "name"`                                        | Join a flag group ([Validation](/rust/validation#groups))            |
-| `exclusive`                                             | Must be given alone ([Validation](/rust/validation#exclusive-flags)) |
+| Attribute                                               | Effect                                                                                                         |
+| ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `conflicts(…)`, `requires(…)`, `overrides(…)`           | Relations to other args ([Validation](/rust/validation))                                                       |
+| `required_if(…)`, `required_if_eq…`, `required_unless…` | Conditional required-ness with single, any, and all forms                                                      |
+| `validate` / `validate_error`                           | Portable expression rule ([Validation](/rust/validation#portable-expressions)); needs the `validation` feature |
+| `group = "name"`                                        | Join a flag group ([Validation](/rust/validation#groups))                                                      |
+| `exclusive`                                             | Must be given alone ([Validation](/rust/validation#exclusive-flags))                                           |
 
 **Deprecation** — a flag on its way out:
 
@@ -237,8 +242,11 @@ their target the way the KDL spec does — `"--long"` or `"-s"`, one value or a 
 stdin: bool,
 ```
 
-Naming a flag that doesn't exist on the command is a **compile error**, not a runtime surprise.
-Relations are flag-to-flag only; a positional cannot carry one.
+Naming a flag or positional that doesn't exist on the command is a **compile error**, not a
+runtime surprise. Conflicts, requires, and conditional requiredness may name flags or
+positionals; `overrides` and some `requires_if` forms stay flag-only. See the
+[compatibility matrix](/rust/clap-compatibility#relationships-and-command-routing) for the
+audited details.
 
 ## Resolution order
 
@@ -272,24 +280,24 @@ A global flag may be given **once per command level**, with the innermost occurr
 
 On the root `#[derive(Cli)]` struct:
 
-| Attribute                           | Effect                                                            |
-| ----------------------------------- | ----------------------------------------------------------------- |
-| `bin = "…"`                         | The binary name (used in help and the spec)                       |
-| `name = "…"`                        | A friendly display name                                           |
-| `version` / `version = "…"`         | Enable `--version`/`-V`; bare form uses `CARGO_PKG_VERSION`       |
-| `long_version = "…"`                | Extended `--version` text while `-V` stays concise                |
-| `about` / `long_about`              | Description (doc comments work too)                               |
-| `usage = "…"`                       | Verbatim synopsis line(s), replacing the generated one            |
-| `before_help` / `after_help`        | Extra text around the help page (`*_long_help` variants too)      |
-| `unknown_flags = "value"\|"error"`  | Treat unknown flags as values instead of errors                   |
-| `default_subcommand = "run"`        | Command to assume when argv names none                            |
-| `multicall`                         | Treat argv[0]'s basename as a subcommand (busybox-style)          |
-| `view("bin", root = "command")`     | Promote a command as another executable surface                   |
-| `completion`                        | Generate completion support ([Completions](/rust/completions))    |
-| `settings`                          | Generate config-settings bindings                                 |
-| `config = Settings`                 | Emit the named type's `config` block ([Settings](/rust/settings)) |
-| `min_usage_version = "…"`           | Declare the minimum usage version the spec needs                  |
-| `group("name", required, multiple)` | Declare a flag group ([Validation](/rust/validation#groups))      |
+| Attribute                           | Effect                                                                                                              |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `bin = "…"`                         | The binary name (used in help and the spec)                                                                         |
+| `name = "…"`                        | A friendly display name                                                                                             |
+| `version` / `version = "…"`         | Enable `--version`/`-V`; bare form uses `CARGO_PKG_VERSION`                                                         |
+| `long_version = "…"`                | Extended `--version` text while `-V` stays concise                                                                  |
+| `about` / `long_about`              | Description (doc comments work too)                                                                                 |
+| `usage = "…"`                       | Verbatim synopsis line(s), replacing the generated one                                                              |
+| `before_help` / `after_help`        | Extra text around the help page (`*_long_help` variants too)                                                        |
+| `unknown_flags = "value"\|"error"`  | Treat unknown flags as values instead of errors                                                                     |
+| `default_subcommand = "run"`        | Command to assume when argv names none                                                                              |
+| `multicall`                         | Treat argv[0]'s basename as a subcommand (busybox-style)                                                            |
+| `view("bin", root = "command")`     | Promote a command as another executable surface                                                                     |
+| `completion`                        | Generate completion support ([Completions](/rust/completions))                                                      |
+| `settings`                          | Root resolves settings even when every `setting =` binding lives on flattened children ([Settings](/rust/settings)) |
+| `config = Settings`                 | Emit the named type's `config` block ([Settings](/rust/settings))                                                   |
+| `min_usage_version = "…"`           | Declare the minimum usage version the spec needs                                                                    |
+| `group("name", required, multiple)` | Declare a flag group ([Validation](/rust/validation#groups))                                                        |
 
 On a `#[derive(Args)]` struct (refused on the root):
 

--- a/docs/rust/clap-compatibility.md
+++ b/docs/rust/clap-compatibility.md
@@ -1,5 +1,9 @@
 # clap compatibility
 
+::: warning Draft
+This page is a draft and has not yet been human reviewed. Details may change.
+:::
+
 This is the audited compatibility matrix for `clap` 4.6.6 and `clap_derive` 4.6.4,
 the versions in this workspace's lockfile. The audit covers clap's public derive
 attributes and the corresponding `Command`, `Arg`, `ArgGroup`, and `PossibleValue`
@@ -26,6 +30,8 @@ The columns distinguish every layer a migration crosses:
 | Mark           | Meaning                                                                                                |
 | -------------- | ------------------------------------------------------------------------------------------------------ |
 | **yes**        | Supported and covered at this layer.                                                                   |
+| **exact**      | Supported with clap-matching truth tables (used where a family of forms must match clap exactly).      |
+| **partial**    | Some forms work; the note names what remains unsupported.                                              |
 | **usage-only** | Direct usage declarations work, but clap exposes no getter or the bridge cannot preserve the behavior. |
 | **lossy**      | Some common forms work; the note names what is lost.                                                   |
 | **different**  | Intentionally differs from clap.                                                                       |

--- a/docs/rust/completions.md
+++ b/docs/rust/completions.md
@@ -1,8 +1,7 @@
 # Completions
 
 ::: warning Draft
-This page is a draft. Some of what it documents is still in open pull requests, and details may
-change before release.
+This page is a draft and has not yet been human reviewed. Details may change.
 :::
 
 Completion support is opt-in: add `completion` to the root attribute and enable the
@@ -10,7 +9,7 @@ Completion support is opt-in: add `completion` to the root attribute and enable 
 
 ```toml
 [dependencies]
-usage = { package = "usage-rs", version = "6", features = ["completions"] }
+usage = { package = "usage-rs", version = "5.1", features = ["completions"] }
 ```
 
 ```rust
@@ -42,10 +41,9 @@ pub fn completion_request(argv: &[OsString]) -> Option<String>;
 
 `Shell` covers `Bash`, `Zsh`, `Fish`, `Nu`, and `PowerShell`.
 
-For the 6.x compatibility contract, bash, fish, PowerShell, and zsh are the
-clap-parity set. Nushell is an additional usage-native target. Elvish is not
-supported in 6.0, so a clap application that currently publishes an Elvish script
-must keep that generator or defer the migration of that artifact.
+For clap parity, bash, fish, PowerShell, and zsh are the covered set. Nushell is an additional
+usage-native target. Elvish is not supported, so a clap application that currently publishes an
+Elvish script must keep that generator or defer the migration of that artifact.
 
 ## How it works
 
@@ -60,12 +58,13 @@ A typical way to expose the scripts:
 #[derive(Args)]
 struct Completion {
     /// Which shell to generate for
-    #[usage(long, value_enum)]
-    shell: Shell,
+    shell: String,
 }
 
 // in your run function:
-print!("{}", Ex::completion_script(cli.completion.shell.into()));
+let shell = usage::complete::Shell::from_name(&completion.shell)
+    .expect("a supported shell name");
+print!("{}", Ex::completion_script(shell));
 ```
 
 Shell aliases are explicit because each shell stores and expands them differently. To complete
@@ -163,7 +162,13 @@ fn tasks_in_file(
     partial: &<Tasks as usage::spec::CommandArgs>::Partial,
     _ctx: &usage::complete::CompleteCtx<'_>,
 ) -> Vec<usage::complete::Candidate<'static>> {
-    let file = partial.file.as_deref().unwrap_or("tasks.toml");
+    // Partial string fields hold the bytes as typed — a word that is not valid UTF-8 is
+    // still a word somebody wrote.
+    let file = partial
+        .file
+        .as_deref()
+        .map(|bytes| String::from_utf8_lossy(bytes).into_owned());
+    let file = file.as_deref().unwrap_or("tasks.toml");
     read_tasks(file)
         .map(|t| usage::complete::Candidate::described(t.name, t.about))
         .collect()

--- a/docs/rust/dispatch.md
+++ b/docs/rust/dispatch.md
@@ -1,8 +1,7 @@
 # Dispatch
 
 ::: warning Draft
-This page is a draft. Some of what it documents is still in open pull requests, and details may
-change before release.
+This page is a draft and has not yet been human reviewed. Details may change.
 :::
 
 A parse ends with a value: an enum whose selected variant holds the command's own struct. What

--- a/docs/rust/help.md
+++ b/docs/rust/help.md
@@ -1,8 +1,7 @@
 # Help, Version, and Errors
 
 ::: warning Draft
-This page is a draft. Some of what it documents is still in open pull requests, and details may
-change before release.
+This page is a draft and has not yet been human reviewed. Details may change.
 :::
 
 ## Help
@@ -114,8 +113,8 @@ clap panics at startup for the same collision.
 `parse_from` returns `usage::Error`, which distinguishes every failure the grammar can produce:
 `UnknownFlag`, `MissingFlagValue`, `UnexpectedArg`, `MissingRequired`, `DuplicateFlag`,
 `InvalidChoice`, `InvalidValue`, `VarTooFew`/`VarTooMany`, `ConflictingFlags`, `MissingGroup`,
-`MissingSubcommand`, `ArgRequiresDoubleDash`, and more — plus `Help` and `Version` as described
-above.
+`MissingSubcommand`, `ArgRequiresDoubleDash`, `MissingArgsHelp`, `HelpAll`,
+`SubcommandConflict`, and more — plus `Help` and `Version` as described above.
 
 `render_failure(spec, argv, &err)` turns any of them into the message users see. Facade defaults
 include `diagnostics`, so the message is clap-shaped out of the box:

--- a/docs/rust/index.md
+++ b/docs/rust/index.md
@@ -1,9 +1,9 @@
 # Rust Framework
 
 ::: warning Experimental — draft docs
-The Rust framework is experimental. It is complete enough that `usage-cli` itself is built with it,
-but attribute names and APIs may still change between releases. These docs are a draft: some of
-what they document is still in open pull requests, and details may change before release.
+The Rust framework is experimental. It is complete enough that it is actively used by some of
+jdx's CLIs, but there may be breaking changes in point releases. These docs are a draft and have
+not yet been human reviewed.
 :::
 
 The Rust framework builds your CLI from Rust types. You declare commands, flags, and args as
@@ -49,7 +49,7 @@ One dependency. Add `usage-rs` to your `Cargo.toml`, aliased to `usage`:
 
 ```toml
 [dependencies]
-usage = { package = "usage-rs", version = "6" }
+usage = { package = "usage-rs", version = "5.1" }
 ```
 
 That is the whole install: derives, the argv runtime, help, and clap-shaped errors come with the
@@ -77,7 +77,8 @@ available for low-level adopters that want a thinner surface:
 | `spec`        |   ✅    | Spec metadata and `to_kdl()`; gates the derives                                                                   |
 | `help`        |   ✅    | `-h` / `--help` page rendering                                                                                    |
 | `diagnostics` |   ✅    | clap-shaped error messages from `render_failure`                                                                  |
-| `completions` |         | Shell completion scripts and the runtime completion protocol                                                      |
+| `completions` |         | Shell completion scripts and the runtime completion protocol (`complete` is an alias of this feature)             |
+| `validation`  |         | Portable `validate` / `validate_error` expressions ([Validation](/rust/validation#portable-expressions))          |
 | `test`        |         | `usage::test`: parse and help assertions (a dev-dependency feature; completion assertions want `completions` too) |
 | `config`      |         | The `usage::Config` derive and the resolver as `usage::config` ([Settings](/rust/settings))                       |
 
@@ -168,7 +169,7 @@ how to opt out of the endpoint.
 - [Args and flags](/rust/args-and-flags) — field types, attributes, env vars, defaults
 - [Subcommands](/rust/subcommands) — command enums, nesting, `flatten`, value enums
 - [Dispatch](/rust/dispatch) — `Run`, `RunWith`, the async pair, and the generated `match`
-- [Validation](/rust/validation) — choices, groups, `exclusive`, `delimiter`, conflicts
+- [Validation](/rust/validation) — choices, groups, `exclusive`, `delimiter`, conflicts, portable `validate`
 - [Help, version, and errors](/rust/help) — what the parser renders and how to hook it
 - [Completions](/rust/completions) — static scripts and runtime completion
 - [Settings](/rust/settings) — settings declared in code: `usage::Config` and layered resolution
@@ -186,7 +187,8 @@ equivalent yet:
 - A declared `value_optional` needs either `default_missing` or an
   `Option<Option<T>>` field to define what a bare flag binds.
 - Rust `value_parser` functions are not portable metadata. Values use `FromStr`; use
-  `validate` for a portable expression rule and `validate_error` for its diagnostic.
+  `validate` / `validate_error` (the opt-in `validation` feature) for a portable expression
+  rule and its diagnostic.
 - Long flags and subcommands require exact spellings. Diagnostics can suggest a close match, but
   usage does not accept prefixes whose meaning could change when another declaration is added.
 - Completion scripts cover bash, fish, Nushell, PowerShell, and zsh. Elvish is not supported; a

--- a/docs/rust/migrating-from-clap.md
+++ b/docs/rust/migrating-from-clap.md
@@ -1,8 +1,12 @@
 # Migrating from clap
 
-usage 6 is a typed parser with static metadata, not a compatibility layer around clap. Most
-derive-based CLIs migrate mechanically. Builder APIs and `ArgMatches` are intentional API
-breaks: move their behavior into typed declarations or keep clap at that boundary.
+::: warning Draft
+This page is a draft and has not yet been human reviewed. Details may change.
+:::
+
+The Rust framework is a typed parser with static metadata, not a compatibility layer around
+clap. Most derive-based CLIs migrate mechanically. Builder APIs and `ArgMatches` are intentional
+API breaks: move their behavior into typed declarations or keep clap at that boundary.
 
 Use the [compatibility matrix](/rust/clap-compatibility) as the audited baseline. It separates
 behavior supported by usage itself from metadata that `clap_usage` can recover from an existing
@@ -14,7 +18,7 @@ Depend on the facade rather than on `usage-derive` or `usage-argv` separately:
 
 ```toml
 [dependencies]
-usage = { package = "usage-rs", version = "6", features = ["completions"] }
+usage = { package = "usage-rs", version = "5.1", features = ["completions"] }
 ```
 
 The defaults include the derive, help, and clap-shaped diagnostics. Add `validation` for portable
@@ -23,7 +27,7 @@ requests.
 
 During a prerelease migration, pin every producer and consumer to one revision. In particular,
 the `usage-rs` dependency that emits KDL and any installed `usage-cli` that renders that KDL must
-use the same 6.x revision. A 5.x CLI reading a 6.x spec is unsupported.
+use the same revision.
 
 The migration also shrinks the dependency graph (`cargo tree` on a minimal binary, clap 4.6.6
 with `derive` against the defaults plus `completions`):
@@ -192,9 +196,13 @@ struct Explicit {
 }
 ```
 
-Relationships that cross a flattened boundary or name a positional are not supported yet. Keep
-the check after parsing until the compatibility matrix marks that row supported; the derive
-rejects selectors it can prove invalid instead of silently weakening them.
+Relationships that cross a flattened boundary are **lossy**: common forms work, but a declaring
+type cannot yet validate a selector supplied by a flattened sibling. Positional relationships
+are **partial**: conflicts, requires, and conditional requiredness work; binding-time `overrides`
+and value-source `requires_if` remain flag-only. Keep a post-parse check only for forms the
+[compatibility matrix](/rust/clap-compatibility#relationships-and-command-routing) still marks
+lossy or partial; the derive rejects selectors it can prove invalid instead of silently
+weakening them.
 
 ## Parse entry points
 
@@ -279,11 +287,11 @@ interpreter for applications that genuinely construct a CLI at runtime.
 
 ## Compatibility policy
 
-Within usage 6.x, changes to accepted argv, typed binding, exit status, stdout versus stderr, or
-the portable spec dialect are parser behavior and follow semver. New clap spellings may be added
-compatibly when they map to existing behavior. A spelling whose clap behavior cannot be carried
-losslessly is rejected or documented as partial; it is not silently accepted with weaker
-semantics.
+While the Rust framework is experimental, changes to accepted argv, typed binding, exit status,
+stdout versus stderr, or the portable spec dialect may land in point releases. New clap
+spellings may be added when they map to existing behavior. A spelling whose clap behavior cannot
+be carried losslessly is rejected or documented as partial; it is not silently accepted with
+weaker semantics.
 
 The compatibility matrix is versioned against the clap releases named at its top. Updating clap
 requires re-auditing that matrix; compiling with a new clap is not by itself a parity claim.

--- a/docs/rust/performance.md
+++ b/docs/rust/performance.md
@@ -1,5 +1,9 @@
 # Parser performance
 
+::: warning Draft
+This page is a draft and has not yet been human reviewed. Details may change.
+:::
+
 usage's compiled Rust parser is designed so ordinary argv parsing reads static
 tables and writes directly into the result. Cold metadata for help, specs, and
 completions is not constructed on a successful parse.

--- a/docs/rust/quickstart.md
+++ b/docs/rust/quickstart.md
@@ -1,8 +1,7 @@
 # Quickstart
 
 ::: warning Draft
-This page is a draft. Some of what it documents is still in open pull requests, and details may
-change before release.
+This page is a draft and has not yet been human reviewed. Details may change.
 :::
 
 One small CLI, end to end: declare it, run it, complete it, and generate its docs — all from one
@@ -16,7 +15,7 @@ cargo new greet
 
 ```toml
 [dependencies]
-usage = { package = "usage-rs", version = "6", features = ["completions"] }
+usage = { package = "usage-rs", version = "5.1", features = ["completions"] }
 ```
 
 ## The declaration
@@ -186,7 +185,7 @@ cmd hello help="Greet someone" {
 
 ```toml
 [dev-dependencies]
-usage = { package = "usage-rs", version = "6", features = ["test", "completions"] }
+usage = { package = "usage-rs", version = "5.1", features = ["test", "completions"] }
 ```
 
 ```rust

--- a/docs/rust/settings.md
+++ b/docs/rust/settings.md
@@ -1,5 +1,9 @@
 # Settings
 
+::: warning Draft
+This page is a draft and has not yet been human reviewed. Details may change.
+:::
+
 CLIs that resolve configuration from several places — flags, environment variables, config
 files — have historically kept three descriptions of every setting in step by hand: a registry
 file, a code generator, and the struct the program reads. `#[derive(usage::Config)]` collapses
@@ -14,13 +18,21 @@ Enable the `config` feature:
 usage = { package = "usage-rs", version = "5.1", features = ["config"] }
 ```
 
+Reading config files is opt-in per format on `usage-config` itself — the facade's `config`
+feature does not pull TOML, JSON, or YAML. Add the format you need when you use `FileLayer`:
+
+```toml
+[dependencies]
+usage-config = { version = "5.1", features = ["toml"] }
+```
+
 ## Declaring
 
 ```rust
-use usage_rs as usage;
+use usage::Config;
 
 /// How this tool behaves, resolved from flags, the environment, and files.
-#[derive(usage::Config)]
+#[derive(Config)]
 struct Settings {
     /// How many jobs to run at once
     #[usage(env = "EX_JOBS", default = 4, cli("--jobs", "-j"))]
@@ -40,7 +52,7 @@ struct Settings {
 }
 
 /// The `task.*` settings.
-#[derive(usage::Config)]
+#[derive(Config)]
 #[usage(prefix = "task")]
 struct TaskSettings {
     /// How task output is interleaved
@@ -114,6 +126,7 @@ use usage::config::{resolve, EnvLayer, FileLayer, FileScope, Layers};
 
 let (cli, cli_layer) = Ex::parse_from_with_settings(&argv)?;
 let env = EnvLayer::from_process();
+// FileLayer needs a format feature on usage-config (`toml`, `json`, or `yaml`).
 let project = FileLayer::find_up("ex.toml", &cwd, None, FileScope::Project);
 let resolved = resolve(
     Settings::SETTINGS_REGISTRY,

--- a/docs/rust/spec.md
+++ b/docs/rust/spec.md
@@ -1,8 +1,7 @@
 # Spec Output
 
 ::: warning Draft
-This page is a draft. Some of what it documents is still in open pull requests, and details may
-change before release.
+This page is a draft and has not yet been human reviewed. Details may change.
 :::
 
 `Cli::to_kdl()` writes a complete [usage spec](/spec/) from the same static metadata the parser
@@ -47,9 +46,16 @@ the conformance suite. The test every adopter should write is one line:
 ```rust
 #[test]
 fn spec_is_valid() {
-    let spec: usage::Spec = Cli::to_kdl().parse().unwrap();
+    // usage-lib is a separate package from the usage-rs facade. Alias it so the
+    // type path does not collide with `usage`.
+    let spec: usage_parser::Spec = Cli::to_kdl().parse().unwrap();
     let _ = spec;
 }
+```
+
+```toml
+[dev-dependencies]
+usage-parser = { package = "usage-lib", version = "5.1" }
 ```
 
 Beyond parsing, `to_kdl` asserts (in debug builds) that the tree is coherent: no duplicate keys,
@@ -150,7 +156,7 @@ with the literal written to portable artifacts:
     bin = host::program_name(),
     bin_spec = "mycli",
     version = build::version(),
-    version_spec = "6.0.0"
+    version_spec = "1.0.0"
 )]
 struct Cli;
 ```
@@ -158,7 +164,7 @@ struct Cli;
 The name and bin expressions return `&'static str`; a computed version implements `ToString`.
 They are evaluated only when the process renders help, version output, diagnostics, or a
 completion script. Successful argument parsing still reads the static tables directly and does
-not allocate or build a command graph. `to_kdl()` keeps `mycli` and `6.0.0`, so generated
+not allocate or build a command graph. `to_kdl()` keeps `mycli` and `1.0.0`, so generated
 artifacts are deterministic and do not depend on the embedding process. `--version` formats the
 computed version, while `version_spec` remains the static value exported to KDL.
 

--- a/docs/rust/subcommands.md
+++ b/docs/rust/subcommands.md
@@ -1,8 +1,7 @@
 # Subcommands
 
 ::: warning Draft
-This page is a draft. Some of what it documents is still in open pull requests, and details may
-change before release.
+This page is a draft and has not yet been human reviewed. Details may change.
 :::
 
 Subcommands are an enum. Each variant wraps a `#[derive(Args)]` struct (or nothing), and the
@@ -57,8 +56,8 @@ Variant attributes: `name`, `alias`, `alias_hidden`, `hide`, `effect`, `help`, `
 `verbatim_doc_comment`, `external_subcommand`, `arg_required_else_help`. Aliases declared on the variant and on the `Args`
 struct are joined.
 
-Two variants wrapping the _same_ struct is a compile error — each command needs its own
-declaration (two byte-identical structs in different modules are fine).
+The same `Args` type may be mounted under more than one variant — useful for shared option
+groups across sibling commands.
 
 ## Default subcommand
 

--- a/docs/rust/testing.md
+++ b/docs/rust/testing.md
@@ -1,8 +1,7 @@
 # Testing
 
 ::: warning Draft
-This page is a draft. Some of what it documents is still in open pull requests, and details may
-change before release.
+This page is a draft and has not yet been human reviewed. Details may change.
 :::
 
 A CLI's observable surface is three things: what a command line parses to, what a user reads
@@ -17,7 +16,7 @@ assertion.
 
 ```toml
 [dev-dependencies]
-usage = { package = "usage-rs", version = "6", features = ["test"] }
+usage = { package = "usage-rs", version = "5.1", features = ["test"] }
 ```
 
 The feature belongs in `dev-dependencies`: nothing in an application's own code calls it.
@@ -130,7 +129,7 @@ that answers a line:
 
 ```toml
 [dev-dependencies]
-usage = { package = "usage-rs", version = "6", features = ["test", "completions"] }
+usage = { package = "usage-rs", version = "5.1", features = ["test", "completions"] }
 ```
 
 `candidates` then answers the question a shell asks: given this half-typed line, what could this

--- a/docs/rust/validation.md
+++ b/docs/rust/validation.md
@@ -1,8 +1,7 @@
 # Validation
 
 ::: warning Draft
-This page is a draft. Some of what it documents is still in open pull requests, and details may
-change before release.
+This page is a draft and has not yet been human reviewed. Details may change.
 :::
 
 Everything on this page runs after argv is bound and env/default fallbacks are applied. Only the
@@ -29,8 +28,8 @@ are `VarTooFew`/`VarTooMany`. For enum-shaped values prefer
 ## Flag relations
 
 `conflicts`, `requires`, `required_if`, `required_if_eq`, and `required_unless` relate arguments to
-another. Targets are named the way the KDL spec names them (`"--long"` or `"-s"`), and naming a
-flag that doesn't exist is a compile error:
+another. Targets are named the way the KDL spec names them (`"--long"` or `"-s"` for flags, or a
+bare positional name), and naming one that doesn't exist is a compile error:
 
 ```rust
 /// Read from standard input
@@ -138,3 +137,27 @@ value and `var_min`/`var_max` count values, not words — `--tags a,b,c,d` with 
 
 The field must be a `Vec`, and the delimiter must be a single ASCII character; both are enforced
 at compile time. Emitted KDL: `flag "--tags <tag>" var=#true delimiter=","`.
+
+## Portable expressions
+
+For a rule that must survive KDL emission — and that clap would have expressed with a
+`value_parser` callback — enable the `validation` feature and declare an expression:
+
+```toml
+[dependencies]
+usage = { package = "usage-rs", version = "5.1", features = ["validation"] }
+```
+
+```rust
+#[usage(
+    long,
+    validate = "int(value) >= 1 && int(value) <= 65535",
+    validate_error = "must be a valid port"
+)]
+port: Option<u16>,
+```
+
+`validate` is evaluated after binding. `validate_error` is the diagnostic users see when the
+expression is false. Rust `value_parser` functions are not portable metadata — use `FromStr`
+for typed conversion and these attributes for declarative rules that docs, manpages, and other
+spec consumers can see.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Rewrites the experimental banner: actively used by some of jdx’s CLIs, possible breaking changes in point releases, docs are an unreviewed draft.
- Aligns install snippets and narrative with published `5.1` (were incorrectly advertising `6`).
- Fixes factual errors found while reviewing the rust docs against the codebase (positional relations, shared `Args`, completer `Partial` bytes, `usage::Spec` round-trip, `FileLayer` format features, flatten/positional relationship guidance).
- Fills gaps: `validation` / `complete` features, portable `validate` section, matrix legend marks, draft banners on pages that lacked them.

## Test plan

- [x] Grep/read-through of `docs/rust/` against `usage-rs` / derive / config sources for the corrected claims
- [x] `prettier -w docs/rust/`
- Docs-only change; no runtime tests required

Verification log:

[rust_docs_review_checks.log](https://cursor.com/agents/bc-2da9bd58-1b67-4f1e-b327-b951e475a37d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frust_docs_review_checks.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2da9bd58-1b67-4f1e-b327-b951e475a37d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2da9bd58-1b67-4f1e-b327-b951e475a37d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Rust documentation with clearer draft-status notices and refreshed version 5.1 examples.
  * Expanded guidance for argument relationships, validation, shell completions, settings, subcommands, and migration from clap.
  * Documented optional validation and configuration features, declarative validation expressions, custom error messages, and evaluation timing.
  * Clarified compatibility status, supported shells, positional relationships, parser usage, help errors, and reusable argument definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->