### PR TITLE
chore: release v6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [6.1.0](https://github.com/jdx/usage/compare/v6.0.0..v6.1.0) - 2026-08-22
+
+### 🚀 Features
+
+- **(cli)** read settings under a prefix mise does not strip by [@JamBalaya56562](https://github.com/JamBalaya56562) in [#1213](https://github.com/jdx/usage/pull/1213)
+- **(derive)** dispatch more of the matches CLIs already write by [@jdx](https://github.com/jdx) in [#1221](https://github.com/jdx/usage/pull/1221)
+- **(spec)** apply runtime identity and flatten headings in help by [@jdx](https://github.com/jdx) in [#1220](https://github.com/jdx/usage/pull/1220)
+
+### 🐛 Bug Fixes
+
+- **(derive)** flow long help and emit kdl raw multiline strings by [@jdx](https://github.com/jdx) in [#1215](https://github.com/jdx/usage/pull/1215)
+
+### 📚 Documentation
+
+- **(rust)** drop the restated one-declaration line from the intro by [@jdx](https://github.com/jdx) in [#1211](https://github.com/jdx/usage/pull/1211)
+- **(spec)** complete KDL reference by [@jdx](https://github.com/jdx) in [#1214](https://github.com/jdx/usage/pull/1214)
+
 ## [6.0.0](https://github.com/jdx/usage/compare/v5.1.0..v6.0.0) - 2026-08-22
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1119,9 +1119,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "memchr"
@@ -2245,11 +2245,11 @@ checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "usage-argv"
-version = "6.0.0"
+version = "6.1.0"
 
 [[package]]
 name = "usage-cli"
-version = "6.0.0"
+version = "6.1.0"
 dependencies = [
  "assert_cmd",
  "ctor",
@@ -2278,7 +2278,7 @@ dependencies = [
 
 [[package]]
 name = "usage-config"
-version = "6.0.0"
+version = "6.1.0"
 dependencies = [
  "serde_json",
  "toml",
@@ -2305,7 +2305,7 @@ dependencies = [
 
 [[package]]
 name = "usage-derive"
-version = "6.0.0"
+version = "6.1.0"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2315,7 +2315,7 @@ dependencies = [
 
 [[package]]
 name = "usage-lib"
-version = "6.0.0"
+version = "6.1.0"
 dependencies = [
  "clap",
  "criterion",
@@ -2343,7 +2343,7 @@ dependencies = [
 
 [[package]]
 name = "usage-rs"
-version = "6.0.0"
+version = "6.1.0"
 dependencies = [
  "serde",
  "usage-argv",
@@ -2356,14 +2356,14 @@ dependencies = [
 
 [[package]]
 name = "usage-test"
-version = "6.0.0"
+version = "6.1.0"
 dependencies = [
  "usage-argv",
 ]
 
 [[package]]
 name = "usage-validation"
-version = "6.0.0"
+version = "6.1.0"
 dependencies = [
  "expr-lang",
 ]
@@ -2376,9 +2376,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.1"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
+checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,19 +42,19 @@ license = "MIT"
 [workspace.dependencies]
 clap_usage = { path = "./clap_usage", version = "5.0.0" }
 usage-cli = { path = "./cli" }
-usage-argv = { path = "./argv", version = "6.0.0" }
-usage-config = { path = "./config", version = "6.0.0" }
-usage-derive = { path = "./derive", version = "6.0.0" }
+usage-argv = { path = "./argv", version = "6.1.0" }
+usage-config = { path = "./config", version = "6.1.0" }
+usage-derive = { path = "./derive", version = "6.1.0" }
 # No features, and defaults off. A feature named here is inherited by every member that writes
 # `workspace = true` and inlines into their published manifests — so `clap` and `validation`
 # reached members that use neither, one of them an adopter's build script. Defaults
 # are off rather than absent because cargo *ignores* a member's `default-features = false` unless
 # the workspace declaration sets it too, and warns that it may become a hard error. Members name
 # what they need, `docs` included.
-usage-lib = { path = "./lib", version = "6.0.0", default-features = false }
-usage-rs = { path = "./usage-rs", version = "6.0.0" }
-usage-test = { path = "./test", version = "6.0.0" }
-usage-validation = { path = "./validation", version = "6.0.0" }
+usage-lib = { path = "./lib", version = "6.1.0", default-features = false }
+usage-rs = { path = "./usage-rs", version = "6.1.0" }
+usage-test = { path = "./test", version = "6.1.0" }
+usage-validation = { path = "./validation", version = "6.1.0" }
 
 [workspace.metadata.release]
 allow-branch = ["main"]

--- a/argv/Cargo.toml
+++ b/argv/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-argv"
 description = "Zero-allocation argv parser for usage specs"
-version = "6.0.0"
+version = "6.1.0"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "usage-cli"
 edition = "2021"
 rust-version = "1.95"
-version = "6.0.0"
+version = "6.1.0"
 description = "CLI for working with usage-based CLIs"
 license = { workspace = true }
 authors = { workspace = true }

--- a/cli/usage.usage.kdl
+++ b/cli/usage.usage.kdl
@@ -2,7 +2,7 @@
 min_usage_version "4.0"
 name usage
 bin usage
-version "6.0.0"
+version "6.1.0"
 repository "https://github.com/jdx/usage"
 source_code_link_template #"""
 {%- set path = path | replace(from='-', to='_') -%}

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-config"
 description = "Layered configuration resolution for usage specs, with provenance"
-version = "6.0.0"
+version = "6.1.0"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-derive"
 description = "Derive macro that compiles a CLI definition into parse tables and a usage spec"
-version = "6.0.0"
+version = "6.1.0"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }

--- a/docs/cli/reference/commands.json
+++ b/docs/cli/reference/commands.json
@@ -1756,7 +1756,7 @@
     "sources": {},
     "files": []
   },
-  "version": "6.0.0",
+  "version": "6.1.0",
   "usage": "Usage: usage <COMMAND>\n       usage --completions <COMPLETIONS>\n       usage --usage-spec",
   "complete": {},
   "source_code_link_template": "{%- set path = path | replace(from='-', to='_') -%}\n{%- if cmd.subcommands | length > 0 -%}\n{%- set path = path ~ \"/mod.rs\" -%}\n{%- elif path in [\"bash\", \"fish\", \"powershell\", \"zsh\"] -%}\n{%- set path = \"shell.rs\" -%}\n{%- else -%}\n{%- set path = path ~ \".rs\" -%}\n{%- endif -%}\nhttps://github.com/jdx/usage/blob/main/cli/src/cli/{{path}}",

--- a/docs/cli/reference/index.md
+++ b/docs/cli/reference/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `usage [--completions <COMPLETIONS>] [--usage-spec] <SUBCOMMAND>`
 
-**Version**: 6.0.0
+**Version**: 6.1.0
 
 **Repository**: https://github.com/jdx/usage
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-lib"
 edition = "2021"
-version = "6.0.0"
+version = "6.1.0"
 rust-version = "1.95"
 include = [
     "/Cargo.toml",

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-test"
 description = "Test helpers for CLIs built with usage"
-version = "6.0.0"
+version = "6.1.0"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }

--- a/usage-rs/Cargo.toml
+++ b/usage-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-rs"
 description = "A compiled CLI parser for Rust, built on usage specs"
-version = "6.0.0"
+version = "6.1.0"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }

--- a/usage-rs/tests/fixtures/runtime-identity/Cargo.lock
+++ b/usage-rs/tests/fixtures/runtime-identity/Cargo.lock
@@ -39,11 +39,11 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "usage-argv"
-version = "6.0.0"
+version = "6.1.0"
 
 [[package]]
 name = "usage-derive"
-version = "6.0.0"
+version = "6.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "usage-rs"
-version = "6.0.0"
+version = "6.1.0"
 dependencies = [
  "usage-argv",
  "usage-derive",

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-validation"
 description = "Portable expression validation for usage specs"
-version = "6.0.0"
+version = "6.1.0"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }


### PR DESCRIPTION
### 🚀 Features

- **(cli)** read settings under a prefix mise does not strip by [@JamBalaya56562](https://github.com/JamBalaya56562) in [#1213](https://github.com/jdx/usage/pull/1213)
- **(derive)** dispatch more of the matches CLIs already write by [@jdx](https://github.com/jdx) in [#1221](https://github.com/jdx/usage/pull/1221)
- **(spec)** apply runtime identity and flatten headings in help by [@jdx](https://github.com/jdx) in [#1220](https://github.com/jdx/usage/pull/1220)

### 🐛 Bug Fixes

- **(derive)** flow long help and emit kdl raw multiline strings by [@jdx](https://github.com/jdx) in [#1215](https://github.com/jdx/usage/pull/1215)

### 📚 Documentation

- **(rust)** drop the restated one-declaration line from the intro by [@jdx](https://github.com/jdx) in [#1211](https://github.com/jdx/usage/pull/1211)
- **(spec)** complete KDL reference by [@jdx](https://github.com/jdx) in [#1214](https://github.com/jdx/usage/pull/1214)