### PR TITLE
feat(docs): configure markdown link extensions

### DIFF
--- a/cli/assets/fig.ts
+++ b/cli/assets/fig.ts
@@ -740,6 +740,15 @@ const completionSpec: Fig.Spec = {
               },
             },
             {
+              name: "--link-extension",
+              description:
+                "Extension for page links (including the dot); empty means extensionless URLs",
+              isRepeatable: false,
+              args: {
+                name: "link_extension",
+              },
+            },
+            {
               name: "--template",
               description:
                 "Replace a built-in Tera template, as NAME=PATH; the names are spec, index, command, argument, flag, and config",

--- a/cli/assets/usage.1
+++ b/cli/assets/usage.1
@@ -574,6 +574,12 @@ Turn four\-space indented blocks in help text into markdown code fences
 \fB\-\-url\-prefix\fR \fI<URL_PREFIX>\fR
 Prefix for the links between pages, such as /cli/reference
 .TP
+\fB\-\-link\-extension\fR \fI<LINK_EXTENSION>\fR
+Extension for page links (including the dot); empty means extensionless URLs
+.RS
+\fIDefault: \fR.md
+.RE
+.TP
 \fB\-\-template\fR \fI<TEMPLATE>\fR
 Replace a built\-in Tera template, as NAME=PATH; the names are spec, index, command, argument, flag, and config
 .TP

--- a/cli/src/cli/generate/markdown.rs
+++ b/cli/src/cli/generate/markdown.rs
@@ -62,6 +62,10 @@ pub struct Markdown {
     #[usage(long)]
     url_prefix: Option<String>,
 
+    /// Extension for page links (including the dot); empty means extensionless URLs
+    #[usage(long, default = ".md")]
+    link_extension: String,
+
     /// Replace a built-in Tera template, as NAME=PATH; the names are spec, index, command, argument, flag, and config
     #[usage(long)]
     template: Vec<String>,
@@ -88,6 +92,7 @@ impl usage_rs::Run for Markdown {
         };
         let spec = select_view(parse_file_or_stdin(&self.file)?, self.view.as_deref())?;
         let mut ctx = MarkdownRenderer::new(spec.clone())
+            .with_link_extension(self.link_extension)
             .with_html_encode(self.html_encode)
             .with_indented_blocks_to_code_fences(self.indented_blocks_to_code_fences);
         for value in &self.template {

--- a/cli/tests/markdown.rs
+++ b/cli/tests/markdown.rs
@@ -215,6 +215,41 @@ fn test_markdown_snapshot_with_examples() {
 }
 
 #[test]
+fn markdown_link_extension_keeps_markdown_output_files() {
+    for extension in [".md", ".html", ""] {
+        let dir = std::env::temp_dir().join(format!(
+            "usage_link_extension_{}_{}",
+            std::process::id(),
+            extension.len()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let output = usage_cmd()
+            .args(["generate", "markdown", "-f"])
+            .arg(example_path("with-examples.usage.kdl"))
+            .args([
+                "--multi",
+                "--url-prefix",
+                "/cli",
+                "--link-extension",
+                extension,
+                "--out-dir",
+            ])
+            .arg(&dir)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let index = std::fs::read_to_string(dir.join("index.md")).unwrap();
+        assert!(index.contains(&format!("{extension})")), "{index}");
+        assert!(!dir.join("index.html").exists());
+        fs::remove_dir_all(&dir).unwrap();
+    }
+}
+
+#[test]
 fn test_markdown_stdout_when_out_file_omitted() {
     // The two spellings of "stdout" have to agree; `--out-file -` exists for callers that
     // build the path in a variable.

--- a/cli/usage.usage.kdl
+++ b/cli/usage.usage.kdl
@@ -406,6 +406,9 @@ Turn four-space indented blocks in help text into markdown code fences
         flag --url-prefix help="Prefix for the links between pages, such as /cli/reference" {
             arg <URL_PREFIX>
         }
+        flag --link-extension help="Extension for page links (including the dot); empty means extensionless URLs" default=.md {
+            arg <LINK_EXTENSION>
+        }
         flag --template help="Replace a built-in Tera template, as NAME=PATH; the names are spec, index, command, argument, flag, and config" var=#true {
             arg <TEMPLATE>
         }

--- a/docs/cli/markdown.md
+++ b/docs/cli/markdown.md
@@ -32,6 +32,12 @@ Links between the pages are written from the root of the output, as `/bash.md`.
 `--url-prefix /cli/reference` puts a path in front of them, `/cli/reference/bash.md`, which is
 what a docs site serving the pages under a subdirectory needs.
 
+Use `--link-extension .html` when your site serves rendered HTML, or
+`--link-extension ''` for extensionless URLs. The default is `.md`. This affects
+command and configuration links, while generated files still end in `.md`.
+Rust callers can use `with_link_extension(".html")`; custom templates receive
+`link_extension` and `config_link` alongside the existing `url_prefix`.
+
 ## Custom templates from the CLI
 
 Every part of the output comes from a [Tera](https://keats.github.io/tera/) template, and

--- a/docs/cli/reference/commands.json
+++ b/docs/cli/reference/commands.json
@@ -1447,6 +1447,24 @@
                 }
               },
               {
+                "name": "link-extension",
+                "usage": "--link-extension <LINK_EXTENSION>",
+                "help": "Extension for page links (including the dot); empty means extensionless URLs",
+                "help_first_line": "Extension for page links (including the dot); empty means extensionless URLs",
+                "short": [],
+                "long": ["link-extension"],
+                "hide": false,
+                "global": false,
+                "arg": {
+                  "name": "LINK_EXTENSION",
+                  "usage": "<LINK_EXTENSION>",
+                  "required": true,
+                  "double_dash": "Optional",
+                  "hide": false
+                },
+                "default": [".md"]
+              },
+              {
                 "name": "template",
                 "usage": "--template <TEMPLATE>",
                 "help": "Replace a built-in Tera template, as NAME=PATH; the names are spec, index, command, argument, flag, and config",

--- a/docs/cli/reference/generate/markdown.md
+++ b/docs/cli/reference/generate/markdown.md
@@ -30,5 +30,9 @@ One page by default, or a page per command with --multi. Every part of the outpu
   `--replace-pre-with-code-fences` is the former name and still works. It was always a misnomer: this has never looked at `<pre>` tags.
 
 - **`--url-prefix <URL_PREFIX>`** — Prefix for the links between pages, such as /cli/reference
+- **`--link-extension <LINK_EXTENSION>`** — Extension for page links (including the dot); empty means extensionless URLs
+
+  **Default:** `.md`
+
 - **`--template <TEMPLATE>`** — Replace a built-in Tera template, as NAME=PATH; the names are spec, index, command, argument, flag, and config
 - **`-h --help`** — Print help

--- a/lib/src/docs/markdown/renderer.rs
+++ b/lib/src/docs/markdown/renderer.rs
@@ -132,6 +132,7 @@ pub struct MarkdownRenderer {
     pub(crate) header_level: usize,
     pub(crate) multi: bool,
     url_prefix: Option<String>,
+    link_extension: String,
     html_encode: bool,
     indented_blocks_to_code_fences: bool,
     theme: MarkdownTheme,
@@ -146,6 +147,7 @@ impl MarkdownRenderer {
             header_level: 1,
             multi: false,
             url_prefix: None,
+            link_extension: ".md".into(),
             html_encode: true,
             indented_blocks_to_code_fences: false,
             theme: MarkdownTheme::default(),
@@ -220,6 +222,13 @@ impl MarkdownRenderer {
         self.with(|r| r.html_encode = html_encode)
     }
 
+    /// Extension for generated page links, including the dot (default `.md`).
+    /// Use `.html` for rendered websites or an empty string for extensionless URLs.
+    /// This does not change the names of generated Markdown files.
+    pub fn with_link_extension(self, extension: impl Into<String>) -> Self {
+        self.with(|r| r.link_extension = extension.into())
+    }
+
     /// Turn four-space indented blocks in help text into fenced code blocks.
     pub fn with_indented_blocks_to_code_fences(self, indented_blocks_to_code_fences: bool) -> Self {
         self.with(|r| r.indented_blocks_to_code_fences = indented_blocks_to_code_fences)
@@ -267,6 +276,11 @@ impl MarkdownRenderer {
         ctx.insert("header_level", &self.header_level);
         ctx.insert("multi", &self.multi);
         ctx.insert("url_prefix", &self.url_prefix);
+        ctx.insert("link_extension", &self.link_extension);
+        ctx.insert(
+            "config_link",
+            &format!("configuration{}", self.link_extension),
+        );
         ctx.insert("html_encode", &self.html_encode);
         ctx
     }
@@ -353,6 +367,27 @@ impl MarkdownRenderer {
 mod tests {
     use super::{escape_md, MarkdownRenderer, MarkdownTemplate};
     use pretty_assertions::assert_eq;
+
+    #[test]
+    fn page_links_follow_extension_without_renaming_files() {
+        let spec: crate::Spec = "bin ex\ncmd go\nconfig {\n prop jobs type=\"uint\"\n}\n"
+            .parse()
+            .unwrap();
+        for extension in [".md", ".html", ""] {
+            let renderer = MarkdownRenderer::new(spec.clone())
+                .with_url_prefix("/cli")
+                .with_link_extension(extension);
+            let index = renderer.render_index().unwrap();
+            assert!(index.contains(&format!("(/cli/go{extension})")), "{index}");
+            assert!(
+                index.contains(&format!("(/cli/configuration{extension})")),
+                "{index}"
+            );
+            assert_eq!(renderer.config_page(), "configuration.md");
+            let custom = renderer.with_template(MarkdownTemplate::Index, "{{ link_extension }}");
+            assert_eq!(custom.render_index().unwrap(), extension);
+        }
+    }
 
     #[test]
     fn escapes_html_around_fenced_code_blocks() {

--- a/lib/src/docs/markdown/templates/cmd_template.md.tera
+++ b/lib/src/docs/markdown/templates/cmd_template.md.tera
@@ -167,7 +167,7 @@
 
 {{ "#" | repeat(count=header_level) }}# Subcommands
 {% endif %}
-- [`{{ (spec.bin ~ " " ~ cmd.usage) | trim }}`]({{ url_prefix }}/{{ cmd.full_cmd | join(sep="/") }}.md)
+- [`{{ (spec.bin ~ " " ~ cmd.usage) | trim }}`]({{ url_prefix }}/{{ cmd.full_cmd | join(sep="/") }}{{ link_extension }})
 {%- endif -%}
 {%- endfor -%}
 {%- endif -%}

--- a/lib/src/docs/markdown/templates/compact_cmd_template.md.tera
+++ b/lib/src/docs/markdown/templates/compact_cmd_template.md.tera
@@ -147,7 +147,7 @@
 
 {{ "#" | repeat(count=header_level) }}# Subcommands
 {% endif %}
-- [`{{ (spec.bin ~ " " ~ cmd.usage) | trim }}`]({{ url_prefix }}/{{ cmd.full_cmd | join(sep="/") }}.md)
+- [`{{ (spec.bin ~ " " ~ cmd.usage) | trim }}`]({{ url_prefix }}/{{ cmd.full_cmd | join(sep="/") }}{{ link_extension }})
 {%- endif -%}
 {%- endfor -%}
 {%- endif -%}

--- a/lib/src/docs/markdown/templates/index_template.md.tera
+++ b/lib/src/docs/markdown/templates/index_template.md.tera
@@ -31,7 +31,7 @@
 
 {{ "#" | repeat(count=header_level) }} Subcommands
 {% endif %}
-- [`{{ (spec.bin ~ " " ~ cmd.usage) | trim }}`]({{ url_prefix }}/{{ cmd.full_cmd | join(sep="/") }}.md)
+- [`{{ (spec.bin ~ " " ~ cmd.usage) | trim }}`]({{ url_prefix }}/{{ cmd.full_cmd | join(sep="/") }}{{ link_extension }})
 {%- endfor %}
 {#- The settings page, written beside this one in `--multi` mode by the same run. Gated on
     the same condition that decides whether the page exists at all, so the index never links
@@ -40,5 +40,5 @@
 
 {{ "#" | repeat(count=header_level) }} Configuration
 
-- [Settings]({{ url_prefix }}/{{ config_page }})
+- [Settings]({{ url_prefix }}/{{ config_link }})
 {%- endif -%}


### PR DESCRIPTION
Generated Markdown links always ended in `.md`, requiring consumers serving HTML or extensionless pages to rewrite them after generation. Add `--link-extension` and `MarkdownRenderer::with_link_extension`, defaulting to `.md`, and apply the setting to command and configuration links without changing output filenames.

Expose the extension and configuration link to custom templates, document the option, and regenerate the CLI reference and man page.

Validation: Markdown library tests, Markdown CLI integration tests (including `.md`, `.html`, and empty extensions), and Clippy for usage-lib and usage-cli with all features/targets and warnings denied.

AI-assisted with Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-generation-only change with a backward-compatible default; no runtime CLI parsing or security-sensitive paths affected.
> 
> **Overview**
> Adds **`--link-extension`** (default `.md`) to `usage generate markdown` and **`MarkdownRenderer::with_link_extension`**, so inter-page links can target `.html`, extensionless URLs, or other suffixes without post-processing. **Output filenames stay `.md`**; only hrefs in generated content change.
> 
> Built-in Tera templates now append `link_extension` instead of hardcoded `.md`, and custom templates get **`link_extension`** and **`config_link`** in context. CLI help, man page, Fig spec, and docs are updated, with library and integration tests covering `.md`, `.html`, and empty extension.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f073033ad7d082c9a6977b97bc5b9ba0d39dd8da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--link-extension` option for Markdown generation.
  * Customize page link extensions, including `.html`, `.md`, or extensionless URLs.
  * Generated files remain in Markdown format regardless of the selected link extension.

* **Documentation**
  * Added CLI usage examples and reference documentation for configurable link extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->