### PR TITLE
fix(parse): report next implicit clause argument

### DIFF
--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -1651,8 +1651,9 @@ fn parse_partial_traced(
     // Now that we've identified all subcommands and executed their mounts,
     // we can parse the remaining arguments, flags, and their values.
 
-    // The cursor into `out.cmd.args`, kept as an index rather than a reference because an
-    // explicit `--` may jump it *past* arguments that stay empty (see the `w == "--"` arm).
+    // The cursor into the active positional arguments, kept as an index rather than a reference
+    // because an explicit `--` may jump it *past* arguments that stay empty (see the `w == "--"`
+    // arm).
     // With such a gap `out.args.len()` no longer equals the cursor, so anything asking "is this
     // argument filled?" has to consult `out.args` by key instead of counting.
     let mut next_arg_idx = cursor_skip_sigils(&out.cmd, 0);
@@ -4857,9 +4858,7 @@ fn record_stop(
     trace: &mut Trace,
     unread: &VecDeque<Token>,
 ) {
-    out.next_arg = out
-        .cmd
-        .args
+    out.next_arg = active_args(&out.cmd)
         .get(cursor_skip_sigils(&out.cmd, next_arg_idx))
         .cloned()
         .map(Arc::new);
@@ -6554,6 +6553,25 @@ clause "tasks" separator=":::" {
 
         let err = parse(&spec, &input(&["ex", "--dump", "lint"])).unwrap_err();
         assert!(err.to_string().contains("on its own"), "{err}");
+    }
+
+    #[test]
+    fn a_partial_parse_reports_the_next_implicit_clause_argument() {
+        let spec: Spec = r#"name "ex"
+bin "ex"
+clause "tools" {
+  arg "<tool@version>"
+}
+"#
+        .parse()
+        .unwrap();
+
+        let parsed = parse_partial(&spec, &input(&["ex"])).unwrap();
+
+        assert_eq!(
+            parsed.next_arg.as_ref().map(|arg| arg.name.as_str()),
+            Some("tool@version")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- report the next implicit clause argument when a partial parse stops
- restore choices and custom completions for that argument on a bare command
- add a regression test for the parser's stopping position

## Problem

The parser tracks `next_arg_idx` against `active_args`, which selects `clause.args` for commands
with a clause. However, `record_stop` resolved that index against `cmd.args` directly. Because a
command cannot declare both top-level arguments and a clause, `cmd.args` is empty for clause
commands.

As a result, parsing a bare command with an implicit clause incorrectly returned
`ParseOutput::next_arg` as `None`, even though the clause's first argument was ready to accept a
value. Completion relies on `next_arg`, so it could not offer the argument's choices or invoke its
custom completer.

## Fix

Resolve the stopping position through `active_args`, matching the collection used by
`next_arg_idx` throughout parsing. Ordinary command arguments retain the existing behavior, while
clause commands now return the corresponding argument from `clause.args`. Update the cursor comment
to describe both cases and cover the implicit-clause case with a focused regression test.

## Testing

- `cargo test -p usage-lib --all-features a_partial_parse_reports_the_next_implicit_clause_argument`
- `cargo test -p usage-lib --all-features parse::tests`
- `mise run lint`
- `mise run lint-fix`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved partial command parsing for commands with clauses.
  - The reported next positional argument now correctly reflects the active clause context, helping users receive more accurate parsing and completion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->