### PR TITLE
perf(argv): reduce sort code size

### DIFF
--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -333,7 +333,7 @@ pub fn completers_on(meta: &CommandMeta<'_>) -> Vec<String> {
             );
         }
     }
-    out.sort();
+    out.sort_unstable();
     out.dedup();
     out
 }
@@ -1261,7 +1261,7 @@ async fn complete_named_with<'a>(
 /// first candidate after derived sorting would prefer `None` over `Some`, discarding the richer
 /// display label or description.
 fn sort_and_dedup_candidates(candidates: &mut Vec<Candidate<'_>>) {
-    candidates.sort();
+    candidates.sort_unstable();
     let mut deduped: Vec<Candidate<'_>> = Vec::with_capacity(candidates.len());
     for mut candidate in candidates.drain(..) {
         if let Some(existing) = deduped

--- a/argv/src/diagnostic.rs
+++ b/argv/src/diagnostic.rs
@@ -236,7 +236,7 @@ fn nearest<'a>(typed: &str, candidates: impl Iterator<Item = &'a str>) -> Vec<&'
         .map(|candidate| (jaro(typed, candidate), candidate))
         .filter(|(score, _)| *score > 0.7)
         .collect();
-    scored.sort_by(|a, b| a.0.total_cmp(&b.0).then_with(|| a.1.cmp(b.1)));
+    scored.sort_unstable_by(|a, b| a.0.total_cmp(&b.0).then_with(|| a.1.cmp(b.1)));
     scored.dedup_by(|a, b| a.1 == b.1);
     scored.into_iter().map(|(_, candidate)| candidate).collect()
 }

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -588,7 +588,7 @@ fn help_structure(
 
     let mut flag_usages: Vec<String> = own.iter().map(|flag| column_usage(flag)).collect();
     flag_usages.extend(inherited.into_iter().map(|(_, usage)| usage));
-    flag_usages.sort_by_key(|usage| core::cmp::Reverse(usage.len()));
+    flag_usages.sort_unstable_by_key(|usage| core::cmp::Reverse(usage.len()));
 
     let mut synopsis = String::new();
     usage_section(&mut synopsis, spec, path, meta);
@@ -762,7 +762,7 @@ fn usage_section(out: &mut String, spec: &Spec<'_>, path: &[&str], meta: &Comman
         }
     }
     let mut visible: Vec<_> = meta.subcommands.iter().filter(|sub| !sub.hide).collect();
