### PR TITLE
feat(spec): add semantic note and warning blocks

### DIFF
--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -19,7 +19,9 @@
 
 use core::fmt::Write as _;
 
-use crate::spec::{ArgMeta, CommandMeta, Example, FlagMeta, Spec, ViewMeta};
+use crate::spec::{
+    AdmonitionKind, AdmonitionMeta, ArgMeta, CommandMeta, Example, FlagMeta, Spec, ViewMeta,
+};
 use crate::Command;
 use crate::DoubleDash;
 
@@ -1919,6 +1921,7 @@ fn long_sections(
                 width,
                 meta.next_line_help,
             );
+            admonitions(out, a.admonitions);
             long_annotations(
                 out,
                 if a.hide_possible_values {
@@ -1959,6 +1962,7 @@ fn long_sections(
                 width,
                 meta.next_line_help,
             );
+            admonitions(out, f.admonitions);
             long_annotations(
                 out,
                 if f.hide_possible_values {
@@ -1988,6 +1992,7 @@ fn long_sections(
         |out, (f, usage)| {
             let text = f.long_help.or(f.help);
             entry(out, usage, text, flag_col, width, meta.next_line_help);
+            admonitions(out, f.admonitions);
             long_annotations(
                 out,
                 if f.hide_possible_values {
@@ -2163,6 +2168,16 @@ fn long_annotations(
     environment_notes(out, env_fallback, deprecated_env, 4);
     if !default.is_empty() {
         let _ = writeln!(out, "    (default: {})", default.join(", "));
+    }
+}
+
+fn admonitions(out: &mut String, blocks: &[AdmonitionMeta<'_>]) {
+    for block in blocks {
+        let label = match block.kind {
+            AdmonitionKind::Note => "Note",
+            AdmonitionKind::Warning => "Warning",
+        };
+        write_indented(out, &format!("{label}: {}", block.text), 4);
     }
 }
 

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -2361,6 +2361,7 @@ fn flat_commands_long(out: &mut String, path: &[&str], meta: &CommandMeta<'_>, w
                 width,
                 meta.next_line_help,
             );
+            admonitions(out, arg.admonitions);
             long_annotations(
                 out,
                 if arg.hide_possible_values {
@@ -2391,6 +2392,7 @@ fn flat_commands_long(out: &mut String, path: &[&str], meta: &CommandMeta<'_>, w
                 width,
                 meta.next_line_help,
             );
+            admonitions(out, flag.admonitions);
             long_annotations(
                 out,
                 if flag.hide_possible_values {

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -980,6 +980,20 @@ pub struct FlattenGroup<'a> {
     pub help_heading: Option<&'a str>,
 }
 
+/// The significance of an explanatory block attached to an argument.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdmonitionKind {
+    Note,
+    Warning,
+}
+
+/// Structured explanatory text that each renderer adapts to its output format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AdmonitionMeta<'a> {
+    pub kind: AdmonitionKind,
+    pub text: &'a str,
+}
+
 /// What a flag knows about itself beyond how it parses.
 #[derive(Debug, Clone, Copy)]
 pub struct FlagMeta<'a> {
@@ -994,6 +1008,8 @@ pub struct FlagMeta<'a> {
     pub help: Option<&'a str>,
     /// Long help, shown by `--help`.
     pub long_help: Option<&'a str>,
+    /// Notes and warnings shown after the extended help text.
+    pub admonitions: &'a [AdmonitionMeta<'a>],
     /// Why this flag is deprecated, plus optional release milestones.
     pub deprecated: Option<&'a str>,
     pub deprecated_warn_at: Option<&'a str>,
@@ -1111,6 +1127,7 @@ impl FlagMeta<'_> {
         hidden_longs: &[],
         help: None,
         long_help: None,
+        admonitions: &[],
         deprecated: None,
         deprecated_warn_at: None,
         deprecated_remove_at: None,
@@ -1197,6 +1214,8 @@ pub struct ArgMeta<'a> {
     pub value_names: &'a [&'a str],
     pub help: Option<&'a str>,
     pub long_help: Option<&'a str>,
+    /// Notes and warnings shown after the extended help text.
+    pub admonitions: &'a [AdmonitionMeta<'a>],
     pub env: Option<&'a str>,
     pub env_fallback: &'a [&'a str],
     pub deprecated_env: &'a [&'a str],
@@ -1260,6 +1279,7 @@ impl ArgMeta<'_> {
         value_names: &[],
         help: None,
         long_help: None,
+        admonitions: &[],
         env: None,
         env_fallback: &[],
         deprecated_env: &[],
@@ -2390,6 +2410,7 @@ fn write_flag(
     write_single_list(out, "required_unless_all", meta.required_unless_all)?;
 
     let has_children = meta.long_help.is_some()
+        || !meta.admonitions.is_empty()
         || !meta.hidden_shorts.is_empty()
         || !meta.hidden_longs.is_empty()
         || meta.flag.takes_value
@@ -2418,6 +2439,14 @@ fn write_flag(
     if let Some(long_help) = meta.long_help {
         indent(out, inner)?;
         writeln!(out, "long_help {}", quoted(long_help))?;
+    }
+    for admonition in meta.admonitions {
+        indent(out, inner)?;
+        let kind = match admonition.kind {
+            AdmonitionKind::Note => "note",
+            AdmonitionKind::Warning => "warning",
+        };
+        writeln!(out, "{kind} {}", quoted(admonition.text))?;
     }
     if !meta.hidden_shorts.is_empty() || !meta.hidden_longs.is_empty() {
         indent(out, inner)?;
@@ -2685,6 +2714,7 @@ fn write_arg(out: &mut String, meta: &ArgMeta<'_>, depth: usize) -> core::fmt::R
     write_single_list(out, "required_unless_all", meta.required_unless_all)?;
 
     let has_children = meta.long_help.is_some()
+        || !meta.admonitions.is_empty()
         || !meta.choices.is_empty()
         || !meta.accepted_choices.is_empty()
         || !meta.choice_details.is_empty()
@@ -2709,6 +2739,14 @@ fn write_arg(out: &mut String, meta: &ArgMeta<'_>, depth: usize) -> core::fmt::R
     if let Some(long_help) = meta.long_help {
         indent(out, inner)?;
         writeln!(out, "long_help {}", quoted(long_help))?;
+    }
+    for admonition in meta.admonitions {
+        indent(out, inner)?;
+        let kind = match admonition.kind {
+            AdmonitionKind::Note => "note",
+            AdmonitionKind::Warning => "warning",
+        };
+        writeln!(out, "{kind} {}", quoted(admonition.text))?;
     }
     if meta.conflicts.len() > 1 {
         indent(out, inner)?;

--- a/conformance/src/tables.rs
+++ b/conformance/src/tables.rs
@@ -29,8 +29,9 @@ use usage::{
     SpecGroup, SpecOutput,
 };
 use usage_argv::spec::{
-    ArgMeta, ChoiceAliasMeta, ChoiceMeta, CommandMeta, DefaultIf, Effect, Example, ExitCodeMeta,
-    FlagMeta, Framing as ArgvFraming, GroupMeta, OutputMeta, RequiredIfEq, RequiresIf,
+    AdmonitionKind, AdmonitionMeta, ArgMeta, ChoiceAliasMeta, ChoiceMeta, CommandMeta, DefaultIf,
+    Effect, Example, ExitCodeMeta, FlagMeta, Framing as ArgvFraming, GroupMeta, OutputMeta,
+    RequiredIfEq, RequiresIf,
 };
 use usage_argv::{Arg, Command, DoubleDash, Flag, UnknownFlags as ArgvUnknownFlags};
 
@@ -379,6 +380,7 @@ fn flag_meta(
         hidden_longs: strs(&f.hidden_aliases),
         help: opt(&f.help),
         long_help: opt(&f.help_long),
+        admonitions: admonitions(&f.admonitions),
         deprecated: opt(&f.deprecated),
         deprecated_warn_at: opt(&f.deprecated_warn_at),
         deprecated_remove_at: opt(&f.deprecated_remove_at),
@@ -488,6 +490,7 @@ fn arg_meta(
         value_names: strs(&a.value_names),
         help: opt(&a.help),
         long_help: opt(&a.help_long),
+        admonitions: admonitions(&a.admonitions),
         env: opt(&a.env),
         env_fallback: strs(&a.env_fallback),
         deprecated_env: strs(&a.deprecated_env),
@@ -608,6 +611,21 @@ fn strs(list: &[String]) -> &'static [&'static str] {
     Box::leak(
         list.iter()
             .map(|s| leak(s))
+            .collect::<Vec<_>>()
+            .into_boxed_slice(),
+    )
+}
+
+fn admonitions(list: &[usage::SpecAdmonition]) -> &'static [AdmonitionMeta<'static>] {
+    Box::leak(
+        list.iter()
+            .map(|block| AdmonitionMeta {
+                kind: match block.kind {
+                    usage::SpecAdmonitionKind::Note => AdmonitionKind::Note,
+                    usage::SpecAdmonitionKind::Warning => AdmonitionKind::Warning,
+                },
+                text: leak(&block.text),
+            })
             .collect::<Vec<_>>()
             .into_boxed_slice(),
     )

--- a/conformance/tests/admonitions.rs
+++ b/conformance/tests/admonitions.rs
@@ -47,6 +47,20 @@ fn semantic_blocks_adapt_to_terminal_help_and_markdown() {
     );
 
     let spec: usage::Spec = kdl.parse().expect("generated spec");
+    let portable_terminal = usage::docs::cli::render_help(&spec, &spec.cmd, true);
+    assert!(
+        portable_terminal.contains("Note: Only changes import resolution."),
+        "{portable_terminal}"
+    );
+    assert!(
+        portable_terminal.contains("Warning: Type-aware linting discovers its own configuration."),
+        "{portable_terminal}"
+    );
+    assert!(
+        portable_terminal.contains("Note: Directories are traversed recursively."),
+        "{portable_terminal}"
+    );
+
     let markdown = MarkdownRenderer::new(spec.clone())
         .render_cmd(&spec.cmd)
         .expect("markdown page");

--- a/conformance/tests/admonitions.rs
+++ b/conformance/tests/admonitions.rs
@@ -1,6 +1,6 @@
 use usage::docs::markdown::MarkdownRenderer;
 use usage_argv::help;
-use usage_derive::Cli;
+use usage_derive::{Args, Cli, Subcommands};
 
 #[derive(Cli)]
 #[usage(bin = "ex")]
@@ -17,6 +17,30 @@ struct Ex {
     /// File to inspect.
     #[usage(note = "Directories are traversed recursively.")]
     file: Option<String>,
+}
+
+#[derive(Args)]
+#[allow(dead_code)]
+struct FlattenedAdmonitions {
+    #[usage(note = "Flattened argument note.")]
+    input: Option<String>,
+
+    #[usage(long, warning = "Flattened flag warning.")]
+    config: bool,
+}
+
+#[derive(Subcommands)]
+#[allow(dead_code)]
+enum FlattenedCommands {
+    Run(FlattenedAdmonitions),
+}
+
+#[derive(Cli)]
+#[usage(bin = "flat", flatten_help)]
+#[allow(dead_code)]
+struct FlattenedCli {
+    #[usage(subcommand)]
+    command: Option<FlattenedCommands>,
 }
 
 #[test]
@@ -71,5 +95,55 @@ fn semantic_blocks_adapt_to_terminal_help_and_markdown() {
     assert!(
         markdown.contains("> **Warning:** Type-aware linting discovers its own configuration."),
         "{markdown}"
+    );
+}
+
+#[test]
+fn semantic_blocks_survive_flattened_and_nested_value_layouts() {
+    let flattened = help::render(FlattenedCli::spec(), FlattenedCli::spec().root.cmd, true)
+        .expect("flattened long help");
+    assert!(
+        flattened.contains("Note: Flattened argument note."),
+        "{flattened}"
+    );
+    assert!(
+        flattened.contains("Warning: Flattened flag warning."),
+        "{flattened}"
+    );
+
+    let mut spec: usage::Spec = Ex::to_kdl().parse().expect("generated spec");
+    let config = spec
+        .cmd
+        .flags
+        .iter_mut()
+        .find(|flag| flag.name == "config")
+        .expect("config flag");
+    config
+        .arg
+        .as_mut()
+        .expect("config value")
+        .admonitions
+        .push(usage::SpecAdmonition::note(
+            "Nested value first.\n\nNested value last.",
+        ));
+
+    let portable_terminal = usage::docs::cli::render_help(&spec, &spec.cmd, true);
+    assert!(
+        portable_terminal.contains("Note: Nested value first.\n\n    Nested value last."),
+        "{portable_terminal:?}"
+    );
+    assert!(
+        portable_terminal
+            .lines()
+            .all(|line| line.trim_end() == line),
+        "{portable_terminal:?}"
+    );
+
+    let markdown = MarkdownRenderer::new(spec.clone())
+        .render_cmd(&spec.cmd)
+        .expect("markdown page");
+    assert!(
+        markdown.contains("> **Note:** Nested value first.\n> \n> Nested value last."),
+        "{markdown:?}"
     );
 }

--- a/conformance/tests/admonitions.rs
+++ b/conformance/tests/admonitions.rs
@@ -1,0 +1,61 @@
+use usage::docs::markdown::MarkdownRenderer;
+use usage_argv::help;
+use usage_derive::Cli;
+
+#[derive(Cli)]
+#[usage(bin = "ex")]
+#[allow(dead_code)]
+struct Ex {
+    /// Override the discovered configuration.
+    #[usage(
+        long,
+        note = "Only changes import resolution.",
+        warning = "Type-aware linting discovers its own configuration."
+    )]
+    config: Option<String>,
+
+    /// File to inspect.
+    #[usage(note = "Directories are traversed recursively.")]
+    file: Option<String>,
+}
+
+#[test]
+fn semantic_blocks_adapt_to_terminal_help_and_markdown() {
+    let terminal = help::render(Ex::spec(), Ex::spec().root.cmd, true).expect("long help");
+    assert!(
+        terminal.contains("Note: Only changes import resolution."),
+        "{terminal}"
+    );
+    assert!(
+        terminal.contains("Warning: Type-aware linting discovers its own configuration."),
+        "{terminal}"
+    );
+    assert!(
+        terminal.contains("Note: Directories are traversed recursively."),
+        "{terminal}"
+    );
+    assert!(!terminal.contains("::: warning"), "{terminal}");
+
+    let kdl = Ex::to_kdl();
+    assert!(
+        kdl.contains("note \"Only changes import resolution.\""),
+        "{kdl}"
+    );
+    assert!(
+        kdl.contains("warning \"Type-aware linting discovers its own configuration.\""),
+        "{kdl}"
+    );
+
+    let spec: usage::Spec = kdl.parse().expect("generated spec");
+    let markdown = MarkdownRenderer::new(spec.clone())
+        .render_cmd(&spec.cmd)
+        .expect("markdown page");
+    assert!(
+        markdown.contains("> **Note:** Only changes import resolution."),
+        "{markdown}"
+    );
+    assert!(
+        markdown.contains("> **Warning:** Type-aware linting discovers its own configuration."),
+        "{markdown}"
+    );
+}

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -17,10 +17,22 @@ use quote::{format_ident, quote};
 
 use crate::crate_name::{crate_name, FoundCrate};
 use crate::model::{
-    rendered_path, to_kebab, type_name, ArgGroup, ArgGroupMember, Cli, ConditionalDefault,
-    Dispatch, DoubleDash, ExampleDecl, Field, Kind, SchemaSource, Shape, Subcommands, ValueEnum,
-    Variant, ViewDecl,
+    rendered_path, to_kebab, type_name, AdmonitionKind, ArgGroup, ArgGroupMember, Cli,
+    ConditionalDefault, Dispatch, DoubleDash, ExampleDecl, Field, Kind, SchemaSource, Shape,
+    Subcommands, ValueEnum, Variant, ViewDecl,
 };
+
+fn admonitions(field: &Field) -> TokenStream {
+    let entries = field.admonitions.iter().map(|admonition| {
+        let text = &admonition.text;
+        let kind = match admonition.kind {
+            AdmonitionKind::Note => quote!(usage_argv::spec::AdmonitionKind::Note),
+            AdmonitionKind::Warning => quote!(usage_argv::spec::AdmonitionKind::Warning),
+        };
+        quote!(usage_argv::spec::AdmonitionMeta { kind: #kind, text: #text })
+    });
+    quote!(&[#(#entries),*])
+}
 
 /// Construct the user's command type after its generated partial has been checked.
 ///
@@ -2524,6 +2536,7 @@ fn flag_meta(cli: &Cli, i: usize, field: &Field, owner: &syn::Ident) -> TokenStr
     let table = format_ident!("FLAG_{i}");
     let help = option_str(field.help.as_deref());
     let long_help = option_str(field.long_help.as_deref());
+    let admonitions = admonitions(field);
     let env = option_str(field.env.as_deref());
     let env_fallback = &field.env_fallback;
     let deprecated_env = &field.deprecated_env;
@@ -2662,6 +2675,7 @@ fn flag_meta(cli: &Cli, i: usize, field: &Field, owner: &syn::Ident) -> TokenStr
             display_order: #display_order,
             help: #help,
             long_help: #long_help,
+            admonitions: #admonitions,
             deprecated: #deprecated,
             deprecated_warn_at: #deprecated_warn_at,
             deprecated_remove_at: #deprecated_remove_at,
@@ -2721,6 +2735,7 @@ fn arg_meta(cli: &Cli, i: usize, field: &Field, owner: &syn::Ident) -> TokenStre
     let table = format_ident!("ARG_{i}");
     let help = option_str(field.help.as_deref());
     let long_help = option_str(field.long_help.as_deref());
+    let admonitions = admonitions(field);
     let env = option_str(field.env.as_deref());
     let env_fallback = &field.env_fallback;
     let deprecated_env = &field.deprecated_env;
@@ -2799,6 +2814,7 @@ fn arg_meta(cli: &Cli, i: usize, field: &Field, owner: &syn::Ident) -> TokenStre
             value_names: &[#(#value_names),*],
             help: #help,
             long_help: #long_help,
+            admonitions: #admonitions,
             env: #env,
             env_fallback: &[#(#env_fallback),*],
             deprecated_env: &[#(#deprecated_env),*],

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -291,6 +291,8 @@
 //! | `default_fn = function` | compute one typed default at parse time without claiming a concrete portable value |
 //! | `default_note = "x"` | describe a `default_fn` in help; the note is prose, not a value |
 //! | `help_heading = "x"` | the section to list this under in help output |
+//! | `note = "x"` | a semantic note shown in long help and generated documentation |
+//! | `warning = "x"` | a semantic warning shown in long help and generated documentation |
 //! | `display_order = n` | explicit help order; positional parsing still follows declaration order |
 //! | `verbatim_doc_comment` | preserve line breaks and whitespace in the doc comment instead of flowing its first paragraph |
 //! | `hide` | keep it out of help and completions |

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -313,6 +313,8 @@ pub struct Field {
     pub value_enum: bool,
     pub help: Option<String>,
     pub long_help: Option<String>,
+    /// Structured notes and warnings, in declaration order.
+    pub admonitions: Vec<AdmonitionDecl>,
     /// Why this flag is deprecated, plus optional release milestones.
     pub deprecated: Option<String>,
     pub deprecated_warn_at: Option<String>,
@@ -472,6 +474,17 @@ pub struct Field {
     pub repeatable: bool,
     pub action: ArgAction,
     pub span: Span,
+}
+
+#[derive(Clone, Copy)]
+pub enum AdmonitionKind {
+    Note,
+    Warning,
+}
+
+pub struct AdmonitionDecl {
+    pub kind: AdmonitionKind,
+    pub text: String,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -2027,6 +2040,7 @@ impl Field {
             optional_value_type: false,
             help: None,
             long_help: None,
+            admonitions: Vec::new(),
             deprecated: None,
             deprecated_warn_at: None,
             deprecated_remove_at: None,
@@ -2178,6 +2192,7 @@ impl Field {
             optional_value_type: false,
             help: None,
             long_help: None,
+            admonitions: Vec::new(),
             deprecated: None,
             deprecated_warn_at: None,
             deprecated_remove_at: None,
@@ -2333,6 +2348,7 @@ impl Field {
             optional_value_type: false,
             help: None,
             long_help: None,
+            admonitions: Vec::new(),
             deprecated: None,
             deprecated_warn_at: None,
             deprecated_remove_at: None,
@@ -2466,6 +2482,7 @@ impl Field {
             optional_value_type: false,
             help: None,
             long_help: None,
+            admonitions: Vec::new(),
             deprecated: None,
             deprecated_warn_at: None,
             deprecated_remove_at: None,
@@ -2597,6 +2614,7 @@ impl Field {
         let mut required_collection = false;
         let mut help_attr: Option<String> = None;
         let mut long_help_attr: Option<String> = None;
+        let mut admonitions = Vec::new();
         let mut deprecated = None;
         let mut deprecated_warn_at = None;
         let mut deprecated_remove_at = None;
@@ -2909,6 +2927,14 @@ impl Field {
                     // help whose breaks are meant literally has to be given directly.
                     "help" => help_attr = Some(string_value(&meta)?),
                     "long_help" => long_help_attr = Some(string_value(&meta)?),
+                    "note" => admonitions.push(AdmonitionDecl {
+                        kind: AdmonitionKind::Note,
+                        text: string_value(&meta)?,
+                    }),
+                    "warning" => admonitions.push(AdmonitionDecl {
+                        kind: AdmonitionKind::Warning,
+                        text: string_value(&meta)?,
+                    }),
                     "deprecated" => deprecated = Some(string_value(&meta)?),
                     "deprecated_warn_at" => deprecated_warn_at = Some(string_value(&meta)?),
                     "deprecated_remove_at" => deprecated_remove_at = Some(string_value(&meta)?),
@@ -2952,7 +2978,7 @@ impl Field {
                                  `default_missing`, `default_if`, \
                                  `required_if`, \
                                  `required_unless`, `required_unless_all`, `help_heading`, `surface`, `available_if`, `select`, `display_order`, `value_name`, `value_names`, `num_args`, \
-                                 `verbatim_doc_comment`, \
+                                 `verbatim_doc_comment`, `note`, `warning`, \
                                  `visible_alias`, `visible_aliases`, `required`, \
                                  `double_dash`, and `skip`"
                             ),
@@ -3895,6 +3921,7 @@ impl Field {
             optional_value_type,
             help,
             long_help,
+            admonitions,
             deprecated,
             deprecated_warn_at,
             deprecated_remove_at,

--- a/docs/rust/args-and-flags.md
+++ b/docs/rust/args-and-flags.md
@@ -170,7 +170,7 @@ does have one stable portable spelling.
 | Attribute                        | Effect                                                                  |
 | -------------------------------- | ----------------------------------------------------------------------- |
 | `help = "…"` / `long_help = "…"` | Help text (doc comments are usually nicer)                              |
-| `note = "…"` / `warning = "…"`   | Semantic blocks in long help and generated Markdown                    |
+| `note = "…"` / `warning = "…"`   | Semantic blocks in long help and generated Markdown                     |
 | `value_name = "…"`               | The placeholder shown in help (`--file <PATH>`)                         |
 | `value_names = ["A", "B"]`       | Distinct placeholders for a fixed multi-value field                     |
 | `help_heading = "…"`             | Group the entry under a heading in help output                          |

--- a/docs/rust/args-and-flags.md
+++ b/docs/rust/args-and-flags.md
@@ -170,6 +170,7 @@ does have one stable portable spelling.
 | Attribute                        | Effect                                                                  |
 | -------------------------------- | ----------------------------------------------------------------------- |
 | `help = "…"` / `long_help = "…"` | Help text (doc comments are usually nicer)                              |
+| `note = "…"` / `warning = "…"`   | Semantic blocks in long help and generated Markdown                    |
 | `value_name = "…"`               | The placeholder shown in help (`--file <PATH>`)                         |
 | `value_names = ["A", "B"]`       | Distinct placeholders for a fixed multi-value field                     |
 | `help_heading = "…"`             | Group the entry under a heading in help output                          |
@@ -188,6 +189,10 @@ does have one stable portable spelling.
 | `setting = "key"`                  | Bind to a config setting ([Configuration](/rust/configuration))                         |
 
 The rest of this section expands the entries that need more than a table row.
+
+`note` and `warning` keep callouts structured instead of embedding terminal- or
+site-specific markup in help text. Long terminal help labels them `Note:` and
+`Warning:`; generated Markdown uses portable blockquotes with the same labels.
 
 ### Skipped fields
 

--- a/docs/spec/reference/arg.md
+++ b/docs/spec/reference/arg.md
@@ -107,12 +107,15 @@ environment variable wins over `default`.
 ```kdl
 arg "<output>" help="Output path" {
   help_md "Write the result to **this path**."
+  note "Relative paths use the working directory."
+  warning "An existing file will be replaced."
   effect "write"
 }
 ```
 
 Without `help_md`, generated Markdown falls back to `long_help` and then
-`help`. An `effect` raises the selected command's declared effect when this
+`help`. `note` and `warning` render as labeled blocks in long terminal help and
+as portable blockquotes in generated Markdown. An `effect` raises the selected command's declared effect when this
 positional is supplied; see [command effects](/spec/#command-effects).
 
 ## Using Variadic Args in Bash

--- a/docs/spec/reference/flag.md
+++ b/docs/spec/reference/flag.md
@@ -117,8 +117,13 @@ flag "--file <file>" {
     more
     text
     """#
+  note "Paths are resolved relative to the working directory."
+  warning "An existing file will be replaced."
 }
 ```
+
+`note` and `warning` are semantic callouts. Long terminal help renders labeled
+indented blocks, while generated Markdown renders portable labeled blockquotes.
 
 ## `deprecated`
 
@@ -358,6 +363,7 @@ and not passed to mounts.
 ```kdl
 flag "--output <path>" help="Output path" {
   help_md "Write the result to **this path**."
+  warning "An existing file will be replaced."
   effect "write"
 }
 ```

--- a/lib/src/docs/cli/templates/spec_template_long.tera
+++ b/lib/src/docs/cli/templates/spec_template_long.tera
@@ -78,6 +78,9 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
     {{ help | indent(width=4) }}
 {%- endif %}
 {%- endif %}
+{%- for admonition in arg.admonitions %}
+    {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | replace(from="\n", to="\n    ") }}
+{%- endfor %}
 {%- if not arg.hide_possible_values and arg.choices and arg.choices.choices %}
     [possible values: {{ arg.choices.choices | join(sep=", ") }}]
 {%- endif %}
@@ -123,6 +126,9 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
     {{ help | indent(width=4) }}
 {%- endif %}
 {%- endif %}
+{%- for admonition in flag.admonitions %}
+    {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | replace(from="\n", to="\n    ") }}
+{%- endfor %}
 {%- if not flag.hide_possible_values and flag.arg.choices and flag.arg.choices.choices %}
     [possible values: {{ flag.arg.choices.choices | join(sep=", ") }}]
 {%- endif %}
@@ -170,6 +176,9 @@ Global flags:
     {{ help | indent(width=4) }}
 {%- endif %}
 {%- endif %}
+{%- for admonition in flag.admonitions %}
+    {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | replace(from="\n", to="\n    ") }}
+{%- endfor %}
 {%- if not flag.hide_possible_values and flag.arg.choices and flag.arg.choices.choices %}
     [possible values: {{ flag.arg.choices.choices | join(sep=", ") }}]
 {%- endif %}
@@ -217,6 +226,9 @@ Global flags:
 {%- else %}
   {{ arg.usage | trim }}
 {%- endif %}
+{%- for admonition in arg.admonitions %}
+    {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | replace(from="\n", to="\n    ") }}
+{%- endfor %}
 {%- if not arg.hide_possible_values and arg.choices and arg.choices.choices %}
     [possible values: {{ arg.choices.choices | join(sep=", ") }}]
 {%- endif %}
@@ -246,6 +258,9 @@ Global flags:
 {%- else %}
   {{ flag.display_usage }}
 {%- endif %}
+{%- for admonition in flag.admonitions %}
+    {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | replace(from="\n", to="\n    ") }}
+{%- endfor %}
 {%- if not flag.hide_possible_values and flag.arg.choices and flag.arg.choices.choices %}
     [possible values: {{ flag.arg.choices.choices | join(sep=", ") }}]
 {%- endif %}

--- a/lib/src/docs/cli/templates/spec_template_long.tera
+++ b/lib/src/docs/cli/templates/spec_template_long.tera
@@ -79,7 +79,7 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
 {%- endif %}
 {%- endif %}
 {%- for admonition in arg.admonitions %}
-    {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | replace(from="\n", to="\n    ") }}
+    {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | indent(width=4) }}
 {%- endfor %}
 {%- if not arg.hide_possible_values and arg.choices and arg.choices.choices %}
     [possible values: {{ arg.choices.choices | join(sep=", ") }}]
@@ -127,8 +127,13 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
 {%- endif %}
 {%- endif %}
 {%- for admonition in flag.admonitions %}
-    {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | replace(from="\n", to="\n    ") }}
+    {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | indent(width=4) }}
 {%- endfor %}
+{%- if flag.arg %}
+{%- for admonition in flag.arg.admonitions %}
+    {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | indent(width=4) }}
+{%- endfor %}
+{%- endif %}
 {%- if not flag.hide_possible_values and flag.arg.choices and flag.arg.choices.choices %}
     [possible values: {{ flag.arg.choices.choices | join(sep=", ") }}]
 {%- endif %}
@@ -177,8 +182,13 @@ Global flags:
 {%- endif %}
 {%- endif %}
 {%- for admonition in flag.admonitions %}
-    {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | replace(from="\n", to="\n    ") }}
+    {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | indent(width=4) }}
 {%- endfor %}
+{%- if flag.arg %}
+{%- for admonition in flag.arg.admonitions %}
+    {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | indent(width=4) }}
+{%- endfor %}
+{%- endif %}
 {%- if not flag.hide_possible_values and flag.arg.choices and flag.arg.choices.choices %}
     [possible values: {{ flag.arg.choices.choices | join(sep=", ") }}]
 {%- endif %}
@@ -227,7 +237,7 @@ Global flags:
   {{ arg.usage | trim }}
 {%- endif %}
 {%- for admonition in arg.admonitions %}
-    {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | replace(from="\n", to="\n    ") }}
+    {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | indent(width=4) }}
 {%- endfor %}
 {%- if not arg.hide_possible_values and arg.choices and arg.choices.choices %}
     [possible values: {{ arg.choices.choices | join(sep=", ") }}]
@@ -259,8 +269,13 @@ Global flags:
   {{ flag.display_usage }}
 {%- endif %}
 {%- for admonition in flag.admonitions %}
-    {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | replace(from="\n", to="\n    ") }}
+    {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | indent(width=4) }}
 {%- endfor %}
+{%- if flag.arg %}
+{%- for admonition in flag.arg.admonitions %}
+    {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | indent(width=4) }}
+{%- endfor %}
+{%- endif %}
 {%- if not flag.hide_possible_values and flag.arg.choices and flag.arg.choices.choices %}
     [possible values: {{ flag.arg.choices.choices | join(sep=", ") }}]
 {%- endif %}

--- a/lib/src/docs/markdown/templates/arg_template.md.tera
+++ b/lib/src/docs/markdown/templates/arg_template.md.tera
@@ -2,6 +2,10 @@
 
 {{ arg.help_md | escape_md }}
 {%- endif %}
+{%- for admonition in arg.admonitions %}
+
+> **{% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}:** {{ admonition.text | escape_md | replace(from="\n", to="\n> ") }}
+{%- endfor %}
 {%- if arg.choices and arg.choices.choices %}
 
 **Choices:**

--- a/lib/src/docs/markdown/templates/flag_template.md.tera
+++ b/lib/src/docs/markdown/templates/flag_template.md.tera
@@ -14,6 +14,10 @@
 
 {{ flag.help_md | escape_md }}
 {%- endif %}
+{%- for admonition in flag.admonitions %}
+
+> **{% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}:** {{ admonition.text | escape_md | replace(from="\n", to="\n> ") }}
+{%- endfor %}
 {%- if flag.arg.choices and flag.arg.choices.choices %}
 
 **Choices:**

--- a/lib/src/docs/markdown/templates/flag_template.md.tera
+++ b/lib/src/docs/markdown/templates/flag_template.md.tera
@@ -18,6 +18,12 @@
 
 > **{% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}:** {{ admonition.text | escape_md | replace(from="\n", to="\n> ") }}
 {%- endfor %}
+{%- if flag.arg %}
+{%- for admonition in flag.arg.admonitions %}
+
+> **{% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}:** {{ admonition.text | escape_md | replace(from="\n", to="\n> ") }}
+{%- endfor %}
+{%- endif %}
 {%- if flag.arg.choices and flag.arg.choices.choices %}
 
 **Choices:**

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -1,6 +1,6 @@
 use crate::docs::markdown::MarkdownRenderer;
 use crate::spec::effect::SpecCommandEffect;
-use crate::SpecChoices;
+use crate::{SpecAdmonition, SpecChoices};
 use indexmap::IndexMap;
 use serde::Serialize;
 
@@ -132,6 +132,7 @@ pub struct SpecFlag {
     pub help: Option<String>,
     pub help_long: Option<String>,
     pub help_md: Option<String>,
+    pub admonitions: Vec<SpecAdmonition>,
     pub help_first_line: Option<String>,
     pub short: Vec<char>,
     pub long: Vec<String>,
@@ -478,6 +479,7 @@ pub struct SpecArg {
     pub help: Option<String>,
     pub help_long: Option<String>,
     pub help_md: Option<String>,
+    pub admonitions: Vec<SpecAdmonition>,
     pub help_first_line: Option<String>,
     pub required: bool,
     pub var: bool,
@@ -974,6 +976,7 @@ impl From<&crate::SpecFlag> for SpecFlag {
             help: said(&flag.help),
             help_long: flag.help_long.clone(),
             help_md: flag.help_md.clone(),
+            admonitions: flag.admonitions.clone(),
             help_first_line: flag.help_first_line.clone(),
             short: flag
                 .short
@@ -1041,6 +1044,7 @@ impl From<&crate::SpecArg> for SpecArg {
             help: said(&arg.help),
             help_long: arg.help_long.clone(),
             help_md: arg.help_md.clone(),
+            admonitions: arg.admonitions.clone(),
             help_first_line: arg.help_first_line.clone(),
             required: arg.required,
             var: arg.var,

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -3,6 +3,7 @@ extern crate insta;
 extern crate log;
 
 pub use crate::parse::{available_flags, parse, Parser};
+pub use crate::spec::admonition::{SpecAdmonition, SpecAdmonitionKind};
 pub use crate::spec::arg::{SpecArg, SpecDoubleDashChoices, SpecRequiredIfEq};
 pub use crate::spec::builder::{SpecArgBuilder, SpecCommandBuilder, SpecFlagBuilder};
 pub use crate::spec::choices::{SpecChoice, SpecChoiceAlias, SpecChoices};

--- a/lib/src/spec/admonition.rs
+++ b/lib/src/spec/admonition.rs
@@ -1,0 +1,32 @@
+use serde::Serialize;
+
+/// The significance of a structured explanatory block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SpecAdmonitionKind {
+    Note,
+    Warning,
+}
+
+/// A note or warning whose presentation is chosen by the renderer.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SpecAdmonition {
+    pub kind: SpecAdmonitionKind,
+    pub text: String,
+}
+
+impl SpecAdmonition {
+    pub fn note(text: impl Into<String>) -> Self {
+        Self {
+            kind: SpecAdmonitionKind::Note,
+            text: text.into(),
+        }
+    }
+
+    pub fn warning(text: impl Into<String>) -> Self {
+        Self {
+            kind: SpecAdmonitionKind::Warning,
+            text: text.into(),
+        }
+    }
+}

--- a/lib/src/spec/arg.rs
+++ b/lib/src/spec/arg.rs
@@ -10,7 +10,7 @@ use crate::spec::context::ParsingContext;
 use crate::spec::effect::{SpecCommandEffect, EFFECT_VALUES};
 use crate::spec::helpers::{string_entry, NodeHelper};
 use crate::spec::is_false;
-use crate::{string, SpecChoices};
+use crate::{string, SpecAdmonition, SpecAdmonitionKind, SpecChoices};
 #[cfg(feature = "clap")]
 use crate::{SpecChoice, SpecChoiceAlias};
 
@@ -71,6 +71,9 @@ pub struct SpecArg {
     /// Markdown-formatted help text
     #[serde(skip_serializing_if = "Option::is_none")]
     pub help_md: Option<String>,
+    /// Structured notes and warnings, in presentation order.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub admonitions: Vec<SpecAdmonition>,
     /// First line of help text (auto-generated)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub help_first_line: Option<String>,
@@ -329,6 +332,12 @@ impl SpecArg {
                 "long_help" => arg.help_long = Some(child.arg(0)?.ensure_string()?),
                 "help_long" => arg.help_long = Some(child.arg(0)?.ensure_string()?),
                 "help_md" => arg.help_md = Some(child.arg(0)?.ensure_string()?),
+                "note" => arg
+                    .admonitions
+                    .push(SpecAdmonition::note(child.arg(0)?.ensure_string()?)),
+                "warning" => arg
+                    .admonitions
+                    .push(SpecAdmonition::warning(child.arg(0)?.ensure_string()?)),
                 "required" => arg.required = child.arg(0)?.ensure_bool()?,
                 "var" => arg.var = child.arg(0)?.ensure_bool()?,
                 "var_min" => arg.var_min = child.arg(0)?.ensure_usize().map(Some)?,
@@ -504,6 +513,16 @@ impl From<&SpecArg> for KdlNode {
         }
         if let Some(desc) = &arg.help_md {
             node.push(string_entry(Some("help_md"), desc));
+        }
+        for admonition in &arg.admonitions {
+            let children = node.children_mut().get_or_insert_with(KdlDocument::new);
+            let name = match admonition.kind {
+                SpecAdmonitionKind::Note => "note",
+                SpecAdmonitionKind::Warning => "warning",
+            };
+            let mut block = KdlNode::new(name);
+            block.push(string_entry(None, &admonition.text));
+            children.nodes_mut().push(block);
         }
         if !arg.required {
             node.push(KdlEntry::new_prop("required", false));
@@ -996,6 +1015,7 @@ impl From<&clap::Arg> for SpecArg {
             help,
             help_long,
             help_md: None,
+            admonitions: Vec::new(),
             help_first_line,
             var,
             var_max: None,

--- a/lib/src/spec/builder.rs
+++ b/lib/src/spec/builder.rs
@@ -33,8 +33,8 @@
 use crate::spec::cmd::SpecExample;
 use crate::spec::effect::SpecCommandEffect;
 use crate::{
-    spec::arg::SpecDoubleDashChoices, SpecArg, SpecChoices, SpecCommand, SpecDefaultIf, SpecFlag,
-    SpecRequiredIfEq, SpecRequiresIf,
+    spec::arg::SpecDoubleDashChoices, SpecAdmonition, SpecArg, SpecChoices, SpecCommand,
+    SpecDefaultIf, SpecFlag, SpecRequiredIfEq, SpecRequiresIf,
 };
 
 /// Builder for SpecFlag
@@ -121,6 +121,18 @@ impl SpecFlagBuilder {
     /// Set markdown help text
     pub fn help_md(mut self, text: impl Into<String>) -> Self {
         self.inner.help_md = Some(text.into());
+        self
+    }
+
+    /// Add a semantic note rendered in help and generated documentation.
+    pub fn note(mut self, text: impl Into<String>) -> Self {
+        self.inner.admonitions.push(SpecAdmonition::note(text));
+        self
+    }
+
+    /// Add a semantic warning rendered in help and generated documentation.
+    pub fn warning(mut self, text: impl Into<String>) -> Self {
+        self.inner.admonitions.push(SpecAdmonition::warning(text));
         self
     }
 
@@ -587,6 +599,18 @@ impl SpecArgBuilder {
     /// Set markdown help text
     pub fn help_md(mut self, text: impl Into<String>) -> Self {
         self.inner.help_md = Some(text.into());
+        self
+    }
+
+    /// Add a semantic note rendered in help and generated documentation.
+    pub fn note(mut self, text: impl Into<String>) -> Self {
+        self.inner.admonitions.push(SpecAdmonition::note(text));
+        self
+    }
+
+    /// Add a semantic warning rendered in help and generated documentation.
+    pub fn warning(mut self, text: impl Into<String>) -> Self {
+        self.inner.admonitions.push(SpecAdmonition::warning(text));
         self
     }
 

--- a/lib/src/spec/flag.rs
+++ b/lib/src/spec/flag.rs
@@ -13,7 +13,7 @@ use crate::spec::context::ParsingContext;
 use crate::spec::effect::{SpecCommandEffect, EFFECT_VALUES};
 use crate::spec::helpers::{string_entry, NodeHelper};
 use crate::spec::is_false;
-use crate::{string, SpecArg, SpecChoices, SpecRequiredIfEq};
+use crate::{string, SpecAdmonition, SpecAdmonitionKind, SpecArg, SpecChoices, SpecRequiredIfEq};
 
 /// A non-binding action performed when a flag is supplied.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -123,6 +123,9 @@ pub struct SpecFlag {
     /// Markdown-formatted help text
     #[serde(skip_serializing_if = "Option::is_none")]
     pub help_md: Option<String>,
+    /// Structured notes and warnings, in presentation order.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub admonitions: Vec<SpecAdmonition>,
     /// First line of help text (auto-generated)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub help_first_line: Option<String>,
@@ -434,6 +437,12 @@ impl SpecFlag {
                 "long_help" => flag.help_long = Some(child.arg(0)?.ensure_string()?),
                 "help_long" => flag.help_long = Some(child.arg(0)?.ensure_string()?),
                 "help_md" => flag.help_md = Some(child.arg(0)?.ensure_string()?),
+                "note" => flag
+                    .admonitions
+                    .push(SpecAdmonition::note(child.arg(0)?.ensure_string()?)),
+                "warning" => flag
+                    .admonitions
+                    .push(SpecAdmonition::warning(child.arg(0)?.ensure_string()?)),
                 "required" => flag.required = child.arg(0)?.ensure_bool()?,
                 "required_if" => {
                     flag.required_if = child
@@ -966,6 +975,16 @@ impl From<&SpecFlag> for KdlNode {
             node.push(string_entry(None, desc));
             children.nodes_mut().push(node);
         }
+        for admonition in &flag.admonitions {
+            let children = node.children_mut().get_or_insert_with(KdlDocument::new);
+            let name = match admonition.kind {
+                SpecAdmonitionKind::Note => "note",
+                SpecAdmonitionKind::Warning => "warning",
+            };
+            let mut block = KdlNode::new(name);
+            block.push(string_entry(None, &admonition.text));
+            children.nodes_mut().push(block);
+        }
         if flag.required {
             node.push(KdlEntry::new_prop("required", true));
         }
@@ -1466,6 +1485,7 @@ impl From<&clap::Arg> for SpecFlag {
             help,
             help_long,
             help_md: None,
+            admonitions: Vec::new(),
             help_first_line,
             var,
             var_min: None,

--- a/lib/src/spec/mod.rs
+++ b/lib/src/spec/mod.rs
@@ -1,3 +1,4 @@
+pub mod admonition;
 pub mod arg;
 pub mod builder;
 pub mod choices;


### PR DESCRIPTION
## Summary

- add structured `note` and `warning` metadata for flags and positional arguments
- render labeled semantic blocks in long terminal help and portable Markdown blockquotes
- preserve the blocks through generated KDL, parsed specs, documentation models, and programmatic builders

## Tests

- `cargo test --all --all-features`
- `cargo clippy --all --all-features --all-targets -- -D warnings`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches public spec, derive attributes, and help/docs rendering, so help output and generated KDL can change for adopters who use the new fields. No parse or security path is involved.
> 
> **Overview**
> Adds structured **note** and **warning** blocks on flags and positional arguments so callouts stay semantic instead of being baked into help markup.
> 
> Authors can declare them as `#[usage(note = "…", warning = "…")]`, KDL `note`/`warning` children, or builder methods. They round-trip through generated specs and documentation models.
> 
> Long terminal help prints indented `Note:` / `Warning:` lines (including flattened layouts and nested flag values). Generated Markdown uses portable labeled blockquotes. Docs and a conformance test cover both renderers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ca505934563c9a333e96324de816d1c15d1a5e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for attaching ordered notes and warnings to command-line arguments and flags.
  * Added builder APIs for creating notes and warnings.
  * Preserved admonitions in generated specifications and metadata.
  * Displayed labeled notes and warnings in long terminal help and generated Markdown, including multiline content.

* **Documentation**
  * Documented the new `note` and `warning` attributes, syntax, and rendering behavior.

* **Tests**
  * Added coverage for terminal help, generated specifications, portable output, and Markdown rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->