### PR TITLE
feat(complete): expose structured completion traces

### DIFF
--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -453,7 +453,7 @@ impl core::fmt::Display for CompletionTrace<'_> {
 pub fn trace<'a>(spec: &'a Spec<'a>, split: &Split) -> CompletionTrace<'a> {
     let position = walk(spec.root.cmd, split.argv());
     let answer = complete(spec, split);
-    trace_from(spec, split, position, answer)
+    trace_from(spec, split, position, answer, None)
 }
 
 /// Explain a completion answer through one executable view.
@@ -464,7 +464,7 @@ pub fn trace_view<'a>(
 ) -> CompletionTrace<'a> {
     let position = walk_view(spec.root.cmd, split.argv(), view);
     let answer = complete_view(spec, split, view);
-    trace_from(spec, split, position, answer)
+    trace_from(spec, split, position, answer, Some(view))
 }
 
 fn trace_from<'a>(
@@ -472,6 +472,7 @@ fn trace_from<'a>(
     split: &Split,
     position: Position<'a>,
     answer: Completions<'a>,
+    view: Option<&crate::spec::ViewMeta<'_>>,
 ) -> CompletionTrace<'a> {
     let chain = metadata_chain_on_route(spec, &position);
     let meta = chain.as_ref().and_then(|chain| chain.last().copied());
