### PR TITLE
fix(completion): handle attached values and emit built-ins

### DIFF
--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -1089,6 +1089,7 @@ fn complete_inner<'a>(
     };
     let meta = metadata_chain_on_route(spec, &position).and_then(|chain| chain.last().copied());
     let token = split.prefix.as_str();
+    let attached = attached_long_value(&position, token);
     let candidates = candidates_inner(spec, split, view);
 
     // Which argument the cursor is at — the same question `candidates` answers, asked once so
@@ -1104,11 +1105,14 @@ fn complete_inner<'a>(
 
     // A dash-prefixed word is a flag or nothing: no path starts with one, and the reference
     // suppresses its own listing there for the same reason.
-    let flag_like = position.flags_possible && token.starts_with('-');
+    let flag_like = attached.is_none() && position.flags_possible && token.starts_with('-');
 
     // The name a value here would have, which is what says whether paths belong, and whether
     // that value declares its own set.
-    let (named, declares_choices, complete_type) = if let Some(flag) = position.awaiting_value {
+    let value_flag = position
+        .awaiting_value
+        .or_else(|| attached.map(|(flag, _, _)| flag));
+    let (named, declares_choices, complete_type) = if let Some(flag) = value_flag {
         let meta = flag_meta(spec.root, flag);
         (
             meta.and_then(|m| m.value_name).or(Some(flag.name)),
@@ -1191,6 +1195,8 @@ pub async fn complete_with<'a>(
         return complete(spec, split);
     };
 
+    let attached = attached_long_value(&position, &split.prefix);
+    let value_prefix = attached.map_or(split.prefix.as_str(), |(_, _, prefix)| prefix);
     let words = split.argv();
     let command_path: Vec<(&Command<'_>, &[String])> = position
         .path
@@ -1200,7 +1206,7 @@ pub async fn complete_with<'a>(
     let ctx = CompleteCtx {
         words: &split.words,
         cword: split.cword,
-        prefix: &split.prefix,
+        prefix: value_prefix,
         command_words: command_words(split, &position),
         command_path: &command_path,
     };
@@ -1208,7 +1214,10 @@ pub async fn complete_with<'a>(
         CompletionHandler::Sync(completer) => completer(&ctx),
         CompletionHandler::Async(completer) => completer(ctx).await,
     };
-    dynamic.retain(|candidate| candidate.value.starts_with(&split.prefix));
+    dynamic.retain(|candidate| candidate.value.starts_with(value_prefix));
+    if let Some((_, form, _)) = attached {
+        attach_candidates(&mut dynamic, form);
+    }
 
     let mut answer = complete(spec, split);
     answer.candidates.extend(dynamic);
@@ -1226,6 +1235,8 @@ async fn complete_named_with<'a>(
     name: &str,
 ) -> Completions<'a> {
     let position = walk(spec.root.cmd, split.argv());
+    let attached = attached_long_value(&position, &split.prefix);
+    let value_prefix = attached.map_or(split.prefix.as_str(), |(_, _, prefix)| prefix);
     let words = split.argv();
     let command_path: Vec<(&Command<'_>, &[String])> = position
         .path
@@ -1235,7 +1246,7 @@ async fn complete_named_with<'a>(
     let ctx = CompleteCtx {
         words: &split.words,
         cword: split.cword,
-        prefix: &split.prefix,
+        prefix: value_prefix,
         command_words: command_words(split, &position),
         command_path: &command_path,
     };
@@ -1247,7 +1258,10 @@ async fn complete_named_with<'a>(
         };
         candidates.append(&mut dynamic);
     }
-    candidates.retain(|candidate| candidate.value.starts_with(&split.prefix));
+    candidates.retain(|candidate| candidate.value.starts_with(value_prefix));
+    if let Some((_, form, _)) = attached {
+        attach_candidates(&mut candidates, form);
+    }
     sort_and_dedup_candidates(&mut candidates);
     Completions {
         candidates,
@@ -1307,8 +1321,10 @@ fn overlay_at_cursor<'o>(
     position: &Position<'_>,
     overlays: &'o [CompletionOverlay<'_>],
 ) -> Option<&'o CompletionOverlay<'o>> {
+    let attached = attached_long_value(position, &split.prefix);
     if split.cword == 0
         || (position.awaiting_value.is_none()
+            && attached.is_none()
             && position.flags_possible
             && split.prefix.starts_with('-'))
     {
@@ -1325,7 +1341,10 @@ fn overlay_at_cursor<'o>(
                 )
             })
         })
