### PR TITLE
fix(parse): complete implicit clause integration

### DIFF
--- a/argv/src/complete.rs
+++ b/argv/src/complete.rs
@@ -3681,6 +3681,7 @@ mod tests {
                 flags: &[],
                 help: None,
                 long_help: None,
+                canonical_selector: |_| None,
                 args: &[ArgMeta {
                     arg: &TASK_ARG,
                     choices: &["build", "check"],

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -901,10 +901,19 @@ fn usage_line_with_subcommands(
                 .join(" ");
             match clause.separator {
                 Some(separator) => {
-                    let _ = write!(out, " {inner} [{separator} {inner}]…");
+                    let _ = write!(out, " [{inner} [{separator} {inner}]…]");
                 }
                 None => {
-                    let _ = write!(out, " {inner}…");
+                    let arg = positional_args
+                        .iter()
+                        .find(|arg| !arg.hide)
+                        .expect("an implicit clause has one visible positional");
+                    let separator = if arg.arg.double_dash == DoubleDash::Required {
+                        "-- "
+                    } else {
+                        ""
+                    };
+                    let _ = write!(out, " [{separator}{}]…", arg.arg.name);
                 }
             }
         } else if args <= INLINE_LIMIT {
@@ -3970,6 +3979,7 @@ mod style_tests {
                 }],
                 help: None,
                 long_help: None,
+                canonical_selector: |_| None,
                 args: &[task_meta, args_meta],
             }),
             ..CommandMeta::EMPTY
@@ -3982,7 +3992,7 @@ mod style_tests {
 
         assert_eq!(
             usage_line(&["ex"], &meta),
-            "ex <TASK> [ARGS]… [::: <TASK> [ARGS]…]…"
+            "ex [<TASK> [ARGS]… [::: <TASK> [ARGS]…]…]"
         );
         let help = super::short_help(&spec, &["ex"], &[&meta]);
         assert!(help.contains("Arguments:"), "{help}");

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -972,6 +972,8 @@ pub struct ClauseMeta<'a> {
     pub long_help: Option<&'a str>,
     pub flags: &'a [FlagMeta<'a>],
     pub args: &'a [ArgMeta<'a>],
+    /// Translate a typed field selector into the spelling written to a portable spec.
+    pub canonical_selector: fn(&str) -> Option<&'static str>,
 }
 
 /// A run of one command's flags that arrived from a flattened `Args` type.
@@ -1921,7 +1923,13 @@ fn write_flag_layout_with(
                         .any(|flag| core::ptr::eq(flag.flag, meta.flags[i].flag))
                 });
                 if !scoped_to_clause {
-                    write_flag(out, &meta.flags[i], depth, inherited_heading)?;
+                    write_flag(
+                        out,
+                        &meta.flags[i],
+                        depth,
+                        inherited_heading,
+                        meta.clause.map(|clause| clause.canonical_selector),
+                    )?;
                 }
                 i += 1;
             }
@@ -1983,7 +1991,13 @@ fn write_body<'a>(
         }
     }
     for supplied in crate::help::supplied_entries(meta.cmd, &claimed) {
-        write_flag(out, supplied, depth, None)?;
+        write_flag(
+            out,
+            supplied,
+            depth,
+            None,
+            meta.clause.map(|clause| clause.canonical_selector),
+        )?;
     }
     for (i, arg) in meta.args.iter().enumerate() {
         debug_assert!(
@@ -2009,7 +2023,7 @@ fn write_body<'a>(
         }
         out.push_str(" {\n");
         for flag in clause.flags {
-            write_flag(out, flag, depth + 1, None)?;
+            write_flag(out, flag, depth + 1, None, Some(clause.canonical_selector))?;
         }
         for arg in clause.args {
             write_arg(out, arg, depth + 1)?;
@@ -2472,12 +2486,37 @@ fn write_completers(
     Ok(())
 }
 
+type CanonicalSelector = fn(&str) -> Option<&'static str>;
+
+fn portable_selector(selector: &str, canonical: Option<CanonicalSelector>) -> &str {
+    canonical
+        .and_then(|resolve| resolve(selector))
+        .unwrap_or(selector)
+}
+
+fn portable_selectors<'a>(
+    selectors: &'a [&'a str],
+    canonical: Option<CanonicalSelector>,
+) -> Vec<&'a str> {
+    selectors
+        .iter()
+        .map(|selector| portable_selector(selector, canonical))
+        .collect()
+}
+
 fn write_flag(
     out: &mut String,
     meta: &FlagMeta<'_>,
     depth: usize,
     inherited_heading: Option<&str>,
+    canonical: Option<CanonicalSelector>,
 ) -> core::fmt::Result {
+    let overrides = portable_selectors(meta.overrides, canonical);
+    let conflicts = portable_selectors(meta.conflicts, canonical);
+    let requires = portable_selectors(meta.requires, canonical);
+    let required_if = portable_selectors(meta.required_if, canonical);
+    let required_unless = portable_selectors(meta.required_unless, canonical);
+    let required_unless_all = portable_selectors(meta.required_unless_all, canonical);
     indent(out, depth)?;
     write!(out, "flag {}", quoted(&flag_forms(meta)))?;
 
@@ -2564,8 +2603,8 @@ fn write_flag(
     write_single_list(out, "env_fallback", meta.env_fallback)?;
     write_single_list(out, "deprecated_env", meta.deprecated_env)?;
     write_single_default(out, meta.default)?;
-    write_single_list(out, "overrides", meta.overrides)?;
-    write_single_list(out, "conflicts", meta.conflicts)?;
+    write_single_list(out, "overrides", &overrides)?;
+    write_single_list(out, "conflicts", &conflicts)?;
     if meta.exclusive {
         out.push_str(" exclusive=#true");
     }
@@ -2601,10 +2640,10 @@ fn write_flag(
             quoted(::core::str::from_utf8(missing).unwrap_or_default())
         )?;
     }
-    write_single_list(out, "requires", meta.requires)?;
-    write_single_list(out, "required_if", meta.required_if)?;
-    write_single_list(out, "required_unless", meta.required_unless)?;
-    write_single_list(out, "required_unless_all", meta.required_unless_all)?;
+    write_single_list(out, "requires", &requires)?;
+    write_single_list(out, "required_if", &required_if)?;
+    write_single_list(out, "required_unless", &required_unless)?;
+    write_single_list(out, "required_unless_all", &required_unless_all)?;
 
     let has_children = meta.long_help.is_some()
         || !meta.admonitions.is_empty()
@@ -2613,16 +2652,16 @@ fn write_flag(
         || meta.flag.takes_value
         || !meta.choices.is_empty()
         || meta.default.len() > 1
-        || meta.overrides.len() > 1
-        || meta.conflicts.len() > 1
-        || meta.requires.len() > 1
+        || overrides.len() > 1
+        || conflicts.len() > 1
+        || requires.len() > 1
         || !meta.requires_if.is_empty()
         || !meta.default_if.is_empty()
         || !meta.required_if_eq.is_empty()
         || !meta.required_if_eq_all.is_empty()
-        || meta.required_if.len() > 1
-        || meta.required_unless.len() > 1
-        || meta.required_unless_all.len() > 1
+        || required_if.len() > 1
+        || required_unless.len() > 1
+        || required_unless_all.len() > 1
         || meta.env_fallback.len() > 1
         || meta.deprecated_env.len() > 1;
     let has_children = has_children || meta.available_if.len() > 1;
@@ -2657,16 +2696,16 @@ fn write_flag(
         out.push_str(" hide=#true\n");
     }
     write_many_defaults(out, meta.default, inner)?;
-    write_many_list(out, "overrides", meta.overrides, inner)?;
-    write_many_list(out, "conflicts", meta.conflicts, inner)?;
-    write_many_list(out, "requires", meta.requires, inner)?;
+    write_many_list(out, "overrides", &overrides, inner)?;
+    write_many_list(out, "conflicts", &conflicts, inner)?;
+    write_many_list(out, "requires", &requires, inner)?;
     for condition in meta.requires_if {
         indent(out, inner)?;
         writeln!(
             out,
             "requires_if {} {}",
             quoted(condition.value),
-            quoted(condition.requires)
+            quoted(portable_selector(condition.requires, canonical))
         )?;
     }
     for condition in meta.default_if {
@@ -2675,13 +2714,13 @@ fn write_flag(
             None => writeln!(
                 out,
                 "default_if {} {}",
-                quoted(condition.selector),
+                quoted(portable_selector(condition.selector, canonical)),
                 quoted(condition.value)
             )?,
             Some(when) => writeln!(
                 out,
                 "default_if {} {} {}",
-                quoted(condition.selector),
+                quoted(portable_selector(condition.selector, canonical)),
                 quoted(when),
                 quoted(condition.value)
             )?,
@@ -2692,7 +2731,7 @@ fn write_flag(
         writeln!(
             out,
             "required_if_eq {} {}",
-            quoted(condition.selector),
+            quoted(portable_selector(condition.selector, canonical)),
             quoted(condition.value)
         )?;
     }
@@ -2703,15 +2742,15 @@ fn write_flag(
             write!(
                 out,
                 " {} {}",
-                quoted(condition.selector),
+                quoted(portable_selector(condition.selector, canonical)),
                 quoted(condition.value)
             )?;
         }
         out.push('\n');
     }
-    write_many_list(out, "required_if", meta.required_if, inner)?;
-    write_many_list(out, "required_unless", meta.required_unless, inner)?;
-    write_many_list(out, "required_unless_all", meta.required_unless_all, inner)?;
+    write_many_list(out, "required_if", &required_if, inner)?;
+    write_many_list(out, "required_unless", &required_unless, inner)?;
+    write_many_list(out, "required_unless_all", &required_unless_all, inner)?;
     write_many_list(out, "env_fallback", meta.env_fallback, inner)?;
     write_many_list(out, "deprecated_env", meta.deprecated_env, inner)?;
     write_many_list(out, "available_if", meta.available_if, inner)?;
@@ -3830,6 +3869,12 @@ pub trait CommandArgs: Sized {
     /// This is the value-aware half needed by conditional defaults and requirements.
     fn argument_matches(partial: &Self::Partial, selector: &str, value: &[u8]) -> Option<bool> {
         let _ = (partial, selector, value);
+        None
+    }
+
+    /// The portable spelling for a selector accepted by this typed command.
+    fn canonical_selector(selector: &str) -> Option<&'static str> {
+        let _ = selector;
         None
     }
 

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -2007,7 +2007,7 @@ fn write_body<'a>(
                 .is_some_and(|a| core::ptr::eq(*a, arg.arg)),
             "argument metadata is out of step with the parse table"
         );
-        write_arg(out, arg, depth)?;
+        write_arg(out, arg, depth, None)?;
     }
     if let Some(clause) = meta.clause {
         indent(out, depth)?;
@@ -2026,7 +2026,7 @@ fn write_body<'a>(
             write_flag(out, flag, depth + 1, None, Some(clause.canonical_selector))?;
         }
         for arg in clause.args {
-            write_arg(out, arg, depth + 1)?;
+            write_arg(out, arg, depth + 1, Some(clause.canonical_selector))?;
         }
         indent(out, depth)?;
         out.push_str("}\n");
@@ -2494,16 +2494,6 @@ fn portable_selector(selector: &str, canonical: Option<CanonicalSelector>) -> &s
         .unwrap_or(selector)
 }
 
