### PR TITLE
fix(docs): render optional subcommands and mount synopses

### DIFF
--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -1019,7 +1019,11 @@ fn usage_line_with_subcommands(
 
     if include_subcommands && !meta.cmd.subcommands.is_empty() {
         let name = meta.subcommand_value_name.unwrap_or("SUBCOMMAND");
-        let _ = write!(out, " <{name}>");
+        if meta.subcommand_required {
+            let _ = write!(out, " <{name}>");
+        } else {
+            let _ = write!(out, " [{name}]");
+        }
     }
     out
 }

--- a/benches/gate/tests/help.rs
+++ b/benches/gate/tests/help.rs
@@ -103,8 +103,8 @@ fn the_root_line_is_what_a_user_would_recognise() {
         "the line should start with the binary: {line}"
     );
     assert!(
-        line.ends_with("<SUBCOMMAND>"),
-        "mise has subcommands, so the line should end by saying so: {line}"
+        line.ends_with("[SUBCOMMAND]"),
+        "mise has optional subcommands, so the line should end by saying so: {line}"
     );
 }
 

--- a/cli/tests/snapshots/markdown__markdown_snapshot_with_examples.snap
+++ b/cli/tests/snapshots/markdown__markdown_snapshot_with_examples.snap
@@ -8,7 +8,7 @@ expression: "markdown_stdout(&[\"--out-file\", \"-\"])"
 A demo CLI with examples
 
 
-- **Usage:** `demo <SUBCOMMAND>`
+- **Usage:** `demo [SUBCOMMAND]`
 
 ## `demo deploy`
 
@@ -42,7 +42,7 @@ demo deploy -e staging --force
 
 ## `demo config`
 
-- **Usage:** `demo config <SUBCOMMAND>`
+- **Usage:** `demo config [SUBCOMMAND]`
 
 Manage configuration
 

--- a/conformance/tests/help_request.rs
+++ b/conformance/tests/help_request.rs
@@ -207,6 +207,7 @@ fn root_help_uses_an_explicit_multiline_synopsis() {
             "{page}"
         );
         assert!(!page.contains("Usage: alternate <SUBCOMMAND>"), "{page}");
+        assert!(!page.contains("Usage: alternate [SUBCOMMAND]"), "{page}");
     }
 }
 
