### PR TITLE
fix(argv): plan for the target platform, not the host

### DIFF
--- a/argv/src/install.rs
+++ b/argv/src/install.rs
@@ -247,7 +247,7 @@ pub fn plan_for(bin: &str, name: &str, shell: Shell, env: &Env) -> Result<Plan, 
     Ok(Plan {
         shell,
         name: name.to_string(),
-        loading: loading(shell, resolved_from, &path),
+        loading: loading(shell, resolved_from, &dir, &path),
         note: note(shell, resolved_from),
         path,
         resolved_from,
@@ -468,17 +468,30 @@ fn first_entry(value: &OsStr, list: bool, platform: Platform) -> Option<&OsStr> 
 /// avoid: a plan is made *for* a platform, not on one. On a Windows host a Linux plan came out
 /// as `/home/u\.local\share\zsh\site-functions`, which no zsh resolves.
 ///
-/// A separator already at the end of `base` is not doubled — a `HOME` of `/home/u/` is as
-/// ordinary as one without.
+/// `base` is appended to rather than rebuilt from a string. `Env` keeps values as `OsString`
+/// because a home directory that is not UTF-8 is still a home directory, and `to_string_lossy`
+/// would turn those bytes into `U+FFFD` and hand back a path that is not the one the variable
+/// named. Only the last byte is looked at, which needs no reconstruction — the unsafe step
+/// `first_entry` says this crate has nothing to spend.
 fn join_for(base: &Path, part: &str, platform: Platform) -> PathBuf {
-    let separator = platform.separator();
-    let base = base.to_string_lossy();
-    let trimmed = base.trim_end_matches(['/', '\\']);
-    // Nothing left means `base` was the root itself, whose separator is the whole of it.
-    if trimmed.is_empty() {
-        return PathBuf::from(format!("{base}{part}"));
+    let bytes = base.as_os_str().as_encoded_bytes();
+    let mut out = base.as_os_str().to_os_string();
+    // A base that already ends in a separator does not get another — a `HOME` of `/home/u/` is
+    // as ordinary as one without, and a root is nothing but its separator.
+    //
+    // What counts as one is the planned platform's business, for the reason everything else here
+    // is: off Windows a `\` is an ordinary character in a filename, so a `HOME` of `/home/u\`
+    // names a directory called `u\`. Reading that trailing byte as a separator would put the
+    // child in `/home/u\.local` — a sibling named `u\.local`, not `.local` inside it.
+    let ends_with_separator = match platform {
+        Platform::Windows => matches!(bytes.last(), Some(b'/' | b'\\')),
+        Platform::Linux | Platform::MacOs => bytes.last() == Some(&b'/'),
+    };
+    if !bytes.is_empty() && !ends_with_separator {
+        out.push(platform.separator().to_string());
     }
-    PathBuf::from(format!("{trimmed}{separator}{part}"))
+    out.push(part);
+    PathBuf::from(out)
 }
 
 /// `Path::is_absolute` answers for the host, which is the wrong question twice over: a Windows path
@@ -497,8 +510,12 @@ fn is_absolute(value: &OsStr, platform: Platform) -> bool {
 }
 
 /// Whether a shell will find this file by itself, and the one line it needs if it will not.
-fn loading(shell: Shell, resolved_from: &'static str, path: &Path) -> Loading {
-    let dir = path.parent().unwrap_or(path);
+///
+/// `dir` is taken rather than derived from `path`. `Path::parent` splits on the *host's*
+/// separator, so on a Unix host a plan made for Windows — `C:\…\_ex`, one component to a parser
+/// that does not read `\` as a separator — has an empty parent, and zsh was told to add nothing
+/// at all to its `$fpath`. The caller already holds the directory it built.
+fn loading(shell: Shell, resolved_from: &'static str, dir: &Path, path: &Path) -> Loading {
     match shell {
         Shell::Bash | Shell::Fish => Loading::Automatic,
         Shell::Zsh => Loading::Manual {
@@ -1127,6 +1144,41 @@ mod tests {
         assert_eq!(
             join_for(Path::new(r"C:\Users\u"), "AppData", Platform::Windows),
             PathBuf::from(r"C:\Users\u\AppData")
+        );
+    }
+
+    #[test]
+    fn zsh_planned_for_windows_names_the_directory_it_was_given() {
+        // `Path::parent` splits on the host's separator, so deriving the directory from an
+        // all-backslash path on a Unix host produced an empty one and `fpath+=('')`.
+        let windows = described(
+            Platform::Windows,
+            &[("XDG_DATA_HOME", r"C:\Users\u\AppData\Local")],
+        );
+        let target = plan("ex", Shell::Zsh, &windows).unwrap();
+        let Loading::Manual { line, .. } = &target.loading else {
+            panic!("zsh finds nothing on its own: {:?}", target.loading);
+        };
+        assert!(
+            line.contains(r"C:\Users\u\AppData\Local\zsh\site-functions"),
+            "{line}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_base_that_is_not_utf8_survives_the_join() {
+        // `Env` keeps values as `OsString` because a home directory that is not UTF-8 is still a
+        // home directory. Building the path through `to_string_lossy` replaced those bytes with
+        // `U+FFFD` and returned a path that is not the one `HOME` named.
+        use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+        let base = PathBuf::from(OsString::from_vec(b"/home/\xff".to_vec()));
+        let joined = join_for(&base, ".local", Platform::Linux);
+        assert_eq!(
+            joined.as_os_str().as_bytes(),
+            b"/home/\xff/.local",
+            "{joined:?}"
         );
     }
 

--- a/argv/src/install.rs
+++ b/argv/src/install.rs
@@ -77,6 +77,20 @@ impl Platform {
     pub const fn is_windows(self) -> bool {
         matches!(self, Platform::Windows)
     }
+
+    /// The separator this platform puts between path components.
+    ///
+    /// For the same reason [`is_absolute`] takes a platform: `Path::join` uses the *host's*
+    /// separator, so a plan made on Windows for a Linux machine came out as
+    /// `/home/u\.local\share\zsh\site-functions` — half of it in each spelling, and a `$fpath`
+    /// entry no zsh would resolve. Everything here answers for the platform being planned for,
+    /// which is not always the one doing the planning.
+    pub const fn separator(self) -> char {
+        match self {
+            Platform::Windows => '\\',
+            Platform::Linux | Platform::MacOs => '/',
+        }
+    }
 }
 
 /// The environment a plan is resolved against: some variables, and a platform.
@@ -229,7 +243,7 @@ pub fn plan_for(bin: &str, name: &str, shell: Shell, env: &Env) -> Result<Plan, 
     }
 
     let (dir, resolved_from) = base_dir(shell, env)?;
-    let path = dir.join(file_name(shell, name));
+    let path = join_for(&dir, &file_name(shell, name), env.platform());
     Ok(Plan {
         shell,
         name: name.to_string(),
@@ -408,8 +422,12 @@ fn base_dir(shell: Shell, env: &Env) -> Result<(PathBuf, &'static str), Error> {
         if !is_absolute(base, env.platform()) {
             continue;
         }
+        // Not `PathBuf::extend`, which joins with the host's separator. See
+        // [`Platform::separator`].
         let mut dir = PathBuf::from(base);
-        dir.extend(source.under.iter());
+        for part in source.under.iter() {
+            dir = join_for(&dir, part, env.platform());
+        }
         return Ok((dir, source.var));
     }
     Err(Error::NoBaseDir {
@@ -444,6 +462,25 @@ fn first_entry(value: &OsStr, list: bool, platform: Platform) -> Option<&OsStr> 
 
 /// Whether a value names a directory from the root, by the rules of the platform being planned for.
 ///
+/// `base` and `part`, joined the way `platform` spells a path.
+///
+/// `Path::join` uses the host's separator, which is the same mistake [`is_absolute`] exists to
+/// avoid: a plan is made *for* a platform, not on one. On a Windows host a Linux plan came out
+/// as `/home/u\.local\share\zsh\site-functions`, which no zsh resolves.
+///
+/// A separator already at the end of `base` is not doubled — a `HOME` of `/home/u/` is as
+/// ordinary as one without.
+fn join_for(base: &Path, part: &str, platform: Platform) -> PathBuf {
+    let separator = platform.separator();
+    let base = base.to_string_lossy();
+    let trimmed = base.trim_end_matches(['/', '\\']);
+    // Nothing left means `base` was the root itself, whose separator is the whole of it.
+    if trimmed.is_empty() {
+        return PathBuf::from(format!("{base}{part}"));
+    }
+    PathBuf::from(format!("{trimmed}{separator}{part}"))
+}
+
 /// `Path::is_absolute` answers for the host, which is the wrong question twice over: a Windows path
 /// is not absolute on Linux, and a `/etc`-style path is not absolute on Windows.
 fn is_absolute(value: &OsStr, platform: Platform) -> bool {
@@ -1006,8 +1043,15 @@ mod tests {
             &[("APPDATA", r"C:\Users\u\AppData\Roaming")],
         );
         let target = plan("ex", Shell::Nu, &windows).unwrap();
+        // Spelled the way a Windows plan is spelled. `Path::ends_with` matches whole components,
+        // and off Windows a `\` is not a separator but an ordinary character — so the slashes
+        // this used to carry only matched while the host's separator was leaking into a plan
+        // made for somewhere else.
         assert!(
-            target.path.ends_with("nushell/completions/ex.nu"),
+            target
+                .path
+                .to_string_lossy()
+                .ends_with(r"nushell\completions\ex.nu"),
             "{target:?}"
         );
         assert_eq!(target.resolved_from, "APPDATA");
@@ -1074,6 +1118,33 @@ mod tests {
     }
 
     #[test]
+    fn a_join_uses_the_planned_platforms_separator_not_the_hosts() {
+        // The bug this replaced: on a Windows host, a Linux plan came out half in each spelling.
+        assert_eq!(
+            join_for(Path::new("/home/u"), ".local", Platform::Linux),
+            PathBuf::from("/home/u/.local")
+        );
+        assert_eq!(
+            join_for(Path::new(r"C:\Users\u"), "AppData", Platform::Windows),
+            PathBuf::from(r"C:\Users\u\AppData")
+        );
+    }
+
+    #[test]
+    fn a_join_does_not_double_a_separator_already_there() {
+        // A `HOME` with a trailing slash is as ordinary as one without.
+        assert_eq!(
+            join_for(Path::new("/home/u/"), ".local", Platform::Linux),
+            PathBuf::from("/home/u/.local")
+        );
+        // And a root is nothing but its separator, so there is none to trim.
+        assert_eq!(
+            join_for(Path::new("/"), "etc", Platform::Linux),
+            PathBuf::from("/etc")
+        );
+    }
+
+    #[test]
     fn a_windows_path_is_absolute_where_a_unix_one_is_not_and_the_reverse() {
         // `Path::is_absolute` answers for the host. Both directions matter: a plan for Windows made
         // on Linux must accept `C:\`, and a plan for Linux must not accept it.
@@ -1112,7 +1183,13 @@ mod tests {
         );
         let target = plan("ex", Shell::Zsh, &relative).unwrap();
         assert_eq!(target.resolved_from, "HOME");
-        assert!(target.path.is_absolute(), "{:?}", target.path);
+        // The crate's own, not `Path::is_absolute` — this plan is for Linux, and asking the host
+        // would call `/home/u/...` relative on the machine these tests run on.
+        assert!(
+            is_absolute(target.path.as_os_str(), Platform::Linux),
+            "{:?}",
+            target.path
+        );
     }
 
     #[test]

--- a/argv/tests/scripts.rs
+++ b/argv/tests/scripts.rs
@@ -122,6 +122,33 @@ fn available(program: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Whether a program can check a script this test would hand it, so a shell that cannot is
+/// skipped rather than failing the suite.
+///
+/// Not `--version`. On Windows the executable search order puts the system directory ahead of
+/// `PATH`, and installing WSL puts `bash.exe` there — a launcher that answers `--version`
+/// perfectly well and then cannot open the file it is given, which is how this test came to
+/// fail rather than skip. The precondition is the whole invocation, so that is what gets tried:
+/// the same program and flags, on a script known to be valid.
+fn can_check_a_script(program: &str, args: &[&str]) -> bool {
+    let dir = std::env::temp_dir().join(format!(
+        "usage_argv_shell_probe_{}_{program}",
+        std::process::id()
+    ));
+    if fs::create_dir_all(&dir).is_err() {
+        return false;
+    }
+    let probe = dir.join("probe");
+    let usable = fs::write(&probe, "echo ok\n").is_ok()
+        && Command::new(program)
+            .args(args)
+            .arg(&probe)
+            .output()
+            .is_ok_and(|out| out.status.success());
+    let _ = fs::remove_dir_all(&dir);
+    usable
+}
+
 #[test]
 fn every_script_is_valid_in_its_own_shell() {
     // A syntax error in generated text is the failure mode that reaches a user as a broken
@@ -134,7 +161,7 @@ fn every_script_is_valid_in_its_own_shell() {
 
     let mut ran = 0;
     for (shell, program, args) in checks {
-        if !available(program) {
+        if !can_check_a_script(program, args) {
             continue;
         }
         let fixture = Fixture::new(&format!("syntax-{program}"), *shell, "");
@@ -152,10 +179,19 @@ fn every_script_is_valid_in_its_own_shell() {
         ran += 1;
     }
     // Named rather than silently skipped: a test that checks nothing should say so.
-    assert!(
-        ran > 0,
-        "no shell was available to check a script against — bash, zsh and fish were all missing"
-    );
+    //
+    // Unix only. CI installs zsh and fish for the Linux job, so none of the three being usable
+    // there is a configuration bug worth stopping for. Nothing installs them on Windows, and a
+    // bare `bash` is the WSL launcher that cannot open the file it is handed — so having no
+    // shell to check against is the expected state there rather than a fault.
+    if cfg!(unix) {
+        assert!(
+            ran > 0,
+            "no shell was available to check a script against — bash, zsh and fish were all missing"
+        );
+    } else if ran == 0 {
+        println!("no shell here could check a script; this verified nothing");
+    }
     if ran < checks.len() {
         println!(
             "checked {ran} of {} shells; the rest are not installed",


### PR DESCRIPTION
> Draft until #1232 merges — this repository accepts one open PR at a time.

`plan` takes a `Platform` because an install plan is made *for* a machine, not on one. `is_absolute` already says so, in a doc explaining that `Path::is_absolute` "answers for the host, which is the wrong question twice over". Three places had not caught up, and running the suite on a Windows runner found them.

## The joins used the host's separator

A Linux plan made on Windows came out half in each spelling:

```
fpath+=('/home/u\.local\share\zsh\site-functions')
```

No zsh resolves that. `Platform::separator` answers for the platform being planned for, and `join_for` uses it — trimming a separator already at the end of the base, so a `HOME` with a trailing slash is as ordinary as one without.

## Two tests were asking the host

`a_relative_value_is_ignored_rather_than_obeyed` asserted with `Path::is_absolute` when the crate has its own platform-aware one three hundred lines up. The plan under test is for Linux, so on Windows the host called `/home/u/…` relative. **The product was right and the test asked the wrong question.**

`nu_follows_each_platform_to_its_own_config_directory` asserted `ends_with("nushell/completions/ex.nu")` on a **Windows** plan. `Path::ends_with` matches whole components, and off Windows a `\` is an ordinary character — so those slashes only ever matched *because* the host's separator was leaking into a plan meant for somewhere else. It was passing on the strength of the bug, and fixing the bug is what surfaced it. Now spelled the way a Windows plan is spelled.

## A probe that a launcher fooled

`every_script_is_valid_in_its_own_shell` skipped on `available()`, which only asks whether `--version` succeeds. On Windows the system directory comes before `PATH` and WSL puts `bash.exe` there — a launcher that answers `--version` and then cannot open the file it is handed. The probe now tries the whole invocation: same program, same flags, on a script known to be valid.

With that, all three shells report themselves unusable on Windows, and the `ran > 0` assertion fired. That assertion is right where CI installs the shells and wrong where nothing does, so it is Unix-only now — the same line #1229 drew for `skip_if_shell_missing`. On Windows the test says it verified nothing rather than claiming a pass.

`available` stays for the ten tests that use it. They were passing on the runner, and they are not what this measured.

## Verified

On a `windows-latest` runner, `cargo test --all --all-features --no-fail-fast` was **2383 passed, 5 failed** before — these three plus two in `usage-config` (#1232). With both PRs applied: **2393 passed, 0 failed**, with only zsh, fish and bash-completion skipping, none of which exist on Windows.

Linux passes unchanged, which is worth stating separately: the `nu` test above is exactly the kind of thing that breaks there when a host-coupled assumption is removed, and it did.

---

_This pull request was generated by Claude Code._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cross-platform path handling so generated plans use the correct separators for the target environment, including root and trailing-path cases.
  - Improved shell validation to reliably detect whether script launchers can execute, including Windows WSL Bash installations.

- **Tests**
  - Expanded platform-specific coverage for Windows and relative paths.
  - Updated script syntax checks to use a temporary probe and handle unavailable shells appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->