### PR TITLE
ci: back mbx with the GitHub Actions cache alone

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,13 +1,7 @@
 name: Set up mbx
-description: Select the trusted jdx server or fork-safe GitHub cache backend
+description: Set up mbx with the GitHub Actions cache backend
 
 inputs:
-  backend:
-    description: Explicit backend for structurally trusted or untrusted callers
-    default: auto
-  mirror-github-cache:
-    description: Mirror a trusted main build into the restore-only cache used by fork PRs
-    default: "false"
   cache-links:
     description: Cache native links; "auto" enables this on Linux
     default: auto
@@ -18,20 +12,9 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Restore the fork PR cache mirror
-      if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
+    - uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
       with:
         version: 0.6.0
         backend: github
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}
-    - uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
-      with:
-        version: 0.6.0
-        cache-links: ${{ inputs.cache-links }}
-        toolchain: ${{ inputs.toolchain }}
-        backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
-        server-url: https://cache.mise.jdx.dev
-        namespace: jdx/usage
-        oidc-audience: https://cache.mise.jdx.dev

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -5,9 +5,6 @@ on:
       trusted:
         required: true
         type: boolean
-      mbx-backend:
-        required: true
-        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -33,9 +30,6 @@ jobs:
           submodules: recursive
           persist-credentials: false
       - uses: ./.github/actions/mbx
-        with:
-          backend: ${{ inputs.mbx-backend }}
-          mirror-github-cache: "true"
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
       # Retries and a longer wait, rather than being allowed to fail. `cli`'s completion
       # tests refuse to skip a missing shell when `CI` is set — see
@@ -149,9 +143,6 @@ jobs:
           submodules: recursive
           persist-credentials: false
       - uses: ./.github/actions/mbx
-        with:
-          backend: ${{ inputs.mbx-backend }}
-          mirror-github-cache: "true"
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
       - run: mise r build
       # `usage bash` runs whatever Windows resolves `bash` to, and `CreateProcess` searches the
@@ -251,7 +242,6 @@ jobs:
         run: rustup toolchain install ${{ matrix.version }} --profile minimal
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.mbx-backend }}
           toolchain: ${{ matrix.version }}
       - name: they build at the version they claim
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
     uses: ./.github/workflows/test-impl.yml
     with:
       trusted: true
-      mbx-backend: server
 
   untrusted:
     if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}
@@ -25,7 +24,6 @@ jobs:
     uses: ./.github/workflows/test-impl.yml
     with:
       trusted: false
-      mbx-backend: github
 
   final:
     name: final


### PR DESCRIPTION
Retires the remote cache server from CI: every job now uses mbx's GitHub Actions cache backend. Removes the backend-selection expression, the `mbx-backend` workflow plumbing, the fork-PR cache mirror, and the server-warming workflow — all of which existed to route trusted builds at cache.mise.jdx.dev. mbx itself stays.

`id-token: write` grants are left in place where they may serve Pages deploys or attestations; they can be tightened separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to Rust build caching; no application code, with possible slower or colder caches on trusted runs until GitHub cache warms.
> 
> **Overview**
> CI no longer splits **trusted** vs **untrusted** builds between a remote mbx cache (`cache.mise.jdx.dev`) and GitHub Actions cache. The composite **mbx** action always sets `backend: github` and drops the `backend` / `mirror-github-cache` inputs, the fork-PR mirror step, and server URL/OIDC settings.
> 
> **test-impl** no longer accepts or forwards `mbx-backend`; every job calls `./.github/actions/mbx` without backend overrides (MSRV still passes `toolchain` only). **test.yml** stops passing `mbx-backend: server` or `github` into the reusable workflow while keeping the trusted/untrusted split for runners, OIDC assertions, and `id-token: write` on trusted jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c306f02c86b35069ada7bccd64f4977bfc65f334. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Standardized build caching to use GitHub’s cache backend.
  - Removed configuration options for selecting alternative cache backends and mirroring caches.
  - Simplified test workflow configuration by removing obsolete cache backend inputs across test, Windows, and minimum-supported-version jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->