### PR TITLE
refactor(deps): replace versions with semver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,15 +956,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
@@ -1133,15 +1124,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
-]
-
-[[package]]
-name = "nom"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1653,6 +1635,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 3.0.3",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2300,6 +2288,7 @@ dependencies = [
  "pretty_assertions",
  "regex",
  "roff",
+ "semver",
  "serde",
  "serde_json",
  "shell-words",
@@ -2308,7 +2297,6 @@ dependencies = [
  "tera",
  "thiserror",
  "usage-validation",
- "versions",
 ]
 
 [[package]]
@@ -2355,16 +2343,6 @@ dependencies = [
  "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "versions"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a7e511ce1795821207a837b7b1c8d8aca0c648810966ad200446ae58f6667f"
-dependencies = [
- "itertools 0.14.0",
- "nom",
 ]
 
 [[package]]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -31,12 +31,12 @@ log = "0.4"
 miette = "7"
 regex = "1"
 roff = { version = "1.0", optional = true }
+semver = "1"
 serde = { version = "1", features = ["derive"] }
 shell-words = "1"
 strum = { version = "0.28", features = ["derive"] }
 tera = { version = "2", optional = true }
 thiserror = "2"
-versions = "7"
 # No `xx`: three helpers (a lazy-regex macro, `file::read_to_string`, `check_status`) were
 # worth 21 crates in every dependent's tree — duct, homedir, nix, rand and their libc
 # subtrees — including one that ran in an adopter's build script.

--- a/lib/src/spec/mod.rs
+++ b/lib/src/spec/mod.rs
@@ -884,17 +884,34 @@ fn flag_matches_selector(flag: &SpecFlag, selector: &str) -> bool {
 }
 
 fn check_usage_version(version: &str) {
-    let cur = versions::Versioning::new(env!("CARGO_PKG_VERSION")).unwrap();
-    match versions::Versioning::new(version) {
-        Some(v) => {
+    let cur = semver::Version::parse(env!("CARGO_PKG_VERSION")).unwrap();
+    match parse_usage_version(version) {
+        Ok(v) => {
             if cur < v {
                 warn!(
                     "This usage spec requires at least version {version}, but you are using version {cur} of usage"
                 );
             }
         }
-        _ => warn!("Invalid version: {version}"),
+        Err(_) => warn!("Invalid version: {version}"),
     }
+}
+
+/// Parse the relaxed SemVer spelling accepted by `min_usage_version`.
+///
+/// Specs have historically used versions such as `4.0`, while the SemVer crate correctly
+/// requires all three numeric components. Fill in omitted components before parsing without
+/// accepting any other non-SemVer syntax.
+fn parse_usage_version(version: &str) -> Result<semver::Version, semver::Error> {
+    let core_end = version.find(['-', '+']).unwrap_or(version.len());
+    let (core, suffix) = version.split_at(core_end);
+    let missing = match core.matches('.').count() {
+        0 => ".0.0",
+        1 => ".0",
+        _ => "",
+    };
+
+    semver::Version::parse(&format!("{core}{missing}{suffix}"))
 }
 
 /// Read a file, keeping its path in the error.
@@ -1338,6 +1355,24 @@ pub fn is_false(b: &bool) -> bool {
 mod tests {
     use super::*;
     use insta::assert_snapshot;
+
+    #[test]
+    fn parses_relaxed_usage_versions_as_semver() {
+        assert_eq!(
+            parse_usage_version("6").unwrap(),
+            semver::Version::new(6, 0, 0)
+        );
+        assert_eq!(
+            parse_usage_version("6.1").unwrap(),
+            semver::Version::new(6, 1, 0)
+        );
+        assert_eq!(
+            parse_usage_version("6.1.2-beta.1+build").unwrap(),
+            semver::Version::parse("6.1.2-beta.1+build").unwrap()
+        );
+        assert!(parse_usage_version("not-a-version").is_err());
+        assert!(parse_usage_version("6.1.2.3").is_err());
+    }
 
     #[test]
     fn test_display() {


### PR DESCRIPTION
## Summary

- replace `versions` with the dependency-free `semver` crate
- preserve relaxed `min_usage_version` spellings such as `4.0`
- remove the transitive `nom` and `itertools 0.14` packages

This addresses the dependency feedback on oxc-project/oxc#26027. Oxc already has `semver` in its lockfile, so updating its usage pin removes three packages without adding a replacement package.

## Verification

- `cargo test -p usage-lib --all-features`
- `cargo clippy -p usage-lib --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

_AI-generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency swap and a small version-parse helper used only for a warning. Behavior is intended to stay compatible with existing spec spellings.
> 
> **Overview**
> Replaces the `versions` dependency with `semver` for `min_usage_version` checks. That drops transitive `nom` and `itertools 0.14` from the lockfile.
> 
> `check_usage_version` now parses via `semver::Version`. A small helper fills missing patch/minor components so historical spellings such as `4.0` still work, while other non-SemVer strings stay invalid. Adds unit coverage for those cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d181279894a231e09b777765cd9394533b95207. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->