### PR TITLE
fix(config): report config paths without the verbatim prefix

### DIFF
--- a/config/src/files.rs
+++ b/config/src/files.rs
@@ -13,7 +13,7 @@
 //! whose files are pkl or `.npmrc` writes its own layer against [`Layer`] and takes nothing it
 //! does not use.
 
-use std::path::{Component, Path, PathBuf};
+use std::path::{Component, Path, PathBuf, Prefix};
 
 use crate::layer::{Layer, LayerCtx, LayerError, LayerOutput};
 use crate::source::{FileScope, Origin, SourceKind};
@@ -421,7 +421,7 @@ fn parse(
 /// compares like with like even when both paths are strange.
 fn normalize(path: &Path) -> PathBuf {
     if let Ok(real) = path.canonicalize() {
-        return real;
+        return plain(real);
     }
     let absolute = std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf());
     let mut out = PathBuf::new();
@@ -442,7 +442,45 @@ fn normalize(path: &Path) -> PathBuf {
             }
         }
     }
-    out
+    plain(out)
+}
+
+/// A canonicalized path in the spelling a person recognizes.
+///
+/// `canonicalize` returns Windows' extended-length form — `\\?\C:\…`, or `\\?\UNC\host\share`
+/// for a network path. That prefix is right for the API that produced it and wrong for
+/// everything downstream: these paths are what a CLI reports as the provenance of a setting, so
+/// `config explain` would name a file the user cannot find by that name, and any comparison
+/// against a plainly-built path is false. Stripping it is the whole of the difference —
+/// canonicalization still did the work of resolving symlinks and `..`.
+///
+/// Read off `Component::Prefix` rather than by trimming a leading `\\?\`, so the UNC form is
+/// rebuilt as `\\host\share` rather than left as `UNC\host\share`. A bare `Verbatim` prefix
+/// (`\\?\pipe\…`) is left alone: there is no plain spelling of one to return.
+///
+/// Off Windows there are no prefixes at all, so this is the identity.
+fn plain(path: PathBuf) -> PathBuf {
+    let mut components = path.components();
+    let Some(Component::Prefix(prefix)) = components.next() else {
+        return path;
+    };
+    let rebuilt = match prefix.kind() {
+        Prefix::VerbatimDisk(letter) => PathBuf::from(format!("{}:\\", letter as char)),
+        Prefix::VerbatimUNC(host, share) => {
+            let mut out = PathBuf::from(r"\\");
+            out.push(host);
+            out.push(share);
+            out
+        }
+        _ => return path,
+    };
+    // `components` has already yielded the prefix; the root that follows it is part of the
+    // spelling rebuilt above, so only what comes after both is appended.
+    rebuilt.join(
+        components
+            .filter(|c| !matches!(c, Component::RootDir))
+            .collect::<PathBuf>(),
+    )
 }
 
 /// The link along `path` that leads nowhere, if there is one.
@@ -789,6 +827,39 @@ mod tests {
     use crate::resolve::{resolve, Layers};
     use crate::ty::{Parser, Ty};
     use crate::value::Value;
+
+    #[test]
+    fn a_verbatim_disk_path_comes_back_in_the_spelling_a_person_knows() {
+        // `cfg!` rather than `#[cfg]`, so both arms are type-checked wherever this compiles.
+        // Off Windows there is no prefix to find and the path is returned as it came.
+        let given = PathBuf::from(r"\\?\C:\Users\u\hk.toml");
+        let want = if cfg!(windows) {
+            PathBuf::from(r"C:\Users\u\hk.toml")
+        } else {
+            given.clone()
+        };
+        assert_eq!(plain(given), want);
+    }
+
+    #[test]
+    fn a_verbatim_unc_path_is_rebuilt_as_a_share_rather_than_trimmed() {
+        // Trimming a leading `\\?\` would leave `UNC\host\share`, which names nothing.
+        let given = PathBuf::from(r"\\?\UNC\host\share\hk.toml");
+        let want = if cfg!(windows) {
+            PathBuf::from(r"\\host\share\hk.toml")
+        } else {
+            given.clone()
+        };
+        assert_eq!(plain(given), want);
+    }
+
+    #[test]
+    fn a_path_with_no_verbatim_prefix_is_left_alone() {
+        for path in [r"C:\Users\u\hk.toml", "/home/u/hk.toml", "hk.toml"] {
+            let given = PathBuf::from(path);
+            assert_eq!(plain(given.clone()), given, "{path}");
+        }
+    }
 
     static PROPS: &[PropMeta] = &[
         PropMeta::new("jobs", Ty::Uint),


### PR DESCRIPTION
`normalize` canonicalizes so a boundary check compares like with like, and on Windows `canonicalize` answers in the extended-length form:

```
\?\D:\a\usage\usage\config\…\hk.toml
```

That prefix is right for the API that produced it and wrong for everything after. `find_up` puts these straight into `FileLayer::paths`, which is what a CLI reports as the provenance of a setting — so `config explain` would name a file by a spelling the user cannot find it under, and any comparison against a plainly-built path is false. The two tests that caught it compare against `current_dir().join(…)`, which is the shape a caller has:

```
left:  "\?\D:\a\usage\usage\config\…\hk.toml"
right: "D:\a\usage\usage\config\…\hk.toml"
```

## The fix

Canonicalization stays. Resolving symlinks and `..` together is the thing no amount of string work can do, and the doc above `normalize` explains why both sides of the comparison need it. Only the prefix comes off, at the one place `normalize` returns.

Read off `Component::Prefix` rather than by trimming a leading `\?\`, so the UNC form is rebuilt as `\host\share` rather than left as `UNC\host\share`, which names nothing. A bare `Verbatim` prefix such as `\?\pipe\…` is left alone, having no plain spelling to return to. Off Windows there are no prefixes and this is the identity.

Three unit tests, written with `cfg!` rather than `#[cfg]` so both arms are type-checked wherever they compile — the same shape as `looks_like_windows_path` in `cli/src/cli/shell.rs`.

## How this was found

By running the suite on a `windows-latest` runner, which nothing does yet. `cargo test --all --all-features --no-fail-fast` there gave **2383 passed, 5 failed** — these two, and three in `usage-argv` that are a separate PR.

Verified on the same runner with both fixes applied: **2393 passed, 0 failed**. Linux unchanged.

## What this is for

A Windows CI job. usage is released for Windows — `publish-cli.yml` builds `x86_64-pc-windows-msvc` and `aarch64-pc-windows-msvc` — but nothing tests it there, so every Windows fix of the last few weeks was verified by hand. This and the `usage-argv` PR are what stand between here and adding that job.

---

_This pull request was generated by Claude Code._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Windows paths now display in a more familiar format by removing internal verbatim disk and network prefixes.
  * Path handling remains unchanged for paths that do not use these prefixes.
  * Improved consistency when resolving paths through fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->