### PR TITLE
chore: release v6.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [6.4.1](https://github.com/jdx/usage/compare/v6.4.0..v6.4.1) - 2026-08-26
+
+### 🐛 Bug Fixes
+
+- **(cli)** color interpreted help output by [@jdx](https://github.com/jdx) in [#1309](https://github.com/jdx/usage/pull/1309)
+- **(docs)** omit hidden commands from markdown by [@jdx](https://github.com/jdx) in [#1315](https://github.com/jdx/usage/pull/1315)
+- **(parse)** require opt-in for negative flag values by [@jdx](https://github.com/jdx) in [#1317](https://github.com/jdx/usage/pull/1317)
+- **(parse)** align negative values across parse phases by [@jdx](https://github.com/jdx) in [#1318](https://github.com/jdx/usage/pull/1318)
+- simplify required-unless predicates by [@jdx](https://github.com/jdx) in [#1326](https://github.com/jdx/usage/pull/1326)
+
+### 🔍 Other Changes
+
+- **(sponsors)** replace 37signals with omacom foundation by [@jdx](https://github.com/jdx) in [#1324](https://github.com/jdx/usage/pull/1324)
+- lower published crate msrv to 1.91 by [@jdx](https://github.com/jdx) in [#1314](https://github.com/jdx/usage/pull/1314)
+
+### 📦️ Dependency Updates
+
+- update rust crate winnow to v1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1313](https://github.com/jdx/usage/pull/1313)
+
 ## [6.4.0](https://github.com/jdx/usage/compare/v6.3.0..v6.4.0) - 2026-08-24
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2012,11 +2012,11 @@ checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "usage-argv"
-version = "6.4.0"
+version = "6.4.1"
 
 [[package]]
 name = "usage-cli"
-version = "6.4.0"
+version = "6.4.1"
 dependencies = [
  "assert_cmd",
  "ctor",
@@ -2043,7 +2043,7 @@ dependencies = [
 
 [[package]]
 name = "usage-config"
-version = "6.4.0"
+version = "6.4.1"
 dependencies = [
  "serde_json",
  "toml",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "usage-derive"
-version = "6.4.0"
+version = "6.4.1"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2079,7 +2079,7 @@ dependencies = [
 
 [[package]]
 name = "usage-dynamic"
-version = "6.4.0"
+version = "6.4.1"
 dependencies = [
  "futures",
  "usage-argv",
@@ -2089,7 +2089,7 @@ dependencies = [
 
 [[package]]
 name = "usage-lib"
-version = "6.4.0"
+version = "6.4.1"
 dependencies = [
  "clap",
  "criterion",
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "usage-rs"
-version = "6.4.0"
+version = "6.4.1"
 dependencies = [
  "serde",
  "shell-words",
@@ -2131,14 +2131,14 @@ dependencies = [
 
 [[package]]
 name = "usage-test"
-version = "6.4.0"
+version = "6.4.1"
 dependencies = [
  "usage-argv",
 ]
 
 [[package]]
 name = "usage-validation"
-version = "6.4.0"
+version = "6.4.1"
 dependencies = [
  "expr-lang",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,20 +42,20 @@ license = "MIT"
 [workspace.dependencies]
 clap_usage = { path = "./clap_usage", version = "5.0.0" }
 usage-cli = { path = "./cli" }
-usage-argv = { path = "./argv", version = "6.4.0" }
-usage-config = { path = "./config", version = "6.4.0" }
-usage-derive = { path = "./derive", version = "6.4.0" }
+usage-argv = { path = "./argv", version = "6.4.1" }
+usage-config = { path = "./config", version = "6.4.1" }
+usage-derive = { path = "./derive", version = "6.4.1" }
 # No features, and defaults off. A feature named here is inherited by every member that writes
 # `workspace = true` and inlines into their published manifests — so `clap` and `validation`
 # reached members that use neither, one of them an adopter's build script. Defaults
 # are off rather than absent because cargo *ignores* a member's `default-features = false` unless
 # the workspace declaration sets it too, and warns that it may become a hard error. Members name
 # what they need, `docs` included.
-usage-lib = { path = "./lib", version = "6.4.0", default-features = false }
-usage-rs = { path = "./usage-rs", version = "6.4.0" }
-usage-dynamic = { path = "./usage-dynamic", version = "6.4.0" }
-usage-test = { path = "./test", version = "6.4.0" }
-usage-validation = { path = "./validation", version = "6.4.0" }
+usage-lib = { path = "./lib", version = "6.4.1", default-features = false }
+usage-rs = { path = "./usage-rs", version = "6.4.1" }
+usage-dynamic = { path = "./usage-dynamic", version = "6.4.1" }
+usage-test = { path = "./test", version = "6.4.1" }
+usage-validation = { path = "./validation", version = "6.4.1" }
 
 [workspace.metadata.release]
 allow-branch = ["main"]

--- a/argv/Cargo.toml
+++ b/argv/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-argv"
 description = "Zero-allocation argv parser for usage specs"
-version = "6.4.0"
+version = "6.4.1"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }

--- a/aube-lock.yaml
+++ b/aube-lock.yaml
@@ -14,16 +14,16 @@ importers:
     devDependencies:
       '@fig/eslint-config-autocomplete':
         specifier: ^2.0.0
-        version: 2.0.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.9.1)(typescript@7.0.2))(eslint@10.9.1)(typescript@7.0.2))(@typescript-eslint/parser@7.18.0(eslint@10.9.1)(typescript@7.0.2))(@withfig/eslint-plugin-fig-linter@1.4.1)(eslint@10.9.1)(eslint-plugin-compat@4.2.0(eslint@10.9.1))(typescript@7.0.2)
+        version: 2.0.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.9.1)(typescript@4.9.5))(eslint@10.9.1)(typescript@4.9.5))(@typescript-eslint/parser@7.18.0(eslint@10.9.1)(typescript@4.9.5))(@withfig/eslint-plugin-fig-linter@1.4.1)(eslint@10.9.1)(eslint-plugin-compat@4.2.0(eslint@10.9.1))(typescript@4.9.5)
       '@tsconfig/node24':
         specifier: ^24.0.5
         version: 24.0.5
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.0.0
-        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.9.1)(typescript@7.0.2))(eslint@10.9.1)(typescript@7.0.2)
+        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.9.1)(typescript@4.9.5))(eslint@10.9.1)(typescript@4.9.5)
       '@typescript-eslint/parser':
         specifier: ^7.0.0
-        version: 7.18.0(eslint@10.9.1)(typescript@7.0.2)
+        version: 7.18.0(eslint@10.9.1)(typescript@4.9.5)
       '@withfig/autocomplete':
         specifier: ^2.692.3
         version: 2.692.3
@@ -47,7 +47,7 @@ importers:
         version: 7.8.5
       typescript:
         specifier: '>=4.7.4'
-        version: 7.0.2
+        version: 4.9.5
 
 packages:
 
@@ -967,126 +967,6 @@ packages:
     resolution: {integrity: sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==}
     engines: {node: ^18.18.0 || >=20.0.0}
 
-  '@typescript/typescript-aix-ppc64@7.0.2':
-    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [ppc64]
-    os: [aix]
-
-  '@typescript/typescript-darwin-arm64@7.0.2':
-    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@typescript/typescript-darwin-x64@7.0.2':
-    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@typescript/typescript-freebsd-arm64@7.0.2':
-    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@typescript/typescript-freebsd-x64@7.0.2':
-    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@typescript/typescript-linux-arm64@7.0.2':
-    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@typescript/typescript-linux-arm@7.0.2':
-    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm]
-    os: [linux]
-
-  '@typescript/typescript-linux-loong64@7.0.2':
-    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@typescript/typescript-linux-mips64el@7.0.2':
-    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
-    engines: {node: '>=16.20.0'}
-    cpu: [mips64el]
-    os: [linux]
-
-  '@typescript/typescript-linux-ppc64@7.0.2':
-    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
-    engines: {node: '>=16.20.0'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@typescript/typescript-linux-riscv64@7.0.2':
-    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@typescript/typescript-linux-s390x@7.0.2':
-    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
-    engines: {node: '>=16.20.0'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@typescript/typescript-linux-x64@7.0.2':
-    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [linux]
-
-  '@typescript/typescript-netbsd-arm64@7.0.2':
-    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@typescript/typescript-netbsd-x64@7.0.2':
-    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [netbsd]
-
-  '@typescript/typescript-openbsd-arm64@7.0.2':
-    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@typescript/typescript-openbsd-x64@7.0.2':
-    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@typescript/typescript-sunos-x64@7.0.2':
-    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@typescript/typescript-win32-arm64@7.0.2':
-    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
-    engines: {node: '>=16.20.0'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@typescript/typescript-win32-x64@7.0.2':
-    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
-    engines: {node: '>=16.20.0'}
-    cpu: [x64]
-    os: [win32]
-
   '@ungap/structured-clone@1.3.3':
     resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
 
@@ -1791,11 +1671,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@7.0.2:
-    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
-    engines: {node: '>=16.20.0'}
-    hasBin: true
-
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
 
@@ -2307,14 +2182,14 @@ snapshots:
       ts-morph: 22.0.0
       typescript: 5.9.3
 
-  '@fig/eslint-config-autocomplete@2.0.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.9.1)(typescript@7.0.2))(eslint@10.9.1)(typescript@7.0.2))(@typescript-eslint/parser@7.18.0(eslint@10.9.1)(typescript@7.0.2))(@withfig/eslint-plugin-fig-linter@1.4.1)(eslint@10.9.1)(eslint-plugin-compat@4.2.0(eslint@10.9.1))(typescript@7.0.2)':
+  '@fig/eslint-config-autocomplete@2.0.0(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.9.1)(typescript@4.9.5))(eslint@10.9.1)(typescript@4.9.5))(@typescript-eslint/parser@7.18.0(eslint@10.9.1)(typescript@4.9.5))(@withfig/eslint-plugin-fig-linter@1.4.1)(eslint@10.9.1)(eslint-plugin-compat@4.2.0(eslint@10.9.1))(typescript@4.9.5)':
     dependencies:
-      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.9.1)(typescript@7.0.2))(eslint@10.9.1)(typescript@7.0.2)
-      '@typescript-eslint/parser': 7.18.0(eslint@10.9.1)(typescript@7.0.2)
+      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.9.1)(typescript@4.9.5))(eslint@10.9.1)(typescript@4.9.5)
+      '@typescript-eslint/parser': 7.18.0(eslint@10.9.1)(typescript@4.9.5)
       '@withfig/eslint-plugin-fig-linter': 1.4.1
       eslint: 10.9.1
       eslint-plugin-compat: 4.2.0(eslint@10.9.1)
-      typescript: 7.0.2
+      typescript: 4.9.5
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -2510,32 +2385,32 @@ snapshots:
 
   '@types/web-bluetooth@0.0.21': {}
 
-  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.9.1)(typescript@7.0.2))(eslint@10.9.1)(typescript@7.0.2)':
+  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@10.9.1)(typescript@4.9.5))(eslint@10.9.1)(typescript@4.9.5)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 7.18.0(eslint@10.9.1)(typescript@7.0.2)
+      '@typescript-eslint/parser': 7.18.0(eslint@10.9.1)(typescript@4.9.5)
       '@typescript-eslint/scope-manager': 7.18.0
-      '@typescript-eslint/type-utils': 7.18.0(eslint@10.9.1)(typescript@7.0.2)
+      '@typescript-eslint/type-utils': 7.18.0(eslint@10.9.1)(typescript@4.9.5)
       '@typescript-eslint/utils': 7.18.0(eslint@10.9.1)
       '@typescript-eslint/visitor-keys': 7.18.0
       eslint: 10.9.1
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 1.4.3(typescript@7.0.2)
-      typescript: 7.0.2
+      ts-api-utils: 1.4.3(typescript@4.9.5)
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.18.0(eslint@10.9.1)(typescript@7.0.2)':
+  '@typescript-eslint/parser@7.18.0(eslint@10.9.1)(typescript@4.9.5)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@7.0.2)
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@4.9.5)
       '@typescript-eslint/visitor-keys': 7.18.0
       debug: 4.4.3
       eslint: 10.9.1
