### PR TITLE
feat(complete): add Elvish runtime completions

### DIFF
--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -730,6 +730,7 @@ impl Request {
         let mut line = String::new();
         let mut cursor = None;
         let mut candidates_for = None;
+        let mut words: Option<Vec<String>> = None;
         let mut rest = argv[1..].iter();
         while let Some(arg) = rest.next() {
             match arg.to_str().unwrap_or_default() {
@@ -754,13 +755,37 @@ impl Request {
                 "--candidates" => {
                     candidates_for = rest.next().map(|v| v.to_string_lossy().into_owned());
                 }
+                "--words" => {
+                    words = Some(
+                        rest.map(|word| word.to_string_lossy().into_owned())
+                            .collect(),
+                    );
+                    break;
+                }
                 _ => {}
             }
         }
-        let cursor = cursor.unwrap_or(line.len());
+        let split = match words {
+            Some(mut words) => {
+                if words.is_empty() {
+                    words.push(String::new());
+                }
+                let cword = words.len() - 1;
+                let prefix = words[cword].clone();
+                Split {
+                    words,
+                    cword,
+                    prefix,
+                }
+            }
+            None => {
+                let cursor = cursor.unwrap_or(line.len());
+                split(&line, cursor, shell)
+            }
+        };
         Some(Self {
             shell,
-            split: split(&line, cursor, shell),
+            split,
             candidates_for,
         })
     }
@@ -828,6 +853,15 @@ pub fn render(answer: &Completions<'_>, shell: Shell) -> String {
                     CandidateKind::File => "file",
                     CandidateKind::Directory => "directory",
                 });
+            }
+            Shell::Elvish => {
+                out.push_str(&candidate.value);
+                out.push('\t');
+                out.push_str(description);
+                out.push('\t');
+                out.push_str(&one_line(
+                    candidate.display.as_deref().unwrap_or(&candidate.value),
+                ));
             }
             Shell::Fish | Shell::Nu => {
                 out.push_str(&candidate.value);
@@ -1781,7 +1815,8 @@ fn arg_meta<'a>(meta: &'a CommandMeta<'a>, arg: &Arg<'_>) -> Option<&'a ArgMeta<
 
 /// Which shell's quoting rules a line follows.
 ///
-/// Only two rule sets, not five: bash, zsh, fish and nushell all follow the POSIX shape
+/// Most shells follow the POSIX word shape, while PowerShell and Elvish need their own
+/// lossless argv handling and output protocols.
 /// closely enough that a completion request cannot tell them apart, while PowerShell escapes
 /// with a backtick and doubles a quote to escape it. The distinction is kept per *shell*
 /// rather than per rule set so that a shell whose rules turn out to differ can be given its
