### PR TITLE
chore: bypass mbx for universal macos release builds

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -122,6 +122,8 @@ jobs:
           codesign_options: runtime
           dry-run: ${{ github.event_name == 'workflow_dispatch' }}
         env:
+          # The universal build passes two --target flags, which mbx cannot handle.
+          MBX_DISABLE: ${{ matrix.target == 'universal-apple-darwin' }}
           CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
           CARGO_PROFILE_RELEASE_LTO: true
       # Signing settles who built the binary; notarization is what Gatekeeper


### PR DESCRIPTION
The universal macOS release build passes both Apple targets to Cargo in one invocation. mbx 1.8.1 rejects this with `managed linker selection supports one Cargo --target per invocation`, causing the release build to fail before compilation.

Set `MBX_DISABLE` for the universal target so the Cargo shim passes through to native Cargo. Other matrix targets retain mbx.

Validation: actionlint, Prettier, and `git diff --check` pass. Verified the bypass behavior in mbx 1.8.1 source; the full signed release build was not run locally.

Fixes the failure in https://github.com/jdx/usage/actions/runs/33987850906/job/101364811217.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only conditional env var for one matrix target; no runtime or application code changes.
> 
> **Overview**
> **Fixes universal macOS release builds** that fail when **mbx** rejects Cargo invocations with more than one `--target` (the universal `apple-darwin` path passes both architectures in a single build).
> 
> The `publish-cli` workflow now sets **`MBX_DISABLE`** only for the `universal-apple-darwin` matrix entry so the Cargo shim falls through to native Cargo for that job. All other release targets keep mbx enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef315d97ed2465598ab3ac7c4bfe30274fcbf5e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed universal Apple Darwin builds by preventing conflicting target processing during packaging.
  * Other build targets continue to use the existing packaging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->