-      typescript: 7.0.2
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
 
@@ -2544,20 +2419,20 @@ snapshots:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
 
-  '@typescript-eslint/type-utils@7.18.0(eslint@10.9.1)(typescript@7.0.2)':
+  '@typescript-eslint/type-utils@7.18.0(eslint@10.9.1)(typescript@4.9.5)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@7.0.2)
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@4.9.5)
       '@typescript-eslint/utils': 7.18.0(eslint@10.9.1)
       debug: 4.4.3
       eslint: 10.9.1
-      ts-api-utils: 1.4.3(typescript@7.0.2)
-      typescript: 7.0.2
+      ts-api-utils: 1.4.3(typescript@4.9.5)
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@7.18.0': {}
 
-  '@typescript-eslint/typescript-estree@7.18.0(typescript@7.0.2)':
+  '@typescript-eslint/typescript-estree@7.18.0(typescript@4.9.5)':
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
@@ -2566,8 +2441,8 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.9
       semver: 7.8.5
-      ts-api-utils: 1.4.3(typescript@7.0.2)
-      typescript: 7.0.2
+      ts-api-utils: 1.4.3(typescript@4.9.5)
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
 
@@ -2576,7 +2451,7 @@ snapshots:
       '@eslint-community/eslint-utils': 4.10.1(eslint@10.9.1)
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@7.0.2)
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@4.9.5)
       eslint: 10.9.1
     transitivePeerDependencies:
       - supports-color
