### PR TITLE
feat(spec): apply runtime identity and flatten headings in help

### DIFF
--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -373,12 +373,15 @@ fn help_structure(
             }
         })
         .collect();
-    if own.iter().any(|flag| flag.help_heading.is_none()) {
+    if own
+        .iter()
+        .any(|flag| flag_help_heading(meta, flag).is_none())
+    {
         headings.push("Flags".to_string());
     }
     headings.extend(
         own.iter()
-            .filter_map(|flag| flag.help_heading)
+            .filter_map(|flag| flag_help_heading(meta, flag))
             .map(str::to_string),
     );
     if !inherited.is_empty() {
@@ -1038,7 +1041,7 @@ fn short_help_with(
         &mut sections.flags,
         "Flags",
         own.iter().copied(),
-        |f| f.help_heading,
+        |f| flag_help_heading(meta, f),
         |out, f| short_entry(out, f, column_usage(f)),
     );
     // After the command's own, and under a heading that says where they came from: `--config`
@@ -1311,12 +1314,41 @@ fn flat_commands_short(out: &mut String, path: &[&str], meta: &CommandMeta<'_>) 
     }
 }
 
+/// The section a flag appears under: its own heading, else the flatten site's
+/// `next_help_heading` when this flag arrived through that group.
+fn flag_help_heading<'a>(meta: &'a CommandMeta<'a>, flag: &'a FlagMeta<'a>) -> Option<&'a str> {
+    flag.help_heading
+        .or_else(|| flatten_site_heading(meta.flatten_groups, flag))
+}
+
+fn flatten_site_heading<'a>(
+    groups: &'a [crate::spec::FlattenGroup<'a>],
+    flag: &FlagMeta<'_>,
+) -> Option<&'a str> {
+    for group in groups {
+        if group
+            .meta
+            .flags
+            .iter()
+            .any(|candidate| core::ptr::eq(candidate.flag, flag.flag))
+        {
+            return group
+                .help_heading
+                .or_else(|| flatten_site_heading(group.meta.flatten_groups, flag));
+        }
+        if let Some(heading) = flatten_site_heading(group.meta.flatten_groups, flag) {
+            return Some(heading);
+        }
+    }
+    None
+}
+
 /// One section per heading, unheaded first, in the order the headings first appear.
 fn groups_section<'m, T: 'm>(
     out: &mut String,
     default_title: &str,
     items: impl Iterator<Item = &'m T> + Clone,
-    heading_of: impl Fn(&T) -> Option<&'m str>,
+    heading_of: impl Fn(&T) -> Option<&str>,
     mut write_item: impl FnMut(&mut String, &T),
 ) {
     // Headings in first-seen order, with the unheaded group before them. Collected rather
@@ -1665,7 +1697,7 @@ fn long_help_with(
         &mut sections.flags,
         "Flags",
         own.iter().copied(),
-        |f| f.help_heading,
+        |f| flag_help_heading(meta, f),
         |out, f| {
             let text = f.long_help.or(f.help);
             entry(

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -923,6 +923,12 @@ pub struct FlattenGroup<'a> {
     /// The flagset's body comes from here rather than from the parent's slice, so a struct
     /// that flattens another can be written as a set that `use`s a set.
     pub meta: &'a CommandMeta<'a>,
+    /// Heading for this group's unheaded flags, from `next_help_heading` on the flatten site.
+    ///
+    /// A field that already names a heading keeps it. This is clap's
+    /// `#[command(flatten, next_help_heading = "…")]`: the section is declared where the
+    /// group is mounted, not on every field inside it.
+    pub help_heading: Option<&'a str>,
 }
 
 /// What a flag knows about itself beyond how it parses.
@@ -1563,6 +1569,14 @@ impl<'a> Flagsets<'a> {
     }
 
     fn record(&mut self, group: &'a FlattenGroup<'a>) {
+        if group.help_heading.is_some() {
+            // A flatten-site heading is per mount, so this run cannot be a shared
+            // `flagset`. Nested sets that have no heading of their own still can.
+            for nested in group.meta.flatten_groups {
+                self.record(nested);
+            }
+            return;
+        }
         if let Some(entry) = self.entries.iter_mut().find(|e| e.name == group.name) {
             if same_group(entry.meta, group.meta) {
                 // The same struct again, whose own sets were recorded the first time.
@@ -1635,6 +1649,16 @@ fn write_flag_layout(
     depth: usize,
     sets: &Flagsets<'_>,
 ) -> core::fmt::Result {
+    write_flag_layout_with(out, meta, depth, sets, None)
+}
+
+fn write_flag_layout_with(
+    out: &mut String,
+    meta: &CommandMeta<'_>,
+    depth: usize,
+    sets: &Flagsets<'_>,
+    inherited_heading: Option<&str>,
+) -> core::fmt::Result {
     let mut i = 0;
     while i < meta.flags.len() {
         // A group that contributed no flags has no run to stand for, and matching it would
@@ -1644,13 +1668,23 @@ fn write_flag_layout(
             .iter()
             .find(|g| g.start == i && !g.meta.flags.is_empty());
         match group {
-            Some(group) if sets.covers(group) => {
+            Some(group)
+                if sets.covers(group)
+                    && group.help_heading.is_none()
+                    && inherited_heading.is_none() =>
+            {
                 indent(out, depth)?;
                 writeln!(out, "use {}", quoted(group.name))?;
                 i += group.meta.flags.len();
             }
             Some(group) => {
-                write_flag_layout(out, group.meta, depth, sets)?;
+                write_flag_layout_with(
+                    out,
+                    group.meta,
+                    depth,
+                    sets,
+                    group.help_heading.or(inherited_heading),
+                )?;
                 i += group.meta.flags.len();
             }
             None => {
@@ -1663,7 +1697,7 @@ fn write_flag_layout(
                         .is_some_and(|f| core::ptr::eq(*f, meta.flags[i].flag)),
                     "flag metadata is out of step with the parse table"
                 );
-                write_flag(out, &meta.flags[i], depth)?;
+                write_flag(out, &meta.flags[i], depth, inherited_heading)?;
                 i += 1;
             }
         }
@@ -2001,7 +2035,12 @@ fn write_completers(
     Ok(())
 }
 
-fn write_flag(out: &mut String, meta: &FlagMeta<'_>, depth: usize) -> core::fmt::Result {
+fn write_flag(
+    out: &mut String,
+    meta: &FlagMeta<'_>,
+    depth: usize,
+    inherited_heading: Option<&str>,
+) -> core::fmt::Result {
     indent(out, depth)?;
     write!(out, "flag {}", quoted(&flag_forms(meta)))?;
 
@@ -2066,7 +2105,7 @@ fn write_flag(out: &mut String, meta: &FlagMeta<'_>, depth: usize) -> core::fmt:
         // name, since that is what a token is matched against.
         write!(out, " negate={}", quoted(&format!("--{negate}")))?;
     }
-    if let Some(heading) = meta.help_heading {
+    if let Some(heading) = meta.help_heading.or(inherited_heading) {
         write!(out, " help_heading={}", quoted(heading))?;
     }
     if let Some(order) = meta.display_order {

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -1683,7 +1683,7 @@ fn write_flag_layout_with(
                     group.meta,
                     depth,
                     sets,
-                    group.help_heading.or(inherited_heading),
+                    inherited_heading.or(group.help_heading),
                 )?;
                 i += group.meta.flags.len();
             }

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -1141,6 +1141,32 @@ pub fn emit(cli: &Cli) -> TokenStream {
 
                 #runtime_app
 
+                /// Render a help page using this CLI's process identity.
+                ///
+                /// [`Self::spec`] keeps the portable `name_spec` / `bin_spec` literals.
+                /// `parse()` already evaluates computed `name` / `bin` when it prints help;
+                /// this is the same overlay for a `parse_from` caller that handles
+                /// [`usage_argv::Error::Help`] itself.
+                pub fn render_help(
+                    cmd: &usage_argv::Command<'_>,
+                    long: bool,
+                ) -> ::std::option::Option<::std::string::String> {
+                    #effective_spec
+                    usage_argv::help::render(__usage_spec, cmd, long)
+                }
+
+                /// Render a parse failure using this CLI's process identity.
+                ///
+                /// The counterpart of [`Self::render_help`] for every error that is not a
+                /// help or version request. `parse()` uses the same overlay on stderr.
+                pub fn render_failure<'v>(
+                    argv: &[&'v ::std::ffi::OsStr],
+                    error: &usage_argv::Error<'static, 'v>,
+                ) -> ::std::string::String {
+                    #effective_spec
+                    usage_argv::render_failure(__usage_spec, argv, error)
+                }
+
                 /// This CLI's spec as KDL, which is what `usage g markdown|manpage`
                 /// and the completion generators read.
                 pub fn to_kdl() -> ::std::string::String {
@@ -1607,7 +1633,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
 /// above it, so there is no path to rewrite.
 fn flatten_checks(cli: &Cli) -> TokenStream {
     let shape_checks = cli.fields.iter().filter_map(|f| {
-        let Kind::Flatten { ty } = &f.kind else {
+        let Kind::Flatten { ty, .. } = &f.kind else {
             return None;
         };
         Some(quote! {
@@ -2849,7 +2875,7 @@ fn tables(cli: &Cli) -> Tables {
                 own_args.push(arg_at);
                 arg_at += 1;
             }
-            Kind::Flatten { ty } => {
+            Kind::Flatten { ty, help_heading } => {
                 flattened = true;
                 if own_since_flatten > 0 {
                     flag_offset.push(quote!(#own_since_flatten));
@@ -2857,11 +2883,13 @@ fn tables(cli: &Cli) -> Tables {
                 }
                 let name = flagset_name(ty);
                 let terms = flag_offset.iter();
+                let help_heading = option_str(help_heading.as_deref());
                 flatten_groups.push(quote! {
                     usage_argv::spec::FlattenGroup {
                         name: #name,
                         start: 0 #(+ #terms)*,
                         meta: <#ty as usage_argv::spec::CommandArgs>::META,
+                        help_heading: #help_heading,
                     }
                 });
                 flag_offset
@@ -3483,7 +3511,7 @@ fn displacements(cli: &Cli, field: &Field) -> Vec<TokenStream> {
         .filter(|selector| cli.field_for_selector(selector).is_none())
     {
         for flattened in &cli.fields {
-            let Kind::Flatten { ty } = &flattened.kind else {
+            let Kind::Flatten { ty, .. } = &flattened.kind else {
                 continue;
             };
             let ident = &flattened.ident;
@@ -3696,7 +3724,7 @@ fn presence_methods(cli: &Cli) -> TokenStream {
         })
     });
     let flattened_given = cli.fields.iter().filter_map(|field| {
-        let Kind::Flatten { ty } = &field.kind else {
+        let Kind::Flatten { ty, .. } = &field.kind else {
             return None;
         };
         let ident = &field.ident;
@@ -3745,7 +3773,7 @@ fn presence_methods(cli: &Cli) -> TokenStream {
         })
     });
     let flattened_exclusive = cli.fields.iter().filter_map(|field| {
-        let Kind::Flatten { ty } = &field.kind else {
+        let Kind::Flatten { ty, .. } = &field.kind else {
             return None;
         };
         let ident = &field.ident;
@@ -3877,7 +3905,7 @@ fn argument_lookup_functions(cli: &Cli) -> TokenStream {
         })
     });
     let state_flattened = cli.fields.iter().filter_map(|field| {
-        let Kind::Flatten { ty } = &field.kind else {
+        let Kind::Flatten { ty, .. } = &field.kind else {
             return None;
         };
         let ident = &field.ident;
@@ -3933,7 +3961,7 @@ fn argument_lookup_functions(cli: &Cli) -> TokenStream {
         Some(quote!(#(#selectors)|* => return ::std::option::Option::Some(#given && #matches),))
     });
     let match_flattened = cli.fields.iter().filter_map(|field| {
-        let Kind::Flatten { ty } = &field.kind else {
+        let Kind::Flatten { ty, .. } = &field.kind else {
             return None;
         };
         let ident = &field.ident;
@@ -3980,7 +4008,7 @@ fn argument_lookup_functions(cli: &Cli) -> TokenStream {
         })
     });
     let displace_flattened = cli.fields.iter().filter_map(|field| {
-        let Kind::Flatten { ty } = &field.kind else {
+        let Kind::Flatten { ty, .. } = &field.kind else {
             return None;
         };
         let ident = &field.ident;
@@ -4023,7 +4051,7 @@ fn argument_lookup_functions(cli: &Cli) -> TokenStream {
         }
     });
     let event_flattened = cli.fields.iter().filter_map(|field| {
-        let Kind::Flatten { ty } = &field.kind else {
+        let Kind::Flatten { ty, .. } = &field.kind else {
             return None;
         };
         Some(quote! {
@@ -4123,7 +4151,7 @@ fn partial_struct(cli: &Cli) -> TokenStream {
         }
         // A flattened struct accumulates into its own partial, whose shape only its derive
         // knows — reached through the trait, like everything else about it.
-        if let Kind::Flatten { ty } = &f.kind {
+        if let Kind::Flatten { ty, .. } = &f.kind {
             let ident = &f.ident;
             return Some(quote! {
                 pub #ident: <#ty as usage_argv::spec::CommandArgs>::Partial,
@@ -4324,7 +4352,7 @@ fn children(cli: &Cli) -> Vec<(TokenStream, TokenStream)> {
         .filter_map(|field| {
             let ident = &field.ident;
             match &field.kind {
-                Kind::Flatten { ty } => Some((
+                Kind::Flatten { ty, .. } => Some((
                     quote!(<#ty as usage_argv::spec::CommandArgs>::SETTINGS_BINDINGS),
                     quote! {
                         <#ty as usage_argv::spec::CommandArgs>::settings_given(
@@ -4504,7 +4532,7 @@ fn partial_defaults(cli: &Cli) -> TokenStream {
         }
         // `start()` rather than `Default`, so the flattened struct's own defaults are in
         // place before parsing — the same reason this function exists at all.
-        if let Kind::Flatten { ty } = &f.kind {
+        if let Kind::Flatten { ty, .. } = &f.kind {
             let ident = &f.ident;
             return Some(quote! {
                 #ident: <#ty as usage_argv::spec::CommandArgs>::start(),
@@ -4589,7 +4617,7 @@ fn field_value(field: &Field, omitter: Option<&TokenStream>) -> TokenStream {
         // clap's skip: not parsed, filled from Default when the struct is built.
         return quote!(::std::default::Default::default());
     }
-    if let Kind::Flatten { ty } = &field.kind {
+    if let Kind::Flatten { ty, .. } = &field.kind {
         // Built by its own derive, which is also what makes a nested flatten work: this is
         // the same call at every level.
         return match omitter {
@@ -4945,7 +4973,7 @@ fn merge_fn(cli: &Cli) -> TokenStream {
         match &field.kind {
             // Not parsed, so this command line said nothing about it.
             Kind::Skip => None,
-            Kind::Flatten { ty } => Some(quote! {
+            Kind::Flatten { ty, .. } => Some(quote! {
                 <#ty as usage_argv::spec::CommandArgs>::merge(
                     partial.#field_ident,
                     &mut __usage_standing.#field_ident,
@@ -5031,7 +5059,7 @@ fn merge_fn(cli: &Cli) -> TokenStream {
 /// boundary on an update.
 fn any_standing_fn(cli: &Cli) -> TokenStream {
     let held = cli.fields.iter().filter_map(|field| {
-        if let Kind::Flatten { ty } = &field.kind {
+        if let Kind::Flatten { ty, .. } = &field.kind {
             let ident = &field.ident;
             return Some(quote! {
                 if let ::std::option::Option::Some(__usage_name) =
@@ -5262,7 +5290,7 @@ fn apply_fn(cli: &Cli) -> TokenStream {
         .fields
         .iter()
         .filter_map(|f| {
-            let Kind::Flatten { ty } = &f.kind else {
+            let Kind::Flatten { ty, .. } = &f.kind else {
                 return None;
             };
             Some(opaque_apply_arm(
@@ -5289,7 +5317,7 @@ fn apply_fn(cli: &Cli) -> TokenStream {
         })
         .collect();
     let mirrored_flattened = cli.fields.iter().filter_map(|f| {
-        let Kind::Flatten { ty } = &f.kind else {
+        let Kind::Flatten { ty, .. } = &f.kind else {
             return None;
         };
         let ident = &f.ident;
@@ -5823,7 +5851,7 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
         .fields
         .iter()
         .filter_map(|field| match &field.kind {
-            Kind::Flatten { ty } => {
+            Kind::Flatten { ty, .. } => {
                 Some(quote!(#ty: usage_argv::spec::ViewCommandArgs<__UsageOmitter>))
             }
             Kind::Subcommand { ty, .. } => {
@@ -5911,7 +5939,7 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
         })
         .unwrap_or_default();
     let omit_flattened = cli.fields.iter().filter_map(|field| {
-        let Kind::Flatten { ty } = &field.kind else {
+        let Kind::Flatten { ty, .. } = &field.kind else {
             return None;
         };
         let ident = &field.ident;
@@ -7796,7 +7824,7 @@ fn group_meta_table(cli: &Cli) -> (TokenStream, TokenStream) {
     let mut emitted = vec![false; entries.len()];
     let mut any_flattened = false;
     for (i, field) in cli.fields.iter().enumerate() {
-        let Kind::Flatten { ty } = &field.kind else {
+        let Kind::Flatten { ty, .. } = &field.kind else {
             continue;
         };
         any_flattened = true;
@@ -7900,7 +7928,7 @@ fn declared_defaults(cli: &Cli, filter_view: bool) -> TokenStream {
         })
     });
     let flattened = cli.fields.iter().filter_map(|f| {
-        let Kind::Flatten { ty } = &f.kind else {
+        let Kind::Flatten { ty, .. } = &f.kind else {
             return None;
         };
         let ident = &f.ident;
@@ -8053,7 +8081,7 @@ fn env_fallbacks(cli: &Cli, filter_view: bool) -> TokenStream {
         })
     });
     let flattened = cli.fields.iter().filter_map(|f| {
-        let Kind::Flatten { ty } = &f.kind else {
+        let Kind::Flatten { ty, .. } = &f.kind else {
             return None;
         };
         let ident = &f.ident;
@@ -8188,7 +8216,7 @@ fn deprecations_fn(cli: &Cli) -> TokenStream {
         })
     });
     let flattened = cli.fields.iter().filter_map(|f| {
-        let Kind::Flatten { ty } = &f.kind else {
+        let Kind::Flatten { ty, .. } = &f.kind else {
             return None;
         };
         let ident = &f.ident;
@@ -8370,7 +8398,7 @@ fn post_binding(cli: &Cli) -> TokenStream {
         Some(policy_given(field))
     });
     let flattened_exclusive_present = cli.fields.iter().filter_map(|field| {
-        let Kind::Flatten { ty } = &field.kind else {
+        let Kind::Flatten { ty, .. } = &field.kind else {
             return None;
         };
         let ident = &field.ident;
@@ -8406,7 +8434,7 @@ fn post_binding(cli: &Cli) -> TokenStream {
     // there is no "in declaration order" to offer — a flattened group's errors interleave with
     // this command's by kind, not by where the field was written.
     let flattened_checks = cli.fields.iter().filter_map(|f| {
-        let Kind::Flatten { ty } = &f.kind else {
+        let Kind::Flatten { ty, .. } = &f.kind else {
             return None;
         };
         let ident = &f.ident;
@@ -8947,7 +8975,7 @@ fn post_binding(cli: &Cli) -> TokenStream {
         let ident = &field.ident;
         let standing = standing_ident(field);
         match &field.kind {
-            Kind::Flatten { ty } => Some(quote! {
+            Kind::Flatten { ty, .. } => Some(quote! {
                 (
                     <#ty as usage_argv::spec::CommandArgs>::any_given(&partial.#ident)
                         .or_else(|| {

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -607,6 +607,9 @@ pub enum Kind {
     Flatten {
         /// The struct's type, as written.
         ty: syn::Type,
+        /// Heading applied to unheaded fields this flatten contributes, clap's
+        /// `next_help_heading` on the flatten site.
+        help_heading: Option<String>,
     },
     /// Holds the enum whose variants are one group of this command's exclusive flags.
     ///
@@ -1961,30 +1964,41 @@ impl Field {
         span: proc_macro2::Span,
     ) -> syn::Result<Option<Self>> {
         let mut found = false;
+        let mut help_heading = None;
         for attr in attrs(&field.attrs) {
             for meta in nested(attr)? {
-                if ident_of(&meta.path().clone()) != "flatten" {
-                    continue;
+                let name = ident_of(&meta.path().clone());
+                match name.as_str() {
+                    "flatten" => {
+                        if !matches!(meta, Meta::Path(_)) {
+                            return Err(syn::Error::new_spanned(
+                                meta.path(),
+                                "`flatten` takes no value: the struct it holds is the field's type",
+                            ));
+                        }
+                        found = true;
+                    }
+                    "next_help_heading" | "help_heading" => {
+                        help_heading = Some(string_value(&meta)?);
+                    }
+                    _ => {}
                 }
-                if !matches!(meta, Meta::Path(_)) {
-                    return Err(syn::Error::new_spanned(
-                        meta.path(),
-                        "`flatten` takes no value: the struct it holds is the field's type",
-                    ));
-                }
-                found = true;
             }
         }
         if !found {
             return Ok(None);
         }
 
-        // Nothing else may be declared beside it. `#[usage(flatten, long)]` reads as though
-        // the flattening were also a flag, and there is no such thing.
+        // A flatten is a seam, not a flag. `next_help_heading` / `help_heading` name the
+        // section its unheaded fields appear under; everything else belongs on the
+        // flattened struct's own fields.
         for attr in attrs(&field.attrs) {
             for meta in nested(attr)? {
                 let name = ident_of(&meta.path().clone());
-                if name != "flatten" {
+                if !matches!(
+                    name.as_str(),
+                    "flatten" | "next_help_heading" | "help_heading"
+                ) {
                     return Err(syn::Error::new_spanned(
                         meta.path(),
                         format!(
@@ -2014,6 +2028,7 @@ impl Field {
             value_optional: false,
             kind: Kind::Flatten {
                 ty: field.ty.clone(),
+                help_heading,
             },
             // Neither holds a flag of its own, so neither has an effect to declare: a
             // flattened group's flags carry their own, and a subcommand field is a command's

--- a/docs/rust/help.md
+++ b/docs/rust/help.md
@@ -18,23 +18,28 @@ request comes back as an _error_, because a parse that stopped to print help has
 value (clap models it the same way):
 
 ```rust
-use usage::{help, Error};
+use usage::Error;
 
 match Ex::parse_from(&argv) {
     Ok(cli) => run(cli),
     Err(Error::Help { cmd, long }) => {
-        print!("{}", help::render(Ex::spec(), cmd, long).unwrap());
+        print!("{}", Ex::render_help(cmd, long).unwrap());
     }
     Err(Error::Version { long }) => {
         let version = if long { LONG_VERSION } else { env!("CARGO_PKG_VERSION") };
         println!("ex {version}");
     }
     Err(err) => {
-        eprint!("{}", usage::render_failure(Ex::spec(), &argv, &err));
+        eprint!("{}", Ex::render_failure(&argv, &err));
         std::process::exit(2);
     }
 }
 ```
+
+`Ex::render_help` and `Ex::render_failure` apply computed `name` / `bin` the same way `parse()`
+does. `help::render(Ex::spec(), …)` and `usage::render_failure(Ex::spec(), …)` keep the portable
+`name_spec` / `bin_spec` literals, which is what generated docs want and not what an embedded
+binary should print.
 
 `Error` is `#[non_exhaustive]` — always keep a fallback arm.
 

--- a/docs/rust/migrating-from-clap.md
+++ b/docs/rust/migrating-from-clap.md
@@ -218,7 +218,8 @@ clap tests usually include argv0. Choose the matching entry point explicitly:
 
 `parse_from` is the allocation-free primitive. `parse_from_argv` also applies multicall basename
 routing. Handle `usage::Error::Help` and `usage::Error::Version` before dispatch when an embedder
-must intercept those built-ins.
+must intercept those built-ins. Render those with `Cli::render_help` and `Cli::render_failure` so
+computed `name` / `bin` appear in the page; `Cli::spec()` is the portable identity.
 
 `update_from` and `try_update_from` carry clap's names but state their merge rules explicitly,
 because a parse cannot be run backwards to seed itself from a value: a standing field satisfies a

--- a/docs/rust/spec.md
+++ b/docs/rust/spec.md
@@ -172,6 +172,10 @@ computed version, while `version_spec` remains the static value exported to KDL.
 not currently apply the computed version. For a caller that already has different identity
 values, `Cli::app().name(...).bin(...).version(...)` provides the split explicitly.
 
+`Cli::render_help` and `Cli::render_failure` are the same overlay for a `parse_from` caller that
+handles help and diagnostics itself instead of using `parse()`. `help::render(Cli::spec(), …)`
+keeps the portable literals.
+
 ## What the parser does with the spec
 
 Nothing, at runtime. The derive compiles your declaration into static tables that usage-argv

--- a/docs/rust/subcommands.md
+++ b/docs/rust/subcommands.md
@@ -164,7 +164,9 @@ struct Config {
 
 The tables are joined at compile time, so the parser walks one flat slice and `flatten` costs
 nothing at run time. Groups and `exclusive` flags declared on the flattened struct are enforced
-(and emitted) on the command that flattens them.
+(and emitted) on the command that flattens them. `#[usage(flatten, next_help_heading = "Network")]`
+puts that struct's unheaded flags under a help section at the mount site; a field that already
+names `help_heading` keeps it.
 
 The emitted KDL says the declarations are shared, rather than repeating them under each command:
 the struct becomes a [`flagset`](/spec/reference/flagset) named after it, and every command that

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -1301,6 +1301,29 @@ struct SiteHeadedFlatten {
 
 #[derive(Args)]
 #[allow(dead_code)]
+struct NestedInnerHeadingArgs {
+    /// Registry URL.
+    #[arg(long)]
+    nested_registry: Option<String>,
+}
+
+#[derive(Args)]
+#[allow(dead_code)]
+struct NestedHeadingArgs {
+    #[usage(flatten, next_help_heading = "Inner")]
+    inner: NestedInnerHeadingArgs,
+}
+
+#[derive(Cli)]
+#[usage(bin = "nested-site-headed-flatten")]
+#[allow(dead_code)]
+struct NestedSiteHeadedFlatten {
+    #[usage(flatten, next_help_heading = "Outer")]
+    nested: NestedHeadingArgs,
+}
+
+#[derive(Args)]
+#[allow(dead_code)]
 struct SiteInstall {
     /// Force reinstall.
     #[arg(long)]
@@ -2151,6 +2174,27 @@ fn flatten_site_next_help_heading_groups_unheaded_fields() {
         !kdl.contains("flagset"),
         "a per-mount heading cannot share a flagset: {kdl}"
     );
+}
+
+#[test]
+fn outer_flatten_site_heading_wins_in_help_and_emitted_kdl() {
+    let spec = NestedSiteHeadedFlatten::spec();
+    for long in [false, true] {
+        let help = usage::help::render(spec, spec.root.cmd, long).unwrap();
+        assert!(help.contains("Outer:"), "{help}");
+        assert!(!help.contains("Inner:"), "{help}");
+        assert!(help.contains("--nested-registry"), "{help}");
+    }
+
+    let kdl = NestedSiteHeadedFlatten::to_kdl();
+    let reparsed: usage_parser::Spec = kdl.parse().expect("the emitted spec parses");
+    let registry = reparsed
+        .cmd
+        .flags
+        .iter()
+        .find(|flag| flag.name == "nested-registry")
+        .expect("nested flattened flag");
+    assert_eq!(registry.help_heading.as_deref(), Some("Outer"), "{kdl}");
 }
 
 #[test]

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -1282,6 +1282,57 @@ struct HeadedFlatten {
 
 #[derive(Args)]
 #[allow(dead_code)]
+struct BareNetworkArgs {
+    /// Registry URL.
+    #[arg(long)]
+    registry: Option<String>,
+}
+
+#[derive(Cli)]
+#[usage(bin = "site-headed-flatten")]
+#[allow(dead_code)]
+struct SiteHeadedFlatten {
+    /// Ordinary root flag.
+    #[arg(long)]
+    verbose: bool,
+    #[usage(flatten, next_help_heading = "Network")]
+    network: BareNetworkArgs,
+}
+
+#[derive(Args)]
+#[allow(dead_code)]
+struct SiteInstall {
+    /// Force reinstall.
+    #[arg(long)]
+    force: bool,
+    #[usage(flatten, next_help_heading = "Lockfile")]
+    lockfile: BareLockfileArgs,
+}
+
+#[derive(Args)]
+#[allow(dead_code)]
+struct BareLockfileArgs {
+    /// Error if the lockfile drifts.
+    #[arg(long)]
+    frozen_lockfile: bool,
+}
+
+#[derive(Subcommands)]
+#[allow(dead_code)]
+enum SiteCommands {
+    Install(SiteInstall),
+}
+
+#[derive(Cli)]
+#[usage(bin = "site-headed-cmd")]
+#[allow(dead_code)]
+struct SiteHeadedCmd {
+    #[usage(subcommand)]
+    command: SiteCommands,
+}
+
+#[derive(Args)]
+#[allow(dead_code)]
 struct FlattenedRepeatPolicy {
     #[arg(long)]
     jobs: Option<u32>,
@@ -1460,6 +1511,20 @@ struct SharedNestedCli {
 const DEFAULT_RUNS: u32 = 7;
 const DYNAMIC_ABOUT: &str = "Metadata from a Rust constant.";
 const DYNAMIC_AFTER_HELP: &str = "More details from a Rust constant.";
+
+fn hosted_program() -> &'static str {
+    "hosted-ex"
+}
+
+#[derive(Cli)]
+#[usage(
+    name = hosted_program(),
+    name_spec = "portable-hosted",
+    bin = hosted_program(),
+    bin_spec = "portable-hosted",
+    unknown_flags = "error"
+)]
+struct HostedEx;
 
 fn computed_version() -> &'static str {
     "1.2.3+runtime"
@@ -2056,6 +2121,56 @@ fn flattened_args_keep_their_help_heading_topology() {
 }
 
 #[test]
+fn flatten_site_next_help_heading_groups_unheaded_fields() {
+    let spec = SiteHeadedFlatten::spec();
+    let registry = spec
+        .root
+        .flags
+        .iter()
+        .find(|field| field.flag.name == "registry")
+        .unwrap();
+    assert_eq!(
+        registry.help_heading, None,
+        "the heading lives on the flatten site, not the field"
+    );
+
+    for long in [false, true] {
+        let help = usage::help::render(spec, spec.root.cmd, long).unwrap();
+        let flags = help.find("Flags:").unwrap();
+        let network = help.find("Network:").unwrap();
+        assert!(flags < network, "{help}");
+        assert!(help.contains("--registry"), "{help}");
+    }
+
+    let kdl = SiteHeadedFlatten::to_kdl();
+    assert!(
+        kdl.contains("help_heading=Network") || kdl.contains("help_heading=\"Network\""),
+        "flatten-site headings must reach emitted KDL: {kdl}"
+    );
+    assert!(
+        !kdl.contains("flagset"),
+        "a per-mount heading cannot share a flagset: {kdl}"
+    );
+}
+
+#[test]
+fn flatten_site_headings_reach_subcommand_help() {
+    let spec = SiteHeadedCmd::spec();
+    let install = spec
+        .root
+        .subcommands
+        .iter()
+        .find(|cmd| cmd.cmd.name == "install")
+        .unwrap();
+    for long in [false, true] {
+        let help = usage::help::render(spec, install.cmd, long).unwrap();
+        assert!(help.contains("Lockfile:"), "{help}");
+        assert!(help.contains("--frozen-lockfile"), "{help}");
+        assert!(help.contains("Flags:"), "{help}");
+    }
+}
+
+#[test]
 fn a_parent_repeat_policy_applies_through_flattening() {
     assert!(
         StrictFlatten::parse_from(&[
@@ -2502,6 +2617,36 @@ fn runtime_program_identity_is_separate_from_the_portable_spec() {
     let script = RuntimeIdentityEx::completion_script(usage::complete::Shell::Bash);
     assert!(script.contains("runtime-ex"), "{script}");
     assert!(!script.contains("'portable-ex'"), "{script}");
+}
+
+#[test]
+fn parse_from_help_helpers_use_runtime_identity() {
+    let portable = HostedEx::spec();
+    assert_eq!(portable.name, "portable-hosted");
+    assert_eq!(portable.bin, Some("portable-hosted"));
+
+    let from_spec = usage::help::render(portable, HostedEx::command(), true).unwrap();
+    assert!(
+        from_spec.contains("Usage: portable-hosted"),
+        "Cli::spec() is the portable identity: {from_spec}"
+    );
+
+    let from_helper = HostedEx::render_help(HostedEx::command(), true).unwrap();
+    assert!(
+        from_helper.contains("Usage: hosted-ex"),
+        "render_help evaluates computed name/bin: {from_helper}"
+    );
+    assert!(!from_helper.contains("portable-hosted"), "{from_helper}");
+
+    let err = match HostedEx::parse_from(&[OsStr::new("--nope")]) {
+        Err(err) => err,
+        Ok(_) => panic!("unknown flags are errors"),
+    };
+    let failure = HostedEx::render_failure(&[OsStr::new("--nope")], &err);
+    assert!(
+        failure.contains("Usage: hosted-ex"),
+        "render_failure evaluates computed name/bin: {failure}"
+    );
 }
 
 /// A CLI whose declarations have all four shapes of deprecation on them.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Fleet clap-swap notes called out two help gaps: flattened clap help headings, and parser help/diagnostics that kept the portable `aube` identity instead of the embedder’s computed name.

`parse()` already overlays computed `name` / `bin`. `parse_from` callers that rendered `Cli::spec()` did not. Flattened `Args` structs that set `next_help_heading` already worked; clap’s **flatten-site** `next_help_heading` did not.

## What

- `Cli::render_help` and `Cli::render_failure` apply the same runtime identity `parse()` uses
- `#[usage(flatten, next_help_heading = "…")]` groups unheaded flags in help and KDL (including on subcommands)
- Docs for `parse_from` now point at those helpers instead of `Cli::spec()`

## Tests

- `parse_from_help_helpers_use_runtime_identity`
- `flatten_site_next_help_heading_groups_unheaded_fields`
- `flatten_site_headings_reach_subcommand_help`
- existing `flattened_args_keep_their_help_heading_topology`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f814bb1b-8d72-440d-b7c8-bd84d8d2c9f4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f814bb1b-8d72-440d-b7c8-bd84d8d2c9f4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for assigning help headings to flattened flags, including nested flatten groups.
  * Added helpers for rendering help and parse failures using the CLI’s runtime identity.
* **Documentation**
  * Documented flattened flag heading behavior and the new rendering helpers.
  * Clarified guidance for handling built-in help and version errors.
* **Tests**
  * Added coverage for heading inheritance, runtime identity, and help/error rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->