### PR TITLE
feat(spec): add output media types

### DIFF
--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -1341,6 +1341,8 @@ impl Framing {
 pub struct OutputMeta<'a> {
     /// The token a user types for it.
     pub name: &'a str,
+    /// The media type of the bytes, independent of their stream framing.
+    pub media_type: Option<&'a str>,
     pub framing: Framing,
     pub help: Option<&'a str>,
     /// What the command writes when nothing selects otherwise.
@@ -1366,6 +1368,7 @@ impl OutputMeta<'_> {
     /// A named output with nothing else said about it, for struct-update syntax.
     pub const EMPTY: OutputMeta<'static> = OutputMeta {
         name: "",
+        media_type: None,
         framing: Framing::Text,
         help: None,
         default: false,
@@ -2167,6 +2170,9 @@ fn write_outputs(out: &mut String, meta: &CommandMeta<'_>, depth: usize) -> core
     for output in meta.outputs {
         indent(out, depth)?;
         write!(out, "output {}", quoted(output.name))?;
+        if let Some(media_type) = output.media_type {
+            write!(out, " media_type={}", quoted(media_type))?;
+        }
         if output.framing != Framing::Text {
             write!(out, " framing={}", quoted(output.framing.as_str()))?;
         }

--- a/conformance/src/tables.rs
+++ b/conformance/src/tables.rs
@@ -763,6 +763,7 @@ fn outputs(list: &[SpecOutput]) -> &'static [OutputMeta<'static>] {
         list.iter()
             .map(|o| OutputMeta {
                 name: leak(&o.name),
+                media_type: opt(&o.media_type),
                 framing: match o.framing {
                     Framing::Text => ArgvFraming::Text,
                     Framing::Json => ArgvFraming::Json,

--- a/conformance/tests/output.rs
+++ b/conformance/tests/output.rs
@@ -123,6 +123,23 @@ fn a_name_and_a_framing_are_different_things() {
 }
 
 #[test]
+fn a_media_type_without_a_selector_starts_a_markdown_list() {
+    let spec: LibSpec = r#"
+name "ex"
+output "xml" media_type="application/xml"
+"#
+    .parse()
+    .expect("standalone output spec");
+    let markdown = usage::docs::markdown::MarkdownRenderer::new(spec.clone())
+        .render_cmd(&spec.cmd)
+        .expect("markdown page");
+    assert!(
+        markdown.contains("`xml`\n\n- **Media type**: `application/xml`"),
+        "{markdown}"
+    );
+}
+
+#[test]
 fn a_schema_reaches_the_spec() {
     let spec = parsed();
     let check = spec.cmd.subcommands.get("check").unwrap();

--- a/conformance/tests/output.rs
+++ b/conformance/tests/output.rs
@@ -117,6 +117,14 @@ fn a_name_and_a_framing_are_different_things() {
     assert!(check.outputs[2].framing.is_streaming());
     assert!(check.outputs[4].hide);
     assert_eq!(
+        check.outputs[1].media_type.as_deref(),
+        Some("application/json")
+    );
+    assert_eq!(
+        check.outputs[2].media_type.as_deref(),
+        Some("application/x-ndjson")
+    );
+    assert_eq!(
         check.outputs[3].media_type.as_deref(),
         Some("application/xml")
     );

--- a/conformance/tests/output.rs
+++ b/conformance/tests/output.rs
@@ -20,11 +20,18 @@ use usage_derive::{Args, Cli, Subcommands};
     output("human", default, help = "A human-readable report"),
     output(
         "json",
+        media_type = "application/json",
         framing = "json",
         help = "One report object",
         schema = "{\n  \"type\": \"object\"\n}"
     ),
-    output("jsonl", framing = "jsonl", help = "One event per line"),
+    output(
+        "jsonl",
+        media_type = "application/x-ndjson",
+        framing = "jsonl",
+        help = "One event per line"
+    ),
+    output("checkstyle", media_type = "application/xml"),
     output("legacy", hide),
     exit_code(0, "all checks passed"),
     exit_code(1, "a check failed")
@@ -102,12 +109,17 @@ fn a_name_and_a_framing_are_different_things() {
             ("human", "text"),
             ("json", "json"),
             ("jsonl", "jsonl"),
+            ("checkstyle", "text"),
             ("legacy", "text"),
         ]
     );
     assert!(check.outputs[0].default);
     assert!(check.outputs[2].framing.is_streaming());
-    assert!(check.outputs[3].hide);
+    assert!(check.outputs[4].hide);
+    assert_eq!(
+        check.outputs[3].media_type.as_deref(),
+        Some("application/xml")
+    );
 }
 
 #[test]
@@ -139,7 +151,12 @@ fn a_field_level_select_names_its_own_flag() {
             .as_ref()
             .and_then(|a| a.choices.as_ref())
             .map(|c| c.values()),
-        Some(vec!["human".into(), "json".into(), "jsonl".into()])
+        Some(vec![
+            "human".into(),
+            "json".into(),
+            "jsonl".into(),
+            "checkstyle".into(),
+        ])
     );
 }
 

--- a/conformance/tests/snapshots/spec_roundtrip__the_emitted_spec_is_stable.snap
+++ b/conformance/tests/snapshots/spec_roundtrip__the_emitted_spec_is_stable.snap
@@ -83,7 +83,7 @@ Takes a while.
     }
     arg <tool> help="the tool to install"
     output human help="a progress log" default=#true
-    output json framing=json {
+    output json media_type="application/json" framing=json {
         schema #"""
 {
   "type": "object"

--- a/conformance/tests/spec_roundtrip.rs
+++ b/conformance/tests/spec_roundtrip.rs
@@ -199,6 +199,7 @@ static INSTALL_META: CommandMeta = CommandMeta {
         },
         OutputMeta {
             name: "json",
+            media_type: Some("application/json"),
             framing: Framing::Json,
             schema: Some("{\n  \"type\": \"object\"\n}"),
             ..OutputMeta::EMPTY

--- a/conformance/tests/spec_roundtrip.rs
+++ b/conformance/tests/spec_roundtrip.rs
@@ -723,6 +723,10 @@ fn outputs_and_exit_codes_survive() {
     );
     assert!(install.outputs[0].default);
     assert_eq!(
+        install.outputs[1].media_type.as_deref(),
+        Some("application/json")
+    );
+    assert_eq!(
         install.outputs[1].schema.as_deref(),
         Some("{\n  \"type\": \"object\"\n}"),
         "a schema with newlines should come back as it went out"

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -3934,6 +3934,7 @@ fn output_tokens(cli: &Cli) -> OutputTokens {
         .enumerate()
         .map(|(i, output)| {
             let name = &output.name;
+            let media_type = option_str(output.media_type.as_deref());
             let framing = match output.framing.as_str() {
                 "json" => quote!(usage_argv::spec::Framing::Json),
                 "jsonl" => quote!(usage_argv::spec::Framing::Jsonl),
@@ -3977,6 +3978,7 @@ fn output_tokens(cli: &Cli) -> OutputTokens {
             quote! {
                 usage_argv::spec::OutputMeta {
                     name: #name,
+                    media_type: #media_type,
                     framing: #framing,
                     help: #help,
                     default: #default,

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -253,9 +253,11 @@ pub struct ViewDecl {
     pub globals: Vec<String>,
 }
 
-/// One `output("json", framing = "json", schema_from = Report)` declaration.
+/// One `output("json", media_type = "application/json", framing = "json")` declaration.
 pub struct OutputDecl {
     pub name: String,
+    /// An IANA media type such as `application/json` or `application/xml`.
+    pub media_type: Option<String>,
     /// Written as the spec spells it — `text`, `json`, `jsonl` — and checked here so a
     /// typo is a compile error rather than something usage-lib rejects later.
     pub framing: String,
@@ -4481,10 +4483,11 @@ fn view_decl(meta: &Meta) -> syn::Result<ViewDecl> {
     })
 }
 
-/// `output("json", framing = "json", help = "…", default, schema_from = Report)`
+/// `output("json", media_type = "application/json", framing = "json", help = "…")`
 ///
-/// The leading string is the token a user types; `framing` is the wire format a consumer
-/// reads. They are separate on purpose — see `lib/src/spec/output.rs`.
+/// The leading string is the token a user types; `media_type` identifies the content and
+/// `framing` describes the stream. They are separate on purpose — see
+/// `lib/src/spec/output.rs`.
 fn output_decl(meta: &Meta) -> syn::Result<OutputDecl> {
     let Meta::List(list) = meta else {
         return Err(syn::Error::new_spanned(
@@ -4496,6 +4499,7 @@ fn output_decl(meta: &Meta) -> syn::Result<OutputDecl> {
         let name: syn::LitStr = input.parse()?;
         let mut output = OutputDecl {
             name: name.value(),
+            media_type: None,
             framing: "text".to_string(),
             help: None,
             default: false,
@@ -4550,6 +4554,7 @@ fn output_decl(meta: &Meta) -> syn::Result<OutputDecl> {
                             }
                             output.framing = framing;
                         }
+                        "media_type" => output.media_type = Some(value.value()),
                         "help" => output.help = Some(value.value()),
                         "select" => output.select = Some(value.value()),
                         "schema" => output.schema = Some(SchemaSource::Literal(value.value())),
@@ -4558,7 +4563,7 @@ fn output_decl(meta: &Meta) -> syn::Result<OutputDecl> {
                                 property,
                                 format!(
                                     "unknown output property `{other}`; an output takes \
-                                     `framing`, `help`, `select`, `schema`, `schema_from`, \
+                                     `media_type`, `framing`, `help`, `select`, `schema`, `schema_from`, \
                                      `schema_fn`, and bare `default` and `hide`"
                                 ),
                             ));
@@ -6950,7 +6955,7 @@ mod tests {
         let parsed = cli(r#"
             #[usage(
                 output("human", default, help = "A table"),
-                output("ndjson", framing = "jsonl"),
+                output("ndjson", media_type = "application/x-ndjson", framing = "jsonl"),
                 select = "--format"
             )]
             struct Ex {
@@ -6965,6 +6970,10 @@ mod tests {
         assert_eq!(parsed.outputs[0].help.as_deref(), Some("A table"));
         // aube's spelling, hk's contract.
         assert_eq!(parsed.outputs[1].name, "ndjson");
+        assert_eq!(
+            parsed.outputs[1].media_type.as_deref(),
+            Some("application/x-ndjson")
+        );
         assert_eq!(parsed.outputs[1].framing, "jsonl");
         assert_eq!(parsed.select.as_deref(), Some("--format"));
     }

--- a/docs/rust/args-and-flags.md
+++ b/docs/rust/args-and-flags.md
@@ -365,7 +365,8 @@ SDKs:
 #[derive(usage::Args)]
 #[usage(
     output("human", default, help = "A human-readable report"),
-    output("json", framing = "json", schema_from = Report),
+    output("json", media_type = "application/json", framing = "json", schema_from = Report),
+    output("checkstyle", media_type = "application/xml"),
     exit_code(0, "all checks passed"),
     exit_code(1, "a check failed"),
 )]
@@ -379,8 +380,9 @@ struct Check {
 `select` on a value-taking flag names it as the selector, and its choices are filled from the
 output names. A boolean flag that picks one output is named from the output instead —
 `output("json", framing = "json", select = "--json")` — and `select = "--format"` as a
-container attribute is the same thing spelled the way the KDL node is. An output also takes
-`hide`, and a schema comes from `schema = "…"`, `schema_from = Type` (via `schemars`), or
+container attribute is the same thing spelled the way the KDL node is. `media_type` identifies
+the content independently of `text`/`json`/`jsonl` stream framing. An output also takes `hide`,
+and a schema comes from `schema = "…"`, `schema_from = Type` (via `schemars`), or
 `schema_fn = path` where the function returns a `String`. Declared on the root `#[derive(Cli)]`
 struct, outputs and exit codes apply CLI-wide, and a command can refine what it inherits. The
 full model — framings, schema files, inheritance — is on the

--- a/docs/spec/reference/output.md
+++ b/docs/spec/reference/output.md
@@ -8,7 +8,7 @@ cmd "check" {
   flag "--format <FORMAT>" help="Output format"
 
   output "human" default=#true help="Human-readable report"
-  output "json" framing="json" help="One report object" {
+  output "json" media_type="application/json" framing="json" help="One report object" {
     schema #"""
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -19,6 +19,7 @@ cmd "check" {
     """#
   }
   output "jsonl" framing="jsonl" help="One event per line"
+  output "checkstyle" media_type="application/xml" help="Checkstyle report"
   select "--format"
 
   exit_code 0 "all checks passed"
@@ -26,8 +27,9 @@ cmd "check" {
 }
 ```
 
-`output`'s first argument is the value a user types. `framing` is the wire contract a
-consumer reads:
+`output`'s first argument is the value a user types. `media_type` identifies the content
+using an IANA media type such as `application/json` or `application/xml`. `framing` is the
+stream contract a consumer reads:
 
 | Framing | Meaning                                            |
 | ------- | -------------------------------------------------- |
@@ -35,13 +37,16 @@ consumer reads:
 | `json`  | One JSON document, read to end of stream           |
 | `jsonl` | One JSON document per line, consumed incrementally |
 
-The name and framing are deliberately separate. An output named `ndjson` can declare
+The name, media type, and framing are deliberately separate. XML can use the default `text`
+framing because it is one document read to end of stream, while JSON Lines uses `jsonl`
+framing because it contains independently consumable records. An output named `ndjson` can declare
 `framing="jsonl"`, allowing consumers to treat equivalent formats alike without knowing each
 CLI's spelling.
 
-An output also accepts `help`, `default=#true`, and `hide=#true`. At most one effective output
-may be the default. `schema` is carried verbatim, so it can use any JSON Schema draft and can
-contain references that another tool resolves.
+An output also accepts `help`, `default=#true`, and `hide=#true`. The media type is optional and
+is not inferred from either the output name or framing. At most one effective output may be the
+default. `schema` is carried verbatim, so it can use any JSON Schema draft and can contain
+references that another tool resolves.
 
 For a schema kept next to the spec, name its file instead of embedding it:
 
@@ -109,7 +114,8 @@ Typed Rust declarations use the same vocabulary:
 #[derive(usage::Args)]
 #[usage(
     output("human", default, help = "Human-readable report"),
-    output("json", framing = "json", schema_from = Report),
+    output("json", media_type = "application/json", framing = "json", schema_from = Report),
+    output("checkstyle", media_type = "application/xml"),
     exit_code(0, "all checks passed"),
     exit_code(1, "a check failed"),
 )]

--- a/lib/src/docs/manpage/renderer.rs
+++ b/lib/src/docs/manpage/renderer.rs
@@ -572,6 +572,9 @@ impl ManpageRenderer {
                         }
                         roff.text([bold(label)]);
                         let mut described = format!("{} output", output.framing);
+                        if let Some(media_type) = &output.media_type {
+                            described.push_str(&format!(" with media type {media_type}"));
+                        }
                         if output.streaming {
                             described.push_str(", one document per line as it arrives");
                         }

--- a/lib/src/docs/markdown/templates/cmd_template.md.tera
+++ b/lib/src/docs/markdown/templates/cmd_template.md.tera
@@ -97,6 +97,9 @@
 
 - **Select**: `{{ output.select }}`
 {%- endif %}
+{%- if output.media_type %}
+- **Media type**: `{{ output.media_type }}`
+{%- endif %}
 - **Framing**: `{{ output.framing }}`{% if output.streaming %} — one document per line, read as it arrives{% endif %}
 {%- if output.help %}
 

--- a/lib/src/docs/markdown/templates/cmd_template.md.tera
+++ b/lib/src/docs/markdown/templates/cmd_template.md.tera
@@ -96,8 +96,11 @@
 {%- if output.select %}
 
 - **Select**: `{{ output.select }}`
-{%- endif %}
 {%- if output.media_type %}
+- **Media type**: `{{ output.media_type }}`
+{%- endif %}
+{%- elif output.media_type %}
+
 - **Media type**: `{{ output.media_type }}`
 {%- endif %}
 - **Framing**: `{{ output.framing }}`{% if output.streaming %} — one document per line, read as it arrives{% endif %}

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -424,6 +424,7 @@ fn group_by_heading<T: Clone>(
 #[derive(Debug, Default, Serialize, Clone)]
 pub struct SpecOutput {
     pub name: String,
+    pub media_type: Option<String>,
     pub framing: String,
     pub streaming: bool,
     pub default: bool,
@@ -436,6 +437,7 @@ impl SpecOutput {
     fn from(output: &crate::SpecOutput, cmd: &crate::SpecCommand) -> Self {
         Self {
             name: output.name.clone(),
+            media_type: output.media_type.clone(),
             framing: output.framing.as_str().to_string(),
             streaming: output.framing.is_streaming(),
             default: output.default,

--- a/lib/src/spec/output.rs
+++ b/lib/src/spec/output.rs
@@ -10,16 +10,18 @@
 //! ```kdl
 //! cmd "check" {
 //!     output "human" default=#true help="Human-readable report"
-//!     output "json"  framing="json"  help="One report object"  { schema #"""{…}"""# }
+//!     output "json" media_type="application/json" framing="json" help="One report object" { schema #"""{…}"""# }
+//!     output "xml" media_type="application/xml" help="One XML document"
 //!     output "jsonl" framing="jsonl" help="One event per line" { schema #"""{…}"""# }
 //!     select "--format"
 //! }
 //! ```
 //!
-//! # Name and framing are not the same thing
+//! # Name, media type, and framing are not the same thing
 //!
-//! The positional is the token a *user* types. [`SpecOutput::framing`] is the contract a
-//! *consumer* reads. They are separate because aube spells its line-delimited output
+//! The positional is the token a *user* types, `media_type` identifies the content, and
+//! [`SpecOutput::framing`] says how a *consumer* reads the stream. They are separate because
+//! XML and prose are both read to the end despite having different media types, while aube spells its line-delimited output
 //! `ndjson` and hk spells the identical wire format `jsonl`: a generated SDK that keyed
 //! off the name would offer `exec_ndjson()` for one and `exec_jsonl()` for the other, and
 //! a caller would be back to knowing which CLI they were talking to — the thing this
@@ -143,6 +145,9 @@ impl Selector {
 pub struct SpecOutput {
     /// The token a user types for it, e.g. `human`, `json`, `ndjson`.
     pub name: String,
+    /// The media type of the bytes, independent of their stream framing.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub media_type: Option<String>,
     /// The wire format, which is what a consumer keys off.
     #[serde(skip_serializing_if = "is_text")]
     pub framing: Framing,
@@ -186,6 +191,11 @@ impl SpecOutput {
         self
     }
 
+    pub fn media_type(mut self, media_type: impl Into<String>) -> Self {
+        self.media_type = Some(media_type.into());
+        self
+    }
+
     pub fn help(mut self, help: impl Into<String>) -> Self {
         self.help = Some(help.into());
         self
@@ -224,6 +234,7 @@ impl SpecOutput {
         let mut output = SpecOutput::new(node.arg(0)?.ensure_string()?);
         for (k, v) in node.props() {
             match k {
+                "media_type" => output.media_type = Some(v.ensure_string()?),
                 "framing" => output.framing = parse_framing(ctx, v.ensure_string()?, v.entry)?,
                 "help" => output.help = Some(v.ensure_string()?),
                 "schema" => output.schema = Some(v.ensure_string()?),
@@ -305,6 +316,9 @@ impl From<&SpecOutput> for KdlNode {
     fn from(output: &SpecOutput) -> KdlNode {
         let mut node = KdlNode::new("output");
         node.push(string_entry(None, &output.name));
+        if let Some(media_type) = &output.media_type {
+            node.push(string_entry(Some("media_type"), media_type));
+        }
         if output.framing != Framing::Text {
             node.push(string_entry(Some("framing"), output.framing.as_str()));
         }
@@ -669,6 +683,7 @@ name "ex"
 cmd "ls" {
     output "human" default=#true
     output "ndjson" framing="jsonl"
+    output "checkstyle" media_type="application/xml"
 }
 "#,
         );
@@ -679,6 +694,8 @@ cmd "ls" {
         // reads. aube calls this `ndjson` and hk calls it `jsonl`.
         assert_eq!(ls.outputs[1].name, "ndjson");
         assert!(ls.outputs[1].framing.is_streaming());
+        assert_eq!(ls.outputs[2].framing, Framing::Text);
+        assert_eq!(ls.outputs[2].media_type.as_deref(), Some("application/xml"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add optional `media_type` metadata to command outputs, independent of output names and stream framing
- preserve media types through derives, generated and parsed KDL, serialized specs, and conformance tables
- expose media types in generated Markdown and manpages, with XML and JSON examples

## Tests

- `cargo test --all --all-features`
- `cargo clippy --all --all-features --all-targets -- -D warnings`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional metadata on the output spec with parse/serialize and docs updates; no auth, runtime I/O, or breaking required fields.
> 
> **Overview**
> Adds an optional `media_type` on command outputs so content type (e.g. `application/json`, `application/xml`) is declared independently of the user-facing name and stream `framing`.
> 
> The field is plumbed through KDL parse/serialize, `OutputMeta` / derive `output(...)`, and generated Markdown and manpages. Docs and tests cover XML-with-text-framing vs JSON Lines, and that media type is not inferred from name or framing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c2895d0fbbc7c4c202ff98652f3472872bc2785. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Output definitions can declare optional media types, including JSON, NDJSON, and XML.
  * Media types are preserved in specifications and displayed in generated command documentation.
  * Added the `checkstyle` XML output format.
* **Documentation**
  * Clarified output names, media types, and stream framing.
  * Added JSON and XML media type examples.
* **Tests**
  * Expanded coverage for parsing, rendering, round trips, framing, and output selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->