### PR TITLE
fix(parse): keep implicit default after a default-only flag

### DIFF
--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -220,7 +220,8 @@ pub struct Command<'a> {
     /// into a compile error.
     pub default_subcommand: ::core::option::Option<&'a Command<'a>>,
     /// Look ahead past parent/default flags before implicitly selecting the default.
-    /// Explicit siblings win; parent-only flags retain their ordinary meaning.
+    /// A sibling name before any default-only flag stays on the parent; after one,
+    /// later words are the default command's args.
     pub default_subcommand_flags: bool,
     /// Whether an unmatched word is forwarded as an external command plus the rest of argv.
     ///
@@ -1798,13 +1799,16 @@ impl<'t: 'v, 'a, 'v> Parser<'t, 'a, 'v> {
                 return at;
             }
             if !is_flag_like(token) {
-                return if self.find_subcommand(token).is_some()
-                    || (token == b"help" && !self.cmd.disable_help_subcommand)
+                // A sibling name before any default-only flag stays on the parent.
+                // After one, later words are the default command's args (`-u pkg`
+                // when `pkg` is also a command).
+                if at.is_none()
+                    && (self.find_subcommand(token).is_some()
+                        || (token == b"help" && !self.cmd.disable_help_subcommand))
                 {
-                    None
-                } else {
-                    at
-                };
+                    return None;
+                }
+                return at;
             }
             let mut value_flag = None;
             let mut attached = None;
@@ -1908,7 +1912,7 @@ impl<'t: 'v, 'a, 'v> Parser<'t, 'a, 'v> {
                         if self.cmd.subcommand_precedence_over_arg
                             && self.find_subcommand(next).is_some()
                         {
-                            return None;
+                            break;
                         }
                         count += values_in(next, flag.delimiter);
                         i += 1;

--- a/conformance/tests/default_subcommand_flags.rs
+++ b/conformance/tests/default_subcommand_flags.rs
@@ -27,6 +27,8 @@ struct Install {
     update: bool,
     #[usage(short = 'a')]
     ask: bool,
+    #[usage(short = 'X', long)]
+    exclude: Option<String>,
     package: Option<String>,
 }
 
