### PR TITLE
feat(help): add semantic command styling

### DIFF
--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -823,7 +823,10 @@ fn styled_help(
                             entry
                                 .strip_prefix(usage)
                                 .filter(|rest| {
-                                    rest.is_empty() || rest.starts_with(char::is_whitespace)
+                                    // Command rows either end after the name or have the
+                                    // table's two-space separator. Group prose uses ordinary
+                                    // word spacing despite sharing the row indentation.
+                                    rest.is_empty() || rest.starts_with("  ")
                                 })
                                 .map(|rest| format!("  {}{rest}", style.command(usage)))
                         })
@@ -4488,7 +4491,7 @@ mod style_tests {
 
     #[test]
     fn coloured_help_styles_structure_without_changing_plain_text() {
-        let page = "A summary ending in:\nUsage: prose is not a synopsis\nExamples:\n\nUsage: ex [OPTIONS]\n       ex --all\n\nCommands:\n  build  Build it\n  help   Print help\n\nArguments:\n  <FILE>  Read this file\n\nOptions:\n  -f, --force  Force it\n    [possible values: --auto]\n    (default: -1)\n";
+        let page = "A summary ending in:\nUsage: prose is not a synopsis\nExamples:\n\nUsage: ex [OPTIONS]\n       ex --all\n\nCommands:\n  build these projects before publishing\n\n  build  Build it\n  help   Print help\n\nArguments:\n  <FILE>  Read this file\n\nOptions:\n  -f, --force  Force it\n    [possible values: --auto]\n    (default: -1)\n";
         let headings = vec![
             "Commands".to_string(),
             "Arguments".to_string(),
@@ -4530,6 +4533,8 @@ mod style_tests {
         assert!(coloured.contains("\u{1b}[1;35m<FILE>\u{1b}[0m"));
         assert!(coloured.contains("\u{1b}[1;32mbuild\u{1b}[0m  Build it"));
         assert!(coloured.contains("\u{1b}[1;32mhelp\u{1b}[0m   Print help"));
+        assert!(coloured.contains("  build these projects before publishing"));
+        assert!(!coloured.contains("\u{1b}[1;32mbuild\u{1b}[0m these projects"));
         assert!(coloured.contains("A summary ending in:\nUsage: prose is not a synopsis"));
         assert!(coloured.contains("Usage: prose is not a synopsis\nExamples:"));
         assert!(coloured.contains("ex \u{1b}[1;32m--all\u{1b}[0m"));

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -311,6 +311,10 @@ impl Style {
         template::semantic("metavar", text, self.coloured)
     }
 
+    fn command(self, text: &str) -> String {
+        template::semantic("command", text, self.coloured)
+    }
+
     /// Render the small Markdown vocabulary accepted in help prose.
     ///
     /// Plain output deliberately keeps the source spelling: generated artifacts and pipes
@@ -586,21 +590,39 @@ fn styled_flag_usage(usage: &str, style: Style) -> String {
     out
 }
 
+struct HelpStructure {
+    headings: Vec<String>,
+    command_usages: Vec<String>,
+    flag_usages: Vec<String>,
+    arg_usages: Vec<String>,
+    synopsis: Vec<String>,
+}
+
 fn help_structure(
     spec: &Spec<'_>,
     path: &[&str],
     chain: &[&CommandMeta<'_>],
     long: bool,
     inherit_version_actions: bool,
-) -> (Vec<String>, Vec<String>, Vec<String>, Vec<String>) {
+) -> HelpStructure {
     let meta = *chain.last().expect("a page is always about some command");
     let mut headings = Vec::new();
+    let mut command_usages = Vec::new();
     if !meta.examples.is_empty() {
         headings.push("Examples".to_string());
     }
     if meta.flatten_help {
         flat_help_headings(&path[1.min(path.len())..], meta, &mut headings);
     } else if meta.subcommands.iter().any(|sub| !sub.hide) {
+        command_usages.extend(
+            meta.subcommands
+                .iter()
+                .filter(|sub| !sub.hide)
+                .map(|sub| sub.cmd.name.to_string()),
+        );
+        if !meta.cmd.disable_help_subcommand {
+            command_usages.push(HELP_SUBCOMMAND.to_string());
+        }
         headings.push(
             meta.subcommand_help_heading
                 .unwrap_or("Commands")
@@ -679,11 +701,18 @@ fn help_structure(
     }
     arg_usages.sort_unstable_by_key(|usage| core::cmp::Reverse(usage.len()));
     flag_usages.sort_unstable_by_key(|usage| core::cmp::Reverse(usage.len()));
+    command_usages.sort_unstable_by_key(|usage| core::cmp::Reverse(usage.len()));
 
     let mut synopsis = String::new();
     usage_section(&mut synopsis, spec, path, meta);
     let synopsis = synopsis.lines().map(str::to_string).collect();
-    (headings, flag_usages, arg_usages, synopsis)
+    HelpStructure {
+        headings,
+        command_usages,
+        flag_usages,
+        arg_usages,
+        synopsis,
+    }
 }
 
 fn flat_help_usages(
@@ -745,6 +774,7 @@ fn styled_help(
     page: &str,
     style: Style,
     headings: &[String],
+    command_usages: &[String],
     flag_usages: &[String],
     arg_usages: &[String],
     synopsis: &[String],
@@ -788,6 +818,16 @@ fn styled_help(
                                 .map(|rest| format!("  {}{rest}", styled_flag_usage(usage, style)))
                         })
                     })
+                    .or_else(|| {
+                        command_usages.iter().find_map(|usage| {
+                            entry
+                                .strip_prefix(usage)
+                                .filter(|rest| {
+                                    rest.is_empty() || rest.starts_with(char::is_whitespace)
+                                })
+                                .map(|rest| format!("  {}{rest}", style.command(usage)))
+                        })
+                    })
             });
             // Examples are shell source, where paired backticks are command substitution rather
             // than prose markup. Every other non-structural line may contain author emphasis;
@@ -818,8 +858,7 @@ fn assembled_help(
     } else {
         short_sections(spec, path, chain, inherit_version_actions)
     };
-    let (headings, flag_usages, arg_usages, synopsis) =
-        help_structure(spec, path, chain, long, inherit_version_actions);
+    let structure = help_structure(spec, path, chain, long, inherit_version_actions);
     let page = match spec
         .help_template
         .filter(|template| !template.trim().is_empty())
@@ -829,20 +868,22 @@ fn assembled_help(
                 styled_help(
                     &part,
                     style,
-                    &headings,
-                    &flag_usages,
-                    &arg_usages,
-                    &synopsis,
+                    &structure.headings,
+                    &structure.command_usages,
+                    &structure.flag_usages,
+                    &structure.arg_usages,
+                    &structure.synopsis,
                 )
             })
         }),
         None => styled_help(
             &sections.concatenated(),
             style,
-            &headings,
-            &flag_usages,
-            &arg_usages,
-            &synopsis,
+            &structure.headings,
+            &structure.command_usages,
+            &structure.flag_usages,
+            &structure.arg_usages,
+            &structure.synopsis,
         ),
     };
     finish_page(page, style)
