### PR TITLE
fix(derive): suppress generated partial field lint

### DIFF
--- a/conformance/tests/clippy.rs
+++ b/conformance/tests/clippy.rs
@@ -4,7 +4,7 @@
 
 use std::ffi::OsStr;
 
-use usage_derive::Cli;
+use usage_derive::{Args, Cli};
 
 mod reusable {
     use usage_derive::Args;
@@ -16,14 +16,25 @@ mod reusable {
     }
 }
 
+// Keep this type private: its generated `Partial` must fulfill the lint expectation too.
+#[derive(Args)]
+struct PrivateShared {
+    #[usage(long)]
+    quiet: bool,
+}
+
 #[derive(Cli)]
 struct App {
     #[usage(flatten)]
     shared: reusable::Shared,
+    #[usage(flatten)]
+    private: PrivateShared,
 }
 
 #[test]
 fn generated_partial_state_is_lint_clean() {
-    let parsed = App::parse_from(&[OsStr::new("--verbose")]).expect("parses");
+    let parsed =
+        App::parse_from(&[OsStr::new("--verbose"), OsStr::new("--quiet")]).expect("parses");
     assert!(parsed.shared.verbose);
+    assert!(parsed.private.quiet);
 }

--- a/conformance/tests/clippy.rs
+++ b/conformance/tests/clippy.rs
@@ -1,0 +1,29 @@
+//! Lint hygiene for code emitted into adopter crates.
+
+#![deny(clippy::allow_attributes, clippy::pub_underscore_fields)]
+
+use std::ffi::OsStr;
+
+use usage_derive::Cli;
+
+mod reusable {
+    use usage_derive::Args;
+
+    #[derive(Args)]
+    pub struct Shared {
+        #[usage(long)]
+        pub verbose: bool,
+    }
+}
+
+#[derive(Cli)]
+struct App {
+    #[usage(flatten)]
+    shared: reusable::Shared,
+}
+
+#[test]
+fn generated_partial_state_is_lint_clean() {
+    let parsed = App::parse_from(&[OsStr::new("--verbose")]).expect("parses");
+    assert!(parsed.shared.verbose);
+}

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -4594,6 +4594,7 @@ fn partial_struct(cli: &Cli) -> TokenStream {
     // declared default has to be in place before parsing begins and nested state has
     // its own starting values.
     quote! {
+        #[expect(clippy::pub_underscore_fields)]
         pub struct Partial {
             pub __usage_view: ::std::option::Option<
                 &'static usage_argv::spec::ViewMeta<'static>,


### PR DESCRIPTION
## Summary

- attach a targeted `#[expect(clippy::pub_underscore_fields)]` to generated command partial structs
- keep the internal fields public for flattened args shared across module boundaries
- add downstream coverage that denies both `pub_underscore_fields` and `allow_attributes`

## Validation

- `cargo test --all --all-features`
- `cargo clippy --all --all-features --all-targets -- -D warnings`

_This pull request was generated with assistance from Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small derive-codegen lint suppression plus a compile-time hygiene test; no parsing or security behavior changes.
> 
> **Overview**
> Stops Clippy `pub_underscore_fields` from firing in adopter crates on generated `Partial` structs.
> 
> Adds `#[expect(clippy::pub_underscore_fields)]` on those structs so internal fields like `__usage_view` can stay public (needed for flattened args across modules) without `allow` attributes.
> 
> Adds a conformance test that denies both `pub_underscore_fields` and `allow_attributes` while flattening public and private nested `Args` types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 528e0c36d8292d8cdf5b935dadcf830e0561af90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->