@@ -484,8 +485,18 @@ fn trace_from<'a>(
             .or_else(|| default_subcommand_arg(spec, split, &position).map(|(_, field)| field.arg))
     };
     let command_path = if position.help_topic {
-        chain
-            .map(|chain| chain.into_iter().map(|meta| meta.cmd.name).collect())
+        let argv = split
+            .argv()
+            .iter()
+            .map(std::ffi::OsStr::new)
+            .collect::<Vec<_>>();
+        let route = match view {
+            Some(view) => crate::help::route_to_view(spec.root.cmd, &argv, position.cmd, view),
+            None => crate::help::route_to(spec.root.cmd, &argv, position.cmd),
+        };
+        route
+            .map(|route| route.into_iter().map(|command| command.name).collect())
+            .or_else(|| chain.map(|chain| chain.into_iter().map(|meta| meta.cmd.name).collect()))
             .unwrap_or_else(|| vec![position.cmd.name])
     } else {
         position
@@ -3356,6 +3367,58 @@ mod tests {
         assert!(trace.help_topic);
         assert_eq!(trace.command_path, ["mise", "plugins"]);
         assert!(trace.to_string().contains("command: mise plugins"));
+    }
+
+    #[test]
+    fn a_help_trace_keeps_the_typed_route_to_a_shared_command() {
+        static SHARED: Command = Command {
+            name: "shared",
+            ..Command::EMPTY
+        };
+        static LEFT: Command = Command {
+            name: "left",
+            subcommands: &[&SHARED],
+            ..Command::EMPTY
+        };
+        static RIGHT: Command = Command {
+            name: "right",
+            subcommands: &[&SHARED],
+            ..Command::EMPTY
+        };
+        static ROOT: Command = Command {
+            name: "ex",
+            subcommands: &[&LEFT, &RIGHT],
+            ..Command::EMPTY
+        };
+        static SHARED_META: CommandMeta = CommandMeta {
+            cmd: &SHARED,
+            ..CommandMeta::EMPTY
+        };
+        static LEFT_META: CommandMeta = CommandMeta {
+            cmd: &LEFT,
+            subcommands: &[&SHARED_META],
+            ..CommandMeta::EMPTY
+        };
+        static RIGHT_META: CommandMeta = CommandMeta {
+            cmd: &RIGHT,
+            subcommands: &[&SHARED_META],
+            ..CommandMeta::EMPTY
+        };
+        static ROOT_META: CommandMeta = CommandMeta {
+            cmd: &ROOT,
+            subcommands: &[&LEFT_META, &RIGHT_META],
+            ..CommandMeta::EMPTY
+        };
+        static SHARED_SPEC: Spec = Spec {
+            name: "ex",
+            bin: Some("ex"),
+            root: &ROOT_META,
+            ..Spec::EMPTY
+        };
+
+        let trace = trace(&SHARED_SPEC, &at_end("ex help right shared "));
+        assert!(trace.help_topic);
+        assert_eq!(trace.command_path, ["ex", "right", "shared"]);
     }
 
     #[test]

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -363,6 +363,27 @@ pub enum Files {
     Extensions(Vec<String>),
 }
 
+impl core::fmt::Display for Files {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Any => f.write_str("paths"),
+            Self::Dirs => f.write_str("directories"),
+            Self::ExecutablePaths => f.write_str("executable paths"),
+            Self::Commands => f.write_str("commands"),
+            Self::Extensions(extensions) => {
+                f.write_str("paths with extensions ")?;
+                for (index, extension) in extensions.iter().enumerate() {
+                    if index > 0 {
+                        f.write_str(", ")?;
+                    }
+                    write!(f, ".{extension}")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
 /// Everything a shell needs to answer one Tab.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Completions<'a> {
@@ -370,6 +391,102 @@ pub struct Completions<'a> {
     pub candidates: Vec<Candidate<'a>>,
     /// Paths the shell should add, if the position admits them.
     pub files: Option<Files>,
+}
+
+/// An inspectable account of how a partial line reached its completion answer.
+///
+/// This is deliberately data rather than log output: a CLI can print it in a hidden diagnostic
+/// command, a test can assert on one field, and another frontend can render it differently.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompletionTrace<'a> {
+    pub words: Vec<String>,
+    pub cword: usize,
+    pub prefix: String,
+    pub command_path: Vec<&'a str>,
+    pub flags_possible: bool,
+    pub awaiting_value: Option<&'a str>,
+    pub next_arg: Option<&'a str>,
+    pub separator_seen: bool,
+    pub help_topic: bool,
+    pub candidates: Vec<Candidate<'a>>,
+    pub files: Option<Files>,
+}
+
+impl core::fmt::Display for CompletionTrace<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        writeln!(f, "words: {:?}", self.words)?;
+        writeln!(
+            f,
+            "cursor: word {} with prefix {:?}",
+            self.cword, self.prefix
+        )?;
+        writeln!(f, "command: {}", self.command_path.join(" "))?;
+        let position = if let Some(flag) = self.awaiting_value {
+            format!("value of {flag}")
+        } else if let Some(arg) = self.next_arg {
+            format!("argument {arg}")
+        } else if self.help_topic {
+            "help topic".to_string()
+        } else {
+            "command or flag".to_string()
+        };
+        writeln!(f, "position: {position}")?;
+        writeln!(f, "flags possible: {}", self.flags_possible)?;
+        writeln!(f, "separator seen: {}", self.separator_seen)?;
+        let candidates = self
+            .candidates
+            .iter()
+            .map(|candidate| candidate.value.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        writeln!(f, "candidates: {candidates}")?;
+        match &self.files {
+            Some(files) => writeln!(f, "shell fallback: {files}"),
+            None => writeln!(f, "shell fallback: none"),
+        }
+    }
+}
+
+/// Explain a completion answer using the same parser walk and tables that produced it.
+pub fn trace<'a>(spec: &'a Spec<'a>, split: &Split) -> CompletionTrace<'a> {
+    let position = walk(spec.root.cmd, split.argv());
+    let answer = complete(spec, split);
+    trace_from(split, position, answer)
+}
+
+/// Explain a completion answer through one executable view.
+pub fn trace_view<'a>(
+    spec: &'a Spec<'a>,
+    split: &Split,
+    view: &'a crate::spec::ViewMeta<'a>,
+) -> CompletionTrace<'a> {
+    let position = walk_view(spec.root.cmd, split.argv(), view);
+    let answer = complete_view(spec, split, view);
+    trace_from(split, position, answer)
+}
+
+fn trace_from<'a>(
+    split: &Split,
+    position: Position<'a>,
+    answer: Completions<'a>,
+) -> CompletionTrace<'a> {
+    CompletionTrace {
+        words: split.words.clone(),
+        cword: split.cword,
+        prefix: split.prefix.clone(),
+        command_path: position
+            .path
+            .iter()
+            .map(|(command, _)| command.name)
+            .collect(),
+        flags_possible: position.flags_possible,
+        awaiting_value: position.awaiting_value.map(|flag| flag.name),
+        next_arg: position.next_arg.map(|arg| arg.name),
+        separator_seen: position.separator_seen,
+        help_topic: position.help_topic,
+        candidates: answer.candidates,
+        files: answer.files,
+    }
 }
 
 /// A completion future supplied by an embedding CLI.
