### PR TITLE
fix(docs): strip authored ANSI from plain help

### DIFF
--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -203,11 +203,59 @@ fn assemble(spec: &Spec<'_>, sections: &Sections, style: Style) -> String {
         Some(template) => sections.substituted(template, style),
         None => sections.concatenated(),
     };
+    finish_page(page, style)
+}
+
+fn finish_page(page: String, style: Style) -> String {
+    let page = if style.coloured {
+        page
+    } else {
+        strip_ansi_sequences(page)
+    };
     let trimmed = page.trim();
     let mut done = String::with_capacity(trimmed.len() + 1);
     done.push_str(trimmed);
     done.push('\n');
     done
+}
+
+/// Remove complete ANSI control-sequence introducer escapes from authored help text.
+///
+/// Applications migrating from clap commonly carry `color_print::cstr!` output in fields such
+/// as `after_long_help`. Those bytes were present before this renderer selected a style, so a
+/// plain page has to remove them as well as declining to add its own styling.
+fn strip_ansi_sequences(text: String) -> String {
+    let bytes = text.as_bytes();
+    let Some(mut at) = bytes.windows(2).position(|pair| pair == b"\x1b[") else {
+        return text;
+    };
+
+    let mut plain = String::with_capacity(text.len());
+    let mut copied = 0;
+    while at + 1 < bytes.len() {
+        if bytes[at] != b'\x1b' || bytes[at + 1] != b'[' {
+            at += 1;
+            continue;
+        }
+
+        let mut end = at + 2;
+        while end < bytes.len() && (0x30..=0x3f).contains(&bytes[end]) {
+            end += 1;
+        }
+        while end < bytes.len() && (0x20..=0x2f).contains(&bytes[end]) {
+            end += 1;
+        }
+        if end == bytes.len() || !(0x40..=0x7e).contains(&bytes[end]) {
+            at += 2;
+            continue;
+        }
+
+        plain.push_str(&text[copied..at]);
+        copied = end + 1;
+        at = copied;
+    }
+    plain.push_str(&text[copied..]);
+    plain
 }
 
 /// Whether help output is coloured.
@@ -221,6 +269,8 @@ pub struct Style {
 
 impl Style {
     /// Plain text, suitable for a pipe or a generated artifact.
+    ///
+    /// ANSI CSI escapes already present in authored help are removed as well.
     pub const PLAIN: Style = Style { coloured: false };
     /// ANSI-coloured text, regardless of the output destination.
     pub const COLOURED: Style = Style { coloured: true };
@@ -795,11 +845,7 @@ fn assembled_help(
             &synopsis,
         ),
     };
-    let trimmed = page.trim();
-    let mut done = String::with_capacity(trimmed.len() + 1);
-    done.push_str(trimmed);
-    done.push('\n');
-    done
+    finish_page(page, style)
 }
 
 /// The `Usage:` line's body, without the `Usage: ` prefix.
