### PR TITLE
feat(derive): dispatch embedded control requests

### DIFF
--- a/argv/src/embedded.rs
+++ b/argv/src/embedded.rs
@@ -2,8 +2,10 @@
 //!
 //! [`crate::Cli::parse`](https://docs.rs/usage-rs) owns a process: it prints help, versions and
 //! failures, then exits where appropriate. An N-API module, WASM host or editor integration cannot
-//! let a library end its process. [`outcome`] turns the same decisions into a value the host can
-//! print or return instead.
+//! let a library end its process. A derived CLI's `embedded_outcome` entry point owns the whole
+//! control protocol — spec and completion requests as well as help, versions and failures — and
+//! turns every decision into a value the host can print or return instead. [`outcome`] is the
+//! lower-level parser-and-renderer for hand-written tables.
 
 use std::ffi::OsStr;
 
@@ -22,7 +24,7 @@ pub struct Exit {
     pub code: i32,
 }
 
-/// The two things parsing inside another runtime can do.
+/// The two things dispatching a CLI inside another runtime can do.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Outcome<T> {
     /// The command line parsed and the host can run it.

--- a/conformance/tests/embedded.rs
+++ b/conformance/tests/embedded.rs
@@ -1,0 +1,56 @@
+use std::ffi::OsString;
+
+use usage_argv::embedded::Outcome;
+use usage_derive::Cli;
+
+#[derive(Debug, Cli)]
+#[usage(bin = "ex", version = "1.2.3", completion)]
+struct Ex {
+    #[usage(long)]
+    force: bool,
+}
+
+fn argv(words: &[&str]) -> Vec<OsString> {
+    words.iter().map(OsString::from).collect()
+}
+
+#[test]
+fn embedded_dispatch_owns_spec_and_completion_requests() {
+    let spec = Ex::embedded_outcome(&argv(&[usage_argv::SPEC_REQUEST]));
+    let exit = spec.exit().expect("the spec endpoint responds");
+    assert_eq!(exit.code, 0);
+    assert!(!exit.stderr);
+    assert!(exit.text.contains("name ex"), "{}", exit.text);
+
+    let completion = Ex::embedded_outcome(&argv(&[
+        "__complete_word__",
+        "--shell",
+        "bash",
+        "--line",
+        "ex --f",
+    ]));
+    let exit = completion.exit().expect("the completion endpoint responds");
+    assert_eq!(exit.code, 0);
+    assert!(!exit.stderr);
+    assert!(exit.text.contains("--force"), "{}", exit.text);
+}
+
+#[test]
+fn embedded_dispatch_parses_or_renders_every_other_outcome() {
+    let Outcome::Parsed(parsed) = Ex::embedded_outcome(&argv(&["--force"])) else {
+        panic!("an ordinary invocation should parse");
+    };
+    assert!(parsed.force);
+
+    let help = Ex::embedded_outcome(&argv(&["--help"]));
+    let exit = help.exit().expect("help is a response");
+    assert_eq!(exit.code, 0);
+    assert!(!exit.stderr);
+    assert!(exit.text.contains("Usage: ex"), "{}", exit.text);
+
+    let failure = Ex::embedded_outcome(&argv(&["--unknown"]));
+    let exit = failure.exit().expect("a parse failure is a response");
+    assert_eq!(exit.code, 2);
+    assert!(exit.stderr);
+    assert!(exit.text.contains("--unknown"), "{}", exit.text);
+}

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -491,6 +491,30 @@ pub fn emit(cli: &Cli) -> TokenStream {
     let apply = apply_fn(cli);
     let post = post_binding(cli);
     let (completion, completion_intercept) = completion_fns(cli);
+    let embedded_spec_request = cli.spec_endpoint.then(|| {
+        quote! {
+            if let ::std::option::Option::Some(__usage_answer) =
+                Self::spec_request(&__usage_refs)
+            {
+                return usage_argv::embedded::Outcome::Exit(usage_argv::embedded::Exit {
+                    text: __usage_answer,
+                    stderr: false,
+                    code: 0,
+                });
+            }
+        }
+    });
+    let embedded_completion_request = cli.completion.then(|| {
+        quote! {
+            if let ::std::option::Option::Some(__usage_answer) = Self::completion_request(argv) {
+                return usage_argv::embedded::Outcome::Exit(usage_argv::embedded::Exit {
+                    text: __usage_answer,
+                    stderr: false,
+                    code: 0,
+                });
+            }
+        }
+    });
     let spec_extra = spec_extra_append(cli);
     // `field: local` rather than the shorthand, because the locals are prefixed:
     // a field called `text` or `parser` would otherwise collide with something the
@@ -1311,6 +1335,27 @@ pub fn emit(cli: &Cli) -> TokenStream {
                 }
 
                 #spec_endpoint
+
+                /// Answer the complete usage control protocol without printing or exiting.
+                ///
+                /// Input excludes the program name, like [`Self::parse_from`]. Spec and
+                /// completion requests become successful stdout responses; ordinary argv is
+                /// parsed, with help, version, and failures represented by the same outcome.
+                pub fn embedded_outcome(
+                    argv: &[::std::ffi::OsString],
+                ) -> usage_argv::embedded::Outcome<Self> {
+                    let __usage_refs: ::std::vec::Vec<&::std::ffi::OsStr> =
+                        argv.iter().map(|arg| arg.as_os_str()).collect();
+                    #embedded_spec_request
+                    #embedded_completion_request
+                    #effective_spec
+                    usage_argv::embedded::outcome(
+                        __usage_spec,
+                        Self::command(),
+                        &__usage_refs,
+                        Self::parse_from,
+                    )
+                }
 
                 #settings_binding_forward
                 #settings_parse


### PR DESCRIPTION
## Summary

- generate `Cli::embedded_outcome(&[OsString])` as the single embedding entry point
- answer spec and completion protocol requests before parsing
- return ordinary parses, help, version, and failures through the existing `embedded::Outcome`
- preserve the low-level `embedded::outcome` API for hand-written tables

Embedded adopters such as Oxc no longer need to preflight `spec_request` and `completion_request` manually before calling the parser.

## Example

```rust
match Cli::embedded_outcome(&args) {
    usage::embedded::Outcome::Parsed(cli) => run(cli),
    usage::embedded::Outcome::Exit(exit) => host.respond(exit),
}
```

## Testing

- `cargo test -p usage-conformance --test embedded`
- `mise run ci`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a generated embedding entry point and tests; it reuses existing spec/completion helpers and does not change process-facing parse or auth/data paths.
> 
> **Overview**
> Hosts of a derived CLI can now call a single `embedded_outcome` entry point instead of preflighting `spec_request` and `completion_request` before parse.
> 
> When those protocol flags are enabled, generated code answers spec and completion requests as successful stdout `Exit` values, then falls through to the existing `embedded::outcome` helper for ordinary parses, help, version, and failures. The low-level `outcome` API stays for hand-written tables.
> 
> Conformance tests cover spec/completion dispatch plus parse, help, and error outcomes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dabfeb203a432a443ffbbf6d0ee621ebde2d45dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added embedded CLI handling for specification and shell-completion requests.
  * Added a unified outcome interface for successful parsing, help, and error responses.
  * Embedded command-line integrations can now return structured results suitable for hosts to display or process.

* **Documentation**
  * Clarified how embedded CLI outcomes and lower-level parsing interfaces are used.

* **Tests**
  * Added coverage for specifications, completions, successful parsing, help output, and parse errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->