@@ -4447,8 +4488,13 @@ mod style_tests {
 
     #[test]
     fn coloured_help_styles_structure_without_changing_plain_text() {
-        let page = "A summary ending in:\nUsage: prose is not a synopsis\nExamples:\n\nUsage: ex [OPTIONS]\n       ex --all\n\nArguments:\n  <FILE>  Read this file\n\nOptions:\n  -f, --force  Force it\n    [possible values: --auto]\n    (default: -1)\n";
-        let headings = vec!["Arguments".to_string(), "Options".to_string()];
+        let page = "A summary ending in:\nUsage: prose is not a synopsis\nExamples:\n\nUsage: ex [OPTIONS]\n       ex --all\n\nCommands:\n  build  Build it\n  help   Print help\n\nArguments:\n  <FILE>  Read this file\n\nOptions:\n  -f, --force  Force it\n    [possible values: --auto]\n    (default: -1)\n";
+        let headings = vec![
+            "Commands".to_string(),
+            "Arguments".to_string(),
+            "Options".to_string(),
+        ];
+        let command_usages = vec!["build".to_string(), "help".to_string()];
         let usages = vec!["-f, --force".to_string()];
         let arg_usages = vec!["<FILE>".to_string()];
         let synopsis = vec![
@@ -4460,6 +4506,7 @@ mod style_tests {
                 page,
                 Style::PLAIN,
                 &headings,
+                &command_usages,
                 &usages,
                 &arg_usages,
                 &synopsis
@@ -4471,6 +4518,7 @@ mod style_tests {
             page,
             Style::COLOURED,
             &headings,
+            &command_usages,
             &usages,
             &arg_usages,
             &synopsis,
@@ -4480,12 +4528,57 @@ mod style_tests {
         assert!(coloured.contains("\u{1b}[1;32m-f\u{1b}[0m"));
         assert!(coloured.contains("\u{1b}[1;32m--force\u{1b}[0m"));
         assert!(coloured.contains("\u{1b}[1;35m<FILE>\u{1b}[0m"));
+        assert!(coloured.contains("\u{1b}[1;32mbuild\u{1b}[0m  Build it"));
+        assert!(coloured.contains("\u{1b}[1;32mhelp\u{1b}[0m   Print help"));
         assert!(coloured.contains("A summary ending in:\nUsage: prose is not a synopsis"));
         assert!(coloured.contains("Usage: prose is not a synopsis\nExamples:"));
         assert!(coloured.contains("ex \u{1b}[1;32m--all\u{1b}[0m"));
         assert!(coloured.contains("[possible values: --auto]"));
         assert!(coloured.contains("(default: -1)"));
         assert_eq!(strip_ansi(&coloured), page);
+    }
+
+    #[test]
+    fn rendered_command_rows_receive_command_style() {
+        let build_command = Command {
+            name: "build",
+            ..Command::EMPTY
+        };
+        let root_command = Command {
+            name: "ex",
+            subcommands: &[&build_command],
+            ..Command::EMPTY
+        };
+        let build_meta = CommandMeta {
+            cmd: &build_command,
+            about: Some("Build it"),
+            ..CommandMeta::EMPTY
+        };
+        let root_meta = CommandMeta {
+            cmd: &root_command,
+            subcommands: &[&build_meta],
+            ..CommandMeta::EMPTY
+        };
+        let spec = Spec {
+            name: "ex",
+            root: &root_meta,
+            ..Spec::EMPTY
+        };
+
+        let plain = render_styled(&spec, &root_command, false, Style::PLAIN).expect("root help");
+        let coloured =
+            render_styled(&spec, &root_command, false, Style::COLOURED).expect("root help");
+        assert!(
+            coloured.contains("\u{1b}[1;32mbuild\u{1b}[0m  Build it"),
+            "{coloured:?}"
+        );
+        assert!(
+            coloured.contains(
+                "\u{1b}[1;32mhelp\u{1b}[0m   Print this message or the help of the given subcommand(s)"
+            ),
+            "{coloured:?}"
+        );
+        assert_eq!(strip_ansi(&coloured), plain);
     }
 
     #[test]
@@ -4654,7 +4747,7 @@ mod style_tests {
     #[test]
     fn coloured_help_renders_inline_markdown_emphasis() {
         let page = "Use **force** for *all* files, _including_hidden_, `--literally`, and ~~never~~ this.\n  --dry_run  Keep snake_case and an unmatched * glob\n\nExamples:\n    $ echo `date`\n";
-        let coloured = styled_help(page, Style::COLOURED, &[], &[], &[], &[]);
+        let coloured = styled_help(page, Style::COLOURED, &[], &[], &[], &[], &[]);
 
         assert!(
             coloured.contains("\u{1b}[1mforce\u{1b}[22m"),

--- a/argv/src/help/template.rs
+++ b/argv/src/help/template.rs
@@ -8,10 +8,11 @@ const MARK: char = '\u{2}';
 const END: char = '\u{3}';
 
 /// The styles accepted in a help template.
-pub const STYLES: [&str; 23] = [
+pub const STYLES: [&str; 24] = [
     "heading",
     "option",
     "metavar",
+    "command",
     "black",
     "red",
     "green",
@@ -60,6 +61,10 @@ impl AnsiStyle {
                 }
                 "metavar" => {
                     self.foreground = Some(35);
+                    self.bold = true;
+                }
+                "command" => {
+                    self.foreground = Some(32);
                     self.bold = true;
                 }
                 "black" => self.foreground = Some(30),

--- a/conformance/tests/help_template.rs
+++ b/conformance/tests/help_template.rs
@@ -198,7 +198,7 @@ struct EverySection {
 #[derive(Cli)]
 #[usage(
     bin = "every-style",
-    help_template = "{$heading}heading{/$} {$option}option{/$} {$metavar}metavar{/$} {$black}black{/$} {$red}red{/$} {$green}green{/$} {$yellow}yellow{/$} {$blue}blue{/$} {$magenta}magenta{/$} {$cyan}cyan{/$} {$white}white{/$} {$bright-black}bright-black{/$} {$bright-red}bright-red{/$} {$bright-green}bright-green{/$} {$bright-yellow}bright-yellow{/$} {$bright-blue}bright-blue{/$} {$bright-magenta}bright-magenta{/$} {$bright-cyan}bright-cyan{/$} {$bright-white}bright-white{/$} {$bold}bold{/$} {$dim}dim{/$} {$italic}italic{/$} {$underline}underline{/$}"
+    help_template = "{$heading}heading{/$} {$option}option{/$} {$metavar}metavar{/$} {$command}command{/$} {$black}black{/$} {$red}red{/$} {$green}green{/$} {$yellow}yellow{/$} {$blue}blue{/$} {$magenta}magenta{/$} {$cyan}cyan{/$} {$white}white{/$} {$bright-black}bright-black{/$} {$bright-red}bright-red{/$} {$bright-green}bright-green{/$} {$bright-yellow}bright-yellow{/$} {$bright-blue}bright-blue{/$} {$bright-magenta}bright-magenta{/$} {$bright-cyan}bright-cyan{/$} {$bright-white}bright-white{/$} {$bold}bold{/$} {$dim}dim{/$} {$italic}italic{/$} {$underline}underline{/$}"
 )]
 struct EveryStyle {}
 

--- a/corpus/help-template-styles.txt
+++ b/corpus/help-template-styles.txt
@@ -1,6 +1,7 @@
 heading
 option
 metavar
+command
 black
 red
 green

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -4519,10 +4519,11 @@ const HELP_SECTIONS: [&str; 10] = [
     "after_help",
 ];
 
-const HELP_STYLES: [&str; 23] = [
+const HELP_STYLES: [&str; 24] = [
     "heading",
     "option",
     "metavar",
+    "command",
     "black",
     "red",
     "green",

--- a/docs/rust/help.md
+++ b/docs/rust/help.md
@@ -215,12 +215,13 @@ Template-authored text and whole sections may be styled with runtime, bunt-like 
 ```
 
 An opening `{$…}` tag applies until its matching `{/$}` and tags may nest. Join styles with `+`,
-as in `{$bold+bright-blue}`. `heading`, `option`, and `metavar` use usage's semantic palette. The
-physical vocabulary contains `black`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, and
-`white`; each `bright-` variant; and `bold`, `dim`, `italic`, and `underline`. Terminal output
-renders the ANSI styles. Plain output and generated Go pages remove the tags while retaining their
-contents. Double the dollar sign to write either delimiter literally: `{$$heading}` renders
-`{$heading}`, and `{/$$}` renders `{/$}`.
+as in `{$bold+bright-blue}`. `heading`, `option`, `metavar`, and `command` use usage's semantic
+palette. Headings are bold yellow by default, options and commands are bold green, and
+metavariables are bold magenta. The physical vocabulary contains `black`, `red`, `green`, `yellow`,
+`blue`, `magenta`, `cyan`, and `white`; each `bright-` variant; and `bold`, `dim`, `italic`, and
+`underline`. Terminal output renders the ANSI styles. Plain output and generated Go pages remove
+the tags while retaining their contents. Double the dollar sign to write either delimiter
+literally: `{$$heading}` renders `{$heading}`, and `{/$$}` renders `{/$}`.
 
 The reference renderer keeps `usage::docs::cli::render_help` plain for generated artifacts and
 snapshots. A process printing a dynamically parsed spec should call `render_help_styled` with

--- a/docs/spec/reference/index.md
+++ b/docs/spec/reference/index.md
@@ -100,12 +100,13 @@ sections may carry terminal styles with `{$style}…{/$}`:
 help_template "{$heading}My tool{/$}\n\n{{usage}}\n\n{$cyan}{{flags}}{/$}"
 ```
 
-Styles may be combined with `+`. The semantic styles are `heading`, `option`, and
-`metavar`; the physical styles are the eight ANSI colour names, their `bright-`
-variants, `bold`, `dim`, `italic`, and `underline`. Plain and generated help removes
-the tags. Tags in substituted descriptions are ordinary prose rather than template
-markup. Double the dollar sign to write a delimiter literally: `{$$heading}` renders
-`{$heading}`, and `{/$$}` renders `{/$}`.
+Styles may be combined with `+`. The semantic styles are `heading`, `option`,
+`metavar`, and `command`. Headings are bold yellow by default, options and commands
+are bold green, and metavariables are bold magenta. The physical styles are the eight
+ANSI colour names, their `bright-` variants, `bold`, `dim`, `italic`, and `underline`.
+Plain and generated help removes the tags. Tags in substituted descriptions are
+ordinary prose rather than template markup. Double the dollar sign to write a delimiter
+literally: `{$$heading}` renders `{$heading}`, and `{/$$}` renders `{/$}`.
 
 ## Root command policy
 

--- a/go/argv/sections.go
+++ b/go/argv/sections.go
@@ -37,7 +37,7 @@ var HelpSections = [...]string{
 
 // HelpStyles is the closed style vocabulary accepted by HelpTemplate.
 var HelpStyles = [...]string{
-	"heading", "option", "metavar",
+	"heading", "option", "metavar", "command",
 	"black", "red", "green", "yellow", "blue", "magenta", "cyan", "white",
 	"bright-black", "bright-red", "bright-green", "bright-yellow", "bright-blue",
 	"bright-magenta", "bright-cyan", "bright-white",

--- a/lib/src/docs/cli/mod.rs
+++ b/lib/src/docs/cli/mod.rs
@@ -2107,4 +2107,49 @@ flag "--output <FILE>" help="Write **the file**"
             "{coloured:?}"
         );
     }
+
+    #[test]
+    fn command_style_does_not_match_command_group_prose() {
+        let spec = crate::spec! { r#"
+bin "testcli"
+heading "Build commands" help="build these projects before publishing"
+cmd "build" help="Build it" help_heading="Build commands"
+        "# }
+        .unwrap();
+
+        let coloured = render_help_styled(&spec, &spec.cmd, true, Style::COLOURED);
+        assert!(
+            coloured.contains("  build these projects before publishing"),
+            "{coloured:?}"
+        );
+        assert!(
+            coloured.contains("\u{1b}[1;32mbuild\u{1b}[0m  Build it"),
+            "{coloured:?}"
+        );
+        assert!(
+            !coloured.contains("\u{1b}[1;32mbuild\u{1b}[0m these projects"),
+            "{coloured:?}"
+        );
+    }
+
+    #[test]
+    fn flattened_help_does_not_apply_command_style() {
+        let spec = crate::spec! { r#"
+bin "testcli"
+flatten_help #true
+help_template "Intro\n  run  should stay prose\n\n{{commands}}"
+cmd "run" help="Run it"
+        "# }
+        .unwrap();
+
+        let coloured = render_help_styled(&spec, &spec.cmd, true, Style::COLOURED);
+        assert!(
+            coloured.contains("  run  should stay prose"),
+            "{coloured:?}"
+        );
+        assert!(
+            !coloured.contains("\u{1b}[1;32mrun\u{1b}[0m"),
+            "{coloured:?}"
+        );
+    }
 }

--- a/lib/src/docs/cli/mod.rs
+++ b/lib/src/docs/cli/mod.rs
@@ -188,7 +188,12 @@ pub fn render_help_styled(spec: &Spec, cmd: &SpecCommand, long: bool, style: Sty
     };
     let rendered = TERA.render(template, &ctx).unwrap();
     let sections = Sections::split(&rendered);
-    let styling = style::Styling::new(&docs_cmd, &inherited, sections.usage);
+    let styling = style::Styling::new(
+        &docs_cmd,
+        &inherited,
+        sections.usage,
+        !cmd.disable_help_subcommand,
+    );
     let page = match spec
         .help_template
         .as_deref()
@@ -2051,7 +2056,8 @@ cmd "run" help="Run it" {
     fn styled_help_colours_semantics_and_template_styles() {
         let mut spec = crate::spec! { r#"
 bin "testcli"
-help_template "{$bright-blue}My tool{/$}\n\n{{usage}}\n\n{{flags}}\n\n{{after_help}}"
+help_template "{$bright-blue}My tool{/$}\n\n{{usage}}\n\n{{commands}}\n\n{{flags}}\n\n{{after_help}}"
+cmd "build" help="Build it"
 flag "--output <FILE>" help="Write **the file**"
         "# }
         .unwrap();
@@ -2080,6 +2086,16 @@ flag "--output <FILE>" help="Write **the file**"
         );
         assert!(
             coloured.contains("\u{1b}[1;35m<FILE>\u{1b}[0m"),
+            "{coloured:?}"
+        );
+        assert!(
+            coloured.contains("\u{1b}[1;32mbuild\u{1b}[0m  Build it"),
+            "{coloured:?}"
+        );
+        assert!(
+            coloured.contains(
+                "\u{1b}[1;32mhelp\u{1b}[0m   Print this message or the help of the given subcommand(s)"
+            ),
             "{coloured:?}"
         );
         assert!(

--- a/lib/src/docs/cli/style.rs
+++ b/lib/src/docs/cli/style.rs
@@ -47,6 +47,7 @@ impl Style {
 
 pub(super) struct Styling {
     headings: Vec<String>,
+    command_usages: Vec<String>,
     flag_usages: Vec<String>,
     arg_usages: Vec<String>,
     synopsis: Vec<String>,
@@ -57,6 +58,7 @@ impl Styling {
         command: &SpecCommand,
         global_flags: &[SpecFlag],
         usage_section: &str,
+        show_help_subcommand: bool,
     ) -> Self {
         let mut headings = vec!["Examples".to_string()];
         headings.extend(command.subcommand_groups.iter().map(|group| {
@@ -82,6 +84,16 @@ impl Styling {
             headings.push("Global flags".to_string());
         }
 
+        let mut command_usages: Vec<String> = command
+            .subcommand_groups
+            .iter()
+            .flat_map(|group| group.items.iter())
+            .map(|command| command.name.clone())
+            .collect();
+        if !command_usages.is_empty() && !command.flatten_help && show_help_subcommand {
+            command_usages.push("help".to_string());
+        }
+        command_usages.sort_unstable_by_key(|usage| std::cmp::Reverse(usage.len()));
         let mut flag_usages = command
             .flag_groups
             .iter()
@@ -105,6 +117,7 @@ impl Styling {
         arg_usages.sort_unstable_by_key(|usage| std::cmp::Reverse(usage.len()));
         Self {
             headings,
+            command_usages,
             flag_usages,
             arg_usages,
             synopsis: usage_section.lines().map(str::to_string).collect(),
@@ -140,6 +153,11 @@ impl Styling {
                             self.arg_usages
                                 .iter()
                                 .find_map(|usage| style_entry(entry, usage, style))
+                        })
+                        .or_else(|| {
+                            self.command_usages
+                                .iter()
+                                .find_map(|usage| style_command_entry(entry, usage, style))
                         })
                 });
                 let body = styled.as_deref().unwrap_or(body);
@@ -186,6 +204,13 @@ fn style_entry(entry: &str, usage: &str, style: Style) -> Option<String> {
         .strip_prefix(usage)
         .filter(|rest| rest.is_empty() || rest.starts_with(char::is_whitespace))
         .map(|rest| format!("  {}{rest}", styled_usage(usage, style)))
+}
+
+fn style_command_entry(entry: &str, usage: &str, style: Style) -> Option<String> {
+    entry
+        .strip_prefix(usage)
+        .filter(|rest| rest.is_empty() || rest.starts_with(char::is_whitespace))
+        .map(|rest| format!("  {}{rest}", style.semantic("command", usage)))
 }
 
 fn styled_usage(usage: &str, style: Style) -> String {

--- a/lib/src/docs/cli/style.rs
+++ b/lib/src/docs/cli/style.rs
@@ -84,13 +84,17 @@ impl Styling {
             headings.push("Global flags".to_string());
         }
 
-        let mut command_usages: Vec<String> = command
-            .subcommand_groups
-            .iter()
-            .flat_map(|group| group.items.iter())
-            .map(|command| command.name.clone())
-            .collect();
-        if !command_usages.is_empty() && !command.flatten_help && show_help_subcommand {
+        let mut command_usages: Vec<String> = if command.flatten_help {
+            Vec::new()
+        } else {
+            command
+                .subcommand_groups
+                .iter()
+                .flat_map(|group| group.items.iter())
+                .map(|command| command.name.clone())
+                .collect()
+        };
+        if !command_usages.is_empty() && show_help_subcommand {
             command_usages.push("help".to_string());
         }
         command_usages.sort_unstable_by_key(|usage| std::cmp::Reverse(usage.len()));
@@ -209,7 +213,9 @@ fn style_entry(entry: &str, usage: &str, style: Style) -> Option<String> {
 fn style_command_entry(entry: &str, usage: &str, style: Style) -> Option<String> {
     entry
         .strip_prefix(usage)
-        .filter(|rest| rest.is_empty() || rest.starts_with(char::is_whitespace))
+        // A rendered row either ends after the name or has the table's two-space column
+        // separator. Group prose has the same indentation, but ordinary word spacing.
+        .filter(|rest| rest.is_empty() || rest.starts_with("  "))
         .map(|rest| format!("  {}{rest}", style.semantic("command", usage)))
 }
 

--- a/lib/src/help_template.rs
+++ b/lib/src/help_template.rs
@@ -37,10 +37,11 @@ pub const SECTIONS: [&str; 10] = [
 ];
 
 /// The styles a template may apply to its own text or to a rendered section.
-pub const STYLES: [&str; 23] = [
+pub const STYLES: [&str; 24] = [
     "heading",
     "option",
     "metavar",
+    "command",
     "black",
     "red",
     "green",
@@ -92,6 +93,10 @@ impl AnsiStyle {
                 }
                 "metavar" => {
                     self.foreground = Some(35);
+                    self.bold = true;
+                }
+                "command" => {
+                    self.foreground = Some(32);
                     self.bold = true;
                 }
                 "black" => self.foreground = Some(30),


### PR DESCRIPTION
## Summary

- add a `command` semantic help style with bold green defaults
- color visible subcommand names and the synthetic `help` row in both Rust renderers
- keep the derive, KDL, Go, and shared conformance vocabularies aligned
- document the semantic palette

Closes #1374

## Tests

- `cargo test --workspace --all-features --exclude gate`
- `cargo clippy --all --all-features --all-targets -- -D warnings`
- focused usage-lib, usage-argv, and help-template conformance tests
- `cargo fmt --all -- --check`
- `npx --yes prettier@latest -w docs/rust/help.md docs/spec/reference/index.md`

The full local gate could not run because this machine has mise 2026.6.13 while the repository requires 2026.8.16; Go and a few shell integration dependencies are also supplied by that managed toolchain.

_This pull request was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Help presentation-only changes with no parsing or spec behavior impact; plain and generated artifacts stay compatible.
> 
> **Overview**
> Coloured terminal help now highlights **subcommand names** (and the built-in **`help`** row when shown) with a new **`command`** semantic style—bold green, same palette family as options. Plain output is unchanged; stripping ANSI still yields byte-identical pages.
> 
> Both render paths pick this up: **`usage-argv`** collects `command_usages` in a refactored **`HelpStructure`** and applies them in **`styled_help`** with row-aware matching (two-space table separator), so **command-group prose** like `build these projects…` is not mistaken for a command row. **`usage-lib`** mirrors the same logic in **`Styling`**, including skipping command names under **`flatten_help`**.
> 
> **`{$command}…{/$}`** is added to the closed help-template style vocabulary everywhere it is validated—**derive**, **corpus**, **Go `HelpStyles`**, and **shared template parsers**—and docs note that **`heading`**, **`option`**, **`metavar`**, and **`command`** are the semantic tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07d0dbd4ea378c570ddb3be93fbe9cc0cb224aa7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added command-specific styling to help output, rendering subcommands and the built-in `help` command in bold green when color is enabled.
  * Added `command` as a supported help-template style.

* **Bug Fixes**
  * Prevented ordinary group prose and flattened help text from being incorrectly styled as commands.

* **Documentation**
  * Updated help-template references to document command styling and its default appearance.

* **Tests**
  * Expanded coverage for styled command rows, prose handling, and the new template style.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->