### PR TITLE
feat(spec): render heading prose in the Go help renderer

### DIFF
--- a/go/argv/help.go
+++ b/go/argv/help.go
@@ -102,6 +102,8 @@ type Help struct {
 	SubcommandRequired    bool
 	// Examples are worked invocations, printed last.
 	Examples []Example
+	// Headings is prose for the sections this command's entries build, by title.
+	Headings []Heading
 }
 
 // HelpTable is the cold help table, indexed by key: entry `Key` sits at

--- a/go/argv/page.go
+++ b/go/argv/page.go
@@ -49,6 +49,14 @@ type HelpSpec struct {
 	HelpTemplate string
 }
 
+// Heading is prose introducing one help section, printed between the heading
+// and its entries. Keyed by title, because a section is assembled from
+// everything that names it rather than owned by any one entry.
+type Heading struct {
+	Title string
+	Help  string
+}
+
 // Example is one worked invocation, as a page prints it.
 type Example struct {
 	Header string
@@ -124,7 +132,7 @@ func ShortHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) s
 	// usage-lib prints the whole path from the root rather than the child's own
 	// name.
 	if meta == nil || !meta.FlattenHelp {
-		commandsSection(&sections.commands, path[min(1, len(path)):], cmd, help)
+		commandsSection(&sections.commands, path[min(1, len(path)):], cmd, help, false)
 	}
 
 	args := visibleArgs(cmd, help, false)
@@ -137,6 +145,7 @@ func ShortHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) s
 	}
 	groupsSection(&sections.args, &sections.ungroupedArgs, &sections.groupedArgs, "Arguments", len(args),
 		func(i int) string { return headingOf(help, args[i].Key) },
+		nil,
 		func(w *strings.Builder, i int) {
 			a := args[i]
 			h := help.Lookup(a.Key)
@@ -200,12 +209,14 @@ func ShortHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) s
 			}
 			return headingOf(help, own[i].key)
 		},