@@ -3911,7 +3957,7 @@ fn recursive_help<'a>(
 mod style_tests {
     use super::{
         commands_section, display_usage_masked, flag_notes, flag_usage, flat_commands_short,
-        inline_environment_notes, long_help, render_styled, render_view_at_styled,
+        inline_environment_notes, long_help, render, render_styled, render_view_at_styled,
         styled_flag_usage, styled_help, styled_inline, usage_line, wrap, Shown, Style,
     };
     use crate::spec::{ArgMeta, ClauseMeta, CommandMeta, FlagMeta, Spec, ViewMeta};
@@ -4404,6 +4450,35 @@ mod style_tests {
         let page = render_styled(&malformed, &command, false, Style::COLOURED)
             .expect("a programmatic malformed template remains renderable");
         assert!(page.starts_with("before {$red and \u{1b}[1;33mUsage:"));
+    }
+
+    #[test]
+    fn plain_help_strips_ansi_authored_before_style_selection() {
+        let command = Command {
+            name: "ex",
+            ..Command::EMPTY
+        };
+        let root = CommandMeta {
+            cmd: &command,
+            after_long_help: Some(
+                "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    \u{1b}[1mex run\u{1b}[22m",
+            ),
+            ..CommandMeta::EMPTY
+        };
+        let spec = Spec {
+            name: "ex",
+            root: &root,
+            ..Spec::EMPTY
+        };
+
+        let plain = render_styled(&spec, &command, true, Style::PLAIN).expect("root page");
+        assert!(plain.contains("Examples:\n\n    ex run"), "{plain}");
+        assert!(!plain.contains('\u{1b}'), "{plain:?}");
+        assert_eq!(render(&spec, &command, true).as_deref(), Some(&*plain));
+
+        let coloured = render_styled(&spec, &command, true, Style::COLOURED).expect("root page");
+        assert!(coloured.contains("\u{1b}[1m\u{1b}[4mExamples:"));
+        assert_eq!(strip_ansi(&coloured), plain);
     }
 
     #[test]

--- a/go/argv/sections.go
+++ b/go/argv/sections.go
@@ -123,7 +123,47 @@ func (s *helpSections) assemble(template string) string {
 	if strings.TrimSpace(template) != "" {
 		page = substituteSections(template, s)
 	}
+	page = stripANSISequences(page)
 	return strings.TrimSpace(page) + "\n"
+}
+
+// stripANSISequences removes complete ANSI control-sequence introducer escapes
+// from authored help. The Go renderer only produces plain pages, so bytes
+// embedded before rendering, such as color_print output carried through a spec,
+// have no place in the finished document.
+func stripANSISequences(text string) string {
+	first := strings.Index(text, "\x1b[")
+	if first < 0 {
+		return text
+	}
+
+	var plain strings.Builder
+	plain.Grow(len(text))
+	copied := 0
+	for at := first; at+1 < len(text); {
+		if text[at] != '\x1b' || text[at+1] != '[' {
+			at++
+			continue
+		}
+
+		end := at + 2
+		for end < len(text) && text[end] >= 0x30 && text[end] <= 0x3f {
+			end++
+		}
+		for end < len(text) && text[end] >= 0x20 && text[end] <= 0x2f {
+			end++
+		}
+		if end == len(text) || text[end] < 0x40 || text[end] > 0x7e {
+			at += 2
+			continue
+		}
+
+		plain.WriteString(text[copied:at])
+		copied = end + 1
+		at = copied
+	}
+	plain.WriteString(text[copied:])
+	return plain.String()
 }
 
 // substituteSections fills a template in, section by section.

--- a/go/argv/sections_test.go
+++ b/go/argv/sections_test.go
@@ -326,6 +326,22 @@ func TestAPlainGoPageStripsTemplateColourMarkupOnly(t *testing.T) {
 	}
 }
 
+func TestAPlainGoPageStripsAuthoredANSI(t *testing.T) {
+	root := &Command{Name: "ex", Key: 1}
+	spec := HelpSpec{
+		Name: "ex", Bin: "ex",
+		AfterLongHelp: "\x1b[1m\x1b[4mExamples:\x1b[22m\x1b[24m\n\n    \x1b[1mex run\x1b[22m",
+	}
+
+	got := LongHelp(spec, []string{"ex"}, []*Command{root}, HelpTable{})
+	if !strings.Contains(got, "Examples:\n\n    ex run") {
+		t.Fatalf("authored help was not preserved as plain text:\n%s", got)
+	}
+	if strings.Contains(got, "\x1b") {
+		t.Fatalf("plain help contains ANSI escapes: %q", got)
+	}
+}
+
 func TestAPlainGoPageKeepsEscapedAndMalformedStyleMarkupLiteral(t *testing.T) {
 	root := &Command{Name: "ex", Key: 1}
 	sections := helpSections{}

--- a/lib/src/docs/cli/mod.rs
+++ b/lib/src/docs/cli/mod.rs
@@ -203,6 +203,11 @@ pub fn render_help_styled(spec: &Spec, cmd: &SpecCommand, long: bool, style: Sty
         }
         None => styling.apply(&sections.concatenated(), style),
     };
+    let page = if style.coloured {
+        std::borrow::Cow::Borrowed(page.as_str())
+    } else {
+        crate::docs::strip_ansi(&page)
+    };
     page.trim().to_string() + "\n"
 }
 
