### PR TITLE
docs(rust): sharpen framework documentation

### DIFF
--- a/docs/rust/args-and-flags.md
+++ b/docs/rust/args-and-flags.md
@@ -1,9 +1,5 @@
 # Args and Flags
 
-::: warning Draft
-This page is a draft and has not yet been human reviewed. Details may change.
-:::
-
 A field on a `#[derive(Cli)]` or `#[derive(Args)]` struct becomes a flag when it carries `long`
 or `short`, and a positional argument otherwise (or explicitly with `#[usage(arg)]`).
 

--- a/docs/rust/args-and-flags.md
+++ b/docs/rust/args-and-flags.md
@@ -61,9 +61,7 @@ required-ness is declared rather than inferred: `#[usage(arg, required)]`.
 jobs: Option<u32>,
 ```
 
-The tables below cover the attributes most CLIs need. Many clap-compatible spellings
-(`visible_alias`, `hide_*`, `last`, `trailing_var_arg`, `requires_if`, and others) are also
-accepted — see [Migrating from clap](/rust/migrating-from-clap).
+The tables below cover the attributes most CLIs need.
 
 **Naming and shape** — what the field is called and what kind of argument it is:
 
@@ -85,7 +83,7 @@ accepted — see [Migrating from clap](/rust/migrating-from-clap).
 | ----------------------------------- | ------------------------------------------------------------------------------ |
 | `var` / `variadic`                  | Repeatable / greedy multi-value (see above)                                    |
 | `var_min = n` / `var_max = n`       | Bounds on how many values a `Vec` may hold                                     |
-| `num_args = n` / `num_args = a..=b` | clap-compatible spelling for exact or ranged `Vec` cardinality                 |
+| `num_args = n` / `num_args = a..=b` | Exact or ranged `Vec` cardinality                                              |
 | `choices("a", "b")`                 | Restrict values to a fixed set                                                 |
 | `choices_strict = false`            | Keep choices as suggestions while accepting other values                       |
 | `value_enum`                        | Take choices from a `#[derive(ValueEnum)]` type                                |
@@ -168,33 +166,32 @@ backend: Option<String>,
 The portable form is `choices strict=#false core git`. Strict validation remains
 the default.
 
-`#[usage(skip)]` is clap's `#[arg(skip)]`: the field stays on the struct so a rewrite can keep
-computed state beside parsed state, and nothing about it reaches the spec, the parse tables, or
-help. Combining it with `long`, `arg`, or any other field option is a compile error. The type
-has to implement `Default`.
+`#[usage(skip)]` keeps a field on the struct for computed state without adding it to the spec,
+parse tables, or help. Combining it with `long`, `arg`, or any other field option is a compile
+error. The type has to implement `Default`.
 
-`value_hint` accepts clap's full stable vocabulary: `Unknown`, `Other`, `FilePath`, `AnyPath`,
-`DirPath`, `ExecutablePath`, `CommandName`, `CommandString`, `CommandWithArguments`,
-`Username`, `Hostname`, `Url`, and `EmailAddress`. `CommandWithArguments` is for wrapper CLIs
-and must be a positional `Vec` with `double_dash = "automatic"`: its first value completes
-from the shell's commands, while later values fall back to ordinary argument paths. `Other`,
-URL, and email values suppress filename fallback without pretending there is a finite list.
+`value_hint` accepts `Unknown`, `Other`, `FilePath`, `AnyPath`, `DirPath`, `ExecutablePath`,
+`CommandName`, `CommandString`, `CommandWithArguments`, `Username`, `Hostname`, `Url`, and
+`EmailAddress`. `CommandWithArguments` is for wrapper CLIs and must be a positional `Vec` with
+`double_dash = "automatic"`: its first value completes from the shell's commands, while later
+values fall back to ordinary argument paths. `Other`, URL, and email values suppress filename
+fallback without pretending there is a finite list.
 
