### PR TITLE
fix(cli): keep long entries from widening help columns

### DIFF
--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -1309,7 +1309,12 @@ fn short_sections(
         |out, (f, usage)| short_entry(out, f, usage.clone()),
     );
     if meta.flatten_help {
-        flat_commands_short(&mut sections.flattened, &path[1.min(path.len())..], meta);
+        flat_commands_short(
+            &mut sections.flattened,
+            &path[1.min(path.len())..],
+            meta,
+            width,
+        );
     }
     examples_section(&mut sections.after_help, spec, meta);
     if let Some(after) = meta.after_help.or(spec.root.after_help) {
@@ -1475,7 +1480,7 @@ fn command_row<'a>(sub: &'a CommandMeta<'a>) -> Option<Cow<'a, str>> {
     Some(Cow::Owned(row))
 }
 
-fn flat_commands_short(out: &mut String, path: &[&str], meta: &CommandMeta<'_>) {
+fn flat_commands_short(out: &mut String, path: &[&str], meta: &CommandMeta<'_>, width: usize) {
     let mut visible: Vec<_> = meta.subcommands.iter().filter(|sub| !sub.hide).collect();
     order_commands(&mut visible);
     for sub in visible {
@@ -1503,18 +1508,20 @@ fn flat_commands_short(out: &mut String, path: &[&str], meta: &CommandMeta<'_>) 
             .iter()
             .map(|arg| arg_usage(arg).chars().count())
             .max()
+            .map(|longest| usage_column_width(longest, width))
             .unwrap_or(0);
         let flag_col = flags
             .iter()
             .map(|flag| column_usage(flag).chars().count())
             .max()
+            .map(|longest| usage_column_width(longest, width))
             .unwrap_or(0);
         for arg in args {
             let usage = arg_usage(arg);
             if meta.next_line_help {
                 let _ = writeln!(out, "  {usage}");
                 if let Some(help) = arg.help.filter(|help| !help.trim().is_empty()) {
-                    write_indented(out, help, 4);
+                    write_indented(out, help, BLOCK_INDENT);
                 }
                 long_annotations(
                     out,
@@ -1539,15 +1546,9 @@ fn flat_commands_short(out: &mut String, path: &[&str], meta: &CommandMeta<'_>) 
                 );
                 continue;
             }
-            if let Some(help) = arg.help.filter(|help| !help.trim().is_empty()) {
-                let _ = write!(out, "  {usage:<arg_col$}  {help}");
-            } else {
-                let _ = write!(out, "  {usage}");
-            }
             let environment =
                 inline_environment_notes(arg.hide_env, arg.env_fallback, arg.deprecated_env);
-            annotations(
-                out,
+            let notes = inline_annotations(
                 if arg.hide_possible_values {
                     &[]
                 } else {
@@ -1562,13 +1563,21 @@ fn flat_commands_short(out: &mut String, path: &[&str], meta: &CommandMeta<'_>) 
                 },
                 None,
             );
+            entry(
+                out,
+                &usage,
+                with_annotations(arg.help, notes).as_deref(),
+                arg_col,
+                width,
+                false,
+            );
         }
         for flag in flags {
             let usage = column_usage(flag);
             if meta.next_line_help {
                 let _ = writeln!(out, "  {usage}");
                 if let Some(help) = flag.help.filter(|help| !help.trim().is_empty()) {
-                    write_indented(out, help, 4);
+                    write_indented(out, help, BLOCK_INDENT);
                 }
                 long_annotations(
                     out,
@@ -1598,11 +1607,6 @@ fn flat_commands_short(out: &mut String, path: &[&str], meta: &CommandMeta<'_>) 
                 flag_notes(out, flag, BLOCK_INDENT);
                 continue;
             }
-            if let Some(help) = flag.help.filter(|help| !help.trim().is_empty()) {
-                let _ = write!(out, "  {usage:<flag_col$}  {help}");
-            } else {
-                let _ = write!(out, "  {usage}");
-            }
             let deprecation = deprecation_label(
                 flag.deprecated,
                 flag.deprecated_warn_at,
@@ -1610,8 +1614,7 @@ fn flat_commands_short(out: &mut String, path: &[&str], meta: &CommandMeta<'_>) 
             );
             let environment =
                 inline_environment_notes(flag.hide_env, flag.env_fallback, flag.deprecated_env);
-            annotations(
-                out,
+            let notes = inline_annotations(
                 if flag.hide_possible_values {
                     &[]
                 } else {
@@ -1626,9 +1629,17 @@ fn flat_commands_short(out: &mut String, path: &[&str], meta: &CommandMeta<'_>) 
                 },
                 deprecation.as_deref(),
             );
+            entry(
+                out,
+                &usage,
+                with_annotations(flag.help, notes).as_deref(),
+                flag_col,
+                width,
+                false,
+            );
         }
         if sub.flatten_help {
-            flat_commands_short(out, &sub_path, sub);
+            flat_commands_short(out, &sub_path, sub, width);
         }
         out.push('\n');
     }
@@ -1775,37 +1786,7 @@ fn command_help_section<'a>(sub: &'a CommandMeta<'a>, default_title: &str) -> Op
     sub.help_heading.filter(|heading| *heading != default_title)
 }
 
-/// The bracketed notes after an entry's help: choices, environment, default.
-fn annotations(
-    out: &mut String,
-    choices: &[&str],
-    env: Option<&str>,
-    environment: Option<&str>,
-    default: &[&str],
-    suffix: Option<&str>,
-) {
-    if !choices.is_empty() {
-        let _ = write!(out, " [{}]", choices.join(", "));
-    }
-    if let Some(env) = env {
-        let _ = write!(out, " [env: {env}]");
-    }
-    if let Some(environment) = environment {
-        let _ = write!(out, " {environment}");
-    }
-    if !default.is_empty() {
-        let _ = write!(out, " (default: {})", default.join(", "));
-    }
-    if let Some(suffix) = suffix {
-        let _ = write!(out, " {suffix}");
-    }
-    out.push('\n');
-}
-
-/// The same annotations as one string, for an entry that carries them in its text.
-///
-/// [`annotations`] writes them straight out, which the flattened sections still want. The
-/// narrow layout cannot: its text has to be complete before it is wrapped.
+/// The bracketed notes after an entry's help, composed before the narrow layout wraps them.
 fn inline_annotations(
     choices: &[&str],
     env: Option<&str>,
@@ -2325,13 +2306,20 @@ fn entry(
     let indent = 2 + col + 2;
     let room = width.saturating_sub(indent);
     // A long outlier leaves the shared column to the ordinary entries and uses a block alone.
-    let block = next_line || usage.chars().count() > col || room < 10;
+    let overflow = usage.chars().count() > col;
+    let block = next_line || overflow || room < 10;
     let Some(help) = help.filter(|h| !h.trim().is_empty()) else {
         let _ = writeln!(out, "  {usage}");
         // An entry with nothing in the column still has annotations to place, and the column is
         // where they go: it is this entry's row that is empty, not the table's.
         return if block { BLOCK_INDENT } else { indent };
     };
+
+    if overflow && !next_line && !help.contains('\n') {
+        let _ = writeln!(out, "  {usage}");
+        write_wrapped_block(out, help, width);
+        return BLOCK_INDENT;
+    }
 
     if block || help.contains('\n') {
         let _ = writeln!(out, "  {usage}");
@@ -2366,6 +2354,14 @@ fn entry(
     // whitespace trimming eats it before it reaches the output — so a wrapped entry is followed
     // directly by the next, and matching means matching that.
     indent
+}
+
+/// Wrap an overflowing entry's description across the width below its usage.
+fn write_wrapped_block(out: &mut String, help: &str, width: usize) {
+    let room = width.saturating_sub(BLOCK_INDENT);
+    for line in wrap(help, room) {
+        let _ = writeln!(out, "{}{}", " ".repeat(BLOCK_INDENT), line);
+    }
 }
 
 /// Whether [`wrap`] would return this text unchanged as a single line.
@@ -2584,11 +2580,13 @@ fn flat_commands_long(out: &mut String, path: &[&str], meta: &CommandMeta<'_>, w
             .iter()
             .map(|arg| arg_usage(arg).chars().count())
             .max()
+            .map(|longest| usage_column_width(longest, width))
             .unwrap_or(0);
         let flag_col = flags
             .iter()
             .map(|flag| column_usage(flag).chars().count())
             .max()
+            .map(|longest| usage_column_width(longest, width))
             .unwrap_or(0);
         for arg in args {
             entry(
@@ -3736,7 +3734,7 @@ mod style_tests {
         };
         let mut page = String::new();
 
-        flat_commands_short(&mut page, &["tool"], &root_meta);
+        flat_commands_short(&mut page, &["tool"], &root_meta, 80);
 
         assert!(
             page.contains("    Use the old mode\n    [deprecated: use --new]"),
@@ -3785,7 +3783,7 @@ mod style_tests {
         };
         let mut page = String::new();
 
-        flat_commands_short(&mut page, &["tool"], &root_meta);
+        flat_commands_short(&mut page, &["tool"], &root_meta, 80);
 
         assert!(page.contains("--old\n"), "{page}");
         assert!(page.contains("[deprecated: use --new]\n"), "{page}");
@@ -4096,4 +4094,15 @@ mod style_tests {
         }
         out
     }
+}
+#[cfg(test)]
+#[test]
+fn an_overflowing_entry_wraps_even_when_the_page_is_very_narrow() {
+    let mut page = String::new();
+    let width = 10;
+    let col = usage_column_width("--long".chars().count(), width);
+
+    entry(&mut page, "--long", Some("alpha beta"), col, width, false);
+
+    assert_eq!(page, "  --long\n    alpha\n    beta\n");
 }

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -1169,6 +1169,7 @@ fn short_sections(
         .iter()
         .map(|a| arg_usage(a).chars().count())
         .max()
+        .map(|longest| usage_column_width(longest, width))
         .unwrap_or(0);
     split_groups_section(
         SectionSink {
@@ -1233,6 +1234,7 @@ fn short_sections(
         .map(|f| column_usage(f).chars().count())
         .chain(inherited.iter().map(|(_, u)| u.chars().count()))
         .max()
+        .map(|longest| usage_column_width(longest, width))
         .unwrap_or(0);
     let short_entry = |out: &mut String, f: &FlagMeta<'_>, usage: String| {
         if meta.next_line_help {
@@ -1371,6 +1373,7 @@ fn commands_section(
         .map(|(_, sub)| sub.cmd.name.chars().count())
         .chain(show_help.then(|| HELP_SUBCOMMAND.chars().count()))
         .max()
+        .map(|longest| usage_column_width(longest, width))
         .unwrap_or(0);
 
     let default_title = meta.subcommand_help_heading.unwrap_or("Commands");
@@ -1992,6 +1995,20 @@ fn terminal_width(meta: &CommandMeta<'_>) -> usize {
     }
 }
 
+/// Keep a single long spelling from narrowing every description on the page.
+///
+/// After the two-space indent and gap, usage gets at most two fifths of what remains. Entries
+/// beyond the cap use block layout on their own; an explicitly unbounded page keeps its natural
+/// column.
+fn usage_column_width(longest: usize, terminal_width: usize) -> usize {
+    if terminal_width == usize::MAX {
+        return longest;
+    }
+    let available = terminal_width.saturating_sub(4);
+    let cap = available / 5 * 2 + available % 5 * 2 / 5;
+    longest.min(cap)
+}
+
 /// Everything `--help` prints.
 ///
 /// The same content as [`short_help`] through a wider layout: help is aligned into a column and
@@ -2096,6 +2113,7 @@ fn long_sections(
         .iter()
         .map(|a| arg_usage(a).chars().count())
         .max()
+        .map(|longest| usage_column_width(longest, width))
         .unwrap_or(0);
     split_groups_section(
         SectionSink {
@@ -2141,6 +2159,7 @@ fn long_sections(
         .map(|f| column_usage(f).chars().count())
         .chain(inherited.iter().map(|(_, u)| u.chars().count()))
         .max()
+        .map(|longest| usage_column_width(longest, width))
         .unwrap_or(0);
     split_groups_section(
         SectionSink {
@@ -2305,8 +2324,8 @@ fn entry(
     // there is room left for it to say anything.
     let indent = 2 + col + 2;
     let room = width.saturating_sub(indent);
-    // Whether anything on this page reaches the column at all.
-    let block = next_line || room < 10;
+    // A long outlier leaves the shared column to the ordinary entries and uses a block alone.
+    let block = next_line || usage.chars().count() > col || room < 10;
     let Some(help) = help.filter(|h| !h.trim().is_empty()) else {
         let _ = writeln!(out, "  {usage}");
         // An entry with nothing in the column still has annotations to place, and the column is

--- a/conformance/tests/metadata.rs
+++ b/conformance/tests/metadata.rs
@@ -30,6 +30,62 @@ struct CappedColumns {
     threads: Option<usize>,
 }
 
+#[derive(Args)]
+#[usage(disable_help_flag, term_width = 0)]
+#[allow(dead_code)]
+struct CappedFlatArgs {
+    /// Disable reporting on warnings
+    #[usage(long)]
+    quiet: bool,
+    /// Choose the severity for unused directives while keeping every long explanation inside the bounded parent help page
+    #[usage(
+        long = "report-unused-disable-directives-severity",
+        value_name = "SEVERITY",
+        env = "COLUMN_CAP_SEVERITY",
+        default = "warn"
+    )]
+    severity: Option<String>,
+    #[usage(
+        long = "an-extraordinarily-long-multiline-option-name",
+        help = "Keep this line.\nAnd this one."
+    )]
+    multiline: bool,
+}
+
+#[derive(Subcommands)]
+#[allow(dead_code)]
+enum CappedFlatCommands {
+    Run(CappedFlatArgs),
+}
+
+#[derive(Args)]
+#[allow(dead_code)]
+struct LongCommandArgs {}
+
+#[derive(Subcommands)]
+#[allow(dead_code)]
+enum LongCommandNames {
+    /// Explain this unusually named command with enough detail to wrap beneath its name on a bounded help page
+    #[usage(name = "an-extraordinarily-long-subcommand-name")]
+    Long(LongCommandArgs),
+}
+
+#[derive(Cli)]
+#[usage(bin = "command-cap", term_width = 80)]
+#[allow(dead_code)]
+struct CappedCommandColumns {
+    #[usage(subcommand)]
+    command: Option<LongCommandNames>,
+}
+
+#[derive(Cli)]
+#[usage(bin = "column-cap-flat", term_width = 80, flatten_help)]
+#[allow(dead_code)]
+struct CappedFlatColumns {
+    #[usage(subcommand)]
+    command: Option<CappedFlatCommands>,
+}
+
 #[test]
 fn a_long_flag_only_moves_its_own_help_below_the_column() {
     let spec = CappedColumns::spec();
@@ -69,6 +125,64 @@ fn a_long_flag_only_moves_its_own_help_below_the_column() {
             Some("Choose the severity for unused directives")
         );
         assert!(lines[outlier + 1].starts_with("    "), "{page}");
+    }
+}
+
+#[test]
+fn flattened_help_caps_each_nested_commands_columns_too() {
+    let spec = CappedFlatColumns::spec();
+    let portable: LibSpec = CappedFlatColumns::to_kdl().parse().expect("valid spec");
+
+    for long in [false, true] {
+        let page = usage_argv::help::render(spec, spec.root.cmd, long).unwrap();
+        assert_eq!(
+            page,
+            usage::docs::cli::render_help(&portable, &portable.cmd, long)
+        );
+        assert!(
+            page.lines().any(|line| {
+                line.contains("--quiet") && line.contains("Disable reporting on warnings")
+            }),
+            "{page}"
+        );
+        assert!(
+            page.contains("--report-unused-disable-directives-severity <SEVERITY>\n    Choose the severity for unused directives while keeping every long\n    explanation inside the bounded parent help page"),
+            "{page}"
+        );
+        assert!(
+            page.contains("--an-extraordinarily-long-multiline-option-name\n    Keep this line.\n    And this one."),
+            "{page}"
+        );
+        if !long {
+            assert!(
+                page.contains("[env: COLUMN_CAP_SEVERITY]") && page.contains("(default: warn)"),
+                "{page}"
+            );
+        }
+        assert!(
+            page.lines()
+                .filter(|line| !line.trim_start().starts_with("column-cap-flat run"))
+                .all(|line| line.chars().count() <= 80),
+            "a flattened help row exceeded 80 columns: {page}"
+        );
+    }
+}
+
+#[test]
+fn a_long_command_name_only_moves_its_own_wrapped_summary_below() {
+    let spec = CappedCommandColumns::spec();
+    let portable: LibSpec = CappedCommandColumns::to_kdl().parse().expect("valid spec");
+
+    for long in [false, true] {
+        let page = usage_argv::help::render(spec, spec.root.cmd, long).unwrap();
+        assert_eq!(
+            page,
+            usage::docs::cli::render_help(&portable, &portable.cmd, long)
+        );
+        assert!(
+            page.contains("an-extraordinarily-long-subcommand-name\n    Explain this unusually named command with enough detail to wrap beneath its\n    name on a bounded help page"),
+            "{page}"
+        );
     }
 }
 

--- a/conformance/tests/metadata.rs
+++ b/conformance/tests/metadata.rs
@@ -12,6 +12,66 @@
 use usage::Spec as LibSpec;
 use usage_derive::{Args, Cli, Subcommands};
 
+#[derive(Cli)]
+#[usage(bin = "column-cap", term_width = 80)]
+#[allow(dead_code)]
+struct CappedColumns {
+    /// Disable reporting on warnings
+    #[usage(long)]
+    quiet: bool,
+    /// Choose the severity for unused directives
+    #[usage(
+        long = "report-unused-disable-directives-severity",
+        value_name = "SEVERITY"
+    )]
+    severity: Option<String>,
+    /// Number of threads to use
+    #[usage(long)]
+    threads: Option<usize>,
+}
+
+#[test]
+fn a_long_flag_only_moves_its_own_help_below_the_column() {
+    let spec = CappedColumns::spec();
+    let portable: LibSpec = CappedColumns::to_kdl().parse().expect("valid spec");
+
+    for long in [false, true] {
+        let page = usage_argv::help::render(spec, spec.root.cmd, long).unwrap();
+        assert_eq!(
+            page,
+            usage::docs::cli::render_help(&portable, &portable.cmd, long)
+        );
+
+        let lines: Vec<_> = page.lines().collect();
+        assert!(
+            lines.iter().any(|line| {
+                line.contains("--quiet") && line.contains("Disable reporting on warnings")
+            }),
+            "{page}"
+        );
+        assert!(
+            lines.iter().any(|line| {
+                line.contains("--threads <THREADS>") && line.contains("Number of threads to use")
+            }),
+            "{page}"
+        );
+
+        let outlier = lines
+            .iter()
+            .position(|line| line.contains("--report-unused-disable-directives-severity"))
+            .expect("outlier flag");
+        assert_eq!(
+            lines[outlier].trim(),
+            "--report-unused-disable-directives-severity <SEVERITY>"
+        );
+        assert_eq!(
+            lines.get(outlier + 1).map(|line| line.trim()),
+            Some("Choose the severity for unused directives")
+        );
+        assert!(lines[outlier + 1].starts_with("    "), "{page}");
+    }
+}
+
 #[derive(Args)]
 #[usage(deprecated = "use inspect", deprecated_remove_at = "7.0")]
 struct Old {}

--- a/go/argv/page.go
+++ b/go/argv/page.go
@@ -143,6 +143,7 @@ func ShortHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) s
 			argCol = n
 		}
 	}
+	argCol = usageColumnWidth(argCol)
 	groupsSection(&sections.args, &sections.ungroupedArgs, &sections.groupedArgs, "Arguments", len(args),
 		func(i int) string { return headingOf(help, args[i].Key) },
 		nil,
@@ -178,6 +179,7 @@ func ShortHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) s
 			flagCol = n
 		}
 	}
+	flagCol = usageColumnWidth(flagCol)
 	flagEntry := func(w *strings.Builder, f shownFlag) {
 		h := help.Lookup(f.key)
 		if f.supplied != "" {
@@ -298,6 +300,7 @@ func commandsSection(out *strings.Builder, path []string, cmd *Command, help Hel
 			col = n
 		}
 	}
+	col = usageColumnWidth(col)
 
 	headings := []string{""}
 	for _, l := range lines {
@@ -390,6 +393,7 @@ func flatCommandsShort(out *strings.Builder, path []string, cmd *Command, help H
 		for _, a := range args {
 			argCol = max(argCol, width(argUsage(a, help.Lookup(a.Key))))
 		}
+		argCol = usageColumnWidth(argCol)
 		flagCol := 0
 		for _, f := range sub.Flags {
 			fh := help.Lookup(f.Key)
@@ -399,6 +403,7 @@ func flatCommandsShort(out *strings.Builder, path []string, cmd *Command, help H
 			flags = append(flags, f)
 			flagCol = max(flagCol, width(columnUsage(f, allShown(f), help)))
 		}
+		flagCol = usageColumnWidth(flagCol)
 		orderFlags(flags, help)
 		for _, a := range args {
 			ah := help.Lookup(a.Key)
@@ -410,12 +415,7 @@ func flatCommandsShort(out *strings.Builder, path []string, cmd *Command, help H
 				}
 				longAnnotations(out, ah, true, blockIndent)
 			} else {
-				if text := helpText(ah); text != "" {
-					out.WriteString("  " + pad(usage, argCol) + "  " + text)
-				} else {
-					out.WriteString("  " + usage)
-				}
-				annotations(out, ah, true)
+				entry(out, usage, withAnnotations(shortSummary(ah), inlineAnnotations(ah, true, false)), argCol, false)
 			}
 		}
 		for _, f := range flags {
@@ -428,12 +428,7 @@ func flatCommandsShort(out *strings.Builder, path []string, cmd *Command, help H
 				}
 				longAnnotations(out, fh, true, blockIndent)
 			} else {
-				if text := helpText(fh); text != "" {
-					out.WriteString("  " + pad(usage, flagCol) + "  " + text)
-				} else {
-					out.WriteString("  " + usage)
-				}
-				annotations(out, fh, true)
+				entry(out, usage, withAnnotations(shortSummary(fh), inlineAnnotations(fh, true, true)), flagCol, false)
 			}
 		}
 		if h != nil && h.FlattenHelp {

--- a/go/argv/page_long.go
+++ b/go/argv/page_long.go
@@ -91,6 +91,7 @@ func LongHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) st
 			argCol = n
 		}
 	}
+	argCol = usageColumnWidth(argCol)
 	groupsSection(&sections.args, &sections.ungroupedArgs, &sections.groupedArgs, "Arguments", len(args),
 		func(i int) string { return headingOf(help, args[i].Key) },
 		headingProse(meta),
@@ -113,6 +114,7 @@ func LongHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) st
 			flagCol = n
 		}
 	}
+	flagCol = usageColumnWidth(flagCol)
 	writeFlag := func(w *strings.Builder, f shownFlag) {
 		if f.supplied != "" {
 			entry(w, f.usage, f.suppliedHelp, flagCol, nextLineHelp)
@@ -237,6 +239,7 @@ func flatCommandsLong(out *strings.Builder, path []string, cmd *Command, help He
 		for _, a := range args {
 			argCol = max(argCol, width(argUsage(a, help.Lookup(a.Key))))
 		}
+		argCol = usageColumnWidth(argCol)
 		flagCol := 0
 		for _, f := range sub.Flags {
 			fh := help.Lookup(f.Key)
@@ -246,6 +249,7 @@ func flatCommandsLong(out *strings.Builder, path []string, cmd *Command, help He
 			flags = append(flags, f)
 			flagCol = max(flagCol, width(columnUsage(f, allShown(f), help)))
 		}
+		flagCol = usageColumnWidth(flagCol)
 		orderFlags(flags, help)
 		for _, a := range args {
 			ah := help.Lookup(a.Key)
@@ -279,8 +283,10 @@ func entry(out *strings.Builder, usage, help string, col int, nextLine bool) int
 	if room < 0 {
 		room = 0
 	}
+	// A long outlier leaves the shared column to the ordinary entries and uses a block alone.
+	overflow := width(usage) > col
 	// Whether anything on this page reaches the column at all.
-	block := nextLine || room < 10
+	block := nextLine || overflow || room < 10
 	if strings.TrimSpace(help) == "" {
 		out.WriteString("  " + usage + "\n")
 		// An entry with nothing in the column still has annotations to place, and the
@@ -289,6 +295,14 @@ func entry(out *strings.Builder, usage, help string, col int, nextLine bool) int
 			return blockIndent
 		}
 		return indent
+	}
+
+	if overflow && !nextLine && !strings.Contains(help, "\n") {
+		out.WriteString("  " + usage + "\n")
+		for _, line := range wrap(help, helpWidth-blockIndent) {
+			out.WriteString(strings.Repeat(" ", blockIndent) + line + "\n")
+		}
+		return blockIndent
 	}
 
 	if block || strings.Contains(help, "\n") {
@@ -305,6 +319,14 @@ func entry(out *strings.Builder, usage, help string, col int, nextLine bool) int
 	// No blank line after a wrapped entry: the reference's template asks for one
 	// and its whitespace trimming eats it before it reaches the output.
 	return indent
+}
+
+// usageColumnWidth prevents one long spelling from narrowing every description on the page.
+// After the two-space indent and gap, usage gets at most two fifths of the remaining width.
+func usageColumnWidth(longest int) int {
+	available := helpWidth - 4
+	cap := available * 2 / 5
+	return min(longest, cap)
 }
 
 // longAnnotations gives each annotation its own line, which is the room the wide

--- a/go/argv/page_test.go
+++ b/go/argv/page_test.go
@@ -336,6 +336,29 @@ func TestFlattenHelp(t *testing.T) {
 	}
 }
 
+func TestALongFlagOnlyMovesItsOwnHelpBelow(t *testing.T) {
+	short := &Flag{Name: "short", Key: 2, Longs: []string{"short"}}
+	long := &Flag{Name: "this-flag-name-is-far-beyond-the-column-cap", Key: 3, Longs: []string{"this-flag-name-is-far-beyond-the-column-cap"}}
+	root := &Command{Name: "ex", Key: 1, Flags: []*Flag{short, long}}
+	help := HelpTable{
+		{Key: 1},
+		{Key: 2, Short: "ordinary help"},
+		{Key: 3, Short: "alpha beta"},
+	}
+
+	for _, page := range []string{
+		ShortHelp(HelpSpec{Bin: "ex"}, []string{"ex"}, []*Command{root}, help),
+		LongHelp(HelpSpec{Bin: "ex"}, []string{"ex"}, []*Command{root}, help),
+	} {
+		if !strings.Contains(page, "      --short                     ordinary help") {
+			t.Fatalf("the ordinary row did not retain a readable description column:\n%s", page)
+		}
+		if !strings.Contains(page, "      --this-flag-name-is-far-beyond-the-column-cap\n    alpha beta") {
+			t.Fatalf("the overflowing row did not move its help below:\n%s", page)
+		}
+	}
+}
+
 func TestFlattenedNextLineHelpKeepsDeprecationSeparate(t *testing.T) {
 	flag := &Flag{Name: "old", Key: 3, Longs: []string{"old"}}
 	sub := &Command{Name: "run", Key: 2, Flags: []*Flag{flag}}

--- a/lib/src/docs/cli/mod.rs
+++ b/lib/src/docs/cli/mod.rs
@@ -98,6 +98,10 @@ pub fn render_help(spec: &Spec, cmd: &SpecCommand, long: bool) -> String {
         );
     }
 
+    // Flattened descendants live on this page, so this page's width governs them. Their own
+    // `term_width` applies when they get a page of their own, not when an ancestor expands them.
+    lay_out_flattened(&mut docs_cmd.flattened_subcommands, width, long);
+
     // The command list, laid out the way the flag list is: one column for the whole page, the
     // name in it, and everything else — summary, aliases, deprecation — trailing as text that
     // wraps under itself. Both pages get the same rows, so `--help` no longer reprints every
@@ -389,6 +393,8 @@ fn supplied_flags(
 fn lay_out(flags: &mut [crate::docs::models::SpecFlag], column: Column) {
     for flag in flags {
         flag.usage_col_width = column.col;
+        flag.help_is_block =
+            column.is_block(crate::docs::layout::visible_width(&flag.display_usage));
         let text = if column.long {
             flag.help_long
                 .as_deref()
@@ -417,6 +423,7 @@ fn lay_out(flags: &mut [crate::docs::models::SpecFlag], column: Column) {
 fn lay_out_args(args: &mut [crate::docs::models::SpecArg], column: Column) {
     for arg in args {
         arg.usage_col_width = column.col;
+        arg.help_is_block = column.is_block(crate::docs::layout::visible_width(&arg.usage));
         let text = if column.long {
             arg.help_long
                 .as_deref()
@@ -434,6 +441,46 @@ fn lay_out_args(args: &mut [crate::docs::models::SpecArg], column: Column) {
             &mut arg.help_is_multiline,
             &mut arg.ann_indent,
         );
+    }
+}
+
+fn lay_out_flattened(commands: &mut [crate::docs::models::SpecCommand], width: usize, long: bool) {
+    for command in commands {
+        let arg_col = crate::docs::layout::usage_column_width(
+            command
+                .arg_groups
+                .iter()
+                .flat_map(|group| group.items.iter())
+                .map(|arg| arg.usage.as_str()),
+            width,
+        );
+        let arg_column = Column {
+            width,
+            col: arg_col,
+            long,
+            next_line: command.flattened_next_line_help,
+        };
+        for group in &mut command.arg_groups {
+            lay_out_args(&mut group.items, arg_column);
+        }
+
+        let flag_col = crate::docs::layout::usage_column_width(
+            command
+                .flag_groups
+                .iter()
+                .flat_map(|group| group.items.iter())
+                .map(|flag| flag.display_usage.as_str()),
+            width,
+        );
+        let flag_column = Column {
+            width,
+            col: flag_col,
+            long,
+            next_line: command.flattened_next_line_help,
+        };
+        for group in &mut command.flag_groups {
+            lay_out(&mut group.items, flag_column);
+        }
     }
 }
 
@@ -459,7 +506,13 @@ fn wrap_into(
     *ann_indent = column.annotation_indent(!column.is_block(usage_width));
     let Some(text) = text else { return };
     if column.is_block(usage_width) {
-        *row = Some(text);
+        *row = Some(
+            if column.usage_overflows(usage_width) && !text.contains('\n') {
+                crate::docs::layout::render_block_text(&text, column.width)
+            } else {
+                text
+            },
+        );
         return;
     }
     let (rendered, is_multiline) =
@@ -585,10 +638,16 @@ struct Column {
 const BLOCK_INDENT: usize = 4;
 
 impl Column {
+    fn usage_overflows(&self, usage_width: usize) -> bool {
+        !self.next_line && usage_width > self.col
+    }
+
     /// Whether this entry stays out of the column: because the page puts every description
     /// underneath, its usage exceeds the capped column, or too little room remains for help.
     fn is_block(&self, usage_width: usize) -> bool {
-        self.next_line || usage_width > self.col || self.width.saturating_sub(2 + self.col + 2) < 10
+        self.next_line
+            || self.usage_overflows(usage_width)
+            || self.width.saturating_sub(2 + self.col + 2) < 10
     }
 
     /// Where an entry's annotations are indented to.
@@ -626,6 +685,9 @@ fn lay_out_commands(
         command.help_rendered = None;
         command.help_is_multiline = false;
         if crate::docs::layout::visible_width(&command.name) > col {
+            if let Some(row) = command.row.as_mut().filter(|row| !row.contains('\n')) {
+                *row = crate::docs::layout::render_block_text(row, terminal_width);
+            }
             continue;
         }
         if let Some(row) = command.row.as_deref() {
@@ -707,10 +769,17 @@ fn render_row(
     col: usize,
     next_line_help: bool,
 ) -> String {
-    if !next_line_help && crate::docs::layout::visible_width(name) <= col {
-        let (rendered, _) = crate::docs::layout::render_help_text(row, terminal_width, col);
-        if !rendered.is_empty() {
-            return format!("  {name:<col$}  {rendered}");
+    if !next_line_help {
+        if crate::docs::layout::visible_width(name) <= col {
+            let (rendered, _) = crate::docs::layout::render_help_text(row, terminal_width, col);
+            if !rendered.is_empty() {
+                return format!("  {name:<col$}  {rendered}");
+            }
+        } else if !row.contains('\n') {
+            return format!(
+                "  {name}\n    {}",
+                crate::docs::layout::render_block_text(row, terminal_width)
+            );
         }
     }
     format!("  {name}\n    {row}")

--- a/lib/src/docs/cli/mod.rs
+++ b/lib/src/docs/cli/mod.rs
@@ -59,13 +59,14 @@ pub fn render_help(spec: &Spec, cmd: &SpecCommand, long: bool) -> String {
     }
 
     let width = crate::docs::layout::help_width(cmd.term_width, cmd.max_term_width);
-    let col = crate::docs::layout::max_usage_width(
+    let col = crate::docs::layout::usage_column_width(
         docs_cmd
             .flag_groups
             .iter()
             .flat_map(|g| g.items.iter())
             .chain(inherited.iter())
             .map(|f| f.display_usage.as_str()),
+        width,
     );
     let flag_column = Column {
         width,
@@ -81,8 +82,10 @@ pub fn render_help(spec: &Spec, cmd: &SpecCommand, long: bool) -> String {
     // The arguments get their own column, laid out here for the page being rendered rather than
     // taken from the model's — which is the long page's, and would put a long description in the
     // short page's column unwrapped.
-    let arg_col =
-        crate::docs::layout::max_usage_width(docs_cmd.args.iter().map(|a| a.usage.as_str()));
+    let arg_col = crate::docs::layout::usage_column_width(
+        docs_cmd.args.iter().map(|a| a.usage.as_str()),
+        width,
+    );
     for group in &mut docs_cmd.arg_groups {
         lay_out_args(
             &mut group.items,
@@ -103,13 +106,14 @@ pub fn render_help(spec: &Spec, cmd: &SpecCommand, long: bool) -> String {
         let show_help_row = !docs_cmd.subcommands.is_empty()
             && !docs_cmd.flatten_help
             && !cmd.disable_help_subcommand;
-        let cmd_col = crate::docs::layout::max_usage_width(
+        let cmd_col = crate::docs::layout::usage_column_width(
             docs_cmd
                 .subcommand_groups
                 .iter()
                 .flat_map(|g| g.items.iter())
                 .map(|c| c.name.as_str())
                 .chain(show_help_row.then_some(HELP_SUBCOMMAND)),
+            width,
         );
         for group in &mut docs_cmd.subcommand_groups {
             lay_out_commands(&mut group.items, width, cmd_col);
@@ -396,6 +400,7 @@ fn lay_out(flags: &mut [crate::docs::models::SpecFlag], column: Column) {
         wrap_into(
             text,
             column,
+            crate::docs::layout::visible_width(&flag.display_usage),
             &mut flag.row,
             &mut flag.help_rendered,
             &mut flag.help_is_multiline,
@@ -423,6 +428,7 @@ fn lay_out_args(args: &mut [crate::docs::models::SpecArg], column: Column) {
         wrap_into(
             text,
             column,
+            crate::docs::layout::visible_width(&arg.usage),
             &mut arg.row,
             &mut arg.help_rendered,
             &mut arg.help_is_multiline,
@@ -439,6 +445,7 @@ fn lay_out_args(args: &mut [crate::docs::models::SpecArg], column: Column) {
 fn wrap_into(
     text: Option<String>,
     column: Column,
+    usage_width: usize,
     row: &mut Option<String>,
     help_rendered: &mut Option<String>,
     help_is_multiline: &mut bool,
@@ -449,14 +456,18 @@ fn wrap_into(
     *help_is_multiline = false;
     // An entry with nothing in the column still has annotations to place, and the column is
     // where they go: it is the entry's own row that is empty, not the table's.
-    *ann_indent = column.annotation_indent(!column.is_block());
+    *ann_indent = column.annotation_indent(!column.is_block(usage_width));
     let Some(text) = text else { return };
+    if column.is_block(usage_width) {
+        *row = Some(text);
+        return;
+    }
     let (rendered, is_multiline) =
         crate::docs::layout::render_help_text(&text, column.width, column.col);
     // `render_help_text` wraps whatever it is given; whether the page *uses* that is the
     // template's decision, and on a next-line page it does not. Both have to agree, or the
     // annotations align to a column the description never entered.
-    *ann_indent = column.annotation_indent(!column.is_block() && !rendered.is_empty());
+    *ann_indent = column.annotation_indent(!rendered.is_empty());
     if !rendered.is_empty() {
         *help_rendered = Some(rendered);
         *help_is_multiline = is_multiline;
@@ -574,10 +585,10 @@ struct Column {
 const BLOCK_INDENT: usize = 4;
 
 impl Column {
-    /// Whether nothing on this page reaches the column: either because the page puts every
-    /// description underneath, or because the column leaves too little room to say anything.
-    fn is_block(&self) -> bool {
-        self.next_line || self.width.saturating_sub(2 + self.col + 2) < 10
+    /// Whether this entry stays out of the column: because the page puts every description
+    /// underneath, its usage exceeds the capped column, or too little room remains for help.
+    fn is_block(&self, usage_width: usize) -> bool {
+        self.next_line || usage_width > self.col || self.width.saturating_sub(2 + self.col + 2) < 10
     }
 
     /// Where an entry's annotations are indented to.
@@ -614,6 +625,9 @@ fn lay_out_commands(
         command.row = command_row(command);
         command.help_rendered = None;
         command.help_is_multiline = false;
+        if crate::docs::layout::visible_width(&command.name) > col {
+            continue;
+        }
         if let Some(row) = command.row.as_deref() {
             let (rendered, is_multiline) =
                 crate::docs::layout::render_help_text(row, terminal_width, col);
@@ -693,7 +707,7 @@ fn render_row(
     col: usize,
     next_line_help: bool,
 ) -> String {
-    if !next_line_help {
+    if !next_line_help && crate::docs::layout::visible_width(name) <= col {
         let (rendered, _) = crate::docs::layout::render_help_text(row, terminal_width, col);
         if !rendered.is_empty() {
             return format!("  {name:<col$}  {rendered}");

--- a/lib/src/docs/cli/templates/spec_template_long.tera
+++ b/lib/src/docs/cli/templates/spec_template_long.tera
@@ -78,6 +78,9 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
 {%- if arg.help_is_multiline %}
 
 {%- endif %}
+{%- elif arg.row %}
+  {{ arg.usage | trim }}
+    {{ arg.row | indent(width=4) }}
 {%- else %}
   {{ arg.usage | trim }}
 {%- set help = arg.help_long | default(value=arg.help | default(value='')) %}
@@ -130,6 +133,10 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
 {%- if flag.help_is_multiline %}
 
 {%- endif %}
+{%- elif flag.row %}
+  {{ flag.display_usage }}
+{%- if flag.aliases %}  [aliases: {{ flag.aliases | join(sep=", ") }}]{% endif %}
+    {{ flag.row | indent(width=4) }}
 {%- else %}
   {{ flag.display_usage }}
 {%- if flag.aliases %}  [aliases: {{ flag.aliases | join(sep=", ") }}]{% endif %}
@@ -187,6 +194,10 @@ Global flags:
 {%- if flag.help_is_multiline %}
 
 {%- endif %}
+{%- elif flag.row %}
+  {{ flag.display_usage }}
+{%- if flag.aliases %}  [aliases: {{ flag.aliases | join(sep=", ") }}]{% endif %}
+    {{ flag.row | indent(width=4) }}
 {%- else %}
   {{ flag.display_usage }}
 {%- if flag.aliases %}  [aliases: {{ flag.aliases | join(sep=", ") }}]{% endif %}
@@ -249,6 +260,9 @@ Global flags:
 {%- endif %}
 {%- elif arg.help_rendered %}
   {{ arg.usage | ljust(width=arg.usage_col_width) }}  {{ arg.help_rendered }}
+{%- elif arg.row %}
+  {{ arg.usage | trim }}
+    {{ arg.row | indent(width=4) }}
 {%- else %}
   {{ arg.usage | trim }}
 {%- endif %}
@@ -283,6 +297,9 @@ Global flags:
 {%- endif %}
 {%- elif flag.help_rendered %}
   {{ flag.display_usage | ljust(width=flag.usage_col_width) }}  {{ flag.help_rendered }}
+{%- elif flag.row %}
+  {{ flag.display_usage }}
+    {{ flag.row | indent(width=4) }}
 {%- else %}
   {{ flag.display_usage }}
 {%- endif %}

--- a/lib/src/docs/cli/templates/spec_template_short.tera
+++ b/lib/src/docs/cli/templates/spec_template_short.tera
@@ -156,9 +156,11 @@ Global flags:
 {%- endif %}
 {%- for group in sub.arg_groups %}
 {%- for arg in group.items %}
-  {% if arg.help %}{% if sub.flattened_next_line_help %}{{ arg.usage | trim }}
-    {{ arg.help | indent(width=4) }}{% else %}{{ arg.usage | trim | ljust(width=arg.usage_col_width) }}  {{ arg.help }}{% endif %}{% else %}{{ arg.usage | trim }}{% endif %}
 {%- if sub.flattened_next_line_help %}
+  {{ arg.usage | trim }}
+{%- if arg.help %}
+    {{ arg.help | indent(width=4) }}
+{%- endif %}
 {%- if not arg.hide_possible_values and arg.choices and arg.choices.choices %}
     [possible values: {{ arg.choices.choices | join(sep=", ") }}]{%- endif %}
 {%- if not arg.hide_possible_values and arg.choices and arg.choices.env %}
@@ -170,20 +172,23 @@ Global flags:
     [deprecated env: {{ env }}]{%- endfor %}{%- endif %}
 {%- if not arg.hide_default_value and arg.default %}
     (default: {{ arg.default | join(sep=", ") }}){%- endif %}
+{%- elif arg.help_rendered %}
+  {{ arg.usage | trim | ljust(width=arg.usage_col_width) }}  {{ arg.help_rendered }}
+{%- elif arg.row %}
+  {{ arg.usage | trim }}
+    {{ arg.row | indent(width=4) }}
 {%- else %}
-{%- if not arg.hide_possible_values and arg.choices and arg.choices.choices %} [{{ arg.choices.choices | join(sep=", ") }}]{%- endif %}
-{%- if not arg.hide_possible_values and arg.choices and arg.choices.env %} [choices env: {{ arg.choices.env }}]{%- endif %}
-{%- if not arg.hide_env and arg.env %} [env: {{ arg.env }}]{%- endif %}
-{%- if not arg.hide_env %}{% for env in arg.env_fallback %} [env fallback: {{ env }}]{%- endfor %}{% for env in arg.deprecated_env %} [deprecated env: {{ env }}]{%- endfor %}{%- endif %}
-{%- if not arg.hide_default_value and arg.default %} (default: {{ arg.default | join(sep=", ") }}){%- endif %}
+  {{ arg.usage | trim }}
 {%- endif %}
 {%- endfor %}
 {%- endfor %}
 {%- for group in sub.flag_groups %}
 {%- for flag in group.items %}
-  {% if flag.help %}{% if sub.flattened_next_line_help %}{{ flag.display_usage }}
-    {{ flag.help | indent(width=4) }}{% else %}{{ flag.display_usage | ljust(width=flag.usage_col_width) }}  {{ flag.help }}{% endif %}{% else %}{{ flag.display_usage }}{% endif %}
 {%- if sub.flattened_next_line_help %}
+  {{ flag.display_usage }}
+{%- if flag.help %}
+    {{ flag.help | indent(width=4) }}
+{%- endif %}
 {%- if not flag.hide_possible_values and flag.arg.choices and flag.arg.choices.choices %}
     [possible values: {{ flag.arg.choices.choices | join(sep=", ") }}]{%- endif %}
 {%- if not flag.hide_possible_values and flag.arg.choices and flag.arg.choices.env %}
@@ -195,15 +200,16 @@ Global flags:
     [deprecated env: {{ env }}]{%- endfor %}{%- endif %}
 {%- if not flag.hide_default_value and flag.default %}
     (default: {{ flag.default | join(sep=", ") }}){%- endif %}
+{%- if flag.deprecated or flag.deprecated_warn_at or flag.deprecated_remove_at %}
+    [deprecated:{% if flag.deprecated %} {{ flag.deprecated }}{% endif %}{% if flag.deprecated_warn_at %}{% if flag.deprecated %};{% endif %} warns at {{ flag.deprecated_warn_at }}{% endif %}{% if flag.deprecated_remove_at %}{% if flag.deprecated or flag.deprecated_warn_at %};{% endif %} removed at {{ flag.deprecated_remove_at }}{% endif %}]{%- endif %}
+{%- elif flag.help_rendered %}
+  {{ flag.display_usage | ljust(width=flag.usage_col_width) }}  {{ flag.help_rendered }}
+{%- elif flag.row %}
+  {{ flag.display_usage }}
+    {{ flag.row | indent(width=4) }}
 {%- else %}
-{%- if not flag.hide_possible_values and flag.arg.choices and flag.arg.choices.choices %} [{{ flag.arg.choices.choices | join(sep=", ") }}]{%- endif %}
-{%- if not flag.hide_possible_values and flag.arg.choices and flag.arg.choices.env %} [choices env: {{ flag.arg.choices.env }}]{%- endif %}
-{%- if not flag.hide_env and flag.env %} [env: {{ flag.env }}]{%- endif %}
-{%- if not flag.hide_env %}{% for env in flag.env_fallback %} [env fallback: {{ env }}]{%- endfor %}{% for env in flag.deprecated_env %} [deprecated env: {{ env }}]{%- endfor %}{%- endif %}
-{%- if not flag.hide_default_value and flag.default %} (default: {{ flag.default | join(sep=", ") }}){%- endif %}
+  {{ flag.display_usage }}
 {%- endif %}
-{%- if flag.deprecated or flag.deprecated_warn_at or flag.deprecated_remove_at %}{% if sub.flattened_next_line_help %}
-    {% else %} {% endif %}[deprecated:{% if flag.deprecated %} {{ flag.deprecated }}{% endif %}{% if flag.deprecated_warn_at %}{% if flag.deprecated %};{% endif %} warns at {{ flag.deprecated_warn_at }}{% endif %}{% if flag.deprecated_remove_at %}{% if flag.deprecated or flag.deprecated_warn_at %};{% endif %} removed at {{ flag.deprecated_remove_at }}{% endif %}]{%- endif %}
 {%- endfor %}
 {%- endfor %}
 {%- endfor %}

--- a/lib/src/docs/layout.rs
+++ b/lib/src/docs/layout.rs
@@ -146,6 +146,11 @@ pub fn render_help_text(
     (result, is_multiline)
 }
 
+/// Wrap text for the four-space block beneath an entry that overflowed its usage column.
+pub fn render_block_text(help: &str, terminal_width: usize) -> String {
+    wrap_text(help, terminal_width.saturating_sub(4)).join("\n")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/lib/src/docs/layout.rs
+++ b/lib/src/docs/layout.rs
@@ -23,6 +23,24 @@ pub fn max_usage_width<'a>(items: impl Iterator<Item = &'a str>) -> usize {
     items.map(visible_width).max().unwrap_or(0)
 }
 
+/// Calculate a readable usage column for a terminal-width help page.
+///
+/// The names get at most two fifths of the width left after the two-space indent and gap. A
+/// longer outlier is rendered as a block by its caller instead of narrowing every description
+/// on the page.
+pub fn usage_column_width<'a>(
+    items: impl Iterator<Item = &'a str>,
+    terminal_width: usize,
+) -> usize {
+    let longest = max_usage_width(items);
+    if terminal_width == usize::MAX {
+        return longest;
+    }
+    let available = terminal_width.saturating_sub(4);
+    let cap = available / 5 * 2 + available % 5 * 2 / 5;
+    longest.min(cap)
+}
+
 /// Calculate visible width of a string (ignoring ANSI codes)
 pub fn visible_width(s: &str) -> usize {
     // Simple implementation - counts chars
@@ -137,6 +155,29 @@ mod tests {
         assert_eq!(visible_width("hello"), 5);
         assert_eq!(visible_width(""), 0);
         assert_eq!(visible_width("hello world"), 11);
+    }
+
+    #[test]
+    fn test_usage_column_width_caps_outliers() {
+        assert_eq!(
+            usage_column_width(["--short", "--longer"].into_iter(), 80),
+            8
+        );
+        assert_eq!(
+            usage_column_width(
+                [
+                    "--short",
+                    "--report-unused-disable-directives-severity <SEVERITY>"
+                ]
+                .into_iter(),
+                80,
+            ),
+            30,
+        );
+        assert_eq!(
+            usage_column_width(["--an-unbounded-column"].into_iter(), usize::MAX),
+            21,
+        );
     }
 
     #[test]

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -192,6 +192,7 @@ pub struct SpecFlag {
     #[serde(skip_serializing_if = "String::is_empty")]
     pub ann_indent: String,
     pub help_is_multiline: bool,
+    pub help_is_block: bool,
     pub usage_col_width: usize,
 }
 
@@ -566,6 +567,7 @@ pub struct SpecArg {
     #[serde(skip_serializing_if = "String::is_empty")]
     pub ann_indent: String,
     pub help_is_multiline: bool,
+    pub help_is_block: bool,
     pub usage_col_width: usize,
 }
 
@@ -643,7 +645,9 @@ impl From<&crate::Spec> for Spec {
 
 impl From<&crate::SpecCommand> for SpecCommand {
     fn from(cmd: &crate::SpecCommand) -> Self {
-        use crate::docs::layout::{help_width, max_usage_width, render_help_text};
+        use crate::docs::layout::{
+            help_width, render_block_text, render_help_text, usage_column_width, visible_width,
+        };
 
         let terminal_width = help_width(cmd.term_width, cmd.max_term_width);
         let flattened_usage = if cmd.flatten_help {
@@ -665,7 +669,8 @@ impl From<&crate::SpecCommand> for SpecCommand {
         };
 
         // Calculate layout for args
-        let args_usage_col_width = max_usage_width(cmd.args.iter().map(|a| a.usage.as_str()));
+        let args_usage_col_width =
+            usage_column_width(cmd.args.iter().map(|a| a.usage.as_str()), terminal_width);
         let mut args: Vec<(usize, SpecArg)> = cmd
             .args
             .iter()
@@ -676,13 +681,21 @@ impl From<&crate::SpecCommand> for SpecCommand {
                 // Get help text (prefer help_long over help)
                 let help_text = spec_arg.help_long.as_deref().or(spec_arg.help.as_deref());
 
+                spec_arg.help_is_block = visible_width(&spec_arg.usage) > args_usage_col_width;
+
                 if let Some(help) = help_text {
-                    let (rendered, is_multiline) =
-                        render_help_text(help, terminal_width, args_usage_col_width);
-                    // Only set help_rendered if we have content (empty string signals block layout)
-                    if !rendered.is_empty() {
-                        spec_arg.help_rendered = Some(rendered);
-                        spec_arg.help_is_multiline = is_multiline;
+                    if spec_arg.help_is_block {
+                        spec_arg.row = Some(render_block_text(help, terminal_width));
+                    } else {
+                        let (rendered, is_multiline) =
+                            render_help_text(help, terminal_width, args_usage_col_width);
+                        // Only set help_rendered if we have content (empty string signals block layout)
+                        if !rendered.is_empty() {
+                            spec_arg.help_rendered = Some(rendered);
+                            spec_arg.help_is_multiline = is_multiline;
+                        } else {
+                            spec_arg.row = Some(help.to_string());
+                        }
                     }
                 }
 
@@ -702,20 +715,32 @@ impl From<&crate::SpecCommand> for SpecCommand {
             .collect();
         flags.sort_by_key(|(_, flag)| flag.display_order.unwrap_or(999));
         let flags: Vec<SpecFlag> = flags.into_iter().map(|(_, flag)| flag).collect();
-        let flags_usage_col_width = max_usage_width(flags.iter().map(|f| f.display_usage.as_str()));
+        let flags_usage_col_width = usage_column_width(
+            flags.iter().map(|f| f.display_usage.as_str()),
+            terminal_width,
+        );
         let flags: Vec<SpecFlag> = flags
             .into_iter()
             .map(|mut spec_flag| {
                 // Get help text (prefer help_long over help)
                 let help_text = spec_flag.help_long.as_deref().or(spec_flag.help.as_deref());
 
+                spec_flag.help_is_block =
+                    visible_width(&spec_flag.display_usage) > flags_usage_col_width;
+
                 if let Some(help) = help_text {
-                    let (rendered, is_multiline) =
-                        render_help_text(help, terminal_width, flags_usage_col_width);
-                    // Only set help_rendered if we have content (empty string signals block layout)
-                    if !rendered.is_empty() {
-                        spec_flag.help_rendered = Some(rendered);
-                        spec_flag.help_is_multiline = is_multiline;
+                    if spec_flag.help_is_block {
+                        spec_flag.row = Some(render_block_text(help, terminal_width));
+                    } else {
+                        let (rendered, is_multiline) =
+                            render_help_text(help, terminal_width, flags_usage_col_width);
+                        // Only set help_rendered if we have content (empty string signals block layout)
+                        if !rendered.is_empty() {
+                            spec_flag.help_rendered = Some(rendered);
+                            spec_flag.help_is_multiline = is_multiline;
+                        } else {
+                            spec_flag.row = Some(help.to_string());
+                        }
                     }
                 }
 
@@ -1099,6 +1124,7 @@ impl From<&crate::SpecFlag> for SpecFlag {
             row: None,
             ann_indent: String::new(),
             help_is_multiline: false,
+            help_is_block: false,
             usage_col_width: 0,
         }
     }
@@ -1153,6 +1179,7 @@ impl From<&crate::SpecArg> for SpecArg {
             row: None,
             ann_indent: String::new(),
             help_is_multiline: false,
+            help_is_block: false,
             usage_col_width: 0,
         }
     }

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -2525,8 +2525,10 @@ fn typed_help_width_reaches_help_and_the_portable_spec() {
     assert_eq!(spec.root.max_term_width, Some(20));
     let page = usage::argv::help::long_help(spec, &["sized-help"], &[spec.root]);
     assert!(
-        page.contains("                         description\n"),
-        "fixed width should wrap and override the lower maximum: {page}"
+        page.contains("    A description long enough to\n")
+            && page.contains("    wrap at the command's declared\n")
+            && page.contains("    help width.\n"),
+        "fixed width should wrap an overflowing entry below its usage: {page}"
     );
 
     let kdl = SizedHelp::to_kdl();
@@ -2535,6 +2537,17 @@ fn typed_help_width_reaches_help_and_the_portable_spec() {
     let portable: usage_parser::Spec = kdl.parse().unwrap();
     assert_eq!(portable.cmd.term_width, Some(36));
     assert_eq!(portable.cmd.max_term_width, Some(20));
+    assert_eq!(
+        page,
+        usage_parser::docs::cli::render_help(&portable, &portable.cmd, true),
+        "the portable long-help template should render the wrapped block row"
+    );
+    assert!(
+        page.lines()
+            .filter(|line| !line.starts_with("Usage:"))
+            .all(|line| line.chars().count() <= 36),
+        "fixed-width help exceeded 36 columns: {page}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- cap aligned usage columns at 40% of the width remaining after indentation
- render only entries exceeding the cap with their help underneath
- keep the reference and zero-allocation help renderers in parity

This prevents a single long flag, such as `--report-unused-disable-directives-severity <SEVERITY>` in oxc, from forcing every flag on an 80-column page into block layout. Explicitly unbounded help retains its natural column width.

## Tests

- `cargo test --all --all-features`
- `cargo clippy --all --all-features -- -D warnings`
- `cargo fmt --all -- --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Help layout is user-visible and must stay byte-aligned across three renderers; a mismatch would change `--help` output for many CLIs, but this is presentation-only with no parse or security impact.
> 
> **Overview**
> Caps the aligned usage column in CLI help so one long flag, argument, or command name cannot squeeze every description on the page.
> 
> Usage names now take at most two fifths of the width left after indent. Entries that exceed that cap drop into a wrapped block under their own spelling; shorter neighbors keep a readable two-column layout. Unbounded pages (`term_width = 0`) still use the natural column.
> 
> The same rule is applied in the zero-allocation argv renderer, the Go renderer, and the portable docs templates, including flattened nested help. Short-help flattened rows now go through the shared `entry` path so wrapping and annotations stay in parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71d36930de94c416ee2aaebe9ac33c056283b088. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI help formatting for unusually long flags, arguments, and command names.
  * Long entries now use an indented block layout instead of widening description columns.
  * Preserved consistent wrapping and indentation across short, long, and flattened help displays.
  * Improved rendering for narrow terminal widths while retaining natural sizing in unbounded layouts.
  * Applied consistent width limits and block formatting to nested command help.
  * Improved placement of descriptions, aliases, and deprecation markers for oversized entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->