### PR TITLE
chore(go): tidy the Go modules, require Go 1.26, and run go fix

### DIFF
--- a/benches/go/cmd/sweep/main.go
+++ b/benches/go/cmd/sweep/main.go
@@ -76,22 +76,19 @@ func sweep(rounds, iters int, f func() bool) stats {
 	// Warm the allocator, the caches, the branch predictors and — for the frameworks
 	// that build a model per call — the heap they will keep reusing. Whatever the first
 	// call pays for is not what a parse costs on the millionth.
-	warm := iters
-	if warm < 200 {
-		warm = 200
-	}
+	warm := max(iters, 200)
 	for i := 0; i < warm; i++ {
 		sink = f()
 	}
 
 	perCall := make([]float64, 0, rounds)
-	for r := 0; r < rounds; r++ {
+	for range rounds {
 		// Between rounds, never inside one: with the collector off, whatever the last
 		// round allocated is still on the heap, and a round that has to grow it is
 		// measuring the allocator's bad day rather than the parser.
 		runtime.GC()
 		start := time.Now()
-		for i := 0; i < iters; i++ {
+		for range iters {
 			sink = f()
 		}
 		perCall = append(perCall, float64(time.Since(start).Nanoseconds())/float64(iters))

--- a/benches/go/go.mod
+++ b/benches/go/go.mod
@@ -9,7 +9,7 @@
 // does the same for the Rust four.
 module github.com/jdx/usage/benches/go
 
-go 1.24
+go 1.26.0
 
 require (
 	github.com/alecthomas/kong v1.16.1

--- a/go/argv/complete_test.go
+++ b/go/argv/complete_test.go
@@ -1,6 +1,7 @@
 package argv
 
 import (
+	"slices"
 	"strings"
 	"testing"
 )
@@ -47,12 +48,7 @@ func values(cs []Candidate) []string {
 }
 
 func offered(list []string, want string) bool {
-	for _, s := range list {
-		if s == want {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(list, want)
 }
 
 func complete(words []string, partial string) []string {

--- a/go/argv/page.go
+++ b/go/argv/page.go
@@ -458,7 +458,7 @@ func groupsSection(out, ungrouped, grouped *strings.Builder, defaultTitle string
 	}
 	var headings []string
 	seen := map[string]bool{}
-	for i := 0; i < n; i++ {
+	for i := range n {
 		h := headingOf(i)
 		if !seen[h] {
 			seen[h] = true
@@ -483,7 +483,7 @@ func groupsSection(out, ungrouped, grouped *strings.Builder, defaultTitle string
 				section.WriteString("\n")
 			}
 		}
-		for i := 0; i < n; i++ {
+		for i := range n {
 			if headingOf(i) == heading {
 				writeItem(&section, i)
 			}
@@ -719,11 +719,4 @@ func trimEnd(s string) string { return strings.TrimRightFunc(s, unicode.IsSpace)
 // with sorting by name, and where it differs this is what a reader sees.
 func sortLines[T any](lines []T, key func(int) string) {
 	sort.SliceStable(lines, func(i, j int) bool { return key(i) < key(j) })
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
 }

--- a/go/argv/page_long.go
+++ b/go/argv/page_long.go
@@ -288,10 +288,7 @@ func entry(out *strings.Builder, usage, help string, col int, nextLine bool) int
 	// The column layout only works for text that has not been broken already, and
 	// only when there is room left for it to say anything.
 	indent := 2 + col + 2
-	room := helpWidth - indent
-	if room < 0 {
-		room = 0
-	}
+	room := max(helpWidth-indent, 0)
 	// A long outlier leaves the shared column to ordinary entries, but keeps its own help on
 	// the row when at least a useful line of prose remains.
 	overflow := width(usage) > col
@@ -431,7 +428,7 @@ func writeWrapped(out *strings.Builder, text string, by int) {
 // wrap breaks text to a width, preserving the breaks the author already made.
 func wrap(text string, width int) []string {
 	var lines []string
-	for _, paragraph := range strings.Split(text, "\n") {
+	for paragraph := range strings.SplitSeq(text, "\n") {
 		if paragraph == "" {
 			lines = append(lines, "")
 			continue
@@ -447,13 +444,10 @@ func wrap(text string, width int) []string {
 		} else {
 			body = trimmed
 		}
-		bodyWidth := width - runeLen(prefix)
-		if bodyWidth < 0 {
-			bodyWidth = 0
-		}
+		bodyWidth := max(width-runeLen(prefix), 0)
 		linePrefix := prefix
 		line := ""
-		for _, word := range strings.Fields(body) {
+		for word := range strings.FieldsSeq(body) {
 			if line != "" && runeLen(line)+1+runeLen(word) > bodyWidth {
 				lines = append(lines, linePrefix+line)
 				line = ""
@@ -476,8 +470,8 @@ func wrap(text string, width int) []string {
 
 func listPrefix(line string) (string, string) {
 	for _, marker := range []string{"* ", "- ", "+ "} {
-		if strings.HasPrefix(line, marker) {
-			return marker, strings.TrimPrefix(line, marker)
+		if after, ok := strings.CutPrefix(line, marker); ok {
+			return marker, after
 		}
 	}
 	for i, r := range line {

--- a/go/argv/parser.go
+++ b/go/argv/parser.go
@@ -1058,12 +1058,7 @@ func (p *Parser) FlagsInScope(fn func(*Flag) bool) {
 
 func (p *Parser) findLong(name string) *Flag {
 	return p.eachInScope(func(f *Flag) bool {
-		for _, l := range f.Longs {
-			if l == name {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(f.Longs, name)
 	})
 }
 
@@ -1082,12 +1077,7 @@ func (p *Parser) findShort(b byte) *Flag {
 		}
 	}
 	f := p.eachInScope(func(f *Flag) bool {
-		for _, s := range f.Shorts {
-			if s == b {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(f.Shorts, b)
 	})
 	if f != nil {
 		return f
@@ -1119,10 +1109,8 @@ func findNamed(cmd *Command, name string) *Command {
 		}
 	}
 	for _, sub := range cmd.Subcommands {
-		for _, a := range sub.Aliases {
-			if a == name {
-				return sub
-			}
+		if slices.Contains(sub.Aliases, name) {
+			return sub
 		}
 	}
 	return nil

--- a/go/argv/post.go
+++ b/go/argv/post.go
@@ -3,6 +3,7 @@ package argv
 import (
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/expr-lang/expr"
@@ -293,12 +294,7 @@ func defaultIfMatches(cond *DefaultIf, filled map[uint64][]string, sources map[u
 		return true
 	}
 	values := explicitRelationshipValues(meta.Lookup(cond.Key), filled[cond.Key], src, negated[cond.Key])
-	for _, value := range values {
-		if value == cond.When {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(values, cond.When)
 }
 
 func explicitRelationshipValues(m *Meta, values []string, source Source, negated bool) []string {

--- a/go/argv/post_test.go
+++ b/go/argv/post_test.go
@@ -323,7 +323,7 @@ func TestApplyDefaultIf(t *testing.T) {
 		t.Errorf("unconditional default when no match: %q from %v", filled[bin], sources[bin])
 	}
 
-	filled = map[uint64][]string{json: {}, bin: []string{"already"}}
+	filled = map[uint64][]string{json: {}, bin: {"already"}}
 	sources = map[uint64]Source{json: FromArgv, bin: FromEnv}
 	ApplyDefaultIf(meta, []uint64{json, bin}, filled, sources, nil)
 	if sources[bin] != FromEnv || !reflect.DeepEqual(filled[bin], []string{"already"}) {

--- a/go/argv/relationships.go
+++ b/go/argv/relationships.go
@@ -1,5 +1,7 @@
 package argv
 
+import "slices"
+
 // RelationshipValues canonicalizes the values used by value-conditional
 // relationships. It leaves value-taking entries alone and turns every boolean
 // source into the same "true" or "false" spelling.
@@ -223,10 +225,8 @@ func CheckRelationshipsWithValuesAndRequirements(meta Metadata, entries []uint64
 			matches := func(condition ValueCondition) bool {
 				return given(condition.Key) && containsValue(valuesOf(condition.Key), condition.Value)
 			}
-			for _, condition := range m.RequiredIfEq {
-				if matches(condition) {
-					return missingRequired(m)
-				}
+			if slices.ContainsFunc(m.RequiredIfEq, matches) {
+				return missingRequired(m)
 			}
 			if len(m.RequiredIfEqAll) > 0 {
 				all := true
@@ -243,12 +243,7 @@ func CheckRelationshipsWithValuesAndRequirements(meta Metadata, entries []uint64
 }
 
 func containsValue(values []string, expected string) bool {
-	for _, value := range values {
-		if value == expected {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(values, expected)
 }
 
 func missingRequired(m *Meta) *Error {
@@ -260,12 +255,7 @@ func missingRequired(m *Meta) *Error {
 }
 
 func anySet(keys []uint64, isSet func(uint64) bool) bool {
-	for _, k := range keys {
-		if isSet(k) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(keys, isSet)
 }
 
 func allSet(keys []uint64, isSet func(uint64) bool) bool {

--- a/go/argv/scope.go
+++ b/go/argv/scope.go
@@ -1,6 +1,7 @@
 package argv
 
 import (
+	"slices"
 	"sort"
 	"strings"
 )
@@ -79,12 +80,7 @@ func visibleFormsOf(f *Flag) []string {
 }
 
 func hasByte(list []byte, value byte) bool {
-	for _, candidate := range list {
-		if candidate == value {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(list, value)
 }
 
 func formsOf(f *Flag) []string {
@@ -106,12 +102,7 @@ func negationOf(f *Flag) string {
 }
 
 func has(list []string, s string) bool {
-	for _, x := range list {
-		if x == s {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(list, s)
 }
 
 // everyFormInScope is every long and short anything in scope answers to, near or
@@ -196,8 +187,8 @@ func ownAndGlobal(chain []*Command, help HelpTable) (own, inherited []shownFlag)
 	}
 
 	keep := map[*Flag]shown{}
-	for i := len(ancestors) - 1; i >= 0; i-- {
-		for _, f := range ancestors[i].Flags {
+	for _, ancestor := range slices.Backward(ancestors) {
+		for _, f := range ancestor.Flags {
 			if !f.Global {
 				continue
 			}

--- a/go/argv/script.go
+++ b/go/argv/script.go
@@ -115,11 +115,10 @@ func fill(script, bin string) string {
 // so the header cannot disagree with the call below it.
 func shellFlag(script string) string {
 	const marker = "--shell "
-	i := strings.Index(script, marker)
-	if i < 0 {
+	_, rest, ok := strings.Cut(script, marker)
+	if !ok {
 		return ""
 	}
-	rest := script[i+len(marker):]
 	if j := strings.IndexAny(rest, " \\\n\t"); j >= 0 {
 		return rest[:j]
 	}

--- a/go/argv/sections.go
+++ b/go/argv/sections.go
@@ -265,7 +265,7 @@ func validStyleMarkup(template string) bool {
 			if end < 0 || end == 2 {
 				return false
 			}
-			for _, style := range strings.Split(tag[2:end], "+") {
+			for style := range strings.SplitSeq(tag[2:end], "+") {
 				known := false
 				for _, candidate := range HelpStyles {
 					if style == candidate {
@@ -343,7 +343,7 @@ func nextTemplateToken(template string) (int, string) {
 func collapseBlankRuns(page string) string {
 	var out strings.Builder
 	blank := false
-	for _, line := range strings.Split(page, "\n") {
+	for line := range strings.SplitSeq(page, "\n") {
 		if strings.TrimSpace(line) == "" {
 			blank = out.Len() > 0
 			continue

--- a/go/conformance/complete_test.go
+++ b/go/conformance/complete_test.go
@@ -46,7 +46,7 @@ func completeWord(t *testing.T, usageBin, kdl string, words []string, cword int)
 		t.Fatalf("the reference should answer %v: %v", words, err)
 	}
 	var lines []string
-	for _, line := range strings.Split(strings.TrimRight(string(out), "\n"), "\n") {
+	for line := range strings.SplitSeq(strings.TrimRight(string(out), "\n"), "\n") {
 		if line != "" {
 			lines = append(lines, line)
 		}

--- a/go/conformance/conformance_test.go
+++ b/go/conformance/conformance_test.go
@@ -65,11 +65,11 @@ type Expect struct {
 // the spec gives each flag or argument, never by the token that set it, so -j,
 // --jobs and an env var all land under `jobs`.
 type Parsed struct {
-	Cmd      []string                            `json:"cmd"`
-	Flags    map[string]interface{}              `json:"flags"`
-	Args     map[string]interface{}              `json:"args"`
-	Clauses  map[string][]map[string]interface{} `json:"clauses,omitempty"`
-	External []string                            `json:"external,omitempty"`
+	Cmd      []string                    `json:"cmd"`
+	Flags    map[string]any              `json:"flags"`
+	Args     map[string]any              `json:"args"`
+	Clauses  map[string][]map[string]any `json:"clauses,omitempty"`
+	External []string                    `json:"external,omitempty"`
 }
 
 type file struct {
@@ -88,7 +88,6 @@ func TestCorpus(t *testing.T) {
 
 	var ran, skipped int
 	for _, v := range vectors {
-		v := v
 		t.Run(v.ID, func(t *testing.T) {
 			if reason, unsupported := notYet[v.ID]; unsupported {
 				skipped++
@@ -350,9 +349,9 @@ func run(s *spec.Spec, args []string, argv0 *string, env map[string]string) (*Pa
 
 	out := &Parsed{
 		Cmd:      []string{},
-		Flags:    map[string]interface{}{},
-		Args:     map[string]interface{}{},
-		Clauses:  map[string][]map[string]interface{}{},
+		Flags:    map[string]any{},
+		Args:     map[string]any{},
+		Clauses:  map[string][]map[string]any{},
 		External: external,
 	}
 	for _, cmd := range path {
@@ -360,7 +359,7 @@ func run(s *spec.Spec, args []string, argv0 *string, env map[string]string) (*Pa
 			continue
 		}
 		for _, instance := range clauseInstances[cmd.Clause.Name] {
-			values := map[string]interface{}{}
+			values := map[string]any{}
 			for _, arg := range cmd.Clause.Args {
 				b := instance[arg.Key]
 				if b == nil {
@@ -550,7 +549,7 @@ func run(s *spec.Spec, args []string, argv0 *string, env map[string]string) (*Pa
 // renderFlag turns what a flag ended up with into the shape the corpus records,
 // which depends on what the flag is rather than on where the value came from.
 func renderFlag(f *argv.Flag, multi map[string]spec.Multi,
-	values []string, source argv.Source, negated bool, occurrences int) (interface{}, bool) {
+	values []string, source argv.Source, negated bool, occurrences int) (any, bool) {
 
 	if !f.TakesValue {
 		// A count flag records one entry per occurrence, so it is asked before
@@ -559,7 +558,7 @@ func renderFlag(f *argv.Flag, multi map[string]spec.Multi,
 			if occurrences == 0 {
 				return nil, false
 			}
-			list := make([]interface{}, occurrences)
+			list := make([]any, occurrences)
 			for i := range list {
 				list[i] = true
 			}
@@ -588,22 +587,22 @@ func renderFlag(f *argv.Flag, multi map[string]spec.Multi,
 	return values[len(values)-1], true
 }
 
-func toList(values []string) []interface{} {
-	out := make([]interface{}, len(values))
+func toList(values []string) []any {
+	out := make([]any, len(values))
 	for i, v := range values {
 		out[i] = v
 	}
 	return out
 }
 
-func strs(v interface{}) []interface{} {
+func strs(v any) []any {
 	if v == nil {
 		return nil
 	}
-	return v.([]interface{})
+	return v.([]any)
 }
 
-func bools(v interface{}) []interface{} { return strs(v) }
+func bools(v any) []any { return strs(v) }
 
 // normalizeExpected puts the JSON expectation into the shape run produces, so the
 // two can be compared directly.
@@ -618,18 +617,18 @@ func normalizeExpected(p *Parsed) *Parsed {
 		out.Cmd = []string{}
 	}
 	if out.Flags == nil {
-		out.Flags = map[string]interface{}{}
+		out.Flags = map[string]any{}
 	}
 	if out.Args == nil {
-		out.Args = map[string]interface{}{}
+		out.Args = map[string]any{}
 	}
 	if out.Clauses == nil {
-		out.Clauses = map[string][]map[string]interface{}{}
+		out.Clauses = map[string][]map[string]any{}
 	}
 	for _, instances := range out.Clauses {
 		for _, instance := range instances {
 			for name, value := range instance {
-				if raw, ok := value.([]interface{}); ok {
+				if raw, ok := value.([]any); ok {
 					strings := make([]string, len(raw))
 					for i, item := range raw {
 						strings[i] = item.(string)

--- a/go/conformance/help_test.go
+++ b/go/conformance/help_test.go
@@ -40,7 +40,6 @@ func TestEveryUsageLineMatchesTheReference(t *testing.T) {
 	collect = func(c *spec.Cmd, path []string) {
 		want[strings.Join(path, " ")] = c.Usage
 		for _, sub := range c.Subcommands {
-			sub := sub
 			collect(&sub.Cmd, append(append([]string{}, path...), sub.Name))
 		}
 	}

--- a/go/conformance/page_test.go
+++ b/go/conformance/page_test.go
@@ -139,12 +139,6 @@ func at(lines []string, i int) string {
 
 func quote(s string) string { b, _ := json.Marshal(s); return string(b) }
 func itoa(n int) string     { b, _ := json.Marshal(n); return string(b) }
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
 
 var _ = spec.Spec{}
 

--- a/go/conformance/producers_test.go
+++ b/go/conformance/producers_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/jdx/usage/go/argv"
@@ -131,10 +132,5 @@ func isEmptySlice(v reflect.Value) bool {
 }
 
 func contains(list []string, s string) bool {
-	for _, x := range list {
-		if x == s {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(list, s)
 }

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,5 +1,5 @@
 module github.com/jdx/usage/go
 
-go 1.21
+go 1.26.0
 
-require github.com/expr-lang/expr v1.17.8 // indirect
+require github.com/expr-lang/expr v1.17.8

--- a/go/internal/shadow/mise/parse_test.go
+++ b/go/internal/shadow/mise/parse_test.go
@@ -198,7 +198,6 @@ func TestParseAllocatesNothingAtScale(t *testing.T) {
 		{"tasks", "run", "build", "extra", "--dry-run", "--", "--verbose"},
 		{"config", "ls", "--cd", "/tmp"},
 	} {
-		args := args
 		t.Run(strings.Join(args, " "), func(t *testing.T) {
 			n := testing.AllocsPerRun(100, func() {
 				p := argv.New(Root, args)

--- a/go/internal/spec/spec.go
+++ b/go/internal/spec/spec.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/jdx/usage/go/argv"
@@ -832,8 +833,8 @@ func (b *builder) resolveRelationships(c *Cmd, out *argv.Command) {
 				}
 			}
 		}
-		for i := len(b.scope) - 1; i >= 0; i-- {
-			if key, ok := b.matchFlag(b.scope[i].Flags, name, true); ok {
+		for _, v := range slices.Backward(b.scope) {
+			if key, ok := b.matchFlag(v.Flags, name, true); ok {
 				return key, true
 			}
 		}
@@ -961,17 +962,13 @@ func (b *builder) matchFlag(flags []*argv.Flag, name string, globalsOnly bool) (
 			return f.Key, true
 		}
 		if long != "" {
-			for _, l := range f.Longs {
-				if l == long {
-					return f.Key, true
-				}
+			if slices.Contains(f.Longs, long) {
+				return f.Key, true
 			}
 		}
 		if short != 0 {
-			for _, s := range f.Shorts {
-				if s == short {
-					return f.Key, true
-				}
+			if slices.Contains(f.Shorts, short) {
+				return f.Key, true
 			}
 		}
 	}
@@ -1235,10 +1232,5 @@ func doubleDash(s string) argv.DoubleDash {
 }
 
 func contains(list []string, s string) bool {
-	for _, x := range list {
-		if x == s {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(list, s)
 }

--- a/integrations/cobra/cobra_usage_test.go
+++ b/integrations/cobra/cobra_usage_test.go
@@ -629,7 +629,7 @@ func assertNotContains(t *testing.T, got, unwanted string) {
 
 // findLine returns the first line of output containing prefix, or "" if none does.
 func findLine(output, prefix string) string {
-	for _, line := range strings.Split(output, "\n") {
+	for line := range strings.SplitSeq(output, "\n") {
 		if strings.Contains(line, prefix) {
 			return line
 		}

--- a/integrations/cobra/convert.go
+++ b/integrations/cobra/convert.go
@@ -156,10 +156,7 @@ func dedent(s string) string {
 
 // commonPrefix returns the longest common leading run of a and b.
 func commonPrefix(a, b string) string {
-	n := len(a)
-	if len(b) < n {
-		n = len(b)
-	}
+	n := min(len(b), len(a))
 	i := 0
 	for i < n && a[i] == b[i] {
 		i++

--- a/integrations/cobra/example/go.mod
+++ b/integrations/cobra/example/go.mod
@@ -1,6 +1,6 @@
 module github.com/jdx/usage/integrations/cobra/example
 
-go 1.21
+go 1.26.0
 
 require (
 	github.com/jdx/usage/integrations/cobra v0.0.0

--- a/integrations/cobra/example/main.go
+++ b/integrations/cobra/example/main.go
@@ -10,6 +10,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"slices"
 
 	cobra_usage "github.com/jdx/usage/integrations/cobra"
 	"github.com/spf13/cobra"
@@ -95,11 +96,9 @@ func main() {
 
 	// Handle --usage-spec: check for the flag in os.Args before Execute.
 	// This is the recommended integration pattern.
-	for _, arg := range os.Args[1:] {
-		if arg == "--usage-spec" {
-			fmt.Print(cobra_usage.Generate(root))
-			return
-		}
+	if slices.Contains(os.Args[1:], "--usage-spec") {
+		fmt.Print(cobra_usage.Generate(root))
+		return
 	}
 
 	if err := root.Execute(); err != nil {

--- a/integrations/cobra/go.mod
+++ b/integrations/cobra/go.mod
@@ -1,6 +1,6 @@
 module github.com/jdx/usage/integrations/cobra
 
-go 1.21
+go 1.26.0
 
 require (
 	github.com/spf13/cobra v1.10.2


### PR DESCRIPTION
Housekeeping across the four Go modules (`go`, `integrations/cobra`, `integrations/cobra/example`, `benches/go`):

- `go mod tidy`. The only content change is dropping the stale `// indirect` marker on `github.com/expr-lang/expr`, which `go/argv` imports directly.
- Raised the `go` directive to `1.26.0`, the oldest supported release. Three modules were on `1.21` and `benches/go` was on `1.24`.
- `go fix ./...`, which the newer language version unlocks: `for range n`, `slices.Contains`/`ContainsFunc`/`Backward`, the `min`/`max` builtins, `strings.SplitSeq`/`FieldsSeq`/`CutPrefix`. Net −80 lines, no behavior change. `go/argv` stays dependency-free — every replacement is standard library.
- `gofmt -s`, which found one redundant composite literal type.

One hand edit on top of the generated output: `go fix` turned an `Index`/slice pair in `go/argv/script.go` into `strings.Cut` but left a redundant `rest := after` behind it, which I folded into the `Cut` destructuring.

`mise run test:go` and `mise run lint:go` pass, as does `go test -race ./...` in the `go` module. `lint:go` covers `go` and `benches/go` only, so I also ran `go vet ./...` in `integrations/cobra` and its example module. The allocation assertions in `go/internal/shadow/mise` still pass.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: 2.1.236.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project and integration modules to require Go 1.26.
  * Promoted the expression engine dependency to a direct module dependency.

* **Refactor**
  * Modernized internal iteration, collection-search, string-processing, and min/max operations using newer Go standard-library features.
  * Simplified test and example code while preserving existing behavior.

* **Tests**
  * Updated conformance, completion, and integration tests to use current Go language and standard-library conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->