### PR TITLE
fix(zsh): complete aliases with argument prefixes

### DIFF
--- a/argv/src/script.rs
+++ b/argv/src/script.rs
@@ -270,9 +270,34 @@ fn zsh(bin: &str, name: &str) -> String {
 {head}
 _{name}() {{
     local -a values=() descriptions=() inserts=() extensions=()
-    local __usage_files= __usage_line __usage_menu=0
+    local -a __usage_words=()
+    local __usage_files= __usage_line __usage_menu=0 __usage_input __usage_prefix
+    local __usage_unprefixed __usage_command __usage_word
+    local __usage_assignment='^[A-Za-z_][A-Za-z0-9_]*\+?='
+    local -A __usage_aliases_seen=()
     # `$BUFFER[1,CURSOR]` is the text before the cursor, cut with zsh's own offset — see the
     # bash script on why the cutting happens here rather than through a `--cursor` argument.
+    __usage_input="${{BUFFER[1,CURSOR]}}"
+    while (( 1 )); do
+        __usage_prefix="${{__usage_input%%[^[:blank:]]*}}"
+        __usage_unprefixed="${{__usage_input#"$__usage_prefix"}}"
+        __usage_words=("${{(z)__usage_unprefixed}}")
+        __usage_command=
+        for __usage_word in "${{__usage_words[@]}}"; do
+            if [[ "$__usage_word" =~ $__usage_assignment ]]; then
+                __usage_unprefixed="${{__usage_unprefixed#"$__usage_word"}}"
+                __usage_prefix+="$__usage_word${{__usage_unprefixed%%[^[:blank:]]*}}"
+                __usage_unprefixed="${{__usage_unprefixed#"${{__usage_unprefixed%%[^[:blank:]]*}}"}}"
+            else
+                __usage_command="$__usage_word"
+                break
+            fi
+        done
+        [[ "${{+aliases[$__usage_command]}}" == 1 &&
+           -z "${{__usage_aliases_seen[$__usage_command]-}}" ]] || break
+        __usage_aliases_seen[$__usage_command]=1
+        __usage_input="${{__usage_prefix}}${{aliases[$__usage_command]}}${{__usage_unprefixed#"$__usage_command"}}"
+    done
     while IFS= read -r __usage_line; do
         case "$__usage_line" in
             $'\001files') __usage_files=any; continue ;;
@@ -294,7 +319,7 @@ _{name}() {{
         # than silently inserting one of several possibilities.
         [[ "${{parts[3]}}" == "'"* ]] && __usage_menu=1
     done < <(command '{bin}' __complete_word__ --shell zsh \
-        --line "${{BUFFER[1,CURSOR]}}" 2>/dev/null)
+        --line "$__usage_input" 2>/dev/null)
 
     local __usage_ret=1
     (( __usage_menu )) && compstate[insert]=menu

--- a/argv/tests/scripts.rs
+++ b/argv/tests/scripts.rs
@@ -65,7 +65,7 @@ impl Fixture {
     /// and not only on what comes back.
     fn echoing(name: &str, shell: Shell) -> Self {
         let fixture = Self::new(name, shell, "");
-        let stand_in = "#!/usr/bin/env bash\n             line=\nwhile [[ $# -gt 0 ]]; do\n               if [[ $1 == --line ]]; then line=$2; shift; fi\n  shift\ndone\n             printf 'line=[%s]\\n' \"$line\"\n";
+        let stand_in = "#!/usr/bin/env bash\n             line=\nwhile [[ $# -gt 0 ]]; do\n               if [[ $1 == --line ]]; then line=$2; shift; fi\n  shift\ndone\n             line=${line//$'\\t'/\\\\t}\n             printf 'line=[%s]\\n' \"$line\"\n";
         let bin = fixture.dir.join("ex");
         fs::write(&bin, stand_in).expect("writing the stand-in");
         make_executable(&bin);
@@ -543,6 +543,44 @@ fn zsh_passes_extension_filters_to_its_native_file_completer() {
         &format!("{ZSH_STUBS}\nsource ./script\nBUFFER='ex '\nCURSOR=3\n_ex\n"),
     );
     assert!(out.contains("_files:-g *.(toml|yaml)"), "{out}");
+}
+
+#[test]
+fn zsh_expands_a_local_alias_before_asking_the_binary() {
+    if !available("zsh") {
+        println!("zsh is not installed; skipping");
+        return;
+    }
+    let fixture = Fixture::echoing("zsh-alias", Shell::Zsh);
+    let out = fixture.run(
+        "zsh",
+        &format!(
+            "{ZSH_STUBS}\nalias true=false\nsource ./script\nalias xa='ex deploy'\nalias empty=''\n\
+             BUFFER='xa feature'\nCURSOR=10\n_ex\n\
+             BUFFER='  xa feature'\nCURSOR=12\n_ex\n\
+             BUFFER=$'\\txa feature'\nCURSOR=11\n_ex\n\
+             BUFFER='empty feature'\nCURSOR=13\n_ex\n\
+             BUFFER='FOO=1 xa feature'\nCURSOR=16\n_ex\n\
+             BUFFER='FOO+=1 xa feature'\nCURSOR=17\n_ex\n\
+             BUFFER=\"FOO='a b' xa feature\"\nCURSOR=20\n_ex\n"
+        ),
+    );
+    assert!(out.contains("display:line=[ex deploy feature]"), "{out}");
+    assert!(out.contains("display:line=[  ex deploy feature]"), "{out}");
+    assert!(out.contains("display:line=[\\tex deploy feature]"), "{out}");
+    assert!(out.contains("display:line=[ feature]"), "{out}");
+    assert!(
+        out.contains("display:line=[FOO=1 ex deploy feature]"),
+        "{out}"
+    );
+    assert!(
+        out.contains("display:line=[FOO+=1 ex deploy feature]"),
+        "{out}"
+    );
+    assert!(
+        out.contains("display:line=[FOO='a b' ex deploy feature]"),
+        "{out}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- expand command-position Zsh aliases before sending the line to `__complete_word__`
- preserve arguments added by aliases such as `gfin="mise run git:finish-branch"`
- stop recursive and cyclic alias expansion safely
- add a real-Zsh regression test for the line received by the completion binary

Bash is unchanged because mise did not previously complete local Bash aliases. Fish is unchanged because its wrapper completion machinery already passes the expanded command line.

## Testing

- `cargo test -p usage-argv --all-features`

_This pull request was generated with assistance from OpenAI Codex._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Zsh completions now expand leading aliases before generating suggestions.
  - Alias expansion supports commands with spaces, tabs, empty aliases, and environment-prefixed commands.
  - Original whitespace is preserved during expansion.

- **Bug Fixes**
  - Cyclic aliases are safely detected to prevent endless expansion.
  - Completion commands now receive the expanded command line for more accurate results.
  - Tab characters are displayed clearly in completion diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->