### PR TITLE
docs: label go as wip and py/js as maybe on landing page

### DIFF
--- a/docs/.vitepress/theme/UsageHero.vue
+++ b/docs/.vitepress/theme/UsageHero.vue
@@ -46,10 +46,10 @@ const javascriptPath =
               <path :d="goPath" />
             </svg>
             <span>Go</span>
-            <span class="usage-tile-experimental-pill">experimental</span>
+            <span class="usage-tile-experimental-pill">wip</span>
             <div class="usage-tile-tooltip">
               <strong>Go framework</strong>
-              <p>Build Go CLIs on the usage spec, with parsing behavior verified against the same conformance corpus as the Rust implementation. Experimental: APIs may change between releases.</p>
+              <p>Build Go CLIs on the usage spec, with parsing behavior verified against the same conformance corpus as the Rust implementation. Work in progress: APIs may change between releases.</p>
             </div>
           </a>
           <span class="usage-tile usage-tile-soon">
@@ -57,14 +57,14 @@ const javascriptPath =
               <path :d="pythonPath" />
             </svg>
             <span>Python</span>
-            <span class="usage-tile-soon-pill">soon</span>
+            <span class="usage-tile-soon-pill">maybe</span>
           </span>
           <span class="usage-tile usage-tile-soon">
             <svg class="usage-tile-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <path :d="javascriptPath" />
             </svg>
             <span>JavaScript</span>
-            <span class="usage-tile-soon-pill">soon</span>
+            <span class="usage-tile-soon-pill">maybe</span>
           </span>
         </div>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Relabel framework status pills on the docs landing page hero:

- **Go** (`usage-go`): `experimental` → `wip` (tooltip wording updated to match)
- **Python** / **JavaScript**: `soon` → `maybe`

Rust remains labeled `experimental`.

### Demo

[Framework tiles with WIP and MAYBE labels](https://cursor.com/agents/bc-3c4339b7-e83a-43f9-9304-b43e86014a8e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flanding_frameworks_labels.webp)

[landing_framework_labels_wip_maybe.mp4](https://cursor.com/agents/bc-3c4339b7-e83a-43f9-9304-b43e86014a8e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flanding_framework_labels_wip_maybe.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c4339b7-e83a-43f9-9304-b43e86014a8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c4339b7-e83a-43f9-9304-b43e86014a8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated framework status labels for Go, Python, and JavaScript.
  * Clarified that Go support is a work in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->