### PR TITLE
perf(cli): make advanced help and runtime spec serialization optional

### DIFF
--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -105,6 +105,7 @@ jobs:
         run: |
           cargo clippy -p usage-lib --no-default-features -- -D warnings
           cargo clippy -p usage-rs --no-default-features -- -D warnings
+          cargo test -p usage-rs --no-default-features --features help,diagnostics,completions --lib --test static_endpoint
           cargo clippy -p usage-config --no-default-features -- -D warnings
       - run: mise r render
       # Same reasoning as `render`: the shadow is checked in, so a change to the derive's

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ license = "MIT"
 [workspace.dependencies]
 clap_usage = { path = "./clap_usage", version = "5.0.0" }
 usage-cli = { path = "./cli" }
-usage-argv = { path = "./argv", version = "6.8.0" }
+usage-argv = { path = "./argv", version = "6.8.0", default-features = false }
 usage-config = { path = "./config", version = "6.8.0" }
 usage-derive = { path = "./derive", version = "6.8.0" }
 # No features, and defaults off. A feature named here is inherited by every member that writes

--- a/argv/Cargo.toml
+++ b/argv/Cargo.toml
@@ -15,6 +15,9 @@ license = { workspace = true }
 [dependencies]
 
 [features]
+default = ["help-advanced"]
+# Flattened subcommand pages and recursive help. Disable defaults for smaller CLIs.
+help-advanced = []
 # Cold-path metadata and spec emission. Off by default so a CLI that wants only
 # a parser does not carry it.
 spec = []

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -598,6 +598,20 @@ struct HelpStructure {
     synopsis: Vec<String>,
 }
 
