### PR TITLE
chore(ci): drop the perf compare gate override

### DIFF
--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -124,17 +124,15 @@ jobs:
       # captured, the comment is posted either way, and a later step re-raises
       # it — so a regression always arrives with the table that explains it.
       #
-      # Raw multiline KDL in cli/usage.usage.kdl costs ~5.75% more to parse than
-      # escaped newlines on the same content (PR #1215; startup +0.07%). That is a
-      # measured step-change in the committed spec, not a parser regression. Allow
-      # it here until merge records the new floor in refs/notes/tak; tak.toml keeps
-      # the default 1% gate for local runs and post-baseline pull requests.
+      # No `--gate-pct` here. The threshold belongs to tak's default and tak.toml,
+      # where a local run reads the same number this does. A flag on this line
+      # outranks both and, once added, keeps loosening every later pull request.
       - name: Compare against the base
         env:
           BASE_SHA: ${{ steps.base.outputs.sha }}
         run: |
           set +e
-          tak compare --gate-pct 6 "$BASE_SHA" > /tmp/tak-report.md
+          tak compare "$BASE_SHA" > /tmp/tak-report.md
           echo $? > /tmp/tak-gate-status
           set -e
           cat /tmp/tak-report.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,27 @@ complete "input" run="find . -name '*.txt'"
 - Shell integration tests require bash, zsh, fish, and pwsh installed
 - Run `cargo insta test --accept` to update snapshots
 
+## Performance Gate
+
+`perf-pr` compares instruction counts against the merge base and fails when one
+rises beyond the gate. It is a signal, not a blocking check: it exists so a
+regression is noticed by the person who caused it, and a red perf check is never
+by itself a reason to change how the check works.
+
+Never loosen, disable, or route around the gate to make a pull request pass. That
+means no `--gate-pct` on the `tak compare` line in `.github/workflows/perf-pr.yml`,
+no raising `gate.pct` in `tak.toml`, no dropping a benchmark, and no
+`continue-on-error` on the compare or gate steps. The same rule applies to any
+other check whose purpose is to tell a human something: don't neuter the check to
+get a green square.
+
+When a change genuinely costs instructions, measure it, say so in the pull request
+with the numbers, and **ask the user** how to proceed. Let them decide between
+absorbing the cost, optimizing, or adjusting the gate themselves. This applies
+generally: whenever the fix under consideration is more invasive than the problem —
+bypassing a check, weakening a test, deleting an assertion, widening a lint
+allowance — stop and ask instead of doing it.
+
 ## Key Dependencies
 
 - `kdl`: KDL parser for spec files

--- a/docs/rust/performance.md
+++ b/docs/rust/performance.md
@@ -142,10 +142,10 @@ a small CLI, and `#[usage(spec_endpoint = false)]` removes it.
 - This measures routing and parsing, not process startup, configuration loading,
   command execution, help rendering, or completion generation.
 - The `markdown` benchmark reads `cli/usage.usage.kdl`, which is a committed spec
-  in the same dialect `usage g` emits. When that file switched from escaped newlines
-  to KDL raw multiline strings for flowed long help, the benchmark rose ~5.75% with
-  byte-identical output — parse cost only. `perf-pr.yml` carries a temporary compare
-  allowance until merge updates `refs/notes/tak`; `tak.toml` keeps the default 1% gate.
+  in the same dialect `usage g` emits. Changing how that spec is written moves the
+  benchmark even when the generated markdown is byte-identical: switching escaped
+  newlines to KDL raw multiline strings for flowed long help cost ~5.75% in parsing
+  alone.
 - The mise fixture changes over time, both by growing and by being refreshed
   from mise's current command tree, so one commit's count is not directly
   comparable with another's. CI protects the absolute instruction target, and

--- a/tak.toml
+++ b/tak.toml
@@ -7,15 +7,6 @@
 #
 # `--version` is deliberately absent. It measures clap rather than usage.
 
-# Checked-in specs now emit flowed long_help as KDL raw multiline strings (`#"""`)
-# instead of escaped `\n` lines. Parsing that form costs more retired instructions
-# on the same bytes: +5.75% on the markdown benchmark (270.7M → 286.2M instructions,
-# startup +0.07%), measured on PR #1215. The generated markdown is unchanged; this
-# is the honest cost of the readable committed spec `usage g markdown` is meant to
-# exercise, not a renderer regression. `.github/workflows/perf-pr.yml` carries a
-# temporary compare allowance until merge updates `refs/notes/tak`; `gate.pct` here
-# stays at the default 1%.
-
 # The fixed cost of any invocation. Reading the generators against this
 # separates "usage got slower to start" from "generation got slower".
 [bench.startup]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Removes `--gate-pct 6` from the `tak compare` step in `.github/workflows/perf-pr.yml`, along with the `tak.toml` and `docs/rust/performance.md` notes that described it as a temporary allowance. The measured cost of writing the committed spec in raw multiline KDL stays documented as a property of the `markdown` benchmark, without the allowance language.

Adds a `## Performance Gate` section to `AGENTS.md`: never loosen, disable, or route around the perf gate to make a pull request pass, and ask the user instead — the gate is a signal for a human, not a blocking check. The rule generalizes to any fix more invasive than the problem (bypassing a check, weakening a test, deleting an assertion, widening a lint allowance).

## Why

Flagged in [#1215 (review comment)](https://github.com/jdx/usage/pull/1215#discussion_r3836863820): a CLI flag outranks `tak.toml`, so nothing removed the 6% allowance after merge recorded the new floor, and every later pull request was silently gated at 6% instead of 1%. The one-time +5.75% parse step is now part of main's baseline, so the default gate is correct again.

## Tests

Ran the perf-pr steps locally on this branch against the merge base (`600c228`, current main), with valgrind installed and no gate flag:

```
| benchmark | trend | instructions | Δ | wall (min) | Δ |
|---|---|---:|---:|---:|---:|
| markdown | `▁█` | 286,118,984 → 286,160,430 | **+0.01%** | 30.83 → 31.29ms | +1.47% |
| startup | `█▁` | 844,608 → 843,779 | **-0.10%** | 0.79 → 0.88ms | +10.27% |

No instruction-count regression above 1%.
```

`tak compare` exited 0, so the default 1% gate passes against post-#1215 main — the step change is in the baseline, not in each pull request.

Also checked: `actionlint` clean, `prettier --check .` clean, and `tak.toml` / `perf-pr.yml` still parse.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a535e6d-612b-4220-9a55-90a2c8cf337c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a535e6d-612b-4220-9a55-90a2c8cf337c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Performance comparisons now use the standard configured threshold while preserving existing baseline and reporting behavior.
  - Documented that raw multiline formatting in KDL specifications can increase parsing time by approximately 5.75%, even when generated Markdown is unchanged.

- **Documentation**
  - Added guidance for interpreting performance-gate results and reporting genuine regressions.
  - Removed outdated benchmark commentary and temporary workflow allowances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->