### PR TITLE
feat(argv): add embedded parse outcomes

### DIFF
--- a/argv/src/embedded.rs
+++ b/argv/src/embedded.rs
@@ -1,0 +1,244 @@
+//! Process control for a CLI embedded in another runtime.
+//!
+//! [`crate::Cli::parse`](https://docs.rs/usage-rs) owns a process: it prints help, versions and
+//! failures, then exits where appropriate. An N-API module, WASM host or editor integration cannot
+//! let a library end its process. [`outcome`] turns the same decisions into a value the host can
+//! print or return instead.
+
+use std::ffi::OsStr;
+
+use crate::help::{self, Page, Style};
+use crate::spec::Spec;
+use crate::{Command, Error};
+
+/// What an embedded host should print before returning the supplied status.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Exit {
+    /// The text exactly as the process-facing renderer produced it.
+    pub text: String,
+    /// Whether the text belongs on stderr rather than stdout.
+    pub stderr: bool,
+    /// The status the standalone process would have exited with.
+    pub code: i32,
+}
+
+/// The two things parsing inside another runtime can do.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Outcome<T> {
+    /// The command line parsed and the host can run it.
+    Parsed(T),
+    /// The host should print a response and return its status without running the command.
+    Exit(Exit),
+}
+
+impl<T> Outcome<T> {
+    /// The parsed value, if the command line was an invocation rather than a response.
+    pub fn parsed(self) -> Option<T> {
+        match self {
+            Self::Parsed(parsed) => Some(parsed),
+            Self::Exit(_) => None,
+        }
+    }
+
+    /// The response an embedded host should return, if parsing did not produce a value.
+    pub fn exit(&self) -> Option<&Exit> {
+        match self {
+            Self::Parsed(_) => None,
+            Self::Exit(exit) => Some(exit),
+        }
+    }
+}
+
+/// Parse one command line without printing or ending the host process.
+///
+/// Pass the CLI's own `parse_from` function item:
+///
+/// ```ignore
+/// match usage::embedded::outcome(Cli::spec(), Cli::command(), &argv, Cli::parse_from) {
+///     usage::embedded::Outcome::Parsed(cli) => run(cli),
+///     usage::embedded::Outcome::Exit(exit) => host.respond(exit),
+/// }
+/// ```
+///
+/// Help and version go to stdout with status 0. Help produced by `arg_required_else_help` and
+/// parse failures go to stderr with status 2. Rendering follows the terminal attached to the
+/// destination stream and honors `NO_COLOR` and `CLICOLOR_FORCE`.
+///
+/// The version response uses the portable identity in `spec`. A CLI whose version or binary name
+/// is computed at runtime should handle [`Error::Version`] itself so it can use that runtime value.
+pub fn outcome<'v, T>(
+    spec: &Spec<'_>,
+    root: &Command<'_>,
+    argv: &[&'v OsStr],
+    parse_from: impl FnOnce(&[&'v OsStr]) -> Result<T, Error<'static, 'v>>,
+) -> Outcome<T> {
+    outcome_with_styles(
+        spec,
+        root,
+        argv,
+        parse_from,
+        Style::auto(),
+        Style::auto_stderr(),
+    )
+}
+
+fn outcome_with_styles<'v, T>(
+    spec: &Spec<'_>,
+    root: &Command<'_>,
+    argv: &[&'v OsStr],
+    parse_from: impl FnOnce(&[&'v OsStr]) -> Result<T, Error<'static, 'v>>,
+    stdout_style: Style,
+    stderr_style: Style,
+) -> Outcome<T> {
+    match parse_from(argv) {
+        Ok(parsed) => Outcome::Parsed(parsed),
+        Err(Error::Version { long }) => {
+            let bin = spec.bin.unwrap_or(spec.name);
+            let version = if long {
+                spec.long_version.or(spec.version)
+            } else {
+                spec.version
+            };
+            Outcome::Exit(Exit {
+                text: format!("{bin} {}\n", version.unwrap_or_default()),
+                stderr: false,
+                code: 0,
+            })
+        }
+        Err(Error::Help { cmd, long }) => Outcome::Exit(Exit {
+            text: help::page(
+                spec,
+                root,
+                argv,
+                cmd,
+                if long { Page::Long } else { Page::Short },
+                stdout_style,
+            )
+            .unwrap_or_default(),
+            stderr: false,
+            code: 0,
+        }),
+        Err(Error::HelpAll { cmd }) => Outcome::Exit(Exit {
+            text: help::page(spec, root, argv, cmd, Page::All, stdout_style).unwrap_or_default(),
+            stderr: false,
+            code: 0,
+        }),
+        Err(Error::MissingArgsHelp { cmd }) => Outcome::Exit(Exit {
+            text: help::page(spec, root, argv, cmd, Page::Short, stderr_style).unwrap_or_default(),
+            stderr: true,
+            code: 2,
+        }),
+        Err(error) => Outcome::Exit(Exit {
+            text: crate::render_failure(spec, argv, &error),
+            stderr: true,
+            code: 2,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::spec::{CommandMeta, Spec};
+    use crate::{Arg, Command, Flag};
+
+    static FILE: Arg<'static> = Arg::REQUIRED;
+    static FORCE: Flag<'static> = Flag {
+        key: 1,
+        name: "force",
+        longs: &["force"],
+        ..Flag::BOOL
+    };
+    static ROOT: Command<'static> = Command {
+        name: "ex",
+        flags: &[&FORCE],
+        args: &[&FILE],
+        ..Command::EMPTY
+    };
+    static ROOT_META: CommandMeta<'static> = CommandMeta {
+        cmd: &ROOT,
+        ..CommandMeta::EMPTY
+    };
+    static SPEC: Spec<'static> = Spec {
+        name: "ex",
+        bin: Some("ex"),
+        version: Some("1.2.3"),
+        root: &ROOT_META,
+        ..Spec::EMPTY
+    };
+
+    fn failed<'v, T>(
+        error: Error<'static, 'v>,
+    ) -> impl FnOnce(&[&'v OsStr]) -> Result<T, Error<'static, 'v>> {
+        |_| Err(error)
+    }
+
+    #[test]
+    fn a_parsed_value_is_returned_to_the_host() {
+        let got = outcome_with_styles(&SPEC, &ROOT, &[], |_| Ok(7), Style::PLAIN, Style::PLAIN);
+        assert_eq!(got.parsed(), Some(7));
+    }
+
+    #[test]
+    fn help_and_version_are_stdout_successes() {
+        let help = outcome_with_styles(
+            &SPEC,
+            &ROOT,
+            &[],
+            failed::<()>(Error::Help {
+                cmd: &ROOT,
+                long: false,
+            }),
+            Style::PLAIN,
+            Style::PLAIN,
+        );
+        let exit = help.exit().expect("help is a response");
+        assert!(!exit.stderr);
+        assert_eq!(exit.code, 0);
+        assert!(exit.text.contains("Usage: ex"), "{}", exit.text);
+
+        let version = outcome_with_styles(
+            &SPEC,
+            &ROOT,
+            &[],
+            failed::<()>(Error::Version { long: false }),
+            Style::PLAIN,
+            Style::PLAIN,
+        );
+        assert_eq!(
+            version.exit().map(|exit| exit.text.as_str()),
+            Some("ex 1.2.3\n")
+        );
+    }
+
+    #[test]
+    fn automatic_help_and_failures_are_stderr_status_two() {
+        let help = outcome_with_styles(
+            &SPEC,
+            &ROOT,
+            &[],
+            failed::<()>(Error::MissingArgsHelp { cmd: &ROOT }),
+            Style::PLAIN,
+            Style::PLAIN,
+        );
+        let exit = help.exit().expect("automatic help is a response");
+        assert!(exit.stderr);
+        assert_eq!(exit.code, 2);
+
+        let argv = [OsStr::new("--wat")];
+        let failure = outcome_with_styles(
+            &SPEC,
+            &ROOT,
+            &argv,
+            failed::<()>(Error::UnknownFlag {
+                token: argv[0].as_encoded_bytes(),
+            }),
+            Style::PLAIN,
+            Style::PLAIN,
+        );
+        let exit = failure.exit().expect("a failure is a response");
+        assert!(exit.stderr);
+        assert_eq!(exit.code, 2);
+        assert!(exit.text.contains("--wat"), "{}", exit.text);
+    }
+}

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -138,6 +138,8 @@ pub enum ValueHint {
 pub mod complete;
 #[cfg(feature = "diagnostics")]
 pub mod diagnostic;
+#[cfg(feature = "spec")]
+pub mod embedded;
 #[cfg(feature = "complete")]
 pub mod install;
 #[cfg(feature = "complete")]

--- a/docs/rust/help.md
+++ b/docs/rust/help.md
@@ -51,6 +51,27 @@ arm and before command dispatch. There is no hidden callback lifecycle: the
 embedding application owns the order explicitly, and `parse()` remains the
 convenience entry point for CLIs that want immediate print-and-exit behavior.
 
+### Embedding without exiting
+
+An N-API module, WASM host, editor integration, or test runner cannot let a library terminate
+its process. `embedded::outcome` turns the same process boundary into a value:
+
+```rust
+match usage::embedded::outcome(Ex::spec(), Ex::command(), &argv, Ex::parse_from) {
+    usage::embedded::Outcome::Parsed(cli) => run(cli),
+    usage::embedded::Outcome::Exit(exit) => {
+        // Send `exit.text` to stdout or stderr according to `exit.stderr`, then return
+        // `exit.code` to the host instead of calling `std::process::exit`.
+        host.respond(exit)
+    }
+}
+```
+
+The outcome renders requested help and version responses as stdout status 0, and automatic help
+or a parse failure as stderr status 2. It uses the portable binary name and version from the spec;
+a CLI whose identity is computed at runtime handles `Error::Version` itself so it can substitute
+that runtime value.
+
 ### Deprecation warnings
 
 A `deprecated` flag or command, or a value that arrived through a `deprecated_env` alias, is


### PR DESCRIPTION
## Summary

- turn parse/help/version/failure process control into an embedded host value
- preserve stdout/stderr destinations and clap-compatible exit statuses
- document the N-API, WASM, editor, and test-runner integration pattern

This addresses the repeated help/version/error match needed by the oxlint and oxfmt N-API entry points in oxc-project/oxc#26018.

## Tests

- cargo test -p usage-argv --all-features
- cargo test -p usage-rs --all-features
- cargo clippy -p usage-argv -p usage-rs --all-features --all-targets -- -D warnings

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Additive API, but it encodes the process-control contract (stream, status, rendered text) that embedders will rely on. A mismatch with standalone `parse()` would show up as wrong help/error behavior in N-API and similar hosts.
> 
> **Overview**
> Hosts that cannot terminate (N-API, WASM, editors, tests) can now parse through `embedded::outcome` instead of matching help/version/failure themselves.
> 
> `Outcome` is either a parsed value or an `Exit` with rendered text, stdout vs stderr, and the clap-compatible status (0 for requested help/version, 2 for automatic help and parse failures). Version text comes from the portable spec identity; runtime-computed names still handle `Error::Version` themselves.
> 
> Gated on the `spec` feature. Docs show the host-respond pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a393cf1ca280ca3dbe446135d0b543aa15a7a00c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for embedding CLI parsing in host applications without terminating the host process.
  * Added structured results for parsed commands, help and version responses, and parsing errors.
  * Help and version output now reports the appropriate text stream and status code.

* **Documentation**
  * Added guidance for integrating embedded CLI parsing and handling returned responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->