### PR TITLE
feat(config): add XDG file layers

### DIFF
--- a/config/src/files.rs
+++ b/config/src/files.rs
@@ -136,7 +136,12 @@ impl FileLayer {
     /// This constructor reads the process environment. Use [`FileLayer::at`] when the
     /// application has already resolved or overridden its config directory.
     pub fn xdg(base: XdgBase, path: impl AsRef<Path>) -> Self {
-        Self::xdg_from(base, path.as_ref(), XdgEnv::from_process())
+        let path = path.as_ref();
+        assert!(
+            is_xdg_relative(path),
+            "an XDG path must be relative to its base and cannot traverse a parent"
+        );
+        Self::xdg_from(base, path, XdgEnv::from_process())
     }
 
     fn xdg_from(base: XdgBase, path: &Path, env: XdgEnv) -> Self {
@@ -389,6 +394,31 @@ fn xdg_dirs(value: Option<OsString>, defaults: &[&str]) -> Vec<PathBuf> {
             .collect(),
         None => defaults.iter().map(PathBuf::from).collect(),
     }
+}
+
+/// Whether a path stays beneath an XDG base on both Unix and Windows.
+///
+/// The host's [`Component`]s catch its native absolute and parent forms. The text checks catch
+/// Windows forms while cross-compiling or testing on Unix, where a backslash and drive prefix
+/// would otherwise be ordinary filename characters.
+fn is_xdg_relative(path: &Path) -> bool {
+    if path.as_os_str().is_empty()
+        || path.components().any(|component| {
+            matches!(
+                component,
+                Component::Prefix(_) | Component::RootDir | Component::ParentDir
+            )
+        })
+    {
+        return false;
+    }
+    let Some(text) = path.to_str() else {
+        return true;
+    };
+    let bytes = text.as_bytes();
+    let windows_prefix = text.starts_with('\\')
+        || (bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':');
+    !windows_prefix && !text.split(['/', '\\']).any(|part| part == "..")
 }
 
 /// What one key in a file turned out to hold.
@@ -1040,6 +1070,32 @@ mod tests {
         fn drop(&mut self) {
             let _ = std::fs::remove_dir_all(&self.0);
         }
+    }
+
+    #[test]
+    fn xdg_paths_are_relative_under_unix_and_windows_rules() {
+        for path in ["ex/config.toml", "ex/./config.toml", "config.toml"] {
+            assert!(is_xdg_relative(Path::new(path)), "{path}");
+        }
+        for path in [
+            "",
+            "/tmp/config.toml",
+            "../config.toml",
+            "ex/../../config.toml",
+            r"\Windows\config.toml",
+            r"C:\config.toml",
+            r"C:config.toml",
+            r"..\config.toml",
+            r"ex\..\config.toml",
+        ] {
+            assert!(!is_xdg_relative(Path::new(path)), "{path}");
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "an XDG path must be relative")]
+    fn the_public_xdg_constructor_rejects_an_escaping_path() {
+        let _ = FileLayer::xdg(XdgBase::Config, "../config.toml");
     }
 
     #[cfg(unix)]

--- a/config/src/files.rs
+++ b/config/src/files.rs
@@ -37,6 +37,48 @@ pub enum Format {
     Yaml,
 }
 
+/// Which XDG base directory a file lives under.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum XdgBase {
+    /// `XDG_CONFIG_HOME` and `XDG_CONFIG_DIRS`.
+    Config,
+    /// `XDG_DATA_HOME` and `XDG_DATA_DIRS`.
+    Data,
+    /// `XDG_STATE_HOME`.
+    State,
+    /// `XDG_CACHE_HOME`.
+    Cache,
+    /// `XDG_RUNTIME_DIR`, which has no fallback.
+    Runtime,
+}
+
+#[derive(Default)]
+struct XdgEnv {
+    home: Option<OsString>,
+    config_home: Option<OsString>,
+    config_dirs: Option<OsString>,
+    data_home: Option<OsString>,
+    data_dirs: Option<OsString>,
+    state_home: Option<OsString>,
+    cache_home: Option<OsString>,
+    runtime_dir: Option<OsString>,
+}
+
+impl XdgEnv {
+    fn from_process() -> Self {
+        Self {
+            home: std::env::var_os("HOME"),
+            config_home: std::env::var_os("XDG_CONFIG_HOME"),
+            config_dirs: std::env::var_os("XDG_CONFIG_DIRS"),
+            data_home: std::env::var_os("XDG_DATA_HOME"),
+            data_dirs: std::env::var_os("XDG_DATA_DIRS"),
+            state_home: std::env::var_os("XDG_STATE_HOME"),
+            cache_home: std::env::var_os("XDG_CACHE_HOME"),
+            runtime_dir: std::env::var_os("XDG_RUNTIME_DIR"),
+        }
+    }
+}
+
 impl Format {
     /// The format an extension implies, when one does.
     ///
@@ -83,57 +125,54 @@ impl FileLayer {
         }
     }
 
-    /// An XDG config file, including the user and system search paths.
+    /// A file under an XDG base directory.
     ///