-    } else if let Some(flag) = position.awaiting_value {
+    } else if let Some(flag) = position
+        .awaiting_value
+        .or_else(|| attached.map(|(flag, _, _)| flag))
+    {
         flag_meta_owner_on_route(spec, position, flag)
             .map(|(owner, field)| (owner, field.value_name.unwrap_or(field.flag.name), false))
     } else {
@@ -1473,7 +1492,23 @@ fn candidates_inner<'a>(
         both.extend(long_flags(spec, &position, ""));
         both
     } else if position.flags_possible && token.starts_with("--") {
-        long_flags(spec, &position, token)
+        match attached_long_value(&position, token) {
+            Some((flag, form, value_prefix)) => flag_meta(spec.root, flag)
+                .map(|meta| {
+                    let mut found = declared(
+                        meta.choices,
+                        meta.choice_details,
+                        meta.complete,
+                        split,
+                        &position,
+                        value_prefix,
+                    );
+                    attach_candidates(&mut found, form);
+                    found
+                })
+                .unwrap_or_default(),
+            None => long_flags(spec, &position, token),
+        }
     } else if position.flags_possible && token.starts_with('-') {
         short_flags(spec, &position, token)
     } else if restarted(meta, split) {
@@ -1518,6 +1553,30 @@ fn candidates_inner<'a>(
 
     sort_and_dedup_candidates(&mut out);
     out
+}
+
+/// A value being typed in the same word as its long flag.
+///
+/// The shell replaces the whole word, so callers complete against the fragment after `=` and
+/// then put the flag spelling back on each candidate.
+fn attached_long_value<'t, 'p>(
+    position: &Position<'t>,
+    token: &'p str,
+) -> Option<(&'t Flag<'t>, &'p str, &'p str)> {
+    let (form, prefix) = token.split_once('=')?;
+    let long = form.strip_prefix("--")?;
+    position
+        .flags
+        .iter()
+        .copied()
+        .find(|flag| (flag.takes_value || flag.bool_value) && flag.longs.contains(&long))
+        .map(|flag| (flag, form, prefix))
+}
+
+fn attach_candidates(candidates: &mut [Candidate<'_>], form: &str) {
+    for candidate in candidates {
+        candidate.value = format!("{form}={}", candidate.value);
+    }
 }
 
 /// Whether the word before the cursor is this command's restart token.
@@ -3929,13 +3988,13 @@ mod tests {
         assert_eq!(a.files, Some(Files::Any));
     }
     #[test]
-    fn an_attached_value_is_not_answered_by_the_positional() {
-        // `--source=⌶` is a dash-prefixed token, so it is a *flag* position: the flag branches
-        // come first and the positional's completer is never reached. Worth pinning, because the
-        // word being completed is excluded from the walk — so the flag is not `awaiting_value`
-        // either, and the position could look like the argument's if the order changed.
+    fn an_attached_value_is_answered_by_its_flag() {
+        // The shell replaces the whole word, so an attached value keeps its flag prefix.
+        assert_eq!(offered("mise install --source="), ["--source=upstream"]);
+        assert_eq!(offered("mise install --source=u"), ["--source=upstream"]);
+
+        // It remains a flag position: the positional's completer is never reached.
         assert!(!offered("mise install --source=").contains(&"node".to_string()));
-        assert!(!offered("mise install --source=").contains(&"upstream".to_string()));
         assert!(!offered("mise install -s").contains(&"node".to_string()));
 
         // Detached, the flag's own completer answers — which is the case that works.

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -1001,8 +1001,10 @@ fn declared_files_at_cursor(
     split: &Split,
     position: &Position<'_>,
 ) -> Option<Files> {
+    let attached = attached_long_value(position, &split.prefix);
     if split.cword == 0
         || (position.awaiting_value.is_none()
+            && attached.is_none()
             && position.flags_possible
             && split.prefix.starts_with('-'))
     {
@@ -1018,12 +1020,16 @@ fn declared_files_at_cursor(
             .or_else(|| default_subcommand_arg(spec, split, position).map(|(_, field)| field.arg))
     };
     if position.awaiting_value.is_none()
+        && attached.is_none()
         && at_cursor.is_some_and(|arg| arg.double_dash == crate::DoubleDash::Required)
         && !position.separator_seen
     {
         return None;
     }
-    let (name, complete_type) = if let Some(flag) = position.awaiting_value {
+    let value_flag = position
+        .awaiting_value
+        .or_else(|| attached.map(|(flag, _, _)| flag));
+    let (name, complete_type) = if let Some(flag) = value_flag {
         let meta = flag_meta(spec.root, flag);
         (
             meta.and_then(|m| m.value_name).or(Some(flag.name)),
@@ -1154,7 +1160,7 @@ fn complete_inner<'a>(
     // different position that happens to have an unfilled positional behind it, and a rule about
     // the positional has nothing to say about the flag: `ex --from ⌶` takes a path whatever the
     // argument after it needs.
-    let needs_separator = position.awaiting_value.is_none()
+    let needs_separator = value_flag.is_none()
         && at_cursor.is_some_and(|arg| arg.double_dash == crate::DoubleDash::Required)
         && !position.separator_seen;
 
@@ -2601,6 +2607,12 @@ mod tests {
             "path",
             runtime_tools,
         )];
+    static FROM_RUNTIME_COMPLETIONS: [CompletionOverlay<'static>; 1] =
+        [CompletionOverlay::asynchronous(
+            "pipe",
+            "FILE",
+            runtime_tools,
+        )];
     static PLUGIN_RUNTIME_COMPLETIONS: [CompletionOverlay<'static>; 1] =
         [CompletionOverlay::asynchronous(
             "plugins",
@@ -2693,6 +2705,20 @@ mod tests {
             "{after_separator:?}"
         );
         assert_eq!(after_separator.files, Some(Files::Any));
+
+        let attached_file = run_ready(complete_with(
+            &SPEC,
+            &at_end("mise pipe --from="),
+            &FROM_RUNTIME_COMPLETIONS,
+        ));
+        assert!(
+            attached_file
+                .candidates
+                .iter()
+                .any(|candidate| candidate.value == "--from=uby"),
+            "{attached_file:?}"
+        );
+        assert_eq!(attached_file.files, Some(Files::Any));
 
         let flag = run_ready(complete_with(
             &SPEC,
@@ -3712,6 +3738,7 @@ mod tests {
         // And a flag waiting for its value is a different position that happens to have that
         // argument behind it: `--from ⌶` takes a path whatever the positional after it needs.
         assert_eq!(answer("mise pipe --from ").files, Some(Files::Any));
+        assert_eq!(answer("mise pipe --from=").files, Some(Files::Any));
     }
 
     #[test]

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -708,11 +708,14 @@ fn usage_line_with_subcommands(
 
     // Hidden entries are absent from the line as they are from the sections: help describes
     // what a user is invited to type.
-    let flags: usize = meta.flags.iter().filter(|f| !f.hide).count();
+    let flags: usize = meta.flags.iter().filter(|f| !f.hide && !f.builtin).count();
     if flags > 0 {
-        let required = meta.flags.iter().any(|f| !f.hide && flag_demanded(f));
+        let required = meta
+            .flags
+            .iter()
+            .any(|f| !f.hide && !f.builtin && flag_demanded(f));
         if flags <= INLINE_LIMIT {
-            for flag in meta.flags.iter().filter(|f| !f.hide) {
+            for flag in meta.flags.iter().filter(|f| !f.hide && !f.builtin) {
                 // A required flag is angled, like a required argument: the brackets are what
                 // say whether leaving it out is allowed.
                 let (open, close) = if flag_demanded(flag) {
@@ -2459,20 +2462,22 @@ pub fn find<'a>(
 /// claimed otherwise would be describing a flag that never binds.
 mod supplied {
     use crate::spec::FlagMeta;
-    use crate::Flag;
+    use crate::{ArgAction, Flag};
 
     macro_rules! entry {
-        ($name:ident, $flag:ident, $key:expr, $label:expr, $longs:expr, $shorts:expr, $help:expr) => {
+        ($name:ident, $flag:ident, $key:expr, $label:expr, $longs:expr, $shorts:expr, $help:expr, $action:expr) => {
             static $flag: Flag<'static> = Flag {
                 key: $key,
                 name: $label,
                 longs: $longs,
                 shorts: $shorts,
+                action: $action,
                 ..Flag::BOOL
             };
             pub static $name: FlagMeta<'static> = FlagMeta {
                 flag: &$flag,
                 help: Some($help),
+                builtin: true,
                 ..FlagMeta::EMPTY
             };
         };
@@ -2485,7 +2490,8 @@ mod supplied {
         "help",
         &["help"],
         b"h",
-        "Print help"
+        "Print help",
+        ArgAction::Help
     );
     entry!(
         HELP_LONG_ONLY,
@@ -2494,7 +2500,8 @@ mod supplied {
         "help",
         &["help"],
         b"",
-        "Print help"
+        "Print help",
+        ArgAction::Help
     );
     // Named `h`, not `help`: the declared name is judged against the forms the entry shows,
     // and a short-only entry called `help` reads as a renamed flag — it printed `help: -h`.
@@ -2505,7 +2512,8 @@ mod supplied {
         "h",
         &[],
         b"h",
-        "Print help"
+        "Print help",
+        ArgAction::Help
     );
     entry!(
         VERSION_BOTH,
@@ -2514,7 +2522,8 @@ mod supplied {
         "version",
         &["version"],
         b"V",
-        "Print version"
+        "Print version",
+        ArgAction::Version
     );
     entry!(
         VERSION_LONG_ONLY,
@@ -2523,7 +2532,8 @@ mod supplied {
         "version",
         &["version"],
         b"",
-        "Print version"
+        "Print version",
+        ArgAction::Version
     );
     entry!(
         VERSION_SHORT_ONLY,
@@ -2532,7 +2542,8 @@ mod supplied {
         "V",
         &[],
         b"V",
-        "Print version"
+        "Print version",
+        ArgAction::Version
     );
 }
 
@@ -2541,7 +2552,10 @@ mod supplied {
 /// `--version` only where the parser actually accepts it: on a command whose table says so,
 /// which the derive sets on the root when a version is declared. A page offering one that the
 /// parser would refuse is worse than a page that stays quiet.
-fn supplied_entries(cmd: &Command<'_>, taken: &[String]) -> Vec<&'static FlagMeta<'static>> {
+pub(crate) fn supplied_entries(
+    cmd: &Command<'_>,
+    taken: &[String],
+) -> Vec<&'static FlagMeta<'static>> {
     // Against the same set every other decision on this page uses, so a spelling claimed by a
     // hidden declaration or by a negation is claimed here too. Offering a `--help` that
     // something else binds is exactly the lie the model exists to prevent.

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -984,6 +984,11 @@ pub struct FlattenGroup<'a> {
 #[derive(Debug, Clone, Copy)]
 pub struct FlagMeta<'a> {
     pub flag: &'a Flag<'a>,
+    /// A parser-supplied public entry point materialized in an exported spec.
+    ///
+    /// It belongs in flag listings and completions, but not in the command synopsis where the
+    /// runtime's implicit help and version flags have never appeared.
+    pub builtin: bool,
     /// Explicit placement within its help section.
     pub display_order: Option<usize>,
     /// Short forms accepted by the parser but omitted from help and completion.
@@ -1106,6 +1111,7 @@ impl FlagMeta<'_> {
         complete: None,
         complete_type: None,
         flag: &Flag::BOOL,
+        builtin: false,
         display_order: None,
         hidden_shorts: &[],
         hidden_longs: &[],
@@ -1671,7 +1677,7 @@ impl Spec<'_> {
         }
         // Nothing above the root, so what it does not state is the default.
         let mut path = Vec::new();
-        write_body(out, self.root, 0, UnknownFlags::Value, &w, &mut path, true)
+        write_body(out, self.root, 0, UnknownFlags::Value, &w, &mut path, &[])
     }
 }
 
@@ -1873,7 +1879,7 @@ fn write_body<'a>(
     inherited_unknown_flags: UnknownFlags,
     w: &Writing<'_, '_>,
     path: &mut Vec<&'a str>,
-    root: bool,
+    inherited_globals: &[&FlagMeta<'a>],
 ) -> core::fmt::Result {
     // The effective setting for everything inside, which is this command's if it stated one
     // and otherwise whatever it inherited.
@@ -1896,6 +1902,22 @@ fn write_body<'a>(
         "every subcommand in the parse table needs metadata"
     );
     write_flag_layout(out, meta, depth, &w.sets)?;
+    let mut claimed = Vec::new();
+    for flag in inherited_globals.iter().copied().chain(meta.flags) {
+        claimed.extend(flag.flag.longs.iter().map(|long| format!("--{long}")));
+        claimed.extend(
+            flag.flag
+                .shorts
+                .iter()
+                .map(|short| format!("-{}", *short as char)),
+        );
+        if let Some(negate) = flag.flag.negate {
+            claimed.push(format!("--{negate}"));
+        }
+    }
+    for supplied in crate::help::supplied_entries(meta.cmd, &claimed) {
+        write_flag(out, supplied, depth, None)?;
+    }
     for (i, arg) in meta.args.iter().enumerate() {
         debug_assert!(
             meta.cmd
@@ -1912,7 +1934,7 @@ fn write_body<'a>(
     for group in meta.groups {
         write_group(out, group, depth)?;
     }
-    if root {
+    if depth == 0 {
         for example in meta.examples {
             write_example(out, example, depth)?;
         }
@@ -1920,8 +1942,18 @@ fn write_body<'a>(
     }
     #[cfg(feature = "complete")]
     write_completers(out, meta, w.bin, depth)?;
+    let mut child_globals = inherited_globals.to_vec();
+    child_globals.extend(meta.flags.iter().filter(|flag| flag.flag.global));
     for sub in meta.subcommands {
-        write_command(out, sub, depth, enclosing_unknown_flags, w, path)?;
+        write_command(
+            out,
+            sub,
+            depth,
+            enclosing_unknown_flags,
+            w,
+            path,
+            &child_globals,
+        )?;
     }
     Ok(())
 }
@@ -1982,6 +2014,7 @@ fn write_command<'a>(
     inherited_unknown_flags: UnknownFlags,
     w: &Writing<'_, '_>,
     path: &mut Vec<&'a str>,
+    inherited_globals: &[&FlagMeta<'a>],
 ) -> core::fmt::Result {
     path.push(meta.cmd.name);
     indent(out, depth)?;
@@ -2131,7 +2164,15 @@ fn write_command<'a>(
     for example in meta.examples {
         write_example(out, example, inner)?;
     }
-    write_body(out, meta, inner, effective_unknown_flags, w, path, false)?;
+    write_body(
+        out,
+        meta,
+        inner,
+        effective_unknown_flags,
+        w,
+        path,
+        inherited_globals,
+    )?;
     // After the body, because usage-lib's writer puts these after the flags, args and
     // subcommands, and `canonical_kdl` compares the two documents byte for byte.
     write_outputs(out, meta, inner)?;
@@ -2313,6 +2354,9 @@ fn write_flag(
                 crate::ArgAction::Version => "version",
             })
         )?;
+    }
+    if meta.builtin {
+        out.push_str(" builtin=#true");
     }
     if meta.repeatable {
         out.push_str(" var=#true");
@@ -4421,7 +4465,7 @@ mod tests {
             UnknownFlags::Value,
             &w,
             &mut Vec::new(),
-            false,
+            &[],
         )
         .unwrap();
 

--- a/benches/fleet/communique.usage.kdl
+++ b/benches/fleet/communique.usage.kdl
@@ -9,6 +9,8 @@ flag "-q --quiet" help="Suppress progress output" global=#true
 flag "-c --config" help="Path to config file (default: communique.toml in repo root)" global=#true {
     arg <CONFIG>
 }
+flag "-h --help" help="Print help" action=help builtin=#true
+flag "-V --version" help="Print version" action=version builtin=#true
 cmd generate help="Generate release notes for a git tag" effect=read {
     flag --github-release help="Push editorialized notes to the GitHub release" effect=write
     flag --changelog help="Update CHANGELOG.md with the generated changelog entry" effect=write
@@ -32,13 +34,16 @@ cmd generate help="Generate release notes for a git tag" effect=read {
     flag "-o --output" help="Write output to a file instead of stdout" effect=write {
         arg <OUTPUT>
     }
+    flag "-h --help" help="Print help" action=help builtin=#true
     arg <TAG> help="Git tag to generate release notes for"
     arg "[PREV_TAG]" help="Previous tag (auto-detected if omitted)"
 }
 cmd init help="Generate a communique.toml config file in the repo root" effect=write {
     flag --force help="Overwrite existing config file" effect=destructive
+    flag "-h --help" help="Print help" action=help builtin=#true
 }
 cmd sponsors help="Show the companies sponsoring communique and the jdx.dev open source tools" effect=read {
+    flag "-h --help" help="Print help" action=help builtin=#true
 }
 cmd usage help="Generates a usage spec for the CLI" hide=#true effect=read {
     long_help #"""
@@ -46,4 +51,5 @@ Generates a usage spec for the CLI
 
 https://usage.jdx.dev
 """#
+    flag "-h --help" help="Print help" action=help builtin=#true
 }

--- a/benches/shadows/communique/src/lib.rs
+++ b/benches/shadows/communique/src/lib.rs
@@ -41,6 +41,9 @@ pub struct GenerateArgs {
     /// Write output to a file instead of stdout
     #[usage(long = "output", short = 'o', effect = "write", value_name = "OUTPUT")]
     pub output: ::std::option::Option<::std::string::String>,
+    /// Print help
+    #[usage(long = "help", short = 'h')]
+    pub help: bool,
     /// Git tag to generate release notes for
     #[usage(arg, name = "TAG")]
     pub tag: ::std::string::String,
@@ -56,19 +59,30 @@ pub struct InitArgs {
     /// Overwrite existing config file
     #[usage(long = "force", effect = "destructive")]
     pub force: bool,
+    /// Print help
+    #[usage(long = "help", short = 'h')]
+    pub help: bool,
 }
 
 /// Show the companies sponsoring communique and the jdx.dev open source tools
 #[derive(Args)]
 #[usage(effect = "read")]
-pub struct SponsorsArgs {}
+pub struct SponsorsArgs {
+    /// Print help
+    #[usage(long = "help", short = 'h')]
+    pub help: bool,
+}
 
 /// Generates a usage spec for the CLI
 ///
 /// https://usage.jdx.dev
 #[derive(Args)]
 #[usage(effect = "read")]
-pub struct UsageArgs {}
+pub struct UsageArgs {
+    /// Print help
+    #[usage(long = "help", short = 'h')]
+    pub help: bool,
+}
 
 /// Editorialized release notes powered by AI
 #[derive(Cli)]
@@ -88,6 +102,12 @@ pub struct Cli {
     /// Path to config file (default: communique.toml in repo root)
     #[usage(long = "config", short = 'c', global, value_name = "CONFIG")]
     pub config: ::std::option::Option<::std::string::String>,
+    /// Print help
+    #[usage(long = "help", short = 'h')]
+    pub help: bool,
+    /// Print version
+    #[usage(long = "version", short = 'V')]
+    pub version: bool,
     #[usage(subcommand)]
     pub command: Commands,
 }

--- a/benches/shadows/communique/src/lib.rs
+++ b/benches/shadows/communique/src/lib.rs
@@ -41,9 +41,6 @@ pub struct GenerateArgs {
     /// Write output to a file instead of stdout
     #[usage(long = "output", short = 'o', effect = "write", value_name = "OUTPUT")]
     pub output: ::std::option::Option<::std::string::String>,
-    /// Print help
-    #[usage(long = "help", short = 'h')]
-    pub help: bool,
     /// Git tag to generate release notes for
     #[usage(arg, name = "TAG")]
     pub tag: ::std::string::String,
@@ -59,30 +56,19 @@ pub struct InitArgs {
     /// Overwrite existing config file
     #[usage(long = "force", effect = "destructive")]
     pub force: bool,
-    /// Print help
-    #[usage(long = "help", short = 'h')]
-    pub help: bool,
 }
 
 /// Show the companies sponsoring communique and the jdx.dev open source tools
 #[derive(Args)]
 #[usage(effect = "read")]
-pub struct SponsorsArgs {
-    /// Print help
-    #[usage(long = "help", short = 'h')]
-    pub help: bool,
-}
+pub struct SponsorsArgs {}
 
 /// Generates a usage spec for the CLI
 ///
 /// https://usage.jdx.dev
 #[derive(Args)]
 #[usage(effect = "read")]
-pub struct UsageArgs {
-    /// Print help
-    #[usage(long = "help", short = 'h')]
-    pub help: bool,
-}
+pub struct UsageArgs {}
 
 /// Editorialized release notes powered by AI
 #[derive(Cli)]
@@ -102,12 +88,6 @@ pub struct Cli {
     /// Path to config file (default: communique.toml in repo root)
     #[usage(long = "config", short = 'c', global, value_name = "CONFIG")]
     pub config: ::std::option::Option<::std::string::String>,
-    /// Print help
-    #[usage(long = "help", short = 'h')]
-    pub help: bool,
-    /// Print version
-    #[usage(long = "version", short = 'V')]
-    pub version: bool,
     #[usage(subcommand)]
     pub command: Commands,
 }

--- a/cli/assets/fig.ts
+++ b/cli/assets/fig.ts
@@ -153,6 +153,11 @@ const completionSpec: Fig.Spec = {
             suggestions: ["bash", "fish", "nu", "powershell", "zsh"],
           },
         },
+        {
+          name: ["-h", "--help"],
+          description: "Print help",
+          isRepeatable: false,
+        },
       ],
       args: {
         name: "words",
@@ -183,6 +188,11 @@ const completionSpec: Fig.Spec = {
         {
           name: "--exit-zero",
           description: "Exit 0 even when there are breaking changes",
+          isRepeatable: false,
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help",
           isRepeatable: false,
         },
       ],
@@ -281,6 +291,11 @@ const completionSpec: Fig.Spec = {
             name: "env",
           },
         },
+        {
+          name: ["-h", "--help"],
+          description: "Print help",
+          isRepeatable: false,
+        },
       ],
       args: {
         name: "argv",
@@ -376,6 +391,11 @@ const completionSpec: Fig.Spec = {
                 name: "usage_cmd",
               },
             },
+            {
+              name: ["-h", "--help"],
+              description: "Print help",
+              isRepeatable: false,
+            },
           ],
           args: [
             {
@@ -402,6 +422,11 @@ const completionSpec: Fig.Spec = {
               args: {
                 name: "usage_bin",
               },
+            },
+            {
+              name: ["-h", "--help"],
+              description: "Print help",
+              isRepeatable: false,
             },
           ],
           args: {
@@ -441,6 +466,11 @@ const completionSpec: Fig.Spec = {
               args: {
                 name: "spec",
               },
+            },
+            {
+              name: ["-h", "--help"],
+              description: "Print help",
+              isRepeatable: false,
             },
           ],
         },
@@ -485,6 +515,11 @@ const completionSpec: Fig.Spec = {
                 name: "spec",
               },
             },
+            {
+              name: ["-h", "--help"],
+              description: "Print help",
+              isRepeatable: false,
+            },
           ],
         },
         {
@@ -516,6 +551,11 @@ const completionSpec: Fig.Spec = {
               args: {
                 name: "view",
               },
+            },
+            {
+              name: ["-h", "--help"],
+              description: "Print help",
+              isRepeatable: false,
             },
           ],
         },
@@ -567,6 +607,11 @@ const completionSpec: Fig.Spec = {
                 name: "url",
               },
             },
+            {
+              name: ["-h", "--help"],
+              description: "Print help",
+              isRepeatable: false,
+            },
           ],
         },
         {
@@ -607,6 +652,11 @@ const completionSpec: Fig.Spec = {
               args: {
                 name: "section",
               },
+            },
+            {
+              name: ["-h", "--help"],
+              description: "Print help",
+              isRepeatable: false,
             },
           ],
         },
@@ -675,6 +725,11 @@ const completionSpec: Fig.Spec = {
                 name: "url_prefix",
               },
             },
+            {
+              name: ["-h", "--help"],
+              description: "Print help",
+              isRepeatable: false,
+            },
           ],
         },
         {
@@ -724,7 +779,19 @@ const completionSpec: Fig.Spec = {
                 name: "spec",
               },
             },
+            {
+              name: ["-h", "--help"],
+              description: "Print help",
+              isRepeatable: false,
+            },
           ],
+        },
+      ],
+      options: [
+        {
+          name: ["-h", "--help"],
+          description: "Print help",
+          isRepeatable: false,
         },
       ],
     },
@@ -750,6 +817,11 @@ const completionSpec: Fig.Spec = {
           name: "--sorted",
           description:
             "Also check that subcommands and flags are declared in sorted order",
+          isRepeatable: false,
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help",
           isRepeatable: false,
         },
       ],
@@ -779,6 +851,11 @@ const completionSpec: Fig.Spec = {
           args: {
             name: "spec",
           },
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help",
+          isRepeatable: false,
         },
       ],
     },
@@ -813,6 +890,13 @@ const completionSpec: Fig.Spec = {
       name: "sponsors",
       description:
         "Show the companies sponsoring usage and the jdx.dev open source tools",
+      options: [
+        {
+          name: ["-h", "--help"],
+          description: "Print help",
+          isRepeatable: false,
+        },
+      ],
     },
     {
       name: "zsh",
@@ -855,6 +939,16 @@ const completionSpec: Fig.Spec = {
     {
       name: "--usage-spec",
       description: "Outputs a `usage.kdl` spec for this CLI itself",
+      isRepeatable: false,
+    },
+    {
+      name: ["-h", "--help"],
+      description: "Print help",
+      isRepeatable: false,
+    },
+    {
+      name: ["-V", "--version"],
+      description: "Print version",
       isRepeatable: false,
     },
   ],

--- a/cli/assets/usage.1
+++ b/cli/assets/usage.1
@@ -15,6 +15,12 @@ Outputs completions for the specified shell for completing the `usage` CLI itsel
 .TP
 \fB\-\-usage\-spec\fR
 Outputs a `usage.kdl` spec for this CLI itself
+.TP
+\fB\-h, \-\-help\fR
+Print help
+.TP
+\fB\-V, \-\-version\fR
+Print version
 .SH COMMANDS
 .TP
 \fBbash\fR
@@ -151,6 +157,9 @@ Current word index
 .RS
 \fIDefault: \fRbash
 .RE
+.TP
+\fB\-h, \-\-help\fR
+Print help
 \fBArguments:\fR
 .PP
 .TP
@@ -188,6 +197,9 @@ Report only breaking changes
 .TP
 \fB\-\-exit\-zero\fR
 Exit 0 even when there are breaking changes
+.TP
+\fB\-h, \-\-help\fR
+Print help
 \fBArguments:\fR
 .PP
 .TP
@@ -251,6 +263,9 @@ A spec\-declared executable view to explain
 Environment to explain against, as KEY=VALUE, repeatable
 
 Given at all, these are the *whole* environment: an explanation pasted into a bug report has to mean the same thing on the machine that reads it. Omitted, the process environment is used, which is what an execution would see.
+.TP
+\fB\-h, \-\-help\fR
+Print help
 \fBArguments:\fR
 .PP
 .TP
@@ -283,6 +298,16 @@ Show help
 Arguments to pass to script
 
 Anything `usage` does not recognise is a value rather than a mistake, which is what lets a shebang script take flags of its own.
+.SH "USAGE GENERATE"
+Generate completions, documentation, and other artifacts from usage specs
+.PP
+\fBUsage:\fR usage generate [OPTIONS] <COMMAND>
+.PP
+\fBOptions:\fR
+.PP
+.TP
+\fB\-h, \-\-help\fR
+Print help
 .SH "USAGE GENERATE COMPLETION"
 Generate shell completion scripts for bash, fish, nu, powershell, or zsh
 .PP
@@ -318,6 +343,9 @@ You may need to set this if you have a different bin named "usage"
 .TP
 \fB\-\-usage\-cmd\fR \fI<USAGE_CMD>\fR
 A command which generates a usage spec e.g.: `mycli \-\-usage` or `mycli completion usage` Defaults to "$bin \-\-usage"
+.TP
+\fB\-h, \-\-help\fR
+Print help
 \fBArguments:\fR
 .PP
 .TP
@@ -346,6 +374,9 @@ You may need to set this if you have a different bin named "usage"
 .RS
 \fIEnvironment: \fR\fBJDX_USAGE_BIN\fR
 .RE
+.TP
+\fB\-h, \-\-help\fR
+Print help
 \fBArguments:\fR
 .PP
 .TP
@@ -367,6 +398,9 @@ File path where the generated Fig spec will be saved, or "\-" for stdout
 .TP
 \fB\-\-spec\fR \fI<SPEC>\fR
 Raw string spec input
+.TP
+\fB\-h, \-\-help\fR
+Print help
 .SH "USAGE GENERATE GO"
 Generate Go parse tables from a usage spec
 
@@ -390,6 +424,9 @@ Go package clause for the generated file (defaults to the spec's bin name)
 .TP
 \fB\-\-spec\fR \fI<SPEC>\fR
 Raw string spec input
+.TP
+\fB\-h, \-\-help\fR
+Print help
 .SH "USAGE GENERATE JSON"
 Outputs a usage spec in json format
 .PP
@@ -406,6 +443,9 @@ raw string spec input
 .TP
 \fB\-\-view\fR \fI<VIEW>\fR
 Render one spec\-declared executable view
+.TP
+\fB\-h, \-\-help\fR
+Print help
 .SH "USAGE GENERATE JSON-SCHEMA"
 Generate a JSON Schema for a CLI's config file from its usage spec
 .PP
@@ -428,6 +468,9 @@ The schema's title, shown by editors
 .TP
 \fB\-\-url\fR \fI<URL>\fR
 Where the schema is published, for its `$id`
+.TP
+\fB\-h, \-\-help\fR
+Print help
 .SH "USAGE GENERATE MANPAGE"
 Generate a manpage from a usage spec
 .PP
@@ -452,6 +495,9 @@ Common sections: \- 1: User commands \- 5: File formats \- 7: Miscellaneous \- 8
 .RS
 \fIDefault: \fR1
 .RE
+.TP
+\fB\-h, \-\-help\fR
+Print help
 .SH "USAGE GENERATE MARKDOWN"
 Generate markdown documentation from usage specs
 .PP
@@ -483,6 +529,9 @@ Replace `<pre>` tags with markdown code fences
 .TP
 \fB\-\-url\-prefix\fR \fI<URL_PREFIX>\fR
 Prefix to add to all URLs
+.TP
+\fB\-h, \-\-help\fR
+Print help
 .SH "USAGE GENERATE SDK"
 Generate a type\-safe SDK from a usage spec
 .PP
@@ -505,6 +554,9 @@ Override the package/module name (defaults to spec bin name)
 .TP
 \fB\-\-spec\fR \fI<SPEC>\fR
 Raw string spec input
+.TP
+\fB\-h, \-\-help\fR
+Print help
 .SH "USAGE LINT"
 Lint a usage spec file for common issues
 .PP
@@ -526,6 +578,9 @@ Treat warnings as errors
 Also check that subcommands and flags are declared in sorted order
 
 Off by default: declaration order is a house convention rather than a correctness question, so a spec that keeps a different order is not wrong. Pair it with \-\-warnings\-as\-errors to hold the order in CI.
+.TP
+\fB\-h, \-\-help\fR
+Print help
 \fBArguments:\fR
 .PP
 .TP
@@ -547,6 +602,9 @@ Usage spec file (not "\-": stdin is the MCP transport)
 .TP
 \fB\-s, \-\-spec\fR \fI<SPEC>\fR
 Raw string spec input
+.TP
+\fB\-h, \-\-help\fR
+Print help
 .SH "USAGE POWERSHELL"
 Execute a shell script with the specified shell
 
@@ -572,6 +630,16 @@ Show help
 Arguments to pass to script
 
 Anything `usage` does not recognise is a value rather than a mistake, which is what lets a shebang script take flags of its own.
+.SH "USAGE SPONSORS"
+Show the companies sponsoring usage and the jdx.dev open source tools
+.PP
+\fBUsage:\fR usage sponsors [OPTIONS]
+.PP
+\fBOptions:\fR
+.PP
+.TP
+\fB\-h, \-\-help\fR
+Print help
 .SH "USAGE ZSH"
 Execute a shell script with the specified shell
 

--- a/cli/usage.usage.kdl
+++ b/cli/usage.usage.kdl
@@ -31,6 +31,8 @@ flag --completions help="Outputs completions for the specified shell for complet
     arg <COMPLETIONS>
 }
 flag --usage-spec help="Outputs a `usage.kdl` spec for this CLI itself"
+flag "-h --help" help="Print help" action=help builtin=#true
+flag "-V --version" help="Print version" action=version builtin=#true
 cmd bash help="Execute a shell script using bash" unknown_flags=value {
     long_help #"""
 Execute a shell script with the specified shell
@@ -71,6 +73,7 @@ This is used internally by shell completion scripts to provide intelligent compl
             choices bash fish nu powershell zsh
         }
     }
+    flag "-h --help" help="Print help" action=help builtin=#true
     arg "[WORDS]..." help="User's input from the command line"
 }
 cmd diff help="Compare two usage specs and report what changed about the interface" effect=read {
@@ -100,6 +103,7 @@ every release does not get left switched on.
     }
     flag "-b --breaking" help="Report only breaking changes"
     flag --exit-zero help="Exit 0 even when there are breaking changes"
+    flag "-h --help" help="Print help" action=help builtin=#true
     arg <OLD> help="The spec as it was, typically the released one, use \"-\" to read from stdin"
     arg <NEW> help="The spec as it is now, use \"-\" to read from stdin"
     complete old type=path
@@ -146,6 +150,7 @@ Given at all, these are the *whole* environment: an explanation pasted into a bu
 """#
         arg <ENV>
     }
+    flag "-h --help" help="Print help" action=help builtin=#true
     arg "[ARGV]..." help="The command line to explain, starting with the program name" double_dash=automatic {
         long_help #"""
 The command line to explain, starting with the program name
@@ -177,6 +182,7 @@ Anything `usage` does not recognise is a value rather than a mistake, which is w
 }
 cmd generate help="Generate completions, documentation, and other artifacts from usage specs" effect=read subcommand_required=#true {
     alias g
+    flag "-h --help" help="Print help" action=help builtin=#true
     cmd completion help="Generate shell completion scripts for bash, fish, nu, powershell, or zsh" effect=read {
         alias c
         alias complete hide=#true
@@ -206,6 +212,7 @@ You may need to set this if you have a different bin named "usage"
         flag --usage-cmd help="A command which generates a usage spec e.g.: `mycli --usage` or `mycli completion usage` Defaults to \"$bin --usage\"" required_unless=--file {
             arg <USAGE_CMD>
         }
+        flag "-h --help" help="Print help" action=help builtin=#true
         arg <SHELL> help="Shell to generate completions for" {
             choices bash fish nu powershell zsh
         }
@@ -228,6 +235,7 @@ You may need to set this if you have a different bin named "usage"
 """#
             arg <USAGE_BIN>
         }
+        flag "-h --help" help="Print help" action=help builtin=#true
         arg <SHELL> help="Shell to generate the init script for" {
             choices bash fish zsh
         }
@@ -242,6 +250,7 @@ You may need to set this if you have a different bin named "usage"
         flag --spec help="Raw string spec input" overrides=--file required_unless=--file {
             arg <SPEC>
         }
+        flag "-h --help" help="Print help" action=help builtin=#true
         complete out_file type=path
     }
     cmd go help="Generate Go parse tables from a usage spec" effect=read {
@@ -264,6 +273,7 @@ The tables are read by github.com/jdx/usage/go/argv. Go has no macros, so what a
         flag --spec help="Raw string spec input" overrides=--file required_unless=--file {
             arg <SPEC>
         }
+        flag "-h --help" help="Print help" action=help builtin=#true
         complete out_file type=path
     }
     cmd json help="Outputs a usage spec in json format" effect=read {
@@ -276,6 +286,7 @@ The tables are read by github.com/jdx/usage/go/argv. Go has no macros, so what a
         flag --view help="Render one spec-declared executable view" {
             arg <VIEW>
         }
+        flag "-h --help" help="Print help" action=help builtin=#true
     }
     cmd json-schema help="Generate a JSON Schema for a CLI's config file from its usage spec" effect=read {
         flag "-f --file" help="A usage spec taken in as a file, use \"-\" to read from stdin" {
@@ -293,6 +304,7 @@ The tables are read by github.com/jdx/usage/go/argv. Go has no macros, so what a
         flag --url help="Where the schema is published, for its `$id`" {
             arg <URL>
         }
+        flag "-h --help" help="Print help" action=help builtin=#true
         complete out_file type=path
     }
     cmd manpage help="Generate a manpage from a usage spec" effect=read {
@@ -314,6 +326,7 @@ Common sections: - 1: User commands - 5: File formats - 7: Miscellaneous - 8: Sy
 """#
             arg <SECTION>
         }
+        flag "-h --help" help="Print help" action=help builtin=#true
         complete out_file type=path
     }
     cmd markdown help="Generate markdown documentation from usage specs" effect=read {
@@ -336,6 +349,7 @@ Common sections: - 1: User commands - 5: File formats - 7: Miscellaneous - 8: Sy
         flag --url-prefix help="Prefix to add to all URLs" {
             arg <URL_PREFIX>
         }
+        flag "-h --help" help="Print help" action=help builtin=#true
         complete out_dir type=dir
         complete out_file type=path
     }
@@ -357,6 +371,7 @@ Common sections: - 1: User commands - 5: File formats - 7: Miscellaneous - 8: Sy
         flag --spec help="Raw string spec input" overrides=--file required_unless=--file {
             arg <SPEC>
         }
+        flag "-h --help" help="Print help" action=help builtin=#true
     }
 }
 cmd lint help="Lint a usage spec file for common issues" effect=read {
@@ -376,6 +391,7 @@ Also check that subcommands and flags are declared in sorted order
 Off by default: declaration order is a house convention rather than a correctness question, so a spec that keeps a different order is not wrong. Pair it with --warnings-as-errors to hold the order in CI.
 """#
     }
+    flag "-h --help" help="Print help" action=help builtin=#true
     arg <FILE> help="A usage spec file to lint, use \"-\" to read from stdin"
 }
 cmd mcp help="Serve a usage spec over the Model Context Protocol" effect=read {
@@ -392,6 +408,7 @@ clients launch a local server. Point one at `usage mcp -f mycli.usage.kdl`.
     flag "-s --spec" help="Raw string spec input" overrides=--file required_unless=--file {
         arg <SPEC>
     }
+    flag "-h --help" help="Print help" action=help builtin=#true
 }
 cmd powershell help="Execute a shell script using PowerShell" unknown_flags=value {
     long_help #"""
@@ -413,6 +430,7 @@ Anything `usage` does not recognise is a value rather than a mistake, which is w
     }
 }
 cmd sponsors help="Show the companies sponsoring usage and the jdx.dev open source tools" effect=read {
+    flag "-h --help" help="Print help" action=help builtin=#true
 }
 cmd zsh help="Execute a shell script using zsh" unknown_flags=value {
     long_help #"""

--- a/conformance/src/tables.rs
+++ b/conformance/src/tables.rs
@@ -375,6 +375,7 @@ fn flag_meta(
     let choices = arg.and_then(|a| a.choices.as_ref());
     FlagMeta {
         flag: table,
+        builtin: f.builtin,
         hidden_shorts: bytes(&f.hidden_short_aliases),
         hidden_longs: strs(&f.hidden_aliases),
         help: opt(&f.help),

--- a/conformance/tests/combinations.rs
+++ b/conformance/tests/combinations.rs
@@ -134,4 +134,14 @@ fn help_and_version_collisions_only_replace_the_claimed_spellings() {
         BuiltinCollisions::parse_from(&argv(["--version"])),
         Err(Error::Version { .. })
     ));
+
+    let kdl = BuiltinCollisions::to_kdl();
+    assert!(
+        kdl.contains("flag -h help=\"Print help\" action=help builtin=#true"),
+        "{kdl}"
+    );
+    assert!(
+        kdl.contains("flag --version help=\"Print version\" action=version builtin=#true"),
+        "{kdl}"
+    );
 }

--- a/conformance/tests/completion.rs
+++ b/conformance/tests/completion.rs
@@ -60,6 +60,23 @@ fn ask(shell: &str, line: &str) -> String {
 }
 
 #[derive(Cli)]
+#[usage(bin = "attached", completion)]
+#[allow(dead_code)]
+struct Attached {
+    /// Output format.
+    #[usage(long, choices("json", "jsonl", "xml"))]
+    format: Option<String>,
+}
+
+fn ask_attached(shell: &str, line: &str) -> String {
+    let argv: Vec<OsString> = ["__complete_word__", "--shell", shell, "--line", line]
+        .iter()
+        .map(OsString::from)
+        .collect();
+    Attached::completion_request(&argv).expect("this is a completion request")
+}
+
+#[derive(Cli)]
 #[usage(bin = "hinted", completion)]
 struct Hinted {
     /// A file to read
@@ -155,6 +172,22 @@ fn each_shell_gets_the_shape_it_reads() {
     assert_eq!(ask("fish", "ex ins"), "install\tInstall a tool\n");
     assert_eq!(ask("zsh", "ex ins"), "install\tInstall a tool\tinstall\n");
     assert_eq!(ask("bash", "ex ins"), "install\n");
+}
+
+#[test]
+fn attached_long_values_complete_as_whole_shell_words() {
+    assert_eq!(
+        ask_attached("bash", "attached --format=j"),
+        "--format=json\n--format=jsonl\n"
+    );
+    assert_eq!(
+        ask_attached("fish", "attached --format=x"),
+        "--format=xml\n"
+    );
+    assert_eq!(
+        ask_attached("zsh", "attached --format=x"),
+        "--format=xml\t\t--format=xml\n"
+    );
 }
 
 #[test]

--- a/conformance/tests/derive.rs
+++ b/conformance/tests/derive.rs
@@ -532,7 +532,7 @@ fn a_cli_with_only_a_positional_works() {
 
     let spec: LibSpec = Bare::to_kdl().parse().expect("should be a valid spec");
     assert_eq!(spec.cmd.args.len(), 1);
-    assert!(spec.cmd.flags.is_empty());
+    assert!(spec.cmd.flags.iter().all(|flag| flag.builtin));
 }
 
 /// And a CLI with no positionals, for the same reason.
@@ -551,7 +551,10 @@ fn a_cli_with_only_a_flag_works() {
 
     let spec: LibSpec = FlagsOnly::to_kdl().parse().expect("should be a valid spec");
     assert!(spec.cmd.args.is_empty());
-    assert_eq!(spec.cmd.flags.len(), 1);
+    assert_eq!(
+        spec.cmd.flags.iter().filter(|flag| !flag.builtin).count(),
+        1
+    );
 }
 
 /// An explicit `long` written with its dashes is the natural mistake, and would

--- a/conformance/tests/flatten.rs
+++ b/conformance/tests/flatten.rs
@@ -145,6 +145,7 @@ fn the_spec_says_the_flags_are_shared() {
     let mut flags: Vec<&str> = config
         .flags
         .iter()
+        .filter(|flag| !flag.builtin)
         .flat_map(|f| f.long.iter().map(|l| l.as_str()))
         .collect();
     flags.sort_unstable();

--- a/conformance/tests/help_request.rs
+++ b/conformance/tests/help_request.rs
@@ -241,18 +241,17 @@ fn asking_for_help_does_not_stop_the_cli_working() {
 }
 
 #[test]
-fn a_help_flag_is_listed_but_still_not_declared() {
-    // The split that replaced "a page lists exactly what its spec declares". The page names
-    // `-h, --help`, because help is written for people and someone looking for how to ask for
-    // help should find it there. The *spec* still does not declare it: the parser supplies it,
-    // and a spec claiming otherwise would have every reader inventing a flag its CLI never
-    // declared.
+fn a_help_flag_is_listed_and_materialized_in_the_generated_spec() {
+    // The page and generated metadata expose the same parser-supplied public entry point.
     let (_, page) = ask(&["--help"]);
     assert!(page.contains("-h, --help"), "{page}");
     assert!(page.contains("Print help"), "{page}");
 
     let kdl = Ex::to_kdl();
-    assert!(!kdl.contains("help\""), "{kdl}");
+    assert!(
+        kdl.contains(r#"flag "-h --help" help="Print help" action=help builtin=#true"#),
+        "{kdl}"
+    );
 }
 
 #[test]

--- a/conformance/tests/snapshots/nesting__the_emitted_spec_reads_like_a_handwritten_one.snap
+++ b/conformance/tests/snapshots/nesting__the_emitted_spec_reads_like_a_handwritten_one.snap
@@ -7,18 +7,23 @@ bin ex
 about "A tool with commands inside commands"
 subcommand_required #true
 flag "-v --verbose" help="Say more" global=#true
+flag "-h --help" help="Print help" action=help builtin=#true
 cmd settings help="Manage settings" subcommand_required=#true {
     flag --file help="Which settings file" {
         arg <FILE>
     }
+    flag "-h --help" help="Print help" action=help builtin=#true
     cmd set help="Set a value" {
+        flag "-h --help" help="Print help" action=help builtin=#true
         arg <KEY> help="Which setting"
         arg <VALUE> help="The value"
     }
     cmd ls help="Show every value" {
         flag --json help="As JSON"
+        flag "-h --help" help="Print help" action=help builtin=#true
     }
 }
 cmd install help="Install a tool" {
+    flag "-h --help" help="Print help" action=help builtin=#true
     arg <TOOL> help="What to install"
 }

--- a/conformance/tests/snapshots/spec_roundtrip__the_emitted_spec_is_stable.snap
+++ b/conformance/tests/snapshots/spec_roundtrip__the_emitted_spec_is_stable.snap
@@ -64,6 +64,7 @@ flag --paths {
     required_if --force --prune
     arg <path>
 }
+flag "-h --help" help="Print help" action=help builtin=#true
 arg "[file]" help="the file" help_heading=Input env=EX_FILE default=a.txt
 example "ex a.txt" header=Basic help="the simplest thing"
 exit_code 0 success
@@ -81,6 +82,7 @@ Takes a while.
     flag --format {
         arg <format>
     }
+    flag "-h --help" help="Print help" action=help builtin=#true
     arg <tool> help="the tool to install"
     output human help="a progress log" default=#true
     output json framing=json {
@@ -95,7 +97,9 @@ Takes a while.
     exit_code 3 "the tool was not found"
 }
 cmd settings help="manage settings" {
+    flag "-h --help" help="Print help" action=help builtin=#true
     cmd set help="set a value" {
+        flag "-h --help" help="Print help" action=help builtin=#true
         arg <mode> {
             choices on off
         }
@@ -103,11 +107,14 @@ cmd settings help="manage settings" {
 }
 cmd run help="run a task" restart_token=::: {
     mount run="ex tasks --usage"
+    flag "-h --help" help="Print help" action=help builtin=#true
     arg "[args]..." double_dash=preserve
 }
 cmd exec help="run a command" effect=destructive {
+    flag "-h --help" help="Print help" action=help builtin=#true
     arg <cmd>... double_dash=required
 }
 cmd watch help="watch files" hide=#true {
+    flag "-h --help" help="Print help" action=help builtin=#true
     arg "[files]..." double_dash=automatic
 }

--- a/conformance/tests/snapshots/subcommands__the_emitted_spec_reads_the_way_a_handwritten_one_would.snap
+++ b/conformance/tests/snapshots/subcommands__the_emitted_spec_reads_the_way_a_handwritten_one_would.snap
@@ -7,13 +7,17 @@ bin ex
 version "1.0"
 about "A tool that does things"
 flag "-v --verbose" help="Say more" global=#true
+flag "-h --help" help="Print help" action=help builtin=#true
+flag "-V --version" help="Print version" action=version builtin=#true
 cmd install help="Install a tool" {
     flag "-f --force" help="Overwrite an existing install"
     flag "-j --jobs" help="How many at once" default="4" {
         arg <JOBS>
     }
+    flag "-h --help" help="Print help" action=help builtin=#true
     arg "[TOOLS]..." help="What to install"
 }
 cmd run help="Run a task" {
+    flag "-h --help" help="Print help" action=help builtin=#true
     arg <TASK> help="The task to run"
 }

--- a/conformance/tests/spec_roundtrip.rs
+++ b/conformance/tests/spec_roundtrip.rs
@@ -845,10 +845,16 @@ fn nothing_is_dropped_on_the_way_out() {
     // Counts, so an entry the writer skips entirely shows up here rather than in
     // whichever assertion happened to name it.
     let spec = parsed();
-    assert_eq!(
-        spec.cmd.flags.len(),
-        ROOT.flags.len(),
-        "every declared flag should reach the spec"
+    for declared in ROOT.flags {
+        assert!(
+            spec.cmd.flags.iter().any(|flag| flag.name == declared.name),
+            "declared flag {} should reach the spec",
+            declared.name
+        );
+    }
+    assert!(
+        spec.cmd.flags.iter().any(|flag| flag.name == "help"),
+        "the generated spec should include the parser-supplied help flag"
     );
     assert_eq!(
         spec.cmd.args.len(),

--- a/conformance/tests/subcommands.rs
+++ b/conformance/tests/subcommands.rs
@@ -196,7 +196,7 @@ fn the_spec_carries_the_commands() {
     // The variant's doc comment wins: it is where a reader of the enum expects to
     // describe the command, and ignoring it would lose the description silently.
     assert_eq!(install.help.as_deref(), Some("Install a tool"));
-    assert_eq!(install.flags.len(), 2);
+    assert_eq!(install.flags.iter().filter(|flag| !flag.builtin).count(), 2);
     assert_eq!(install.args.len(), 1);
     assert!(install.args[0].var, "`tools` is a Vec, so it takes several");
 
@@ -399,7 +399,7 @@ fn boxing_changes_nothing_about_the_spec() {
     let spec: LibSpec = Boxed::to_kdl().parse().expect("valid spec");
     let install = spec.cmd.subcommands.get("install").expect("install");
     assert_eq!(install.aliases, vec!["i".to_string()]);
-    assert_eq!(install.flags.len(), 1);
+    assert_eq!(install.flags.iter().filter(|flag| !flag.builtin).count(), 1);
     assert_eq!(install.args.len(), 1);
     assert!(!Boxed::to_kdl().contains("Box"), "{}", Boxed::to_kdl());
 }

--- a/conformance/tests/unit_variants.rs
+++ b/conformance/tests/unit_variants.rs
@@ -119,7 +119,7 @@ fn it_reaches_the_spec_like_any_other_command() {
     let sponsors = spec.cmd.subcommands.get("sponsors").expect("sponsors");
     assert_eq!(sponsors.help.as_deref(), Some("Show who pays for this"));
     // Nothing of its own, which is the point — and it still declares itself.
-    assert!(sponsors.flags.is_empty());
+    assert!(sponsors.flags.iter().all(|flag| flag.builtin));
     assert!(sponsors.args.is_empty());
 }
 

--- a/conformance/tests/version.rs
+++ b/conformance/tests/version.rs
@@ -12,10 +12,8 @@
 //! The root only. clap propagates it to subcommands only when asked (`propagate_version`), and
 //! a subcommand that declares its own `-V` keeps it.
 //!
-//! Supplied by the parser and *not* listed in help, exactly as `--help` is: a spec does not
-//! declare either, so listing one would make the rendered page disagree with the spec it came
-//! from. That is this crate's existing answer for `--help` and there is no reason for the two
-//! to differ.
+//! Supplied by the parser and emitted as explicit action flags in generated specs, so metadata
+//! consumers see the same public surface as terminal help and parsing.
 
 use std::ffi::OsStr;
 
@@ -193,18 +191,22 @@ fn a_declared_long_wins_too() {
 }
 
 #[test]
-fn the_flag_is_listed_but_still_not_declared() {
-    // Listed, because a reader looking for the version should find it where they are looking.
-    // Not *declared*: the parser supplies it, and a spec claiming otherwise would have every
-    // reader inventing a flag its CLI never wrote.
+fn built_in_flags_are_listed_and_emitted() {
+    // Listed because a reader looking for these entry points should find them.
     let page = usage_argv::help::render(Versioned::spec(), Versioned::spec().root.cmd, true)
         .expect("a page");
     assert!(page.contains("-V, --version"), "{page}");
     assert!(page.contains("Print version"), "{page}");
 
     let kdl = Versioned::to_kdl();
-    assert!(!kdl.contains("--version"), "{kdl}");
-    // But the version itself is declared, which is what the flag answers with.
+    assert!(
+        kdl.contains(r#"flag "-h --help" help="Print help" action=help builtin=#true"#),
+        "{kdl}"
+    );
+    assert!(
+        kdl.contains(r#"flag "-V --version" help="Print version" action=version builtin=#true"#),
+        "{kdl}"
+    );
     assert!(kdl.contains(r#"version "1.2.3""#), "{kdl}");
 }
 

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -238,10 +238,11 @@
 //! script checking for it keeps working. `Cli::parse_from(argv)` hands the error back instead,
 //! for a library embedding a CLI that wants to decide for itself.
 //!
-//! Declaring a `version` or `long_version` also gives the CLI `--version` and `-V`, as clap does — supplied by
-//! the parser rather than listed in the spec, exactly as `--help` is, and yielding to either
-//! spelling the CLI declares for itself. clap refuses that collision by panicking at startup;
-//! here the declaration simply wins and the other spelling still answers.
+//! Declaring a `version` or `long_version` also gives the CLI `--version` and `-V`, as clap does.
+//! The parser supplies version and help entry points, and generated specs materialize their
+//! surviving spellings as `action` flags so metadata consumers see the same interface. Either
+//! spelling yields to a flag the CLI declares for itself. clap refuses that collision by
+//! panicking at startup; here the declaration simply wins and the other spelling still answers.
 //!
 //! On the struct itself: `bin`, `version`, `long_version`, `author`, `license`, `repository`,
 //! `source_code_link_template` — a tera template rendered with the command path as `path`,

--- a/docs/cli/reference/commands.json
+++ b/docs/cli/reference/commands.json
@@ -150,6 +150,18 @@
               }
             },
             "default": ["bash"]
+          },
+          {
+            "name": "help",
+            "usage": "-h --help",
+            "help": "Print help",
+            "help_first_line": "Print help",
+            "short": ["h"],
+            "long": ["help"],
+            "hide": false,
+            "global": false,
+            "action": "help",
+            "builtin": true
           }
         ],
         "mounts": [],
@@ -237,6 +249,18 @@
             "long": ["exit-zero"],
             "hide": false,
             "global": false
+          },
+          {
+            "name": "help",
+            "usage": "-h --help",
+            "help": "Print help",
+            "help_first_line": "Print help",
+            "short": ["h"],
+            "long": ["help"],
+            "hide": false,
+            "global": false,
+            "action": "help",
+            "builtin": true
           }
         ],
         "mounts": [],
@@ -445,6 +469,18 @@
               "double_dash": "Optional",
               "hide": false
             }
+          },
+          {
+            "name": "help",
+            "usage": "-h --help",
+            "help": "Print help",
+            "help_first_line": "Print help",
+            "short": ["h"],
+            "long": ["help"],
+            "hide": false,
+            "global": false,
+            "action": "help",
+            "builtin": true
           }
         ],
         "mounts": [],
@@ -654,6 +690,18 @@
                   "double_dash": "Optional",
                   "hide": false
                 }
+              },
+              {
+                "name": "help",
+                "usage": "-h --help",
+                "help": "Print help",
+                "help_first_line": "Print help",
+                "short": ["h"],
+                "long": ["help"],
+                "hide": false,
+                "global": false,
+                "action": "help",
+                "builtin": true
               }
             ],
             "mounts": [],
@@ -705,6 +753,18 @@
                 },
                 "default": ["usage"],
                 "env": "JDX_USAGE_BIN"
+              },
+              {
+                "name": "help",
+                "usage": "-h --help",
+                "help": "Print help",
+                "help_first_line": "Print help",
+                "short": ["h"],
+                "long": ["help"],
+                "hide": false,
+                "global": false,
+                "action": "help",
+                "builtin": true
               }
             ],
             "mounts": [],
@@ -778,6 +838,18 @@
                   "hide": false
                 },
                 "overrides": ["--file"]
+              },
+              {
+                "name": "help",
+                "usage": "-h --help",
+                "help": "Print help",
+                "help_first_line": "Print help",
+                "short": ["h"],
+                "long": ["help"],
+                "hide": false,
+                "global": false,
+                "action": "help",
+                "builtin": true
               }
             ],
             "mounts": [],
@@ -873,6 +945,18 @@
                   "hide": false
                 },
                 "overrides": ["--file"]
+              },
+              {
+                "name": "help",
+                "usage": "-h --help",
+                "help": "Print help",
+                "help_first_line": "Print help",
+                "short": ["h"],
+                "long": ["help"],
+                "hide": false,
+                "global": false,
+                "action": "help",
+                "builtin": true
               }
             ],
             "mounts": [],
@@ -951,6 +1035,18 @@
                   "double_dash": "Optional",
                   "hide": false
                 }
+              },
+              {
+                "name": "help",
+                "usage": "-h --help",
+                "help": "Print help",
+                "help_first_line": "Print help",
+                "short": ["h"],
+                "long": ["help"],
+                "hide": false,
+                "global": false,
+                "action": "help",
+                "builtin": true
               }
             ],
             "mounts": [],
@@ -1057,6 +1153,18 @@
                   "double_dash": "Optional",
                   "hide": false
                 }
+              },
+              {
+                "name": "help",
+                "usage": "-h --help",
+                "help": "Print help",
+                "help_first_line": "Print help",
+                "short": ["h"],
+                "long": ["help"],
+                "hide": false,
+                "global": false,
+                "action": "help",
+                "builtin": true
               }
             ],
             "mounts": [],
@@ -1153,6 +1261,18 @@
                   "hide": false
                 },
                 "default": ["1"]
+              },
+              {
+                "name": "help",
+                "usage": "-h --help",
+                "help": "Print help",
+                "help_first_line": "Print help",
+                "short": ["h"],
+                "long": ["help"],
+                "hide": false,
+                "global": false,
+                "action": "help",
+                "builtin": true
               }
             ],
             "mounts": [],
