### PR TITLE
fix(test): compile the platform-conditional fixtures warning-free on windows

### DIFF
--- a/conformance/tests/derive_settings.rs
+++ b/conformance/tests/derive_settings.rs
@@ -12,7 +12,7 @@
 use std::ffi::OsStr;
 use std::path::PathBuf;
 
-use usage_config::{resolve, Const, Layers, PropMeta, Registry, Ty, Value, WarningKind};
+use usage_config::{resolve, Const, Layers, PropMeta, Registry, Ty, Value};
 use usage_derive::Cli;
 
 /// A tool with settings
@@ -177,6 +177,7 @@ fn a_value_that_is_not_text_is_reported_rather_than_rendered() {
     // still held the real bytes, and the command line's answer is the one that outranks every file
     // on the machine.
     use std::os::unix::ffi::OsStrExt;
+    use usage_config::WarningKind;
 
     let bytes = OsStr::from_bytes(b"/etc/co\xffnfig");
     let argv = [OsStr::new("--config"), bytes];

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -1332,6 +1332,11 @@ struct StrictFlatten {
 
 #[derive(ValueEnum)]
 #[usage(ignore_case)]
+// `PowerShell` ends with the enum name, which `clippy::enum_variant_names` reads as a prefix
+// worth hoisting. It is the shell's actual name, and the lint only fires on Windows, where the
+// variant exists at all — a rename to satisfy it would leave the enum spelling something no
+// user types.
+#[allow(clippy::enum_variant_names)]
 enum Shell {
     #[usage(
         aliases(["bourne-again", "bash-shell"]),


### PR DESCRIPTION
Two compiler warnings that only a Windows build can see. Both are created by `#[cfg]`, and neither has ever been compiled here, because there is no `windows-latest` job.

They matter more than warnings usually do: `mise r lint:clippy` is

```
cargo clippy --all --all-features --all-targets -- -D warnings
```

`--all-targets` covers test targets and `-D warnings` denies. On Windows these are a build failure, not noise — so this is a prerequisite for the CI job rather than a tidy-up.

## `conformance/tests/derive_settings.rs` — `unused import: WarningKind`

`WarningKind` is imported at the top of the file, and the only test that uses it is `#[cfg(unix)]`: it builds a non-UTF-8 path with `OsStr::from_bytes`, which exists only there. Everywhere else the import has no use.

It moves inside the test, beside the `use std::os::unix::ffi::OsStrExt;` that is already there for the same reason.

I looked at whether the test could instead run on Windows, since the mechanism under test is platform-independent — `SettingGiven::NotText` is decided by `std::str::from_utf8` over bytes. It cannot, and the reason is documented in `argv/src/lib.rs`: `os_string_from_bytes` deliberately **refuses** an unpaired surrogate on Windows rather than reaching for `from_encoded_bytes_unchecked`, so the crate needs no `unsafe`. The Unix test's first assertion — that the field keeps the real bytes — is therefore false on Windows *by design*. A Windows sibling would be a different test asserting that refusal, which is a coverage gap worth filling but not this change.

## `usage-rs/tests/facade.rs` — `variant name ends with the enum's name`

```rust
enum Shell {
    Bash,
    Zsh,
    #[cfg(windows)]
    PowerShell,
}
```

On Linux the enum is `{ Bash, Zsh }` and nothing fires. On Windows the third variant appears, a variant name ends with the enum's own, and `clippy::enum_variant_names` reports it.

Allowed with a reason rather than renamed. `PowerShell` is the shell's actual name, and a spelling picked to satisfy the lint would be one no user types — which is the opposite of what a `ValueEnum` fixture should demonstrate.

## Measurement

Run on `windows-latest` in a fork, since there is no Windows job here yet.

**Before** — `cargo clippy --all --all-features --all-targets` with warnings *not* denied, to enumerate rather than stop at the first:

```
warning: unused import: `WarningKind`
  --> conformance\tests\derive_settings.rs:15:75
warning: variant name ends with the enum's name
    --> usage-rs\tests\facade.rs:1349:5
```

Two, and only two.

**After** — the real task, `mise r lint:clippy`, with no `continue-on-error`:

```
[lint:clippy] $ cargo clippy --all --all-features --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 19s
```

Green. The Linux test job on the same commit is green too, so neither edit changes anything there — as expected, since neither warning exists on Linux (0 hits for `warning:` across 4,415 lines of that job's log).

## Why draft

Behind #1232 and #1233, which fix the five actual Windows test failures. This one clears the *lint* half of the same door. The `windows-latest` job follows once all three land.

---

_This description was generated by Claude Code._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved platform-specific test organization without changing behavior.
  - Preserved the user-facing spelling of the Windows PowerShell option while clarifying its platform-specific usage.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->