@@ -2586,72 +2461,12 @@ snapshots:
       '@typescript-eslint/types': 7.18.0
       eslint-visitor-keys: 3.4.3
 
-  '@typescript/typescript-aix-ppc64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-darwin-arm64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-darwin-x64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-freebsd-arm64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-freebsd-x64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-linux-arm64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-linux-arm@7.0.2':
-    optional: true
-
-  '@typescript/typescript-linux-loong64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-linux-mips64el@7.0.2':
-    optional: true
-
-  '@typescript/typescript-linux-ppc64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-linux-riscv64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-linux-s390x@7.0.2':
-    optional: true
-
-  '@typescript/typescript-linux-x64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-netbsd-arm64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-netbsd-x64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-openbsd-arm64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-openbsd-x64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-sunos-x64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-win32-arm64@7.0.2':
-    optional: true
-
-  '@typescript/typescript-win32-x64@7.0.2':
-    optional: true
-
   '@ungap/structured-clone@1.3.3': {}
 
-  '@vitejs/plugin-vue@5.2.4(vite@5.4.21)(vue@3.5.41(typescript@7.0.2))':
+  '@vitejs/plugin-vue@5.2.4(vite@5.4.21)(vue@3.5.41(typescript@4.9.5))':
     dependencies:
       vite: 5.4.21
