### PR TITLE
fix(complete): keep the path separator the caller typed

### DIFF
--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -658,6 +658,7 @@ impl CompleteWord {
         filter: impl Fn(&Path) -> bool,
     ) -> Vec<String> {
         trace!("complete_path: {ctoken}");
+        let separator = rendered_separator(ctoken);
         let path = PathBuf::from(ctoken);
         let exact = if path.is_absolute() {
             path.clone()
@@ -702,9 +703,9 @@ impl CompleteWord {
                     .strip_prefix(base)
                     .unwrap_or(&p)
                     .to_string_lossy()
-                    .to_string();
+                    .replace(std::path::MAIN_SEPARATOR, separator);
                 if is_dir {
-                    s.push('/');
+                    s.push_str(separator);
                 }
                 s
             })
@@ -784,6 +785,27 @@ impl usage_rs::Run for CompleteWord {
         }
 
         Ok(())
+    }
+}
+
+/// The separator to render a completion with: the one already in the token.
+///
+/// `read_dir` hands back the platform's, so on Windows a token typed with `/` came back as
+/// `target\debug\incremental/` — the segments in one spelling and the trailing marker in another,
+/// which is neither what was typed nor a path the shell will match against what follows. A
+/// completion is finishing a word a person is in the middle of typing, so their spelling is the
+/// one to continue.
+///
+/// A backslash counts as a separator on Windows only: on Unix it is an ordinary character in a
+/// filename, and a file called `a\b` must not be read as two components.
+///
+/// `/` when the token has neither, which is what the trailing marker has always used and what
+/// every POSIX shell wants.
+fn rendered_separator(ctoken: &str) -> &'static str {
+    if cfg!(windows) && ctoken.contains('\\') && !ctoken.contains('/') {
+        "\\"
+    } else {
+        "/"
     }
 }
 
@@ -1020,7 +1042,38 @@ fn zsh_shell_quote(s: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{command_name_starts_with, render_completer_run};
+    use super::{command_name_starts_with, render_completer_run, rendered_separator};
+
+    #[test]
+    fn a_slash_in_the_token_is_kept() {
+        // Every platform: `/` is a separator on all of them, and what was typed comes back.
+        assert_eq!(rendered_separator("target/de"), "/");
+        assert_eq!(rendered_separator("/abs/path"), "/");
+    }
+
+    #[test]
+    fn a_token_with_no_separator_yet_gets_a_slash() {
+        // Which is what the trailing directory marker has always used.
+        assert_eq!(rendered_separator(""), "/");
+        assert_eq!(rendered_separator("target"), "/");
+    }
+
+    #[test]
+    fn a_backslash_is_a_separator_only_on_windows() {
+        // On Unix `a\b` is one filename, and reading the backslash as a separator would render a
+        // completion nothing matches. `cfg!` rather than `#[cfg]` so both arms are type-checked
+        // wherever this is compiled.
+        let expected = if cfg!(windows) { "\\" } else { "/" };
+        assert_eq!(rendered_separator(r"target\de"), expected);
+        assert_eq!(rendered_separator(r"C:\Users\me"), expected);
+    }
+
+    #[test]
+    fn a_mixed_token_settles_on_the_slash() {
+        // Deterministic rather than clever: one of them has to win, and `/` works in both the
+        // shells that reach here on Windows and everywhere else.
+        assert_eq!(rendered_separator(r"target\de/inc"), "/");
+    }
 
     #[test]
     fn windows_command_prefixes_ignore_ascii_case() {


### PR DESCRIPTION
Path completion hands back a token nobody typed and no shell will match:

```
left:  "target\debug\incremental/\n"
right: "target/debug/incremental/\n"
```

The input was `target/de/inc`. The segments come from `read_dir`, so on Windows they arrive with `\`, and the trailing directory marker is a hard-coded `/` — one spelling for the middle of the path and another for the end.

`complete_path` already reads either separator on the way in (`ctoken.contains(MAIN_SEPARATOR) || (cfg!(windows) && ctoken.contains('/'))`), so the token was understood; only the answer was written in the platform's spelling rather than the caller's.

## The fix

Render with the separator already in the token:

```rust
fn rendered_separator(ctoken: &str) -> &'static str {
    if cfg!(windows) && ctoken.contains('\') && !ctoken.contains('/') {
        "\\"
    } else {
        "/"
    }
}
```

A completion finishes a word someone is in the middle of typing, so their spelling is the one to continue. `/` when the token has neither, which is what the trailing marker has always used and what every POSIX shell wants — so Unix output is unchanged, and `MAIN_SEPARATOR` there is already `/`, making the replacement a no-op.

A backslash counts as a separator on Windows only. On Unix it is an ordinary character in a filename, and reading `a\b` as two components would produce a completion that matches nothing.

A mixed token settles on `/` rather than guessing: one of them has to win, and `/` works in the shells that reach here on Windows as well as everywhere else.

## Tests

Four unit tests on `rendered_separator` in `complete_word.rs`, written with `cfg!` rather than `#[cfg]` so both arms are type-checked wherever they are compiled — the same shape as `looks_like_windows_path` in `cli/src/cli/shell.rs`. They cover a slash token, a token with no separator yet, a backslash being platform-dependent, and the mixed case.

`test_complete_path_preserves_partially_typed_segments` — which named this behaviour all along — passes on Windows now, and `test_complete_path_adds_trailing_slash_for_directories` still passes beside it.

## Verified

Windows: the two path tests pass, `usage-cli` unit tests 174/174. Linux: unchanged, including `complete_word`'s 50 and `clippy --all-targets` clean.

Not a breaking change — this replaces output that mixed separators with output that does not.

---

_This pull request was generated by Claude Code._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Path completion now preserves the separator style used in the input, including Unix `/` and Windows `\`.
  - Directory completions now use the appropriate separator instead of always adding `/`.
  - Mixed-separator inputs are handled more consistently.
  - Paths without an existing separator now default to `/`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->