### PR TITLE
fix(manpage): render mount synopses and custom command names

### DIFF
--- a/lib/src/docs/manpage/renderer.rs
+++ b/lib/src/docs/manpage/renderer.rs
@@ -275,12 +275,15 @@ impl ManpageRenderer {
 
         // Add subcommands indicator
         if !cmd.subcommands.is_empty() {
+            let name = cmd.subcommand_value_name.as_deref().unwrap_or("COMMAND");
             if cmd.subcommand_required {
-                parts.push("<COMMAND>".to_string());
+                parts.push(format!("<{name}>"));
             } else {
-                parts.push("[COMMAND]".to_string());
+                parts.push(format!("[{name}]"));
             }
         }
+
+        parts.extend(cmd.mount_synopses.iter().cloned());
 
         parts.join(" ")
     }
@@ -514,7 +517,13 @@ impl ManpageRenderer {
             let has_outputs = !subcmd.outputs.is_empty();
             let has_exit_codes = !subcmd.exit_codes.is_empty();
 
-            if has_flags || has_documented_args || has_examples || has_outputs || has_exit_codes {
+            if has_flags
+                || has_documented_args
+                || has_examples
+                || has_outputs
+                || has_exit_codes
+                || !subcmd.mount_synopses.is_empty()
+            {
                 // Section header for this subcommand
                 roff.control("SH", [full_name.to_uppercase().as_str()]);
 
@@ -778,6 +787,23 @@ config {
         let spec: Spec = "name \"ex\"\nbin \"ex\"\n".parse().unwrap();
         let page = ManpageRenderer::new(spec).render().unwrap();
         assert!(!page.contains("CONFIGURATION"), "{page}");
+    }
+
+    #[test]
+    fn unresolved_mounts_and_custom_subcommands_reach_manpage_synopses() {
+        for required in [false, true] {
+            let spec: Spec = format!("name ex\nbin ex\nsubcommand_required #{required}\nsubcommand_value_name ACTION\nmount run=must-not-execute synopsis=\"[ROOT]…\"\ncmd run {{\n mount run=must-not-execute synopsis=\"[TASK] [ARGS]…\"\n}}\n").parse().unwrap();
+            let page = ManpageRenderer::new(spec).render().unwrap();
+            let placeholder = if required { "<ACTION>" } else { "[ACTION]" };
+            assert!(
+                page.contains(&format!("\\fBex\\fR {placeholder} [ROOT]…")),
+                "{page}"
+            );
+            assert!(
+                page.contains("\\fBUsage:\\fR ex run [TASK] [ARGS]…"),
+                "{page}"
+            );
+        }
     }
 
     #[test]

--- a/lib/src/docs/models.rs
+++ b/lib/src/docs/models.rs
@@ -50,7 +50,8 @@ pub struct SpecCommand {
     pub arg_groups: Vec<Group<SpecArg>>,
     /// Prose for this command's help sections, by heading title.
     pub headings: Vec<SpecHeading>,
-    // pub mounts: Vec<SpecMount>,
+    /// Display fragments for unresolved mounts, without running discovery.
+    pub mount_synopses: Vec<String>,
     pub deprecated: Option<String>,
     pub deprecated_warn_at: Option<String>,
     pub deprecated_remove_at: Option<String>,
@@ -65,6 +66,7 @@ pub struct SpecCommand {
     pub available_if: Vec<String>,
     pub display_order: Option<usize>,
     pub subcommand_required: bool,
+    pub subcommand_value_name: Option<String>,
     pub subcommand_help_heading: Option<String>,
     pub next_line_help: bool,
     pub flatten_help: bool,
@@ -724,7 +726,7 @@ impl From<&crate::SpecCommand> for SpecCommand {
             display_order,
             subcommand_required,
             subcommand_help_heading,
-            subcommand_value_name: _,
+            subcommand_value_name,
             next_line_help,
             flatten_help,
             // Consumed above while laying help out; templates need only the result.
@@ -881,6 +883,12 @@ impl From<&crate::SpecCommand> for SpecCommand {
             available_if: available_if.clone(),
             display_order: *display_order,
             subcommand_required: *subcommand_required,
+            subcommand_value_name: subcommand_value_name.clone(),
+            mount_synopses: cmd
+                .mounts
+                .iter()
+                .filter_map(|mount| mount.synopsis.clone())
+                .collect(),
             subcommand_help_heading: subcommand_help_heading.clone(),
             next_line_help: *next_line_help,
             flatten_help: *flatten_help,


### PR DESCRIPTION
## Summary

Complete the man-page side of #1393, found while integrating the merged documentation fixes into mise#12889. The man-page renderer builds its own synopsis from the documentation model; that model previously discarded custom subcommand names and unresolved mount fragments.

- Carry declarative mount synopses and custom subcommand names into the documentation model.
- Include mount fragments in root and subcommand synopses without executing discovery.
- Render a detailed section for a command whose only documentation is a mount synopsis.
- Preserve existing man-page formatting and optional/required subcommand behavior.

Please include this in the release tracked by #1389 before mise switches to published dependencies.

Validation: 16 focused man-page tests, including required/optional custom names, root mounts, and mount-only commands whose discovery executable does not exist.

All 785 usage-lib unit tests and Clippy with all features/targets and warnings denied also pass.

AI-generated with Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to the docs model and man-page renderer; no runtime CLI or discovery behavior.
> 
> **Overview**
> The documentation model now keeps **`subcommand_value_name`** and declarative **`mount_synopses`** (from each mount’s `synopsis`, without running discovery), which the man-page renderer previously dropped when building its own synopsis.
> 
> Man pages use the custom subcommand placeholder instead of hard-coded `<COMMAND>` / `[COMMAND]`, append mount synopsis fragments to root and per-command usage lines, and emit a subcommand detail section when the only documentation is a mount synopsis. A regression test covers required/optional custom names, root vs nested mounts, and non-executable discovery targets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37a974774e408309222138670bee45c726dcc3b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Manpage synopses now support custom subcommand value names.
  * Required and optional subcommand forms are rendered correctly.
  * Mounted command synopses are included in root and nested command documentation.
  * Subcommand detail sections are now shown when mount synopses are available, even without other documented content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->