### PR TITLE
docs: add benchmark charts to rust and go pages

### DIFF
--- a/docs/.vitepress/theme/UsageBenches.vue
+++ b/docs/.vitepress/theme/UsageBenches.vue
@@ -119,8 +119,10 @@ onBeforeUnmount(() => window.removeEventListener("resize", replace));
 
 <template>
   <section class="usage-bench" :class="{ embedded: embedded }">
-    <p class="usage-hero-label">Benchmarks</p>
-    <h2 class="usage-bench-title">Parser overhead</h2>
+    <template v-if="!embedded">
+      <p class="usage-hero-label">Benchmarks</p>
+      <h2 class="usage-bench-title">Parser overhead</h2>
+    </template>
     <p class="usage-bench-sub">
       What parsing <code>mise use -g node@20</code> costs each framework, against a shadow
       of <a href="https://mise.jdx.dev">mise</a>'s CLI: 211 commands,

--- a/docs/.vitepress/theme/UsageBenches.vue
+++ b/docs/.vitepress/theme/UsageBenches.vue
@@ -1,5 +1,22 @@
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted } from "vue";
+import { computed, onBeforeUnmount, onMounted } from "vue";
+
+const props = withDefaults(
+  defineProps<{
+    // Homepage shows both cards. Framework pages pass the language they are
+    // documenting so the other card does not sit in the way of that page's
+    // own install instructions.
+    lang?: "all" | "rust" | "go";
+    // Doc-column layout: the homepage padding and 1120px cap do not belong
+    // inside a VitePress article.
+    embedded?: boolean;
+  }>(),
+  { lang: "all", embedded: false },
+);
+
+const showRust = computed(() => props.lang !== "go");
+const showGo = computed(() => props.lang !== "rust");
+const idPrefix = computed(() => `bench-${props.lang}`);
 
 // Rust wall clock from `time-sweep.rs`, which runs each parser repeatedly in one
 // process and keeps the fastest of many short rounds — throughput rather than
@@ -101,7 +118,7 @@ onBeforeUnmount(() => window.removeEventListener("resize", replace));
 </script>
 
 <template>
-  <section class="usage-bench">
+  <section class="usage-bench" :class="{ embedded: embedded }">
     <p class="usage-hero-label">Benchmarks</p>
     <h2 class="usage-bench-title">Parser overhead</h2>
     <p class="usage-bench-sub">
@@ -111,8 +128,11 @@ onBeforeUnmount(() => window.removeEventListener("resize", replace));
       what differs is the parser rather than one of them being written more carefully.
     </p>
 
-    <div class="usage-bench-cards">
-      <div class="usage-bench-card">
+    <div
+      class="usage-bench-cards"
+      :class="{ 'usage-bench-cards-single': !(showRust && showGo) }"
+    >
+      <div v-if="showRust" class="usage-bench-card">
         <h3>usage-rs <span>vs clap, argh, bpaf</span></h3>
         <p class="usage-bench-metric">
           wall time,
@@ -121,9 +141,9 @@ onBeforeUnmount(() => window.removeEventListener("resize", replace));
             tabindex="0"
             @mouseenter="clamp"
             @focusin="clamp"
-            aria-describedby="bench-tip-warmed"
+            :aria-describedby="`${idPrefix}-tip-warmed`"
             >in-process parse throughput
-            <span class="usage-bench-tip" id="bench-tip-warmed" role="tooltip">
+            <span class="usage-bench-tip" :id="`${idPrefix}-tip-warmed`" role="tooltip">
               <strong>How this is measured</strong>
               <span>
                 Each parser runs repeatedly inside one process; process startup is excluded,
@@ -160,9 +180,9 @@ onBeforeUnmount(() => window.removeEventListener("resize", replace));
             tabindex="0"
             @mouseenter="clamp"
             @focusin="clamp"
-            aria-describedby="bench-tip-build"
+            :aria-describedby="`${idPrefix}-tip-build`"
             >build a parser before they can use one
