### PR TITLE
chore(ci): update performance runner image

### DIFF
--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -29,7 +29,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-usage-rust1.97.1
+  TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-usage-rust1.97.1-img5263c143
 
 jobs:
   authorize:
@@ -84,7 +84,7 @@ jobs:
     # the report would say "nothing was compared" instead of anything useful.
     runs-on: [self-hosted, jdx-perf-v1]
     container:
-      image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9
+      image: ghcr.io/jdx/perf-runner@sha256:5263c143b12ce2234e7b0b21d3d6501c2ed05837b42937d0eaeaa191cd5c8e68
       # Anonymous by design; perf-runner#10 prunes it after this container stops.
       options: --cpuset-cpus 0-7 --mount type=volume,dst=/var/cache/mbx
     timeout-minutes: 40
@@ -133,8 +133,8 @@ jobs:
           {
             echo '### Runner metadata'
             echo '```text'
-            echo 'environment-revision: perf-runner@6ab972a'
-            echo 'image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9'
+            echo 'environment-revision: perf-runner@fd66d9b'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:5263c143b12ce2234e7b0b21d3d6501c2ed05837b42937d0eaeaa191cd5c8e68'
             uname -a
             lscpu
             mise --version

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -27,7 +27,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-usage-rust1.97.1
+  TAK_RUNNER: jdx-perf-v1-ubuntu24.04-x64-usage-rust1.97.1-img5263c143
 
 jobs:
   measure:
@@ -41,7 +41,7 @@ jobs:
     # that wanders between runners is unreadable.
     runs-on: [self-hosted, jdx-perf-v1]
     container:
-      image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9
+      image: ghcr.io/jdx/perf-runner@sha256:5263c143b12ce2234e7b0b21d3d6501c2ed05837b42937d0eaeaa191cd5c8e68
       options: --cpuset-cpus 0-7 --mount type=bind,src=/var/cache/jdx-perf/mbx,dst=/var/cache/mbx
     timeout-minutes: 30
     permissions:
@@ -77,8 +77,8 @@ jobs:
           {
             echo '### Runner metadata'
             echo '```text'
-            echo 'environment-revision: perf-runner@6ab972a'
-            echo 'image: ghcr.io/jdx/perf-runner@sha256:6f35a3dec67758d195d8fd01103f10f6c7aeaf8815dd41bf2aa2726fa3e9d4a9'
+            echo 'environment-revision: perf-runner@fd66d9b'
+            echo 'image: ghcr.io/jdx/perf-runner@sha256:5263c143b12ce2234e7b0b21d3d6501c2ed05837b42937d0eaeaa191cd5c8e68'
             uname -a
             lscpu
             mise --version


### PR DESCRIPTION
## Summary

- pin performance workflows to the verified perf-runner image containing GitHub CLI
- report perf-runner revision fd66d9b in job summaries
- start a fresh TAK_RUNNER series for the rebuilt measurement environment

Image: `ghcr.io/jdx/perf-runner@sha256:5263c143b12ce2234e7b0b21d3d6501c2ed05837b42937d0eaeaa191cd5c8e68`

## Validation

- `actionlint`
- `git diff --check`

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only pinning of the self-hosted perf container; no application or auth changes, with the main effect being a deliberate break in comparability with measurements recorded under the old image until series baselines use the new label.
> 
> **Overview**
> Bumps the pinned **`ghcr.io/jdx/perf-runner`** container digest for both **`perf`** (main measurements) and **`perf-pr`** (PR instruction-count compare) so CI runs on **`perf-runner@fd66d9b`** instead of the previous image.
> 
> The **`TAK_RUNNER`** env label gains an **`-img5263c143`** suffix so `tak` can treat this image as a distinct runner environment, and the **Runner metadata** step logs the new revision and digest to match what jobs actually use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef3b0e99afff9321e549daee4ed7e9ce3c8c0db8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->