### PR TITLE
fix(ci): keep unpublished crates out of set-version

### DIFF
--- a/tasks/release-plz
+++ b/tasks/release-plz
@@ -97,7 +97,26 @@ git cliff "$release_range" --tag "$version" --prepend CHANGELOG.md --include-pat
 # Strip version header since PR title already has version
 PR_BODY="$(git cliff "$release_range" --tag "$version" --strip all --include-path 'lib/**' --include-path 'cli/**' --include-path 'argv/**' --include-path 'config/**' --include-path 'derive/**' --include-path 'test/**' --include-path 'usage-rs/**' --include-path 'validation/**' | tail -n +3)"
 
-cargo set-version "${version#v}" --exclude clap_usage --exclude usage-conformance
+# clap_usage is versioned by hand. Everything still at 0.0.0 is unpublished
+# (xtask, conformance, benches) and must stay there. `cargo set-version`
+# otherwise stamps those too; `cargo update` writes 6.x into Cargo.lock; git add
+# below does not include their manifests — MSRV `cargo check --locked` then
+# fails (https://github.com/jdx/usage/pull/795).
+exclude_args=(--exclude clap_usage)
+while IFS= read -r pkg; do
+  exclude_args+=(--exclude "$pkg")
+done < <(
+  cargo metadata --format-version 1 --no-deps --offline | python3 -c '
+import json, sys
+
+data = json.load(sys.stdin)
+members = set(data["workspace_members"])
+for package in data["packages"]:
+    if package["id"] in members and package["version"] == "0.0.0":
+        print(package["name"])
+'
+)
+cargo set-version "${version#v}" "${exclude_args[@]}"
 mise run render
 
 git config user.name mise-en-dev


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

[#795](https://github.com/jdx/usage/pull/795) (`chore: release v6.0.0`) fails MSRV because `Cargo.lock` and unpublished manifests disagree.

`cargo set-version 6.0.0` was only excluding `clap_usage` and `usage-conformance`. It still stamped `xtask`, `gate`, and every `benches/shadows/*` crate to `6.0.0`. `cargo update` wrote those versions into `Cargo.lock` (which is committed). Their `Cargo.toml` files are not in the `git add` list, so they stay at `0.0.0`. `cargo check --locked` then fails on both MSRV jobs.

## Change

`tasks/release-plz` now excludes `clap_usage` and every workspace member whose version is still `0.0.0` (xtask, conformance, gate, shadows). New unpublished members are picked up automatically.

## Validation

- `cargo set-version 6.0.0 -n` with the new excludes upgrades only the published crates (`usage-argv`, `usage-cli`, `usage-config`, `usage-derive`, `usage-lib`, `usage-rs`, `usage-test`, `usage-validation`) and their workspace dependency entries.
- After a real bump + `cargo update` (then reverted): lockfile keeps `xtask` / `gate` / `shadow-mise` / `usage-conformance` at `0.0.0`; `cargo check --locked -p usage-argv` succeeds on the default toolchain and on `1.91`.

After this merges, the next `release-plz` run should force-push a consistent `release` branch onto #795.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f0778eb-0efb-4ce8-94c2-7875348fdb1f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f0778eb-0efb-4ce8-94c2-7875348fdb1f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release processing now preserves packages that have not yet been published while updating releasable package versions.
  * Improved version handling for workspace packages during releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->