### PR TITLE
docs(rust): align performance chart values

### DIFF
--- a/docs/.vitepress/theme/UsageBenches.vue
+++ b/docs/.vitepress/theme/UsageBenches.vue
@@ -32,9 +32,9 @@ const idPrefix = computed(() => `bench-${props.lang}`);
 // runner, and genuinely one *cold* parse — `parse-n` is differenced against the
 // same binary parsing nothing.
 const rustRows = [
-  { name: "usage-rs", value: 194, label: "190 ns", us: true },
+  { name: "usage-rs", value: 194, label: "0.19 µs", us: true },
   { name: "clap", value: 479605, label: "480 µs", note: "~2,500× more", us: false },
-  { name: "bpaf", value: 1597028, label: "1.6 ms", note: "~8,200× more", us: false },
+  { name: "bpaf", value: 1597028, label: "1,600 µs", note: "~8,200× more", us: false },
 ];
 
 // Go figures from go/README.md are whole-process wall time and subtract the

--- a/docs/.vitepress/theme/UsageBenches.vue
+++ b/docs/.vitepress/theme/UsageBenches.vue
@@ -177,9 +177,10 @@ onBeforeUnmount(() => window.removeEventListener("resize", replace));
                   :style="{ width: width(row.value, rustMax) }"
                 ></span>
               </span>
-              <span class="usage-bench-value"
-                >{{ row.label }}<em v-if="row.note"> · {{ row.note }}</em></span
-              >
+              <span class="usage-bench-value">
+                <span class="usage-bench-measure">{{ row.label }}</span>
+                <em v-if="row.note">· {{ row.note }}</em>
+              </span>
             </span>
           </div>
         </div>
@@ -238,9 +239,10 @@ onBeforeUnmount(() => window.removeEventListener("resize", replace));
                   :style="{ width: width(row.value, goMax) }"
                 ></span>
               </span>
-              <span class="usage-bench-value"
-                >{{ row.label }}<em v-if="row.note"> · {{ row.note }}</em></span
-              >
+              <span class="usage-bench-value">
+                <span class="usage-bench-measure">{{ row.label }}</span>
+                <em v-if="row.note">· {{ row.note }}</em>
+              </span>
             </span>
           </div>
         </div>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -654,11 +654,19 @@
 }
 
 .usage-bench-value {
-  flex: 0 0 8.5rem;
+  flex: 0 0 12rem;
+  display: grid;
+  grid-template-columns: 5.5rem 1fr;
+  column-gap: 0.45rem;
+  min-width: 0;
   font-family: var(--vp-font-family-mono);
   font-size: 0.75rem;
   color: rgba(245, 240, 255, 0.85);
   white-space: nowrap;
+}
+
+.usage-bench-measure {
+  text-align: right;
 }
 
 .usage-bench-value em {

--- a/docs/rust/performance.md
+++ b/docs/rust/performance.md
@@ -15,7 +15,7 @@ measurements subtract startup from two runs of the same binary.
 | --------- | -----------: | -------: | --------: | ---------------------------: |
 | usage     |        7,377 |        — |    0.7 µs |                            0 |
 | clap      |        6.31M |     855x |    544 µs |                        6,560 |
-| bpaf      |        21.9M |   2,957x |   1.61 ms |                            — |
+| bpaf      |        21.9M |   2,957x |  1,610 µs |                            — |
 
 clap and bpaf construct and validate a parser at runtime before reading a
 single word, so their floor is hundreds of microseconds. usage reads tables the


### PR DESCRIPTION
## Summary

- express all Rust parser timings in microseconds
- align benchmark measurements and comparison notes in stable columns
- apply the same value layout to the Rust and Go benchmark cards

## Validation

- `npm run docs:build`
- `npx prettier --check docs/.vitepress/theme/UsageBenches.vue docs/.vitepress/theme/custom.css`

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and CSS-only presentation of existing benchmark numbers; no runtime or security impact.
> 
> **Overview**
> Puts Rust parser wall times on a single **µs** scale (`0.19 µs`, `1,600 µs`) in the homepage benches and the performance table, so usage, clap, and bpaf can be compared without mixing ns/ms.
> 
> Splits each bar’s measure and “× more” note into a two-column grid on both the Rust and Go cards so the numbers line up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f351af6a055798a46f25c5e27f0d1137379eb7c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Rust and Go benchmark displays with clearer measurement formatting.
  * Improved benchmark value alignment and spacing for easier comparison.
  * Updated the Rust performance table to show wall time in microseconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->