### PR TITLE
chore(ci): update mbx to 1.4.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## mbx build cache
 
-`mise install` installs mbx 1.3. `mise run` activates the project's transparent
+`mise install` installs mbx 1.4. `mise run` activates the project's transparent
 Cargo wrapper, so compilation-heavy mise tasks use ordinary `cargo` commands.
 Standalone Cargo commands require an activated mise shell. If the wrapper fails
 or creates a development papercut, rerun the exact equivalent command from

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ See the [contributing guide](https://usage.jdx.dev/contributing).
 
 ## mbx build cache
 
-`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.3. The normal
+`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.4. The normal
 `mise run build`, `mise run test`, and `mise run lint:clippy` workflows activate
 its transparent Cargo wrapper and therefore use the cache while invoking Cargo
 normally. Standalone Cargo commands require an activated mise shell. To bypass

--- a/mise.lock
+++ b/mise.lock
@@ -458,44 +458,44 @@ checksum = "sha256:f0c0a0d33ba94f4d2c5dbc887334ce678b21813504ddb3aafcb06e60a5a66
 url = "https://dl.google.com/go/go1.27.0.windows-amd64.zip"
 
 [[tools.mr-boxington]]
-version = "1.4.0"
+version = "1.4.1"
 backend = "github:jdx/mr-boxington"
 
 [tools.mr-boxington."platforms.linux-arm64"]
-checksum = "sha256:7c2771c6da3e9f63d5bd27b22be21101f928e71b09d8e3cf94d93c16df590a7b"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540435998"
+checksum = "sha256:7ca1deeb64ad22bd5ddc9f45c749c78d3eb32608562c363727de3f0c595df0f0"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505948"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-arm64-musl"]
-checksum = "sha256:50e2bac80ca8902dccf25b5fc964237cc7cf1c1cda386abe210bac306d8cd7f1"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540435997"
+checksum = "sha256:3113dfce87c8ee6d3485f7eb99f87ae130b9b9f2c73224720edf2cef7279b5d1"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505946"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64"]
-checksum = "sha256:ca2e02ba52583e5617344c5be849e1c5efc1d82eac0977d716a8f486a3287289"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540436013"
+checksum = "sha256:5bc7434333a941f664bbe73ae229edf6111c9fb5f771f959ca411a11358baf8a"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505965"
 provenance = "github-attestations"
 provenance_verified = true
 
 [tools.mr-boxington."platforms.linux-x64-musl"]
-checksum = "sha256:2416466f524730f75c08026553b3e6f730e637f0d216121da165d4fecfedc656"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540436016"
+checksum = "sha256:7277ceabefae1b444b39200c2cb944018a87da628ff77aa94291a8cc338546e6"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505964"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.macos-arm64"]
-checksum = "sha256:0556a8dfd32466ab9147b03cf1c722499bd68bfb24f712d8dd9c0a046a0fedaa"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540435994"
+checksum = "sha256:57f1cac111d9972ad675aa80cbedf4c86b3423dfb11091383175db0f6341847e"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505945"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64"]
-checksum = "sha256:7eaab88593c03dafb0ff0e78668b81f06b7530d62bafa466193e6b3f0ccbd50c"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540436009"
+checksum = "sha256:346cb0405129bbca4f7a24fc916b036cfd806d497d52ba47fc8bb0a0531b4382"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505963"
 provenance = "github-attestations"
 
 [[tools.node]]

--- a/mise.lock
+++ b/mise.lock
@@ -458,44 +458,44 @@ checksum = "sha256:f0c0a0d33ba94f4d2c5dbc887334ce678b21813504ddb3aafcb06e60a5a66
 url = "https://dl.google.com/go/go1.27.0.windows-amd64.zip"
 
 [[tools.mr-boxington]]
-version = "1.3.2"
+version = "1.4.0"
 backend = "github:jdx/mr-boxington"
 
 [tools.mr-boxington."platforms.linux-arm64"]
-checksum = "sha256:18aabfdfaced4316b9e9fd488d65df0915b241aa3af8e761b4df0fc0bdc1a4f7"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849887"
+checksum = "sha256:7c2771c6da3e9f63d5bd27b22be21101f928e71b09d8e3cf94d93c16df590a7b"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540435998"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-arm64-musl"]
-checksum = "sha256:abbbcc8cc7c080febc5f6c77e1ae7af89faf15476248282f7bf4c331e836ee1b"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849885"
+checksum = "sha256:50e2bac80ca8902dccf25b5fc964237cc7cf1c1cda386abe210bac306d8cd7f1"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540435997"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64"]
-checksum = "sha256:6096035ae9bb47d718b7c0ca2860e1142047ebf724b37c02d3a520a4b9804d2d"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849911"
+checksum = "sha256:ca2e02ba52583e5617344c5be849e1c5efc1d82eac0977d716a8f486a3287289"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540436013"
 provenance = "github-attestations"
 provenance_verified = true
 
 [tools.mr-boxington."platforms.linux-x64-musl"]
-checksum = "sha256:a31a332095ac291686777736d450b2f62658145ac173ff543f83271e44850df7"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849909"
+checksum = "sha256:2416466f524730f75c08026553b3e6f730e637f0d216121da165d4fecfedc656"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540436016"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.macos-arm64"]
-checksum = "sha256:3a91ecb2d6ff4ad84662e79599d11e79eff4738c222a35ed432db4b15ade4d1e"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849886"
+checksum = "sha256:0556a8dfd32466ab9147b03cf1c722499bd68bfb24f712d8dd9c0a046a0fedaa"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540435994"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64"]
-checksum = "sha256:49e3a4570034612fd7b193e4f56830bdece32c73ac92eb7f0d580c85695492df"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849907"
+checksum = "sha256:7eaab88593c03dafb0ff0e78668b81f06b7530d62bafa466193e6b3f0ccbd50c"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540436009"
 provenance = "github-attestations"
 
 [[tools.node]]

--- a/mise.toml
+++ b/mise.toml
@@ -5,7 +5,7 @@ CARGO_TERM_COLOR = 'always'
 _.path = ["./target/debug"]
 
 [tools]
-mr-boxington = "1.4.0"
+mr-boxington = "1.4.1"
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change
 # in usage's numbers, indistinguishable from a real regression. Bump deliberately.

--- a/mise.toml
+++ b/mise.toml
@@ -5,7 +5,7 @@ CARGO_TERM_COLOR = 'always'
 _.path = ["./target/debug"]
 
 [tools]
-mr-boxington = "1.3.2"
+mr-boxington = "1.4.0"
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change
 # in usage's numbers, indistinguishable from a real regression. Bump deliberately.


### PR DESCRIPTION
## Summary

- update mr-boxington from 1.3.2 to 1.4.1 in mise.toml and the generated lockfile
- keep contributor and agent guidance on the mbx 1.4 line
- include the grouped-export GC fix released in mbx 1.4.1

## Validation

- mise lock mr-boxington
- verified the published v1.4.1 release has all eight platform assets
- verified the locked release installs and reports mbx 1.4.1
- git diff --check
- verified no changelog files changed

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build cache and contribution guidance to reference mbx 1.4.
* **Chores**
  * Updated the project’s mr-boxington tool version from 1.3.2 to 1.4.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->