### PR TITLE
test(windows): let the suite run where zsh, fish and bash-completion are not

### DIFF
--- a/cli/tests/completion_install.rs
+++ b/cli/tests/completion_install.rs
@@ -335,7 +335,12 @@ fn a_failed_install_says_what_the_system_said() {
     let scratch = Scratch::new("io_cause");
     // A file where a directory has to go: deterministic, and the same failure for root, which is
     // who a container runs as.
-    let target = scratch.dir.join("data/zsh/site-functions");
+    //
+    // Joined a segment at a time. `join("data/zsh/site-functions")` keeps the slashes it was
+    // given, so on Windows `display()` renders `…\data/zsh/site-functions` while the error
+    // being matched against says `…\data\zsh\site-functions` — the same path, spelled two
+    // ways, and the assertion below compares spellings.
+    let target = scratch.dir.join("data").join("zsh").join("site-functions");
     std::fs::create_dir_all(target.parent().unwrap()).unwrap();
     std::fs::write(&target, "not a directory\n").unwrap();
 

--- a/cli/tests/shell_completions_integration.rs
+++ b/cli/tests/shell_completions_integration.rs
@@ -101,7 +101,11 @@ fn skip_if_shell_missing(shell: &str) -> bool {
     if shell_can_run_a_script(shell) {
         return false;
     }
-    if env::var("CI").is_ok_and(|v| !v.is_empty()) {
+    // Unix only. The workflow installs zsh and fish for the Linux job alone, so a shell missing
+    // there is a configuration bug and refusing to skip is what catches it. Nothing installs them
+    // on Windows, where their absence is the expected state rather than a mistake — mise draws the
+    // same line, installing no POSIX shells on its Windows runners at all.
+    if cfg!(unix) && env::var("CI").is_ok_and(|v| !v.is_empty()) {
         panic!("shell `{shell}` cannot run a script but CI is set — refusing to skip");
     }
     eprintln!(
@@ -178,7 +182,11 @@ fn bash_completion_or_skip() -> Option<PathBuf> {
     if let Some(path) = system_bash_completion() {
         return Some(path);
     }
-    if env::var("CI").is_ok_and(|v| !v.is_empty()) {
+    // Unix only, for the same reason as `skip_if_shell_missing` and a stronger one: there is no
+    // bash-completion to install on Windows. Git for Windows does not ship the library, and usage
+    // stopped carrying its own copy in 6.0 (#1176) — so unlike a missing zsh, this is not a thing
+    // a runner could be configured to have.
+    if cfg!(unix) && env::var("CI").is_ok_and(|v| !v.is_empty()) {
         panic!(
             "no usable bash-completion but CI is set — refusing to skip. Tried: {:?}",
             bash_completion_candidates()


### PR DESCRIPTION
Groundwork for a `windows-latest` job. Two things stop `cargo test -p usage-cli` there, and neither is about usage — they are the tests' own doing.

## A path compared against itself, spelled two ways

`a_failed_install_says_what_the_system_said` builds its target with `join("data/zsh/site-functions")`, and `Path::join` keeps the slashes it was given:

```
join("data/zsh/site-functions") = C:\tmp\scratch\data/zsh/site-functions
join chained                    = C:\tmp\scratch\data\zsh\site-functions
```

The error the test then matches against says `data\zsh\site-functions`, so the final assertion compared two spellings of one path:

```
Error:   × creating C:
  │ \Users\…\usage_completion_install_io_cause_23128_0\da
  │ ta\zsh\site-functions failed: … (os error 183)
```

Joined a segment at a time, `display()` renders it the way the error does. On Unix the two forms are the same string, so nothing changes there.

## A guard that cannot hold on Windows

`bash_completion_or_skip` refuses to skip when `CI` is set — a good rule, because a job that quietly tested nothing is worse than one that stopped. It cannot hold on Windows, though: Git for Windows does not ship the bash-completion library, and usage stopped carrying its own copy in 6.0 (#1176). Unlike a missing zsh, this is not something a runner could be configured to have, so the rule is now Unix-only.

`skip_if_shell_missing` gets the same treatment for the weaker version of the same reason. The workflow installs zsh and fish for the Linux job alone, so their absence is a configuration bug there and the expected state on Windows. mise draws the same line — its Windows jobs install no POSIX shells at all.

**The mount guard in `complete_word.rs` is deliberately left strict.** bash does exist on Windows, and the fixtures run once `USAGECLI_SHELL_BASH` names one — 50 of 50, nothing skipped. Relaxing that one would hide something that works.

## Verified

`completion_install` on Windows: **13/13**, was 12/1.

That the guards were not loosened too far — on Linux, with `CI=1` and `zsh` replaced by a stub that exits 127:

```
shell `zsh` cannot run a script but CI is set — refusing to skip
```

Still refuses, as it should. Linux is otherwise unchanged.

## What is left

One Windows failure remains, `test_complete_path_preserves_partially_typed_segments`, and it is a real bug rather than a test artefact — path completion returns `target\debug\incremental/`, mixing separators. That is its own PR, since it changes what the CLI outputs rather than what a test asserts.

---

_This pull request was generated by Claude Code._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cross-platform path handling in installation error tests.
  * Updated Unix shell-completion tests to fail clearly when required dependencies are unavailable.
  * Preserved test skipping behavior on Windows when optional dependencies are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->