### PR TITLE
feat(help): list commands by name in one aligned column

### DIFF
--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -18,6 +18,7 @@
 //! corpus: usage-lib is the reference, and a divergence is a decision rather than an accident.
 
 use core::fmt::Write as _;
+use std::borrow::Cow;
 
 use crate::spec::{
     AdmonitionKind, AdmonitionMeta, ArgMeta, CommandMeta, Example, FlagMeta, Spec, ViewMeta,
@@ -1415,35 +1416,54 @@ fn commands_section(
 ///
 /// Aliases and deprecation trail the summary rather than sitting beside the name, so they wrap
 /// with the text instead of pushing every description out of the column.
-fn command_row(sub: &CommandMeta<'_>) -> Option<String> {
-    let mut parts: Vec<String> = Vec::new();
+fn command_row<'a>(sub: &'a CommandMeta<'a>) -> Option<Cow<'a, str>> {
     // A command that wrote only a long description still has a summary: its first line. Both
     // pages read the same one, so `-h` never says less about a command than `--help` does.
     let summary = summarize(sub.about)
         .or_else(|| summarize(sub.long_about.and_then(|about| about.lines().next())));
-    if let Some(summary) = summary {
-        parts.push(summary.to_string());
-    }
     // Visible aliases only: a hidden alias works and is not advertised, which is the whole of
     // the distinction.
-    let visible_aliases: Vec<&str> = sub
+    let mut visible_aliases = sub
         .cmd
         .aliases
         .iter()
         .copied()
         .filter(|a| !sub.hidden_aliases.contains(a))
-        .collect();
-    if !visible_aliases.is_empty() {
-        parts.push(format!("[aliases: {}]", visible_aliases.join(", ")));
-    }
-    if let Some(label) = deprecation_label(
+        .peekable();
+    let label = deprecation_label(
         sub.deprecated,
         sub.deprecated_warn_at,
         sub.deprecated_remove_at,
-    ) {
-        parts.push(label);
+    );
+    // A summary and nothing else is what almost every row is, and borrowing it there keeps the
+    // whole list off the allocator — which `usage --help` notices, since it renders one.
+    if visible_aliases.peek().is_none() && label.is_none() {
+        return summary.map(Cow::Borrowed);
     }
-    (!parts.is_empty()).then(|| parts.join(" "))
+    let mut row = String::new();
+    if let Some(summary) = summary {
+        row.push_str(summary);
+    }
+    if visible_aliases.peek().is_some() {
+        if !row.is_empty() {
+            row.push(' ');
+        }
+        row.push_str("[aliases: ");
+        for (index, alias) in visible_aliases.enumerate() {
+            if index > 0 {
+                row.push_str(", ");
+            }
+            row.push_str(alias);
+        }
+        row.push(']');
+    }
+    if let Some(label) = label {
+        if !row.is_empty() {
+            row.push(' ');
+        }
+        row.push_str(&label);
+    }
+    Some(Cow::Owned(row))
 }
 
 fn flat_commands_short(out: &mut String, path: &[&str], meta: &CommandMeta<'_>) {
@@ -2228,6 +2248,24 @@ fn entry(
         return;
     }
 
+    // Text that already fits is text `wrap` would hand straight back, so skip it and the two
+    // allocations it makes. Worth the check because it is the common case — most descriptions
+    // are shorter than the column leaves room for.
+    if fits(help, room) {
+        // Assembled rather than formatted. This is the row every entry on every page takes, and
+        // `{usage:<col$}` drags in the whole formatting machinery to pad a string.
+        out.push_str("  ");
+        out.push_str(usage);
+        // Padded by characters, as the format directive it replaces was: a usage can hold a `…`.
+        for _ in 0..col.saturating_sub(usage.chars().count()) {
+            out.push(' ');
+        }
+        out.push_str("  ");
+        out.push_str(help);
+        out.push('\n');
+        return;
+    }
+
     let lines = wrap(help, room);
     let _ = writeln!(out, "  {usage:<col$}  {}", lines[0]);
     for line in &lines[1..] {
@@ -2238,7 +2276,42 @@ fn entry(
     // directly by the next, and matching means matching that.
 }
 
+/// Whether [`wrap`] would return this text unchanged as a single line.
+///
+/// True only for text already spelled the way `wrap` spells it — one line, single spaces
+/// between words, none at either end — and no wider than the room available.
+///
+/// Answering conservatively is free: a false answer costs only the wrap it was going to avoid,
+/// and `wrap` returns the same single line anyway. So this reads bytes rather than characters —
+/// a byte count is never below a character count, which settles the width without counting, and
+/// anything non-ASCII is handed to `wrap` rather than reasoned about here, since the whitespace
+/// it would fold is not all ASCII.
+fn fits(text: &str, room: usize) -> bool {
+    if text.len() > room {
+        return false;
+    }
+    // The start counts as a space so that a leading one, which `wrap` would drop, fails here.
+    let mut after_space = true;
+    for &byte in text.as_bytes() {
+        match byte {
+            // A run of spaces collapses, which is `wrap` rewriting the text.
+            b' ' if after_space => return false,
+            b' ' => after_space = true,
+            // Any other whitespace becomes a space, and any non-ASCII byte may be some.
+            b'\t' | b'\n' | b'\r' | 0x0b | 0x0c => return false,
+            0x80.. => return false,
+            _ => after_space = false,
+        }
+    }
+    // A trailing space would be dropped too.
+    !after_space
+}
+
 /// Break text at word boundaries to fit a width, keeping any breaks it already has.
+///
+/// The width of the line under construction is carried along rather than recounted for each
+/// word. Recounting made this quadratic in the length of a line, which went unnoticed while
+/// only the long page wrapped and was 3% of `usage --help` once the command list did too.
 fn wrap(text: &str, width: usize) -> Vec<String> {
     let mut lines = Vec::new();
     for paragraph in text.split('\n') {
@@ -2247,15 +2320,19 @@ fn wrap(text: &str, width: usize) -> Vec<String> {
             continue;
         }
         let mut line = String::new();
+        let mut line_width = 0;
         for word in paragraph.split_whitespace() {
             let word_width = word.chars().count();
-            if !line.is_empty() && line.chars().count() + 1 + word_width > width {
+            if !line.is_empty() && line_width + 1 + word_width > width {
                 lines.push(std::mem::take(&mut line));
+                line_width = 0;
             }
             if !line.is_empty() {
                 line.push(' ');
+                line_width += 1;
             }
             line.push_str(word);
+            line_width += word_width;
         }
         if !line.is_empty() {
             lines.push(line);

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -1136,11 +1136,16 @@ fn short_sections(
     command_deprecation(out, meta, 0);
     usage_section(&mut sections.usage, spec, path, meta);
 
-    // The path without the binary, which is what a listed subcommand shows: usage-lib prints
-    // `tool-alias get <TOOL>` under `mise tool-alias`, the whole path from the root rather
-    // than the child's own name.
+    // The path without the binary: it is the sort key the reference orders the list by, even
+    // now that the row itself shows the child's own name.
     if !meta.flatten_help {
-        commands_section(&mut sections.commands, &path[1.min(path.len())..], meta);
+        commands_section(
+            &mut sections.commands,
+            &path[1.min(path.len())..],
+            meta,
+            terminal_width(meta),
+            false,
+        );
     }
 
     // The short page lines its columns up too. It did not: every description began directly
@@ -1306,7 +1311,23 @@ fn short_sections(
 }
 
 /// The list of subcommands, and the `help` command every CLI with subcommands has.
-fn commands_section(out: &mut String, path: &[&str], meta: &CommandMeta<'_>) {
+/// The entry every command list ends with, unless the CLI turned it off.
+const HELP_SUBCOMMAND: &str = "help";
+const HELP_SUBCOMMAND_SUMMARY: &str = "Print this message or the help of the given subcommand(s)";
+
+/// The command list, identical on both pages.
+///
+/// The name alone occupies the column, so the summaries line up down the page and the syntax a
+/// command takes belongs to that command's own page. Both pages read the same summary: a
+/// parent's list says what each child is *for*, and what a child does at length belongs on the
+/// child's own page rather than repeated in every ancestor's.
+fn commands_section(
+    out: &mut String,
+    path: &[&str],
+    meta: &CommandMeta<'_>,
+    width: usize,
+    long: bool,
+) {
     let mut visible: Vec<&&CommandMeta<'_>> = meta.subcommands.iter().filter(|c| !c.hide).collect();
     order_commands(&mut visible);
     // Nothing visible, no section — `mise direnv` and `mise dotfiles` have subcommands and
@@ -1318,7 +1339,8 @@ fn commands_section(out: &mut String, path: &[&str], meta: &CommandMeta<'_>) {
     }
     // Sorted by the rendered usage rather than by name, as usage-lib sorts them — for a
     // command with no flags or arguments the two agree, and where they differ this is the
-    // order a reader sees in the reference.
+    // order a reader sees in the reference. The usage is the sort key and nothing else now:
+    // the row shows the name.
     let mut lines: Vec<(String, &&CommandMeta<'_>)> = visible
         .iter()
         .map(|sub| {
@@ -1334,6 +1356,16 @@ fn commands_section(out: &mut String, path: &[&str], meta: &CommandMeta<'_>) {
             .then_with(|| a.0.cmp(&b.0))
     });
 
+    // One column for the page, not for the section: a CLI that groups its commands reads as one
+    // table with rules through it, which is what the flag list already does.
+    let show_help = !meta.cmd.disable_help_subcommand;
+    let col = lines
+        .iter()
+        .map(|(_, sub)| sub.cmd.name.chars().count())
+        .chain(show_help.then(|| HELP_SUBCOMMAND.chars().count()))
+        .max()
+        .unwrap_or(0);
+
     let default_title = meta.subcommand_help_heading.unwrap_or("Commands");
     let mut headings = vec![None];
     for (_, sub) in &lines {
@@ -1345,56 +1377,73 @@ fn commands_section(out: &mut String, path: &[&str], meta: &CommandMeta<'_>) {
     for heading in headings {
         let title = heading.unwrap_or(default_title);
         let _ = writeln!(out, "\n{title}:");
-        for (usage, sub) in lines
+        // A `help_heading` on a subcommand builds a section like a flag's does, so it takes
+        // prose on the same terms: the long page only, and only once declared.
+        if long {
+            if let Some(prose) = heading.and_then(|title| heading_help(meta, title)) {
+                write_indented(out, prose, 2);
+                out.push('\n');
+            }
+        }
+        for (_, sub) in lines
             .iter()
             .filter(|(_, sub)| command_help_section(sub, default_title) == heading)
         {
-            let _ = write!(out, "  {usage}");
-            // Visible aliases only: a hidden alias works and is not advertised, which is the
-            // whole of the distinction.
-            let visible_aliases: Vec<&str> = sub
-                .cmd
-                .aliases
-                .iter()
-                .copied()
-                .filter(|a| !sub.hidden_aliases.contains(a))
-                .collect();
-            if !visible_aliases.is_empty() {
-                let _ = write!(out, " [aliases: {}]", visible_aliases.join(", "));
-            }
-            if let Some(about) = sub.about {
-                if meta.next_line_help {
-                    out.push('\n');
-                    write_indented(out, about.trim_end(), 4);
-                    continue;
-                }
-                // The row writes its own newline below. Trim trailing whitespace in both
-                // layouts, as usage-lib does before choosing a layout.
-                let _ = write!(out, "  {}", about.trim_end());
-            }
-            if let Some(label) = deprecation_label(
-                sub.deprecated,
-                sub.deprecated_warn_at,
-                sub.deprecated_remove_at,
-            ) {
-                let _ = write!(out, "  {label}");
-            }
-            out.push('\n');
+            entry(
+                out,
+                sub.cmd.name,
+                command_row(sub).as_deref(),
+                col,
+                width,
+                meta.next_line_help,
+            );
         }
-        if heading.is_none() && !meta.cmd.disable_help_subcommand {
-            if meta.next_line_help {
-                let _ = writeln!(
-                    out,
-                    "  help\n    Print this message or the help of the given subcommand(s)"
-                );
-            } else {
-                let _ = writeln!(
-                    out,
-                    "  help  Print this message or the help of the given subcommand(s)"
-                );
-            }
+        if heading.is_none() && show_help {
+            entry(
+                out,
+                HELP_SUBCOMMAND,
+                Some(HELP_SUBCOMMAND_SUMMARY),
+                col,
+                width,
+                meta.next_line_help,
+            );
         }
     }
+}
+
+/// Everything that follows a command's name in its parent's list, as one string.
+///
+/// Aliases and deprecation trail the summary rather than sitting beside the name, so they wrap
+/// with the text instead of pushing every description out of the column.
+fn command_row(sub: &CommandMeta<'_>) -> Option<String> {
+    let mut parts: Vec<String> = Vec::new();
+    // A command that wrote only a long description still has a summary: its first line. Both
+    // pages read the same one, so `-h` never says less about a command than `--help` does.
+    let summary = summarize(sub.about)
+        .or_else(|| summarize(sub.long_about.and_then(|about| about.lines().next())));
+    if let Some(summary) = summary {
+        parts.push(summary.to_string());
+    }
+    // Visible aliases only: a hidden alias works and is not advertised, which is the whole of
+    // the distinction.
+    let visible_aliases: Vec<&str> = sub
+        .cmd
+        .aliases
+        .iter()
+        .copied()
+        .filter(|a| !sub.hidden_aliases.contains(a))
+        .collect();
+    if !visible_aliases.is_empty() {
+        parts.push(format!("[aliases: {}]", visible_aliases.join(", ")));
+    }
+    if let Some(label) = deprecation_label(
+        sub.deprecated,
+        sub.deprecated_warn_at,
+        sub.deprecated_remove_at,
+    ) {
+        parts.push(label);
+    }
+    (!parts.is_empty()).then(|| parts.join(" "))
 }
 
 fn flat_commands_short(out: &mut String, path: &[&str], meta: &CommandMeta<'_>) {
@@ -1941,7 +1990,13 @@ fn long_sections(
     usage_section(&mut sections.usage, spec, path, meta);
 
     if !meta.flatten_help {
-        long_commands_section(&mut sections.commands, &path[1.min(path.len())..], meta);
+        commands_section(
+            &mut sections.commands,
+            &path[1.min(path.len())..],
+            meta,
+            width,
+            true,
+        );
     }
 
     // One column width per section, over its visible entries — the same two the reference
@@ -2243,6 +2298,11 @@ fn admonitions(out: &mut String, blocks: &[AdmonitionMeta<'_>]) {
     }
 }
 
+/// A description reduced to what a list can show, or nothing if it says nothing.
+fn summarize(text: Option<&str>) -> Option<&str> {
+    text.map(str::trim_end).filter(|text| !text.is_empty())
+}
+
 fn deprecation_label(
     message: Option<&str>,
     warn_at: Option<&str>,
@@ -2303,82 +2363,6 @@ fn flag_notes(out: &mut String, meta: &FlagMeta<'_>, indent: usize) {
         meta.deprecated_remove_at,
     ) {
         let _ = writeln!(out, "{}{label}", " ".repeat(indent));
-    }
-}
-
-/// The commands list, with each command's help beneath its usage.
-fn long_commands_section(out: &mut String, path: &[&str], meta: &CommandMeta<'_>) {
-    let mut visible: Vec<&&CommandMeta<'_>> = meta.subcommands.iter().filter(|c| !c.hide).collect();
-    order_commands(&mut visible);
-    if visible.is_empty() {
-        return;
-    }
-    let mut lines: Vec<(String, &&CommandMeta<'_>)> = visible
-        .iter()
-        .map(|sub| {
-            let mut sub_path: Vec<&str> = path.to_vec();
-            sub_path.push(sub.cmd.name);
-            (usage_line(&sub_path, sub), *sub)
-        })
-        .collect();
-    lines.sort_unstable_by(|a, b| {
-        a.1.display_order
-            .unwrap_or(999)
-            .cmp(&b.1.display_order.unwrap_or(999))
-            .then_with(|| a.0.cmp(&b.0))
-    });
-
-    let default_title = meta.subcommand_help_heading.unwrap_or("Commands");
-    let mut headings = vec![None];
-    for (_, sub) in &lines {
-        let heading = command_help_section(sub, default_title);
-        if !headings.contains(&heading) {
-            headings.push(heading);
-        }
-    }
-    for heading in headings {
-        let title = heading.unwrap_or(default_title);
-        let _ = writeln!(out, "\n{title}:");
-        // A `help_heading` on a subcommand builds a section like a flag's does, so it takes
-        // prose on the same terms: the long page only, and only once declared.
-        if let Some(prose) = heading.and_then(|title| heading_help(meta, title)) {
-            write_indented(out, prose, 2);
-            out.push('\n');
-        }
-        for (usage, sub) in lines
-            .iter()
-            .filter(|(_, sub)| command_help_section(sub, default_title) == heading)
-        {
-            let _ = write!(out, "  {usage}");
-            let visible_aliases: Vec<&str> = sub
-                .cmd
-                .aliases
-                .iter()
-                .copied()
-                .filter(|a| !sub.hidden_aliases.contains(a))
-                .collect();
-            if !visible_aliases.is_empty() {
-                let _ = write!(out, " [aliases: {}]", visible_aliases.join(", "));
-            }
-            out.push('\n');
-            if let Some(about) = sub.long_about.or(sub.about) {
-                // Trailing whitespace trimmed: the blank line after each entry is written below, and
-                // a description that happens to end in a newline — which clap's `long_about` often
-                // does, reaching the spec verbatim — added a second one and left a stray blank in
-                // the middle of the list.
-                write_indented(out, about.trim_end(), 4);
-            }
-            command_deprecation(out, sub, 4);
-            // A blank line between entries, which the wider layout can afford and which keeps a
-            // multi-line description from running into the next command's name.
-            out.push('\n');
-        }
-        if heading.is_none() && !meta.cmd.disable_help_subcommand {
-            let _ = writeln!(
-                out,
-                "  help\n    Print this message or the help of the given subcommand(s)"
-            );
-        }
     }
 }
 
@@ -3665,10 +3649,10 @@ mod style_tests {
         };
         let mut page = String::new();
 
-        commands_section(&mut page, &[], &root_meta);
+        commands_section(&mut page, &[], &root_meta, 80, false);
 
-        assert!(page.contains("  run  run it\n  help"));
-        assert!(!page.contains("  run  run it\n\n  help"));
+        assert!(page.contains("  run   run it\n  help"));
+        assert!(!page.contains("  run   run it\n\n  help"));
     }
 
     #[test]

--- a/conformance/tests/help_request.rs
+++ b/conformance/tests/help_request.rs
@@ -29,6 +29,10 @@ enum Commands {
 }
 
 /// A tool whose help is worth asking for
+///
+/// The long form has this paragraph and the short form does not, which is what gives the two
+/// pages something to differ by — the command list no longer does, since a parent says the same
+/// thing about a child on either page.
 #[derive(Cli)]
 #[usage(bin = "ex")]
 struct Ex {
@@ -443,7 +447,9 @@ fn the_page_advertises_exactly_where_the_word_works() {
     let spec = Deep::spec();
     let root_page = usage_argv::help::short_help(spec, &["deep"], &[spec.root]);
     assert!(
-        root_page.contains("\n  help  Print this message"),
+        root_page
+            .lines()
+            .any(|line| line.starts_with("  help") && line.contains("Print this message")),
         "{root_page}"
     );
 

--- a/conformance/tests/trailing_whitespace.rs
+++ b/conformance/tests/trailing_whitespace.rs
@@ -1,10 +1,10 @@
 //! A description that ends in a newline should not add a blank line to the page.
 //!
 //! clap's `long_about` often ends with one — a `///` block whose last line is empty, or an
-//! examples section written with a trailing break — and it reaches the spec verbatim. Both
-//! renderers write their own blank line after a description, so one already in the text doubled
-//! it: a stray blank in the middle of `Commands:`, and a second gap under the program's own
-//! description.
+//! examples section written with a trailing break — and it reaches the spec verbatim. Wherever
+//! a renderer writes its own blank line after a description, one already in the text doubled it:
+//! a stray blank in the middle of `Commands:` back when that list printed long descriptions, and
+//! a second gap under the program's own description, which it still would.
 //!
 //! Found on pitchfork's `daemons add` and mise's `plugins ls-remote`, which is why the fix is in
 //! both renderers rather than one — trimming either side alone traded one CLI's divergence for
@@ -103,13 +103,17 @@ fn the_commands_still_parse() {
 }
 
 #[test]
-fn the_entries_still_have_one_blank_between_them() {
-    // Trimming must not run the entries together: the separator is written by the renderer and
-    // stays whether or not the text ended in a break.
+fn the_entries_sit_on_consecutive_lines() {
+    // The long page lists commands the way the short one does — one line each, in one column,
+    // with no separator between them — so a description ending in a break has nowhere to leave
+    // a blank behind, and the entries must not gain one either.
     let page = help::render(Ex::spec(), Ex::command(), true).expect("a page");
     let commands = page
         .split_once("Commands:\n")
         .expect("a commands section")
         .1;
-    assert!(commands.contains("\n\n  two"), "{commands:?}");
+    assert!(
+        commands.starts_with("  one   Short one\n  two   Short two\n"),
+        "{commands:?}"
+    );
 }

--- a/corpus/render/03-sections.json
+++ b/corpus/render/03-sections.json
@@ -120,7 +120,7 @@
     },
     {
       "id": "commands-list-with-aliases",
-      "doc": "Subcommands are listed by their rendered usage with visible aliases beside them; a hidden alias works and is not advertised. Note the supplied `help` entry, which is written flush rather than into the column the declared commands share — the reference's behaviour, pinned here so that fixing it is a decision rather than an accident.",
+      "doc": "Subcommands are listed by name in one column, with the summary after it and the aliases after that; a hidden alias works and is not advertised. The supplied `help` entry sits in the same column as the declared commands, because it is a row like any other.",
       "spec": "name \"ex\"\nbin \"ex\"\nabout \"An example\"\ncmd \"install\" help=\"Install a tool\" {\n    alias \"i\"\n    alias \"add\" hide=#true\n    arg \"<TOOL>\"\n}\ncmd \"remove\" help=\"Remove a tool\" hide=#true\n",
       "expect": {
         "usage": "ex <SUBCOMMAND>",
@@ -130,8 +130,8 @@
           "Usage: ex <SUBCOMMAND>",
           "",
           "Commands:",
-          "  install <TOOL> [aliases: i]  Install a tool",
-          "  help  Print this message or the help of the given subcommand(s)",
+          "  install  Install a tool [aliases: i]",
+          "  help     Print this message or the help of the given subcommand(s)",
           "",
           "Flags:",
           "  -h, --help  Print help"
@@ -204,7 +204,7 @@
           "Usage: ex [--shown] [shown] <SUBCOMMAND>",
           "",
           "Commands:",
-          "  go  Go",
+          "  go    Go",
           "  help  Print this message or the help of the given subcommand(s)",
           "",
           "Arguments:",

--- a/docs/go/help.md
+++ b/docs/go/help.md
@@ -36,14 +36,19 @@ Global flags:
 
 The output is not merely similar to the reference implementation's — all 211 of mise's usage
 lines, `-h` pages, and `--help` pages are compared **byte for byte** against usage-lib's
-rendering in CI. Layout details you get for free: sections in canonical order, commands sorted
-with `[aliases: …]` shown for visible aliases, `help_heading` groups (first-seen order, unheaded
-entries first), a 4-column short-flag gutter, required entries in angle brackets, `[env: X]` and
-default annotations, and the long page wrapped at a fixed 80 columns.
+rendering in CI. Layout details you get for free: sections in canonical order, commands listed by
+name in one column per page with `[aliases: …]` after the summary for visible aliases,
+`help_heading` groups (first-seen order, unheaded entries first), a 4-column short-flag gutter,
+required entries in angle brackets, `[env: X]` and default annotations, and both pages wrapped at
+a fixed 80 columns.
+
+Both pages list a command's children identically: the name, then the summary — `help`, or the
+first line of `long_help` when there is no `help`. A child's full `long_help` appears on the
+child's own page, not repeated in every ancestor's list.
 
 The short page appends `[choices]`, `[env: X]`, and (for arguments) `(default: …)` inline; the
-long page gives each its own line and prefers `long_help` over `help`. Examples declared on the
-root are inherited by commands that declare none.
+long page gives each its own line and prefers `long_help` over `help` for the command's own
+description. Examples declared on the root are inherited by commands that declare none.
 
 One rule is load-bearing: a page only advertises a flag spelling where that flag is the one that
 would _bind_ it. Masking is per spelling — a subcommand redeclaring `--jobs` leaves an inherited

--- a/docs/rust/help.md
+++ b/docs/rust/help.md
@@ -9,6 +9,11 @@ declares its own `--help`, your declaration wins for that spelling.
 `-h` renders the short page, `--help` the long page: the first paragraph of each doc comment
 versus the whole comment, `long_help` over `help`, `long_about` over `about`.
 
+That preference is about the page's own subject. A command's _list_ of children reads the same on
+both pages — each child's name in one column, then its summary — because a parent says what each
+child is for, and what a child does at length belongs on the child's own page rather than
+repeated in every ancestor's list. A child with only a `long_help` contributes its first line.
+
 With `parse()`, help is handled for you — printed to stdout, exit `0`. With `parse_from`, a help
 request comes back as an _error_, because a parse that stopped to print help has not produced a
 value (clap models it the same way):

--- a/docs/rust/quickstart.md
+++ b/docs/rust/quickstart.md
@@ -147,14 +147,9 @@ Greets people, politely
 Usage: greet <SUBCOMMAND>
 
 Commands:
-  completion <--shell <SHELL>>
-    Print a completion script
-
-  hello [NAME]
-    Greet someone
-
-  help
-    Print this message or the help of the given subcommand(s)
+  completion  Print a completion script
+  hello       Greet someone
+  help        Print this message or the help of the given subcommand(s)
 
 Flags:
   -h, --help     Print help

--- a/go/argv/page.go
+++ b/go/argv/page.go
@@ -241,6 +241,17 @@ func ShortHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) s
 
 // commandsSection lists the subcommands, and the `help` command every CLI with
 // subcommands has.
+// helpSubcommand is the entry every command list ends with, unless the CLI turned it off.
+const (
+	helpSubcommand        = "help"
+	helpSubcommandSummary = "Print this message or the help of the given subcommand(s)"
+)
+
+// commandsSection writes the command list, which is identical on both pages. The name
+// alone occupies the column, so the summaries line up down the page and the syntax a
+// command takes belongs to that command's own page. Both pages read the same summary: a
+// parent's list says what each child is *for*, and what a child does at length belongs on
+// the child's own page rather than repeated in every ancestor's.
 func commandsSection(out *strings.Builder, path []string, cmd *Command, help HelpTable) {
 	type line struct {
 		usage string
@@ -269,6 +280,8 @@ func commandsSection(out *strings.Builder, path []string, cmd *Command, help Hel
 		}
 		nextLineHelp = h.NextLineHelp
 	}
+	// Sorted by the rendered usage, which is how usage-lib sorts them. That is all the
+	// usage is used for now: the row shows the name.
 	sort.SliceStable(lines, func(i, j int) bool {
 		left, right := helpOrder(help, lines[i].sub.Key, 999), helpOrder(help, lines[j].sub.Key, 999)
 		if left != right {
@@ -276,6 +289,19 @@ func commandsSection(out *strings.Builder, path []string, cmd *Command, help Hel
 		}
 		return lines[i].usage < lines[j].usage
 	})
+
+	// One column for the page, not for the section: a CLI that groups its commands reads
+	// as one table with rules through it, which is what the flag list already does.
+	showHelp := !cmd.DisableHelpSubcommand
+	col := 0
+	if showHelp {
+		col = len([]rune(helpSubcommand))
+	}
+	for _, l := range lines {
+		if n := len([]rune(l.sub.Name)); n > col {
+			col = n
+		}
+	}
 
 	headings := []string{""}
 	for _, l := range lines {
@@ -299,39 +325,40 @@ func commandsSection(out *strings.Builder, path []string, cmd *Command, help Hel
 			if itemSection != section {
 				continue
 			}
-			out.WriteString("  " + l.usage)
-			if h := help.Lookup(l.sub.Key); h != nil {
-				// Visible aliases only: a hidden alias works and is not advertised,
-				// which is the whole of the distinction.
-				if len(h.VisibleAliases) > 0 {
-					out.WriteString(" [aliases: " + strings.Join(h.VisibleAliases, ", ") + "]")
-				}
-				if nextLineHelp {
-					out.WriteString("\n")
-					if strings.TrimSpace(h.Short) != "" {
-						writeIndented(out, trimEnd(h.Short), 4)
-					}
-					if label := deprecationLabel(h); label != "" {
-						writeIndented(out, label, 4)
-					}
-					continue
-				}
-				if text := helpText(h); text != "" {
-					// The row owns its terminating newline. Trim the description in both
-					// layouts, as usage-lib does before selecting a layout.
-					out.WriteString("  " + trimEnd(text))
-				}
-			}
-			out.WriteString("\n")
+			entry(out, l.sub.Name, commandRow(help.Lookup(l.sub.Key)), col, nextLineHelp)
 		}
-		if section == "" && !cmd.DisableHelpSubcommand {
-			if nextLineHelp {
-				out.WriteString("  help\n    Print this message or the help of the given subcommand(s)\n")
-			} else {
-				out.WriteString("  help  Print this message or the help of the given subcommand(s)\n")
-			}
+		if section == "" && showHelp {
+			entry(out, helpSubcommand, helpSubcommandSummary, col, nextLineHelp)
 		}
 	}
+}
+
+// commandRow is everything that follows a command's name in its parent's list, as one
+// string. Aliases and deprecation trail the summary rather than sitting beside the name,
+// so they wrap with the text instead of pushing every description out of the column.
+func commandRow(h *Help) string {
+	if h == nil {
+		return ""
+	}
+	parts := []string{}
+	// A command that wrote only a long description still has a summary: its first line.
+	// Both pages read the same one, so `-h` never says less than `--help` does.
+	summary := trimEnd(h.Short)
+	if summary == "" {
+		summary = trimEnd(strings.SplitN(h.Long, "\n", 2)[0])
+	}
+	if summary != "" {
+		parts = append(parts, summary)
+	}
+	// Visible aliases only: a hidden alias works and is not advertised, which is the
+	// whole of the distinction.
+	if len(h.VisibleAliases) > 0 {
+		parts = append(parts, "[aliases: "+strings.Join(h.VisibleAliases, ", ")+"]")
+	}
+	if label := deprecationLabel(h); label != "" {
+		parts = append(parts, label)
+	}
+	return strings.Join(parts, " ")
 }
 
 func flatCommandsShort(out *strings.Builder, path []string, cmd *Command, help HelpTable, nextLine bool) {

--- a/go/argv/page_long.go
+++ b/go/argv/page_long.go
@@ -1,7 +1,6 @@
 package argv
 
 import (
-	"slices"
 	"sort"
 	"strings"
 )
@@ -77,7 +76,7 @@ func LongHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) st
 	}
 
 	if meta == nil || !meta.FlattenHelp {
-		longCommandsSection(&sections.commands, path[min(1, len(path)):], cmd, help)
+		commandsSection(&sections.commands, path[min(1, len(path)):], cmd, help)
 	}
 
 	// One column width per section, over its visible entries — separately, so a
@@ -208,83 +207,6 @@ func AllHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) str
 
 // longCommandsSection lists the subcommands, each description on its own indented
 // line rather than beside the name.
-func longCommandsSection(out *strings.Builder, path []string, cmd *Command, help HelpTable) {
-	type line struct {
-		usage string
-		sub   *Command
-	}
-	var lines []line
-	for _, sub := range cmd.Subcommands {
-		if h := help.Lookup(sub.Key); h != nil && h.Hide {
-			continue
-		}
-		subPath := append(append([]string{}, path...), sub.Name)
-		lines = append(lines, line{UsageLine(subPath, sub, help), sub})
-	}
-	if len(lines) == 0 {
-		return
-	}
-	heading := "Commands"
-	if h := help.Lookup(cmd.Key); h != nil && h.SubcommandHelpHeading != "" {
-		heading = h.SubcommandHelpHeading
-	}
-	sort.SliceStable(lines, func(i, j int) bool {
-		left, right := helpOrder(help, lines[i].sub.Key, 999), helpOrder(help, lines[j].sub.Key, 999)
-		if left != right {
-			return left < right
-		}
-		return lines[i].usage < lines[j].usage
-	})
-
-	headings := []string{""}
-	for _, l := range lines {
-		if h := headingOf(help, l.sub.Key); h == heading {
-			continue
-		} else if h != "" && !slices.Contains(headings, h) {
-			headings = append(headings, h)
-		}
-	}
-	for _, section := range headings {
-		title := section
-		if title == "" {
-			title = heading
-		}
-		out.WriteString("\n" + title + ":\n")
-		for _, l := range lines {
-			itemSection := headingOf(help, l.sub.Key)
-			if itemSection == heading {
-				itemSection = ""
-			}
-			if itemSection != section {
-				continue
-			}
-			out.WriteString("  " + l.usage)
-			h := help.Lookup(l.sub.Key)
-			if h != nil && len(h.VisibleAliases) > 0 {
-				out.WriteString(" [aliases: " + strings.Join(h.VisibleAliases, ", ") + "]")
-			}
-			out.WriteString("\n")
-			if h != nil {
-				// Trailing whitespace trimmed: the blank line after each entry is
-				// written below, and a description that happens to end in a newline
-				// added a second one — a stray blank in the middle of the list.
-				if about := trimEnd(firstOf(h.Long, h.Short)); about != "" {
-					writeIndented(out, about, 4)
-				}
-				if label := deprecationLabel(h); label != "" {
-					writeIndented(out, label, 4)
-				}
-			}
-			// A blank line between entries, which the wider layout can afford and
-			// which keeps a multi-line description from running into the next name.
-			out.WriteString("\n")
-		}
-		if section == "" && !cmd.DisableHelpSubcommand {
-			out.WriteString("  help\n    Print this message or the help of the given subcommand(s)\n")
-		}
-	}
-}
-
 func flatCommandsLong(out *strings.Builder, path []string, cmd *Command, help HelpTable, nextLine bool) {
 	visible := append([]*Command{}, cmd.Subcommands...)
 	orderCommands(visible, help)

--- a/go/argv/page_test.go
+++ b/go/argv/page_test.go
@@ -169,8 +169,10 @@ func TestCommandDeprecationAppearsInListingsAndFlattenedHelp(t *testing.T) {
 
 	help[0].NextLineHelp = true
 	nextLinePage := ShortHelp(HelpSpec{Bin: "ex"}, []string{"ex"}, []*Command{root}, help)
-	if !strings.Contains(nextLinePage, "old\n    old command\n    [deprecated: warns at 6.1]") {
-		t.Fatalf("next-line command listing glued deprecation to its description:\n%s", nextLinePage)
+	// In a command list the label trails the summary rather than taking a line of its own,
+	// in either layout: it wraps with the text instead of pushing it out of the column.
+	if !strings.Contains(nextLinePage, "old\n    old command [deprecated: warns at 6.1]") {
+		t.Fatalf("next-line command listing misplaced the deprecation:\n%s", nextLinePage)
 	}
 	help[0].NextLineHelp = false
 

--- a/lib/src/docs/cli/mod.rs
+++ b/lib/src/docs/cli/mod.rs
@@ -72,6 +72,40 @@ pub fn render_help(spec: &Spec, cmd: &SpecCommand, long: bool) -> String {
     }
     lay_out(&mut inherited, width, col);
 
+    // The command list, laid out the way the flag list is: one column for the whole page, the
+    // name in it, and everything else — summary, aliases, deprecation — trailing as text that
+    // wraps under itself. Both pages get the same rows, so `--help` no longer reprints every
+    // child's long help on its parent's page.
+    let help_row = {
+        let show_help_row = !docs_cmd.subcommands.is_empty()
+            && !docs_cmd.flatten_help
+            && !cmd.disable_help_subcommand;
+        let cmd_col = crate::docs::layout::max_usage_width(
+            docs_cmd
+                .subcommand_groups
+                .iter()
+                .flat_map(|g| g.items.iter())
+                .map(|c| c.name.as_str())
+                .chain(show_help_row.then_some(HELP_SUBCOMMAND)),
+        );
+        for group in &mut docs_cmd.subcommand_groups {
+            lay_out_commands(&mut group.items, width, cmd_col);
+        }
+        // Rendered here rather than in the template because it is a row like any other: it
+        // sits in the same column and wraps by the same rule, and neither is something a
+        // template should be working out.
+        show_help_row.then(|| {
+            render_row(
+                HELP_SUBCOMMAND,
+                HELP_SUBCOMMAND_SUMMARY,
+                width,
+                cmd_col,
+                cmd.next_line_help,
+            )
+        })
+    };
+    ctx.insert("help_row", &help_row);
+
     let arg_has_ungrouped = docs_cmd
         .arg_groups
         .iter()
@@ -341,6 +375,112 @@ fn lay_out(flags: &mut [crate::docs::models::SpecFlag], terminal_width: usize, c
             }
         }
     }
+}
+
+/// The entry every command list ends with, unless the CLI turned it off.
+const HELP_SUBCOMMAND: &str = "help";
+const HELP_SUBCOMMAND_SUMMARY: &str = "Print this message or the help of the given subcommand(s)";
+
+/// Fit a list of subcommand summaries to the page's command column.
+///
+/// `lay_out`'s counterpart for the command list: the same column, the same wrapping, the same
+/// "an empty rendering means use the block layout" signal to the template.
+fn lay_out_commands(
+    commands: &mut [crate::docs::models::HelpCommand],
+    terminal_width: usize,
+    col: usize,
+) {
+    for command in commands {
+        command.usage_col_width = col;
+        command.row = command_row(command);
+        command.help_rendered = None;
+        command.help_is_multiline = false;
+        if let Some(row) = command.row.as_deref() {
+            let (rendered, is_multiline) =
+                crate::docs::layout::render_help_text(row, terminal_width, col);
+            if !rendered.is_empty() {
+                command.help_rendered = Some(rendered);
+                command.help_is_multiline = is_multiline;
+            }
+        }
+    }
+}
+
+/// Everything that follows a command's name in its parent's list, as one string.
+///
+/// The name alone occupies the column, so the summaries line up down the page and the syntax a
+/// command takes belongs to that command's own page. What qualifies the command rather than
+/// describing it — the names it also answers to, that it is going away — trails the summary,
+/// where it wraps with the text instead of pushing it out of the column.
+fn command_row(cmd: &crate::docs::models::HelpCommand) -> Option<String> {
+    let mut parts = Vec::new();
+    // A command that wrote only `help_long` still has a summary: its first line. Both pages
+    // read the same one, so `-h` never says less about a command than `--help` does.
+    let summary = summarize(cmd.help.as_deref()).or_else(|| {
+        summarize(
+            cmd.help_long
+                .as_deref()
+                .and_then(|help| help.lines().next()),
+        )
+    });
+    if let Some(summary) = summary {
+        parts.push(summary.to_string());
+    }
+    if !cmd.aliases.is_empty() {
+        parts.push(format!("[aliases: {}]", cmd.aliases.join(", ")));
+    }
+    if let Some(label) = deprecation_label(
+        cmd.deprecated.as_deref(),
+        cmd.deprecated_warn_at.as_deref(),
+        cmd.deprecated_remove_at.as_deref(),
+    ) {
+        parts.push(label);
+    }
+    (!parts.is_empty()).then(|| parts.join(" "))
+}
+
+/// A description reduced to what a list can show, or nothing if it says nothing.
+fn summarize(text: Option<&str>) -> Option<&str> {
+    text.map(str::trim_end).filter(|text| !text.is_empty())
+}
+
+/// How a page says something is going away, in the one place both lists read it from.
+fn deprecation_label(
+    message: Option<&str>,
+    warn_at: Option<&str>,
+    remove_at: Option<&str>,
+) -> Option<String> {
+    if message.is_none() && warn_at.is_none() && remove_at.is_none() {
+        return None;
+    }
+    let mut parts = Vec::new();
+    if let Some(message) = message {
+        parts.push(message.to_string());
+    }
+    if let Some(at) = warn_at {
+        parts.push(format!("warns at {at}"));
+    }
+    if let Some(at) = remove_at {
+        parts.push(format!("removed at {at}"));
+    }
+    Some(format!("[deprecated: {}]", parts.join("; ")))
+}
+
+/// One command row, ready to print — the form the synthetic `help` entry takes.
+fn render_row(
+    name: &str,
+    row: &str,
+    terminal_width: usize,
+    col: usize,
+    next_line_help: bool,
+) -> String {
+    if !next_line_help {
+        let (rendered, _) = crate::docs::layout::render_help_text(row, terminal_width, col);
+        if !rendered.is_empty() {
+            return format!("  {name:<col$}  {rendered}");
+        }
+    }
+    format!("  {name}\n    {row}")
 }
 
 /// The flags a command inherits, as its page should list them.
@@ -962,11 +1102,8 @@ cmd "run" help="Run it"
           -V, --version  Print version
 
         Commands:
-          run
-            Run it
-
-          help
-            Print this message or the help of the given subcommand(s)
+          run   Run it
+          help  Print this message or the help of the given subcommand(s)
 
         Read the docs.
 
@@ -1207,8 +1344,9 @@ cmd "new-cmd" help="Do something better"
 
         Commands:
           new-cmd  Do something better
-          old-cmd [deprecated: use new-cmd instead; warns at 6.2; removed at 7.0]  Do something
-          help  Print this message or the help of the given subcommand(s)
+          old-cmd  Do something [deprecated: use new-cmd instead; warns at 6.2; removed
+                   at 7.0]
+          help     Print this message or the help of the given subcommand(s)
 
         Flags:
               --old   Old switch [deprecated: use --new; warns at 6.1; removed at 7.0]
@@ -1227,7 +1365,7 @@ cmd "old-cmd" help="Do something" deprecated_warn_at="6.2"
 
         let page = render_help(&spec, &spec.cmd, false);
         assert!(
-            page.contains("old-cmd [deprecated: warns at 6.2]"),
+            page.contains("old-cmd  Do something [deprecated: warns at 6.2]"),
             "{page}"
         );
         assert!(page.contains("[deprecated: removed at 7.0]"), "{page}");

--- a/lib/src/docs/cli/templates/spec_template_long.tera
+++ b/lib/src/docs/cli/templates/spec_template_long.tera
@@ -36,6 +36,7 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
 {%- endif %}{{ mark_commands }}
 
 {%- if cmd.subcommands and not cmd.flatten_help %}
+{%- set next_line_help = cmd.next_line_help %}
 {%- for group in cmd.subcommand_groups %}
 
 {{ group.heading | default(value=cmd.subcommand_help_heading | default(value="Commands")) }}:
@@ -43,17 +44,17 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
   {{ group.help | indent(width=2) }}
 {% endif %}
 {%- for cmd in group.items %}
-  {{ cmd.usage | trim }}
-{%- if cmd.deprecated or cmd.deprecated_warn_at or cmd.deprecated_remove_at %} [deprecated:{% if cmd.deprecated %} {{ cmd.deprecated }}{% endif %}{% if cmd.deprecated_warn_at %}{% if cmd.deprecated %};{% endif %} warns at {{ cmd.deprecated_warn_at }}{% endif %}{% if cmd.deprecated_remove_at %}{% if cmd.deprecated or cmd.deprecated_warn_at %};{% endif %} removed at {{ cmd.deprecated_remove_at }}{% endif %}]{%- endif %}
-{%- if cmd.aliases %} [aliases: {{ cmd.aliases | join(sep=", ") }}]{% endif %}
-{%- set help = cmd.help_long | default(value=cmd.help | default(value='')) %}
-{%- if help %}
-    {{ help | indent(width=4) }}
+{%- if cmd.help_rendered and not next_line_help %}
+  {{ cmd.name | ljust(width=cmd.usage_col_width) }}  {{ cmd.help_rendered }}
+{%- elif cmd.row %}
+  {{ cmd.name }}
+    {{ cmd.row | indent(width=4) }}
+{%- else %}
+  {{ cmd.name }}
 {%- endif %}
-{% endfor %}
-{%- if not group.heading and show_help_subcommand %}
-  help
-    Print this message or the help of the given subcommand(s)
+{%- endfor %}
+{%- if not group.heading and help_row %}
+{{ help_row }}
 {%- endif %}
 {%- endfor %}
 {%- endif %}{{ mark_args }}{% if not arg_has_ungrouped %}{{ mark_grouped_args }}{% endif %}

--- a/lib/src/docs/cli/templates/spec_template_short.tera
+++ b/lib/src/docs/cli/templates/spec_template_short.tera
@@ -33,15 +33,17 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
 
 {{ group.heading | default(value=cmd.subcommand_help_heading | default(value="Commands")) }}:
 {%- for cmd in group.items %}
-  {{ cmd.usage | trim }}
-{%- if cmd.deprecated or cmd.deprecated_warn_at or cmd.deprecated_remove_at %} [deprecated:{% if cmd.deprecated %} {{ cmd.deprecated }}{% endif %}{% if cmd.deprecated_warn_at %}{% if cmd.deprecated %};{% endif %} warns at {{ cmd.deprecated_warn_at }}{% endif %}{% if cmd.deprecated_remove_at %}{% if cmd.deprecated or cmd.deprecated_warn_at %};{% endif %} removed at {{ cmd.deprecated_remove_at }}{% endif %}]{%- endif %}
-{%- if cmd.aliases %} [aliases: {{ cmd.aliases | join(sep=", ") }}]{% endif %}
-{%- if cmd.help %}{% if next_line_help %}
-    {{ cmd.help | indent(width=4) }}{% else %}  {{ cmd.help }}{% endif %}{%- endif %}
+{%- if cmd.help_rendered and not next_line_help %}
+  {{ cmd.name | ljust(width=cmd.usage_col_width) }}  {{ cmd.help_rendered }}
+{%- elif cmd.row %}
+  {{ cmd.name }}
+    {{ cmd.row | indent(width=4) }}
+{%- else %}
+  {{ cmd.name }}
+{%- endif %}
 {%- endfor %}
-{%- if not group.heading and show_help_subcommand %}
-{% if next_line_help %}  help
-    Print this message or the help of the given subcommand(s){% else %}  help  Print this message or the help of the given subcommand(s){% endif %}
+{%- if not group.heading and help_row %}
+{{ help_row }}
 {%- endif %}
 {%- endfor %}
 {%- endif %}{{ mark_args }}{% if not arg_has_ungrouped %}{{ mark_grouped_args }}{% endif %}

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -97,6 +97,8 @@ pub struct SpecCommand {
 /// ancestor merely to put one level of command summaries in presentation order.
 #[derive(Debug, Serialize, Clone)]
 pub struct HelpCommand {
+    /// The word a reader would type here — the leaf name, not the path that reached it.
+    pub name: String,
     pub usage: String,
     pub deprecated: Option<String>,
     pub deprecated_warn_at: Option<String>,
@@ -107,11 +109,18 @@ pub struct HelpCommand {
     pub help_heading: Option<String>,
     pub surface: Option<String>,
     pub available_if: Vec<String>,
+    /// Everything that follows the name, as one string: summary, aliases, deprecation.
+    /// Composed once the page's column is known — see `lay_out_commands`.
+    pub row: Option<String>,
+    pub usage_col_width: usize,
+    pub help_rendered: Option<String>,
+    pub help_is_multiline: bool,
 }
 
 impl From<&SpecCommand> for HelpCommand {
     fn from(cmd: &SpecCommand) -> Self {
         Self {
+            name: cmd.name.clone(),
             usage: cmd.usage.clone(),
             deprecated: cmd.deprecated.clone(),
             deprecated_warn_at: cmd.deprecated_warn_at.clone(),
@@ -122,6 +131,10 @@ impl From<&SpecCommand> for HelpCommand {
             help_heading: cmd.help_heading.clone(),
             surface: cmd.surface.clone(),
             available_if: cmd.available_if.clone(),
+            row: None,
+            usage_col_width: 0,
+            help_rendered: None,
+            help_is_multiline: false,
         }
     }
 }

--- a/lib/tests/parse.rs
+++ b/lib/tests/parse.rs
@@ -171,7 +171,7 @@ cmd_help_short:
     expected=r#"Usage: <SUBCOMMAND>
 
 Commands:
-  cmd  shorthelp
+  cmd   shorthelp
   help  Print this message or the help of the given subcommand(s)
 
 Flags:
@@ -184,13 +184,8 @@ cmd_help_long:
     expected=r#"Usage: <SUBCOMMAND>
 
 Commands:
-  cmd
-    help
-    fooo
-    bar
-
-  help
-    Print this message or the help of the given subcommand(s)
+  cmd   shorthelp
+  help  Print this message or the help of the given subcommand(s)
 
 Flags:
   -h, --help  Print help
@@ -204,8 +199,8 @@ subcommand_help_short:
     expected=r#"Usage: plugins <SUBCOMMAND>
 
 Commands:
-  plugins install  shorthelp
-  help  Print this message or the help of the given subcommand(s)
+  install  shorthelp
+  help     Print this message or the help of the given subcommand(s)
 
 Flags:
   -h, --help  Print help

--- a/usage-dynamic/tests/catalog.rs
+++ b/usage-dynamic/tests/catalog.rs
@@ -208,17 +208,17 @@ fn nested_help_merges_summaries_aliases_headings_and_ordering() {
     for long in [false, true] {
         let help = app.help("plugins", long).unwrap();
         assert!(help.contains("Installed plugins:"), "{help}");
-        assert!(help.contains("plugins formatter"), "{help}");
+        assert!(help.contains("  formatter  Format a project"), "{help}");
         assert!(help.contains("[aliases: fmt]"), "{help}");
         assert!(!help.contains("oldfmt"), "{help}");
         assert!(
-            help.find("plugins audit").unwrap() < help.find("plugins formatter").unwrap(),
+            help.find("  audit").unwrap() < help.find("  formatter").unwrap(),
             "{help}"
         );
     }
     let plugin_help = app.help("plugins formatter", false).unwrap();
     assert!(plugin_help.contains("--color"), "{plugin_help}");
-    assert!(plugin_help.contains("formatter check"), "{plugin_help}");
+    assert!(plugin_help.contains("\n  check"), "{plugin_help}");
     let nested_help = app.help("plugins fmt check", false).unwrap();
     assert!(nested_help.contains("--fix"), "{nested_help}");
 }

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -2448,8 +2448,9 @@ fn explicit_display_order_reaches_help_and_the_portable_spec() {
         flags.find("--first").unwrap() < flags.find("--second").unwrap(),
         "{page}"
     );
+    let commands = page.split_once("\nCommands:\n").unwrap().1;
     assert!(
-        page.find("first  Shown first.").unwrap() < page.find("second  Shown second.").unwrap(),
+        commands.find("  first ").unwrap() < commands.find("  second ").unwrap(),
         "{page}"
     );
     let child = &spec.root.subcommands[0];


### PR DESCRIPTION
## What

`mise -h` was the motivating case: 60 command rows, each carrying its full usage syntax inline, descriptions two spaces after whatever that syntax happened to be, so nothing lined up.

```
  bin-paths [--bin-names] [-J --json] [TOOL@VERSION]…  List all the active runtime bin paths
  bootstrap [FLAGS] <SUBCOMMAND> [aliases: bs]  Set up a machine for the current config in one command
  cache <SUBCOMMAND>  Manage the mise cache
```

`--help` was worse — it inlined every child's complete `long_help`, so the root page ran to hundreds of lines and `bootstrap` alone contributed a 40-line numbered list of its steps.

Both pages now read:

```
Commands:
  bin-paths     List all the active runtime bin paths
  bootstrap     Set up a machine for the current config in one command [aliases: bs]
  cache         Manage the mise cache
  en            Starts a new shell with the mise environment built from the
                current configuration
```

mise's root `--help` goes from hundreds of lines to 136.

## Decisions

- **One column per page**, shared across `help_heading` groups, so a CLI that groups its commands reads as one table with rules through it — the rule the flag list already follows.
- **Same summary on both pages**: `help`, or the first line of `help_long` when a command wrote only that. A parent's list says what each child is *for*; what a child does at length belongs on the child's own page rather than repeated in every ancestor's.
- **Aliases and deprecation trail the summary**, so they wrap with the text instead of pushing every description out of the column.
- **Rows show the leaf name**, not the path that reached them: `mise plugins -h` lists `install` where it listed `plugins install`. This is what clap does.
- **Sorting is untouched** (display order, then rendered usage). The usage line is now only a sort key. Keeping it means this diff is a format change and not also a reordering of 211 pages.

Two things this change settles that were previously pinned as known-wrong:

- The **deprecation label** now trails the description in every renderer. They disagreed before — the Tera template wrote it *before* the description, usage-argv *after* — and the gates only passed because mise has no visible deprecated subcommand.
- The synthetic **`help` row** sits in the column with everything else instead of flush. `corpus/render/03-sections.json` had pinned the old behaviour explicitly "so that fixing it is a decision rather than an accident" — this is the decision.

## Scope

All three renderers move together, as the gates require: usage-lib's Tera templates, usage-argv's hand-rolled pages, and the Go port. usage-argv's and Go's two command sections each converge on one function, since the pages are now identical.

Rendered help changes for every downstream CLI, so adopters with snapshot tests over their help output will see diffs. No API change.

## Verification

- `benches/gate/tests/help.rs` — all 211 mise commands, `-h` and `--help`, byte for byte against the reference: green.
- `benches/gate/tests/fleet.rs` — the seven jdx CLIs plus the external shadows: green.
- `go test ./...` including `go/conformance`, which renders the Rust reference via `xtask help-pages` and compares: green.
- `render-oracle` reports zero divergences; two corpus vectors regenerated from it.
- `mise run ci` green; `mise run render` produces no drift, confirming markdown, manpage, and completion output are untouched.

## Unrelated finding

While running the suite, the `no_unexplained_disagreement` proptest in `benches/gate/tests/differential.rs` found a real parse disagreement on `mise github token --log-level=v --include-global --trace` — usage-argv accepts it, usage-lib refuses, clap reports InvalidChoice. It reproduces on a clean checkout of `109821da`, so it predates this work; I did not commit the regression seed it wrote, and it is not addressed here.

_This PR description was generated by Claude Code._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-visible help text changes for every downstream CLI (snapshots will break). Layout and wrapping logic is shared across three renderers, so a mismatch would be a visible regression, but there is no API or parse-path change.
> 
> **Overview**
> **Command lists on `-h` and `--help` now match:** one aligned column of leaf names, then a short summary. Usage syntax and a child's full `long_help` stay on that child's own page instead of being inlined (or repeated) in every ancestor.
> 
> Aliases and deprecation trail the summary so they wrap with the text. The synthetic `help` row sits in the same column. Sorting is unchanged (display order, then rendered usage as a sort key only).
> 
> All three renderers move together: usage-lib templates, usage-argv (short and long share `commands_section`), and the Go port. Wrapping skips the common already-fits case and is no longer quadratic. Adopters with help snapshots will see diffs; markdown/man/completions are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66f4c13827cf71f899acc976a8e3d86522e90c57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Help pages now display commands in aligned, width-aware rows with concise summaries.
  - Visible aliases and deprecation notices appear consistently alongside command descriptions.
  - Built-in `help` commands are shown when available.
  - Command listings no longer include usage arguments, reducing clutter.
  - Short and long help use consistent summaries, while detailed child-command help remains on the child’s own page.

- **Documentation**
  - Updated help guidance and examples to reflect the streamlined command-list format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
