### PR TITLE
feat(cli): split grouped help template sections

### DIFF
--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -45,8 +45,23 @@ const INLINE_LIMIT: usize = 2;
 /// | `commands`     | the subcommand list, or the flattened bodies under `flatten_help`     |
 /// | `args`         | every argument group, each under its heading                          |
 /// | `flags`        | this command's flag groups, then the globals it inherits             |
+/// | `grouped_args` | arguments with a declared help heading                               |
+/// | `ungrouped_args` | arguments under the default `Arguments` heading                    |
+/// | `grouped_flags` | flags with a declared help heading                                  |
+/// | `ungrouped_flags` | flags under `Flags`, plus inherited global flags                   |
 /// | `after_help`   | examples, `after_help`, and the author/license footer on a long page  |
-pub const SECTIONS: [&str; 6] = ["about", "usage", "commands", "args", "flags", "after_help"];
+pub const SECTIONS: [&str; 10] = [
+    "about",
+    "usage",
+    "commands",
+    "args",
+    "flags",
+    "grouped_args",
+    "ungrouped_args",
+    "grouped_flags",
+    "ungrouped_flags",
+    "after_help",
+];
 
 /// The first placeholder in a template that names no section, if there is one.
 ///
@@ -91,6 +106,10 @@ struct Sections {
     commands: String,
     args: String,
     flags: String,
+    grouped_args: String,
+    ungrouped_args: String,
+    grouped_flags: String,
+    ungrouped_flags: String,
     flattened: String,
     after_help: String,
 }
@@ -136,6 +155,10 @@ impl Sections {
             }
             "args" => self.args.trim().to_string(),
             "flags" => self.flags.trim().to_string(),
+            "grouped_args" => self.grouped_args.trim().to_string(),
+            "ungrouped_args" => self.ungrouped_args.trim().to_string(),
+            "grouped_flags" => self.grouped_flags.trim().to_string(),
+            "ungrouped_flags" => self.ungrouped_flags.trim().to_string(),
             "after_help" => self.after_help.trim().to_string(),
             _ => return None,
         })
