### PR TITLE
docs: add sponsor logos to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,24 @@ the supported mappings and intentional differences.
 
 ## Sponsors
 
-usage is sponsored by [entire.io](https://entire.io) and [Omacom Foundation](https://omarchy.org/patrons/).
-
-[View all sponsors](https://jdx.dev/sponsors.html).
+<p align="center">
+  Sponsored by<br><br>
+  <a href="https://entire.io">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://jdx.dev/sponsors/entire-lockup.svg">
+      <img src="https://jdx.dev/sponsors/entire-lockup-on-light.svg" alt="Entire" height="36">
+    </picture>
+  </a>
+  &nbsp;&nbsp;&nbsp;
+  <a href="https://omarchy.org/patrons/">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://jdx.dev/sponsors/omacom-foundation.svg">
+      <img src="https://jdx.dev/sponsors/omacom-foundation-on-light.svg" alt="Omacom Foundation" height="36">
+    </picture>
+  </a>
+  <br><br>
+  <a href="https://jdx.dev/sponsors.html">View all sponsors</a>
+</p>
 
 ## Acknowledgements
 


### PR DESCRIPTION
## Summary
- replace the text-only sponsor line with linked Entire and Omarchy wordmarks
- select dark- or light-background assets based on the reader theme
- retain the link to the complete sponsor list

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README formatting with external image URLs; no runtime or security impact.
> 
> **Overview**
> The **Sponsors** section in `README.md` no longer uses a single text line naming Entire and Omacom Foundation. It now uses a centered HTML block with **linked wordmark images** for both sponsors.
> 
> Each logo uses a `<picture>` element so **dark- or light-theme SVGs** load from `jdx.dev` based on `prefers-color-scheme`. The **View all sponsors** link to `jdx.dev/sponsors.html` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26fab368d085108219cfc876bd1ffa1e9f78f254. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->