### PR TITLE
feat(spec): add surface availability metadata

### DIFF
--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -835,6 +835,10 @@ pub struct CommandMeta<'a> {
     pub hide: bool,
     /// Help section this command appears under in its parent's command list.
     pub help_heading: Option<&'a str>,
+    /// Named audience or compatibility surface this command belongs to.
+    pub surface: Option<&'a str>,
+    /// Descriptive availability conditions; they do not affect parsing.
+    pub available_if: &'a [&'a str],
     /// Explicit placement within the parent's command section.
     pub display_order: Option<usize>,
     /// What running this does to the world, for a caller deciding whether to
@@ -921,6 +925,8 @@ impl CommandMeta<'_> {
         hidden_aliases: &[],
         hide: false,
         help_heading: None,
+        surface: None,
+        available_if: &[],
         display_order: None,
         effect: None,
         mount: None,
@@ -1087,6 +1093,10 @@ pub struct FlagMeta<'a> {
     /// Heading to list this flag under in help output. Presentational: it groups
     /// a long flag list into sections and changes nothing about parsing.
     pub help_heading: Option<&'a str>,
+    /// Named audience or compatibility surface this flag belongs to.
+    pub surface: Option<&'a str>,
+    /// Descriptive availability conditions; they do not affect parsing.
+    pub available_if: &'a [&'a str],
     pub effect: Option<Effect>,
 }
 
@@ -1146,6 +1156,8 @@ impl FlagMeta<'_> {
         required_unless: &[],
         required_unless_all: &[],
         help_heading: None,
+        surface: None,
+        available_if: &[],
         effect: None,
     };
 }
@@ -1228,6 +1240,10 @@ pub struct ArgMeta<'a> {
     pub delimiter: Option<char>,
     /// Heading to list this argument under in help output.
     pub help_heading: Option<&'a str>,
+    /// Named audience or compatibility surface this argument belongs to.
+    pub surface: Option<&'a str>,
+    /// Descriptive availability conditions; they do not affect parsing.
+    pub available_if: &'a [&'a str],
     /// What answers for this argument when a shell asks. See [`FlagMeta::complete`].
     pub complete: Option<Completer>,
     /// A built-in completion class such as `path` or `dir`.
@@ -1275,6 +1291,8 @@ impl ArgMeta<'_> {
         var_max: None,
         delimiter: None,
         help_heading: None,
+        surface: None,
+        available_if: &[],
     };
 }
 
