### PR TITLE
feat: add dynamic command catalogs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -198,7 +198,7 @@ jobs:
           - version: "1.91"
             crates: usage-argv usage-derive usage-config usage-validation usage-rs usage-test
           - version: "1.95"
-            crates: usage-lib clap_usage usage-cli
+            crates: usage-lib usage-dynamic clap_usage usage-cli
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2274,6 +2274,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "usage-dynamic"
+version = "6.1.1"
+dependencies = [
+ "futures",
+ "usage-argv",
+ "usage-lib",
+ "usage-rs",
+]
+
+[[package]]
 name = "usage-lib"
 version = "6.1.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "derive",
     "test",
     "usage-rs",
+    "usage-dynamic",
     "validation",
     "clap_usage",
     "cli",
@@ -52,6 +53,7 @@ usage-derive = { path = "./derive", version = "6.1.1" }
 # what they need, `docs` included.
 usage-lib = { path = "./lib", version = "6.1.1", default-features = false }
 usage-rs = { path = "./usage-rs", version = "6.1.1" }
+usage-dynamic = { path = "./usage-dynamic", version = "6.1.1" }
 usage-test = { path = "./test", version = "6.1.1" }
 usage-validation = { path = "./validation", version = "6.1.1" }
 

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -699,12 +699,74 @@ impl<'a> App<'a> {
             }
         }
         let spec = self.view.spec();
-        let answer = if let Some(name) = request.candidates_for {
-            complete_named_with(&spec, &split, self.overlays, &name).await
+        let mut answer = if let Some(ref name) = request.candidates_for {
+            complete_named_with(&spec, &split, self.overlays, name).await
         } else {
             complete_with(&spec, &split, self.overlays).await
         };
+        if request.candidates_for.is_none() {
+            merge_runtime_commands(&self.view, &spec, &split, &mut answer);
+        }
         Some(render(&answer, request.shell))
+    }
+}
+
+fn merge_runtime_commands<'a>(
+    view: &'a SpecView<'a>,
+    spec: &'a Spec<'a>,
+    split: &Split,
+    answer: &mut Completions<'a>,
+) {
+    let position = walk(spec.root.cmd, split.argv());
+    if position.awaiting_value.is_some()
+        || position.help_topic
+        || (position.flags_possible && split.prefix.starts_with('-'))
+    {
+        return;
+    }
+    let Some(chain) = metadata_chain_on_route(spec, &position) else {
+        return;
+    };
+    let path: Vec<&str> = chain.iter().skip(1).map(|meta| meta.cmd.name).collect();
+    let runtime = view.runtime_at(&path);
+    if runtime.is_empty() {
+        return;
+    }
+
+    // Once any external command has already been selected, its application owns deeper
+    // completion. Ask the parser rather than scanning words: a plugin name can also be a
+    // flag value, and only the parser knows which role that token actually had.
+    let argv: Vec<&std::ffi::OsStr> = split.argv().iter().map(std::ffi::OsStr::new).collect();
+    let mut parser = Parser::new(spec.root.cmd, &argv);
+    let mut selected = false;
+    while let Some(event) = parser.next_event() {
+        if matches!(event, Ok(crate::Event::External { .. })) {
+            selected = true;
+            break;
+        }
+    }
+    if selected {
+        answer.candidates.clear();
+        answer.files = None;
+        return;
+    }
+
+    for command in runtime.into_iter().filter(|command| !command.hide) {
+        for name in core::iter::once(&command.name).chain(command.aliases.iter()) {
+            if command.hidden_aliases.contains(name) || !name.starts_with(&split.prefix) {
+                continue;
+            }
+            answer.candidates.push(Candidate {
+                value: name.clone(),
+                kind: CandidateKind::Command,
+                display: None,
+                description: command.about.as_deref().map(std::borrow::Cow::Borrowed),
+            });
+        }
+    }
+    sort_and_dedup_candidates(&mut answer.candidates);
+    if !answer.candidates.is_empty() {
+        answer.files = None;
     }
 }
 

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -699,74 +699,12 @@ impl<'a> App<'a> {
             }
         }
         let spec = self.view.spec();
-        let mut answer = if let Some(ref name) = request.candidates_for {
-            complete_named_with(&spec, &split, self.overlays, name).await
+        let answer = if let Some(name) = request.candidates_for {
+            complete_named_with(&spec, &split, self.overlays, &name).await
         } else {
             complete_with(&spec, &split, self.overlays).await
         };
-        if request.candidates_for.is_none() {
-            merge_runtime_commands(&self.view, &spec, &split, &mut answer);
-        }
         Some(render(&answer, request.shell))
-    }
-}
-
-fn merge_runtime_commands<'a>(
-    view: &'a SpecView<'a>,
-    spec: &'a Spec<'a>,
-    split: &Split,
-    answer: &mut Completions<'a>,
-) {
-    let position = walk(spec.root.cmd, split.argv());
-    if position.awaiting_value.is_some()
-        || position.help_topic
-        || (position.flags_possible && split.prefix.starts_with('-'))
-    {
-        return;
-    }
-    let Some(chain) = metadata_chain_on_route(spec, &position) else {
-        return;
-    };
-    let path: Vec<&str> = chain.iter().skip(1).map(|meta| meta.cmd.name).collect();
-    let runtime = view.runtime_at(&path);
-    if runtime.is_empty() {
-        return;
-    }
-
-    // Once any external command has already been selected, its application owns deeper
-    // completion. Ask the parser rather than scanning words: a plugin name can also be a
-    // flag value, and only the parser knows which role that token actually had.
-    let argv: Vec<&std::ffi::OsStr> = split.argv().iter().map(std::ffi::OsStr::new).collect();
-    let mut parser = Parser::new(spec.root.cmd, &argv);
-    let mut selected = false;
-    while let Some(event) = parser.next_event() {
-        if matches!(event, Ok(crate::Event::External { .. })) {
-            selected = true;
-            break;
-        }
-    }
-    if selected {
-        answer.candidates.clear();
-        answer.files = None;
-        return;
-    }
-
-    for command in runtime.into_iter().filter(|command| !command.hide) {
-        for name in core::iter::once(&command.name).chain(command.aliases.iter()) {
-            if command.hidden_aliases.contains(name) || !name.starts_with(&split.prefix) {
-                continue;
-            }
-            answer.candidates.push(Candidate {
-                value: name.clone(),
-                kind: CandidateKind::Command,
-                display: None,
-                description: command.about.as_deref().map(std::borrow::Cow::Borrowed),
-            });
-        }
-    }
-    sort_and_dedup_candidates(&mut answer.candidates);
-    if !answer.candidates.is_empty() {
-        answer.files = None;
     }
 }
 

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -70,6 +70,16 @@ pub struct Position<'t> {
     /// Taken from the parser rather than gathered again, so what is offered is what would be
     /// accepted — shadowing included.
     pub flags: Vec<&'t Flag<'t>>,
+    /// Where the words left these tables for a program they do not describe, as an index into
+    /// the words `walk` was given: the external command's own word.
+    ///
+    /// `Some` only past an [`external_subcommand`](Command::external_subcommand) catch-all,
+    /// which forwards that word and everything after it. [`cmd`](Self::cmd) is still the
+    /// command that declared the catch-all — it is what the words selected — but the rest of
+    /// this position describes *that* command, and nothing it says is true of the forwarded
+    /// program. Whoever knows what the external name means answers from there; whoever does
+    /// not offers nothing.
+    pub external: Option<usize>,
 }
 
 /// Walk the words before the cursor, and report what the cursor is at.
@@ -102,6 +112,7 @@ pub fn walk_view<'t>(
     let mut position = walk_inner(root, &projected, Some(view));
     let original_index = |index: usize| index.saturating_sub(count);
     position.command_start = original_index(position.command_start);
+    position.external = position.external.map(original_index);
     for (_, start) in &mut position.path {
         *start = original_index(*start);
     }
@@ -121,6 +132,7 @@ fn walk_inner<'t>(
     let mut awaiting_value = None;
     let mut last_arg = None;
     let mut last_arg_values = 0u32;
+    let mut external = None;
 
     while let Some(event) = parser.next_event() {
         match event {
@@ -131,6 +143,12 @@ fn walk_inner<'t>(
                     last_arg = Some(arg);
                     last_arg_values = 1;
                 }
+            }
+            // The words named a command these tables do not describe. Everything from that
+            // word on was forwarded in one go, so where it began is what is left of the line
+            // to say — the parser is finished either way.
+            Ok(crate::Event::External { values }) => {
+                external = Some(argv.len() - values.len());
             }
             Ok(_) => {}
             // The one error that says something about the cursor rather than about the line:
@@ -157,6 +175,7 @@ fn walk_inner<'t>(
                     command_start: 0,
                     help_topic: true,
                     flags: Vec::new(),
+                    external: None,
                 }
             }
             Err(_) => break,
@@ -179,6 +198,7 @@ fn walk_inner<'t>(
         command_start: parser.command_start(),
         help_topic: false,
         flags: parser.flags_in_scope().collect(),
+        external,
     }
 }
 
@@ -193,7 +213,7 @@ fn walk_inner<'t>(
 /// reference resolves a `complete` block by, so the two agree about which completer a `run=`
 /// belongs to. `None` when nothing of that name declares one.
 pub fn for_name<'a>(
-    spec: &'a Spec<'a>,
+    spec: &Spec<'a>,
     name: &str,
     ctx: &CompleteCtx<'_>,
 ) -> Option<Vec<Candidate<'static>>> {
@@ -203,7 +223,7 @@ pub fn for_name<'a>(
 
 /// Answer for a named completer through an executable view.
 pub fn for_name_view<'a>(
-    spec: &'a Spec<'a>,
+    spec: &Spec<'a>,
     name: &str,
     ctx: &CompleteCtx<'_>,
     view: &'a crate::spec::ViewMeta<'a>,
@@ -213,7 +233,7 @@ pub fn for_name_view<'a>(
 }
 
 fn for_name_at<'a>(
-    spec: &'a Spec<'a>,
+    spec: &Spec<'a>,
     name: &str,
     ctx: &CompleteCtx<'_>,
     reached: &Position<'a>,
@@ -450,7 +470,7 @@ impl core::fmt::Display for CompletionTrace<'_> {
 }
 
 /// Explain a completion answer using the same parser walk and tables that produced it.
-pub fn trace<'a>(spec: &'a Spec<'a>, split: &Split) -> CompletionTrace<'a> {
+pub fn trace<'a>(spec: &Spec<'a>, split: &Split) -> CompletionTrace<'a> {
     let position = walk(spec.root.cmd, split.argv());
     let answer = complete(spec, split);
     trace_from(spec, split, position, answer, None)
@@ -458,7 +478,7 @@ pub fn trace<'a>(spec: &'a Spec<'a>, split: &Split) -> CompletionTrace<'a> {
 
 /// Explain a completion answer through one executable view.
 pub fn trace_view<'a>(
-    spec: &'a Spec<'a>,
+    spec: &Spec<'a>,
     split: &Split,
     view: &'a crate::spec::ViewMeta<'a>,
 ) -> CompletionTrace<'a> {
@@ -468,7 +488,7 @@ pub fn trace_view<'a>(
 }
 
 fn trace_from<'a>(
-    spec: &'a Spec<'a>,
+    spec: &Spec<'a>,
     split: &Split,
     position: Position<'a>,
     answer: Completions<'a>,
@@ -685,8 +705,19 @@ impl<'a> App<'a> {
 
     /// Answer a hidden completion invocation, or return `None` for ordinary argv.
     pub async fn completion_request(self, argv: &[OsString]) -> Option<String> {
-        let request = Request::parse(argv)?;
-        let mut split = request.split;
+        let request = CompletionRequest::parse(argv)?;
+        let answer = self.complete_request(&request).await;
+        Some(render(&answer, request.shell))
+    }
+
+    /// The words this app actually walks: the request's, with any multicall projection spliced
+    /// in after argv0.
+    ///
+    /// A caller that has to know where in the line the cursor landed — which command it
+    /// selected, whether it left these tables — has to ask about the same words the answer was
+    /// computed from, or its indices point one projection away from where it thinks.
+    pub fn effective_split(&self, split: &Split) -> Split {
+        let mut split = split.clone();
         if let Some(path) = self.projection {
             let projected: Vec<String> =
                 path.split_ascii_whitespace().map(str::to_string).collect();
@@ -698,13 +729,21 @@ impl<'a> App<'a> {
                 split.cword += count;
             }
         }
+        split
+    }
+
+    /// The answer to a parsed request, before it is written the way a shell reads it.
+    ///
+    /// [`completion_request`](Self::completion_request) is this plus [`render`]. They are
+    /// separate for a caller that answers part of a line itself — a host whose runtime commands
+    /// these tables do not describe — and needs this half's answer as data to add to.
+    pub async fn complete_request(&self, request: &CompletionRequest) -> Completions<'a> {
+        let split = self.effective_split(&request.split);
         let spec = self.view.spec();
-        let answer = if let Some(name) = request.candidates_for {
-            complete_named_with(&spec, &split, self.overlays, &name).await
-        } else {
-            complete_with(&spec, &split, self.overlays).await
-        };
-        Some(render(&answer, request.shell))
+        match &request.candidates_for {
+            Some(name) => complete_named_with(&spec, &split, self.overlays, name).await,
+            None => complete_with(&spec, &split, self.overlays).await,
+        }
     }
 }
 
@@ -715,14 +754,37 @@ impl<'a> SpecView<'a> {
     }
 }
 
-struct Request {
-    shell: Shell,
-    split: Split,
-    candidates_for: Option<String>,
+/// What a shell asked, read off the hidden `__complete_word__` invocation.
+///
+/// The protocol is small and its own thing: five options, none of them in any CLI's tables,
+/// because a completion is not a command anybody runs. This is the one reader of it — a host
+/// that answers part of a line itself parses the request once, here, rather than keeping a
+/// second idea of what the flags mean.
+///
+/// `#[non_exhaustive]` because the protocol may grow an option; these come from
+/// [`parse`](Self::parse), never from a literal.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct CompletionRequest {
+    /// Which shell is asking, and so how the answer is written.
+    pub shell: Shell,
+    /// The line, split the way that shell splits it, with the cursor's word singled out.
+    pub split: Split,
+    /// The single named completer being asked for, when a spec's `run=` line asked for one
+    /// rather than for everything the cursor could take.
+    pub candidates_for: Option<String>,
 }
 
-impl Request {
-    fn parse(argv: &[OsString]) -> Option<Self> {
+impl CompletionRequest {
+    /// Read a completion request, or return `None` for ordinary argv.
+    ///
+    /// `None` is the load-bearing case: it is what tells a `main` that this is a real
+    /// invocation and the parse should go ahead.
+    ///
+    /// Unknown options are ignored rather than refused. A stale generated script asking with a
+    /// flag this version dropped should still complete something; a beeping shell is worse than
+    /// an ignored word.
+    pub fn parse(argv: &[OsString]) -> Option<Self> {
         if argv.first()?.to_str()? != "__complete_word__" {
             return None;
         }
@@ -1071,13 +1133,13 @@ fn declared_files_at_cursor(
 ///
 /// Hidden things are never offered, in any branch. What is *not* here yet: the file fallback
 /// for a word nothing is known about, and the `run=` completions a spec can declare.
-pub fn complete<'a>(spec: &'a Spec<'a>, split: &Split) -> Completions<'a> {
+pub fn complete<'a>(spec: &Spec<'a>, split: &Split) -> Completions<'a> {
     complete_inner(spec, split, None)
 }
 
 /// Complete through an executable view, omitting root globals it does not carry.
 pub fn complete_view<'a>(
-    spec: &'a Spec<'a>,
+    spec: &Spec<'a>,
     split: &Split,
     view: &'a crate::spec::ViewMeta<'a>,
 ) -> Completions<'a> {
@@ -1085,7 +1147,7 @@ pub fn complete_view<'a>(
 }
 
 fn complete_inner<'a>(
-    spec: &'a Spec<'a>,
+    spec: &Spec<'a>,
     split: &Split,
     view: Option<&'a crate::spec::ViewMeta<'a>>,
 ) -> Completions<'a> {
@@ -1093,6 +1155,17 @@ fn complete_inner<'a>(
         Some(view) => walk_view(spec.root.cmd, split.argv(), view),
         None => walk(spec.root.cmd, split.argv()),
     };
+    // Past an external catch-all the cursor is inside another program's line, and these tables
+    // describe none of it. The command that declared the catch-all still has subcommands, flags
+    // and an unfilled positional to report, and every one of them would be an answer about the
+    // wrong CLI. Nothing is the honest answer — including no working directory, which would
+    // claim paths belong somewhere only the external program knows.
+    if position.external.is_some() {
+        return Completions {
+            candidates: Vec::new(),
+            files: None,
+        };
+    }
     let meta = metadata_chain_on_route(spec, &position).and_then(|chain| chain.last().copied());
     let token = split.prefix.as_str();
     let attached = attached_long_value(&position, token);
@@ -1192,7 +1265,7 @@ fn complete_inner<'a>(
 ///
 /// No future or callback is created until a completion request reaches a field with an overlay.
 pub async fn complete_with<'a>(
-    spec: &'a Spec<'a>,
+    spec: &Spec<'a>,
     split: &Split,
     overlays: &[CompletionOverlay<'_>],
 ) -> Completions<'a> {
@@ -1235,7 +1308,7 @@ pub async fn complete_with<'a>(
 }
 
 async fn complete_named_with<'a>(
-    spec: &'a Spec<'a>,
+    spec: &Spec<'a>,
     split: &Split,
     overlays: &[CompletionOverlay<'_>],
     name: &str,
@@ -1328,7 +1401,11 @@ fn overlay_at_cursor<'o>(
     overlays: &'o [CompletionOverlay<'_>],
 ) -> Option<&'o CompletionOverlay<'o>> {
     let attached = attached_long_value(position, &split.prefix);
+    // The external case is the same rule as the flag one: past a catch-all the position reports
+    // the parent's unfilled positional, and firing that positional's completer against another
+    // program's line answers a question nobody asked.
     if split.cword == 0
+        || position.external.is_some()
         || (position.awaiting_value.is_none()
             && attached.is_none()
             && position.flags_possible
@@ -1408,7 +1485,7 @@ fn overlay_at_cursor<'o>(
 }
 
 fn flag_meta_owner_on_route<'a>(
-    spec: &'a Spec<'a>,
+    spec: &Spec<'a>,
     position: &Position<'_>,
     flag: &Flag<'_>,
 ) -> Option<(&'a CommandMeta<'a>, &'a FlagMeta<'a>)> {
@@ -1423,7 +1500,7 @@ fn flag_meta_owner_on_route<'a>(
 }
 
 fn arg_meta_owner_on_route<'a>(
-    spec: &'a Spec<'a>,
+    spec: &Spec<'a>,
     position: &Position<'_>,
     arg: &Arg<'_>,
 ) -> Option<(&'a CommandMeta<'a>, &'a ArgMeta<'a>)> {
@@ -1438,7 +1515,7 @@ fn arg_meta_owner_on_route<'a>(
 }
 
 fn default_subcommand_arg<'a>(
-    spec: &'a Spec<'a>,
+    spec: &Spec<'a>,
     split: &Split,
     position: &Position<'_>,
 ) -> Option<(&'a CommandMeta<'a>, &'a ArgMeta<'a>)> {
@@ -1456,7 +1533,7 @@ fn default_subcommand_arg<'a>(
 /// The metadata route selected by the parser, preserving parent identity even when two
 /// wrappers reuse the same nested command tables.
 fn metadata_chain_on_route<'a>(
-    spec: &'a Spec<'a>,
+    spec: &Spec<'a>,
     position: &Position<'_>,
 ) -> Option<Vec<&'a CommandMeta<'a>>> {
     if position.path.is_empty() {
@@ -1476,12 +1553,12 @@ fn metadata_chain_on_route<'a>(
 }
 
 /// Just the candidates this CLI knows about, without the question of paths.
-pub fn candidates<'a>(spec: &'a Spec<'a>, split: &Split) -> Vec<Candidate<'a>> {
+pub fn candidates<'a>(spec: &Spec<'a>, split: &Split) -> Vec<Candidate<'a>> {
     candidates_inner(spec, split, None)
 }
 
 fn candidates_inner<'a>(
-    spec: &'a Spec<'a>,
+    spec: &Spec<'a>,
     split: &Split,
     view: Option<&'a crate::spec::ViewMeta<'a>>,
 ) -> Vec<Candidate<'a>> {
@@ -1489,6 +1566,10 @@ fn candidates_inner<'a>(
         Some(view) => walk_view(spec.root.cmd, split.argv(), view),
         None => walk(spec.root.cmd, split.argv()),
     };
+    // See `complete_inner`: nothing these tables hold describes the forwarded program.
+    if position.external.is_some() {
+        return Vec::new();
+    }
     let meta = metadata_chain_on_route(spec, &position).and_then(|chain| chain.last().copied());
     let token = split.prefix.as_str();
 
@@ -1635,7 +1716,7 @@ fn subcommands<'a>(meta: &'a CommandMeta<'a>, token: &str) -> Vec<Candidate<'a>>
 }
 
 /// The long forms of every flag in scope, and the negations of those that have one.
