### PR TITLE
feat: support Cobra's `Example` field

### DIFF
--- a/docs/spec/integrations/cobra.md
+++ b/docs/spec/integrations/cobra.md
@@ -62,6 +62,7 @@ For completions, `--usage-cmd 'mycli --usage-spec'` can replace the pipe and
 | `cmd.Aliases`                                      | `alias`                                       |
 | `cmd.Hidden`                                       | `hide=#true`                                  |
 | `cmd.Deprecated`                                   | `deprecated="message"`                        |
+| `cmd.Example`                                      | `example` node (top-level for root)           |
 | `cmd.Use` args (`<required>`, `[optional]`, `...`) | `arg` nodes                                   |
 | `cmd.ValidArgs`                                    | `choices` on first arg                        |
 | Persistent flags                                   | `global=#true`                                |
@@ -75,6 +76,10 @@ For completions, `--usage-cmd 'mycli --usage-spec'` can replace the pipe and
 | Count flags (`CountP`)                             | `count=#true var=#true`                       |
 | Other flags                                        | `arg <UPPER_NAME>` child                      |
 | `MarkFlagRequired`                                 | `required=#true`                              |
+
+Cobra's `Example` is a single free-form block rather than a list of structured
+examples, so it maps to one `example` node holding the whole text, dedented.
+Comment lines the author wrote stay inside the example code.
 
 ## Example
 

--- a/integrations/cobra/README.md
+++ b/integrations/cobra/README.md
@@ -74,6 +74,7 @@ mycli --usage-spec | usage generate man -f -
 | `cmd.Aliases`                                      | `alias`                                       |
 | `cmd.Hidden`                                       | `hide=#true`                                  |
 | `cmd.Deprecated`                                   | `deprecated="message"`                        |
+| `cmd.Example`                                      | `example` node (top-level for root)           |
 | `cmd.Use` args (`<required>`, `[optional]`, `...`) | `arg` nodes                                   |
 | `cmd.ValidArgs`                                    | `choices` on first arg                        |
 | Persistent flags                                   | `global=#true`                                |
@@ -87,6 +88,10 @@ mycli --usage-spec | usage generate man -f -
 | Count flags (`CountP`)                             | `count=#true var=#true`                       |
 | Other flags                                        | `arg <UPPER_NAME>` child                      |
 | `MarkFlagRequired`                                 | `required=#true`                              |
+
+Cobra's `Example` is a single free-form block rather than a list of structured
+examples, so it maps to one `example` node holding the whole text, dedented.
+Comment lines the author wrote stay inside the example code.
 
 ## Example
 