@@ -1298,6 +1418,18 @@
                   "double_dash": "Optional",
                   "hide": false
                 }
+              },
+              {
+                "name": "help",
+                "usage": "-h --help",
+                "help": "Print help",
+                "help_first_line": "Print help",
+                "short": ["h"],
+                "long": ["help"],
+                "hide": false,
+                "global": false,
+                "action": "help",
+                "builtin": true
               }
             ],
             "mounts": [],
@@ -1418,6 +1550,18 @@
                   "hide": false
                 },
                 "overrides": ["--file"]
+              },
+              {
+                "name": "help",
+                "usage": "-h --help",
+                "help": "Print help",
+                "help_first_line": "Print help",
+                "short": ["h"],
+                "long": ["help"],
+                "hide": false,
+                "global": false,
+                "action": "help",
+                "builtin": true
               }
             ],
             "mounts": [],
@@ -1433,7 +1577,20 @@
           }
         },
         "args": [],
-        "flags": [],
+        "flags": [
+          {
+            "name": "help",
+            "usage": "-h --help",
+            "help": "Print help",
+            "help_first_line": "Print help",
+            "short": ["h"],
+            "long": ["help"],
+            "hide": false,
+            "global": false,
+            "action": "help",
+            "builtin": true
+          }
+        ],
         "mounts": [],
         "effect": "read",
         "unknown_flags": null,