-      vue: 3.5.41(typescript@7.0.2)
+      vue: 3.5.41(typescript@4.9.5)
 
   '@vue/compiler-core@3.5.41':
     dependencies:
@@ -2725,25 +2540,25 @@ snapshots:
 
   '@vue/shared@3.5.41': {}
 
-  '@vueuse/core@12.8.2(typescript@7.0.2)':
+  '@vueuse/core@12.8.2(typescript@4.9.5)':
     dependencies:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 12.8.2
-      '@vueuse/shared': 12.8.2(typescript@7.0.2)
-      vue: 3.5.41(typescript@7.0.2)
+      '@vueuse/shared': 12.8.2(typescript@4.9.5)
+      vue: 3.5.41(typescript@4.9.5)
 
   '@vueuse/integrations@12.8.2(focus-trap@7.8.0)':
     dependencies:
-      '@vueuse/core': 12.8.2(typescript@7.0.2)
-      '@vueuse/shared': 12.8.2(typescript@7.0.2)
+      '@vueuse/core': 12.8.2(typescript@4.9.5)
+      '@vueuse/shared': 12.8.2(typescript@4.9.5)
       focus-trap: 7.8.0
-      vue: 3.5.41(typescript@7.0.2)
+      vue: 3.5.41(typescript@4.9.5)
 
   '@vueuse/metadata@12.8.2': {}
 
-  '@vueuse/shared@12.8.2(typescript@7.0.2)':
+  '@vueuse/shared@12.8.2(typescript@4.9.5)':
     dependencies:
-      vue: 3.5.41(typescript@7.0.2)
+      vue: 3.5.41(typescript@4.9.5)
 
   '@withfig/autocomplete-tools@2.11.0':
     dependencies:
@@ -3426,9 +3241,9 @@ snapshots:
 
   trim-lines@3.0.1: {}
 
-  ts-api-utils@1.4.3(typescript@7.0.2):
+  ts-api-utils@1.4.3(typescript@4.9.5):
     dependencies:
-      typescript: 7.0.2
+      typescript: 4.9.5
 
   ts-morph@22.0.0:
     dependencies:
