### PR TITLE
fix(derive): skip choice checks for typed defaults

### DIFF
--- a/conformance/tests/dynamic_defaults.rs
+++ b/conformance/tests/dynamic_defaults.rs
@@ -10,12 +10,22 @@ fn default_port() -> u16 {
     NEXT_PORT.fetch_add(1, Ordering::Relaxed)
 }
 
+fn default_format() -> String {
+    String::new()
+}
+
 #[derive(Debug, Cli)]
 #[usage(bin = "serve")]
 struct Serve {
     /// Port to listen on
     #[usage(long, default_fn = default_port, default_note = "selected at runtime")]
     port: u16,
+}
+
+#[derive(Debug, Cli)]
+struct Report {
+    #[usage(long, choices("files", "timings"), default_fn = default_format)]
+    debug: String,
 }
 
 #[test]
@@ -28,6 +38,21 @@ fn a_function_supplies_a_fresh_typed_default() {
     let argv = [OsStr::new("--port"), OsStr::new("9000")];
     let explicit = Serve::parse_from(&argv).expect("argv still wins");
     assert_eq!(explicit.port, 9000);
+}
+
+#[test]
+fn a_typed_computed_default_is_not_revalidated_as_cli_text() {
+    let defaulted = Report::parse_from(&[]).expect("the typed default is already valid");
+    assert_eq!(defaulted.debug, "");
+
+    let explicit = [OsStr::new("--debug"), OsStr::new("files")];
+    assert_eq!(Report::parse_from(&explicit).unwrap().debug, "files");
+
+    let invalid = [OsStr::new("--debug"), OsStr::new("other")];
+    assert!(matches!(
+        Report::parse_from(&invalid),
+        Err(usage_argv::Error::InvalidChoice { name: "debug", .. })
+    ));
 }
 
 #[test]

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -9133,8 +9133,13 @@ fn post_binding(cli: &Cli) -> TokenStream {
         };
         let active = view_field_active(f);
         let standing_only = unless_standing_only(f);
+        let given = format_ident!("__given_{}", ident);
         Some(quote! {
-            if #active #standing_only {
+            // Choices validate lexical input. A typed computed default is already a value of
+            // the field's type; its `Display` form exists only so the partial can carry it to
+            // the final conversion and need not itself be one of the advertised CLI words.
+            // Environment values mark the field given, so they still take this path.
+            if #active && partial.#given #standing_only {
                 if partial.#invalid {
                     return ::std::result::Result::Err(
                         usage_argv::Error::InvalidChoice {


### PR DESCRIPTION
## Summary

- restrict lexical choice validation to values supplied by argv or environment variables
- allow a `default_fn` to return an already-typed value whose display form is not an advertised CLI choice
- retain `InvalidChoice` for explicitly supplied invalid values

This covers the Oxc case where an empty typed debug-options default is valid internally, while user-facing values remain limited to choices such as `files` and `timings`.

## Testing

- `cargo test -p usage-conformance --test dynamic_defaults`
- `mise run ci`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow derive-codegen change to when choice lists are applied; parsing of user-supplied values is unchanged.
> 
> **Overview**
> Choice checks no longer run on values that were never supplied on the CLI. A `default_fn` can return an already-typed value (for example an empty string) even when that display form is not one of the advertised choices.
> 
> Explicit argv and environment values still go through `InvalidChoice`. A conformance test covers a `choices` flag whose computed default is empty while `files`/`timings` remain the only accepted user input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d9e06610730afe8c20bafeddedb2288c8522f7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Computed and declared default values are now accepted even when their displayed format differs from configured CLI choices.
  * Explicitly provided invalid values from command-line arguments or environment variables continue to be rejected.
* **Tests**
  * Added coverage for typed runtime defaults and constrained debug values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->