### PR TITLE
chore(ci): use mbx server cache for trusted builds

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -5,10 +5,20 @@ inputs:
   backend:
     description: Backend selected by the structurally trusted caller
     default: github
+  mirror-github-cache:
+    description: Mirror a trusted main build into the restore-only cache used by fork PRs
+    default: "false"
 
 runs:
   using: composite
   steps:
+    - name: Restore the fork PR cache mirror
+      if: inputs.mirror-github-cache == 'true' && inputs.backend == 'server' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
+      with:
+        version: 1.3.0
+        backend: github
+        cache-generation: v2
     - uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
       with:
         version: 1.3.0

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -3,8 +3,8 @@ description: Select the trusted jdx server or fork-safe GitHub cache backend
 
 inputs:
   backend:
-    description: Explicit backend for structurally trusted or untrusted callers
-    default: auto
+    description: Backend selected by the structurally trusted caller
+    default: github
 
 runs:
   using: composite
@@ -13,7 +13,7 @@ runs:
       with:
         version: 1.3.0
         cache-generation: v2
-        backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
+        backend: ${{ inputs.backend }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/usage
         oidc-audience: https://cache.mise.jdx.dev

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,5 +1,10 @@
 name: Set up mbx
-description: Set up mbx with the GitHub Actions cache backend
+description: Select the trusted jdx server or fork-safe GitHub cache backend
+
+inputs:
+  backend:
+    description: Explicit backend for structurally trusted or untrusted callers
+    default: auto
 
 runs:
   using: composite
@@ -7,5 +12,8 @@ runs:
     - uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
       with:
         version: 1.3.0
-        backend: github
         cache-generation: v2
+        backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
+        server-url: https://cache.mise.jdx.dev
+        namespace: jdx/usage
+        oidc-audience: https://cache.mise.jdx.dev

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -30,6 +30,8 @@ jobs:
           submodules: recursive
           persist-credentials: false
       - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.trusted && 'server' || 'github' }}
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
       # Retries and a longer wait, rather than being allowed to fail. `cli`'s completion
       # tests refuse to skip a missing shell when `CI` is set — see
@@ -143,6 +145,8 @@ jobs:
           submodules: recursive
           persist-credentials: false
       - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.trusted && 'server' || 'github' }}
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
       - run: mise r build
       # `usage bash` runs whatever Windows resolves `bash` to, and `CreateProcess` searches the
@@ -241,6 +245,8 @@ jobs:
       - name: install the toolchain under test
         run: rustup toolchain install ${{ matrix.version }} --profile minimal
       - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.trusted && 'server' || 'github' }}
       - name: they build at the version they claim
         run: |
           for crate in ${{ matrix.crates }}; do

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ inputs.trusted && 'server' || 'github' }}
+          mirror-github-cache: "true"
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
       # Retries and a longer wait, rather than being allowed to fail. `cli`'s completion
       # tests refuse to skip a missing shell when `CI` is set — see
@@ -147,6 +148,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ inputs.trusted && 'server' || 'github' }}
+          mirror-github-cache: "true"
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
       - run: mise r build
       # `usage bash` runs whatever Windows resolves `bash` to, and `CreateProcess` searches the


### PR DESCRIPTION
## Summary

- route trusted jdx builds through cache.mise.jdx.dev with OIDC
- retain the GitHub Actions cache backend for forks and untrusted callers
- isolate cache entries under the repository namespace

## Validation

- actionlint -shellcheck= .github/workflows/*.yml
- git diff --check

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI cache auth and backend selection; misconfiguration could break builds or leak cache scope, but impact is limited to CI infrastructure rather than runtime product code.
> 
> **Overview**
> **Trusted CI** now routes `mbx` through `cache.mise.jdx.dev` (OIDC, namespace `jdx/usage`); **untrusted/fork** runs keep the GitHub Actions cache backend.
> 
> The composite **`.github/actions/mbx`** action gains `backend` and `mirror-github-cache` inputs. When mirroring is enabled on trusted **main** pushes with the server backend, it first restores the GitHub cache so fork PRs can benefit from a warm restore-only mirror. **`test-impl.yml`** wires `backend: ${{ inputs.trusted && 'server' || 'github' }}` on all `mbx` steps; `mirror-github-cache: "true"` is set on **test** and **test-windows** only (not **msrv**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d04c4e2fa7621feec0b86a03a0513018400ab160. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for selecting between the trusted server and GitHub Actions cache backends.
  - Added configuration options for the server URL, namespace, OIDC audience, and cache mirroring.
  - Configured workflows to select the appropriate backend based on trust settings.
  - Improved cache availability for pull requests from forks and external contributors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->