### PR TITLE
feat(config): close Config derive and spec authoring gaps

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -76,11 +76,11 @@ pub use explain::explain;
 #[cfg(any(feature = "toml", feature = "json", feature = "yaml"))]
 pub use files::{FileLayer, Format};
 pub use layer::{Entry, Layer, LayerCtx, LayerError, LayerOutput, Warning, WarningKind};
-pub use props::{concat_props, Props};
+pub use props::{concat_prop_specs, concat_props, Props};
 pub use read::{Fold, FromValue, ReadError, ReadErrorKind, ReadErrors};
 pub use registry::{Lookup, Merge, PropId, PropMeta, Registry, Scope};
 pub use resolve::{resolve, Layers, Resolved};
 pub use source::{FileScope, Origin, SourceKind, Trust};
-pub use spec::spec_kdl;
+pub use spec::{spec_kdl, spec_kdl_with, ConfigSpec, PropSpec, SpecFile, SpecSource};
 pub use ty::{Parser, Ty, TypeError};
 pub use value::{Const, Value};

--- a/config/src/props.rs
+++ b/config/src/props.rs
@@ -8,6 +8,7 @@
 
 use crate::read::Fold;
 use crate::registry::PropMeta;
+use crate::spec::PropSpec;
 
 /// A group of settings declared in code.
 ///
