### PR TITLE
feat(docs): allow overriding markdown templates

### DIFF
--- a/cli/assets/fig.ts
+++ b/cli/assets/fig.ts
@@ -726,6 +726,14 @@ const completionSpec: Fig.Spec = {
               },
             },
             {
+              name: "--template",
+              description: "Override a Tera template with NAME=PATH",
+              isRepeatable: true,
+              args: {
+                name: "template",
+              },
+            },
+            {
               name: ["-h", "--help"],
               description: "Print help",
               isRepeatable: false,

--- a/cli/assets/usage.1
+++ b/cli/assets/usage.1
@@ -530,6 +530,9 @@ Replace `<pre>` tags with markdown code fences
 \fB\-\-url\-prefix\fR \fI<URL_PREFIX>\fR
 Prefix to add to all URLs
 .TP
+\fB\-\-template\fR \fI<TEMPLATE>\fR
+Override a Tera template with NAME=PATH
+.TP
 \fB\-h, \-\-help\fR
 Print help
 .SH "USAGE GENERATE SDK"

--- a/cli/src/cli/generate/markdown.rs
+++ b/cli/src/cli/generate/markdown.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 
 use super::{parse_file_or_stdin, select_view, write_or_stdout};
-use usage::docs::markdown::MarkdownRenderer;
+use usage::docs::markdown::{MarkdownRenderer, MarkdownTemplate};
+use usage::error::UsageErr;
 use usage_rs::Args;
 
 /// Generate markdown documentation from usage specs
@@ -51,6 +52,30 @@ pub struct Markdown {
     /// Prefix to add to all URLs
     #[usage(long)]
     url_prefix: Option<String>,
+
+    /// Tera template file for the complete single-file document
+    #[usage(long, value_hint = usage_rs::ValueHint::FilePath)]
+    spec_template: Option<PathBuf>,
+
+    /// Tera template file for the multi-file landing page
+    #[usage(long, value_hint = usage_rs::ValueHint::FilePath)]
+    index_template: Option<PathBuf>,
+
+    /// Tera template file for each command
+    #[usage(long, value_hint = usage_rs::ValueHint::FilePath)]
+    command_template: Option<PathBuf>,
+
+    /// Tera template file for each positional argument
+    #[usage(long, value_hint = usage_rs::ValueHint::FilePath)]
+    argument_template: Option<PathBuf>,
+
+    /// Tera template file for each flag
+    #[usage(long, value_hint = usage_rs::ValueHint::FilePath)]
+    flag_template: Option<PathBuf>,
+
+    /// Tera template file for the configuration reference
+    #[usage(long, value_hint = usage_rs::ValueHint::FilePath)]
+    config_template: Option<PathBuf>,
 }
 
 impl usage_rs::Run for Markdown {
@@ -76,6 +101,20 @@ impl usage_rs::Run for Markdown {
         let mut ctx = MarkdownRenderer::new(spec.clone())
             .with_html_encode(self.html_encode)
             .with_replace_pre_with_code_fences(self.replace_pre_with_code_fences);
+        for (template, path) in [
+            (MarkdownTemplate::Spec, self.spec_template.as_ref()),
+            (MarkdownTemplate::Index, self.index_template.as_ref()),
+            (MarkdownTemplate::Command, self.command_template.as_ref()),
+            (MarkdownTemplate::Argument, self.argument_template.as_ref()),
+            (MarkdownTemplate::Flag, self.flag_template.as_ref()),
+            (MarkdownTemplate::Config, self.config_template.as_ref()),
+        ] {
+            if let Some(path) = path {
+                let source = std::fs::read_to_string(path)
+                    .map_err(|err| UsageErr::FileError(err, path.clone()))?;
+                ctx = ctx.with_template(template, source);
+            }
+        }
         if let Some(url_prefix) = &self.url_prefix {
             ctx = ctx.with_url_prefix(url_prefix);
         }

--- a/cli/src/cli/generate/markdown.rs
+++ b/cli/src/cli/generate/markdown.rs
@@ -53,29 +53,9 @@ pub struct Markdown {
     #[usage(long)]
     url_prefix: Option<String>,
 
-    /// Tera template file for the complete single-file document
-    #[usage(long, value_hint = usage_rs::ValueHint::FilePath)]
-    spec_template: Option<PathBuf>,
-
-    /// Tera template file for the multi-file landing page
-    #[usage(long, value_hint = usage_rs::ValueHint::FilePath)]
-    index_template: Option<PathBuf>,
-
-    /// Tera template file for each command
-    #[usage(long, value_hint = usage_rs::ValueHint::FilePath)]
-    command_template: Option<PathBuf>,
-
-    /// Tera template file for each positional argument
-    #[usage(long, value_hint = usage_rs::ValueHint::FilePath)]
-    argument_template: Option<PathBuf>,
-
-    /// Tera template file for each flag
-    #[usage(long, value_hint = usage_rs::ValueHint::FilePath)]
-    flag_template: Option<PathBuf>,
-
-    /// Tera template file for the configuration reference
-    #[usage(long, value_hint = usage_rs::ValueHint::FilePath)]
-    config_template: Option<PathBuf>,
+    /// Override a Tera template with NAME=PATH
+    #[usage(long)]
+    template: Vec<String>,
 }
 
 impl usage_rs::Run for Markdown {
@@ -101,19 +81,25 @@ impl usage_rs::Run for Markdown {
         let mut ctx = MarkdownRenderer::new(spec.clone())
             .with_html_encode(self.html_encode)
             .with_replace_pre_with_code_fences(self.replace_pre_with_code_fences);
-        for (template, path) in [
-            (MarkdownTemplate::Spec, self.spec_template.as_ref()),
-            (MarkdownTemplate::Index, self.index_template.as_ref()),
-            (MarkdownTemplate::Command, self.command_template.as_ref()),
-            (MarkdownTemplate::Argument, self.argument_template.as_ref()),
-            (MarkdownTemplate::Flag, self.flag_template.as_ref()),
-            (MarkdownTemplate::Config, self.config_template.as_ref()),
-        ] {
-            if let Some(path) = path {
-                let source = std::fs::read_to_string(path)
-                    .map_err(|err| UsageErr::FileError(err, path.clone()))?;
-                ctx = ctx.with_template(template, source);
-            }
+        for value in &self.template {
+            let Some((name, path)) = value.split_once('=') else {
+                miette::bail!("invalid template `{value}`; expected NAME=PATH");
+            };
+            let template = match name {
+                "spec" => MarkdownTemplate::Spec,
+                "index" => MarkdownTemplate::Index,
+                "command" => MarkdownTemplate::Command,
+                "argument" => MarkdownTemplate::Argument,
+                "flag" => MarkdownTemplate::Flag,
+                "config" => MarkdownTemplate::Config,
+                _ => miette::bail!(
+                    "unknown template `{name}`; expected spec, index, command, argument, flag, or config"
+                ),
+            };
+            let path = PathBuf::from(path);
+            let source = std::fs::read_to_string(&path)
+                .map_err(|err| UsageErr::FileError(err, path.clone()))?;
+            ctx = ctx.with_template(template, source);
         }
         if let Some(url_prefix) = &self.url_prefix {
             ctx = ctx.with_url_prefix(url_prefix);

--- a/cli/tests/markdown.rs
+++ b/cli/tests/markdown.rs
@@ -269,10 +269,10 @@ fn markdown_template_files_override_named_renderer_templates() {
     let mut cmd = usage_cmd();
     cmd.args(["generate", "markdown", "-f"])
         .arg(&spec)
-        .arg("--spec-template")
-        .arg(&spec_template)
-        .arg("--flag-template")
-        .arg(&flag_template)
+        .arg("--template")
+        .arg(format!("spec={}", spec_template.display()))
+        .arg("--template")
+        .arg(format!("flag={}", flag_template.display()))
         .args(["--out-file", "-"]);
 
     let output = cmd.output().unwrap();

--- a/cli/tests/markdown.rs
+++ b/cli/tests/markdown.rs
@@ -251,6 +251,44 @@ fn test_markdown_out_file_dash_writes_no_file() {
 }
 
 #[test]
+fn markdown_template_files_override_named_renderer_templates() {
+    let dir = std::env::temp_dir().join(format!("usage_md_templates_{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    let spec = dir.join("custom.usage.kdl");
+    let spec_template = dir.join("spec.md.tera");
+    let flag_template = dir.join("flag.md.tera");
+    fs::write(&spec, "bin \"custom\"\nflag \"--force\"\n").unwrap();
+    fs::write(
+        &spec_template,
+        "CUSTOM {{ spec.bin }}\n{% set cmd = spec.cmd %}{% include \"cmd_template.md.tera\" %}",
+    )
+    .unwrap();
+    fs::write(&flag_template, "CUSTOM FLAG {{ flag.usage }}").unwrap();
+
+    let mut cmd = usage_cmd();
+    cmd.args(["generate", "markdown", "-f"])
+        .arg(&spec)
+        .arg("--spec-template")
+        .arg(&spec_template)
+        .arg("--flag-template")
+        .arg(&flag_template)
+        .args(["--out-file", "-"]);
+
+    let output = cmd.output().unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("CUSTOM custom"), "{stdout}");
+    assert!(stdout.contains("CUSTOM FLAG --force"), "{stdout}");
+
+    fs::remove_dir_all(&dir).unwrap();
+}
+
+#[test]
 fn test_source_code_links_exist() {
     // A command's path is not its file's path: `complete-word` lives in `complete_word.rs`,
     // `generate` in `generate/mod.rs`, and `bash` in `shell.rs`, which it shares with the

--- a/cli/usage.usage.kdl
+++ b/cli/usage.usage.kdl
@@ -349,6 +349,9 @@ Common sections: - 1: User commands - 5: File formats - 7: Miscellaneous - 8: Sy
         flag --url-prefix help="Prefix to add to all URLs" {
             arg <URL_PREFIX>
         }
+        flag --template help="Override a Tera template with NAME=PATH" var=#true {
+            arg <TEMPLATE>
+        }
         flag "-h --help" help="Print help" action=help builtin=#true
         complete out_dir type=dir
         complete out_file type=path

--- a/docs/cli/markdown.md
+++ b/docs/cli/markdown.md
@@ -24,6 +24,29 @@ docs
 └── update.md
 ```
 
+## Custom templates from the CLI
+
+Each renderer template can be replaced with a Tera template file. For example, a custom
+single-file document can keep the built-in command template:
+
+```sh
+$ usage g markdown -f ./mycli.usage.kdl \
+    --spec-template ./templates/spec.md.tera \
+    --out-file ./docs/cli.md
+```
+
+```tera
+{# templates/spec.md.tera #}
+# {{ spec.bin }} reference
+{% set cmd = spec.cmd %}
+{% include "cmd_template.md.tera" %}
+```
+
+The available options are `--spec-template`, `--index-template`, `--command-template`,
+`--argument-template`, `--flag-template`, and `--config-template`. Options can be combined;
+templates that are not named keep their built-in definitions and remain available through
+Tera's `include`.
+
 ## Custom templates from Rust
 
 `MarkdownRenderer` bundles a complete set of Tera templates. A Rust caller can replace one

--- a/docs/cli/markdown.md
+++ b/docs/cli/markdown.md
@@ -31,7 +31,7 @@ single-file document can keep the built-in command template:
 
 ```sh
 $ usage g markdown -f ./mycli.usage.kdl \
-    --spec-template ./templates/spec.md.tera \
+    --template spec=./templates/spec.md.tera \
     --out-file ./docs/cli.md
 ```
 
@@ -42,10 +42,9 @@ $ usage g markdown -f ./mycli.usage.kdl \
 {% include "cmd_template.md.tera" %}
 ```
 
-The available options are `--spec-template`, `--index-template`, `--command-template`,
-`--argument-template`, `--flag-template`, and `--config-template`. Options can be combined;
-templates that are not named keep their built-in definitions and remain available through
-Tera's `include`.
+The available names are `spec`, `index`, `command`, `argument`, `flag`, and `config`. Repeat
+`--template` to replace more than one. Templates that are not named keep their built-in
+definitions and remain available through Tera's `include`.
 
 ## Custom templates from Rust
 

--- a/docs/cli/markdown.md
+++ b/docs/cli/markdown.md
@@ -23,3 +23,25 @@ docs
 ├── index.md
 └── update.md
 ```
+
+## Custom templates from Rust
+
+`MarkdownRenderer` bundles a complete set of Tera templates. A Rust caller can replace one
+member without copying the rest:
+
+```rust
+use usage::docs::markdown::{MarkdownRenderer, MarkdownTemplate};
+
+let spec: usage::Spec = std::fs::read_to_string("mycli.usage.kdl")?.parse()?;
+let markdown = MarkdownRenderer::new(spec)
+    .with_template(
+        MarkdownTemplate::Spec,
+        "# {{ spec.bin }} reference\n{% set cmd = spec.cmd %}\n{% include \"cmd_template.md.tera\" %}",
+    )
+    .render_spec()?;
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+The selectable members are `Spec`, `Index`, `Command`, `Argument`, `Flag`, and `Config`.
+Templates that are not replaced remain available through Tera's `include`; syntax and include
+errors are returned when the page is rendered.

--- a/docs/cli/reference/commands.json
+++ b/docs/cli/reference/commands.json
@@ -1420,6 +1420,24 @@
                 }
               },
               {
+                "name": "template",
+                "usage": "--template… <TEMPLATE>",
+                "help": "Override a Tera template with NAME=PATH",
+                "help_first_line": "Override a Tera template with NAME=PATH",
+                "short": [],
+                "long": ["template"],
+                "var": true,
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "TEMPLATE",
+                  "usage": "<TEMPLATE>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false
+                }
+              },
+              {
                 "name": "help",
                 "usage": "-h --help",
                 "help": "Print help",

--- a/docs/cli/reference/generate/markdown.md
+++ b/docs/cli/reference/generate/markdown.md
@@ -47,6 +47,10 @@ Replace `<pre>` tags with markdown code fences
 
 Prefix to add to all URLs
 
+### `--template… <TEMPLATE>`
+
+Override a Tera template with NAME=PATH
+
 ### `-h --help`
 
 Print help

--- a/lib/src/docs/markdown/mod.rs
+++ b/lib/src/docs/markdown/mod.rs
@@ -6,4 +6,4 @@ mod renderer;
 mod spec;
 mod tera;
 
-pub use renderer::MarkdownRenderer;
+pub use renderer::{MarkdownRenderer, MarkdownTemplate};

--- a/lib/src/docs/markdown/renderer.rs
+++ b/lib/src/docs/markdown/renderer.rs
@@ -5,6 +5,41 @@ use itertools::Itertools;
 use regex::Regex;
 use std::sync::LazyLock;
 
+/// One of the templates used to generate Markdown documentation.
+///
+/// A renderer starts with a complete built-in template set. Replacing one member keeps the
+/// others available, including through Tera's `{% include %}` directive. This lets an adopter
+/// change the document shell or the presentation of one kind of item without copying the whole
+/// theme.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MarkdownTemplate {
+    /// A single-file document containing the root and every subcommand.
+    Spec,
+    /// The landing page generated in multi-file mode.
+    Index,
+    /// A command and its arguments, flags, outputs, exits, and examples.
+    Command,
+    /// The details beneath one positional argument.
+    Argument,
+    /// The details beneath one flag.
+    Flag,
+    /// The configuration reference appended to a spec or written in multi-file mode.
+    Config,
+}
+
+impl MarkdownTemplate {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Spec => "spec_template.md.tera",
+            Self::Index => "index_template.md.tera",
+            Self::Command => "cmd_template.md.tera",
+            Self::Argument => "arg_template.md.tera",
+            Self::Flag => "flag_template.md.tera",
+            Self::Config => "config_template.md.tera",
+        }
+    }
+}
+
 /// An ANSI escape sequence: what `color_print::cstr!` leaves in help text.
 static SGR: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\x1b\[[0-?]*[ -/]*[@-~]").unwrap());
 /// A backtick span, or a bare `<` outside one.
@@ -75,6 +110,7 @@ pub struct MarkdownRenderer {
     url_prefix: Option<String>,
     html_encode: bool,
     replace_pre_with_code_fences: bool,
+    templates: Vec<(MarkdownTemplate, String)>,
 }
 
 impl MarkdownRenderer {
@@ -87,6 +123,7 @@ impl MarkdownRenderer {
             url_prefix: None,
             html_encode: true,
             replace_pre_with_code_fences: false,
+            templates: Vec::new(),
         };
         let mut spec = renderer.spec.clone();
         spec.render_md(&renderer);
@@ -149,6 +186,17 @@ impl MarkdownRenderer {
         self
     }
 
+    /// Replace one built-in Markdown template.
+    ///
+    /// Templates use [Tera](https://keats.github.io/tera/). A replacement may include any of the
+    /// templates it did not replace; for example, a custom [`MarkdownTemplate::Spec`] can still
+    /// contain `{% include "cmd_template.md.tera" %}`. Replacing the same member more than once
+    /// uses the last value. Syntax and include errors are returned by the render method.
+    pub fn with_template(mut self, template: MarkdownTemplate, source: impl Into<String>) -> Self {
+        self.templates.push((template, source.into()));
+        self
+    }
+
     fn tera_ctx(&self) -> tera::Context {
         let mut ctx = tera::Context::new();
         ctx.insert("spec", &self.spec);
@@ -170,6 +218,10 @@ impl MarkdownRenderer {
         enrich: impl FnOnce(&mut tera::Context),
     ) -> Result<String, UsageErr> {
         let mut tera = TERA.clone();
+
+        for (template, source) in &self.templates {
+            tera.add_raw_template(template.name(), source)?;
+        }
 
         let html_encode = self.html_encode;
         tera.register_filter(
@@ -221,7 +273,7 @@ impl MarkdownRenderer {
 
 #[cfg(test)]
 mod tests {
-    use super::escape_md;
+    use super::{escape_md, MarkdownRenderer, MarkdownTemplate};
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -270,5 +322,45 @@ mod tests {
 
         assert_eq!(escape_md(input, true), expected);
         assert_eq!(escape_md(input, false), expected);
+    }
+
+    #[test]
+    fn one_template_can_be_replaced_without_copying_its_includes() {
+        let spec = "bin \"ex\"\nflag \"--force\" help=\"Do it anyway\"\n"
+            .parse()
+            .unwrap();
+        let page = MarkdownRenderer::new(spec)
+            .with_template(
+                MarkdownTemplate::Spec,
+                "# Custom {{ spec.bin }}\n{% set cmd = spec.cmd %}\n{% include \"cmd_template.md.tera\" %}",
+            )
+            .render_spec()
+            .unwrap();
+
+        assert!(page.starts_with("# Custom ex\n"), "{page}");
+        assert!(page.contains("### `--force`"), "{page}");
+    }
+
+    #[test]
+    fn the_last_replacement_of_a_template_wins() {
+        let spec = "bin \"ex\"\n".parse().unwrap();
+        let page = MarkdownRenderer::new(spec)
+            .with_template(MarkdownTemplate::Spec, "first")
+            .with_template(MarkdownTemplate::Spec, "second")
+            .render_spec()
+            .unwrap();
+
+        assert_eq!(page, "second");
+    }
+
+    #[test]
+    fn a_bad_custom_template_is_a_render_error() {
+        let spec = "bin \"ex\"\n".parse().unwrap();
+        let err = MarkdownRenderer::new(spec)
+            .with_template(MarkdownTemplate::Spec, "{{")
+            .render_spec()
+            .unwrap_err();
+
+        assert!(err.to_string().contains("template"), "{err}");
     }
 }

--- a/lib/src/docs/markdown/renderer.rs
+++ b/lib/src/docs/markdown/renderer.rs
@@ -193,7 +193,16 @@ impl MarkdownRenderer {
     /// contain `{% include "cmd_template.md.tera" %}`. Replacing the same member more than once
     /// uses the last value. Syntax and include errors are returned by the render method.
     pub fn with_template(mut self, template: MarkdownTemplate, source: impl Into<String>) -> Self {
-        self.templates.push((template, source.into()));
+        let source = source.into();
+        if let Some((_, current)) = self
+            .templates
+            .iter_mut()
+            .find(|(current, _)| *current == template)
+        {
+            *current = source;
+        } else {
+            self.templates.push((template, source));
+        }
         self
     }
 
@@ -345,7 +354,7 @@ mod tests {
     fn the_last_replacement_of_a_template_wins() {
         let spec = "bin \"ex\"\n".parse().unwrap();
         let page = MarkdownRenderer::new(spec)
-            .with_template(MarkdownTemplate::Spec, "first")
+            .with_template(MarkdownTemplate::Spec, "{{")
             .with_template(MarkdownTemplate::Spec, "second")
             .render_spec()
             .unwrap();


### PR DESCRIPTION
Expose a typed `MarkdownTemplate` selector and let `MarkdownRenderer` replace individual bundled Tera templates. Unchanged templates remain available to custom templates through includes, and invalid custom syntax is returned through the existing render error path.

This enables adopters to preserve an established documentation layout without forking the renderer or discarding usage metadata.

Validation:
- `cargo test -p usage-lib docs::markdown::renderer --all-features`
- `cargo clippy -p usage-lib --all-features -- -D warnings`

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive docs-generation API and CLI flag; default templates are unchanged and invalid custom templates fail at render time.
> 
> **Overview**
> Adopters can now customize markdown output without forking the renderer. `MarkdownRenderer` exposes `MarkdownTemplate` and `with_template`, so one of `spec`, `index`, `command`, `argument`, `flag`, or `config` can be replaced while the rest stay available via Tera `{% include %}`.
> 
> `usage generate markdown` gains a repeatable `--template NAME=PATH` flag that loads those files. Unknown names and bad `NAME=PATH` values fail before render; Tera syntax errors still surface from the existing render path. Docs and tests cover both the library and CLI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ce8fb8a06854919e942dd66bcae93f17598e5ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customizing built-in Markdown templates.
  * Exposed template options for specifications, indexes, commands, arguments, flags, and configurations.
  * Custom templates can include existing built-in templates and override earlier customizations.

* **Bug Fixes**
  * Improved template handling so invalid custom templates report rendering errors correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->