### PR TITLE
perf(derive): share the repeated-value collection loop across fields

### DIFF
--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -1356,6 +1356,73 @@ pub fn invalid_os_value<'t, 'v>(name: &'t str, bytes: Vec<u8>) -> Error<'t, 'v> 
     )
 }
 
+/// Convert every repeated value of one text field, reporting `name` for the
+/// first that is not UTF-8.
+///
+/// The shared body of what a generated `build` does per collecting text field:
+/// one loop in the binary rather than one per field. Converts element by
+/// element rather than with `collect` so the error can carry the value that
+/// failed rather than only that one did.
+pub fn utf8_values<'t, 'v>(
+    values: Vec<Vec<u8>>,
+    name: &'t str,
+) -> Result<Vec<String>, Error<'t, 'v>> {
+    let mut out = Vec::with_capacity(values.len());
+    for value in values {
+        match String::from_utf8(value) {
+            Ok(text) => out.push(text),
+            Err(bad) => return Err(invalid_utf8_value(name, bad)),
+        }
+    }
+    Ok(out)
+}
+
+/// Convert every repeated value of one field through
+/// [`FromStr`](std::str::FromStr), reporting `name` for the first that fails.
+///
+/// Monomorphized once per target type rather than expanded once per field.
+pub fn parsed_values<'t, 'v, T>(
+    values: Vec<Vec<u8>>,
+    name: &'t str,
+) -> Result<Vec<T>, Error<'t, 'v>>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    let mut out = Vec::with_capacity(values.len());
+    for value in values {
+        let text = match String::from_utf8(value) {
+            Ok(text) => text,
+            Err(bad) => return Err(invalid_utf8_value(name, bad)),
+        };
+        match text.parse() {
+            Ok(parsed) => out.push(parsed),
+            Err(reason) => return Err(invalid_parsed_value(name, text, &reason)),
+        }
+    }
+    Ok(out)
+}
+
+/// Convert every repeated value of one path-like field, reporting `name` for
+/// the first the platform cannot hold.
+///
+/// `T` is what the field collects — [`PathBuf`](std::path::PathBuf) or
+/// [`OsString`] — so one body serves both. The same platform note as
+/// [`os_string_from_bytes`] applies: lossless on Unix, partial on Windows.
+pub fn os_values<'t, 'v, T: From<OsString>>(
+    values: Vec<Vec<u8>>,
+    name: &'t str,
+) -> Result<Vec<T>, Error<'t, 'v>> {
+    let mut out = Vec::with_capacity(values.len());
+    for value in values {
+        match os_string_from_bytes(value) {
+            Ok(os) => out.push(T::from(os)),
+            Err(bytes) => return Err(invalid_os_value(name, bytes)),
+        }
+    }
+    Ok(out)
+}
+
 /// A single-pass parse over `argv`.
 ///
 /// Created with [`Parser::new`] and driven with [`Parser::next_event`].

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -1363,7 +1363,25 @@ pub fn invalid_os_value<'t, 'v>(name: &'t str, bytes: Vec<u8>) -> Error<'t, 'v> 
 /// one loop in the binary rather than one per field. Converts element by
 /// element rather than with `collect` so the error can carry the value that
 /// failed rather than only that one did.
+///
+/// The empty case is answered here rather than in the shared loop, and this is
+/// what keeps sharing the loop free: a command at mise's scale declares dozens
+/// of collecting fields and a command line names one or two of them, so most of
+/// these calls have nothing to convert. Testing that at the field costs a branch;
+/// reaching the loop to learn it costs the call.
+#[inline]
 pub fn utf8_values<'t, 'v>(
+    values: Vec<Vec<u8>>,
+    name: &'t str,
+) -> Result<Vec<String>, Error<'t, 'v>> {
+    if values.is_empty() {
+        return Ok(Vec::new());
+    }
+    utf8_values_given(values, name)
+}
+
+#[inline(never)]
+fn utf8_values_given<'t, 'v>(
     values: Vec<Vec<u8>>,
     name: &'t str,
 ) -> Result<Vec<String>, Error<'t, 'v>> {
@@ -1380,8 +1398,25 @@ pub fn utf8_values<'t, 'v>(
 /// Convert every repeated value of one field through
 /// [`FromStr`](std::str::FromStr), reporting `name` for the first that fails.
 ///
-/// Monomorphized once per target type rather than expanded once per field.
+/// Monomorphized once per target type rather than expanded once per field, and
+/// the empty case is answered at the field for the reason [`utf8_values`] gives.
+#[inline]
 pub fn parsed_values<'t, 'v, T>(
+    values: Vec<Vec<u8>>,
+    name: &'t str,
+) -> Result<Vec<T>, Error<'t, 'v>>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    if values.is_empty() {
+        return Ok(Vec::new());
+    }
+    parsed_values_given(values, name)
+}
+
+#[inline(never)]
+fn parsed_values_given<'t, 'v, T>(
     values: Vec<Vec<u8>>,
     name: &'t str,
 ) -> Result<Vec<T>, Error<'t, 'v>>
@@ -1408,8 +1443,21 @@ where
 ///
 /// `T` is what the field collects — [`PathBuf`](std::path::PathBuf) or
 /// [`OsString`] — so one body serves both. The same platform note as
-/// [`os_string_from_bytes`] applies: lossless on Unix, partial on Windows.
+/// [`os_string_from_bytes`] applies: lossless on Unix, partial on Windows. The
+/// empty case is answered at the field for the reason [`utf8_values`] gives.
+#[inline]
 pub fn os_values<'t, 'v, T: From<OsString>>(
+    values: Vec<Vec<u8>>,
+    name: &'t str,
+) -> Result<Vec<T>, Error<'t, 'v>> {
+    if values.is_empty() {
+        return Ok(Vec::new());
+    }
+    os_values_given(values, name)
+}
+
+#[inline(never)]
+fn os_values_given<'t, 'v, T: From<OsString>>(
     values: Vec<Vec<u8>>,
     name: &'t str,
 ) -> Result<Vec<T>, Error<'t, 'v>> {

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -2946,6 +2946,29 @@ pub trait ValueEnum: Sized {
     fn from_choice(value: &str) -> Option<Self>;
 }
 
+/// Convert every repeated value of one [`ValueEnum`] field, reporting `name`
+/// for the first word that is not one of the declared values.
+///
+/// The shared body of what a generated `build` does per collecting enum field —
+/// monomorphized once per enum type rather than expanded once per field.
+pub fn choice_values<'t, 'v, T: ValueEnum>(
+    values: Vec<Vec<u8>>,
+    name: &'t str,
+) -> Result<Vec<T>, crate::Error<'t, 'v>> {
+    let mut out = Vec::with_capacity(values.len());
+    for value in values {
+        let text = match String::from_utf8(value) {
+            Ok(text) => text,
+            Err(bad) => return Err(crate::invalid_utf8_value(name, bad)),
+        };
+        match T::from_choice(&text) {
+            Some(parsed) => out.push(parsed),
+            None => return Err(crate::invalid_choice_value(name, text)),
+        }
+    }
+    Ok(out)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ChoiceMeta<'a> {
     pub value: &'a str,

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -2950,8 +2950,21 @@ pub trait ValueEnum: Sized {
 /// for the first word that is not one of the declared values.
 ///
 /// The shared body of what a generated `build` does per collecting enum field —
-/// monomorphized once per enum type rather than expanded once per field.
+/// monomorphized once per enum type rather than expanded once per field. The
+/// empty case is answered at the field for the reason [`crate::utf8_values`] gives.
+#[inline]
 pub fn choice_values<'t, 'v, T: ValueEnum>(
+    values: Vec<Vec<u8>>,
+    name: &'t str,
+) -> Result<Vec<T>, crate::Error<'t, 'v>> {
+    if values.is_empty() {
+        return Ok(Vec::new());
+    }
+    choice_values_given(values, name)
+}
+
+#[inline(never)]
+fn choice_values_given<'t, 'v, T: ValueEnum>(
     values: Vec<Vec<u8>>,
     name: &'t str,
 ) -> Result<Vec<T>, crate::Error<'t, 'v>> {

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -4763,15 +4763,11 @@ fn field_value(field: &Field, omitter: Option<&TokenStream>) -> TokenStream {
                 })
             }
             Shape::Many => {
-                let value = converted(quote!(__usage_value));
-                let collected = quote! {{
-                    let mut __usage_values =
-                        ::std::vec::Vec::with_capacity(partial.#ident.len());
-                    for __usage_value in partial.#ident {
-                        __usage_values.push(#value);
-                    }
-                    __usage_values
-                }};
+                // One shared loop in the runtime rather than one per field — the
+                // collecting fields were most of what a large `build` still held.
+                let collected = quote! {
+                    usage_argv::os_values(partial.#ident, #name)?
+                };
                 if field.optional_collection {
                     let given = format_ident!("__given_{}", ident);
                     let defaulted = !field.default.is_empty();
@@ -4864,21 +4860,16 @@ fn field_value(field: &Field, omitter: Option<&TokenStream>) -> TokenStream {
             })
         }
         Shape::Many => {
-            let one = converted(quote!(__usage_value));
-            // Built by hand rather than with `collect`, so the error can carry the value
-            // that failed rather than only that one did.
-            // A `Vec<String>` is moved whole. Rebuilding it element by element allocated a
-            // second `Vec` to hold what the first already held, which is one allocation per
-            // collecting field — and mise's commands collect a lot.
-            // Built by hand rather than with `collect`, so the error can carry the value
-            // that failed rather than only that one did.
-            let collected = quote! {{
-                let mut __usage_values = ::std::vec::Vec::with_capacity(partial.#ident.len());
-                for __usage_value in partial.#ident {
-                    __usage_values.push(#one);
-                }
-                __usage_values
-            }};
+            // One shared loop in the runtime rather than one per field — the collecting
+            // fields were most of what a large `build` still held. Each helper converts
+            // element by element so the error carries the value that failed.
+            let collected = if field.value_enum {
+                quote!(usage_argv::spec::choice_values::<#ty>(partial.#ident, #name)?)
+            } else if is_std_string {
+                quote!(usage_argv::utf8_values(partial.#ident, #name)?)
+            } else {
+                quote!(usage_argv::parsed_values::<#ty>(partial.#ident, #name)?)
+            };
             if field.optional_collection {
                 let given = format_ident!("__given_{}", ident);
                 // A declared default is a value, so a field that has one is never `None`. It


### PR DESCRIPTION
Stacked on #1235.

After the error paths moved out of line, most of what a large `build()` still held was the collecting fields: every `Vec`-shaped field carried its own `with_capacity` + loop + push + conversion. `WatchArgs::build` (the watchexec-scale command) was still 31 KB.

Two commits, because the first one had a cost worth naming rather than burying.

**1. Share the loop.** Four runtime helpers — `utf8_values`, `parsed_values`, `os_values` (generic over `From<OsString>`, so `Vec<PathBuf>` and `Vec<OsString>` share one body), and `spec::choice_values` — monomorphized once per element type instead of expanded once per field. Each still converts element by element, so the error carries the value that failed. Messages unchanged.

That bought 65 KB and **cost about 6% of the parse's wall time** (366 → 380 ns) plus 246 instructions. A command at mise's scale declares dozens of collecting fields and a command line names one or two, so most of these calls were reaching the shared loop only to find nothing to convert — where the inlined version had a loop LLVM could fold away entirely.

**2. Answer the empty case at the field.** Each helper now tests `is_empty()` in an `#[inline]` wrapper and calls an `#[inline(never)]` body only when there is something to convert. The branch at the field costs a few bytes; the call it replaces was the actual cost. This gives back 14 KB of the 65 and recovers the time — ending up *below* the branch point on instructions.

## Measurements

Mise shadow gate binary (`parse-n`, stripped, full workspace release build):

| | #1235 (base) | commit 1 | this PR | vs base |
|---|---|---|---|---|
| stripped binary | 1,369,072 B | 1,304,408 B | 1,318,288 B | **−51 KB (−3.7%)** |
| cold parse, instructions | 7,433 | 7,679 | 7,385 | **−0.6%** |
| parse wall time | 364 ns | 380 ns | 369 ns | indistinguishable |

Wall time is the min of 8 interleaved runs of each build on one machine — base, this PR and `main` measured 364 / 369 / 365 ns against a run-to-run spread of about 15%, so nothing separates them. The instruction count is the deterministic figure and is the basis for the claim: 7,385 is lower than both the base of this PR (7,433) and `main` (7,501).

CI's own shadow measurement confirms this on different hardware: its cold-parse instruction count went 8,351 (base) -> 8,603 (commit 1) -> 8,345 (this PR), so the second commit lands slightly under the branch point there too. In that run `argh`, whose code is untouched, timed 294 ns against usage's 433; on the base run it timed 271 against 415. Normalised against the unchanged parser measured in the same run, this PR is 1.47x argh where the base was 1.53x -- no regression survives the machine-to-machine drift.

Cumulative for the stack: 1,579,248 → 1,318,288 B, **−261 KB (−16.5%)**, with no measurable wall-time change and instruction counts down 1.5%.

Verified: full conformance suite (535 tests), argv/derive/usage-rs suites (480 tests), clippy, fmt.

_This PR description was generated by Claude Code._
