### PR TITLE
fix(ci): commit fixture lockfiles after set-version

### DIFF
--- a/tasks/release-plz
+++ b/tasks/release-plz
@@ -122,10 +122,18 @@ mise run render
 git config user.name mise-en-dev
 git config user.email 123107610+mise-en-dev@users.noreply.github.com
 cargo update
+# Nested lockfiles pin path deps at the workspace version. Tests run
+# `cargo run --manifest-path` against them, which rewrites the lock when
+# set-version bumps those crates — CI then fails the render dirty-tree
+# gate (https://github.com/jdx/usage/actions/runs/32546629713).
+while IFS= read -r lock; do
+  cargo generate-lockfile --manifest-path "${lock%/Cargo.lock}/Cargo.toml"
+done < <(git ls-files 'usage-rs/tests/fixtures/*/Cargo.lock')
 aube update
 mise run lint-fix
 git add \
   {./,argv/,cli/,config/,derive/,lib/,test/,usage-rs/,validation/}Cargo.* \
+  usage-rs/tests/fixtures/*/Cargo.lock \
   package.json aube-lock.yaml \
   cli/usage.usage.kdl \
   docs/cli/reference/* \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

[#795](https://github.com/jdx/usage/pull/795) still fails `test` after the MSRV lockfile fix. [Job 96966142310](https://github.com/jdx/usage/actions/runs/32546629713/job/96966142310) dies on the dirty-tree gate because `usage-rs/tests/fixtures/runtime-identity/Cargo.lock` is rewritten from `5.1.0` to `6.0.0` for `usage-argv` / `usage-derive` / `usage-rs`.

That fixture path-depends on `usage-rs`. Tests run `cargo run --manifest-path` against it, which updates the nested lock after `set-version`. `tasks/release-plz` never committed that lockfile.

## Change

After the workspace `cargo update`, regenerate every tracked fixture `Cargo.lock` with `cargo generate-lockfile` and `git add` them.

## Validation

A local `set-version 6.0.0` plus `cargo generate-lockfile` on the fixture produced the same three-line version bump CI reported. `git add usage-rs/tests/fixtures/*/Cargo.lock` stages that file (it is tracked despite `fixtures/.gitignore`).

After merge, the next `release-plz` run should force-push a release commit whose fixture lock already matches 6.0.0.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f0778eb-0efb-4ce8-94c2-7875348fdb1f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f0778eb-0efb-4ce8-94c2-7875348fdb1f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

