### PR TITLE
feat(spec): add help prose to heading sections

### DIFF
--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -1159,12 +1159,16 @@ fn short_sections(
         .max()
         .unwrap_or(0);
     split_groups_section(
-        &mut sections.args,
-        &mut sections.ungrouped_args,
-        &mut sections.grouped_args,
+        SectionSink {
+            page: &mut sections.args,
+            ungrouped: &mut sections.ungrouped_args,
+            grouped: &mut sections.grouped_args,
+        },
         "Arguments",
         args.iter().copied(),
         |a| a.help_heading,
+        // Section prose belongs to the long page, like an entry's admonitions.
+        |_| None,
         |out, a| {
             let usage = arg_usage(a);
             if meta.next_line_help {
@@ -1264,23 +1268,29 @@ fn short_sections(
         );
     };
     split_groups_section(
-        &mut sections.flags,
-        &mut sections.ungrouped_flags,
-        &mut sections.grouped_flags,
+        SectionSink {
+            page: &mut sections.flags,
+            ungrouped: &mut sections.ungrouped_flags,
+            grouped: &mut sections.grouped_flags,
+        },
         "Flags",
         own.iter().copied(),
         |f| flag_help_heading(meta, f),
+        |_| None,
         |out, f| short_entry(out, f, column_usage(f)),
     );
     // After the command's own, and under a heading that says where they came from: `--config`
     // belongs to the program, not to this command, and a reader should be able to see that.
     // The text is precomputed, since a spelling a descendant claimed is left out of it.
     split_groups_section(
-        &mut sections.flags,
-        &mut sections.ungrouped_flags,
-        &mut sections.grouped_flags,
+        SectionSink {
+            page: &mut sections.flags,
+            ungrouped: &mut sections.ungrouped_flags,
+            grouped: &mut sections.grouped_flags,
+        },
         "Global flags",
         inherited.iter(),
+        |_| None,
         |_| None,
         |out, (f, usage)| short_entry(out, f, usage.clone()),
     );
@@ -1573,15 +1583,42 @@ fn flatten_site_heading<'a>(
     None
 }
 
+/// The prose introducing a section, from this command's own declarations or from a
+/// flattened type that declared the text where it declared the group.
+fn heading_help<'a>(meta: &'a CommandMeta<'a>, title: &str) -> Option<&'a str> {
+    if let Some(found) = meta
+        .headings
+        .iter()
+        .find(|heading| heading.title == title)
+        .map(|heading| heading.help)
+    {
+        return Some(found);
+    }
+    // The host's own declaration wins; only then does a flattened type get to speak for
+    // the section it contributed.
+    meta.flatten_groups
+        .iter()
+        .find_map(|group| heading_help(group.meta, title))
+}
+
+/// Where a rendered section goes: the page, plus the two partitions a template can name.
+///
+/// One value rather than three parameters, because the three always travel together — a
+/// section written to the page but not to its partition is a bug, not a configuration.
+struct SectionSink<'s> {
+    page: &'s mut String,
+    ungrouped: &'s mut String,
+    grouped: &'s mut String,
+}
+
 /// One section per heading, unheaded first, while also keeping the named and default groups
 /// available to a template.
 fn split_groups_section<'m, T: 'm>(
-    out: &mut String,
-    ungrouped: &mut String,
-    grouped: &mut String,
+    sink: SectionSink<'_>,
     default_title: &str,
     items: impl Iterator<Item = &'m T> + Clone,
     heading_of: impl Fn(&T) -> Option<&str>,
+    prose_of: impl Fn(&str) -> Option<&'m str>,
     mut write_item: impl FnMut(&mut String, &T),
 ) {
     // Headings in first-seen order, with the unheaded group before them. Collected rather
@@ -1600,14 +1637,22 @@ fn split_groups_section<'m, T: 'm>(
 
     for heading in headings {
         let mut section = String::new();
-        let _ = writeln!(section, "\n{}:", heading.unwrap_or(default_title));
+        let title = heading.unwrap_or(default_title);
+        let _ = writeln!(section, "\n{title}:");
+        // Between the heading and its entries, where a reader looking at the section is
+        // already looking. Written verbatim like an admonition rather than rewrapped, so
+        // an author's own line breaks survive and the reference renderer can match it.
+        if let Some(prose) = prose_of(title) {
+            write_indented(&mut section, prose, 2);
+            section.push('\n');
+        }
         for item in items.clone().filter(|i| heading_of(i) == heading) {
             write_item(&mut section, item);
         }
-        out.push_str(&section);
+        sink.page.push_str(&section);
         match heading {
-            Some(_) => grouped.push_str(&section),
-            None => ungrouped.push_str(&section),
+            Some(_) => sink.grouped.push_str(&section),
+            None => sink.ungrouped.push_str(&section),
         }
     }
 }
@@ -1908,12 +1953,15 @@ fn long_sections(
         .max()
         .unwrap_or(0);
     split_groups_section(
-        &mut sections.args,
-        &mut sections.ungrouped_args,
-        &mut sections.grouped_args,
+        SectionSink {
+            page: &mut sections.args,
+            ungrouped: &mut sections.ungrouped_args,
+            grouped: &mut sections.grouped_args,
+        },
         "Arguments",
         args.iter().copied(),
         |a| a.help_heading,
+        |title| heading_help(meta, title),
         |out, a| {
             let text = a.long_help.or(a.help);
             entry(
@@ -1949,12 +1997,15 @@ fn long_sections(
         .max()
         .unwrap_or(0);
     split_groups_section(
-        &mut sections.flags,
-        &mut sections.ungrouped_flags,
-        &mut sections.grouped_flags,
+        SectionSink {
+            page: &mut sections.flags,
+            ungrouped: &mut sections.ungrouped_flags,
+            grouped: &mut sections.grouped_flags,
+        },
         "Flags",
         own.iter().copied(),
         |f| flag_help_heading(meta, f),
+        |title| heading_help(meta, title),
         |out, f| {
             let text = f.long_help.or(f.help);
             entry(
@@ -1986,11 +2037,14 @@ fn long_sections(
     // Not grouped by `help_heading` — an ancestor's headings describe that command's page, and
     // borrowing them here would put a section title on flags that are only visiting.
     split_groups_section(
-        &mut sections.flags,
-        &mut sections.ungrouped_flags,
-        &mut sections.grouped_flags,
+        SectionSink {
+            page: &mut sections.flags,
+            ungrouped: &mut sections.ungrouped_flags,
+            grouped: &mut sections.grouped_flags,
+        },
         "Global flags",
         inherited.iter(),
+        |_| None,
         |_| None,
         |out, (f, usage)| {
             let text = f.long_help.or(f.help);

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -2339,6 +2339,12 @@ fn long_commands_section(out: &mut String, path: &[&str], meta: &CommandMeta<'_>
     for heading in headings {
         let title = heading.unwrap_or(default_title);
         let _ = writeln!(out, "\n{title}:");
+        // A `help_heading` on a subcommand builds a section like a flag's does, so it takes
+        // prose on the same terms: the long page only, and only once declared.
+        if let Some(prose) = heading.and_then(|title| heading_help(meta, title)) {
+            write_indented(out, prose, 2);
+            out.push('\n');
+        }
         for (usage, sub) in lines
             .iter()
             .filter(|(_, sub)| command_help_section(sub, default_title) == heading)
@@ -2829,7 +2835,10 @@ fn topic_id(title: &str) -> String {
     }
 }
 
-fn topic_blocks(sections: &Sections) -> Vec<(String, String)> {
+fn topic_blocks<'m>(
+    sections: &Sections,
+    prose_of: impl Fn(&str) -> Option<&'m str>,
+) -> Vec<(String, String)> {
     let mut topics: Vec<(String, String)> = Vec::new();
     for section in [&sections.commands, &sections.args, &sections.flags] {
         let mut title: Option<&str> = None;
@@ -2850,6 +2859,17 @@ fn topic_blocks(sections: &Sections) -> Vec<(String, String)> {
                     return;
                 }
                 if let Some((_, existing)) = topics.iter_mut().find(|(known, _)| known == title) {
+                    // One heading can build a block in more than one section — args and flags
+                    // both naming it — and each block introduces itself with the prose. Merged
+                    // into the single topic that heading addresses, it must say it once.
+                    let mut body = body;
+                    if let Some(prose) = prose_of(title) {
+                        let mut introduction = String::new();
+                        write_indented(&mut introduction, prose, 2);
+                        if let Some(rest) = body.strip_prefix(introduction.trim_end_matches('\n')) {
+                            body = rest.trim_start_matches('\n');
+                        }
+                    }
                     if !existing.is_empty() {
                         existing.push_str("\n\n");
                     }
@@ -2892,7 +2912,7 @@ fn topics_with_blocks(
     };
     let mut used = Vec::<String>::new();
     Some(
-        topic_blocks(&sections)
+        topic_blocks(&sections, |title| heading_help(chain.last()?, title))
             .into_iter()
             .map(|(title, block)| {
                 let base = topic_id(&title);

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -1642,7 +1642,12 @@ fn split_groups_section<'m, T: 'm>(
         // Between the heading and its entries, where a reader looking at the section is
         // already looking. Written verbatim like an admonition rather than rewrapped, so
         // an author's own line breaks survive and the reference renderer can match it.
-        if let Some(prose) = prose_of(title) {
+        //
+        // Only a declared heading takes prose. The default title names the group that
+        // exists because entries did not ask for a section, and it is not one title: the
+        // same unheaded flags render under `Flags` here and under `Global Flags` in a
+        // Markdown page, so keying prose to it would mean different things per renderer.
+        if let Some(prose) = heading.and_then(&prose_of) {
             write_indented(&mut section, prose, 2);
             section.push('\n');
         }

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -887,6 +887,8 @@ pub struct CommandMeta<'a> {
     pub after_help: Option<&'a str>,
     pub after_long_help: Option<&'a str>,
     pub examples: &'a [Example<'a>],
+    /// Prose for this command's help sections, by heading title.
+    pub headings: &'a [HeadingMeta<'a>],
     /// What this command writes, and how a consumer should read it.
     pub outputs: &'a [OutputMeta<'a>],
     /// The flag whose value picks among [`Self::outputs`], e.g. `--format`.
@@ -944,6 +946,7 @@ impl CommandMeta<'_> {
         after_help: None,
         after_long_help: None,
         examples: &[],
+        headings: &[],
         outputs: &[],
         select: None,
         exit_codes: &[],
@@ -1328,6 +1331,17 @@ pub struct Example<'a> {
     pub code: &'a str,
     pub header: Option<&'a str>,
     pub help: Option<&'a str>,
+}
+
+/// Prose introducing one help section.
+///
+/// Keyed by the heading's title rather than attached to a flag, because a section is
+/// assembled from whatever names it — a field's `help_heading`, a flatten site's
+/// `next_help_heading` — and the text describes the section, not any one entry in it.
+#[derive(Debug, Clone, Copy)]
+pub struct HeadingMeta<'a> {
+    pub title: &'a str,
+    pub help: &'a str,
 }
 
 /// The wire format of what a command writes to stdout.
@@ -1958,6 +1972,7 @@ fn write_body<'a>(
         write_group(out, group, depth)?;
     }
     if depth == 0 {
+        write_headings(out, meta, depth)?;
         for example in meta.examples {
             write_example(out, example, depth)?;
         }
@@ -2184,6 +2199,7 @@ fn write_command<'a>(
         indent(out, inner)?;
         writeln!(out, "mount run={}", quoted(mount))?;
     }
+    write_headings(out, meta, inner)?;
     for example in meta.examples {
         write_example(out, example, inner)?;
     }
@@ -2303,6 +2319,49 @@ fn write_exit_codes(out: &mut String, meta: &CommandMeta<'_>, depth: usize) -> c
         write_exit_codes(out, group.meta, depth)?;
     }
     Ok(())
+}
+
+/// Section prose for one command: its own, then whatever its flattened types declared for
+/// sections they contributed, first title winning so the emitted spec says what help renders.
+fn write_headings(out: &mut String, meta: &CommandMeta<'_>, depth: usize) -> core::fmt::Result {
+    let mut written: Vec<&str> = Vec::new();
+    collect_headings(&mut written, meta);
+    let mut seen: Vec<&str> = Vec::new();
+    for title in written {
+        if seen.contains(&title) {
+            continue;
+        }
+        seen.push(title);
+        let Some(help) = heading_help_of(meta, title) else {
+            continue;
+        };
+        indent(out, depth)?;
+        writeln!(out, "heading {} help={}", quoted(title), quoted(help))?;
+    }
+    Ok(())
+}
+
+fn collect_headings<'a>(titles: &mut Vec<&'a str>, meta: &CommandMeta<'a>) {
+    for heading in meta.headings {
+        titles.push(heading.title);
+    }
+    for group in meta.flatten_groups {
+        collect_headings(titles, group.meta);
+    }
+}
+
+fn heading_help_of<'a>(meta: &CommandMeta<'a>, title: &str) -> Option<&'a str> {
+    if let Some(help) = meta
+        .headings
+        .iter()
+        .find(|heading| heading.title == title)
+        .map(|heading| heading.help)
+    {
+        return Some(help);
+    }
+    meta.flatten_groups
+        .iter()
+        .find_map(|group| heading_help_of(group.meta, title))
 }
 
 fn write_example(out: &mut String, example: &Example<'_>, depth: usize) -> core::fmt::Result {

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -1972,10 +1972,10 @@ fn write_body<'a>(
         write_group(out, group, depth)?;
     }
     if depth == 0 {
-        write_headings(out, meta, depth)?;
         for example in meta.examples {
             write_example(out, example, depth)?;
         }
+        write_headings(out, meta, depth)?;
         write_outputs(out, meta, depth)?;
     }
     #[cfg(feature = "complete")]
@@ -2199,10 +2199,6 @@ fn write_command<'a>(
         indent(out, inner)?;
         writeln!(out, "mount run={}", quoted(mount))?;
     }
-    write_headings(out, meta, inner)?;
-    for example in meta.examples {
-        write_example(out, example, inner)?;
-    }
     write_body(
         out,
         meta,
@@ -2214,6 +2210,10 @@ fn write_command<'a>(
     )?;
     // After the body, because usage-lib's writer puts these after the flags, args and
     // subcommands, and `canonical_kdl` compares the two documents byte for byte.
+    for example in meta.examples {
+        write_example(out, example, inner)?;
+    }
+    write_headings(out, meta, inner)?;
     write_outputs(out, meta, inner)?;
 
     indent(out, depth)?;

--- a/conformance/src/tables.rs
+++ b/conformance/src/tables.rs
@@ -23,15 +23,15 @@
 //! `Spec::usage` arrived this way — the build broke, carrying it took one line, and doing so
 //! turned up a rule the two implementations disagree about that nothing had recorded.
 
-use usage::spec::cmd::SpecExample;
+use usage::spec::cmd::{SpecExample, SpecHeading};
 use usage::{
     Framing, Spec, SpecArg, SpecChoices, SpecCommand, SpecComplete, SpecExitCode, SpecFlag,
     SpecGroup, SpecOutput,
 };
 use usage_argv::spec::{
     AdmonitionKind, AdmonitionMeta, ArgMeta, ChoiceAliasMeta, ChoiceMeta, CommandMeta, DefaultIf,
-    Effect, Example, ExitCodeMeta, FlagMeta, Framing as ArgvFraming, GroupMeta, OutputMeta,
-    RequiredIfEq, RequiresIf,
+    Effect, Example, ExitCodeMeta, FlagMeta, Framing as ArgvFraming, GroupMeta, HeadingMeta,
+    OutputMeta, RequiredIfEq, RequiresIf,
 };
 use usage_argv::{Arg, Command, DoubleDash, Flag, UnknownFlags as ArgvUnknownFlags};
 
@@ -175,6 +175,7 @@ pub fn build(
         after_help: opt(&cmd.after_help),
         after_long_help: opt(&cmd.after_help_long),
         examples: examples(&cmd.examples),
+        headings: headings(&cmd.headings),
         outputs: outputs(&cmd.outputs),
         select: opt(&cmd.select),
         exit_codes: exit_codes(&cmd.exit_codes),
@@ -806,6 +807,18 @@ fn exit_codes(list: &[SpecExitCode]) -> &'static [ExitCodeMeta<'static>] {
             .map(|e| ExitCodeMeta {
                 code: e.code,
                 help: leak(&e.help),
+            })
+            .collect::<Vec<_>>()
+            .into_boxed_slice(),
+    )
+}
+
+fn headings(list: &[SpecHeading]) -> &'static [HeadingMeta<'static>] {
+    Box::leak(
+        list.iter()
+            .map(|heading| HeadingMeta {
+                title: leak(&heading.title),
+                help: leak(&heading.help),
             })
             .collect::<Vec<_>>()
             .into_boxed_slice(),

--- a/conformance/tests/canonical_kdl.rs
+++ b/conformance/tests/canonical_kdl.rs
@@ -8,7 +8,9 @@ use usage_derive::{Args, Cli, Subcommands};
     name = "canonical",
     bin = "canonical",
     version = "1.2.3",
-    unknown_flags = "error"
+    unknown_flags = "error",
+    example("canonical run build", header = "Run a task"),
+    heading("Output Options", help = "Formats are stable across releases.")
 )]
 struct Ex {
     /// Number of jobs to run.
@@ -16,7 +18,7 @@ struct Ex {
     jobs: usize,
 
     /// Select the output format.
-    #[usage(long, choices("human", "json"))]
+    #[usage(long, choices("human", "json"), help_heading = "Output Options")]
     format: Option<String>,
 
     #[usage(subcommand)]
@@ -30,9 +32,16 @@ enum Commands {
 }
 
 #[derive(Args)]
+#[usage(
+    example("canonical run build", header = "Build"),
+    heading(
+        "Task Options",
+        help = "A task name is resolved against the config file."
+    )
+)]
 struct Run {
     /// Configuration file.
-    #[usage(long)]
+    #[usage(long, help_heading = "Task Options")]
     config: Option<String>,
 
     /// Task name.

--- a/conformance/tests/heading_help.rs
+++ b/conformance/tests/heading_help.rs
@@ -138,6 +138,39 @@ fn section_prose_reaches_generated_markdown() {
     );
 }
 
+/// Prose named for a default section title, which is not a declared heading.
+#[derive(Cli)]
+#[usage(
+    bin = "dflt",
+    heading("Flags", help = "Should not appear on any page.")
+)]
+#[allow(dead_code)]
+struct DefaultTitled {
+    /// Do it anyway.
+    #[usage(long)]
+    force: bool,
+}
+
+#[test]
+fn only_a_declared_heading_takes_prose() {
+    let long = help::render(DefaultTitled::spec(), DefaultTitled::spec().root.cmd, true)
+        .expect("long help");
+    assert!(long.contains("Flags:"), "{long}");
+    assert!(!long.contains("Should not appear"), "{long}");
+
+    // The unheaded group is the one that exists because nothing asked for a section, and
+    // it renders under a different default title per page, so keying prose to it would
+    // mean different things in each renderer. Both must agree that it takes none.
+    let spec: usage::Spec = DefaultTitled::to_kdl().parse().expect("generated spec");
+    let reference = usage::docs::cli::render_help(&spec, &spec.cmd, true);
+    assert_eq!(reference, long);
+
+    let markdown = MarkdownRenderer::new(spec.clone())
+        .render_cmd(&spec.cmd)
+        .expect("markdown page");
+    assert!(!markdown.contains("Should not appear"), "{markdown}");
+}
+
 #[test]
 fn a_flattened_type_speaks_for_the_section_it_contributes() {
     let long =

--- a/conformance/tests/heading_help.rs
+++ b/conformance/tests/heading_help.rs
@@ -1,6 +1,6 @@
 use usage::docs::markdown::{MarkdownRenderer, MarkdownTheme};
 use usage_argv::help;
-use usage_derive::{Args, Cli};
+use usage_derive::{Args, Cli, Subcommands};
 
 const FILTERS: &str = "Filters accumulate from left to right on the command line.\n\
 For example: `-D correctness -A no-debugger`.";
@@ -182,4 +182,84 @@ fn a_flattened_type_speaks_for_the_section_it_contributes() {
 
     let kdl = FlattenedCli::to_kdl();
     assert!(kdl.contains("heading Output"), "{kdl}");
+}
+
+/// One heading naming both an argument and a flag, which builds a block in each section.
+#[derive(Cli)]
+#[usage(
+    bin = "shared",
+    heading("Selection", help = "Patterns are matched against the path.")
+)]
+#[allow(dead_code)]
+struct Shared {
+    /// Pattern to match.
+    #[usage(long, help_heading = "Selection")]
+    pattern: Option<String>,
+
+    /// Path to search.
+    #[usage(help_heading = "Selection")]
+    target: Option<String>,
+}
+
+#[test]
+fn a_shared_heading_introduces_its_topic_once() {
+    // The page renders the heading once per section, each block introducing itself, and both
+    // renderers agree on that.
+    let long = help::render(Shared::spec(), Shared::spec().root.cmd, true).expect("long help");
+    assert_eq!(long.matches("Patterns are matched").count(), 2, "{long}");
+    let spec: usage::Spec = Shared::to_kdl().parse().expect("generated spec");
+    assert_eq!(usage::docs::cli::render_help(&spec, &spec.cmd, true), long);
+
+    // The topic is the one block that heading addresses, so it says it once.
+    let topic =
+        usage_argv::help::render_topic(Shared::spec(), Shared::command(), "selection", true)
+            .expect("the heading is a topic");
+    assert_eq!(topic.matches("Patterns are matched").count(), 1, "{topic}");
+    assert!(
+        topic.contains("--pattern") && topic.contains("[TARGET]"),
+        "{topic}"
+    );
+}
+
+/// Prose for a section built by a `help_heading` on a subcommand.
+#[derive(Cli)]
+#[usage(
+    bin = "subs",
+    heading("Build Commands", help = "These write to the target directory.")
+)]
+#[allow(dead_code)]
+struct Subs {
+    #[usage(subcommand)]
+    command: Cmds,
+}
+
+#[derive(Subcommands)]
+#[allow(dead_code)]
+enum Cmds {
+    /// Compile the project.
+    #[usage(help_heading = "Build Commands")]
+    Compile(NoArgs),
+}
+
+#[derive(Args)]
+#[allow(dead_code)]
+struct NoArgs {}
+
+#[test]
+fn a_subcommand_heading_takes_prose_like_any_other() {
+    let long = help::render(Subs::spec(), Subs::spec().root.cmd, true).expect("long help");
+    assert!(
+        long.contains("Build Commands:\n  These write to the target directory.\n"),
+        "{long}"
+    );
+    let build = long.find("Build Commands:").expect("the heading");
+    let compile = long.find("compile").expect("the command it introduces");
+    assert!(build < compile, "{long}");
+
+    let spec: usage::Spec = Subs::to_kdl().parse().expect("generated spec");
+    assert_eq!(usage::docs::cli::render_help(&spec, &spec.cmd, true), long);
+
+    // A summary stays a summary.
+    let short = help::render(Subs::spec(), Subs::spec().root.cmd, false).expect("short help");
+    assert!(!short.contains("These write to"), "{short}");
 }

--- a/conformance/tests/heading_help.rs
+++ b/conformance/tests/heading_help.rs
@@ -1,0 +1,152 @@
+use usage::docs::markdown::{MarkdownRenderer, MarkdownTheme};
+use usage_argv::help;
+use usage_derive::{Args, Cli};
+
+const FILTERS: &str = "Filters accumulate from left to right on the command line.\n\
+For example: `-D correctness -A no-debugger`.";
+
+#[derive(Args)]
+#[allow(dead_code)]
+struct Filters {
+    /// Allow the rule or category.
+    #[usage(short = 'A', long)]
+    allow: Vec<String>,
+
+    /// Deny the rule or category.
+    #[usage(short = 'D', long)]
+    deny: Vec<String>,
+}
+
+#[derive(Cli)]
+#[usage(
+    bin = "ex",
+    heading("Filters", help = FILTERS),
+    heading("Ignore Files", help = "Paths are matched the way `.gitignore` matches them.")
+)]
+#[allow(dead_code)]
+struct Ex {
+    #[usage(flatten, next_help_heading = "Filters")]
+    filters: Filters,
+
+    /// Ignore file to read.
+    #[usage(long, help_heading = "Ignore Files")]
+    ignore_path: Option<String>,
+
+    /// File to inspect.
+    file: Option<String>,
+}
+
+/// Prose declared on the flattened type itself, for the section it contributes.
+#[derive(Args)]
+#[usage(heading("Output", help = "Formats are stable; parse the JSON one."))]
+#[allow(dead_code)]
+struct Output {
+    /// Output format.
+    #[usage(long, help_heading = "Output")]
+    format: Option<String>,
+}
+
+#[derive(Cli)]
+#[usage(bin = "flat")]
+#[allow(dead_code)]
+struct FlattenedCli {
+    #[usage(flatten)]
+    output: Output,
+}
+
+#[test]
+fn section_prose_introduces_its_heading_on_the_long_page() {
+    let long = help::render(Ex::spec(), Ex::spec().root.cmd, true).expect("long help");
+    assert!(
+        long.contains(
+            "Filters:\n  Filters accumulate from left to right on the command line.\n  For example: `-D correctness -A no-debugger`.\n"
+        ),
+        "{long}"
+    );
+    assert!(
+        long.contains("Ignore Files:\n  Paths are matched the way `.gitignore` matches them.\n"),
+        "{long}"
+    );
+    // The prose introduces the section rather than replacing it.
+    let filters = long.find("Filters:").expect("filters heading");
+    let allow = long.find("--allow").expect("the section's own entries");
+    assert!(filters < allow, "{long}");
+
+    // A short page stays a summary, as it does for admonitions.
+    let short = help::render(Ex::spec(), Ex::spec().root.cmd, false).expect("short help");
+    assert!(short.contains("Filters:"), "{short}");
+    assert!(!short.contains("accumulate from left to right"), "{short}");
+}
+
+#[test]
+fn a_topic_opens_with_its_sections_prose() {
+    let topic = usage_argv::help::render_topic(Ex::spec(), Ex::command(), "filters", true)
+        .expect("the heading is a topic");
+    assert!(
+        topic.starts_with(
+            "Filters:\n  Filters accumulate from left to right on the command line.\n"
+        ),
+        "{topic}"
+    );
+}
+
+#[test]
+fn section_prose_survives_the_round_trip_through_the_spec() {
+    let kdl = Ex::to_kdl();
+    assert!(kdl.contains("heading \"Ignore Files\""), "{kdl}");
+    assert!(kdl.contains("heading Filters"), "{kdl}");
+
+    let spec: usage::Spec = kdl.parse().expect("generated spec");
+    assert_eq!(spec.cmd.headings.len(), 2);
+    let filters = spec
+        .cmd
+        .headings
+        .iter()
+        .find(|heading| heading.title == "Filters")
+        .expect("filters prose");
+    assert_eq!(filters.help, FILTERS);
+
+    // The reference renderer is held byte-identical to the compiled one.
+    let reference = usage::docs::cli::render_help(&spec, &spec.cmd, true);
+    let compiled = help::render(Ex::spec(), Ex::spec().root.cmd, true).expect("long help");
+    assert_eq!(reference, compiled);
+}
+
+#[test]
+fn section_prose_reaches_generated_markdown() {
+    let spec: usage::Spec = Ex::to_kdl().parse().expect("generated spec");
+
+    let compact = MarkdownRenderer::new(spec.clone())
+        .render_cmd(&spec.cmd)
+        .expect("markdown page");
+    assert!(
+        compact.contains("Filters accumulate from left to right on the command line."),
+        "{compact}"
+    );
+    assert!(
+        compact.contains("Paths are matched the way `.gitignore` matches them."),
+        "{compact}"
+    );
+
+    let detailed = MarkdownRenderer::new(spec.clone())
+        .with_theme(MarkdownTheme::Detailed)
+        .render_cmd(&spec.cmd)
+        .expect("detailed markdown page");
+    assert!(
+        detailed.contains("Filters accumulate from left to right on the command line."),
+        "{detailed}"
+    );
+}
+
+#[test]
+fn a_flattened_type_speaks_for_the_section_it_contributes() {
+    let long =
+        help::render(FlattenedCli::spec(), FlattenedCli::spec().root.cmd, true).expect("long help");
+    assert!(
+        long.contains("Output:\n  Formats are stable; parse the JSON one.\n"),
+        "{long}"
+    );
+
+    let kdl = FlattenedCli::to_kdl();
+    assert!(kdl.contains("heading Output"), "{kdl}");
+}

--- a/conformance/tests/snapshots/spec_roundtrip__the_emitted_spec_is_stable.snap
+++ b/conformance/tests/snapshots/spec_roundtrip__the_emitted_spec_is_stable.snap
@@ -77,13 +77,13 @@ Installs a tool.
 
 Takes a while.
 """#
-    example "ex install node@20" help="install a specific version"
     flag "-f --force" help="overwrite an existing install"
     flag --format {
         arg <format>
     }
     flag "-h --help" help="Print help" action=help builtin=#true
     arg <tool> help="the tool to install"
+    example "ex install node@20" help="install a specific version"
     output human help="a progress log" default=#true
     output json media_type="application/json" framing=json {
         schema #"""

--- a/corpus/render/03-sections.json
+++ b/corpus/render/03-sections.json
@@ -339,6 +339,40 @@
       "reference": {
         "diverges": "usage-lib's help renderer ignores a declared `usage` and writes the generated line; its manpage renderer honours it (`lib/src/docs/manpage/renderer.rs`). usage-argv honours it on the root page, which is what #965 added it for. The fleet gate cannot see this even though six of its seven CLIs declare one, because `xtask gen-shadow` does not carry the node into the shadow it generates — so each shadow's `Spec::usage` is `None` and both sides render the generated line. Recorded rather than fixed here because it is the reference that needs changing, not the expectation."
       }
+    },
+    {
+      "id": "heading-prose",
+      "doc": "Prose declared for a heading introduces its section on the long page, between the heading and its entries, and is absent from the short page the way an admonition is.",
+      "spec": "name \"ex\"\nbin \"ex\"\nabout \"An example\"\nheading \"Ignore Files\" help=\"Patterns are matched the way `.gitignore` matches them.\"\nflag \"--ignore-path <PATH>\" help=\"Ignore file to read\" help_heading=\"Ignore Files\"\nflag \"--force\" help=\"Do it anyway\"\n",
+      "expect": {
+        "usage": "ex [--ignore-path <PATH>] [--force]",
+        "long_help": [
+          "An example",
+          "",
+          "Usage: ex [--ignore-path <PATH>] [--force]",
+          "",
+          "Flags:",
+          "      --force               Do it anyway",
+          "  -h, --help                Print help",
+          "",
+          "Ignore Files:",
+          "  Patterns are matched the way `.gitignore` matches them.",
+          "",
+          "      --ignore-path <PATH>  Ignore file to read"
+        ],
+        "short_help": [
+          "An example",
+          "",
+          "Usage: ex [--ignore-path <PATH>] [--force]",
+          "",
+          "Flags:",
+          "      --force               Do it anyway",
+          "  -h, --help                Print help",
+          "",
+          "Ignore Files:",
+          "      --ignore-path <PATH>  Ignore file to read"
+        ]
+      }
     }
   ]
 }

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -18,8 +18,8 @@ use quote::{format_ident, quote};
 use crate::crate_name::{crate_name, FoundCrate};
 use crate::model::{
     rendered_path, to_kebab, type_name, AdmonitionKind, ArgGroup, ArgGroupMember, Cli,
-    ConditionalDefault, Dispatch, DoubleDash, ExampleDecl, Field, Kind, SchemaSource, Shape,
-    Subcommands, ValueEnum, Variant, ViewDecl,
+    ConditionalDefault, Dispatch, DoubleDash, ExampleDecl, Field, HeadingDecl, Kind, SchemaSource,
+    Shape, Subcommands, ValueEnum, Variant, ViewDecl,
 };
 
 fn admonitions(field: &Field) -> TokenStream {
@@ -235,6 +235,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
     let after_help = option_expr(cli.after_help.as_ref());
     let after_long_help = option_expr(cli.after_long_help.as_ref());
     let examples = examples_table(&cli.examples);
+    let headings = headings_table(&cli.headings);
     let root_key = key_ident("COMMAND", None);
     let keys = key_consts(&cli.fingerprint, flags.len(), args.len());
     let flag_tables = flags.iter().enumerate().map(|(i, f)| flag_table(i, f));
@@ -1084,6 +1085,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
                 after_help: #after_help,
                 after_long_help: #after_long_help,
                 examples: #examples,
+                headings: #headings,
                 flags: #flag_meta_table_ref,
                 args: #arg_meta_table_ref,
                 groups: #group_meta_table_ref,
@@ -4009,6 +4011,24 @@ fn examples_table(examples: &[ExampleDecl]) -> TokenStream {
     quote!(&[#(#entries),*])
 }
 
+/// The `headings` slice for a command's metadata.
+///
+/// Cold like the examples beside it: a section's prose is read when a page is rendered or a
+/// spec written, never by a parse.
+fn headings_table(headings: &[HeadingDecl]) -> TokenStream {
+    let entries = headings.iter().map(|heading| {
+        let title = &heading.title;
+        let help = &heading.help;
+        quote! {
+            usage_argv::spec::HeadingMeta {
+                title: #title,
+                help: #help,
+            }
+        }
+    });
+    quote!(&[#(#entries),*])
+}
+
 /// What a command's `output`, `select` and `exit_code` declarations become in its
 /// `CommandMeta`, plus the schema functions those refer to.
 ///
@@ -6173,6 +6193,7 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
     let after_help = option_expr(cli.after_help.as_ref());
     let after_long_help = option_expr(cli.after_long_help.as_ref());
     let examples = examples_table(&cli.examples);
+    let headings = headings_table(&cli.headings);
 
     let flags: Vec<&Field> = cli
         .fields
@@ -6459,6 +6480,7 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
                 after_help: #after_help,
                 after_long_help: #after_long_help,
                 examples: #examples,
+                headings: #headings,
                 flags: #flag_meta_table_ref,
                 args: #arg_meta_table_ref,
                 groups: #group_meta_table_ref,

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -207,6 +207,11 @@ pub struct Cli {
     /// no way to declare one, so every example in the fleet lives as prose inside
     /// `after_long_help` where nothing can read it — or check it.
     pub examples: Vec<ExampleDecl>,
+    /// Prose introducing a help section, by the title of the heading it belongs under.
+    ///
+    /// Declared here rather than on a field because a section is assembled from whatever
+    /// names it, and the text describes the section rather than any one entry in it.
+    pub headings: Vec<HeadingDecl>,
     /// The word that starts another invocation of the same command: mise's `:::`.
     pub restart_token: Option<String>,
     /// A command to run for subcommands discovered at completion time.
@@ -841,6 +846,7 @@ impl Cli {
             after_help: None,
             after_long_help: None,
             examples: Vec::new(),
+            headings: Vec::new(),
             restart_token: None,
             mount: None,
             groups: Vec::new(),
@@ -1086,6 +1092,19 @@ impl Cli {
                     "mount" => cli.mount = Some(string_value(&meta)?),
                     "group" => cli.groups.push(group_decl(&meta)?),
                     "example" => cli.examples.push(example_decl(&meta)?),
+                    "heading" => {
+                        let heading = heading_decl(&meta)?;
+                        if cli.headings.iter().any(|h| h.title == heading.title) {
+                            return Err(syn::Error::new_spanned(
+                                &meta,
+                                format!(
+                                    "prose for the `{}` heading is already declared",
+                                    heading.title
+                                ),
+                            ));
+                        }
+                        cli.headings.push(heading);
+                    }
                     "output" => {
                         let output = output_decl(&meta)?;
                         if cli.outputs.iter().any(|o| o.name == output.name) {
@@ -1153,7 +1172,7 @@ impl Cli {
                                  `name`, `name_spec`, `bin`, `bin_spec`, `version`, `version_spec`, `long_version`, `long_version_spec`, `author`, `license`, `repository`, `source_code_link_template`, `usage`, `alias`, `alias_hidden`, `visible_alias`, `hide`, `surface`, `available_if`, `deprecated`, `deprecated_warn_at`, `deprecated_remove_at`, `verbatim_doc_comment`, `unknown_flags`, \
                                  `default_subcommand`, `multicall`, `no_binary_name`, `arg_required_else_help`, `disable_help_flag`, `disable_help_subcommand`, `disable_version_flag`, `dont_delimit_trailing_values`, `args_override_self`, `subcommand_negates_reqs`, `args_conflicts_with_subcommands`, `subcommand_precedence_over_arg`, `allow_missing_positional`, \
                                  `next_help_heading`, `subcommand_help_heading`, `next_line_help`, `flatten_help`, `help_template`, `term_width`, `max_term_width`, \
-                                 `subcommand_value_name`, `restart_token`, `mount`, `example`, `select`, `output`, `exit_code`, `run`, `run_with`, `run_async`, `run_async_with`, \
+                                 `subcommand_value_name`, `restart_token`, `mount`, `example`, `heading`, `select`, `output`, `exit_code`, `run`, `run_with`, `run_async`, `run_async_with`, \
                                  `group`, `view`, `validate_with`, and `try_into` here, and the description comes from the doc comment"
                             ),
                         ));
@@ -4407,6 +4426,59 @@ pub struct ExampleDecl {
     pub code: proc_macro2::TokenStream,
     pub header: Option<proc_macro2::TokenStream>,
     pub help: Option<proc_macro2::TokenStream>,
+}
+
+pub struct HeadingDecl {
+    /// A literal, because it has to match a `help_heading` spelling to find its section.
+    pub title: String,
+    pub help: proc_macro2::TokenStream,
+}
+
+fn heading_decl(meta: &Meta) -> syn::Result<HeadingDecl> {
+    let Meta::List(list) = meta else {
+        return Err(syn::Error::new_spanned(
+            meta,
+            "section prose is declared as \
+             `heading(\"Ignore Files\", help = \"…\")`, naming the heading it introduces",
+        ));
+    };
+    list.parse_args_with(|input: syn::parse::ParseStream| {
+        let title: syn::LitStr = input.parse()?;
+        let mut help = None;
+        while !input.is_empty() {
+            input.parse::<syn::Token![,]>()?;
+            if input.is_empty() {
+                break;
+            }
+            let property: syn::Ident = input.parse()?;
+            input.parse::<syn::Token![=]>()?;
+            let value: Expr = input.parse()?;
+            let value = quote::ToTokens::to_token_stream(&value);
+            match property.to_string().as_str() {
+                "help" => help = Some(value),
+                other => {
+                    return Err(syn::Error::new_spanned(
+                        property,
+                        format!(
+                            "unknown heading property `{other}`; a heading takes \
+                             `help` after the title it introduces"
+                        ),
+                    ));
+                }
+            }
+        }
+        let Some(help) = help else {
+            return Err(syn::Error::new_spanned(
+                &title,
+                "a heading needs the prose it introduces: \
+                 `heading(\"Ignore Files\", help = \"…\")`",
+            ));
+        };
+        Ok(HeadingDecl {
+            title: title.value(),
+            help,
+        })
+    })
 }
 
 fn example_decl(meta: &Meta) -> syn::Result<ExampleDecl> {

--- a/docs/cli/reference/commands.json
+++ b/docs/cli/reference/commands.json
@@ -60,7 +60,8 @@
         "name": "bash",
         "aliases": [],
         "hidden_aliases": [],
-        "examples": []
+        "examples": [],
+        "headings": []
       },
       "complete-word": {
         "full_cmd": ["complete-word"],
@@ -174,7 +175,8 @@
         "name": "complete-word",
         "aliases": ["cw"],
         "hidden_aliases": [],
-        "examples": []
+        "examples": [],
+        "headings": []
       },
       "diff": {
         "full_cmd": ["diff"],
@@ -274,6 +276,7 @@
         "aliases": [],
         "hidden_aliases": [],
         "examples": [],
+        "headings": [],
         "complete": {
           "old": {
             "name": "old",
@@ -349,7 +352,8 @@
         "name": "exec",
         "aliases": ["x"],
         "hidden_aliases": [],
-        "examples": []
+        "examples": [],
+        "headings": []
       },
       "explain": {
         "full_cmd": ["explain"],
@@ -494,6 +498,7 @@
         "aliases": [],
         "hidden_aliases": [],
         "examples": [],
+        "headings": [],
         "complete": {
           "argv": {
             "name": "argv",
@@ -560,7 +565,8 @@
         "name": "fish",
         "aliases": [],
         "hidden_aliases": [],
-        "examples": []
+        "examples": [],
+        "headings": []
       },
       "generate": {
         "full_cmd": ["generate"],
@@ -713,7 +719,8 @@
             "name": "completion",
             "aliases": ["c"],
             "hidden_aliases": ["complete", "completions"],
-            "examples": []
+            "examples": [],
+            "headings": []
           },
           "completion-init": {
             "full_cmd": ["generate", "completion-init"],
@@ -777,7 +784,8 @@
             "name": "completion-init",
             "aliases": ["ci"],
             "hidden_aliases": ["init", "completions-init"],
-            "examples": []
+            "examples": [],
+            "headings": []
           },
           "fig": {
             "full_cmd": ["generate", "fig"],
@@ -862,6 +870,7 @@
             "aliases": [],
             "hidden_aliases": [],
             "examples": [],
+            "headings": [],
             "complete": {
               "out_file": {
                 "name": "out_file",
@@ -970,6 +979,7 @@
             "aliases": [],
             "hidden_aliases": [],
             "examples": [],
+            "headings": [],
             "complete": {
               "out_file": {
                 "name": "out_file",
@@ -1058,7 +1068,8 @@
             "name": "json",
             "aliases": [],
             "hidden_aliases": [],
-            "examples": []
+            "examples": [],
+            "headings": []
           },
           "json-schema": {
             "full_cmd": ["generate", "json-schema"],
@@ -1177,6 +1188,7 @@
             "aliases": [],
             "hidden_aliases": [],
             "examples": [],
+            "headings": [],
             "complete": {
               "out_file": {
                 "name": "out_file",
@@ -1285,6 +1297,7 @@
             "aliases": ["man"],
             "hidden_aliases": [],
             "examples": [],
+            "headings": [],
             "complete": {
               "out_file": {
                 "name": "out_file",
@@ -1460,6 +1473,7 @@
             "aliases": ["md"],
             "hidden_aliases": [],
             "examples": [],
+            "headings": [],
             "complete": {
               "out_dir": {
                 "name": "out_dir",
@@ -1591,7 +1605,8 @@
             "name": "sdk",
             "aliases": [],
             "hidden_aliases": [],
-            "examples": []
+            "examples": [],
+            "headings": []
           }
         },
         "args": [],
@@ -1619,7 +1634,8 @@
         "name": "generate",
         "aliases": ["g"],
         "hidden_aliases": [],
-        "examples": []
+        "examples": [],
+        "headings": []
       },
       "lint": {
         "full_cmd": ["lint"],
@@ -1709,7 +1725,8 @@
         "name": "lint",
         "aliases": [],
         "hidden_aliases": [],
-        "examples": []
+        "examples": [],
+        "headings": []
       },
       "mcp": {
         "full_cmd": ["mcp"],
@@ -1776,7 +1793,8 @@
         "name": "mcp",
         "aliases": ["mcp-server"],
         "hidden_aliases": [],
-        "examples": []
+        "examples": [],
+        "headings": []
       },
       "powershell": {
         "full_cmd": ["powershell"],
@@ -1833,7 +1851,8 @@
         "name": "powershell",
         "aliases": [],
         "hidden_aliases": [],
-        "examples": []
+        "examples": [],
+        "headings": []
       },
       "sponsors": {
         "full_cmd": ["sponsors"],
@@ -1863,7 +1882,8 @@
         "name": "sponsors",
         "aliases": [],
         "hidden_aliases": [],
-        "examples": []
+        "examples": [],
+        "headings": []
       },
       "zsh": {
         "full_cmd": ["zsh"],
@@ -1920,7 +1940,8 @@
         "name": "zsh",
         "aliases": [],
         "hidden_aliases": [],
-        "examples": []
+        "examples": [],
+        "headings": []
       }
     },
     "args": [],
@@ -1985,7 +2006,8 @@
     "name": "usage",
     "aliases": [],
     "hidden_aliases": [],
-    "examples": []
+    "examples": [],
+    "headings": []
   },
   "config": {
     "props": {},

--- a/docs/rust/help.md
+++ b/docs/rust/help.md
@@ -120,8 +120,10 @@ full rule, including what a default does not count as, is in
   the section rather than any one entry in it. Declared on an `Args` type, it speaks for the
   section that type contributes; a heading the host also declares prose for keeps the host's.
   Like an admonition, it is absent from the short page, and it reaches the emitted spec, so
-  generated Markdown and manpages carry it too. This is bpaf's `group_help`; clap has no
-  equivalent.
+  generated Markdown and manpages carry it too. Only a declared heading takes prose: the
+  default `Flags` and `Arguments` sections hold the entries that never asked for one, and the
+  same entries appear under a different default title per renderer, so a title matching one of
+  those renders nowhere. This is bpaf's `group_help`; clap has no equivalent.
 - `display_order = n` on a field or subcommand controls its position within a help section
   without changing positional parsing order.
 - `next_line_help` on a command puts every argument, flag, and subcommand description beneath

--- a/docs/rust/help.md
+++ b/docs/rust/help.md
@@ -113,6 +113,15 @@ full rule, including what a default does not count as, is in
   `after_long_help`, a declared example reaches the emitted spec, so docs, manpages and
   `usage lint` can all read it — the last of those checks that it still parses.
 - `help_heading` on a field or subcommand variant groups it under a heading.
+- `heading("Ignore Files", help = "…")` on a command gives one of those headings a paragraph,
+  rendered on the long page between the heading and its entries. The prose is keyed by title
+  rather than attached to a field, because a section is assembled from everything that names
+  it — a field's `help_heading`, a flatten site's `next_help_heading` — and the text describes
+  the section rather than any one entry in it. Declared on an `Args` type, it speaks for the
+  section that type contributes; a heading the host also declares prose for keeps the host's.
+  Like an admonition, it is absent from the short page, and it reaches the emitted spec, so
+  generated Markdown and manpages carry it too. This is bpaf's `group_help`; clap has no
+  equivalent.
 - `display_order = n` on a field or subcommand controls its position within a help section
   without changing positional parsing order.
 - `next_line_help` on a command puts every argument, flag, and subcommand description beneath
@@ -249,7 +258,9 @@ if let Some(text) = usage::help::render_topic(
 Each visible `help_heading` becomes a topic. Ordinary Commands, Arguments, Flags, and Global flags
 sections are topics too. IDs are command-local lowercase slugs; `render_topic` also accepts the
 visible title case-insensitively. If an argument group and flag group share one heading, the topic
-combines both blocks in their normal help order. Hidden entries never create or enter a topic.
+combines both blocks in their normal help order. Hidden entries never create or enter a topic. A
+topic whose heading declares `heading(…, help = …)` opens with that prose, since the topic is the
+section as the long page renders it.
 
 ## Version
 

--- a/docs/rust/help.md
+++ b/docs/rust/help.md
@@ -114,7 +114,8 @@ full rule, including what a default does not count as, is in
   `usage lint` can all read it — the last of those checks that it still parses.
 - `help_heading` on a field or subcommand variant groups it under a heading.
 - `heading("Ignore Files", help = "…")` on a command gives one of those headings a paragraph,
-  rendered on the long page between the heading and its entries. The prose is keyed by title
+  rendered on the long page between the heading and its entries, whether the section was built
+  by flags, positionals, or subcommands. The prose is keyed by title
   rather than attached to a field, because a section is assembled from everything that names
   it — a field's `help_heading`, a flatten site's `next_help_heading` — and the text describes
   the section rather than any one entry in it. Declared on an `Args` type, it speaks for the

--- a/docs/spec/reference/cmd.md
+++ b/docs/spec/reference/cmd.md
@@ -62,8 +62,9 @@ cmd "lint" {
 
 A `heading` node gives prose to the section a `help_heading` creates. It is rendered on the
 long help page between the heading and its entries, and under the corresponding heading in
-generated Markdown and manpages; short help omits it. A title naming no section renders
-nowhere.
+generated Markdown and manpages; short help omits it. A title naming no declared section
+renders nowhere — including the default `Flags` and `Arguments` titles, which name the
+entries that asked for no section of their own.
 
 `term_width` fixes the width used to wrap help; zero disables wrapping.
 `max_term_width` caps a detected terminal width when `term_width` is unset;

--- a/docs/spec/reference/cmd.md
+++ b/docs/spec/reference/cmd.md
@@ -60,7 +60,8 @@ cmd "lint" {
 }
 ```
 
-A `heading` node gives prose to the section a `help_heading` creates. It is rendered on the
+A `heading` node gives prose to the section a `help_heading` creates, on a flag, a positional,
+or a subcommand. It is rendered on the
 long help page between the heading and its entries, and under the corresponding heading in
 generated Markdown and manpages; short help omits it. A title naming no declared section
 renders nowhere — including the default `Flags` and `Arguments` titles, which name the

--- a/docs/spec/reference/cmd.md
+++ b/docs/spec/reference/cmd.md
@@ -52,7 +52,18 @@ cmd "list" {
     ]
   """# header="JSON output"
 }
+
+cmd "lint" {
+  // Prose for one help section, named by the heading it introduces.
+  heading "Ignore Files" help="Patterns are matched the way `.gitignore` matches them."
+  flag "--ignore-path <PATH>" help="Ignore file to read" help_heading="Ignore Files"
+}
 ```
+
+A `heading` node gives prose to the section a `help_heading` creates. It is rendered on the
+long help page between the heading and its entries, and under the corresponding heading in
+generated Markdown and manpages; short help omits it. A title naming no section renders
+nowhere.
 
 `term_width` fixes the width used to wrap help; zero disables wrapping.
 `max_term_width` caps a detected terminal width when `term_width` is unset;

--- a/lib/src/docs/cli/mod.rs
+++ b/lib/src/docs/cli/mod.rs
@@ -50,6 +50,7 @@ pub fn render_help(spec: &Spec, cmd: &SpecCommand, long: bool) -> String {
                     0,
                     crate::docs::models::Group {
                         heading: None,
+                        help: None,
                         items: supplied,
                     },
                 ),

--- a/lib/src/docs/cli/templates/spec_template_long.tera
+++ b/lib/src/docs/cli/templates/spec_template_long.tera
@@ -39,6 +39,9 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
 {%- for group in cmd.subcommand_groups %}
 
 {{ group.heading | default(value=cmd.subcommand_help_heading | default(value="Commands")) }}:
+{%- if group.help %}
+  {{ group.help | indent(width=2) }}
+{% endif %}
 {%- for cmd in group.items %}
   {{ cmd.usage | trim }}
 {%- if cmd.deprecated or cmd.deprecated_warn_at or cmd.deprecated_remove_at %} [deprecated:{% if cmd.deprecated %} {{ cmd.deprecated }}{% endif %}{% if cmd.deprecated_warn_at %}{% if cmd.deprecated %};{% endif %} warns at {{ cmd.deprecated_warn_at }}{% endif %}{% if cmd.deprecated_remove_at %}{% if cmd.deprecated or cmd.deprecated_warn_at %};{% endif %} removed at {{ cmd.deprecated_remove_at }}{% endif %}]{%- endif %}

--- a/lib/src/docs/cli/templates/spec_template_long.tera
+++ b/lib/src/docs/cli/templates/spec_template_long.tera
@@ -59,6 +59,9 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
 {%- if group.heading and arg_has_ungrouped and loop.index0 == 1 %}{{ mark_grouped_args }}{% endif %}
 
 {{ group.heading | default(value="Arguments") }}:
+{%- if group.help %}
+  {{ group.help | indent(width=2) }}
+{% endif %}
 {%- for arg in group.items %}
 {%- if cmd.next_line_help %}
   {{ arg.usage | trim }}
@@ -107,6 +110,9 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
 {%- if group.heading and flag_has_ungrouped and loop.index0 == 1 %}{{ mark_grouped_flags }}{% endif %}
 
 {{ group.heading | default(value="Flags") }}:
+{%- if group.help %}
+  {{ group.help | indent(width=2) }}
+{% endif %}
 {%- for flag in group.items %}
 {%- if cmd.next_line_help %}
   {{ flag.display_usage }}

--- a/lib/src/docs/markdown/templates/cmd_template.md.tera
+++ b/lib/src/docs/markdown/templates/cmd_template.md.tera
@@ -42,6 +42,10 @@
 {%- if group_args %}
 
 {{ "#" | repeat(count=header_level) }}# {{ arg_group.heading | default(value="Arguments") }}
+{%- if arg_group.help %}
+
+{{ arg_group.help }}
+{%- endif %}
 
 {%- for arg in group_args %}
 
@@ -77,6 +81,10 @@
 {%- if group_flags %}
 
 {{ "#" | repeat(count=header_level) }}# {{ flag_group.heading | default(value="Flags") }}
+{%- if flag_group.help %}
+
+{{ flag_group.help }}
+{%- endif %}
 
 {%- for flag in group_flags %}
 

--- a/lib/src/docs/markdown/templates/compact_cmd_template.md.tera
+++ b/lib/src/docs/markdown/templates/compact_cmd_template.md.tera
@@ -31,6 +31,10 @@
 {%- if visible %}
 
 {{ "#" | repeat(count=header_level) }}# {{ arg_group.heading | default(value="Arguments") }}
+{%- if arg_group.help %}
+
+{{ arg_group.help }}
+{%- endif %}
 {% for arg in visible %}
 {%- include "arg_template.md.tera" -%}
 {%- if not loop.last %}{{ "\n" }}{% endif %}
@@ -60,6 +64,10 @@
 {%- if group_flags %}
 
 {{ "#" | repeat(count=header_level) }}# {{ flag_group.heading | default(value="Flags") }}
+{%- if flag_group.help %}
+
+{{ flag_group.help }}
+{%- endif %}
 {% for flag in group_flags %}
 {%- include "flag_template.md.tera" -%}
 {%- if not loop.last %}{{ "\n" }}{% endif %}

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -837,6 +837,7 @@ impl From<&crate::SpecCommand> for SpecCommand {
         let mut arg_groups = group_by_heading(&args, |a| a.help_heading.as_deref());
         attach_heading_help(&mut flag_groups, &headings);
         attach_heading_help(&mut arg_groups, &headings);
+        attach_heading_help(&mut subcommand_groups, &headings);
 
         Self {
             full_cmd: full_cmd.clone(),
@@ -1201,6 +1202,7 @@ impl SpecCommand {
         self.arg_groups = group_by_heading(&self.args, |a| a.help_heading.as_deref());
         attach_heading_help(&mut self.flag_groups, &self.headings);
         attach_heading_help(&mut self.arg_groups, &self.headings);
+        attach_heading_help(&mut self.subcommand_groups, &self.headings);
     }
 }
 

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "docs")]
 use crate::docs::markdown::MarkdownRenderer;
+use crate::spec::cmd::SpecHeading;
 use crate::spec::effect::SpecCommandEffect;
 use crate::{SpecAdmonition, SpecChoices};
 use indexmap::IndexMap;
@@ -46,6 +47,8 @@ pub struct SpecCommand {
     pub flag_groups: Vec<Group<SpecFlag>>,
     /// `args`, partitioned by `help_heading`.
     pub arg_groups: Vec<Group<SpecArg>>,
+    /// Prose for this command's help sections, by heading title.
+    pub headings: Vec<SpecHeading>,
     // pub mounts: Vec<SpecMount>,
     pub deprecated: Option<String>,
     pub deprecated_warn_at: Option<String>,
@@ -182,6 +185,8 @@ pub struct SpecFlag {
 #[derive(Debug, Default, Serialize, Clone)]
 pub struct Group<T> {
     pub heading: Option<String>,
+    /// Prose introducing this section, when the command declared some for the heading.
+    pub help: Option<String>,
     pub items: Vec<T>,
 }
 
@@ -415,12 +420,29 @@ fn group_by_heading<T: Clone>(
             Some(group) => group.items.push(item.clone()),
             None => groups.push(Group {
                 heading,
+                help: None,
                 items: vec![item.clone()],
             }),
         }
     }
     groups.sort_by_key(|g| g.heading.is_some());
     groups
+}
+
+/// Attach each section's declared prose to the group that renders it.
+///
+/// Separate from grouping because the prose is declared on the command, by title, while a
+/// group is discovered from the entries that name it.
+fn attach_heading_help<T>(groups: &mut [Group<T>], headings: &[SpecHeading]) {
+    for group in groups {
+        let Some(title) = group.heading.as_deref() else {
+            continue;
+        };
+        group.help = headings
+            .iter()
+            .find(|heading| heading.title == title)
+            .map(|heading| heading.help.clone());
+    }
 }
 
 /// One declared output, as a page renders it.
@@ -709,6 +731,7 @@ impl From<&crate::SpecCommand> for SpecCommand {
             after_help_long,
             after_help_md,
             examples,
+            headings,
             restart_token,
             // How a command line is read, which no rendered page shows.
             unknown_flags: _,
@@ -788,6 +811,7 @@ impl From<&crate::SpecCommand> for SpecCommand {
                 0,
                 Group {
                     heading: None,
+                    help: None,
                     items: Vec::new(),
                 },
             );
@@ -808,14 +832,21 @@ impl From<&crate::SpecCommand> for SpecCommand {
             }
         }
 
+        let headings: Vec<SpecHeading> = headings.clone();
+        let mut flag_groups = group_by_heading(&flags, |f| f.help_heading.as_deref());
+        let mut arg_groups = group_by_heading(&args, |a| a.help_heading.as_deref());
+        attach_heading_help(&mut flag_groups, &headings);
+        attach_heading_help(&mut arg_groups, &headings);
+
         Self {
             full_cmd: full_cmd.clone(),
             usage: usage.clone(),
             subcommands: rendered_subcommands,
             help_subcommands,
             subcommand_groups,
-            flag_groups: group_by_heading(&flags, |f| f.help_heading.as_deref()),
-            arg_groups: group_by_heading(&args, |a| a.help_heading.as_deref()),
+            flag_groups,
+            arg_groups,
+            headings,
             args,
             flags,
             deprecated: deprecated.clone(),
@@ -1168,6 +1199,8 @@ impl SpecCommand {
     fn regroup(&mut self) {
         self.flag_groups = group_by_heading(&self.flags, |f| f.help_heading.as_deref());
         self.arg_groups = group_by_heading(&self.args, |a| a.help_heading.as_deref());
+        attach_heading_help(&mut self.flag_groups, &self.headings);
+        attach_heading_help(&mut self.arg_groups, &self.headings);
     }
 }
 

--- a/lib/src/spec/cmd.rs
+++ b/lib/src/spec/cmd.rs
@@ -214,6 +214,8 @@ pub struct SpecCommand {
     pub after_help_md: Option<String>,
     /// Usage examples for this command
     pub examples: Vec<SpecExample>,
+    /// Prose introducing this command's help sections, by heading title.
+    pub headings: Vec<SpecHeading>,
     /// What this command writes, and how a consumer should read it.
     ///
     /// Folded with the spec's CLI-wide outputs on read rather than here — see
@@ -296,6 +298,7 @@ impl Default for SpecCommand {
             after_help_long: None,
             after_help_md: None,
             examples: vec![],
+            headings: vec![],
             outputs: vec![],
             select: None,
             exit_codes: vec![],
@@ -339,6 +342,36 @@ impl SpecExample {
     pub fn lang(mut self, lang: impl Into<String>) -> Self {
         self.lang = lang.into();
         self
+    }
+}
+
+/// Prose introducing one help section.
+///
+/// Keyed by the heading's title, because a section is assembled from every flag and
+/// argument that names it and the text describes the section rather than any one of them.
+#[derive(Debug, Default, Serialize, Clone)]
+#[non_exhaustive]
+pub struct SpecHeading {
+    pub title: String,
+    pub help: String,
+}
+
+impl SpecHeading {
+    /// Prose shown between a help section's heading and its entries.
+    pub fn new(title: impl Into<String>, help: impl Into<String>) -> Self {
+        Self {
+            title: title.into(),
+            help: help.into(),
+        }
+    }
+}
+
+impl From<&SpecHeading> for KdlNode {
+    fn from(heading: &SpecHeading) -> KdlNode {
+        let mut node = KdlNode::new("heading");
+        node.push(string_entry(None, &heading.title));
+        node.push(string_entry(Some("help"), &heading.help));
+        node
     }
 }
 
@@ -510,6 +543,20 @@ impl SpecCommand {
                         }
                     }
                     cmd.examples.push(example);
+                }
+                "heading" => {
+                    let title = child.ensure_arg_len(1..=1)?.arg(0)?.ensure_string()?;
+                    let mut help = None;
+                    for (k, v) in child.props() {
+                        match k {
+                            "help" => help = Some(v.ensure_string()?),
+                            k => bail_parse!(ctx, v.entry.span(), "unsupported heading key {k}"),
+                        }
+                    }
+                    let Some(help) = help else {
+                        bail_parse!(ctx, child.node.span(), "heading {title} needs help text");
+                    };
+                    cmd.headings.push(SpecHeading::new(title, help));
                 }
                 "output" => cmd.outputs.push(SpecOutput::parse(ctx, &child)?),
                 "exit_code" => cmd.exit_codes.push(SpecExitCode::parse(ctx, &child)?),
@@ -763,6 +810,7 @@ impl SpecCommand {
             aliases,
             hidden_aliases,
             examples,
+            headings,
             outputs,
             select,
             exit_codes,
@@ -871,6 +919,9 @@ impl SpecCommand {
         }
         if !examples.is_empty() {
             self.examples = examples;
+        }
+        if !headings.is_empty() {
+            self.headings = headings;
         }
         // Outputs describe what the *mounted* program writes, so they move with the flags
         // rather than being folded into what was here — the same reason groups follow the
@@ -1091,6 +1142,7 @@ impl From<&SpecCommand> for KdlNode {
             subcommands,
             complete,
             examples,
+            headings,
             outputs,
             select,
             exit_codes,
@@ -1302,6 +1354,10 @@ impl From<&SpecCommand> for KdlNode {
         for example in examples {
             let children = node.children_mut().get_or_insert_with(KdlDocument::new);
             children.nodes_mut().push(example.into());
+        }
+        for heading in headings {
+            let children = node.children_mut().get_or_insert_with(KdlDocument::new);
+            children.nodes_mut().push(heading.into());
         }
         // Outputs before the flag that picks among them, so a reader meets the things
         // being chosen before the rule for choosing — the same order groups follow.
@@ -1754,6 +1810,7 @@ cmd "install" help="Install a package" subcommand_required=#false {
     complete "pkg" run="mycli list --available" descriptions=#true
     example "mycli install foo" header="Install foo" help="Installs foo" lang="sh"
     example "mycli install bar"
+    heading "Output" help="Formats are stable across releases."
     output "human" default=#true help="A progress log"
     output "json" framing="json" help="One report object" {
         schema "{\n  \"type\": \"object\"\n}"
@@ -1805,6 +1862,7 @@ cmd "hidden" hide=#true
             "effect",
             "restart_token",
             "examples",
+            "headings",
             "complete",
             "mounts",
             "aliases",

--- a/lib/src/spec/mod.rs
+++ b/lib/src/spec/mod.rs
@@ -32,7 +32,7 @@ use std::str::FromStr;
 use std::sync::LazyLock;
 
 use crate::error::UsageErr;
-use crate::spec::cmd::{SpecCommand, SpecExample};
+use crate::spec::cmd::{SpecCommand, SpecExample, SpecHeading};
 use crate::spec::config::SpecConfig;
 use crate::spec::context::ParsingContext;
 use crate::spec::exit_code::SpecExitCode;
@@ -688,6 +688,20 @@ impl Spec {
                     }
                     schema.examples.push(example);
                 }
+                "heading" => {
+                    let title = node.ensure_arg_len(1..=1)?.arg(0)?.ensure_string()?;
+                    let mut help = None;
+                    for (k, v) in node.props() {
+                        match k {
+                            "help" => help = Some(v.ensure_string()?),
+                            k => bail_parse!(ctx, v.entry.span(), "unsupported heading key {k}"),
+                        }
+                    }
+                    let Some(help) = help else {
+                        bail_parse!(ctx, node.node.span(), "heading {title} needs help text");
+                    };
+                    schema.cmd.headings.push(SpecHeading::new(title, help));
+                }
                 "output" => schema.outputs.push(SpecOutput::parse(ctx, &node)?),
                 "exit_code" => schema.exit_codes.push(SpecExitCode::parse(ctx, &node)?),
                 "select" => {
@@ -1230,6 +1244,9 @@ impl Display for Spec {
         }
         for example in self.examples.iter() {
             nodes.push(example.into());
+        }
+        for heading in self.cmd.headings.iter() {
+            nodes.push(heading.into());
         }
         for output in self.outputs.iter() {
             nodes.push(output.into());


### PR DESCRIPTION
## Summary

`help_heading` can create a help section, but nothing could describe one. A CLI whose section needs a sentence — what the lint categories mean, how ignore patterns are matched — had to put that text in `long_about`, which renders *above* the usage line, far from the flags it explains.

bpaf had this as `group_help`. [oxc-project/oxc#26027](https://github.com/oxc-project/oxc/pull/26027) lost the placement migrating off bpaf: oxlint's `-A/-W/-D` category table used to sit inside its "Allowing / Denying Multiple Lints" section and now opens the page.

`heading("Ignore Files", help = "…")` declares that prose:

```
Ignore Files:
  Patterns are matched the way `.gitignore` matches them.

      --ignore-path <PATH>  Ignore file to read
```

Design notes:

- **Keyed by title, declared on the container.** A section is assembled from everything that names it — a field's `help_heading`, a flatten site's `next_help_heading` — so the prose belongs to the heading, not to any one entry. It also cannot live on the flatten site: flatten resolves at runtime through `FlattenGroup.meta`, so the derive cannot see a flattened type's attributes. A flattened `Args` type may declare prose for the section it contributes; the host wins if both do.
- **Verbatim at a two-space indent, like an admonition.** Not rewrapped, so an author's own line breaks survive and the compiled and reference renderers agree without either one reflowing. Short help omits it, exactly as it omits admonitions.
- **No `help_template` change.** The prose is written into the section string, so it flows into `{{flags}}` / `{{grouped_flags}}` untouched and the closed 10-name vocabulary is unaffected. Help topics get it for free, since a topic is the section as the long page renders it.
- `heading "Title" help="…"` in KDL, mirroring the `example` node.

## Verification

- `cargo test --all --all-features` (145 test binaries, 0 failures)
- `cargo clippy --all --all-features -- -D warnings`
- `cargo fmt --all`, `mise run render`
- New `conformance/tests/heading_help.rs`: long page shows the prose and short page does not, a topic opens with it, KDL round-trips through the lib parser, generated Markdown carries it in both themes, a flattened type speaks for its own section, and **the compiled and reference renderers are asserted byte-identical**.
- New `heading-prose` vector in `corpus/render/03-sections.json` pinning both whole pages, so `the_two_implementations_agree_with_each_other` covers the new bytes.
- The whole-vocabulary KDL round-trip fixture in `lib/src/spec/cmd.rs` now exercises `headings` (its guard list is what caught the omission).

`split_groups_section` grew past clippy's argument limit, so its three output strings — which always travel together — became a `SectionSink` struct rather than an `allow`.

## Deferred

Go parity. The Go renderer ignores unknown spec fields, so nothing breaks, but it will not display the prose until `go/internal/spec/spec.go` and the long-page renderer learn the field. Happy to fold that in here if you'd rather not carry the gap.

_This pull request was generated by Claude Code._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the spec model, KDL parse/emit, derive, and both help renderers, so heading/help output can change, but it is documentation-only and does not affect parsing.
> 
> **Overview**
> Adds **section prose** for named help headings so a CLI can describe a group of flags, args, or subcommands next to those entries instead of in `long_about`.
> 
> Declare it as `heading("Ignore Files", help = "…")` on a command (or flattened `Args` type) and as `heading "Title" help="…"` in KDL. Long help, help topics, Markdown, and manpages insert the text between the heading and its entries; short help omits it. Only a declared heading gets prose (not default `Flags`/`Arguments`). Host declarations win over flattened types.
> 
> The spec, derive, argv renderer, and usage-lib docs models all carry `headings`. `split_groups_section` now takes a `SectionSink` plus a prose callback. Example nodes in nested command KDL emit after the body so they stay next to headings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 219a3d7b5e9e5af2f0da4e1b077755d8584ae34f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added descriptive prose beneath explicitly declared argument and flag section headings in long-form help.
  - Heading descriptions are preserved in command specifications, KDL, Markdown, and manpage documentation.
  - Topic pages include heading prose, while short help omits it; undeclared default sections do not display descriptions.

- **Documentation**
  - Documented heading declarations and rendering behavior.

- **Tests**
  - Added coverage for help output, topics, specifications, and generated documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->