### PR TITLE
fix(spec): make the two KDL writers agree on three more nodes

### DIFF
--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -1548,6 +1548,20 @@ impl Spec<'_> {
         if let Some(at) = self.root.deprecated_remove_at {
             prop(out, "deprecated_remove_at", at)?;
         }
+        // The text around the page. The root's nodes are written here rather than by
+        // `write_body`, so these had to be repeated — and were not, which left a root's
+        // preamble out of the spec that docs, manpages and completions read. Written in
+        // usage-lib's order, and where usage-lib writes them, so the two documents match.
+        for (node, text) in [
+            ("before_help", self.root.before_help),
+            ("after_help", self.root.after_help),
+            ("before_long_help", self.root.before_long_help),
+            ("after_long_help", self.root.after_long_help),
+        ] {
+            if let Some(text) = text {
+                prop(out, node, text)?;
+            }
+        }
         if let Some(usage) = self.usage {
             prop(out, "usage", usage)?;
         }
@@ -1661,19 +1675,6 @@ impl Spec<'_> {
         // usage CLI, another shell's generator, a doc page — gets a `run=` that works, and this
         // binary answers it without a second program in the way.
 
-        // The text around the page. The root's nodes are written here rather than by
-        // `write_body`, so these had to be repeated — and were not, which left a root's
-        // preamble out of the spec that docs, manpages and completions read.
-        for (node, text) in [
-            ("before_help", self.root.before_help),
-            ("before_long_help", self.root.before_long_help),
-            ("after_help", self.root.after_help),
-            ("after_long_help", self.root.after_long_help),
-        ] {
-            if let Some(text) = text {
-                prop(out, node, text)?;
-            }
-        }
         // The root's own nodes sit at the top level rather than inside a `cmd`
         // block, so they are written here instead of by write_command.
         //
@@ -2057,6 +2058,10 @@ fn write_command<'a>(
     path.push(meta.cmd.name);
     indent(out, depth)?;
     write!(out, "cmd {}", quoted(meta.cmd.name))?;
+    // Before `help`, because usage-lib's writer has it there.
+    if let Some(heading) = meta.help_heading {
+        write!(out, " help_heading={}", quoted(heading))?;
+    }
     if let Some(help) = meta.about {
         write!(out, " help={}", quoted(help))?;
     }