-`#[usage(allow_hyphen_values)]` is clap's attribute of the same name: `--args -destroy` binds
-`-destroy` instead of reading `-d` as a short. The flag has to take a value; a positional that
-needs the same thing already has `double_dash = "automatic"`. Emitted KDL:
+`#[usage(allow_hyphen_values)]` makes `--args -destroy` bind `-destroy` instead of reading `-d`
+as a short. The flag has to take a value; a positional that needs the same thing already has
+`double_dash = "automatic"`. Emitted KDL:
 `flag "--args <ARGS>" allow_hyphen_values=#true`.
 
-`#[usage(allow_negative_numbers)]` is the narrower clap policy: `--jobs -1` binds
-`-1`, while `--jobs --force` still leaves a flag-like token for normal parsing.
+`#[usage(allow_negative_numbers)]` makes `--jobs -1` bind `-1`, while `--jobs --force` still
+leaves a flag-like token for normal parsing.
 
 `#[usage(value_terminator = ";")]` ends a `Vec` without storing the terminator.
 It works on variadic flags and positionals and emits `value_terminator=";"` in KDL.
 
-Fixed multi-value fields can retain clap's familiar attribute unchanged:
+Fixed multi-value fields declare their cardinality and placeholders together:
 
 ```rust
-#[arg(long, num_args = 2, value_names = ["START", "END"])]
+#[usage(long, num_args = 2, value_names = ["START", "END"])]
 range: Vec<String>,
 ```
 
@@ -206,8 +203,8 @@ while flag-level bounds count how many times a repeatable flag appears. A range
 such as `num_args = 1..=3` sets the corresponding nested bounds; distinct
 `value_names` require an exact bound matching their count.
 
-`#[usage(require_equals)]` is clap's attribute of the same name: `--inspect=9229` binds
-and `--inspect 9229` is a missing value. The flag has to take a value. Emitted KDL:
+`#[usage(require_equals)]` makes `--inspect=9229` bind while `--inspect 9229` is a missing
+value. The flag has to take a value. Emitted KDL:
 `flag "--inspect <PORT>" require_equals=#true`.
 
 `#[usage(bool_value)]` is an opt-in for explicit boolean long-flag values:
@@ -215,9 +212,9 @@ and `--inspect 9229` is a missing value. The flag has to take a value. Emitted K
 detached `--color false` never consumes `false`; it remains a positional. The
 portable form is `flag "--color" bool_value=#true`.
 
-`#[usage(default_missing = "always")]` is clap's `default_missing_value`: `--color`
-binds `always`, `--color=never` binds `never`, and an absent flag stays `None`.
-The flag has to take a value. Help shows the value as optional. Emitted KDL:
+With `#[usage(default_missing = "always")]`, `--color` binds `always`, `--color=never` binds
+`never`, and an absent flag stays `None`. The flag has to take a value. Help shows the value as
+optional. Emitted KDL:
 `flag "--color <WHEN>" default_missing="always"`. Combined with `require_equals`,
 a following word is still refused.
 
@@ -226,11 +223,10 @@ flag is `None`, a bare `--bump` is `Some(None)`, and `--bump=5` is
 `Some(Some(5))`. It infers a zero-or-one value range and renders `[BUMP]` in help
 and the portable spec.
 
-`#[usage(default_if("--json", "true"))]` is clap's `default_value_if` with
-`ArgPredicate::IsPresent`. Three arguments (`default_if("--output", "json", "pretty")`)
-are `Equals`. First match wins. The target's own argv and env suppress it. An
-applied `default_if` is a default: it does not set `__given_*`, so it does not
-activate `requires_if`. Emitted KDL:
+`#[usage(default_if("--json", "true"))]` applies when `--json` is present. Three arguments
+(`default_if("--output", "json", "pretty")`) apply when the other flag equals the middle value.
+First match wins. The target's own argv and env suppress it. An applied `default_if` is a
+default: it does not set `__given_*`, so it does not activate `requires_if`. Emitted KDL:
 
 ```kdl
 flag "--bin-names" {
@@ -248,8 +244,7 @@ stdin: bool,
 
 Naming a flag or positional that doesn't exist on the command is a **compile error**, not a
 runtime surprise. Conflicts, requires, and conditional requiredness may name flags or
-positionals; `overrides` and some `requires_if` forms stay flag-only. See
-[Compatibility gaps](/rust/migrating-from-clap#compatibility-gaps) for the migration details.
+positionals; `overrides` and some `requires_if` forms stay flag-only.
 
 ## Resolution order
 
@@ -275,9 +270,9 @@ A `global` flag declared on a parent is accepted anywhere below it:
 yes: bool,
 ```
 
