### PR TITLE
feat(derive): dispatch more of the matches CLIs already write

### DIFF
--- a/conformance/tests/dispatch.rs
+++ b/conformance/tests/dispatch.rs
@@ -230,3 +230,186 @@ fn dispatch_says_nothing_in_the_spec() {
     assert!(kdl.contains("cmd config"), "{kdl}");
     assert!(!kdl.contains("run"), "{kdl}");
 }
+
+/// A unit variant and an inline variant still have a type to implement `Run` on: the derive
+/// writes `{Enum}{Variant}` for them.
+#[derive(Subcommands)]
+#[usage(run)]
+enum Shape {
+    /// Greet
+    Hi,
+    /// Add a path
+    Add { path: String },
+}
+
+impl Run for ShapeHi {
+    type Output = String;
+    fn run(self) -> Self::Output {
+        "hi".to_string()
+    }
+}
+
+impl Run for ShapeAdd {
+    type Output = String;
+    fn run(self) -> Self::Output {
+        self.path
+    }
+}
+
+/// A tool whose commands are declared inline
+#[derive(Cli)]
+#[usage(bin = "shape", run)]
+struct ShapeCli {
+    /// Print more
+    #[usage(short = 'v', long)]
+    verbose: bool,
+    #[usage(subcommand)]
+    command: Shape,
+}
+
+#[test]
+fn a_unit_variant_dispatches_through_the_struct_written_for_it() {
+    let argv = [OsStr::new("hi")];
+    let cli = ShapeCli::parse_from(&argv).expect("valid command line");
+    assert!(!cli.verbose);
+    assert_eq!(cli.run_command(), "hi");
+}
+
+#[test]
+fn an_inline_variant_dispatches_through_the_struct_written_for_it() {
+    let argv = [OsStr::new("add"), OsStr::new("src")];
+    let cli = ShapeCli::parse_from(&argv).expect("valid command line");
+    assert_eq!(cli.run_command(), "src");
+}
+
+#[test]
+fn a_root_with_flags_reads_them_then_run_command() {
+    let argv = [OsStr::new("--verbose"), OsStr::new("hi")];
+    let cli = ShapeCli::parse_from(&argv).expect("valid command line");
+    assert!(cli.verbose);
+    assert_eq!(cli.run_command(), "hi");
+}
+
+fn fallback(argv: Vec<String>) -> String {
+    format!("ext {}", argv.join(" "))
+}
+
+/// Ping
+#[derive(Args)]
+struct Ping;
+
+impl Run for Ping {
+    type Output = String;
+    fn run(self) -> Self::Output {
+        "pong".to_string()
+    }
+}
+
+#[derive(Subcommands)]
+#[usage(run, external = fallback, output = String)]
+enum Catch {
+    /// Ping
+    Ping(Ping),
+    #[usage(external_subcommand)]
+    Other(Vec<String>),
+}
+
+/// A tool with a catch-all
+#[derive(Cli)]
+#[usage(bin = "catch")]
+struct CatchCli {
+    #[usage(subcommand)]
+    command: Catch,
+}
+
+#[test]
+fn an_external_subcommand_calls_the_named_fallback() {
+    let ping = [OsStr::new("ping")];
+    let cli = CatchCli::parse_from(&ping).expect("valid command line");
+    assert_eq!(cli.command.run(), "pong");
+
+    let extra = [OsStr::new("git"), OsStr::new("status")];
+    let cli = CatchCli::parse_from(&extra).expect("valid command line");
+    assert_eq!(cli.command.run(), "ext git status");
+}
+
+/// Show the version
+#[derive(Args)]
+struct Version;
+
+/// Get a value
+#[derive(Args)]
+struct Get {
+    /// What to get
+    key: String,
+}
+
+impl Run for Version {
+    type Output = String;
+    fn run(self) -> Self::Output {
+        "1".to_string()
+    }
+}
+
+impl RunWith<&str> for Get {
+    type Output = String;
+    fn run_with(self, ctx: &str) -> Self::Output {
+        format!("{ctx}:{}", self.key)
+    }
+}
+
+#[derive(Subcommands)]
+#[usage(run_with)]
+enum MixedCtx {
+    /// Show the version
+    #[usage(no_ctx)]
+    Version(Version),
+    /// Get a value
+    Get(Get),
+}
+
+/// A tool that loads context only for some commands
+#[derive(Cli)]
+#[usage(bin = "mixed-ctx")]
+struct MixedCtxCli {
+    #[usage(subcommand)]
+    command: MixedCtx,
+}
+
+#[test]
+fn a_command_can_skip_the_context_the_rest_of_the_enum_takes() {
+    let argv = [OsStr::new("version")];
+    let cli = MixedCtxCli::parse_from(&argv).expect("valid command line");
+    assert_eq!(cli.command.run_with("loaded"), "1");
+
+    let argv = [OsStr::new("get"), OsStr::new("k")];
+    let cli = MixedCtxCli::parse_from(&argv).expect("valid command line");
+    assert_eq!(cli.command.run_with("loaded"), "loaded:k");
+}
+
+#[test]
+fn a_skipped_context_is_not_built_when_loaded_lazily() {
+    let argv = [OsStr::new("version")];
+    let cli = MixedCtxCli::parse_from(&argv).expect("valid command line");
+    let mut built = false;
+    assert_eq!(
+        cli.command.run_with_lazy(|| {
+            built = true;
+            "loaded"
+        }),
+        "1"
+    );
+    assert!(!built);
+
+    let argv = [OsStr::new("get"), OsStr::new("k")];
+    let cli = MixedCtxCli::parse_from(&argv).expect("valid command line");
+    built = false;
+    assert_eq!(
+        cli.command.run_with_lazy(|| {
+            built = true;
+            "loaded"
+        }),
+        "loaded:k"
+    );
+    assert!(built);
+}

--- a/conformance/tests/dispatch.rs
+++ b/conformance/tests/dispatch.rs
@@ -282,6 +282,39 @@ fn an_inline_variant_dispatches_through_the_struct_written_for_it() {
     assert_eq!(cli.run_command(), "src");
 }
 
+mod separate_inline_module {
+    use usage_derive::{Cli, Subcommands};
+
+    #[derive(Subcommands)]
+    #[usage(run)]
+    pub enum Command {
+        /// Print one value
+        Print { value: String },
+    }
+
+    /// A tool whose inline command is implemented outside this module
+    #[derive(Cli)]
+    #[usage(bin = "separate-inline")]
+    pub struct App {
+        #[usage(subcommand)]
+        pub command: Command,
+    }
+}
+
+impl Run for separate_inline_module::CommandPrint {
+    type Output = String;
+    fn run(self) -> Self::Output {
+        self.value
+    }
+}
+
+#[test]
+fn generated_inline_fields_are_public_for_out_of_module_dispatch() {
+    let argv = [OsStr::new("print"), OsStr::new("visible")];
+    let cli = separate_inline_module::App::parse_from(&argv).expect("valid command line");
+    assert_eq!(cli.command.run(), "visible");
+}
+
 #[test]
 fn a_root_with_flags_reads_them_then_run_command() {
     let argv = [OsStr::new("--verbose"), OsStr::new("hi")];

--- a/conformance/tests/dispatch_async.rs
+++ b/conformance/tests/dispatch_async.rs
@@ -284,6 +284,58 @@ fn async_dispatch_says_nothing_in_the_spec() {
     assert!(!kdl.contains("run"), "{kdl}");
 }
 
+/// Print immediately
+#[derive(Args)]
+struct Immediate;
+
+/// Fetch something
+#[derive(Args)]
+struct Fetch;
+
+impl Run for Immediate {
+    type Output = String;
+    fn run(self) -> Self::Output {
+        "now".to_string()
+    }
+}
+
+impl RunAsync for Fetch {
+    type Output = String;
+    async fn run_async(self) -> Self::Output {
+        yield_once().await;
+        "later".to_string()
+    }
+}
+
+#[derive(Subcommands)]
+#[usage(run_async)]
+enum Mix {
+    /// Print immediately
+    #[usage(run)]
+    Immediate(Immediate),
+    /// Fetch something
+    Fetch(Fetch),
+}
+
+/// A tool with mixed sync and async commands
+#[derive(Cli)]
+#[usage(bin = "mix")]
+struct MixCli {
+    #[usage(subcommand)]
+    command: Mix,
+}
+
+#[test]
+fn an_async_enum_can_still_run_a_synchronous_command() {
+    let argv = [OsStr::new("immediate")];
+    let cli = MixCli::parse_from(&argv).expect("valid command line");
+    assert_eq!(block_on(cli.command.run_async()), "now");
+
+    let argv = [OsStr::new("fetch")];
+    let cli = MixCli::parse_from(&argv).expect("valid command line");
+    assert_eq!(block_on(cli.command.run_async()), "later");
+}
+
 /// The smallest executor that proves these are real futures: no runtime dependency in the
 /// conformance crate, and a command that yields is resumed rather than run to completion on
 /// the first poll.

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -18,7 +18,8 @@ use quote::{format_ident, quote};
 use crate::crate_name::{crate_name, FoundCrate};
 use crate::model::{
     rendered_path, to_kebab, type_name, ArgGroup, ArgGroupMember, Cli, ConditionalDefault,
-    Dispatch, DoubleDash, ExampleDecl, Field, Kind, Shape, Subcommands, ValueEnum, ViewDecl,
+    Dispatch, DoubleDash, ExampleDecl, Field, Kind, Shape, Subcommands, ValueEnum, Variant,
+    ViewDecl,
 };
 
 /// Construct the user's command type after its generated partial has been checked.
@@ -6525,6 +6526,207 @@ impl DispatchTrait {
     }
 }
 
