### PR TITLE
ci(release): bump packslip to v1.0.2

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -243,7 +243,7 @@ jobs:
           gh release upload "$GITHUB_REF_NAME" usage.usage.kdl --repo "$REPO" --clobber
         env:
           REPO: ${{ github.repository }}
-      - uses: jdx/packslip@a6eddff2d884891faa2efbec374b48e7053df2c4 # v1.0.1
+      - uses: jdx/packslip@5c1cced7cfa661140dbc972a0de55b2b6bd81522 # v1.0.2
         with:
           artifacts: dist/usage-*.tar.gz dist/usage-*.zip
           bin: usage


### PR DESCRIPTION
v1.0.1 uploaded the packslip with `gh release upload "$TAG" "$BUNDLE" --clobber` and no `--repo`, so `gh` fell back to asking git which repository it was in. The job that runs it only downloads artifacts and has no checkout, so the upload failed with

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

after the packslip had already been created and verified.
The packslip job here has not run on a tag yet (it landed after v6.6.1), so the next release would be the first to hit it. jdx/mr-boxington and jdx/tak hit exactly this today.


v1.0.2 carries jdx/packslip#71, which passes `--repo`. Pinned to the release commit `5c1cced`, which is what the `v1.0.2` tag points at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI dependency pin in the release workflow; no application or runtime behavior changes.
> 
> **Overview**
> Updates the **packslip** GitHub Action pin in `publish-cli.yml` from **v1.0.1** to **v1.0.2** (`5c1cced`).
> 
> v1.0.1 uploaded the packslip bundle with `gh release upload` without `--repo`, so `gh` tried to infer the repository from git. The packslip job only downloads release artifacts and never checks out the repo, which caused release publishing to fail after the bundle was built. v1.0.2 passes `--repo` so tagged releases can publish the signed packslip inventory successfully.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 278a5dee7a4b31da65883023c031148747057752. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the command-line publishing workflow to use the latest approved packaging action version.
  - No user-facing functionality or behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->