### PR TITLE
fix(complete): complete attached long flag values

### DIFF
--- a/cli/src/cli/complete_word.rs
+++ b/cli/src/cli/complete_word.rs
@@ -241,12 +241,48 @@ impl CompleteWord {
                 .max_by_key(|(_, _, sigil, _)| sigil.len())
         })
         .flatten();
+        let attached_long_value = flags_possible
+            .then(|| Self::attached_long_value(&flags, &ctoken))
+            .flatten();
+        let mut used_file_fallback = false;
         let mut choices = if flags_possible && ctoken == "-" {
             let shorts = self.complete_short_flag_names(&flags, "");
             let longs = self.complete_long_flag_names(&flags, "");
             shorts.into_iter().chain(longs).collect::<Vec<_>>()
         } else if flags_possible && ctoken.starts_with("--") {
-            self.complete_long_flag_names(&flags, &ctoken)
+            if let Some((flag, form, prefix)) = attached_long_value {
+                let arg = flag.arg.as_ref().unwrap();
+                // Dynamic completers inspect `words[CURRENT]`; expose the value fragment just
+                // like sigil completion does, since the flag prefix is handled separately.
+                let mut attached_ctx = ctx.clone();
+                let mut attached_words = self.words.clone();
+                if let Some(current) = attached_words.get_mut(cword) {
+                    *current = prefix.to_string();
+                }
+                attached_ctx.insert("words", &attached_words);
+                let attached_cx = Ctx {
+                    tera: &attached_ctx,
+                    spec: cx.spec,
+                    parsed: cx.parsed,
+                    after_restart_token: cx.after_restart_token,
+                };
+                let (mut found, closed) =
+                    self.complete_arg(&attached_cx, &parsed.cmd, arg, prefix)?;
+                has_explicit_choices = closed || arg.choices.is_some();
+                if found.is_empty() && !has_explicit_choices {
+                    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+                    found = self
+                        .complete_path(&cwd, prefix, |_| true)
+                        .into_iter()
+                        .map(|name| (name, String::new()))
+                        .collect();
+                    used_file_fallback = true;
+                }
+                Self::attach_long_value_candidates(&mut found, form);
+                found
+            } else {
+                self.complete_long_flag_names(&flags, &ctoken)
+            }
         } else if flags_possible && ctoken.starts_with('-') {
             self.complete_short_flag_names(&flags, &ctoken)
         } else if after_restart_token {
@@ -343,8 +379,9 @@ impl CompleteWord {
         // flag. Past a `--` a dash-prefixed word is not a flag but a value, so a path like
         // `-input` still gets completed there.
         let looks_like_a_flag = flags_possible && ctoken.starts_with('-');
-        let files = choices.is_empty() && !looks_like_a_flag && !has_explicit_choices;
-        if files {
+        let files = used_file_fallback
+            || (choices.is_empty() && !looks_like_a_flag && !has_explicit_choices);
+        if files && choices.is_empty() {
             let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
             let files = self.complete_path(&cwd, &ctoken, |_| true);
             choices = files.into_iter().map(|n| (n, String::new())).collect();
@@ -428,6 +465,28 @@ impl CompleteWord {
             .map(|c| (format!("-{c}"), String::new()))
             .sorted()
             .collect()
+    }
+
+    /// A value being typed in the same word as its long flag.
+    ///
+    /// The shell replaces the whole word, so callers complete against the fragment after `=`
+    /// and then put the flag spelling back on each candidate.
+    fn attached_long_value<'f, 't>(
+        flags: &'f BTreeMap<String, Arc<SpecFlag>>,
+        token: &'t str,
+    ) -> Option<(&'f SpecFlag, &'t str, &'t str)> {
+        let (form, prefix) = token.split_once('=')?;
+        let long = form.strip_prefix("--")?;
+        flags
+            .values()
+            .find(|flag| flag.arg.is_some() && flag.long.iter().any(|candidate| candidate == long))
+            .map(|flag| (flag.as_ref(), form, prefix))
+    }
+
+    fn attach_long_value_candidates(candidates: &mut [(String, String)], form: &str) {
+        for (candidate, _) in candidates {
+            *candidate = format!("{form}={candidate}");
+        }
     }
 
     /// Completions for a reserved `type=`, and whether the set they came from is *closed*.

--- a/cli/tests/complete_word.rs
+++ b/cli/tests/complete_word.rs
@@ -225,6 +225,8 @@ fn complete_word_long_flag_val() {
         &["--", "plugins", "install", "--dir", ""],
     )
     .stdout(contains("src").and(contains("tests")));
+    assert_cmd("basic.usage.kdl", &["--", "plugins", "install", "--dir=s"])
+        .stdout(contains("--dir=src/"));
 }
 
 #[test]
@@ -250,6 +252,60 @@ fn complete_word_choices() {
         &["--", "activate", "--shell", ""],
     )
     .stdout("bash\nelvish\nfish\nnu\nxonsh\nzsh\npwsh\n");
+}
+
+#[test]
+fn complete_word_attached_long_flag_value_choices() {
+    let spec = r#"
+name "ex"
+bin "ex"
+flag "--format <F>" {
+    arg "<F>" {
+        choices "json" "yaml" "toml"
+    }
+}
+"#;
+    Command::new(cargo::cargo_bin!("usage"))
+        .args([
+            "cw",
+            "--shell",
+            "fish",
+            "--spec",
+            spec,
+            "--",
+            "ex",
+            "--format=j",
+        ])
+        .assert()
+        .success()
+        .stdout("--format=json\n");
+}
+
+#[test]
+fn complete_word_attached_long_flag_value_run_receives_value_fragment() {
+    let spec = r#"
+name "ex"
+bin "ex"
+flag "--format <F>" {
+    arg "<F>" {
+    }
+}
+complete "F" run="printf '%s\\n' {{ words[CURRENT] | shell_quote }}"
+"#;
+    Command::new(cargo::cargo_bin!("usage"))
+        .args([
+            "cw",
+            "--shell",
+            "fish",
+            "--spec",
+            spec,
+            "--",
+            "ex",
+            "--format=j",
+        ])
+        .assert()
+        .success()
+        .stdout("--format=j\n");
 }
 
 #[test]

--- a/corpus/complete/02-values-and-restarts.json
+++ b/corpus/complete/02-values-and-restarts.json
@@ -21,6 +21,15 @@
       }
     },
     {
+      "id": "an-attached-long-flag-value-narrows",
+      "doc": "A value typed after `=` in the same long-flag word is still that flag's value. Completion narrows against the fragment after `=` and keeps the flag spelling in the replacement because shells replace the whole word.",
+      "spec": "name \"ex\"\nbin \"ex\"\nflag \"--format <F>\" {\n  arg \"<F>\" {\n    choices \"json\" \"yaml\" \"toml\"\n  }\n}\n",
+      "line": "ex --format=j",
+      "expect": {
+        "candidates": ["--format=json"]
+      }
+    },
+    {
       "id": "a-positionals-choices-are-offered",
       "doc": "A positional carrying choices answers at command position, alongside the subcommands rather than instead of them \u2014 a word there could be either.",
       "spec": "name \"ex\"\nbin \"ex\"\narg \"<MODE>\" {\n  choices \"fast\" \"slow\"\n}\ncmd \"go\" {}\n",


### PR DESCRIPTION
## Summary

- complete attached long flag values against the fragment after `=`
- reattach the long flag form to candidates because shells replace the whole word
- keep file fallback working for open attached values and add CLI/corpus regressions

Fixes #999.

## Tests

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p usage-cli --test complete_word complete_word -- --nocapture`
- `CARGO_BUILD_JOBS=1 cargo test -p usage-conformance --test complete -- --nocapture`
- `CARGO_BUILD_JOBS=1 cargo test -p usage-argv --features complete an_attached_value_is_answered_by_its_flag -- --nocapture`

Full `mise run ci` was not run locally because broader Cargo builds hit the `/tmp` disk quota on this machine.

AI note: This PR was prepared with help from OpenAI Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added completion for inline long-option values using `--flag=value` syntax.
  * Preserves the full option prefix when suggesting values.
  * Supports dynamic value completion for attached long-option arguments.
  * Falls back to filesystem path suggestions when no explicit value choices are available.

* **Bug Fixes**
  * Improved narrowing of values based on text entered after `=`.
  * Corrected suggestions so the complete option and value are returned together.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->