### PR TITLE
feat(help): expose addressable help topics

### DIFF
--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -1077,6 +1077,18 @@ fn short_help_with(
     chain: &[&CommandMeta<'_>],
     inherit_version_actions: bool,
 ) -> String {
+    assemble(
+        spec,
+        &short_sections(spec, path, chain, inherit_version_actions),
+    )
+}
+
+fn short_sections(
+    spec: &Spec<'_>,
+    path: &[&str],
+    chain: &[&CommandMeta<'_>],
+    inherit_version_actions: bool,
+) -> Sections {
     let meta = *chain.last().expect("a page is always about some command");
     let (own, inherited) = own_and_global(chain, inherit_version_actions);
     let own: Vec<_> = own
@@ -1275,7 +1287,7 @@ fn short_help_with(
         let _ = writeln!(sections.after_help, "\n{after}");
     }
 
-    assemble(spec, &sections)
+    sections
 }
 
 /// The list of subcommands, and the `help` command every CLI with subcommands has.
@@ -1809,6 +1821,18 @@ fn long_help_with(
     chain: &[&CommandMeta<'_>],
     inherit_version_actions: bool,
 ) -> String {
+    assemble(
+        spec,
+        &long_sections(spec, path, chain, inherit_version_actions),
+    )
+}
+
+fn long_sections(
+    spec: &Spec<'_>,
+    path: &[&str],
+    chain: &[&CommandMeta<'_>],
+    inherit_version_actions: bool,
+) -> Sections {
     let meta = *chain.last().expect("a page is always about some command");
     let (own, inherited) = own_and_global(chain, inherit_version_actions);
     let own: Vec<_> = own
@@ -2027,7 +2051,7 @@ fn long_help_with(
         }
     }
 
-    assemble(spec, &sections)
+    sections
 }
 
 /// Write text with every line indented, leaving blank lines blank.
@@ -2681,6 +2705,142 @@ fn own_and_global<'a>(
     }
     own.extend(supplied_entries(here.cmd, &claimed));
     (own, inherited)
+}
+
+/// A named section of one command's help page.
+///
+/// `id` is a deterministic, command-local spelling suitable for `tool help <id>` and completion;
+/// `title` is the heading users see. Topics include the ordinary Commands, Arguments, Flags,
+/// and Global flags sections plus every declared `help_heading` group that has visible entries.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Topic {
+    pub id: String,
+    pub title: String,
+}
+
+fn topic_id(title: &str) -> String {
+    let mut out = String::new();
+    let mut separator = false;
+    for ch in title.chars() {
+        if ch.is_alphanumeric() {
+            if separator && !out.is_empty() {
+                out.push('-');
+            }
+            out.extend(ch.to_lowercase());
+            separator = false;
+        } else {
+            separator = true;
+        }
+    }
+    if out.is_empty() {
+        "topic".to_string()
+    } else {
+        out
+    }
+}
+
+fn topic_blocks(sections: &Sections) -> Vec<(String, String)> {
+    let mut topics: Vec<(String, String)> = Vec::new();
+    for section in [&sections.commands, &sections.args, &sections.flags] {
+        let mut title: Option<&str> = None;
+        let mut block = String::new();
+        let finish =
+            |title: Option<&str>, block: &mut String, topics: &mut Vec<(String, String)>| {
+                let Some(title) = title else {
+                    block.clear();
+                    return;
+                };
+                let text = block.trim().to_string();
+                if text.is_empty() {
+                    block.clear();
+                    return;
+                }
+                if let Some((_, existing)) = topics.iter_mut().find(|(known, _)| known == title) {
+                    let continuation = text
+                        .split_once('\n')
+                        .map_or(text.as_str(), |(_, body)| body);
+                    if !existing.is_empty() {
+                        existing.push_str("\n\n");
+                    }
+                    existing.push_str(continuation);
+                } else {
+                    topics.push((title.to_string(), text));
+                }
+                block.clear();
+            };
+        for line in section.lines() {
+            let heading = (!line.starts_with(char::is_whitespace))
+                .then(|| line.strip_suffix(':'))
+                .flatten();
+            if let Some(heading) = heading {
+                finish(title, &mut block, &mut topics);
+                title = Some(heading);
+            }
+            if title.is_some() {
+                if !block.is_empty() {
+                    block.push('\n');
+                }
+                block.push_str(line);
+            }
+        }
+        finish(title, &mut block, &mut topics);
+    }
+    topics
+}
+
+fn topics_with_blocks(
+    spec: &Spec<'_>,
+    cmd: &Command<'_>,
+    long: bool,
+) -> Option<Vec<(Topic, String)>> {
+    let (path, chain) = find(spec, cmd)?;
+    let sections = if long {
+        long_sections(spec, &path, &chain, false)
+    } else {
+        short_sections(spec, &path, &chain, false)
+    };
+    let mut used = Vec::<String>::new();
+    Some(
+        topic_blocks(&sections)
+            .into_iter()
+            .map(|(title, block)| {
+                let base = topic_id(&title);
+                let mut id = base.clone();
+                let mut suffix = 2;
+                while used.contains(&id) {
+                    id = format!("{base}-{suffix}");
+                    suffix += 1;
+                }
+                used.push(id.clone());
+                (Topic { id, title }, block)
+            })
+            .collect(),
+    )
+}
+
+/// List the addressable topics on one command's short or long help page.
+pub fn topics(spec: &Spec<'_>, cmd: &Command<'_>, long: bool) -> Option<Vec<Topic>> {
+    Some(
+        topics_with_blocks(spec, cmd, long)?
+            .into_iter()
+            .map(|(topic, _)| topic)
+            .collect(),
+    )
+}
+
+/// Render one addressable help topic by its [`Topic::id`] or visible title.
+///
+/// The result contains the heading and its visible entries, independent of the page's
+/// `help_template`. This makes a topic suitable for `tool help configuration`, an editor panel,
+/// or an interactive picker without making the group a fake subcommand.
+pub fn render_topic(spec: &Spec<'_>, cmd: &Command<'_>, topic: &str, long: bool) -> Option<String> {
+    topics_with_blocks(spec, cmd, long)?
+        .into_iter()
+        .find(|(known, _)| known.id == topic || known.title.eq_ignore_ascii_case(topic))
+        .map(|(_, mut block)| {
+            block.push('\n');
+            block
+        })
 }
 
 /// The page a help request asks for, ready to print.

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -2751,18 +2751,19 @@ fn topic_blocks(sections: &Sections) -> Vec<(String, String)> {
                     return;
                 };
                 let text = block.trim().to_string();