@@ -362,17 +363,17 @@ fn usage_line_of(page: &str) -> &str {
 fn the_help_command_answers_about_the_command_it_names() {
     // What the page itself advertises — "help  Print this message or the help of the given
     // subcommand(s)" — and what it did not do until now.
-    assert_eq!(usage_line_of(&ask_deep(&["help"])), "deep <SUBCOMMAND>");
+    assert_eq!(usage_line_of(&ask_deep(&["help"])), "deep [SUBCOMMAND]");
     assert_eq!(
         usage_line_of(&ask_deep(&["help", "config"])),
-        "deep config <SUBCOMMAND>"
+        "deep config [SUBCOMMAND]"
     );
 
     // Every name a command answers to, since `help` is asking about the command rather than
     // about the word: `ex help cfg` is a question about `config`.
     assert_eq!(
         usage_line_of(&ask_deep(&["help", "cfg"])),
-        "deep config <SUBCOMMAND>"
+        "deep config [SUBCOMMAND]"
     );
 
     // The whole path, not just the first word.
@@ -387,7 +388,7 @@ fn help_stops_at_a_word_that_names_no_command() {
     // `help` are a question, and the most useful answer to a half-recognised one is the page
     // for as far as it got.
     let page = ask_deep(&["help", "config", "nonsense"]);
-    assert_eq!(usage_line_of(&page), "deep config <SUBCOMMAND>");
+    assert_eq!(usage_line_of(&page), "deep config [SUBCOMMAND]");
 }
 
 #[test]

--- a/corpus/render/02-usage-line.json
+++ b/corpus/render/02-usage-line.json
@@ -78,13 +78,13 @@
       "id": "subcommands-are-named-generically",
       "doc": "A command with subcommands ends its line by saying so, whatever they are called.",
       "spec": "name \"ex\"\nbin \"ex\"\ncmd \"go\" help=\"Go\"\ncmd \"stop\" help=\"Stop\"\n",
-      "expect": { "usage": "ex <SUBCOMMAND>" }
+      "expect": { "usage": "ex [SUBCOMMAND]" }
     },
     {
       "id": "subcommands-all-hidden-still-say-subcommand",
-      "doc": "The line is computed before hidden commands are filtered, so a command whose subcommands are all hidden still says `<SUBCOMMAND>` while listing none. Recorded because it looks like a bug and is the reference's behaviour, which mise reaches on `direnv` and `dotfiles`.",
+      "doc": "The line is computed before hidden commands are filtered, so a command whose subcommands are all hidden still says `[SUBCOMMAND]` while listing none. Recorded because it looks like a bug and is the reference's behaviour, which mise reaches on `direnv` and `dotfiles`.",
       "spec": "name \"ex\"\nbin \"ex\"\ncmd \"go\" help=\"Go\" hide=#true\n",
-      "expect": { "usage": "ex <SUBCOMMAND>" }
+      "expect": { "usage": "ex [SUBCOMMAND]" }
     },
     {
       "id": "subcommand-line-starts-at-the-command",

--- a/corpus/render/03-sections.json
+++ b/corpus/render/03-sections.json
@@ -123,11 +123,11 @@
       "doc": "Subcommands are listed by name in one column, with the summary after it and the aliases after that; a hidden alias works and is not advertised. The supplied `help` entry sits in the same column as the declared commands, because it is a row like any other.",
       "spec": "name \"ex\"\nbin \"ex\"\nabout \"An example\"\ncmd \"install\" help=\"Install a tool\" {\n    alias \"i\"\n    alias \"add\" hide=#true\n    arg \"<TOOL>\"\n}\ncmd \"remove\" help=\"Remove a tool\" hide=#true\n",
       "expect": {
-        "usage": "ex <SUBCOMMAND>",
+        "usage": "ex [SUBCOMMAND]",
         "short_help": [
           "An example",
           "",
-          "Usage: ex <SUBCOMMAND>",
+          "Usage: ex [SUBCOMMAND]",
           "",
           "Commands:",
           "  install  Install a tool [aliases: i]",
@@ -197,11 +197,11 @@
       "doc": "`hide` keeps a flag, an argument and a subcommand out of the page as well as out of the usage line.",
       "spec": "name \"ex\"\nbin \"ex\"\nabout \"An example\"\nflag \"--shown\" help=\"Visible\"\nflag \"--secret\" help=\"Hidden\" hide=#true\narg \"[shown]\" help=\"Visible\"\narg \"[buried]\" help=\"Hidden\" hide=#true\ncmd \"go\" help=\"Go\"\ncmd \"lurk\" help=\"Hidden\" hide=#true\n",
       "expect": {
-        "usage": "ex [--shown] [shown] <SUBCOMMAND>",
+        "usage": "ex [--shown] [shown] [SUBCOMMAND]",
         "short_help": [
           "An example",
           "",
-          "Usage: ex [--shown] [shown] <SUBCOMMAND>",
+          "Usage: ex [--shown] [shown] [SUBCOMMAND]",
           "",
           "Commands:",
           "  go    Go",

--- a/corpus/render/04-help-template.json
+++ b/corpus/render/04-help-template.json
@@ -27,11 +27,11 @@
       "doc": "A section the template does not name is not on the page. A CLI whose subcommands are documented elsewhere can leave `{{commands}}` out, and the entries are still parsed — omitting a section changes the page and nothing else.",
       "spec": "name \"ex\"\nbin \"ex\"\nabout \"An example\"\nhelp_template \"{{about}}\\n\\n{{usage}}\\n\\n{{flags}}\"\ncmd \"install\" help=\"Install a tool\"\ncmd \"remove\" help=\"Remove a tool\"\n",
       "expect": {
-        "usage": "ex <SUBCOMMAND>",
+        "usage": "ex [SUBCOMMAND]",
         "short_help": [
           "An example",
           "",
-          "Usage: ex <SUBCOMMAND>",
+          "Usage: ex [SUBCOMMAND]",
           "",
           "Flags:",
           "  -h, --help  Print help"

--- a/docs/spec/reference/cmd.md
+++ b/docs/spec/reference/cmd.md
@@ -165,6 +165,10 @@ This metadata does not declare arguments or change parsing or completion. Withou
 `synopsis`, an unresolved mount adds no placeholder. Static subcommands use
 `[SUBCOMMAND]` when optional and `<SUBCOMMAND>` when `subcommand_required` is true.
 
+Producers must require a usage release that supports mount `synopsis` before
+emitting it for external consumers. Serialization preserves explicitly declared
+metadata; it does not negotiate a target consumer version or silently drop it.
+
 Resolving a mount runs a process, so when the root's mount runs depends on what is
 asking for it:
 

--- a/docs/spec/reference/cmd.md
+++ b/docs/spec/reference/cmd.md
@@ -152,6 +152,19 @@ cmd "install"
 mount run="mycli plugin-commands"
 ```
 
+An unresolved mount can declare a display-only synopsis for generated documentation:
+
+```kdl
+cmd "run" {
+    mount run="mycli tasks --usage" synopsis="[TASK] [ARGS]…"
+}
+```
+
+The generated usage line includes `run [TASK] [ARGS]…` without running discovery.
+This metadata does not declare arguments or change parsing or completion. Without
+`synopsis`, an unresolved mount adds no placeholder. Static subcommands use
+`[SUBCOMMAND]` when optional and `<SUBCOMMAND>` when `subcommand_required` is true.
+
 Resolving a mount runs a process, so when the root's mount runs depends on what is
 asking for it:
 

--- a/examples/docs/MISE_INLINE.md
+++ b/examples/docs/MISE_INLINE.md
@@ -5,7 +5,7 @@
 mise prepares your development environment before each command runs. https://github.com/jdx/mise
 
 
-- **Usage:** `mise [FLAGS] [TASK] <SUBCOMMAND>`
+- **Usage:** `mise [FLAGS] [TASK] [SUBCOMMAND]`
 
 ## Arguments
 - **`[TASK]`** — Task to run.
@@ -94,7 +94,7 @@ $ (&mise activate pwsh) | Out-String | Invoke-Expression
 
 ## `mise tool-alias`
 
-- **Usage:** `mise tool-alias [-p --tool <TOOL>] [--no-header] <SUBCOMMAND>`
+- **Usage:** `mise tool-alias [-p --tool <TOOL>] [--no-header] [SUBCOMMAND]`
 - **Effect:** read-only
 
 Manage tool version aliases.
@@ -198,7 +198,7 @@ $ mise tool-alias unset node lts-jod
 
 ## `mise backends`
 
-- **Usage:** `mise backends <SUBCOMMAND>`
+- **Usage:** `mise backends [SUBCOMMAND]`
 - **Effect:** read-only
 
 Manage backends
@@ -251,7 +251,7 @@ List all the active runtime bin paths
 
 ## `mise bootstrap`
 
-- **Usage:** `mise bootstrap [FLAGS] <SUBCOMMAND>`
+- **Usage:** `mise bootstrap [FLAGS] [SUBCOMMAND]`
 - **Effect:** destructive — may delete or irreversibly overwrite
 
 Set up a machine for the current config in one command
@@ -1217,7 +1217,7 @@ Manage current-user bootstrap settings from `[bootstrap.user]`
 
 ## `mise cache`
 
-- **Usage:** `mise cache <SUBCOMMAND>`
+- **Usage:** `mise cache [SUBCOMMAND]`
 - **Effect:** read-only
 
 Manage the mise cache
@@ -1304,7 +1304,7 @@ $ mise completion powershell >> $PROFILE
 
 ## `mise config`
 
-- **Usage:** `mise config [FLAGS] <SUBCOMMAND>`
+- **Usage:** `mise config [FLAGS] [SUBCOMMAND]`
 - **Aliases:** `cfg`
 - **Effect:** read-only
 
@@ -1417,7 +1417,7 @@ $ mise deactivate
 
 ## `mise doctor`
 
-- **Usage:** `mise doctor [-J --json] <SUBCOMMAND>`
+- **Usage:** `mise doctor [-J --json] [SUBCOMMAND]`
 - **Aliases:** `dr`
 - **Effect:** read-only
 
@@ -2574,7 +2574,7 @@ $ mise patrons --refresh
 
 ## `mise plugins`
 
-- **Usage:** `mise plugins [FLAGS] <SUBCOMMAND>`
+- **Usage:** `mise plugins [FLAGS] [SUBCOMMAND]`
 - **Aliases:** `p`
 - **Effect:** read-only
 
@@ -2762,7 +2762,7 @@ $ mise plugins update cmake#beta  # specify a ref
 
 ## `mise deps`
 
-- **Usage:** `mise deps [FLAGS] [PROVIDER] <SUBCOMMAND>`
+- **Usage:** `mise deps [FLAGS] [PROVIDER] [SUBCOMMAND]`
 - **Aliases:** `dep`
 - **Effect:** modifies state
 
@@ -3231,7 +3231,7 @@ Enter value for API_KEY: [hidden input]
 
 ## `mise settings`
 
-- **Usage:** `mise settings [FLAGS] [SETTING] [VALUE] <SUBCOMMAND>`
+- **Usage:** `mise settings [FLAGS] [SETTING] [VALUE] [SUBCOMMAND]`
 - **Effect:** modifies state
 
 Manage settings
@@ -3424,7 +3424,7 @@ v20.0.0
 
 ## `mise shell-alias`
 
-- **Usage:** `mise shell-alias [--no-header] <SUBCOMMAND>`
+- **Usage:** `mise shell-alias [--no-header] [SUBCOMMAND]`
 - **Effect:** read-only
 
 Manage shell aliases.
@@ -3598,7 +3598,7 @@ $ mise use -g ruby - Use the latest version of Ruby installed by Homebrew
 
 ## `mise tasks`
 
-- **Usage:** `mise tasks [FLAGS] [TASK] <SUBCOMMAND>`
+- **Usage:** `mise tasks [FLAGS] [TASK] [SUBCOMMAND]`
 - **Aliases:** `t`
 - **Effect:** read-only
 

--- a/examples/docs/MISE_MULTI.md
+++ b/examples/docs/MISE_MULTI.md
@@ -5,7 +5,7 @@
 mise prepares your development environment before each command runs. https://github.com/jdx/mise
 
 
-- **Usage:** `mise [FLAGS] [TASK] <SUBCOMMAND>`
+- **Usage:** `mise [FLAGS] [TASK] [SUBCOMMAND]`
 
 ## Arguments
 - **`[TASK]`** — Task to run.
@@ -94,7 +94,7 @@ $ (&mise activate pwsh) | Out-String | Invoke-Expression
 
 ## `mise tool-alias`
 
-- **Usage:** `mise tool-alias [-p --tool <TOOL>] [--no-header] <SUBCOMMAND>`
+- **Usage:** `mise tool-alias [-p --tool <TOOL>] [--no-header] [SUBCOMMAND]`
 - **Effect:** read-only
 
 Manage tool version aliases.
@@ -198,7 +198,7 @@ $ mise tool-alias unset node lts-jod
 
 ## `mise backends`
 
-- **Usage:** `mise backends <SUBCOMMAND>`
+- **Usage:** `mise backends [SUBCOMMAND]`
 - **Effect:** read-only
 
 Manage backends
@@ -251,7 +251,7 @@ List all the active runtime bin paths
 
 ## `mise bootstrap`
 
-- **Usage:** `mise bootstrap [FLAGS] <SUBCOMMAND>`
+- **Usage:** `mise bootstrap [FLAGS] [SUBCOMMAND]`
 - **Effect:** destructive — may delete or irreversibly overwrite
 
 Set up a machine for the current config in one command
@@ -1217,7 +1217,7 @@ Manage current-user bootstrap settings from `[bootstrap.user]`
 
 ## `mise cache`
 
-- **Usage:** `mise cache <SUBCOMMAND>`
+- **Usage:** `mise cache [SUBCOMMAND]`
 - **Effect:** read-only
 
 Manage the mise cache
@@ -1304,7 +1304,7 @@ $ mise completion powershell >> $PROFILE
 
 ## `mise config`
 
-- **Usage:** `mise config [FLAGS] <SUBCOMMAND>`
+- **Usage:** `mise config [FLAGS] [SUBCOMMAND]`
 - **Aliases:** `cfg`
 - **Effect:** read-only
 
@@ -1417,7 +1417,7 @@ $ mise deactivate
 
 ## `mise doctor`
 
-- **Usage:** `mise doctor [-J --json] <SUBCOMMAND>`
+- **Usage:** `mise doctor [-J --json] [SUBCOMMAND]`
 - **Aliases:** `dr`
 - **Effect:** read-only
 
@@ -2574,7 +2574,7 @@ $ mise patrons --refresh
 
 ## `mise plugins`
 
-- **Usage:** `mise plugins [FLAGS] <SUBCOMMAND>`
+- **Usage:** `mise plugins [FLAGS] [SUBCOMMAND]`
 - **Aliases:** `p`
 - **Effect:** read-only
 
@@ -2762,7 +2762,7 @@ $ mise plugins update cmake#beta  # specify a ref
 
 ## `mise deps`
 
-- **Usage:** `mise deps [FLAGS] [PROVIDER] <SUBCOMMAND>`
+- **Usage:** `mise deps [FLAGS] [PROVIDER] [SUBCOMMAND]`
 - **Aliases:** `dep`
 - **Effect:** modifies state
 
@@ -3231,7 +3231,7 @@ Enter value for API_KEY: [hidden input]
 
 ## `mise settings`
 
-- **Usage:** `mise settings [FLAGS] [SETTING] [VALUE] <SUBCOMMAND>`
+- **Usage:** `mise settings [FLAGS] [SETTING] [VALUE] [SUBCOMMAND]`
 - **Effect:** modifies state
 
 Manage settings
@@ -3424,7 +3424,7 @@ v20.0.0
 
 ## `mise shell-alias`
 
-- **Usage:** `mise shell-alias [--no-header] <SUBCOMMAND>`
+- **Usage:** `mise shell-alias [--no-header] [SUBCOMMAND]`
 - **Effect:** read-only
 
 Manage shell aliases.
@@ -3598,7 +3598,7 @@ $ mise use -g ruby - Use the latest version of Ruby installed by Homebrew
 
 ## `mise tasks`
 
-- **Usage:** `mise tasks [FLAGS] [TASK] <SUBCOMMAND>`
+- **Usage:** `mise tasks [FLAGS] [TASK] [SUBCOMMAND]`
 - **Aliases:** `t`
 - **Effect:** read-only
 

--- a/go/README.md
+++ b/go/README.md
@@ -254,7 +254,7 @@ tables and `HelpText`:
 
 ```go
 argv.UsageLine([]string{"mise"}, mise.Root, mise.HelpText)
-// mise [FLAGS] [TASK] <SUBCOMMAND>
+// mise [FLAGS] [TASK] [SUBCOMMAND]
 ```
 
 `argv.ShortHelp` renders the whole page `-h` prints — header, `Commands`,

--- a/go/argv/help.go
+++ b/go/argv/help.go
@@ -220,10 +220,18 @@ func usageLine(path []string, cmd *Command, help HelpTable, includeSubcommands b
 
 	if includeSubcommands && len(cmd.Subcommands) > 0 {
 		name := "SUBCOMMAND"
-		if h := help.Lookup(cmd.Key); h != nil && h.SubcommandValueName != "" {
-			name = h.SubcommandValueName
+		required := false
+		if h := help.Lookup(cmd.Key); h != nil {
+			required = h.SubcommandRequired
+			if h.SubcommandValueName != "" {
+				name = h.SubcommandValueName
+			}
 		}
-		out.WriteString(" <" + name + ">")
+		if required {
+			out.WriteString(" <" + name + ">")
+		} else {
+			out.WriteString(" [" + name + "]")
+		}
 	}
 	return out.String()
 }

--- a/go/argv/page_test.go
+++ b/go/argv/page_test.go
@@ -202,7 +202,7 @@ func TestSubcommandPresentation(t *testing.T) {
 		ShortHelp(HelpSpec{Name: "ex", Bin: "ex"}, []string{"ex"}, []*Command{root}, help),
 		LongHelp(HelpSpec{Name: "ex", Bin: "ex"}, []string{"ex"}, []*Command{root}, help),
 	} {
-		if !strings.Contains(page, "Usage: ex <ACTION>") || !strings.Contains(page, "\nActions:\n") {
+		if !strings.Contains(page, "Usage: ex [ACTION]") || !strings.Contains(page, "\nActions:\n") {
 			t.Fatalf("subcommand presentation was not preserved:\n%s", page)
 		}
 	}

--- a/go/argv/render_test.go
+++ b/go/argv/render_test.go
@@ -5,6 +5,26 @@ import (
 	"testing"
 )
 
+func TestUsageLineHonorsSubcommandRequirementsAndNames(t *testing.T) {
+	root := &Command{Name: "ex", Key: 1, Subcommands: []*Command{{Name: "run", Key: 2}}}
+	for _, required := range []bool{false, true} {
+		for _, name := range []string{"", "ACTION"} {
+			help := HelpTable{{Key: 1, SubcommandRequired: required, SubcommandValueName: name}}
+			placeholder := name
+			if placeholder == "" {
+				placeholder = "SUBCOMMAND"
+			}
+			want := "ex [" + placeholder + "]"
+			if required {
+				want = "ex <" + placeholder + ">"
+			}
+			if got := UsageLine([]string{"ex"}, root, help); got != want {
+				t.Errorf("required=%v name=%q: got %q, want %q", required, name, got, want)
+			}
+		}
+	}
+}
+
 // A rendered failure is judged on three things rather than on bytes: it says what
 // went wrong, it shows the command the user was actually in, and it says what to
 // try next. There is no reference to match here — see render.go.

--- a/go/argv/sections_test.go
+++ b/go/argv/sections_test.go
@@ -130,7 +130,7 @@ func TestATemplateOmitsASection(t *testing.T) {
 	want := strings.Join([]string{
 		"An example",
 		"",
-		"Usage: ex <SUBCOMMAND>",
+		"Usage: ex [SUBCOMMAND]",
 		"",
 		"Flags:",
 		"  -h, --help  Print help",

--- a/go/conformance/help_test.go
+++ b/go/conformance/help_test.go
@@ -93,8 +93,8 @@ func TestTheRootLineIsWhatAUserWouldRecognise(t *testing.T) {
 	if !strings.HasPrefix(line, "mise ") {
 		t.Errorf("the line should start with the binary: %s", line)
 	}
-	if !strings.HasSuffix(line, "<SUBCOMMAND>") {
-		t.Errorf("mise has subcommands, so the line should say so: %s", line)
+	if !strings.HasSuffix(line, "[SUBCOMMAND]") {
+		t.Errorf("mise has optional subcommands, so the line should say so: %s", line)
 	}
 }
 

--- a/lib/src/docs/cli/mod.rs
+++ b/lib/src/docs/cli/mod.rs
@@ -1305,7 +1305,7 @@ cmd sneaky hide=#true help="a hidden command"
         // above it did not mention. A heading whose every entry is hidden produces no
         // section, which is the rule markdown rendering already followed.
         assert_snapshot!(render_help(&spec, &spec.cmd, false), @"
-        Usage: ex [--visible] [SHOWN] <SUBCOMMAND>
+        Usage: ex [--visible] [SHOWN] [SUBCOMMAND]
 
         Commands:
           open  a command
@@ -1543,7 +1543,7 @@ cmd "run" help="Run it"
         assert_snapshot!(render_help(&spec, &spec.cmd, false), @"
         An example
 
-        Usage: ex [--force] <file> <SUBCOMMAND>
+        Usage: ex [--force] <file> [SUBCOMMAND]
 
         Flags:
               --force  Do it anyway
@@ -1575,7 +1575,7 @@ cmd "run" help="Run it"
         .unwrap();
 
         assert_snapshot!(render_help(&spec, &spec.cmd, true), @"
-        Usage: ex [--force] <SUBCOMMAND>
+        Usage: ex [--force] [SUBCOMMAND]
 
         Flags:
               --force    Do it anyway
@@ -1869,7 +1869,7 @@ cmd "new-cmd" help="Do something better"
         .unwrap();
 
         assert_snapshot!(render_help(&spec, &spec.cmd, false), @"
-        Usage: testcli [--old] <SUBCOMMAND>
+        Usage: testcli [--old] [SUBCOMMAND]
 
         Commands:
           new-cmd  Do something better
@@ -1912,7 +1912,7 @@ cmd "run" help="Run it\n"
         .unwrap();
 
         let page = render_help(&spec, &spec.cmd, false);
-        assert!(page.contains("Usage: testcli <ACTION>"), "{page}");
+        assert!(page.contains("Usage: testcli [ACTION]"), "{page}");
         assert!(page.contains("\nActions:\n"), "{page}");
     }
 

--- a/lib/src/docs/markdown/cmd.rs
+++ b/lib/src/docs/markdown/cmd.rs
@@ -42,7 +42,7 @@ mod tests {
         assert_snapshot!(ctx.render_cmd(&SPEC_KITCHEN_SINK.cmd).unwrap(), @"
         # `mycli`
 
-        - **Usage:** `mycli [FLAGS] <ARGS>… <SUBCOMMAND>`
+        - **Usage:** `mycli [FLAGS] <ARGS>… [SUBCOMMAND]`
 
         ## Arguments
         - **`<arg1>`** — arg1 description
@@ -96,7 +96,7 @@ mod tests {
 
         ## Subcommands
 
-        - [`mycli plugin <SUBCOMMAND>`](/plugin.md)
+        - [`mycli plugin [SUBCOMMAND]`](/plugin.md)
         ");
     }
 
@@ -236,7 +236,7 @@ cmd "sub" help="a subcommand"
         assert_snapshot!(ctx.render_cmd(&spec.cmd).unwrap(), @"
         # `mycli`
 
-        - **Usage:** `mycli [FLAGS] <SUBCOMMAND>`
+        - **Usage:** `mycli [FLAGS] [SUBCOMMAND]`
 
         ## Global Flags
         - **`--verbose`** — Verbose output

--- a/lib/src/docs/markdown/spec.rs
+++ b/lib/src/docs/markdown/spec.rs
@@ -101,7 +101,7 @@ mod tests {
         assert_snapshot!(ctx.render_spec().unwrap(), @"
         # `mycli`
 
-        - **Usage:** `mycli [FLAGS] <ARGS>… <SUBCOMMAND>`
+        - **Usage:** `mycli [FLAGS] <ARGS>… [SUBCOMMAND]`
 
         ## Arguments
         - **`<arg1>`** — arg1 description
@@ -149,7 +149,7 @@ mod tests {
 
         ## `mycli plugin`
 
-        - **Usage:** `mycli plugin <SUBCOMMAND>`
+        - **Usage:** `mycli plugin [SUBCOMMAND]`
         - **Source code:** [`src/cli/plugin.rs`](https://github.com/jdx/mise/blob/main/src/cli/plugin.rs)
 
         ## `mycli plugin install`

--- a/lib/src/sdk/python/snapshots/usage__sdk__python__tests__python_client.snap
+++ b/lib/src/sdk/python/snapshots/usage__sdk__python__tests__python_client.snap
@@ -14,7 +14,7 @@ class Mycli:
         self.plugin = Plugin(self._runner)
 
     def exec(self, args: MycliArgs, flags: Optional[MycliFlags] = None) -> CliResult:
-        """[FLAGS] <ARGS>… <SUBCOMMAND>"""
+        """[FLAGS] <ARGS>… [SUBCOMMAND]"""
         cmd_args: list[str] = []
         if args.arg1 is not None: cmd_args.append(str(args.arg1))
         if args.arg2 is not None: cmd_args.append(str(args.arg2))
@@ -41,7 +41,7 @@ class Plugin:
         self.install = Install(self._runner)
 
     def exec(self) -> CliResult:
-        """plugin <SUBCOMMAND>"""
+        """plugin [SUBCOMMAND]"""
         cmd_args: list[str] = ["plugin"]
         return self._runner.run(cmd_args)
 

--- a/lib/src/sdk/python/snapshots/usage__sdk__python__tests__python_client_edge_cases.snap
+++ b/lib/src/sdk/python/snapshots/usage__sdk__python__tests__python_client_edge_cases.snap
@@ -15,7 +15,7 @@ class Runner:
         self.info = Info(self._runner)
 
     def exec(self, args: RunnerArgs, flags: Optional[RunnerFlags] = None) -> CliResult:
-        """[-v --verbose] [--debug] <input> <extra>… <SUBCOMMAND>"""
+        """[-v --verbose] [--debug] <input> <extra>… [SUBCOMMAND]"""
         cmd_args: list[str] = []
         if args._input is not None: cmd_args.append(str(args._input))
         if args.extra is not None: cmd_args.extend(args.extra)

--- a/lib/src/sdk/python/snapshots/usage__sdk__python__tests__python_deep_nesting.snap
+++ b/lib/src/sdk/python/snapshots/usage__sdk__python__tests__python_deep_nesting.snap
@@ -14,7 +14,7 @@ class App:
         self.db = Db(self._runner)
 
     def exec(self) -> CliResult:
-        """<SUBCOMMAND>"""
+        """[SUBCOMMAND]"""
         cmd_args: list[str] = []
         return self._runner.run(cmd_args)
 
@@ -25,7 +25,7 @@ class Db:
         self.migration = Migration(self._runner)
 
     def exec(self) -> CliResult:
-        """db <SUBCOMMAND>"""
+        """db [SUBCOMMAND]"""
         cmd_args: list[str] = ["db"]
         return self._runner.run(cmd_args)
 
@@ -37,7 +37,7 @@ class Migration:
         self.run = Run(self._runner)
 
     def exec(self) -> CliResult:
-        """db migration <SUBCOMMAND>"""
+        """db migration [SUBCOMMAND]"""
         cmd_args: list[str] = ["db", "migration"]
         return self._runner.run(cmd_args)
 

--- a/lib/src/sdk/python/snapshots/usage__sdk__python__tests__python_double_dash_automatic.snap
+++ b/lib/src/sdk/python/snapshots/usage__sdk__python__tests__python_double_dash_automatic.snap
@@ -14,7 +14,7 @@ class Runner:
         self.run = Run(self._runner)
 
     def exec(self, args: RunnerArgs, flags: Optional[RunnerFlags] = None) -> CliResult:
-        """[--verbose] <input> <extra>… <SUBCOMMAND>"""
+        """[--verbose] <input> <extra>… [SUBCOMMAND]"""
         cmd_args: list[str] = []
         if args._input is not None: cmd_args.append(str(args._input))
         if args.extra is not None: cmd_args.extend(args.extra)

--- a/lib/src/sdk/python/snapshots/usage__sdk__python__tests__python_example_without_lang.snap
+++ b/lib/src/sdk/python/snapshots/usage__sdk__python__tests__python_example_without_lang.snap
@@ -14,7 +14,7 @@ class App:
         self.greet = Greet(self._runner)
 
     def exec(self) -> CliResult:
-        """<SUBCOMMAND>"""
+        """[SUBCOMMAND]"""
         cmd_args: list[str] = []
         return self._runner.run(cmd_args)
 

--- a/lib/src/sdk/python/snapshots/usage__sdk__python__tests__python_exec_edge_cases.snap
+++ b/lib/src/sdk/python/snapshots/usage__sdk__python__tests__python_exec_edge_cases.snap
@@ -15,7 +15,7 @@ class Runner:
         self.info = Info(self._runner)
 
     def exec(self, args: RunnerArgs, flags: Optional[RunnerFlags] = None) -> CliResult:
-        """[-v --verbose] <input> <extra>… <SUBCOMMAND>"""
+        """[-v --verbose] <input> <extra>… [SUBCOMMAND]"""
         cmd_args: list[str] = []
         if args._input is not None: cmd_args.append(str(args._input))
         if args.extra is not None: cmd_args.extend(args.extra)

--- a/lib/src/sdk/python/snapshots/usage__sdk__python__tests__python_flags_only_subcommand.snap
+++ b/lib/src/sdk/python/snapshots/usage__sdk__python__tests__python_flags_only_subcommand.snap
@@ -14,7 +14,7 @@ class App:
         self.status = Status(self._runner)
 
     def exec(self) -> CliResult:
-        """<SUBCOMMAND>"""
+        """[SUBCOMMAND]"""
         cmd_args: list[str] = []
         return self._runner.run(cmd_args)
 

--- a/lib/src/sdk/python/snapshots/usage__sdk__python__tests__python_full_feature_client.snap
+++ b/lib/src/sdk/python/snapshots/usage__sdk__python__tests__python_full_feature_client.snap
@@ -15,7 +15,7 @@ class Mytool:
         self.deploy = Deploy(self._runner)
 
     def exec(self, args: MytoolArgs, flags: Optional[MytoolFlags] = None) -> CliResult:
-        """[FLAGS] <input> <extra>… <SUBCOMMAND>"""
+        """[FLAGS] <input> <extra>… [SUBCOMMAND]"""
         cmd_args: list[str] = []
         if args._input is not None: cmd_args.append(str(args._input))
         if args.extra is not None: cmd_args.extend(args.extra)

--- a/lib/src/sdk/python/snapshots/usage__sdk__python__tests__python_global_flags_flags_only.snap
+++ b/lib/src/sdk/python/snapshots/usage__sdk__python__tests__python_global_flags_flags_only.snap
@@ -15,7 +15,7 @@ class App:
         self.info = Info(self._runner)
 
     def exec(self, flags: Optional[AppFlags] = None) -> CliResult:
-        """[-v --verbose] <SUBCOMMAND>"""
+        """[-v --verbose] [SUBCOMMAND]"""
         cmd_args: list[str] = []
         flag_args = self._build_flag_args(flags)
         return self._runner.run(cmd_args + flag_args)

--- a/lib/src/sdk/python/snapshots/usage__sdk__python__tests__python_hyphenated_subcommands.snap
+++ b/lib/src/sdk/python/snapshots/usage__sdk__python__tests__python_hyphenated_subcommands.snap
@@ -15,7 +15,7 @@ class Cli:
         self.remove_remote = RemoveRemote(self._runner)
 
     def exec(self) -> CliResult:
-        """<SUBCOMMAND>"""
+        """[SUBCOMMAND]"""
         cmd_args: list[str] = []
         return self._runner.run(cmd_args)
 

--- a/lib/src/sdk/typescript/snapshots/usage__sdk__typescript__types__tests__deep_nesting.snap
+++ b/lib/src/sdk/typescript/snapshots/usage__sdk__typescript__types__tests__deep_nesting.snap
@@ -15,7 +15,7 @@ export class App {
     this.runner = new CliRunner(binPath ?? "app");
     this.db = new Db(this.runner);
   }
-  /** <SUBCOMMAND> */
+  /** [SUBCOMMAND] */
   async exec(): Promise<CliResult> {
     return this.runner.run([]);
   }
@@ -31,7 +31,7 @@ export class Db {
     this.runner = runner;
     this.migration = new Migration(this.runner);
   }
-  /** db <SUBCOMMAND> */
+  /** db [SUBCOMMAND] */
   async exec(): Promise<CliResult> {
     return this.runner.run(["db"]);
   }
@@ -50,7 +50,7 @@ export class Migration {
     this.create = new Create(this.runner);
     this.run = new Run(this.runner);
   }
-  /** db migration <SUBCOMMAND> */
+  /** db migration [SUBCOMMAND] */
   async exec(): Promise<CliResult> {
     return this.runner.run(["db", "migration"]);
   }

--- a/lib/src/sdk/typescript/snapshots/usage__sdk__typescript__types__tests__flags_only_subcommand.snap
+++ b/lib/src/sdk/typescript/snapshots/usage__sdk__typescript__types__tests__flags_only_subcommand.snap
@@ -15,7 +15,7 @@ export class App {
     this.runner = new CliRunner(binPath ?? "app");
     this.status = new Status(this.runner);
   }
-  /** <SUBCOMMAND> */
+  /** [SUBCOMMAND] */
   async exec(): Promise<CliResult> {
     return this.runner.run([]);
   }

--- a/lib/src/sdk/typescript/snapshots/usage__sdk__typescript__types__tests__full_feature_client.snap
+++ b/lib/src/sdk/typescript/snapshots/usage__sdk__typescript__types__tests__full_feature_client.snap
@@ -20,7 +20,7 @@ export class Mytool {
     this.build = new Build(this.runner);
     this.deploy = new Deploy(this.runner);
   }
-  /** [FLAGS] <input> <extra>… <SUBCOMMAND> */
+  /** [FLAGS] <input> <extra>… [SUBCOMMAND] */
   async exec(args: MytoolArgs, flags?: MytoolFlags): Promise<CliResult> {
     const cmdArgs: string[] = [];
     if (args.input !== undefined) { cmdArgs.push(String(args.input)); }

--- a/lib/src/sdk/typescript/snapshots/usage__sdk__typescript__types__tests__hyphenated_subcommands.snap
+++ b/lib/src/sdk/typescript/snapshots/usage__sdk__typescript__types__tests__hyphenated_subcommands.snap
@@ -18,7 +18,7 @@ export class Cli {
     this.addRemote = new AddRemote(this.runner);
     this.removeRemote = new RemoveRemote(this.runner);
   }
-  /** <SUBCOMMAND> */
+  /** [SUBCOMMAND] */
   async exec(): Promise<CliResult> {
     return this.runner.run([]);
   }

--- a/lib/src/sdk/typescript/snapshots/usage__sdk__typescript__types__tests__typescript_client.snap
+++ b/lib/src/sdk/typescript/snapshots/usage__sdk__typescript__types__tests__typescript_client.snap
@@ -14,7 +14,7 @@ export class Mycli {
     this.runner = new CliRunner(binPath ?? "mycli");
     this.plugin = new Plugin(this.runner);
   }
-  /** [FLAGS] <ARGS>… <SUBCOMMAND> */
+  /** [FLAGS] <ARGS>… [SUBCOMMAND] */
   async exec(args: MycliArgs, flags?: MycliFlags): Promise<CliResult> {
     const cmdArgs: string[] = [];
     if (args.arg1 !== undefined) { cmdArgs.push(String(args.arg1)); }
@@ -47,7 +47,7 @@ export class Plugin {
     this.runner = runner;
     this.install = new Install(this.runner);
   }
-  /** plugin <SUBCOMMAND> */
+  /** plugin [SUBCOMMAND] */
   async exec(): Promise<CliResult> {
     return this.runner.run(["plugin"]);
   }

--- a/lib/src/sdk/typescript/snapshots/usage__sdk__typescript__types__tests__typescript_client_edge_cases.snap
+++ b/lib/src/sdk/typescript/snapshots/usage__sdk__typescript__types__tests__typescript_client_edge_cases.snap
@@ -18,7 +18,7 @@ export class Runner {
     this.run = new Run(this.runner);
     this.info = new Info(this.runner);
   }
-  /** [-v --verbose] [--debug] <input> <extra>… <SUBCOMMAND> */
+  /** [-v --verbose] [--debug] <input> <extra>… [SUBCOMMAND] */
   async exec(args: RunnerArgs, flags?: RunnerFlags): Promise<CliResult> {
     const cmdArgs: string[] = [];
     if (args.input !== undefined) { cmdArgs.push(String(args.input)); }

--- a/lib/src/sdk/typescript/snapshots/usage__sdk__typescript__types__tests__typescript_double_dash_automatic.snap
+++ b/lib/src/sdk/typescript/snapshots/usage__sdk__typescript__types__tests__typescript_double_dash_automatic.snap
@@ -15,7 +15,7 @@ export class Runner {
     this.runner = new CliRunner(binPath ?? "runner");
     this.run = new Run(this.runner);
   }
-  /** [--verbose] <input> <extra>… <SUBCOMMAND> */
+  /** [--verbose] <input> <extra>… [SUBCOMMAND] */
   async exec(args: RunnerArgs, flags?: RunnerFlags): Promise<CliResult> {
     const cmdArgs: string[] = [];
     if (args.input !== undefined) { cmdArgs.push(String(args.input)); }

--- a/lib/src/sdk/typescript/snapshots/usage__sdk__typescript__types__tests__typescript_example_without_lang.snap
+++ b/lib/src/sdk/typescript/snapshots/usage__sdk__typescript__types__tests__typescript_example_without_lang.snap
@@ -15,7 +15,7 @@ export class App {
     this.runner = new CliRunner(binPath ?? "app");
     this.greet = new Greet(this.runner);
   }
-  /** <SUBCOMMAND> */
+  /** [SUBCOMMAND] */
   async exec(): Promise<CliResult> {
     return this.runner.run([]);
   }

--- a/lib/src/sdk/typescript/snapshots/usage__sdk__typescript__types__tests__typescript_global_flags_flags_only.snap
+++ b/lib/src/sdk/typescript/snapshots/usage__sdk__typescript__types__tests__typescript_global_flags_flags_only.snap
@@ -18,7 +18,7 @@ export class App {
     this.status = new Status(this.runner);
     this.info = new Info(this.runner);
   }
-  /** [-v --verbose] <SUBCOMMAND> */
+  /** [-v --verbose] [SUBCOMMAND] */
   async exec(flags?: AppFlags): Promise<CliResult> {
     const cmdArgs: string[] = [];
     const flagArgs = this.buildFlagArgs(flags);

--- a/lib/src/spec/cmd.rs
+++ b/lib/src/spec/cmd.rs
@@ -875,7 +875,18 @@ impl SpecCommand {
                 .subcommand_value_name
                 .as_deref()
                 .unwrap_or("SUBCOMMAND");
-            usage = format!("{usage} <{name}>");
+            usage = if self.subcommand_required {
+                format!("{usage} <{name}>")
+            } else {
+                format!("{usage} [{name}]")
+            };
+        }
+        for synopsis in self
+            .mounts
+            .iter()
+            .filter_map(|mount| mount.synopsis.as_deref())
+        {
+            usage = format!("{usage} {synopsis}");
         }
         usage.trim().to_string()
     }

--- a/lib/src/spec/mod.rs
+++ b/lib/src/spec/mod.rs
@@ -1549,7 +1549,7 @@ source_code_link_template "https://github.com/jdx/mise/blob/main/src/cli/{{path}
         assert_eq!(go.full_cmd, ["go"]);
         // `usage()` names the command and then what it takes — `go` has a subcommand, so it
         // says so. The point is that the command's own name is in there at all.
-        assert_eq!(go.usage, "go <SUBCOMMAND>");
+        assert_eq!(go.usage, "go [SUBCOMMAND]");
 
         // And all the way down, which is what makes it a walk rather than one level.
         let fast = go.subcommands.get("fast").expect("fast");
@@ -2329,7 +2329,7 @@ echo "hello"
             ["plugins", "formatter"]
         );
         assert!(
-            path(&grafted, &["plugins"]).1.contains("<SUBCOMMAND>"),
+            path(&grafted, &["plugins"]).1.contains("[SUBCOMMAND]"),
             "{:?}",
             path(&grafted, &["plugins"]).1
         );

--- a/lib/src/spec/mod.rs
+++ b/lib/src/spec/mod.rs
@@ -209,6 +209,7 @@ impl Spec {
             && self.default_subcommand.is_some()
             && !self.cmd.mounts.iter().any(|mount| mount.overrides_default);
         resolve(&mut self.cmd, outputs, default_outranks_root_mounts)?;
+        self.restamp();
         self.cmd
             .validate_clause_flag_spellings()
             .map_err(UsageErr::InvalidSpec)
@@ -2259,6 +2260,24 @@ echo "hello"
         assert_eq!(spec.name, "my-script.usage.kdl");
         assert_eq!(spec.bin, "my-script.usage.kdl");
         assert!(spec.cmd.name.is_empty());
+    }
+
+    #[test]
+    fn resolving_mounts_replaces_the_unresolved_synopsis() {
+        let mut spec: Spec = "bin ex\nmount run=tasks synopsis=\"[TASK] [ARGS]…\""
+            .parse()
+            .unwrap();
+        assert!(spec.cmd.usage.contains("[TASK] [ARGS]…"));
+        spec.resolve_mount_outputs(&HashMap::from([(
+            "tasks".to_string(),
+            "cmd build".to_string(),
+        )]))
+        .unwrap();
+        assert!(spec.cmd.mounts.is_empty());
+        assert_eq!(spec.cmd.usage, "[SUBCOMMAND]");
+        assert_eq!(spec.cmd.subcommands["build"].usage, "build");
+        let json = serde_json::to_value(&spec).unwrap();
+        assert_eq!(json["cmd"]["usage"], "[SUBCOMMAND]");
     }
 
     #[test]

--- a/lib/src/spec/mount.rs
+++ b/lib/src/spec/mount.rs
@@ -11,6 +11,9 @@ use crate::spec::helpers::{string_entry, NodeHelper};
 #[non_exhaustive]
 pub struct SpecMount {
     pub run: String,
+    /// Display-only arguments for this unresolved mount; never executes discovery.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub synopsis: Option<String>,
     /// Whether a discovered command may take precedence over
     /// [`Spec::default_subcommand`](crate::Spec::default_subcommand).
     ///
@@ -27,6 +30,7 @@ impl SpecMount {
     pub fn new(run: impl Into<String>) -> Self {
         Self {
             run: run.into(),
+            synopsis: None,
             overrides_default: false,
         }
     }
@@ -35,6 +39,7 @@ impl SpecMount {
     pub fn overriding_default(run: impl Into<String>) -> Self {
         Self {
             run: run.into(),
+            synopsis: None,
             overrides_default: true,
         }
     }
@@ -46,6 +51,7 @@ impl SpecMount {
         for (k, v) in node.props() {
             match k {
                 "run" => mount.run = v.ensure_string()?,
+                "synopsis" => mount.synopsis = Some(v.ensure_string()?),
                 "overrides_default" => mount.overrides_default = v.ensure_bool()?,
                 k => bail_parse!(ctx, v.entry.span(), "unsupported mount key {k}"),
             }
@@ -53,6 +59,7 @@ impl SpecMount {
         for child in node.children() {
             match child.name() {
                 "run" => mount.run = child.arg(0)?.ensure_string()?,
+                "synopsis" => mount.synopsis = Some(child.arg(0)?.ensure_string()?),
                 "overrides_default" => mount.overrides_default = child.arg(0)?.ensure_bool()?,
                 k => bail_parse!(
                     ctx,
@@ -75,6 +82,9 @@ impl From<&SpecMount> for KdlNode {
     fn from(mount: &SpecMount) -> KdlNode {
         let mut node = KdlNode::new("mount");
         node.push(string_entry(Some("run"), &mount.run));
+        if let Some(synopsis) = &mount.synopsis {
+            node.push(string_entry(Some("synopsis"), synopsis));
+        }
         if mount.overrides_default {
             node.push(KdlEntry::new_prop("overrides_default", true));
         }
@@ -85,5 +95,45 @@ impl From<&SpecMount> for KdlNode {
 impl Display for SpecMount {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.usage())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn unresolved_mount_synopsis_round_trips_and_renders_without_discovery() {
+        let spec: crate::Spec = "bin ex\ncmd run {\n mount run=\"this-command-must-never-run\" synopsis=\"[TASK] [ARGS]…\"\n}\n".parse().unwrap();
+        let run = &spec.cmd.subcommands["run"];
+        assert_eq!(run.usage, "run [TASK] [ARGS]…");
+        let again: crate::Spec = spec.to_string().parse().unwrap();
+        assert_eq!(
+            again.cmd.subcommands["run"].mounts[0].synopsis.as_deref(),
+            Some("[TASK] [ARGS]…")
+        );
+        let json = serde_json::to_value(&spec).unwrap();
+        assert_eq!(
+            json["cmd"]["subcommands"]["run"]["usage"],
+            "run [TASK] [ARGS]…"
+        );
+        #[cfg(feature = "markdown")]
+        assert!(crate::docs::markdown::MarkdownRenderer::new(spec.clone())
+            .render_cmd(run)
+            .unwrap()
+            .contains("run [TASK] [ARGS]…"));
+        #[cfg(feature = "cli-help")]
+        assert!(crate::docs::cli::render_help(&spec, run, true).contains("run [TASK] [ARGS]…"));
+    }
+
+    #[test]
+    fn subcommand_required_controls_custom_placeholder() {
+        for (required, expected) in [(true, "<ACTION>"), (false, "[ACTION]")] {
+            let source = format!(
+                "bin ex\nsubcommand_required #{required}\nsubcommand_value_name ACTION\ncmd go\n"
+            );
+            let spec: crate::Spec = source.parse().unwrap();
+            assert_eq!(spec.cmd.usage, expected);
+        }
+        let spec: crate::Spec = "bin ex\nmount run=\"never-run\"\n".parse().unwrap();
+        assert_eq!(spec.cmd.usage, "");
     }
 }

--- a/lib/tests/parse.rs
+++ b/lib/tests/parse.rs
@@ -166,7 +166,7 @@ Flags:
 cmd_help_short:
     spec=r#"cmd "cmd" help="shorthelp" help_long="help\nfooo\nbar""#,
     args="-h",
-    expected=r#"Usage: <SUBCOMMAND>
+    expected=r#"Usage: [SUBCOMMAND]
 
 Commands:
   cmd   shorthelp
@@ -179,7 +179,7 @@ Flags:
 cmd_help_long:
     spec=r#"cmd "cmd" help="shorthelp" help_long="help\nfooo\nbar""#,
     args="--help",
-    expected=r#"Usage: <SUBCOMMAND>
+    expected=r#"Usage: [SUBCOMMAND]
 
 Commands:
   cmd   shorthelp
@@ -194,7 +194,7 @@ subcommand_help_short:
     cmd "install" help="shorthelp" help_long="help\nfooo\nbar"
 }"#,
     args="plugins -h",
-    expected=r#"Usage: plugins <SUBCOMMAND>
+    expected=r#"Usage: plugins [SUBCOMMAND]
 
 Commands:
   install  shorthelp

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -2400,7 +2400,7 @@ fn typed_subcommand_presentation_reaches_help_and_the_spec() {
     assert!(kdl.contains("subcommand_value_name ACTION"), "{kdl}");
     let spec = PresentedSubcommands::spec();
     let page = usage::argv::help::short_help(spec, &["presented"], &[spec.root]);
-    assert!(page.contains("<ACTION>"), "{page}");
+    assert!(page.contains("[ACTION]"), "{page}");
     assert!(page.contains("Actions:"), "{page}");
 }
 


### PR DESCRIPTION
Generated synopses displayed `<SUBCOMMAND>` even when the command could run without a subcommand. Honor `subcommand_required` and custom placeholder names in the shared generated usage string, keeping terminal help, Markdown, man pages, JSON, and SDK documentation consistent.

Add optional `synopsis` metadata to unresolved mounts, allowing `mount run="mycli tasks --usage" synopsis="[TASK] [ARGS]…"` to document dynamic arguments without invoking discovery. This is display metadata only; parsing and completion remain unchanged. Consumers must require a usage release supporting the new property before emitting it.

Validation: all usage-lib unit and integration tests, KDL/JSON round trips and no-discovery rendering tests, updated presentation snapshots, and Clippy with all features/targets and warnings denied.

Also verified the compiled argv/reference fleet parity and all eight generated-help parity tests, the 83 facade tests, and repository render/shadow generators. The broader local shell integration run was not clean on macOS (including the system Bash lacking `complete -D`); no checks or assertions were disabled.

AI-assisted with Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to help and documentation strings plus display-only mount metadata; argv parsing and completion behavior are explicitly unchanged.
> 
> **Overview**
> Generated usage synopses always showed **`<SUBCOMMAND>`** even when a command does not require a child. Help, Markdown, man pages, JSON, and SDK docs now use **`[SUBCOMMAND]`** (or **`[ACTION]`** etc.) when `subcommand_required` is false, and keep angle brackets when it is true. The same rule is applied in **usage-lib** (`SpecCommand::usage`), **usage-argv** help rendering, and **usage-go** `UsageLine`.
> 
> **Unresolved mounts** can declare an optional **`synopsis`** (e.g. `synopsis="[TASK] [ARGS]…"`) so documentation shows dynamic-looking placeholders **without** running discovery; parsing and completion are unchanged. After mounts resolve, usage is **restamped** so the display-only synopsis is replaced by the real subcommand tree.
> 
> Corpus fixtures, conformance tests, mise parity checks, and generated mise docs snapshots were updated to expect **`[SUBCOMMAND]`** where subcommands are optional.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a73b97b59b4477d1f9aea6ba33fe17daaedcd0f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->