-            <span class="usage-bench-tip" id="bench-tip-build" role="tooltip">
+            <span class="usage-bench-tip" :id="`${idPrefix}-tip-build`" role="tooltip">
               <strong>Where their time goes</strong>
               <span>
                 Most of clap's is constructing and validating its command tree. bpaf's is
@@ -177,9 +197,9 @@ onBeforeUnmount(() => window.removeEventListener("resize", replace));
             tabindex="0"
             @mouseenter="clamp"
             @focusin="clamp"
-            aria-describedby="bench-tip-express"
+            :aria-describedby="`${idPrefix}-tip-express`"
             >express less
-            <span class="usage-bench-tip" id="bench-tip-express" role="tooltip">
+            <span class="usage-bench-tip" :id="`${idPrefix}-tip-express`" role="tooltip">
               <strong>Missing from the argh and bpaf shadows</strong>
               <span>
                 Aliases, hidden commands, global flags, and a positional beside a
@@ -191,7 +211,7 @@ onBeforeUnmount(() => window.removeEventListener("resize", replace));
         </p>
       </div>
 
-      <div class="usage-bench-card">
+      <div v-if="showGo" class="usage-bench-card">
         <h3>usage-go <span>vs cobra, urfave/cli, kong</span></h3>
         <p class="usage-bench-metric">
           wall time,
@@ -200,9 +220,9 @@ onBeforeUnmount(() => window.removeEventListener("resize", replace));
             tabindex="0"
             @mouseenter="clamp"
             @focusin="clamp"
-            aria-describedby="bench-tip-cold"
+            :aria-describedby="`${idPrefix}-tip-cold`"
             >one cold parse
-            <span class="usage-bench-tip" id="bench-tip-cold" role="tooltip">
+            <span class="usage-bench-tip" :id="`${idPrefix}-tip-cold`" role="tooltip">
               <strong>How this is measured</strong>
               <span>
                 Whole-process, with the ~0.95ms of Go runtime startup a do-nothing process
@@ -238,13 +258,18 @@ onBeforeUnmount(() => window.removeEventListener("resize", replace));
 
     <p class="usage-bench-method">
       Methodology and raw numbers:
-      <a href="https://github.com/jdx/usage/blob/main/go/README.md">go/README.md</a> ·
-      <a href="https://github.com/jdx/usage/blob/main/tasks/perf-shadow.sh">tasks/perf-shadow.sh</a>
-      ·
-      <a
-        href="https://github.com/jdx/usage/blob/main/benches/gate/src/bin/time-sweep.rs"
-        >time-sweep.rs</a
-      >
+      <template v-if="showGo">
+        <a href="https://github.com/jdx/usage/blob/main/go/README.md">go/README.md</a>
+        <template v-if="showRust"> · </template>
+      </template>
+      <template v-if="showRust">
+        <a href="https://github.com/jdx/usage/blob/main/tasks/perf-shadow.sh">tasks/perf-shadow.sh</a>
+        ·
+        <a
+          href="https://github.com/jdx/usage/blob/main/benches/gate/src/bin/time-sweep.rs"
+          >time-sweep.rs</a
+        >
+      </template>
     </p>
   </section>
 </template>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -553,8 +553,15 @@
    the doc column. Keep the cards, drop the stage. */
 .usage-bench.embedded {
   max-width: none;
-  margin: 2rem 0 2.75rem;
+  margin: 0.5rem 0 2.75rem;
   padding: 0;
+  text-align: left;
+}
+
+.usage-bench.embedded .usage-bench-sub {
+  margin-left: 0;
+  margin-right: 0;
+  max-width: none;
 }
 
 .vp-doc .usage-bench.embedded .usage-bench-title {

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -545,6 +545,30 @@
   text-align: left;
 }
 