@@ -1576,6 +1594,17 @@ impl Spec<'_> {
         }
         if self.root.flatten_help {
             writeln!(out, "flatten_help #true")?;
+        }
+        if let Some(surface) = self.root.surface {
+            prop(out, "surface", surface)?;
+        }
+        if !self.root.available_if.is_empty() {
+            indent(out, 0)?;
+            write!(out, "available_if")?;
+            for condition in self.root.available_if {
+                write!(out, " {}", quoted(condition))?;
+            }
+            out.push('\n');
         }
         if let Some(width) = self.root.term_width {
             writeln!(out, "term_width {width}")?;
@@ -1975,6 +2004,10 @@ fn write_command<'a>(
     if let Some(heading) = meta.help_heading {
         write!(out, " help_heading={}", quoted(heading))?;
     }
+    if let Some(surface) = meta.surface {
+        write!(out, " surface={}", quoted(surface))?;
+    }
+    write_single_list(out, "available_if", meta.available_if)?;
     let effect = w
         .overlays
         .iter()
@@ -2065,6 +2098,7 @@ fn write_command<'a>(
     out.push_str(" {\n");
 
     let inner = depth + 1;
+    write_many_list(out, "available_if", meta.available_if, inner)?;
     for alias in meta.cmd.aliases {
         indent(out, inner)?;
         write!(out, "alias {}", quoted(alias))?;
@@ -2297,6 +2331,10 @@ fn write_flag(
     if let Some(heading) = meta.help_heading.or(inherited_heading) {
         write!(out, " help_heading={}", quoted(heading))?;
     }
+    if let Some(surface) = meta.surface {
+        write!(out, " surface={}", quoted(surface))?;
+    }
+    write_single_list(out, "available_if", meta.available_if)?;
     if let Some(order) = meta.display_order {
         write!(out, " display_order={order}")?;
     }
@@ -2369,6 +2407,7 @@ fn write_flag(
         || meta.required_unless_all.len() > 1
         || meta.env_fallback.len() > 1
         || meta.deprecated_env.len() > 1;
+    let has_children = has_children || meta.available_if.len() > 1;
     if !has_children {
         out.push('\n');
         return Ok(());
@@ -2449,6 +2488,7 @@ fn write_flag(
     write_many_list(out, "required_unless_all", meta.required_unless_all, inner)?;
     write_many_list(out, "env_fallback", meta.env_fallback, inner)?;
     write_many_list(out, "deprecated_env", meta.deprecated_env, inner)?;
+    write_many_list(out, "available_if", meta.available_if, inner)?;
     if meta.flag.takes_value {
         indent(out, inner)?;
         let exact = exact_arity(meta.value_var_min, meta.value_var_max);
@@ -2618,6 +2658,10 @@ fn write_arg(out: &mut String, meta: &ArgMeta<'_>, depth: usize) -> core::fmt::R
     if let Some(heading) = meta.help_heading {
         write!(out, " help_heading={}", quoted(heading))?;
     }
+    if let Some(surface) = meta.surface {
+        write!(out, " surface={}", quoted(surface))?;
+    }
+    write_single_list(out, "available_if", meta.available_if)?;
     if let Some(order) = meta.display_order {
         write!(out, " display_order={order}")?;
     }
@@ -2654,6 +2698,7 @@ fn write_arg(out: &mut String, meta: &ArgMeta<'_>, depth: usize) -> core::fmt::R
         || meta.required_unless_all.len() > 1
         || meta.env_fallback.len() > 1
         || meta.deprecated_env.len() > 1;
+    let has_children = has_children || meta.available_if.len() > 1;
     if !has_children {
         out.push('\n');
         return Ok(());
@@ -2701,6 +2746,7 @@ fn write_arg(out: &mut String, meta: &ArgMeta<'_>, depth: usize) -> core::fmt::R
     write_many_list(out, "required_unless_all", meta.required_unless_all, inner)?;
     write_many_list(out, "env_fallback", meta.env_fallback, inner)?;
     write_many_list(out, "deprecated_env", meta.deprecated_env, inner)?;
+    write_many_list(out, "available_if", meta.available_if, inner)?;
     write_many_defaults(out, meta.default, inner)?;
     write_choices(
         out,

--- a/conformance/src/tables.rs
+++ b/conformance/src/tables.rs
@@ -154,6 +154,8 @@ pub fn build(
         hide: cmd.hide,
         display_order: cmd.display_order,
         help_heading: opt(&cmd.help_heading),
+        surface: opt(&cmd.surface),
+        available_if: strs(&cmd.available_if),
         effect: cmd.effect.map(effect),
         // A command carries at most one mount in the tables; a spec may list several, and the
         // first is the one the tables can hold.
@@ -466,6 +468,8 @@ fn flag_meta(
         required_unless: strs(&f.required_unless),
         required_unless_all: strs(&f.required_unless_all),
         help_heading: opt(&f.help_heading),
+        surface: opt(&f.surface),
+        available_if: strs(&f.available_if),
         display_order: f.display_order,
         effect: f.effect.map(effect),
         complete_type: complete_type(completers, &f.name, arg.map(|a| a.name.as_str())),
@@ -534,6 +538,8 @@ fn arg_meta(
         var_min: a.var_min,
         var_max: a.var_max,
         help_heading: opt(&a.help_heading),
+        surface: opt(&a.surface),
+        available_if: strs(&a.available_if),
         complete_type: complete_type(completers, &a.name, None),
         complete: NO_COMPLETER,
     }

--- a/conformance/tests/surface_metadata.rs
+++ b/conformance/tests/surface_metadata.rs
@@ -82,3 +82,17 @@ fn annotations_do_not_change_parsing_or_help_visibility() {
         .expect("root help");
     assert!(help.contains("doctor"), "{help}");
 }
+
+#[test]
+fn root_annotations_with_kdl_sensitive_strings_round_trip() {
+    let mut spec: LibSpec = SurfaceDemo::to_kdl().parse().expect("generated spec");
+    spec.cmd.surface = Some("-private".into());
+    spec.cmd.available_if = vec!["feature\u{1b}[0m".into()];
+
+    let written = spec.to_string();
+    let reparsed: LibSpec = written
+        .parse()
+        .unwrap_or_else(|error| panic!("written spec does not parse: {error}\n{written}"));
+    assert_eq!(reparsed.cmd.surface, spec.cmd.surface);
+    assert_eq!(reparsed.cmd.available_if, spec.cmd.available_if);
+}

--- a/conformance/tests/surface_metadata.rs
+++ b/conformance/tests/surface_metadata.rs
@@ -1,0 +1,84 @@
+//! Audience and availability annotations remain descriptive metadata.
+
+use std::ffi::OsStr;
+
+use usage::Spec as LibSpec;
+use usage_derive::{Args, Cli, Subcommands};
+
+#[derive(Args)]
+struct Doctor {
+    /// Emit a machine-readable report
+    #[usage(long, surface = "automation", available_if("json-feature"))]
+    json: bool,
+
+    /// Optional state directory
+    #[usage(surface = "advanced", available_if("filesystem", "writable-state"))]
+    state: Option<String>,
+}
+
+#[derive(Subcommands)]
+enum Command {
+    /// Inspect internal state
+    #[usage(surface = "internal", available_if("debug-build"))]
+    Doctor(Doctor),
+}
+
+/// A CLI with explicitly described contract surfaces.
+#[derive(Cli)]
+#[usage(
+    bin = "surface-demo",
+    surface = "public",
+    available_if("supported-platform")
+)]
+struct SurfaceDemo {
+    #[usage(subcommand)]
+    command: Option<Command>,
+}
+
+#[test]
+fn metadata_reaches_the_portable_spec() {
+    let kdl = SurfaceDemo::to_kdl();
+    let spec: LibSpec = kdl.parse().expect("valid generated spec");
+
+    assert_eq!(spec.cmd.surface.as_deref(), Some("public"));
+    assert_eq!(spec.cmd.available_if, ["supported-platform"]);
+
+    let doctor = spec.cmd.subcommands.get("doctor").expect("doctor command");
+    assert_eq!(doctor.surface.as_deref(), Some("internal"));
+    assert_eq!(doctor.available_if, ["debug-build"]);
+
+    let json = doctor
+        .flags
+        .iter()
+        .find(|flag| flag.name == "json")
+        .unwrap();
+    assert_eq!(json.surface.as_deref(), Some("automation"));
+    assert_eq!(json.available_if, ["json-feature"]);
+
+    let state = doctor
+        .args
+        .iter()
+        .find(|arg| arg.name.eq_ignore_ascii_case("state"))
+        .unwrap();
+    assert_eq!(state.surface.as_deref(), Some("advanced"));
+    assert_eq!(state.available_if, ["filesystem", "writable-state"]);
+
+    let round_trip: LibSpec = spec.to_string().parse().expect("round-tripped spec");
+    assert_eq!(round_trip.cmd.surface, spec.cmd.surface);
+    assert_eq!(round_trip.cmd.available_if, spec.cmd.available_if);
+}
+
+#[test]
+fn annotations_do_not_change_parsing_or_help_visibility() {
+    let argv = ["doctor", "--json", "state-dir"].map(OsStr::new);
+    let parsed = SurfaceDemo::parse_from(&argv).expect("annotated declarations still parse");
+    let Some(Command::Doctor(doctor)) = parsed.command else {
+        panic!("expected doctor")
+    };
+    assert!(doctor.json);
+    assert_eq!(doctor.state.as_deref(), Some("state-dir"));
+
+    let help = usage_argv::help::render(SurfaceDemo::spec(), SurfaceDemo::command(), false)
+        .expect("root help");
+    assert!(help.contains("doctor"), "{help}");
+}

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -257,6 +257,8 @@ pub fn emit(cli: &Cli) -> TokenStream {
     let deprecated = option_str(cli.deprecated.as_deref());
     let deprecated_warn_at = option_str(cli.deprecated_warn_at.as_deref());
     let deprecated_remove_at = option_str(cli.deprecated_remove_at.as_deref());
+    let surface = option_str(cli.surface.as_deref());
+    let available_if = &cli.available_if;
 
     // The same wiring a nested command uses: the root differs only in how it is
     // entered, so it does not get its own copy.
@@ -902,6 +904,8 @@ pub fn emit(cli: &Cli) -> TokenStream {
                 deprecated: #deprecated,
                 deprecated_warn_at: #deprecated_warn_at,
                 deprecated_remove_at: #deprecated_remove_at,
+                surface: #surface,
+                available_if: &[#(#available_if),*],
                 restart_token: #restart_token,
                 subcommand_required: #subcommand_required,
                 subcommand_help_heading: #subcommand_help_heading,
@@ -2415,6 +2419,8 @@ fn flag_meta(cli: &Cli, i: usize, field: &Field, owner: &syn::Ident) -> TokenStr
     let env_fallback = &field.env_fallback;
     let deprecated_env = &field.deprecated_env;
     let help_heading = option_str(field.help_heading.as_deref());
+    let surface = option_str(field.surface.as_deref());
+    let available_if = &field.available_if;
     let display_order = option_usize(field.display_order);
     let deprecated = option_str(field.deprecated.as_deref());
     let deprecated_warn_at = option_str(field.deprecated_warn_at.as_deref());
@@ -2555,6 +2561,8 @@ fn flag_meta(cli: &Cli, i: usize, field: &Field, owner: &syn::Ident) -> TokenStr
             deprecated_env: &[#(#deprecated_env),*],
             default: #default,
             help_heading: #help_heading,
+            surface: #surface,
+            available_if: &[#(#available_if),*],
             value_name: #value_name,
             value_names: &[#(#value_names),*],
             hide: #hide,
@@ -2608,6 +2616,8 @@ fn arg_meta(cli: &Cli, i: usize, field: &Field, owner: &syn::Ident) -> TokenStre
     let env_fallback = &field.env_fallback;
     let deprecated_env = &field.deprecated_env;
     let help_heading = option_str(field.help_heading.as_deref());
+    let surface = option_str(field.surface.as_deref());
+    let available_if = &field.available_if;
     let display_order = option_usize(field.display_order);
     let complete_type = option_str(field.complete_type.as_deref());
     let value_names = &field.value_names;
@@ -2685,6 +2695,8 @@ fn arg_meta(cli: &Cli, i: usize, field: &Field, owner: &syn::Ident) -> TokenStre
             deprecated_env: &[#(#deprecated_env),*],
             default: #default,
             help_heading: #help_heading,
+            surface: #surface,
+            available_if: &[#(#available_if),*],
             hide: #hide,
             hide_default_value: #hide_default_value,
             hide_env: #hide_env,
@@ -5965,6 +5977,8 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
     let deprecated = option_str(cli.deprecated.as_deref());
     let deprecated_warn_at = option_str(cli.deprecated_warn_at.as_deref());
     let deprecated_remove_at = option_str(cli.deprecated_remove_at.as_deref());
+    let surface = option_str(cli.surface.as_deref());
+    let available_if = &cli.available_if;
     let partial = partial_struct(cli);
     let argument_lookup = argument_lookup_functions(cli);
     let deprecations = deprecations_fn(cli);
@@ -6180,6 +6194,8 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
                 deprecated: #deprecated,
                 deprecated_warn_at: #deprecated_warn_at,
                 deprecated_remove_at: #deprecated_remove_at,
+                surface: #surface,
+                available_if: &[#(#available_if),*],
                 hidden_aliases: &[#(#hidden_aliases),*],
                 hide: #hide,
                 restart_token: #restart_token,
@@ -7404,6 +7420,17 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
             // the variant, which is where the command itself is declared.
             let hide = v.hide;
             let help_heading = option_str(v.help_heading.as_deref());
+            let surface = v
+                .surface
+                .as_deref()
+                .map(|surface| option_str(Some(surface)))
+                .unwrap_or_else(|| quote!(<#ty as usage_argv::spec::CommandArgs>::META.surface));
+            let available_if = if v.available_if.is_empty() {
+                quote!(<#ty as usage_argv::spec::CommandArgs>::META.available_if)
+            } else {
+                let conditions = &v.available_if;
+                quote!(&[#(#conditions),*])
+            };
             let display_order = option_usize(v.display_order);
             quote! {
                 const #hidden_groups: &[&[&str]] = &[
@@ -7427,6 +7454,8 @@ pub fn emit_subcommands(subs: &Subcommands) -> TokenStream {
                         examples: #examples,
                         hide: #hide || <#ty as usage_argv::spec::CommandArgs>::META.hide,
                         help_heading: #help_heading,
+                        surface: #surface,
+                        available_if: #available_if,
                         display_order: #display_order,
                         hidden_aliases: &#hidden_name,
                         ..*<#ty as usage_argv::spec::CommandArgs>::META

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -121,6 +121,10 @@ pub struct Cli {
     pub hidden_aliases: Vec<String>,
     /// Whether a command using this argument struct is omitted from help and completions.
     pub hide: bool,
+    /// Named audience or compatibility surface for this command.
+    pub surface: Option<String>,
+    /// Descriptive availability conditions for this command.
+    pub available_if: Vec<String>,
     /// Default casing for inferred flag and positional names.
     rename_all: Option<CasingStyle>,
     /// Default casing for environment names inferred by bare `env`.
@@ -328,6 +332,10 @@ pub struct Field {
     /// the explicit portable spelling emitted in static metadata.
     pub default_value_t: Option<proc_macro2::TokenStream>,
     pub help_heading: Option<String>,
+    /// Named audience or compatibility surface for this field.
+    pub surface: Option<String>,
+    /// Descriptive availability conditions for this field.
+    pub available_if: Vec<String>,
     /// `#[usage(select)]`: this flag's value picks among the command's outputs.
     ///
     /// The ergonomic half of the struct-level `select = "--format"` — it reads where the
@@ -760,6 +768,8 @@ impl Cli {
             aliases: Vec::new(),
             hidden_aliases: Vec::new(),
             hide: false,
+            surface: None,
+            available_if: Vec::new(),
             rename_all: None,
             rename_all_env: CasingStyle::ScreamingSnake,
             attr_span: input
@@ -898,6 +908,8 @@ impl Cli {
                     }
                     "alias_hidden" => cli.hidden_aliases.extend(selectors(&meta)?),
                     "hide" => cli.hide = flag_value(&meta)?,
+                    "surface" => cli.surface = Some(string_value(&meta)?),
+                    "available_if" => cli.available_if.extend(selectors(&meta)?),
                     "min_usage_version" => cli.min_usage_version = Some(string_value(&meta)?),
                     "usage" => cli.usage = Some(string_value(&meta)?),
                     "version" => {
@@ -1104,7 +1116,7 @@ impl Cli {
                             path,
                             format!(
                                 "unknown option `{other}` on a struct; usage::Cli takes \
-                                 `name`, `name_spec`, `bin`, `bin_spec`, `version`, `version_spec`, `long_version`, `long_version_spec`, `author`, `license`, `repository`, `source_code_link_template`, `usage`, `alias`, `alias_hidden`, `visible_alias`, `hide`, `deprecated`, `deprecated_warn_at`, `deprecated_remove_at`, `verbatim_doc_comment`, `unknown_flags`, \
+                                 `name`, `name_spec`, `bin`, `bin_spec`, `version`, `version_spec`, `long_version`, `long_version_spec`, `author`, `license`, `repository`, `source_code_link_template`, `usage`, `alias`, `alias_hidden`, `visible_alias`, `hide`, `surface`, `available_if`, `deprecated`, `deprecated_warn_at`, `deprecated_remove_at`, `verbatim_doc_comment`, `unknown_flags`, \
                                  `default_subcommand`, `multicall`, `no_binary_name`, `arg_required_else_help`, `disable_help_flag`, `disable_help_subcommand`, `disable_version_flag`, `dont_delimit_trailing_values`, `args_override_self`, `subcommand_negates_reqs`, `args_conflicts_with_subcommands`, `subcommand_precedence_over_arg`, `allow_missing_positional`, \
                                  `next_help_heading`, `subcommand_help_heading`, `next_line_help`, `flatten_help`, `help_template`, `term_width`, `max_term_width`, \
                                  `subcommand_value_name`, `restart_token`, `mount`, `example`, `select`, `output`, `exit_code`, `run`, `run_with`, `run_async`, `run_async_with`, \
@@ -1992,6 +2004,8 @@ impl Field {
             default: Vec::new(),
             default_value_t: None,
             help_heading: None,
+            surface: None,
+            available_if: Vec::new(),
             select: false,
             display_order: None,
             value_name: None,
@@ -2140,6 +2154,8 @@ impl Field {
             default: Vec::new(),
             default_value_t: None,
             help_heading: None,
+            surface: None,
+            available_if: Vec::new(),
             select: false,
             display_order: None,
             value_name: None,
@@ -2292,6 +2308,8 @@ impl Field {
             default: Vec::new(),
             default_value_t: None,
             help_heading: None,
+            surface: None,
+            available_if: Vec::new(),
             select: false,
             display_order: None,
             value_name: None,
@@ -2422,6 +2440,8 @@ impl Field {
             default: Vec::new(),
             default_value_t: None,
             help_heading: None,
+            surface: None,
+            available_if: Vec::new(),
             select: false,
             display_order: None,
             value_name: None,
@@ -2527,6 +2547,8 @@ impl Field {
         let mut default: Vec<String> = Vec::new();
         let mut default_value_t = None;
         let mut help_heading = None;
+        let mut surface = None;
+        let mut available_if = Vec::new();
         let mut select = false;
         let mut display_order = None;
         let mut effect = None;
@@ -2818,6 +2840,8 @@ impl Field {
                         });
                     }
                     "help_heading" => help_heading = Some(string_value(&meta)?),
+                    "surface" => surface = Some(string_value(&meta)?),
+                    "available_if" => available_if.extend(selectors(&meta)?),
                     "display_order" => display_order = Some(int_value(&meta)?),
                     "effect" => effect = Some(effect_value(&meta)?),
                     "value_name" => value_name = Some(string_value(&meta)?),
@@ -2877,7 +2901,7 @@ impl Field {
                                  `value_terminator`, `require_equals`, `bool_value`, \
                                  `default_missing`, `default_if`, \
                                  `required_if`, \
-                                 `required_unless`, `required_unless_all`, `help_heading`, `select`, `display_order`, `value_name`, `value_names`, `num_args`, \
+                                 `required_unless`, `required_unless_all`, `help_heading`, `surface`, `available_if`, `select`, `display_order`, `value_name`, `value_names`, `num_args`, \
                                  `verbatim_doc_comment`, \
                                  `visible_alias`, `visible_aliases`, `required`, \
                                  `double_dash`, and `skip`"
@@ -3797,6 +3821,8 @@ impl Field {
             default,
             default_value_t,
             help_heading,
+            surface,
+            available_if,
             select,
             display_order,
             effect,
@@ -5158,6 +5184,10 @@ pub struct Variant {
     pub ident: syn::Ident,
     /// Help section this command appears under in its parent's command list.
     pub help_heading: Option<String>,
+    /// Named audience or compatibility surface for this command.
+    pub surface: Option<String>,
+    /// Descriptive availability conditions for this command.
+    pub available_if: Vec<String>,
     /// Explicit placement within the parent's command section.
     pub display_order: Option<usize>,
     /// Whether the command is kept out of help and completions.
@@ -5450,6 +5480,8 @@ impl Variant {
         let mut effect = None;
         let mut hide = false;
         let mut help_heading = None;
+        let mut surface = None;
+        let mut available_if = Vec::new();
         let mut display_order = None;
         let mut external = false;
         let mut help_attr: Option<proc_macro2::TokenStream> = None;
@@ -5476,6 +5508,8 @@ impl Variant {
                     "alias_hidden" => hidden_aliases.extend(selectors(&meta)?),
                     "hide" => hide = flag_value(&meta)?,
                     "help_heading" => help_heading = Some(string_value(&meta)?),
+                    "surface" => surface = Some(string_value(&meta)?),
+                    "available_if" => available_if.extend(selectors(&meta)?),
                     "display_order" => display_order = Some(int_value(&meta)?),
                     "external_subcommand" => external = flag_value(&meta)?,
                     "effect" => {
@@ -5515,7 +5549,7 @@ impl Variant {
                             path,
                             format!(
                                 "unknown option `{other}` on a variant; a subcommand \
-                                 variant takes `name`, `alias`, `alias_hidden`, `help_heading`, `display_order`, \
+                                 variant takes `name`, `alias`, `alias_hidden`, `help_heading`, `surface`, `available_if`, `display_order`, \
                                  `external_subcommand`, `help`, `long_help`, `deprecated`, `deprecated_warn_at`, `deprecated_remove_at`, `before_help`, \
                                  `before_long_help`, `after_help`, `after_long_help`, `example`, `verbatim_doc_comment`, \
                                  `run`, `run_async`, and `no_ctx` here, \
@@ -5623,6 +5657,8 @@ impl Variant {
                 ident: variant.ident.clone(),
                 hide: false,
                 help_heading: None,
+                surface: None,
+                available_if: Vec::new(),
                 name,
                 effect: None,
                 display_order: None,
@@ -5694,6 +5730,8 @@ impl Variant {
         Ok(Variant {
             ident: variant.ident.clone(),
             help_heading,
+            surface,
+            available_if,
             display_order,
             hide,
             name,

--- a/docs/rust/args-and-flags.md
+++ b/docs/rust/args-and-flags.md
@@ -72,6 +72,13 @@ The tables below cover the attributes most CLIs need.
 | `global`                 | Usable on any subcommand below this one                         |
 | `required`               | Explicit required-ness (for `Vec` fields)                       |
 | `skip`                   | Not an argument; filled from `Default` when the struct is built |
+| `surface = "…"`          | Descriptive audience or compatibility surface metadata          |
+| `available_if("…", …)`   | Descriptive availability conditions; does not gate parsing      |
+
+The metadata attributes also work on the root `Cli`, an `Args` command struct, and a
+`Subcommands` variant. Their values are intentionally project-defined: `public`, `automation`,
+and `internal` are common surfaces, while `unix`, `debug-build`, or `feature=json` are typical
+availability conditions. Use `hide` or an application-level check when behavior should change.
 
 **Values and cardinality** — what a field accepts and how many:
 

--- a/docs/spec/reference/cmd.md
+++ b/docs/spec/reference/cmd.md
@@ -15,6 +15,7 @@ cmd "config" flatten_help=#true // expand visible subcommands into this page
 cmd "config" display_order=10 // present before commands with a greater order
 cmd "config" help_heading="Configuration" // group under this heading in its parent's help
 cmd "config" term_width=100 max_term_width=120
+cmd "config" surface="public" available_if="supported-platform"
 
 // these are shown under -h
 cmd "config" before_help="shown before the command"
@@ -59,6 +60,10 @@ zero disables that cap.
 
 Markdown documentation prefers the `*_md` form, then long help, then short
 help. Flags and arguments also accept `help_md`.
+
+`surface` and `available_if` are descriptive contract metadata shared with flags and arguments.
+Several conditions use an `available_if "first" "second"` child node. They are emitted to JSON
+and documentation models without hiding or disabling the command.
 
 Commands can also declare their stdout formats, JSON Schemas, and exit statuses. See
 [Command outputs and exit codes](./output.md).

--- a/docs/spec/reference/index.md
+++ b/docs/spec/reference/index.md
@@ -46,6 +46,26 @@ exit_code 0 "success"
 exit_code 1 "error"
 ```
 
+## Surface and availability metadata
+
+Commands, arguments, and flags may carry descriptive contract metadata:
+
+```kdl
+surface "public"
+available_if "supported-platform"
+
+cmd "doctor" surface="internal" {
+  available_if "debug-build" "admin-policy"
+  flag "--json" surface="automation" available_if="json-feature"
+}
+```
+
+`surface` is a project-defined audience or compatibility label such as `public`, `advanced`,
+`automation`, or `internal`. `available_if` is an ordered list of project-defined conditions.
+Neither changes parsing, help visibility, or validation: generators, documentation sites, API
+catalogs, and migration tooling decide how to interpret them. Use `hide` for an entry that should
+not be advertised and ordinary validation for a condition that must be enforced at runtime.
+
 ## Help variants
 
 The plain fields (`about`, `before_help`, and `after_help`) are the short-help

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -56,6 +56,8 @@ pub struct SpecCommand {
     pub exit_codes: Vec<SpecExitCode>,
     pub hide: bool,
     pub help_heading: Option<String>,
+    pub surface: Option<String>,
+    pub available_if: Vec<String>,
     pub display_order: Option<usize>,
     pub subcommand_required: bool,
     pub subcommand_help_heading: Option<String>,
@@ -99,6 +101,8 @@ pub struct HelpCommand {
     pub help: Option<String>,
     pub help_long: Option<String>,
     pub help_heading: Option<String>,
+    pub surface: Option<String>,
+    pub available_if: Vec<String>,
 }
 
 impl From<&SpecCommand> for HelpCommand {
@@ -112,6 +116,8 @@ impl From<&SpecCommand> for HelpCommand {
             help: cmd.help.clone(),
             help_long: cmd.help_long.clone(),
             help_heading: cmd.help_heading.clone(),
+            surface: cmd.surface.clone(),
+            available_if: cmd.available_if.clone(),
         }
     }
 }
@@ -152,6 +158,8 @@ pub struct SpecFlag {
     pub env_fallback: Vec<String>,
     pub deprecated_env: Vec<String>,
     pub help_heading: Option<String>,
+    pub surface: Option<String>,
+    pub available_if: Vec<String>,
     pub display_order: Option<usize>,
     pub rendered: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -490,6 +498,8 @@ pub struct SpecArg {
     pub env_fallback: Vec<String>,
     pub deprecated_env: Vec<String>,
     pub help_heading: Option<String>,
+    pub surface: Option<String>,
+    pub available_if: Vec<String>,
     pub display_order: Option<usize>,
     pub rendered: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -656,6 +666,8 @@ impl From<&crate::SpecCommand> for SpecCommand {
             effect,
             hide,
             help_heading,
+            surface,
+            available_if,
             display_order,
             subcommand_required,
             subcommand_help_heading,
@@ -799,6 +811,8 @@ impl From<&crate::SpecCommand> for SpecCommand {
             exit_codes: cmd.exit_codes.iter().map(SpecExitCode::from).collect(),
             hide: *hide,
             help_heading: help_heading.clone(),
+            surface: surface.clone(),
+            available_if: available_if.clone(),
             display_order: *display_order,
             subcommand_required: *subcommand_required,
             subcommand_help_heading: subcommand_help_heading.clone(),
@@ -996,6 +1010,8 @@ impl From<&crate::SpecFlag> for SpecFlag {
             env_fallback: flag.env_fallback.clone(),
             deprecated_env: flag.deprecated_env.clone(),
             help_heading: flag.help_heading.clone(),
+            surface: flag.surface.clone(),
+            available_if: flag.available_if.clone(),
             display_order: flag.display_order,
             rendered: false,
             help_rendered: None,
@@ -1045,6 +1061,8 @@ impl From<&crate::SpecArg> for SpecArg {
             env_fallback: arg.env_fallback.clone(),
             deprecated_env: arg.deprecated_env.clone(),
             help_heading: arg.help_heading.clone(),
+            surface: arg.surface.clone(),
+            available_if: arg.available_if.clone(),
             display_order: arg.display_order,
             rendered: false,
             help_rendered: None,

--- a/lib/src/spec/arg.rs
+++ b/lib/src/spec/arg.rs
@@ -174,6 +174,16 @@ pub struct SpecArg {
     /// like the flag field of the same name.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub help_heading: Option<String>,
+    /// Named audience or contract surface this argument belongs to.
+    ///
+    /// Metadata only: parsers and help renderers do not filter on this value.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub surface: Option<String>,
+    /// Conditions under which this argument is available, in declaration order.
+    ///
+    /// These are descriptive labels for docs, schema consumers, and compatibility tools.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub available_if: Vec<String>,
     /// Explicit placement within its help section.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub display_order: Option<usize>,
@@ -262,6 +272,8 @@ impl SpecArg {
                 "validate" => arg.validate = v.ensure_string().map(Some)?,
                 "validate_error" => arg.validate_error = v.ensure_string().map(Some)?,
                 "help_heading" => arg.help_heading = v.ensure_string().map(Some)?,
+                "surface" => arg.surface = v.ensure_string().map(Some)?,
+                "available_if" => arg.available_if = vec![v.ensure_string()?],
                 "display_order" => arg.display_order = v.ensure_usize().map(Some)?,
                 k => bail_parse!(ctx, v.entry.span(), "unsupported arg key {k}"),
             }
@@ -294,6 +306,8 @@ impl SpecArg {
                 "help_heading" => {
                     arg.help_heading = child.arg(0)?.ensure_string().map(Some)?;
                 }
+                "surface" => arg.surface = child.arg(0)?.ensure_string().map(Some)?,
+                "available_if" => arg.available_if = string_args(&child)?,
                 "display_order" => {
                     arg.display_order = child.arg(0)?.ensure_usize().map(Some)?;
                 }
@@ -589,6 +603,10 @@ impl From<&SpecArg> for KdlNode {
         if let Some(help_heading) = &arg.help_heading {
             node.push(string_entry(Some("help_heading"), help_heading));
         }
+        if let Some(surface) = &arg.surface {
+            node.push(string_entry(Some("surface"), surface));
+        }
+        serialize_selector_list(&mut node, "available_if", &arg.available_if);
         if let Some(order) = arg.display_order {
             node.push(KdlEntry::new_prop("display_order", order as i128));
         }
@@ -1010,6 +1028,8 @@ impl From<&clap::Arg> for SpecArg {
             env_fallback: Vec::new(),
             deprecated_env: Vec::new(),
             help_heading: arg.get_help_heading().map(|s| s.to_string()),
+            surface: None,
+            available_if: Vec::new(),
             display_order: Some(arg.get_display_order()),
         };
         arg.choices = choices;

--- a/lib/src/spec/builder.rs
+++ b/lib/src/spec/builder.rs
@@ -124,6 +124,18 @@ impl SpecFlagBuilder {
         self
     }
 
+    /// Label the audience or compatibility surface this flag belongs to.
+    pub fn surface(mut self, surface: impl Into<String>) -> Self {
+        self.inner.surface = Some(surface.into());
+        self
+    }
+
+    /// Add a descriptive availability condition.
+    pub fn available_if(mut self, condition: impl Into<String>) -> Self {
+        self.inner.available_if.push(condition.into());
+        self
+    }
+
     /// Set as variadic (can be specified multiple times)
     pub fn var(mut self, is_var: bool) -> Self {
         self.inner.var = is_var;
@@ -501,6 +513,18 @@ impl SpecArgBuilder {
         Self::default()
     }
 
+    /// Label the audience or compatibility surface this argument belongs to.
+    pub fn surface(mut self, surface: impl Into<String>) -> Self {
+        self.inner.surface = Some(surface.into());
+        self
+    }
+
+    /// Add a descriptive availability condition.
+    pub fn available_if(mut self, condition: impl Into<String>) -> Self {
+        self.inner.available_if.push(condition.into());
+        self
+    }
+
     /// Set the argument name
     pub fn name(mut self, name: impl Into<String>) -> Self {
         self.inner.name = name.into();
@@ -780,6 +804,17 @@ pub struct SpecCommandBuilder {
 }
 
 impl SpecCommandBuilder {
+    /// Label the audience or compatibility surface this command belongs to.
+    pub fn surface(mut self, surface: impl Into<String>) -> Self {
+        self.inner.surface = Some(surface.into());
+        self
+    }
+
+    /// Add a descriptive availability condition.
+    pub fn available_if(mut self, condition: impl Into<String>) -> Self {
+        self.inner.available_if.push(condition.into());
+        self
+    }
     /// Create a new SpecCommandBuilder
     pub fn new() -> Self {
         Self::default()

--- a/lib/src/spec/cmd.rs
+++ b/lib/src/spec/cmd.rs
@@ -92,6 +92,12 @@ pub struct SpecCommand {
     /// Help section this command appears under in its parent's command list.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub help_heading: Option<String>,
+    /// Named audience or contract surface this command belongs to. Metadata only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub surface: Option<String>,
+    /// Descriptive conditions under which this command is available.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub available_if: Vec<String>,
     /// Explicit placement within its parent's command section.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub display_order: Option<usize>,
@@ -253,6 +259,8 @@ impl Default for SpecCommand {
             unknown_flags: None,
             hide: false,
             help_heading: None,
+            surface: None,
+            available_if: vec![],
             display_order: None,
             mounted: false,
             flags_from_mount: false,
@@ -407,6 +415,8 @@ impl SpecCommand {
                 "allow_missing_positional" => cmd.allow_missing_positional = v.ensure_bool()?,
                 "hide" => cmd.hide = v.ensure_bool()?,
                 "help_heading" => cmd.help_heading = Some(v.ensure_string()?),
+                "surface" => cmd.surface = Some(v.ensure_string()?),
+                "available_if" => cmd.available_if = vec![v.ensure_string()?],
                 "display_order" => cmd.display_order = Some(v.ensure_usize()?),
                 "unknown_flags" => {
                     let raw = v.ensure_string()?;
@@ -541,6 +551,16 @@ impl SpecCommand {
                 }
                 "help_heading" => {
                     cmd.help_heading = Some(child.ensure_arg_len(1..=1)?.arg(0)?.ensure_string()?)
+                }
+                "surface" => {
+                    cmd.surface = Some(child.ensure_arg_len(1..=1)?.arg(0)?.ensure_string()?)
+                }
+                "available_if" => {
+                    cmd.available_if = child
+                        .ensure_arg_len(1..)?
+                        .args()
+                        .map(|entry| entry.ensure_string())
+                        .collect::<Result<Vec<_>, _>>()?;
                 }
                 "subcommand_help_heading" => {
                     cmd.subcommand_help_heading =
@@ -736,6 +756,8 @@ impl SpecCommand {
             exit_codes,
             hide,
             help_heading,
+            surface,
+            available_if,
             display_order,
             subcommand_required,
             subcommand_help_heading,
@@ -853,6 +875,12 @@ impl SpecCommand {
         self.hide = hide;
         if help_heading.is_some() {
             self.help_heading = help_heading;
+        }
+        if surface.is_some() {
+            self.surface = surface;
+        }
+        if !available_if.is_empty() {
+            self.available_if = available_if;
         }
         if display_order.is_some() {
             self.display_order = display_order;
@@ -1006,6 +1034,8 @@ impl From<&SpecCommand> for KdlNode {
             name,
             hide,
             help_heading,
+            surface,
+            available_if,
             display_order,
             subcommand_required,
             subcommand_help_heading,
@@ -1070,6 +1100,17 @@ impl From<&SpecCommand> for KdlNode {
         if let Some(heading) = help_heading {
             node.entries_mut()
                 .push(KdlEntry::new_prop("help_heading", heading.clone()));
+        }
+        if let Some(surface) = surface {
+            node.push(KdlEntry::new_prop("surface", surface.clone()));
+        }
+        if !available_if.is_empty() {
+            let children = node.children_mut().get_or_insert_with(KdlDocument::new);
+            let mut condition = KdlNode::new("available_if");
+            for value in available_if {
+                condition.push(string_entry(None, value));
+            }
+            children.nodes_mut().push(condition);
         }
         if let Some(order) = display_order {
             node.entries_mut()

--- a/lib/src/spec/flag.rs
+++ b/lib/src/spec/flag.rs
@@ -302,6 +302,12 @@ pub struct SpecFlag {
     /// it.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub help_heading: Option<String>,
+    /// Named audience or contract surface this flag belongs to. Metadata only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub surface: Option<String>,
+    /// Descriptive conditions under which this flag is available.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub available_if: Vec<String>,
     /// Explicit placement within its help section.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub display_order: Option<usize>,
@@ -412,6 +418,8 @@ impl SpecFlag {
                 "env_fallback" => flag.env_fallback = vec![v.ensure_string()?],
                 "deprecated_env" => flag.deprecated_env = vec![v.ensure_string()?],
                 "help_heading" => flag.help_heading = v.ensure_string().map(Some)?,
+                "surface" => flag.surface = v.ensure_string().map(Some)?,
+                "available_if" => flag.available_if = vec![v.ensure_string()?],
                 "display_order" => flag.display_order = v.ensure_usize().map(Some)?,
                 k => bail_parse!(ctx, v.entry.span(), "unsupported flag key {k}"),
             }
@@ -567,6 +575,14 @@ impl SpecFlag {
                 }
                 "help_heading" => {
                     flag.help_heading = child.arg(0)?.ensure_string().map(Some)?;
+                }
+                "surface" => flag.surface = child.arg(0)?.ensure_string().map(Some)?,
+                "available_if" => {
+                    flag.available_if = child
+                        .ensure_arg_len(1..)?
+                        .args()
+                        .map(|entry| entry.ensure_string())
+                        .collect::<Result<_>>()?;
                 }
                 "display_order" => {
                     flag.display_order = child.arg(0)?.ensure_usize().map(Some)?;
@@ -1095,6 +1111,10 @@ impl From<&SpecFlag> for KdlNode {
         if let Some(help_heading) = &flag.help_heading {
             node.push(string_entry(Some("help_heading"), help_heading));
         }
+        if let Some(surface) = &flag.surface {
+            node.push(string_entry(Some("surface"), surface));
+        }
+        serialize_flag_list(&mut node, "available_if", &flag.available_if);
         if let Some(order) = flag.display_order {
             node.push(KdlEntry::new_prop("display_order", order as i128));
         }
@@ -1480,6 +1500,8 @@ impl From<&clap::Arg> for SpecFlag {
             env_fallback: vec![],
             deprecated_env: vec![],
             help_heading: c.get_help_heading().map(|s| s.to_string()),
+            surface: None,
+            available_if: Vec::new(),
             display_order: Some(c.get_display_order()),
         };
         if c.is_allow_hyphen_values_set() {

--- a/lib/src/spec/mod.rs
+++ b/lib/src/spec/mod.rs
@@ -487,6 +487,14 @@ impl Spec {
                 "long_about" => schema.about_long = Some(node.arg(0)?.ensure_string()?),
                 "about_long" => schema.about_long = Some(node.arg(0)?.ensure_string()?),
                 "about_md" => schema.about_md = Some(node.arg(0)?.ensure_string()?),
+                "surface" => schema.cmd.surface = Some(node.arg(0)?.ensure_string()?),
+                "available_if" => {
+                    schema.cmd.available_if = node
+                        .ensure_arg_len(1..)?
+                        .args()
+                        .map(|entry| entry.ensure_string())
+                        .collect::<Result<Vec<_>, _>>()?;
+                }
                 "license" => schema.license = Some(node.arg(0)?.ensure_string()?),
                 "before_help" => schema.before_help = Some(node.arg(0)?.ensure_string()?),
                 "after_help" => schema.after_help = Some(node.arg(0)?.ensure_string()?),
@@ -1103,6 +1111,18 @@ impl Display for Spec {
         if let Some(message) = &self.cmd.deprecated {
             let mut node = KdlNode::new("deprecated");
             node.push(string_entry(None, message));
+            nodes.push(node);
+        }
+        if let Some(surface) = &self.cmd.surface {
+            let mut node = KdlNode::new("surface");
+            node.push(surface.clone());
+            nodes.push(node);
+        }
+        if !self.cmd.available_if.is_empty() {
+            let mut node = KdlNode::new("available_if");
+            for condition in &self.cmd.available_if {
+                node.push(condition.clone());
+            }
             nodes.push(node);
         }
         if let Some(at) = &self.cmd.deprecated_warn_at {

--- a/lib/src/spec/mod.rs
+++ b/lib/src/spec/mod.rs
@@ -1115,13 +1115,13 @@ impl Display for Spec {
         }
         if let Some(surface) = &self.cmd.surface {
             let mut node = KdlNode::new("surface");
-            node.push(surface.clone());
+            node.push(string_entry(None, surface));
             nodes.push(node);
         }
         if !self.cmd.available_if.is_empty() {
             let mut node = KdlNode::new("available_if");
             for condition in &self.cmd.available_if {
-                node.push(condition.clone());
+                node.push(string_entry(None, condition));
             }
             nodes.push(node);
         }


### PR DESCRIPTION
## Summary

- add project-defined surface labels and ordered availability conditions to commands, flags, and arguments
- carry metadata through derives, builders, portable KDL and JSON, docs models, views, and conformance tables
- keep annotations descriptive so parsing, validation, help visibility, and completion behavior remain unchanged
- document public, automation, advanced, and internal use cases without imposing a closed vocabulary

## Testing

- `mise run ci`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends the public spec, derive API, and serialization surface across many types, so consumers and generators must ignore or handle the new fields. Parsing and help behavior are unchanged, which limits runtime risk.
> 
> **Overview**
> Adds **descriptive** `surface` and `available_if` annotations on commands, flags, and arguments so CLIs can label audience (e.g. `public`, `internal`) and ordered availability conditions without changing parse, help, or completions.
> 
> The fields flow through derive attributes (`#[usage(surface = "…", available_if(…))]`), builders, argv `CommandMeta`/`FlagMeta`/`ArgMeta`, KDL parse/serialize (including quoted round-trips), JSON/docs models, and conformance tables. Subcommand variants can override the nested `Args` struct’s values. Docs and a conformance test lock in that these labels stay metadata-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e365afac29d087c20b4e63f65d37a7bcd8034667. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->