### PR TITLE
ci(release): publish a signed packslip with each release

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -204,10 +204,57 @@ jobs:
             exit 1
           fi
           echo "notarized: submission $id"
+  # The packslip is this release's signed inventory: every archive's digest,
+  # the executable and man page inside it, the shared objects it needs from
+  # the host, and the workflow identity that signed for all of it. An
+  # installer checks a download against jdx/usage's identity rather than
+  # against a key this project would have to hold. See https://packslip.dev.
+  #
+  # Its own job because build-and-publish uploads straight to the release from
+  # each runner; one document covering the whole release can only be written
+  # once every target has landed.
+  packslip:
+    name: Publish the packslip
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [build-and-publish]
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Download the release assets
+        run: |
+          mkdir -p dist
+          gh release download "$GITHUB_REF_NAME" --repo "$REPO" --dir dist --clobber \
+            --pattern 'usage-*.tar.gz' --pattern 'usage-*.zip'
+          ls -la dist
+        env:
+          REPO: ${{ github.repository }}
+      # usage is the tool that reads these specs, so it prints its own. A
+      # consumer generates completions and documentation from the file with
+      # its own copy of usage, and nothing of this release's has to run.
+      - name: Publish the CLI specification
+        run: |
+          mkdir -p bin
+          tar -xzf dist/usage-x86_64-unknown-linux-gnu.tar.gz -C bin
+          bin/usage --usage-spec > usage.usage.kdl
+          gh release upload "$GITHUB_REF_NAME" usage.usage.kdl --repo "$REPO" --clobber
+        env:
+          REPO: ${{ github.repository }}
+      - uses: jdx/packslip@433c0c0f033e64c22f12433471768c255ef2bd93 # v0.3.0
+        with:
+          artifacts: dist/usage-*.tar.gz dist/usage-*.zip
+          bin: usage
+          resources: |
+            man=archive:usage.1
+            cli-spec/usage=asset:usage.usage.kdl
+
   release:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [build-and-publish, enhance-release]
+    needs: [build-and-publish, enhance-release, packslip]
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     permissions:
       contents: write


### PR DESCRIPTION
Part of adopting [packslip](https://packslip.dev) across the jdx.dev CLIs.

Each release now publishes `packslip.sigstore.json` beside the archives — one signed document listing:

- every archive's sha256 and sha512
- the executable inside each one (`usage`, `usage.exe` on Windows) and the `usage.1` man page beside it
- the shared objects each build needs from the host, read out of the binaries — `vcruntime140.dll` on Windows, nothing on Linux or macOS
- a build-provenance attestation per file, linked by digest
- the source repo, tag, and commit

signed keylessly with this workflow's OIDC identity, so an installer verifies a download against the identity `github.com/jdx/usage` instead of a signing key this project would have to hold and rotate.

`usage --usage-spec` is run against the freshly built Linux binary and uploaded as `usage.usage.kdl`, listed as a `cli-spec` resource. usage is the tool that reads these specs, so publishing its own is the example the format asks for.

### Changes

- A new `packslip` job, needing `build-and-publish`. It needs to be its own job: `build-and-publish` uploads straight to the release from each runner, so no step there sees the whole release, and one document covering all of it can only be written once every target has landed. It downloads the release's own archives back, generates the CLI spec, and writes the bundle.
- `release` now also needs `packslip`, so the draft is complete before it is published. Both jobs carry the same `startsWith(github.ref, 'refs/tags/v')` guard, so the dispatch path is unchanged.

### Verification

Rehearsed end to end against the real v6.6.1 release: downloaded all seven assets, ran `usage --usage-spec` from the linux-gnu build (456 lines), and created a bundle.

```
usage-aarch64-unknown-linux-gnu.tar.gz  | linux  aarch64 gnu  tar.gz | ['usage']
usage-aarch64-unknown-linux-musl.tar.gz | linux  aarch64 musl tar.gz | ['usage']
usage-universal-apple-darwin.tar.gz     | darwin  -       -   tar.gz | ['usage']
usage-x86_64-unknown-linux-gnu.tar.gz   | linux  x86_64  gnu  tar.gz | ['usage']
usage-x86_64-unknown-linux-musl.tar.gz  | linux  x86_64  musl tar.gz | ['usage']
usage-aarch64-pc-windows-msvc.zip       | windows aarch64  -  zip    | ['usage.exe']
usage-x86_64-pc-windows-msvc.zip        | windows x86_64   -  zip    | ['usage.exe']
```

The universal macOS build correctly comes out with no `arch`, so it matches either one. `zizmor --offline` reports no findings on the changed workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release gating and adds OIDC/attestation permissions plus third-party release uploads; a packslip failure would block publishing the release.
> 
> **Overview**
> Adds a **`packslip`** job to `publish-cli.yml` that runs on version tags after **`build-and-publish`**, because matrix runners upload assets independently and only a follow-up job can see the full release.
> 
> That job **re-downloads** all `usage-*.tar.gz` / `usage-*.zip` assets, **extracts the Linux GNU binary** to emit **`usage.usage.kdl`** via `usage --usage-spec` and uploads it to the release, then runs **`jdx/packslip@v0.3.0`** to publish a keyless OIDC-signed inventory (`packslip.sigstore.json`) covering archive digests, the `usage` binary, bundled **`usage.1`**, and the CLI spec as a **`cli-spec`** resource.
> 
> The final **`release`** job now **`needs: packslip`** as well as `enhance-release`, so the draft is not marked published until the packslip (and spec asset) are on the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12793a712d6f483022ab77034f621e995a4de15f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Releases now include a CLI usage specification for easier tooling and integration.
  - Published release assets now include a signed inventory covering archives, manual pages, and CLI specifications.
- **Chores**
  - Release publishing now verifies that all generated release resources are available before completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->