-    visible.sort_by_key(|sub| sub.cmd.name);
+    visible.sort_unstable_by_key(|sub| sub.cmd.name);
     if meta.flatten_help && !visible.is_empty() {
         let mut lines = Vec::new();
         if !meta.subcommand_required || meta.cmd.args_conflicts_with_subcommands {
@@ -1300,7 +1300,7 @@ fn commands_section(out: &mut String, path: &[&str], meta: &CommandMeta<'_>) {
             (usage_line(&sub_path, sub), *sub)
         })
         .collect();
-    lines.sort_by(|a, b| {
+    lines.sort_unstable_by(|a, b| {
         a.1.display_order
             .unwrap_or(999)
             .cmp(&b.1.display_order.unwrap_or(999))
@@ -1576,7 +1576,10 @@ fn split_groups_section<'m, T: 'm>(
             headings.push(heading);
         }
     }
-    headings.sort_by_key(|h| h.is_some());
+    if let Some(index) = headings.iter().position(Option::is_none) {
+        let unheaded = headings.remove(index);
+        headings.insert(0, unheaded);
+    }
 
     for heading in headings {
         let mut section = String::new();
@@ -1593,29 +1596,27 @@ fn split_groups_section<'m, T: 'm>(
 }
 
 fn order_args<'a>(items: &mut Vec<&'a ArgMeta<'a>>, declared: &'a [ArgMeta<'a>]) {
-    items.sort_by_key(|item| {
-        item.display_order.unwrap_or_else(|| {
-            declared
-                .iter()
-                .position(|candidate| core::ptr::eq(candidate, *item))
-                .unwrap_or(usize::MAX)
-        })
+    items.sort_unstable_by_key(|item| {
+        let position = declared
+            .iter()
+            .position(|candidate| core::ptr::eq(candidate, *item))
+            .unwrap_or(usize::MAX);
+        (item.display_order.unwrap_or(position), position)
     });
 }
 
 fn order_flags<'a>(items: &mut Vec<&'a FlagMeta<'a>>, declared: &'a [FlagMeta<'a>]) {
-    items.sort_by_key(|item| {
-        item.display_order.unwrap_or_else(|| {
-            declared
-                .iter()
-                .position(|candidate| core::ptr::eq(candidate, *item))
-                .unwrap_or(usize::MAX)
-        })
+    items.sort_unstable_by_key(|item| {
+        let position = declared
+            .iter()
+            .position(|candidate| core::ptr::eq(candidate, *item))
+            .unwrap_or(usize::MAX);
+        (item.display_order.unwrap_or(position), position)
     });
 }
 
 fn order_commands(items: &mut Vec<&&CommandMeta<'_>>) {
-    items.sort_by(|a, b| {
+    items.sort_unstable_by(|a, b| {
         a.display_order
             .unwrap_or(999)
             .cmp(&b.display_order.unwrap_or(999))
@@ -2219,7 +2220,7 @@ fn long_commands_section(out: &mut String, path: &[&str], meta: &CommandMeta<'_>
             (usage_line(&sub_path, sub), *sub)
         })
         .collect();
-    lines.sort_by(|a, b| {
+    lines.sort_unstable_by(|a, b| {
         a.1.display_order
             .unwrap_or(999)
             .cmp(&b.1.display_order.unwrap_or(999))
@@ -2639,13 +2640,12 @@ fn own_and_global<'a>(
         .iter()
         .map(|(flag, _)| *flag as *const _)
         .collect();
-    inherited.sort_by_key(|(flag, _)| {
-        flag.display_order.unwrap_or_else(|| {
-            inherited_positions
-                .iter()
-                .position(|candidate| core::ptr::eq(*candidate, *flag as *const _))
-                .unwrap_or(usize::MAX)
-        })
+    inherited.sort_unstable_by_key(|(flag, _)| {
+        let position = inherited_positions
+            .iter()
+            .position(|candidate| core::ptr::eq(*candidate, *flag as *const _))
+            .unwrap_or(usize::MAX);
+        (flag.display_order.unwrap_or(position), position)
     });
 
     // Last in the command's own section, which is where clap has them: they carry no
@@ -3165,7 +3165,7 @@ fn recursive_help<'a>(
 
         let current = *chain.last().expect("a recursive page has a command");
         let mut children: Vec<_> = current.subcommands.iter().filter(|cmd| !cmd.hide).collect();
-        children.sort_by_key(|cmd| (cmd.display_order.unwrap_or(999), cmd.cmd.name));
+        children.sort_unstable_by_key(|cmd| (cmd.display_order.unwrap_or(999), cmd.cmd.name));
         for child in children {
             path.push(child.cmd.name);
             chain.push(child);


### PR DESCRIPTION
## Summary

- use unstable sorting where presentation comparators already define deterministic order
- preserve declared order for equal `display_order` values with explicit position tie-breakers
- move the optional unheaded help section without instantiating stable-sort machinery

This avoids linking repeated stable-sort implementations for help, diagnostics, and completion metadata.

## Size

Measured on `oxlint` from oxc-project/oxc#26018 with its fat-LTO release profile and local usage-rs paths:

| section | main | this PR | delta |
|---|---:|---:|---:|
| `.text` | 12,147,246 B | 12,145,358 B | -1,888 B |
| linked sections (`size -A` total) | 15,839,316 B | 15,834,628 B | -4,688 B |

The ELF file remains the same on-disk size because the reduction does not cross its current page-alignment boundary. `oxlint __usage_spec__` remains byte-for-byte unchanged at 8,816 bytes.

## Verification

- `mise run ci`
- `mise run perf:shadow` (usage: 8,759 cold instructions; clap/usage ratio: 721x)
- Oxc fat-LTO release build and generated-spec comparison

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only sort changes with added tie-breakers; wrong comparators could reorder help, but this is not auth or data-path logic.
> 
> **Overview**
> Switches presentation sorts in help, diagnostics, and completion to **unstable** variants so the crate does not pull in repeated stable-sort codegen.
> 
> Where order used to rely on stability (`display_order` ties, unheaded help groups), the comparators now include an explicit **declaration-position** tie-breaker, and the unheaded section is moved to the front without sorting. Help/spec output is intended to stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f46650cf562d70afae9c211719d5efb4c1e6eba8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved the consistency and efficiency of command-line completion and diagnostic suggestions.
  * Help output now uses deterministic ordering when items share the same display priority.
  * Ungrouped help entries are presented consistently, with stable ordering across commands, arguments, flags, and inherited options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->