### PR TITLE
ci: route mbx caching by runner provider

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -10,10 +10,17 @@ runs:
   using: composite
   steps:
     - name: Set up mise for the mbx install
+      if: runner.os != 'Windows'
+      uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+      with:
+        install: false
+        cache: false
+    - name: Set up mise for the mbx install on Windows
+      if: runner.os == 'Windows'
       uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       env:
-        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.tool_cache) || env.MISE_DATA_DIR }}
-        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.tool_cache) || env.MISE_CACHE_DIR }}
+        MISE_DATA_DIR: ${{ format('{0}/mise-data', runner.tool_cache) }}
+        MISE_CACHE_DIR: ${{ format('{0}/mise-cache', runner.tool_cache) }}
       with:
         install: false
         cache: false
@@ -26,10 +33,12 @@ runs:
       shell: bash
       env:
         MBX_BACKEND: ${{ inputs.backend }}
-        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.tool_cache) || env.MISE_DATA_DIR }}
-        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.tool_cache) || env.MISE_CACHE_DIR }}
       run:
         | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
+        if [[ "$RUNNER_OS" == Windows ]]; then
+          export MISE_DATA_DIR="$RUNNER_TOOL_CACHE/mise-data"
+          export MISE_CACHE_DIR="$RUNNER_TOOL_CACHE/mise-cache"
+        fi
         mise install mr-boxington
         mise reshim -f
         mise where mr-boxington >> "$GITHUB_PATH"

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -12,8 +12,8 @@ runs:
     - name: Set up mise for the mbx install
       uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       env:
-        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.temp) || env.MISE_DATA_DIR }}
-        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.temp) || env.MISE_CACHE_DIR }}
+        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.tool_cache) || env.MISE_DATA_DIR }}
+        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.tool_cache) || env.MISE_CACHE_DIR }}
       with:
         install: false
         cache: false
@@ -26,8 +26,8 @@ runs:
       shell: bash
       env:
         MBX_BACKEND: ${{ inputs.backend }}
-        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.temp) || env.MISE_DATA_DIR }}
-        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.temp) || env.MISE_CACHE_DIR }}
+        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.tool_cache) || env.MISE_DATA_DIR }}
+        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.tool_cache) || env.MISE_CACHE_DIR }}
       run:
         | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
         mise install mr-boxington

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -11,6 +11,9 @@ runs:
   steps:
     - name: Set up mise for the mbx install
       uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+      env:
+        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.temp) || env.MISE_DATA_DIR }}
+        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.temp) || env.MISE_CACHE_DIR }}
       with:
         install: false
         cache: false
@@ -23,6 +26,8 @@ runs:
       shell: bash
       env:
         MBX_BACKEND: ${{ inputs.backend }}
+        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.temp) || env.MISE_DATA_DIR }}
+        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.temp) || env.MISE_CACHE_DIR }}
       run:
         | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
         mise install mr-boxington

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -24,6 +24,8 @@ runs:
       with:
         install: false
         cache: false
+        env: false
+        add_shims_to_path: false
     - name: Mount the local mbx store on the Namespace cache volume
       if: inputs.backend == 'local'
       uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,10 +1,10 @@
 name: Set up mbx
-description: Install mbx with a local Namespace, remote server, or ephemeral store
+description: Install mbx with a local Namespace store or the GitHub Actions cache server
 
 inputs:
   backend:
-    description: Store selected by the structurally trusted caller
-    default: github
+    description: Use local on Namespace runners and server on GitHub-hosted runners
+    default: server
 
 runs:
   using: composite