@@ -1511,6 +1668,18 @@
             "long": ["sorted"],
             "hide": false,
             "global": false
+          },
+          {
+            "name": "help",
+            "usage": "-h --help",
+            "help": "Print help",
+            "help_first_line": "Print help",
+            "short": ["h"],
+            "long": ["help"],
+            "hide": false,
+            "global": false,
+            "action": "help",
+            "builtin": true
           }
         ],
         "mounts": [],
@@ -1565,6 +1734,18 @@
               "hide": false
             },
             "overrides": ["--file"]
+          },
+          {
+            "name": "help",
+            "usage": "-h --help",
+            "help": "Print help",
+            "help_first_line": "Print help",
+            "short": ["h"],
+            "long": ["help"],
+            "hide": false,
+            "global": false,
+            "action": "help",
+            "builtin": true
           }
         ],
         "mounts": [],
@@ -1641,7 +1822,20 @@
         "usage": "sponsors",
         "subcommands": {},
         "args": [],
-        "flags": [],
+        "flags": [
+          {
+            "name": "help",
+            "usage": "-h --help",
+            "help": "Print help",
+            "help_first_line": "Print help",
+            "short": ["h"],
+            "long": ["help"],
+            "hide": false,
+            "global": false,
+            "action": "help",
+            "builtin": true
+          }
+        ],
         "mounts": [],
         "effect": "read",
         "unknown_flags": null,
