### PR TITLE
fix(docs): omit hidden commands from markdown

### DIFF
--- a/lib/src/docs/markdown/spec.rs
+++ b/lib/src/docs/markdown/spec.rs
@@ -115,6 +115,24 @@ mod tests {
     }
 
     #[test]
+    fn hidden_commands_are_omitted_from_single_file_markdown() {
+        let spec: Spec = r#"
+            name "mycli"
+            bin "mycli"
+            cmd "visible" help="A documented command"
+            cmd "setup" hide=#true help="An internal command"
+        "#
+        .parse()
+        .unwrap();
+
+        let output = MarkdownRenderer::new(spec).render_spec().unwrap();
+
+        assert!(output.contains("## `mycli visible`"), "{output}");
+        assert!(!output.contains("mycli setup"), "{output}");
+        assert!(!output.contains("An internal command"), "{output}");
+    }
+
+    #[test]
     fn package_metadata_reaches_markdown() {
         let spec: Spec = r#"
             name "metadata"

--- a/lib/src/docs/markdown/templates/spec_template.md.tera
+++ b/lib/src/docs/markdown/templates/spec_template.md.tera
@@ -40,7 +40,7 @@
 {%- include "cmd_template.md.tera" %}
 {%- set header_level = header_level + 1 %}
 
-{%- for cmd in all_commands %}
+{%- for cmd in all_commands | filter(attribute="hide", value=false) %}
 {%- set full_cmd = cmd.full_cmd | join(sep=" ") %}
 
 {{ "#" | repeat(count=header_level) }} `{{ (spec.bin ~ " " ~ full_cmd) | trim }}`


### PR DESCRIPTION
## Summary

- filter hidden commands from single-file Markdown references
- add regression coverage for hidden command headings and help text

## Tests

- `cargo fmt --all -- --check`
- `cargo test -p usage-lib --all-features hidden_commands_are_omitted_from_single_file_markdown`
- `cargo test -p usage-lib --all-features docs::markdown::spec::tests`

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation rendering only; behavior aligns hidden subcommands with existing index and flag/arg filtering.
> 
> **Overview**
> **Single-file Markdown reference generation** no longer emits sections for commands marked `hide=#true`. The `spec_template.md.tera` subcommand loop now uses the same `filter(attribute="hide", value=false)` pattern already used on the index and for hidden args/flags.
> 
> A regression test asserts that a visible command still gets a `##` heading while a hidden `setup` command and its help text never appear in `render_spec()` output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29355b482b0823be4608fedf680ee6977c129743. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Single-command Markdown documentation now excludes commands marked as hidden.
  - Visible commands continue to appear in generated documentation.

- **Tests**
  - Added regression coverage to verify hidden commands are omitted while visible commands remain documented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->