### PR TITLE
ci: run the test suite on windows-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,14 +95,6 @@ jobs:
       # Run here rather than in a job of its own: the corpus vectors carry KDL
       # specs, and lowering them needs the `usage` CLI this job has already built.
       - run: mise r test:go
-      # `os_string_from_bytes` has a `cfg` branch per platform, and every test of it is
-      # `#[cfg(unix)]` — so the Windows one is not compiled anywhere else in this pipeline.
-      # A compile check is not coverage, but it is what keeps that branch from rotting
-      # unseen.
-      - name: check the Windows-only conversion still compiles
-        run: |
-          rustup target add x86_64-pc-windows-msvc
-          cargo check -p usage-argv --all-features --target x86_64-pc-windows-msvc
       # Everything else in this pipeline builds with `--all-features`, and resolver-v2 unification
       # means a workspace build turns a feature on for every member as soon as one member wants it.
       # So the shapes an adopter actually gets — usage-lib without `docs`, usage-rs without its
@@ -128,6 +120,59 @@ jobs:
             exit 1
           fi
       - run: mise r lint
+
+  # The only job that is not Linux, and for several `cfg` branches the only place they are
+  # compiled at all. The argv path planner, the config path normaliser and
+  # `os_string_from_bytes` all exist for Windows and had never been built on it — each of
+  # #1232, #1233 and #1234 fixed something no other job could see. This is the job that keeps
+  # that true going forward rather than once.
+  test-windows:
+    runs-on: windows-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      # Before the checkout, and not optional: there is no `.gitattributes`, and Windows git
+      # defaults to `autocrlf=true`. The fixtures would arrive with CRLF and the help snapshots
+      # in `lib/tests/parse.rs` and `cli/tests/markdown.rs` would fail on a difference
+      # `pretty_assertions` prints as two identical strings.
+      - run: git config --global core.autocrlf false
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+          persist-credentials: false
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          shared-key: test-windows
+      - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+      - run: mise r build
+      # `usage bash` runs whatever Windows resolves `bash` to, and `CreateProcess` searches the
+      # system directory before `PATH`. On this runner that is `C:\Windows\System32\bash.exe` —
+      # the WSL launcher, with no distribution installed — so the mount fixtures cannot run.
+      # Naming Git Bash is what makes them run rather than skip.
+      #
+      # `USAGECLI_`, not `USAGE_`: mise strips `usage_*` from a task's environment by comparing
+      # six characters case-insensitively, and Windows variable names are case-insensitive, so
+      # `USAGE_SHELL_BASH` would not survive `mise r`. That collision is why the `USAGECLI_`
+      # spelling exists.
+      #
+      # Unquoted on purpose. In double quotes YAML reads `\b` as a backspace.
+      #
+      # If this ever stops arriving, the job fails rather than passing quietly:
+      # `skip_if_posix_shell_missing` panics under CI on every platform, so a run cannot skip
+      # its way to green.
+      - env:
+          USAGECLI_SHELL_BASH: C:\Program Files\Git\bin\bash.exe
+        run: mise r test
+      # No zsh, fish or bash-completion, and nothing to install them with: they have no Windows
+      # equivalent, which is why `skip_if_shell_missing` and `bash_completion_or_skip` limit
+      # their CI panic to Unix. Three tests skip here and the Linux job covers them.
+      #
+      # Linting here is not duplication of the Linux job. `#[cfg]` decides whether code exists,
+      # so a warning can be real on one platform and absent on the other — both of the ones
+      # #1234 fixed were invisible to every other job in this file. `lint:clippy` denies
+      # warnings and passes `--all-targets`, which makes those a build failure rather than noise.
+      - run: mise r lint:clippy
 
   # The declared `rust-version` is a promise to anyone depending on these crates, and nothing
   # was checking it. It said 1.80 — set in 2024 when `LazyLock` landed and never revisited —


