### PR TITLE
docs(rust): use microseconds in performance chart

### DIFF
--- a/docs/.vitepress/theme/UsageBenches.vue
+++ b/docs/.vitepress/theme/UsageBenches.vue
@@ -32,9 +32,9 @@ const idPrefix = computed(() => `bench-${props.lang}`);
 // runner, and genuinely one *cold* parse — `parse-n` is differenced against the
 // same binary parsing nothing.
 const rustRows = [
-  { name: "usage-rs", value: 194, label: "190 ns", us: true },
+  { name: "usage-rs", value: 194, label: "0.19 µs", us: true },
   { name: "clap", value: 479605, label: "480 µs", note: "~2,500× more", us: false },
-  { name: "bpaf", value: 1597028, label: "1.6 ms", note: "~8,200× more", us: false },
+  { name: "bpaf", value: 1597028, label: "1,600 µs", note: "~8,200× more", us: false },
 ];
 
 // Go figures from go/README.md are whole-process wall time and subtract the

--- a/docs/rust/performance.md
+++ b/docs/rust/performance.md
@@ -15,7 +15,7 @@ measurements subtract startup from two runs of the same binary.
 | --------- | -----------: | -------: | --------: | ---------------------------: |
 | usage     |        7,377 |        — |    0.7 µs |                            0 |
 | clap      |        6.31M |     855x |    544 µs |                        6,560 |
-| bpaf      |        21.9M |   2,957x |   1.61 ms |                            — |
+| bpaf      |        21.9M |   2,957x |  1,610 µs |                            — |
 
 clap and bpaf construct and validate a parser at runtime before reading a
 single word, so their floor is hundreds of microseconds. usage reads tables the


### PR DESCRIPTION
## Summary

- express every usage-rs wall-time value in the homepage benchmark chart in microseconds
- express every wall-time value in the Rust performance documentation chart in microseconds
- leave the benchmark reporters and usage-go chart unchanged

## Testing

- `npx prettier --check docs/.vitepress/theme/UsageBenches.vue docs/rust/performance.md`
- `npm run docs:build`
- `git diff --check origin/main`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation label-only change; no code, benchmarks, or runtime behavior is modified.
> 
> **Overview**
> Puts Rust wall-time labels on a single unit so the homepage bench card and the performance table are easier to compare.
> 
> `usage-rs` is shown as `0.19 µs` instead of `190 ns`, and bpaf as `1,600 µs` / `1,610 µs` instead of milliseconds. Numeric values and the Go chart are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c89f16ed9d07780aaa99fbe2a358c9f1fb8e470. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark displays to use consistent microsecond units.
  * Corrected Rust performance table values while preserving equivalent measured times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->