### PR TITLE
chore: generate release notes before publishing

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -125,7 +125,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [build-and-publish]
+    needs: [build-and-publish, enhance-release]
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     permissions:
       contents: write
@@ -142,7 +142,7 @@ jobs:
   enhance-release:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: [release]
+    needs: [create-release]
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- run Communiqué against the draft release in parallel with binary builds
- publish only after both the artifacts and final release notes are ready
- leave the draft unpublished when note generation or sponsor normalization fails

## Validation

- actionlint with ShellCheck enabled
- git diff --check
- verified the publish job depends on both build-and-publish and enhance-release

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI job-graph only; no product, auth, or artifact-build logic changes. A failed enhance-release now blocks publishing, which is the intended safeguard.
> 
> **Overview**
> Reorders `publish-cli` so `enhance-release` (Communiqué notes + sponsor blurb) runs after `create-release` in parallel with binary builds, instead of after the release is published.
> 
> The `release` job now waits on both `build-and-publish` and `enhance-release` before undrafting. If note generation fails, the draft stays unpublished.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffaa3c4c4edf03e7b604ad24126a7b93b95f5042. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release workflow so release enhancements complete before publishing finishes.
  * Ensured the final release step waits for all required build, publishing, and enhancement tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

