### PR TITLE
ci: seed mbx cache for fork PRs

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -5,10 +5,19 @@ inputs:
   backend:
     description: Explicit backend for structurally trusted or untrusted callers
     default: auto
+  mirror-github-cache:
+    description: Mirror a trusted main build into the restore-only cache used by fork PRs
+    default: "false"
 
 runs:
   using: composite
   steps:
+    - name: Restore the fork PR cache mirror
+      if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
+      with:
+        version: 0.4.0
+        backend: github
     - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
       with:
         version: 0.4.0

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -35,6 +35,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ inputs.mbx-backend }}
+          mirror-github-cache: "true"
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
       # Retries and a longer wait, rather than being allowed to fail. `cli`'s completion
       # tests refuse to skip a missing shell when `CI` is set — see
@@ -150,6 +151,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ inputs.mbx-backend }}
+          mirror-github-cache: "true"
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
       - run: mise r build
       # `usage bash` runs whatever Windows resolves `bash` to, and `CreateProcess` searches the


### PR DESCRIPTION
## Summary

- restore the fork-facing GitHub Actions mbx cache in one canonical CI job per supported OS
- keep the trusted server backend active for compilation, then save the updated local store under the exact key format fork PRs restore
- restrict mirror writes to jdx pushes on main; fork and other untrusted PR runs remain restore-only and OIDC-free

## Validation

- actionlint
- high-severity zizmor audit
- git diff check
- confirmed release workflows do not enable the mirror

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only cache wiring with mirror writes gated to jdx pushes on main; fork/untrusted runs stay on the existing restore-only GitHub path.
> 
> **Overview**
> Adds an optional **`mirror-github-cache`** input to the **mbx** composite action. When enabled on **jdx** pushes to **main**, it runs an extra **mr-boxington** step with the **GitHub** backend first so trusted CI can warm the same restore-only cache keys fork PRs use, while the existing step still picks **server** vs **GitHub** via **`backend: auto`**.
> 
> The reusable **test-impl** workflow turns mirroring on for the canonical **test** (Linux) and **test-windows** jobs so each supported OS seeds the fork-facing cache during normal main-branch CI. Other callers (e.g. **msrv**) keep the default and do not mirror.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6901774d85b081afae16df4bca636aff116111d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to mirror trusted pushes to the main branch into GitHub’s cache.
  - Enabled cache mirroring for Linux and Windows test workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->