### PR TITLE
fix(cli): show help for bare exec command

### DIFF
--- a/cli/src/cli/mod.rs
+++ b/cli/src/cli/mod.rs
@@ -127,6 +127,32 @@ impl Cli {
         // went wrong instead of ending the process — which is what lets the error come out
         // through the same path as every other failure here.
         let words: Vec<&OsStr> = argv.iter().skip(1).map(OsStr::new).collect();
+        // `exec` owns `-h` and `--help`: once COMMAND and BIN are present they describe the
+        // wrapped script, not this command. With no script to describe, answer the ordinary
+        // command-help request before its required positionals are checked. `usage help exec`
+        // reaches the same page through the parser's synthesized help command.
+        if let [command, help] = words.as_slice() {
+            if matches!(command.to_str(), Some("exec" | "x"))
+                && matches!(help.to_str(), Some("-h" | "--help"))
+            {
+                let spec = Self::spec();
+                let exec = spec
+                    .root
+                    .subcommands
+                    .iter()
+                    .find(|subcommand| subcommand.cmd.name == "exec")
+                    .expect("the CLI declares its exec command");
+                if let Some(page) = usage_rs::help::render_styled(
+                    spec,
+                    exec.cmd,
+                    *help == OsStr::new("--help"),
+                    usage_rs::help::Style::auto(),
+                ) {
+                    print!("{page}");
+                }
+                return Ok(());
+            }
+        }
         let cli = match Self::parse_from(&words) {
             Ok(cli) => cli,
             // Not failures: someone asked a question, and the answer goes to stdout.

--- a/cli/tests/examples.rs
+++ b/cli/tests/examples.rs
@@ -235,3 +235,23 @@ fn test_exec_help() {
         .stdout(contains("<file>"))
         .stdout(contains("File to process"));
 }
+
+#[test]
+fn test_exec_help_without_a_script() {
+    for command in ["exec", "x"] {
+        for help in ["-h", "--help"] {
+            let mut cmd = Command::new(cargo::cargo_bin!("usage"));
+            cmd.args([command, help]);
+
+            cmd.assert()
+                .success()
+                .stdout(contains(
+                    "Execute a script, parsing args and exposing them as environment variables",
+                ))
+                .stdout(contains("Usage: usage exec"))
+                .stdout(contains("<COMMAND>"))
+                .stdout(contains("<BIN>"))
+                .stderr("");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1360.

`exec` intentionally owns `-h` and `--help` so a fully specified invocation can render the wrapped script's usage spec. Handle the bare command before required positional validation so `usage exec --help` prints the `exec` command page instead of reporting a missing `<COMMAND>`.

This preserves wrapped-script help for `usage exec <COMMAND> <BIN> --help` and supports the `x` alias plus both help spellings.

Tests:
- `cargo test -p usage-cli --all-features`
- `cargo clippy -p usage-cli --all-features --all-targets -- -D warnings`

_This PR was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small pre-parse branch in the CLI entrypoint; behavior change is limited to bare exec help and is covered by new tests.
> 
> **Overview**
> **`usage exec -h` / `usage exec --help`** (and the **`x`** alias) now print the **`exec`** subcommand help instead of failing on missing **`<COMMAND>`** / **`<BIN>`**.
> 
> `Cli::run` intercepts that two-argument pattern **before** normal parsing and renders the **`exec`** page via **`usage_rs::help::render_styled`**, matching what **`usage help exec`** already shows. Invocations with a command and binary still route **`-h`/`--help`** to the wrapped script’s usage, unchanged.
> 
> Integration test **`test_exec_help_without_a_script`** covers **`exec`/`x`** × **`-h`/`--help`** and expects success with empty stderr.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be4fdc1ee4f14f6dbc28aa4ee1b127356d2bfa4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->