### PR TITLE
feat(parse): support scoped flags in implicit clauses

### DIFF
--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -3663,7 +3663,8 @@ mod tests {
         static TASKS: crate::Clause = crate::Clause {
             key: 92,
             name: "tasks",
-            separator: b":::",
+            separator: Some(b":::"),
+            flags: &[],
             args: &[&TASK_ARG],
         };
         static COMMAND: Command = Command {
@@ -3676,7 +3677,8 @@ mod tests {
             restart_token: Some(":::"),
             clause: Some(crate::spec::ClauseMeta {
                 name: "tasks",
-                separator: ":::",
+                separator: Some(":::"),
+                flags: &[],
                 help: None,
                 long_help: None,
                 args: &[ArgMeta {

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -839,6 +839,15 @@ fn positional_args<'a>(meta: &'a CommandMeta<'a>) -> &'a [ArgMeta<'a>] {
     meta.clause.map_or(meta.args, |clause| clause.args)
 }
 
+fn is_clause_flag(meta: &CommandMeta<'_>, flag: &FlagMeta<'_>) -> bool {
+    meta.clause.is_some_and(|clause| {
+        clause
+            .flags
+            .iter()
+            .any(|scoped| core::ptr::eq(scoped.flag, flag.flag))
+    })
+}
+
 fn usage_line_with_subcommands(
     path: &[&str],
     meta: &CommandMeta<'_>,
@@ -854,14 +863,15 @@ fn usage_line_with_subcommands(
 
     // Hidden entries are absent from the line as they are from the sections: help describes
     // what a user is invited to type.
-    let flags: usize = meta.flags.iter().filter(|f| !f.hide && !f.builtin).count();
+    let command_flags = meta
+        .flags
+        .iter()
+        .filter(|f| !f.hide && !f.builtin && !is_clause_flag(meta, f));
+    let flags = command_flags.clone().count();
     if flags > 0 {
-        let required = meta
-            .flags
-            .iter()
-            .any(|f| !f.hide && !f.builtin && flag_demanded(f));
+        let required = command_flags.clone().any(flag_demanded);
         if flags <= INLINE_LIMIT {
-            for flag in meta.flags.iter().filter(|f| !f.hide && !f.builtin) {
+            for flag in command_flags {
                 // A required flag is angled, like a required argument: the brackets are what
                 // say whether leaving it out is allowed.
                 let (open, close) = if flag_demanded(flag) {
@@ -889,7 +899,14 @@ fn usage_line_with_subcommands(
                 .map(arg_usage)
                 .collect::<Vec<_>>()
                 .join(" ");
-            let _ = write!(out, " {inner} [{} {inner}]…", clause.separator);
+            match clause.separator {
+                Some(separator) => {
+                    let _ = write!(out, " {inner} [{separator} {inner}]…");
+                }
+                None => {
+                    let _ = write!(out, " {inner}…");
+                }
+            }
         } else if args <= INLINE_LIMIT {
             for arg in positional_args.iter().filter(|a| !a.hide) {
                 let _ = write!(out, " {}", arg_usage(arg));
@@ -3893,6 +3910,12 @@ mod style_tests {
 
     #[test]
     fn compiled_clause_arguments_appear_in_usage_and_help() {
+        let postinstall = Flag {
+            key: 4,
+            name: "postinstall",
+            longs: &["postinstall"],
+            ..Flag::VALUE
+        };
         let task = Arg {
             name: "TASK",
             ..Arg::REQUIRED
@@ -3905,10 +3928,12 @@ mod style_tests {
         };
         let command = Command {
             name: "run",
+            flags: &[&postinstall],
             clause: Some(Clause {
                 key: 0,
                 name: "tasks",
-                separator: b":::",
+                separator: Some(b":::"),
+                flags: &[&postinstall],
                 args: &[&task, &args],
             }),
             ..Command::EMPTY
@@ -3928,9 +3953,21 @@ mod style_tests {
         };
         let meta = CommandMeta {
             cmd: &command,
+            flags: &[FlagMeta {
+                flag: &postinstall,
+                required: true,
+                help: Some("Command to run after install"),
+                ..FlagMeta::EMPTY
+            }],
             clause: Some(ClauseMeta {
                 name: "tasks",
-                separator: ":::",
+                separator: Some(":::"),
+                flags: &[FlagMeta {
+                    flag: &postinstall,
+                    required: true,
+                    help: Some("Command to run after install"),
+                    ..FlagMeta::EMPTY
+                }],
                 help: None,
                 long_help: None,
                 args: &[task_meta, args_meta],

--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -201,7 +201,7 @@ pub struct Command<'a> {
     pub flags: &'a [&'a Flag<'a>],
     /// Positional arguments, in the order they are filled.
     pub args: &'a [&'a Arg<'a>],
-    /// A repeatable group of positional arguments, if this command has one.
+    /// A repeatable group of scoped flags and positional arguments, if this command has one.
     pub clause: ::core::option::Option<Clause<'a>>,
     pub subcommands: &'a [&'a Command<'a>],
     /// Where a word goes when it names no subcommand of this one.
@@ -306,12 +306,15 @@ impl Command<'_> {
     };
 }
 
-/// A separator-delimited positional group.
+/// A repeatable group of scoped flags and positional arguments.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Clause<'a> {
     pub key: u64,
     pub name: &'a str,
-    pub separator: &'a [u8],
+    /// An explicit token that starts the next instance. When absent, consuming the
+    /// clause's sole required positional completes the current instance.
+    pub separator: ::core::option::Option<&'a [u8]>,
+    pub flags: &'a [&'a Flag<'a>],
     pub args: &'a [&'a Arg<'a>],
 }
 
@@ -1297,6 +1300,89 @@ pub const fn assert_unique_subcommand_names(subcommands: &[&Command<'_>]) {
     }
 }
 
+/// Assert that flags scoped to a clause do not reuse a command-level spelling.
+///
+/// Derive-generated command tables include scoped flags so the parser can find them. Entries
+/// that share a key are therefore the same declaration and are ignored here; every other pair
+/// must have disjoint long, short, alias, and negated spellings.
+pub const fn assert_clause_flag_spellings(command: &Command<'_>) {
+    let Some(clause) = command.clause else {
+        return;
+    };
+    let mut scoped_at = 0;
+    while scoped_at < clause.flags.len() {
+        let scoped = clause.flags[scoped_at];
+        let mut command_at = 0;
+        while command_at < command.flags.len() {
+            let flag = command.flags[command_at];
+            if flag.key != scoped.key && const_flag_forms_overlap(flag, scoped) {
+                panic!("a clause flag spelling conflicts with a command-level flag");
+            }
+            command_at += 1;
+        }
+        scoped_at += 1;
+    }
+}
+
+const fn const_flag_forms_overlap(a: &Flag<'_>, b: &Flag<'_>) -> bool {
+    let mut i = 0;
+    while i < a.longs.len() {
+        let mut j = 0;
+        while j < b.longs.len() {
+            if const_bytes_eq(a.longs[i].as_bytes(), b.longs[j].as_bytes()) {
+                return true;
+            }
+            j += 1;
+        }
+        if let Some(negate) = b.negate {
+            if const_bytes_eq(a.longs[i].as_bytes(), negate.as_bytes()) {
+                return true;
+            }
+        }
+        i += 1;
+    }
+    i = 0;
+    while i < a.shorts.len() {
+        let mut j = 0;
+        while j < b.shorts.len() {
+            if a.shorts[i] == b.shorts[j] {
+                return true;
+            }
+            j += 1;
+        }
+        i += 1;
+    }
+    if let Some(negate) = a.negate {
+        let mut j = 0;
+        while j < b.longs.len() {
+            if const_bytes_eq(negate.as_bytes(), b.longs[j].as_bytes()) {
+                return true;
+            }
+            j += 1;
+        }
+        if let Some(other) = b.negate {
+            if const_bytes_eq(negate.as_bytes(), other.as_bytes()) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+const fn const_bytes_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut i = 0;
+    while i < a.len() {
+        if a[i] != b[i] {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}
+
 /// `==` on strings, in a `const fn`.
 const fn str_eq(a: &str, b: &str) -> bool {
     let (a, b) = (a.as_bytes(), b.as_bytes());
@@ -1618,6 +1704,8 @@ pub struct Parser<'t, 'a, 'v> {
     /// that happens to spell a sibling's name. Two indices rather than the commands
     /// themselves, so the parser keeps allocating nothing.
     help_span: (usize, usize),
+    /// An implicit clause boundary follows the positional event that completed it.
+    pending_clause_boundary: ::core::option::Option<Clause<'t>>,
 }
 
 impl<'t: 'v, 'a, 'v> Parser<'t, 'a, 'v> {
@@ -1671,6 +1759,7 @@ impl<'t: 'v, 'a, 'v> Parser<'t, 'a, 'v> {
             done: false,
             action_errors,
             help_span: (0, 0),
+            pending_clause_boundary: ::core::option::Option::None,
         }
     }
 
@@ -1792,6 +1881,14 @@ impl<'t: 'v, 'a, 'v> Parser<'t, 'a, 'v> {
     }
 
     fn step(&mut self) -> Option<Result<Event<'t, 'a, 'v>, Error<'t, 'v>>> {
+        if let Some(clause) = self.pending_clause_boundary.take() {
+            self.arg_pos = 0;
+            self.arg_taken = 0;
+            self.arg_filled = false;
+            self.collecting = None;
+            self.flags_stopped = false;
+            return Some(Ok(Event::ClauseSeparator { clause }));
+        }
         // A partly-read short bundle takes priority: its remaining bytes are
         // still part of the token being processed.
         if !self.bundle.is_empty() {
@@ -1826,6 +1923,7 @@ impl<'t: 'v, 'a, 'v> Parser<'t, 'a, 'v> {
                 Some(next)
                     if (!is_flag_like(bytes(next))
                         || (flag.allow_negative_numbers && is_negative_number(bytes(next))))
+                        && self.clause_separator(bytes(next)).is_none()
                         && bytes(next) != b"--" =>
                 {
                     self.pos += 1;
@@ -1866,15 +1964,13 @@ impl<'t: 'v, 'a, 'v> Parser<'t, 'a, 'v> {
 
         // A clause separator remains syntax after an automatic positional stopped flags.
         // Only an explicit `--` protects a literal separator.
-        if !self.separator_seen {
-            if let Some(clause) = self.cmd.clause.filter(|clause| token == clause.separator) {
-                self.arg_pos = 0;
-                self.arg_taken = 0;
-                self.arg_filled = false;
-                self.collecting = None;
-                self.flags_stopped = false;
-                return Some(Ok(Event::ClauseSeparator { clause }));
-            }
+        if let Some(clause) = self.clause_separator(token) {
+            self.arg_pos = 0;
+            self.arg_taken = 0;
+            self.arg_filled = false;
+            self.collecting = None;
+            self.flags_stopped = false;
+            return Some(Ok(Event::ClauseSeparator { clause }));
         }
 
         // An automatic trailing argument stops flag interpretation without consuming an
@@ -2154,9 +2250,10 @@ impl<'t: 'v, 'a, 'v> Parser<'t, 'a, 'v> {
         }
         match self.argv.get(self.pos) {
             Some(next)
-                if flag.allow_hyphen_values
-                    || !is_flag_like(bytes(next))
-                    || (flag.allow_negative_numbers && is_negative_number(bytes(next))) =>
+                if self.clause_separator(bytes(next)).is_none()
+                    && (flag.allow_hyphen_values
+                        || !is_flag_like(bytes(next))
+                        || (flag.allow_negative_numbers && is_negative_number(bytes(next)))) =>
             {
                 self.pos += 1;
                 Ok(Some(bytes(next)))
@@ -2171,6 +2268,13 @@ impl<'t: 'v, 'a, 'v> Parser<'t, 'a, 'v> {
             None if flag.value_optional => Ok(None),
             None => Err(Error::MissingFlagValue { flag }),
         }
+    }
+
+    fn clause_separator(&self, token: &[u8]) -> Option<Clause<'t>> {
+        (!self.separator_seen)
+            .then_some(self.cmd.clause)
+            .flatten()
+            .filter(|clause| clause.separator.is_some_and(|separator| token == separator))
     }
 
     fn word(&mut self, token: &'v [u8]) -> Result<Event<'t, 'a, 'v>, Error<'t, 'v>> {
@@ -2354,6 +2458,13 @@ impl<'t: 'v, 'a, 'v> Parser<'t, 'a, 'v> {
             }
         } else {
             self.advance_arg();
+        }
+        if self
+            .cmd
+            .clause
+            .is_some_and(|clause| clause.separator.is_none() && self.next_arg().is_none())
+        {
+            self.pending_clause_boundary = self.cmd.clause;
         }
         Ok(Event::Arg {
             arg,
@@ -2725,7 +2836,8 @@ mod tests {
             clause: Some(Clause {
                 key: 90,
                 name: "tasks",
-                separator: b":::",
+                separator: Some(b":::"),
+                flags: &[],
                 args: &[&TASK, &REST],
             }),
             ..Command::EMPTY
@@ -2756,6 +2868,64 @@ mod tests {
                 ("task", "test".into())
             ]
         );
+    }
+
+    #[test]
+    fn clause_separator_is_not_a_scoped_flag_value() {
+        static POSTINSTALL: Flag = Flag {
+            key: 93,
+            name: "postinstall",
+            longs: &["postinstall"],
+            takes_value: true,
+            variadic: true,
+            ..Flag::BOOL
+        };
+        static TOOL: Arg = Arg {
+            key: 94,
+            name: "tool",
+            ..Arg::REQUIRED
+        };
+        static ROOT: Command = Command {
+            name: "ex",
+            flags: &[&POSTINSTALL],
+            clause: Some(Clause {
+                key: 95,
+                name: "tools",
+                separator: Some(b":::"),
+                flags: &[&POSTINSTALL],
+                args: &[&TOOL],
+            }),
+            ..Command::EMPTY
+        };
+        let argv = [OsStr::new("--postinstall"), OsStr::new(":::")];
+        let mut parser = Parser::new(&ROOT, &argv);
+        assert!(matches!(
+            parser.next_event(),
+            Some(Err(Error::MissingFlagValue { flag })) if flag.key == POSTINSTALL.key
+        ));
+
+        let argv = [
+            OsStr::new("--postinstall"),
+            OsStr::new("setup"),
+            OsStr::new(":::"),
+            OsStr::new("tool"),
+        ];
+        let mut parser = Parser::new(&ROOT, &argv);
+        assert!(matches!(
+            parser.next_event(),
+            Some(Ok(Event::Flag {
+                value: Some(b"setup"),
+                ..
+            }))
+        ));
+        assert!(matches!(
+            parser.next_event(),
+            Some(Ok(Event::ClauseSeparator { clause })) if clause.key == 95
+        ));
+        assert!(matches!(
+            parser.next_event(),
+            Some(Ok(Event::Arg { value: b"tool", .. }))
+        ));
     }
 
     static FORCE: Flag = Flag {

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -967,9 +967,10 @@ impl CommandMeta<'_> {
 #[derive(Debug, Clone, Copy)]
 pub struct ClauseMeta<'a> {
     pub name: &'a str,
-    pub separator: &'a str,
+    pub separator: Option<&'a str>,
     pub help: Option<&'a str>,
     pub long_help: Option<&'a str>,
+    pub flags: &'a [FlagMeta<'a>],
     pub args: &'a [ArgMeta<'a>],
 }
 
@@ -1913,7 +1914,15 @@ fn write_flag_layout_with(
                         .is_some_and(|f| core::ptr::eq(*f, meta.flags[i].flag)),
                     "flag metadata is out of step with the parse table"
                 );
-                write_flag(out, &meta.flags[i], depth, inherited_heading)?;
+                let scoped_to_clause = meta.clause.is_some_and(|clause| {
+                    clause
+                        .flags
+                        .iter()
+                        .any(|flag| core::ptr::eq(flag.flag, meta.flags[i].flag))
+                });
+                if !scoped_to_clause {
+                    write_flag(out, &meta.flags[i], depth, inherited_heading)?;
+                }
                 i += 1;
             }
         }
@@ -1946,6 +1955,7 @@ fn write_body<'a>(
     );
     if let (Some(clause), Some(clause_meta)) = (meta.cmd.clause, meta.clause) {
         debug_assert_eq!(clause.args.len(), clause_meta.args.len());
+        debug_assert_eq!(clause.flags.len(), clause_meta.flags.len());
     } else {
         debug_assert_eq!(
             meta.cmd.args.len(),
@@ -1987,12 +1997,10 @@ fn write_body<'a>(
     }
     if let Some(clause) = meta.clause {
         indent(out, depth)?;
-        write!(
-            out,
-            "clause {} separator={}",
-            quoted(clause.name),
-            quoted(clause.separator)
-        )?;
+        write!(out, "clause {}", quoted(clause.name))?;
+        if let Some(separator) = clause.separator {
+            write!(out, " separator={}", quoted(separator))?;
+        }
         if let Some(help) = clause.help {
             write!(out, " help={}", quoted(help))?;
         }
@@ -2000,6 +2008,9 @@ fn write_body<'a>(
             write!(out, " help_long={}", quoted(help))?;
         }
         out.push_str(" {\n");
+        for flag in clause.flags {
+            write_flag(out, flag, depth + 1, None)?;
+        }
         for arg in clause.args {
             write_arg(out, arg, depth + 1)?;
         }

--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -180,7 +180,8 @@ impl CompleteWord {
                 .cmd
                 .clause
                 .as_ref()
-                .is_some_and(|clause| prev_token == Some(clause.separator.as_str()));
+                .and_then(|clause| clause.separator.as_deref())
+                .is_some_and(|separator| prev_token == Some(separator));
 
         let cx = Ctx {
             tera: &ctx,

--- a/cli/src/cli/diff.rs
+++ b/cli/src/cli/diff.rs
@@ -462,18 +462,35 @@ fn diff_command_props(old: &SpecCommand, new: &SpecCommand, path: &str, c: &mut 
             "clause-added",
             path,
             format!(
-                "clause '{}' using separator '{}' was added, so matching words now start a new clause",
-                now.name, now.separator
+                "clause '{}'{} was added",
+                now.name,
+                now.separator
+                    .as_ref()
+                    .map(|separator| format!(
+                        " using separator '{separator}', so matching words now start a new clause"
+                    ))
+                    .unwrap_or_default()
             ),
         ),
-        (Some(was), Some(now)) if was.separator != now.separator => c.breaking(
-            "clause-separator-changed",
-            path,
-            format!(
-                "clause separator changed from '{}' to '{}'",
-                was.separator, now.separator
-            ),
-        ),
+        (Some(was), Some(now)) => {
+            if was.separator != now.separator {
+                c.breaking(
+                    "clause-separator-changed",
+                    path,
+                    format!(
+                        "clause separator changed from '{}' to '{}'",
+                        was.separator.as_deref().unwrap_or("implicit"),
+                        now.separator.as_deref().unwrap_or("implicit")
+                    ),
+                );
+            }
+            let mut was_cmd = old.clone();
+            was_cmd.flags = was.flags.clone();
+            let mut now_cmd = new.clone();
+            now_cmd.flags = now.flags.clone();
+            diff_flags(&was_cmd, &now_cmd, path, c);
+            diff_args(&was.args, &now.args, path, c);
+        }
         _ => {}
     }
 
@@ -2368,10 +2385,25 @@ clause "tasks" separator="+++" {
     arg "<task>"
 }
 "#;
+        let required_flag = r#"
+name "ex"
+bin "ex"
+clause "tasks" separator=":::" {
+    flag "--postinstall <COMMAND>" required=#true
+    arg "<task>"
+}
+"#;
 
         assert_eq!(codes(plain, colon), ["breaking:clause-added"]);
         assert_eq!(codes(colon, plain), ["breaking:clause-removed"]);
         assert_eq!(codes(colon, plus), ["breaking:clause-separator-changed"]);
+        assert!(
+            codes(colon, required_flag)
+                .iter()
+                .any(|code| code == "breaking:required-flag-added"),
+            "{:?}",
+            codes(colon, required_flag)
+        );
     }
 
     #[test]

--- a/conformance/src/tables.rs
+++ b/conformance/src/tables.rs
@@ -78,17 +78,28 @@ pub fn build(
         .chain(cmd.complete.values())
         .collect();
 
-    let flags: Vec<&'static Flag<'static>> = cmd.flags.iter().map(build_flag).collect();
+    let command_flags: Vec<&'static Flag<'static>> = cmd.flags.iter().map(build_flag).collect();
     let args: Vec<&'static Arg<'static>> = cmd.args.iter().map(build_arg).collect();
     let clause_args: Vec<&'static Arg<'static>> = cmd
         .clause
         .as_ref()
         .map(|clause| clause.args.iter().map(build_arg).collect())
         .unwrap_or_default();
+    let clause_flags: Vec<&'static Flag<'static>> = cmd
+        .clause
+        .as_ref()
+        .map(|clause| clause.flags.iter().map(build_flag).collect())
+        .unwrap_or_default();
+    let flags: Vec<&'static Flag<'static>> =
+        command_flags.iter().chain(&clause_flags).copied().collect();
     let clause = cmd.clause.as_ref().map(|clause| Clause {
         key: 0,
         name: leak(&clause.name),
-        separator: leak(&clause.separator).as_bytes(),
+        separator: clause
+            .separator
+            .as_ref()
+            .map(|separator| leak(separator).as_bytes()),
+        flags: Box::leak(clause_flags.clone().into_boxed_slice()),
         args: Box::leak(clause_args.clone().into_boxed_slice()),
     });
     let subs: Vec<Built> = cmd
@@ -137,9 +148,11 @@ pub fn build(
         key: 0,
     }));
 
-    let flag_metas: Vec<FlagMeta<'static>> = cmd
+    let all_spec_flags = cmd
         .flags
         .iter()
+        .chain(cmd.clause.iter().flat_map(|clause| clause.flags.iter()));
+    let flag_metas: Vec<FlagMeta<'static>> = all_spec_flags
         .zip(&flags)
         .map(|(f, table)| flag_meta(f, table, &completers))
         .collect();
@@ -151,9 +164,18 @@ pub fn build(
         .collect();
     let clause_meta = cmd.clause.as_ref().map(|clause| ClauseMeta {
         name: leak(&clause.name),
-        separator: leak(&clause.separator),
+        separator: clause.separator.as_ref().map(|separator| leak(separator)),
         help: opt(&clause.help),
         long_help: opt(&clause.help_long),
+        flags: Box::leak(
+            clause
+                .flags
+                .iter()
+                .zip(&clause_flags)
+                .map(|(flag, table)| flag_meta(flag, table, &completers))
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        ),
         args: Box::leak(
             clause
                 .args

--- a/conformance/tests/clause.rs
+++ b/conformance/tests/clause.rs
@@ -1,6 +1,6 @@
 use usage::parse::ParseValue;
 use usage::Spec;
-use usage_derive::{Args, Cli};
+use usage_derive::{Args, Cli, Subcommands};
 
 #[derive(Debug, PartialEq, Eq, Args)]
 struct TaskClause {
@@ -16,6 +16,38 @@ struct TypedClause {
     tasks: Vec<TaskClause>,
 }
 
+#[derive(Debug, PartialEq, Eq, Args)]
+struct ToolClause {
+    #[usage(long)]
+    postinstall: Option<String>,
+    tool: String,
+}
+
+#[derive(Debug, Cli)]
+#[usage(bin = "implicit-clause", unknown_flags = "error")]
+struct ImplicitClause {
+    #[usage(clause)]
+    tools: Vec<ToolClause>,
+}
+
+#[derive(Debug, Cli)]
+#[usage(bin = "nested-clause")]
+struct NestedClause {
+    #[usage(subcommand)]
+    command: NestedCommands,
+}
+
+#[derive(Debug, Subcommands)]
+enum NestedCommands {
+    Use(NestedUse),
+}
+
+#[derive(Debug, Args)]
+struct NestedUse {
+    #[usage(clause)]
+    tools: Vec<ToolClause>,
+}
+
 fn spec() -> Spec {
     r#"
 min_usage_version "6.6"
@@ -28,6 +60,21 @@ clause "tasks" separator=":::" {
 "#
     .parse()
     .expect("valid clause spec")
+}
+
+fn implicit_spec() -> Spec {
+    r#"
+min_usage_version "6.6"
+name "implicit-clause"
+bin "implicit-clause"
+unknown_flags "error"
+clause "tools" {
+  flag "--postinstall <COMMAND>"
+  arg "<tool>"
+}
+"#
+    .parse()
+    .expect("valid implicit clause spec")
 }
 
 fn strings<'a>(
@@ -66,6 +113,48 @@ fn explicit_double_dash_protects_a_literal_separator() {
     let instances = &parsed.clauses["tasks"];
     assert_eq!(instances.len(), 1);
     assert_eq!(strings(instances[0].iter(), "args"), [":::", "tail"]);
+}
+
+#[test]
+fn explicit_separator_does_not_hide_a_missing_scoped_flag_value() {
+    let spec: Spec = r#"
+name "clause"
+bin "clause"
+clause "tasks" separator=":::" {
+  flag "--postinstall <COMMAND>"
+  arg "<task>"
+}
+"#
+    .parse()
+    .expect("valid clause spec");
+    let error = usage::Parser::new(&spec)
+        .parse(&["clause", "--postinstall", ":::"].map(str::to_string))
+        .unwrap_err();
+    assert!(
+        error.to_string().contains("requires an argument"),
+        "{error}"
+    );
+}
+
+#[test]
+fn double_dash_does_not_hide_a_missing_implicit_scoped_flag_value() {
+    let spec: Spec = r#"
+name "implicit-clause"
+bin "implicit-clause"
+clause "tools" {
+  flag "--postinstall <COMMAND>"
+  arg "<tool>"
+}
+"#
+    .parse()
+    .expect("valid implicit clause spec");
+    let error = usage::Parser::new(&spec)
+        .parse(&["implicit-clause", "--postinstall", "--", "a"].map(str::to_string))
+        .unwrap_err();
+    assert!(
+        error.to_string().contains("requires an argument"),
+        "{error}"
+    );
 }
 
 #[test]
@@ -116,8 +205,230 @@ fn clause_round_trips_through_canonical_kdl() {
     let reparsed: Spec = emitted.parse().expect("emitted clause spec reparses");
     let clause = reparsed.cmd.clause.expect("clause retained");
     assert_eq!(clause.name, "tasks");
-    assert_eq!(clause.separator, ":::");
+    assert_eq!(clause.separator.as_deref(), Some(":::"));
     assert_eq!(clause.args.len(), 2);
+}
+
+#[test]
+fn implicit_clause_round_trips_and_scopes_reference_flags() {
+    let spec = implicit_spec();
+    let emitted = spec.to_string();
+    assert!(emitted.contains("clause tools {"), "{emitted}");
+    assert!(emitted.contains("flag --postinstall"), "{emitted}");
+    let reparsed: Spec = emitted.parse().expect("emitted implicit clause reparses");
+    assert_eq!(reparsed.cmd.clause.as_ref().unwrap().separator, None);
+
+    let parsed = usage::Parser::new(&reparsed)
+        .parse(
+            &[
+                "implicit-clause",
+                "--postinstall",
+                "A",
+                "a",
+                "--postinstall",
+                "B",
+                "b",
+            ]
+            .map(str::to_string),
+        )
+        .expect("valid invocation");
+    assert_eq!(parsed.clauses["tools"].len(), 2);
+    assert_eq!(strings(parsed.clauses["tools"][0].iter(), "tool"), ["a"]);
+    assert_eq!(strings(parsed.clauses["tools"][1].iter(), "tool"), ["b"]);
+    let flags = &parsed.clause_flags["tools"];
+    assert_eq!(flags.len(), 2);
+    assert!(matches!(
+        flags[0]
+            .iter()
+            .find(|(flag, _)| flag.name == "postinstall")
+            .map(|(_, value)| value),
+        Some(ParseValue::String(value)) if value == "A"
+    ));
+    assert!(matches!(
+        flags[1]
+            .iter()
+            .find(|(flag, _)| flag.name == "postinstall")
+            .map(|(_, value)| value),
+        Some(ParseValue::String(value)) if value == "B"
+    ));
+
+    for (case, invalid) in [
+        vec![
+            "implicit-clause",
+            "--postinstall",
+            "A",
+            "--postinstall",
+            "B",
+            "a",
+        ],
+        vec!["implicit-clause", "--postinstall", "A"],
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        assert!(
+            usage::Parser::new(&reparsed)
+                .parse(&invalid.into_iter().map(str::to_string).collect::<Vec<_>>())
+                .is_err(),
+            "accepted invalid implicit clause {case}"
+        );
+    }
+}
+
+#[test]
+fn scoped_flag_requirements_are_checked_per_instance() {
+    let spec: Spec = r#"
+name "implicit-clause"
+bin "implicit-clause"
+flag "--format <FORMAT>" default="json"
+clause "tools" {
+  flag "--postinstall <COMMAND>" required=#true
+  arg "<tool>"
+}
+"#
+    .parse()
+    .expect("valid required scoped flag spec");
+
+    usage::Parser::new(&spec)
+        .parse(&["implicit-clause".to_string()])
+        .expect("a required scoped flag does not manufacture a clause instance");
+    usage::Parser::new(&spec)
+        .parse(&[
+            "implicit-clause".to_string(),
+            "--postinstall".to_string(),
+            "setup".to_string(),
+            "a".to_string(),
+        ])
+        .expect("the scoped flag satisfies its own instance");
+
+    for argv in [
+        vec!["implicit-clause", "a"],
+        vec!["implicit-clause", "--postinstall", "setup", "a", "b"],
+    ] {
+        let error = usage::Parser::new(&spec)
+            .parse(&argv.into_iter().map(str::to_string).collect::<Vec<_>>())
+            .unwrap_err();
+        assert!(format!("{error:?}").contains("postinstall"), "{error:?}");
+    }
+}
+
+#[test]
+fn scoped_flag_conflicts_do_not_cross_clause_instances() {
+    let spec: Spec = r#"
+name "implicit-clause"
+bin "implicit-clause"
+clause "tools" {
+  flag "--build" conflicts="--skip-build"
+  flag "--skip-build"
+  arg "<tool>"
+}
+"#
+    .parse()
+    .expect("valid scoped conflict spec");
+
+    usage::Parser::new(&spec)
+        .parse(&["implicit-clause", "--build", "a", "--skip-build", "b"].map(str::to_string))
+        .expect("flags in different instances do not conflict");
+    let error = usage::Parser::new(&spec)
+        .parse(&["implicit-clause", "--build", "--skip-build", "a"].map(str::to_string))
+        .unwrap_err();
+    assert!(format!("{error:?}").contains("conflicts"), "{error:?}");
+}
+
+#[test]
+fn scoped_flag_fallbacks_fill_each_existing_instance() {
+    let spec: Spec = r#"
+name "implicit-clause"
+bin "implicit-clause"
+clause "tools" {
+  flag "--postinstall <COMMAND>" env="SETUP" required=#true
+  flag "--mode <MODE>" default="auto" conflicts="--special"
+  flag "--special"
+  flag "--label <LABEL>" {
+    default_if "--special" "special"
+  }
+  flag "--from-format <FORMAT>" {
+    default_if "--format=json" "json"
+  }
+  arg "<tool>"
+}
+"#
+    .parse()
+    .expect("valid scoped fallback spec");
+    let parsed = usage::Parser::new(&spec)
+        .with_env([("SETUP".to_string(), "shared".to_string())].into())
+        .parse(&["implicit-clause", "a", "--special", "b"].map(str::to_string))
+        .expect("scoped fallbacks satisfy each instance");
+    let instances = &parsed.clause_flags["tools"];
+    assert_eq!(instances.len(), 2);
+    for instance in instances {
+        assert!(instance.iter().any(|(flag, value)| {
+            flag.name == "postinstall"
+                && matches!(value, ParseValue::String(value) if value == "shared")
+        }));
+        assert!(instance.iter().any(|(flag, value)| {
+            flag.name == "mode" && matches!(value, ParseValue::String(value) if value == "auto")
+        }));
+    }
+    assert!(!instances[0].keys().any(|flag| flag.name == "label"));
+    assert!(instances[1].iter().any(|(flag, value)| {
+        flag.name == "label" && matches!(value, ParseValue::String(value) if value == "special")
+    }));
+    assert!(instances
+        .iter()
+        .all(|instance| !instance.keys().any(|flag| flag.name == "from-format")));
+
+    let empty = usage::Parser::new(&spec)
+        .with_env([("SETUP".to_string(), "shared".to_string())].into())
+        .parse(&["implicit-clause".to_string()])
+        .expect("fallbacks do not manufacture a clause instance");
+    assert!(empty.clauses.get("tools").is_none_or(Vec::is_empty));
+    assert!(empty.clause_flags.get("tools").is_none_or(Vec::is_empty));
+}
+
+#[test]
+fn runtime_tables_keep_scoped_flag_identity_when_emitted() {
+    let built = usage_conformance::tables::build_spec(&implicit_spec());
+    let emitted = built.to_kdl();
+    assert_eq!(
+        emitted.matches("flag --postinstall").count(),
+        1,
+        "{emitted}"
+    );
+    emitted
+        .parse::<Spec>()
+        .expect("runtime tables emit a reparsable scoped flag");
+}
+
+#[test]
+fn implicit_clause_rejects_ambiguous_layouts_and_flag_spellings() {
+    for invalid in [
+        r#"name bad
+bin bad
+clause tools { arg "[tool]" }
+"#,
+        r#"name bad
+bin bad
+clause tools { arg "<tool>" var=#true }
+"#,
+        r#"name bad
+bin bad
+clause tools { arg "<tool>"; arg "<version>" }
+"#,
+        r#"name bad
+bin bad
+flag --postinstall
+clause tools { flag --postinstall; arg "<tool>" }
+"#,
+        r#"name bad
+bin bad
+flagset shared { flag --postinstall }
+use shared
+clause tools { flag --postinstall; arg "<tool>" }
+"#,
+    ] {
+        assert!(invalid.parse::<Spec>().is_err(), "accepted:\n{invalid}");
+    }
 }
 
 #[test]
@@ -215,6 +526,17 @@ fn derive_collects_each_clause_instance() {
 }
 
 #[test]
+fn explicit_clause_rejects_a_trailing_separator() {
+    let error =
+        TypedClause::parse_from(&[std::ffi::OsStr::new("lint"), std::ffi::OsStr::new(":::")])
+            .unwrap_err();
+    assert!(
+        matches!(error, usage_argv::Error::MissingRequired { name: "TASK" }),
+        "{error:?}"
+    );
+}
+
+#[test]
 fn derived_clause_arguments_appear_in_compiled_help() {
     let spec = TypedClause::spec();
     let usage = usage_argv::help::usage_line(&["typed-clause"], spec.root);
@@ -225,4 +547,112 @@ fn derived_clause_arguments_appear_in_compiled_help() {
     assert!(help.contains("Arguments:"), "{help}");
     assert!(help.contains("<TASK>"), "{help}");
     assert!(help.contains("[ARGS]…"), "{help}");
+}
+
+#[test]
+fn implicit_clause_flags_apply_to_the_following_positional() {
+    let emitted = ImplicitClause::to_kdl();
+    assert!(emitted.contains("clause tools {"), "{emitted}");
+    assert_eq!(
+        emitted.matches("flag --postinstall").count(),
+        1,
+        "{emitted}"
+    );
+    let spec = ImplicitClause::spec();
+    let help = usage_argv::help::short_help(spec, &["implicit-clause"], &[spec.root]);
+    assert!(help.contains("--postinstall"), "{help}");
+    assert!(help.contains("<TOOL>…"), "{help}");
+    for line in ["implicit-clause --", "implicit-clause a --"] {
+        let split =
+            usage_argv::complete::split(line, line.len(), usage_argv::complete::Shell::Bash);
+        assert!(
+            usage_argv::complete::candidates(spec, &split)
+                .iter()
+                .any(|candidate| candidate.value == "--postinstall"),
+            "scoped flag missing after {line:?}"
+        );
+    }
+    let parsed = ImplicitClause::parse_from(&[
+        std::ffi::OsStr::new("--postinstall"),
+        std::ffi::OsStr::new("setup-a"),
+        std::ffi::OsStr::new("a"),
+        std::ffi::OsStr::new("--postinstall"),
+        std::ffi::OsStr::new("setup-b"),
+        std::ffi::OsStr::new("b"),
+        std::ffi::OsStr::new("c"),
+    ])
+    .expect("implicit clauses parse");
+    assert_eq!(
+        parsed.tools,
+        [
+            ToolClause {
+                postinstall: Some("setup-a".into()),
+                tool: "a".into(),
+            },
+            ToolClause {
+                postinstall: Some("setup-b".into()),
+                tool: "b".into(),
+            },
+            ToolClause {
+                postinstall: None,
+                tool: "c".into(),
+            },
+        ]
+    );
+}
+
+#[test]
+fn an_implicit_clause_may_have_no_instances() {
+    let parsed = ImplicitClause::parse_from(&[]).expect("an outer Vec clause is optional");
+    assert!(parsed.tools.is_empty());
+
+    let parsed = usage::Parser::new(&implicit_spec())
+        .parse(&["implicit-clause".to_string()])
+        .expect("the reference parser agrees that an outer clause is optional");
+    assert!(parsed.clauses.get("tools").is_none_or(Vec::is_empty));
+}
+
+#[test]
+fn non_root_derive_emits_and_parses_implicit_clauses() {
+    let spec = NestedClause::spec();
+    let use_meta = spec.root.cmd.subcommands[0];
+    assert!(use_meta.clause.is_some());
+    assert_eq!(use_meta.clause.unwrap().args[0].name, "TOOL");
+
+    let parsed = NestedClause::parse_from(&[
+        std::ffi::OsStr::new("use"),
+        std::ffi::OsStr::new("--postinstall"),
+        std::ffi::OsStr::new("setup"),
+        std::ffi::OsStr::new("a"),
+    ])
+    .expect("nested clause parses");
+    let NestedCommands::Use(command) = parsed.command;
+    assert_eq!(command.tools[0].postinstall.as_deref(), Some("setup"));
+    assert_eq!(command.tools[0].tool, "a");
+}
+
+#[test]
+fn implicit_clause_rejects_duplicate_or_unterminated_scoped_flags() {
+    let duplicate = ImplicitClause::parse_from(&[
+        std::ffi::OsStr::new("--postinstall"),
+        std::ffi::OsStr::new("one"),
+        std::ffi::OsStr::new("--postinstall"),
+        std::ffi::OsStr::new("two"),
+        std::ffi::OsStr::new("tool"),
+    ])
+    .unwrap_err();
+    assert!(matches!(duplicate, usage_argv::Error::DuplicateFlag { .. }));
+
+    let unterminated = ImplicitClause::parse_from(&[
+        std::ffi::OsStr::new("--postinstall"),
+        std::ffi::OsStr::new("setup"),
+    ])
+    .unwrap_err();
+    assert!(
+        matches!(
+            unterminated,
+            usage_argv::Error::MissingRequired { name: "TOOL" }
+        ),
+        "{unterminated:?}"
+    );
 }

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -257,11 +257,18 @@ pub fn emit(cli: &Cli) -> TokenStream {
     let clause_table = clause_field
         .map(|(field, ty, separator)| {
             let name = proc_macro2::Literal::string(&field.name);
-            let separator = proc_macro2::Literal::byte_string(separator.as_bytes());
+            let separator = separator.as_ref().map_or_else(
+                || quote!(::core::option::Option::None),
+                |separator| {
+                    let separator = proc_macro2::Literal::byte_string(separator.as_bytes());
+                    quote!(::core::option::Option::Some(#separator))
+                },
+            );
             quote!(::core::option::Option::Some(usage_argv::Clause {
                 key: 0,
                 name: #name,
                 separator: #separator,
+                flags: <#ty as usage_argv::spec::CommandArgs>::COMMAND.flags,
                 args: <#ty as usage_argv::spec::CommandArgs>::COMMAND.args,
             }))
         })
@@ -269,16 +276,43 @@ pub fn emit(cli: &Cli) -> TokenStream {
     let clause_meta = clause_field
         .map(|(field, ty, separator)| {
             let name = proc_macro2::Literal::string(&field.name);
-            let separator = proc_macro2::Literal::string(separator);
+            let separator = option_str(separator.as_deref());
             quote!(::core::option::Option::Some(usage_argv::spec::ClauseMeta {
                 name: #name,
                 separator: #separator,
                 help: ::core::option::Option::None,
                 long_help: ::core::option::Option::None,
+                flags: <#ty as usage_argv::spec::CommandArgs>::META.flags,
                 args: <#ty as usage_argv::spec::CommandArgs>::META.args,
             }))
         })
         .unwrap_or_else(|| quote!(::core::option::Option::None));
+    let implicit_clause_assertions = clause_field
+        .filter(|(_, _, separator)| separator.is_none())
+        .map(|(_, ty, _)| {
+            quote! {
+                const _: () = {
+                    const INNER: &usage_argv::Command<'static> =
+                        <#ty as usage_argv::spec::CommandArgs>::COMMAND;
+                    assert!(
+                        INNER.args.len() == 1,
+                        "an implicit clause needs exactly one positional argument",
+                    );
+                    assert!(
+                        INNER.args[0].required && !INNER.args[0].var,
+                        "an implicit clause positional must be required and non-variadic",
+                    );
+                    assert!(
+                        INNER.subcommands.is_empty(),
+                        "an implicit clause cannot contain subcommands",
+                    );
+                    assert!(
+                        INNER.args[0].sigil.is_none(),
+                        "an implicit clause positional cannot use a sigil",
+                    );
+                };
+            }
+        });
 
     // Both the plain slices and, when a field is flattened, the joined arrays.
     let tables = tables(cli);
@@ -1081,6 +1115,8 @@ pub fn emit(cli: &Cli) -> TokenStream {
                 !#multicall || !ROOT.subcommands.is_empty(),
                 "`multicall` needs at least one named subcommand to select",
             );
+            #implicit_clause_assertions
+            const _: () = usage_argv::assert_clause_flag_spellings(&ROOT);
 
             #(#flag_metas)*
             #(#arg_metas)*
@@ -3268,7 +3304,19 @@ fn tables(cli: &Cli) -> Tables {
                 flag_groups.push(quote!(<#ty as usage_argv::spec::ArgGroup>::FLAGS));
                 flag_meta_groups.push(quote!(<#ty as usage_argv::spec::ArgGroup>::FLAG_METAS));
             }
-            Kind::Clause { .. } | Kind::Subcommand { .. } | Kind::Skip => {}
+            Kind::Clause { ty, .. } => {
+                flattened = true;
+                if own_since_flatten > 0 {
+                    flag_offset.push(quote!(#own_since_flatten));
+                    own_since_flatten = 0;
+                }
+                flag_offset
+                    .push(quote!(<#ty as usage_argv::spec::CommandArgs>::COMMAND.flags.len()));
+                flush_flags(&mut own_flags, &mut flag_groups, &mut flag_meta_groups);
+                flag_groups.push(quote!(<#ty as usage_argv::spec::CommandArgs>::COMMAND.flags));
+                flag_meta_groups.push(quote!(<#ty as usage_argv::spec::CommandArgs>::META.flags));
+            }
+            Kind::Subcommand { .. } | Kind::Skip => {}
         }
     }
     flush_flags(&mut own_flags, &mut flag_groups, &mut flag_meta_groups);
@@ -5133,14 +5181,28 @@ fn field_value(field: &Field, omitter: Option<&TokenStream>) -> TokenStream {
             },
         };
     }
-    if let Kind::Clause { ty, .. } = &field.kind {
+    if let Kind::Clause { ty, separator } = &field.kind {
         let current = format_ident!("__usage_current_{}", ident);
+        let finish_current = if separator.is_some() {
+            quote!(__usage_instances.push(partial.#current);)
+        } else {
+            quote! {
+                if <#ty as usage_argv::spec::CommandArgs>::any_given(&partial.#current)
+                    .is_some()
+                {
+                    __usage_instances.push(partial.#current);
+                }
+            }
+        };
         return quote! {
-            partial.#ident
-                .into_iter()
-                .chain(::core::iter::once(partial.#current))
-                .map(<#ty as usage_argv::spec::CommandArgs>::build)
-                .collect::<::std::result::Result<::std::vec::Vec<_>, _>>()?
+            {
+                let mut __usage_instances = partial.#ident;
+                #finish_current
+                __usage_instances
+                    .into_iter()
+                    .map(<#ty as usage_argv::spec::CommandArgs>::build)
+                    .collect::<::std::result::Result<::std::vec::Vec<_>, _>>()?
+            }
         };
     }
     // The group's own `build` says which member was given; the field's type says what "none"
@@ -6331,6 +6393,59 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
         .iter()
         .enumerate()
         .map(|(i, f)| arg_meta(cli, i, f, &cli.ident));
+    let clause_field = cli.fields.iter().find_map(|field| match &field.kind {
+        Kind::Clause { ty, separator } => Some((field, ty, separator)),
+        _ => None,
+    });
+    let clause_table = clause_field.map_or_else(
+        || quote!(::core::option::Option::None),
+        |(field, ty, separator)| {
+            let name = proc_macro2::Literal::string(&field.name);
+            let separator = separator.as_ref().map_or_else(
+                || quote!(::core::option::Option::None),
+                |value| {
+                    let value = proc_macro2::Literal::byte_string(value.as_bytes());
+                    quote!(::core::option::Option::Some(#value))
+                },
+            );
+            quote!(::core::option::Option::Some(usage_argv::Clause {
+                key: 0, name: #name, separator: #separator,
+                flags: <#ty as usage_argv::spec::CommandArgs>::COMMAND.flags,
+                args: <#ty as usage_argv::spec::CommandArgs>::COMMAND.args,
+            }))
+        },
+    );
+    let clause_meta = clause_field.map_or_else(
+        || quote!(::core::option::Option::None),
+        |(field, ty, separator)| {
+            let name = proc_macro2::Literal::string(&field.name);
+            let separator = option_str(separator.as_deref());
+            quote!(::core::option::Option::Some(usage_argv::spec::ClauseMeta {
+                name: #name, separator: #separator, help: ::core::option::Option::None,
+                long_help: ::core::option::Option::None,
+                flags: <#ty as usage_argv::spec::CommandArgs>::META.flags,
+                args: <#ty as usage_argv::spec::CommandArgs>::META.args,
+            }))
+        },
+    );
+    let implicit_clause_assertions = clause_field
+        .filter(|(_, _, separator)| separator.is_none())
+        .map(|(_, ty, _)| {
+            quote! {
+                const _: () = {
+                    const INNER: &usage_argv::Command<'static> =
+                        <#ty as usage_argv::spec::CommandArgs>::COMMAND;
+                    assert!(INNER.args.len() == 1,
+                        "an implicit clause needs exactly one positional argument");
+                    assert!(INNER.args[0].required && !INNER.args[0].var,
+                        "an implicit clause positional must be required and non-variadic");
+                    assert!(INNER.subcommands.is_empty(),
+                        "an implicit clause cannot contain subcommands");
+                    assert!(INNER.args[0].sigil.is_none(),
+                        "an implicit clause positional cannot use a sigil");
+                };
+            }
+        });
     // Both the plain slices and, when a field is flattened, the joined arrays.
     let tables = tables(cli);
     let table_decls = &tables.decls;
@@ -6551,10 +6666,13 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
                 dont_delimit_trailing_values: #dont_delimit_trailing_values,
                 flags: #flag_table_ref,
                 args: #arg_table_ref,
+                clause: #clause_table,
                 #sub_commands
                 #sub_external
                 ..usage_argv::Command::EMPTY
             };
+            #implicit_clause_assertions
+            const _: () = usage_argv::assert_clause_flag_spellings(&COMMAND);
 
             #(#flag_metas)*
             #(#arg_metas)*
@@ -6597,6 +6715,7 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
                 headings: #headings,
                 flags: #flag_meta_table_ref,
                 args: #arg_meta_table_ref,
+                clause: #clause_meta,
                 groups: #group_meta_table_ref,
                 flatten_groups: #flatten_group_table_ref,
                 #sub_metas
@@ -9335,6 +9454,39 @@ fn post_binding(cli: &Cli) -> TokenStream {
             }
         })
     });
+    let clause_checks = cli.fields.iter().filter_map(|field| {
+        let Kind::Clause { ty, separator } = &field.kind else {
+            return None;
+        };
+        let ident = &field.ident;
+        let current = format_ident!("__usage_current_{}", ident);
+        let check_current = if separator.is_some() {
+            quote!(true)
+        } else {
+            quote!(
+                <#ty as usage_argv::spec::CommandArgs>::any_given(&partial.#current).is_some()
+            )
+        };
+        Some(quote! {
+            if !__usage_exclusive_present
+                || <#ty as usage_argv::spec::CommandArgs>::exclusive_given(&partial.#current)
+                    .is_some()
+            {
+                for __usage_instance in &mut partial.#ident {
+                    <#ty as usage_argv::spec::CommandArgs>::check_with_args_override_self(
+                        __usage_instance,
+                        false,
+                    )?;
+                }
+                if #check_current {
+                    <#ty as usage_argv::spec::CommandArgs>::check_with_args_override_self(
+                        &mut partial.#current,
+                        false,
+                    )?;
+                }
+            }
+        })
+    });
     let duplicate_checks = cli
         .fields
         .iter()
@@ -10230,6 +10382,7 @@ fn post_binding(cli: &Cli) -> TokenStream {
         #exclusive_cross_checks
         #(#group_exclusivity_checks)*
         #(#flattened_checks)*
+        #(#clause_checks)*
         // An exclusive occurrence is the command's escape from requiredness, just as in clap:
         // `--version` remains usable on a command that otherwise requires an input. Conflicts
         // and other validation still ran above; only errors about absent siblings are skipped.

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -663,7 +663,10 @@ pub enum Kind {
         sigil: Option<String>,
     },
     /// Holds repeatable instances of a positional-only `Args` struct.
-    Clause { ty: syn::Type, separator: String },
+    Clause {
+        ty: syn::Type,
+        separator: Option<String>,
+    },
     /// Holds the enum whose variants are this command's subcommands.
     ///
     /// The type is carried rather than resolved, because the derive cannot see the
@@ -2362,12 +2365,13 @@ impl Field {
                 }
             }
         }
-        let separator =
-            separator.ok_or_else(|| syn::Error::new(span, "a clause needs `separator = \"…\"`"))?;
-        if separator.is_empty() || separator.starts_with('-') {
+        if separator
+            .as_ref()
+            .is_some_and(|separator| separator.is_empty() || separator.starts_with('-'))
+        {
             return Err(syn::Error::new(
                 span,
-                "a clause separator must be non-empty and cannot start with `-`",
+                "a clause separator, when supplied, must be non-empty and cannot start with `-`",
             ));
         }
         let ty = vec_element_type(&field.ty).ok_or_else(|| {

--- a/docs/spec/reference/clause.md
+++ b/docs/spec/reference/clause.md
@@ -1,7 +1,7 @@
 # Clauses
 
-A clause is a repeatable group of positional arguments. A separator ends the current
-instance and starts another without discarding the values already parsed.
+A clause is a repeatable group of scoped flags and positional arguments. It can use an
+explicit separator, or a required terminal positional can end each instance implicitly.
 
 ```kdl
 min_usage_version "6.6"
@@ -20,10 +20,31 @@ The separator is recognized even after `double_dash="automatic"` made tokens ver
 and it re-enables flags for the next instance. An explicit `--` protects the separator,
 so `run lint -- :::` passes `:::` as data instead.
 
-Version 1 deliberately keeps clauses narrow:
+When `separator` is omitted, the clause must contain exactly one required,
+non-variadic positional argument and no subcommands. Consuming that terminal positional
+ends the current instance, resets its scoped flags, and starts the next one:
+
+```kdl
+clause "tools" {
+  flag "--postinstall <COMMAND>"
+  arg "<tool>"
+}
+```
+
+`use --postinstall A a --postinstall B b` produces two `tools` instances. The first
+contains `postinstall="A"` and `tool="a"`; the second contains `postinstall="B"` and
+`tool="b"`. Scoped flags therefore precede and apply to the next terminal positional.
+A scalar flag may appear at most once in one instance, but may appear again after that
+instance's terminal positional. A scoped flag at the end of argv is invalid because it
+does not belong to a completed instance.
+
+Clauses deliberately keep their grammar narrow:
 
 - A command may declare one clause.
-- A clause contains positional `arg` nodes only.
+- An explicit-separator clause may contain multiple positional `arg` nodes. An implicit
+  clause has exactly one required, non-variadic positional.
+- `flag` nodes inside the clause are scoped to one instance. Their spellings must not
+  conflict with command-level flags.
 - Top-level arguments, `restart_token`, and sigil arguments cannot be combined with a
   clause on the same command.
 - Defaults and environment variables do not fill inner arguments; every instance reflects
@@ -52,3 +73,20 @@ struct Run {
 ```
 
 The compiled parser emits a clause-boundary event and builds each nested partial independently.
+
+For an implicit clause, omit `separator` and put scoped fields on the nested `Args` type:
+
+```rust
+#[derive(usage::Args)]
+struct ToolClause {
+    #[usage(long)]
+    postinstall: Option<String>,
+    tool: String,
+}
+
+#[derive(usage::Cli)]
+struct Use {
+    #[usage(clause)]
+    tools: Vec<ToolClause>,
+}
+```

--- a/go/argv/argv.go
+++ b/go/argv/argv.go
@@ -108,11 +108,12 @@ type Command struct {
 	Key uint64
 }
 
-// Clause is a repeatable separator-delimited positional group.
+// Clause is a repeatable group of scoped flags and positional arguments.
 type Clause struct {
 	Key       uint64
 	Name      string
 	Separator string
+	Flags     []*Flag
 	Args      []*Arg
 }
 

--- a/go/argv/help.go
+++ b/go/argv/help.go
@@ -1,6 +1,7 @@
 package argv
 
 import (
+	"slices"
 	"sort"
 	"strings"
 )
@@ -146,6 +147,11 @@ func usageLine(path []string, cmd *Command, help HelpTable, includeSubcommands b
 	visibleFlags := make([]*Flag, 0, len(cmd.Flags))
 	demandedFlag := false
 	for _, f := range cmd.Flags {
+		if cmd.Clause != nil && slices.ContainsFunc(cmd.Clause.Flags, func(scoped *Flag) bool {
+			return scoped.Key == f.Key
+		}) {
+			continue
+		}
 		h := help.Lookup(f.Key)
 		if h != nil && h.Hide {
 			continue
@@ -196,7 +202,11 @@ func usageLine(path []string, cmd *Command, help HelpTable, includeSubcommands b
 				}
 				inner.WriteString(argUsage(a, help.Lookup(a.Key)))
 			}
-			out.WriteString(" " + inner.String() + " [" + cmd.Clause.Separator + " " + inner.String() + "]…")
+			if cmd.Clause.Separator == "" {
+				out.WriteString(" " + inner.String() + "…")
+			} else {
+				out.WriteString(" " + inner.String() + " [" + cmd.Clause.Separator + " " + inner.String() + "]…")
+			}
 		} else if n <= inlineLimit {
 			for _, a := range visibleArgs {
 				out.WriteString(" " + argUsage(a, help.Lookup(a.Key)))

--- a/go/argv/parser.go
+++ b/go/argv/parser.go
@@ -76,6 +76,9 @@ type Parser struct {
 	// asking this question want to know what the user wrote, not what state the
 	// parser reached.
 	separatorSeen bool
+	// clauseBoundaryPending emits the implicit boundary after the terminal
+	// positional event, before the next token is read.
+	clauseBoundaryPending bool
 	// defaultTaken records whether the default subcommand has been used, which may
 	// happen at most once: a default that itself declares one would otherwise
 	// descend on every word until the tree ran out.
@@ -198,6 +201,15 @@ func (p *Parser) emit(e Event) bool {
 
 func (p *Parser) step() bool {
 	for {
+		if p.clauseBoundaryPending {
+			p.clauseBoundaryPending = false
+			p.argPos = 0
+			p.argTaken = 0
+			p.argFilled = false
+			p.collecting = nil
+			p.flagsStopped = false
+			return p.emit(Event{Kind: KindClauseSeparator, Clause: p.cmd.Clause})
+		}
 		// A partly-read short bundle takes priority: its remaining bytes are still
 		// part of the token being processed.
 		if len(p.bundle) > 0 {
@@ -227,7 +239,7 @@ func (p *Parser) step() bool {
 					p.collecting = nil
 					continue
 				}
-				if (!isFlagLike(next) || (flag.AllowNegativeNumbers && isNegativeNumber(next))) && next != "--" {
+				if (!isFlagLike(next) || (flag.AllowNegativeNumbers && isNegativeNumber(next))) && !p.isClauseSeparator(next) && next != "--" {
 					p.pos++
 					p.collected += valuesIn(next, flag.Delimiter)
 					// Same rule as a positional: a bounded occurrence takes that many and
@@ -252,7 +264,7 @@ func (p *Parser) step() bool {
 		token := p.argv[p.pos]
 		p.pos++
 
-		if !p.separatorSeen && p.cmd.Clause != nil && token == p.cmd.Clause.Separator {
+		if p.isClauseSeparator(token) {
 			p.argPos = 0
 			p.argTaken = 0
 			p.argFilled = false
@@ -511,12 +523,16 @@ func (p *Parser) takeDetachedValue(flag *Flag, long string, short byte) (string,
 	if flag.RequireEquals {
 		return p.missingOrDefault(flag, long, short)
 	}
-	if p.pos < len(p.argv) && (flag.AllowHyphenValues || !isFlagLike(p.argv[p.pos]) || (flag.AllowNegativeNumbers && isNegativeNumber(p.argv[p.pos]))) {
+	if p.pos < len(p.argv) && !p.isClauseSeparator(p.argv[p.pos]) && (flag.AllowHyphenValues || !isFlagLike(p.argv[p.pos]) || (flag.AllowNegativeNumbers && isNegativeNumber(p.argv[p.pos]))) {
 		v := p.argv[p.pos]
 		p.pos++
 		return v, true, true
 	}
 	return p.missingOrDefault(flag, long, short)
+}
+
+func (p *Parser) isClauseSeparator(token string) bool {
+	return !p.separatorSeen && p.cmd.Clause != nil && p.cmd.Clause.Separator != "" && token == p.cmd.Clause.Separator
 }
 
 // missingOrDefault is the value when a detached one is refused or absent.
@@ -682,6 +698,9 @@ func (p *Parser) word(token string) bool {
 		}
 	} else {
 		p.advanceArg()
+		if p.cmd.Clause != nil && p.cmd.Clause.Separator == "" && p.argPos >= len(p.currentArgs()) {
+			p.clauseBoundaryPending = true
+		}
 	}
 	return p.emit(Event{
 		Kind: KindArg, Arg: arg, Value: token, HasValue: true, Delimit: delimit,

--- a/go/argv/parser_test.go
+++ b/go/argv/parser_test.go
@@ -76,6 +76,8 @@ func collect(cmd *Command, args ...string) string {
 			out = append(out, s)
 		case KindArg:
 			out = append(out, "arg:"+ev.Arg.Name+"="+ev.Value)
+		case KindClauseSeparator:
+			out = append(out, "clause:"+ev.Clause.Name)
 		case KindExternal:
 			out = append(out, "external:"+strings.Join(ev.Values, ","))
 		}
@@ -84,6 +86,40 @@ func collect(cmd *Command, args ...string) string {
 		out = append(out, "err:"+err.(*Error).Code.String())
 	}
 	return strings.Join(out, " ")
+}
+
+func TestImplicitClauseResetsAfterItsTerminalPositional(t *testing.T) {
+	postinstall := &Flag{Key: 20, Name: "postinstall", Longs: []string{"postinstall"}, TakesValue: true}
+	tool := &Arg{Key: 21, Name: "tool", Required: true}
+	cmd := &Command{
+		Name:   "use",
+		Flags:  []*Flag{postinstall},
+		Clause: &Clause{Key: 22, Name: "tools", Flags: []*Flag{postinstall}, Args: []*Arg{tool}},
+	}
+	got := collect(cmd, "--postinstall", "A", "a", "--postinstall", "B", "b")
+	want := "flag:postinstall=A arg:tool=a clause:tools flag:postinstall=B arg:tool=b clause:tools"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestClauseSeparatorIsNotAScopedFlagValue(t *testing.T) {
+	postinstall := &Flag{Key: 23, Name: "postinstall", Longs: []string{"postinstall"}, TakesValue: true, Variadic: true}
+	tool := &Arg{Key: 24, Name: "tool", Required: true}
+	cmd := &Command{
+		Name:  "use",
+		Flags: []*Flag{postinstall},
+		Clause: &Clause{
+			Key: 25, Name: "tools", Separator: ":::",
+			Flags: []*Flag{postinstall}, Args: []*Arg{tool},
+		},
+	}
+	if got := collect(cmd, "--postinstall", ":::"); got != "err:missing_flag_value" {
+		t.Fatalf("got %q", got)
+	}
+	if got := collect(cmd, "--postinstall", "setup", ":::", "tool"); got != "flag:postinstall=setup clause:tools arg:tool=tool" {
+		t.Fatalf("got %q", got)
+	}
 }
 
 func TestAllowMissingPositionalReservesLastWord(t *testing.T) {

--- a/go/argv/sections_test.go
+++ b/go/argv/sections_test.go
@@ -278,13 +278,16 @@ func TestAPageWithoutATemplateIsUnchanged(t *testing.T) {
 }
 
 func TestClauseArgumentsAppearInUsageAndHelp(t *testing.T) {
+	postinstall := &Flag{Key: 4, Name: "postinstall", Longs: []string{"postinstall"}, TakesValue: true}
 	task := &Arg{Key: 2, Name: "task", Required: true}
 	args := &Arg{Key: 3, Name: "args", Var: true}
 	root := &Command{
 		Name: "ex", Key: 1,
-		Clause: &Clause{Name: "tasks", Separator: ":::", Args: []*Arg{task, args}},
+		Flags:  []*Flag{postinstall},
+		Clause: &Clause{Name: "tasks", Separator: ":::", Flags: []*Flag{{Key: 4, Name: "postinstall", Longs: []string{"postinstall"}, TakesValue: true}}, Args: []*Arg{task, args}},
 	}
 	help := helpKeyed(
+		Help{Key: 4, Short: "Command to run after install", Demanded: true},
 		Help{Key: 2, Short: "Task to run", Demanded: true},
 		Help{Key: 3, Short: "Arguments for the task"},
 	)

--- a/go/internal/spec/spec.go
+++ b/go/internal/spec/spec.go
@@ -136,6 +136,7 @@ type Cmd struct {
 type Clause struct {
 	Name      string `json:"name"`
 	Separator string `json:"separator"`
+	Flags     []Flag `json:"flags"`
 	Args      []Arg  `json:"args"`
 }
 
@@ -556,8 +557,12 @@ func (s *Spec) MultiFlags() map[string]Multi {
 }
 
 func collectMulti(c *Cmd, out map[string]Multi) {
-	for i := range c.Flags {
-		f := &c.Flags[i]
+	flags := c.Flags
+	if c.Clause != nil {
+		flags = append(flags, c.Clause.Flags...)
+	}
+	for i := range flags {
+		f := &flags[i]
 		switch {
 		case f.Count:
 			out[f.Name] = MultiCount
@@ -768,6 +773,11 @@ func (b *builder) command(c *Cmd, inherited argv.UnknownFlags) *argv.Command {
 	}
 	if c.Clause != nil {
 		out.Clause = &argv.Clause{Key: b.next(), Name: c.Clause.Name, Separator: c.Clause.Separator}
+		for i := range c.Clause.Flags {
+			flag := b.flag(&c.Clause.Flags[i], true)
+			out.Clause.Flags = append(out.Clause.Flags, flag)
+			out.Flags = append(out.Flags, flag)
+		}
 		for i := range c.Clause.Args {
 			out.Clause.Args = append(out.Clause.Args, b.arg(&c.Clause.Args[i]))
 		}
@@ -810,6 +820,13 @@ func (b *builder) resolveRelationships(c *Cmd, out *argv.Command) {
 			for _, arg := range out.Args {
 				if arg.Name == name {
 					return arg.Key, true
+				}
+			}
+			if out.Clause != nil {
+				for _, arg := range out.Clause.Args {
+					if arg.Name == name {
+						return arg.Key, true
+					}
 				}
 			}
 		}
@@ -857,9 +874,13 @@ func (b *builder) resolveRelationships(c *Cmd, out *argv.Command) {
 		return out
 	}
 
-	// `c.Flags` and `out.Flags` are built in step, so the index is the join.
-	for i := range c.Flags {
-		src := &c.Flags[i]
+	// Command and clause flags are appended to `out.Flags` in this order, so the index is the join.
+	flags := c.Flags
+	if c.Clause != nil {
+		flags = append(flags, c.Clause.Flags...)
+	}
+	for i := range flags {
+		src := &flags[i]
 		m := &b.meta[out.Flags[i].Key-1]
 		m.Conflicts = resolve(src.Conflicts)
 		m.Overrides = resolve(src.Overrides)
@@ -882,6 +903,19 @@ func (b *builder) resolveRelationships(c *Cmd, out *argv.Command) {
 		m.RequiredIfEqAll = resolveConditions(src.RequiredIfEqAll)
 		m.RequiredUnless = resolve(src.RequiredUnless)
 		m.RequiredUnlessAll = resolve(src.RequiredUnlessAll)
+	}
+	if c.Clause != nil {
+		for i := range c.Clause.Args {
+			src := &c.Clause.Args[i]
+			m := &b.meta[out.Clause.Args[i].Key-1]
+			m.Conflicts = resolve(src.Conflicts)
+			m.Requires = resolve(src.Requires)
+			m.RequiredIf = resolve(src.RequiredIf)
+			m.RequiredIfEq = resolveConditions(src.RequiredIfEq)
+			m.RequiredIfEqAll = resolveConditions(src.RequiredIfEqAll)
+			m.RequiredUnless = resolve(src.RequiredUnless)
+			m.RequiredUnlessAll = resolve(src.RequiredUnlessAll)
+		}
 	}
 }
 

--- a/go/internal/spec/spec_test.go
+++ b/go/internal/spec/spec_test.go
@@ -323,6 +323,28 @@ func TestConflictsCanNamePositionals(t *testing.T) {
 	}
 }
 
+func TestClauseRelationshipsCanNameScopedPositionalsAndFlags(t *testing.T) {
+	root, meta := build(&Spec{
+		Name: "ex", Bin: "ex",
+		Cmd: Cmd{Name: "ex", Clause: &Clause{
+			Name: "tools",
+			Flags: []Flag{{
+				Name: "postinstall", Long: []string{"postinstall"}, Requires: []string{"tool"},
+			}},
+			Args: []Arg{{Name: "tool", Conflicts: []string{"--postinstall"}}},
+		}},
+	})
+
+	postinstall := root.Clause.Flags[0]
+	tool := root.Clause.Args[0]
+	if got := meta.Lookup(postinstall.Key).Requires; !reflect.DeepEqual(got, []uint64{tool.Key}) {
+		t.Fatalf("scoped flag should resolve the clause positional: %v", got)
+	}
+	if got := meta.Lookup(tool.Key).Conflicts; !reflect.DeepEqual(got, []uint64{postinstall.Key}) {
+		t.Fatalf("clause positional should resolve the scoped flag: %v", got)
+	}
+}
+
 // A subcommand redeclaring an inherited name shadows it, here as at parse time.
 func TestALocalFlagShadowsTheGlobalOfTheSameName(t *testing.T) {
 	root, meta := build(&Spec{

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -43,6 +43,9 @@ pub enum UsageErr {
     #[error("Invalid usage config")]
     InvalidInput(String, SourceSpan, NamedSource<String>),
 
+    #[error("Invalid usage spec: {0}")]
+    InvalidSpec(String),
+
     #[error("Missing required arg: <{0}>")]
     MissingArg(String),
 

--- a/lib/src/go/mod.rs
+++ b/lib/src/go/mod.rs
@@ -209,6 +209,22 @@ impl<'a> Emitter<'a> {
                     .collect::<Vec<_>>()
             })
             .unwrap_or_default();
+        let clause_flags = cmd
+            .clause
+            .as_ref()
+            .map(|clause| {
+                clause
+                    .flags
+                    .iter()
+                    .map(|flag| {
+                        (
+                            flag.clone(),
+                            self.name("Flag", path, &format!("{}-{}", clause.name, flag.name)),
+                        )
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
 
         let index = out.len();
         out.push(Emitted {
@@ -216,6 +232,7 @@ impl<'a> Emitter<'a> {
             cmd: cmd.clone(),
             flags,
             args,
+            clause_flags,
             clause_args,
             subcommands: Vec::new(),
             root,
@@ -294,6 +311,11 @@ impl<'a> Emitter<'a> {
         for e in commands {
             entries.push((&e.named.key, e.named.number));
             entries.extend(e.flags.iter().map(|(_, n)| (n.key.as_str(), n.number)));
+            entries.extend(
+                e.clause_flags
+                    .iter()
+                    .map(|(_, n)| (n.key.as_str(), n.number)),
+            );
             entries.extend(e.args.iter().map(|(_, n)| (n.key.as_str(), n.number)));
             entries.extend(
                 e.clause_args
@@ -368,9 +390,9 @@ impl<'a> Emitter<'a> {
                 lines.push(Line::Field("Aliases".into(), format!("[]string{{{list}}}")));
             }
 
-            if !e.flags.is_empty() {
+            if !e.flags.is_empty() || !e.clause_flags.is_empty() {
                 let mut block = vec!["Flags: []*argv.Flag{".to_string()];
-                for (flag, named) in &e.flags {
+                for (flag, named) in e.flags.iter().chain(&e.clause_flags) {
                     block.push(format!("\t{},", flag_literal(flag, named)));
                 }
                 block.push("},".to_string());
@@ -389,7 +411,15 @@ impl<'a> Emitter<'a> {
                 let mut block = vec!["Clause: &argv.Clause{".to_string()];
                 block.push(format!("\tKey: {},", e.named.key));
                 block.push(format!("\tName: {},", go_string(&clause.name)));
-                block.push(format!("\tSeparator: {},", go_string(&clause.separator)));
+                block.push(format!(
+                    "\tSeparator: {},",
+                    go_string(clause.separator.as_deref().unwrap_or_default())
+                ));
+                block.push("\tFlags: []*argv.Flag{".to_string());
+                for (flag, named) in &e.clause_flags {
+                    block.push(format!("\t\t{},", flag_literal(flag, named)));
+                }
+                block.push("\t},".to_string());
                 block.push("\tArgs: []*argv.Arg{".to_string());
                 for (arg, named) in &e.clause_args {
                     block.push(format!("\t\t{},", arg_literal(arg, named)));
@@ -493,7 +523,7 @@ impl Emitter<'_> {
         // By key, so the slice can be written in one pass in index order.
         let mut by_key: BTreeMap<u64, String> = BTreeMap::new();
         for e in commands {
-            for (flag, named) in &e.flags {
+            for (flag, named) in e.flags.iter().chain(&e.clause_flags) {
                 by_key.insert(named.number, self.flag_meta(flag, named, e, commands));
             }
             for (arg, named) in &e.args {
@@ -506,7 +536,7 @@ impl Emitter<'_> {
 
         let total = commands
             .iter()
-            .map(|e| 1 + e.flags.len() + e.args.len() + e.clause_args.len())
+            .map(|e| 1 + e.flags.len() + e.clause_flags.len() + e.args.len() + e.clause_args.len())
             .sum::<usize>() as u64;
 
         let _ = writeln!(
@@ -546,7 +576,11 @@ impl Emitter<'_> {
             format!("Name: {}", go_string(&flag.name)),
             "Flag: true".to_string(),
         ];
-        if !owner.cmd.args_override_self
+        let scoped = owner
+            .clause_flags
+            .iter()
+            .any(|(_, candidate)| candidate.key == named.key);
+        if (!owner.cmd.args_override_self || scoped)
             && !flag.var
             && !flag.count
             && !flag.arg.as_ref().is_some_and(|arg| arg.var)
@@ -901,7 +935,7 @@ fn match_flag(cmd: &Emitted, name: &str, globals_only: bool) -> Option<String> {
         (None, None, Some(name))
     };
 
-    let ordinary = cmd.flags.iter().find(|(flag, _)| {
+    let ordinary = cmd.flags.iter().chain(&cmd.clause_flags).find(|(flag, _)| {
         if !eligible(flag) {
             return false;
         }
@@ -922,6 +956,7 @@ fn match_flag(cmd: &Emitted, name: &str, globals_only: bool) -> Option<String> {
     // usage-lib resolves it that way round too.
     cmd.flags
         .iter()
+        .chain(&cmd.clause_flags)
         .find(|(flag, _)| eligible(flag) && flag.negate.as_deref() == Some(name))
         .map(|(_, named)| named.key.clone())
 }
@@ -984,7 +1019,7 @@ impl Emitter<'_> {
         let mut by_key: BTreeMap<u64, String> = BTreeMap::new();
         for e in commands {
             by_key.insert(e.named.number, command_help(e));
-            for (flag, named) in &e.flags {
+            for (flag, named) in e.flags.iter().chain(&e.clause_flags) {
                 by_key.insert(named.number, flag_help(flag, named));
             }
             for (arg, named) in &e.args {
@@ -997,7 +1032,7 @@ impl Emitter<'_> {
 
         let total = commands
             .iter()
-            .map(|e| 1 + e.flags.len() + e.args.len() + e.clause_args.len())
+            .map(|e| 1 + e.flags.len() + e.clause_flags.len() + e.args.len() + e.clause_args.len())
             .sum::<usize>() as u64;
 
         let _ = writeln!(
@@ -1406,6 +1441,7 @@ struct Emitted {
     cmd: SpecCommand,
     flags: Vec<(SpecFlag, Named)>,
     args: Vec<(SpecArg, Named)>,
+    clause_flags: Vec<(SpecFlag, Named)>,
     clause_args: Vec<(SpecArg, Named)>,
     /// Indices into the flat list, in declaration order.
     subcommands: Vec<usize>,
@@ -2281,6 +2317,7 @@ bin "ex"
 cmd "run" {
     flag "--needs-task" requires="task"
     clause "items" separator=":::" {
+        flag "--postinstall <command>"
         arg "<task>" help="Task to run"
     }
 }
@@ -2305,6 +2342,13 @@ cmd "later" {
         );
         assert!(
             meta.lines().any(|line| {
+                line.contains("Key: FlagRunItemsPostinstall")
+                    && line.contains("RejectDuplicate: true")
+            }),
+            "{out}"
+        );
+        assert!(
+            meta.lines().any(|line| {
                 line.contains("Key: FlagRunNeedsTask")
                     && line.contains("Requires: []uint64{ArgRunItemsTask}")
             }),
@@ -2323,10 +2367,13 @@ cmd "later" {
         );
         for generated in [
             "type RunCmdItemsClause struct {",
+            "Postinstall string",
+            "Flags: []*argv.Flag{",
+            "clauseFlag := map[uint64]bool{FlagRunItemsPostinstall: true}",
             "case argv.KindClauseSeparator:",
-            "for _, instance := range clauseInstances[CmdRun] {",
-            "if err := argv.Check(Meta.Lookup(key), values, 0); err != nil {",
-            "clauseSources := map[uint64]argv.Source{ArgRunItemsTask: argv.Unset}",
+            "for instanceIndex, instance := range clauseInstances[CmdRun] {",
+            "if err := argv.Check(Meta.Lookup(key), values, instanceOccurrences[key]); err != nil {",
+            "clauseSources := map[uint64]argv.Source{FlagRunItemsPostinstall: argv.Unset, ArgRunItemsTask: argv.Unset}",
             "cmdRunV.Items = append(cmdRunV.Items, item)",
         ] {
             assert!(out.contains(generated), "missing {generated:?}:\n{out}");
@@ -2423,8 +2470,8 @@ bin "ex"
 flag "--pair <ITEM>..." {
     arg "<ITEM>..." var=#true var_min=2 var_max=2 {
         value_names "ITEM"
+        }
     }
-}
 arg "<ITEM>..." var=#true var_min=2 var_max=2 {
     value_names "ITEM"
 }
@@ -2433,6 +2480,55 @@ arg "<ITEM>..." var=#true var_min=2 var_max=2 {
         assert_eq!(
             out.matches("ValueNames: []string{\"ITEM\"}").count(),
             2,
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn scoped_flag_binding_preserves_counts_and_boolean_polarity() {
+        let out = go(r#"
+name "ex"
+bin "ex"
+clause "tools" {
+    flag "--required" required=#true
+    flag "-v --verbose" count=#true
+    flag "--color" negate="--no-color" bool_value=#true
+    arg "<tool>"
+}
+"#);
+
+        for generated in [
+            "if clauseFlag[f.Key] {",
+            "instanceOccurrences := clauseInstanceOccurrences[CmdRoot][instanceIndex]",
+            "argv.Check(Meta.Lookup(key), values, instanceOccurrences[key])",
+            "item.Required = !instanceNegated[FlagToolsRequired]",
+            "item.Verbose = instanceOccurrences[FlagToolsVerbose]",
+            "item.Color = (values[len(values)-1] == \"true\") != instanceNegated[FlagToolsColor]",
+            "item.Color = !instanceNegated[FlagToolsColor]",
+        ] {
+            assert!(out.contains(generated), "missing {generated:?}:\n{out}");
+        }
+    }
+
+    #[test]
+    fn a_bare_optional_scoped_flag_does_not_index_an_empty_value() {
+        let out = go(r#"
+name "ex"
+bin "ex"
+clause "tools" {
+    flag "--label [LABEL]" value_optional=#true
+    arg "<tool>"
+}
+"#);
+
+        assert!(
+            out.contains(
+                "if values := instance[FlagToolsLabel]; len(values) > 0 {\n\t\t\t\titem.Label = values[len(values)-1]"
+            ),
+            "{out}"
+        );
+        assert!(
+            !out.contains("if values, ok := instance[FlagToolsLabel]; ok"),
             "{out}"
         );
     }

--- a/lib/src/go/structs.rs
+++ b/lib/src/go/structs.rs
@@ -46,27 +46,29 @@ pub(super) fn emit(out: &mut String, commands: &[Emitted]) {
                 clause.name
             );
             let _ = writeln!(out, "type {type_name} struct {{");
-            let fields = e
-                .clause_args
-                .iter()
-                .map(|(arg, named)| {
-                    let base = field_name(&arg.name);
-                    let field = if taken.insert(base.clone()) {
-                        base
-                    } else {
-                        let mut n = 2;
-                        loop {
-                            let candidate = format!("{base}{n}");
-                            if taken.insert(candidate.clone()) {
-                                break candidate;
-                            }
-                            n += 1;
+            let mut fields = Vec::new();
+            let mut add_field = |base: String, ty: String, named: &super::Named| {
+                let field = if taken.insert(base.clone()) {
+                    base
+                } else {
+                    let mut n = 2;
+                    loop {
+                        let candidate = format!("{base}{n}");
+                        if taken.insert(candidate.clone()) {
+                            break candidate;
                         }
-                    };
-                    args.insert(named.key.clone(), field.clone());
-                    (field, arg_type(arg), named.key.as_str())
-                })
-                .collect::<Vec<_>>();
+                        n += 1;
+                    }
+                };
+                args.insert(named.key.clone(), field.clone());
+                fields.push((field, ty, named.key.clone()));
+            };
+            for (flag, named) in &e.clause_flags {
+                add_field(field_name(&flag.name), flag_type(flag).to_string(), named);
+            }
+            for (arg, named) in &e.clause_args {
+                add_field(field_name(&arg.name), arg_type(arg).to_string(), named);
+            }
             let name_col = fields.iter().map(|(n, _, _)| n.len()).max().unwrap_or(0);
             let type_col = fields.iter().map(|(_, t, _)| t.len()).max().unwrap_or(0);
             for (field, ty, key) in fields {
@@ -178,6 +180,17 @@ fn parse_fn(out: &mut String, commands: &[Emitted], assigned: &Fields, clauses: 
                         && !flag.arg.as_ref().is_some_and(|arg| arg.var)
                 })
                 .map(|(_, named)| named.key.as_str())
+                .chain(
+                    command
+                        .clause_flags
+                        .iter()
+                        .filter(|(flag, _)| {
+                            !flag.var
+                                && !flag.count
+                                && !flag.arg.as_ref().is_some_and(|arg| arg.var)
+                        })
+                        .map(|(_, named)| named.key.as_str()),
+                )
         })
         .collect::<Vec<_>>();
     strict_keys.sort_unstable();
@@ -190,6 +203,13 @@ fn parse_fn(out: &mut String, commands: &[Emitted], assigned: &Fields, clauses: 
                 .iter()
                 .filter(|(flag, _)| !command.cmd.args_override_self && flag.negate.is_some())
                 .map(|(_, named)| named.key.as_str())
+                .chain(
+                    command
+                        .clause_flags
+                        .iter()
+                        .filter(|(flag, _)| flag.negate.is_some())
+                        .map(|(_, named)| named.key.as_str()),
+                )
         })
         .collect::<Vec<_>>();
     strict_negate_keys.sort_unstable();
@@ -243,19 +263,26 @@ fn parse_fn(out: &mut String, commands: &[Emitted], assigned: &Fields, clauses: 
         format!("\t\t\tlevelSeen = map[uint64]int{{}}\n{polarity}")
     };
     let has_relationship_values = commands.iter().any(|command| {
-        command.flags.iter().any(|(flag, _)| {
-            !flag.requires_if.is_empty()
-                || !flag.required_if_eq.is_empty()
-                || !flag.required_if_eq_all.is_empty()
-        }) || command
-            .args
+        command
+            .flags
             .iter()
-            .chain(command.clause_args.iter())
-            .any(|(arg, _)| !arg.required_if_eq.is_empty() || !arg.required_if_eq_all.is_empty())
+            .chain(command.clause_flags.iter())
+            .any(|(flag, _)| {
+                !flag.requires_if.is_empty()
+                    || !flag.required_if_eq.is_empty()
+                    || !flag.required_if_eq_all.is_empty()
+            })
+            || command
+                .args
+                .iter()
+                .chain(command.clause_args.iter())
+                .any(|(arg, _)| {
+                    !arg.required_if_eq.is_empty() || !arg.required_if_eq_all.is_empty()
+                })
     });
     let has_default_if = commands
         .iter()
-        .flat_map(|command| command.flags.iter())
+        .flat_map(|command| command.flags.iter().chain(command.clause_flags.iter()))
         .any(|(flag, _)| !flag.default_if.is_empty());
     let needs_negated = has_relationship_values || has_default_if;
     let conditional_state = if needs_negated {
@@ -274,24 +301,86 @@ fn parse_fn(out: &mut String, commands: &[Emitted], assigned: &Fields, clauses: 
         ""
     };
     let clause_state = if clauses.is_empty() {
-        ""
+        String::new()
     } else {
-        "\tclauseGiven := map[uint64][]string{}\n\tclauseInstances := map[uint64][]map[uint64][]string{}\n"
+        let keys = commands
+            .iter()
+            .flat_map(|command| command.clause_flags.iter())
+            .map(|(_, named)| format!("{}: true", named.key))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!(
+            "\tclauseGiven := map[uint64][]string{{}}\n\
+             \tclauseOccurrences := map[uint64]int{{}}\n\
+             \tclauseNegated := map[uint64]bool{{}}\n\
+             \tclauseInstances := map[uint64][]map[uint64][]string{{}}\n\
+             \tclauseInstanceOccurrences := map[uint64][]map[uint64]int{{}}\n\
+             \tclauseInstanceNegated := map[uint64][]map[uint64]bool{{}}\n\
+             \tclauseFlag := map[uint64]bool{{{keys}}}\n"
+        )
     };
     let clause_arg_values = if clauses.is_empty() {
         "\t\t\tgiven[ev.Arg.Key] = append(given[ev.Arg.Key], values...)\n"
     } else {
         "\t\t\tif p.Command().Clause != nil {\n\t\t\t\tclauseGiven[ev.Arg.Key] = append(clauseGiven[ev.Arg.Key], values...)\n\t\t\t} else {\n\t\t\t\tgiven[ev.Arg.Key] = append(given[ev.Arg.Key], values...)\n\t\t\t}\n"
     };
-    let clause_separator_event = if clauses.is_empty() {
+    let clause_flag_target = if clauses.is_empty() {
         ""
     } else {
-        "\t\tcase argv.KindClauseSeparator:\n\t\t\tclauseInstances[ev.Clause.Key] = append(clauseInstances[ev.Clause.Key], clauseGiven)\n\t\t\tclauseGiven = map[uint64][]string{}\n"
+        "\t\t\tflagGiven := given\n\t\t\tif clauseFlag[ev.Flag.Key] {\n\
+         \t\t\t\tflagGiven = clauseGiven\n\
+         \t\t\t\tclauseOccurrences[ev.Flag.Key]++\n\
+         \t\t\t\tclauseNegated[ev.Flag.Key] = ev.Negated\n\
+         \t\t\t}\n"
+    };
+    let flag_values = if clauses.is_empty() {
+        "given"
+    } else {
+        "flagGiven"
+    };
+    let skip_clause_flag = if clauses.is_empty() {
+        ""
+    } else {
+        "\t\t\tif clauseFlag[f.Key] {\n\t\t\t\tcontinue\n\t\t\t}\n"
+    };
+    let clause_separator_event = if clauses.is_empty() {
+        String::new()
+    } else {
+        let duplicate = if strict_keys.is_empty() {
+            ""
+        } else {
+            "\t\t\t\tif strictSeen[flag.Key] {\n\t\t\t\t\tclauseOccurrences[flag.Key] = 1\n\t\t\t\t\tif duplicateSeen[flag.Key] {\n\t\t\t\t\t\tclauseOccurrences[flag.Key] = 2\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\tdelete(levelSeen, flag.Key)\n\t\t\t\tdelete(strictSeen, flag.Key)\n\t\t\t\tdelete(duplicateSeen, flag.Key)\n"
+        };
+        let polarity = if strict_negate_keys.is_empty() {
+            ""
+        } else {
+            "\t\t\t\tdelete(polaritySeen, flag.Key)\n"
+        };
+        format!(
+            "\t\tcase argv.KindClauseSeparator:\n\
+             \t\t\tclauseInstances[ev.Clause.Key] = append(clauseInstances[ev.Clause.Key], clauseGiven)\n\
+             \t\t\tfor _, flag := range ev.Clause.Flags {{\n\t\t\t\tdelete(seen, flag.Key)\n{duplicate}{polarity}\t\t\t}}\n\
+             \t\t\tclauseInstanceOccurrences[ev.Clause.Key] = append(clauseInstanceOccurrences[ev.Clause.Key], clauseOccurrences)\n\
+             \t\t\tclauseInstanceNegated[ev.Clause.Key] = append(clauseInstanceNegated[ev.Clause.Key], clauseNegated)\n\
+             \t\t\tclauseGiven = map[uint64][]string{{}}\n\
+             \t\t\tclauseOccurrences = map[uint64]int{{}}\n\
+             \t\t\tclauseNegated = map[uint64]bool{{}}\n"
+        )
+    };
+    let finish_normalize = if strict_keys.is_empty() {
+        ""
+    } else {
+        "\t\tfor _, flag := range p.Command().Clause.Flags {\n\t\t\tif strictSeen[flag.Key] {\n\t\t\t\tclauseOccurrences[flag.Key] = 1\n\t\t\t\tif duplicateSeen[flag.Key] {\n\t\t\t\t\tclauseOccurrences[flag.Key] = 2\n\t\t\t\t}\n\t\t\t}\n\t\t}\n"
     };
     let finish_clause = if clauses.is_empty() {
-        ""
+        String::new()
     } else {
-        "\tif p.Command().Clause != nil {\n\t\tclauseInstances[p.Command().Clause.Key] = append(clauseInstances[p.Command().Clause.Key], clauseGiven)\n\t}\n"
+        format!("\tif p.Command().Clause != nil && (p.Command().Clause.Separator != \"\" || len(clauseGiven) > 0) {{\n\
+         {finish_normalize}\
+         \t\tclauseInstances[p.Command().Clause.Key] = append(clauseInstances[p.Command().Clause.Key], clauseGiven)\n\
+         \t\tclauseInstanceOccurrences[p.Command().Clause.Key] = append(clauseInstanceOccurrences[p.Command().Clause.Key], clauseOccurrences)\n\
+         \t\tclauseInstanceNegated[p.Command().Clause.Key] = append(clauseInstanceNegated[p.Command().Clause.Key], clauseNegated)\n\
+         \t}}\n")
     };
     let _ = writeln!(
         out,
@@ -360,20 +449,21 @@ fn parse_fn(out: &mut String, commands: &[Emitted], assigned: &Fields, clauses: 
         "\t\t\t}}\n\t\tcase argv.KindFlag:\n\t\t\tseen[ev.Flag.Key]++\n\
          {duplicate_event}\
          {conditional_event}\
+         {clause_flag_target}\
          \t\t\tif ev.Flag.BoolValue {{\n\
          \t\t\t\t// Boolean binding is last-one-wins. Replace an earlier attached value even\n\
          \t\t\t\t// when the last occurrence is bare, so relationship polarity follows the field.\n\
          \t\t\t\tif ev.HasValue {{\n\
-         \t\t\t\t\tgiven[ev.Flag.Key] = []string{{ev.Value}}\n\
+         \t\t\t\t\t{flag_values}[ev.Flag.Key] = []string{{ev.Value}}\n\
          \t\t\t\t}} else {{\n\
-         \t\t\t\t\tgiven[ev.Flag.Key] = []string{{}}\n\
+         \t\t\t\t\t{flag_values}[ev.Flag.Key] = []string{{}}\n\
          \t\t\t\t}}\n\
          \t\t\t}} else if ev.HasValue {{\n\
-         \t\t\t\tgiven[ev.Flag.Key] = append(given[ev.Flag.Key], argv.SplitValue(ev.Value, ev.Flag.Delimiter, true)...)\n\
-         \t\t\t}} else if given[ev.Flag.Key] == nil {{\n\
+         \t\t\t\t{flag_values}[ev.Flag.Key] = append({flag_values}[ev.Flag.Key], argv.SplitValue(ev.Value, ev.Flag.Delimiter, true)...)\n\
+         \t\t\t}} else if {flag_values}[ev.Flag.Key] == nil {{\n\
          \t\t\t\t// Given without a value is still given, and nil would read as\n\
          \t\t\t\t// absent when the fallbacks are applied.\n\
-         \t\t\t\tgiven[ev.Flag.Key] = []string{{}}\n\t\t\t}}\n\
+         \t\t\t\t{flag_values}[ev.Flag.Key] = []string{{}}\n\t\t\t}}\n\
          \t\t\tswitch ev.Flag.Key {{"
     );
     for e in commands {
@@ -422,7 +512,9 @@ fn parse_fn(out: &mut String, commands: &[Emitted], assigned: &Fields, clauses: 
          \trequirements := map[uint64]bool{{}}\n\
          \tfor i, cmd := range chain {{\n\
          \t\tcheckRequirements := i == len(chain)-1 || !cmd.SubcommandNegatesReqs\n\
-         \t\tfor _, f := range cmd.Flags {{\n\t\t\tscope = append(scope, f.Key)\n\t\t\trequirements[f.Key] = checkRequirements\n\t\t}}\n\
+         \t\tfor _, f := range cmd.Flags {{\n\
+         {skip_clause_flag}\
+         \t\t\tscope = append(scope, f.Key)\n\t\t\trequirements[f.Key] = checkRequirements\n\t\t}}\n\
          \t\tfor _, a := range cmd.Args {{\n\t\t\tscope = append(scope, a.Key)\n\t\t\trequirements[a.Key] = checkRequirements\n\t\t}}\n\
          \t}}\n\
          \tsources := map[uint64]argv.Source{{}}\n\
@@ -459,23 +551,45 @@ fn parse_fn(out: &mut String, commands: &[Emitted], assigned: &Fields, clauses: 
         .iter()
         .flat_map(|command| {
             command
-                .clause_args
+                .clause_flags
                 .iter()
                 .map(|(_, named)| named.key.as_str())
+                .chain(
+                    command
+                        .clause_args
+                        .iter()
+                        .map(|(_, named)| named.key.as_str()),
+                )
         })
         .collect::<Vec<_>>()
         .join(", ");
     if !clauses.is_empty() {
         let initial_sources = commands
             .iter()
-            .flat_map(|command| command.clause_args.iter())
-            .map(|(_, named)| format!("{}: argv.Unset", named.key))
+            .flat_map(|command| {
+                command
+                    .clause_flags
+                    .iter()
+                    .map(|(_, named)| named)
+                    .chain(command.clause_args.iter().map(|(_, named)| named))
+            })
+            .map(|named| format!("{}: argv.Unset", named.key))
             .collect::<Vec<_>>()
             .join(", ");
         let aggregate_values = if has_relationship_values {
-            "\t\t\tclauseValues[key] = append(clauseValues[key], values...)\n"
+            "\t\t\tclauseValues[key] = append(clauseValues[key], argv.RelationshipValues(Meta.Lookup(key), values, argv.FromArgv, clauseInstanceNegated[clauseKey][instanceIndex][key])...)\n"
         } else {
             ""
+        };
+        let aggregate_instances = if has_relationship_values {
+            "clauseKey, instances"
+        } else {
+            "_, instances"
+        };
+        let aggregate_instance = if has_relationship_values {
+            "instanceIndex, instance"
+        } else {
+            "_, instance"
         };
         let aggregate_binding = if has_relationship_values {
             "key, values"
@@ -491,8 +605,8 @@ fn parse_fn(out: &mut String, commands: &[Emitted], assigned: &Fields, clauses: 
             out,
             "\tclauseSources := map[uint64]argv.Source{{{initial_sources}}}\n\
              {values_state}\
-             \tfor _, instances := range clauseInstances {{\n\
-             \t\tfor _, instance := range instances {{\n\
+             \tfor {aggregate_instances} := range clauseInstances {{\n\
+             \t\tfor {aggregate_instance} := range instances {{\n\
              \t\t\tfor {aggregate_binding} := range instance {{\n\
              \t\t\t\tclauseSources[key] = argv.FromArgv\n\
              {aggregate_values}\
@@ -511,7 +625,7 @@ fn parse_fn(out: &mut String, commands: &[Emitted], assigned: &Fields, clauses: 
             "\t\treturn argv.RelationshipValues(Meta.Lookup(k), resolved[k], sources[k], negated[k])\n".to_string()
         } else {
             format!(
-                "\t\tswitch k {{\n\t\tcase {clause_keys}:\n\t\t\treturn argv.RelationshipValues(Meta.Lookup(k), clauseValues[k], clauseSources[k], false)\n\t\tdefault:\n\t\t\treturn argv.RelationshipValues(Meta.Lookup(k), resolved[k], sources[k], negated[k])\n\t\t}}\n"
+                "\t\tswitch k {{\n\t\tcase {clause_keys}:\n\t\t\treturn clauseValues[k]\n\t\tdefault:\n\t\t\treturn argv.RelationshipValues(Meta.Lookup(k), resolved[k], sources[k], negated[k])\n\t\t}}\n"
             )
         };
         let _ = writeln!(
@@ -534,11 +648,9 @@ fn parse_fn(out: &mut String, commands: &[Emitted], assigned: &Fields, clauses: 
 
 /// Validate each clause independently and append its typed value to the command field.
 ///
-/// Clause arguments deliberately stay out of the command-wide `given` and `scope`: reusing
+/// Clause entries deliberately stay out of the command-wide `given` and `scope`: reusing
 /// those maps would collapse repeated instances into one value and let one instance satisfy
-/// another's required argument. Flags remain visible through the source/value callbacks, but
-/// are not entries in this pass: flag relationships are judged once against clause values
-/// aggregated across every instance, matching the reference parser.
+/// another's requirements.
 fn emit_clause_instances(
     out: &mut String,
     commands: &[Emitted],
@@ -550,24 +662,46 @@ fn emit_clause_instances(
             continue;
         };
         let keys = e
-            .clause_args
+            .clause_flags
             .iter()
             .map(|(_, named)| named.key.as_str())
+            .chain(e.clause_args.iter().map(|(_, named)| named.key.as_str()))
             .collect::<Vec<_>>();
         let key_list = keys.join(", ");
+        let flag_key_list = e
+            .clause_flags
+            .iter()
+            .map(|(_, named)| named.key.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
         let owner = owner_of(e);
+        let instance_negated = format!(
+            "\t\t\tinstanceNegated := clauseInstanceNegated[{}][instanceIndex]\n",
+            e.named.key
+        );
         let _ = writeln!(
             out,
             "\t{{\n\t\tclauseScope := []uint64{{{key_list}}}\n\
-             \t\tfor _, instance := range clauseInstances[{}] {{\n\
+             \t\tclauseFlagScope := []uint64{{{flag_key_list}}}\n\
+             \t\tfor instanceIndex, instance := range clauseInstances[{}] {{\n\
+             \t\t\tinstanceOccurrences := clauseInstanceOccurrences[{}][instanceIndex]\n\
+             {instance_negated}\
              \t\t\tclauseSources := map[uint64]argv.Source{{}}\n\
              \t\t\tfor _, key := range clauseScope {{\n\
+             \t\t\t\tif _, ok := instance[key]; ok {{\n\t\t\t\t\tclauseSources[key] = argv.FromArgv\n\t\t\t\t}} else {{\n\t\t\t\t\tclauseSources[key] = argv.Unset\n\t\t\t\t}}\n\
+             \t\t\t}}\n\
+             \t\t\tfor _, key := range clauseFlagScope {{\n\
+             \t\t\t\tvalues, source := argv.Fill(Meta.Lookup(key), instance[key], argv.LookupEnv)\n\
+             \t\t\t\tif values != nil {{\n\t\t\t\t\tinstance[key] = values\n\t\t\t\t}} else {{\n\t\t\t\t\tdelete(instance, key)\n\t\t\t\t}}\n\
+             \t\t\t\tclauseSources[key] = source\n\
+             \t\t\t}}\n\
+             \t\t\targv.ApplyDefaultIf(Meta, clauseFlagScope, instance, clauseSources, instanceNegated)\n\
+             \t\t\tfor _, key := range clauseScope {{\n\
              \t\t\t\tvalues := instance[key]\n\
-             \t\t\t\tif values != nil {{\n\t\t\t\t\tclauseSources[key] = argv.FromArgv\n\t\t\t\t}} else {{\n\t\t\t\t\tclauseSources[key] = argv.Unset\n\t\t\t\t}}\n\
-             \t\t\t\tif err := argv.Check(Meta.Lookup(key), values, 0); err != nil {{\n\t\t\t\t\treturn nil, err\n\t\t\t\t}}\n\
+             \t\t\t\tif err := argv.Check(Meta.Lookup(key), values, instanceOccurrences[key]); err != nil {{\n\t\t\t\t\treturn nil, err\n\t\t\t\t}}\n\
              \t\t\t}}\n\
              \t\t\tinstanceScope := clauseScope\n",
-            e.named.key
+            e.named.key, e.named.key
         );
         if has_relationship_values {
             let _ = writeln!(
@@ -575,7 +709,7 @@ fn emit_clause_instances(
                 "\t\t\tif err := argv.CheckRelationshipsWithValuesAndRequirements(Meta, instanceScope, func(k uint64) argv.Source {{\n\
                  \t\t\t\tswitch k {{\n\t\t\t\tcase {key_list}:\n\t\t\t\t\treturn clauseSources[k]\n\t\t\t\tdefault:\n\t\t\t\t\treturn sources[k]\n\t\t\t\t}}\n\
                  \t\t\t}}, func(k uint64) []string {{\n\
-                 \t\t\t\tswitch k {{\n\t\t\t\tcase {key_list}:\n\t\t\t\t\treturn argv.RelationshipValues(Meta.Lookup(k), instance[k], clauseSources[k], false)\n\t\t\t\tdefault:\n\t\t\t\t\treturn argv.RelationshipValues(Meta.Lookup(k), resolved[k], sources[k], negated[k])\n\t\t\t\t}}\n\
+                 \t\t\t\tswitch k {{\n\t\t\t\tcase {key_list}:\n\t\t\t\t\treturn argv.RelationshipValues(Meta.Lookup(k), instance[k], clauseSources[k], instanceNegated[k])\n\t\t\t\tdefault:\n\t\t\t\t\treturn argv.RelationshipValues(Meta.Lookup(k), resolved[k], sources[k], negated[k])\n\t\t\t\t}}\n\
                  \t\t\t}}, func(k uint64) bool {{\n\
                  \t\t\t\tswitch k {{\n\t\t\t\tcase {key_list}:\n\t\t\t\t\treturn true\n\t\t\t\tdefault:\n\t\t\t\t\treturn requirements[k]\n\t\t\t\t}}\n\
                  \t\t\t}}); err != nil {{\n\t\t\t\treturn nil, err\n\t\t\t}}"
@@ -591,6 +725,19 @@ fn emit_clause_instances(
             );
         }
         let _ = writeln!(out, "\t\t\titem := {}{{}}", fields.type_name);
+        for (flag, named) in &e.clause_flags {
+            let field = &fields.args[&named.key];
+            let assign = clause_flag_assign(flag, field, &named.key);
+            let guard = match flag_type(flag) {
+                "int" => format!("if _, ok := instance[{}]; ok", named.key),
+                "bool" if !flag.bool_value => {
+                    format!("if _, ok := instance[{}]; ok", named.key)
+                }
+                "bool" => format!("if values, ok := instance[{}]; ok", named.key),
+                _ => format!("if values := instance[{}]; len(values) > 0", named.key),
+            };
+            let _ = writeln!(out, "\t\t\t{guard} {{\n\t\t\t\t{assign}\n\t\t\t}}",);
+        }
         for (arg, named) in &e.clause_args {
             let field = &fields.args[&named.key];
             let assign = if arg.var {
@@ -705,5 +852,19 @@ fn flag_assign(flag: &SpecFlag, owner: &str, field: &str) -> String {
             "\t\t\t\tif ev.HasValue {{\n\t\t\t\t\t{owner}.{field} = append({owner}.{field}, argv.SplitValue(ev.Value, ev.Flag.Delimiter, true)...)\n\t\t\t\t}}"
         ),
         _ => format!("\t\t\t\t{owner}.{field} = ev.Value"),
+    }
+}
+
+fn clause_flag_assign(flag: &SpecFlag, field: &str, key: &str) -> String {
+    match flag_type(flag) {
+        "int" => format!("item.{field} = instanceOccurrences[{key}]"),
+        "bool" if flag.bool_value => format!(
+            "if clauseSources[{key}] == argv.FromEnv {{\n\t\t\t\t\titem.{field} = argv.EnvTruth(values[len(values)-1])\n\t\t\t\t}} else if clauseSources[{key}] == argv.FromDefault {{\n\t\t\t\t\titem.{field} = values[len(values)-1] == \"true\"\n\t\t\t\t}} else if len(values) > 0 {{\n\t\t\t\t\titem.{field} = (values[len(values)-1] == \"true\") != instanceNegated[{key}]\n\t\t\t\t}} else {{\n\t\t\t\t\titem.{field} = !instanceNegated[{key}]\n\t\t\t\t}}"
+        ),
+        "bool" => format!(
+            "if clauseSources[{key}] == argv.FromEnv {{\n\t\t\t\t\titem.{field} = argv.EnvTruth(values[len(values)-1])\n\t\t\t\t}} else if clauseSources[{key}] == argv.FromDefault {{\n\t\t\t\t\titem.{field} = values[len(values)-1] == \"true\"\n\t\t\t\t}} else {{\n\t\t\t\t\titem.{field} = !instanceNegated[{key}]\n\t\t\t\t}}"
+        ),
+        "[]string" => format!("item.{field} = append(item.{field}, values...)"),
+        _ => format!("item.{field} = values[len(values)-1]"),
     }
 }

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -193,6 +193,7 @@ fn flag_keys(flag: &SpecFlag) -> Vec<String> {
 fn gather_flags(cmd: &SpecCommand) -> BTreeMap<String, Arc<SpecFlag>> {
     cmd.flags
         .iter()
+        .chain(cmd.clause.iter().flat_map(|clause| &clause.flags))
         .flat_map(|f| {
             let f = Arc::new(f.clone()); // One clone per flag, then cheap Arc refs
             flag_keys(&f)
@@ -386,6 +387,8 @@ pub struct ParseOutput {
     pub args: IndexMap<Arc<SpecArg>, ParseValue>,
     /// Separator-delimited positional instances, keyed by clause name.
     pub clauses: IndexMap<String, Vec<IndexMap<Arc<SpecArg>, ParseValue>>>,
+    /// Per-instance flags belonging to a repeatable clause, keyed by clause name.
+    pub clause_flags: IndexMap<String, Vec<IndexMap<Arc<SpecFlag>, ParseValue>>>,
     pub flags: IndexMap<Arc<SpecFlag>, ParseValue>,
     /// What each word of the command line became, in argv order, one entry per word.
     ///
@@ -770,6 +773,7 @@ impl<'a> Parser<'a> {
             self.env.as_ref(),
             self.mount_outputs.as_ref(),
             MountTiming::WhenAWordIsUnknown,
+            true,
             &mut trace,
         ) {
             // A parse that got as far as stopping normally already moved its tokens onto the
@@ -787,6 +791,7 @@ impl<'a> Parser<'a> {
             custom_env,
             self.mount_outputs.as_ref(),
             MountTiming::WhenAWordIsUnknown,
+            false,
         )?;
         restore_current_clause(&mut out);
         trace!("{out:?}");
@@ -916,7 +921,12 @@ impl<'a> Parser<'a> {
         // that was filled from env. Applying both in one pass would make the
         // answer depend on declaration order: `--bin-names` before `--json`
         // would miss `EX_JSON=1`.
-        let flags: Vec<Arc<SpecFlag>> = out.available_flags.values().cloned().collect();
+        let flags: Vec<Arc<SpecFlag>> = out
+            .available_flags
+            .values()
+            .filter(|flag| !is_clause_scoped_flag(&out, flag))
+            .cloned()
+            .collect();
         for flag in &flags {
             if out.flags.contains_key(flag) || overridden_flags.contains(&flag.name) {
                 continue;
@@ -1026,6 +1036,18 @@ impl<'a> Parser<'a> {
                 }
             }
         }
+        // The binding phase leaves the last clause instance in `args`/`flags` so
+        // completion can inspect it. A full parse closes it before applying scoped
+        // fallbacks: defaults and environment values fill instances that argv made,
+        // but never manufacture a repeated group on their own.
+        finalize_current_clause(&mut out);
+        let clause_explicit = apply_clause_flag_fallbacks(&mut out, &overridden_flags, custom_env)?;
+        validate_clause_relationships(
+            &mut out,
+            &overridden_flags,
+            custom_env,
+            clause_explicit.as_deref(),
+        );
         // Declarative value validation is deliberately post-binding. Defaults and
         // environment fallbacks have landed by here, and delimiters were already split
         // while binding. Like clap's value parsers, a declaration judges each resulting
@@ -1046,7 +1068,6 @@ impl<'a> Parser<'a> {
                 .get(&clause.name)
                 .into_iter()
                 .flatten()
-                .chain(std::iter::once(&out.args))
                 .enumerate()
             {
                 for arg in &clause.args {
@@ -1094,7 +1115,18 @@ impl<'a> Parser<'a> {
             }
             out.errors.extend(clause_errors);
         }
-        for (flag, parsed) in &out.flags {
+        let clause_flag_names = out
+            .cmd
+            .clause
+            .iter()
+            .flat_map(|clause| &clause.flags)
+            .map(|flag| flag.name.as_str())
+            .collect::<HashSet<_>>();
+        for (flag, parsed) in out
+            .flags
+            .iter()
+            .filter(|(flag, _)| !clause_flag_names.contains(flag.name.as_str()))
+        {
             if let Some(arg) = &flag.arg {
                 validate_expression(
                     &flag.name,
@@ -1108,7 +1140,6 @@ impl<'a> Parser<'a> {
         // Applied once, here, because this is where the CLI's own version is known: a
         // `deprecated_warn_at` the spec has not reached yet is an author saying *not yet*.
         crate::warn::retain_reached(&mut out.warnings, self.spec.version.as_deref());
-        finalize_current_clause(&mut out);
         Ok(out)
     }
 }
@@ -1129,7 +1160,7 @@ pub fn parse(spec: &Spec, input: &[String]) -> Result<ParseOutput, miette::Error
 /// Use this for help text generation or when you need the raw parsed values.
 #[must_use = "parsing result should be used"]
 pub fn parse_partial(spec: &Spec, input: &[String]) -> Result<ParseOutput, miette::Error> {
-    parse_partial_with_env(spec, input, None, None, MountTiming::Eager).map(|(out, _)| out)
+    parse_partial_with_env(spec, input, None, None, MountTiming::Eager, true).map(|(out, _)| out)
 }
 
 /// Basename of argv[0] for a multicall CLI: last path component, with a trailing
@@ -1266,6 +1297,7 @@ fn parse_partial_with_env(
     custom_env: Option<&HashMap<String, String>>,
     mount_outputs: Option<&HashMap<String, String>>,
     mount_timing: MountTiming,
+    validate_clauses: bool,
 ) -> Result<(ParseOutput, HashSet<String>), miette::Error> {
     let mut trace = Trace::new(input);
     parse_partial_traced(
@@ -1274,6 +1306,7 @@ fn parse_partial_with_env(
         custom_env,
         mount_outputs,
         mount_timing,
+        validate_clauses,
         &mut trace,
     )
 }
@@ -1290,6 +1323,7 @@ fn parse_partial_traced(
     custom_env: Option<&HashMap<String, String>>,
     mount_outputs: Option<&HashMap<String, String>>,
     mount_timing: MountTiming,
+    validate_clauses: bool,
     trace: &mut Trace,
 ) -> Result<(ParseOutput, HashSet<String>), miette::Error> {
     if let Some(view) = input.first().and_then(|argv0| spec.view_for_program(argv0)) {
@@ -1300,6 +1334,7 @@ fn parse_partial_traced(
             custom_env,
             mount_outputs,
             mount_timing,
+            validate_clauses,
             trace,
         );
     }
@@ -1334,6 +1369,7 @@ fn parse_partial_traced(
         cmds: vec![spec.cmd.clone()],
         args: IndexMap::new(),
         clauses: IndexMap::new(),
+        clause_flags: IndexMap::new(),
         flags: IndexMap::new(),
         tokens: vec![],
         flag_origins: IndexMap::new(),
@@ -1654,16 +1690,35 @@ fn parse_partial_traced(
         // flags. Only an explicit `--` protects a literal separator.
         if !seen_double_dash {
             if let Some(clause) = out.cmd.clause.as_ref() {
-                if w == clause.separator {
+                if clause.separator.as_deref() == Some(w.as_str()) {
+                    while try_bind_default_missing(
+                        &mut out.flags,
+                        &mut out.flag_awaiting_value,
+                        custom_env,
+                        &mut out.flag_origins,
+                    )? {}
+                    if let Some(flag) = out.flag_awaiting_value.first() {
+                        let spelling = flag
+                            .long
+                            .first()
+                            .map(|long| format!("--{long}"))
+                            .or_else(|| flag.short.first().map(|short| format!("-{short}")))
+                            .unwrap_or_else(|| flag.name.clone());
+                        return Err(UsageErr::InvalidFlag {
+                            token: spelling.clone(),
+                            reason: "requires an argument".to_string(),
+                            span: (0, spelling.len()).into(),
+                            input: spelling,
+                        }
+                        .into());
+                    }
                     let name = clause.name.clone();
-                    out.clauses
-                        .entry(name.clone())
-                        .or_default()
-                        .push(std::mem::take(&mut out.args));
+                    finalize_current_clause(&mut out);
                     out.arg_origins.clear();
                     trace.record(argv, TokenRole::ClauseSeparator { name });
                     next_arg_idx = 0;
                     out.flag_awaiting_value.clear();
+                    reset_clause_scalar_occurrences(&out, &mut scalar_occurrences);
                     enable_flags = true;
                     seen_double_dash = false;
                     continue;
@@ -2414,6 +2469,44 @@ fn parse_partial_traced(
                     .insert(Arc::new(arg.clone()), ParseValue::String(w));
                 next_arg_idx += 1;
             }
+            if out
+                .cmd
+                .clause
+                .as_ref()
+                .is_some_and(|clause| clause.separator.is_none())
+                && next_arg_idx >= active_args(&out.cmd).len()
+            {
+                while try_bind_default_missing(
+                    &mut out.flags,
+                    &mut out.flag_awaiting_value,
+                    custom_env,
+                    &mut out.flag_origins,
+                )? {}
+                if let Some(flag) = out.flag_awaiting_value.first() {
+                    let spelling = flag
+                        .long
+                        .first()
+                        .map(|long| format!("--{long}"))
+                        .or_else(|| flag.short.first().map(|short| format!("-{short}")))
+                        .unwrap_or_else(|| flag.name.clone());
+                    return Err(UsageErr::InvalidFlag {
+                        token: spelling.clone(),
+                        reason: "requires an argument".to_string(),
+                        span: (0, spelling.len()).into(),
+                        input: spelling,
+                    }
+                    .into());
+                }
+                let name = out.cmd.clause.as_ref().unwrap().name.clone();
+                finalize_current_clause(&mut out);
+                out.arg_origins.clear();
+                trace.record(argv, TokenRole::ClauseSeparator { name });
+                next_arg_idx = 0;
+                out.flag_awaiting_value.clear();
+                reset_clause_scalar_occurrences(&out, &mut scalar_occurrences);
+                enable_flags = true;
+                seen_double_dash = false;
+            }
             continue;
         }
         if is_help_arg(spec, &out.cmd, &w) {
@@ -2450,7 +2543,16 @@ fn parse_partial_traced(
     }
 
     record_stop(&mut out, next_arg_idx, seen_double_dash, trace, &input);
-    validate_clause_relationships(&mut out, &overridden_flags, custom_env);
+    if validate_clauses {
+        validate_clause_relationships(&mut out, &overridden_flags, custom_env, None);
+    }
+    let clause_flag_names = out
+        .cmd
+        .clause
+        .iter()
+        .flat_map(|clause| &clause.flags)
+        .map(|flag| flag.name.clone())
+        .collect::<HashSet<_>>();
 
     // `out.flags` is keyed by `SpecFlag`, whose equality is intentionally name-only. Two
     // declarations with the same canonical name therefore share one public value entry even
@@ -2531,8 +2633,9 @@ fn parse_partial_traced(
     // command that otherwise needs an input. Companions are still diagnosed below, but an
     // exclusive occurrence suppresses the missing-value checks that would make it unusable
     // whether it was alone or not.
-    let exclusive_present =
-        unique_flags(out.available_flags.values().chain(out.flags.keys())).any(|flag| {
+    let exclusive_present = unique_flags(out.available_flags.values().chain(out.flags.keys()))
+        .filter(|flag| !clause_flag_names.contains(&flag.name))
+        .any(|flag| {
             exclusive_occurrence(flag)
                 && !overridden_flags.contains(&flag.name)
                 && (flag_was_parsed(flag) || flag_has_env(flag, custom_env))
@@ -2646,7 +2749,9 @@ fn parse_partial_traced(
     // has a value, not how it got one. That is what clap does, and an asymmetric rule
     // would make the same pair of flags a conflict or not depending on which one
     // happened to be typed.
-    for flag in unique_flags(out.available_flags.values()) {
+    for flag in unique_flags(out.available_flags.values())
+        .filter(|flag| !clause_flag_names.contains(&flag.name))
+    {
         let given = out.flags.contains_key(flag) || flag_has_env(flag, custom_env);
         if !given || overridden_flags.contains(&flag.name) {
             continue;
@@ -2749,7 +2854,9 @@ fn parse_partial_traced(
     // exclusive one is nobody saying anything, and counting it would make the exclusive
     // flag unusable on any command that has a default. Environment values do count, also as
     // `conflicts` reads them, so the spec parser and the derive agree.
-    for flag in unique_flags(out.available_flags.values().chain(out.flags.keys())) {
+    for flag in unique_flags(out.available_flags.values().chain(out.flags.keys()))
+        .filter(|flag| !clause_flag_names.contains(&flag.name))
+    {
         // `SpecFlag` equality is intentionally name-only for the public parsed-value map,
         // but re-declared aliases can leave distinct declarations with that same name in
         // scope. Exclusivity is about the declaration the typed spelling resolved to, so
@@ -2759,6 +2866,7 @@ fn parse_partial_traced(
             continue;
         }
         let other_flag = unique_flags(out.available_flags.values().chain(out.flags.keys()))
+            .filter(|other| !clause_flag_names.contains(&other.name))
             .find(|other| {
                 !Arc::ptr_eq(other, flag)
                     && !overridden_flags.contains(&other.name)
@@ -2860,7 +2968,9 @@ fn parse_partial_traced(
     out.errors.extend(group_errors);
 
     if !exclusive_present {
-        for flag in unique_flags(out.available_flags.values()) {
+        for flag in unique_flags(out.available_flags.values())
+            .filter(|flag| !clause_flag_names.contains(&flag.name))
+        {
             let owner = out
                 .cmds
                 .iter()
@@ -2949,7 +3059,9 @@ fn parse_partial_traced(
     // Validate var_min/var_max constraints for variadic flags. These are bounds on
     // repeated occurrences of the flag itself. Bounds on its nested argument are enforced
     // by binding once per occurrence, where the per-occurrence count is still available.
-    for flag in unique_flags(out.available_flags.values()) {
+    for flag in unique_flags(out.available_flags.values())
+        .filter(|flag| !clause_flag_names.contains(&flag.name))
+    {
         if flag.var {
             let bound = match out.flags.get(flag) {
                 Some(ParseValue::MultiString(values)) => values.len(),
@@ -3192,17 +3304,34 @@ fn bind_flag_fallback(
     custom_env: Option<&HashMap<String, String>>,
     origin: ValueOrigin,
 ) -> Result<(), miette::Error> {
-    if values.is_empty() {
+    let Some(value) = flag_fallback_value(flag, values, &mut out.errors, custom_env)? else {
         return Ok(());
+    };
+    out.flags.insert(Arc::clone(flag), value);
+    out.flag_origins
+        .entry(Arc::clone(flag))
+        .or_default()
+        .push(origin);
+    Ok(())
+}
+
+fn flag_fallback_value(
+    flag: &SpecFlag,
+    values: &[String],
+    errors: &mut Vec<UsageErr>,
+    custom_env: Option<&HashMap<String, String>>,
+) -> Result<Option<ParseValue>, miette::Error> {
+    if values.is_empty() {
+        return Ok(None);
     }
     if let Some(arg) = flag.arg.as_ref() {
         let values = split_fallback_values(values, arg.delimiter);
         if flag.var || arg.var {
             if flag.var {
-                validate_flag_fallback_count(flag, values.len(), &mut out.errors);
+                validate_flag_fallback_count(flag, values.len(), errors);
             }
             if arg.var {
-                validate_flag_arg_fallback_count(flag, arg, values.len(), &mut out.errors);
+                validate_flag_arg_fallback_count(flag, arg, values.len(), errors);
             }
             validate_choice_values(
                 ChoiceTarget::option(flag),
@@ -3210,8 +3339,7 @@ fn bind_flag_fallback(
                 arg.choices.as_ref(),
                 custom_env,
             )?;
-            out.flags
-                .insert(Arc::clone(flag), ParseValue::MultiString(values));
+            Ok(Some(ParseValue::MultiString(values)))
         } else {
             let value = values.into_iter().next().unwrap_or_default();
             validate_choice_value(
@@ -3220,25 +3348,183 @@ fn bind_flag_fallback(
                 arg.choices.as_ref(),
                 custom_env,
             )?;
-            out.flags
-                .insert(Arc::clone(flag), ParseValue::String(value));
+            Ok(Some(ParseValue::String(value)))
         }
     } else if flag.var {
-        validate_flag_fallback_count(flag, values.len(), &mut out.errors);
+        validate_flag_fallback_count(flag, values.len(), errors);
         let bools: Vec<bool> = values.iter().map(|s| fallback_is_true(s)).collect();
-        out.flags
-            .insert(Arc::clone(flag), ParseValue::MultiBool(bools));
+        Ok(Some(ParseValue::MultiBool(bools)))
     } else {
-        out.flags.insert(
-            Arc::clone(flag),
-            ParseValue::Bool(fallback_is_true(&values[0])),
-        );
+        Ok(Some(ParseValue::Bool(fallback_is_true(&values[0]))))
     }
-    out.flag_origins
-        .entry(Arc::clone(flag))
-        .or_default()
-        .push(origin);
-    Ok(())
+}
+
+/// Fill scoped flags inside the clause instances argv created.
+///
+/// The returned sets contain argv and environment sources only. Relationship
+/// validation uses them to keep defaults from becoming explicit conflicts while
+/// still allowing a fallback value to satisfy a required scoped flag.
+fn apply_clause_flag_fallbacks(
+    out: &mut ParseOutput,
+    overridden_flags: &HashSet<String>,
+    custom_env: Option<&HashMap<String, String>>,
+) -> Result<Option<Vec<HashSet<String>>>, miette::Error> {
+    let Some(clause) = out.cmd.clause.clone() else {
+        return Ok(None);
+    };
+    let Some(positional_instances) = out.clauses.get(&clause.name) else {
+        return Ok(None);
+    };
+    let positional_instances = positional_instances.clone();
+    let mut flag_instances = out
+        .clause_flags
+        .shift_remove(&clause.name)
+        .unwrap_or_default();
+    flag_instances.resize_with(positional_instances.len(), IndexMap::new);
+    let get_env = |key: &str| -> Option<String> {
+        custom_env
+            .and_then(|values| values.get(key).cloned())
+            .or_else(|| {
+                custom_env
+                    .is_none()
+                    .then(|| std::env::var(key).ok())
+                    .flatten()
+            })
+    };
+    let mut explicit_instances = Vec::with_capacity(flag_instances.len());
+
+    for (instance_index, scoped) in flag_instances.iter_mut().enumerate() {
+        let positional = &positional_instances[instance_index];
+        let mut explicit = scoped
+            .keys()
+            .map(|flag| flag.name.clone())
+            .collect::<HashSet<_>>();
+
+        // Environment first so every default_if sees all explicit sources,
+        // independent of declaration order.
+        for declared in &clause.flags {
+            let flag = Arc::new(declared.clone());
+            if scoped.contains_key(&flag) {
+                continue;
+            }
+            let Some((env_name, env_value)) = first_set_env(declared.env_names(), &get_env) else {
+                continue;
+            };
+            if let Some(warning) = flag_deprecation(declared) {
+                out.warnings.push(warning);
+            }
+            if flag_env_is_deprecated(declared, env_name) {
+                out.warnings
+                    .push(Warning::env(env_name, flag_current_env(declared)));
+            }
+            if let Some(value) = flag_fallback_value(
+                declared,
+                std::slice::from_ref(&env_value),
+                &mut out.errors,
+                custom_env,
+            )? {
+                scoped.insert(flag, value);
+                explicit.insert(declared.name.clone());
+            }
+        }
+
+        let condition_matches =
+            |condition: &crate::SpecDefaultIf| {
+                if let Some(flag) = clause
+                    .flags
+                    .iter()
+                    .find(|flag| flag_matches_selector(flag, &condition.selector))
+                {
+                    if !explicit.contains(&flag.name) {
+                        return false;
+                    }
+                    return condition.when.as_ref().is_none_or(|expected| {
+                        scoped
+                            .iter()
+                            .find(|(present, _)| present.name == flag.name)
+                            .is_some_and(|(_, value)| parse_value_has(value, expected))
+                    });
+                }
+                if let Some(arg) = clause.args.iter().find(|arg| {
+                    !condition.selector.starts_with('-') && arg.name == condition.selector
+                }) {
+                    return positional.get(arg).is_some_and(|value| {
+                        condition
+                            .when
+                            .as_ref()
+                            .is_none_or(|expected| parse_value_has(value, expected))
+                    });
+                }
+                let command_flag = out
+                    .available_flags
+                    .values()
+                    .chain(out.flags.keys())
+                    .filter(|flag| !is_clause_scoped_flag(out, flag))
+                    .find(|flag| flag_matches_selector(flag, &condition.selector));
+                command_flag.is_some_and(|flag| {
+                    !overridden_flags.contains(&flag.name)
+                        && command_flag_has_explicit_source(flag, out)
+                        && condition.when.as_ref().is_none_or(|expected| {
+                            out.flags
+                                .get(flag)
+                                .is_some_and(|value| parse_value_has(value, expected))
+                        })
+                })
+            };
+
+        let conditional = clause
+            .flags
+            .iter()
+            .filter(|flag| !scoped.keys().any(|present| present.name == flag.name))
+            .filter_map(|flag| {
+                flag.default_if
+                    .iter()
+                    .find(|condition| condition_matches(condition))
+                    .map(|condition| (flag.clone(), condition.value.clone()))
+            })
+            .collect::<Vec<_>>();
+        for (declared, value) in conditional {
+            if let Some(value) = flag_fallback_value(
+                &declared,
+                std::slice::from_ref(&value),
+                &mut out.errors,
+                custom_env,
+            )? {
+                scoped.insert(Arc::new(declared), value);
+            }
+        }
+
+        for declared in &clause.flags {
+            let flag = Arc::new(declared.clone());
+            if scoped.contains_key(&flag) {
+                continue;
+            }
+            let values = if !declared.default.is_empty() {
+                &declared.default
+            } else if let Some(arg) = declared.arg.as_ref().filter(|arg| !arg.default.is_empty()) {
+                &arg.default
+            } else {
+                continue;
+            };
+            if let Some(value) = flag_fallback_value(declared, values, &mut out.errors, custom_env)?
+            {
+                scoped.insert(flag, value);
+            }
+        }
+        explicit_instances.push(explicit);
+    }
+
+    out.clause_flags.insert(clause.name, flag_instances);
+    Ok(Some(explicit_instances))
+}
+
+fn command_flag_has_explicit_source(flag: &SpecFlag, out: &ParseOutput) -> bool {
+    out.flags.contains_key(flag)
+        && out.flag_origins.get(flag).is_none_or(|origins| {
+            origins
+                .iter()
+                .any(|origin| matches!(origin, ValueOrigin::DefaultMissing | ValueOrigin::Env(_)))
+        })
 }
 
 fn default_if_condition_matches(
@@ -3311,10 +3597,48 @@ fn parse_value_has(value: &ParseValue, expected: &str) -> bool {
     }
 }
 
+/// Clause flags share the command's spelling table so they can be recognized while parsing,
+/// but their values and validation belong to one clause instance rather than the command.
+fn is_clause_scoped_flag(out: &ParseOutput, flag: &SpecFlag) -> bool {
+    out.cmd
+        .clause
+        .as_ref()
+        .is_some_and(|clause| clause.flags.iter().any(|scoped| scoped.name == flag.name))
+}
+
+fn selected_clause_flag<'a>(out: &'a ParseOutput, selector: &str) -> Option<&'a SpecFlag> {
+    out.cmd
+        .clause
+        .as_ref()?
+        .flags
+        .iter()
+        .find(|flag| flag_matches_selector(flag, selector))
+}
+
+fn clause_flag_is_explicit(out: &ParseOutput, flag: &SpecFlag) -> bool {
+    out.clause_flags
+        .values()
+        .flatten()
+        .any(|instance| instance.keys().any(|present| present.name == flag.name))
+        || out.flags.keys().any(|present| present.name == flag.name)
+}
+
+fn clause_flag_has_value(out: &ParseOutput, flag: &SpecFlag, expected: &str) -> bool {
+    out.clause_flags.values().flatten().any(|instance| {
+        instance
+            .iter()
+            .any(|(present, value)| present.name == flag.name && parse_value_has(value, expected))
+    }) || out
+        .flags
+        .iter()
+        .any(|(present, value)| present.name == flag.name && parse_value_has(value, expected))
+}
+
 fn validate_clause_relationships(
     out: &mut ParseOutput,
     overridden_flags: &HashSet<String>,
     custom_env: Option<&HashMap<String, String>>,
+    explicit_instances: Option<&[HashSet<String>]>,
 ) {
     let Some(clause) = out.cmd.clause.as_ref() else {
         return;
@@ -3322,52 +3646,196 @@ fn validate_clause_relationships(
     let Some(instances) = out.clauses.get(&clause.name) else {
         return;
     };
-    let flag_is_explicit = |selector: &str| {
+    let command_flag_is_explicit = |selector: &str| {
         out.available_flags
             .values()
             .chain(out.flags.keys())
+            .filter(|flag| !is_clause_scoped_flag(out, flag))
             .any(|flag| {
                 flag_matches_selector(flag, selector)
                     && !overridden_flags.contains(&flag.name)
                     && (out.flags.contains_key(flag) || flag_has_env(flag, custom_env))
             })
     };
-    let flag_matches_value = |selector: &str, expected: &str| {
+    let command_flag_matches_value = |selector: &str, expected: &str| {
         out.available_flags
             .values()
             .chain(out.flags.keys())
+            .filter(|flag| !is_clause_scoped_flag(out, flag))
             .find(|flag| flag_matches_selector(flag, selector))
             .is_some_and(|flag| {
                 !overridden_flags.contains(&flag.name)
                     && explicit_flag_has_value(flag, expected, out, custom_env)
             })
     };
-    let flag_is_satisfied = |selector: &str| {
+    let command_flag_is_satisfied = |selector: &str| {
         out.available_flags
             .values()
             .chain(out.flags.keys())
+            .filter(|flag| !is_clause_scoped_flag(out, flag))
             .any(|flag| flag_matches_selector(flag, selector))
             && selector_is_satisfied(selector, out, overridden_flags, custom_env)
     };
     let mut errors = Vec::new();
     for (instance_index, instance) in instances.iter().enumerate() {
+        let explicit = explicit_instances.and_then(|instances| instances.get(instance_index));
+        let scoped = out
+            .clause_flags
+            .get(&clause.name)
+            .and_then(|instances| instances.get(instance_index));
+        let scoped_flag = |selector: &str| {
+            clause
+                .flags
+                .iter()
+                .find(|flag| flag_matches_selector(flag, selector))
+        };
+        let scoped_value = |flag: &SpecFlag| {
+            scoped.and_then(|values| {
+                values
+                    .iter()
+                    .find(|(present, _)| present.name == flag.name)
+                    .map(|(_, value)| value)
+            })
+        };
         let arg_is_explicit = |selector: &str| {
             instance
                 .keys()
                 .any(|arg| !selector.starts_with('-') && arg.name == selector)
         };
-        let selector_is_explicit =
-            |selector: &str| flag_is_explicit(selector) || arg_is_explicit(selector);
+        let selector_is_explicit = |selector: &str| {
+            scoped_flag(selector).is_some_and(|flag| {
+                explicit
+                    .map(|given| given.contains(&flag.name))
+                    .unwrap_or_else(|| scoped_value(flag).is_some())
+            }) || command_flag_is_explicit(selector)
+                || arg_is_explicit(selector)
+        };
         let selector_has_value = |selector: &str, expected: &str| {
-            flag_matches_value(selector, expected)
+            scoped_flag(selector)
+                .filter(|flag| {
+                    explicit
+                        .map(|given| given.contains(&flag.name))
+                        .unwrap_or_else(|| scoped_value(flag).is_some())
+                })
+                .and_then(scoped_value)
+                .is_some_and(|value| parse_value_has(value, expected))
+                || command_flag_matches_value(selector, expected)
                 || instance.iter().any(|(arg, value)| {
                     !selector.starts_with('-')
                         && arg.name == selector
                         && parse_value_has(value, expected)
                 })
         };
-        let selector_is_satisfied =
-            |selector: &str| selector_is_explicit(selector) || flag_is_satisfied(selector);
+        let selector_is_satisfied = |selector: &str| {
+            scoped_flag(selector).is_some_and(|flag| scoped_value(flag).is_some())
+                || command_flag_is_satisfied(selector)
+                || arg_is_explicit(selector)
+        };
+        let selector_name = |selector: &str| {
+            scoped_flag(selector)
+                .map(|flag| flag.name.clone())
+                .or_else(|| selector_flag_name(selector, out))
+                .unwrap_or_else(|| selector.to_string())
+        };
+
+        for flag in &clause.flags {
+            let value = scoped_value(flag);
+            if value.is_none() {
+                let required_if = flag
+                    .required_if
+                    .iter()
+                    .any(|selector| selector_is_explicit(selector));
+                let required_if_eq = flag
+                    .required_if_eq
+                    .iter()
+                    .any(|condition| selector_has_value(&condition.selector, &condition.value));
+                let required_if_eq_all = !flag.required_if_eq_all.is_empty()
+                    && flag
+                        .required_if_eq_all
+                        .iter()
+                        .all(|condition| selector_has_value(&condition.selector, &condition.value));
+                let unless_any = flag
+                    .required_unless
+                    .iter()
+                    .any(|selector| selector_is_explicit(selector));
+                let unless_all = !flag.required_unless_all.is_empty()
+                    && flag
+                        .required_unless_all
+                        .iter()
+                        .all(|selector| selector_is_explicit(selector));
+                let required_unless = !(unless_any
+                    || unless_all
+                    || (flag.required_unless.is_empty() && flag.required_unless_all.is_empty()));
+                if flag.required
+                    || required_if
+                    || required_if_eq
+                    || required_if_eq_all
+                    || required_unless
+                {
+                    errors.push(UsageErr::MissingFlag(flag.name.clone()));
+                }
+                continue;
+            }
+
+            let explicitly_provided = explicit
+                .map(|given| given.contains(&flag.name))
+                .unwrap_or(true);
+
+            if explicitly_provided {
+                for other in &flag.conflicts {
+                    if selector_is_explicit(other) {
+                        errors.push(UsageErr::InvalidFlag {
+                            token: format!("--{}", flag.name),
+                            reason: format!("conflicts with {other}"),
+                            span: (0, 0).into(),
+                            input: format!("--{} {other}", flag.name),
+                        });
+                    }
+                }
+                for other in &flag.requires {
+                    if !selector_is_satisfied(other) {
+                        errors.push(UsageErr::MissingFlag(selector_name(other)));
+                    }
+                }
+                for condition in &flag.requires_if {
+                    if value.is_some_and(|value| parse_value_has(value, &condition.value))
+                        && !selector_is_satisfied(&condition.requires)
+                    {
+                        errors.push(UsageErr::MissingFlag(selector_name(&condition.requires)));
+                    }
+                }
+            }
+            if let (true, Some(value)) = (flag.var, value) {
+                let count = match value {
+                    ParseValue::MultiString(values) => values.len(),
+                    ParseValue::MultiBool(values) => values.len(),
+                    _ => 1,
+                };
+                if let Some(min) = flag.var_min.filter(|min| count < *min) {
+                    errors.push(UsageErr::VarFlagTooFew {
+                        name: flag.name.clone(),
+                        min,
+                        got: count,
+                    });
+                }
+                if let Some(max) = flag.var_max.filter(|max| count > *max) {
+                    errors.push(UsageErr::VarFlagTooMany {
+                        name: flag.name.clone(),
+                        max,
+                        got: count,
+                    });
+                }
+            }
+            if let (Some(arg), Some(value)) = (&flag.arg, value) {
+                validate_expression(
+                    &flag.name,
+                    arg.validate.as_deref(),
+                    arg.validate_error.as_deref(),
+                    value,
+                    &mut errors,
+                );
+            }
+        }
         for arg in &clause.args {
             let given = instance.keys().any(|present| present.name == arg.name);
             if !given {
@@ -3420,8 +3888,7 @@ fn validate_clause_relationships(
                     continue;
                 }
                 if other.starts_with('-') {
-                    let name = selector_flag_name(other, out).unwrap_or_else(|| other.clone());
-                    errors.push(UsageErr::MissingFlag(name));
+                    errors.push(UsageErr::MissingFlag(selector_name(other)));
                 } else {
                     errors.push(UsageErr::MissingClauseArg {
                         clause: clause.name.clone(),
@@ -3442,10 +3909,14 @@ fn selector_explicit_has_value(
     overridden_flags: &HashSet<String>,
     custom_env: Option<&HashMap<String, String>>,
 ) -> bool {
+    if let Some(flag) = selected_clause_flag(out, selector) {
+        return clause_flag_has_value(out, flag, expected);
+    }
     if let Some(flag) = out
         .available_flags
         .values()
         .chain(out.flags.keys())
+        .filter(|flag| !is_clause_scoped_flag(out, flag))
         .find(|flag| flag_matches_selector(flag, selector))
     {
         return !overridden_flags.contains(&flag.name)
@@ -3493,16 +3964,20 @@ fn selector_is_explicit(
     overridden_flags: &HashSet<String>,
     custom_env: Option<&HashMap<String, String>>,
 ) -> bool {
+    let scoped_flag_is_explicit =
+        selected_clause_flag(out, selector).is_some_and(|flag| clause_flag_is_explicit(out, flag));
     let flag_is_explicit = out
         .available_flags
         .values()
         .chain(out.flags.keys())
+        .filter(|flag| !is_clause_scoped_flag(out, flag))
         .any(|flag| {
             flag_matches_selector(flag, selector)
                 && !overridden_flags.contains(&flag.name)
                 && (out.flags.contains_key(flag) || flag_has_env(flag, custom_env))
         });
-    flag_is_explicit
+    scoped_flag_is_explicit
+        || flag_is_explicit
         || selector_arg(selector, out).is_some_and(|arg| arg_is_explicit(arg, out, custom_env))
 }
 
@@ -3512,9 +3987,13 @@ fn selector_is_explicit(
 /// about a flag that is *missing* has to say which one, and the selector may be a short
 /// form or an alias rather than the name.
 fn selector_flag_name(selector: &str, out: &ParseOutput) -> Option<String> {
+    if let Some(flag) = selected_clause_flag(out, selector) {
+        return Some(flag.name.clone());
+    }
     out.available_flags
         .values()
         .chain(out.flags.keys())
+        .filter(|flag| !is_clause_scoped_flag(out, flag))
         .find(|flag| flag_matches_selector(flag, selector))
         .map(|flag| flag.name.clone())
         .or_else(|| selector_arg(selector, out).map(|arg| arg.name.clone()))
@@ -3542,6 +4021,7 @@ fn selector_is_satisfied(
         .available_flags
         .values()
         .chain(out.flags.keys())
+        .filter(|flag| !is_clause_scoped_flag(out, flag))
         .filter(|flag| flag_matches_selector(flag, selector))
         .any(|flag| {
             !overridden_flags.contains(&flag.name)
@@ -3834,9 +4314,13 @@ fn record_scalar_flag_occurrence(
     occurrences: &mut HashMap<(usize, usize), u8>,
     errors: &mut Vec<UsageErr>,
 ) {
-    let strict = cmds
-        .get(command_level)
-        .is_some_and(|cmd| !cmd.args_override_self);
+    let strict = cmds.get(command_level).is_some_and(|cmd| {
+        !cmd.args_override_self
+            || cmd
+                .clause
+                .as_ref()
+                .is_some_and(|clause| clause.flags.iter().any(|candidate| candidate == &**flag))
+    });
     let collects_values = flag.var || flag.arg.as_ref().is_some_and(|arg| arg.var);
     if !strict || flag.count || collects_values {
         return;
@@ -4389,10 +4873,28 @@ fn finalize_current_clause(out: &mut ParseOutput) {
     let Some(clause) = out.cmd.clause.as_ref() else {
         return;
     };
+    let has_scoped_flags = clause
+        .flags
+        .iter()
+        .any(|flag| out.flags.contains_key(&Arc::new(flag.clone())));
+    if clause.separator.is_none() && out.args.is_empty() && !has_scoped_flags {
+        return;
+    }
     out.clauses
         .entry(clause.name.clone())
         .or_default()
         .push(std::mem::take(&mut out.args));
+    let mut flags = IndexMap::new();
+    for clause_flag in &clause.flags {
+        let key = Arc::new(clause_flag.clone());
+        if let Some((flag, value)) = out.flags.shift_remove_entry(&key) {
+            flags.insert(flag, value);
+        }
+    }
+    out.clause_flags
+        .entry(clause.name.clone())
+        .or_default()
+        .push(flags);
 }
 
 fn restore_current_clause(out: &mut ParseOutput) {
@@ -4402,6 +4904,28 @@ fn restore_current_clause(out: &mut ParseOutput) {
     if let Some(current) = out.clauses.get_mut(&clause.name).and_then(Vec::pop) {
         out.args = current;
     }
+    if let Some(current) = out.clause_flags.get_mut(&clause.name).and_then(Vec::pop) {
+        out.flags.extend(current);
+    }
+}
+
+fn reset_clause_scalar_occurrences(
+    out: &ParseOutput,
+    occurrences: &mut HashMap<(usize, usize), u8>,
+) {
+    let Some(clause) = out.cmd.clause.as_ref() else {
+        return;
+    };
+    let names = clause
+        .flags
+        .iter()
+        .map(|flag| flag.name.as_str())
+        .collect::<HashSet<_>>();
+    let pointers = unique_flags(out.available_flags.values())
+        .filter(|flag| names.contains(flag.name.as_str()))
+        .map(|flag| Arc::as_ptr(flag) as usize)
+        .collect::<HashSet<_>>();
+    occurrences.retain(|(flag, _), _| !pointers.contains(flag));
 }
 
 fn cursor_skip_sigils(cmd: &SpecCommand, mut idx: usize) -> usize {

--- a/lib/src/spec/clause.rs
+++ b/lib/src/spec/clause.rs
@@ -2,15 +2,17 @@ use crate::error::Result;
 use crate::kdl::{KdlDocument, KdlEntry, KdlNode};
 use crate::spec::context::ParsingContext;
 use crate::spec::helpers::{string_entry, NodeHelper};
-use crate::SpecArg;
+use crate::{SpecArg, SpecFlag};
 use serde::Serialize;
+use std::collections::HashSet;
 
-/// A repeatable, separator-delimited group of positional arguments.
+/// A repeatable group of scoped flags and positional arguments.
 #[derive(Debug, Default, Clone, Serialize)]
 #[non_exhaustive]
 pub struct SpecClause {
     pub name: String,
-    pub separator: String,
+    pub separator: Option<String>,
+    pub flags: Vec<SpecFlag>,
     pub args: Vec<SpecArg>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub help: Option<String>,
@@ -20,6 +22,31 @@ pub struct SpecClause {
 }
 
 impl SpecClause {
+    pub(crate) fn conflicting_flag_spelling(&self, command_flags: &[SpecFlag]) -> Option<String> {
+        fn spellings(flag: &SpecFlag) -> impl Iterator<Item = String> + '_ {
+            flag.long
+                .iter()
+                .chain(&flag.hidden_aliases)
+                .map(|name| format!("--{name}"))
+                .chain(
+                    flag.short
+                        .iter()
+                        .chain(&flag.hidden_short_aliases)
+                        .map(|name| format!("-{name}")),
+                )
+                .chain(flag.negate.iter().cloned())
+        }
+
+        let mut seen = command_flags
+            .iter()
+            .flat_map(spellings)
+            .collect::<HashSet<_>>();
+        self.flags
+            .iter()
+            .flat_map(spellings)
+            .find(|spelling| !seen.insert(spelling.clone()))
+    }
+
     pub(crate) fn parse(ctx: &ParsingContext, node: &NodeHelper) -> Result<Self> {
         let mut clause = Self {
             name: node.arg(0)?.ensure_string()?,
@@ -27,7 +54,7 @@ impl SpecClause {
         };
         for (key, value) in node.props() {
             match key {
-                "separator" => clause.separator = value.ensure_string()?,
+                "separator" => clause.separator = Some(value.ensure_string()?),
                 "help" => clause.help = Some(value.ensure_string()?),
                 "help_long" | "long_help" => clause.help_long = Some(value.ensure_string()?),
                 key => bail_parse!(ctx, value.entry.span(), "unsupported clause key {key}"),
@@ -36,6 +63,7 @@ impl SpecClause {
         for child in node.children() {
             match child.name() {
                 "arg" => clause.args.push(SpecArg::parse(ctx, &child)?),
+                "flag" => clause.flags.push(SpecFlag::parse(ctx, &child)?),
                 key => bail_parse!(
                     ctx,
                     child.node.name().span(),
@@ -46,15 +74,14 @@ impl SpecClause {
         if clause.name.is_empty() {
             bail_parse!(ctx, node.span(), "a clause needs a name");
         }
-        if clause.separator.is_empty() {
-            bail_parse!(
-                ctx,
-                node.span(),
-                "clause {} needs a non-empty separator",
-                clause.name
-            );
+        if clause.separator.as_ref().is_some_and(String::is_empty) {
+            bail_parse!(ctx, node.span(), "clause separator cannot be empty");
         }
-        if clause.separator.starts_with('-') {
+        if clause
+            .separator
+            .as_ref()
+            .is_some_and(|separator| separator.starts_with('-'))
+        {
             bail_parse!(ctx, node.span(), "clause separator cannot start with `-`");
         }
         if clause.args.is_empty() {
@@ -63,6 +90,15 @@ impl SpecClause {
                 node.span(),
                 "clause {} needs at least one argument",
                 clause.name
+            );
+        }
+        if clause.separator.is_none()
+            && (clause.args.len() != 1 || !clause.args[0].required || clause.args[0].var)
+        {
+            bail_parse!(
+                ctx,
+                node.span(),
+                "an implicit clause needs exactly one required, non-variadic positional argument"
             );
         }
         clause.usage = clause.usage();
@@ -76,7 +112,10 @@ impl SpecClause {
             .map(SpecArg::usage)
             .collect::<Vec<_>>()
             .join(" ");
-        format!("{inner} [{} {inner}]…", self.separator)
+        match &self.separator {
+            Some(separator) => format!("{inner} [{separator} {inner}]…"),
+            None => format!("{inner}…"),
+        }
     }
 }
 
@@ -84,7 +123,9 @@ impl From<&SpecClause> for KdlNode {
     fn from(clause: &SpecClause) -> Self {
         let mut node = KdlNode::new("clause");
         node.push(KdlEntry::new(clause.name.clone()));
-        node.push(string_entry(Some("separator"), &clause.separator));
+        if let Some(separator) = &clause.separator {
+            node.push(string_entry(Some("separator"), separator));
+        }
         if let Some(help) = &clause.help {
             node.push(string_entry(Some("help"), help));
         }
@@ -92,6 +133,9 @@ impl From<&SpecClause> for KdlNode {
             node.push(string_entry(Some("help_long"), help));
         }
         let children = node.children_mut().get_or_insert_with(KdlDocument::new);
+        children
+            .nodes_mut()
+            .extend(clause.flags.iter().map(Into::into));
         children
             .nodes_mut()
             .extend(clause.args.iter().map(Into::into));

--- a/lib/src/spec/cmd.rs
+++ b/lib/src/spec/cmd.rs
@@ -758,6 +758,13 @@ impl SpecCommand {
                     "sigil arguments are not supported inside clauses"
                 );
             }
+            if let Some(spelling) = clause.conflicting_flag_spelling(&cmd.flags) {
+                bail_parse!(
+                    ctx,
+                    node.span(),
+                    "clause flag spelling {spelling:?} conflicts with another flag on this command"
+                );
+            }
         }
         Ok(cmd)
     }
@@ -782,6 +789,24 @@ impl SpecCommand {
         }
 
         validate(self, &[])
+    }
+
+    pub(crate) fn validate_clause_flag_spellings(&self) -> Result<(), String> {
+        fn validate(cmd: &SpecCommand) -> Result<(), String> {
+            if let Some(clause) = &cmd.clause {
+                if let Some(spelling) = clause.conflicting_flag_spelling(&cmd.flags) {
+                    return Err(format!(
+                        "clause flag spelling {spelling:?} conflicts with another flag on this command"
+                    ));
+                }
+            }
+            for subcommand in cmd.subcommands.values() {
+                validate(subcommand)?;
+            }
+            Ok(())
+        }
+
+        validate(self)
     }
     pub(crate) fn is_empty(&self) -> bool {
         self.args.is_empty()
@@ -1161,7 +1186,8 @@ impl SpecCommand {
             self.flags_from_mount |= !spec.cmd.flags.is_empty();
             self.merge(spec.cmd);
         }
-        Ok(())
+        self.validate_clause_flag_spellings()
+            .map_err(UsageErr::InvalidSpec)
     }
 
     /// Mark this command and all of its subcommands as coming from a mount.

--- a/lib/src/spec/mod.rs
+++ b/lib/src/spec/mod.rs
@@ -208,7 +208,10 @@ impl Spec {
         let default_outranks_root_mounts = apply_default_subcommand
             && self.default_subcommand.is_some()
             && !self.cmd.mounts.iter().any(|mount| mount.overrides_default);
-        resolve(&mut self.cmd, outputs, default_outranks_root_mounts)
+        resolve(&mut self.cmd, outputs, default_outranks_root_mounts)?;
+        self.cmd
+            .validate_clause_flag_spellings()
+            .map_err(UsageErr::InvalidSpec)
     }
 
     /// Parse a spec from a file.
@@ -802,10 +805,21 @@ impl Spec {
                     "sigil arguments are not supported inside clauses"
                 );
             }
+            if let Some(spelling) = clause.conflicting_flag_spelling(&schema.cmd.flags) {
+                bail_parse!(
+                    ctx,
+                    kdl.span(),
+                    "clause flag spelling {spelling:?} conflicts with another flag on this command"
+                );
+            }
         }
         // Before ancestors are stamped, because expanding a flagset or narrowing a selector can
         // add a flag to a command and the usage strings are computed from the flag list.
         flagset::expand(ctx, &mut schema.cmd, &mut schema.flagsets)?;
+        schema
+            .cmd
+            .validate_clause_flag_spellings()
+            .map_err(|message| ctx.build_err(message, (0, ctx.spec.len()).into()))?;
         if resolve_outputs {
             output::resolve_selectors(&mut schema)?;
         }


### PR DESCRIPTION
## Summary
- allow typed repeated clauses to own scoped flags
- allow separator-free clauses with one required terminal positional, which implicitly ends each instance
- keep compiled Rust, portable KDL/reference parsing, help/completion, and generated Go bindings in sync
- reject ambiguous implicit layouts, conflicting flag spellings, duplicate scalar flags within an instance, and unterminated scoped flags

## Testing
- `mise run ci`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core CLI parsing, binding, and compatibility across Rust, reference parser, and Go; behavior changes for clauses and flag scoping are easy to get wrong at instance boundaries.
> 
> **Overview**
> **Clauses** are no longer separator-only positional groups: they can carry **scoped flags** per repeatable instance, and **`separator` is optional**—when omitted, finishing the single required non-variadic positional implicitly starts the next instance (with flag state reset).
> 
> The change threads through **argv parsing** (clause separators not consumed as flag values, implicit `ClauseSeparator` events), **derive/codegen** (clause inner `Args` flags merged into tables; compile-time checks for implicit layout and non-conflicting spellings), **help/completion/KDL emission**, the **reference parser** (`clause_flags`, per-instance requirements/conflicts/fallbacks), **spec diff** diagnostics, **Go codegen/parser**, and updated **clause docs**.
> 
> **Breaking API shape**: `Clause.separator` is now `Option<…>` and clauses include a `flags` slice everywhere tables/metadata are built.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f40be4ef04c5bbf31b268e3bdc04a9e37af9f10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added implicit clauses that repeat without separators.
  * Added clause-scoped flags that apply to the next clause argument and reset for each instance.
  * Added validation for invalid layouts, duplicate or trailing flags, and conflicting flag spellings.
* **Help & Documentation**
  * Updated usage and help output for both clause styles.
  * Expanded clause documentation with syntax, behavior, and examples.
* **Bug Fixes**
  * Improved parsing, completion, generated bindings, and compatibility diagnostics for optional separators and scoped flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->