### PR TITLE
docs(rust): remove experimental label

### DIFF
--- a/docs/.vitepress/theme/UsageHero.vue
+++ b/docs/.vitepress/theme/UsageHero.vue
@@ -23,9 +23,8 @@ const javascriptPath =
         <p class="usage-hero-desc">
           Usage is a toolkit for building command-line tools. Define your CLI's commands,
           flags, and args once in a KDL spec — get argument parsing, shell completions,
-          <code>--help</code>, docs, and manpages from that one definition. Experimental reference
-          frameworks for Rust and Go build your CLI from the spec, with Python and
-          JavaScript planned.
+          <code>--help</code>, docs, and manpages from that one definition. The Rust framework
+          builds your CLI from the spec, with Go in development and Python and JavaScript planned.
         </p>
 
         <p class="usage-hero-label">Frameworks</p>
@@ -35,10 +34,9 @@ const javascriptPath =
               <path :d="rustPath" />
             </svg>
             <span>Rust</span>
-            <span class="usage-tile-experimental-pill">experimental</span>
             <div class="usage-tile-tooltip">
               <strong>Rust framework</strong>
-              <p>Derive your CLI from Rust types — parsing, help, and completions generated from the usage spec. Experimental: APIs may change between releases.</p>
+              <p>Derive your CLI from Rust types — parsing, help, and completions generated from the usage spec.</p>
             </div>
           </a>
           <a href="/go/" class="usage-tile usage-tile-live">

--- a/docs/go/binding.md
+++ b/docs/go/binding.md
@@ -1,8 +1,8 @@
 # Binding and Values
 
 ::: danger Not ready for testing
-The Go framework is far more experimental than the [Rust framework](/rust/) and is **not ready
-for any amount of testing yet** — do not build against it. Much of what this page documents only
+The Go framework is experimental and **not ready for any amount of testing yet** — do not build
+against it. Much of what this page documents only
 exists in open pull requests and may change before release. These docs are a draft published for
 review, not an invitation to try it.
 :::

--- a/docs/go/completions.md
+++ b/docs/go/completions.md
@@ -1,8 +1,8 @@
 # Completions
 
 ::: danger Not ready for testing
-The Go framework is far more experimental than the [Rust framework](/rust/) and is **not ready
-for any amount of testing yet** — do not build against it. Much of what this page documents only
+The Go framework is experimental and **not ready for any amount of testing yet** — do not build
+against it. Much of what this page documents only
 exists in open pull requests and may change before release. These docs are a draft published for
 review, not an invitation to try it.
 :::

--- a/docs/go/generated-code.md
+++ b/docs/go/generated-code.md
@@ -1,8 +1,8 @@
 # Generated Code
 
 ::: danger Not ready for testing
-The Go framework is far more experimental than the [Rust framework](/rust/) and is **not ready
-for any amount of testing yet** — do not build against it. Much of what this page documents only
+The Go framework is experimental and **not ready for any amount of testing yet** — do not build
+against it. Much of what this page documents only
 exists in open pull requests and may change before release. These docs are a draft published for
 review, not an invitation to try it.
 :::

--- a/docs/go/help.md
+++ b/docs/go/help.md
@@ -1,8 +1,8 @@
 # Help and Errors
 
 ::: danger Not ready for testing
-The Go framework is far more experimental than the [Rust framework](/rust/) and is **not ready
-for any amount of testing yet** — do not build against it. Much of what this page documents only
+The Go framework is experimental and **not ready for any amount of testing yet** — do not build
+against it. Much of what this page documents only
 exists in open pull requests and may change before release. These docs are a draft published for
 review, not an invitation to try it.
 :::

--- a/docs/go/index.md
+++ b/docs/go/index.md
@@ -1,9 +1,9 @@
 # Go Framework
 
 ::: danger Not ready for testing
-The Go framework is far more experimental than the [Rust framework](/rust/) and is **not ready
-for any amount of testing yet** — do not build against it. Unlike usage-rs, which is experimental
-but complete enough that `usage-cli` itself is built with it, usage-go's APIs, generated output,
+The Go framework is experimental and **not ready for any amount of testing yet** — do not build
+against it. Unlike [usage-rs](/rust/), which is complete enough that `usage-cli` itself is built
+with it, usage-go's APIs, generated output,
 and behavior are all still in flux, and much of what these pages document only exists in open
 pull requests. These docs are a draft published for review, not an invitation to try it.
 :::