-                if text.is_empty() {
+                let Some((_, body)) = text.split_once('\n') else {
+                    block.clear();
+                    return;
+                };
+                if body.trim().is_empty() {
                     block.clear();
                     return;
                 }
                 if let Some((_, existing)) = topics.iter_mut().find(|(known, _)| known == title) {
-                    let continuation = text
-                        .split_once('\n')
-                        .map_or(text.as_str(), |(_, body)| body);
                     if !existing.is_empty() {
                         existing.push_str("\n\n");
                     }
-                    existing.push_str(continuation);
+                    existing.push_str(body);
                 } else {
                     topics.push((title.to_string(), text));
                 }

--- a/conformance/tests/help_topics.rs
+++ b/conformance/tests/help_topics.rs
@@ -1,0 +1,71 @@
+#![allow(dead_code)]
+
+use usage_argv::help;
+use usage_derive::{Cli, Subcommands};
+
+#[derive(Cli)]
+#[usage(bin = "guide")]
+struct Guide {
+    /// Configuration file
+    #[usage(long, help_heading = "Configuration")]
+    config: Option<String>,
+
+    /// Runtime profile
+    #[usage(arg, help_heading = "Configuration")]
+    profile: Option<String>,
+
+    /// Internal switch
+    #[usage(long, hide, help_heading = "Internals")]
+    internal: bool,
+
+    #[usage(subcommand)]
+    command: Option<Command>,
+}
+
+#[derive(Subcommands)]
+enum Command {
+    /// Clear cached data
+    #[usage(help_heading = "Maintenance")]
+    Clean,
+    /// Print current state
+    Status,
+}
+
+#[test]
+fn visible_help_groups_and_standard_sections_are_addressable() {
+    let topics = help::topics(Guide::spec(), Guide::command(), true).expect("the root command");
+    let listed: Vec<_> = topics
+        .iter()
+        .map(|topic| (topic.id.as_str(), topic.title.as_str()))
+        .collect();
+    assert!(listed.contains(&("commands", "Commands")), "{listed:?}");
+    assert!(
+        listed.contains(&("maintenance", "Maintenance")),
+        "{listed:?}"
+    );
+    assert!(
+        listed.contains(&("configuration", "Configuration")),
+        "{listed:?}"
+    );
+    assert!(!listed.iter().any(|(_, title)| *title == "Internals"));
+}
+
+#[test]
+fn one_topic_combines_argument_and_flag_groups_with_the_same_heading() {
+    let topic = help::render_topic(Guide::spec(), Guide::command(), "configuration", true)
+        .expect("the declared heading");
+    assert!(topic.starts_with("Configuration:\n"), "{topic}");
+    assert!(topic.contains("--config <CONFIG>"), "{topic}");
+    assert!(topic.contains("[PROFILE]"), "{topic}");
+    assert!(!topic.contains("--internal"), "{topic}");
+    assert!(!topic.contains("clean"), "{topic}");
+    assert_eq!(topic.matches("Configuration:").count(), 1, "{topic}");
+
+    let by_title = help::render_topic(Guide::spec(), Guide::command(), "Configuration", true);
+    assert_eq!(by_title.as_deref(), Some(topic.as_str()));
+}
+
+#[test]
+fn a_topic_that_is_not_on_the_page_is_absent() {
+    assert!(help::render_topic(Guide::spec(), Guide::command(), "internals", false).is_none());
+}

--- a/conformance/tests/help_topics.rs
+++ b/conformance/tests/help_topics.rs
@@ -31,6 +31,20 @@ enum Command {
     Status,
 }
 
+#[derive(Cli)]
+#[usage(bin = "custom", disable_help_subcommand)]
+struct OnlyCustomCommands {
+    #[usage(subcommand)]
+    command: Option<OnlyCustomCommand>,
+}
+
+#[derive(Subcommands)]
+enum OnlyCustomCommand {
+    /// Run the task
+    #[usage(help_heading = "Actions")]
+    Run,
+}
+
 #[test]
 fn visible_help_groups_and_standard_sections_are_addressable() {
     let topics = help::topics(Guide::spec(), Guide::command(), true).expect("the root command");
@@ -68,4 +82,16 @@ fn one_topic_combines_argument_and_flag_groups_with_the_same_heading() {
 #[test]
 fn a_topic_that_is_not_on_the_page_is_absent() {
     assert!(help::render_topic(Guide::spec(), Guide::command(), "internals", false).is_none());
+}
+
+#[test]
+fn an_empty_standard_heading_is_not_a_topic() {
+    let topics = help::topics(
+        OnlyCustomCommands::spec(),
+        OnlyCustomCommands::command(),
+        true,
+    )
+    .expect("the root command");
+    assert!(topics.iter().any(|topic| topic.title == "Actions"));
+    assert!(!topics.iter().any(|topic| topic.title == "Commands"));
 }

--- a/docs/rust/help.md
+++ b/docs/rust/help.md
@@ -219,6 +219,35 @@ than pasted. The sections map like this:
 clap keeps its `get_help_template` getter private, so `clap_usage` cannot recover a template from
 a `clap::Command` — a template is one of the settings to carry across by hand when migrating.
 
+### Addressing one help topic
+
+Named help groups are available independently of the complete page. This is useful for a
+`tool help configuration` command, an editor panel, an interactive picker, or completion without
+modeling a presentation group as a fake subcommand:
+
+```rust
+let topics = usage::help::topics(Cli::spec(), Cli::command(), true)
+    .expect("this command belongs to the spec");
+
+for topic in topics {
+    println!("{}\t{}", topic.id, topic.title);
+}
+
+if let Some(text) = usage::help::render_topic(
+    Cli::spec(),
+    Cli::command(),
+    "configuration",
+    true,
+) {
+    print!("{text}");
+}
+```
+
+Each visible `help_heading` becomes a topic. Ordinary Commands, Arguments, Flags, and Global flags
+sections are topics too. IDs are command-local lowercase slugs; `render_topic` also accepts the
+visible title case-insensitively. If an argument group and flag group share one heading, the topic
+combines both blocks in their normal help order. Hidden entries never create or enter a topic.
+
 ## Version
 
 Declaring `version` (or bare `version`, which reads `CARGO_PKG_VERSION`) gives the root command


### PR DESCRIPTION
## Summary

- expose deterministic, command-local help topic IDs and visible titles
- render individual standard or custom help sections without inventing fake subcommands
- merge argument and flag groups that share a heading, while preserving hidden-entry behavior
- document and test topic discovery and rendering

## Testing

- `mise run ci`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive help-rendering API with tests; existing full-page help output is unchanged aside from an internal split of section assembly.
> 
> **Overview**
> Lets callers address one help section at a time via `help::topics` and `help::render_topic`, so a CLI can do `tool help configuration`, completion, or a picker without inventing fake subcommands.
> 
> Standard Commands/Arguments/Flags/Global flags sections and visible `help_heading` groups become topics with command-local slug IDs. Lookup also accepts the visible title case-insensitively. Shared headings across args and flags merge into one block; hidden entries never appear. Empty standard headings are omitted.
> 
> Short/long help still assemble the full page; section building is split out so topics reuse the same layout. Documented in `docs/rust/help.md` with conformance tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42760439f4bb019d0858eba65363edc8a2f9d192. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->