### PR TITLE
perf(cli): avoid color analysis for plain help

### DIFF
--- a/argv/src/diagnostic.rs
+++ b/argv/src/diagnostic.rs
@@ -343,6 +343,32 @@ fn tip(style: Style, noun: &str, near: &[&str]) -> String {
     }
 }
 
+// Both parser errors use the same spelling suggestions and output layout.
+#[inline(never)]
+fn unexpected_flag(out: &mut String, style: Style, typed: &str, chain: &[&CommandMeta<'_>]) {
+    let _ = writeln!(
+        out,
+        "{} unexpected argument '{}' found",
+        style.error("error:"),
+        style.invalid(typed)
+    );
+    // Scored without the dashes, and only then written back with them. Every flag
+    // starts `--`, and the prefix bonus in Jaro-Winkler counts that agreement — so
+    // `--fore` came out similar to `--quiet`, which it is not. clap compares the bare
+    // names for the same reason.
+    let bare = typed.trim_start_matches('-');
+    let names: Vec<&str> = flags_in_scope(chain).flat_map(long_spellings).collect();
+    let near: Vec<String> = nearest(bare, names.into_iter())
+        .into_iter()
+        .map(|name| format!("--{name}"))
+        .collect();
+    out.push_str(&tip(
+        style,
+        "argument",
+        &near.iter().map(String::as_str).collect::<Vec<_>>(),
+    ));
+}
+
 /// A name as a usage line writes it: `<TOOL>`, `[TOOL]…`, `--jobs`.
 ///
 /// The error carries the spec's name for a thing; a user reads the form the help shows. Both come
@@ -850,27 +876,7 @@ fn render_inner<'a>(
             with_usage = true;
             let whole = String::from_utf8_lossy(token);
             let typed = flag_named(&whole);
-            let _ = writeln!(
-                out,
-                "{} unexpected argument '{}' found",
-                style.error("error:"),
-                style.invalid(typed)
-            );
-            // Scored without the dashes, and only then written back with them. Every flag
-            // starts `--`, and the prefix bonus in Jaro-Winkler counts that agreement — so
-            // `--fore` came out similar to `--quiet`, which it is not. clap compares the bare
-            // names for the same reason.
-            let bare = typed.trim_start_matches('-');
-            let names: Vec<&str> = flags_in_scope(chain).flat_map(long_spellings).collect();
-            let near: Vec<String> = nearest(bare, names.into_iter())
-                .into_iter()
-                .map(|name| format!("--{name}"))
-                .collect();
-            out.push_str(&tip(
-                style,
-                "argument",
-                &near.iter().map(String::as_str).collect::<Vec<_>>(),
-            ));
+            unexpected_flag(&mut out, style, typed, chain);
         }
         Error::UnexpectedArg { token } => {
             with_usage = true;
@@ -884,23 +890,7 @@ fn render_inner<'a>(
                 // Same rule as a refused flag: a value attached with `=` is not part of the
                 // name, and the word reaches here by the same spelling mistake.
                 let named = flag_named(&word);
-                let _ = writeln!(
-                    out,
-                    "{} unexpected argument '{}' found",
-                    style.error("error:"),
-                    style.invalid(named)
-                );
-                let bare = named.trim_start_matches('-');
-                let names: Vec<&str> = flags_in_scope(chain).flat_map(long_spellings).collect();
-                let near: Vec<String> = nearest(bare, names.into_iter())
-                    .into_iter()
-                    .map(|name| format!("--{name}"))
-                    .collect();
-                out.push_str(&tip(
-                    style,
-                    "argument",
-                    &near.iter().map(String::as_str).collect::<Vec<_>>(),
-                ));
+                unexpected_flag(&mut out, style, named, chain);
             } else if cmd.subcommands.is_empty() {
                 let _ = writeln!(
                     out,

--- a/argv/src/help.rs
+++ b/argv/src/help.rs
@@ -590,6 +590,7 @@ fn styled_flag_usage(usage: &str, style: Style) -> String {
     out
 }
 
+#[derive(Default)]
 struct HelpStructure {
     headings: Vec<String>,
     command_usages: Vec<String>,
@@ -875,7 +876,12 @@ fn assembled_help(
     } else {
         short_sections(spec, path, chain, inherit_version_actions)
     };
-    let structure = help_structure(spec, path, chain, long, inherit_version_actions);
+    // Plain output never reads the spellings used to recognize colored spans.
+    let structure = if style.coloured {
+        help_structure(spec, path, chain, long, inherit_version_actions)
+    } else {
+        HelpStructure::default()
+    };
     let page = match spec
         .help_template
         .filter(|template| !template.trim().is_empty())

--- a/benches/gate/src/bin/time-help.rs
+++ b/benches/gate/src/bin/time-help.rs
@@ -42,6 +42,21 @@ fn main() {
             usage_argv::help::render(black_box(spec), black_box(meta.cmd), true).unwrap()
         });
     }
+    // The process renderer also recognizes structural spans for colored output.
+    for (name, style) in [
+        ("plain", usage_argv::help::Style::PLAIN),
+        ("colored", usage_argv::help::Style::COLOURED),
+    ] {
+        bench(&format!("mise root process help ({name})"), 1_000, || {
+            usage_argv::help::render_styled(
+                black_box(spec),
+                black_box(spec.root.cmd),
+                true,
+                black_box(style),
+            )
+            .unwrap()
+        });
+    }
     bench("mise KDL", 20, || black_box(spec).to_kdl());
     bench("mise recursive help", 5, || {
         usage_argv::help::render_all(black_box(spec), black_box(spec.root.cmd)).unwrap()


### PR DESCRIPTION
Plain help currently builds the headings and spellings used to recognize colored spans, then discards them. Skip that work when color is disabled, and share the duplicated invalid-flag diagnostic formatting. Extend the timing tool to cover the process renderer in both plain and colored modes.

Paired local mise measurements: plain process help **42.15 → 34.68 µs (-18%)**, recursive help **4.88 → 3.36 ms (-31%)**. Colored help remains roughly unchanged. These are wall-clock measurements, not instruction counts.

Machine code shrinks by 2,896 B across the oxc binaries, but Mach-O alignment leaves only **32 B of combined on-disk savings**. With the preceding size changes:

| Stripped binary | bpaf | usage-rs (no bpaf) |
| --- | ---: | ---: |
| oxlint | 12,421,856 B | 12,587,296 B (+1.33%) |
| oxfmt | 5,044,368 B | 5,143,328 B (+1.96%) |

Same arm64 macOS / Rust 1.98.1 release configuration and strip/sign procedure as #1400, including the optional-feature/embedded-spec configuration from #1399.

Validation: the 733,411-byte help dump and 56 oxc process comparisons (plain and forced color) match exactly. Full Clippy, Rust 1.91, reduced-feature tests, formatting and spelling of added text pass. Full workspace tests: 2,725 passed; only the previously reproduced local zsh completion timeout failed.

_Implemented with AI assistance._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Output-preserving performance refactor in help and error formatting; behavior is validated by byte-identical help dumps and diagnostic tests.
> 
> **Overview**
> **Plain `--help` no longer builds the heading/flag/argument spellings used only to paint colored spans.** Styled rendering still runs `help_structure` when `style.coloured` is true; otherwise it passes an empty `HelpStructure` so recursive and process help avoid that work without changing bytes on the wire.
> 
> **Invalid long-flag diagnostics are deduplicated** into a shared `unexpected_flag` helper used for both `UnknownFlag` and dash-prefixed `UnexpectedArg`, keeping the same clap-style message and Jaro-based tips.
> 
> The help timing bench now measures **process `render_styled` in plain and colored** modes alongside the existing paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19980677b725d701b4565cd9142d65ee82d56065. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of unknown-flag and unexpected-argument messages, including normalized flag names and relevant suggestions.

* **Performance**
  * Reduced unnecessary help-formatting work when displaying plain, uncolored help output.

* **Tests**
  * Added coverage for rendering root help in both plain and colored styles, including process-based rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->