### PR TITLE
ci: remove obsolete pre-6 semver guard

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -89,6 +89,7 @@ run = 'cargo clippy --all --all-features --all-targets -- -D warnings'
 [tasks."lint:fmt"]
 run = 'cargo fmt --all -- --check'
 [tasks."lint:semver"]
+tools = { rust = "1.95" }
 # Held back until 6.0 is out, because a break that has been *decided* cannot pass this.
 # `check-release` compares against the published crate, so `feat(lib)!:` work is red from
 # the moment it is written until release-plz ships the major it implies — and a gate that

--- a/mise.toml
+++ b/mise.toml
@@ -90,25 +90,7 @@ run = 'cargo clippy --all --all-features --all-targets -- -D warnings'
 run = 'cargo fmt --all -- --check'
 [tasks."lint:semver"]
 tools = { rust = "1.95" }
-# Held back until 6.0 is out, because a break that has been *decided* cannot pass this.
-# `check-release` compares against the published crate, so `feat(lib)!:` work is red from
-# the moment it is written until release-plz ships the major it implies — and a gate that
-# cannot pass is a gate people learn to ignore, which is worse than not running it.
-#
-# The condition clears itself rather than needing remembering: once the crates are on
-# 6.x, the break is in the published baseline and this runs again, catching the *next*
-# unintended one. Raise the number the same way if a later major is declared the same way.
-#
-# One block rather than a list, because each entry of a list is its own shell and the
-# version would not survive between them.
-run = '''
-major=$(sed -n 's/^version = "\([0-9]*\)\..*/\1/p' lib/Cargo.toml | head -1)
-if [ "$major" -lt 6 ]; then
-  echo "skipped: usage-lib is $major.x, and the 6.0 break this would report is declared rather than accidental"
-  exit 0
-fi
-cargo semver-checks check-release -p usage-lib
-'''
+run = "cargo semver-checks check-release -p usage-lib"
 [tasks."lint:rust-docs-version"]
 run = '''
 major=$(sed -n 's/^version = "\([0-9]*\)\..*/\1/p' lib/Cargo.toml | head -1)

--- a/mise.toml
+++ b/mise.toml
@@ -89,7 +89,6 @@ run = 'cargo clippy --all --all-features --all-targets -- -D warnings'
 [tasks."lint:fmt"]
 run = 'cargo fmt --all -- --check'
 [tasks."lint:semver"]
-tools = { rust = "1.95" }
 run = "cargo semver-checks check-release -p usage-lib"
 [tasks."lint:rust-docs-version"]
 run = '''


### PR DESCRIPTION
`usage-lib` 6.x is published, so the temporary guard that skipped semver checks before the 6.0 release is now dead code. Run `cargo-semver-checks` directly.

The newly published 6.4.1 baseline declares Rust 1.91, so no special toolchain override is needed.

Validation:
- `mise x rust@1.94 -- cargo semver-checks check-release -p usage-lib`
- both current and published 6.4.1 rustdoc builds completed
- 223 semver checks passed, 31 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified semantic version linting for more consistent validation.
  * Removed version-specific requirements and skip behavior from the linting process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->