### PR TITLE
feat(release): notarize the macOS binary

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -118,10 +118,92 @@ jobs:
           include: cli/assets/usage.1
           codesign: "Developer ID Application: Jeffrey Dickey (4993Y37DX6)"
           codesign_prefix: dev.jdx.
+          # Apple will not notarize a binary without the hardened runtime.
+          codesign_options: runtime
           dry-run: ${{ github.event_name == 'workflow_dispatch' }}
         env:
           CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
           CARGO_PROFILE_RELEASE_LTO: true
+      # Signing settles who built the binary; notarization is what Gatekeeper
+      # demands once an archive carries the quarantine bit, which is to say
+      # whenever someone downloads it in a browser rather than with curl.
+      # Without a ticket it is blocked behind a "cannot be verified" dialog that
+      # only a deliberate override gets past.
+      #
+      # The ticket lives on Apple's side and is keyed to the binary's cdhash, so
+      # nothing here rewrites what was already built or uploaded -- stapling
+      # would, but `stapler` only writes into bundles, disk images, and
+      # installer packages, and this is a bare Mach-O in an archive. Gatekeeper
+      # resolves the ticket online instead.
+      - name: Notarize macOS binary
+        if: matrix.os == 'macos-latest'
+        shell: bash
+        env:
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          BINARIES: target/${{ matrix.target }}/release/usage
+        run: |
+          set -euo pipefail
+
+          if [ -z "$APPLE_API_KEY_P8" ] || [ -z "$APPLE_API_KEY_ID" ] || [ -z "$APPLE_API_ISSUER_ID" ]; then
+            echo "::warning title=Not notarized::App Store Connect credentials are unset, so this release ships signed but un-notarized macOS binaries. Gatekeeper will block them for anyone who downloads an archive through a browser."
+            exit 0
+          fi
+
+          # Outside the workspace, so no later step can sweep the key into an
+          # artifact, and removed even when notarization fails.
+          work="$(mktemp -d)"
+          trap 'rm -rf "$work"' EXIT
+          printf '%s' "$APPLE_API_KEY_P8" | base64 --decode > "$work/key.p8"
+
+          # notarytool takes a container, never a bare executable. Copies are
+          # fine: a Mach-O carries its signature inline, so the cdhash the
+          # ticket is keyed to is the one already shipped.
+          mkdir "$work/stage"
+          for binary in $BINARIES; do
+            cp "$binary" "$work/stage/"
+          done
+          # Apple rejects a binary without the hardened runtime or a secure
+          # timestamp. Naming a missing one here turns an opaque Invalid verdict
+          # into a diagnosis; Apple stays the authority on whether to accept.
+          for binary in $BINARIES; do
+            details="$(codesign --display --verbose=4 "$binary" 2>&1 || true)"
+            case "$details" in
+              *runtime*) ;;
+              *) echo "::warning title=No hardened runtime::$binary is signed without --options runtime, which Apple requires; expect an Invalid verdict below." ;;
+            esac
+            case "$details" in
+              *Timestamp=*) ;;
+              *) echo "::warning title=No secure timestamp::$binary carries no secure timestamp, which Apple requires; expect an Invalid verdict below." ;;
+            esac
+          done
+
+          ditto -c -k --norsrc --noextattr "$work/stage" "$work/submission.zip"
+
+          # `--wait` is not a gate on its own: it can return zero on an Invalid
+          # submission, so the reported status is what decides. plutil reads
+          # JSON and ships with macOS, which keeps this off jq.
+          result="$(xcrun notarytool submit "$work/submission.zip" \
+            --key "$work/key.p8" \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER_ID" \
+            --output-format json \
+            --timeout 30m \
+            --wait)"
+          echo "$result"
+
+          status="$(printf '%s' "$result" | plutil -extract status raw -o - -)"
+          id="$(printf '%s' "$result" | plutil -extract id raw -o - -)"
+          if [ "$status" != "Accepted" ]; then
+            echo "::error::notarization returned $status for submission $id"
+            xcrun notarytool log "$id" \
+              --key "$work/key.p8" \
+              --key-id "$APPLE_API_KEY_ID" \
+              --issuer "$APPLE_API_ISSUER_ID" || true
+            exit 1
+          fi
+          echo "notarized: submission $id"
   release:
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
usage is the last jdx.dev CLI that signs its macOS binary without notarizing
it. mise, hk, fnox, pitchfork, and packslip all submit to `notarytool`; this
brings usage in line.

A signature settles who built the binary. Notarization is what Gatekeeper
demands once a download carries the quarantine bit — whenever someone fetches
an archive through a browser rather than with curl. Without a ticket the
binary sits behind the "cannot be verified" dialog that only a deliberate
override gets past.

Two changes:

- `codesign_options: runtime` on the existing `upload-rust-binary-action`
  step. Apple rejects a submission signed without the hardened runtime, and
  that input is the only part of the signature the action exposes. The secure
  timestamp Apple also requires is `codesign`'s own default for a Developer ID
  identity, so it needs no flag.
- A notarize step that submits the built `universal-apple-darwin` binary and
  requires an `Accepted` verdict. `--wait` is not a gate on its own — it can
  return zero on an `Invalid` submission — so the reported status is what
  decides, and the notary log is dumped before failing.

Nothing is stapled. The ticket is keyed to the binary's cdhash and lives on
Apple's side, so this rewrites neither the archive nor the uploaded asset;
`stapler` only writes into bundles, disk images, and installer packages, and
this is a bare Mach-O in an archive. Gatekeeper resolves the ticket online.

## Secrets

This repository has `APPLE_DEVELOPER_ID_APPLICATION_CERTS_P12` and its
password, but none of the App Store Connect credentials the other repos got on
2026-08-26. Three are needed, and they are the same values already in
`jdx/mise`, `jdx/hk`, `jdx/fnox`, and `jdx/pitchfork`:

- `APPLE_API_KEY_P8` — the base64-encoded `.p8`
- `APPLE_API_KEY_ID`
- `APPLE_API_ISSUER_ID`

The step follows hk's behaviour when they are missing: it warns that the
release ships signed but un-notarized and carries on, rather than failing the
build. So this is safe to merge before the secrets are added — releases keep
working, and the warning is visible in the job log until they land.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.176.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the macOS CI release workflow; missing API secrets only warn, though configured credentials make notarization failure block the macOS publish job.
> 
> **Overview**
> Adds **Apple notarization** to the `publish-cli` macOS release path so browser downloads pass Gatekeeper, matching the other jdx.dev CLIs.
> 
> The existing `upload-rust-binary-action` step now sets **`codesign_options: runtime`** (required for notarization). A new **Notarize macOS binary** job runs only on `macos-latest`: it stages the built `usage` binary, zips it for `notarytool`, checks for hardened runtime and secure timestamp (workflow warnings only), submits with App Store Connect API secrets, and **fails the job** unless Apple returns **`Accepted`** (with notary logs on failure). API key material is decoded in a temp directory and removed on exit.
> 
> If **`APPLE_API_KEY_*` secrets are missing**, the step emits a **workflow warning** and skips notarization so signed-but-un-notarized releases can still ship until credentials are added. **No stapling** — Gatekeeper is expected to validate the online ticket for the shipped Mach-O.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4829238ae29c2bd3a7eb026b554273997f9a9c61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - macOS command-line binaries are now signed with enhanced security protections.
  - Releases can now be notarized by Apple, helping macOS recognize the binaries as trusted software and reducing security warnings during installation or execution.
  - Notarization is applied when the required release credentials are available; otherwise, the signed binary remains available without notarization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->