### PR TITLE
docs: lay hero tiles out in even columns when the hero stacks

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -811,12 +811,15 @@
     text-align: center;
   }
 
+  /* The stacked hero centers its column, so the text block is shrink-to-fit and
+     would otherwise be widened past the viewport by the tile grid below. */
   .usage-hero-text {
     text-align: center;
+    align-self: stretch;
+    min-width: 0;
   }
 
-  .usage-hero-actions,
-  .usage-hero-tiles {
+  .usage-hero-actions {
     justify-content: center;
   }
 
@@ -824,6 +827,26 @@
   .usage-hero-desc {
     margin-left: auto;
     margin-right: auto;
+  }
+
+  /* Once the hero stacks, wrapping leaves ragged trailing rows. Even columns
+     keep the tiles aligned at every count. The floor clears the widest tile
+     ("Rust" plus its pill), so phones drop to one column rather than squeezing
+     a label against its pill. */
+  .usage-hero-tiles {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(208px, 1fr));
+    width: 100%;
+    max-width: 440px;
+  }
+
+  .usage-hero-tiles .usage-tile {
+    justify-content: center;
+  }
+
+  /* An odd tile count would otherwise leave the last one alone in a column. */
+  .usage-hero-tiles > :last-child:nth-child(odd) {
+    grid-column: 1 / -1;
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The home page hero tiles wrap in a flexbox, so once the hero stacks and centers its column the rows come out ragged — three frameworks then a lone JavaScript, four tools then a lone `usage-cli`.

Below 960px the tile groups now use a grid instead. Columns are even, so every row lines up at any tile count, and an odd last tile spans the row rather than sitting alone in one column.

## Details

- The column floor is 208px, just past the widest tile (`Rust` plus its `experimental` pill, measured at 201px), so phones fall back to one column instead of squeezing a label against its pill. Two columns from about 450px up, one below.
- `.usage-hero-text` gets `align-self: stretch` and `min-width: 0`. The stacked hero centers its column, which makes the text block shrink-to-fit; without this the grid widens it past the viewport and `overflow-x: clip` on the hero cuts the tiles off at both edges.
- Desktop above 960px is untouched: the hero is still two columns with left-aligned tiles, where wrapping reads naturally.

## Verification

Built the site and measured tiles per row over CDP at each width. Before: `[[3,1],[4,1]]` at 900px and 600px. After: `[[2,2],[2,2,1]]` at 900px and 600px, `[[1,1,1,1],[1,1,1,1,1]]` at 430px. No horizontal document overflow at 320, 375, 430, 480, 600, 900, or 961px.

Before, at 900px:

[Hero tiles wrapping into ragged rows of three and four](https://cursor.com/agents/bc-e0b65075-0c8a-4d91-81fe-7fb60fb9ba2d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhero_tiles_before_900.png)

After, at 900px:

[Hero tiles in even two-column rows with usage-cli spanning the last row](https://cursor.com/agents/bc-e0b65075-0c8a-4d91-81fe-7fb60fb9ba2d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhero_tiles_after_900.png)

After, at 430px:

[Hero tiles in a single column on a phone-width viewport](https://cursor.com/agents/bc-e0b65075-0c8a-4d91-81fe-7fb60fb9ba2d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhero_tiles_after_430.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0b65075-0c8a-4d91-81fe-7fb60fb9ba2d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0b65075-0c8a-4d91-81fe-7fb60fb9ba2d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive hero layouts for screens up to 960px wide.
  * Centered hero actions and tiles for better visual alignment.
  * Updated tile grids to handle narrow screens and odd numbers of tiles more cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->