### PR TITLE
feat(derive): emit embedded_outcome_into for converted CLIs

### DIFF
--- a/argv/src/embedded.rs
+++ b/argv/src/embedded.rs
@@ -49,6 +49,14 @@ impl<T> Outcome<T> {
             Self::Exit(exit) => Some(exit),
         }
     }
+
+    /// The same outcome over a converted value, for a host that finalizes what it parsed.
+    pub fn map<U>(self, f: impl FnOnce(T) -> U) -> Outcome<U> {
+        match self {
+            Self::Parsed(parsed) => Outcome::Parsed(f(parsed)),
+            Self::Exit(exit) => Outcome::Exit(exit),
+        }
+    }
 }
 
 /// Parse one command line without printing or ending the host process.
@@ -179,6 +187,26 @@ mod tests {
     fn a_parsed_value_is_returned_to_the_host() {
         let got = outcome_with_styles(&SPEC, &ROOT, &[], |_| Ok(7), Style::PLAIN, Style::PLAIN);
         assert_eq!(got.parsed(), Some(7));
+    }
+
+    #[test]
+    fn a_mapped_outcome_converts_only_a_parsed_value() {
+        let parsed = outcome_with_styles(&SPEC, &ROOT, &[], |_| Ok(7), Style::PLAIN, Style::PLAIN);
+        assert_eq!(parsed.map(|value| value * 2).parsed(), Some(14));
+
+        let failure = outcome_with_styles(
+            &SPEC,
+            &ROOT,
+            &[],
+            failed::<i32>(Error::Version { long: false }),
+            Style::PLAIN,
+            Style::PLAIN,
+        );
+        let mapped = failure.map(|value| value.to_string());
+        assert_eq!(
+            mapped.exit().map(|exit| exit.text.as_str()),
+            Some("ex 1.2.3\n")
+        );
     }
 
     #[test]

--- a/conformance/tests/embedded.rs
+++ b/conformance/tests/embedded.rs
@@ -1,6 +1,7 @@
 use std::ffi::OsString;
 
 use usage_argv::embedded::Outcome;
+use usage_argv::ValidationError;
 use usage_derive::Cli;
 
 #[derive(Debug, Cli)]
@@ -8,6 +9,38 @@ use usage_derive::Cli;
 struct Ex {
     #[usage(long)]
     force: bool,
+}
+
+#[derive(Debug, Cli)]
+#[usage(bin = "exi", version = "1.2.3", completion, try_into = ExiCommand)]
+struct Exi {
+    #[usage(long)]
+    force: bool,
+    #[usage(long)]
+    mode: Option<String>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ExiCommand {
+    force: bool,
+    mode: String,
+}
+
+impl TryFrom<Exi> for ExiCommand {
+    type Error = ValidationError;
+
+    fn try_from(parsed: Exi) -> Result<Self, Self::Error> {
+        let mode = parsed.mode.unwrap_or_else(|| "fast".to_string());
+        if mode == "banned" {
+            return Err(ValidationError::field("--mode")
+                .value(mode)
+                .reason("that mode was retired"));
+        }
+        Ok(Self {
+            force: parsed.force,
+            mode,
+        })
+    }
 }
 
 fn argv(words: &[&str]) -> Vec<OsString> {
@@ -53,4 +86,71 @@ fn embedded_dispatch_parses_or_renders_every_other_outcome() {
     assert_eq!(exit.code, 2);
     assert!(exit.stderr);
     assert!(exit.text.contains("--unknown"), "{}", exit.text);
+}
+
+#[test]
+fn finalizing_dispatch_owns_spec_and_completion_requests() {
+    let spec = Exi::embedded_outcome_into(&argv(&[usage_argv::SPEC_REQUEST]));
+    let exit = spec.exit().expect("the spec endpoint responds");
+    assert_eq!(exit.code, 0);
+    assert!(!exit.stderr);
+    assert!(exit.text.contains("name exi"), "{}", exit.text);
+
+    let completion = Exi::embedded_outcome_into(&argv(&[
+        "__complete_word__",
+        "--shell",
+        "bash",
+        "--line",
+        "exi --f",
+    ]));
+    let exit = completion.exit().expect("the completion endpoint responds");
+    assert_eq!(exit.code, 0);
+    assert!(!exit.stderr);
+    assert!(exit.text.contains("--force"), "{}", exit.text);
+}
+
+#[test]
+fn finalizing_dispatch_converts_a_parsed_command_line() {
+    let Outcome::Parsed(command) = Exi::embedded_outcome_into(&argv(&["--force"])) else {
+        panic!("an ordinary invocation should parse and finalize");
+    };
+    assert_eq!(
+        command,
+        ExiCommand {
+            force: true,
+            mode: "fast".to_string(),
+        }
+    );
+
+    let help = Exi::embedded_outcome_into(&argv(&["--help"]));
+    let exit = help.exit().expect("help is a response");
+    assert_eq!(exit.code, 0);
+    assert!(!exit.stderr);
+    assert!(exit.text.contains("Usage: exi"), "{}", exit.text);
+}
+
+#[test]
+fn finalization_failures_render_like_parse_failures() {
+    let rejected = Exi::embedded_outcome_into(&argv(&["--mode", "banned"]));
+    let exit = rejected
+        .exit()
+        .expect("a rejected conversion is a response");
+    assert_eq!(exit.code, 2);
+    assert!(exit.stderr);
+    assert!(exit.text.contains("that mode was retired"), "{}", exit.text);
+
+    let failure = Exi::embedded_outcome_into(&argv(&["--unknown"]));
+    let exit = failure.exit().expect("a parse failure is a response");
+    assert_eq!(exit.code, 2);
+    assert!(exit.stderr);
+    assert!(exit.text.contains("--unknown"), "{}", exit.text);
+}
+
+#[test]
+fn a_host_can_finalize_an_unconverted_outcome_itself() {
+    let mapped = Ex::embedded_outcome(&argv(&["--force"])).map(|parsed| parsed.force);
+    assert_eq!(mapped.parsed(), Some(true));
+
+    let help = Ex::embedded_outcome(&argv(&["--help"])).map(|parsed| parsed.force);
+    assert_eq!(help.exit().map(|exit| exit.code), Some(0));
 }

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -910,6 +910,33 @@ pub fn emit(cli: &Cli) -> TokenStream {
         }
     };
 
+    // The embedded counterpart to `parse_into_from`. It cannot live in the `parse_into` block
+    // above, which is built before the runtime identity `effective_spec` depends on.
+    let embedded_outcome_into = cli.try_into.as_ref().map(|target| {
+        quote! {
+            /// [`Self::embedded_outcome`], finalized into the application's domain type.
+            ///
+            /// Spec and completion requests, help, versions and failures behave exactly as
+            /// they do there, and a `TryFrom` finalization error becomes the same failure
+            /// response a parse error does.
+            pub fn embedded_outcome_into(
+                argv: &[::std::ffi::OsString],
+            ) -> usage_argv::embedded::Outcome<#target> {
+                let __usage_refs: ::std::vec::Vec<&::std::ffi::OsStr> =
+                    argv.iter().map(|arg| arg.as_os_str()).collect();
+                #embedded_spec_request
+                #embedded_completion_request
+                #effective_spec
+                usage_argv::embedded::outcome(
+                    __usage_spec,
+                    Self::command(),
+                    &__usage_refs,
+                    Self::parse_into_from,
+                )
+            }
+        }
+    });
+
     // One renderer for every help request. Which page a request becomes — and whether it is the
     // route the words took or a fallback by address — is decided once, in usage-argv, rather
     // than three times here in code nobody reads until it is wrong. It is also what lets a test
@@ -1368,6 +1395,8 @@ pub fn emit(cli: &Cli) -> TokenStream {
                         Self::parse_from,
                     )
                 }
