### PR TITLE
docs: sharpen the usage-rs pitch and cross-link framework completions

### DIFF
--- a/docs/cli/completions.md
+++ b/docs/cli/completions.md
@@ -1,5 +1,12 @@
 # Generating Completion Scripts
 
+::: tip Building with usage-rs or usage-go?
+Both frameworks generate and answer completions from the tables compiled into your binary, so
+there is no spec file to ship and no `usage` runtime dependency for your users. See
+[Rust completions](/rust/completions) and [Go completions](/go/completions). This page covers
+generating scripts with the `usage` CLI from a `.usage.kdl` spec or a `usage`-shebang script.
+:::
+
 ## Auto-completion for shebang scripts (bash)
 
 If you have shell scripts that use the `usage` shebang

--- a/docs/rust/index.md
+++ b/docs/rust/index.md
@@ -4,18 +4,24 @@
 Used by some of jdx's CLIs, but point releases may break.
 :::
 
-`usage-rs` is a fast, typed framework for building complete command-line applications in Rust.
+`usage-rs` is a CLI framework for Rust applications, and the reference implementation of the
+[usage spec](/spec/). It is fully featured — more of what a real CLI needs than clap offers —
+and its parser is up to thousands of times faster.
+
 Declare commands, flags, arguments, and settings with familiar structs and enums, and get
 first-class environment and config-file resolution, advanced shell completions, portable
-validation, negation flags, typed argument groups, categorized subcommands, and more.
+validation, negation flags, typed argument groups, categorized subcommands, and more. The derive
+accepts most clap spellings, so a migration is largely mechanical.
 
-In the mise-scale benchmark it parses hundreds of times faster than clap, with no third-party
-runtime crates and a 1.3 MB stripped binary versus clap's 3.1 MB. See the
-[performance results](/rust/performance) and [clap migration guide](/rust/migrating-from-clap).
+The speed comes from where the work happens: the derive lays the command tree out as static
+tables while your application compiles, so a parse never builds and validates a parser the way
+clap and bpaf do on every run. At mise scale that is 855x fewer instructions than clap and
+2,957x fewer than bpaf, in a 1.3 MB stripped binary against clap's 3.1 MB, with no third-party
+crates linked into your binary. See the [performance results](/rust/performance) and
+[clap migration guide](/rust/migrating-from-clap).
 
-The same declaration also becomes a portable [usage spec](/spec/) that the binary can print.
-`usage-cli` turns it into documentation, manpages, and completions — the same toolchain used
-across jdx's CLIs.
+The same declaration also becomes a portable spec that the binary can print. `usage-cli` turns
+it into documentation, manpages, and completions — the same toolchain used across jdx's CLIs.
 
 ```rust
 use usage::Cli;

--- a/docs/rust/performance.md
+++ b/docs/rust/performance.md
@@ -1,8 +1,10 @@
 # Parser performance
 
-usage's compiled Rust parser is designed so ordinary argv parsing reads static
-tables and writes directly into the result. Cold metadata for help, specs, and
-completions is not constructed on a successful parse.
+`usage-rs` has the fastest argument parser of the Rust frameworks measured here:
+at mise scale it parses in 0.7 µs, 855x fewer instructions than clap and 2,957x
+fewer than bpaf. The derive lays the command tree out as static tables while
+your application compiles, so a parse reads what the compiler already built
+instead of constructing and validating a parser on every run.
 
 ## Mise-scale result
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Three copy changes, one per commit.

## `/rust/` opening

Opened with what `usage-rs` is rather than how it works: a CLI framework for Rust applications and the reference implementation of the usage spec, fully featured against clap, with a parser up to thousands of times faster. The mechanics (structs and enums, clap-compatible derive spellings) moved into the second paragraph, and the speed claim now says where the speed comes from — static tables laid out at compile time instead of a parser built and validated on every run.

Numbers are the ones the gate measures: 855x fewer instructions than clap, 2,957x fewer than bpaf, 1.3 MB stripped against clap's 3.1 MB.

## `/rust/performance` opening

Leads with the measured standing and the compile-time reason for it. Dropped the "Cold metadata for help, specs, and completions is not constructed on a successful parse" sentence — [Why it is fast](https://usage.jdx.dev/rust/performance#why-it-is-fast) already covers it in context.

## `/cli/completions` callout

Readers building with `usage-rs` or `usage-go` were landing on the spec-driven CLI workflow. A tip at the top sends them to the framework pages and notes that those binaries answer completions from compiled tables, with no spec file to ship and no `usage` runtime dependency for their users.

## Verification

Built the site and read the rendered pages.

[Rust framework landing page with the new opening](https://cursor.com/agents/bc-e0b65075-0c8a-4d91-81fe-7fb60fb9ba2d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frust_landing_intro.png)

[Parser performance page leading with the measured result](https://cursor.com/agents/bc-e0b65075-0c8a-4d91-81fe-7fb60fb9ba2d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fperformance_intro.png)

[Completion scripts page with the new framework callout](https://cursor.com/agents/bc-e0b65075-0c8a-4d91-81fe-7fb60fb9ba2d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcli_completions_callout.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0b65075-0c8a-4d91-81fe-7fb60fb9ba2d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0b65075-0c8a-4d91-81fe-7fb60fb9ba2d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the distinction between framework-generated completions and scripts generated by the `usage` CLI.
  - Updated Rust framework documentation with expanded feature descriptions, migration guidance, and performance highlights.
  - Added quantified parser performance comparisons and explained how compiled command tables improve parsing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->