### PR TITLE
fix(docs): separate visible flag aliases

### DIFF
--- a/examples/docs/MISE_INLINE.md
+++ b/examples/docs/MISE_INLINE.md
@@ -1210,7 +1210,9 @@ Write to the local config instead of the global config
 
 Print the config change without writing it
 
-#### `-p --path --file <PATH>`
+#### `-p --path <PATH>`
+
+**Aliases:** `--file`
 
 Write to this config file or directory
 
@@ -1243,7 +1245,9 @@ Write to the local config instead of the global config
 
 Print the config change without writing it
 
-#### `-p --path --file <PATH>`
+#### `-p --path <PATH>`
+
+**Aliases:** `--file`
 
 Write to this config file or directory
 
@@ -1288,7 +1292,9 @@ Import every linked formula, including dependencies
 
 Print the config change without writing config
 
-#### `-p --path --file <PATH>`
+#### `-p --path <PATH>`
+
+**Aliases:** `--file`
 
 Write to this config file or directory
 
@@ -1435,7 +1441,9 @@ local one
 
 Print the commands that would run without writing config or installing
 
-#### `-p --path --file <PATH>`
+#### `-p --path <PATH>`
+
+**Aliases:** `--file`
 
 Write to this config file or directory
 
@@ -2044,7 +2052,9 @@ The path of the config to display
 
 ### Flags
 
-#### `-f --file --path <FILE>`
+#### `-f --file <FILE>`
+
+**Aliases:** `--path`
 
 The path to the mise.toml file to read
 
@@ -2105,7 +2115,9 @@ The value to set the key to (optional if provided as KEY=VALUE)
 
 ### Flags
 
-#### `-f --file --path <FILE>`
+#### `-f --file <FILE>`
+
+**Aliases:** `--path`
 
 The path to the mise.toml file to edit
 
@@ -5164,7 +5176,9 @@ Can be used multiple times. Requires --age-encrypt.
 
 Can be used multiple times. Requires --age-encrypt.
 
-#### `--file --path <FILE>`
+#### `--file <FILE>`
+
+**Aliases:** `--path`
 
 The TOML file to update
 
@@ -6723,7 +6737,9 @@ e.g.: NODE_ENV
 
 ### Flags
 
-#### `-f --file --path <FILE>`
+#### `-f --file <FILE>`
+
+**Aliases:** `--path`
 
 Specify a file to use instead of `mise.toml`
 
@@ -6794,7 +6810,9 @@ Create/modify an environment-specific config file like .mise.<env>.toml
 
 Use the global config file (`~/.config/mise/config.toml`) instead of the local one
 
-#### `-p --path --file <PATH>`
+#### `-p --path <PATH>`
+
+**Aliases:** `--file`
 
 Specify a path to a config file or directory
 

--- a/examples/docs/MISE_MULTI.md
+++ b/examples/docs/MISE_MULTI.md
@@ -1210,7 +1210,9 @@ Write to the local config instead of the global config
 
 Print the config change without writing it
 
-#### `-p --path --file <PATH>`
+#### `-p --path <PATH>`
+
+**Aliases:** `--file`
 
 Write to this config file or directory
 
@@ -1243,7 +1245,9 @@ Write to the local config instead of the global config
 
 Print the config change without writing it
 
-#### `-p --path --file <PATH>`
+#### `-p --path <PATH>`
+
+**Aliases:** `--file`
 
 Write to this config file or directory
 
@@ -1288,7 +1292,9 @@ Import every linked formula, including dependencies
 
 Print the config change without writing config
 
-#### `-p --path --file <PATH>`
+#### `-p --path <PATH>`
+
+**Aliases:** `--file`
 
 Write to this config file or directory
 
@@ -1435,7 +1441,9 @@ local one
 
 Print the commands that would run without writing config or installing
 
-#### `-p --path --file <PATH>`
+#### `-p --path <PATH>`
+
+**Aliases:** `--file`
 
 Write to this config file or directory
 
@@ -2044,7 +2052,9 @@ The path of the config to display
 
 ### Flags
 
-#### `-f --file --path <FILE>`
+#### `-f --file <FILE>`
+
+**Aliases:** `--path`
 
 The path to the mise.toml file to read
 
@@ -2105,7 +2115,9 @@ The value to set the key to (optional if provided as KEY=VALUE)
 
 ### Flags
 
