### PR TITLE
docs: fix stale and incorrect claims, tighten rust-page prose

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -68,14 +68,14 @@ export default defineConfig({
           { text: "Updating Values", link: "/rust/update-from" },
           { text: "Subcommands", link: "/rust/subcommands" },
           { text: "Dispatch", link: "/rust/dispatch" },
-          { text: "Migrating from clap", link: "/rust/migrating-from-clap" },
           { text: "Validation", link: "/rust/validation" },
-          { text: "Configuration", link: "/rust/configuration" },
           { text: "Help, Version, and Errors", link: "/rust/help" },
-          { text: "Performance", link: "/rust/performance" },
           { text: "Completions", link: "/rust/completions" },
+          { text: "Configuration", link: "/rust/configuration" },
           { text: "Testing", link: "/rust/testing" },
-          { text: "Spec Output", link: "/rust/spec" }
+          { text: "Spec Output", link: "/rust/spec" },
+          { text: "Migrating from clap", link: "/rust/migrating-from-clap" },
+          { text: "Performance", link: "/rust/performance" }
         ]
       },
       {

--- a/docs/cli/completions.md
+++ b/docs/cli/completions.md
@@ -114,9 +114,9 @@ usage g completion powershell mycli -f ./mycli.usage.kdl > ./mycli.ps1
 mycli --<TAB>
 ```
 
-The supported 6.x targets are bash, zsh, fish, PowerShell, and Nushell. The
-first four are the clap-compatibility set; Nushell is a usage extension. Elvish
-is not a 6.0 target.
+Spec-based generation with `usage g completion` supports bash, zsh, fish,
+PowerShell, and Nushell. Elvish is not among them — though the
+[Rust framework](/rust/completions)'s runtime completions do support it.
 
 ::: info
 Usage CLI is a runtime dependency for the generated completion scripts. Your users

--- a/docs/cli/markdown.md
+++ b/docs/cli/markdown.md
@@ -2,28 +2,12 @@
 
 Usage CLI can generate markdown documentation from a Usage definition either into a single file, or a directory.
 
-Single file (will be injected in the comment):
+Single file, written with `--out-file` (or to stdout, the default, so you can redirect it
+wherever you like):
 
 ```sh
-$ cat <<EOF > ./README.md
-# My CLI
-## Header
-...
-## CLI Commands
-<!-- usage:start -->
-## Footer
-...
-EOF
-$ usage g markdown -f ./mycli.usage.kdl --inject README.md
-$ cat README.md
-# My CLI
-## Header
-## CLI Commands
-<!-- usage:start -->
-### `mycli config add KEY VALUE`
-### `mycli config remove NAME`
-<!-- usage:end   -->
-## Footer
+$ usage g markdown -f ./mycli.usage.kdl --out-file ./docs/cli.md
+$ usage g markdown -f ./mycli.usage.kdl > ./docs/cli.md
 ```
 
 Multiple files:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -25,16 +25,16 @@ respond to every PR with detailed context. A rejection may be brief.
 
 ## Code Style
 
-All of these repos use [hk](https://hk.jdx.dev) for linting and formatting.
-Run the checks before opening a PR:
+Linting and formatting run through mise tasks. Run the checks before opening a
+PR:
 
 ```sh
-hk check --all
-hk fix --all
+mise run lint
+mise run lint-fix
 ```
 
-Some repos also expose wrapper tasks such as `mise run lint` and
-`mise run lint-fix`; prefer those when they exist.
+`mise run ci` runs the full CI check. (Some of my other repos use
+[hk](https://hk.jdx.dev) for this instead — check each repo for its own tasks.)
 
 ## Commit and PR Titles
 

--- a/docs/go/completions.md
+++ b/docs/go/completions.md
@@ -23,12 +23,16 @@ whole point. The `Position` tells you where the cursor stands:
 
 ```go
 type Position struct {
-	Cmd           *argv.Command   // the command in scope
-	Chain         []*argv.Command // root → here
-	FlagsPossible bool            // false past `--`
-	AwaitingValue *argv.Flag      // cursor is inside this flag's value
-	NextArg       *argv.Arg       // the positional that would bind next
-	HelpTopic     bool            // after `help`: completing a topic, not a command to run
+	Cmd                 *argv.Command   // the command in scope
+	Chain               []*argv.Command // root → here
+	FlagsPossible       bool            // false past `--`
+	SubcommandsPossible bool            // false once a positional has taken a word
+	AwaitingValue       *argv.Flag      // cursor is inside this flag's value
+	Collecting          *argv.Flag      // a variadic flag still claiming words
+	NextArg             *argv.Arg       // the positional that would bind next
+	NextArgValues       uint32          // values already bound to NextArg
+	SeparatorSeen       bool            // a `--` has been typed
+	HelpTopic           bool            // after `help`: completing a topic, not a command to run
 }
 ```
 
@@ -73,14 +77,33 @@ calls your binary back with
 ```
 
 Unlike the Rust framework — which intercepts `__complete_word__` automatically — the Go side
-leaves the wiring to you today:
+asks for one call before normal parsing:
 
-1. **Recognize the hidden subcommand** before normal parsing (check `args[0]`).
-2. **Split the line** into completed words plus the partial word under the cursor.
-3. Call `Walk` → `Candidates` → `RenderAnswer` and print the result.
-4. **Generate the install scripts** from your spec with the Rust CLI:
-   `usage g completion bash mycli --file mycli.usage.kdl` (and zsh/fish/…).
+```go
+if out, ok := argv.Respond(os.Args[1:], mycli.Root, mycli.HelpText, mycli.Meta); ok {
+	fmt.Print(out)
+	return
+}
+```
 
-Also not carried into the generated tables yet: spec-level `complete` run-scripts (only
-`choices` are known to `Candidates`) and `value_hint` (derive an `Answer.Files` request
-yourself where you want path completion).
+`Respond` recognizes the hidden subcommand, splits the line at the cursor, walks the tables,
+and renders the answer in the calling shell's dialect. `false` means argv was an ordinary
+invocation — the cue to parse it as one. The steps are exported individually when you want to
+stand between them: `argv.ParseRequest` reads the request out of argv, `Request.Answer` works
+out the candidates and whether paths belong, and `argv.Split` does the shell-aware line
+splitting on its own.
+
+The scripts that register your binary with each shell come from the same package:
+
+```go
+argv.Script("mycli", argv.Zsh) // and Bash, Fish, Nu, PowerShell
+```
+
+Each script's whole job is to hand the line to your binary and present what comes back the way
+its shell presents things. There is no runtime dependency on the `usage` CLI and no spec file
+involved — the binary was compiled with the tables.
+
+One thing is not answered from the tables: spec-level `complete` run-scripts. A `run=` block
+shells out, which this package will not do on a Tab. File, directory, executable, and command
+completion need no script — `Answer` derives them from a `complete` block's declared type and
+from value names like `<FILE>` and `<DIR>`, and asks the shell to complete the path itself.

--- a/docs/go/index.md
+++ b/docs/go/index.md
@@ -12,8 +12,9 @@ The Go framework builds your CLI from a usage spec — but unlike most Go CLI li
 shipped binary never parses the spec. `usage generate go` lowers the KDL into plain Go tables,
 typed structs, and a `Parse` function at build time. The result:
 
-- **Zero dependencies.** The module is `github.com/jdx/usage/go` and imports nothing but the
-  standard library.
+- **One small dependency.** The module is `github.com/jdx/usage/go`; beyond the standard
+  library it imports only [expr](https://github.com/expr-lang/expr), which evaluates a spec's
+  validation expressions.
 - **Zero-allocation routing.** The low-level event parser allocates nothing on success or
   failure — roughly 57–110ns per parse on mise's real 211-command spec. Generated `Parse` adds
   typed binding, defaults, and validation on top.
@@ -146,9 +147,9 @@ Worth knowing before you commit:
   `argv.ApplyOverrides` itself.
 - **Fields are `string`, `bool`, `[]string`, or `int` (for counts).** A spec says what a value is
   called, never what type it is — convert with [`argv.Int`, `argv.Duration`, etc.](/go/binding#typed-values)
-- **`complete` scripts, `config` nodes, `group`, `value_hint`, and `mount` are not carried into
-  the generated tables.** Completions know `choices`; config resolution is not implemented.
-- **Completion shell scripts come from the Rust side.** The Go runtime answers completion
-  requests over the same protocol, but you wire up the hidden subcommand yourself — see
-  [Completions](/go/completions).
+- **`complete` run-scripts, `config` nodes, `group`, `value_hint`, and `mount` are not carried
+  into the generated tables.** Completions still offer `choices` and derive file, directory,
+  executable, and command completion from `complete` types and value names — only `run=`
+  shell-out completers are unsupported, since they mean running a subprocess on every Tab. See
+  [Completions](/go/completions). Config resolution is not implemented.
 - Command trees deeper than 16 levels are rejected (`CodeTooDeep`); short flags must be ASCII.

--- a/docs/rust/args-and-flags.md
+++ b/docs/rust/args-and-flags.md
@@ -35,7 +35,8 @@ has nowhere to put "absent", so `T` means required:
 
 Values are built with `FromStr`, so `PathBuf`, `usize`, `IpAddr`, and your own types all work.
 The `FromStr` error type must implement `Display` (a compile error names the type otherwise);
-a conversion failure at runtime becomes `Error::InvalidValue { name, value, reason }`.
+a conversion failure at runtime becomes `Error::InvalidValue(e)`, whose payload carries the
+argument's name, the offending value, and the reason.
 
 On Unix, `PathBuf` and `OsString` keep non-UTF-8 argv bytes unchanged. `String` fields report
 invalid UTF-8 rather than replacing it. On Windows, values that cannot be converted safely are
@@ -176,7 +177,7 @@ fallback without pretending there is a finite list.
 
 `#[usage(allow_hyphen_values)]` makes `--args -destroy` bind `-destroy` instead of reading `-d`
 as a short. The flag has to take a value; a positional that needs the same thing already has
-`double_dash = "automatic"`. Emitted KDL:
+`double_dash = "automatic"`. In KDL:
 `flag "--args <ARGS>" allow_hyphen_values=#true`.
 
 `#[usage(allow_negative_numbers)]` makes `--jobs -1` bind `-1`, while `--jobs --force` still
@@ -201,7 +202,7 @@ such as `num_args = 1..=3` sets the corresponding nested bounds; distinct
 `value_names` require an exact bound matching their count.
 
 `#[usage(require_equals)]` makes `--inspect=9229` bind while `--inspect 9229` is a missing
-value. The flag has to take a value. Emitted KDL:
+value. The flag has to take a value. In KDL:
 `flag "--inspect <PORT>" require_equals=#true`.
 
 `#[usage(bool_value)]` is an opt-in for explicit boolean long-flag values:
@@ -211,7 +212,7 @@ portable form is `flag "--color" bool_value=#true`.
 
 With `#[usage(default_missing = "always")]`, `--color` binds `always`, `--color=never` binds
 `never`, and an absent flag stays `None`. The flag has to take a value. Help shows the value as
-optional. Emitted KDL:
+optional. In KDL:
 `flag "--color <WHEN>" default_missing="always"`. Combined with `require_equals`,
 a following word is still refused.
 
@@ -302,3 +303,35 @@ On a `#[derive(Args)]` struct (refused on the root):
 | `mount = "…"`           | Mount a subprocess-provided spec for completions ([Spec output](/rust/spec)) |
 | `restart_token = ":::"` | Token that restarts parsing (for wrapper CLIs)                               |
 | `effect = "…"`          | The command's [effect classification](/spec/#command-effects)                |
+
+## Outputs and exit codes
+
+A command can also declare what it writes to stdout and what its exit statuses mean. The
+declarations travel into the spec, generated docs and manpages, `usage mcp`, and generated
+SDKs:
+
+```rust
+/// Check the project
+#[derive(usage::Args)]
+#[usage(
+    output("human", default, help = "A human-readable report"),
+    output("json", framing = "json", schema_from = Report),
+    exit_code(0, "all checks passed"),
+    exit_code(1, "a check failed"),
+)]
+struct Check {
+    /// Output format
+    #[usage(long, select)]
+    format: Option<String>,
+}
+```
+
+`select` on a value-taking flag names it as the selector, and its choices are filled from the
+output names. A boolean flag that picks one output is named from the output instead —
+`output("json", framing = "json", select = "--json")` — and `select = "--format"` as a
+container attribute is the same thing spelled the way the KDL node is. An output also takes
+`hide`, and a schema comes from `schema = "…"`, `schema_from = Type` (via `schemars`), or
+`schema_fn = path` where the function returns a `String`. Declared on the root `#[derive(Cli)]`
+struct, outputs and exit codes apply CLI-wide, and a command can refine what it inherits. The
+full model — framings, schema files, inheritance — is on the
+[spec reference](/spec/reference/output).

--- a/docs/rust/args-and-flags.md
+++ b/docs/rust/args-and-flags.md
@@ -151,6 +151,14 @@ The tables below cover the attributes most CLIs need.
 | `effect = "…"`                     | `"read"`, `"write"`, or `"destructive"` — see [command effects](/spec/#command-effects) |
 | `setting = "key"`                  | Bind to a config setting ([Configuration](/rust/configuration))                         |
 
+The rest of this section expands the entries that need more than a table row.
+
+### Skipped fields
+
+`#[usage(skip)]` keeps a field on the struct for computed state without adding it to the spec,
+parse tables, or help. Combining it with `long`, `arg`, or any other field option is a compile
+error. The type has to implement `Default`.
+
 ### Suggested values without strict validation
 
 Use `choices_strict = false` when the declared choices should drive help and
@@ -164,27 +172,7 @@ backend: Option<String>,
 The portable form is `choices strict=#false core git`. Strict validation remains
 the default.
 
-`#[usage(skip)]` keeps a field on the struct for computed state without adding it to the spec,
-parse tables, or help. Combining it with `long`, `arg`, or any other field option is a compile
-error. The type has to implement `Default`.
-
-`value_hint` accepts `Unknown`, `Other`, `FilePath`, `AnyPath`, `DirPath`, `ExecutablePath`,
-`CommandName`, `CommandString`, `CommandWithArguments`, `Username`, `Hostname`, `Url`, and
-`EmailAddress`. `CommandWithArguments` is for wrapper CLIs and must be a positional `Vec` with
-`double_dash = "automatic"`: its first value completes from the shell's commands, while later
-values fall back to ordinary argument paths. `Other`, URL, and email values suppress filename
-fallback without pretending there is a finite list.
-
-`#[usage(allow_hyphen_values)]` makes `--args -destroy` bind `-destroy` instead of reading `-d`
-as a short. The flag has to take a value; a positional that needs the same thing already has
-`double_dash = "automatic"`. In KDL:
-`flag "--args <ARGS>" allow_hyphen_values=#true`.
-
-`#[usage(allow_negative_numbers)]` makes `--jobs -1` bind `-1`, while `--jobs --force` still
-leaves a flag-like token for normal parsing.
-
-`#[usage(value_terminator = ";")]` ends a `Vec` without storing the terminator.
-It works on variadic flags and positionals and emits `value_terminator=";"` in KDL.
+### Multiple values
 
 Fixed multi-value fields declare their cardinality and placeholders together:
 
@@ -201,6 +189,19 @@ while flag-level bounds count how many times a repeatable flag appears. A range
 such as `num_args = 1..=3` sets the corresponding nested bounds; distinct
 `value_names` require an exact bound matching their count.
 
+`#[usage(value_terminator = ";")]` ends a `Vec` without storing the terminator.
+It works on variadic flags and positionals and emits `value_terminator=";"` in KDL.
+
+### Parsing behavior
+
+`#[usage(allow_hyphen_values)]` makes `--args -destroy` bind `-destroy` instead of reading `-d`
+as a short. The flag has to take a value; a positional that needs the same thing already has
+`double_dash = "automatic"`. In KDL:
+`flag "--args <ARGS>" allow_hyphen_values=#true`.
+
+`#[usage(allow_negative_numbers)]` makes `--jobs -1` bind `-1`, while `--jobs --force` still
+leaves a flag-like token for normal parsing.
+
 `#[usage(require_equals)]` makes `--inspect=9229` bind while `--inspect 9229` is a missing
 value. The flag has to take a value. In KDL:
 `flag "--inspect <PORT>" require_equals=#true`.
@@ -209,6 +210,8 @@ value. The flag has to take a value. In KDL:
 `--color`, `--color=true`, and `--color=false` bind true, true, and false. A
 detached `--color false` never consumes `false`; it remains a positional. The
 portable form is `flag "--color" bool_value=#true`.
+
+### Optional values and conditional defaults
 
 With `#[usage(default_missing = "always")]`, `--color` binds `always`, `--color=never` binds
 `never`, and an absent flag stays `None`. The flag has to take a value. Help shows the value as
@@ -232,6 +235,8 @@ flag "--bin-names" {
 }
 ```
 
+### Argument relations
+
 Argument relations (`conflicts`, `requires`, `required_if`, `required_if_eq`, `required_unless`) name
 their target the way the KDL spec does — `"--long"` or `"-s"`, one value or a list:
 
@@ -243,6 +248,15 @@ stdin: bool,
 Naming a flag or positional that doesn't exist on the command is a **compile error**, not a
 runtime surprise. Conflicts, requires, and conditional requiredness may name flags or
 positionals; `overrides` and some `requires_if` forms stay flag-only.
+
+### Completion hints
+
+`value_hint` accepts `Unknown`, `Other`, `FilePath`, `AnyPath`, `DirPath`, `ExecutablePath`,
+`CommandName`, `CommandString`, `CommandWithArguments`, `Username`, `Hostname`, `Url`, and
+`EmailAddress`. `CommandWithArguments` is for wrapper CLIs and must be a positional `Vec` with
+`double_dash = "automatic"`: its first value completes from the shell's commands, while later
+values fall back to ordinary argument paths. `Other`, URL, and email values suppress filename
+fallback without pretending there is a finite list.
 
 ## Resolution order
 

--- a/docs/rust/completions.md
+++ b/docs/rust/completions.md
@@ -35,9 +35,8 @@ pub fn install_completion_for_alias(alias, shell, env, on_foreign) -> Result<Ins
 pub fn completion_request(argv: &[OsString]) -> Option<String>;
 ```
 
-`Shell` covers `Bash`, `Elvish`, `Zsh`, `Fish`, `Nu`, and `PowerShell`.
-
-This covers clap's native shell set and adds a usage-native Nushell target.
+`Shell` covers `Bash`, `Elvish`, `Zsh`, `Fish`, `Nu`, and `PowerShell` — clap's native shell
+set plus a usage-native Nushell target.
 
 ## How it works
 

--- a/docs/rust/configuration.md
+++ b/docs/rust/configuration.md
@@ -203,12 +203,23 @@ that narrows further than the setting does — a `uint` setting held as a `u16` 
 
 ## The spec carries the settings
 
-A root deriving [`Cli`](/rust/args-and-flags) names its settings type, and its emitted spec
-carries the `config` block — so docs, JSON schema, and the reserved `config_keys` /
-`config_values` completers read declarations made in Rust exactly as they read ones made in
-KDL:
+The struct is the only declaration. `Settings::spec_kdl()` renders it as the spec's
+`config { source …; file …; prop … }` block, and a root deriving [`Cli`](/rust/args-and-flags)
+puts that block in its emitted spec by naming the type — so docs, the JSON schema, and the
+reserved `config_keys` / `config_values` completers read settings declared in Rust exactly as
+they read ones written in KDL:
 
 ```rust
+#[derive(usage::Config)]
+#[usage(source(kind = "git", name = "git config", doc_hint = "git config `{key}`"))]
+#[usage(file(path = "/etc/ex.toml", scope = "system"))]
+#[usage(file(path = "ex.toml", findup))]
+struct Settings {
+    #[usage(env = "EX_JOBS", default = 4, help_heading = "Performance", writes_to = "git",
+            x("ex.restart_required", true))]
+    jobs: u64,
+}
+
 #[derive(usage::Cli)]
 #[usage(bin = "ex", config = Settings)]
 struct Ex {
@@ -223,26 +234,6 @@ documented one. The adopter's whole drift test is one line:
 
 ```rust
 assert_eq!(Settings::SETTINGS_REGISTRY.drift(Ex::SETTINGS_BINDINGS), Vec::<String>::new());
-```
-
-## The spec block
-
-The struct is the only declaration. `Settings::spec_kdl()` renders it as the spec's
-`config { source …; file …; prop … }` block, and `#[usage(config = Settings)]` on the `Cli`
-root puts that block in the emitted spec — so docs, the JSON schema, and the `config_keys` /
-`config_values` completers read settings declared in Rust exactly as they read ones written
-in KDL.
-
-```rust
-#[derive(usage::Config)]
-#[usage(source(kind = "git", name = "git config", doc_hint = "git config `{key}`"))]
-#[usage(file(path = "/etc/ex.toml", scope = "system"))]
-#[usage(file(path = "ex.toml", findup))]
-struct Settings {
-    #[usage(env = "EX_JOBS", default = 4, help_heading = "Performance", writes_to = "git",
-            x("ex.restart_required", true))]
-    jobs: u64,
-}
 ```
 
 There is no second, KDL-first backend to choose between: a `build.rs` that generated the

--- a/docs/rust/dispatch.md
+++ b/docs/rust/dispatch.md
@@ -118,8 +118,7 @@ naming it.
 
 The generated implementation is generic over the context, so `RunWith<&Config>`,
 `RunWith<&mut App>` and `RunWith<Arc<Ctx>>` are all ordinary implementations rather than shapes
-this crate has to anticipate. An enum may say both `run` and `run_with`, which is what a CLI
-part-way through adopting a context needs.
+this crate has to anticipate.
 
 Two traits rather than one with a defaulted context, because otherwise the noise lands on the
 wrong side: a hundred commands that need nothing shared would each carry `fn run(self, _: ())`.

--- a/docs/rust/dispatch.md
+++ b/docs/rust/dispatch.md
@@ -341,7 +341,9 @@ enum Commands {
 
 `run_with` passes `(argv, ctx)`; `run_async` awaits the function. If the first command is not
 a reliable `Output` source — or the catch-all is the first variant — name the type with
-`output = miette::Result<()>`.
+`output = miette::Result<()>`. This `output =` is the dispatch return type, unrelated to
+`#[usage(output(...))]`, which declares what a command
+[writes to stdout](/rust/args-and-flags#outputs-and-exit-codes).
 
 ## What it says in the spec
 

--- a/docs/rust/help.md
+++ b/docs/rust/help.md
@@ -39,10 +39,6 @@ binary should print.
 
 `Error` is `#[non_exhaustive]` — always keep a fallback arm.
 
-`version` supplies the concise `-V` response. `long_version` optionally supplies a richer
-`--version` response, falling back to `version` when omitted. Computed expressions use matching
-`version_spec` / `long_version_spec` literals so emitted KDL stays portable.
-
 That match is also the post-parse interception point. An application that must
 run an update notifier, rewrite output, or re-exec before answering help or
 version does that work in the corresponding arm and then renders or returns.
@@ -222,9 +218,11 @@ a `clap::Command` — a template is one of the settings to carry across by hand 
 ## Version
 
 Declaring `version` (or bare `version`, which reads `CARGO_PKG_VERSION`) gives the root command
-`--version` and `-V`, and lists them on its page. If your CLI declares its own `--version` or
-`-V`, your spelling wins, the other still answers, and the page shows whichever is left — where
-clap panics at startup for the same collision.
+`--version` and `-V`, and lists them on its page. `long_version` optionally supplies a richer
+`--version` response, falling back to `version` when omitted; computed expressions use matching
+`version_spec` / `long_version_spec` literals so emitted KDL stays portable. If your CLI declares
+its own `--version` or `-V`, your spelling wins, the other still answers, and the page shows
+whichever is left — where clap panics at startup for the same collision.
 
 `parse()` prints `{bin} {version}` and exits `0`.
 

--- a/docs/rust/index.md
+++ b/docs/rust/index.md
@@ -10,7 +10,7 @@ first-class environment and config-file resolution, advanced shell completions, 
 validation, negation flags, typed argument groups, categorized subcommands, and more.
 
 In the mise-scale benchmark it parses hundreds of times faster than clap, with no third-party
-runtime crates and a 1.6 MB stripped binary versus clap's 3.1 MB. See the
+runtime crates and a 1.3 MB stripped binary versus clap's 3.1 MB. See the
 [performance results](/rust/performance) and [clap migration guide](/rust/migrating-from-clap).
 
 The same declaration also becomes a portable [usage spec](/spec/) that the binary can print.
@@ -68,13 +68,13 @@ derive's compiler, which runs at build time ([comparison with clap](/rust/migrat
 `usage-rs` is a facade. Applications should depend on it alone. The split underneath stays
 available for low-level adopters that want a thinner surface:
 
-| Crate          | Role                                                                                   |
-| -------------- | -------------------------------------------------------------------------------------- |
-| `usage-rs`     | The one package an application depends on; re-exports the whole runtime                |
-| `usage-derive` | The derive macros: `Cli`, `Args`, `Subcommands`, `ValueEnum`, `ArgGroup`               |
-| `usage-argv`   | The zero-allocation, zero-dependency runtime the derive emits code against             |
-| `usage-test`   | Test helpers: what a command line parses to, what a page says, what a shell is offered |
-| `usage-config` | Layered settings resolution with provenance ([Configuration](/rust/configuration))     |
+| Crate          | Role                                                                                                                 |
+| -------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `usage-rs`     | The one package an application depends on; re-exports the whole runtime                                              |
+| `usage-derive` | The derive macros: `Cli`, `Args`, `Subcommands`, `ValueEnum`, `ArgGroup`, and `Config` (behind the `config` feature) |
+| `usage-argv`   | The zero-allocation, zero-dependency runtime the derive emits code against                                           |
+| `usage-test`   | Test helpers: what a command line parses to, what a page says, what a shell is offered                               |
+| `usage-config` | Layered settings resolution with provenance ([Configuration](/rust/configuration))                                   |
 
 ### Cargo features
 
@@ -97,7 +97,7 @@ available for low-level adopters that want a thinner surface:
 pub fn parse() -> Self;
 
 // parse the given argv; hand errors (including help/version requests) back to you
-pub fn parse_from<'v>(argv: &'v [&'v OsStr]) -> Result<Self, usage::Error<'static, 'v>>;
+pub fn parse_from<'v>(argv: &[&'v OsStr]) -> Result<Self, usage::Error<'static, 'v>>;
 
 // the static parse tables and spec metadata
 pub fn command() -> &'static usage::Command<'static>;

--- a/docs/rust/index.md
+++ b/docs/rust/index.md
@@ -14,8 +14,8 @@ runtime crates and a 1.3 MB stripped binary versus clap's 3.1 MB. See the
 [performance results](/rust/performance) and [clap migration guide](/rust/migrating-from-clap).
 
 The same declaration also becomes a portable [usage spec](/spec/) that the binary can print.
-`usage-cli` turns it into documentation, manpages, and completions—the same toolchain used across
-jdx's CLIs.
+`usage-cli` turns it into documentation, manpages, and completions — the same toolchain used
+across jdx's CLIs.
 
 ```rust
 use usage::Cli;

--- a/docs/rust/migrating-from-clap.md
+++ b/docs/rust/migrating-from-clap.md
@@ -30,7 +30,7 @@ that need a decision.
 - **Prefix inference.** Intentionally unsupported. Long flags and subcommands must be spelled
   with their full name or a declared alias.
 - **Help templates and styles.** clap templates and style palettes don't port as-is. Rewrite
-  them against usage's six [help sections](/rust/help#laying-a-page-out); usage chooses terminal
+  them against usage's ten [help sections](/rust/help#laying-a-page-out); usage chooses terminal
   styles automatically.
 
 If you're migrating from a `clap::Command` value rather than from the Rust declaration,
@@ -150,6 +150,13 @@ confirmation. The ones with a nuance worth knowing:
   in-progress variadic value owner.
 - `allow_missing_positional` leaves earlier optional fields empty when only enough words remain
   for later required positionals.
+- `no_binary_name` keeps clap's meaning for `try_parse_from`: every supplied word is an
+  argument, with no argv0 to strip.
+- `dont_delimit_trailing_values` stops `delimiter` splitting once parsing crosses the trailing
+  boundary.
+- `term_width` and `max_term_width` fix or cap the width help pages wrap to.
+- Field-level `trailing_var_arg` is accepted as clap's spelling for a final greedy positional;
+  it lowers to `double_dash = "automatic"`.
 - The granular help-visibility options — `hide_default_value`, `hide_env`, `hide_env_values`,
   `hide_possible_values`, `hide_short_help`, `hide_long_help` — change presentation only, never
   defaults, environment fallback, or accepted values.
@@ -279,13 +286,13 @@ weakening them.
 clap tests usually include argv0; usage makes the choice explicit rather than guessing. Pick the
 entry point that matches what you're handing it:
 
-| Need                                       | Entry point                         |
-| ------------------------------------------ | ----------------------------------- |
-| process argv, including help/version exits | `Cli::parse()`                      |
-| words after argv0                          | `Cli::parse_from(&[&OsStr])`        |
-| full argv with argv0, returning errors     | `Cli::parse_from_argv(&[OsString])` |
-| clap-shaped call sites                     | `Cli::try_parse_from(iter)`         |
-| merging into a value you already have      | `cli.try_update_from(&[&OsStr])`    |
+| Need                                       | Entry point                       |
+| ------------------------------------------ | --------------------------------- |
+| process argv, including help/version exits | `Cli::parse()`                    |
+| words after argv0                          | `Cli::parse_from(&[&OsStr])`      |
+| full argv with argv0, returning errors     | `Cli::parse_from_argv(&[&OsStr])` |
+| clap-shaped call sites                     | `Cli::try_parse_from(&[&OsStr])`  |
+| merging into a value you already have      | `cli.try_update_from(&[&OsStr])`  |
 
 `parse_from` is the allocation-free primitive; `parse_from_argv` additionally applies multicall
 basename routing. An embedder that must intercept the built-ins handles `usage::Error::Help` and

--- a/docs/rust/spec.md
+++ b/docs/rust/spec.md
@@ -7,30 +7,33 @@ scripts for other consumers, SDK generation, and linting all consume that KDL.
 For the declarations shown across these pages, the emitted spec looks like:
 
 ```kdl
-name "ex"
-bin "ex"
+name ex
+bin ex
 version "1.2.3"
 about "does things"
-flag "-j --jobs" help="how many jobs" global=#true help_heading="Performance" env="EX_JOBS" default="4" {
-    long_help "More about jobs.\nOn two lines."
-    arg "<n>"
+flag "-j --jobs" help="how many jobs" global=#true help_heading=Performance env=EX_JOBS default="4" {
+    long_help #"""
+More about jobs.
+On two lines.
+"""#
+    arg <n>
 }
-flag "--color" help="colorize output" negate="--no-color" default="true"
+flag --color help="colorize output" negate=--no-color default="true"
 flag "-v --verbose" hide=#true count=#true
-flag "--include" var=#true var_min=1 var_max=5 overrides="--exclude" {
-    arg "<pattern>..."
+flag --include var=#true var_min=1 var_max=5 overrides=--exclude {
+    arg <pattern>...
 }
-group "input" "--file" "--url" "--stdin" required=#true
-arg "[file]" help="the file" env="EX_FILE" default="a.txt"
-cmd "install" help="install a tool" effect="write" {
-    alias "i"
-    alias "add" hide=#true
+group input --file --url --stdin required=#true
+arg "[file]" help="the file" env=EX_FILE default=a.txt
+cmd install help="install a tool" effect=write {
+    alias i
+    alias add hide=#true
     flag "-f --force"
-    arg "<tool>"
+    arg <tool>
 }
-cmd "run" help="run a task" restart_token=":::" {
+cmd run help="run a task" restart_token=::: {
     mount run="ex tasks --usage"
-    arg "[args]..." double_dash="preserve"
+    arg "[args]..." double_dash=preserve
 }
 ```
 

--- a/docs/rust/subcommands.md
+++ b/docs/rust/subcommands.md
@@ -50,8 +50,9 @@ struct Install {
   sync/async commands are covered in [Dispatch](/rust/dispatch).
 
 Variant attributes: `name`, `alias`, `alias_hidden`, `hide`, `effect`, `help`, `long_help`,
-`verbatim_doc_comment`, `external_subcommand`, `arg_required_else_help`. Aliases declared on the variant and on the `Args`
-struct are joined.
+`help_heading`, `display_order`, `deprecated`, `before_help`/`after_help` (and their `_long_`
+forms), `example`, `verbatim_doc_comment`, `external_subcommand`. Aliases declared on the variant
+and on the `Args` struct are joined.
 
 The same `Args` type may be mounted under more than one variant — useful for shared option
 groups across sibling commands.

--- a/docs/rust/validation.md
+++ b/docs/rust/validation.md
@@ -86,7 +86,7 @@ spelling, so giving one member as `-s` and another as `--file` still counts. A c
 reported before an unsatisfied group.
 
 Groups are emitted into the KDL spec
-(`group "input" "--file" "--url" "--stdin" required=#true`), and a group declared on a
+(`group input --file --url --stdin required=#true`), and a group declared on a
 [flattened](/rust/subcommands#sharing-declarations-with-flatten) struct is enforced on every
 command that flattens it. Malformed groups — one member, no members, declared twice, a group on
 a positional — are compile errors.
@@ -144,7 +144,7 @@ given. There is no default variant, so that distinction is the only spelling of 
 group has.
 
 Nothing new reaches the spec. The enum lowers to the same `group` node
-(`group "format" "--json" "--yaml" "--plain"`), so `--json --yaml` is the same
+(`group format --json --yaml --plain`), so `--json --yaml` is the same
 `ConflictingFlags` a hand-written group produces, a required group with none of its members
 given is the same `MissingGroup`, and help, docs and completions list the member flags without
 knowing an enum was involved.
@@ -194,7 +194,7 @@ value and `var_min`/`var_max` count values, not words — `--tags a,b,c,d` with 
 `VarTooMany { got: 4 }`.
 
 The field must be a `Vec`, and the delimiter must be a single ASCII character; both are enforced
-at compile time. Emitted KDL: `flag "--tags <tag>" var=#true delimiter=","`.
+at compile time. In KDL: `flag "--tags <tag>" var=#true delimiter=","`.
 
 ## Portable expressions
 

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -8,7 +8,7 @@ for CLIs. Here are some potential reasons for defining your CLI with a Usage spe
 - Generate autocompletion scripts
 - Generate markdown documentation
 - Generate man pages
-- Generate type-safe SDK client libraries for TypeScript, Python, and Rust
+- Generate type-safe SDK client libraries for TypeScript and Python
 - Use an advanced arg parser in any language
 - Scaffold one spec into different CLI frameworks—even different languages
 - [coming soon] Host your CLI documentation on usage.sh
@@ -43,8 +43,8 @@ arg "[file]" help="The file to read"     // optional positional argument
 And here is an example CLI with nested subcommands:
 
 ```kdl
-flag "-v --verbose" "Enable verbose logging" global=#true count=#true
-flag "-q --quiet" "Enable quiet logging" global=#true
+flag "-v --verbose" help="Enable verbose logging" global=#true count=#true
+flag "-q --quiet" help="Enable quiet logging" global=#true
 flag "-u --user <user>" help="User to run as"
 
 cmd "update" help="Update the CLI"

--- a/docs/spec/integrations/clap.md
+++ b/docs/spec/integrations/clap.md
@@ -6,7 +6,7 @@
 
 ```toml
 [dependencies]
-clap_usage = "6"
+clap_usage = "5"
 ```
 
 ## Quick Start
@@ -63,13 +63,16 @@ if matches.get_flag("usage-spec") {
 }
 ```
 
-Then pipe the output to `usage`:
+Then pipe the output to `usage`, passing `-f -` to read the spec from stdin:
 
 ```bash
-mycli --usage-spec | usage generate completion bash
-mycli --usage-spec | usage generate md --out-file docs.md
-mycli --usage-spec | usage generate manpage --out-file mycli.1
+mycli --usage-spec | usage generate completion bash mycli -f -
+mycli --usage-spec | usage generate md -f - --out-file docs.md
+mycli --usage-spec | usage generate manpage -f - --out-file mycli.1
 ```
+
+For completions, `--usage-cmd 'mycli --usage-spec'` can replace the pipe and
+`-f -`, letting the completion script fetch a fresh spec itself at runtime.
 
 ## What a generated spec cannot carry
 

--- a/docs/spec/integrations/cobra.md
+++ b/docs/spec/integrations/cobra.md
@@ -31,13 +31,16 @@ for _, arg := range os.Args[1:] {
 rootCmd.Execute()
 ```
 
-Then pipe the output to `usage`:
+Then pipe the output to `usage`, passing `-f -` to read the spec from stdin:
 
 ```bash
-mycli --usage-spec | usage generate completion bash
-mycli --usage-spec | usage generate md --out-file docs.md
-mycli --usage-spec | usage generate manpage --out-file mycli.1
+mycli --usage-spec | usage generate completion bash mycli -f -
+mycli --usage-spec | usage generate md -f - --out-file docs.md
+mycli --usage-spec | usage generate manpage -f - --out-file mycli.1
 ```
+
+For completions, `--usage-cmd 'mycli --usage-spec'` can replace the pipe and
+`-f -`, letting the completion script fetch a fresh spec itself at runtime.
 
 ## API
 

--- a/docs/spec/reference/arg.md
+++ b/docs/spec/reference/arg.md
@@ -46,6 +46,23 @@ Several placeholders in one argument declare fixed arity. Each label is retained
 help and generated Rust and Go tables; `var_min` and `var_max` must match the number
 of placeholders.
 
+The labels can also be spelled out with a `value_names` child node, which takes one
+or more strings:
+
+```kdl
+arg "<range>" {
+  value_names "START" "END" // same as arg "<START> <END>"
+}
+
+arg "<ITEM>..." var=#true var_min=2 var_max=2 {
+  value_names "ITEM" // one label, shown as <ITEM> <ITEM>
+}
+```
+
+The first name replaces the argument's own label. More than one name declares fixed
+arity: `var_min` and `var_max` default to the number of names and must equal it when
+given. A single name relabels the values of an exact-arity variadic.
+
 Positionals accept the same post-parse relationship nodes as flags: `conflicts`,
 `requires`, `required_if`, `required_if_eq`, `required_if_eq_all`, `required_unless`,
 and `required_unless_all`. Bare selectors name positionals and dashed selectors name
@@ -128,6 +145,8 @@ arg "<shell>" {
 
 arg "<env>" {
   choices env="DEPLOY_ENVS" // values from $DEPLOY_ENVS, split on commas and/or whitespace
+  // note: `choices env=` requires the `unstable_choices_env` cargo feature of
+  // usage-lib; the usage CLI enables it, but library consumers must opt in
 }
 
 // Rich choices keep clap PossibleValue metadata portable in KDL.
@@ -148,7 +167,7 @@ arg "<backend>" {
 
 arg "<file>" help_heading="Input" // group this arg under a heading in help output
 
-arg "<file>" long_help="longer help for --help (as oppoosed to -h)"
+arg "<file>" long_help="longer help for --help (as opposed to -h)"
 
 // double-dash behavior
 arg "<file>" double_dash="required" // arg only accepts values after a double dash; `mycli file.txt` is an error, `mycli -- file.txt` is not

--- a/docs/spec/reference/cmd.md
+++ b/docs/spec/reference/cmd.md
@@ -162,170 +162,6 @@ completion offering a command that running would hand to the default subcommand
 instead is worse than not offering it. So a root mount under a `default_subcommand`
 contributes nothing anywhere until it asks to outrank it.
 
-### Unknown flags
-
-A flag-like token that names no flag becomes a word, offered to the positionals like
-any other — because a spec often parses a command line whose flags belong to
-something else. A command that owns all of its flags can refuse them instead:
-
-```kdl
-unknown_flags "error"               // for the whole CLI
-cmd "exec" unknown_flags="value"    // except here, which forwards a command line
-```
-
-The nearest command that states a preference wins, then the spec, then `value`.
-Unlike [`effect`](#effect), this is inherited: it describes how a command line is
-read rather than what a command does. See
-[the argv grammar](../argv.md#unrecognized-flags) for the reasoning and the cost.
-
-### External subcommands
-
-An unmatched word that names no subcommand can be forwarded as an external
-command plus the rest of argv. This is clap's `allow_external_subcommands`, not
-`unknown_flags=value`: known subcommands still win, a `default_subcommand` still
-catches first, and a flag-like token on the parent is still an unknown flag.
-
-```kdl
-unknown_flags "error"
-external_subcommand #true            // the whole CLI
-cmd "exec" external_subcommand=#true // or one command
-```
-
-`ex git --help` forwards `git --help`. `ex --wat` is still an error. Once the
-unmatched word is taken, remaining tokens — including `--help` — are not parsed
-as this command's flags.
-
-See [the argv grammar](../argv.md#external-subcommands).
-
-### Require an argument or show help
-
-`arg_required_else_help` makes a bare invocation request the command's short help:
-
-```kdl
-arg_required_else_help #true             // for the whole CLI
-cmd "run" arg_required_else_help=#true // or one command
-```
-
-The policy observes argv belonging to the selected command. A global flag before a
-subcommand does not count as that subcommand's argument, and values supplied later by an
-environment variable or default do not suppress help.
-
-### Control built-in help and version entry points
-
-Each synthesized entry can be removed independently:
-
-```kdl
-disable_help_flag #true
-disable_help_subcommand #true
-disable_version_flag #true
-```
-
-The same properties are accepted on a `cmd` node. A declared flag can then relocate the
-behavior with `action="help"`, `help_short`, `help_long`, `help_all`, or `version`; its ordinary `help`
-text is what the help page displays.
-
-### Let a subcommand satisfy parent requirements
-
-`subcommand_negates_reqs` makes required arguments, flags, groups, and conditional
-requirements on a parent optional when a child is selected:
-
-```kdl
-subcommand_negates_reqs #true
-arg "<input>"
-cmd "inspect"
-```
-
-`ex inspect` is valid, while bare `ex` still requires `input`. Conflicts continue to apply,
-and the selected child must still satisfy its own requirements.
-
-### Make parent arguments conflict with subcommands
-
-`args_conflicts_with_subcommands` makes arguments on a command and its child
-subcommands mutually exclusive. Once that command binds a flag or positional, a
-later child name is rejected; arguments after a selected child belong to the
-child as usual:
-
-```kdl
-args_conflicts_with_subcommands #true
-```
-
-### Prefer a known subcommand to a variadic value
-
-`subcommand_precedence_over_arg` lets a known child name end a variadic flag
-or positional that would otherwise consume it.
-
-```kdl
-subcommand_precedence_over_arg #true
-```
-
-### Allow a missing optional positional
-
-`allow_missing_positional` lets a later required positional claim the last
-available word while an earlier optional positional remains empty. Without the
-opt-in, positional binding remains strictly left to right.
-
-```kdl
-allow_missing_positional #true
-arg "[optional]"
-arg "<required>"
-```
-
-### Preserve delimiters in trailing values
-
-`dont_delimit_trailing_values` keeps a positional token whole after `--`, or once a
-`double_dash="automatic"` positional begins. The same argument still applies its
-`delimiter` before that boundary:
-
-```kdl
-dont_delimit_trailing_values #true
-arg "<values>..." delimiter=","
-```
-
-`ex a,b -- c,d` binds `a`, `b`, and `c,d`. The policy is inherited by
-subcommands, matching clap's command-wide setting.
-
-### Repeated scalar flags
-
-Later occurrences of a single-valued flag replace earlier ones by default. Set
-`args_override_self` to false on commands that require strict duplicate checking:
-
-```kdl
-args_override_self #false
-cmd "publish" args_override_self=#false
-```
-
-Repeatable, variadic, and count flags continue collecting or counting regardless of this setting.
-
-### Restart argument parsing
-
-`restart_token` lets one command line contain several invocations of the same
-command. Encountering the token clears the positional cursor, pending flag
-value, and `--` separator state before parsing the next invocation:
-
-```kdl
-cmd "run" restart_token=":::" {
-  arg "<task>"
-  flag "--jobs <N>"
-}
-```
-
-`mycli run lint ::: test` parses `lint` and then restarts at `test`. The parser
-retains the last invocation's scalar bindings. This is a command-only property;
-it is not accepted as a top-level node.
-
-### Command-local completions
-
-A `complete` child applies only while parsing that command. It has the same
-`run`, `type`, and `descriptions` properties as a
-[top-level completer](./complete.md):
-
-```kdl
-cmd "deploy" {
-  arg "<environment>"
-  complete "environment" run="mycli environments"
-}
-```
-
 ### Global flags and mounted commands
 
 A mounted command describes a different program, so the flags of the commands it is mounted under
@@ -353,3 +189,167 @@ cmd "task1" {
 `dev stage prod` rather than the global's `<ENV>` value. Global flags are still recognized _before_
 the mounted command (`mycli --env prod run task1`), where they also propagate to the mount command
 itself.
+
+## Unknown flags
+
+A flag-like token that names no flag becomes a word, offered to the positionals like
+any other — because a spec often parses a command line whose flags belong to
+something else. A command that owns all of its flags can refuse them instead:
+
+```kdl
+unknown_flags "error"               // for the whole CLI
+cmd "exec" unknown_flags="value"    // except here, which forwards a command line
+```
+
+The nearest command that states a preference wins, then the spec, then `value`.
+Unlike [`effect`](/spec/#command-effects), this is inherited: it describes how a command line is
+read rather than what a command does. See
+[the argv grammar](../argv.md#unrecognized-flags) for the reasoning and the cost.
+
+## External subcommands
+
+An unmatched word that names no subcommand can be forwarded as an external
+command plus the rest of argv. This is clap's `allow_external_subcommands`, not
+`unknown_flags=value`: known subcommands still win, a `default_subcommand` still
+catches first, and a flag-like token on the parent is still an unknown flag.
+
+```kdl
+unknown_flags "error"
+external_subcommand #true            // the whole CLI
+cmd "exec" external_subcommand=#true // or one command
+```
+
+`ex git --help` forwards `git --help`. `ex --wat` is still an error. Once the
+unmatched word is taken, remaining tokens — including `--help` — are not parsed
+as this command's flags.
+
+See [the argv grammar](../argv.md#external-subcommands).
+
+## Require an argument or show help
+
+`arg_required_else_help` makes a bare invocation request the command's short help:
+
+```kdl
+arg_required_else_help #true             // for the whole CLI
+cmd "run" arg_required_else_help=#true // or one command
+```
+
+The policy observes argv belonging to the selected command. A global flag before a
+subcommand does not count as that subcommand's argument, and values supplied later by an
+environment variable or default do not suppress help.
+
+## Control built-in help and version entry points
+
+Each synthesized entry can be removed independently:
+
+```kdl
+disable_help_flag #true
+disable_help_subcommand #true
+disable_version_flag #true
+```
+
+The same properties are accepted on a `cmd` node. A declared flag can then relocate the
+behavior with `action="help"`, `help_short`, `help_long`, `help_all`, or `version`; its ordinary `help`
+text is what the help page displays.
+
+## Let a subcommand satisfy parent requirements
+
+`subcommand_negates_reqs` makes required arguments, flags, groups, and conditional
+requirements on a parent optional when a child is selected:
+
+```kdl
+subcommand_negates_reqs #true
+arg "<input>"
+cmd "inspect"
+```
+
+`ex inspect` is valid, while bare `ex` still requires `input`. Conflicts continue to apply,
+and the selected child must still satisfy its own requirements.
+
+## Make parent arguments conflict with subcommands
+
+`args_conflicts_with_subcommands` makes arguments on a command and its child
+subcommands mutually exclusive. Once that command binds a flag or positional, a
+later child name is rejected; arguments after a selected child belong to the
+child as usual:
+
+```kdl
+args_conflicts_with_subcommands #true
+```
+
+## Prefer a known subcommand to a variadic value
+
+`subcommand_precedence_over_arg` lets a known child name end a variadic flag
+or positional that would otherwise consume it.
+
+```kdl
+subcommand_precedence_over_arg #true
+```
+
+## Allow a missing optional positional
+
+`allow_missing_positional` lets a later required positional claim the last
+available word while an earlier optional positional remains empty. Without the
+opt-in, positional binding remains strictly left to right.
+
+```kdl
+allow_missing_positional #true
+arg "[optional]"
+arg "<required>"
+```
+
+## Preserve delimiters in trailing values
+
+`dont_delimit_trailing_values` keeps a positional token whole after `--`, or once a
+`double_dash="automatic"` positional begins. The same argument still applies its
+`delimiter` before that boundary:
+
+```kdl
+dont_delimit_trailing_values #true
+arg "<values>..." delimiter=","
+```
+
+`ex a,b -- c,d` binds `a`, `b`, and `c,d`. The policy is inherited by
+subcommands, matching clap's command-wide setting.
+
+## Repeated scalar flags
+
+Later occurrences of a single-valued flag replace earlier ones by default. Set
+`args_override_self` to false on commands that require strict duplicate checking:
+
+```kdl
+args_override_self #false
+cmd "publish" args_override_self=#false
+```
+
+Repeatable, variadic, and count flags continue collecting or counting regardless of this setting.
+
+## Restart argument parsing
+
+`restart_token` lets one command line contain several invocations of the same
+command. Encountering the token clears the positional cursor, pending flag
+value, and `--` separator state before parsing the next invocation:
+
+```kdl
+cmd "run" restart_token=":::" {
+  arg "<task>"
+  flag "--jobs <N>"
+}
+```
+
+`mycli run lint ::: test` parses `lint` and then restarts at `test`. The parser
+retains the last invocation's scalar bindings. This is a command-only property;
+it is not accepted as a top-level node.
+
+## Command-local completions
+
+A `complete` child applies only while parsing that command. It has the same
+`run`, `type`, and `descriptions` properties as a
+[top-level completer](./complete.md):
+
+```kdl
+cmd "deploy" {
+  arg "<environment>"
+  complete "environment" run="mycli environments"
+}
+```

--- a/docs/spec/reference/complete.md
+++ b/docs/spec/reference/complete.md
@@ -21,15 +21,23 @@ Append a comma-separated extension list to `path:` or `file:` to keep directory 
 offering only matching files. Extensions omit the leading dot; for example,
 `type="path:toml,yaml"` offers directories plus `.toml` and `.yaml` files.
 
-| type            | completes                                                            |
-| --------------- | -------------------------------------------------------------------- |
-| `file`, `path`  | files and directories, relative to the working directory             |
-| `dir`           | directories only                                                     |
-| `executable`    | executable paths                                                     |
-| `command`       | commands known to the shell, including names found on `PATH`         |
-| `command_args`  | a command for the first value, then ordinary argument paths          |
-| `config_keys`   | the settings this spec's [`config`](./config.md) block declares      |
-| `config_values` | the values accepted by the setting named earlier on the command line |
+| type                   | completes                                                                              |
+| ---------------------- | -------------------------------------------------------------------------------------- |
+| `file`, `path`         | files and directories, relative to the working directory                               |
+| `dir`                  | directories only                                                                       |
+| `executable`           | executable paths                                                                       |
+| `command`              | commands known to the shell, including names found on `PATH`                           |
+| `command_args`         | a command for the first value, then ordinary argument paths                            |
+| `config_keys`          | the settings this spec's [`config`](./config.md) block declares                        |
+| `config_values`        | the values accepted by the setting named earlier on the command line                   |
+| `username`             | user names, from the environment and `/etc/passwd`                                     |
+| `hostname`             | host names, from the environment and `/etc/hosts`                                      |
+| `none`, `url`, `email` | nothing — the value has no completable candidates, and the file fallback is suppressed |
+| `unknown`              | nothing, but the shell's normal fallback stays available                               |
+
+The types below `config_values` exist mostly so specs generated from clap can carry
+its `ValueHint`s. `username` and `hostname` offer real candidates; `none`, `url`,
+`email`, and `unknown` are hint passthroughs with no candidates of their own.
 
 An arg or flag with no completer of its own falls back to `file` unless its declared
 `choices` say otherwise, so `type="file"` is only worth writing to be explicit.
@@ -126,7 +134,7 @@ complete "module" run="ls modules"
 complete "controller" run="ls modules/{{ words[PREV] | shell_quote }}/controllers"
 ```
 
-Example of using multiple words (one, two, three) for the completions of the forth argument:
+Example of using multiple words (one, two, three) for the completions of the fourth argument:
 
 ```kdl
 arg "<one>"

--- a/docs/spec/reference/config.md
+++ b/docs/spec/reference/config.md
@@ -88,6 +88,7 @@ files, so a setting a repository must not be able to change can say so.
 | property                                     | meaning                                                                                                      |
 | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | `type`                                       | the type, see [below](#types). Defaults to `string`                                                          |
+| `env`                                        | an environment variable that sets it — the child node form below takes several                               |
 | `default`                                    | the value when nothing supplies one — a typed KDL value: `4`, `#true`, `"x"`                                 |
 | `optional`                                   | explicitly permit or require absence; otherwise inferred from the type and default                           |
 | `default_note`                               | what to print instead of the default, when the real one needs explaining                                     |

--- a/docs/spec/reference/flag.md
+++ b/docs/spec/reference/flag.md
@@ -95,6 +95,8 @@ flag "--port <port>" {
 
 flag "--env <env>" {
   choices env="DEPLOY_ENVS" // values from $DEPLOY_ENVS, split on commas and/or whitespace
+  // note: `choices env=` requires the `unstable_choices_env` cargo feature of
+  // usage-lib; the usage CLI enables it, but library consumers must opt in
 }
 
 // argv wins, then APP_TOKEN, then the fallbacks from left to right, then the

--- a/go/README.md
+++ b/go/README.md
@@ -11,10 +11,11 @@ A CLI framework for Go, built the way [usage-argv](../argv) is built for Rust: t
 command line is bound against **static tables** instead of a command tree
 assembled at run time.
 
-> **Status: the binder.** `argv` implements the [argv grammar](../docs/spec/argv.md)
-> and passes every binding vector in the [conformance corpus](../corpus). The code
-> generator that emits tables from a spec, and the layer above binding that fills a
-> typed struct, are not written yet. See [what is missing](#what-is-missing).
+> **Status: parsing, binding, help, and completions.** `argv` implements the
+> [argv grammar](../docs/spec/argv.md) and passes every binding vector in the
+> [conformance corpus](../corpus). `usage generate go` emits the tables from a spec,
+> along with a typed `Parse` that fills a struct per command. See
+> [what is missing](#what-is-missing).
 
 ## Why
 
@@ -297,8 +298,6 @@ claim is measured at real scale rather than against a fixture with four flags:
 
 ## What is missing
 
-- **A typed front door.** The conversions exist; what is missing is generated
-  code that calls them, so a CLI author gets a struct rather than events.
 - **Shadow programs for the other frameworks.** usage-go's own numbers are
   reproducible with `mise run perf:go`; urfave's and kong's are still
   hand-measured, because generating mise-sized programs for them from the spec is


### PR DESCRIPTION
## What this does

A full audit of the docs site against the implementation, in two commits.

### Commit 1 — accuracy fixes (21 files)

Every fix was verified against the code before editing:

**Documented things that did not exist or did not work**
- `cli/markdown.md` documented an `--inject` flag and `<!-- usage:start -->` marker injection that exist nowhere in the code; the root CLI errors on unknown flags, so the example failed outright. Rewritten around `--out-file`/stdout.
- The clap and cobra integration pipelines failed as written (`generate completion` needs the `<BIN>` positional and `--file`/`--usage-cmd`; `md`/`manpage` require `-f`). Fixed to working `-f -` stdin invocations.
- `go/completions.md` told Go users to generate completion scripts with the Rust CLI — those scripts call back to `usage`, never the Go binary, so the described wiring could never work. Rewritten around `argv.Respond` and `argv.Script`.
- `spec/index.md`'s own example passed flag help as a bare string, which the parser silently drops.
- `rust/args-and-flags.md` showed `Error::InvalidValue` with a struct-variant shape that would not compile.

**Stale claims**
- Go docs claimed zero dependencies (expr-lang/expr is a direct import) and that the generator and typed `Parse` "are not written yet" (both shipped).
- "Elvish is not a 6.0 target" predated the runtime Elvish completions; "six help sections" predated the split to ten; the index said 1.6 MB where the performance page says 1.3 MB; `contributing.md` pointed at hk, which this repo does not use; `clap_usage = "6"` pointed at a version that is not published — now `"5"`, since clap_usage releases out of sync with the monorepo.

**Gaps**
- New Rust-side "Outputs and exit codes" section (`output(...)`/`exit_code(...)`/`select` had only spec-side docs), plus a disambiguating note where dispatch's unrelated `output =` is documented.
- Documented `value_names`, `prop env=`, the ValueHint completion types, the `unstable_choices_env` feature gate, and five undocumented clap-compat settings; fixed wrong entry-point signatures; regenerated `rust/spec.md`'s emitted-KDL example to match the writer's actual output (per the roundtrip snapshot); promoted twelve `cmd.md` policy sections that were filed under "Mounting dynamic commands"; fixed a broken anchor and typos.

### Commit 2 — prose and flow on the /rust pages

- **args-and-flags**: the elaboration paragraphs after the attribute tables were a grab-bag under one unrelated heading; grouped under headings that mirror the tables, ordered to match.
- **configuration**: two sections said the same thing almost verbatim; merged.
- **help**: the `version`/`long_version` paragraph sat in the Help section while a Version section existed below; moved.
- **completions**, **dispatch**: removed a stilted two-line paragraph and a sentence repeated verbatim from the page intro.
- **sidebar**: rust pages now follow the index's reading order, with the migration and performance appendices last.

## Verification

- `npx vitepress build docs` passes (dead-link check included)
- `mise run render` produces no drift (generated reference pages untouched)
- prettier clean
- Every claim in commit 1 was checked against the parser, derive, argv, config, and Go sources; API signatures in new examples verified against the code and conformance tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime, API, or security impact.
> 
> **Overview**
> Corrects docs that did not match the code: markdown generation now uses `--out-file`/stdout instead of a nonexistent `--inject` flow; clap/cobra pipelines include the required `<BIN>` and `-f -`; Go completions are wired with `argv.Respond` and `argv.Script` rather than the Rust CLI.
> 
> Updates stale facts (Go’s `expr` dependency and shipped `Parse`, Elvish runtime completions, 1.3 MB binary, `clap_usage = "5"`, mise lint tasks) and fills gaps: Rust `output`/`exit_code`, `value_names`, ValueHint types, clap-compat settings, and a regenerated emitted-KDL example.
> 
> Rust pages are regrouped to match the attribute tables, duplicate config/help copy is merged, and the sidebar puts migration and performance last.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e9a30586cf2fd0c2a24fe197fb62c1d79e03b03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->