-A global flag may be given **once per command level**, with the innermost occurrence winning —
-`mycli -y install -y` works, matching clap. Giving it twice at the _same_ level is still a
-`DuplicateFlag` error: `mycli -y -y` is refused.
+A global flag may be given **once per command level**, with the innermost occurrence winning:
+`mycli -y install -y` works. Giving it twice at the _same_ level is still a `DuplicateFlag`
+error: `mycli -y -y` is refused.
 
 ## Container attributes
 

--- a/docs/rust/completions.md
+++ b/docs/rust/completions.md
@@ -1,9 +1,5 @@
 # Completions
 
-::: warning Draft
-This page is a draft and has not yet been human reviewed. Details may change.
-:::
-
 Completion support is opt-in: add `completion` to the root attribute and enable the
 `completions` cargo feature (forgetting the feature is a compile error that names it):
 

--- a/docs/rust/configuration.md
+++ b/docs/rust/configuration.md
@@ -1,9 +1,5 @@
 # Configuration
 
-::: warning Draft
-This page is a draft and has not yet been human reviewed. Details may change.
-:::
-
 CLIs that resolve configuration from several places — flags, environment variables, config
 files — have historically kept three descriptions of every setting in step by hand: a registry
 file, a code generator, and the struct the program reads. `#[derive(usage::Config)]` collapses

--- a/docs/rust/dispatch.md
+++ b/docs/rust/dispatch.md
@@ -257,11 +257,3 @@ which is the reason dispatch is opt-in rather than always generated. The other r
 the generated implementation is the only one the enum can have: a CLI that wants to do
 something of its own between the parse and the dispatch leaves the attribute off and writes the
 match.
-
-## What it says in the spec
-
-Nothing. Which Rust function carries out a command is not part of what the CLI _is_, and a spec
-recording it could be read by nothing but this program — so `run` and `run_with` reach the parse
-tables, the help output and the emitted KDL exactly as much as `#[usage(skip)]` does, which is
-not at all. `usage`'s own CLI moved to a generated dispatch without one byte of its spec, its
-manpage or its completions changing.

--- a/docs/rust/dispatch.md
+++ b/docs/rust/dispatch.md
@@ -1,9 +1,5 @@
 # Dispatch
 
-::: warning Draft
-This page is a draft and has not yet been human reviewed. Details may change.
-:::
-
 A parse ends with a value: an enum whose selected variant holds the command's own struct. What
 every CLI then writes is the same `match` — one arm per command, each calling the one function
 that command exists for. At mise's size that is 210 arms of pure routing, and nothing checks

--- a/docs/rust/help.md
+++ b/docs/rust/help.md
@@ -1,9 +1,5 @@
 # Help, Version, and Errors
 
-::: warning Draft
-This page is a draft and has not yet been human reviewed. Details may change.
-:::
-
 ## Help
 
 `-h` and `--help` are supplied by the parser — you never declare them. They aren't written into

--- a/docs/rust/index.md
+++ b/docs/rust/index.md
@@ -4,10 +4,18 @@
 Used by some of jdx's CLIs, but point releases may break.
 :::
 