### PR DESCRIPTION
Everything platform-specific in this repo exists for a machine no job ever built it on. The argv path planner, the config path normaliser and `os_string_from_bytes` all have a Windows branch, and none of them had been compiled there.

Measured in a fork, that came to **five test failures and two warnings**, fixed in #1232, #1233 and #1234. This job is what keeps them fixed rather than fixed once.

## What it costs

| | |
|---|---|
| `mise r test` on windows-latest | **2,394 passed, 0 failed, 13 ignored** |
| `mise r lint:clippy` | green, warnings denied |
| Wall clock | **11m51s**, against the Linux job's 10m18s in the same run |

No `continue-on-error` anywhere — the numbers above are from the job exactly as proposed.

## The three things it needs

Each of these was found by getting it wrong first.

**`core.autocrlf false`, in a step before the checkout.** There is no `.gitattributes`, and Windows git defaults to `autocrlf=true`. The fixtures arrive with CRLF and the help snapshots in `lib/tests/parse.rs` and `cli/tests/markdown.rs` fail — on a difference `pretty_assertions` renders as two identical strings, which is a bad hour.

**`USAGECLI_SHELL_BASH` pointing at Git Bash.** `usage bash` runs whatever Windows resolves `bash` to, and `CreateProcess` searches the system directory before `PATH`. This runner has the WSL launcher at `C:\Windows\System32\bash.exe` with no distribution installed, so a bare `bash` cannot open the mount fixtures. Note `where` and `CreateProcess` disagree here — `where bash` lists Git Bash first, because it searches `PATH` only.

`USAGECLI_` rather than `USAGE_` matters specifically because this goes through `mise r`: mise strips `usage_*` from a task's environment by comparing six characters case-insensitively, and Windows variable names are case-insensitive, so `USAGE_SHELL_BASH` would not survive the trip. That collision is what #1213 introduced the `USAGECLI_` spelling for.

The value is an unquoted plain scalar on purpose. In double quotes YAML reads the `\b` of `\bin\bash.exe` as a backspace.

**No zsh, fish or bash-completion.** Unlike the Linux job, there is nothing to install: they have no Windows equivalent, which is why `skip_if_shell_missing` and `bash_completion_or_skip` already limit their CI panic to Unix. Three tests skip here and the Linux job covers them.

`skip_if_posix_shell_missing` deliberately keeps panicking on every platform, and that is what makes this job trustworthy: if the shell override ever stops arriving, the job **fails** rather than skipping its way to green. `complete_word` ran its 50 tests and `shell_completions_integration` its 21 in the verification run, so the override is reaching them through mise today.

## Why lint runs here too

Not duplication. `#[cfg]` decides whether code exists, so a warning can be real on one platform and absent on the other — both of the ones #1234 fixed were invisible to every other job in this file, and `lint:clippy` denies warnings and passes `--all-targets`, which makes them a build failure rather than noise.

`render`, `gen-shadow`, `gen-go` and the rest of `lint` stay Linux-only: they assert a clean `git status`, which line endings make unstable, and `lint:prettier` and `lint:semver` are not platform properties. `test:go` is left out as unmeasured on Windows rather than assumed to work.

## One removal

The Linux job's `cargo check -p usage-argv --target x86_64-pc-windows-msvc` goes. Its own comment said it existed because "the Windows one is not compiled anywhere else in this pipeline" and granted that "a compile check is not coverage". Both stop being true here — usage-argv is now built and run on Windows, tests included — so what is left is a `rustup target add` and a check build on every Linux run. The Linux job is green in the verification run without it.

## Verification

Fork run with both jobs, on this exact commit: https://github.com/JamBalaya56562/usage/pull/3

---

_This description was generated by Claude Code._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added dedicated Windows build and test coverage.
  * Added Windows-specific test execution and platform-aware linting.
  * Continued running Unix-only shell tests on Linux.
  * Improved Git configuration for consistent Windows checkouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->