### PR TITLE
feat(config): gate deprecated settings by explicit CLI version

### DIFF
--- a/config/src/layer.rs
+++ b/config/src/layer.rs
@@ -80,6 +80,9 @@ pub enum WarningKind {
     OutOfScope,
     /// A setting whose spec says not to use it any more.
     Deprecated,
+    /// A configured value for a setting whose removal milestone has been reached, and which was
+    /// therefore ignored.
+    Removed,
     /// A value that arrived under an old name and was read as the setting that replaced it.
     Renamed,
     /// A value that was passed over because another name for the same setting won.

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -27,6 +27,9 @@
 //!   otherwise.
 //! - **Warnings, not output.** Nothing here prints. An unknown key, a value of the wrong
 //!   type, a deprecated setting: all returned, for the CLI to render when its logging is up.
+//! - **Lifecycle gates are explicit.** `deprecated_warn_at` and `deprecated_remove_at` act
+//!   against the running CLI version supplied to [`resolve_with_context`]. This crate's own
+//!   package version is never assumed.
 //!
 //! # Example
 //!
@@ -79,7 +82,7 @@ pub use layer::{Entry, Layer, LayerCtx, LayerError, LayerOutput, Warning, Warnin
 pub use props::{concat_prop_specs, concat_props, Props};
 pub use read::{Fold, FromValue, ReadError, ReadErrorKind, ReadErrors};
 pub use registry::{Lookup, Merge, PropId, PropMeta, Registry, Scope};
-pub use resolve::{resolve, Layers, Resolved};
+pub use resolve::{resolve, resolve_with_context, Layers, ResolutionContext, Resolved};
 pub use source::{FileScope, Origin, SourceKind, Trust};
 pub use spec::{spec_kdl, spec_kdl_with, ConfigSpec, PropSpec, SpecFile, SpecSource};
 pub use ty::{Parser, Ty, TypeError};

--- a/config/src/registry.rs
+++ b/config/src/registry.rs
@@ -109,7 +109,8 @@ pub struct PropMeta {
     pub default_note: Option<&'static str>,
     /// The release that introduced this setting, when the declaration says.
     pub since: Option<&'static str>,
-    /// The release that starts warning about a deprecated setting, and the one that removes it.
+    /// The CLI version that starts warning about a deprecated setting, and the one after which
+    /// configured values for it are ignored.
     pub deprecated_warn_at: Option<&'static str>,
     pub deprecated_remove_at: Option<&'static str>,
     /// Values worth showing a reader, verbatim.
@@ -314,7 +315,7 @@ impl Registry {
         })
     }
 
-    /// The first deprecation notice along the rename chain that starts at `key`.
+    /// The first deprecated declaration along the rename chain that starts at `key`.
     ///
     /// The chain, not the declaration named: `a` renamed to `b`, and `b` the one carrying the notice
     /// that says to use `c`. A user who wrote `a` is being told the same thing either way, and which
@@ -324,7 +325,7 @@ impl Registry {
     /// rather than following them forever — the same guard [`Registry::lookup`] uses, and for the
     /// same reason: this is an authoring mistake, and hanging is a worse way to report one than
     /// nothing at all. The derive refuses such a declaration outright.
-    pub fn deprecation(&self, key: &str) -> Option<&'static str> {
+    pub fn deprecation_meta(&self, key: &str) -> Option<&'static PropMeta> {
         let mut current = self
             .props
             .iter()
@@ -332,12 +333,20 @@ impl Registry {
             .map(|index| PropId(index as u16))?;
         for _ in 0..self.props.len() {
             let meta = self.get(current);
-            if let Some(why) = meta.deprecated {
-                return Some(why);
+            if meta.deprecated.is_some() {
+                return Some(meta);
             }
             current = meta.renamed_to.and_then(|next| self.lookup_exact(next))?;
         }
         None
+    }
+
+    /// The first deprecation notice along the rename chain that starts at `key`.
+    ///
+    /// Kept as the message-only counterpart to [`Registry::deprecation_meta`] for callers that do
+    /// not need lifecycle milestones.
+    pub fn deprecation(&self, key: &str) -> Option<&'static str> {
+        self.deprecation_meta(key).and_then(|meta| meta.deprecated)
     }
 
     /// The settings an environment variable sets, and the variable that set them.
@@ -509,6 +518,10 @@ mod tests {
         assert_eq!(
             registry.deprecation("parallelism"),
             Some("Use jobs instead.")
+        );
+        assert_eq!(
+            registry.deprecation_meta("parallelism").unwrap().key,
+            "concurrency"
         );
     }
 

--- a/config/src/resolve.rs
+++ b/config/src/resolve.rs
@@ -9,6 +9,7 @@
 //! Layers are given highest precedence first — the order they read in the builder and the
 //! order `--help` describes them — and folded lowest first, so the last writer wins.
 
+use std::cmp::Ordering;
 use std::collections::BTreeMap;
 
 use crate::layer::{Layer, LayerCtx, LayerError, Warning, WarningKind};
@@ -137,12 +138,68 @@ impl<'a> Layers<'a> {
     }
 }
 
+/// Runtime facts that affect configuration resolution.
+///
+/// The resolver cannot infer the running CLI's version from this crate's package version: a
+/// library release and an adopting CLI release are unrelated, and a CLI may compute its version at
+/// runtime. Pass it explicitly with [`ResolutionContext::for_cli_version`] when lifecycle gates
+/// should be enforced.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct ResolutionContext<'a> {
+    cli_version: Option<&'a str>,
+}
+
+impl<'a> ResolutionContext<'a> {
+    /// A context with no CLI version.
+    ///
+    /// This preserves the historical [`resolve`] behavior: deprecations warn immediately, while
+    /// removal milestones do not discard values when the resolver cannot know whether they have
+    /// been reached.
+    pub const fn new() -> Self {
+        Self { cli_version: None }
+    }
+
+    /// A context for the running CLI version.
+    pub const fn for_cli_version(version: &'a str) -> Self {
+        Self {
+            cli_version: Some(version),
+        }
+    }
+
+    /// The running CLI version, if the caller supplied one.
+    pub const fn cli_version(self) -> Option<&'a str> {
+        self.cli_version
+    }
+}
+
 /// Resolve every setting in `registry` from `layers`.
 ///
 /// Declared defaults are the bottom layer always, and are not a [`Layer`]: they cost one
 /// `const` conversion per setting that needs one and cannot fail, so making them an
 /// implementation would be ceremony that could also be forgotten.