@@ -45,10 +45,12 @@ runs:
         mise reshim -f
         mise where mr-boxington >> "$GITHUB_PATH"
         {
-          if [[ "$MBX_BACKEND" == server ]]; then
-            echo "MBX_REMOTE_URL=https://cache.mise.jdx.dev"
+          if [[ "$MBX_BACKEND" == server && -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]]; then
+            echo "MBX_REMOTE_URL=https://cache.jdx.dev"
             echo "MBX_REMOTE_NAMESPACE=jdx/usage"
-            echo "MBX_REMOTE_OIDC_AUDIENCE=https://cache.mise.jdx.dev"
+            echo "MBX_REMOTE_OIDC_AUDIENCE=https://cache.jdx.dev"
+          elif [[ "$MBX_BACKEND" == server ]]; then
+            echo "::notice::GitHub OIDC is unavailable; using an ephemeral local mbx store"
           fi
           if [[ "$RUNNER_OS" == Linux ]]; then
             echo "MBX_CACHE_LINKS=1"

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -45,12 +45,14 @@ runs:
         mise reshim -f
         mise where mr-boxington >> "$GITHUB_PATH"
         {
-          if [[ "$MBX_BACKEND" == server && -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]]; then
+          if [[ "$MBX_BACKEND" == server ]]; then
             echo "MBX_REMOTE_URL=https://cache.jdx.dev"
             echo "MBX_REMOTE_NAMESPACE=jdx/usage"
-            echo "MBX_REMOTE_OIDC_AUDIENCE=https://cache.jdx.dev"
-          elif [[ "$MBX_BACKEND" == server ]]; then
-            echo "::notice::GitHub OIDC is unavailable; using an ephemeral local mbx store"
+            if [[ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]]; then
+              echo "MBX_REMOTE_OIDC_AUDIENCE=https://cache.jdx.dev"
+            else
+              echo "::notice::GitHub OIDC is unavailable; using public read-only cache access" >&2
+            fi
           fi
           if [[ "$RUNNER_OS" == Linux ]]; then
             echo "MBX_CACHE_LINKS=1"

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,19 +1,15 @@
 name: Set up mbx
-description: Use the local Namespace volume or fork-safe GitHub cache backend
+description: Install mbx with a local Namespace, remote server, or ephemeral store
 
 inputs:
   backend:
-    description: Backend selected by the structurally trusted caller; local skips transport
+    description: Store selected by the structurally trusted caller
     default: github
-  mirror-github-cache:
-    description: Mirror a trusted main build into the restore-only cache used by fork PRs
-    default: "false"
 
 runs:
   using: composite
   steps:
-    - name: Set up mise for the local mbx install
-      if: inputs.backend == 'local'
+    - name: Set up mise for the mbx install
       uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       with:
         install: false
@@ -23,29 +19,22 @@ runs:
       uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
       with:
         path: ${{ runner.os == 'macOS' && '~/Library/Caches/mbx' || '~/.cache/mbx' }}
-    - name: Install mbx for local caching
-      if: inputs.backend == 'local'
+    - name: Install and configure mbx
       shell: bash
+      env:
+        MBX_BACKEND: ${{ inputs.backend }}
       run:
         | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
         mise install mr-boxington
         mise reshim -f
-        echo "$(mise where mr-boxington)" >> "$GITHUB_PATH"
-        echo "MBX_REMOTE_URL=" >> "$GITHUB_ENV"
-        if [[ "$RUNNER_OS" == Linux ]]; then
-          echo "MBX_CACHE_LINKS=1" >> "$GITHUB_ENV"
-        fi
-    - name: Restore the fork PR cache mirror
-      if: inputs.mirror-github-cache == 'true' && inputs.backend == 'local' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
-      with:
-        backend: github
-        cache-generation: v2
-    - if: inputs.backend != 'local'
-      uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
-      with:
-        cache-generation: v2
-        backend: ${{ inputs.backend }}
-        server-url: https://cache.mise.jdx.dev
-        namespace: jdx/usage
-        oidc-audience: https://cache.mise.jdx.dev
+        mise where mr-boxington >> "$GITHUB_PATH"
+        {
+          if [[ "$MBX_BACKEND" == server ]]; then
+            echo "MBX_REMOTE_URL=https://cache.mise.jdx.dev"
+            echo "MBX_REMOTE_NAMESPACE=jdx/usage"
+            echo "MBX_REMOTE_OIDC_AUDIENCE=https://cache.mise.jdx.dev"
+          fi
+          if [[ "$RUNNER_OS" == Linux ]]; then
+            echo "MBX_CACHE_LINKS=1"
+          fi
+        } >> "$GITHUB_ENV"

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'local' || 'github' }}
+          backend: ${{ inputs.trusted && 'local' || 'server' }}
       # Retries and a longer wait, rather than being allowed to fail. `cli`'s completion
       # tests refuse to skip a missing shell when `CI` is set — see
       # `skip_if_shell_missing` — which is a deliberate policy this step exists to keep:
@@ -245,7 +245,7 @@ jobs:
           install_args: mr-boxington
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'local' || 'github' }}
+          backend: ${{ inputs.trusted && 'local' || 'server' }}
       - name: they build at the version they claim
         run: |
           for crate in ${{ matrix.crates }}; do

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -33,7 +33,6 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ inputs.trusted && 'local' || 'github' }}
-          mirror-github-cache: "true"
       # Retries and a longer wait, rather than being allowed to fail. `cli`'s completion
       # tests refuse to skip a missing shell when `CI` is set — see
       # `skip_if_shell_missing` — which is a deliberate policy this step exists to keep:
@@ -149,7 +148,6 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: github
-          mirror-github-cache: "true"
       - run: mise r build
       # `usage bash` runs whatever Windows resolves `bash` to, and `CreateProcess` searches the
       # system directory before `PATH`. On this runner that is `C:\Windows\System32\bash.exe` —

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'local' || 'server' }}
+          backend: ${{ inputs.trusted && 'local' || 'github' }}
       # Retries and a longer wait, rather than being allowed to fail. `cli`'s completion
       # tests refuse to skip a missing shell when `CI` is set — see
       # `skip_if_shell_missing` — which is a deliberate policy this step exists to keep:
@@ -245,7 +245,7 @@ jobs:
           install_args: mr-boxington
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'local' || 'server' }}
+          backend: ${{ inputs.trusted && 'local' || 'github' }}
       - name: they build at the version they claim
         run: |
           for crate in ${{ matrix.crates }}; do

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -20,11 +20,6 @@ jobs:
     # Without this, a hung step sits until GitHub's 6-hour job limit.
     timeout-minutes: 30
     steps:
-      - name: Assert OIDC is unavailable to untrusted CI
-        if: ${{ !inputs.trusted }}
-        run: |
-          test -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}"
-          test -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
@@ -32,7 +27,7 @@ jobs:
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'local' || 'github' }}
+          backend: ${{ inputs.trusted && 'local' || 'server' }}
       # Retries and a longer wait, rather than being allowed to fail. `cli`'s completion
       # tests refuse to skip a missing shell when `CI` is set — see
       # `skip_if_shell_missing` — which is a deliberate policy this step exists to keep:
@@ -147,7 +142,7 @@ jobs:
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       - uses: ./.github/actions/mbx
         with:
-          backend: github
+          backend: server
       - run: mise r build
       # `usage bash` runs whatever Windows resolves `bash` to, and `CreateProcess` searches the
       # system directory before `PATH`. On this runner that is `C:\Windows\System32\bash.exe` —
@@ -250,7 +245,7 @@ jobs:
           install_args: mr-boxington
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'local' || 'github' }}
+          backend: ${{ inputs.trusted && 'local' || 'server' }}
       - name: they build at the version they claim
         run: |
           for crate in ${{ matrix.crates }}; do

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,6 @@ jobs:
     if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}
     permissions:
       contents: read
-      id-token: write
     uses: ./.github/workflows/test-impl.yml
     with:
       trusted: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
     if: ${{ github.actor == 'jdx' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')) }}
     permissions:
       contents: read
+      id-token: write
     uses: ./.github/workflows/test-impl.yml
     with:
       trusted: true
@@ -20,6 +21,7 @@ jobs:
     if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}
     permissions:
       contents: read
+      id-token: write
     uses: ./.github/workflows/test-impl.yml
     with:
       trusted: false

--- a/mise.lock
+++ b/mise.lock
@@ -458,44 +458,44 @@ checksum = "sha256:f0c0a0d33ba94f4d2c5dbc887334ce678b21813504ddb3aafcb06e60a5a66
 url = "https://dl.google.com/go/go1.27.0.windows-amd64.zip"
 
 [[tools.mr-boxington]]
-version = "1.4.1"
+version = "1.5.0"
 backend = "github:jdx/mr-boxington"
 
 [tools.mr-boxington."platforms.linux-arm64"]
-checksum = "sha256:7ca1deeb64ad22bd5ddc9f45c749c78d3eb32608562c363727de3f0c595df0f0"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505948"
+checksum = "sha256:3782db0c07a47334d01d426896e9f6af2480b311def2d0f0a3ab1327b57247b2"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541628921"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-arm64-musl"]
-checksum = "sha256:3113dfce87c8ee6d3485f7eb99f87ae130b9b9f2c73224720edf2cef7279b5d1"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505946"
+checksum = "sha256:95e189127cf22f6586b0e7337893896dfb18b2018c7226e60844955e237234b8"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541628922"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64"]
-checksum = "sha256:5bc7434333a941f664bbe73ae229edf6111c9fb5f771f959ca411a11358baf8a"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505965"
+checksum = "sha256:83a5f4cb83a62cf028256c482a9f579911cc0793f79f1c2c06b83291c5c723d0"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541629161"
 provenance = "github-attestations"
 provenance_verified = true
 
 [tools.mr-boxington."platforms.linux-x64-musl"]
