### PR TITLE
ci: use shared Namespace volume for local mbx caching

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,7 +4,7 @@ self-hosted-runner:
     - jdx-perf-v1
     - bamboo-perf
     - macos-14
-    - namespace-profile-endev-linux-amd64
+    - namespace-profile-endev-linux-amd64;overrides.cache-tag=cache
     - buildjet-32vcpu-ubuntu-2204-arm
     - buildjet-16vcpu-ubuntu-2204-arm
     - buildjet-8vcpu-ubuntu-2204-arm

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -12,6 +12,12 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Set up mise for the local mbx install
+      if: inputs.backend == 'local'
+      uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+      with:
+        install: false
+        cache: false
     - name: Mount the local mbx store on the Namespace cache volume
       if: inputs.backend == 'local'
       uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
@@ -20,7 +26,8 @@ runs:
     - name: Install mbx for local caching
       if: inputs.backend == 'local'
       shell: bash
-      run: | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
+      run:
+        | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
         mise install mr-boxington
         echo "$(mise where mr-boxington)" >> "$GITHUB_PATH"
         echo "MBX_REMOTE_URL=" >> "$GITHUB_ENV"

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -12,6 +12,21 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Mount the local mbx store on the Namespace cache volume
+      if: inputs.backend == 'local'
+      uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
+      with:
+        path: ${{ runner.os == 'macOS' && '~/Library/Caches/mbx' || '~/.cache/mbx' }}
+    - name: Install mbx for local caching
+      if: inputs.backend == 'local'
+      shell: bash
+      run: |
+        mise install mr-boxington
+        echo "$(mise where mr-boxington)" >> "$GITHUB_PATH"
+        echo "MBX_REMOTE_URL=" >> "$GITHUB_ENV"
+        if [[ "$RUNNER_OS" == Linux ]]; then
+          echo "MBX_CACHE_LINKS=1" >> "$GITHUB_ENV"
+        fi
     - name: Restore the fork PR cache mirror
       if: inputs.mirror-github-cache == 'true' && inputs.backend == 'local' && github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -20,7 +20,7 @@ runs:
     - name: Install mbx for local caching
       if: inputs.backend == 'local'
       shell: bash
-      run: |
+      run: | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
         mise install mr-boxington
         echo "$(mise where mr-boxington)" >> "$GITHUB_PATH"
         echo "MBX_REMOTE_URL=" >> "$GITHUB_ENV"

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,9 +1,9 @@
 name: Set up mbx
-description: Select the trusted jdx server or fork-safe GitHub cache backend
+description: Use the local Namespace volume or fork-safe GitHub cache backend
 
 inputs:
   backend:
-    description: Backend selected by the structurally trusted caller
+    description: Backend selected by the structurally trusted caller; local skips transport
     default: github
   mirror-github-cache:
     description: Mirror a trusted main build into the restore-only cache used by fork PRs
@@ -13,12 +13,13 @@ runs:
   using: composite
   steps:
     - name: Restore the fork PR cache mirror
-      if: inputs.mirror-github-cache == 'true' && inputs.backend == 'server' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: inputs.mirror-github-cache == 'true' && inputs.backend == 'local' && github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
       with:
         backend: github
         cache-generation: v2
-    - uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
+    - if: inputs.backend != 'local'
+      uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
       with:
         cache-generation: v2
         backend: ${{ inputs.backend }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,4 +61,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v3.0.2-node.24

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   test:
-    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=cache' }}
     # Without this, a hung step sits until GitHub's 6-hour job limit.
     timeout-minutes: 30
     steps:
@@ -190,7 +190,7 @@ jobs:
   # `cargo check` rather than `cargo test`: dev-dependencies are not part of what an adopter
   # compiles, and holding them to the MSRV would pin the toolchain past what the library needs.
   msrv:
-    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ !inputs.trusted && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=cache' }}
     timeout-minutes: 15
     strategy:
       fail-fast: false

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -148,7 +148,7 @@ jobs:
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'local' || 'github' }}
+          backend: github
           mirror-github-cache: "true"
       - run: mise r build
       # `usage bash` runs whatever Windows resolves `bash` to, and `CreateProcess` searches the

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'server' || 'github' }}
+          backend: ${{ inputs.trusted && 'local' || 'github' }}
           mirror-github-cache: "true"
       # Retries and a longer wait, rather than being allowed to fail. `cli`'s completion
       # tests refuse to skip a missing shell when `CI` is set — see
@@ -148,7 +148,7 @@ jobs:
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'server' || 'github' }}
+          backend: ${{ inputs.trusted && 'local' || 'github' }}
           mirror-github-cache: "true"
       - run: mise r build
       # `usage bash` runs whatever Windows resolves `bash` to, and `CreateProcess` searches the
@@ -252,7 +252,7 @@ jobs:
           install_args: mr-boxington
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'server' || 'github' }}
+          backend: ${{ inputs.trusted && 'local' || 'github' }}
       - name: they build at the version they claim
         run: |
           for crate in ${{ matrix.crates }}; do

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,6 @@ jobs:
     if: ${{ github.actor == 'jdx' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')) }}
     permissions:
       contents: read
-      id-token: write
     uses: ./.github/workflows/test-impl.yml
     with:
       trusted: true


### PR DESCRIPTION
Keep Mr Boxington as the local build cacher for ordinary trusted Namespace jobs, using the shared Namespace volume selected by `overrides.cache-tag=cache`.

Trusted jobs use the project `mbx` wrapper locally without GitHub-cache or remote-server transport. Untrusted jobs remain on GitHub-hosted runners with the GitHub cache backend.

Privileged release, signing, deployment, and architecture-specific release jobs retain their existing isolated or untagged runner profiles.

Validation: actionlint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved caching for trusted test workflows by using local storage.
  - Updated cache handling to avoid unnecessary transport steps when local storage is selected.
  - Refined self-hosted runner configuration for consistent cache usage.
  - Standardized caching behavior across supported test environments.
  - Updated the documentation deployment action reference.

- **Security**
  - Reduced permissions for the trusted workflow by removing its ability to mint identity tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes to caching and runner selection; removing trusted `id-token` aligns with no longer calling the OIDC-backed remote cache, with untrusted jobs unchanged on GitHub cache.
> 
> **Overview**
> Trusted CI jobs now cache builds with **local mbx** on a Namespace runner profile tagged `overrides.cache-tag=cache`, instead of the remote **server** backend and `mr-boxington-action` transport to `cache.mise.jdx.dev`.
> 
> The **`mbx` composite action** adds a `local` path: mount the shared cache volume via `nscloud-cache-action`, install `mr-boxington` with mise, clear `MBX_REMOTE_URL`, and set `MBX_CACHE_LINKS` on Linux. Non-local backends still use `mr-boxington-action`. Main-branch fork cache mirroring runs when `backend` is `local`, not `server`.
> 
> **`test-impl.yml`** switches trusted `test` and `msrv` jobs to `backend: local` and the cache-tagged runner label; the Windows job always uses `backend: github`. **`test.yml`** drops **`id-token: write`** from the trusted workflow because local caching no longer needs OIDC for the remote cache server.
> 
> Minor: **actionlint** runner label list updated; **docs** workflow pins a `deploy-pages` comment to `v3.0.2-node.24`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3b6241ebe1b6c2be4c12d17597bf1f01d3a5c81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->