### PR TITLE
feat(parse): add structured diagnostic reports

### DIFF
--- a/argv/src/diagnostic.rs
+++ b/argv/src/diagnostic.rs
@@ -26,6 +26,82 @@ use core::fmt::Write as _;
 use crate::spec::{CommandMeta, FlagMeta, Spec, ViewMeta};
 use crate::{Command, Error};
 
+/// A stable machine-readable category for one parse outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Code {
+    UnknownFlag,
+    MissingFlagValue,
+    UnexpectedArg,
+    ArgRequiresDoubleDash,
+    SubcommandConflict,
+    TooDeep,
+    MissingRequired,
+    DuplicateFlag,
+    InvalidChoice,
+    VarTooFew,
+    VarTooMany,
+    ConflictingFlags,
+    InvalidValue,
+    MissingGroup,
+    MissingSubcommand,
+    Help,
+    MissingArgsHelp,
+    HelpAll,
+    Version,
+}
+
+impl Code {
+    /// The stable snake-case spelling intended for JSON, logs, and editor protocols.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::UnknownFlag => "unknown_flag",
+            Self::MissingFlagValue => "missing_flag_value",
+            Self::UnexpectedArg => "unexpected_arg",
+            Self::ArgRequiresDoubleDash => "arg_requires_double_dash",
+            Self::SubcommandConflict => "subcommand_conflict",
+            Self::TooDeep => "too_deep",
+            Self::MissingRequired => "missing_required",
+            Self::DuplicateFlag => "duplicate_flag",
+            Self::InvalidChoice => "invalid_choice",
+            Self::VarTooFew => "var_too_few",
+            Self::VarTooMany => "var_too_many",
+            Self::ConflictingFlags => "conflicting_flags",
+            Self::InvalidValue => "invalid_value",
+            Self::MissingGroup => "missing_group",
+            Self::MissingSubcommand => "missing_subcommand",
+            Self::Help => "help",
+            Self::MissingArgsHelp => "missing_args_help",
+            Self::HelpAll => "help_all",
+            Self::Version => "version",
+        }
+    }
+}
+
+/// The bytes within one argv word responsible for a diagnostic.
+///
+/// `index` addresses the argv slice passed to [`report`]. `start` and `end` are byte offsets in
+/// that [`std::ffi::OsStr`], so the location remains lossless for non-UTF-8 command lines.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ArgvSpan {
+    pub index: usize,
+    pub start: usize,
+    pub end: usize,
+}
+
+/// A parse outcome ready for a JSON reporter, editor, or another diagnostic framework.
+///
+/// The parser's original [`Error`] remains allocation-free on ordinary grammar failures. This
+/// cold-path value owns its human rendering and optional subject so an embedding does not need
+/// to reverse-engineer enum variants or scrape terminal text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Report {
+    pub code: Code,
+    pub subject: Option<String>,
+    pub location: Option<ArgvSpan>,
+    pub rendered: String,
+}
+
 /// Whether to colour, and what with.
 ///
 /// The codes are clap's, so that a terminal shows the same thing: bold red for `error:`, yellow
@@ -424,6 +500,147 @@ fn resolve<'a>(
         chain.push(next);
     }
     Some((names, chain))