-fn portable_selectors<'a>(
-    selectors: &'a [&'a str],
-    canonical: Option<CanonicalSelector>,
-) -> Vec<&'a str> {
-    selectors
-        .iter()
-        .map(|selector| portable_selector(selector, canonical))
-        .collect()
-}
-
 fn write_flag(
     out: &mut String,
     meta: &FlagMeta<'_>,
@@ -2511,12 +2501,6 @@ fn write_flag(
     inherited_heading: Option<&str>,
     canonical: Option<CanonicalSelector>,
 ) -> core::fmt::Result {
-    let overrides = portable_selectors(meta.overrides, canonical);
-    let conflicts = portable_selectors(meta.conflicts, canonical);
-    let requires = portable_selectors(meta.requires, canonical);
-    let required_if = portable_selectors(meta.required_if, canonical);
-    let required_unless = portable_selectors(meta.required_unless, canonical);
-    let required_unless_all = portable_selectors(meta.required_unless_all, canonical);
     indent(out, depth)?;
     write!(out, "flag {}", quoted(&flag_forms(meta)))?;
 
@@ -2603,8 +2587,8 @@ fn write_flag(
     write_single_list(out, "env_fallback", meta.env_fallback)?;
     write_single_list(out, "deprecated_env", meta.deprecated_env)?;
     write_single_default(out, meta.default)?;
-    write_single_list(out, "overrides", &overrides)?;
-    write_single_list(out, "conflicts", &conflicts)?;
+    write_single_selectors(out, "overrides", meta.overrides, canonical)?;
+    write_single_selectors(out, "conflicts", meta.conflicts, canonical)?;
     if meta.exclusive {
         out.push_str(" exclusive=#true");
     }
@@ -2640,10 +2624,15 @@ fn write_flag(
             quoted(::core::str::from_utf8(missing).unwrap_or_default())
         )?;
     }
-    write_single_list(out, "requires", &requires)?;
-    write_single_list(out, "required_if", &required_if)?;
-    write_single_list(out, "required_unless", &required_unless)?;
-    write_single_list(out, "required_unless_all", &required_unless_all)?;
+    write_single_selectors(out, "requires", meta.requires, canonical)?;
+    write_single_selectors(out, "required_if", meta.required_if, canonical)?;
+    write_single_selectors(out, "required_unless", meta.required_unless, canonical)?;
+    write_single_selectors(
+        out,
+        "required_unless_all",
+        meta.required_unless_all,
+        canonical,
+    )?;
 
     let has_children = meta.long_help.is_some()
         || !meta.admonitions.is_empty()
@@ -2652,16 +2641,16 @@ fn write_flag(
         || meta.flag.takes_value
         || !meta.choices.is_empty()
         || meta.default.len() > 1
-        || overrides.len() > 1
-        || conflicts.len() > 1
-        || requires.len() > 1
+        || meta.overrides.len() > 1
+        || meta.conflicts.len() > 1
+        || meta.requires.len() > 1
         || !meta.requires_if.is_empty()
         || !meta.default_if.is_empty()
         || !meta.required_if_eq.is_empty()
         || !meta.required_if_eq_all.is_empty()
-        || required_if.len() > 1
-        || required_unless.len() > 1
-        || required_unless_all.len() > 1
+        || meta.required_if.len() > 1
+        || meta.required_unless.len() > 1
+        || meta.required_unless_all.len() > 1
         || meta.env_fallback.len() > 1
         || meta.deprecated_env.len() > 1;
     let has_children = has_children || meta.available_if.len() > 1;
@@ -2696,9 +2685,9 @@ fn write_flag(
         out.push_str(" hide=#true\n");
     }
     write_many_defaults(out, meta.default, inner)?;
-    write_many_list(out, "overrides", &overrides, inner)?;
-    write_many_list(out, "conflicts", &conflicts, inner)?;
-    write_many_list(out, "requires", &requires, inner)?;
+    write_many_selectors(out, "overrides", meta.overrides, inner, canonical)?;
+    write_many_selectors(out, "conflicts", meta.conflicts, inner, canonical)?;
+    write_many_selectors(out, "requires", meta.requires, inner, canonical)?;
     for condition in meta.requires_if {
         indent(out, inner)?;
         writeln!(
@@ -2748,9 +2737,21 @@ fn write_flag(
         }
         out.push('\n');
     }
-    write_many_list(out, "required_if", &required_if, inner)?;
-    write_many_list(out, "required_unless", &required_unless, inner)?;
-    write_many_list(out, "required_unless_all", &required_unless_all, inner)?;
+    write_many_selectors(out, "required_if", meta.required_if, inner, canonical)?;
+    write_many_selectors(
+        out,
+        "required_unless",
+        meta.required_unless,
+        inner,
+        canonical,
+    )?;
+    write_many_selectors(
+        out,
+        "required_unless_all",
+        meta.required_unless_all,
+        inner,
+        canonical,
+    )?;
     write_many_list(out, "env_fallback", meta.env_fallback, inner)?;
     write_many_list(out, "deprecated_env", meta.deprecated_env, inner)?;
     write_many_list(out, "available_if", meta.available_if, inner)?;
@@ -2865,7 +2866,12 @@ fn write_help_hides(
     Ok(())
 }
 
-fn write_arg(out: &mut String, meta: &ArgMeta<'_>, depth: usize) -> core::fmt::Result {
+fn write_arg(
+    out: &mut String,
+    meta: &ArgMeta<'_>,
+    depth: usize,
+    canonical: Option<CanonicalSelector>,
+) -> core::fmt::Result {
     indent(out, depth)?;
     let name = if meta.arg.name.is_empty() {
         "arg"
@@ -2904,9 +2910,7 @@ fn write_arg(out: &mut String, meta: &ArgMeta<'_>, depth: usize) -> core::fmt::R
         meta.hide_short_help,
         meta.hide_long_help,
     )?;
-    if meta.conflicts.len() == 1 {
-        write!(out, " conflicts={}", quoted(meta.conflicts[0]))?;
-    }
+    write_single_selectors(out, "conflicts", meta.conflicts, canonical)?;
     if let Some(min) = meta.var_min {
         write!(out, " var_min={min}")?;
     }
@@ -2959,10 +2963,15 @@ fn write_arg(out: &mut String, meta: &ArgMeta<'_>, depth: usize) -> core::fmt::R
         }
     }
     write_single_default(out, meta.default)?;
-    write_single_list(out, "requires", meta.requires)?;
-    write_single_list(out, "required_if", meta.required_if)?;
-    write_single_list(out, "required_unless", meta.required_unless)?;
-    write_single_list(out, "required_unless_all", meta.required_unless_all)?;
+    write_single_selectors(out, "requires", meta.requires, canonical)?;
+    write_single_selectors(out, "required_if", meta.required_if, canonical)?;
+    write_single_selectors(out, "required_unless", meta.required_unless, canonical)?;
+    write_single_selectors(
+        out,
+        "required_unless_all",
+        meta.required_unless_all,
+        canonical,
+    )?;
 
     let has_children = meta.long_help.is_some()
         || !meta.admonitions.is_empty()
@@ -3003,18 +3012,18 @@ fn write_arg(out: &mut String, meta: &ArgMeta<'_>, depth: usize) -> core::fmt::R
         indent(out, inner)?;
         out.push_str("conflicts");
         for conflict in meta.conflicts {
-            write!(out, " {}", quoted(conflict))?;
+            write!(out, " {}", quoted(portable_selector(conflict, canonical)))?;
         }
         out.push('\n');
     }
-    write_many_list(out, "requires", meta.requires, inner)?;
-    write_many_list(out, "required_if", meta.required_if, inner)?;
+    write_many_selectors(out, "requires", meta.requires, inner, canonical)?;
+    write_many_selectors(out, "required_if", meta.required_if, inner, canonical)?;
     for condition in meta.required_if_eq {
         indent(out, inner)?;
         writeln!(
             out,
             "required_if_eq {} {}",
-            quoted(condition.selector),
+            quoted(portable_selector(condition.selector, canonical)),
             quoted(condition.value)
         )?;
     }
@@ -3025,14 +3034,26 @@ fn write_arg(out: &mut String, meta: &ArgMeta<'_>, depth: usize) -> core::fmt::R
             write!(
                 out,
                 " {} {}",
-                quoted(condition.selector),
+                quoted(portable_selector(condition.selector, canonical)),
                 quoted(condition.value)
             )?;
         }
         out.push('\n');
     }
-    write_many_list(out, "required_unless", meta.required_unless, inner)?;
-    write_many_list(out, "required_unless_all", meta.required_unless_all, inner)?;
+    write_many_selectors(
+        out,
+        "required_unless",
+        meta.required_unless,
+        inner,
+        canonical,
+    )?;
+    write_many_selectors(
+        out,
+        "required_unless_all",
+        meta.required_unless_all,
+        inner,
+        canonical,
+    )?;
     write_many_list(out, "env_fallback", meta.env_fallback, inner)?;
     write_many_list(out, "deprecated_env", meta.deprecated_env, inner)?;
     write_many_list(out, "available_if", meta.available_if, inner)?;
@@ -3060,6 +3081,18 @@ fn write_single_list(out: &mut String, key: &str, values: &[&str]) -> core::fmt:
     Ok(())
 }
 
+fn write_single_selectors(
+    out: &mut String,
+    key: &str,
+    values: &[&str],
+    canonical: Option<CanonicalSelector>,
+) -> core::fmt::Result {
+    if let [only] = values {
+        write!(out, " {key}={}", quoted(portable_selector(only, canonical)))?;
+    }
+    Ok(())
+}
+
 /// Several values, as `overrides "a" "b"`.
 ///
 /// The same trap as defaults: `overrides="a" overrides="b"` is one node with a
@@ -3077,6 +3110,25 @@ fn write_many_list(
     write!(out, "{key}")?;
     for value in values {
         write!(out, " {}", quoted(value))?;
+    }
+    out.push('\n');
+    Ok(())
+}
+
+fn write_many_selectors(
+    out: &mut String,
+    key: &str,
+    values: &[&str],
+    depth: usize,
+    canonical: Option<CanonicalSelector>,
+) -> core::fmt::Result {
+    if values.len() < 2 {
+        return Ok(());
+    }
+    indent(out, depth)?;
+    write!(out, "{key}")?;
+    for value in values {
+        write!(out, " {}", quoted(portable_selector(value, canonical)))?;
     }
     out.push('\n');
     Ok(())
@@ -3869,6 +3921,18 @@ pub trait CommandArgs: Sized {
     /// This is the value-aware half needed by conditional defaults and requirements.
     fn argument_matches(partial: &Self::Partial, selector: &str, value: &[u8]) -> Option<bool> {
         let _ = (partial, selector, value);
+        None
+    }
+
+    /// Find an argument by selector in a value the caller already holds.
+    fn standing_state(standing: &Self, selector: &str) -> Option<ArgumentState> {
+        let _ = (standing, selector);
+        None
+    }
+
+    /// Whether an argument in a value the caller already holds matches `value`.
+    fn standing_matches(standing: &Self, selector: &str, value: &[u8]) -> Option<bool> {
+        let _ = (standing, selector, value);
         None
     }
 

--- a/conformance/src/tables.rs
+++ b/conformance/src/tables.rs
@@ -167,6 +167,7 @@ pub fn build(
         separator: clause.separator.as_ref().map(|separator| leak(separator)),
         help: opt(&clause.help),
         long_help: opt(&clause.help_long),
+        canonical_selector: |_| None,
         flags: Box::leak(
             clause
                 .flags

--- a/conformance/tests/clause.rs
+++ b/conformance/tests/clause.rs
@@ -41,6 +41,21 @@ struct RelatedClause {
     tools: Vec<ToolClause>,
 }
 
+#[derive(Debug, Args)]
+struct ArgRelationshipToolClause {
+    #[usage(long)]
+    postinstall: Option<String>,
+    #[usage(value_name = "TOOL", requires = "postinstall")]
+    tool: String,
+}
+
+#[derive(Debug, Cli)]
+#[usage(bin = "arg-related-clause", unknown_flags = "error")]
+struct ArgRelatedClause {
+    #[usage(clause)]
+    tools: Vec<ArgRelationshipToolClause>,
+}
+
 #[derive(Debug, Cli)]
 #[usage(bin = "nested-clause")]
 struct NestedClause {
@@ -666,6 +681,32 @@ fn command_flags_can_name_clause_arguments() {
         conflict.to_string().contains("conflicts with TOOL"),
         "{conflict}"
     );
+
+    let mut standing = RelatedClause::parse_from(&[std::ffi::OsStr::new("node")]).unwrap();
+    standing
+        .try_update_from(&[std::ffi::OsStr::new("--force")])
+        .expect("a standing clause terminal satisfies an update requirement");
+    let conflict = standing
+        .try_update_from(&[std::ffi::OsStr::new("--select")])
+        .unwrap_err();
+    assert!(
+        matches!(
+            conflict,
+            usage_argv::Error::ConflictingFlags { other: "TOOL", .. }
+        ),
+        "{conflict:?}"
+    );
+}
+
+#[test]
+fn clause_argument_relationships_use_portable_selectors() {
+    let kdl = ArgRelatedClause::to_kdl();
+    assert!(kdl.contains("requires=--postinstall"), "{kdl}");
+    let portable: Spec = kdl.parse().expect("derived relationship spec reparses");
+    let explained = usage::Parser::new(&portable)
+        .explain(&["arg-related-clause", "--postinstall", "setup", "node"].map(str::to_string))
+        .expect("the reference parser binds the invocation");
+    assert!(explained.errors.is_empty(), "{explained:#?}");
 }
 
 #[test]

--- a/conformance/tests/clause.rs
+++ b/conformance/tests/clause.rs
@@ -31,6 +31,17 @@ struct ImplicitClause {
 }
 
 #[derive(Debug, Cli)]
+#[usage(bin = "related-clause", unknown_flags = "error")]
+struct RelatedClause {
+    #[usage(long, requires = "tool")]
+    force: bool,
+    #[usage(long, conflicts = "tool")]
+    select: bool,
+    #[usage(clause)]
+    tools: Vec<ToolClause>,
+}
+
+#[derive(Debug, Cli)]
 #[usage(bin = "nested-clause")]
 struct NestedClause {
     #[usage(subcommand)]
@@ -561,7 +572,7 @@ fn implicit_clause_flags_apply_to_the_following_positional() {
     let spec = ImplicitClause::spec();
     let help = usage_argv::help::short_help(spec, &["implicit-clause"], &[spec.root]);
     assert!(help.contains("--postinstall"), "{help}");
-    assert!(help.contains("<TOOL>…"), "{help}");
+    assert!(help.contains("[TOOL]…"), "{help}");
     for line in ["implicit-clause --", "implicit-clause a --"] {
         let split =
             usage_argv::complete::split(line, line.len(), usage_argv::complete::Shell::Bash);
@@ -598,6 +609,62 @@ fn implicit_clause_flags_apply_to_the_following_positional() {
                 tool: "c".into(),
             },
         ]
+    );
+}
+
+#[test]
+fn command_flags_can_name_clause_arguments() {
+    let spec = RelatedClause::spec();
+    let force = spec
+        .root
+        .flags
+        .iter()
+        .find(|flag| flag.flag.name == "force")
+        .expect("force metadata");
+    assert_eq!(force.requires, ["tool"]);
+
+    RelatedClause::parse_from(&[
+        std::ffi::OsStr::new("--force"),
+        std::ffi::OsStr::new("node"),
+    ])
+    .expect("the clause terminal satisfies the command flag requirement");
+
+    let missing = RelatedClause::parse_from(&[std::ffi::OsStr::new("--force")]).unwrap_err();
+    assert!(
+        matches!(missing, usage_argv::Error::MissingRequired { name: "TOOL" }),
+        "{missing:?}"
+    );
+
+    let conflict = RelatedClause::parse_from(&[
+        std::ffi::OsStr::new("--select"),
+        std::ffi::OsStr::new("node"),
+    ])
+    .unwrap_err();
+    assert!(
+        matches!(
+            conflict,
+            usage_argv::Error::ConflictingFlags { other: "TOOL", .. }
+        ),
+        "{conflict:?}"
+    );
+
+    let kdl = RelatedClause::to_kdl();
+    assert!(kdl.contains("requires=TOOL"), "{kdl}");
+    assert!(kdl.contains("conflicts=TOOL"), "{kdl}");
+    let portable: Spec = kdl.parse().expect("derived relationship spec reparses");
+    let explained = usage::Parser::new(&portable)
+        .explain(&["related-clause", "--force", "node"].map(str::to_string))
+        .expect("the reference parser binds the invocation");
+    assert!(
+        explained.errors.is_empty(),
+        "the reference parser resolves command relationships into the clause: {explained:#?}"
+    );
+    let conflict = usage::Parser::new(&portable)
+        .parse(&["related-clause", "--select", "node"].map(str::to_string))
+        .unwrap_err();
+    assert!(
+        conflict.to_string().contains("conflicts with TOOL"),
+        "{conflict}"
     );
 }
 

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -284,6 +284,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
                 long_help: ::core::option::Option::None,
                 flags: <#ty as usage_argv::spec::CommandArgs>::META.flags,
                 args: <#ty as usage_argv::spec::CommandArgs>::META.args,
+                canonical_selector: <#ty as usage_argv::spec::CommandArgs>::canonical_selector,
             }))
         })
         .unwrap_or_else(|| quote!(::core::option::Option::None));
@@ -4349,6 +4350,10 @@ fn presence_methods(cli: &Cli) -> TokenStream {
             argument_state(partial, selector)
         }
 
+        fn canonical_selector(selector: &str) -> ::std::option::Option<&'static str> {
+            canonical_selector(selector)
+        }
+
         fn argument_matches(
             partial: &Self::Partial,
             selector: &str,
@@ -4401,6 +4406,35 @@ fn field_selectors(field: &Field) -> Vec<String> {
 /// through `CommandArgs`. Keeping the lookup beside the partial avoids building a dynamic
 /// command graph or allocating on the successful parse path.
 fn argument_lookup_functions(cli: &Cli) -> TokenStream {
+    let canonical_arms = cli.fields.iter().filter_map(|field| {
+        let canonical = Cli::selector_for_field(field)?;
+        let selectors = field_selectors(field);
+        Some(quote!(#(#selectors)|* => return ::std::option::Option::Some(#canonical),))
+    });
+    let canonical_flattened = cli.fields.iter().filter_map(|field| {
+        let Kind::Flatten { ty, .. } = &field.kind else {
+            return None;
+        };
+        Some(quote! {
+            if let ::std::option::Option::Some(canonical) =
+                <#ty as usage_argv::spec::CommandArgs>::canonical_selector(selector)
+            {
+                return ::std::option::Option::Some(canonical);
+            }
+        })
+    });
+    let canonical_clause = cli.fields.iter().filter_map(|field| {
+        let Kind::Clause { ty, .. } = &field.kind else {
+            return None;
+        };
+        Some(quote! {
+            if let ::std::option::Option::Some(canonical) =
+                <#ty as usage_argv::spec::CommandArgs>::canonical_selector(selector)
+            {
+                return ::std::option::Option::Some(canonical);
+            }
+        })
+    });
     let state_arms = cli.fields.iter().filter_map(|field| {
         if matches!(
             field.kind,
@@ -4465,6 +4499,32 @@ fn argument_lookup_functions(cli: &Cli) -> TokenStream {
             }
         })
     });
+    let state_clause = cli.fields.iter().filter_map(|field| {
+        let Kind::Clause { ty, .. } = &field.kind else {
+            return None;
+        };
+        let ident = &field.ident;
+        let current = format_ident!("__usage_current_{}", ident);
+        Some(quote! {
+            let mut __usage_clause_state = ::std::option::Option::None;
+            for __usage_instance in partial.#ident.iter().chain(::core::iter::once(&partial.#current)) {
+                if let ::std::option::Option::Some(state) =
+                    <#ty as usage_argv::spec::CommandArgs>::argument_state(
+                        __usage_instance,
+                        selector,
+                    )
+                {
+                    if state.given || state.satisfied {
+                        return ::std::option::Option::Some(state);
+                    }
+                    __usage_clause_state = ::std::option::Option::Some(state);
+                }
+            }
+            if __usage_clause_state.is_some() {
+                return __usage_clause_state;
+            }
+        })
+    });
     let match_arms = cli.fields.iter().filter_map(|field| {
         if matches!(
             field.kind,
@@ -4524,6 +4584,34 @@ fn argument_lookup_functions(cli: &Cli) -> TokenStream {
                 )
             {
                 return ::std::option::Option::Some(matches);
+            }
+        })
+    });
+    let match_clause = cli.fields.iter().filter_map(|field| {
+        let Kind::Clause { ty, .. } = &field.kind else {
+            return None;
+        };
+        let ident = &field.ident;
+        let current = format_ident!("__usage_current_{}", ident);
+        Some(quote! {
+            let mut __usage_clause_recognized = false;
+            for __usage_instance in partial.#ident.iter().chain(::core::iter::once(&partial.#current)) {
+                match <#ty as usage_argv::spec::CommandArgs>::argument_matches(
+                    __usage_instance,
+                    selector,
+                    value,
+                ) {
+                    ::std::option::Option::Some(true) => {
+                        return ::std::option::Option::Some(true);
+                    }
+                    ::std::option::Option::Some(false) => {
+                        __usage_clause_recognized = true;
+                    }
+                    ::std::option::Option::None => {}
+                }
+            }
+            if __usage_clause_recognized {
+                return ::std::option::Option::Some(false);
             }
         })
     });
@@ -4605,6 +4693,17 @@ fn argument_lookup_functions(cli: &Cli) -> TokenStream {
     });
     quote! {
         #[allow(dead_code)]
+        pub fn canonical_selector(selector: &str) -> ::std::option::Option<&'static str> {
+            match selector {
+                #(#canonical_arms)*
+                _ => {}
+            }
+            #(#canonical_flattened)*
+            #(#canonical_clause)*
+            ::std::option::Option::None
+        }
+
+        #[allow(dead_code)]
         pub fn argument_state(
             partial: &Partial,
             selector: &str,
@@ -4615,6 +4714,7 @@ fn argument_lookup_functions(cli: &Cli) -> TokenStream {
             }
             #(#state_flattened)*
             #(#state_grouped)*
+            #(#state_clause)*
             ::std::option::Option::None
         }
 
