### PR TITLE
docs(rust): refresh clap binary size comparison

### DIFF
--- a/docs/rust/performance.md
+++ b/docs/rust/performance.md
@@ -116,7 +116,7 @@ same workspace release build, stripped:
 
 | Framework | Stripped binary |
 | --------- | --------------: |
-| usage     |          1.5 MB |
+| usage     |          1.6 MB |
 | bpaf      |          2.5 MB |
 | clap      |          3.1 MB |
 
@@ -134,9 +134,11 @@ a small CLI, and `#[usage(spec_endpoint = false)]` removes it.
   its framework cannot express — so a framework is measured on its own vocabulary,
   and the drops are themselves part of the comparison.
 - Binary sizes are the gate's `parse-n*` binaries from a full workspace release
-  build, stripped. The workspace build matters: cargo unifies features, so clap
-  gets the features (color, suggestions, help, derive, env) a real CLI of this
-  size enables.
+  build, stripped (`strip` with no extra flags). Regenerated against rustc 1.97.1
+  on x86_64-unknown-linux-gnu: usage 1,579,200 bytes, bpaf 2,493,264, clap
+  3,101,640, shown above as decimal megabytes to one place. The workspace build
+  matters: cargo unifies features, so clap gets the features (color, suggestions,
+  help, derive, env) a real CLI of this size enables.
 - This measures routing and parsing, not process startup, configuration loading,
   command execution, help rendering, or completion generation.
 - The mise fixture changes over time, both by growing and by being refreshed


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rebuilds the gate’s mise-scale `parse-n*` binaries (`cargo build --release` of the full workspace, then `strip` with no extra flags) and updates the published sizes on the Rust performance page.

**Method**

- rustc 1.97.1, x86_64-unknown-linux-gnu
- Each binary parsed `use -g node@20` (`PARSE_N=1`) and printed `1`
- Sizes are stripped copies, decimal megabytes to one place

| Framework | Stripped bytes | Documented |
| --------- | -------------: | ---------: |
| usage     |      1,579,200 |     1.6 MB |
| bpaf      |      2,493,264 |     2.5 MB |
| clap      |      3,101,640 |     3.1 MB |

clap (3.1 MB) and bpaf (2.5 MB) were already accurate. usage moved from 1.5 MB to 1.6 MB at the same rounding. clap remains about 2× the stripped usage binary.

argh’s `parse-n-argh` measured 1,010,232 bytes; it is not in the published table, matching the instruction-count table on that page.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abacaead-dc6d-4d6e-aaac-2828b6321307?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abacaead-dc6d-4d6e-aaac-2828b6321307&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented binary size from 1.5 MB to 1.6 MB.
  * Clarified the binary-size measurement methodology, including toolchain, target, exact byte counts, unit conversion, and feature settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->