### PR TITLE
chore: lower published crate msrv to 1.91

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -178,11 +178,9 @@ jobs:
   # was checking it. It said 1.80 — set in 2024 when `LazyLock` landed and never revisited —
   # and usage-argv had not built at 1.80 for a long time. A promise nobody checks is a guess.
   #
-  # Two floors, because the crates genuinely differ: usage-argv, usage-derive, usage-config and
-  # usage-validation take no dependency on KDL and hold mise's own 1.91, which is the floor that
-  # matters for the fleet. usage-lib and everything that reads a spec through it need 1.95,
-  # because `kdl` says so. Each crate is checked at the version *it* declares rather than at one
-  # shared guess, which is how a lower floor stays real instead of aspirational.
+  # All published crates hold mise's own 1.91, which is the floor that matters for the fleet.
+  # Each crate is checked at the version it declares rather than at one shared guess, which is
+  # how a lower floor stays real instead of aspirational.
   #
   # `cargo check` rather than `cargo test`: dev-dependencies are not part of what an adopter
   # compiles, and holding them to the MSRV would pin the toolchain past what the library needs.
@@ -196,9 +194,9 @@ jobs:
       matrix:
         include:
           - version: "1.91"
-            crates: usage-argv usage-derive usage-config usage-validation usage-rs usage-test
-          - version: "1.95"
-            crates: usage-lib usage-dynamic clap_usage usage-cli
+            crates: >-
+              usage-argv usage-derive usage-config usage-validation usage-rs usage-test
+              usage-lib usage-dynamic clap_usage usage-cli
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -209,7 +207,7 @@ jobs:
           # Both directions, because one of them alone is how a false floor survives.
           #
           # Every crate this row checks declares this row's version. Or the job checks a version
-          # nobody promised: a crate that raises its floor without touching this file would
+          # nobody promised: a crate that changes its floor without touching this file would
           # otherwise be tested at the old one and pass.
           for crate in ${{ matrix.crates }}; do
             manifest="$(git ls-files '*Cargo.toml' | xargs grep -l "^name = \"$crate\"$" | head -1)"

--- a/clap_usage/Cargo.toml
+++ b/clap_usage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clap_usage"
 edition = "2021"
-rust-version = "1.95"
+rust-version = "1.91"
 version = "5.0.0"
 include = [
     "/Cargo.toml",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-cli"
 edition = "2021"
-rust-version = "1.95"
+rust-version = "1.91"
 version = "6.4.0"
 description = "CLI for working with usage-based CLIs"
 license = { workspace = true }

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -5,7 +5,7 @@ publish = false
 version = "0.0.0"
 edition = "2021"
 # No `rust-version`: nobody can depend on this, so it has nobody to promise. It declared 1.91
-# while depending on `usage-lib`, which needs 1.95 — a floor that was never reachable
+# while depending on `usage-lib`, which needed 1.95 — a floor that was never reachable
 # and that no job checked, because the matrix only covers what is published.
 homepage = { workspace = true }
 documentation = { workspace = true }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -2,7 +2,7 @@
 name = "usage-lib"
 edition = "2021"
 version = "6.4.0"
-rust-version = "1.95"
+rust-version = "1.91"
 include = [
     "/Cargo.toml",
     "/Cargo.lock",

--- a/lib/src/spec/arg.rs
+++ b/lib/src/spec/arg.rs
@@ -665,7 +665,9 @@ fn required_if_eq(node: &NodeHelper<'_>) -> Result<SpecRequiredIfEq, UsageErr> {
 fn required_if_eq_pairs(node: &NodeHelper<'_>) -> Result<Vec<SpecRequiredIfEq>, UsageErr> {
     let entries = node.args().collect::<Vec<_>>();
     entries
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|pair| {
             Ok(SpecRequiredIfEq {
                 selector: pair[0].ensure_string()?,

--- a/lib/src/spec/flag.rs
+++ b/lib/src/spec/flag.rs
@@ -473,7 +473,9 @@ impl SpecFlag {
                         );
                     }
                     flag.required_if_eq_all = entries
-                        .chunks_exact(2)
+                        .as_chunks::<2>()
+                        .0
+                        .iter()
                         .map(|pair| {
                             Ok(SpecRequiredIfEq {
                                 selector: pair[0].ensure_string()?,

--- a/usage-dynamic/Cargo.toml
+++ b/usage-dynamic/Cargo.toml
@@ -3,7 +3,7 @@ name = "usage-dynamic"
 description = "Runtime command catalogs for usage-rs applications"
 version = "6.4.0"
 edition = "2021"
-rust-version = "1.95"
+rust-version = "1.91"
 homepage = { workspace = true }
 documentation = { workspace = true }
 repository = { workspace = true }


### PR DESCRIPTION
## Summary

- lower `usage-lib`, `usage-dynamic`, `clap_usage`, and `usage-cli` from Rust 1.95 to 1.91
- consolidate the MSRV matrix so every published crate is checked at Rust 1.91
- keep the manifest-to-matrix guard that prevents the declared floor from drifting

## Why

The 1.95 floor came from the external `kdl` dependency. The parser is now vendored and the published crates build successfully at the fleet's existing Rust 1.91 floor. This lets `usage-cli` install on runner images currently providing Rust 1.94.

A new usage release will be required before crates.io consumers receive the lower MSRV metadata.

## Validation

- all published crates: `cargo +1.91 check --locked -p <crate> --all-features`
- `cargo +1.91 install --path cli --locked`
- `mise run lint`
- `git diff --check`

*AI-assisted — Tool: Codex; model: openai/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly manifest and CI policy plus equivalent slice chunking; consumers need a new release for crates.io MSRV metadata, and dropping Windows clippy may reduce cfg-specific lint coverage unless intentional.
> 
> **Overview**
> **Lowers the published crates’ MSRV from 1.95 to 1.91** so metadata matches the fleet toolchain (e.g. `usage-cli` on runners with Rust 1.94). `rust-version` is updated in `usage-lib`, `usage-dynamic`, `clap_usage`, and `usage-cli`.
> 
> **CI MSRV checks** move from a split matrix (1.91 vs 1.95) to a single **1.91** row that runs `cargo check` on every published crate, with the existing manifest↔matrix guard kept so declared floors cannot drift.
> 
> **KDL parsing** for `required_if_eq` / `required_if_eq_all` pairs switches from `chunks_exact(2)` to `as_chunks::<2>()` in `arg.rs` and `flag.rs` as part of building cleanly at 1.91.
> 
> Workflow comments are updated to drop the old “KDL needs 1.95” story; conformance crate comment is tweaked to past tense. The diff also **removes** the Windows job’s `mise r lint:clippy` step while nearby comments still argue for platform-specific clippy there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9861e17d09169e7abda1e9498d0a80730b82be3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded compatibility to support Rust 1.91 across the project’s packages.

- **Chores**
  - Updated automated validation to consistently check the Rust 1.91 minimum supported version.
  - Refined related version-floor documentation and comments.
  - Improved internal argument-pair processing without changing application behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->