+.usage-bench-cards-single {
+  grid-template-columns: 1fr;
+}
+
+/* Inside a framework article the homepage's outer padding and 1120px cap fight
+   the doc column. Keep the cards, drop the stage. */
+.usage-bench.embedded {
+  max-width: none;
+  margin: 2rem 0 2.75rem;
+  padding: 0;
+}
+
+.vp-doc .usage-bench.embedded .usage-bench-title {
+  border-top: none;
+  padding-top: 0;
+  margin-top: 0;
+}
+
+.vp-doc .usage-bench.embedded .usage-bench-card h3 {
+  border-top: none;
+  padding-top: 0;
+  margin-top: 0;
+}
+
 .usage-bench-card {
   position: relative;
   background: rgba(21, 8, 54, 0.7);

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -16,7 +16,8 @@ export default {
       'layout-bottom': () => [h(EndevSponsors), h(EndevFooter)]
     })
   },
-  enhanceApp() {
+  enhanceApp({ app }) {
+    app.component('UsageBenches', UsageBenches)
     initBanner()
   },
   setup() {

--- a/docs/go/index.md
+++ b/docs/go/index.md
@@ -20,6 +20,8 @@ typed structs, and a `Parse` function at build time. The result:
   tables; the linker drops the ones you don't reference. No `init` functions.
 - **One source of truth.** The same KDL spec generates your completions, docs, and manpages.
 
+<UsageBenches lang="go" embedded />
+
 ## Quick start
 
 Write a spec:

--- a/docs/go/index.md
+++ b/docs/go/index.md
@@ -20,6 +20,8 @@ typed structs, and a `Parse` function at build time. The result:
   tables; the linker drops the ones you don't reference. No `init` functions.
 - **One source of truth.** The same KDL spec generates your completions, docs, and manpages.
 
+## Parser overhead
+
 <UsageBenches lang="go" embedded />
 
 ## Quick start

--- a/docs/rust/index.md
+++ b/docs/rust/index.md
@@ -43,6 +43,8 @@ fn main() {
 Doc comments are the help text: the first paragraph becomes the short help shown by `-h`, the
 whole comment becomes the long help shown by `--help`.
 
+## Parser overhead
+
 <UsageBenches lang="rust" embedded />
 
 ## Installation

--- a/docs/rust/index.md
+++ b/docs/rust/index.md
@@ -43,6 +43,8 @@ fn main() {
 Doc comments are the help text: the first paragraph becomes the short help shown by `-h`, the
 whole comment becomes the long help shown by `--help`.
 
+<UsageBenches lang="rust" embedded />
+
 ## Installation
 
 One dependency. Add `usage-rs` to your `Cargo.toml`, aliased to `usage`:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The homepage already shows parser-overhead charts for usage-rs and usage-go. This reuses that component on the Rust and Go landing pages so each framework page carries the matching comparison.

- `UsageBenches` accepts `lang` (`rust` / `go` / `all`) and `embedded` for the doc column
- Rust page shows the clap / argh / bpaf card
- Go page shows the cobra / urfave/cli / kong card
- Embedded charts keep a markdown `Parser overhead` heading so they appear in the page outline

[usage-rs benchmark chart on the Rust landing page](https://cursor.com/agents/bc-193b2cfb-a36f-450c-afbf-46ea935ff540/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frust_page_benchmark_chart.webp)
[usage-go benchmark chart on the Go landing page](https://cursor.com/agents/bc-193b2cfb-a36f-450c-afbf-46ea935ff540/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgo_page_benchmark_chart.webp)
[rust_and_go_benchmark_charts.mp4](https://cursor.com/agents/bc-193b2cfb-a36f-450c-afbf-46ea935ff540/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frust_and_go_benchmark_charts.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-193b2cfb-a36f-450c-afbf-46ea935ff540?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-193b2cfb-a36f-450c-afbf-46ea935ff540&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added language-specific Rust and Go benchmark views.
  * Embedded parser-overhead benchmarks directly into the Rust and Go documentation pages.
  * Added responsive single-card layouts and styling for embedded benchmark sections.
  * Improved accessibility with unique tooltip identifiers.
  * Adjusted headings and methodology links to match the selected benchmark view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->