### PR TITLE
feat(complete): complete sigil-prefixed positionals

### DIFF
--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -1426,6 +1426,7 @@ fn overlay_at_cursor<'o>(
         return None;
     }
     let meta = metadata_chain_on_route(spec, position).and_then(|chain| chain.last().copied());
+    let sigil_target = sigil_arg_at_cursor(spec, position, &split.prefix);
     let target = if restarted(meta, split) {
         meta.and_then(|owner| {
             owner.args.first().map(|field| {
@@ -1442,6 +1443,8 @@ fn overlay_at_cursor<'o>(
     {
         flag_meta_owner_on_route(spec, position, flag)
             .map(|(owner, field)| (owner, field.value_name.unwrap_or(field.flag.name), false))
+    } else if let Some((owner, field, _, _)) = sigil_target {
+        Some((owner, field.arg.name, false))
     } else {
         position
             .next_arg
@@ -1494,6 +1497,26 @@ fn overlay_at_cursor<'o>(
     overlays.iter().rev().find(|overlay| {
         overlay.value.eq_ignore_ascii_case(value) && overlay.command.matches(owner, &path)
     })
+}
+
+fn sigil_arg_at_cursor<'a, 'p>(
+    spec: &Spec<'a>,
+    position: &Position<'_>,
+    token: &'p str,
+) -> Option<(&'a CommandMeta<'a>, &'a ArgMeta<'a>, &'a str, &'p str)> {
+    if !position.flags_possible {
+        return None;
+    }
+    metadata_chain_on_route(spec, position)?
+        .into_iter()
+        .flat_map(|owner| owner.args.iter().map(move |field| (owner, field)))
+        .filter_map(|(owner, field)| {
+            let sigil = field.arg.sigil.and_then(|value| core::str::from_utf8(value).ok())?;
+            token
+                .strip_prefix(sigil)
+                .map(|prefix| (owner, field, sigil, prefix))
+        })
+        .max_by_key(|(_, _, sigil, _)| sigil.len())
 }
 
 fn flag_meta_owner_on_route<'a>(
@@ -1584,6 +1607,7 @@ fn candidates_inner<'a>(
     }
     let meta = metadata_chain_on_route(spec, &position).and_then(|chain| chain.last().copied());
     let token = split.prefix.as_str();
+    let sigil_arg = sigil_arg_at_cursor(spec, &position, token);
 
     let mut out = if position.flags_possible && token == "-" {
         // Both forms, because a lone dash says nothing about which was meant.
@@ -1630,6 +1654,12 @@ fn candidates_inner<'a>(
                 )
             })
             .unwrap_or_default()
+    } else if let Some((_, arg, sigil, prefix)) = sigil_arg {
+        let mut found = positional(arg, &position, split, prefix);
+        for candidate in &mut found {
+            candidate.value.insert_str(0, sigil);
+        }
+        found
     } else {
         let mut found = Vec::new();
         if let Some(arg) = position.next_arg {
@@ -2663,6 +2693,43 @@ mod tests {
             .into_iter()
             .map(|c| c.value)
             .collect()
+    }
+
+    #[test]
+    fn sigil_completion_matches_the_stripped_value_and_restores_the_prefix() {
+        static OVERLAY: Arg = Arg {
+            key: 90,
+            name: "TOOL",
+            sigil: Some(b"+"),
+            ..Arg::VAR
+        };
+        static COMMAND: Command = Command {
+            name: "ex",
+            args: &[&OVERLAY],
+            ..Command::EMPTY
+        };
+        static META: CommandMeta = CommandMeta {
+            cmd: &COMMAND,
+            args: &[ArgMeta {
+                arg: &OVERLAY,
+                choices: &["node@22", "node@24", "python@3.14"],
+                ..ArgMeta::EMPTY
+            }],
+            ..CommandMeta::EMPTY
+        };
+        static SIGIL_SPEC: Spec = Spec {
+            name: "ex",
+            bin: Some("ex"),
+            root: &META,
+            ..Spec::EMPTY
+        };
+
+        let values = candidates(&SIGIL_SPEC, &at_end("ex +n"))
+            .into_iter()
+            .map(|candidate| candidate.value)
+            .collect::<Vec<_>>();
+        assert_eq!(values, ["+node@22", "+node@24"]);
+        assert!(candidates(&SIGIL_SPEC, &at_end("ex -- +n")).is_empty());
     }
 
     fn runtime_tools(ctx: CompleteCtx<'_>) -> CompletionFuture<'_> {

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -1086,7 +1086,7 @@ fn declared_files_at_cursor(
     }
     let meta = metadata_chain_on_route(spec, position).and_then(|chain| chain.last().copied());
     let after_restart = restarted(meta, split);
-    let sigil_cursor = sigil_arg_at_cursor(spec, position, &split.prefix);
+    let sigil_cursor = sigil_arg_at_cursor(spec, position, split);
     let at_cursor = if after_restart {
         meta.and_then(|m| m.args.first()).map(|m| m.arg)
     } else {
@@ -1193,7 +1193,7 @@ fn complete_inner<'a>(
     // argument, whatever the words before the token filled, and everything below follows from
     // that: whether paths belong, whether the set is declared, whether a separator is owed.
     let after_restart = restarted(meta, split);
-    let sigil_cursor = sigil_arg_at_cursor(spec, &position, token);
+    let sigil_cursor = sigil_arg_at_cursor(spec, &position, split);
     let at_cursor = if after_restart {
         meta.and_then(|m| m.args.first()).map(|m| m.arg)
     } else {
@@ -1298,8 +1298,7 @@ pub async fn complete_with<'a>(
     let sigil = attached
         .is_none()
         .then(|| {
-            sigil_arg_at_cursor(spec, &position, &split.prefix)
-                .map(|(_, _, sigil, prefix)| (sigil, prefix))
+            sigil_arg_at_cursor(spec, &position, split).map(|(_, _, sigil, prefix)| (sigil, prefix))
         })
         .flatten();
     let value_prefix = attached
@@ -1352,8 +1351,7 @@ async fn complete_named_with<'a>(
     let sigil = attached
         .is_none()
         .then(|| {
-            sigil_arg_at_cursor(spec, &position, &split.prefix)
-                .map(|(_, _, sigil, prefix)| (sigil, prefix))
+            sigil_arg_at_cursor(spec, &position, split).map(|(_, _, sigil, prefix)| (sigil, prefix))
         })
         .flatten();
     let value_prefix = attached
@@ -1462,7 +1460,7 @@ fn overlay_at_cursor<'o>(
         return None;
     }
     let meta = metadata_chain_on_route(spec, position).and_then(|chain| chain.last().copied());
-    let sigil_target = sigil_arg_at_cursor(spec, position, &split.prefix);
+    let sigil_target = sigil_arg_at_cursor(spec, position, split);
     let target = if restarted(meta, split) {
         meta.and_then(|owner| {
             owner.args.first().map(|field| {
@@ -1538,11 +1536,13 @@ fn overlay_at_cursor<'o>(
 fn sigil_arg_at_cursor<'a, 'p>(
     spec: &Spec<'a>,
     position: &Position<'_>,
-    token: &'p str,
+    split: &'p Split,
 ) -> Option<(&'a CommandMeta<'a>, &'a ArgMeta<'a>, &'a str, &'p str)> {
-    if !position.flags_possible {
+    let meta = metadata_chain_on_route(spec, position).and_then(|chain| chain.last().copied());
+    if !position.flags_possible || position.awaiting_value.is_some() || restarted(meta, split) {
         return None;
     }
+    let token = split.prefix.as_str();
     metadata_chain_on_route(spec, position)?
         .into_iter()
         .flat_map(|owner| owner.args.iter().map(move |field| (owner, field)))
@@ -1646,7 +1646,7 @@ fn candidates_inner<'a>(
     }
     let meta = metadata_chain_on_route(spec, &position).and_then(|chain| chain.last().copied());
     let token = split.prefix.as_str();
-    let sigil_arg = sigil_arg_at_cursor(spec, &position, token);
+    let sigil_arg = sigil_arg_at_cursor(spec, &position, split);
 
     let mut out = if position.flags_possible && token == "-" {
         // Both forms, because a lone dash says nothing about which was meant.
@@ -2749,11 +2749,17 @@ mod tests {
         };
         static COMMAND: Command = Command {
             name: "ex",
+            flags: &[&JOBS],
             args: &[&FILE_ARG, &OVERLAY],
             ..Command::EMPTY
         };
         static META: CommandMeta = CommandMeta {
             cmd: &COMMAND,
+            restart_token: Some(":::"),
+            flags: &[FlagMeta {
+                flag: &JOBS,
+                ..FlagMeta::EMPTY
+            }],
             args: &[
                 ArgMeta {
                     arg: &FILE_ARG,
@@ -2784,6 +2790,14 @@ mod tests {
         // The ordinary positional would ask the shell for files, but a sigil token is
         // classified as the closed-choice overlay field even when no choice matches.
         assert_eq!(complete(&SIGIL_SPEC, &at_end("ex +z")).files, None);
+        assert_eq!(
+            complete(&SIGIL_SPEC, &at_end("ex --jobs +z")).files,
+            Some(Files::Any)
+        );
+        assert_eq!(
+            complete(&SIGIL_SPEC, &at_end("ex file ::: +z")).files,
+            Some(Files::Any)
+        );
 
         static OPEN_META: CommandMeta = CommandMeta {
             cmd: &COMMAND,

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -1089,8 +1089,9 @@ fn declared_files_at_cursor(
     let at_cursor = if after_restart {
         meta.and_then(|m| m.args.first()).map(|m| m.arg)
     } else {
-        position
-            .next_arg
+        sigil_arg_at_cursor(spec, position, &split.prefix)
+            .map(|(_, field, _, _)| field.arg)
+            .or(position.next_arg)
             .or_else(|| default_subcommand_arg(spec, split, position).map(|(_, field)| field.arg))
     };
     if position.awaiting_value.is_none()
@@ -1191,7 +1192,9 @@ fn complete_inner<'a>(
     let at_cursor = if after_restart {
         meta.and_then(|m| m.args.first()).map(|m| m.arg)
     } else {
-        position.next_arg
+        sigil_arg_at_cursor(spec, &position, token)
+            .map(|(_, field, _, _)| field.arg)
+            .or(position.next_arg)
     };
 
     // A dash-prefixed word is a flag or nothing: no path starts with one, and the reference
@@ -1287,7 +1290,17 @@ pub async fn complete_with<'a>(
     };
 
     let attached = attached_long_value(&position, &split.prefix);
-    let value_prefix = attached.map_or(split.prefix.as_str(), |(_, _, prefix)| prefix);
+    let sigil = attached
+        .is_none()
+        .then(|| {
+            sigil_arg_at_cursor(spec, &position, &split.prefix)
+                .map(|(_, _, sigil, prefix)| (sigil, prefix))
+        })
+        .flatten();
+    let value_prefix = attached
+        .map(|(_, _, prefix)| prefix)
+        .or_else(|| sigil.map(|(_, prefix)| prefix))
+        .unwrap_or(split.prefix.as_str());
     let words = split.argv();
     let command_path: Vec<(&Command<'_>, &[String])> = position
         .path
@@ -1308,6 +1321,10 @@ pub async fn complete_with<'a>(
     dynamic.retain(|candidate| candidate.value.starts_with(value_prefix));
     if let Some((_, form, _)) = attached {
         attach_candidates(&mut dynamic, form);
+    } else if let Some((sigil, _)) = sigil {
+        for candidate in &mut dynamic {
+            candidate.value.insert_str(0, sigil);
+        }
     }
 
     let mut answer = complete(spec, split);
@@ -1327,7 +1344,17 @@ async fn complete_named_with<'a>(
 ) -> Completions<'a> {
     let position = walk(spec.root.cmd, split.argv());
     let attached = attached_long_value(&position, &split.prefix);
-    let value_prefix = attached.map_or(split.prefix.as_str(), |(_, _, prefix)| prefix);
+    let sigil = attached
+        .is_none()
+        .then(|| {
+            sigil_arg_at_cursor(spec, &position, &split.prefix)
+                .map(|(_, _, sigil, prefix)| (sigil, prefix))
+        })
+        .flatten();
+    let value_prefix = attached
+        .map(|(_, _, prefix)| prefix)
+        .or_else(|| sigil.map(|(_, prefix)| prefix))
+        .unwrap_or(split.prefix.as_str());
     let words = split.argv();
     let command_path: Vec<(&Command<'_>, &[String])> = position
         .path
@@ -1352,6 +1379,10 @@ async fn complete_named_with<'a>(
     candidates.retain(|candidate| candidate.value.starts_with(value_prefix));
     if let Some((_, form, _)) = attached {
         attach_candidates(&mut candidates, form);
+    } else if let Some((sigil, _)) = sigil {
+        for candidate in &mut candidates {
+            candidate.value.insert_str(0, sigil);
+        }
     }
     sort_and_dedup_candidates(&mut candidates);
     Completions {
@@ -1511,7 +1542,10 @@ fn sigil_arg_at_cursor<'a, 'p>(
         .into_iter()
         .flat_map(|owner| owner.args.iter().map(move |field| (owner, field)))
         .filter_map(|(owner, field)| {
-            let sigil = field.arg.sigil.and_then(|value| core::str::from_utf8(value).ok())?;
+            let sigil = field
+                .arg
+                .sigil
+                .and_then(|value| core::str::from_utf8(value).ok())?;
             token
                 .strip_prefix(sigil)
                 .map(|prefix| (owner, field, sigil, prefix))
@@ -2697,6 +2731,11 @@ mod tests {
 
     #[test]
     fn sigil_completion_matches_the_stripped_value_and_restores_the_prefix() {
+        static FILE_ARG: Arg = Arg {
+            key: 89,
+            name: "file",
+            ..Arg::REQUIRED
+        };
         static OVERLAY: Arg = Arg {
             key: 90,
             name: "TOOL",
@@ -2705,16 +2744,22 @@ mod tests {
         };
         static COMMAND: Command = Command {
             name: "ex",
-            args: &[&OVERLAY],
+            args: &[&FILE_ARG, &OVERLAY],
             ..Command::EMPTY
         };
         static META: CommandMeta = CommandMeta {
             cmd: &COMMAND,
-            args: &[ArgMeta {
-                arg: &OVERLAY,
-                choices: &["node@22", "node@24", "python@3.14"],
-                ..ArgMeta::EMPTY
-            }],
+            args: &[
+                ArgMeta {
+                    arg: &FILE_ARG,
+                    ..ArgMeta::EMPTY
+                },
+                ArgMeta {
+                    arg: &OVERLAY,
+                    choices: &["node@22", "node@24", "python@3.14"],
+                    ..ArgMeta::EMPTY
+                },
+            ],
             ..CommandMeta::EMPTY
         };
         static SIGIL_SPEC: Spec = Spec {
@@ -2730,6 +2775,22 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(values, ["+node@22", "+node@24"]);
         assert!(candidates(&SIGIL_SPEC, &at_end("ex -- +n")).is_empty());
+
+        // The ordinary positional would ask the shell for files, but a sigil token is
+        // classified as the closed-choice overlay field even when no choice matches.
+        assert_eq!(complete(&SIGIL_SPEC, &at_end("ex +z")).files, None);
+
+        static RUNTIME: [CompletionOverlay<'static>; 1] =
+            [CompletionOverlay::async_any("TOOL", runtime_tools)];
+        let dynamic = run_ready(complete_with(&SIGIL_SPEC, &at_end("ex +r"), &RUNTIME));
+        assert_eq!(
+            dynamic
+                .candidates
+                .iter()
+                .map(|candidate| candidate.value.as_str())
+                .collect::<Vec<_>>(),
+            ["+ruby"]
+        );
     }
 
     fn runtime_tools(ctx: CompleteCtx<'_>) -> CompletionFuture<'_> {

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -497,8 +497,7 @@ fn trace_from<'a>(
     let chain = metadata_chain_on_route(spec, &position);
     let meta = chain.as_ref().and_then(|chain| chain.last().copied());
     let next_arg = if restarted(meta, split) {
-        meta.and_then(|meta| meta.args.first())
-            .map(|field| field.arg)
+        meta.and_then(first_ordinary_arg).map(|field| field.arg)
     } else {
         position
             .next_arg
@@ -1088,7 +1087,7 @@ fn declared_files_at_cursor(
     let after_restart = restarted(meta, split);
     let sigil_cursor = sigil_arg_at_cursor(spec, position, split);
     let at_cursor = if after_restart {
-        meta.and_then(|m| m.args.first()).map(|m| m.arg)
+        meta.and_then(first_ordinary_arg).map(|m| m.arg)
     } else {
         sigil_cursor
             .map(|(_, field, _, _)| field.arg)
@@ -1190,12 +1189,13 @@ fn complete_inner<'a>(
 
     // Which argument the cursor is at — the same question `candidates` answers, asked once so
     // that the two halves cannot disagree. Past a restart token it is the command's *first*
-    // argument, whatever the words before the token filled, and everything below follows from
-    // that: whether paths belong, whether the set is declared, whether a separator is owed.
+    // ordinary argument, whatever the words before the token filled, and everything below
+    // follows from that: whether paths belong, whether the set is declared, whether a separator
+    // is owed. Sigil arguments are overlays and do not occupy the positional cursor.
     let after_restart = restarted(meta, split);
     let sigil_cursor = sigil_arg_at_cursor(spec, &position, split);
     let at_cursor = if after_restart {
-        meta.and_then(|m| m.args.first()).map(|m| m.arg)
+        meta.and_then(first_ordinary_arg).map(|m| m.arg)
     } else {
         sigil_cursor
             .map(|(_, field, _, _)| field.arg)
@@ -1463,7 +1463,7 @@ fn overlay_at_cursor<'o>(
     let sigil_target = sigil_arg_at_cursor(spec, position, split);
     let target = if restarted(meta, split) {
         meta.and_then(|owner| {
-            owner.args.first().map(|field| {
+            first_ordinary_arg(owner).map(|field| {
                 (
                     owner,
                     field.arg.name,
@@ -1601,7 +1601,12 @@ fn default_subcommand_arg<'a>(
     subcommands()
         .find(|sub| sub.cmd.name == default)
         .or_else(|| subcommands().find(|sub| sub.cmd.aliases.contains(&default)))
-        .and_then(|sub| sub.args.first().map(|field| (sub, field)))
+        .and_then(|sub| first_ordinary_arg(sub).map(|field| (sub, field)))
+}
+
+/// The first argument that advances the ordinary positional cursor.
+fn first_ordinary_arg<'m, 'a>(meta: &'m CommandMeta<'a>) -> Option<&'m ArgMeta<'a>> {
+    meta.args.iter().find(|field| field.arg.sigil.is_none())
 }
 
 /// The metadata route selected by the parser, preserving parent identity even when two
@@ -1675,9 +1680,9 @@ fn candidates_inner<'a>(
         short_flags(spec, &position, token)
     } else if restarted(meta, split) {
         // Past a restart token — mise's `:::`, which starts a fresh invocation of the same
-        // command — the cursor is at that command's *first* argument again, whatever the
-        // words before the token filled.
-        meta.and_then(|m| m.args.first())
+        // command — the cursor is at that command's first ordinary argument again, whatever
+        // the words before the token filled. Sigil arguments do not occupy that cursor.
+        meta.and_then(first_ordinary_arg)
             .map(|m| positional(m, &position, split, token))
             .unwrap_or_default()
     } else if let Some(flag) = position.awaiting_value {
@@ -2757,7 +2762,7 @@ mod tests {
         static COMMAND: Command = Command {
             name: "ex",
             flags: &[&JOBS],
-            args: &[&FILE_ARG, &OVERLAY],
+            args: &[&OVERLAY, &FILE_ARG],
             ..Command::EMPTY
         };
         static META: CommandMeta = CommandMeta {
@@ -2769,12 +2774,12 @@ mod tests {
             }],
             args: &[
                 ArgMeta {
-                    arg: &FILE_ARG,
+                    arg: &OVERLAY,
+                    choices: &["node@22", "node@24", "python@3.14"],
                     ..ArgMeta::EMPTY
                 },
                 ArgMeta {
-                    arg: &OVERLAY,
-                    choices: &["node@22", "node@24", "python@3.14"],
+                    arg: &FILE_ARG,
                     ..ArgMeta::EMPTY
                 },
             ],

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -1539,7 +1539,7 @@ fn sigil_arg_at_cursor<'a, 'p>(
     split: &'p Split,
 ) -> Option<(&'a CommandMeta<'a>, &'a ArgMeta<'a>, &'a str, &'p str)> {
     let meta = metadata_chain_on_route(spec, position).and_then(|chain| chain.last().copied());
-    if !position.flags_possible || position.awaiting_value.is_some() || restarted(meta, split) {
+    if !position.flags_possible || position.awaiting_value.is_some() || restart_seen(meta, split) {
         return None;
     }
     let token = split.prefix.as_str();
@@ -1757,6 +1757,13 @@ fn restarted(meta: Option<&CommandMeta<'_>>, split: &Split) -> bool {
         return false;
     };
     split.cword > 0 && split.words[split.cword - 1] == token
+}
+
+fn restart_seen(meta: Option<&CommandMeta<'_>>, split: &Split) -> bool {
+    let Some(token) = meta.and_then(|m| m.restart_token) else {
+        return false;
+    };
+    split.words[..split.cword].iter().any(|word| word == token)
 }
 
 /// The subcommands a word here could name, each under every name it answers to.
@@ -2796,6 +2803,10 @@ mod tests {
         );
         assert_eq!(
             complete(&SIGIL_SPEC, &at_end("ex file ::: +z")).files,
+            Some(Files::Any)
+        );
+        assert_eq!(
+            complete(&SIGIL_SPEC, &at_end("ex file ::: value +z")).files,
             Some(Files::Any)
         );
 

--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -1086,10 +1086,11 @@ fn declared_files_at_cursor(
     }
     let meta = metadata_chain_on_route(spec, position).and_then(|chain| chain.last().copied());
     let after_restart = restarted(meta, split);
+    let sigil_cursor = sigil_arg_at_cursor(spec, position, &split.prefix);
     let at_cursor = if after_restart {
         meta.and_then(|m| m.args.first()).map(|m| m.arg)
     } else {
-        sigil_arg_at_cursor(spec, position, &split.prefix)
+        sigil_cursor
             .map(|(_, field, _, _)| field.arg)
             .or(position.next_arg)
             .or_else(|| default_subcommand_arg(spec, split, position).map(|(_, field)| field.arg))
@@ -1099,6 +1100,9 @@ fn declared_files_at_cursor(
         && at_cursor.is_some_and(|arg| arg.double_dash == crate::DoubleDash::Required)
         && !position.separator_seen
     {
+        return None;
+    }
+    if sigil_cursor.is_some() {
         return None;
     }
     let value_flag = position
@@ -1189,10 +1193,11 @@ fn complete_inner<'a>(
     // argument, whatever the words before the token filled, and everything below follows from
     // that: whether paths belong, whether the set is declared, whether a separator is owed.
     let after_restart = restarted(meta, split);
+    let sigil_cursor = sigil_arg_at_cursor(spec, &position, token);
     let at_cursor = if after_restart {
         meta.and_then(|m| m.args.first()).map(|m| m.arg)
     } else {
-        sigil_arg_at_cursor(spec, &position, token)
+        sigil_cursor
             .map(|(_, field, _, _)| field.arg)
             .or(position.next_arg)
     };
@@ -1263,7 +1268,7 @@ fn complete_inner<'a>(
     let closed =
         !candidates.is_empty() || declares_choices || declared_non_file_type || position.help_topic;
 
-    let files = if flag_like || needs_separator {
+    let files = if flag_like || needs_separator || sigil_cursor.is_some() {
         None
     } else if asked_for.is_some() {
         asked_for
@@ -2779,6 +2784,29 @@ mod tests {
         // The ordinary positional would ask the shell for files, but a sigil token is
         // classified as the closed-choice overlay field even when no choice matches.
         assert_eq!(complete(&SIGIL_SPEC, &at_end("ex +z")).files, None);
+
+        static OPEN_META: CommandMeta = CommandMeta {
+            cmd: &COMMAND,
+            args: &[
+                ArgMeta {
+                    arg: &FILE_ARG,
+                    ..ArgMeta::EMPTY
+                },
+                ArgMeta {
+                    arg: &OVERLAY,
+                    complete_type: Some("path"),
+                    ..ArgMeta::EMPTY
+                },
+            ],
+            ..CommandMeta::EMPTY
+        };
+        static OPEN_SIGIL_SPEC: Spec = Spec {
+            name: "ex",
+            bin: Some("ex"),
+            root: &OPEN_META,
+            ..Spec::EMPTY
+        };
+        assert_eq!(complete(&OPEN_SIGIL_SPEC, &at_end("ex +z")).files, None);
 
         static RUNTIME: [CompletionOverlay<'static>; 1] =
             [CompletionOverlay::async_any("TOOL", runtime_tools)];

--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -189,19 +189,21 @@ impl CompleteWord {
         // An explicit `--` stops the parser reading flags, so past one there is no such thing
         // as a flag to complete — a dash-prefixed word is a positional value.
         let flags_possible = !parsed.double_dash_seen;
-        let sigil_arg = flags_possible.then(|| {
-            parsed
-                .cmds
-                .iter()
-                .flat_map(|cmd| cmd.args.iter())
-                .filter_map(|arg| {
-                    let sigil = arg.sigil.as_deref()?;
-                    ctoken
-                        .strip_prefix(sigil)
-                        .map(|prefix| (arg, sigil, prefix))
-                })
-                .max_by_key(|(_, sigil, _)| sigil.len())
-        }).flatten();
+        let sigil_arg = flags_possible
+            .then(|| {
+                parsed
+                    .cmds
+                    .iter()
+                    .flat_map(|cmd| cmd.args.iter())
+                    .filter_map(|arg| {
+                        let sigil = arg.sigil.as_deref()?;
+                        ctoken
+                            .strip_prefix(sigil)
+                            .map(|prefix| (arg, sigil, prefix))
+                    })
+                    .max_by_key(|(_, sigil, _)| sigil.len())
+            })
+            .flatten();
         let mut choices = if flags_possible && ctoken == "-" {
             let shorts = self.complete_short_flag_names(&flags, "");
             let longs = self.complete_long_flag_names(&flags, "");

--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -189,6 +189,19 @@ impl CompleteWord {
         // An explicit `--` stops the parser reading flags, so past one there is no such thing
         // as a flag to complete — a dash-prefixed word is a positional value.
         let flags_possible = !parsed.double_dash_seen;
+        let sigil_arg = flags_possible.then(|| {
+            parsed
+                .cmds
+                .iter()
+                .flat_map(|cmd| cmd.args.iter())
+                .filter_map(|arg| {
+                    let sigil = arg.sigil.as_deref()?;
+                    ctoken
+                        .strip_prefix(sigil)
+                        .map(|prefix| (arg, sigil, prefix))
+                })
+                .max_by_key(|(_, sigil, _)| sigil.len())
+        }).flatten();
         let mut choices = if flags_possible && ctoken == "-" {
             let shorts = self.complete_short_flag_names(&flags, "");
             let longs = self.complete_long_flag_names(&flags, "");
@@ -218,6 +231,13 @@ impl CompleteWord {
             let arg = flag.arg.as_ref().unwrap();
             let (found, closed) = self.complete_arg(&cx, &parsed.cmd, arg, &ctoken)?;
             has_explicit_choices = closed || arg.choices.is_some();
+            found
+        } else if let Some((arg, sigil, prefix)) = sigil_arg {
+            let (mut found, closed) = self.complete_arg(&cx, &parsed.cmd, arg, prefix)?;
+            for (candidate, _) in &mut found {
+                candidate.insert_str(0, sigil);
+            }
+            has_explicit_choices = closed || arg.choices.is_some() || found.is_empty();
             found
         } else {
             let mut choices = vec![];

--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -164,7 +164,8 @@ impl CompleteWord {
             });
         }
 
-        // Check if previous token was a restart_token - if so, complete from first arg
+        // Check if previous token was a restart_token - if so, complete from the first
+        // ordinary arg. Sigil arguments are overlays and do not occupy that cursor.
         let prev_token = if cword > 0 {
             self.words.get(cword - 1).map(|s| s.as_str())
         } else {
@@ -240,11 +241,11 @@ impl CompleteWord {
         } else if flags_possible && ctoken.starts_with('-') {
             self.complete_short_flag_names(&flags, &ctoken)
         } else if after_restart_token {
-            // After a restart_token, complete from the first arg of the current command
+            // After a restart_token, complete from the first ordinary arg of the current command
             // This must be checked after flag checks (to allow --flag after :::)
             // but before flag_awaiting_value (since restart clears pending flag values)
             let mut choices = vec![];
-            if let Some(arg) = parsed.cmd.args.first() {
+            if let Some(arg) = first_ordinary_arg(&parsed.cmd) {
                 let (found, constrained) = self.complete_positional(
                     &cx,
                     &parsed.cmd,
@@ -304,7 +305,7 @@ impl CompleteWord {
             if parsed.cmd.name == spec.cmd.name {
                 if let Some(default_name) = &spec.default_subcommand {
                     if let Some(default_cmd) = spec.cmd.find_subcommand(default_name) {
-                        // Include completions from default subcommand's first arg.
+                        // Include completions from default subcommand's first ordinary arg.
                         //
                         // The `constrained` half is dropped on purpose: unlike the two call
                         // sites above, this arg belongs to a *different* command and is only
@@ -314,7 +315,7 @@ impl CompleteWord {
                         // them — see `complete_word_default_subcommand_choices_do_not_block_
                         // root_file_fallback`. The `double_dash="required"` rule does apply,
                         // which is why this goes through the helper at all.
-                        if let Some(arg) = default_cmd.args.first() {
+                        if let Some(arg) = first_ordinary_arg(default_cmd) {
                             let (found, _) = self.complete_positional(
                                 &cx,
                                 default_cmd,
@@ -1063,6 +1064,11 @@ struct Ctx<'a> {
     spec: &'a Spec,
     parsed: &'a ParseOutput,
     after_restart_token: bool,
+}
+
+/// The first argument that advances the ordinary positional cursor.
+fn first_ordinary_arg(cmd: &SpecCommand) -> Option<&SpecArg> {
+    cmd.args.iter().find(|arg| arg.sigil.is_none())
 }
 
 /// A description reduced to one line.

--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -221,14 +221,14 @@ impl CompleteWord {
             parsed
                 .cmds
                 .iter()
-                .flat_map(|cmd| cmd.args.iter())
-                .filter_map(|arg| {
+                .flat_map(|cmd| cmd.args.iter().map(move |arg| (cmd, arg)))
+                .filter_map(|(cmd, arg)| {
                     let sigil = arg.sigil.as_deref()?;
                     ctoken
                         .strip_prefix(sigil)
-                        .map(|prefix| (arg, sigil, prefix))
+                        .map(|prefix| (cmd, arg, sigil, prefix))
                 })
-                .max_by_key(|(_, sigil, _)| sigil.len())
+                .max_by_key(|(_, _, sigil, _)| sigil.len())
         })
         .flatten();
         let mut choices = if flags_possible && ctoken == "-" {
@@ -261,8 +261,8 @@ impl CompleteWord {
             let (found, closed) = self.complete_arg(&cx, &parsed.cmd, arg, &ctoken)?;
             has_explicit_choices = closed || arg.choices.is_some();
             found
-        } else if let Some((arg, sigil, prefix)) = sigil_arg {
-            let (mut found, closed) = self.complete_arg(&cx, &parsed.cmd, arg, prefix)?;
+        } else if let Some((owner, arg, sigil, prefix)) = sigil_arg {
+            let (mut found, closed) = self.complete_arg(&cx, owner, arg, prefix)?;
             for (candidate, _) in &mut found {
                 candidate.insert_str(0, sigil);
             }

--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -262,7 +262,23 @@ impl CompleteWord {
             has_explicit_choices = closed || arg.choices.is_some();
             found
         } else if let Some((owner, arg, sigil, prefix)) = sigil_arg {
-            let (mut found, closed) = self.complete_arg(&cx, owner, arg, prefix)?;
+            // A dynamic completer and the candidate filter must see the same word. The
+            // parser removes a sigil before binding its value, so expose that stripped
+            // value through `words[CURRENT]` too; the prefix is restored only after the
+            // completer has answered.
+            let mut sigil_ctx = ctx.clone();
+            let mut sigil_words = self.words.clone();
+            if let Some(current) = sigil_words.get_mut(cword) {
+                *current = prefix.to_string();
+            }
+            sigil_ctx.insert("words", &sigil_words);
+            let sigil_cx = Ctx {
+                tera: &sigil_ctx,
+                spec: cx.spec,
+                parsed: cx.parsed,
+                after_restart_token: cx.after_restart_token,
+            };
+            let (mut found, closed) = self.complete_arg(&sigil_cx, owner, arg, prefix)?;
             for (candidate, _) in &mut found {
                 candidate.insert_str(0, sigil);
             }

--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -188,22 +188,49 @@ impl CompleteWord {
         let flags = parsed.completion_flags();
         // An explicit `--` stops the parser reading flags, so past one there is no such thing
         // as a flag to complete — a dash-prefixed word is a positional value.
-        let flags_possible = !parsed.double_dash_seen;
-        let sigil_arg = flags_possible
-            .then(|| {
-                parsed
-                    .cmds
+        let restart_seen = parsed.tokens.iter().any(|token| {
+            token
+                .roles
+                .iter()
+                .any(|role| matches!(role, usage::parse::TokenRole::Restart))
+        });
+        let automatic_trailing_seen = parsed
+            .tokens
+            .iter()
+            .rev()
+            .take_while(|token| {
+                !token
+                    .roles
                     .iter()
-                    .flat_map(|cmd| cmd.args.iter())
-                    .filter_map(|arg| {
-                        let sigil = arg.sigil.as_deref()?;
-                        ctoken
-                            .strip_prefix(sigil)
-                            .map(|prefix| (arg, sigil, prefix))
-                    })
-                    .max_by_key(|(_, sigil, _)| sigil.len())
+                    .any(|role| matches!(role, usage::parse::TokenRole::Restart))
             })
-            .flatten();
+            .flat_map(|token| &token.roles)
+            .any(|role| match role {
+                usage::parse::TokenRole::Arg { arg, .. }
+                | usage::parse::TokenRole::Sigil { arg, .. } => {
+                    arg.double_dash == usage::SpecDoubleDashChoices::Automatic
+                }
+                _ => false,
+            });
+        let flags_possible = !parsed.double_dash_seen && !automatic_trailing_seen;
+        let sigil_arg = (flags_possible
+            && !restart_seen
+            && !after_restart_token
+            && parsed.flag_awaiting_value.is_empty())
+        .then(|| {
+            parsed
+                .cmds
+                .iter()
+                .flat_map(|cmd| cmd.args.iter())
+                .filter_map(|arg| {
+                    let sigil = arg.sigil.as_deref()?;
+                    ctoken
+                        .strip_prefix(sigil)
+                        .map(|prefix| (arg, sigil, prefix))
+                })
+                .max_by_key(|(_, sigil, _)| sigil.len())
+        })
+        .flatten();
         let mut choices = if flags_possible && ctoken == "-" {
             let shorts = self.complete_short_flag_names(&flags, "");
             let longs = self.complete_long_flag_names(&flags, "");

--- a/cli/tests/complete_word.rs
+++ b/cli/tests/complete_word.rs
@@ -253,6 +253,15 @@ fn complete_word_choices() {
 }
 
 #[test]
+fn complete_word_sigil_arg_strips_for_matching_and_restores_for_output() {
+    assert_cmd("sigil.usage.kdl", &["--", "+n"]).stdout("+node@22\n+node@24\n");
+    assert_cmd("sigil.usage.kdl", &["--", "+"])
+        .stdout("+node@22\n+node@24\n+python@3.14\n");
+    // A separator protects the same token from sigil classification.
+    assert_cmd("sigil.usage.kdl", &["--", "--", "+n"]).stdout("");
+}
+
+#[test]
 fn complete_word_choices_from_env() {
     cmd("env-choices.usage.kdl", Some("fish"))
         .env("DEPLOY_ENVS", "foo,bar baz")

--- a/cli/tests/complete_word.rs
+++ b/cli/tests/complete_word.rs
@@ -255,8 +255,7 @@ fn complete_word_choices() {
 #[test]
 fn complete_word_sigil_arg_strips_for_matching_and_restores_for_output() {
     assert_cmd("sigil.usage.kdl", &["--", "+n"]).stdout("+node@22\n+node@24\n");
-    assert_cmd("sigil.usage.kdl", &["--", "+"])
-        .stdout("+node@22\n+node@24\n+python@3.14\n");
+    assert_cmd("sigil.usage.kdl", &["--", "+"]).stdout("+node@22\n+node@24\n+python@3.14\n");
     // A separator protects the same token from sigil classification.
     assert_cmd("sigil.usage.kdl", &["--", "--", "+n"]).stdout("");
 }

--- a/cli/tests/complete_word.rs
+++ b/cli/tests/complete_word.rs
@@ -261,6 +261,23 @@ fn complete_word_sigil_arg_strips_for_matching_and_restores_for_output() {
 }
 
 #[test]
+fn complete_word_sigil_run_receives_the_stripped_current_word() {
+    let spec = r#"
+name "ex"
+bin "ex"
+arg "[tool]..." sigil="+"
+complete "tool" run="printf '%s\\n' {{ words[CURRENT] | shell_quote }}"
+"#;
+    Command::new(cargo::cargo_bin!("usage"))
+        .args([
+            "cw", "--shell", "fish", "--spec", spec, "--", "mycli", "+node",
+        ])
+        .assert()
+        .success()
+        .stdout("+node\n");
+}
+
+#[test]
 fn complete_word_choices_from_env() {
     cmd("env-choices.usage.kdl", Some("fish"))
         .env("DEPLOY_ENVS", "foo,bar baz")

--- a/cli/tests/complete_word.rs
+++ b/cli/tests/complete_word.rs
@@ -278,6 +278,29 @@ complete "tool" run="printf '%s\\n' {{ words[CURRENT] | shell_quote }}"
 }
 
 #[test]
+fn complete_word_restart_skips_leading_sigil_args() {
+    let spec = r#"
+name "ex"
+bin "ex"
+cmd "run" restart_token=":::" {
+    arg "[tool]..." sigil="+" {
+        choices "node@22" "node@24"
+    }
+    arg "<command>" {
+        choices "build" "check"
+    }
+}
+"#;
+    Command::new(cargo::cargo_bin!("usage"))
+        .args([
+            "cw", "--shell", "fish", "--spec", spec, "--", "mycli", "run", "build", ":::", "b",
+        ])
+        .assert()
+        .success()
+        .stdout("build\n");
+}
+
+#[test]
 fn complete_word_choices_from_env() {
     cmd("env-choices.usage.kdl", Some("fish"))
         .env("DEPLOY_ENVS", "foo,bar baz")

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -120,6 +120,7 @@ export default defineConfig({
             link: "/spec/reference/",
             items: [
               { text: "arg", link: "/spec/reference/arg" },
+              { text: "sigils", link: "/spec/reference/sigils" },
               { text: "cmd", link: "/spec/reference/cmd" },
               { text: "complete", link: "/spec/reference/complete" },
               { text: "flag", link: "/spec/reference/flag" },

--- a/docs/spec/reference/sigils.md
+++ b/docs/spec/reference/sigils.md
@@ -1,0 +1,68 @@
+# Sigil arguments
+
+A sigil argument is a positional classified by a leading prefix instead of by its
+place in the positional sequence. The prefix is syntax: the parser removes it before
+storing, validating, or completing the value.
+
+```kdl
+min_usage_version "6.5"
+
+arg "[tool]..." sigil="+" {
+  choices "node@22" "node@24" "python@3.14"
+}
+arg "<command>"
+arg "[args]..."
+```
+
+With that declaration, `ex +node@24 node -v` binds `tool=["node@24"]`,
+`command="node"`, and `args=["-v"]`. A sigil argument never advances the ordinary
+positional cursor, so several classified values can appear before the command.
+
+## Matching
+
+Sigils follow a deliberately small grammar:
+
+- A token must start with the declared sigil and contain at least one byte after it.
+  A bare `+` is ordinary positional data.
+- When declarations overlap, the longest prefix wins. With `sigil="+"` and
+  `sigil="++"`, `++edge` belongs to the latter and stores `edge`.
+- A flag waiting for a detached value wins before sigil matching, so
+  `--label +raw` stores the literal flag value `+raw`.
+- Sigils are recognized only while flags are enabled and only in the leading segment.
+  An explicit `--`, the first value of a `double_dash="automatic"` argument, or a
+  command restart boundary makes later sigil-shaped tokens ordinary data.
+- Binding a sigil argument does not block a later subcommand from being selected.
+
+The sigil must be non-empty, may not start with `-`, and may not contain whitespace.
+Each command may declare a sigil only once. Sigil arguments cannot use
+`value_terminator` or a non-optional `double_dash` policy.
+
+## Completion
+
+Completion uses the argument declaration after removing the prefix, then restores the
+prefix on every candidate. Given the example above, completing `+n` offers
+`+node@22` and `+node@24`. This applies equally to fixed `choices`, built-in completion
+types, and runtime completers.
+
+The prefix is part of the shell word. Bash, zsh, fish, nushell, and PowerShell all pass
+`+node` as one completion token; no shell-specific escaping is required.
+
+## Rust derive
+
+The same declaration is available on typed Rust fields:
+
+```rust
+#[derive(usage::Cli)]
+struct Cli {
+    #[usage(sigil = "+")]
+    tools: Vec<String>,
+    command: String,
+    args: Vec<String>,
+}
+```
+
+Generated Rust and Go tables carry the sigil in their hot parser metadata, so parsing,
+completion, emitted KDL, and generated SDK invocation builders use the same contract.
+
+Sigils classify individual arguments. For a repeatable sequence made of several
+positionals separated by a boundary token, use a [clause](./clause.md).

--- a/docs/spec/reference/sigils.md
+++ b/docs/spec/reference/sigils.md
@@ -23,18 +23,22 @@ positional cursor, so several classified values can appear before the command.
 Sigils follow a deliberately small grammar:
 
 - A token must start with the declared sigil and contain at least one byte after it.
-  A bare `+` is ordinary positional data.
-- When declarations overlap, the longest prefix wins. With `sigil="+"` and
-  `sigil="++"`, `++edge` belongs to the latter and stores `edge`.
+  A bare `+` is an invalid value; write `-- +` when it should be ordinary positional
+  data.
+- Active sigils must be prefix-free. Declarations such as `sigil="+"` and
+  `sigil="++"` are rejected instead of assigning meaning by longest-prefix order.
 - A flag waiting for a detached value wins before sigil matching, so
   `--label +raw` stores the literal flag value `+raw`.
-- Sigils are recognized only while flags are enabled and only in the leading segment.
-  An explicit `--`, the first value of a `double_dash="automatic"` argument, or a
+- Sigils are recognized while flags are enabled, including after ordinary positional
+  values and in subcommands. A subcommand inherits the sigils declared by its
+  ancestors.
+- An explicit `--`, the first value of a `double_dash="automatic"` argument, or a
   command restart boundary makes later sigil-shaped tokens ordinary data.
 - Binding a sigil argument does not block a later subcommand from being selected.
 
 The sigil must be non-empty, may not start with `-`, and may not contain whitespace.
-Each command may declare a sigil only once. Sigil arguments cannot use
+No command may introduce a sigil that overlaps another sigil active at that command.
+Sigil arguments cannot use
 `value_terminator` or a non-optional `double_dash` policy.
 
 ## Completion

--- a/examples/sigil.usage.kdl
+++ b/examples/sigil.usage.kdl
@@ -1,0 +1,7 @@
+min_usage_version "6.5"
+name "Sigil example"
+bin "sigil"
+arg "[tool]..." sigil="+" help="Temporary tool selection" {
+  choices "node@22" "node@24" "python@3.14"
+}
+arg "<command>" help="Command to run"


### PR DESCRIPTION
## Summary
- match completions against the value after the declared sigil
- restore the sigil on emitted completion candidates
- keep explicit double dash behavior intact
- add dedicated sigil documentation and completion examples

## Stack
- Depends on #1322

## Test plan
- cargo test -p usage-cli complete_word_sigil
- cargo test -p usage-conformance --test sigil
- mise run lint

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Completion routing changes are broad (argv, CLI, overlays, file fallback, restart/`--` edge cases) and user-visible at the shell, though scoped to completion with new tests.
> 
> **Overview**
> **Tab completion now understands arguments declared with a `sigil` prefix** (for example `+node@22`). When the current word starts with that prefix, matchers use the text *after* the sigil and put the prefix back on every candidate. The same strip/restore behavior applies to static choices, declared completion types, and runtime/async overlays.
> 
> **Sigil fields are treated as overlays on the positional cursor**, not the next ordinary slot. Restart handling (`:::`), default-subcommand guessing, file fallback, and overlay targeting all use a new **`first_ordinary_arg`** helper so leading sigil-only args are skipped. **`sigil_arg_at_cursor`** (and the parallel logic in `complete_word`) picks the longest active sigil; sigil completion is disabled after `--`, when a flag is awaiting a value, or once a restart token has appeared earlier on the line. Explicit `--` still prevents classifying `+…` as a sigil.
> 
> The **usage CLI `cw` path** mirrors the argv engine: `run=` completers see the stripped current word via an adjusted Tera `words` context, and **`flags_possible`** also turns off after an `automatic` double-dash trailing segment. **Docs and tests** add a sigils reference page, an example spec, and coverage for choices, runtime completion, restart, and separator behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d27ebdb6f9dc2b669159c2c5ce11e6c9b5982ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->