### PR TITLE
chore: release v6.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,68 @@
 # Changelog
 
+## [6.2.0](https://github.com/jdx/usage/compare/v6.1.1..v6.2.0) - 2026-08-24
+
+### 🚀 Features
+
+- **(argv)** add embedded parse outcomes by [@jdx](https://github.com/jdx) in [#1250](https://github.com/jdx/usage/pull/1250)
+- **(cli)** render inline formatting in help text by [@jdx](https://github.com/jdx) in [#1245](https://github.com/jdx/usage/pull/1245)
+- **(cli)** split grouped help template sections by [@jdx](https://github.com/jdx) in [#1251](https://github.com/jdx/usage/pull/1251)
+- **(complete)** add presentation labels to candidates by [@jdx](https://github.com/jdx) in [#1239](https://github.com/jdx/usage/pull/1239)
+- **(complete)** expose structured completion traces by [@jdx](https://github.com/jdx) in [#1241](https://github.com/jdx/usage/pull/1241)
+- **(complete)** add semantic candidate kinds by [@jdx](https://github.com/jdx) in [#1242](https://github.com/jdx/usage/pull/1242)
+- **(complete)** add Elvish runtime completions by [@jdx](https://github.com/jdx) in [#1243](https://github.com/jdx/usage/pull/1243)
+- **(derive)** let argument groups carry values by [@jdx](https://github.com/jdx) in [#1253](https://github.com/jdx/usage/pull/1253)
+- **(derive)** add typed command finalization by [@jdx](https://github.com/jdx) in [#1254](https://github.com/jdx/usage/pull/1254)
+- **(derive)** add runtime-computed defaults by [@jdx](https://github.com/jdx) in [#1256](https://github.com/jdx/usage/pull/1256)
+- **(derive)** dispatch embedded control requests by [@jdx](https://github.com/jdx) in [#1270](https://github.com/jdx/usage/pull/1270)
+- **(derive)** emit embedded_outcome_into for converted CLIs by [@jdx](https://github.com/jdx) in [#1281](https://github.com/jdx/usage/pull/1281)
+- **(docs)** allow overriding markdown templates by [@jdx](https://github.com/jdx) in [#1267](https://github.com/jdx/usage/pull/1267)
+- **(docs)** default to compact markdown references by [@jdx](https://github.com/jdx) in [#1272](https://github.com/jdx/usage/pull/1272)
+- **(docs)** polish compact markdown references by [@jdx](https://github.com/jdx) in [#1280](https://github.com/jdx/usage/pull/1280)
+- **(help)** expose addressable help topics by [@jdx](https://github.com/jdx) in [#1257](https://github.com/jdx/usage/pull/1257)
+- **(help)** list commands by name in one aligned column by [@jdx](https://github.com/jdx) in [#1284](https://github.com/jdx/usage/pull/1284)
+- **(help)** wrap the short help page by [@jdx](https://github.com/jdx) in [#1287](https://github.com/jdx/usage/pull/1287)
+- **(parse)** add structured diagnostic reports by [@jdx](https://github.com/jdx) in [#1255](https://github.com/jdx/usage/pull/1255)
+- **(parse)** add opt-in response files by [@jdx](https://github.com/jdx) in [#1259](https://github.com/jdx/usage/pull/1259)
+- **(parse)** preserve ordered argument groups by [@jdx](https://github.com/jdx) in [#1271](https://github.com/jdx/usage/pull/1271)
+- **(spec)** declare command outputs and exit codes by [@jdx](https://github.com/jdx) in [#1249](https://github.com/jdx/usage/pull/1249)
+- **(spec)** add surface availability metadata by [@jdx](https://github.com/jdx) in [#1258](https://github.com/jdx/usage/pull/1258)
+- **(spec)** add semantic note and warning blocks by [@jdx](https://github.com/jdx) in [#1273](https://github.com/jdx/usage/pull/1273)
+- **(spec)** add output media types by [@jdx](https://github.com/jdx) in [#1274](https://github.com/jdx/usage/pull/1274)
+- **(spec)** add help prose to heading sections by [@jdx](https://github.com/jdx) in [#1282](https://github.com/jdx/usage/pull/1282)
+- add dynamic command catalogs by [@jdx](https://github.com/jdx) in [#1275](https://github.com/jdx/usage/pull/1275)
+
+### 🐛 Bug Fixes
+
+- **(completion)** handle attached values and emit built-ins by [@jdx](https://github.com/jdx) in [#1277](https://github.com/jdx/usage/pull/1277)
+- **(derive)** preserve flattened command metadata by [@jdx](https://github.com/jdx) in [#1268](https://github.com/jdx/usage/pull/1268)
+- **(derive)** skip choice checks for typed defaults by [@jdx](https://github.com/jdx) in [#1269](https://github.com/jdx/usage/pull/1269)
+- **(derive)** suppress generated partial field lint by [@jdx](https://github.com/jdx) in [#1278](https://github.com/jdx/usage/pull/1278)
+- **(derive)** keep an invalid choice after an override displaces the flag by [@jdx](https://github.com/jdx) in [#1286](https://github.com/jdx/usage/pull/1286)
+- **(spec)** make the two KDL writers agree on three more nodes by [@jdx](https://github.com/jdx) in [#1289](https://github.com/jdx/usage/pull/1289)
+
+### 🚜 Refactor
+
+- **(deps)** replace versions with semver by [@jdx](https://github.com/jdx) in [#1285](https://github.com/jdx/usage/pull/1285)
+
+### ⚡ Performance
+
+- **(argv)** reduce sort code size by [@jdx](https://github.com/jdx) in [#1264](https://github.com/jdx/usage/pull/1264)
+- **(markdown)** skip empty admonition context by [@jdx](https://github.com/jdx) in [#1279](https://github.com/jdx/usage/pull/1279)
+- document usage-rs parser tradeoffs by [@jdx](https://github.com/jdx) in [#1265](https://github.com/jdx/usage/pull/1265)
+
+### 🛡️ Security
+
+- **(complete)** filter path candidates by extension by [@jdx](https://github.com/jdx) in [#1240](https://github.com/jdx/usage/pull/1240)
+
+### 🔍 Other Changes
+
+- update usage of deprecated `str downcase` thingy in nushell by [@TheBearodactyl](https://github.com/TheBearodactyl) in [#1262](https://github.com/jdx/usage/pull/1262)
+
+### New Contributors
+
+- @TheBearodactyl made their first contribution in [#1262](https://github.com/jdx/usage/pull/1262)
+
 ## [6.1.1](https://github.com/jdx/usage/compare/v6.1.0..v6.1.1) - 2026-08-23
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,7 +329,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -489,7 +489,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -511,7 +511,7 @@ checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
 dependencies = [
  "darling_core 0.24.1",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -750,7 +750,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1472,7 +1472,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1537,7 +1537,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1633,7 +1633,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1669,7 +1669,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1680,7 +1680,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1917,9 +1917,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1991,7 +1991,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2068,7 +2068,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2193,11 +2193,11 @@ checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "usage-argv"
-version = "6.1.1"
+version = "6.2.0"
 
 [[package]]
 name = "usage-cli"
-version = "6.1.1"
+version = "6.2.0"
 dependencies = [
  "assert_cmd",
  "ctor",
@@ -2226,7 +2226,7 @@ dependencies = [
 
 [[package]]
 name = "usage-config"
-version = "6.1.1"
+version = "6.2.0"
 dependencies = [
  "serde_json",
  "toml",
@@ -2253,17 +2253,17 @@ dependencies = [
 
 [[package]]
 name = "usage-derive"
-version = "6.1.1"
+version = "6.2.0"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "usage-dynamic"
-version = "6.1.1"
+version = "6.2.0"
 dependencies = [
  "futures",
  "usage-argv",
@@ -2273,7 +2273,7 @@ dependencies = [
 
 [[package]]
 name = "usage-lib"
-version = "6.1.1"
+version = "6.2.0"
 dependencies = [
  "clap",
  "criterion",
@@ -2301,7 +2301,7 @@ dependencies = [
 
 [[package]]
 name = "usage-rs"
-version = "6.1.1"
+version = "6.2.0"
 dependencies = [
  "serde",
  "shell-words",
@@ -2316,14 +2316,14 @@ dependencies = [
 
 [[package]]
 name = "usage-test"
-version = "6.1.1"
+version = "6.2.0"
 dependencies = [
  "usage-argv",
 ]
 
 [[package]]
 name = "usage-validation"
-version = "6.1.1"
+version = "6.2.0"
 dependencies = [
  "expr-lang",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,20 +42,20 @@ license = "MIT"
 [workspace.dependencies]
 clap_usage = { path = "./clap_usage", version = "5.0.0" }
 usage-cli = { path = "./cli" }
-usage-argv = { path = "./argv", version = "6.1.1" }
-usage-config = { path = "./config", version = "6.1.1" }
-usage-derive = { path = "./derive", version = "6.1.1" }
+usage-argv = { path = "./argv", version = "6.2.0" }
+usage-config = { path = "./config", version = "6.2.0" }
+usage-derive = { path = "./derive", version = "6.2.0" }
 # No features, and defaults off. A feature named here is inherited by every member that writes
 # `workspace = true` and inlines into their published manifests — so `clap` and `validation`
 # reached members that use neither, one of them an adopter's build script. Defaults
 # are off rather than absent because cargo *ignores* a member's `default-features = false` unless
 # the workspace declaration sets it too, and warns that it may become a hard error. Members name
 # what they need, `docs` included.
-usage-lib = { path = "./lib", version = "6.1.1", default-features = false }
-usage-rs = { path = "./usage-rs", version = "6.1.1" }
-usage-dynamic = { path = "./usage-dynamic", version = "6.1.1" }
-usage-test = { path = "./test", version = "6.1.1" }
-usage-validation = { path = "./validation", version = "6.1.1" }
+usage-lib = { path = "./lib", version = "6.2.0", default-features = false }
+usage-rs = { path = "./usage-rs", version = "6.2.0" }
+usage-dynamic = { path = "./usage-dynamic", version = "6.2.0" }
+usage-test = { path = "./test", version = "6.2.0" }
+usage-validation = { path = "./validation", version = "6.2.0" }
 
 [workspace.metadata.release]
 allow-branch = ["main"]

--- a/argv/Cargo.toml
+++ b/argv/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-argv"
 description = "Zero-allocation argv parser for usage specs"
-version = "6.1.1"
+version = "6.2.0"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "usage-cli"
 edition = "2021"
 rust-version = "1.95"
-version = "6.1.1"
+version = "6.2.0"
 description = "CLI for working with usage-based CLIs"
 license = { workspace = true }
 authors = { workspace = true }

--- a/cli/usage.usage.kdl
+++ b/cli/usage.usage.kdl
@@ -2,7 +2,7 @@
 min_usage_version "4.0"
 name usage
 bin usage
-version "6.1.1"
+version "6.2.0"
 repository "https://github.com/jdx/usage"
 source_code_link_template #"""
 {%- set path = path | replace(from='-', to='_') -%}

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-config"
 description = "Layered configuration resolution for usage specs, with provenance"
-version = "6.1.1"
+version = "6.2.0"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-derive"
 description = "Derive macro that compiles a CLI definition into parse tables and a usage spec"
-version = "6.1.1"
+version = "6.2.0"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }

--- a/docs/cli/reference/commands.json
+++ b/docs/cli/reference/commands.json
@@ -2014,7 +2014,7 @@
     "sources": {},
     "files": []
   },
-  "version": "6.1.1",
+  "version": "6.2.0",
   "usage": "Usage: usage <COMMAND>\n       usage --completions <COMPLETIONS>\n       usage --usage-spec",
   "complete": {},
   "source_code_link_template": "{%- set path = path | replace(from='-', to='_') -%}\n{%- if cmd.subcommands | length > 0 -%}\n{%- set path = path ~ \"/mod.rs\" -%}\n{%- elif path in [\"bash\", \"fish\", \"powershell\", \"zsh\"] -%}\n{%- set path = \"shell.rs\" -%}\n{%- else -%}\n{%- set path = path ~ \".rs\" -%}\n{%- endif -%}\nhttps://github.com/jdx/usage/blob/main/cli/src/cli/{{path}}",

--- a/docs/cli/reference/index.md
+++ b/docs/cli/reference/index.md
@@ -4,7 +4,7 @@
 
 **Usage:** `usage [--completions <COMPLETIONS>] [--usage-spec] <SUBCOMMAND>`
 
-**Version:** 6.1.1
+**Version:** 6.2.0
 
 **Repository:** https://github.com/jdx/usage
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-lib"
 edition = "2021"
-version = "6.1.1"
+version = "6.2.0"
 rust-version = "1.95"
 include = [
     "/Cargo.toml",

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-test"
 description = "Test helpers for CLIs built with usage"
-version = "6.1.1"
+version = "6.2.0"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }

--- a/usage-dynamic/Cargo.toml
+++ b/usage-dynamic/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-dynamic"
 description = "Runtime command catalogs for usage-rs applications"
-version = "6.1.1"
+version = "6.2.0"
 edition = "2021"
 rust-version = "1.95"
 homepage = { workspace = true }
@@ -12,7 +12,7 @@ license = { workspace = true }
 
 [dependencies]
 usage-argv = { workspace = true, features = ["spec", "complete"] }
-usage-parser = { package = "usage-lib", path = "../lib", version = "6.1.1", default-features = false, features = ["cli-help"] }
+usage-parser = { package = "usage-lib", path = "../lib", version = "6.2.0", default-features = false, features = ["cli-help"] }
 
 [package.metadata.release]
 shared-version = true

--- a/usage-rs/Cargo.toml
+++ b/usage-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-rs"
 description = "A compiled CLI parser for Rust, built on usage specs"
-version = "6.1.1"
+version = "6.2.0"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }

--- a/usage-rs/tests/fixtures/runtime-identity/Cargo.lock
+++ b/usage-rs/tests/fixtures/runtime-identity/Cargo.lock
@@ -22,9 +22,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -39,11 +39,11 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "usage-argv"
-version = "6.1.1"
+version = "6.2.0"
 
 [[package]]
 name = "usage-derive"
-version = "6.1.1"
+version = "6.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "usage-rs"
-version = "6.1.1"
+version = "6.2.0"
 dependencies = [
  "usage-argv",
  "usage-derive",

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-validation"
 description = "Portable expression validation for usage specs"
-version = "6.1.1"
+version = "6.2.0"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }


### PR DESCRIPTION
### 🚀 Features

- **(argv)** add embedded parse outcomes by [@jdx](https://github.com/jdx) in [#1250](https://github.com/jdx/usage/pull/1250)
- **(cli)** render inline formatting in help text by [@jdx](https://github.com/jdx) in [#1245](https://github.com/jdx/usage/pull/1245)
- **(cli)** split grouped help template sections by [@jdx](https://github.com/jdx) in [#1251](https://github.com/jdx/usage/pull/1251)
- **(complete)** add presentation labels to candidates by [@jdx](https://github.com/jdx) in [#1239](https://github.com/jdx/usage/pull/1239)
- **(complete)** expose structured completion traces by [@jdx](https://github.com/jdx) in [#1241](https://github.com/jdx/usage/pull/1241)
- **(complete)** add semantic candidate kinds by [@jdx](https://github.com/jdx) in [#1242](https://github.com/jdx/usage/pull/1242)
- **(complete)** add Elvish runtime completions by [@jdx](https://github.com/jdx) in [#1243](https://github.com/jdx/usage/pull/1243)
- **(derive)** let argument groups carry values by [@jdx](https://github.com/jdx) in [#1253](https://github.com/jdx/usage/pull/1253)
- **(derive)** add typed command finalization by [@jdx](https://github.com/jdx) in [#1254](https://github.com/jdx/usage/pull/1254)
- **(derive)** add runtime-computed defaults by [@jdx](https://github.com/jdx) in [#1256](https://github.com/jdx/usage/pull/1256)
- **(derive)** dispatch embedded control requests by [@jdx](https://github.com/jdx) in [#1270](https://github.com/jdx/usage/pull/1270)
- **(derive)** emit embedded_outcome_into for converted CLIs by [@jdx](https://github.com/jdx) in [#1281](https://github.com/jdx/usage/pull/1281)
- **(docs)** allow overriding markdown templates by [@jdx](https://github.com/jdx) in [#1267](https://github.com/jdx/usage/pull/1267)
- **(docs)** default to compact markdown references by [@jdx](https://github.com/jdx) in [#1272](https://github.com/jdx/usage/pull/1272)
- **(docs)** polish compact markdown references by [@jdx](https://github.com/jdx) in [#1280](https://github.com/jdx/usage/pull/1280)
- **(help)** expose addressable help topics by [@jdx](https://github.com/jdx) in [#1257](https://github.com/jdx/usage/pull/1257)
- **(help)** list commands by name in one aligned column by [@jdx](https://github.com/jdx) in [#1284](https://github.com/jdx/usage/pull/1284)
- **(help)** wrap the short help page by [@jdx](https://github.com/jdx) in [#1287](https://github.com/jdx/usage/pull/1287)
- **(parse)** add structured diagnostic reports by [@jdx](https://github.com/jdx) in [#1255](https://github.com/jdx/usage/pull/1255)
- **(parse)** add opt-in response files by [@jdx](https://github.com/jdx) in [#1259](https://github.com/jdx/usage/pull/1259)
- **(parse)** preserve ordered argument groups by [@jdx](https://github.com/jdx) in [#1271](https://github.com/jdx/usage/pull/1271)
- **(spec)** declare command outputs and exit codes by [@jdx](https://github.com/jdx) in [#1249](https://github.com/jdx/usage/pull/1249)
- **(spec)** add surface availability metadata by [@jdx](https://github.com/jdx) in [#1258](https://github.com/jdx/usage/pull/1258)
- **(spec)** add semantic note and warning blocks by [@jdx](https://github.com/jdx) in [#1273](https://github.com/jdx/usage/pull/1273)
- **(spec)** add output media types by [@jdx](https://github.com/jdx) in [#1274](https://github.com/jdx/usage/pull/1274)
- **(spec)** add help prose to heading sections by [@jdx](https://github.com/jdx) in [#1282](https://github.com/jdx/usage/pull/1282)
- add dynamic command catalogs by [@jdx](https://github.com/jdx) in [#1275](https://github.com/jdx/usage/pull/1275)

### 🐛 Bug Fixes

- **(completion)** handle attached values and emit built-ins by [@jdx](https://github.com/jdx) in [#1277](https://github.com/jdx/usage/pull/1277)
- **(derive)** preserve flattened command metadata by [@jdx](https://github.com/jdx) in [#1268](https://github.com/jdx/usage/pull/1268)
- **(derive)** skip choice checks for typed defaults by [@jdx](https://github.com/jdx) in [#1269](https://github.com/jdx/usage/pull/1269)
- **(derive)** suppress generated partial field lint by [@jdx](https://github.com/jdx) in [#1278](https://github.com/jdx/usage/pull/1278)
- **(derive)** keep an invalid choice after an override displaces the flag by [@jdx](https://github.com/jdx) in [#1286](https://github.com/jdx/usage/pull/1286)
- **(spec)** make the two KDL writers agree on three more nodes by [@jdx](https://github.com/jdx) in [#1289](https://github.com/jdx/usage/pull/1289)

### 🚜 Refactor

- **(deps)** replace versions with semver by [@jdx](https://github.com/jdx) in [#1285](https://github.com/jdx/usage/pull/1285)

### ⚡ Performance

- **(argv)** reduce sort code size by [@jdx](https://github.com/jdx) in [#1264](https://github.com/jdx/usage/pull/1264)
- **(markdown)** skip empty admonition context by [@jdx](https://github.com/jdx) in [#1279](https://github.com/jdx/usage/pull/1279)
- document usage-rs parser tradeoffs by [@jdx](https://github.com/jdx) in [#1265](https://github.com/jdx/usage/pull/1265)

### 🛡️ Security

- **(complete)** filter path candidates by extension by [@jdx](https://github.com/jdx) in [#1240](https://github.com/jdx/usage/pull/1240)

### 🔍 Other Changes

- update usage of deprecated `str downcase` thingy in nushell by [@TheBearodactyl](https://github.com/TheBearodactyl) in [#1262](https://github.com/jdx/usage/pull/1262)

### New Contributors

- @TheBearodactyl made their first contribution in [#1262](https://github.com/jdx/usage/pull/1262)