@@ -3191,6 +3308,18 @@ mod tests {
             render(&answer, Shell::Bash),
             "\u{1}extensions\ttoml\tyaml\n"
         );
+    }
+
+    #[test]
+    fn a_trace_exposes_the_parser_decision_behind_an_answer() {
+        let trace = trace(&SPEC, &at_end("mise use --jobs "));
+        assert_eq!(trace.command_path, ["mise", "use"]);
+        assert_eq!(trace.awaiting_value, Some("jobs"));
+        assert_eq!(trace.next_arg, Some("TOOL"));
+        assert_eq!(trace.files, None);
+        let rendered = trace.to_string();
+        assert!(rendered.contains("position: value of jobs"), "{rendered}");
+        assert!(rendered.contains("shell fallback: none"), "{rendered}");
     }
 
     #[test]

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -473,7 +473,8 @@ fn trace_from<'a>(
     position: Position<'a>,
     answer: Completions<'a>,
 ) -> CompletionTrace<'a> {
-    let meta = metadata_chain_on_route(spec, &position).and_then(|chain| chain.last().copied());
+    let chain = metadata_chain_on_route(spec, &position);
+    let meta = chain.as_ref().and_then(|chain| chain.last().copied());
     let next_arg = if restarted(meta, split) {
         meta.and_then(|meta| meta.args.first())
             .map(|field| field.arg)
@@ -483,7 +484,9 @@ fn trace_from<'a>(
             .or_else(|| default_subcommand_arg(spec, split, &position).map(|(_, field)| field.arg))
     };
     let command_path = if position.help_topic {
-        command_path_to(spec.root.cmd, position.cmd)
+        chain
+            .map(|chain| chain.into_iter().map(|meta| meta.cmd.name).collect())
+            .unwrap_or_else(|| vec![position.cmd.name])
     } else {
         position
             .path
@@ -503,35 +506,6 @@ fn trace_from<'a>(
         help_topic: position.help_topic,
         candidates: answer.candidates,
         files: answer.files,
-    }
-}
-
-fn command_path_to<'a>(root: &'a Command<'a>, target: &'a Command<'a>) -> Vec<&'a str> {
-    fn visit<'a>(
-        command: &'a Command<'a>,
-        target: &'a Command<'a>,
-        path: &mut Vec<&'a str>,
-    ) -> bool {
-        path.push(command.name);
-        if core::ptr::eq(command, target) {
-            return true;
-        }
-        if command
-            .subcommands
-            .iter()
-            .any(|subcommand| visit(subcommand, target, path))
-        {
-            return true;
-        }
-        path.pop();
-        false
-    }
-
-    let mut path = Vec::new();
-    if visit(root, target, &mut path) {
-        path
-    } else {
-        vec![target.name]
     }
 }
 

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -491,7 +491,12 @@ fn trace_from<'a>(
             .map(std::ffi::OsStr::new)
             .collect::<Vec<_>>();
         let route = match view {
-            Some(view) => crate::help::route_to_view(spec.root.cmd, &argv, position.cmd, view),
+            Some(view) => {
+                let mut view_argv = Vec::with_capacity(argv.len() + 1);
+                view_argv.push(std::ffi::OsStr::new(view.bin));
+                view_argv.extend_from_slice(&argv);
+                crate::help::route_to_view(spec.root.cmd, &view_argv, position.cmd, view)
+            }
             None => crate::help::route_to(spec.root.cmd, &argv, position.cmd),
         };
         route