-    /// `path` is relative to each XDG config directory, for example
-    /// `"ex/config.toml"`. Files are read in ascending precedence: the directories in
-    /// `XDG_CONFIG_DIRS` (whose first entry wins) followed by `XDG_CONFIG_HOME`. When the
-    /// variables are unset or empty, the XDG defaults of `/etc/xdg` and
-    /// `$HOME/.config` are used. Relative paths in XDG variables are invalid according to
-    /// the specification and are ignored.
+    /// `path` is relative to the chosen base, for example `"ex/config.toml"`. Config and
+    /// data files include their system search directories and are read in ascending
+    /// precedence, with the user file last. State and cache use their standard
+    /// `$HOME/.local/state` and `$HOME/.cache` fallbacks; the runtime directory has no
+    /// fallback. Relative paths in XDG variables are invalid and are ignored.
     ///
     /// This constructor reads the process environment. Use [`FileLayer::at`] when the
     /// application has already resolved or overridden its config directory.
-    pub fn xdg(path: impl AsRef<Path>) -> Self {
-        Self::xdg_from(
-            path.as_ref(),
-            std::env::var_os("XDG_CONFIG_HOME"),
-            std::env::var_os("HOME"),
-            std::env::var_os("XDG_CONFIG_DIRS"),
-        )
+    pub fn xdg(base: XdgBase, path: impl AsRef<Path>) -> Self {
+        Self::xdg_from(base, path.as_ref(), XdgEnv::from_process())
     }
 
-    fn xdg_from(
-        path: &Path,
-        config_home: Option<OsString>,
-        home: Option<OsString>,
-        config_dirs: Option<OsString>,
-    ) -> Self {
+    fn xdg_from(base: XdgBase, path: &Path, env: XdgEnv) -> Self {
         let mut paths = Vec::new();
         let mut scopes = Vec::new();
 
-        let system_dirs: Vec<PathBuf> = match config_dirs.filter(|value| !value.is_empty()) {
-            Some(value) => std::env::split_paths(&value)
-                .filter(|dir| dir.is_absolute())
-                .collect(),
-            None => vec![PathBuf::from("/etc/xdg")],
+        let system_dirs: Vec<PathBuf> = match base {
+            XdgBase::Config => xdg_dirs(env.config_dirs, &["/etc/xdg"]),
+            XdgBase::Data => xdg_dirs(env.data_dirs, &["/usr/local/share", "/usr/share"]),
+            XdgBase::State | XdgBase::Cache | XdgBase::Runtime => Vec::new(),
         };
-        // XDG_CONFIG_DIRS is highest-precedence first, while one FileLayer is merged in the
-        // order stored. Reverse it so the first directory gets the last word.
+        // XDG *_DIRS are highest-precedence first, while one FileLayer is merged in the order
+        // stored. Reverse them so the first directory gets the last word.
         for dir in system_dirs.into_iter().rev() {
             paths.push(dir.join(path));
             scopes.push(FileScope::System);
         }
 
-        let user_dir = match config_home.filter(|value| !value.is_empty()) {
+        let (user, fallback) = match base {
+            XdgBase::Config => (env.config_home, Some(Path::new(".config"))),
+            XdgBase::Data => (env.data_home, Some(Path::new(".local/share"))),
+            XdgBase::State => (env.state_home, Some(Path::new(".local/state"))),
+            XdgBase::Cache => (env.cache_home, Some(Path::new(".cache"))),
+            XdgBase::Runtime => (env.runtime_dir, None),
+        };
+        let user_dir = match user.filter(|value| !value.is_empty()) {
             Some(value) => {
                 let dir = PathBuf::from(value);
                 dir.is_absolute().then_some(dir)
             }
-            None => home
+            None => env
+                .home
                 .map(PathBuf::from)
                 .filter(|dir| dir.is_absolute())
-                .map(|dir| dir.join(".config")),
+                .zip(fallback)
+                .map(|(dir, suffix)| dir.join(suffix)),
         };
         if let Some(dir) = user_dir {
             paths.push(dir.join(path));
@@ -340,6 +379,15 @@ impl Layer for FileLayer {
             self.read(path, scope, ctx, &mut out)?;
         }
         Ok(out)
+    }
+}
+
+fn xdg_dirs(value: Option<OsString>, defaults: &[&str]) -> Vec<PathBuf> {
+    match value.filter(|value| !value.is_empty()) {
+        Some(value) => std::env::split_paths(&value)
+            .filter(|dir| dir.is_absolute())
+            .collect(),
+        None => defaults.iter().map(PathBuf::from).collect(),
     }
 }
 
@@ -998,10 +1046,13 @@ mod tests {
     #[test]
     fn xdg_paths_put_the_user_above_system_directories() {
         let layer = FileLayer::xdg_from(
+            XdgBase::Config,
             Path::new("ex/config.toml"),
-            Some(OsString::from("/home/user/config")),
-            Some(OsString::from("/ignored")),
-            Some(OsString::from("/etc/xdg:/opt/xdg")),
+            XdgEnv {
+                config_home: Some(OsString::from("/home/user/config")),
+                config_dirs: Some(OsString::from("/etc/xdg:/opt/xdg")),
+                ..Default::default()
+            },
         );
         assert_eq!(
             layer.paths(),
@@ -1021,10 +1072,14 @@ mod tests {
     #[test]
     fn xdg_paths_use_the_spec_defaults() {
         let layer = FileLayer::xdg_from(
+            XdgBase::Config,
             Path::new("ex/config.toml"),
-            Some(OsString::new()),
-            Some(OsString::from("/home/user")),
-            Some(OsString::new()),
+            XdgEnv {
+                home: Some(OsString::from("/home/user")),
+                config_home: Some(OsString::new()),
+                config_dirs: Some(OsString::new()),
+                ..Default::default()
+            },
         );
         assert_eq!(
             layer.paths(),
@@ -1039,13 +1094,58 @@ mod tests {
     #[test]
     fn xdg_paths_ignore_relative_environment_values() {
         let layer = FileLayer::xdg_from(
+            XdgBase::Config,
             Path::new("ex/config.toml"),
-            Some(OsString::from("relative/user")),
-            Some(OsString::from("/home/user")),
-            Some(OsString::from("relative:/etc/ex:also-relative")),
+            XdgEnv {
+                home: Some(OsString::from("/home/user")),
+                config_home: Some(OsString::from("relative/user")),
+                config_dirs: Some(OsString::from("relative:/etc/ex:also-relative")),
+                ..Default::default()
+            },
         );
         assert_eq!(layer.paths(), &[PathBuf::from("/etc/ex/ex/config.toml")]);
         assert_eq!(layer.scopes, [FileScope::System]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn each_xdg_base_uses_its_own_home_and_fallback() {
+        let env = || XdgEnv {
+            home: Some(OsString::from("/home/user")),
+            ..Default::default()
+        };
+        let path = Path::new("ex/value");
+        assert_eq!(
+            FileLayer::xdg_from(XdgBase::Data, path, env()).paths(),
+            &[
+                PathBuf::from("/usr/share/ex/value"),
+                PathBuf::from("/usr/local/share/ex/value"),
+                PathBuf::from("/home/user/.local/share/ex/value"),
+            ]
+        );
+        assert_eq!(
+            FileLayer::xdg_from(XdgBase::State, path, env()).paths(),
+            &[PathBuf::from("/home/user/.local/state/ex/value")]
+        );
+        assert_eq!(
+            FileLayer::xdg_from(XdgBase::Cache, path, env()).paths(),
+            &[PathBuf::from("/home/user/.cache/ex/value")]
+        );
+        assert!(FileLayer::xdg_from(XdgBase::Runtime, path, env())
+            .paths()
+            .is_empty());
+        assert_eq!(
+            FileLayer::xdg_from(
+                XdgBase::Runtime,
+                path,
+                XdgEnv {
+                    runtime_dir: Some(OsString::from("/run/user/1000")),
+                    ..Default::default()
+                }
+            )
+            .paths(),
+            &[PathBuf::from("/run/user/1000/ex/value")]
+        );
     }
 
     #[cfg(feature = "toml")]

--- a/config/src/files.rs
+++ b/config/src/files.rs
@@ -13,6 +13,7 @@
 //! whose files are pkl or `.npmrc` writes its own layer against [`Layer`] and takes nothing it
 //! does not use.
 
+use std::ffi::OsString;
 use std::path::{Component, Path, PathBuf, Prefix};
 
 use crate::layer::{Layer, LayerCtx, LayerError, LayerOutput};
@@ -64,7 +65,7 @@ impl Format {
 /// accident, and that is the check a `scope="global"` setting exists for.
 pub struct FileLayer {
     paths: Vec<PathBuf>,
-    scope: FileScope,
+    scopes: Vec<FileScope>,
     format: Option<Format>,
     prefix: Option<String>,
     preprocess: Option<Preprocess>,
@@ -75,7 +76,73 @@ impl FileLayer {
     pub fn at(path: impl Into<PathBuf>, scope: FileScope) -> Self {
         Self {
             paths: vec![path.into()],
-            scope,
+            scopes: vec![scope],
+            format: None,
+            prefix: None,
+            preprocess: None,
+        }
+    }
+
+    /// An XDG config file, including the user and system search paths.
+    ///
+    /// `path` is relative to each XDG config directory, for example
+    /// `"ex/config.toml"`. Files are read in ascending precedence: the directories in
+    /// `XDG_CONFIG_DIRS` (whose first entry wins) followed by `XDG_CONFIG_HOME`. When the
+    /// variables are unset or empty, the XDG defaults of `/etc/xdg` and
+    /// `$HOME/.config` are used. Relative paths in XDG variables are invalid according to
+    /// the specification and are ignored.
+    ///
+    /// This constructor reads the process environment. Use [`FileLayer::at`] when the
+    /// application has already resolved or overridden its config directory.
+    pub fn xdg(path: impl AsRef<Path>) -> Self {
+        Self::xdg_from(
+            path.as_ref(),
+            std::env::var_os("XDG_CONFIG_HOME"),
+            std::env::var_os("HOME"),
+            std::env::var_os("XDG_CONFIG_DIRS"),
+        )
+    }
+
+    fn xdg_from(
+        path: &Path,
+        config_home: Option<OsString>,
+        home: Option<OsString>,
+        config_dirs: Option<OsString>,
+    ) -> Self {
+        let mut paths = Vec::new();
+        let mut scopes = Vec::new();
+
+        let system_dirs: Vec<PathBuf> = match config_dirs.filter(|value| !value.is_empty()) {
+            Some(value) => std::env::split_paths(&value)
+                .filter(|dir| dir.is_absolute())
+                .collect(),
+            None => vec![PathBuf::from("/etc/xdg")],
+        };
+        // XDG_CONFIG_DIRS is highest-precedence first, while one FileLayer is merged in the
+        // order stored. Reverse it so the first directory gets the last word.
+        for dir in system_dirs.into_iter().rev() {
+            paths.push(dir.join(path));
+            scopes.push(FileScope::System);
+        }
+
+        let user_dir = match config_home.filter(|value| !value.is_empty()) {
+            Some(value) => {
+                let dir = PathBuf::from(value);
+                dir.is_absolute().then_some(dir)
+            }
+            None => home
+                .map(PathBuf::from)
+                .filter(|dir| dir.is_absolute())
+                .map(|dir| dir.join(".config")),
+        };
+        if let Some(dir) = user_dir {
+            paths.push(dir.join(path));
+            scopes.push(FileScope::Global);
+        }
+
+        Self {
+            paths,
+            scopes,
             format: None,
             prefix: None,
             preprocess: None,
@@ -124,9 +191,10 @@ impl FileLayer {
             dir = current.parent();
         }
         found.reverse();
+        let found_len = found.len();
         Self {
             paths: found,
-            scope,
+            scopes: vec![scope; found_len],
             format: None,
             prefix: None,
             preprocess: None,
@@ -167,7 +235,13 @@ impl FileLayer {
         &self.paths
     }
 
-    fn read(&self, path: &Path, ctx: &LayerCtx, out: &mut LayerOutput) -> Result<(), LayerError> {
+    fn read(
+        &self,
+        path: &Path,
+        scope: FileScope,
+        ctx: &LayerCtx,
+        out: &mut LayerOutput,
+    ) -> Result<(), LayerError> {
         // Absent is the normal case, not a failure: a find-up chain is mostly directories with
         // no config file in them. *Only* absent, though — a file that is there and cannot be
         // read is the case this module's own doc calls an error, and `read_to_string` also
@@ -231,7 +305,7 @@ impl FileLayer {
                 }
             })?;
         for (key, found) in flat {
-            let origin = Origin::file(format!("{}#{key}", path.display()), self.scope);
+            let origin = Origin::file(format!("{}#{key}", path.display()), scope);
             match found {
                 // Through `entry_for_key`, which is what makes an unknown key a warning,
                 // follows a rename while remembering the name that was written, and reads the
@@ -262,8 +336,8 @@ impl Layer for FileLayer {
 
     fn load(&self, ctx: &LayerCtx) -> Result<LayerOutput, LayerError> {
         let mut out = LayerOutput::new();
-        for path in &self.paths {
-            self.read(path, ctx, &mut out)?;
+        for (path, scope) in self.paths.iter().zip(self.scopes.iter().copied()) {
+            self.read(path, scope, ctx, &mut out)?;
         }
         Ok(out)
     }
@@ -918,6 +992,60 @@ mod tests {
         fn drop(&mut self) {
             let _ = std::fs::remove_dir_all(&self.0);
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn xdg_paths_put_the_user_above_system_directories() {
+        let layer = FileLayer::xdg_from(
+            Path::new("ex/config.toml"),
+            Some(OsString::from("/home/user/config")),
+            Some(OsString::from("/ignored")),
+            Some(OsString::from("/etc/xdg:/opt/xdg")),
+        );
+        assert_eq!(
+            layer.paths(),
+            &[
+                PathBuf::from("/opt/xdg/ex/config.toml"),
+                PathBuf::from("/etc/xdg/ex/config.toml"),
+                PathBuf::from("/home/user/config/ex/config.toml"),
+            ]
+        );
+        assert_eq!(
+            layer.scopes,
+            [FileScope::System, FileScope::System, FileScope::Global]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn xdg_paths_use_the_spec_defaults() {
+        let layer = FileLayer::xdg_from(
+            Path::new("ex/config.toml"),
+            Some(OsString::new()),
+            Some(OsString::from("/home/user")),
+            Some(OsString::new()),
+        );
+        assert_eq!(
+            layer.paths(),
+            &[
+                PathBuf::from("/etc/xdg/ex/config.toml"),
+                PathBuf::from("/home/user/.config/ex/config.toml"),
+            ]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn xdg_paths_ignore_relative_environment_values() {
+        let layer = FileLayer::xdg_from(
+            Path::new("ex/config.toml"),
+            Some(OsString::from("relative/user")),
+            Some(OsString::from("/home/user")),
+            Some(OsString::from("relative:/etc/ex:also-relative")),
+        );
+        assert_eq!(layer.paths(), &[PathBuf::from("/etc/ex/ex/config.toml")]);
+        assert_eq!(layer.scopes, [FileScope::System]);
     }
 
     #[cfg(feature = "toml")]

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -77,7 +77,7 @@ pub use cli::CliLayer;
 pub use env::EnvLayer;
 pub use explain::explain;
 #[cfg(any(feature = "toml", feature = "json", feature = "yaml"))]
-pub use files::{FileLayer, Format};
+pub use files::{FileLayer, Format, XdgBase};
 pub use layer::{Entry, Layer, LayerCtx, LayerError, LayerOutput, Warning, WarningKind};
 pub use props::{concat_prop_specs, concat_props, Props};
 pub use read::{Fold, FromValue, ReadError, ReadErrorKind, ReadErrors};

--- a/conformance/tests/derive_config.rs
+++ b/conformance/tests/derive_config.rs
@@ -43,6 +43,7 @@ struct TaskSettings {
     set_hint = "git config {key} {value}"
 ))]
 #[usage(file(path = "/etc/ex.toml", scope = "system", format = "toml"))]
+#[usage(file(path = "ex/config.toml", xdg, format = "toml"))]
 #[usage(file(path = "ex.toml", findup))]
 struct Settings {
     /// How many jobs to run at once
@@ -289,10 +290,23 @@ fn the_emitted_config_block_is_the_spec_grammar() {
             .iter()
             .map(|file| file.path.as_str())
             .collect::<Vec<_>>(),
-        vec!["/etc/ex.toml", "ex.toml"],
+        vec![
+            "/etc/ex.toml",
+            "$XDG_CONFIG_DIRS/ex/config.toml",
+            "$XDG_CONFIG_HOME/ex/config.toml",
+            "ex.toml"
+        ],
         "file declaration order is precedence"
     );
-    assert!(spec.config.files[1].findup);
+    assert_eq!(
+        spec.config.files[1].scope,
+        usage::spec::config::SpecConfigFileScope::System
+    );
+    assert_eq!(
+        spec.config.files[2].scope,
+        usage::spec::config::SpecConfigFileScope::Global
+    );
+    assert!(spec.config.files[3].findup);
     assert!(
         !spec
             .config

--- a/conformance/tests/derive_config.rs
+++ b/conformance/tests/derive_config.rs
@@ -43,7 +43,7 @@ struct TaskSettings {
     set_hint = "git config {key} {value}"
 ))]
 #[usage(file(path = "/etc/ex.toml", scope = "system", format = "toml"))]
-#[usage(file(path = "ex/config.toml", xdg = "config", format = "toml"))]
+#[usage(file(path = "ex/config.toml", xdg = "config"))]
 #[usage(file(path = "ex.toml", findup))]
 struct Settings {
     /// How many jobs to run at once

--- a/conformance/tests/derive_config.rs
+++ b/conformance/tests/derive_config.rs
@@ -43,7 +43,7 @@ struct TaskSettings {
     set_hint = "git config {key} {value}"
 ))]
 #[usage(file(path = "/etc/ex.toml", scope = "system", format = "toml"))]
-#[usage(file(path = "ex/config.toml", xdg, format = "toml"))]
+#[usage(file(path = "ex/config.toml", xdg = "config", format = "toml"))]
 #[usage(file(path = "ex.toml", findup))]
 struct Settings {
     /// How many jobs to run at once

--- a/derive/src/config.rs
+++ b/derive/src/config.rs
@@ -98,7 +98,7 @@ struct Source {
 struct File {
     path: String,
     findup: bool,
-    xdg: bool,
+    xdg: Option<XdgBase>,
     scope: FileScope,
     format: Option<String>,
 }
@@ -108,6 +108,15 @@ enum FileScope {
     Project,
     Global,
     System,
+}
+
+#[derive(Clone, Copy)]
+enum XdgBase {
+    Config,
+    Data,
+    State,
+    Cache,
+    Runtime,
 }
 
 enum Field {
@@ -495,8 +504,7 @@ fn file_decl(meta: &Meta) -> syn::Result<File> {
     let mut path = None;
     let mut findup = false;
     let mut saw_findup = false;
-    let mut xdg = false;
-    let mut saw_xdg = false;
+    let mut xdg = None;
     let mut scope = FileScope::Project;
     let mut saw_scope = false;
     let mut format = None;
@@ -516,11 +524,26 @@ fn file_decl(meta: &Meta) -> syn::Result<File> {
                 saw_findup = true;
             }
             "xdg" => {
-                if saw_xdg {
+                if xdg.is_some() {
                     return Err(syn::Error::new_spanned(&item, "`xdg` is given twice"));
                 }
-                xdg = flag_value(&item)?;
-                saw_xdg = true;
+                let value = string_value(&item)?;
+                xdg = Some(match value.as_str() {
+                    "config" => XdgBase::Config,
+                    "data" => XdgBase::Data,
+                    "state" => XdgBase::State,
+                    "cache" => XdgBase::Cache,
+                    "runtime" => XdgBase::Runtime,
+                    _ => {
+                        return Err(syn::Error::new_spanned(
+                            &item,
+                            format!(
+                                "`{value}` is not an XDG base; use `config`, `data`, `state`, \
+                                 `cache`, or `runtime`"
+                            ),
+                        ))
+                    }
+                });
             }
             "scope" => {
                 if saw_scope {
@@ -568,14 +591,14 @@ fn file_decl(meta: &Meta) -> syn::Result<File> {
             "a config file path cannot be empty",
         ));
     }
-    if xdg && (saw_findup || saw_scope) {
+    if xdg.is_some() && (saw_findup || saw_scope) {
         return Err(syn::Error::new_spanned(
             meta,
-            "an XDG config file decides its own user and system scopes; do not combine `xdg` \
-             with `findup` or `scope`",
+            "an XDG file's base decides its scope; do not combine `xdg` with `findup` or \
+             `scope`",
         ));
     }
-    if xdg && std::path::Path::new(&path).is_absolute() {
+    if xdg.is_some() && std::path::Path::new(&path).is_absolute() {
         return Err(syn::Error::new_spanned(
             meta,
             "an XDG config file path must be relative to the XDG config directories",
@@ -1443,23 +1466,32 @@ pub fn emit(config: &Config) -> TokenStream {
     let files = config.files.iter().flat_map(|file| {
         let path = &file.path;
         let format = option_str(&file.format);
-        if file.xdg {
-            let system = format!("$XDG_CONFIG_DIRS/{path}");
-            let global = format!("$XDG_CONFIG_HOME/{path}");
-            vec![
-                quote!(#cfg::SpecFile {
+        if let Some(base) = file.xdg {
+            let (dirs, home) = match base {
+                XdgBase::Config => (Some("$XDG_CONFIG_DIRS"), "$XDG_CONFIG_HOME"),
+                XdgBase::Data => (Some("$XDG_DATA_DIRS"), "$XDG_DATA_HOME"),
+                XdgBase::State => (None, "$XDG_STATE_HOME"),
+                XdgBase::Cache => (None, "$XDG_CACHE_HOME"),
+                XdgBase::Runtime => (None, "$XDG_RUNTIME_DIR"),
+            };
+            let global = format!("{home}/{path}");
+            let mut expanded = Vec::new();
+            if let Some(dirs) = dirs {
+                let system = format!("{dirs}/{path}");
+                expanded.push(quote!(#cfg::SpecFile {
                     path: #system,
                     findup: false,
                     scope: #cfg::FileScope::System,
                     format: #format,
-                }),
-                quote!(#cfg::SpecFile {
-                    path: #global,
-                    findup: false,
-                    scope: #cfg::FileScope::Global,
-                    format: #format,
-                }),
-            ]
+                }));
+            }
+            expanded.push(quote!(#cfg::SpecFile {
+                path: #global,
+                findup: false,
+                scope: #cfg::FileScope::Global,
+                format: #format,
+            }));
+            expanded
         } else {
             let findup = file.findup;
             let scope = match file.scope {
@@ -2386,7 +2418,7 @@ mod tests {
             r#"
             #[usage(source(kind = "git", name = "git config"))]
             #[usage(file(path = "ex.toml", findup, scope = "project"))]
-            #[usage(file(path = "ex/config.toml", xdg, format = "toml"))]
+            #[usage(file(path = "ex/config.toml", xdg = "config", format = "toml"))]
             struct Settings {
                 jobs: u64,
             }
@@ -2438,8 +2470,8 @@ mod tests {
         assert!(err.contains("not a config file scope"), "unhelpful: {err}");
 
         for declaration in [
-            r#"file(path = "ex/config.toml", xdg, findup)"#,
-            r#"file(path = "ex/config.toml", xdg, scope = "global")"#,
+            r#"file(path = "ex/config.toml", xdg = "config", findup)"#,
+            r#"file(path = "ex/config.toml", xdg = "cache", scope = "global")"#,
         ] {
             let err = rejection(&format!(
                 r#"
@@ -2449,11 +2481,18 @@ mod tests {
                 }}
                 "#
             ));
-            assert!(
-                err.contains("decides its own user and system scopes"),
-                "{err}"
-            );
+            assert!(err.contains("base decides its scope"), "{err}");
         }
+
+        let err = rejection(
+            r#"
+            #[usage(file(path = "ex/value", xdg = "local"))]
+            struct Settings {
+                jobs: u64,
+            }
+            "#,
+        );
+        assert!(err.contains("not an XDG base"), "{err}");
 
         let err = rejection(
             r#"

--- a/derive/src/config.rs
+++ b/derive/src/config.rs
@@ -98,6 +98,7 @@ struct Source {
 struct File {
     path: String,
     findup: bool,
+    xdg: bool,
     scope: FileScope,
     format: Option<String>,
 }
@@ -494,6 +495,8 @@ fn file_decl(meta: &Meta) -> syn::Result<File> {
     let mut path = None;
     let mut findup = false;
     let mut saw_findup = false;
+    let mut xdg = false;
+    let mut saw_xdg = false;
     let mut scope = FileScope::Project;
     let mut saw_scope = false;
     let mut format = None;
@@ -511,6 +514,13 @@ fn file_decl(meta: &Meta) -> syn::Result<File> {
                 }
                 findup = flag_value(&item)?;
                 saw_findup = true;
+            }
+            "xdg" => {
+                if saw_xdg {
+                    return Err(syn::Error::new_spanned(&item, "`xdg` is given twice"));
+                }
+                xdg = flag_value(&item)?;
+                saw_xdg = true;
             }
             "scope" => {
                 if saw_scope {
@@ -544,7 +554,7 @@ fn file_decl(meta: &Meta) -> syn::Result<File> {
                     item.path(),
                     format!(
                         "a config file does not understand `{other}`; use `path`, `findup`, \
-                         `scope`, or `format`"
+                         `xdg`, `scope`, or `format`"
                     ),
                 ))
             }
@@ -558,9 +568,23 @@ fn file_decl(meta: &Meta) -> syn::Result<File> {
             "a config file path cannot be empty",
         ));
     }
+    if xdg && (saw_findup || saw_scope) {
+        return Err(syn::Error::new_spanned(
+            meta,
+            "an XDG config file decides its own user and system scopes; do not combine `xdg` \
+             with `findup` or `scope`",
+        ));
+    }
+    if xdg && std::path::Path::new(&path).is_absolute() {
+        return Err(syn::Error::new_spanned(
+            meta,
+            "an XDG config file path must be relative to the XDG config directories",
+        ));
+    }
     Ok(File {
         path,
         findup,
+        xdg,
         scope,
         format,
     })
@@ -1416,21 +1440,40 @@ pub fn emit(config: &Config) -> TokenStream {
             set_hint: #set_hint,
         })
     });
-    let files = config.files.iter().map(|file| {
+    let files = config.files.iter().flat_map(|file| {
         let path = &file.path;
-        let findup = file.findup;
-        let scope = match file.scope {
-            FileScope::Project => quote!(#cfg::FileScope::Project),
-            FileScope::Global => quote!(#cfg::FileScope::Global),
-            FileScope::System => quote!(#cfg::FileScope::System),
-        };
         let format = option_str(&file.format);
-        quote!(#cfg::SpecFile {
-            path: #path,
-            findup: #findup,
-            scope: #scope,
-            format: #format,
-        })
+        if file.xdg {
+            let system = format!("$XDG_CONFIG_DIRS/{path}");
+            let global = format!("$XDG_CONFIG_HOME/{path}");
+            vec![
+                quote!(#cfg::SpecFile {
+                    path: #system,
+                    findup: false,
+                    scope: #cfg::FileScope::System,
+                    format: #format,
+                }),
+                quote!(#cfg::SpecFile {
+                    path: #global,
+                    findup: false,
+                    scope: #cfg::FileScope::Global,
+                    format: #format,
+                }),
+            ]
+        } else {
+            let findup = file.findup;
+            let scope = match file.scope {
+                FileScope::Project => quote!(#cfg::FileScope::Project),
+                FileScope::Global => quote!(#cfg::FileScope::Global),
+                FileScope::System => quote!(#cfg::FileScope::System),
+            };
+            vec![quote!(#cfg::SpecFile {
+                path: #path,
+                findup: #findup,
+                scope: #scope,
+                format: #format,
+            })]
+        }
     });
 
     // Reads in declaration order, advancing a cursor: one id per own prop, a group's length
@@ -2343,6 +2386,7 @@ mod tests {
             r#"
             #[usage(source(kind = "git", name = "git config"))]
             #[usage(file(path = "ex.toml", findup, scope = "project"))]
+            #[usage(file(path = "ex/config.toml", xdg, format = "toml"))]
             struct Settings {
                 jobs: u64,
             }
@@ -2392,6 +2436,24 @@ mod tests {
         "#,
         );
         assert!(err.contains("not a config file scope"), "unhelpful: {err}");
+
+        for declaration in [
+            r#"file(path = "ex/config.toml", xdg, findup)"#,
+            r#"file(path = "ex/config.toml", xdg, scope = "global")"#,
+        ] {
+            let err = rejection(&format!(
+                r#"
+                #[usage({declaration})]
+                struct Settings {{
+                    jobs: u64,
+                }}
+                "#
+            ));
+            assert!(
+                err.contains("decides its own user and system scopes"),
+                "{err}"
+            );
+        }
 
         let err = rejection(
             r#"

--- a/docs/rust/configuration.md
+++ b/docs/rust/configuration.md
@@ -71,12 +71,12 @@ exactly as they do for flags.
 Struct-level attributes declare the `config` block around those settings. They are
 documentation for resolvers the CLI already owns, not extra runtime layers:
 
-| Attribute                                                                   | Effect                                                                                                       |
-| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `prefix = "task"`                                                           | Prefix every field's key in this struct                                                                      |
-| `source(kind = "git", name = "git config", doc_hint = "…", set_hint = "…")` | A custom source kind's display metadata. Repeatable; kinds are written in sorted order                       |
-| `file(path = "ex.toml", findup, scope = "project", format = "toml")`        | A config file in the documented precedence chain. Repeatable; **declaration order is precedence**, last wins |
-| `file(path = "ex/config.toml", xdg, format = "toml")`                       | User and system XDG config locations; expands into their standard precedence in the emitted spec             |
+| Attribute                                                                   | Effect                                                                                                           |
+| --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `prefix = "task"`                                                           | Prefix every field's key in this struct                                                                          |
+| `source(kind = "git", name = "git config", doc_hint = "…", set_hint = "…")` | A custom source kind's display metadata. Repeatable; kinds are written in sorted order                           |
+| `file(path = "ex.toml", findup, scope = "project", format = "toml")`        | A config file in the documented precedence chain. Repeatable; **declaration order is precedence**, last wins     |
+| `file(path = "ex/config.toml", xdg = "config", format = "toml")`            | XDG config, data, state, cache, or runtime locations; expands into their standard precedence in the emitted spec |
 
 `source` and `file` belong to the struct they are written on. Flattening another `Config`
 type splices its _settings_, not its source/file declarations — a nested group that also
@@ -154,12 +154,12 @@ struct. The CLI names the layers it has — that stays its own business — and 
 decides what every value means:
 
 ```rust
-use usage::config::{resolve, EnvLayer, FileLayer, FileScope, Layers};
+use usage::config::{resolve, EnvLayer, FileLayer, FileScope, Layers, XdgBase};
 
 let (cli, cli_layer) = Ex::parse_from_with_settings(&argv)?;
 let env = EnvLayer::from_process();
 // FileLayer needs a format feature on usage-config (`toml`, `json`, or `yaml`).
-let user_and_system = FileLayer::xdg("ex/config.toml");
+let user_and_system = FileLayer::xdg(XdgBase::Config, "ex/config.toml");
 let project = FileLayer::find_up("ex.toml", &cwd, None, FileScope::Project);
 let resolved = resolve(
     Settings::SETTINGS_REGISTRY,
@@ -175,10 +175,11 @@ for warning in usage::config::explain::warnings(&resolved) {
 }
 ```
 
-Pair `#[usage(file(path = "ex/config.toml", xdg))]` on the derived settings struct with
-`FileLayer::xdg("ex/config.toml")` at runtime. The derive expands the declaration to the
-system and user paths in the emitted spec, while `FileLayer::xdg` reads the process's XDG
-config locations in their standard precedence:
+Pair `#[usage(file(path = "ex/config.toml", xdg = "config"))]` on the derived settings
+struct with `FileLayer::xdg(XdgBase::Config, "ex/config.toml")` at runtime. The base may
+instead be `data`, `state`, `cache`, or `runtime`. The derive expands the declaration into
+the corresponding paths in the emitted spec, while `FileLayer::xdg` reads the process's XDG
+locations in their standard precedence. For the config base:
 the user file under `XDG_CONFIG_HOME` wins over files under `XDG_CONFIG_DIRS`, and the first
 directory in `XDG_CONFIG_DIRS` wins over later ones. Unset variables fall back to
 `$HOME/.config` and `/etc/xdg`.

--- a/docs/rust/configuration.md
+++ b/docs/rust/configuration.md
@@ -76,6 +76,7 @@ documentation for resolvers the CLI already owns, not extra runtime layers:
 | `prefix = "task"`                                                           | Prefix every field's key in this struct                                                                      |
 | `source(kind = "git", name = "git config", doc_hint = "…", set_hint = "…")` | A custom source kind's display metadata. Repeatable; kinds are written in sorted order                       |
 | `file(path = "ex.toml", findup, scope = "project", format = "toml")`        | A config file in the documented precedence chain. Repeatable; **declaration order is precedence**, last wins |
+| `file(path = "ex/config.toml", xdg, format = "toml")`                       | User and system XDG config locations; expands into their standard precedence in the emitted spec             |
 
 `source` and `file` belong to the struct they are written on. Flattening another `Config`
 type splices its _settings_, not its source/file declarations — a nested group that also
@@ -158,16 +159,29 @@ use usage::config::{resolve, EnvLayer, FileLayer, FileScope, Layers};
 let (cli, cli_layer) = Ex::parse_from_with_settings(&argv)?;
 let env = EnvLayer::from_process();
 // FileLayer needs a format feature on usage-config (`toml`, `json`, or `yaml`).
+let user_and_system = FileLayer::xdg("ex/config.toml");
 let project = FileLayer::find_up("ex.toml", &cwd, None, FileScope::Project);
 let resolved = resolve(
     Settings::SETTINGS_REGISTRY,
-    Layers::new().then(&cli_layer).then(&env).then(&project),
+    Layers::new()
+        .then(&cli_layer)
+        .then(&env)
+        .then(&project)
+        .then(&user_and_system),
 )?;
 let settings = Settings::read(&resolved)?;
 for warning in usage::config::explain::warnings(&resolved) {
     eprintln!("{warning}");
 }
 ```
+
+Pair `#[usage(file(path = "ex/config.toml", xdg))]` on the derived settings struct with
+`FileLayer::xdg("ex/config.toml")` at runtime. The derive expands the declaration to the
+system and user paths in the emitted spec, while `FileLayer::xdg` reads the process's XDG
+config locations in their standard precedence:
+the user file under `XDG_CONFIG_HOME` wins over files under `XDG_CONFIG_DIRS`, and the first
+directory in `XDG_CONFIG_DIRS` wins over later ones. Unset variables fall back to
+`$HOME/.config` and `/etc/xdg`.
 
 `read` visits every field before returning, so the error is the whole list of what is wrong
 rather than the first thing found. Provenance is the merge's own output: `explain`, `list`,


### PR DESCRIPTION
## Summary

- add `FileLayer::xdg(XdgBase, path)` for explicit XDG config, data, state, cache, and runtime locations
- honor each base's defaults, absolute-path rules, and precedence without adding dependencies
- include system search directories for config and data while keeping state, cache, and runtime user-scoped
- add `#[usage(file(path = "…", xdg = "config"))]` derive metadata, with all five XDG bases supported
- document pairing the derive declaration with the runtime layer

## Testing

- `cargo test --all --all-features`
- `cargo clippy --all --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `prettier -c docs/rust/configuration.md`

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches config discovery and FileScope/trust assignment (system vs global) plus path-escape checks. Incorrect precedence or scope would change which files win and how trusted they are.
> 
> **Overview**
> Adds **XDG file layers** so a relative path can be resolved under config, data, state, cache, or runtime bases without extra dependencies.
> 
> `FileLayer::xdg` reads process env (absolute values only), applies spec fallbacks, and for config/data includes system dirs with **user last**. Each path now carries its own `FileScope` (`System` vs `Global`). Relative/escaping paths are rejected.
> 
> The Config derive accepts `file(..., xdg = "config")` (not combined with `findup`/`scope`) and expands it in the emitted spec to `$XDG_*_DIRS` / `$XDG_*_HOME` entries. Docs show pairing the attribute with the runtime layer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01fea3a33bd480bc100f5b5482fb9206aad5e204. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for selecting XDG config, data, state, cache, and runtime locations.
  - Configuration files can be resolved from user and system directories with defined precedence and fallbacks.
  - Runtime locations have no fallback.
  - Added validation for XDG paths and unsupported location combinations.
  - XDG declarations now require an explicit location type.

- **Documentation**
  - Documented XDG syntax, supported locations, directory resolution, runtime behavior, and precedence rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->