+}
+
+fn span_of_slice(argv: &[&std::ffi::OsStr], slice: &[u8]) -> Option<ArgvSpan> {
+    let start = slice.as_ptr() as usize;
+    let end = start.checked_add(slice.len())?;
+    argv.iter().enumerate().find_map(|(index, word)| {
+        let bytes = word.as_encoded_bytes();
+        let word_start = bytes.as_ptr() as usize;
+        let word_end = word_start.checked_add(bytes.len())?;
+        (start >= word_start && end <= word_end).then(|| ArgvSpan {
+            index,
+            start: start - word_start,
+            end: end - word_start,
+        })
+    })
+}
+
+fn value_span(
+    root: &Command<'_>,
+    argv: &[&std::ffi::OsStr],
+    name: &str,
+    wanted: impl Fn(&str) -> bool,
+) -> Option<ArgvSpan> {
+    let mut parser = crate::Parser::new(root, argv);
+    while let Some(event) = parser.next_event() {
+        let value = match event {
+            Ok(crate::Event::Arg { arg, value, .. }) if arg.name == name => value,
+            Ok(crate::Event::Flag {
+                flag,
+                value: Some(value),
+                ..
+            }) if flag.name == name => value,
+            Ok(_) => continue,
+            Err(_) => break,
+        };
+        if wanted(&String::from_utf8_lossy(value)) {
+            return span_of_slice(argv, value);
+        }
+    }
+    None
+}
+
+fn flag_span(argv: &[&std::ffi::OsStr], flag: &crate::Flag<'_>) -> Option<ArgvSpan> {
+    argv.iter().enumerate().rev().find_map(|(index, word)| {
+        let bytes = word.as_encoded_bytes();
+        if let Some(long) = bytes.strip_prefix(b"--") {
+            let name = long.split(|byte| *byte == b'=').next().unwrap_or(long);
+            return flag.longs.iter().find_map(|candidate| {
+                (name == candidate.as_bytes()).then_some(ArgvSpan {
+                    index,
+                    start: 0,
+                    end: candidate.len() + 2,
+                })
+            });
+        }
+        let shorts = bytes.strip_prefix(b"-")?;
+        shorts.iter().enumerate().find_map(|(offset, short)| {
+            flag.shorts.contains(short).then_some(ArgvSpan {
+                index,
+                start: offset + 1,
+                end: offset + 2,
+            })
+        })
+    })
+}
+
+fn code(error: &Error<'_, '_>) -> Code {
+    match error {
+        Error::UnknownFlag { .. } => Code::UnknownFlag,
+        Error::MissingFlagValue { .. } => Code::MissingFlagValue,
+        Error::UnexpectedArg { .. } => Code::UnexpectedArg,
+        Error::ArgRequiresDoubleDash { .. } => Code::ArgRequiresDoubleDash,
+        Error::SubcommandConflict { .. } => Code::SubcommandConflict,
+        Error::TooDeep => Code::TooDeep,
+        Error::MissingRequired { .. } => Code::MissingRequired,
+        Error::DuplicateFlag { .. } => Code::DuplicateFlag,
+        Error::InvalidChoice { .. } => Code::InvalidChoice,
+        Error::VarTooFew { .. } => Code::VarTooFew,
+        Error::VarTooMany { .. } => Code::VarTooMany,
+        Error::ConflictingFlags { .. } => Code::ConflictingFlags,
+        Error::InvalidValue(_) => Code::InvalidValue,
+        Error::MissingGroup { .. } => Code::MissingGroup,
+        Error::MissingSubcommand => Code::MissingSubcommand,
+        Error::Help { .. } => Code::Help,
+        Error::MissingArgsHelp { .. } => Code::MissingArgsHelp,
+        Error::HelpAll { .. } => Code::HelpAll,
+        Error::Version { .. } => Code::Version,
+    }
+}
+
+fn subject(error: &Error<'_, '_>) -> Option<String> {
+    match error {
+        Error::UnknownFlag { token } | Error::UnexpectedArg { token } => {
+            Some(String::from_utf8_lossy(token).into_owned())
+        }
+        Error::MissingFlagValue { flag } => Some(flag.name.to_string()),
+        Error::ArgRequiresDoubleDash { arg } => Some(arg.name.to_string()),
+        Error::SubcommandConflict { subcommand } => Some(subcommand.name.to_string()),
+        Error::MissingRequired { name }
+        | Error::DuplicateFlag { name }
+        | Error::InvalidChoice { name, .. }
+        | Error::VarTooFew { name, .. }
+        | Error::VarTooMany { name, .. }
+        | Error::ConflictingFlags { name, .. } => Some((*name).to_string()),
+        Error::InvalidValue(invalid) => Some(invalid.name.to_string()),
+        Error::MissingGroup { group, .. } => Some((*group).to_string()),
+        Error::TooDeep
+        | Error::MissingSubcommand
+        | Error::Help { .. }
+        | Error::MissingArgsHelp { .. }
+        | Error::HelpAll { .. }
+        | Error::Version { .. } => None,
+    }
+}
+
+fn location(spec: &Spec<'_>, argv: &[&std::ffi::OsStr], error: &Error<'_, '_>) -> Option<ArgvSpan> {
+    match error {
+        Error::UnknownFlag { token } | Error::UnexpectedArg { token } => span_of_slice(argv, token),
+        Error::MissingFlagValue { flag } => flag_span(argv, flag),
+        Error::InvalidChoice { name, choices } => {
+            value_span(spec.root.cmd, argv, name, |value| !choices.contains(&value))
+        }
+        Error::InvalidValue(invalid) => value_span(spec.root.cmd, argv, invalid.name, |value| {
+            value == invalid.value
+        }),
+        _ => None,
+    }
+}
+
+/// Describe a parse outcome as stable fields plus the ordinary plain-text rendering.
+///
+/// Locations are present when one argv word (or bytes within it) caused the failure. They are
+/// absent for omissions and command-wide relationship failures, which have no honest single
+/// token to underline.
+pub fn report(spec: &Spec<'_>, argv: &[&std::ffi::OsStr], error: &Error<'_, '_>) -> Report {
+    Report {
+        code: code(error),
+        subject: subject(error),
+        location: location(spec, argv, error),
+        rendered: render(spec, argv, error, Style::PLAIN),
+    }
 }
 
 /// Render `error` the way a user should read it.