@@ -1739,6 +1933,30 @@
         "long": ["usage-spec"],
         "hide": false,
         "global": false
+      },
+      {
+        "name": "help",
+        "usage": "-h --help",
+        "help": "Print help",
+        "help_first_line": "Print help",
+        "short": ["h"],
+        "long": ["help"],
+        "hide": false,
+        "global": false,
+        "action": "help",
+        "builtin": true
+      },
+      {
+        "name": "version",
+        "usage": "-V --version",
+        "help": "Print version",
+        "help_first_line": "Print version",
+        "short": ["V"],
+        "long": ["version"],
+        "hide": false,
+        "global": false,
+        "action": "version",
+        "builtin": true
       }
     ],
     "mounts": [],

--- a/docs/cli/reference/complete-word.md
+++ b/docs/cli/reference/complete-word.md
@@ -42,3 +42,7 @@ Current word index
 - `zsh`
 
 **Default:** `bash`
+
+### `-h --help`
+
+Print help

--- a/docs/cli/reference/diff.md
+++ b/docs/cli/reference/diff.md
@@ -51,3 +51,7 @@ Report only breaking changes
 ### `--exit-zero`
 
 Exit 0 even when there are breaking changes
+
+### `-h --help`
+
+Print help

--- a/docs/cli/reference/explain.md
+++ b/docs/cli/reference/explain.md
@@ -50,3 +50,7 @@ A spec-declared executable view to explain
 Environment to explain against, as KEY=VALUE, repeatable
 
 Given at all, these are the _whole_ environment: an explanation pasted into a bug report has to mean the same thing on the machine that reads it. Omitted, the process environment is used, which is what an execution would see.
