### PR TITLE
feat(parse): preserve ordered argument groups

### DIFF
--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -3254,7 +3254,7 @@ pub fn choice_matches(choices: &[&str], value: &str, ignore_case: bool) -> bool 
         .any(|choice| *choice == value || ignore_case && choice.eq_ignore_ascii_case(value))
 }
 
-/// An enum whose variants are one command's mutually exclusive flags.
+/// An enum whose variants are one command's related flags.
 ///
 /// What a CLI spells `--json` or `--yaml` and holds as a `Mode`, rather than as one `bool` per
 /// member plus a `match` over which of them is set. Nothing new reaches the spec: the enum
@@ -3264,7 +3264,8 @@ pub fn choice_matches(choices: &[&str], value: &str, ignore_case: bool) -> bool 
 /// A field holding one says `#[usage(arg_group)]`. `Option<Mode>` is a group that may be left
 /// alone and a bare `Mode` is one that has to be given, which is how the rest of the derive
 /// reads required-ness from a type. There is no default variant, so required-ness has exactly
-/// one spelling.
+/// one spelling. A group declared `multiple` is held by `Vec<Mode>` and retains every member in
+/// command-line order.
 pub trait ArgGroup: Sized {
     /// What the group is called, in the emitted spec and in a failed check.
     const NAME: &'static str;
@@ -3277,6 +3278,8 @@ pub trait ArgGroup: Sized {
     const FLAG_METAS: &'static [FlagMeta<'static>];
     /// The selectors naming [`FLAGS`](Self::FLAGS), for [`GroupMeta::members`].
     const MEMBERS: &'static [&'static str];
+    /// Whether every member occurrence is retained rather than enforcing exclusivity.
+    const MULTIPLE: bool = false;
 
     /// Which members have been given so far. Partly-filled by construction, since a parse
     /// can stop early.
