### PR TITLE
chore: release v6.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [6.1.1](https://github.com/jdx/usage/compare/v6.1.0..v6.1.1) - 2026-08-23
+
+### 🐛 Bug Fixes
+
+- **(argv)** simplify generated completion headers by [@jdx](https://github.com/jdx) in [#1226](https://github.com/jdx/usage/pull/1226)
+- **(argv)** plan for the target platform, not the host by [@JamBalaya56562](https://github.com/JamBalaya56562) in [#1233](https://github.com/jdx/usage/pull/1233)
+- **(complete)** keep the path separator the caller typed by [@JamBalaya56562](https://github.com/JamBalaya56562) in [#1230](https://github.com/jdx/usage/pull/1230)
+- **(config)** report config paths without the verbatim prefix by [@JamBalaya56562](https://github.com/JamBalaya56562) in [#1232](https://github.com/jdx/usage/pull/1232)
+- **(docs)** separate visible flag aliases by [@jdx](https://github.com/jdx) in [#1228](https://github.com/jdx/usage/pull/1228)
+- **(test)** compile the platform-conditional fixtures warning-free on windows by [@JamBalaya56562](https://github.com/JamBalaya56562) in [#1234](https://github.com/jdx/usage/pull/1234)
+
+### ⚡ Performance
+
+- **(derive)** outline invalid-value error construction from generated builds by [@jdx](https://github.com/jdx) in [#1235](https://github.com/jdx/usage/pull/1235)
+- **(derive)** share the repeated-value collection loop across fields by [@jdx](https://github.com/jdx) in [#1236](https://github.com/jdx/usage/pull/1236)
+
+### 🧪 Testing
+
+- **(windows)** let the suite run where zsh, fish and bash-completion are not by [@JamBalaya56562](https://github.com/JamBalaya56562) in [#1229](https://github.com/jdx/usage/pull/1229)
+
 ## [6.1.0](https://github.com/jdx/usage/compare/v6.0.0..v6.1.0) - 2026-08-22
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2245,11 +2245,11 @@ checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "usage-argv"
-version = "6.1.0"
+version = "6.1.1"
 
 [[package]]
 name = "usage-cli"
-version = "6.1.0"
+version = "6.1.1"
 dependencies = [
  "assert_cmd",
  "ctor",
@@ -2278,7 +2278,7 @@ dependencies = [
 
 [[package]]
 name = "usage-config"
-version = "6.1.0"
+version = "6.1.1"
 dependencies = [
  "serde_json",
  "toml",
@@ -2305,7 +2305,7 @@ dependencies = [
 
 [[package]]
 name = "usage-derive"
-version = "6.1.0"
+version = "6.1.1"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2315,7 +2315,7 @@ dependencies = [
 
 [[package]]
 name = "usage-lib"
-version = "6.1.0"
+version = "6.1.1"
 dependencies = [
  "clap",
  "criterion",
@@ -2343,7 +2343,7 @@ dependencies = [
 
 [[package]]
 name = "usage-rs"
-version = "6.1.0"
+version = "6.1.1"
 dependencies = [
  "serde",
  "usage-argv",
@@ -2356,14 +2356,14 @@ dependencies = [
 
 [[package]]
 name = "usage-test"
-version = "6.1.0"
+version = "6.1.1"
 dependencies = [
  "usage-argv",
 ]
 
 [[package]]
 name = "usage-validation"
-version = "6.1.0"
+version = "6.1.1"
 dependencies = [
  "expr-lang",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,19 +42,19 @@ license = "MIT"
 [workspace.dependencies]
 clap_usage = { path = "./clap_usage", version = "5.0.0" }
 usage-cli = { path = "./cli" }
-usage-argv = { path = "./argv", version = "6.1.0" }
-usage-config = { path = "./config", version = "6.1.0" }
-usage-derive = { path = "./derive", version = "6.1.0" }
+usage-argv = { path = "./argv", version = "6.1.1" }
+usage-config = { path = "./config", version = "6.1.1" }
+usage-derive = { path = "./derive", version = "6.1.1" }
 # No features, and defaults off. A feature named here is inherited by every member that writes
 # `workspace = true` and inlines into their published manifests — so `clap` and `validation`
 # reached members that use neither, one of them an adopter's build script. Defaults
 # are off rather than absent because cargo *ignores* a member's `default-features = false` unless
 # the workspace declaration sets it too, and warns that it may become a hard error. Members name
 # what they need, `docs` included.
-usage-lib = { path = "./lib", version = "6.1.0", default-features = false }
-usage-rs = { path = "./usage-rs", version = "6.1.0" }
-usage-test = { path = "./test", version = "6.1.0" }
-usage-validation = { path = "./validation", version = "6.1.0" }
+usage-lib = { path = "./lib", version = "6.1.1", default-features = false }
+usage-rs = { path = "./usage-rs", version = "6.1.1" }
+usage-test = { path = "./test", version = "6.1.1" }
+usage-validation = { path = "./validation", version = "6.1.1" }
 
 [workspace.metadata.release]
 allow-branch = ["main"]

--- a/argv/Cargo.toml
+++ b/argv/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-argv"
 description = "Zero-allocation argv parser for usage specs"
-version = "6.1.0"
+version = "6.1.1"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "usage-cli"
 edition = "2021"
 rust-version = "1.95"
-version = "6.1.0"
+version = "6.1.1"
 description = "CLI for working with usage-based CLIs"
 license = { workspace = true }
 authors = { workspace = true }

--- a/cli/usage.usage.kdl
+++ b/cli/usage.usage.kdl
@@ -2,7 +2,7 @@
 min_usage_version "4.0"
 name usage
 bin usage
-version "6.1.0"
+version "6.1.1"
 repository "https://github.com/jdx/usage"
 source_code_link_template #"""
 {%- set path = path | replace(from='-', to='_') -%}

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-config"
 description = "Layered configuration resolution for usage specs, with provenance"
-version = "6.1.0"
+version = "6.1.1"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-derive"
 description = "Derive macro that compiles a CLI definition into parse tables and a usage spec"
-version = "6.1.0"
+version = "6.1.1"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }

--- a/docs/cli/reference/commands.json
+++ b/docs/cli/reference/commands.json
@@ -1756,7 +1756,7 @@
     "sources": {},
     "files": []
   },
-  "version": "6.1.0",
+  "version": "6.1.1",
   "usage": "Usage: usage <COMMAND>\n       usage --completions <COMPLETIONS>\n       usage --usage-spec",
   "complete": {},
   "source_code_link_template": "{%- set path = path | replace(from='-', to='_') -%}\n{%- if cmd.subcommands | length > 0 -%}\n{%- set path = path ~ \"/mod.rs\" -%}\n{%- elif path in [\"bash\", \"fish\", \"powershell\", \"zsh\"] -%}\n{%- set path = \"shell.rs\" -%}\n{%- else -%}\n{%- set path = path ~ \".rs\" -%}\n{%- endif -%}\nhttps://github.com/jdx/usage/blob/main/cli/src/cli/{{path}}",

--- a/docs/cli/reference/index.md
+++ b/docs/cli/reference/index.md
@@ -4,7 +4,7 @@
 
 **Usage**: `usage [--completions <COMPLETIONS>] [--usage-spec] <SUBCOMMAND>`
 
-**Version**: 6.1.0
+**Version**: 6.1.1
 
 **Repository**: https://github.com/jdx/usage
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-lib"
 edition = "2021"
-version = "6.1.0"
+version = "6.1.1"
 rust-version = "1.95"
 include = [
     "/Cargo.toml",

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-test"
 description = "Test helpers for CLIs built with usage"
-version = "6.1.0"
+version = "6.1.1"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }

--- a/usage-rs/Cargo.toml
+++ b/usage-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-rs"
 description = "A compiled CLI parser for Rust, built on usage specs"
-version = "6.1.0"
+version = "6.1.1"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }

--- a/usage-rs/tests/fixtures/runtime-identity/Cargo.lock
+++ b/usage-rs/tests/fixtures/runtime-identity/Cargo.lock
@@ -39,11 +39,11 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "usage-argv"
-version = "6.1.0"
+version = "6.1.1"
 
 [[package]]
 name = "usage-derive"
-version = "6.1.0"
+version = "6.1.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "usage-rs"
-version = "6.1.0"
+version = "6.1.1"
 dependencies = [
  "usage-argv",
  "usage-derive",

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-validation"
 description = "Portable expression validation for usage specs"
-version = "6.1.0"
+version = "6.1.1"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }


### PR DESCRIPTION
### 🐛 Bug Fixes

- **(argv)** simplify generated completion headers by [@jdx](https://github.com/jdx) in [#1226](https://github.com/jdx/usage/pull/1226)
- **(argv)** plan for the target platform, not the host by [@JamBalaya56562](https://github.com/JamBalaya56562) in [#1233](https://github.com/jdx/usage/pull/1233)
- **(complete)** keep the path separator the caller typed by [@JamBalaya56562](https://github.com/JamBalaya56562) in [#1230](https://github.com/jdx/usage/pull/1230)
- **(config)** report config paths without the verbatim prefix by [@JamBalaya56562](https://github.com/JamBalaya56562) in [#1232](https://github.com/jdx/usage/pull/1232)
- **(docs)** separate visible flag aliases by [@jdx](https://github.com/jdx) in [#1228](https://github.com/jdx/usage/pull/1228)
- **(test)** compile the platform-conditional fixtures warning-free on windows by [@JamBalaya56562](https://github.com/JamBalaya56562) in [#1234](https://github.com/jdx/usage/pull/1234)

### ⚡ Performance

- **(derive)** outline invalid-value error construction from generated builds by [@jdx](https://github.com/jdx) in [#1235](https://github.com/jdx/usage/pull/1235)
- **(derive)** share the repeated-value collection loop across fields by [@jdx](https://github.com/jdx) in [#1236](https://github.com/jdx/usage/pull/1236)

### 🧪 Testing

- **(windows)** let the suite run where zsh, fish and bash-completion are not by [@JamBalaya56562](https://github.com/JamBalaya56562) in [#1229](https://github.com/jdx/usage/pull/1229)