### PR TITLE
chore(sponsors): replace 37signals with omacom foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ the supported mappings and intentional differences.
 
 ## Sponsors
 
-usage is sponsored by [entire.io](https://entire.io) and [37signals](https://37signals.com).
+usage is sponsored by [entire.io](https://entire.io) and [Omacom Foundation](https://omarchy.org/patrons/).
 
 [View all sponsors](https://jdx.dev/sponsors.html).
 

--- a/cli/src/cli/sponsors.rs
+++ b/cli/src/cli/sponsors.rs
@@ -14,7 +14,7 @@ impl usage_rs::Run for Sponsors {
 
     fn run(self) -> Self::Output {
         println!(
-            "usage and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n\nView all sponsors: https://jdx.dev/sponsors.html"
+            "usage and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  Omacom Foundation - https://omarchy.org/patrons/\n\nView all sponsors: https://jdx.dev/sponsors.html"
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary
- replace 37signals with the Omacom Foundation in the README
- update the `usage sponsors` output and foundation link

## Verification
- `cargo fmt --all --check`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated sponsor attribution in the README to the Omacom Foundation.
  * Updated the CLI sponsor message with the Omacom Foundation name and patrons link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->