### PR TITLE
perf(markdown): skip empty admonition context

### DIFF
--- a/lib/src/docs/cli/templates/spec_template_long.tera
+++ b/lib/src/docs/cli/templates/spec_template_long.tera
@@ -78,9 +78,11 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
     {{ help | indent(width=4) }}
 {%- endif %}
 {%- endif %}
+{%- if arg.admonitions %}
 {%- for admonition in arg.admonitions %}
     {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | indent(width=4) }}
 {%- endfor %}
+{%- endif %}
 {%- if not arg.hide_possible_values and arg.choices and arg.choices.choices %}
     [possible values: {{ arg.choices.choices | join(sep=", ") }}]
 {%- endif %}
@@ -126,10 +128,12 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
     {{ help | indent(width=4) }}
 {%- endif %}
 {%- endif %}
+{%- if flag.admonitions %}
 {%- for admonition in flag.admonitions %}
     {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | indent(width=4) }}
 {%- endfor %}
-{%- if flag.arg %}
+{%- endif %}
+{%- if flag.arg and flag.arg.admonitions %}
 {%- for admonition in flag.arg.admonitions %}
     {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | indent(width=4) }}
 {%- endfor %}
@@ -181,10 +185,12 @@ Global flags:
     {{ help | indent(width=4) }}
 {%- endif %}
 {%- endif %}
+{%- if flag.admonitions %}
 {%- for admonition in flag.admonitions %}
     {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | indent(width=4) }}
 {%- endfor %}
-{%- if flag.arg %}
+{%- endif %}
+{%- if flag.arg and flag.arg.admonitions %}
 {%- for admonition in flag.arg.admonitions %}
     {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | indent(width=4) }}
 {%- endfor %}
@@ -236,9 +242,11 @@ Global flags:
 {%- else %}
   {{ arg.usage | trim }}
 {%- endif %}
+{%- if arg.admonitions %}
 {%- for admonition in arg.admonitions %}
     {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | indent(width=4) }}
 {%- endfor %}
+{%- endif %}
 {%- if not arg.hide_possible_values and arg.choices and arg.choices.choices %}
     [possible values: {{ arg.choices.choices | join(sep=", ") }}]
 {%- endif %}
@@ -268,10 +276,12 @@ Global flags:
 {%- else %}
   {{ flag.display_usage }}
 {%- endif %}
+{%- if flag.admonitions %}
 {%- for admonition in flag.admonitions %}
     {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | indent(width=4) }}
 {%- endfor %}
-{%- if flag.arg %}
+{%- endif %}
+{%- if flag.arg and flag.arg.admonitions %}
 {%- for admonition in flag.arg.admonitions %}
     {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | indent(width=4) }}
 {%- endfor %}

--- a/lib/src/docs/markdown/templates/arg_template.md.tera
+++ b/lib/src/docs/markdown/templates/arg_template.md.tera
@@ -2,10 +2,12 @@
 
 {{ arg.help_md | escape_md }}
 {%- endif %}
+{%- if arg.admonitions %}
 {%- for admonition in arg.admonitions %}
 
 > **{% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}:** {{ admonition.text | escape_md | replace(from="\n", to="\n> ") }}
 {%- endfor %}
+{%- endif %}
 {%- if arg.choices and arg.choices.choices %}
 
 **Choices:**

--- a/lib/src/docs/markdown/templates/flag_template.md.tera
+++ b/lib/src/docs/markdown/templates/flag_template.md.tera
@@ -14,11 +14,13 @@
 
 {{ flag.help_md | escape_md }}
 {%- endif %}
+{%- if flag.admonitions %}
 {%- for admonition in flag.admonitions %}
 
 > **{% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}:** {{ admonition.text | escape_md | replace(from="\n", to="\n> ") }}
 {%- endfor %}
-{%- if flag.arg %}
+{%- endif %}
+{%- if flag.arg and flag.arg.admonitions %}
 {%- for admonition in flag.arg.admonitions %}
 
 > **{% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}:** {{ admonition.text | escape_md | replace(from="\n", to="\n> ") }}

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -132,6 +132,7 @@ pub struct SpecFlag {
     pub help: Option<String>,
     pub help_long: Option<String>,
     pub help_md: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub admonitions: Vec<SpecAdmonition>,
     pub help_first_line: Option<String>,
     pub short: Vec<char>,
@@ -479,6 +480,7 @@ pub struct SpecArg {
     pub help: Option<String>,
     pub help_long: Option<String>,
     pub help_md: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub admonitions: Vec<SpecAdmonition>,
     pub help_first_line: Option<String>,
     pub required: bool,


### PR DESCRIPTION
## Summary

- omit empty admonition arrays from Markdown render contexts
- avoid entering admonition template loops when no semantic blocks exist
- preserve note and warning rendering for argument, flag, nested-value, and portable help layouts

This follows #1273, whose performance gate measured a 3.15% Markdown instruction-count increase. The optimized branch measured 308,365,170 instructions locally against the CI baseline of 305,679,051, approximately +0.88% and below the 1% gate.

## Verification

- cargo test --all --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- focused admonition and Markdown CLI tests
- mise run render
- mise run gen-shadow
- mise run gen-go
- tak run --bench markdown --runs 3

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-template and serde-skip-only change; no CLI parsing, auth, or data-path behavior is affected.
> 
> **Overview**
> Cuts Markdown/help render cost by omitting empty `admonitions` from docs-model serialization and skipping those template loops unless notes or warnings exist.
> 
> `SpecArg` and `SpecFlag` now `skip_serializing_if` empty admonition vecs. CLI long-help and Markdown arg/flag templates wrap the loops in `{% if …admonitions %}` (including nested `flag.arg.admonitions`) so Tera does not iterate empty lists on every flag/arg. Rendered note/warning output is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65d307c41b5618bc2181da7b9739c1193343d70d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->