+		nil,
 		func(w *strings.Builder, i int) { flagEntry(w, own[i]) })
 	// After the command's own, and under a heading that says where they came
 	// from: a global belongs to the program, not to this command, and a reader
 	// should be able to see that.
 	groupsSection(&sections.flags, &sections.ungroupedFlags, &sections.groupedFlags, "Global flags", len(inherited),
 		func(int) string { return "" },
+		nil,
 		func(w *strings.Builder, i int) { flagEntry(w, inherited[i]) })
 	if meta != nil && meta.FlattenHelp {
 		flatCommandsShort(&sections.flattened, path[min(1, len(path)):], cmd, help, nextLineHelp)
@@ -237,7 +248,7 @@ const (
 // command takes belongs to that command's own page. Both pages read the same summary: a
 // parent's list says what each child is *for*, and what a child does at length belongs on
 // the child's own page rather than repeated in every ancestor's.
-func commandsSection(out *strings.Builder, path []string, cmd *Command, help HelpTable) {
+func commandsSection(out *strings.Builder, path []string, cmd *Command, help HelpTable, long bool) {
 	type line struct {
 		usage string
 		sub   *Command
@@ -302,6 +313,16 @@ func commandsSection(out *strings.Builder, path []string, cmd *Command, help Hel
 			title = heading
 		}
 		out.WriteString("\n" + title + ":\n")
+		// A `help_heading` on a subcommand builds a section like a flag's does, so it
+		// takes prose on the same terms: the long page only, and only once declared.
+		if long && section != "" {
+			if proseOf := headingProse(help.Lookup(cmd.Key)); proseOf != nil {
+				if prose := proseOf(section); prose != "" {
+					writeIndented(out, prose, 2)
+					out.WriteString("\n")
+				}
+			}
+		}
 		for _, l := range lines {
 			itemSection := headingOf(help, l.sub.Key)
 			if itemSection == heading {
@@ -424,8 +445,11 @@ func flatCommandsShort(out *strings.Builder, path []string, cmd *Command, help H
 
 // groupsSection writes one section per heading, unheaded first, in the order the
 // headings first appear.
+// proseOf, where a caller supplies one, is the prose introducing a section. Only a
+// declared heading takes it: the default title names the entries that asked for no
+// section, and the same entries appear under a different default per renderer.
 func groupsSection(out, ungrouped, grouped *strings.Builder, defaultTitle string, n int,
-	headingOf func(int) string, writeItem func(*strings.Builder, int)) {
+	headingOf func(int) string, proseOf func(string) string, writeItem func(*strings.Builder, int)) {
 
 	if n == 0 {
 		return
@@ -451,6 +475,12 @@ func groupsSection(out, ungrouped, grouped *strings.Builder, defaultTitle string
 			title = defaultTitle
 		}
 		section.WriteString("\n" + title + ":\n")
+		if heading != "" && proseOf != nil {
+			if prose := proseOf(heading); prose != "" {
+				writeIndented(&section, prose, 2)
+				section.WriteString("\n")
+			}
+		}
 		for i := 0; i < n; i++ {
 			if headingOf(i) == heading {
 				writeItem(&section, i)

--- a/go/argv/page_long.go
+++ b/go/argv/page_long.go
@@ -76,7 +76,7 @@ func LongHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) st
 	}
 
 	if meta == nil || !meta.FlattenHelp {
-		commandsSection(&sections.commands, path[min(1, len(path)):], cmd, help)
+		commandsSection(&sections.commands, path[min(1, len(path)):], cmd, help, true)
 	}
 
 	// One column width per section, over its visible entries — separately, so a
@@ -90,6 +90,7 @@ func LongHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) st
 	}
 	groupsSection(&sections.args, &sections.ungroupedArgs, &sections.groupedArgs, "Arguments", len(args),
 		func(i int) string { return headingOf(help, args[i].Key) },
+		headingProse(meta),
 		func(w *strings.Builder, i int) {
 			h := help.Lookup(args[i].Key)
 			entry(w, argUsage(args[i], h), firstOf(metaField(h, func(x *Help) string { return x.Long }),
@@ -126,12 +127,14 @@ func LongHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) st
 			}
 			return headingOf(help, own[i].key)
 		},
+		headingProse(meta),
 		func(w *strings.Builder, i int) { writeFlag(w, own[i]) })
 	// Not grouped by heading: an ancestor's headings describe that command's page,
 	// and borrowing them here would put a section title on flags that are only
 	// visiting.
 	groupsSection(&sections.flags, &sections.ungroupedFlags, &sections.groupedFlags, "Global flags", len(inherited),
 		func(int) string { return "" },
+		nil,
 		func(w *strings.Builder, i int) { writeFlag(w, inherited[i]) })
 	if meta != nil && meta.FlattenHelp {
 		flatCommandsLong(&sections.flattened, path[min(1, len(path)):], cmd, help, nextLineHelp)
@@ -323,6 +326,22 @@ func longAnnotations(out *strings.Builder, h *Help, withDefault bool) {
 // an indented empty line is trailing whitespace, which the reference does not
 // emit. Indenting them instead differs on every page, which is how this was
 // settled rather than by reading the template.
+// headingProse is the prose a command declares for one of its section titles.
+// Nil where it declares none, so a caller pays nothing for the common case.
+func headingProse(meta *Help) func(string) string {
+	if meta == nil || len(meta.Headings) == 0 {
+		return nil
+	}
+	return func(title string) string {
+		for _, heading := range meta.Headings {
+			if heading.Title == title {
+				return heading.Help
+			}
+		}
+		return ""
+	}
+}
+
 func writeIndented(out *strings.Builder, text string, by int) {
 	prefix := strings.Repeat(" ", by)
 	for i, line := range strings.Split(text, "\n") {

--- a/go/argv/page_test.go
+++ b/go/argv/page_test.go
@@ -420,3 +420,63 @@ func TestAllHelpWalksVisibleDescendants(t *testing.T) {
 		t.Fatalf("explicit display order followed unordered commands:\n%s", page)
 	}
 }
+
+func TestHeadingProse(t *testing.T) {
+	root := &Command{
+		Name: "ex",
+		Key:  1,
+		Flags: []*Flag{
+			{Name: "allow", Longs: []string{"allow"}, Shorts: []byte{'A'}, Key: 2},
+			{Name: "quiet", Longs: []string{"quiet"}, Key: 3},
+		},
+	}
+	help := HelpTable{
+		{Key: 1, Headings: []Heading{
+			{Title: "Filters", Help: "Filters accumulate from left to right.\nFor example: `-A no-debugger`."},
+			{Title: "Flags", Help: "Should not appear: the default title is not a declared heading."},
+		}},
+		{Key: 2, Short: "allow a rule", Heading: "Filters"},
+		{Key: 3, Short: "say less"},
+	}
+
+	long := LongHelp(HelpSpec{Bin: "ex"}, []string{"ex"}, []*Command{root}, help)
+	want := "\nFilters:\n  Filters accumulate from left to right.\n  For example: `-A no-debugger`.\n\n"
+	if !strings.Contains(long, want) {
+		t.Fatalf("prose does not introduce its section:\n%s", long)
+	}
+	// Within the section, not the usage line above it: the prose opens the block and the
+	// entries still follow.
+	section := long[strings.Index(long, "\nFilters:\n"):]
+	if i, j := strings.Index(section, "For example"), strings.Index(section, "--allow"); j < i {
+		t.Fatalf("prose replaced the section instead of introducing it:\n%s", long)
+	}
+	// The default title names the entries that asked for no section, and it is not one
+	// title — the same flags read as `Flags` here and as `Global Flags` elsewhere.
+	if strings.Contains(long, "Should not appear") {
+		t.Fatalf("an undeclared default title took prose:\n%s", long)
+	}
+
+	// A summary stays a summary, as it does for admonitions.
+	short := ShortHelp(HelpSpec{Bin: "ex"}, []string{"ex"}, []*Command{root}, help)
+	if strings.Contains(short, "accumulate from left to right") {
+		t.Fatalf("prose reached the short page:\n%s", short)
+	}
+}
+
+func TestSubcommandHeadingProse(t *testing.T) {
+	compile := &Command{Name: "compile", Key: 2}
+	root := &Command{Name: "ex", Key: 1, Subcommands: []*Command{compile}}
+	help := HelpTable{
+		{Key: 1, Headings: []Heading{{Title: "Build Commands", Help: "These write to the target directory."}}},
+		{Key: 2, Short: "compile it", Heading: "Build Commands"},
+	}
+
+	long := LongHelp(HelpSpec{Bin: "ex"}, []string{"ex"}, []*Command{root}, help)
+	if !strings.Contains(long, "\nBuild Commands:\n  These write to the target directory.\n\n") {
+		t.Fatalf("a subcommand heading took no prose:\n%s", long)
+	}
+	short := ShortHelp(HelpSpec{Bin: "ex"}, []string{"ex"}, []*Command{root}, help)
+	if strings.Contains(short, "These write to") {
+		t.Fatalf("prose reached the short page:\n%s", short)
+	}
+}

--- a/go/internal/spec/spec.go
+++ b/go/internal/spec/spec.go
@@ -106,6 +106,7 @@ type Cmd struct {
 	BeforeHelpLong              string      `json:"before_help_long"`
 	AfterHelpLong               string      `json:"after_help_long"`
 	Examples                    []Example   `json:"examples"`
+	Headings                    []Heading   `json:"headings"`
 	Aliases                     []string    `json:"aliases"`
 	HiddenAliases               []string    `json:"hidden_aliases"`
 	Subcommands                 Subcommands `json:"subcommands"`
@@ -395,6 +396,12 @@ type Example struct {
 	Header string `json:"header"`
 	Code   string `json:"code"`
 	Help   string `json:"help"`
+}
+
+// Heading is prose introducing one help section, named by the heading it opens.
+type Heading struct {
+	Title string `json:"title"`
+	Help  string `json:"help"`
 }
 
 // Choices is the declared set of values, which the lowering nests one level.
@@ -698,6 +705,10 @@ func (b *builder) command(c *Cmd, inherited argv.UnknownFlags) *argv.Command {
 	for _, e := range c.Examples {
 		examples = append(examples, argv.Example{Header: e.Header, Code: e.Code, Help: e.Help})
 	}
+	headings := make([]argv.Heading, 0, len(c.Headings))
+	for _, h := range c.Headings {
+		headings = append(headings, argv.Heading{Title: h.Title, Help: h.Help})
+	}
 	commandHelp := argv.Help{
 		Hide:    c.Hide,
 		Heading: c.HelpHeading,
@@ -725,6 +736,7 @@ func (b *builder) command(c *Cmd, inherited argv.UnknownFlags) *argv.Command {
 		FlattenHelp:           c.FlattenHelp,
 		SubcommandRequired:    c.SubcommandRequired,
 		Examples:              examples,
+		Headings:              headings,
 	}
 	if c.DisplayOrder != nil {
 		commandHelp.DisplayOrder = *c.DisplayOrder

--- a/lib/src/go/mod.rs
+++ b/lib/src/go/mod.rs
@@ -1128,6 +1128,25 @@ fn command_help(e: &Emitted) -> String {
             .join(", ");
         fields.push(format!("Examples: []argv.Example{{{items}}}"));
     }
+    // The prose introducing each help section. Lowered from a spec it travels with the
+    // rest of the help metadata, and a generated CLI that dropped it printed the heading
+    // with nothing under it while every other reader of the same spec showed the text.
+    if !e.cmd.headings.is_empty() {
+        let items = e
+            .cmd
+            .headings
+            .iter()
+            .map(|heading| {
+                format!(
+                    "{{Title: {}, Help: {}}}",
+                    go_string(&heading.title),
+                    go_string(&heading.help)
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        fields.push(format!("Headings: []argv.Heading{{{items}}}"));
+    }
     format!("{{{}}}", fields.join(", "))
 }
 
@@ -1944,6 +1963,31 @@ cmd "run" help="Run it" {
         assert!(
             run.contains(r#"{Code: "ex run"}"#),
             "an example with no header emits no header: {run}"
+        );
+    }
+
+    /// A section's prose reaches the tables.
+    ///
+    /// It is lowered from a spec the same way, so the two producers only agree
+    /// if the emitter writes it too — and mise declares no `heading`, so the
+    /// producer comparison over its spec cannot see this either.
+    #[test]
+    fn heading_prose_reaches_the_tables() {
+        let out = go(r#"
+name "ex"
+bin "ex"
+cmd "run" help="Run it" {
+    heading "Filters" help="Filters accumulate from left to right."
+    flag "--allow <NAME>" help="Allow it" help_heading="Filters"
+}
+"#);
+        let run = out
+            .lines()
+            .find(|l| l.contains("Headings: []argv.Heading"))
+            .expect("the command's headings are emitted");
+        assert!(
+            run.contains(r#"{Title: "Filters", Help: "Filters accumulate from left to right."}"#),
+            "both fields are emitted: {run}"
         );
     }
 


### PR DESCRIPTION
## Summary

#1282 added prose introducing a help section and deferred the Go renderer to a follow-up. This is that follow-up. Until now Go ignored the new `headings` field and printed the heading alone, so the same spec produced two different pages depending on which renderer drew it — the one thing the two are not allowed to do.

- `Heading` joins `Example` on the command's help metadata, lowered from the same `headings` the emitter writes to the spec.
- `groupsSection` takes a prose lookup, supplied on the long page and nil on the short one, matching the Rust renderer's decision to keep a summary a summary.
- `commandsSection` takes the `long` flag its Rust counterpart already has, so a section built by a subcommand's `help_heading` reads the same on both.
- **`usage generate go` now writes the field too.** It did not, so a generated CLI would have printed the heading alone while every other reader of the same spec showed the text. `TestTheTwoProducersAgree` exists to hold the lowering and generated paths together, but it runs over mise's spec, and mise declares no `heading`.
- Only a declared heading takes prose, as in Rust: the default `Flags` and `Arguments` titles name the entries that asked for no section of their own, and those same entries read under a different default title depending on the renderer.

## On verification

Worth being explicit, because the usual guarantee does not reach this feature. The cross-language page harness compares Go against the reference over mise's 211 pages, and mise declares no headings — so it proves this change breaks nothing, not that the new output matches. `corpus/render`, where the Rust side pins these bytes, has no Go reader.

So the prose itself is covered by unit tests asserting the same byte shape the Rust tests assert (`"\nFilters:\n  …\n\n"`), including that the short page omits it and that an undeclared default title takes none, plus a table test for the emitter.

**Wiring Go into `corpus/render` would cover this and every render feature after it by construction.** That is the real fix for the gap and is worth doing next; it is a larger change than this one and did not belong in it.

## Validation

- `go test ./...` — argv, conformance (corpus, producer comparison, the 211-page mise parity tests), spec, shadow
- `cargo test --all --all-features`, `cargo clippy --all --all-features -- -D warnings`
- `go vet ./...`, `gofmt`, `cargo fmt --all`

_This PR was written by Claude Code._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-facing help layout and generated table emission; a mismatch would show different pages per renderer, though this is presentation-only and covered by unit tests.
> 
> **Overview**
> The Go help renderer now prints **section prose** from a command’s `headings` metadata, matching the Rust renderer so the same spec no longer drops that text on generated CLIs.
> 
> On `--help`, declared section titles (flags, args, and subcommand `help_heading` groups) get indented intro text between the title and entries. `-h` stays a summary: prose is omitted. Default titles like `Flags` / `Arguments` never take prose, because those names are renderer-specific, not declared headings.
> 
> `Heading` is lowered from the spec JSON and emitted into generated Go tables alongside examples. Unit tests pin the long-page byte shape and that short help and undeclared defaults stay clean.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52bb9f7cc8c83c9b585a806dbe20d03ee073e8fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->