### PR TITLE
fix(derive): name the count type in standing presence checks

### DIFF
--- a/conformance/tests/update_from.rs
+++ b/conformance/tests/update_from.rs
@@ -642,3 +642,42 @@ fn a_standing_group_member_conflicts_with_a_sibling_flag() {
         "standing --yaml still conflicts with --strict",
     );
 }
+
+/// A counted `u8` whose presence is "not the default". The generated
+/// `!= Default::default()` must name `u8`, or `serde_json`'s `PartialEq<Value> for u8`
+/// makes the comparison ambiguous — hk's CLI hit that on every build that pulls
+/// `serde_json` into the same crate.
+#[derive(Cli, Debug, PartialEq)]
+#[usage(bin = "counted", completion)]
+struct Counted {
+    #[usage(short, long, global, count, overrides("--quiet"))]
+    verbose: u8,
+    #[usage(short, long, global, overrides("--verbose"))]
+    quiet: bool,
+    #[usage(subcommand)]
+    command: CountedCmd,
+}
+
+#[derive(Subcommands, Debug, PartialEq)]
+enum CountedCmd {
+    Run,
+}
+
+#[test]
+fn a_standing_count_compiles_beside_serde_json() {
+    // Keep `serde_json` live in this module so its `PartialEq` impls stay in scope.
+    let _ = serde_json::json!({"n": 1u8});
+
+    let a = argv(["-vv", "run"]);
+    let mut counted = Counted::parse_from(&a).expect("two -v");
+    assert_eq!(counted.verbose, 2);
+
+    // A second line that says nothing about `-v` must keep the standing count —
+    // presence is "not the default", and that comparison has to name `u8`.
+    let a = argv(["run"]);
+    counted
+        .try_update_from(&a)
+        .expect("the standing count answers for itself");
+    assert_eq!(counted.verbose, 2);
+    assert!(!counted.quiet);
+}

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -3233,7 +3233,13 @@ fn standing_presence(field: &Field) -> Option<TokenStream> {
         }),
         Kind::Flag { .. } | Kind::Arg { .. } => Some(match field.shape {
             Shape::Bool => quote!(__usage_s.#ident),
-            Shape::Count => quote!(__usage_s.#ident != ::std::default::Default::default()),
+            // Name the field's type: `Default::default()` alone is ambiguous when an
+            // adopter also brings `serde_json::Value`'s `PartialEq<u8>` into scope
+            // (hk's `verbose: u8` count under a workspace that pulls serde_json).
+            Shape::Count => {
+                let ty = &field.ty;
+                quote!(__usage_s.#ident != <#ty as ::std::default::Default>::default())
+            }
             Shape::Optional => quote!(__usage_s.#ident.is_some()),
             // Nowhere to put "absent", so the field always holds something. The same
             // reading of the type that makes it required in the first place.
@@ -4918,7 +4924,8 @@ fn merge_present(field: &Field) -> TokenStream {
     match field.shape {
         Shape::Bool => quote!(partial.#given || partial.#ident),
         Shape::Count => {
-            quote!(partial.#given || partial.#ident != ::std::default::Default::default())
+            let ty = &field.ty;
+            quote!(partial.#given || partial.#ident != <#ty as ::std::default::Default>::default())
         }
         Shape::Optional => quote!(partial.#given || partial.#ident.is_some()),
         Shape::Required | Shape::Many => quote!(partial.#given || !partial.#ident.is_empty()),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`update_from` standing presence for `count` fields generated `!= Default::default()`. When an adopter also has `serde_json` in the same crate, `PartialEq<Value> for u8` makes that comparison ambiguous and the derive fails to compile.

hk's CLI (`verbose: u8` with `count`, plus `completion` / globals / overrides) hits this on current main after #1197. Name the field type so the comparison stays `u8`.

This is a blocker for repinning the fleet clap→usage PRs onto current main for the v6 swap.

## Fleet readiness (companion)

Reviewed and locally checked against this revision:

| PR | Status vs latest usage |
|----|------------------------|
| tak#47, pitchfork#754 | compile ok; need git SHA repin |
| fnox#725 | CI green; need repin (local check blocked on libudev) |
| hk#1211 | needs this fix, then repin + regenerate `hk.usage.kdl` (flagset) |
| aube#1336 | compile ok; CI red on `completion` flag order (`force`/`install`); patch ready |
| communique#265 | compile ok; oldest pin — need repin + regen kdl |
| mise#12221 | compile ok with rustls; rebase + unify vfox dual pin + repin |

This agent only has write access to `jdx/usage`, so fleet PR updates could not be pushed from here.

## Test plan

- [x] New conformance test `a_standing_count_compiles_beside_serde_json`
- [x] Full `update_from` suite green
- [x] Minimal repro with `completion` + global count + overrides + `serde_json` compiles
- [x] `hk` on `agent/usage-6-experiment` compiles against this revision
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e871948-f9e1-43e1-802a-f9027d139f61?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e871948-f9e1-43e1-802a-f9027d139f61&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed updates for standing counted `u8` flags so their existing values remain unchanged when no new value is provided.
  * Improved handling of counted short flags, subcommands, and default quiet-state behavior.
  * Resolved type handling issues that could affect presence checks for counted options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->