### PR TITLE
chore: include usage-dynamic in release automation

### DIFF
--- a/tasks/release-plz
+++ b/tasks/release-plz
@@ -61,18 +61,17 @@ fi
 # is satisfied; catch it up if it is behind. usage-argv rides the shared version
 # and depends on nothing, so the same catch-up applies to it.
 #
-# usage-config and usage-validation shipped in-tree at the tagged version, while
-# usage-dynamic was added afterward with that shared version. Publish all three
-# here so the next shared release can depend on them. Do not catch up usage-test /
-# usage-rs at the already-tagged version:
+# usage-config and usage-validation shipped in-tree at the tagged version but were
+# never published — publish them here so the next `usage-rs` release can depend on
+# them. Do not catch up usage-test / usage-rs / usage-dynamic at the already-tagged
+# version:
 # crates.io usage-argv at that version has no features, while in-tree manifests
-# require `usage-argv/complete`. Those crates debut on the next version bump
+# require its `complete` and `spec` features. Those crates debut on the next version bump
 # (first branch above), which republishes argv with the features they need.
 publish_crate_if_needed usage-argv
 publish_crate_if_needed usage-derive
 publish_crate_if_needed usage-config
 publish_crate_if_needed usage-validation
-publish_crate_if_needed usage-dynamic
 publish_crate_if_needed clap_usage
 
 # Anchor the range before filtering paths. A release tag may point at a commit that only

--- a/tasks/release-plz
+++ b/tasks/release-plz
@@ -48,6 +48,7 @@ if ! echo "$released_versions" | grep -q "^v$cur_version$"; then
     publish_crate_if_needed usage-test
     publish_crate_if_needed usage-rs
     publish_crate_if_needed usage-lib
+    publish_crate_if_needed usage-dynamic
     publish_crate_if_needed clap_usage
     publish_crate_if_needed usage-cli
     git tag "v$cur_version"
@@ -60,9 +61,10 @@ fi
 # is satisfied; catch it up if it is behind. usage-argv rides the shared version
 # and depends on nothing, so the same catch-up applies to it.
 #
-# usage-config and usage-validation shipped in-tree at the tagged version but were
-# never published — publish them here so the next `usage-rs` release can depend on
-# them. Do not catch up usage-test / usage-rs at the already-tagged version:
+# usage-config and usage-validation shipped in-tree at the tagged version, while
+# usage-dynamic was added afterward with that shared version. Publish all three
+# here so the next shared release can depend on them. Do not catch up usage-test /
+# usage-rs at the already-tagged version:
 # crates.io usage-argv at that version has no features, while in-tree manifests
 # require `usage-argv/complete`. Those crates debut on the next version bump
 # (first branch above), which republishes argv with the features they need.
@@ -70,13 +72,14 @@ publish_crate_if_needed usage-argv
 publish_crate_if_needed usage-derive
 publish_crate_if_needed usage-config
 publish_crate_if_needed usage-validation
+publish_crate_if_needed usage-dynamic
 publish_crate_if_needed clap_usage
 
 # Anchor the range before filtering paths. A release tag may point at a commit that only
 # changes root release files; letting the path filter hide that tag can make cliff propose
 # a version lower than the one already published.
 release_range="v$cur_version..HEAD"
-version="$(git cliff "$release_range" --bumped-version --include-path 'lib/**' --include-path 'cli/**' --include-path 'argv/**' --include-path 'config/**' --include-path 'derive/**' --include-path 'test/**' --include-path 'usage-rs/**' --include-path 'validation/**')"
+version="$(git cliff "$release_range" --bumped-version --include-path 'lib/**' --include-path 'cli/**' --include-path 'argv/**' --include-path 'config/**' --include-path 'derive/**' --include-path 'test/**' --include-path 'usage-rs/**' --include-path 'usage-dynamic/**' --include-path 'validation/**')"
 
 if [ "v$cur_version" == "$version" ]; then
   echo "No library changes since $version; nothing to release"
@@ -85,17 +88,17 @@ fi
 
 if [ "${usage_dry_run:-}" == 1 ]; then
   echo "version: $version"
