### PR TITLE
ci: refresh local mbx wrapper

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -29,6 +29,7 @@ runs:
       run:
         | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
         mise install mr-boxington
+        mise reshim -f
         echo "$(mise where mr-boxington)" >> "$GITHUB_PATH"
         echo "MBX_REMOTE_URL=" >> "$GITHUB_ENV"
         if [[ "$RUNNER_OS" == Linux ]]; then


### PR DESCRIPTION
Run `mise reshim -f` after installing mr-boxington in the local cache setup action. This refreshes the configured Cargo wrapper so plain `cargo` invocations use mbx.

Follow-up to the late review feedback on the Namespace cache PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only shim refresh after tool install; no application, auth, or data-path changes.
> 
> **Overview**
> After `mise install mr-boxington` in the **local** mbx composite action, CI now runs **`mise reshim -f`** so mise regenerates shims/wrappers. That keeps the Cargo wrapper in sync so later jobs that call plain **`cargo`** still go through mbx for caching.
> 
> This is a one-line follow-up to Namespace cache setup feedback; it only affects the `backend == 'local'` install step in `.github/actions/mbx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4948433255235671b6dc9deb0bae78b08d628bc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup reliability by ensuring the required command is available after installation in automated workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->