### PR TITLE
fix(config): accept case-insensitive boolean words

### DIFF
--- a/config/src/ty.rs
+++ b/config/src/ty.rs
@@ -140,9 +140,23 @@ impl Ty {
             (Self::Bool, Value::String(text)) => match text.as_str() {
                 // The spellings every one of these registries accepts. Deliberately not
                 // "anything non-empty is true": `FOO=false` meaning true is the kind of
-                // surprise a config system exists to prevent.
-                "true" | "1" | "yes" | "y" | "on" => Ok(Value::Bool(true)),
-                "false" | "0" | "no" | "n" | "off" | "" => Ok(Value::Bool(false)),
+                // surprise a config system exists to prevent. Words are ASCII-case-insensitive:
+                // environment variables such as fnox's `FNOX_NO_DEFAULTS=TRUE` accepted that
+                // spelling before moving to this shared resolver.
+                "1" => Ok(Value::Bool(true)),
+                "0" | "" => Ok(Value::Bool(false)),
+                word if ["true", "yes", "y", "on"]
+                    .iter()
+                    .any(|known| word.eq_ignore_ascii_case(known)) =>
+                {
+                    Ok(Value::Bool(true))
+                }
+                word if ["false", "no", "n", "off"]
+                    .iter()
+                    .any(|known| word.eq_ignore_ascii_case(known)) =>
+                {
+                    Ok(Value::Bool(false))
+                }
                 _ => Err(TypeError {
                     expected: "a boolean",
                     found: text,
@@ -299,6 +313,12 @@ mod tests {
         // in a real CLI take.
         assert_eq!(Ty::Bool.coerce(s("yes")), Ok(Value::Bool(true)));
         assert_eq!(Ty::Bool.coerce(s("off")), Ok(Value::Bool(false)));
+        for value in ["TRUE", "True", "YES", "On"] {
+            assert_eq!(Ty::Bool.coerce(s(value)), Ok(Value::Bool(true)), "{value}");
+        }
+        for value in ["FALSE", "False", "NO", "Off"] {
+            assert_eq!(Ty::Bool.coerce(s(value)), Ok(Value::Bool(false)), "{value}");
+        }
         assert_eq!(Ty::Int.coerce(s("-3")), Ok(Value::Int(-3)));
         assert_eq!(Ty::Float.coerce(s(" 1.5 ")), Ok(Value::Float(1.5)));
         // Whitespace around a number is a typo, not a different number.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Preserve fnox's existing settings behavior while moving its registry to `usage-config`: boolean words from textual layers are now ASCII-case-insensitive.

Before the migration, values such as `FNOX_NO_DEFAULTS=TRUE`, `YES`, or `ON` were accepted. The shared resolver only accepted lowercase words, warned, and fell back to `false`, which could unexpectedly merge top-level secrets.

Numeric `1`/`0` and the existing strict rejection of unknown non-empty values are unchanged.

## Test plan

- [ ] `cargo test -p usage-config`
- [ ] `cargo clippy -p usage-config --all-features -- -D warnings`
- [ ] fnox settings tests against this revision

Part of preparing the fleet settings stack for the usage v6 swap.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e871948-f9e1-43e1-802a-f9027d139f61?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e871948-f9e1-43e1-802a-f9027d139f61&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Boolean configuration values now recognize standard true and false words regardless of capitalization.
  * Improved handling for mixed-case boolean values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->