### PR TITLE
docs(spec): complete KDL reference

### DIFF
--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -50,7 +50,7 @@ flag "-u --user <user>" help="User to run as"
 cmd "update" help="Update the CLI"
 cmd "config" help="Manage the CLI config" {
   // "set" is an alias for "add"
-  cmd "add" "Add/set a config" {
+  cmd "add" help="Add/set a config" {
     alias "set"
     arg "<key>" help="The key for the config"
     arg "<value>" help="The new config value"

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -70,13 +70,19 @@ cmd "help" help="Print the CLI help"
 Flags/args can be backed by config files, environment variables, or defaults:
 
 ```kdl
-config_file ".mycli.toml" findup=#true
-flag "-u --user <user>" help="User to run as" env="MYCLI_USER" config="settings.user" default="admin"
+flag "-u --user <user>" help="User to run as"
+config {
+  file ".mycli.toml" findup=#true
+  prop "settings.user" type="string" default="admin" {
+    cli "--user"
+    env "MYCLI_USER"
+  }
+}
 ```
 
-The priority over which is used (CLI flag, env var, config file, default) is the order which they
-are defined,
-so in this example it will be "CLI flag > env var > config file > default".
+The priority is always CLI flag > environment variable > config file > default. See the
+[config reference](/spec/reference/config) for settings and files, and
+[configuration resolution](/spec/resolution) for the complete precedence and merging rules.
 
 ## Command effects
 

--- a/docs/spec/reference/arg.md
+++ b/docs/spec/reference/arg.md
@@ -1,6 +1,6 @@
 # `arg`
 
-Positionals accept `hide_default_value`, `hide_env`, `hide_env_values`,
+Positionals accept `hide`, `hide_default_value`, `hide_env`, `hide_env_values`,
 `hide_possible_values`, `hide_short_help`, and `hide_long_help`. These affect
 help presentation only; defaults, environment fallback, and validation remain
 active.
@@ -12,14 +12,15 @@ arg "[file]"                             // optional positional arg
 arg "<file>" default="file.txt"          // default value for arg
 arg "<file>" env="MY_FILE"               // arg can be backed by an env var
 arg "<file>" display_order=10             // explicit order in help; parse order is unchanged
-arg "<file>" parse="mycli parse-file {}" // parse arg value with external command
 arg "<port>" validate="int(value) >= 1 && int(value) <= 65535" validate_error="must be a valid port"
+arg "<output>" effect="write"             // raises the command effect when supplied
 
 arg "[file]" var=#true // multiple args can be passed (e.g. mycli file1 file2 file3) (0 or more)
 arg "<file>" var=#true // multiple args can be passed (e.g. mycli file1 file2 file3) (1 or more)
 arg "<file>..."        // shorthand for var=#true (trailing ellipsis)
 arg "<file>" var=#true var_min=3 // at least 3 args must be passed
 arg "<file>" var=#true var_max=3 // up to 3 args can be passed
+arg "<tag>..." delimiter="," // one word such as a,b becomes two values
 arg "<start> <end>" var_min=2 var_max=2 // exactly two values with distinct labels
 arg "<number>" allow_negative_numbers=#true // -1 is a value, --force is still flag-like
 arg "<item>..." value_terminator=";" // stop before ; without storing it
@@ -37,6 +38,9 @@ arg "[checksum]" {
 `allow_negative_numbers` accepts a leading-minus integer or decimal where a normal
 dash-prefixed token would be treated as a flag. `value_terminator` is valid only on a
 variadic argument; it ends that argument without binding the terminator token.
+
+`delimiter` splits one word into several values before choices and validation
+are applied, so it is valid only on a variadic argument.
 
 Several placeholders in one argument declare fixed arity. Each label is retained in
 help and generated Rust and Go tables; `var_min` and `var_max` must match the number
@@ -62,6 +66,37 @@ adds it to its own manifest:
 ```toml
 expr-lang = { version = "2.1", features = ["temporal"] }
 ```
+
+## Environment sources
+
+`env` is the canonical variable. `env_fallback` names additional variables in
+precedence order, and `deprecated_env` names compatibility aliases consulted
+last and reported as deprecated:
+
+```kdl
+arg "<profile>" env="MYCLI_PROFILE" {
+  env_fallback "MYCLI_ENV" "PROFILE"
+  deprecated_env "OLD_PROFILE"
+}
+```
+
+Command-line values win over every environment source. A value from an
+environment variable wins over `default`.
+
+## Markdown help and effects
+
+`help_md` supplies Markdown directly to generated Markdown documentation:
+
+```kdl
+arg "<output>" help="Output path" {
+  help_md "Write the result to **this path**."
+  effect "write"
+}
+```
+
+Without `help_md`, generated Markdown falls back to `long_help` and then
+`help`. An `effect` raises the selected command's declared effect when this
+positional is supplied; see [command effects](/spec/#command-effects).
 
 ## Using Variadic Args in Bash
 

--- a/docs/spec/reference/cmd.md
+++ b/docs/spec/reference/cmd.md
@@ -37,19 +37,19 @@ cmd "config" {
 }
 
 cmd "list" {
-  example "Basic usage" #"""
+  example #"""
     $ mycli list
     FRUIT  COLOR
     apple  red
     banana yellow
-  """#
-  example "JSON output" #"""
+  """# header="Basic usage"
+  example #"""
     $ mycli list --json
     [
       {"FRUIT": "apple", "COLOR": "red"},
       {"FRUIT": "banana", "COLOR": "yellow"}
     ]
-  """#
+  """# header="JSON output"
 }
 ```
 
@@ -338,7 +338,7 @@ cmd "run" {
 ```
 
 ```kdl
-# emitted by the mount
+// emitted by the mount
 cmd "task1" {
   flag "--env <name>" {
     choices "dev" "stage" "prod"

--- a/docs/spec/reference/cmd.md
+++ b/docs/spec/reference/cmd.md
@@ -14,6 +14,7 @@ cmd "config" next_line_help=#true // put descriptions below each entry
 cmd "config" flatten_help=#true // expand visible subcommands into this page
 cmd "config" display_order=10 // present before commands with a greater order
 cmd "config" help_heading="Configuration" // group under this heading in its parent's help
+cmd "config" term_width=100 max_term_width=120
 
 // these are shown under -h
 cmd "config" before_help="shown before the command"
@@ -28,6 +29,11 @@ cmd "config" {
   before_long_help "shown before the command"
   long_help "longer description"
   after_long_help "shown after the command"
+
+  // used directly in generated markdown docs
+  before_help_md "Markdown before the command"
+  help_md "A **markdown** description"
+  after_help_md "Markdown after the command"
 }
 
 cmd "list" {
@@ -46,6 +52,13 @@ cmd "list" {
   """#
 }
 ```
+
+`term_width` fixes the width used to wrap help; zero disables wrapping.
+`max_term_width` caps a detected terminal width when `term_width` is unset;
+zero disables that cap.
+
+Markdown documentation prefers the `*_md` form, then long help, then short
+help. Flags and arguments also accept `help_md`.
 
 ## Deprecating a command
 
@@ -85,12 +98,12 @@ Calling `mycli mount-usage-tasks` would emit something like this:
 
 ```kdl
 cmd "task1" {
-  arg "arg1" help="task1 arg1"
-  flag "flag1" help="task1 flag1"
+  arg "<arg1>" help="task1 arg1"
+  flag "--flag1" help="task1 flag1"
 }
 cmd "task2" {
-  arg "arg1" help="task2 arg1"
-  flag "flag1" help="task2 flag1"
+  arg "<arg1>" help="task2 arg1"
+  flag "--flag1" help="task2 flag1"
 }
 ```
 
@@ -279,6 +292,36 @@ cmd "publish" args_override_self=#false
 ```
 
 Repeatable, variadic, and count flags continue collecting or counting regardless of this setting.
+
+### Restart argument parsing
+
+`restart_token` lets one command line contain several invocations of the same
+command. Encountering the token clears the positional cursor, pending flag
+value, and `--` separator state before parsing the next invocation:
+
+```kdl
+cmd "run" restart_token=":::" {
+  arg "<task>"
+  flag "--jobs <N>"
+}
+```
+
+`mycli run lint ::: test` parses `lint` and then restarts at `test`. The parser
+retains the last invocation's scalar bindings. This is a command-only property;
+it is not accepted as a top-level node.
+
+### Command-local completions
+
+A `complete` child applies only while parsing that command. It has the same
+`run`, `type`, and `descriptions` properties as a
+[top-level completer](./complete.md):
+
+```kdl
+cmd "deploy" {
+  arg "<environment>"
+  complete "environment" run="mycli environments"
+}
+```
 
 ### Global flags and mounted commands
 

--- a/docs/spec/reference/flag.md
+++ b/docs/spec/reference/flag.md
@@ -1,6 +1,7 @@
 # `flag`
 
-Help annotations and page variants can be hidden independently without changing
+Flags can be removed from every help page and completion with `hide`. Help
+annotations and page variants can also be hidden independently without changing
 parsing or fallback behavior. Flags accept `hide_default_value`, `hide_env`,
 `hide_env_values`, `hide_possible_values`, `hide_short_help`, and
 `hide_long_help`. Usage help prints an environment variable's name but never its
@@ -17,6 +18,8 @@ flag "--user" { alias "-u" hide=#true } // hide alias from docs and completions
 
 flag "-f --force" global=#true          // global can be set on any subcommand
 flag "--force" display_order=10         // explicit order within its help section
+flag "--config <file>" required=#true   // invocation must provide a value
+flag "--clear" effect="destructive"     // raises the command effect when supplied
 flag "--file <file>" default="file.txt" // default value for flag
 flag "-v --verbose" count=#true         // instead of true/false $usage_verbose is # of times
                                         // flag was used (e.g. -vvv = 3)
@@ -345,3 +348,18 @@ can take it into account, and it is not offered inside a mounted command — see
 A non-global flag belongs to the command that declares it, but may still appear before one of
 that command's subcommands (`mycli run --force task`): it is parsed there, just not inherited
 and not passed to mounts.
+
+## Markdown help and effects
+
+`help_md` supplies Markdown directly to generated Markdown documentation:
+
+```kdl
+flag "--output <path>" help="Output path" {
+  help_md "Write the result to **this path**."
+  effect "write"
+}
+```
+
+Without `help_md`, generated Markdown falls back to `long_help` and then
+`help`. An `effect` raises the selected command's declared effect when this flag
+is supplied; see [command effects](/spec/#command-effects).

--- a/docs/spec/reference/index.md
+++ b/docs/spec/reference/index.md
@@ -22,6 +22,12 @@ before_long_help "before about"
 long_about "longer help"
 after_long_help "after about"
 
+// markdown used by generated markdown documentation
+about_md "Longer **markdown** description"
+
+// replace the generated synopsis
+usage "mycli [OPTIONS] <COMMAND>"
+
 // examples (shown in markdown and manpage docs)
 example "mycli --help" header="Getting help" help="Display help information"
 example "mycli --version"
@@ -34,6 +40,48 @@ include file="./my_overrides.usage.kdl" // include another spec, will be merged 
 // a reusable set of flags, pulled into a command with `use` (see ./flagset.md)
 flagset "common" { flag "-v --verbose" }
 ```
+
+## Help variants
+
+The plain fields (`about`, `before_help`, and `after_help`) are the short-help
+forms. Their `long_` variants are used for long help. `about_md` supplies
+Markdown directly to generated Markdown documentation; commands, flags, and
+arguments have the corresponding `help_md`, and commands also accept
+`before_help_md` and `after_help_md`. When no Markdown form is declared, the
+generator falls back to long help and then short help.
+
+`usage` replaces the generated synopsis at the root. A command's synopsis is
+otherwise generated from its flags, arguments, and subcommands.
+
+## Laying out help
+
+`help_template` controls the order of the six pre-rendered sections in every
+help page:
+
+```kdl
+help_template "{{about}}\n\n{{usage}}\n\n{{flags}}\n\n{{args}}\n\n{{commands}}\n\n{{after_help}}"
+```
+
+The supported placeholders are `about`, `usage`, `commands`, `args`, `flags`,
+and `after_help`. A placeholder outside that closed vocabulary is rejected
+when the spec is parsed. A template may omit a section or add literal text.
+
+## Root command policy
+
+The root accepts the same command-policy nodes documented in the
+[`cmd` reference](./cmd.md), except `restart_token`, which belongs to a named
+`cmd`. These root-only settings are also available:
+
+```kdl
+default_subcommand "run"
+disable_help #true
+```
+
+`default_subcommand` routes an unmatched first word to the named command. Known
+subcommands still take precedence. `disable_help` disables the parser's built-in
+recognition of `-h`, `--help`, `-?`, and `help`; use the narrower
+`disable_help_flag` or `disable_help_subcommand` command policies when only one
+entry point should be removed.
 
 ## Multicall
 

--- a/lib/tests/docs_examples.rs
+++ b/lib/tests/docs_examples.rs
@@ -152,6 +152,7 @@ fn every_kdl_example_on_the_checked_pages_parses() {
             .to_string_lossy()
             .to_string();
         let blocks = kdl_blocks(&std::fs::read_to_string(&page).expect("readable"));
+        assert!(!blocks.is_empty(), "{name} contains no KDL examples");
         let dir = tempfile::tempdir().expect("temp dir");
         let files = write_files(dir.path(), &blocks);
 

--- a/lib/tests/docs_examples.rs
+++ b/lib/tests/docs_examples.rs
@@ -1,16 +1,14 @@
-//! Every KDL example on the config and flagset reference pages parses.
+//! Every KDL example on the introductory, command, config, and flagset pages parses.
 //!
 //! That page used to document a vocabulary which had never existed — `file`, `findup`,
 //! `default "k" "v"`, `alias`, `config_file` — while the parser accepted only `prop`, which
 //! the page never mentioned. Nobody noticed because nothing checked. This checks.
 //!
-//! Only that page, for now. The other reference pages are *catalogues*: a block lists half
+//! Only pages whose blocks can each stand alone, for now. Some reference pages are *catalogues*:
+//! a block lists half
 //! a dozen alternative spellings of an `arg` or a `flag`, which is not a spec and does not
 //! parse as one (one of them puts an argument after a variadic, which the parser refuses
-//! for good reason). Covering those means checking a catalogue line by line, which is worth
-//! doing and is not this change. Running this test against them today reports five
-//! failures, one of which — `flag "flag1"` in `cmd.md`, missing its dashes — is a real
-//! documentation bug of exactly the kind this test exists to catch.
+//! for good reason). Covering those means checking a catalogue line by line.
 //!
 //! A block that reads another file is parsed from disk rather than skipped, because the
 //! `include` examples are the ones a reader is least able to check for themselves: the
@@ -136,6 +134,8 @@ fn write_files(dir: &Path, blocks: &[String]) -> Vec<(usize, PathBuf)> {
 #[test]
 fn every_kdl_example_on_the_checked_pages_parses() {
     let pages = [
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../docs/spec/index.md"),
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../docs/spec/reference/cmd.md"),
         Path::new(env!("CARGO_MANIFEST_DIR")).join("../docs/spec/reference/config.md"),
         // Every block on the flagset page is a whole spec, a top-level fragment or a file
         // another block reads, so the page can be held to parsing from the day it was


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- replace stale configuration and argument examples with syntax accepted by the current parser
- document implemented root, command, flag, and positional settings missing from the spec reference
- extend KDL example parsing coverage to the spec introduction and command reference
- repair additional invalid command and example syntax exposed by the expanded regression test
- require every checked documentation page to contain at least one extracted KDL example

## Testing

- `cargo test -p usage-lib --all-features every_kdl_example_on_the_checked_pages_parses -- --nocapture`
- `pnpm docs:build`
- `cargo fmt --all -- --check`
- `git diff --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b164fcc-764b-4b66-b712-b40a416822a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b164fcc-764b-4b66-b712-b40a416822a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated configuration examples and clarified precedence between CLI flags, environment variables, config files, and defaults.
  - Expanded command, flag, and positional argument references with hiding options, Markdown help, effects, delimiters, completion, restart behavior, and terminal width controls.
  - Added guidance for help variants, templates, root command policies, default subcommands, and custom metadata.
  - Updated examples for clearer command descriptions and argument syntax.

- **Tests**
  - Expanded documentation parsing coverage to include introductory and command reference pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->