### PR TITLE
chore(ci): remove non-default Rust checks

### DIFF
--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -182,82 +182,6 @@ jobs:
       # warnings and passes `--all-targets`, which makes those a build failure rather than noise.
       - run: mise r lint:clippy
 
-  # The declared `rust-version` is a promise to anyone depending on these crates, and nothing
-  # was checking it. It said 1.80 — set in 2024 when `LazyLock` landed and never revisited —
-  # and usage-argv had not built at 1.80 for a long time. A promise nobody checks is a guess.
-  #
-  # All published crates hold mise's own 1.91, which is the floor that matters for the fleet.
-  # Each crate is checked at the version it declares rather than at one shared guess, which is
-  # how a lower floor stays real instead of aspirational.
-  #
-  # `cargo check` rather than `cargo test`: dev-dependencies are not part of what an adopter
-  # compiles, and holding them to the MSRV would pin the toolchain past what the library needs.
-  msrv:
-    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - version: "1.91"
-            crates: >-
-              usage-argv usage-derive usage-config usage-validation usage-rs usage-test
-              usage-lib usage-dynamic clap_usage usage-cli
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          submodules: recursive
-          persist-credentials: false
-      - name: the matrix and the manifests agree
-        run: |
-          # Both directions, because one of them alone is how a false floor survives.
-          #
-          # Every crate this row checks declares this row's version. Or the job checks a version
-          # nobody promised: a crate that changes its floor without touching this file would
-          # otherwise be tested at the old one and pass.
-          for crate in ${{ matrix.crates }}; do
-            manifest="$(git ls-files '*Cargo.toml' | xargs grep -l "^name = \"$crate\"$" | head -1)"
-            declared="$(sed -n 's/^rust-version *= *"\(.*\)".*/\1/p' "$manifest" | head -1)"
-            if [ "$declared" != "${{ matrix.version }}" ]; then
-              echo "::error::$crate declares $declared, checked here at ${{ matrix.version }}"
-              exit 1
-            fi
-          done
-          # And every published crate declaring this row's version is in this row. Without this
-          # half, a new crate — or one that was simply never listed — makes a floor promise that
-          # no toolchain ever tries. `usage-conformance` and `xtask` promised 1.91 for as long as
-          # this job existed while depending on a crate that needs 1.95; nothing noticed, because
-          # nothing looked from the manifests back to the matrix.
-          #
-          # Published only: a floor is a promise to whoever depends on the crate, so a
-          # `publish = false` member has nobody to make one to and should not declare one.
-          for manifest in $(git ls-files '*Cargo.toml'); do
-            declared="$(sed -n 's/^rust-version *= *"\(.*\)".*/\1/p' "$manifest" | head -1)"
-            [ "$declared" = "${{ matrix.version }}" ] || continue
-            grep -q '^publish *= *false' "$manifest" && continue
-            name="$(sed -n 's/^name *= *"\(.*\)".*/\1/p' "$manifest" | head -1)"
-            case " ${{ matrix.crates }} " in
-              *" $name "*) ;;
-              *)
-                echo "::error::$name declares $declared and is published, but no row checks it"
-                exit 1
-                ;;
-            esac
-          done
-      # `rustup` rather than an action: it is already on the runner, and this needs one
-      # toolchain and no other behaviour — a pinned third-party action would be one more
-      # thing to keep current for no gain.
-      - name: install the toolchain under test
-        run: rustup toolchain install ${{ matrix.version }} --profile minimal
-      - uses: ./.github/actions/mbx
-        with:
-          backend: ${{ inputs.mbx-backend }}
-      - name: they build at the version they claim
-        run: |
-          for crate in ${{ matrix.crates }}; do
-            mbx +${{ matrix.version }} check --locked -p "$crate" --all-features
-          done
-
   # Single fan-in gate, so branch protection can require one stable check
   # instead of an enumerated list that goes stale when jobs are added or renamed.
   final:
@@ -265,7 +189,6 @@ jobs:
     needs:
       - test
       - test-windows
-      - msrv
     runs-on: ubuntu-latest
     timeout-minutes: 1
     # Run on success or upstream failure but skip when the workflow is cancelled
@@ -275,7 +198,6 @@ jobs:
       - name: Check job results
         if: |
           needs.test.result != 'success' ||
-          needs.test-windows.result != 'success' ||
-          needs.msrv.result != 'success'
+          needs.test-windows.result != 'success'
         run: exit 1
       - run: echo "All CI jobs completed successfully"


### PR DESCRIPTION
## Summary

- remove the dedicated Rust 1.91 MSRV job
- remove the MSRV job from the final CI fan-in
- retain `rust-version` package metadata while avoiding alternate toolchain execution

## Testing

- `mise run lint:actionlint`
- repository-wide scan confirms no explicit alternate Rust toolchain commands remain

_This PR was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Drops automated enforcement that published crates build at their declared MSRV, so a floor mismatch could slip through until someone builds on an older toolchain.
> 
> **Overview**
> **Removes the `msrv` CI job** that installed Rust 1.91 via `rustup`, verified each published crate’s `rust-version` matched the matrix, and ran `mbx +1.91 check --locked` per crate.
> 
> The **`final` fan-in job** now only gates on `test` and `test-windows` success; it no longer waits on or fails for `msrv`.
> 
> Crate **`rust-version` metadata is unchanged**—CI simply stops building against a non-default toolchain. Linux/Windows jobs continue to use the default toolchain from mise/mbx.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19b9dda7e0e0baff71384948de9e30e3d79cee52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->