@@ -3442,29 +3257,6 @@ snapshots:
   typescript@4.9.5: {}
 
   typescript@5.9.3: {}
-
-  typescript@7.0.2:
-    optionalDependencies:
-      '@typescript/typescript-aix-ppc64': 7.0.2
-      '@typescript/typescript-darwin-arm64': 7.0.2
-      '@typescript/typescript-darwin-x64': 7.0.2
-      '@typescript/typescript-freebsd-arm64': 7.0.2
-      '@typescript/typescript-freebsd-x64': 7.0.2
-      '@typescript/typescript-linux-arm': 7.0.2
-      '@typescript/typescript-linux-arm64': 7.0.2
-      '@typescript/typescript-linux-loong64': 7.0.2
-      '@typescript/typescript-linux-mips64el': 7.0.2
-      '@typescript/typescript-linux-ppc64': 7.0.2
-      '@typescript/typescript-linux-riscv64': 7.0.2
-      '@typescript/typescript-linux-s390x': 7.0.2
-      '@typescript/typescript-linux-x64': 7.0.2
-      '@typescript/typescript-netbsd-arm64': 7.0.2
-      '@typescript/typescript-netbsd-x64': 7.0.2
-      '@typescript/typescript-openbsd-arm64': 7.0.2
-      '@typescript/typescript-openbsd-x64': 7.0.2
-      '@typescript/typescript-sunos-x64': 7.0.2
-      '@typescript/typescript-win32-arm64': 7.0.2
-      '@typescript/typescript-win32-x64': 7.0.2
 
   unist-util-is@6.0.1:
     dependencies:
@@ -3526,17 +3318,17 @@ snapshots:
       '@shikijs/transformers': 2.5.0
       '@shikijs/types': 2.5.0
       '@types/markdown-it': 14.2.0
-      '@vitejs/plugin-vue': 5.2.4(vite@5.4.21)(vue@3.5.41(typescript@7.0.2))
+      '@vitejs/plugin-vue': 5.2.4(vite@5.4.21)(vue@3.5.41(typescript@4.9.5))
       '@vue/devtools-api': 7.7.10
       '@vue/shared': 3.5.41
-      '@vueuse/core': 12.8.2(typescript@7.0.2)
+      '@vueuse/core': 12.8.2(typescript@4.9.5)
       '@vueuse/integrations': 12.8.2(focus-trap@7.8.0)
       focus-trap: 7.8.0
       mark.js: 8.11.1
       minisearch: 7.2.0
       shiki: 2.5.0
       vite: 5.4.21
-      vue: 3.5.41(typescript@7.0.2)
+      vue: 3.5.41(typescript@4.9.5)
     transitivePeerDependencies:
       - '@types/node'
       - '@types/react'
@@ -3563,14 +3355,14 @@ snapshots:
       - terser
       - universal-cookie
 
-  vue@3.5.41(typescript@7.0.2):
+  vue@3.5.41(typescript@4.9.5):
     dependencies:
       '@vue/compiler-dom': 3.5.41
       '@vue/compiler-sfc': 3.5.41
       '@vue/runtime-dom': 3.5.41
       '@vue/server-renderer': 3.5.41
       '@vue/shared': 3.5.41
-      typescript: 7.0.2
+      typescript: 4.9.5
 
   which@2.0.2:
     dependencies:

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "usage-cli"
 edition = "2021"
 rust-version = "1.91"
-version = "6.4.0"
+version = "6.4.1"
 description = "CLI for working with usage-based CLIs"
 license = { workspace = true }
 authors = { workspace = true }

--- a/cli/usage.usage.kdl
+++ b/cli/usage.usage.kdl
@@ -2,7 +2,7 @@
 min_usage_version "4.0"
 name usage
 bin usage
-version "6.4.0"
+version "6.4.1"
 repository "https://github.com/jdx/usage"
 source_code_link_template #"""
 {%- set path = path | replace(from='-', to='_') -%}

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-config"
 description = "Layered configuration resolution for usage specs, with provenance"
-version = "6.4.0"
+version = "6.4.1"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-derive"
 description = "Derive macro that compiles a CLI definition into parse tables and a usage spec"
-version = "6.4.0"
+version = "6.4.1"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }

--- a/docs/cli/reference/commands.json
+++ b/docs/cli/reference/commands.json
@@ -2014,7 +2014,7 @@
     "sources": {},
     "files": []
   },
