### PR TITLE
perf(cli): shrink help sorting without allocating cached keys

### DIFF
--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -2037,8 +2037,11 @@ fn split_groups_section<'m, T: 'm>(
     }
 }
 
+// Cache declaration positions once per row: searching them inside the sort comparator
+// repeats the scan and expands it into each specialized sorting routine. Both row types
+// use the same numeric keys, so their cached-key sorts can share the sorting code.
 fn order_args<'a>(items: &mut Vec<&'a ArgMeta<'a>>, declared: &'a [ArgMeta<'a>]) {
-    items.sort_unstable_by_key(|item| {
+    items.sort_by_cached_key(|item| {
         let position = declared
             .iter()
             .position(|candidate| core::ptr::eq(candidate, *item))
@@ -2048,7 +2051,7 @@ fn order_args<'a>(items: &mut Vec<&'a ArgMeta<'a>>, declared: &'a [ArgMeta<'a>])
 }
 
 fn order_flags<'a>(items: &mut Vec<&'a FlagMeta<'a>>, declared: &'a [FlagMeta<'a>]) {
-    items.sort_unstable_by_key(|item| {
+    items.sort_by_cached_key(|item| {
         let position = declared
             .iter()
             .position(|candidate| core::ptr::eq(candidate, *item))
@@ -3985,6 +3988,39 @@ mod style_tests {
     };
     use crate::spec::{ArgMeta, ClauseMeta, CommandMeta, Example, FlagMeta, Spec, ViewMeta};
     use crate::{Arg, ArgAction, Clause, Command, Flag};
+
+    #[test]
+    fn filtered_help_rows_keep_declaration_order_as_the_tie_breaker() {
+        macro_rules! check {
+            ($meta:ident, $order:ident) => {{
+                let declared = [
+                    $meta::EMPTY,
+                    $meta {
+                        display_order: Some(1),
+                        ..$meta::EMPTY
+                    },
+                    $meta::EMPTY,
+                    $meta {
+                        display_order: Some(0),
+                        ..$meta::EMPTY
+                    },
+                    $meta {
+                        display_order: Some(1),
+                        ..$meta::EMPTY
+                    },
+                ];
+                // Filtering out a row must not renumber the remaining defaults. Shuffle rows
+                // so equal explicit orders must use declaration position.
+                let mut rows = vec![&declared[4], &declared[2], &declared[3], &declared[1]];
+                super::$order(&mut rows, &declared);
+                for (row, expected) in rows.iter().zip([3, 1, 4, 2]) {
+                    assert!(core::ptr::eq(*row, &declared[expected]));
+                }
+            }};
+        }
+        check!(ArgMeta, order_args);
+        check!(FlagMeta, order_flags);
+    }
 
     #[test]
     fn compiled_clause_arguments_appear_in_usage_and_help() {

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -1040,7 +1040,11 @@ fn usage_section(out: &mut String, spec: &Spec<'_>, path: &[&str], meta: &Comman
         }
     }
     let mut visible: Vec<_> = meta.subcommands.iter().filter(|sub| !sub.hide).collect();
-    visible.sort_unstable_by_key(|sub| sub.cmd.name);
+    #[inline(never)]
+    fn compare_names(a: &CommandMeta<'_>, b: &CommandMeta<'_>) -> core::cmp::Ordering {
+        a.cmd.name.cmp(b.cmd.name)
+    }
+    visible.sort_unstable_by(|a, b| compare_names(a, b));
     if meta.flatten_help && !visible.is_empty() {
         let mut lines = Vec::new();
         if !meta.subcommand_required || meta.cmd.args_conflicts_with_subcommands {
@@ -2037,36 +2041,64 @@ fn split_groups_section<'m, T: 'm>(
     }
 }
 
-// Cache declaration positions once per row: searching them inside the sort comparator
-// repeats the scan and expands it into each specialized sorting routine. Both row types
-// use the same numeric keys, so their cached-key sorts can share the sorting code.
-fn order_args<'a>(items: &mut Vec<&'a ArgMeta<'a>>, declared: &'a [ArgMeta<'a>]) {
-    items.sort_by_cached_key(|item| {
-        let position = declared
+// Rows refer into their declaration slice. Compute the index without repeatedly scanning
+// that slice from inside the sort comparator. Check identity to preserve the fallback for
+// a row outside the slice; no pointer is dereferenced or offset outside its allocation.
+fn declaration_position<T>(item: &T, declared: &[T]) -> usize {
+    let offset = core::ptr::from_ref(item)
+        .addr()
+        .wrapping_sub(declared.as_ptr().addr());
+    let Some(index) = offset.checked_div(core::mem::size_of::<T>()) else {
+        return declared
             .iter()
-            .position(|candidate| core::ptr::eq(candidate, *item))
+            .position(|candidate| core::ptr::eq(candidate, item))
             .unwrap_or(usize::MAX);
-        (item.display_order.unwrap_or(position), position)
-    });
+    };
+    declared
+        .get(index)
+        .filter(|candidate| core::ptr::eq(*candidate, item))
+        .map_or(usize::MAX, |_| index)
+}
+
+// Outlining the comparators keeps fat LTO from duplicating their bodies throughout
+// the sort implementation. The sort remains unstable and needs no key allocation.
+fn order_args<'a>(items: &mut Vec<&'a ArgMeta<'a>>, declared: &'a [ArgMeta<'a>]) {
+    #[inline(never)]
+    fn compare(a: &ArgMeta<'_>, b: &ArgMeta<'_>, declared: &[ArgMeta<'_>]) -> core::cmp::Ordering {
+        let key = |item: &ArgMeta<'_>| {
+            let position = declaration_position(item, declared);
+            (item.display_order.unwrap_or(position), position)
+        };
+        key(a).cmp(&key(b))
+    }
+    items.sort_unstable_by(|a, b| compare(a, b, declared));
 }
 
 fn order_flags<'a>(items: &mut Vec<&'a FlagMeta<'a>>, declared: &'a [FlagMeta<'a>]) {
-    items.sort_by_cached_key(|item| {
-        let position = declared
-            .iter()
-            .position(|candidate| core::ptr::eq(candidate, *item))
-            .unwrap_or(usize::MAX);
-        (item.display_order.unwrap_or(position), position)
-    });
+    #[inline(never)]
+    fn compare(
+        a: &FlagMeta<'_>,
+        b: &FlagMeta<'_>,
+        declared: &[FlagMeta<'_>],
+    ) -> core::cmp::Ordering {
+        let key = |item: &FlagMeta<'_>| {
+            let position = declaration_position(item, declared);
+            (item.display_order.unwrap_or(position), position)
+        };
+        key(a).cmp(&key(b))
+    }
+    items.sort_unstable_by(|a, b| compare(a, b, declared));
 }
 
 fn order_commands(items: &mut Vec<&&CommandMeta<'_>>) {
-    items.sort_unstable_by(|a, b| {
+    #[inline(never)]
+    fn compare(a: &CommandMeta<'_>, b: &CommandMeta<'_>) -> core::cmp::Ordering {
         a.display_order
             .unwrap_or(999)
             .cmp(&b.display_order.unwrap_or(999))
             .then_with(|| a.cmd.name.cmp(b.cmd.name))
-    });
+    }
+    items.sort_unstable_by(|a, b| compare(a, b));
 }
 
 fn command_help_section<'a>(sub: &'a CommandMeta<'a>, default_title: &str) -> Option<&'a str> {
@@ -3955,7 +3987,7 @@ fn recursive_help<'a>(
 
         let current = *chain.last().expect("a recursive page has a command");
         let mut children: Vec<_> = current.subcommands.iter().filter(|cmd| !cmd.hide).collect();
-        children.sort_unstable_by_key(|cmd| (cmd.display_order.unwrap_or(999), cmd.cmd.name));
+        order_commands(&mut children);
         for child in children {
             path.push(child.cmd.name);
             chain.push(child);
@@ -3988,6 +4020,32 @@ mod style_tests {
     };
     use crate::spec::{ArgMeta, ClauseMeta, CommandMeta, Example, FlagMeta, Spec, ViewMeta};
     use crate::{Arg, ArgAction, Clause, Command, Flag};
+
+    #[test]
+    fn declaration_positions_match_identity_search() {
+        let values = [11_u32, 22, 11, 44];
+        let other = 11;
+        for declared in [&values[..], &values[1..3], &values[..0]] {
+            for item in values.iter().chain([&other]) {
+                let expected = declared
+                    .iter()
+                    .position(|candidate| core::ptr::eq(candidate, item))
+                    .unwrap_or(usize::MAX);
+                assert_eq!(super::declaration_position(item, declared), expected);
+            }
+        }
+        // The helper is generic, even though help metadata is never zero-sized.
+        let values = [(); 3];
+        for declared in [&values[..], &values[..0]] {
+            for item in &values {
+                let expected = declared
+                    .iter()
+                    .position(|candidate| core::ptr::eq(candidate, item))
+                    .unwrap_or(usize::MAX);
+                assert_eq!(super::declaration_position(item, declared), expected);
+            }
+        }
+    }
 
     #[test]
     fn filtered_help_rows_keep_declaration_order_as_the_tie_breaker() {

--- a/benches/gate/src/bin/time-help.rs
+++ b/benches/gate/src/bin/time-help.rs
@@ -1,0 +1,49 @@
+//! In-process help timing for real mise pages. Run with `cargo run -p gate --release --bin time-help`.
+use std::hint::black_box;
+use std::time::Instant;
+
+fn bench(label: &str, runs: u32, mut render: impl FnMut() -> String) {
+    if std::env::args().any(|arg| arg == "--dump") {
+        print!("{label}\n{}", render());
+        return;
+    }
+    for _ in 0..10 {
+        black_box(render());
+    }
+    let mut best = f64::MAX;
+    for _ in 0..7 {
+        let start = Instant::now();
+        for _ in 0..runs {
+            black_box(render());
+        }
+        best = best.min(start.elapsed().as_secs_f64() * 1e9 / f64::from(runs));
+    }
+    println!("{label:<32}{best:>10.0} ns");
+}
+
+fn main() {
+    let spec = shadow_mise::Cli::spec();
+    for path in [
+        &[][..],
+        &["version"][..],
+        &["use"][..],
+        &["tasks", "run"][..],
+    ] {
+        let mut meta = spec.root;
+        for name in path {
+            meta = meta
+                .subcommands
+                .iter()
+                .find(|meta| meta.cmd.name == *name)
+                .unwrap();
+        }
+        let label = format!("mise {} --help", path.join(" "));
+        bench(&label, 1_000, || {
+            usage_argv::help::render(black_box(spec), black_box(meta.cmd), true).unwrap()
+        });
+    }
+    bench("mise KDL", 20, || black_box(spec).to_kdl());
+    bench("mise recursive help", 5, || {
+        usage_argv::help::render_all(black_box(spec), black_box(spec.root.cmd)).unwrap()
+    });
+}


### PR DESCRIPTION
Reduce help-rendering code size while retaining allocation-free unstable sorting:

- Compute declaration positions directly from metadata slice addresses, with identity checks preserving the existing fallback for outside references.
- Keep comparator bodies out of the sort implementation and share command ordering between ordinary and recursive help.
- Add ordering regression tests and an in-process mise help benchmark (`cargo run -p gate --release --bin time-help`).

### Size

Measured with [the oxc migration PR](https://github.com/oxc-project/oxc/pull/26027), comparing bpaf on main (`0d31f5865`) with the migration (`5396b74e1`) plus this patch:

| Binary | bpaf | usage-rs + this patch | Difference |
| --- | ---: | ---: | ---: |
| oxlint | 12,421,856 B | 12,669,440 B | +247,584 B (+1.99%) |
| oxfmt | 5,044,368 B | 5,241,888 B | +197,520 B (+3.92%) |

This patch saves **180,592 B (176.4 KiB)** combined versus the migration using released usage-rs 6.8.0. Measurements use Rust 1.98.1, macOS arm64, fat LTO, one codegen unit, allocator enabled, and identical stripping/signing; oxfmt disables default features.

### Performance and validation

Local mise help timings ranged from −0.2% to +1.3%; the unchanged KDL control varied by 5%, so these samples do not establish an instruction-count improvement. Sorting adds no cached-key allocation. Oxc help and 719 KB of sampled mise help/KDL output are byte-identical to baseline.

- Clippy, formatting, and Rust 1.91 compatibility checks passed.
- Full workspace tests: **2,722 passed**; the sole failure is a zsh interactive-completion timeout also reproduced on unmodified main.

*AI-assisted with Codex (GPT-6).*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Help output now consistently preserves declaration order when arguments or flags share the same display order.
  * Subcommands and usage synopsis entries are ordered consistently throughout help pages, including nested commands.
  * Argument and flag listings are sorted more efficiently, improving performance when generating help information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->