--- a/docs/go/parser.md
+++ b/docs/go/parser.md
@@ -1,8 +1,8 @@
 # The Parser
 
 ::: danger Not ready for testing
-The Go framework is far more experimental than the [Rust framework](/rust/) and is **not ready
-for any amount of testing yet** — do not build against it. Much of what this page documents only
+The Go framework is experimental and **not ready for any amount of testing yet** — do not build
+against it. Much of what this page documents only
 exists in open pull requests and may change before release. These docs are a draft published for
 review, not an invitation to try it.
 :::

--- a/docs/rust/index.md
+++ b/docs/rust/index.md
@@ -1,9 +1,5 @@
 # Rust Framework
 
-::: warning Experimental
-Used by some of jdx's CLIs, but point releases may break.
-:::
-
 `usage-rs` is a fast, typed framework for building complete command-line applications in Rust.
 Declare commands, flags, arguments, and settings with familiar structs and enums, and get
 first-class environment and config-file resolution, advanced shell completions, portable

--- a/go/README.md
+++ b/go/README.md
@@ -1,11 +1,10 @@
 # usage-go
 
 > [!CAUTION]
-> **usage-go is not ready for any amount of testing.** It is far more experimental
-> than the Rust framework (`usage-rs`) — which is itself experimental, but complete
-> enough that `usage-cli` is built with it. usage-go's APIs, generated output, and
-> behavior are all still in flux, and parts of what is described below only exist in
-> open pull requests. Do not build against it yet.
+> **usage-go is not ready for any amount of testing.** Unlike the Rust framework
+> (`usage-rs`), which is complete enough that `usage-cli` is built with it, usage-go's
+> APIs, generated output, and behavior are all still in flux, and parts of what is
+> described below only exist in open pull requests. Do not build against it yet.
 
 A CLI framework for Go, built the way [usage-argv](../argv) is built for Rust: the
 command line is bound against **static tables** instead of a command tree


### PR DESCRIPTION
## Summary

- remove the experimental warning from the usage-rs landing page
- remove the experimental label and API-stability warning from the homepage Rust tile
- update Go documentation and its README so they no longer imply usage-rs is experimental
- retain the experimental warning for the separate usage-dynamic crate

## Testing

- `prettier --check docs/.vitepress/theme/UsageHero.vue go/README.md docs/rust/index.md docs/go/index.md docs/go/parser.md docs/go/help.md docs/go/generated-code.md docs/go/completions.md docs/go/binding.md`
- `git diff --check`
- repository-wide search for usage-rs/Rust framework stability language

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and marketing copy only; no code, auth, or behavioral changes.
> 
> **Overview**
> **Repositions `usage-rs` as the production-ready Rust framework** in docs and the site hero, while keeping Go clearly not ready for use.
> 
> The Rust framework landing page drops the **Experimental** admonition entirely. The VitePress hero now describes Rust as the framework that builds CLIs from the spec (Go **in development**, Python/JS planned), removes the Rust tile’s **experimental** pill and API-stability caveat in the tooltip, and leaves Go labeled **wip**.
> 
> Across **Go** docs (`docs/go/*`) and **`go/README.md`**, the “not ready for testing” warnings are tightened so they no longer say Go is “far more experimental than” Rust or that Rust is experimental—Rust is framed as complete enough that **`usage-cli` is built with it**. Go remains experimental and off-limits for adopters.
> 
> No runtime or API changes; messaging only. The separate **usage-dynamic** experimental warning (per PR intent) is unchanged in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 965aa02a317cc1cd51007ff383c26c3c8e9dd3a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated framework readiness messaging across the documentation.
  * Clarified that the Rust framework is sufficiently complete for use, while Go remains experimental and not ready for testing.
  * Removed comparative wording and outdated experimental warnings.
  * Documented that Go APIs, generated output, behavior, and features remain subject to change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->