### PR TITLE
chore: allow empty commits to trigger release prs

### DIFF
--- a/tasks/release-plz
+++ b/tasks/release-plz
@@ -74,30 +74,30 @@ publish_crate_if_needed usage-config
 publish_crate_if_needed usage-validation
 publish_crate_if_needed clap_usage
 
-# Anchor the range before filtering paths. A release tag may point at a commit that only
-# changes root release files; letting the path filter hide that tag can make cliff propose
-# a version lower than the one already published.
+# Anchor the range at the current release and include commits regardless of changed paths.
+# Empty conventional commits (for example, `fix(cli): trigger release pr`) must also
+# reach git-cliff so they can trigger a version bump and appear in the release notes.
 release_range="v$cur_version..HEAD"
-version="$(git cliff "$release_range" --bumped-version --include-path 'lib/**' --include-path 'cli/**' --include-path 'argv/**' --include-path 'config/**' --include-path 'derive/**' --include-path 'test/**' --include-path 'usage-rs/**' --include-path 'usage-dynamic/**' --include-path 'validation/**')"
+version="$(git cliff "$release_range" --bumped-version)"
 
 if [ "v$cur_version" == "$version" ]; then
-  echo "No library changes since $version; nothing to release"
+  echo "No version bump since $version; nothing to release"
   exit 0
 fi
 
 if [ "${usage_dry_run:-}" == 1 ]; then
   echo "version: $version"
-  changelog="$(git cliff "$release_range" --tag "$version" --strip all --include-path 'lib/**' --include-path 'cli/**' --include-path 'argv/**' --include-path 'config/**' --include-path 'derive/**' --include-path 'test/**' --include-path 'usage-rs/**' --include-path 'usage-dynamic/**' --include-path 'validation/**')"
+  changelog="$(git cliff "$release_range" --tag "$version" --strip all)"
   echo "changelog: $changelog"
   exit 0
 fi
 
 # Generate changelog using git-cliff (LLM editorialization happens in release.yml after merge)
-git cliff "$release_range" --tag "$version" --prepend CHANGELOG.md --include-path 'lib/**' --include-path 'cli/**' --include-path 'argv/**' --include-path 'config/**' --include-path 'derive/**' --include-path 'test/**' --include-path 'usage-rs/**' --include-path 'usage-dynamic/**' --include-path 'validation/**'
+git cliff "$release_range" --tag "$version" --prepend CHANGELOG.md
 
 # Get the unreleased notes for PR body
 # Strip version header since PR title already has version
-PR_BODY="$(git cliff "$release_range" --tag "$version" --strip all --include-path 'lib/**' --include-path 'cli/**' --include-path 'argv/**' --include-path 'config/**' --include-path 'derive/**' --include-path 'test/**' --include-path 'usage-rs/**' --include-path 'usage-dynamic/**' --include-path 'validation/**' | tail -n +3)"
+PR_BODY="$(git cliff "$release_range" --tag "$version" --strip all | tail -n +3)"
 
 # clap_usage is versioned by hand. Everything still at 0.0.0 is unpublished
 # (xtask, conformance, benches) and must stay there. `cargo set-version`


### PR DESCRIPTION
Empty `fix` commits triggered the release workflow but were excluded by git-cliff's crate path filters, so no release PR was created. Remove those filters from version calculation, dry-run notes, the changelog, and the PR body while retaining the explicit range from the current release tag.

Commits outside crate directories now also participate in the existing git-cliff bump and changelog rules.

Validation: on the actual `v6.7.0..31c9336c` history, the previous command returns `v6.7.0`, while the updated command returns `v6.7.1` and includes the empty fix commit in the release notes. ShellCheck, `bash -n`, and `git diff --check` pass.

_This PR description was generated by Codex._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release versioning and changelog inputs for all future releases; commits outside crate directories may now trigger bumps and appear in release notes.
> 
> **Overview**
> Release automation in `tasks/release-plz` no longer passes `--include-path` filters to **git-cliff** for version bumps, changelog generation, dry-run output, or the release PR body. The range stays `v$cur_version..HEAD`, but every conventional commit in that range can now drive a bump and show up in notes—including empty `fix` commits that only touch non-crate paths (e.g. workflow-only changes).
> 
> The early-exit message is reworded from “no library changes” to **“no version bump”** to match the broader scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e74fb587c79561eea8b842c9a9e1f8d7996df064. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Process**
  - Release notes and version updates now account for all qualifying commits since the current release, including root-level changes and empty conventional commits.
  - Releases with no applicable changes now display a more general message rather than language specific to a particular component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->