@@ -1996,15 +2001,20 @@ cmd "run" help="Run it" {
 
     #[test]
     fn styled_help_colours_semantics_and_template_styles() {
-        let spec = crate::spec! { r#"
+        let mut spec = crate::spec! { r#"
 bin "testcli"
-help_template "{$bright-blue}My tool{/$}\n\n{{usage}}\n\n{{flags}}"
+help_template "{$bright-blue}My tool{/$}\n\n{{usage}}\n\n{{flags}}\n\n{{after_help}}"
 flag "--output <FILE>" help="Write **the file**"
         "# }
         .unwrap();
+        spec.cmd.after_help_long = Some(
+            "\u{1b}[1m\u{1b}[4mExamples:\u{1b}[22m\u{1b}[24m\n\n    \u{1b}[1mtestcli run\u{1b}[22m"
+                .to_string(),
+        );
 
         let plain = render_help(&spec, &spec.cmd, true);
         assert!(plain.contains("My tool"), "{plain}");
+        assert!(plain.contains("Examples:\n\n    testcli run"), "{plain}");
         assert!(!plain.contains('\u{1b}'), "{plain:?}");
 
         let coloured = render_help_styled(&spec, &spec.cmd, true, Style::COLOURED);
@@ -2026,6 +2036,10 @@ flag "--output <FILE>" help="Write **the file**"
         );
         assert!(
             coloured.contains("\u{1b}[1mthe file\u{1b}[22m"),
+            "{coloured:?}"
+        );
+        assert!(
+            coloured.contains("\u{1b}[1m\u{1b}[4mExamples:"),
             "{coloured:?}"
         );
     }

--- a/lib/src/docs/cli/style.rs
+++ b/lib/src/docs/cli/style.rs
@@ -8,6 +8,8 @@ pub struct Style {
 
 impl Style {
     /// Plain text, suitable for a pipe or generated artifact.
+    ///
+    /// ANSI CSI escapes already present in authored help are removed as well.
     pub const PLAIN: Style = Style { coloured: false };
     /// ANSI-coloured text, regardless of the output destination.
     pub const COLOURED: Style = Style { coloured: true };

--- a/lib/src/docs/markdown/renderer.rs
+++ b/lib/src/docs/markdown/renderer.rs
@@ -50,8 +50,6 @@ impl MarkdownTemplate {
     }
 }
 
-/// An ANSI escape sequence: what `color_print::cstr!` leaves in help text.
-static SGR: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\x1b\[[0-?]*[ -/]*[@-~]").unwrap());
 /// A backtick span, or a bare `<` outside one.
 static CODE_SPAN_OR_LT: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(`[^`]*`)|(<)").unwrap());
 
@@ -61,7 +59,7 @@ fn escape_md_with_indent(value: &str, html_encode: bool, indent: bool) -> String
     // their examples with `color_print::cstr!`, which embeds SGR sequences even when color is
     // disabled at runtime. Terminal styling has no meaning in generated Markdown, and leaving
     // it here publishes literal escape bytes in docs and downstream static sites.
-    let value = SGR.replace_all(value, "");
+    let value = crate::docs::strip_ansi(value);
 
     value
         .lines()

--- a/lib/src/docs/mod.rs
+++ b/lib/src/docs/mod.rs
@@ -1,3 +1,7 @@
+use regex::Regex;
+use std::borrow::Cow;
+use std::sync::LazyLock;
+
 #[cfg(feature = "cli-help")]
 pub mod cli;
 #[cfg(feature = "cli-help")]
@@ -8,3 +12,12 @@ pub mod manpage;
 pub mod markdown;
 #[cfg(feature = "cli-help")]
 pub(crate) mod models;
+
+/// An ANSI control-sequence introducer escape, including the SGR sequences commonly embedded by
+/// `color_print::cstr!`.
+static ANSI_CSI: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\x1b\[[0-?]*[ -/]*[@-~]").unwrap());
+
+pub(crate) fn strip_ansi(value: &str) -> Cow<'_, str> {
+    ANSI_CSI.replace_all(value, "")
+}


### PR DESCRIPTION
## Summary

- make `Style::PLAIN` remove ANSI CSI sequences already embedded in authored help
- keep the `usage-argv` and `usage-lib` renderers in parity without adding argv dependencies
- reuse the reference ANSI sanitizer for Markdown and terminal help

This lets adopters such as mise select plain rendering after resolving their own color policy, even when clap-era `color_print::cstr!` help remains in command metadata.

Addresses the renderer behavior behind https://github.com/jdx/mise/discussions/12671.

## Verification

- `mise run ci`
- `cargo test -p gate --test fleet every_jdx_cli_matches_the_reference`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Output-formatting change limited to stripping escape bytes on plain paths; coloured terminal help is unchanged aside from shared finalization.
> 
> **Overview**
> **Plain help and docs no longer leak ANSI escapes** that were already baked into command metadata (typical when migrating from clap/`color_print::cstr!` in fields like `after_long_help`).
> 
> The **usage-argv** renderer centralizes page finalization in `finish_page`: when `Style::PLAIN` is selected it strips complete CSI sequences before trim/newline, while **coloured** output keeps both renderer styling and any authored escapes. The **Go argv** renderer applies the same rule in `assemble` via `stripANSISequences`, since it only emits plain pages.
> 
> **usage-lib** adds a shared `docs::strip_ansi` helper (regex-based) and wires it into CLI plain rendering and Markdown generation, replacing a duplicate SGR regex in the markdown renderer. `Style::PLAIN` is documented to include this sanitization.
> 
> Tests cover Rust argv, Go argv, and usage-lib styled vs plain behaviour for authored ANSI in long help.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 718cd8686c5911ee9a453ec287eebb4c026a64a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->