+
+                #embedded_outcome_into
 
                 #settings_binding_forward
                 #settings_parse

--- a/docs/rust/help.md
+++ b/docs/rust/help.md
@@ -68,6 +68,13 @@ or a parse failure as stderr status 2. It uses the portable binary name and vers
 a CLI whose identity is computed at runtime handles `Error::Version` itself so it can substitute
 that runtime value.
 
+A derived CLI does not need to assemble that call. `Ex::embedded_outcome(&argv)` answers the whole
+control protocol — the spec and completion endpoints as well as help, version, and failures — and
+a CLI declaring [`try_into`](/rust/validation#cross-field-validation-and-typed-finalization) has
+`Ex::embedded_outcome_into(&argv)`, which returns `Outcome<Domain>` with a rejected conversion
+rendered as the same failure response a parse error produces. A host that finalizes some other way
+can convert a parsed value in place with `Outcome::map`.
+
 ### Deprecation warnings
 
 A `deprecated` flag or command, or a value that arrived through a `deprecated_env` alias, is

--- a/docs/rust/validation.md
+++ b/docs/rust/validation.md
@@ -282,7 +282,8 @@ fn main() {
 ```
 
 `parse_into_from`, `parse_into_from_with_warnings`, `parse_into_from_argv`, and
-`try_parse_into_from` are the returning-error counterparts. The original `parse_*` methods remain
+`try_parse_into_from` are the returning-error counterparts, and `embedded_outcome_into` is the
+[embedded](/rust/help#embedding-without-exiting) one. The original `parse_*` methods remain
 available when a caller wants the declaration type itself.
 
 ## Portable expressions


### PR DESCRIPTION
## Summary

A CLI declaring `try_into` gets `parse_into_from`, `parse_into_from_with_warnings`, `parse_into_from_argv`, `try_parse_into_from`, and `parse_into` — every finalizing entry point except the embedded one. `embedded_outcome` returns `Outcome<Self>` unconditionally and hardcodes `Self::parse_from`, so a host that both embeds and finalizes has no method to call.

oxc hit this in [oxc-project/oxc#26027](https://github.com/oxc-project/oxc/pull/26027): oxfmt reimplements the generated `embedded_outcome` body verbatim just to pass `parse_into_from`, while oxlint — which finalizes by hand instead of with `try_into` — delegates to the generated method. Two apps in one migration, two shapes, because the framework only supported one of them. The copy also hardcodes `Self::spec()` where codegen interpolates the runtime-identity spec, so a later `runtime_version` would be honored on every generated path except the hand-rolled one.

- `embedded_outcome_into` is emitted alongside the rest of the `try_into` family: same `spec_request` and `completion_request` endpoints, same `effective_spec`, returning `Outcome<Target>`.
- A `TryFrom` rejection renders as the same failure response a parse error produces, via the existing `ValidationError::into_parse_error` path.
- `Outcome::map` covers hosts that finalize some other way — previously `Outcome` exposed only `parsed()` and `exit()`, so even a three-line adapter over the generated method was impossible.

## Verification

- `cargo test --all --all-features` (144 test binaries, 0 failures)
- `cargo clippy --all --all-features -- -D warnings`
- `cargo fmt --all`
- New coverage in `conformance/tests/embedded.rs`: a `try_into` CLI with `completion`, asserting spec/completion interception, conversion of a parsed command line, help, a rejected conversion, an unknown flag, and an `Outcome::map` round-trip. `conformance/tests/finalize.rs` and the existing embedded tests are unchanged and still pass — the two features had never been combined in a test before.

_This pull request was generated by Claude Code._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive library API and codegen for the existing try_into/embedded paths; no auth, data, or process-exit behavior changes beyond filling a previously missing entry point.
> 
> **Overview**
> CLIs that declare `try_into` now get `embedded_outcome_into`, the missing embedded counterpart to `parse_into_from`. Hosts can parse, finalize, and still own spec/completion/help/version/failure responses without copying generated dispatch.
> 
> A `TryFrom` rejection is rendered like a parse failure. Hosts that convert some other way can use new `Outcome::map` instead of reimplementing the protocol.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25d6366eb67a81526d9055d9207d3280c7526a55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for converting parsed command-line values into application-specific types without exiting.
  * Added embedded handling for specifications, completions, help, version information, and validation failures.
  * Added command finalization with default mode handling and validation of unsupported values.

* **Documentation**
  * Documented the new embedded conversion and outcome-mapping APIs.
  * Clarified how embedded parsing complements existing conversion methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->