### PR TITLE
feat(complete): filter path candidates by extension

### DIFF
--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -783,8 +783,9 @@ fn declared_files(type_: &str, next_arg_values: u32) -> Option<Files> {
     {
         let extensions = extensions
             .split(',')
+            .map(|extension| extension.trim().trim_start_matches('.'))
             .filter(|extension| !extension.is_empty())
-            .map(|extension| extension.trim_start_matches('.').to_string())
+            .map(str::to_string)
             .collect::<Vec<_>>();
         if !extensions.is_empty() {
             return Some(Files::Extensions(extensions));
@@ -3176,7 +3177,7 @@ mod tests {
     #[test]
     fn extension_types_preserve_the_filter_for_the_shell() {
         assert_eq!(
-            declared_files("path:toml,.yaml", 0),
+            declared_files("path:toml, .yaml,.", 0),
             Some(Files::Extensions(vec![
                 "toml".to_string(),
                 "yaml".to_string()

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -349,7 +349,7 @@ pub fn completers_on(meta: &CommandMeta<'_>) -> Vec<String> {
 /// This is a deliberate divergence from usage-lib, which reads the directory itself and returns
 /// the names. The conformance comparison holds the two equivalent rather than equal: where the
 /// reference answers with a listing, this answers with the marker.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Files {
     /// Anything: files, directories, whatever the shell shows for a path.
     Any,
@@ -359,6 +359,8 @@ pub enum Files {
     ExecutablePaths,
     /// Command names, including entries from the shell's command table and `PATH`.
     Commands,
+    /// Files with one of these extensions, plus directories for continued traversal.
+    Extensions(Vec<String>),
 }
 
 /// Everything a shell needs to answer one Tab.
@@ -677,7 +679,7 @@ pub fn render(answer: &Completions<'_>, shell: Shell) -> String {
         out.push('\n');
     }
 
-    match answer.files {
+    match &answer.files {
         Some(Files::Any) => {
             out.push_str(FILES_MARKER);
             out.push('\n');
@@ -692,6 +694,14 @@ pub fn render(answer: &Completions<'_>, shell: Shell) -> String {
         }
         Some(Files::Commands) => {
             out.push_str(COMMANDS_MARKER);
+            out.push('\n');
+        }
+        Some(Files::Extensions(extensions)) => {
+            out.push_str("\u{1}extensions");
+            for extension in extensions {
+                out.push('\t');
+                out.push_str(extension);
+            }
             out.push('\n');
         }
         None => {}
@@ -767,6 +777,19 @@ fn files_for(name: &str) -> Option<Files> {
 }
 
 fn declared_files(type_: &str, next_arg_values: u32) -> Option<Files> {
+    if let Some(extensions) = type_
+        .strip_prefix("path:")
+        .or_else(|| type_.strip_prefix("file:"))
+    {
+        let extensions = extensions
+            .split(',')
+            .filter(|extension| !extension.is_empty())
+            .map(|extension| extension.trim_start_matches('.').to_string())
+            .collect::<Vec<_>>();
+        if !extensions.is_empty() {
+            return Some(Files::Extensions(extensions));
+        }
+    }
     if type_.eq_ignore_ascii_case("command_args") {
         return Some(if next_arg_values == 0 {
             Files::Commands
@@ -3148,6 +3171,25 @@ mod tests {
         assert_eq!(offered("mise edit "), ["mise.local.toml", "mise.toml"]);
         // And a flag's value is named by its placeholder, not by the flag.
         assert_eq!(answer("mise edit --into ").files, Some(Files::Dirs));
+    }
+
+    #[test]
+    fn extension_types_preserve_the_filter_for_the_shell() {
+        assert_eq!(
+            declared_files("path:toml,.yaml", 0),
+            Some(Files::Extensions(vec![
+                "toml".to_string(),
+                "yaml".to_string()
+            ]))
+        );
+        let answer = Completions {
+            candidates: Vec::new(),
+            files: declared_files("path:toml,yaml", 0),
+        };
+        assert_eq!(
+            render(&answer, Shell::Bash),
+            "\u{1}extensions\ttoml\tyaml\n"
+        );
     }
 
     #[test]

--- a/argv/src/script.rs
+++ b/argv/src/script.rs
@@ -129,7 +129,7 @@ fn bash(bin: &str, name: &str) -> String {
     format!(
         r#"{head}
 _usage_complete_{name}() {{
-    local __usage_out __usage_line __usage_files=
+    local __usage_out __usage_line __usage_files= __usage_extensions=
     # Truncated here rather than passed with an offset: every shell counts a cursor in its own
     # units — characters in a UTF-8 locale for bash and zsh, characters for fish and PowerShell —
     # and a number that means one thing here and another there is a bug waiting for a non-ASCII
@@ -145,6 +145,10 @@ _usage_complete_{name}() {{
             $'\001dirs') __usage_files=dirs ;;
             $'\001executables') __usage_files=executables ;;
             $'\001commands') __usage_files=commands ;;
+            $'\001extensions\t'*)
+                __usage_files=extensions
+                __usage_extensions="${{__usage_line#*$'\t'}}"
+                ;;
             '') ;;
             *) COMPREPLY+=("$__usage_line") ;;
         esac
@@ -168,8 +172,19 @@ _usage_complete_{name}() {{
             while IFS= read -r __usage_path; do __usage_paths+=("$__usage_path"); done \
                 < <(compgen -d -- "$__usage_cur")
         else
-            while IFS= read -r __usage_path; do __usage_paths+=("$__usage_path"); done \
-                < <(compgen -f -- "$__usage_cur")
+            while IFS= read -r __usage_path; do
+                if [[ $__usage_files != extensions || -d "$__usage_path" ]]; then
+                    __usage_paths+=("$__usage_path")
+                    continue
+                fi
+                local __usage_extension
+                while IFS= read -r __usage_extension; do
+                    [[ "$__usage_path" == *."$__usage_extension" ]] && {{
+                        __usage_paths+=("$__usage_path")
+                        break
+                    }}
+                done < <(tr '\t' '\n' <<< "$__usage_extensions")
+            done < <(compgen -f -- "$__usage_cur")
         fi
         # Guarded, because an empty array expands to one empty word in older bash.
         (( ${{#__usage_paths[@]}} )) && COMPREPLY+=("${{__usage_paths[@]}}")
@@ -199,7 +214,7 @@ fn zsh(bin: &str, name: &str) -> String {
         r#"#compdef {name}
 {head}
 _{name}() {{
-    local -a values=() descriptions=() inserts=()
+    local -a values=() descriptions=() inserts=() extensions=()
     local __usage_files= __usage_line __usage_menu=0
     # `$BUFFER[1,CURSOR]` is the text before the cursor, cut with zsh's own offset — see the
     # bash script on why the cutting happens here rather than through a `--cursor` argument.
@@ -209,6 +224,11 @@ _{name}() {{
             $'\001dirs') __usage_files=dirs; continue ;;
             $'\001executables') __usage_files=executables; continue ;;
             $'\001commands') __usage_files=commands; continue ;;
+            $'\001extensions\t'*)
+                __usage_files=extensions
+                extensions=("${{(@ps:\t:)${{__usage_line#*$'\t'}}}}")
+                continue
+                ;;
             '') continue ;;
         esac
         local -a parts=("${{(@ps:\t:)__usage_line}}")
@@ -247,6 +267,10 @@ _{name}() {{
         dirs) _files -/ && __usage_ret=0 ;;
         executables) _files -g '*(-/,*)' && __usage_ret=0 ;;
         commands) _command_names && __usage_ret=0 ;;
+        extensions)
+            local __usage_glob="*.(${{(j:|:)extensions}})"
+            _files -g "$__usage_glob" && __usage_ret=0
+            ;;
     esac
     return $__usage_ret
 }}
@@ -279,7 +303,9 @@ function __usage_complete_{name}
     set -l marker_dirs (printf '\x01dirs')
     set -l marker_executables (printf '\x01executables')
     set -l marker_commands (printf '\x01commands')
+    set -l marker_extensions (printf '\x01extensions')
     set -l files ""
+    set -l extensions
     for entry in $out
         if test "$entry" = "$marker_any"
             set files any
@@ -289,6 +315,10 @@ function __usage_complete_{name}
             set files executables
         else if test "$entry" = "$marker_commands"
             set files commands
+        else if string match -q "$marker_extensions*" -- "$entry"
+            set files extensions
+            set extensions (string split (printf '\t') -- "$entry")
+            set -e extensions[1]
         else if test -n "$entry"
             # printf, not echo: fish's echo reads a leading -n, -e, -s or -E as its own option,
             # so a CLI with a `-n` would have that candidate swallowed on the way to the prompt.
@@ -311,6 +341,20 @@ function __usage_complete_{name}
             end
         case commands
             __fish_complete_command (commandline -ct)
+        case extensions
+            for candidate in (__fish_complete_path (commandline -ct))
+                set -l value (string split -m 1 (printf '\t') -- $candidate)[1]
+                if test -d "$value"
+                    printf '%s\n' $candidate
+                    continue
+                end
+                for extension in $extensions
+                    if string match -q "*.$extension" -- "$value"
+                        printf '%s\n' $candidate
+                        break
+                    end
+                end
+            end
     end
 end
 
@@ -336,7 +380,7 @@ def --env __usage_complete_{ident} [spans: list<string>] {{
     if $out.exit_code != 0 {{ return null }}
     let lines = ($out.stdout | lines | where {{|l| $l != "" }})
     let marker = "\u{{1}}"
-    let wants_files = ($lines | any {{|l| $l == $marker + "files" or $l == $marker + "dirs" or $l == $marker + "executables" }})
+    let wants_files = ($lines | any {{|l| $l == $marker + "files" or $l == $marker + "dirs" or $l == $marker + "executables" or ($l | str starts-with ($marker + "extensions" + (char tab))) }})
     let wants_commands = ($lines | any {{|l| $l == $marker + "commands" }})
     let declared = (
         $lines
@@ -419,6 +463,7 @@ Register-ArgumentCompleter -Native -CommandName '{name}' -ScriptBlock {{
     $out = @(& '{bin}' __complete_word__ --shell powershell --line $line 2>$null)
 
     $files = $null
+    $extensions = @()
     $results = [System.Collections.Generic.List[System.Management.Automation.CompletionResult]]::new()
     foreach ($entry in $out) {{
         if ([string]::IsNullOrEmpty($entry)) {{ continue }}
@@ -426,6 +471,11 @@ Register-ArgumentCompleter -Native -CommandName '{name}' -ScriptBlock {{
         if ($entry -eq ($marker + 'dirs')) {{ $files = 'dirs'; continue }}
         if ($entry -eq ($marker + 'executables')) {{ $files = 'executables'; continue }}
         if ($entry -eq ($marker + 'commands')) {{ $files = 'commands'; continue }}
+        if ($entry.StartsWith($marker + "extensions`t")) {{
+            $files = 'extensions'
+            $extensions = @($entry -split "`t" | Select-Object -Skip 1)
+            continue
+        }}
         $parts = $entry -split "`t", 3
         $value = $parts[0]
         $description = if ($parts.Count -gt 1 -and $parts[1]) {{ $parts[1] }} else {{ $value }}
@@ -458,6 +508,12 @@ Register-ArgumentCompleter -Native -CommandName '{name}' -ScriptBlock {{
             if ($files -eq 'executables' -and $path.ResultType -ne 'ProviderContainer') {{
                 $candidatePath = $path.CompletionText.Trim([char[]]@([char]39, [char]34))
                 if (-not (Get-Command -Name $candidatePath -CommandType Application, ExternalScript -ErrorAction SilentlyContinue)) {{
+                    continue
+                }}
+            }}
+            if ($files -eq 'extensions' -and $path.ResultType -ne 'ProviderContainer') {{
+                $candidatePath = $path.CompletionText.Trim([char[]]@([char]39, [char]34))
+                if ($extensions -notcontains [System.IO.Path]::GetExtension($candidatePath).TrimStart('.')) {{
                     continue
                 }}
             }}

--- a/argv/src/script.rs
+++ b/argv/src/script.rs
@@ -473,7 +473,7 @@ Register-ArgumentCompleter -Native -CommandName '{name}' -ScriptBlock {{
         if ($entry -eq ($marker + 'commands')) {{ $files = 'commands'; continue }}
         if ($entry.StartsWith($marker + "extensions`t")) {{
             $files = 'extensions'
-            $extensions = @($entry -split "`t" | Select-Object -Skip 1)
+            $extensions = @($entry -split "`t" | Select-Object -Skip 1 | ForEach-Object {{ $_.TrimStart('.') }})
             continue
         }}
         $parts = $entry -split "`t", 3
@@ -513,7 +513,15 @@ Register-ArgumentCompleter -Native -CommandName '{name}' -ScriptBlock {{
             }}
             if ($files -eq 'extensions' -and $path.ResultType -ne 'ProviderContainer') {{
                 $candidatePath = $path.CompletionText.Trim([char[]]@([char]39, [char]34))
-                if ($extensions -notcontains [System.IO.Path]::GetExtension($candidatePath).TrimStart('.')) {{
+                $candidateName = [System.IO.Path]::GetFileName($candidatePath)
+                $matchesExtension = $false
+                foreach ($extension in $extensions) {{
+                    if ($candidateName.EndsWith('.' + $extension, [System.StringComparison]::OrdinalIgnoreCase)) {{
+                        $matchesExtension = $true
+                        break
+                    }}
+                }}
+                if (-not $matchesExtension) {{
                     continue
                 }}
             }}

--- a/argv/tests/scripts.rs
+++ b/argv/tests/scripts.rs
@@ -47,6 +47,8 @@ impl Fixture {
         // Files for the path cases to find, and a directory among them so `dirs` can differ.
         fs::write(dir.join("alpha.txt"), "").expect("a file");
         fs::write(dir.join("beta.txt"), "").expect("another");
+        fs::write(dir.join("manifest.toml"), "").expect("a filtered file");
+        fs::write(dir.join("settings.yaml"), "").expect("another filtered file");
         fs::create_dir(dir.join("gamma")).expect("a directory");
 
         Self { dir }
@@ -279,6 +281,38 @@ printf '%s\n' "${COMPREPLY[@]}"
 }
 
 #[test]
+fn bash_filters_files_by_the_extensions_the_binary_declared() {
+    if !available("bash") {
+        println!("bash is not installed; skipping");
+        return;
+    }
+    let fixture = Fixture::new(
+        "bash-extensions",
+        Shell::Bash,
+        "\u{1}extensions\ttoml\tyaml\n",
+    );
+    let out = fixture.run(
+        "bash",
+        r#"source ./script
+COMP_LINE='ex '
+COMP_POINT=3
+COMP_WORDS=(ex '')
+COMP_CWORD=1
+_usage_complete_ex
+printf '%s\n' "${COMPREPLY[@]}"
+"#,
+    );
+    let offered: Vec<&str> = out.lines().filter(|line| !line.is_empty()).collect();
+    assert!(offered.contains(&"manifest.toml"), "{offered:?}");
+    assert!(offered.contains(&"settings.yaml"), "{offered:?}");
+    assert!(
+        offered.contains(&"gamma"),
+        "directories remain traversable: {offered:?}"
+    );
+    assert!(!offered.contains(&"alpha.txt"), "{offered:?}");
+}
+
+#[test]
 fn fish_prints_the_candidates_it_was_given() {
     if !available("fish") {
         println!("fish is not installed; skipping");
@@ -427,6 +461,24 @@ fn zsh_hands_paths_to_files_and_forces_a_menu_when_a_value_needs_quoting() {
         &format!("{ZSH_STUBS}\nsource ./script\nBUFFER='ex '\nCURSOR=3\n_ex\n"),
     );
     assert!(out.contains("_files:-/"), "{out}");
+}
+
+#[test]
+fn zsh_passes_extension_filters_to_its_native_file_completer() {
+    if !available("zsh") {
+        println!("zsh is not installed; skipping");
+        return;
+    }
+    let fixture = Fixture::new(
+        "zsh-extensions",
+        Shell::Zsh,
+        "\u{1}extensions\ttoml\tyaml\n",
+    );
+    let out = fixture.run(
+        "zsh",
+        &format!("{ZSH_STUBS}\nsource ./script\nBUFFER='ex '\nCURSOR=3\n_ex\n"),
+    );
+    assert!(out.contains("_files:-g *.(toml|yaml)"), "{out}");
 }
 
 #[test]

--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -362,7 +362,12 @@ impl CompleteWord {
         {
             let extensions = encoded
                 .split(',')
-                .map(|extension| extension.trim_start_matches('.').to_ascii_lowercase())
+                .map(|extension| {
+                    extension
+                        .trim()
+                        .trim_start_matches('.')
+                        .to_ascii_lowercase()
+                })
                 .filter(|extension| !extension.is_empty())
                 .collect::<Vec<_>>();
             if !extensions.is_empty() {

--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -362,17 +362,22 @@ impl CompleteWord {
         {
             let extensions = encoded
                 .split(',')
+                .map(|extension| extension.trim_start_matches('.').to_ascii_lowercase())
                 .filter(|extension| !extension.is_empty())
                 .collect::<Vec<_>>();
             if !extensions.is_empty() {
                 let cwd = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
                 let paths = self.complete_path(&cwd, ctoken, |path| {
                     path.is_dir()
-                        || path.extension().is_some_and(|extension| {
-                            extensions.iter().any(|wanted| {
-                                extension.to_string_lossy().eq_ignore_ascii_case(wanted)
+                        || path
+                            .file_name()
+                            .and_then(|name| name.to_str())
+                            .is_some_and(|name| {
+                                let name = name.to_ascii_lowercase();
+                                extensions
+                                    .iter()
+                                    .any(|wanted| name.ends_with(&format!(".{wanted}")))
                             })
-                        })
                 });
                 return (
                     paths

--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -356,6 +356,33 @@ impl CompleteWord {
         type_: &str,
         ctoken: &str,
     ) -> (Vec<(String, String)>, bool) {
+        if let Some(encoded) = type_
+            .strip_prefix("path:")
+            .or_else(|| type_.strip_prefix("file:"))
+        {
+            let extensions = encoded
+                .split(',')
+                .filter(|extension| !extension.is_empty())
+                .collect::<Vec<_>>();
+            if !extensions.is_empty() {
+                let cwd = env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+                let paths = self.complete_path(&cwd, ctoken, |path| {
+                    path.is_dir()
+                        || path.extension().is_some_and(|extension| {
+                            extensions.iter().any(|wanted| {
+                                extension.to_string_lossy().eq_ignore_ascii_case(wanted)
+                            })
+                        })
+                });
+                return (
+                    paths
+                        .into_iter()
+                        .map(|value| (value, String::new()))
+                        .collect(),
+                    true,
+                );
+            }
+        }
         // The two config completers describe values, so they carry their own descriptions
         // rather than going through the path branch's empty ones.
         match type_ {

--- a/cli/tests/complete_word.rs
+++ b/cli/tests/complete_word.rs
@@ -673,6 +673,34 @@ fn complete_word_filters_declared_file_extensions() {
 }
 
 #[test]
+fn complete_word_normalizes_leading_dots_and_matches_compound_extensions() {
+    let dir =
+        std::env::temp_dir().join(format!("usage_compound_extensions_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("archive.tar.gz"), "").unwrap();
+    fs::write(dir.join("archive.gz"), "").unwrap();
+    fs::write(dir.join("config.toml"), "").unwrap();
+
+    let spec = r#"
+name "mycli"
+bin "mycli"
+arg "<FILE>"
+complete "file" type="path:.tar.gz,toml"
+"#;
+    Command::new(cargo::cargo_bin!("usage"))
+        .current_dir(&dir)
+        .args(["cw", "--shell", "fish", "--spec", spec, "--", "mycli", ""])
+        .assert()
+        .success()
+        .stdout(contains("archive.tar.gz\n"))
+        .stdout(contains("config.toml\n"))
+        .stdout(predicates::str::contains("archive.gz\n").not());
+
+    fs::remove_dir_all(dir).unwrap();
+}
+
+#[test]
 fn complete_word_command_args_starts_with_executables() {
     let usage = cargo::cargo_bin!("usage");
     let executable = usage.file_name().unwrap().to_string_lossy().into_owned();

--- a/cli/tests/complete_word.rs
+++ b/cli/tests/complete_word.rs
@@ -666,6 +666,13 @@ fn complete_word_fallback_to_files() {
 }
 
 #[test]
+fn complete_word_filters_declared_file_extensions() {
+    assert_cmd("extensions.usage.kdl", &["C"])
+        .stdout(contains("Cargo.toml\n"))
+        .stdout(predicates::str::contains("Cargo.lock").not());
+}
+
+#[test]
 fn complete_word_command_args_starts_with_executables() {
     let usage = cargo::cargo_bin!("usage");
     let executable = usage.file_name().unwrap().to_string_lossy().into_owned();

--- a/cli/tests/complete_word.rs
+++ b/cli/tests/complete_word.rs
@@ -686,7 +686,7 @@ fn complete_word_normalizes_leading_dots_and_matches_compound_extensions() {
 name "mycli"
 bin "mycli"
 arg "<FILE>"
-complete "file" type="path:.tar.gz,toml"
+complete "file" type="path:.tar.gz, toml,."
 "#;
     Command::new(cargo::cargo_bin!("usage"))
         .current_dir(&dir)

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -296,6 +296,7 @@
 //! | `value_enum` | the words come from the field's type, which derives [`ValueEnum`] |
 //! | `arg_group` | the flags come from the field's type, which derives [`ArgGroup`]; at most one may be given |
 //! | `value_hint = usage::ValueHint::FilePath` | ask the shell for paths, executables, or forwarded command argv |
+//! | `extensions("toml", "yaml")` | limit a file-path hint to these extensions while retaining directories |
 //! | `arg` | force a field to be positional |
 //! | `value_name = "NAME"` | a positional name, or the placeholder for a flag value |
 //! | `choices("a", "b")` | accepted values; typed conversion still uses the field type's `FromStr` |

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -2426,6 +2426,7 @@ impl Field {
         let mut validate_error: Option<String> = None;
         let mut complete: Option<syn::Path> = None;
         let mut complete_type: Option<String> = None;
+        let mut completion_extensions: Vec<String> = Vec::new();
         let mut value_enum = false;
         let mut var_min: Option<usize> = None;
         let mut var_max: Option<usize> = None;
@@ -2554,6 +2555,35 @@ impl Field {
                         complete = Some(path.path.clone());
                     }
                     "value_hint" => complete_type = Some(value_hint(&meta)?),
+                    "extensions" => {
+                        let Meta::List(list) = &meta else {
+                            return Err(syn::Error::new_spanned(
+                                meta.path(),
+                                "`extensions` takes a list, as in `extensions(\"toml\", \"yaml\")`",
+                            ));
+                        };
+                        completion_extensions = list
+                            .parse_args_with(
+                                syn::punctuated::Punctuated::<syn::LitStr, syn::Token![,]>::parse_terminated,
+                            )?
+                            .into_iter()
+                            .map(|lit| lit.value().trim_start_matches('.').to_string())
+                            .collect();
+                        if completion_extensions.is_empty()
+                            || completion_extensions.iter().any(|extension| {
+                                extension.is_empty()
+                                    || !extension.chars().all(|c| {
+                                        c.is_ascii_alphanumeric()
+                                            || matches!(c, '.' | '_' | '+' | '-')
+                                    })
+                            })
+                        {
+                            return Err(syn::Error::new_spanned(
+                                meta.path(),
+                                "`extensions` needs one or more filename extensions without paths",
+                            ));
+                        }
+                    }
                     "choices" => {
                         let Meta::List(list) = &meta else {
                             return Err(syn::Error::new_spanned(
@@ -2978,6 +3008,19 @@ impl Field {
                 span,
                 "`validate_error` needs a `validate` expression to report for",
             ));
+        }
+        if !completion_extensions.is_empty() {
+            match complete_type.as_deref() {
+                Some("path") => {
+                    complete_type = Some(format!("path:{}", completion_extensions.join(",")));
+                }
+                _ => {
+                    return Err(syn::Error::new(
+                        span,
+                        "`extensions` needs `value_hint = usage::ValueHint::FilePath` or `AnyPath`",
+                    ));
+                }
+            }
         }
         if complete_type.is_some() && matches!(shape, Shape::Bool | Shape::Count) {
             return Err(syn::Error::new(

--- a/docs/rust/args-and-flags.md
+++ b/docs/rust/args-and-flags.md
@@ -146,6 +146,7 @@ The tables below cover the attributes most CLIs need.
 | ---------------------------------- | --------------------------------------------------------------------------------------- |
 | `complete = my_fn`                 | Custom completion function ([Completions](/rust/completions))                           |
 | `value_hint = ValueHint::FilePath` | Ask the shell for path completion (see below)                                           |
+| `extensions("toml", "yaml")`      | Limit a `FilePath` or `AnyPath` hint to these filename extensions                         |
 | `effect = "…"`                     | `"read"`, `"write"`, or `"destructive"` — see [command effects](/spec/#command-effects) |
 | `setting = "key"`                  | Bind to a config setting ([Configuration](/rust/configuration))                         |
 

--- a/docs/rust/args-and-flags.md
+++ b/docs/rust/args-and-flags.md
@@ -146,7 +146,7 @@ The tables below cover the attributes most CLIs need.
 | ---------------------------------- | --------------------------------------------------------------------------------------- |
 | `complete = my_fn`                 | Custom completion function ([Completions](/rust/completions))                           |
 | `value_hint = ValueHint::FilePath` | Ask the shell for path completion (see below)                                           |
-| `extensions("toml", "yaml")`      | Limit a `FilePath` or `AnyPath` hint to these filename extensions                         |
+| `extensions("toml", "yaml")`       | Limit a `FilePath` or `AnyPath` hint to these filename extensions                       |
 | `effect = "…"`                     | `"read"`, `"write"`, or `"destructive"` — see [command effects](/spec/#command-effects) |
 | `setting = "key"`                  | Bind to a config setting ([Configuration](/rust/configuration))                         |
 

--- a/docs/rust/completions.md
+++ b/docs/rust/completions.md
@@ -140,6 +140,14 @@ format: Option<String>,
 #[usage(long, value_hint = usage::ValueHint::FilePath)]
 file: Option<PathBuf>,
 
+// filtered paths — directories remain available for traversal
+#[usage(
+    long,
+    value_hint = usage::ValueHint::FilePath,
+    extensions("toml", "yaml")
+)]
+manifest: Option<PathBuf>,
+
 // anything you can compute
 #[usage(arg, name = "TASK", complete = tasks_in_file)]
 task: Option<String>,

--- a/docs/spec/reference/complete.md
+++ b/docs/spec/reference/complete.md
@@ -12,9 +12,14 @@ and `type` are alternatives; setting both is an error.
 
 ```kdl
 complete "path" type="file"
+complete "manifest" type="path:toml,yaml"
 complete "key" type="config_keys"
 complete "value" type="config_values"
 ```
+
+Append a comma-separated extension list to `path:` or `file:` to keep directory traversal while
+offering only matching files. Extensions omit the leading dot; for example,
+`type="path:toml,yaml"` offers directories plus `.toml` and `.yaml` files.
 
 | type            | completes                                                            |
 | --------------- | -------------------------------------------------------------------- |

--- a/examples/extensions.usage.kdl
+++ b/examples/extensions.usage.kdl
@@ -1,0 +1,3 @@
+name mycli
+arg "<manifest>"
+complete manifest type="path:toml"

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -17,6 +17,48 @@ struct Ex {
 }
 
 #[derive(Cli)]
+#[usage(bin = "filtered-completion")]
+#[cfg_attr(feature = "completions", usage(completion))]
+#[allow(dead_code)]
+struct FilteredCompletion {
+    #[usage(
+        long,
+        value_hint = usage::ValueHint::FilePath,
+        extensions("toml", ".yaml")
+    )]
+    manifest: Option<PathBuf>,
+}
+
+#[test]
+fn file_extension_hints_are_portable() {
+    let kdl = FilteredCompletion::to_kdl();
+    assert!(
+        kdl.contains("complete manifest type=path:toml,yaml"),
+        "{kdl}"
+    );
+    let portable: usage_parser::Spec = kdl.parse().expect("usage-lib should read the filter");
+    assert_eq!(
+        portable.complete["manifest"].type_.as_deref(),
+        Some("path:toml,yaml")
+    );
+}
+
+#[cfg(feature = "completions")]
+#[test]
+fn file_extension_hints_reach_the_shell_protocol() {
+    let line = "filtered-completion --manifest ";
+    let split = usage::complete::split(line, line.len(), usage::complete::Shell::Bash);
+    let answer = usage::complete::complete(FilteredCompletion::spec(), &split);
+    assert_eq!(
+        answer.files,
+        Some(usage::complete::Files::Extensions(vec![
+            "toml".to_string(),
+            "yaml".to_string()
+        ]))
+    );
+}
+
+#[derive(Cli)]
 #[usage(
     bin = "view-host",
     version = "1.2.3",


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the completion wire protocol and generated scripts for every supported shell, so a marker or filter bug can silently drop or over-offer files. Not a security-critical path, but it is user-facing completion infrastructure.
> 
> **Overview**
> Path completions can now be limited to declared filename extensions while still offering directories for traversal.
> 
> Specs use `type="path:toml,yaml"` (or `file:`). The derive API adds `extensions("toml", "yaml")` next to a `FilePath`/`AnyPath` hint, which emits that type into KDL. The completion protocol adds a `\u{1}extensions\t…` marker; generated bash, zsh, fish, nu, and PowerShell scripts apply the filter in the shell. The usage CLI’s `complete_word` builtin does the same when it lists files itself.
> 
> Leading dots and empty tokens are stripped. Compound extensions such as `.tar.gz` match as a suffix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6a27f5add5eb112d46d6fecf1bdb0fdc7f2a7a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->