### PR TITLE
fix(cli): omit repeatability markers from output

### DIFF
--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -795,7 +795,7 @@ fn usage_section(out: &mut String, spec: &Spec<'_>, path: &[&str], meta: &Comman
 
 /// How one flag appears in the usage line: `-f --force`, plus its value if it takes one.
 fn flag_usage(meta: &FlagMeta<'_>) -> String {
-    flag_usage_masked(meta, &Shown::all(meta))
+    flag_usage_masked(meta, &Shown::all(meta), true)
 }
 
 /// The spellings of one flag that a page should offer.
@@ -878,7 +878,7 @@ impl<'a> Shown<'a> {
 /// A descendant may take one of an ancestor's two spellings — its own `-v` beside the root's
 /// `-v, --verbose` — and the parser still accepts the other, so the page has to offer the other
 /// and not the one that now means something else.
-fn flag_usage_masked(meta: &FlagMeta<'_>, show: &Shown) -> String {
+fn flag_usage_masked(meta: &FlagMeta<'_>, show: &Shown, show_repeatable: bool) -> String {
     let flag = meta.flag;
     let mut out = String::new();
 
@@ -921,7 +921,7 @@ fn flag_usage_masked(meta: &FlagMeta<'_>, show: &Shown) -> String {
 
     // A repeatable flag, which is the spec's `var=#true` — not one occurrence taking several
     // values, which is the value's own business below.
-    if meta.repeatable {
+    if show_repeatable && meta.repeatable {
         out.push('…');
     }
     if flag.takes_value {
@@ -1863,7 +1863,10 @@ pub(crate) fn flag_spelling(meta: &FlagMeta<'_>) -> String {
 }
 
 fn display_usage_masked(meta: &FlagMeta<'_>, show: &Shown) -> String {
-    let usage = flag_usage_masked(meta, show);
+    // Repetition is useful in the formal usage grammar, but an ellipsis immediately after a
+    // flag spelling looks like terminal truncation in the aligned help table. clap and most
+    // other CLIs list the ordinary spelling here and leave repeatability to the description.
+    let usage = flag_usage_masked(meta, show, false);
     match meta.flag.negate.filter(|_| show.negate) {
         // A flag whose only spelling is its negation has nothing before it: the name prefix
         // would repeat the spelling, so `flag_usage_masked` writes nothing and the negation

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -795,7 +795,7 @@ fn usage_section(out: &mut String, spec: &Spec<'_>, path: &[&str], meta: &Comman
 
 /// How one flag appears in the usage line: `-f --force`, plus its value if it takes one.
 fn flag_usage(meta: &FlagMeta<'_>) -> String {
-    flag_usage_masked(meta, &Shown::all(meta), true)
+    flag_usage_masked(meta, &Shown::all(meta))
 }
 
 /// The spellings of one flag that a page should offer.
@@ -878,7 +878,7 @@ impl<'a> Shown<'a> {
 /// A descendant may take one of an ancestor's two spellings — its own `-v` beside the root's
 /// `-v, --verbose` — and the parser still accepts the other, so the page has to offer the other
 /// and not the one that now means something else.
-fn flag_usage_masked(meta: &FlagMeta<'_>, show: &Shown, show_repeatable: bool) -> String {
+fn flag_usage_masked(meta: &FlagMeta<'_>, show: &Shown) -> String {
     let flag = meta.flag;
     let mut out = String::new();
 
@@ -887,8 +887,8 @@ fn flag_usage_masked(meta: &FlagMeta<'_>, show: &Shown, show_repeatable: bool) -
     // spec does not.
     //
     // Judged on the forms this page is *showing*. mise's root has a global `-E --env`; a
-    // descendant that claims `--env` leaves `-E` inherited, and `-E… <ENV>` alone gives a
-    // reader nothing to connect it to the `--env` they saw elsewhere. `env: -E… <ENV>` does.
+    // descendant that claims `--env` leaves `-E` inherited, and `-E <ENV>` alone gives a
+    // reader nothing to connect it to the `--env` they saw elsewhere. `env: -E <ENV>` does.
     let long = show.long;
     let short = show.short.as_ref();
     let implied = long.or_else(|| short.map(|_| ""));
@@ -919,11 +919,6 @@ fn flag_usage_masked(meta: &FlagMeta<'_>, show: &Shown, show_repeatable: bool) -
         let _ = write!(out, "--{long}");
     }
 
-    // A repeatable flag, which is the spec's `var=#true` — not one occurrence taking several
-    // values, which is the value's own business below.
-    if show_repeatable && meta.repeatable {
-        out.push('…');
-    }
     if flag.takes_value {
         // Angled where the value must be given, squared where it need not — the same brackets
         // an argument uses, and for the same reason. pitchfork's `--bump` is the fleet's case.
@@ -1863,10 +1858,7 @@ pub(crate) fn flag_spelling(meta: &FlagMeta<'_>) -> String {
 }
 
 fn display_usage_masked(meta: &FlagMeta<'_>, show: &Shown) -> String {
-    // Repetition is useful in the formal usage grammar, but an ellipsis immediately after a
-    // flag spelling looks like terminal truncation in the aligned help table. clap and most
-    // other CLIs list the ordinary spelling here and leave repeatability to the description.
-    let usage = flag_usage_masked(meta, show, false);
+    let usage = flag_usage_masked(meta, show);
     match meta.flag.negate.filter(|_| show.negate) {
         // A flag whose only spelling is its negation has nothing before it: the name prefix
         // would repeat the spelling, so `flag_usage_masked` writes nothing and the negation

--- a/conformance/tests/flag_column.rs
+++ b/conformance/tests/flag_column.rs
@@ -15,6 +15,7 @@
 //! there is a long form to line up with. `-j <JOBS>` has none, so it does not pad; that is
 //! clap's behaviour and not an oversight in it.
 
+use usage::docs::markdown::MarkdownRenderer;
 use usage_argv::help;
 use usage_derive::Cli;
 
@@ -37,26 +38,41 @@ struct Ex {
     /// Its description is long enough to need wrapping at any sane width
     #[usage(long)]
     describe: bool,
+}
+
+#[derive(Cli)]
+#[usage(bin = "repeat")]
+#[allow(dead_code)]
+struct Repeatable {
     /// A repeatable value
-    #[usage(long)]
-    tag: Vec<String>,
+    #[usage(short = 'A', long, value_name = "NAME")]
+    allow: Vec<String>,
     /// Repeatable verbosity
     #[usage(long, count)]
     verbose: u8,
 }
 
 #[test]
-fn repeatable_flags_do_not_look_truncated_in_the_help_table() {
+fn repeatable_flags_have_ordinary_spellings_in_every_rendered_format() {
     for long in [false, true] {
-        let compiled = page(long);
-        assert!(compiled.contains("--tag <TAG>"), "long={long}: {compiled}");
+        let compiled =
+            help::render(Repeatable::spec(), Repeatable::spec().root.cmd, long).expect("a page");
+        assert!(
+            compiled.contains("-A, --allow <NAME>"),
+            "long={long}: {compiled}"
+        );
         assert!(compiled.contains("--verbose"), "long={long}: {compiled}");
-        assert!(!compiled.contains("--tag…"), "long={long}: {compiled}");
-        assert!(!compiled.contains("--verbose…"), "long={long}: {compiled}");
+        assert!(!compiled.contains('…'), "long={long}: {compiled}");
 
-        let spec: usage::Spec = Ex::to_kdl().parse().expect("generated spec");
+        let spec: usage::Spec = Repeatable::to_kdl().parse().expect("generated spec");
         let reference = usage::docs::cli::render_help(&spec, &spec.cmd, long);
         assert_eq!(reference, compiled);
+
+        let markdown = MarkdownRenderer::new(spec.clone())
+            .render_cmd(&spec.cmd)
+            .expect("markdown page");
+        assert!(markdown.contains("-A --allow <NAME>"), "{markdown}");
+        assert!(!markdown.contains('…'), "{markdown}");
     }
 }
 

--- a/conformance/tests/flag_column.rs
+++ b/conformance/tests/flag_column.rs
@@ -37,6 +37,27 @@ struct Ex {
     /// Its description is long enough to need wrapping at any sane width
     #[usage(long)]
     describe: bool,
+    /// A repeatable value
+    #[usage(long)]
+    tag: Vec<String>,
+    /// Repeatable verbosity
+    #[usage(long, count)]
+    verbose: u8,
+}
+
+#[test]
+fn repeatable_flags_do_not_look_truncated_in_the_help_table() {
+    for long in [false, true] {
+        let compiled = page(long);
+        assert!(compiled.contains("--tag <TAG>"), "long={long}: {compiled}");
+        assert!(compiled.contains("--verbose"), "long={long}: {compiled}");
+        assert!(!compiled.contains("--tag…"), "long={long}: {compiled}");
+        assert!(!compiled.contains("--verbose…"), "long={long}: {compiled}");
+
+        let spec: usage::Spec = Ex::to_kdl().parse().expect("generated spec");
+        let reference = usage::docs::cli::render_help(&spec, &spec.cmd, long);
+        assert_eq!(reference, compiled);
+    }
 }
 
 fn page(long: bool) -> String {

--- a/conformance/tests/flag_column.rs
+++ b/conformance/tests/flag_column.rs
@@ -65,6 +65,13 @@ fn repeatable_flags_have_ordinary_spellings_in_every_rendered_format() {
         assert!(!compiled.contains('…'), "long={long}: {compiled}");
 
         let spec: usage::Spec = Repeatable::to_kdl().parse().expect("generated spec");
+        let allow = spec
+            .cmd
+            .flags
+            .iter()
+            .find(|flag| flag.name == "allow")
+            .expect("generated spec should contain allow");
+        assert!(allow.var, "allow must remain repeatable in generated spec");
         let reference = usage::docs::cli::render_help(&spec, &spec.cmd, long);
         assert_eq!(reference, compiled);
 

--- a/corpus/render/01-flag-values.json
+++ b/corpus/render/01-flag-values.json
@@ -60,10 +60,10 @@
     },
     {
       "id": "flag-repeatable-with-optional-value",
-      "doc": "A repeatable flag's own ellipsis follows the spellings, before the value — so a repeatable flag taking an optional value shows both.",
+      "doc": "A repeatable flag uses its ordinary spelling in output; repeatability remains structural metadata rather than a presentation suffix.",
       "spec": "name \"ex\"\nbin \"ex\"\nflag \"--jobs [n]\" var=#true required=#true help=\"How many\"\n",
       "expect": {
-        "usage": "ex <--jobs… [n]>"
+        "usage": "ex <--jobs [n]>"
       }
     },
     {

--- a/docs/cli/reference/commands.json
+++ b/docs/cli/reference/commands.json
@@ -457,7 +457,7 @@
           },
           {
             "name": "env",
-            "usage": "-e --env… <ENV>",
+            "usage": "-e --env <ENV>",
             "help": "Environment to explain against, as KEY=VALUE, repeatable",
             "help_long": "Environment to explain against, as KEY=VALUE, repeatable\n\nGiven at all, these are the *whole* environment: an explanation pasted into a bug report has to mean the same thing on the machine that reads it. Omitted, the process environment is used, which is what an execution would see.",
             "help_first_line": "Environment to explain against, as KEY=VALUE, repeatable",
@@ -1434,7 +1434,7 @@
               },
               {
                 "name": "template",
-                "usage": "--template… <TEMPLATE>",
+                "usage": "--template <TEMPLATE>",
                 "help": "Override a Tera template with NAME=PATH",
                 "help_first_line": "Override a Tera template with NAME=PATH",
                 "short": [],

--- a/docs/cli/reference/explain.md
+++ b/docs/cli/reference/explain.md
@@ -29,7 +29,7 @@ command line does not parse: the report succeeded, and that is the case worth a 
   **Default:** `text`
 
 - **`--view <VIEW>`** — A spec-declared executable view to explain
-- **`-e --env… <ENV>`** — Environment to explain against, as KEY=VALUE, repeatable
+- **`-e --env <ENV>`** — Environment to explain against, as KEY=VALUE, repeatable
 
   Given at all, these are the _whole_ environment: an explanation pasted into a bug report has to mean the same thing on the machine that reads it. Omitted, the process environment is used, which is what an execution would see.
 

--- a/docs/cli/reference/generate/markdown.md
+++ b/docs/cli/reference/generate/markdown.md
@@ -25,5 +25,5 @@ Generate markdown documentation from usage specs
 
 - **`--replace-pre-with-code-fences`** — Replace `<pre>` tags with markdown code fences
 - **`--url-prefix <URL_PREFIX>`** — Prefix to add to all URLs
-- **`--template… <TEMPLATE>`** — Override a Tera template with NAME=PATH
+- **`--template <TEMPLATE>`** — Override a Tera template with NAME=PATH
 - **`-h --help`** — Print help

--- a/examples/docs/MISE_INLINE.md
+++ b/examples/docs/MISE_INLINE.md
@@ -14,12 +14,12 @@ mise prepares your development environment before each command runs. https://git
 
 ## Global Flags
 - **`-C --cd <DIR>`** — Change directory before running command
-- **`-E --env… <ENV>`** — Set the environment for loading `mise.<ENV>.toml`
+- **`-E --env <ENV>`** — Set the environment for loading `mise.<ENV>.toml`
 - **`-j --jobs <JOBS>`** — How many jobs to run in parallel; values below 1 are treated as 1 [default: 8]
 
   **Environment Variable:** `MISE_JOBS`
 - **`-q --quiet`** — Suppress non-error messages
-- **`-v --verbose…`** — Show extra output (use -vv for even more)
+- **`-v --verbose`** — Show extra output (use -vv for even more)
 - **`-y --yes`** — Answer yes to all confirmation prompts
 - **`--raw`** — Read/write directly to stdin/stdout/stderr instead of by line
 - **`--locked`** — Require lockfile URLs to be present during installation
@@ -289,13 +289,13 @@ Use `--skip <part>` to skip named parts, or `--only <part>` to run just named pa
 - **`-n --dry-run`** — Print what would happen without installing anything
 - **`-y --yes`** — Skip confirmation prompts
 - **`--force-dotfiles`** — Overwrite existing files that conflict with whole-file dotfile entries
-- **`--only… <ONLY>`** — Run only one or more bootstrap parts
+- **`--only <ONLY>`** — Run only one or more bootstrap parts
 
   Can be passed multiple times or as a comma-separated list. Cannot be used with `--skip`.
 
   **Choices:** `plugins`, `packages`, `accounts`, `files`, `services`, `firewall`, `compose`, `repos`, `dotfiles`, `mise-shell-activate`, `macos-defaults`, `macos-launchd-agents`, `linux-systemd-units`, `user`, `tools`, `task`, `final-hook`
 - **`--prompt-secrets`** — Prompt securely for missing bootstrap secret inputs
-- **`--skip… <SKIP>`** — Skip one or more bootstrap parts
+- **`--skip <SKIP>`** — Skip one or more bootstrap parts
 
   Can be passed multiple times or as a comma-separated list.
 
@@ -1032,29 +1032,29 @@ Bootstrap one or more machines over OpenSSH
 - **`--connect-timeout <CONNECT_TIMEOUT>`** — SSH connection timeout in seconds
 
   **Default:** `10`
-- **`--copy-link… <PATH>`** — Dereference one source-relative symbolic link; repeat for multiple links
+- **`--copy-link <PATH>`** — Dereference one source-relative symbolic link; repeat for multiple links
 - **`--copy-links`** — Dereference every symbolic link in the source archive
-- **`--exclude… <PATTERN>`** — Additional archive pattern to exclude; repeat for multiple patterns
+- **`--exclude <PATTERN>`** — Additional archive pattern to exclude; repeat for multiple patterns
 - **`--fail-fast`** — Stop after the first failed target
 - **`--force-dotfiles`** — Allow remote dotfile conflicts to be replaced
-- **`--host… <[USER@]HOST>`** — Ad-hoc SSH destination (`[user@]host`); repeat for multiple hosts
+- **`--host <[USER@]HOST>`** — Ad-hoc SSH destination (`[user@]host`); repeat for multiple hosts
 - **`-i --identity-file <IDENTITY_FILE>`** — SSH identity file override
 - **`-n --dry-run`** — Print the remote bootstrap changes without applying them
 - **`--keep-staging`** — Keep the remote staging directory for debugging
 - **`--mise-bin <MISE_BIN>`** — Local mise binary to upload (escape hatch for custom architectures)
-- **`--only… <ONLY>`** — Run only one or more remote bootstrap parts
+- **`--only <ONLY>`** — Run only one or more remote bootstrap parts
 
   **Choices:** `plugins`, `packages`, `accounts`, `files`, `services`, `firewall`, `compose`, `repos`, `dotfiles`, `mise-shell-activate`, `macos-defaults`, `macos-launchd-agents`, `linux-systemd-units`, `user`, `tools`, `task`, `final-hook`
 - **`--port <PORT>`** — SSH port override
 - **`--prompt-secrets`** — Prompt securely for missing secret inputs on the remote host
-- **`--remote-env… <ENV>`** — Config environments to load on the remote host; repeat or delimit with commas (for example, ci,dotfiles)
+- **`--remote-env <ENV>`** — Config environments to load on the remote host; repeat or delimit with commas (for example, ci,dotfiles)
 - **`--remote-mise <COMMAND>`** — Existing mise executable name or path; relative paths use the staged project
-- **`--skip… <SKIP>`** — Skip one or more remote bootstrap parts
+- **`--skip <SKIP>`** — Skip one or more remote bootstrap parts
 
   **Choices:** `plugins`, `packages`, `accounts`, `files`, `services`, `firewall`, `compose`, `repos`, `dotfiles`, `mise-shell-activate`, `macos-defaults`, `macos-launchd-agents`, `linux-systemd-units`, `user`, `tools`, `task`, `final-hook`
 - **`--source <SOURCE>`** — Local directory archived and sent to each target
-- **`--ssh-option… <OPTION>`** — OpenSSH `-o` option; repeat for multiple options
-- **`--tag… <TAG>`** — Select configured hosts with this tag; repeat to match any tag
+- **`--ssh-option <OPTION>`** — OpenSSH `-o` option; repeat for multiple options
+- **`--tag <TAG>`** — Select configured hosts with this tag; repeat to match any tag
 - **`--update`** — Refresh package manager metadata and update configured repos remotely
 - **`-y --yes`** — Skip remote confirmation prompts
 
@@ -1251,7 +1251,7 @@ Show the cache directory path
 
 ## `mise cache prune`
 
-- **Usage:** `mise cache prune [-v --verbose…] [--dry-run] [TOOL]…`
+- **Usage:** `mise cache prune [-v --verbose] [--dry-run] [TOOL]…`
 - **Aliases:** `p`
 - **Effect:** modifies state
 
@@ -1264,7 +1264,7 @@ By default, this command will remove files that have not been accessed in 30 day
   e.g.: node, python
 
 ### Flags
-- **`-v --verbose…`** — Show pruned files
+- **`-v --verbose`** — Show pruned files
 - **`--dry-run`** — Just show what would be pruned
 
 ## `mise cache task`
@@ -1725,12 +1725,12 @@ The "--" separates runtimes from the commands to pass along to the subprocess.
   [default: 4]
 
   **Environment Variable:** `MISE_JOBS`
-- **`--allow-env… <VAR>`** — Allow specific env var through (implies --deny-env for everything else)
+- **`--allow-env <VAR>`** — Allow specific env var through (implies --deny-env for everything else)
   Supports wildcards, e.g. --allow-env='MYAPP_*'
-- **`--allow-net… <HOST>`** — Allow network to specific host (implies --deny-net for everything else)
+- **`--allow-net <HOST>`** — Allow network to specific host (implies --deny-net for everything else)
   macOS only in v1; on Linux falls back to allowing all network
-- **`--allow-read… <PATH>`** — Allow reads from specific path (implies --deny-read for everything else)
-- **`--allow-write… <PATH>`** — Allow writes to specific path (implies --deny-write for everything else)
+- **`--allow-read <PATH>`** — Allow reads from specific path (implies --deny-read for everything else)
+- **`--allow-write <PATH>`** — Allow writes to specific path (implies --deny-write for everything else)
 - **`--deny-all`** — Block reads, writes, network, and env vars
 - **`--deny-env`** — Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)
 - **`--deny-net`** — Block all network access
@@ -2002,10 +2002,10 @@ When generating stubs with platform-specific URLs, the command will append new p
   **Default:** `http`
 - **`--lock`** — Resolve and embed lockfile data (exact version + platform URLs/checksums)
   into an existing stub file for reproducible installs without runtime API calls
-- **`--platform-bin… <PLATFORM_BIN>`** — Platform-specific binary paths in the format platform:path
+- **`--platform-bin <PLATFORM_BIN>`** — Platform-specific binary paths in the format platform:path
 
   Examples: --platform-bin windows-x64:tool.exe --platform-bin linux-x64:bin/tool
-- **`--platform-url… <PLATFORM_URL>`** — Platform-specific URLs in the format platform:url or just url (auto-detect platform)
+- **`--platform-url <PLATFORM_URL>`** — Platform-specific URLs in the format platform:url or just url (auto-detect platform)
 
   When the output file already exists, new platforms will be appended to the existing platforms table. Existing platform URLs will be updated if specified again.
 
@@ -2134,7 +2134,7 @@ Use `mise local` to set a tool version locally in the current directory.
 - **`--path`** — Get the path of the global config file
 - **`--pin`** — Save exact version to `~/.tool-versions`
   e.g.: `mise global --pin node@20` will save `node 20.0.0` to ~/.tool-versions
-- **`--remove… <TOOL>`** — Remove the tool(s) from ~/.tool-versions
+- **`--remove <TOOL>`** — Remove the tool(s) from ~/.tool-versions
 
 Examples:
     # set the current version of node to 20.x
@@ -2235,7 +2235,7 @@ Tools will be installed in parallel. To disable, set `--jobs=1` or `MISE_JOBS=1`
 
   **Environment Variable:** `MISE_JOBS`
 - **`-n --dry-run`** — Show what would be installed without actually installing
-- **`-v --verbose…`** — Show installation output
+- **`-v --verbose`** — Show installation output
 
   This argument will print backend output such as download, configuration, and compilation output.
 - **`--dry-run-code`** — Like --dry-run but exits with code 1 if there are tools to install
@@ -2370,7 +2370,7 @@ Use this to set a tool's version when within a directory Use `mise global` to se
 - **`--path`** — Get the path of the config file
 - **`--pin`** — Save exact version to `.tool-versions`
   e.g.: `mise local --pin node@20` will save `node 20.0.0` to .tool-versions
-- **`--remove… <TOOL>`** — Remove the tool(s) from .tool-versions
+- **`--remove <TOOL>`** — Remove the tool(s) from .tool-versions
 
 Examples:
     # set the current version of node to 20.x for the current directory
@@ -2413,7 +2413,7 @@ Updates checksums and download URLs for all platforms already specified in the l
 
   **Environment Variable:** `MISE_JOBS`
 - **`-n --dry-run`** — Show what would be updated without making changes
-- **`-p --platform… <PLATFORM>`** — Comma-separated list of platforms to target
+- **`-p --platform <PLATFORM>`** — Comma-separated list of platforms to target
   e.g.: linux-x64,macos-arm64,windows-x64
   If not specified, all platforms already in lockfile will be updated
 - **`--bump`** — Re-resolve fuzzy version selectors against the latest available versions
@@ -2627,7 +2627,7 @@ Each tool version becomes its own content-addressable OCI layer. Bumping a tool 
 Requires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`).
 
 ### Flags
-- **`--copy… <HOST_PATH:IMAGE_PATH>`** — Copy a host file, directory, or symlink into the image (repeatable, HOST:IMAGE)
+- **`--copy <HOST_PATH:IMAGE_PATH>`** — Copy a host file, directory, or symlink into the image (repeatable, HOST:IMAGE)
 - **`-o --output <OUTPUT>`** — Output directory for the OCI image layout
 
   **Default:** `./mise-oci`
@@ -2754,10 +2754,10 @@ Requires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`) and one of
 - **`--owner <UID[:GID]>`** — UID[:GID] to assign to every tar entry when building (conflicts with --image-dir)
 
   Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive.
-- **`--volume… <HOST:CONTAINER>`** — Bind-mount a host path (repeatable, `HOST:CONTAINER[:MODE]`)
+- **`--volume <HOST:CONTAINER>`** — Bind-mount a host path (repeatable, `HOST:CONTAINER[:MODE]`)
 
   Note: unlike `docker run -v`, there's no `-v` short flag here because mise reserves `-v` for --verbose. Use `--volume` or `--mount`.
-- **`-e --env… <KEY=VAL>`** — Set environment variable in the container (repeatable, `KEY=VAL`)
+- **`-e --env <KEY=VAL>`** — Set environment variable in the container (repeatable, `KEY=VAL`)
 - **`-i --interactive`** — Run interactively (pass `-i` to the engine)
 - **`-t --tty`** — Allocate a TTY (pass `-t` to the engine)
 - **`-w --workdir <WORKDIR>`** — Working directory inside the container
@@ -2895,7 +2895,7 @@ This behavior can be modified in ~/.config/mise/config.toml
 - **`-f --force`** — Reinstall even if plugin exists
 - **`-j --jobs <JOBS>`** — Number of jobs to run in parallel
   Values below 1 are treated as 1
-- **`-v --verbose…`** — Show installation output
+- **`-v --verbose`** — Show installation output
 
 Examples:
 
@@ -3054,8 +3054,8 @@ Providers with `auto = true` are automatically invoked before `mise x` and `mise
   Requires monorepo_root = true plus explicit [monorepo].config_roots in the monorepo root config. Providers are named like //apps/api:uv.
 
   **Environment Variable:** `MISE_MONOREPO`
-- **`--only… <ONLY>`** — Run specific deps rule(s) only
-- **`--skip… <SKIP>`** — Skip specific deps rule(s)
+- **`--only <ONLY>`** — Run specific deps rule(s) only
+- **`--skip <SKIP>`** — Skip specific deps rule(s)
 
 Examples:
 
@@ -3123,8 +3123,8 @@ Checks if dependency lockfiles are newer than installed outputs and runs install
   Requires monorepo_root = true plus explicit [monorepo].config_roots in the monorepo root config. Providers are named like //apps/api:uv.
 
   **Environment Variable:** `MISE_MONOREPO`
-- **`--only… <ONLY>`** — Run specific deps rule(s) only
-- **`--skip… <SKIP>`** — Skip specific deps rule(s)
+- **`--only <ONLY>`** — Run specific deps rule(s) only
+- **`--skip <SKIP>`** — Skip specific deps rule(s)
 
 ## `mise deps remove`
 
@@ -3295,13 +3295,13 @@ Alternatively, tasks can be defined as standalone scripts. These must be located
 - **`-S --silent`** — Don't show any output except for errors
 
   **Environment Variable:** `MISE_SILENT`
-- **`-t --tool… <TOOL@VERSION>`** — Tool(s) to run in addition to what is in mise.toml files
+- **`-t --tool <TOOL@VERSION>`** — Tool(s) to run in addition to what is in mise.toml files
   e.g.: node@20 python@3.10
-- **`--allow-env… <VAR>`** — Allow specific env var through (implies --deny-env for everything else)
+- **`--allow-env <VAR>`** — Allow specific env var through (implies --deny-env for everything else)
   Supports wildcards, e.g. --allow-env='MYAPP_*'
-- **`--allow-net… <HOST>`** — Allow network to specific host (implies --deny-net for everything else)
-- **`--allow-read… <PATH>`** — Allow reads from specific path (implies --deny-read for everything else)
-- **`--allow-write… <PATH>`** — Allow writes to specific path (implies --deny-write for everything else)
+- **`--allow-net <HOST>`** — Allow network to specific host (implies --deny-net for everything else)
+- **`--allow-read <PATH>`** — Allow reads from specific path (implies --deny-read for everything else)
+- **`--allow-write <PATH>`** — Allow writes to specific path (implies --deny-write for everything else)
 - **`--deny-all`** — Block reads, writes, network, and env vars
 - **`--deny-env`** — Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)
 - **`--deny-net`** — Block all network access
@@ -3438,10 +3438,10 @@ Use `-E <env>` to create/modify environment-specific config files like `mise.<en
 - **`--age-key-file <PATH>`** — [experimental] Age identity file for encryption
 
   Defaults to ~/.config/mise/age.txt if it exists
-- **`--age-recipient… <RECIPIENT>`** — [experimental] Age recipient (x25519 public key) for encryption
+- **`--age-recipient <RECIPIENT>`** — [experimental] Age recipient (x25519 public key) for encryption
 
   Can be used multiple times. Requires --age-encrypt.
-- **`--age-ssh-recipient… <PATH_OR_PUBKEY>`** — [experimental] SSH recipient (public key or path) for age encryption
+- **`--age-ssh-recipient <PATH_OR_PUBKEY>`** — [experimental] SSH recipient (public key or path) for age encryption
 
   Can be used multiple times. Requires --age-encrypt.
 - **`--file <FILE>`** — The TOML file to update
@@ -3866,18 +3866,18 @@ Adds a task to the local mise.toml file. See https://mise.jdx.dev/configuration.
 - **`[-- RUN]…`**
 
 ### Flags
-- **`-a --alias… <ALIAS>`** — Other names for the task
-- **`-d --depends… <DEPENDS>`** — Add dependencies to the task
+- **`-a --alias <ALIAS>`** — Other names for the task
+- **`-d --depends <DEPENDS>`** — Add dependencies to the task
 - **`-D --dir <DIR>`** — Run the task in a specific directory
 - **`-f --file`** — Create a file task instead of a toml task
 - **`-H --hide`** — Hide the task from `mise tasks` and completions
 - **`-q --quiet`** — Do not print the command before running
 - **`-r --raw`** — Directly connect stdin/stdout/stderr
-- **`-s --sources… <SOURCES>`** — Glob patterns of files this task uses as input
-- **`-w --wait-for… <WAIT_FOR>`** — Wait for these tasks to complete if they are to run
-- **`--depends-post… <DEPENDS_POST>`** — Dependencies to run after the task runs
+- **`-s --sources <SOURCES>`** — Glob patterns of files this task uses as input
+- **`-w --wait-for <WAIT_FOR>`** — Wait for these tasks to complete if they are to run
+- **`--depends-post <DEPENDS_POST>`** — Dependencies to run after the task runs
 - **`--description <DESCRIPTION>`** — Description of the task
-- **`--outputs… <OUTPUTS>`** — Glob patterns of files this task creates, to skip if they are not modified
+- **`--outputs <OUTPUTS>`** — Glob patterns of files this task creates, to skip if they are not modified
 - **`--run-windows <RUN_WINDOWS>`** — Command to run on windows
 - **`--shell <SHELL>`** — Run the task in a specific shell
 - **`--silent`** — Do not print the command or its output
@@ -4103,13 +4103,13 @@ Alternatively, tasks can be defined as standalone scripts. These must be located
 - **`-S --silent`** — Don't show any output except for errors
 
   **Environment Variable:** `MISE_SILENT`
-- **`-t --tool… <TOOL@VERSION>`** — Tool(s) to run in addition to what is in mise.toml files
+- **`-t --tool <TOOL@VERSION>`** — Tool(s) to run in addition to what is in mise.toml files
   e.g.: node@20 python@3.10
-- **`--allow-env… <VAR>`** — Allow specific env var through (implies --deny-env for everything else)
+- **`--allow-env <VAR>`** — Allow specific env var through (implies --deny-env for everything else)
   Supports wildcards, e.g. --allow-env='MYAPP_*'
-- **`--allow-net… <HOST>`** — Allow network to specific host (implies --deny-net for everything else)
-- **`--allow-read… <PATH>`** — Allow reads from specific path (implies --deny-read for everything else)
-- **`--allow-write… <PATH>`** — Allow writes to specific path (implies --deny-write for everything else)
+- **`--allow-net <HOST>`** — Allow network to specific host (implies --deny-net for everything else)
+- **`--allow-read <PATH>`** — Allow reads from specific path (implies --deny-read for everything else)
+- **`--allow-write <PATH>`** — Allow writes to specific path (implies --deny-write for everything else)
 - **`--deny-all`** — Block reads, writes, network, and env vars
 - **`--deny-env`** — Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)
 - **`--deny-net`** — Block all network access
@@ -4581,7 +4581,7 @@ This will update mise.lock if it is enabled, see https://mise.jdx.dev/configurat
 
   **Environment Variable:** `MISE_JOBS`
 - **`-n --dry-run`** — Just print what would be done, don't actually do it
-- **`-x --exclude… <INSTALLED_TOOL>`** — Tool(s) to exclude from upgrading
+- **`-x --exclude <INSTALLED_TOOL>`** — Tool(s) to exclude from upgrading
   e.g.: go python
 - **`--dry-run-code`** — Like --dry-run but exits with code 1 if there are outdated tools
 
@@ -4710,7 +4710,7 @@ Use the `--global` flag to use the global config file instead.
   Consider using mise.lock as a better alternative to pinning in mise.toml: https://mise.jdx.dev/configuration/settings.html#lockfile
 - **`--raw`** — Connect backend install command stdin/stdout/stderr directly to the terminal
   Implies `--jobs=1`
-- **`--remove… <TOOL>`** — Remove the tool(s) from config file
+- **`--remove <TOOL>`** — Remove the tool(s) from config file
 
 Examples:
 
@@ -4812,7 +4812,7 @@ For more advanced process management (daemon management, auto-restart, readiness
   This has no practical effect on Windows as the command is always forcefully terminated; see '--stop-signal' for why.
 
   **Default:** `10s`
-- **`--map-signal… <SIGNAL:SIGNAL>`** — Translate signals from the OS to signals to send to the command
+- **`--map-signal <SIGNAL:SIGNAL>`** — Translate signals from the OS to signals to send to the command
 
   Takes a pair of signal names, separated by a colon, such as "TERM:INT" to map SIGTERM to SIGINT. The first signal is the one received by watchexec, and the second is the one sent to the command. The second can be omitted to discard the first signal, such as "TERM:" to not do anything on SIGTERM.
 
@@ -4862,7 +4862,7 @@ For more advanced process management (daemon management, auto-restart, readiness
   By default, the working directory of the command is the working directory of Watchexec. You can change that with this option. Note that paths may be less intuitive to use with this.
 
 ### Filtering
-- **`-w --watch… <PATH>`** — Watch a specific file or directory
+- **`-w --watch <PATH>`** — Watch a specific file or directory
 
   By default, Watchexec watches the current directory.
 
@@ -4873,7 +4873,7 @@ For more advanced process management (daemon management, auto-restart, readiness
   This option can be specified multiple times to watch multiple files or directories.
 
   The special value '/dev/null', provided as the only path watched, will cause Watchexec to not watch any paths. Other event sources (like signals or key events) may still be used.
-- **`-W --watch-non-recursive… <PATH>`** — Watch a specific directory, non-recursively
+- **`-W --watch-non-recursive <PATH>`** — Watch a specific directory, non-recursively
 
   Unlike '-w', folders watched with this option are not recursed into.
 
@@ -4929,20 +4929,20 @@ For more advanced process management (daemon management, auto-restart, readiness
   This is a shorthand for '--no-discover-ignore', '--no-default-ignore'.
 
   Note that ignores explicitly loaded via other command line options, such as '--ignore' or '--ignore-file', will still be used.
-- **`-e --exts… <EXTENSIONS>`** — Filename extensions to filter to
+- **`-e --exts <EXTENSIONS>`** — Filename extensions to filter to
 
   This is a quick filter to only emit events for files with the given extensions. Extensions can be given with or without the leading dot (e.g. 'js' or '.js'). Multiple extensions can be given by repeating the option or by separating them with commas.
-- **`-f --filter… <PATTERN>`** — Filename patterns to filter to
+- **`-f --filter <PATTERN>`** — Filename patterns to filter to
 
   Provide a glob-like filter pattern, and only events for files matching the pattern will be emitted. Multiple patterns can be given by repeating the option. Events that are not from files (e.g. signals, keyboard events) will pass through untouched.
-- **`--filter-file… <PATH>`** — Files to load filters from
+- **`--filter-file <PATH>`** — Files to load filters from
 
   Provide a path to a file containing filters, one per line. Empty lines and lines starting with '#' are ignored. Uses the same pattern format as the '--filter' option.
 
   This can also be used via the $WATCHEXEC_FILTER_FILES environment variable.
 
   **Environment Variable:** `WATCHEXEC_FILTER_FILES`
-- **`-J --filter-prog… <EXPRESSION>`** — [experimental] Filter programs.
+- **`-J --filter-prog <EXPRESSION>`** — [experimental] Filter programs.
 
   /!\ This option is EXPERIMENTAL and may change and/or vanish without notice.
 
@@ -4993,17 +4993,17 @@ For more advanced process management (daemon management, auto-restart, readiness
   Ignore files that start with shebangs:
 
     'any(.tags[] | select(.kind == "path" && .filetype == "file"); .absolute | read(2) == "#!") | not'
-- **`-i --ignore… <PATTERN>`** — Filename patterns to filter out
+- **`-i --ignore <PATTERN>`** — Filename patterns to filter out
 
   Provide a glob-like filter pattern, and events for files matching the pattern will be excluded. Multiple patterns can be given by repeating the option. Events that are not from files (e.g. signals, keyboard events) will pass through untouched.
-- **`--ignore-file… <PATH>`** — Files to load ignores from
+- **`--ignore-file <PATH>`** — Files to load ignores from
 
   Provide a path to a file containing ignores, one per line. Empty lines and lines starting with '#' are ignored. Uses the same pattern format as the '--ignore' option.
 
   This can also be used via the $WATCHEXEC_IGNORE_FILES environment variable.
 
   **Environment Variable:** `WATCHEXEC_IGNORE_FILES`
-- **`--fs-events… <EVENTS>`** — Filesystem events to filter to
+- **`--fs-events <EVENTS>`** — Filesystem events to filter to
 
   This is a quick filter to only emit events for the given types of filesystem changes. Choose from 'access', 'create', 'remove', 'rename', 'modify', 'metadata'. Multiple types can be given by repeating the option or by separating them with commas. By default, this is all types except for 'access'.
 
@@ -5161,7 +5161,7 @@ For more advanced process management (daemon management, auto-restart, readiness
   **Choices:** `environment`, `stdio`, `file`, `json-stdio`, `json-file`, `none`
 
   **Default:** `none`
-- **`-E --env… <KEY=VALUE>`** — Add env vars to the command
+- **`-E --env <KEY=VALUE>`** — Add env vars to the command
 
   This is a convenience option for setting environment variables for the command, without setting them for the Watchexec process itself.
 

--- a/examples/docs/MISE_MULTI.md
+++ b/examples/docs/MISE_MULTI.md
@@ -14,12 +14,12 @@ mise prepares your development environment before each command runs. https://git
 
 ## Global Flags
 - **`-C --cd <DIR>`** — Change directory before running command
-- **`-E --env… <ENV>`** — Set the environment for loading `mise.<ENV>.toml`
+- **`-E --env <ENV>`** — Set the environment for loading `mise.<ENV>.toml`
 - **`-j --jobs <JOBS>`** — How many jobs to run in parallel; values below 1 are treated as 1 [default: 8]
 
   **Environment Variable:** `MISE_JOBS`
 - **`-q --quiet`** — Suppress non-error messages
-- **`-v --verbose…`** — Show extra output (use -vv for even more)
+- **`-v --verbose`** — Show extra output (use -vv for even more)
 - **`-y --yes`** — Answer yes to all confirmation prompts
 - **`--raw`** — Read/write directly to stdin/stdout/stderr instead of by line
 - **`--locked`** — Require lockfile URLs to be present during installation
@@ -289,13 +289,13 @@ Use `--skip <part>` to skip named parts, or `--only <part>` to run just named pa
 - **`-n --dry-run`** — Print what would happen without installing anything
 - **`-y --yes`** — Skip confirmation prompts
 - **`--force-dotfiles`** — Overwrite existing files that conflict with whole-file dotfile entries
-- **`--only… <ONLY>`** — Run only one or more bootstrap parts
+- **`--only <ONLY>`** — Run only one or more bootstrap parts
 
   Can be passed multiple times or as a comma-separated list. Cannot be used with `--skip`.
 
   **Choices:** `plugins`, `packages`, `accounts`, `files`, `services`, `firewall`, `compose`, `repos`, `dotfiles`, `mise-shell-activate`, `macos-defaults`, `macos-launchd-agents`, `linux-systemd-units`, `user`, `tools`, `task`, `final-hook`
 - **`--prompt-secrets`** — Prompt securely for missing bootstrap secret inputs
-- **`--skip… <SKIP>`** — Skip one or more bootstrap parts
+- **`--skip <SKIP>`** — Skip one or more bootstrap parts
 
   Can be passed multiple times or as a comma-separated list.
 
@@ -1032,29 +1032,29 @@ Bootstrap one or more machines over OpenSSH
 - **`--connect-timeout <CONNECT_TIMEOUT>`** — SSH connection timeout in seconds
 
   **Default:** `10`
-- **`--copy-link… <PATH>`** — Dereference one source-relative symbolic link; repeat for multiple links
+- **`--copy-link <PATH>`** — Dereference one source-relative symbolic link; repeat for multiple links
 - **`--copy-links`** — Dereference every symbolic link in the source archive
-- **`--exclude… <PATTERN>`** — Additional archive pattern to exclude; repeat for multiple patterns
+- **`--exclude <PATTERN>`** — Additional archive pattern to exclude; repeat for multiple patterns
 - **`--fail-fast`** — Stop after the first failed target
 - **`--force-dotfiles`** — Allow remote dotfile conflicts to be replaced
-- **`--host… <[USER@]HOST>`** — Ad-hoc SSH destination (`[user@]host`); repeat for multiple hosts
+- **`--host <[USER@]HOST>`** — Ad-hoc SSH destination (`[user@]host`); repeat for multiple hosts
 - **`-i --identity-file <IDENTITY_FILE>`** — SSH identity file override
 - **`-n --dry-run`** — Print the remote bootstrap changes without applying them
 - **`--keep-staging`** — Keep the remote staging directory for debugging
 - **`--mise-bin <MISE_BIN>`** — Local mise binary to upload (escape hatch for custom architectures)
-- **`--only… <ONLY>`** — Run only one or more remote bootstrap parts
+- **`--only <ONLY>`** — Run only one or more remote bootstrap parts
 
   **Choices:** `plugins`, `packages`, `accounts`, `files`, `services`, `firewall`, `compose`, `repos`, `dotfiles`, `mise-shell-activate`, `macos-defaults`, `macos-launchd-agents`, `linux-systemd-units`, `user`, `tools`, `task`, `final-hook`
 - **`--port <PORT>`** — SSH port override
 - **`--prompt-secrets`** — Prompt securely for missing secret inputs on the remote host
-- **`--remote-env… <ENV>`** — Config environments to load on the remote host; repeat or delimit with commas (for example, ci,dotfiles)
+- **`--remote-env <ENV>`** — Config environments to load on the remote host; repeat or delimit with commas (for example, ci,dotfiles)
 - **`--remote-mise <COMMAND>`** — Existing mise executable name or path; relative paths use the staged project
-- **`--skip… <SKIP>`** — Skip one or more remote bootstrap parts
+- **`--skip <SKIP>`** — Skip one or more remote bootstrap parts
 
   **Choices:** `plugins`, `packages`, `accounts`, `files`, `services`, `firewall`, `compose`, `repos`, `dotfiles`, `mise-shell-activate`, `macos-defaults`, `macos-launchd-agents`, `linux-systemd-units`, `user`, `tools`, `task`, `final-hook`
 - **`--source <SOURCE>`** — Local directory archived and sent to each target
-- **`--ssh-option… <OPTION>`** — OpenSSH `-o` option; repeat for multiple options
-- **`--tag… <TAG>`** — Select configured hosts with this tag; repeat to match any tag
+- **`--ssh-option <OPTION>`** — OpenSSH `-o` option; repeat for multiple options
+- **`--tag <TAG>`** — Select configured hosts with this tag; repeat to match any tag
 - **`--update`** — Refresh package manager metadata and update configured repos remotely
 - **`-y --yes`** — Skip remote confirmation prompts
 
@@ -1251,7 +1251,7 @@ Show the cache directory path
 
 ## `mise cache prune`
 
-- **Usage:** `mise cache prune [-v --verbose…] [--dry-run] [TOOL]…`
+- **Usage:** `mise cache prune [-v --verbose] [--dry-run] [TOOL]…`
 - **Aliases:** `p`
 - **Effect:** modifies state
 
@@ -1264,7 +1264,7 @@ By default, this command will remove files that have not been accessed in 30 day
   e.g.: node, python
 
 ### Flags
-- **`-v --verbose…`** — Show pruned files
+- **`-v --verbose`** — Show pruned files
 - **`--dry-run`** — Just show what would be pruned
 
 ## `mise cache task`
@@ -1725,12 +1725,12 @@ The "--" separates runtimes from the commands to pass along to the subprocess.
   [default: 4]
 
   **Environment Variable:** `MISE_JOBS`
-- **`--allow-env… <VAR>`** — Allow specific env var through (implies --deny-env for everything else)
+- **`--allow-env <VAR>`** — Allow specific env var through (implies --deny-env for everything else)
   Supports wildcards, e.g. --allow-env='MYAPP_*'
-- **`--allow-net… <HOST>`** — Allow network to specific host (implies --deny-net for everything else)
+- **`--allow-net <HOST>`** — Allow network to specific host (implies --deny-net for everything else)
   macOS only in v1; on Linux falls back to allowing all network
-- **`--allow-read… <PATH>`** — Allow reads from specific path (implies --deny-read for everything else)
-- **`--allow-write… <PATH>`** — Allow writes to specific path (implies --deny-write for everything else)
+- **`--allow-read <PATH>`** — Allow reads from specific path (implies --deny-read for everything else)
+- **`--allow-write <PATH>`** — Allow writes to specific path (implies --deny-write for everything else)
 - **`--deny-all`** — Block reads, writes, network, and env vars
 - **`--deny-env`** — Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)
 - **`--deny-net`** — Block all network access
@@ -2002,10 +2002,10 @@ When generating stubs with platform-specific URLs, the command will append new p
   **Default:** `http`
 - **`--lock`** — Resolve and embed lockfile data (exact version + platform URLs/checksums)
   into an existing stub file for reproducible installs without runtime API calls
-- **`--platform-bin… <PLATFORM_BIN>`** — Platform-specific binary paths in the format platform:path
+- **`--platform-bin <PLATFORM_BIN>`** — Platform-specific binary paths in the format platform:path
 
   Examples: --platform-bin windows-x64:tool.exe --platform-bin linux-x64:bin/tool
-- **`--platform-url… <PLATFORM_URL>`** — Platform-specific URLs in the format platform:url or just url (auto-detect platform)
+- **`--platform-url <PLATFORM_URL>`** — Platform-specific URLs in the format platform:url or just url (auto-detect platform)
 
   When the output file already exists, new platforms will be appended to the existing platforms table. Existing platform URLs will be updated if specified again.
 
@@ -2134,7 +2134,7 @@ Use `mise local` to set a tool version locally in the current directory.
 - **`--path`** — Get the path of the global config file
 - **`--pin`** — Save exact version to `~/.tool-versions`
   e.g.: `mise global --pin node@20` will save `node 20.0.0` to ~/.tool-versions
-- **`--remove… <TOOL>`** — Remove the tool(s) from ~/.tool-versions
+- **`--remove <TOOL>`** — Remove the tool(s) from ~/.tool-versions
 
 Examples:
     # set the current version of node to 20.x
@@ -2235,7 +2235,7 @@ Tools will be installed in parallel. To disable, set `--jobs=1` or `MISE_JOBS=1`
 
   **Environment Variable:** `MISE_JOBS`
 - **`-n --dry-run`** — Show what would be installed without actually installing
-- **`-v --verbose…`** — Show installation output
+- **`-v --verbose`** — Show installation output
 
   This argument will print backend output such as download, configuration, and compilation output.
 - **`--dry-run-code`** — Like --dry-run but exits with code 1 if there are tools to install
@@ -2370,7 +2370,7 @@ Use this to set a tool's version when within a directory Use `mise global` to se
 - **`--path`** — Get the path of the config file
 - **`--pin`** — Save exact version to `.tool-versions`
   e.g.: `mise local --pin node@20` will save `node 20.0.0` to .tool-versions
-- **`--remove… <TOOL>`** — Remove the tool(s) from .tool-versions
+- **`--remove <TOOL>`** — Remove the tool(s) from .tool-versions
 
 Examples:
     # set the current version of node to 20.x for the current directory
@@ -2413,7 +2413,7 @@ Updates checksums and download URLs for all platforms already specified in the l
 
   **Environment Variable:** `MISE_JOBS`
 - **`-n --dry-run`** — Show what would be updated without making changes
-- **`-p --platform… <PLATFORM>`** — Comma-separated list of platforms to target
+- **`-p --platform <PLATFORM>`** — Comma-separated list of platforms to target
   e.g.: linux-x64,macos-arm64,windows-x64
   If not specified, all platforms already in lockfile will be updated
 - **`--bump`** — Re-resolve fuzzy version selectors against the latest available versions
@@ -2627,7 +2627,7 @@ Each tool version becomes its own content-addressable OCI layer. Bumping a tool 
 Requires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`).
 
 ### Flags
-- **`--copy… <HOST_PATH:IMAGE_PATH>`** — Copy a host file, directory, or symlink into the image (repeatable, HOST:IMAGE)
+- **`--copy <HOST_PATH:IMAGE_PATH>`** — Copy a host file, directory, or symlink into the image (repeatable, HOST:IMAGE)
 - **`-o --output <OUTPUT>`** — Output directory for the OCI image layout
 
   **Default:** `./mise-oci`
@@ -2754,10 +2754,10 @@ Requires `mise settings experimental=true` (or `MISE_EXPERIMENTAL=1`) and one of
 - **`--owner <UID[:GID]>`** — UID[:GID] to assign to every tar entry when building (conflicts with --image-dir)
 
   Overrides [oci].user_id / [oci].group_id. Defaults to 0:0. If GID is omitted, it defaults to UID. This affects file ownership only; [oci].user controls the image USER directive.
-- **`--volume… <HOST:CONTAINER>`** — Bind-mount a host path (repeatable, `HOST:CONTAINER[:MODE]`)
+- **`--volume <HOST:CONTAINER>`** — Bind-mount a host path (repeatable, `HOST:CONTAINER[:MODE]`)
 
   Note: unlike `docker run -v`, there's no `-v` short flag here because mise reserves `-v` for --verbose. Use `--volume` or `--mount`.
-- **`-e --env… <KEY=VAL>`** — Set environment variable in the container (repeatable, `KEY=VAL`)
+- **`-e --env <KEY=VAL>`** — Set environment variable in the container (repeatable, `KEY=VAL`)
 - **`-i --interactive`** — Run interactively (pass `-i` to the engine)
 - **`-t --tty`** — Allocate a TTY (pass `-t` to the engine)
 - **`-w --workdir <WORKDIR>`** — Working directory inside the container
@@ -2895,7 +2895,7 @@ This behavior can be modified in ~/.config/mise/config.toml
 - **`-f --force`** — Reinstall even if plugin exists
 - **`-j --jobs <JOBS>`** — Number of jobs to run in parallel
   Values below 1 are treated as 1
-- **`-v --verbose…`** — Show installation output
+- **`-v --verbose`** — Show installation output
 
 Examples:
 
@@ -3054,8 +3054,8 @@ Providers with `auto = true` are automatically invoked before `mise x` and `mise
   Requires monorepo_root = true plus explicit [monorepo].config_roots in the monorepo root config. Providers are named like //apps/api:uv.
 
   **Environment Variable:** `MISE_MONOREPO`
-- **`--only… <ONLY>`** — Run specific deps rule(s) only
-- **`--skip… <SKIP>`** — Skip specific deps rule(s)
+- **`--only <ONLY>`** — Run specific deps rule(s) only
+- **`--skip <SKIP>`** — Skip specific deps rule(s)
 
 Examples:
 
@@ -3123,8 +3123,8 @@ Checks if dependency lockfiles are newer than installed outputs and runs install
   Requires monorepo_root = true plus explicit [monorepo].config_roots in the monorepo root config. Providers are named like //apps/api:uv.
 
   **Environment Variable:** `MISE_MONOREPO`
-- **`--only… <ONLY>`** — Run specific deps rule(s) only
-- **`--skip… <SKIP>`** — Skip specific deps rule(s)
+- **`--only <ONLY>`** — Run specific deps rule(s) only
+- **`--skip <SKIP>`** — Skip specific deps rule(s)
 
 ## `mise deps remove`
 
@@ -3295,13 +3295,13 @@ Alternatively, tasks can be defined as standalone scripts. These must be located
 - **`-S --silent`** — Don't show any output except for errors
 
   **Environment Variable:** `MISE_SILENT`
-- **`-t --tool… <TOOL@VERSION>`** — Tool(s) to run in addition to what is in mise.toml files
+- **`-t --tool <TOOL@VERSION>`** — Tool(s) to run in addition to what is in mise.toml files
   e.g.: node@20 python@3.10
-- **`--allow-env… <VAR>`** — Allow specific env var through (implies --deny-env for everything else)
+- **`--allow-env <VAR>`** — Allow specific env var through (implies --deny-env for everything else)
   Supports wildcards, e.g. --allow-env='MYAPP_*'
-- **`--allow-net… <HOST>`** — Allow network to specific host (implies --deny-net for everything else)
-- **`--allow-read… <PATH>`** — Allow reads from specific path (implies --deny-read for everything else)
-- **`--allow-write… <PATH>`** — Allow writes to specific path (implies --deny-write for everything else)
+- **`--allow-net <HOST>`** — Allow network to specific host (implies --deny-net for everything else)
+- **`--allow-read <PATH>`** — Allow reads from specific path (implies --deny-read for everything else)
+- **`--allow-write <PATH>`** — Allow writes to specific path (implies --deny-write for everything else)
 - **`--deny-all`** — Block reads, writes, network, and env vars
 - **`--deny-env`** — Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)
 - **`--deny-net`** — Block all network access
@@ -3438,10 +3438,10 @@ Use `-E <env>` to create/modify environment-specific config files like `mise.<en
 - **`--age-key-file <PATH>`** — [experimental] Age identity file for encryption
 
   Defaults to ~/.config/mise/age.txt if it exists
-- **`--age-recipient… <RECIPIENT>`** — [experimental] Age recipient (x25519 public key) for encryption
+- **`--age-recipient <RECIPIENT>`** — [experimental] Age recipient (x25519 public key) for encryption
 
   Can be used multiple times. Requires --age-encrypt.
-- **`--age-ssh-recipient… <PATH_OR_PUBKEY>`** — [experimental] SSH recipient (public key or path) for age encryption
+- **`--age-ssh-recipient <PATH_OR_PUBKEY>`** — [experimental] SSH recipient (public key or path) for age encryption
 
   Can be used multiple times. Requires --age-encrypt.
 - **`--file <FILE>`** — The TOML file to update
@@ -3866,18 +3866,18 @@ Adds a task to the local mise.toml file. See https://mise.jdx.dev/configuration.
 - **`[-- RUN]…`**
 
 ### Flags
-- **`-a --alias… <ALIAS>`** — Other names for the task
-- **`-d --depends… <DEPENDS>`** — Add dependencies to the task
+- **`-a --alias <ALIAS>`** — Other names for the task
+- **`-d --depends <DEPENDS>`** — Add dependencies to the task
 - **`-D --dir <DIR>`** — Run the task in a specific directory
 - **`-f --file`** — Create a file task instead of a toml task
 - **`-H --hide`** — Hide the task from `mise tasks` and completions
 - **`-q --quiet`** — Do not print the command before running
 - **`-r --raw`** — Directly connect stdin/stdout/stderr
-- **`-s --sources… <SOURCES>`** — Glob patterns of files this task uses as input
-- **`-w --wait-for… <WAIT_FOR>`** — Wait for these tasks to complete if they are to run
-- **`--depends-post… <DEPENDS_POST>`** — Dependencies to run after the task runs
+- **`-s --sources <SOURCES>`** — Glob patterns of files this task uses as input
+- **`-w --wait-for <WAIT_FOR>`** — Wait for these tasks to complete if they are to run
+- **`--depends-post <DEPENDS_POST>`** — Dependencies to run after the task runs
 - **`--description <DESCRIPTION>`** — Description of the task
-- **`--outputs… <OUTPUTS>`** — Glob patterns of files this task creates, to skip if they are not modified
+- **`--outputs <OUTPUTS>`** — Glob patterns of files this task creates, to skip if they are not modified
 - **`--run-windows <RUN_WINDOWS>`** — Command to run on windows
 - **`--shell <SHELL>`** — Run the task in a specific shell
 - **`--silent`** — Do not print the command or its output
@@ -4103,13 +4103,13 @@ Alternatively, tasks can be defined as standalone scripts. These must be located
 - **`-S --silent`** — Don't show any output except for errors
 
   **Environment Variable:** `MISE_SILENT`
-- **`-t --tool… <TOOL@VERSION>`** — Tool(s) to run in addition to what is in mise.toml files
+- **`-t --tool <TOOL@VERSION>`** — Tool(s) to run in addition to what is in mise.toml files
   e.g.: node@20 python@3.10
-- **`--allow-env… <VAR>`** — Allow specific env var through (implies --deny-env for everything else)
+- **`--allow-env <VAR>`** — Allow specific env var through (implies --deny-env for everything else)
   Supports wildcards, e.g. --allow-env='MYAPP_*'
-- **`--allow-net… <HOST>`** — Allow network to specific host (implies --deny-net for everything else)
-- **`--allow-read… <PATH>`** — Allow reads from specific path (implies --deny-read for everything else)
-- **`--allow-write… <PATH>`** — Allow writes to specific path (implies --deny-write for everything else)
+- **`--allow-net <HOST>`** — Allow network to specific host (implies --deny-net for everything else)
+- **`--allow-read <PATH>`** — Allow reads from specific path (implies --deny-read for everything else)
+- **`--allow-write <PATH>`** — Allow writes to specific path (implies --deny-write for everything else)
 - **`--deny-all`** — Block reads, writes, network, and env vars
 - **`--deny-env`** — Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through)
 - **`--deny-net`** — Block all network access
@@ -4581,7 +4581,7 @@ This will update mise.lock if it is enabled, see https://mise.jdx.dev/configurat
 
   **Environment Variable:** `MISE_JOBS`
 - **`-n --dry-run`** — Just print what would be done, don't actually do it
-- **`-x --exclude… <INSTALLED_TOOL>`** — Tool(s) to exclude from upgrading
+- **`-x --exclude <INSTALLED_TOOL>`** — Tool(s) to exclude from upgrading
   e.g.: go python
 - **`--dry-run-code`** — Like --dry-run but exits with code 1 if there are outdated tools
 
@@ -4710,7 +4710,7 @@ Use the `--global` flag to use the global config file instead.
   Consider using mise.lock as a better alternative to pinning in mise.toml: https://mise.jdx.dev/configuration/settings.html#lockfile
 - **`--raw`** — Connect backend install command stdin/stdout/stderr directly to the terminal
   Implies `--jobs=1`
-- **`--remove… <TOOL>`** — Remove the tool(s) from config file
+- **`--remove <TOOL>`** — Remove the tool(s) from config file
 
 Examples:
 
@@ -4812,7 +4812,7 @@ For more advanced process management (daemon management, auto-restart, readiness
   This has no practical effect on Windows as the command is always forcefully terminated; see '--stop-signal' for why.
 
   **Default:** `10s`
-- **`--map-signal… <SIGNAL:SIGNAL>`** — Translate signals from the OS to signals to send to the command
+- **`--map-signal <SIGNAL:SIGNAL>`** — Translate signals from the OS to signals to send to the command
 
   Takes a pair of signal names, separated by a colon, such as "TERM:INT" to map SIGTERM to SIGINT. The first signal is the one received by watchexec, and the second is the one sent to the command. The second can be omitted to discard the first signal, such as "TERM:" to not do anything on SIGTERM.
 
@@ -4862,7 +4862,7 @@ For more advanced process management (daemon management, auto-restart, readiness
   By default, the working directory of the command is the working directory of Watchexec. You can change that with this option. Note that paths may be less intuitive to use with this.
 
 ### Filtering
-- **`-w --watch… <PATH>`** — Watch a specific file or directory
+- **`-w --watch <PATH>`** — Watch a specific file or directory
 
   By default, Watchexec watches the current directory.
 
@@ -4873,7 +4873,7 @@ For more advanced process management (daemon management, auto-restart, readiness
   This option can be specified multiple times to watch multiple files or directories.
 
   The special value '/dev/null', provided as the only path watched, will cause Watchexec to not watch any paths. Other event sources (like signals or key events) may still be used.
-- **`-W --watch-non-recursive… <PATH>`** — Watch a specific directory, non-recursively
+- **`-W --watch-non-recursive <PATH>`** — Watch a specific directory, non-recursively
 
   Unlike '-w', folders watched with this option are not recursed into.
 
@@ -4929,20 +4929,20 @@ For more advanced process management (daemon management, auto-restart, readiness
   This is a shorthand for '--no-discover-ignore', '--no-default-ignore'.
 
   Note that ignores explicitly loaded via other command line options, such as '--ignore' or '--ignore-file', will still be used.
-- **`-e --exts… <EXTENSIONS>`** — Filename extensions to filter to
+- **`-e --exts <EXTENSIONS>`** — Filename extensions to filter to
 
   This is a quick filter to only emit events for files with the given extensions. Extensions can be given with or without the leading dot (e.g. 'js' or '.js'). Multiple extensions can be given by repeating the option or by separating them with commas.
-- **`-f --filter… <PATTERN>`** — Filename patterns to filter to
+- **`-f --filter <PATTERN>`** — Filename patterns to filter to
 
   Provide a glob-like filter pattern, and only events for files matching the pattern will be emitted. Multiple patterns can be given by repeating the option. Events that are not from files (e.g. signals, keyboard events) will pass through untouched.
-- **`--filter-file… <PATH>`** — Files to load filters from
+- **`--filter-file <PATH>`** — Files to load filters from
 
   Provide a path to a file containing filters, one per line. Empty lines and lines starting with '#' are ignored. Uses the same pattern format as the '--filter' option.
 
   This can also be used via the $WATCHEXEC_FILTER_FILES environment variable.
 
   **Environment Variable:** `WATCHEXEC_FILTER_FILES`
-- **`-J --filter-prog… <EXPRESSION>`** — [experimental] Filter programs.
+- **`-J --filter-prog <EXPRESSION>`** — [experimental] Filter programs.
 
   /!\ This option is EXPERIMENTAL and may change and/or vanish without notice.
 
@@ -4993,17 +4993,17 @@ For more advanced process management (daemon management, auto-restart, readiness
   Ignore files that start with shebangs:
 
     'any(.tags[] | select(.kind == "path" && .filetype == "file"); .absolute | read(2) == "#!") | not'
-- **`-i --ignore… <PATTERN>`** — Filename patterns to filter out
+- **`-i --ignore <PATTERN>`** — Filename patterns to filter out
 
   Provide a glob-like filter pattern, and events for files matching the pattern will be excluded. Multiple patterns can be given by repeating the option. Events that are not from files (e.g. signals, keyboard events) will pass through untouched.
-- **`--ignore-file… <PATH>`** — Files to load ignores from
+- **`--ignore-file <PATH>`** — Files to load ignores from
 
   Provide a path to a file containing ignores, one per line. Empty lines and lines starting with '#' are ignored. Uses the same pattern format as the '--ignore' option.
 
   This can also be used via the $WATCHEXEC_IGNORE_FILES environment variable.
 
   **Environment Variable:** `WATCHEXEC_IGNORE_FILES`
-- **`--fs-events… <EVENTS>`** — Filesystem events to filter to
+- **`--fs-events <EVENTS>`** — Filesystem events to filter to
 
   This is a quick filter to only emit events for the given types of filesystem changes. Choose from 'access', 'create', 'remove', 'rename', 'modify', 'metadata'. Multiple types can be given by repeating the option or by separating them with commas. By default, this is all types except for 'access'.
 
@@ -5161,7 +5161,7 @@ For more advanced process management (daemon management, auto-restart, readiness
   **Choices:** `environment`, `stdio`, `file`, `json-stdio`, `json-file`, `none`
 
   **Default:** `none`
-- **`-E --env… <KEY=VALUE>`** — Add env vars to the command
+- **`-E --env <KEY=VALUE>`** — Add env vars to the command
 
   This is a convenience option for setting environment variables for the command, without setting them for the Watchexec process itself.
 

--- a/go/argv/help.go
+++ b/go/argv/help.go
@@ -37,8 +37,8 @@ type Help struct {
 	// drag the post-binding table in with it — which would undo the whole reason
 	// these are separate.
 	Demanded bool
-	// Repeatable is the spec's `var` on a flag: the `…` in `--tag… <t>`, meaning
-	// the flag may be given again, not that one occurrence takes several values.
+	// Repeatable is the spec's `var` on a flag, meaning the flag may be given
+	// again, not that one occurrence takes several values.
 	Repeatable bool
 	// ValueName is what a flag's value is called. Empty for a flag that takes
 	// none.
@@ -279,11 +279,6 @@ func flagUsageShown(f *Flag, show shown, h *Help) string {
 		out.WriteString("--" + long)
 	}
 
-	// A repeatable flag, which is the spec's `var` — not one occurrence taking
-	// several values, which is the value's own business below.
-	if h != nil && h.Repeatable {
-		out.WriteString("…")
-	}
 	if f.TakesValue {
 		name := f.Name
 		if h != nil && h.ValueName != "" {

--- a/go/argv/help.go
+++ b/go/argv/help.go
@@ -37,8 +37,9 @@ type Help struct {
 	// drag the post-binding table in with it — which would undo the whole reason
 	// these are separate.
 	Demanded bool
-	// Repeatable is the spec's `var` on a flag, meaning the flag may be given
-	// again, not that one occurrence takes several values.
+	// Repeatable preserves the spec's `var` on a flag for callers that inspect a
+	// HelpTable. Help renderers deliberately omit repeatability markers because
+	// the flag's ordinary spelling is valid for every occurrence.
 	Repeatable bool
 	// ValueName is what a flag's value is called. Empty for a flag that takes
 	// none.

--- a/go/argv/page_test.go
+++ b/go/argv/page_test.go
@@ -69,6 +69,24 @@ func TestHiddenFlagAliasesStayOutOfHelp(t *testing.T) {
 	}
 }
 
+func TestRepeatableFlagUsesOrdinarySpelling(t *testing.T) {
+	flag := &Flag{Key: 2, Name: "allow", Longs: []string{"allow"}, Shorts: []byte{'A'}, TakesValue: true}
+	root := &Command{Name: "ex", Key: 1, Flags: []*Flag{flag}}
+	help := HelpTable{{Key: 1}, {Key: 2, Repeatable: true, ValueName: "NAME", ValueDemanded: true}}
+
+	for _, page := range []string{
+		ShortHelp(HelpSpec{Name: "ex", Bin: "ex"}, []string{"ex"}, []*Command{root}, help),
+		LongHelp(HelpSpec{Name: "ex", Bin: "ex"}, []string{"ex"}, []*Command{root}, help),
+	} {
+		if !strings.Contains(page, "-A, --allow <NAME>") {
+			t.Errorf("repeatable flag should use ordinary spelling:\n%s", page)
+		}
+		if strings.Contains(page, "--allow…") {
+			t.Errorf("repeatability marker should be omitted:\n%s", page)
+		}
+	}
+}
+
 func TestFixedArityHelpKeepsDistinctValueNames(t *testing.T) {
 	flag := &Flag{Key: 2, Name: "range", Longs: []string{"range"}, TakesValue: true, Variadic: true}
 	arg := &Arg{Key: 3, Name: "PAIR", Var: true}

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -990,7 +990,11 @@ const SHORT_COL: usize = 4;
 /// The twin of `column_usage` in `usage-argv`'s `help` module; the two must agree, and the gate
 /// over mise's spec is what says they do.
 fn column_usage(flag: &crate::SpecFlag) -> String {
-    let usage = flag.usage.trim();
+    // `var` marks repeatable occurrences in the formal usage grammar. In an interactive help
+    // row its ellipsis looks like the terminal truncated the flag name, so keep the ordinary
+    // spelling here. A variadic value's trailing ellipsis is separate and remains visible.
+    let column_usage = flag.usage_without_repeatable();
+    let usage = column_usage.trim();
     let rest = match flag.negate.as_deref().map(str::trim) {
         // `SpecFlag::usage` already writes the negation for a flag that has no other
         // spelling — clap's `SetFalse`, tak's `--no-credit` — and appending it again rendered

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -990,11 +990,7 @@ const SHORT_COL: usize = 4;
 /// The twin of `column_usage` in `usage-argv`'s `help` module; the two must agree, and the gate
 /// over mise's spec is what says they do.
 fn column_usage(flag: &crate::SpecFlag) -> String {
-    // `var` marks repeatable occurrences in the formal usage grammar. In an interactive help
-    // row its ellipsis looks like the terminal truncated the flag name, so keep the ordinary
-    // spelling here. A variadic value's trailing ellipsis is separate and remains visible.
-    let column_usage = flag.usage_without_repeatable();
-    let usage = column_usage.trim();
+    let usage = flag.usage.trim();
     let rest = match flag.negate.as_deref().map(str::trim) {
         // `SpecFlag::usage` already writes the negation for a flag that has no other
         // spelling — clap's `SetFalse`, tak's `--no-credit` — and appending it again rendered
@@ -1055,9 +1051,6 @@ fn reference_usage(flag: &crate::SpecFlag) -> String {
         forms.insert(0, format!("{}:", flag.name));
     }
     let mut usage = forms.join(" ");
-    if flag.var {
-        usage.push('…');
-    }
     if let Some(arg) = &flag.arg {
         let arg_usage = arg.usage();
         if flag.require_equals && (flag.value_optional || !arg.required) {

--- a/lib/src/sdk/python/snapshots/usage__sdk__python__tests__python_client_edge_cases.snap
+++ b/lib/src/sdk/python/snapshots/usage__sdk__python__tests__python_client_edge_cases.snap
@@ -15,7 +15,7 @@ class Runner:
         self.info = Info(self._runner)
 
     def exec(self, args: RunnerArgs, flags: Optional[RunnerFlags] = None) -> CliResult:
-        """[-v --verbose] [--debug…] <input> <extra>… <SUBCOMMAND>"""
+        """[-v --verbose] [--debug] <input> <extra>… <SUBCOMMAND>"""
         cmd_args: list[str] = []
         if args._input is not None: cmd_args.append(str(args._input))
         if args.extra is not None: cmd_args.extend(args.extra)

--- a/lib/src/sdk/python/snapshots/usage__sdk__python__tests__python_double_dash_automatic.snap
+++ b/lib/src/sdk/python/snapshots/usage__sdk__python__tests__python_double_dash_automatic.snap
@@ -14,7 +14,7 @@ class Runner:
         self.run = Run(self._runner)
 
     def exec(self, args: RunnerArgs, flags: Optional[RunnerFlags] = None) -> CliResult:
-        """[--verbose…] <input> <extra>… <SUBCOMMAND>"""
+        """[--verbose] <input> <extra>… <SUBCOMMAND>"""
         cmd_args: list[str] = []
         if args._input is not None: cmd_args.append(str(args._input))
         if args.extra is not None: cmd_args.extend(args.extra)

--- a/lib/src/sdk/python/snapshots/usage__sdk__python__tests__python_full_feature_client.snap
+++ b/lib/src/sdk/python/snapshots/usage__sdk__python__tests__python_full_feature_client.snap
@@ -42,7 +42,7 @@ class Build:
         self._runner = runner
 
     def exec(self, args: BuildArgs, flags: Optional[BuildFlags] = None) -> CliResult:
-        """build [-j --jobs… <n>] [--release] <target> <-- output>"""
+        """build [-j --jobs <n>] [--release] <target> <-- output>"""
         cmd_args: list[str] = ["build"]
         if args.target is not None: cmd_args.append(str(args.target))
         cmd_args.append("--")

--- a/lib/src/sdk/typescript/snapshots/usage__sdk__typescript__types__tests__full_feature_client.snap
+++ b/lib/src/sdk/typescript/snapshots/usage__sdk__typescript__types__tests__full_feature_client.snap
@@ -52,7 +52,7 @@ export class Build {
     this.runner = runner;
   }
   /**
-   * build [-j --jobs… <n>] [--release] <target> <-- output>
+   * build [-j --jobs <n>] [--release] <target> <-- output>
    * @example Build in release mode
    * ```bash
    * mytool build --release target

--- a/lib/src/sdk/typescript/snapshots/usage__sdk__typescript__types__tests__typescript_client_edge_cases.snap
+++ b/lib/src/sdk/typescript/snapshots/usage__sdk__typescript__types__tests__typescript_client_edge_cases.snap
@@ -18,7 +18,7 @@ export class Runner {
     this.run = new Run(this.runner);
     this.info = new Info(this.runner);
   }
-  /** [-v --verbose] [--debug…] <input> <extra>… <SUBCOMMAND> */
+  /** [-v --verbose] [--debug] <input> <extra>… <SUBCOMMAND> */
   async exec(args: RunnerArgs, flags?: RunnerFlags): Promise<CliResult> {
     const cmdArgs: string[] = [];
     if (args.input !== undefined) { cmdArgs.push(String(args.input)); }

--- a/lib/src/sdk/typescript/snapshots/usage__sdk__typescript__types__tests__typescript_double_dash_automatic.snap
+++ b/lib/src/sdk/typescript/snapshots/usage__sdk__typescript__types__tests__typescript_double_dash_automatic.snap
@@ -15,7 +15,7 @@ export class Runner {
     this.runner = new CliRunner(binPath ?? "runner");
     this.run = new Run(this.runner);
   }
-  /** [--verbose…] <input> <extra>… <SUBCOMMAND> */
+  /** [--verbose] <input> <extra>… <SUBCOMMAND> */
   async exec(args: RunnerArgs, flags?: RunnerFlags): Promise<CliResult> {
     const cmdArgs: string[] = [];
     if (args.input !== undefined) { cmdArgs.push(String(args.input)); }

--- a/lib/src/spec/flag.rs
+++ b/lib/src/spec/flag.rs
@@ -867,6 +867,14 @@ impl SpecFlag {
     }
 
     pub fn usage(&self) -> String {
+        self.usage_with_repeatable(true)
+    }
+
+    pub(crate) fn usage_without_repeatable(&self) -> String {
+        self.usage_with_repeatable(false)
+    }
+
+    fn usage_with_repeatable(&self, show_repeatable: bool) -> String {
         let mut parts = vec![];
         let name = get_name_from_short_and_long(&self.short, &self.long).unwrap_or_default();
         // A flag whose only spelling is its negation — clap's `SetFalse`, tak's
@@ -890,7 +898,7 @@ impl SpecFlag {
             parts.push(format!("--{long}"));
         }
         let mut out = parts.join(" ");
-        if self.var {
+        if show_repeatable && self.var {
             out = format!("{out}…");
         }
         if let Some(arg) = &self.arg {

--- a/lib/src/spec/flag.rs
+++ b/lib/src/spec/flag.rs
@@ -867,14 +867,6 @@ impl SpecFlag {
     }
 
     pub fn usage(&self) -> String {
-        self.usage_with_repeatable(true)
-    }
-
-    pub(crate) fn usage_without_repeatable(&self) -> String {
-        self.usage_with_repeatable(false)
-    }
-
-    fn usage_with_repeatable(&self, show_repeatable: bool) -> String {
         let mut parts = vec![];
         let name = get_name_from_short_and_long(&self.short, &self.long).unwrap_or_default();
         // A flag whose only spelling is its negation — clap's `SetFalse`, tak's
@@ -898,9 +890,6 @@ impl SpecFlag {
             parts.push(format!("--{long}"));
         }
         let mut out = parts.join(" ");
-        if show_repeatable && self.var {
-            out = format!("{out}…");
-        }
         if let Some(arg) = &self.arg {
             let usage = arg.usage();
             if self.require_equals && (self.value_optional || !arg.required) {
@@ -1631,11 +1620,11 @@ mod tests {
         assert_snapshot!("-f".parse::<SpecFlag>().unwrap(), @"-f");
         assert_snapshot!("--flag".parse::<SpecFlag>().unwrap(), @"--flag");
         assert_snapshot!("-f --flag".parse::<SpecFlag>().unwrap(), @"-f --flag");
-        assert_snapshot!("-f --flag…".parse::<SpecFlag>().unwrap(), @"-f --flag…");
-        assert_snapshot!("-f --flag …".parse::<SpecFlag>().unwrap(), @"-f --flag…");
+        assert_snapshot!("-f --flag…".parse::<SpecFlag>().unwrap(), @"-f --flag");
+        assert_snapshot!("-f --flag …".parse::<SpecFlag>().unwrap(), @"-f --flag");
         assert_snapshot!("--flag <arg>".parse::<SpecFlag>().unwrap(), @"--flag <arg>");
         assert_snapshot!("-f --flag <arg>".parse::<SpecFlag>().unwrap(), @"-f --flag <arg>");
-        assert_snapshot!("-f --flag… <arg>".parse::<SpecFlag>().unwrap(), @"-f --flag… <arg>");
+        assert_snapshot!("-f --flag… <arg>".parse::<SpecFlag>().unwrap(), @"-f --flag <arg>");
         assert_snapshot!("-f --flag <arg>…".parse::<SpecFlag>().unwrap(), @"-f --flag <arg>…");
         let range = "--range <start> <end>".parse::<SpecFlag>().unwrap();
         let arg = range.arg.as_ref().unwrap();
@@ -1978,9 +1967,9 @@ mod tests {
             require_equals: true,
             ..repeatable
         };
-        assert_eq!(repeatable.usage(), "--tag…=<TAG>");
+        assert_eq!(repeatable.usage(), "--tag=<TAG>");
         let reparsed: SpecFlag = repeatable.usage().parse().unwrap();
-        assert!(reparsed.var);
+        assert!(!reparsed.var);
         assert!(reparsed.require_equals);
         assert!(!reparsed.arg.as_ref().unwrap().var);
 
@@ -1990,9 +1979,9 @@ mod tests {
             require_equals: true,
             ..repeatable_optional
         };
-        assert_eq!(repeatable_optional.usage(), "--color…[=WHEN]");
+        assert_eq!(repeatable_optional.usage(), "--color[=WHEN]");
         let reparsed: SpecFlag = repeatable_optional.usage().parse().unwrap();
-        assert!(reparsed.var);
+        assert!(!reparsed.var);
         assert!(reparsed.require_equals);
         assert!(!reparsed.arg.as_ref().unwrap().var);
     }


### PR DESCRIPTION
## Summary

- omit repeatability ellipses from help tables and `Usage:` synopses
- remove the truncation-like glyph from Markdown and generated SDK documentation
- preserve repeatability structurally through `var=#true`
- keep compiled and reference renderers byte-identical

## Tests

- `cargo test -p usage-lib --all-features`
- `cargo test -p usage-argv --all-features`
- `cargo test -p usage-conformance --test flag_column --test heading_help --test canonical_kdl`
- `mise run render:example-md`

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public help, docs, and SDK usage strings change, and `SpecFlag::usage()` no longer preserves `var` on round-trip. Parsing and flag behavior are otherwise unchanged.
> 
> **Overview**
> Stop appending `…` to **repeatable flags** in help, usage synopses, Markdown, and generated SDK docs. Repeatability stays in the spec as `var`; only the presentation suffix is gone. Value-side ellipses (`<arg>…`) are unchanged.
> 
> Rust (`flag_usage_masked`, `SpecFlag::usage`, docs models) and Go (`flagUsageShown`) no longer emit the marker. `Help.Repeatable` is still stored for inspectors. Tests and generated mise/CLI docs now expect ordinary spellings like `--env <ENV>` instead of `--env… <ENV>`.
> 
> **Note:** `usage()` no longer round-trips `var` — parsing `--flag…` still sets `var`, but reprinting yields `--flag`, so reparse loses repeatability. Specs should keep `var=#true` as the source of truth.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 128dc8af3fca8e471ef60a18f1d57cc7664c13ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CLI documentation to display complete option names without trailing ellipsis markers.
  * Preserved repeatability and value syntax details in option descriptions.
  * Refreshed generated and reference documentation for consistent option formatting.

* **Bug Fixes**
  * Standardized help and usage output so repeatable flags render consistently across formats.
  * Improved Markdown help output and aligned flag listings for repeatable options.
  * Ensured repeatable flags retain their behavior while displaying ordinary flag spellings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->