### PR TITLE
feat(test): add CLI contract record and replay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2358,6 +2358,9 @@ dependencies = [
 name = "usage-test"
 version = "6.1.1"
 dependencies = [
+ "serde",
+ "serde_json",
+ "tempfile",
  "usage-argv",
 ]
 

--- a/docs/rust/testing.md
+++ b/docs/rust/testing.md
@@ -40,6 +40,40 @@ The test must be under `tests/`. Cargo provides the compiled path as
 `target/` lives. The raw `stdout` and `stderr` byte vectors remain available for commands that
 intentionally write non-UTF-8 data.
 
+## Recording a migration contract
+
+When replacing a parser or an entire CLI implementation, record the old binary's observable
+behavior and replay the same cases against the new binary:
+
+```rust
+use usage::test::contract::{Case, Contract};
+
+let cases = [
+    Case::new("short help", ["-h"]),
+    Case::new("invalid format", ["--format", "wat"]),
+    Case::new("stdin input", ["--stdin"]).stdin(b"hello\n".to_vec()),
+];
+
+// Run intentionally when establishing or updating the checked-in fixture.
+Contract::record("target/debug/old-cli", cases)?.save("tests/cli-contract.json")?;
+
+// Keep this in the candidate CLI's integration tests.
+Contract::load("tests/cli-contract.json")?
+    .replay(env!("CARGO_BIN_EXE_new-cli"))?
+    .assert_match();
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+The versioned JSON fixture stores each case's argv, environment overrides and removals, optional
+stdin and working directory, then the exact exit status, stdout, and stderr. UTF-8 streams remain
+readable strings; non-UTF-8 streams use byte arrays. Replay runs every case and reports all changed
+surfaces together, so a migration can distinguish intended help changes from accidental exit-code
+or diagnostic regressions.
+
+The process inherits the test's environment unless a case overrides or removes a variable. Keep
+inputs deterministic: timestamps, random temporary paths, network responses, and inherited locale
+should be pinned by the test when they affect output.
+
 ## What a command line does
 
 `outcome` gives back what `parse()` would have _done_, as a value: a struct, a page, a version,

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -10,10 +10,12 @@ repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
 
-# A test harness may have dependencies where the runtime may not, and still has none:
-# everything here is the cold half of usage-argv, asked a question instead of printed.
+# A test harness may have dependencies where the runtime may not. serde is used only for
+# portable black-box migration contracts; everything else is the cold half of usage-argv.
 [dependencies]
 usage-argv = { workspace = true, features = ["spec"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [features]
 # Asking what a CLI would offer for a half-typed line. Off by default, so a CLI that only
@@ -23,3 +25,6 @@ completions = ["usage-argv/complete"]
 [package.metadata.release]
 shared-version = true
 release = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/test/src/contract.rs
+++ b/test/src/contract.rs
@@ -1,0 +1,317 @@
+//! Record and replay a CLI's black-box behavior during a migration.
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use serde::{Deserialize, Serialize};
+
+const FORMAT_VERSION: u32 = 1;
+
+/// One invocation whose observable behavior belongs to a CLI's compatibility contract.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Case {
+    pub name: String,
+    pub argv: Vec<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub env: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env_remove: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(with = "bytes")]
+    pub stdin: Vec<u8>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+}
+
+impl Case {
+    pub fn new<I, S>(name: impl Into<String>, argv: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self {
+            name: name.into(),
+            argv: argv.into_iter().map(Into::into).collect(),
+            env: BTreeMap::new(),
+            env_remove: Vec::new(),
+            stdin: Vec::new(),
+            cwd: None,
+        }
+    }
+
+    pub fn env(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.env.insert(name.into(), value.into());
+        self
+    }
+
+    pub fn env_remove(mut self, name: impl Into<String>) -> Self {
+        self.env_remove.push(name.into());
+        self
+    }
+
+    pub fn stdin(mut self, bytes: impl Into<Vec<u8>>) -> Self {
+        self.stdin = bytes.into();
+        self
+    }
+
+    pub fn cwd(mut self, path: impl Into<String>) -> Self {
+        self.cwd = Some(path.into());
+        self
+    }
+}
+
+/// The exact process result recorded for one case.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Observation {
+    pub success: bool,
+    pub code: Option<i32>,
+    #[serde(with = "bytes")]
+    pub stdout: Vec<u8>,
+    #[serde(with = "bytes")]
+    pub stderr: Vec<u8>,
+}
+
+/// One named input and the result produced by the reference binary.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecordedCase {
+    #[serde(flatten)]
+    pub input: Case,
+    pub expected: Observation,
+}
+
+/// A versioned, portable set of black-box CLI expectations.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Contract {
+    pub format_version: u32,
+    pub cases: Vec<RecordedCase>,
+}
+
+impl Contract {
+    /// Run every case against a reference binary and capture its observable contract.
+    pub fn record<I>(program: impl AsRef<Path>, cases: I) -> std::io::Result<Self>
+    where
+        I: IntoIterator<Item = Case>,
+    {
+        let program = program.as_ref();
+        let cases = cases
+            .into_iter()
+            .map(|input| {
+                let expected = run(program, &input)?;
+                Ok(RecordedCase { input, expected })
+            })
+            .collect::<std::io::Result<Vec<_>>>()?;
+        Ok(Self {
+            format_version: FORMAT_VERSION,
+            cases,
+        })
+    }
+
+    /// Write a stable, reviewable JSON fixture.
+    pub fn save(&self, path: impl AsRef<Path>) -> std::io::Result<()> {
+        let mut bytes = serde_json::to_vec_pretty(self).map_err(invalid_data)?;
+        bytes.push(b'\n');
+        std::fs::write(path, bytes)
+    }
+
+    /// Read a fixture and reject formats this version does not understand.
+    pub fn load(path: impl AsRef<Path>) -> std::io::Result<Self> {
+        let contract: Self = serde_json::from_slice(&std::fs::read(path)?).map_err(invalid_data)?;
+        if contract.format_version != FORMAT_VERSION {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "unsupported CLI contract format {}; expected {FORMAT_VERSION}",
+                    contract.format_version
+                ),
+            ));
+        }
+        Ok(contract)
+    }
+
+    /// Run the recorded inputs against another binary and return every mismatch.
+    pub fn replay(&self, program: impl AsRef<Path>) -> std::io::Result<Replay> {
+        let program = program.as_ref();
+        let mut mismatches = Vec::new();
+        for recorded in &self.cases {
+            let actual = run(program, &recorded.input)?;
+            if actual != recorded.expected {
+                mismatches.push(Mismatch {
+                    name: recorded.input.name.clone(),
+                    expected: recorded.expected.clone(),
+                    actual,
+                });
+            }
+        }
+        Ok(Replay { mismatches })
+    }
+}
+
+/// The result of replaying a contract against a candidate binary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Replay {
+    pub mismatches: Vec<Mismatch>,
+}
+
+impl Replay {
+    pub fn is_match(&self) -> bool {
+        self.mismatches.is_empty()
+    }
+
+    /// Assert every case matched, with a compact text diff of changed process surfaces.
+    #[track_caller]
+    pub fn assert_match(self) {
+        assert!(self.is_match(), "{self}");
+    }
+}
+
+impl fmt::Display for Replay {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.is_match() {
+            return f.write_str("all CLI contract cases matched");
+        }
+        writeln!(f, "{} CLI contract case(s) changed:", self.mismatches.len())?;
+        for mismatch in &self.mismatches {
+            writeln!(f, "- {}", mismatch.name)?;
+            if (mismatch.expected.success, mismatch.expected.code)
+                != (mismatch.actual.success, mismatch.actual.code)
+            {
+                writeln!(
+                    f,
+                    "  status: expected {:?}, got {:?}",
+                    mismatch.expected.code, mismatch.actual.code
+                )?;
+            }
+            if mismatch.expected.stdout != mismatch.actual.stdout {
+                writeln!(
+                    f,
+                    "  stdout:\n    expected: {:?}\n    actual:   {:?}",
+                    String::from_utf8_lossy(&mismatch.expected.stdout),
+                    String::from_utf8_lossy(&mismatch.actual.stdout)
+                )?;
+            }
+            if mismatch.expected.stderr != mismatch.actual.stderr {
+                writeln!(
+                    f,
+                    "  stderr:\n    expected: {:?}\n    actual:   {:?}",
+                    String::from_utf8_lossy(&mismatch.expected.stderr),
+                    String::from_utf8_lossy(&mismatch.actual.stderr)
+                )?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// One case whose status or output changed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Mismatch {
+    pub name: String,
+    pub expected: Observation,
+    pub actual: Observation,
+}
+
+fn run(program: &Path, case: &Case) -> std::io::Result<Observation> {
+    let mut command = Command::new(program);
+    command.args(&case.argv).envs(&case.env);
+    for name in &case.env_remove {
+        command.env_remove(name);
+    }
+    if let Some(cwd) = &case.cwd {
+        command.current_dir(cwd);
+    }
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = command.spawn()?;
+    let input = case.stdin.clone();
+    let stdin_writer = child
+        .stdin
+        .take()
+        .map(|mut stdin| {
+            std::thread::Builder::new()
+                .name("usage-contract-stdin".into())
+                .spawn(move || stdin.write_all(&input))
+        })
+        .transpose()?;
+    let output = child.wait_with_output()?;
+    if let Some(stdin_writer) = stdin_writer {
+        stdin_writer
+            .join()
+            .map_err(|_| std::io::Error::other("CLI contract stdin writer panicked"))??;
+    }
+    Ok(Observation {
+        success: output.status.success(),
+        code: output.status.code(),
+        stdout: output.stdout,
+        stderr: output.stderr,
+    })
+}
+
+fn invalid_data(error: impl std::error::Error + Send + Sync + 'static) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidData, error)
+}
+
+mod bytes {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match std::str::from_utf8(bytes) {
+            Ok(text) => serializer.serialize_str(text),
+            Err(_) => bytes.serialize(serializer),
+        }
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum TextOrBytes {
+            Text(String),
+            Bytes(Vec<u8>),
+        }
+        Ok(match TextOrBytes::deserialize(deserializer)? {
+            TextOrBytes::Text(text) => text.into_bytes(),
+            TextOrBytes::Bytes(bytes) => bytes,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_contract_round_trips_and_replays() {
+        let program = std::env::current_exe().unwrap();
+        let contract = Contract::record(&program, [Case::new("help", ["--help"])]).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("contract.json");
+        contract.save(&path).unwrap();
+        let fixture = std::fs::read_to_string(&path).unwrap();
+        assert!(fixture.contains(r#""stdout": "#), "{fixture}");
+        let loaded = Contract::load(path).unwrap();
+        assert_eq!(loaded, contract);
+        loaded.replay(program).unwrap().assert_match();
+    }
+
+    #[test]
+    fn replay_reports_the_surface_that_changed() {
+        let program = std::env::current_exe().unwrap();
+        let mut contract = Contract::record(&program, [Case::new("help", ["--help"])]).unwrap();
+        contract.cases[0].expected.stdout = b"old help\n".to_vec();
+        let replay = contract.replay(program).unwrap();
+        assert_eq!(replay.mismatches.len(), 1);
+        let rendered = replay.to_string();
+        assert!(rendered.contains("help"), "{rendered}");
+        assert!(rendered.contains("stdout"), "{rendered}");
+    }
+}

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -51,6 +51,8 @@ use usage_argv::Error;
 
 pub use usage_argv::help::Page;
 
+pub mod contract;
+
 #[cfg(feature = "completions")]
 pub use usage_argv::complete::{Completions, Files, Shell};
 


### PR DESCRIPTION
## Summary

- add a versioned JSON contract format for black-box CLI migration tests
- record argv, environment, stdin, working directory, status, stdout, and stderr from a reference binary
- replay all cases against a candidate binary and report every changed surface together
- preserve readable UTF-8 output while supporting exact non-UTF-8 byte streams
- document the record-and-replay workflow

## Testing

- `mise run ci`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-harness only: new record/replay helpers and serde JSON fixtures, with no runtime CLI or security-path changes.
> 
> **Overview**
> Adds a **record-and-replay contract** in `usage-test` for migrating a parser or whole CLI: capture a reference binary’s observable behavior, check it in as versioned JSON, then replay the same cases against a candidate.
> 
> Each `Case` can pin argv, env overrides/removals, stdin, and cwd. Replay compares exit status, stdout, and stderr together and prints every changed surface. UTF-8 streams stay readable strings in the fixture; non-UTF-8 is stored as bytes.
> 
> `Contract::record` / `save` / `load` / `replay().assert_match()` is documented in the Rust testing guide. `serde`/`serde_json` are added as harness dependencies (not the CLI runtime).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 819e5d3887ebc4a868607ef731dc6945107fd69c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->