-#### `-f --file --path <FILE>`
+#### `-f --file <FILE>`
+
+**Aliases:** `--path`
 
 The path to the mise.toml file to edit
 
@@ -5164,7 +5176,9 @@ Can be used multiple times. Requires --age-encrypt.
 
 Can be used multiple times. Requires --age-encrypt.
 
-#### `--file --path <FILE>`
+#### `--file <FILE>`
+
+**Aliases:** `--path`
 
 The TOML file to update
 
@@ -6723,7 +6737,9 @@ e.g.: NODE_ENV
 
 ### Flags
 
-#### `-f --file --path <FILE>`
+#### `-f --file <FILE>`
+
+**Aliases:** `--path`
 
 Specify a file to use instead of `mise.toml`
 
@@ -6794,7 +6810,9 @@ Create/modify an environment-specific config file like .mise.<env>.toml
 
 Use the global config file (`~/.config/mise/config.toml`) instead of the local one
 
-#### `-p --path --file <PATH>`
+#### `-p --path <PATH>`
+
+**Aliases:** `--file`
 
 Specify a path to a config file or directory
 

--- a/lib/src/docs/cli/mod.rs
+++ b/lib/src/docs/cli/mod.rs
@@ -504,6 +504,21 @@ mod tests {
     use insta::assert_snapshot;
 
     #[test]
+    fn flag_aliases_do_not_leak_into_interactive_help() {
+        let spec = crate::spec! { r#"
+bin "ex"
+flag "-t -f --tail --follow" help="Follow output"
+        "# }
+        .unwrap();
+
+        for long in [false, true] {
+            let page = super::render_help(&spec, &spec.cmd, long);
+            assert!(page.contains("-t, --tail"), "long={long}:\n{page}");
+            assert!(!page.contains("aliases:"), "long={long}:\n{page}");
+        }
+    }
+
+    #[test]
     fn a_hidden_ancestor_claim_keeps_help_off_the_page() {
         // `--help` is supplied by the parser, and a hidden global that declares it still binds
         // first — `hide` keeps a flag off the page, not out of the parse. Deciding the supplied

--- a/lib/src/docs/markdown/cmd.rs
+++ b/lib/src/docs/markdown/cmd.rs
@@ -258,7 +258,7 @@ cmd "sub" help="a subcommand"
     }
 
     #[test]
-    fn generated_reference_lists_every_visible_flag_alias() {
+    fn generated_reference_separates_visible_flag_aliases() {
         let spec: Spec = r#"
 bin "mycli"
 flag "-t -f --tail --follow" help="Follow output"
@@ -267,8 +267,13 @@ flag "-t -f --tail --follow" help="Follow output"
         .unwrap();
         let ctx = MarkdownRenderer::new(spec.clone()).with_multi(true);
         let rendered = ctx.render_cmd(&spec.cmd).unwrap();
+        assert!(rendered.contains("### `-t --tail`"), "{rendered}");
         assert!(
-            rendered.contains("### `-t -f --tail --follow`"),
+            rendered.contains("**Aliases:** `-f`, `--follow`"),
+            "{rendered}"
+        );
+        assert!(
+            !rendered.contains("### `-t -f --tail --follow`"),
             "{rendered}"
         );
     }

--- a/lib/src/docs/markdown/templates/flag_template.md.tera
+++ b/lib/src/docs/markdown/templates/flag_template.md.tera
@@ -1,3 +1,7 @@
+{%- if flag.aliases %}
+
+**Aliases:** {% for alias in flag.aliases %}`{{ alias }}`{% if not loop.last %}, {% endif %}{% endfor %}
+{%- endif %}
 {%- if flag.effect %}
 
 **Effect**: {% if flag.effect == "read" %}read-only{% elif flag.effect == "destructive" %}destructive — may delete or irreversibly overwrite{% else %}modifies state{% endif %}

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -854,30 +854,15 @@ fn reference_usage(flag: &crate::SpecFlag) -> String {
     usage
 }
 
-/// Additional visible spellings for generated reference documentation.
-fn reference_aliases(flag: &crate::SpecFlag) -> Vec<String> {
-    flag.short
-        .iter()
-        .filter(|short| !flag.hidden_short_aliases.contains(short))
-        .skip(1)
-        .map(|short| format!("-{short}"))
-        .chain(
-            flag.long
-                .iter()
-                .filter(|long| !flag.hidden_aliases.contains(long))
-                .skip(1)
-                .map(|long| format!("--{long}")),
-        )
-        .collect()
-}
-
 impl From<&crate::SpecFlag> for SpecFlag {
     fn from(flag: &crate::SpecFlag) -> Self {
         Self {
             name: flag.name.clone(),
             effect: flag.effect,
             usage: reference_usage(flag),
-            aliases: reference_aliases(flag),
+            // Interactive help intentionally keeps aliases out of its aligned flag table.
+            // Markdown fills these from the already-filtered spelling lists in `render_md`.
+            aliases: Vec::new(),
             display_usage: column_usage(flag),
             help: said(&flag.help),
             help_long: flag.help_long.clone(),
@@ -1061,6 +1046,13 @@ impl SpecFlag {
                 self.help_md = Some(renderer.replace_code_fences(h));
             }
         }
+        self.aliases = self
+            .short
+            .iter()
+            .skip(1)
+            .map(|short| format!("-{short}"))
+            .chain(self.long.iter().skip(1).map(|long| format!("--{long}")))
+            .collect();
     }
 }
 

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -117,6 +117,7 @@ pub struct SpecFlag {
     pub name: String,
     pub effect: Option<crate::spec::effect::SpecCommandEffect>,
     pub usage: String,
+    pub aliases: Vec<String>,
     pub display_usage: String,
     pub help: Option<String>,
     pub help_long: Option<String>,
@@ -811,20 +812,19 @@ fn column_usage(flag: &crate::SpecFlag) -> String {
     format!("{short:<SHORT_COL$}{after}")
 }
 
-/// Every visible spelling for generated reference documentation.
-///
-/// Interactive help keeps the compact first short/long pair in its aligned
-/// column, while a reference page should document aliases users can type.
+/// The canonical visible spelling for generated reference documentation.
 fn reference_usage(flag: &crate::SpecFlag) -> String {
     let mut forms: Vec<String> = flag
         .short
         .iter()
         .filter(|short| !flag.hidden_short_aliases.contains(short))
+        .take(1)
         .map(|short| format!("-{short}"))
         .chain(
             flag.long
                 .iter()
                 .filter(|long| !flag.hidden_aliases.contains(long))
+                .take(1)
                 .map(|long| format!("--{long}")),
         )
         .collect();
@@ -854,12 +854,30 @@ fn reference_usage(flag: &crate::SpecFlag) -> String {
     usage
 }
 
+/// Additional visible spellings for generated reference documentation.
+fn reference_aliases(flag: &crate::SpecFlag) -> Vec<String> {
+    flag.short
+        .iter()
+        .filter(|short| !flag.hidden_short_aliases.contains(short))
+        .skip(1)
+        .map(|short| format!("-{short}"))
+        .chain(
+            flag.long
+                .iter()
+                .filter(|long| !flag.hidden_aliases.contains(long))
+                .skip(1)
+                .map(|long| format!("--{long}")),
+        )
+        .collect()
+}
+
 impl From<&crate::SpecFlag> for SpecFlag {
     fn from(flag: &crate::SpecFlag) -> Self {
         Self {
             name: flag.name.clone(),
             effect: flag.effect,
             usage: reference_usage(flag),
+            aliases: reference_aliases(flag),
             display_usage: column_usage(flag),
             help: said(&flag.help),
             help_long: flag.help_long.clone(),


### PR DESCRIPTION
## Summary
- keep only the canonical short and long forms in generated reference headings
- list additional visible spellings in a separate aliases field and Markdown line
- preserve hidden-alias filtering and interactive help behavior

## Verification
- `cargo test -p usage-lib --all-features`
- `cargo clippy -p usage-lib --all-features -- -D warnings`

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-generation and example markdown only; CLI parsing and interactive help stay the same.
> 
> **Overview**
> Generated CLI reference headings now show a **single canonical short and long form** instead of stuffing every visible spelling into the heading.
> 
> Extra visible spellings (after hidden-alias filtering) go on a separate **Aliases** line in Markdown. Interactive help still uses the compact first pair and does not print aliases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b98b0ff31e8f7f52b6f2822d06d774039f1511c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved generated flag documentation by displaying the primary short and long forms prominently.
  * Added a dedicated **Aliases** section for additional visible flag spellings.
  * Ensured aliases are listed separately rather than combined in the main heading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->