### PR TITLE
docs(rust): refresh binary-size table and document size levers

### DIFF
--- a/docs/rust/performance.md
+++ b/docs/rust/performance.md
@@ -59,7 +59,7 @@ shadow, built by the same workspace release build, stripped:
 
 | Framework | Stripped binary |
 | --------- | --------------: |
-| usage     |          1.6 MB |
+| usage     |          1.3 MB |
 | bpaf      |          2.5 MB |
 | clap      |          3.1 MB |
 
@@ -67,6 +67,20 @@ The ordering matches the dependency story: usage links no third-party crates,
 clap links eight. For what the spec endpoint itself weighs, see
 [Spec output](/rust/spec#the-endpoint) — 65 KB on a small CLI, and
 `#[usage(spec_endpoint = false)]` removes it.
+
+### Where the size lives, and what removes it
+
+The runtime crate itself compiles to about 16 KB; nearly all of the parser's
+footprint is the per-command binding code the derive generates, plus the static
+tables it reads (about 150 KB at mise scale). Size therefore tracks how many
+commands and fields a CLI declares, not which usage features it turns on.
+
+Two profile settings any CLI can apply cut further, independent of usage:
+
+- `strip = true` removes symbols and debug info — the tables above already
+  assume it.
+- `panic = "abort"` removes unwinding landing pads and the backtrace machinery
+  std otherwise links. On the mise-scale binary this is another 84 KB (−6%).
 
 ## Method and limits
 


### PR DESCRIPTION
Stacked on #1236.

Refreshes the binary-size table in the Rust performance page: after #1235 and #1236 the stripped mise-scale gate binary is 1.3 MB (was 1.6 MB). bpaf and clap re-measured from the same full workspace release build and unchanged at 2.5 MB and 3.1 MB.

Also adds a short "Where the size lives, and what removes it" section:

- the runtime crate is ~16 KB and the static tables ~150 KB at mise scale, so nearly all footprint is generated per-command binding code — size tracks how many commands and fields a CLI declares, not which usage features it enables;
- the profile levers a CLI controls itself: `strip = true` and `panic = "abort"`, the latter measured at −84 KB (−6%) on the same fixture.

An earlier draft of this page claimed unrendered help text and spec metadata are dead-stripped. That is dropped: a real CLI renders its help, so it carries that prose, and the note would only mislead someone sizing a real binary.

_This PR description was generated by Claude Code._