-  changelog="$(git cliff "$release_range" --tag "$version" --strip all --include-path 'lib/**' --include-path 'cli/**' --include-path 'argv/**' --include-path 'config/**' --include-path 'derive/**' --include-path 'test/**' --include-path 'usage-rs/**' --include-path 'validation/**')"
+  changelog="$(git cliff "$release_range" --tag "$version" --strip all --include-path 'lib/**' --include-path 'cli/**' --include-path 'argv/**' --include-path 'config/**' --include-path 'derive/**' --include-path 'test/**' --include-path 'usage-rs/**' --include-path 'usage-dynamic/**' --include-path 'validation/**')"
   echo "changelog: $changelog"
   exit 0
 fi
 
 # Generate changelog using git-cliff (LLM editorialization happens in release.yml after merge)
-git cliff "$release_range" --tag "$version" --prepend CHANGELOG.md --include-path 'lib/**' --include-path 'cli/**' --include-path 'argv/**' --include-path 'config/**' --include-path 'derive/**' --include-path 'test/**' --include-path 'usage-rs/**' --include-path 'validation/**'
+git cliff "$release_range" --tag "$version" --prepend CHANGELOG.md --include-path 'lib/**' --include-path 'cli/**' --include-path 'argv/**' --include-path 'config/**' --include-path 'derive/**' --include-path 'test/**' --include-path 'usage-rs/**' --include-path 'usage-dynamic/**' --include-path 'validation/**'
 
 # Get the unreleased notes for PR body
 # Strip version header since PR title already has version
-PR_BODY="$(git cliff "$release_range" --tag "$version" --strip all --include-path 'lib/**' --include-path 'cli/**' --include-path 'argv/**' --include-path 'config/**' --include-path 'derive/**' --include-path 'test/**' --include-path 'usage-rs/**' --include-path 'validation/**' | tail -n +3)"
+PR_BODY="$(git cliff "$release_range" --tag "$version" --strip all --include-path 'lib/**' --include-path 'cli/**' --include-path 'argv/**' --include-path 'config/**' --include-path 'derive/**' --include-path 'test/**' --include-path 'usage-rs/**' --include-path 'usage-dynamic/**' --include-path 'validation/**' | tail -n +3)"
 
 # clap_usage is versioned by hand. Everything still at 0.0.0 is unpublished
 # (xtask, conformance, benches) and must stay there. `cargo set-version`
@@ -174,7 +177,7 @@ done < <(git ls-files 'usage-rs/tests/fixtures/*/Cargo.lock')
 aube update
 mise run lint-fix
 git add \
-  {./,argv/,cli/,config/,derive/,lib/,test/,usage-rs/,validation/}Cargo.* \
+  {./,argv/,cli/,config/,derive/,lib/,test/,usage-rs/,usage-dynamic/,validation/}Cargo.* \
   usage-rs/tests/fixtures/*/Cargo.lock \
   package.json aube-lock.yaml \
   cli/usage.usage.kdl \


### PR DESCRIPTION
## Summary

- publish `usage-dynamic` during catch-up and normal shared releases
- include `usage-dynamic` changes in release versioning and changelog generation
- stage the crate manifest in generated release commits

## Testing

- `bash -n tasks/release-plz`
- `shellcheck tasks/release-plz`
- `usage_dry_run=1 ./tasks/release-plz`

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches crates.io publish order and version-bump/changelog path filters. A mistake could skip or mistime publishing `usage-dynamic`, but the change is small and confined to the release script.
> 
> **Overview**
> Wires the new `usage-dynamic` crate into `tasks/release-plz` so it follows the shared workspace release.
> 
> On a new version tag it is published after `usage-lib` (it depends on argv, lib, and usage-rs). Catch-up at an already-tagged version still skips it, same as `usage-test` / `usage-rs`, because crates.io `usage-argv` at that version lacks the `complete` and `spec` features those crates need.
> 
> `git cliff` path filters now include `usage-dynamic/**` so changes there bump the version and changelog. Release commits also stage `usage-dynamic/Cargo.*`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 534c18da5f8c534346e2b5a929a6bff660e3f8bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated the new `usage-dynamic` package into the release publishing workflow.
  * Included `usage-dynamic` changes in generated changelogs and release documentation.
  * Ensured its package manifests are included in release commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->