### PR TITLE
fix(derive): preserve flattened command metadata

### DIFF
--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -2164,6 +2164,18 @@ fn write_group(out: &mut String, group: &GroupMeta<'_>, depth: usize) -> core::f
 /// order — outputs, then `select`, then exit codes — has to match what usage-lib's writer
 /// produces or `canonical_kdl` fails.
 fn write_outputs(out: &mut String, meta: &CommandMeta<'_>, depth: usize) -> core::fmt::Result {
+    write_own_outputs(out, meta, depth)?;
+    // A flattened `Args` type contributes to the command it is mounted on. Its flags and
+    // groups are already composed into the parent's metadata tables; command-level output
+    // metadata has to follow the same seam or a selector declared beside those flags simply
+    // disappears from the emitted spec.
+    for group in meta.flatten_groups {
+        write_outputs(out, group.meta, depth)?;
+    }
+    Ok(())
+}
+
+fn write_own_outputs(out: &mut String, meta: &CommandMeta<'_>, depth: usize) -> core::fmt::Result {
     for output in meta.outputs {
         indent(out, depth)?;
         write!(out, "output {}", quoted(output.name))?;

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -2164,18 +2164,18 @@ fn write_group(out: &mut String, group: &GroupMeta<'_>, depth: usize) -> core::f
 /// order — outputs, then `select`, then exit codes — has to match what usage-lib's writer
 /// produces or `canonical_kdl` fails.
 fn write_outputs(out: &mut String, meta: &CommandMeta<'_>, depth: usize) -> core::fmt::Result {
-    write_own_outputs(out, meta, depth)?;
     // A flattened `Args` type contributes to the command it is mounted on. Its flags and
     // groups are already composed into the parent's metadata tables; command-level output
     // metadata has to follow the same seam or a selector declared beside those flags simply
-    // disappears from the emitted spec.
-    for group in meta.flatten_groups {
-        write_outputs(out, group.meta, depth)?;
-    }
-    Ok(())
+    // disappears from the emitted spec. Each kind gets its own recursive pass so flattening
+    // cannot interleave an exit code before a nested output: the portable writer's canonical
+    // order is every output, then selectors, then exit codes.
+    write_output_decls(out, meta, depth)?;
+    write_selects(out, meta, depth)?;
+    write_exit_codes(out, meta, depth)
 }
 
-fn write_own_outputs(out: &mut String, meta: &CommandMeta<'_>, depth: usize) -> core::fmt::Result {
+fn write_output_decls(out: &mut String, meta: &CommandMeta<'_>, depth: usize) -> core::fmt::Result {
     for output in meta.outputs {
         indent(out, depth)?;
         write!(out, "output {}", quoted(output.name))?;
@@ -2205,10 +2205,24 @@ fn write_own_outputs(out: &mut String, meta: &CommandMeta<'_>, depth: usize) -> 
             None => out.push('\n'),
         }
     }
+    for group in meta.flatten_groups {
+        write_output_decls(out, group.meta, depth)?;
+    }
+    Ok(())
+}
+
+fn write_selects(out: &mut String, meta: &CommandMeta<'_>, depth: usize) -> core::fmt::Result {
     if let Some(select) = meta.select {
         indent(out, depth)?;
         writeln!(out, "select {}", quoted_arg(select))?;
     }
+    for group in meta.flatten_groups {
+        write_selects(out, group.meta, depth)?;
+    }
+    Ok(())
+}
+
+fn write_exit_codes(out: &mut String, meta: &CommandMeta<'_>, depth: usize) -> core::fmt::Result {
     for exit_code in meta.exit_codes {
         indent(out, depth)?;
         writeln!(
@@ -2217,6 +2231,9 @@ fn write_own_outputs(out: &mut String, meta: &CommandMeta<'_>, depth: usize) -> 
             exit_code.code,
             quoted(exit_code.help)
         )?;
+    }
+    for group in meta.flatten_groups {
+        write_exit_codes(out, group.meta, depth)?;
     }
     Ok(())
 }

--- a/conformance/tests/output.rs
+++ b/conformance/tests/output.rs
@@ -99,7 +99,7 @@ struct NestedOutput {
 }
 
 #[derive(Cli)]
-#[usage(name = "flattened-output")]
+#[usage(name = "flattened-output", exit_code(130, "interrupted"))]
 #[allow(dead_code)]
 struct FlattenedOutput {
     #[usage(flatten)]
@@ -118,6 +118,8 @@ fn flattened_args_contribute_command_output_metadata() {
     let spec: LibSpec = kdl
         .parse()
         .unwrap_or_else(|e| panic!("usage-lib could not parse the emitted spec: {e}\n\n{kdl}"));
+    assert!(kdl.find("output human") < kdl.find("select \"--format\""));
+    assert!(kdl.find("select \"--format\"") < kdl.find("exit_code 130"));
 
     assert_eq!(spec.outputs.len(), 2, "{kdl}");
     assert_eq!(spec.outputs[0].name, "human");
@@ -130,6 +132,7 @@ fn flattened_args_contribute_command_output_metadata() {
             .map(|exit| exit.help.as_str()),
         Some("invalid output selection")
     );
+    assert_eq!(spec.exit_codes[0].code, 130);
 
     let format = spec
         .cmd

--- a/conformance/tests/output.rs
+++ b/conformance/tests/output.rs
@@ -81,10 +81,70 @@ struct RootOrder {
     verbose: bool,
 }
 
+#[derive(Args)]
+#[usage(
+    output("human", default),
+    output("json", framing = "json"),
+    exit_code(2, "invalid output selection")
+)]
+struct SharedOutput {
+    #[usage(long, select)]
+    format: Option<String>,
+}
+
+#[derive(Args)]
+struct NestedOutput {
+    #[usage(flatten)]
+    output: SharedOutput,
+}
+
+#[derive(Cli)]
+#[usage(name = "flattened-output")]
+#[allow(dead_code)]
+struct FlattenedOutput {
+    #[usage(flatten)]
+    output: NestedOutput,
+}
+
 fn parsed() -> LibSpec {
     let kdl = Ex::to_kdl();
     kdl.parse()
         .unwrap_or_else(|e| panic!("usage-lib could not parse the emitted spec: {e}\n\n{kdl}"))
+}
+
+#[test]
+fn flattened_args_contribute_command_output_metadata() {
+    let kdl = FlattenedOutput::to_kdl();
+    let spec: LibSpec = kdl
+        .parse()
+        .unwrap_or_else(|e| panic!("usage-lib could not parse the emitted spec: {e}\n\n{kdl}"));
+
+    assert_eq!(spec.outputs.len(), 2, "{kdl}");
+    assert_eq!(spec.outputs[0].name, "human");
+    assert_eq!(spec.outputs[1].name, "json");
+    assert_eq!(spec.select.as_deref(), Some("--format"));
+    assert_eq!(
+        spec.exit_codes
+            .iter()
+            .find(|exit| exit.code == 2)
+            .map(|exit| exit.help.as_str()),
+        Some("invalid output selection")
+    );
+
+    let format = spec
+        .cmd
+        .flags
+        .iter()
+        .find(|flag| flag.name == "format")
+        .unwrap();
+    assert_eq!(
+        format
+            .arg
+            .as_ref()
+            .and_then(|arg| arg.choices.as_ref())
+            .map(|choices| choices.values()),
+        Some(vec!["human".into(), "json".into()])
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- emit output declarations contributed by flattened `Args`
- preserve flattened `select` and exit-code metadata, including through nested flattening
- verify selector choices still resolve from the composed output declarations

This removes the need for adopters such as the Oxc usage-rs integration to hoist output metadata from a reusable flattened options struct onto the root CLI.

## Testing

- `cargo test -p usage-conformance --test output`
- `mise run ci`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Spec-emission fix plus a conformance test; parsing and auth are unchanged. Canonical KDL order is the main thing to watch.
> 
> **Overview**
> Emitted specs now include **outputs, `select`, and exit codes** declared on flattened `Args` types, including nested flatten, instead of dropping them while flags were already composed.
> 
> `write_outputs` walks `flatten_groups` in three passes so canonical order stays **all outputs, then selectors, then exit codes**. Adopters no longer need to hoist reusable output metadata onto the root CLI.
> 
> A conformance test checks nested flatten, selector choices from composed outputs, and mixed parent/child exit codes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b59c864f5987dcb1786cfad8c7937e74c47b4be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Command specifications now correctly include output formats, selectors, and exit codes declared by flattened argument groups.
  * Ensures output-related metadata remains available when command options are composed from nested structures.

* **Tests**
  * Added coverage verifying inherited output formats, selection flags, valid choices, and custom exit-code messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->