@@ -3320,6 +3323,17 @@ pub trait ArgGroup: Sized {
     /// [`Self::Partial`] until this step, just as an ordinary command field does.
     fn try_build(partial: &Self::Partial) -> Result<Option<Self>, crate::Error<'static, 'static>> {
         Ok(Self::build(partial))
+    }
+
+    /// Build every selected member in command-line order for a multiple group.
+    ///
+    /// The default keeps hand-written exclusive groups source-compatible and gives a useful
+    /// single-element answer when they are held by a collection accidentally; derived multiple
+    /// groups override it with their ordered occurrence log.
+    fn try_build_many(
+        partial: &Self::Partial,
+    ) -> Result<Vec<Self>, crate::Error<'static, 'static>> {
+        Ok(Self::try_build(partial)?.into_iter().collect())
     }
 
     /// Find a member by any selector it accepts.

--- a/conformance/tests/arg_group.rs
+++ b/conformance/tests/arg_group.rs
@@ -75,6 +75,8 @@ enum LintFilter {
 struct OrderedFilters {
     #[usage(arg_group)]
     filters: Vec<LintFilter>,
+    #[usage(long, overrides = "--allow")]
+    all: bool,
 }
 
 #[test]
@@ -103,6 +105,27 @@ fn a_multiple_argument_group_preserves_cross_flag_order() {
     assert!(
         kdl.contains("group lint-filter --allow --warn --deny multiple=#true"),
         "{kdl}"
+    );
+}
+
+#[test]
+fn overriding_a_multiple_group_member_removes_its_ordered_occurrences() {
+    let a = argv([
+        "-A",
+        "dead-code",
+        "-Wstyle",
+        "--allow=unused",
+        "--all",
+        "-Dwarnings",
+    ]);
+    let parsed = OrderedFilters::parse_from(&a).expect("overridden filters");
+    assert!(parsed.all);
+    assert_eq!(
+        parsed.filters,
+        vec![
+            LintFilter::Warn("style".into()),
+            LintFilter::Deny("warnings".into()),
+        ]
     );
 }
 

--- a/conformance/tests/arg_group.rs
+++ b/conformance/tests/arg_group.rs
@@ -59,6 +59,53 @@ enum Mode {
     StdinFilepath(std::path::PathBuf),
 }
 
+/// Lint severity overrides, applied from left to right.
+#[derive(ArgGroup, Debug, PartialEq)]
+#[usage(name = "lint-filter", multiple)]
+enum LintFilter {
+    #[usage(short = 'A')]
+    Allow(String),
+    #[usage(short = 'W')]
+    Warn(String),
+    #[usage(short = 'D')]
+    Deny(String),
+}
+
+#[derive(Cli)]
+struct OrderedFilters {
+    #[usage(arg_group)]
+    filters: Vec<LintFilter>,
+}
+
+#[test]
+fn a_multiple_argument_group_preserves_cross_flag_order() {
+    let a = argv([
+        "-D",
+        "all",
+        "--allow=no-debugger",
+        "-Wstyle",
+        "--deny",
+        "correctness",
+    ]);
+    assert_eq!(
+        OrderedFilters::parse_from(&a)
+            .expect("ordered filters")
+            .filters,
+        vec![
+            LintFilter::Deny("all".into()),
+            LintFilter::Allow("no-debugger".into()),
+            LintFilter::Warn("style".into()),
+            LintFilter::Deny("correctness".into()),
+        ]
+    );
+
+    let kdl = OrderedFilters::to_kdl();
+    assert!(
+        kdl.contains("group lint-filter --allow --warn --deny multiple=#true"),
+        "{kdl}"
+    );
+}
+
 #[derive(Cli)]
 #[usage(bin = "valued-group")]
 struct ValuedGroup {

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -3476,6 +3476,7 @@ fn standing_presence(field: &Field) -> Option<TokenStream> {
     let ident = &field.ident;
     match &field.kind {
         Kind::Skip | Kind::Flatten { .. } => None,
+        Kind::ArgGroup { multiple: true, .. } => Some(quote!(!__usage_s.#ident.is_empty())),
         Kind::ArgGroup { optional, .. } | Kind::Subcommand { optional, .. } => Some(if *optional {
             quote!(__usage_s.#ident.is_some())
         } else {
@@ -3520,13 +3521,18 @@ fn standing_locals(cli: &Cli) -> TokenStream {
             },
             // The nested value itself, so a parent can ask which member stands — a bool
             // would answer required-ness and nothing about `--json` vs `--yaml`.
+            Kind::ArgGroup { multiple: true, .. } => quote! {
+                let #name = __usage_standing.map(|__usage_s| &__usage_s.#ident);
+            },
             Kind::ArgGroup { optional: true, .. } | Kind::Subcommand { optional: true, .. } => {
                 quote! {
                     let #name = __usage_standing.and_then(|__usage_s| __usage_s.#ident.as_ref());
                 }
             }
             Kind::ArgGroup {
-                optional: false, ..
+                optional: false,
+                multiple: false,
+                ..
             }
             | Kind::Subcommand {
                 optional: false, ..
@@ -4951,8 +4957,16 @@ fn field_value(field: &Field, omitter: Option<&TokenStream>) -> TokenStream {
     // means. `check` has already reported both a second member and a required group with none,
     // so this arm is reached only for a group that was satisfied — the error stays for the
     // case where a caller drives `build` without it, rather than being an `unreachable!`.
-    if let Kind::ArgGroup { ty, optional } = &field.kind {
+    if let Kind::ArgGroup {
+        ty,
+        optional,
+        multiple,
+    } = &field.kind
+    {
         let group = quote!(<#ty as usage_argv::spec::ArgGroup>);
+        if *multiple {
+            return quote!(#group::try_build_many(&partial.#ident)?);
+        }
         return if *optional {
             quote!(#group::try_build(&partial.#ident)?)
         } else {
@@ -5253,8 +5267,20 @@ fn merge_fn(cli: &Cli) -> TokenStream {
                 )?;
             }),
             // A group with no member given is this argv saying nothing about the group.
-            Kind::ArgGroup { ty, optional } => {
+            Kind::ArgGroup {
+                ty,
+                optional,
+                multiple,
+            } => {
                 let group = quote!(<#ty as usage_argv::spec::ArgGroup>);
+                if *multiple {
+                    return Some(quote! {
+                        if #group::any_given(&partial.#field_ident).is_some() {
+                            __usage_standing.#field_ident =
+                                #group::try_build_many(&partial.#field_ident)?;
+                        }
+                    });
+                }
                 let selected = if *optional {
                     quote!(::std::option::Option::Some(__usage_member))
                 } else {
@@ -8381,13 +8407,17 @@ fn group_meta_table(cli: &Cli) -> (TokenStream, TokenStream) {
         })
         .collect();
     // Read from the enum rather than copied out of it: the members are its variants, and the
-    // field's type is the only thing that says whether one of them is needed. `multiple` is
-    // false because exclusivity is what an argument group is for.
+    // field's type says whether one or many results are built.
     for (at, field) in cli.fields.iter().enumerate() {
-        let Kind::ArgGroup { ty, optional } = &field.kind else {
+        let Kind::ArgGroup {
+            ty,
+            optional,
+            multiple,
+        } = &field.kind
+        else {
             continue;
         };
-        let required = !optional;
+        let required = !optional && !multiple;
         entries.push((
             at,
             quote! {
@@ -8395,7 +8425,13 @@ fn group_meta_table(cli: &Cli) -> (TokenStream, TokenStream) {
                     name: <#ty as usage_argv::spec::ArgGroup>::NAME,
                     members: <#ty as usage_argv::spec::ArgGroup>::MEMBERS,
                     required: #required,
-                    multiple: false,
+                    multiple: {
+                        assert!(
+                            <#ty as usage_argv::spec::ArgGroup>::MULTIPLE == #multiple,
+                            "an ArgGroup marked multiple must be held by Vec<T>, and Vec<T> needs #[usage(multiple)] on the ArgGroup"
+                        );
+                        #multiple
+                    },
                 }
             },
         ));
@@ -8867,17 +8903,17 @@ fn deprecations_fn(cli: &Cli) -> TokenStream {
 /// replaces the standing variant, so relationships must not keep reading the old one.
 fn argument_state_standing(cli: &Cli) -> TokenStream {
     let overlays = cli.fields.iter().filter_map(|field| {
-        let Kind::ArgGroup { ty, .. } = &field.kind else {
+        let Kind::ArgGroup { ty, multiple, .. } = &field.kind else {
             return None;
         };
         let ident = &field.ident;
         let standing = standing_ident(field);
         let group = quote!(<#ty as usage_argv::spec::ArgGroup>);
-        Some(quote! {
-            if #group::any_given(&partial.#ident).is_none() {
-                if let ::std::option::Option::Some(__usage_s) = #standing {
+        let read_standing = if *multiple {
+            quote! {
+                for __usage_member in __usage_s {
                     if let ::std::option::Option::Some(__usage_standing_state) =
-                        #group::standing_state(__usage_s, selector)
+                        #group::standing_state(__usage_member, selector)
                     {
                         if __usage_standing_state.given {
                             return ::std::option::Option::Some(__usage_standing_state);
@@ -8885,25 +8921,55 @@ fn argument_state_standing(cli: &Cli) -> TokenStream {
                     }
                 }
             }
+        } else {
+            quote! {
+                if let ::std::option::Option::Some(__usage_standing_state) =
+                    #group::standing_state(__usage_s, selector)
+                {
+                    if __usage_standing_state.given {
+                        return ::std::option::Option::Some(__usage_standing_state);
+                    }
+                }
+            }
+        };
+        Some(quote! {
+            if #group::any_given(&partial.#ident).is_none() {
+                if let ::std::option::Option::Some(__usage_s) = #standing {
+                    #read_standing
+                }
+            }
         })
     });
     let match_overlays = cli.fields.iter().filter_map(|field| {
-        let Kind::ArgGroup { ty, .. } = &field.kind else {
+        let Kind::ArgGroup { ty, multiple, .. } = &field.kind else {
             return None;
         };
         let ident = &field.ident;
         let standing = standing_ident(field);
         let group = quote!(<#ty as usage_argv::spec::ArgGroup>);
+        let read_standing = if *multiple {
+            quote! {
+                for __usage_member in __usage_s {
+                    if #group::standing_matches(__usage_member, selector, value)
+                        == ::std::option::Option::Some(true)
+                    {
+                        return ::std::option::Option::Some(true);
+                    }
+                }
+            }
+        } else {
+            quote! {
+                if #group::standing_matches(__usage_s, selector, value)
+                    == ::std::option::Option::Some(true)
+                {
+                    return ::std::option::Option::Some(true);
+                }
+            }
+        };
         Some(quote! {
             if #group::any_given(&partial.#ident).is_none() {
                 if let ::std::option::Option::Some(__usage_s) = #standing {
-                    if let ::std::option::Option::Some(__usage_standing_match) =
-                        #group::standing_matches(__usage_s, selector, value)
-                    {
-                        if __usage_standing_match {
-                            return ::std::option::Option::Some(true);
-                        }
-                    }
+                    #read_standing
                 }
             }
         })
@@ -9744,24 +9810,31 @@ fn post_binding(cli: &Cli) -> TokenStream {
     // read, so it answers them and this command reports them — in the same two phases, so a
     // conflict here still comes before an unsatisfied group anywhere on the command.
     for field in &cli.fields {
-        let Kind::ArgGroup { ty, optional } = &field.kind else {
+        let Kind::ArgGroup {
+            ty,
+            optional,
+            multiple,
+        } = &field.kind
+        else {
             continue;
         };
         let ident = &field.ident;
         let group = quote!(<#ty as usage_argv::spec::ArgGroup>);
-        group_exclusivity_checks.push(quote! {
-            if let ::std::option::Option::Some((__usage_earlier, __usage_later)) =
-                #group::conflict(&partial.#ident)
-            {
-                return ::std::result::Result::Err(
-                    usage_argv::Error::ConflictingFlags {
-                        name: __usage_later,
-                        other: __usage_earlier,
-                    },
-                );
-            }
-        });
-        if *optional {
+        if !multiple {
+            group_exclusivity_checks.push(quote! {
+                if let ::std::option::Option::Some((__usage_earlier, __usage_later)) =
+                    #group::conflict(&partial.#ident)
+                {
+                    return ::std::result::Result::Err(
+                        usage_argv::Error::ConflictingFlags {
+                            name: __usage_later,
+                            other: __usage_earlier,
+                        },
+                    );
+                }
+            });
+        }
+        if *optional || *multiple {
             continue;
         }
         // A bare `T` has nowhere to put "no member", which is the whole declaration — the
@@ -10043,6 +10116,7 @@ pub fn emit_arg_group(group: &ArgGroup) -> TokenStream {
     let ident = &group.ident;
     let runtime = runtime_path();
     let name = &group.name;
+    let multiple = group.multiple;
 
     // Minted from this declaration and the module it sits in, like a command's: two argument
     // groups in different modules cannot hand a parse the same key, and the arm that claims an
@@ -10114,6 +10188,7 @@ pub fn emit_arg_group(group: &ArgGroup) -> TokenStream {
                 help: #help,
                 long_help: #long_help,
                 hide: #hide,
+                repeatable: #multiple,
                 value_name: #value_name,
                 accepted_choices: #accepted_choices,
                 choices: #choices,
@@ -10130,6 +10205,9 @@ pub fn emit_arg_group(group: &ArgGroup) -> TokenStream {
         quote!(#(#cfg)* #selector)
     });
 
+    let ordered_field = multiple.then(|| {
+        quote!(pub ordered: ::std::vec::Vec<(usize, ::std::option::Option<::std::vec::Vec<u8>>)> ,)
+    });
     let partial_fields = group.variants.iter().enumerate().map(|(i, member)| {
         let given = format_ident!("given_{i}");
         let cfg = &member.cfg_attrs;
@@ -10144,6 +10222,15 @@ pub fn emit_arg_group(group: &ArgGroup) -> TokenStream {
         let key = key_ident("FLAG", Some(i));
         let given = format_ident!("given_{i}");
         let cfg = &member.cfg_attrs;
+        let record = if multiple {
+            if member.value_ty.is_some() {
+                quote!(partial.ordered.push((#i, value.map(<[u8]>::to_vec)));)
+            } else {
+                quote!(partial.ordered.push((#i, ::std::option::Option::None));)
+            }
+        } else {
+            quote!()
+        };
         let assign = if member.value_ty.is_some() {
             quote! {
                 if let ::std::option::Option::Some(value) = value {
@@ -10156,6 +10243,7 @@ pub fn emit_arg_group(group: &ArgGroup) -> TokenStream {
         quote! {
             #(#cfg)*
             #key if ::core::ptr::eq(*flag, &#table) => {
+                #record
                 #assign
                 true
             }
@@ -10179,25 +10267,33 @@ pub fn emit_arg_group(group: &ArgGroup) -> TokenStream {
     });
     // The first two given, in declaration order, which is the pair the user has to choose
     // between — and the same pair a hand-written group's pairwise check reports.
-    let conflict_arms = group.variants.iter().enumerate().map(|(i, member)| {
-        let given = format_ident!("given_{i}");
-        let cfg = &member.cfg_attrs;
-        let name = &member.name;
-        let is_given = if member.value_ty.is_some() {
-            quote!(partial.#given.is_some())
-        } else {
-            quote!(partial.#given)
-        };
-        quote! {
-            #(#cfg)*
-            if #is_given {
-                if let ::std::option::Option::Some(__usage_earlier) = __usage_first {
-                    return ::std::option::Option::Some((__usage_earlier, #name));
-                }
-                __usage_first = ::std::option::Option::Some(#name);
+    let conflict_arms: Vec<_> = group
+        .variants
+        .iter()
+        .enumerate()
+        .filter_map(|(i, member)| {
+            if multiple {
+                return None;
             }
-        }
-    });
+            let given = format_ident!("given_{i}");
+            let cfg = &member.cfg_attrs;
+            let name = &member.name;
+            let is_given = if member.value_ty.is_some() {
+                quote!(partial.#given.is_some())
+            } else {
+                quote!(partial.#given)
+            };
+            Some(quote! {
+                #(#cfg)*
+                if #is_given {
+                    if let ::std::option::Option::Some(__usage_earlier) = __usage_first {
+                        return ::std::option::Option::Some((__usage_earlier, #name));
+                    }
+                    __usage_first = ::std::option::Option::Some(#name);
+                }
+            })
+        })
+        .collect();
     let build_arms = group.variants.iter().enumerate().map(|(i, member)| {
         let given = format_ident!("given_{i}");
         let cfg = &member.cfg_attrs;
@@ -10279,6 +10375,84 @@ pub fn emit_arg_group(group: &ArgGroup) -> TokenStream {
                 return ::std::result::Result::Ok(
                     ::std::option::Option::Some(Self::#variant(__usage_value)),
                 );
+            }
+        }
+    });
+    let build_many_arms = group.variants.iter().enumerate().map(|(i, member)| {
+        let cfg = &member.cfg_attrs;
+        let variant = &member.ident;
+        let Some(ty) = &member.value_ty else {
+            return quote! {
+                #(#cfg)*
+                #i => Self::#variant,
+            };
+        };
+        let name = &member.name;
+        let rendered = rendered_path(ty);
+        let converted = match rendered.as_str() {
+            "PathBuf" | "std::path::PathBuf" | "::std::path::PathBuf" => quote! {
+                match usage_argv::os_string_from_bytes(__usage_value) {
+                    ::std::result::Result::Ok(value) => ::std::path::PathBuf::from(value),
+                    ::std::result::Result::Err(bytes) => {
+                        return ::std::result::Result::Err(
+                            usage_argv::invalid_os_value(#name, bytes),
+                        );
+                    }
+                }
+            },
+            "OsString" | "std::ffi::OsString" | "::std::ffi::OsString" => quote! {
+                match usage_argv::os_string_from_bytes(__usage_value) {
+                    ::std::result::Result::Ok(value) => value,
+                    ::std::result::Result::Err(bytes) => {
+                        return ::std::result::Result::Err(
+                            usage_argv::invalid_os_value(#name, bytes),
+                        );
+                    }
+                }
+            },
+            _ if member.value_enum => quote! {{
+                let __usage_text = match ::std::string::String::from_utf8(__usage_value) {
+                    ::std::result::Result::Ok(text) => text,
+                    ::std::result::Result::Err(bad) => {
+                        return ::std::result::Result::Err(
+                            usage_argv::invalid_utf8_value(#name, bad),
+                        );
+                    }
+                };
+                match <#ty as usage_argv::spec::ValueEnum>::from_choice(&__usage_text) {
+                    ::std::option::Option::Some(value) => value,
+                    ::std::option::Option::None => {
+                        return ::std::result::Result::Err(
+                            usage_argv::invalid_choice_value(#name, __usage_text),
+                        );
+                    }
+                }
+            }},
+            _ => quote! {{
+                let __usage_text = match ::std::string::String::from_utf8(__usage_value) {
+                    ::std::result::Result::Ok(text) => text,
+                    ::std::result::Result::Err(bad) => {
+                        return ::std::result::Result::Err(
+                            usage_argv::invalid_utf8_value(#name, bad),
+                        );
+                    }
+                };
+                match ::std::str::FromStr::from_str(&__usage_text) {
+                    ::std::result::Result::Ok(value) => value,
+                    ::std::result::Result::Err(reason) => {
+                        return ::std::result::Result::Err(
+                            usage_argv::invalid_parsed_value(#name, __usage_text, &reason),
+                        );
+                    }
+                }
+            }},
+        };
+        quote! {
+            #(#cfg)*
+            #i => {
+                let __usage_value = __usage_value.clone().unwrap_or_default();
+                let __usage_value: #ty = #converted;
+                Self::#variant(__usage_value)
             }
         }
     });
@@ -10421,6 +10595,26 @@ pub fn emit_arg_group(group: &ArgGroup) -> TokenStream {
             }
         }
     });
+    let build_many_impl = multiple.then(|| {
+        quote! {
+            fn try_build_many(
+                partial: &Self::Partial,
+            ) -> ::std::result::Result<
+                ::std::vec::Vec<Self>,
+                usage_argv::Error<'static, 'static>,
+            > {
+                let mut __usage_members = ::std::vec::Vec::with_capacity(partial.ordered.len());
+                for (__usage_at, __usage_value) in &partial.ordered {
+                    let __usage_member = match *__usage_at {
+                        #(#build_many_arms)*
+                        _ => continue,
+                    };
+                    __usage_members.push(__usage_member);
+                }
+                ::std::result::Result::Ok(__usage_members)
+            }
+        }
+    });
 
     quote! {
         #[doc(hidden)]
@@ -10441,6 +10635,7 @@ pub fn emit_arg_group(group: &ArgGroup) -> TokenStream {
 
             #[derive(Default)]
             pub struct Partial {
+                #ordered_field
                 #(#partial_fields)*
             }
 
@@ -10450,6 +10645,7 @@ pub fn emit_arg_group(group: &ArgGroup) -> TokenStream {
                 const FLAG_METAS: &'static [usage_argv::spec::FlagMeta<'static>] =
                     &[#(#flag_metas),*];
                 const MEMBERS: &'static [&'static str] = &[#(#members),*];
+                const MULTIPLE: bool = #multiple;
 
                 type Partial = Partial;
 
@@ -10497,6 +10693,8 @@ pub fn emit_arg_group(group: &ArgGroup) -> TokenStream {
                     #(#build_arms)*
                     ::std::result::Result::Ok(::std::option::Option::None)
                 }
+
+                #build_many_impl
 
                 fn argument_state(
                     partial: &Self::Partial,

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -10570,6 +10570,8 @@ pub fn emit_arg_group(group: &ArgGroup) -> TokenStream {
         // selector is known to this type, so a parent that short-circuits on the
         // first true does not fall through to "unresolved" when the member was
         // simply not given. Clearing is what happens when it *was* given.
+        let clear_ordered =
+            multiple.then(|| quote!(partial.ordered.retain(|(__usage_at, _)| *__usage_at != #i);));
         let clear = if member.value_ty.is_some() {
             quote!(partial.#given = ::std::option::Option::None;)
         } else {
@@ -10578,6 +10580,7 @@ pub fn emit_arg_group(group: &ArgGroup) -> TokenStream {
         quote! {
             #(#cfg)*
             #(#selectors)|* => {
+                #clear_ordered
                 #clear
                 return true;
             }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -298,7 +298,7 @@
 //! | `double_dash = "…"` | how a positional relates to `--`: `optional` (the default), `required` (fillable only after one), `preserve` (the `--` is a value), `automatic` (filling it ends flag parsing, so a wrapper forwards) |
 //! | `complete = my_fn` | a function that answers for this value when a shell asks |
 //! | `value_enum` | the words come from the field's type, which derives [`ValueEnum`] |
-//! | `arg_group` | the flags come from the field's type, which derives [`ArgGroup`]; at most one may be given |
+//! | `arg_group` | the flags come from the field's type, which derives [`ArgGroup`]; `Vec<T>` preserves a `multiple` group's occurrence order |
 //! | `value_hint = usage::ValueHint::FilePath` | ask the shell for paths, executables, or forwarded command argv |
 //! | `extensions("toml", "yaml")` | limit a file-path hint to these extensions while retaining directories |
 //! | `arg` | force a field to be positional |
@@ -542,11 +542,11 @@ pub fn derive_value_enum(input: TokenStream) -> TokenStream {
     }
 }
 
-/// Compile an enum into a set of flags at most one of which may be given.
+/// Compile an enum into a set of related flags.
 ///
-/// clap's most-requested derive ergonomic (clap#2621): mutually exclusive flags as enum
-/// variants, so the code that reads them matches on a type rather than on which of several
-/// `bool`s is set. Each variant is one switch, named by its own name in kebab-case:
+/// Exclusive or ordered flags as enum variants, so the code that reads them matches on a type
+/// rather than on which of several fields is set. Each variant is one switch, named by its own
+/// name in kebab-case:
 ///
 /// ```ignore
 /// #[derive(usage::ArgGroup)]
@@ -584,6 +584,9 @@ pub fn derive_value_enum(input: TokenStream) -> TokenStream {
 /// [`Error::MissingGroup`](usage_argv::Error::MissingGroup). A tuple variant with one field is a
 /// value-taking member such as `Migrate(Source)`; `value_name` and `value_enum` describe that
 /// payload exactly as they do on an ordinary flag.
+///
+/// `#[usage(multiple)]` changes the group into an ordered instruction stream. Hold it as
+/// `Vec<Mode>` and every occurrence is returned in argv order, including interleaved variants.
 ///
 /// A variant's doc comment becomes its help. `help = "..."`, `long_help = "..."`, `hide`, and
 /// `short = 'x'` are the rest of what a member has; `cfg` and `cfg_attr` are copied to the

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -664,17 +664,19 @@ pub enum Kind {
         /// `next_help_heading` on the flatten site.
         help_heading: Option<String>,
     },
-    /// Holds the enum whose variants are one group of this command's exclusive flags.
+    /// Holds the enum whose variants are one group of this command's related flags.
     ///
     /// The type is carried rather than resolved, as for a flatten: the derive cannot see the
     /// enum's variants, so the switches, their metadata, and the state that collects them all
     /// arrive through [`ArgGroup`](usage_argv::spec::ArgGroup).
     ArgGroup {
-        /// The enum's type with any `Option` stripped, which is what names the trait.
+        /// The enum's type with any `Option` or `Vec` stripped, which names the trait.
         ty: syn::Type,
         /// Whether the field is `Option<T>`, and so may be left alone. A bare `T` says one
         /// member has to be given, which is reported once the last token has been read.
         optional: bool,
+        /// Whether every occurrence is collected, in command-line order, into a `Vec<T>`.
+        multiple: bool,
     },
     /// A field that is not an argument at all, filled from `Default`.
     ///
@@ -2292,14 +2294,17 @@ impl Field {
         // like `Option<crate::fmt::Format>` keeps the inner type intact; `type_name` would
         // collapse it to `Format` and put a name that is not in scope into the generated
         // tables.
-        let (ty, optional) = match peel(&field.ty, "Option") {
-            Some(inner) => (inner, true),
-            None => (field.ty.clone(), false),
+        let (ty, optional, multiple) = match peel(&field.ty, "Option") {
+            Some(inner) => (inner, true, false),
+            None => match peel(&field.ty, "Vec") {
+                Some(inner) => (inner, false, true),
+                None => (field.ty.clone(), false, false),
+            },
         };
 
         // Anything wrapped around the enum is refused here, where the field is, rather than
         // left to the unsatisfied trait bound the generated code would report: a group
-        // resolves to at most one member, so there is nothing for a container to hold.
+        // resolves to one optional value or one ordered collection.
         let inner = type_name(&ty);
         if let Some(container) = ["Vec", "Option", "Box"]
             .into_iter()
@@ -2308,9 +2313,8 @@ impl Field {
             return Err(syn::Error::new_spanned(
                 &field.ty,
                 format!(
-                    "`arg_group` holds its enum as `Mode` for a required group or \
-                     `Option<Mode>` for an optional one: a group resolves to at most one \
-                     member, so there is nothing for `{container}` to hold"
+                    "`arg_group` holds its enum as `Mode`, `Option<Mode>`, or `Vec<Mode>`: \
+                     nested `{container}` wrappers cannot represent a group's result"
                 ),
             ));
         }
@@ -2320,7 +2324,11 @@ impl Field {
             ty: field.ty.clone(),
             name: to_kebab(&ident.to_string()),
             value_optional: false,
-            kind: Kind::ArgGroup { ty, optional },
+            kind: Kind::ArgGroup {
+                ty,
+                optional,
+                multiple,
+            },
             // Each member carries its own, as a flattened group's flags do: the field holds
             // no flag of its own to describe.
             effect: None,
@@ -6190,7 +6198,7 @@ impl ValueEnum {
     }
 }
 
-/// An enum whose variants are one group of a command's exclusive flags.
+/// An enum whose variants are one group of a command's related flags.
 pub struct ArgGroup {
     pub ident: syn::Ident,
     /// What the group is called in the emitted spec: the type's name in kebab-case,
@@ -6198,6 +6206,8 @@ pub struct ArgGroup {
     pub name: String,
     /// What this type's keys are derived from. See [`Cli::fingerprint`].
     pub fingerprint: String,
+    /// Whether members may be repeated and combined, preserving their occurrence order.
+    pub multiple: bool,
     /// Each variant, and the switch it answers to.
     pub variants: Vec<ArgGroupMember>,
 }
@@ -6225,8 +6235,7 @@ impl ArgGroup {
         let Data::Enum(data) = &input.data else {
             return Err(syn::Error::new_spanned(
                 &input.ident,
-                "usage::ArgGroup describes a set of flags at most one of which may be given, \
-                 so it needs an enum",
+                "usage::ArgGroup describes a related set of flags, so it needs an enum",
             ));
         };
         if !input.generics.params.is_empty() {
@@ -6238,17 +6247,19 @@ impl ArgGroup {
         }
 
         let mut name = to_kebab(&input.ident.unraw().to_string());
+        let mut multiple = false;
         for attr in attrs(&input.attrs) {
             for meta in nested(attr)? {
                 let path = meta.path().clone();
                 match ident_of(&path).as_str() {
                     "name" => name = string_value(&meta)?,
+                    "multiple" => multiple = flag_value(&meta)?,
                     other => {
                         return Err(syn::Error::new_spanned(
                             path,
                             format!(
                                 "unknown arg-group option `{other}`; the enum takes `name` \
-                                 here, and everything else belongs on a variant"
+                                 or `multiple` here, and everything else belongs on a variant"
                             ),
                         ))
                     }
@@ -6428,6 +6439,7 @@ impl ArgGroup {
             ident: input.ident.clone(),
             name,
             fingerprint: quote::ToTokens::to_token_stream(input).to_string(),
+            multiple,
             variants,
         })
     }
@@ -8251,7 +8263,7 @@ mod tests {
             optional,
             "`Option<Format>` is a group that may be left alone"
         );
-        let Kind::ArgGroup { optional, ty } = &parsed.fields[1].kind else {
+        let Kind::ArgGroup { optional, ty, .. } = &parsed.fields[1].kind else {
             panic!("expected an argument group");
         };
         assert!(!optional, "a bare `Source` is a group that has to be given");
@@ -8266,7 +8278,7 @@ mod tests {
             }
         "#)
         .expect("should compile");
-        let Kind::ArgGroup { ty, optional } = &parsed.fields[0].kind else {
+        let Kind::ArgGroup { ty, optional, .. } = &parsed.fields[0].kind else {
             panic!("expected an argument group");
         };
         assert!(optional);
@@ -8275,9 +8287,25 @@ mod tests {
             "crate :: fmt :: Format"
         );
 
-        // And nothing wrapped around it, which the field says rather than the trait bound the
-        // generated code would otherwise fail.
-        for ty in ["Vec<Format>", "Option<Option<Format>>", "Box<Format>"] {
+        let parsed = cli(r#"
+            struct Ex {
+                #[usage(arg_group)]
+                filters: Vec<Filter>,
+            }
+        "#)
+        .expect("an ordered group is a collection");
+        let Kind::ArgGroup { ty, multiple, .. } = &parsed.fields[0].kind else {
+            panic!("expected an argument group");
+        };
+        assert!(multiple);
+        assert_eq!(super::type_name(ty), "Filter");
+
+        // Nested wrappers cannot describe one of the three supported result shapes.
+        for ty in [
+            "Option<Option<Format>>",
+            "Option<Vec<Format>>",
+            "Box<Format>",
+        ] {
             let err = rejection(&format!(
                 r#"
                 struct Ex {{
@@ -8286,7 +8314,7 @@ mod tests {
                 }}
             "#
             ));
-            assert!(err.contains("at most one member"), "unhelpful: {err}");
+            assert!(err.contains("cannot represent"), "unhelpful: {err}");
         }
     }
 

--- a/docs/rust/validation.md
+++ b/docs/rust/validation.md
@@ -143,7 +143,35 @@ The field's type says whether the group is required, exactly as it does everywhe
 given. There is no default variant, so that distinction is the only spelling of required-ness a
 group has.
 
-Nothing new reaches the spec. The enum lowers to the same `group` node
+A group whose occurrences form an ordered instruction stream declares `multiple` and is held by
+`Vec<T>`. Every member may repeat, and variants from different members remain interleaved exactly
+as they appeared in argv:
+
+```rust
+#[derive(ArgGroup)]
+#[usage(name = "lint-filter", multiple)]
+enum LintFilter {
+    #[usage(short = 'A')]
+    Allow(String),
+    #[usage(short = 'W')]
+    Warn(String),
+    #[usage(short = 'D')]
+    Deny(String),
+}
+
+#[derive(Cli)]
+struct Lint {
+    #[usage(arg_group)]
+    filters: Vec<LintFilter>,
+}
+```
+
+Parsing `-D all -A no-debugger` produces
+`vec![LintFilter::Deny("all"), LintFilter::Allow("no-debugger")]`. This differs from three
+independent `Vec<String>` fields, which preserve order within each flag but lose their order
+relative to one another.
+
+The enum lowers to the same `group` node
 (`group format --json --yaml --plain`), so `--json --yaml` is the same
 `ConflictingFlags` a hand-written group produces, a required group with none of its members
 given is the same `MissingGroup`, and help, docs and completions list the member flags without


### PR DESCRIPTION
## Summary

- add `#[usage(multiple)]` to `ArgGroup` enums
- collect a multiple group into `Vec<T>` in original argv order
- retain interleaving across related flags such as `-A`, `-W`, and `-D`
- emit the portable `group ... multiple=#true` contract

This lets Oxc model lint severity overrides as one typed instruction stream and remove its second argv parser pass.

## Validation

- `cargo fmt --all --check`
- `cargo test --all --all-features`
- `cargo clippy -p usage-argv -p usage-derive -p usage-conformance --all-features --all-targets -- -D warnings`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core parse/derive for argument groups (build, merge, standing state, spec). Exclusive groups stay the default; mismatch of multiple vs Vec is asserted at compile time.
> 
> **Overview**
> ArgGroup enums can now be an **ordered instruction stream** instead of only mutually exclusive flags.
> 
> Mark the enum `#[usage(multiple)]` and hold it as `Vec<T>`. Occurrences of related flags (e.g. `-A`/`-W`/`-D`) are kept in argv order, including interleaved variants. Exclusive groups are unchanged. The spec emits `group … multiple=#true`. Overrides still drop that member’s ordered entries.
> 
> `ArgGroup` gains `MULTIPLE` and `try_build_many`. Derive skips exclusivity/required checks for multiple groups, records an occurrence log, and compile-time-asserts that `multiple` on the enum matches `Vec<T>` on the field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc040a60c6117b4f60521098d585f10c3f7d58d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->