+
+### `-h --help`
+
+Print help

--- a/docs/cli/reference/generate.md
+++ b/docs/cli/reference/generate.md
@@ -9,6 +9,12 @@
 
 Generate completions, documentation, and other artifacts from usage specs
 
+## Flags
+
+### `-h --help`
+
+Print help
+
 ## Subcommands
 
 - [`usage generate completion [FLAGS] <SHELL> <BIN>`](/cli/reference/generate/completion.md)

--- a/docs/cli/reference/generate/completion-init.md
+++ b/docs/cli/reference/generate/completion-init.md
@@ -34,3 +34,7 @@ You may need to set this if you have a different bin named "usage"
 **Default:** `usage`
 
 **Environment Variable:** `JDX_USAGE_BIN`
+
+### `-h --help`
+
+Print help

--- a/docs/cli/reference/generate/completion.md
+++ b/docs/cli/reference/generate/completion.md
@@ -64,3 +64,7 @@ You may need to set this if you have a different bin named "usage"
 ### `--usage-cmd <USAGE_CMD>`
 
 A command which generates a usage spec e.g.: `mycli --usage` or `mycli completion usage` Defaults to "$bin --usage"
+
+### `-h --help`
+
+Print help

--- a/docs/cli/reference/generate/fig.md
+++ b/docs/cli/reference/generate/fig.md
@@ -23,3 +23,7 @@ File path where the generated Fig spec will be saved, or "-" for stdout
 ### `--spec <SPEC>`
 
 Raw string spec input