@@ -1790,6 +1825,7 @@ fn arg_meta<'a>(meta: &'a CommandMeta<'a>, arg: &Arg<'_>) -> Option<&'a ArgMeta<
 #[non_exhaustive]
 pub enum Shell {
     Bash,
+    Elvish,
     Zsh,
     Fish,
     Nu,
@@ -1801,6 +1837,7 @@ impl Shell {
     pub fn as_str(self) -> &'static str {
         match self {
             Shell::Bash => "bash",
+            Shell::Elvish => "elvish",
             Shell::Zsh => "zsh",
             Shell::Fish => "fish",
             Shell::Nu => "nu",
@@ -1812,6 +1849,7 @@ impl Shell {
     pub fn from_name(name: &str) -> Option<Self> {
         match name {
             "bash" => Some(Shell::Bash),
+            "elvish" => Some(Shell::Elvish),
             "zsh" => Some(Shell::Zsh),
             "fish" => Some(Shell::Fish),
             "nu" | "nushell" => Some(Shell::Nu),
@@ -3681,6 +3719,12 @@ mod tests {
         // fish and nu take a description after a tab.
         assert_eq!(render(&answer, Shell::Fish), "plugins\tManage plugins\n");
 
+        // Elvish receives insertion, description, and presentation separately.
+        assert_eq!(
+            render(&answer, Shell::Elvish),
+            "plugins\tManage plugins\tplugins\n"
+        );
+
         // PowerShell also receives its separately selectable display text.
         assert_eq!(
             render(&answer, Shell::PowerShell),
@@ -3692,6 +3736,24 @@ mod tests {
             render(&answer, Shell::Zsh),
             "plugins\tManage plugins\tplugins\n"
         );
+    }
+
+    #[test]
+    fn a_shell_that_already_split_words_can_send_them_losslessly() {
+        let argv = [
+            OsString::from("__complete_word__"),
+            OsString::from("--shell"),
+            OsString::from("elvish"),
+            OsString::from("--words"),
+            OsString::from("mise"),
+            OsString::from("run"),
+            OsString::from("two words"),
+        ];
+        let request = Request::parse(&argv).expect("a completion request");
+        assert_eq!(request.shell, Shell::Elvish);
+        assert_eq!(request.split.words, ["mise", "run", "two words"]);
+        assert_eq!(request.split.cword, 2);
+        assert_eq!(request.split.prefix, "two words");
     }
 
     #[test]

--- a/argv/src/install.rs
+++ b/argv/src/install.rs
@@ -259,6 +259,7 @@ fn file_name(shell: Shell, name: &str) -> String {
     match shell {
         // bash-completion loads `<cmd>` on demand, by the command's exact name.
         Shell::Bash => name.to_string(),
+        Shell::Elvish => format!("{name}.elv"),
         // `compinit` autoloads `_<cmd>` and calls the function the file is named after, which is
         // what the generated script's tail is written for.
         Shell::Zsh => format!("_{name}"),
@@ -351,6 +352,19 @@ fn sources(shell: Shell, platform: Platform) -> &'static [Source] {
         Source::var("USERPROFILE", &[".config", "fish", "completions"]),
     ];
 
+    const ELVISH: &[Source] = &[
+        Source::var("XDG_CONFIG_HOME", &["elvish", "completions"]),
+        Source::var("HOME", &[".config", "elvish", "completions"]),
+    ];
+    const ELVISH_WINDOWS: &[Source] = &[
+        Source::var("XDG_CONFIG_HOME", &["elvish", "completions"]),
+        Source::var("APPDATA", &["elvish", "completions"]),
+        Source::var(
+            "USERPROFILE",
+            &["AppData", "Roaming", "elvish", "completions"],
+        ),
+    ];
+
     // A vendor autoload directory is the only place nushell reads a completion from without being
     // told to, and the only way to know where one is, is to be told. Everything after it is a plain
     // file plus a reported `source` line, which is true on every nushell that has ever shipped.
@@ -395,6 +409,8 @@ fn sources(shell: Shell, platform: Platform) -> &'static [Source] {
     match (shell, platform) {
         (Shell::Bash, Windows) => BASH_WINDOWS,
         (Shell::Bash, Linux | MacOs) => BASH,
+        (Shell::Elvish, Windows) => ELVISH_WINDOWS,
+        (Shell::Elvish, Linux | MacOs) => ELVISH,
         (Shell::Zsh, Windows) => ZSH_WINDOWS,
         (Shell::Zsh, Linux | MacOs) => ZSH,
         (Shell::Fish, Windows) => FISH_WINDOWS,
@@ -518,6 +534,17 @@ fn is_absolute(value: &OsStr, platform: Platform) -> bool {
 fn loading(shell: Shell, resolved_from: &'static str, dir: &Path, path: &Path) -> Loading {
     match shell {
         Shell::Bash | Shell::Fish => Loading::Automatic,
+        Shell::Elvish => Loading::Manual {
+            line: format!("source {}", quote(shell, &path.display().to_string())),
+            file: dir
+                .parent()
+                .unwrap_or(dir)
+                .join("rc.elv")
+                .display()
+                .to_string(),
+            why: "Elvish argument completers are registered by evaluating configuration, so its \
+                  rc.elv must source the generated file.",
+        },
         Shell::Zsh => Loading::Manual {
             line: format!(
                 "fpath+=({})\nautoload -Uz compinit && compinit",
@@ -564,7 +591,7 @@ fn note(shell: Shell, resolved_from: &'static str) -> Option<&'static str> {
             "a config.nu that assigns $env.config wholesale after autoload replaces the completer \
              this script chained onto.",
         ),
-        Shell::Zsh | Shell::Fish | Shell::Nu | Shell::PowerShell => None,
+        Shell::Elvish | Shell::Zsh | Shell::Fish | Shell::Nu | Shell::PowerShell => None,
     }
 }
 
@@ -876,8 +903,9 @@ mod tests {
         described(platform, &[("HOME", "/home/u")])
     }
 
-    const SHELLS: [Shell; 5] = [
+    const SHELLS: [Shell; 6] = [
         Shell::Bash,
+        Shell::Elvish,
         Shell::Zsh,
         Shell::Fish,
         Shell::Nu,
@@ -974,6 +1002,20 @@ mod tests {
             target.path,
             Path::new("/home/u/.config/fish/completions/ex.fish")
         );
+    }
+
+    #[test]
+    fn elvish_reports_the_rc_line_that_registers_its_completer() {
+        let target = plan("ex", Shell::Elvish, &home(Platform::Linux)).unwrap();
+        assert_eq!(
+            target.path,
+            PathBuf::from("/home/u/.config/elvish/completions/ex.elv")
+        );
+        let Loading::Manual { line, file, .. } = target.loading else {
+            panic!("Elvish needs its rc file to source the generated script");
+        };
+        assert_eq!(line, "source '/home/u/.config/elvish/completions/ex.elv'");
+        assert_eq!(file, "/home/u/.config/elvish/rc.elv");
     }
 
     #[test]

--- a/argv/src/install.rs
+++ b/argv/src/install.rs
@@ -247,7 +247,7 @@ pub fn plan_for(bin: &str, name: &str, shell: Shell, env: &Env) -> Result<Plan, 
     Ok(Plan {
         shell,
         name: name.to_string(),
-        loading: loading(shell, resolved_from, &dir, &path),
+        loading: loading(shell, resolved_from, &dir, &path, env.platform()),
         note: note(shell, resolved_from),
         path,
         resolved_from,
@@ -531,15 +531,18 @@ fn is_absolute(value: &OsStr, platform: Platform) -> bool {
 /// separator, so on a Unix host a plan made for Windows — `C:\…\_ex`, one component to a parser
 /// that does not read `\` as a separator — has an empty parent, and zsh was told to add nothing
 /// at all to its `$fpath`. The caller already holds the directory it built.
-fn loading(shell: Shell, resolved_from: &'static str, dir: &Path, path: &Path) -> Loading {
+fn loading(
+    shell: Shell,
+    resolved_from: &'static str,
+    dir: &Path,
+    path: &Path,
+    platform: Platform,
+) -> Loading {
     match shell {
         Shell::Bash | Shell::Fish => Loading::Automatic,
         Shell::Elvish => Loading::Manual {
             line: format!("source {}", quote(shell, &path.display().to_string())),
-            file: dir
-                .parent()
-                .unwrap_or(dir)
-                .join("rc.elv")
+            file: join_for(dir.parent().unwrap_or(dir), "rc.elv", platform)
                 .display()
                 .to_string(),
             why: "Elvish argument completers are registered by evaluating configuration, so its \

--- a/argv/src/install.rs
+++ b/argv/src/install.rs
@@ -541,12 +541,15 @@ fn loading(
     match shell {
         Shell::Bash | Shell::Fish => Loading::Automatic,
         Shell::Elvish => Loading::Manual {
-            line: format!("source {}", quote(shell, &path.display().to_string())),
+            line: format!(
+                "eval (slurp <{})",
+                quote(shell, &path.display().to_string())
+            ),
             file: join_for(dir.parent().unwrap_or(dir), "rc.elv", platform)
                 .display()
                 .to_string(),
             why: "Elvish argument completers are registered by evaluating configuration, so its \
-                  rc.elv must source the generated file.",
+                  rc.elv must evaluate the generated file.",
         },
         Shell::Zsh => Loading::Manual {
             line: format!(
@@ -1018,7 +1021,10 @@ mod tests {
         let Loading::Manual { line, file, .. } = target.loading else {
             panic!("Elvish needs its rc file to source the generated script");
         };
-        assert_eq!(line, "source '/home/u/.config/elvish/completions/ex.elv'");
+        assert_eq!(
+            line,
+            "eval (slurp <'/home/u/.config/elvish/completions/ex.elv')"
+        );
         assert_eq!(file, "/home/u/.config/elvish/rc.elv");
         assert_eq!(quote(Shell::Elvish, "a'b"), "'a''b'");
     }

--- a/argv/src/install.rs
+++ b/argv/src/install.rs
@@ -599,11 +599,12 @@ fn note(shell: Shell, resolved_from: &'static str) -> Option<&'static str> {
 ///
 /// Single quotes rather than double: a single-quoted string has nothing left to expand, so a `$` or
 /// a space in a home directory cannot change what the line means. The escape differs — POSIX shells
-/// and nushell end the string, add an escaped quote and start again; PowerShell doubles its own —
-/// and the two agree on every path containing no quote at all, which is almost all of them.
+/// and nushell end the string, add an escaped quote and start again; Elvish and PowerShell double
+/// their own — and the two forms agree on every path containing no quote at all, which is almost
+/// all of them.
 fn quote(shell: Shell, text: &str) -> String {
     match shell {
-        Shell::PowerShell => format!("'{}'", text.replace('\'', "''")),
+        Shell::Elvish | Shell::PowerShell => format!("'{}'", text.replace('\'', "''")),
         _ => format!("'{}'", text.replace('\'', "'\\''")),
     }
 }
@@ -1016,6 +1017,7 @@ mod tests {
         };
         assert_eq!(line, "source '/home/u/.config/elvish/completions/ex.elv'");
         assert_eq!(file, "/home/u/.config/elvish/rc.elv");
+        assert_eq!(quote(Shell::Elvish, "a'b"), "'a''b'");
     }
 
     #[test]

--- a/argv/src/script.rs
+++ b/argv/src/script.rs
@@ -101,9 +101,8 @@ fn elvish(bin: &str, name: &str) -> String {
         r#"{head}use os
 use str
 
-var usage-command = (external '{bin}')
-
 set edit:completion:arg-completer[{name}] = {{|@words|
+    var usage-command = (external '{bin}')
     var lines = [($usage-command __complete_word__ --shell elvish --words $@words 2>$os:dev-null | from-lines)]
     for line $lines {{
         if (eq $line "\x01files") {{
@@ -661,7 +660,9 @@ mod tests {
     fn elvish_keeps_candidates_as_values_through_its_protocol() {
         let out = script("mise", Shell::Elvish);
         assert!(
-            out.contains("var usage-command = (external 'mise')"),
+            out.contains(
+                "arg-completer[mise] = {|@words|\n    var usage-command = (external 'mise')"
+            ),
             "{out}"
         );
         assert!(out.contains("| from-lines)"), "{out}");

--- a/argv/src/script.rs
+++ b/argv/src/script.rs
@@ -87,11 +87,61 @@ pub fn script_for(bin: &str, name: &str, shell: Shell) -> String {
     );
     match shell {
         Shell::Bash => bash(bin, name),
+        Shell::Elvish => elvish(bin, name),
         Shell::Zsh => zsh(bin, name),
         Shell::Fish => fish(bin, name),
         Shell::Nu => nu(bin, name, &nu_ident(name)),
         Shell::PowerShell => powershell(bin, name),
     }
+}
+
+fn elvish(bin: &str, name: &str) -> String {
+    let head = header(bin, Shell::Elvish, "#");
+    format!(
+        r#"{head}use edit
+use str
+
+var usage-command = '{bin}'
+
+set edit:completion:arg-completer[{name}] = {{|@words|
+    var lines = [($usage-command __complete_word__ --shell elvish --words $@words 2>/dev/null | to-lines)]
+    for line $lines {{
+        if (eq $line "\x01files") {{
+            edit:complete-filename $@words
+            continue
+        }}
+        if (eq $line "\x01dirs") {{
+            edit:complete-dirname $@words
+            continue
+        }}
+        if (eq $line "\x01executables") {{
+            edit:complete-filename $@words
+            continue
+        }}
+        if (str:has-prefix $line "\x01extensions\t") {{
+            # Elvish's native filename completer owns quoting and directory traversal. It does
+            # not expose an extension-filter option, so this target degrades to native paths.
+            edit:complete-filename $@words
+            continue
+        }}
+        if (or (eq $line "\x01commands") (eq $line '')) {{
+            continue
+        }}
+
+        var parts = (str:split "\t" $line)
+        var value = $parts[0]
+        var display = $value
+        if (> (count $parts) 2) {{
+            set display = $parts[2]
+        }}
+        if (and (> (count $parts) 1) (not-eq $parts[1] '')) {{
+            set display = (str:join '  -- ' [$display $parts[1]])
+        }}
+        edit:complex-candidate $value &display=$display
+    }}
+}}
+"#,
+    )
 }
 
 /// A nushell identifier for a binary's name, one name to one identifier.
@@ -552,6 +602,7 @@ mod tests {
     fn every_script_names_the_binary_and_the_hidden_command() {
         for shell in [
             Shell::Bash,
+            Shell::Elvish,
             Shell::Zsh,
             Shell::Fish,
             Shell::Nu,
@@ -574,6 +625,11 @@ mod tests {
                 Shell::Bash,
                 "complete -F _usage_complete_m 'm'",
                 "command 'mise'",
+            ),
+            (
+                Shell::Elvish,
+                "arg-completer[m]",
+                "var usage-command = 'mise'",
             ),
             (Shell::Zsh, "#compdef m", "command 'mise'"),
             (Shell::Fish, "complete -c 'm'", "command 'mise'"),
@@ -672,10 +728,16 @@ mod tests {
     #[test]
     fn two_names_that_are_not_identifiers_do_not_become_one() {
         // `foo-bar` and `foo+bar` are two binaries. Flattening both to `foo_bar` meant that with
-        // two scripts loaded, completing one ran the other's completer — so bash, zsh and fish
-        // take the name verbatim (all three accept these characters in a function name) and
+        // two scripts loaded, completing one ran the other's completer — so bash, Elvish, zsh and
+        // fish take the name verbatim (all accept these characters in this position) and
         // nushell, which cannot, escapes rather than flattens.
-        for shell in [Shell::Bash, Shell::Zsh, Shell::Fish, Shell::Nu] {
+        for shell in [
+            Shell::Bash,
+            Shell::Elvish,
+            Shell::Zsh,
+            Shell::Fish,
+            Shell::Nu,
+        ] {
             let dash = script("foo-bar", shell);
             let plus = script("foo+bar", shell);
             assert_ne!(dash, plus, "{shell:?} generated the same script for both");

--- a/argv/src/script.rs
+++ b/argv/src/script.rs
@@ -98,13 +98,12 @@ pub fn script_for(bin: &str, name: &str, shell: Shell) -> String {
 fn elvish(bin: &str, name: &str) -> String {
     let head = header(bin, Shell::Elvish, "#");
     format!(
-        r#"{head}use edit
-use str
+        r#"{head}use str
 
-var usage-command = '{bin}'
+var usage-command = (external '{bin}')
 
 set edit:completion:arg-completer[{name}] = {{|@words|
-    var lines = [($usage-command __complete_word__ --shell elvish --words $@words 2>/dev/null | to-lines)]
+    var lines = [($usage-command __complete_word__ --shell elvish --words $@words 2>/dev/null | from-lines)]
     for line $lines {{
         if (eq $line "\x01files") {{
             edit:complete-filename $@words
@@ -124,11 +123,17 @@ set edit:completion:arg-completer[{name}] = {{|@words|
             edit:complete-filename $@words
             continue
         }}
-        if (or (eq $line "\x01commands") (eq $line '')) {{
+        if (eq $line "\x01commands") {{
+            # complete-sudo's first argument is a command position, so this asks Elvish for
+            # external commands without recursively invoking this argument completer.
+            edit:complete-sudo sudo $words[-1]
+            continue
+        }}
+        if (eq $line '') {{
             continue
         }}
 
-        var parts = (str:split "\t" $line)
+        var parts = [(str:split "\t" $line)]
         var value = $parts[0]
         var display = $value
         if (> (count $parts) 2) {{
@@ -629,7 +634,7 @@ mod tests {
             (
                 Shell::Elvish,
                 "arg-completer[m]",
-                "var usage-command = 'mise'",
+                "var usage-command = (external 'mise')",
             ),
             (Shell::Zsh, "#compdef m", "command 'mise'"),
             (Shell::Fish, "complete -c 'm'", "command 'mise'"),
@@ -649,6 +654,19 @@ mod tests {
                 assert!(!out.contains("`_mise`"), "{out}");
             }
         }
+    }
+
+    #[test]
+    fn elvish_keeps_candidates_as_values_through_its_protocol() {
+        let out = script("mise", Shell::Elvish);
+        assert!(
+            out.contains("var usage-command = (external 'mise')"),
+            "{out}"
+        );
+        assert!(out.contains("| from-lines)"), "{out}");
+        assert!(!out.contains("| to-lines)"), "{out}");
+        assert!(out.contains("var parts = [(str:split"), "{out}");
+        assert!(out.contains("edit:complete-sudo sudo $words[-1]"), "{out}");
     }
 
     /// zsh reads `#compdef` on the *first* line and nowhere else.

--- a/argv/src/script.rs
+++ b/argv/src/script.rs
@@ -98,12 +98,13 @@ pub fn script_for(bin: &str, name: &str, shell: Shell) -> String {
 fn elvish(bin: &str, name: &str) -> String {
     let head = header(bin, Shell::Elvish, "#");
     format!(
-        r#"{head}use str
+        r#"{head}use os
+use str
 
 var usage-command = (external '{bin}')
 
 set edit:completion:arg-completer[{name}] = {{|@words|
-    var lines = [($usage-command __complete_word__ --shell elvish --words $@words 2>/dev/null | from-lines)]
+    var lines = [($usage-command __complete_word__ --shell elvish --words $@words 2>$os:dev-null | from-lines)]
     for line $lines {{
         if (eq $line "\x01files") {{
             edit:complete-filename $@words
@@ -665,6 +666,8 @@ mod tests {
         );
         assert!(out.contains("| from-lines)"), "{out}");
         assert!(!out.contains("| to-lines)"), "{out}");
+        assert!(out.contains("2>$os:dev-null"), "{out}");
+        assert!(!out.contains("/dev/null"), "{out}");
         assert!(out.contains("var parts = [(str:split"), "{out}");
         assert!(out.contains("edit:complete-sudo sudo $words[-1]"), "{out}");
     }

--- a/argv/tests/install.rs
+++ b/argv/tests/install.rs
@@ -74,8 +74,9 @@ impl Drop for Fixture {
     }
 }
 
-const SHELLS: [Shell; 5] = [
+const SHELLS: [Shell; 6] = [
     Shell::Bash,
+    Shell::Elvish,
     Shell::Zsh,
     Shell::Fish,
     Shell::Nu,

--- a/argv/tests/scripts.rs
+++ b/argv/tests/scripts.rs
@@ -14,6 +14,8 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+#[cfg(unix)]
+use std::process::Stdio;
 use usage_argv::complete::Shell;
 use usage_argv::script::script;
 
@@ -157,7 +159,6 @@ fn every_script_is_valid_in_its_own_shell() {
     // prompt, so it is worth checking even where the shell cannot be driven any further.
     let checks: &[(Shell, &str, &[&str])] = &[
         (Shell::Bash, "bash", &["-n"]),
-        (Shell::Elvish, "elvish", &["-compileonly"]),
         (Shell::Zsh, "zsh", &["-n"]),
         (Shell::Fish, "fish", &["--no-execute"]),
     ];
@@ -201,6 +202,63 @@ fn every_script_is_valid_in_its_own_shell() {
             checks.len()
         );
     }
+}
+
+#[cfg(unix)]
+#[test]
+fn elvish_offers_what_the_binary_answered() {
+    use std::io::Write;
+
+    // Elvish's noninteractive compiler does not define the interactive `edit:` namespace, so
+    // loading this as an RC file in a real pseudoterminal is both the syntax and behavior check.
+    if !available("elvish") || !available("script") {
+        println!("elvish or the script PTY driver is not installed; skipping");
+        return;
+    }
+    let fixture = Fixture::new(
+        "elvish-candidates",
+        Shell::Elvish,
+        "install\tInstall a package\tINSTALL\n",
+    );
+    let rc = fixture.dir.join("script");
+    let command = format!("elvish -rc {}", shell_quote(&rc.to_string_lossy()));
+    let mut child = Command::new("script")
+        .args(["-qfc", &command, "/dev/null"])
+        .current_dir(&fixture.dir)
+        .env(
+            "PATH",
+            format!(
+                "{}:{}",
+                fixture.dir.display(),
+                std::env::var("PATH").unwrap_or_default()
+            ),
+        )
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("starting Elvish in a pseudoterminal");
+    let mut stdin = child.stdin.take().expect("PTY stdin");
+    std::thread::sleep(std::time::Duration::from_millis(500));
+    stdin.write_all(b"ex i\t").expect("requesting completion");
+    stdin.flush().expect("flushing completion request");
+    std::thread::sleep(std::time::Duration::from_millis(500));
+    stdin.write_all(b"\x03").expect("cancelling the input line");
+    stdin.flush().expect("flushing cancellation");
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    stdin.write_all(b"\x04").expect("exiting Elvish");
+    let out = child.wait_with_output().expect("waiting for Elvish");
+    assert!(
+        out.status.success(),
+        "Elvish failed:\n{}\n{}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("nstall") && !stdout.contains("no candidates"),
+        "candidate was not displayed: {stdout:?}"
+    );
 }
 
 #[test]

--- a/argv/tests/scripts.rs
+++ b/argv/tests/scripts.rs
@@ -17,7 +17,7 @@ use std::process::Command;
 #[cfg(unix)]
 use std::process::Stdio;
 use usage_argv::complete::Shell;
-use usage_argv::script::script;
+use usage_argv::script::{script, script_for};
 
 /// A directory of this test's own, with the generated script and a stand-in `ex` binary in it.
 struct Fixture {
@@ -220,6 +220,9 @@ fn elvish_offers_what_the_binary_answered() {
         Shell::Elvish,
         "install\tInstall a package\tINSTALL\n",
     );
+    let mut rc = fs::read_to_string(fixture.dir.join("script")).expect("reading the Elvish RC");
+    rc.push_str(&script_for("ex", "ex-alias", Shell::Elvish));
+    fs::write(fixture.dir.join("script"), rc).expect("writing both Elvish completers");
     let rc = fixture.dir.join("script");
     let command = format!("elvish -rc {}", shell_quote(&rc.to_string_lossy()));
     let mut child = Command::new("script")

--- a/argv/tests/scripts.rs
+++ b/argv/tests/scripts.rs
@@ -17,7 +17,9 @@ use std::process::Command;
 #[cfg(unix)]
 use std::process::Stdio;
 use usage_argv::complete::Shell;
-use usage_argv::script::{script, script_for};
+use usage_argv::script::script;
+#[cfg(unix)]
+use usage_argv::script::script_for;
 
 /// A directory of this test's own, with the generated script and a stand-in `ex` binary in it.
 struct Fixture {

--- a/argv/tests/scripts.rs
+++ b/argv/tests/scripts.rs
@@ -157,6 +157,7 @@ fn every_script_is_valid_in_its_own_shell() {
     // prompt, so it is worth checking even where the shell cannot be driven any further.
     let checks: &[(Shell, &str, &[&str])] = &[
         (Shell::Bash, "bash", &["-n"]),
+        (Shell::Elvish, "elvish", &["-compileonly"]),
         (Shell::Zsh, "zsh", &["-n"]),
         (Shell::Fish, "fish", &["--no-execute"]),
     ];

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -1907,6 +1907,8 @@ fn completion_fns(cli: &Cli) -> (TokenStream, TokenStream) {
             let mut cursor = ::std::option::Option::None;
             let mut candidates_for: ::std::option::Option<::std::string::String> =
                 ::std::option::Option::None;
+            let mut words: ::std::option::Option<::std::vec::Vec<::std::string::String>> =
+                ::std::option::Option::None;
             let mut rest = argv[1..].iter();
             while let ::std::option::Option::Some(arg) = rest.next() {
                 match arg.to_str().unwrap_or_default() {
@@ -1938,6 +1940,14 @@ fn completion_fns(cli: &Cli) -> (TokenStream, TokenStream) {
                     "--candidates" => {
                         candidates_for = rest.next().map(|v| v.to_string_lossy().into_owned());
                     }
+                    // Elvish already hands its completer losslessly split words. Keeping them as
+                    // argv avoids re-quoting text just so the shared line splitter can undo it.
+                    "--words" => {
+                        words = ::std::option::Option::Some(
+                            rest.map(|word| word.to_string_lossy().into_owned()).collect(),
+                        );
+                        break;
+                    }
                     // Anything else is a shell passing something this version does not know
                     // about. Ignored rather than refused: a completion that errors out is a
                     // shell that beeps at every keystroke.
@@ -1946,8 +1956,20 @@ fn completion_fns(cli: &Cli) -> (TokenStream, TokenStream) {
             }
             // No cursor means the end of the line, which is where a shell puts it when it has
             // no way to say — nushell, whose completer only ever sees the words.
-            let cursor = cursor.unwrap_or(line.len());
-            let mut split = usage_argv::complete::split(&line, cursor, shell);
+            let mut split = match words {
+                ::std::option::Option::Some(mut words) => {
+                    if words.is_empty() {
+                        words.push(::std::string::String::new());
+                    }
+                    let cword = words.len() - 1;
+                    let prefix = words[cword].clone();
+                    usage_argv::complete::Split { words, cword, prefix }
+                }
+                ::std::option::Option::None => {
+                    let cursor = cursor.unwrap_or(line.len());
+                    usage_argv::complete::split(&line, cursor, shell)
+                }
+            };
             let __usage_selected_view = split.words.first().and_then(|__usage_program| {
                 usage_argv::spec::view_for_program(
                     Self::spec(),

--- a/docs/rust/completions.md
+++ b/docs/rust/completions.md
@@ -101,7 +101,7 @@ Where each shell keeps a user's own scripts, and whether it finds one without be
 | Shell      | Directory                                                                                     | Loads by itself            |
 | ---------- | --------------------------------------------------------------------------------------------- | -------------------------- |
 | bash       | `$BASH_COMPLETION_USER_DIR/completions`, else `$XDG_DATA_HOME/bash-completion/completions`    | yes, via bash-completion   |
-| Elvish     | `$XDG_CONFIG_HOME/elvish/completions`                                                     | no — needs sourcing        |
+| Elvish     | `$XDG_CONFIG_HOME/elvish/completions`                                                         | no — needs sourcing        |
 | fish       | `$XDG_CONFIG_HOME/fish/completions`                                                           | yes                        |
 | nushell    | `$NU_VENDOR_AUTOLOAD_DIR`, else the nushell config directory                                  | only in a vendor directory |
 | zsh        | `$XDG_DATA_HOME/zsh/site-functions`, as `_<name>`                                             | no — needs `fpath+=`       |

--- a/docs/rust/completions.md
+++ b/docs/rust/completions.md
@@ -35,11 +35,9 @@ pub fn install_completion_for_alias(alias, shell, env, on_foreign) -> Result<Ins
 pub fn completion_request(argv: &[OsString]) -> Option<String>;
 ```
 
-`Shell` covers `Bash`, `Zsh`, `Fish`, `Nu`, and `PowerShell`.
+`Shell` covers `Bash`, `Elvish`, `Zsh`, `Fish`, `Nu`, and `PowerShell`.
 
-For clap parity, bash, fish, PowerShell, and zsh are the covered set. Nushell is an additional
-usage-native target. Elvish is not supported, so a clap application that currently publishes an
-Elvish script must keep that generator or defer the migration of that artifact.
+This covers clap's native shell set and adds a usage-native Nushell target.
 
 ## How it works
 
@@ -103,6 +101,7 @@ Where each shell keeps a user's own scripts, and whether it finds one without be
 | Shell      | Directory                                                                                     | Loads by itself            |
 | ---------- | --------------------------------------------------------------------------------------------- | -------------------------- |
 | bash       | `$BASH_COMPLETION_USER_DIR/completions`, else `$XDG_DATA_HOME/bash-completion/completions`    | yes, via bash-completion   |
+| Elvish     | `$XDG_CONFIG_HOME/elvish/completions`                                                     | no — needs sourcing        |
 | fish       | `$XDG_CONFIG_HOME/fish/completions`                                                           | yes                        |
 | nushell    | `$NU_VENDOR_AUTOLOAD_DIR`, else the nushell config directory                                  | only in a vendor directory |
 | zsh        | `$XDG_DATA_HOME/zsh/site-functions`, as `_<name>`                                             | no — needs `fpath+=`       |

--- a/docs/rust/migrating-from-clap.md
+++ b/docs/rust/migrating-from-clap.md
@@ -18,7 +18,6 @@ Check these before starting a migration:
 | Some relationships through `flatten` or on positionals are not available at binding time.     | Keep a post-parse check for the cases described under [Subcommands and shared arguments](#subcommands-and-shared-arguments).    |
 | Prefix inference is intentionally unsupported.                                                | Long flags and subcommands must use a full name or declared alias.                                                              |
 | clap help templates and style palettes are not portable as-is.                                | Rewrite templates using usage's six [help sections](/rust/help#laying-a-page-out); usage chooses terminal styles automatically. |
-| Completion generation does not target Elvish.                                                 | Keep `clap_complete` or another generator for that artifact.                                                                    |
 
 If a migration begins from a `clap::Command` rather than the Rust declaration,
 `clap_usage::spec_with_report` detects recoverable losses. It cannot report state for which clap


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the public `Shell` enum, completion request protocol, and generated shell scripts. Behavior is additive and covered by unit plus optional live Elvish tests, but a protocol or quoting bug would break tab-complete in that shell.
> 
> **Overview**
> Adds **Elvish** as a first-class completion target, matching clap’s native shell set plus the existing usage-native Nushell path.
> 
> The generated script registers `edit:completion:arg-completer` and calls the binary with a new `--words` protocol so already-split argv (including spaces) is not re-quoted. Completions render as `value`, description, and display; file/dir/command markers fall back to Elvish’s native completers (extension filters degrade to all files).
> 
> Install writes `{name}.elv` under Elvish’s completions dir and reports a **manual** `rc.elv` line (`eval (slurp <…>)`). Paths are quoted like PowerShell (doubled single quotes). Docs drop the “Elvish not supported” migration caveat.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d885fd706d6eed20030f7c13601b08d2d7dec26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->