### PR TITLE
feat(help): align long-help annotations to the description column

### DIFF
--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -26,6 +26,9 @@ use crate::spec::{
 use crate::Command;
 use crate::DoubleDash;
 
+/// The indent a page uses where it cannot align to its column.
+const BLOCK_INDENT: usize = 4;
+
 /// How many flags or arguments are listed individually before collapsing to a placeholder.
 ///
 /// usage-lib's number. Beyond it the line would be longer than it is useful, so it becomes
@@ -1196,6 +1199,7 @@ fn short_sections(
                     if a.hide_env { &[] } else { a.env_fallback },
                     if a.hide_env { &[] } else { a.deprecated_env },
                     if a.hide_default_value { &[] } else { a.default },
+                    BLOCK_INDENT,
                 );
                 return;
             }
@@ -1247,8 +1251,9 @@ fn short_sections(
                 if f.hide_env { &[] } else { f.env_fallback },
                 if f.hide_env { &[] } else { f.deprecated_env },
                 if f.hide_default_value { &[] } else { f.default },
+                BLOCK_INDENT,
             );
-            flag_notes(out, f, 4);
+            flag_notes(out, f, BLOCK_INDENT);
             return;
         }
         let deprecation =
@@ -1527,6 +1532,7 @@ fn flat_commands_short(out: &mut String, path: &[&str], meta: &CommandMeta<'_>) 
                     } else {
                         arg.default
                     },
+                    BLOCK_INDENT,
                 );
                 continue;
             }
@@ -1584,8 +1590,9 @@ fn flat_commands_short(out: &mut String, path: &[&str], meta: &CommandMeta<'_>) 
                     } else {
                         flag.default
                     },
+                    BLOCK_INDENT,
                 );