@@ -4630,6 +4730,7 @@ fn argument_lookup_functions(cli: &Cli) -> TokenStream {
             }
             #(#match_flattened)*
             #(#match_grouped)*
+            #(#match_clause)*
             ::std::option::Option::None
         }
 
@@ -6425,6 +6526,7 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
                 long_help: ::core::option::Option::None,
                 flags: <#ty as usage_argv::spec::CommandArgs>::META.flags,
                 args: <#ty as usage_argv::spec::CommandArgs>::META.args,
+                canonical_selector: <#ty as usage_argv::spec::CommandArgs>::canonical_selector,
             }))
         },
     );

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -3699,6 +3699,9 @@ fn standing_locals(cli: &Cli) -> TokenStream {
             Kind::Flatten { .. } => quote! {
                 let #name = __usage_standing.map(|__usage_s| &__usage_s.#ident);
             },
+            Kind::Clause { .. } => quote! {
+                let #name = __usage_standing.map(|__usage_s| &__usage_s.#ident);
+            },
             // The nested value itself, so a parent can ask which member stands — a bool
             // would answer required-ness and nothing about `--json` vs `--yaml`.
             Kind::ArgGroup { multiple: true, .. } => quote! {
@@ -4362,6 +4365,21 @@ fn presence_methods(cli: &Cli) -> TokenStream {
             argument_matches(partial, selector, value)
         }
 
+        fn standing_state(
+            standing: &Self,
+            selector: &str,
+        ) -> ::std::option::Option<usage_argv::spec::ArgumentState> {
+            standing_state(standing, selector)
+        }
+
+        fn standing_matches(
+            standing: &Self,
+            selector: &str,
+            value: &[u8],
+        ) -> ::std::option::Option<bool> {
+            standing_matches(standing, selector, value)
+        }
+
         fn displace(partial: &mut Self::Partial, selector: &str) -> bool {
             displace(partial, selector)
         }
@@ -4406,6 +4424,7 @@ fn field_selectors(field: &Field) -> Vec<String> {
 /// through `CommandArgs`. Keeping the lookup beside the partial avoids building a dynamic
 /// command graph or allocating on the successful parse path.
 fn argument_lookup_functions(cli: &Cli) -> TokenStream {
+    let args = &cli.ident;
     let canonical_arms = cli.fields.iter().filter_map(|field| {
         let canonical = Cli::selector_for_field(field)?;
         let selectors = field_selectors(field);
@@ -4615,6 +4634,216 @@ fn argument_lookup_functions(cli: &Cli) -> TokenStream {
             }
         })
     });
+    let standing_state_arms = cli.fields.iter().filter_map(|field| {
+        if matches!(
+            field.kind,
+            Kind::Flatten { .. }
+                | Kind::ArgGroup { .. }
+                | Kind::Clause { .. }
+                | Kind::Subcommand { .. }
+                | Kind::Skip
+        ) {
+            return None;
+        }
+        let selectors = field_selectors(field);
+        let present = standing_presence(field)?;
+        let name = &field.name;
+        Some(quote! {
+            #(#selectors)|* => {
+                let given = #present;
+                return ::std::option::Option::Some(usage_argv::spec::ArgumentState {
+                    name: #name,
+                    given,
+                    satisfied: given,
+                });
+            }
+        })
+    });
+    let standing_state_flattened = cli.fields.iter().filter_map(|field| {
+        let Kind::Flatten { ty, .. } = &field.kind else {
+            return None;
+        };
+        let ident = &field.ident;
+        Some(quote! {
+            if let ::std::option::Option::Some(state) =
+                <#ty as usage_argv::spec::CommandArgs>::standing_state(
+                    &__usage_s.#ident,
+                    selector,
+                )
+            {
+                return ::std::option::Option::Some(state);
+            }
+        })
+    });
+    let standing_state_grouped = cli.fields.iter().filter_map(|field| {
+        let Kind::ArgGroup {
+            ty,
+            multiple,
+            optional,
+            ..
+        } = &field.kind
+        else {
+            return None;
+        };
+        let ident = &field.ident;
+        let values = if *multiple || *optional {
+            quote!(__usage_s.#ident.iter())
+        } else {
+            quote!(::core::iter::once(&__usage_s.#ident))
+        };
+        Some(quote! {
+            let mut __usage_standing_group_state = ::std::option::Option::None;
+            for __usage_member in #values {
+                if let ::std::option::Option::Some(state) =
+                    <#ty as usage_argv::spec::ArgGroup>::standing_state(
+                        __usage_member,
+                        selector,
+                    )
+                {
+                    if state.given || state.satisfied {
+                        return ::std::option::Option::Some(state);
+                    }
+                    __usage_standing_group_state = ::std::option::Option::Some(state);
+                }
+            }
+            if __usage_standing_group_state.is_some() {
+                return __usage_standing_group_state;
+            }
+        })
+    });
+    let standing_state_clause = cli.fields.iter().filter_map(|field| {
+        let Kind::Clause { ty, .. } = &field.kind else {
+            return None;
+        };
+        let ident = &field.ident;
+        Some(quote! {
+            let mut __usage_standing_clause_state = ::std::option::Option::None;
+            for __usage_instance in &__usage_s.#ident {
+                if let ::std::option::Option::Some(state) =
+                    <#ty as usage_argv::spec::CommandArgs>::standing_state(
+                        __usage_instance,
+                        selector,
+                    )
+                {
+                    if state.given || state.satisfied {
+                        return ::std::option::Option::Some(state);
+                    }
+                    __usage_standing_clause_state = ::std::option::Option::Some(state);
+                }
+            }
+            if __usage_standing_clause_state.is_some() {
+                return __usage_standing_clause_state;
+            }
+        })
+    });
+    let standing_match_arms = cli.fields.iter().filter_map(|field| {
+        if matches!(
+            field.kind,
+            Kind::Flatten { .. }
+                | Kind::ArgGroup { .. }
+                | Kind::Clause { .. }
+                | Kind::Subcommand { .. }
+                | Kind::Skip
+        ) {
+            return None;
+        }
+        let selectors = field_selectors(field);
+        let ident = &field.ident;
+        let matches = match field.shape {
+            Shape::Bool => quote!(
+                (value == b"true" && __usage_s.#ident)
+                    || (value == b"false" && !__usage_s.#ident)
+            ),
+            Shape::Count => quote!(
+                (value == b"true" && __usage_s.#ident > 0)
+                    || (value == b"false" && __usage_s.#ident == 0)
+            ),
+            Shape::Optional | Shape::Required | Shape::Many => quote!(false),
+        };
+        Some(quote!(#(#selectors)|* => return ::std::option::Option::Some(#matches),))
+    });
+    let standing_match_flattened = cli.fields.iter().filter_map(|field| {
+        let Kind::Flatten { ty, .. } = &field.kind else {
+            return None;
+        };
+        let ident = &field.ident;
+        Some(quote! {
+            if let ::std::option::Option::Some(matches) =
+                <#ty as usage_argv::spec::CommandArgs>::standing_matches(
+                    &__usage_s.#ident,
+                    selector,
+                    value,
+                )
+            {
+                return ::std::option::Option::Some(matches);
+            }
+        })
+    });
+    let standing_match_grouped = cli.fields.iter().filter_map(|field| {
+        let Kind::ArgGroup {
+            ty,
+            multiple,
+            optional,
+            ..
+        } = &field.kind
+        else {
+            return None;
+        };
+        let ident = &field.ident;
+        let values = if *multiple || *optional {
+            quote!(__usage_s.#ident.iter())
+        } else {
+            quote!(::core::iter::once(&__usage_s.#ident))
+        };
+        Some(quote! {
+            let mut __usage_standing_group_recognized = false;
+            for __usage_member in #values {
+                match <#ty as usage_argv::spec::ArgGroup>::standing_matches(
+                    __usage_member,
+                    selector,
+                    value,
+                ) {
+                    ::std::option::Option::Some(true) => {
+                        return ::std::option::Option::Some(true);
+                    }
+                    ::std::option::Option::Some(false) => {
+                        __usage_standing_group_recognized = true;
+                    }
+                    ::std::option::Option::None => {}
+                }
+            }
+            if __usage_standing_group_recognized {
+                return ::std::option::Option::Some(false);
+            }
+        })
+    });
+    let standing_match_clause = cli.fields.iter().filter_map(|field| {
+        let Kind::Clause { ty, .. } = &field.kind else {
+            return None;
+        };
+        let ident = &field.ident;
+        Some(quote! {
+            let mut __usage_standing_clause_recognized = false;
+            for __usage_instance in &__usage_s.#ident {
+                match <#ty as usage_argv::spec::CommandArgs>::standing_matches(
+                    __usage_instance,
+                    selector,
+                    value,
+                ) {
+                    ::std::option::Option::Some(true) => {
+                        return ::std::option::Option::Some(true);
+                    }
+                    ::std::option::Option::Some(false) => {
+                        __usage_standing_clause_recognized = true;
+                    }
+                    ::std::option::Option::None => {}
+                }
+            }
+            if __usage_standing_clause_recognized {
+                return ::std::option::Option::Some(false);
+            }
+        })
+    });
     let displace_arms = cli.fields.iter().filter_map(|field| {
         if !matches!(field.kind, Kind::Flag { .. }) || !is_displaceable(cli, field) {
             return None;
@@ -4731,6 +4960,37 @@ fn argument_lookup_functions(cli: &Cli) -> TokenStream {
             #(#match_flattened)*
             #(#match_grouped)*
             #(#match_clause)*
+            ::std::option::Option::None
+        }
+
+        #[allow(dead_code)]
+        pub fn standing_state(
+            __usage_s: &#args,
+            selector: &str,
+        ) -> ::std::option::Option<usage_argv::spec::ArgumentState> {
+            match selector {
+                #(#standing_state_arms)*
+                _ => {}
+            }
+            #(#standing_state_flattened)*
+            #(#standing_state_grouped)*
+            #(#standing_state_clause)*
+            ::std::option::Option::None
+        }
+
+        #[allow(dead_code)]
+        pub fn standing_matches(
+            __usage_s: &#args,
+            selector: &str,
+            value: &[u8],
+        ) -> ::std::option::Option<bool> {
+            match selector {
+                #(#standing_match_arms)*
+                _ => {}
+            }
+            #(#standing_match_flattened)*
+            #(#standing_match_grouped)*
+            #(#standing_match_clause)*
             ::std::option::Option::None
         }
 
@@ -9413,6 +9673,66 @@ fn argument_state_standing(cli: &Cli) -> TokenStream {
             }
         })
     });
+    let clause_overlays = cli.fields.iter().filter_map(|field| {
+        let Kind::Clause { ty, .. } = &field.kind else {
+            return None;
+        };
+        let ident = &field.ident;
+        let current = format_ident!("__usage_current_{}", ident);
+        let standing = standing_ident(field);
+        Some(quote! {
+            if !partial.#ident.iter().chain(::core::iter::once(&partial.#current)).any(
+                |__usage_instance| {
+                    <#ty as usage_argv::spec::CommandArgs>::any_given(__usage_instance).is_some()
+                },
+            ) {
+                if let ::std::option::Option::Some(__usage_s) = #standing {
+                    for __usage_instance in __usage_s {
+                        if let ::std::option::Option::Some(__usage_standing_state) =
+                            <#ty as usage_argv::spec::CommandArgs>::standing_state(
+                                __usage_instance,
+                                selector,
+                            )
+                        {
+                            if __usage_standing_state.given
+                                || __usage_standing_state.satisfied
+                            {
+                                return ::std::option::Option::Some(__usage_standing_state);
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    });
+    let clause_match_overlays = cli.fields.iter().filter_map(|field| {
+        let Kind::Clause { ty, .. } = &field.kind else {
+            return None;
+        };
+        let ident = &field.ident;
+        let current = format_ident!("__usage_current_{}", ident);
+        let standing = standing_ident(field);
+        Some(quote! {
+            if !partial.#ident.iter().chain(::core::iter::once(&partial.#current)).any(
+                |__usage_instance| {
+                    <#ty as usage_argv::spec::CommandArgs>::any_given(__usage_instance).is_some()
+                },
+            ) {
+                if let ::std::option::Option::Some(__usage_s) = #standing {
+                    for __usage_instance in __usage_s {
+                        if <#ty as usage_argv::spec::CommandArgs>::standing_matches(
+                            __usage_instance,
+                            selector,
+                            value,
+                        ) == ::std::option::Option::Some(true)
+                        {
+                            return ::std::option::Option::Some(true);
+                        }
+                    }
+                }
+            }
+        })
+    });
     quote! {
         // Shadow the module helper for every check below: an update's standing group
         // member has to answer `requires` / `conflicts` the same way a standing flag does,
@@ -9428,6 +9748,7 @@ fn argument_state_standing(cli: &Cli) -> TokenStream {
                     }
                     recognized => {
                         #(#overlays)*
+                        #(#clause_overlays)*
                         recognized
                     }
                 }
@@ -9442,6 +9763,7 @@ fn argument_state_standing(cli: &Cli) -> TokenStream {
                     ::std::option::Option::Some(true) => ::std::option::Option::Some(true),
                     recognized => {
                         #(#match_overlays)*
+                        #(#clause_match_overlays)*
                         recognized
                     }
                 }

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -1934,6 +1934,9 @@ impl Cli {
         // is the advantage of declaring them in code: a spec written by hand can only
         // find a typo'd selector at parse time, or never, since a selector naming
         // nothing quietly holds no relationship at all.
+        // Flattened, grouped, and clause fields are separate derived types. Their
+        // selectors are intentionally opaque here: the parent model cannot inspect
+        // them, so valid nested selectors are resolved by the generated lookup.
         let has_opaque = self.fields.iter().any(|field| {
             matches!(
                 field.kind,

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -1934,10 +1934,12 @@ impl Cli {
         // is the advantage of declaring them in code: a spec written by hand can only
         // find a typo'd selector at parse time, or never, since a selector naming
         // nothing quietly holds no relationship at all.
-        let has_opaque = self
-            .fields
-            .iter()
-            .any(|field| matches!(field.kind, Kind::Flatten { .. } | Kind::ArgGroup { .. }));
+        let has_opaque = self.fields.iter().any(|field| {
+            matches!(
+                field.kind,
+                Kind::Flatten { .. } | Kind::ArgGroup { .. } | Kind::Clause { .. }
+            )
+        });
         for field in &self.fields {
             for (option, selectors) in [
                 ("overrides", &field.overrides),

--- a/lib/src/docs/manpage/renderer.rs
+++ b/lib/src/docs/manpage/renderer.rs
@@ -256,15 +256,20 @@ impl ManpageRenderer {
             parts.push("[OPTIONS]".to_string());
         }
 
-        // Add arguments
-        for arg in &cmd.args {
-            if arg.required {
-                parts.push(format!("<{}>", arg.name));
-            } else {
-                parts.push(format!("[<{}>]", arg.name));
-            }
-            if arg.var {
-                parts.push("...".to_string());
+        // Add arguments. A clause's inner positional can be required while the
+        // outer repeated clause remains optional, so use its complete synopsis.
+        if let Some(clause) = &cmd.clause {
+            parts.push(clause.usage.clone());
+        } else {
+            for arg in &cmd.args {
+                if arg.required {
+                    parts.push(format!("<{}>", arg.name));
+                } else {
+                    parts.push(format!("[<{}>]", arg.name));
+                }
+                if arg.var {
+                    parts.push("...".to_string());
+                }
             }
         }
 
@@ -789,6 +794,31 @@ cmd "run"
         assert!(page.contains("\\fBex\\fR <COMMAND>"), "{page}");
         assert!(page.contains("\\fBex\\fR \\-\\-print\\-spec"), "{page}");
         assert!(!page.contains("[COMMAND]"), "{page}");
+    }
+
+    #[test]
+    fn clause_fields_reach_subcommand_manpage_sections() {
+        let spec: Spec = r#"
+name "mycli"
+bin "mycli"
+cmd "use" {
+    clause tools {
+        flag "--postinstall <command>" help="Run after installation"
+        arg <tool> help="Tool to install"
+    }
+}
+"#
+        .parse()
+        .unwrap();
+        let page = ManpageRenderer::new(spec).render().unwrap();
+
+        assert!(
+            page.contains("\\fBUsage:\\fR mycli use [OPTIONS] [tool]…"),
+            "{page}"
+        );
+        assert!(page.contains("\\-\\-postinstall"), "{page}");
+        assert!(page.contains("Run after installation"), "{page}");
+        assert!(page.contains("Tool to install"), "{page}");
     }
 
     #[test]

--- a/lib/src/docs/markdown/cmd.rs
+++ b/lib/src/docs/markdown/cmd.rs
@@ -154,6 +154,36 @@ cmd "version" help="Show the version"
     }
 
     #[test]
+    fn clause_fields_are_documented_like_the_arguments_users_type() {
+        let spec: Spec = r#"
+bin "mycli"
+cmd "use" {
+    clause tools {
+        flag "--postinstall <command>" help="Run after installation"
+        arg <tool> help="Tool to install"
+    }
+}
+        "#
+        .parse()
+        .unwrap();
+        let ctx = MarkdownRenderer::new(spec.clone()).with_multi(true);
+        let rendered = ctx
+            .render_cmd(spec.cmd.subcommands.get("use").unwrap())
+            .unwrap();
+
+        assert!(rendered.contains("## Arguments"), "{rendered}");
+        assert!(
+            rendered.contains("**`<tool>`** — Tool to install"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("## Flags"), "{rendered}");
+        assert!(
+            rendered.contains("**`--postinstall <command>`** — Run after installation"),
+            "{rendered}"
+        );
+    }
+
+    #[test]
     fn test_render_markdown_groups_by_heading() {
         let spec: Spec = r#"
 bin "mycli"

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -672,21 +672,38 @@ impl From<&crate::SpecCommand> for SpecCommand {
         let mut args: Vec<(usize, SpecArg)> = cmd
             .args
             .iter()
-            .chain(cmd.clause.iter().flat_map(|clause| clause.args.iter()))
             .enumerate()
             .map(|(index, arg)| (index, SpecArg::from(arg)))
             .collect();
+        if let Some(clause) = &cmd.clause {
+            let offset = args.len();
+            args.extend(
+                clause
+                    .args
+                    .iter()
+                    .enumerate()
+                    .map(|(index, arg)| (offset + index, SpecArg::from(arg))),
+            );
+        }
         args.sort_by_key(|(_, arg)| arg.display_order.unwrap_or(999));
         let args: Vec<SpecArg> = args.into_iter().map(|(_, arg)| arg).collect();
 
         let mut flags: Vec<(usize, SpecFlag)> = cmd
-            .clause
+            .flags
             .iter()
-            .flat_map(|clause| clause.flags.iter())
-            .chain(cmd.flags.iter())
             .enumerate()
             .map(|(index, flag)| (index, SpecFlag::from(flag)))
             .collect();
+        if let Some(clause) = &cmd.clause {
+            let offset = flags.len();
+            flags.extend(
+                clause
+                    .flags
+                    .iter()
+                    .enumerate()
+                    .map(|(index, flag)| (offset + index, SpecFlag::from(flag))),
+            );
+        }
         flags.sort_by_key(|(_, flag)| flag.display_order.unwrap_or(999));
         let flags: Vec<SpecFlag> = flags.into_iter().map(|(_, flag)| flag).collect();
 

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -672,6 +672,7 @@ impl From<&crate::SpecCommand> for SpecCommand {
         let mut args: Vec<(usize, SpecArg)> = cmd
             .args
             .iter()
+            .chain(cmd.clause.iter().flat_map(|clause| clause.args.iter()))
             .enumerate()
             .map(|(index, arg)| (index, SpecArg::from(arg)))
             .collect();
@@ -679,8 +680,10 @@ impl From<&crate::SpecCommand> for SpecCommand {
         let args: Vec<SpecArg> = args.into_iter().map(|(_, arg)| arg).collect();
 
         let mut flags: Vec<(usize, SpecFlag)> = cmd
-            .flags
+            .clause
             .iter()
+            .flat_map(|clause| clause.flags.iter())
+            .chain(cmd.flags.iter())
             .enumerate()
             .map(|(index, flag)| (index, SpecFlag::from(flag)))
             .collect();

--- a/lib/src/spec/clause.rs
+++ b/lib/src/spec/clause.rs
@@ -115,7 +115,10 @@ impl SpecClause {
         match &self.separator {
             Some(separator) => format!("[{inner} [{separator} {inner}]…]"),
             None => {
-                let mut arg = self.args[0].clone();
+                let Some(arg) = self.args.first() else {
+                    return String::new();
+                };
+                let mut arg = arg.clone();
                 arg.required = false;
                 arg.var = true;
                 arg.usage()
@@ -145,5 +148,15 @@ impl From<&SpecClause> for KdlNode {
             .nodes_mut()
             .extend(clause.args.iter().map(Into::into));
         node
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SpecClause;
+
+    #[test]
+    fn an_empty_default_clause_has_an_empty_synopsis() {
+        assert_eq!(SpecClause::default().usage(), "");
     }
 }

--- a/lib/src/spec/clause.rs
+++ b/lib/src/spec/clause.rs
@@ -113,8 +113,13 @@ impl SpecClause {
             .collect::<Vec<_>>()
             .join(" ");
         match &self.separator {
-            Some(separator) => format!("{inner} [{separator} {inner}]…"),
-            None => format!("{inner}…"),
+            Some(separator) => format!("[{inner} [{separator} {inner}]…]"),
+            None => {
+                let mut arg = self.args[0].clone();
+                arg.required = false;
+                arg.var = true;
+                arg.usage()
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- let command-level relationships resolve arguments inside typed clauses in the compiled parser
- canonicalize typed field selectors when emitting portable KDL so reference parsing preserves those relationships
- render optional repeated clauses correctly in compiled help, Markdown, and manpages
- include clause-scoped flags and arguments in generated documentation

## Why

The mise `use --postinstall` integration exercises implicit clauses end to end. It exposed these remaining gaps after #1343: `--force` could not require the clause terminal in the compiled parser, the emitted KDL retained the Rust field selector instead of the portable argument name, and generated documentation omitted clause members. These fixes are needed in the first Usage release containing implicit clauses.

## Tests

- `mise run ci`
- `cargo test -p usage-conformance --test clause`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches derive-generated parse/validation paths and KDL emission for clause relationships; behavior changes for help text and portable specs, but scope is CLI parsing/docs rather than security-critical infrastructure.
> 
> **Overview**
> **Command-level flag relationships** (`requires`, `conflicts`, etc.) can now target arguments inside typed **clauses** in the compiled parser. The derive layer resolves selectors across clause instances (including in-progress and standing state during `try_update_from`), and conformance tests cover cases like `--force` requiring the clause terminal `TOOL`.
> 
> **Portable KDL** gains **`canonical_selector`** on `ClauseMeta` so relationship fields are emitted with spec-facing names (e.g. `TOOL`, `--postinstall`) instead of Rust field selectors, keeping reference-parser round-trips valid.
> 
> **Usage and docs** treat repeated clauses as optional groups: compiled help, `SpecClause::usage`, manpage synopsis, and Markdown now wrap clause patterns in `[…]` and surface clause-scoped flags and arguments in documentation models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a7d15b6ce8a510966029ef7068c9b1e1eeebd1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added portable selector support for command specifications and argument relationships.
  * Improved handling of clause-defined arguments and flags during parsing, validation, and specification generation.
  * Added support for validating relationships involving standing clause values.

* **Documentation**
  * Updated help, synopsis, and Markdown output to accurately document clause arguments, flags, optional groups, and repeated values.

* **Bug Fixes**
  * Corrected usage-line rendering for separated and implicit clauses.
  * Improved relationship resolution and error handling for clause fields.
  * Prevented failures when rendering empty clauses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->