### PR TITLE
fix: keep generated shadow source clippy-clean

### DIFF
--- a/xtask/src/shadow.rs
+++ b/xtask/src/shadow.rs
@@ -1920,7 +1920,7 @@ fn needs_declaring(help: Option<&str>, long: Option<&str>) -> bool {
     // A long form with no short one cannot be a comment at all: a comment's first paragraph *is*
     // the short form, so writing one would invent a short help the spec never gave.
     let long_only =
-        long.is_some_and(|l| !l.trim().is_empty()) && !help.is_some_and(|h| !h.trim().is_empty());
+        long.is_some_and(|l| !l.trim().is_empty()) && help.is_none_or(|h| h.trim().is_empty());
     flowed || independent || long_only
 }
 


### PR DESCRIPTION
`mise run render` runs the clippy autofix task and currently rewrites `xtask/src/shadow.rs`, causing the primary CI render-parity assertion to fail. Commit the equivalent predicate that current Clippy generates.

This is intentionally separate from the mbx adoption PR because the failure also exists on `main` with the current toolchain.

Validation:
- `cargo fmt --all -- --check`
- `cargo clippy -p xtask --all-targets -- -D warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single equivalent boolean refactor in shadow generator logic with existing test coverage for help-declaration behavior.
> 
> **Overview**
> Updates the **`long_only`** branch in **`needs_declaring`** so the “long help without short help” check uses **`help.is_none_or(|h| h.trim().is_empty())`** instead of negating **`help.is_some_and(...)`**.
> 
> Behavior is unchanged; this matches what **`cargo clippy`** autofix emits so **`mise run render`** no longer rewrites **`xtask/src/shadow.rs`** and breaks render-parity CI on **`main`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71efbe9e83b42a81d13b01e7d813f7e688aad60c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal help-text detection logic without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->