@@ -3371,6 +3376,12 @@ mod tests {
 
     #[test]
     fn a_help_trace_keeps_the_typed_route_to_a_shared_command() {
+        static CONFIG: Flag = Flag {
+            name: "config",
+            longs: &["config"],
+            global: true,
+            ..Flag::VALUE
+        };
         static SHARED: Command = Command {
             name: "shared",
             ..Command::EMPTY
@@ -3387,6 +3398,7 @@ mod tests {
         };
         static ROOT: Command = Command {
             name: "ex",
+            flags: &[&CONFIG],
             subcommands: &[&LEFT, &RIGHT],
             ..Command::EMPTY
         };
@@ -3406,6 +3418,10 @@ mod tests {
         };
         static ROOT_META: CommandMeta = CommandMeta {
             cmd: &ROOT,
+            flags: &[FlagMeta {
+                flag: &CONFIG,
+                ..FlagMeta::EMPTY
+            }],
             subcommands: &[&LEFT_META, &RIGHT_META],
             ..CommandMeta::EMPTY
         };
@@ -3415,8 +3431,24 @@ mod tests {
             root: &ROOT_META,
             ..Spec::EMPTY
         };
+        static RIGHT_VIEW: crate::spec::ViewMeta = crate::spec::ViewMeta {
+            id: "right",
+            name: "right",
+            bin: "right",
+            root: "right",
+            all_globals: true,
+            globals: &[],
+        };
 
         let trace = trace(&SHARED_SPEC, &at_end("ex help right shared "));
+        assert!(trace.help_topic);
+        assert_eq!(trace.command_path, ["ex", "right", "shared"]);
+
+        let trace = trace_view(
+            &SHARED_SPEC,
+            &at_end("right --config alpha help shared "),
+            &RIGHT_VIEW,
+        );
         assert!(trace.help_topic);
         assert_eq!(trace.command_path, ["ex", "right", "shared"]);
     }

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -423,6 +423,8 @@ impl core::fmt::Display for CompletionTrace<'_> {
         writeln!(f, "command: {}", self.command_path.join(" "))?;
         let position = if let Some(flag) = self.awaiting_value {
             format!("value of {flag}")
+        } else if self.flags_possible && self.prefix.starts_with('-') {
+            "flag".to_string()
         } else if let Some(arg) = self.next_arg {
             format!("argument {arg}")
         } else if self.help_topic {
@@ -451,7 +453,7 @@ impl core::fmt::Display for CompletionTrace<'_> {
 pub fn trace<'a>(spec: &'a Spec<'a>, split: &Split) -> CompletionTrace<'a> {
     let position = walk(spec.root.cmd, split.argv());
     let answer = complete(spec, split);
-    trace_from(split, position, answer)
+    trace_from(spec, split, position, answer)
 }
 
 /// Explain a completion answer through one executable view.
@@ -462,30 +464,74 @@ pub fn trace_view<'a>(
 ) -> CompletionTrace<'a> {
     let position = walk_view(spec.root.cmd, split.argv(), view);
     let answer = complete_view(spec, split, view);
-    trace_from(split, position, answer)
+    trace_from(spec, split, position, answer)
 }
 
 fn trace_from<'a>(
+    spec: &'a Spec<'a>,
     split: &Split,
     position: Position<'a>,
     answer: Completions<'a>,
 ) -> CompletionTrace<'a> {