@@ -1005,6 +1222,109 @@ mod tests {
         let owned: Vec<std::ffi::OsString> = words.iter().map(std::ffi::OsString::from).collect();
         let argv: Vec<&std::ffi::OsStr> = owned.iter().map(|o| o.as_os_str()).collect();
         render(&SPEC, &argv, &error, Style::PLAIN)
+    }
+
+    #[test]
+    fn a_structured_report_locates_the_exact_unknown_word() {
+        let owned = [
+            std::ffi::OsString::from("use"),
+            std::ffi::OsString::from("--fore"),
+        ];
+        let argv = owned
+            .iter()
+            .map(|word| word.as_os_str())
+            .collect::<Vec<_>>();
+        let error = Error::UnknownFlag {
+            token: argv[1].as_encoded_bytes(),
+        };
+        let report = report(&SPEC, &argv, &error);
+        assert_eq!(report.code, Code::UnknownFlag);
+        assert_eq!(report.code.as_str(), "unknown_flag");
+        assert_eq!(report.subject.as_deref(), Some("--fore"));
+        assert_eq!(
+            report.location,
+            Some(ArgvSpan {
+                index: 1,
+                start: 0,
+                end: 6,
+            })
+        );
+        assert!(report.rendered.starts_with("error: unexpected argument"));
+    }
+
+    #[test]
+    fn a_structured_report_locates_an_attached_invalid_value() {
+        let owned = [
+            std::ffi::OsString::from("use"),
+            std::ffi::OsString::from("--jobs=wat"),
+            std::ffi::OsString::from("tool"),
+        ];
+        let argv = owned
+            .iter()
+            .map(|word| word.as_os_str())
+            .collect::<Vec<_>>();
+        let error = Error::InvalidValue(Box::new(crate::InvalidValue {
+            name: "jobs",
+            value: "wat".to_string(),
+            reason: "invalid digit found in string".to_string(),
+        }));
+        let report = report(&SPEC, &argv, &error);
+        assert_eq!(report.code, Code::InvalidValue);
+        assert_eq!(
+            report.location,
+            Some(ArgvSpan {
+                index: 1,
+                start: 7,
+                end: 10,
+            })
+        );
+    }
+
+    #[test]
+    fn a_structured_report_finds_the_refused_value_in_a_variadic() {
+        let owned = [
+            std::ffi::OsString::from("use"),
+            std::ffi::OsString::from("tool"),
+            std::ffi::OsString::from("bash"),
+            std::ffi::OsString::from("fish"),
+        ];
+        let argv = owned
+            .iter()
+            .map(|word| word.as_os_str())
+            .collect::<Vec<_>>();
+        let error = Error::InvalidChoice {
+            name: "SHELLS",
+            choices: &["bash", "zsh"],
+        };
+        assert_eq!(
+            report(&SPEC, &argv, &error).location,
+            Some(ArgvSpan {
+                index: 3,
+                start: 0,
+                end: 4,
+            })
+        );
+    }
+
+    #[test]
+    fn a_missing_flag_value_points_at_the_flag() {
+        let owned = [
+            std::ffi::OsString::from("use"),
+            std::ffi::OsString::from("--jobs"),
+        ];
+        let argv = owned
+            .iter()
+            .map(|word| word.as_os_str())
+            .collect::<Vec<_>>();
+        let error = Error::MissingFlagValue { flag: &JOBS };
+        assert_eq!(
+            report(&SPEC, &argv, &error).location,
+            Some(ArgvSpan {
+                index: 1,
+                start: 0,
+                end: 6,
+            })
+        );
     }
 
     #[test]

