### PR TITLE
fix(zsh): forward cursor to generated completions

### DIFF
--- a/cli/assets/completions/_usage
+++ b/cli/assets/completions/_usage
@@ -36,7 +36,7 @@ _usage() {
     descs+=("${parts[2]}")
     inserts+=("${parts[3]}")
     [[ "${parts[3]}" == "'"* ]] && needs_menu=1
-  done < <(command usage complete-word --shell zsh -f "$spec_file" -- "${(Q)words[@]}")
+  done < <(command usage complete-word --shell zsh -f "$spec_file" --cword=$((CURRENT - 1)) -- "${(Q)words[@]}")
   (( needs_menu )) && compstate[insert]=menu
   if (( ${#inserts[@]} )); then
     local -a _usage_display=()

--- a/cli/tests/shell_completions_integration.rs
+++ b/cli/tests/shell_completions_integration.rs
@@ -802,6 +802,80 @@ echo "COMPLETION_TEST_DONE"
     let _ = fs::remove_dir_all(&temp_dir);
 }
 
+/// Regression test for https://github.com/jdx/usage/issues/1298.
+///
+/// Zsh's `CURRENT` is one-based while `complete-word --cword` is zero-based.
+/// The generated completion must forward the converted index so completing a
+/// word in the middle of the command line does not target the final word.
+#[test]
+fn test_zsh_completion_forwards_midline_cursor() {
+    if skip_if_shell_missing("zsh") {
+        return;
+    }
+
+    let usage_bin = build_usage_binary();
+    let temp_dir = env::temp_dir().join(format!("usage_zsh_midline_test_{}", std::process::id()));
+    fs::create_dir_all(&temp_dir).unwrap();
+
+    let spec = r#"
+bin "testcli"
+flag "--foo"
+arg "<value>"
+"#;
+    let spec_file = temp_dir.join("testcli.kdl");
+    fs::write(&spec_file, spec).unwrap();
+
+    let generated = Command::new(&usage_bin)
+        .args(["generate", "completion", "zsh", "testcli", "-f"])
+        .arg(spec_file.to_str().unwrap())
+        .output()
+        .expect("Failed to generate zsh completion");
+    let completion_file = temp_dir.join("_testcli");
+    fs::write(&completion_file, &generated.stdout).unwrap();
+
+    let test_script = format!(
+        r#"#!/usr/bin/env zsh
+set -e
+export PATH="{usage_dir}:$PATH"
+export XDG_CACHE_HOME="{tmp}"
+
+autoload -U compinit
+compinit -u
+source {completion}
+
+compadd() {{
+    print -r -- "[compadd:inserts] ${{inserts[*]}}"
+}}
+
+words=(testcli --f trailing)
+CURRENT=2
+_testcli
+"#,
+        usage_dir = path_var_entry("zsh", usage_bin.parent().unwrap()),
+        tmp = sh_path(&temp_dir),
+        completion = sh_path(&completion_file),
+    );
+    let script_file = temp_dir.join("test.zsh");
+    fs::write(&script_file, test_script).unwrap();
+
+    let result = script_command("zsh", &script_file)
+        .output()
+        .expect("Failed to run zsh test");
+    let stdout = String::from_utf8_lossy(&result.stdout);
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(
+        result.status.success(),
+        "zsh completion script exited non-zero ({}).\nstdout:\n{stdout}\nstderr:\n{stderr}",
+        result.status
+    );
+    assert!(
+        stdout.contains("[compadd:inserts] --foo"),
+        "expected `--foo` for mid-line `--f`, got: {stdout}"
+    );
+
+    let _ = fs::remove_dir_all(&temp_dir);
+}
+
 /// Regression test for https://github.com/jdx/usage/issues/634
 ///
 /// `usage complete-word --shell zsh` emits two tab-separated columns per

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-2.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-2.snap
@@ -43,7 +43,7 @@ _mycli() {
     descs+=("${parts[2]}")
     inserts+=("${parts[3]}")
     [[ "${parts[3]}" == "'"* ]] && needs_menu=1
-  done < <(command usage complete-word --shell zsh -f "$spec_file" -- "${(Q)words[@]}")
+  done < <(command usage complete-word --shell zsh -f "$spec_file" --cword=$((CURRENT - 1)) -- "${(Q)words[@]}")
   (( needs_menu )) && compstate[insert]=menu
   if (( ${#inserts[@]} )); then
     local -a _usage_display=()

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-3.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh-3.snap
@@ -91,7 +91,7 @@ __USAGE_EOF__
     descs+=("${parts[2]}")
     inserts+=("${parts[3]}")
     [[ "${parts[3]}" == "'"* ]] && needs_menu=1
-  done < <(command usage complete-word --shell zsh -f "$spec_file" -- "${(Q)words[@]}")
+  done < <(command usage complete-word --shell zsh -f "$spec_file" --cword=$((CURRENT - 1)) -- "${(Q)words[@]}")
   (( needs_menu )) && compstate[insert]=menu
   if (( ${#inserts[@]} )); then
     local -a _usage_display=()

--- a/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh.snap
+++ b/lib/src/complete/snapshots/usage__complete__zsh__tests__complete_zsh.snap
@@ -40,7 +40,7 @@ _mycli() {
     descs+=("${parts[2]}")
     inserts+=("${parts[3]}")
     [[ "${parts[3]}" == "'"* ]] && needs_menu=1
-  done < <(command usage complete-word --shell zsh -f "$spec_file" -- "${(Q)words[@]}")
+  done < <(command usage complete-word --shell zsh -f "$spec_file" --cword=$((CURRENT - 1)) -- "${(Q)words[@]}")
   (( needs_menu )) && compstate[insert]=menu
   if (( ${#inserts[@]} )); then
     local -a _usage_display=()

--- a/lib/src/complete/zsh.rs
+++ b/lib/src/complete/zsh.rs
@@ -153,7 +153,11 @@ fi"#
         String::new()
     };
 
-    let completion_loop = render_completion_loop(usage_bin, "  ", r#"-f "$spec_file""#);
+    let completion_loop = render_completion_loop(
+        usage_bin,
+        "  ",
+        r#"-f "$spec_file" --cword=$((CURRENT - 1))"#,
+    );
 
     out.push(format!(
         r#"


### PR DESCRIPTION
## Summary

- pass zsh’s one-based `CURRENT` to `complete-word` as a zero-based `--cword`
- preserve correct completion behavior when the cursor is in the middle of a command line
- add an integration test that completes `--f` before a trailing argument

Fixes #1298.

## Tests

- `cargo test -p usage-lib --all-features complete::zsh::tests -- --nocapture`
- `cargo test -p usage-cli --all-features zsh_completion -- --nocapture`
- `cargo fmt --all -- --check`

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Shell completion generation only; no auth, data, or runtime CLI behavior beyond tab-complete.
> 
> **Overview**
> Fixes zsh completions completing the last word instead of the word under the cursor (issue #1298).
> 
> Generated scripts now pass `--cword=$((CURRENT - 1))` into `complete-word`, converting zsh’s 1-based `CURRENT` to the 0-based index the CLI expects. Adds a regression test that completes `--f` with a trailing argument after the cursor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3220eb728e3849cb4c63e12d9c5a39397da5dea4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved zsh tab completion when the cursor is positioned mid-command.
  * Completions now correctly reflect the current word’s context, including options such as `--foo`.

* **Tests**
  * Added regression coverage for accurate zsh completions at different cursor positions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->