### PR TITLE
chore(release): improve sponsor message

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -177,9 +177,9 @@ jobs:
 
           ## 💚 Sponsor usage
 
-          usage is maintained by [@jdx](https://github.com/jdx), an open source developer for [**entire.io**](https://entire.io), the title sponsor of the [jdx.dev](https://jdx.dev) open source tools including [mise](https://mise.jdx.dev/), [aube](https://aube.jdx.dev/), hk, and more. Work on usage is funded by sponsorships.
+          usage is built and maintained by [@jdx](https://github.com/jdx), an open source developer at [**entire.io**](https://entire.io/), the title sponsor of his open source work.
 
-          If `usage` powers CLI specs, docs, or completions for a tool you maintain or use, please consider [sponsoring at jdx.dev](https://jdx.dev/sponsors.html). Every sponsorship helps the project stay independent and moving.
+          If `usage` powers CLI specs, docs, or completions for a tool you maintain or use, please consider becoming an [individual or company sponsor](https://jdx.dev/sponsors.html). Your support funds ongoing development and helps keep usage fast, free, and independent.
           EOF
           } > /tmp/release-notes.md
           gh release edit "$TAG" --notes-file /tmp/release-notes.md


### PR DESCRIPTION
## Summary

- clarify Entire's sponsorship of jdx's open source work
- link the sponsorship call to action directly to the individual and company sponsor page
- tighten the release-note copy while preserving each CLI's tailored message

## Testing

- git diff --check
- parsed the updated workflow as YAML

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-note marketing copy only in CI; no product or auth behavior changes.
> 
> **Overview**
> Updates the **Sponsor usage** section that the `publish-cli` workflow appends to GitHub releases after `communique` runs.
> 
> The Entire.io line is shortened: it now says usage is *built and maintained* by @jdx as a developer at Entire.io (title sponsor of his open source work), instead of listing jdx.dev tools (mise, aube, hk, etc.). The sponsorship paragraph now points readers to **individual or company** sponsors on jdx.dev and adds a line about funding ongoing development and keeping usage fast, free, and independent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d09818fd6815942487316ea7d1f9b7f2c631da4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the sponsorship message included with GitHub releases.
  * The message now highlights that `usage` is built and maintained by its creator and invites readers to consider individual or company sponsorship.
  * Removed references to other open-source tools and the previous sponsorship wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->