### PR TITLE
chore: release v6.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [6.8.0](https://github.com/jdx/usage/compare/v6.7.1..v6.8.0) - 2026-09-06
+
+### 🚀 Features
+
+- **(cli)** publish native completions in packslip by [@jdx](https://github.com/jdx) in [#1388](https://github.com/jdx/usage/pull/1388)
+- **(docs)** configure markdown link extensions by [@jdx](https://github.com/jdx) in [#1394](https://github.com/jdx/usage/pull/1394)
+
+### 🐛 Bug Fixes
+
+- **(docs)** render optional subcommands and mount synopses by [@jdx](https://github.com/jdx) in [#1393](https://github.com/jdx/usage/pull/1393)
+- **(docs)** preserve markdown code blocks and headings by [@jdx](https://github.com/jdx) in [#1392](https://github.com/jdx/usage/pull/1392)
+- **(manpage)** render mount synopses and custom command names by [@jdx](https://github.com/jdx) in [#1395](https://github.com/jdx/usage/pull/1395)
+
+### 📚 Documentation
+
+- improve guides, navigation, and landing page by [@jdx](https://github.com/jdx) in [#1391](https://github.com/jdx/usage/pull/1391)
+
+### 📦️ Dependency Updates
+
+- bump mr-boxington to 1.8.3 by [@jdx](https://github.com/jdx) in [#1390](https://github.com/jdx/usage/pull/1390)
+
 ## [6.7.1](https://github.com/jdx/usage/compare/v6.7.0..v6.7.1) - 2026-09-05
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2029,11 +2029,11 @@ checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "usage-argv"
-version = "6.7.1"
+version = "6.8.0"
 
 [[package]]
 name = "usage-cli"
-version = "6.7.1"
+version = "6.8.0"
 dependencies = [
  "assert_cmd",
  "ctor",
@@ -2060,7 +2060,7 @@ dependencies = [
 
 [[package]]
 name = "usage-config"
-version = "6.7.1"
+version = "6.8.0"
 dependencies = [
  "serde_json",
  "toml",
@@ -2086,7 +2086,7 @@ dependencies = [
 
 [[package]]
 name = "usage-derive"
-version = "6.7.1"
+version = "6.8.0"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "usage-dynamic"
-version = "6.7.1"
+version = "6.8.0"
 dependencies = [
  "futures",
  "usage-argv",
@@ -2106,7 +2106,7 @@ dependencies = [
 
 [[package]]
 name = "usage-lib"
-version = "6.7.1"
+version = "6.8.0"
 dependencies = [
  "clap",
  "criterion",
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "usage-rs"
-version = "6.7.1"
+version = "6.8.0"
 dependencies = [
  "serde",
  "shell-words",
@@ -2149,14 +2149,14 @@ dependencies = [
 
 [[package]]
 name = "usage-test"
-version = "6.7.1"
+version = "6.8.0"
 dependencies = [
  "usage-argv",
 ]
 
 [[package]]
 name = "usage-validation"
-version = "6.7.1"
+version = "6.8.0"
 dependencies = [
  "expr-lang",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,20 +42,20 @@ license = "MIT"
 [workspace.dependencies]
 clap_usage = { path = "./clap_usage", version = "5.0.0" }
 usage-cli = { path = "./cli" }
-usage-argv = { path = "./argv", version = "6.7.1" }
-usage-config = { path = "./config", version = "6.7.1" }
-usage-derive = { path = "./derive", version = "6.7.1" }
+usage-argv = { path = "./argv", version = "6.8.0" }
+usage-config = { path = "./config", version = "6.8.0" }
+usage-derive = { path = "./derive", version = "6.8.0" }
 # No features, and defaults off. A feature named here is inherited by every member that writes
 # `workspace = true` and inlines into their published manifests — so `clap` and `validation`
 # reached members that use neither, one of them an adopter's build script. Defaults
 # are off rather than absent because cargo *ignores* a member's `default-features = false` unless
 # the workspace declaration sets it too, and warns that it may become a hard error. Members name
 # what they need, `docs` included.
-usage-lib = { path = "./lib", version = "6.7.1", default-features = false }
-usage-rs = { path = "./usage-rs", version = "6.7.1" }
-usage-dynamic = { path = "./usage-dynamic", version = "6.7.1" }
-usage-test = { path = "./test", version = "6.7.1" }
-usage-validation = { path = "./validation", version = "6.7.1" }
+usage-lib = { path = "./lib", version = "6.8.0", default-features = false }
+usage-rs = { path = "./usage-rs", version = "6.8.0" }
+usage-dynamic = { path = "./usage-dynamic", version = "6.8.0" }
+usage-test = { path = "./test", version = "6.8.0" }
+usage-validation = { path = "./validation", version = "6.8.0" }
 
 [workspace.metadata.release]
 allow-branch = ["main"]

--- a/argv/Cargo.toml
+++ b/argv/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-argv"
 description = "Zero-allocation argv parser for usage specs"
-version = "6.7.1"
+version = "6.8.0"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "usage-cli"
 edition = "2021"
 rust-version = "1.91"
-version = "6.7.1"
+version = "6.8.0"
 description = "CLI for working with usage-based CLIs"
 license = { workspace = true }
 authors = { workspace = true }

--- a/cli/usage.usage.kdl
+++ b/cli/usage.usage.kdl
@@ -2,7 +2,7 @@
 min_usage_version "6.5"
 name usage
 bin usage
-version "6.7.1"
+version "6.8.0"
 repository "https://github.com/jdx/usage"
 source_code_link_template #"""
 {%- set path = path | replace(from='-', to='_') -%}

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-config"
 description = "Layered configuration resolution for usage specs, with provenance"
-version = "6.7.1"
+version = "6.8.0"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-derive"
 description = "Derive macro that compiles a CLI definition into parse tables and a usage spec"
-version = "6.7.1"
+version = "6.8.0"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }

--- a/docs/cli/reference/commands.json
+++ b/docs/cli/reference/commands.json
@@ -2053,7 +2053,7 @@
     "sources": {},
     "files": []
   },
-  "version": "6.7.1",
+  "version": "6.8.0",
   "usage": "Usage: usage <COMMAND>\n       usage --completions <COMPLETIONS>\n       usage --usage-spec",
   "complete": {},
   "source_code_link_template": "{%- set path = path | replace(from='-', to='_') -%}\n{%- if cmd.subcommands | length > 0 -%}\n{%- set path = path ~ \"/mod.rs\" -%}\n{%- elif path in [\"bash\", \"fish\", \"powershell\", \"zsh\"] -%}\n{%- set path = \"shell.rs\" -%}\n{%- else -%}\n{%- set path = path ~ \".rs\" -%}\n{%- endif -%}\nhttps://github.com/jdx/usage/blob/main/cli/src/cli/{{path}}",

--- a/docs/cli/reference/index.md
+++ b/docs/cli/reference/index.md
@@ -2,7 +2,7 @@
 
 # `usage`
 
-**Version:** 6.7.1
+**Version:** 6.8.0
 
 **Repository:** https://github.com/jdx/usage
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-lib"
 edition = "2021"
-version = "6.7.1"
+version = "6.8.0"
 rust-version = "1.91"
 include = [
     "/Cargo.toml",

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-test"
 description = "Test helpers for CLIs built with usage"
-version = "6.7.1"
+version = "6.8.0"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }

--- a/usage-dynamic/Cargo.toml
+++ b/usage-dynamic/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-dynamic"
 description = "Runtime command catalogs for usage-rs applications"
-version = "6.7.1"
+version = "6.8.0"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }
@@ -12,7 +12,7 @@ license = { workspace = true }
 
 [dependencies]
 usage-argv = { workspace = true, features = ["spec", "complete"] }
-usage-parser = { package = "usage-lib", path = "../lib", version = "6.7.1", default-features = false, features = ["cli-help"] }
+usage-parser = { package = "usage-lib", path = "../lib", version = "6.8.0", default-features = false, features = ["cli-help"] }
 
 [package.metadata.release]
 shared-version = true

--- a/usage-rs/Cargo.toml
+++ b/usage-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-rs"
 description = "A compiled CLI parser for Rust, built on usage specs"
-version = "6.7.1"
+version = "6.8.0"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }

--- a/usage-rs/tests/fixtures/runtime-identity/Cargo.lock
+++ b/usage-rs/tests/fixtures/runtime-identity/Cargo.lock
@@ -39,11 +39,11 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "usage-argv"
-version = "6.7.1"
+version = "6.8.0"
 
 [[package]]
 name = "usage-derive"
-version = "6.7.1"
+version = "6.8.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "usage-rs"
-version = "6.7.1"
+version = "6.8.0"
 dependencies = [
  "usage-argv",
  "usage-derive",

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usage-validation"
 description = "Portable expression validation for usage specs"
-version = "6.7.1"
+version = "6.8.0"
 edition = "2021"
 rust-version = "1.91"
 homepage = { workspace = true }


### PR DESCRIPTION
### 🚀 Features

- **(cli)** publish native completions in packslip by [@jdx](https://github.com/jdx) in [#1388](https://github.com/jdx/usage/pull/1388)
- **(docs)** configure markdown link extensions by [@jdx](https://github.com/jdx) in [#1394](https://github.com/jdx/usage/pull/1394)

### 🐛 Bug Fixes

- **(docs)** render optional subcommands and mount synopses by [@jdx](https://github.com/jdx) in [#1393](https://github.com/jdx/usage/pull/1393)
- **(docs)** preserve markdown code blocks and headings by [@jdx](https://github.com/jdx) in [#1392](https://github.com/jdx/usage/pull/1392)
- **(manpage)** render mount synopses and custom command names by [@jdx](https://github.com/jdx) in [#1395](https://github.com/jdx/usage/pull/1395)

### 📚 Documentation

- improve guides, navigation, and landing page by [@jdx](https://github.com/jdx) in [#1391](https://github.com/jdx/usage/pull/1391)

### 📦️ Dependency Updates

- bump mr-boxington to 1.8.3 by [@jdx](https://github.com/jdx) in [#1390](https://github.com/jdx/usage/pull/1390)