### PR TITLE
fix(parse): align negative values across parse phases

### DIFF
--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -1443,9 +1443,7 @@ fn parse_partial_traced(
                 if f.arg.is_some()
                     && !word.contains('=')
                     && idx < input.len()
-                    && (!is_flag_like(&input[idx].word)
-                        || (f.arg.as_ref().is_some_and(|arg| arg.allow_negative_numbers)
-                            && is_negative_number(&input[idx].word)))
+                    && accepts_detached_flag_value(&f, &input[idx].word)
                 {
                     if let Some(words) = forwarded.as_mut() {
                         words.push(input[idx].word.clone());
@@ -1600,16 +1598,12 @@ fn parse_partial_traced(
         // still be waiting once the separator has done its job, so the starvation rule
         // below has no path around it.
         if enable_flags
+            && !attached_continuation
             && w.starts_with('-')
-            && out.flag_awaiting_value.last().is_some_and(|flag| {
-                !flag.require_equals
-                    && (flag.allow_hyphen_values()
-                        || (flag
-                            .arg
-                            .as_ref()
-                            .is_some_and(|arg| arg.allow_negative_numbers)
-                            && is_negative_number(&w)))
-            })
+            && out
+                .flag_awaiting_value
+                .last()
+                .is_some_and(|flag| accepts_detached_flag_value(flag, &w))
         {
             // A variadic argument collects here too: which token supplied its first
             // value says nothing about how many it takes.
@@ -1644,14 +1638,7 @@ fn parse_partial_traced(
             && !out.flag_awaiting_value.is_empty()
             && out.flag_awaiting_value.last().is_some_and(|flag| {
                 (flag.default_missing.is_some() || flag.value_optional)
-                    && (flag.require_equals
-                        || (is_flag_like(&w)
-                            && !flag.allow_hyphen_values()
-                            && !(flag
-                                .arg
-                                .as_ref()
-                                .is_some_and(|arg| arg.allow_negative_numbers)
-                                && is_negative_number(&w))))
+                    && !accepts_detached_flag_value(flag, &w)
             })
         {
             try_bind_default_missing(
@@ -2086,12 +2073,10 @@ fn parse_partial_traced(
         if enable_flags
             && !out.flag_awaiting_value.is_empty()
             && (attached_continuation
-                || !is_flag_like(&w)
-                || (is_negative_number(&w)
-                    && out
-                        .flag_awaiting_value
-                        .last()
-                        .is_some_and(|flag| flag.default_missing.is_none())))
+                || out
+                    .flag_awaiting_value
+                    .last()
+                    .is_some_and(|flag| accepts_detached_flag_value(flag, &w)))
         {
             // Held before the drain pops it: a flag whose argument is variadic keeps
             // taking values after this first one.
@@ -3492,6 +3477,23 @@ fn is_flag_like(token: &str) -> bool {
 
 fn is_negative_number(token: &str) -> bool {
     token.strip_prefix('-').is_some_and(is_number)
+}
+
+/// Whether a flag may claim its following token as a detached value.
+///
+/// A required value keeps the historical negative-number exception. A value
+/// that may be omitted needs an explicit opt-in to distinguish a negative value
+/// from the flag's bare form.
+fn accepts_detached_flag_value(flag: &SpecFlag, token: &str) -> bool {
+    !flag.require_equals
+        && (!is_flag_like(token)
+            || flag.allow_hyphen_values()
+            || (is_negative_number(token)
+                && (flag
+                    .arg
+                    .as_ref()
+                    .is_some_and(|arg| arg.allow_negative_numbers)
+                    || (flag.default_missing.is_none() && !flag.value_optional))))
 }
 
 fn record_scalar_flag_occurrence(
@@ -9235,6 +9237,16 @@ flag "--kids <N>" default_missing="default missing" allow_negative_numbers=#true
 
         let parsed = parse(&spec, &input(&["test", "--kids", "-1"])).unwrap();
         assert_eq!(flag_string_value(&parsed, "kids"), "-1");
+
+        let external_spec = r#"
+external_subcommand #true
+flag "--apps <N>"
+"#
+        .parse::<Spec>()
+        .unwrap();
+        let parsed = parse(&external_spec, &input(&["test", "--apps", "-1"])).unwrap();
+        assert_eq!(flag_string_value(&parsed, "apps"), "-1");
+        assert!(parsed.external.is_none());
 
         for words in [
             &["test", "--apps", "--jobs", "1"][..],


### PR DESCRIPTION
## Summary

- use one detached-value eligibility rule during subcommand discovery and argument binding
- prevent `external_subcommand` discovery from consuming a required flag's negative value
- preserve attached short-bundle values and optional-value ambiguity rules
- add regression coverage for `--apps -1` with `external_subcommand`

Follow-up to #1317 and its final review feedback.

## Testing

- `cargo test -p usage-lib --all-features`
- `cargo fmt --all -- --check`

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core CLI argument parsing semantics for flags, optional values, and external subcommand discovery; incorrect rules would mis-bind arguments or break clap-aligned edge cases.
> 
> **Overview**
> **Unifies when a flag may consume the next token** by introducing `accepts_detached_flag_value` and using it everywhere detached values are decided (prefix forwarding, `allow_hyphen_values`, optional/default-missing binding, and pending-flag binding) instead of duplicated `is_flag_like` / negative-number checks.
> 
> **Tightens negative detached values for optional flags:** tokens like `-1` are only taken as a detached value when `allow_negative_numbers` is set, or when the flag has a **required** value (no `default_missing` and not `value_optional`). That keeps optional/`default_missing` flags from swallowing `-1` during subcommand discovery while still allowing required flags and explicit `allow_negative_numbers`.
> 
> **Skips the early hyphen-value path when `attached_continuation` is set**, so attached short-bundle continuations are not mis-handled.
> 
> **Adds a regression test** for `external_subcommand` with `--apps -1` so `-1` binds to the flag instead of being treated as external input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1a7e8277c0188390221106c2f9186853924eec5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->