### PR TITLE
feat(parse): parse Args without an enclosing CLI

### DIFF
--- a/argv/src/lib.rs
+++ b/argv/src/lib.rs
@@ -177,6 +177,8 @@ pub mod run;
 #[cfg(feature = "spec")]
 pub mod spec;
 #[cfg(feature = "spec")]
+pub use spec::{parse_args_from, parse_args_from_argv};
+#[cfg(feature = "spec")]
 pub mod warn;
 
 pub use run::{Run, RunAsync, RunAsyncWith, RunWith};

--- a/argv/src/spec.rs
+++ b/argv/src/spec.rs
@@ -22,6 +22,7 @@
 //! `help_heading` went in that way.
 //!
 use core::fmt::Write as _;
+use std::ffi::OsStr;
 
 use crate::UnknownFlags;
 use crate::{Arg, Command, DoubleDash, Flag};
@@ -3788,6 +3789,70 @@ pub struct ArgumentState {
     pub given: bool,
     /// Whether the argument is satisfied, including an unconditional default.
     pub satisfied: bool,
+}
+
+/// Parse arguments directly into a derived [`CommandArgs`] type.
+///
+/// Unlike a root CLI's `parse_from`, this needs no enclosing CLI declaration: it
+/// starts at the command represented by `T` and treats `argv` as that command's
+/// arguments. This is useful for adapters and embedded command surfaces that
+/// need one command's exact parser without parsing and dispatching the complete
+/// application again.
+pub fn parse_args_from<'v, T>(argv: &[&'v OsStr]) -> Result<T, crate::Error<'static, 'v>>
+where
+    T: CommandArgs,
+{
+    let mut partial = T::start();
+    let mut parser = crate::Parser::new(T::COMMAND, argv);
+    while let Some(event) = parser.next_event() {
+        let event = event?;
+        if let crate::Event::Flag { flag, .. } = &event {
+            if crate::is_help_flag(flag) {
+                if flag.action == crate::ArgAction::HelpAll {
+                    return Err(crate::Error::HelpAll {
+                        cmd: parser.command(),
+                    });
+                }
+                let long = match flag.action {
+                    crate::ArgAction::HelpShort => false,
+                    crate::ArgAction::HelpLong => true,
+                    crate::ArgAction::Help => !flag.longs.is_empty(),
+                    _ => false,
+                };
+                return Err(crate::Error::Help {
+                    cmd: parser.command(),
+                    long,
+                });
+            }
+            if crate::is_version_flag(flag) {
+                return Err(crate::Error::Version {
+                    long: !flag.longs.is_empty(),
+                });
+            }
+        }
+        T::apply(&mut partial, &event);
+    }
+
+    if parser.command().arg_required_else_help && parser.command_start() == argv.len() {
+        return Err(crate::Error::MissingArgsHelp {
+            cmd: parser.command(),
+        });
+    }
+
+    T::check(&mut partial)?;
+    T::build(partial)
+}
+
+/// Parse a full argv into a derived [`CommandArgs`] type, stripping argv0.
+///
+/// This is the full-argv counterpart to [`parse_args_from`]. The first element
+/// identifies the embedding command and is not parsed as one of its arguments.
+pub fn parse_args_from_argv<'v, T>(argv: &[&'v OsStr]) -> Result<T, crate::Error<'static, 'v>>
+where
+    T: CommandArgs,
+{
+    let words = argv.split_first().map_or(argv, |(_, words)| words);
+    parse_args_from(words)
 }
 
 pub trait CommandArgs: Sized {

--- a/usage-rs/src/lib.rs
+++ b/usage-rs/src/lib.rs
@@ -62,6 +62,27 @@
 //! assert_eq!(ex.file.as_deref(), Some(std::path::Path::new("input.txt")));
 //! # }
 //! ```
+//!
+//! A derived [`Args`] type can also be parsed on its own. This lets an adapter
+//! reuse one command's exact argument contract without constructing or parsing
+//! the application's root CLI:
+//!
+//! ```
+//! use usage_rs as usage;
+//! use usage::Args;
+//!
+//! #[derive(Debug, Args)]
+//! struct Install {
+//!     #[usage(short, long)]
+//!     force: bool,
+//!     tools: Vec<String>,
+//! }
+//!
+//! let argv = ["--force", "node@24"].map(std::ffi::OsStr::new);
+//! let install = usage::parse_args_from::<Install>(&argv).unwrap();
+//! assert!(install.force);
+//! assert_eq!(install.tools, ["node@24"]);
+//! ```
 
 #![forbid(unsafe_code)]
 

--- a/usage-rs/src/lib.rs
+++ b/usage-rs/src/lib.rs
@@ -69,7 +69,13 @@
 //!
 //! ```
 //! use usage_rs as usage;
+//! # #[cfg(feature = "spec")]
 //! use usage::Args;
+//! #
+//! # #[cfg(not(feature = "spec"))]
+//! # fn main() {}
+//! # #[cfg(feature = "spec")]
+//! # fn main() {
 //!
 //! #[derive(Debug, Args)]
 //! struct Install {
@@ -82,6 +88,7 @@
 //! let install = usage::parse_args_from::<Install>(&argv).unwrap();
 //! assert!(install.force);
 //! assert_eq!(install.tools, ["node@24"]);
+//! # }
 //! ```
 
 #![forbid(unsafe_code)]

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -629,6 +629,24 @@ struct StandaloneInstall {
     tools: Vec<String>,
 }
 
+#[derive(Debug, Args, PartialEq, Eq)]
+struct StandaloneNested {
+    #[usage(subcommand)]
+    command: StandaloneNestedCommand,
+}
+
+#[derive(Debug, Subcommands, PartialEq, Eq)]
+enum StandaloneNestedCommand {
+    Run(StandaloneRun),
+}
+
+#[derive(Debug, Args, PartialEq, Eq)]
+struct StandaloneRun {
+    #[usage(long)]
+    profile: String,
+    task: String,
+}
+
 #[test]
 fn args_parse_without_an_enclosing_cli() {
     let words = ["--force", "--jobs", "2", "node@24", "python@3.14"].map(OsStr::new);
@@ -666,6 +684,26 @@ fn standalone_args_return_their_normal_parse_errors() {
         panic!("expected a help request, got {help:?}");
     };
     assert_eq!(cmd.name, "standalone-install");
+}
+
+#[test]
+fn standalone_args_route_and_validate_subcommands() {
+    let words = ["run", "--profile", "release", "build"].map(OsStr::new);
+    assert_eq!(
+        usage::parse_args_from::<StandaloneNested>(&words).unwrap(),
+        StandaloneNested {
+            command: StandaloneNestedCommand::Run(StandaloneRun {
+                profile: "release".to_string(),
+                task: "build".to_string(),
+            }),
+        }
+    );
+
+    let missing_profile = ["run", "build"].map(OsStr::new);
+    assert!(matches!(
+        usage::parse_args_from::<StandaloneNested>(&missing_profile),
+        Err(usage::Error::MissingRequired { name: "profile" })
+    ));
 }
 
 #[derive(Cli)]

--- a/usage-rs/tests/facade.rs
+++ b/usage-rs/tests/facade.rs
@@ -618,6 +618,56 @@ enum RepeatedGlobalCommand {
     Run(RepeatedGlobalChild),
 }
 
+#[derive(Debug, Args, PartialEq, Eq)]
+struct StandaloneInstall {
+    #[usage(short, long)]
+    force: bool,
+    #[usage(long, default = "4")]
+    jobs: usize,
+    #[usage(long, default = "fast", choices("fast", "slow"))]
+    mode: String,
+    tools: Vec<String>,
+}
+
+#[test]
+fn args_parse_without_an_enclosing_cli() {
+    let words = ["--force", "--jobs", "2", "node@24", "python@3.14"].map(OsStr::new);
+    assert_eq!(
+        usage::parse_args_from::<StandaloneInstall>(&words).unwrap(),
+        StandaloneInstall {
+            force: true,
+            jobs: 2,
+            mode: "fast".to_string(),
+            tools: vec!["node@24".to_string(), "python@3.14".to_string()],
+        }
+    );
+
+    let argv = ["install", "--mode", "slow", "ruby@4"].map(OsStr::new);
+    assert_eq!(
+        usage::parse_args_from_argv::<StandaloneInstall>(&argv).unwrap(),
+        StandaloneInstall {
+            force: false,
+            jobs: 4,
+            mode: "slow".to_string(),
+            tools: vec!["ruby@4".to_string()],
+        }
+    );
+}
+
+#[test]
+fn standalone_args_return_their_normal_parse_errors() {
+    let invalid = ["--mode", "turbo"].map(OsStr::new);
+    let invalid = usage::parse_args_from::<StandaloneInstall>(&invalid).unwrap_err();
+    assert!(matches!(invalid, usage::Error::InvalidChoice { .. }));
+
+    let help = ["--help"].map(OsStr::new);
+    let help = usage::parse_args_from::<StandaloneInstall>(&help).unwrap_err();
+    let usage::Error::Help { cmd, .. } = help else {
+        panic!("expected a help request, got {help:?}");
+    };
+    assert_eq!(cmd.name, "standalone-install");
+}
+
 #[derive(Cli)]
 #[usage(bin = "repeated-global")]
 struct RepeatedGlobal {


### PR DESCRIPTION
Adapters and embedded command surfaces can now parse one derived `Args` type without constructing or parsing the application’s root CLI. This lets callers reuse the command’s compiled flags, positional arguments, defaults, validation, subcommand routing, and typed construction directly.

```rust
let install = usage::parse_args_from::<Install>(&args)?;
let install = usage::parse_args_from_argv::<Install>(&argv)?;
```

The second form follows the full-argv convention and strips argv0. Both return ordinary usage parse errors, including help requests, for the selected command.

Validation: `mise run ci` (Rust workspace tests and doctests, Clippy, formatting, semver checks, Prettier, and Go tests).

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public API on the existing parser path; behavior is covered by new integration tests with no changes to root CLI parsing.
> 
> **Overview**
> Adds **`parse_args_from`** and **`parse_args_from_argv`** so a derived **`CommandArgs`** / **`Args`** type can be parsed without a root **`Cli`**. Parsing starts at that command’s tables (flags, positionals, defaults, validation, nested subcommands) and returns the same **`Error`** variants as full-app parsing, including help, version, and missing-args help.
> 
> **`parse_args_from`** treats the slice as that command’s words only; **`parse_args_from_argv`** strips argv0 first. Both are re-exported from **`usage-rs`** (via **`usage_argv`**) behind the **`spec`** feature. Docs and facade tests cover success paths, choices, help, and subcommand routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9149f89ba43917812bd45e8994b0e47a1f3c6458. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added standalone argument parsing for individual command definitions without requiring a complete CLI application.
  - Supports defaults, positional arguments, choice validation, help, version, required arguments, and nested subcommands.
  - Exposed public parsing entry points for adapter and integration use.

- **Documentation**
  - Added guidance and examples for standalone argument parsing.

- **Tests**
  - Added coverage for successful parsing, defaults, choices, positional arguments, nested commands, help, and invalid or missing input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->