-The Rust framework builds your CLI from Rust types. You declare commands, flags, and args as
-structs and enums; a derive macro compiles that declaration into the parse tables the binary runs
-on and a [usage spec](/spec/) it can print. Docs, manpages, and completions are generated from
-that spec.
+`usage-rs` is a fast, typed framework for building complete command-line applications in Rust.
+Declare commands, flags, arguments, and settings with familiar structs and enums, and get
+first-class environment and config-file resolution, advanced shell completions, portable
+validation, negation flags, typed argument groups, categorized subcommands, and more.
+
+In the mise-scale benchmark it parses hundreds of times faster than clap, with no third-party
+runtime crates and a 1.6 MB stripped binary versus clap's 3.1 MB. See the
+[performance results](/rust/performance) and [clap migration guide](/rust/migrating-from-clap).
+
+The same declaration also becomes a portable [usage spec](/spec/) that the binary can print.
+`usage-cli` turns it into documentation, manpages, and completions—the same toolchain used across
+jdx's CLIs.
 
 ```rust
 use usage::Cli;
@@ -44,13 +52,6 @@ whole comment becomes the long help shown by `--help`.
 ## Parser overhead
 
 <UsageBenches lang="rust" embedded />
-
-The derive emits the command tree as static tables at compile time. At runtime the parser walks
-only the selected command path, scans that command's flags plus inherited globals, and writes
-bindings into the result in place. It does not build a command tree, allocate a lookup map, or
-touch help and spec metadata on a successful parse. A bare parse allocates nothing; an owned
-value allocates only when argv actually supplies it. See [Parser performance](/rust/performance)
-for the instruction counts, allocation tests, and benchmark limits.
 
 ## Installation
 

--- a/docs/rust/migrating-from-clap.md
+++ b/docs/rust/migrating-from-clap.md
@@ -1,9 +1,5 @@
 # Migrating from clap
 
-::: warning Draft
-This page is a draft and has not yet been human reviewed. Details may change.
-:::
-
 The Rust framework is a typed parser with static metadata, not a compatibility layer around
 clap. Most derive-based CLIs migrate mechanically. Builder APIs and `ArgMatches` are intentional
 API breaks: move their behavior into typed declarations or keep clap at that boundary.

--- a/docs/rust/migrating-from-clap.md
+++ b/docs/rust/migrating-from-clap.md
@@ -98,6 +98,28 @@ enum Command {
 Unknown flags are values by default, which is useful for wrapper CLIs. Add
 `unknown_flags = "error"` on each command where unknown flag-like words must be rejected.
 
+### Familiar field attributes
+
+Many derive attributes migrate unchanged; `#[arg(...)]` remains accepted while a CLI is being
+converted:
+
+| clap declaration                                      | usage behavior or spelling                                       |
+| ----------------------------------------------------- | ---------------------------------------------------------------- |
+| `visible_alias`, `hide_*`, `last`, `trailing_var_arg` | Accepted with their existing meanings                            |
+| `requires_if` and the other relationship attributes   | Accepted; see the cross-boundary limits below                    |
+| `skip`                                                | Accepted; the field is filled from `Default`                     |
+| `num_args = n` / `num_args = a..=b`                   | Exact or ranged `Vec` cardinality                                |
+| `value_hint = ValueHint::…`                           | The full stable `ValueHint` vocabulary is accepted               |
+| `allow_hyphen_values`, `allow_negative_numbers`       | Accepted with their existing token policies                      |
+| `value_terminator`, `require_equals`                  | Accepted with their existing parsing behavior                    |
+| `global`                                              | May appear once per command level; the innermost occurrence wins |
+| `default_missing_value = "…"`                         | Write `default_missing = "…"`                                    |
+| `default_value_if(…, ArgPredicate::IsPresent, value)` | Write `default_if(other, value)`                                 |
+| `default_value_if(…, value, default)`                 | Write `default_if(other, value, default)`                        |
+
+The native forms and their exact runtime behavior are documented under
+[Args and flags](/rust/args-and-flags).
+
 Repeated scalar flags also use permissive last-one-wins behavior by default. Add
 `#[command(args_override_self = false)]` on commands that should reject a second occurrence.
 The clap bridge records clap's setting, so generated specs retain the source command's policy.
@@ -305,15 +327,3 @@ separately named usage spec/view API.
 These are architectural boundaries, not temporarily undocumented compatibility promises. The
 static typed path is what keeps normal parsing allocation-free; `usage-lib` remains the dynamic
 interpreter for applications that genuinely construct a CLI at runtime.
-
-## Compatibility policy
-
-While the Rust framework is experimental, changes to accepted argv, typed binding, exit status,
-stdout versus stderr, or the portable spec dialect may land in point releases. New clap
-spellings may be added when they map to existing behavior. A spelling whose clap behavior cannot
-be carried losslessly is rejected or documented as partial; it is not silently accepted with
-weaker semantics.
-
-The paired conformance tests are audited against the clap versions in the workspace lockfile.
-Updating clap requires re-running and reviewing those tests; compiling with a new clap is not by
-itself a parity claim.