--- a/integrations/cobra/cobra_usage_test.go
+++ b/integrations/cobra/cobra_usage_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// TestSimpleCommand checks that a flat command's name, bin, version, about, and
+// flags all reach the spec.
 func TestSimpleCommand(t *testing.T) {
 	cmd := &cobra.Command{
 		Use:     "mycli",
@@ -27,6 +29,7 @@ func TestSimpleCommand(t *testing.T) {
 	assertContains(t, got, `arg <CONFIG>`)
 }
 
+// TestNestedSubcommands checks that subcommands are converted recursively.
 func TestNestedSubcommands(t *testing.T) {
 	root := &cobra.Command{Use: "app", Short: "An app"}
 	sub := &cobra.Command{Use: "sub", Short: "A subcommand"}
@@ -41,6 +44,7 @@ func TestNestedSubcommands(t *testing.T) {
 	assertContains(t, got, `cmd nested help="A nested command"`)
 }
 
+// TestPersistentFlags checks that a root persistent flag is marked global.
 func TestPersistentFlags(t *testing.T) {
 	root := &cobra.Command{Use: "app"}
 	root.PersistentFlags().BoolP("debug", "d", false, "Enable debug mode")
@@ -53,6 +57,8 @@ func TestPersistentFlags(t *testing.T) {
 	assertContains(t, got, `flag "-d --debug" help="Enable debug mode" global=#true`)
 }
 
+// TestRequiredFlags checks that a flag marked required in Cobra is required in the
+// spec.
 func TestRequiredFlags(t *testing.T) {
 	cmd := &cobra.Command{Use: "deploy"}
 	cmd.Flags().String("env", "", "Target environment")
@@ -63,6 +69,8 @@ func TestRequiredFlags(t *testing.T) {
 	assertContains(t, got, `flag --env help="Target environment" required=#true`)
 }
 
+// TestHiddenAndDeprecated checks that hidden commands, deprecated commands, and
+// hidden flags carry their markers through.
 func TestHiddenAndDeprecated(t *testing.T) {
 	root := &cobra.Command{Use: "app"}
 	hidden := &cobra.Command{Use: "internal", Short: "Internal command", Hidden: true}
@@ -79,6 +87,8 @@ func TestHiddenAndDeprecated(t *testing.T) {
 	assertContains(t, got, `flag --secret help="Secret flag" hide=#true`)
 }
 
+// TestArgInference checks that required, optional, variadic, and mixed positional
+// args are inferred from a command's Use string.
 func TestArgInference(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -118,6 +128,8 @@ func TestArgInference(t *testing.T) {
 	}
 }
 
+// TestValidArgsChoices checks that Cobra's ValidArgs become a choices block on the
+// first positional arg.
 func TestValidArgsChoices(t *testing.T) {
 	cmd := &cobra.Command{
 		Use:       "deploy <env>",
@@ -133,6 +145,7 @@ func TestValidArgsChoices(t *testing.T) {
 	assertContains(t, got, `"prod"`)
 }
 
+// TestCountFlag checks that a pflag count flag is marked var and count.
 func TestCountFlag(t *testing.T) {
 	cmd := &cobra.Command{Use: "app"}
 	cmd.Flags().CountP("verbose", "v", "Increase verbosity")
@@ -142,6 +155,7 @@ func TestCountFlag(t *testing.T) {
 	assertContains(t, got, `flag "-v --verbose" help="Increase verbosity" var=#true count=#true`)
 }
 
+// TestDefaultValues checks that string and int flag defaults are rendered.
 func TestDefaultValues(t *testing.T) {
 	cmd := &cobra.Command{Use: "app"}
 	cmd.Flags().String("output", "json", "Output format")
@@ -153,6 +167,7 @@ func TestDefaultValues(t *testing.T) {
 	assertContains(t, got, `flag --retries help="Number of retries" default="3"`)
 }
 
+// TestBoolFlagNoArg checks that a bool flag takes no value argument.
 func TestBoolFlagNoArg(t *testing.T) {
 	cmd := &cobra.Command{Use: "app"}
 	cmd.Flags().Bool("force", false, "Force the operation")
@@ -168,6 +183,8 @@ func TestBoolFlagNoArg(t *testing.T) {
 	}
 }
 
+// TestSkipsBuiltinCommands checks that Cobra's auto-added help and completion
+// commands are left out of the spec.
 func TestSkipsBuiltinCommands(t *testing.T) {
 	root := &cobra.Command{Use: "app", Version: "1.0.0"}
 	root.AddCommand(&cobra.Command{Use: "run", Short: "Run"})
@@ -180,6 +197,8 @@ func TestSkipsBuiltinCommands(t *testing.T) {
 	assertContains(t, got, `cmd run`)
 }
 
+// TestSkipsBuiltinFlags checks that Cobra's auto-added --help and --version flags
+// are left out of the spec.
 func TestSkipsBuiltinFlags(t *testing.T) {
 	cmd := &cobra.Command{Use: "app", Version: "1.0.0"}
 	cmd.Flags().String("custom", "", "A custom flag")
@@ -191,6 +210,8 @@ func TestSkipsBuiltinFlags(t *testing.T) {
 	assertContains(t, got, `flag --custom`)
 }
 
+// TestSubcommandRequired checks that a command with subcommands and no Run handler
+// is marked subcommand_required.
 func TestSubcommandRequired(t *testing.T) {
 	root := &cobra.Command{Use: "app"}
 	sub := &cobra.Command{Use: "config", Short: "Manage config"}
@@ -203,6 +224,7 @@ func TestSubcommandRequired(t *testing.T) {
 	assertContains(t, got, `subcommand_required=#true`)
 }
 
+// TestAliases checks that command aliases are rendered as an alias node.
 func TestAliases(t *testing.T) {
 	root := &cobra.Command{Use: "app"}
 	sub := &cobra.Command{
@@ -217,6 +239,8 @@ func TestAliases(t *testing.T) {
 	assertContains(t, got, `alias i add`)
 }
 
+// TestGenerateJSON checks the top-level shape of the JSON output: spec metadata
+// plus a root cmd object with map-based subcommands.
 func TestGenerateJSON(t *testing.T) {
 	cmd := &cobra.Command{
 		Use:     "mycli",
@@ -241,6 +265,8 @@ func TestGenerateJSON(t *testing.T) {
 	assertContains(t, jsonStr, `"run"`)
 }
 
+// TestGenerateJSONChoices checks that arg choices serialize under the "choices"
+// key that usage-lib expects, not "values".
 func TestGenerateJSONChoices(t *testing.T) {
 	cmd := &cobra.Command{
 		Use:       "deploy <env>",
@@ -260,6 +286,7 @@ func TestGenerateJSONChoices(t *testing.T) {
 	assertNotContains(t, jsonStr, `"values"`)
 }
 
+// TestLongHelp checks that Short and Long map to about and long_about.
 func TestLongHelp(t *testing.T) {
 	root := &cobra.Command{
 		Use:   "app",
@@ -273,6 +300,8 @@ func TestLongHelp(t *testing.T) {
 	assertContains(t, got, `long_about "This is a much longer description of the app."`)
 }
 
+// TestRunnableCommandWithSubcommands checks that a command with both a Run handler
+// and subcommands is not marked subcommand_required.
 func TestRunnableCommandWithSubcommands(t *testing.T) {
 	root := &cobra.Command{Use: "app"}
 	sub := &cobra.Command{
@@ -292,6 +321,8 @@ func TestRunnableCommandWithSubcommands(t *testing.T) {
 	}
 }
 
+// TestCommandPlaceholderSkipped checks that Cobra's [command] placeholder in a Use
+// string is not mistaken for a positional arg.
 func TestCommandPlaceholderSkipped(t *testing.T) {
 	root := &cobra.Command{Use: "app [command]"}
 	root.AddCommand(&cobra.Command{Use: "sub", Short: "A sub"})
@@ -303,6 +334,8 @@ func TestCommandPlaceholderSkipped(t *testing.T) {
 	assertContains(t, got, `cmd sub`)
 }
 
+// TestStringDefaultZero checks that the string default "0" is preserved rather than
+// treated as an empty zero value.
 func TestStringDefaultZero(t *testing.T) {
 	cmd := &cobra.Command{Use: "app"}
 	cmd.Flags().String("port", "0", "Port number")
@@ -313,6 +346,8 @@ func TestStringDefaultZero(t *testing.T) {
 	assertContains(t, got, `default="0"`)
 }
 
+// TestSpecialCharacterEscaping checks that kdlQuoteAlways escapes newlines, tabs,
+// carriage returns, backslashes, and double quotes.
 func TestSpecialCharacterEscaping(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -361,6 +396,8 @@ func TestSpecialCharacterEscaping(t *testing.T) {
 	}
 }
 
+// TestNewlineInCommandHelp checks that a multi-line Long is escaped into a single
+// quoted long_about value.
 func TestNewlineInCommandHelp(t *testing.T) {
 	root := &cobra.Command{
 		Use:   "app",
@@ -373,6 +410,8 @@ func TestNewlineInCommandHelp(t *testing.T) {
 	assertContains(t, got, `long_about "First line.\nSecond line.\n\nThird paragraph."`)
 }
 
+// TestSpecialCharsInFlagHelp checks that a multi-line flag help string is escaped
+// into a single quoted property.
 func TestSpecialCharsInFlagHelp(t *testing.T) {
 	cmd := &cobra.Command{Use: "app"}
 	cmd.Flags().String("format", "", "Output format:\n  json\n  yaml")
@@ -382,6 +421,7 @@ func TestSpecialCharsInFlagHelp(t *testing.T) {
 	assertContains(t, got, `help="Output format:\n  json\n  yaml"`)
 }
 
+// TestCommandExample checks that a subcommand's Example becomes an example node.
 func TestCommandExample(t *testing.T) {
 	root := &cobra.Command{Use: "mycli"}
 	deploy := &cobra.Command{
@@ -397,6 +437,8 @@ func TestCommandExample(t *testing.T) {
 	assertContains(t, got, `example "mycli deploy --env prod"`)
 }
 
+// TestRootExample checks that the root command's Example becomes an unindented
+// top-level example node.
 func TestRootExample(t *testing.T) {
 	root := &cobra.Command{
 		Use:     "mycli",
@@ -413,6 +455,8 @@ func TestRootExample(t *testing.T) {
 	}
 }
 
+// TestExampleMultilineDedent checks that a multi-line Example becomes one example
+// node with its shared leading indent removed.
 func TestExampleMultilineDedent(t *testing.T) {
 	root := &cobra.Command{Use: "mycli"}
 	deploy := &cobra.Command{
@@ -435,6 +479,8 @@ func TestExampleMultilineDedent(t *testing.T) {
 	assertNotContains(t, got, `\n  mycli deploy`)
 }
 
+// TestExampleRelativeIndentPreserved checks that dedenting keeps indentation that
+// is relative to the block's common prefix.
 func TestExampleRelativeIndentPreserved(t *testing.T) {
 	root := &cobra.Command{Use: "mycli"}
 	sub := &cobra.Command{
@@ -451,6 +497,8 @@ func TestExampleRelativeIndentPreserved(t *testing.T) {
 	assertContains(t, got, `example "mycli run\n  --with-continuation"`)
 }
 
+// TestExampleAsOnlyChild checks that an example alone is enough to open a cmd
+// node's child block.
 func TestExampleAsOnlyChild(t *testing.T) {
 	root := &cobra.Command{Use: "mycli"}
 	sub := &cobra.Command{
@@ -471,6 +519,7 @@ func TestExampleAsOnlyChild(t *testing.T) {
 	assertContains(t, got, `    example "mycli ping"`)
 }
 
+// TestNoExample checks that a command without an Example emits no example node.
 func TestNoExample(t *testing.T) {
 	root := &cobra.Command{Use: "mycli", Short: "A CLI"}
 	sub := &cobra.Command{
@@ -485,6 +534,7 @@ func TestNoExample(t *testing.T) {
 	assertNotContains(t, got, "example ")
 }
 
+// TestExampleWhitespaceOnly checks that a whitespace-only Example is dropped.
 func TestExampleWhitespaceOnly(t *testing.T) {
 	root := &cobra.Command{Use: "mycli", Short: "A CLI", Example: "  \n\t\n"}
 
@@ -493,6 +543,8 @@ func TestExampleWhitespaceOnly(t *testing.T) {
 	assertNotContains(t, got, "example ")
 }
 
+// TestExampleSpecialChars checks that quotes and backslashes inside an example are
+// escaped.
 func TestExampleSpecialChars(t *testing.T) {
 	root := &cobra.Command{Use: "mycli"}
 	sub := &cobra.Command{
@@ -508,6 +560,8 @@ func TestExampleSpecialChars(t *testing.T) {
 	assertContains(t, got, `example "mycli grep \"a\\b\""`)
 }
 
+// TestExampleCRLF checks that CRLF line endings are normalized to LF and trailing
+// newlines are trimmed.
 func TestExampleCRLF(t *testing.T) {
 	root := &cobra.Command{Use: "mycli", Example: "mycli one\r\nmycli two\r\n"}
 
@@ -517,6 +571,8 @@ func TestExampleCRLF(t *testing.T) {
 	assertNotContains(t, got, `\r`)
 }
 
+// TestGenerateJSONExamples checks that examples serialize with all four fields
+// present and that commands without examples still emit an empty array.
 func TestGenerateJSONExamples(t *testing.T) {
 	root := &cobra.Command{
 		Use:     "mycli",
@@ -555,6 +611,7 @@ func TestGenerateJSONExamples(t *testing.T) {
 
 // --- helpers ---
 
+// assertContains fails the test when got does not contain want.
 func assertContains(t *testing.T, got, want string) {
 	t.Helper()
 	if !strings.Contains(got, want) {
@@ -562,6 +619,7 @@ func assertContains(t *testing.T, got, want string) {
 	}
 }
 
+// assertNotContains fails the test when got contains unwanted.
 func assertNotContains(t *testing.T, got, unwanted string) {
 	t.Helper()
 	if strings.Contains(got, unwanted) {
@@ -569,6 +627,7 @@ func assertNotContains(t *testing.T, got, unwanted string) {
 	}
 }
 
+// findLine returns the first line of output containing prefix, or "" if none does.
 func findLine(output, prefix string) string {
 	for _, line := range strings.Split(output, "\n") {
 		if strings.Contains(line, prefix) {

--- a/integrations/cobra/cobra_usage_test.go
+++ b/integrations/cobra/cobra_usage_test.go
@@ -382,6 +382,177 @@ func TestSpecialCharsInFlagHelp(t *testing.T) {
 	assertContains(t, got, `help="Output format:\n  json\n  yaml"`)
 }
 
+func TestCommandExample(t *testing.T) {
+	root := &cobra.Command{Use: "mycli"}
+	deploy := &cobra.Command{
+		Use:     "deploy",
+		Short:   "Deploy the app",
+		Example: "mycli deploy --env prod",
+		Run:     func(cmd *cobra.Command, args []string) {},
+	}
+	root.AddCommand(deploy)
+
+	got := Generate(root)
+
+	assertContains(t, got, `example "mycli deploy --env prod"`)
+}
+
+func TestRootExample(t *testing.T) {
+	root := &cobra.Command{
+		Use:     "mycli",
+		Short:   "A CLI",
+		Example: "  mycli --help",
+	}
+
+	got := Generate(root)
+
+	// The root's example is a top-level node, so it must not be indented.
+	line := findLine(got, "example ")
+	if line != `example "mycli --help"` {
+		t.Errorf("root example should be an unindented top-level node, got %q", line)
+	}
+}
+
+func TestExampleMultilineDedent(t *testing.T) {
+	root := &cobra.Command{Use: "mycli"}
+	deploy := &cobra.Command{
+		Use:   "deploy",
+		Short: "Deploy the app",
+		Example: `  # deploy to production
+  mycli deploy --env prod
+
+  # dry run first
+  mycli deploy --dry-run`,
+		Run: func(cmd *cobra.Command, args []string) {},
+	}
+	root.AddCommand(deploy)
+
+	got := Generate(root)
+
+	// One node holding the whole block, dedented, with newlines escaped.
+	assertContains(t, got, `example "# deploy to production\nmycli deploy --env prod\n\n# dry run first\nmycli deploy --dry-run"`)
+	// The shared two-space indent is gone from inside the quotes.
+	assertNotContains(t, got, `\n  mycli deploy`)
+}
+
+func TestExampleRelativeIndentPreserved(t *testing.T) {
+	root := &cobra.Command{Use: "mycli"}
+	sub := &cobra.Command{
+		Use:   "run",
+		Short: "Run it",
+		Example: `  mycli run
+    --with-continuation`,
+		Run: func(cmd *cobra.Command, args []string) {},
+	}
+	root.AddCommand(sub)
+
+	got := Generate(root)
+
+	assertContains(t, got, `example "mycli run\n  --with-continuation"`)
+}
+
+func TestExampleAsOnlyChild(t *testing.T) {
+	root := &cobra.Command{Use: "mycli"}
+	sub := &cobra.Command{
+		Use:     "ping",
+		Short:   "Ping",
+		Example: "mycli ping",
+		Run:     func(cmd *cobra.Command, args []string) {},
+	}
+	root.AddCommand(sub)
+
+	got := Generate(root)
+
+	// The example is the command's only child, so the block must still open.
+	line := findLine(got, `cmd ping`)
+	if !strings.HasSuffix(line, "{") {
+		t.Errorf("cmd node should open a child block, got %q", line)
+	}
+	assertContains(t, got, `    example "mycli ping"`)
+}
+
+func TestNoExample(t *testing.T) {
+	root := &cobra.Command{Use: "mycli", Short: "A CLI"}
+	sub := &cobra.Command{
+		Use:   "ping",
+		Short: "Ping",
+		Run:   func(cmd *cobra.Command, args []string) {},
+	}
+	root.AddCommand(sub)
+
+	got := Generate(root)
+
+	assertNotContains(t, got, "example ")
+}
+
+func TestExampleWhitespaceOnly(t *testing.T) {
+	root := &cobra.Command{Use: "mycli", Short: "A CLI", Example: "  \n\t\n"}
+
+	got := Generate(root)
+
+	assertNotContains(t, got, "example ")
+}
+
+func TestExampleSpecialChars(t *testing.T) {
+	root := &cobra.Command{Use: "mycli"}
+	sub := &cobra.Command{
+		Use:     "grep",
+		Short:   "Grep",
+		Example: `mycli grep "a\b"`,
+		Run:     func(cmd *cobra.Command, args []string) {},
+	}
+	root.AddCommand(sub)
+
+	got := Generate(root)
+
+	assertContains(t, got, `example "mycli grep \"a\\b\""`)
+}
+
+func TestExampleCRLF(t *testing.T) {
+	root := &cobra.Command{Use: "mycli", Example: "mycli one\r\nmycli two\r\n"}
+
+	got := Generate(root)
+
+	assertContains(t, got, `example "mycli one\nmycli two"`)
+	assertNotContains(t, got, `\r`)
+}
+
+func TestGenerateJSONExamples(t *testing.T) {
+	root := &cobra.Command{
+		Use:     "mycli",
+		Short:   "A CLI",
+		Example: "mycli --help",
+	}
+	deploy := &cobra.Command{
+		Use:     "deploy",
+		Short:   "Deploy",
+		Example: "mycli deploy",
+		Run:     func(cmd *cobra.Command, args []string) {},
+	}
+	plain := &cobra.Command{
+		Use:   "status",
+		Short: "Status",
+		Run:   func(cmd *cobra.Command, args []string) {},
+	}
+	root.AddCommand(deploy, plain)
+
+	data, err := GenerateJSON(root)
+	if err != nil {
+		t.Fatalf("GenerateJSON failed: %v", err)
+	}
+	got := string(data)
+
+	// All four SpecExample fields always serialize, matching usage-lib.
+	assertContains(t, got, `"code": "mycli --help"`)
+	assertContains(t, got, `"header": null`)
+	assertContains(t, got, `"help": null`)
+	assertContains(t, got, `"lang": ""`)
+	assertContains(t, got, `"code": "mycli deploy"`)
+	// Command-level examples always emit an array, mirroring Rust's
+	// SpecCommand.examples having no skip_serializing_if.
+	assertContains(t, got, `"examples": []`)
+}
+
 // --- helpers ---
 
 func assertContains(t *testing.T, got, want string) {

--- a/integrations/cobra/convert.go
+++ b/integrations/cobra/convert.go
@@ -22,6 +22,9 @@ func convertRoot(cmd *cobra.Command) Spec {
 	if cmd.Long != "" {
 		spec.Long = cmd.Long
 	}
+	// The root's examples belong at spec level, which is where a top-level KDL
+	// example node parses to.
+	spec.Examples = convertExamples(cmd.Example)
 
 	spec.Flags = convertPersistentFlags(cmd)
 	spec.Flags = append(spec.Flags, convertLocalFlags(cmd, true)...)
@@ -51,6 +54,7 @@ func convertCommand(cmd *cobra.Command) SpecCommand {
 	if cmd.Long != "" {
 		sc.HelpLong = cmd.Long
 	}
+	sc.Examples = convertExamples(cmd.Example)
 	if cmd.Hidden {
 		sc.Hide = true
 	}
@@ -86,6 +90,81 @@ func convertCommand(cmd *cobra.Command) SpecCommand {
 	}
 
 	return sc
+}
+
+// convertExamples turns a cobra Example string into spec examples.
+// Cobra's Example is one free-form block with no header/help split of its own, so
+// it maps to a single example node holding the whole dedented text as its code.
+// Comment lines the author wrote stay inside that code rather than being lifted
+// out, so nothing is reordered or dropped.
+func convertExamples(example string) []SpecExample {
+	code := dedent(example)
+	if code == "" {
+		return nil
+	}
+	return []SpecExample{{Code: code}}
+}
+
+// dedent normalizes line endings, drops surrounding blank lines, strips the
+// leading whitespace prefix shared by every non-blank line, and trims trailing
+// whitespace from each line. Cobra examples are conventionally written indented
+// inside a raw string literal; without this every line would render indented
+// inside the generated code block.
+func dedent(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\r", "\n")
+
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimRight(line, " \t")
+	}
+	for len(lines) > 0 && lines[0] == "" {
+		lines = lines[1:]
+	}
+	for len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+
+	prefix := ""
+	seen := false
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		indent := line[:len(line)-len(strings.TrimLeft(line, " \t"))]
+		if !seen {
+			prefix = indent
+			seen = true
+			continue
+		}
+		prefix = commonPrefix(prefix, indent)
+		if prefix == "" {
+			break
+		}
+	}
+	if prefix != "" {
+		for i, line := range lines {
+			lines[i] = strings.TrimPrefix(line, prefix)
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// commonPrefix returns the longest common leading run of a and b.
+func commonPrefix(a, b string) string {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	i := 0
+	for i < n && a[i] == b[i] {
+		i++
+	}
+	return a[:i]
 }
 
 // convertPersistentFlags converts persistent flags from a command (global=true).

--- a/integrations/cobra/example/main.go
+++ b/integrations/cobra/example/main.go
@@ -15,6 +15,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// main builds the demo command tree and either prints its usage spec, when
+// --usage-spec is present in os.Args, or runs the CLI normally.
 func main() {
 	root := &cobra.Command{
 		Use:     "deploy-tool",

--- a/integrations/cobra/example/main.go
+++ b/integrations/cobra/example/main.go
@@ -21,6 +21,7 @@ func main() {
 		Short:   "A deployment management tool",
 		Long:    "deploy-tool manages deployments across multiple environments with rollback support.",
 		Version: "0.1.0",
+		Example: "  deploy-tool deploy api --env prod",
 	}
 
 	root.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose output")
@@ -30,7 +31,12 @@ func main() {
 		Use:   "deploy <service>",
 		Short: "Deploy a service",
 		Long:  "Deploy a service to the specified environment. Defaults to staging if --env is not set.",
-		Args:  cobra.ExactArgs(1),
+		Example: `  # deploy to production
+  deploy-tool deploy api --env prod
+
+  # see what would change first
+  deploy-tool deploy api --env prod --dry-run`,
+		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Printf("Deploying %s\n", args[0])
 		},
@@ -41,9 +47,10 @@ func main() {
 
 	// rollback subcommand
 	rollback := &cobra.Command{
-		Use:   "rollback <service> [version]",
-		Short: "Rollback a service to a previous version",
-		Args:  cobra.RangeArgs(1, 2),
+		Use:     "rollback <service> [version]",
+		Short:   "Rollback a service to a previous version",
+		Example: "  deploy-tool rollback api 1.2.3",
+		Args:    cobra.RangeArgs(1, 2),
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Printf("Rolling back %s\n", args[0])
 		},

--- a/integrations/cobra/json.go
+++ b/integrations/cobra/json.go
@@ -111,6 +111,8 @@ func toJSON(spec *Spec) jsonSpec {
 	return js
 }
 
+// commandToJSON converts a SpecCommand and its subcommand tree into the JSON
+// shape usage-lib expects, threading the full command path down to each child.
 func commandToJSON(cmd *SpecCommand, fullCmd []string) jsonCommand {
 	jc := jsonCommand{
 		FullCmd:            fullCmd,
@@ -155,6 +157,8 @@ func examplesToJSON(examples []SpecExample) []jsonExample {
 	return out
 }
 
+// exampleToJSON converts a single example, leaving the optional header and help
+// fields nil when unset so they marshal as null rather than "".
 func exampleToJSON(ex *SpecExample) jsonExample {
 	je := jsonExample{
 		Code: ex.Code,
@@ -169,6 +173,8 @@ func exampleToJSON(ex *SpecExample) jsonExample {
 	return je
 }
 
+// flagToJSON converts a SpecFlag, deriving the flag's name and usage string from
+// its long and short spellings and its optional value argument.
 func flagToJSON(f *SpecFlag) jsonFlag {
 	jf := jsonFlag{
 		Help:       f.Help,
@@ -219,6 +225,8 @@ func flagToJSON(f *SpecFlag) jsonFlag {
 	return jf
 }
 
+// argToJSON converts a SpecArg, rendering its usage string as <name> when the arg
+// is required and [name] when it is not.
 func argToJSON(a *SpecArg) jsonArg {
 	ja := jsonArg{
 		Name:     a.Name,

--- a/integrations/cobra/json.go
+++ b/integrations/cobra/json.go
@@ -8,13 +8,14 @@ import (
 // JSON types matching the usage-lib JSON schema (Spec -> serde serialization).
 
 type jsonSpec struct {
-	Name     string       `json:"name,omitempty"`
-	Bin      string       `json:"bin,omitempty"`
-	Cmd      jsonCommand  `json:"cmd"`
-	Version  string       `json:"version,omitempty"`
-	Usage    string       `json:"usage,omitempty"`
-	About    string       `json:"about,omitempty"`
-	AboutLon string       `json:"about_long,omitempty"`
+	Name     string        `json:"name,omitempty"`
+	Bin      string        `json:"bin,omitempty"`
+	Cmd      jsonCommand   `json:"cmd"`
+	Version  string        `json:"version,omitempty"`
+	Usage    string        `json:"usage,omitempty"`
+	About    string        `json:"about,omitempty"`
+	AboutLon string        `json:"about_long,omitempty"`
+	Examples []jsonExample `json:"examples,omitempty"`
 }
 
 type jsonCommand struct {
@@ -31,6 +32,7 @@ type jsonCommand struct {
 	Deprecated         string                  `json:"deprecated,omitempty"`
 	Aliases            []string                `json:"aliases"`
 	HiddenAliases      []string                `json:"hidden_aliases"`
+	Examples           []jsonExample           `json:"examples"`
 }
 
 type jsonFlag struct {
@@ -64,6 +66,15 @@ type jsonChoices struct {
 	Choices []string `json:"choices"`
 }
 
+// jsonExample mirrors usage-lib's SpecExample, which derives a plain Serialize:
+// every field is always present, and header/help are null when unset.
+type jsonExample struct {
+	Code   string  `json:"code"`
+	Header *string `json:"header"`
+	Help   *string `json:"help"`
+	Lang   string  `json:"lang"`
+}
+
 // toJSON converts internal Spec to the JSON-serializable format matching usage-lib.
 func toJSON(spec *Spec) jsonSpec {
 	js := jsonSpec{
@@ -74,12 +85,15 @@ func toJSON(spec *Spec) jsonSpec {
 		AboutLon: spec.Long,
 	}
 
+	js.Examples = examplesToJSON(spec.Examples)
+
 	// Root command
 	js.Cmd = jsonCommand{
 		FullCmd:       []string{},
 		Name:          spec.Name,
 		Aliases:       []string{},
 		HiddenAliases: []string{},
+		Examples:      []jsonExample{},
 		Subcommands:   make(map[string]*jsonCommand),
 	}
 
@@ -108,6 +122,7 @@ func commandToJSON(cmd *SpecCommand, fullCmd []string) jsonCommand {
 		SubcommandRequired: cmd.SubcommandRequired,
 		Aliases:            cmd.Aliases,
 		HiddenAliases:      []string{},
+		Examples:           examplesToJSON(cmd.Examples),
 		Subcommands:        make(map[string]*jsonCommand),
 	}
 	if jc.Aliases == nil {
@@ -127,6 +142,31 @@ func commandToJSON(cmd *SpecCommand, fullCmd []string) jsonCommand {
 	}
 
 	return jc
+}
+
+// examplesToJSON converts internal examples, always returning a non-nil slice so
+// the field marshals as [] rather than null - usage-lib's SpecCommand.examples
+// has no skip_serializing_if and always emits an array.
+func examplesToJSON(examples []SpecExample) []jsonExample {
+	out := make([]jsonExample, 0, len(examples))
+	for i := range examples {
+		out = append(out, exampleToJSON(&examples[i]))
+	}
+	return out
+}
+
+func exampleToJSON(ex *SpecExample) jsonExample {
+	je := jsonExample{
+		Code: ex.Code,
+		Lang: ex.Lang,
+	}
+	if ex.Header != "" {
+		je.Header = &ex.Header
+	}
+	if ex.Help != "" {
+		je.Help = &ex.Help
+	}
+	return je
 }
 
 func flagToJSON(f *SpecFlag) jsonFlag {

--- a/integrations/cobra/kdl.go
+++ b/integrations/cobra/kdl.go
@@ -39,6 +39,12 @@ func renderKDL(spec *Spec) string {
 		b.WriteString(renderArg(&arg, 0))
 	}
 
+	// Root examples: after args and before subcommands, matching usage-lib's own
+	// top-level node order.
+	for _, ex := range spec.Examples {
+		b.WriteString(renderExample(&ex, 0))
+	}
+
 	// Subcommands
 	for _, cmd := range spec.Cmds {
 		b.WriteString(renderCommand(&cmd, 0))
@@ -73,6 +79,7 @@ func renderCommand(cmd *SpecCommand, depth int) string {
 		len(cmd.Aliases) > 0 ||
 		len(cmd.Flags) > 0 ||
 		len(cmd.Args) > 0 ||
+		len(cmd.Examples) > 0 ||
 		len(cmd.Cmds) > 0
 
 	if !hasChildren {
@@ -112,7 +119,35 @@ func renderCommand(cmd *SpecCommand, depth int) string {
 		b.WriteString(renderCommand(&sub, depth+1))
 	}
 
+	// Examples: after subcommands, matching usage-lib's own child node order.
+	for _, ex := range cmd.Examples {
+		b.WriteString(renderExample(&ex, depth+1))
+	}
+
 	fmt.Fprintf(&b, "%s}\n", indent)
+	return b.String()
+}
+
+// renderExample renders a SpecExample as a KDL example node.
+// The code is always fully quoted: example code contains spaces and shell
+// punctuation, and a multi-line example has to come out as \n escapes.
+func renderExample(ex *SpecExample, depth int) string {
+	var b strings.Builder
+	indent := strings.Repeat("    ", depth)
+
+	fmt.Fprintf(&b, "%sexample %s", indent, kdlQuoteAlways(ex.Code))
+
+	if ex.Header != "" {
+		fmt.Fprintf(&b, " header=%s", kdlQuote(ex.Header))
+	}
+	if ex.Help != "" {
+		fmt.Fprintf(&b, " help=%s", kdlQuote(ex.Help))
+	}
+	if ex.Lang != "" {
+		fmt.Fprintf(&b, " lang=%s", kdlQuote(ex.Lang))
+	}
+
+	b.WriteString("\n")
 	return b.String()
 }
 

--- a/integrations/cobra/spec.go
+++ b/integrations/cobra/spec.go
@@ -4,15 +4,16 @@ package cobra_usage
 // Spec is the root struct representing a CLI definition.
 // Used internally for KDL rendering.
 type Spec struct {
-	Name    string
-	Bin     string
-	Version string
-	About   string
-	Long    string
-	Usage   string
-	Flags   []SpecFlag
-	Args    []SpecArg
-	Cmds    []SpecCommand
+	Name     string
+	Bin      string
+	Version  string
+	About    string
+	Long     string
+	Usage    string
+	Flags    []SpecFlag
+	Args     []SpecArg
+	Examples []SpecExample
+	Cmds     []SpecCommand
 }
 
 // SpecCommand represents a subcommand.
@@ -26,6 +27,7 @@ type SpecCommand struct {
 	SubcommandRequired bool
 	Flags              []SpecFlag
 	Args               []SpecArg
+	Examples           []SpecExample
 	Cmds               []SpecCommand
 }
 
@@ -54,6 +56,14 @@ type SpecArg struct {
 	Hide     bool
 	Default  []string
 	Choices  *SpecChoices
+}
+
+// SpecExample represents a usage example for a command.
+type SpecExample struct {
+	Code   string
+	Header string
+	Help   string
+	Lang   string
 }
 
 // SpecChoices represents a set of valid choices for an argument.

--- a/mise.toml
+++ b/mise.toml
@@ -70,12 +70,13 @@ run = 'mbx test --all --all-features'
 [tasks."test:go"]
 dir = '{{config_root}}'
 depends = ['build']
-# The shadows are the second line, and skipped when the frameworks cannot be fetched: they
+# The shadows are the last line, and skipped when the frameworks cannot be fetched: they
 # are a benchmark fixture, and a machine without a proxy should still get the suite that
 # matters. Asked as its own question rather than with `|| true`, so a generator change that
 # broke a shadow is a failure rather than a skip.
 run = [
     'cd go && go test ./...',
+    'cd integrations/cobra && go test ./...',
     'cd benches/go && if go mod download >/dev/null 2>&1; then go test ./...; else echo "skipped: the benchmark frameworks could not be fetched"; fi',
 ]
 


### PR DESCRIPTION
This PR adds support for Cobra's `Example` field so it is included in specs generated with `--usage-spec`. 

Given a Cobra CLI with `Example` set on the root and on a subcommand:

```go
root := &cobra.Command{
      Use:     "greet",
      Short:   "Greet someone",
      Example: "  greet --help",
}

hello := &cobra.Command{
      Use:   "hello <name>",
      Short: "Say hello",
      Example: `  # the usual greeting
  greet hello world

  # shout it
  greet hello world --loud`,
      Run: func(cmd *cobra.Command, args []string) {},
}
hello.Flags().Bool("loud", false, "Use an exclamation mark")

root.AddCommand(hello)
```

`greet --usage-spec` now emits:

```kdl
name greet
bin greet
about "Greet someone"
example "greet --help"
cmd hello help="Say hello" {
    flag --loud help="Use an exclamation mark"
    arg <name>
    example "# the usual greeting\ngreet hello world\n\n# shout it\ngreet hello world --loud"
}
```

The root's `Example` becomes a top-level `example` node (spec-level); a subcommand's
becomes a child of its `cmd` block, after the subcommands. The conventional two-space
indent is stripped, and comment lines stay inside the example code. 

NOTE: Cobra's `Example` is one free-form text block, so it maps to one example node verbatim rather than being split into `help`/`code` pairs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Cobra command examples in generated usage specifications.
  - Examples are rendered for root and nested commands in KDL and JSON outputs.
  - Multiline examples preserve relative indentation, normalize line endings, and retain comment lines.
  - Example metadata, including headers, help text, and language, is supported.

- **Documentation**
  - Updated Cobra integration documentation and examples to describe example rendering.

- **Tests**
  - Added coverage for rendering, serialization, formatting, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->