### PR TITLE
fix(cli): color interpreted help output

### DIFF
--- a/cli/src/cli/exec.rs
+++ b/cli/src/cli/exec.rs
@@ -35,7 +35,15 @@ pub struct Exec {
 impl Exec {
     pub fn help(&self, spec: &Spec, args: &[String], long: bool) -> usage::miette::Result<()> {
         let parsed = usage::parse::parse_partial(spec, args)?;
-        println!("{}", usage::docs::cli::render_help(spec, &parsed.cmd, long));
+        print!(
+            "{}",
+            usage::docs::cli::render_help_styled(
+                spec,
+                &parsed.cmd,
+                long,
+                usage::docs::cli::Style::auto(),
+            )
+        );
         Ok(())
     }
 }

--- a/cli/src/cli/mod.rs
+++ b/cli/src/cli/mod.rs
@@ -131,13 +131,22 @@ impl Cli {
             Ok(cli) => cli,
             // Not failures: someone asked a question, and the answer goes to stdout.
             Err(usage_rs::Error::Help { cmd, long }) => {
-                if let Some(page) = usage_rs::help::render(Self::spec(), cmd, long) {
+                if let Some(page) = usage_rs::help::render_styled(
+                    Self::spec(),
+                    cmd,
+                    long,
+                    usage_rs::help::Style::auto(),
+                ) {
                     print!("{page}");
                 }
                 return Ok(());
             }
             Err(usage_rs::Error::HelpAll { cmd }) => {
-                if let Some(page) = usage_rs::help::render_all(Self::spec(), cmd) {
+                if let Some(page) = usage_rs::help::render_all_styled(
+                    Self::spec(),
+                    cmd,
+                    usage_rs::help::Style::auto(),
+                ) {
                     print!("{page}");
                 }
                 return Ok(());

--- a/cli/src/cli/shell.rs
+++ b/cli/src/cli/shell.rs
@@ -143,7 +143,15 @@ impl Shell {
 
     pub fn help(&self, spec: &Spec, args: &[String], long: bool) -> usage::miette::Result<()> {
         let parsed = usage::parse::parse_partial(spec, args)?;
-        println!("{}", usage::docs::cli::render_help(spec, &parsed.cmd, long));
+        print!(
+            "{}",
+            usage::docs::cli::render_help_styled(
+                spec,
+                &parsed.cmd,
+                long,
+                usage::docs::cli::Style::auto(),
+            )
+        );
         Ok(())
     }
 }

--- a/cli/tests/examples.rs
+++ b/cli/tests/examples.rs
@@ -1,5 +1,6 @@
 use assert_cmd::cargo;
 use assert_cmd::prelude::*;
+use predicates::prelude::PredicateBooleanExt;
 use predicates::str::contains;
 use std::process::Command;
 
@@ -56,6 +57,39 @@ fn test_new_usage_syntax_with_space() {
         .stdout(contains("Option value"))
         .stdout(contains("baz"))
         .stdout(contains("Positional value"));
+}
+
+#[test]
+fn shell_help_honours_terminal_colour_environment() {
+    let mut coloured = Command::new(cargo::cargo_bin!("usage"));
+    coloured
+        .env("NO_COLOR", "")
+        .env("CLICOLOR_FORCE", "1")
+        .args(["bash", "../examples/test-new-usage-syntax.sh", "--help"]);
+    coloured
+        .assert()
+        .success()
+        .stdout(contains("\u{1b}[1;33mUsage:\u{1b}[0m"))
+        .stdout(contains("\u{1b}[1;32m--foo\u{1b}[0m"));
+
+    let mut plain = Command::new(cargo::cargo_bin!("usage"));
+    plain.env("NO_COLOR", "1").env("CLICOLOR_FORCE", "1").args([
+        "bash",
+        "../examples/test-new-usage-syntax.sh",
+        "--help",
+    ]);
+    plain.assert().success().stdout(contains("\u{1b}[").not());
+}
+
+#[test]
+fn usage_own_help_uses_the_process_colour_policy() {
+    let mut cmd = Command::new(cargo::cargo_bin!("usage"));
+    cmd.env("NO_COLOR", "")
+        .env("CLICOLOR_FORCE", "1")
+        .arg("--help");
+    cmd.assert()
+        .success()
+        .stdout(contains("\u{1b}[1;33mUsage:\u{1b}[0m"));
 }
 
 /// Test that the #[USAGE] syntax (no space) works correctly

--- a/conformance/tests/help_template.rs
+++ b/conformance/tests/help_template.rs
@@ -100,6 +100,16 @@ fn the_page_a_compiled_parser_prints_is_the_one_the_reference_renders() {
         coloured.contains("\u{1b}[1;36mSee the docs for more.\u{1b}[0m"),
         "{coloured:?}"
     );
+    assert_eq!(
+        coloured,
+        usage::docs::cli::render_help_styled(
+            &lib,
+            &lib.cmd,
+            false,
+            usage::docs::cli::Style::COLOURED,
+        ),
+        "the reference and compiled terminal renderers should apply identical styles"
+    );
 
     // The sections themselves are untouched by the reordering — a template moves a page's parts
     // and does not rewrite them.
@@ -258,6 +268,15 @@ fn the_two_rust_vocabularies_are_the_same_words() {
         usage_argv::help::Style::COLOURED,
     )
     .expect("every style renders");
+    assert_eq!(
+        coloured,
+        usage::docs::cli::render_help_styled(
+            &portable,
+            &portable.cmd,
+            false,
+            usage::docs::cli::Style::COLOURED,
+        )
+    );
     for style in &canonical {
         assert!(
             coloured.contains(style),

--- a/docs/rust/help.md
+++ b/docs/rust/help.md
@@ -222,6 +222,10 @@ renders the ANSI styles. Plain output and generated Go pages remove the tags whi
 contents. Double the dollar sign to write either delimiter literally: `{$$heading}` renders
 `{$heading}`, and `{/$$}` renders `{/$}`.
 
+The reference renderer keeps `usage::docs::cli::render_help` plain for generated artifacts and
+snapshots. A process printing a dynamically parsed spec should call `render_help_styled` with
+`usage::docs::cli::Style::auto()`; this is the path used by `usage bash` and `usage exec`.
+
 The template applies to the terminal help page. Markdown, manpages, and JSON keep their own
 structure.
 

--- a/lib/src/docs/cli/mod.rs
+++ b/lib/src/docs/cli/mod.rs
@@ -2,7 +2,15 @@ use crate::{Spec, SpecCommand};
 use std::sync::LazyLock;
 use tera::Tera;
 
+mod style;
+pub use style::Style;
+
 pub fn render_help(spec: &Spec, cmd: &SpecCommand, long: bool) -> String {
+    render_help_styled(spec, cmd, long, Style::PLAIN)
+}
+
+/// Render a terminal help page with an explicit colour policy.
+pub fn render_help_styled(spec: &Spec, cmd: &SpecCommand, long: bool, style: Style) -> String {
     // Convert to docs models to get layout calculations
     let docs_spec = crate::docs::models::Spec::from(spec);
     let mut docs_cmd = crate::docs::models::SpecCommand::from(&without_hidden(cmd, long));
@@ -180,13 +188,20 @@ pub fn render_help(spec: &Spec, cmd: &SpecCommand, long: bool) -> String {
     };
     let rendered = TERA.render(template, &ctx).unwrap();
     let sections = Sections::split(&rendered);
+    let styling = style::Styling::new(&docs_cmd, &inherited, sections.usage);
     let page = match spec
         .help_template
         .as_deref()
         .filter(|t| crate::help_template::is_set(t))
     {
-        Some(template) => crate::help_template::substitute(template, |name| sections.named(name)),
-        None => sections.concatenated(),
+        Some(template) => {
+            crate::help_template::substitute_with_style(template, style.coloured, |name| {
+                sections
+                    .named(name)
+                    .map(|section| styling.apply(&section, style))
+            })
+        }
+        None => styling.apply(&sections.concatenated(), style),
     };
     page.trim().to_string() + "\n"
 }
@@ -1977,5 +1992,41 @@ cmd "run" help="Run it" {
                 "{page}"
             );
         }
+    }
+
+    #[test]
+    fn styled_help_colours_semantics_and_template_styles() {
+        let spec = crate::spec! { r#"
+bin "testcli"
+help_template "{$bright-blue}My tool{/$}\n\n{{usage}}\n\n{{flags}}"
+flag "--output <FILE>" help="Write **the file**"
+        "# }
+        .unwrap();
+
+        let plain = render_help(&spec, &spec.cmd, true);
+        assert!(plain.contains("My tool"), "{plain}");
+        assert!(!plain.contains('\u{1b}'), "{plain:?}");
+
+        let coloured = render_help_styled(&spec, &spec.cmd, true, Style::COLOURED);
+        assert!(
+            coloured.contains("\u{1b}[94mMy tool\u{1b}[0m"),
+            "{coloured:?}"
+        );
+        assert!(
+            coloured.contains("\u{1b}[1;33mUsage:\u{1b}[0m"),
+            "{coloured:?}"
+        );
+        assert!(
+            coloured.contains("\u{1b}[1;32m--output\u{1b}[0m"),
+            "{coloured:?}"
+        );
+        assert!(
+            coloured.contains("\u{1b}[1;35m<FILE>\u{1b}[0m"),
+            "{coloured:?}"
+        );
+        assert!(
+            coloured.contains("\u{1b}[1mthe file\u{1b}[22m"),
+            "{coloured:?}"
+        );
     }
 }

--- a/lib/src/docs/cli/style.rs
+++ b/lib/src/docs/cli/style.rs
@@ -1,0 +1,411 @@
+use crate::docs::models::{SpecCommand, SpecFlag};
+
+/// Whether terminal help is rendered with ANSI styling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Style {
+    pub(super) coloured: bool,
+}
+
+impl Style {
+    /// Plain text, suitable for a pipe or generated artifact.
+    pub const PLAIN: Style = Style { coloured: false };
+    /// ANSI-coloured text, regardless of the output destination.
+    pub const COLOURED: Style = Style { coloured: true };
+
+    /// Colour when stdout is a terminal and the environment permits it.
+    pub fn auto() -> Style {
+        use std::io::IsTerminal as _;
+        Self::auto_for(std::io::stdout().is_terminal())
+    }
+
+    fn auto_for(is_terminal: bool) -> Style {
+        let forced = std::env::var_os("CLICOLOR_FORCE").is_some_and(|value| value != "0");
+        let refused = std::env::var_os("NO_COLOR").is_some_and(|value| !value.is_empty());
+        if refused {
+            Style::PLAIN
+        } else if forced || is_terminal {
+            Style::COLOURED
+        } else {
+            Style::PLAIN
+        }
+    }
+
+    fn semantic(self, specification: &str, text: &str) -> String {
+        crate::help_template::semantic(specification, text, self.coloured)
+    }
+
+    fn inline(self, text: &str) -> String {
+        if self.coloured {
+            styled_inline(text, None)
+        } else {
+            text.to_string()
+        }
+    }
+}
+
+pub(super) struct Styling {
+    headings: Vec<String>,
+    flag_usages: Vec<String>,
+    arg_usages: Vec<String>,
+    synopsis: Vec<String>,
+}
+
+impl Styling {
+    pub(super) fn new(
+        command: &SpecCommand,
+        global_flags: &[SpecFlag],
+        usage_section: &str,
+    ) -> Self {
+        let mut headings = vec!["Examples".to_string()];
+        headings.extend(command.subcommand_groups.iter().map(|group| {
+            group
+                .heading
+                .clone()
+                .or_else(|| command.subcommand_help_heading.clone())
+                .unwrap_or_else(|| "Commands".to_string())
+        }));
+        headings.extend(command.arg_groups.iter().map(|group| {
+            group
+                .heading
+                .clone()
+                .unwrap_or_else(|| "Arguments".to_string())
+        }));
+        headings.extend(
+            command
+                .flag_groups
+                .iter()
+                .map(|group| group.heading.clone().unwrap_or_else(|| "Flags".to_string())),
+        );
+        if !global_flags.is_empty() {
+            headings.push("Global flags".to_string());
+        }
+
+        let mut flag_usages = command
+            .flag_groups
+            .iter()
+            .flat_map(|group| group.items.iter())
+            .map(|flag| flag.display_usage.clone())
+            .chain(global_flags.iter().map(|flag| flag.display_usage.clone()))
+            .collect();
+        let mut arg_usages = command
+            .arg_groups
+            .iter()
+            .flat_map(|group| group.items.iter())
+            .map(|arg| arg.usage.trim().to_string())
+            .collect();
+        collect_flattened(
+            &command.flattened_subcommands,
+            &mut headings,
+            &mut flag_usages,
+            &mut arg_usages,
+        );
+        flag_usages.sort_unstable_by_key(|usage| std::cmp::Reverse(usage.len()));
+        arg_usages.sort_unstable_by_key(|usage| std::cmp::Reverse(usage.len()));
+        Self {
+            headings,
+            flag_usages,
+            arg_usages,
+            synopsis: usage_section.lines().map(str::to_string).collect(),
+        }
+    }
+
+    pub(super) fn apply(&self, page: &str, style: Style) -> String {
+        if !style.coloured {
+            return page.to_string();
+        }
+        let mut out = String::with_capacity(page.len());
+        for line in page.split_inclusive('\n') {
+            let (body, newline) = line
+                .strip_suffix('\n')
+                .map_or((line, ""), |body| (body, "\n"));
+            if self.synopsis.iter().any(|known| known == body) && body.starts_with("Usage:") {
+                let usage = body.strip_prefix("Usage:").unwrap_or_default();
+                out.push_str(&style.semantic("heading", "Usage:"));
+                out.push_str(&styled_usage(usage, style));
+            } else if self.synopsis.iter().any(|known| known == body) {
+                out.push_str(&styled_usage(body, style));
+            } else if body
+                .strip_suffix(':')
+                .is_some_and(|heading| self.headings.iter().any(|known| known == heading))
+            {
+                out.push_str(&style.semantic("heading", body));
+            } else {
+                let styled = body.strip_prefix("  ").and_then(|entry| {
+                    self.flag_usages
+                        .iter()
+                        .find_map(|usage| style_entry(entry, usage, style))
+                        .or_else(|| {
+                            self.arg_usages
+                                .iter()
+                                .find_map(|usage| style_entry(entry, usage, style))
+                        })
+                });
+                let body = styled.as_deref().unwrap_or(body);
+                if body.trim_start().starts_with("$ ") {
+                    out.push_str(body);
+                } else {
+                    out.push_str(&style.inline(body));
+                }
+            }
+            out.push_str(newline);
+        }
+        out
+    }
+}
+
+fn collect_flattened(
+    commands: &[SpecCommand],
+    headings: &mut Vec<String>,
+    flags: &mut Vec<String>,
+    args: &mut Vec<String>,
+) {
+    for command in commands {
+        headings.push(command.full_cmd.join(" "));
+        flags.extend(
+            command
+                .flag_groups
+                .iter()
+                .flat_map(|group| group.items.iter())
+                .map(|flag| flag.display_usage.clone()),
+        );
+        args.extend(
+            command
+                .arg_groups
+                .iter()
+                .flat_map(|group| group.items.iter())
+                .map(|arg| arg.usage.trim().to_string()),
+        );
+        collect_flattened(&command.flattened_subcommands, headings, flags, args);
+    }
+}
+
+fn style_entry(entry: &str, usage: &str, style: Style) -> Option<String> {
+    entry
+        .strip_prefix(usage)
+        .filter(|rest| rest.is_empty() || rest.starts_with(char::is_whitespace))
+        .map(|rest| format!("  {}{rest}", styled_usage(usage, style)))
+}
+
+fn styled_usage(usage: &str, style: Style) -> String {
+    let mut out = String::with_capacity(usage.len());
+    let mut at = 0;
+    while at < usage.len() {
+        let rest = &usage[at..];
+        let previous = usage[..at].chars().next_back();
+        if rest.starts_with('-')
+            && previous.is_none_or(|c| c.is_whitespace() || matches!(c, ',' | ':' | '[' | '<'))
+        {
+            let end = rest
+                .char_indices()
+                .skip(1)
+                .find_map(|(index, c)| {
+                    (c.is_whitespace() || matches!(c, ',' | '=' | '[' | ']' | '<' | '>'))
+                        .then_some(index)
+                })
+                .unwrap_or(rest.len());
+            out.push_str(&style.semantic("option", &rest[..end]));
+            at += end;
+            continue;
+        }
+        if rest.starts_with("<-") {
+            out.push('<');
+            at += 1;
+            continue;
+        }
+        if rest.starts_with('<') {
+            if let Some(end) = rest.find('>') {
+                let end = end + 1;
+                out.push_str(&style.semantic("metavar", &rest[..end]));
+                at += end;
+                continue;
+            }
+        }
+        if let Some(value) = rest.strip_prefix("[=") {
+            if let Some(end) = value.find(']') {
+                out.push_str("[=");
+                out.push_str(&style.semantic("metavar", &value[..end]));
+                out.push(']');
+                at += end + 3;
+                continue;
+            }
+        }
+        if let Some(value) = rest.strip_prefix('=') {
+            out.push('=');
+            at += 1;
+            if !value.starts_with('<') {
+                let end = value
+                    .find(|c: char| c.is_whitespace() || matches!(c, ',' | ']' | '>'))
+                    .unwrap_or(value.len());
+                if end > 0 {
+                    out.push_str(&style.semantic("metavar", &value[..end]));
+                    at += end;
+                }
+            }
+            continue;
+        }
+        if previous == Some('[') && !rest.starts_with('-') {
+            let end = rest.find(']').unwrap_or(rest.len());
+            if end > 0 {
+                out.push_str(&style.semantic("metavar", &rest[..end]));
+                at += end;
+                continue;
+            }
+        }
+        if rest.starts_with(|c: char| c.is_ascii_uppercase())
+            && previous.is_none_or(|c| c.is_whitespace() || matches!(c, '=' | '[' | '<'))
+        {
+            let end = rest
+                .find(|c: char| {
+                    !(c.is_ascii_uppercase() || c.is_ascii_digit() || matches!(c, '_' | '-' | '@'))
+                })
+                .unwrap_or(rest.len());
+            let boundary = rest[end..].chars().next();
+            if boundary.is_none_or(|c| {
+                c.is_whitespace() || matches!(c, ',' | '=' | '[' | ']' | '<' | '>' | '.')
+            }) {
+                out.push_str(&style.semantic("metavar", &rest[..end]));
+                at += end;
+                continue;
+            }
+        }
+        let ch = rest.chars().next().expect("at is on a character boundary");
+        out.push(ch);
+        at += ch.len_utf8();
+    }
+    out
+}
+
+fn styled_inline(text: &str, parent: Option<&str>) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut at = 0;
+    let mut allow_run_remainder = false;
+    while at < text.len() {
+        let rest = &text[at..];
+        if let Some(escaped) = rest
+            .strip_prefix('\\')
+            .and_then(|after| after.chars().next())
+        {
+            if matches!(escaped, '*' | '_' | '~' | '`' | '\\') {
+                out.push(escaped);
+                at += 1 + escaped.len_utf8();
+                allow_run_remainder = false;
+                continue;
+            }
+        }
+        let span = [
+            ("***", "1;3", "22;23", false, true),
+            ("___", "1;3", "22;23", true, true),
+            ("**", "1", "22", false, true),
+            ("__", "1", "22", true, true),
+            ("~~", "9", "29", false, true),
+            ("*", "3", "23", false, true),
+            ("_", "3", "23", true, true),
+            ("`", "36", "39", false, false),
+        ]
+        .into_iter()
+        .find_map(|(delimiter, open, close, word_boundary, recurse)| {
+            rest.strip_prefix(delimiter)?;
+            let marker = delimiter.chars().next()?;
+            let previous = text[..at].chars().next_back();
+            if (previous == Some(marker) && !allow_run_remainder)
+                || (delimiter.len() == 1 && rest[delimiter.len()..].starts_with(marker))
+                || (word_boundary && previous.is_some_and(char::is_alphanumeric))
+            {
+                return None;
+            }
+            let content_start = at + delimiter.len();
+            let (end, after) = closing_delimiter(text, content_start, delimiter, word_boundary, 0)?;
+            Some((delimiter, open, close, recurse, content_start, end, after))
+        });
+        if let Some((delimiter, open, close, recurse, content_start, end, after)) = span {
+            out.push_str("\u{1b}[");
+            out.push_str(open);
+            out.push('m');
+            if recurse {
+                out.push_str(&styled_inline(&text[content_start..end], Some(open)));
+            } else {
+                out.push_str(&text[content_start..end]);
+            }
+            out.push_str("\u{1b}[");
+            out.push_str(close);
+            out.push('m');
+            if let Some(parent) = parent {
+                out.push_str("\u{1b}[");
+                out.push_str(parent);
+                out.push('m');
+            }
+            let marker = delimiter.chars().next().expect("a delimiter has a marker");
+            allow_run_remainder =
+                text[after..].starts_with(marker) && text[..after].ends_with(marker);
+            at = after;
+            continue;
+        }
+        let ch = rest.chars().next().expect("at is on a character boundary");
+        out.push(ch);
+        at += ch.len_utf8();
+        allow_run_remainder = false;
+    }
+    out
+}
+
+fn closing_delimiter(
+    text: &str,
+    content_start: usize,
+    delimiter: &str,
+    word_boundary: bool,
+    reserve: usize,
+) -> Option<(usize, usize)> {
+    let marker = delimiter.chars().next()?;
+    let width = delimiter.len();
+    let mut search_at = content_start;
+    while let Some(found) = text[search_at..].find(marker) {
+        let run_start = search_at + found;
+        let run_len = text[run_start..]
+            .chars()
+            .take_while(|ch| *ch == marker)
+            .count();
+        let run_end = run_start + run_len;
+        let escaped = text[..run_start]
+            .chars()
+            .rev()
+            .take_while(|ch| *ch == '\\')
+            .count()
+            % 2
+            == 1;
+        if escaped {
+            search_at = run_start + marker.len_utf8();
+            continue;
+        }
+        let nested_width = match (run_len, marker) {
+            (1..=3, '*' | '_') if run_len != width => run_len,
+            _ => 0,
+        };
+        if nested_width != 0 {
+            let nested = &text[run_start..run_start + nested_width];
+            if let Some((_, after)) =
+                closing_delimiter(text, run_start + nested_width, nested, marker == '_', width)
+            {
+                search_at = after;
+                continue;
+            }
+        }
+        if run_len >= width {
+            let after = run_start + width;
+            let left_in_run = run_end - after;
+            let boundary_ok = !word_boundary
+                || !text[after..]
+                    .chars()
+                    .next()
+                    .is_some_and(char::is_alphanumeric);
+            if run_start > content_start
+                && !text[content_start..run_start].trim().is_empty()
+                && (left_in_run == 0 || left_in_run >= reserve)
+                && boundary_ok
+            {
+                return Some((run_start, after));
+            }
+        }
+        search_at = run_end;
+    }
+    None
+}

--- a/lib/src/help_template.rs
+++ b/lib/src/help_template.rs
@@ -147,6 +147,7 @@ impl AnsiStyle {
     }
 }
 
+#[cfg(feature = "cli-help")]
 pub(crate) fn semantic(specification: &str, text: &str, coloured: bool) -> String {
     if !coloured {
         return text.to_string();

--- a/lib/src/help_template.rs
+++ b/lib/src/help_template.rs
@@ -63,6 +63,104 @@ pub const STYLES: [&str; 23] = [
     "underline",
 ];
 
+const MARK: char = '\u{2}';
+const END: char = '\u{3}';
+
+#[derive(Clone, Copy, Default)]
+struct AnsiStyle {
+    foreground: Option<u8>,
+    bold: bool,
+    dim: bool,
+    italic: bool,
+    underline: bool,
+}
+
+impl AnsiStyle {
+    fn apply(mut self, specification: &str) -> Option<Self> {
+        if specification.is_empty() {
+            return None;
+        }
+        for fragment in specification.split('+') {
+            match fragment {
+                "heading" => {
+                    self.foreground = Some(33);
+                    self.bold = true;
+                }
+                "option" => {
+                    self.foreground = Some(32);
+                    self.bold = true;
+                }
+                "metavar" => {
+                    self.foreground = Some(35);
+                    self.bold = true;
+                }
+                "black" => self.foreground = Some(30),
+                "red" => self.foreground = Some(31),
+                "green" => self.foreground = Some(32),
+                "yellow" => self.foreground = Some(33),
+                "blue" => self.foreground = Some(34),
+                "magenta" => self.foreground = Some(35),
+                "cyan" => self.foreground = Some(36),
+                "white" => self.foreground = Some(37),
+                "bright-black" => self.foreground = Some(90),
+                "bright-red" => self.foreground = Some(91),
+                "bright-green" => self.foreground = Some(92),
+                "bright-yellow" => self.foreground = Some(93),
+                "bright-blue" => self.foreground = Some(94),
+                "bright-magenta" => self.foreground = Some(95),
+                "bright-cyan" => self.foreground = Some(96),
+                "bright-white" => self.foreground = Some(97),
+                "bold" => self.bold = true,
+                "dim" => self.dim = true,
+                "italic" => self.italic = true,
+                "underline" => self.underline = true,
+                _ => return None,
+            }
+        }
+        Some(self)
+    }
+
+    fn write(self, out: &mut String) {
+        let mut separator = "";
+        out.push_str("\u{1b}[");
+        for (enabled, code) in [
+            (self.bold, 1),
+            (self.dim, 2),
+            (self.italic, 3),
+            (self.underline, 4),
+        ] {
+            if enabled {
+                out.push_str(separator);
+                out.push_str(&code.to_string());
+                separator = ";";
+            }
+        }
+        if let Some(foreground) = self.foreground {
+            out.push_str(separator);
+            out.push_str(&foreground.to_string());
+            separator = ";";
+        }
+        if separator.is_empty() {
+            out.push('0');
+        }
+        out.push('m');
+    }
+}
+
+pub(crate) fn semantic(specification: &str, text: &str, coloured: bool) -> String {
+    if !coloured {
+        return text.to_string();
+    }
+    let mut out = String::with_capacity(text.len() + 16);
+    AnsiStyle::default()
+        .apply(specification)
+        .unwrap_or_default()
+        .write(&mut out);
+    out.push_str(text);
+    AnsiStyle::default().write(&mut out);
+    out
+}
+
 /// Whether a template is one an author wrote, rather than an empty or whitespace-only
 /// string that should render as the default page.
 ///
@@ -113,56 +211,70 @@ pub fn check(template: &str) -> Result<(), String> {
 /// most have no examples — so a template is written with the separators a full page wants and
 /// the empty sections are what [`collapse_blank_runs`] then takes back out.
 pub fn substitute(template: &str, section: impl Fn(&str) -> Option<String>) -> String {
+    substitute_with_style(template, false, section)
+}
+
+pub(crate) fn substitute_with_style(
+    template: &str,
+    coloured: bool,
+    section: impl FnMut(&str) -> Option<String>,
+) -> String {
     if check_styles(template).is_err() {
         return substitute_sections_only(template, section);
     }
-    let mut out = String::with_capacity(template.len());
+    let mut marked = String::with_capacity(template.len());
     let mut rest = template;
+    let mut section = section;
     loop {
-        let placeholder = rest.find("{{").map(|at| (at, 0));
-        let style = next_style_event(rest).map(|(at, event)| (at, event as u8 + 1));
-        let Some((at, kind)) = [placeholder, style]
-            .into_iter()
-            .flatten()
-            .min_by_key(|(at, _)| *at)
-        else {
-            out.push_str(rest);
+        let placeholder = rest.find("{{").map(|at| (at, Event::Placeholder));
+        let style = next_style_event(rest);
+        let Some((at, event)) = earliest(placeholder, style) else {
+            push_escaped(&mut marked, rest);
             break;
         };
-        out.push_str(&rest[..at]);
+        push_escaped(&mut marked, &rest[..at]);
         rest = &rest[at..];
-        match kind {
-            0 => {
+        match event {
+            Event::Placeholder => {
                 let after = &rest[2..];
                 let Some(end) = after.find("}}") else {
-                    out.push_str(rest);
+                    push_escaped(&mut marked, rest);
                     break;
                 };
                 match section(after[..end].trim()) {
-                    Some(text) => out.push_str(&text),
-                    None => out.push_str(&rest[..2 + end + 2]),
+                    Some(text) => push_escaped(&mut marked, &text),
+                    None => push_escaped(&mut marked, &rest[..2 + end + 2]),
                 }
                 rest = &after[end + 2..];
             }
-            1 => {
+            Event::Open => {
                 let Some(end) = rest.find('}') else {
-                    out.push_str(rest);
+                    push_escaped(&mut marked, rest);
                     break;
                 };
+                marked.push(MARK);
+                marked.push('+');
+                marked.push_str(&rest[2..end]);
+                marked.push(END);
                 rest = &rest[end + 1..];
             }
-            2 => rest = &rest[4..],
-            3 => {
-                out.push_str("{$");
+            Event::Close => {
+                marked.push(MARK);
+                marked.push('-');
+                marked.push(END);
+                rest = &rest[4..];
+            }
+            Event::EscapeOpen => {
+                push_escaped(&mut marked, "{$");
                 rest = &rest[3..];
             }
-            _ => {
-                out.push_str("{/$}");
+            Event::EscapeClose => {
+                push_escaped(&mut marked, "{/$}");
                 rest = &rest[5..];
             }
         }
     }
-    collapse_blank_runs(&out)
+    render_marked(&collapse_styled_blank_runs(&marked), coloured)
 }
 
 fn check_styles(template: &str) -> Result<(), String> {
@@ -171,9 +283,9 @@ fn check_styles(template: &str) -> Result<(), String> {
     while let Some((at, event)) = next_style_event(rest) {
         let tag = &rest[at..];
         match event {
-            StyleEvent::EscapeOpen => rest = &tag[3..],
-            StyleEvent::EscapeClose => rest = &tag[5..],
-            StyleEvent::Open => {
+            Event::EscapeOpen => rest = &tag[3..],
+            Event::EscapeClose => rest = &tag[5..],
+            Event::Open => {
                 let Some(end) = tag.find('}') else {
                     return Err("help_template has a `{$` with no `}` after it".to_string());
                 };
@@ -193,13 +305,14 @@ fn check_styles(template: &str) -> Result<(), String> {
                 depth += 1;
                 rest = &tag[end + 1..];
             }
-            StyleEvent::Close => {
+            Event::Close => {
                 if depth == 0 {
                     return Err("help_template has a `{/$}` with no open style tag".to_string());
                 }
                 depth -= 1;
                 rest = &tag[4..];
             }
+            Event::Placeholder => unreachable!("style scanning does not return placeholders"),
         }
     }
     if depth == 0 {
@@ -210,19 +323,27 @@ fn check_styles(template: &str) -> Result<(), String> {
 }
 
 #[derive(Clone, Copy)]
-enum StyleEvent {
-    Open = 0,
-    Close = 1,
-    EscapeOpen = 2,
-    EscapeClose = 3,
+enum Event {
+    Placeholder,
+    Open,
+    Close,
+    EscapeOpen,
+    EscapeClose,
 }
 
-fn next_style_event(template: &str) -> Option<(usize, StyleEvent)> {
+fn earliest(left: Option<(usize, Event)>, right: Option<(usize, Event)>) -> Option<(usize, Event)> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(if left.0 <= right.0 { left } else { right }),
+        (left, right) => left.or(right),
+    }
+}
+
+fn next_style_event(template: &str) -> Option<(usize, Event)> {
     [
-        ("{$$", StyleEvent::EscapeOpen),
-        ("{/$$}", StyleEvent::EscapeClose),
-        ("{$", StyleEvent::Open),
-        ("{/$}", StyleEvent::Close),
+        ("{$$", Event::EscapeOpen),
+        ("{/$$}", Event::EscapeClose),
+        ("{$", Event::Open),
+        ("{/$}", Event::Close),
     ]
     .into_iter()
     .enumerate()
@@ -231,7 +352,172 @@ fn next_style_event(template: &str) -> Option<(usize, StyleEvent)> {
     .map(|((at, _), event)| (at, event))
 }
 
-fn substitute_sections_only(template: &str, section: impl Fn(&str) -> Option<String>) -> String {
+fn push_escaped(out: &mut String, text: &str) {
+    if !text.contains(MARK) {
+        out.push_str(text);
+        return;
+    }
+    for ch in text.chars() {
+        out.push(ch);
+        if ch == MARK {
+            out.push(MARK);
+        }
+    }
+}
+
+fn collapse_styled_blank_runs(page: &str) -> String {
+    let mut out = String::with_capacity(page.len());
+    let mut blank = false;
+    let mut wrote_visible = false;
+    for line in page.split('\n') {
+        if visible_is_blank(line) {
+            push_markers(&mut out, line);
+            blank = wrote_visible;
+            continue;
+        }
+        if wrote_visible {
+            out.push('\n');
+            if blank {
+                out.push('\n');
+            }
+        }
+        blank = false;
+        out.push_str(line);
+        wrote_visible = true;
+    }
+    out
+}
+
+fn visible_is_blank(line: &str) -> bool {
+    let mut rest = line;
+    while let Some(at) = rest.find(MARK) {
+        if !rest[..at].trim().is_empty() {
+            return false;
+        }
+        let after = &rest[at + MARK.len_utf8()..];
+        if after.starts_with(MARK) {
+            return false;
+        } else if let Some(end) = after.find(END) {
+            rest = &after[end + END.len_utf8()..];
+        } else {
+            return false;
+        }
+    }
+    rest.trim().is_empty()
+}
+
+fn push_markers(out: &mut String, line: &str) {
+    let mut rest = line;
+    while let Some(at) = rest.find(MARK) {
+        let marker = &rest[at..];
+        let Some(end) = marker.find(END) else {
+            return;
+        };
+        out.push_str(&marker[..=end]);
+        rest = &marker[end + END.len_utf8()..];
+    }
+}
+
+fn render_marked(marked: &str, coloured: bool) -> String {
+    let mut out = String::with_capacity(marked.len());
+    let mut stack = vec![AnsiStyle::default()];
+    let mut rest = marked;
+    while let Some(at) = rest.find(MARK) {
+        push_content(
+            &mut out,
+            &rest[..at],
+            coloured,
+            stack.last().copied().unwrap_or_default(),
+        );
+        let after = &rest[at + MARK.len_utf8()..];
+        if after.starts_with(MARK) {
+            out.push(MARK);
+            rest = &after[MARK.len_utf8()..];
+            continue;
+        }
+        let Some(end) = after.find(END) else {
+            out.push(MARK);
+            out.push_str(after);
+            break;
+        };
+        let marker = &after[..end];
+        if let Some(specification) = marker.strip_prefix('+') {
+            let next = stack
+                .last()
+                .copied()
+                .unwrap_or_default()
+                .apply(specification)
+                .unwrap_or_default();
+            stack.push(next);
+            if coloured {
+                next.write(&mut out);
+            }
+        } else {
+            if stack.len() > 1 {
+                stack.pop();
+            }
+            if coloured {
+                AnsiStyle::default().write(&mut out);
+                let parent = stack.last().copied().unwrap_or_default();
+                if parent.foreground.is_some()
+                    || parent.bold
+                    || parent.dim
+                    || parent.italic
+                    || parent.underline
+                {
+                    parent.write(&mut out);
+                }
+            }
+        }
+        rest = &after[end + END.len_utf8()..];
+    }
+    push_content(
+        &mut out,
+        rest,
+        coloured,
+        stack.last().copied().unwrap_or_default(),
+    );
+    out
+}
+
+fn push_content(out: &mut String, text: &str, coloured: bool, active: AnsiStyle) {
+    if !coloured
+        || (!active.bold
+            && !active.dim
+            && !active.italic
+            && !active.underline
+            && active.foreground.is_none())
+    {
+        out.push_str(text);
+        return;
+    }
+    let mut rest = text;
+    while let Some(at) = rest.find("\u{1b}[") {
+        out.push_str(&rest[..at]);
+        let sequence = &rest[at..];
+        let Some(end) = sequence.find('m') else {
+            out.push_str(sequence);
+            return;
+        };
+        out.push_str(&sequence[..=end]);
+        let parameters = &sequence[2..end];
+        if parameters.split(';').any(|parameter| {
+            matches!(
+                parameter,
+                "" | "0" | "22" | "23" | "24" | "25" | "27" | "28" | "29" | "39" | "49"
+            )
+        }) {
+            active.write(out);
+        }
+        rest = &sequence[end + 1..];
+    }
+    out.push_str(rest);
+}
+
+fn substitute_sections_only(
+    template: &str,
+    mut section: impl FnMut(&str) -> Option<String>,
+) -> String {
     let mut out = String::with_capacity(template.len());
     let mut rest = template;
     while let Some(at) = rest.find("{{") {


### PR DESCRIPTION
## Summary

- add terminal-aware semantic styling to the usage-lib help renderer while preserving its plain rendering API
- make usage bash, usage exec, and the usage CLI own help honor TTY, CLICOLOR_FORCE, and NO_COLOR
- verify exact styled-output parity with usage-argv, including help_template styles

Addresses https://github.com/jdx/usage/discussions/1306.

## Tests

- cargo test --all --all-features
- cargo clippy --all --all-features --all-targets -- -D warnings
- cargo fmt --all -- --check
- prettier -c docs/rust/help.md

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect help text formatting only; plain rendering is unchanged and colour is gated by explicit style or auto-detected terminal policy.
> 
> **Overview**
> Terminal help from **usage-lib** can now be rendered with ANSI semantic styling (headings, options, metvars, inline markdown, and `help_template` `{$…}` tags) via **`render_help_styled`**, while **`render_help`** stays plain for snapshots and generated artifacts.
> 
> **`Style::auto()`** picks colour when stdout is a TTY and respects **`NO_COLOR`** / **`CLICOLOR_FORCE`**. The **usage** CLI, **`usage bash`**, and **`usage exec`** now print help through the styled path instead of plain text.
> 
> Template substitution gained a styled pipeline (`substitute_with_style`) so custom layouts keep their colour tags when enabled. Conformance and CLI tests assert parity with **usage-argv** and verify environment-driven colour on/off behaviour.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1763bbbf1366a984e6f94bcc03911df87a845d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added styled, colour-aware help output for CLI commands.
  * Help styling respects terminal settings, including `CLICOLOR_FORCE` and `NO_COLOR`.
  * Added styling for headings, options, values, descriptions, and formatted text in custom templates.
  * Plain help output remains available when styling is disabled.

* **Documentation**
  * Documented when to use plain versus styled help rendering.

* **Tests**
  * Added coverage for colour handling and consistency between help renderers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->