+/// Which trait one variant actually implements, which may differ from the enum's.
+///
+/// A `#[usage(run)]` variant in an async enum is synchronous; `#[usage(no_ctx)]` skips
+/// the context the rest of the match is handed. The generated arm and its bound both
+/// read this so they cannot disagree.
+fn arm_kind(kind: &DispatchTrait, v: &Variant) -> DispatchTrait {
+    let is_async = kind.is_async && !v.run_sync;
+    let ctx = kind.ctx && !v.no_ctx;
+    match (is_async, ctx) {
+        (false, false) => DispatchTrait {
+            wanted: true,
+            name: "Run",
+            method: "run",
+            ctx: false,
+            is_async: false,
+        },
+        (false, true) => DispatchTrait {
+            wanted: true,
+            name: "RunWith",
+            method: "run_with",
+            ctx: true,
+            is_async: false,
+        },
+        (true, false) => DispatchTrait {
+            wanted: true,
+            name: "RunAsync",
+            method: "run_async",
+            ctx: false,
+            is_async: true,
+        },
+        (true, true) => DispatchTrait {
+            wanted: true,
+            name: "RunAsyncWith",
+            method: "run_async_with",
+            ctx: true,
+            is_async: true,
+        },
+    }
+}
+
+fn first_command(subs: &Subcommands) -> Option<&Variant> {
+    subs.variants.iter().find(|v| !v.external)
+}
+
+fn dispatch_output_ty(subs: &Subcommands, kind: &DispatchTrait) -> TokenStream {
+    if let Some(ty) = &subs.dispatch_output {
+        return quote!(#ty);
+    }
+    let first = first_command(subs).expect("a dispatched enum names a command");
+    let ty = &first.ty;
+    let of = arm_kind(kind, first).as_of(&quote!(#ty));
+    quote!(#of::Output)
+}
+
+fn dispatch_pat(enum_ident: &syn::Ident, v: &Variant) -> TokenStream {
+    let variant = &v.ident;
+    if v.unit {
+        quote!(#enum_ident::#variant)
+    } else if let Some(fields) = &v.inline_fields {
+        let bindings = fields.iter().map(|field| {
+            let name = field
+                .ident
+                .as_ref()
+                .expect("named variant fields have names");
+            let cfg_attrs = field
+                .attrs
+                .iter()
+                .filter(|attr| meta_controls_field_presence(&attr.meta));
+            quote! { #(#cfg_attrs)* #name }
+        });
+        quote!(#enum_ident::#variant { #(#bindings),* })
+    } else {
+        quote!(#enum_ident::#variant(__usage_inner))
+    }
+}
+
+fn dispatch_value(v: &Variant) -> TokenStream {
+    if v.unit {
+        let ty = &v.ty;
+        quote!(#ty {})
+    } else if let Some(fields) = &v.inline_fields {
+        let ty = &v.ty;
+        let bindings = fields.iter().map(|field| {
+            let name = field
+                .ident
+                .as_ref()
+                .expect("named variant fields have names");
+            let cfg_attrs = field
+                .attrs
+                .iter()
+                .filter(|attr| meta_controls_field_presence(&attr.meta));
+            quote! { #(#cfg_attrs)* #name }
+        });
+        quote!(#ty { #(#bindings),* })
+    } else if v.boxed {
+        quote!(*__usage_inner)
+    } else {
+        quote!(__usage_inner)
+    }
+}
+
+fn dispatch_arm_call(
+    kind: &DispatchTrait,
+    v: &Variant,
+    ident: &syn::Ident,
+    external: Option<&syn::Path>,
+) -> TokenStream {
+    let pat = dispatch_pat(ident, v);
+    let value = dispatch_value(v);
+    let call = if v.external {
+        let path = external.expect("external variants name a function");
+        let call = if kind.ctx {
+            quote!(#path(#value, __usage_ctx))
+        } else {
+            quote!(#path(#value))
+        };
+        if kind.is_async {
+            quote!(#call.await)
+        } else {
+            call
+        }
+    } else {
+        let arm = arm_kind(kind, v);
+        let mut call = arm.call(value);
+        if kind.ctx && !arm.ctx {
+            call = quote! {{
+                let _ = __usage_ctx;
+                #call
+            }};
+        }
+        call
+    };
+    quote!(#pat => #call,)
+}
+
+fn variant_bound(
+    kind: &DispatchTrait,
+    v: &Variant,
+    i: usize,
+    first_non_external: usize,
+    output: &TokenStream,
+    named_output: bool,
+) -> Option<TokenStream> {
+    if v.external {
+        return None;
+    }
+    let ty = &v.ty;
+    let arm = arm_kind(kind, v);
+    if named_output || i != first_non_external {
+        let bound = arm.path_with_output(output);
+        Some(quote!(#ty: #bound))
+    } else {
+        let path = arm.path();
+        Some(quote!(#ty: #path))
+    }
+}
+
+fn lazy_arm_call(
+    kind: &DispatchTrait,
+    v: &Variant,
+    ident: &syn::Ident,
+    external: Option<&syn::Path>,
+) -> TokenStream {
+    let pat = dispatch_pat(ident, v);
+    let value = dispatch_value(v);
+    let arm = arm_kind(kind, v);
+    let call = if v.external {
+        let path = external.expect("external variants name a function");
+        let invoked = if kind.ctx {
+            quote!(#path(#value, __usage_load()))
+        } else {
+            quote! {{
+                let _ = __usage_load;
+                #path(#value)
+            }}
+        };
+        if kind.is_async {
+            quote!(#invoked.await)
+        } else {
+            invoked
+        }
+    } else if arm.ctx {
+        let name = format_ident!("{}", arm.name);
+        let method = format_ident!("{}", arm.method);
+        let invoked = quote!(usage_argv::#name::<__UsageCtx>::#method(#value, __usage_load()));
+        if arm.is_async {
+            quote!(#invoked.await)
+        } else {
+            invoked
+        }
+    } else {
+        let mut call = arm.call(value);
+        call = quote! {{
+            let _ = __usage_load;
+            #call
+        }};
+        call
+    };
+    quote!(#pat => #call,)
+}
+
 /// The dispatch a `#[usage(run)]` enum gets: the `match` every CLI writes by hand.
 ///
 /// One arm per variant, handing the command's own struct to the trait that carries it out.
@@ -6532,20 +6734,21 @@ impl DispatchTrait {
 /// command is not part of what the CLI *is*, and a spec recording it could be read by nothing
 /// but this program. `#[usage(skip)]` follows the same rule.
 ///
-/// The output type is the first variant's, and every other variant is required to agree —
-/// stated as a bound naming that variant's type, so a command returning something else is
-/// reported on the command rather than inside a generated arm. Both bounds are written as
-/// `where` clauses rather than checked here, which is also what lets the enum be declared
-/// before the implementations it dispatches to exist.
+/// The output type is the first command's, unless the enum names it, and every other variant
+/// is required to agree — stated as a bound naming that variant's type, so a command returning
+/// something else is reported on the command rather than inside a generated arm. Both bounds
+/// are written as `where` clauses rather than checked here, which is also what lets the enum
+/// be declared before the implementations it dispatches to exist.
 fn emit_subcommands_dispatch(subs: &Subcommands, runtime: &TokenStream) -> TokenStream {
     if !subs.dispatch.any() {
         return TokenStream::new();
     }
     let ident = &subs.ident;
-    // Checked in `Subcommands::from_input`: a dispatched enum has variants, and each holds a
-    // named struct rather than nothing or its fields inline.
-    let first_ty = &subs.variants[0].ty;
-    let first = quote!(#first_ty);
+    let external = subs.dispatch_external.as_ref();
+    let named_output = subs.dispatch_output.is_some();
+    let first_non_external = subs.variants.iter().position(|v| !v.external).unwrap_or(0);
+    let wants_lazy = subs.variants.iter().any(|v| v.no_ctx)
+        && (subs.dispatch.run_with || subs.dispatch.run_async_with);
 
     let impls = DispatchTrait::all(subs.dispatch)
         .into_iter()
@@ -6554,37 +6757,57 @@ fn emit_subcommands_dispatch(subs: &Subcommands, runtime: &TokenStream) -> Token
             let generics = kind.impl_generics();
             let path = kind.path();
             let signature = kind.signature();
-            let output = kind.as_of(&first);
-            let bounds = subs.variants.iter().enumerate().map(|(i, v)| {
-                let ty = &v.ty;
-                if i == 0 {
-                    let path = kind.path();
-                    quote!(#ty: #path)
-                } else {
-                    let bound = kind.path_with_output(&quote!(#output::Output));
-                    quote!(#ty: #bound)
-                }
+            let output = dispatch_output_ty(subs, &kind);
+            let bounds = subs.variants.iter().enumerate().filter_map(|(i, v)| {
+                variant_bound(&kind, v, i, first_non_external, &output, named_output)
             });
-            // `*inner` is the one place a `Box` shows: the box is how the variant holds the
-            // struct, and the struct is what implements the trait.
-            let arms = subs.variants.iter().map(|v| {
-                let variant = &v.ident;
-                let inner = if v.boxed {
-                    quote!(*__usage_inner)
-                } else {
-                    quote!(__usage_inner)
-                };
-                let call = kind.call(inner);
-                quote!(#ident::#variant(__usage_inner) => #call,)
-            });
+            let arms = subs
+                .variants
+                .iter()
+                .map(|v| dispatch_arm_call(&kind, v, ident, external));
             quote! {
                 #generics #path for #ident
                 where
                     #(#bounds,)*
                 {
-                    type Output = #output::Output;
+                    type Output = #output;
 
                     #signature {
+                        match self {
+                            #(#arms)*
+                        }
+                    }
+                }
+            }
+        });
+
+    let lazy = DispatchTrait::all(subs.dispatch)
+        .into_iter()
+        .filter(|kind| kind.wanted && kind.ctx && wants_lazy)
+        .map(|kind| {
+            let output = dispatch_output_ty(subs, &kind);
+            let arms = subs
+                .variants
+                .iter()
+                .map(|v| lazy_arm_call(&kind, v, ident, external));
+            let (name, asyncness) = if kind.is_async {
+                (format_ident!("run_async_with_lazy"), quote!(async))
+            } else {
+                (format_ident!("run_with_lazy"), TokenStream::new())
+            };
+            let bounds = subs.variants.iter().enumerate().filter_map(|(i, v)| {
+                variant_bound(&kind, v, i, first_non_external, &output, named_output)
+            });
+            quote! {
+                impl #ident {
+                    pub #asyncness fn #name<__UsageCtx, __UsageLoad>(
+                        self,
+                        __usage_load: __UsageLoad,
+                    ) -> #output
+                    where
+                        __UsageLoad: ::core::ops::FnOnce() -> __UsageCtx,
+                        #(#bounds,)*
+                    {
                         match self {
                             #(#arms)*
                         }
@@ -6599,23 +6822,21 @@ fn emit_subcommands_dispatch(subs: &Subcommands, runtime: &TokenStream) -> Token
             use #runtime as usage_argv;
 
             #(#impls)*
+            #(#lazy)*
         };
     }
 }
 
 /// The dispatch a `#[usage(run)]` struct gets: a forward to its subcommands.
 ///
-/// The `config`-style group that has no work of its own — declared as a struct holding
-/// nothing but its subcommand field, which is what [`Cli::check`](crate::model::Cli::check)
-/// holds it to, since forwarding is all this can do and a struct with arguments of its own has
-/// to decide what becomes of them.
+/// A container that holds only that field implements the trait. A root that also
+/// declares flags gets `run_command`, which moves the subcommand out and leaves the
+/// flags for whoever parsed them.
 fn emit_command_dispatch(cli: &Cli, runtime: &TokenStream) -> TokenStream {
     if !cli.dispatch.any() {
         return TokenStream::new();
     }
     let ident = &cli.ident;
-    // Checked in `Cli::check`: a struct asking for a dispatch holds exactly one field, and it
-    // is a non-optional subcommand.
     let Some((field, held_ty)) = cli.fields.iter().find_map(|field| match &field.kind {
         Kind::Subcommand {
             ty,
@@ -6626,6 +6847,59 @@ fn emit_command_dispatch(cli: &Cli, runtime: &TokenStream) -> TokenStream {
         return TokenStream::new();
     };
     let held_ty = quote!(#held_ty);
+    let extras = cli.fields.iter().any(|field| {
+        !matches!(
+            field.kind,
+            Kind::Subcommand {
+                optional: false,
+                ..
+            }
+        )
+    });
+
+    if extras {
+        let methods = DispatchTrait::all(cli.dispatch)
+            .into_iter()
+            .filter(|kind| kind.wanted)
+            .map(|kind| {
+                let held = kind.as_of(&held_ty);
+                let output = quote!(#held::Output);
+                let value = quote!(#field);
+                let call = kind.call(value);
+                let name = if kind.is_async && kind.ctx {
+                    format_ident!("run_command_async_with")
+                } else if kind.is_async {
+                    format_ident!("run_command_async")
+                } else if kind.ctx {
+                    format_ident!("run_command_with")
+                } else {
+                    format_ident!("run_command")
+                };
+                let asyncness = kind.is_async.then(|| quote!(async));
+                let generics = kind.ctx.then(|| quote!(<__UsageCtx>));
+                let ctx_arg = kind.ctx.then(|| quote!(, __usage_ctx: __UsageCtx));
+                let path = kind.path();
+                quote! {
+                    pub #asyncness fn #name #generics(self #ctx_arg) -> #output
+                    where
+                        #held_ty: #path,
+                    {
+                        let Self { #field, .. } = self;
+                        #call
+                    }
+                }
+            });
+        return quote! {
+            #[doc(hidden)]
+            const _: () = {
+                use #runtime as usage_argv;
+
+                impl #ident {
+                    #(#methods)*
+                }
+            };
+        };
+    }
 
     let impls = DispatchTrait::all(cli.dispatch)
         .into_iter()
@@ -6690,8 +6964,20 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
                     .collect();
                 field
             });
+            let hidden = quote!(#name).to_string().contains("__Usage");
+            let doc = if hidden {
+                quote!(#[doc(hidden)])
+            } else {
+                let variant = v.ident.to_string();
+                let enum_name = ident.to_string();
+                let doc = format!(
+                    "Parsed arguments for `{enum_name}::{variant}`. Implement `usage::Run` \
+                     (or the context / async pair) on this type."
+                );
+                quote!(#[doc = #doc])
+            };
             quote! {
-                #[doc(hidden)]
+                #doc
                 #[derive(#derive::Args)]
                 #effect
                 pub struct #name {

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -6956,15 +6956,18 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
                 .effect
                 .as_ref()
                 .map(|word| quote!(#[usage(effect = #word)]));
+            let hidden = quote!(#name).to_string().contains("__Usage");
             let fields = v.inline_fields.iter().flatten().cloned().map(|mut field| {
                 field.attrs = field
                     .attrs
                     .into_iter()
                     .filter_map(inline_field_attr)
                     .collect();
+                if !hidden {
+                    field.vis = syn::parse_quote!(pub);
+                }
                 field
             });
-            let hidden = quote!(#name).to_string().contains("__Usage");
             let doc = if hidden {
                 quote!(#[doc(hidden)])
             } else {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -148,12 +148,14 @@
 //! bound imposed either way. An enum may say several.
 //!
 //! The output type is the first variant's, and each of the others is required to agree, so a
-//! command returning something else is reported on the command. A `#[usage(run)]` *struct* gets
-//! a forward to its own subcommands, which is all it can get: it holds one field, its
-//! subcommands and not in an `Option`, since anything else would mean dropping what the struct
-//! declared or deciding what no command means. A variant holding nothing, holding its fields
-//! inline, or holding an `external_subcommand`'s argv cannot be dispatched — there is no type to
-//! implement the trait for — and says so where it is declared.
+//! command returning something else is reported on the command. A `#[usage(run)]` *struct* that
+//! holds only its subcommands implements the trait as a forward; a root that also declares
+//! flags gets `run_command`, which moves the subcommand out and leaves the flags for the
+//! caller. A variant that holds nothing or its fields inline is dispatched through the
+//! `{Enum}{Variant}` struct the derive writes for it. An `external_subcommand` is dispatched
+//! by `external = fallback` on the enum. A command that should not wait when the rest of the
+//! enum does says `#[usage(run)]` on the variant; one that should not take the context says
+//! `#[usage(no_ctx)]`.
 //!
 //! Nothing about any of this reaches the spec, the parse tables, or help: which Rust function
 //! carries out a command is not part of what the CLI *is*. `#[usage(skip)]` follows the same

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -1581,51 +1581,47 @@ impl Cli {
             }
         }
 
-        // What `run` on a *struct* can generate is a forwarder to its subcommands, and only
-        // that: a struct that declares arguments of its own has to decide what to do with
-        // them, and a generated `run` that quietly dropped them would be a wrong program
-        // rather than a missing one. So the attribute belongs on a container — the
-        // `config`-style group that is nothing but its subcommand field — and every other
-        // shape says so where it is written, next to the alternative, which is to implement
-        // the trait by hand.
+        // What `run` on a *struct* can generate is a forwarder to its subcommands. A
+        // container that holds only that field implements the trait; a root that also
+        // declares flags gets `run_command`, which moves the subcommand out and leaves the
+        // flags for the caller. An `Option` subcommand still has a state — no command at
+        // all — that nothing generated can decide, so that shape implements the trait by
+        // hand.
         if self.dispatch.any() {
             let span = self.attr_span.unwrap_or_else(Span::call_site);
-            // Quoted back rather than hardcoded, so an author who wrote `run_async_with` is not
-            // told about `run`.
             let (attr, dispatch_trait) = self.dispatch.named();
-            match self.fields.iter().find(|field| {
-                !matches!(
+            let required_sub = self.fields.iter().any(|field| {
+                matches!(
                     field.kind,
                     Kind::Subcommand {
                         optional: false,
                         ..
                     }
                 )
-            }) {
-                Some(field) => {
-                    return Err(syn::Error::new(
-                        field.span,
+            });
+            if !required_sub {
+                let optional = self
+                    .fields
+                    .iter()
+                    .any(|field| matches!(field.kind, Kind::Subcommand { optional: true, .. }));
+                return Err(syn::Error::new(
+                    span,
+                    if optional {
                         format!(
                             "`{attr}` on a struct forwards to its subcommands and can do \
-                             nothing else, so the struct holds one field: its subcommands, not \
-                             in an `Option`. A command that has arguments of its own — or that \
-                             decides what no subcommand means — implements `{dispatch_trait}` \
-                             itself, and forwarding to the field is what this would have written"
-                        ),
-                    ));
-                }
-                None if self.fields.is_empty() => {
-                    return Err(syn::Error::new(
-                        span,
+                             nothing else, so the subcommand is not in an `Option`. A command \
+                             that decides what no subcommand means implements `{dispatch_trait}` \
+                             itself"
+                        )
+                    } else {
                         format!(
                             "`{attr}` on a struct forwards to its subcommands, and this struct \
                              has none. A command that does the work itself implements \
                              `{dispatch_trait}` for it: that is the point the generated dispatch \
                              calls"
-                        ),
-                    ));
-                }
-                None => {}
+                        )
+                    },
+                ));
             }
         }
 
@@ -4898,6 +4894,11 @@ pub struct Subcommands {
     /// for it is also what makes a variant that cannot be dispatched an error where it is
     /// declared rather than a missing implementation somewhere else.
     pub dispatch: Dispatch,
+    /// The `Output` every arm has to produce, when the enum names it rather than taking it
+    /// from the first command.
+    pub dispatch_output: Option<syn::Type>,
+    /// Called with the unmatched argv of an `external_subcommand` variant.
+    pub dispatch_external: Option<syn::Path>,
 }
 
 /// Which of the four dispatches a command or a command set asked the derive to write.
@@ -4941,16 +4942,26 @@ impl Dispatch {
 ///
 /// The enum's name is in it because two enums in one module may each declare a `Sponsors`, and
 /// two structs of one name is a worse error than the one this is avoiding.
-fn unit_struct_ident(enum_ident: &syn::Ident, variant: &syn::Ident) -> syn::Ident {
+///
+/// When the enum is dispatched, the name is `{Enum}{Variant}` — `CommandSponsors` — so the
+/// command can implement `Run` on a type it can spell. Otherwise the struct stays hidden
+/// under a length-prefixed name nothing else should mention: length-prefixed rather than
+/// concatenated, because `Foo::BarBaz` and `FooBar::Baz` both read as `FooBarBaz`, and an
+/// underscore between the parts would land a `non_camel_case_types` warning in the adopter's
+/// crate about a type they never wrote.
+fn unit_struct_ident(
+    enum_ident: &syn::Ident,
+    variant: &syn::Ident,
+    for_dispatch: bool,
+) -> syn::Ident {
     // `unraw` first: a raw identifier prints as `r#type`, and `Ident::new` *panics* on the
     // `#` — a proc-macro panic, which is the worst way for a CLI to learn it used a keyword
     // for a command name.
     let enum_name = enum_ident.unraw();
     let variant_name = variant.unraw();
-    // Length-prefixed rather than separated: plain concatenation is ambiguous — `Foo::BarBaz`
-    // and `FooBar::Baz` both read as `FooBarBaz` — and an underscore between the parts would
-    // land a `non_camel_case_types` warning in the adopter's crate about a type they never
-    // wrote. A count is unambiguous and still spells a name Rust is happy with.
+    if for_dispatch {
+        return syn::Ident::new(&format!("{enum_name}{variant_name}"), variant.span());
+    }
     let n = enum_name.to_string().chars().count();
     syn::Ident::new(
         &format!("__Usage{n}{enum_name}{variant_name}"),
@@ -4991,6 +5002,13 @@ pub struct Variant {
     /// Fields declared directly on a struct-style enum variant. They are copied
     /// into a generated Args struct, then moved back into the enum after binding.
     pub inline_fields: Option<Vec<syn::Field>>,
+    /// `#[usage(run)]` on a variant: this command is synchronous even when the enum awaits.
+    pub run_sync: bool,
+    /// `#[usage(run_async)]` on a variant: this command is awaited. Requires `run_async` on
+    /// the enum.
+    pub run_async: bool,
+    /// `#[usage(no_ctx)]`: this command does not take the context the rest of the enum does.
+    pub no_ctx: bool,
     /// The struct the variant wraps, with any `Box` taken off.
     ///
     /// Everything generated speaks to the struct — its tables, its partial, its `build` —
@@ -5047,6 +5065,8 @@ impl Subcommands {
 
         let mut rename_all = None;
         let mut dispatch = Dispatch::default();
+        let mut dispatch_output = None;
+        let mut dispatch_external = None;
         for attr in attrs(&input.attrs) {
             for meta in nested(attr)? {
                 let path = meta.path().clone();
@@ -5056,13 +5076,24 @@ impl Subcommands {
                     "run_with" => dispatch.run_with = flag_value(&meta)?,
                     "run_async" => dispatch.run_async = flag_value(&meta)?,
                     "run_async_with" => dispatch.run_async_with = flag_value(&meta)?,
+                    "output" => {
+                        let value = &meta.require_name_value()?.value;
+                        dispatch_output =
+                            Some(syn::parse2(quote::ToTokens::to_token_stream(value))?);
+                    }
+                    "external" => {
+                        let value = &meta.require_name_value()?.value;
+                        dispatch_external =
+                            Some(syn::parse2(quote::ToTokens::to_token_stream(value))?);
+                    }
                     other => {
                         return Err(syn::Error::new_spanned(
                             path,
                             format!(
                                 "unknown option `{other}` on a subcommand enum; \
                                  usage::Subcommands takes `rename_all`, `run`, \
-                                 `run_with`, `run_async` and `run_async_with` here"
+                                 `run_with`, `run_async`, `run_async_with`, \
+                                 `output` and `external` here"
                             ),
                         ));
                     }
@@ -5073,7 +5104,7 @@ impl Subcommands {
         let variants = data
             .variants
             .iter()
-            .map(|v| Variant::from_variant(v, &input.ident, rename_all))
+            .map(|v| Variant::from_variant(v, &input.ident, rename_all, dispatch.any()))
             .collect::<syn::Result<Vec<_>>>()?;
         for v in &variants {
             if v.effect.is_some() && !v.unit && v.inline_fields.is_none() {
@@ -5124,54 +5155,95 @@ impl Subcommands {
             // Quoted back rather than hardcoded, so an author who wrote `run_async_with` is not
             // told about `run`.
             let (attr, dispatch_trait) = dispatch.named();
-            // A dispatch is a `match` over the variants, so every variant has to name
-            // something that can run. An `external_subcommand` variant names argv — the words
-            // nothing here claimed — and there is no type to implement the trait for, so the
-            // enum keeps its hand-written match rather than getting a generated one that
-            // cannot be exhaustive.
-            if let Some(external) = variants.iter().find(|v| v.external) {
-                return Err(syn::Error::new_spanned(
-                    &external.ident,
-                    format!(
-                        "`{attr}` generates a match over every variant, and this one holds the \
-                         argv of a command that is not declared here — there is nothing to \
-                         implement `{dispatch_trait}` for. Write the match by hand, or move the \
-                         catch-all out of the dispatched enum"
-                    ),
-                ));
-            }
+            let has_async = dispatch.run_async || dispatch.run_async_with;
+            let has_ctx = dispatch.run_with || dispatch.run_async_with;
             if variants.is_empty() {
                 return Err(syn::Error::new_spanned(
                     &input.ident,
                     format!("`{attr}` generates a match over the variants, and this enum has none"),
                 ));
             }
-            // A dispatched arm hands the command's own value to the trait, so the variant has
-            // to hold a type the CLI can write an implementation for. A bare variant and a
-            // variant declaring its fields inline are both served by a struct this derive
-            // writes for them, under a name nothing else can name — so the command that has
-            // work to do says where that work lives by holding its `Args` struct.
-            if let Some(variant) = variants
-                .iter()
-                .find(|v| v.unit || v.inline_fields.is_some())
-            {
+            // A catch-all holds argv, not a command struct. The generated match calls the
+            // function named here rather than a trait the words could not implement.
+            let externals: Vec<_> = variants.iter().filter(|v| v.external).collect();
+            if let Some(external) = externals.first() {
+                if dispatch_external.is_none() {
+                    return Err(syn::Error::new_spanned(
+                        &external.ident,
+                        format!(
+                            "`{attr}` generates a match over every variant, and this one holds \
+                             the argv of a command that is not declared here — name the function \
+                             that should receive those words: `#[{attr}, external = fallback]`, \
+                             or leave `{attr}` off and write the match by hand"
+                        ),
+                    ));
+                }
+            } else if dispatch_external.is_some() {
                 return Err(syn::Error::new_spanned(
-                    &variant.ident,
+                    &input.ident,
+                    "`external` names the function that receives an `external_subcommand` \
+                     variant's argv, and this enum has no such variant",
+                ));
+            }
+            if dispatch_output.is_none() && variants.iter().all(|v| v.external) {
+                return Err(syn::Error::new_spanned(
+                    &input.ident,
                     format!(
-                        "a dispatched command holds the struct its work is implemented on, and \
-                         this variant holds nothing this crate can name: write \
-                         `#[derive(usage::Args)] struct Sponsors;` and hold it — \
-                         `Sponsors(Sponsors)` — or leave `{attr}` off and write the match by \
-                         hand"
+                        "`{attr}` takes its `Output` from the first command, and every variant \
+                         here is a catch-all — name the type with `output = …`"
                     ),
                 ));
             }
+            if dispatch.run && has_async && variants.iter().any(|v| v.run_sync) {
+                return Err(syn::Error::new_spanned(
+                    &input.ident,
+                    "`run` and `run_async` on one enum generate two methods, and a command \
+                     marked `#[usage(run)]` is only reachable from the async one — leave `run` \
+                     off this enum and call `run_async`",
+                ));
+            }
+            for v in &variants {
+                if v.run_async && !has_async {
+                    return Err(syn::Error::new_spanned(
+                        &v.ident,
+                        format!(
+                            "`run_async` on a variant is awaited by the generated dispatch, so \
+                             the enum has to say `run_async` (or `run_async_with`) too — or \
+                             leave it off `{attr}` and write the match by hand"
+                        ),
+                    ));
+                }
+                if v.no_ctx && !has_ctx {
+                    return Err(syn::Error::new_spanned(
+                        &v.ident,
+                        format!(
+                            "`no_ctx` skips the context `{dispatch_trait}` would have handed \
+                             this command, so the enum has to say `run_with` or `run_async_with`"
+                        ),
+                    ));
+                }
+                if v.external && (v.run_sync || v.run_async || v.no_ctx) {
+                    return Err(syn::Error::new_spanned(
+                        &v.ident,
+                        "an `external_subcommand` is dispatched by the enum's `external = …` \
+                         function, not by `run` / `run_async` / `no_ctx` on the variant",
+                    ));
+                }
+            }
+        } else if dispatch_external.is_some() || dispatch_output.is_some() {
+            return Err(syn::Error::new_spanned(
+                &input.ident,
+                "`output` and `external` belong on a dispatched enum — add `run`, `run_with`, \
+                 `run_async` or `run_async_with`",
+            ));
         }
 
         Ok(Subcommands {
             ident: input.ident.clone(),
             variants,
             dispatch,
+            dispatch_output,
+            dispatch_external,
         })
     }
 }
@@ -5181,6 +5253,7 @@ impl Variant {
         variant: &syn::Variant,
         enum_ident: &syn::Ident,
         rename_all: Option<CasingStyle>,
+        for_dispatch: bool,
     ) -> syn::Result<Self> {
         let mut verbatim_doc_comment = false;
         // `unraw` first: `r#type` is how a variant named after a keyword prints, and a command
@@ -5206,6 +5279,9 @@ impl Variant {
         let mut after_help = None;
         let mut after_long_help = None;
         let mut examples: Vec<ExampleDecl> = Vec::new();
+        let mut run_sync = false;
+        let mut run_async = false;
+        let mut no_ctx = false;
 
         for attr in attrs(&variant.attrs) {
             let clap_attr = attr.path().is_ident("command");
@@ -5244,6 +5320,9 @@ impl Variant {
                     "after_long_help" => after_long_help = Some(metadata_expr(&meta)?),
                     "example" => examples.push(example_decl(&meta)?),
                     "verbatim_doc_comment" => verbatim_doc_comment = flag_value(&meta)?,
+                    "run" => run_sync = flag_value(&meta)?,
+                    "run_async" => run_async = flag_value(&meta)?,
+                    "no_ctx" => no_ctx = flag_value(&meta)?,
                     other => {
                         return Err(syn::Error::new_spanned(
                             path,
@@ -5251,7 +5330,8 @@ impl Variant {
                                 "unknown option `{other}` on a variant; a subcommand \
                                  variant takes `name`, `alias`, `alias_hidden`, `help_heading`, `display_order`, \
                                  `external_subcommand`, `help`, `long_help`, `deprecated`, `deprecated_warn_at`, `deprecated_remove_at`, `before_help`, \
-                                 `before_long_help`, `after_help`, `after_long_help`, `example`, and `verbatim_doc_comment` here, \
+                                 `before_long_help`, `after_help`, `after_long_help`, `example`, `verbatim_doc_comment`, \
+                                 `run`, `run_async`, and `no_ctx` here, \
                                  and its description comes from the doc comment"
                             ),
                         ));
@@ -5361,6 +5441,9 @@ impl Variant {
                 display_order: None,
                 unit: false,
                 inline_fields: None,
+                run_sync,
+                run_async,
+                no_ctx,
                 ty: held,
                 boxed: false,
                 external: true,
@@ -5392,11 +5475,11 @@ impl Variant {
             Fields::Unnamed(unnamed) if unnamed.unnamed.len() == 1 => unnamed.unnamed[0].ty.clone(),
             Fields::Unit => {
                 unit = true;
-                let ident = unit_struct_ident(enum_ident, &variant.ident);
+                let ident = unit_struct_ident(enum_ident, &variant.ident, for_dispatch);
                 syn::parse_quote!(#ident)
             }
             Fields::Named(named) => {
-                let ident = unit_struct_ident(enum_ident, &variant.ident);
+                let ident = unit_struct_ident(enum_ident, &variant.ident, for_dispatch);
                 inline_fields = Some(named.named.iter().cloned().collect());
                 syn::parse_quote!(#ident)
             }
@@ -5431,6 +5514,9 @@ impl Variant {
             effect,
             unit,
             inline_fields,
+            run_sync,
+            run_async,
+            no_ctx,
             ty,
             boxed,
             external: false,
@@ -6010,6 +6096,7 @@ impl ArgGroup {
 #[cfg(test)]
 mod tests {
     use super::{ArgGroup, Cli, DoubleDash, Kind, Shape, Subcommands, ValueEnum};
+    use syn::Type;
 
     fn cli(body: &str) -> syn::Result<Cli> {
         Cli::from_input(&syn::parse_str::<syn::DeriveInput>(body).expect("valid Rust"))
@@ -8835,12 +8922,9 @@ mod tests {
         assert!(cli.dispatch.run_with);
     }
 
-    /// Forwarding is all a generated `run` on a struct can do, so a struct with arguments of
-    /// its own is refused rather than having them dropped on the way past.
     #[test]
-    fn a_dispatched_struct_holds_nothing_but_its_subcommands() {
-        let err = rejection(
-            r#"
+    fn a_dispatched_struct_with_flags_gets_run_command() {
+        let cli = cli(r#"
             #[usage(run)]
             struct Ex {
                 #[usage(long)]
@@ -8848,16 +8932,9 @@ mod tests {
                 #[usage(subcommand)]
                 command: Command,
             }
-        "#,
-        );
-        assert!(
-            err.contains("forwards to its subcommands"),
-            "unhelpful: {err}"
-        );
-        assert!(
-            err.contains("implements `usage::Run` itself"),
-            "unhelpful: {err}"
-        );
+        "#)
+        .expect("a root with flags gets run_command rather than a dropped forward");
+        assert!(cli.dispatch.run);
     }
 
     /// An `Option` has a state — no command at all — that nothing generated can decide what to
@@ -8927,9 +9004,7 @@ mod tests {
         let err = enum_rejection(
             r#"
             #[usage(run_async_with)]
-            enum Command {
-                Sponsors,
-            }
+            enum Command {}
         "#,
         );
         assert!(err.contains("`run_async_with`"), "unhelpful: {err}");
@@ -8938,12 +9013,7 @@ mod tests {
         let struct_err = rejection(
             r#"
             #[usage(run_async)]
-            struct Ex {
-                #[usage(long)]
-                verbose: bool,
-                #[usage(subcommand)]
-                command: Command,
-            }
+            struct Ex;
         "#,
         );
         assert!(
@@ -8956,10 +9026,9 @@ mod tests {
         );
     }
 
-    /// The catch-all holds the argv of a command that is not declared here, so there is no type
-    /// to implement the trait for and no exhaustive match to generate.
+    /// The catch-all holds argv, so the generated match needs a function to hand them to.
     #[test]
-    fn a_dispatched_enum_refuses_an_external_subcommand() {
+    fn a_dispatched_enum_needs_external_to_name_a_function() {
         let err = enum_rejection(
             r#"
             #[usage(run)]
@@ -8970,14 +9039,27 @@ mod tests {
             }
         "#,
         );
-        assert!(err.contains("nothing to implement"), "unhelpful: {err}");
+        assert!(err.contains("external = fallback"), "unhelpful: {err}");
+
+        let ok = subcommands(
+            r#"
+            #[usage(run, external = fallback)]
+            enum Command {
+                Install(Install),
+                #[usage(external_subcommand)]
+                Other(Vec<String>),
+            }
+        "#,
+        )
+        .expect("a named fallback is enough to dispatch a catch-all");
+        assert!(ok.dispatch_external.is_some());
     }
 
-    /// A bare variant's struct is written by the derive, under a name nothing else can name —
-    /// so the command that has work to do holds its own `Args` struct instead.
+    /// A bare or inline variant's struct is written for it under `{Enum}{Variant}` so the
+    /// command can implement `Run` on a type it can spell.
     #[test]
-    fn a_dispatched_enum_refuses_a_variant_that_holds_nothing() {
-        let err = enum_rejection(
+    fn a_dispatched_enum_names_the_struct_a_bare_variant_implies() {
+        let subs = subcommands(
             r#"
             #[usage(run)]
             enum Command {
@@ -8985,23 +9067,26 @@ mod tests {
                 Sponsors,
             }
         "#,
-        );
+        )
+        .expect("a unit variant is dispatched via the struct written for it");
+        assert!(subs.variants[1].unit);
         assert!(
-            err.contains("holds nothing this crate can name"),
-            "unhelpful: {err}"
+            matches!(&subs.variants[1].ty, Type::Path(p) if p.path.is_ident("CommandSponsors"))
         );
 
-        let inline = enum_rejection(
+        let inline = subcommands(
             r#"
             #[usage(run_with)]
             enum Command {
                 Add { path: String },
             }
         "#,
-        );
-        assert!(
-            inline.contains("holds nothing this crate can name"),
-            "unhelpful: {inline}"
-        );
+        )
+        .expect("an inline variant is dispatched via the struct written for it");
+        assert!(inline.variants[0].inline_fields.is_some());
+        assert!(matches!(
+            &inline.variants[0].ty,
+            Type::Path(p) if p.path.is_ident("CommandAdd")
+        ));
     }
 }

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -5004,8 +5004,8 @@ pub struct Variant {
     pub inline_fields: Option<Vec<syn::Field>>,
     /// `#[usage(run)]` on a variant: this command is synchronous even when the enum awaits.
     pub run_sync: bool,
-    /// `#[usage(run_async)]` on a variant: this command is awaited. Requires `run_async` on
-    /// the enum.
+    /// Whether the variant wrote redundant `#[usage(run_async)]`, retained so validation can
+    /// point at the variant and explain that async enum dispatch already awaits by default.
     pub run_async: bool,
     /// `#[usage(no_ctx)]`: this command does not take the context the rest of the enum does.
     pub no_ctx: bool,
@@ -5155,6 +5155,7 @@ impl Subcommands {
             // Quoted back rather than hardcoded, so an author who wrote `run_async_with` is not
             // told about `run`.
             let (attr, dispatch_trait) = dispatch.named();
+            let has_sync = dispatch.run || dispatch.run_with;
             let has_async = dispatch.run_async || dispatch.run_async_with;
             let has_ctx = dispatch.run_with || dispatch.run_async_with;
             if variants.is_empty() {
@@ -5194,23 +5195,34 @@ impl Subcommands {
                     ),
                 ));
             }
-            if dispatch.run && has_async && variants.iter().any(|v| v.run_sync) {
+            if has_sync && has_async && variants.iter().any(|v| v.run_sync) {
                 return Err(syn::Error::new_spanned(
                     &input.ident,
-                    "`run` and `run_async` on one enum generate two methods, and a command \
-                     marked `#[usage(run)]` is only reachable from the async one — leave `run` \
-                     off this enum and call `run_async`",
+                    "sync and async dispatch on one enum generate two methods, and a command \
+                     marked `#[usage(run)]` only changes the async one — request only async \
+                     dispatch when variants mix synchronous and asynchronous commands",
                 ));
             }
             for v in &variants {
-                if v.run_async && !has_async {
+                if v.external && (v.run_sync || v.run_async || v.no_ctx) {
                     return Err(syn::Error::new_spanned(
                         &v.ident,
-                        format!(
-                            "`run_async` on a variant is awaited by the generated dispatch, so \
-                             the enum has to say `run_async` (or `run_async_with`) too — or \
-                             leave it off `{attr}` and write the match by hand"
-                        ),
+                        "an `external_subcommand` is dispatched by the enum's `external = …` \
+                         function, not by `run` / `run_async` / `no_ctx` on the variant",
+                    ));
+                }
+                if v.run_sync && !has_async {
+                    return Err(syn::Error::new_spanned(
+                        &v.ident,
+                        "`run` on a variant only changes an async enum's dispatch; synchronous \
+                         dispatch already calls `Run` for every variant",
+                    ));
+                }
+                if v.run_async {
+                    return Err(syn::Error::new_spanned(
+                        &v.ident,
+                        "`run_async` on a variant is redundant; async enum dispatch already \
+                         awaits every variant unless that variant says `#[usage(run)]`",
                     ));
                 }
                 if v.no_ctx && !has_ctx {
@@ -5222,19 +5234,17 @@ impl Subcommands {
                         ),
                     ));
                 }
-                if v.external && (v.run_sync || v.run_async || v.no_ctx) {
-                    return Err(syn::Error::new_spanned(
-                        &v.ident,
-                        "an `external_subcommand` is dispatched by the enum's `external = …` \
-                         function, not by `run` / `run_async` / `no_ctx` on the variant",
-                    ));
-                }
             }
-        } else if dispatch_external.is_some() || dispatch_output.is_some() {
+        } else if dispatch_external.is_some()
+            || dispatch_output.is_some()
+            || variants
+                .iter()
+                .any(|v| v.run_sync || v.run_async || v.no_ctx)
+        {
             return Err(syn::Error::new_spanned(
                 &input.ident,
-                "`output` and `external` belong on a dispatched enum — add `run`, `run_with`, \
-                 `run_async` or `run_async_with`",
+                "`output`, `external`, and variant dispatch overrides belong on a dispatched \
+                 enum — add `run`, `run_with`, `run_async` or `run_async_with`",
             ));
         }
 
@@ -8995,6 +9005,50 @@ mod tests {
 
         let dispatch = subs.dispatch;
         assert!(dispatch.run && dispatch.run_with && dispatch.run_async && dispatch.run_async_with);
+    }
+
+    #[test]
+    fn variant_dispatch_overrides_have_to_change_the_enum_dispatch() {
+        let sync = enum_rejection(
+            r#"
+            #[usage(run)]
+            enum Command {
+                #[usage(run)]
+                Install(Install),
+            }
+        "#,
+        );
+        assert!(
+            sync.contains("only changes an async enum"),
+            "unhelpful: {sync}"
+        );
+
+        let async_variant = enum_rejection(
+            r#"
+            #[usage(run_async)]
+            enum Command {
+                #[usage(run_async)]
+                Install(Install),
+            }
+        "#,
+        );
+        assert!(
+            async_variant.contains("is redundant"),
+            "unhelpful: {async_variant}"
+        );
+
+        let undispatched = enum_rejection(
+            r#"
+            enum Command {
+                #[usage(no_ctx)]
+                Install(Install),
+            }
+        "#,
+        );
+        assert!(
+            undispatched.contains("belong on a dispatched enum"),
+            "unhelpful: {undispatched}"
+        );
     }
 
     /// A diagnostic quotes back the attribute the author wrote. Naming `run` at someone who

--- a/docs/rust/dispatch.md
+++ b/docs/rust/dispatch.md
@@ -317,7 +317,7 @@ enum Commands {
     Get(Get),
 }
 
-cli.command.run_with_lazy(|| load_config(&cli)?)?;
+cli.command.run_with_lazy(|| load_config(&cli))?;
 ```
 
 ## Catch-alls

--- a/docs/rust/dispatch.md
+++ b/docs/rust/dispatch.md
@@ -225,31 +225,128 @@ pub struct Generate {
 }
 ```
 
-That is all a generated `run` on a struct can do, so the struct holds one field: its
-subcommands, not in an `Option`. Any other shape is a compile error, because forwarding past
-arguments the struct declared would drop them:
+That is all a generated `run` on a **container** can do — a struct whose one field is its
+subcommands, not in an `Option`. A **root** that also declares flags gets `run_command` instead
+of `impl Run`: the flags stay on `self`, the subcommand is moved out, and whoever parsed them
+decides what `--verbose` means before calling it:
 
-- A struct with **flags or arguments of its own** has to decide what to do with them, so it
-  implements `Run` by hand — usually reading them and then calling `self.command.run()`. That
-  is the root's usual case: `--verbose` is set up before anything dispatches.
-- An **`Option` subcommand** has a state — no command at all — that nothing generated can
-  decide about. Whoever knows what an empty command line means writes the implementation.
+```rust
+fn main() -> miette::Result<()> {
+    let cli = Cli::parse();
+    if cli.verbose {
+        enable_tracing();
+    }
+    cli.run_command()
+}
+```
 
-## What cannot be dispatched
+`run_with` / `run_async` / `run_async_with` on that root become `run_command_with`,
+`run_command_async`, and `run_command_async_with`.
 
-A dispatched arm hands the command's own value to the trait, so every variant has to hold a
-type you can implement the trait for:
+An **`Option` subcommand** still has a state — no command at all — that nothing generated can
+decide about. Whoever knows what an empty command line means writes the implementation.
 
-- A **unit variant** (`Sponsors,`) and a **variant declaring its fields inline**
-  (`Add { path: String }`) are both served by a struct the derive writes for them, under a name
-  nothing else can name. Hold an `Args` struct instead — `Sponsors(Sponsors)` — which is where
-  the command's `effect` and description belong anyway.
-- An **`external_subcommand`** variant holds the argv of a command that is not declared here.
-  There is nothing to implement `Run` for and no exhaustive match to generate, so an enum with
-  a catch-all keeps its hand-written match.
+## Unit and inline variants
 
-Both are compile errors on the variant rather than a missing implementation somewhere else,
-which is the reason dispatch is opt-in rather than always generated. The other reason is that
-the generated implementation is the only one the enum can have: a CLI that wants to do
-something of its own between the parse and the dispatch leaves the attribute off and writes the
-match.
+A dispatched arm still needs a type the command can implement the trait for. A **unit variant**
+(`Sponsors,`) and a **variant declaring its fields inline** (`Add { path: String }`) get one:
+the derive writes `{Enum}{Variant}` — `CommandSponsors`, `CommandAdd` — and the generated match
+rebuilds that struct from the variant. Implement `Run` there:
+
+```rust
+#[derive(Subcommands)]
+#[usage(run)]
+enum Command {
+    Sponsors,
+    Add { path: String },
+}
+
+impl Run for CommandSponsors {
+    type Output = miette::Result<()>;
+    fn run(self) -> Self::Output {
+        print_sponsors();
+        Ok(())
+    }
+}
+
+impl Run for CommandAdd {
+    type Output = miette::Result<()>;
+    fn run(self) -> Self::Output {
+        add(&self.path)
+    }
+}
+```
+
+Holding a separately declared `Args` struct — `Sponsors(Sponsors)` — is still the usual shape
+when the command has work and description of its own. The generated name is for CLIs that kept
+clap's unit and inline layout.
+
+## Mixed sync and async
+
+One generated `async fn` can call a synchronous command and await another. The enum says
+`run_async`; a variant that should not wait says `#[usage(run)]`:
+
+```rust
+#[derive(Subcommands)]
+#[usage(run_async)]
+enum Commands {
+    #[usage(run)]
+    Activate(Activate),
+    Install(Install),
+}
+```
+
+`Activate` implements `Run`; `Install` implements `RunAsync`. The match is still one type,
+because both produce the same `Output`. Do not also put `run` on the enum: that would generate
+a second, synchronous method the async commands cannot enter.
+
+## Context some commands do not want
+
+`RunWith<Ctx>` still takes a context by value, and a variant that should not see it says
+`#[usage(no_ctx)]`. That arm implements `Run` (or `RunAsync`) instead. When at least one
+command skips the context, the enum also gets `run_with_lazy` / `run_async_with_lazy`, which
+take `FnOnce() -> Ctx` and only call it for an arm that needs it — so a missing config file is
+not opened for `version`:
+
+```rust
+#[derive(Subcommands)]
+#[usage(run_with)]
+enum Commands {
+    #[usage(no_ctx)]
+    Version(Version),
+    Get(Get),
+}
+
+cli.command.run_with_lazy(|| load_config(&cli)?)?;
+```
+
+## Catch-alls
+
+An `external_subcommand` holds argv, not a command struct. Name the function that should
+receive those words:
+
+```rust
+fn fallback(argv: Vec<OsString>) -> miette::Result<()> {
+    start_from_argv(argv)
+}
+
+#[derive(Subcommands)]
+#[usage(run, external = fallback)]
+enum Commands {
+    Start(Start),
+    #[usage(external_subcommand)]
+    Fallback(Vec<OsString>),
+}
+```
+
+`run_with` passes `(argv, ctx)`; `run_async` awaits the function. If the first command is not
+a reliable `Output` source — or the catch-all is the first variant — name the type with
+`output = miette::Result<()>`.
+
+## What it says in the spec
+
+Nothing. Which Rust function carries out a command is not part of what the CLI _is_, and a spec
+recording it could be read by nothing but this program — so `run` and `run_with` reach the parse
+tables, the help output and the emitted KDL exactly as much as `#[usage(skip)]` does, which is
+not at all. `usage`'s own CLI moved to a generated dispatch without one byte of its spec, its
+manpage or its completions changing.

--- a/docs/rust/migrating-from-clap.md
+++ b/docs/rust/migrating-from-clap.md
@@ -262,9 +262,9 @@ The `match cli.command { … }` a clap CLI writes after parsing can go too: impl
 `usage::Run` on each command struct, say `#[usage(run)]` on the enum, and the routing is
 generated. Commands that need shared state implement `usage::RunWith<Ctx>` and the enum says
 `#[usage(run_with)]`; async commands implement `usage::RunAsync` or `usage::RunAsyncWith<Ctx>`
-under `#[usage(run_async)]` / `#[usage(run_async_with)]`. A variant holding nothing — clap's unit
-or inline-struct variants, and `external_subcommand` — has no type to implement the trait for, so
-those keep their hand-written arms; see [Dispatch](/rust/dispatch).
+under `#[usage(run_async)]` / `#[usage(run_async_with)]`. A clap unit or inline-struct variant
+is dispatched through the `{Enum}{Variant}` struct the derive writes for it. A catch-all
+`external_subcommand` names `external = fallback` on the enum. See [Dispatch](/rust/dispatch).
 
 ## Help, specs, and completions
 

--- a/docs/rust/subcommands.md
+++ b/docs/rust/subcommands.md
@@ -46,7 +46,8 @@ struct Install {
   `#[usage(subcommand)]` field, up to a maximum depth of 16.
 - `#[usage(run)]` on the enum generates the `match` that hands the selected command to the code
   that carries it out — with `run_with`, `run_async` and `run_async_with` for a dispatch that
-  carries a context, is awaited, or both; see [Dispatch](/rust/dispatch).
+  carries a context, is awaited, or both; unit and inline variants, catch-alls, and mixed
+  sync/async commands are covered in [Dispatch](/rust/dispatch).
 
 Variant attributes: `name`, `alias`, `alias_hidden`, `hide`, `effect`, `help`, `long_help`,
 `verbatim_doc_comment`, `external_subcommand`, `arg_required_else_help`. Aliases declared on the variant and on the `Args`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`#[usage(run)]` previously required every variant to wrap a named `Args` type, the whole enum to be sync or async, and the root to hold nothing but its subcommand field. That is a poor fit for clap-shaped CLIs.

This keeps the four traits and the generated match, and covers the shapes those CLIs actually have:

- **Unit and inline variants** — the derive already wrote a struct for parsing; with dispatch it is named `{Enum}{Variant}` (`CommandSponsors`, `CommandAdd`) so the command can `impl Run` on it. The match rebuilds that value from the variant.
- **Mixed sync/async** — `#[usage(run_async)]` on the enum, `#[usage(run)]` on a variant that should not wait. One `async fn`, one `Output`.
- **Catch-alls** — `#[usage(run, external = fallback)]` calls that function with the unmatched argv (and the context, when `run_with` is on).
- **Roots with flags** — `#[usage(run)]` on a struct that has `--verbose` and a required subcommand generates `run_command` (and the with/async spellings) instead of `impl Run`, so flags are not dropped. An `Option` subcommand is still refused.
- **Context some commands skip** — `#[usage(no_ctx)]` plus `run_with_lazy` / `run_async_with_lazy` (`FnOnce() -> Ctx`) so `version` does not load a config file.
- **`output = Type`** — names the match's `Output` instead of taking it from the first command.

None of this reaches the spec. Fleet PRs are unchanged.

### Tests
- `cargo test -p usage-derive` (dispatch diagnostics and naming)
- `cargo test -p usage-conformance --test dispatch --test dispatch_async`
- `cargo test -p usage-derive -p usage-cli -p usage-rs --all-features`
- `cargo clippy -p usage-derive --all-features -- -D warnings`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e1cae0c-a316-4b88-adfb-c15ceed4180c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e1cae0c-a316-4b88-adfb-c15ceed4180c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded command dispatch for unit, inline, boxed, synchronous, and asynchronous subcommands.
  - Added external-subcommand fallback handling without manual dispatch logic.
  - Added generated forwarding methods for root commands with flags.
  - Added per-variant context suppression, lazy context creation, and explicit output types.
  - Added support for mixed synchronous and asynchronous command hierarchies.

- **Documentation**
  - Updated dispatch, subcommand, and migration guides to describe supported command patterns and generated wrappers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->