### PR TITLE
feat(complete): add semantic candidate kinds

### DIFF
--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -16,7 +16,7 @@
 //! in a real invocation.
 
 use crate::spec::{ArgMeta, CommandMeta, CommandSelector, FlagMeta, Spec, SpecView};
-pub use crate::spec::{Candidate, CompleteCtx, Completer};
+pub use crate::spec::{Candidate, CandidateKind, CompleteCtx, Completer};
 use crate::{Arg, Command, Error, Flag, Parser};
 use core::future::Future;
 use core::pin::Pin;
@@ -820,6 +820,14 @@ pub fn render(answer: &Completions<'_>, shell: Shell) -> String {
                 out.push_str(&one_line(
                     candidate.display.as_deref().unwrap_or(&candidate.value),
                 ));
+                out.push('\t');
+                out.push_str(match candidate.kind {
+                    CandidateKind::Value => "value",
+                    CandidateKind::Command => "command",
+                    CandidateKind::Flag => "flag",
+                    CandidateKind::File => "file",
+                    CandidateKind::Directory => "directory",
+                });
             }
             Shell::Fish | Shell::Nu => {
                 out.push_str(&candidate.value);
@@ -1512,6 +1520,7 @@ fn subcommands<'a>(meta: &'a CommandMeta<'a>, token: &str) -> Vec<Candidate<'a>>
             if name.starts_with(token) {
                 out.push(Candidate {
                     value: (*name).to_string(),
+                    kind: CandidateKind::Command,
                     display: None,
                     description: deprecated_description(
                         sub.about,
@@ -1550,6 +1559,7 @@ fn long_flags<'a>(spec: &'a Spec<'a>, position: &Position<'_>, token: &str) -> V
             if value.starts_with(token) {
                 out.push(Candidate {
                     value,
+                    kind: CandidateKind::Flag,
                     display: None,
                     description: description.clone(),
                 });
@@ -1565,6 +1575,7 @@ fn long_flags<'a>(spec: &'a Spec<'a>, position: &Position<'_>, token: &str) -> V
             if value.starts_with(token) {
                 out.push(Candidate {
                     value,
+                    kind: CandidateKind::Flag,
                     display: None,
                     description: description.clone(),
                 });
@@ -1598,6 +1609,7 @@ fn short_flags<'a>(spec: &'a Spec<'a>, position: &Position<'_>, token: &str) -> 
             if asked_about {
                 out.push(Candidate {
                     value: format!("-{}", short as char),
+                    kind: CandidateKind::Flag,
                     display: None,
                     description: meta.and_then(|m| {
                         deprecated_description(
@@ -1656,6 +1668,7 @@ fn positional<'a>(
         if token.is_empty() {
             return vec![Candidate {
                 value: "--".to_string(),
+                kind: CandidateKind::Value,
                 display: None,
                 description: None,
             }];
@@ -1733,6 +1746,7 @@ fn choices<'a>(
         .filter(|c| c.starts_with(token))
         .map(|c| Candidate {
             value: (*c).to_string(),
+            kind: CandidateKind::Value,
             display: None,
             description: details
                 .iter()
@@ -3670,7 +3684,7 @@ mod tests {
         // PowerShell also receives its separately selectable display text.
         assert_eq!(
             render(&answer, Shell::PowerShell),
-            "plugins\tManage plugins\tplugins\n"
+            "plugins\tManage plugins\tplugins\tcommand\n"
         );
 
         // zsh takes a third field: what to type, which is not always what is shown.
@@ -3691,12 +3705,26 @@ mod tests {
         assert_eq!(render(&answer, Shell::Fish), "iad\tUS East\n");
         assert_eq!(
             render(&answer, Shell::PowerShell),
-            "iad\tUS East\tIAD · Virginia\n"
+            "iad\tUS East\tIAD · Virginia\tvalue\n"
         );
         assert_eq!(
             render(&answer, Shell::Zsh),
             "IAD · Virginia\tUS East\tiad\n"
         );
+    }
+
+    #[test]
+    fn powershell_receives_native_candidate_kinds() {
+        let answer = Completions {
+            candidates: vec![Candidate::new("deploy").with_kind(CandidateKind::Command)],
+            files: None,
+        };
+        assert_eq!(
+            render(&answer, Shell::PowerShell),
+            "deploy\t\tdeploy\tcommand\n"
+        );
+        // Shells without a typed candidate API lose only the metadata.
+        assert_eq!(render(&answer, Shell::Fish), "deploy\n");
     }
 
     #[test]

--- a/argv/src/script.rs
+++ b/argv/src/script.rs
@@ -476,13 +476,22 @@ Register-ArgumentCompleter -Native -CommandName '{name}' -ScriptBlock {{
             $extensions = @($entry -split "`t" | Select-Object -Skip 1 | ForEach-Object {{ $_.TrimStart('.') }})
             continue
         }}
-        $parts = $entry -split "`t", 3
+        $parts = $entry -split "`t", 4
         $value = $parts[0]
         $description = if ($parts.Count -gt 1 -and $parts[1]) {{ $parts[1] }} else {{ $value }}
         $display = if ($parts.Count -gt 2 -and $parts[2]) {{ $parts[2] }} else {{ $value }}
+        $kind = if ($parts.Count -gt 3) {{
+            switch ($parts[3]) {{
+                'command' {{ 'Command' }}
+                'flag' {{ 'ParameterName' }}
+                'file' {{ 'ProviderItem' }}
+                'directory' {{ 'ProviderContainer' }}
+                default {{ 'ParameterValue' }}
+            }}
+        }} else {{ 'ParameterValue' }}
         $results.Add(
             [System.Management.Automation.CompletionResult]::new(
-                $value, $display, 'ParameterValue', $description
+                $value, $display, $kind, $description
             )
         )
     }}

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -254,6 +254,21 @@ impl<'a> CompleteCtx<'a> {
 /// capture anything.
 pub type Completer = fn(&CompleteCtx<'_>) -> Vec<Candidate<'static>>;
 
+/// The semantic role of one completion candidate.
+///
+/// PowerShell presents these with its native result types. Other shells currently preserve the
+/// value and description while ignoring the kind.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[non_exhaustive]
+pub enum CandidateKind {
+    #[default]
+    Value,
+    Command,
+    Flag,
+    File,
+    Directory,
+}
+
 /// Something a shell could offer at the cursor.
 ///
 /// `value` is what the shell inserts. `display` may replace it in shells whose completion API
@@ -261,6 +276,7 @@ pub type Completer = fn(&CompleteCtx<'_>) -> Vec<Candidate<'static>>;
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Candidate<'a> {
     pub value: String,
+    pub kind: CandidateKind,
     /// A presentation-only label. Zsh and PowerShell support this distinction; other shells
     /// display [`Self::value`] because their native candidate format couples the two.
     pub display: Option<::std::borrow::Cow<'a, str>>,
@@ -273,6 +289,7 @@ impl Candidate<'_> {
     pub fn new(value: impl Into<String>) -> Self {
         Self {
             value: value.into(),
+            kind: CandidateKind::Value,
             display: None,
             description: None,
         }
@@ -282,6 +299,7 @@ impl Candidate<'_> {
     pub fn described(value: impl Into<String>, description: impl Into<String>) -> Self {
         Self {
             value: value.into(),
+            kind: CandidateKind::Value,
             display: None,
             description: Some(::std::borrow::Cow::Owned(description.into())),
         }
@@ -290,6 +308,12 @@ impl Candidate<'_> {
     /// Use a different label in shells that can display one value while inserting another.
     pub fn displayed(mut self, display: impl Into<String>) -> Self {
         self.display = Some(::std::borrow::Cow::Owned(display.into()));
+        self
+    }
+
+    /// Classify the candidate for shells that present semantic result types.
+    pub fn with_kind(mut self, kind: CandidateKind) -> Self {
+        self.kind = kind;
         self
     }
 }

--- a/docs/rust/completions.md
+++ b/docs/rust/completions.md
@@ -185,6 +185,9 @@ with `Candidate::new(value)` or `Candidate::described(value, description)`; shel
 descriptions show them, shells that don't get the value alone. Chain `.displayed(label)` when a
 short insertion needs a more explanatory presentation; zsh and PowerShell keep that label
 separate from the text inserted into the command line, while other shells display the value.
+Chain `.with_kind(CandidateKind::Command)` (or `Flag`, `File`, or `Directory`) when a runtime
+candidate has a more specific role. PowerShell maps it to the corresponding native completion
+result type; shells without typed candidates keep the same value and description.
 
 ## Tracing an answer
 


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public Candidate struct gains a required kind field, so existing struct literals and custom completers must be updated. PowerShell’s completion protocol also gains a fourth tab-separated field.
> 
> **Overview**
> Completion candidates now carry a **semantic kind** (`Value`, `Command`, `Flag`, `File`, `Directory`) so PowerShell can use native `CompletionResult` types instead of treating everything as `ParameterValue`.
> 
> Built-in offers set the kind automatically: subcommands as `Command`, flags as `Flag`, choices and `--` as `Value`. Custom completers can chain `.with_kind(...)`. Other shells ignore the metadata.
> 
> PowerShell’s render protocol adds a fourth tab field (`command` / `flag` / `file` / `directory` / `value`), and the generated script maps those to `Command`, `ParameterName`, `ProviderItem`, `ProviderContainer`, or `ParameterValue`. Missing kinds still default to `ParameterValue`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a3ec9a6028c9996b9238f9646ea7d93a302cd2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->