+
+### `-h --help`
+
+Print help

--- a/docs/cli/reference/generate/go.md
+++ b/docs/cli/reference/generate/go.md
@@ -31,3 +31,7 @@ Go package clause for the generated file (defaults to the spec's bin name)
 ### `--spec <SPEC>`
 
 Raw string spec input
+
+### `-h --help`
+
+Print help

--- a/docs/cli/reference/generate/json-schema.md
+++ b/docs/cli/reference/generate/json-schema.md
@@ -31,3 +31,7 @@ The schema's title, shown by editors
 ### `--url <URL>`
 
 Where the schema is published, for its `$id`
+
+### `-h --help`
+
+Print help

--- a/docs/cli/reference/generate/json.md
+++ b/docs/cli/reference/generate/json.md
@@ -21,3 +21,7 @@ raw string spec input
 ### `--view <VIEW>`
 
 Render one spec-declared executable view
+
+### `-h --help`
+
+Print help

--- a/docs/cli/reference/generate/manpage.md
+++ b/docs/cli/reference/generate/manpage.md
@@ -32,3 +32,7 @@ Manual section number (default: 1)
 Common sections: - 1: User commands - 5: File formats - 7: Miscellaneous - 8: System administration commands
 
 **Default:** `1`
+
+### `-h --help`
+
+Print help

--- a/docs/cli/reference/generate/markdown.md
+++ b/docs/cli/reference/generate/markdown.md
@@ -46,3 +46,7 @@ Replace `<pre>` tags with markdown code fences
 ### `--url-prefix <URL_PREFIX>`
 
 Prefix to add to all URLs
+
+### `-h --help`
+
+Print help

--- a/docs/cli/reference/generate/sdk.md
+++ b/docs/cli/reference/generate/sdk.md
@@ -34,3 +34,7 @@ Override the package/module name (defaults to spec bin name)
 ### `--spec <SPEC>`
 
 Raw string spec input
+
+### `-h --help`
+
+Print help

--- a/docs/cli/reference/index.md
+++ b/docs/cli/reference/index.md
@@ -20,6 +20,14 @@ Outputs completions for the specified shell for completing the `usage` CLI itsel
 
 Outputs a `usage.kdl` spec for this CLI itself
 
+### `-h --help`
+
+Print help
+
+### `-V --version`
+
+Print version
+
 ## Subcommands
 
 - [`usage bash [-h] [--help] <SCRIPT> [ARGS]…`](/cli/reference/bash.md)

--- a/docs/cli/reference/lint.md
+++ b/docs/cli/reference/lint.md
@@ -36,3 +36,7 @@ Treat warnings as errors
 Also check that subcommands and flags are declared in sorted order
 
 Off by default: declaration order is a house convention rather than a correctness question, so a spec that keeps a different order is not wrong. Pair it with --warnings-as-errors to hold the order in CI.
+
+### `-h --help`
+
+Print help

--- a/docs/cli/reference/mcp.md
+++ b/docs/cli/reference/mcp.md
@@ -21,3 +21,7 @@ Usage spec file (not "-": stdin is the MCP transport)
 ### `-s --spec <SPEC>`
 
 Raw string spec input
+
+### `-h --help`
+
+Print help

--- a/docs/cli/reference/sponsors.md
+++ b/docs/cli/reference/sponsors.md
@@ -7,3 +7,9 @@
 - **Source code**: [`cli/src/cli/sponsors.rs`](https://github.com/jdx/usage/blob/main/cli/src/cli/sponsors.rs)
 
 Show the companies sponsoring usage and the jdx.dev open source tools
+
+## Flags
+
+### `-h --help`
+
+Print help

--- a/docs/rust/completions.md
+++ b/docs/rust/completions.md
@@ -129,6 +129,10 @@ survives one.
 
 Three ways to say what a value can be:
 
+Value choices and custom completers work for both detached values (`--format j`) and attached
+long values (`--format=j`). Attached candidates retain the flag prefix because shells replace
+the whole word, so the latter completes to a word such as `--format=json`.
+
 ```rust
 // a fixed set of words
 #[usage(long, choices("json", "table"))]

--- a/docs/spec/reference/cmd.md
+++ b/docs/spec/reference/cmd.md
@@ -257,6 +257,11 @@ The same properties are accepted on a `cmd` node. A declared flag can then reloc
 behavior with `action="help"`, `help_short`, `help_long`, `help_all`, or `version`; its ordinary `help`
 text is what the help page displays.
 
+Rust-derived generated specs write the parser-supplied help and version spellings as explicit
+flags with those actions and `builtin=#true`. This keeps generated metadata complete for
+documentation and other consumers while keeping built-ins out of ordinary command synopses. If
+a declared flag claims one spelling, only the surviving built-in spelling is written.
+
 ## Let a subcommand satisfy parent requirements
 
 `subcommand_negates_reqs` makes required arguments, flags, groups, and conditional

--- a/docs/spec/reference/flag.md
+++ b/docs/spec/reference/flag.md
@@ -27,6 +27,7 @@ flag "--assist" action="help_short" help="Show concise help"
 flag "--manual" action="help_long" help="Show full help"
 flag "--help-all" action="help_all" help="Show help for every command"
 flag "--release" action="version" help="Print version"
+flag "-h --help" action="help" builtin=#true // parser-supplied, materialized by a generator
 
 flag "--include <pattern>" var=#true            // flag can be repeated (--include a --include b)
 flag "--include... <pattern>"                   // same as above, ellipsis on flag

--- a/lib/src/spec/cmd.rs
+++ b/lib/src/spec/cmd.rs
@@ -679,7 +679,11 @@ impl SpecCommand {
 
     fn usage_with_subcommands(&self, include_subcommands: bool) -> String {
         let mut usage = self.full_cmd.join(" ");
-        let flags = self.flags.iter().filter(|f| !f.hide).collect_vec();
+        let flags = self
+            .flags
+            .iter()
+            .filter(|f| !f.hide && !f.builtin)
+            .collect_vec();
         let args = self.args.iter().filter(|a| !a.hide).collect_vec();
         if !flags.is_empty() {
             if flags.len() <= 2 {

--- a/lib/src/spec/flag.rs
+++ b/lib/src/spec/flag.rs
@@ -314,6 +314,9 @@ pub struct SpecFlag {
     /// Whether this flag binds a value or requests help/version output.
     #[serde(skip_serializing_if = "is_set_action")]
     pub action: SpecFlagAction,
+    /// Whether this is a parser-supplied entry materialized by a generated spec.
+    #[serde(skip_serializing_if = "is_false")]
+    pub builtin: bool,
 }
 
 fn is_set_action(action: &SpecFlagAction) -> bool {
@@ -379,6 +382,7 @@ impl SpecFlag {
                     };
                     flag.action = action;
                 }
+                "builtin" => flag.builtin = v.ensure_bool()?,
                 "allow_hyphen_values" => allow_hyphen_values = v.ensure_bool()?,
                 "allow_negative_numbers" => allow_negative_numbers = v.ensure_bool()?,
                 "value_terminator" => value_terminator = Some(v.ensure_string()?),
@@ -517,6 +521,7 @@ impl SpecFlag {
                     };
                     flag.action = action;
                 }
+                "builtin" => flag.builtin = child.arg(0)?.ensure_bool()?,
                 "allow_hyphen_values" => {
                     allow_hyphen_values = child.arg(0)?.ensure_bool()?;
                 }
@@ -1021,6 +1026,9 @@ impl From<&SpecFlag> for KdlNode {
         if flag.action != SpecFlagAction::Set {
             node.push(string_entry(Some("action"), flag.action.as_str()));
         }
+        if flag.builtin {
+            node.push(KdlEntry::new_prop("builtin", true));
+        }
         if flag.allow_hyphen_values() {
             node.push(KdlEntry::new_prop("allow_hyphen_values", true));
         }
@@ -1487,6 +1495,7 @@ impl From<&clap::Arg> for SpecFlag {
                 clap::ArgAction::Version => SpecFlagAction::Version,
                 _ => SpecFlagAction::Set,
             },
+            builtin: false,
             default,
             deprecated: None,
             negate,

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -3080,10 +3080,20 @@ fn a_struct_flattened_twice_is_written_once_as_a_flagset() {
     // The set stands where the struct did, so help order is still declaration order.
     let spec: usage_parser::Spec = kdl.parse().expect("the emitted set should parse back");
     let build = spec.cmd.subcommands.get("build").expect("build");
-    let flags: Vec<&str> = build.flags.iter().map(|f| f.name.as_str()).collect();
+    let flags: Vec<&str> = build
+        .flags
+        .iter()
+        .filter(|f| !f.builtin)
+        .map(|f| f.name.as_str())
+        .collect();
     assert_eq!(flags, ["release", "verbose", "jobs", "target"], "{kdl}");
     let test = spec.cmd.subcommands.get("test").expect("test");
-    let flags: Vec<&str> = test.flags.iter().map(|f| f.name.as_str()).collect();
+    let flags: Vec<&str> = test
+        .flags
+        .iter()
+        .filter(|f| !f.builtin)
+        .map(|f| f.name.as_str())
+        .collect();
     assert_eq!(flags, ["verbose", "jobs"], "{kdl}");
 
     // Help text and values survive the trip, not just the names: a set that lost them
@@ -3185,7 +3195,12 @@ fn a_struct_that_flattens_another_is_a_set_that_uses_a_set() {
     let spec: usage_parser::Spec = kdl.parse().expect("composed sets should parse back");
     for name in ["one", "two"] {
         let cmd = spec.cmd.subcommands.get(name).expect(name);
-        let flags: Vec<&str> = cmd.flags.iter().map(|f| f.name.as_str()).collect();
+        let flags: Vec<&str> = cmd
+            .flags
+            .iter()
+            .filter(|f| !f.builtin)
+            .map(|f| f.name.as_str())
+            .collect();
         assert_eq!(flags, ["inner", "outer"], "{name}: {kdl}");
     }
 }
@@ -3301,6 +3316,7 @@ fn two_structs_whose_names_end_the_same_way_get_no_set_at_all() {
     assert_eq!(
         one.flags
             .iter()
+            .filter(|f| !f.builtin)
             .map(|f| f.name.as_str())
             .collect::<Vec<_>>(),
         ["left"],
@@ -3310,6 +3326,7 @@ fn two_structs_whose_names_end_the_same_way_get_no_set_at_all() {
     assert_eq!(
         two.flags
             .iter()
+            .filter(|f| !f.builtin)
             .map(|f| f.name.as_str())
             .collect::<Vec<_>>(),
         ["right"],
@@ -3362,6 +3379,7 @@ fn a_collision_does_not_hide_the_one_inside_it() {
     assert_eq!(
         one.flags
             .iter()
+            .filter(|f| !f.builtin)
             .map(|f| f.name.as_str())
             .collect::<Vec<_>>(),
         ["left", "one"],
@@ -3371,6 +3389,7 @@ fn a_collision_does_not_hide_the_one_inside_it() {
     assert_eq!(
         two.flags
             .iter()
+            .filter(|f| !f.builtin)
             .map(|f| f.name.as_str())
             .collect::<Vec<_>>(),
         ["right", "two"],

--- a/xtask/src/shadow.rs
+++ b/xtask/src/shadow.rs
@@ -713,6 +713,13 @@ fn emit_command(out: &mut String, cmd: &SpecCommand, ty: &Type, is_root: bool, r
         .flags
         .iter()
         .filter_map(|flag| {
+            // Exported specs materialize parser-supplied help and version entries so docs and
+            // completion generators can see them. A generated parser must leave those entries
+            // to its framework again; emitting ordinary fields would duplicate the built-ins
+            // and, for usage, incorrectly put them back into command synopses.
+            if flag.builtin {
+                return None;
+            }
             let long = flag
                 .long
                 .iter()
@@ -2359,6 +2366,23 @@ mod tests {
         );
         assert!(out.contains(r#"env = "EX_FILE""#), "{out}");
         assert!(out.contains(r#"help_heading = "Input""#), "{out}");
+    }
+
+    #[test]
+    fn parser_supplied_flags_are_left_to_the_shadow_parser() {
+        let spec = "name \"ex\"\nbin \"ex\"\nflag \"-h --help\" action=help builtin=#true\nflag \"-V --version\" action=version builtin=#true\n";
+
+        for dialect in [Dialect::Usage, Dialect::Clap, Dialect::Argh, Dialect::Bpaf] {
+            let (out, skipped) = rendered_as(spec, dialect);
+            assert!(!out.contains("pub help:"), "{}: {out}", dialect.as_str());
+            assert!(!out.contains("pub version:"), "{}: {out}", dialect.as_str());
+            assert!(
+                skipped.counts.is_empty(),
+                "{}: {:?}",
+                dialect.as_str(),
+                skipped.counts
+            );
+        }
     }
 
     #[test]

--- a/xtask/src/shadow.rs
+++ b/xtask/src/shadow.rs
@@ -2372,7 +2372,7 @@ mod tests {
     fn parser_supplied_flags_are_left_to_the_shadow_parser() {
         let spec = "name \"ex\"\nbin \"ex\"\nflag \"-h --help\" action=help builtin=#true\nflag \"-V --version\" action=version builtin=#true\n";
 
-        for dialect in [Dialect::Usage, Dialect::Clap, Dialect::Argh, Dialect::Bpaf] {
+        for dialect in [Dialect::Usage, Dialect::Clap, Dialect::Bpaf] {
             let (out, skipped) = rendered_as(spec, dialect);
             assert!(!out.contains("pub help:"), "{}: {out}", dialect.as_str());
             assert!(!out.contains("pub version:"), "{}: {out}", dialect.as_str());


### PR DESCRIPTION
## Summary

- complete the value fragment in attached long options such as `--format=j`, then return whole-word candidates such as `--format=json`
- route static choices, named completers, and runtime completion overlays through the attached-value context
- materialize parser-supplied help and version flags in generated specs, including collision-aware surviving spellings
- mark materialized entries as built-ins so listings and completion consumers see them without changing ordinary usage synopses

## Tests

- `cargo test --all --all-features`
- `cargo clippy --all --all-features --all-targets -- -D warnings`
- `cargo test -p usage-argv --all-features`
- `cargo test -p usage-conformance --all-features`
- `cargo test -p gate --test fleet --all-features`
- `cargo fmt --check`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches completion routing and the generated spec surface (KDL/JSON/docs). Builtin flags change what consumers see without altering parse behavior, but a mismatch in `builtin` handling could duplicate help/version in generated parsers or synopses.
> 
> **Overview**
> Shell completion now treats `--flag=prefix` as a value position. Candidates are matched against the fragment after `=` and rewritten as whole words (`--flag=json`) so static choices, named completers, and runtime overlays work for attached longs.
> 
> Generated specs materialize the parser-supplied help/version spellings (collision-aware) as `action` flags with `builtin=#true`. They show up in listings, completions, and docs, but stay out of command synopses. Shadow codegen skips those entries so generated parsers do not redeclare the framework built-ins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f752a7a8b075d8e26937aa6371cb91af9e933c2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->