-                flag_notes(out, flag, 4);
+                flag_notes(out, flag, BLOCK_INDENT);
                 continue;
             }
             if let Some(help) = flag.help.filter(|help| !help.trim().is_empty()) {
@@ -2102,7 +2109,7 @@ fn long_sections(
         |title| heading_help(meta, title),
         |out, a| {
             let text = a.long_help.or(a.help);
-            entry(
+            let indent = entry(
                 out,
                 &arg_usage(a),
                 text,
@@ -2122,6 +2129,7 @@ fn long_sections(
                 if a.hide_env { &[] } else { a.env_fallback },
                 if a.hide_env { &[] } else { a.deprecated_env },
                 if a.hide_default_value { &[] } else { a.default },
+                indent,
             );
         },
     );
@@ -2146,7 +2154,7 @@ fn long_sections(
         |title| heading_help(meta, title),
         |out, f| {
             let text = f.long_help.or(f.help);
-            entry(
+            let indent = entry(
                 out,
                 &column_usage(f),
                 text,
@@ -2166,8 +2174,9 @@ fn long_sections(
                 if f.hide_env { &[] } else { f.env_fallback },
                 if f.hide_env { &[] } else { f.deprecated_env },
                 if f.hide_default_value { &[] } else { f.default },
+                indent,
             );
-            flag_notes(out, f, 4);
+            flag_notes(out, f, indent);
         },
     );
     // After the command's own, and under a heading that says where they came from: `--config`
@@ -2186,7 +2195,7 @@ fn long_sections(
         |_| None,
         |out, (f, usage)| {
             let text = f.long_help.or(f.help);
-            entry(out, usage, text, flag_col, width, meta.next_line_help);
+            let indent = entry(out, usage, text, flag_col, width, meta.next_line_help);
             admonitions(out, f.admonitions);
             long_annotations(
                 out,
@@ -2199,8 +2208,9 @@ fn long_sections(
                 if f.hide_env { &[] } else { f.env_fallback },
                 if f.hide_env { &[] } else { f.deprecated_env },
                 if f.hide_default_value { &[] } else { f.default },
+                indent,
             );
-            flag_notes(out, f, 4);
+            flag_notes(out, f, indent);
         },
     );
     if meta.flatten_help {
@@ -2290,20 +2300,24 @@ fn entry(
     col: usize,
     width: usize,
     next_line: bool,
-) {
-    let Some(help) = help.filter(|h| !h.trim().is_empty()) else {
-        let _ = writeln!(out, "  {usage}");
-        return;
-    };
-
+) -> usize {
     // The column layout only works for text that has not been broken already, and only when
     // there is room left for it to say anything.
     let indent = 2 + col + 2;
     let room = width.saturating_sub(indent);
-    if next_line || help.contains('\n') || room < 10 {
+    // Whether anything on this page reaches the column at all.
+    let block = next_line || room < 10;
+    let Some(help) = help.filter(|h| !h.trim().is_empty()) else {
         let _ = writeln!(out, "  {usage}");
-        write_indented(out, help, 4);
-        return;
+        // An entry with nothing in the column still has annotations to place, and the column is
+        // where they go: it is this entry's row that is empty, not the table's.
+        return if block { BLOCK_INDENT } else { indent };
+    };
+
+    if block || help.contains('\n') {
+        let _ = writeln!(out, "  {usage}");
+        write_indented(out, help, BLOCK_INDENT);
+        return BLOCK_INDENT;
     }
 
     // Text that already fits is text `wrap` would hand straight back, so skip it and the two
@@ -2321,7 +2335,7 @@ fn entry(
         out.push_str("  ");
         out.push_str(help);
         out.push('\n');
-        return;
+        return indent;
     }
 
     let lines = wrap(help, room);
@@ -2332,6 +2346,7 @@ fn entry(
     // No blank line after a wrapped entry. The reference's template asks for one, and its
     // whitespace trimming eats it before it reaches the output — so a wrapped entry is followed
     // directly by the next, and matching means matching that.
+    indent
 }
 
 /// Whether [`wrap`] would return this text unchanged as a single line.
@@ -2403,6 +2418,11 @@ fn wrap(text: &str, width: usize) -> Vec<String> {
 }
 
 /// The annotations, each on its own line as the wider layout puts them.
+///
+/// `indent` is where the entry above them ended up: the description column when the
+/// description reached it, and [`BLOCK_INDENT`] when it did not. An annotation is a note about
+/// the same entry, so it belongs under the text it qualifies rather than in the gutter beside a
+/// column it is ignoring.
 fn long_annotations(
     out: &mut String,
     choices: &[&str],
@@ -2410,16 +2430,28 @@ fn long_annotations(
     env_fallback: &[&str],
     deprecated_env: &[&str],
     default: &[&str],
+    indent: usize,
 ) {
+    // Most entries annotate nothing, and this is called for every one of them — so the indent
+    // is not built until there is a line to put it on.
+    if choices.is_empty()
+        && env.is_none()
+        && env_fallback.is_empty()
+        && deprecated_env.is_empty()
+        && default.is_empty()
+    {
+        return;
+    }
+    let pad = " ".repeat(indent);
     if !choices.is_empty() {
-        let _ = writeln!(out, "    [possible values: {}]", choices.join(", "));
+        let _ = writeln!(out, "{pad}[possible values: {}]", choices.join(", "));
     }
     if let Some(env) = env {
-        let _ = writeln!(out, "    [env: {env}]");
+        let _ = writeln!(out, "{pad}[env: {env}]");
     }
-    environment_notes(out, env_fallback, deprecated_env, 4);
+    environment_notes(out, env_fallback, deprecated_env, indent);
     if !default.is_empty() {
-        let _ = writeln!(out, "    (default: {})", default.join(", "));
+        let _ = writeln!(out, "{pad}(default: {})", default.join(", "));
     }
 }
 
@@ -2568,6 +2600,7 @@ fn flat_commands_long(out: &mut String, path: &[&str], meta: &CommandMeta<'_>, w
                 } else {
                     arg.default
                 },
+                BLOCK_INDENT,
             );
         }
         for flag in flags {
@@ -2603,8 +2636,9 @@ fn flat_commands_long(out: &mut String, path: &[&str], meta: &CommandMeta<'_>, w
                 } else {
                     flag.default
                 },
+                BLOCK_INDENT,
             );
-            flag_notes(out, flag, 4);
+            flag_notes(out, flag, BLOCK_INDENT);
         }
         if sub.flatten_help {
             flat_commands_long(out, &sub_path, sub, width);

--- a/corpus/render/03-sections.json
+++ b/corpus/render/03-sections.json
@@ -40,7 +40,7 @@
     },
     {
       "id": "annotations-on-one-line-and-on-their-own",
-      "doc": "Choices, environment and default are bracketed after an entry's help in the short form and each get a line in the long form. The two layouts differ in more than width, which is why both are pinned here.",
+      "doc": "Choices, environment and default are bracketed after an entry's help in the short form and each get a line of their own in the long form, indented to the description column so the section stays one grid. The two layouts differ in more than width, which is why both are pinned here.",
       "spec": "name \"ex\"\nbin \"ex\"\nabout \"An example\"\nflag \"--shell <SHELL>\" help=\"Which shell\" env=\"EX_SHELL\" {\n    arg \"<SHELL>\" default=\"bash\" {\n        choices \"bash\" \"zsh\"\n    }\n}\narg \"[file]\" help=\"Where to write\" default=\"-\"\n",
       "expect": {
         "usage": "ex [--shell [SHELL]] [file]",
@@ -63,12 +63,12 @@
           "",
           "Arguments:",
           "  [file]  Where to write",
-          "    (default: -)",
+          "          (default: -)",
           "",
           "Flags:",
           "      --shell [SHELL]  Which shell",
-          "    [possible values: bash, zsh]",
-          "    [env: EX_SHELL]",
+          "                       [possible values: bash, zsh]",
+          "                       [env: EX_SHELL]",
           "  -h, --help           Print help"
         ]
       }

--- a/docs/go/help.md
+++ b/docs/go/help.md
@@ -46,9 +46,12 @@ Both pages list a command's children identically: the name, then the summary —
 first line of `long_help` when there is no `help`. A child's full `long_help` appears on the
 child's own page, not repeated in every ancestor's list.
 
-The short page appends `[choices]`, `[env: X]`, and (for arguments) `(default: …)` inline; the
-long page gives each its own line and prefers `long_help` over `help` for the command's own
-description. Examples declared on the root are inherited by commands that declare none.
+The short page appends `[choices]`, `[env: X]`, and (for arguments) `(default: …)` to the
+description, wrapping with it; the long page gives each its own line, indented to the description
+column so the section stays one grid, and prefers `long_help` over `help` for the command's own
+description. Where a description is already a block under its usage — a `next_line_help` page, or
+one whose text has breaks of its own — the annotations join it there. Examples declared on the
+root are inherited by commands that declare none.
 
 One rule is load-bearing: a page only advertises a flag spelling where that flag is the one that
 would _bind_ it. Masking is per spelling — a subcommand redeclaring `--jobs` leaves an inherited

--- a/go/argv/page.go
+++ b/go/argv/page.go
@@ -146,7 +146,7 @@ func ShortHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) s
 				if text := helpText(h); text != "" {
 					writeIndented(w, text, 4)
 				}
-				longAnnotations(w, h, true)
+				longAnnotations(w, h, true, blockIndent)
 				return
 			}
 			entry(w, usage, withAnnotations(shortSummary(h), inlineAnnotations(h, true, false)), argCol, false)
@@ -188,7 +188,7 @@ func ShortHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) s
 			if text := metaField(h, func(x *Help) string { return x.Short }); text != "" {
 				writeIndented(w, text, 4)
 			}
-			longAnnotations(w, h, true)
+			longAnnotations(w, h, true, blockIndent)
 			return
 		}
 		entry(w, f.usage, withAnnotations(shortSummary(h), inlineAnnotations(h, true, true)), flagCol, false)
@@ -387,7 +387,7 @@ func flatCommandsShort(out *strings.Builder, path []string, cmd *Command, help H
 				if text := metaField(ah, func(x *Help) string { return x.Short }); text != "" {
 					writeIndented(out, text, 4)
 				}
-				longAnnotations(out, ah, true)
+				longAnnotations(out, ah, true, blockIndent)
 			} else {
 				if text := helpText(ah); text != "" {
 					out.WriteString("  " + pad(usage, argCol) + "  " + text)
@@ -405,7 +405,7 @@ func flatCommandsShort(out *strings.Builder, path []string, cmd *Command, help H
 				if text := metaField(fh, func(x *Help) string { return x.Short }); text != "" {
 					writeIndented(out, text, 4)
 				}
-				longAnnotations(out, fh, true)
+				longAnnotations(out, fh, true, blockIndent)
 			} else {
 				if text := helpText(fh); text != "" {
 					out.WriteString("  " + pad(usage, flagCol) + "  " + text)

--- a/go/argv/page_long.go
+++ b/go/argv/page_long.go
@@ -20,6 +20,9 @@ import (
 // so 80 is what both sides use and what keeps the two comparable.
 const helpWidth = 80
 
+// blockIndent is what a page uses where it cannot align to its column.
+const blockIndent = 4
+
 // LongHelp renders what `--help` prints for the command at the end of `chain`.
 func LongHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) string {
 	if len(chain) == 0 {
@@ -92,9 +95,9 @@ func LongHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) st
 		func(i int) string { return headingOf(help, args[i].Key) },
 		func(w *strings.Builder, i int) {
 			h := help.Lookup(args[i].Key)
-			entry(w, argUsage(args[i], h), firstOf(metaField(h, func(x *Help) string { return x.Long }),
+			indent := entry(w, argUsage(args[i], h), firstOf(metaField(h, func(x *Help) string { return x.Long }),
 				metaField(h, func(x *Help) string { return x.Short })), argCol, nextLineHelp)
-			longAnnotations(w, h, true)
+			longAnnotations(w, h, true, indent)
 		})
 
 	own, inherited := ownAndGlobal(chain, help)
@@ -115,9 +118,9 @@ func LongHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) st
 			return
 		}
 		h := help.Lookup(f.key)
-		entry(w, f.usage, firstOf(metaField(h, func(x *Help) string { return x.Long }),
+		indent := entry(w, f.usage, firstOf(metaField(h, func(x *Help) string { return x.Long }),
 			metaField(h, func(x *Help) string { return x.Short })), flagCol, nextLineHelp)
-		longAnnotations(w, h, true)
+		longAnnotations(w, h, true, indent)
 	}
 	groupsSection(&sections.flags, &sections.ungroupedFlags, &sections.groupedFlags, "Flags", len(own),
 		func(i int) string {
@@ -245,14 +248,14 @@ func flatCommandsLong(out *strings.Builder, path []string, cmd *Command, help He
 			ah := help.Lookup(a.Key)
 			entry(out, argUsage(a, ah), firstOf(metaField(ah, func(x *Help) string { return x.Long }),
 				metaField(ah, func(x *Help) string { return x.Short })), argCol, nextLine)
-			longAnnotations(out, ah, true)
+			longAnnotations(out, ah, true, blockIndent)
 		}
 		for _, f := range flags {
 			fh := help.Lookup(f.Key)
 			entry(out, columnUsage(f, allShown(f), help), firstOf(
 				metaField(fh, func(x *Help) string { return x.Long }),
 				metaField(fh, func(x *Help) string { return x.Short })), flagCol, nextLine)
-			longAnnotations(out, fh, true)
+			longAnnotations(out, fh, true, blockIndent)
 		}
 		if h != nil && h.FlattenHelp {
 			flatCommandsLong(out, subPath, sub, help, h.NextLineHelp)
@@ -263,12 +266,9 @@ func flatCommandsLong(out *strings.Builder, path []string, cmd *Command, help He
 
 // entry writes one flag or argument: its help in a column beside it, wrapped — or
 // indented underneath, where the text has line breaks of its own.
-func entry(out *strings.Builder, usage, help string, col int, nextLine bool) {
-	if strings.TrimSpace(help) == "" {
-		out.WriteString("  " + usage + "\n")
-		return
-	}
-
+// entry writes one flag or argument and returns the indent its annotations should take:
+// the description column when the description reached it, and blockIndent when it did not.
+func entry(out *strings.Builder, usage, help string, col int, nextLine bool) int {
 	// The column layout only works for text that has not been broken already, and
 	// only when there is room left for it to say anything.
 	indent := 2 + col + 2
@@ -276,10 +276,22 @@ func entry(out *strings.Builder, usage, help string, col int, nextLine bool) {
 	if room < 0 {
 		room = 0
 	}
-	if nextLine || strings.Contains(help, "\n") || room < 10 {
+	// Whether anything on this page reaches the column at all.
+	block := nextLine || room < 10
+	if strings.TrimSpace(help) == "" {
 		out.WriteString("  " + usage + "\n")
-		writeIndented(out, help, 4)
-		return
+		// An entry with nothing in the column still has annotations to place, and the
+		// column is where they go: it is this entry's row that is empty, not the table's.
+		if block {
+			return blockIndent
+		}
+		return indent
+	}
+
+	if block || strings.Contains(help, "\n") {
+		out.WriteString("  " + usage + "\n")
+		writeIndented(out, help, blockIndent)
+		return blockIndent
 	}
 
 	lines := wrap(help, room)
@@ -289,33 +301,39 @@ func entry(out *strings.Builder, usage, help string, col int, nextLine bool) {
 	}
 	// No blank line after a wrapped entry: the reference's template asks for one
 	// and its whitespace trimming eats it before it reaches the output.
+	return indent
 }
 
 // longAnnotations gives each annotation its own line, which is the room the wide
 // layout has and the short one does not.
-func longAnnotations(out *strings.Builder, h *Help, withDefault bool) {
+// longAnnotations gives each annotation its own line, indented to where the entry above
+// them ended up: the description column when the description reached it, and blockIndent
+// when it did not. An annotation is a note about the same entry, so it belongs under the
+// text it qualifies rather than in the gutter beside a column it is ignoring.
+func longAnnotations(out *strings.Builder, h *Help, withDefault bool, indent int) {
 	if h == nil {
 		return
 	}
+	pad := strings.Repeat(" ", indent)
 	if !h.HidePossibleValues && len(h.Choices) > 0 {
-		out.WriteString("    [possible values: " + strings.Join(h.Choices, ", ") + "]\n")
+		out.WriteString(pad + "[possible values: " + strings.Join(h.Choices, ", ") + "]\n")
 	}
 	if !h.HideEnv && h.Env != "" {
-		out.WriteString("    [env: " + h.Env + "]\n")
+		out.WriteString(pad + "[env: " + h.Env + "]\n")
 	}
 	if !h.HideEnv {
 		for _, env := range h.EnvFallback {
-			out.WriteString("    [env fallback: " + env + "]\n")
+			out.WriteString(pad + "[env fallback: " + env + "]\n")
 		}
 		for _, env := range h.DeprecatedEnv {
-			out.WriteString("    [deprecated env: " + env + "]\n")
+			out.WriteString(pad + "[deprecated env: " + env + "]\n")
 		}
 	}
 	if withDefault && !h.HideDefaultValue && len(h.Default) > 0 {
-		out.WriteString("    (default: " + strings.Join(h.Default, ", ") + ")\n")
+		out.WriteString(pad + "(default: " + strings.Join(h.Default, ", ") + ")\n")
 	}
 	if label := deprecationLabel(h); label != "" {
-		out.WriteString("    " + label + "\n")
+		out.WriteString(pad + label + "\n")
 	}
 }
 

--- a/lib/src/docs/cli/mod.rs
+++ b/lib/src/docs/cli/mod.rs
@@ -67,10 +67,16 @@ pub fn render_help(spec: &Spec, cmd: &SpecCommand, long: bool) -> String {
             .chain(inherited.iter())
             .map(|f| f.display_usage.as_str()),
     );
+    let flag_column = Column {
+        width,
+        col,
+        long,
+        next_line: cmd.next_line_help,
+    };
     for group in &mut docs_cmd.flag_groups {
-        lay_out(&mut group.items, width, col, long);
+        lay_out(&mut group.items, flag_column);
     }
-    lay_out(&mut inherited, width, col, long);
+    lay_out(&mut inherited, flag_column);
 
     // The arguments get their own column, laid out here for the page being rendered rather than
     // taken from the model's — which is the long page's, and would put a long description in the
@@ -78,7 +84,15 @@ pub fn render_help(spec: &Spec, cmd: &SpecCommand, long: bool) -> String {
     let arg_col =
         crate::docs::layout::max_usage_width(docs_cmd.args.iter().map(|a| a.usage.as_str()));
     for group in &mut docs_cmd.arg_groups {
-        lay_out_args(&mut group.items, width, arg_col, long);
+        lay_out_args(
+            &mut group.items,
+            Column {
+                width,
+                col: arg_col,
+                long,
+                next_line: cmd.next_line_help,
+            },
+        );
     }
 
     // The command list, laid out the way the flag list is: one column for the whole page, the
@@ -368,15 +382,10 @@ fn supplied_flags(
 /// command's own flags and the ones it inherits. The width is not only padding — a wrapped
 /// description is indented to sit under itself — so it cannot be decided per section and then
 /// shared.
-fn lay_out(
-    flags: &mut [crate::docs::models::SpecFlag],
-    terminal_width: usize,
-    col: usize,
-    long: bool,
-) {
+fn lay_out(flags: &mut [crate::docs::models::SpecFlag], column: Column) {
     for flag in flags {
-        flag.usage_col_width = col;
-        let text = if long {
+        flag.usage_col_width = column.col;
+        let text = if column.long {
             flag.help_long
                 .as_deref()
                 .or(flag.help.as_deref())
@@ -386,11 +395,11 @@ fn lay_out(
         };
         wrap_into(
             text,
-            terminal_width,
-            col,
+            column,
             &mut flag.row,
             &mut flag.help_rendered,
             &mut flag.help_is_multiline,
+            &mut flag.ann_indent,
         );
     }
 }
@@ -400,15 +409,10 @@ fn lay_out(
 /// `SpecCommand::from` already made one, but it made the long page's — the short page prefers
 /// the short description and carries the annotations in the text — so the page it is actually
 /// rendering gets the last word.
-fn lay_out_args(
-    args: &mut [crate::docs::models::SpecArg],
-    terminal_width: usize,
-    col: usize,
-    long: bool,
-) {
+fn lay_out_args(args: &mut [crate::docs::models::SpecArg], column: Column) {
     for arg in args {
-        arg.usage_col_width = col;
-        let text = if long {
+        arg.usage_col_width = column.col;
+        let text = if column.long {
             arg.help_long
                 .as_deref()
                 .or(arg.help.as_deref())
@@ -418,11 +422,11 @@ fn lay_out_args(
         };
         wrap_into(
             text,
-            terminal_width,
-            col,
+            column,
             &mut arg.row,
             &mut arg.help_rendered,
             &mut arg.help_is_multiline,
+            &mut arg.ann_indent,
         );
     }
 }
@@ -434,18 +438,25 @@ fn lay_out_args(
 /// which is the case the template reads `row` for.
 fn wrap_into(
     text: Option<String>,
-    terminal_width: usize,
-    col: usize,
+    column: Column,
     row: &mut Option<String>,
     help_rendered: &mut Option<String>,
     help_is_multiline: &mut bool,
+    ann_indent: &mut String,
 ) {
     *row = None;
     *help_rendered = None;
     *help_is_multiline = false;
+    // An entry with nothing in the column still has annotations to place, and the column is
+    // where they go: it is the entry's own row that is empty, not the table's.
+    *ann_indent = column.annotation_indent(!column.is_block());
     let Some(text) = text else { return };
     let (rendered, is_multiline) =
-        crate::docs::layout::render_help_text(&text, terminal_width, col);
+        crate::docs::layout::render_help_text(&text, column.width, column.col);
+    // `render_help_text` wraps whatever it is given; whether the page *uses* that is the
+    // template's decision, and on a next-line page it does not. Both have to agree, or the
+    // annotations align to a column the description never entered.
+    *ann_indent = column.annotation_indent(!column.is_block() && !rendered.is_empty());
     if !rendered.is_empty() {
         *help_rendered = Some(rendered);
         *help_is_multiline = is_multiline;
@@ -544,6 +555,45 @@ fn value_annotations(
         parts.push(format!("(default: {})", default.join(", ")));
     }
     parts
+}
+
+/// What a page is fitting its entries to.
+#[derive(Clone, Copy)]
+struct Column {
+    /// The width the page is laid out for.
+    width: usize,
+    /// How wide the usage column is.
+    col: usize,
+    /// The long page, which prefers the long description and gives each annotation a line.
+    long: bool,
+    /// A page that puts every description under its usage rather than beside it.
+    next_line: bool,
+}
+
+/// The indent a page uses when it cannot align to its column.
+const BLOCK_INDENT: usize = 4;
+
+impl Column {
+    /// Whether nothing on this page reaches the column: either because the page puts every
+    /// description underneath, or because the column leaves too little room to say anything.
+    fn is_block(&self) -> bool {
+        self.next_line || self.width.saturating_sub(2 + self.col + 2) < 10
+    }
+
+    /// Where an entry's annotations are indented to.
+    ///
+    /// The description column, when the description reached it — an annotation is a note about
+    /// the same entry and belongs under the text it qualifies, not in the gutter beside a
+    /// column it is ignoring. Where the description is already a block underneath, there is no
+    /// column to align to and the annotations join it there.
+    fn annotation_indent(&self, reached_column: bool) -> String {
+        let indent = if reached_column {
+            2 + self.col + 2
+        } else {
+            BLOCK_INDENT
+        };
+        " ".repeat(indent)
+    }
 }
 
 /// The entry every command list ends with, unless the CLI turned it off.
@@ -1091,9 +1141,9 @@ flag "--debug" help="Debug mode"
 
         Flags:
               --color    Enable color output
-            [env: MYCLI_COLOR]
+                         [env: MYCLI_COLOR]
               --verbose  Verbose output
-            [env: MYCLI_VERBOSE]
+                         [env: MYCLI_VERBOSE]
               --debug    Debug mode
           -h, --help     Print help
         ");
@@ -1128,12 +1178,12 @@ arg "[default]" help="Arg with default value" default="default value"
 
         Arguments:
           <input>    Input file
-            [env: MY_INPUT]
+                     [env: MY_INPUT]
           <output>   Output file
-            [env: MY_OUTPUT]
+                     [env: MY_OUTPUT]
           <extra>    Extra arg without env
           [default]  Arg with default value
-            (default: default value)
+                     (default: default value)
 
         Flags:
           -h, --help  Print help
@@ -1163,7 +1213,7 @@ flag "--verbose" help="Verbose output"
 
         Flags:
               --compress / --no-compress  Compress output
-            (default: true)
+                                          (default: true)
               --verbose                   Verbose output
           -h, --help                      Print help
         ");

--- a/lib/src/docs/cli/templates/spec_template_long.tera
+++ b/lib/src/docs/cli/templates/spec_template_long.tera
@@ -91,21 +91,21 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
 {%- endfor %}
 {%- endif %}
 {%- if not arg.hide_possible_values and arg.choices and arg.choices.choices %}
-    [possible values: {{ arg.choices.choices | join(sep=", ") }}]
+{{ arg.ann_indent }}[possible values: {{ arg.choices.choices | join(sep=", ") }}]
 {%- endif %}
 {%- if not arg.hide_possible_values and arg.choices and arg.choices.env %}
-    [choices env: {{ arg.choices.env }}]
+{{ arg.ann_indent }}[choices env: {{ arg.choices.env }}]
 {%- endif %}
 {%- if not arg.hide_env and arg.env %}
-    [env: {{ arg.env }}]
+{{ arg.ann_indent }}[env: {{ arg.env }}]
 {%- endif %}
 {%- if not arg.hide_env %}{% for env in arg.env_fallback %}
-    [env fallback: {{ env }}]
+{{ arg.ann_indent }}[env fallback: {{ env }}]
 {%- endfor %}{% for env in arg.deprecated_env %}
-    [deprecated env: {{ env }}]
+{{ arg.ann_indent }}[deprecated env: {{ env }}]
 {%- endfor %}{%- endif %}
 {%- if not arg.hide_default_value and arg.default %}
-    (default: {{ arg.default | join(sep=", ") }})
+{{ arg.ann_indent }}(default: {{ arg.default | join(sep=", ") }})
 {%- endif %}
 {%- endfor %}
 {%- endfor %}{% if arg_has_ungrouped and not arg_has_grouped %}{{ mark_grouped_args }}{% endif %}{{ mark_flags }}{% if not flag_has_ungrouped %}{{ mark_grouped_flags }}{% endif %}
@@ -149,24 +149,24 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
 {%- endfor %}
 {%- endif %}
 {%- if not flag.hide_possible_values and flag.arg.choices and flag.arg.choices.choices %}
-    [possible values: {{ flag.arg.choices.choices | join(sep=", ") }}]
+{{ flag.ann_indent }}[possible values: {{ flag.arg.choices.choices | join(sep=", ") }}]
 {%- endif %}
 {%- if not flag.hide_possible_values and flag.arg.choices and flag.arg.choices.env %}
-    [choices env: {{ flag.arg.choices.env }}]
+{{ flag.ann_indent }}[choices env: {{ flag.arg.choices.env }}]
 {%- endif %}
 {%- if not flag.hide_env and flag.env %}
-    [env: {{ flag.env }}]
+{{ flag.ann_indent }}[env: {{ flag.env }}]
 {%- endif %}
 {%- if not flag.hide_env %}{% for env in flag.env_fallback %}
-    [env fallback: {{ env }}]
+{{ flag.ann_indent }}[env fallback: {{ env }}]
 {%- endfor %}{% for env in flag.deprecated_env %}
-    [deprecated env: {{ env }}]
+{{ flag.ann_indent }}[deprecated env: {{ env }}]
 {%- endfor %}{%- endif %}
 {%- if not flag.hide_default_value and flag.default %}
-    (default: {{ flag.default | join(sep=", ") }})
+{{ flag.ann_indent }}(default: {{ flag.default | join(sep=", ") }})
 {%- endif %}
 {%- if flag.deprecated or flag.deprecated_warn_at or flag.deprecated_remove_at %}
-    [deprecated:{% if flag.deprecated %} {{ flag.deprecated }}{% endif %}{% if flag.deprecated_warn_at %}{% if flag.deprecated %};{% endif %} warns at {{ flag.deprecated_warn_at }}{% endif %}{% if flag.deprecated_remove_at %}{% if flag.deprecated or flag.deprecated_warn_at %};{% endif %} removed at {{ flag.deprecated_remove_at }}{% endif %}]
+{{ flag.ann_indent }}[deprecated:{% if flag.deprecated %} {{ flag.deprecated }}{% endif %}{% if flag.deprecated_warn_at %}{% if flag.deprecated %};{% endif %} warns at {{ flag.deprecated_warn_at }}{% endif %}{% if flag.deprecated_remove_at %}{% if flag.deprecated or flag.deprecated_warn_at %};{% endif %} removed at {{ flag.deprecated_remove_at }}{% endif %}]
 {%- endif %}
 {%- endfor %}
 {%- endfor %}{% if flag_has_ungrouped and not flag_has_grouped %}{{ mark_grouped_flags }}{% endif %}{{ mark_global_flags }}
@@ -206,24 +206,24 @@ Global flags:
 {%- endfor %}
 {%- endif %}
 {%- if not flag.hide_possible_values and flag.arg.choices and flag.arg.choices.choices %}
-    [possible values: {{ flag.arg.choices.choices | join(sep=", ") }}]
+{{ flag.ann_indent }}[possible values: {{ flag.arg.choices.choices | join(sep=", ") }}]
 {%- endif %}
 {%- if not flag.hide_possible_values and flag.arg.choices and flag.arg.choices.env %}
-    [choices env: {{ flag.arg.choices.env }}]
+{{ flag.ann_indent }}[choices env: {{ flag.arg.choices.env }}]
 {%- endif %}
 {%- if not flag.hide_env and flag.env %}
-    [env: {{ flag.env }}]
+{{ flag.ann_indent }}[env: {{ flag.env }}]
 {%- endif %}
 {%- if not flag.hide_env %}{% for env in flag.env_fallback %}
-    [env fallback: {{ env }}]
+{{ flag.ann_indent }}[env fallback: {{ env }}]
 {%- endfor %}{% for env in flag.deprecated_env %}
-    [deprecated env: {{ env }}]
+{{ flag.ann_indent }}[deprecated env: {{ env }}]
 {%- endfor %}{%- endif %}
 {%- if not flag.hide_default_value and flag.default %}
-    (default: {{ flag.default | join(sep=", ") }})
+{{ flag.ann_indent }}(default: {{ flag.default | join(sep=", ") }})
 {%- endif %}
 {%- if flag.deprecated or flag.deprecated_warn_at or flag.deprecated_remove_at %}
-    [deprecated:{% if flag.deprecated %} {{ flag.deprecated }}{% endif %}{% if flag.deprecated_warn_at %}{% if flag.deprecated %};{% endif %} warns at {{ flag.deprecated_warn_at }}{% endif %}{% if flag.deprecated_remove_at %}{% if flag.deprecated or flag.deprecated_warn_at %};{% endif %} removed at {{ flag.deprecated_remove_at }}{% endif %}]
+{{ flag.ann_indent }}[deprecated:{% if flag.deprecated %} {{ flag.deprecated }}{% endif %}{% if flag.deprecated_warn_at %}{% if flag.deprecated %};{% endif %} warns at {{ flag.deprecated_warn_at }}{% endif %}{% if flag.deprecated_remove_at %}{% if flag.deprecated or flag.deprecated_warn_at %};{% endif %} removed at {{ flag.deprecated_remove_at }}{% endif %}]
 {%- endif %}
 {%- endfor %}
 {%- endif %}{{ mark_flattened }}

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -186,6 +186,11 @@ pub struct SpecFlag {
     /// The same text unwrapped, for the layout that indents it under the usage instead.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub row: Option<String>,
+    /// The indent this entry's annotations take: the description column, or the block indent
+    /// where the description is already a block. Serialized as the spaces themselves so a
+    /// template writes it rather than working it out.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub ann_indent: String,
     pub help_is_multiline: bool,
     pub usage_col_width: usize,
 }
@@ -555,6 +560,11 @@ pub struct SpecArg {
     /// The same text unwrapped, for the layout that indents it under the usage instead.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub row: Option<String>,
+    /// The indent this entry's annotations take: the description column, or the block indent
+    /// where the description is already a block. Serialized as the spaces themselves so a
+    /// template writes it rather than working it out.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub ann_indent: String,
     pub help_is_multiline: bool,
     pub usage_col_width: usize,
 }
@@ -1087,6 +1097,7 @@ impl From<&crate::SpecFlag> for SpecFlag {
             rendered: false,
             help_rendered: None,
             row: None,
+            ann_indent: String::new(),
             help_is_multiline: false,
             usage_col_width: 0,
         }
@@ -1140,6 +1151,7 @@ impl From<&crate::SpecArg> for SpecArg {
             rendered: false,
             help_rendered: None,
             row: None,
+            ann_indent: String::new(),
             help_is_multiline: false,
             usage_col_width: 0,
         }


### PR DESCRIPTION
Follows #1284 and #1287, both merged. Last of the three help-layout changes.

## What

On the wide page each annotation gets a line of its own, and every one of them was written at a fixed four-space indent regardless of where the description it belonged to sat. So a section held together right up to the point an entry had something to annotate:

```
Flags:
  -m, --manager <MANAGER>  Only prune packages for this manager
                           [possible values: brew, brew-cask]
    (default: brew)
```

Both of those lines follow the same description. The `[possible values:]` line is a wrapped continuation, which has always been indented to the column; `(default: brew)` is an annotation, which was not. Two rules for two lines that read as one list.

Now:

```
Flags:
  -m, --manager <MANAGER>  Only prune packages for this manager
                           [possible values: brew, brew-cask]
                           (default: brew)
  -n, --dry-run            Print what would be removed without deleting anything
  -y, --yes                Skip the confirmation prompt
  -h, --help               Print help
```

An annotation is a note about the same entry, so it belongs under the text it qualifies rather than in the gutter beside a column it was ignoring.

## Where the old indent stays

Wherever the description is already a block underneath its usage, there is no column to align to and the annotations join it there — which is where they already were:

- a `next_line_help` page,
- an entry whose description has breaks of its own,
- a column so deep there is no room left to say anything.

**Admonitions** keep the fixed indent regardless: they are multi-line prose rather than a note in a bracket, and a deep column would leave them nothing to wrap into. The **flattened** sections keep it too, since their entries have no column either.

## How the two renderers stay agreed

`entry` now returns the indent it settled on, so the annotations cannot disagree with the description above them about where the column is — the decision is made once, by the code that laid the description out. usage-lib carries the same decision into its templates as a serialized indent rather than making a template work it out.

One subtlety worth knowing if you touch this: `render_help_text` wraps whatever it is handed, but a `next_line_help` page ignores the result and blocks anyway. The indent has to follow what the page *does*, not what the wrapper returned, or the annotations align to a column the description never entered.

## Verification

- `benches/gate/tests/help.rs` — mise's 211 commands, both pages, byte for byte: green.
- `benches/gate/tests/fleet.rs`, `go test ./...` including `go/conformance`: green.
- One corpus vector regenerated (`annotations-on-one-line-and-on-their-own`) — it exists to pin exactly this, and its `doc` now says the rule. `render-oracle` reports no new divergences.
- Three inline snapshots accepted, each showing an annotation moving into the column.

## Perf

`bench.startup` is `usage --help`, so this is on the measured path. The whole cost was one allocation: `long_annotations` built its indent for every entry it was called for, and most entries annotate nothing. Building it only when there is a line to put it on takes this to **0.06% below this branch's base** — measured locally with cachegrind, 868,740 against 869,244.

Being straight about the cumulative number, since the gate only ever sees one step at a time: across all three PRs, `usage --help` went from 859,600 to 868,740, or **+1.06%**. Each step passed its own gate and the largest single item was a quadratic `wrap` that #1284 *fixed*, but the total is above what the gate would allow in one move. Happy to spend another pass on it if you want it back under 1% — the remaining cost is spread across the row assembly rather than sitting in one place.

_This PR description was generated by Claude Code._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-facing help layout across three renderers; a mismatch would show up as visible `--help` diffs. Logic is presentation-only, with corpus and snapshot coverage.
> 
> **Overview**
> On the wide `--help` page, choices, env, defaults, and deprecation notes used a fixed four-space indent. Wrapped description continuations already sat in the description column, so those notes looked like a second, misaligned list.
> 
> They now take the indent `entry` actually used: the description column when help sat beside usage, and `BLOCK_INDENT` (4) when the description is already a block (`next_line_help`, author line breaks, or no room in the column). Flattened sections and admonitions stay at the block indent.
> 
> Rust argv, Go, and usage-lib share that rule. `entry` returns the indent; usage-lib serializes it as `ann_indent` so templates do not recompute it. Corpus, snapshots, and Go help docs pin the new grid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58f6a9c809d71d4e84b77f60d4b3810e60016fd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved help-page formatting so annotations such as defaults, choices, and environment variables align beneath their descriptions.
  * Long and multi-line help entries now preserve consistent indentation across supported layouts.

* **Documentation**
  * Clarified how annotations are displayed and wrapped in short, long, and block-style help pages.

* **Bug Fixes**
  * Corrected annotation alignment for long descriptions and entries displayed on a separate line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->