### PR TITLE
docs: delegate crate versioning to release-plz

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,12 @@ Cargo the permanent path, and do not post externally without user authorization.
 
 This file provides guidance to coding agents working in this repository.
 
+## Crate versioning
+
+Do not manually change crate versions in `Cargo.toml`, generated manifests, or
+lockfiles. `release-plz` owns crate version updates and applies them as part of
+the release workflow.
+
 ## Conventional Commits
 
 All commit messages and PR titles MUST follow conventional commit format:


### PR DESCRIPTION
Document that release-plz exclusively owns crate version updates, including generated manifests and lockfiles. Because `CLAUDE.md` links to `AGENTS.md`, the rule applies to Claude and other coding agents from the shared instructions.

_This PR was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only guidance for agents; no runtime, CI, or release tooling behavior changes in this diff.
> 
> **Overview**
> Adds a **Crate versioning** section to `AGENTS.md` so coding agents know not to hand-edit crate versions in `Cargo.toml`, generated manifests, or lockfiles. **release-plz** is documented as the sole owner of version bumps, applied through the release workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 122a3b3147457998008878b52546b5674a58e47d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance clarifying that crate version updates in manifests and lockfiles are managed exclusively by the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->