-  "version": "6.4.0",
+  "version": "6.4.1",
   "usage": "Usage: usage <COMMAND>\n       usage --completions <COMPLETIONS>\n       usage --usage-spec",
   "complete": {},
   "source_code_link_template": "{%- set path = path | replace(from='-', to='_') -%}\n{%- if cmd.subcommands | length > 0 -%}\n{%- set path = path ~ \"/mod.rs\" -%}\n{%- elif path in [\"bash\", \"fish\", \"powershell\", \"zsh\"] -%}\n{%- set path = \"shell.rs\" -%}\n{%- else -%}\n{%- set path = path ~ \".rs\" -%}\n{%- endif -%}\nhttps://github.com/jdx/usage/blob/main/cli/src/cli/{{path}}",

--- a/docs/cli/reference/index.md
+++ b/docs/cli/reference/index.md
@@ -4,7 +4,7 @@
 
 **Usage:** `usage [--completions <COMPLETIONS>] [--usage-spec] <SUBCOMMAND>`
 
-**Version:** 6.4.0
+**Version:** 6.4.1
 
 **Repository:** https://github.com/jdx/usage
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-lib"
 edition = "2021"
-version = "6.4.0"
+version = "6.4.1"
 rust-version = "1.91"
 include = [
     "/Cargo.toml",

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-test"
 description = "Test helpers for CLIs built with usage"
-version = "6.4.0"
+version = "6.4.1"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }

--- a/usage-dynamic/Cargo.toml
+++ b/usage-dynamic/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-dynamic"
 description = "Runtime command catalogs for usage-rs applications"
-version = "6.4.0"
+version = "6.4.1"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }
@@ -12,7 +12,7 @@ license = { workspace = true }
 
 [dependencies]
 usage-argv = { workspace = true, features = ["spec", "complete"] }
-usage-parser = { package = "usage-lib", path = "../lib", version = "6.4.0", default-features = false, features = ["cli-help"] }
+usage-parser = { package = "usage-lib", path = "../lib", version = "6.4.1", default-features = false, features = ["cli-help"] }
 
 [package.metadata.release]
 shared-version = true

--- a/usage-rs/Cargo.toml
+++ b/usage-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-rs"
 description = "A compiled CLI parser for Rust, built on usage specs"
-version = "6.4.0"
+version = "6.4.1"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }

--- a/usage-rs/tests/fixtures/runtime-identity/Cargo.lock
+++ b/usage-rs/tests/fixtures/runtime-identity/Cargo.lock
@@ -39,11 +39,11 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "usage-argv"
-version = "6.4.0"
+version = "6.4.1"
 
 [[package]]
 name = "usage-derive"
-version = "6.4.0"
+version = "6.4.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "usage-rs"
-version = "6.4.0"
+version = "6.4.1"
 dependencies = [
  "usage-argv",
  "usage-derive",

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-validation"
 description = "Portable expression validation for usage specs"
-version = "6.4.0"
+version = "6.4.1"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }


### PR DESCRIPTION
### 🐛 Bug Fixes

- **(cli)** color interpreted help output by [@jdx](https://github.com/jdx) in [#1309](https://github.com/jdx/usage/pull/1309)
- **(docs)** omit hidden commands from markdown by [@jdx](https://github.com/jdx) in [#1315](https://github.com/jdx/usage/pull/1315)
- **(parse)** require opt-in for negative flag values by [@jdx](https://github.com/jdx) in [#1317](https://github.com/jdx/usage/pull/1317)
- **(parse)** align negative values across parse phases by [@jdx](https://github.com/jdx) in [#1318](https://github.com/jdx/usage/pull/1318)
- simplify required-unless predicates by [@jdx](https://github.com/jdx) in [#1326](https://github.com/jdx/usage/pull/1326)

### 🔍 Other Changes

- **(sponsors)** replace 37signals with omacom foundation by [@jdx](https://github.com/jdx) in [#1324](https://github.com/jdx/usage/pull/1324)
- lower published crate msrv to 1.91 by [@jdx](https://github.com/jdx) in [#1314](https://github.com/jdx/usage/pull/1314)

### 📦️ Dependency Updates

- update rust crate winnow to v1 by [@renovate[bot]](https://github.com/renovate[bot]) in [#1313](https://github.com/jdx/usage/pull/1313)