--- a/argv/src/diagnostic.rs
+++ b/argv/src/diagnostic.rs
@@ -522,8 +522,12 @@ fn value_span(
     argv: &[&std::ffi::OsStr],
     name: &str,
     wanted: impl Fn(&str) -> bool,
+    view: Option<&ViewMeta<'_>>,
 ) -> Option<ArgvSpan> {
     let mut parser = crate::Parser::new(root, argv);
+    if let Some(view) = view {
+        parser = parser.with_view(view);
+    }
     while let Some(event) = parser.next_event() {
         let value = match event {
             Ok(crate::Event::Arg { arg, value, .. }) if arg.name == name => value,
@@ -542,9 +546,25 @@ fn value_span(
     None
 }
 
-fn flag_span(argv: &[&std::ffi::OsStr], flag: &crate::Flag<'_>) -> Option<ArgvSpan> {
-    argv.iter().enumerate().rev().find_map(|(index, word)| {
-        let bytes = word.as_encoded_bytes();
+fn flag_span(
+    root: &Command<'_>,
+    argv: &[&std::ffi::OsStr],
+    flag: &crate::Flag<'_>,
+    view: Option<&ViewMeta<'_>>,
+) -> Option<ArgvSpan> {
+    let mut parser = crate::Parser::new(root, argv);
+    if let Some(view) = view {
+        parser = parser.with_view(view);
+    }
+    while let Some(event) = parser.next_event() {
+        let Err(Error::MissingFlagValue { flag: missing }) = event else {
+            continue;
+        };
+        if !core::ptr::eq(missing, flag) {
+            return None;
+        }
+        let index = parser.pos.checked_sub(1)?;
+        let bytes = argv.get(index)?.as_encoded_bytes();
         if let Some(long) = bytes.strip_prefix(b"--") {
             let name = long.split(|byte| *byte == b'=').next().unwrap_or(long);
             return flag.longs.iter().find_map(|candidate| {
@@ -556,14 +576,15 @@ fn flag_span(argv: &[&std::ffi::OsStr], flag: &crate::Flag<'_>) -> Option<ArgvSp
             });
         }
         let shorts = bytes.strip_prefix(b"-")?;
-        shorts.iter().enumerate().find_map(|(offset, short)| {
+        return shorts.iter().enumerate().find_map(|(offset, short)| {
             flag.shorts.contains(short).then_some(ArgvSpan {
                 index,
                 start: offset + 1,
                 end: offset + 2,
             })
-        })
-    })
+        });
+    }
+    None
 }
 
 fn code(error: &Error<'_, '_>) -> Code {
@@ -615,16 +636,29 @@ fn subject(error: &Error<'_, '_>) -> Option<String> {
     }
 }
 
-fn location(spec: &Spec<'_>, argv: &[&std::ffi::OsStr], error: &Error<'_, '_>) -> Option<ArgvSpan> {
+fn location(
+    spec: &Spec<'_>,
+    argv: &[&std::ffi::OsStr],
+    error: &Error<'_, '_>,
+    view: Option<&ViewMeta<'_>>,
+) -> Option<ArgvSpan> {
     match error {
         Error::UnknownFlag { token } | Error::UnexpectedArg { token } => span_of_slice(argv, token),
-        Error::MissingFlagValue { flag } => flag_span(argv, flag),
-        Error::InvalidChoice { name, choices } => {
-            value_span(spec.root.cmd, argv, name, |value| !choices.contains(&value))
-        }
-        Error::InvalidValue(invalid) => value_span(spec.root.cmd, argv, invalid.name, |value| {
-            value == invalid.value
-        }),
+        Error::MissingFlagValue { flag } => flag_span(spec.root.cmd, argv, flag, view),
+        Error::InvalidChoice { name, choices } => value_span(
+            spec.root.cmd,
+            argv,
+            name,
+            |value| !choices.contains(&value),
+            view,
+        ),
+        Error::InvalidValue(invalid) => value_span(
+            spec.root.cmd,
+            argv,
+            invalid.name,
+            |value| value == invalid.value,
+            view,
+        ),
         _ => None,
     }
 }
@@ -638,8 +672,38 @@ pub fn report(spec: &Spec<'_>, argv: &[&std::ffi::OsStr], error: &Error<'_, '_>)
     Report {
         code: code(error),
         subject: subject(error),
-        location: location(spec, argv, error),
+        location: location(spec, argv, error, None),
         rendered: render(spec, argv, error, Style::PLAIN),
+    }
+}
+
+/// Describe a parse outcome through a spec-declared executable view.
+///
+/// `argv` is the original full argv, including the view executable as argv0. Locations address
+/// that original slice; synthetic words from the view's canonical root are never exposed.
+pub fn report_view<'a>(
+    spec: &'a Spec<'a>,
+    argv: &[&std::ffi::OsStr],
+    error: &Error<'_, '_>,
+    view: &'a ViewMeta<'a>,
+) -> Report {
+    let words = argv.get(1..).unwrap_or_default();
+    let root_depth = view.root.split_ascii_whitespace().count();
+    let mut rewritten = Vec::with_capacity(words.len() + root_depth);
+    rewritten.extend(view.root.split_ascii_whitespace().map(std::ffi::OsStr::new));
+    rewritten.extend_from_slice(words);
+    let location = location(spec, &rewritten, error, Some(view)).and_then(|span| {
+        (span.index >= root_depth).then_some(ArgvSpan {
+            index: span.index - root_depth + 1,
+            start: span.start,
+            end: span.end,
+        })
+    });
+    Report {
+        code: code(error),
+        subject: subject(error),
+        location,
+        rendered: render_inner(spec, &rewritten, error, Style::PLAIN, Some(view)),
     }
 }
 
@@ -1323,6 +1387,84 @@ mod tests {
                 index: 1,
                 start: 0,
                 end: 6,
+            })
+        );
+    }
+
+    #[test]
+    fn a_repeated_missing_flag_points_at_the_occurrence_the_parser_refused() {
+        let owned = [
+            std::ffi::OsString::from("use"),
+            std::ffi::OsString::from("--jobs"),
+            std::ffi::OsString::from("--jobs"),
+        ];
+        let argv = owned
+            .iter()
+            .map(|word| word.as_os_str())
+            .collect::<Vec<_>>();
+        let error = Error::MissingFlagValue { flag: &JOBS };
+        assert_eq!(
+            report(&SPEC, &argv, &error).location,
+            Some(ArgvSpan {
+                index: 1,
+                start: 0,
+                end: 6,
+            })
+        );
+    }
+
+    #[test]
+    fn view_reports_map_invalid_values_back_to_the_original_argv() {
+        static VIEW: ViewMeta = ViewMeta {
+            id: "runner",
+            name: "runner",
+            bin: "runner",
+            root: "use",
+            all_globals: false,
+            globals: &[],
+        };
+
+        let invalid_owned = [
+            std::ffi::OsString::from("runner"),
+            std::ffi::OsString::from("--jobs=wat"),
+        ];
+        let invalid_argv = invalid_owned
+            .iter()
+            .map(|word| word.as_os_str())
+            .collect::<Vec<_>>();
+        let invalid = Error::InvalidValue(Box::new(crate::InvalidValue {
+            name: "jobs",
+            value: "wat".to_string(),
+            reason: "invalid digit found in string".to_string(),
+        }));
+        assert_eq!(
+            report_view(&SPEC, &invalid_argv, &invalid, &VIEW).location,
+            Some(ArgvSpan {
+                index: 1,
+                start: 7,
+                end: 10,
+            })
+        );
+
+        let choice_owned = [
+            std::ffi::OsString::from("runner"),
+            std::ffi::OsString::from("tool"),
+            std::ffi::OsString::from("fish"),
+        ];
+        let choice_argv = choice_owned
+            .iter()
+            .map(|word| word.as_os_str())
+            .collect::<Vec<_>>();
+        let choice = Error::InvalidChoice {
+            name: "SHELLS",
+            choices: &["bash", "zsh"],
+        };
+        assert_eq!(
+            report_view(&SPEC, &choice_argv, &choice, &VIEW).location,
+            Some(ArgvSpan {
+                index: 2,
+                start: 0,
+                end: 4,
             })
         );
     }

--- a/argv/src/diagnostic.rs
+++ b/argv/src/diagnostic.rs
@@ -677,6 +677,18 @@ pub fn report(spec: &Spec<'_>, argv: &[&std::ffi::OsStr], error: &Error<'_, '_>)
     }
 }
 
+fn view_argv<'a>(
+    argv: &'a [&'a std::ffi::OsStr],
+    view: &'a ViewMeta<'_>,
+) -> (Vec<&'a std::ffi::OsStr>, usize) {
+    let words = argv.get(1..).unwrap_or_default();
+    let root_depth = view.root.split_ascii_whitespace().count();
+    let mut rewritten = Vec::with_capacity(words.len() + root_depth);
+    rewritten.extend(view.root.split_ascii_whitespace().map(std::ffi::OsStr::new));
+    rewritten.extend_from_slice(words);
+    (rewritten, root_depth)
+}
+
 /// Describe a parse outcome through a spec-declared executable view.
 ///
 /// `argv` is the original full argv, including the view executable as argv0. Locations address
