### PR TITLE
fix: simplify required-unless predicates

### DIFF
--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -2434,9 +2434,9 @@ fn parse_partial_traced(
                 && arg.required_unless_all.iter().all(|selector| {
                     selector_is_explicit(selector, &out, &overridden_flags, custom_env)
                 });
-            let required_unless = (!arg.required_unless.is_empty()
-                || !arg.required_unless_all.is_empty())
-                && !(unless_any || unless_all);
+            let required_unless = !(unless_any
+                || unless_all
+                || (arg.required_unless.is_empty() && arg.required_unless_all.is_empty()));
             if (arg.required
                 || required_if
                 || required_if_eq
@@ -2720,9 +2720,9 @@ fn parse_partial_traced(
                 && flag.required_unless_all.iter().all(|selector| {
                     selector_is_explicit(selector, &out, &overridden_flags, custom_env)
                 });
-            let required_unless = (!flag.required_unless.is_empty()
-                || !flag.required_unless_all.is_empty())
-                && !(unless_any || unless_all);
+            let required_unless = !(unless_any
+                || unless_all
+                || (flag.required_unless.is_empty() && flag.required_unless_all.is_empty()));
             if (flag.required
                 || required_if
                 || required_if_eq


### PR DESCRIPTION
## Summary

- simplify the equivalent `required_unless` predicates for arguments and flags
- keep the existing behavior while satisfying current clippy `nonminimal_bool`

## Validation

- `cargo fmt --check -- lib/src/parse.rs`
- `cargo clippy -p usage-lib --no-default-features -- -D warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only change to equivalent boolean logic in CLI validation; no intended behavior change.
> 
> **Overview**
> Rewrites how **`required_unless`** is computed when validating missing args and flags in **`parse.rs`**. The old form `(lists non-empty) && !(unless satisfied)` is replaced with a single negated OR: not `(unless_any || unless_all || no unless rules defined)`.
> 
> **Behavior is unchanged**—only the boolean shape changes so **`clippy::nonminimal_bool`** passes with `-D warnings`. The same logic is applied in both the argument and flag missing-value checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c3e278cd1c9939dc11acf6b9d8bd93fb17bfba9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected requiredness validation for positional arguments and flags.
  - Missing-value errors are now reported consistently when no conditional exceptions are configured.
  - Updated handling ensures required-unless conditions correctly reflect whether any exception selectors match.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->