-checksum = "sha256:7277ceabefae1b444b39200c2cb944018a87da628ff77aa94291a8cc338546e6"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505964"
+checksum = "sha256:8ffd1ffc4b53ce10ed1d0271e24d9d264e843b7be3f0a076389c4475a16e4132"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541629170"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.macos-arm64"]
-checksum = "sha256:57f1cac111d9972ad675aa80cbedf4c86b3423dfb11091383175db0f6341847e"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505945"
+checksum = "sha256:d88ebea6ebf1a5b8b4a51a440a91baeb1214fdea49a6013dfe9b56e4bd4a6c84"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541628925"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64"]
-checksum = "sha256:346cb0405129bbca4f7a24fc916b036cfd806d497d52ba47fc8bb0a0531b4382"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505963"
+checksum = "sha256:970f974d3ee56b089c34a4b03fdb80dfcc0b260b3de950009a77240c9187a4c7"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541629146"
 provenance = "github-attestations"
 
 [[tools.node]]

--- a/mise.toml
+++ b/mise.toml
@@ -5,7 +5,7 @@ CARGO_TERM_COLOR = 'always'
 _.path = ["./target/debug"]
 
 [tools]
-mr-boxington = "1.4.1"
+mr-boxington = "1.5.0"
 # Pinned rather than "latest" because tak is the measuring instrument: an
 # upgrade that changes how it samples would land in the series as a step change
 # in usage's numbers, indistinguishable from a real regression. Bump deliberately.


### PR DESCRIPTION
Route mbx storage according to the runner provider.

- Namespace jobs keep the local backend on the shared Namespace cache volume.
- GitHub-hosted Linux, macOS, and Windows jobs use the Azure-backed cache at `https://cache.jdx.dev` with GitHub OIDC.
- GitHub-hosted fork jobs use public, namespace-scoped read access when GitHub withholds OIDC; they receive no cache credential and cannot write.
- Authenticated pull requests and tags are also read-only; only protected `main` pushes may publish.
- No mbx cache tarballs are mirrored through GitHub Actions Cache.

Validation: actionlint; git diff --check

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI cache authentication and removes GitHub Actions cache mirroring; misconfigured OIDC or env could slow builds or affect fork vs trusted cache access, but scope is limited to CI tooling.
> 
> **Overview**
> **Replaces the `mr-boxington-action` + GitHub Actions cache mirror with a single composite action** that installs **mr-boxington 1.5.0** via mise and sets **`MBX_*` env** for either Namespace **local** storage or the **remote cache at `https://cache.jdx.dev`**.
> 
> Trusted Namespace jobs still use **`backend: local`**; GitHub-hosted jobs use **`backend: server`** (renamed from `github`). The **`mirror-github-cache`** input and main-branch mirror restore step are **removed**. Server mode wires **`MBX_REMOTE_URL`**, namespace, and **OIDC audience** when `ACTIONS_ID_TOKEN_REQUEST_URL` is present; otherwise it logs a notice and relies on **public read-only** access.
> 
> Workflow updates: **`test.yml`** grants **`id-token: write`** on the trusted path; **`test-impl.yml`** drops the untrusted OIDC assertion and stops passing **`mirror-github-cache`**. The mbx action also adds **Windows mise paths** under `runner.tool_cache` so install works on `windows-latest`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f7d88ff394d01c248095112c6059dbdef2328a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->