### PR TITLE
chore(ci): update mr-boxington action pin

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -17,12 +17,12 @@ runs:
   steps:
     - name: Restore the fork PR cache mirror
       if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@ccdc5852f8bd93375379830a75f24794407443df
+      uses: jdx/mr-boxington-action@0bb0a01e0b2b3f34db827eddc8307bd4b1fb48ec
       with:
         version: 0.5.4
         backend: github
         cache-links: ${{ inputs.cache-links }}
-    - uses: jdx/mr-boxington-action@ccdc5852f8bd93375379830a75f24794407443df
+    - uses: jdx/mr-boxington-action@0bb0a01e0b2b3f34db827eddc8307bd4b1fb48ec
       with:
         version: 0.5.4
         cache-links: ${{ inputs.cache-links }}

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -248,7 +248,9 @@ jobs:
       # toolchain and no other behaviour — a pinned third-party action would be one more
       # thing to keep current for no gain.
       - name: install the toolchain under test
-        run: rustup toolchain install ${{ matrix.version }} --profile minimal
+        run: |
+          rustup toolchain install ${{ matrix.version }} --profile minimal
+          rustup default ${{ matrix.version }}
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ inputs.mbx-backend }}


### PR DESCRIPTION
Update `jdx/mr-boxington-action` to `0bb0a01e0b2b3f34db827eddc8307bd4b1fb48ec`, which scopes generated cache keys by Rust compiler identity.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions; the main effect is safer cache keying and more reliable MSRV toolchain selection, with no application or auth impact.
> 
> **Overview**
> **CI cache:** Both `jdx/mr-boxington-action` references in `.github/actions/mbx` move from `ccdc5852…` to `0bb0a01e…` (still on mr-boxington **0.5.4**). The newer revision is expected to **scope cache keys by Rust compiler identity**, so builds with different toolchains are less likely to share the wrong cache entries.
> 
> **MSRV job:** After `rustup toolchain install` for the matrix version, the workflow now runs **`rustup default ${{ matrix.version }}`** so the runner’s default toolchain matches the MSRV under test before `mbx` and `mbx +${{ matrix.version }} check` run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10703c587dfe2114127deec08c579c35859b5d67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the automation action reference to a newer verified revision.
  * Improved the minimum-supported Rust version workflow by selecting the requested toolchain as the default before running checks.
  * No changes to application behavior, user-facing features, inputs, or configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->