@@ -48,7 +50,21 @@ fn parent_help_and_explicit_siblings_keep_their_meaning() {
     assert!(parsed.command.is_none());
     let parsed = Em::parse_from(&[OsStr::new("query")]).unwrap();
     assert!(matches!(parsed.command, Some(Commands::Query)));
-    assert!(Em::parse_from(&["-u", "query"].map(OsStr::new)).is_err());
+    let parsed = Em::parse_from(&["-p", "query"].map(OsStr::new)).unwrap();
+    assert!(parsed.pretend);
+    assert!(matches!(parsed.command, Some(Commands::Query)));
+    let parsed = Em::parse_from(&["-u", "query"].map(OsStr::new)).unwrap();
+    let Some(Commands::Install(install)) = parsed.command else {
+        panic!("expected install: a default-only flag already committed the line")
+    };
+    assert!(install.update);
+    assert_eq!(install.package.as_deref(), Some("query"));
+    let parsed = Em::parse_from(&["-X", "foo", "query"].map(OsStr::new)).unwrap();
+    let Some(Commands::Install(install)) = parsed.command else {
+        panic!("expected install")
+    };
+    assert_eq!(install.exclude.as_deref(), Some("foo"));
+    assert_eq!(install.package.as_deref(), Some("query"));
     let Err(usage_argv::Error::Help { cmd, .. }) = Em::parse_from(&[OsStr::new("--help")]) else {
         panic!("expected parent help")
     };

--- a/corpus/16-default-subcommand-flags.json
+++ b/corpus/16-default-subcommand-flags.json
@@ -145,20 +145,36 @@
     },
     {
       "id": "default-flags-sibling-wins",
-      "doc": "A sibling prevents default routing; its prefix still rejects a default-only flag.",
+      "doc": "After a default-only flag, a sibling name is the default command's arg.",
       "spec": "name \"em\"\nbin \"em\"\nunknown_flags \"error\"\ndefault_subcommand \"install\"\ndefault_subcommand_flags #true\nflag \"-p --pretend\"\nflag \"-c --config <path>\"\nflag \"-v --verbose\" global=#true\ncmd \"install\" {\n alias \"i\"\n flag \"-u --update\"\n flag \"-a --ask\"\n flag \"-r --remove\"\n flag \"--output <path>\"\n arg \"[package]\"\n}\ncmd \"query\" { alias \"q\"; }\ncmd \"search\" {}\n",
       "argv": ["-u", "query"],
       "expect": {
-        "error": "unknown_flag"
+        "ok": {
+          "cmd": ["install"],
+          "flags": {
+            "update": true
+          },
+          "args": {
+            "package": "query"
+          }
+        }
       }
     },
     {
       "id": "default-flags-alias-wins",
-      "doc": "Sibling aliases have the same precedence as canonical names.",
+      "doc": "A sibling alias after a default-only flag is also a default-command arg.",
       "spec": "name \"em\"\nbin \"em\"\nunknown_flags \"error\"\ndefault_subcommand \"install\"\ndefault_subcommand_flags #true\nflag \"-p --pretend\"\nflag \"-c --config <path>\"\nflag \"-v --verbose\" global=#true\ncmd \"install\" {\n alias \"i\"\n flag \"-u --update\"\n flag \"-a --ask\"\n flag \"-r --remove\"\n flag \"--output <path>\"\n arg \"[package]\"\n}\ncmd \"query\" { alias \"q\"; }\ncmd \"search\" {}\n",
       "argv": ["-u", "q"],
       "expect": {
-        "error": "unknown_flag"
+        "ok": {
+          "cmd": ["install"],
+          "flags": {
+            "update": true
+          },
+          "args": {
+            "package": "q"
+          }
+        }
       }
     },
     {
@@ -181,11 +197,19 @@
     },
     {
       "id": "default-flags-explicit-prefix",
-      "doc": "Opting in does not legalize child-only flags before an explicit command.",
+      "doc": "The default command's own name after a default-only flag is an arg, not a selector.",
       "spec": "name \"em\"\nbin \"em\"\nunknown_flags \"error\"\ndefault_subcommand \"install\"\ndefault_subcommand_flags #true\nflag \"-p --pretend\"\nflag \"-c --config <path>\"\nflag \"-v --verbose\" global=#true\ncmd \"install\" {\n alias \"i\"\n flag \"-u --update\"\n flag \"-a --ask\"\n flag \"-r --remove\"\n flag \"--output <path>\"\n arg \"[package]\"\n}\ncmd \"query\" { alias \"q\"; }\ncmd \"search\" {}\n",
       "argv": ["-u", "install"],
       "expect": {
-        "error": "unknown_flag"
+        "ok": {
+          "cmd": ["install"],
+          "flags": {
+            "update": true
+          },
+          "args": {
+            "package": "install"
+          }
+        }
       }
     },
     {
@@ -248,11 +272,19 @@
     },
     {
       "id": "default-flags-value-then-sibling",
-      "doc": "A real selector after a default flag value still wins.",
+      "doc": "A sibling name after a default flag value is the default command's arg.",
       "spec": "name \"em\"\nbin \"em\"\nunknown_flags \"error\"\ndefault_subcommand \"install\"\ndefault_subcommand_flags #true\nflag \"-p --pretend\"\nflag \"-c --config <path>\"\nflag \"-v --verbose\" global=#true\ncmd \"install\" {\n alias \"i\"\n flag \"-u --update\"\n flag \"-a --ask\"\n flag \"-r --remove\"\n flag \"--output <path>\"\n arg \"[package]\"\n}\ncmd \"query\" { alias \"q\"; }\ncmd \"search\" {}\n",
       "argv": ["--output", "query", "search"],
       "expect": {
-        "error": "unknown_flag"
+        "ok": {
+          "cmd": ["install"],
+          "flags": {
+            "output": "query"
+          },
+          "args": {
+            "package": "search"
+          }
+        }
       }
     },
     {
@@ -329,11 +361,19 @@
     },
     {
       "id": "default-flags-optional-equals",
-      "doc": "An optional equals-only value leaves a sibling selector visible.",
+      "doc": "An optional equals-only value still commits to the default; the next word is an arg.",
       "spec": "name \"em\"\nbin \"em\"\nunknown_flags \"error\"\ndefault_subcommand \"install\"\ndefault_subcommand_flags #true\nflag \"-p --pretend\"\nflag \"-c --config <path>\"\nflag \"-v --verbose\" global=#true\ncmd \"install\" {\n alias \"i\"\n flag \"-u --update\"\n flag \"-a --ask\"\n flag \"-r --remove\"\n flag \"--output <path>\"\n flag \"--color <when>\" require_equals=#true default_missing=\"auto\"\n arg \"[package]\"\n}\ncmd \"query\" { alias \"q\"; }\ncmd \"search\" {}\n",
       "argv": ["--color", "query"],
       "expect": {
-        "error": "unknown_flag"
+        "ok": {
+          "cmd": ["install"],
+          "flags": {
+            "color": "auto"
+          },
+          "args": {
+            "package": "query"
+          }
+        }
       }
     },
     {
@@ -375,29 +415,53 @@
     },
     {
       "id": "default-flags-variadic-limit",
-      "doc": "A sibling after a bounded variadic value remains a selector.",
+      "doc": "A sibling after a bounded variadic value is the default command's arg.",
       "spec": "name \"em\"\nbin \"em\"\nunknown_flags \"error\"\ndefault_subcommand \"install\"\ndefault_subcommand_flags #true\nflag \"-p --pretend\"\nflag \"-c --config <path>\"\nflag \"-v --verbose\" global=#true\ncmd \"install\" {\n alias \"i\"\n flag \"-u --update\"\n flag \"-a --ask\"\n flag \"-r --remove\"\n flag \"--output <path>\"\n flag \"--include <item>...\" { arg \"<item>...\" var_max=1; }\n arg \"[package]\"\n}\ncmd \"query\" { alias \"q\"; }\ncmd \"search\" {}\n",
       "argv": ["--include", "one", "query"],
       "expect": {
-        "error": "unknown_flag"
+        "ok": {
+          "cmd": ["install"],
+          "flags": {
+            "include": ["one"]
+          },
+          "args": {
+            "package": "query"
+          }
+        }
       }
     },
     {
       "id": "default-flags-variadic-terminator",
-      "doc": "A value terminator exposes the following sibling selector.",
+      "doc": "A value terminator still leaves later words as the default command's args.",
       "spec": "name \"em\"\nbin \"em\"\nunknown_flags \"error\"\ndefault_subcommand \"install\"\ndefault_subcommand_flags #true\nflag \"-p --pretend\"\nflag \"-c --config <path>\"\nflag \"-v --verbose\" global=#true\ncmd \"install\" {\n alias \"i\"\n flag \"-u --update\"\n flag \"-a --ask\"\n flag \"-r --remove\"\n flag \"--output <path>\"\n flag \"--include <item>...\" { arg \"<item>...\" value_terminator=\"END\"; }\n arg \"[package]\"\n}\ncmd \"query\" { alias \"q\"; }\ncmd \"search\" {}\n",
       "argv": ["--include", "one", "END", "query"],
       "expect": {
-        "error": "unknown_flag"
+        "ok": {
+          "cmd": ["install"],
+          "flags": {
+            "include": ["one"]
+          },
+          "args": {
+            "package": "query"
+          }
+        }
       }
     },
     {
       "id": "default-flags-negative-value",
-      "doc": "An opted-in negative value is skipped before a sibling selector.",
+      "doc": "An opted-in negative value is skipped; the following sibling name is an arg.",
       "spec": "name \"em\"\nbin \"em\"\nunknown_flags \"error\"\ndefault_subcommand \"install\"\ndefault_subcommand_flags #true\nflag \"-p --pretend\"\nflag \"-c --config <path>\"\nflag \"-v --verbose\" global=#true\ncmd \"install\" {\n alias \"i\"\n flag \"-u --update\"\n flag \"-a --ask\"\n flag \"-r --remove\"\n flag \"--output <path>\"\n flag \"--offset <n>\" { arg \"<n>\" allow_negative_numbers=#true; }\n arg \"[package]\"\n}\ncmd \"query\" { alias \"q\"; }\ncmd \"search\" {}\n",
       "argv": ["--offset", "-2", "query"],
       "expect": {
-        "error": "unknown_flag"
+        "ok": {
+          "cmd": ["install"],
+          "flags": {
+            "offset": "-2"
+          },
+          "args": {
+            "package": "query"
+          }
+        }
       }
     },
     {
@@ -522,11 +586,20 @@
     },
     {
       "id": "default-flags-mixed-sibling",
-      "doc": "Explicit sibling precedence also applies to mixed bundles.",
+      "doc": "A mixed bundle that includes a default-only short commits later words as args.",
       "spec": "name \"em\"\nbin \"em\"\nunknown_flags \"error\"\ndefault_subcommand \"install\"\ndefault_subcommand_flags #true\nflag \"-p --pretend\"\nflag \"-c --config <path>\"\nflag \"-v --verbose\" global=#true\ncmd \"install\" {\n alias \"i\"\n flag \"-u --update\"\n flag \"-a --ask\"\n flag \"-r --remove\"\n flag \"--output <path>\"\n arg \"[package]\"\n}\ncmd \"query\" { alias \"q\"; }\ncmd \"search\" {}\n",
       "argv": ["-pu", "query"],
       "expect": {
-        "error": "unknown_flag"
+        "ok": {
+          "cmd": ["install"],
+          "flags": {
+            "pretend": true,
+            "update": true
+          },
+          "args": {
+            "package": "query"
+          }
+        }
       }
     },
     {

--- a/docs/spec/reference/index.md
+++ b/docs/spec/reference/index.md
@@ -163,8 +163,10 @@ cmd "query" {}
 
 `em -ua @world` then means `em install -ua @world`. The parser looks past
 recognized parent/default flags and their values for an explicit command name
-or alias. An explicit sibling keeps ordinary parsing: `em -u query` still
-rejects `-u` on the parent. Parent-only flags, including `--help`, and an empty
+or alias. A sibling name _before_ any default-only flag keeps ordinary parsing
+(`em query`, `em -p query`). After a default-only flag, later words are the
+default command's args: `em -u query` is `em install -u query`, even when
+`query` is also a command. Parent-only flags, including `--help`, and an empty
 invocation stay on the parent.
 
 The implicit command boundary is immediately before the first default-only

--- a/go/argv/parser.go
+++ b/go/argv/parser.go
@@ -116,8 +116,9 @@ func New(root *Command, argv []string) Parser {
 	return p
 }
 
-// defaultFlagRoute chooses an implicit boundary without binding any flags. A
-// sibling selector wins, and a flag's values are never mistaken for selectors.
+// defaultFlagRoute chooses an implicit boundary without binding any flags.
+// A sibling name before any default-only flag stays on the parent; after one,
+// later words are the default command's args.
 func (p *Parser) defaultFlagRoute() int {
 	d := p.cmd.DefaultSubcommand
 	if d == nil {
@@ -134,7 +135,7 @@ func (p *Parser) defaultFlagRoute() int {
 			return at
 		}
 		if !isFlagLike(token) {
-			if p.findSubcommand(token) != nil || (token == "help" && !p.cmd.DisableHelpSubcommand) {
+			if at < 0 && (p.findSubcommand(token) != nil || (token == "help" && !p.cmd.DisableHelpSubcommand)) {
 				return -1
 			}
 			return at
@@ -235,7 +236,7 @@ func (p *Parser) defaultFlagRoute() int {
 						break
 					}
 					if p.cmd.SubcommandPrecedenceOverArg && p.findSubcommand(next) != nil {
-						return -1
+						break
 					}
 					count += valuesIn(next, f.Delimiter)
 					i++

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -1351,15 +1351,15 @@ fn default_flag_route(spec: &Spec, root: &SpecCommand, input: &VecDeque<Token>) 
             return at;
         }
         if !is_flag_like(token) {
-            return if root.find_subcommand(token).is_some()
-                || (token == "help"
-                    && spec.disable_help != Some(true)
-                    && !root.disable_help_subcommand)
+            if at.is_none()
+                && (root.find_subcommand(token).is_some()
+                    || (token == "help"
+                        && spec.disable_help != Some(true)
+                        && !root.disable_help_subcommand))
             {
-                None
-            } else {
-                at
-            };
+                return None;
+            }
+            return at;
         }
         let mut value_flag = None;
         let mut attached = None;
@@ -1449,7 +1449,7 @@ fn default_flag_route(spec: &Spec, root: &SpecCommand, input: &VecDeque<Token>) 
                         break;
                     }
                     if root.subcommand_precedence_over_arg && root.find_subcommand(next).is_some() {
-                        return None;
+                        break;
                     }
                     count += count_values(next);
                     i += 1;


### PR DESCRIPTION
Once a default-only flag has been seen, later words are the default command's args.

`em query` / `em -p query` still select the sibling. `em -u query` is `em install -u query` even when `query` is also a command, so a default command whose positionals are an open name set (`pkg`, `use`, `search`) does not get `UnknownFlag -u`.

Closes #1417.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved command-line parsing when default subcommand flags precede words matching another subcommand, alias, or the configured default command.
  - Arguments following a default-only flag are now correctly assigned to the default command.
  - Improved handling of flag values, optional and variadic values, negative values, and combined short flags.
  - Preserved expected routing for parent flags, explicit sibling commands, and help requests.

- **Documentation**
  - Clarified default-command flag parsing rules and examples.

- **New Features**
  - Exposed argument-parsing helpers at the crate root when the specification feature is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->