@@ -687,11 +699,7 @@ pub fn report_view<'a>(
     error: &Error<'_, '_>,
     view: &'a ViewMeta<'a>,
 ) -> Report {
-    let words = argv.get(1..).unwrap_or_default();
-    let root_depth = view.root.split_ascii_whitespace().count();
-    let mut rewritten = Vec::with_capacity(words.len() + root_depth);
-    rewritten.extend(view.root.split_ascii_whitespace().map(std::ffi::OsStr::new));
-    rewritten.extend_from_slice(words);
+    let (rewritten, root_depth) = view_argv(argv, view);
     let location = location(spec, &rewritten, error, Some(view)).and_then(|span| {
         (span.index >= root_depth).then_some(ArgvSpan {
             index: span.index - root_depth + 1,
@@ -765,11 +773,7 @@ pub fn render_view<'a>(
     style: Style,
     view: &'a ViewMeta<'a>,
 ) -> String {
-    let words = argv.get(1..).unwrap_or_default();
-    let mut rewritten =
-        Vec::with_capacity(words.len() + view.root.split_ascii_whitespace().count());
-    rewritten.extend(view.root.split_ascii_whitespace().map(std::ffi::OsStr::new));
-    rewritten.extend_from_slice(words);
+    let (rewritten, _) = view_argv(argv, view);
     render_inner(spec, &rewritten, error, style, Some(view))
 }
 
@@ -1396,6 +1400,7 @@ mod tests {
         let owned = [
             std::ffi::OsString::from("use"),
             std::ffi::OsString::from("--jobs"),
+            std::ffi::OsString::from("4"),
             std::ffi::OsString::from("--jobs"),
         ];
         let argv = owned
@@ -1406,7 +1411,7 @@ mod tests {
         assert_eq!(
             report(&SPEC, &argv, &error).location,
             Some(ArgvSpan {
-                index: 1,
+                index: 3,
                 start: 0,
                 end: 6,
             })

--- a/docs/rust/help.md
+++ b/docs/rust/help.md
@@ -251,3 +251,24 @@ Without `diagnostics` (for example after `default-features = false`, or when dep
 `usage-argv` alone), it falls back to the `Debug` form of the error — fine for internal tools,
 not what you want to ship. `parse()` prints the rendered failure to **stderr** and exits **2**,
 clap's status, so scripts that check for it keep working.
+
+### Structured diagnostics
+
+Editors, JSON reporters, NAPI/WASM hosts, and diagnostic frameworks can read the same failure as
+fields instead of scraping its terminal rendering:
+
+```rust
+let error = Ex::parse_from(&argv).unwrap_err();
+let report = usage::diagnostic::report(Ex::spec(), &argv, &error);
+
+assert_eq!(report.code.as_str(), "invalid_value");
+if let Some(location) = report.location {
+    // The argv word and the exact byte range within it.
+    eprintln!("argv[{}], bytes {}..{}", location.index, location.start, location.end);
+}
+```
+
+`Report` also carries the diagnostic's subject and its ordinary plain-text rendering. Locations
+use byte offsets into `OsStr`, so they remain exact for non-UTF-8 argv. A location is intentionally
+absent when no single token is responsible, such as a missing required argument or a conflict
+between two otherwise-valid flags.


### PR DESCRIPTION
## Summary

- add a stable `diagnostic::Code` for every parser error/help outcome
- add `diagnostic::Report` with a machine-readable code, subject, optional argv byte span, and the existing plain human rendering
- locate exact words, attached values, refused variadic choices, and flags missing their values without changing the hot-path `Error` or parser allocation behavior
- document the API for JSON reporters, editors, NAPI/WASM hosts, and integrations with diagnostic frameworks

`ArgvSpan` indexes the exact argv slice passed by the caller and uses byte offsets into `OsStr`, preserving non-UTF-8 command lines. Omissions and multi-token relationship failures honestly return no single location.

## Example

```rust
let error = Cli::parse_from(&argv).unwrap_err();
let report = usage::diagnostic::report(Cli::spec(), &argv, &error);

assert_eq!(report.code.as_str(), "invalid_value");
if let Some(span) = report.location {
    emit_label(span.index, span.start..span.end);
}
```

## Validation

- `mise run ci`
- unit coverage for unknown words, attached invalid values, refused values inside a variadic, and missing flag values
- existing no-allocation parser test remains green

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New public diagnostic API with pointer-based argv span recovery and extra parser walks on the cold path. Parse allocation behavior and existing error rendering stay the same.
> 
> **Overview**
> Adds a machine-readable diagnostic layer so hosts can consume parse failures without scraping terminal text or matching `Error` variants.
> 
> `diagnostic::report` / `report_view` return a `Report` with a stable `Code` (`as_str()` snake_case), optional subject, optional `ArgvSpan` (argv index plus byte offsets into `OsStr`), and the existing plain rendering. Locations cover unknown tokens, attached invalid values, refused variadic choices, and the refused occurrence of a missing flag value; omissions and multi-token conflicts stay location-less. View reports remap spans onto the original argv so synthetic root words are never exposed.
> 
> The hot-path `Error` type is unchanged. View argv rewriting is shared with `render_view`. Docs and unit tests cover the new API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09c42732d6abca13dd6959b0c7383072a1bf6eb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added structured diagnostics with stable error codes, readable messages, affected arguments, and precise byte locations.
  - Diagnostics identify unknown flags, invalid values, unsupported choices, and missing values.
  - Locations remain accurate for attached, variadic, non-UTF-8, and view-generated arguments.
  - Repeated missing flags now identify the exact refused occurrence.

- **Documentation**
  - Added guidance for using structured diagnostics and interpreting codes, subjects, rendered messages, and byte locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->