### PR TITLE
fix(cli): improve terminal help layout

### DIFF
--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -1273,7 +1273,7 @@ fn short_sections(
         write_wrapped_indented(out, about.trim_end(), width, 0);
         out.push('\n');
     }
-    command_deprecation(out, meta, 0);
+    command_deprecation(out, meta, 0, width);
     usage_section(&mut sections.usage, spec, path, meta);
 
     // The path without the binary: it is the sort key the reference orders the list by, even
@@ -1631,9 +1631,9 @@ fn flat_commands_short(out: &mut String, path: &[&str], meta: &CommandMeta<'_>, 
         sub_path.push(sub.cmd.name);
         let _ = writeln!(out, "\n{}:", sub_path.join(" "));
         if let Some(about) = sub.about.filter(|about| !about.trim().is_empty()) {
-            let _ = writeln!(out, "{}", about.trim_end());
+            write_wrapped_indented(out, about.trim_end(), width, 0);
         }
-        command_deprecation(out, sub, 0);
+        command_deprecation(out, sub, 0, width);
 
         let mut args: Vec<_> = sub
             .args
@@ -2222,7 +2222,7 @@ fn long_sections(
         write_wrapped_indented(out, about.trim_end(), width, 0);
         out.push('\n');
     }
-    command_deprecation(out, meta, 0);
+    command_deprecation(out, meta, 0, width);
     usage_section(&mut sections.usage, spec, path, meta);
 
     if !meta.flatten_help {
@@ -2777,13 +2777,13 @@ fn deprecation_label(
     Some(format!("[deprecated: {}]", parts.join("; ")))
 }
 
-fn command_deprecation(out: &mut String, meta: &CommandMeta<'_>, indent: usize) {
+fn command_deprecation(out: &mut String, meta: &CommandMeta<'_>, indent: usize, width: usize) {
     if let Some(label) = deprecation_label(
         meta.deprecated,
         meta.deprecated_warn_at,
         meta.deprecated_remove_at,
     ) {
-        let _ = writeln!(out, "{}{label}", " ".repeat(indent));
+        write_wrapped_indented(out, &label, width, indent);
     }
 }
 
@@ -2822,9 +2822,9 @@ fn flat_commands_long(out: &mut String, path: &[&str], meta: &CommandMeta<'_>, w
             .or(sub.about)
             .filter(|about| !about.trim().is_empty())
         {
-            let _ = writeln!(out, "{}", about.trim_end());
+            write_wrapped_indented(out, about.trim_end(), width, 0);
         }
-        command_deprecation(out, sub, 0);
+        command_deprecation(out, sub, 0, width);
 
         let mut args: Vec<_> = sub
             .args

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -31,6 +31,7 @@ pub use template::STYLES;
 
 /// The indent a page uses where it cannot align to its column.
 const BLOCK_INDENT: usize = 4;
+const MIN_INLINE_HELP_WIDTH: usize = 30;
 
 /// How many flags or arguments are listed individually before collapsing to a placeholder.
 ///
@@ -1247,7 +1248,8 @@ fn short_sections(
     // Text the command puts above everything else, and below it. The short form has only the
     // one pair; the long form prefers the long variants.
     if let Some(before) = meta.before_help.or(spec.root.before_help) {
-        let _ = writeln!(out, "{before}\n");
+        write_wrapped_indented(out, before, width, 0);
+        out.push('\n');
     }
 
     // The program, then what it is for — on the program's own page. A subcommand's page says
@@ -1268,7 +1270,8 @@ fn short_sections(
     if let Some(about) = about {
         // Trimmed for the same reason the entries below are: the blank line after the
         // description is written here, so one already in the text doubles it.
-        let _ = writeln!(out, "{}\n", about.trim_end());
+        write_wrapped_indented(out, about.trim_end(), width, 0);
+        out.push('\n');
     }
     command_deprecation(out, meta, 0);
     usage_section(&mut sections.usage, spec, path, meta);
@@ -1308,6 +1311,7 @@ fn short_sections(
             grouped: &mut sections.grouped_args,
         },
         "Arguments",
+        width,
         args.iter().copied(),
         |a| a.help_heading,
         // Section prose belongs to the long page, like an entry's admonitions.
@@ -1317,7 +1321,7 @@ fn short_sections(
             if meta.next_line_help {
                 let _ = writeln!(out, "  {usage}");
                 if let Some(help) = a.help.filter(|h| !h.trim().is_empty()) {
-                    write_indented(out, help, 4);
+                    write_wrapped_block(out, help, width);
                 }
                 long_annotations(
                     out,
@@ -1330,7 +1334,10 @@ fn short_sections(
                     if a.hide_env { &[] } else { a.env_fallback },
                     if a.hide_env { &[] } else { a.deprecated_env },
                     if a.hide_default_value { &[] } else { a.default },
-                    BLOCK_INDENT,
+                    AnnotationLayout {
+                        indent: BLOCK_INDENT,
+                        width,
+                    },
                 );
                 return;
             }
@@ -1370,7 +1377,7 @@ fn short_sections(
         if meta.next_line_help {
             let _ = writeln!(out, "  {usage}");
             if let Some(help) = f.help.filter(|h| !h.trim().is_empty()) {
-                write_indented(out, help, 4);
+                write_wrapped_block(out, help, width);
             }
             long_annotations(
                 out,
@@ -1383,9 +1390,12 @@ fn short_sections(
                 if f.hide_env { &[] } else { f.env_fallback },
                 if f.hide_env { &[] } else { f.deprecated_env },
                 if f.hide_default_value { &[] } else { f.default },
-                BLOCK_INDENT,
+                AnnotationLayout {
+                    indent: BLOCK_INDENT,
+                    width,
+                },
             );
-            flag_notes(out, f, BLOCK_INDENT);
+            flag_notes(out, f, BLOCK_INDENT, width);
             return;
         }
         let deprecation =
@@ -1418,6 +1428,7 @@ fn short_sections(
             grouped: &mut sections.grouped_flags,
         },
         "Flags",
+        width,
         own.iter().copied(),
         |f| flag_help_heading(meta, f),
         |_| None,
@@ -1433,6 +1444,7 @@ fn short_sections(
             grouped: &mut sections.grouped_flags,
         },
         "Global flags",
+        width,
         inherited.iter(),
         |_| None,
         |_| None,
@@ -1448,7 +1460,8 @@ fn short_sections(
     }
     examples_section(&mut sections.after_help, spec, meta);
     if let Some(after) = meta.after_help.or(spec.root.after_help) {
-        let _ = writeln!(sections.after_help, "\n{after}");
+        sections.after_help.push('\n');
+        write_wrapped_indented(&mut sections.after_help, after, width, 0);
     }
 
     sections
@@ -1526,7 +1539,7 @@ fn commands_section(
         // prose on the same terms: the long page only, and only once declared.
         if long {
             if let Some(prose) = heading.and_then(|title| heading_help(meta, title)) {
-                write_indented(out, prose, 2);
+                write_wrapped_indented(out, prose, width, 2);
                 out.push('\n');
             }
         }
@@ -1651,7 +1664,7 @@ fn flat_commands_short(out: &mut String, path: &[&str], meta: &CommandMeta<'_>, 
             if meta.next_line_help {
                 let _ = writeln!(out, "  {usage}");
                 if let Some(help) = arg.help.filter(|help| !help.trim().is_empty()) {
-                    write_indented(out, help, BLOCK_INDENT);
+                    write_wrapped_block(out, help, width);
                 }
                 long_annotations(
                     out,
@@ -1672,7 +1685,10 @@ fn flat_commands_short(out: &mut String, path: &[&str], meta: &CommandMeta<'_>, 
                     } else {
                         arg.default
                     },
-                    BLOCK_INDENT,
+                    AnnotationLayout {
+                        indent: BLOCK_INDENT,
+                        width,
+                    },
                 );
                 continue;
             }
@@ -1707,7 +1723,7 @@ fn flat_commands_short(out: &mut String, path: &[&str], meta: &CommandMeta<'_>, 
             if meta.next_line_help {
                 let _ = writeln!(out, "  {usage}");
                 if let Some(help) = flag.help.filter(|help| !help.trim().is_empty()) {
-                    write_indented(out, help, BLOCK_INDENT);
+                    write_wrapped_block(out, help, width);
                 }
                 long_annotations(
                     out,
@@ -1732,9 +1748,12 @@ fn flat_commands_short(out: &mut String, path: &[&str], meta: &CommandMeta<'_>, 
                     } else {
                         flag.default
                     },
-                    BLOCK_INDENT,
+                    AnnotationLayout {
+                        indent: BLOCK_INDENT,
+                        width,
+                    },
                 );
-                flag_notes(out, flag, BLOCK_INDENT);
+                flag_notes(out, flag, BLOCK_INDENT, width);
                 continue;
             }
             let deprecation = deprecation_label(
@@ -1837,6 +1856,7 @@ struct SectionSink<'s> {
 fn split_groups_section<'m, T: 'm>(
     sink: SectionSink<'_>,
     default_title: &str,
+    width: usize,
     items: impl Iterator<Item = &'m T> + Clone,
     heading_of: impl Fn(&T) -> Option<&str>,
     prose_of: impl Fn(&str) -> Option<&'m str>,
@@ -1869,7 +1889,7 @@ fn split_groups_section<'m, T: 'm>(
         // same unheaded flags render under `Flags` here and under `Global Flags` in a
         // Markdown page, so keying prose to it would mean different things per renderer.
         if let Some(prose) = heading.and_then(&prose_of) {
-            write_indented(&mut section, prose, 2);
+            write_wrapped_indented(&mut section, prose, width, 2);
             section.push('\n');
         }
         for item in items.clone().filter(|i| heading_of(i) == heading) {
@@ -2172,7 +2192,8 @@ fn long_sections(
         .or(spec.root.before_long_help)
         .or(spec.root.before_help)
     {
-        let _ = writeln!(out, "{before}\n");
+        write_wrapped_indented(out, before, width, 0);
+        out.push('\n');
     }
 
     // The banner and the program's own description belong to the program's page. A
@@ -2198,7 +2219,8 @@ fn long_sections(
     if let Some(about) = about {
         // Trimmed for the same reason the entries below are: the blank line after the
         // description is written here, so one already in the text doubles it.
-        let _ = writeln!(out, "{}\n", about.trim_end());
+        write_wrapped_indented(out, about.trim_end(), width, 0);
+        out.push('\n');
     }
     command_deprecation(out, meta, 0);
     usage_section(&mut sections.usage, spec, path, meta);
@@ -2234,6 +2256,7 @@ fn long_sections(
             grouped: &mut sections.grouped_args,
         },
         "Arguments",
+        width,
         args.iter().copied(),
         |a| a.help_heading,
         |title| heading_help(meta, title),
@@ -2247,7 +2270,7 @@ fn long_sections(
                 width,
                 meta.next_line_help,
             );
-            admonitions(out, a.admonitions);
+            admonitions(out, a.admonitions, width);
             long_annotations(
                 out,
                 if a.hide_possible_values {
@@ -2259,7 +2282,7 @@ fn long_sections(
                 if a.hide_env { &[] } else { a.env_fallback },
                 if a.hide_env { &[] } else { a.deprecated_env },
                 if a.hide_default_value { &[] } else { a.default },
-                indent,
+                AnnotationLayout { indent, width },
             );
         },
     );
@@ -2280,6 +2303,7 @@ fn long_sections(
             grouped: &mut sections.grouped_flags,
         },
         "Flags",
+        width,
         own.iter().copied(),
         |f| flag_help_heading(meta, f),
         |title| heading_help(meta, title),
@@ -2293,7 +2317,7 @@ fn long_sections(
                 width,
                 meta.next_line_help,
             );
-            admonitions(out, f.admonitions);
+            admonitions(out, f.admonitions, width);
             long_annotations(
                 out,
                 if f.hide_possible_values {
@@ -2305,9 +2329,9 @@ fn long_sections(
                 if f.hide_env { &[] } else { f.env_fallback },
                 if f.hide_env { &[] } else { f.deprecated_env },
                 if f.hide_default_value { &[] } else { f.default },
-                indent,
+                AnnotationLayout { indent, width },
             );
-            flag_notes(out, f, indent);
+            flag_notes(out, f, indent, width);
         },
     );
     // After the command's own, and under a heading that says where they came from: `--config`
@@ -2321,13 +2345,14 @@ fn long_sections(
             grouped: &mut sections.grouped_flags,
         },
         "Global flags",
+        width,
         inherited.iter(),
         |_| None,
         |_| None,
         |out, (f, usage)| {
             let text = f.long_help.or(f.help);
             let indent = entry(out, usage, text, flag_col, width, meta.next_line_help);
-            admonitions(out, f.admonitions);
+            admonitions(out, f.admonitions, width);
             long_annotations(
                 out,
                 if f.hide_possible_values {
@@ -2339,9 +2364,9 @@ fn long_sections(
                 if f.hide_env { &[] } else { f.env_fallback },
                 if f.hide_env { &[] } else { f.deprecated_env },
                 if f.hide_default_value { &[] } else { f.default },
-                indent,
+                AnnotationLayout { indent, width },
             );
-            flag_notes(out, f, indent);
+            flag_notes(out, f, indent, width);
         },
     );
     if meta.flatten_help {
@@ -2378,7 +2403,8 @@ fn long_sections(
         .or(spec.root.after_long_help)
         .or(spec.root.after_help);
     if let Some(after) = after {
-        let _ = writeln!(out, "\n{after}");
+        out.push('\n');
+        write_wrapped_indented(out, after, width, 0);
     }
     if spec.author.is_some() || spec.license.is_some() {
         // The reference template starts the footer in a new paragraph without trimming the
@@ -2436,26 +2462,51 @@ fn entry(
     // there is room left for it to say anything.
     let indent = 2 + col + 2;
     let room = width.saturating_sub(indent);
-    // A long outlier leaves the shared column to the ordinary entries and uses a block alone.
+    // A long outlier leaves the shared column to ordinary entries, but keeps its own help on
+    // the row when at least a useful line of prose remains.
     let overflow = usage.chars().count() > col;
-    let block = next_line || overflow || room < 10;
+    let inline_start = if overflow {
+        2 + usage.chars().count() + 2
+    } else {
+        indent
+    };
+    let inline_room = width.saturating_sub(inline_start);
+    let can_inline = !next_line
+        && if overflow {
+            inline_room >= MIN_INLINE_HELP_WIDTH
+        } else {
+            room >= 10
+        };
+    let block = !can_inline;
+    let block_indent = if !next_line && width.saturating_sub(indent) >= 10 {
+        indent
+    } else {
+        BLOCK_INDENT
+    };
     let Some(help) = help.filter(|h| !h.trim().is_empty()) else {
         let _ = writeln!(out, "  {usage}");
         // An entry with nothing in the column still has annotations to place, and the column is
         // where they go: it is this entry's row that is empty, not the table's.
-        return if block { BLOCK_INDENT } else { indent };
+        return if block { block_indent } else { indent };
     };
 
-    if overflow && !next_line && !help.contains('\n') {
+    if block {
         let _ = writeln!(out, "  {usage}");
-        write_wrapped_block(out, help, width);
-        return BLOCK_INDENT;
+        write_wrapped_indented(out, help, width, block_indent);
+        return block_indent;
     }
 
-    if block || help.contains('\n') {
-        let _ = writeln!(out, "  {usage}");
-        write_indented(out, help, BLOCK_INDENT);
-        return BLOCK_INDENT;
+    if overflow {
+        let lines = wrap_at(help, inline_room, room);
+        let _ = writeln!(out, "  {usage}  {}", lines[0]);
+        for line in &lines[1..] {
+            if line.is_empty() {
+                out.push('\n');
+            } else {
+                let _ = writeln!(out, "{}{line}", " ".repeat(indent));
+            }
+        }
+        return indent;
     }
 
     // Text that already fits is text `wrap` would hand straight back, so skip it and the two
@@ -2479,7 +2530,11 @@ fn entry(
     let lines = wrap(help, room);
     let _ = writeln!(out, "  {usage:<col$}  {}", lines[0]);
     for line in &lines[1..] {
-        let _ = writeln!(out, "{}{line}", " ".repeat(indent));
+        if line.is_empty() {
+            out.push('\n');
+        } else {
+            let _ = writeln!(out, "{}{line}", " ".repeat(indent));
+        }
     }
     // No blank line after a wrapped entry. The reference's template asks for one, and its
     // whitespace trimming eats it before it reaches the output — so a wrapped entry is followed
@@ -2487,11 +2542,35 @@ fn entry(
     indent
 }
 
+fn wrap_at(text: &str, first_width: usize, continuation_width: usize) -> Vec<String> {
+    let mut lines = Vec::new();
+    for (index, line) in text.split('\n').enumerate() {
+        lines.extend(wrap(
+            line,
+            if index == 0 {
+                first_width
+            } else {
+                continuation_width
+            },
+        ));
+    }
+    lines
+}
+
 /// Wrap an overflowing entry's description across the width below its usage.
 fn write_wrapped_block(out: &mut String, help: &str, width: usize) {
-    let room = width.saturating_sub(BLOCK_INDENT);
+    write_wrapped_indented(out, help, width, BLOCK_INDENT);
+}
+
+fn write_wrapped_indented(out: &mut String, help: &str, width: usize, indent: usize) {
+    let room = width.saturating_sub(indent);
+    let pad = " ".repeat(indent);
     for line in wrap(help, room) {
-        let _ = writeln!(out, "{}{}", " ".repeat(BLOCK_INDENT), line);
+        if line.is_empty() {
+            out.push('\n');
+        } else {
+            let _ = writeln!(out, "{pad}{line}");
+        }
     }
 }
 
@@ -2538,12 +2617,22 @@ fn wrap(text: &str, width: usize) -> Vec<String> {
             lines.push(String::new());
             continue;
         }
+        if paragraph.starts_with("    ") || paragraph.starts_with('\t') {
+            lines.push(paragraph.to_string());
+            continue;
+        }
+        let paragraph = paragraph.trim();
+        let (prefix, body) = list_prefix(paragraph).unwrap_or(("", paragraph));
+        let body_width = width.saturating_sub(prefix.chars().count());
+        let mut line_prefix = prefix.to_string();
         let mut line = String::new();
         let mut line_width = 0;
-        for word in paragraph.split_whitespace() {
+        for word in body.split_whitespace() {
             let word_width = word.chars().count();
-            if !line.is_empty() && line_width + 1 + word_width > width {
-                lines.push(std::mem::take(&mut line));
+            if !line.is_empty() && line_width + 1 + word_width > body_width {
+                lines.push(format!("{line_prefix}{line}"));
+                line.clear();
+                line_prefix = " ".repeat(prefix.chars().count());
                 line_width = 0;
             }
             if !line.is_empty() {
@@ -2554,13 +2643,26 @@ fn wrap(text: &str, width: usize) -> Vec<String> {
             line_width += word_width;
         }
         if !line.is_empty() {
-            lines.push(line);
+            lines.push(format!("{line_prefix}{line}"));
         }
     }
     if lines.is_empty() {
         lines.push(String::new());
     }
     lines
+}
+
+fn list_prefix(line: &str) -> Option<(&str, &str)> {
+    for marker in ["* ", "- ", "+ "] {
+        if let Some(body) = line.strip_prefix(marker) {
+            return Some((marker, body));
+        }
+    }
+    let digits = line.bytes().take_while(u8::is_ascii_digit).count();
+    if digits > 0 && line.as_bytes().get(digits..digits + 2) == Some(b". ") {
+        return Some(line.split_at(digits + 2));
+    }
+    None
 }
 
 /// The annotations, each on its own line as the wider layout puts them.
@@ -2576,8 +2678,9 @@ fn long_annotations(
     env_fallback: &[&str],
     deprecated_env: &[&str],
     default: &[&str],
-    indent: usize,
+    layout: AnnotationLayout,
 ) {
+    let AnnotationLayout { indent, width } = layout;
     // Most entries annotate nothing, and this is called for every one of them — so the indent
     // is not built until there is a line to put it on.
     if choices.is_empty()
@@ -2588,26 +2691,63 @@ fn long_annotations(
     {
         return;
     }
-    let pad = " ".repeat(indent);
     if !choices.is_empty() {
-        let _ = writeln!(out, "{pad}[possible values: {}]", choices.join(", "));
+        write_wrapped_indented(
+            out,
+            &format!("[possible values: {}]", choices.join(", ")),
+            width,
+            indent,
+        );
     }
     if let Some(env) = env {
-        let _ = writeln!(out, "{pad}[env: {env}]");
+        write_wrapped_indented(out, &format!("[env: {env}]"), width, indent);
     }
-    environment_notes(out, env_fallback, deprecated_env, indent);
+    for env in env_fallback {
+        write_wrapped_indented(out, &format!("[env fallback: {env}]"), width, indent);
+    }
+    for env in deprecated_env {
+        write_wrapped_indented(out, &format!("[deprecated env: {env}]"), width, indent);
+    }
     if !default.is_empty() {
-        let _ = writeln!(out, "{pad}(default: {})", default.join(", "));
+        write_wrapped_indented(
+            out,
+            &format!("(default: {})", default.join(", ")),
+            width,
+            indent,
+        );
     }
 }
 
-fn admonitions(out: &mut String, blocks: &[AdmonitionMeta<'_>]) {
+#[derive(Clone, Copy)]
+struct AnnotationLayout {
+    indent: usize,
+    width: usize,
+}
+
+fn admonitions(out: &mut String, blocks: &[AdmonitionMeta<'_>], width: usize) {
     for block in blocks {
         let label = match block.kind {
             AdmonitionKind::Note => "Note",
             AdmonitionKind::Warning => "Warning",
         };
-        write_indented(out, &format!("{label}: {}", block.text), 4);
+        write_labelled(out, label, block.text, width, 4);
+    }
+}
+
+fn write_labelled(out: &mut String, label: &str, text: &str, width: usize, indent: usize) {
+    let prefix = format!("{label}: ");
+    let continuation = indent + prefix.chars().count();
+    let lines = wrap(text, width.saturating_sub(continuation));
+    let pad = " ".repeat(indent);
+    let continuation_pad = " ".repeat(continuation);
+    for (index, line) in lines.iter().enumerate() {
+        if index == 0 {
+            let _ = writeln!(out, "{pad}{prefix}{line}");
+        } else if line.is_empty() {
+            out.push('\n');
+        } else {
+            let _ = writeln!(out, "{continuation_pad}{line}");
+        }
     }
 }
 
@@ -2660,22 +2800,13 @@ fn inline_environment_notes(hide: bool, fallbacks: &[&str], deprecated: &[&str])
     (!notes.is_empty()).then(|| notes.join(" "))
 }
 
-fn environment_notes(out: &mut String, fallbacks: &[&str], deprecated: &[&str], indent: usize) {
-    for env in fallbacks {
-        let _ = writeln!(out, "{}[env fallback: {env}]", " ".repeat(indent));
-    }
-    for env in deprecated {
-        let _ = writeln!(out, "{}[deprecated env: {env}]", " ".repeat(indent));
-    }
-}
-
-fn flag_notes(out: &mut String, meta: &FlagMeta<'_>, indent: usize) {
+fn flag_notes(out: &mut String, meta: &FlagMeta<'_>, indent: usize, width: usize) {
     if let Some(label) = deprecation_label(
         meta.deprecated,
         meta.deprecated_warn_at,
         meta.deprecated_remove_at,
     ) {
-        let _ = writeln!(out, "{}{label}", " ".repeat(indent));
+        write_wrapped_indented(out, &label, width, indent);
     }
 }
 
@@ -2728,7 +2859,7 @@ fn flat_commands_long(out: &mut String, path: &[&str], meta: &CommandMeta<'_>, w
                 width,
                 meta.next_line_help,
             );
-            admonitions(out, arg.admonitions);
+            admonitions(out, arg.admonitions, width);
             long_annotations(
                 out,
                 if arg.hide_possible_values {
@@ -2748,7 +2879,10 @@ fn flat_commands_long(out: &mut String, path: &[&str], meta: &CommandMeta<'_>, w
                 } else {
                     arg.default
                 },
-                BLOCK_INDENT,
+                AnnotationLayout {
+                    indent: BLOCK_INDENT,
+                    width,
+                },
             );
         }
         for flag in flags {
@@ -2760,7 +2894,7 @@ fn flat_commands_long(out: &mut String, path: &[&str], meta: &CommandMeta<'_>, w
                 width,
                 meta.next_line_help,
             );
-            admonitions(out, flag.admonitions);
+            admonitions(out, flag.admonitions, width);
             long_annotations(
                 out,
                 if flag.hide_possible_values {
@@ -2784,9 +2918,12 @@ fn flat_commands_long(out: &mut String, path: &[&str], meta: &CommandMeta<'_>, w
                 } else {
                     flag.default
                 },
-                BLOCK_INDENT,
+                AnnotationLayout {
+                    indent: BLOCK_INDENT,
+                    width,
+                },
             );
-            flag_notes(out, flag, BLOCK_INDENT);
+            flag_notes(out, flag, BLOCK_INDENT, width);
         }
         if sub.flatten_help {
             flat_commands_long(out, &sub_path, sub, width);
@@ -3899,7 +4036,7 @@ mod style_tests {
         };
         let mut page = String::new();
 
-        flag_notes(&mut page, &meta, 4);
+        flag_notes(&mut page, &meta, 4, 80);
 
         assert!(page.is_empty());
 

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -2621,8 +2621,15 @@ fn wrap(text: &str, width: usize) -> Vec<String> {
             lines.push(paragraph.to_string());
             continue;
         }
-        let paragraph = paragraph.trim();
-        let (prefix, body) = list_prefix(paragraph).unwrap_or(("", paragraph));
+        let trimmed = paragraph.trim();
+        let leading_trimmed = paragraph.trim_start_matches(' ');
+        let (prefix, body) = match list_prefix(leading_trimmed) {
+            Some((marker, body)) => (
+                &paragraph[..paragraph.len() - leading_trimmed.len() + marker.len()],
+                body,
+            ),
+            None => ("", trimmed),
+        };
         let body_width = width.saturating_sub(prefix.chars().count());
         let mut line_prefix = prefix.to_string();
         let mut line = String::new();
@@ -3865,10 +3872,26 @@ mod style_tests {
     use super::{
         commands_section, display_usage_masked, flag_notes, flag_usage, flat_commands_short,
         inline_environment_notes, long_help, render_styled, render_view_at_styled,
-        styled_flag_usage, styled_help, styled_inline, Shown, Style,
+        styled_flag_usage, styled_help, styled_inline, wrap, Shown, Style,
     };
     use crate::spec::{ArgMeta, CommandMeta, FlagMeta, Spec, ViewMeta};
     use crate::{Arg, ArgAction, Command, Flag};
+
+    #[test]
+    fn nested_lists_keep_their_hanging_indent() {
+        assert_eq!(
+            wrap("  - a nested item with enough words to wrap", 24),
+            ["  - a nested item with", "    enough words to wrap"]
+        );
+        assert_eq!(
+            wrap("  1. a numbered item with enough words to wrap", 24),
+            [
+                "  1. a numbered item",
+                "     with enough words",
+                "     to wrap"
+            ]
+        );
+    }
 
     #[test]
     fn optional_equals_values_put_the_equals_inside_the_brackets() {

--- a/conformance/tests/admonitions.rs
+++ b/conformance/tests/admonitions.rs
@@ -142,7 +142,7 @@ fn semantic_blocks_survive_flattened_and_nested_value_layouts() {
 
     let portable_terminal = usage::docs::cli::render_help(&spec, &spec.cmd, true);
     assert!(
-        portable_terminal.contains("Note: Nested value first.\n\n    Nested value last."),
+        portable_terminal.contains("Note: Nested value first.\n\n          Nested value last."),
         "{portable_terminal:?}"
     );
     assert!(

--- a/conformance/tests/metadata.rs
+++ b/conformance/tests/metadata.rs
@@ -30,6 +30,79 @@ struct CappedColumns {
     threads: Option<usize>,
 }
 
+#[derive(Cli)]
+#[usage(
+    bin = "oxlint-layout",
+    term_width = 80,
+    about = "A fast JavaScript and TypeScript linter with a deliberately long introduction that must wrap cleanly"
+)]
+#[allow(dead_code)]
+struct OxcHelpLayout {
+    /// Do not fail when a supplied pattern matches no files
+    #[usage(long)]
+    no_error_on_unmatched_pattern: bool,
+    /// Disable the TypeScript language service plugin
+    #[usage(long)]
+    disable_typescript_plugin: bool,
+    /// Add a pattern to the ignore list while retaining every previously configured pattern
+    #[usage(long, value_name = "PATTERN")]
+    ignore_pattern: Vec<String>,
+    #[usage(
+        long,
+        value_name = "OPTIONS",
+        help = "Enable debug output for selected subsystems",
+        long_help = "Enable debug output for selected subsystems.\n\n- parser: trace parsed files and recovered syntax\n- resolver: trace module resolution and cache decisions"
+    )]
+    debug: Option<String>,
+    #[usage(
+        long,
+        value_name = "PATH",
+        help = "Use a configuration file",
+        long_help = "Use a configuration file. Configuration discovered from parent directories is merged first.\n\nWarning: explicit files replace project-local defaults.\n\n    oxlint-layout --config ./oxlint.json"
+    )]
+    config: Option<String>,
+}
+
+#[test]
+fn oxc_shaped_help_keeps_useful_prose_inline_and_wraps_the_rest() {
+    let spec = OxcHelpLayout::spec();
+    let portable: LibSpec = OxcHelpLayout::to_kdl().parse().expect("valid spec");
+
+    for long in [false, true] {
+        let page = usage_argv::help::render(spec, spec.root.cmd, long).unwrap();
+        assert_eq!(
+            page,
+            usage::docs::cli::render_help(&portable, &portable.cmd, long)
+        );
+        assert!(page.lines().any(|line| {
+            line.contains("--no-error-on-unmatched-pattern") && line.contains("Do not fail when")
+        }));
+        assert!(page.lines().any(|line| {
+            line.contains("--disable-typescript-plugin") && line.contains("Disable the TypeScript")
+        }));
+        assert!(page.lines().all(|line| !line.ends_with(' ')), "{page}");
+        for line in page.lines() {
+            if !line.trim_start().starts_with("oxlint-layout --config")
+                && !line.starts_with("Usage:")
+            {
+                assert!(
+                    line.chars().count() <= 80,
+                    "line exceeds width: {line:?}\n{page}"
+                );
+            }
+        }
+    }
+
+    let long = usage_argv::help::render(spec, spec.root.cmd, true).unwrap();
+    assert!(long.contains("\n\n"), "{long}");
+    assert!(long.contains("- parser:"), "{long}");
+    assert!(long.contains("- resolver:"), "{long}");
+    assert!(
+        long.contains("    oxlint-layout --config ./oxlint.json"),
+        "{long}"
+    );
+}
+
 #[derive(Args)]
 #[usage(disable_help_flag, term_width = 0)]
 #[allow(dead_code)]
@@ -145,17 +218,30 @@ fn flattened_help_caps_each_nested_commands_columns_too() {
             }),
             "{page}"
         );
-        assert!(
-            page.contains("--report-unused-disable-directives-severity <SEVERITY>\n    Choose the severity for unused directives while keeping every long\n    explanation inside the bounded parent help page"),
-            "{page}"
+        let lines = page.lines().collect::<Vec<_>>();
+        let severity = lines
+            .iter()
+            .position(|line| line.contains("--report-unused-disable-directives-severity"))
+            .expect("severity flag");
+        assert_eq!(
+            lines[severity + 1].trim(),
+            "Choose the severity for unused directives"
         );
-        assert!(
-            page.contains("--an-extraordinarily-long-multiline-option-name\n    Keep this line.\n    And this one."),
-            "{page}"
+        assert_eq!(
+            lines[severity + 2].trim(),
+            "while keeping every long explanation inside"
         );
+        let multiline = lines
+            .iter()
+            .position(|line| line.contains("--an-extraordinarily-long-multiline-option-name"))
+            .expect("multiline flag");
+        assert_eq!(lines[multiline + 1].trim(), "Keep this line.");
+        assert_eq!(lines[multiline + 2].trim(), "And this one.");
         if !long {
             assert!(
-                page.contains("[env: COLUMN_CAP_SEVERITY]") && page.contains("(default: warn)"),
+                page.contains("[env:")
+                    && page.contains("COLUMN_CAP_SEVERITY]")
+                    && page.contains("(default: warn)"),
                 "{page}"
             );
         }
@@ -169,7 +255,7 @@ fn flattened_help_caps_each_nested_commands_columns_too() {
 }
 
 #[test]
-fn a_long_command_name_only_moves_its_own_wrapped_summary_below() {
+fn a_long_command_name_keeps_help_inline_when_useful_room_remains() {
     let spec = CappedCommandColumns::spec();
     let portable: LibSpec = CappedCommandColumns::to_kdl().parse().expect("valid spec");
 
@@ -180,7 +266,7 @@ fn a_long_command_name_only_moves_its_own_wrapped_summary_below() {
             usage::docs::cli::render_help(&portable, &portable.cmd, long)
         );
         assert!(
-            page.contains("an-extraordinarily-long-subcommand-name\n    Explain this unusually named command with enough detail to wrap beneath its\n    name on a bounded help page"),
+            page.contains("an-extraordinarily-long-subcommand-name  Explain this unusually named command\n                                  with enough detail to wrap beneath\n                                  its name on a bounded help page"),
             "{page}"
         );
     }

--- a/go/argv/page.go
+++ b/go/argv/page.go
@@ -159,7 +159,7 @@ func ShortHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) s
 			if nextLineHelp {
 				w.WriteString("  " + usage + "\n")
 				if text := helpText(h); text != "" {
-					writeIndented(w, text, 4)
+					writeWrapped(w, text, 4)
 				}
 				longAnnotations(w, h, true, blockIndent)
 				return
@@ -192,7 +192,7 @@ func ShortHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) s
 			if nextLineHelp {
 				w.WriteString("  " + f.usage + "\n")
 				if text := f.suppliedHelp; text != "" {
-					writeIndented(w, text, 4)
+					writeWrapped(w, text, 4)
 				}
 				return
 			}
@@ -202,7 +202,7 @@ func ShortHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) s
 		if nextLineHelp {
 			w.WriteString("  " + f.usage + "\n")
 			if text := metaField(h, func(x *Help) string { return x.Short }); text != "" {
-				writeIndented(w, text, 4)
+				writeWrapped(w, text, 4)
 			}
 			longAnnotations(w, h, true, blockIndent)
 			return
@@ -387,10 +387,10 @@ func flatCommandsShort(out *strings.Builder, path []string, cmd *Command, help H
 		subPath := append(append([]string{}, path...), sub.Name)
 		out.WriteString("\n" + strings.Join(subPath, " ") + ":\n")
 		if text := metaField(h, func(x *Help) string { return x.Short }); strings.TrimSpace(text) != "" {
-			out.WriteString(trimEnd(text) + "\n")
+			writeWrapped(out, trimEnd(text), 0)
 		}
 		if label := deprecationLabel(h); label != "" {
-			out.WriteString(label + "\n")
+			writeWrapped(out, label, 0)
 		}
 
 		args := visibleArgs(sub, help, false)
@@ -478,7 +478,7 @@ func groupsSection(out, ungrouped, grouped *strings.Builder, defaultTitle string
 		section.WriteString("\n" + title + ":\n")
 		if heading != "" && proseOf != nil {
 			if prose := proseOf(heading); prose != "" {
-				writeIndented(&section, prose, 2)
+				writeWrapped(&section, prose, 2)
 				section.WriteString("\n")
 			}
 		}

--- a/go/argv/page.go
+++ b/go/argv/page.go
@@ -92,7 +92,8 @@ func ShortHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) s
 		before = meta.BeforeHelp
 	}
 	if before != "" {
-		out.WriteString(before + "\n\n")
+		writeWrapped(out, before, 0)
+		out.WriteString("\n")
 	}
 
 	// The program, then what it is for — on the program's own page. A
@@ -117,7 +118,8 @@ func ShortHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) s
 	// under a description belongs to the renderer, so one already in the text is a
 	// second one.
 	if about := trimEnd(about); about != "" {
-		out.WriteString(about + "\n\n")
+		writeWrapped(out, about, 0)
+		out.WriteString("\n")
 	}
 	if label := deprecationLabel(meta); label != "" {
 		out.WriteString(label + "\n\n")
@@ -234,7 +236,8 @@ func ShortHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) s
 		after = meta.AfterHelp
 	}
 	if after != "" {
-		sections.afterHelp.WriteString("\n" + after + "\n")
+		sections.afterHelp.WriteString("\n")
+		writeWrapped(&sections.afterHelp, after, 0)
 	}
 
 	return sections.assemble(spec.HelpTemplate)
@@ -324,7 +327,7 @@ func commandsSection(out *strings.Builder, path []string, cmd *Command, help Hel
 		if long && section != "" {
 			if proseOf := headingProse(help.Lookup(cmd.Key)); proseOf != nil {
 				if prose := proseOf(section); prose != "" {
-					writeIndented(out, prose, 2)
+					writeWrapped(out, prose, 2)
 					out.WriteString("\n")
 				}
 			}
@@ -414,7 +417,7 @@ func flatCommandsShort(out *strings.Builder, path []string, cmd *Command, help H
 			if nextLine {
 				out.WriteString("  " + usage + "\n")
 				if text := metaField(ah, func(x *Help) string { return x.Short }); text != "" {
-					writeIndented(out, text, 4)
+					writeWrapped(out, text, 4)
 				}
 				longAnnotations(out, ah, true, blockIndent)
 			} else {
@@ -427,7 +430,7 @@ func flatCommandsShort(out *strings.Builder, path []string, cmd *Command, help H
 			if nextLine {
 				out.WriteString("  " + usage + "\n")
 				if text := metaField(fh, func(x *Help) string { return x.Short }); text != "" {
-					writeIndented(out, text, 4)
+					writeWrapped(out, text, 4)
 				}
 				longAnnotations(out, fh, true, blockIndent)
 			} else {

--- a/go/argv/page.go
+++ b/go/argv/page.go
@@ -122,7 +122,8 @@ func ShortHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) s
 		out.WriteString("\n")
 	}
 	if label := deprecationLabel(meta); label != "" {
-		out.WriteString(label + "\n\n")
+		writeWrapped(out, label, 0)
+		out.WriteString("\n")
 	}
 
 	for i, line := range usageLines(path, cmd, help) {

--- a/go/argv/page_long.go
+++ b/go/argv/page_long.go
@@ -234,7 +234,7 @@ func flatCommandsLong(out *strings.Builder, path []string, cmd *Command, help He
 			writeWrapped(out, trimEnd(about), 0)
 		}
 		if label := deprecationLabel(h); label != "" {
-			out.WriteString(label + "\n")
+			writeWrapped(out, label, 0)
 		}
 
 		args := visibleArgs(sub, help, true)

--- a/go/argv/page_long.go
+++ b/go/argv/page_long.go
@@ -22,6 +22,7 @@ const helpWidth = 80
 
 // blockIndent is what a page uses where it cannot align to its column.
 const blockIndent = 4
+const minInlineHelpWidth = 30
 
 // LongHelp renders what `--help` prints for the command at the end of `chain`.
 func LongHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) string {
@@ -38,7 +39,8 @@ func LongHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) st
 		metaField(meta, func(h *Help) string { return h.BeforeHelp }),
 		spec.BeforeLongHelp, spec.BeforeHelp)
 	if before != "" {
-		out.WriteString(before + "\n\n")
+		writeWrapped(out, before, 0)
+		out.WriteString("\n")
 	}
 
 	// The banner and the program's own description belong to the program's page.
@@ -64,7 +66,8 @@ func LongHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) st
 	// an examples section written with a trailing newline — and it reaches the spec
 	// verbatim.
 	if about := trimEnd(about); about != "" {
-		out.WriteString(about + "\n\n")
+		writeWrapped(out, about, 0)
+		out.WriteString("\n")
 	}
 	if label := deprecationLabel(meta); label != "" {
 		out.WriteString(label + "\n\n")
@@ -166,7 +169,8 @@ func LongHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) st
 		metaField(meta, func(h *Help) string { return h.AfterHelp }),
 		spec.AfterLongHelp, spec.AfterHelp)
 	if after != "" {
-		out.WriteString("\n" + after + "\n")
+		out.WriteString("\n")
+		writeWrapped(out, after, 0)
 	}
 	if spec.Author != "" || spec.License != "" {
 		out.WriteByte('\n')
@@ -227,7 +231,7 @@ func flatCommandsLong(out *strings.Builder, path []string, cmd *Command, help He
 		out.WriteString("\n" + strings.Join(subPath, " ") + ":\n")
 		if about := firstOf(metaField(h, func(x *Help) string { return x.Long }),
 			metaField(h, func(x *Help) string { return x.Short })); strings.TrimSpace(about) != "" {
-			out.WriteString(trimEnd(about) + "\n")
+			writeWrapped(out, trimEnd(about), 0)
 		}
 		if label := deprecationLabel(h); label != "" {
 			out.WriteString(label + "\n")
@@ -283,42 +287,73 @@ func entry(out *strings.Builder, usage, help string, col int, nextLine bool) int
 	if room < 0 {
 		room = 0
 	}
-	// A long outlier leaves the shared column to the ordinary entries and uses a block alone.
+	// A long outlier leaves the shared column to ordinary entries, but keeps its own help on
+	// the row when at least a useful line of prose remains.
 	overflow := width(usage) > col
-	// Whether anything on this page reaches the column at all.
-	block := nextLine || overflow || room < 10
+	inlineStart := indent
+	if overflow {
+		inlineStart = 2 + width(usage) + 2
+	}
+	inlineRoom := helpWidth - inlineStart
+	canInline := !nextLine && ((overflow && inlineRoom >= minInlineHelpWidth) || (!overflow && room >= 10))
+	block := !canInline
+	stackIndent := blockIndent
+	if !nextLine && helpWidth-indent >= 10 {
+		stackIndent = indent
+	}
 	if strings.TrimSpace(help) == "" {
 		out.WriteString("  " + usage + "\n")
 		// An entry with nothing in the column still has annotations to place, and the
 		// column is where they go: it is this entry's row that is empty, not the table's.
 		if block {
-			return blockIndent
+			return stackIndent
 		}
 		return indent
 	}
 
-	if overflow && !nextLine && !strings.Contains(help, "\n") {
+	if block {
 		out.WriteString("  " + usage + "\n")
-		for _, line := range wrap(help, helpWidth-blockIndent) {
-			out.WriteString(strings.Repeat(" ", blockIndent) + line + "\n")
-		}
-		return blockIndent
+		writeWrapped(out, help, stackIndent)
+		return stackIndent
 	}
 
-	if block || strings.Contains(help, "\n") {
-		out.WriteString("  " + usage + "\n")
-		writeIndented(out, help, blockIndent)
-		return blockIndent
+	if overflow {
+		lines := wrapAt(help, inlineRoom, room)
+		out.WriteString("  " + usage + "  " + lines[0] + "\n")
+		for _, line := range lines[1:] {
+			if line == "" {
+				out.WriteByte('\n')
+			} else {
+				out.WriteString(strings.Repeat(" ", indent) + line + "\n")
+			}
+		}
+		return indent
 	}
 
 	lines := wrap(help, room)
 	out.WriteString("  " + pad(usage, col) + "  " + lines[0] + "\n")
 	for _, line := range lines[1:] {
-		out.WriteString(strings.Repeat(" ", indent) + line + "\n")
+		if line == "" {
+			out.WriteByte('\n')
+		} else {
+			out.WriteString(strings.Repeat(" ", indent) + line + "\n")
+		}
 	}
 	// No blank line after a wrapped entry: the reference's template asks for one
 	// and its whitespace trimming eats it before it reaches the output.
 	return indent
+}
+
+func wrapAt(text string, firstWidth, continuationWidth int) []string {
+	var lines []string
+	for index, line := range strings.Split(text, "\n") {
+		lineWidth := continuationWidth
+		if index == 0 {
+			lineWidth = firstWidth
+		}
+		lines = append(lines, wrap(line, lineWidth)...)
+	}
+	return lines
 }
 
 // usageColumnWidth prevents one long spelling from narrowing every description on the page.
@@ -339,26 +374,25 @@ func longAnnotations(out *strings.Builder, h *Help, withDefault bool, indent int
 	if h == nil {
 		return
 	}
-	pad := strings.Repeat(" ", indent)
 	if !h.HidePossibleValues && len(h.Choices) > 0 {
-		out.WriteString(pad + "[possible values: " + strings.Join(h.Choices, ", ") + "]\n")
+		writeWrapped(out, "[possible values: "+strings.Join(h.Choices, ", ")+"]", indent)
 	}
 	if !h.HideEnv && h.Env != "" {
-		out.WriteString(pad + "[env: " + h.Env + "]\n")
+		writeWrapped(out, "[env: "+h.Env+"]", indent)
 	}
 	if !h.HideEnv {
 		for _, env := range h.EnvFallback {
-			out.WriteString(pad + "[env fallback: " + env + "]\n")
+			writeWrapped(out, "[env fallback: "+env+"]", indent)
 		}
 		for _, env := range h.DeprecatedEnv {
-			out.WriteString(pad + "[deprecated env: " + env + "]\n")
+			writeWrapped(out, "[deprecated env: "+env+"]", indent)
 		}
 	}
 	if withDefault && !h.HideDefaultValue && len(h.Default) > 0 {
-		out.WriteString(pad + "(default: " + strings.Join(h.Default, ", ") + ")\n")
+		writeWrapped(out, "(default: "+strings.Join(h.Default, ", ")+")", indent)
 	}
 	if label := deprecationLabel(h); label != "" {
-		out.WriteString(pad + label + "\n")
+		writeWrapped(out, label, indent)
 	}
 }
 
@@ -398,6 +432,17 @@ func writeIndented(out *strings.Builder, text string, by int) {
 	}
 }
 
+func writeWrapped(out *strings.Builder, text string, by int) {
+	prefix := strings.Repeat(" ", by)
+	for _, line := range wrap(text, helpWidth-by) {
+		if line == "" {
+			out.WriteString("\n")
+		} else {
+			out.WriteString(prefix + line + "\n")
+		}
+	}
+}
+
 // wrap breaks text to a width, preserving the breaks the author already made.
 func wrap(text string, width int) []string {
 	var lines []string
@@ -406,11 +451,23 @@ func wrap(text string, width int) []string {
 			lines = append(lines, "")
 			continue
 		}
+		if strings.HasPrefix(paragraph, "    ") || strings.HasPrefix(paragraph, "\t") {
+			lines = append(lines, paragraph)
+			continue
+		}
+		paragraph = strings.TrimSpace(paragraph)
+		prefix, body := listPrefix(paragraph)
+		bodyWidth := width - runeLen(prefix)
+		if bodyWidth < 0 {
+			bodyWidth = 0
+		}
+		linePrefix := prefix
 		line := ""
-		for _, word := range strings.Fields(paragraph) {
-			if line != "" && runeLen(line)+1+runeLen(word) > width {
-				lines = append(lines, line)
+		for _, word := range strings.Fields(body) {
+			if line != "" && runeLen(line)+1+runeLen(word) > bodyWidth {
+				lines = append(lines, linePrefix+line)
 				line = ""
+				linePrefix = strings.Repeat(" ", runeLen(prefix))
 			}
 			if line != "" {
 				line += " "
@@ -418,13 +475,30 @@ func wrap(text string, width int) []string {
 			line += word
 		}
 		if line != "" {
-			lines = append(lines, line)
+			lines = append(lines, linePrefix+line)
 		}
 	}
 	if len(lines) == 0 {
 		lines = append(lines, "")
 	}
 	return lines
+}
+
+func listPrefix(line string) (string, string) {
+	for _, marker := range []string{"* ", "- ", "+ "} {
+		if strings.HasPrefix(line, marker) {
+			return marker, strings.TrimPrefix(line, marker)
+		}
+	}
+	for i, r := range line {
+		if r < '0' || r > '9' {
+			if i > 0 && strings.HasPrefix(line[i:], ". ") {
+				return line[:i+2], line[i+2:]
+			}
+			break
+		}
+	}
+	return "", line
 }
 
 func runeLen(s string) int { return len([]rune(s)) }

--- a/go/argv/page_long.go
+++ b/go/argv/page_long.go
@@ -70,7 +70,8 @@ func LongHelp(spec HelpSpec, path []string, chain []*Command, help HelpTable) st
 		out.WriteString("\n")
 	}
 	if label := deprecationLabel(meta); label != "" {
-		out.WriteString(label + "\n\n")
+		writeWrapped(out, label, 0)
+		out.WriteString("\n")
 	}
 
 	for i, line := range usageLines(path, cmd, help) {
@@ -396,10 +397,6 @@ func longAnnotations(out *strings.Builder, h *Help, withDefault bool, indent int
 	}
 }
 
-// writeIndented writes text with every line indented, leaving blank lines blank —
-// an indented empty line is trailing whitespace, which the reference does not
-// emit. Indenting them instead differs on every page, which is how this was
-// settled rather than by reading the template.
 // headingProse is the prose a command declares for one of its section titles.
 // Nil where it declares none, so a caller pays nothing for the common case.
 func headingProse(meta *Help) func(string) string {
@@ -413,22 +410,6 @@ func headingProse(meta *Help) func(string) string {
 			}
 		}
 		return ""
-	}
-}
-
-func writeIndented(out *strings.Builder, text string, by int) {
-	prefix := strings.Repeat(" ", by)
-	for i, line := range strings.Split(text, "\n") {
-		// The first line carries the indent whatever it holds, and later blank
-		// lines do not. mise has a command whose description *begins* with an
-		// empty line, and the reference prints four spaces there and nothing on
-		// the blank lines below it — a template indenting where it starts writing
-		// rather than trimming each line.
-		if line == "" && i > 0 {
-			out.WriteString("\n")
-			continue
-		}
-		out.WriteString(prefix + line + "\n")
 	}
 }
 
@@ -455,8 +436,13 @@ func wrap(text string, width int) []string {
 			lines = append(lines, paragraph)
 			continue
 		}
-		paragraph = strings.TrimSpace(paragraph)
-		prefix, body := listPrefix(paragraph)
+		trimmed := strings.TrimSpace(paragraph)
+		prefix, body := listPrefix(strings.TrimLeft(paragraph, " "))
+		if prefix != "" {
+			prefix = paragraph[:len(paragraph)-len(strings.TrimLeft(paragraph, " "))] + prefix
+		} else {
+			body = trimmed
+		}
 		bodyWidth := width - runeLen(prefix)
 		if bodyWidth < 0 {
 			bodyWidth = 0

--- a/go/argv/page_test.go
+++ b/go/argv/page_test.go
@@ -371,7 +371,15 @@ func TestALongFlagOnlyMovesItsOwnHelpBelow(t *testing.T) {
 		if !strings.Contains(page, "      --short                     ordinary help") {
 			t.Fatalf("the ordinary row did not retain a readable description column:\n%s", page)
 		}
-		if !strings.Contains(page, "      --this-flag-name-is-far-beyond-the-column-cap\n    alpha beta") {
+		lines := strings.Split(page, "\n")
+		var stacked bool
+		for i, line := range lines[:len(lines)-1] {
+			if strings.HasPrefix(strings.TrimSpace(line), "--this-flag-name-is-far-beyond-the-column-cap") {
+				stacked = strings.TrimSpace(lines[i+1]) == "alpha beta"
+				break
+			}
+		}
+		if !stacked {
 			t.Fatalf("the overflowing row did not move its help below:\n%s", page)
 		}
 	}

--- a/go/argv/page_test.go
+++ b/go/argv/page_test.go
@@ -5,6 +5,20 @@ import (
 	"testing"
 )
 
+func TestNestedListsKeepTheirHangingIndent(t *testing.T) {
+	got := wrap("  - a nested item with enough words to wrap", 24)
+	want := []string{"  - a nested item with", "    enough words to wrap"}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("nested bullet lost its indentation: got %q, want %q", got, want)
+	}
+
+	got = wrap("  1. a numbered item with enough words to wrap", 24)
+	want = []string{"  1. a numbered item", "     with enough words", "     to wrap"}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("nested numbered item lost its indentation: got %q, want %q", got, want)
+	}
+}
+
 // Examples declared once at the root appear on a page that declares none.
 //
 // The same fallback `BeforeHelp` and `AfterHelp` get. mise declares no root

--- a/lib/src/docs/cli/mod.rs
+++ b/lib/src/docs/cli/mod.rs
@@ -51,6 +51,7 @@ pub fn render_help(spec: &Spec, cmd: &SpecCommand, long: bool) -> String {
                     crate::docs::models::Group {
                         heading: None,
                         help: None,
+                        help_rendered: None,
                         items: supplied,
                     },
                 ),
@@ -59,6 +60,10 @@ pub fn render_help(spec: &Spec, cmd: &SpecCommand, long: bool) -> String {
     }
 
     let width = crate::docs::layout::help_width(cmd.term_width, cmd.max_term_width);
+    ctx.insert("terminal_width", &width);
+    lay_out_group_help(&mut docs_cmd.subcommand_groups, width);
+    lay_out_group_help(&mut docs_cmd.arg_groups, width);
+    lay_out_group_help(&mut docs_cmd.flag_groups, width);
     let col = crate::docs::layout::usage_column_width(
         docs_cmd
             .flag_groups
@@ -120,7 +125,7 @@ pub fn render_help(spec: &Spec, cmd: &SpecCommand, long: bool) -> String {
             width,
         );
         for group in &mut docs_cmd.subcommand_groups {
-            lay_out_commands(&mut group.items, width, cmd_col);
+            lay_out_commands(&mut group.items, width, cmd_col, cmd.next_line_help);
         }
         // Rendered here rather than in the template because it is a row like any other: it
         // sits in the same column and wraps by the same rule, and neither is something a
@@ -394,12 +399,14 @@ fn lay_out(flags: &mut [crate::docs::models::SpecFlag], column: Column) {
     for flag in flags {
         flag.usage_col_width = column.col;
         flag.help_is_block =
-            column.is_block(crate::docs::layout::visible_width(&flag.display_usage));
+            !column.can_inline(crate::docs::layout::visible_width(&flag.display_usage));
         let text = if column.long {
             flag.help_long
                 .as_deref()
                 .or(flag.help.as_deref())
                 .map(str::to_string)
+        } else if column.next_line {
+            flag.help.clone()
         } else {
             with_annotations(flag.help.as_deref(), flag_annotations(flag))
         };
@@ -423,12 +430,14 @@ fn lay_out(flags: &mut [crate::docs::models::SpecFlag], column: Column) {
 fn lay_out_args(args: &mut [crate::docs::models::SpecArg], column: Column) {
     for arg in args {
         arg.usage_col_width = column.col;
-        arg.help_is_block = column.is_block(crate::docs::layout::visible_width(&arg.usage));
+        arg.help_is_block = !column.can_inline(crate::docs::layout::visible_width(&arg.usage));
         let text = if column.long {
             arg.help_long
                 .as_deref()
                 .or(arg.help.as_deref())
                 .map(str::to_string)
+        } else if column.next_line {
+            arg.help.clone()
         } else {
             with_annotations(arg.help.as_deref(), arg_annotations(arg))
         };
@@ -446,6 +455,8 @@ fn lay_out_args(args: &mut [crate::docs::models::SpecArg], column: Column) {
 
 fn lay_out_flattened(commands: &mut [crate::docs::models::SpecCommand], width: usize, long: bool) {
     for command in commands {
+        lay_out_group_help(&mut command.arg_groups, width);
+        lay_out_group_help(&mut command.flag_groups, width);
         let arg_col = crate::docs::layout::usage_column_width(
             command
                 .arg_groups
@@ -484,6 +495,15 @@ fn lay_out_flattened(commands: &mut [crate::docs::models::SpecCommand], width: u
     }
 }
 
+fn lay_out_group_help<T>(groups: &mut [crate::docs::models::Group<T>], width: usize) {
+    for group in groups {
+        group.help_rendered = group
+            .help
+            .as_deref()
+            .map(|help| crate::docs::layout::render_indented_text(help, width, 2));
+    }
+}
+
 /// Fit one entry's text to the column, and say which layout it wants.
 ///
 /// `row` is the text as composed and `help_rendered` the same text wrapped; an empty wrapping
@@ -503,20 +523,24 @@ fn wrap_into(
     *help_is_multiline = false;
     // An entry with nothing in the column still has annotations to place, and the column is
     // where they go: it is the entry's own row that is empty, not the table's.
-    *ann_indent = column.annotation_indent(!column.is_block(usage_width));
+    *ann_indent = column.annotation_indent(column.can_inline(usage_width));
     let Some(text) = text else { return };
-    if column.is_block(usage_width) {
-        *row = Some(
-            if column.usage_overflows(usage_width) && !text.contains('\n') {
-                crate::docs::layout::render_block_text(&text, column.width)
-            } else {
-                text
-            },
-        );
+    if !column.can_inline(usage_width) {
+        let indent = column.block_indent();
+        *row = Some(indent_text(
+            &crate::docs::layout::render_indented_text(&text, column.width, indent),
+            indent,
+        ));
         return;
     }
-    let (rendered, is_multiline) =
-        crate::docs::layout::render_help_text(&text, column.width, column.col);
+    let first_indent = column.inline_help_start(usage_width);
+    let continuation_indent = column.description_indent();
+    let (rendered, is_multiline) = crate::docs::layout::render_help_text_at(
+        &text,
+        column.width,
+        first_indent,
+        continuation_indent,
+    );
     // `render_help_text` wraps whatever it is given; whether the page *uses* that is the
     // template's decision, and on a next-line page it does not. Both have to agree, or the
     // annotations align to a column the description never entered.
@@ -526,6 +550,20 @@ fn wrap_into(
         *help_is_multiline = is_multiline;
     }
     *row = Some(text);
+}
+
+fn indent_text(text: &str, indent: usize) -> String {
+    let pad = " ".repeat(indent);
+    text.lines()
+        .map(|line| {
+            if line.is_empty() {
+                String::new()
+            } else {
+                format!("{pad}{line}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// A short entry's description with its annotations joined on.
@@ -642,12 +680,31 @@ impl Column {
         !self.next_line && usage_width > self.col
     }
 
-    /// Whether this entry stays out of the column: because the page puts every description
-    /// underneath, its usage exceeds the capped column, or too little room remains for help.
-    fn is_block(&self, usage_width: usize) -> bool {
-        self.next_line
-            || self.usage_overflows(usage_width)
-            || self.width.saturating_sub(2 + self.col + 2) < 10
+    fn description_indent(&self) -> usize {
+        2 + self.col + 2
+    }
+
+    fn inline_help_start(&self, usage_width: usize) -> usize {
+        if self.usage_overflows(usage_width) {
+            2 + usage_width + 2
+        } else {
+            self.description_indent()
+        }
+    }
+
+    /// Keep an outlier inline only when its spelling leaves a useful amount of prose.
+    fn can_inline(&self, usage_width: usize) -> bool {
+        if self.next_line {
+            return false;
+        }
+        let minimum = if self.usage_overflows(usage_width) {
+            crate::docs::layout::MIN_INLINE_HELP_WIDTH
+        } else {
+            10
+        };
+        self.width
+            .saturating_sub(self.inline_help_start(usage_width))
+            >= minimum
     }
 
     /// Where an entry's annotations are indented to.
@@ -658,11 +715,22 @@ impl Column {
     /// column to align to and the annotations join it there.
     fn annotation_indent(&self, reached_column: bool) -> String {
         let indent = if reached_column {
-            2 + self.col + 2
+            self.description_indent()
         } else {
-            BLOCK_INDENT
+            self.block_indent()
         };
         " ".repeat(indent)
+    }
+
+    /// Prefer the normal description column for a stacked entry whenever it still leaves a
+    /// useful line. Exceptionally narrow pages retain the compact four-space fallback.
+    fn block_indent(&self) -> usize {
+        let description = self.description_indent();
+        if !self.next_line && self.width.saturating_sub(description) >= 10 {
+            description
+        } else {
+            BLOCK_INDENT
+        }
     }
 }
 
@@ -678,24 +746,38 @@ fn lay_out_commands(
     commands: &mut [crate::docs::models::HelpCommand],
     terminal_width: usize,
     col: usize,
+    next_line: bool,
 ) {
+    let column = Column {
+        width: terminal_width,
+        col,
+        long: false,
+        next_line,
+    };
     for command in commands {
         command.usage_col_width = col;
         command.row = command_row(command);
         command.help_rendered = None;
         command.help_is_multiline = false;
-        if crate::docs::layout::visible_width(&command.name) > col {
-            if let Some(row) = command.row.as_mut().filter(|row| !row.contains('\n')) {
-                *row = crate::docs::layout::render_block_text(row, terminal_width);
-            }
-            continue;
-        }
+        let usage_width = crate::docs::layout::visible_width(&command.name);
         if let Some(row) = command.row.as_deref() {
-            let (rendered, is_multiline) =
-                crate::docs::layout::render_help_text(row, terminal_width, col);
-            if !rendered.is_empty() {
-                command.help_rendered = Some(rendered);
-                command.help_is_multiline = is_multiline;
+            if column.can_inline(usage_width) {
+                let (rendered, is_multiline) = crate::docs::layout::render_help_text_at(
+                    row,
+                    terminal_width,
+                    column.inline_help_start(usage_width),
+                    column.description_indent(),
+                );
+                if !rendered.is_empty() {
+                    command.help_rendered = Some(rendered);
+                    command.help_is_multiline = is_multiline;
+                }
+            } else if let Some(row) = command.row.as_mut() {
+                let indent = column.block_indent();
+                *row = indent_text(
+                    &crate::docs::layout::render_indented_text(row, terminal_width, indent),
+                    indent,
+                );
             }
         }
     }
@@ -977,6 +1059,78 @@ static TERA: LazyLock<Tera> = LazyLock::new(|| {
             } else {
                 Ok(value.clone())
             }
+        },
+    );
+    tera.register_filter(
+        "terminal_wrap",
+        |value: &tera::Value, args: tera::Kwargs, _: &tera::State| -> tera::TeraResult<String> {
+            let value = value.as_str().unwrap_or("");
+            let width = args.get::<u64>("width")?.unwrap_or(80) as usize;
+            let indent = args.get::<u64>("indent")?.unwrap_or(0) as usize;
+            Ok(crate::docs::layout::render_indented_text(
+                value, width, indent,
+            ))
+        },
+    );
+    tera.register_filter(
+        "terminal_label",
+        |value: &tera::Value, args: tera::Kwargs, _: &tera::State| -> tera::TeraResult<String> {
+            let value = value.as_str().unwrap_or("");
+            let label = args.must_get::<String>("label")?;
+            let width = args.get::<u64>("width")?.unwrap_or(80) as usize;
+            let indent = args.get::<u64>("indent")?.unwrap_or(0) as usize;
+            Ok(crate::docs::layout::render_labelled_text(
+                &label, value, width, indent,
+            ))
+        },
+    );
+    tera.register_filter(
+        "terminal_annotation",
+        |value: &tera::Value, args: tera::Kwargs, _: &tera::State| -> tera::TeraResult<String> {
+            let body = if let Some(values) = value.as_array() {
+                values
+                    .iter()
+                    .filter_map(tera::Value::as_str)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            } else {
+                value.as_str().unwrap_or("").to_string()
+            };
+            let label = args.get::<String>("label")?.unwrap_or_default();
+            let suffix = args.get::<String>("suffix")?.unwrap_or_default();
+            let indent = args
+                .get::<String>("indent")?
+                .unwrap_or_default()
+                .chars()
+                .count();
+            let width = args.get::<u64>("width")?.unwrap_or(80) as usize;
+            let rendered = crate::docs::layout::render_indented_text(
+                &format!("{label}{body}{suffix}"),
+                width,
+                indent,
+            );
+            Ok(indent_text(&rendered, indent))
+        },
+    );
+    tera.register_filter(
+        "terminal_deprecation",
+        |value: &tera::Value, args: tera::Kwargs, _: &tera::State| -> tera::TeraResult<String> {
+            let field = |name| value.get_from_path(name).and_then(tera::Value::as_str);
+            let Some(label) = deprecation_label(
+                field("deprecated"),
+                field("deprecated_warn_at"),
+                field("deprecated_remove_at"),
+            ) else {
+                return Ok(String::new());
+            };
+            let indent = args
+                .get::<String>("indent")?
+                .unwrap_or_default()
+                .chars()
+                .count();
+            let width = args.get::<u64>("width")?.unwrap_or(80) as usize;
+            let rendered = crate::docs::layout::render_indented_text(&label, width, indent);
+            Ok(indent_text(&rendered, indent))
         },
     );
 

--- a/lib/src/docs/cli/templates/spec_template_long.tera
+++ b/lib/src/docs/cli/templates/spec_template_long.tera
@@ -242,7 +242,7 @@ Global flags:
 {{ sub.full_cmd | join(sep=" ") }}:
 {%- set about = sub.help_long | default(value=sub.help | default(value='')) %}
 {%- if about %}
-{{ about | trim }}
+{{ about | trim | terminal_wrap(width=terminal_width) }}
 {%- endif %}
 {%- if sub.deprecated or sub.deprecated_warn_at or sub.deprecated_remove_at %}
 {{ sub | terminal_deprecation(width=terminal_width) }}
@@ -268,18 +268,21 @@ Global flags:
 {%- endfor %}
 {%- endif %}
 {%- if not arg.hide_possible_values and arg.choices and arg.choices.choices %}
-    [possible values: {{ arg.choices.choices | join(sep=", ") }}]
+{{ arg.choices.choices | terminal_annotation(label="[possible values: ", suffix="]", indent="    ", width=terminal_width) }}
+{%- endif %}
+{%- if not arg.hide_possible_values and arg.choices and arg.choices.env %}
+{{ arg.choices.env | terminal_annotation(label="[choices env: ", suffix="]", indent="    ", width=terminal_width) }}
 {%- endif %}
 {%- if not arg.hide_env and arg.env %}
-    [env: {{ arg.env }}]
+{{ arg.env | terminal_annotation(label="[env: ", suffix="]", indent="    ", width=terminal_width) }}
 {%- endif %}
 {%- if not arg.hide_env %}{% for env in arg.env_fallback %}
-    [env fallback: {{ env }}]
+{{ env | terminal_annotation(label="[env fallback: ", suffix="]", indent="    ", width=terminal_width) }}
 {%- endfor %}{% for env in arg.deprecated_env %}
-    [deprecated env: {{ env }}]
+{{ env | terminal_annotation(label="[deprecated env: ", suffix="]", indent="    ", width=terminal_width) }}
 {%- endfor %}{%- endif %}
 {%- if not arg.hide_default_value and arg.default %}
-    (default: {{ arg.default | join(sep=", ") }})
+{{ arg.default | terminal_annotation(label="(default: ", suffix=")", indent="    ", width=terminal_width) }}
 {%- endif %}
 {%- endfor %}
 {%- endfor %}
@@ -309,18 +312,21 @@ Global flags:
 {%- endfor %}
 {%- endif %}
 {%- if not flag.hide_possible_values and flag.arg.choices and flag.arg.choices.choices %}
-    [possible values: {{ flag.arg.choices.choices | join(sep=", ") }}]
+{{ flag.arg.choices.choices | terminal_annotation(label="[possible values: ", suffix="]", indent="    ", width=terminal_width) }}
+{%- endif %}
+{%- if not flag.hide_possible_values and flag.arg.choices and flag.arg.choices.env %}
+{{ flag.arg.choices.env | terminal_annotation(label="[choices env: ", suffix="]", indent="    ", width=terminal_width) }}
 {%- endif %}
 {%- if not flag.hide_env and flag.env %}
-    [env: {{ flag.env }}]
+{{ flag.env | terminal_annotation(label="[env: ", suffix="]", indent="    ", width=terminal_width) }}
 {%- endif %}
 {%- if not flag.hide_env %}{% for env in flag.env_fallback %}
-    [env fallback: {{ env }}]
+{{ env | terminal_annotation(label="[env fallback: ", suffix="]", indent="    ", width=terminal_width) }}
 {%- endfor %}{% for env in flag.deprecated_env %}
-    [deprecated env: {{ env }}]
+{{ env | terminal_annotation(label="[deprecated env: ", suffix="]", indent="    ", width=terminal_width) }}
 {%- endfor %}{%- endif %}
 {%- if not flag.hide_default_value and flag.default %}
-    (default: {{ flag.default | join(sep=", ") }})
+{{ flag.default | terminal_annotation(label="(default: ", suffix=")", indent="    ", width=terminal_width) }}
 {%- endif %}
 {%- if flag.deprecated or flag.deprecated_warn_at or flag.deprecated_remove_at %}
 {{ flag | terminal_deprecation(indent="    ", width=terminal_width) }}

--- a/lib/src/docs/cli/templates/spec_template_long.tera
+++ b/lib/src/docs/cli/templates/spec_template_long.tera
@@ -242,7 +242,7 @@ Global flags:
 {{ sub.full_cmd | join(sep=" ") }}:
 {%- set about = sub.help_long | default(value=sub.help | default(value='')) %}
 {%- if about %}
-{{ about | trim | terminal_wrap(width=terminal_width) }}
+{{ about | terminal_wrap(width=terminal_width) }}
 {%- endif %}
 {%- if sub.deprecated or sub.deprecated_warn_at or sub.deprecated_remove_at %}
 {{ sub | terminal_deprecation(width=terminal_width) }}

--- a/lib/src/docs/cli/templates/spec_template_long.tera
+++ b/lib/src/docs/cli/templates/spec_template_long.tera
@@ -1,30 +1,30 @@
-{%- if cmd.before_help_long %}{{ cmd.before_help_long }}
+{%- if cmd.before_help_long %}{{ cmd.before_help_long | terminal_wrap(width=terminal_width) }}
 
-{% elif cmd.before_help %}{{ cmd.before_help }}
+{% elif cmd.before_help %}{{ cmd.before_help | terminal_wrap(width=terminal_width) }}
 
-{% elif spec.before_help_long %}{{ spec.before_help_long }}
+{% elif spec.before_help_long %}{{ spec.before_help_long | terminal_wrap(width=terminal_width) }}
 
-{% elif spec.before_help %}{{ spec.before_help }}
+{% elif spec.before_help %}{{ spec.before_help | terminal_wrap(width=terminal_width) }}
 
 {% endif -%}
 {%- if root %}
 {%- if spec.name and spec.version %}{{ spec.name }} {{ spec.version }}
 {% elif spec.version %}{{ spec.bin }} {{ spec.version }}
 {% endif -%}
-{%- if spec.about_long %}{{ spec.about_long }}
+{%- if spec.about_long %}{{ spec.about_long | terminal_wrap(width=terminal_width) }}
 
-{% elif spec.about %}{{ spec.about }}
+{% elif spec.about %}{{ spec.about | terminal_wrap(width=terminal_width) }}
 
 {% endif -%}
 {%- else -%}
-{%- if cmd.help_long %}{{ cmd.help_long }}
+{%- if cmd.help_long %}{{ cmd.help_long | terminal_wrap(width=terminal_width) }}
 
-{% elif cmd.help %}{{ cmd.help }}
+{% elif cmd.help %}{{ cmd.help | terminal_wrap(width=terminal_width) }}
 
 {% endif -%}
 {%- endif -%}
 {%- if cmd.deprecated or cmd.deprecated_warn_at or cmd.deprecated_remove_at %}
-[deprecated:{% if cmd.deprecated %} {{ cmd.deprecated }}{% endif %}{% if cmd.deprecated_warn_at %}{% if cmd.deprecated %};{% endif %} warns at {{ cmd.deprecated_warn_at }}{% endif %}{% if cmd.deprecated_remove_at %}{% if cmd.deprecated or cmd.deprecated_warn_at %};{% endif %} removed at {{ cmd.deprecated_remove_at }}{% endif %}]
+{{ cmd | terminal_deprecation(width=terminal_width) }}
 
 {%- endif -%}{{ mark_usage }}
 {%- if cmd.flatten_help and cmd.flattened_usage %}
@@ -40,15 +40,15 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
 {%- for group in cmd.subcommand_groups %}
 
 {{ group.heading | default(value=cmd.subcommand_help_heading | default(value="Commands")) }}:
-{%- if group.help %}
-  {{ group.help | indent(width=2) }}
+{%- if group.help_rendered %}
+  {{ group.help_rendered | indent(width=2) }}
 {% endif %}
 {%- for cmd in group.items %}
 {%- if cmd.help_rendered and not next_line_help %}
   {{ cmd.name | ljust(width=cmd.usage_col_width) }}  {{ cmd.help_rendered }}
 {%- elif cmd.row %}
   {{ cmd.name }}
-    {{ cmd.row | indent(width=4) }}
+{{ cmd.row }}
 {%- else %}
   {{ cmd.name }}
 {%- endif %}
@@ -63,15 +63,14 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
 {%- if group.heading and arg_has_ungrouped and loop.index0 == 1 %}{{ mark_grouped_args }}{% endif %}
 
 {{ group.heading | default(value="Arguments") }}:
-{%- if group.help %}
-  {{ group.help | indent(width=2) }}
+{%- if group.help_rendered %}
+  {{ group.help_rendered | indent(width=2) }}
 {% endif %}
 {%- for arg in group.items %}
 {%- if cmd.next_line_help %}
   {{ arg.usage | trim }}
-{%- set help = arg.help_long | default(value=arg.help | default(value='')) %}
-{%- if help %}
-    {{ help | indent(width=4) }}
+{%- if arg.row %}
+{{ arg.row }}
 {%- endif %}
 {%- elif arg.help_rendered %}
   {{ arg.usage | ljust(width=arg.usage_col_width) }}  {{ arg.help_rendered }}
@@ -80,35 +79,35 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
 {%- endif %}
 {%- elif arg.row %}
   {{ arg.usage | trim }}
-    {{ arg.row | indent(width=4) }}
+{{ arg.row }}
 {%- else %}
   {{ arg.usage | trim }}
 {%- set help = arg.help_long | default(value=arg.help | default(value='')) %}
 {%- if help %}
-    {{ help | indent(width=4) }}
+{{ help | terminal_annotation(indent="    ", width=terminal_width) }}
 {%- endif %}
 {%- endif %}
 {%- if arg.admonitions %}
 {%- for admonition in arg.admonitions %}
-    {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | indent(width=4) }}
+    {% if admonition.kind == "warning" %}{{ admonition.text | terminal_label(label="Warning", width=terminal_width, indent=4) | indent(width=4) }}{% else %}{{ admonition.text | terminal_label(label="Note", width=terminal_width, indent=4) | indent(width=4) }}{% endif %}
 {%- endfor %}
 {%- endif %}
 {%- if not arg.hide_possible_values and arg.choices and arg.choices.choices %}
-{{ arg.ann_indent }}[possible values: {{ arg.choices.choices | join(sep=", ") }}]
+{{ arg.choices.choices | terminal_annotation(label="[possible values: ", suffix="]", indent=arg.ann_indent, width=terminal_width) }}
 {%- endif %}
 {%- if not arg.hide_possible_values and arg.choices and arg.choices.env %}
-{{ arg.ann_indent }}[choices env: {{ arg.choices.env }}]
+{{ arg.choices.env | terminal_annotation(label="[choices env: ", suffix="]", indent=arg.ann_indent, width=terminal_width) }}
 {%- endif %}
 {%- if not arg.hide_env and arg.env %}
-{{ arg.ann_indent }}[env: {{ arg.env }}]
+{{ arg.env | terminal_annotation(label="[env: ", suffix="]", indent=arg.ann_indent, width=terminal_width) }}
 {%- endif %}
 {%- if not arg.hide_env %}{% for env in arg.env_fallback %}
-{{ arg.ann_indent }}[env fallback: {{ env }}]
+{{ env | terminal_annotation(label="[env fallback: ", suffix="]", indent=arg.ann_indent, width=terminal_width) }}
 {%- endfor %}{% for env in arg.deprecated_env %}
-{{ arg.ann_indent }}[deprecated env: {{ env }}]
+{{ env | terminal_annotation(label="[deprecated env: ", suffix="]", indent=arg.ann_indent, width=terminal_width) }}
 {%- endfor %}{%- endif %}
 {%- if not arg.hide_default_value and arg.default %}
-{{ arg.ann_indent }}(default: {{ arg.default | join(sep=", ") }})
+{{ arg.default | terminal_annotation(label="(default: ", suffix=")", indent=arg.ann_indent, width=terminal_width) }}
 {%- endif %}
 {%- endfor %}
 {%- endfor %}{% if arg_has_ungrouped and not arg_has_grouped %}{{ mark_grouped_args }}{% endif %}{{ mark_flags }}{% if not flag_has_ungrouped %}{{ mark_grouped_flags }}{% endif %}
@@ -117,16 +116,15 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
 {%- if group.heading and flag_has_ungrouped and loop.index0 == 1 %}{{ mark_grouped_flags }}{% endif %}
 
 {{ group.heading | default(value="Flags") }}:
-{%- if group.help %}
-  {{ group.help | indent(width=2) }}
+{%- if group.help_rendered %}
+  {{ group.help_rendered | indent(width=2) }}
 {% endif %}
 {%- for flag in group.items %}
 {%- if cmd.next_line_help %}
   {{ flag.display_usage }}
 {%- if flag.aliases %}  [aliases: {{ flag.aliases | join(sep=", ") }}]{% endif %}
-{%- set help = flag.help_long | default(value=flag.help | default(value='')) %}
-{%- if help %}
-    {{ help | indent(width=4) }}
+{%- if flag.row %}
+{{ flag.row }}
 {%- endif %}
 {%- elif flag.help_rendered %}
   {{ flag.display_usage | ljust(width=flag.usage_col_width) }}  {{ flag.help_rendered }}
@@ -136,44 +134,44 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
 {%- elif flag.row %}
   {{ flag.display_usage }}
 {%- if flag.aliases %}  [aliases: {{ flag.aliases | join(sep=", ") }}]{% endif %}
-    {{ flag.row | indent(width=4) }}
+{{ flag.row }}
 {%- else %}
   {{ flag.display_usage }}
 {%- if flag.aliases %}  [aliases: {{ flag.aliases | join(sep=", ") }}]{% endif %}
 {%- set help = flag.help_long | default(value=flag.help | default(value='')) %}
 {%- if help %}
-    {{ help | indent(width=4) }}
+{{ help | terminal_annotation(indent="    ", width=terminal_width) }}
 {%- endif %}
 {%- endif %}
 {%- if flag.admonitions %}
 {%- for admonition in flag.admonitions %}
-    {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | indent(width=4) }}
+    {% if admonition.kind == "warning" %}{{ admonition.text | terminal_label(label="Warning", width=terminal_width, indent=4) | indent(width=4) }}{% else %}{{ admonition.text | terminal_label(label="Note", width=terminal_width, indent=4) | indent(width=4) }}{% endif %}
 {%- endfor %}
 {%- endif %}
 {%- if flag.arg and flag.arg.admonitions %}
 {%- for admonition in flag.arg.admonitions %}
-    {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | indent(width=4) }}
+    {% if admonition.kind == "warning" %}{{ admonition.text | terminal_label(label="Warning", width=terminal_width, indent=4) | indent(width=4) }}{% else %}{{ admonition.text | terminal_label(label="Note", width=terminal_width, indent=4) | indent(width=4) }}{% endif %}
 {%- endfor %}
 {%- endif %}
 {%- if not flag.hide_possible_values and flag.arg.choices and flag.arg.choices.choices %}
-{{ flag.ann_indent }}[possible values: {{ flag.arg.choices.choices | join(sep=", ") }}]
+{{ flag.arg.choices.choices | terminal_annotation(label="[possible values: ", suffix="]", indent=flag.ann_indent, width=terminal_width) }}
 {%- endif %}
 {%- if not flag.hide_possible_values and flag.arg.choices and flag.arg.choices.env %}
-{{ flag.ann_indent }}[choices env: {{ flag.arg.choices.env }}]
+{{ flag.arg.choices.env | terminal_annotation(label="[choices env: ", suffix="]", indent=flag.ann_indent, width=terminal_width) }}
 {%- endif %}
 {%- if not flag.hide_env and flag.env %}
-{{ flag.ann_indent }}[env: {{ flag.env }}]
+{{ flag.env | terminal_annotation(label="[env: ", suffix="]", indent=flag.ann_indent, width=terminal_width) }}
 {%- endif %}
 {%- if not flag.hide_env %}{% for env in flag.env_fallback %}
-{{ flag.ann_indent }}[env fallback: {{ env }}]
+{{ env | terminal_annotation(label="[env fallback: ", suffix="]", indent=flag.ann_indent, width=terminal_width) }}
 {%- endfor %}{% for env in flag.deprecated_env %}
-{{ flag.ann_indent }}[deprecated env: {{ env }}]
+{{ env | terminal_annotation(label="[deprecated env: ", suffix="]", indent=flag.ann_indent, width=terminal_width) }}
 {%- endfor %}{%- endif %}
 {%- if not flag.hide_default_value and flag.default %}
-{{ flag.ann_indent }}(default: {{ flag.default | join(sep=", ") }})
+{{ flag.default | terminal_annotation(label="(default: ", suffix=")", indent=flag.ann_indent, width=terminal_width) }}
 {%- endif %}
 {%- if flag.deprecated or flag.deprecated_warn_at or flag.deprecated_remove_at %}
-{{ flag.ann_indent }}[deprecated:{% if flag.deprecated %} {{ flag.deprecated }}{% endif %}{% if flag.deprecated_warn_at %}{% if flag.deprecated %};{% endif %} warns at {{ flag.deprecated_warn_at }}{% endif %}{% if flag.deprecated_remove_at %}{% if flag.deprecated or flag.deprecated_warn_at %};{% endif %} removed at {{ flag.deprecated_remove_at }}{% endif %}]
+{{ flag | terminal_deprecation(indent=flag.ann_indent, width=terminal_width) }}
 {%- endif %}
 {%- endfor %}
 {%- endfor %}{% if flag_has_ungrouped and not flag_has_grouped %}{{ mark_grouped_flags }}{% endif %}{{ mark_global_flags }}
@@ -185,9 +183,8 @@ Global flags:
 {%- if cmd.next_line_help %}
   {{ flag.display_usage }}
 {%- if flag.aliases %}  [aliases: {{ flag.aliases | join(sep=", ") }}]{% endif %}
-{%- set help = flag.help_long | default(value=flag.help | default(value='')) %}
-{%- if help %}
-    {{ help | indent(width=4) }}
+{%- if flag.row %}
+{{ flag.row }}
 {%- endif %}
 {%- elif flag.help_rendered %}
   {{ flag.display_usage | ljust(width=flag.usage_col_width) }}  {{ flag.help_rendered }}
@@ -197,44 +194,44 @@ Global flags:
 {%- elif flag.row %}
   {{ flag.display_usage }}
 {%- if flag.aliases %}  [aliases: {{ flag.aliases | join(sep=", ") }}]{% endif %}
-    {{ flag.row | indent(width=4) }}
+{{ flag.row }}
 {%- else %}
   {{ flag.display_usage }}
 {%- if flag.aliases %}  [aliases: {{ flag.aliases | join(sep=", ") }}]{% endif %}
 {%- set help = flag.help_long | default(value=flag.help | default(value='')) %}
 {%- if help %}
-    {{ help | indent(width=4) }}
+{{ help | terminal_annotation(indent="    ", width=terminal_width) }}
 {%- endif %}
 {%- endif %}
 {%- if flag.admonitions %}
 {%- for admonition in flag.admonitions %}
-    {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | indent(width=4) }}
+    {% if admonition.kind == "warning" %}{{ admonition.text | terminal_label(label="Warning", width=terminal_width, indent=4) | indent(width=4) }}{% else %}{{ admonition.text | terminal_label(label="Note", width=terminal_width, indent=4) | indent(width=4) }}{% endif %}
 {%- endfor %}
 {%- endif %}
 {%- if flag.arg and flag.arg.admonitions %}
 {%- for admonition in flag.arg.admonitions %}
-    {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | indent(width=4) }}
+    {% if admonition.kind == "warning" %}{{ admonition.text | terminal_label(label="Warning", width=terminal_width, indent=4) | indent(width=4) }}{% else %}{{ admonition.text | terminal_label(label="Note", width=terminal_width, indent=4) | indent(width=4) }}{% endif %}
 {%- endfor %}
 {%- endif %}
 {%- if not flag.hide_possible_values and flag.arg.choices and flag.arg.choices.choices %}
-{{ flag.ann_indent }}[possible values: {{ flag.arg.choices.choices | join(sep=", ") }}]
+{{ flag.arg.choices.choices | terminal_annotation(label="[possible values: ", suffix="]", indent=flag.ann_indent, width=terminal_width) }}
 {%- endif %}
 {%- if not flag.hide_possible_values and flag.arg.choices and flag.arg.choices.env %}
-{{ flag.ann_indent }}[choices env: {{ flag.arg.choices.env }}]
+{{ flag.arg.choices.env | terminal_annotation(label="[choices env: ", suffix="]", indent=flag.ann_indent, width=terminal_width) }}
 {%- endif %}
 {%- if not flag.hide_env and flag.env %}
-{{ flag.ann_indent }}[env: {{ flag.env }}]
+{{ flag.env | terminal_annotation(label="[env: ", suffix="]", indent=flag.ann_indent, width=terminal_width) }}
 {%- endif %}
 {%- if not flag.hide_env %}{% for env in flag.env_fallback %}
-{{ flag.ann_indent }}[env fallback: {{ env }}]
+{{ env | terminal_annotation(label="[env fallback: ", suffix="]", indent=flag.ann_indent, width=terminal_width) }}
 {%- endfor %}{% for env in flag.deprecated_env %}
-{{ flag.ann_indent }}[deprecated env: {{ env }}]
+{{ env | terminal_annotation(label="[deprecated env: ", suffix="]", indent=flag.ann_indent, width=terminal_width) }}
 {%- endfor %}{%- endif %}
 {%- if not flag.hide_default_value and flag.default %}
-{{ flag.ann_indent }}(default: {{ flag.default | join(sep=", ") }})
+{{ flag.default | terminal_annotation(label="(default: ", suffix=")", indent=flag.ann_indent, width=terminal_width) }}
 {%- endif %}
 {%- if flag.deprecated or flag.deprecated_warn_at or flag.deprecated_remove_at %}
-{{ flag.ann_indent }}[deprecated:{% if flag.deprecated %} {{ flag.deprecated }}{% endif %}{% if flag.deprecated_warn_at %}{% if flag.deprecated %};{% endif %} warns at {{ flag.deprecated_warn_at }}{% endif %}{% if flag.deprecated_remove_at %}{% if flag.deprecated or flag.deprecated_warn_at %};{% endif %} removed at {{ flag.deprecated_remove_at }}{% endif %}]
+{{ flag | terminal_deprecation(indent=flag.ann_indent, width=terminal_width) }}
 {%- endif %}
 {%- endfor %}
 {%- endif %}{{ mark_flattened }}
@@ -248,27 +245,26 @@ Global flags:
 {{ about | trim }}
 {%- endif %}
 {%- if sub.deprecated or sub.deprecated_warn_at or sub.deprecated_remove_at %}
-[deprecated:{% if sub.deprecated %} {{ sub.deprecated }}{% endif %}{% if sub.deprecated_warn_at %}{% if sub.deprecated %};{% endif %} warns at {{ sub.deprecated_warn_at }}{% endif %}{% if sub.deprecated_remove_at %}{% if sub.deprecated or sub.deprecated_warn_at %};{% endif %} removed at {{ sub.deprecated_remove_at }}{% endif %}]
+{{ sub | terminal_deprecation(width=terminal_width) }}
 {%- endif %}
 {%- for group in sub.arg_groups %}
 {%- for arg in group.items %}
 {%- if sub.flattened_next_line_help %}
   {{ arg.usage | trim }}
-{%- set help = arg.help_long | default(value=arg.help | default(value='')) %}
-{%- if help %}
-    {{ help | indent(width=4) }}
+{%- if arg.row %}
+{{ arg.row }}
 {%- endif %}
 {%- elif arg.help_rendered %}
   {{ arg.usage | ljust(width=arg.usage_col_width) }}  {{ arg.help_rendered }}
 {%- elif arg.row %}
   {{ arg.usage | trim }}
-    {{ arg.row | indent(width=4) }}
+{{ arg.row }}
 {%- else %}
   {{ arg.usage | trim }}
 {%- endif %}
 {%- if arg.admonitions %}
 {%- for admonition in arg.admonitions %}
-    {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | indent(width=4) }}
+    {% if admonition.kind == "warning" %}{{ admonition.text | terminal_label(label="Warning", width=terminal_width, indent=4) | indent(width=4) }}{% else %}{{ admonition.text | terminal_label(label="Note", width=terminal_width, indent=4) | indent(width=4) }}{% endif %}
 {%- endfor %}
 {%- endif %}
 {%- if not arg.hide_possible_values and arg.choices and arg.choices.choices %}
@@ -291,26 +287,25 @@ Global flags:
 {%- for flag in group.items %}
 {%- if sub.flattened_next_line_help %}
   {{ flag.display_usage }}
-{%- set help = flag.help_long | default(value=flag.help | default(value='')) %}
-{%- if help %}
-    {{ help | indent(width=4) }}
+{%- if flag.row %}
+{{ flag.row }}
 {%- endif %}
 {%- elif flag.help_rendered %}
   {{ flag.display_usage | ljust(width=flag.usage_col_width) }}  {{ flag.help_rendered }}
 {%- elif flag.row %}
   {{ flag.display_usage }}
-    {{ flag.row | indent(width=4) }}
+{{ flag.row }}
 {%- else %}
   {{ flag.display_usage }}
 {%- endif %}
 {%- if flag.admonitions %}
 {%- for admonition in flag.admonitions %}
-    {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | indent(width=4) }}
+    {% if admonition.kind == "warning" %}{{ admonition.text | terminal_label(label="Warning", width=terminal_width, indent=4) | indent(width=4) }}{% else %}{{ admonition.text | terminal_label(label="Note", width=terminal_width, indent=4) | indent(width=4) }}{% endif %}
 {%- endfor %}
 {%- endif %}
 {%- if flag.arg and flag.arg.admonitions %}
 {%- for admonition in flag.arg.admonitions %}
-    {% if admonition.kind == "warning" %}Warning{% else %}Note{% endif %}: {{ admonition.text | indent(width=4) }}
+    {% if admonition.kind == "warning" %}{{ admonition.text | terminal_label(label="Warning", width=terminal_width, indent=4) | indent(width=4) }}{% else %}{{ admonition.text | terminal_label(label="Note", width=terminal_width, indent=4) | indent(width=4) }}{% endif %}
 {%- endfor %}
 {%- endif %}
 {%- if not flag.hide_possible_values and flag.arg.choices and flag.arg.choices.choices %}
@@ -328,7 +323,7 @@ Global flags:
     (default: {{ flag.default | join(sep=", ") }})
 {%- endif %}
 {%- if flag.deprecated or flag.deprecated_warn_at or flag.deprecated_remove_at %}
-    [deprecated:{% if flag.deprecated %} {{ flag.deprecated }}{% endif %}{% if flag.deprecated_warn_at %}{% if flag.deprecated %};{% endif %} warns at {{ flag.deprecated_warn_at }}{% endif %}{% if flag.deprecated_remove_at %}{% if flag.deprecated or flag.deprecated_warn_at %};{% endif %} removed at {{ flag.deprecated_remove_at }}{% endif %}]
+{{ flag | terminal_deprecation(indent="    ", width=terminal_width) }}
 {%- endif %}
 {%- endfor %}
 {%- endfor %}
@@ -363,16 +358,16 @@ Examples:
 
 {%- if cmd.after_help_long %}
 
-{{ cmd.after_help_long }}
+{{ cmd.after_help_long | terminal_wrap(width=terminal_width) }}
 {%- elif cmd.after_help %}
 
-{{ cmd.after_help }}
+{{ cmd.after_help | terminal_wrap(width=terminal_width) }}
 {%- elif spec.after_help_long %}
 
-{{ spec.after_help_long }}
+{{ spec.after_help_long | terminal_wrap(width=terminal_width) }}
 {%- elif spec.after_help %}
 
-{{ spec.after_help }}
+{{ spec.after_help | terminal_wrap(width=terminal_width) }}
 {%- endif %}
 
 {%- if spec.author or spec.license %}

--- a/lib/src/docs/cli/templates/spec_template_short.tera
+++ b/lib/src/docs/cli/templates/spec_template_short.tera
@@ -1,22 +1,22 @@
-{%- if cmd.before_help %}{{ cmd.before_help }}
+{%- if cmd.before_help %}{{ cmd.before_help | terminal_wrap(width=terminal_width) }}
 
-{% elif spec.before_help %}{{ spec.before_help }}
+{% elif spec.before_help %}{{ spec.before_help | terminal_wrap(width=terminal_width) }}
 
 {% endif -%}
 {%- if root %}
 {%- if spec.name and spec.version %}{{ spec.name }} {{ spec.version }}
 {% elif spec.version %}{{ spec.bin }} {{ spec.version }}
 {% endif -%}
-{%- if spec.about %}{{ spec.about }}
+{%- if spec.about %}{{ spec.about | terminal_wrap(width=terminal_width) }}
 
 {% endif -%}
 {%- else -%}
-{%- if cmd.help %}{{ cmd.help }}
+{%- if cmd.help %}{{ cmd.help | terminal_wrap(width=terminal_width) }}
 
 {% endif -%}
 {%- endif -%}
 {%- if cmd.deprecated or cmd.deprecated_warn_at or cmd.deprecated_remove_at %}
-[deprecated:{% if cmd.deprecated %} {{ cmd.deprecated }}{% endif %}{% if cmd.deprecated_warn_at %}{% if cmd.deprecated %};{% endif %} warns at {{ cmd.deprecated_warn_at }}{% endif %}{% if cmd.deprecated_remove_at %}{% if cmd.deprecated or cmd.deprecated_warn_at %};{% endif %} removed at {{ cmd.deprecated_remove_at }}{% endif %}]
+{{ cmd | terminal_deprecation(width=terminal_width) }}
 
 {%- endif -%}{{ mark_usage }}
 {%- if cmd.flatten_help and cmd.flattened_usage %}
@@ -37,7 +37,7 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
   {{ cmd.name | ljust(width=cmd.usage_col_width) }}  {{ cmd.help_rendered }}
 {%- elif cmd.row %}
   {{ cmd.name }}
-    {{ cmd.row | indent(width=4) }}
+{{ cmd.row }}
 {%- else %}
   {{ cmd.name }}
 {%- endif %}
@@ -55,24 +55,24 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
 {%- for arg in group.items %}
 {%- if cmd.next_line_help %}
   {{ arg.usage | trim }}
-{%- if arg.help %}
-    {{ arg.help | indent(width=4) }}{% endif %}
+{%- if arg.row %}
+{{ arg.row }}{% endif %}
 {%- if not arg.hide_possible_values and arg.choices and arg.choices.choices %}
-    [possible values: {{ arg.choices.choices | join(sep=", ") }}]{%- endif %}
+{{ arg.choices.choices | terminal_annotation(label="[possible values: ", suffix="]", indent="    ", width=terminal_width) }}{%- endif %}
 {%- if not arg.hide_possible_values and arg.choices and arg.choices.env %}
-    [choices env: {{ arg.choices.env }}]{%- endif %}
+{{ arg.choices.env | terminal_annotation(label="[choices env: ", suffix="]", indent="    ", width=terminal_width) }}{%- endif %}
 {%- if not arg.hide_env and arg.env %}
-    [env: {{ arg.env }}]{%- endif %}
+{{ arg.env | terminal_annotation(label="[env: ", suffix="]", indent="    ", width=terminal_width) }}{%- endif %}
 {%- if not arg.hide_env %}{% for env in arg.env_fallback %}
-    [env fallback: {{ env }}]{%- endfor %}{% for env in arg.deprecated_env %}
-    [deprecated env: {{ env }}]{%- endfor %}{%- endif %}
+{{ env | terminal_annotation(label="[env fallback: ", suffix="]", indent="    ", width=terminal_width) }}{%- endfor %}{% for env in arg.deprecated_env %}
+{{ env | terminal_annotation(label="[deprecated env: ", suffix="]", indent="    ", width=terminal_width) }}{%- endfor %}{%- endif %}
 {%- if not arg.hide_default_value and arg.default %}
-    (default: {{ arg.default | join(sep=", ") }}){%- endif %}
+{{ arg.default | terminal_annotation(label="(default: ", suffix=")", indent="    ", width=terminal_width) }}{%- endif %}
 {%- elif arg.help_rendered %}
   {{ arg.usage | trim | ljust(width=arg.usage_col_width) }}  {{ arg.help_rendered }}
 {%- elif arg.row %}
   {{ arg.usage | trim }}
-    {{ arg.row | indent(width=4) }}
+{{ arg.row }}
 {%- else %}
   {{ arg.usage | trim }}
 {%- endif %}
@@ -86,26 +86,26 @@ Usage: {{ (spec.bin ~ " " ~ cmd.usage) | trim }}
 {%- for flag in group.items %}
 {%- if cmd.next_line_help %}
   {{ flag.display_usage }}{% if flag.aliases %}  [aliases: {{ flag.aliases | join(sep=", ") }}]{% endif %}
-{%- if flag.help %}
-    {{ flag.help | indent(width=4) }}{% endif %}
+{%- if flag.row %}
+{{ flag.row }}{% endif %}
 {%- if not flag.hide_possible_values and flag.arg.choices and flag.arg.choices.choices %}
-    [possible values: {{ flag.arg.choices.choices | join(sep=", ") }}]{%- endif %}
+{{ flag.arg.choices.choices | terminal_annotation(label="[possible values: ", suffix="]", indent="    ", width=terminal_width) }}{%- endif %}
 {%- if not flag.hide_possible_values and flag.arg.choices and flag.arg.choices.env %}
-    [choices env: {{ flag.arg.choices.env }}]{%- endif %}
+{{ flag.arg.choices.env | terminal_annotation(label="[choices env: ", suffix="]", indent="    ", width=terminal_width) }}{%- endif %}
 {%- if not flag.hide_env and flag.env %}
-    [env: {{ flag.env }}]{%- endif %}
+{{ flag.env | terminal_annotation(label="[env: ", suffix="]", indent="    ", width=terminal_width) }}{%- endif %}
 {%- if not flag.hide_env %}{% for env in flag.env_fallback %}
-    [env fallback: {{ env }}]{%- endfor %}{% for env in flag.deprecated_env %}
-    [deprecated env: {{ env }}]{%- endfor %}{%- endif %}
+{{ env | terminal_annotation(label="[env fallback: ", suffix="]", indent="    ", width=terminal_width) }}{%- endfor %}{% for env in flag.deprecated_env %}
+{{ env | terminal_annotation(label="[deprecated env: ", suffix="]", indent="    ", width=terminal_width) }}{%- endfor %}{%- endif %}
 {%- if not flag.hide_default_value and flag.default %}
-    (default: {{ flag.default | join(sep=", ") }}){%- endif %}
+{{ flag.default | terminal_annotation(label="(default: ", suffix=")", indent="    ", width=terminal_width) }}{%- endif %}
 {%- if flag.deprecated or flag.deprecated_warn_at or flag.deprecated_remove_at %}
-    [deprecated:{% if flag.deprecated %} {{ flag.deprecated }}{% endif %}{% if flag.deprecated_warn_at %}{% if flag.deprecated %};{% endif %} warns at {{ flag.deprecated_warn_at }}{% endif %}{% if flag.deprecated_remove_at %}{% if flag.deprecated or flag.deprecated_warn_at %};{% endif %} removed at {{ flag.deprecated_remove_at }}{% endif %}]{%- endif %}
+{{ flag | terminal_deprecation(indent="    ", width=terminal_width) }}{%- endif %}
 {%- elif flag.help_rendered %}
   {{ flag.display_usage | ljust(width=flag.usage_col_width) }}{% if flag.aliases %}  [aliases: {{ flag.aliases | join(sep=", ") }}]{% endif %}  {{ flag.help_rendered }}
 {%- elif flag.row %}
   {{ flag.display_usage }}{% if flag.aliases %}  [aliases: {{ flag.aliases | join(sep=", ") }}]{% endif %}
-    {{ flag.row | indent(width=4) }}
+{{ flag.row }}
 {%- else %}
   {{ flag.display_usage }}{% if flag.aliases %}  [aliases: {{ flag.aliases | join(sep=", ") }}]{% endif %}
 {%- endif %}
@@ -118,26 +118,26 @@ Global flags:
 {%- for flag in global_flags %}
 {%- if cmd.next_line_help %}
   {{ flag.display_usage }}{% if flag.aliases %}  [aliases: {{ flag.aliases | join(sep=", ") }}]{% endif %}
-{%- if flag.help %}
-    {{ flag.help | indent(width=4) }}{% endif %}
+{%- if flag.row %}
+{{ flag.row }}{% endif %}
 {%- if not flag.hide_possible_values and flag.arg.choices and flag.arg.choices.choices %}
-    [possible values: {{ flag.arg.choices.choices | join(sep=", ") }}]{%- endif %}
+{{ flag.arg.choices.choices | terminal_annotation(label="[possible values: ", suffix="]", indent="    ", width=terminal_width) }}{%- endif %}
 {%- if not flag.hide_possible_values and flag.arg.choices and flag.arg.choices.env %}
-    [choices env: {{ flag.arg.choices.env }}]{%- endif %}
+{{ flag.arg.choices.env | terminal_annotation(label="[choices env: ", suffix="]", indent="    ", width=terminal_width) }}{%- endif %}
 {%- if not flag.hide_env and flag.env %}
-    [env: {{ flag.env }}]{%- endif %}
+{{ flag.env | terminal_annotation(label="[env: ", suffix="]", indent="    ", width=terminal_width) }}{%- endif %}
 {%- if not flag.hide_env %}{% for env in flag.env_fallback %}
-    [env fallback: {{ env }}]{%- endfor %}{% for env in flag.deprecated_env %}
-    [deprecated env: {{ env }}]{%- endfor %}{%- endif %}
+{{ env | terminal_annotation(label="[env fallback: ", suffix="]", indent="    ", width=terminal_width) }}{%- endfor %}{% for env in flag.deprecated_env %}
+{{ env | terminal_annotation(label="[deprecated env: ", suffix="]", indent="    ", width=terminal_width) }}{%- endfor %}{%- endif %}
 {%- if not flag.hide_default_value and flag.default %}
-    (default: {{ flag.default | join(sep=", ") }}){%- endif %}
+{{ flag.default | terminal_annotation(label="(default: ", suffix=")", indent="    ", width=terminal_width) }}{%- endif %}
 {%- if flag.deprecated or flag.deprecated_warn_at or flag.deprecated_remove_at %}
-    [deprecated:{% if flag.deprecated %} {{ flag.deprecated }}{% endif %}{% if flag.deprecated_warn_at %}{% if flag.deprecated %};{% endif %} warns at {{ flag.deprecated_warn_at }}{% endif %}{% if flag.deprecated_remove_at %}{% if flag.deprecated or flag.deprecated_warn_at %};{% endif %} removed at {{ flag.deprecated_remove_at }}{% endif %}]{%- endif %}
+{{ flag | terminal_deprecation(indent="    ", width=terminal_width) }}{%- endif %}
 {%- elif flag.help_rendered %}
   {{ flag.display_usage | ljust(width=flag.usage_col_width) }}{% if flag.aliases %}  [aliases: {{ flag.aliases | join(sep=", ") }}]{% endif %}  {{ flag.help_rendered }}
 {%- elif flag.row %}
   {{ flag.display_usage }}{% if flag.aliases %}  [aliases: {{ flag.aliases | join(sep=", ") }}]{% endif %}
-    {{ flag.row | indent(width=4) }}
+{{ flag.row }}
 {%- else %}
   {{ flag.display_usage }}{% if flag.aliases %}  [aliases: {{ flag.aliases | join(sep=", ") }}]{% endif %}
 {%- endif %}
@@ -149,34 +149,34 @@ Global flags:
 
 {{ sub.full_cmd | join(sep=" ") }}:
 {%- if sub.help %}
-{{ sub.help | trim }}
+{{ sub.help | trim | terminal_wrap(width=terminal_width) }}
 {%- endif %}
 {%- if sub.deprecated or sub.deprecated_warn_at or sub.deprecated_remove_at %}
-[deprecated:{% if sub.deprecated %} {{ sub.deprecated }}{% endif %}{% if sub.deprecated_warn_at %}{% if sub.deprecated %};{% endif %} warns at {{ sub.deprecated_warn_at }}{% endif %}{% if sub.deprecated_remove_at %}{% if sub.deprecated or sub.deprecated_warn_at %};{% endif %} removed at {{ sub.deprecated_remove_at }}{% endif %}]
+{{ sub | terminal_deprecation(width=terminal_width) }}
 {%- endif %}
 {%- for group in sub.arg_groups %}
 {%- for arg in group.items %}
 {%- if sub.flattened_next_line_help %}
   {{ arg.usage | trim }}
-{%- if arg.help %}
-    {{ arg.help | indent(width=4) }}
+{%- if arg.row %}
+{{ arg.row }}
 {%- endif %}
 {%- if not arg.hide_possible_values and arg.choices and arg.choices.choices %}
-    [possible values: {{ arg.choices.choices | join(sep=", ") }}]{%- endif %}
+{{ arg.choices.choices | terminal_annotation(label="[possible values: ", suffix="]", indent="    ", width=terminal_width) }}{%- endif %}
 {%- if not arg.hide_possible_values and arg.choices and arg.choices.env %}
-    [choices env: {{ arg.choices.env }}]{%- endif %}
+{{ arg.choices.env | terminal_annotation(label="[choices env: ", suffix="]", indent="    ", width=terminal_width) }}{%- endif %}
 {%- if not arg.hide_env and arg.env %}
-    [env: {{ arg.env }}]{%- endif %}
+{{ arg.env | terminal_annotation(label="[env: ", suffix="]", indent="    ", width=terminal_width) }}{%- endif %}
 {%- if not arg.hide_env %}{% for env in arg.env_fallback %}
-    [env fallback: {{ env }}]{%- endfor %}{% for env in arg.deprecated_env %}
-    [deprecated env: {{ env }}]{%- endfor %}{%- endif %}
+{{ env | terminal_annotation(label="[env fallback: ", suffix="]", indent="    ", width=terminal_width) }}{%- endfor %}{% for env in arg.deprecated_env %}
+{{ env | terminal_annotation(label="[deprecated env: ", suffix="]", indent="    ", width=terminal_width) }}{%- endfor %}{%- endif %}
 {%- if not arg.hide_default_value and arg.default %}
-    (default: {{ arg.default | join(sep=", ") }}){%- endif %}
+{{ arg.default | terminal_annotation(label="(default: ", suffix=")", indent="    ", width=terminal_width) }}{%- endif %}
 {%- elif arg.help_rendered %}
   {{ arg.usage | trim | ljust(width=arg.usage_col_width) }}  {{ arg.help_rendered }}
 {%- elif arg.row %}
   {{ arg.usage | trim }}
-    {{ arg.row | indent(width=4) }}
+{{ arg.row }}
 {%- else %}
   {{ arg.usage | trim }}
 {%- endif %}
@@ -186,27 +186,27 @@ Global flags:
 {%- for flag in group.items %}
 {%- if sub.flattened_next_line_help %}
   {{ flag.display_usage }}
-{%- if flag.help %}
-    {{ flag.help | indent(width=4) }}
+{%- if flag.row %}
+{{ flag.row }}
 {%- endif %}
 {%- if not flag.hide_possible_values and flag.arg.choices and flag.arg.choices.choices %}
-    [possible values: {{ flag.arg.choices.choices | join(sep=", ") }}]{%- endif %}
+{{ flag.arg.choices.choices | terminal_annotation(label="[possible values: ", suffix="]", indent="    ", width=terminal_width) }}{%- endif %}
 {%- if not flag.hide_possible_values and flag.arg.choices and flag.arg.choices.env %}
-    [choices env: {{ flag.arg.choices.env }}]{%- endif %}
+{{ flag.arg.choices.env | terminal_annotation(label="[choices env: ", suffix="]", indent="    ", width=terminal_width) }}{%- endif %}
 {%- if not flag.hide_env and flag.env %}
-    [env: {{ flag.env }}]{%- endif %}
+{{ flag.env | terminal_annotation(label="[env: ", suffix="]", indent="    ", width=terminal_width) }}{%- endif %}
 {%- if not flag.hide_env %}{% for env in flag.env_fallback %}
-    [env fallback: {{ env }}]{%- endfor %}{% for env in flag.deprecated_env %}
-    [deprecated env: {{ env }}]{%- endfor %}{%- endif %}
+{{ env | terminal_annotation(label="[env fallback: ", suffix="]", indent="    ", width=terminal_width) }}{%- endfor %}{% for env in flag.deprecated_env %}
+{{ env | terminal_annotation(label="[deprecated env: ", suffix="]", indent="    ", width=terminal_width) }}{%- endfor %}{%- endif %}
 {%- if not flag.hide_default_value and flag.default %}
-    (default: {{ flag.default | join(sep=", ") }}){%- endif %}
+{{ flag.default | terminal_annotation(label="(default: ", suffix=")", indent="    ", width=terminal_width) }}{%- endif %}
 {%- if flag.deprecated or flag.deprecated_warn_at or flag.deprecated_remove_at %}
-    [deprecated:{% if flag.deprecated %} {{ flag.deprecated }}{% endif %}{% if flag.deprecated_warn_at %}{% if flag.deprecated %};{% endif %} warns at {{ flag.deprecated_warn_at }}{% endif %}{% if flag.deprecated_remove_at %}{% if flag.deprecated or flag.deprecated_warn_at %};{% endif %} removed at {{ flag.deprecated_remove_at }}{% endif %}]{%- endif %}
+{{ flag | terminal_deprecation(indent="    ", width=terminal_width) }}{%- endif %}
 {%- elif flag.help_rendered %}
   {{ flag.display_usage | ljust(width=flag.usage_col_width) }}  {{ flag.help_rendered }}
 {%- elif flag.row %}
   {{ flag.display_usage }}
-    {{ flag.row | indent(width=4) }}
+{{ flag.row }}
 {%- else %}
   {{ flag.display_usage }}
 {%- endif %}
@@ -237,8 +237,8 @@ Examples:
 
 {%- if cmd.after_help %}
 
-{{ cmd.after_help }}
+{{ cmd.after_help | terminal_wrap(width=terminal_width) }}
 {%- elif spec.after_help %}
 
-{{ spec.after_help }}
+{{ spec.after_help | terminal_wrap(width=terminal_width) }}
 {%- endif -%}

--- a/lib/src/docs/cli/templates/spec_template_short.tera
+++ b/lib/src/docs/cli/templates/spec_template_short.tera
@@ -149,7 +149,7 @@ Global flags:
 
 {{ sub.full_cmd | join(sep=" ") }}:
 {%- if sub.help %}
-{{ sub.help | trim | terminal_wrap(width=terminal_width) }}
+{{ sub.help | terminal_wrap(width=terminal_width) }}
 {%- endif %}
 {%- if sub.deprecated or sub.deprecated_warn_at or sub.deprecated_remove_at %}
 {{ sub | terminal_deprecation(width=terminal_width) }}

--- a/lib/src/docs/layout.rs
+++ b/lib/src/docs/layout.rs
@@ -6,6 +6,9 @@ pub fn get_terminal_width() -> usize {
         .unwrap_or(80)
 }
 
+/// Minimum useful room for prose beside an entry wider than the shared usage column.
+pub const MIN_INLINE_HELP_WIDTH: usize = 30;
+
 /// Resolve a command's help width using clap-compatible precedence.
 pub fn help_width(term_width: Option<usize>, max_term_width: Option<usize>) -> usize {
     if let Some(width) = term_width {
@@ -56,22 +59,34 @@ pub fn wrap_text(text: &str, width: usize) -> Vec<String> {
 
     let mut lines = Vec::new();
 
-    // Handle explicit newlines in the input
+    // Keep explicit line boundaries. Indented lines are preformatted; list items get a
+    // hanging indent while ordinary prose is folded at word boundaries.
     for paragraph in text.split('\n') {
         if paragraph.is_empty() {
             lines.push(String::new());
             continue;
         }
 
+        if paragraph.starts_with("    ") || paragraph.starts_with('\t') {
+            lines.push(paragraph.to_string());
+            continue;
+        }
+
+        let paragraph = paragraph.trim();
+        let (prefix, body) = list_prefix(paragraph).unwrap_or(("", paragraph));
+        let body_width = width.saturating_sub(visible_width(prefix));
+        let mut line_prefix = prefix.to_string();
+
         let mut current_line = String::new();
         let mut current_width = 0;
 
-        for word in paragraph.split_whitespace() {
+        for word in body.split_whitespace() {
             let word_width = visible_width(word);
 
             // If adding this word would exceed width, start a new line
-            if current_width > 0 && current_width + 1 + word_width > width {
-                lines.push(current_line);
+            if current_width > 0 && current_width + 1 + word_width > body_width {
+                lines.push(format!("{line_prefix}{current_line}"));
+                line_prefix = " ".repeat(visible_width(prefix));
                 current_line = String::new();
                 current_width = 0;
             }
@@ -87,7 +102,7 @@ pub fn wrap_text(text: &str, width: usize) -> Vec<String> {
         }
 
         if !current_line.is_empty() {
-            lines.push(current_line);
+            lines.push(format!("{line_prefix}{current_line}"));
         }
     }
 
@@ -99,6 +114,19 @@ pub fn wrap_text(text: &str, width: usize) -> Vec<String> {
     }
 }
 
+fn list_prefix(line: &str) -> Option<(&str, &str)> {
+    for marker in ["* ", "- ", "+ "] {
+        if let Some(body) = line.strip_prefix(marker) {
+            return Some((marker, body));
+        }
+    }
+    let digits = line.bytes().take_while(u8::is_ascii_digit).count();
+    if digits > 0 && line.as_bytes().get(digits..digits + 2) == Some(b". ") {
+        return Some(line.split_at(digits + 2));
+    }
+    None
+}
+
 /// Render help text with proper alignment and wrapping
 /// Returns (rendered_text, is_multiline)
 pub fn render_help_text(
@@ -106,28 +134,45 @@ pub fn render_help_text(
     terminal_width: usize,
     usage_col_width: usize,
 ) -> (String, bool) {
-    // If help contains explicit newlines, use block layout (legacy behavior)
-    if help.contains('\n') {
-        // Return None for inline rendering - template will use block layout
-        return (String::new(), false);
-    }
-
     // Format: "  <usage>PADDING  help text"
     let indent = 2;
     let gap = 2;
     let first_line_prefix_width = indent + usage_col_width + gap;
-    let continuation_indent = first_line_prefix_width;
+    render_help_text_at(
+        help,
+        terminal_width,
+        first_line_prefix_width,
+        first_line_prefix_width,
+    )
+}
 
+/// Render help whose opening line and continuations begin in different columns.
+pub fn render_help_text_at(
+    help: &str,
+    terminal_width: usize,
+    first_line_prefix_width: usize,
+    continuation_indent: usize,
+) -> (String, bool) {
     let available_width = terminal_width.saturating_sub(first_line_prefix_width);
+    let continuation_width = terminal_width.saturating_sub(continuation_indent);
 
     // Minimum readable width
-    if available_width < 10 {
+    if available_width < 10 || continuation_width < 10 {
         // Terminal too narrow, use block layout
         return (String::new(), false);
     }
 
-    // Wrap text to available width
-    let wrapped_lines = wrap_text(help, available_width);
+    let mut wrapped_lines = Vec::new();
+    for (index, line) in help.split('\n').enumerate() {
+        wrapped_lines.extend(wrap_text(
+            line,
+            if index == 0 {
+                available_width
+            } else {
+                continuation_width
+            },
+        ));
+    }
 
     if wrapped_lines.is_empty() || (wrapped_lines.len() == 1 && wrapped_lines[0].is_empty()) {
         return (String::new(), false);
@@ -139,8 +184,10 @@ pub fn render_help_text(
     let mut result = wrapped_lines[0].clone();
     for line in &wrapped_lines[1..] {
         result.push('\n');
-        result.push_str(&" ".repeat(continuation_indent));
-        result.push_str(line);
+        if !line.is_empty() {
+            result.push_str(&" ".repeat(continuation_indent));
+            result.push_str(line);
+        }
     }
 
     (result, is_multiline)
@@ -148,7 +195,38 @@ pub fn render_help_text(
 
 /// Wrap text for the four-space block beneath an entry that overflowed its usage column.
 pub fn render_block_text(help: &str, terminal_width: usize) -> String {
-    wrap_text(help, terminal_width.saturating_sub(4)).join("\n")
+    render_indented_text(help, terminal_width, 4)
+}
+
+/// Wrap text that a caller will indent by `indent` columns.
+pub fn render_indented_text(help: &str, terminal_width: usize, indent: usize) -> String {
+    wrap_text(help, terminal_width.saturating_sub(indent)).join("\n")
+}
+
+/// Render labelled prose with continuations hanging below the text after the label.
+pub fn render_labelled_text(
+    label: &str,
+    text: &str,
+    terminal_width: usize,
+    indent: usize,
+) -> String {
+    let prefix = format!("{label}: ");
+    let lines = wrap_text(
+        text,
+        terminal_width.saturating_sub(indent + visible_width(&prefix)),
+    );
+    let Some((first, rest)) = lines.split_first() else {
+        return format!("{label}:");
+    };
+    let mut out = format!("{prefix}{first}");
+    for line in rest {
+        out.push('\n');
+        if !line.is_empty() {
+            out.push_str(&" ".repeat(visible_width(&prefix)));
+            out.push_str(line);
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -227,10 +305,21 @@ mod tests {
 
     #[test]
     fn test_render_help_text_with_newlines() {
-        // Help with explicit newlines should use block layout (returns empty)
         let help = "Line one\nLine two";
         let (rendered, is_multiline) = render_help_text(help, 80, 20);
-        assert_eq!(rendered, "");
-        assert!(!is_multiline);
+        assert_eq!(rendered, "Line one\n                        Line two");
+        assert!(is_multiline);
+    }
+
+    #[test]
+    fn list_items_wrap_with_a_hanging_indent_and_code_is_preserved() {
+        assert_eq!(
+            wrap_text("* alpha beta gamma delta", 14),
+            ["* alpha beta", "  gamma delta"]
+        );
+        assert_eq!(
+            wrap_text("    $ ex --a-deliberately-long-example", 10),
+            ["    $ ex --a-deliberately-long-example"]
+        );
     }
 }

--- a/lib/src/docs/layout.rs
+++ b/lib/src/docs/layout.rs
@@ -72,8 +72,15 @@ pub fn wrap_text(text: &str, width: usize) -> Vec<String> {
             continue;
         }
 
-        let paragraph = paragraph.trim();
-        let (prefix, body) = list_prefix(paragraph).unwrap_or(("", paragraph));
+        let trimmed = paragraph.trim();
+        let leading_trimmed = paragraph.trim_start_matches(' ');
+        let (prefix, body) = match list_prefix(leading_trimmed) {
+            Some((marker, body)) => (
+                &paragraph[..paragraph.len() - leading_trimmed.len() + marker.len()],
+                body,
+            ),
+            None => ("", trimmed),
+        };
         let body_width = width.saturating_sub(visible_width(prefix));
         let mut line_prefix = prefix.to_string();
 
@@ -316,6 +323,10 @@ mod tests {
         assert_eq!(
             wrap_text("* alpha beta gamma delta", 14),
             ["* alpha beta", "  gamma delta"]
+        );
+        assert_eq!(
+            wrap_text("  - a nested item with enough words to wrap", 24),
+            ["  - a nested item with", "    enough words to wrap"]
         );
         assert_eq!(
             wrap_text("    $ ex --a-deliberately-long-example", 10),

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -209,6 +209,9 @@ pub struct Group<T> {
     pub heading: Option<String>,
     /// Prose introducing this section, when the command declared some for the heading.
     pub help: Option<String>,
+    /// Terminal-width rendering of `help`; absent in format-neutral model conversion.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub help_rendered: Option<String>,
     pub items: Vec<T>,
 }
 
@@ -443,6 +446,7 @@ fn group_by_heading<T: Clone>(
             None => groups.push(Group {
                 heading,
                 help: None,
+                help_rendered: None,
                 items: vec![item.clone()],
             }),
         }
@@ -645,11 +649,6 @@ impl From<&crate::Spec> for Spec {
 
 impl From<&crate::SpecCommand> for SpecCommand {
     fn from(cmd: &crate::SpecCommand) -> Self {
-        use crate::docs::layout::{
-            help_width, render_block_text, render_help_text, usage_column_width, visible_width,
-        };
-
-        let terminal_width = help_width(cmd.term_width, cmd.max_term_width);
         let flattened_usage = if cmd.flatten_help {
             let mut lines = Vec::new();
             if !cmd.subcommand_required || cmd.args_conflicts_with_subcommands {
@@ -668,45 +667,15 @@ impl From<&crate::SpecCommand> for SpecCommand {
             Vec::new()
         };
 
-        // Calculate layout for args
-        let args_usage_col_width =
-            usage_column_width(cmd.args.iter().map(|a| a.usage.as_str()), terminal_width);
         let mut args: Vec<(usize, SpecArg)> = cmd
             .args
             .iter()
             .enumerate()
-            .map(|(index, arg)| {
-                let mut spec_arg = SpecArg::from(arg);
-
-                // Get help text (prefer help_long over help)
-                let help_text = spec_arg.help_long.as_deref().or(spec_arg.help.as_deref());
-
-                spec_arg.help_is_block = visible_width(&spec_arg.usage) > args_usage_col_width;
-
-                if let Some(help) = help_text {
-                    if spec_arg.help_is_block {
-                        spec_arg.row = Some(render_block_text(help, terminal_width));
-                    } else {
-                        let (rendered, is_multiline) =
-                            render_help_text(help, terminal_width, args_usage_col_width);
-                        // Only set help_rendered if we have content (empty string signals block layout)
-                        if !rendered.is_empty() {
-                            spec_arg.help_rendered = Some(rendered);
-                            spec_arg.help_is_multiline = is_multiline;
-                        } else {
-                            spec_arg.row = Some(help.to_string());
-                        }
-                    }
-                }
-
-                spec_arg.usage_col_width = args_usage_col_width;
-                (index, spec_arg)
-            })
+            .map(|(index, arg)| (index, SpecArg::from(arg)))
             .collect();
         args.sort_by_key(|(_, arg)| arg.display_order.unwrap_or(999));
         let args: Vec<SpecArg> = args.into_iter().map(|(_, arg)| arg).collect();
 
-        // Calculate layout for flags
         let mut flags: Vec<(usize, SpecFlag)> = cmd
             .flags
             .iter()
@@ -715,39 +684,6 @@ impl From<&crate::SpecCommand> for SpecCommand {
             .collect();
         flags.sort_by_key(|(_, flag)| flag.display_order.unwrap_or(999));
         let flags: Vec<SpecFlag> = flags.into_iter().map(|(_, flag)| flag).collect();
-        let flags_usage_col_width = usage_column_width(
-            flags.iter().map(|f| f.display_usage.as_str()),
-            terminal_width,
-        );
-        let flags: Vec<SpecFlag> = flags
-            .into_iter()
-            .map(|mut spec_flag| {
-                // Get help text (prefer help_long over help)
-                let help_text = spec_flag.help_long.as_deref().or(spec_flag.help.as_deref());
-
-                spec_flag.help_is_block =
-                    visible_width(&spec_flag.display_usage) > flags_usage_col_width;
-
-                if let Some(help) = help_text {
-                    if spec_flag.help_is_block {
-                        spec_flag.row = Some(render_block_text(help, terminal_width));
-                    } else {
-                        let (rendered, is_multiline) =
-                            render_help_text(help, terminal_width, flags_usage_col_width);
-                        // Only set help_rendered if we have content (empty string signals block layout)
-                        if !rendered.is_empty() {
-                            spec_flag.help_rendered = Some(rendered);
-                            spec_flag.help_is_multiline = is_multiline;
-                        } else {
-                            spec_flag.row = Some(help.to_string());
-                        }
-                    }
-                }
-
-                spec_flag.usage_col_width = flags_usage_col_width;
-                spec_flag
-            })
-            .collect();
 
         // Destructured exhaustively (no `..`) so that adding a field to the spec
         // model fails to compile until this decides whether docs need it.
@@ -866,6 +802,7 @@ impl From<&crate::SpecCommand> for SpecCommand {
                 Group {
                     heading: None,
                     help: None,
+                    help_rendered: None,
                     items: Vec::new(),
                 },
             );

--- a/lib/tests/parse.rs
+++ b/lib/tests/parse.rs
@@ -127,11 +127,10 @@ arg_choices_help_long:
     expected=r#"Usage: <shell>
 
 Arguments:
-  <shell>
-    help
-    fooo
-    bar
-    [possible values: bash, fish, zsh]
+  <shell>  help
+           fooo
+           bar
+           [possible values: bash, fish, zsh]
 
 Flags:
   -h, --help  Print help
@@ -157,11 +156,10 @@ flag_choices_help_long:
     expected=r#"Usage: [--shell <shell>]
 
 Flags:
-      --shell <shell>
-    help
-    fooo
-    bar
-    [possible values: bash, fish, zsh]
+      --shell <shell>  help
+                       fooo
+                       bar
+                       [possible values: bash, fish, zsh]
   -h, --help           Print help
 "#,
 

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -2525,10 +2525,11 @@ fn typed_help_width_reaches_help_and_the_portable_spec() {
     assert_eq!(spec.root.max_term_width, Some(20));
     let page = usage::argv::help::long_help(spec, &["sized-help"], &[spec.root]);
     assert!(
-        page.contains("    A description long enough to\n")
-            && page.contains("    wrap at the command's declared\n")
-            && page.contains("    help width.\n"),
-        "fixed width should wrap an overflowing entry below its usage: {page}"
+        page.contains("                A description long\n")
+            && page.contains("                enough to wrap at\n")
+            && page.contains("                the command's\n")
+            && page.contains("                declared help width.\n"),
+        "fixed width should wrap an overflowing entry at the description column: {page}"
     );
 
     let kdl = SizedHelp::to_kdl();


### PR DESCRIPTION
## Summary

- use a hybrid help layout: long spellings keep prose inline when at least 30 columns remain, otherwise prose starts at the shared description column
- wrap paragraphs, section introductions, annotations, bullets, and labelled admonitions while preserving blank and preformatted lines
- keep the Rust reference renderer, dependency-free usage-argv renderer, and generated Go renderer in parity
- move terminal-only layout work out of format-neutral docs model conversion

## Oxc comparison

Validated against oxc-project/oxc#26027 with local Cargo patches for usage-rs, usage-argv, usage-derive, and usage-lib.

Before:

```text
      --disable-typescript-plugin
    Disable TypeScript plugin, which is turned on by default

      --ignore-pattern <PAT>
    Specify patterns of files to ignore (in addition to those in .eslintignore)
```

After:

```text
      --disable-typescript-plugin  Disable TypeScript plugin, which is turned on
                                  by default

      --ignore-pattern <PAT>      Specify patterns of files to ignore (in
                                  addition to those in .eslintignore)
```

Multiline config/debug help now opens beside the option, wraps paragraphs and bullets to 80 columns, preserves explicit blank lines and example commands, and wraps possible-value annotations. The regenerated oxfmt and oxlint terminal snapshot tests pass.

## Validation

- cargo test --all --all-features
- cargo clippy --all --all-features --all-targets -- -D warnings
- Go renderer and conformance tests
- fleet/help renderer parity gates
- cargo fmt, gofmt, Prettier, actionlint, and semver checks
- mise run ci
- Oxc website_formatter and website_linter terminal snapshot regeneration with local patches

## Performance

Accepted presentation-path cost:

| benchmark | instructions | change |
| --- | ---: | ---: |
| markdown | 342,021,678 → 339,146,616 | -0.84% |
| startup/help | 855,497 → 866,031 | +1.23% |

The startup/help result is 0.23 percentage points over the 1% gate. This is documented rather than weakening the gate; the added work is the requested terminal wrapping and layout behavior.

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide-reaching presentation changes to help output across Rust, Go, and templates; low functional risk but high visibility for any CLI relying on exact help formatting or golden tests.
> 
> **Overview**
> **Terminal help now wraps to the configured width** across short/long pages, flattened views, section intros, deprecation lines, env/default annotations, and labelled Notes/Warnings—instead of printing raw prose that runs past the terminal edge (especially on `-h`).
> 
> **Hybrid column layout:** entries with spellings wider than the shared usage column can keep help **on the same row** when at least **30** columns remain (`MIN_INLINE_HELP_WIDTH`); otherwise prose stacks under the normal description column (not always a fixed 4-space block). `entry` / `Column::can_inline` and `wrap_at` separate first-line vs continuation widths; multiline author text is wrapped rather than forcing block-only layout.
> 
> **Smarter `wrap`:** bullet/numbered lists get hanging indents; lines starting with 4 spaces or tabs stay preformatted; blank lines in wrapped output are preserved.
> 
> **Parity across renderers:** the same behavior is implemented in `argv` help, Go `page`/`page_long`, and the Tera-based reference (`terminal_wrap`, `terminal_label`, `terminal_annotation`, `terminal_deprecation` filters; pre-rendered `help_rendered` on groups). Layout work moves out of format-neutral `SpecCommand::from` into render-time `lay_out_*`.
> 
> Conformance and snapshot tests (including oxc-shaped fixtures) assert ≤80-column lines, inline flags where room allows, and matching output between `usage-argv` and `usage-lib`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4bf1d05b7bcd4a6b87846cb8b95eb7a56d96d7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Improved CLI help wrapping across short and long formats.
  - Help text now adapts to terminal width with clearer indentation and alignment.
  - Multiline descriptions remain inline when space allows or use a readable block layout.
  - Lists retain hanging indentation, while preformatted paragraphs preserve their formatting.
  - Annotations, warnings, notes, defaults, environment details, and deprecation notices wrap consistently.
  - Improved rendering for commands, arguments, flags, grouped sections, and flattened help views.
  - Consistent formatting is now available across supported help renderers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->