+///
+/// This compatibility entry point has no CLI version context. Use [`resolve_with_context`] to
+/// enforce `deprecated_warn_at` and `deprecated_remove_at` against the running CLI version.
 pub fn resolve(registry: Registry, layers: Layers<'_>) -> Result<Resolved, LayerError> {
+    resolve_with_context(registry, layers, ResolutionContext::new())
+}
+
+/// Resolve every setting with explicit runtime context.
+///
+/// A configured value before `deprecated_warn_at` is accepted without a deprecation warning. At
+/// that release it is accepted with a warning. At `deprecated_remove_at` it is ignored with a
+/// [`WarningKind::Removed`] warning, just like an unsupported configuration key costs only that
+/// value rather than failing the whole file. Declared defaults remain the floor: the gate removes
+/// external contributions, not the compiled setting from the caller's Rust type.
+///
+/// Missing or unreadable versions are conservative in both directions: they warn, because silence
+/// can hide a deprecation forever, but do not remove a value, because uncertainty must not silently
+/// change configuration.
+pub fn resolve_with_context(
+    registry: Registry,
+    layers: Layers<'_>,
+    context: ResolutionContext<'_>,
+) -> Result<Resolved, LayerError> {
     let ctx = LayerCtx::new(registry);
     let count = registry.props.len();
     let mut resolved = Resolved {
@@ -222,14 +279,34 @@ pub fn resolve(registry: Registry, layers: Layers<'_>) -> Result<Resolved, Layer
             // always done: a notice can sit on a name further along, and reading only the one the
             // user wrote meant `config explain` told them to stop using a key that running the CLI
             // said nothing about.
-            if let Some(why) = registry.deprecation(written_key) {
-                resolved.warnings.push(
-                    Warning::at(
-                        format!("{written_key} is deprecated: {why}"),
-                        entry.origin.clone(),
-                    )
-                    .of(WarningKind::Deprecated),
-                );
+            if let Some(deprecated) = registry.deprecation_meta(written_key) {
+                let why = deprecated.deprecated.expect("deprecated declaration");
+                if milestone_reached(context.cli_version, deprecated.deprecated_remove_at)
+                    == Some(true)
+                {
+                    let at = deprecated
+                        .deprecated_remove_at
+                        .expect("reached removal milestone");
+                    resolved.warnings.push(
+                        Warning::at(
+                            format!("{written_key} was removed at {at}: {why}"),
+                            entry.origin,
+                        )
+                        .of(WarningKind::Removed),
+                    );
+                    continue;
+                }
+                if milestone_reached(context.cli_version, deprecated.deprecated_warn_at)
+                    != Some(false)
+                {
+                    resolved.warnings.push(
+                        Warning::at(
+                            format!("{written_key} is deprecated: {why}"),
+                            entry.origin.clone(),
+                        )
+                        .of(WarningKind::Deprecated),
+                    );
+                }
             }
             if entry.renamed_from.is_some() || prop != entry.prop {
                 // Both names: the key the user wrote, and the one it was read as.
@@ -276,6 +353,57 @@ pub fn resolve(registry: Registry, layers: Layers<'_>) -> Result<Resolved, Layer
     }
 
     Ok(resolved)
+}
+
+/// Whether both versions are readable and `current` has reached `milestone`.
+///
+/// `None` is deliberately distinct from `false`: callers warn on uncertainty but only remove on
+/// certainty.
+fn milestone_reached(current: Option<&str>, milestone: Option<&str>) -> Option<bool> {
+    let ordering = compare_versions(current?, milestone?)?;
+    Some(ordering != Ordering::Less)
+}
+
+/// Compare dotted numeric versions under the argv/spec lifecycle rule.
+///
+/// Missing numeric segments are zero, prereleases sort before their release, and build metadata is
+/// ignored. This intentionally accepts calver as well as semver.
+fn compare_versions(a: &str, b: &str) -> Option<Ordering> {
+    let (a_core, a_pre) = split_version(a);
+    let (b_core, b_pre) = split_version(b);
+    let mut a_segments = a_core.split('.');
+    let mut b_segments = b_core.split('.');
+    loop {
+        let (a_next, b_next) = (a_segments.next(), b_segments.next());
+        if a_next.is_none() && b_next.is_none() {
+            break;
+        }
+        match version_segment(a_next)?.cmp(&version_segment(b_next)?) {
+            Ordering::Equal => continue,
+            ordering => return Some(ordering),
+        }
+    }
+    Some(match (a_pre, b_pre) {
+        (None, None) => Ordering::Equal,
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (Some(a), Some(b)) => a.cmp(b),
+    })
+}
+
+fn split_version(version: &str) -> (&str, Option<&str>) {
+    let version = version.split('+').next().unwrap_or(version);
+    match version.split_once('-') {
+        Some((core, pre)) => (core, Some(pre)),
+        None => (version, None),
+    }
+}
+
+fn version_segment(segment: Option<&str>) -> Option<u64> {
+    match segment {
+        None => Some(0),
+        Some(text) => text.parse().ok(),
+    }
 }
 
 /// Why this scope will not take a value from this origin, if it will not.
@@ -760,6 +888,163 @@ mod tests {
             resolved.warnings[0].origin.as_ref().unwrap().describe(),
             "hk.toml"
         );
+    }
+
+    static GATED_PROPS: &[PropMeta] = &[PropMeta {
+        default: Some(Const::Int(1)),
+        deprecated: Some("Use modern instead."),
+        deprecated_warn_at: Some("2.0.0"),
+        deprecated_remove_at: Some("3.0.0"),
+        ..PropMeta::new("legacy", Ty::Uint)
+    }];
+    const GATED: Registry = Registry::new(GATED_PROPS);
+
+    fn gated_layer() -> Fixed {
+        Fixed {
+            kind: SourceKind::FILE,
+            entries: vec![Entry::new(
+                PropId(0),
+                Value::Int(8),
+                Origin::file("app.toml", FileScope::Project),
+            )],
+        }
+    }
+
+    #[test]
+    fn deprecation_versions_gate_warnings_and_configured_values_at_boundaries() {
+        let cases = [
+            ("1.9.9", Some(8), None),
+            ("2.0.0-rc.1", Some(8), None),
+            ("2", Some(8), Some(WarningKind::Deprecated)),
+            ("2.9.9", Some(8), Some(WarningKind::Deprecated)),
+            ("3.0.0-rc.1", Some(8), Some(WarningKind::Deprecated)),
+            ("3.0.0", Some(1), Some(WarningKind::Removed)),
+            ("4.0.0", Some(1), Some(WarningKind::Removed)),
+        ];
+
+        for (version, expected, kind) in cases {
+            let layer = gated_layer();
+            let resolved = resolve_with_context(
+                GATED,
+                Layers::new().then(&layer),
+                ResolutionContext::for_cli_version(version),
+            )
+            .expect(version);
+            assert_eq!(
+                resolved.get_key("legacy"),
+                expected.map(Value::Int).as_ref(),
+                "{version}"
+            );
+            assert_eq!(
+                resolved.warnings.iter().map(|warning| warning.kind).next(),
+                kind,
+                "{version}: {:?}",
+                resolved.warnings
+            );
+        }
+    }
+
+    #[test]
+    fn a_reached_removal_is_ignored_out_loud_and_falls_back_to_the_default() {
+        let layer = gated_layer();
+        let resolved = resolve_with_context(
+            GATED,
+            Layers::new().then(&layer),
+            ResolutionContext::for_cli_version("3.0.0+build.7"),
+        )
+        .expect("resolves");
+
+        assert_eq!(resolved.get_key("legacy"), Some(&Value::Int(1)));
+        assert_eq!(
+            resolved.origin_key("legacy").unwrap().describe(),
+            "the default"
+        );
+        assert_eq!(resolved.contributors_key("legacy").len(), 1);
+        assert_eq!(resolved.warnings[0].kind, WarningKind::Removed);
+        assert_eq!(
+            resolved.warnings[0].message,
+            "legacy was removed at 3.0.0: Use modern instead."
+        );
+        assert_eq!(
+            resolved.warnings[0].origin.as_ref().unwrap().describe(),
+            "app.toml"
+        );
+    }
+
+    #[test]
+    fn no_or_unreadable_version_warns_without_discarding_configuration() {
+        for context in [
+            ResolutionContext::new(),
+            ResolutionContext::for_cli_version("nightly"),
+            ResolutionContext::for_cli_version(""),
+        ] {
+            let layer = gated_layer();
+            let resolved =
+                resolve_with_context(GATED, Layers::new().then(&layer), context).expect("resolves");
+            assert_eq!(resolved.get_key("legacy"), Some(&Value::Int(8)));
+            assert_eq!(resolved.warnings.len(), 1);
+            assert_eq!(resolved.warnings[0].kind, WarningKind::Deprecated);
+            assert_eq!(
+                resolved.warnings[0].message,
+                "legacy is deprecated: Use modern instead."
+            );
+        }
+
+        let layer = gated_layer();
+        let compatible = resolve(GATED, Layers::new().then(&layer)).expect("resolves");
+        assert_eq!(compatible.get_key("legacy"), Some(&Value::Int(8)));
+        assert_eq!(compatible.warnings[0].kind, WarningKind::Deprecated);
+    }
+
+    #[test]
+    fn unreadable_milestones_warn_but_never_remove() {
+        static INVALID_PROPS: &[PropMeta] = &[PropMeta {
+            deprecated: Some("Use modern instead."),
+            deprecated_warn_at: Some("next"),
+            deprecated_remove_at: Some("eventually"),
+            ..PropMeta::new("legacy", Ty::Uint)
+        }];
+        const INVALID: Registry = Registry::new(INVALID_PROPS);
+        let layer = Fixed {
+            kind: SourceKind::FILE,
+            entries: vec![Entry::new(
+                PropId(0),
+                Value::Int(8),
+                Origin::file("app.toml", FileScope::Project),
+            )],
+        };
+        let resolved = resolve_with_context(
+            INVALID,
+            Layers::new().then(&layer),
+            ResolutionContext::for_cli_version("99.0.0"),
+        )
+        .expect("resolves");
+
+        assert_eq!(resolved.get_key("legacy"), Some(&Value::Int(8)));
+        assert_eq!(resolved.warnings[0].kind, WarningKind::Deprecated);
+    }
+
+    #[test]
+    fn version_comparison_matches_the_argv_spec_rule() {
+        assert_eq!(
+            compare_versions("2026.12", "2026.12.0"),
+            Some(Ordering::Equal)
+        );
+        assert_eq!(
+            compare_versions("2027.1.0", "2026.12.99"),
+            Some(Ordering::Greater)
+        );
+        assert_eq!(
+            compare_versions("1.0.0-rc.1", "1.0.0"),
+            Some(Ordering::Less)
+        );
+        assert_eq!(
+            compare_versions("1.0.0+one", "1.0.0+two"),
+            Some(Ordering::Equal)
+        );
+        assert_eq!(compare_versions("nightly", "2.0.0"), None);
+        assert_eq!(compare_versions("2.0.0", "whenever"), None);
+        assert_eq!(compare_versions("", "2.0.0"), None);
     }
 
     #[test]

--- a/conformance/tests/derive_config.rs
+++ b/conformance/tests/derive_config.rs
@@ -10,7 +10,9 @@ use std::collections::BTreeMap;
 use std::ffi::OsStr;
 use std::path::PathBuf;
 
-use usage_config::{resolve, Const, EnvLayer, Layers, Ty, Value};
+use usage_config::{
+    resolve, resolve_with_context, Const, EnvLayer, Layers, ResolutionContext, Ty, Value,
+};
 use usage_derive::{Cli, Config};
 
 fn default_cache_dir() -> PathBuf {
@@ -389,6 +391,52 @@ fn the_metadata_only_docs_read_survives_the_round_trip() {
         Some("Stop at the first failure\n\nWhether a failing job stops the rest of them.")
     );
     assert_eq!(parsed.long_help.as_deref(), declared.long_help);
+}
+
+#[derive(Config, Debug, PartialEq)]
+struct GatedSetting {
+    #[usage(
+        env = "EX_LEGACY",
+        deprecated = "use modern",
+        deprecated_warn_at = "6.0.0",
+        deprecated_remove_at = "7.0.0"
+    )]
+    legacy: Option<bool>,
+}
+
+#[test]
+fn derived_config_lifecycle_metadata_controls_resolution() {
+    let env = EnvLayer::new([("EX_LEGACY".to_string(), "true".to_string())]);
+
+    let before = resolve_with_context(
+        GatedSetting::SETTINGS_REGISTRY,
+        Layers::new().then(&env),
+        ResolutionContext::for_cli_version("5.9.9"),
+    )
+    .expect("resolves before warning");
+    assert_eq!(GatedSetting::read(&before).unwrap().legacy, Some(true));
+    assert!(before.warnings.is_empty());
+
+    let warning = resolve_with_context(
+        GatedSetting::SETTINGS_REGISTRY,
+        Layers::new().then(&env),
+        ResolutionContext::for_cli_version("6.0.0"),
+    )
+    .expect("resolves at warning");
+    assert_eq!(GatedSetting::read(&warning).unwrap().legacy, Some(true));
+    assert_eq!(
+        warning.warnings[0].kind,
+        usage_config::WarningKind::Deprecated
+    );
+
+    let removed = resolve_with_context(
+        GatedSetting::SETTINGS_REGISTRY,
+        Layers::new().then(&env),
+        ResolutionContext::for_cli_version("7.0.0"),
+    )
+    .expect("resolves at removal");
+    assert_eq!(GatedSetting::read(&removed).unwrap().legacy, None);
+    assert_eq!(removed.warnings[0].kind, usage_config::WarningKind::Removed);
 }
 
 /// A CLI whose settings-bound flag is deprecated.

--- a/docs/rust/settings.md
+++ b/docs/rust/settings.md
@@ -88,26 +88,27 @@ CLI's file chain.
 
 Field attributes mirror the spec's [`prop` vocabulary](/spec/reference/config):
 
-| Attribute                                                | Effect                                                                                                              |
-| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `env = "X"` / `env("A", "B")`                            | Environment variables, highest precedence first                                                                     |
-| `deprecated_env("OLD")`                                  | Deprecated aliases, consulted afterwards and warned about                                                           |
-| `default = 4` / `default(80, 443)`                       | The value when no layer supplies one                                                                                |
-| `default_fn = path`                                      | A computed default (`fn() -> T`), applied after the resolution                                                      |
-| `default_note = "…"`                                     | Prose beside the default, for docs                                                                                  |
-| `cli("--jobs", "-j")`                                    | The flags that set it — what `Registry::drift` holds bindings against                                               |
-| `source("git", "hk.jobs")`                               | Its keys in sources usage does not know about                                                                       |
-| `choices("a", "b")`                                      | The only values it accepts                                                                                          |
-| `merge = "union"` / `"deep"`                             | How a collection combines across layers                                                                             |
-| `scope = "global"` / `"env"`                             | Where a value is accepted from                                                                                      |
-| `parse = "list_by_comma"`                                | How one string becomes several values                                                                               |
-| `alias("other")`                                         | Equivalent keys accepted without a warning — written in full, so a group's `prefix` is repeated rather than implied |
-| `key = "match"`                                          | The dotted key, when the field name is not it                                                                       |
-| `hide`, `deprecated = "…"`, `since = "…"`, `examples(…)` | Documentation and lifecycle metadata                                                                                |
-| `help_heading = "Performance"`                           | The section to list this setting under in generated docs                                                            |
-| `writes_to = "git"`                                      | Where `config set` should write this, when it is not the usual file                                                 |
-| `x("tool.key", value)`                                   | Tool-private `x` metadata. Spec-only: resolution does not interpret it. Repeatable; order is preserved              |
-| `flatten`                                                | Splice another `Config` struct's settings in at this position                                                       |
+| Attribute                                    | Effect                                                                                                              |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `env = "X"` / `env("A", "B")`                | Environment variables, highest precedence first                                                                     |
+| `deprecated_env("OLD")`                      | Deprecated aliases, consulted afterwards and warned about                                                           |
+| `default = 4` / `default(80, 443)`           | The value when no layer supplies one                                                                                |
+| `default_fn = path`                          | A computed default (`fn() -> T`), applied after the resolution                                                      |
+| `default_note = "…"`                         | Prose beside the default, for docs                                                                                  |
+| `cli("--jobs", "-j")`                        | The flags that set it — what `Registry::drift` holds bindings against                                               |
+| `source("git", "hk.jobs")`                   | Its keys in sources usage does not know about                                                                       |
+| `choices("a", "b")`                          | The only values it accepts                                                                                          |
+| `merge = "union"` / `"deep"`                 | How a collection combines across layers                                                                             |
+| `scope = "global"` / `"env"`                 | Where a value is accepted from                                                                                      |
+| `parse = "list_by_comma"`                    | How one string becomes several values                                                                               |
+| `alias("other")`                             | Equivalent keys accepted without a warning — written in full, so a group's `prefix` is repeated rather than implied |
+| `key = "match"`                              | The dotted key, when the field name is not it                                                                       |
+| `hide`, `since = "…"`, `examples(…)`         | Documentation and lifecycle metadata                                                                                |
+| `deprecated = "…"` and its `*_at` milestones | Warn, then ignore configured values when explicit CLI version context reaches removal                               |
+| `help_heading = "Performance"`               | The section to list this setting under in generated docs                                                            |
+| `writes_to = "git"`                          | Where `config set` should write this, when it is not the usual file                                                 |
+| `x("tool.key", value)`                       | Tool-private `x` metadata. Spec-only: resolution does not interpret it. Repeatable; order is preserved              |
+| `flatten`                                    | Splice another `Config` struct's settings in at this position                                                       |
 
 `help_heading`, `writes_to`, and `x` are spec metadata. They ride in `SETTINGS_SPEC` beside
 the runtime registry rather than on `PropMeta`, because the merge never reads them. The
@@ -124,6 +125,18 @@ An `alias` is written in full, including a group's `prefix` — `alias("task.out
 `#[usage(prefix = "task")]` group, not `alias("out")`. An alias is usually a name a setting
 used to have, and one that moved into a group often wants its old unprefixed spelling, so the
 full form is the one that can say either.
+
+Pass the running program version explicitly when resolving lifecycle gates:
+
+```rust
+let context = usage::config::ResolutionContext::for_cli_version(env!("CARGO_PKG_VERSION"));
+let resolved =
+    usage::config::resolve_with_context(Settings::SETTINGS_REGISTRY, layers, context)?;
+```
+
+The caller chooses that string because an adopting CLI's version is not `usage-config`'s package
+version and may be computed at runtime. `resolve(...)` remains available for compatibility when
+there is no version context; it warns about a deprecated setting but does not remove its value.
 
 A default and a choice are written as the type the field holds. Nothing coerces a declared
 default — the resolver seeds it as written and hands it to the field — so `default = 1` on a

--- a/docs/spec/reference/config.md
+++ b/docs/spec/reference/config.md
@@ -96,7 +96,7 @@ files, so a setting a repository must not be able to change can say so.
 | `merge`                                      | `replace` (default), `union` for collections, `deep` for maps                                                |
 | `scope`                                      | `any` (default), `global` (never from a project file), `env` (never from a file)                             |
 | `deprecated`                                 | why not to use it any more                                                                                   |
-| `deprecated_warn_at`, `deprecated_remove_at` | versions, for a tool that warns then removes                                                                 |
+| `deprecated_warn_at`, `deprecated_remove_at` | CLI versions that start warnings and stop accepting configured values                                       |
 | `renamed_to`                                 | the property that replaces this one, so an old key folds into the new                                        |
 | `hide`                                       | keep it out of docs and completions                                                                          |
 | `since`                                      | the version that introduced it                                                                               |
@@ -117,6 +117,23 @@ And as child nodes, for anything multi-valued or long:
 | `example "…"`                     | one invocation worth showing                                   |
 | `choices { choice "a" help="…" }` | the values it accepts, each with its own help                  |
 | `x "ns.key" value`                | see [extensions](#extensions)                                  |
+
+### Deprecation gates
+
+`deprecated_warn_at` withholds a setting's deprecation warning until the running CLI version
+reaches that release. At `deprecated_remove_at`, configured values for the setting are ignored and
+reported as removed; resolution continues, as it does for an unknown setting, and a declared
+default remains available to the compiled settings type.
+
+The CLI version is runtime context, not the version of `usage-config`. Rust callers pass it
+explicitly with `resolve_with_context` and `ResolutionContext::for_cli_version`. The compatibility
+`resolve` entry point has no version context: it warns but keeps the value. An unreadable CLI
+version or milestone does the same, so uncertainty neither hides the deprecation nor silently
+changes configuration.
+
+Versions follow the same rule as [argv deprecations](/spec/argv#warnings): dotted numeric segments
+support semver and calver, missing segments are zero, prereleases precede their release, and build
+metadata is ignored.
 
 ## Types
 

--- a/docs/spec/reference/config.md
+++ b/docs/spec/reference/config.md
@@ -96,7 +96,7 @@ files, so a setting a repository must not be able to change can say so.
 | `merge`                                      | `replace` (default), `union` for collections, `deep` for maps                                                |
 | `scope`                                      | `any` (default), `global` (never from a project file), `env` (never from a file)                             |
 | `deprecated`                                 | why not to use it any more                                                                                   |
-| `deprecated_warn_at`, `deprecated_remove_at` | CLI versions that start warnings and stop accepting configured values                                       |
+| `deprecated_warn_at`, `deprecated_remove_at` | CLI versions that start warnings and stop accepting configured values                                        |
 | `renamed_to`                                 | the property that replaces this one, so an old key folds into the new                                        |
 | `hide`                                       | keep it out of docs and completions                                                                          |
 | `since`                                      | the version that introduced it                                                                               |

--- a/docs/spec/resolution.md
+++ b/docs/spec/resolution.md
@@ -158,11 +158,17 @@ program acts on:
 | `not-allowed`     | a value the declared choices do not allow          |
 | `out-of-scope`    | a place that may not set this setting              |
 | `deprecated`      | a setting whose spec says not to use it            |
+| `removed`         | a configured value ignored after its removal gate  |
 | `renamed`         | a value read as the setting that replaced its name |
 | `not-read`        | a value passed over because another name won       |
 
 An unknown key is a warning and never an error: a config file written for a newer
 binary must still work with an older one.
+
+Deprecation gates use the running CLI version supplied to resolution. Before
+`deprecated_warn_at` the value is accepted quietly; from that release it is accepted with
+a warning; from `deprecated_remove_at` it is ignored with a `removed` warning. A missing or
+unreadable version warns without removing, preserving the old no-context behavior.
 
 ## The conformance corpus
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- add explicit `ResolutionContext` and `resolve_with_context` APIs for supplying the running CLI version
- enforce `deprecated_warn_at` and `deprecated_remove_at` during layered resolution
- retain the existing `resolve` compatibility path without hidden package-version assumptions
- document lifecycle behavior and cover generated Config metadata through conformance tests

Before the warning milestone, configured values remain silent. At or after it they produce a deprecation warning. At or after removal, that contribution is ignored with a `Removed` warning and lower layers/defaults may supply the value. Missing or unreadable version context keeps the value and warns rather than silently removing it.

## Testing

- `cargo test -p usage-config --all-features` (166 tests + 2 doctests)
- `cargo test -p usage-conformance --test derive_config --test derive --test derive_settings --test derive_settings_env --test derive_settings_flatten`
- `cargo clippy -p usage-config --all-features -- -D warnings`
- `cargo fmt --all`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e77b5c4c-4ee6-4519-bc56-8430a6a90d17?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e77b5c4c-4ee6-4519-bc56-8430a6a90d17&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