--- a/docs/rust/performance.md
+++ b/docs/rust/performance.md
@@ -1,9 +1,5 @@
 # Parser performance
 
-::: warning Draft
-This page is a draft and has not yet been human reviewed. Details may change.
-:::
-
 usage's compiled Rust parser is designed so ordinary argv parsing reads static
 tables and writes directly into the result. Cold metadata for help, specs, and
 completions is not constructed on a successful parse.

--- a/docs/rust/quickstart.md
+++ b/docs/rust/quickstart.md
@@ -1,9 +1,5 @@
 # Quickstart
 
-::: warning Draft
-This page is a draft and has not yet been human reviewed. Details may change.
-:::
-
 ## A new project
 
 ```bash

--- a/docs/rust/spec.md
+++ b/docs/rust/spec.md
@@ -1,9 +1,5 @@
 # Spec Output
 
-::: warning Draft
-This page is a draft and has not yet been human reviewed. Details may change.
-:::
-
 `Cli::to_kdl()` writes a complete [usage spec](/spec/) from the same static metadata the parser
 runs on. This is the bridge to the rest of the toolkit: markdown docs, manpages, completion
 scripts for other consumers, SDK generation, and linting all consume that KDL.

--- a/docs/rust/subcommands.md
+++ b/docs/rust/subcommands.md
@@ -1,9 +1,5 @@
 # Subcommands
 
-::: warning Draft
-This page is a draft and has not yet been human reviewed. Details may change.
-:::
-
 Subcommands are an enum. Each variant wraps a `#[derive(Args)]` struct (or nothing), and the
 enum derives `Subcommands`:
 

--- a/docs/rust/testing.md
+++ b/docs/rust/testing.md
@@ -1,9 +1,5 @@
 # Testing
 
-::: warning Draft
-This page is a draft and has not yet been human reviewed. Details may change.
-:::
-
 A CLI test can run the compiled program and assert on stdout, stderr, and its exit status.
 Lower-level helpers assert what argv parses to, what a user reads when it does not, and what a
 shell offers while one is being typed.

--- a/docs/rust/update-from.md
+++ b/docs/rust/update-from.md
@@ -1,9 +1,5 @@
 # Updating an existing value
 
-::: warning Draft
-This page is a draft and has not yet been human reviewed. Details may change.
-:::
-
 Long-running programs such as REPLs and daemons can merge another command line into a value they
 already hold:
 

--- a/docs/rust/validation.md
+++ b/docs/rust/validation.md
@@ -1,9 +1,5 @@
 # Validation
 
-::: warning Draft
-This page is a draft and has not yet been human reviewed. Details may change.
-:::
-
 Everything on this page runs after argv is bound and env/default fallbacks are applied. Only the
 command that actually ran is judged. Contradictory declarations — `choices` on a `bool`,
 `var_min` greater than `var_max`, a default that isn't one of the choices — are compile errors,


### PR DESCRIPTION
## Summary

- strengthen the usage-rs landing-page pitch around its own capabilities
- keep clap-specific compatibility details in the migration guide
- remove redundant parser, dispatch, and compatibility-policy prose

## Testing

- `npm run docs:build`

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to the Rust framework pages; no runtime, API, or security behavior changes.
> 
> **Overview**
> Marks the Rust framework docs as reviewed by dropping **Draft** banners across those pages, and rewrites the landing page around `usage-rs` itself: typed CLIs, env/config, completions, and mise-scale speed/size versus clap.
> 
> Moves clap-specific attribute mapping into the migration guide (including a **Familiar field attributes** table) and describes native `#[usage(...)]` behavior on the args page without clap framing. Trims overlapping parser-overhead, dispatch-spec, and experimental compatibility-policy prose.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d474e660f16a69c9573ea149914b4e9791442f84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Rust argument and flag behavior, including defaults, value handling, booleans, multi-value arguments, relationships, and global flags.
  * Expanded clap migration guidance with supported attribute mappings and spellings.
  * Updated the Rust introduction with framework capabilities, performance, binary size, and toolchain information.
  * Removed outdated dispatch and compatibility-policy details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->