### PR TITLE
chore(ci): bump packslip to v1.1.1

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -243,7 +243,7 @@ jobs:
           gh release upload "$GITHUB_REF_NAME" usage.usage.kdl --repo "$REPO" --clobber
         env:
           REPO: ${{ github.repository }}
-      - uses: jdx/packslip@5c1cced7cfa661140dbc972a0de55b2b6bd81522 # v1.0.2
+      - uses: jdx/packslip@a0d434ad57571c62dbd0ab5095b4eff607a71fd3 # v1.1.1
         with:
           artifacts: dist/usage-*.tar.gz dist/usage-*.zip
           bin: usage


### PR DESCRIPTION
Update the release workflow to use packslip v1.1.1 at its immutable commit SHA. This release pins the nested provenance action, so repositories enforcing full-length action SHAs can load the composite action.

Validation: `git diff --check`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI dependency pin in the packslip release job; no application or runtime behavior changes.
> 
> **Overview**
> Updates the **publish-cli** workflow’s `packslip` step from **v1.0.2** to **v1.1.1**, pinning the composite action at commit `a0d434ad57571c62dbd0ab5095b4eff607a71fd3`.
> 
> The bump is intended so packslip’s nested provenance action is pinned at a full SHA, which keeps the release job working under policies that require immutable action references. **Artifacts, `bin`, and `resources` inputs are unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cbc9fe629f4a6fe50dbf22d3f5974c4156b3101. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package publishing workflow to use a newer version of its packaging tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->