@@ -21,6 +22,9 @@ pub trait Props: Sized {
     /// parent's joined slice — which is why reading takes a `base`.
     const PROPS: &'static [PropMeta];
 
+    /// Spec-only metadata parallel to [`Props::PROPS`].
+    const PROP_SPECS: &'static [PropSpec];
+
     /// Read this group's fields from a fold, its props starting at `base`.
     ///
     /// `None` means a field could not be read and the fold has recorded why. Every field is
@@ -28,6 +32,29 @@ pub trait Props: Sized {
     /// checks [`Fold::finish`] before treating `None` as anything but "already reported".
     #[doc(hidden)]
     fn read_at(fold: &mut Fold<'_>, base: u16) -> Option<Self>;
+}
+
+/// Join flattened groups' spec metadata in the same order as their properties.
+pub const fn concat_prop_specs<const N: usize>(groups: &[&[PropSpec]]) -> [PropSpec; N] {
+    let mut out = [PropSpec::EMPTY; N];
+    let mut at = 0;
+    let mut g = 0;
+    while g < groups.len() {
+        let group = groups[g];
+        let mut i = 0;
+        while i < group.len() {
+            out[at] = group[i];
+            at += 1;
+            i += 1;
+        }
+        g += 1;
+    }
+    assert!(
+        at == N,
+        "`N` must be the summed length of the groups, or property spec metadata would not \
+         line up with its setting"
+    );
+    out
 }
 
 /// Join groups of prop metadata into one slice, at compile time.
@@ -215,5 +242,26 @@ mod tests {
         assert_eq!(JOINED[0].key, "jobs");
         assert_eq!(JOINED[1].key, "task.output");
         assert_eq!(JOINED[2].key, "task.jobs");
+    }
+
+    #[test]
+    fn spec_metadata_joins_in_the_same_order_as_props() {
+        static OWN: &[PropSpec] = &[PropSpec {
+            help_heading: Some("Performance"),
+            writes_to: None,
+            extensions: &[],
+        }];
+        static CHILD: &[PropSpec] = &[
+            PropSpec {
+                writes_to: Some("git"),
+                ..PropSpec::EMPTY
+            },
+            PropSpec::EMPTY,
+        ];
+        const N: usize = OWN.len() + CHILD.len();
+        static JOINED: [PropSpec; N] = concat_prop_specs(&[OWN, CHILD]);
+        assert_eq!(JOINED[0].help_heading, Some("Performance"));
+        assert_eq!(JOINED[1].writes_to, Some("git"));
+        assert_eq!(JOINED[2], PropSpec::EMPTY);
     }
 }

--- a/config/src/spec.rs
+++ b/config/src/spec.rs
@@ -10,23 +10,124 @@
 //! fixed one the spec parser defines.
 
 use crate::registry::{Merge, PropMeta, Scope};
+use crate::source::FileScope;
 use crate::value::Const;
 use std::fmt::Write;
+
+/// Documentation-only metadata for one property.
+///
+/// Kept beside, rather than in, [`PropMeta`]: resolution never interprets these fields. A
+/// derived [`crate::Props`] exposes a parallel slice in the same declaration order.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct PropSpec {
+    pub help_heading: Option<&'static str>,
+    pub writes_to: Option<&'static str>,
+    /// Tool-private metadata, emitted as `x "key" value` nodes.
+    pub extensions: &'static [(&'static str, Const)],
+}
+
+impl PropSpec {
+    pub const EMPTY: Self = Self {
+        help_heading: None,
+        writes_to: None,
+        extensions: &[],
+    };
+}
+
+/// A custom source declaration at the top of a spec's `config` block.
+#[derive(Debug, Copy, Clone)]
+pub struct SpecSource {
+    pub kind: &'static str,
+    pub name: Option<&'static str>,
+    pub doc_hint: Option<&'static str>,
+    pub set_hint: Option<&'static str>,
+}
+
+/// A config file declaration. Slice order is ascending precedence.
+#[derive(Debug, Copy, Clone)]
+pub struct SpecFile {
+    pub path: &'static str,
+    pub findup: bool,
+    pub scope: FileScope,
+    pub format: Option<&'static str>,
+}
+
+/// Spec-only declarations generated from a settings struct.
+#[derive(Debug, Copy, Clone)]
+pub struct ConfigSpec {
+    pub props: &'static [PropSpec],
+    pub sources: &'static [SpecSource],
+    pub files: &'static [SpecFile],
+}
+
+impl ConfigSpec {
+    pub const fn new(
+        props: &'static [PropSpec],
+        sources: &'static [SpecSource],
+        files: &'static [SpecFile],
+    ) -> Self {
+        Self {
+            props,
+            sources,
+            files,
+        }
+    }
+}
 
 /// The spec `config` block for these settings, as KDL.
 ///
 /// Ends with a newline, so it can be appended to an emitted spec as-is. Props are written in
 /// registry order, which for a derived registry is declaration order.
 pub fn spec_kdl(props: &[PropMeta]) -> String {
+    spec_kdl_with(props, ConfigSpec::new(&[], &[], &[]))
+}
+
+/// The complete spec `config` block, including metadata resolution does not use.
+pub fn spec_kdl_with(props: &[PropMeta], spec: ConfigSpec) -> String {
+    assert!(
+        spec.props.is_empty() || spec.props.len() == props.len(),
+        "property spec metadata must have one entry per property"
+    );
     let mut out = String::from("config {\n");
-    for meta in props {
-        let _ = write_prop(&mut out, meta);
+    // Source kinds are sorted by the derive; files deliberately retain author order because
+    // their order is precedence.
+    for source in spec.sources {
+        let _ = write!(out, "    source {}", quoted(source.kind));
+        if let Some(name) = source.name {
+            let _ = write!(out, " name={}", quoted(name));
+        }
+        if let Some(hint) = source.doc_hint {
+            let _ = write!(out, " doc_hint={}", quoted(hint));
+        }
+        if let Some(hint) = source.set_hint {
+            let _ = write!(out, " set_hint={}", quoted(hint));
+        }
+        out.push('\n');
+    }
+    for file in spec.files {
+        let _ = write!(out, "    file {}", quoted(file.path));
+        if file.findup {
+            out.push_str(" findup=#true");
+        }
+        match file.scope {
+            FileScope::Project => {}
+            FileScope::Global => out.push_str(" scope=\"global\""),
+            FileScope::System => out.push_str(" scope=\"system\""),
+        }
+        if let Some(format) = file.format {
+            let _ = write!(out, " format={}", quoted(format));
+        }
+        out.push('\n');
+    }
+    for (index, meta) in props.iter().enumerate() {
+        let prop_spec = spec.props.get(index).copied().unwrap_or(PropSpec::EMPTY);
+        let _ = write_prop(&mut out, meta, prop_spec);
     }
     out.push_str("}\n");
     out
 }
 
-fn write_prop(out: &mut String, meta: &PropMeta) -> std::fmt::Result {
+fn write_prop(out: &mut String, meta: &PropMeta, spec: PropSpec) -> std::fmt::Result {
     write!(
         out,
         "    prop {} type={}",
@@ -78,6 +179,12 @@ fn write_prop(out: &mut String, meta: &PropMeta) -> std::fmt::Result {
     }
     if let Some(long_help) = meta.long_help {
         write!(out, " long_help={}", quoted(long_help))?;
+    }
+    if let Some(heading) = spec.help_heading {
+        write!(out, " help_heading={}", quoted(heading))?;
+    }
+    if let Some(writes_to) = spec.writes_to {
+        write!(out, " writes_to={}", quoted(writes_to))?;
     }
 
     let mut children = Vec::new();
@@ -135,6 +242,9 @@ fn write_prop(out: &mut String, meta: &PropMeta) -> std::fmt::Result {
         }
         block.push_str("        }");
         children.push(block);
+    }
+    for (key, value) in spec.extensions {
+        children.push(format!("x {} {}", quoted(key), const_kdl(*value)));
     }
 
     if children.is_empty() {
@@ -335,6 +445,67 @@ mod tests {
 
     /// A prop whose only choices are shapes the grammar cannot spell gets no `choices` block at
     /// all, rather than one holding a node with no argument.
+    #[test]
+    fn spec_only_metadata_is_written_without_changing_property_order() {
+        static PROPS: &[PropMeta] = &[
+            PropMeta::new("jobs", Ty::Uint),
+            PropMeta::new("exclude", Ty::List(&Ty::String)),
+        ];
+        static PROP_SPECS: &[PropSpec] = &[
+            PropSpec {
+                help_heading: Some("Performance"),
+                writes_to: Some("git"),
+                extensions: &[("ex.restart_required", Const::Bool(true))],
+            },
+            PropSpec::EMPTY,
+        ];
+        let spec = ConfigSpec::new(
+            PROP_SPECS,
+            &[
+                SpecSource {
+                    kind: "git",
+                    name: Some("git config"),
+                    doc_hint: Some("git config `{key}`"),
+                    set_hint: None,
+                },
+                SpecSource {
+                    kind: "npmrc",
+                    name: Some(".npmrc"),
+                    doc_hint: None,
+                    set_hint: None,
+                },
+            ],
+            &[
+                SpecFile {
+                    path: "/etc/ex.toml",
+                    findup: false,
+                    scope: FileScope::System,
+                    format: Some("toml"),
+                },
+                SpecFile {
+                    path: "ex.toml",
+                    findup: true,
+                    scope: FileScope::Project,
+                    format: None,
+                },
+            ],
+        );
+        assert_eq!(
+            spec_kdl_with(PROPS, spec),
+            r#"config {
+    source "git" name="git config" doc_hint="git config `{key}`"
+    source "npmrc" name=".npmrc"
+    file "/etc/ex.toml" scope="system" format="toml"
+    file "ex.toml" findup=#true
+    prop "jobs" type="uint" help_heading="Performance" writes_to="git" {
+        x "ex.restart_required" #true
+    }
+    prop "exclude" type="list<string>"
+}
+"#
+        );
+    }
+
     #[test]
     fn choices_no_single_value_can_hold_leave_no_block_behind() {
         static PROPS: &[PropMeta] = &[PropMeta {

--- a/conformance/tests/derive_config.rs
+++ b/conformance/tests/derive_config.rs
@@ -267,7 +267,7 @@ fn the_emitted_config_block_is_the_spec_grammar() {
             ),
             (
                 "ex.restart_required".to_string(),
-                usage::spec::config::SpecConfigValue::Boolean(true)
+                usage::spec::config::SpecConfigValue::Bool(true)
             ),
         ]
     );
@@ -280,10 +280,7 @@ fn the_emitted_config_block_is_the_spec_grammar() {
     let git = spec.config.sources.get("git").expect("declared");
     assert_eq!(git.name.as_deref(), Some("git config"));
     assert_eq!(git.doc_hint.as_deref(), Some("git config `{key}`"));
-    assert_eq!(
-        git.set_hint.as_deref(),
-        Some("git config {key} {value}")
-    );
+    assert_eq!(git.set_hint.as_deref(), Some("git config {key} {value}"));
     assert_eq!(
         spec.config
             .files

--- a/conformance/tests/derive_config.rs
+++ b/conformance/tests/derive_config.rs
@@ -20,6 +20,7 @@ fn default_cache_dir() -> PathBuf {
 /// The `task.*` settings, as their own group.
 #[derive(Config, Debug, PartialEq)]
 #[usage(prefix = "task")]
+#[usage(file(path = "task.toml", findup))]
 struct TaskSettings {
     /// How task output is interleaved
     #[usage(default = "prefix", choices("prefix", "interleave"), alias("task.out"))]
@@ -32,6 +33,15 @@ struct TaskSettings {
 
 /// Every setting ex has — one of everything the derive carries.
 #[derive(Config, Debug, PartialEq)]
+#[usage(source(kind = "npmrc", name = ".npmrc"))]
+#[usage(source(
+    kind = "git",
+    name = "git config",
+    doc_hint = "git config `{key}`",
+    set_hint = "git config {key} {value}"
+))]
+#[usage(file(path = "/etc/ex.toml", scope = "system", format = "toml"))]
+#[usage(file(path = "ex.toml", findup))]
 struct Settings {
     /// How many jobs to run at once
     #[usage(
@@ -39,7 +49,11 @@ struct Settings {
         deprecated_env = "EX_JOBS_OLD",
         default = 4,
         cli("--jobs", "-j"),
-        source("git", "ex.jobs")
+        source("git", "ex.jobs"),
+        help_heading = "Performance",
+        writes_to = "git",
+        x("ex.rust_type", "u64"),
+        x("ex.restart_required", true)
     )]
     jobs: u64,
 
@@ -118,6 +132,18 @@ fn the_registry_is_the_struct_in_declaration_order() {
     assert_eq!(jobs.cli, &["--jobs", "-j"]);
     assert_eq!(jobs.bindings, &[("git", "ex.jobs")]);
     assert_eq!(jobs.help, Some("How many jobs to run at once"));
+    assert_eq!(
+        Settings::SETTINGS_SPEC.props[0].help_heading,
+        Some("Performance")
+    );
+    assert_eq!(Settings::SETTINGS_SPEC.props[0].writes_to, Some("git"));
+    assert_eq!(
+        Settings::SETTINGS_SPEC.props[0].extensions,
+        &[
+            ("ex.rust_type", Const::Str("u64")),
+            ("ex.restart_required", Const::Bool(true))
+        ]
+    );
 
     let cache_dir = &Settings::SETTINGS_PROPS[2];
     assert_eq!(cache_dir.ty, Ty::Path);
@@ -230,6 +256,52 @@ fn the_emitted_config_block_is_the_spec_grammar() {
         jobs.default
     );
     assert_eq!(jobs.help.as_deref(), Some("How many jobs to run at once"));
+    assert_eq!(jobs.help_heading.as_deref(), Some("Performance"));
+    assert_eq!(jobs.writes_to.as_deref(), Some("git"));
+    assert_eq!(
+        jobs.extensions,
+        vec![
+            (
+                "ex.rust_type".to_string(),
+                usage::spec::config::SpecConfigValue::String("u64".to_string())
+            ),
+            (
+                "ex.restart_required".to_string(),
+                usage::spec::config::SpecConfigValue::Boolean(true)
+            ),
+        ]
+    );
+
+    assert_eq!(
+        spec.config.sources.keys().collect::<Vec<_>>(),
+        vec![&"git".to_string(), &"npmrc".to_string()],
+        "source declarations have deterministic key order"
+    );
+    let git = spec.config.sources.get("git").expect("declared");
+    assert_eq!(git.name.as_deref(), Some("git config"));
+    assert_eq!(git.doc_hint.as_deref(), Some("git config `{key}`"));
+    assert_eq!(
+        git.set_hint.as_deref(),
+        Some("git config {key} {value}")
+    );
+    assert_eq!(
+        spec.config
+            .files
+            .iter()
+            .map(|file| file.path.as_str())
+            .collect::<Vec<_>>(),
+        vec!["/etc/ex.toml", "ex.toml"],
+        "file declaration order is precedence"
+    );
+    assert!(spec.config.files[1].findup);
+    assert!(
+        !spec
+            .config
+            .files
+            .iter()
+            .any(|file| file.path == "task.toml"),
+        "a flattened group's top-level files belong to its standalone spec, not its parent"
+    );
 
     let output = spec.config.props.get("task.output").expect("declared");
     assert_eq!(output.choices.len(), 2);
@@ -240,6 +312,13 @@ fn the_emitted_config_block_is_the_spec_grammar() {
         Some("under the user cache directory")
     );
     assert_eq!(cache_dir.optional, Some(true));
+}
+
+#[test]
+fn a_nested_config_keeps_its_own_top_level_declarations_when_emitted_alone() {
+    let kdl = format!("name \"task\"\nbin \"task\"\n{}", TaskSettings::spec_kdl());
+    let spec: usage::Spec = kdl.parse().expect("nested declaration parses alone");
+    assert_eq!(spec.config.files[0].path, "task.toml");
 }
 
 #[test]
@@ -424,6 +503,14 @@ fn the_clis_spec_carries_its_settings() {
     assert!(
         spec.config.props.contains_key("task.output"),
         "the config block rides in the emitted spec: {kdl}"
+    );
+    assert!(
+        spec.config.sources.contains_key("git"),
+        "struct-level source declarations ride with the CLI spec: {kdl}"
+    );
+    assert_eq!(
+        spec.config.files.last().map(|file| file.path.as_str()),
+        Some("ex.toml")
     );
 }
 

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -270,7 +270,10 @@ pub fn emit(cli: &Cli) -> TokenStream {
     // appends to the same string — a root can have both.
     let config_extra = match &cli.config {
         Some(ty) => quote! {
-            __usage_kdl.push_str(&#config::spec_kdl(<#ty>::SETTINGS_PROPS));
+            __usage_kdl.push_str(&#config::spec_kdl_with(
+                <#ty>::SETTINGS_PROPS,
+                <#ty>::SETTINGS_SPEC,
+            ));
         },
         None => TokenStream::new(),
     };

--- a/derive/src/config.rs
+++ b/derive/src/config.rs
@@ -460,14 +460,16 @@ fn source_decl(meta: &Meta) -> syn::Result<Source> {
         if slot.is_some() {
             return Err(syn::Error::new_spanned(
                 &item,
-                format!("`{}` is given twice in this config source", ident_of(item.path())),
+                format!(
+                    "`{}` is given twice in this config source",
+                    ident_of(item.path())
+                ),
             ));
         }
         *slot = Some(string_value(&item)?);
     }
-    let kind = kind.ok_or_else(|| {
-        syn::Error::new_spanned(meta, "a config source needs `kind = \"...\"`")
-    })?;
+    let kind = kind
+        .ok_or_else(|| syn::Error::new_spanned(meta, "a config source needs `kind = \"...\"`"))?;
     if kind.is_empty() {
         return Err(syn::Error::new_spanned(
             meta,
@@ -1257,8 +1259,7 @@ fn extension(meta: &Meta) -> syn::Result<(String, Const)> {
     let mut values = values.into_iter();
     let key_expr = values.next().expect("length checked");
     let Expr::Lit(ExprLit {
-        lit: Lit::Str(key),
-        ..
+        lit: Lit::Str(key), ..
     }) = key_expr
     else {
         return Err(syn::Error::new_spanned(
@@ -2370,10 +2371,7 @@ mod tests {
             }
         "#,
         );
-        assert!(
-            err.contains("source(kind ="),
-            "unhelpful: {err}"
-        );
+        assert!(err.contains("source(kind ="), "unhelpful: {err}");
 
         let err = rejection(
             r#"
@@ -2393,10 +2391,7 @@ mod tests {
             }
         "#,
         );
-        assert!(
-            err.contains("not a config file scope"),
-            "unhelpful: {err}"
-        );
+        assert!(err.contains("not a config file scope"), "unhelpful: {err}");
 
         let err = rejection(
             r#"

--- a/derive/src/config.rs
+++ b/derive/src/config.rs
@@ -84,6 +84,29 @@ pub(crate) fn config_path() -> TokenStream {
 pub struct Config {
     ident: syn::Ident,
     fields: Vec<Field>,
+    sources: Vec<Source>,
+    files: Vec<File>,
+}
+
+struct Source {
+    kind: String,
+    name: Option<String>,
+    doc_hint: Option<String>,
+    set_hint: Option<String>,
+}
+
+struct File {
+    path: String,
+    findup: bool,
+    scope: FileScope,
+    format: Option<String>,
+}
+
+#[derive(Clone, Copy)]
+enum FileScope {
+    Project,
+    Global,
+    System,
 }
 
 enum Field {
@@ -125,6 +148,9 @@ struct Prop {
     examples: Vec<String>,
     help: Option<String>,
     long_help: Option<String>,
+    help_heading: Option<String>,
+    writes_to: Option<String>,
+    extensions: Vec<(String, Const)>,
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -298,10 +324,14 @@ impl Config {
         }
 
         let mut prefix = None;
+        let mut sources = Vec::new();
+        let mut files = Vec::new();
         for attr in attrs(&input.attrs) {
             for meta in nested(attr)? {
                 match ident_of(meta.path()).as_str() {
                     "prefix" => prefix = Some(string_value(&meta)?),
+                    "source" => sources.push(source_decl(&meta)?),
+                    "file" => files.push(file_decl(&meta)?),
                     other => {
                         return Err(syn::Error::new_spanned(
                             meta.path(),
@@ -309,6 +339,19 @@ impl Config {
                         ));
                     }
                 }
+            }
+        }
+        sources.sort_by(|a, b| a.kind.cmp(&b.kind));
+        for pair in sources.windows(2) {
+            if pair[0].kind == pair[1].kind {
+                return Err(syn::Error::new_spanned(
+                    &input.ident,
+                    format!(
+                        "config source `{}` is declared more than once; combine its metadata \
+                         into one `source(...)`",
+                        pair[0].kind
+                    ),
+                ));
             }
         }
 
@@ -372,8 +415,153 @@ impl Config {
         Ok(Self {
             ident: input.ident.clone(),
             fields,
+            sources,
+            files,
         })
     }
+}
+
+fn nested_meta(meta: &Meta) -> syn::Result<Vec<Meta>> {
+    let Meta::List(list) = meta else {
+        return Ok(Vec::new());
+    };
+    let parsed = list
+        .parse_args_with(syn::punctuated::Punctuated::<Meta, syn::Token![,]>::parse_terminated)?;
+    Ok(parsed.into_iter().collect())
+}
+
+fn source_decl(meta: &Meta) -> syn::Result<Source> {
+    let Meta::List(_) = meta else {
+        return Err(syn::Error::new_spanned(
+            meta,
+            "a config source is `source(kind = \"git\", name = \"git config\", ...)`",
+        ));
+    };
+    let mut kind = None;
+    let mut name = None;
+    let mut doc_hint = None;
+    let mut set_hint = None;
+    for item in nested_meta(meta)? {
+        let slot = match ident_of(item.path()).as_str() {
+            "kind" => &mut kind,
+            "name" => &mut name,
+            "doc_hint" => &mut doc_hint,
+            "set_hint" => &mut set_hint,
+            other => {
+                return Err(syn::Error::new_spanned(
+                    item.path(),
+                    format!(
+                        "a config source does not understand `{other}`; use `kind`, `name`, \
+                         `doc_hint`, or `set_hint`"
+                    ),
+                ))
+            }
+        };
+        if slot.is_some() {
+            return Err(syn::Error::new_spanned(
+                &item,
+                format!("`{}` is given twice in this config source", ident_of(item.path())),
+            ));
+        }
+        *slot = Some(string_value(&item)?);
+    }
+    let kind = kind.ok_or_else(|| {
+        syn::Error::new_spanned(meta, "a config source needs `kind = \"...\"`")
+    })?;
+    if kind.is_empty() {
+        return Err(syn::Error::new_spanned(
+            meta,
+            "a config source kind cannot be empty",
+        ));
+    }
+    Ok(Source {
+        kind,
+        name,
+        doc_hint,
+        set_hint,
+    })
+}
+
+fn file_decl(meta: &Meta) -> syn::Result<File> {
+    let Meta::List(_) = meta else {
+        return Err(syn::Error::new_spanned(
+            meta,
+            "a config file is `file(path = \"ex.toml\", findup, scope = \"project\")`",
+        ));
+    };
+    let mut path = None;
+    let mut findup = false;
+    let mut saw_findup = false;
+    let mut scope = FileScope::Project;
+    let mut saw_scope = false;
+    let mut format = None;
+    for item in nested_meta(meta)? {
+        match ident_of(item.path()).as_str() {
+            "path" => {
+                if path.is_some() {
+                    return Err(syn::Error::new_spanned(&item, "`path` is given twice"));
+                }
+                path = Some(string_value(&item)?);
+            }
+            "findup" => {
+                if saw_findup {
+                    return Err(syn::Error::new_spanned(&item, "`findup` is given twice"));
+                }
+                findup = flag_value(&item)?;
+                saw_findup = true;
+            }
+            "scope" => {
+                if saw_scope {
+                    return Err(syn::Error::new_spanned(&item, "`scope` is given twice"));
+                }
+                let value = string_value(&item)?;
+                scope = match value.as_str() {
+                    "project" => FileScope::Project,
+                    "global" => FileScope::Global,
+                    "system" => FileScope::System,
+                    _ => {
+                        return Err(syn::Error::new_spanned(
+                            &item,
+                            format!(
+                                "`{value}` is not a config file scope; use `project`, `global`, \
+                                 or `system`"
+                            ),
+                        ))
+                    }
+                };
+                saw_scope = true;
+            }
+            "format" => {
+                if format.is_some() {
+                    return Err(syn::Error::new_spanned(&item, "`format` is given twice"));
+                }
+                format = Some(string_value(&item)?);
+            }
+            other => {
+                return Err(syn::Error::new_spanned(
+                    item.path(),
+                    format!(
+                        "a config file does not understand `{other}`; use `path`, `findup`, \
+                         `scope`, or `format`"
+                    ),
+                ))
+            }
+        }
+    }
+    let path =
+        path.ok_or_else(|| syn::Error::new_spanned(meta, "a config file needs `path = \"...\"`"))?;
+    if path.is_empty() {
+        return Err(syn::Error::new_spanned(
+            meta,
+            "a config file path cannot be empty",
+        ));
+    }
+    Ok(File {
+        path,
+        findup,
+        scope,
+        format,
+    })
 }
 
 impl Field {
@@ -410,6 +598,9 @@ impl Field {
             examples: Vec::new(),
             help: None,
             long_help: None,
+            help_heading: None,
+            writes_to: None,
+            extensions: Vec::new(),
         };
         (prop.help, prop.long_help) = doc_comment(&field.attrs, false)?;
 
@@ -425,6 +616,7 @@ impl Field {
                     "cli" => prop.cli.extend(strings(&meta)?),
                     "alias" | "aliases" => prop.aliases.extend(strings(&meta)?),
                     "example" | "examples" => prop.examples.extend(strings(&meta)?),
+                    "x" | "extension" => prop.extensions.push(extension(&meta)?),
                     "source" => {
                         let mut words = strings(&meta)?;
                         if words.len() < 2 {
@@ -500,6 +692,8 @@ impl Field {
                     "since" => prop.since = Some(string_value(&meta)?),
                     "help" => prop.help = Some(string_value(&meta)?),
                     "long_help" => prop.long_help = Some(string_value(&meta)?),
+                    "help_heading" => prop.help_heading = Some(string_value(&meta)?),
+                    "writes_to" => prop.writes_to = Some(string_value(&meta)?),
                     other => {
                         return Err(syn::Error::new_spanned(
                             meta.path(),
@@ -535,6 +729,9 @@ impl Field {
                 (prop.deprecated_warn_at.is_some(), "deprecated_warn_at"),
                 (prop.deprecated_remove_at.is_some(), "deprecated_remove_at"),
                 (prop.since.is_some(), "since"),
+                (prop.help_heading.is_some(), "help_heading"),
+                (prop.writes_to.is_some(), "writes_to"),
+                (!prop.extensions.is_empty(), "x"),
             ];
             if let Some((_, what)) = described.iter().find(|(given, _)| *given) {
                 return Err(syn::Error::new(
@@ -1040,6 +1237,52 @@ fn consts(meta: &Meta) -> syn::Result<Vec<Const>> {
     parsed.into_iter().map(|expr| const_expr(&expr)).collect()
 }
 
+/// `x("mise.rust_type", "Duration")`: one tool-private key and one scalar value.
+fn extension(meta: &Meta) -> syn::Result<(String, Const)> {
+    let Meta::List(list) = meta else {
+        return Err(syn::Error::new_spanned(
+            meta,
+            "an extension is `x(\"tool.key\", value)`",
+        ));
+    };
+    let values = list
+        .parse_args_with(syn::punctuated::Punctuated::<Expr, syn::Token![,]>::parse_terminated)?;
+    if values.len() != 2 {
+        return Err(syn::Error::new_spanned(
+            meta,
+            "an extension takes exactly a string key and one scalar value, as in \
+             `x(\"tool.key\", \"value\")`",
+        ));
+    }
+    let mut values = values.into_iter();
+    let key_expr = values.next().expect("length checked");
+    let Expr::Lit(ExprLit {
+        lit: Lit::Str(key),
+        ..
+    }) = key_expr
+    else {
+        return Err(syn::Error::new_spanned(
+            key_expr,
+            "an extension key must be a string",
+        ));
+    };
+    if key.value().is_empty() {
+        return Err(syn::Error::new_spanned(
+            key,
+            "an extension key cannot be empty",
+        ));
+    }
+    let value_expr = values.next().expect("length checked");
+    let value = const_expr(&value_expr)?;
+    if matches!(value, Const::List(_)) {
+        return Err(syn::Error::new_spanned(
+            value_expr,
+            "an extension value is one scalar, not a list",
+        ));
+    }
+    Ok((key.value(), value))
+}
+
 fn const_expr(expr: &Expr) -> syn::Result<Const> {
     match expr {
         Expr::Lit(ExprLit { lit, .. }) => const_lit(lit, false),
@@ -1095,6 +1338,14 @@ pub fn emit(config: &Config) -> TokenStream {
             Field::Flatten { .. } => None,
         })
         .collect();
+    let prop_specs: Vec<TokenStream> = config
+        .fields
+        .iter()
+        .filter_map(|field| match field {
+            Field::Prop(prop) => Some(prop_spec(prop, &cfg)),
+            Field::Flatten { .. } => None,
+        })
+        .collect();
 
     let has_flatten = config
         .fields
@@ -1117,8 +1368,20 @@ pub fn emit(config: &Config) -> TokenStream {
                 Field::Flatten { ty, .. } => quote!(<#ty as #cfg::Props>::PROPS),
             })
             .collect();
+        let spec_parts: Vec<TokenStream> = config
+            .fields
+            .iter()
+            .map(|field| match field {
+                Field::Prop(prop) => {
+                    let spec = prop_spec(prop, &cfg);
+                    quote!(&[#spec])
+                }
+                Field::Flatten { ty, .. } => quote!(<#ty as #cfg::Props>::PROP_SPECS),
+            })
+            .collect();
         quote! {
             const __USAGE_PARTS: &[&[#cfg::PropMeta]] = &[#(#parts),*];
+            const __USAGE_SPEC_PARTS: &[&[#cfg::PropSpec]] = &[#(#spec_parts),*];
             const __USAGE_LEN: usize = {
                 let mut total = 0;
                 let mut i = 0;
@@ -1130,12 +1393,44 @@ pub fn emit(config: &Config) -> TokenStream {
             };
             static __USAGE_PROPS: [#cfg::PropMeta; __USAGE_LEN] =
                 #cfg::concat_props(__USAGE_PARTS);
+            static __USAGE_PROP_SPECS: [#cfg::PropSpec; __USAGE_LEN] =
+                #cfg::concat_prop_specs(__USAGE_SPEC_PARTS);
         }
     } else {
         quote! {
             static __USAGE_PROPS: [#cfg::PropMeta; #metas_len] = [#(#metas),*];
+            static __USAGE_PROP_SPECS: [#cfg::PropSpec; #metas_len] = [#(#prop_specs),*];
         }
     };
+
+    let sources = config.sources.iter().map(|source| {
+        let kind = &source.kind;
+        let name = option_str(&source.name);
+        let doc_hint = option_str(&source.doc_hint);
+        let set_hint = option_str(&source.set_hint);
+        quote!(#cfg::SpecSource {
+            kind: #kind,
+            name: #name,
+            doc_hint: #doc_hint,
+            set_hint: #set_hint,
+        })
+    });
+    let files = config.files.iter().map(|file| {
+        let path = &file.path;
+        let findup = file.findup;
+        let scope = match file.scope {
+            FileScope::Project => quote!(#cfg::FileScope::Project),
+            FileScope::Global => quote!(#cfg::FileScope::Global),
+            FileScope::System => quote!(#cfg::FileScope::System),
+        };
+        let format = option_str(&file.format);
+        quote!(#cfg::SpecFile {
+            path: #path,
+            findup: #findup,
+            scope: #scope,
+            format: #format,
+        })
+    });
 
     // Reads in declaration order, advancing a cursor: one id per own prop, a group's length
     // for a flattened child. Everything is read before anything is judged, so the fold holds
@@ -1197,6 +1492,7 @@ pub fn emit(config: &Config) -> TokenStream {
 
             impl #cfg::Props for #ident {
                 const PROPS: &'static [#cfg::PropMeta] = &__USAGE_PROPS;
+                const PROP_SPECS: &'static [#cfg::PropSpec] = &__USAGE_PROP_SPECS;
 
                 fn read_at(
                     __usage_fold: &mut #cfg::Fold<'_>,
@@ -1222,6 +1518,13 @@ pub fn emit(config: &Config) -> TokenStream {
                 /// the layers.
                 pub const SETTINGS_REGISTRY: #cfg::Registry =
                     #cfg::Registry::new(Self::SETTINGS_PROPS);
+
+                /// Metadata used only when lowering this declaration into a usage spec.
+                pub const SETTINGS_SPEC: #cfg::ConfigSpec = #cfg::ConfigSpec::new(
+                    <Self as #cfg::Props>::PROP_SPECS,
+                    &[#(#sources),*],
+                    &[#(#files),*],
+                );
 
                 /// This resolution's values, as the struct.
                 ///
@@ -1267,7 +1570,7 @@ pub fn emit(config: &Config) -> TokenStream {
                 /// `usage::Cli` names this type in `#[usage(config = ...)]` instead of
                 /// calling this, and its `to_kdl` carries the block.
                 pub fn spec_kdl() -> ::std::string::String {
-                    #cfg::spec_kdl(Self::SETTINGS_PROPS)
+                    #cfg::spec_kdl_with(Self::SETTINGS_PROPS, Self::SETTINGS_SPEC)
                 }
             }
         };
@@ -1279,6 +1582,29 @@ fn read_local(ident: &syn::Ident) -> syn::Ident {
     let name = ident.to_string();
     let name = name.strip_prefix("r#").unwrap_or(&name);
     format_ident!("__usage_read_{name}")
+}
+
+fn option_str(value: &Option<String>) -> TokenStream {
+    match value {
+        Some(value) => quote!(::std::option::Option::Some(#value)),
+        None => quote!(::std::option::Option::None),
+    }
+}
+
+fn prop_spec(prop: &Prop, cfg: &TokenStream) -> TokenStream {
+    let help_heading = option_str(&prop.help_heading);
+    let writes_to = option_str(&prop.writes_to);
+    let extensions = prop.extensions.iter().map(|(key, value)| {
+        let value = value.tokens(cfg);
+        quote!((#key, #value))
+    });
+    quote! {
+        #cfg::PropSpec {
+            help_heading: #help_heading,
+            writes_to: #writes_to,
+            extensions: &[#(#extensions),*],
+        }
+    }
 }
 
 /// One prop as registry metadata, in struct-update form over `PropMeta::new`.
@@ -1962,6 +2288,9 @@ mod tests {
             r#"deprecated_warn_at = "6.0.0""#,
             r#"deprecated_remove_at = "7.0.0""#,
             r#"since = "5.2.0""#,
+            r#"help_heading = "Performance""#,
+            r#"writes_to = "git""#,
+            r#"x("tool.key", true)"#,
         ] {
             let err = rejection(&format!(
                 r#"
@@ -1987,6 +2316,99 @@ mod tests {
                 task: TaskSettings,
             }
         "#,
+        );
+    }
+
+    #[test]
+    fn spec_only_field_metadata_is_accepted() {
+        accepted(
+            r#"
+            struct Settings {
+                #[usage(
+                    help_heading = "Performance",
+                    writes_to = "git",
+                    x("ex.rust_type", "u64"),
+                    x("ex.restart_required", true)
+                )]
+                jobs: u64,
+            }
+        "#,
+        );
+    }
+
+    #[test]
+    fn a_config_source_and_file_are_struct_declarations() {
+        accepted(
+            r#"
+            #[usage(source(kind = "git", name = "git config"))]
+            #[usage(file(path = "ex.toml", findup, scope = "project"))]
+            struct Settings {
+                jobs: u64,
+            }
+        "#,
+        );
+
+        let err = rejection(
+            r#"
+            #[usage(source(kind = "git"))]
+            #[usage(source(kind = "git", name = "git"))]
+            struct Settings {
+                jobs: u64,
+            }
+        "#,
+        );
+        assert!(
+            err.contains("source `git` is declared more than once"),
+            "unhelpful: {err}"
+        );
+
+        let err = rejection(
+            r#"
+            #[usage(source = "git")]
+            struct Settings {
+                jobs: u64,
+            }
+        "#,
+        );
+        assert!(
+            err.contains("source(kind ="),
+            "unhelpful: {err}"
+        );
+
+        let err = rejection(
+            r#"
+            #[usage(file(findup))]
+            struct Settings {
+                jobs: u64,
+            }
+        "#,
+        );
+        assert!(err.contains("needs `path"), "unhelpful: {err}");
+
+        let err = rejection(
+            r#"
+            #[usage(file(path = "ex.toml", scope = "trusted"))]
+            struct Settings {
+                jobs: u64,
+            }
+        "#,
+        );
+        assert!(
+            err.contains("not a config file scope"),
+            "unhelpful: {err}"
+        );
+
+        let err = rejection(
+            r#"
+            struct Settings {
+                #[usage(x("key"))]
+                jobs: u64,
+            }
+        "#,
+        );
+        assert!(
+            err.contains("exactly a string key and one scalar value"),
+            "unhelpful: {err}"
         );
     }
 }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -473,10 +473,10 @@ pub fn derive_subcommands(input: TokenStream) -> TokenStream {
 /// The struct the CLI already holds its settings in becomes the declaration: field types are
 /// the settings' types, doc comments are their help, and `#[usage(...)]` carries what a spec's
 /// `prop` node would — `env`, `default`, `merge`, `scope`, `choices`, `source` bindings.
-/// The derive generates `SETTINGS_PROPS`, `SETTINGS_REGISTRY`, `read(&Resolved)`, and
-/// `spec_kdl()`, so the registry, the reader, and the documentation cannot drift from the
-/// struct or from each other. The whole field vocabulary is in the guide:
-/// <https://usage.jdx.dev/rust/settings>.
+/// The derive generates `SETTINGS_PROPS`, `SETTINGS_REGISTRY`, `SETTINGS_SPEC`,
+/// `read(&Resolved)`, and `spec_kdl()`, so the registry, the reader, and the documentation
+/// cannot drift from the struct or from each other. The whole field vocabulary is in the
+/// guide: <https://usage.jdx.dev/rust/settings>.
 ///
 /// ```ignore
 /// #[derive(usage::Config)]

--- a/docs/rust/settings.md
+++ b/docs/rust/settings.md
@@ -60,6 +60,20 @@ with `ty = "…"` — a `String` field with `ty = "duration"` holds a span of ti
 which is how the fleet's registries store one. Doc comments become `help` and `long_help`,
 exactly as they do for flags.
 
+Struct-level attributes declare the `config` block around those settings. They are
+documentation for resolvers the CLI already owns, not extra runtime layers:
+
+| Attribute | Effect |
+| --------- | ------ |
+| `prefix = "task"` | Prefix every field's key in this struct |
+| `source(kind = "git", name = "git config", doc_hint = "…", set_hint = "…")` | A custom source kind's display metadata. Repeatable; kinds are written in sorted order |
+| `file(path = "ex.toml", findup, scope = "project", format = "toml")` | A config file in the documented precedence chain. Repeatable; **declaration order is precedence**, last wins |
+
+`source` and `file` belong to the struct they are written on. Flattening another `Config`
+type splices its *settings*, not its source/file declarations — a nested group that also
+documents `task.toml` still does so when emitted on its own, and does not rewrite the parent
+CLI's file chain.
+
 Field attributes mirror the spec's [`prop` vocabulary](/spec/reference/config):
 
 | Attribute                                                | Effect                                                                                                              |
@@ -78,7 +92,15 @@ Field attributes mirror the spec's [`prop` vocabulary](/spec/reference/config):
 | `alias("other")`                                         | Equivalent keys accepted without a warning — written in full, so a group's `prefix` is repeated rather than implied |
 | `key = "match"`                                          | The dotted key, when the field name is not it                                                                       |
 | `hide`, `deprecated = "…"`, `since = "…"`, `examples(…)` | Documentation and lifecycle metadata                                                                                |
+| `help_heading = "Performance"`                           | The section to list this setting under in generated docs                                                            |
+| `writes_to = "git"`                                      | Where `config set` should write this, when it is not the usual file                                                 |
+| `x("tool.key", value)`                                   | Tool-private `x` metadata. Spec-only: resolution does not interpret it. Repeatable; order is preserved              |
 | `flatten`                                                | Splice another `Config` struct's settings in at this position                                                       |
+
+`help_heading`, `writes_to`, and `x` are spec metadata. They ride in `SETTINGS_SPEC` beside
+the runtime registry rather than on `PropMeta`, because the merge never reads them. The
+emitted `config` block still carries them, so docs and round-trips match a KDL authoring of
+the same CLI.
 
 `ty` renames what the spec calls a setting; it cannot change what the field holds. The merge
 coerces to the _declared_ type, so that is what decides the shape the field is handed — a
@@ -184,9 +206,22 @@ assert_eq!(Settings::SETTINGS_REGISTRY.drift(Ex::SETTINGS_BINDINGS), Vec::<Strin
 ## The spec block
 
 The struct is the only declaration. `Settings::spec_kdl()` renders it as the spec's
-`config { prop … }` block, and `#[usage(config = Settings)]` on the `Cli` root puts that
-block in the emitted spec — so docs, the JSON schema, and the `config_keys` / `config_values`
-completers read settings declared in Rust exactly as they read ones written in KDL.
+`config { source …; file …; prop … }` block, and `#[usage(config = Settings)]` on the `Cli`
+root puts that block in the emitted spec — so docs, the JSON schema, and the `config_keys` /
+`config_values` completers read settings declared in Rust exactly as they read ones written
+in KDL.
+
+```rust
+#[derive(usage::Config)]
+#[usage(source(kind = "git", name = "git config", doc_hint = "git config `{key}`"))]
+#[usage(file(path = "/etc/ex.toml", scope = "system"))]
+#[usage(file(path = "ex.toml", findup))]
+struct Settings {
+    #[usage(env = "EX_JOBS", default = 4, help_heading = "Performance", writes_to = "git",
+            x("ex.restart_required", true))]
+    jobs: u64,
+}
+```
 
 There is no second, KDL-first backend to choose between: a `build.rs` that generated the
 registry from the spec was a third description of every setting, which is the drift this

--- a/docs/rust/settings.md
+++ b/docs/rust/settings.md
@@ -63,14 +63,14 @@ exactly as they do for flags.
 Struct-level attributes declare the `config` block around those settings. They are
 documentation for resolvers the CLI already owns, not extra runtime layers:
 
-| Attribute | Effect |
-| --------- | ------ |
-| `prefix = "task"` | Prefix every field's key in this struct |
-| `source(kind = "git", name = "git config", doc_hint = "…", set_hint = "…")` | A custom source kind's display metadata. Repeatable; kinds are written in sorted order |
-| `file(path = "ex.toml", findup, scope = "project", format = "toml")` | A config file in the documented precedence chain. Repeatable; **declaration order is precedence**, last wins |
+| Attribute                                                                   | Effect                                                                                                       |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `prefix = "task"`                                                           | Prefix every field's key in this struct                                                                      |
+| `source(kind = "git", name = "git config", doc_hint = "…", set_hint = "…")` | A custom source kind's display metadata. Repeatable; kinds are written in sorted order                       |
+| `file(path = "ex.toml", findup, scope = "project", format = "toml")`        | A config file in the documented precedence chain. Repeatable; **declaration order is precedence**, last wins |
 
 `source` and `file` belong to the struct they are written on. Flattening another `Config`
-type splices its *settings*, not its source/file declarations — a nested group that also
+type splices its _settings_, not its source/file declarations — a nested group that also
 documents `task.toml` still does so when emitted on its own, and does not rewrite the parent
 CLI's file chain.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- let Config fields declare `help_heading`, `writes_to`, and ordered extension metadata
- let Config structs declare top-level config source and file metadata
- preserve file precedence order while canonicalizing source kinds and rejecting duplicates
- carry spec-only metadata beside runtime `PropMeta`, including through flattened settings
- emit complete config blocks from `#[usage(config = Settings)]`
- document the typed authoring surface and add diagnostics/conformance coverage

Runtime resolution remains unchanged: these additions describe the portable spec and generated documentation rather than expanding hot/runtime property metadata.

## Testing

- `cargo test -p usage-config`
- `cargo test -p usage-derive config`
- `cargo test -p usage-conformance --test derive_config` (19 passed)
- `cargo clippy -p usage-config -p usage-derive --all-features -- -D warnings`
- `cargo fmt --all`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e77b5c4c-4ee6-4519-bc56-8430a6a90d17?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e77b5c4c-4ee6-4519-bc56-8430a6a90d17&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