@@ -1118,8 +1141,10 @@ fn short_help_with(
         .map(|a| arg_usage(a).chars().count())
         .max()
         .unwrap_or(0);
-    groups_section(
+    split_groups_section(
         &mut sections.args,
+        &mut sections.ungrouped_args,
+        &mut sections.grouped_args,
         "Arguments",
         args.iter().copied(),
         |a| a.help_heading,
@@ -1221,8 +1246,10 @@ fn short_help_with(
             deprecation.as_deref(),
         );
     };
-    groups_section(
+    split_groups_section(
         &mut sections.flags,
+        &mut sections.ungrouped_flags,
+        &mut sections.grouped_flags,
         "Flags",
         own.iter().copied(),
         |f| flag_help_heading(meta, f),
@@ -1231,8 +1258,10 @@ fn short_help_with(
     // After the command's own, and under a heading that says where they came from: `--config`
     // belongs to the program, not to this command, and a reader should be able to see that.
     // The text is precomputed, since a spelling a descendant claimed is left out of it.
-    groups_section(
+    split_groups_section(
         &mut sections.flags,
+        &mut sections.ungrouped_flags,
+        &mut sections.grouped_flags,
         "Global flags",
         inherited.iter(),
         |_| None,
@@ -1527,9 +1556,12 @@ fn flatten_site_heading<'a>(
     None
 }
 
-/// One section per heading, unheaded first, in the order the headings first appear.
-fn groups_section<'m, T: 'm>(
+/// One section per heading, unheaded first, while also keeping the named and default groups
+/// available to a template.
+fn split_groups_section<'m, T: 'm>(
     out: &mut String,
+    ungrouped: &mut String,
+    grouped: &mut String,
     default_title: &str,
     items: impl Iterator<Item = &'m T> + Clone,
     heading_of: impl Fn(&T) -> Option<&str>,
@@ -1547,9 +1579,15 @@ fn groups_section<'m, T: 'm>(
     headings.sort_by_key(|h| h.is_some());
 
     for heading in headings {
-        let _ = writeln!(out, "\n{}:", heading.unwrap_or(default_title));
+        let mut section = String::new();
+        let _ = writeln!(section, "\n{}:", heading.unwrap_or(default_title));
         for item in items.clone().filter(|i| heading_of(i) == heading) {
-            write_item(out, item);
+            write_item(&mut section, item);
+        }
+        out.push_str(&section);
+        match heading {
+            Some(_) => grouped.push_str(&section),
+            None => ungrouped.push_str(&section),
         }
     }
 }
@@ -1839,8 +1877,10 @@ fn long_help_with(
         .map(|a| arg_usage(a).chars().count())
         .max()
         .unwrap_or(0);
-    groups_section(
+    split_groups_section(
         &mut sections.args,
+        &mut sections.ungrouped_args,
+        &mut sections.grouped_args,
         "Arguments",
         args.iter().copied(),
         |a| a.help_heading,
@@ -1877,8 +1917,10 @@ fn long_help_with(
         .chain(inherited.iter().map(|(_, u)| u.chars().count()))
         .max()
         .unwrap_or(0);
-    groups_section(
+    split_groups_section(
         &mut sections.flags,
+        &mut sections.ungrouped_flags,
+        &mut sections.grouped_flags,
         "Flags",
         own.iter().copied(),
         |f| flag_help_heading(meta, f),
@@ -1911,8 +1953,10 @@ fn long_help_with(
     // belongs to the program, not to this command, and a reader should be able to see that.
     // Not grouped by `help_heading` — an ancestor's headings describe that command's page, and
     // borrowing them here would put a section title on flags that are only visiting.
-    groups_section(
+    split_groups_section(
         &mut sections.flags,
+        &mut sections.ungrouped_flags,
+        &mut sections.grouped_flags,
         "Global flags",
         inherited.iter(),
         |_| None,

--- a/conformance/tests/help_template.rs
+++ b/conformance/tests/help_template.rs
@@ -142,12 +142,12 @@ fn a_template_survives_the_round_trip_through_kdl() {
     );
 }
 
-/// A CLI naming every section there is, in an order no default page uses.
+/// A CLI naming every original, combined section, in an order no default page uses.
 ///
-/// The fixture that holds the vocabularies together. The derive keeps its own copy of the six
-/// names — a proc-macro crate cannot depend on the crate its output calls into — so a name
-/// missing from that copy refuses this struct at compile time, and one missing from
-/// `usage_argv::help` renders here as the braces somebody typed.
+/// Together with `SplitSections`, this holds the vocabularies together. The derive keeps its own
+/// copy of the ten names — a proc-macro crate cannot depend on the crate its output calls into —
+/// so a name missing from that copy refuses one of those structs at compile time, and one missing
+/// from `usage_argv::help` renders as the braces somebody typed.
 #[derive(Cli)]
 #[usage(
     bin = "every-section",
@@ -178,7 +178,7 @@ fn every_section_the_vocabulary_holds_can_be_placed() {
     // substitution as literal braces rather than fail, so the braces are what to look for.
     assert!(!page.contains("{{"), "a section went unfilled:\n{page}");
 
-    // Each of the six put its own content where the template asked for it.
+    // Each combined section put its own content where the template asked for it.
     let at = |needle: &str| {
         page.find(needle)
             .unwrap_or_else(|| panic!("{needle}:\n{page}"))
@@ -205,15 +205,71 @@ fn every_section_the_vocabulary_holds_can_be_placed() {
 }
 
 #[test]
-fn the_two_rust_vocabularies_are_the_same_six_words() {
+fn the_two_rust_vocabularies_are_the_same_words() {
     // One list, three Rust copies: this one, usage-argv's, and the derive's. The derive's cannot
-    // be reached from here, which is what `every_section_the_vocabulary_holds_can_be_placed` is
-    // for; these two can be compared outright.
+    // be reached from here, which is what the two derived fixtures above are for; these two can
+    // be compared outright.
     assert_eq!(
         usage::help_template::SECTIONS,
         usage_argv::help::SECTIONS,
         "the reference and the compiled renderer name different sections"
     );
+}
+
+/// A ported CLI that needs headed flags before its positional arguments, with the ordinary
+/// flags after them. The combined `args` and `flags` sections cannot express that ordering.
+#[derive(Cli)]
+#[usage(
+    bin = "ported",
+    help_template = "{{grouped_flags}}\n\n{{ungrouped_args}}\n\n{{ungrouped_flags}}\n\n{{grouped_args}}"
+)]
+struct SplitSections {
+    /// Read settings from this file
+    #[usage(long, help_heading = "Configuration")]
+    config: Option<String>,
+
+    /// Print more detail
+    #[usage(long)]
+    verbose: bool,
+
+    /// File to process
+    #[usage(arg, name = "file")]
+    file: String,
+
+    /// Processing mode
+    #[usage(arg, name = "mode", help_heading = "Modes")]
+    mode: Option<String>,
+}
+
+#[test]
+fn grouped_and_ungrouped_sections_can_be_interleaved() {
+    let spec = SplitSections::spec();
+    let page = usage_argv::help::short_help(spec, &["ported"], &[spec.root]);
+
+    let lib: LibSpec = spec
+        .to_kdl()
+        .parse()
+        .expect("the derive emits a valid spec");
+    assert_eq!(page, usage::docs::cli::render_help(&lib, &lib.cmd, false));
+
+    let at = |needle: &str| {
+        page.find(needle)
+            .unwrap_or_else(|| panic!("{needle}:\n{page}"))
+    };
+    let order = [
+        at("Configuration:"),
+        at("Arguments:"),
+        at("Flags:"),
+        at("Modes:"),
+    ];
+    assert!(
+        order.windows(2).all(|pair| pair[0] < pair[1]),
+        "the split sections are not in the template's order:\n{page}"
+    );
+    assert_eq!(page.matches("Configuration:").count(), 1, "{page}");
+    assert_eq!(page.matches("Arguments:").count(), 1, "{page}");
+    assert_eq!(page.matches("Flags:").count(), 1, "{page}");
+    assert_eq!(page.matches("Modes:").count(), 1, "{page}");
 }
 
 #[test]
@@ -272,4 +328,17 @@ fn the_cli_a_template_describes_still_parses() {
     assert!(every.force);
     assert_eq!(every.file.as_deref(), Some("notes.txt"));
     assert!(every.command.is_none());
+
+    let split = SplitSections::parse_from(&[
+        OsStr::new("--config"),
+        OsStr::new("settings.toml"),
+        OsStr::new("--verbose"),
+        OsStr::new("notes.txt"),
+        OsStr::new("fast"),
+    ])
+    .expect("split-section fixture parses like the page says");
+    assert_eq!(split.config.as_deref(), Some("settings.toml"));
+    assert!(split.verbose);
+    assert_eq!(split.file, "notes.txt");
+    assert_eq!(split.mode.as_deref(), Some("fast"));
 }

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -3932,11 +3932,22 @@ pub(crate) fn string_value(meta: &Meta) -> syn::Result<String> {
 ///
 /// The same closed vocabulary `usage_argv::help::SECTIONS` renders and the KDL parser accepts,
 /// repeated rather than imported: a proc-macro crate cannot depend on the crate its output calls
-/// into, and the list is six words. What keeps the copies together is
+/// into. What keeps the copies together is
 /// `conformance/tests/help_template.rs`, which renders a page from a template naming every one of
 /// them — a section this copy had lost would refuse that fixture at compile time, and one it had
 /// gained would render as literal braces.
-const HELP_SECTIONS: [&str; 6] = ["about", "usage", "commands", "args", "flags", "after_help"];
+const HELP_SECTIONS: [&str; 10] = [
+    "about",
+    "usage",
+    "commands",
+    "args",
+    "flags",
+    "grouped_args",
+    "ungrouped_args",
+    "grouped_flags",
+    "ungrouped_flags",
+    "after_help",
+];
 
 /// Whether every `{{…}}` in a template names a section.
 fn check_help_template(template: &str) -> Result<(), String> {

--- a/docs/rust/help.md
+++ b/docs/rust/help.md
@@ -137,7 +137,9 @@ help_template "{{about}}\n\n{{usage}}\n\n{{flags}}\n\n{{args}}\n\n{{commands}}"
 ```
 
 A template is placed on the root and lays out every page in the CLI, subcommands included. It
-holds six named sections and nothing else:
+holds ten named sections and nothing else. `args` and `flags` retain the complete sections used by
+existing templates; their grouped and ungrouped variants expose the same content in smaller pieces
+when a port needs to interleave them:
 
 | section          | what it covers                                                                       |
 | ---------------- | ------------------------------------------------------------------------------------ |
@@ -146,6 +148,10 @@ holds six named sections and nothing else:
 | `{{commands}}`   | the subcommand list — or, under `flatten_help`, the subcommands' own bodies          |
 | `{{args}}`       | every argument group, each under its heading                                         |
 | `{{flags}}`      | this command's flag groups, then the global flags it inherits                        |
+| `{{grouped_args}}` | arguments with a declared help heading                                             |
+| `{{ungrouped_args}}` | arguments under the default `Arguments` heading                                  |
+| `{{grouped_flags}}` | flags with a declared help heading                                                |
+| `{{ungrouped_flags}}` | flags under `Flags`, plus inherited global flags                                 |
 | `{{after_help}}` | the Examples section, `after_help`, and the author and licence a long page ends with |
 
 Reorder them, leave them out, or put text of your own around them. Two rules make that
@@ -163,6 +169,15 @@ predictable:
 
 The template applies to the terminal help page. Markdown, manpages, and JSON keep their own
 structure.
+
+For example, a CLI migrating from a renderer that put named option groups before positionals and
+ordinary options after them can preserve that order without recreating help text itself:
+
+```rust
+#[usage(
+    help_template = "{{grouped_flags}}\n\n{{ungrouped_args}}\n\n{{ungrouped_flags}}"
+)]
+```
 
 #### Coming from clap
 

--- a/docs/rust/help.md
+++ b/docs/rust/help.md
@@ -141,18 +141,18 @@ holds ten named sections and nothing else. `args` and `flags` retain the complet
 existing templates; their grouped and ungrouped variants expose the same content in smaller pieces
 when a port needs to interleave them:
 
-| section          | what it covers                                                                       |
-| ---------------- | ------------------------------------------------------------------------------------ |
-| `{{about}}`      | `before_help`, the `{bin} {version}` banner, and the description                     |
-| `{{usage}}`      | the `Usage:` synopsis, however many lines it takes                                   |
-| `{{commands}}`   | the subcommand list — or, under `flatten_help`, the subcommands' own bodies          |
-| `{{args}}`       | every argument group, each under its heading                                         |
-| `{{flags}}`      | this command's flag groups, then the global flags it inherits                        |
-| `{{grouped_args}}` | arguments with a declared help heading                                             |
-| `{{ungrouped_args}}` | arguments under the default `Arguments` heading                                  |
-| `{{grouped_flags}}` | flags with a declared help heading                                                |
-| `{{ungrouped_flags}}` | flags under `Flags`, plus inherited global flags                                 |
-| `{{after_help}}` | the Examples section, `after_help`, and the author and licence a long page ends with |
+| section               | what it covers                                                                       |
+| --------------------- | ------------------------------------------------------------------------------------ |
+| `{{about}}`           | `before_help`, the `{bin} {version}` banner, and the description                     |
+| `{{usage}}`           | the `Usage:` synopsis, however many lines it takes                                   |
+| `{{commands}}`        | the subcommand list — or, under `flatten_help`, the subcommands' own bodies          |
+| `{{args}}`            | every argument group, each under its heading                                         |
+| `{{flags}}`           | this command's flag groups, then the global flags it inherits                        |
+| `{{grouped_args}}`    | arguments with a declared help heading                                               |
+| `{{ungrouped_args}}`  | arguments under the default `Arguments` heading                                      |
+| `{{grouped_flags}}`   | flags with a declared help heading                                                   |
+| `{{ungrouped_flags}}` | flags under `Flags`, plus inherited global flags                                     |
+| `{{after_help}}`      | the Examples section, `after_help`, and the author and licence a long page ends with |
 
 Reorder them, leave them out, or put text of your own around them. Two rules make that
 predictable:

--- a/docs/spec/reference/index.md
+++ b/docs/spec/reference/index.md
@@ -55,7 +55,7 @@ otherwise generated from its flags, arguments, and subcommands.
 
 ## Laying out help
 
-`help_template` controls the order of the six pre-rendered sections in every
+`help_template` controls the order of the ten pre-rendered sections in every
 help page:
 
 ```kdl
@@ -63,8 +63,12 @@ help_template "{{about}}\n\n{{usage}}\n\n{{flags}}\n\n{{args}}\n\n{{commands}}\n
 ```
 
 The supported placeholders are `about`, `usage`, `commands`, `args`, `flags`,
-and `after_help`. A placeholder outside that closed vocabulary is rejected
-when the spec is parsed. A template may omit a section or add literal text.
+`grouped_args`, `ungrouped_args`, `grouped_flags`, `ungrouped_flags`, and
+`after_help`. `args` and `flags` contain their complete sections for backwards
+compatibility; the grouped and ungrouped forms expose the same content in smaller
+pieces when a port needs to interleave it. Ungrouped flags include inherited global
+flags. A placeholder outside that closed vocabulary is rejected when the spec is
+parsed. A template may omit a section or add literal text.
 
 ## Root command policy
 

--- a/go/argv/page.go
+++ b/go/argv/page.go
@@ -135,7 +135,7 @@ func ShortHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) s
 			argCol = n
 		}
 	}
-	groupsSection(&sections.args, "Arguments", len(args),
+	groupsSection(&sections.args, &sections.ungroupedArgs, &sections.groupedArgs, "Arguments", len(args),
 		func(i int) string { return headingOf(help, args[i].Key) },
 		func(w *strings.Builder, i int) {
 			a := args[i]
@@ -208,7 +208,7 @@ func ShortHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) s
 		}
 		annotations(w, h, true)
 	}
-	groupsSection(&sections.flags, "Flags", len(own),
+	groupsSection(&sections.flags, &sections.ungroupedFlags, &sections.groupedFlags, "Flags", len(own),
 		func(i int) string {
 			if own[i].supplied != "" {
 				return ""
@@ -219,7 +219,7 @@ func ShortHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) s
 	// After the command's own, and under a heading that says where they came
 	// from: a global belongs to the program, not to this command, and a reader
 	// should be able to see that.
-	groupsSection(&sections.flags, "Global flags", len(inherited),
+	groupsSection(&sections.flags, &sections.ungroupedFlags, &sections.groupedFlags, "Global flags", len(inherited),
 		func(int) string { return "" },
 		func(w *strings.Builder, i int) { entry(w, inherited[i]) })
 	if meta != nil && meta.FlattenHelp {
@@ -412,7 +412,7 @@ func flatCommandsShort(out *strings.Builder, path []string, cmd *Command, help H
 
 // groupsSection writes one section per heading, unheaded first, in the order the
 // headings first appear.
-func groupsSection(out *strings.Builder, defaultTitle string, n int,
+func groupsSection(out, ungrouped, grouped *strings.Builder, defaultTitle string, n int,
 	headingOf func(int) string, writeItem func(*strings.Builder, int)) {
 
 	if n == 0 {
@@ -433,15 +433,22 @@ func groupsSection(out *strings.Builder, defaultTitle string, n int,
 	})
 
 	for _, heading := range headings {
+		var section strings.Builder
 		title := heading
 		if title == "" {
 			title = defaultTitle
 		}
-		out.WriteString("\n" + title + ":\n")
+		section.WriteString("\n" + title + ":\n")
 		for i := 0; i < n; i++ {
 			if headingOf(i) == heading {
-				writeItem(out, i)
+				writeItem(&section, i)
 			}
+		}
+		out.WriteString(section.String())
+		if heading == "" && ungrouped != nil {
+			ungrouped.WriteString(section.String())
+		} else if heading != "" && grouped != nil {
+			grouped.WriteString(section.String())
 		}
 	}
 }

--- a/go/argv/page_long.go
+++ b/go/argv/page_long.go
@@ -89,7 +89,7 @@ func LongHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) st
 			argCol = n
 		}
 	}
-	groupsSection(&sections.args, "Arguments", len(args),
+	groupsSection(&sections.args, &sections.ungroupedArgs, &sections.groupedArgs, "Arguments", len(args),
 		func(i int) string { return headingOf(help, args[i].Key) },
 		func(w *strings.Builder, i int) {
 			h := help.Lookup(args[i].Key)
@@ -120,7 +120,7 @@ func LongHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) st
 			metaField(h, func(x *Help) string { return x.Short })), flagCol, nextLineHelp)
 		longAnnotations(w, h, true)
 	}
-	groupsSection(&sections.flags, "Flags", len(own),
+	groupsSection(&sections.flags, &sections.ungroupedFlags, &sections.groupedFlags, "Flags", len(own),
 		func(i int) string {
 			if own[i].supplied != "" {
 				return ""
@@ -131,7 +131,7 @@ func LongHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) st
 	// Not grouped by heading: an ancestor's headings describe that command's page,
 	// and borrowing them here would put a section title on flags that are only
 	// visiting.
-	groupsSection(&sections.flags, "Global flags", len(inherited),
+	groupsSection(&sections.flags, &sections.ungroupedFlags, &sections.groupedFlags, "Global flags", len(inherited),
 		func(int) string { return "" },
 		func(w *strings.Builder, i int) { writeFlag(w, inherited[i]) })
 	if meta != nil && meta.FlattenHelp {

--- a/go/argv/sections.go
+++ b/go/argv/sections.go
@@ -18,27 +18,39 @@ import "strings"
 //	about       BeforeHelp, the version banner, and the description
 //	usage       the Usage: synopsis, however many lines it takes
 //	commands    the subcommand list, or the flattened bodies under FlattenHelp
-//	args        every argument group, each under its heading
-//	flags       this command's flag groups, then the globals it inherits
-//	after_help  examples, AfterHelp, and the author/license footer on a long page
+//	args             every argument group, each under its heading
+//	flags            this command's flag groups, then the globals it inherits
+//	grouped_args     arguments with a declared help heading
+//	ungrouped_args   arguments under the default Arguments heading
+//	grouped_flags    flags with a declared help heading
+//	ungrouped_flags  flags under Flags, plus inherited global flags
+//	after_help       examples, AfterHelp, and the author/license footer on a long page
 //
 // An array rather than a slice, so the vocabulary cannot grow or shrink the way
 // a package-level slice can. The names themselves are still assignable; nothing
 // in this package writes them.
-var HelpSections = [...]string{"about", "usage", "commands", "args", "flags", "after_help"}
+var HelpSections = [...]string{
+	"about", "usage", "commands", "args", "flags",
+	"grouped_args", "ungrouped_args", "grouped_flags", "ungrouped_flags",
+	"after_help",
+}
 
 // helpSections is a page under construction, cut at the boundaries a template may
 // reorder. `flattened` is not a section an author can name: it is the other half of
 // `commands`, since FlattenHelp replaces a command list with the subcommands' own
 // bodies, and only one of the two is ever written.
 type helpSections struct {
-	about     strings.Builder
-	usage     strings.Builder
-	commands  strings.Builder
-	args      strings.Builder
-	flags     strings.Builder
-	flattened strings.Builder
-	afterHelp strings.Builder
+	about          strings.Builder
+	usage          strings.Builder
+	commands       strings.Builder
+	args           strings.Builder
+	flags          strings.Builder
+	groupedArgs    strings.Builder
+	ungroupedArgs  strings.Builder
+	groupedFlags   strings.Builder
+	ungroupedFlags strings.Builder
+	flattened      strings.Builder
+	afterHelp      strings.Builder
 }
 
 // concatenated is the default page: every section in the order it was written.
@@ -78,6 +90,14 @@ func (s *helpSections) named(name string) (string, bool) {
 		return strings.TrimSpace(s.args.String()), true
 	case "flags":
 		return strings.TrimSpace(s.flags.String()), true
+	case "grouped_args":
+		return strings.TrimSpace(s.groupedArgs.String()), true
+	case "ungrouped_args":
+		return strings.TrimSpace(s.ungroupedArgs.String()), true
+	case "grouped_flags":
+		return strings.TrimSpace(s.groupedFlags.String()), true
+	case "ungrouped_flags":
+		return strings.TrimSpace(s.ungroupedFlags.String()), true
 	case "after_help":
 		return strings.TrimSpace(s.afterHelp.String()), true
 	}

--- a/go/argv/sections_test.go
+++ b/go/argv/sections_test.go
@@ -60,6 +60,46 @@ func TestATemplateReordersTheSections(t *testing.T) {
 	}
 }
 
+func TestGroupedAndUngroupedSectionsCanBeInterleaved(t *testing.T) {
+	config := &Flag{Key: 2, Name: "config", Longs: []string{"config"}, TakesValue: true}
+	verbose := &Flag{Key: 3, Name: "verbose", Longs: []string{"verbose"}}
+	file := &Arg{Key: 4, Name: "file", Required: true}
+	mode := &Arg{Key: 5, Name: "mode"}
+	root := &Command{
+		Name: "ported", Key: 1,
+		Flags: []*Flag{config, verbose}, Args: []*Arg{file, mode},
+	}
+	help := helpKeyed(
+		Help{Key: 2, Short: "Read settings from this file", Heading: "Configuration", ValueName: "path", ValueDemanded: true},
+		Help{Key: 3, Short: "Print more detail"},
+		Help{Key: 4, Short: "File to process", Demanded: true},
+		Help{Key: 5, Short: "Processing mode", Heading: "Modes"},
+	)
+	spec := HelpSpec{
+		Name: "ported", Bin: "ported",
+		HelpTemplate: "{{grouped_flags}}\n\n{{ungrouped_args}}\n\n{{ungrouped_flags}}\n\n{{grouped_args}}",
+	}
+	page := ShortHelp(spec, []string{"ported"}, []*Command{root}, help)
+
+	headings := []string{"Configuration:", "Arguments:", "Flags:", "Modes:"}
+	last := -1
+	for _, heading := range headings {
+		if strings.Count(page, heading) != 1 {
+			t.Fatalf("expected one %q heading:\n%s", heading, page)
+		}
+		at := strings.Index(page, heading)
+		if at <= last {
+			t.Fatalf("sections are not in template order:\n%s", page)
+		}
+		last = at
+	}
+	for _, text := range []string{"--config", "<file>", "--verbose", "--help", "[mode]"} {
+		if !strings.Contains(page, text) {
+			t.Fatalf("missing %q:\n%s", text, page)
+		}
+	}
+}
+
 func TestATemplateOmitsASection(t *testing.T) {
 	// corpus/render/04-help-template.json#template-omits-a-section
 	install := &Command{Name: "install", Key: 4}
@@ -221,8 +261,12 @@ func TestAPlaceholderNamingNoSectionIsLeftAlone(t *testing.T) {
 	}
 }
 
-func TestTheSectionVocabularyIsTheSameSixWords(t *testing.T) {
-	want := []string{"about", "usage", "commands", "args", "flags", "after_help"}
+func TestTheSectionVocabularyMatchesThePortableTemplate(t *testing.T) {
+	want := []string{
+		"about", "usage", "commands", "args", "flags",
+		"grouped_args", "ungrouped_args", "grouped_flags", "ungrouped_flags",
+		"after_help",
+	}
 	if len(HelpSections) != len(want) {
 		t.Fatalf("HelpSections = %v, want %v", HelpSections, want)
 	}

--- a/lib/src/docs/cli/mod.rs
+++ b/lib/src/docs/cli/mod.rs
@@ -71,6 +71,27 @@ pub fn render_help(spec: &Spec, cmd: &SpecCommand, long: bool) -> String {
     }
     lay_out(&mut inherited, width, col);
 
+    let arg_has_ungrouped = docs_cmd
+        .arg_groups
+        .iter()
+        .any(|group| group.heading.is_none());
+    let arg_has_grouped = docs_cmd
+        .arg_groups
+        .iter()
+        .any(|group| group.heading.is_some());
+    let flag_has_ungrouped = docs_cmd
+        .flag_groups
+        .iter()
+        .any(|group| group.heading.is_none());
+    let flag_has_grouped = docs_cmd
+        .flag_groups
+        .iter()
+        .any(|group| group.heading.is_some());
+    ctx.insert("arg_has_ungrouped", &arg_has_ungrouped);
+    ctx.insert("arg_has_grouped", &arg_has_grouped);
+    ctx.insert("flag_has_ungrouped", &flag_has_ungrouped);
+    ctx.insert("flag_has_grouped", &flag_has_grouped);
+
     // Inserted after the layout, not before: the template reads the widths, and a `cmd` put
     // into the context first would carry the ones computed before the two lists were joined.
     ctx.insert("cmd", &docs_cmd);
@@ -78,6 +99,9 @@ pub fn render_help(spec: &Spec, cmd: &SpecCommand, long: bool) -> String {
     for (name, mark) in MARKS {
         ctx.insert(name, &mark);
     }
+    ctx.insert("mark_grouped_args", &MARK_GROUPED_ARGS);
+    ctx.insert("mark_grouped_flags", &MARK_GROUPED_FLAGS);
+    ctx.insert("mark_global_flags", &MARK_GLOBAL_FLAGS);
     let template = if long {
         "spec_template_long.tera"
     } else {
@@ -114,6 +138,9 @@ const MARKS: [(&str, &str); 6] = [
     ("mark_flattened", "\u{1}flattened\u{1}"),
     ("mark_after_help", "\u{1}after_help\u{1}"),
 ];
+const MARK_GROUPED_ARGS: &str = "\u{1}grouped_args\u{1}";
+const MARK_GROUPED_FLAGS: &str = "\u{1}grouped_flags\u{1}";
+const MARK_GLOBAL_FLAGS: &str = "\u{1}global_flags\u{1}";
 
 /// A rendered page cut into the sections a `help_template` may reorder.
 ///
@@ -124,8 +151,12 @@ struct Sections<'a> {
     about: &'a str,
     usage: &'a str,
     commands: &'a str,
-    args: &'a str,
-    flags: &'a str,
+    args: String,
+    flags: String,
+    grouped_args: &'a str,
+    ungrouped_args: &'a str,
+    grouped_flags: &'a str,
+    ungrouped_flags: String,
     flattened: &'a str,
     after_help: &'a str,
 }
@@ -147,12 +178,25 @@ impl<'a> Sections<'a> {
             }
         }
         parts.push(rest);
+        let (ungrouped_args, grouped_args) = parts[3]
+            .split_once(MARK_GROUPED_ARGS)
+            .unwrap_or((parts[3], ""));
+        let (own_flags, global_flags) = parts[4]
+            .split_once(MARK_GLOBAL_FLAGS)
+            .unwrap_or((parts[4], ""));
+        let (own_ungrouped_flags, grouped_flags) = own_flags
+            .split_once(MARK_GROUPED_FLAGS)
+            .unwrap_or((own_flags, ""));
         Self {
             about: parts[0],
             usage: parts[1],
             commands: parts[2],
-            args: parts[3],
-            flags: parts[4],
+            args: format!("{ungrouped_args}{grouped_args}"),
+            flags: format!("{own_ungrouped_flags}{grouped_flags}{global_flags}"),
+            grouped_args,
+            ungrouped_args,
+            grouped_flags,
+            ungrouped_flags: format!("{own_ungrouped_flags}{global_flags}"),
             flattened: parts[5],
             after_help: parts[6],
         }
@@ -164,8 +208,8 @@ impl<'a> Sections<'a> {
             self.about,
             self.usage,
             self.commands,
-            self.args,
-            self.flags,
+            self.args.as_str(),
+            self.flags.as_str(),
             self.flattened,
             self.after_help,
         ]
@@ -190,6 +234,10 @@ impl<'a> Sections<'a> {
             }
             "args" => self.args.trim().to_string(),
             "flags" => self.flags.trim().to_string(),
+            "grouped_args" => self.grouped_args.trim().to_string(),
+            "ungrouped_args" => self.ungrouped_args.trim().to_string(),
+            "grouped_flags" => self.grouped_flags.trim().to_string(),
+            "ungrouped_flags" => self.ungrouped_flags.trim().to_string(),
             "after_help" => self.after_help.trim().to_string(),
             _ => return None,
         })

--- a/lib/src/docs/cli/templates/spec_template_long.tera
+++ b/lib/src/docs/cli/templates/spec_template_long.tera
@@ -53,9 +53,10 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
     Print this message or the help of the given subcommand(s)
 {%- endif %}
 {%- endfor %}
-{%- endif %}{{ mark_args }}
+{%- endif %}{{ mark_args }}{% if not arg_has_ungrouped %}{{ mark_grouped_args }}{% endif %}
 
 {%- for group in cmd.arg_groups %}
+{%- if group.heading and arg_has_ungrouped and loop.index0 == 1 %}{{ mark_grouped_args }}{% endif %}
 
 {{ group.heading | default(value="Arguments") }}:
 {%- for arg in group.items %}
@@ -95,9 +96,10 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
     (default: {{ arg.default | join(sep=", ") }})
 {%- endif %}
 {%- endfor %}
-{%- endfor %}{{ mark_flags }}
+{%- endfor %}{% if arg_has_ungrouped and not arg_has_grouped %}{{ mark_grouped_args }}{% endif %}{{ mark_flags }}{% if not flag_has_ungrouped %}{{ mark_grouped_flags }}{% endif %}
 
 {%- for group in cmd.flag_groups %}
+{%- if group.heading and flag_has_ungrouped and loop.index0 == 1 %}{{ mark_grouped_flags }}{% endif %}
 
 {{ group.heading | default(value="Flags") }}:
 {%- for flag in group.items %}
@@ -142,7 +144,7 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
     [deprecated:{% if flag.deprecated %} {{ flag.deprecated }}{% endif %}{% if flag.deprecated_warn_at %}{% if flag.deprecated %};{% endif %} warns at {{ flag.deprecated_warn_at }}{% endif %}{% if flag.deprecated_remove_at %}{% if flag.deprecated or flag.deprecated_warn_at %};{% endif %} removed at {{ flag.deprecated_remove_at }}{% endif %}]
 {%- endif %}
 {%- endfor %}
-{%- endfor %}
+{%- endfor %}{% if flag_has_ungrouped and not flag_has_grouped %}{{ mark_grouped_flags }}{% endif %}{{ mark_global_flags }}
 
 {%- if global_flags %}
 

--- a/lib/src/docs/cli/templates/spec_template_short.tera
+++ b/lib/src/docs/cli/templates/spec_template_short.tera
@@ -44,9 +44,10 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
     Print this message or the help of the given subcommand(s){% else %}  help  Print this message or the help of the given subcommand(s){% endif %}
 {%- endif %}
 {%- endfor %}
-{%- endif %}{{ mark_args }}
+{%- endif %}{{ mark_args }}{% if not arg_has_ungrouped %}{{ mark_grouped_args }}{% endif %}
 
 {%- for group in cmd.arg_groups %}
+{%- if group.heading and arg_has_ungrouped and loop.index0 == 1 %}{{ mark_grouped_args }}{% endif %}
 
 {{ group.heading | default(value="Arguments") }}:
 {%- for arg in group.items %}
@@ -72,9 +73,10 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
 {%- if not arg.hide_default_value and arg.default %} (default: {{ arg.default | join(sep=", ") }}){%- endif %}
 {%- endif %}
 {%- endfor %}
-{%- endfor %}{{ mark_flags }}
+{%- endfor %}{% if arg_has_ungrouped and not arg_has_grouped %}{{ mark_grouped_args }}{% endif %}{{ mark_flags }}{% if not flag_has_ungrouped %}{{ mark_grouped_flags }}{% endif %}
 
 {%- for group in cmd.flag_groups %}
+{%- if group.heading and flag_has_ungrouped and loop.index0 == 1 %}{{ mark_grouped_flags }}{% endif %}
 
 {{ group.heading | default(value="Flags") }}:
 {%- for flag in group.items %}
@@ -102,7 +104,7 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
 {%- if flag.deprecated or flag.deprecated_warn_at or flag.deprecated_remove_at %}{% if cmd.next_line_help %}
     {% else %} {% endif %}[deprecated:{% if flag.deprecated %} {{ flag.deprecated }}{% endif %}{% if flag.deprecated_warn_at %}{% if flag.deprecated %};{% endif %} warns at {{ flag.deprecated_warn_at }}{% endif %}{% if flag.deprecated_remove_at %}{% if flag.deprecated or flag.deprecated_warn_at %};{% endif %} removed at {{ flag.deprecated_remove_at }}{% endif %}]{%- endif %}
 {%- endfor %}
-{%- endfor %}
+{%- endfor %}{% if flag_has_ungrouped and not flag_has_grouped %}{{ mark_grouped_flags }}{% endif %}{{ mark_global_flags }}
 
 {%- if global_flags %}
 

--- a/lib/src/help_template.rs
+++ b/lib/src/help_template.rs
@@ -18,8 +18,23 @@
 /// | `commands`   | the subcommand list, or the flattened bodies under `flatten_help`   |
 /// | `args`       | every argument group, each under its heading                        |
 /// | `flags`      | this command's flag groups, then the globals it inherits            |
+/// | `grouped_args` | arguments with a declared help heading                            |
+/// | `ungrouped_args` | arguments under the default `Arguments` heading                 |
+/// | `grouped_flags` | flags with a declared help heading                               |
+/// | `ungrouped_flags` | flags under `Flags`, plus inherited global flags                |
 /// | `after_help` | examples, `after_help`, and the author/license footer on a long page |
-pub const SECTIONS: [&str; 6] = ["about", "usage", "commands", "args", "flags", "after_help"];
+pub const SECTIONS: [&str; 10] = [
+    "about",
+    "usage",
+    "commands",
+    "args",
+    "flags",
+    "grouped_args",
+    "ungrouped_args",
+    "grouped_flags",
+    "ungrouped_flags",
+    "after_help",
+];
 
 /// Whether a template is one an author wrote, rather than an empty or whitespace-only
 /// string that should render as the default page.


### PR DESCRIPTION
## Summary

- add `grouped_args`, `ungrouped_args`, `grouped_flags`, and `ungrouped_flags` help-template sections
- retain the existing combined `args` and `flags` sections unchanged
- implement the same section boundaries in usage-lib, usage-argv, the derive, and generated Go
- document and test interleaving named option groups with positionals and ordinary options

This addresses the help-ordering limitation encountered while migrating oxlint and oxfmt in [oxc-project/oxc#26018](https://github.com/oxc-project/oxc/pull/26018).

## Tests

- `cargo test -p usage-conformance --test help_template --all-features`
- `cargo test -p usage-lib --all-features`
- `cargo test -p usage-argv --all-features`
- `cargo test -p usage-rs --all-features`
- `go test ./argv`
- `cargo clippy -p usage-argv -p usage-lib -p usage-derive -p usage-conformance --all-features --all-targets -- -D warnings`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Help-page layout is user-facing and must stay identical across Rust, Go, and the derive. Existing `args`/`flags` templates are preserved, but marker-based splitting in the Tera renderer is easy to get wrong.
> 
> **Overview**
> Help templates gain four finer sections so a page can interleave named groups with default argument/flag lists (the layout some clap ports need). Combined `{{args}}` and `{{flags}}` stay as they were.
> 
> `{{grouped_args}}` / `{{grouped_flags}}` are items with a declared `help_heading`. `{{ungrouped_args}}` is the default Arguments list; `{{ungrouped_flags}}` is Flags plus inherited globals.
> 
> The same closed vocabulary is updated in usage-lib, usage-argv, the derive, and generated Go. Docs and conformance tests cover the new order, including a fixture that places Configuration flags before positionals and ordinary flags after them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a325949432bc68308eac1aa931b18c241d1b487. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Help templates support separate sections for grouped and ungrouped arguments and flags, including inherited global flags.
  - Argument and flag sections can be reordered and interleaved in custom help layouts.
  - Existing combined argument and flag sections remain available for standard rendering.

- **Documentation**
  - Updated help-template reference documentation with the new sections and customization examples.

- **Tests**
  - Added coverage for grouped and ungrouped section rendering across supported implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->