### PR TITLE
feat(parse): add opt-in response files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2346,6 +2346,8 @@ name = "usage-rs"
 version = "6.1.1"
 dependencies = [
  "serde",
+ "shell-words",
+ "tempfile",
  "usage-argv",
  "usage-config",
  "usage-derive",

--- a/docs/rust/index.md
+++ b/docs/rust/index.md
@@ -78,15 +78,16 @@ available for low-level adopters that want a thinner surface:
 
 ### Cargo features
 
-| Feature       | Default | What it enables                                                                                          |
-| ------------- | :-----: | -------------------------------------------------------------------------------------------------------- |
-| `spec`        |   ✅    | Spec metadata and `to_kdl()`; gates the derives                                                          |
-| `help`        |   ✅    | `-h` / `--help` page rendering                                                                           |
-| `diagnostics` |   ✅    | clap-shaped error messages from `render_failure`                                                         |
-| `completions` |         | Shell completion scripts and the runtime completion protocol (`complete` is an alias of this feature)    |
-| `validation`  |         | Portable `validate` / `validate_error` expressions ([Validation](/rust/validation#portable-expressions)) |
-| `test`        |         | `usage::test`: command output, parse, and help assertions (completion assertions want `completions` too) |
-| `config`      |         | The `usage::Config` derive and the resolver as `usage::config` ([Configuration](/rust/configuration))    |
+| Feature          | Default | What it enables                                                                                          |
+| ---------------- | :-----: | -------------------------------------------------------------------------------------------------------- |
+| `spec`           |   ✅    | Spec metadata and `to_kdl()`; gates the derives                                                          |
+| `help`           |   ✅    | `-h` / `--help` page rendering                                                                           |
+| `diagnostics`    |   ✅    | clap-shaped error messages from `render_failure`                                                         |
+| `completions`    |         | Shell completion scripts and the runtime completion protocol (`complete` is an alias of this feature)    |
+| `validation`     |         | Portable `validate` / `validate_error` expressions ([Validation](/rust/validation#portable-expressions)) |
+| `test`           |         | `usage::test`: command output, parse, and help assertions (completion assertions want `completions` too) |
+| `config`         |         | The `usage::Config` derive and the resolver as `usage::config` ([Configuration](/rust/configuration))    |
+| `response-files` |         | Explicit `@file` argument expansion as `usage::response` ([Response files](/rust/response-files))        |
 
 ## Parse entry points
 
@@ -150,6 +151,7 @@ how to opt out of the endpoint.
 - [Help, version, and errors](/rust/help) — what the parser renders and how to hook it
 - [Completions](/rust/completions) — static scripts and runtime completion
 - [Configuration](/rust/configuration) — settings declared in code: `usage::Config` and layered resolution
+- [Response files](/rust/response-files) — opt-in, nested `@file` argument expansion
 - [Testing](/rust/testing) — run commands or assert directly on parsing, help, and completions
 - [Spec output](/rust/spec) — the emitted KDL and usage-cli integration
 - [Migrating from clap](/rust/migrating-from-clap) — mechanical rewrites and intentional API breaks

--- a/docs/rust/response-files.md
+++ b/docs/rust/response-files.md
@@ -15,7 +15,6 @@ use usage::Cli;
 let expanded = usage::response::expand(std::env::args_os().skip(1))?;
 let argv: Vec<&OsStr> = expanded.iter().map(|word| word.as_os_str()).collect();
 let cli = MyCli::parse_from(&argv)?;
-# Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
 An argument beginning with `@` names a UTF-8 file of shell-style words:

--- a/docs/rust/response-files.md
+++ b/docs/rust/response-files.md
@@ -1,0 +1,36 @@
+# Response files
+
+Large generated command lines can be placed in a response file and expanded before parsing.
+This is opt-in so ordinary parsing performs no filesystem access or allocation.
+
+```toml
+[dependencies]
+usage = { package = "usage-rs", version = "6", features = ["response-files"] }
+```
+
+```rust
+use std::ffi::OsStr;
+use usage::Cli;
+
+let expanded = usage::response::expand(std::env::args_os().skip(1))?;
+let argv: Vec<&OsStr> = expanded.iter().map(|word| word.as_os_str()).collect();
+let cli = MyCli::parse_from(&argv)?;
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+An argument beginning with `@` names a UTF-8 file of shell-style words:
+
+```text
+--format json
+--output "release report.json"
+@more-options.args
+```
+
+Nested paths are resolved relative to the file containing them. `@@value` produces the literal
+argument `@value`; a lone `@` and non-UTF-8 arguments pass through unchanged. Includes are limited
+to 16 levels by default and cycles are rejected. Use `expand_with` and `Options` to select another
+depth limit.
+
+Expansion deliberately happens before `Cli::parse_from` rather than inside the parser. This keeps
+filesystem policy visible to the application, lets callers decide whether response files are
+allowed in privileged contexts, and preserves usage-argv's normal zero-allocation path.

--- a/usage-rs/Cargo.toml
+++ b/usage-rs/Cargo.toml
@@ -16,6 +16,7 @@ usage-derive = { workspace = true, optional = true }
 usage-test = { workspace = true, optional = true }
 usage-validation = { workspace = true, optional = true }
 usage-config = { workspace = true, optional = true }
+shell-words = { version = "1", optional = true }
 
 [features]
 # Applications get a usable CLI out of the box: parse tables, help, and
@@ -35,6 +36,8 @@ validation = ["dep:usage-validation"]
 test = ["spec", "help", "dep:usage-test"]
 # Settings: the `usage::Config` derive, and the resolver as `usage::config`.
 config = ["spec", "dep:usage-config"]
+# Explicit, cold-path expansion of @response files before parsing.
+response-files = ["dep:shell-words"]
 
 [package.metadata.release]
 shared-version = true
@@ -42,4 +45,5 @@ release = true
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
+tempfile = "3"
 usage-parser = { package = "usage-lib", path = "../lib" }

--- a/usage-rs/src/lib.rs
+++ b/usage-rs/src/lib.rs
@@ -62,6 +62,8 @@ pub use usage_derive::{ArgGroup, Args, Cli, Subcommands, ValueEnum};
 pub use usage_test as test;
 #[cfg(feature = "validation")]
 pub use usage_validation as validation;
+#[cfg(feature = "response-files")]
+pub mod response;
 
 #[cfg(all(test, feature = "spec"))]
 mod tests {

--- a/usage-rs/src/response.rs
+++ b/usage-rs/src/response.rs
@@ -1,0 +1,264 @@
+//! Explicit expansion of `@response-file` arguments.
+//!
+//! Expansion is separate from the parser so ordinary invocations retain the zero-allocation
+//! hot path and applications choose exactly where filesystem access is allowed.
+
+use std::collections::HashSet;
+use std::ffi::OsString;
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+/// Response-file expansion policy.
+#[derive(Debug, Clone, Copy)]
+pub struct Options {
+    /// Maximum number of nested response files. The outermost file counts as one.
+    pub max_depth: usize,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self { max_depth: 16 }
+    }
+}
+
+/// Why a response file could not be expanded.
+#[derive(Debug)]
+pub enum ErrorKind {
+    /// The path could not be resolved or read as UTF-8 text.
+    Io(std::io::Error),
+    /// The file's shell-style quoting was invalid.
+    Syntax(shell_words::ParseError),
+    /// Expanding this file would exceed [`Options::max_depth`].
+    DepthExceeded { max_depth: usize },
+    /// A file included itself, directly or indirectly.
+    Cycle,
+}
+
+/// A response-file failure with the file that caused it.
+#[derive(Debug)]
+pub struct Error {
+    pub path: PathBuf,
+    pub kind: ErrorKind,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.kind {
+            ErrorKind::Io(error) => write!(f, "could not read {}: {error}", self.path.display()),
+            ErrorKind::Syntax(error) => {
+                write!(f, "could not parse {}: {error}", self.path.display())
+            }
+            ErrorKind::DepthExceeded { max_depth } => write!(
+                f,
+                "response file {} exceeds the nesting limit of {max_depth}",
+                self.path.display()
+            ),
+            ErrorKind::Cycle => write!(
+                f,
+                "response file {} includes itself through an include cycle",
+                self.path.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match &self.kind {
+            ErrorKind::Io(error) => Some(error),
+            ErrorKind::Syntax(error) => Some(error),
+            ErrorKind::DepthExceeded { .. } | ErrorKind::Cycle => None,
+        }
+    }
+}
+
+/// Expand `@path` arguments using the default policy.
+///
+/// Each file is UTF-8 shell-style words: whitespace separates arguments, single and double
+/// quotes preserve whitespace, and backslash escapes the next character. A nested relative path
+/// is resolved beside the file that contains it. `@@value` escapes a literal argument beginning
+/// with `@`. Non-UTF-8 arguments and a lone `@` are passed through unchanged.
+pub fn expand<I, S>(argv: I) -> Result<Vec<OsString>, Error>
+where
+    I: IntoIterator<Item = S>,
+    S: Into<OsString>,
+{
+    expand_with(argv, Options::default())
+}
+
+/// Expand `@path` arguments with an explicit policy.
+pub fn expand_with<I, S>(argv: I, options: Options) -> Result<Vec<OsString>, Error>
+where
+    I: IntoIterator<Item = S>,
+    S: Into<OsString>,
+{
+    let mut out = Vec::new();
+    let mut active = HashSet::new();
+    let cwd = std::env::current_dir().map_err(|error| Error {
+        path: PathBuf::from("."),
+        kind: ErrorKind::Io(error),
+    })?;
+    for arg in argv {
+        expand_one(arg.into(), &cwd, options, &mut active, &mut out)?;
+    }
+    Ok(out)
+}
+
+fn expand_one(
+    arg: OsString,
+    base: &Path,
+    options: Options,
+    active: &mut HashSet<PathBuf>,
+    out: &mut Vec<OsString>,
+) -> Result<(), Error> {
+    let Some(text) = arg.to_str() else {
+        out.push(arg);
+        return Ok(());
+    };
+    if let Some(literal) = text.strip_prefix("@@") {
+        out.push(OsString::from(format!("@{literal}")));
+        return Ok(());
+    }
+    let Some(raw_path) = text.strip_prefix('@').filter(|path| !path.is_empty()) else {
+        out.push(arg);
+        return Ok(());
+    };
+
+    let requested = Path::new(raw_path);
+    let path = if requested.is_absolute() {
+        requested.to_path_buf()
+    } else {
+        base.join(requested)
+    };
+    if active.len() >= options.max_depth {
+        return Err(Error {
+            path,
+            kind: ErrorKind::DepthExceeded {
+                max_depth: options.max_depth,
+            },
+        });
+    }
+    let canonical = std::fs::canonicalize(&path).map_err(|error| Error {
+        path: path.clone(),
+        kind: ErrorKind::Io(error),
+    })?;
+    if !active.insert(canonical.clone()) {
+        return Err(Error {
+            path: canonical,
+            kind: ErrorKind::Cycle,
+        });
+    }
+
+    let result = (|| {
+        let contents = std::fs::read_to_string(&canonical).map_err(|error| Error {
+            path: canonical.clone(),
+            kind: ErrorKind::Io(error),
+        })?;
+        let words = shell_words::split(&contents).map_err(|error| Error {
+            path: canonical.clone(),
+            kind: ErrorKind::Syntax(error),
+        })?;
+        let next_base = canonical.parent().unwrap_or(base);
+        for word in words {
+            expand_one(OsString::from(word), next_base, options, active, out)?;
+        }
+        Ok(())
+    })();
+    active.remove(&canonical);
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsStr;
+
+    fn words(values: &[OsString]) -> Vec<&OsStr> {
+        values.iter().map(OsString::as_os_str).collect()
+    }
+
+    #[test]
+    fn nested_files_are_relative_to_the_file_that_names_them() {
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("nested");
+        std::fs::create_dir(&nested).unwrap();
+        std::fs::write(nested.join("more.args"), "'two words' --last").unwrap();
+        std::fs::write(
+            dir.path().join("main.args"),
+            "--first one @nested/more.args",
+        )
+        .unwrap();
+
+        let expanded = expand([OsString::from(format!(
+            "@{}",
+            dir.path().join("main.args").display()
+        ))])
+        .unwrap();
+        assert_eq!(
+            words(&expanded),
+            ["--first", "one", "two words", "--last"].map(OsStr::new)
+        );
+    }
+
+    #[test]
+    fn an_at_sign_can_be_escaped() {
+        let expanded = expand(["@@literal", "@", "ordinary"]).unwrap();
+        assert_eq!(
+            words(&expanded),
+            ["@literal", "@", "ordinary"].map(OsStr::new)
+        );
+    }
+
+    #[test]
+    fn include_cycles_are_reported() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.args"), "@b.args").unwrap();
+        std::fs::write(dir.path().join("b.args"), "@a.args").unwrap();
+        let error = expand([OsString::from(format!(
+            "@{}",
+            dir.path().join("a.args").display()
+        ))])
+        .unwrap_err();
+        assert!(matches!(error.kind, ErrorKind::Cycle));
+    }
+
+    #[test]
+    fn nesting_has_a_configurable_bound() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.args"), "@b.args").unwrap();
+        std::fs::write(dir.path().join("b.args"), "value").unwrap();
+        let error = expand_with(
+            [OsString::from(format!(
+                "@{}",
+                dir.path().join("a.args").display()
+            ))],
+            Options { max_depth: 1 },
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error.kind,
+            ErrorKind::DepthExceeded { max_depth: 1 }
+        ));
+    }
+
+    #[cfg(feature = "spec")]
+    #[test]
+    fn expanded_words_feed_the_typed_parser() {
+        #[derive(crate::Cli)]
+        #[usage(bin = "response-demo")]
+        struct Cli {
+            #[usage(long)]
+            format: Option<String>,
+            files: Vec<String>,
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("args");
+        std::fs::write(&path, "--format json 'one file' two").unwrap();
+        let expanded = expand([OsString::from(format!("@{}", path.display()))]).unwrap();
+        let argv = words(&expanded);
+        let parsed = Cli::parse_from(&argv).unwrap();
+        assert_eq!(parsed.format.as_deref(), Some("json"));
+        assert_eq!(parsed.files, ["one file", "two"]);
+    }
+}

--- a/usage-rs/src/response.rs
+++ b/usage-rs/src/response.rs
@@ -130,24 +130,25 @@ fn expand_one(
     } else {
         base.join(requested)
     };
-    if active.len() >= options.max_depth {
-        return Err(Error {
-            path,
-            kind: ErrorKind::DepthExceeded {
-                max_depth: options.max_depth,
-            },
-        });
-    }
     let canonical = std::fs::canonicalize(&path).map_err(|error| Error {
         path: path.clone(),
         kind: ErrorKind::Io(error),
     })?;
-    if !active.insert(canonical.clone()) {
+    if active.contains(&canonical) {
         return Err(Error {
             path: canonical,
             kind: ErrorKind::Cycle,
         });
     }
+    if active.len() >= options.max_depth {
+        return Err(Error {
+            path: canonical,
+            kind: ErrorKind::DepthExceeded {
+                max_depth: options.max_depth,
+            },
+        });
+    }
+    active.insert(canonical.clone());
 
     let result = (|| {
         let contents = std::fs::read_to_string(&canonical).map_err(|error| Error {
@@ -218,6 +219,21 @@ mod tests {
             "@{}",
             dir.path().join("a.args").display()
         ))])
+        .unwrap_err();
+        assert!(matches!(error.kind, ErrorKind::Cycle));
+    }
+
+    #[test]
+    fn a_cycle_at_the_depth_boundary_is_still_a_cycle() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.args"), "@a.args").unwrap();
+        let error = expand_with(
+            [OsString::from(format!(
+                "@{}",
+                dir.path().join("a.args").display()
+            ))],
+            Options { max_depth: 1 },
+        )
         .unwrap_err();
         assert!(matches!(error.kind, ErrorKind::Cycle));
     }


### PR DESCRIPTION
## Summary

- add opt-in response-file expansion to the usage-rs facade
- support shell-style words, nested relative includes, and @@ escaping
- reject include cycles and bound nesting depth with path-aware errors
- keep filesystem access and allocation outside usage-argv's ordinary parse path
- document the explicit expansion flow and verify expanded words feed typed parsing

## Testing

- `mise run ci`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New filesystem reads from user-supplied `@path` arguments (canonicalize, include cycles). Risk is bounded by being opt-in, pre-parse, and depth/cycle-limited, but callers must still decide when this is safe.
> 
> **Overview**
> Adds an opt-in `response-files` feature so apps can expand `@file` arguments **before** `Cli::parse_from`, keeping filesystem I/O and allocation off usage-argv’s zero-allocation parse path.
> 
> `usage::response::expand` / `expand_with` read UTF-8 shell-quoted words (`shell-words`), resolve nested includes relative to the including file, treat `@@value` as a literal `@value`, and reject cycles with a default nesting cap of 16. Errors include the offending path.
> 
> Docs cover the explicit expansion flow and why it is not inside the parser.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01f4b722573a479718e0fd67cbb0384f8d4ef8cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->