+    let meta = metadata_chain_on_route(spec, &position).and_then(|chain| chain.last().copied());
+    let next_arg = if restarted(meta, split) {
+        meta.and_then(|meta| meta.args.first())
+            .map(|field| field.arg)
+    } else {
+        position
+            .next_arg
+            .or_else(|| default_subcommand_arg(spec, split, &position).map(|(_, field)| field.arg))
+    };
+    let command_path = if position.help_topic {
+        command_path_to(spec.root.cmd, position.cmd)
+    } else {
+        position
+            .path
+            .iter()
+            .map(|(command, _)| command.name)
+            .collect()
+    };
     CompletionTrace {
         words: split.words.clone(),
         cword: split.cword,
         prefix: split.prefix.clone(),
-        command_path: position
-            .path
-            .iter()
-            .map(|(command, _)| command.name)
-            .collect(),
+        command_path,
         flags_possible: position.flags_possible,
         awaiting_value: position.awaiting_value.map(|flag| flag.name),
-        next_arg: position.next_arg.map(|arg| arg.name),
+        next_arg: next_arg.map(|arg| arg.name),
         separator_seen: position.separator_seen,
         help_topic: position.help_topic,
         candidates: answer.candidates,
         files: answer.files,
+    }
+}
+
+fn command_path_to<'a>(root: &'a Command<'a>, target: &'a Command<'a>) -> Vec<&'a str> {
+    fn visit<'a>(
+        command: &'a Command<'a>,
+        target: &'a Command<'a>,
+        path: &mut Vec<&'a str>,
+    ) -> bool {
+        path.push(command.name);
+        if core::ptr::eq(command, target) {
+            return true;
+        }
+        if command
+            .subcommands
+            .iter()
+            .any(|subcommand| visit(subcommand, target, path))
+        {
+            return true;
+        }
+        path.pop();
+        false
+    }
+
+    let mut path = Vec::new();
+    if visit(root, target, &mut path) {
+        path
+    } else {
+        vec![target.name]
     }
 }
 
@@ -3320,6 +3366,30 @@ mod tests {
         let rendered = trace.to_string();
         assert!(rendered.contains("position: value of jobs"), "{rendered}");
         assert!(rendered.contains("shell fallback: none"), "{rendered}");
+    }
+
+    #[test]
+    fn a_trace_uses_the_effective_argument_after_a_restart() {
+        let trace = trace(&SPEC, &at_end("mise ship fast script ::: "));
+        assert_eq!(trace.next_arg, Some("MODE"));
+        assert_eq!(trace.files, None);
+        assert!(trace.to_string().contains("position: argument MODE"));
+    }
+
+    #[test]
+    fn a_help_trace_keeps_the_selected_topic_path() {
+        let trace = trace(&SPEC, &at_end("mise help plugins "));
+        assert!(trace.help_topic);
+        assert_eq!(trace.command_path, ["mise", "plugins"]);
+        assert!(trace.to_string().contains("command: mise plugins"));
+    }
+
+    #[test]
+    fn a_trace_labels_a_dash_prefixed_cursor_as_a_flag_position() {
+        let trace = trace(&SPEC, &at_end("mise install --s"));
+        assert!(trace.flags_possible);
+        assert_eq!(trace.next_arg, Some("TOOL"));
+        assert!(trace.to_string().contains("position: flag"));
     }
 
     #[test]

--- a/docs/rust/completions.md
+++ b/docs/rust/completions.md
@@ -185,3 +185,21 @@ with `Candidate::new(value)` or `Candidate::described(value, description)`; shel
 descriptions show them, shells that don't get the value alone. Chain `.displayed(label)` when a
 short insertion needs a more explanatory presentation; zsh and PowerShell keep that label
 separate from the text inserted into the command line, while other shells display the value.
+
+## Tracing an answer
+
+Completion decisions are available as structured diagnostic data. This uses the same split,
+parser walk, and completion tables as the runtime request:
+
+```rust
+let line = "ex build --out ";
+let split = usage::complete::split(line, line.len(), usage::complete::Shell::Zsh);
+let trace = usage::complete::trace(Ex::spec(), &split);
+
+assert_eq!(trace.awaiting_value, Some("out"));
+eprintln!("{trace}");
+```
+
+The trace includes the shell-split words and prefix, selected command path, cursor owner, flag and
+separator state, candidates, and native shell fallback. Applications can expose its `Display`
+form from a diagnostic command or render the public fields themselves.


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive diagnostic API and tests; it does not change how completions are computed or rendered for shells.
> 
> **Overview**
> Adds a public **`CompletionTrace`** so apps can inspect *why* a Tab answer was produced, using the same split, parser walk, and tables as runtime completion.
> 
> `trace` / `trace_view` record words, prefix, command path, cursor owner (flag value, argument, help topic, or flag), separator state, candidates, and shell path fallback. `Display` is meant for a hidden diagnostic command; fields stay assertable in tests. Help traces keep the typed topic route, including shared commands and executable views. `Files` also implements `Display` for the fallback line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa3a8ea24065cb27b380f0d7bcd32e59bb187e1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->