-fn long_flags<'a>(spec: &'a Spec<'a>, position: &Position<'_>, token: &str) -> Vec<Candidate<'a>> {
+fn long_flags<'a>(spec: &Spec<'a>, position: &Position<'_>, token: &str) -> Vec<Candidate<'a>> {
     let mut out = Vec::new();
     for flag in &position.flags {
         let meta = flag_meta(spec.root, flag);
@@ -1688,7 +1769,7 @@ fn long_flags<'a>(spec: &'a Spec<'a>, position: &Position<'_>, token: &str) -> V
 ///
 /// A token of `-x` is asking about the letter `x`, so only that letter's flag is offered:
 /// bundling means anything else would be a candidate for a different position in the token.
-fn short_flags<'a>(spec: &'a Spec<'a>, position: &Position<'_>, token: &str) -> Vec<Candidate<'a>> {
+fn short_flags<'a>(spec: &Spec<'a>, position: &Position<'_>, token: &str) -> Vec<Candidate<'a>> {
     let wanted = token.as_bytes().get(1).copied();
     let mut out = Vec::new();
     for flag in &position.flags {
@@ -3835,7 +3916,7 @@ mod tests {
             OsString::from("run"),
             OsString::from("two words"),
         ];
-        let request = Request::parse(&argv).expect("a completion request");
+        let request = CompletionRequest::parse(&argv).expect("a completion request");
         assert_eq!(request.shell, Shell::Elvish);
         assert_eq!(request.split.words, ["mise", "run", "two words"]);
         assert_eq!(request.split.cword, 2);
@@ -4027,5 +4108,99 @@ mod tests {
         // Detached, the flag's own completer answers — which is the case that works.
         assert_eq!(offered("mise install --source "), ["upstream"]);
         assert_eq!(offered("mise install "), ["node", "python", "ruby"]);
+    }
+
+    static EXT_LS: Command = Command {
+        name: "ls",
+        ..Command::EMPTY
+    };
+    static EXT_QUIET: Flag = Flag {
+        key: 40,
+        name: "quiet",
+        longs: &["quiet"],
+        ..Flag::BOOL
+    };
+    static EXT_PLUGINS: Command = Command {
+        name: "plugins",
+        flags: &[&EXT_QUIET],
+        subcommands: &[&EXT_LS],
+        external_subcommand: true,
+        ..Command::EMPTY
+    };
+    static EXT_ROOT: Command = Command {
+        name: "host",
+        subcommands: &[&EXT_PLUGINS],
+        ..Command::EMPTY
+    };
+    static EXT_META_PLUGINS: CommandMeta = CommandMeta {
+        cmd: &EXT_PLUGINS,
+        subcommands: &[&CommandMeta {
+            cmd: &EXT_LS,
+            ..CommandMeta::EMPTY
+        }],
+        ..CommandMeta::EMPTY
+    };
+    static EXT_META: CommandMeta = CommandMeta {
+        cmd: &EXT_ROOT,
+        subcommands: &[&EXT_META_PLUGINS],
+        ..CommandMeta::EMPTY
+    };
+    static EXT_SPEC: Spec = Spec {
+        name: "host",
+        root: &EXT_META,
+        ..Spec::EMPTY
+    };
+
+    #[test]
+    fn a_walk_reports_where_the_words_left_these_tables() {
+        // The word after the catch-all is the boundary, and it is an index into the words the
+        // walk was given — `split.argv()`, which is argv0-less and cursor-less.
+        let split = at_end("host plugins myplugin ");
+        let position = walk(&EXT_ROOT, split.argv());
+        assert_eq!(position.external, Some(1), "{:?}", split.argv());
+        assert_eq!(position.cmd.name, "plugins", "the boundary's declarer");
+
+        // A flag of the host's own before the name is still the host's: it binds, and the name
+        // after it is still where the line left.
+        let split = at_end("host plugins --quiet myplugin ");
+        assert_eq!(walk(&EXT_ROOT, split.argv()).external, Some(2));
+
+        // The name being *typed* is not past anything. The cursor's word is excluded from the
+        // walk, so this is the ordinary "which subcommand?" position and stays static.
+        let split = at_end("host plugins mypl");
+        assert_eq!(walk(&EXT_ROOT, split.argv()).external, None);
+        let split = at_end("host plugins ");
+        assert_eq!(walk(&EXT_ROOT, split.argv()).external, None);
+
+        // A dash-prefixed word never forwards — it is a flag or an error, not a command name.
+        let split = at_end("host plugins --nope ");
+        assert_eq!(walk(&EXT_ROOT, split.argv()).external, None);
+    }
+
+    #[test]
+    fn nothing_is_offered_past_an_external_boundary() {
+        // The declarer still has a subcommand and a flag to report, and both would be answers
+        // about the wrong CLI: `myplugin` is a program these tables do not describe.
+        let answer = complete(&EXT_SPEC, &at_end("host plugins myplugin "));
+        assert!(answer.candidates.is_empty(), "{answer:?}");
+        assert_eq!(answer.files, None, "no working directory either");
+        assert!(candidates(&EXT_SPEC, &at_end("host plugins myplugin ")).is_empty());
+
+        // Including for a dash-prefixed word: the host's flags are not the plugin's.
+        let flags = complete(&EXT_SPEC, &at_end("host plugins myplugin --"));
+        assert!(flags.candidates.is_empty(), "{flags:?}");
+        assert_eq!(flags.files, None);
+
+        // The position *before* the boundary is untouched.
+        let parent = complete(&EXT_SPEC, &at_end("host plugins "));
+        assert_eq!(
+            parent
+                .candidates
+                .iter()
+                .map(|candidate| candidate.value.as_str())
+                .collect::<Vec<_>>(),
+            ["ls"],
+            "{parent:?}"
+        );
     }
 }

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -776,6 +776,18 @@ pub struct CompletionRequest {
 }
 
 impl CompletionRequest {
+    /// A request for a line that is already split, with everything else defaulted.
+    ///
+    /// For a caller holding a [`Split`] rather than the argv a shell passed — a host answering
+    /// part of a line itself, a test asking what a position offers.
+    pub const fn for_split(split: Split) -> Self {
+        Self {
+            shell: Shell::Bash,
+            split,
+            candidates_for: None,
+        }
+    }
+
     /// Read a completion request, or return `None` for ordinary argv.
     ///
     /// `None` is the load-bearing case: it is what tells a `main` that this is a real

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -20,7 +20,8 @@
 use core::fmt::Write as _;
 
 use crate::spec::{
-    AdmonitionKind, AdmonitionMeta, ArgMeta, CommandMeta, Example, FlagMeta, Spec, ViewMeta,
+    AdmonitionKind, AdmonitionMeta, ArgMeta, CommandMeta, Example, FlagMeta, RuntimeCommand,
+    Spec, SpecView, ViewMeta,
 };
 use crate::Command;
 use crate::DoubleDash;
@@ -593,7 +594,7 @@ fn help_structure(
     flag_usages.sort_unstable_by_key(|usage| core::cmp::Reverse(usage.len()));
 
     let mut synopsis = String::new();
-    usage_section(&mut synopsis, spec, path, meta);
+    usage_section(&mut synopsis, spec, path, meta, false);
     let synopsis = synopsis.lines().map(str::to_string).collect();
     (headings, flag_usages, synopsis)
 }
@@ -759,7 +760,13 @@ fn usage_line_with_subcommands(
 ///
 /// An explicit synopsis belongs to the program rather than every command below it. Subcommand
 /// pages still derive their own invocation from the route and command metadata.
-fn usage_section(out: &mut String, spec: &Spec<'_>, path: &[&str], meta: &CommandMeta<'_>) {
+fn usage_section(
+    out: &mut String,
+    spec: &Spec<'_>,
+    path: &[&str],
+    meta: &CommandMeta<'_>,
+    has_runtime_commands: bool,
+) {
     if path.len() <= 1 {
         if let Some(usage) = spec.usage.filter(|usage| !usage.trim().is_empty()) {
             let _ = writeln!(out, "{}", usage.trim());
@@ -785,7 +792,12 @@ fn usage_section(out: &mut String, spec: &Spec<'_>, path: &[&str], meta: &Comman
             }
         }
     } else {
-        let _ = writeln!(out, "Usage: {}", usage_line(path, meta));
+        let mut line = usage_line(path, meta);
+        if has_runtime_commands && meta.cmd.subcommands.is_empty() {
+            let name = meta.subcommand_value_name.unwrap_or("SUBCOMMAND");
+            let _ = write!(line, " <{name}>");
+        }
+        let _ = writeln!(out, "Usage: {line}");
     }
 }
 
@@ -1073,7 +1085,7 @@ fn exact_arity(min: Option<usize>, max: Option<usize>) -> Option<usize> {
 ///
 /// `path` is the command as invoked, as for [`usage_line`].
 pub fn short_help(spec: &Spec<'_>, path: &[&str], chain: &[&CommandMeta<'_>]) -> String {
-    short_help_with(spec, path, chain, false)
+    short_help_with(spec, path, chain, false, &[])
 }
 
 fn short_help_with(
@@ -1081,10 +1093,11 @@ fn short_help_with(
     path: &[&str],
     chain: &[&CommandMeta<'_>],
     inherit_version_actions: bool,
+    runtime: &[&RuntimeCommand],
 ) -> String {
     assemble(
         spec,
-        &short_sections(spec, path, chain, inherit_version_actions),
+        &short_sections(spec, path, chain, inherit_version_actions, runtime),
     )
 }
 
@@ -1093,6 +1106,7 @@ fn short_sections(
     path: &[&str],
     chain: &[&CommandMeta<'_>],
     inherit_version_actions: bool,
+    runtime: &[&RuntimeCommand],
 ) -> Sections {
     let meta = *chain.last().expect("a page is always about some command");
     let (own, inherited) = own_and_global(chain, inherit_version_actions);
@@ -1134,13 +1148,18 @@ fn short_sections(
         let _ = writeln!(out, "{}\n", about.trim_end());
     }
     command_deprecation(out, meta, 0);
-    usage_section(&mut sections.usage, spec, path, meta);
+    usage_section(&mut sections.usage, spec, path, meta, !runtime.is_empty());
 
     // The path without the binary, which is what a listed subcommand shows: usage-lib prints
     // `tool-alias get <TOOL>` under `mise tool-alias`, the whole path from the root rather
     // than the child's own name.
     if !meta.flatten_help {
-        commands_section(&mut sections.commands, &path[1.min(path.len())..], meta);
+        commands_section(
+            &mut sections.commands,
+            &path[1.min(path.len())..],
+            meta,
+            runtime,
+        );
     }
 
     // The short page lines its columns up too. It did not: every description began directly
@@ -1296,14 +1315,19 @@ fn short_sections(
 }
 
 /// The list of subcommands, and the `help` command every CLI with subcommands has.
-fn commands_section(out: &mut String, path: &[&str], meta: &CommandMeta<'_>) {
+fn commands_section(
+    out: &mut String,
+    path: &[&str],
+    meta: &CommandMeta<'_>,
+    runtime: &[&RuntimeCommand],
+) {
     let mut visible: Vec<&&CommandMeta<'_>> = meta.subcommands.iter().filter(|c| !c.hide).collect();
     order_commands(&mut visible);
     // Nothing visible, no section — `mise direnv` and `mise dotfiles` have subcommands and
     // every one of them is hidden. The usage *line* still says `<SUBCOMMAND>`, because
     // usage-lib computes it before filtering and stores it; matching the reference means
     // matching that too, odd as the pair looks together.
-    if visible.is_empty() {
+    if visible.is_empty() && runtime.iter().all(|command| command.hide) {
         return;
     }
     // Sorted by the rendered usage rather than by name, as usage-lib sorts them — for a
@@ -1328,6 +1352,15 @@ fn commands_section(out: &mut String, path: &[&str], meta: &CommandMeta<'_>) {
     let mut headings = vec![None];
     for (_, sub) in &lines {
         let heading = command_help_section(sub, default_title);
+        if !headings.contains(&heading) {
+            headings.push(heading);
+        }
+    }
+    for command in runtime.iter().filter(|command| !command.hide) {
+        let heading = command
+            .help_heading
+            .as_deref()
+            .filter(|heading| *heading != default_title);
         if !headings.contains(&heading) {
             headings.push(heading);
         }
@@ -1368,6 +1401,47 @@ fn commands_section(out: &mut String, path: &[&str], meta: &CommandMeta<'_>) {
                 sub.deprecated_remove_at,
             ) {
                 let _ = write!(out, "  {label}");
+            }
+            out.push('\n');
+        }
+        let mut dynamic: Vec<_> = runtime
+            .iter()
+            .copied()
+            .filter(|command| {
+                !command.hide
+                    && command
+                        .help_heading
+                        .as_deref()
+                        .filter(|h| *h != default_title)
+                        == heading
+            })
+            .collect();
+        dynamic.sort_unstable_by(|a, b| {
+            a.display_order
+                .unwrap_or(999)
+                .cmp(&b.display_order.unwrap_or(999))
+                .then_with(|| a.name.cmp(&b.name))
+        });
+        for command in dynamic {
+            let mut usage = path.to_vec();
+            usage.push(&command.name);
+            let _ = write!(out, "  {}", usage.join(" "));
+            let aliases: Vec<_> = command
+                .aliases
+                .iter()
+                .filter(|alias| !command.hidden_aliases.contains(alias))
+                .map(String::as_str)
+                .collect();
+            if !aliases.is_empty() {
+                let _ = write!(out, " [aliases: {}]", aliases.join(", "));
+            }
+            if let Some(about) = &command.about {
+                if meta.next_line_help {
+                    out.push('\n');
+                    write_indented(out, about.trim_end(), 4);
+                    continue;
+                }
+                let _ = write!(out, "  {}", about.trim_end());
             }
             out.push('\n');
         }
@@ -1818,7 +1892,7 @@ fn terminal_width(meta: &CommandMeta<'_>) -> usize {
 /// under the usage rather than beside it, because there is no column that keeps a line the
 /// author already broke readable.
 pub fn long_help(spec: &Spec<'_>, path: &[&str], chain: &[&CommandMeta<'_>]) -> String {
-    long_help_with(spec, path, chain, false)
+    long_help_with(spec, path, chain, false, &[])
 }
 
 fn long_help_with(
@@ -1826,10 +1900,11 @@ fn long_help_with(
     path: &[&str],
     chain: &[&CommandMeta<'_>],
     inherit_version_actions: bool,
+    runtime: &[&RuntimeCommand],
 ) -> String {
     assemble(
         spec,
-        &long_sections(spec, path, chain, inherit_version_actions),
+        &long_sections(spec, path, chain, inherit_version_actions, runtime),
     )
 }
 
@@ -1838,6 +1913,7 @@ fn long_sections(
     path: &[&str],
     chain: &[&CommandMeta<'_>],
     inherit_version_actions: bool,
+    runtime: &[&RuntimeCommand],
 ) -> Sections {
     let meta = *chain.last().expect("a page is always about some command");
     let (own, inherited) = own_and_global(chain, inherit_version_actions);
@@ -1888,10 +1964,15 @@ fn long_sections(
         let _ = writeln!(out, "{}\n", about.trim_end());
     }
     command_deprecation(out, meta, 0);
-    usage_section(&mut sections.usage, spec, path, meta);
+    usage_section(&mut sections.usage, spec, path, meta, !runtime.is_empty());
 
     if !meta.flatten_help {
-        long_commands_section(&mut sections.commands, &path[1.min(path.len())..], meta);
+        long_commands_section(
+            &mut sections.commands,
+            &path[1.min(path.len())..],
+            meta,
+            runtime,
+        );
     }
 
     // One column width per section, over its visible entries — the same two the reference
@@ -2248,10 +2329,15 @@ fn flag_notes(out: &mut String, meta: &FlagMeta<'_>, indent: usize) {
 }
 
 /// The commands list, with each command's help beneath its usage.
-fn long_commands_section(out: &mut String, path: &[&str], meta: &CommandMeta<'_>) {
+fn long_commands_section(
+    out: &mut String,
+    path: &[&str],
+    meta: &CommandMeta<'_>,
+    runtime: &[&RuntimeCommand],
+) {
     let mut visible: Vec<&&CommandMeta<'_>> = meta.subcommands.iter().filter(|c| !c.hide).collect();
     order_commands(&mut visible);
-    if visible.is_empty() {
+    if visible.is_empty() && runtime.iter().all(|command| command.hide) {
         return;
     }
     let mut lines: Vec<(String, &&CommandMeta<'_>)> = visible
@@ -2273,6 +2359,15 @@ fn long_commands_section(out: &mut String, path: &[&str], meta: &CommandMeta<'_>
     let mut headings = vec![None];
     for (_, sub) in &lines {
         let heading = command_help_section(sub, default_title);
+        if !headings.contains(&heading) {
+            headings.push(heading);
+        }
+    }
+    for command in runtime.iter().filter(|command| !command.hide) {
+        let heading = command
+            .help_heading
+            .as_deref()
+            .filter(|heading| *heading != default_title);
         if !headings.contains(&heading) {
             headings.push(heading);
         }
@@ -2306,6 +2401,43 @@ fn long_commands_section(out: &mut String, path: &[&str], meta: &CommandMeta<'_>
             command_deprecation(out, sub, 4);
             // A blank line between entries, which the wider layout can afford and which keeps a
             // multi-line description from running into the next command's name.
+            out.push('\n');
+        }
+        let mut dynamic: Vec<_> = runtime
+            .iter()
+            .copied()
+            .filter(|command| {
+                !command.hide
+                    && command
+                        .help_heading
+                        .as_deref()
+                        .filter(|h| *h != default_title)
+                        == heading
+            })
+            .collect();
+        dynamic.sort_unstable_by(|a, b| {
+            a.display_order
+                .unwrap_or(999)
+                .cmp(&b.display_order.unwrap_or(999))
+                .then_with(|| a.name.cmp(&b.name))
+        });
+        for command in dynamic {
+            let mut usage = path.to_vec();
+            usage.push(&command.name);
+            let _ = write!(out, "  {}", usage.join(" "));
+            let aliases: Vec<_> = command
+                .aliases
+                .iter()
+                .filter(|alias| !command.hidden_aliases.contains(alias))
+                .map(String::as_str)
+                .collect();
+            if !aliases.is_empty() {
+                let _ = write!(out, " [aliases: {}]", aliases.join(", "));
+            }
+            out.push('\n');
+            if let Some(about) = command.long_about.as_ref().or(command.about.as_ref()) {
+                write_indented(out, about.trim_end(), 4);
+            }
             out.push('\n');
         }
         if heading.is_none() && !meta.cmd.disable_help_subcommand {
@@ -2827,9 +2959,9 @@ fn topics_with_blocks(
 ) -> Option<Vec<(Topic, String)>> {
     let (path, chain) = find(spec, cmd)?;
     let sections = if long {
-        long_sections(spec, &path, &chain, false)
+        long_sections(spec, &path, &chain, false, &[])
     } else {
-        short_sections(spec, &path, &chain, false)
+        short_sections(spec, &path, &chain, false, &[])
     };
     let mut used = Vec::<String>::new();
     Some(
@@ -2901,6 +3033,47 @@ pub fn render_styled(
         short_help(spec, &path, &chain)
     };
     let (headings, flag_usages, synopsis) = help_structure(spec, &path, &chain, long, false);
+    Some(styled_help(
+        &page,
+        style,
+        &headings,
+        &flag_usages,
+        &synopsis,
+    ))
+}
+
+/// Render a static command page with the runtime summaries attached to its [`SpecView`].
+///
+/// The route is canonical and excludes the root name. Runtime entries affect only this
+/// command's list and synopsis; they do not become navigable pages in the host tree.
+pub fn render_runtime(
+    view: &SpecView<'_>,
+    route: &str,
+    long: bool,
+    style: Style,
+) -> Option<String> {
+    let spec = view.spec();
+    let route_parts: Vec<&str> = route.split_ascii_whitespace().collect();
+    let mut path = vec![spec.bin.unwrap_or(spec.name)];
+    let mut chain = vec![spec.root];
+    let mut current = spec.root;
+    for name in &route_parts {
+        current = current
+            .subcommands
+            .iter()
+            .copied()
+            .find(|command| command.cmd.name == *name || command.cmd.aliases.contains(name))?;
+        path.push(current.cmd.name);
+        chain.push(current);
+    }
+    let canonical: Vec<&str> = chain.iter().skip(1).map(|meta| meta.cmd.name).collect();
+    let runtime = view.runtime_at(&canonical);
+    let page = if long {
+        long_help_with(&spec, &path, &chain, false, &runtime)
+    } else {
+        short_help_with(&spec, &path, &chain, false, &runtime)
+    };
+    let (headings, flag_usages, synopsis) = help_structure(&spec, &path, &chain, long, false);
     Some(styled_help(
         &page,
         style,
@@ -3108,9 +3281,9 @@ pub fn render_view_at_styled(
         ..*spec
     };
     let page = if long {
-        long_help_with(&viewed, &path, &chain, true)
+        long_help_with(&viewed, &path, &chain, true, &[])
     } else {
-        short_help_with(&viewed, &path, &chain, true)
+        short_help_with(&viewed, &path, &chain, true, &[])
     };
     let (headings, flag_usages, synopsis) = help_structure(&viewed, &path, &chain, long, true);
     Some(styled_help(
@@ -3344,7 +3517,7 @@ fn recursive_help<'a>(
         if !out.is_empty() {
             out.push('\n');
         }
-        let page = long_help_with(spec, path, chain, inherit_version_actions);
+        let page = long_help_with(spec, path, chain, inherit_version_actions, &[]);
         let (headings, flag_usages, synopsis) =
             help_structure(spec, path, chain, true, inherit_version_actions);
         out.push_str(&styled_help(
@@ -3586,7 +3759,7 @@ mod style_tests {
         };
         let mut page = String::new();
 
-        commands_section(&mut page, &[], &root_meta);
+        commands_section(&mut page, &[], &root_meta, &[]);
 
         assert!(page.contains("  run  run it\n  help"));
         assert!(!page.contains("  run  run it\n\n  help"));

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -2438,7 +2438,7 @@ fn flat_commands_long(out: &mut String, path: &[&str], meta: &CommandMeta<'_>, w
 ///
 /// `None` when the command is not in this spec, which means the two came from different CLIs.
 pub fn find<'a>(
-    spec: &'a Spec<'a>,
+    spec: &Spec<'a>,
     cmd: &Command<'_>,
 ) -> Option<(Vec<&'a str>, Vec<&'a CommandMeta<'a>>)> {
     fn walk<'a>(

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -20,8 +20,7 @@
 use core::fmt::Write as _;
 
 use crate::spec::{
-    AdmonitionKind, AdmonitionMeta, ArgMeta, CommandMeta, Example, FlagMeta, RuntimeCommand,
-    Spec, SpecView, ViewMeta,
+    AdmonitionKind, AdmonitionMeta, ArgMeta, CommandMeta, Example, FlagMeta, Spec, ViewMeta,
 };
 use crate::Command;
 use crate::DoubleDash;
@@ -594,7 +593,7 @@ fn help_structure(
     flag_usages.sort_unstable_by_key(|usage| core::cmp::Reverse(usage.len()));
 
     let mut synopsis = String::new();
-    usage_section(&mut synopsis, spec, path, meta, false);
+    usage_section(&mut synopsis, spec, path, meta);
     let synopsis = synopsis.lines().map(str::to_string).collect();
     (headings, flag_usages, synopsis)
 }
@@ -760,13 +759,7 @@ fn usage_line_with_subcommands(
 ///
 /// An explicit synopsis belongs to the program rather than every command below it. Subcommand
 /// pages still derive their own invocation from the route and command metadata.
-fn usage_section(
-    out: &mut String,
-    spec: &Spec<'_>,
-    path: &[&str],
-    meta: &CommandMeta<'_>,
-    has_runtime_commands: bool,
-) {
+fn usage_section(out: &mut String, spec: &Spec<'_>, path: &[&str], meta: &CommandMeta<'_>) {
     if path.len() <= 1 {
         if let Some(usage) = spec.usage.filter(|usage| !usage.trim().is_empty()) {
             let _ = writeln!(out, "{}", usage.trim());
@@ -792,12 +785,7 @@ fn usage_section(
             }
         }
     } else {
-        let mut line = usage_line(path, meta);
-        if has_runtime_commands && meta.cmd.subcommands.is_empty() {
-            let name = meta.subcommand_value_name.unwrap_or("SUBCOMMAND");
-            let _ = write!(line, " <{name}>");
-        }
-        let _ = writeln!(out, "Usage: {line}");
+        let _ = writeln!(out, "Usage: {}", usage_line(path, meta));
     }
 }
 
@@ -1085,7 +1073,7 @@ fn exact_arity(min: Option<usize>, max: Option<usize>) -> Option<usize> {
 ///
 /// `path` is the command as invoked, as for [`usage_line`].
 pub fn short_help(spec: &Spec<'_>, path: &[&str], chain: &[&CommandMeta<'_>]) -> String {
-    short_help_with(spec, path, chain, false, &[])
+    short_help_with(spec, path, chain, false)
 }
 
 fn short_help_with(
@@ -1093,11 +1081,10 @@ fn short_help_with(
     path: &[&str],
     chain: &[&CommandMeta<'_>],
     inherit_version_actions: bool,
-    runtime: &[&RuntimeCommand],
 ) -> String {
     assemble(
         spec,
-        &short_sections(spec, path, chain, inherit_version_actions, runtime),
+        &short_sections(spec, path, chain, inherit_version_actions),
     )
 }
 
@@ -1106,7 +1093,6 @@ fn short_sections(
     path: &[&str],
     chain: &[&CommandMeta<'_>],
     inherit_version_actions: bool,
-    runtime: &[&RuntimeCommand],
 ) -> Sections {
     let meta = *chain.last().expect("a page is always about some command");
     let (own, inherited) = own_and_global(chain, inherit_version_actions);
@@ -1148,18 +1134,13 @@ fn short_sections(
         let _ = writeln!(out, "{}\n", about.trim_end());
     }
     command_deprecation(out, meta, 0);
-    usage_section(&mut sections.usage, spec, path, meta, !runtime.is_empty());
+    usage_section(&mut sections.usage, spec, path, meta);
 
     // The path without the binary, which is what a listed subcommand shows: usage-lib prints
     // `tool-alias get <TOOL>` under `mise tool-alias`, the whole path from the root rather
     // than the child's own name.
     if !meta.flatten_help {
-        commands_section(
-            &mut sections.commands,
-            &path[1.min(path.len())..],
-            meta,
-            runtime,
-        );
+        commands_section(&mut sections.commands, &path[1.min(path.len())..], meta);
     }
 
     // The short page lines its columns up too. It did not: every description began directly
@@ -1315,19 +1296,14 @@ fn short_sections(
 }
 
 /// The list of subcommands, and the `help` command every CLI with subcommands has.
-fn commands_section(
-    out: &mut String,
-    path: &[&str],
-    meta: &CommandMeta<'_>,
-    runtime: &[&RuntimeCommand],
-) {
+fn commands_section(out: &mut String, path: &[&str], meta: &CommandMeta<'_>) {
     let mut visible: Vec<&&CommandMeta<'_>> = meta.subcommands.iter().filter(|c| !c.hide).collect();
     order_commands(&mut visible);
     // Nothing visible, no section — `mise direnv` and `mise dotfiles` have subcommands and
     // every one of them is hidden. The usage *line* still says `<SUBCOMMAND>`, because
     // usage-lib computes it before filtering and stores it; matching the reference means
     // matching that too, odd as the pair looks together.
-    if visible.is_empty() && runtime.iter().all(|command| command.hide) {
+    if visible.is_empty() {
         return;
     }
     // Sorted by the rendered usage rather than by name, as usage-lib sorts them — for a
@@ -1352,15 +1328,6 @@ fn commands_section(
     let mut headings = vec![None];
     for (_, sub) in &lines {
         let heading = command_help_section(sub, default_title);
-        if !headings.contains(&heading) {
-            headings.push(heading);
-        }
-    }
-    for command in runtime.iter().filter(|command| !command.hide) {
-        let heading = command
-            .help_heading
-            .as_deref()
-            .filter(|heading| *heading != default_title);
         if !headings.contains(&heading) {
             headings.push(heading);
         }
@@ -1401,47 +1368,6 @@ fn commands_section(
                 sub.deprecated_remove_at,
             ) {
                 let _ = write!(out, "  {label}");
-            }
-            out.push('\n');
-        }
-        let mut dynamic: Vec<_> = runtime
-            .iter()
-            .copied()
-            .filter(|command| {
-                !command.hide
-                    && command
-                        .help_heading
-                        .as_deref()
-                        .filter(|h| *h != default_title)
-                        == heading
-            })
-            .collect();
-        dynamic.sort_unstable_by(|a, b| {
-            a.display_order
-                .unwrap_or(999)
-                .cmp(&b.display_order.unwrap_or(999))
-                .then_with(|| a.name.cmp(&b.name))
-        });
-        for command in dynamic {
-            let mut usage = path.to_vec();
-            usage.push(&command.name);
-            let _ = write!(out, "  {}", usage.join(" "));
-            let aliases: Vec<_> = command
-                .aliases
-                .iter()
-                .filter(|alias| !command.hidden_aliases.contains(alias))
-                .map(String::as_str)
-                .collect();
-            if !aliases.is_empty() {
-                let _ = write!(out, " [aliases: {}]", aliases.join(", "));
-            }
-            if let Some(about) = &command.about {
-                if meta.next_line_help {
-                    out.push('\n');
-                    write_indented(out, about.trim_end(), 4);
-                    continue;
-                }
-                let _ = write!(out, "  {}", about.trim_end());
             }
             out.push('\n');
         }
@@ -1892,7 +1818,7 @@ fn terminal_width(meta: &CommandMeta<'_>) -> usize {
 /// under the usage rather than beside it, because there is no column that keeps a line the
 /// author already broke readable.
 pub fn long_help(spec: &Spec<'_>, path: &[&str], chain: &[&CommandMeta<'_>]) -> String {
-    long_help_with(spec, path, chain, false, &[])
+    long_help_with(spec, path, chain, false)
 }
 
 fn long_help_with(
@@ -1900,11 +1826,10 @@ fn long_help_with(
     path: &[&str],
     chain: &[&CommandMeta<'_>],
     inherit_version_actions: bool,
-    runtime: &[&RuntimeCommand],
 ) -> String {
     assemble(
         spec,
-        &long_sections(spec, path, chain, inherit_version_actions, runtime),
+        &long_sections(spec, path, chain, inherit_version_actions),
     )
 }
 
@@ -1913,7 +1838,6 @@ fn long_sections(
     path: &[&str],
     chain: &[&CommandMeta<'_>],
     inherit_version_actions: bool,
-    runtime: &[&RuntimeCommand],
 ) -> Sections {
     let meta = *chain.last().expect("a page is always about some command");
     let (own, inherited) = own_and_global(chain, inherit_version_actions);
@@ -1964,15 +1888,10 @@ fn long_sections(
         let _ = writeln!(out, "{}\n", about.trim_end());
     }
     command_deprecation(out, meta, 0);
-    usage_section(&mut sections.usage, spec, path, meta, !runtime.is_empty());
+    usage_section(&mut sections.usage, spec, path, meta);
 
     if !meta.flatten_help {
-        long_commands_section(
-            &mut sections.commands,
-            &path[1.min(path.len())..],
-            meta,
-            runtime,
-        );
+        long_commands_section(&mut sections.commands, &path[1.min(path.len())..], meta);
     }
 
     // One column width per section, over its visible entries — the same two the reference
@@ -2329,15 +2248,10 @@ fn flag_notes(out: &mut String, meta: &FlagMeta<'_>, indent: usize) {
 }
 
 /// The commands list, with each command's help beneath its usage.
-fn long_commands_section(
-    out: &mut String,
-    path: &[&str],
-    meta: &CommandMeta<'_>,
-    runtime: &[&RuntimeCommand],
-) {
+fn long_commands_section(out: &mut String, path: &[&str], meta: &CommandMeta<'_>) {
     let mut visible: Vec<&&CommandMeta<'_>> = meta.subcommands.iter().filter(|c| !c.hide).collect();
     order_commands(&mut visible);
-    if visible.is_empty() && runtime.iter().all(|command| command.hide) {
+    if visible.is_empty() {
         return;
     }
     let mut lines: Vec<(String, &&CommandMeta<'_>)> = visible
@@ -2359,15 +2273,6 @@ fn long_commands_section(
     let mut headings = vec![None];
     for (_, sub) in &lines {
         let heading = command_help_section(sub, default_title);
-        if !headings.contains(&heading) {
-            headings.push(heading);
-        }
-    }
-    for command in runtime.iter().filter(|command| !command.hide) {
-        let heading = command
-            .help_heading
-            .as_deref()
-            .filter(|heading| *heading != default_title);
         if !headings.contains(&heading) {
             headings.push(heading);
         }
@@ -2401,43 +2306,6 @@ fn long_commands_section(
             command_deprecation(out, sub, 4);
             // A blank line between entries, which the wider layout can afford and which keeps a
             // multi-line description from running into the next command's name.
-            out.push('\n');
-        }
-        let mut dynamic: Vec<_> = runtime
-            .iter()
-            .copied()
-            .filter(|command| {
-                !command.hide
-                    && command
-                        .help_heading
-                        .as_deref()
-                        .filter(|h| *h != default_title)
-                        == heading
-            })
-            .collect();
-        dynamic.sort_unstable_by(|a, b| {
-            a.display_order
-                .unwrap_or(999)
-                .cmp(&b.display_order.unwrap_or(999))
-                .then_with(|| a.name.cmp(&b.name))
-        });
-        for command in dynamic {
-            let mut usage = path.to_vec();
-            usage.push(&command.name);
-            let _ = write!(out, "  {}", usage.join(" "));
-            let aliases: Vec<_> = command
-                .aliases
-                .iter()
-                .filter(|alias| !command.hidden_aliases.contains(alias))
-                .map(String::as_str)
-                .collect();
-            if !aliases.is_empty() {
-                let _ = write!(out, " [aliases: {}]", aliases.join(", "));
-            }
-            out.push('\n');
-            if let Some(about) = command.long_about.as_ref().or(command.about.as_ref()) {
-                write_indented(out, about.trim_end(), 4);
-            }
             out.push('\n');
         }
         if heading.is_none() && !meta.cmd.disable_help_subcommand {
@@ -2959,9 +2827,9 @@ fn topics_with_blocks(
 ) -> Option<Vec<(Topic, String)>> {
     let (path, chain) = find(spec, cmd)?;
     let sections = if long {
-        long_sections(spec, &path, &chain, false, &[])
+        long_sections(spec, &path, &chain, false)
     } else {
-        short_sections(spec, &path, &chain, false, &[])
+        short_sections(spec, &path, &chain, false)
     };
     let mut used = Vec::<String>::new();
     Some(
@@ -3033,47 +2901,6 @@ pub fn render_styled(
         short_help(spec, &path, &chain)
     };
     let (headings, flag_usages, synopsis) = help_structure(spec, &path, &chain, long, false);
-    Some(styled_help(
-        &page,
-        style,
-        &headings,
-        &flag_usages,
-        &synopsis,
-    ))
-}
-
-/// Render a static command page with the runtime summaries attached to its [`SpecView`].
-///
-/// The route is canonical and excludes the root name. Runtime entries affect only this
-/// command's list and synopsis; they do not become navigable pages in the host tree.
-pub fn render_runtime(
-    view: &SpecView<'_>,
-    route: &str,
-    long: bool,
-    style: Style,
-) -> Option<String> {
-    let spec = view.spec();
-    let route_parts: Vec<&str> = route.split_ascii_whitespace().collect();
-    let mut path = vec![spec.bin.unwrap_or(spec.name)];
-    let mut chain = vec![spec.root];
-    let mut current = spec.root;
-    for name in &route_parts {
-        current = current
-            .subcommands
-            .iter()
-            .copied()
-            .find(|command| command.cmd.name == *name || command.cmd.aliases.contains(name))?;
-        path.push(current.cmd.name);
-        chain.push(current);
-    }
-    let canonical: Vec<&str> = chain.iter().skip(1).map(|meta| meta.cmd.name).collect();
-    let runtime = view.runtime_at(&canonical);
-    let page = if long {
-        long_help_with(&spec, &path, &chain, false, &runtime)
-    } else {
-        short_help_with(&spec, &path, &chain, false, &runtime)
-    };
-    let (headings, flag_usages, synopsis) = help_structure(&spec, &path, &chain, long, false);
     Some(styled_help(
         &page,
         style,
@@ -3281,9 +3108,9 @@ pub fn render_view_at_styled(
         ..*spec
     };
     let page = if long {
-        long_help_with(&viewed, &path, &chain, true, &[])
+        long_help_with(&viewed, &path, &chain, true)
     } else {
-        short_help_with(&viewed, &path, &chain, true, &[])
+        short_help_with(&viewed, &path, &chain, true)
     };
     let (headings, flag_usages, synopsis) = help_structure(&viewed, &path, &chain, long, true);
     Some(styled_help(
@@ -3517,7 +3344,7 @@ fn recursive_help<'a>(
         if !out.is_empty() {
             out.push('\n');
         }
-        let page = long_help_with(spec, path, chain, inherit_version_actions, &[]);
+        let page = long_help_with(spec, path, chain, inherit_version_actions);
         let (headings, flag_usages, synopsis) =
             help_structure(spec, path, chain, true, inherit_version_actions);
         out.push_str(&styled_help(
@@ -3759,7 +3586,7 @@ mod style_tests {
         };
         let mut page = String::new();
 
-        commands_section(&mut page, &[], &root_meta, &[]);
+        commands_section(&mut page, &[], &root_meta);
 
         assert!(page.contains("  run  run it\n  help"));
         assert!(!page.contains("  run  run it\n\n  help"));

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -465,6 +465,24 @@ pub struct CommandOverlay<'a> {
     pub effect: Effect,
 }
 
+/// An owned runtime command summary attached to a static command path.
+///
+/// Runtime commands are presentation metadata only. They are never inserted into the
+/// derive-generated [`Command`] tables, so they cannot affect parsing or emitted KDL.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeCommand {
+    /// Canonical, space-separated static parent path. The empty string is the root.
+    pub parent: std::string::String,
+    pub name: std::string::String,
+    pub aliases: std::vec::Vec<std::string::String>,
+    pub hidden_aliases: std::vec::Vec<std::string::String>,
+    pub about: Option<std::string::String>,
+    pub long_about: Option<std::string::String>,
+    pub help_heading: Option<std::string::String>,
+    pub hide: bool,
+    pub display_order: Option<usize>,
+}
+
 impl<'a> CommandOverlay<'a> {
     pub const fn effect(path: &'a str, effect: Effect) -> Self {
         Self {
@@ -494,6 +512,7 @@ pub struct SpecView<'a> {
     version: Option<&'a str>,
     omit_version: bool,
     commands: Vec<CommandOverlay<'a>>,
+    runtime_commands: Vec<RuntimeCommand>,
 }
 
 impl<'a> SpecView<'a> {
@@ -505,6 +524,7 @@ impl<'a> SpecView<'a> {
             version: None,
             omit_version: false,
             commands: Vec::new(),
+            runtime_commands: Vec::new(),
         }
     }
 
@@ -519,6 +539,7 @@ impl<'a> SpecView<'a> {
             version: self.version,
             omit_version: self.omit_version,
             commands: self.commands,
+            runtime_commands: self.runtime_commands,
         }
     }
 
@@ -571,6 +592,42 @@ impl<'a> SpecView<'a> {
         let mut view = self.reborrow();
         view.commands.extend_from_slice(commands);
         view
+    }
+
+    /// Add owned command summaries to help and command-name completion.
+    ///
+    /// This does not alter [`Self::spec`], argv parsing, or [`Self::to_kdl`]. Companion
+    /// crates should validate paths and collisions before constructing the view.
+    pub fn runtime_commands(mut self, commands: impl IntoIterator<Item = RuntimeCommand>) -> Self {
+        self.runtime_commands.extend(commands);
+        self
+    }
+
+    pub(crate) fn runtime_at(&self, path: &[&str]) -> Vec<&RuntimeCommand> {
+        self.runtime_commands
+            .iter()
+            .filter(|command| {
+                command
+                    .parent
+                    .split_ascii_whitespace()
+                    .eq(path.iter().copied())
+            })
+            .collect()
+    }
+
+    /// Render short or long help for a canonical static command path.
+    pub fn help(&self, path: &str, long: bool) -> Option<std::string::String> {
+        crate::help::render_runtime(self, path, long, crate::help::Style::PLAIN)
+    }
+
+    /// Render help with an explicit colour policy.
+    pub fn help_styled(
+        &self,
+        path: &str,
+        long: bool,
+        style: crate::help::Style,
+    ) -> Option<std::string::String> {
+        crate::help::render_runtime(self, path, long, style)
     }
 
     /// The shallow effective spec. Its command metadata still borrows the derive's static tree.

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -465,24 +465,6 @@ pub struct CommandOverlay<'a> {
     pub effect: Effect,
 }
 
-/// An owned runtime command summary attached to a static command path.
-///
-/// Runtime commands are presentation metadata only. They are never inserted into the
-/// derive-generated [`Command`] tables, so they cannot affect parsing or emitted KDL.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct RuntimeCommand {
-    /// Canonical, space-separated static parent path. The empty string is the root.
-    pub parent: std::string::String,
-    pub name: std::string::String,
-    pub aliases: std::vec::Vec<std::string::String>,
-    pub hidden_aliases: std::vec::Vec<std::string::String>,
-    pub about: Option<std::string::String>,
-    pub long_about: Option<std::string::String>,
-    pub help_heading: Option<std::string::String>,
-    pub hide: bool,
-    pub display_order: Option<usize>,
-}
-
 impl<'a> CommandOverlay<'a> {
     pub const fn effect(path: &'a str, effect: Effect) -> Self {
         Self {
@@ -512,7 +494,6 @@ pub struct SpecView<'a> {
     version: Option<&'a str>,
     omit_version: bool,
     commands: Vec<CommandOverlay<'a>>,
-    runtime_commands: Vec<RuntimeCommand>,
 }
 
 impl<'a> SpecView<'a> {
@@ -524,7 +505,6 @@ impl<'a> SpecView<'a> {
             version: None,
             omit_version: false,
             commands: Vec::new(),
-            runtime_commands: Vec::new(),
         }
     }
 
@@ -539,7 +519,6 @@ impl<'a> SpecView<'a> {
             version: self.version,
             omit_version: self.omit_version,
             commands: self.commands,
-            runtime_commands: self.runtime_commands,
         }
     }
 
@@ -592,42 +571,6 @@ impl<'a> SpecView<'a> {
         let mut view = self.reborrow();
         view.commands.extend_from_slice(commands);
         view
-    }
-
-    /// Add owned command summaries to help and command-name completion.
-    ///
-    /// This does not alter [`Self::spec`], argv parsing, or [`Self::to_kdl`]. Companion
-    /// crates should validate paths and collisions before constructing the view.
-    pub fn runtime_commands(mut self, commands: impl IntoIterator<Item = RuntimeCommand>) -> Self {
-        self.runtime_commands.extend(commands);
-        self
-    }
-
-    pub(crate) fn runtime_at(&self, path: &[&str]) -> Vec<&RuntimeCommand> {
-        self.runtime_commands
-            .iter()
-            .filter(|command| {
-                command
-                    .parent
-                    .split_ascii_whitespace()
-                    .eq(path.iter().copied())
-            })
-            .collect()
-    }
-
-    /// Render short or long help for a canonical static command path.
-    pub fn help(&self, path: &str, long: bool) -> Option<std::string::String> {
-        crate::help::render_runtime(self, path, long, crate::help::Style::PLAIN)
-    }
-
-    /// Render help with an explicit colour policy.
-    pub fn help_styled(
-        &self,
-        path: &str,
-        long: bool,
-        style: crate::help::Style,
-    ) -> Option<std::string::String> {
-        crate::help::render_runtime(self, path, long, style)
     }
 
     /// The shallow effective spec. Its command metadata still borrows the derive's static tree.

--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -152,6 +152,18 @@ impl CompleteWord {
         let parsed = usage::parse::parse_partial(spec, &words)?;
         debug!("parsed cmd: {}", parsed.cmd.full_cmd.join(" "));
 
+        // Past an `external_subcommand` catch-all the cursor is inside another program's line.
+        // The command that declared the catch-all still has subcommands, flags and an unfilled
+        // positional to offer, and every one of them would describe the wrong CLI — so would
+        // the working directory, which claims paths belong somewhere only that program knows.
+        // Whoever knows what the external name means answers from there; this spec does not.
+        if parsed.external.is_some() {
+            return Ok(CandidateAnswer {
+                candidates: vec![],
+                files: false,
+            });
+        }
+
         // Check if previous token was a restart_token - if so, complete from first arg
         let prev_token = if cword > 0 {
             self.words.get(cword - 1).map(|s| s.as_str())

--- a/conformance/src/complete.rs
+++ b/conformance/src/complete.rs
@@ -92,6 +92,14 @@ pub struct Expect {
     /// Whether the order of `candidates` is itself the claim.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub ordered: bool,
+    /// Whether offering *nothing* is the claim.
+    ///
+    /// An empty expectation is almost always a spec that did not say what its author thought,
+    /// so the corpus refuses one by default. Saying this marks the rare case where silence is
+    /// the answer being pinned — past an external boundary, where the words belong to a program
+    /// this spec does not describe — and keeps the guard for everything else.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub nothing: bool,
 }
 
 /// Whether the reference implementation matches a vector's expectation.

--- a/conformance/tests/complete.rs
+++ b/conformance/tests/complete.rs
@@ -69,9 +69,14 @@ fn every_vector_says_something() {
             vector.id
         );
         assert!(
-            !vector.expect.candidates.is_empty() || vector.expect.files,
-            "{} [{file}] expects nothing at all — if that is really the claim, say so in `doc` \
-             and relax this check",
+            !vector.expect.candidates.is_empty() || vector.expect.files || vector.expect.nothing,
+            "{} [{file}] expects nothing at all — if that is really the claim, say so with \
+             `\"nothing\": true` and explain it in `doc`",
+            vector.id
+        );
+        assert!(
+            !vector.expect.nothing || (vector.expect.candidates.is_empty() && !vector.expect.files),
+            "{} [{file}] claims to expect nothing while expecting something",
             vector.id
         );
     }

--- a/corpus/complete/03-external-boundary.json
+++ b/corpus/complete/03-external-boundary.json
@@ -38,9 +38,7 @@
       "spec": "name \"ex\"\nbin \"ex\"\ncmd \"plugins\" {\n  external_subcommand #true\n  cmd \"ls\" {}\n}\n",
       "line": "ex plugins ",
       "expect": {
-        "candidates": [
-          "ls"
-        ]
+        "candidates": ["ls"]
       }
     },
     {
@@ -49,9 +47,7 @@
       "spec": "name \"ex\"\nbin \"ex\"\ncmd \"plugins\" {\n  external_subcommand #true\n  cmd \"ls\" {}\n}\n",
       "line": "ex plugins l",
       "expect": {
-        "candidates": [
-          "ls"
-        ]
+        "candidates": ["ls"]
       }
     },
     {

--- a/corpus/complete/03-external-boundary.json
+++ b/corpus/complete/03-external-boundary.json
@@ -1,0 +1,68 @@
+{
+  "section": "external-boundary",
+  "about": "An `external_subcommand` catch-all forwards an unrecognized command word and everything after it to a program the spec does not describe. Past that word the cursor is inside another CLI's line, and this spec knows nothing about it — not its flags, not its arguments, not whether a path belongs there. The declaring command still has subcommands, flags and an unfilled positional to report, which is exactly the trap: every one of them is an answer about the wrong CLI. A host that does know what the external name means answers from its own tables; one that does not offers nothing at all.",
+  "vectors": [
+    {
+      "id": "nothing-past-the-boundary",
+      "doc": "The word after a forwarded command name belongs to that command. Offering the catch-all's own subcommands there — the position's `cmd` is still the declarer — would complete `plugins ls` into a line that runs `myplugin`.",
+      "spec": "name \"ex\"\nbin \"ex\"\ncmd \"plugins\" {\n  external_subcommand #true\n  cmd \"ls\" {}\n}\n",
+      "line": "ex plugins myplugin ",
+      "expect": {
+        "candidates": [],
+        "nothing": true
+      }
+    },
+    {
+      "id": "no-path-fallback-past-the-boundary",
+      "doc": "Deferring to the shell's file completion is itself a claim: that a path is what goes here. Only the external program knows that, so the empty answer has to be empty of files too.",
+      "spec": "name \"ex\"\nbin \"ex\"\ncmd \"plugins\" {\n  external_subcommand #true\n  cmd \"ls\" {}\n}\n",
+      "line": "ex plugins myplugin ",
+      "expect": {
+        "candidates": [],
+        "nothing": true
+      }
+    },
+    {
+      "id": "no-flags-past-the-boundary",
+      "doc": "The host's flags are not the plugin's. A dash-prefixed word past the boundary is the plugin's business, and offering `--verbose` there advertises a flag that would be forwarded, not bound.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--verbose\"\ncmd \"plugins\" {\n  external_subcommand #true\n  flag \"--quiet\"\n}\n",
+      "line": "ex plugins myplugin --",
+      "expect": {
+        "candidates": [],
+        "nothing": true
+      }
+    },
+    {
+      "id": "the-command-position-itself-is-unaffected",
+      "doc": "The boundary is crossed by a word the walk already passed, not by the one being typed. At the catch-all's own command position the declared subcommands are still the answer — a catch-all means \"and also anything else\", not \"nothing\".",
+      "spec": "name \"ex\"\nbin \"ex\"\ncmd \"plugins\" {\n  external_subcommand #true\n  cmd \"ls\" {}\n}\n",
+      "line": "ex plugins ",
+      "expect": {
+        "candidates": [
+          "ls"
+        ]
+      }
+    },
+    {
+      "id": "a-partial-name-is-still-a-command-position",
+      "doc": "A half-typed word could still become a declared subcommand, so it completes as one. Nothing is forwarded until a word is complete enough to not be `ls`.",
+      "spec": "name \"ex\"\nbin \"ex\"\ncmd \"plugins\" {\n  external_subcommand #true\n  cmd \"ls\" {}\n}\n",
+      "line": "ex plugins l",
+      "expect": {
+        "candidates": [
+          "ls"
+        ]
+      }
+    },
+    {
+      "id": "a-declared-flag-before-the-name-does-not-move-the-boundary",
+      "doc": "A flag of the host's own before the external name binds to the host, and the name after it still forwards. The boundary is where the grammar stopped recognizing words, not where the first dash appeared.",
+      "spec": "name \"ex\"\nbin \"ex\"\ncmd \"plugins\" {\n  external_subcommand #true\n  flag \"--quiet\"\n  cmd \"ls\" {}\n}\n",
+      "line": "ex plugins --quiet myplugin ",
+      "expect": {
+        "candidates": [],
+        "nothing": true
+      }
+    }
+  ]
+}

--- a/corpus/complete/README.md
+++ b/corpus/complete/README.md
@@ -61,6 +61,20 @@ test of the machine it runs on, so it states the _kind_ instead:
 which asserts that the implementation defers to the shell's own file completion rather than
 offering words of its own. What the filesystem then contains is not the corpus's business.
 
+## Vectors that expect nothing
+
+An empty expectation is almost always a spec that did not say what its author thought, so the
+corpus refuses one unless the vector says the silence is deliberate:
+
+```jsonc
+"expect": { "nothing": true }
+```
+
+The case that needs it is [`03-external-boundary.json`](03-external-boundary.json): past an
+`external_subcommand` catch-all the words belong to a program the spec does not describe, and
+offering the catch-all's own subcommands, flags or the working directory would answer about the
+wrong CLI. Offering nothing is the claim, path fallback included.
+
 ## Keeping it honest
 
 Every vector carries a `reference` label, defaulting to `agrees`, saying whether `usage-cli` —

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -67,6 +67,7 @@ export default defineConfig({
           { text: "Args and Flags", link: "/rust/args-and-flags" },
           { text: "Updating Values", link: "/rust/update-from" },
           { text: "Subcommands", link: "/rust/subcommands" },
+          { text: "Dynamic Commands", link: "/rust/dynamic-commands" },
           { text: "Dispatch", link: "/rust/dispatch" },
           { text: "Validation", link: "/rust/validation" },
           { text: "Help, Version, and Errors", link: "/rust/help" },

--- a/docs/rust/dynamic-commands.md
+++ b/docs/rust/dynamic-commands.md
@@ -18,6 +18,8 @@ are not modified, and normal parsing stays exactly as fast.
 [dependencies]
 usage = { package = "usage-rs", version = "6", features = ["completions"] }
 usage-dynamic = "6"
+# Any executor works; the example below uses futures' to answer completion requests.
+futures = "0.3"
 ```
 
 The `completions` feature is only needed for the completion half; help and parsing work
@@ -242,8 +244,9 @@ alias its spec declares.
 | `None`                   | No catalogued command matches that name.                                                                                                                           |
 
 `None` is not an error: do whatever the application did with unknown commands before it had
-plugins. Handle `Err(Error::NonUtf8)` the same way — the spec model is UTF-8 strings, but the
-captured `OsString`s are intact, so raw dispatch still works.
+plugins. Handle `Err(usage_dynamic::Error::NonUtf8)` the same way — the spec model is UTF-8
+strings, but the captured `OsString`s are intact, so raw dispatch still works. (This `Error` is
+the catalog's own type, not the parser's `usage::Error` from the example.)
 
 ## Help and completion
 

--- a/docs/rust/dynamic-commands.md
+++ b/docs/rust/dynamic-commands.md
@@ -6,15 +6,16 @@ it cannot discover plugin names from runtime configuration.
 
 Applications with a derived host and runtime-discovered commands can add the optional
 `usage-dynamic` companion crate. It keeps the host tables static and adds an owned catalog for
-two cold paths:
+a fully merged command tree on cold paths:
 
-- host help and command-name completion show discovered command names, aliases, summaries,
-  headings, visibility, and ordering;
+- host help can navigate runtime commands and their nested pages;
+- completion descends into runtime subcommands, flags, and declared choices;
 - argv already captured by an `external_subcommand` variant can be parsed generically from the
   corresponding supplied usage spec.
 
-The catalog does not mutate derived parse tables. Its summaries therefore do not change normal
-parse performance or `Cli::to_kdl()` output.
+The catalog does not mutate derived parse tables. The merged tree therefore does not change
+normal parse performance or `Cli::to_kdl()` output. `catalog.app().spec()` exposes the separate
+merged portable tree.
 
 ## Setup
 
@@ -70,7 +71,24 @@ let short_help = catalog.app().help("plugins", false).unwrap();
 ```
 
 Use `Catalog::builder(Ex::app()).root(spec)` when the derived root itself has the external
-catch-all. Multiple `root` and `under` calls add multiple entries.
+catch-all. That makes the supplied command a real top-level runtime command: if the spec is
+named `foo`, `ex foo` is captured for catalog parsing, `foo` appears in root help and completion,
+and `catalog.app().help("foo", false)` renders its page. Multiple `root` and `under` calls add
+multiple entries.
+
+For example, a host that accepts top-level plugins declares the catch-all directly in its root
+subcommand enum:
+
+```rust
+#[derive(Subcommands)]
+enum Commands {
+    Builtin,
+    #[usage(external_subcommand)]
+    External(Vec<OsString>),
+}
+
+let catalog = Catalog::builder(Ex::app()).root(foo_spec).build()?;
+```
 
 ## Dispatch
 
@@ -101,9 +119,10 @@ parent path, and `usage-lib`'s generic `ParseOutput`. Defaults and environment f
 applied by that parser. Input is accepted as `OsString`; non-UTF-8 input that the portable spec
 model cannot represent returns a structured error containing the token position.
 
-For completion requests, use `catalog.app().completion_app()`. The host offers runtime command
-names and visible aliases while selecting a subcommand. Once one is selected, deeper completion
-belongs to the plugin or application.
+For completion requests, use `catalog.app().completion_app()`. Completion walks the fully merged
+tree, including nested plugin commands, plugin flags, declared choices, and path hints. A
+spec-declared `run=` completer is not executed: the catalog performs no subprocess execution, so
+applications that want executable dynamic completers should delegate those requests explicitly.
 
 ## Catalog constraints
 
@@ -115,9 +134,6 @@ Catalog construction rejects ambiguous or unsafe trees:
 - empty names and aliases are invalid;
 - supplied specs must have every mount resolved already.
 
-The application owns discovery, caching, and refresh. `usage-dynamic` performs no callbacks,
-filesystem reads, or subprocess execution.
-
-This first version intentionally merges only command summaries into the host. It does not merge
-nested plugin pages or plugin flags into the derived tree. Plugin-specific help and version
-requests are instead returned as `Outcome::Help` and `Outcome::Version` after selection.
+The application owns discovery, caching, refresh, and handler registration. `usage-dynamic`
+performs no callbacks, filesystem reads, or subprocess execution. Plugin-specific parse help and
+version requests are also available as `Outcome::Help` and `Outcome::Version` after selection.

--- a/docs/rust/dynamic-commands.md
+++ b/docs/rust/dynamic-commands.md
@@ -4,14 +4,13 @@
 `usage-dynamic` is new. Its API may change ahead of the rest of the framework.
 :::
 
-A plugin manager does not know what `ex format` is until it has read its own configuration,
-which happens long after the tables describing the rest of its CLI were compiled. So `ex --help`
-never lists it, `ex format <TAB>` completes nothing, and `ex format --check` is a bag of
-unparsed words the application has to pick through itself.
+A plugin manager can't compile tables for commands it hasn't met. If `ex format` is a plugin
+the user installed yesterday, `ex --help` won't list it, `ex format <TAB>` completes nothing,
+and when it runs, the application receives raw words to interpret by hand.
 
-The `usage-dynamic` crate closes that gap without giving up the static tables. The application
-discovers plugins its own way and hands their specs to a **catalog**, which grafts them onto the
-compiled tree for the three things it cannot answer alone: help, completion, and parsing.
+`usage-dynamic` adds the three missing answers — help, completion, and parsing for
+runtime-discovered commands — without touching the static tables. The derive's parse tables,
+the KDL it emits, and normal parse performance stay exactly as they were.
 
 ```toml
 [dependencies]
@@ -19,26 +18,42 @@ usage = { package = "usage-rs", version = "6", features = ["completions"] }
 usage-dynamic = "6"
 ```
 
-The `completions` feature is what gives the host a completion surface for the catalog to extend;
-without it you still get help and parsing.
+The `completions` feature is what the completion half builds on; help and parsing work
+without it.
 
-Everything else stays where it was. The derive's parse tables are not touched, `Cli::to_kdl()`
-emits what it emitted before, and the ordinary parse path costs what it cost before. The
-catalog is consulted on cold paths only.
+Two responsibilities stay with the application, deliberately. It finds its plugins — a
+directory scan, a lockfile, a registry — and it decides when to look. `usage-dynamic` runs no
+subprocesses, reads no files, and calls nothing back.
 
-## What the application still owns
+## Built-in commands never pay for plugins
 
-`usage-dynamic` performs no callbacks, no filesystem reads, and no subprocess execution. Finding
-plugins, caching what they said, deciding when that cache is stale, and running the command
-afterwards are all the application's — which is the point, because only it knows whether a
-plugin lives in `~/.local/share`, what a stale cache costs, and whether a discovery pass is
-worth doing before rendering a help page.
+Discovery costs real work: directory scans, file reads, spec parses. Most invocations are
+built-in commands, so the design keeps that work off their path entirely:
 
-## A spec is a plugin's half of the contract
+1. `Ex::parse_from(argv)` runs against the static tables alone. A built-in command parses and
+   runs with no plugin discovered, loaded, or parsed.
+2. Words the tables don't recognize land in an `external_subcommand` catch-all. That is the
+   signal to go find plugins — after the parse, only on the invocations that need them.
+3. Help and completion do want plugin specs up front, but both are interactive: reading a
+   directory of KDL files is cheap next to rendering a page.
 
-A plugin describes itself in [KDL](/spec/reference/), the same format `usage` reads everywhere
-else. Whatever produces that text — a file next to the plugin, a `--usage` flag on it, a
-manifest — the application parses it into a `Spec`:
+The API's costs line up with that ordering:
+
+| Call                          | Cost                                             | Needs                 |
+| ----------------------------- | ------------------------------------------------ | --------------------- |
+| `Catalog::builder(…).build()` | validates names and parents; microseconds        | the specs you pass it |
+| `catalog.parse_external(…)`   | one parse of the captured argv, against one spec | the matched spec      |
+| `catalog.app()`               | merges the full command tree; once, then kept    | every catalogued spec |
+
+`app()` is the only expensive call, and only help and completion use it. A catalog built with a
+single plugin's spec is a complete dispatcher for that plugin — nothing requires loading the
+rest.
+
+## A plugin describes itself with a spec
+
+A plugin's half of the contract is a [usage spec](/spec/) in KDL — the same format everything
+else in usage reads. Where the text comes from is the application's convention: a file next to
+the plugin, a `--usage` flag on its binary, a field in a manifest. Parsing it gives a `Spec`:
 
 ```rust
 use usage_dynamic::Spec;
@@ -59,16 +74,17 @@ cmd "check" help="Check formatting" {
 }
 ```
 
-That spec is what the catalog renders help from, completes against, and parses with. A plugin
-that declares choices gets those choices completed; one that declares nothing gets a name in the
-list and no more.
+Everything the catalog does for a plugin comes from this spec: `about` is its line in the
+parent's help, `cmd` and `flag` and `choices` are what completion descends into, and the whole
+thing is what its argv parses against. A plugin that declares little gets little — a name in
+the list — which also means a cheap stub spec (`name` and `about` only) is enough to make a
+plugin _visible_ before its real spec has ever been loaded.
 
-## Declaring where runtime commands may appear
+## The host declares where plugins may appear
 
-A catalog does not graft commands anywhere it likes. It attaches them to a command that invited
-them, by declaring an
-[`external_subcommand`](/rust/subcommands#external-subcommands) catch-all — the variant that captures an unrecognized
-word and everything after it:
+Plugins attach to a command that opted in, by declaring an
+[`external_subcommand`](/rust/subcommands#external-subcommands) catch-all — the variant that
+captures an unrecognized word and everything after it:
 
 ```rust
 use std::ffi::OsString;
@@ -90,68 +106,87 @@ enum Commands {
 }
 ```
 
-The catch-all is what makes the arrangement honest: the parser already had to accept these
-words, and the catalog only explains what it accepted. A parent without one is rejected at
-construction rather than silently doing nothing.
+The catch-all matters because it means the parser was already going to accept these words; the
+catalog explains what was accepted rather than changing what parses. Attaching to a command
+without one is an error at `build()`.
 
-| Method                    | Where the command lands                                        |
-| ------------------------- | -------------------------------------------------------------- |
-| `.root(spec)`             | Top level. `ex format` runs it, and it appears in `ex --help`. |
-| `.under("plugins", spec)` | Beneath a static command. `ex plugins format` runs it.         |
+Each plugin spec is attached with one of two builder calls, repeated per plugin:
 
-Both take the command's name from the spec — `name "formatter"` becomes `format`'s counterpart
-`formatter` — and both may be called as many times as there are plugins. A path given to `under`
-may be spelled with a static alias; the catalog stores the canonical one.
+| Method                    | Result                                            |
+| ------------------------- | ------------------------------------------------- |
+| `.root(spec)`             | `ex formatter` — a top-level command              |
+| `.under("plugins", spec)` | `ex plugins formatter` — beneath a static command |
 
-## Putting it together
+The command's name is the spec's `name`. A path given to `under` may use a static command's
+alias, visible or hidden; the catalog stores the canonical spelling.
 
-`Cli::app()` is the derive-generated view of the static tables — the same thing that renders
-help and completion for a CLI with no plugins at all. The catalog wraps it, and the host's
-`main` routes three kinds of words: a completion request, the host's own commands, and whatever
-the catch-all captured.
+## A complete host
+
+This is `usage-dynamic/examples/host.rs`, compiled in CI. Built-ins run before any plugin
+exists; the three paths that need plugins — the catch-all, help, completion — each load them
+at the moment of use.
 
 ```rust
 use std::ffi::{OsStr, OsString};
-use usage_dynamic::{Catalog, Outcome};
-use usage::{Cli, Error};
+use usage_dynamic::{Catalog, Outcome, Spec};
+use usage::complete::{render, CompletionRequest};
+use usage::{Cli, Error, Subcommands};
+
+/// Discovery is the application's: scan a directory, read a lockfile, whatever fits.
+fn plugin_catalog() -> Catalog<'static> {
+    let mut builder = Catalog::builder(Ex::app());
+    for spec in discover_plugin_specs() {
+        builder = builder.root(spec);
+    }
+    builder.build().unwrap()
+}
 
 fn main() {
-    let catalog = Catalog::builder(Ex::app())
-        .root(load_plugin_spec("formatter"))
-        .build()
-        .unwrap();
-    let app = catalog.app().unwrap();
-
-    // A completion request is not a command anybody runs, so it is answered before the parse.
     let argv: Vec<OsString> = std::env::args_os().skip(1).collect();
-    if let Some(answer) = futures::executor::block_on(app.completion_request(&argv)) {
-        print!("{answer}");
+
+    // A completion request is not a command anybody runs, so it is recognized before the
+    // parse. It is also interactive: loading plugins here is affordable, and it is what puts
+    // their names in the answer.
+    if let Some(request) = CompletionRequest::parse(&argv) {
+        let catalog = plugin_catalog();
+        let answer = futures::executor::block_on(
+            catalog.app().unwrap().complete_request(&request),
+        );
+        print!("{}", render(&answer, request.shell));
         return;
     }
 
     let words: Vec<&OsStr> = argv.iter().map(OsString::as_os_str).collect();
     match Ex::parse_from(&words) {
+        // A built-in command runs with no plugin loaded. This is the hot path, and nothing on
+        // it knows plugins exist.
         Ok(Ex { command: Commands::Build }) => build(),
+
+        // The catch-all fired: now, and only now, load plugins.
         Ok(Ex { command: Commands::External(captured) }) => {
+            let catalog = plugin_catalog();
             match catalog.parse_external("", &captured) {
                 Ok(Some(Outcome::Parsed(parsed))) => run_plugin(&parsed.name, &parsed.output),
                 Ok(Some(Outcome::Help(help))) => print!("{}", help.page),
                 Ok(Some(Outcome::Version(version))) => println!("{}", version.version),
-                // `Outcome` is `#[non_exhaustive]`, so this arm is required — and it is where
-                // the two cases the host answers for itself land: a name nobody catalogued,
-                // and a token the spec model cannot represent. The argv is intact in both, so
-                // dispatch it the way this host dispatched unrecognized words all along.
+                // A name no loaded plugin answers to, or argv the spec model cannot
+                // represent. The words are untouched either way: handle them however this
+                // application handled unrecognized commands before it had plugins.
                 _ => fallback(&captured),
             }
         }
-        // The host's own help, rendered from the merged tree so that runtime commands appear
-        // on the page.
+
+        // Help is a cold path too. Render it through the catalog so plugins appear on the
+        // page; `usage::help::find` turns the command the parser stopped at into the path
+        // `help` takes.
         Err(Error::Help { cmd, long }) => {
+            let catalog = plugin_catalog();
             let path = usage::help::find(Ex::spec(), cmd)
                 .map(|(path, _)| path[1..].join(" "))
                 .unwrap_or_default();
-            print!("{}", app.help(&path, long).unwrap());
+            print!("{}", catalog.app().unwrap().help(&path, long).unwrap());
         }
+        Err(Error::Version { .. }) => println!("ex {}", env!("CARGO_PKG_VERSION")),
         Err(err) => {
             eprint!("{}", Ex::render_failure(&words, &err));
             std::process::exit(2);
@@ -160,54 +195,52 @@ fn main() {
 }
 ```
 
-Two things are deliberate. `parse_from` rather than the process-exiting `Cli::parse()`, because
-the application needs the argv in hand to answer completion and to route the captured words. And
-help rendered through `app` rather than `Ex::render_help`, because that is what makes a runtime
-command appear on the host's page — `usage::help::find` turns the command the parser stopped at
-into the path `help` takes.
+Note `parse_from`, not the process-exiting `Cli::parse()`: the application needs the argv in
+hand, and it needs help to render through the catalog rather than from the static tables, or
+plugins would vanish from the page.
 
-This example is `usage-dynamic/examples/host.rs`, kept compiling in CI.
+An application that can map a command name to its spec file — `plugins/<name>.usage.kdl`, say
+— can go further in the catch-all arm and load exactly one spec instead of all of them. Aliases
+are the caveat: a plugin invoked by an alias won't be found by a filename lookup on the typed
+word.
 
 ## Dispatch
 
-`parse_external` takes the path of the command the catch-all sits on — the empty string for the
-root — and the words it captured. The first word is the plugin's name, by any spelling it
-answers to.
+`catalog.parse_external(parent, argv)` takes the path of the command the catch-all sits on
+(`""` for the root) and the captured words. The first word is the plugin's name, by any
+spelling its spec declares.
 
-| Outcome                  | What happened                                                                                                                                                                                                                  |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `Some(Outcome::Parsed)`  | The words parsed against the plugin's spec. `parsed.output` is the usual `ParseOutput`, with defaults and environment fallbacks applied; `parsed.name` is the canonical name and `parsed.invoked_as` the alias actually typed. |
-| `Some(Outcome::Help)`    | The words asked for `--help`. `help.page` is the rendered page.                                                                                                                                                                |
-| `Some(Outcome::Version)` | The words asked for `--version`.                                                                                                                                                                                               |
-| `None`                   | No catalogued command answers to that name.                                                                                                                                                                                    |
+| Outcome                  | Meaning                                                                                                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `Some(Outcome::Parsed)`  | Parsed against the plugin's spec. `output` is a normal `ParseOutput` with defaults and env fallbacks applied; `name` is canonical, `invoked_as` is what was typed. |
+| `Some(Outcome::Help)`    | The words asked for `--help`; `page` is the rendered page.                                                                                                         |
+| `Some(Outcome::Version)` | The words asked for `--version`.                                                                                                                                   |
+| `None`                   | No catalogued command answers to that name.                                                                                                                        |
 
-`None` is not a failure — it is the case that keeps whatever fallback the host had before it
-grew a catalog. `Err(Error::NonUtf8)` deserves the same treatment: the portable spec model parses
-`String`s, and a token that is not one cannot be represented. The derive handed over `OsString`s,
-which lose nothing, so the words are still intact — dispatch them the way you dispatch `None`
-rather than failing a command whose argument happens to be an unusual path.
+`None` is not an error; it's the case that preserves whatever the host did with unrecognized
+words before it had plugins. Treat `Err(Error::NonUtf8)` the same way: the spec model parses
+`String`s and can't represent a non-UTF-8 token, but the captured `OsString`s are intact, so
+raw dispatch still works.
 
 ## Help and completion
 
-`catalog.app()` is the merged tree: the host's commands with the catalogued ones grafted in.
+`catalog.app()` merges the host's tree with every catalogued command. `app().help(path, long)`
+renders any page by path — the empty path is the root, `long` picks between the `-h` summary
+and the `--help` page — with plugin commands listed, ordered, and grouped under their
+`help_heading` like anything static.
 
-```rust
-let app = catalog.app()?;
-print!("{}", app.help("plugins formatter", false).unwrap());
-```
+Completion splits each line in two at the catch-all:
 
-`help` takes a command path, where the empty string is the root, and a `long` flag — `false` is
-what `-h` renders, `true` what `--help` does. Runtime commands are reachable by path like any
-other, nested pages included.
+- **Before it**, the words are the host's, and the host's own engine answers — registered
+  completers (sync and async), multicall projections, and `--candidates` requests all behave
+  exactly as they do without a catalog. Plugin names and visible aliases are added wherever a
+  subcommand belongs.
+- **After it**, the words are one plugin's, and that plugin's spec answers alone: its
+  subcommands, flags, and declared choices. A name no plugin answers to completes nothing —
+  not the host's flags, not the working directory.
 
-Completion is answered by two engines, and the seam is the catch-all. Up to it the words are the
-host's, and the host's own tables answer for them — so registered completers, multicall
-projections, and the `--candidates` half of the protocol all keep working, with catalogued names
-added wherever a subcommand belongs. Past it the words are a plugin's, and that plugin's spec
-answers alone: its subcommands, its flags, its declared choices.
-
-If the host registered runtime completers or a multicall projection, tell the builder, exactly as
-you would tell [`completion_app`](/rust/completions):
+If the host has runtime completers or a projection of its own, pass them to the builder — the
+same values `completion_app` would take:
 
 ```rust
 let catalog = Catalog::builder(Ex::app())
@@ -216,37 +249,28 @@ let catalog = Catalog::builder(Ex::app())
     .build()?;
 ```
 
-One thing the catalog will not do is run a spec's `run=` completer. That is a subprocess, and
-this crate spawns none — an application that wants executable completers should answer those
-requests itself.
+One deliberate hole: a `run=` completer declared in a plugin spec is a subprocess, and the
+catalog spawns none. Those requests return nothing; an application that wants them answers
+them itself.
 
-## What construction rejects
+## What `build()` rejects
 
-Building a catalog validates against the static tables, so a mistake is a `Result` at startup
-rather than a command that mysteriously does nothing:
+| Rejected                                                                         | Why                                                     |
+| -------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| A parent path that doesn't exist, or has no `external_subcommand` catch-all      | No words would ever reach the plugin                    |
+| A name or alias that collides — with a static command, another plugin, or `help` | Two commands can't answer to one word                   |
+| An empty name or alias                                                           | Nothing to type                                         |
+| A spec containing an unresolved `mount`                                          | Resolving one runs a subprocess; do it before attaching |
 
-| Rejected                                                                  | Because                                                           |
-| ------------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| A parent that does not exist, or declares no catch-all                    | Nothing would ever reach the grafted command.                     |
-| A name or alias colliding with a static command, another entry, or `help` | Two commands answering to one word is not resolvable.             |
-| An empty name or alias                                                    | Not a word anybody can type.                                      |
-| A supplied spec with an unresolved `mount`                                | Resolving one runs a subprocess, which is the application's call. |
+All of it is checked against the static tables at `build()`, so a bad configuration is a
+startup error instead of a command that silently does nothing.
 
-## Compared with `mount`
+## `mount` or a catalog?
 
-[`mount`](/rust/subcommands#mounts-and-restart-tokens) solves a neighbouring problem: it names a command that prints
-a spec, and the parser runs it during completion. Reach for it when one command's subcommands
-come from a subprocess the CLI is happy to spawn on a cold path — mise tasks are the case it was
-built for.
+[`mount`](/rust/subcommands#mounts-and-restart-tokens) covers a neighbouring case: one command
+whose subcommands come from a subprocess the parser may run during completion — mise tasks.
+If that's the shape, `mount` is less machinery.
 
-Reach for a catalog when the application already knows what its runtime commands are, or wants
-to decide for itself when to find out. A catalog runs nothing, caches nothing, and covers help
-and parsing as well as completion; `mount` covers completion and asks no questions.
-
-## What stays static
-
-Everything that was fast. The derive's parse tables are unchanged, so an ordinary command parses
-in the same nanoseconds it did before. `Cli::to_kdl()` emits the same spec, so nothing
-downstream of it learns about plugins it cannot see. The merged tree is assembled the first time
-something asks for it and not before — a CLI that only ever dispatches a plugin command never
-builds one at all.
+A catalog is for the application that already knows its runtime commands, or wants control
+over when to find out. It covers help and dispatch as well as completion, and it never runs
+anything.

--- a/docs/rust/dynamic-commands.md
+++ b/docs/rust/dynamic-commands.md
@@ -4,9 +4,9 @@
 `usage-dynamic` is new. Its API may change ahead of the rest of the framework.
 :::
 
-usage compiles a CLI's command tree at build time. A plugin manager doesn't have its full
-command tree at build time: plugins add commands, and which plugins are installed is only known
-at runtime. Out of the box those commands don't appear in `--help`, don't complete, and reach
+usage compiles a CLI's command tree at build time. A CLI that has plugins doesn't know its full
+command tree until runtime: plugins add commands, and which plugins are installed is only known
+by looking. Out of the box those commands don't appear in `--help`, don't complete, and reach
 the application as unparsed words.
 
 `usage-dynamic` handles this. The application loads a spec for each plugin and hands them to a

--- a/docs/rust/dynamic-commands.md
+++ b/docs/rust/dynamic-commands.md
@@ -4,13 +4,15 @@
 `usage-dynamic` is new. Its API may change ahead of the rest of the framework.
 :::
 
-A plugin manager can't compile tables for commands it hasn't met. If `ex format` is a plugin
-the user installed yesterday, `ex --help` won't list it, `ex format <TAB>` completes nothing,
-and when it runs, the application receives raw words to interpret by hand.
+usage compiles a CLI's command tree at build time. A plugin manager doesn't have its full
+command tree at build time: plugins add commands, and which plugins are installed is only known
+at runtime. Out of the box those commands don't appear in `--help`, don't complete, and reach
+the application as unparsed words.
 
-`usage-dynamic` adds the three missing answers — help, completion, and parsing for
-runtime-discovered commands — without touching the static tables. The derive's parse tables,
-the KDL it emits, and normal parse performance stay exactly as they were.
+`usage-dynamic` handles this. The application loads a spec for each plugin and hands them to a
+`Catalog`. The catalog merges them into the host's command tree for help and completion, and
+parses the argv a plugin command was invoked with. The derived parse tables and the emitted KDL
+are not modified, and normal parsing stays exactly as fast.
 
 ```toml
 [dependencies]
@@ -18,26 +20,27 @@ usage = { package = "usage-rs", version = "6", features = ["completions"] }
 usage-dynamic = "6"
 ```
 
-The `completions` feature is what the completion half builds on; help and parsing work
+The `completions` feature is only needed for the completion half; help and parsing work
 without it.
 
-Two responsibilities stay with the application, deliberately. It finds its plugins — a
-directory scan, a lockfile, a registry — and it decides when to look. `usage-dynamic` runs no
-subprocesses, reads no files, and calls nothing back.
+`usage-dynamic` does not discover anything itself: it runs no subprocesses, reads no files, and
+has no callbacks. The application finds its plugins — a directory scan, a lockfile, a registry
+— and decides when to look.
 
-## Built-in commands never pay for plugins
+## Plugins load only when needed
 
-Discovery costs real work: directory scans, file reads, spec parses. Most invocations are
-built-in commands, so the design keeps that work off their path entirely:
+Because loading plugins is expensive relative to running a built-in command — directory scans,
+file reads, spec parses — and most invocations never touch a plugin, the API is arranged so
+that work only happens when something needs it:
 
-1. `Ex::parse_from(argv)` runs against the static tables alone. A built-in command parses and
-   runs with no plugin discovered, loaded, or parsed.
-2. Words the tables don't recognize land in an `external_subcommand` catch-all. That is the
-   signal to go find plugins — after the parse, only on the invocations that need them.
-3. Help and completion do want plugin specs up front, but both are interactive: reading a
-   directory of KDL files is cheap next to rendering a page.
+1. Parse argv with the static tables first. A built-in command parses and runs without any
+   plugin being loaded.
+2. Words the tables don't recognize land in an `external_subcommand` catch-all. That's when to
+   load plugins: after the parse, only on the invocations that involve one.
+3. Help and completion do need the plugin list up front — but both are interactive, where
+   reading a directory of KDL files is cheap next to rendering a page.
 
-The API's costs line up with that ordering:
+The API's costs match that ordering:
 
 | Call                          | Cost                                             | Needs                 |
 | ----------------------------- | ------------------------------------------------ | --------------------- |
@@ -45,15 +48,15 @@ The API's costs line up with that ordering:
 | `catalog.parse_external(…)`   | one parse of the captured argv, against one spec | the matched spec      |
 | `catalog.app()`               | merges the full command tree; once, then kept    | every catalogued spec |
 
-`app()` is the only expensive call, and only help and completion use it. A catalog built with a
+`app()` is the only expensive call, and only help and completion use it. A catalog built from a
 single plugin's spec is a complete dispatcher for that plugin — nothing requires loading the
 rest.
 
-## A plugin describes itself with a spec
+## Plugin specs
 
-A plugin's half of the contract is a [usage spec](/spec/) in KDL — the same format everything
-else in usage reads. Where the text comes from is the application's convention: a file next to
-the plugin, a `--usage` flag on its binary, a field in a manifest. Parsing it gives a `Spec`:
+Each plugin provides a [usage spec](/spec/) in KDL, the same format used everywhere else in
+usage. How the text gets to the application is its own convention — a file next to the plugin,
+a `--usage` flag on its binary, a field in a manifest. Parse it into a `Spec`:
 
 ```rust
 use usage_dynamic::Spec;
@@ -74,15 +77,14 @@ cmd "check" help="Check formatting" {
 }
 ```
 
-Everything the catalog does for a plugin comes from this spec: `about` is its line in the
-parent's help, `cmd` and `flag` and `choices` are what completion descends into, and the whole
-thing is what its argv parses against. A plugin that declares little gets little — a name in
-the list — which also means a cheap stub spec (`name` and `about` only) is enough to make a
-plugin _visible_ before its real spec has ever been loaded.
+The spec is everything the catalog knows about a plugin: `about` becomes its summary in help,
+its commands, flags, and choices drive completion, and its argv parses against it. A minimal
+spec — just `name` and `about` — is enough for the plugin to show up in help and completion by
+name.
 
-## The host declares where plugins may appear
+## Declaring where plugins attach
 
-Plugins attach to a command that opted in, by declaring an
+Plugins attach beneath a command that declares an
 [`external_subcommand`](/rust/subcommands#external-subcommands) catch-all — the variant that
 captures an unrecognized word and everything after it:
 
@@ -106,25 +108,25 @@ enum Commands {
 }
 ```
 
-The catch-all matters because it means the parser was already going to accept these words; the
-catalog explains what was accepted rather than changing what parses. Attaching to a command
-without one is an error at `build()`.
+The catch-all is what makes the parser accept unknown words there in the first place; the
+catalog gives those words meaning without changing what parses. Attaching to a command without
+one is an error at `build()`.
 
-Each plugin spec is attached with one of two builder calls, repeated per plugin:
+Attach one spec per plugin, with either builder call:
 
 | Method                    | Result                                            |
 | ------------------------- | ------------------------------------------------- |
 | `.root(spec)`             | `ex formatter` — a top-level command              |
 | `.under("plugins", spec)` | `ex plugins formatter` — beneath a static command |
 
-The command's name is the spec's `name`. A path given to `under` may use a static command's
-alias, visible or hidden; the catalog stores the canonical spelling.
+The command's name comes from the spec's `name`. Paths given to `under` may use a static
+command's aliases; the catalog stores the canonical path.
 
 ## A complete host
 
-This is `usage-dynamic/examples/host.rs`, compiled in CI. Built-ins run before any plugin
-exists; the three paths that need plugins — the catch-all, help, completion — each load them
-at the moment of use.
+This example is `usage-dynamic/examples/host.rs` and compiles in CI. Built-in commands run
+without loading anything; the catch-all, help, and completion each load plugins at the moment
+of use.
 
 ```rust
 use std::ffi::{OsStr, OsString};
@@ -132,7 +134,7 @@ use usage_dynamic::{Catalog, Outcome, Spec};
 use usage::complete::{render, CompletionRequest};
 use usage::{Cli, Error, Subcommands};
 
-/// Discovery is the application's: scan a directory, read a lockfile, whatever fits.
+/// How plugins are found is up to the application: a directory scan, a lockfile, a registry.
 fn plugin_catalog() -> Catalog<'static> {
     let mut builder = Catalog::builder(Ex::app());
     for spec in discover_plugin_specs() {
@@ -144,40 +146,36 @@ fn plugin_catalog() -> Catalog<'static> {
 fn main() {
     let argv: Vec<OsString> = std::env::args_os().skip(1).collect();
 
-    // A completion request is not a command anybody runs, so it is recognized before the
-    // parse. It is also interactive: loading plugins here is affordable, and it is what puts
-    // their names in the answer.
+    // Completion requests are recognized before the parse. They are interactive, so loading
+    // plugins here is affordable — and it is what puts plugin names in the answer.
     if let Some(request) = CompletionRequest::parse(&argv) {
         let catalog = plugin_catalog();
-        let answer = futures::executor::block_on(
-            catalog.app().unwrap().complete_request(&request),
-        );
+        let answer =
+            futures::executor::block_on(catalog.app().unwrap().complete_request(&request));
         print!("{}", render(&answer, request.shell));
         return;
     }
 
     let words: Vec<&OsStr> = argv.iter().map(OsString::as_os_str).collect();
     match Ex::parse_from(&words) {
-        // A built-in command runs with no plugin loaded. This is the hot path, and nothing on
-        // it knows plugins exist.
+        // Built-in commands run without loading any plugin.
         Ok(Ex { command: Commands::Build }) => build(),
 
-        // The catch-all fired: now, and only now, load plugins.
+        // The words named something the static tables don't know. Load plugins now.
         Ok(Ex { command: Commands::External(captured) }) => {
             let catalog = plugin_catalog();
             match catalog.parse_external("", &captured) {
                 Ok(Some(Outcome::Parsed(parsed))) => run_plugin(&parsed.name, &parsed.output),
                 Ok(Some(Outcome::Help(help))) => print!("{}", help.page),
                 Ok(Some(Outcome::Version(version))) => println!("{}", version.version),
-                // A name no loaded plugin answers to, or argv the spec model cannot
-                // represent. The words are untouched either way: handle them however this
-                // application handled unrecognized commands before it had plugins.
+                // No loaded plugin matches, or the argv is not UTF-8. The captured words are
+                // untouched — handle them like any unknown command.
                 _ => fallback(&captured),
             }
         }
 
-        // Help is a cold path too. Render it through the catalog so plugins appear on the
-        // page; `usage::help::find` turns the command the parser stopped at into the path
+        // Render help through the catalog so plugin commands appear on the page.
+        // `usage::help::find` converts the command the parser stopped at into the path
         // `help` takes.
         Err(Error::Help { cmd, long }) => {
             let catalog = plugin_catalog();
@@ -195,52 +193,47 @@ fn main() {
 }
 ```
 
-Note `parse_from`, not the process-exiting `Cli::parse()`: the application needs the argv in
-hand, and it needs help to render through the catalog rather than from the static tables, or
-plugins would vanish from the page.
+Use `parse_from`, not the process-exiting `Cli::parse()`: `parse()` renders help from the
+static tables and exits, so plugin commands would never appear on the page. Rendering help
+through the catalog is what adds them.
 
-An application that can map a command name to its spec file — `plugins/<name>.usage.kdl`, say
-— can go further in the catch-all arm and load exactly one spec instead of all of them. Aliases
-are the caveat: a plugin invoked by an alias won't be found by a filename lookup on the typed
-word.
+If the application can map a command name to its spec file — `plugins/<name>.usage.kdl` — the
+catch-all arm can load just that one spec instead of all of them. Watch out for aliases: a
+plugin invoked by an alias won't be found by a filename lookup on the typed word.
 
 ## Dispatch
 
-`catalog.parse_external(parent, argv)` takes the path of the command the catch-all sits on
-(`""` for the root) and the captured words. The first word is the plugin's name, by any
-spelling its spec declares.
+`catalog.parse_external(parent, argv)` takes the path of the command with the catch-all (`""`
+for the root) and the captured words. The first word selects the plugin, by its name or any
+alias its spec declares.
 
 | Outcome                  | Meaning                                                                                                                                                            |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `Some(Outcome::Parsed)`  | Parsed against the plugin's spec. `output` is a normal `ParseOutput` with defaults and env fallbacks applied; `name` is canonical, `invoked_as` is what was typed. |
 | `Some(Outcome::Help)`    | The words asked for `--help`; `page` is the rendered page.                                                                                                         |
 | `Some(Outcome::Version)` | The words asked for `--version`.                                                                                                                                   |
-| `None`                   | No catalogued command answers to that name.                                                                                                                        |
+| `None`                   | No catalogued command matches that name.                                                                                                                           |
 
-`None` is not an error; it's the case that preserves whatever the host did with unrecognized
-words before it had plugins. Treat `Err(Error::NonUtf8)` the same way: the spec model parses
-`String`s and can't represent a non-UTF-8 token, but the captured `OsString`s are intact, so
-raw dispatch still works.
+`None` is not an error: do whatever the application did with unknown commands before it had
+plugins. Handle `Err(Error::NonUtf8)` the same way — the spec model is UTF-8 strings, but the
+captured `OsString`s are intact, so raw dispatch still works.
 
 ## Help and completion
 
-`catalog.app()` merges the host's tree with every catalogued command. `app().help(path, long)`
-renders any page by path — the empty path is the root, `long` picks between the `-h` summary
-and the `--help` page — with plugin commands listed, ordered, and grouped under their
-`help_heading` like anything static.
+`catalog.app()` returns the merged tree. `app().help(path, long)` renders any command's page by
+path — the empty path is the root, `long` selects the `--help` page over the `-h` summary —
+with plugin commands sorted and grouped under their `help_heading` like static ones.
 
-Completion splits each line in two at the catch-all:
+Completion splits the line at the catch-all:
 
-- **Before it**, the words are the host's, and the host's own engine answers — registered
-  completers (sync and async), multicall projections, and `--candidates` requests all behave
-  exactly as they do without a catalog. Plugin names and visible aliases are added wherever a
-  subcommand belongs.
-- **After it**, the words are one plugin's, and that plugin's spec answers alone: its
-  subcommands, flags, and declared choices. A name no plugin answers to completes nothing —
-  not the host's flags, not the working directory.
+- **Before it**, the host's own completion engine answers. Registered completers (sync and
+  async), multicall projections, and `--candidates` requests work exactly as they do without a
+  catalog, and plugin names and visible aliases are offered wherever a subcommand could go.
+- **After it**, the matched plugin's spec answers: its subcommands, flags, and declared
+  choices. An unknown name completes nothing — no host flags, no file fallback.
 
 If the host has runtime completers or a projection of its own, pass them to the builder — the
-same values `completion_app` would take:
+same values `completion_app` takes:
 
 ```rust
 let catalog = Catalog::builder(Ex::app())
@@ -249,9 +242,8 @@ let catalog = Catalog::builder(Ex::app())
     .build()?;
 ```
 
-One deliberate hole: a `run=` completer declared in a plugin spec is a subprocess, and the
-catalog spawns none. Those requests return nothing; an application that wants them answers
-them itself.
+The catalog never executes a `run=` completer from a plugin spec — that's a subprocess. Those
+requests return nothing; answer them in the application if you want them.
 
 ## What `build()` rejects
 
@@ -262,15 +254,14 @@ them itself.
 | An empty name or alias                                                           | Nothing to type                                         |
 | A spec containing an unresolved `mount`                                          | Resolving one runs a subprocess; do it before attaching |
 
-All of it is checked against the static tables at `build()`, so a bad configuration is a
-startup error instead of a command that silently does nothing.
+Every check runs against the static tables at `build()`, so a bad configuration fails at
+startup instead of producing a command that silently does nothing.
 
 ## `mount` or a catalog?
 
-[`mount`](/rust/subcommands#mounts-and-restart-tokens) covers a neighbouring case: one command
-whose subcommands come from a subprocess the parser may run during completion — mise tasks.
-If that's the shape, `mount` is less machinery.
+[`mount`](/rust/subcommands#mounts-and-restart-tokens) handles a related case: one command
+whose subcommands come from a subprocess the parser is allowed to run during completion — mise
+tasks. If that's the shape, `mount` is less machinery.
 
-A catalog is for the application that already knows its runtime commands, or wants control
-over when to find out. It covers help and dispatch as well as completion, and it never runs
-anything.
+A catalog is for applications that manage the specs themselves, or want control over when
+loading happens. It also covers help and dispatch, and it never runs anything.

--- a/docs/rust/dynamic-commands.md
+++ b/docs/rust/dynamic-commands.md
@@ -1,0 +1,123 @@
+# Dynamic command catalogs
+
+`usage-rs` normally compiles the entire command tree into static parse tables. That is the
+fast path: it is a good fit when the commands are known while the application is compiled, but
+it cannot discover plugin names from runtime configuration.
+
+Applications with a derived host and runtime-discovered commands can add the optional
+`usage-dynamic` companion crate. It keeps the host tables static and adds an owned catalog for
+two cold paths:
+
+- host help and command-name completion show discovered command names, aliases, summaries,
+  headings, visibility, and ordering;
+- argv already captured by an `external_subcommand` variant can be parsed generically from the
+  corresponding supplied usage spec.
+
+The catalog does not mutate derived parse tables. Its summaries therefore do not change normal
+parse performance or `Cli::to_kdl()` output.
+
+## Setup
+
+```toml
+[dependencies]
+usage = { package = "usage-rs", version = "6", features = ["completions"] }
+usage-dynamic = "6"
+```
+
+Declare an external catch-all where runtime commands may appear:
+
+```rust
+use std::ffi::OsString;
+use usage::{Cli, Subcommands};
+
+#[derive(Cli)]
+#[usage(bin = "ex")]
+struct Ex {
+    #[usage(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommands)]
+enum Commands {
+    Plugins {
+        #[usage(subcommand)]
+        command: PluginCommands,
+    },
+}
+
+#[derive(Subcommands)]
+enum PluginCommands {
+    List,
+    #[usage(external_subcommand)]
+    External(Vec<OsString>),
+}
+```
+
+Load and cache plugin specs in application code, then build the catalog. A parent path may use
+a static alias; the catalog normalizes it to the canonical path.
+
+```rust
+use usage_dynamic::{Catalog, Outcome, Spec};
+
+# fn example(formatter_spec: Spec) -> Result<(), usage_dynamic::Error> {
+let catalog = Catalog::builder(Ex::app())
+    .under("plugins", formatter_spec)
+    .build()?;
+
+let short_help = catalog.app().help("plugins", false).unwrap();
+# Ok(())
+# }
+```
+
+Use `Catalog::builder(Ex::app()).root(spec)` when the derived root itself has the external
+catch-all. Multiple `root` and `under` calls add multiple entries.
+
+## Dispatch
+
+Parse the host with `parse_from`, then hand the captured vector to the catalog. Do not use the
+process-exiting `Cli::parse()` entry point: the application needs to route host help and
+completion through `catalog.app()` and inspect the catalog's typed dynamic outcomes.
+
+```rust
+# use std::ffi::{OsStr, OsString};
+# use usage_dynamic::{Catalog, Outcome};
+# fn dispatch(catalog: &Catalog<'_>, external: &[OsString]) -> Result<(), usage_dynamic::Error> {
+match catalog.parse_external("plugins", external)? {
+    Some(Outcome::Parsed(parsed)) => {
+        // Dispatch `parsed.name` using `parsed.output`.
+    }
+    Some(Outcome::Help(help)) => print!("{}", help.page),
+    Some(Outcome::Version(version)) => println!("{}", version.version),
+    None => {
+        // The name was not catalogued. Preserve arbitrary fallback dispatch here.
+    }
+}
+# Ok(())
+# }
+```
+
+`Parsed` includes the canonical plugin name, the alias actually invoked, its canonical static
+parent path, and `usage-lib`'s generic `ParseOutput`. Defaults and environment fallbacks are
+applied by that parser. Input is accepted as `OsString`; non-UTF-8 input that the portable spec
+model cannot represent returns a structured error containing the token position.
+
+For completion requests, use `catalog.app().completion_app()`. The host offers runtime command
+names and visible aliases while selecting a subcommand. Once one is selected, deeper completion
+belongs to the plugin or application.
+
+## Catalog constraints
+
+Catalog construction rejects ambiguous or unsafe trees:
+
+- the static parent must exist and declare an external-subcommand catch-all;
+- plugin names and aliases cannot collide with static commands, other catalog entries, or the
+  synthetic `help` command;
+- empty names and aliases are invalid;
+- supplied specs must have every mount resolved already.
+
+The application owns discovery, caching, and refresh. `usage-dynamic` performs no callbacks,
+filesystem reads, or subprocess execution.
+
+This first version intentionally merges only command summaries into the host. It does not merge
+nested plugin pages or plugin flags into the derived tree. Plugin-specific help and version
+requests are instead returned as `Outcome::Help` and `Outcome::Version` after selection.

--- a/docs/rust/dynamic-commands.md
+++ b/docs/rust/dynamic-commands.md
@@ -1,23 +1,17 @@
-# Dynamic command catalogs
+# Dynamic Commands
 
-`usage-rs` normally compiles the entire command tree into static parse tables. That is the
-fast path: it is a good fit when the commands are known while the application is compiled, but
-it cannot discover plugin names from runtime configuration.
+::: warning Experimental
+`usage-dynamic` is new. Its API may change ahead of the rest of the framework.
+:::
 
-Applications with a derived host and runtime-discovered commands can add the optional
-`usage-dynamic` companion crate. It keeps the host tables static and adds an owned catalog for
-a fully merged command tree on cold paths:
+A plugin manager does not know what `ex format` is until it has read its own configuration,
+which happens long after the tables describing the rest of its CLI were compiled. So `ex --help`
+never lists it, `ex format <TAB>` completes nothing, and `ex format --check` is a bag of
+unparsed words the application has to pick through itself.
 
-- host help can navigate runtime commands and their nested pages;
-- completion descends into runtime subcommands, flags, and declared choices;
-- argv already captured by an `external_subcommand` variant can be parsed generically from the
-  corresponding supplied usage spec.
-
-The catalog does not mutate derived parse tables. The merged tree therefore does not change
-normal parse performance or `Cli::to_kdl()` output. `catalog.app().spec()` exposes the separate
-merged portable tree.
-
-## Setup
+The `usage-dynamic` crate closes that gap without giving up the static tables. The application
+discovers plugins its own way and hands their specs to a **catalog**, which grafts them onto the
+compiled tree for the three things it cannot answer alone: help, completion, and parsing.
 
 ```toml
 [dependencies]
@@ -25,7 +19,56 @@ usage = { package = "usage-rs", version = "6", features = ["completions"] }
 usage-dynamic = "6"
 ```
 
-Declare an external catch-all where runtime commands may appear:
+The `completions` feature is what gives the host a completion surface for the catalog to extend;
+without it you still get help and parsing.
+
+Everything else stays where it was. The derive's parse tables are not touched, `Cli::to_kdl()`
+emits what it emitted before, and the ordinary parse path costs what it cost before. The
+catalog is consulted on cold paths only.
+
+## What the application still owns
+
+`usage-dynamic` performs no callbacks, no filesystem reads, and no subprocess execution. Finding
+plugins, caching what they said, deciding when that cache is stale, and running the command
+afterwards are all the application's — which is the point, because only it knows whether a
+plugin lives in `~/.local/share`, what a stale cache costs, and whether a discovery pass is
+worth doing before rendering a help page.
+
+## A spec is a plugin's half of the contract
+
+A plugin describes itself in [KDL](/spec/reference/), the same format `usage` reads everywhere
+else. Whatever produces that text — a file next to the plugin, a `--usage` flag on it, a
+manifest — the application parses it into a `Spec`:
+
+```rust
+use usage_dynamic::Spec;
+
+let formatter: Spec = std::fs::read_to_string("plugins/formatter.usage.kdl")?.parse()?;
+```
+
+```kdl
+name "formatter"
+bin "formatter"
+about "Format a project"
+flag "--color <WHEN>" {
+    choices "always" "never"
+}
+arg "[path]"
+cmd "check" help="Check formatting" {
+    flag "--fix" help="Apply fixes"
+}
+```
+
+That spec is what the catalog renders help from, completes against, and parses with. A plugin
+that declares choices gets those choices completed; one that declares nothing gets a name in the
+list and no more.
+
+## Declaring where runtime commands may appear
+
+A catalog does not graft commands anywhere it likes. It attaches them to a command that invited
+them, by declaring an
+[`external_subcommand`](/rust/subcommands#external-subcommands) catch-all — the variant that captures an unrecognized
+word and everything after it:
 
 ```rust
 use std::ffi::OsString;
@@ -40,100 +83,170 @@ struct Ex {
 
 #[derive(Subcommands)]
 enum Commands {
-    Plugins {
-        #[usage(subcommand)]
-        command: PluginCommands,
-    },
-}
-
-#[derive(Subcommands)]
-enum PluginCommands {
-    List,
+    /// Built into ex
+    Build,
     #[usage(external_subcommand)]
     External(Vec<OsString>),
 }
 ```
 
-Load and cache plugin specs in application code, then build the catalog. A parent path may use
-a static alias; the catalog normalizes it to the canonical path.
+The catch-all is what makes the arrangement honest: the parser already had to accept these
+words, and the catalog only explains what it accepted. A parent without one is rejected at
+construction rather than silently doing nothing.
+
+| Method                    | Where the command lands                                        |
+| ------------------------- | -------------------------------------------------------------- |
+| `.root(spec)`             | Top level. `ex format` runs it, and it appears in `ex --help`. |
+| `.under("plugins", spec)` | Beneath a static command. `ex plugins format` runs it.         |
+
+Both take the command's name from the spec — `name "formatter"` becomes `format`'s counterpart
+`formatter` — and both may be called as many times as there are plugins. A path given to `under`
+may be spelled with a static alias; the catalog stores the canonical one.
+
+## Putting it together
+
+`Cli::app()` is the derive-generated view of the static tables — the same thing that renders
+help and completion for a CLI with no plugins at all. The catalog wraps it, and the host's
+`main` routes three kinds of words: a completion request, the host's own commands, and whatever
+the catch-all captured.
 
 ```rust
-use usage_dynamic::{Catalog, Outcome, Spec};
+use std::ffi::{OsStr, OsString};
+use usage_dynamic::{Catalog, Outcome};
+use usage::{Cli, Error};
 
-# fn example(formatter_spec: Spec) -> Result<(), usage_dynamic::Error> {
-let catalog = Catalog::builder(Ex::app())
-    .under("plugins", formatter_spec)
-    .build()?;
+fn main() {
+    let catalog = Catalog::builder(Ex::app())
+        .root(load_plugin_spec("formatter"))
+        .build()
+        .unwrap();
+    let app = catalog.app().unwrap();
 
-let short_help = catalog.app().help("plugins", false).unwrap();
-# Ok(())
-# }
-```
+    // A completion request is not a command anybody runs, so it is answered before the parse.
+    let argv: Vec<OsString> = std::env::args_os().skip(1).collect();
+    if let Some(answer) = futures::executor::block_on(app.completion_request(&argv)) {
+        print!("{answer}");
+        return;
+    }
 
-Use `Catalog::builder(Ex::app()).root(spec)` when the derived root itself has the external
-catch-all. That makes the supplied command a real top-level runtime command: if the spec is
-named `foo`, `ex foo` is captured for catalog parsing, `foo` appears in root help and completion,
-and `catalog.app().help("foo", false)` renders its page. Multiple `root` and `under` calls add
-multiple entries.
-
-For example, a host that accepts top-level plugins declares the catch-all directly in its root
-subcommand enum:
-
-```rust
-#[derive(Subcommands)]
-enum Commands {
-    Builtin,
-    #[usage(external_subcommand)]
-    External(Vec<OsString>),
+    let words: Vec<&OsStr> = argv.iter().map(OsString::as_os_str).collect();
+    match Ex::parse_from(&words) {
+        Ok(Ex { command: Commands::Build }) => build(),
+        Ok(Ex { command: Commands::External(captured) }) => {
+            match catalog.parse_external("", &captured) {
+                Ok(Some(Outcome::Parsed(parsed))) => run_plugin(&parsed.name, &parsed.output),
+                Ok(Some(Outcome::Help(help))) => print!("{}", help.page),
+                Ok(Some(Outcome::Version(version))) => println!("{}", version.version),
+                // `Outcome` is `#[non_exhaustive]`, so this arm is required — and it is where
+                // the two cases the host answers for itself land: a name nobody catalogued,
+                // and a token the spec model cannot represent. The argv is intact in both, so
+                // dispatch it the way this host dispatched unrecognized words all along.
+                _ => fallback(&captured),
+            }
+        }
+        // The host's own help, rendered from the merged tree so that runtime commands appear
+        // on the page.
+        Err(Error::Help { cmd, long }) => {
+            let path = usage::help::find(Ex::spec(), cmd)
+                .map(|(path, _)| path[1..].join(" "))
+                .unwrap_or_default();
+            print!("{}", app.help(&path, long).unwrap());
+        }
+        Err(err) => {
+            eprint!("{}", Ex::render_failure(&words, &err));
+            std::process::exit(2);
+        }
+    }
 }
-
-let catalog = Catalog::builder(Ex::app()).root(foo_spec).build()?;
 ```
+
+Two things are deliberate. `parse_from` rather than the process-exiting `Cli::parse()`, because
+the application needs the argv in hand to answer completion and to route the captured words. And
+help rendered through `app` rather than `Ex::render_help`, because that is what makes a runtime
+command appear on the host's page — `usage::help::find` turns the command the parser stopped at
+into the path `help` takes.
+
+This example is `usage-dynamic/examples/host.rs`, kept compiling in CI.
 
 ## Dispatch
 
-Parse the host with `parse_from`, then hand the captured vector to the catalog. Do not use the
-process-exiting `Cli::parse()` entry point: the application needs to route host help and
-completion through `catalog.app()` and inspect the catalog's typed dynamic outcomes.
+`parse_external` takes the path of the command the catch-all sits on — the empty string for the
+root — and the words it captured. The first word is the plugin's name, by any spelling it
+answers to.
+
+| Outcome                  | What happened                                                                                                                                                                                                                  |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `Some(Outcome::Parsed)`  | The words parsed against the plugin's spec. `parsed.output` is the usual `ParseOutput`, with defaults and environment fallbacks applied; `parsed.name` is the canonical name and `parsed.invoked_as` the alias actually typed. |
+| `Some(Outcome::Help)`    | The words asked for `--help`. `help.page` is the rendered page.                                                                                                                                                                |
+| `Some(Outcome::Version)` | The words asked for `--version`.                                                                                                                                                                                               |
+| `None`                   | No catalogued command answers to that name.                                                                                                                                                                                    |
+
+`None` is not a failure — it is the case that keeps whatever fallback the host had before it
+grew a catalog. `Err(Error::NonUtf8)` deserves the same treatment: the portable spec model parses
+`String`s, and a token that is not one cannot be represented. The derive handed over `OsString`s,
+which lose nothing, so the words are still intact — dispatch them the way you dispatch `None`
+rather than failing a command whose argument happens to be an unusual path.
+
+## Help and completion
+
+`catalog.app()` is the merged tree: the host's commands with the catalogued ones grafted in.
 
 ```rust
-# use std::ffi::{OsStr, OsString};
-# use usage_dynamic::{Catalog, Outcome};
-# fn dispatch(catalog: &Catalog<'_>, external: &[OsString]) -> Result<(), usage_dynamic::Error> {
-match catalog.parse_external("plugins", external)? {
-    Some(Outcome::Parsed(parsed)) => {
-        // Dispatch `parsed.name` using `parsed.output`.
-    }
-    Some(Outcome::Help(help)) => print!("{}", help.page),
-    Some(Outcome::Version(version)) => println!("{}", version.version),
-    None => {
-        // The name was not catalogued. Preserve arbitrary fallback dispatch here.
-    }
-}
-# Ok(())
-# }
+let app = catalog.app()?;
+print!("{}", app.help("plugins formatter", false).unwrap());
 ```
 
-`Parsed` includes the canonical plugin name, the alias actually invoked, its canonical static
-parent path, and `usage-lib`'s generic `ParseOutput`. Defaults and environment fallbacks are
-applied by that parser. Input is accepted as `OsString`; non-UTF-8 input that the portable spec
-model cannot represent returns a structured error containing the token position.
+`help` takes a command path, where the empty string is the root, and a `long` flag — `false` is
+what `-h` renders, `true` what `--help` does. Runtime commands are reachable by path like any
+other, nested pages included.
 
-For completion requests, use `catalog.app().completion_app()`. Completion walks the fully merged
-tree, including nested plugin commands, plugin flags, declared choices, and path hints. A
-spec-declared `run=` completer is not executed: the catalog performs no subprocess execution, so
-applications that want executable dynamic completers should delegate those requests explicitly.
+Completion is answered by two engines, and the seam is the catch-all. Up to it the words are the
+host's, and the host's own tables answer for them — so registered completers, multicall
+projections, and the `--candidates` half of the protocol all keep working, with catalogued names
+added wherever a subcommand belongs. Past it the words are a plugin's, and that plugin's spec
+answers alone: its subcommands, its flags, its declared choices.
 
-## Catalog constraints
+If the host registered runtime completers or a multicall projection, tell the builder, exactly as
+you would tell [`completion_app`](/rust/completions):
 
-Catalog construction rejects ambiguous or unsafe trees:
+```rust
+let catalog = Catalog::builder(Ex::app())
+    .completions(&OVERLAYS)
+    .root(spec)
+    .build()?;
+```
 
-- the static parent must exist and declare an external-subcommand catch-all;
-- plugin names and aliases cannot collide with static commands, other catalog entries, or the
-  synthetic `help` command;
-- empty names and aliases are invalid;
-- supplied specs must have every mount resolved already.
+One thing the catalog will not do is run a spec's `run=` completer. That is a subprocess, and
+this crate spawns none — an application that wants executable completers should answer those
+requests itself.
 
-The application owns discovery, caching, refresh, and handler registration. `usage-dynamic`
-performs no callbacks, filesystem reads, or subprocess execution. Plugin-specific parse help and
-version requests are also available as `Outcome::Help` and `Outcome::Version` after selection.
+## What construction rejects
+
+Building a catalog validates against the static tables, so a mistake is a `Result` at startup
+rather than a command that mysteriously does nothing:
+
+| Rejected                                                                  | Because                                                           |
+| ------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| A parent that does not exist, or declares no catch-all                    | Nothing would ever reach the grafted command.                     |
+| A name or alias colliding with a static command, another entry, or `help` | Two commands answering to one word is not resolvable.             |
+| An empty name or alias                                                    | Not a word anybody can type.                                      |
+| A supplied spec with an unresolved `mount`                                | Resolving one runs a subprocess, which is the application's call. |
+
+## Compared with `mount`
+
+[`mount`](/rust/subcommands#mounts-and-restart-tokens) solves a neighbouring problem: it names a command that prints
+a spec, and the parser runs it during completion. Reach for it when one command's subcommands
+come from a subprocess the CLI is happy to spawn on a cold path — mise tasks are the case it was
+built for.
+
+Reach for a catalog when the application already knows what its runtime commands are, or wants
+to decide for itself when to find out. A catalog runs nothing, caches nothing, and covers help
+and parsing as well as completion; `mount` covers completion and asks no questions.
+
+## What stays static
+
+Everything that was fast. The derive's parse tables are unchanged, so an ordinary command parses
+in the same nanoseconds it did before. `Cli::to_kdl()` emits the same spec, so nothing
+downstream of it learns about plugins it cannot see. The merged tree is assembled the first time
+something asks for it and not before — a CLI that only ever dispatches a plugin command never
+builds one at all.

--- a/docs/rust/dynamic-commands.md
+++ b/docs/rust/dynamic-commands.md
@@ -82,6 +82,33 @@ its commands, flags, and choices drive completion, and its argv parses against i
 spec — just `name` and `about` — is enough for the plugin to show up in help and completion by
 name.
 
+KDL is the format for commands that come from _outside_ the process — it's what a plugin binary
+can print and any language can produce. For commands the application itself defines at runtime,
+such as tasks read from a config file, don't render KDL just to parse it back: build the
+command directly and convert it. `Spec: From<SpecCommand>` takes the command's `name` as the
+spec's name and its `help` as the `about`:
+
+```rust
+use usage_dynamic::{Spec, SpecArgBuilder, SpecCommandBuilder, SpecFlagBuilder};
+
+let task: Spec = SpecCommandBuilder::new()
+    .name("deploy")
+    .help("Deploy the project")
+    .flag(
+        SpecFlagBuilder::new()
+            .name("env")
+            .long("env")
+            .arg(SpecArgBuilder::new().name("ENV").build())
+            .help("Target environment")
+            .build(),
+    )
+    .build()
+    .into();
+```
+
+Either origin behaves identically from here on — the catalog doesn't know or care which one
+produced a spec.
+
 ## Declaring where plugins attach
 
 Plugins attach beneath a command that declares an

--- a/docs/rust/index.md
+++ b/docs/rust/index.md
@@ -72,13 +72,14 @@ derive's compiler, which runs at build time ([comparison with clap](/rust/migrat
 `usage-rs` is a facade. Applications should depend on it alone. The split underneath stays
 available for low-level adopters that want a thinner surface:
 
-| Crate          | Role                                                                                                                 |
-| -------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `usage-rs`     | The one package an application depends on; re-exports the whole runtime                                              |
-| `usage-derive` | The derive macros: `Cli`, `Args`, `Subcommands`, `ValueEnum`, `ArgGroup`, and `Config` (behind the `config` feature) |
-| `usage-argv`   | The zero-allocation, zero-dependency runtime the derive emits code against                                           |
-| `usage-test`   | Test helpers: what a command line parses to, what a page says, what a shell is offered                               |
-| `usage-config` | Layered settings resolution with provenance ([Configuration](/rust/configuration))                                   |
+| Crate           | Role                                                                                                                 |
+| --------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `usage-rs`      | The one package an application depends on; re-exports the whole runtime                                              |
+| `usage-derive`  | The derive macros: `Cli`, `Args`, `Subcommands`, `ValueEnum`, `ArgGroup`, and `Config` (behind the `config` feature) |
+| `usage-argv`    | The zero-allocation, zero-dependency runtime the derive emits code against                                           |
+| `usage-test`    | Test helpers: what a command line parses to, what a page says, what a shell is offered                               |
+| `usage-config`  | Layered settings resolution with provenance ([Configuration](/rust/configuration))                                   |
+| `usage-dynamic` | Opt-in runtime command catalogs for plugin-aware derived hosts ([Dynamic commands](/rust/dynamic-commands))          |
 
 ### Cargo features
 
@@ -150,6 +151,7 @@ how to opt out of the endpoint.
 - [Args and flags](/rust/args-and-flags) — field types, attributes, env vars, defaults
 - [Updating values](/rust/update-from) — merge another command line into an existing value
 - [Subcommands](/rust/subcommands) — command enums, nesting, `flatten`, value enums
+- [Dynamic commands](/rust/dynamic-commands) — add runtime-discovered plugin summaries and generic parsing
 - [Dispatch](/rust/dispatch) — `Run`, `RunWith`, the async pair, and the generated `match`
 - [Validation](/rust/validation) — choices, groups, `exclusive`, `delimiter`, conflicts, portable `validate`
 - [Help, version, and errors](/rust/help) — what the parser renders and how to hook it

--- a/docs/rust/index.md
+++ b/docs/rust/index.md
@@ -151,7 +151,7 @@ how to opt out of the endpoint.
 - [Args and flags](/rust/args-and-flags) — field types, attributes, env vars, defaults
 - [Updating values](/rust/update-from) — merge another command line into an existing value
 - [Subcommands](/rust/subcommands) — command enums, nesting, `flatten`, value enums
-- [Dynamic commands](/rust/dynamic-commands) — add runtime-discovered plugin summaries and generic parsing
+- [Dynamic commands](/rust/dynamic-commands) — merge runtime-discovered plugins into help and completion
 - [Dispatch](/rust/dispatch) — `Run`, `RunWith`, the async pair, and the generated `match`
 - [Validation](/rust/validation) — choices, groups, `exclusive`, `delimiter`, conflicts, portable `validate`
 - [Help, version, and errors](/rust/help) — what the parser renders and how to hook it

--- a/docs/rust/index.md
+++ b/docs/rust/index.md
@@ -79,7 +79,7 @@ available for low-level adopters that want a thinner surface:
 | `usage-argv`    | The zero-allocation, zero-dependency runtime the derive emits code against                                           |
 | `usage-test`    | Test helpers: what a command line parses to, what a page says, what a shell is offered                               |
 | `usage-config`  | Layered settings resolution with provenance ([Configuration](/rust/configuration))                                   |
-| `usage-dynamic` | Opt-in runtime command catalogs for plugin-aware derived hosts ([Dynamic commands](/rust/dynamic-commands))          |
+| `usage-dynamic` | Commands discovered at runtime, merged into help and completion ([Dynamic commands](/rust/dynamic-commands))         |
 
 ### Cargo features
 
@@ -151,7 +151,7 @@ how to opt out of the endpoint.
 - [Args and flags](/rust/args-and-flags) — field types, attributes, env vars, defaults
 - [Updating values](/rust/update-from) — merge another command line into an existing value
 - [Subcommands](/rust/subcommands) — command enums, nesting, `flatten`, value enums
-- [Dynamic commands](/rust/dynamic-commands) — merge runtime-discovered plugins into help and completion
+- [Dynamic commands](/rust/dynamic-commands) — commands discovered at runtime, in help and completion
 - [Dispatch](/rust/dispatch) — `Run`, `RunWith`, the async pair, and the generated `match`
 - [Validation](/rust/validation) — choices, groups, `exclusive`, `delimiter`, conflicts, portable `validate`
 - [Help, version, and errors](/rust/help) — what the parser renders and how to hook it

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -45,7 +45,9 @@ usage-validation = { workspace = true, optional = true }
 
 [features]
 default = ["docs"]
-docs = ["tera", "roff"]
+# CLI help is useful to lightweight consumers that do not generate Markdown or manpages.
+cli-help = ["tera"]
+docs = ["cli-help", "roff"]
 validation = ["dep:usage-validation"]
 unstable_choices_env = []
 

--- a/lib/src/docs/cli/mod.rs
+++ b/lib/src/docs/cli/mod.rs
@@ -4,7 +4,7 @@ use tera::Tera;
 
 pub fn render_help(spec: &Spec, cmd: &SpecCommand, long: bool) -> String {
     // Convert to docs models to get layout calculations
-    let docs_spec = crate::docs::models::Spec::from(spec.clone());
+    let docs_spec = crate::docs::models::Spec::from(spec);
     let mut docs_cmd = crate::docs::models::SpecCommand::from(&without_hidden(cmd, long));
 
     let mut ctx = tera::Context::new();

--- a/lib/src/docs/mod.rs
+++ b/lib/src/docs/mod.rs
@@ -1,5 +1,10 @@
+#[cfg(feature = "cli-help")]
 pub mod cli;
+#[cfg(feature = "cli-help")]
 mod layout;
+#[cfg(feature = "docs")]
 pub mod manpage;
+#[cfg(feature = "docs")]
 pub mod markdown;
+#[cfg(feature = "cli-help")]
 pub(crate) mod models;

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "docs")]
 use crate::docs::markdown::MarkdownRenderer;
 use crate::spec::effect::SpecCommandEffect;
 use crate::{SpecAdmonition, SpecChoices};
@@ -240,6 +241,7 @@ pub struct SpecConfigChoice {
 }
 
 impl SpecConfig {
+    #[cfg(feature = "docs")]
     pub fn render_md(&mut self, renderer: &MarkdownRenderer) {
         if self.rendered {
             return;
@@ -255,12 +257,14 @@ impl SpecConfig {
         }
     }
 
+    #[cfg(feature = "docs")]
     pub fn is_empty(&self) -> bool {
         self.props.is_empty() && self.files.is_empty()
     }
 }
 
 impl SpecConfigProp {
+    #[cfg(feature = "docs")]
     pub fn render_md(&mut self, renderer: &MarkdownRenderer) {
         if self.rendered {
             return;
@@ -1081,6 +1085,7 @@ impl From<&crate::SpecArg> for SpecArg {
 }
 
 impl Spec {
+    #[cfg(feature = "docs")]
     pub fn render_md(&mut self, renderer: &MarkdownRenderer) {
         if self.rendered {
             return;
@@ -1098,6 +1103,7 @@ impl Spec {
 }
 
 impl SpecCommand {
+    #[cfg(feature = "docs")]
     pub fn all_subcommands(&self) -> Vec<&SpecCommand> {
         let mut cmds = vec![];
         for cmd in self.subcommands.values() {
@@ -1107,6 +1113,7 @@ impl SpecCommand {
         cmds
     }
 
+    #[cfg(feature = "docs")]
     pub fn render_md(&mut self, renderer: &MarkdownRenderer) {
         if self.rendered {
             return;
@@ -1148,6 +1155,7 @@ impl SpecCommand {
     /// Rebuild the grouped views from `flags` and `args`.
     ///
     /// Anything that mutates either list has to call this, or the groups go stale.
+    #[cfg(feature = "docs")]
     fn regroup(&mut self) {
         self.flag_groups = group_by_heading(&self.flags, |f| f.help_heading.as_deref());
         self.arg_groups = group_by_heading(&self.args, |a| a.help_heading.as_deref());
@@ -1155,6 +1163,7 @@ impl SpecCommand {
 }
 
 impl SpecFlag {
+    #[cfg(feature = "docs")]
     pub fn render_md(&mut self, renderer: &MarkdownRenderer) {
         if self.rendered {
             return;
@@ -1176,6 +1185,7 @@ impl SpecFlag {
 }
 
 impl SpecArg {
+    #[cfg(feature = "docs")]
     pub fn render_md(&mut self, renderer: &MarkdownRenderer) {
         if self.rendered {
             return;
@@ -1190,6 +1200,7 @@ impl SpecArg {
 }
 
 impl SpecExample {
+    #[cfg(feature = "docs")]
     pub fn render_md(&mut self, renderer: &MarkdownRenderer) {
         if self.rendered {
             return;

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -547,9 +547,18 @@ fn fold_outputs(
 
 impl From<crate::Spec> for Spec {
     fn from(spec: crate::Spec) -> Self {
+        Self::from(&spec)
+    }
+}
+
+impl From<&crate::Spec> for Spec {
+    fn from(spec: &crate::Spec) -> Self {
+        // One clone, because folding rewrites every command's effective outputs and the
+        // caller's spec is not ours to change. Taking a reference is what keeps this to one:
+        // rendering a help page used to clone at the call site and again right here.
         let spec = {
             let mut folded = spec.clone();
-            fold_outputs(&spec, &mut folded.cmd, &mut Vec::new());
+            fold_outputs(spec, &mut folded.cmd, &mut Vec::new());
             folded
         };
         Self {

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -33,7 +33,7 @@ pub mod complete;
 pub mod spec;
 pub use error::Result;
 
-#[cfg(feature = "docs")]
+#[cfg(any(feature = "docs", feature = "cli-help"))]
 pub mod docs;
 pub mod go;
 pub mod help_template;

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -8,7 +8,7 @@ use std::fmt::{Debug, Display, Formatter};
 use std::sync::Arc;
 use strum::EnumTryAs;
 
-#[cfg(feature = "docs")]
+#[cfg(feature = "cli-help")]
 use crate::docs;
 use crate::error::UsageErr;
 use crate::spec::arg::SpecDoubleDashChoices;
@@ -3192,12 +3192,12 @@ fn apply_flag_overrides(
     attributed.remove(&flag.name);
 }
 
-#[cfg(feature = "docs")]
+#[cfg(feature = "cli-help")]
 fn render_help_err(spec: &Spec, cmd: &SpecCommand, long: bool) -> UsageErr {
     UsageErr::Help(docs::cli::render_help(spec, cmd, long))
 }
 
-#[cfg(feature = "docs")]
+#[cfg(feature = "cli-help")]
 fn render_help_all_err(spec: &Spec, cmd: &SpecCommand) -> UsageErr {
     fn append(out: &mut String, spec: &Spec, cmd: &SpecCommand) {
         if !out.is_empty() {
@@ -3220,12 +3220,12 @@ fn render_help_all_err(spec: &Spec, cmd: &SpecCommand) -> UsageErr {
     UsageErr::Help(out)
 }
 
-#[cfg(not(feature = "docs"))]
+#[cfg(not(feature = "cli-help"))]
 fn render_help_err(_spec: &Spec, _cmd: &SpecCommand, _long: bool) -> UsageErr {
     UsageErr::Help("help".to_string())
 }
 
-#[cfg(not(feature = "docs"))]
+#[cfg(not(feature = "cli-help"))]
 fn render_help_all_err(_spec: &Spec, _cmd: &SpecCommand) -> UsageErr {
     UsageErr::Help("help".to_string())
 }

--- a/lib/src/spec/choices.rs
+++ b/lib/src/spec/choices.rs
@@ -283,8 +283,8 @@ impl SpecChoices {
     }
 
     /// The choices as a help page lists them: visible values only, and no details.
-    // Only `docs` renders help, and without it this is dead code that `-D warnings` fails on.
-    #[cfg(feature = "docs")]
+    // Only `cli-help` renders help, and without it this is dead code under `-D warnings`.
+    #[cfg(feature = "cli-help")]
     pub(crate) fn for_help(&self) -> Self {
         let mut choices = self.clone();
         choices.choices = self.visible_declared();

--- a/lib/src/spec/cmd.rs
+++ b/lib/src/spec/cmd.rs
@@ -670,9 +670,9 @@ impl SpecCommand {
         self.usage_with_subcommands(true)
     }
 
-    // `docs` only, like `SpecChoices::for_help`: the usage line without the subcommand
+    // `cli-help` only, like `SpecChoices::for_help`: the usage line without the subcommand
     // placeholder is a help-page shape, and nothing else asks for it.
-    #[cfg(feature = "docs")]
+    #[cfg(feature = "cli-help")]
     pub(crate) fn usage_without_subcommands(&self) -> String {
         self.usage_with_subcommands(false)
     }

--- a/lib/src/spec/cmd.rs
+++ b/lib/src/spec/cmd.rs
@@ -727,6 +727,14 @@ impl SpecCommand {
         }
         usage.trim().to_string()
     }
+    /// Forget which subcommands this command was asked for.
+    ///
+    /// `find_subcommand` memoizes names and aliases into a `OnceLock`, so anything that adds or
+    /// removes a subcommand has to say so or the lookup keeps answering for the old set.
+    pub(crate) fn reset_subcommand_lookup(&mut self) {
+        self.subcommand_lookup = OnceLock::new();
+    }
+
     pub(crate) fn merge(&mut self, other: Self) {
         // Merging can add subcommands and aliases, and `find_subcommand` memoizes
         // its lookup into a OnceLock — so the cache has to go, or a name that

--- a/lib/src/spec/mod.rs
+++ b/lib/src/spec/mod.rs
@@ -1302,6 +1302,28 @@ impl From<&clap::Command> for Spec {
     }
 }
 
+/// A spec wrapping one command, for command trees built in Rust rather than parsed from KDL.
+///
+/// The command's own `name` becomes the spec's `name` and `bin`, and its `help` becomes the
+/// spec's `about` — the same correspondence `usage-dynamic` applies in the other direction when
+/// it grafts a spec into a host as a command.
+impl From<SpecCommand> for Spec {
+    fn from(cmd: SpecCommand) -> Self {
+        let mut spec = Self {
+            name: cmd.name.clone(),
+            bin: cmd.name.clone(),
+            about: cmd.help.clone(),
+            about_long: cmd.help_long.clone(),
+            cmd,
+            ..Self::default()
+        };
+        // A built tree has never been stamped: nested commands do not know their paths, so
+        // their usage lines are missing the words a user would type.
+        spec.restamp();
+        spec
+    }
+}
+
 #[inline]
 pub fn is_true(b: &bool) -> bool {
     *b

--- a/lib/src/spec/mod.rs
+++ b/lib/src/spec/mod.rs
@@ -156,6 +156,22 @@ pub struct Spec {
 }
 
 impl Spec {
+    /// Recompute everything a command's position in this tree decides, after building one by
+    /// hand: each command's path, its usage line, and the memoized subcommand lookup.
+    ///
+    /// A `SpecCommand` inserted into `subcommands` carries the path it had wherever it came
+    /// from — a spec of its own, most likely, where it was the root and its path was empty. Its
+    /// help page would say so. So would its parent's, which gains a `<SUBCOMMAND>` placeholder
+    /// the first time it acquires a child. Call this after grafting, and the tree is
+    /// indistinguishable from one that declared the same commands in KDL.
+    ///
+    /// The alternative — writing the tree out and parsing it back, which is how this was reached
+    /// before — costs a KDL round trip of the whole spec. For a large one that is a quarter of a
+    /// second to fix up strings.
+    pub fn restamp(&mut self) {
+        restamp_paths(&mut self.cmd, &[], true);
+    }
+
     /// Resolve every mount from supplied command outputs without spawning processes.
     ///
     /// This is intended for deterministic generators and conformance harnesses. The
@@ -931,6 +947,23 @@ fn extract_usage_from_comments(full: &str) -> String {
 }
 
 fn set_subcommand_ancestors(cmd: &mut SpecCommand, ancestors: &[String]) {
+    restamp_paths(cmd, ancestors, false);
+}
+
+/// Recompute what a command's position in the tree decides: its path, its usage line, and the
+/// lookup that answers to its subcommands' names and aliases.
+///
+/// A command does not know where it sits — `full_cmd` is stamped onto it by whoever assembled
+/// the tree, `usage` is rendered from that path, and `find_subcommand` memoizes what it found.
+/// Move a command, or graft one in, and all three describe where it used to be. This is the pass
+/// that fixes them, and the only one: a tree built by hand is otherwise as stale as one built by
+/// hand always was, which is why building one used to mean writing it out as KDL and parsing it
+/// back.
+///
+/// `force` says whether a usage line that is already there is trusted. Parsing writes them as it
+/// goes and only wants the blanks filled; a graft brings a subtree whose lines are all correct
+/// for the spec it came from and all wrong here.
+fn restamp_paths(cmd: &mut SpecCommand, ancestors: &[String], force: bool) {
     for subcmd in cmd.subcommands.values_mut() {
         subcmd.full_cmd = ancestors
             .iter()
@@ -938,9 +971,14 @@ fn set_subcommand_ancestors(cmd: &mut SpecCommand, ancestors: &[String]) {
             .chain(once(subcmd.name.clone()))
             .collect();
         let child_ancestors = subcmd.full_cmd.clone();
-        set_subcommand_ancestors(subcmd, &child_ancestors);
+        restamp_paths(subcmd, &child_ancestors, force);
     }
-    if cmd.usage.is_empty() {
+    if force {
+        // The lookup memoizes names *and* aliases, so a grafted sibling is missing from it and a
+        // removed one is still in it. Dropping it costs the next lookup and nothing else.
+        cmd.reset_subcommand_lookup();
+        cmd.usage = cmd.usage();
+    } else if cmd.usage.is_empty() {
         cmd.usage = cmd.usage();
     }
 }
@@ -2112,5 +2150,70 @@ echo "hello"
         spec.resolve_mount_outputs(&outputs).unwrap();
 
         assert!(spec.cmd.subcommands.contains_key("leaf"));
+    }
+
+    #[test]
+    fn restamping_a_grafted_tree_matches_writing_it_out_and_reading_it_back() {
+        // The claim the whole thing rests on: grafting a command in and restamping produces the
+        // tree a spec declaring the same commands would have parsed to. If it ever stops being
+        // true, the cheap path is silently wrong rather than slow.
+        let host: Spec =
+            "name \"host\"\nbin \"host\"\ncmd \"plugins\" {\n  external_subcommand #true\n}\n"
+                .parse()
+                .unwrap();
+        let plugin: Spec =
+            "name \"formatter\"\nbin \"formatter\"\narg \"[path]\"\ncmd \"check\" {\n  flag \"--fix\"\n}\n"
+                .parse()
+                .unwrap();
+
+        let mut grafted = host.clone();
+        grafted
+            .cmd
+            .subcommands
+            .get_mut("plugins")
+            .unwrap()
+            .subcommands
+            .insert("formatter".to_string(), plugin.cmd.clone());
+        grafted.restamp();
+
+        let reparsed: Spec = grafted.to_string().parse().unwrap();
+        let path = |spec: &Spec, words: &[&str]| {
+            let mut cmd = &spec.cmd;
+            for word in words {
+                cmd = cmd.find_subcommand(word).unwrap();
+            }
+            (cmd.full_cmd.clone(), cmd.usage.clone())
+        };
+        for words in [
+            &[][..],
+            &["plugins"],
+            &["plugins", "formatter"],
+            &["plugins", "formatter", "check"],
+        ] {
+            assert_eq!(
+                path(&grafted, words),
+                path(&reparsed, words),
+                "at {words:?}"
+            );
+        }
+
+        // Specifically: the plugin no longer claims to be a root, and its new parent has
+        // learned that it takes a subcommand at all.
+        assert_eq!(
+            path(&grafted, &["plugins", "formatter"]).0,
+            ["plugins", "formatter"]
+        );
+        assert!(
+            path(&grafted, &["plugins"]).1.contains("<SUBCOMMAND>"),
+            "{:?}",
+            path(&grafted, &["plugins"]).1
+        );
+        // And the memoized lookup answers for what is there now, aliases included.
+        assert!(grafted
+            .cmd
+            .find_subcommand("plugins")
+            .unwrap()
+            .find_subcommand("formatter")
+            .is_some());
     }
 }

--- a/usage-dynamic/Cargo.toml
+++ b/usage-dynamic/Cargo.toml
@@ -12,7 +12,7 @@ license = { workspace = true }
 
 [dependencies]
 usage-argv = { workspace = true, features = ["spec", "complete"] }
-usage-parser = { package = "usage-lib", path = "../lib", version = "6.1.1", default-features = false }
+usage-parser = { package = "usage-lib", path = "../lib", version = "6.1.1", default-features = false, features = ["cli-help"] }
 
 [package.metadata.release]
 shared-version = true

--- a/usage-dynamic/Cargo.toml
+++ b/usage-dynamic/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "usage-dynamic"
+description = "Runtime command catalogs for usage-rs applications"
+version = "6.1.1"
+edition = "2021"
+rust-version = "1.95"
+homepage = { workspace = true }
+documentation = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+
+[dependencies]
+usage-argv = { workspace = true, features = ["spec", "complete"] }
+usage-parser = { package = "usage-lib", path = "../lib", version = "6.1.1", default-features = false }
+
+[package.metadata.release]
+shared-version = true
+release = true
+
+[dev-dependencies]
+futures = "0.3"
+usage-rs = { workspace = true, features = ["completions"] }

--- a/usage-dynamic/examples/host.rs
+++ b/usage-dynamic/examples/host.rs
@@ -1,0 +1,77 @@
+//! A plugin-aware host, end to end: discovery, completion, dispatch, and help.
+//!
+//! This is the example `docs/rust/dynamic-commands.md` shows, kept here so that it compiles.
+
+use std::ffi::{OsStr, OsString};
+use usage_dynamic::{Catalog, Outcome, ParseOutput, Spec};
+use usage_rs::{Cli, Error, Subcommands};
+
+#[derive(Cli)]
+#[usage(bin = "ex")]
+struct Ex {
+    #[usage(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommands)]
+enum Commands {
+    /// Built into ex
+    Build,
+    #[usage(external_subcommand)]
+    External(Vec<OsString>),
+}
+
+fn load_plugin_spec(_name: &str) -> Spec {
+    "name \"formatter\"\nbin \"formatter\"\n".parse().unwrap()
+}
+fn build() {}
+fn run_plugin(_name: &str, _output: &ParseOutput) {}
+fn fallback(_words: &[OsString]) {}
+
+fn main() {
+    let catalog = Catalog::builder(Ex::app())
+        .root(load_plugin_spec("formatter"))
+        .build()
+        .unwrap();
+    let app = catalog.app().unwrap();
+
+    // A completion request is not a command anybody runs, so it is answered before the parse.
+    let argv: Vec<OsString> = std::env::args_os().skip(1).collect();
+    if let Some(answer) = futures::executor::block_on(app.completion_request(&argv)) {
+        print!("{answer}");
+        return;
+    }
+
+    let words: Vec<&OsStr> = argv.iter().map(OsString::as_os_str).collect();
+    match Ex::parse_from(&words) {
+        Ok(Ex {
+            command: Commands::Build,
+        }) => build(),
+        Ok(Ex {
+            command: Commands::External(captured),
+        }) => {
+            match catalog.parse_external("", &captured) {
+                Ok(Some(Outcome::Parsed(parsed))) => run_plugin(&parsed.name, &parsed.output),
+                Ok(Some(Outcome::Help(help))) => print!("{}", help.page),
+                Ok(Some(Outcome::Version(version))) => println!("{}", version.version),
+                // `Outcome` is `#[non_exhaustive]`, so this arm is required — and it is where
+                // the two cases the host answers for itself land: a name nobody catalogued,
+                // and a token the spec model cannot represent. The argv is intact in both, so
+                // dispatch it the way this host dispatched unrecognized words all along.
+                _ => fallback(&captured),
+            }
+        }
+        // The host's own help and version, rendered from the merged tree so that runtime
+        // commands appear on the page.
+        Err(Error::Help { cmd, long }) => {
+            let path = usage_rs::help::find(Ex::spec(), cmd)
+                .map(|(path, _)| path[1..].join(" "))
+                .unwrap_or_default();
+            print!("{}", app.help(&path, long).unwrap());
+        }
+        Err(err) => {
+            eprint!("{}", Ex::render_failure(&words, &err));
+            std::process::exit(2);
+        }
+    }
+}

--- a/usage-dynamic/examples/host.rs
+++ b/usage-dynamic/examples/host.rs
@@ -1,9 +1,13 @@
-//! A plugin-aware host, end to end: discovery, completion, dispatch, and help.
+//! A plugin-aware host, end to end.
 //!
-//! This is the example `docs/rust/dynamic-commands.md` shows, kept here so that it compiles.
+//! This is the example `docs/rust/dynamic-commands.md` shows, kept here so it compiles. The
+//! shape it demonstrates: parse first, against the static tables alone, so a built-in command
+//! runs without any plugin being discovered, loaded, or parsed. Plugins load only on the paths
+//! that need them — the catch-all, help, and completion.
 
 use std::ffi::{OsStr, OsString};
 use usage_dynamic::{Catalog, Outcome, ParseOutput, Spec};
+use usage_rs::complete::{render, CompletionRequest};
 use usage_rs::{Cli, Error, Subcommands};
 
 #[derive(Cli)]
@@ -21,54 +25,70 @@ enum Commands {
     External(Vec<OsString>),
 }
 
-fn load_plugin_spec(_name: &str) -> Spec {
-    "name \"formatter\"\nbin \"formatter\"\n".parse().unwrap()
+/// Discovery is the application's: scan a directory, read a lockfile, whatever fits.
+fn plugin_catalog() -> Catalog<'static> {
+    let mut builder = Catalog::builder(Ex::app());
+    for spec in discover_plugin_specs() {
+        builder = builder.root(spec);
+    }
+    builder.build().unwrap()
+}
+
+fn discover_plugin_specs() -> Vec<Spec> {
+    vec!["name \"formatter\"\nbin \"formatter\"\n".parse().unwrap()]
 }
 fn build() {}
 fn run_plugin(_name: &str, _output: &ParseOutput) {}
 fn fallback(_words: &[OsString]) {}
 
 fn main() {
-    let catalog = Catalog::builder(Ex::app())
-        .root(load_plugin_spec("formatter"))
-        .build()
-        .unwrap();
-    let app = catalog.app().unwrap();
-
-    // A completion request is not a command anybody runs, so it is answered before the parse.
     let argv: Vec<OsString> = std::env::args_os().skip(1).collect();
-    if let Some(answer) = futures::executor::block_on(app.completion_request(&argv)) {
-        print!("{answer}");
+
+    // A completion request is not a command anybody runs, so it is recognized before the
+    // parse. It is also interactive: loading plugins here is affordable, and it is what puts
+    // their names in the answer.
+    if let Some(request) = CompletionRequest::parse(&argv) {
+        let catalog = plugin_catalog();
+        let answer = futures::executor::block_on(catalog.app().unwrap().complete_request(&request));
+        print!("{}", render(&answer, request.shell));
         return;
     }
 
     let words: Vec<&OsStr> = argv.iter().map(OsString::as_os_str).collect();
     match Ex::parse_from(&words) {
+        // A built-in command runs with no plugin loaded. This is the hot path, and nothing on
+        // it knows plugins exist.
         Ok(Ex {
             command: Commands::Build,
         }) => build(),
+
+        // The catch-all fired: now, and only now, load plugins.
         Ok(Ex {
             command: Commands::External(captured),
         }) => {
+            let catalog = plugin_catalog();
             match catalog.parse_external("", &captured) {
                 Ok(Some(Outcome::Parsed(parsed))) => run_plugin(&parsed.name, &parsed.output),
                 Ok(Some(Outcome::Help(help))) => print!("{}", help.page),
                 Ok(Some(Outcome::Version(version))) => println!("{}", version.version),
-                // `Outcome` is `#[non_exhaustive]`, so this arm is required — and it is where
-                // the two cases the host answers for itself land: a name nobody catalogued,
-                // and a token the spec model cannot represent. The argv is intact in both, so
-                // dispatch it the way this host dispatched unrecognized words all along.
+                // A name no loaded plugin answers to, or argv the spec model cannot
+                // represent. The words are untouched either way: handle them however this
+                // application handled unrecognized commands before it had plugins.
                 _ => fallback(&captured),
             }
         }
-        // The host's own help and version, rendered from the merged tree so that runtime
-        // commands appear on the page.
+
+        // Help is a cold path too. Render it through the catalog so plugins appear on the
+        // page; `usage::help::find` turns the command the parser stopped at into the path
+        // `help` takes.
         Err(Error::Help { cmd, long }) => {
+            let catalog = plugin_catalog();
             let path = usage_rs::help::find(Ex::spec(), cmd)
                 .map(|(path, _)| path[1..].join(" "))
                 .unwrap_or_default();
-            print!("{}", app.help(&path, long).unwrap());
+            print!("{}", catalog.app().unwrap().help(&path, long).unwrap());
         }
+        Err(Error::Version { .. }) => println!("ex {}", env!("CARGO_PKG_VERSION")),
         Err(err) => {
             eprint!("{}", Ex::render_failure(&words, &err));
             std::process::exit(2);

--- a/usage-dynamic/examples/host.rs
+++ b/usage-dynamic/examples/host.rs
@@ -1,9 +1,9 @@
 //! A plugin-aware host, end to end.
 //!
 //! This is the example `docs/rust/dynamic-commands.md` shows, kept here so it compiles. The
-//! shape it demonstrates: parse first, against the static tables alone, so a built-in command
-//! runs without any plugin being discovered, loaded, or parsed. Plugins load only on the paths
-//! that need them — the catch-all, help, and completion.
+//! shape it demonstrates: parse against the static tables first, so built-in commands run
+//! without loading any plugin. Plugins load only on the paths that need them — the catch-all,
+//! help, and completion.
 
 use std::ffi::{OsStr, OsString};
 use usage_dynamic::{Catalog, Outcome, ParseOutput, Spec};
@@ -25,7 +25,7 @@ enum Commands {
     External(Vec<OsString>),
 }
 
-/// Discovery is the application's: scan a directory, read a lockfile, whatever fits.
+/// How plugins are found is up to the application: a directory scan, a lockfile, a registry.
 fn plugin_catalog() -> Catalog<'static> {
     let mut builder = Catalog::builder(Ex::app());
     for spec in discover_plugin_specs() {
@@ -44,9 +44,8 @@ fn fallback(_words: &[OsString]) {}
 fn main() {
     let argv: Vec<OsString> = std::env::args_os().skip(1).collect();
 
-    // A completion request is not a command anybody runs, so it is recognized before the
-    // parse. It is also interactive: loading plugins here is affordable, and it is what puts
-    // their names in the answer.
+    // Completion requests are recognized before the parse. They are interactive, so loading
+    // plugins here is affordable — and it is what puts plugin names in the answer.
     if let Some(request) = CompletionRequest::parse(&argv) {
         let catalog = plugin_catalog();
         let answer = futures::executor::block_on(catalog.app().unwrap().complete_request(&request));
@@ -56,13 +55,12 @@ fn main() {
 
     let words: Vec<&OsStr> = argv.iter().map(OsString::as_os_str).collect();
     match Ex::parse_from(&words) {
-        // A built-in command runs with no plugin loaded. This is the hot path, and nothing on
-        // it knows plugins exist.
+        // Built-in commands run without loading any plugin.
         Ok(Ex {
             command: Commands::Build,
         }) => build(),
 
-        // The catch-all fired: now, and only now, load plugins.
+        // The words named something the static tables don't know. Load plugins now.
         Ok(Ex {
             command: Commands::External(captured),
         }) => {
@@ -71,15 +69,14 @@ fn main() {
                 Ok(Some(Outcome::Parsed(parsed))) => run_plugin(&parsed.name, &parsed.output),
                 Ok(Some(Outcome::Help(help))) => print!("{}", help.page),
                 Ok(Some(Outcome::Version(version))) => println!("{}", version.version),
-                // A name no loaded plugin answers to, or argv the spec model cannot
-                // represent. The words are untouched either way: handle them however this
-                // application handled unrecognized commands before it had plugins.
+                // No loaded plugin matches, or the argv is not UTF-8. The captured words are
+                // untouched — handle them like any unknown command.
                 _ => fallback(&captured),
             }
         }
 
-        // Help is a cold path too. Render it through the catalog so plugins appear on the
-        // page; `usage::help::find` turns the command the parser stopped at into the path
+        // Render help through the catalog so plugin commands appear on the page.
+        // `usage::help::find` converts the command the parser stopped at into the path
         // `help` takes.
         Err(Error::Help { cmd, long }) => {
             let catalog = plugin_catalog();

--- a/usage-dynamic/examples/host.rs
+++ b/usage-dynamic/examples/host.rs
@@ -1,4 +1,4 @@
-//! A plugin-aware host, end to end.
+//! A CLI with plugin commands, end to end.
 //!
 //! This is the example `docs/rust/dynamic-commands.md` shows, kept here so it compiles. The
 //! shape it demonstrates: parse against the static tables first, so built-in commands run

--- a/usage-dynamic/src/lib.rs
+++ b/usage-dynamic/src/lib.rs
@@ -25,6 +25,10 @@ use usage_parser::Parser;
 
 pub use usage_parser::parse::ParseOutput;
 pub use usage_parser::Spec;
+// For command trees built in Rust rather than parsed from KDL. `Spec: From<SpecCommand>`
+// wraps a built root; the builders come along so an application defining runtime commands
+// programmatically needs no direct usage-lib dependency.
+pub use usage_parser::{SpecArgBuilder, SpecCommandBuilder, SpecFlagBuilder};
 
 /// A validated collection of caller-supplied runtime command specs.
 ///
@@ -654,8 +658,12 @@ impl<'a> Builder<'a> {
         let host = self.host.spec();
         let mut entries = Vec::with_capacity(self.pending.len());
         let mut claimed: HashMap<String, HashSet<String>> = HashMap::new();
-        for (requested_parent, spec) in self.pending {
+        for (requested_parent, mut spec) in self.pending {
             reject_mounts(&spec.cmd)?;
+            // Parsing stamps a tree; building one in Rust does not. Restamping here makes the
+            // two origins indistinguishable — for a parsed spec it recomputes what is already
+            // there — so nothing downstream has to know where a spec came from.
+            spec.restamp();
             let (parent, parent_meta) = resolve_parent(host.root, &requested_parent)?;
             if !parent_meta.cmd.external_subcommand {
                 return Err(Error::ParentNotExternal(parent));

--- a/usage-dynamic/src/lib.rs
+++ b/usage-dynamic/src/lib.rs
@@ -1,14 +1,17 @@
 //! Opt-in runtime command catalogs for a derive-generated usage-rs host.
 //!
 //! Applications discover and cache plugin specs themselves, then attach them below a static
-//! command that declares an external-subcommand variant. The catalog adds summaries to host
-//! help and command-name completion while generic parsing stays isolated in `usage-lib`.
+//! command that declares an external-subcommand variant. The catalog builds a separate merged
+//! tree for navigable help and deep completion while generic parsing stays in `usage-lib` and
+//! the derive-generated parse tables remain unchanged.
 
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
 use std::fmt;
 
-use usage_argv::spec::{CommandMeta, RuntimeCommand, SpecView};
+use usage_argv::complete::{self, Completions, Files, Shell, Split};
+use usage_argv::spec::{Candidate, CandidateKind, CommandMeta, SpecView};
 use usage_parser::error::UsageErr;
 use usage_parser::Parser;
 
@@ -20,6 +23,8 @@ pub use usage_parser::Spec;
 pub struct Catalog<'a> {
     host: SpecView<'a>,
     entries: Vec<Entry>,
+    merged: Spec,
+    completion: Spec,
 }
 
 #[derive(Debug)]
@@ -28,6 +33,12 @@ struct Entry {
     name: String,
     aliases: Vec<String>,
     spec: Spec,
+}
+
+/// Cold-path help and completion over the fully merged runtime tree.
+#[derive(Debug, Clone, Copy)]
+pub struct App<'a> {
+    catalog: &'a Catalog<'a>,
 }
 
 /// A catalog under construction.
@@ -46,27 +57,9 @@ impl<'a> Catalog<'a> {
         }
     }
 
-    /// The host presentation view, including dynamic command summaries.
-    pub fn app(&self) -> SpecView<'a> {
-        self.host
-            .clone()
-            .runtime_commands(self.entries.iter().map(|entry| {
-                let cmd = &entry.spec.cmd;
-                RuntimeCommand {
-                    parent: entry.parent.clone(),
-                    name: entry.name.clone(),
-                    aliases: cmd.aliases.clone(),
-                    hidden_aliases: cmd.hidden_aliases.clone(),
-                    about: cmd.help.clone().or_else(|| entry.spec.about.clone()),
-                    long_about: cmd
-                        .help_long
-                        .clone()
-                        .or_else(|| entry.spec.about_long.clone()),
-                    help_heading: cmd.help_heading.clone(),
-                    hide: cmd.hide,
-                    display_order: cmd.display_order,
-                }
-            }))
+    /// Cold-path help, completion, and spec access over the fully merged command tree.
+    pub fn app(&self) -> App<'_> {
+        App { catalog: self }
     }
 
     /// Parse argv captured by an existing external-subcommand variant.
@@ -132,6 +125,246 @@ impl<'a> Catalog<'a> {
     }
 }
 
+impl App<'_> {
+    /// The fully merged portable spec used for dynamic help and completion.
+    pub fn spec(&self) -> &Spec {
+        &self.catalog.merged
+    }
+
+    /// Render help for a static or dynamic command path. The empty path is the root.
+    pub fn help(self, path: &str, long: bool) -> Option<String> {
+        let command = find_command(&self.catalog.merged, path)?;
+        Some(usage_parser::docs::cli::render_help(
+            &self.catalog.merged,
+            command,
+            long,
+        ))
+    }
+
+    /// Use this merged tree to answer the usage-rs completion protocol.
+    pub const fn completion_app(self) -> Self {
+        self
+    }
+
+    /// Complete an already split command line without rendering a shell protocol.
+    pub fn complete(self, split: &Split) -> Result<Completions<'static>, Error> {
+        complete_merged(&self.catalog.completion, split)
+    }
+
+    /// Answer a hidden `__complete_word__` invocation, or return `None` for ordinary argv.
+    pub async fn completion_request(self, argv: &[OsString]) -> Option<String> {
+        let request = CompletionRequest::parse(argv)?;
+        let answer = self.complete(&request.split).ok()?;
+        Some(complete::render(&answer, request.shell))
+    }
+}
+
+fn find_command<'a>(spec: &'a Spec, path: &str) -> Option<&'a usage_parser::SpecCommand> {
+    let mut command = &spec.cmd;
+    for component in path.split_ascii_whitespace() {
+        command = command.find_subcommand(component)?;
+    }
+    Some(command)
+}
+
+fn complete_merged(spec: &Spec, split: &Split) -> Result<Completions<'static>, Error> {
+    let words: Vec<String> = split.words.iter().take(split.cword).cloned().collect();
+    let parsed = usage_parser::parse::parse_partial(spec, &words)
+        .map_err(|error| Error::Parse(error.to_string()))?;
+    let prefix = &split.prefix;
+    let flags_possible = !parsed.double_dash_seen;
+    let mut candidates = Vec::new();
+    let mut files = None;
+    let mut declared_completion = false;
+
+    if let Some(flag) = parsed.flag_awaiting_value.first() {
+        if let Some(arg) = &flag.arg {
+            candidates.extend(choice_candidates(arg, prefix));
+            declared_completion = completion_for(spec, &parsed.cmd, &arg.name).is_some();
+            files = completion_files(spec, &parsed.cmd, &arg.name);
+        }
+    } else if flags_possible && prefix.starts_with('-') {
+        for (form, flag) in parsed.completion_flags() {
+            if flag.hide || !form.starts_with(prefix) || hidden_flag_form(&form, &flag) {
+                continue;
+            }
+            candidates.push(Candidate {
+                value: form,
+                kind: CandidateKind::Flag,
+                display: None,
+                description: flag.help.clone().map(Cow::Owned),
+            });
+        }
+    } else {
+        if let Some(arg) = parsed.next_arg.as_deref() {
+            candidates.extend(choice_candidates(arg, prefix));
+            declared_completion = completion_for(spec, &parsed.cmd, &arg.name).is_some();
+            files = completion_files(spec, &parsed.cmd, &arg.name);
+        }
+        for command in parsed
+            .cmd
+            .subcommands
+            .values()
+            .filter(|command| !command.hide)
+        {
+            for name in std::iter::once(&command.name).chain(&command.aliases) {
+                if name.starts_with(prefix) {
+                    candidates.push(Candidate {
+                        value: name.clone(),
+                        kind: CandidateKind::Command,
+                        display: None,
+                        description: command.help.clone().map(Cow::Owned),
+                    });
+                }
+            }
+        }
+    }
+    candidates.sort_unstable();
+    candidates.dedup_by(|a, b| a.value == b.value);
+    if candidates.is_empty() && files.is_none() && !declared_completion && !prefix.starts_with('-')
+    {
+        files = Some(Files::Any);
+    }
+    Ok(Completions { candidates, files })
+}
+
+fn choice_candidates(arg: &usage_parser::SpecArg, prefix: &str) -> Vec<Candidate<'static>> {
+    let Some(choices) = &arg.choices else {
+        return Vec::new();
+    };
+    let details: HashMap<_, _> = choices
+        .details
+        .iter()
+        .map(|choice| (choice.value.as_str(), choice))
+        .collect();
+    let mut candidates = Vec::new();
+    for value in &choices.choices {
+        let detail = details.get(value.as_str()).copied();
+        if detail.is_some_and(|choice| choice.hide) {
+            continue;
+        }
+        for form in std::iter::once(value.as_str()).chain(
+            detail
+                .into_iter()
+                .flat_map(|choice| &choice.aliases)
+                .filter(|alias| !alias.hide)
+                .map(|alias| alias.value.as_str()),
+        ) {
+            if form.starts_with(prefix) {
+                candidates.push(Candidate {
+                    value: form.to_owned(),
+                    kind: CandidateKind::Value,
+                    display: None,
+                    description: detail
+                        .and_then(|choice| choice.help.clone())
+                        .map(Cow::Owned),
+                });
+            }
+        }
+    }
+    candidates
+}
+
+fn hidden_flag_form(form: &str, flag: &usage_parser::SpecFlag) -> bool {
+    form.strip_prefix("--")
+        .is_some_and(|long| flag.hidden_aliases.iter().any(|hidden| hidden == long))
+        || form
+            .strip_prefix('-')
+            .filter(|short| short.len() == 1)
+            .and_then(|short| short.chars().next())
+            .is_some_and(|short| flag.hidden_short_aliases.contains(&short))
+}
+
+fn completion_files(spec: &Spec, command: &usage_parser::SpecCommand, name: &str) -> Option<Files> {
+    let completion = completion_for(spec, command, name)?;
+    let type_ = completion.type_.as_deref()?;
+    let (kind, filter) = type_
+        .split_once(':')
+        .map_or((type_, None), |(kind, filter)| (kind, Some(filter)));
+    match kind {
+        "path" | "file" => match filter {
+            Some(filter) => Some(Files::Extensions(
+                filter
+                    .split(',')
+                    .map(|extension| extension.trim_start_matches('.').to_owned())
+                    .collect(),
+            )),
+            None => Some(Files::Any),
+        },
+        "dir" | "directory" => Some(Files::Dirs),
+        "executable" | "executable_path" => Some(Files::ExecutablePaths),
+        "command" => Some(Files::Commands),
+        _ => None,
+    }
+}
+
+fn completion_for<'a>(
+    spec: &'a Spec,
+    command: &'a usage_parser::SpecCommand,
+    name: &str,
+) -> Option<&'a usage_parser::SpecComplete> {
+    command
+        .complete
+        .get(name)
+        .or_else(|| spec.complete.get(name))
+}
+
+struct CompletionRequest {
+    shell: Shell,
+    split: Split,
+}
+
+impl CompletionRequest {
+    fn parse(argv: &[OsString]) -> Option<Self> {
+        if argv.first()?.to_str()? != "__complete_word__" {
+            return None;
+        }
+        let mut shell = Shell::Bash;
+        let mut line = String::new();
+        let mut cursor = None;
+        let mut words: Option<Vec<String>> = None;
+        let mut rest = argv[1..].iter();
+        while let Some(arg) = rest.next() {
+            match arg.to_str().unwrap_or_default() {
+                "--shell" => {
+                    shell = rest
+                        .next()
+                        .and_then(|name| Shell::from_name(&name.to_string_lossy()))
+                        .unwrap_or(shell);
+                }
+                "--line" => {
+                    line = rest.next()?.to_string_lossy().into_owned();
+                }
+                "--cursor" => {
+                    cursor = rest.next()?.to_str()?.parse().ok();
+                }
+                "--words" => {
+                    words = Some(
+                        rest.map(|word| word.to_string_lossy().into_owned())
+                            .collect(),
+                    );
+                    break;
+                }
+                _ => {}
+            }
+        }
+        let split = if let Some(mut words) = words {
+            if words.is_empty() {
+                words.push(String::new());
+            }
+            let cword = words.len() - 1;
+            Split {
+                prefix: words[cword].clone(),
+                words,
+                cword,
+            }
+        } else {
+            complete::split(&line, cursor.unwrap_or(line.len()), shell)
+        };
+        Some(Self { shell, split })
+    }
+}
+
 impl<'a> Builder<'a> {
     /// Attach a supplied plugin spec beneath the static root.
     pub fn root(mut self, spec: Spec) -> Self {
@@ -151,6 +384,12 @@ impl<'a> Builder<'a> {
     /// Validate all parents and namespaces and finish the catalog.
     pub fn build(self) -> Result<Catalog<'a>, Error> {
         let host = self.host.spec();
+        let mut merged: Spec = self
+            .host
+            .clone()
+            .to_kdl()
+            .parse()
+            .map_err(|error: UsageErr| Error::HostSpec(error.to_string()))?;
         let mut entries = Vec::with_capacity(self.pending.len());
         let mut claimed: HashMap<String, HashSet<String>> = HashMap::new();
         for (requested_parent, spec) in self.pending {
@@ -167,7 +406,12 @@ impl<'a> Builder<'a> {
             if name.is_empty() {
                 return Err(Error::EmptyName);
             }
-            let aliases = spec.cmd.aliases.clone();
+            let mut aliases = spec.cmd.aliases.clone();
+            for alias in &spec.cmd.hidden_aliases {
+                if !aliases.contains(alias) {
+                    aliases.push(alias.clone());
+                }
+            }
             let mut forms = Vec::with_capacity(1 + aliases.len());
             forms.push(name.clone());
             forms.extend(aliases.iter().cloned());
@@ -178,6 +422,7 @@ impl<'a> Builder<'a> {
             for command in parent_meta.subcommands {
                 static_forms.insert(command.cmd.name);
                 static_forms.extend(command.cmd.aliases.iter().copied());
+                static_forms.extend(command.hidden_aliases.iter().copied());
             }
             if !parent_meta.cmd.disable_help_subcommand {
                 static_forms.insert("help");
@@ -191,6 +436,7 @@ impl<'a> Builder<'a> {
                     });
                 }
             }
+            insert_plugin(&mut merged, &parent, &name, &spec)?;
             entries.push(Entry {
                 parent,
                 name,
@@ -198,11 +444,49 @@ impl<'a> Builder<'a> {
                 spec,
             });
         }
+        // Re-reading recalculates every `full_cmd`, usage line, and command lookup cache after
+        // insertion. This is cold construction work and keeps the merged tree internally
+        // indistinguishable from a spec that declared the commands in KDL.
+        merged = merged
+            .to_string()
+            .parse()
+            .map_err(|error: UsageErr| Error::HostSpec(error.to_string()))?;
+        let mut completion = merged.clone();
+        clear_mounts(&mut completion.cmd);
         Ok(Catalog {
             host: self.host,
             entries,
+            merged,
+            completion,
         })
     }
+}
+
+fn insert_plugin(merged: &mut Spec, parent: &str, name: &str, plugin: &Spec) -> Result<(), Error> {
+    let mut command = plugin.cmd.clone();
+    command.name = name.to_owned();
+    command.help = command.help.or_else(|| plugin.about.clone());
+    command.help_long = command.help_long.or_else(|| plugin.about_long.clone());
+    command.before_help = command.before_help.or_else(|| plugin.before_help.clone());
+    command.before_help_long = command
+        .before_help_long
+        .or_else(|| plugin.before_help_long.clone());
+    command.after_help = command.after_help.or_else(|| plugin.after_help.clone());
+    command.after_help_long = command
+        .after_help_long
+        .or_else(|| plugin.after_help_long.clone());
+    for (key, complete) in &plugin.complete {
+        command.complete.insert(key.clone(), complete.clone());
+    }
+    let mut current = &mut merged.cmd;
+    for component in parent.split_ascii_whitespace() {
+        current = current
+            .subcommands
+            .get_mut(component)
+            .ok_or_else(|| Error::MissingParent(parent.to_owned()))?;
+    }
+    current.subcommands.insert(name.to_owned(), command);
+    Ok(())
 }
 
 fn canonical_parent(root: &CommandMeta<'_>, requested: &str) -> Result<String, Error> {
@@ -235,6 +519,13 @@ fn reject_mounts(command: &usage_parser::SpecCommand) -> Result<(), Error> {
         reject_mounts(child)?;
     }
     Ok(())
+}
+
+fn clear_mounts(command: &mut usage_parser::SpecCommand) {
+    command.mounts.clear();
+    for child in command.subcommands.values_mut() {
+        clear_mounts(child);
+    }
 }
 
 /// The result of parsing a catalogued external command.
@@ -274,6 +565,7 @@ pub struct Version {
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum Error {
+    HostSpec(String),
     MissingParent(String),
     ParentNotExternal(String),
     EmptyName,
@@ -287,6 +579,7 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::HostSpec(error) => write!(f, "could not construct merged host spec: {error}"),
             Self::MissingParent(parent) => write!(f, "static parent `{parent}` does not exist"),
             Self::ParentNotExternal(parent) => {
                 write!(

--- a/usage-dynamic/src/lib.rs
+++ b/usage-dynamic/src/lib.rs
@@ -1,6 +1,6 @@
 //! Runtime commands for a derive-generated usage-rs host.
 //!
-//! A plugin manager knows what `host plugin-x` is only after it has read its own configuration,
+//! A CLI that has plugins knows what `host plugin-x` is only after it has read its own configuration,
 //! which is long after the tables describing the rest of its CLI were compiled. Those tables
 //! stay as they are: an application discovers and caches plugin specs itself, and a [`Catalog`]
 //! attaches them beneath a static command that declared an

--- a/usage-dynamic/src/lib.rs
+++ b/usage-dynamic/src/lib.rs
@@ -1,0 +1,319 @@
+//! Opt-in runtime command catalogs for a derive-generated usage-rs host.
+//!
+//! Applications discover and cache plugin specs themselves, then attach them below a static
+//! command that declares an external-subcommand variant. The catalog adds summaries to host
+//! help and command-name completion while generic parsing stays isolated in `usage-lib`.
+
+use std::collections::{HashMap, HashSet};
+use std::ffi::OsString;
+use std::fmt;
+
+use usage_argv::spec::{CommandMeta, RuntimeCommand, SpecView};
+use usage_parser::error::UsageErr;
+use usage_parser::Parser;
+
+pub use usage_parser::parse::ParseOutput;
+pub use usage_parser::Spec;
+
+/// A validated collection of caller-supplied runtime command specs.
+#[derive(Debug)]
+pub struct Catalog<'a> {
+    host: SpecView<'a>,
+    entries: Vec<Entry>,
+}
+
+#[derive(Debug)]
+struct Entry {
+    parent: String,
+    name: String,
+    aliases: Vec<String>,
+    spec: Spec,
+}
+
+/// A catalog under construction.
+#[derive(Debug)]
+pub struct Builder<'a> {
+    host: SpecView<'a>,
+    pending: Vec<(String, Spec)>,
+}
+
+impl<'a> Catalog<'a> {
+    /// Begin a catalog over a derive-generated `Cli::app()`.
+    pub fn builder(host: SpecView<'a>) -> Builder<'a> {
+        Builder {
+            host,
+            pending: Vec::new(),
+        }
+    }
+
+    /// The host presentation view, including dynamic command summaries.
+    pub fn app(&self) -> SpecView<'a> {
+        self.host
+            .clone()
+            .runtime_commands(self.entries.iter().map(|entry| {
+                let cmd = &entry.spec.cmd;
+                RuntimeCommand {
+                    parent: entry.parent.clone(),
+                    name: entry.name.clone(),
+                    aliases: cmd.aliases.clone(),
+                    hidden_aliases: cmd.hidden_aliases.clone(),
+                    about: cmd.help.clone().or_else(|| entry.spec.about.clone()),
+                    long_about: cmd
+                        .help_long
+                        .clone()
+                        .or_else(|| entry.spec.about_long.clone()),
+                    help_heading: cmd.help_heading.clone(),
+                    hide: cmd.hide,
+                    display_order: cmd.display_order,
+                }
+            }))
+    }
+
+    /// Parse argv captured by an existing external-subcommand variant.
+    ///
+    /// `parent` is a static command path, with the empty string denoting the root. The first
+    /// argv token is the external command name. Unknown names return `Ok(None)` so callers may
+    /// retain arbitrary fallback dispatch.
+    pub fn parse_external(
+        &self,
+        parent: &str,
+        argv: &[OsString],
+    ) -> Result<Option<Outcome>, Error> {
+        let canonical_parent = canonical_parent(self.host.spec().root, parent)?;
+        let Some(invoked) = argv.first() else {
+            return Ok(None);
+        };
+        let invoked = invoked.to_str().ok_or(Error::NonUtf8 { index: 0 })?;
+        let Some(entry) = self.entries.iter().find(|entry| {
+            entry.parent == canonical_parent
+                && (entry.name == invoked || entry.aliases.iter().any(|alias| alias == invoked))
+        }) else {
+            return Ok(None);
+        };
+        let mut input = Vec::with_capacity(argv.len());
+        for (index, token) in argv.iter().enumerate() {
+            input.push(token.to_str().ok_or(Error::NonUtf8 { index })?.to_owned());
+        }
+        let mut output = Parser::new(&entry.spec)
+            .explain(&input)
+            .map_err(|error| Error::Parse(error.to_string()))?;
+        if let Some(index) = output
+            .errors
+            .iter()
+            .position(|error| matches!(error, UsageErr::Help(_) | UsageErr::Version(_)))
+        {
+            return Ok(Some(match output.errors.swap_remove(index) {
+                UsageErr::Help(page) => Outcome::Help(Help {
+                    parent: entry.parent.clone(),
+                    name: entry.name.clone(),
+                    invoked_as: invoked.to_owned(),
+                    page,
+                }),
+                UsageErr::Version(version) => Outcome::Version(Version {
+                    parent: entry.parent.clone(),
+                    name: entry.name.clone(),
+                    invoked_as: invoked.to_owned(),
+                    version,
+                }),
+                _ => unreachable!(),
+            }));
+        }
+        if !output.errors.is_empty() {
+            return Err(Error::InvalidArgv(
+                output.errors.iter().map(ToString::to_string).collect(),
+            ));
+        }
+        Ok(Some(Outcome::Parsed(Box::new(Parsed {
+            parent: entry.parent.clone(),
+            name: entry.name.clone(),
+            invoked_as: invoked.to_owned(),
+            output,
+        }))))
+    }
+}
+
+impl<'a> Builder<'a> {
+    /// Attach a supplied plugin spec beneath the static root.
+    pub fn root(mut self, spec: Spec) -> Self {
+        self.pending.push((String::new(), spec));
+        self
+    }
+
+    /// Attach a supplied plugin spec beneath a static command path.
+    ///
+    /// Components may use visible or hidden static aliases; construction stores the canonical
+    /// path. The parent must declare an external-subcommand catch-all.
+    pub fn under(mut self, parent: impl Into<String>, spec: Spec) -> Self {
+        self.pending.push((parent.into(), spec));
+        self
+    }
+
+    /// Validate all parents and namespaces and finish the catalog.
+    pub fn build(self) -> Result<Catalog<'a>, Error> {
+        let host = self.host.spec();
+        let mut entries = Vec::with_capacity(self.pending.len());
+        let mut claimed: HashMap<String, HashSet<String>> = HashMap::new();
+        for (requested_parent, spec) in self.pending {
+            reject_mounts(&spec.cmd)?;
+            let (parent, parent_meta) = resolve_parent(host.root, &requested_parent)?;
+            if !parent_meta.cmd.external_subcommand {
+                return Err(Error::ParentNotExternal(parent));
+            }
+            let name = if spec.name.trim().is_empty() {
+                spec.cmd.name.trim().to_owned()
+            } else {
+                spec.name.trim().to_owned()
+            };
+            if name.is_empty() {
+                return Err(Error::EmptyName);
+            }
+            let aliases = spec.cmd.aliases.clone();
+            let mut forms = Vec::with_capacity(1 + aliases.len());
+            forms.push(name.clone());
+            forms.extend(aliases.iter().cloned());
+            if forms.iter().any(|form| form.is_empty()) {
+                return Err(Error::EmptyName);
+            }
+            let mut static_forms = HashSet::new();
+            for command in parent_meta.subcommands {
+                static_forms.insert(command.cmd.name);
+                static_forms.extend(command.cmd.aliases.iter().copied());
+            }
+            if !parent_meta.cmd.disable_help_subcommand {
+                static_forms.insert("help");
+            }
+            let parent_claimed = claimed.entry(parent.clone()).or_default();
+            for form in &forms {
+                if static_forms.contains(form.as_str()) || !parent_claimed.insert(form.clone()) {
+                    return Err(Error::Collision {
+                        parent,
+                        name: form.clone(),
+                    });
+                }
+            }
+            entries.push(Entry {
+                parent,
+                name,
+                aliases,
+                spec,
+            });
+        }
+        Ok(Catalog {
+            host: self.host,
+            entries,
+        })
+    }
+}
+
+fn canonical_parent(root: &CommandMeta<'_>, requested: &str) -> Result<String, Error> {
+    resolve_parent(root, requested).map(|(path, _)| path)
+}
+
+fn resolve_parent<'a>(
+    root: &'a CommandMeta<'a>,
+    requested: &str,
+) -> Result<(String, &'a CommandMeta<'a>), Error> {
+    let mut current = root;
+    let mut canonical = Vec::new();
+    for component in requested.split_ascii_whitespace() {
+        let Some(next) = current.subcommands.iter().copied().find(|candidate| {
+            candidate.cmd.name == component || candidate.cmd.aliases.contains(&component)
+        }) else {
+            return Err(Error::MissingParent(requested.to_owned()));
+        };
+        canonical.push(next.cmd.name);
+        current = next;
+    }
+    Ok((canonical.join(" "), current))
+}
+
+fn reject_mounts(command: &usage_parser::SpecCommand) -> Result<(), Error> {
+    if !command.mounts.is_empty() {
+        return Err(Error::UnresolvedMount(command.name.clone()));
+    }
+    for child in command.subcommands.values() {
+        reject_mounts(child)?;
+    }
+    Ok(())
+}
+
+/// The result of parsing a catalogued external command.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum Outcome {
+    Parsed(Box<Parsed>),
+    Help(Help),
+    Version(Version),
+}
+
+#[derive(Debug)]
+pub struct Parsed {
+    pub parent: String,
+    pub name: String,
+    pub invoked_as: String,
+    pub output: ParseOutput,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Help {
+    pub parent: String,
+    pub name: String,
+    pub invoked_as: String,
+    pub page: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Version {
+    pub parent: String,
+    pub name: String,
+    pub invoked_as: String,
+    pub version: String,
+}
+
+/// A catalog construction or dynamic parse failure.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum Error {
+    MissingParent(String),
+    ParentNotExternal(String),
+    EmptyName,
+    Collision { parent: String, name: String },
+    UnresolvedMount(String),
+    NonUtf8 { index: usize },
+    InvalidArgv(Vec<String>),
+    Parse(String),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingParent(parent) => write!(f, "static parent `{parent}` does not exist"),
+            Self::ParentNotExternal(parent) => {
+                write!(
+                    f,
+                    "static parent `{parent}` has no external-subcommand catch-all"
+                )
+            }
+            Self::EmptyName => f.write_str("dynamic command name cannot be empty"),
+            Self::Collision { parent, name } => {
+                write!(
+                    f,
+                    "dynamic command form `{name}` collides beneath `{parent}`"
+                )
+            }
+            Self::UnresolvedMount(command) => {
+                write!(
+                    f,
+                    "dynamic spec contains an unresolved mount beneath `{command}`"
+                )
+            }
+            Self::NonUtf8 { index } => {
+                write!(f, "dynamic argv token {index} is not valid UTF-8")
+            }
+            Self::InvalidArgv(errors) => f.write_str(&errors.join("\n")),
+            Self::Parse(error) => f.write_str(error),
+        }
+    }
+}
+
+impl std::error::Error for Error {}

--- a/usage-dynamic/src/lib.rs
+++ b/usage-dynamic/src/lib.rs
@@ -252,6 +252,9 @@ impl<'a> App<'a> {
     }
 
     /// The answer to a parsed request, before it is written the way a shell reads it.
+    ///
+    /// For a caller holding a [`Split`] rather than a shell's argv, build the request with
+    /// [`CompletionRequest::for_split`].
     pub async fn complete_request(self, request: &CompletionRequest) -> Completions<'static> {
         let host = self.catalog.host_app();
         let split = host.effective_split(&request.split);
@@ -273,14 +276,6 @@ impl<'a> App<'a> {
             },
             Some(index) => self.complete_plugin(&position, index, &split),
         }
-    }
-
-    /// Complete an already split command line without rendering a shell protocol.
-    pub fn complete(self, split: &Split) -> Completions<'static> {
-        // Overlays may be async; this half is for callers that registered none, so polling a
-        // future that never suspends is enough to get at the answer.
-        let request = CompletionRequest::for_split(split.clone());
-        pollster(self.complete_request(&request))
     }
 
     /// Add the runtime commands catalogued beneath the command the cursor is at.
@@ -411,23 +406,7 @@ fn own(answer: Completions<'_>) -> Completions<'static> {
     }
 }
 
-/// Drive a future that never suspends.
-///
-/// Everything here is synchronous; the async signature exists because a host's *registered*
-/// completers may not be, and this half of the surface is for callers that registered none.
-fn pollster<T>(future: impl std::future::Future<Output = T>) -> T {
-    use std::pin::pin;
-    use std::task::{Context, Poll, Waker};
-    let mut future = pin!(future);
-    match future
-        .as_mut()
-        .poll(&mut Context::from_waker(Waker::noop()))
-    {
-        Poll::Ready(value) => value,
-        Poll::Pending => unreachable!("a completion with no registered callbacks cannot suspend"),
-    }
-}
-
+/// The command a space-separated path names, static or runtime alike.
 fn find_command<'a>(spec: &'a Spec, path: &str) -> Option<&'a usage_parser::SpecCommand> {
     let mut command = &spec.cmd;
     for component in path.split_ascii_whitespace() {

--- a/usage-dynamic/src/lib.rs
+++ b/usage-dynamic/src/lib.rs
@@ -1,16 +1,24 @@
-//! Opt-in runtime command catalogs for a derive-generated usage-rs host.
+//! Runtime commands for a derive-generated usage-rs host.
 //!
-//! Applications discover and cache plugin specs themselves, then attach them below a static
-//! command that declares an external-subcommand variant. The catalog builds a separate merged
-//! tree for navigable help and deep completion while generic parsing stays in `usage-lib` and
-//! the derive-generated parse tables remain unchanged.
+//! A plugin manager knows what `host plugin-x` is only after it has read its own configuration,
+//! which is long after the tables describing the rest of its CLI were compiled. Those tables
+//! stay as they are: an application discovers and caches plugin specs itself, and a [`Catalog`]
+//! attaches them beneath a static command that declared an
+//! [`external_subcommand`](usage_parser::SpecCommand::external_subcommand) catch-all.
+//!
+//! What that buys is the three things the static tables cannot answer for a command they have
+//! never seen: help that lists and navigates runtime commands, completion that descends into
+//! them, and a parse of the argv the catch-all captured. Nothing here mutates the derived parse
+//! tables or the KDL they emit, and nothing here runs a subprocess, reads a file, or calls back
+//! into the application.
 
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
 use std::fmt;
+use std::sync::OnceLock;
 
-use usage_argv::complete::{self, Completions, Files, Shell, Split};
+use usage_argv::complete::{self, CompletionOverlay, CompletionRequest, Completions, Files, Split};
 use usage_argv::spec::{Candidate, CandidateKind, CommandMeta, SpecView};
 use usage_parser::error::UsageErr;
 use usage_parser::Parser;
@@ -19,26 +27,45 @@ pub use usage_parser::parse::ParseOutput;
 pub use usage_parser::Spec;
 
 /// A validated collection of caller-supplied runtime command specs.
+///
+/// Building one validates; it does not assemble. The merged tree help and completion navigate
+/// costs a KDL round trip of the whole host spec, and dispatching a plugin command needs none of
+/// it — so it is built when something asks for it, and a host that only ever runs plugins never
+/// pays. See [`app`](Self::app).
 #[derive(Debug)]
 pub struct Catalog<'a> {
     host: SpecView<'a>,
     entries: Vec<Entry>,
-    merged: Spec,
-    completion: Spec,
+    overlays: &'a [CompletionOverlay<'a>],
+    projection: Option<&'a str>,
+    merged: OnceLock<Result<Spec, Error>>,
 }
 
 #[derive(Debug)]
 struct Entry {
     parent: String,
     name: String,
+    /// Answered to and advertised.
     aliases: Vec<String>,
+    /// Answered to and never advertised — an old name kept working.
+    hidden_aliases: Vec<String>,
     spec: Spec,
 }
 
-/// Cold-path help and completion over the fully merged runtime tree.
+impl Entry {
+    /// Whether this is what the user typed, by any name it answers to.
+    fn answers_to(&self, word: &str) -> bool {
+        self.name == word
+            || self.aliases.iter().any(|alias| alias == word)
+            || self.hidden_aliases.iter().any(|alias| alias == word)
+    }
+}
+
+/// Help and completion over the whole command tree, static and runtime alike.
 #[derive(Debug, Clone, Copy)]
 pub struct App<'a> {
     catalog: &'a Catalog<'a>,
+    merged: &'a Spec,
 }
 
 /// A catalog under construction.
@@ -46,6 +73,8 @@ pub struct App<'a> {
 pub struct Builder<'a> {
     host: SpecView<'a>,
     pending: Vec<(String, Spec)>,
+    overlays: &'a [CompletionOverlay<'a>],
+    projection: Option<&'a str>,
 }
 
 impl<'a> Catalog<'a> {
@@ -54,19 +83,87 @@ impl<'a> Catalog<'a> {
         Builder {
             host,
             pending: Vec::new(),
+            overlays: &[],
+            projection: None,
         }
     }
 
-    /// Cold-path help, completion, and spec access over the fully merged command tree.
-    pub fn app(&self) -> App<'_> {
-        App { catalog: self }
+    /// Help and completion over the whole tree, static commands and runtime ones alike.
+    ///
+    /// The merged tree is assembled here, on the first call, and kept. Building it is a KDL
+    /// round trip of the host spec — cheap next to rendering a page, and not something
+    /// [`parse_external`](Self::parse_external) should ever pay for, which is why it waits until
+    /// somebody asks.
+    ///
+    /// The error is a disagreement between the derived tables and the spec model that read
+    /// them, which [`Builder::build`] cannot see because it has not lowered the host yet.
+    pub fn app(&self) -> Result<App<'_>, &Error> {
+        let merged = self.merged.get_or_init(|| self.merge()).as_ref()?;
+        Ok(App {
+            catalog: self,
+            merged,
+        })
     }
 
-    /// Parse argv captured by an existing external-subcommand variant.
+    /// Whether the merged tree has been assembled yet.
     ///
-    /// `parent` is a static command path, with the empty string denoting the root. The first
-    /// argv token is the external command name. Unknown names return `Ok(None)` so callers may
-    /// retain arbitrary fallback dispatch.
+    /// [`app`](Self::app) builds it once and keeps it, so this answers whether the next call is
+    /// the expensive one. A catalog that is only ever dispatched through never assembles.
+    pub fn is_assembled(&self) -> bool {
+        self.merged.get().is_some()
+    }
+
+    /// Lower the host tables into a spec and graft every entry into it.
+    fn merge(&self) -> Result<Spec, Error> {
+        let mut merged: Spec = self
+            .host
+            .clone()
+            .to_kdl()
+            .parse()
+            .map_err(|error: UsageErr| Error::HostSpec(error.to_string()))?;
+        for entry in &self.entries {
+            insert_plugin(&mut merged, entry)?;
+        }
+        // A grafted command still carries the path it had in the spec it came from, where it was
+        // the root — and so does its parent's usage line, which has just gained a subcommand.
+        // Restamping is what makes the result indistinguishable from a spec that declared these
+        // commands in KDL.
+        merged.restamp();
+        Ok(merged)
+    }
+
+    /// The entry a word beneath a canonical parent path names, by any name it answers to.
+    fn entry(&self, parent: &str, word: &str) -> Option<&Entry> {
+        self.entries
+            .iter()
+            .find(|entry| entry.parent == parent && entry.answers_to(word))
+    }
+
+    /// The static tables' own completion surface, carrying whatever the host registered.
+    fn host_app(&self) -> usage_argv::complete::App<'_> {
+        let app = usage_argv::complete::App::new(self.host.clone()).completions(self.overlays);
+        match self.projection {
+            Some(path) => app.project(path),
+            None => app,
+        }
+    }
+
+    /// Parse the argv an external-subcommand variant captured.
+    ///
+    /// `parent` is the static command path the catch-all sits on, with the empty string meaning
+    /// the root. The first token is the runtime command's name, by any spelling it answers to.
+    ///
+    /// Two of the outcomes here are the caller's to handle rather than errors:
+    ///
+    /// - `Ok(None)` — no catalogued command answers to that name. Whatever the host did with
+    ///   unrecognized words before it had a catalog, it should still do.
+    /// - `Err(Error::NonUtf8)` — a token the portable spec model cannot represent, because it
+    ///   parses `String`s and this one is not one. The derive handed over `OsString`s, which
+    ///   lose nothing, so the argv is still intact: dispatch it the same way as `Ok(None)`
+    ///   rather than failing a command whose argument happens to be an unusual path.
+    ///
+    /// Defaults and environment fallbacks are applied by the plugin's own spec, and `--help` and
+    /// `--version` come back as [`Outcome`]s rather than as errors.
     pub fn parse_external(
         &self,
         parent: &str,
@@ -77,10 +174,7 @@ impl<'a> Catalog<'a> {
             return Ok(None);
         };
         let invoked = invoked.to_str().ok_or(Error::NonUtf8 { index: 0 })?;
-        let Some(entry) = self.entries.iter().find(|entry| {
-            entry.parent == canonical_parent
-                && (entry.name == invoked || entry.aliases.iter().any(|alias| alias == invoked))
-        }) else {
+        let Some(entry) = self.entry(&canonical_parent, invoked) else {
             return Ok(None);
         };
         let mut input = Vec::with_capacity(argv.len());
@@ -125,37 +219,212 @@ impl<'a> Catalog<'a> {
     }
 }
 
-impl App<'_> {
-    /// The fully merged portable spec used for dynamic help and completion.
-    pub fn spec(&self) -> &Spec {
-        &self.catalog.merged
+impl<'a> App<'a> {
+    /// The merged tree: the host's commands with the catalogued ones grafted in.
+    pub fn spec(&self) -> &'a Spec {
+        self.merged
     }
 
-    /// Render help for a static or dynamic command path. The empty path is the root.
+    /// Render help for a static or runtime command path. The empty path is the root.
+    ///
+    /// `long` is the `--help` / `-h` distinction: the full page or the summary.
     pub fn help(self, path: &str, long: bool) -> Option<String> {
-        let command = find_command(&self.catalog.merged, path)?;
+        let command = find_command(self.merged, path)?;
         Some(usage_parser::docs::cli::render_help(
-            &self.catalog.merged,
+            self.merged,
             command,
             long,
         ))
     }
 
-    /// Use this merged tree to answer the usage-rs completion protocol.
-    pub const fn completion_app(self) -> Self {
-        self
+    /// Answer a hidden `__complete_word__` invocation, or return `None` for ordinary argv.
+    ///
+    /// Two answerers, one line. Up to the catch-all the words are the host's, and the host's own
+    /// tables answer for them — the same engine, so registered completers, multicall
+    /// projections and a `--candidates` request all keep working, and the catalogued names are
+    /// added where a subcommand belongs. Past it the words are a plugin's, and that plugin's
+    /// spec answers alone. A name in neither is a program nobody here can describe, and the
+    /// answer is nothing.
+    pub async fn completion_request(self, argv: &[OsString]) -> Option<String> {
+        let request = CompletionRequest::parse(argv)?;
+        let answer = self.complete_request(&request).await;
+        Some(complete::render(&answer, request.shell))
+    }
+
+    /// The answer to a parsed request, before it is written the way a shell reads it.
+    pub async fn complete_request(self, request: &CompletionRequest) -> Completions<'static> {
+        let host = self.catalog.host_app();
+        let split = host.effective_split(&request.split);
+        let position = complete::walk(self.catalog.host.spec().root.cmd, split.argv());
+        match position.external {
+            None => {
+                let mut answer = own(host.complete_request(request).await);
+                if request.candidates_for.is_none() {
+                    self.add_catalogued_commands(&position, &split, &mut answer);
+                }
+                answer
+            }
+            // A spec's `run=` names a completer to *execute*, and executing one is the thing
+            // this crate does not do. A stale script asking for one gets nothing rather than
+            // the wrong list.
+            Some(_) if request.candidates_for.is_some() => Completions {
+                candidates: Vec::new(),
+                files: None,
+            },
+            Some(index) => self.complete_plugin(&position, index, &split),
+        }
     }
 
     /// Complete an already split command line without rendering a shell protocol.
-    pub fn complete(self, split: &Split) -> Result<Completions<'static>, Error> {
-        complete_merged(&self.catalog.completion, split)
+    pub fn complete(self, split: &Split) -> Completions<'static> {
+        // Overlays may be async; this half is for callers that registered none, so polling a
+        // future that never suspends is enough to get at the answer.
+        let request = CompletionRequest::for_split(split.clone());
+        pollster(self.complete_request(&request))
     }
 
-    /// Answer a hidden `__complete_word__` invocation, or return `None` for ordinary argv.
-    pub async fn completion_request(self, argv: &[OsString]) -> Option<String> {
-        let request = CompletionRequest::parse(argv)?;
-        let answer = self.complete(&request.split).ok()?;
-        Some(complete::render(&answer, request.shell))
+    /// Add the runtime commands catalogued beneath the command the cursor is at.
+    ///
+    /// The static tables have never heard of them, so this is the one place their names come
+    /// from. Where they belong is wherever a subcommand of that parent would: not in a flag's
+    /// value, not after a dash, and not where a `help` topic is being asked for.
+    fn add_catalogued_commands(
+        self,
+        position: &usage_argv::complete::Position<'_>,
+        split: &Split,
+        answer: &mut Completions<'static>,
+    ) {
+        if position.help_topic
+            || position.awaiting_value.is_some()
+            || (position.flags_possible && split.prefix.starts_with('-'))
+        {
+            return;
+        }
+        let parent = position
+            .path
+            .iter()
+            .skip(1)
+            .map(|(command, _)| command.name)
+            .collect::<Vec<_>>()
+            .join(" ");
+        let before = answer.candidates.len();
+        for entry in self.catalog.entries.iter().filter(|e| e.parent == parent) {
+            let description = entry
+                .spec
+                .cmd
+                .help
+                .clone()
+                .or_else(|| entry.spec.about.clone());
+            for name in std::iter::once(&entry.name).chain(&entry.aliases) {
+                if name.starts_with(&split.prefix) {
+                    answer.candidates.push(Candidate {
+                        value: name.clone(),
+                        kind: CandidateKind::Command,
+                        display: None,
+                        description: description.clone().map(Cow::Owned),
+                    });
+                }
+            }
+        }
+        if answer.candidates.len() == before {
+            return;
+        }
+        sort_and_dedup(&mut answer.candidates);
+
+        // The static tables offered the working directory because *they* had nothing to say
+        // here; a catalogued name is something to say, and the same rule that closes a position
+        // with candidates in it closes this one. Only when no argument is at the cursor, since
+        // an argument may have asked for paths outright — then both belong.
+        if position.next_arg.is_none()
+            && position.awaiting_value.is_none()
+            && matches!(answer.files, Some(Files::Any))
+        {
+            answer.files = None;
+        }
+    }
+
+    /// Answer from the plugin's own spec, for the words that belong to it.
+    fn complete_plugin(
+        self,
+        position: &usage_argv::complete::Position<'_>,
+        index: usize,
+        split: &Split,
+    ) -> Completions<'static> {
+        let nothing = Completions {
+            candidates: Vec::new(),
+            files: None,
+        };
+        let parent = position
+            .path
+            .iter()
+            .skip(1)
+            .map(|(command, _)| command.name)
+            .collect::<Vec<_>>()
+            .join(" ");
+        let words = split.argv();
+        let Some(invoked) = words.get(index) else {
+            return nothing;
+        };
+        let Some(entry) = self.catalog.entry(&parent, invoked) else {
+            return nothing;
+        };
+        // The plugin's spec describes a program of its own, so the words it is given start with
+        // its own name — its `bin`, not whichever alias was typed, so that a spec selecting an
+        // applet or a view by argv0 selects the same one either way.
+        let argv0 = if entry.spec.bin.trim().is_empty() {
+            entry.name.clone()
+        } else {
+            entry.spec.bin.clone()
+        };
+        let mut input = vec![argv0];
+        input.extend(words[index + 1..].iter().cloned());
+        complete_subtree(&entry.spec, &input, &split.prefix).unwrap_or(nothing)
+    }
+}
+
+/// Sorted and deduplicated the way the static engine does it, so an answer with catalogued
+/// names in it reads as one list rather than two concatenated.
+fn sort_and_dedup(candidates: &mut Vec<Candidate<'static>>) {
+    candidates.sort_unstable();
+    candidates.dedup_by(|a, b| a.value == b.value);
+}
+
+/// Take ownership of an answer borrowed from the static tables.
+///
+/// The tables are `'static` in a real program, but a caller's are not required to be, and this
+/// crate's answers say nothing about where they came from.
+fn own(answer: Completions<'_>) -> Completions<'static> {
+    Completions {
+        candidates: answer
+            .candidates
+            .into_iter()
+            .map(|candidate| Candidate {
+                value: candidate.value,
+                kind: candidate.kind,
+                display: candidate.display.map(|text| Cow::Owned(text.into_owned())),
+                description: candidate
+                    .description
+                    .map(|text| Cow::Owned(text.into_owned())),
+            })
+            .collect(),
+        files: answer.files,
+    }
+}
+
+/// Drive a future that never suspends.
+///
+/// Everything here is synchronous; the async signature exists because a host's *registered*
+/// completers may not be, and this half of the surface is for callers that registered none.
+fn pollster<T>(future: impl std::future::Future<Output = T>) -> T {
+    use std::pin::pin;
+    use std::task::{Context, Poll, Waker};
+    let mut future = pin!(future);
+    match future
+        .as_mut()
+        .poll(&mut Context::from_waker(Waker::noop()))
+    {
+        Poll::Ready(value) => value,
+        Poll::Pending => unreachable!("a completion with no registered callbacks cannot suspend"),
     }
 }
 
@@ -167,23 +436,44 @@ fn find_command<'a>(spec: &'a Spec, path: &str) -> Option<&'a usage_parser::Spec
     Some(command)
 }
 
-fn complete_merged(spec: &Spec, split: &Split) -> Result<Completions<'static>, Error> {
-    let words: Vec<String> = split.words.iter().take(split.cword).cloned().collect();
-    let parsed = usage_parser::parse::parse_partial(spec, &words)
+/// What could go at the cursor, asked of one plugin's own spec.
+///
+/// `input` is the plugin's argv as the plugin would see it — its own name first — and `prefix`
+/// is the word being typed, which is not in `input`: a half-typed word constrains the answer
+/// without being part of the line yet.
+fn complete_subtree(
+    spec: &Spec,
+    input: &[String],
+    prefix: &str,
+) -> Result<Completions<'static>, Error> {
+    let parsed = usage_parser::parse::parse_partial(spec, input)
         .map_err(|error| Error::Parse(error.to_string()))?;
-    let prefix = &split.prefix;
+    // A plugin may itself forward to a program of its own. One level down, the same rule: these
+    // words describe nothing this spec knows about.
+    if parsed.external.is_some() {
+        return Ok(Completions {
+            candidates: Vec::new(),
+            files: None,
+        });
+    }
     let flags_possible = !parsed.double_dash_seen;
+    // A dash-prefixed word is a flag or nothing: no path starts with one.
+    let flag_like = flags_possible && prefix.starts_with('-');
     let mut candidates = Vec::new();
     let mut files = None;
-    let mut declared_completion = false;
+    // Whether the position names its own answers. An unmatched prefix against a declared set
+    // means "nothing matched what you typed", not "ask the filesystem" — offering the working
+    // directory for a mistyped choice answers a question nobody asked.
+    let mut closed = false;
+    let mut at_cursor = None;
 
     if let Some(flag) = parsed.flag_awaiting_value.first() {
         if let Some(arg) = &flag.arg {
             candidates.extend(choice_candidates(arg, prefix));
-            declared_completion = completion_for(spec, &parsed.cmd, &arg.name).is_some();
+            closed |= declares_its_own(spec, &parsed.cmd, arg);
             files = completion_files(spec, &parsed.cmd, &arg.name);
         }
-    } else if flags_possible && prefix.starts_with('-') {
+    } else if flag_like {
         for (form, flag) in parsed.completion_flags() {
             if flag.hide || !form.starts_with(prefix) || hidden_flag_form(&form, &flag) {
                 continue;
@@ -197,8 +487,9 @@ fn complete_merged(spec: &Spec, split: &Split) -> Result<Completions<'static>, E
         }
     } else {
         if let Some(arg) = parsed.next_arg.as_deref() {
+            at_cursor = Some(arg);
             candidates.extend(choice_candidates(arg, prefix));
-            declared_completion = completion_for(spec, &parsed.cmd, &arg.name).is_some();
+            closed |= declares_its_own(spec, &parsed.cmd, arg);
             files = completion_files(spec, &parsed.cmd, &arg.name);
         }
         for command in parsed
@@ -219,13 +510,41 @@ fn complete_merged(spec: &Spec, split: &Split) -> Result<Completions<'static>, E
             }
         }
     }
-    candidates.sort_unstable();
-    candidates.dedup_by(|a, b| a.value == b.value);
-    if candidates.is_empty() && files.is_none() && !declared_completion && !prefix.starts_with('-')
-    {
+    sort_and_dedup(&mut candidates);
+
+    // An argument that requires a `--` is asking for that one word specifically; nothing else
+    // belongs at the cursor until it is there.
+    let needs_separator = parsed.flag_awaiting_value.is_empty()
+        && at_cursor
+            .is_some_and(|arg| arg.double_dash == usage_parser::SpecDoubleDashChoices::Required)
+        && !parsed.double_dash_seen;
+
+    if flag_like || needs_separator {
+        files = None;
+    } else if files.is_none() && candidates.is_empty() && !closed {
         files = Some(Files::Any);
     }
     Ok(Completions { candidates, files })
+}
+
+/// Whether this position states what it accepts, so an unmatched prefix means "no matches".
+///
+/// Choices are the obvious case. A declared `complete` block is one too — unless it says its
+/// values are paths, which is a way of saying the filesystem *is* the answer, or says nothing
+/// at all with `unknown`.
+fn declares_its_own(
+    spec: &Spec,
+    command: &usage_parser::SpecCommand,
+    arg: &usage_parser::SpecArg,
+) -> bool {
+    if arg.choices.is_some() {
+        return true;
+    }
+    completion_for(spec, command, &arg.name).is_some_and(|completion| {
+        completion.type_.as_deref().is_some_and(|type_| {
+            !type_.eq_ignore_ascii_case("unknown") && files_kind(type_).is_none()
+        })
+    })
 }
 
 fn choice_candidates(arg: &usage_parser::SpecArg, prefix: &str) -> Vec<Candidate<'static>> {
@@ -276,8 +595,11 @@ fn hidden_flag_form(form: &str, flag: &usage_parser::SpecFlag) -> bool {
 }
 
 fn completion_files(spec: &Spec, command: &usage_parser::SpecCommand, name: &str) -> Option<Files> {
-    let completion = completion_for(spec, command, name)?;
-    let type_ = completion.type_.as_deref()?;
+    files_kind(completion_for(spec, command, name)?.type_.as_deref()?)
+}
+
+/// The path fallback a declared `complete` type asks for, if it asks for one at all.
+fn files_kind(type_: &str) -> Option<Files> {
     let (kind, filter) = type_
         .split_once(':')
         .map_or((type_, None), |(kind, filter)| (kind, Some(filter)));
@@ -309,62 +631,6 @@ fn completion_for<'a>(
         .or_else(|| spec.complete.get(name))
 }
 
-struct CompletionRequest {
-    shell: Shell,
-    split: Split,
-}
-
-impl CompletionRequest {
-    fn parse(argv: &[OsString]) -> Option<Self> {
-        if argv.first()?.to_str()? != "__complete_word__" {
-            return None;
-        }
-        let mut shell = Shell::Bash;
-        let mut line = String::new();
-        let mut cursor = None;
-        let mut words: Option<Vec<String>> = None;
-        let mut rest = argv[1..].iter();
-        while let Some(arg) = rest.next() {
-            match arg.to_str().unwrap_or_default() {
-                "--shell" => {
-                    shell = rest
-                        .next()
-                        .and_then(|name| Shell::from_name(&name.to_string_lossy()))
-                        .unwrap_or(shell);
-                }
-                "--line" => {
-                    line = rest.next()?.to_string_lossy().into_owned();
-                }
-                "--cursor" => {
-                    cursor = rest.next()?.to_str()?.parse().ok();
-                }
-                "--words" => {
-                    words = Some(
-                        rest.map(|word| word.to_string_lossy().into_owned())
-                            .collect(),
-                    );
-                    break;
-                }
-                _ => {}
-            }
-        }
-        let split = if let Some(mut words) = words {
-            if words.is_empty() {
-                words.push(String::new());
-            }
-            let cword = words.len() - 1;
-            Split {
-                prefix: words[cword].clone(),
-                words,
-                cword,
-            }
-        } else {
-            complete::split(&line, cursor.unwrap_or(line.len()), shell)
-        };
-        Some(Self { shell, split })
-    }
-}
-
 impl<'a> Builder<'a> {
     /// Attach a supplied plugin spec beneath the static root.
     pub fn root(mut self, spec: Spec) -> Self {
@@ -381,15 +647,32 @@ impl<'a> Builder<'a> {
         self
     }
 
-    /// Validate all parents and namespaces and finish the catalog.
+    /// Register the host's own completion callbacks, as
+    /// [`usage_argv::complete::App::completions`] would.
+    ///
+    /// Words before a runtime command are the host's, and the host's engine answers for them —
+    /// so whatever it was given, it keeps.
+    pub const fn completions(mut self, overlays: &'a [CompletionOverlay<'a>]) -> Self {
+        self.overlays = overlays;
+        self
+    }
+
+    /// Answer as though this command path came after argv0, for a multicall binary.
+    ///
+    /// The same projection [`usage_argv::complete::App::project`] applies, applied once, before
+    /// anything asks where the words are.
+    pub const fn project(mut self, command_path: &'a str) -> Self {
+        self.projection = Some(command_path);
+        self
+    }
+
+    /// Validate every parent and name, and finish the catalog.
+    ///
+    /// What is checked here is what the static tables can answer on their own: that the parent
+    /// exists, that it invited runtime commands, and that no name collides. Assembling the
+    /// merged tree is left to [`Catalog::app`] — dispatching a plugin command never needs it.
     pub fn build(self) -> Result<Catalog<'a>, Error> {
         let host = self.host.spec();
-        let mut merged: Spec = self
-            .host
-            .clone()
-            .to_kdl()
-            .parse()
-            .map_err(|error: UsageErr| Error::HostSpec(error.to_string()))?;
         let mut entries = Vec::with_capacity(self.pending.len());
         let mut claimed: HashMap<String, HashSet<String>> = HashMap::new();
         for (requested_parent, spec) in self.pending {
@@ -406,15 +689,18 @@ impl<'a> Builder<'a> {
             if name.is_empty() {
                 return Err(Error::EmptyName);
             }
-            let mut aliases = spec.cmd.aliases.clone();
-            for alias in &spec.cmd.hidden_aliases {
-                if !aliases.contains(alias) {
-                    aliases.push(alias.clone());
-                }
-            }
-            let mut forms = Vec::with_capacity(1 + aliases.len());
+            let aliases = spec.cmd.aliases.clone();
+            let hidden_aliases: Vec<String> = spec
+                .cmd
+                .hidden_aliases
+                .iter()
+                .filter(|alias| !aliases.contains(alias))
+                .cloned()
+                .collect();
+            let mut forms = Vec::with_capacity(1 + aliases.len() + hidden_aliases.len());
             forms.push(name.clone());
             forms.extend(aliases.iter().cloned());
+            forms.extend(hidden_aliases.iter().cloned());
             if forms.iter().any(|form| form.is_empty()) {
                 return Err(Error::EmptyName);
             }
@@ -436,35 +722,32 @@ impl<'a> Builder<'a> {
                     });
                 }
             }
-            insert_plugin(&mut merged, &parent, &name, &spec)?;
             entries.push(Entry {
                 parent,
                 name,
                 aliases,
+                hidden_aliases,
                 spec,
             });
         }
-        // Re-reading recalculates every `full_cmd`, usage line, and command lookup cache after
-        // insertion. This is cold construction work and keeps the merged tree internally
-        // indistinguishable from a spec that declared the commands in KDL.
-        merged = merged
-            .to_string()
-            .parse()
-            .map_err(|error: UsageErr| Error::HostSpec(error.to_string()))?;
-        let mut completion = merged.clone();
-        clear_mounts(&mut completion.cmd);
         Ok(Catalog {
             host: self.host,
             entries,
-            merged,
-            completion,
+            overlays: self.overlays,
+            projection: self.projection,
+            merged: OnceLock::new(),
         })
     }
 }
 
-fn insert_plugin(merged: &mut Spec, parent: &str, name: &str, plugin: &Spec) -> Result<(), Error> {
+/// Graft one entry's spec into the merged tree as a command of its parent.
+///
+/// A spec describes a program, and a command is one thing a program can be. What the two models
+/// keep in different places — a program's `about` is a command's `help` — moves across here.
+fn insert_plugin(merged: &mut Spec, entry: &Entry) -> Result<(), Error> {
+    let plugin = &entry.spec;
     let mut command = plugin.cmd.clone();
-    command.name = name.to_owned();
+    command.name = entry.name.clone();
     command.help = command.help.or_else(|| plugin.about.clone());
     command.help_long = command.help_long.or_else(|| plugin.about_long.clone());
     command.before_help = command.before_help.or_else(|| plugin.before_help.clone());
@@ -479,13 +762,13 @@ fn insert_plugin(merged: &mut Spec, parent: &str, name: &str, plugin: &Spec) -> 
         command.complete.insert(key.clone(), complete.clone());
     }
     let mut current = &mut merged.cmd;
-    for component in parent.split_ascii_whitespace() {
+    for component in entry.parent.split_ascii_whitespace() {
         current = current
             .subcommands
             .get_mut(component)
-            .ok_or_else(|| Error::MissingParent(parent.to_owned()))?;
+            .ok_or_else(|| Error::MissingParent(entry.parent.clone()))?;
     }
-    current.subcommands.insert(name.to_owned(), command);
+    current.subcommands.insert(entry.name.clone(), command);
     Ok(())
 }
 
@@ -501,7 +784,11 @@ fn resolve_parent<'a>(
     let mut canonical = Vec::new();
     for component in requested.split_ascii_whitespace() {
         let Some(next) = current.subcommands.iter().copied().find(|candidate| {
-            candidate.cmd.name == component || candidate.cmd.aliases.contains(&component)
+            candidate.cmd.name == component
+                || candidate.cmd.aliases.contains(&component)
+                // A hidden alias is one the CLI answers to, and an application naming its own
+                // static command is not "a user" being kept from an old spelling.
+                || candidate.hidden_aliases.contains(&component)
         }) else {
             return Err(Error::MissingParent(requested.to_owned()));
         };
@@ -519,13 +806,6 @@ fn reject_mounts(command: &usage_parser::SpecCommand) -> Result<(), Error> {
         reject_mounts(child)?;
     }
     Ok(())
-}
-
-fn clear_mounts(command: &mut usage_parser::SpecCommand) {
-    command.mounts.clear();
-    for child in command.subcommands.values_mut() {
-        clear_mounts(child);
-    }
 }
 
 /// The result of parsing a catalogued external command.

--- a/usage-dynamic/tests/catalog.rs
+++ b/usage-dynamic/tests/catalog.rs
@@ -713,3 +713,76 @@ fn a_builtin_never_needs_a_catalog_and_a_fallback_needs_one_spec() {
         .unwrap()
         .is_none());
 }
+
+#[test]
+fn a_spec_built_in_rust_works_like_one_parsed_from_kdl() {
+    // KDL is the contract with out-of-process plugins. Commands the application itself defines
+    // at runtime — tasks from a config file, say — should not have to render KDL text just so
+    // the catalog can parse it back. A `Spec` assembled with the builders must behave
+    // identically.
+    use usage_dynamic::{SpecArgBuilder, SpecCommandBuilder, SpecFlagBuilder};
+
+    let task: Spec = SpecCommandBuilder::new()
+        .name("deploy")
+        .help("Deploy the project")
+        .flag(
+            SpecFlagBuilder::new()
+                .name("env")
+                .long("env")
+                .arg(SpecArgBuilder::new().name("ENV").build())
+                .help("Target environment")
+                .build(),
+        )
+        .subcommand(
+            SpecCommandBuilder::new()
+                .name("status")
+                .help("Show deploy status")
+                .build(),
+        )
+        .build()
+        .into();
+    assert_eq!(task.name, "deploy");
+    assert_eq!(task.about.as_deref(), Some("Deploy the project"));
+
+    let catalog = Catalog::builder(Host::app())
+        .under("plugins", task)
+        .build()
+        .unwrap();
+
+    // Dispatch parses against the built spec, help/version included.
+    let parsed = catalog
+        .parse_external(
+            "plugins",
+            &[
+                OsString::from("deploy"),
+                OsString::from("--env"),
+                OsString::from("prod"),
+            ],
+        )
+        .unwrap()
+        .unwrap();
+    let Outcome::Parsed(parsed) = parsed else {
+        panic!("expected parsed")
+    };
+    assert!(!parsed.output.flags.is_empty());
+    let help = catalog
+        .parse_external(
+            "plugins",
+            &[OsString::from("deploy"), OsString::from("--help")],
+        )
+        .unwrap()
+        .unwrap();
+    let Outcome::Help(help) = help else {
+        panic!("expected help")
+    };
+    // The page's usage line reflects where the command sits, same as a KDL-parsed spec's would.
+    assert!(help.page.contains("deploy"), "{}", help.page);
+    assert!(help.page.contains("status"), "{}", help.page);
+    assert!(help.page.contains("--env"), "{}", help.page);
+
+    // Merged help and completion see it too.
+    let app = catalog.app().unwrap();
+    assert!(app.help("plugins deploy", false).unwrap().contains("--env"));
+    let offered = answer(&catalog, &["host", "plugins", "deploy", ""]);
+    assert!(offered.contains(&"status".to_string()), "{offered:?}");
+}

--- a/usage-dynamic/tests/catalog.rs
+++ b/usage-dynamic/tests/catalog.rs
@@ -1,0 +1,294 @@
+use std::ffi::{OsStr, OsString};
+
+use futures::executor::block_on;
+use usage_dynamic::{Catalog, Error, Outcome, Spec};
+use usage_rs::{Cli, Subcommands};
+
+#[derive(Cli)]
+#[usage(bin = "host")]
+struct Host {
+    #[usage(subcommand)]
+    command: HostCommand,
+}
+
+#[derive(Subcommands)]
+enum HostCommand {
+    /// Built into the host.
+    Builtin,
+    /// Manage plugins.
+    #[usage(alias = "p")]
+    Plugins {
+        #[usage(subcommand)]
+        command: PluginCommand,
+    },
+}
+
+#[derive(Subcommands)]
+enum PluginCommand {
+    /// A static plugin operation.
+    #[usage(alias = "ls")]
+    List,
+    #[usage(external_subcommand)]
+    External(Vec<OsString>),
+}
+
+#[derive(Cli)]
+#[usage(bin = "root-host")]
+#[allow(dead_code)]
+struct RootHost {
+    #[usage(subcommand)]
+    command: RootCommand,
+}
+
+#[derive(Subcommands)]
+#[allow(dead_code)]
+enum RootCommand {
+    Known,
+    #[usage(external_subcommand)]
+    External(Vec<String>),
+}
+
+#[derive(Cli)]
+#[usage(bin = "closed")]
+#[allow(dead_code)]
+struct Closed {
+    #[usage(subcommand)]
+    command: ClosedCommand,
+}
+
+#[derive(Subcommands)]
+enum ClosedCommand {
+    Child,
+}
+
+fn plugin(name: &str, extra: &str) -> Spec {
+    format!("name \"{name}\"\nbin \"{name}\"\n{extra}")
+        .parse()
+        .unwrap()
+}
+
+fn catalog() -> usage_dynamic::Catalog<'static> {
+    let mut formatter = plugin(
+        "formatter",
+        r#"
+version "2.4"
+unknown_flags "error"
+flag "--color <WHEN>" env="USAGE_DYNAMIC_TEST_COLOR" default="always"
+arg "[path]"
+"#,
+    );
+    formatter.about = Some("Format a project".into());
+    formatter.about_long = Some("Format a project using its configured style.".into());
+    formatter.cmd.help_heading = Some("Installed plugins".into());
+    formatter.cmd.display_order = Some(2);
+    formatter.cmd.aliases = vec!["fmt".into(), "oldfmt".into()];
+    formatter.cmd.hidden_aliases = vec!["oldfmt".into()];
+    let mut audit = plugin("audit", "");
+    audit.about = Some("Audit a project".into());
+    audit.cmd.help_heading = Some("Installed plugins".into());
+    audit.cmd.display_order = Some(1);
+    Catalog::builder(Host::app())
+        .under("p", formatter)
+        .under("plugins", audit)
+        .build()
+        .unwrap()
+}
+
+#[test]
+fn root_summaries_appear_in_help_and_completion() {
+    let mut spec = plugin("doctor", "");
+    spec.about = Some("Inspect plugin health".into());
+    let catalog = Catalog::builder(RootHost::app())
+        .root(spec)
+        .build()
+        .unwrap();
+    assert_eq!(RootHost::app().to_kdl(), catalog.app().to_kdl());
+    let help = catalog.app().help("", false).unwrap();
+    assert!(help.contains("doctor  Inspect plugin health"), "{help}");
+
+    let argv = [
+        OsString::from("__complete_word__"),
+        OsString::from("--words"),
+        OsString::from("root-host"),
+        OsString::new(),
+    ];
+    let answer = block_on(catalog.app().completion_app().completion_request(&argv)).unwrap();
+    assert!(
+        answer.lines().any(|line| line.starts_with("doctor")),
+        "{answer}"
+    );
+}
+
+#[test]
+fn nested_help_merges_summaries_aliases_headings_and_ordering() {
+    let app = catalog().app();
+    for long in [false, true] {
+        let help = app.help("plugins", long).unwrap();
+        assert!(help.contains("Installed plugins:"), "{help}");
+        assert!(help.contains("plugins formatter [aliases: fmt]"), "{help}");
+        assert!(!help.contains("oldfmt"), "{help}");
+        assert!(
+            help.find("plugins audit").unwrap() < help.find("plugins formatter").unwrap(),
+            "{help}"
+        );
+    }
+}
+
+#[test]
+fn command_completion_offers_visible_names_and_delegates_after_selection() {
+    let app = catalog().app().completion_app();
+    let request = |words: &[&str]| {
+        let mut argv = vec![
+            OsString::from("__complete_word__"),
+            OsString::from("--words"),
+        ];
+        argv.extend(words.iter().map(OsString::from));
+        block_on(app.clone().completion_request(&argv)).unwrap()
+    };
+    let answer = request(&["host", "plugins", ""]);
+    assert!(
+        answer.lines().any(|line| line.starts_with("formatter")),
+        "{answer}"
+    );
+    assert!(
+        answer.lines().any(|line| line.starts_with("fmt")),
+        "{answer}"
+    );
+    assert!(!answer.contains("oldfmt"), "{answer}");
+    assert_eq!(request(&["host", "plugins", "formatter", ""]), "");
+}
+
+#[test]
+fn canonical_alias_unknown_help_version_and_invalid_argv_are_typed() {
+    let catalog = catalog();
+    let parsed = catalog
+        .parse_external("p", &[OsString::from("fmt"), OsString::from("project")])
+        .unwrap()
+        .unwrap();
+    let Outcome::Parsed(parsed) = parsed else {
+        panic!("expected parsed")
+    };
+    assert_eq!(parsed.parent, "plugins");
+    assert_eq!(parsed.name, "formatter");
+    assert_eq!(parsed.invoked_as, "fmt");
+    assert!(!parsed.output.tokens.is_empty());
+    assert!(!parsed.output.flags.is_empty(), "default should be applied");
+
+    std::env::set_var("USAGE_DYNAMIC_TEST_COLOR", "never");
+    let from_env = catalog
+        .parse_external("plugins", &[OsString::from("formatter")])
+        .unwrap()
+        .unwrap();
+    std::env::remove_var("USAGE_DYNAMIC_TEST_COLOR");
+    let Outcome::Parsed(from_env) = from_env else {
+        panic!("expected parsed")
+    };
+    assert!(from_env
+        .output
+        .flag_origins
+        .values()
+        .flatten()
+        .any(|origin| format!("{origin:?}").contains("Env")));
+
+    assert!(catalog
+        .parse_external("plugins", &[OsString::from("missing")])
+        .unwrap()
+        .is_none());
+    let help = catalog
+        .parse_external(
+            "plugins",
+            &[OsString::from("formatter"), OsString::from("--help")],
+        )
+        .unwrap();
+    assert!(matches!(help, Some(Outcome::Help(_))), "{help:?}");
+    assert!(matches!(
+        catalog
+            .parse_external(
+                "plugins",
+                &[OsString::from("formatter"), OsString::from("--version")]
+            )
+            .unwrap(),
+        Some(Outcome::Version(_))
+    ));
+    assert!(matches!(
+        catalog.parse_external(
+            "plugins",
+            &[OsString::from("formatter"), OsString::from("--bogus")]
+        ),
+        Err(Error::Parse(_)) | Err(Error::InvalidArgv(_))
+    ));
+}
+
+#[test]
+fn derived_external_variant_receives_the_same_argv_the_catalog_parses() {
+    let host =
+        Host::parse_from(&[OsStr::new("plugins"), OsStr::new("fmt"), OsStr::new("src")]).unwrap();
+    let HostCommand::Plugins {
+        command: PluginCommand::External(argv),
+    } = host.command
+    else {
+        panic!("expected nested external command")
+    };
+    assert!(matches!(
+        catalog().parse_external("plugins", &argv).unwrap(),
+        Some(Outcome::Parsed(_))
+    ));
+}
+
+#[test]
+fn validation_rejects_bad_parents_namespaces_and_mounts() {
+    assert!(matches!(
+        Catalog::builder(Host::app())
+            .under("absent", plugin("x", ""))
+            .build(),
+        Err(Error::MissingParent(_))
+    ));
+    assert!(matches!(
+        Catalog::builder(Closed::app())
+            .under("child", plugin("x", ""))
+            .build(),
+        Err(Error::ParentNotExternal(_))
+    ));
+    assert!(matches!(
+        Catalog::builder(Host::app())
+            .under("plugins", plugin("", ""))
+            .build(),
+        Err(Error::EmptyName)
+    ));
+    for name in ["list", "ls", "help"] {
+        assert!(matches!(
+            Catalog::builder(Host::app())
+                .under("plugins", plugin(name, ""))
+                .build(),
+            Err(Error::Collision { .. })
+        ));
+    }
+    let mut alias_collision = plugin("one", "");
+    alias_collision.cmd.aliases.push("same".into());
+    assert!(matches!(
+        Catalog::builder(Host::app())
+            .under("plugins", alias_collision)
+            .under("plugins", plugin("same", ""))
+            .build(),
+        Err(Error::Collision { .. })
+    ));
+    assert!(matches!(
+        Catalog::builder(Host::app())
+            .under("plugins", plugin("mounted", "mount run=\"discover\"\n"))
+            .build(),
+        Err(Error::UnresolvedMount(_))
+    ));
+}
+
+#[cfg(unix)]
+#[test]
+fn non_utf8_reports_the_external_token_position() {
+    use std::os::unix::ffi::OsStringExt;
+    let error = catalog()
+        .parse_external(
+            "plugins",
+            &[OsString::from("formatter"), OsString::from_vec(vec![0xff])],
+        )
+        .unwrap_err();
+    assert!(matches!(error, Error::NonUtf8 { index: 1 }));
+}

--- a/usage-dynamic/tests/catalog.rs
+++ b/usage-dynamic/tests/catalog.rs
@@ -670,3 +670,46 @@ fn a_named_completer_request_is_answered_by_the_host() {
     let rendered = block_on(catalog.app().unwrap().completion_request(&argv)).unwrap();
     assert!(rendered.trim().is_empty(), "{rendered:?}");
 }
+
+#[test]
+fn a_builtin_never_needs_a_catalog_and_a_fallback_needs_one_spec() {
+    // The design's cost promise: parse first, against the static tables alone. A built-in
+    // command dispatches before any catalog exists, so a plugin manager pays for discovery
+    // only when the catch-all actually fired — and then only for the specs it chose to load.
+    let host = Host::parse_from(&[OsStr::new("builtin")]).unwrap();
+    assert!(matches!(host.command, HostCommand::Builtin));
+    // No catalog was constructed on that path at all.
+
+    let host = Host::parse_from(&[
+        OsStr::new("plugins"),
+        OsStr::new("formatter"),
+        OsStr::new("src"),
+    ])
+    .unwrap();
+    let HostCommand::Plugins {
+        command: PluginCommand::External(captured),
+    } = host.command
+    else {
+        panic!("expected the catch-all")
+    };
+    // Load exactly one plugin's spec, after the parse decided one is needed.
+    let catalog = Catalog::builder(Host::app())
+        .under("plugins", plugin("formatter", "arg \"[path]\"\n"))
+        .build()
+        .unwrap();
+    assert!(matches!(
+        catalog.parse_external("plugins", &captured).unwrap(),
+        Some(Outcome::Parsed(_))
+    ));
+    assert!(!catalog.is_assembled(), "dispatch built no merged tree");
+
+    // A name the loaded specs do not answer to falls through, same as always.
+    let catalog = Catalog::builder(Host::app())
+        .under("plugins", plugin("audit", ""))
+        .build()
+        .unwrap();
+    assert!(catalog
+        .parse_external("plugins", &captured)
+        .unwrap()
+        .is_none());
+}

--- a/usage-dynamic/tests/catalog.rs
+++ b/usage-dynamic/tests/catalog.rs
@@ -32,6 +32,65 @@ enum PluginCommand {
     External(Vec<OsString>),
 }
 
+/// A host with a value flag a runtime completer answers for.
+#[derive(Cli)]
+#[usage(bin = "themehost")]
+#[allow(dead_code)]
+struct ThemeHost {
+    /// Which theme to use.
+    #[usage(long)]
+    theme: Option<String>,
+    #[usage(subcommand)]
+    command: ThemeCommand,
+}
+
+#[derive(Subcommands)]
+#[allow(dead_code)]
+enum ThemeCommand {
+    Plugins {
+        #[usage(subcommand)]
+        command: ThemePluginCommand,
+    },
+}
+
+#[derive(Subcommands)]
+#[allow(dead_code)]
+enum ThemePluginCommand {
+    List,
+    #[usage(external_subcommand)]
+    External(Vec<OsString>),
+}
+
+/// A host flag, declared where runtime commands also appear.
+#[derive(Cli)]
+#[usage(bin = "flaghost")]
+#[allow(dead_code)]
+struct FlagHost {
+    #[usage(subcommand)]
+    command: FlagHostCommand,
+}
+
+#[derive(Subcommands)]
+#[allow(dead_code)]
+enum FlagHostCommand {
+    Plugins {
+        /// Say less.
+        #[usage(long)]
+        quiet: bool,
+        #[usage(subcommand)]
+        command: FlagPluginCommand,
+    },
+}
+
+#[derive(Subcommands)]
+#[allow(dead_code)]
+enum FlagPluginCommand {
+    /// A static plugin operation.
+    List,
+    #[usage(external_subcommand)]
+    External(Vec<OsString>),
+}
+
 #[derive(Cli)]
 #[usage(bin = "root-host")]
 #[allow(dead_code)]
@@ -73,7 +132,9 @@ fn catalog() -> usage_dynamic::Catalog<'static> {
         r#"
 version "2.4"
 unknown_flags "error"
-flag "--color <WHEN>" env="USAGE_DYNAMIC_TEST_COLOR" default="always"
+flag "--color <WHEN>" env="USAGE_DYNAMIC_TEST_COLOR" default="always" {
+    choices "always" "never"
+}
 arg "[path]"
 cmd "check" help="Check formatting" {
     flag "--fix" help="Apply fixes"
@@ -107,10 +168,11 @@ fn root_summaries_appear_in_help_and_completion() {
         .build()
         .unwrap();
     assert_eq!(static_kdl, RootHost::app().to_kdl());
-    let help = catalog.app().help("", false).unwrap();
+    let help = catalog.app().unwrap().help("", false).unwrap();
     assert!(help.contains("doctor  Inspect plugin health"), "{help}");
     assert!(catalog
         .app()
+        .unwrap()
         .help("doctor", false)
         .unwrap()
         .contains("Inspect plugin health"));
@@ -121,7 +183,7 @@ fn root_summaries_appear_in_help_and_completion() {
         OsString::from("root-host"),
         OsString::new(),
     ];
-    let answer = block_on(catalog.app().completion_app().completion_request(&argv)).unwrap();
+    let answer = block_on(catalog.app().unwrap().completion_request(&argv)).unwrap();
     assert!(
         answer.lines().any(|line| line.starts_with("doctor")),
         "{answer}"
@@ -142,7 +204,7 @@ fn root_summaries_appear_in_help_and_completion() {
 #[test]
 fn nested_help_merges_summaries_aliases_headings_and_ordering() {
     let catalog = catalog();
-    let app = catalog.app();
+    let app = catalog.app().unwrap();
     for long in [false, true] {
         let help = app.help("plugins", long).unwrap();
         assert!(help.contains("Installed plugins:"), "{help}");
@@ -164,7 +226,7 @@ fn nested_help_merges_summaries_aliases_headings_and_ordering() {
 #[test]
 fn command_completion_offers_visible_names_and_delegates_after_selection() {
     let catalog = catalog();
-    let app = catalog.app().completion_app();
+    let app = catalog.app().unwrap();
     let parsed = usage_parser::parse::parse_partial(
         app.spec(),
         &["host".into(), "plugins".into(), "formatter".into()],
@@ -334,4 +396,277 @@ fn non_utf8_reports_the_external_token_position() {
         )
         .unwrap_err();
     assert!(matches!(error, Error::NonUtf8 { index: 1 }));
+}
+
+/// The answer to a completion request, as the lines a shell would read.
+fn answer(catalog: &Catalog<'_>, words: &[&str]) -> Vec<String> {
+    let mut argv = vec![
+        OsString::from("__complete_word__"),
+        OsString::from("--words"),
+    ];
+    argv.extend(words.iter().map(OsString::from));
+    block_on(catalog.app().unwrap().completion_request(&argv))
+        .unwrap()
+        .lines()
+        .map(|line| line.split('\t').next().unwrap_or_default().to_string())
+        .collect()
+}
+
+#[test]
+fn a_catalogued_name_is_offered_where_a_subcommand_belongs() {
+    let catalog = catalog();
+    let offered = answer(&catalog, &["host", "plugins", ""]);
+    // Static commands and runtime ones, in one list: a user typing here cannot tell which is
+    // which, and should not have to.
+    for name in ["list", "ls", "audit", "formatter", "fmt"] {
+        assert!(offered.contains(&name.to_string()), "{name}: {offered:?}");
+    }
+    // A hidden alias answers but is never advertised — the same rule static ones follow.
+    assert!(!offered.contains(&"oldfmt".to_string()), "{offered:?}");
+    // One list, sorted and deduplicated, rather than two concatenated.
+    let mut sorted = offered.clone();
+    sorted.sort();
+    sorted.dedup();
+    assert_eq!(offered, sorted, "{offered:?}");
+
+    // A prefix narrows runtime names as it narrows static ones.
+    assert_eq!(answer(&catalog, &["host", "plugins", "fo"]), ["formatter"]);
+}
+
+#[test]
+fn a_flag_position_is_the_hosts_alone() {
+    // Runtime commands are commands. Where a flag is what could be typed, the host's tables are
+    // the whole answer and a plugin name would be a word that cannot go there.
+    let catalog = Catalog::builder(FlagHost::app())
+        .under("plugins", plugin("formatter", ""))
+        .build()
+        .unwrap();
+    let offered = answer(&catalog, &["flaghost", "plugins", "--"]);
+    assert!(offered.iter().any(|line| line == "--quiet"), "{offered:?}");
+    assert!(!offered.contains(&"formatter".to_string()), "{offered:?}");
+}
+
+#[test]
+fn completion_descends_into_a_plugins_own_spec() {
+    let catalog = catalog();
+    // Its subcommands, and not the sibling static ones it is being completed alongside.
+    let offered = answer(&catalog, &["host", "plugins", "formatter", ""]);
+    assert!(offered.contains(&"check".to_string()), "{offered:?}");
+    assert!(!offered.contains(&"list".to_string()), "{offered:?}");
+
+    // Its flags.
+    let flags = answer(&catalog, &["host", "plugins", "formatter", "--"]);
+    assert!(flags.contains(&"--color".to_string()), "{flags:?}");
+
+    // Its nested command's flags, reached through an alias of its own.
+    let nested = answer(&catalog, &["host", "plugins", "fmt", "check", "--f"]);
+    assert!(nested.contains(&"--fix".to_string()), "{nested:?}");
+
+    // And its declared choices, which are the whole answer: a mistyped one is no matches, not
+    // an invitation to complete a path.
+    let choices = answer(&catalog, &["host", "plugins", "formatter", "--color", ""]);
+    assert_eq!(choices, ["always", "never"], "{choices:?}");
+    let mistyped = answer(&catalog, &["host", "plugins", "formatter", "--color", "zz"]);
+    assert!(mistyped.is_empty(), "{mistyped:?}");
+}
+
+#[test]
+fn a_hidden_alias_descends_without_being_advertised() {
+    let catalog = catalog();
+    let offered = answer(&catalog, &["host", "plugins", "oldfmt", ""]);
+    assert!(offered.contains(&"check".to_string()), "{offered:?}");
+}
+
+#[test]
+fn an_uncatalogued_name_is_answered_with_nothing() {
+    // The host has no idea what `unknownthing` is, and neither does this catalog. Offering the
+    // parent's static subcommands there would complete a line that runs something else, and
+    // offering the working directory would claim a path belongs to a program nobody can ask.
+    let catalog = catalog();
+    let offered = answer(&catalog, &["host", "plugins", "unknownthing", ""]);
+    assert!(offered.is_empty(), "{offered:?}");
+    let raw = {
+        let argv = [
+            OsString::from("__complete_word__"),
+            OsString::from("--words"),
+            OsString::from("host"),
+            OsString::from("plugins"),
+            OsString::from("unknownthing"),
+            OsString::new(),
+        ];
+        block_on(catalog.app().unwrap().completion_request(&argv)).unwrap()
+    };
+    assert!(!raw.contains('\u{1}'), "no path fallback either: {raw:?}");
+}
+
+#[test]
+fn a_host_flag_before_the_name_does_not_move_the_boundary() {
+    let catalog = Catalog::builder(FlagHost::app())
+        .under("plugins", plugin("formatter", "cmd \"check\" {}\n"))
+        .build()
+        .unwrap();
+    let offered = answer(
+        &catalog,
+        &["flaghost", "plugins", "--quiet", "formatter", ""],
+    );
+    assert!(offered.contains(&"check".to_string()), "{offered:?}");
+}
+
+#[test]
+fn a_line_and_a_word_list_are_the_same_question() {
+    // Two ways in to the same protocol: elvish hands over pre-split words, the others a line
+    // and a cursor. A host answering half the line itself must not make them disagree.
+    let catalog = catalog();
+    let by_words = answer(&catalog, &["host", "plugins", "formatter", ""]);
+    let by_line = {
+        let argv = [
+            OsString::from("__complete_word__"),
+            OsString::from("--line"),
+            OsString::from("host plugins formatter "),
+        ];
+        block_on(catalog.app().unwrap().completion_request(&argv))
+            .unwrap()
+            .lines()
+            .map(|line| line.split('\t').next().unwrap_or_default().to_string())
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(by_words, by_line);
+
+    // A cursor before the end completes what is under it, and the words after it are not part
+    // of the question.
+    let mid = {
+        let line = "host plugins formatter check";
+        let argv = [
+            OsString::from("__complete_word__"),
+            OsString::from("--line"),
+            OsString::from(line),
+            OsString::from("--cursor"),
+            OsString::from("21"),
+        ];
+        block_on(catalog.app().unwrap().completion_request(&argv))
+            .unwrap()
+            .lines()
+            .map(|line| line.split('\t').next().unwrap_or_default().to_string())
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(mid, ["formatter"], "completing `form⌶` mid-line");
+}
+
+#[test]
+fn an_open_position_still_defers_to_the_shells_paths() {
+    // The tightening is about positions that state their own answers. One that has nothing to
+    // say still hands over to the shell, or completing a plugin's file argument would offer
+    // nothing at all. `check` declares a flag and no words of its own, so a bare word there is
+    // the filesystem's to answer.
+    let catalog = catalog();
+    let argv = [
+        OsString::from("__complete_word__"),
+        OsString::from("--words"),
+        OsString::from("host"),
+        OsString::from("plugins"),
+        OsString::from("formatter"),
+        OsString::from("check"),
+        OsString::new(),
+    ];
+    let raw = block_on(catalog.app().unwrap().completion_request(&argv)).unwrap();
+    assert!(raw.contains("\u{1}files"), "{raw:?}");
+}
+
+#[test]
+fn dispatch_never_builds_the_merged_tree() {
+    // The point of the split: running a plugin command is the hot path, and the merged tree is
+    // a KDL round trip of the whole host spec. A catalog that is only ever dispatched through
+    // must never assemble one — which is observable, because `app()` is what assembles it.
+    let catalog = catalog();
+    assert!(matches!(
+        catalog
+            .parse_external("plugins", &[OsString::from("fmt")])
+            .unwrap(),
+        Some(Outcome::Parsed(_))
+    ));
+    assert!(!catalog.is_assembled());
+    catalog.app().unwrap();
+    assert!(catalog.is_assembled());
+}
+
+/// A runtime completer of the host's own, of the kind `completions` registers.
+fn theme_values(
+    _: &usage_rs::complete::CompleteCtx<'_>,
+) -> Vec<usage_rs::complete::Candidate<'static>> {
+    vec![usage_rs::complete::Candidate::new("solarized")]
+}
+
+fn theme_values_async(
+    ctx: usage_rs::complete::CompleteCtx<'_>,
+) -> usage_rs::complete::CompletionFuture<'_> {
+    let _ = ctx;
+    Box::pin(async { vec![usage_rs::complete::Candidate::new("midnight")] })
+}
+
+static OVERLAYS: [usage_rs::complete::CompletionOverlay<'static>; 1] =
+    [usage_rs::complete::CompletionOverlay::sync_any(
+        "theme",
+        theme_values,
+    )];
+
+static ASYNC_OVERLAYS: [usage_rs::complete::CompletionOverlay<'static>; 1] =
+    [usage_rs::complete::CompletionOverlay::async_any(
+        "theme",
+        theme_values_async,
+    )];
+
+#[test]
+fn the_hosts_own_completers_still_answer_for_the_hosts_words() {
+    // The catalog answers part of the line, not all of it. Everything the host registered has
+    // to keep working, or adopting runtime commands would quietly cost a CLI its completions.
+    for (overlays, expected) in [
+        (&OVERLAYS[..], "solarized"),
+        (&ASYNC_OVERLAYS[..], "midnight"),
+    ] {
+        let catalog = Catalog::builder(ThemeHost::app())
+            .completions(overlays)
+            .under("plugins", plugin("formatter", ""))
+            .build()
+            .unwrap();
+        let argv = [
+            OsString::from("__complete_word__"),
+            OsString::from("--line"),
+            OsString::from("themehost --theme "),
+        ];
+        let rendered = block_on(catalog.app().unwrap().completion_request(&argv)).unwrap();
+        assert!(rendered.contains(expected), "{rendered:?}");
+    }
+}
+
+#[test]
+fn a_named_completer_request_is_answered_by_the_host() {
+    // What a spec's `run=` line asks for: one named completer's values rather than everything
+    // the cursor could take. The request has its own flag, and a host that dropped it would
+    // answer a different question than the KDL it emitted promised.
+    let catalog = Catalog::builder(ThemeHost::app())
+        .completions(&OVERLAYS)
+        .under("plugins", plugin("formatter", ""))
+        .build()
+        .unwrap();
+    let argv = [
+        OsString::from("__complete_word__"),
+        OsString::from("--candidates"),
+        OsString::from("theme"),
+        OsString::from("--line"),
+        OsString::from("themehost "),
+    ];
+    let rendered = block_on(catalog.app().unwrap().completion_request(&argv)).unwrap();
+    assert!(rendered.contains("solarized"), "{rendered:?}");
+
+    // Past a runtime command there is nothing to run it with: a `run=` completer is a
+    // subprocess, and this crate spawns none.
+    let argv = [
+        OsString::from("__complete_word__"),
+        OsString::from("--candidates"),
+        OsString::from("theme"),
+        OsString::from("--line"),
+        OsString::from("themehost plugins formatter "),
+    ];
+    let rendered = block_on(catalog.app().unwrap().completion_request(&argv)).unwrap();
+    assert!(rendered.trim().is_empty(), "{rendered:?}");
 }

--- a/usage-dynamic/tests/catalog.rs
+++ b/usage-dynamic/tests/catalog.rs
@@ -299,6 +299,16 @@ fn canonical_alias_unknown_help_version_and_invalid_argv_are_typed() {
         .parse_external("plugins", &[OsString::from("missing")])
         .unwrap()
         .is_none());
+    // A hidden alias dispatches like any other spelling; hiding is a help/completion property.
+    let hidden = catalog
+        .parse_external("plugins", &[OsString::from("oldfmt")])
+        .unwrap()
+        .unwrap();
+    let Outcome::Parsed(hidden) = hidden else {
+        panic!("expected parsed")
+    };
+    assert_eq!(hidden.name, "formatter");
+    assert_eq!(hidden.invoked_as, "oldfmt");
     let help = catalog
         .parse_external(
             "plugins",

--- a/usage-dynamic/tests/catalog.rs
+++ b/usage-dynamic/tests/catalog.rs
@@ -75,13 +75,16 @@ version "2.4"
 unknown_flags "error"
 flag "--color <WHEN>" env="USAGE_DYNAMIC_TEST_COLOR" default="always"
 arg "[path]"
+cmd "check" help="Check formatting" {
+    flag "--fix" help="Apply fixes"
+}
 "#,
     );
     formatter.about = Some("Format a project".into());
     formatter.about_long = Some("Format a project using its configured style.".into());
     formatter.cmd.help_heading = Some("Installed plugins".into());
     formatter.cmd.display_order = Some(2);
-    formatter.cmd.aliases = vec!["fmt".into(), "oldfmt".into()];
+    formatter.cmd.aliases = vec!["fmt".into()];
     formatter.cmd.hidden_aliases = vec!["oldfmt".into()];
     let mut audit = plugin("audit", "");
     audit.about = Some("Audit a project".into());
@@ -98,13 +101,19 @@ arg "[path]"
 fn root_summaries_appear_in_help_and_completion() {
     let mut spec = plugin("doctor", "");
     spec.about = Some("Inspect plugin health".into());
+    let static_kdl = RootHost::app().to_kdl();
     let catalog = Catalog::builder(RootHost::app())
         .root(spec)
         .build()
         .unwrap();
-    assert_eq!(RootHost::app().to_kdl(), catalog.app().to_kdl());
+    assert_eq!(static_kdl, RootHost::app().to_kdl());
     let help = catalog.app().help("", false).unwrap();
     assert!(help.contains("doctor  Inspect plugin health"), "{help}");
+    assert!(catalog
+        .app()
+        .help("doctor", false)
+        .unwrap()
+        .contains("Inspect plugin health"));
 
     let argv = [
         OsString::from("__complete_word__"),
@@ -117,33 +126,58 @@ fn root_summaries_appear_in_help_and_completion() {
         answer.lines().any(|line| line.starts_with("doctor")),
         "{answer}"
     );
+    let RootCommand::External(argv) = RootHost::parse_from(&[OsStr::new("doctor")])
+        .unwrap()
+        .command
+    else {
+        panic!("expected top-level external command")
+    };
+    let argv: Vec<OsString> = argv.into_iter().map(OsString::from).collect();
+    assert!(matches!(
+        catalog.parse_external("", &argv).unwrap(),
+        Some(Outcome::Parsed(_))
+    ));
 }
 
 #[test]
 fn nested_help_merges_summaries_aliases_headings_and_ordering() {
-    let app = catalog().app();
+    let catalog = catalog();
+    let app = catalog.app();
     for long in [false, true] {
         let help = app.help("plugins", long).unwrap();
         assert!(help.contains("Installed plugins:"), "{help}");
-        assert!(help.contains("plugins formatter [aliases: fmt]"), "{help}");
+        assert!(help.contains("plugins formatter"), "{help}");
+        assert!(help.contains("[aliases: fmt]"), "{help}");
         assert!(!help.contains("oldfmt"), "{help}");
         assert!(
             help.find("plugins audit").unwrap() < help.find("plugins formatter").unwrap(),
             "{help}"
         );
     }
+    let plugin_help = app.help("plugins formatter", false).unwrap();
+    assert!(plugin_help.contains("--color"), "{plugin_help}");
+    assert!(plugin_help.contains("formatter check"), "{plugin_help}");
+    let nested_help = app.help("plugins fmt check", false).unwrap();
+    assert!(nested_help.contains("--fix"), "{nested_help}");
 }
 
 #[test]
 fn command_completion_offers_visible_names_and_delegates_after_selection() {
-    let app = catalog().app().completion_app();
+    let catalog = catalog();
+    let app = catalog.app().completion_app();
+    let parsed = usage_parser::parse::parse_partial(
+        app.spec(),
+        &["host".into(), "plugins".into(), "formatter".into()],
+    )
+    .unwrap();
+    assert_eq!(parsed.cmd.name, "formatter", "{:?}", parsed.cmds);
     let request = |words: &[&str]| {
         let mut argv = vec![
             OsString::from("__complete_word__"),
             OsString::from("--words"),
         ];
         argv.extend(words.iter().map(OsString::from));
-        block_on(app.clone().completion_request(&argv)).unwrap()
+        block_on(app.completion_request(&argv)).unwrap()
     };
     let answer = request(&["host", "plugins", ""]);
     assert!(
@@ -155,7 +189,16 @@ fn command_completion_offers_visible_names_and_delegates_after_selection() {
         "{answer}"
     );
     assert!(!answer.contains("oldfmt"), "{answer}");
-    assert_eq!(request(&["host", "plugins", "formatter", ""]), "");
+    let flags = request(&["host", "plugins", "formatter", "--"]);
+    assert!(
+        flags.lines().any(|line| line.starts_with("--color")),
+        "{flags}"
+    );
+    let nested = request(&["host", "plugins", "formatter", "ch"]);
+    assert!(
+        nested.lines().any(|line| line.starts_with("check")),
+        "{nested}"
+    );
 }
 
 #[test]

--- a/usage-dynamic/tests/catalog.rs
+++ b/usage-dynamic/tests/catalog.rs
@@ -674,7 +674,7 @@ fn a_named_completer_request_is_answered_by_the_host() {
 #[test]
 fn a_builtin_never_needs_a_catalog_and_a_fallback_needs_one_spec() {
     // The design's cost promise: parse first, against the static tables alone. A built-in
-    // command dispatches before any catalog exists, so a plugin manager pays for discovery
+    // command dispatches before any catalog exists, so an application pays for discovery
     // only when the catch-all actually fired — and then only for the specs it chose to load.
     let host = Host::parse_from(&[OsStr::new("builtin")]).unwrap();
     assert!(matches!(host.command, HostCommand::Builtin));


### PR DESCRIPTION
## Summary

Add `usage-dynamic`: commands an application discovers at runtime, merged into a derived host's
help, completion, and parsing. Plugins attach to a static command that declared an
`external_subcommand` catch-all, via `root(spec)` or `under(path, spec)`. The derive's parse
tables, the emitted KDL, and the ordinary parse path are untouched.

## How the pieces fit

**Completion has two answerers, split at the catch-all.** Up to it the words are the host's and
the host's own engine answers for them, so registered sync/async completers, multicall
projections, and the `--candidates` half of the protocol keep working — with catalogued names
added wherever a subcommand belongs. Past it the plugin's own spec answers alone: its
subcommands, flags, and declared choices, under the same rules the static engine uses for when a
position is closed to the shell's path fallback.

**Which required saying where a line leaves the static tables.** `walk` discarded
`Event::External`, so a position past a catch-all looked like the declaring command's own — and
completion answered with that command's subcommands, flags, and working directory, all of them
answers about a CLI these tables do not describe. `Position::external` reports the boundary, and
both implementations now offer nothing past it. That is a behavior fix on `main` independent of
this crate, pinned by new corpus vectors (`corpus/complete/03-external-boundary.json`) that
needed a way to say "nothing is the claim" — an empty expectation stays refused otherwise.

**Building the merged tree is lazy, and cheap when it happens.** Dispatch reads only the entry
specs, never the merged tree, so assembling one waits for `app()`. The round trip that used to
follow insertion — writing the whole spec out as KDL and parsing it back, purely to fix
`full_cmd`, usage lines, and a memoized lookup — is now `Spec::restamp`, with a test pinning it
against the round trip it replaces.

Measured on `benches/mise.usage.kdl` (256 KB):

| | before | after |
|---|---:|---:|
| `build()`, per dispatch | ~230 ms | 0 |
| fixup after grafting | 97 ms | 97 µs |

Hot path unchanged: 8,720 instructions cold parse, 490 ns median.

## Also

- `CompletionRequest` is argv's protocol parser made public, so the workspace has one fewer copy
  of it; `App::complete_request` is its answer before rendering.
- Non-UTF-8 argv still errors — the spec model parses `String`s — but the docs now say plainly
  that the argv is intact and belongs in the same fallback arm as an uncatalogued name.
- A parent path spelled with a hidden static alias resolves, as `under` always said it would.
- `docs/rust/dynamic-commands.md` is rewritten around one end-to-end `main`, which lives in
  `usage-dynamic/examples/host.rs` and compiles in CI. That is how two API shapes the prose
  would otherwise have got wrong surfaced: `parse_from` takes `&[&OsStr]`, and rendering host
  help through the merged tree needs the command's path rather than its name. The page is in the
  sidebar now.
- The catalog no longer clears mounts from a completion copy of the tree, so `app().spec()` is
  the host's spec as written.

## Trade-off worth naming

`usage-dynamic` pulls `usage-lib` — kdl, tera, miette — into a derive-based binary. That is the
cost of a portable spec model at runtime, and it is confined to cold paths, but it is real and
an application that does not need runtime commands should not depend on this crate.

## Validation

- `mise run ci`
- `mise run perf:shadow` — 8,720 instructions, 490 ns median
- `cargo +1.95 check --locked -p usage-dynamic --all-features`
- `npm run docs:build`

`cargo package -p usage-dynamic` still cannot verify until `usage-lib`'s new `cli-help` feature
is published; Cargo resolves the 6.1.1 metadata, which predates it. The workspace build, tests,
clippy, and the 1.95 check all compile the packaged source against this PR's `usage-lib`.

_This pull request was generated by Claude Code._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New public crate and completion-protocol APIs plus a behavior change: completions past an `external_subcommand` now offer nothing. Static parse hot path is unchanged, but help/completion merge and grafting are new surface area.
> 
> **Overview**
> Adds **`usage-dynamic`**: applications discover plugin specs themselves and attach them to a static `external_subcommand` catch-all via `Catalog::builder`. Built-in commands still parse against derived tables only; `parse_external` dispatches captured argv against one spec; `app()` lazily merges the tree for help and completion.
> 
> **Completion splits at the catch-all.** Host engine (overlays, projections, `--candidates`) answers before it; the plugin spec answers after. `Position::external` records where words left the static tables. Past that boundary, both argv and `usage-cli` now offer **nothing** (no host flags, no path fallback). Corpus vectors use a new `"nothing": true` expectation.
> 
> **Spec grafting is cheap.** `Spec::restamp` restamps `full_cmd`, usage lines, and subcommand lookup instead of a KDL round-trip. `From<SpecCommand> for Spec` supports in-process command trees. CLI help is split onto a `cli-help` feature so the catalog can render pages without full docs.
> 
> Also publicizes `CompletionRequest` / `complete_request` so hosts share one protocol parser. Experimental docs and `examples/host.rs` show the intended `parse_from` + catalog help/completion flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe7f4908be101c03466c9458a174bcd1ab7a2c6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime-discovered commands with merged help, completion, version information, and dispatch.
  * Added independent CLI help support and expanded completion request handling.
  * Added dynamic command documentation and a host integration example.

* **Bug Fixes**
  * Suppressed host suggestions and file fallback after external subcommands.
  * Improved updates when commands are dynamically grafted into an existing tree.

* **Documentation**
  * Clarified dynamic command catalogs, lazy loading, validation, and host integration.

* **Tests**
  * Added coverage for dynamic commands, forwarding, help, completion, validation, and dispatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->