@@ -2071,9 +2076,6 @@ fn write_command<'a>(
     }
     if meta.hide {
         out.push_str(" hide=#true");
-    }
-    if let Some(heading) = meta.help_heading {
-        write!(out, " help_heading={}", quoted(heading))?;
     }
     if let Some(surface) = meta.surface {
         write!(out, " surface={}", quoted(surface))?;
@@ -2224,9 +2226,11 @@ fn write_command<'a>(
 
 fn write_group(out: &mut String, group: &GroupMeta<'_>, depth: usize) -> core::fmt::Result {
     indent(out, depth)?;
-    write!(out, "group {}", quoted(group.name))?;
+    // Node arguments, so a member spelled `--allow` has to be quoted: usage-lib quotes it
+    // for the same reason, and the two documents are compared byte for byte.
+    write!(out, "group {}", quoted_arg(group.name))?;
     for member in group.members {
-        write!(out, " {}", quoted(member))?;
+        write!(out, " {}", quoted_arg(member))?;
     }
     if group.required {
         out.push_str(" required=#true");

--- a/conformance/tests/arg_group.rs
+++ b/conformance/tests/arg_group.rs
@@ -103,7 +103,7 @@ fn a_multiple_argument_group_preserves_cross_flag_order() {
 
     let kdl = OrderedFilters::to_kdl();
     assert!(
-        kdl.contains("group lint-filter --allow --warn --deny multiple=#true"),
+        kdl.contains("group lint-filter \"--allow\" \"--warn\" \"--deny\" multiple=#true"),
         "{kdl}"
     );
 }
@@ -188,7 +188,7 @@ fn a_value_carrying_group_member_reaches_help_and_the_spec() {
         "{kdl}"
     );
     assert!(
-        kdl.contains("group mode --write --check --migrate --stdin-filepath"),
+        kdl.contains("group mode \"--write\" \"--check\" \"--migrate\" \"--stdin-filepath\""),
         "{kdl}"
     );
 }
@@ -318,9 +318,12 @@ fn the_group_reaches_the_emitted_spec_and_usage_lib_agrees() {
     ] {
         assert!(kdl.contains(flag), "{flag} missing from:\n{kdl}");
     }
-    assert!(kdl.contains("group format --json --yaml --plain"), "{kdl}");
     assert!(
-        kdl.contains("group source --stdin --clipboard required=#true"),
+        kdl.contains("group format \"--json\" \"--yaml\" \"--plain\""),
+        "{kdl}"
+    );
+    assert!(
+        kdl.contains("group source \"--stdin\" \"--clipboard\" required=#true"),
         "{kdl}"
     );
 
@@ -404,7 +407,10 @@ fn a_group_works_on_a_subcommand_beside_a_flattened_one() {
     // The subcommand's flags are joined in the order the fields were written: the flattened
     // struct's, then the group's, then this command's own positional.
     let kdl = Nested::to_kdl();
-    assert!(kdl.contains("group format --json --yaml --plain"), "{kdl}");
+    assert!(
+        kdl.contains("group format \"--json\" \"--yaml\" \"--plain\""),
+        "{kdl}"
+    );
 }
 
 /// A sibling flag that names a group member — the relationship lookup Bugbot caught as missing.

--- a/conformance/tests/canonical_kdl.rs
+++ b/conformance/tests/canonical_kdl.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 use usage::Spec;
-use usage_derive::{Args, Cli, Subcommands};
+use usage_derive::{ArgGroup, Args, Cli, Subcommands};
 
 #[derive(Cli)]
 #[usage(
@@ -51,6 +51,98 @@ struct Run {
 #[test]
 fn direct_derive_output_is_the_canonical_portable_serialization() {
     let direct = Ex::to_kdl();
+    let parsed: Spec = direct
+        .parse()
+        .unwrap_or_else(|error| panic!("derived KDL is valid: {error}\n{direct}"));
+    assert_eq!(direct, parsed.to_string());
+}
+
+// A command declaring every node the two writers both emit, at the root and nested, because
+// each disagreement found so far — `example` above the flags, a `heading` before it, an
+// unquoted group member, `help` before `help_heading`, a preamble in the wrong place — was a
+// combination no fixture happened to declare.
+#[derive(Cli)]
+#[usage(
+    name = "maximal",
+    bin = "maximal",
+    version = "1.2.3",
+    unknown_flags = "error",
+    before_help = "before",
+    after_help = "after",
+    before_long_help = "before, at length",
+    after_long_help = "after, at length",
+    example("maximal run build", header = "Run", help = "Runs it"),
+    heading("Output Options", help = "Formats are stable across releases."),
+    output(
+        "json",
+        media_type = "application/json",
+        framing = "json",
+        help = "JSON"
+    ),
+    output("text", default, help = "Text"),
+    exit_code(0, "fine"),
+    exit_code(1, "not fine")
+)]
+struct Maximal {
+    /// Number of jobs to run.
+    #[usage(short, long, global, env = "JOBS", default = "4")]
+    jobs: usize,
+
+    /// Select the output format.
+    #[usage(long, choices("human", "json"), help_heading = "Output Options")]
+    format: Option<String>,
+
+    #[usage(arg_group)]
+    filters: Vec<MaximalFilter>,
+
+    #[usage(subcommand)]
+    command: MaximalCommands,
+}
+
+#[derive(Clone, ArgGroup)]
+#[usage(name = "filter", multiple)]
+enum MaximalFilter {
+    /// Allow it.
+    #[usage(short = 'A', value_name = "NAME")]
+    Allow(String),
+
+    /// Deny it.
+    #[usage(short = 'D', value_name = "NAME")]
+    Deny(String),
+}
+
+#[derive(Subcommands)]
+enum MaximalCommands {
+    /// Run a task.
+    #[usage(alias = "r", help_heading = "Task Commands")]
+    Run(MaximalRun),
+
+    /// Something else.
+    Other(MaximalRun),
+}
+
+#[derive(Args)]
+#[usage(
+    example("maximal run build", header = "Build"),
+    heading(
+        "Task Options",
+        help = "A task name is resolved against the config file."
+    ),
+    output("junit", media_type = "application/xml", help = "JUnit"),
+    exit_code(2, "the task failed")
+)]
+struct MaximalRun {
+    /// Configuration file.
+    #[usage(long, help_heading = "Task Options")]
+    config: Option<String>,
+
+    /// Task name.
+    task: String,
+}
+
+#[test]
+fn every_node_the_two_writers_share_serializes_identically() {
+    let direct = Maximal::to_kdl();
     let parsed: Spec = direct
         .parse()
         .unwrap_or_else(|error| panic!("derived KDL is valid: {error}\n{direct}"));

--- a/conformance/tests/flatten.rs
+++ b/conformance/tests/flatten.rs
@@ -318,7 +318,7 @@ fn a_flattened_structs_group_is_enforced_and_emitted() {
     // spec would describe a CLI without a rule the CLI enforces.
     let kdl = Flattened::to_kdl();
     assert!(
-        kdl.contains("group output --json --yaml required=#true"),
+        kdl.contains("group output \"--json\" \"--yaml\" required=#true"),
         "{kdl}"
     );
     let spec: LibSpec = kdl.parse().expect("the emitted spec should parse");

--- a/conformance/tests/post_binding.rs
+++ b/conformance/tests/post_binding.rs
@@ -798,10 +798,10 @@ fn a_group_that_is_not_required_may_be_left_alone() {
 fn a_group_reaches_the_emitted_spec_and_usage_lib_agrees() {
     let kdl = Grp::to_kdl();
     assert!(
-        kdl.contains("group input --file --url --stdin required=#true"),
+        kdl.contains("group input \"--file\" \"--url\" \"--stdin\" required=#true"),
         "{kdl}"
     );
-    assert!(kdl.contains("group format --json --yaml"), "{kdl}");
+    assert!(kdl.contains("group format \"--json\" \"--yaml\""), "{kdl}");
 
     // The reference implementation reads what the derive wrote, and enforces the same
     // rule — which is the point of the spec being the definition rather than a summary.

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -1903,7 +1903,7 @@ fn positional_relationships_parse_and_emit_losslessly() {
         !kdl.contains("arg \"[VALUE]\" conflicts="),
         "several positional conflicts belong only in the child node: {kdl}"
     );
-    assert!(kdl.contains("group input --from-file VALUE"), "{kdl}");
+    assert!(kdl.contains("group input \"--from-file\" VALUE"), "{kdl}");
 }
 
 #[test]
@@ -2424,7 +2424,7 @@ fn native_groups_and_required_flags_survive_flattening() {
     assert!(FlattenedGroupCli::parse_from(&[OsStr::new("--left"), OsStr::new("--right")]).is_err());
     let kdl = FlattenedGroupCli::to_kdl();
     assert!(
-        kdl.contains("group choice --left --right required=#true"),
+        kdl.contains("group choice \"--left\" \"--right\" required=#true"),
         "{kdl}"
     );
     assert!(matches!(


### PR DESCRIPTION
## Summary

`canonical_kdl` holds the invariant that what usage-argv writes and what usage-lib writes back are the same document. It asserted that about one fixture, and every disagreement found so far has been a combination that fixture did not happen to declare — #1282 moved `example` and `heading` for exactly this reason.

So this declares the rest. Three more writers disagreed:

- **A group's members were not quoted.** They are node arguments, so a member spelled `--allow` has to be. usage-lib quotes it deliberately — `string_entry`'s comment says the bare form "produced specs that failed to reparse, which the argv round-trip tests caught" — and usage-argv already has `quoted_arg` for precisely this, used when writing `select`. `write_group` reached for `quoted` instead, so it wrote `group filter --allow --deny` where usage-lib writes `group filter "--allow" "--deny"`.
- **A `cmd` wrote `help` before `help_heading`.** usage-lib writes them the other way round.
- **The root preamble was in the wrong place, and in the wrong order.** usage-argv wrote `before_help`/`after_help` after `unknown_flags` and `subcommand_required`; usage-lib writes them before. Within the group, usage-argv paired short-then-long (`before_help`, `before_long_help`, `after_help`, `after_long_help`) while usage-lib pairs before-then-after.

All three are pre-existing on `main` and none is reachable from today's fixtures.

## The fixture

The lasting half of this is `every_node_the_two_writers_share_serializes_identically`: one command declaring every node both writers emit — preamble, examples, headings, outputs, exit codes, a multiple argument group, choices, env, defaults, globals — at the root **and** on a subcommand, with an aliased and heading-grouped variant. The next disagreement of this kind fails in CI instead of in review.

## Note on the test changes

Eight assertions across four suites pinned the unquoted group form as a substring of usage-argv's output. They now pin the quoted form. That is the visible half of the first fix rather than a separate decision — usage-lib's spelling is the canonical one, and the emitted spec is what docs, manpages and completions read.

## Validation

- `cargo test --all --all-features`
- `cargo clippy --all --all-features -- -D warnings`
- `cargo fmt --all`, `mise run render` (no generated output moves)

_This PR was written by Claude Code._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Serialization-order and quoting-only changes to emitted KDL, plus tests. Parsing and CLI behavior are unchanged.
> 
> **Overview**
> Makes argv’s KDL emission match usage-lib byte-for-byte on three more nodes so docs, manpages, and completions see the same spec.
> 
> `write_group` now uses `quoted_arg` so dashed members like `--allow` are quoted. `cmd` writes `help_heading` before `help`. Root `before_help` / `after_help` (and long forms) move earlier and into usage-lib’s before-then-after order.
> 
> Adds a maximal `canonical_kdl` fixture covering preamble, groups, headings, outputs, and nested commands so the next writer mismatch fails in CI. Existing group substring assertions pin the quoted form.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb9b02cbf7fa8a4a8744bd3d50077904480896fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->