### PR TITLE
chore(release): bump packslip action to v1.0.0

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -243,7 +243,7 @@ jobs:
           gh release upload "$GITHUB_REF_NAME" usage.usage.kdl --repo "$REPO" --clobber
         env:
           REPO: ${{ github.repository }}
-      - uses: jdx/packslip@433c0c0f033e64c22f12433471768c255ef2bd93 # v0.3.0
+      - uses: jdx/packslip@0121abf6972fe6ca13633233402439a715f4cc0e # v1.0.0
         with:
           artifacts: dist/usage-*.tar.gz dist/usage-*.zip
           bin: usage

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -243,7 +243,7 @@ jobs:
           gh release upload "$GITHUB_REF_NAME" usage.usage.kdl --repo "$REPO" --clobber
         env:
           REPO: ${{ github.repository }}
-      - uses: jdx/packslip@0121abf6972fe6ca13633233402439a715f4cc0e # v1.0.0
+      - uses: jdx/packslip@a6eddff2d884891faa2efbec374b48e7053df2c4 # v1.0.1
         with:
           artifacts: dist/usage-*.tar.gz dist/usage-*.zip
           bin: usage


### PR DESCRIPTION
## Summary
- Bumps the pinned `jdx/packslip` action from v0.3.0 to v1.0.0.
- v1.0.0 declares the manifest format stable, fixes the `packslip.dev/releases/v1` predicate URL that previously 404d, and requires every artifact to declare a format (already satisfied here — every artifact is an archive, which infers its format from the file name).

## Test plan
- [ ] Next tagged release runs the packslip step successfully and uploads `packslip.sigstore.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single pinned GitHub Action version in CI with no application or auth logic changes; verify the next tag run uploads `packslip.sigstore.json` as expected.
> 
> **Overview**
> Updates the **publish-cli** workflow’s `packslip` job to pin **`jdx/packslip`** from **v0.3.0** to **v1.0.1** (new commit SHA). Inputs (`artifacts`, `bin`, `resources`) are unchanged.
> 
> This is a release-pipeline-only change: tagged releases still generate the signed packslip manifest over the same CLI archives and uploaded `usage.usage.kdl` asset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d1cc71970154c7adfebcda63f0eb3625acce87c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the package publishing workflow to use the newer pinned Packslip action version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

*AI-assisted — Tool: Claude Code; model: anthropic/claude-sonnet-5; version: unavailable.*
