### PR TITLE
feat(cli): render inline formatting in help text

### DIFF
--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -328,8 +328,8 @@ fn styled_inline(text: &str, parent: Option<&str>) -> String {
             let previous = text[..at].chars().next_back();
             // Do not reinterpret part of a delimiter run when the longer form was rejected.
             // In particular, neither underscore in `word__word__` may become an italic opener.
-            if delimiter.len() == 1
-                && (previous == Some(marker) || rest[delimiter.len()..].starts_with(marker))
+            if previous == Some(marker)
+                || (delimiter.len() == 1 && rest[delimiter.len()..].starts_with(marker))
             {
                 return None;
             }
@@ -3534,8 +3534,8 @@ mod style_tests {
     #[test]
     fn intraword_underscore_runs_remain_literal() {
         assert_eq!(
-            styled_inline("foo__bar__ baz_qux", None),
-            "foo__bar__ baz_qux"
+            styled_inline("foo__bar__ foo___bar___ baz_qux", None),
+            "foo__bar__ foo___bar___ baz_qux"
         );
     }
 

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -296,6 +296,7 @@ impl Style {
 fn styled_inline(text: &str, parent: Option<&str>) -> String {
     let mut out = String::with_capacity(text.len());
     let mut at = 0;
+    let mut allow_run_remainder = false;
     while at < text.len() {
         let rest = &text[at..];
 
@@ -307,6 +308,7 @@ fn styled_inline(text: &str, parent: Option<&str>) -> String {
             if matches!(escaped, '*' | '_' | '~' | '`' | '\\') {
                 out.push(escaped);
                 at += 1 + escaped.len_utf8();
+                allow_run_remainder = false;
                 continue;
             }
         }
@@ -328,7 +330,7 @@ fn styled_inline(text: &str, parent: Option<&str>) -> String {
             let previous = text[..at].chars().next_back();
             // Do not reinterpret part of a delimiter run when the longer form was rejected.
             // In particular, neither underscore in `word__word__` may become an italic opener.
-            if previous == Some(marker)
+            if (previous == Some(marker) && !allow_run_remainder)
                 || (delimiter.len() == 1 && rest[delimiter.len()..].starts_with(marker))
             {
                 return None;
@@ -341,7 +343,7 @@ fn styled_inline(text: &str, parent: Option<&str>) -> String {
             Some((delimiter, open, close, recurse, content_start, end, after))
         });
 
-        if let Some((_, open, close, recurse, content_start, end, after)) = span {
+        if let Some((delimiter, open, close, recurse, content_start, end, after)) = span {
             out.push_str("\u{1b}[");
             out.push_str(open);
             out.push('m');
@@ -358,6 +360,9 @@ fn styled_inline(text: &str, parent: Option<&str>) -> String {
                 out.push_str(parent);
                 out.push('m');
             }
+            let marker = delimiter.chars().next().expect("a delimiter has a marker");
+            allow_run_remainder =
+                text[after..].starts_with(marker) && text[..after].ends_with(marker);
             at = after;
             continue;
         }
@@ -365,16 +370,17 @@ fn styled_inline(text: &str, parent: Option<&str>) -> String {
         let ch = rest.chars().next().expect("at is on a character boundary");
         out.push(ch);
         at += ch.len_utf8();
+        allow_run_remainder = false;
     }
     out
 }
 
-/// Find a span's close while stepping over valid spans of the other width.
+/// Find a span's close while stepping over valid spans of another width.
 ///
-/// A one-marker italic span may contain a two-marker bold span and vice versa. Combined closing
-/// runs such as the final `***` in `*italic and **bold***` are shared: two markers close bold and
-/// the last closes italic. `reserve` tells a nested search how many markers its parent still
-/// needs from such a run.
+/// Italic, bold, and combined spans may nest within one another. Combined closing runs such as
+/// the final `***` in `*italic and **bold***` are shared: two markers close bold and the last
+/// closes italic. `reserve` tells a nested search how many markers its parent still needs from
+/// such a run.
 fn closing_delimiter(
     text: &str,
     content_start: usize,
@@ -384,11 +390,6 @@ fn closing_delimiter(
 ) -> Option<(usize, usize)> {
     let marker = delimiter.chars().next()?;
     let width = delimiter.len();
-    let nested_width = match (width, marker) {
-        (1, '*' | '_') => 2,
-        (2, '*' | '_') => 1,
-        _ => 0,
-    };
     let mut search_at = content_start;
 
     while let Some(found) = text[search_at..].find(marker) {
@@ -412,7 +413,11 @@ fn closing_delimiter(
             continue;
         }
 
-        if run_len == nested_width {
+        let nested_width = match (run_len, marker) {
+            (1..=3, '*' | '_') if run_len != width => run_len,
+            _ => 0,
+        };
+        if nested_width != 0 {
             let nested = &text[run_start..run_start + nested_width];
             if let Some((_, after)) =
                 closing_delimiter(text, run_start + nested_width, nested, marker == '_', width)
@@ -3560,6 +3565,30 @@ mod style_tests {
         assert_eq!(
             styled_inline("___combined___", None),
             "\u{1b}[1;3mcombined\u{1b}[22;23m"
+        );
+    }
+
+    #[test]
+    fn combined_emphasis_can_nest_in_single_emphasis() {
+        assert_eq!(
+            styled_inline("*italic ***combined*** tail*", None),
+            "\u{1b}[3mitalic \u{1b}[1;3mcombined\u{1b}[22;23m\u{1b}[3m tail\u{1b}[23m"
+        );
+        assert_eq!(
+            styled_inline("**bold ***combined*** tail**", None),
+            "\u{1b}[1mbold \u{1b}[1;3mcombined\u{1b}[22;23m\u{1b}[1m tail\u{1b}[22m"
+        );
+    }
+
+    #[test]
+    fn a_closing_run_remainder_can_open_an_adjacent_span() {
+        assert_eq!(
+            styled_inline("*italic***bold**", None),
+            "\u{1b}[3mitalic\u{1b}[23m\u{1b}[1mbold\u{1b}[22m"
+        );
+        assert_eq!(
+            styled_inline("**bold***italic*", None),
+            "\u{1b}[1mbold\u{1b}[22m\u{1b}[3mitalic\u{1b}[23m"
         );
     }
 

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -312,6 +312,8 @@ fn styled_inline(text: &str, parent: Option<&str>) -> String {
         }
 
         let span = [
+            ("***", "1;3", "22;23", false, true),
+            ("___", "1;3", "22;23", true, true),
             ("**", "1", "22", false, true),
             ("__", "1", "22", true, true),
             ("~~", "9", "29", false, true),
@@ -3546,6 +3548,18 @@ mod style_tests {
         assert_eq!(
             styled_inline("**bold \\***", None),
             "\u{1b}[1mbold *\u{1b}[22m"
+        );
+    }
+
+    #[test]
+    fn a_shared_delimiter_run_is_bold_and_italic() {
+        assert_eq!(
+            styled_inline("***combined***", None),
+            "\u{1b}[1;3mcombined\u{1b}[22;23m"
+        );
+        assert_eq!(
+            styled_inline("___combined___", None),
+            "\u{1b}[1;3mcombined\u{1b}[22;23m"
         );
     }
 

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -404,7 +404,9 @@ fn closing_delimiter(
             % 2
             == 1;
         if escaped {
-            search_at = run_end;
+            // A backslash escapes one marker, not its whole run. The rest may still close the
+            // span: `*italic \**` is an escaped literal star followed by the italic close.
+            search_at = run_start + marker.len_utf8();
             continue;
         }
 
@@ -3532,6 +3534,18 @@ mod style_tests {
         assert_eq!(
             styled_inline("foo__bar__ baz_qux", None),
             "foo__bar__ baz_qux"
+        );
+    }
+
+    #[test]
+    fn an_escape_skips_one_closing_marker() {
+        assert_eq!(
+            styled_inline("*italic \\**", None),
+            "\u{1b}[3mitalic *\u{1b}[23m"
+        );
+        assert_eq!(
+            styled_inline("**bold \\***", None),
+            "\u{1b}[1mbold *\u{1b}[22m"
         );
     }
 

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -322,50 +322,21 @@ fn styled_inline(text: &str, parent: Option<&str>) -> String {
         .into_iter()
         .find_map(|(delimiter, open, close, word_boundary, recurse)| {
             rest.strip_prefix(delimiter)?;
-            if word_boundary
-                && text[..at]
-                    .chars()
-                    .next_back()
-                    .is_some_and(char::is_alphanumeric)
+            let marker = delimiter.chars().next().expect("a delimiter has a marker");
+            let previous = text[..at].chars().next_back();
+            // Do not reinterpret part of a delimiter run when the longer form was rejected.
+            // In particular, neither underscore in `word__word__` may become an italic opener.
+            if delimiter.len() == 1
+                && (previous == Some(marker) || rest[delimiter.len()..].starts_with(marker))
             {
                 return None;
             }
-            let content_start = at + delimiter.len();
-            let mut search_at = content_start;
-            while let Some(found) = text[search_at..].find(delimiter) {
-                let mut end = search_at + found;
-                // In `**bold and *italic***`, the first star in the closing run belongs to
-                // the inner emphasis. Taking the first two would close bold early and leave
-                // the last star to open a new span.
-                if delimiter == "**"
-                    && text[end..].starts_with("***")
-                    && text[content_start..end].matches('*').count() % 2 == 1
-                {
-                    end += 1;
-                }
-                let after = end + delimiter.len();
-                let escaped = text[..end]
-                    .chars()
-                    .rev()
-                    .take_while(|ch| *ch == '\\')
-                    .count()
-                    % 2
-                    == 1;
-                let boundary_ok = !word_boundary
-                    || !text[after..]
-                        .chars()
-                        .next()
-                        .is_some_and(char::is_alphanumeric);
-                if !escaped
-                    && end > content_start
-                    && !text[content_start..end].trim().is_empty()
-                    && boundary_ok
-                {
-                    return Some((delimiter, open, close, recurse, content_start, end, after));
-                }
-                search_at = after;
+            if word_boundary && previous.is_some_and(char::is_alphanumeric) {
+                return None;
             }
-            None
+            let content_start = at + delimiter.len();
+            let (end, after) = closing_delimiter(text, content_start, delimiter, word_boundary, 0)?;
+            Some((delimiter, open, close, recurse, content_start, end, after))
         });
 
         if let Some((_, open, close, recurse, content_start, end, after)) = span {
@@ -394,6 +365,79 @@ fn styled_inline(text: &str, parent: Option<&str>) -> String {
         at += ch.len_utf8();
     }
     out
+}
+
+/// Find a span's close while stepping over valid spans of the other width.
+///
+/// A one-marker italic span may contain a two-marker bold span and vice versa. Combined closing
+/// runs such as the final `***` in `*italic and **bold***` are shared: two markers close bold and
+/// the last closes italic. `reserve` tells a nested search how many markers its parent still
+/// needs from such a run.
+fn closing_delimiter(
+    text: &str,
+    content_start: usize,
+    delimiter: &str,
+    word_boundary: bool,
+    reserve: usize,
+) -> Option<(usize, usize)> {
+    let marker = delimiter.chars().next()?;
+    let width = delimiter.len();
+    let nested_width = match width {
+        1 => 2,
+        2 if matches!(marker, '*' | '_') => 1,
+        _ => 0,
+    };
+    let mut search_at = content_start;
+
+    while let Some(found) = text[search_at..].find(marker) {
+        let run_start = search_at + found;
+        let run_len = text[run_start..]
+            .chars()
+            .take_while(|ch| *ch == marker)
+            .count();
+        let run_end = run_start + run_len;
+        let escaped = text[..run_start]
+            .chars()
+            .rev()
+            .take_while(|ch| *ch == '\\')
+            .count()
+            % 2
+            == 1;
+        if escaped {
+            search_at = run_end;
+            continue;
+        }
+
+        if run_len == nested_width {
+            let nested = &text[run_start..run_start + nested_width];
+            if let Some((_, after)) =
+                closing_delimiter(text, run_start + nested_width, nested, marker == '_', width)
+            {
+                search_at = after;
+                continue;
+            }
+        }
+
+        if run_len >= width {
+            let after = run_start + width;
+            let left_in_run = run_end - after;
+            let leaves_parent_close = left_in_run == 0 || left_in_run >= reserve;
+            let boundary_ok = !word_boundary
+                || !text[after..]
+                    .chars()
+                    .next()
+                    .is_some_and(char::is_alphanumeric);
+            if run_start > content_start
+                && !text[content_start..run_start].trim().is_empty()
+                && leaves_parent_close
+                && boundary_ok
+            {
+                return Some((run_start, after));
+            }
+        }
+        search_at = run_end;
+    }
+    None
 }
 
 fn styled_flag_usage(usage: &str, style: Style) -> String {
@@ -3472,6 +3516,22 @@ mod style_tests {
         assert_eq!(
             styled_inline("**bold and *italic*** plus \\*literal\\*", None),
             "\u{1b}[1mbold and \u{1b}[3mitalic\u{1b}[23m\u{1b}[1m\u{1b}[22m plus *literal*"
+        );
+        assert_eq!(
+            styled_inline("*italic and **bold***", None),
+            "\u{1b}[3mitalic and \u{1b}[1mbold\u{1b}[22m\u{1b}[3m\u{1b}[23m"
+        );
+        assert_eq!(
+            styled_inline("_italic and __bold___", None),
+            "\u{1b}[3mitalic and \u{1b}[1mbold\u{1b}[22m\u{1b}[3m\u{1b}[23m"
+        );
+    }
+
+    #[test]
+    fn intraword_underscore_runs_remain_literal() {
+        assert_eq!(
+            styled_inline("foo__bar__ baz_qux", None),
+            "foo__bar__ baz_qux"
         );
     }
 

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -272,6 +272,128 @@ impl Style {
     fn literal(self, text: &str) -> String {
         self.wrap("36", text)
     }
+
+    /// Render the small Markdown vocabulary accepted in help prose.
+    ///
+    /// Plain output deliberately keeps the source spelling: generated artifacts and pipes
+    /// remain byte-for-byte compatible, while a terminal can turn the same familiar syntax
+    /// into presentation. This is inline prose, not a Markdown document — lists, headings and
+    /// links belong to the help page's existing structure.
+    fn inline(self, text: &str) -> String {
+        if !self.coloured {
+            return text.to_string();
+        }
+        styled_inline(text, None)
+    }
+}
+
+/// Markdown-like emphasis in author-written help.
+///
+/// Kept deliberately small and dependency-free: help is cold-path code, but the renderer is a
+/// foundational crate and pulling a document parser into every adopter for four inline spans
+/// would be disproportionate. Delimiters must close on the same line; an unmatched delimiter
+/// is ordinary text.
+fn styled_inline(text: &str, parent: Option<&str>) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut at = 0;
+    while at < text.len() {
+        let rest = &text[at..];
+
+        // Markdown escapes are useful in prose that genuinely means `*`, `_`, `~`, or `` ` ``.
+        if let Some(escaped) = rest
+            .strip_prefix('\\')
+            .and_then(|after| after.chars().next())
+        {
+            if matches!(escaped, '*' | '_' | '~' | '`' | '\\') {
+                out.push(escaped);
+                at += 1 + escaped.len_utf8();
+                continue;
+            }
+        }
+
+        let span = [
+            ("**", "1", "22", false, true),
+            ("__", "1", "22", true, true),
+            ("~~", "9", "29", false, true),
+            ("*", "3", "23", false, true),
+            ("_", "3", "23", true, true),
+            ("`", "36", "39", false, false),
+        ]
+        .into_iter()
+        .find_map(|(delimiter, open, close, word_boundary, recurse)| {
+            rest.strip_prefix(delimiter)?;
+            if word_boundary
+                && text[..at]
+                    .chars()
+                    .next_back()
+                    .is_some_and(char::is_alphanumeric)
+            {
+                return None;
+            }
+            let content_start = at + delimiter.len();
+            let mut search_at = content_start;
+            while let Some(found) = text[search_at..].find(delimiter) {
+                let mut end = search_at + found;
+                // In `**bold and *italic***`, the first star in the closing run belongs to
+                // the inner emphasis. Taking the first two would close bold early and leave
+                // the last star to open a new span.
+                if delimiter == "**"
+                    && text[end..].starts_with("***")
+                    && text[content_start..end].matches('*').count() % 2 == 1
+                {
+                    end += 1;
+                }
+                let after = end + delimiter.len();
+                let escaped = text[..end]
+                    .chars()
+                    .rev()
+                    .take_while(|ch| *ch == '\\')
+                    .count()
+                    % 2
+                    == 1;
+                let boundary_ok = !word_boundary
+                    || !text[after..]
+                        .chars()
+                        .next()
+                        .is_some_and(char::is_alphanumeric);
+                if !escaped
+                    && end > content_start
+                    && !text[content_start..end].trim().is_empty()
+                    && boundary_ok
+                {
+                    return Some((delimiter, open, close, recurse, content_start, end, after));
+                }
+                search_at = after;
+            }
+            None
+        });
+
+        if let Some((_, open, close, recurse, content_start, end, after)) = span {
+            out.push_str("\u{1b}[");
+            out.push_str(open);
+            out.push('m');
+            if recurse {
+                out.push_str(&styled_inline(&text[content_start..end], Some(open)));
+            } else {
+                out.push_str(&text[content_start..end]);
+            }
+            out.push_str("\u{1b}[");
+            out.push_str(close);
+            out.push('m');
+            if let Some(parent) = parent {
+                out.push_str("\u{1b}[");
+                out.push_str(parent);
+                out.push('m');
+            }
+            at = after;
+            continue;
+        }
+
+        let ch = rest.chars().next().expect("at is on a character boundary");
+        out.push(ch);
+        at += ch.len_utf8();
+    }
+    out
 }
 
 fn styled_flag_usage(usage: &str, style: Style) -> String {
@@ -446,7 +568,16 @@ fn styled_help(
                         .map(|rest| format!("  {}{rest}", styled_flag_usage(usage, style)))
                 })
             });
-            out.push_str(styled.as_deref().unwrap_or(body));
+            // Examples are shell source, where paired backticks are command substitution rather
+            // than prose markup. Every other non-structural line may contain author emphasis;
+            // option and argument spellings are harmless because intraword underscores do not
+            // open spans and unmatched shell globs remain literal.
+            let body = styled.as_deref().unwrap_or(body);
+            if body.trim_start().starts_with("$ ") {
+                out.push_str(body);
+            } else {
+                out.push_str(&style.inline(body));
+            }
         }
         out.push_str(newline);
     }
@@ -2966,7 +3097,7 @@ mod style_tests {
     use super::{
         commands_section, display_usage_masked, flag_notes, flag_usage, flat_commands_short,
         inline_environment_notes, long_help, render_view_at_styled, styled_flag_usage, styled_help,
-        Shown, Style,
+        styled_inline, Shown, Style,
     };
     use crate::spec::{CommandMeta, FlagMeta, Spec, ViewMeta};
     use crate::{ArgAction, Command, Flag};
@@ -3306,6 +3437,41 @@ mod style_tests {
         assert_eq!(
             styled_flag_usage("--color[=WHEN]", Style::COLOURED),
             "\u{1b}[36m--color\u{1b}[0m[=WHEN]"
+        );
+    }
+
+    #[test]
+    fn coloured_help_renders_inline_markdown_emphasis() {
+        let page = "Use **force** for *all* files, _including_hidden_, `--literally`, and ~~never~~ this.\n  --dry_run  Keep snake_case and an unmatched * glob\n\nExamples:\n    $ echo `date`\n";
+        let coloured = styled_help(page, Style::COLOURED, &[], &[], &[]);
+
+        assert!(
+            coloured.contains("\u{1b}[1mforce\u{1b}[22m"),
+            "{coloured:?}"
+        );
+        assert!(coloured.contains("\u{1b}[3mall\u{1b}[23m"), "{coloured:?}");
+        assert!(
+            coloured.contains("\u{1b}[3mincluding_hidden\u{1b}[23m"),
+            "{coloured:?}"
+        );
+        assert!(
+            coloured.contains("\u{1b}[36m--literally\u{1b}[39m"),
+            "{coloured:?}"
+        );
+        assert!(
+            coloured.contains("\u{1b}[9mnever\u{1b}[29m"),
+            "{coloured:?}"
+        );
+        assert!(coloured.contains("--dry_run  Keep snake_case and an unmatched * glob"));
+        assert!(coloured.contains("    $ echo `date`"));
+        assert!(!coloured.contains("**force**"));
+    }
+
+    #[test]
+    fn inline_emphasis_nests_and_can_be_escaped() {
+        assert_eq!(
+            styled_inline("**bold and *italic*** plus \\*literal\\*", None),
+            "\u{1b}[1mbold and \u{1b}[3mitalic\u{1b}[23m\u{1b}[1m\u{1b}[22m plus *literal*"
         );
     }
 

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -382,9 +382,9 @@ fn closing_delimiter(
 ) -> Option<(usize, usize)> {
     let marker = delimiter.chars().next()?;
     let width = delimiter.len();
-    let nested_width = match width {
-        1 => 2,
-        2 if matches!(marker, '*' | '_') => 1,
+    let nested_width = match (width, marker) {
+        (1, '*' | '_') => 2,
+        (2, '*' | '_') => 1,
         _ => 0,
     };
     let mut search_at = content_start;

--- a/docs/rust/help.md
+++ b/docs/rust/help.md
@@ -100,6 +100,22 @@ full rule, including what a default does not count as, is in
 The rendered output matches what usage-lib renders from the same spec — the two renderers are
 held to identical output over mise's 211 command pages in CI.
 
+### Formatting help text
+
+Help prose accepts a small inline Markdown vocabulary when it is printed to a styled terminal:
+
+| source                   | terminal style |
+| ------------------------ | -------------- |
+| `**bold**` / `__bold__`  | bold           |
+| `*italic*` / `_italic_`  | italic         |
+| `` `literal` ``          | code/literal   |
+| `~~obsolete~~`           | strikethrough  |
+
+The forms can be nested, and a backslash escapes a delimiter (`\*literal\*`). Formatting is
+terminal-aware: `parse()` emits ANSI styling only on a terminal (or with `CLICOLOR_FORCE`), and
+honours `NO_COLOR`. Plain renderers, generated artifacts, and piped help keep the source spelling.
+Shell lines in declared examples are left verbatim, so backticks remain command substitutions.
+
 ### Laying a page out
 
 The words above change what a page _says_. `help_template` changes the order it says it in:

--- a/docs/rust/help.md
+++ b/docs/rust/help.md
@@ -104,12 +104,12 @@ held to identical output over mise's 211 command pages in CI.
 
 Help prose accepts a small inline Markdown vocabulary when it is printed to a styled terminal:
 
-| source                   | terminal style |
-| ------------------------ | -------------- |
-| `**bold**` / `__bold__`  | bold           |
-| `*italic*` / `_italic_`  | italic         |
-| `` `literal` ``          | code/literal   |
-| `~~obsolete~~`           | strikethrough  |
+| source                  | terminal style |
+| ----------------------- | -------------- |
+| `**bold**` / `__bold__` | bold           |
+| `*italic*` / `_italic_` | italic         |
+| `` `literal` ``         | code/literal   |
+| `~~obsolete~~`          | strikethrough  |
 
 The forms can be nested, and a backslash escapes a delimiter (`\*literal\*`). Formatting is
 terminal-aware: `parse()` emits ANSI styling only on a terminal (or with `CLICOLOR_FORCE`), and


### PR DESCRIPTION
## Summary

- render Markdown-like bold, italic, inline-code, and strikethrough spans in terminal help
- support nested spans and escaped delimiters while preserving shell example lines
- keep plain and piped output unchanged, respecting existing color environment controls
- document the supported formatting vocabulary

## Tests

- `cargo fmt --all -- --check`
- `cargo test -p usage-argv --all-features`
- `cargo clippy -p usage-argv --all-features --all-targets -- -D warnings`
- `git diff --check`

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Help-only presentation change with no parse, auth, or data-path impact. Plain output is unchanged so generated artifacts stay compatible.
> 
> **Overview**
> Coloured `--help` now styles author-written inline Markdown in prose: **bold**, *italic*, `code`, and ~~strikethrough~~ (plus nested and escaped forms). Plain, piped, and generated help keep the source spelling.
> 
> A small dependency-free scanner in `styled_inline` handles same-line spans, shared delimiter runs, and word-boundary underscores so snake_case and unmatched globs stay literal. Example lines starting with `$ ` are left untouched so backticks remain shell substitutions.
> 
> Docs list the supported vocabulary. Tests cover nesting, escapes, combined `***`/`___`, and the example-line exception.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10ace2f8812ec4c51289244f6f46f65b7de7b575. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added inline Markdown-style formatting to colored help output, including bold, italic, strikethrough, and code styles.
  - Supports nested formatting, escaped markers, and literal intraword underscores.
  - Keeps shell examples unchanged and preserves plain-text or piped help output without styling.

- **Documentation**
  - Improved table spacing in the terminal help-formatting documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->