+/// Validate advanced-help metadata, including in generated static declarations.
+#[doc(hidden)]
+pub const fn __usage_advanced_help(enabled: bool) -> bool {
+    assert!(
+        !enabled || cfg!(feature = "help-advanced"),
+        "flatten_help and HelpAll require the `help-advanced` feature"
+    );
+    enabled && cfg!(feature = "help-advanced")
+}
+
+fn flatten_help(meta: &CommandMeta<'_>) -> bool {
+    __usage_advanced_help(meta.flatten_help)
+}
+
 fn help_structure(
     spec: &Spec<'_>,
     path: &[&str],
@@ -611,7 +625,7 @@ fn help_structure(
     if !meta.examples.is_empty() {
         headings.push("Examples".to_string());
     }
-    if meta.flatten_help {
+    if flatten_help(meta) {
         flat_help_headings(&path[1.min(path.len())..], meta, &mut headings);
     } else if meta.subcommands.iter().any(|sub| !sub.hide) {
         command_usages.extend(
@@ -696,7 +710,7 @@ fn help_structure(
 
     let mut flag_usages: Vec<String> = own.iter().map(|flag| column_usage(flag)).collect();
     flag_usages.extend(inherited.into_iter().map(|(_, usage)| usage));
-    if meta.flatten_help {
+    if flatten_help(meta) {
         flat_help_usages(meta, long, &mut flag_usages, &mut arg_usages);
     }
     arg_usages.sort_unstable_by_key(|usage| core::cmp::Reverse(usage.len()));
@@ -751,7 +765,7 @@ fn flat_help_usages(
                 })
                 .map(column_usage),
         );
-        if sub.flatten_help {
+        if flatten_help(sub) {
             flat_help_usages(sub, long, flag_usages, arg_usages);
         }
     }
@@ -764,7 +778,7 @@ fn flat_help_headings(path: &[&str], meta: &CommandMeta<'_>, headings: &mut Vec<
         let mut sub_path = path.to_vec();
         sub_path.push(sub.cmd.name);
         headings.push(sub_path.join(" "));
-        if sub.flatten_help {
+        if flatten_help(sub) {
             flat_help_headings(&sub_path, sub, headings);
         }
     }
@@ -1045,7 +1059,7 @@ fn usage_section(out: &mut String, spec: &Spec<'_>, path: &[&str], meta: &Comman
         a.cmd.name.cmp(b.cmd.name)
     }
     visible.sort_unstable_by(|a, b| compare_names(a, b));
-    if meta.flatten_help && !visible.is_empty() {
+    if flatten_help(meta) && !visible.is_empty() {
         let mut lines = Vec::new();
         if !meta.subcommand_required || meta.cmd.args_conflicts_with_subcommands {
             lines.push(usage_line_with_subcommands(path, meta, false));
@@ -1416,7 +1430,7 @@ fn short_sections(
 
     // The path without the binary: it is the sort key the reference orders the list by, even
     // now that the row itself shows the child's own name.
-    if !meta.flatten_help {
+    if !flatten_help(meta) {
         commands_section(
             &mut sections.commands,
             &path[1.min(path.len())..],
@@ -1588,7 +1602,7 @@ fn short_sections(
         |_| None,
         |out, (f, usage)| short_entry(out, f, usage.clone()),
     );
-    if meta.flatten_help {
+    if flatten_help(meta) {
         flat_commands_short(
             &mut sections.flattened,
             &path[1.min(path.len())..],
@@ -1925,7 +1939,7 @@ fn flat_commands_short(out: &mut String, path: &[&str], meta: &CommandMeta<'_>, 
                 false,
             );
         }
-        if sub.flatten_help {
+        if flatten_help(sub) {
             flat_commands_short(out, &sub_path, sub, width);
         }
         out.push('\n');
@@ -2375,7 +2389,7 @@ fn long_sections(
     command_deprecation(out, meta, 0, width);
     usage_section(&mut sections.usage, spec, path, meta);
 
-    if !meta.flatten_help {
+    if !flatten_help(meta) {
         commands_section(
             &mut sections.commands,
             &path[1.min(path.len())..],
@@ -2519,7 +2533,7 @@ fn long_sections(
             flag_notes(out, f, indent, width);
         },
     );
-    if meta.flatten_help {
+    if flatten_help(meta) {
         flat_commands_long(
             &mut sections.flattened,
             &path[1.min(path.len())..],
@@ -3076,7 +3090,7 @@ fn flat_commands_long(out: &mut String, path: &[&str], meta: &CommandMeta<'_>, w
             );
             flag_notes(out, flag, BLOCK_INDENT, width);
         }
-        if sub.flatten_help {
+        if flatten_help(sub) {
             flat_commands_long(out, &sub_path, sub, width);
         }
         out.push('\n');
@@ -3567,11 +3581,17 @@ pub fn render_styled(
 }
 
 /// Long help for a command and every visible descendant, in depth-first order.
+///
+/// # Panics
+/// Panics without the `help-advanced` feature.
 pub fn render_all(spec: &Spec<'_>, cmd: &Command<'_>) -> Option<String> {
     render_all_styled(spec, cmd, Style::PLAIN)
 }
 
 /// Recursive long help with an explicit colour policy.
+///
+/// # Panics
+/// Panics without the `help-advanced` feature.
 pub fn render_all_styled(spec: &Spec<'_>, cmd: &Command<'_>, style: Style) -> Option<String> {
     let (path, chain) = find(spec, cmd)?;
     Some(recursive_help(spec, path, chain, style, false))
@@ -3755,11 +3775,17 @@ pub fn render_view_at_styled(
 }
 
 /// Recursive long help for a command reached by a known route.
+///
+/// # Panics
+/// Panics without the `help-advanced` feature.
 pub fn render_all_at(spec: &Spec<'_>, route: &[&Command<'_>]) -> Option<String> {
     render_all_at_styled(spec, route, Style::PLAIN)
 }
 
 /// Route-specific recursive long help with an explicit colour policy.
+///
+/// # Panics
+/// Panics without the `help-advanced` feature.
 pub fn render_all_at_styled(
     spec: &Spec<'_>,
     route: &[&Command<'_>],
@@ -3770,6 +3796,9 @@ pub fn render_all_at_styled(
 }
 
 /// Recursive long help through a spec-declared executable view.
+///
+/// # Panics
+/// Panics without the `help-advanced` feature.
 pub fn render_all_view_at_styled(
     spec: &Spec<'_>,
     route: &[&Command<'_>],
@@ -3965,6 +3994,7 @@ fn recursive_help<'a>(
     style: Style,
     inherit_version_actions: bool,
 ) -> String {
+    __usage_advanced_help(true);
     fn append<'a>(
         out: &mut String,
         spec: &'a Spec<'a>,

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -16,7 +16,7 @@ license = { workspace = true }
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-usage-argv = { workspace = true, features = ["spec", "complete", "diagnostics"] }
+usage-argv = { workspace = true, features = ["help-advanced", "spec", "complete", "diagnostics"] }
 usage-config = { workspace = true }
 usage-cli = { workspace = true }
 # Both named explicitly: the corpus carries `validate=` vectors, checked against usage-lib's

--- a/derive/src/codegen.rs
+++ b/derive/src/codegen.rs
@@ -1144,7 +1144,7 @@ pub fn emit(cli: &Cli) -> TokenStream {
                 subcommand_help_heading: #subcommand_help_heading,
                 subcommand_value_name: #subcommand_value_name,
                 next_line_help: #next_line_help,
-                flatten_help: #flatten_help,
+                flatten_help: usage_argv::help::__usage_advanced_help(#flatten_help),
                 term_width: #term_width,
                 max_term_width: #max_term_width,
                 args_override_self: #args_override_self,
@@ -2029,6 +2029,14 @@ fn spec_endpoint_fns(cli: &Cli) -> (TokenStream, TokenStream) {
     if !cli.spec_endpoint {
         return (TokenStream::new(), TokenStream::new());
     }
+    let response = match &cli.spec_endpoint_file {
+        Some(path) => quote! {
+            ::std::string::String::from(::core::include_str!(::core::concat!(
+                ::core::env!("CARGO_MANIFEST_DIR"), "/", #path,
+            )))
+        },
+        None => quote! { Self::to_kdl() },
+    };
     let functions = quote! {
         /// This CLI's own spec, when argv asks for it.
         ///
@@ -2043,7 +2051,7 @@ fn spec_endpoint_fns(cli: &Cli) -> (TokenStream, TokenStream) {
             argv: &[&::std::ffi::OsStr],
         ) -> ::std::option::Option<::std::string::String> {
             if usage_argv::is_spec_request(Self::command(), argv) {
-                ::std::option::Option::Some(Self::to_kdl())
+                ::std::option::Option::Some(#response)
             } else {
                 ::std::option::Option::None
             }
@@ -2416,7 +2424,10 @@ fn flag_table(i: usize, field: &Field) -> TokenStream {
         crate::model::ArgAction::Help => quote!(usage_argv::ArgAction::Help),
         crate::model::ArgAction::HelpShort => quote!(usage_argv::ArgAction::HelpShort),
         crate::model::ArgAction::HelpLong => quote!(usage_argv::ArgAction::HelpLong),
-        crate::model::ArgAction::HelpAll => quote!(usage_argv::ArgAction::HelpAll),
+        crate::model::ArgAction::HelpAll => quote!({
+            usage_argv::help::__usage_advanced_help(true);
+            usage_argv::ArgAction::HelpAll
+        }),
         crate::model::ArgAction::Version => quote!(usage_argv::ArgAction::Version),
     };
     quote! {
@@ -7064,7 +7075,7 @@ pub fn emit_args(cli: &Cli) -> TokenStream {
                 subcommand_help_heading: #subcommand_help_heading,
                 subcommand_value_name: #subcommand_value_name,
                 next_line_help: #next_line_help,
-                flatten_help: #flatten_help,
+                flatten_help: usage_argv::help::__usage_advanced_help(#flatten_help),
                 term_width: #term_width,
                 max_term_width: #max_term_width,
                 args_override_self: #args_override_self,

--- a/derive/src/model.rs
+++ b/derive/src/model.rs
@@ -62,6 +62,8 @@ pub struct Cli {
     /// remembers to write is an endpoint nothing can rely on. `spec_endpoint = false` is for a
     /// binary that does not want to carry the KDL writer at all.
     pub spec_endpoint: bool,
+    /// Pre-generated endpoint KDL, included relative to the declaring crate.
+    pub spec_endpoint_file: Option<String>,
     /// A file whose KDL is appended to the emitted spec.
     ///
     /// The escape hatch for a node no attribute carries, so a CLI that needs one keeps a single
@@ -792,6 +794,7 @@ impl Cli {
             runtime_bin: None,
             completion: false,
             spec_endpoint: true,
+            spec_endpoint_file: None,
             spec_extra: None,
             settings: false,
             dispatch: Dispatch::default(),
@@ -921,6 +924,7 @@ impl Cli {
                     // decorative after it.
                     "completion" => cli.completion = flag_value(&meta)?,
                     "spec_endpoint" => cli.spec_endpoint = flag_value(&meta)?,
+                    "spec_endpoint_file" => cli.spec_endpoint_file = Some(string_value(&meta)?),
                     "spec_extra" => cli.spec_extra = Some(string_value(&meta)?),
                     "settings" => cli.settings = flag_value(&meta)?,
                     "run" => cli.dispatch.run = flag_value(&meta)?,
@@ -1186,6 +1190,13 @@ impl Cli {
                     }
                 }
             }
+        }
+
+        if cli.spec_endpoint_file.is_some() && !cli.spec_endpoint {
+            return Err(syn::Error::new_spanned(
+                &input.ident,
+                "`spec_endpoint_file` requires `spec_endpoint` to be enabled",
+            ));
         }
 
         (cli.about, cli.long_about) = doc_comment(&input.attrs, verbatim_doc_comment)?;
@@ -6889,6 +6900,23 @@ mod tests {
             Ok(_) => panic!("should not have compiled"),
             Err(e) => e.to_string(),
         }
+    }
+
+    #[test]
+    fn a_static_endpoint_file_requires_the_endpoint() {
+        assert!(rejection(
+            r#"
+            #[usage(spec_endpoint = false, spec_endpoint_file = "cli.usage.kdl")]
+            struct Ex {}
+        "#
+        )
+        .contains("requires `spec_endpoint`"));
+        let parsed = cli(r#"
+            #[usage(spec_endpoint_file = "cli.usage.kdl")]
+            struct Ex {}
+        "#)
+        .unwrap();
+        assert_eq!(parsed.spec_endpoint_file.as_deref(), Some("cli.usage.kdl"));
     }
 
     #[test]

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -13,7 +13,7 @@ license = { workspace = true }
 # A test harness may have dependencies where the runtime may not, and still has none:
 # everything here is the cold half of usage-argv, asked a question instead of printed.
 [dependencies]
-usage-argv = { workspace = true, features = ["spec"] }
+usage-argv = { workspace = true, features = ["help-advanced", "spec"] }
 
 [features]
 # Asking what a CLI would offer for a half-typed line. Off by default, so a CLI that only

--- a/usage-dynamic/Cargo.toml
+++ b/usage-dynamic/Cargo.toml
@@ -11,7 +11,7 @@ authors = { workspace = true }
 license = { workspace = true }
 
 [dependencies]
-usage-argv = { workspace = true, features = ["spec", "complete"] }
+usage-argv = { workspace = true, features = ["help-advanced", "spec", "complete"] }
 usage-parser = { package = "usage-lib", path = "../lib", version = "6.8.0", default-features = false, features = ["cli-help"] }
 
 [package.metadata.release]

--- a/usage-rs/Cargo.toml
+++ b/usage-rs/Cargo.toml
@@ -23,9 +23,10 @@ shell-words = { version = "1", optional = true }
 # clap-shaped errors. Completions and expression validation stay opt-in.
 # Low-level adopters that want only the binding runtime keep depending on
 # `usage-argv` directly (no defaults).
-default = ["spec", "help", "diagnostics"]
+default = ["spec", "help", "diagnostics", "help-advanced"]
 spec = ["usage-argv/spec", "dep:usage-derive"]
 help = ["spec"]
+help-advanced = ["help", "usage-argv/help-advanced"]
 completions = ["spec", "usage-argv/complete", "usage-test?/completions"]
 # Kept as a spelling close to the runtime feature for low-level adopters.
 complete = ["completions"]

--- a/usage-rs/src/lib.rs
+++ b/usage-rs/src/lib.rs
@@ -10,6 +10,25 @@
 //! usage = { package = "usage-rs", version = "6" }
 //! ```
 //!
+//! # Smaller binaries
+//!
+//! CLIs without `flatten_help` or `HelpAll` actions can omit `help-advanced`:
+//!
+//! ```toml
+//! usage = { package = "usage-rs", version = "6", default-features = false, features = ["help", "diagnostics", "completions"] }
+//! ```
+//!
+//! Advanced help remains enabled by default. Declaring those actions without its feature
+//! fails at compile time; hand-written metadata requesting advanced help panics when rendered.
+//! Cargo features are additive: another dependency enabling it restores advanced help.
+//!
+//! To keep the spec endpoint without linking the KDL writer, use
+//! `#[usage(spec_endpoint_file = "cli.usage.kdl")]`. The file is included at compile time,
+//! relative to the declaring crate. Generate it with `Cli::to_kdl()` in a development tool,
+//! and test that `Cli::spec_request(&[usage::SPEC_REQUEST.as_ref()])` equals `Cli::to_kdl()`.
+//! Regenerate after changing CLI metadata or its version. `to_kdl()` still uses the live
+//! metadata, including settings and `spec_extra`; only the endpoint uses the file.
+//!
 //! What happens after a parse can come from the same declaration: a command implements [`Run`],
 //! the subcommand enum says `#[usage(run)]`, and the `match` that routes argv to the code
 //! carrying it out is generated rather than written. [`RunWith`] under `#[usage(run_with)]` hands

--- a/usage-rs/tests/fixtures/static.usage.kdl
+++ b/usage-rs/tests/fixtures/static.usage.kdl
@@ -1,0 +1,4 @@
+name static-spec
+bin static-spec
+flag --verbose
+flag "-h --help" help="Print help" action=help builtin=#true

--- a/usage-rs/tests/static_endpoint.rs
+++ b/usage-rs/tests/static_endpoint.rs
@@ -1,0 +1,60 @@
+#![cfg(feature = "spec")]
+
+use std::ffi::{OsStr, OsString};
+
+#[derive(Debug, usage_rs::Cli)]
+#[usage(
+    bin = "static-spec",
+    spec_endpoint_file = "tests/fixtures/static.usage.kdl"
+)]
+struct StaticSpec {
+    #[usage(long)]
+    verbose: bool,
+}
+
+#[test]
+fn embedded_spec_matches_the_live_serializer() {
+    let expected = StaticSpec::to_kdl();
+    let request = [OsStr::new(usage_rs::SPEC_REQUEST)];
+    assert_eq!(
+        StaticSpec::spec_request(&request).as_deref(),
+        Some(expected.as_str())
+    );
+    let outcome = StaticSpec::embedded_outcome(&[OsString::from(usage_rs::SPEC_REQUEST)]);
+    let exit = outcome.exit().unwrap();
+    assert_eq!(exit.text, expected);
+    assert_eq!(exit.code, 0);
+    assert!(!exit.stderr);
+}
+
+#[test]
+fn ordinary_arguments_still_parse() {
+    assert!(StaticSpec::spec_request(&[OsStr::new("--verbose")]).is_none());
+    assert!(
+        StaticSpec::parse_from(&[OsStr::new("--verbose")])
+            .unwrap()
+            .verbose
+    );
+}
+
+#[cfg(not(feature = "help-advanced"))]
+#[test]
+#[should_panic(expected = "require the `help-advanced` feature")]
+fn recursive_help_is_explicitly_unavailable_in_the_small_build() {
+    usage_rs::help::render_all(StaticSpec::spec(), StaticSpec::command());
+}
+
+#[cfg(not(feature = "help-advanced"))]
+#[test]
+#[should_panic(expected = "require the `help-advanced` feature")]
+fn hand_written_flattened_metadata_is_not_silently_ignored() {
+    let root = usage_rs::spec::CommandMeta {
+        flatten_help: true,
+        ..*StaticSpec::spec().root
+    };
+    let spec = usage_rs::spec::Spec {
+        root: &root,
+        ..*StaticSpec::spec()
+    };
+    usage_rs::help::render(&spec, StaticSpec::command(), false);
+}


### PR DESCRIPTION
CLIs that do not use flattened or recursive help can now omit the default-enabled `help-advanced` feature. `spec_endpoint_file` serves a generated KDL file included at compile time, keeping the spec endpoint without linking the runtime serializer. `to_kdl()` continues to generate from live metadata so adopters can regenerate the file and test for drift.

Measured with both options in the oxc migration, on top of #1396:

| Stripped binary | bpaf | usage-rs with these changes | Difference |
| --- | ---: | ---: | ---: |
| oxlint | 12,421,856 B | 12,620,112 B | +198,256 B (+1.60%) |
| oxfmt | 5,044,368 B | 5,176,144 B | +131,776 B (+2.61%) |

This saves another 115,072 B (112.4 KiB) combined beyond #1396. macOS arm64, Rust 1.98.1, release fat LTO, one codegen unit, allocator enabled, oxfmt default features disabled, identical stripping and signing. All 24 process comparisons matched exit status, stdout and stderr, including help, diagnostics, versions, spec responses and completion requests.

Advanced help remains enabled by default. Dependencies explicitly disabling defaults must enable `help-advanced` when declaring `flatten_help` or `HelpAll`; derives reject missing support at compile time. Hand-written metadata requesting unavailable advanced help panics explicitly. Embedded spec files must be regenerated after metadata or version changes; the docs describe a parity test against `to_kdl()`.

Validation: full Clippy, formatting, Rust 1.91 check, and the isolated reduced-feature tests pass. Full workspace tests: 2,725 passed, with the previously reproduced local zsh completion timeout as the only failure. Oxc's 33 focused lint CLI tests and 38 formatter library tests pass; its broader lint library run failed in suppression fixture setup/cleanup. Added text passes `mise x typos`; the repository-wide scan reports existing findings.

_Implemented with AI assistance._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default feature propagation and CLI compile-time behavior for help and spec responses; adopters who disable defaults must opt in correctly, and static spec files can drift from live metadata if not regenerated.
> 
> **Overview**
> **Advanced help** (`flatten_help`, `HelpAll`, recursive `render_all`) moves behind a new `help-advanced` feature on `usage-argv`, wired through `usage-rs` defaults so slim CLIs can turn it off. The derive and runtime gate those declarations with `__usage_advanced_help` (compile-time assert / runtime panic) instead of silently ignoring flattened metadata.
> 
> **Spec endpoint** can now use `#[usage(spec_endpoint_file = "...")]`, which answers `__usage_spec__` from `include_str!` instead of linking the live KDL serializer; `to_kdl()` is unchanged for regeneration and drift tests.
> 
> Workspace `usage-argv` is declared with `default-features = false`, and CI runs an extra `usage-rs` test (`static_endpoint`) under the trimmed feature set alongside the existing clippy checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56356638acc99dac389e28b3b51cf4b03c2aab99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional advanced help capabilities, including flattened and recursive help pages.
  * Added support for serving a pre-generated usage specification file through the specification endpoint.
  * Added configuration guidance for producing smaller CLI binaries while retaining specification support.

* **Bug Fixes**
  * Advanced help usage now reports clear errors when the required feature is unavailable.

* **Tests**
  * Expanded coverage for static specifications, standard argument parsing, feature combinations, and advanced help behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->