### PR TITLE
feat(rust): support compact embedded parsers

### DIFF
--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -560,14 +560,17 @@ impl<'a> SpecView<'a> {
     }
 }
 
-struct Request {
-    shell: Shell,
-    split: Split,
-    candidates_for: Option<String>,
+/// A parsed hidden completion protocol request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Request {
+    pub shell: Shell,
+    pub split: Split,
+    pub candidates_for: Option<String>,
 }
 
 impl Request {
-    fn parse(argv: &[OsString]) -> Option<Self> {
+    /// Parse `__complete_word__` arguments. Returns `None` for a normal command.
+    pub fn parse(argv: &[OsString]) -> Option<Self> {
         if argv.first()?.to_str()? != "__complete_word__" {
             return None;
         }
@@ -1813,6 +1816,7 @@ fn floor_char_boundary(s: &str, index: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::spec::{FlagMetaBehavior, FlagMetaExtra};
     use std::task::{Context, Poll, Waker};
 
     fn run_ready<F: Future>(future: F) -> F::Output {
@@ -1823,6 +1827,30 @@ mod tests {
             Poll::Ready(output) => output,
             Poll::Pending => panic!("test completion unexpectedly needed an executor wakeup"),
         }
+    }
+
+    #[test]
+    fn public_request_parser_recognizes_only_the_hidden_completion_protocol() {
+        assert!(Request::parse(&[OsString::from("run")]).is_none());
+
+        let request = Request::parse(&[
+            OsString::from("__complete_word__"),
+            OsString::from("--shell"),
+            OsString::from("zsh"),
+            OsString::from("--line"),
+            OsString::from("vp run bu"),
+            OsString::from("--cursor"),
+            OsString::from("9"),
+            OsString::from("--candidates"),
+            OsString::from("task"),
+        ])
+        .expect("completion protocol request");
+
+        assert_eq!(request.shell, Shell::Zsh);
+        assert_eq!(request.candidates_for.as_deref(), Some("task"));
+        assert_eq!(request.split.words, ["vp", "run", "bu"]);
+        assert_eq!(request.split.cword, 2);
+        assert_eq!(request.split.prefix, "bu");
     }
 
     /// A small tree with the shapes that make a cursor's position non-obvious: a global flag,
@@ -2001,14 +2029,19 @@ mod tests {
         flags: &[FlagMeta {
             flag: &JOBS,
             help: Some("How many at once"),
-            choices: &["1", "2", "4"],
-            choice_details: &[crate::spec::ChoiceMeta {
-                value: "2",
-                help: Some("Two workers"),
-                hide: false,
-                aliases: &[],
-            }],
-            ..FlagMeta::EMPTY
+            behavior: &FlagMetaBehavior {
+                extra: &FlagMetaExtra {
+                    choices: &["1", "2", "4"],
+                    choice_details: &[crate::spec::ChoiceMeta {
+                        value: "2",
+                        help: Some("Two workers"),
+                        hide: false,
+                        aliases: &[],
+                    }],
+                    ..FlagMetaExtra::EMPTY
+                },
+                ..FlagMetaBehavior::EMPTY
+            },
         }],
         args: &[ArgMeta {
             arg: &TOOL,
@@ -2067,14 +2100,24 @@ mod tests {
             FlagMeta {
                 flag: &ONLY,
                 help: Some("Just this one"),
-                complete: Some(tools),
-                ..FlagMeta::EMPTY
+                behavior: &FlagMetaBehavior {
+                    extra: &FlagMetaExtra {
+                        complete: Some(tools),
+                        ..FlagMetaExtra::EMPTY
+                    },
+                    ..FlagMetaBehavior::EMPTY
+                },
             },
             FlagMeta {
                 flag: &SOURCE,
                 help: Some("Where from"),
-                complete: Some(sources),
-                ..FlagMeta::EMPTY
+                behavior: &FlagMetaBehavior {
+                    extra: &FlagMetaExtra {
+                        complete: Some(sources),
+                        ..FlagMetaExtra::EMPTY
+                    },
+                    ..FlagMetaBehavior::EMPTY
+                },
             },
         ],
         args: &[ArgMeta {
@@ -2110,8 +2153,10 @@ mod tests {
         flags: &[FlagMeta {
             flag: &FROM,
             help: Some("Read from"),
-            value_name: Some("FILE"),
-            ..FlagMeta::EMPTY
+            behavior: &FlagMetaBehavior {
+                value_name: Some("FILE"),
+                ..FlagMetaBehavior::EMPTY
+            },
         }],
         args: &[ArgMeta {
             arg: &PIPED,
@@ -2126,8 +2171,10 @@ mod tests {
         flags: &[FlagMeta {
             flag: &INTO,
             help: Some("Where to write it"),
-            value_name: Some("DIR"),
-            ..FlagMeta::EMPTY
+            behavior: &FlagMetaBehavior {
+                value_name: Some("DIR"),
+                ..FlagMetaBehavior::EMPTY
+            },
         }],
         args: &[ArgMeta {
             arg: &FILE,

--- a/argv/src/diagnostic.rs
+++ b/argv/src/diagnostic.rs
@@ -236,7 +236,21 @@ fn nearest<'a>(typed: &str, candidates: impl Iterator<Item = &'a str>) -> Vec<&'
         .map(|candidate| (jaro(typed, candidate), candidate))
         .filter(|(score, _)| *score > 0.7)
         .collect();
-    scored.sort_by(|a, b| a.0.total_cmp(&b.0).then_with(|| a.1.cmp(b.1)));
+    // Error suggestions are a small cold-path list. Insertion sort keeps its stable order
+    // without instantiating the much larger general-purpose slice sorter for this tuple.
+    for index in 1..scored.len() {
+        let mut position = index;
+        while position > 0
+            && scored[position]
+                .0
+                .total_cmp(&scored[position - 1].0)
+                .then_with(|| scored[position].1.cmp(scored[position - 1].1))
+                .is_lt()
+        {
+            scored.swap(position, position - 1);
+            position -= 1;
+        }
+    }
     scored.dedup_by(|a, b| a.1 == b.1);
     scored.into_iter().map(|(_, candidate)| candidate).collect()
 }
@@ -863,7 +877,7 @@ fn render_inner<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::spec::{ArgMeta, FlagMeta};
+    use crate::spec::{ArgMeta, FlagMeta, FlagMetaBehavior};
     use crate::{Arg, Flag};
 
     static FORCE: Flag = Flag {
@@ -946,8 +960,10 @@ mod tests {
             FlagMeta {
                 flag: &JOBS,
                 help: Some("How many"),
-                value_name: Some("JOBS"),
-                ..FlagMeta::EMPTY
+                behavior: &FlagMetaBehavior {
+                    value_name: Some("JOBS"),
+                    ..FlagMetaBehavior::EMPTY
+                },
             },
         ],
         args: &[
@@ -1036,7 +1052,10 @@ mod tests {
             cmd: &ROOT,
             flags: &[FlagMeta {
                 flag: &FILE,
-                value_name: Some("PATH"),
+                behavior: &FlagMetaBehavior {
+                    value_name: Some("PATH"),
+                    ..FlagMetaBehavior::EMPTY
+                },
                 ..FlagMeta::EMPTY
             }],
             ..CommandMeta::EMPTY

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -17,7 +17,7 @@
 //! Where the two disagree the difference is recorded, in the same spirit as the parser's
 //! corpus: usage-lib is the reference, and a divergence is a decision rather than an accident.
 
-use core::fmt::Write as _;
+use core::{cmp::Ordering, fmt::Write as _};
 
 use crate::spec::{ArgMeta, CommandMeta, Example, FlagMeta, Spec, ViewMeta};
 use crate::Command;
@@ -390,7 +390,7 @@ fn help_structure(
 
     let mut flag_usages: Vec<String> = own.iter().map(|flag| column_usage(flag)).collect();
     flag_usages.extend(inherited.into_iter().map(|(_, usage)| usage));
-    flag_usages.sort_by_key(|usage| core::cmp::Reverse(usage.len()));
+    stable_insertion_sort_by(&mut flag_usages, |a, b| b.len().cmp(&a.len()));
 
     let mut synopsis = String::new();
     usage_section(&mut synopsis, spec, path, meta);
@@ -503,12 +503,15 @@ fn usage_line_with_subcommands(
     // what a user is invited to type.
     let flags: usize = meta.flags.iter().filter(|f| !f.hide).count();
     if flags > 0 {
-        let required = meta.flags.iter().any(|f| !f.hide && flag_demanded(f));
+        let required = meta
+            .flags
+            .iter()
+            .any(|f| !f.hide && flag_demanded_in(meta, f));
         if flags <= INLINE_LIMIT {
             for flag in meta.flags.iter().filter(|f| !f.hide) {
                 // A required flag is angled, like a required argument: the brackets are what
                 // say whether leaving it out is allowed.
-                let (open, close) = if flag_demanded(flag) {
+                let (open, close) = if flag_demanded_in(meta, flag) {
                     ('<', '>')
                 } else {
                     ('[', ']')
@@ -555,7 +558,7 @@ fn usage_section(out: &mut String, spec: &Spec<'_>, path: &[&str], meta: &Comman
         }
     }
     let mut visible: Vec<_> = meta.subcommands.iter().filter(|sub| !sub.hide).collect();
-    visible.sort_by_key(|sub| sub.cmd.name);
+    stable_insertion_sort_by(&mut visible, |a, b| a.cmd.name.cmp(b.cmd.name));
     if meta.flatten_help && !visible.is_empty() {
         let mut lines = Vec::new();
         if !meta.subcommand_required || meta.cmd.args_conflicts_with_subcommands {
@@ -784,6 +787,40 @@ fn append_flag_value(
 /// the parser fills when it is left out.
 fn flag_demanded(meta: &FlagMeta<'_>) -> bool {
     meta.required && meta.default.is_empty()
+}
+
+/// Whether a flag is required directly or is the only visible member of a required group.
+///
+/// An executable view can omit all but one member of a host group. The remaining flag then
+/// carries the group's requirement in its synopsis without changing the immutable metadata.
+fn flag_demanded_in(command: &CommandMeta<'_>, flag: &FlagMeta<'_>) -> bool {
+    flag_demanded(flag)
+        || command.groups.iter().any(|group| {
+            if !group.required {
+                return false;
+            }
+            let mut members = group.members.iter().filter_map(|selector| {
+                command
+                    .flags
+                    .iter()
+                    .find(|candidate| flag_matches_selector(candidate, selector))
+            });
+            members
+                .next()
+                .is_some_and(|member| core::ptr::eq(member.flag, flag.flag))
+                && members.next().is_none()
+        })
+}
+
+fn flag_matches_selector(flag: &FlagMeta<'_>, selector: &str) -> bool {
+    selector
+        .strip_prefix("--")
+        .is_some_and(|long| flag.flag.longs.contains(&long))
+        || selector
+            .strip_prefix('-')
+            .filter(|short| short.len() == 1)
+            .and_then(|short| short.as_bytes().first().copied())
+            .is_some_and(|short| flag.flag.shorts.contains(&short))
 }
 
 /// Whether an argument must be given, which is not quite what `required` says.
@@ -1087,7 +1124,7 @@ fn commands_section(out: &mut String, path: &[&str], meta: &CommandMeta<'_>) {
             (usage_line(&sub_path, sub), *sub)
         })
         .collect();
-    lines.sort_by(|a, b| {
+    stable_insertion_sort_by(&mut lines, |a, b| {
         a.1.display_order
             .unwrap_or(999)
             .cmp(&b.1.display_order.unwrap_or(999))
@@ -1360,7 +1397,7 @@ fn groups_section<'m, T: 'm>(
             headings.push(heading);
         }
     }
-    headings.sort_by_key(|h| h.is_some());
+    unheaded_first(&mut headings);
 
     for heading in headings {
         let _ = writeln!(out, "\n{}:", heading.unwrap_or(default_title));
@@ -1371,34 +1408,62 @@ fn groups_section<'m, T: 'm>(
 }
 
 fn order_args<'a>(items: &mut Vec<&'a ArgMeta<'a>>, declared: &'a [ArgMeta<'a>]) {
-    items.sort_by_key(|item| {
-        item.display_order.unwrap_or_else(|| {
-            declared
-                .iter()
-                .position(|candidate| core::ptr::eq(candidate, *item))
-                .unwrap_or(usize::MAX)
-        })
+    stable_insertion_sort_by(items, |a, b| {
+        let item = *a;
+        let position = declared
+            .iter()
+            .position(|candidate| core::ptr::eq(candidate, item))
+            .unwrap_or(usize::MAX);
+        let a = (item.display_order.unwrap_or(position), position);
+        let item = *b;
+        let position = declared
+            .iter()
+            .position(|candidate| core::ptr::eq(candidate, item))
+            .unwrap_or(usize::MAX);
+        a.cmp(&(item.display_order.unwrap_or(position), position))
     });
 }
 
 fn order_flags<'a>(items: &mut Vec<&'a FlagMeta<'a>>, declared: &'a [FlagMeta<'a>]) {
-    items.sort_by_key(|item| {
-        item.display_order.unwrap_or_else(|| {
-            declared
-                .iter()
-                .position(|candidate| core::ptr::eq(candidate, *item))
-                .unwrap_or(usize::MAX)
-        })
+    stable_insertion_sort_by(items, |a, b| {
+        let item = *a;
+        let position = declared
+            .iter()
+            .position(|candidate| core::ptr::eq(candidate, item))
+            .unwrap_or(usize::MAX);
+        let a = (item.display_order.unwrap_or(position), position);
+        let item = *b;
+        let position = declared
+            .iter()
+            .position(|candidate| core::ptr::eq(candidate, item))
+            .unwrap_or(usize::MAX);
+        a.cmp(&(item.display_order.unwrap_or(position), position))
     });
 }
 
 fn order_commands(items: &mut Vec<&&CommandMeta<'_>>) {
-    items.sort_by(|a, b| {
+    stable_insertion_sort_by(items, |a, b| {
         a.display_order
             .unwrap_or(999)
             .cmp(&b.display_order.unwrap_or(999))
             .then_with(|| a.cmd.name.cmp(b.cmd.name))
     });
+}
+
+fn unheaded_first(headings: &mut [Option<&str>]) {
+    if let Some(index) = headings.iter().position(Option::is_none) {
+        headings[..=index].rotate_right(1);
+    }
+}
+
+fn stable_insertion_sort_by<T>(items: &mut [T], mut compare: impl FnMut(&T, &T) -> Ordering) {
+    for index in 1..items.len() {
+        let mut position = index;
+        while position > 0 && compare(&items[position], &items[position - 1]).is_lt() {
+            items.swap(position, position - 1);
+            position -= 1;
+        }
+    }
 }
 
 fn command_help_section<'a>(sub: &'a CommandMeta<'a>, default_title: &str) -> Option<&'a str> {
@@ -1991,7 +2056,7 @@ fn long_commands_section(out: &mut String, path: &[&str], meta: &CommandMeta<'_>
             (usage_line(&sub_path, sub), *sub)
         })
         .collect();
-    lines.sort_by(|a, b| {
+    stable_insertion_sort_by(&mut lines, |a, b| {
         a.1.display_order
             .unwrap_or(999)
             .cmp(&b.1.display_order.unwrap_or(999))
@@ -2411,13 +2476,17 @@ fn own_and_global<'a>(
         .iter()
         .map(|(flag, _)| *flag as *const _)
         .collect();
-    inherited.sort_by_key(|(flag, _)| {
-        flag.display_order.unwrap_or_else(|| {
-            inherited_positions
-                .iter()
-                .position(|candidate| core::ptr::eq(*candidate, *flag as *const _))
-                .unwrap_or(usize::MAX)
-        })
+    stable_insertion_sort_by(&mut inherited, |a, b| {
+        let position = inherited_positions
+            .iter()
+            .position(|candidate| core::ptr::eq(*candidate, a.0 as *const _))
+            .unwrap_or(usize::MAX);
+        let a = (a.0.display_order.unwrap_or(position), position);
+        let position = inherited_positions
+            .iter()
+            .position(|candidate| core::ptr::eq(*candidate, b.0 as *const _))
+            .unwrap_or(usize::MAX);
+        a.cmp(&(b.0.display_order.unwrap_or(position), position))
     });
 
     // Last in the command's own section, which is where clap has them: they carry no
@@ -2868,18 +2937,8 @@ pub(crate) fn view_root_fields<'a>(
     promoted: &CommandMeta<'a>,
     view: &ViewMeta<'a>,
 ) -> (Vec<FlagMeta<'a>>, Vec<crate::spec::GroupMeta<'a>>) {
-    let mut flags = view_root_flags(spec, promoted, view);
+    let flags = view_root_flags(spec, promoted, view);
     let carried = flags.len().saturating_sub(promoted.flags.len());
-    let matches = |flag: &FlagMeta<'_>, selector: &str| {
-        selector
-            .strip_prefix("--")
-            .is_some_and(|long| flag.flag.longs.contains(&long))
-            || selector
-                .strip_prefix('-')
-                .filter(|short| short.len() == 1)
-                .and_then(|short| short.as_bytes().first().copied())
-                .is_some_and(|short| flag.flag.shorts.contains(&short))
-    };
     let mut groups = Vec::new();
     for group in spec.root.groups {
         let members: Vec<usize> = group
@@ -2888,11 +2947,11 @@ pub(crate) fn view_root_fields<'a>(
             .filter_map(|selector| {
                 flags[..carried]
                     .iter()
-                    .position(|flag| matches(flag, selector))
+                    .position(|flag| flag_matches_selector(flag, selector))
             })
             .collect();
         match members.as_slice() {
-            [only] if group.required => flags[*only].required = true,
+            [_] if group.required => groups.push(*group),
             [_, _, ..] => {
                 // Help and diagnostics only need the relationship and its requiredness; the
                 // parser continues to enforce the canonical group. Retaining the original
@@ -2937,7 +2996,10 @@ fn recursive_help<'a>(
 
         let current = *chain.last().expect("a recursive page has a command");
         let mut children: Vec<_> = current.subcommands.iter().filter(|cmd| !cmd.hide).collect();
-        children.sort_by_key(|cmd| (cmd.display_order.unwrap_or(999), cmd.cmd.name));
+        stable_insertion_sort_by(&mut children, |a, b| {
+            (a.display_order.unwrap_or(999), a.cmd.name)
+                .cmp(&(b.display_order.unwrap_or(999), b.cmd.name))
+        });
         for child in children {
             path.push(child.cmd.name);
             chain.push(child);
@@ -2968,7 +3030,9 @@ mod style_tests {
         inline_environment_notes, long_help, render_view_at_styled, styled_flag_usage, styled_help,
         Shown, Style,
     };
-    use crate::spec::{CommandMeta, FlagMeta, Spec, ViewMeta};
+    use crate::spec::{
+        CommandMeta, FlagMeta, FlagMetaBehavior, FlagMetaExtra, FlagMetaRules, Spec, ViewMeta,
+    };
     use crate::{ArgAction, Command, Flag};
 
     #[test]
@@ -2981,8 +3045,11 @@ mod style_tests {
         };
         let meta = FlagMeta {
             flag: &flag,
-            value_name: Some("WHEN"),
-            value_optional: true,
+            behavior: &FlagMetaBehavior {
+                value_name: Some("WHEN"),
+                value_optional: true,
+                ..FlagMetaBehavior::EMPTY
+            },
             ..FlagMeta::EMPTY
         };
 
@@ -3045,8 +3112,16 @@ mod style_tests {
         let flag_meta = FlagMeta {
             flag: &flag,
             help: Some("Use the old mode"),
-            deprecated: Some("use --new"),
-            ..FlagMeta::EMPTY
+            behavior: &FlagMetaBehavior {
+                extra: &FlagMetaExtra {
+                    rules: &FlagMetaRules {
+                        deprecated: Some("use --new"),
+                        ..FlagMetaRules::EMPTY
+                    },
+                    ..FlagMetaExtra::EMPTY
+                },
+                ..FlagMetaBehavior::EMPTY
+            },
         };
         let sub_cmd = Command {
             name: "run",
@@ -3089,7 +3164,16 @@ mod style_tests {
         let flags = [
             FlagMeta {
                 flag: &old,
-                deprecated: Some("use --new"),
+                behavior: &FlagMetaBehavior {
+                    extra: &FlagMetaExtra {
+                        rules: &FlagMetaRules {
+                            deprecated: Some("use --new"),
+                            ..FlagMetaRules::EMPTY
+                        },
+                        ..FlagMetaExtra::EMPTY
+                    },
+                    ..FlagMetaBehavior::EMPTY
+                },
                 ..FlagMeta::EMPTY
             },
             FlagMeta {
@@ -3130,9 +3214,18 @@ mod style_tests {
         };
         let meta = FlagMeta {
             flag: &flag,
-            hide_env: true,
-            env_fallback: &["OLD_TOKEN"],
-            deprecated_env: &["LEGACY_TOKEN"],
+            behavior: &FlagMetaBehavior {
+                extra: &FlagMetaExtra {
+                    rules: &FlagMetaRules {
+                        hide_env: true,
+                        env_fallback: &["OLD_TOKEN"],
+                        deprecated_env: &["LEGACY_TOKEN"],
+                        ..FlagMetaRules::EMPTY
+                    },
+                    ..FlagMetaExtra::EMPTY
+                },
+                ..FlagMetaBehavior::EMPTY
+            },
             ..FlagMeta::EMPTY
         };
         let mut page = String::new();

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -935,27 +935,47 @@ pub struct FlattenGroup<'a> {
 #[derive(Debug, Clone, Copy)]
 pub struct FlagMeta<'a> {
     pub flag: &'a Flag<'a>,
-    /// Explicit placement within its help section.
-    pub display_order: Option<usize>,
-    /// Short forms accepted by the parser but omitted from help and completion.
-    pub hidden_shorts: &'a [u8],
-    /// Long forms accepted by the parser but omitted from help and completion.
-    pub hidden_longs: &'a [&'a str],
     /// Short help, shown by `-h`.
     pub help: Option<&'a str>,
-    /// Long help, shown by `--help`.
-    pub long_help: Option<&'a str>,
-    /// Why this flag is deprecated, plus optional release milestones.
-    pub deprecated: Option<&'a str>,
-    pub deprecated_warn_at: Option<&'a str>,
-    pub deprecated_remove_at: Option<&'a str>,
+    /// Value and behavior metadata that is absent from Boolean flags.
+    pub behavior: &'a FlagMetaBehavior<'a>,
+}
+
+/// Value and behavior metadata that is absent from Boolean flags.
+///
+/// Keeping this behind a reference lets ordinary Boolean flags share one empty value
+/// instead of carrying a value placeholder, six booleans, and another reference in every
+/// generated table entry.
+#[derive(Debug, Clone, Copy)]
+pub struct FlagMetaBehavior<'a> {
     /// The placeholder for the flag's value, such as `n` in `--jobs <n>`.
     pub value_name: Option<&'a str>,
+    pub required: bool,
+    /// Whether the flag's value may be left off, as in `--bump` or `--bump 5`.
+    pub value_optional: bool,
+    pub hide: bool,
+    /// Whether repetition is counted rather than collected, as in `-vvv`.
+    pub count: bool,
+    /// Whether the flag may be given more than once. Distinct from
+    /// [`Flag::variadic`], which is one occurrence taking several values.
+    pub repeatable: bool,
+    /// Metadata that is absent from most flags.
+    pub extra: &'a FlagMetaExtra<'a>,
+}
+
+/// Uncommon flag metadata.
+///
+/// Keeping this behind a reference lets ordinary flags share one empty value instead of
+/// carrying pointer-sized empty slices and options in every generated table entry.
+#[derive(Debug, Clone, Copy)]
+pub struct FlagMetaExtra<'a> {
+    /// Explicit placement within its help section.
+    pub display_order: Option<usize>,
+    /// Long help, shown by `--help`.
+    pub long_help: Option<&'a str>,
     /// Ordered placeholders for one fixed-arity occurrence.
     pub value_names: &'a [&'a str],
     pub env: Option<&'a str>,
-    pub env_fallback: &'a [&'a str],
-    pub deprecated_env: &'a [&'a str],
     pub default: &'a [&'a str],
     /// Canonical choices plus aliases accepted by the value type.
     pub accepted_choices: &'a [&'a str],
@@ -965,29 +985,6 @@ pub struct FlagMeta<'a> {
     /// Per-canonical presentation metadata used when emitting a lossless spec.
     pub choice_details: &'a [ChoiceMeta<'a>],
     pub ignore_case: bool,
-    /// Accept values outside `choices` while retaining the list for help and completion.
-    pub allow_unknown_choices: bool,
-    /// Portable expr expression evaluated for each raw value.
-    pub validate: Option<&'a str>,
-    /// Message reported when validation returns false.
-    pub validate_error: Option<&'a str>,
-    pub required: bool,
-    /// Whether the flag's value may be left off, as in `--bump` or `--bump 5`.
-    ///
-    /// Help only, and deliberately: usage-lib's parser refuses a bare `--bump` exactly as it
-    /// refuses a bare `--port`, so this changes no binding — it changes the brackets, `[BUMP]`
-    /// rather than `<BUMP>`, which is what a spec's `arg "[BUMP]" required=#false` says. In
-    /// [`FlagMeta`] and not in [`Flag`] for that reason: a parse never reads it.
-    pub value_optional: bool,
-    pub hide: bool,
-    pub hide_default_value: bool,
-    pub hide_env: bool,
-    pub hide_env_values: bool,
-    pub hide_possible_values: bool,
-    pub hide_short_help: bool,
-    pub hide_long_help: bool,
-    /// Whether repetition is counted rather than collected, as in `-vvv`.
-    pub count: bool,
     /// What answers for this flag's value when a shell asks.
     ///
     /// The Rust counterpart of a spec's `run=`: it is written into the emitted KDL as a command
@@ -996,9 +993,41 @@ pub struct FlagMeta<'a> {
     pub complete: Option<Completer>,
     /// A built-in completion class such as `path` or `dir`.
     pub complete_type: Option<&'a str>,
-    /// Whether the flag may be given more than once. Distinct from
-    /// [`Flag::variadic`], which is one occurrence taking several values.
-    pub repeatable: bool,
+    /// Heading to list this flag under in help output. Presentational: it groups
+    /// a long flag list into sections and changes nothing about parsing.
+    pub help_heading: Option<&'a str>,
+    /// Rules and compatibility metadata that is absent from most value flags.
+    pub rules: &'a FlagMetaRules<'a>,
+}
+
+/// Uncommon rules and compatibility metadata for a flag.
+///
+/// This is separate from [`FlagMetaExtra`] so a flag with a default, choices, or long help
+/// does not also carry every relationship and compatibility field.
+#[derive(Debug, Clone, Copy)]
+pub struct FlagMetaRules<'a> {
+    /// Short forms accepted by the parser but omitted from help and completion.
+    pub hidden_shorts: &'a [u8],
+    /// Long forms accepted by the parser but omitted from help and completion.
+    pub hidden_longs: &'a [&'a str],
+    /// Why this flag is deprecated, plus optional release milestones.
+    pub deprecated: Option<&'a str>,
+    pub deprecated_warn_at: Option<&'a str>,
+    pub deprecated_remove_at: Option<&'a str>,
+    pub env_fallback: &'a [&'a str],
+    pub deprecated_env: &'a [&'a str],
+    /// Accept values outside `choices` while retaining the list for help and completion.
+    pub allow_unknown_choices: bool,
+    /// Portable expr expression evaluated for each raw value.
+    pub validate: Option<&'a str>,
+    /// Message reported when validation returns false.
+    pub validate_error: Option<&'a str>,
+    pub hide_default_value: bool,
+    pub hide_env: bool,
+    pub hide_env_values: bool,
+    pub hide_possible_values: bool,
+    pub hide_short_help: bool,
+    pub hide_long_help: bool,
     pub var_min: Option<usize>,
     pub var_max: Option<usize>,
     /// Bounds on values consumed by one occurrence, distinct from the
@@ -1041,51 +1070,94 @@ pub struct FlagMeta<'a> {
     pub required_unless: &'a [&'a str],
     /// All selectors must be present to make this unnecessary.
     pub required_unless_all: &'a [&'a str],
-    /// Heading to list this flag under in help output. Presentational: it groups
-    /// a long flag list into sections and changes nothing about parsing.
-    pub help_heading: Option<&'a str>,
     pub effect: Option<Effect>,
 }
 
 impl FlagMeta<'_> {
     /// Metadata for a flag with nothing declared, for struct update syntax.
     pub const EMPTY: FlagMeta<'static> = FlagMeta {
+        flag: &Flag::BOOL,
+        help: None,
+        behavior: &FlagMetaBehavior::EMPTY,
+    };
+}
+
+impl FlagMetaBehavior<'_> {
+    /// Value and behavior metadata with no declared values.
+    pub const EMPTY: FlagMetaBehavior<'static> = FlagMetaBehavior {
+        value_name: None,
+        required: false,
+        value_optional: false,
+        hide: false,
+        count: false,
+        repeatable: false,
+        extra: &FlagMetaExtra::EMPTY,
+    };
+}
+
+impl<'a> core::ops::Deref for FlagMeta<'a> {
+    type Target = FlagMetaBehavior<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        self.behavior
+    }
+}
+
+impl<'a> core::ops::Deref for FlagMetaBehavior<'a> {
+    type Target = FlagMetaExtra<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        self.extra
+    }
+}
+
+impl FlagMetaExtra<'_> {
+    /// Uncommon metadata with no declared values.
+    pub const EMPTY: FlagMetaExtra<'static> = FlagMetaExtra {
         complete: None,
         complete_type: None,
-        flag: &Flag::BOOL,
         display_order: None,
-        hidden_shorts: &[],
-        hidden_longs: &[],
-        help: None,
         long_help: None,
-        deprecated: None,
-        deprecated_warn_at: None,
-        deprecated_remove_at: None,
-        value_name: None,
         value_names: &[],
         env: None,
-        env_fallback: &[],
-        deprecated_env: &[],
         default: &[],
         accepted_choices: &[],
         choices: &[],
         choice_aliases: &[],
         choice_details: &[],
         ignore_case: false,
+        help_heading: None,
+        rules: &FlagMetaRules::EMPTY,
+    };
+}
+
+impl<'a> core::ops::Deref for FlagMetaExtra<'a> {
+    type Target = FlagMetaRules<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        self.rules
+    }
+}
+
+impl FlagMetaRules<'_> {
+    /// Uncommon rules and compatibility metadata with no declared values.
+    pub const EMPTY: FlagMetaRules<'static> = FlagMetaRules {
+        hidden_shorts: &[],
+        hidden_longs: &[],
+        deprecated: None,
+        deprecated_warn_at: None,
+        deprecated_remove_at: None,
+        env_fallback: &[],
+        deprecated_env: &[],
         allow_unknown_choices: false,
         validate: None,
         validate_error: None,
-        required: false,
-        value_optional: false,
-        hide: false,
         hide_default_value: false,
         hide_env: false,
         hide_env_values: false,
         hide_possible_values: false,
         hide_short_help: false,
         hide_long_help: false,
-        count: false,
-        repeatable: false,
         var_min: None,
         var_max: None,
         value_var_min: None,
@@ -1102,7 +1174,6 @@ impl FlagMeta<'_> {
         required_if_eq_all: &[],
         required_unless: &[],
         required_unless_all: &[],
-        help_heading: None,
         effect: None,
     };
 }
@@ -1633,6 +1704,7 @@ impl<'a> Flagsets<'a> {
 /// per-command overlays a view applies, and which flagsets exist. Passing them one by one had
 /// `write_command` and `write_body` at eight parameters each, most of them pass-through.
 struct Writing<'a, 'o> {
+    #[cfg_attr(not(feature = "complete"), allow(dead_code))]
     bin: &'a str,
     overlays: &'o [CommandOverlay<'o>],
     sets: Flagsets<'a>,
@@ -4303,11 +4375,28 @@ mod tests {
         assert_eq!(
             flag_forms(&FlagMeta {
                 flag: &F,
-                hidden_shorts: b"w",
-                hidden_longs: &["workers"],
+                behavior: &FlagMetaBehavior {
+                    extra: &FlagMetaExtra {
+                        rules: &FlagMetaRules {
+                            hidden_shorts: b"w",
+                            hidden_longs: &["workers"],
+                            ..FlagMetaRules::EMPTY
+                        },
+                        ..FlagMetaExtra::EMPTY
+                    },
+                    ..FlagMetaBehavior::EMPTY
+                },
                 ..FlagMeta::EMPTY
             }),
             "-j --jobs"
+        );
+    }
+
+    #[test]
+    fn ordinary_flag_metadata_stays_compact() {
+        assert!(
+            core::mem::size_of::<FlagMeta<'static>>() <= 4 * core::mem::size_of::<usize>(),
+            "ordinary Boolean flags must not carry value metadata inline"
         );
     }
 

--- a/benches/gate/tests/help.rs
+++ b/benches/gate/tests/help.rs
@@ -265,7 +265,15 @@ fn the_text_around_a_page_is_rendered_where_the_reference_puts_it() {
         flags: &[usage_argv::spec::FlagMeta {
             flag: &DEEP,
             help: Some("Dig"),
-            long_help: Some("Dig deeper.\n\n    indented\n    \nand a line of only spaces above"),
+            behavior: &usage_argv::spec::FlagMetaBehavior {
+                extra: &usage_argv::spec::FlagMetaExtra {
+                    long_help: Some(
+                        "Dig deeper.\n\n    indented\n    \nand a line of only spaces above",
+                    ),
+                    ..usage_argv::spec::FlagMetaExtra::EMPTY
+                },
+                ..usage_argv::spec::FlagMetaBehavior::EMPTY
+            },
             ..usage_argv::spec::FlagMeta::EMPTY
         }],
         examples: &[usage_argv::spec::Example {

--- a/conformance/src/tables.rs
+++ b/conformance/src/tables.rs
@@ -27,7 +27,7 @@ use usage::spec::cmd::SpecExample;
 use usage::{Spec, SpecArg, SpecChoices, SpecCommand, SpecComplete, SpecFlag, SpecGroup};
 use usage_argv::spec::{
     ArgMeta, ChoiceAliasMeta, ChoiceMeta, CommandMeta, DefaultIf, Effect, Example, FlagMeta,
-    GroupMeta, RequiredIfEq, RequiresIf,
+    FlagMetaBehavior, FlagMetaExtra, FlagMetaRules, GroupMeta, RequiredIfEq, RequiresIf,
 };
 use usage_argv::{Arg, Command, DoubleDash, Flag, UnknownFlags as ArgvUnknownFlags};
 
@@ -358,45 +358,23 @@ fn flag_meta(
 ) -> FlagMeta<'static> {
     let arg = f.arg.as_ref();
     let choices = arg.and_then(|a| a.choices.as_ref());
-    FlagMeta {
-        flag: table,
+    let rules = Box::leak(Box::new(FlagMetaRules {
         hidden_shorts: bytes(&f.hidden_short_aliases),
         hidden_longs: strs(&f.hidden_aliases),
-        help: opt(&f.help),
-        long_help: opt(&f.help_long),
         deprecated: opt(&f.deprecated),
         deprecated_warn_at: opt(&f.deprecated_warn_at),
         deprecated_remove_at: opt(&f.deprecated_remove_at),
-        value_name: arg.map(|a| leak(&a.name)),
-        value_names: arg.map_or(&[], |a| strs(&a.value_names)),
-        // The value's own bracket bit, which is not the flag's — usage-lib renders a flag from
-        // two independent `required` bits and a spec can write either without the other. Folded
-        // with the value's own default the way usage-lib folds a positional's, so
-        // `arg "<n>" default="4"` inside a flag reads as optional; a default declared on the
-        // *flag* is a different statement and stays in `default` below.
-        value_optional: arg.is_some_and(|a| !a.required || !a.default.is_empty()),
-        env: opt(&f.env),
         env_fallback: strs(&f.env_fallback),
         deprecated_env: strs(&f.deprecated_env),
-        default: strs(&f.default),
-        accepted_choices: accepted_choices(choices),
-        choices: visible_choices(choices),
-        choice_aliases: choice_aliases(choices),
-        choice_details: choice_details(choices),
-        ignore_case: choices.is_some_and(|c| c.ignore_case),
         allow_unknown_choices: choices.is_some_and(|c| !c.strict),
         validate: arg.and_then(|a| a.validate.as_deref()).map(leak),
         validate_error: arg.and_then(|a| a.validate_error.as_deref()).map(leak),
-        required: f.required,
-        hide: f.hide,
         hide_default_value: f.hide_default_value,
         hide_env: f.hide_env,
         hide_env_values: f.hide_env_values,
         hide_possible_values: f.hide_possible_values,
         hide_short_help: f.hide_short_help,
         hide_long_help: f.hide_long_help,
-        count: f.count,
-        repeatable: f.var,
         // The separator as declared, a `char`: the metadata is the cold model and says what
         // the spec said, where the binding table beside it holds the byte binding counts by.
         delimiter: arg.and_then(|a| a.delimiter),
@@ -452,11 +430,44 @@ fn flag_meta(
         ),
         required_unless: strs(&f.required_unless),
         required_unless_all: strs(&f.required_unless_all),
+        effect: f.effect.map(effect),
+    }));
+    let extra = Box::leak(Box::new(FlagMetaExtra {
+        long_help: opt(&f.help_long),
+        value_names: arg.map_or(&[], |a| strs(&a.value_names)),
+        env: opt(&f.env),
+        default: strs(&f.default),
+        accepted_choices: accepted_choices(choices),
+        choices: visible_choices(choices),
+        choice_aliases: choice_aliases(choices),
+        choice_details: choice_details(choices),
+        ignore_case: choices.is_some_and(|c| c.ignore_case),
         help_heading: opt(&f.help_heading),
         display_order: f.display_order,
-        effect: f.effect.map(effect),
         complete_type: complete_type(completers, &f.name, arg.map(|a| a.name.as_str())),
         complete: NO_COMPLETER,
+        rules,
+    }));
+    let behavior = Box::leak(Box::new(FlagMetaBehavior {
+        value_name: arg.map(|a| leak(&a.name)),
+        // The value's own bracket bit, which is not the flag's — usage-lib renders a flag from
+        // two independent `required` bits and a spec can write either without the other. Folded
+        // with the value's own default the way usage-lib folds a positional's, so
+        // `arg "<n>" default="4"` inside a flag reads as optional; a default declared on the
+        // *flag* is a different statement and stays in `default` below.
+        value_optional: arg.is_some_and(|a| !a.required || !a.default.is_empty()),
+        required: f.required,
+        hide: f.hide,
+        count: f.count,
+        repeatable: f.var,
+        extra,
+        ..FlagMetaBehavior::EMPTY
+    }));
+    FlagMeta {
+        flag: table,
+        help: opt(&f.help),
+        behavior,
+        ..FlagMeta::EMPTY
     }
 }
 

--- a/conformance/tests/spec_roundtrip.rs
+++ b/conformance/tests/spec_roundtrip.rs
@@ -12,7 +12,10 @@
 //! than as a diff nobody reads.
 
 use usage::Spec as LibSpec;
-use usage_argv::spec::{ArgMeta, CommandMeta, Effect, Example, FlagMeta, Spec};
+use usage_argv::spec::{
+    ArgMeta, CommandMeta, Effect, Example, FlagMeta, FlagMetaBehavior, FlagMetaExtra,
+    FlagMetaRules, Spec,
+};
 use usage_argv::{Arg, Command, DoubleDash, Flag};
 
 static JOBS: Flag = Flag {
@@ -237,43 +240,76 @@ static ROOT_META: CommandMeta = CommandMeta {
         FlagMeta {
             flag: &JOBS,
             help: Some(r#"how many jobs, and a quote: ""#),
-            long_help: Some("More about jobs.\nOn two lines."),
-            value_name: Some("n"),
-            env: Some("EX_JOBS"),
-            default: &["4"],
-            help_heading: Some("Performance"),
+            behavior: &FlagMetaBehavior {
+                value_name: Some("n"),
+                extra: &FlagMetaExtra {
+                    long_help: Some("More about jobs.\nOn two lines."),
+                    env: Some("EX_JOBS"),
+                    default: &["4"],
+                    help_heading: Some("Performance"),
+                    ..FlagMetaExtra::EMPTY
+                },
+                ..FlagMetaBehavior::EMPTY
+            },
             ..FlagMeta::EMPTY
         },
         FlagMeta {
             flag: &COLOR,
             help: Some("colorize output"),
-            default: &["true"],
+            behavior: &FlagMetaBehavior {
+                extra: &FlagMetaExtra {
+                    default: &["true"],
+                    ..FlagMetaExtra::EMPTY
+                },
+                ..FlagMetaBehavior::EMPTY
+            },
             ..FlagMeta::EMPTY
         },
         FlagMeta {
             flag: &VERBOSE,
-            count: true,
-            hide: true,
+            behavior: &FlagMetaBehavior {
+                count: true,
+                hide: true,
+                ..FlagMetaBehavior::EMPTY
+            },
             ..FlagMeta::EMPTY
         },
         FlagMeta {
             flag: &INCLUDE,
             help: Some("patterns to include"),
-            value_name: Some("pattern"),
-            repeatable: true,
-            var_min: Some(1),
-            var_max: Some(5),
-            overrides: &["--exclude"],
-            // One target, which the writer puts on the node as a property.
-            required_if: &["--verbose"],
+            behavior: &FlagMetaBehavior {
+                value_name: Some("pattern"),
+                repeatable: true,
+                extra: &FlagMetaExtra {
+                    rules: &FlagMetaRules {
+                        var_min: Some(1),
+                        var_max: Some(5),
+                        overrides: &["--exclude"],
+                        // One target, which the writer puts on the node as a property.
+                        required_if: &["--verbose"],
+                        ..FlagMetaRules::EMPTY
+                    },
+                    ..FlagMetaExtra::EMPTY
+                },
+                ..FlagMetaBehavior::EMPTY
+            },
             ..FlagMeta::EMPTY
         },
         FlagMeta {
             flag: &SHELL,
-            required: true,
-            // Two of them, which cannot be written as repeated properties.
-            required_unless: &["--jobs", "--color"],
-            choices: &["bash", "zsh", "fish"],
+            behavior: &FlagMetaBehavior {
+                required: true,
+                extra: &FlagMetaExtra {
+                    // Two of them, which cannot be written as repeated properties.
+                    choices: &["bash", "zsh", "fish"],
+                    rules: &FlagMetaRules {
+                        required_unless: &["--jobs", "--color"],
+                        ..FlagMetaRules::EMPTY
+                    },
+                    ..FlagMetaExtra::EMPTY
+                },
+                ..FlagMetaBehavior::EMPTY
+            },
             ..FlagMeta::EMPTY
         },
         // A flag that destroys something: the effect belongs on the flag, not
@@ -281,22 +317,40 @@ static ROOT_META: CommandMeta = CommandMeta {
         FlagMeta {
             flag: &PRUNE,
             help: Some("delete anything unused"),
-            // A control character, which KDL will not take literally. Help text
-            // really does contain these: ANSI-colored help has an escape in it.
-            long_help: Some("Deletes things.\u{1b}[0m Carefully."),
-            effect: Some(Effect::Destructive),
-            overrides: &["--keep", "--dry-run"],
-            conflicts: &["--force"],
+            behavior: &FlagMetaBehavior {
+                extra: &FlagMetaExtra {
+                    // A control character, which KDL will not take literally. Help text
+                    // really does contain these: ANSI-colored help has an escape in it.
+                    long_help: Some("Deletes things.\u{1b}[0m Carefully."),
+                    rules: &FlagMetaRules {
+                        effect: Some(Effect::Destructive),
+                        overrides: &["--keep", "--dry-run"],
+                        conflicts: &["--force"],
+                        ..FlagMetaRules::EMPTY
+                    },
+                    ..FlagMetaExtra::EMPTY
+                },
+                ..FlagMetaBehavior::EMPTY
+            },
             ..FlagMeta::EMPTY
         },
         // More than one default, which cannot be written as a property. Neither can
         // more than one conflict or condition, so they go in the same child block.
         FlagMeta {
             flag: &PATHS,
-            value_name: Some("path"),
-            default: &["/usr/bin", "/usr/local/bin"],
-            conflicts: &["--include", "--prune"],
-            required_if: &["--force", "--prune"],
+            behavior: &FlagMetaBehavior {
+                value_name: Some("path"),
+                extra: &FlagMetaExtra {
+                    default: &["/usr/bin", "/usr/local/bin"],
+                    rules: &FlagMetaRules {
+                        conflicts: &["--include", "--prune"],
+                        required_if: &["--force", "--prune"],
+                        ..FlagMetaRules::EMPTY
+                    },
+                    ..FlagMetaExtra::EMPTY
+                },
+                ..FlagMetaBehavior::EMPTY
+            },
             ..FlagMeta::EMPTY
         },
     ],
@@ -1121,8 +1175,14 @@ fn two_fields_on_one_command_can_mean_different_things_by_one_name() {
         cmd: &CMD,
         flags: &[FlagMeta {
             flag: &SOURCE,
-            value_name: Some("TOOL"),
-            complete: Some(remote_tools),
+            behavior: &FlagMetaBehavior {
+                value_name: Some("TOOL"),
+                extra: &FlagMetaExtra {
+                    complete: Some(remote_tools),
+                    ..FlagMetaExtra::EMPTY
+                },
+                ..FlagMetaBehavior::EMPTY
+            },
             ..FlagMeta::EMPTY
         }],
         args: &[ArgMeta {

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -13,6 +13,11 @@ license = { workspace = true }
 [lib]
 proc-macro = true
 
+[features]
+# Ignore clap helper attributes when the same types derive both parser frameworks.
+# usage still reads only `#[usage(...)]`; this feature does not interpret clap metadata.
+clap-coexistence = []
+
 [package.metadata.release]
 shared-version = true
 release = true

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -1118,6 +1118,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
                 root: &ROOT_META,
             };
 
+            #[allow(clippy::disallowed_macros)]
             impl #ident {
                 /// The parse tables for this CLI.
                 ///
@@ -2358,6 +2359,9 @@ fn completer_tokens(
 
 fn flag_meta(cli: &Cli, i: usize, field: &Field, owner: &syn::Ident) -> TokenStream {
     let name = format_ident!("FLAG_META_{i}");
+    let behavior_name = format_ident!("FLAG_META_BEHAVIOR_{i}");
+    let extra_name = format_ident!("FLAG_META_EXTRA_{i}");
+    let rules_name = format_ident!("FLAG_META_RULES_{i}");
     let table = format_ident!("FLAG_{i}");
     let help = option_str(field.help.as_deref());
     let long_help = option_str(field.long_help.as_deref());
@@ -2487,63 +2491,165 @@ fn flag_meta(cli: &Cli, i: usize, field: &Field, owner: &syn::Ident) -> TokenStr
         .effect
         .clone()
         .unwrap_or_else(|| quote!(::core::option::Option::None));
+    let has_rules = field.deprecated.is_some()
+        || field.deprecated_warn_at.is_some()
+        || field.deprecated_remove_at.is_some()
+        || !field.env_fallback.is_empty()
+        || !field.deprecated_env.is_empty()
+        || field.allow_unknown_choices
+        || field.validate.is_some()
+        || field.validate_error.is_some()
+        || field.hide_default_value
+        || field.hide_env
+        || field.hide_env_values
+        || field.hide_possible_values
+        || field.hide_short_help
+        || field.hide_long_help
+        || field.var_min.is_some()
+        || field.var_max.is_some()
+        || field.value_var_min.is_some()
+        || field.value_var_max.is_some()
+        || !field.overrides.is_empty()
+        || !field.conflicts.is_empty()
+        || field.delimiter.is_some()
+        || field.exclusive
+        || !field.requires.is_empty()
+        || !field.requires_if.is_empty()
+        || !field.default_if.is_empty()
+        || !field.required_if.is_empty()
+        || !field.required_if_eq.is_empty()
+        || !field.required_if_eq_all.is_empty()
+        || !field.required_unless.is_empty()
+        || !field.required_unless_all.is_empty()
+        || field.effect.is_some()
+        || !hidden_longs.is_empty();
+    let (rules_decl, rules) = if has_rules {
+        (
+            quote! {
+                pub static #rules_name: usage_argv::spec::FlagMetaRules =
+                    usage_argv::spec::FlagMetaRules {
+                        effect: #effect,
+                        deprecated: #deprecated,
+                        deprecated_warn_at: #deprecated_warn_at,
+                        deprecated_remove_at: #deprecated_remove_at,
+                        env_fallback: &[#(#env_fallback),*],
+                        deprecated_env: &[#(#deprecated_env),*],
+                        hide_default_value: #hide_default_value,
+                        hide_env: #hide_env,
+                        hide_env_values: #hide_env_values,
+                        hide_possible_values: #hide_possible_values,
+                        hide_short_help: #hide_short_help,
+                        hide_long_help: #hide_long_help,
+                        hidden_shorts: &[],
+                        hidden_longs: &[#(#hidden_longs),*],
+                        allow_unknown_choices: #allow_unknown_choices,
+                        validate: #validate,
+                        validate_error: #validate_error,
+                        var_min: #var_min,
+                        var_max: #var_max,
+                        value_var_min: #value_var_min,
+                        value_var_max: #value_var_max,
+                        overrides: &[#(#overrides),*],
+                        conflicts: &[#(#conflicts),*],
+                        requires: &[#(#requires),*],
+                        requires_if: &[#(#requires_if),*],
+                        default_if: &[#(#default_if),*],
+                        exclusive: #exclusive,
+                        delimiter: #delimiter,
+                        required_if: &[#(#required_if),*],
+                        required_if_eq: &[#(#required_if_eq),*],
+                        required_if_eq_all: &[#(#required_if_eq_all),*],
+                        required_unless: &[#(#required_unless),*],
+                        required_unless_all: &[#(#required_unless_all),*],
+                    };
+            },
+            quote!(&#rules_name),
+        )
+    } else {
+        (
+            TokenStream::new(),
+            quote!(&usage_argv::spec::FlagMetaRules::EMPTY),
+        )
+    };
+    let has_extra = field.display_order.is_some()
+        || field.long_help.is_some()
+        || !field.value_names.is_empty()
+        || field.env.is_some()
+        || !field.default.is_empty()
+        || field.value_enum
+        || !field.choices.is_empty()
+        || field.complete.is_some()
+        || field.complete_type.is_some()
+        || field.help_heading.is_some()
+        || has_rules;
+    let (extra_decl, extra) = if has_extra {
+        (
+            quote! {
+                pub static #extra_name: usage_argv::spec::FlagMetaExtra =
+                    usage_argv::spec::FlagMetaExtra {
+                        complete: #completer,
+                        complete_type: #complete_type,
+                        display_order: #display_order,
+                        long_help: #long_help,
+                        env: #env,
+                        default: #default,
+                        help_heading: #help_heading,
+                        value_names: &[#(#value_names),*],
+                        accepted_choices: #accepted_choices,
+                        choices: #choices,
+                        choice_aliases: #choice_aliases,
+                        choice_details: #choice_details,
+                        ignore_case: #ignore_case,
+                        rules: #rules,
+                    };
+            },
+            quote!(&#extra_name),
+        )
+    } else {
+        (
+            TokenStream::new(),
+            quote!(&usage_argv::spec::FlagMetaExtra::EMPTY),
+        )
+    };
+    let has_behavior = field.value_name.is_some()
+        || required
+        || value_optional
+        || hide
+        || count
+        || repeatable
+        || has_extra;
+    let (behavior_decl, behavior) = if has_behavior {
+        (
+            quote! {
+                pub static #behavior_name: usage_argv::spec::FlagMetaBehavior =
+                    usage_argv::spec::FlagMetaBehavior {
+                        value_name: #value_name,
+                        hide: #hide,
+                        count: #count,
+                        repeatable: #repeatable,
+                        required: #required,
+                        value_optional: #value_optional,
+                        extra: #extra,
+                        ..usage_argv::spec::FlagMetaBehavior::EMPTY
+                    };
+            },
+            quote!(&#behavior_name),
+        )
+    } else {
+        (
+            TokenStream::new(),
+            quote!(&usage_argv::spec::FlagMetaBehavior::EMPTY),
+        )
+    };
     quote! {
         #completer_decl
+        #rules_decl
+        #extra_decl
+        #behavior_decl
         pub static #name: usage_argv::spec::FlagMeta = usage_argv::spec::FlagMeta {
-            effect: #effect,
-            complete: #completer,
-            complete_type: #complete_type,
             flag: &#table,
-            display_order: #display_order,
             help: #help,
-            long_help: #long_help,
-            deprecated: #deprecated,
-            deprecated_warn_at: #deprecated_warn_at,
-            deprecated_remove_at: #deprecated_remove_at,
-            env: #env,
-            env_fallback: &[#(#env_fallback),*],
-            deprecated_env: &[#(#deprecated_env),*],
-            default: #default,
-            help_heading: #help_heading,
-            value_name: #value_name,
-            value_names: &[#(#value_names),*],
-            hide: #hide,
-            hide_default_value: #hide_default_value,
-            hide_env: #hide_env,
-            hide_env_values: #hide_env_values,
-            hide_possible_values: #hide_possible_values,
-            hide_short_help: #hide_short_help,
-            hide_long_help: #hide_long_help,
-            count: #count,
-            repeatable: #repeatable,
-            hidden_shorts: &[],
-            hidden_longs: &[#(#hidden_longs),*],
-            required: #required,
-            value_optional: #value_optional,
-            accepted_choices: #accepted_choices,
-            choices: #choices,
-            choice_aliases: #choice_aliases,
-            choice_details: #choice_details,
-            ignore_case: #ignore_case,
-            allow_unknown_choices: #allow_unknown_choices,
-            validate: #validate,
-            validate_error: #validate_error,
-            var_min: #var_min,
-            var_max: #var_max,
-            value_var_min: #value_var_min,
-            value_var_max: #value_var_max,
-            overrides: &[#(#overrides),*],
-            conflicts: &[#(#conflicts),*],
-            requires: &[#(#requires),*],
-            requires_if: &[#(#requires_if),*],
-            default_if: &[#(#default_if),*],
-            exclusive: #exclusive,
-            delimiter: #delimiter,
-            required_if: &[#(#required_if),*],
-            required_if_eq: &[#(#required_if_eq),*],
-            required_if_eq_all: &[#(#required_if_eq_all),*],
-            required_unless: &[#(#required_unless),*],
-            required_unless_all: &[#(#required_unless_all),*],
+            behavior: #behavior,
             ..usage_argv::spec::FlagMeta::EMPTY
         };
     }
@@ -4224,6 +4330,7 @@ fn partial_struct(cli: &Cli) -> TokenStream {
     // declared default has to be in place before parsing begins and nested state has
     // its own starting values.
     quote! {
+        #[allow(clippy::pub_underscore_fields)]
         pub struct Partial {
             pub __usage_view: ::std::option::Option<
                 &'static usage_argv::spec::ViewMeta<'static>,
@@ -6346,6 +6453,7 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
 
 /// The enum a `subcommand` field holds: its variants' tables, and the trait a
 /// parent uses to route events into them.
+#[cfg(not(feature = "clap-coexistence"))]
 fn rewrite_inline_arg_meta(meta: &mut syn::Meta) {
     if matches!(meta, syn::Meta::Path(path) if path.is_ident("arg")) {
         *meta = syn::parse_quote!(usage(arg));
@@ -6378,9 +6486,14 @@ fn rewrite_inline_arg_meta(meta: &mut syn::Meta) {
 
 fn inline_field_meta(meta: &syn::Meta) -> Option<syn::Meta> {
     if meta.path().is_ident("arg") {
-        let mut meta = meta.clone();
-        rewrite_inline_arg_meta(&mut meta);
-        return Some(meta);
+        #[cfg(feature = "clap-coexistence")]
+        return None;
+        #[cfg(not(feature = "clap-coexistence"))]
+        {
+            let mut meta = meta.clone();
+            rewrite_inline_arg_meta(&mut meta);
+            return Some(meta);
+        }
     }
     if meta.path().is_ident("usage") || meta.path().is_ident("doc") || meta.path().is_ident("cfg") {
         return Some(meta.clone());
@@ -9762,13 +9875,33 @@ pub fn emit_arg_group(group: &ArgGroup) -> TokenStream {
         let help = option_str(member.help.as_deref());
         let long_help = option_str(member.long_help.as_deref());
         let hide = member.hide;
+        let extra = if member.long_help.is_some() {
+            quote! {
+                &usage_argv::spec::FlagMetaExtra {
+                    long_help: #long_help,
+                    ..usage_argv::spec::FlagMetaExtra::EMPTY
+                }
+            }
+        } else {
+            quote!(&usage_argv::spec::FlagMetaExtra::EMPTY)
+        };
+        let behavior = if member.long_help.is_some() || hide {
+            quote! {
+                &usage_argv::spec::FlagMetaBehavior {
+                    hide: #hide,
+                    extra: #extra,
+                    ..usage_argv::spec::FlagMetaBehavior::EMPTY
+                }
+            }
+        } else {
+            quote!(&usage_argv::spec::FlagMetaBehavior::EMPTY)
+        };
         quote! {
             #(#cfg)*
             usage_argv::spec::FlagMeta {
                 flag: &#table,
                 help: #help,
-                long_help: #long_help,
-                hide: #hide,
+                behavior: #behavior,
                 ..usage_argv::spec::FlagMeta::EMPTY
             }
         }

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -3839,6 +3839,12 @@ pub(crate) fn attrs(attrs: &[Attribute]) -> impl Iterator<Item = &Attribute> {
     attrs.iter().filter(|a| a.path().is_ident("usage"))
 }
 
+#[cfg(feature = "clap-coexistence")]
+fn reject_legacy_attrs(_input: &DeriveInput) -> syn::Result<()> {
+    Ok(())
+}
+
+#[cfg(not(feature = "clap-coexistence"))]
 fn reject_legacy_attrs(input: &DeriveInput) -> syn::Result<()> {
     let mut error: Option<syn::Error> = None;
     let mut inspect = |attrs: &[Attribute]| {
@@ -5999,6 +6005,7 @@ mod tests {
         assert!(err.contains("#[usage(flatten)]"), "unhelpful: {err}");
     }
 
+    #[cfg(not(feature = "clap-coexistence"))]
     #[test]
     fn clap_attribute_names_are_rejected_at_every_location() {
         for name in ["arg", "command", "value", "group"] {
@@ -6023,6 +6030,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "clap-coexistence"))]
     #[test]
     fn every_declaration_derive_rejects_legacy_namespaces() {
         let input: DeriveInput = syn::parse_str(
@@ -6075,6 +6083,70 @@ mod tests {
             Err(error) => error.into_compile_error().to_string(),
         };
         assert!(group_err.contains("`#[arg(...)]`"), "{group_err}");
+    }
+
+    #[cfg(feature = "clap-coexistence")]
+    #[test]
+    fn clap_attributes_can_coexist_without_defining_the_usage_grammar() {
+        let parsed = cli(r#"
+            #[command(name = "clap-name")]
+            #[usage(name = "usage-name")]
+            struct Ex {
+                #[arg(long = "clap-value")]
+                #[usage(long = "usage-value")]
+                value: bool,
+            }
+        "#)
+        .expect("clap helper attributes are ignored in coexistence mode");
+
+        assert_eq!(parsed.name, "usage-name");
+        let Kind::Flag { longs, .. } = &parsed.fields[0].kind else {
+            panic!("the usage attribute must define a flag");
+        };
+        assert_eq!(longs, &["usage-value"]);
+
+        let subcommands: DeriveInput = syn::parse_str(
+            r#"
+            enum Commands {
+                #[command(name = "clap-run")]
+                #[usage(name = "usage-run")]
+                Run {
+                    #[arg(long)]
+                    #[usage(long)]
+                    fast: bool,
+                },
+            }
+        "#,
+        )
+        .expect("valid Rust");
+        Subcommands::from_input(&subcommands)
+            .expect("subcommand and inline field clap attributes can coexist");
+
+        let values: DeriveInput = syn::parse_str(
+            r#"
+            #[value(rename_all = "snake_case")]
+            enum Mode {
+                #[value(name = "clap-fast")]
+                #[usage(name = "usage-fast")]
+                Fast,
+            }
+        "#,
+        )
+        .expect("valid Rust");
+        ValueEnum::from_input(&values).expect("value attributes can coexist");
+
+        let group: DeriveInput = syn::parse_str(
+            r#"
+            enum Format {
+                #[arg(long = "clap-json")]
+                #[usage(name = "usage-json")]
+                Json,
+                Yaml,
+            }
+        "#,
+        )
+        .expect("valid Rust");
+        ArgGroup::from_input(&group).expect("argument-group attributes can coexist");
     }
 
     #[test]

--- a/docs/rust/completions.md
+++ b/docs/rust/completions.md
@@ -48,6 +48,11 @@ The installed script calls your binary back at completion time with a hidden
 any parsing, so it never appears in your grammar, help, or spec. `parse()` intercepts it
 automatically; with `parse_from`, call `completion_request` first and print whatever it returns.
 
+A composite CLI can parse the protocol without asking one spec to answer it. Use
+`usage::complete::Request::parse` to get the shell, split command line, and optional named
+candidate request. Merge candidates from the selected command grammars, then pass the result to
+`usage::complete::render`. Normal command arguments return `None`.
+
 A typical way to expose the scripts:
 
 ```rust

--- a/docs/rust/index.md
+++ b/docs/rust/index.md
@@ -84,6 +84,7 @@ available for low-level adopters that want a thinner surface:
 | `help`        |   ✅    | `-h` / `--help` page rendering                                                                           |
 | `diagnostics` |   ✅    | clap-shaped error messages from `render_failure`                                                         |
 | `completions` |         | Shell completion scripts and the runtime completion protocol (`complete` is an alias of this feature)    |
+| `clap-coexistence` |     | Ignore clap helper attributes while both derive systems share a type during a staged migration          |
 | `validation`  |         | Portable `validate` / `validate_error` expressions ([Validation](/rust/validation#portable-expressions)) |
 | `test`        |         | `usage::test`: command output, parse, and help assertions (completion assertions want `completions` too) |
 | `config`      |         | The `usage::Config` derive and the resolver as `usage::config` ([Configuration](/rust/configuration))    |

--- a/docs/rust/migrating-from-clap.md
+++ b/docs/rust/migrating-from-clap.md
@@ -68,6 +68,16 @@ clap_derive itself. The opt-in `validation` feature is the exception; it adds `e
 Rename every helper attribute when replacing the derive. usage rejects clap's helper namespaces
 and points the compile error to `#[usage(...)]`.
 
+For a staged migration, enable `clap-coexistence` while the same type derives both frameworks:
+
+```toml
+usage = { package = "usage-rs", version = "6", features = ["clap-coexistence"] }
+```
+
+This feature ignores `#[command]`, `#[arg]`, `#[value]`, and `#[group]` attributes. It does not
+translate them. Add the equivalent `#[usage(...)]` attributes, compare both parsers, and remove
+the feature with the clap derives.
+
 ```rust
 use usage::{Cli, Subcommands};
 

--- a/usage-rs/Cargo.toml
+++ b/usage-rs/Cargo.toml
@@ -24,6 +24,7 @@ usage-config = { workspace = true, optional = true }
 # `usage-argv` directly (no defaults).
 default = ["spec", "help", "diagnostics"]
 spec = ["usage-argv/spec", "dep:usage-derive"]
+clap-coexistence = ["usage-derive/clap-coexistence"]
 help = ["spec"]
 completions = ["spec", "usage-argv/complete", "usage-test?/completions"]
 # Kept as a spelling close to the runtime feature for low-level adopters.

--- a/usage-rs/src/lib.rs
+++ b/usage-rs/src/lib.rs
@@ -22,6 +22,9 @@
 //! usage = { package = "usage-rs", version = "6", features = ["validation"] }
 //! ```
 //!
+//! During a staged clap migration, `clap-coexistence` lets both derive systems share a type.
+//! It ignores clap helper attributes and still reads the grammar only from `#[usage(...)]`.
+//!
 //! ```
 //! use usage_rs as usage;
 //! # #[cfg(feature = "spec")]


### PR DESCRIPTION
Add compact metadata storage for generated Rust parsers. Keep common flag data in `FlagMeta`. Store value, help, and relationship data only when a flag needs it. Use stable cold-path sorts for help and diagnostics. These changes reduce code and data size for embedded parsers.

Expose `Request` for composite completion providers. Add the `clap-coexistence` feature for shared types during a staged migration. Document both APIs.

This change modifies the public `FlagMeta` layout. Existing field reads continue to work through `Deref`. External struct literals do not continue to compile. Please review whether this change needs a major release or a compatible constructor API.

The parser, derive, conformance, help, diagnostic, and completion tests cover these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for staged coexistence with clap derives through the `clap-coexistence` feature.
  * Exposed completion request parsing for applications that combine completion candidates from multiple command grammars.
  * Improved completion metadata support for choices, value names, and completers.
* **Bug Fixes**
  * Help output now preserves declaration order more consistently.
  * Required flags within single-item groups are recognized correctly.
* **Documentation**
  * Added guidance for composite completions and migrating from clap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->